### PR TITLE
fix(reasoning): remove [truncated...] text injection on /v1/chat/completions + /v1/responses (R-01 cross-route)

### DIFF
--- a/tests/test_harmony_finalize.py
+++ b/tests/test_harmony_finalize.py
@@ -553,16 +553,18 @@ def test_streaming_harmony_cut_short_does_not_leak_into_content_length(monkeypat
     streaming call site's harmony synthetic_raw injection makes the
     rescue helper's gate fire, suppressing the trace.
 
-    H-01 (2026-06-21): the strict-null contract is preserved under the
-    env opt-out (``RAPID_MLX_REASONING_CUTOFF_NOTICE=disabled``). With
-    the env-default H-01 sentinel ON, the terminal chunk surfaces the
-    literal cutoff-notice string in ``delta.content`` so SDK consumers
-    see a clear "truncated, raise max_tokens" signal — that is NOT a
-    leak of the parser-internal trace, so the D-HARMONY-LEAK contract
-    (no byte-for-byte reasoning prose into content) still holds. Run
-    the assertion under the env opt-out to keep this test focused on
-    the original D-HARMONY-LEAK regression guard; the H-01 behaviour
-    has its own dedicated test in ``test_reasoning_content_null_rescue.py``.
+    R-01 (2026-06-21, was H-01): the strict-null contract is the
+    default. The cutoff sentinel is opt-IN via
+    ``RAPID_MLX_REASONING_CUTOFF_NOTICE=1``; with the env var unset (or
+    any non-enable value), the terminal chunk ships
+    ``delta.content=None`` and the D-HARMONY-LEAK contract (no
+    byte-for-byte reasoning prose into content) holds trivially. The
+    explicit ``setenv("disabled")`` below is kept as a belt-and-braces
+    pin against a future env flip — anything outside the documented
+    enable set keeps the sentinel off. The sentinel opt-in behaviour
+    has its own dedicated tests in
+    ``test_reasoning_content_null_rescue.py`` and
+    ``test_truncation_no_synthetic_text.py``.
     """
     monkeypatch.setenv("RAPID_MLX_REASONING_CUTOFF_NOTICE", "disabled")
     events = _drive_streaming_harmony("length")

--- a/tests/test_no_out_of_band_routing.py
+++ b/tests/test_no_out_of_band_routing.py
@@ -235,17 +235,20 @@ ALLOWED_RAPID_MLX_ENV_VARS: frozenset[str] = frozenset(
         "RAPID_MLX_CORS_ALLOW_HEADERS",
         "RAPID_MLX_CORS_MAX_AGE",
         "RAPID_MLX_CORS_ALLOW_CREDENTIALS",
-        # H-01 cutoff sentinel opt-out. Pure UX knob — when reasoning
-        # generation is cut short before ``</think>`` (length-finish
-        # mid-think), surface a literal sentinel string in ``content``
-        # so SDK consumers see a clear "truncated, raise max_tokens"
-        # signal. ``RAPID_MLX_REASONING_CUTOFF_NOTICE=disabled`` reverts
-        # to strict ``content=None`` for callers (internal agents) that
-        # already handle the null shape. Never selects a model, parser,
-        # or routing tier; consumed only by
+        # R-01 (was H-01) cutoff sentinel opt-IN. Pure UX knob — default
+        # OFF after the R-01 dogfood reversal: every transport already
+        # carries an unambiguous structured truncation signal
+        # (``finish_reason="length"`` / ``status="incomplete"`` /
+        # ``stop_reason="max_tokens"``), so synthesizing a literal text
+        # block the model never produced is treated as harmful
+        # injection. Callers who DO want the legacy literal-text cue
+        # can re-enable it on a single envelope field via
+        # ``RAPID_MLX_REASONING_CUTOFF_NOTICE=1`` (or
+        # ``true`` / ``on`` / ``yes`` / ``enabled``). Never selects a
+        # model, parser, or routing tier; consumed only by
         # ``vllm_mlx.service.helpers._cutoff_notice_enabled`` to decide
-        # whether the sentinel notice is surfaced on a single envelope
-        # field. See PR fix/h-01-reasoning-content-null-rescue.
+        # whether the sentinel notice is surfaced. See PR
+        # fix/r01-truncated-injection-cross-route.
         "RAPID_MLX_REASONING_CUTOFF_NOTICE",
     }
 )

--- a/tests/test_reasoning_content_null_rescue.py
+++ b/tests/test_reasoning_content_null_rescue.py
@@ -1,40 +1,37 @@
 # SPDX-License-Identifier: Apache-2.0
-"""H-01 regression tests: reasoning-cutoff sentinel notice.
+"""R-01 (was H-01) regression tests: reasoning-cutoff sentinel notice.
 
 Background
 ----------
-Every OpenAI SDK consumer reads ``choices[0].message.content`` and
-renders empty bubbles when:
+Every reasoning model (qwen3, deepseek_r1, phi-4-mini-reasoning, glm4,
+gemma4, vibethinker, …) can be called with a low ``max_tokens`` budget
+that cuts generation off BEFORE ``</think>`` (or the harmony
+final-channel marker). The parser-wide rule pinned by D-STOP-THINK +
+D-HARMONY-LEAK is "route everything to ``reasoning_content`` and leave
+``content`` null/empty" — the in-progress thought trace is NOT the final
+answer, so promoting it to ``content`` would ship byte-identical bytes
+in both fields (the leak shape those PRs explicitly closed).
 
-* A reasoning model (qwen3, deepseek_r1, phi-4-mini-reasoning, glm4,
-  gemma4, vibethinker, …) is called with low ``max_tokens`` (256 / 512
-  is a common SDK default)
-* ``</think>`` is never reached → ``content=null``, every byte goes to
-  ``reasoning_content``
-* ``finish_reason="length"``
+History
+-------
+* H-01 (PR #802, 0.8.3) introduced an opt-OUT sentinel that injected the
+  literal string ``[truncated — reasoning incomplete; raise max_tokens]``
+  into ``content`` by default so SDK consumers saw something instead of
+  an empty bubble.
+* R-01 (0.8.5 dogfood) flips the policy: synthesizing a placeholder text
+  block the model never produced is harmful injection. Every transport
+  already carries an unambiguous structured truncation signal
+  (``finish_reason="length"`` / ``status="incomplete"`` /
+  ``stop_reason="max_tokens"``) plus ``reasoning_content`` / ``thinking``
+  populated. The sentinel is preserved as an opt-IN behaviour for callers
+  (e.g. chat UIs that only render text blocks) who still want the legacy
+  literal-text cue.
 
-The just-merged D-STOP-THINK (PR #799) and D-HARMONY-LEAK (PR #794)
-reinforced "cut-short routes to ``reasoning_content`` only" as the
-parser-wide rule. H-01 is the complementary UX gap: the strict routing
-is correct for stop-string mid-think (where re-asking can drive past
-the stop string), but on ``finish_reason="length"`` with no closed
-``</think>`` AND no content streamed, SDK consumers see broken empty
-messages with no signal beyond ``finish_reason``.
-
-Policy A (parser-independent, route-boundary): when
-
-* ``finish_reason="length"`` AND
-* ``content`` is empty/None AND
-* ``reasoning_content`` is non-empty AND
-* no tool calls were extracted
-
-surface a clearly-marked literal sentinel string in ``content`` so SDK
-consumers see something. The sentinel is parser-independent text —
-NEVER the parser-internal reasoning trace — so it cannot re-introduce
-the leak D-STOP-THINK / D-HARMONY-LEAK closed.
-
-Opt-out via ``RAPID_MLX_REASONING_CUTOFF_NOTICE=disabled`` for callers
-that already handle ``content is None`` natively.
+Default (R-01) is now OFF. ``RAPID_MLX_REASONING_CUTOFF_NOTICE=1``
+re-enables the sentinel. The helper lives in
+``vllm_mlx.service.helpers._apply_reasoning_cutoff_notice`` and is the
+single source of truth for ``/v1/chat/completions``,
+``/v1/responses``, and ``/v1/messages``.
 """
 
 from __future__ import annotations
@@ -56,17 +53,96 @@ from vllm_mlx.service.helpers import (
 class TestApplyReasoningCutoffNotice:
     """Unit-level predicate tests on ``_apply_reasoning_cutoff_notice``.
 
-    The helper owns every predicate (env var, finish_reason, content
+    The helper owns every predicate (env opt-in, finish_reason, content
     emptiness, reasoning presence, tool-call gate). These tests pin the
     truth table so route call sites can stay trivial and any future
     drift between surfaces fails here first.
     """
 
-    def test_fires_on_length_cut_mid_think(self):
-        """Exact H-01 production failure: ``finish_reason="length"``
-        + empty ``content`` + non-empty reasoning + no tool calls.
-        The sentinel surfaces in ``content``; reasoning stays as-is.
-        """
+    def test_default_is_disabled_when_env_unset(self, monkeypatch):
+        """R-01 contract: unset env var → sentinel disabled. Strict-null
+        contract is the default — the structured truncation signal on
+        every transport (``finish_reason`` / ``status`` / ``stop_reason``)
+        is the canonical cue, so the route ships ``content=None`` and
+        clients render whatever they render for null content."""
+        monkeypatch.delenv("RAPID_MLX_REASONING_CUTOFF_NOTICE", raising=False)
+        result = _apply_reasoning_cutoff_notice(
+            final_content=None,
+            reasoning_text="<incomplete thought>",
+            tool_calls=None,
+            finish_reason="length",
+        )
+        assert result is None, (
+            f"R-01: unset env var must keep the helper as a no-op; got {result!r}"
+        )
+
+    @pytest.mark.parametrize(
+        "enabled_value",
+        ["1", "true", "TRUE", "True", "on", "yes", "enabled"],
+    )
+    def test_env_opt_in_enables_sentinel(self, monkeypatch, enabled_value):
+        """Opt-in: any of the documented enable values re-enables the
+        legacy literal-text cue. Case-insensitive matching is locked so
+        ``"True"`` and ``"TRUE"`` both work — env vars are commonly
+        provided in mixed case by shell wrappers."""
+        monkeypatch.setenv("RAPID_MLX_REASONING_CUTOFF_NOTICE", enabled_value)
+        result = _apply_reasoning_cutoff_notice(
+            final_content=None,
+            reasoning_text="Let me think about 17*23... 17*20=340, 17*3=",
+            tool_calls=None,
+            finish_reason="length",
+        )
+        assert result == REASONING_CUTOFF_SENTINEL, (
+            f"env value {enabled_value!r} must enable the sentinel"
+        )
+
+    @pytest.mark.parametrize(
+        "non_enable_value",
+        # Documented disable spellings + arbitrary unknown strings.
+        # R-01 closes the ENABLE set, so anything outside it stays off.
+        [
+            "0",
+            "false",
+            "FALSE",
+            "no",
+            "off",
+            "disabled",
+            "",
+            "anything",
+            "garbage",
+            "maybe",
+        ],
+    )
+    def test_env_non_enable_values_keep_sentinel_disabled(
+        self, monkeypatch, non_enable_value
+    ):
+        """R-01 closes the enable set: anything outside
+        ``{1, true, on, yes, enabled}`` (case-insensitive) leaves the
+        sentinel disabled — including the empty string and any
+        arbitrary unrecognised value."""
+        monkeypatch.setenv("RAPID_MLX_REASONING_CUTOFF_NOTICE", non_enable_value)
+        result = _apply_reasoning_cutoff_notice(
+            final_content=None,
+            reasoning_text="<truncated thought>",
+            tool_calls=None,
+            finish_reason="length",
+        )
+        assert result is None, (
+            f"env value {non_enable_value!r} must keep the sentinel disabled"
+        )
+
+    # ----- opt-in branch: the legacy H-01 truth table still holds -----
+    #
+    # All gates below run with the opt-in env var set, so they exercise
+    # the sentinel path. The same predicates govern when the sentinel
+    # fires; only the default flipped.
+
+    def test_optin_fires_on_length_cut_mid_think(self, monkeypatch):
+        """Exact H-01 production failure shape under opt-in:
+        ``finish_reason="length"`` + empty ``content`` + non-empty
+        reasoning + no tool calls. The sentinel surfaces in ``content``;
+        reasoning stays as-is."""
+        monkeypatch.setenv("RAPID_MLX_REASONING_CUTOFF_NOTICE", "1")
         result = _apply_reasoning_cutoff_notice(
             final_content=None,
             reasoning_text="Let me think about 17*23... 17*20=340, 17*3=",
@@ -75,10 +151,11 @@ class TestApplyReasoningCutoffNotice:
         )
         assert result == REASONING_CUTOFF_SENTINEL
 
-    def test_fires_when_content_is_empty_string(self):
+    def test_optin_fires_when_content_is_empty_string(self, monkeypatch):
         """Empty-string ``content`` (downstream sanitization collapsed
-        the buffer to ``""``) is treated the same as ``None`` — clients
-        render an empty bubble either way."""
+        the buffer to ``""``) is treated the same as ``None`` under
+        opt-in — clients render an empty bubble either way."""
+        monkeypatch.setenv("RAPID_MLX_REASONING_CUTOFF_NOTICE", "1")
         result = _apply_reasoning_cutoff_notice(
             final_content="",
             reasoning_text="<incomplete thought>",
@@ -87,11 +164,11 @@ class TestApplyReasoningCutoffNotice:
         )
         assert result == REASONING_CUTOFF_SENTINEL
 
-    def test_fires_when_content_is_whitespace_only(self):
-        """Whitespace-only ``content`` looks identical to clients —
-        they see an empty bubble. Match the same semantics as the
-        silent-drop helper's whitespace-only check (#676 codex r3
-        NIT)."""
+    def test_optin_fires_when_content_is_whitespace_only(self, monkeypatch):
+        """Whitespace-only ``content`` looks identical to clients under
+        opt-in — they see an empty bubble. Match the same semantics as
+        the silent-drop helper's whitespace-only check."""
+        monkeypatch.setenv("RAPID_MLX_REASONING_CUTOFF_NOTICE", "1")
         result = _apply_reasoning_cutoff_notice(
             final_content="   \n\t",
             reasoning_text="<incomplete thought>",
@@ -100,11 +177,12 @@ class TestApplyReasoningCutoffNotice:
         )
         assert result == REASONING_CUTOFF_SENTINEL
 
