### PR TITLE
feat(models): UI-TARS aliases + Computer-Use action parser + Anthropic tool_use mapping

### DIFF
--- a/scripts/audit_tool_parser_coverage.py
+++ b/scripts/audit_tool_parser_coverage.py
@@ -92,6 +92,14 @@ MATRIX_EXEMPT: dict[str, str] = {
     "functionary": "TODO: add Functionary-medium model to golden_models",
     "xlam": "TODO: add xLAM model to golden_models",
     "seed_oss": "TODO: add Seed-OSS model to golden_models",
+    # UI-TARS (ByteDance) — GUI-agent VLM. Adding a real golden_models
+    # entry requires running a Qwen2-VL / Qwen2.5-VL backbone in the
+    # pr_validate matrix (mlx-vlm path, not the plain mlx-lm path the
+    # other matrix entries use). Track as TODO until vision-VLM matrix
+    # support lands.
+    "ui_tars": "TODO: add UI-TARS-1.5-7B-4bit to golden_models once the VLM matrix supports mlx-vlm-backed Computer-Use models",
+    "ui-tars": "alias of ui_tars (kebab-case spelling)",
+    "uitars": "alias of ui_tars (no-separator spelling)",
 }
 
 

--- a/tests/test_tool_call_streaming_parity.py
+++ b/tests/test_tool_call_streaming_parity.py
@@ -190,6 +190,17 @@ PARITY_FIXTURES: list = [
         ),
         [("read_file", {"path": "/etc/hostname"})],
     ),
+    # ui_tars — Computer-Use action line. Stream / non-stream paths both
+    # MUST recover the canonical (name="computer", args={action, point})
+    # tuple. The streaming finalize path runs the same _iter_actions
+    # scanner as the non-stream path, so coverage is the same shape —
+    # this fixture guards against a future regression where they diverge.
+    (
+        "ui_tars",
+        "ui_tars_action",
+        "Thought: Click search.\nAction: click(point='<point>200 300</point>')",
+        [("computer", {"action": "click", "point": [200, 300]})],
+    ),
 ]
 
 
@@ -240,6 +251,8 @@ _PARITY_COVERAGE_EXEMPT: dict[str, str] = {
     "qwen3": "alias of qwen",
     "qwen3_coder": "alias of hermes",
     "nous": "alias of hermes",
+    "ui-tars": "alias of ui_tars (kebab-case spelling)",
+    "uitars": "alias of ui_tars (no-separator spelling)",
     "auto": "router, not a wire-format parser",
     "generic": "router, not a wire-format parser",
 }

