### PR TITLE
chore: bump version to 0.8.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.8.4"
+version = "0.8.5"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## Why

Bump release to ship 6 PRs landed since 0.8.4 — five bug-fix PRs closing 0.8.3 dogfood HIGH findings (Anthropic envelope/spec conformance, capabilities detection, embed alias, envelope leak) plus the UI-TARS first-class support PR. **Closes 0.8.3 dogfood follow-ups.**

## What ships in 0.8.5

- **#811** envelope wrapper + content-block discriminator + role-block matrix + empty-messages guard (D-ANTHRO-VALIDATION — F1+F4+F10+F11)
- **#804** unified capabilities detection + single mlx_audio probe + ``--embedding-model`` exit-on-missing (D-CAPABILITIES-DETECTION)
- **#810** ``tool_choice=none`` strip + omit null fields + ``toolu_`` prefix + ``tool_choice=tool`` best-effort + ``count_tokens`` parity (D-ANTHRO-SPEC-POLISH — F6+F7+F8+F9+F12)
- **#807** enforce ``tool_choice.type=any`` + plumb prompt_tokens into streaming usage (D-ANTHRO-TOOL-USAGE — F3+F5)
- **#805** populate ``ValidationError.param`` + render field name + resolve ``--embedding-model`` aliases (D-ENVELOPE-FIELD-LEAK + D-EMBED-ALIAS — F-S2-1/F-S2-2)
- **#812** **UI-TARS** aliases + Computer-Use action parser + Anthropic ``tool_use`` mapping (9 new aliases)

PRs still parked for operator review (not in 0.8.5):
- **#799** D-STOP-THINK (codex oscillation)
- **#806** D-TOOLCHOICE-R1+QWEN3 (codex oscillation — 7 rounds)

Release SOP: this PR is bump-only — subject ``chore: bump version to 0.8.5`` is the auto-release.yml trigger.

## Test plan

- [x] ``pyproject.toml`` bumped 0.8.4 → 0.8.5
- [x] Subject is exactly ``chore: bump version to 0.8.5`` (auto-release.yml gate)
- [x] No other files touched