-    def test_noop_when_content_is_populated(self):
-        """Happy path: model produced a real answer. The sentinel must
-        NEVER overwrite legitimate content. Closed
-        ``<think>...</think>answer`` flows must come through
-        unchanged."""
+    def test_optin_noop_when_content_is_populated(self, monkeypatch):
+        """Happy path under opt-in: model produced a real answer. The
+        sentinel must NEVER overwrite legitimate content. Closed
+        ``<think>...</think>answer`` flows must come through unchanged
+        even when the env knob is on."""
+        monkeypatch.setenv("RAPID_MLX_REASONING_CUTOFF_NOTICE", "1")
         result = _apply_reasoning_cutoff_notice(
             final_content="The answer is 391.",
             reasoning_text="17*23 = 17*(20+3) = 340 + 51 = 391",
@@ -113,13 +191,11 @@ class TestApplyReasoningCutoffNotice:
         )
         assert result == "The answer is 391."
 
-    def test_noop_on_stop_finish_d_stop_think_regression_guard(self):
-        """D-STOP-THINK regression guard: stop-string cut mid-think
-        keeps strict-null behaviour. The sentinel ONLY fires on
-        ``finish_reason="length"``. Stop-string is a documented
-        contract (the caller asked for ``stop:["X"]`` and the model
-        emitted X mid-thought — re-requesting with a different stop
-        list is the right recovery path, not a sentinel)."""
+    def test_optin_noop_on_stop_finish_d_stop_think_regression_guard(self, monkeypatch):
+        """D-STOP-THINK regression guard, even under opt-in: stop-string
+        cut mid-think keeps strict-null behaviour. The sentinel ONLY
+        fires on ``finish_reason="length"``."""
+        monkeypatch.setenv("RAPID_MLX_REASONING_CUTOFF_NOTICE", "1")
         result = _apply_reasoning_cutoff_notice(
             final_content=None,
             reasoning_text="<incomplete thought before stop string>",
@@ -128,9 +204,10 @@ class TestApplyReasoningCutoffNotice:
         )
         assert result is None
 
-    def test_noop_on_tool_calls_finish(self):
+    def test_optin_noop_on_tool_calls_finish(self, monkeypatch):
         """OpenAI spec: tool-call turns ship ``content=None``. Sentinel
-        must not interfere."""
+        must not interfere even under opt-in."""
+        monkeypatch.setenv("RAPID_MLX_REASONING_CUTOFF_NOTICE", "1")
         result = _apply_reasoning_cutoff_notice(
             final_content=None,
             reasoning_text="I should call get_weather",
@@ -139,11 +216,11 @@ class TestApplyReasoningCutoffNotice:
         )
         assert result is None
 
-    def test_noop_when_tool_calls_present_even_on_length(self):
+    def test_optin_noop_when_tool_calls_present_even_on_length(self, monkeypatch):
         """Even on ``finish_reason="length"``, a tool-call turn ships
         ``content=None``. The tool-call gate is independent of
-        finish_reason — codex r1 BLOCKING on #676 documented the same
-        precaution for the silent-drop rescue."""
+        finish_reason."""
+        monkeypatch.setenv("RAPID_MLX_REASONING_CUTOFF_NOTICE", "1")
         result = _apply_reasoning_cutoff_notice(
             final_content=None,
             reasoning_text="planning the call...",
@@ -152,12 +229,13 @@ class TestApplyReasoningCutoffNotice:
         )
         assert result is None
 
-    def test_noop_when_reasoning_is_none(self):
+    def test_optin_noop_when_reasoning_is_none(self, monkeypatch):
         """If the model produced no reasoning either (truly empty
         response), there's nothing semantically rescue-worthy. We do
         NOT fabricate a "raise max_tokens" hint when the upstream
         bug is "model emitted zero tokens" — that's a different bug
         class."""
+        monkeypatch.setenv("RAPID_MLX_REASONING_CUTOFF_NOTICE", "1")
         result = _apply_reasoning_cutoff_notice(
             final_content=None,
             reasoning_text=None,
@@ -166,9 +244,10 @@ class TestApplyReasoningCutoffNotice:
         )
         assert result is None
 
-    def test_noop_when_reasoning_is_whitespace_only(self):
+    def test_optin_noop_when_reasoning_is_whitespace_only(self, monkeypatch):
         """Whitespace-only reasoning — same as ``None`` for rescue
         purposes."""
+        monkeypatch.setenv("RAPID_MLX_REASONING_CUTOFF_NOTICE", "1")
         result = _apply_reasoning_cutoff_notice(
             final_content=None,
             reasoning_text="   \n\t",
@@ -177,83 +256,14 @@ class TestApplyReasoningCutoffNotice:
         )
         assert result is None
 
-    @pytest.mark.parametrize(
-        "disabled_value",
-        [
-            "disabled",
-            "0",
-            "false",
-            "False",
-            "FALSE",
-            "no",
-            "off",
-            "",
-        ],
-    )
-    def test_env_opt_out_disables_sentinel(self, monkeypatch, disabled_value):
-        """``RAPID_MLX_REASONING_CUTOFF_NOTICE`` with any of the
-        documented disable values reverts to strict null behaviour
-        — for callers (internal agents, advanced clients) that
-        already detect ``content is None`` natively and don't want
-        the literal sentinel polluting their downstream parsing."""
-        monkeypatch.setenv("RAPID_MLX_REASONING_CUTOFF_NOTICE", disabled_value)
-        result = _apply_reasoning_cutoff_notice(
-            final_content=None,
-            reasoning_text="<truncated thought>",
-            tool_calls=None,
-            finish_reason="length",
-        )
-        assert result is None, f"env value {disabled_value!r} must disable the sentinel"
-
-    @pytest.mark.parametrize(
-        "enabled_value",
-        [
-            "enabled",
-            "1",
-            "true",
-            "on",
-            "yes",
-            # Any other arbitrary string also stays enabled — the disable
-            # set is closed and unknown values fall through to "default on".
-            "anything",
-        ],
-    )
-    def test_env_other_values_keep_sentinel_enabled(self, monkeypatch, enabled_value):
-        """Anything outside the documented disable set leaves the
-        sentinel enabled. This includes truthy strings AND unknown
-        values — the disable set is closed, the default is on."""
-        monkeypatch.setenv("RAPID_MLX_REASONING_CUTOFF_NOTICE", enabled_value)
-        result = _apply_reasoning_cutoff_notice(
-            final_content=None,
-            reasoning_text="<truncated thought>",
-            tool_calls=None,
-            finish_reason="length",
-        )
-        assert result == REASONING_CUTOFF_SENTINEL
-
-    def test_default_is_enabled_when_env_unset(self, monkeypatch):
-        """Unset env var → sentinel is enabled. Matches the H-01 fix
-        intent: the broken empty-bubble UX is the default thing every
-        rapid-mlx install used to suffer; the sentinel is the new
-        default and only opt-out reverts."""
-        monkeypatch.delenv("RAPID_MLX_REASONING_CUTOFF_NOTICE", raising=False)
-        result = _apply_reasoning_cutoff_notice(
-            final_content=None,
-            reasoning_text="<truncated thought>",
-            tool_calls=None,
-            finish_reason="length",
-        )
-        assert result == REASONING_CUTOFF_SENTINEL
-
 
 # ──────────────────────────────────────────────────────────────────────
 # Parser-wide assembly tests: drive _finalize_content_and_reasoning +
 # _rescue_silent_drop_from_reasoning + _apply_reasoning_cutoff_notice
 # in the same orchestration the chat route runs, against every
 # ``<think>``-style parser family. Pins the parser-INDEPENDENT contract
-# H-01 was filed against — the rescue lives at the route boundary, so
-# it must produce the same sentinel for qwen3 / deepseek_r1 / glm4 /
-# gemma4 / vibethinker / phi-4-mini-reasoning.
+# the helper guards — under R-01 default-off, the sentinel never fires;
+# under opt-in, it fires uniformly across parsers.
 # ──────────────────────────────────────────────────────────────────────
 
 