--- a/tests/test_ui_tars_parser.py
+++ b/tests/test_ui_tars_parser.py
@@ -1,0 +1,716 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for UI-TARS Computer-Use action parser and reasoning parser.
+
+Covers:
+- All nine Computer-Use action verbs (click, left_double, right_single,
+  drag, hotkey, type, scroll, wait, finished)
+- Mobile-extension verbs (long_press, open_app, press_home, press_back)
+- Leading ``Thought: ...`` preamble routed to reasoning_content
+- ``Reflection: ... Action_Summary: ...`` (UI-TARS-1.5 reflective shape)
+- Multi-action responses (one tool_call per action, sequential indices)
+- Streaming dedup (don't double-emit already-yielded actions)
+- Partial mid-stream action (no balanced close ``)``) doesn't crash
+- Tokenizer detection regression guard — no ``Ġ`` / ``Ċ`` BPE markers
+  in reasoning_content
+- Anthropic adapter: same input → tool_use blocks with name="computer"
+- Alias registry resolves to the ``ui_tars`` parsers
+- Auto-config regex resolves bare HF paths to the ``ui_tars`` parsers
+
+Tests deliberately use deterministic small inputs (no real model weights,
+no real screenshots) and assert PARSER behavior, not model accuracy.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from vllm_mlx.model_aliases import resolve_profile
+from vllm_mlx.model_auto_config import detect_model_config
+from vllm_mlx.reasoning import get_parser as get_reasoning_parser
+from vllm_mlx.reasoning.ui_tars_parser import UiTarsReasoningParser
+from vllm_mlx.tool_parsers import ToolParserManager, UiTarsToolParser
+from vllm_mlx.tool_parsers.ui_tars_tool_parser import (
+    _find_balanced_close,
+    _normalize_action,
+    _parse_kwargs,
+    _parse_point,
+)
+
+# ---------------------------------------------------------------------------
+# Registry / wiring
+# ---------------------------------------------------------------------------
+
+
+class TestRegistry:
+    def test_tool_parser_registered_under_canonical_name(self):
+        cls = ToolParserManager.get_tool_parser("ui_tars")
+        assert cls is UiTarsToolParser
+
+    @pytest.mark.parametrize("alias", ["ui-tars", "uitars"])
+    def test_tool_parser_alias_names(self, alias: str):
+        assert ToolParserManager.get_tool_parser(alias) is UiTarsToolParser
+
+    def test_reasoning_parser_registered(self):
+        cls = get_reasoning_parser("ui_tars")
+        assert cls is UiTarsReasoningParser
+
+    def test_tool_parser_declares_wire_format(self):
+        # Audit guard: every parser must declare at least one wire format.
+        # Adding a new label here also requires updating
+        # ``WIRE_FORMAT_LABELS`` in abstract_tool_parser.
+        assert UiTarsToolParser.EXPECTED_WIRE_FORMATS == ("ui_tars_action",)
+
+
+class TestAliases:
+    @pytest.mark.parametrize(
+        "alias,hf_path",
+        [
+            ("ui-tars-1.5-7b-4bit", "mlx-community/UI-TARS-1.5-7B-4bit"),
+            ("ui-tars-1.5-7b-6bit", "mlx-community/UI-TARS-1.5-7B-6bit"),
+            ("ui-tars-1.5-7b-8bit", "mlx-community/UI-TARS-1.5-7B-8bit"),
+            ("ui-tars-7b-dpo-4bit", "mlx-community/UI-TARS-7B-DPO-4bit"),
+            ("ui-tars-7b-dpo-6bit", "mlx-community/UI-TARS-7B-DPO-6bit"),
+            ("ui-tars-7b-dpo-8bit", "mlx-community/UI-TARS-7B-DPO-8bit"),
+            ("ui-tars-7b-sft-4bit", "mlx-community/UI-TARS-7B-SFT-4bit"),
+            ("ui-tars-7b-sft-8bit", "mlx-community/UI-TARS-7B-SFT-8bit"),
+            ("ui-tars-72b-dpo-4bit", "mlx-community/UI-TARS-72B-DPO-4bit"),
+        ],
+    )
+    def test_alias_resolves_to_ui_tars_parsers(self, alias: str, hf_path: str):
+        profile = resolve_profile(alias)
+        assert profile is not None, f"alias {alias} not in aliases.json"
+        assert profile.hf_path == hf_path
+        assert profile.tool_call_parser == "ui_tars"
+        assert profile.reasoning_parser == "ui_tars"
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "ByteDance-Seed/UI-TARS-1.5-7B",
+            "ByteDance/UI-TARS-7B-DPO",
+            "ByteDance/UI-TARS-72B-SFT",
+            "uitars-experimental-7b",  # underscore-elided variant
+            "ui_tars_local_checkpoint",
+        ],
+    )
+    def test_regex_fallback_resolves_bare_hf_paths(self, path: str):
+        cfg = detect_model_config(path)
+        assert cfg is not None, f"no config for {path}"
+        assert cfg.tool_call_parser == "ui_tars"
+        assert cfg.reasoning_parser == "ui_tars"
+
+
+# ---------------------------------------------------------------------------
+# Coordinate normalization
+# ---------------------------------------------------------------------------
+
+
+class TestParsePoint:
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            ("<point>200 300</point>", [200, 300]),
+            ("<point>0 0</point>", [0, 0]),
+            ("<point>999 1000</point>", [999, 1000]),
+            ("<point>500.0 400.5</point>", [500, 400.5]),  # subpixel preserved
+            ("<bbox>10 20 30 40</bbox>", [10, 20, 30, 40]),
+            # UI-TARS-1.5 sentinel — verified against the live
+            # mlx-community/UI-TARS-1.5-7B-4bit checkpoint (2026-06-21).
+            ("<|box_start|>(233,45)<|box_end|>", [233, 45]),
+            ("<|box_start|>(10,20),(30,40)<|box_end|>", [10, 20, 30, 40]),
+            ("<200, 300>", [200, 300]),
+            ("<200 300>", [200, 300]),
+            ("[100, 200]", [100, 200]),
+            ("(100, 200)", [100, 200]),
+            ("100,200", [100, 200]),
+        ],
+    )
+    def test_parse_recognized_shapes(self, raw: str, expected: list):
+        assert _parse_point(raw) == expected
+
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            "",
+            "not a point",
+            "<point></point>",
+            "garbage",
+        ],
+    )
+    def test_unrecognized_returns_none(self, raw: str):
+        assert _parse_point(raw) is None
+
+    def test_non_string_returns_none(self):
+        assert _parse_point(None) is None  # type: ignore[arg-type]
+        assert _parse_point(123) is None  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Kwarg parsing
+# ---------------------------------------------------------------------------
+
+
+class TestParseKwargs:
+    def test_single_kwarg(self):
+        assert _parse_kwargs("point='<point>1 2</point>'") == {
+            "point": "<point>1 2</point>"
+        }
+
+    def test_multi_kwarg(self):
+        out = _parse_kwargs(
+            "start_point='<point>1 2</point>', end_point='<point>3 4</point>'"
+        )
+        assert out == {
+            "start_point": "<point>1 2</point>",
+            "end_point": "<point>3 4</point>",
+        }
+
+    def test_double_quote_kwarg(self):
+        assert _parse_kwargs('content="hello"') == {"content": "hello"}
+
+    def test_escaped_newline(self):
+        # Escape sequences inside quoted args should round-trip the
+        # literal newline (Python string semantics), not the ``\n``
+        # token.
+        assert _parse_kwargs("content='line1\\nline2'") == {"content": "line1\nline2"}
+
+    def test_paren_inside_string(self):
+        # ``)`` inside the string must not truncate the body.
+        out = _parse_kwargs("content='hello (world)'")
+        assert out == {"content": "hello (world)"}
+
+    def test_empty_body(self):
+        assert _parse_kwargs("") == {}
+
+    def test_malformed_falls_through_to_lenient(self):
+        # Unclosed quote — ast.parse fails, lenient regex picks it up.
+        # (We accept best-effort here; no crash is the contract.)
+        out = _parse_kwargs("key='unclosed")
+        # Could be {} or {"key": "unclosed"} depending on fallback —
+        # the load-bearing assertion is: no exception.
+        assert isinstance(out, dict)
+
+
+# ---------------------------------------------------------------------------
+# Action normalization
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeAction:
+    def test_click(self):
+        args = _normalize_action("click", {"point": "<point>200 300</point>"})
+        assert args == {"action": "click", "point": [200, 300]}
+
+    def test_drag_two_points(self):
+        args = _normalize_action(
+            "drag",
+            {
+                "start_point": "<point>1 2</point>",
+                "end_point": "<point>3 4</point>",
+            },
+        )
+        assert args == {
+            "action": "drag",
+            "start_point": [1, 2],
+            "end_point": [3, 4],
+        }
+
+    def test_hotkey_passthrough(self):
+        args = _normalize_action("hotkey", {"key": "ctrl c"})
+        assert args == {"action": "hotkey", "key": "ctrl c"}
+
+    def test_unknown_verb_emitted_verbatim(self):
+        # Future UI-TARS verb — preserve so we don't silently drop calls.
+        args = _normalize_action(
+            "tap_with_pressure",
+            {"point": "<point>10 20</point>", "pressure": 0.5},
+        )
+        assert args == {
+            "action": "tap_with_pressure",
+            "point": [10, 20],
+            "pressure": 0.5,
+        }
+
+    def test_unparseable_point_kept_as_string(self):
+        # If the coord body is junk, preserve the raw string in args so
+        # the downstream consumer can decide what to do.
+        args = _normalize_action("click", {"point": "garbage"})
+        assert args == {"action": "click", "point": "garbage"}
+
+
+# ---------------------------------------------------------------------------
+# Balanced-paren close
+# ---------------------------------------------------------------------------
+
+
+class TestFindBalancedClose:
+    def test_simple(self):
+        s = "abc)"
+        assert _find_balanced_close(s, 0) == 3
+
+    def test_nested(self):
+        s = "a(b)c)"
+        assert _find_balanced_close(s, 0) == 5
+
+    def test_paren_in_string(self):
+        s = "x='hi)', y=1)"
+        assert _find_balanced_close(s, 0) == len(s) - 1
+
+    def test_unbalanced_returns_minus_one(self):
+        assert _find_balanced_close("no close here", 0) == -1
+
+    def test_escaped_quote(self):
+        s = "x='it\\'s', y=2)"
+        assert _find_balanced_close(s, 0) == len(s) - 1
+
+
+# ---------------------------------------------------------------------------
+# Tool parser — complete-response
+# ---------------------------------------------------------------------------
+
+
+def _decode(tc: dict) -> dict:
+    """Round-trip the JSON arguments back to a dict for assertions."""
+    return json.loads(tc["arguments"])
+
+
+class TestToolParserComplete:
+    def setup_method(self) -> None:
+        self.p = UiTarsToolParser()
+
+    def test_click(self):
+        text = (
+            "Thought: I need to click search.\n"
+            "Action: click(point='<point>200 300</point>')"
+        )
+        r = self.p.extract_tool_calls(text)
+        assert r.tools_called is True
+        assert len(r.tool_calls) == 1
+        assert r.tool_calls[0]["name"] == "computer"
+        args = _decode(r.tool_calls[0])
+        assert args == {"action": "click", "point": [200, 300]}
+
+    def test_left_double(self):
+        text = "Action: left_double(point='<point>10 20</point>')"
+        r = self.p.extract_tool_calls(text)
+        assert _decode(r.tool_calls[0]) == {
+            "action": "left_double",
+            "point": [10, 20],
+        }
+
+    def test_right_single(self):
+        text = "Action: right_single(point='<point>10 20</point>')"
+        r = self.p.extract_tool_calls(text)
+        assert _decode(r.tool_calls[0]) == {
+            "action": "right_single",
+            "point": [10, 20],
+        }
+
+    def test_drag(self):
+        text = (
+            "Action: drag(start_point='<point>1 2</point>', "
+            "end_point='<point>3 4</point>')"
+        )
+        r = self.p.extract_tool_calls(text)
+        assert _decode(r.tool_calls[0]) == {
+            "action": "drag",
+            "start_point": [1, 2],
+            "end_point": [3, 4],
+        }
+
+    def test_hotkey(self):
+        text = "Action: hotkey(key='ctrl c')"
+        r = self.p.extract_tool_calls(text)
+        assert _decode(r.tool_calls[0]) == {"action": "hotkey", "key": "ctrl c"}
+
+    def test_type(self):
+        text = "Action: type(content='hello world\\n')"
+        r = self.p.extract_tool_calls(text)
+        assert _decode(r.tool_calls[0]) == {
+            "action": "type",
+            "content": "hello world\n",
+        }
+
+    def test_scroll(self):
+        text = "Action: scroll(point='<point>500 400</point>', direction='down')"
+        r = self.p.extract_tool_calls(text)
+        assert _decode(r.tool_calls[0]) == {
+            "action": "scroll",
+            "point": [500, 400],
+            "direction": "down",
+        }
+
+    def test_wait(self):
+        text = "Action: wait()"
+        r = self.p.extract_tool_calls(text)
+        assert _decode(r.tool_calls[0]) == {"action": "wait"}
+
+    def test_finished(self):
+        text = "Action: finished(content='done')"
+        r = self.p.extract_tool_calls(text)
+        assert _decode(r.tool_calls[0]) == {"action": "finished", "content": "done"}
+
+    def test_mobile_long_press(self):
+        text = "Action: long_press(point='<point>50 60</point>')"
+        r = self.p.extract_tool_calls(text)
+        assert _decode(r.tool_calls[0]) == {
+            "action": "long_press",
+            "point": [50, 60],
+        }
+
+    def test_mobile_press_home(self):
+        text = "Action: press_home()"
+        r = self.p.extract_tool_calls(text)
+        assert _decode(r.tool_calls[0]) == {"action": "press_home"}
+
+    def test_mobile_open_app(self):
+        text = "Action: open_app(app_name='Calendar')"
+        r = self.p.extract_tool_calls(text)
+        assert _decode(r.tool_calls[0]) == {
+            "action": "open_app",
+            "app_name": "Calendar",
+        }
+
+    def test_multi_action_sequential_indices(self):
+        text = (
+            "Thought: Click then type.\n"
+            "Action: click(point='<point>1 2</point>')\n"
+            "Action: type(content='hi')"
+        )
+        r = self.p.extract_tool_calls(text)
+        assert len(r.tool_calls) == 2
+        first = _decode(r.tool_calls[0])
+        second = _decode(r.tool_calls[1])
+        assert first == {"action": "click", "point": [1, 2]}
+        assert second == {"action": "type", "content": "hi"}
+
+    def test_actions_stripped_from_content(self):
+        text = "Thought: Click search.\nAction: click(point='<point>200 300</point>')"
+        r = self.p.extract_tool_calls(text)
+        # Both Action: and Thought: preamble are stripped — the reasoning
+        # parser owns the chain-of-thought channel, the tool parser owns
+        # the action channel, content should be empty (or whatever sits
+        # between Action: lines). Stripping Thought: here is a defensive
+        # mirror so the chain-of-thought doesn't double-render when the
+        # reasoning parser also extracts it.
+        assert "Action:" not in (r.content or "")
+        assert "Thought:" not in (r.content or "")
+
+    def test_box_start_sentinel_normalized(self):
+        # UI-TARS-1.5 emits ``start_box='<|box_start|>(x,y)<|box_end|>'``
+        # — verified against the live mlx-community/UI-TARS-1.5-7B-4bit
+        # checkpoint (2026-06-21). Coords are absolute pixel offsets.
+        text = "Action: click(start_box='<|box_start|>(233,45)<|box_end|>')"
+        r = self.p.extract_tool_calls(text)
+        assert _decode(r.tool_calls[0]) == {
+            "action": "click",
+            "start_box": [233, 45],
+        }
+
+    def test_no_action_passes_through(self):
+        text = "Just a thought, no action."
+        r = self.p.extract_tool_calls(text)
+        assert r.tools_called is False
+        assert r.content == text
+
+    def test_empty_input(self):
+        r = self.p.extract_tool_calls("")
+        assert r.tools_called is False
+        assert r.content == ""
+
+    def test_unbalanced_paren_skipped_gracefully(self):
+        # Partial mid-stream (no balanced ``)``) — must not crash, no
+        # tool_calls emitted.
+        text = "Action: click(point='<point>1 2</point>'"
+        r = self.p.extract_tool_calls(text)
+        assert r.tools_called is False
+
+    def test_double_quote_args(self):
+        # Per UI-TARS prompt, kwargs are single-quoted, but some
+        # quantized variants emit double-quoted — accept both.
+        text = 'Action: click(point="<point>10 20</point>")'
+        r = self.p.extract_tool_calls(text)
+        assert _decode(r.tool_calls[0]) == {"action": "click", "point": [10, 20]}
+
+    def test_paren_inside_string_arg(self):
+        # ``type(content='paste (here)')`` — ``)`` inside string must
+        # not terminate the action body early.
+        text = "Action: type(content='paste (here)')"
+        r = self.p.extract_tool_calls(text)
+        assert _decode(r.tool_calls[0]) == {
+            "action": "type",
+            "content": "paste (here)",
+        }
+
+    def test_call_id_uses_call_prefix(self):
+        # Coordinated with D-ANTHRO-SPEC-POLISH: every parser stays on
+        # the OpenAI ``call_`` convention; the Anthropic adapter rewrites
+        # to ``toolu_`` at the /v1/messages boundary.
+        text = "Action: wait()"
+        r = self.p.extract_tool_calls(text)
+        assert r.tool_calls[0]["id"].startswith("call_")
+
+
+class TestToolParserStreaming:
+    def setup_method(self) -> None:
+        self.p = UiTarsToolParser()
+
+    def _stream(self, deltas: list[str]) -> list:
+        prev = ""
+        out = []
+        for d in deltas:
+            cur = prev + d
+            msg = self.p.extract_tool_calls_streaming(prev, cur, d)
+            if msg is not None:
+                out.append(msg)
+            prev = cur
+        return out
+
+    def test_partial_action_no_double_emit(self):
+        deltas = [
+            "Thought: hi\n",
+            "Action: click(",
+            "point='<point>1 2</point>'",
+            ")",  # close arrives in a separate delta
+        ]
+        events = self._stream(deltas)
+        # Only one tool_call emitted, on the delta that closes the paren.
+        tool_events = [e for e in events if "tool_calls" in e]
+        assert len(tool_events) == 1
+        assert tool_events[0]["tool_calls"][0]["index"] == 0
+        args = json.loads(tool_events[0]["tool_calls"][0]["function"]["arguments"])
+        assert args == {"action": "click", "point": [1, 2]}
+
+    def test_multi_action_streaming(self):
+        deltas = [
+            "Action: click(point='<point>1 2</point>')\n",
+            "Action: type(content='hi')",
+        ]
+        events = self._stream(deltas)
+        tool_events = [e for e in events if "tool_calls" in e]
+        assert len(tool_events) == 2
+        assert tool_events[0]["tool_calls"][0]["index"] == 0
+        assert tool_events[1]["tool_calls"][0]["index"] == 1
+
+    def test_thought_passes_through_as_content(self):
+        # Before any Action: token arrives, deltas stream through as
+        # content (the reasoning parser claims them downstream).
+        prev = ""
+        msg = self.p.extract_tool_calls_streaming(prev, "Thought: hi", "Thought: hi")
+        assert msg == {"content": "Thought: hi"}
+
+    def test_has_pending_tool_call_partial(self):
+        # An open ``Action: foo(`` should keep the postprocessor in
+        # "hold" mode.
+        assert self.p.has_pending_tool_call("Action: click(") is True
+        # A completed action — not pending anymore.
+        assert self.p.has_pending_tool_call("Action: wait()") is False
+        # No action at all — not pending.
+        assert self.p.has_pending_tool_call("Thought: hi") is False
+
+
+# ---------------------------------------------------------------------------
+# Reasoning parser — Thought:/Reflection: preamble split
+# ---------------------------------------------------------------------------
+
+
+class TestReasoningParserComplete:
+    def setup_method(self) -> None:
+        self.p = UiTarsReasoningParser()
+
+    def test_thought_preamble(self):
+        text = (
+            "Thought: I need to click search.\n"
+            "Action: click(point='<point>200 300</point>')"
+        )
+        reasoning, content = self.p.extract_reasoning(text)
+        assert reasoning is not None
+        assert "I need to click search" in reasoning
+        assert content is not None
+        assert content.startswith("Action:")
+
+    def test_reflection_action_summary_preamble(self):
+        text = (
+            "Reflection: Last action missed.\n"
+            "Action_Summary: Click the correct button.\n"
+            "Action: click(point='<point>100 200</point>')"
+        )
+        reasoning, content = self.p.extract_reasoning(text)
+        assert reasoning is not None
+        assert "Reflection:" in reasoning
+        assert "Action_Summary:" in reasoning
+        assert content is not None
+        assert content.startswith("Action:")
+
+    def test_no_preamble(self):
+        # Grounding template: action-only.
+        text = "Action: click(point='<point>1 2</point>')"
+        reasoning, content = self.p.extract_reasoning(text)
+        assert reasoning is None
+        assert content == text
+
+    def test_empty_input(self):
+        reasoning, content = self.p.extract_reasoning("")
+        assert reasoning is None
+        assert content == ""
+
+    def test_bpe_markers_do_not_leak(self):
+        # Regression guard: ensure no Qwen/BPE artifacts (``Ġ``, ``Ċ``)
+        # are introduced into reasoning_content by the parser. UI-TARS
+        # tokenizers use byte-level BPE; if the upstream pipeline
+        # already detokenized the bytes back to UTF-8 the parser must
+        # not add them. Run with markers in source and verify they
+        # survive untouched (i.e. parser doesn't munge or strip
+        # legitimate text content).
+        text = "Thought: This thought has no bpe markers.\nAction: wait()"
+        reasoning, _ = self.p.extract_reasoning(text)
+        assert reasoning is not None
+        assert "Ġ" not in reasoning
+        assert "Ċ" not in reasoning
+
+
+class TestReasoningParserStreaming:
+    def setup_method(self) -> None:
+        self.p = UiTarsReasoningParser()
+
+    def _stream(self, deltas: list[str]) -> list:
+        prev = ""
+        out = []
+        for d in deltas:
+            cur = prev + d
+            msg = self.p.extract_reasoning_streaming(prev, cur, d)
+            if msg is not None:
+                out.append(msg)
+            prev = cur
+        return out
+
+    def test_thought_streamed_as_reasoning(self):
+        events = self._stream(["Thought: ", "I'm thinking.\n", "Action: wait()"])
+        reasoning_concat = "".join(e.reasoning or "" for e in events)
+        content_concat = "".join(e.content or "" for e in events)
+        assert "I'm thinking" in reasoning_concat
+        assert content_concat.startswith("Action:")
+
+    def test_boundary_split_in_single_delta(self):
+        events = self._stream(["Thought: hi.\nAction: wait()"])
+        reasoning_concat = "".join(e.reasoning or "" for e in events)
+        content_concat = "".join(e.content or "" for e in events)
+        assert "hi" in reasoning_concat
+        # Boundary delta must NOT have ``Action:`` in reasoning side.
+        assert "Action:" not in reasoning_concat
+        assert content_concat.startswith("Action:")
+
+    def test_no_preamble_routes_to_content(self):
+        # Buffer reaches Action_Summary: length (15 chars) without a
+        # preamble opener → flips to content.
+        events = self._stream(["Action: wait() done extra padding bytes"])
+        content_concat = "".join(e.content or "" for e in events)
+        reasoning_concat = "".join(e.reasoning or "" for e in events)
+        assert reasoning_concat == ""
+        assert content_concat.startswith("Action:")
+
+    def test_partial_action_opener_held_back(self):
+        # Regression for the live-stream symptom: model emits
+        # ``Action`` then ``:`` in separate deltas. Without the
+        # partial-opener hold, the ``Action`` token leaks into the
+        # reasoning channel and the tool parser sees ``: click(...)``
+        # without the leading ``Action:`` sentinel — extracts no
+        # tool_calls. The hold keeps the trailing ``Action`` in
+        # reasoning's buffer until the ``:`` arrives, then releases
+        # ``Action:`` as a single content event so the tool parser
+        # sees the full token.
+        events = self._stream(
+            [
+                "Thought: ",
+                "click.\n",
+                "Action",  # partial opener
+                ":",  # boundary resolves
+                " click(point='<point>1 2</point>')",
+            ]
+        )
+        reasoning_concat = "".join(e.reasoning or "" for e in events)
+        content_concat = "".join(e.content or "" for e in events)
+        # No ``Action`` token leaked into reasoning.
+        assert "Action" not in reasoning_concat
+        # Tool parser sees the complete ``Action:`` opener.
+        assert "Action:" in content_concat
+
+
+# ---------------------------------------------------------------------------
+# Anthropic adapter end-to-end mapping
+# ---------------------------------------------------------------------------
+
+
+class TestAnthropicAdapter:
+    """UI-TARS tool_calls should round-trip cleanly to Anthropic tool_use blocks."""
+
+    def setup_method(self) -> None:
+        self.p = UiTarsToolParser()
+
+    def _to_openai_choice(self, text: str):
+        """Build a minimal OpenAI-style ChatCompletion response with parser output."""
+        # Import inside the test to avoid pulling the adapter into module
+        # import paths used by smaller parser-only tests.
+        from vllm_mlx.api.models import (
+            AssistantMessage,
+            ChatCompletionChoice,
+            ChatCompletionResponse,
+            FunctionCall,
+            ToolCall,
+        )
+
+        r = self.p.extract_tool_calls(text)
+        oai_tool_calls = [
+            ToolCall(
+                id=tc["id"],
+                type="function",
+                function=FunctionCall(name=tc["name"], arguments=tc["arguments"]),
+            )
+            for tc in r.tool_calls
+        ]
+        return ChatCompletionResponse(
+            id="chatcmpl-test",
+            object="chat.completion",
+            created=0,
+            model="ui-tars-1.5-7b-4bit",
+            choices=[
+                ChatCompletionChoice(
+                    index=0,
+                    message=AssistantMessage(
+                        role="assistant",
+                        content=r.content,
+                        tool_calls=oai_tool_calls or None,
+                    ),
+                    finish_reason="tool_calls" if r.tools_called else "stop",
+                )
+            ],
+        )
+
+    def test_click_maps_to_tool_use_with_computer_name(self):
+        from vllm_mlx.api.anthropic_adapter import openai_to_anthropic
+
+        text = "Thought: Click search.\nAction: click(point='<point>200 300</point>')"
+        openai_resp = self._to_openai_choice(text)
+        anth = openai_to_anthropic(openai_resp, "ui-tars-1.5-7b-4bit")
+        tool_use_blocks = [b for b in anth.content if b.type == "tool_use"]
+        assert len(tool_use_blocks) == 1
+        tu = tool_use_blocks[0]
+        assert tu.name == "computer"
+        assert tu.input == {"action": "click", "point": [200, 300]}
+
+    def test_multi_action_emits_multiple_tool_use_blocks(self):
+        from vllm_mlx.api.anthropic_adapter import openai_to_anthropic
+
+        text = (
+            "Thought: Click then type.\n"
+            "Action: click(point='<point>1 2</point>')\n"
+            "Action: type(content='hi')"
+        )
+        openai_resp = self._to_openai_choice(text)
+        anth = openai_to_anthropic(openai_resp, "ui-tars-1.5-7b-4bit")
+        tool_use_blocks = [b for b in anth.content if b.type == "tool_use"]
+        assert len(tool_use_blocks) == 2
+        assert tool_use_blocks[0].input["action"] == "click"
+        assert tool_use_blocks[1].input["action"] == "type"

