### PR TITLE
docs(readme): add UI-TARS row to model family table

### DIFF
--- a/README.md
+++ b/README.md
@@ -510,10 +510,10 @@ Decoded examples:
 
 ### Full model lineup
 
-83 explicit aliases across 14 families ship today. Run `rapid-mlx models` for the live list with parser, hybrid / MoE flags, and DFlash eligibility.
+103 explicit aliases across 15 families ship today. Run `rapid-mlx models` for the live list with parser, hybrid / MoE flags, and DFlash eligibility.
 
 <details>
-<summary><strong>Show all 83 aliases by family</strong></summary>
+<summary><strong>Show all 103 aliases by family</strong></summary>
 
 | Family | Aliases | Notable |
 |---|---|---|
@@ -531,6 +531,7 @@ Decoded examples:
 | **Mistral / Devstral** | `mistral-24b-4bit`, `devstral-24b-4bit`, `devstral-v2-24b-4bit`, `ministral-3b-4bit` | |
 | **Other** | `phi-4-14b-4bit`, `phi-4-mini-4bit`, `smollm3-3b-4bit`, `nemotron-30b-4bit`, `bonsai-1.7b-unpacked`, `-4b-unpacked`, `-8b-unpacked`, `granite4-tiny-4bit`, `vibethinker-1.5b-4bit`, `vibethinker-3b-8bit` | Weibo VibeThinker 1.5B / 3B reasoning (MIT) |
 | 🆕 **Text-Diffusion** | `diffusion-gemma-26b-4bit`, `diffusion-gemma-26b-8bit` | Non-autoregressive (block denoising); same `/v1/chat/completions` API |
+| 🆕 **UI-TARS** | `ui-tars-1.5-7b-4bit`, `-6bit`, `-8bit`, `ui-tars-7b-dpo-4bit`, `-6bit`, `-8bit`, `ui-tars-7b-sft-4bit`, `-8bit`, `ui-tars-72b-dpo-4bit` | ByteDance GUI agent (Qwen2-VL); Computer-Use actions parsed as OpenAI `tool_calls` + Anthropic `tool_use` (`name="computer"`) |
 
 ✨ = DFlash speculative decoding supported (opt in with `--enable-dflash`). `rapid-mlx info <alias>` shows per-alias capabilities.
 


### PR DESCRIPTION
## Summary

- Add UI-TARS row to the family table in the *Full model lineup* section
- Bump count from \"83 explicit aliases across 14 families\" → \"103 explicit aliases across 15 families\" (current ``aliases.json`` has 103 entries; UI-TARS PR #812 added 9 new aliases)
- Call out that Computer-Use actions are parsed as OpenAI ``tool_calls`` (``name=\"computer\"``) and Anthropic ``tool_use`` blocks

## Why

PR #812 shipped UI-TARS aliases + Computer-Use action parser as a first-class model family. The README family table is the user-facing model catalog — keeping it in sync so users can discover UI-TARS without grepping ``aliases.json``.

Companion landing-page update is being prepared separately in the rapidmlx.com repo (FAQ JSON-LD + visible text).

## Test plan

- [x] Family count matches ``aliases.json`` line count
- [x] All 9 UI-TARS aliases listed match PR #812
- [x] Markdown renders correctly on GitHub