@@ -269,7 +279,7 @@ def _finalize_route_assembly(
 
     1. ``_finalize_content_and_reasoning`` — extracts reasoning/content
     2. ``_rescue_silent_drop_from_reasoning`` — issue #569 rescue
-    3. ``_apply_reasoning_cutoff_notice`` — H-01 sentinel
+    3. ``_apply_reasoning_cutoff_notice`` — R-01 sentinel (opt-in)
 
     Returns ``(final_content, reasoning_text)`` exactly as the route
     layer would set them on the AssistantMessage.
@@ -286,9 +296,7 @@ def _finalize_route_assembly(
 
     cleaned_text, reasoning_text = _finalize_content_and_reasoning(
         raw_text=raw_text,
-        cleaned_text=raw_text,  # route hands the raw output through
-        # clean_output_text earlier; mirror that
-        # at the call site.
+        cleaned_text=raw_text,
         tool_calls=[],
         reasoning_parser=reasoning_parser,
         engine_reasoning_text=engine_reasoning_text,
@@ -317,19 +325,9 @@ def _finalize_route_assembly(
 
 def _parser_cases():
     """Every ``<think>``-tag reasoning-parser family alongside shared
-    raw-text shapes that produce the four scenarios H-01 cares about:
-    open-only (mid-think), closed+answer, closed+truncated-answer, and
-    the happy-path closed pair.
-
-    Gemma4 (channel tokens) and Harmony (analysis/final channels) are
-    structurally different — their parser path doesn't produce the
-    ``(reasoning, None)`` silent-drop shape on unclosed input (Gemma4's
-    parser routes orphan ``<|channel>thought\\n…`` to ``content``;
-    harmony's analysis channel is engine-routed before reaching the
-    parser). Those families exercise the H-01 rescue via the
-    engine-routed branch in ``_finalize_content_and_reasoning`` and
-    have their own dedicated tests below (``TestGemma4EngineRouted``,
-    ``TestHarmonyEngineRouted``).
+    raw-text shapes that produce the four scenarios this helper cares
+    about: open-only (mid-think), closed+truncated-answer, stop-cut
+    mid-think, and the happy-path closed pair.
 
     Each entry: ``(name, parser_class, raw_open_only, raw_closed_trunc,
     raw_stop_cut_mid, raw_happy)``."""
@@ -340,7 +338,6 @@ def _parser_cases():
     from vllm_mlx.reasoning.glm4_parser import Glm4ReasoningParser
     from vllm_mlx.reasoning.qwen3_parser import Qwen3ReasoningParser
 
-    # ``<think>`` family — same input shapes for all four parsers
     think_open_only = "<think>Let me think about 17*23. 17 * 20 = 340. 17 * 3 ="
     think_closed_trunc = "<think>17 * 23 = 391.</think>The answer is 39"
     think_stop_mid = "<think>The user wants weather. Let me check"
@@ -384,10 +381,6 @@ def _parser_cases():
 
 @pytest.fixture(params=_parser_cases(), ids=lambda p: p[0])
 def parser_case(request):
-    """Each test using this fixture runs across every reasoning-parser
-    family with the parser-specific raw-text shapes that produce the
-    four H-01 scenarios. Confirms H-01 is fixed parser-wide at the
-    route boundary."""
     name, cls, raw_open_only, raw_closed_trunc, raw_stop_mid, raw_happy = request.param
     return {
         "name": name,
@@ -399,80 +392,75 @@ def parser_case(request):
     }
 
 
-class TestParserWideLengthCutMidThink:
-    """The core H-01 contract: length-cut mid-think MUST produce the
-    sentinel for every reasoning parser family. The route boundary is
-    where the fix lives, so the assertion is on the assembled
-    ``(content, reasoning)`` pair — not on any individual parser's
-    extract method."""
+class TestParserWideLengthCutMidThinkDefault:
+    """R-01 default-off: length-cut mid-think must produce strict-null
+    content (NO sentinel) for every reasoning parser family. The
+    structured truncation signal (``finish_reason="length"`` +
+    ``reasoning_content``) is the canonical cue.
+    """
 
-    def test_length_cut_mid_think_produces_sentinel(self, parser_case):
-        """Length-cut with an unclosed reasoning block: sentinel fires,
-        reasoning is preserved (parser-wide — same contract whether
-        the protocol is ``<think>`` or ``<|channel>thought\\n…``)."""
+    def test_length_cut_mid_think_no_sentinel_by_default(self, parser_case):
+        """Default-off contract: length-cut with an unclosed reasoning
+        block must NOT inject the sentinel into ``content``. Reasoning
+        stays populated so clients that read ``reasoning_content`` (or
+        the equivalent ``thinking`` block on the Anthropic surface) see
+        the trace."""
         content, reasoning = _finalize_route_assembly(
             raw_text=parser_case["raw_open_only"],
             reasoning_parser=parser_case["parser"],
             finish_reason="length",
         )
-        assert content == REASONING_CUTOFF_SENTINEL, (
-            f"H-01 [{parser_case['name']}]: length-cut mid-think must "
-            f"surface sentinel; got content={content!r}"
+        # Strict-null contract: no synthetic text injection.
+        assert "truncated" not in (content or "").lower(), (
+            f"R-01 [{parser_case['name']}]: default must not inject the "
+            f"truncated sentinel; got content={content!r}"
         )
-        # ``reasoning_content`` keeps the trace; clients that DO read
-        # it see the same bytes they saw before the fix.
+        assert content != REASONING_CUTOFF_SENTINEL, (
+            f"R-01 [{parser_case['name']}]: default must not surface the "
+            f"sentinel literal; got content={content!r}"
+        )
+        # ``reasoning_content`` keeps the trace.
         assert reasoning is not None and "17" in reasoning, (
             f"reasoning_content must remain populated for "
             f"{parser_case['name']}; got {reasoning!r}"
         )
 
-    def test_length_cut_after_close_no_sentinel(self, parser_case):
-        """Happy path: the reasoning block CLOSED before the truncation
-        point. The sentinel must NOT fire — ``content`` carries the
-        partial answer, and overwriting it with the sentinel would
-        destroy real bytes the model produced."""
+    def test_length_cut_after_close_preserves_partial_answer(self, parser_case):
+        """Happy(ish) path: the reasoning block CLOSED before the
+        truncation point. ``content`` carries the partial answer and
+        must NOT be overwritten with anything — sentinel never gets a
+        chance to fire (gate: ``content`` is non-empty)."""
         content, reasoning = _finalize_route_assembly(
             raw_text=parser_case["raw_closed_trunc"],
             reasoning_parser=parser_case["parser"],
             finish_reason="length",
         )
-        # ``content`` carries the partial answer — preserved exactly.
         assert content == "The answer is 39", (
             f"length-cut AFTER reasoning-close [{parser_case['name']}]: "
             f"must preserve partial answer; got content={content!r}"
         )
-        # Sanity: reasoning is still populated.
         assert reasoning is not None and "391" in reasoning
 
-    def test_stop_cut_mid_think_no_sentinel(self, parser_case):
-        """H-01 contract: stop-cut mid-think NEVER carries the
-        sentinel — the sentinel ONLY fires on
-        ``finish_reason="length"``. This is the regression guard
-        that the H-01 fix doesn't widen the rescue to stop-string
-        cuts (D-STOP-THINK's job to police what the silent-drop
-        rescue does on ``stop``; H-01's job is only the length-cut
-        UX). Whatever the silent-drop rescue settled on for
-        stop-cut, the sentinel string is NOT present.
-        """
+    def test_stop_cut_mid_think_strict_null(self, parser_case):
+        """D-STOP-THINK contract still holds: stop-cut mid-think never
+        carries the sentinel. Under R-01 default-off this is also
+        strict-null, but the sentinel-absence assertion is what
+        D-STOP-THINK pins."""
         content, reasoning = _finalize_route_assembly(
             raw_text=parser_case["raw_stop_mid"],
             reasoning_parser=parser_case["parser"],
             finish_reason="stop",
         )
-        # Strict contract: H-01 sentinel is NEVER produced on stop-cut.
-        # Whatever the downstream pipeline chose (None, the trace, an
-        # empty string) — it MUST NOT be the sentinel literal that
-        # H-01 introduced.
         assert content != REASONING_CUTOFF_SENTINEL, (
-            f"[{parser_case['name']}]: H-01 sentinel must not fire on "
+            f"[{parser_case['name']}]: sentinel must not fire on "
             f"finish_reason=stop; got content={content!r}"
         )
-        # Reasoning still populated.
         assert reasoning is not None and reasoning.strip()
 
-    def test_happy_path_full_generation_no_sentinel(self, parser_case):
+    def test_happy_path_full_generation_preserves_answer(self, parser_case):
         """Full closed reasoning + answer flow: content has the answer,
-        reasoning has the trace. Sentinel must not fire."""
+        reasoning has the trace. Sentinel must not fire (gate: content
+        non-empty)."""
         content, reasoning = _finalize_route_assembly(
             raw_text=parser_case["raw_happy"],
             reasoning_parser=parser_case["parser"],
@@ -485,48 +473,54 @@ class TestParserWideLengthCutMidThink:
         assert reasoning is not None and "391" in reasoning
 
 
-# ──────────────────────────────────────────────────────────────────────
-# Gemma4 + Harmony: engine-routed reasoning shape
-#
-# These parsers don't share the ``<think>``-tag protocol. Their
-# silent-drop shape arrives via the engine's token-level OutputRouter,
-# which sets ``GenerationOutput.reasoning_text`` directly. The
-# downstream ``clean_output_text`` strips channel markers and that
-# determines whether content surfaces non-empty — those parser-
-# specific details belong to the gemma4/harmony parser tests, not
-# H-01. The contract H-01 owns is "when content lands empty AND
-# reasoning is populated AND finish=length, emit sentinel" — pinned by
-# the unit tests at the top of this file. The two tests below confirm
-# the H-01 helper composes cleanly with the engine-routed branch of
-# ``_finalize_content_and_reasoning`` when ``cleaned_text`` arrives
-# empty (the post-clean shape that triggers the silent-drop UX).
-# ──────────────────────────────────────────────────────────────────────
-
-
-class TestGemma4EngineRouted:
-    """H-01 contract on the engine-routed (token-level OutputRouter)
-    branch — the production failure shape for gemma-4 family models.
-
-    Gemma4's engine path strips channel markers before they ever land
-    in the route's ``raw_text``; the route then sees ``cleaned_text``
-    empty (or whitespace-only) and the rescue helper above already
-    decided to leave content empty. H-01 surfaces the literal sentinel
-    in that envelope.
+class TestParserWideLengthCutMidThinkOptIn:
+    """Opt-in path: ``RAPID_MLX_REASONING_CUTOFF_NOTICE=1`` restores the
+    legacy H-01 sentinel for callers who want it. The same parser-
+    independent contract still holds: every reasoning-parser family
+    surfaces the sentinel uniformly on length-cut mid-think.
     """
 
-    def test_length_cut_with_empty_cleaned_text_surfaces_sentinel(self):
-        """When the engine produced reasoning tokens but the route's
-        ``cleaned_text`` is empty (engine consumed every channel
-        marker, no final-channel emitted), H-01 must fire.
+    def test_optin_length_cut_mid_think_produces_sentinel(
+        self, parser_case, monkeypatch
+    ):
+        monkeypatch.setenv("RAPID_MLX_REASONING_CUTOFF_NOTICE", "1")
+        content, reasoning = _finalize_route_assembly(
+            raw_text=parser_case["raw_open_only"],
+            reasoning_parser=parser_case["parser"],
+            finish_reason="length",
+        )
+        assert content == REASONING_CUTOFF_SENTINEL, (
+            f"opt-in [{parser_case['name']}]: length-cut mid-think must "
+            f"surface sentinel; got content={content!r}"
+        )
+        assert reasoning is not None and "17" in reasoning
 
-        Drives the helper directly because gemma4's ``clean_output_text``
-        regex stripping pre-empts the empty-content shape — the
-        engine-route path that produces it isn't easily reproducible at
-        the unit level without spinning up the full pipeline. The
-        contract being pinned: regardless of parser family, when the
-        upstream pipeline lands at (empty content, populated reasoning,
-        length finish, no tool calls), the sentinel fires.
-        """
+
+# ──────────────────────────────────────────────────────────────────────
+# Gemma4 + Harmony: engine-routed reasoning shape
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestGemma4HarmonyEngineRouted:
+    """Engine-routed reasoning families (gemma4, harmony) reach the
+    helper via a different upstream path (the OutputRouter strips
+    channel markers before the route's ``cleaned_text`` is computed).
+    The helper-level contract is identical though: default-off →
+    sentinel never fires; opt-in → sentinel surfaces.
+    """
+
+    def test_default_off_no_sentinel_on_empty_cleaned_text(self, monkeypatch):
+        monkeypatch.delenv("RAPID_MLX_REASONING_CUTOFF_NOTICE", raising=False)
+        content = _apply_reasoning_cutoff_notice(
+            final_content=None,
+            reasoning_text=("The user wants to know about the weather. Let me think"),
+            tool_calls=None,
+            finish_reason="length",
+        )
+        assert content is None
+
+    def test_optin_surfaces_sentinel_on_empty_cleaned_text(self, monkeypatch):
+        monkeypatch.setenv("RAPID_MLX_REASONING_CUTOFF_NOTICE", "1")
         content = _apply_reasoning_cutoff_notice(
             final_content=None,
             reasoning_text=("The user wants to know about the weather. Let me think"),
@@ -535,23 +529,8 @@ class TestGemma4EngineRouted:
         )
         assert content == REASONING_CUTOFF_SENTINEL
 
-
-class TestHarmonyEngineRouted:
-    """H-01 contract on the harmony analysis-without-final shape pinned
-    by D-HARMONY-LEAK. Engine-routed analysis bytes hit
-    ``reasoning_text`` and the silent-drop rescue suppresses promoting
-    them to content — H-01 instead surfaces the literal sentinel.
-    """
-
-    def test_analysis_only_with_empty_cleaned_text_surfaces_sentinel(self):
-        """Drives the helper directly because the full assembly path
-        depends on ``clean_output_text``'s marker-stripping behaviour
-        which is harmony-specific. The contract H-01 owns is helper-
-        level: empty content + populated reasoning + length finish +
-        no tool calls = sentinel. The route-boundary wiring tests
-        below confirm this helper IS called from every relevant route
-        module.
-        """
+    def test_harmony_analysis_only_default_off(self, monkeypatch):
+        monkeypatch.delenv("RAPID_MLX_REASONING_CUTOFF_NOTICE", raising=False)
         content = _apply_reasoning_cutoff_notice(
             final_content=None,
             reasoning_text=(
@@ -560,56 +539,24 @@ class TestHarmonyEngineRouted:
             tool_calls=None,
             finish_reason="length",
         )
-        assert content == REASONING_CUTOFF_SENTINEL
+        assert content is None
 
 
 # ──────────────────────────────────────────────────────────────────────
-# Env opt-out integration test against the route-assembly pipeline:
-# ensures the env-var gate composes correctly with the rescue helper —
-# the env var unwinds H-01 behaviour cleanly without disturbing the
-# pre-H-01 strict-null contract.
-# ──────────────────────────────────────────────────────────────────────
-
-
-def test_env_opt_out_reverts_to_pre_h01_strict_null(monkeypatch):
-    """Setting ``RAPID_MLX_REASONING_CUTOFF_NOTICE=disabled`` must
-    restore the exact pre-H-01 envelope shape: ``content=None`` on
-    length-cut mid-think. This is the regression contract for callers
-    who already detect ``content is None`` and don't want the literal
-    sentinel polluting their downstream parsing.
-    """
-    monkeypatch.setenv("RAPID_MLX_REASONING_CUTOFF_NOTICE", "disabled")
-    from vllm_mlx.reasoning.qwen3_parser import Qwen3ReasoningParser
-
-    content, reasoning = _finalize_route_assembly(
-        raw_text="<think>Some incomplete thought",
-        reasoning_parser=Qwen3ReasoningParser(),
-        finish_reason="length",
-    )
-    assert content is None, (
-        "env opt-out: content must stay None on length-cut mid-think"
-    )
-    assert reasoning is not None and reasoning.strip(), (
-        "reasoning must still be populated"
-    )
-
-
-# ──────────────────────────────────────────────────────────────────────
-# Streaming SSE: sentinel appears as ONE final-chunk delta, not per-token
+# Streaming SSE: default-off → no sentinel emitted; opt-in → one
+# final-chunk event carrying the literal sentinel.
 # ──────────────────────────────────────────────────────────────────────
 
 
 class _StreamEngine:
-    """Minimal streaming engine for the H-01 streaming surface tests.
+    """Minimal streaming engine for the streaming-surface tests.
 
-    The engine emits text-mode (``channel=None``) deltas so the route's
-    reasoning parser is on the hot path — the test then configures a
-    Qwen3 parser via ``cfg.reasoning_parser`` and the deltas start with
-    a literal ``<think>`` opener so the parser's ``_saw_any_tag`` flag
-    flips and the streaming rescue's truncated-think gate fires. That
-    suppression is precisely the case H-01 was filed for: rescue says
-    "don't promote the trace into content", and H-01 surfaces the
-    sentinel instead.
+    Emits text-mode (``channel=None``) deltas so the route's reasoning
+    parser is on the hot path — the test then configures a Qwen3 parser
+    via ``cfg.reasoning_parser`` and the deltas start with a literal
+    ``<think>`` opener so the parser's ``_saw_any_tag`` flag flips and
+    the streaming rescue's truncated-think gate fires. That suppression
+    is precisely the case the helper was filed for.
 
     Set ``include_open_tag=False`` to opt out of the ``<think>`` opener
     for tests that want to assert the plain silent-drop rescue path
@@ -639,11 +586,6 @@ class _StreamEngine:
 
         self.stream_calls.append({"messages": messages, "kwargs": kwargs})
         accumulated = ""
-        # Prepend ``<think>`` to the first delta so the route's
-        # streaming reasoning parser sees the opener and flips
-        # ``_saw_any_tag=True`` — required for the streaming rescue's
-        # truncated-think suppression gate to fire (the case H-01
-        # rescues with the sentinel).
         deltas = list(self._deltas)
         if self._include_open_tag and deltas:
             deltas[0] = "<think>" + deltas[0]
@@ -698,10 +640,6 @@ def _stream_post(
     cfg.model_name = "test-model"
     cfg.model_registry = None
     cfg.no_thinking = False
-    # Qwen3 parser so streaming postprocessor flips ``_saw_any_tag=True``
-    # on the ``<think>`` opener prepended by the engine. The streaming
-    # rescue's truncated-think gate then suppresses promoting the trace
-    # to content — exactly the case H-01 surfaces the sentinel for.
     cfg.reasoning_parser = Qwen3ReasoningParser()
     cfg.reasoning_parser_name = "qwen3"
 
@@ -724,37 +662,30 @@ def _stream_post(
         reset_config()
 
 
-def test_streaming_length_cut_emits_sentinel_in_terminal_chunk():
-    """SSE streaming surface: when reasoning streamed but no content
-    streamed AND ``finish_reason="length"``, the terminal chunk's
-    ``delta.content`` MUST carry the sentinel string (not the
-    accumulated reasoning trace — that would re-introduce the leak
-    D-STOP-THINK / D-HARMONY-LEAK closed). The per-delta
-    ``reasoning_content`` chunks have already gone out during the
-    loop."""
+def test_streaming_default_off_no_sentinel_in_terminal_chunk(monkeypatch):
+    """R-01 default contract on the streaming surface: when reasoning
+    streamed but no content streamed AND ``finish_reason="length"``,
+    NO sentinel must appear in any ``delta.content`` event. Per-delta
+    ``reasoning_content`` chunks still flow during the loop."""
+    monkeypatch.delenv("RAPID_MLX_REASONING_CUTOFF_NOTICE", raising=False)
     events = _stream_post(
         ["Let me think about ", "the weather query. ", "I should call"],
         finish_reason="length",
     )
     assert events, "expected at least the terminal SSE chunk"
 
-    terminal_events = [
-        e
-        for e in events
-        if any(ch.get("finish_reason") is not None for ch in e.get("choices", []))
-    ]
-    assert terminal_events, "expected SSE chunk with finish_reason"
-    terminal = terminal_events[-1]
-    delta = terminal["choices"][0].get("delta", {})
+    for ev in events:
+        for choice in ev.get("choices", []):
+            d = choice.get("delta") or {}
+            content = d.get("content")
+            if content:
+                assert "truncated" not in content.lower(), (
+                    f"R-01 streaming default: no chunk may carry the "
+                    f"truncated sentinel; got delta.content={content!r}"
+                )
+                assert content != REASONING_CUTOFF_SENTINEL
 
-    assert delta.get("content") == REASONING_CUTOFF_SENTINEL, (
-        f"H-01 streaming: terminal chunk must carry sentinel; "
-        f"got {delta.get('content')!r}"
-    )
-
-    # Reasoning content stream is independent — the per-delta
-    # reasoning_content chunks are preserved, not collapsed into the
-    # sentinel.
+    # Reasoning content stream is independent and still flows.
     streamed_reasoning = ""
     for ev in events:
         for choice in ev.get("choices", []):
@@ -762,17 +693,40 @@ def test_streaming_length_cut_emits_sentinel_in_terminal_chunk():
             if d.get("reasoning_content"):
                 streamed_reasoning += d["reasoning_content"]
     assert "weather query" in streamed_reasoning, (
-        "per-delta reasoning_content chunks must NOT be collapsed; "
+        "per-delta reasoning_content chunks must still flow on default-off; "
         f"got streamed={streamed_reasoning!r}"
     )
 
 
-def test_streaming_sentinel_is_single_event_not_per_token():
-    """The sentinel surfaces as ONE final-chunk event, not per-token.
-    Counting ``content`` deltas across the whole stream MUST yield
-    exactly one chunk carrying the sentinel — never split. This
-    guards against a future regression that would emit the sentinel
-    character-by-character as if it were a model token."""
+def test_streaming_optin_emits_sentinel_in_terminal_chunk(monkeypatch):
+    """Opt-in: ``RAPID_MLX_REASONING_CUTOFF_NOTICE=1`` restores the H-01
+    streaming behaviour — the terminal chunk's ``delta.content`` carries
+    the sentinel string. Per-delta reasoning_content unchanged."""
+    monkeypatch.setenv("RAPID_MLX_REASONING_CUTOFF_NOTICE", "1")
+    events = _stream_post(
+        ["Let me think about ", "the weather query. ", "I should call"],
+        finish_reason="length",
+    )
+    assert events
+    terminal_events = [
+        e
+        for e in events
+        if any(ch.get("finish_reason") is not None for ch in e.get("choices", []))
+    ]
+    assert terminal_events
+    terminal = terminal_events[-1]
+    delta = terminal["choices"][0].get("delta", {})
+    assert delta.get("content") == REASONING_CUTOFF_SENTINEL, (
+        f"opt-in streaming: terminal chunk must carry sentinel; "
+        f"got {delta.get('content')!r}"
+    )
+
+
+def test_streaming_optin_sentinel_is_single_event_not_per_token(monkeypatch):
+    """When opt-in, the sentinel surfaces as ONE final-chunk event,
+    not per-token. Counting ``content`` deltas across the whole stream
+    MUST yield exactly one chunk carrying the sentinel — never split."""
+    monkeypatch.setenv("RAPID_MLX_REASONING_CUTOFF_NOTICE", "1")
     events = _stream_post(
         ["Buffer ", "more ", "thought"],
         finish_reason="length",
@@ -791,16 +745,16 @@ def test_streaming_sentinel_is_single_event_not_per_token():
     )
 
 
-def test_streaming_stop_cut_mid_think_no_sentinel_d_stop_think_guard():
+def test_streaming_stop_cut_mid_think_no_sentinel_d_stop_think_guard(monkeypatch):
     """SSE D-STOP-THINK regression guard: stop-string cut mid-think
-    keeps ``delta.content=None`` on every chunk (including the
-    terminal). The sentinel ONLY fires on ``finish_reason="length"``."""
+    keeps ``delta.content=None`` on every chunk. The sentinel ONLY
+    fires on ``finish_reason="length"`` even under opt-in."""
+    monkeypatch.setenv("RAPID_MLX_REASONING_CUTOFF_NOTICE", "1")
     events = _stream_post(
         ["Buffer ", "more ", "thought"],
         finish_reason="stop",
     )
 
-    # No chunk should carry content at all.
     for ev in events:
         for choice in ev.get("choices", []):
             d = choice.get("delta") or {}
@@ -810,32 +764,13 @@ def test_streaming_stop_cut_mid_think_no_sentinel_d_stop_think_guard():
             )
 
 
-def test_streaming_env_opt_out_reverts_to_pre_h01_null(monkeypatch):
-    """Env opt-out integration on the streaming surface: when
-    ``RAPID_MLX_REASONING_CUTOFF_NOTICE=disabled``, the terminal
-    chunk's ``delta.content`` stays ``None`` on length-cut. Pins
-    streaming/non-streaming parity under the env knob."""
-    monkeypatch.setenv("RAPID_MLX_REASONING_CUTOFF_NOTICE", "disabled")
-    events = _stream_post(
-        ["Buffer ", "more"],
-        finish_reason="length",
-    )
-    for ev in events:
-        for choice in ev.get("choices", []):
-            d = choice.get("delta") or {}
-            assert not d.get("content"), (
-                f"env opt-out: streaming must not emit sentinel; got delta={d!r}"
-            )
-
-
-def test_streaming_happy_path_no_sentinel_when_content_streamed():
-    """SSE happy-path guard: when content WAS streamed during the loop
-    (normal turn that closed ``</think>`` and produced an answer), the
-    sentinel must NOT fire and the assembled content stream MUST equal
-    the original output. The pre-existing #569 streaming test pins this
-    for ``finish_reason="stop"``; this re-pins it for ``"length"`` so
-    the sentinel can't sneak in via the length-finish path when content
-    was actually emitted (truncated answer, not truncated thought)."""
+def test_streaming_happy_path_no_sentinel_when_content_streamed(monkeypatch):
+    """Happy-path guard (default-off): when content WAS streamed during
+    the loop (normal turn that closed ``</think>`` and produced an
+    answer), the assembled content stream MUST equal the original
+    output. No sentinel sneaks in via the length-finish path when
+    content was actually emitted."""
+    monkeypatch.delenv("RAPID_MLX_REASONING_CUTOFF_NOTICE", raising=False)
     from fastapi import FastAPI
     from fastapi.testclient import TestClient
 
@@ -861,8 +796,6 @@ def test_streaming_happy_path_no_sentinel_when_content_streamed():
                     prompt_tokens=4,
                     completion_tokens=i + 1,
                     finished=is_last,
-                    # Force length-finish to specifically guard the
-                    # H-01 path against firing on real-content streams.
                     finish_reason="length" if is_last else None,
                     channel=None,
                 )
@@ -898,29 +831,19 @@ def test_streaming_happy_path_no_sentinel_when_content_streamed():
             f"happy-path content stream must equal engine output; "
             f"got {streamed_content!r}"
         )
-        # No sentinel snuck in.
         assert REASONING_CUTOFF_SENTINEL not in streamed_content
     finally:
         reset_config()
 
 
 # ──────────────────────────────────────────────────────────────────────
-# Anthropic /v1/messages surface — same UX rescue must apply
+# Route-wiring tests: assert the helper is CALLED from every route
+# (source-grep guard against accidental deletion of the call site) and
+# the default-off contract holds end-to-end on every transport.
 # ──────────────────────────────────────────────────────────────────────
 
 
 def _route_source(module_name: str) -> str:
-    """Read a route module's source. Static-source inspection is the
-    cheapest way to assert "the helper is actually CALLED here" without
-    spinning up the full request pipeline for every route.
-
-    Codex r1 BLOCKING on H-01: the previous wiring tests only checked
-    ``"_apply_reasoning_cutoff_notice" in dir(module)`` — which passes
-    even if the production call sites are deleted but the import
-    survives. The strengthened assertion below greps the module source
-    for a call (``_apply_reasoning_cutoff_notice(``), so deletion of
-    the call site without removing the import fails the test.
-    """
     import importlib
     import inspect
 
@@ -929,16 +852,14 @@ def _route_source(module_name: str) -> str:
 
 
 def test_anthropic_route_helper_call_site_present():
-    """Pins that the Anthropic ``/v1/messages`` route CALLS the H-01
-    helper, so the sentinel behaviour applies uniformly to anthropic
-    SDK consumers. Source-level grep guards against a future refactor
-    that deletes the call site but leaves the import intact (codex
-    r1 BLOCKING).
-    """
+    """Pins that the Anthropic ``/v1/messages`` route CALLS the helper,
+    so the env-knob behaviour applies uniformly to Anthropic SDK
+    consumers. Source-level grep guards against a future refactor that
+    deletes the call site but leaves the import intact."""
     src = _route_source("vllm_mlx.routes.anthropic")
     assert "_apply_reasoning_cutoff_notice(" in src, (
-        "Anthropic route must invoke the H-01 cutoff sentinel helper "
-        "(not just import it)"
+        "Anthropic route must invoke the cutoff sentinel helper "
+        "(not just import it) — single source of truth"
     )
 
 
@@ -946,21 +867,19 @@ def test_responses_route_helper_call_site_present():
     """Same call-site grep for ``/v1/responses``."""
     src = _route_source("vllm_mlx.routes.responses")
     assert "_apply_reasoning_cutoff_notice(" in src, (
-        "Responses route must invoke the H-01 cutoff sentinel helper "
-        "(not just import it)"
+        "Responses route must invoke the cutoff sentinel helper "
+        "(not just import it) — single source of truth"
     )
 
 
 def test_chat_route_helper_call_site_present():
     """Same call-site grep for ``/v1/chat/completions``. The chat
     module hosts BOTH the non-stream and stream paths, so the helper
-    must be invoked twice. Pinning the count locks in streaming +
-    non-streaming surfaces against accidental removal of either.
-    """
+    must be invoked twice."""
     src = _route_source("vllm_mlx.routes.chat")
     invocation_count = src.count("_apply_reasoning_cutoff_notice(")
     assert invocation_count >= 2, (
-        "Chat route must invoke the H-01 cutoff sentinel helper from "
+        "Chat route must invoke the cutoff sentinel helper from "
         "BOTH the non-stream and stream paths; "
         f"found {invocation_count} call site(s)"
     )
@@ -971,9 +890,9 @@ class _EngineLengthCutMidThink:
 
     Returns a single ``GenerationOutput`` with an unclosed ``<think>``
     opener and ``finish_reason="length"`` — the exact production
-    failure shape H-01 was filed against. Used across chat / responses /
-    anthropic e2e wiring tests so the contract is identical on every
-    surface.
+    failure shape the helper was filed against. Used across chat /
+    responses / anthropic e2e wiring tests so the contract is identical
+    on every surface.
     """
 
     preserve_native_tool_format = False
@@ -1022,13 +941,59 @@ def _seed_length_cut_engine(cfg):
     cfg.reasoning_parser_name = "qwen3"
 
 
-def test_chat_route_helper_actually_invoked_on_length_cut():
-    """End-to-end behavioral wiring proof for ``/v1/chat/completions``
-    non-streaming: a length-cut mid-think envelope MUST carry the
-    sentinel as ``message.content``. Drives the route via TestClient
-    so deletion of the call site (even with import preserved) fails
-    the test — the codex r1 BLOCKING regression guard.
-    """
+def test_chat_route_default_off_no_sentinel_on_length_cut(monkeypatch):
+    """R-01 e2e contract for ``/v1/chat/completions`` non-streaming:
+    a length-cut mid-think envelope under the default env settings must
+    NOT carry the sentinel. The structured truncation signal
+    (``finish_reason="length"`` + ``reasoning_content``) is the cue."""
+    monkeypatch.delenv("RAPID_MLX_REASONING_CUTOFF_NOTICE", raising=False)
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    from vllm_mlx.config import reset_config
+    from vllm_mlx.routes.chat import router as chat_router
+
+    cfg = reset_config()
+    _seed_length_cut_engine(cfg)
+
+    try:
+        app = FastAPI()
+        app.include_router(chat_router)
+        client = TestClient(app)
+        resp = client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "test-model",
+                "stream": False,
+                "max_tokens": 16,
+                "messages": [{"role": "user", "content": "compute 17*23"}],
+            },
+        )
+        assert resp.status_code == 200, resp.text
+        payload = resp.json()
+        msg = payload["choices"][0]["message"]
+        content = msg.get("content")
+        assert content != REASONING_CUTOFF_SENTINEL, (
+            f"R-01 e2e: chat non-stream must NOT inject sentinel by "
+            f"default; got content={content!r}"
+        )
+        if content:
+            assert "truncated" not in content.lower(), (
+                f"R-01 e2e: chat non-stream content must not carry "
+                f"'truncated' synthetic text; got {content!r}"
+            )
+        assert payload["choices"][0]["finish_reason"] == "length"
+        assert msg.get("reasoning_content"), (
+            "reasoning_content must remain populated as the canonical truncation cue"
+        )
+    finally:
+        reset_config()
+
+
+def test_chat_route_optin_surfaces_sentinel_on_length_cut(monkeypatch):
+    """Opt-in: ``RAPID_MLX_REASONING_CUTOFF_NOTICE=1`` restores the
+    legacy H-01 behaviour end-to-end on ``/v1/chat/completions``."""
+    monkeypatch.setenv("RAPID_MLX_REASONING_CUTOFF_NOTICE", "1")
     from fastapi import FastAPI
     from fastapi.testclient import TestClient
 
@@ -1055,23 +1020,20 @@ def test_chat_route_helper_actually_invoked_on_length_cut():
         payload = resp.json()
         msg = payload["choices"][0]["message"]
         assert msg.get("content") == REASONING_CUTOFF_SENTINEL, (
-            "H-01 e2e wiring: chat non-stream must surface sentinel on "
-            f"length-cut mid-think; got content={msg.get('content')!r}"
+            "opt-in: chat non-stream must surface sentinel on length-cut "
+            f"mid-think; got content={msg.get('content')!r}"
         )
         assert payload["choices"][0]["finish_reason"] == "length"
-        assert msg.get("reasoning_content"), (
-            "reasoning_content must remain populated alongside sentinel"
-        )
     finally:
         reset_config()
 
 
-def test_anthropic_route_helper_actually_invoked_on_length_cut():
-    """End-to-end behavioral wiring proof for ``/v1/messages``: a
-    length-cut mid-think envelope MUST surface the sentinel in the
-    Anthropic adapter's content blocks. Codex r1 BLOCKING regression
-    guard.
-    """
+def test_anthropic_route_default_off_no_sentinel_on_length_cut(monkeypatch):
+    """R-01 e2e contract for ``/v1/messages``: default must NOT inject
+    the sentinel into any content block. ``stop_reason="max_tokens"``
+    + the ``thinking`` content block are the canonical truncation
+    cues."""
+    monkeypatch.delenv("RAPID_MLX_REASONING_CUTOFF_NOTICE", raising=False)
     from fastapi import FastAPI
     from fastapi.testclient import TestClient
 
@@ -1090,40 +1052,92 @@ def test_anthropic_route_helper_actually_invoked_on_length_cut():
             json={
                 "model": "test-model",
                 "max_tokens": 16,
-                "messages": [
-                    {"role": "user", "content": "compute 17*23"},
-                ],
+                "messages": [{"role": "user", "content": "compute 17*23"}],
                 "stream": False,
             },
         )
         if resp.status_code != 200:
-            import pytest as _pytest
-
-            _pytest.skip(
+            pytest.skip(
                 f"/v1/messages adapter rejected synthetic shape "
                 f"({resp.status_code}); behavior covered by chat e2e "
                 f"and unit-level helper tests — call-site source-grep "
                 f"above still pins the wiring."
             )
         payload = resp.json()
-        # Search the body for the sentinel — the Anthropic adapter
-        # places content in ``content[].text`` blocks, but the exact
-        # path can vary by adapter version. The source-grep test
-        # above pins the call site presence; this test pins behavior.
-        body_str = str(payload)
-        assert REASONING_CUTOFF_SENTINEL in body_str, (
-            "H-01 e2e wiring: /v1/messages must surface sentinel on "
-            f"length-cut mid-think; got payload={payload!r}"
+        body_str = json.dumps(payload)
+        assert REASONING_CUTOFF_SENTINEL not in body_str, (
+            f"R-01 e2e: /v1/messages must NOT carry the sentinel by "
+            f"default; got payload={payload!r}"
+        )
+        assert "truncated" not in body_str.lower() or (
+            # Allow harmless "truncated" inside non-content fields if
+            # any future metadata mentions it — guard the content block
+            # specifically.
+            all(
+                "truncated" not in (block.get("text") or "").lower()
+                for block in payload.get("content") or []
+                if block.get("type") == "text"
+            )
+        ), (
+            f"R-01 e2e: /v1/messages text content blocks must not carry "
+            f"'truncated' synthetic text; got payload={payload!r}"
         )
     finally:
         reset_config()
 
 
-def test_responses_route_helper_actually_invoked_on_length_cut():
-    """End-to-end behavioral wiring proof for ``/v1/responses``: a
-    length-cut mid-think envelope MUST carry the sentinel in the
-    Responses adapter's output. Codex r1 BLOCKING regression guard.
-    """
+def test_anthropic_route_optin_surfaces_sentinel(monkeypatch):
+    """Opt-in: legacy H-01 behaviour restored on ``/v1/messages``."""
+    monkeypatch.setenv("RAPID_MLX_REASONING_CUTOFF_NOTICE", "1")
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    from vllm_mlx.config import reset_config
+    from vllm_mlx.routes.anthropic import router as anthropic_router
+
+    cfg = reset_config()
+    _seed_length_cut_engine(cfg)
+
+    try:
+        app = FastAPI()
+        app.include_router(anthropic_router)
+        client = TestClient(app)
+        resp = client.post(
+            "/v1/messages",
+            json={
+                "model": "test-model",
+                "max_tokens": 16,
+                "messages": [{"role": "user", "content": "compute 17*23"}],
+                "stream": False,
+            },
+        )
+        if resp.status_code != 200:
+            pytest.skip(
+                f"/v1/messages adapter rejected synthetic shape ({resp.status_code})"
+            )
+        payload = resp.json()
+        # Compare against the JSON-decoded text block payloads — the raw
+        # ``json.dumps`` body escapes the em-dash to ``—`` and would
+        # spuriously fail a substring check against the unicode literal.
+        text_blocks = [
+            (block.get("text") or "")
+            for block in (payload.get("content") or [])
+            if block.get("type") == "text"
+        ]
+        assert any(REASONING_CUTOFF_SENTINEL in t for t in text_blocks), (
+            f"opt-in e2e: /v1/messages must surface sentinel in a text "
+            f"content block on length-cut mid-think; got payload={payload!r}"
+        )
+    finally:
+        reset_config()
+
+
+def test_responses_route_default_off_no_sentinel_on_length_cut(monkeypatch):
+    """R-01 e2e contract for ``/v1/responses``: default must NOT inject
+    the sentinel into any output_text block. ``status="incomplete"`` +
+    ``usage.output_tokens_details.reasoning_tokens`` are the canonical
+    truncation cues."""
+    monkeypatch.delenv("RAPID_MLX_REASONING_CUTOFF_NOTICE", raising=False)
     from fastapi import FastAPI
     from fastapi.testclient import TestClient
 
@@ -1147,19 +1161,74 @@ def test_responses_route_helper_actually_invoked_on_length_cut():
             },
         )
         if resp.status_code != 200:
-            import pytest as _pytest
-
-            _pytest.skip(
+            pytest.skip(
                 f"/v1/responses adapter rejected synthetic shape "
                 f"({resp.status_code}); behavior covered by chat e2e "
                 f"and unit-level helper tests — call-site source-grep "
                 f"above still pins the wiring."
             )
         payload = resp.json()
-        body_str = str(payload)
-        assert REASONING_CUTOFF_SENTINEL in body_str, (
-            "H-01 e2e wiring: /v1/responses must surface sentinel on "
-            f"length-cut mid-think; got payload={payload!r}"
+        body_str = json.dumps(payload)
+        assert REASONING_CUTOFF_SENTINEL not in body_str, (
+            f"R-01 e2e: /v1/responses must NOT carry the sentinel by "
+            f"default; got payload={payload!r}"
+        )
+        # Walk output[].content[] explicitly to catch any synthetic
+        # output_text block.
+        for item in payload.get("output") or []:
+            for block in item.get("content") or []:
+                text = block.get("text") or ""
+                assert "truncated" not in text.lower(), (
+                    f"R-01 e2e: /v1/responses output_text must not "
+                    f"carry 'truncated' synthetic text; got block={block!r}"
+                )
+    finally:
+        reset_config()
+
+
+def test_responses_route_optin_surfaces_sentinel(monkeypatch):
+    """Opt-in: legacy H-01 behaviour restored on ``/v1/responses``."""
+    monkeypatch.setenv("RAPID_MLX_REASONING_CUTOFF_NOTICE", "1")
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    from vllm_mlx.config import reset_config
+    from vllm_mlx.routes.responses import router as responses_router
+
+    cfg = reset_config()
+    _seed_length_cut_engine(cfg)
+
+    try:
+        app = FastAPI()
+        app.include_router(responses_router)
+        client = TestClient(app)
+        resp = client.post(
+            "/v1/responses",
+            json={
+                "model": "test-model",
+                "max_output_tokens": 16,
+                "input": "compute 17*23",
+                "stream": False,
+            },
+        )
+        if resp.status_code != 200:
+            pytest.skip(
+                f"/v1/responses adapter rejected synthetic shape ({resp.status_code})"
+            )
+        payload = resp.json()
+        # Walk ``output[].content[]`` for a text block carrying the
+        # sentinel literal — the JSON-dumped body escapes the em-dash,
+        # so a substring check against the unicode literal there is
+        # brittle. The decoded text block is the authoritative payload.
+        sentinel_texts: list[str] = []
+        for item in payload.get("output") or []:
+            for block in item.get("content") or []:
+                if block.get("type") == "output_text":
+                    sentinel_texts.append(block.get("text") or "")
+        assert any(REASONING_CUTOFF_SENTINEL in t for t in sentinel_texts), (
+            f"opt-in e2e: /v1/responses must surface sentinel in an "
+            f"output_text block on length-cut mid-think; "
+            f"got payload={payload!r}"
         )
     finally:
         reset_config()

--- a/tests/test_reasoning_content_null_rescue.py
+++ b/tests/test_reasoning_content_null_rescue.py
@@ -1056,13 +1056,7 @@ def test_anthropic_route_default_off_no_sentinel_on_length_cut(monkeypatch):
                 "stream": False,
             },
         )
-        if resp.status_code != 200:
-            pytest.skip(
-                f"/v1/messages adapter rejected synthetic shape "
-                f"({resp.status_code}); behavior covered by chat e2e "
-                f"and unit-level helper tests — call-site source-grep "
-                f"above still pins the wiring."
-            )
+        assert resp.status_code == 200, resp.text
         payload = resp.json()
         body_str = json.dumps(payload)
         assert REASONING_CUTOFF_SENTINEL not in body_str, (
@@ -1111,10 +1105,7 @@ def test_anthropic_route_optin_surfaces_sentinel(monkeypatch):
                 "stream": False,
             },
         )
-        if resp.status_code != 200:
-            pytest.skip(
-                f"/v1/messages adapter rejected synthetic shape ({resp.status_code})"
-            )
+        assert resp.status_code == 200, resp.text
         payload = resp.json()
         # Compare against the JSON-decoded text block payloads — the raw
         # ``json.dumps`` body escapes the em-dash to ``—`` and would
@@ -1160,13 +1151,7 @@ def test_responses_route_default_off_no_sentinel_on_length_cut(monkeypatch):
                 "stream": False,
             },
         )
-        if resp.status_code != 200:
-            pytest.skip(
-                f"/v1/responses adapter rejected synthetic shape "
-                f"({resp.status_code}); behavior covered by chat e2e "
-                f"and unit-level helper tests — call-site source-grep "
-                f"above still pins the wiring."
-            )
+        assert resp.status_code == 200, resp.text
         payload = resp.json()
         body_str = json.dumps(payload)
         assert REASONING_CUTOFF_SENTINEL not in body_str, (
@@ -1211,10 +1196,7 @@ def test_responses_route_optin_surfaces_sentinel(monkeypatch):
                 "stream": False,
             },
         )
-        if resp.status_code != 200:
-            pytest.skip(
-                f"/v1/responses adapter rejected synthetic shape ({resp.status_code})"
-            )
+        assert resp.status_code == 200, resp.text
         payload = resp.json()
         # Walk ``output[].content[]`` for a text block carrying the
         # sentinel literal — the JSON-dumped body escapes the em-dash,

--- a/tests/test_truncation_no_synthetic_text.py
+++ b/tests/test_truncation_no_synthetic_text.py
@@ -1,0 +1,554 @@
+# SPDX-License-Identifier: Apache-2.0
+"""R-01 cross-route truncation contract: no synthetic text injection.
+
+When a reasoning model is cut short mid-``<think>`` by a ``max_tokens``
+cap, no transport may inject a literal placeholder string into the
+model's ``content`` / ``output_text`` / ``text`` field. Every transport
+already carries an unambiguous structured truncation signal — that, plus
+the populated ``reasoning_content`` (or ``thinking`` block), is the
+canonical cue.
+
+Transports under test:
+    * ``/v1/chat/completions``    → ``finish_reason="length"``
+    * ``/v1/responses``           → ``status="incomplete"`` +
+                                     ``output_tokens_details.reasoning_tokens``
+    * ``/v1/messages`` (Anthropic) → ``stop_reason="max_tokens"`` +
+                                     ``thinking`` content block
+
+Each transport is covered for BOTH streaming and non-streaming paths.
+
+The fix lives at a single source of truth
+(``vllm_mlx.service.helpers._apply_reasoning_cutoff_notice``); these
+tests pin the user-visible behaviour on every route boundary so the
+helper cannot drift between surfaces.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+
+import pytest
+
+from vllm_mlx.service.helpers import REASONING_CUTOFF_SENTINEL
+
+# Substrings that flag synthetic truncation text. Case-insensitive.
+_TRUNCATED_SUBSTRING = "truncated"
+
+
+# ---------------------------------------------------------------------
+# Mock engine: a reasoning model whose ``<think>`` block never closes.
+# Used uniformly across all three routes so the contract is identical.
+# ---------------------------------------------------------------------
+
+
+class _LengthCutMidThinkEngine:
+    """Single-output engine: ``<think>`` opens but never closes, and
+    generation finishes with ``finish_reason="length"`` — the exact
+    production shape R-01 was filed against."""
+
+    preserve_native_tool_format = False
+    is_mllm = False
+    supports_guided_generation = False
+    tokenizer = None
+    chat_template = ""
+
+    def __init__(self):
+        self.chat_calls: list[dict] = []
+
+    def build_prompt(self, messages, tools=None, enable_thinking=None):
+        return "PROMPT"
+
+    def estimate_prompt_tokens(self, prompt):
+        return 4
+
+    async def chat(self, messages, **kwargs):
+        from vllm_mlx.engine.base import GenerationOutput
+
+        self.chat_calls.append({"messages": messages, "kwargs": kwargs})
+        return GenerationOutput(
+            text="<think>Reasoning about 17*23 step by step",
+            new_text="<think>Reasoning about 17*23 step by step",
+            prompt_tokens=4,
+            completion_tokens=12,
+            finished=True,
+            finish_reason="length",
+            channel=None,
+        )
+
+    async def stream_chat(self, messages, **kwargs):
+        # Streaming path: emit partial reasoning across multiple deltas
+        # so the streaming postprocessor exercises the per-delta path,
+        # then close with ``finish_reason="length"`` without ever
+        # emitting ``</think>``.
+        from vllm_mlx.engine.base import GenerationOutput
+
+        deltas = [
+            "<think>Reasoning ",
+            "about 17 * 23 ",
+            "step by step",
+        ]
+        accumulated = ""
+        for i, delta in enumerate(deltas):
+            accumulated += delta
+            is_last = i == len(deltas) - 1
+            yield GenerationOutput(
+                text=accumulated,
+                new_text=delta,
+                prompt_tokens=4,
+                completion_tokens=i + 1,
+                finished=is_last,
+                finish_reason="length" if is_last else None,
+                channel=None,
+            )
+
+
+def _seed_cfg(cfg):
+    """Common cfg shape for every test below: qwen3 reasoning parser +
+    length-cut mock engine."""
+    from vllm_mlx.reasoning.qwen3_parser import Qwen3ReasoningParser
+
+    cfg.engine = _LengthCutMidThinkEngine()
+    cfg.model_name = "test-model"
+    cfg.model_registry = None
+    cfg.no_thinking = False
+    cfg.reasoning_parser = Qwen3ReasoningParser()
+    cfg.reasoning_parser_name = "qwen3"
+
+
+def _parse_sse(text: str) -> list[dict]:
+    events = []
+    for line in text.splitlines():
+        line = line.strip()
+        if not line.startswith("data:"):
+            continue
+        payload = line.removeprefix("data:").strip()
+        if payload == "[DONE]":
+            continue
+        try:
+            events.append(json.loads(payload))
+        except json.JSONDecodeError:
+            continue
+    return events
+
+
+def _parse_sse_named(text: str) -> list[tuple[str | None, dict]]:
+    """Parse SSE preserving ``event:`` names (Responses surface uses
+    named events; chat-completions uses unnamed ``data:`` lines)."""
+    events: list[tuple[str | None, dict]] = []
+    current_event: str | None = None
+    for raw in text.splitlines():
+        line = raw.strip()
+        if line.startswith("event:"):
+            current_event = line.removeprefix("event:").strip()
+            continue
+        if not line.startswith("data:"):
+            if line == "":
+                current_event = None
+            continue
+        payload = line.removeprefix("data:").strip()
+        if payload == "[DONE]":
+            continue
+        try:
+            events.append((current_event, json.loads(payload)))
+        except json.JSONDecodeError:
+            continue
+    return events
+
+
+@pytest.fixture(autouse=True)
+def _default_off_env(monkeypatch):
+    """Every R-01 test runs with the env knob explicitly unset, so the
+    R-01 default-off behaviour is what the assertions exercise. Tests
+    that want to verify the opt-in path live in
+    ``test_reasoning_content_null_rescue.py`` — this file is the
+    cross-route no-injection contract."""
+    monkeypatch.delenv("RAPID_MLX_REASONING_CUTOFF_NOTICE", raising=False)
+
+
+# ---------------------------------------------------------------------
+# /v1/chat/completions — OpenAI lane
+# ---------------------------------------------------------------------
+
+
+def test_chat_completions_nonstream_no_truncated_injection():
+    """OpenAI chat lane non-streaming: ``message.content`` must NOT
+    carry the ``[truncated…]`` sentinel. ``finish_reason="length"`` is
+    the canonical truncation cue and ``reasoning_content`` carries the
+    thought trace."""
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    from vllm_mlx.config import reset_config
+    from vllm_mlx.routes.chat import router as chat_router
+
+    cfg = reset_config()
+    _seed_cfg(cfg)
+
+    try:
+        app = FastAPI()
+        app.include_router(chat_router)
+        client = TestClient(app)
+        resp = client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "test-model",
+                "stream": False,
+                "max_tokens": 16,
+                "messages": [{"role": "user", "content": "compute 17*23"}],
+            },
+        )
+        assert resp.status_code == 200, resp.text
+        payload = resp.json()
+        msg = payload["choices"][0]["message"]
+        content = msg.get("content")
+
+        assert content != REASONING_CUTOFF_SENTINEL, (
+            f"chat non-stream must NOT inject sentinel; got content={content!r}"
+        )
+        if content:
+            assert _TRUNCATED_SUBSTRING not in content.lower(), (
+                f"chat non-stream content must not carry 'truncated' "
+                f"synthetic text; got {content!r}"
+            )
+        assert payload["choices"][0]["finish_reason"] == "length"
+        assert msg.get("reasoning_content"), (
+            "reasoning_content must remain populated as the canonical truncation cue"
+        )
+    finally:
+        reset_config()
+
+
+def test_chat_completions_stream_no_truncated_injection():
+    """OpenAI chat lane streaming: NO ``delta.content`` chunk in the
+    SSE stream may carry the ``[truncated…]`` sentinel.
+    ``finish_reason="length"`` on the terminal chunk is the canonical
+    truncation cue and ``delta.reasoning_content`` carries the trace."""
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    from vllm_mlx.config import reset_config
+    from vllm_mlx.routes.chat import router as chat_router
+
+    cfg = reset_config()
+    _seed_cfg(cfg)
+
+    try:
+        app = FastAPI()
+        app.include_router(chat_router)
+        client = TestClient(app)
+        resp = client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "test-model",
+                "stream": True,
+                "max_tokens": 64,
+                "messages": [{"role": "user", "content": "compute 17*23"}],
+            },
+        )
+        assert resp.status_code == 200, resp.text
+        events = _parse_sse(resp.text)
+        assert events
+
+        streamed_reasoning = ""
+        terminal_finish_reason: str | None = None
+        for ev in events:
+            for choice in ev.get("choices", []):
+                d = choice.get("delta") or {}
+                content = d.get("content")
+                if content:
+                    assert content != REASONING_CUTOFF_SENTINEL, (
+                        f"chat stream must NOT inject sentinel into any "
+                        f"delta.content chunk; got {content!r}"
+                    )
+                    assert _TRUNCATED_SUBSTRING not in content.lower(), (
+                        f"chat stream delta.content must not carry "
+                        f"'truncated' synthetic text; got {content!r}"
+                    )
+                if d.get("reasoning_content"):
+                    streamed_reasoning += d["reasoning_content"]
+                if choice.get("finish_reason") is not None:
+                    terminal_finish_reason = choice["finish_reason"]
+        assert terminal_finish_reason == "length", (
+            "chat stream must surface finish_reason=length as the "
+            "canonical truncation cue"
+        )
+        assert streamed_reasoning, (
+            "chat stream reasoning_content deltas must still flow"
+        )
+    finally:
+        reset_config()
+
+
+# ---------------------------------------------------------------------
+# /v1/responses — Responses lane
+# ---------------------------------------------------------------------
+
+
+def test_responses_nonstream_no_truncated_injection():
+    """Responses lane non-streaming: ``output[*].content[*].text`` must
+    NOT carry the ``[truncated…]`` sentinel. ``status="incomplete"`` +
+    ``usage.output_tokens_details.reasoning_tokens`` are the canonical
+    truncation cues."""
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    from vllm_mlx.config import reset_config
+    from vllm_mlx.routes.responses import router as responses_router
+
+    cfg = reset_config()
+    _seed_cfg(cfg)
+
+    try:
+        app = FastAPI()
+        app.include_router(responses_router)
+        client = TestClient(app)
+        resp = client.post(
+            "/v1/responses",
+            json={
+                "model": "test-model",
+                "max_output_tokens": 16,
+                "input": "compute 17*23",
+                "stream": False,
+            },
+        )
+        if resp.status_code != 200:
+            pytest.skip(
+                f"/v1/responses adapter rejected synthetic shape "
+                f"({resp.status_code}); behavior covered by helper unit "
+                f"tests in test_reasoning_content_null_rescue.py"
+            )
+        payload = resp.json()
+        body_str = json.dumps(payload)
+
+        assert REASONING_CUTOFF_SENTINEL not in body_str, (
+            f"responses non-stream must NOT carry the sentinel anywhere "
+            f"in the envelope; got payload={payload!r}"
+        )
+        for item in payload.get("output") or []:
+            for block in item.get("content") or []:
+                text = block.get("text") or ""
+                assert _TRUNCATED_SUBSTRING not in text.lower(), (
+                    f"responses non-stream output_text must not carry "
+                    f"'truncated' synthetic text; got block={block!r}"
+                )
+        # Sanity: the structured truncation cue is present.
+        assert payload.get("status") == "incomplete", (
+            f"responses non-stream must surface status='incomplete' as "
+            f"the canonical truncation cue; got status={payload.get('status')!r}"
+        )
+    finally:
+        reset_config()
+
+
+def test_responses_stream_no_truncated_injection():
+    """Responses lane streaming: NO ``response.output_text.delta`` SSE
+    event may carry the ``[truncated…]`` sentinel."""
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    from vllm_mlx.config import reset_config
+    from vllm_mlx.routes.responses import router as responses_router
+
+    cfg = reset_config()
+    _seed_cfg(cfg)
+
+    try:
+        app = FastAPI()
+        app.include_router(responses_router)
+        client = TestClient(app)
+        resp = client.post(
+            "/v1/responses",
+            json={
+                "model": "test-model",
+                "max_output_tokens": 64,
+                "input": "compute 17*23",
+                "stream": True,
+            },
+        )
+        if resp.status_code != 200:
+            pytest.skip(
+                f"/v1/responses stream adapter rejected synthetic shape "
+                f"({resp.status_code}); covered by helper unit tests"
+            )
+        events = _parse_sse_named(resp.text)
+        assert events, "expected at least one SSE event"
+
+        for event_name, payload in events:
+            body_str = json.dumps(payload)
+            assert REASONING_CUTOFF_SENTINEL not in body_str, (
+                f"responses stream event {event_name!r} must NOT carry "
+                f"the sentinel; got payload={payload!r}"
+            )
+            # Specifically check ``output_text.delta`` event shape.
+            if event_name == "response.output_text.delta":
+                delta = payload.get("delta") or ""
+                if isinstance(delta, str):
+                    assert _TRUNCATED_SUBSTRING not in delta.lower(), (
+                        f"responses stream output_text.delta must not "
+                        f"carry 'truncated' synthetic text; got {delta!r}"
+                    )
+    finally:
+        reset_config()
+
+
+# ---------------------------------------------------------------------
+# /v1/messages — Anthropic lane
+# ---------------------------------------------------------------------
+
+
+def test_messages_nonstream_no_truncated_injection():
+    """Anthropic lane non-streaming: no text-type content block in the
+    response may carry the ``[truncated…]`` sentinel.
+    ``stop_reason="max_tokens"`` + the ``thinking`` content block are
+    the canonical truncation cues."""
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    from vllm_mlx.config import reset_config
+    from vllm_mlx.routes.anthropic import router as anthropic_router
+
+    cfg = reset_config()
+    _seed_cfg(cfg)
+
+    try:
+        app = FastAPI()
+        app.include_router(anthropic_router)
+        client = TestClient(app)
+        resp = client.post(
+            "/v1/messages",
+            json={
+                "model": "test-model",
+                "max_tokens": 16,
+                "messages": [{"role": "user", "content": "compute 17*23"}],
+                "stream": False,
+            },
+        )
+        if resp.status_code != 200:
+            pytest.skip(
+                f"/v1/messages adapter rejected synthetic shape "
+                f"({resp.status_code}); behavior covered by helper unit "
+                f"tests"
+            )
+        payload = resp.json()
+        body_str = json.dumps(payload)
+
+        assert REASONING_CUTOFF_SENTINEL not in body_str, (
+            f"messages non-stream must NOT carry the sentinel anywhere; "
+            f"got payload={payload!r}"
+        )
+        for block in payload.get("content") or []:
+            if block.get("type") == "text":
+                text = block.get("text") or ""
+                assert _TRUNCATED_SUBSTRING not in text.lower(), (
+                    f"messages non-stream text block must not carry "
+                    f"'truncated' synthetic text; got block={block!r}"
+                )
+        # Sanity: structured truncation cue present.
+        assert payload.get("stop_reason") == "max_tokens", (
+            f"messages non-stream must surface stop_reason='max_tokens' "
+            f"as the canonical truncation cue; "
+            f"got {payload.get('stop_reason')!r}"
+        )
+    finally:
+        reset_config()
+
+
+def test_messages_stream_no_truncated_injection():
+    """Anthropic lane streaming: NO ``content_block_delta`` event with a
+    ``text_delta`` payload may carry the ``[truncated…]`` sentinel."""
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    from vllm_mlx.config import reset_config
+    from vllm_mlx.routes.anthropic import router as anthropic_router
+
+    cfg = reset_config()
+    _seed_cfg(cfg)
+
+    try:
+        app = FastAPI()
+        app.include_router(anthropic_router)
+        client = TestClient(app)
+        resp = client.post(
+            "/v1/messages",
+            json={
+                "model": "test-model",
+                "max_tokens": 64,
+                "messages": [{"role": "user", "content": "compute 17*23"}],
+                "stream": True,
+            },
+        )
+        if resp.status_code != 200:
+            pytest.skip(
+                f"/v1/messages stream adapter rejected synthetic shape "
+                f"({resp.status_code})"
+            )
+        events = _parse_sse_named(resp.text)
+        assert events, "expected at least one SSE event"
+
+        for event_name, payload in events:
+            body_str = json.dumps(payload)
+            assert REASONING_CUTOFF_SENTINEL not in body_str, (
+                f"messages stream event {event_name!r} must NOT carry "
+                f"the sentinel; got payload={payload!r}"
+            )
+            if event_name == "content_block_delta":
+                delta = payload.get("delta") or {}
+                if delta.get("type") == "text_delta":
+                    text = delta.get("text") or ""
+                    assert _TRUNCATED_SUBSTRING not in text.lower(), (
+                        f"messages stream text_delta must not carry "
+                        f"'truncated' synthetic text; got {text!r}"
+                    )
+    finally:
+        reset_config()
+
+
+# ---------------------------------------------------------------------
+# Belt-and-braces: helper truth table at default-off
+# ---------------------------------------------------------------------
+
+
+def test_helper_returns_none_on_default_env(monkeypatch):
+    """Direct helper assertion at default-off — pins that no synthetic
+    text can leak even if a future route call site forgets to pass
+    every predicate. The helper itself defaults to no-op."""
+    from vllm_mlx.service.helpers import _apply_reasoning_cutoff_notice
+
+    monkeypatch.delenv("RAPID_MLX_REASONING_CUTOFF_NOTICE", raising=False)
+    result = _apply_reasoning_cutoff_notice(
+        final_content=None,
+        reasoning_text="<incomplete thought>",
+        tool_calls=None,
+        finish_reason="length",
+    )
+    assert result is None, (
+        f"R-01 helper default must return None on length-cut mid-think; got {result!r}"
+    )
+
+
+def test_no_truncated_literal_in_route_module_call_sites():
+    """Static guard: the literal sentinel string must NOT appear inline
+    in any route module. The only legitimate definition site is the
+    ``REASONING_CUTOFF_SENTINEL`` constant in ``service.helpers``. A
+    future regression that hard-codes the literal at a route call site
+    (e.g. a regex band-aid) fails this test."""
+    import importlib
+    import inspect
+
+    pattern = re.compile(r"\[truncated.*reasoning incomplete")
+    for module_name in (
+        "vllm_mlx.routes.chat",
+        "vllm_mlx.routes.responses",
+        "vllm_mlx.routes.anthropic",
+    ):
+        mod = importlib.import_module(module_name)
+        src = inspect.getsource(mod)
+        assert not pattern.search(src), (
+            f"R-01 single-source-of-truth: the truncated sentinel literal "
+            f"must NOT appear inline in {module_name}; it is defined once "
+            f"in vllm_mlx.service.helpers.REASONING_CUTOFF_SENTINEL and "
+            f"applied via _apply_reasoning_cutoff_notice. A literal here "
+            f"indicates a regex band-aid that bypasses the helper."
+        )

--- a/tests/test_truncation_no_synthetic_text.py
+++ b/tests/test_truncation_no_synthetic_text.py
@@ -312,12 +312,7 @@ def test_responses_nonstream_no_truncated_injection():
                 "stream": False,
             },
         )
-        if resp.status_code != 200:
-            pytest.skip(
-                f"/v1/responses adapter rejected synthetic shape "
-                f"({resp.status_code}); behavior covered by helper unit "
-                f"tests in test_reasoning_content_null_rescue.py"
-            )
+        assert resp.status_code == 200, resp.text
         payload = resp.json()
         body_str = json.dumps(payload)
 
@@ -366,11 +361,7 @@ def test_responses_stream_no_truncated_injection():
                 "stream": True,
             },
         )
-        if resp.status_code != 200:
-            pytest.skip(
-                f"/v1/responses stream adapter rejected synthetic shape "
-                f"({resp.status_code}); covered by helper unit tests"
-            )
+        assert resp.status_code == 200, resp.text
         events = _parse_sse_named(resp.text)
         assert events, "expected at least one SSE event"
 
@@ -424,12 +415,7 @@ def test_messages_nonstream_no_truncated_injection():
                 "stream": False,
             },
         )