--- a/tests/test_ui_tars_parser.py
+++ b/tests/test_ui_tars_parser.py
@@ -525,6 +525,37 @@ class TestToolParserStreaming:
         # No action at all — not pending.
         assert self.p.has_pending_tool_call("Thought: hi") is False
 
+    def test_residual_content_after_action_in_same_delta(self):
+        # codex r2 BLOCKING #1 + NIT #3: when a delta contains a
+        # completed action followed by ordinary text (e.g. the model
+        # appends ``  done`` after ``Action: wait()`` in a single chunk),
+        # the parser MUST emit both the ``tool_calls`` and the trailing
+        # text as ``content`` — otherwise the trailing bytes are lost
+        # from the response.
+        events = self._stream(["Action: wait() done"])
+        tool_events = [e for e in events if "tool_calls" in e]
+        assert len(tool_events) == 1
+        assert tool_events[0]["tool_calls"][0]["function"]["name"] == "computer"
+        # Content side must carry the trailing `` done`` bytes — note
+        # leading space is preserved verbatim (no normalization).
+        assert tool_events[0].get("content") == " done"
+
+    def test_residual_content_between_two_actions_in_same_delta(self):
+        # Same regression as above but exercises the leading/trailing
+        # residual paths simultaneously: ``prefix Action: wait() between
+        # Action: finished() trailing`` packs prefix/inter-action/trailing
+        # non-action text alongside two completed actions in one delta.
+        # All three text spans must surface in the ``content`` field.
+        delta = "leading Action: wait() between Action: finished() trailing"
+        events = self._stream([delta])
+        tool_events = [e for e in events if "tool_calls" in e]
+        assert len(tool_events) == 1
+        assert len(tool_events[0]["tool_calls"]) == 2
+        residual = tool_events[0].get("content", "")
+        assert "leading " in residual
+        assert " between " in residual
+        assert " trailing" in residual
+
 
 # ---------------------------------------------------------------------------
 # Reasoning parser — Thought:/Reflection: preamble split

--- a/tests/test_ui_tars_parser.py
+++ b/tests/test_ui_tars_parser.py
@@ -409,6 +409,21 @@ class TestToolParserComplete:
             "start_box": [233, 45],
         }
 
+    def test_nested_action_in_string_arg_not_double_parsed(self):
+        # Codex r1 BLOCKING #1 (2026-06-21): ``Action: type(content=
+        # 'Action: wait()')`` previously parsed as TWO calls because the
+        # outer ``finditer`` matched the sentinel inside the string arg.
+        # The scanner now advances past each matched ``)`` before
+        # searching for the next ``Action:``, so the inner sentinel
+        # stays as plain string content.
+        text = "Action: type(content='Action: wait()')"
+        r = self.p.extract_tool_calls(text)
+        assert len(r.tool_calls) == 1
+        assert _decode(r.tool_calls[0]) == {
+            "action": "type",
+            "content": "Action: wait()",
+        }
+
     def test_no_action_passes_through(self):
         text = "Just a thought, no action."
         r = self.p.extract_tool_calls(text)
@@ -556,19 +571,34 @@ class TestReasoningParserComplete:
         assert reasoning is None
         assert content == ""
 
-    def test_bpe_markers_do_not_leak(self):
-        # Regression guard: ensure no Qwen/BPE artifacts (``Ġ``, ``Ċ``)
-        # are introduced into reasoning_content by the parser. UI-TARS
-        # tokenizers use byte-level BPE; if the upstream pipeline
-        # already detokenized the bytes back to UTF-8 the parser must
-        # not add them. Run with markers in source and verify they
-        # survive untouched (i.e. parser doesn't munge or strip
-        # legitimate text content).
-        text = "Thought: This thought has no bpe markers.\nAction: wait()"
-        reasoning, _ = self.p.extract_reasoning(text)
+    def test_bpe_markers_pass_through_untouched(self):
+        # Regression guard: if a buggy upstream pipeline forwards raw
+        # byte-level BPE artifacts (``Ġ`` for space, ``Ċ`` for newline)
+        # to the reasoning parser, we must NOT silently strip them — we
+        # also must not add them where they didn't exist. The parser is
+        # a string-level slicer; markers should round-trip verbatim into
+        # the reasoning channel so the caller can detect the upstream
+        # detokenizer bug instead of having it hidden here.
+        # (codex r1 NIT #3: the previous version of this test claimed to
+        # exercise marker handling but never fed markers in.)
+        text = "Thought:ĠThisĠthoughtĠhasĠBPEĠmarkers.ĊAction: wait()"
+        reasoning, content = self.p.extract_reasoning(text)
+        # Marker bytes survive untouched in reasoning (no covert strip).
         assert reasoning is not None
-        assert "Ġ" not in reasoning
-        assert "Ċ" not in reasoning
+        assert "Ġ" in reasoning
+        assert "Ċ" in reasoning
+        # And the parser doesn't smear markers into the content side
+        # where the source text had none.
+        assert content is not None
+        assert "Ġ" not in content
+        assert "Ċ" not in content
+
+        # Companion check: with NO markers in source, none appear in
+        # output either (parser never invents BPE artifacts).
+        clean = "Thought: a clean thought.\nAction: wait()"
+        r2, c2 = self.p.extract_reasoning(clean)
+        assert r2 is not None and "Ġ" not in r2 and "Ċ" not in r2
+        assert c2 is not None and "Ġ" not in c2 and "Ċ" not in c2
 
 
 class TestReasoningParserStreaming:
@@ -610,6 +640,34 @@ class TestReasoningParserStreaming:
         reasoning_concat = "".join(e.reasoning or "" for e in events)
         assert reasoning_concat == ""
         assert content_concat.startswith("Action:")
+
+    def test_short_action_only_response_routes_promptly(self):
+        # codex r1 BLOCKING #2: when the response is a short action-only
+        # ack (Grounding template, no Thought:) and the bytes arrive
+        # split across tiny deltas, the parser must flip to content as
+        # soon as ``Action:`` is complete — NOT wait until the buffer
+        # reaches ``Action_Summary:`` length (15 chars). Otherwise a
+        # bare ``Action: wait()`` (13 chars) gets held forever and the
+        # dispatcher emits an empty assistant message.
+        events = self._stream(
+            [
+                "Action",  # 6 chars — could still be Action: prefix
+                ":",  # now ``Action:`` complete at 7 chars
+                " wait()",
+            ]
+        )
+        reasoning_concat = "".join(e.reasoning or "" for e in events)
+        content_concat = "".join(e.content or "" for e in events)
+        # All bytes route to content (no preamble).
+        assert reasoning_concat == ""
+        # Content stream contains the full ``Action: wait()`` sentinel
+        # ready for the tool parser to extract.
+        assert "Action:" in content_concat
+        assert "wait()" in content_concat
+        # And we actually emitted at least one content event before
+        # end-of-stream — i.e. the bytes weren't held until the buffer
+        # reached 15 chars (the response is only 13 chars total).
+        assert sum(1 for e in events if e.content) >= 1
 
     def test_partial_action_opener_held_back(self):
         # Regression for the live-stream symptom: model emits

--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -1005,5 +1005,95 @@
     "is_moe": false,
     "supports_spec_decode": false,
     "supports_dflash": false
+  },
+  "ui-tars-1.5-7b-4bit": {
+    "hf_path": "mlx-community/UI-TARS-1.5-7B-4bit",
+    "tool_call_parser": "ui_tars",
+    "reasoning_parser": "ui_tars",
+    "is_hybrid": false,
+    "is_moe": false,
+    "supports_spec_decode": false,
+    "supports_dflash": false,
+    "suffix_decoding_tier": "unknown"
+  },
+  "ui-tars-1.5-7b-6bit": {
+    "hf_path": "mlx-community/UI-TARS-1.5-7B-6bit",
+    "tool_call_parser": "ui_tars",
+    "reasoning_parser": "ui_tars",
+    "is_hybrid": false,
+    "is_moe": false,
+    "supports_spec_decode": false,
+    "supports_dflash": false,
+    "suffix_decoding_tier": "unknown"
+  },
+  "ui-tars-1.5-7b-8bit": {
+    "hf_path": "mlx-community/UI-TARS-1.5-7B-8bit",
+    "tool_call_parser": "ui_tars",
+    "reasoning_parser": "ui_tars",
+    "is_hybrid": false,
+    "is_moe": false,
+    "supports_spec_decode": false,
+    "supports_dflash": false,
+    "suffix_decoding_tier": "unknown"
+  },
+  "ui-tars-7b-dpo-4bit": {
+    "hf_path": "mlx-community/UI-TARS-7B-DPO-4bit",
+    "tool_call_parser": "ui_tars",
+    "reasoning_parser": "ui_tars",
+    "is_hybrid": false,
+    "is_moe": false,
+    "supports_spec_decode": false,
+    "supports_dflash": false,
+    "suffix_decoding_tier": "unknown"
+  },
+  "ui-tars-7b-dpo-6bit": {
+    "hf_path": "mlx-community/UI-TARS-7B-DPO-6bit",
+    "tool_call_parser": "ui_tars",
+    "reasoning_parser": "ui_tars",
+    "is_hybrid": false,
+    "is_moe": false,
+    "supports_spec_decode": false,
+    "supports_dflash": false,
+    "suffix_decoding_tier": "unknown"
+  },
+  "ui-tars-7b-dpo-8bit": {
+    "hf_path": "mlx-community/UI-TARS-7B-DPO-8bit",
+    "tool_call_parser": "ui_tars",
+    "reasoning_parser": "ui_tars",
+    "is_hybrid": false,
+    "is_moe": false,
+    "supports_spec_decode": false,
+    "supports_dflash": false,
+    "suffix_decoding_tier": "unknown"
+  },
+  "ui-tars-7b-sft-4bit": {
+    "hf_path": "mlx-community/UI-TARS-7B-SFT-4bit",
+    "tool_call_parser": "ui_tars",
+    "reasoning_parser": "ui_tars",
+    "is_hybrid": false,
+    "is_moe": false,
+    "supports_spec_decode": false,
+    "supports_dflash": false,
+    "suffix_decoding_tier": "unknown"
+  },
+  "ui-tars-7b-sft-8bit": {
+    "hf_path": "mlx-community/UI-TARS-7B-SFT-8bit",
+    "tool_call_parser": "ui_tars",
+    "reasoning_parser": "ui_tars",
+    "is_hybrid": false,
+    "is_moe": false,
+    "supports_spec_decode": false,
+    "supports_dflash": false,
+    "suffix_decoding_tier": "unknown"
+  },
+  "ui-tars-72b-dpo-4bit": {
+    "hf_path": "mlx-community/UI-TARS-72B-DPO-4bit",
+    "tool_call_parser": "ui_tars",
+    "reasoning_parser": "ui_tars",
+    "is_hybrid": false,
+    "is_moe": false,
+    "supports_spec_decode": false,
+    "supports_dflash": false,
+    "suffix_decoding_tier": "unknown"
   }
 }

--- a/vllm_mlx/api/utils.py
+++ b/vllm_mlx/api/utils.py
@@ -629,6 +629,17 @@ MLLM_PATTERNS = [
     "InternVL",  # InternVL
     "deepseek-vl",
     "DeepSeek-VL",  # DeepSeek-VL
+    # UI-TARS (ByteDance) — Qwen2-VL / Qwen2.5-VL based GUI-agent VLM.
+    # The model id ``UI-TARS-…`` does not match the generic ``-VL-`` pattern
+    # (the VL part is in the underlying architecture, not the public name),
+    # so list it explicitly. Without this entry, ``is_mllm_model`` returns
+    # False on full HF paths like ``mlx-community/UI-TARS-1.5-7B-4bit``
+    # and the engine boots the text-only path, breaking the screenshot+
+    # instruction contract every UI-TARS deployment needs.
+    "UI-TARS",
+    "ui-tars",
+    "UI_TARS",
+    "ui_tars",
 ]
 
 

--- a/vllm_mlx/model_auto_config.py
+++ b/vllm_mlx/model_auto_config.py
@@ -141,6 +141,25 @@ _MODEL_PATTERNS: list[tuple[re.Pattern, ModelConfig]] = [
             reasoning_parser=None,
         ),
     ),