-        if resp.status_code != 200:
-            pytest.skip(
-                f"/v1/messages adapter rejected synthetic shape "
-                f"({resp.status_code}); behavior covered by helper unit "
-                f"tests"
-            )
+        assert resp.status_code == 200, resp.text
         payload = resp.json()
         body_str = json.dumps(payload)
 
@@ -479,11 +465,7 @@ def test_messages_stream_no_truncated_injection():
                 "stream": True,
             },
         )
-        if resp.status_code != 200:
-            pytest.skip(
-                f"/v1/messages stream adapter rejected synthetic shape "
-                f"({resp.status_code})"
-            )
+        assert resp.status_code == 200, resp.text
         events = _parse_sse_named(resp.text)
         assert events, "expected at least one SSE event"
 

--- a/vllm_mlx/routes/anthropic.py
+++ b/vllm_mlx/routes/anthropic.py
@@ -983,15 +983,15 @@ async def create_anthropic_message(
             raw_text=output.raw_text or output.text,
             reasoning_is_case4=reasoning_is_case4,
         )
-        # H-01: Anthropic-side mirror of the chat-route cutoff sentinel.
-        # The OpenAI-shaped envelope built below is later adapted to the
-        # ``/v1/messages`` ``ContentBlock`` list — the empty-TextBlock
-        # rescue documented downstream relies on ``final_content`` being
-        # NON-empty to surface a text block. Applying the sentinel here
-        # ensures Anthropic SDK consumers see the same "truncated, raise
-        # max_tokens" signal as OpenAI consumers, gated by the same
-        # ``RAPID_MLX_REASONING_CUTOFF_NOTICE`` env var. See helper
-        # docstring for the full predicate set.
+        # R-01 (was H-01): Anthropic-side mirror of the chat-route opt-in
+        # cutoff sentinel. Default-off — the Anthropic envelope already
+        # carries ``stop_reason="max_tokens"`` + the ``thinking`` content
+        # block, so SDK consumers have an unambiguous structured
+        # truncation signal without any synthetic ``text`` block. When
+        # the env knob ``RAPID_MLX_REASONING_CUTOFF_NOTICE=1`` is set,
+        # the helper restores the legacy literal-text cue for callers
+        # who want it (e.g. chat UIs that only render text blocks). See
+        # helper docstring for the full predicate set.
         final_content = _apply_reasoning_cutoff_notice(
             final_content,
             reasoning_text,

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -2096,20 +2096,16 @@ async def _create_chat_completion_impl(
             raw_text=output.raw_text or output.text,
             reasoning_is_case4=reasoning_is_case4,
         )
-        # H-01: when the rescue above explicitly chose NOT to promote the
-        # reasoning trace into ``content`` (truncated-``<think>`` /
-        # harmony analysis-without-final / Case-4 no-tag fallback —
-        # D-STOP-THINK + D-HARMONY-LEAK contracts), the response still
-        # ships ``content=None`` on a ``length`` finish and SDK consumers
-        # render an empty bubble. Surface a parser-independent literal
-        # sentinel as ``content`` instead, so every OpenAI SDK client
-        # sees a clear "truncated, raise max_tokens" signal. The sentinel
-        # is NEVER the reasoning text — that would re-introduce exactly
-        # the leak D-STOP-THINK / D-HARMONY-LEAK closed. Opt-out via
-        # ``RAPID_MLX_REASONING_CUTOFF_NOTICE=disabled`` for callers
-        # that already handle ``content is None`` natively. The helper
-        # itself owns ALL the predicates (env, finish_reason, content
-        # emptiness, tool-call gate) so this call site stays trivial.
+        # R-01 (was H-01): opt-IN cutoff sentinel. By default the helper
+        # is a no-op — the structured truncation signal
+        # (``finish_reason="length"`` + ``reasoning_content`` populated)
+        # is enough for SDK consumers, and synthesizing a literal text
+        # block the model never produced is harmful injection. Callers
+        # who DO want the legacy literal-text cue can opt back in via
+        # ``RAPID_MLX_REASONING_CUTOFF_NOTICE=1``. The helper itself owns
+        # ALL the predicates (env opt-in, finish_reason, content
+        # emptiness, tool-call gate, reasoning presence) so this call
+        # site stays trivial.
         final_content = _apply_reasoning_cutoff_notice(
             final_content,
             reasoning_text,
@@ -2601,18 +2597,20 @@ async def stream_chat_completion(
                         "content",
                         len(terminal_content),
                     )
-            # H-01 streaming mirror: when the SSE rescue above did NOT
-            # promote reasoning into ``terminal_content`` (strict null
-            # path won — truncated ``<think>`` / harmony analysis-
-            # without-final / Case-4 no-tag), emit the literal cutoff
-            # sentinel as ONE final-chunk ``delta.content`` event so
-            # streaming SDK consumers see the same signal as their
-            # non-streaming counterparts. Per-token reasoning deltas
-            # have already been sent during the loop; this is a single
+            # R-01 (was H-01) streaming mirror: helper is opt-IN. When
+            # ``RAPID_MLX_REASONING_CUTOFF_NOTICE=1`` AND the SSE rescue
+            # above did NOT promote reasoning into ``terminal_content``
+            # (strict null path won — truncated ``<think>`` / harmony
+            # analysis-without-final / Case-4 no-tag), emit the literal
+            # cutoff sentinel as ONE final-chunk ``delta.content`` event
+            # so streaming SDK consumers see the same signal as their
+            # non-streaming counterparts. Per-token reasoning deltas have
+            # already been sent during the loop; this is a single
             # extra-bytes-on-the-final-chunk event, NOT a per-token
             # mirror of the reasoning trace (D-STOP-THINK regression
-            # guard). Gating logic matches the non-streaming call site —
-            # the helper owns it.
+            # guard). Default-off: no event is emitted unless the env
+            # knob is set. Gating logic matches the non-streaming call
+            # site — the helper owns it.
             if not has_any_tool_calls and not structured_output_requested:
                 cutoff_content = _apply_reasoning_cutoff_notice(
                     terminal_content or None,

--- a/vllm_mlx/routes/responses.py
+++ b/vllm_mlx/routes/responses.py
@@ -654,22 +654,19 @@ async def _non_stream(
 
     finish_reason = "tool_calls" if tool_calls else output.finish_reason
 
-    # H-01: /v1/responses mirror of the chat-route cutoff sentinel.
-    #
-    # Codex r1 NIT (PR #802): the Responses surface intentionally does
-    # NOT run ``_rescue_silent_drop_from_reasoning`` (this endpoint
-    # never carried the issue#569 silent-drop pre-history, and the
-    # adapter shape makes the rescue's #569 promotion semantically
-    # ambiguous), so the predicate set this helper sees on Responses
-    # is broader than on chat/anthropic — ANY length-finished response
-    # with empty content + non-empty reasoning + no tool calls trips
-    # the sentinel, NOT specifically "rescue-suppressed promotion".
-    # That broader scope is OK here: the same UX gap (SDK consumers
-    # see empty bubbles) is exactly what the sentinel fixes, and on
-    # this surface there is no ``_rescue_silent_drop_from_reasoning``
-    # call that could have produced the empty shape for a different
-    # reason. Helper owns the env opt-out + finish-reason gate so
-    # back-compat is preserved.
+    # R-01 (was H-01): /v1/responses mirror of the opt-in cutoff
+    # sentinel. Default-off — the Responses envelope already reports
+    # ``status="incomplete"`` and
+    # ``usage.output_tokens_details.reasoning_tokens``, so SDK consumers
+    # have an unambiguous structured truncation signal without any
+    # synthetic ``output_text`` block. When the env knob
+    # ``RAPID_MLX_REASONING_CUTOFF_NOTICE=1`` is set, the helper restores
+    # the legacy literal-text cue for callers who want it. The Responses
+    # surface intentionally does NOT run
+    # ``_rescue_silent_drop_from_reasoning`` (this endpoint never
+    # carried the issue#569 silent-drop pre-history), so the helper sees
+    # a broader predicate set here than on chat/anthropic — that scope
+    # is fine because the helper itself owns all the gates.
     final_content = _apply_reasoning_cutoff_notice(
         final_content,
         reasoning_text,

--- a/vllm_mlx/service/helpers.py
+++ b/vllm_mlx/service/helpers.py
@@ -756,7 +756,7 @@ def _rescue_silent_drop_from_reasoning(
 
 
 # ---------------------------------------------------------------------------
-# H-01: reasoning-cutoff sentinel
+# H-01 / R-01: reasoning-cutoff sentinel (opt-in)
 # ---------------------------------------------------------------------------
 #
 # When a reasoning model (qwen3, deepseek_r1, phi-4-mini-reasoning, glm4,
@@ -768,73 +768,86 @@ def _rescue_silent_drop_from_reasoning(
 # promoting it to ``content`` would ship byte-identical bytes in both
 # fields (the leak shape those PRs explicitly closed).
 #
-# The complementary UX gap (H-01): every OpenAI SDK consumer reads
-# ``choices[0].message.content`` and renders an empty bubble. SDK defaults
-# of ``max_tokens=256`` or ``max_tokens=512`` are common, so the most
-# observable failure mode of a reasoning model on a tight budget is a
-# silently empty assistant turn — clients have no signal beyond
-# ``finish_reason="length"`` (which only sophisticated consumers check).
+# History: H-01 (PR #802, 2026-06-21) introduced an opt-OUT sentinel that
+# was injected into ``content`` by default to give SDK consumers a literal
+# "truncated, raise max_tokens" cue instead of an empty bubble.
 #
-# Policy A (this helper): when the response was cut off mid-think on a
-# ``length`` finish AND the rescue helper above already decided NOT to
-# promote reasoning into content (strict routing wins), emit a clearly-
-# marked sentinel string in ``content`` so SDK consumers see something.
-# The sentinel is a literal, parser-independent notice — NEVER the
-# parser-internal reasoning text — so it cannot re-introduce the
-# D-STOP-THINK / D-HARMONY-LEAK leak shape. ``reasoning_content`` stays
-# populated as before.
+# R-01 (0.8.5 dogfood, this commit): operator policy reverses the default.
+# Synthesizing a placeholder text block that the model never produced is
+# treated as harmful injection — every transport already carries an
+# unambiguous truncation signal:
 #
-# Scope:
+#   * /v1/chat/completions  → ``finish_reason="length"``
+#   * /v1/responses         → ``status="incomplete"`` +
+#                              ``output_tokens_details.reasoning_tokens``
+#   * /v1/messages          → ``stop_reason="max_tokens"`` +
+#                              ``thinking`` content block
 #
-# * Fires ONLY on ``finish_reason="length"`` (NOT on ``"stop"`` — stop-
-#   string mid-think is D-STOP-THINK's exact case, where the strict null
-#   contract must hold and the caller can re-request to drive the model
-#   past the stop string).
+# Clients that DO want the legacy literal-text cue (e.g. chat UIs that do
+# not render the structured truncation fields) can re-enable the sentinel
+# on a single envelope field via ``RAPID_MLX_REASONING_CUTOFF_NOTICE=1``
+# (or ``true`` / ``on`` / ``yes`` / ``enabled``). The helper is preserved
+# as a single source of truth so the OpenAI chat lane, the Responses lane,
+# and the Anthropic adapter cannot drift apart.
+#
+# Scope (unchanged across the flip):
+#
+# * Fires ONLY when the env var explicitly enables the notice.
+# * Fires ONLY on ``finish_reason="length"`` (NOT on ``"stop"`` —
+#   stop-string mid-think is D-STOP-THINK's exact case, where the strict
+#   null contract must hold and the caller can re-request to drive the
+#   model past the stop string).
 # * Fires ONLY when ``content`` is empty/None AND ``reasoning_text`` is
 #   non-empty — the silent-drop shape clients actually trip on. Happy-
 #   path (closed ``</think>answer`` split) flows untouched.
 # * Fires ONLY when no ``tool_calls`` were extracted — tool-only responses
 #   legitimately ship ``content=None`` per the OpenAI spec.
-# * Opt-out via ``RAPID_MLX_REASONING_CUTOFF_NOTICE``: any of
-#   ``"0"`` / ``"false"`` / ``"no"`` / ``"off"`` / ``"disabled"`` /
-#   ``""`` reverts to the strict-null behaviour for callers who already
-#   handle ``content is None`` (e.g. internal agents in this repo).
-#   Default is ``enabled``.
 #
 # Single source of truth — both the OpenAI ``/v1/chat/completions``
 # non-stream + stream paths AND the Anthropic ``/v1/messages`` adapter
-# call this helper so the user-visible behaviour cannot drift between
-# surfaces. (The streaming path emits the sentinel as one final-chunk
-# ``delta.content`` event, not per-token, so no token-by-token leak of
-# the sentinel string itself.)
+# AND the ``/v1/responses`` adapter call this helper, so the user-visible
+# behaviour cannot drift between surfaces. (The streaming path, when the
+# env knob is on, emits the sentinel as one final-chunk ``delta.content``
+# event, not per-token, so no token-by-token leak of the sentinel string
+# itself.)
 
-#: Literal sentinel surfaced to ``content`` when generation is cut short
-#: mid-think on ``finish_reason="length"``. Kept short and unambiguous so
-#: agentic clients can pattern-match if they want to auto-retry with a
-#: larger ``max_tokens``, but verbose enough that a human user sees a
-#: clear "this turn was truncated" signal in the bubble rather than the
-#: previous silently-empty render.
+#: Literal sentinel surfaced to ``content`` when the env-opt-in is set AND
+#: generation is cut short mid-think on ``finish_reason="length"``. Kept
+#: short and unambiguous so agentic clients can pattern-match if they
+#: want to auto-retry with a larger ``max_tokens``.
 REASONING_CUTOFF_SENTINEL = "[truncated — reasoning incomplete; raise max_tokens]"
 
-#: Env var values that DISABLE the sentinel notice (revert to strict null
-#: behaviour). Anything outside this set — including unset — leaves the
-#: sentinel enabled (the default for the user-facing UX fix).
-_CUTOFF_NOTICE_DISABLED_VALUES = frozenset({"0", "false", "no", "off", "disabled", ""})
+#: Env var values that EXPLICITLY ENABLE the sentinel notice (R-01 flip:
+#: default is now OFF). Anything outside this set — including unset —
+#: keeps the strict-null behaviour (no synthetic text injection).
+_CUTOFF_NOTICE_ENABLED_VALUES = frozenset({"1", "true", "on", "yes", "enabled"})
 
 
 def _cutoff_notice_enabled() -> bool:
-    """Whether the H-01 cutoff sentinel is enabled for this process.
+    """Whether the cutoff sentinel is enabled for this process.
 
-    Reads ``RAPID_MLX_REASONING_CUTOFF_NOTICE`` on each call so test
-    harnesses can flip the env var per-request via
-    ``monkeypatch.setenv`` without restarting the process. The cost is
-    negligible (``os.environ.get`` is a dict lookup) and matches how
-    every other ``RAPID_MLX_*`` env-gated knob is read in this module.
+    R-01 flip: default is OFF. The structured truncation signal carried by
+    every transport (``finish_reason="length"`` /
+    ``status="incomplete"`` / ``stop_reason="max_tokens"``) is the
+    canonical truncation cue. The literal sentinel is opt-in via
+    ``RAPID_MLX_REASONING_CUTOFF_NOTICE``.
+
+    Reads the env var on each call so test harnesses can flip the gate
+    per-request via ``monkeypatch.setenv`` without restarting the
+    process. The cost is negligible (``os.environ.get`` is a dict
+    lookup) and matches how every other ``RAPID_MLX_*`` env-gated knob
+    is read in this module.
+
+    Accepted enable values (case-insensitive, surrounding whitespace
+    stripped): ``"1"`` / ``"true"`` / ``"on"`` / ``"yes"`` /
+    ``"enabled"``. Anything else — including unset, the empty string,
+    ``"0"``, ``"false"``, ``"no"``, ``"off"``, ``"disabled"``, or any
+    arbitrary unrecognised value — leaves the sentinel disabled.
     """
     raw = os.environ.get("RAPID_MLX_REASONING_CUTOFF_NOTICE")
     if raw is None:
-        return True  # default on
-    return raw.strip().lower() not in _CUTOFF_NOTICE_DISABLED_VALUES
+        return False  # R-01: default OFF
+    return raw.strip().lower() in _CUTOFF_NOTICE_ENABLED_VALUES
 
 
 def _apply_reasoning_cutoff_notice(


### PR DESCRIPTION
## Summary

- R-01 (0.8.5 dogfood, `0.8TODO.md` r4): the H-01 cutoff sentinel injected `[truncated — reasoning incomplete; raise max_tokens]` into `content` on length-cut mid-think across every route. The 0.8.3 H-01 fix (PR #802) intended this as a UX rescue, but operator policy on R-01 reverses it: every transport already carries an unambiguous structured truncation signal, so the synthetic text block is harmful injection.
- Systemic fix at the reasoning-finalize layer (single source of truth): flip `_apply_reasoning_cutoff_notice` from opt-OUT to opt-IN. The helper now reads `RAPID_MLX_REASONING_CUTOFF_NOTICE` as a closed enable set (`1` / `true` / `on` / `yes` / `enabled`, case-insensitive); anything outside that set — including unset, `0`, `false`, `disabled`, or any unrecognised value — keeps the sentinel disabled. All three routes call the same helper, so behaviour cannot drift between surfaces.
- Callers that want the legacy literal-text cue (e.g. chat UIs that only render text blocks) set `RAPID_MLX_REASONING_CUTOFF_NOTICE=1`.

## Dogfood evidence cited

- Yuki F3 — `/tmp/dogfood-085/yuki-r1.md` + `/tmp/dogfood-085/yuki-evidence-F3.json` (R-01 on `/v1/responses`).
- Marcus — `/tmp/dogfood-085/marcus-r1.md` (R-01 on `/v1/chat/completions`).
- Yuki R10 — `/tmp/dogfood-085/yuki-r2.md` (cross-lane regression evidence).

## Why not a per-route regex band-aid

The helper at `vllm_mlx/service/helpers.py::_apply_reasoning_cutoff_notice` is already the single source of truth for the chat lane, the responses lane, and the Anthropic adapter — it owns the env-gate, the `finish_reason="length"` gate, the content-emptiness gate, the tool-call gate, and the reasoning-presence gate. Flipping the default in the helper is the minimal-surface, state-machine fix; no route-level synthesis logic is touched (only the comments at each call site are updated to reflect the new default), and a new static guard in `test_truncation_no_synthetic_text.py` greps every route module for the literal sentinel substring so any future regex band-aid that bypasses the helper fails the suite.

## Probe verification (qwen3-0.6b-8bit, max_tokens=15, prompt "Think step by step: what is 7 times 8?")

| Route | Before (default-on H-01) | After (R-01 default-off) | After + `RAPID_MLX_REASONING_CUTOFF_NOTICE=1` |
| --- | --- | --- | --- |
| `/v1/chat/completions` | `content="[truncated — reasoning incomplete; raise max_tokens]"` | `content=None`, `finish_reason="length"`, `reasoning_content` populated | `content="[truncated — reasoning incomplete; raise max_tokens]"` (legacy H-01 restored) |
| `/v1/responses` | `output[0].content[0].text="[truncated — …]"` | `output=[]`, `status="incomplete"`, `usage.output_tokens_details.reasoning_tokens` populated | sentinel restored on `output[0].content[0]` |
| `/v1/messages` | `content[1].text="[truncated — …]"` after the `thinking` block | `content=[{type:"thinking", thinking:"..."}]`, `stop_reason="max_tokens"` | sentinel restored on the trailing text block |

(Anthropic lane was NOT clean before — confirmed locally on this branch; the operator's `0.8TODO.md` note that PR #810 had fixed it was incorrect. All three routes converged on the same systemic fix.)

## Test plan

- [x] New `tests/test_truncation_no_synthetic_text.py` — 8 tests pinning the cross-route no-injection contract on streaming AND non-streaming paths of all three transports, plus a static guard that the literal sentinel cannot reappear inline in any route module.
- [x] Rewritten `tests/test_reasoning_content_null_rescue.py` — 64 tests covering the helper truth table at both default-off and opt-in, parser-wide (qwen3 / deepseek_r1 / vibethinker / glm4), streaming + non-streaming, plus route-wiring proofs and source-grep guards.
- [x] Updated `tests/test_no_out_of_band_routing.py` allowlist comment and `tests/test_harmony_finalize.py` D-HARMONY-LEAK regression guard to reflect the flipped semantics.
- [x] `ruff check vllm_mlx/ tests/` clean.
- [x] `ruff format vllm_mlx/ tests/` clean.
- [x] `pytest tests/test_truncation_no_synthetic_text.py` — 8/8 passed.
- [x] `pytest tests/test_reasoning_content_null_rescue.py` — 64/64 passed.
- [x] `pytest -k 'truncat or reasoning_finalize or stop_reason or stop_think or harmony_finalize or cutoff_notice or reasoning_content_null'` — 161/161 passed (collection-error skips on unrelated PIL/aiohttp deps not introduced here).
- [x] Live probe against fresh `rapid-mlx serve qwen3-0.6b-8bit` confirms default-off behaviour and opt-in restoration on all 3 routes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)