+    # UI-TARS (ByteDance) — Qwen2-VL / Qwen2.5-VL based GUI-agent VLM.
+    # Wire format is the literal ``Action: verb(kwargs)`` Computer-Use
+    # shape (see vllm_mlx.tool_parsers.ui_tars_tool_parser). MUST come
+    # BEFORE any generic Qwen2/Qwen2.5 pattern would otherwise match —
+    # full HF paths like ``mlx-community/UI-TARS-7B-DPO-4bit`` should
+    # resolve here, not to the generic Qwen3 fallback.
+    (
+        re.compile(r"ui[-_]?tars", re.IGNORECASE),
+        ModelConfig(
+            tool_call_parser="ui_tars",
+            reasoning_parser="ui_tars",
+            is_hybrid=False,
+            # UI-TARS uses Qwen2-VL/Qwen2.5-VL mrope; spec decode hasn't
+            # been benched on the VLM variant. Keep off until verified
+            # to avoid silent quality regressions (mirrors the gemma 3n
+            # / phi-3.5 conservative defaults).
+            supports_spec_decode=False,
+        ),
+    ),
     # Qwopus (Qwen3.5 distilled with Claude Opus reasoning) — hybrid base
     (
         re.compile(r"qwopus", re.IGNORECASE),

--- a/vllm_mlx/reasoning/__init__.py
+++ b/vllm_mlx/reasoning/__init__.py
@@ -85,6 +85,7 @@ def _register_builtin_parsers():
     from .harmony_parser import HarmonyReasoningParser
     from .minimax_parser import MiniMaxReasoningParser
     from .qwen3_parser import Qwen3ReasoningParser
+    from .ui_tars_parser import UiTarsReasoningParser
 
     register_parser("gemma4", Gemma4ReasoningParser)
     register_parser("qwen3", Qwen3ReasoningParser)
@@ -98,6 +99,11 @@ def _register_builtin_parsers():
     register_parser("gpt_oss", GptOssReasoningParser)
     register_parser("harmony", HarmonyReasoningParser)
     register_parser("minimax", MiniMaxReasoningParser)
+    # ``ui_tars`` — UI-TARS Thought:/Reflection: preamble splitter (no
+    # ``<think>`` tags; labels are literal). Auto-wired by the ``ui-tars*``
+    # regex in ``model_auto_config`` and by the alias entries in
+    # ``aliases.json``.
+    register_parser("ui_tars", UiTarsReasoningParser)
 
 
 # Register built-in parsers on module load

--- a/vllm_mlx/reasoning/ui_tars_parser.py
+++ b/vllm_mlx/reasoning/ui_tars_parser.py
@@ -152,12 +152,30 @@ class UiTarsReasoningParser(ReasoningParser):
                 self._in_reasoning = True
                 # FALLTHROUGH to the reasoning branch below — first delta
                 # of the preamble emits as reasoning.
+            elif stripped.startswith("Action:"):
+                # Action-only response (Grounding template) — no preamble.
+                # Flip to content immediately so a ``wait()`` / ``finished()``
+                # ack lands promptly instead of being held until the buffer
+                # reaches ``Action_Summary:`` length (codex r1 BLOCKING #2).
+                # ``previous_text`` is whatever we previously held back
+                # (returned ``None`` for); prepend it so the tool parser
+                # sees the complete ``Action:`` sentinel including any
+                # leading whitespace.
+                self._in_content = True
+                if previous_text:
+                    return DeltaMessage(content=previous_text + delta_text)
+                return DeltaMessage(content=delta_text)
             else:
-                # No preamble. If the buffer is long enough to definitively
-                # rule out a preamble (longest opener is ``Action_Summary:``
-                # at 15 chars), route to content from here on out.
-                if len(stripped) >= len("Action_Summary:"):
+                # Buffer doesn't yet match any opener. Use the SHORTEST
+                # disambiguating prefix length — once ``len(stripped) >=
+                # len("Action:")`` (7), we know it can't be a preamble
+                # whose opener starts with ``T``/``R``/``A`` because
+                # those would have matched above. Flip to content and
+                # flush any previously held bytes alongside this delta.
+                if len(stripped) >= len("Action:"):
                     self._in_content = True
+                    if previous_text:
+                        return DeltaMessage(content=previous_text + delta_text)
                     return DeltaMessage(content=delta_text)
                 # Hold off — the next delta might complete a preamble.
                 return None

--- a/vllm_mlx/reasoning/ui_tars_parser.py
+++ b/vllm_mlx/reasoning/ui_tars_parser.py
@@ -228,20 +228,34 @@ class UiTarsReasoningParser(ReasoningParser):
         # the tool parser sees the full ``Action:`` token.
         delta_start_in_current = len(previous_text)
         boundary_in_delta = action_pos - delta_start_in_current
-        self._in_content = True
         if boundary_in_delta <= 0:
             # Boundary at the start of this delta — but the prefix
             # bytes of ``Action:`` might already be in previous_text
             # that we previously held off emitting. Prepend the held
             # window so the tool parser receives the complete token.
+            # Only flip ``_in_content=True`` once we know we have a real
+            # content-bearing emission (codex r2 BLOCKING #2: never set
+            # the flag along a path that emits no content bytes — a
+            # subsequent delta would otherwise be misrouted).
+            self._in_content = True
             held_prefix = current_text[action_pos:delta_start_in_current]
             return DeltaMessage(content=held_prefix + delta_text)
         if boundary_in_delta >= len(delta_text):
-            # Boundary past end of this delta (defensive).
-            return DeltaMessage(reasoning=delta_text)
+            # Defensive: ``action_pos`` indexes a position past this
+            # delta's end. ``current_text = previous_text + delta_text``
+            # means this can only happen if some earlier code path
+            # mutated ``current_text``. Treat as a no-op (don't flip
+            # ``_in_content`` and don't classify the delta — leave the
+            # bytes for the postprocessor's hold buffer). Critically,
+            # codex r2 BLOCKING #2 flagged the previous behavior of
+            # eagerly setting ``_in_content=True`` here, which then
+            # caused subsequent deltas to skip the boundary-split branch
+            # entirely and lose the action-side bytes permanently.
+            return None
 
         reasoning_part = delta_text[:boundary_in_delta]
         content_part = delta_text[boundary_in_delta:]
+        self._in_content = True
         return DeltaMessage(reasoning=reasoning_part, content=content_part)
 
     def _compute_partial_action_hold(self, current_text: str) -> int:

--- a/vllm_mlx/reasoning/ui_tars_parser.py
+++ b/vllm_mlx/reasoning/ui_tars_parser.py
@@ -1,0 +1,254 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Reasoning parser for UI-TARS (ByteDance) GUI-agent VLMs.
+
+UI-TARS emits an unambiguous ``Thought: <chain-of-thought>\n\nAction: ...``
+shape per the upstream ``codes/ui_tars/prompt.py`` (COMPUTER_USE_DOUBAO,
+MOBILE_USE_DOUBAO). The 1.5 line also occasionally opens with
+``Reflection: ... Action_Summary: ...`` as a richer scratchpad — both
+preludes are reasoning, not user-facing prose.
+
+This parser splits the prelude into ``reasoning_content`` and leaves the
+``Action:`` lines for the matching ``UiTarsToolParser`` to consume.
+Symmetric with the tool parser: the action lines are the tool channel,
+the ``Thought:`` / ``Reflection:`` line is the reasoning channel.
+"""
+
+import re
+
+from .base import DeltaMessage, ReasoningParser
+
+# Anchor at start-of-output so a mid-response mention of "Thought:" inside
+# a user-supplied screenshot caption doesn't get misclassified.
+#
+# Three preamble shapes are recognized (one match per response):
+#   1. "Thought: ...\nAction: ..."         (default UI-TARS prompt)
+#   2. "Reflection: ...\nAction_Summary: ...\nAction: ..."  (1.5 reflective shape)
+#   3. "Action_Summary: ...\nAction: ..."  (1.5 minimal-reflection shape)
+#
+# Non-greedy up to the first ``Action:`` literal so a runaway thought
+# trace doesn't swallow the entire response.
+_PREAMBLE_RE = re.compile(
+    r"^\s*"
+    r"(?P<thought>"
+    r"(?:Thought:\s*(?:.*?))"
+    r"|(?:Reflection:\s*(?:.*?)\s*Action_Summary:\s*(?:.*?))"
+    r"|(?:Action_Summary:\s*(?:.*?))"
+    r")"
+    r"(?=\s*Action:)",
+    re.DOTALL,
+)
+
+
+class UiTarsReasoningParser(ReasoningParser):
+    """Reasoning parser for UI-TARS Thought:/Reflection: preambles.
+
+    Returns the ``Thought:`` / ``Reflection: ... Action_Summary: ...``
+    prelude as ``reasoning`` and everything from the first ``Action:`` line
+    onward as ``content``. The tool parser then strips the ``Action:``
+    lines from that content and emits them as ``tool_calls`` — the
+    reasoning parser stays out of that concern.
+
+    Streaming: greedy in the early bytes. If we've seen ``Thought:`` /
+    ``Reflection:`` / ``Action_Summary:`` at offset 0 but no ``Action:``
+    yet, every delta streams to reasoning. Once the first ``Action:``
+    arrives we flip channels and the rest goes to content. This matches
+    DeepSeek-R1's pattern but with literal-label boundaries instead of
+    ``<think>`` tags.
+    """
+
+    _PREAMBLE_OPENERS: tuple[str, ...] = (
+        "Thought:",
+        "Reflection:",
+        "Action_Summary:",
+    )
+
+    # Maximum trailing-byte prefix that could be the start of the
+    # ``Action:`` boundary token. ``Action:`` is 7 chars; we hold back up
+    # to 6 trailing bytes from a reasoning delta when they might be the
+    # partial opener so the tool parser sees the complete ``Action:``
+    # token in its content stream, not pre-truncated to ``ction:`` etc.
+    _MAX_BOUNDARY_PREFIX = len("Action:") - 1
+
+    def __init__(self, tokenizer=None):
+        super().__init__(tokenizer)
+        # Streaming state: True once we've routed at least one byte to
+        # reasoning so the channel is sticky until ``Action:`` shows up.
+        self._in_reasoning = False
+        self._in_content = False
+
+    # ------------------------------------------------------------------
+    # Complete-response API
+    # ------------------------------------------------------------------
+    def extract_reasoning(
+        self,
+        model_output: str,
+        enable_thinking: bool | None = None,
+    ) -> tuple[str | None, str | None]:
+        """Split a complete UI-TARS response into (reasoning, content).
+
+        ``enable_thinking`` is accepted for protocol compatibility with the
+        base class but ignored — the UI-TARS prompt always elicits the
+        Thought: preamble unless the request explicitly used the
+        Grounding template (no preamble, action-only). In that case the
+        regex simply fails to match and we return ``(None, model_output)``.
+        """
+        if not model_output:
+            return None, model_output
+
+        m = _PREAMBLE_RE.match(model_output)
+        if m is None:
+            # No preamble — pure-action response (Grounding template) or
+            # a malformed output. Surface as content; tool parser will
+            # still extract the actions.
+            return None, model_output
+
+        thought = m.group("thought").strip() or None
+        rest = model_output[m.end() :].lstrip()
+        return thought, (rest if rest else None)
+
+    # ------------------------------------------------------------------
+    # Streaming API
+    # ------------------------------------------------------------------
+    def extract_reasoning_streaming(
+        self,
+        previous_text: str,
+        current_text: str,
+        delta_text: str,
+    ) -> DeltaMessage | None:
+        """Route each streaming delta to ``reasoning`` or ``content``.
+
+        State machine:
+
+        * Initial: route delta bytes to ``content`` until we've seen
+          either an unambiguous preamble opener (``Thought:`` /
+          ``Reflection:`` / ``Action_Summary:``) anchored at offset 0, OR
+          an ``Action:`` token (which means there's no preamble at all and
+          the entire response is content).
+        * Reasoning: route delta bytes to ``reasoning`` until the literal
+          ``Action:`` arrives. On the transition delta, split bytes
+          around the ``Action:`` boundary.
+        * Content: route delta bytes to ``content`` until end-of-stream.
+
+        Returns ``None`` on a no-op delta (e.g. partial ``Thoug`` /
+        ``Reflec`` opener that hasn't matched yet — bytes are held by
+        the postprocessor through ``flush_held_content``).
+        """
+        if not delta_text:
+            return None
+
+        # Already past the preamble — all remaining bytes are content.
+        if self._in_content:
+            return DeltaMessage(content=delta_text)
+
+        # Discriminate the very first delta(s). We're "in reasoning" as
+        # soon as we've seen a preamble opener at offset 0 of the buffer.
+        if not self._in_reasoning:
+            stripped = current_text.lstrip()
+            if not stripped:
+                # All whitespace so far — defer decision until we have
+                # a real token.
+                return None
+            if any(stripped.startswith(p) for p in self._PREAMBLE_OPENERS):
+                self._in_reasoning = True
+                # FALLTHROUGH to the reasoning branch below — first delta
+                # of the preamble emits as reasoning.
+            else:
+                # No preamble. If the buffer is long enough to definitively
+                # rule out a preamble (longest opener is ``Action_Summary:``
+                # at 15 chars), route to content from here on out.
+                if len(stripped) >= len("Action_Summary:"):
+                    self._in_content = True
+                    return DeltaMessage(content=delta_text)
+                # Hold off — the next delta might complete a preamble.
+                return None
+
+        # In reasoning channel. Look for the ``Action:`` boundary inside
+        # this delta to decide whether to split.
+        action_pos = current_text.find("Action:")
+        if action_pos == -1:
+            # No full ``Action:`` yet. The trailing bytes of current_text
+            # MIGHT be the partial leading edge of ``Action:`` (e.g.
+            # delta ``Action`` then later ``:``). Hold any tail bytes
+            # back so the tool parser receives the complete ``Action:``
+            # token once the boundary forms, instead of seeing the
+            # leading ``Action`` token leak into the reasoning channel.
+            held = self._compute_partial_action_hold(current_text)
+            if held == 0:
+                return DeltaMessage(reasoning=delta_text)
+            # ``held`` bytes are the trailing partial-opener candidate.
+            # Emit only the prefix bytes of this delta that fall BEFORE
+            # the partial-opener zone. Bytes already in previous_text
+            # were emitted on a prior delta — those can't be unsent —
+            # but we can still avoid streaming the boundary candidate
+            # bytes that arrived in THIS delta.
+            held_window_start = len(current_text) - held
+            delta_start_in_current = len(previous_text)
+            if held_window_start <= delta_start_in_current:
+                # Every byte of this delta is in the held window — emit
+                # nothing this round (postprocessor's per-event buffer
+                # holds the bytes until the next delta resolves them).
+                return None
+            split = held_window_start - delta_start_in_current
+            return DeltaMessage(reasoning=delta_text[:split])
+
+        # ``Action:`` is in current_text but might be straddling this
+        # delta or might be entirely in previous_text. Compute the offset
+        # of the boundary within the delta.
+        prev_action_pos = previous_text.find("Action:") if previous_text else -1
+        if prev_action_pos != -1:
+            # Boundary was already crossed on a prior delta — should not
+            # happen in practice (we flip ``_in_content=True`` below the
+            # first time it does), but defend against double-fire.
+            self._in_content = True
+            return DeltaMessage(content=delta_text)
+
+        # First time we see ``Action:``. Split delta around the boundary:
+        # bytes before it are reasoning, bytes from it onward are content.
+        # NOTE: if any partial-opener bytes were held back on a prior
+        # delta (e.g. trailing ``Action`` while the colon hadn't arrived
+        # yet), they're now part of the content half — prepend them so
+        # the tool parser sees the full ``Action:`` token.
+        delta_start_in_current = len(previous_text)
+        boundary_in_delta = action_pos - delta_start_in_current
+        self._in_content = True
+        if boundary_in_delta <= 0:
+            # Boundary at the start of this delta — but the prefix
+            # bytes of ``Action:`` might already be in previous_text
+            # that we previously held off emitting. Prepend the held
+            # window so the tool parser receives the complete token.
+            held_prefix = current_text[action_pos:delta_start_in_current]
+            return DeltaMessage(content=held_prefix + delta_text)
+        if boundary_in_delta >= len(delta_text):
+            # Boundary past end of this delta (defensive).
+            return DeltaMessage(reasoning=delta_text)
+
+        reasoning_part = delta_text[:boundary_in_delta]
+        content_part = delta_text[boundary_in_delta:]
+        return DeltaMessage(reasoning=reasoning_part, content=content_part)
+
+    def _compute_partial_action_hold(self, current_text: str) -> int:
+        """Return the number of trailing bytes that might be a partial ``Action:``.
+
+        Specifically: the longest non-empty suffix ``current_text[-k:]``
+        (1 ≤ k ≤ 6) that matches a strict prefix of ``"Action:"``. Returns
+        0 if no such partial overlap exists.
+
+        Example: current_text ends with ``...thing.\nAction`` — the
+        trailing 6 bytes ``Action`` match the 6-char prefix of
+        ``Action:``, so we hold those 6 bytes back. The next delta brings
+        ``:``, the full ``Action:`` resolves, and the held bytes are
+        released to content alongside.
+        """
+        for k in range(self._MAX_BOUNDARY_PREFIX, 0, -1):
+            if k > len(current_text):
+                continue
+            if "Action:".startswith(current_text[-k:]):
+                return k
+        return 0
+
+    # ------------------------------------------------------------------
+    # Lifecycle hook used by the streaming dispatcher between requests.
+    # ------------------------------------------------------------------
+    def reset_state(self) -> None:
+        self._in_reasoning = False
+        self._in_content = False

--- a/vllm_mlx/tool_parsers/__init__.py
+++ b/vllm_mlx/tool_parsers/__init__.py
@@ -65,6 +65,7 @@ from .nemotron_tool_parser import NemotronToolParser
 from .qwen3coder_tool_parser import Qwen3CoderToolParser
 from .qwen_tool_parser import QwenToolParser
 from .seed_oss_tool_parser import SeedOssToolParser
+from .ui_tars_tool_parser import UiTarsToolParser
 from .xlam_tool_parser import xLAMToolParser
 
 __all__ = [
@@ -91,4 +92,5 @@ __all__ = [
     "SeedOssToolParser",
     "DeepSeekV31ToolParser",
     "Qwen3CoderToolParser",
+    "UiTarsToolParser",
 ]

--- a/vllm_mlx/tool_parsers/abstract_tool_parser.py
+++ b/vllm_mlx/tool_parsers/abstract_tool_parser.py
@@ -87,6 +87,8 @@ class ExtractedToolCallInformation:
 #                           </arguments></function>  VibeThinker auto-emit
 #                           (F-042); distinct from ``function_bare`` which
 #                           uses the inline ``<function=NAME>`` attribute form.
+#   ui_tars_action        — Action: verb(kwargs)  UI-TARS GUI-agent action
+#                           lines, normalized to ``computer`` tool_calls.
 WIRE_FORMAT_LABELS: frozenset[str] = frozenset(
     {
         "tool_call_json",
@@ -108,6 +110,7 @@ WIRE_FORMAT_LABELS: frozenset[str] = frozenset(
         "deepseek_native",
         "deepseek_v31_native",
         "qwen3_coder_xml_named",
+        "ui_tars_action",
     }
 )
 

--- a/vllm_mlx/tool_parsers/ui_tars_tool_parser.py
+++ b/vllm_mlx/tool_parsers/ui_tars_tool_parser.py
@@ -1,0 +1,566 @@
+# SPDX-License-Identifier: Apache-2.0
+"""UI-TARS Computer-Use action parser for rapid-mlx.
+
+UI-TARS (ByteDance) is a Qwen2-VL / Qwen2.5-VL based GUI agent VLM that
+takes a screenshot + instruction and emits one or more action calls in
+the literal ``Action: <verb>(<args>)`` shape. The actions follow the
+Anthropic Computer-Use idiom — ``click`` / ``drag`` / ``hotkey`` / ``type``
+/ ``scroll`` / ``wait`` / ``finished`` / ``call_user`` plus mobile
+variants ``long_press`` / ``open_app`` / ``press_home`` / ``press_back``.
+
+Reference: https://github.com/bytedance/UI-TARS (``codes/ui_tars/prompt.py``
++ ``codes/ui_tars/action_parser.py``).
+
+Wire format examples this parser is responsible for:
+
+    Thought: Click the search button in the top-right.
+    Action: click(point='<point>200 300</point>')
+
+    Thought: Drag the slider from left to right.
+    Action: drag(start_point='<point>100 500</point>', end_point='<point>800 500</point>')
+
+    Action: type(content='hello world\\n')
+
+    Action: hotkey(key='ctrl c')
+
+This parser emits each ``Action: <verb>(<kwargs>)`` line as a single
+OpenAI ``tool_call`` whose ``function.name`` is ``"computer"`` (mirroring
+Anthropic's ``computer`` tool) and ``function.arguments`` is a JSON object
+of the canonical shape ``{"action": "<verb>", ...kwargs}``. Coordinate
+arguments are normalized from the model's ``'<point>x y</point>'`` string
+to a 2-int list ``[x, y]`` — downstream consumers ``json.loads`` the
+arguments string and get a structured point, not a UI-TARS-specific
+template string.
+
+The accompanying reasoning parser (``vllm_mlx.reasoning.ui_tars_parser``)
+splits the leading ``Thought: ...`` (or ``Reflection: ... Action_Summary:
+...``) preamble into ``reasoning_content`` so SDK consumers don't see the
+chain-of-thought leak into ``content``.
+
+The ``Action:`` lines are stripped out of the residual ``content`` field
+so OpenAI/Anthropic SDK consumers don't double-render them as both
+``tool_calls`` and prose.
+
+Streaming: emit each completed action eagerly the moment its closing
+``)`` arrives. Dedup against the count of actions already emitted on the
+previous delta (mirrors the pattern in ``QwenToolParser`` / ``HermesToolParser``).
+"""
+
+import ast
+import json
+import logging
+import re
+import uuid
+from collections.abc import Sequence
+from typing import Any
+
+from .abstract_tool_parser import (
+    ExtractedToolCallInformation,
+    ToolParser,
+    ToolParserManager,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# Canonical OpenAI function name for every UI-TARS action. Mirrors the
+# Anthropic ``computer`` / ``computer_20241022`` tool that Computer-Use
+# clients are already prompting for, so a Claude SDK consumer can swap
+# UI-TARS in without rewriting the tool-handler dispatch.
+COMPUTER_TOOL_NAME = "computer"
+
+
+# Verbs UI-TARS may emit. The set is a superset of the desktop
+# (``COMPUTER_USE_DOUBAO``) and mobile (``MOBILE_USE_DOUBAO``) action
+# spaces in ``codes/ui_tars/prompt.py``. Verbs not in this set are still
+# parsed and surfaced verbatim — we intentionally don't gate on the list
+# so a future UI-TARS revision that adds a verb won't silently drop calls
+# during the upgrade window.
+_KNOWN_VERBS: frozenset[str] = frozenset(
+    {
+        # Desktop / Computer-Use
+        "click",
+        "left_double",
+        "right_single",
+        "drag",
+        "hotkey",
+        "type",
+        "scroll",
+        "wait",
+        "finished",
+        "done",
+        "call_user",
+        # Mobile additions
+        "long_press",
+        "open_app",
+        "press_home",
+        "press_back",
+    }
+)
+
+
+# Action line: ``Action: verb(kwargs)`` — verb identifier, parenthesized
+# args body. Body may span newlines (e.g. ``type(content='line1\nline2')``)
+# but must end on a balanced ``)``. We match minimally and use a manual
+# brace-balanced consumer in ``_iter_actions`` for correctness on nested
+# parens inside string args.
+_ACTION_LINE = re.compile(r"\bAction:\s*([A-Za-z_][A-Za-z0-9_]*)\s*\(", re.MULTILINE)
+
+# Reasoning-channel preamble at the start of a UI-TARS response. When the
+# tool parser is run on its own (no separate reasoning parser configured),
+# we strip this preamble out of ``content`` so the same chain-of-thought
+# doesn't surface twice (once in ``reasoning_content`` via the reasoning
+# parser, once in ``content`` via the tool parser). The reasoning parser
+# is configured to extract this same prefix; stripping here keeps the
+# two surfaces aligned regardless of postprocessor invocation order.
+_PREAMBLE_LEADING = re.compile(
+    r"^\s*(?:Thought|Reflection|Action_Summary):.*?(?=\s*Action:|\Z)",
+    re.DOTALL,
+)
+
+# Point/box body the model emits inside kwargs:
+#   point='<point>x1 y1</point>'
+#   start_point='<point>x1 y1</point>'
+#   end_point='<point>x2 y2</point>'
+#   start_box='<bbox>x1 y1 x2 y2</bbox>'  (UI-TARS-1.5 absolute-coord shape)
+# Tolerant of single/double quotes, extra whitespace, and missing tag
+# (some quantized checkpoints emit bare ``<x,y>`` without ``<point>`` —
+# verified in 2026-06 community forks; preserve robustness).
+_POINT_TAGGED = re.compile(
+    r"<point>\s*([-+]?\d+(?:\.\d+)?)\s+([-+]?\d+(?:\.\d+)?)\s*</point>"
+)
+_POINT_BARE_ANGLE = re.compile(
+    r"<\s*([-+]?\d+(?:\.\d+)?)\s*[,\s]\s*([-+]?\d+(?:\.\d+)?)\s*>"
+)
+_BBOX_TAGGED = re.compile(
+    r"<bbox>\s*([-+]?\d+(?:\.\d+)?)\s+([-+]?\d+(?:\.\d+)?)\s+"
+    r"([-+]?\d+(?:\.\d+)?)\s+([-+]?\d+(?:\.\d+)?)\s*</bbox>"
+)
+# UI-TARS-1.5 sentinel-token format observed in live 4-bit checkpoint:
+#   start_box='<|box_start|>(x,y)<|box_end|>'
+#   start_box='<|box_start|>(x1,y1),(x2,y2)<|box_end|>'  (4-tuple variant)
+# Coords are absolute pixel offsets into the input image (see
+# action_parser.py's qwen25vl branch in upstream UI-TARS repo).
+_BOX_SENTINEL = re.compile(
+    r"<\|box_start\|>\s*(\([^)]+\)(?:\s*,\s*\([^)]+\))?)\s*<\|box_end\|>"
+)
+
+
+def _generate_tool_id() -> str:
+    """Mint an OpenAI-flavored tool-call id.
+
+    Adapter layer (``vllm_mlx/api/anthropic_adapter.py``) rewrites the
+    prefix to ``toolu_`` on the ``/v1/messages`` surface — coordinated
+    with D-ANTHRO-SPEC-POLISH so all parsers stay on the OpenAI ``call_``
+    convention and the per-surface prefix is owned by a single helper.
+    """
+    return f"call_{uuid.uuid4().hex[:8]}"
+
+
+def _coerce_int(value: float) -> int | float:
+    """Snap a UI-TARS coord to int if it's a whole number, else preserve float.
+
+    UI-TARS-1.0 emits integer 0-1000 normalized coords; UI-TARS-1.5 emits
+    absolute integer pixel coords. Both are integral. We keep the float
+    type for the rare case that future variants emit subpixel decimals
+    (e.g. for sub-grid drag interpolation) — round-tripping ``200.5`` →
+    ``200`` would silently change semantics.
+    """
+    if isinstance(value, float) and value.is_integer():
+        return int(value)
+    return value
+
+
+def _parse_point(raw: str) -> list[float | int] | None:
+    """Parse a point/box string to a coordinate list.
+
+    Recognized shapes (in priority order):
+      1. ``<point>x y</point>``     → ``[x, y]``
+      2. ``<bbox>x1 y1 x2 y2</bbox>`` → ``[x1, y1, x2, y2]``
+      3. ``<x, y>`` or ``<x y>``     → ``[x, y]``  (bare-angle fallback)
+      4. ``x, y`` or ``[x, y]``      → ``[x, y]``  (Python-literal fallback)
+
+    Returns ``None`` if no recognizable coordinate pattern is found so the
+    caller can preserve the raw string in ``arguments`` (don't drop user
+    intent on a malformed action).
+    """
+    if not isinstance(raw, str):
+        return None
+
+    s = raw.strip()
+    m = _POINT_TAGGED.search(s)
+    if m is not None:
+        return [_coerce_int(float(m.group(1))), _coerce_int(float(m.group(2)))]
+
+    m = _BBOX_TAGGED.search(s)
+    if m is not None:
+        return [_coerce_int(float(m.group(i))) for i in (1, 2, 3, 4)]
+
+    # UI-TARS-1.5 sentinel — ``<|box_start|>(x,y)<|box_end|>`` (single point)
+    # or ``<|box_start|>(x1,y1),(x2,y2)<|box_end|>`` (bbox). Split the inner
+    # tuples cheaply via regex; coord parsing reuses the comma-split fallback
+    # below by stripping parens.
+    m = _BOX_SENTINEL.search(s)
+    if m is not None:
+        body = m.group(1)
+        nums: list[int | float] = []
+        for tup in re.findall(r"\(([^)]+)\)", body):
+            for part in tup.split(","):
+                try:
+                    nums.append(_coerce_int(float(part.strip())))
+                except ValueError:
+                    continue
+        if nums:
+            return nums
+
+    m = _POINT_BARE_ANGLE.search(s)
+    if m is not None:
+        return [_coerce_int(float(m.group(1))), _coerce_int(float(m.group(2)))]
+
+    # Python-literal fallback: ``[200, 300]`` or ``(200, 300)`` or ``200,300``
+    candidate = s.strip("[]()")
+    parts = [p.strip() for p in candidate.split(",")]
+    if 2 <= len(parts) <= 4:
+        try:
+            nums = [_coerce_int(float(p)) for p in parts]
+        except ValueError:
+            return None
+        return nums
+
+    return None
+
+
+def _find_balanced_close(text: str, start: int) -> int:
+    """Return the index of the ``)`` that closes the paren at ``text[start-1]``.
+
+    Skips parens that appear inside Python string literals (single, double,
+    or triple-quoted) so that ``type(content='hello (world)')`` is consumed
+    as a single action. Returns ``-1`` if no balanced close is found before
+    end-of-string — that signals a partial mid-stream action which the
+    streaming path should NOT emit yet.
+
+    Algorithm: scan forward, tracking quote state (none / single / double
+    / triple-single / triple-double) and paren depth. Backslash escapes
+    are honored inside quoted regions.
+    """
+    n = len(text)
+    depth = 1
+    i = start
+    quote: str | None = None  # one of None, "'", '"', "'''", '"""'
+    while i < n:
+        ch = text[i]
+        if quote is None:
+            if ch == "(":
+                depth += 1
+                i += 1
+                continue
+            if ch == ")":
+                depth -= 1
+                if depth == 0:
+                    return i
+                i += 1
+                continue
+            if ch in ("'", '"'):
+                # Probe for triple-quote
+                if i + 2 < n and text[i + 1] == ch and text[i + 2] == ch:
+                    quote = ch * 3
+                    i += 3
+                    continue
+                quote = ch
+                i += 1
+                continue
+            i += 1
+            continue
+        # Inside a quoted string.
+        if ch == "\\" and i + 1 < n:
+            i += 2
+            continue
+        if len(quote) == 3:
+            if i + 2 < n and text[i : i + 3] == quote:
+                i += 3
+                quote = None
+                continue
+            i += 1
+            continue
+        # Single-char quote.
+        if ch == quote:
+            quote = None
+            i += 1
+            continue
+        i += 1
+    return -1
+
+
+def _parse_kwargs(body: str) -> dict[str, Any]:
+    """Parse the kwargs body of an action call.
+
+    UI-TARS emits Python kwargs syntax: ``key='value', key2='value2'``.
+    We use ``ast.parse`` to handle escapes / quoted-paren correctly, with
+    a regex fallback for malformed bodies (e.g. unclosed quotes from a
+    truncated stream — keeps the parser graceful instead of crashing).
+
+    Special-cases the upstream ``parse_action_to_structure_output`` rename
+    where ``start_point`` / ``end_point`` are aliased to
+    ``start_box`` / ``end_box`` and bare ``point`` becomes ``start_box``.
+    We DON'T do that rename here — we preserve the verb-author's intent
+    so a downstream consumer can dispatch on the original kwarg name.
+    """
+    body = body.strip()
+    if not body:
+        return {}
+    try:
+        # Wrap as a function call to use Python's grammar for kwargs.
+        node = ast.parse(f"_({body})", mode="eval")
+    except SyntaxError:
+        return _parse_kwargs_lenient(body)
+
+    call = node.body
+    if not isinstance(call, ast.Call):
+        return {}
+    kwargs: dict[str, Any] = {}
+    for kw in call.keywords:
+        if kw.arg is None:  # **kwargs splat — unsupported in UI-TARS
+            continue
+        try:
+            value: Any = ast.literal_eval(kw.value)
+        except (ValueError, SyntaxError):
+            try:
+                value = ast.unparse(kw.value)
+            except AttributeError:
+                value = None
+        kwargs[kw.arg] = value
+    # Positional args (e.g. ``finished("done")`` instead of
+    # ``finished(content="done")``) — UI-TARS doesn't emit these per the
+    # upstream prompt, but quantized variants occasionally do. Bind them
+    # by position to a best-effort name so they're not silently lost.
+    for idx, pos in enumerate(call.args):
+        try:
+            kwargs.setdefault(f"arg{idx}", ast.literal_eval(pos))
+        except (ValueError, SyntaxError):
+            continue
+    return kwargs
+
+
+_KWARG_REGEX = re.compile(
+    r"([A-Za-z_][A-Za-z0-9_]*)\s*=\s*"
+    r"(?:'((?:[^'\\]|\\.)*)'|\"((?:[^\"\\]|\\.)*)\"|([^,]+))",
+    re.DOTALL,
+)
+
+
+def _parse_kwargs_lenient(body: str) -> dict[str, Any]:
+    """Regex fallback when ``ast.parse`` rejects a malformed body."""
+    out: dict[str, Any] = {}
+    for m in _KWARG_REGEX.finditer(body):
+        key = m.group(1)
+        sq, dq, bare = m.group(2), m.group(3), m.group(4)
+        if sq is not None:
+            out[key] = sq.encode().decode("unicode_escape", errors="replace")
+        elif dq is not None:
+            out[key] = dq.encode().decode("unicode_escape", errors="replace")
+        else:
+            val = (bare or "").strip()
+            # Try Python literal first; fall back to raw string.
+            try:
+                out[key] = ast.literal_eval(val)
+            except (ValueError, SyntaxError):
+                out[key] = val
+    return out
+
+
+def _normalize_action(verb: str, kwargs: dict[str, Any]) -> dict[str, Any]:
+    """Map a parsed (verb, kwargs) pair to the canonical computer-tool args.
+
+    Output shape: ``{"action": "<verb>", ...normalized_kwargs}``.
+
+    Point-bearing kwargs (``point``, ``start_point``, ``end_point``,
+    ``start_box``, ``end_box``) are normalized to integer lists when the
+    coordinate body parses cleanly. Other kwargs pass through untouched.
+    Unknown verbs are NOT rejected — emit them verbatim so a future
+    UI-TARS-2.0 verb doesn't get dropped during the upgrade window.
+    """
+    out: dict[str, Any] = {"action": verb}
+    _COORD_KEYS = ("point", "start_point", "end_point", "start_box", "end_box")
+    for key, value in kwargs.items():
+        if key in _COORD_KEYS and isinstance(value, str):
+            parsed = _parse_point(value)
+            if parsed is not None:
+                out[key] = parsed
+                continue
+        out[key] = value
+    return out
+
+
+def _iter_actions(text: str) -> list[tuple[int, int, str, dict[str, Any]]]:
+    """Find every ``Action: verb(...)`` block in left-to-right order.
+
+    Returns a list of ``(start, end, verb, kwargs)`` tuples. ``start`` /
+    ``end`` are byte offsets into ``text`` for the full ``Action: ...``
+    line so the caller can blank out the matched spans when computing the
+    residual ``content``. Bodies are extracted via the balanced-paren
+    scanner above so embedded ``)`` inside string args don't truncate.
+
+    A partial action mid-stream (no balanced ``)`` yet) is NOT returned —
+    the streaming path relies on this to avoid double-emitting once the
+    rest of the body arrives.
+    """
+    actions: list[tuple[int, int, str, dict[str, Any]]] = []
+    for m in _ACTION_LINE.finditer(text):
+        verb = m.group(1)
+        body_start = m.end()
+        close = _find_balanced_close(text, body_start)
+        if close == -1:
+            # Partial action — skip until the body finishes. The streaming
+            # callsite re-scans on every delta, so we'll catch it later.
+            continue
+        body = text[body_start:close]
+        kwargs = _parse_kwargs(body)
+        actions.append((m.start(), close + 1, verb, kwargs))
+    return actions
+
+
+@ToolParserManager.register_module(["ui_tars", "ui-tars", "uitars"])
+class UiTarsToolParser(ToolParser):
+    """Tool-call parser for UI-TARS (ByteDance) GUI-agent VLMs.
+
+    Wire format: ``Action: <verb>(<kwargs>)`` lines (typically preceded
+    by a ``Thought: ...`` chain-of-thought block which the matching
+    reasoning parser handles separately).
+
+    Each action becomes a single OpenAI ``tool_call`` with
+    ``function.name = "computer"`` and ``function.arguments`` a JSON
+    object of the form ``{"action": "<verb>", ...kwargs}`` — see
+    ``_normalize_action`` for the kwarg-normalization contract.
+
+    Used when ``--tool-call-parser ui_tars`` is set (or auto-wired by
+    the ``ui-tars*`` regex in ``model_auto_config``).
+    """
+
+    EXPECTED_WIRE_FORMATS = ("ui_tars_action",)
+
+    # Chat template for UI-TARS does NOT define ``role="tool"`` handling;
+    # action results flow back through user messages with screenshots
+    # rather than structured tool_result blocks. Leave the native-format
+    # flag off — the engine will text-convert any historical tool calls.
+    SUPPORTS_NATIVE_TOOL_FORMAT = False
+
+    def extract_tool_calls(
+        self, model_output: str, request: dict[str, Any] | None = None
+    ) -> ExtractedToolCallInformation:
+        """Parse a complete UI-TARS response.
+
+        Empty / no-action input passes through with ``tools_called=False``
+        and the original text as ``content`` so non-action prose
+        (e.g. ``call_user()`` rejection messages) isn't lost.
+        """
+        if not model_output or "Action:" not in model_output:
+            return ExtractedToolCallInformation(
+                tools_called=False, tool_calls=[], content=model_output
+            )
+
+        actions = _iter_actions(model_output)
+        if not actions:
+            return ExtractedToolCallInformation(
+                tools_called=False, tool_calls=[], content=model_output
+            )
+
+        # Build tool_calls + blank out matched spans for residual content.
+        tool_calls: list[dict[str, Any]] = []
+        residual_parts: list[str] = []
+        cursor = 0
+        for start, end, verb, kwargs in actions:
+            residual_parts.append(model_output[cursor:start])
+            cursor = end
+            args = _normalize_action(verb, kwargs)
+            tool_calls.append(
+                {
+                    "id": _generate_tool_id(),
+                    "name": COMPUTER_TOOL_NAME,
+                    "arguments": json.dumps(args, ensure_ascii=False),
+                }
+            )
+        residual_parts.append(model_output[cursor:])
+        content = "".join(residual_parts)
+        # Strip the standalone ``Thought:`` / ``Reflection:`` /
+        # ``Action_Summary:`` preamble from ``content`` so the same chain
+        # of thought doesn't surface twice (once in ``reasoning_content``
+        # via the reasoning parser, once in ``content`` here). The
+        # reasoning parser owns the channel; this strip is a defensive
+        # mirror so a misconfigured server (tool parser ON, reasoning
+        # parser OFF) still produces clean content.
+        content = _PREAMBLE_LEADING.sub("", content).strip()
+        return ExtractedToolCallInformation(
+            tools_called=True,
+            tool_calls=tool_calls,
+            content=content or None,
+        )
+
+    def extract_tool_calls_streaming(
+        self,
+        previous_text: str,
+        current_text: str,
+        delta_text: str,
+        previous_token_ids: Sequence[int] | None = None,
+        current_token_ids: Sequence[int] | None = None,
+        delta_token_ids: Sequence[int] | None = None,
+        request: dict[str, Any] | None = None,
+    ) -> dict[str, Any] | None:
+        """Streaming variant — emit each action exactly once when its body closes.
+
+        Strategy: count balanced ``Action: ...)`` blocks in ``previous_text``
+        vs ``current_text``. If the count increased, parse the newly
+        completed actions and emit them with the right ``index`` offset.
+
+        Edge cases:
+        - Partial action mid-stream (no closing ``)`` yet) — ``_iter_actions``
+          skips it, count stays unchanged, no emit. Once the ``)`` lands
+          on a future delta, the action counts forward.
+        - Mid-stream backslash-escaped close inside a string literal —
+          ``_find_balanced_close`` honors quote state so we don't
+          prematurely emit on ``type(content='oops)')``.
+        - No ``Action:`` seen yet — passthrough delta as content so the
+          ``Thought:`` preamble streams to the reasoning channel via the
+          reasoning parser (which sees the same delta).
+        """
+        if "Action:" not in current_text:
+            return {"content": delta_text}
+
+        prev_actions = _iter_actions(previous_text) if previous_text else []
+        cur_actions = _iter_actions(current_text)
+
+        if len(cur_actions) <= len(prev_actions):
+            return None
+
+        new_actions = cur_actions[len(prev_actions) :]
+        tool_calls = []
+        for i, (_start, _end, verb, kwargs) in enumerate(new_actions):
+            args = _normalize_action(verb, kwargs)
+            tool_calls.append(
+                {
+                    "index": len(prev_actions) + i,
+                    "id": _generate_tool_id(),
+                    "type": "function",
+                    "function": {
+                        "name": COMPUTER_TOOL_NAME,
+                        "arguments": json.dumps(args, ensure_ascii=False),
+                    },
+                }
+            )
+        return {"tool_calls": tool_calls}
+
+    def has_pending_tool_call(self, text: str) -> bool:
+        """Return True if text contains an unfinished ``Action: verb(`` block.
+
+        The ``finalize()`` postprocessor uses this to decide whether to
+        hold delta bytes back vs. flush them as content at end-of-stream.
+        For UI-TARS we conservatively say "pending" iff an ``Action:``
+        token appears with no balanced ``)`` after it — that's the only
+        case where a late-arriving byte could change parser output.
+        """
+        if "Action:" not in text:
+            return False
+        for m in _ACTION_LINE.finditer(text):
+            close = _find_balanced_close(text, m.end())
+            if close == -1:
+                return True
+        return False

--- a/vllm_mlx/tool_parsers/ui_tars_tool_parser.py
+++ b/vllm_mlx/tool_parsers/ui_tars_tool_parser.py
@@ -400,22 +400,33 @@ def _iter_actions(text: str) -> list[tuple[int, int, str, dict[str, Any]]]:
     residual ``content``. Bodies are extracted via the balanced-paren
     scanner above so embedded ``)`` inside string args don't truncate.
 
+    Action: sentinels that appear INSIDE an already-consumed action's
+    body — e.g. ``Action: type(content='Action: wait()')`` — are skipped
+    so the inner string-literal content is not re-parsed as a second
+    tool call. The scanner advances past each matched ``)`` cursor.
+
     A partial action mid-stream (no balanced ``)`` yet) is NOT returned —
     the streaming path relies on this to avoid double-emitting once the
     rest of the body arrives.
     """
     actions: list[tuple[int, int, str, dict[str, Any]]] = []
-    for m in _ACTION_LINE.finditer(text):
+    cursor = 0
+    n = len(text)
+    while cursor < n:
+        m = _ACTION_LINE.search(text, cursor)
+        if m is None:
+            break
         verb = m.group(1)
         body_start = m.end()
         close = _find_balanced_close(text, body_start)
         if close == -1:
             # Partial action — skip until the body finishes. The streaming
             # callsite re-scans on every delta, so we'll catch it later.
-            continue
+            break
         body = text[body_start:close]
         kwargs = _parse_kwargs(body)
         actions.append((m.start(), close + 1, verb, kwargs))
+        cursor = close + 1
     return actions
 
 

--- a/vllm_mlx/tool_parsers/ui_tars_tool_parser.py
+++ b/vllm_mlx/tool_parsers/ui_tars_tool_parser.py
@@ -557,7 +557,44 @@ class UiTarsToolParser(ToolParser):
                     },
                 }
             )
-        return {"tool_calls": tool_calls}
+
+        # codex r2 BLOCKING #1: a single delta can contain a completed
+        # action plus trailing/leading non-action text — e.g. delta
+        # ``Action: wait() done`` where `` done`` is regular content the
+        # model emitted after the action. Without explicit handling, the
+        # original implementation only returned ``{"tool_calls": ...}``
+        # and the trailing bytes were silently dropped from the response.
+        #
+        # Recover those bytes by computing the residual portion of THIS
+        # delta that falls outside any newly completed action span. We
+        # operate on offsets into ``current_text`` and clip to the slice
+        # that this specific delta contributed.
+        delta_start_in_current = len(previous_text)
+        residual_pieces: list[str] = []
+        cursor = delta_start_in_current
+        for start, end, _verb, _kwargs in new_actions:
+            # Bytes from the prior cursor up to the action's start that
+            # fall inside this delta's window are residual content.
+            if start > cursor:
+                # Clip to [delta_start_in_current, len(current_text))
+                piece_start = max(cursor, delta_start_in_current)
+                piece_end = min(start, len(current_text))
+                if piece_end > piece_start:
+                    residual_pieces.append(current_text[piece_start:piece_end])
+            cursor = end
+        # Trailing bytes after the last newly completed action that fall
+        # inside this delta's window.
+        if cursor < len(current_text):
+            piece_start = max(cursor, delta_start_in_current)
+            piece_end = len(current_text)
+            if piece_end > piece_start:
+                residual_pieces.append(current_text[piece_start:piece_end])
+
+        residual = "".join(residual_pieces)
+        result: dict[str, Any] = {"tool_calls": tool_calls}
+        if residual:
+            result["content"] = residual
+        return result
 
     def has_pending_tool_call(self, text: str) -> bool:
         """Return True if text contains an unfinished ``Action: verb(`` block.


### PR DESCRIPTION
## Summary

Add first-class support for ByteDance's UI-TARS GUI-agent VLM family. Closes the gap where serving any UI-TARS checkpoint left the raw `Action: verb(...)` wire format leaking into `content` with no structured `tool_calls`.

- **Aliases**: 9 verified `mlx-community` entries (UI-TARS-1.5-7B 4/6/8bit, UI-TARS-7B-DPO/SFT 4/6/8bit, UI-TARS-72B-DPO-4bit) all wired to the new `ui_tars` tool + reasoning parsers.
- **Tool parser** (`vllm_mlx/tool_parsers/ui_tars_tool_parser.py`): matches `Action: <verb>(<kwargs>)` lines and normalizes the 9 desktop + 4 mobile Computer-Use verbs into a single OpenAI `tool_call` with `name="computer"` and structured `arguments`. Coordinate kwargs (`point`, `start_point`, `end_point`, `start_box`, `end_box`) are normalized from the model's literal string into integer lists.
- **Reasoning parser** (`vllm_mlx/reasoning/ui_tars_parser.py`): routes the `Thought: ...` / `Reflection: ... Action_Summary: ...` preamble to `reasoning_content`. Streaming holds back the trailing partial `Action` opener until the colon lands so the tool parser sees the complete sentinel.
- **Anthropic adapter**: no new code — the existing `openai_to_anthropic` path round-trips UI-TARS tool_calls to `/v1/messages` `tool_use` blocks with `name="computer"` and structured `input`. Verified live.

## Model-card research

| Model | Architecture | Action format | Coords |
| --- | --- | --- | --- |
| `ByteDance-Seed/UI-TARS-1.5-7B` | `qwen2_5_vl` | `Action: click(point='<point>x y</point>')` | absolute pixel |
| `ByteDance/UI-TARS-7B-DPO` | `qwen2_vl` | `Action: click(point='<point>x y</point>')` | 0-1000 normalized |
| `ByteDance/UI-TARS-72B-DPO` | `qwen2_vl` | same | 0-1000 normalized |

Action verbs: `click`, `left_double`, `right_single`, `drag` (start_point + end_point), `hotkey(key='ctrl c')`, `type(content='…')`, `scroll(point=…, direction=…)`, `wait()`, `finished(content='…')` plus mobile `long_press`, `open_app`, `press_home`, `press_back`. Verified verbatim against [the upstream prompt template](https://github.com/bytedance/UI-TARS/blob/main/codes/ui_tars/prompt.py) (`COMPUTER_USE_DOUBAO` / `MOBILE_USE_DOUBAO`).

UI-TARS-1.5 also emits a sentinel-token coordinate shape `<|box_start|>(x,y)<|box_end|>` — observed live on `mlx-community/UI-TARS-1.5-7B-4bit` and normalized by the parser to `[x, y]`.

## Alias registry

| Alias | HF path | parsers |
| --- | --- | --- |
| `ui-tars-1.5-7b-4bit` | `mlx-community/UI-TARS-1.5-7B-4bit` | ui_tars / ui_tars |
| `ui-tars-1.5-7b-6bit` | `mlx-community/UI-TARS-1.5-7B-6bit` | ui_tars / ui_tars |
| `ui-tars-1.5-7b-8bit` | `mlx-community/UI-TARS-1.5-7B-8bit` | ui_tars / ui_tars |
| `ui-tars-7b-dpo-4bit` | `mlx-community/UI-TARS-7B-DPO-4bit` | ui_tars / ui_tars |
| `ui-tars-7b-dpo-6bit` | `mlx-community/UI-TARS-7B-DPO-6bit` | ui_tars / ui_tars |
| `ui-tars-7b-dpo-8bit` | `mlx-community/UI-TARS-7B-DPO-8bit` | ui_tars / ui_tars |
| `ui-tars-7b-sft-4bit` | `mlx-community/UI-TARS-7B-SFT-4bit` | ui_tars / ui_tars |
| `ui-tars-7b-sft-8bit` | `mlx-community/UI-TARS-7B-SFT-8bit` | ui_tars / ui_tars |
| `ui-tars-72b-dpo-4bit` | `mlx-community/UI-TARS-72B-DPO-4bit` | ui_tars / ui_tars |

Each HF path verified `curl HEAD 200`. Auto-config regex `ui[-_]?tars` covers any other UI-TARS HF path (e.g. `ByteDance-Seed/UI-TARS-1.5-7B`).

## Before / after envelope (live verify, `mlx-community/UI-TARS-1.5-7B-4bit`)

**Before** (no parser, `/tmp/ui-tars-baseline.json`):
```json
"content": "Thought: I noticed a blue search button in the upper right corner... \nAction: click(start_box='(220,43)')"
```

**After** (with parsers, `/tmp/ui-tars-after-openai.json`):
```json
"content": null,
"reasoning_content": "Thought: I noticed a blue search button in the upper right corner...",
"tool_calls": [{
  "id": "call_ed0521b9",
  "type": "function",
  "function": {
    "name": "computer",
    "arguments": "{\"action\": \"click\", \"start_box\": [233, 45]}"
  }
}]
```

**After Anthropic** (`/tmp/ui-tars-after-anthropic.json`):
```json
"content": [
  {"type": "thinking", "thinking": "Thought: ..."},
  {"type": "tool_use", "id": "call_98038f0d", "name": "computer",
   "input": {"action": "click", "start_box": [1043, 108]}}
]
```

**Streaming** (`/tmp/ui-tars-stream-events.json`): reasoning deltas for the Thought, then `Action:` arrives intact as a content delta, then a structured `tool_call` event fires.

## Test plan

- [x] `pytest tests/test_ui_tars_parser.py` — 89 tests pass (all 9 desktop + 4 mobile verbs, partial-action streaming, sentinel + `<point>` + bare-angle + Python-literal coord shapes, Anthropic adapter mapping, alias resolution, regex auto-config)
- [x] `pytest tests/test_tool_call_streaming_parity.py` — `ui_tars_action` parity fixture added; stream / non-stream paths return identical tool_calls
- [x] `pytest tests/test_tool_parser_coverage.py` — `ui_tars` TODO entry + `ui-tars` / `uitars` alias exemptions documented; audit passes
- [x] `pytest tests/test_tool_parser_wire_formats.py` — `ui_tars_action` registered in `WIRE_FORMAT_LABELS`; structural test passes
- [x] `pytest tests/test_model_profiles_ssot.py tests/test_aliases_contract.py tests/test_model_auto_config.py` — alias entries load cleanly, no schema regressions
- [x] `pytest tests/test_routes.py tests/test_anthropic_adapter.py tests/test_api_utils.py` — no regressions on adapter / route surfaces
- [x] Full unit sweep ex-extras — 56 failed, 7696 passed (same 56 baseline failures as `6731973`; +193 net new passes from UI-TARS tests, no NEW failures)
- [x] `ruff check` + `ruff format` clean on all 10 touched files
- [x] Live wire verify on `mlx-community/UI-TARS-1.5-7B-4bit` (server port 8980): non-streaming OpenAI, non-streaming Anthropic, streaming OpenAI — all three produce structured `tool_calls` / `tool_use` blocks with normalized integer coords. Evidence at `/tmp/ui-tars-{baseline,after-openai,after-anthropic,stream-events}.json`.

## Coordination

PR #810 (D-ANTHRO-SPEC-POLISH) is touching the Anthropic adapter for `toolu_` IDs in parallel. This PR uses the standard `call_` convention everywhere; if #810 merges first, the adapter rewrites IDs at the `/v1/messages` boundary. If this PR merges first, #810 picks up UI-TARS tool_calls and applies the prefix translation through its existing helper.

## Post-merge follow-up (non-gated)

- Add an mlx-vlm-backed golden_models.yaml entry once the pr_validate matrix gains VLM coverage; `ui_tars` TODO entry in `audit_tool_parser_coverage` will then be removed.
- Expand the streaming parity fixture with a multi-action UI-TARS shape (`Action: click(...)\nAction: type(...)`) once non-VLM models start emitting parallel tool_calls under the same wire format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)