### PR TITLE
fix(/v1/responses): reasoning item + tool_choice + cross-lane parity + UI-TARS Computer-Use + SSE events + truncation/service_tier echo

### DIFF
--- a/tests/test_responses_adapter.py
+++ b/tests/test_responses_adapter.py
@@ -85,17 +85,24 @@ class TestConvertTools:
         assert td.function["description"] == "Get weather"
         assert td.function["parameters"]["properties"] == {"city": {"type": "string"}}
 
-    def test_drops_non_function_tools(self):
-        tools = _convert_tools(
-            [
-                {"type": "function", "name": "real_one"},
-                {"type": "web_search"},
-                {"type": "code_interpreter"},
-                {"type": "image_generation"},
-            ]
-        )
-        assert tools is not None and len(tools) == 1
-        assert tools[0].function["name"] == "real_one"
+    def test_unsupported_tool_types_raise_400(self):
+        """Yuki F13 (0.8.5 dogfood): unsupported tool types now raise a
+        clean 400 instead of silently dropping. The chat/anthropic lanes
+        already 400; the /v1/responses lane now matches.
+        """
+        import pytest
+        from fastapi import HTTPException
+
+        for unsupported in ("web_search", "code_interpreter", "image_generation"):
+            with pytest.raises(HTTPException) as exc_info:
+                _convert_tools(
+                    [
+                        {"type": "function", "name": "real_one"},
+                        {"type": unsupported},
+                    ]
+                )
+            assert exc_info.value.status_code == 400
+            assert "unsupported_tool_type" in str(exc_info.value.detail)
 
     def test_drops_function_without_name(self):
         tools = _convert_tools([{"type": "function", "description": "no name"}])

--- a/tests/test_responses_bundle.py
+++ b/tests/test_responses_bundle.py
@@ -681,6 +681,50 @@ class TestC06ComputerUseReachability:
         assert cc["action"]["type"] == "click"
         assert cc["action"]["start_box"] == [128, 128]
 
+    def test_computer_call_emitted_even_when_caller_supplies_custom_tool_name(
+        self, make_responses_client
+    ):
+        """Codex r2 BLOCKING (PR #817): a request like
+        ``{type:"computer_20251022", name:"screen"}`` previously
+        registered a tool named ``"screen"`` while the UI-TARS parser
+        always emits ``function.name == "computer"`` — no match, and
+        the lane downgraded to a plain ``function_call``. The fix
+        forces the canonical name at the adapter boundary so the
+        ``computer_call`` translation lights up.
+        """
+        state = make_responses_client(
+            text="",
+            tool_calls=[
+                _make_function_call(
+                    "computer",
+                    json.dumps({"action": "click", "start_box": [50, 50]}),
+                    call_id="call_screen",
+                )
+            ],
+            finish_reason="tool_calls",
+        )
+
+        resp = state.client.post(
+            "/v1/responses",
+            json=_payload(
+                tools=[
+                    {
+                        "type": "computer_20251022",
+                        "name": "screen",  # Non-canonical caller name
+                        "display_width": 800,
+                        "display_height": 600,
+                        "environment": "linux",
+                    }
+                ]
+            ),
+            headers=_AUTH,
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+
+        computer_calls = [o for o in body["output"] if o["type"] == "computer_call"]
+        assert computer_calls, body["output"]
+
     def test_function_tool_without_computer_use_still_emits_function_call(
         self, make_responses_client
     ):

--- a/tests/test_responses_bundle.py
+++ b/tests/test_responses_bundle.py
@@ -1,0 +1,741 @@
+# SPDX-License-Identifier: Apache-2.0
+"""HTTP-level tests for the 0.8.5 dogfood ``/v1/responses`` bundle fixes.
+
+Covers Yuki F4, F6, F8, F13 + Yuki R6, R7, R10 + Ana C-06. See
+``0.8TODO.md`` r4 section and ``/tmp/dogfood-085/yuki-r{1,2}.md`` for
+the original evidence. Each test class names its finding so a future
+regression triages to the right report.
+
+Same lightweight-engine harness shape as ``test_responses_route.py`` —
+no MLX import — so the tests stay fast and CI-portable.
+"""
+
+import json
+import sys
+import types
+from dataclasses import dataclass, field
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+# ---------------------------------------------------------------------------
+# Lightweight engine harness — copy of routes/test_responses_route.py's
+# fixture with a richer mock so the new tests can exercise reasoning
+# content, tool_calls, and Computer-Use translation in one place.
+# ---------------------------------------------------------------------------
+
+
+class _Tokenizer:
+    chat_template = ""
+
+    def __init__(self):
+        self.calls = []
+
+    def encode(self, text: str) -> list[int]:
+        self.calls.append(text)
+        return list(range(len(text)))
+
+
+class _BaseEngine:
+    pass
+
+
+@dataclass
+class _GenerationOutput:
+    text: str
+    raw_text: str = ""
+    tokens: list[int] = field(default_factory=list)
+    prompt_tokens: int = 0
+    completion_tokens: int = 0
+    finish_reason: str | None = "stop"
+    new_text: str = ""
+    finished: bool = True
+    logprobs: Any = None
+    channel: str | None = None
+    tool_calls: list | None = None
+    reasoning_text: str = ""
+
+
+def _make_function_call(name: str, args: str, call_id: str = "call_test"):
+    """Build a structured tool_call dict in the shape the engine surfaces
+    to ``_parse_tool_calls_with_parser`` (flat ``name``/``arguments``/
+    ``id`` — see service/helpers.py L1816)."""
+    return {
+        "id": call_id,
+        "name": name,
+        "arguments": args,
+    }
+
+
+class _Engine:
+    preserve_native_tool_format = False
+
+    def __init__(
+        self,
+        *,
+        text: str = "hello world",
+        reasoning_text: str = "",
+        tool_calls: list | None = None,
+        finish_reason: str = "stop",
+    ):
+        self.calls: list[SimpleNamespace] = []
+        self.stream_calls: list[SimpleNamespace] = []
+        self.tokenizer = _Tokenizer()
+        self._text = text
+        self._reasoning_text = reasoning_text
+        self._tool_calls = tool_calls
+        self._finish_reason = finish_reason
+
+    async def chat(self, messages, **kwargs):
+        self.calls.append(SimpleNamespace(messages=messages, kwargs=kwargs))
+        return _GenerationOutput(
+            text=self._text,
+            raw_text=self._text,
+            prompt_tokens=3,
+            completion_tokens=2,
+            finish_reason=self._finish_reason,
+            tool_calls=self._tool_calls,
+            reasoning_text=self._reasoning_text,
+        )
+
+    async def stream_chat(self, messages, **kwargs):
+        """Emit a tiny synthetic stream: three text chunks then EOS, with
+        optional reasoning_text and tool_calls on the final chunk."""
+        self.stream_calls.append(SimpleNamespace(messages=messages, kwargs=kwargs))
+        chunks = ["Hello", " from", " rapid"]
+        for i, c in enumerate(chunks):
+            yield _GenerationOutput(
+                text="".join(chunks[: i + 1]),
+                new_text=c,
+                prompt_tokens=3 if i == 0 else 0,
+                completion_tokens=i + 1,
+                finish_reason=None if i < len(chunks) - 1 else self._finish_reason,
+                tool_calls=self._tool_calls if i == len(chunks) - 1 else None,
+                reasoning_text=self._reasoning_text if i == len(chunks) - 1 else "",
+            )
+
+
+def _install_lightweight_engine_modules(monkeypatch):
+    engine_pkg = types.ModuleType("vllm_mlx.engine")
+    engine_pkg.BaseEngine = _BaseEngine
+    engine_pkg.GenerationOutput = _GenerationOutput
+
+    base_mod = types.ModuleType("vllm_mlx.engine.base")
+    base_mod.BaseEngine = _BaseEngine
+    base_mod.GenerationOutput = _GenerationOutput
+
+    monkeypatch.setitem(sys.modules, "vllm_mlx.engine", engine_pkg)
+    monkeypatch.setitem(sys.modules, "vllm_mlx.engine.base", base_mod)
+
+
+_IMPORTED_UNDER_LIGHTWEIGHT_ENGINE = (
+    "vllm_mlx.config",
+    "vllm_mlx.config.server_config",
+    "vllm_mlx.engine",
+    "vllm_mlx.engine.base",
+    "vllm_mlx.middleware.auth",
+    "vllm_mlx.service.helpers",
+    "vllm_mlx.routes.responses",
+)
+_PARENT_ATTRS_UNDER_LIGHTWEIGHT_ENGINE = (
+    ("vllm_mlx", "config"),
+    ("vllm_mlx", "engine"),
+    ("vllm_mlx.config", "server_config"),
+    ("vllm_mlx.engine", "base"),
+    ("vllm_mlx.middleware", "auth"),
+    ("vllm_mlx.service", "helpers"),
+    ("vllm_mlx.routes", "responses"),
+)
+_MISSING = object()
+
+
+def _make_client(monkeypatch, engine: _Engine) -> SimpleNamespace:
+    previous_modules = {
+        name: sys.modules.get(name, _MISSING)
+        for name in _IMPORTED_UNDER_LIGHTWEIGHT_ENGINE
+    }
+    previous_attrs = {}
+    for module_name, attr in _PARENT_ATTRS_UNDER_LIGHTWEIGHT_ENGINE:
+        module = sys.modules.get(module_name)
+        previous_attrs[(module_name, attr)] = (
+            getattr(module, attr, _MISSING) if module is not None else _MISSING
+        )
+
+    _install_lightweight_engine_modules(monkeypatch)
+
+    from vllm_mlx.config import reset_config
+    from vllm_mlx.middleware.auth import rate_limiter
+    from vllm_mlx.middleware.exception_handlers import install_exception_handlers
+    from vllm_mlx.routes.responses import router
+
+    cfg = reset_config()
+    cfg.api_key = "test-secret"
+    cfg.engine = engine
+    cfg.model_name = "test-model"
+    cfg.model_registry = None
+
+    rate_limiter.enabled = False
+    rate_limiter.requests_per_minute = 60
+    rate_limiter._requests.clear()
+
+    app = FastAPI()
+    install_exception_handlers(app)
+    app.include_router(router)
+
+    return SimpleNamespace(
+        client=TestClient(app),
+        engine=engine,
+        previous_modules=previous_modules,
+        previous_attrs=previous_attrs,
+        reset_config=reset_config,
+        rate_limiter=rate_limiter,
+    )
+
+
+def _teardown_client(state: SimpleNamespace):
+    state.reset_config()
+    state.rate_limiter.enabled = False
+    state.rate_limiter.requests_per_minute = 60
+    state.rate_limiter._requests.clear()
+
+    for name, previous in state.previous_modules.items():
+        if previous is _MISSING:
+            sys.modules.pop(name, None)
+        else:
+            sys.modules[name] = previous
+    for (module_name, attr), previous in state.previous_attrs.items():
+        module = sys.modules.get(module_name)
+        if module is None:
+            continue
+        if previous is _MISSING:
+            if hasattr(module, attr):
+                delattr(module, attr)
+        else:
+            setattr(module, attr, previous)
+
+
+@pytest.fixture
+def make_responses_client(monkeypatch):
+    """Factory fixture so each test can supply its own configured engine."""
+    states: list[SimpleNamespace] = []
+
+    def _factory(**engine_kwargs):
+        engine = _Engine(**engine_kwargs)
+        state = _make_client(monkeypatch, engine)
+        states.append(state)
+        return state
+
+    yield _factory
+
+    for state in reversed(states):
+        _teardown_client(state)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+_AUTH = {"Authorization": "Bearer test-secret"}
+
+
+def _payload(**overrides) -> dict:
+    base = {
+        "model": "test-model",
+        "input": "Hello, world",
+    }
+    base.update(overrides)
+    return base
+
+
+def _parse_sse(body: str) -> list[tuple[str, dict]]:
+    """Parse Codex-shape ``event: ...\\ndata: {...}\\n\\n`` framing."""
+    events = []
+    for raw in body.split("\n\n"):
+        if not raw.strip():
+            continue
+        lines = raw.split("\n")
+        event_name = None
+        data_text = None
+        for line in lines:
+            if line.startswith("event: "):
+                event_name = line[len("event: ") :].strip()
+            elif line.startswith("data: "):
+                data_text = line[len("data: ") :].strip()
+        if event_name and data_text is not None:
+            events.append((event_name, json.loads(data_text)))
+    return events
+
+
+# ---------------------------------------------------------------------------
+# Yuki F4 / R10 — reasoning output item emitted on /v1/responses
+# ---------------------------------------------------------------------------
+
+
+class TestF4ReasoningOutputItem:
+    """Yuki F4 (0.8.5 dogfood): the prior shim dropped reasoning
+    content entirely on /v1/responses even though /v1/chat/completions
+    returned ``message.reasoning_content``. The fix emits a top-level
+    ``reasoning`` output item with ``summary[].text`` populated.
+    """
+
+    def test_reasoning_emitted_when_engine_returns_reasoning_text(
+        self, make_responses_client
+    ):
+        state = make_responses_client(
+            text="The answer is 4.",
+            reasoning_text="Two plus two equals four because addition is commutative.",
+        )
+
+        resp = state.client.post(
+            "/v1/responses",
+            json=_payload(input="What is 2+2?"),
+            headers=_AUTH,
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+
+        reasoning_items = [o for o in body["output"] if o["type"] == "reasoning"]
+        message_items = [o for o in body["output"] if o["type"] == "message"]
+
+        assert len(reasoning_items) == 1, (
+            f"expected 1 reasoning item, got output={body['output']}"
+        )
+        assert len(message_items) == 1, body["output"]
+
+        # Reasoning item ships before the message item per OpenAI spec.
+        types_ = [o["type"] for o in body["output"]]
+        assert types_.index("reasoning") < types_.index("message"), types_
+
+        # Summary text carries the engine's reasoning_text verbatim.
+        summary = reasoning_items[0]["summary"]
+        assert summary and summary[0]["type"] == "summary_text"
+        assert "Two plus two equals four" in summary[0]["text"]
+
+    def test_no_reasoning_item_when_engine_returns_none(self, make_responses_client):
+        """Sanity: when reasoning_text is empty, no ``reasoning`` item
+        appears — back-compat with the pre-0.8.5 envelope shape for
+        non-reasoning models."""
+        state = make_responses_client(text="plain reply", reasoning_text="")
+
+        resp = state.client.post("/v1/responses", json=_payload(), headers=_AUTH)
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+
+        assert not [o for o in body["output"] if o["type"] == "reasoning"]
+
+
+# ---------------------------------------------------------------------------
+# Yuki R10 — cross-lane reasoning parity (chat-completions ⇄ responses)
+# ---------------------------------------------------------------------------
+
+
+class TestR10CrossLaneReasoningParity:
+    """Yuki R10 (0.8.5 dogfood): same model + prompt sent to
+    /v1/chat/completions and /v1/responses returned reasoning on the
+    chat lane and nothing on the responses lane. After the F4 fix the
+    semantic content matches: chat ``message.reasoning_content`` ==
+    responses ``output[i].summary[0].text`` (for type=='reasoning').
+    """
+
+    def test_responses_reasoning_summary_matches_chat_reasoning_content(
+        self, make_responses_client
+    ):
+        reasoning = (
+            "I'll work through this step by step. First, 2 is the number two. "
+            "Adding two and two yields four. So 2+2=4."
+        )
+        state = make_responses_client(text="4.", reasoning_text=reasoning)
+
+        # Drive the same engine through the Responses adapter.
+        resp = state.client.post(
+            "/v1/responses",
+            json=_payload(input="What is 2+2? Think briefly."),
+            headers=_AUTH,
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+
+        reasoning_items = [o for o in body["output"] if o["type"] == "reasoning"]
+        assert reasoning_items, body["output"]
+        summary_text = reasoning_items[0]["summary"][0]["text"]
+
+        # Same engine's reasoning_text — adapter must carry the bytes
+        # over verbatim (or as a strict prefix when summarisation
+        # lands). For the no-summarisation release, bytes match.
+        assert reasoning in summary_text
+
+
+# ---------------------------------------------------------------------------
+# Yuki F6 — tool_choice enforcement on /v1/responses
+# ---------------------------------------------------------------------------
+
+
+class TestF6ToolChoiceEnforcement:
+    """Yuki F6 (0.8.5 dogfood): ``tool_choice="required"`` and the
+    named-function form returned a plain message instead of a forced
+    ``function_call``. The fix mirrors the chat-route post-parse
+    synthesis: when the model returns no tool_calls under a forced
+    choice, synthesise a stub call so the OpenAI guarantee holds.
+    """
+
+    _PING_TOOL = {
+        "type": "function",
+        "name": "ping",
+        "parameters": {
+            "type": "object",
+            "properties": {"msg": {"type": "string"}},
+            "required": ["msg"],
+        },
+    }
+
+    def test_required_with_single_tool_synthesises_function_call(
+        self, make_responses_client
+    ):
+        state = make_responses_client(text="just chatty text", tool_calls=None)
+
+        resp = state.client.post(
+            "/v1/responses",
+            json=_payload(
+                tools=[self._PING_TOOL],
+                tool_choice="required",
+            ),
+            headers=_AUTH,
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+
+        function_calls = [o for o in body["output"] if o["type"] == "function_call"]
+        assert function_calls, body["output"]
+        assert function_calls[0]["name"] == "ping"
+
+    def test_named_function_choice_synthesises_call_to_named_tool(
+        self, make_responses_client
+    ):
+        state = make_responses_client(text="text-only reply", tool_calls=None)
+
+        resp = state.client.post(
+            "/v1/responses",
+            json=_payload(
+                tools=[
+                    self._PING_TOOL,
+                    {"type": "function", "name": "pong", "parameters": {}},
+                ],
+                tool_choice={"type": "function", "name": "pong"},
+            ),
+            headers=_AUTH,
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+
+        function_calls = [o for o in body["output"] if o["type"] == "function_call"]
+        assert function_calls, body["output"]
+        assert function_calls[0]["name"] == "pong"
+
+    def test_required_without_tools_is_400(self, make_responses_client):
+        state = make_responses_client(text="hi")
+
+        resp = state.client.post(
+            "/v1/responses",
+            json=_payload(tool_choice="required"),
+            headers=_AUTH,
+        )
+        assert resp.status_code == 400
+        body = resp.json()
+        assert "required" in body["error"]["message"].lower()
+
+    def test_named_function_not_in_tools_is_400(self, make_responses_client):
+        state = make_responses_client(text="hi")
+
+        resp = state.client.post(
+            "/v1/responses",
+            json=_payload(
+                tools=[self._PING_TOOL],
+                tool_choice={"type": "function", "name": "not_present"},
+            ),
+            headers=_AUTH,
+        )
+        assert resp.status_code == 400
+        body = resp.json()
+        assert "not_present" in body["error"]["message"]
+
+    def test_auto_does_not_synthesise_when_model_returns_text(
+        self, make_responses_client
+    ):
+        """Sanity: only the forced shapes coerce — ``auto`` lets the
+        model decide and we don't inject phantom tool_calls."""
+        state = make_responses_client(text="hello", tool_calls=None)
+
+        resp = state.client.post(
+            "/v1/responses",
+            json=_payload(tools=[self._PING_TOOL], tool_choice="auto"),
+            headers=_AUTH,
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert not [o for o in body["output"] if o["type"] == "function_call"]
+
+
+# ---------------------------------------------------------------------------
+# Ana C-06 — Computer-Use (UI-TARS) reachability via /v1/responses
+# ---------------------------------------------------------------------------
+
+
+class TestC06ComputerUseReachability:
+    """Ana C-06 (0.8.5 dogfood): UI-TARS was unreachable via
+    /v1/responses. The documented input shape returned 400 and
+    ``computer_call`` output items were never emitted. The fix:
+
+    * The route accepts ``tools=[{"type":"computer_20251022", ...}]``.
+    * When the underlying parser emits ``function.name == "computer"``,
+      the adapter translates it to a ``computer_call`` output item with
+      an OpenAI-spec ``action`` envelope.
+    """
+
+    _COMPUTER_TOOL = {
+        "type": "computer_20251022",
+        "name": "computer",
+        "display_width": 1280,
+        "display_height": 800,
+        "environment": "linux",
+    }
+
+    def test_computer_use_tool_type_accepted_no_400(self, make_responses_client):
+        state = make_responses_client(text="ok, ready")
+
+        resp = state.client.post(
+            "/v1/responses",
+            json=_payload(tools=[self._COMPUTER_TOOL]),
+            headers=_AUTH,
+        )
+        assert resp.status_code == 200, resp.text
+
+    def test_computer_call_emitted_when_parser_returns_computer_function(
+        self, make_responses_client
+    ):
+        """Simulate UI-TARS parser output (function.name=='computer',
+        canonical JSON args ``{"action": "click", "start_box": [128, 128]}``)
+        — the response envelope must emit a ``computer_call`` item with
+        the action shape per the OpenAI Computer-Use SDK contract."""
+        state = make_responses_client(
+            text="",
+            tool_calls=[
+                _make_function_call(
+                    "computer",
+                    json.dumps({"action": "click", "start_box": [128, 128]}),
+                    call_id="call_ui_tars",
+                )
+            ],
+            finish_reason="tool_calls",
+        )
+
+        resp = state.client.post(
+            "/v1/responses",
+            json=_payload(tools=[self._COMPUTER_TOOL]),
+            headers=_AUTH,
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+
+        computer_calls = [o for o in body["output"] if o["type"] == "computer_call"]
+        assert computer_calls, body["output"]
+        cc = computer_calls[0]
+        assert cc["action"]["type"] == "click"
+        assert cc["action"]["start_box"] == [128, 128]
+
+    def test_function_tool_without_computer_use_still_emits_function_call(
+        self, make_responses_client
+    ):
+        """When the request did NOT submit a computer_20251022 tool, a
+        ``function`` call named ``"computer"`` is NOT mistaken for a
+        Computer-Use action — it stays a regular ``function_call``."""
+        state = make_responses_client(
+            text="",
+            tool_calls=[
+                _make_function_call("computer", '{"action":"click"}', call_id="call_x")
+            ],
+            finish_reason="tool_calls",
+        )
+
+        resp = state.client.post(
+            "/v1/responses",
+            json=_payload(
+                tools=[{"type": "function", "name": "computer", "parameters": {}}],
+            ),
+            headers=_AUTH,
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+
+        assert [o for o in body["output"] if o["type"] == "function_call"]
+        assert not [o for o in body["output"] if o["type"] == "computer_call"]
+
+
+# ---------------------------------------------------------------------------
+# Yuki F8 — streaming SSE event coverage
+# ---------------------------------------------------------------------------
+
+
+class TestF8StreamingSseEvents:
+    """Yuki F8 (0.8.5 dogfood): the streaming /v1/responses pipeline
+    was missing ``response.content_part.added`` and
+    ``response.output_text.done`` per OpenAI Responses SSE spec.
+    Clients gating UI state on those events never saw them.
+    """
+
+    def test_stream_emits_content_part_added_and_output_text_done(
+        self, make_responses_client
+    ):
+        state = make_responses_client(text="Hello from rapid")
+
+        with state.client.stream(
+            "POST",
+            "/v1/responses",
+            json=_payload(stream=True),
+            headers=_AUTH,
+        ) as resp:
+            assert resp.status_code == 200
+            body = "".join(resp.iter_text())
+
+        events = _parse_sse(body)
+        event_names = [e[0] for e in events]
+
+        assert "response.content_part.added" in event_names, event_names
+        assert "response.output_text.done" in event_names, event_names
+
+        # Spec order: created → output_item.added (message) →
+        # content_part.added → output_text.delta → output_text.done →
+        # content_part.done → output_item.done → completed.
+        added_idx = event_names.index("response.output_item.added")
+        cpa_idx = event_names.index("response.content_part.added")
+        delta_idx = event_names.index("response.output_text.delta")
+        otd_idx = event_names.index("response.output_text.done")
+        item_done_idx = event_names.index("response.output_item.done")
+        completed_idx = event_names.index("response.completed")
+        assert (
+            added_idx < cpa_idx < delta_idx < otd_idx < item_done_idx < completed_idx
+        ), event_names
+
+    def test_output_text_done_carries_full_assistant_text(self, make_responses_client):
+        state = make_responses_client()  # default emits "Hello from rapid"
+
+        with state.client.stream(
+            "POST",
+            "/v1/responses",
+            json=_payload(stream=True),
+            headers=_AUTH,
+        ) as resp:
+            body = "".join(resp.iter_text())
+
+        events = _parse_sse(body)
+        done_events = [d for (name, d) in events if name == "response.output_text.done"]
+        assert done_events
+        assert done_events[0]["text"] == "Hello from rapid"
+
+
+# ---------------------------------------------------------------------------
+# Yuki R6 / R7 — truncation + service_tier echo
+# ---------------------------------------------------------------------------
+
+
+class TestR6R7TruncationAndServiceTierEcho:
+    """Yuki R6 / R7 (0.8.5 dogfood): ``truncation="auto"`` and
+    ``service_tier="flex"`` were silently dropped — neither echoed on
+    the response envelope. The fix echoes both; truncation behaviour
+    is a no-op for this release (operator preference, see
+    ResponsesRequest docstring).
+    """
+
+    def test_truncation_echoed_on_response_envelope(self, make_responses_client):
+        state = make_responses_client()
+
+        resp = state.client.post(
+            "/v1/responses",
+            json=_payload(truncation="auto"),
+            headers=_AUTH,
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body.get("truncation") == "auto"
+
+    def test_service_tier_echoed_on_response_envelope(self, make_responses_client):
+        state = make_responses_client()
+
+        resp = state.client.post(
+            "/v1/responses",
+            json=_payload(service_tier="flex"),
+            headers=_AUTH,
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body.get("service_tier") == "flex"
+
+
+# ---------------------------------------------------------------------------
+# Yuki F13 — declining unimplemented tool types
+# ---------------------------------------------------------------------------
+
+
+class TestF13UnsupportedToolTypes:
+    """Yuki F13 (0.8.5 dogfood): ``web_search`` / ``file_search`` /
+    ``code_interpreter`` were silently accepted with 200 and the tools
+    were never actually invoked. The fix returns a clean 400 listing
+    the supported types.
+    """
+
+    @pytest.mark.parametrize(
+        "unsupported",
+        ["web_search", "file_search", "code_interpreter", "image_generation"],
+    )
+    def test_unsupported_tool_type_returns_400(
+        self, make_responses_client, unsupported
+    ):
+        state = make_responses_client()
+
+        resp = state.client.post(
+            "/v1/responses",
+            json=_payload(tools=[{"type": unsupported}]),
+            headers=_AUTH,
+        )
+        assert resp.status_code == 400, resp.text
+        body = resp.json()
+        assert "unsupported_tool_type" in str(body)
+        # The error message lists the allowlist so callers can fix
+        # their request without guessing.
+        assert "function" in body["error"]["message"]
+        assert "computer_20251022" in body["error"]["message"]
+
+    def test_function_tool_type_still_accepted(self, make_responses_client):
+        state = make_responses_client()
+
+        resp = state.client.post(
+            "/v1/responses",
+            json=_payload(
+                tools=[{"type": "function", "name": "ok_tool", "parameters": {}}]
+            ),
+            headers=_AUTH,
+        )
+        assert resp.status_code == 200, resp.text
+
+    def test_computer_20251022_tool_type_still_accepted(self, make_responses_client):
+        state = make_responses_client()
+
+        resp = state.client.post(
+            "/v1/responses",
+            json=_payload(
+                tools=[
+                    {
+                        "type": "computer_20251022",
+                        "name": "computer",
+                        "display_width": 1280,
+                        "display_height": 800,
+                        "environment": "linux",
+                    }
+                ]
+            ),
+            headers=_AUTH,
+        )
+        assert resp.status_code == 200, resp.text

--- a/tests/test_responses_bundle.py
+++ b/tests/test_responses_bundle.py
@@ -478,6 +478,108 @@ class TestF6ToolChoiceEnforcement:
         body = resp.json()
         assert not [o for o in body["output"] if o["type"] == "function_call"]
 
+    def test_required_with_multiple_tools_no_call_returns_422(
+        self, make_responses_client
+    ):
+        """Codex r1 BLOCKING #1 (PR #817): with multiple submitted
+        tools, ``required`` can't pick a target deterministically. The
+        route 422s (parity with chat.py) instead of silently violating
+        the contract.
+        """
+        state = make_responses_client(text="text-only", tool_calls=None)
+
+        resp = state.client.post(
+            "/v1/responses",
+            json=_payload(
+                tools=[
+                    self._PING_TOOL,
+                    {"type": "function", "name": "pong", "parameters": {}},
+                ],
+                tool_choice="required",
+            ),
+            headers=_AUTH,
+        )
+        assert resp.status_code == 422, resp.text
+        body = resp.json()
+        assert "tool_choice_required_unfulfilled" in str(body)
+
+    def test_required_streaming_with_synthesis_suppresses_message_item(
+        self, make_responses_client
+    ):
+        """Codex r1 BLOCKING #2 (PR #817): when the streaming model
+        emits text under forced choice AND no tool_call, the message
+        item must NOT be emitted (the synthesised tool_call is the
+        only legitimate output for the contract). Pre-fix the client
+        saw BOTH ``response.output_text.delta`` for the model's prose
+        AND a synthesised ``function_call`` — violating the
+        tool_call-guaranteed contract.
+        """
+        state = make_responses_client(text="Hello from rapid", tool_calls=None)
+
+        with state.client.stream(
+            "POST",
+            "/v1/responses",
+            json=_payload(
+                stream=True,
+                tools=[self._PING_TOOL],
+                tool_choice="required",
+            ),
+            headers=_AUTH,
+        ) as resp:
+            assert resp.status_code == 200
+            body = "".join(resp.iter_text())
+        events = _parse_sse(body)
+        names = [n for (n, _) in events]
+
+        # No text deltas should reach the client.
+        assert "response.output_text.delta" not in names, names
+        # Function-call item IS emitted via the synthesis path.
+        assert any(
+            d.get("item", {}).get("type") == "function_call"
+            for (n, d) in events
+            if n == "response.output_item.added"
+        ), events
+
+    def test_required_streaming_with_real_tool_call_keeps_text(
+        self, make_responses_client
+    ):
+        """When the model produces a real tool_call AND text under
+        forced choice, the buffered text is flushed (no synthesis
+        fires, so the assistant's prose stays as legitimate context).
+        """
+        state = make_responses_client(
+            text="Hello from rapid",
+            tool_calls=[
+                _make_function_call(
+                    "ping", json.dumps({"msg": "hi"}), call_id="call_real"
+                )
+            ],
+            finish_reason="tool_calls",
+        )
+
+        with state.client.stream(
+            "POST",
+            "/v1/responses",
+            json=_payload(
+                stream=True,
+                tools=[self._PING_TOOL],
+                tool_choice="required",
+            ),
+            headers=_AUTH,
+        ) as resp:
+            body = "".join(resp.iter_text())
+        events = _parse_sse(body)
+        names = [n for (n, _) in events]
+
+        # Text delta flushed because the model produced a real call.
+        assert "response.output_text.delta" in names, names
+        # And the real call is shipped.
+        assert any(
+            d.get("item", {}).get("type") == "function_call"
+            for (n, d) in events
+            if n == "response.output_item.added"
+        ), events
+
 
 # ---------------------------------------------------------------------------
 # Ana C-06 — Computer-Use (UI-TARS) reachability via /v1/responses

--- a/tests/test_responses_bundle.py
+++ b/tests/test_responses_bundle.py
@@ -540,6 +540,39 @@ class TestF6ToolChoiceEnforcement:
             if n == "response.output_item.added"
         ), events
 
+    def test_required_streaming_multi_tool_unfulfilled_emits_response_failed(
+        self, make_responses_client
+    ):
+        """Codex r2 BLOCKING (PR #817): the non-stream path 422s for
+        multi-tool ``required`` with no model call, but the streaming
+        path cannot raise mid-stream — the SSE headers are already
+        committed. Emit a ``response.failed`` event with the same
+        error code/message so clients see a clean shutdown.
+        """
+        state = make_responses_client(text="text-only", tool_calls=None)
+
+        with state.client.stream(
+            "POST",
+            "/v1/responses",
+            json=_payload(
+                stream=True,
+                tools=[
+                    self._PING_TOOL,
+                    {"type": "function", "name": "pong", "parameters": {}},
+                ],
+                tool_choice="required",
+            ),
+            headers=_AUTH,
+        ) as resp:
+            assert resp.status_code == 200, resp.text
+            body = "".join(resp.iter_text())
+        events = _parse_sse(body)
+        failed = [d for (n, d) in events if n == "response.failed"]
+        assert failed, [n for (n, _) in events]
+        assert failed[0]["response"]["error"]["code"] == (
+            "tool_choice_required_unfulfilled"
+        )
+
     def test_required_streaming_with_real_tool_call_keeps_text(
         self, make_responses_client
     ):

--- a/tests/test_responses_bundle.py
+++ b/tests/test_responses_bundle.py
@@ -478,6 +478,38 @@ class TestF6ToolChoiceEnforcement:
         body = resp.json()
         assert not [o for o in body["output"] if o["type"] == "function_call"]
 
+    def test_named_function_model_called_wrong_tool_returns_422(
+        self, make_responses_client
+    ):
+        """Codex r3 BLOCKING #1 (PR #817): when the request pins
+        ``tool_choice={type:"function","name":"pong"}`` but the model
+        produces a call to ``ping``, the route 422s (parity with
+        chat.py L1969). Pre-fix the wrong call was shipped to the
+        client as if the contract had been satisfied.
+        """
+        state = make_responses_client(
+            text="",
+            tool_calls=[
+                _make_function_call("ping", '{"msg":"hi"}', call_id="call_wrong")
+            ],
+            finish_reason="tool_calls",
+        )
+
+        resp = state.client.post(
+            "/v1/responses",
+            json=_payload(
+                tools=[
+                    self._PING_TOOL,
+                    {"type": "function", "name": "pong", "parameters": {}},
+                ],
+                tool_choice={"type": "function", "name": "pong"},
+            ),
+            headers=_AUTH,
+        )
+        assert resp.status_code == 422, resp.text
+        body = resp.json()
+        assert "tool_choice_named_mismatch" in str(body)
+
     def test_required_with_multiple_tools_no_call_returns_422(
         self, make_responses_client
     ):
@@ -851,6 +883,31 @@ class TestR6R7TruncationAndServiceTierEcho:
         assert resp.status_code == 200, resp.text
         body = resp.json()
         assert body.get("service_tier") == "flex"
+
+    def test_truncation_invalid_value_returns_400(self, make_responses_client):
+        """Codex r3 NIT (PR #817): truncation typed as
+        ``Literal["auto","disabled"]`` so typos like ``"enabled"``
+        surface as a 400 instead of silently round-tripping."""
+        state = make_responses_client()
+
+        resp = state.client.post(
+            "/v1/responses",
+            json=_payload(truncation="enabled"),
+            headers=_AUTH,
+        )
+        assert resp.status_code == 400, resp.text
+
+    def test_truncation_disabled_also_echoed(self, make_responses_client):
+        state = make_responses_client()
+
+        resp = state.client.post(
+            "/v1/responses",
+            json=_payload(truncation="disabled"),
+            headers=_AUTH,
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body.get("truncation") == "disabled"
 
 
 # ---------------------------------------------------------------------------

--- a/vllm_mlx/api/responses_adapter.py
+++ b/vllm_mlx/api/responses_adapter.py
@@ -16,6 +16,8 @@ hot path despite the simplification.
 import json
 import uuid
 
+from fastapi import HTTPException
+
 from .models import (
     ChatCompletionRequest,
     ChatCompletionResponse,
@@ -33,6 +35,201 @@ from .responses_models import (
     ResponsesResponse,
     ResponsesUsage,
 )
+
+# Yuki F13 (0.8.5 dogfood) — allowlist of tool types accepted by the
+# /v1/responses lane. Single source of truth: route, adapter, and tests
+# all consult this set so the contract can't drift per-call site.
+#
+#   ``function``          — the standard local-model tool surface
+#   ``computer_20251022`` — OpenAI Computer-Use tool input shape
+#                           (Ana C-06); routed to UI-TARS when the
+#                           loaded model is UI-TARS, otherwise this
+#                           route accepts the type but the request
+#                           will surface a 400 when the model can't
+#                           fulfil it.
+#
+# Anything else (``web_search``, ``file_search``, ``code_interpreter``,
+# ``image_generation``, …) is rejected with a 400 listing the supported
+# types — silent acceptance was the pre-0.8.5 behaviour and led to
+# clients believing their tool was being invoked (Yuki F13).
+SUPPORTED_RESPONSES_TOOL_TYPES: frozenset[str] = frozenset(
+    {
+        "function",
+        "computer_20251022",
+    }
+)
+
+
+def _raise_unsupported_tool_type(tool_type: str) -> None:
+    """Single source of truth for the F13 envelope (Yuki R1 0.8.5 dogfood).
+
+    Raised by the adapter when an incoming tool entry has a ``type``
+    that is not in :data:`SUPPORTED_RESPONSES_TOOL_TYPES`. Routes that
+    want to short-circuit before the adapter runs (e.g. SSE prelude
+    has already started) call :func:`validate_responses_tool_types`
+    directly.
+    """
+    supported = sorted(SUPPORTED_RESPONSES_TOOL_TYPES)
+    raise HTTPException(
+        status_code=400,
+        detail={
+            "error": {
+                "message": (
+                    f"Tool type {tool_type!r} is not supported by this "
+                    f"server. Supported types: {supported}. "
+                    "``computer_20251022`` requires a UI-TARS model to "
+                    "be loaded (other vision+tool-calling models may "
+                    "not fulfil the request)."
+                ),
+                "type": "invalid_request_error",
+                "code": "unsupported_tool_type",
+                "param": "tools",
+            }
+        },
+    )
+
+
+def validate_responses_tool_types(tools: list[dict] | None) -> None:
+    """Raise 400 if any ``tools[i].type`` falls outside the allowlist.
+
+    Idempotent — safe to call from both the route entry point and from
+    the adapter's own ``responses_to_openai`` path. The route gate fires
+    BEFORE we touch the engine so unsupported requests don't admit a
+    scheduler slot.
+    """
+    if not tools:
+        return
+    for t in tools:
+        if not isinstance(t, dict):
+            continue
+        ttype = t.get("type")
+        if ttype and ttype not in SUPPORTED_RESPONSES_TOOL_TYPES:
+            _raise_unsupported_tool_type(ttype)
+
+
+def _is_computer_use_tool(tool: dict) -> bool:
+    """True iff the tool entry is the OpenAI Computer-Use shape.
+
+    Documented input shape (Ana C-06):
+        {"type":"computer_20251022","name":"computer",
+         "display_width":1280,"display_height":800,"environment":"linux"}
+
+    Only the ``type`` is load-bearing; ``name``, ``display_*``, and
+    ``environment`` are passed through as part of the converted
+    function-tool's parameters so a Computer-Use-aware model (UI-TARS)
+    sees the screen geometry hints.
+    """
+    return isinstance(tool, dict) and tool.get("type") == "computer_20251022"
+
+
+def request_uses_computer_use(request: ResponsesRequest) -> bool:
+    """True iff any submitted tool has ``type == "computer_20251022"``.
+
+    Surfaces to the route + adapter so we know when to translate
+    ``function_call`` items with ``name=="computer"`` into the
+    Computer-Use ``computer_call`` output-item shape (Ana C-06).
+    """
+    return bool(request.tools) and any(_is_computer_use_tool(t) for t in request.tools)
+
+
+def validate_responses_tool_choice(
+    tool_choice: str | dict | None, tools: list[dict] | None
+) -> None:
+    """Reject malformed tool_choice up-front (Yuki F6 0.8.5 dogfood).
+
+    The chat-completions lane gates ``tool_choice`` at the prompt
+    rendering layer (``routes/chat.py``); /v1/responses skipped this
+    check, so ``tool_choice="required"`` and the named-function form
+    silently degraded to ``auto``. Mirror the chat-route gate here so
+    the contract is enforced at the SAME point in the request
+    lifecycle on both surfaces.
+
+    Validation rules:
+      * ``"required"`` requires a non-empty ``tools`` array (otherwise
+        the model has nothing to choose from).
+      * ``{type:"function","name":X}`` requires a tool named ``X`` in
+        ``tools``.
+      * ``"auto"`` / ``"none"`` / object-without-name pass through.
+    """
+    if tool_choice is None:
+        return
+    if isinstance(tool_choice, str):
+        if tool_choice == "required" and not tools:
+            raise HTTPException(
+                status_code=400,
+                detail={
+                    "error": {
+                        "message": (
+                            "tool_choice='required' but the request has "
+                            "no 'tools' array — the model has nothing to "
+                            "choose from. Either drop tool_choice or "
+                            "add at least one tool definition."
+                        ),
+                        "type": "invalid_request_error",
+                        "code": "tool_choice_required_without_tools",
+                        "param": "tool_choice",
+                    }
+                },
+            )
+        return
+    if isinstance(tool_choice, dict):
+        if tool_choice.get("type") == "function":
+            target = tool_choice.get("name") or (
+                (tool_choice.get("function") or {}).get("name")
+            )
+            if not target:
+                raise HTTPException(
+                    status_code=400,
+                    detail={
+                        "error": {
+                            "message": (
+                                "tool_choice.type='function' requires a "
+                                "non-empty 'name' field."
+                            ),
+                            "type": "invalid_request_error",
+                            "code": "tool_choice_missing_name",
+                            "param": "tool_choice.name",
+                        }
+                    },
+                )
+            tool_names = _submitted_tool_names(tools)
+            if target not in tool_names:
+                raise HTTPException(
+                    status_code=400,
+                    detail={
+                        "error": {
+                            "message": (
+                                f"tool_choice references function "
+                                f"{target!r} which is not present in the "
+                                "'tools' array. Add the tool definition "
+                                "or pick one of the submitted names."
+                            ),
+                            "type": "invalid_request_error",
+                            "code": "tool_choice_unknown_function",
+                            "param": "tool_choice.name",
+                        }
+                    },
+                )
+
+
+def _submitted_tool_names(tools: list[dict] | None) -> set[str]:
+    """Extract the set of tool names from the Responses-flat ``tools``
+    list. ``computer_20251022`` always maps to ``"computer"`` (see
+    ``_convert_tools``), so include that synthetic name too.
+    """
+    names: set[str] = set()
+    if not tools:
+        return names
+    for t in tools:
+        if not isinstance(t, dict):
+            continue
+        if t.get("type") == "function":
+            n = t.get("name") or (t.get("function") or {}).get("name")
+            if n:
+                names.add(n)
+        elif t.get("type") == "computer_20251022":
+            names.add(t.get("name") or "computer")
+    return names
 
 
 def responses_to_openai(request: ResponsesRequest) -> ChatCompletionRequest:
@@ -175,16 +372,37 @@ def openai_to_responses(
     Convert an OpenAI Chat Completions response to a Responses-API
     response shape.
 
-    The ``output`` array is built in Codex CLI's expected order:
-    first a ``message`` item with the assistant text, then one
-    ``function_call`` item per tool call. An empty assistant turn (only
-    tool calls, no text) emits no ``message`` item — matches the
-    public Responses API.
+    The ``output`` array is built in OpenAI Responses spec order:
+        1. ``reasoning`` (when the model produced reasoning content)
+        2. ``message`` (assistant text reply)
+        3. ``function_call`` / ``computer_call`` (one per tool call)
+
+    Yuki F4 / R10 (0.8.5 dogfood): the prior shim dropped
+    ``message.reasoning_content`` entirely even though the
+    chat-completions lane returned it for the SAME model + prompt. The
+    top-level ``reasoning`` item closes the cross-lane parity gap so a
+    Responses-API client walking ``output[i].type == "reasoning"`` finds
+    the model's chain-of-thought summary.
+
+    Ana C-06 (0.8.5 dogfood): when the request supplied
+    ``tools=[{"type":"computer_20251022",...}]`` and the parser surfaced
+    a ``function.name == "computer"`` call, emit a ``computer_call``
+    item instead of ``function_call`` so the OpenAI Computer-Use SDK
+    contract is honoured.
     """
     output: list[ResponsesOutputItem] = []
     choice = response.choices[0] if response.choices else None
 
+    uses_computer_use = request_uses_computer_use(request)
+
     if choice:
+        # Yuki F4 / R10: emit ``reasoning`` BEFORE ``message`` so
+        # walkers that consume ``output[]`` in order see the
+        # spec-compliant sequence.
+        reasoning_text = getattr(choice.message, "reasoning_content", None) or ""
+        if reasoning_text:
+            output.append(_build_reasoning_output_item(reasoning_text))
+
         text = choice.message.content or ""
         if text:
             output.append(
@@ -200,16 +418,7 @@ def openai_to_responses(
             )
 
         for tc in choice.message.tool_calls or []:
-            output.append(
-                ResponsesOutputItem(
-                    type="function_call",
-                    id=f"fc_{uuid.uuid4().hex[:24]}",
-                    call_id=tc.id,
-                    name=tc.function.name,
-                    arguments=tc.function.arguments or "",
-                    status="completed",
-                )
-            )
+            output.append(_build_tool_call_output_item(tc, uses_computer_use))
 
     status = _convert_status(choice.finish_reason if choice else None)
 
@@ -226,7 +435,95 @@ def openai_to_responses(
         tools=request.tools or [],
         metadata=request.metadata,
         instructions=request.instructions,
+        # Yuki R6 / R7: echo truncation + service_tier on the envelope.
+        # Truncation is a no-op at the engine level (see ResponsesRequest
+        # docstring) but is echoed so migrating clients see the field
+        # round-trip. ``service_tier`` is echoed as the requested value.
+        truncation=request.truncation,
+        service_tier=request.service_tier,
     )
+
+
+def _build_reasoning_output_item(reasoning_text: str) -> ResponsesOutputItem:
+    """Build the top-level ``reasoning`` output item (Yuki F4 / R10).
+
+    Spec shape (OpenAI Responses):
+        {"type":"reasoning","id":"rs_<hex>",
+         "summary":[{"type":"summary_text","text":"..."}]}
+
+    rapid-mlx does not run a separate summarization model — the
+    ``summary_text`` carries the raw reasoning chain-of-thought
+    verbatim. Large reasoning blobs are chunk-capped at the engine
+    level via ``reasoning_max_tokens`` (upstream vLLM PR #20859),
+    which already runs upstream of this adapter call.
+    """
+    return ResponsesOutputItem(
+        type="reasoning",
+        id=f"rs_{uuid.uuid4().hex[:24]}",
+        status="completed",
+        summary=[{"type": "summary_text", "text": reasoning_text}],
+    )
+
+
+def _build_tool_call_output_item(
+    tool_call, uses_computer_use: bool
+) -> ResponsesOutputItem:
+    """Translate one OpenAI ``ToolCall`` to a Responses-API output item.
+
+    When the request used Computer-Use AND the tool call's function
+    name is ``"computer"`` (the canonical UI-TARS function name —
+    every emitted UI-TARS tool_call uses that name), emit a
+    ``computer_call`` envelope per Ana C-06. The ``action`` field is
+    parsed from the JSON arguments string and surfaced in the
+    OpenAI-documented shape ``{"type": <verb>, ...kwargs}``.
+    """
+    if uses_computer_use and (tool_call.function.name or "") == "computer":
+        action = _parse_computer_action(tool_call.function.arguments or "")
+        return ResponsesOutputItem(
+            type="computer_call",
+            id=f"cu_{uuid.uuid4().hex[:24]}",
+            call_id=tool_call.id,
+            status="completed",
+            action=action,
+            pending_safety_checks=[],
+        )
+    return ResponsesOutputItem(
+        type="function_call",
+        id=f"fc_{uuid.uuid4().hex[:24]}",
+        call_id=tool_call.id,
+        name=tool_call.function.name,
+        arguments=tool_call.function.arguments or "",
+        status="completed",
+    )
+
+
+def _parse_computer_action(arguments: str) -> dict:
+    """Translate the UI-TARS canonical JSON arguments to a Responses
+    ``computer_call.action`` envelope.
+
+    UI-TARS parser emits arguments like::
+
+        {"action": "click", "start_box": [128, 128]}
+
+    The OpenAI Computer-Use spec uses ``type`` for the verb instead
+    of ``action``. Map ``action`` → ``type`` and pass through the
+    remaining kwargs verbatim so a downstream Computer-Use runtime
+    can dispatch on ``action.type``.
+
+    Defensive: invalid JSON or non-dict arguments degrade to a
+    ``{"type": "unknown", "raw": "..."}`` envelope rather than 500 —
+    the caller is otherwise blind to the parser failure.
+    """
+    try:
+        parsed = json.loads(arguments) if arguments else {}
+    except (ValueError, TypeError):
+        return {"type": "unknown", "raw": arguments}
+    if not isinstance(parsed, dict):
+        return {"type": "unknown", "raw": arguments}
+    out = dict(parsed)
+    if "action" in out and "type" not in out:
+        out["type"] = out.pop("action")
+    return out
 
 
 # ---------------------------------------------------------------------------
@@ -349,36 +646,86 @@ def _convert_tools(tools: list[dict] | None) -> list[ToolDefinition] | None:
     Responses: ``{type: "function", name, description, parameters}``
     Chat:      ``{type: "function", function: {name, description, parameters}}``
 
-    Non-function tool types (web_search, image_generation, code_interpreter,
-    file_search, computer_use, etc.) are silently dropped — Codex CLI
-    won't send them to a third-party backend, and they have no analog
-    on a local engine.
+    Computer-Use (``computer_20251022``) is translated to a synthetic
+    ``function`` tool named ``"computer"`` so the UI-TARS tool parser
+    (which always emits ``function.name == "computer"``) sees a matching
+    entry in the request. The original ``display_width`` /
+    ``display_height`` / ``environment`` hints are placed in the
+    function parameters' ``properties`` so they reach the chat template
+    and the model can ground its actions to the actual screen geometry
+    instead of guessing 0-1000 normalized coords.
+
+    Other non-function tool types (web_search, image_generation,
+    code_interpreter, file_search, …) trigger the F13 400 envelope
+    — silent acceptance was the pre-0.8.5 behaviour and led migrating
+    clients to believe their tool was being invoked.
     """
     if not tools:
         return None
     converted: list[ToolDefinition] = []
     for t in tools:
-        if t.get("type") != "function":
+        if not isinstance(t, dict):
             continue
-        # OpenAI's Responses-flat shape sometimes nests parameters under
-        # ``parameters`` and sometimes alongside a ``strict`` flag; we
-        # carry both through verbatim — engine layer expects nested.
-        name = t.get("name") or t.get("function", {}).get("name", "")
-        if not name:
-            continue
-        converted.append(
-            ToolDefinition(
-                type="function",
-                function={
-                    "name": name,
-                    "description": t.get("description")
-                    or t.get("function", {}).get("description", ""),
-                    "parameters": t.get("parameters")
-                    or t.get("function", {}).get("parameters")
-                    or {"type": "object", "properties": {}},
-                },
+        ttype = t.get("type")
+        if ttype == "function":
+            # OpenAI's Responses-flat shape sometimes nests parameters under
+            # ``parameters`` and sometimes alongside a ``strict`` flag; we
+            # carry both through verbatim — engine layer expects nested.
+            name = t.get("name") or t.get("function", {}).get("name", "")
+            if not name:
+                continue
+            converted.append(
+                ToolDefinition(
+                    type="function",
+                    function={
+                        "name": name,
+                        "description": t.get("description")
+                        or t.get("function", {}).get("description", ""),
+                        "parameters": t.get("parameters")
+                        or t.get("function", {}).get("parameters")
+                        or {"type": "object", "properties": {}},
+                    },
+                )
             )
-        )
+        elif ttype == "computer_20251022":
+            # Ana C-06: translate Computer-Use to the canonical
+            # ``computer`` function tool. The UI-TARS tool parser emits
+            # ``function.name == "computer"`` regardless of which tools
+            # the request submitted, so as long as we register a tool by
+            # that name the post-parse synthesis path lets the parsed
+            # call flow through to the response envelope. Screen
+            # geometry hints stay in the parameters so the
+            # render-template / system-prompt can ground the model.
+            geometry: dict = {
+                "type": "object",
+                "properties": {
+                    "display_width": {"type": "integer"},
+                    "display_height": {"type": "integer"},
+                    "environment": {"type": "string"},
+                },
+                "_computer_use": {
+                    "display_width": t.get("display_width"),
+                    "display_height": t.get("display_height"),
+                    "environment": t.get("environment"),
+                },
+            }
+            converted.append(
+                ToolDefinition(
+                    type="function",
+                    function={
+                        "name": t.get("name") or "computer",
+                        "description": "Computer-Use (UI-TARS) GUI action tool",
+                        "parameters": geometry,
+                    },
+                )
+            )
+        else:
+            # Anything outside the allowlist — surface the F13 envelope.
+            # The route-level ``validate_responses_tool_types`` normally
+            # fires before we reach here, but keep this as defense-in-
+            # depth so a future bypass still 400s instead of silently
+            # dropping the tool entry.
+            _raise_unsupported_tool_type(ttype or "<missing>")
     return converted or None
 
 

--- a/vllm_mlx/api/responses_adapter.py
+++ b/vllm_mlx/api/responses_adapter.py
@@ -510,12 +510,16 @@ def _parse_computer_action(arguments: str) -> dict:
     remaining kwargs verbatim so a downstream Computer-Use runtime
     can dispatch on ``action.type``.
 
-    Defensive: invalid JSON or non-dict arguments degrade to a
-    ``{"type": "unknown", "raw": "..."}`` envelope rather than 500 —
-    the caller is otherwise blind to the parser failure.
+    Defensive: invalid JSON, non-dict arguments, AND empty / missing
+    arguments all degrade to a ``{"type": "unknown", "raw": "..."}``
+    envelope. Returning ``{}`` would produce a ``computer_call.action``
+    without a ``type`` field — harder for SDK dispatchers than the
+    sentinel shape (codex r1 NIT on PR #817).
     """
+    if not arguments:
+        return {"type": "unknown", "raw": arguments}
     try:
-        parsed = json.loads(arguments) if arguments else {}
+        parsed = json.loads(arguments)
     except (ValueError, TypeError):
         return {"type": "unknown", "raw": arguments}
     if not isinstance(parsed, dict):
@@ -523,6 +527,10 @@ def _parse_computer_action(arguments: str) -> dict:
     out = dict(parsed)
     if "action" in out and "type" not in out:
         out["type"] = out.pop("action")
+    # Even with valid JSON, a missing verb is still ambiguous — fall
+    # back to the sentinel so the dispatcher can detect the gap.
+    if "type" not in out:
+        return {"type": "unknown", "raw": arguments}
     return out
 
 

--- a/vllm_mlx/api/responses_adapter.py
+++ b/vllm_mlx/api/responses_adapter.py
@@ -228,7 +228,9 @@ def _submitted_tool_names(tools: list[dict] | None) -> set[str]:
             if n:
                 names.add(n)
         elif t.get("type") == "computer_20251022":
-            names.add(t.get("name") or "computer")
+            # Force canonical name to match the ``_convert_tools``
+            # contract — see Codex r2 BLOCKING fix in that function.
+            names.add("computer")
     return names
 
 
@@ -697,13 +699,21 @@ def _convert_tools(tools: list[dict] | None) -> list[ToolDefinition] | None:
             )
         elif ttype == "computer_20251022":
             # Ana C-06: translate Computer-Use to the canonical
-            # ``computer`` function tool. The UI-TARS tool parser emits
-            # ``function.name == "computer"`` regardless of which tools
-            # the request submitted, so as long as we register a tool by
-            # that name the post-parse synthesis path lets the parsed
-            # call flow through to the response envelope. Screen
-            # geometry hints stay in the parameters so the
-            # render-template / system-prompt can ground the model.
+            # ``computer`` function tool. The UI-TARS tool parser ALWAYS
+            # emits ``function.name == "computer"`` regardless of which
+            # ``name`` field the caller supplied. We force the canonical
+            # name here so the post-parse ``computer_call`` translation
+            # in ``_build_tool_call_output_item`` (which keys off
+            # ``function.name == "computer"``) lights up — even when
+            # the caller submitted e.g. ``{type:"computer_20251022",
+            # name:"screen"}``. Codex r2 BLOCKING (PR #817): keying the
+            # downstream check on the original ``type`` instead of the
+            # function name would require threading the tool-type
+            # metadata through the engine surface; forcing the name at
+            # the boundary is simpler and keeps the parser → adapter
+            # contract intact. Screen geometry hints stay in the
+            # parameters so the chat template / system prompt can
+            # ground the model.
             geometry: dict = {
                 "type": "object",
                 "properties": {
@@ -721,7 +731,8 @@ def _convert_tools(tools: list[dict] | None) -> list[ToolDefinition] | None:
                 ToolDefinition(
                     type="function",
                     function={
-                        "name": t.get("name") or "computer",
+                        # NB: hard-coded ``"computer"`` — see comment above.
+                        "name": "computer",
                         "description": "Computer-Use (UI-TARS) GUI action tool",
                         "parameters": geometry,
                     },

--- a/vllm_mlx/api/responses_models.py
+++ b/vllm_mlx/api/responses_models.py
@@ -14,7 +14,7 @@ client).
 """
 
 import uuid
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import BaseModel, Field, field_validator, model_validator
 
@@ -105,7 +105,11 @@ class ResponsesRequest(BaseModel):
     # NOTE: implement actual auto-truncation in a follow-up — operator
     # preference (0.8 dogfood r4) is to echo + no-op so migrating
     # clients don't see a silent drop while the implementation lands.
-    truncation: str | None = None
+    #
+    # Codex r3 NIT (PR #817): ``Literal[...]`` so typos like
+    # ``"enabled"`` produce a Pydantic 400 instead of silently
+    # round-tripping as if they were valid.
+    truncation: Literal["auto", "disabled"] | None = None
     # Per-request cap on reasoning tokens — see ``ChatCompletionRequest``
     # for the full semantic. ``None`` = no cap. Validated >= 1 by the
     # post-init validator below; the Responses route forwards this to
@@ -274,9 +278,10 @@ class ResponsesResponse(BaseModel):
     # Yuki R6 / R7 (0.8.5 dogfood): the OpenAI Responses spec exposes
     # ``truncation`` and ``service_tier`` as response-envelope fields.
     # ``truncation`` is echoed (today no-op'd at the engine level — see
-    # ``_convert_truncation`` in the adapter), ``service_tier`` is
-    # echoed as the requested value so clients see the contract round-
-    # trip. Both default to ``None`` so non-strict SDKs that ignore
-    # them keep working.
-    truncation: str | None = None
+    # ``ResponsesRequest`` docstring), ``service_tier`` is echoed as
+    # the requested value so clients see the contract round-trip. Both
+    # default to ``None`` so non-strict SDKs that ignore them keep
+    # working. ``truncation`` is ``Literal`` so the request-side
+    # validator's contract carries over to the response shape too.
+    truncation: Literal["auto", "disabled"] | None = None
     service_tier: str | None = None

--- a/vllm_mlx/api/responses_models.py
+++ b/vllm_mlx/api/responses_models.py
@@ -97,6 +97,15 @@ class ResponsesRequest(BaseModel):
     max_output_tokens: int | None = None
     temperature: float | None = None
     top_p: float | None = None
+    # Yuki R6 (0.8.5 dogfood): OpenAI Responses spec defines
+    # ``truncation`` as ``"auto" | "disabled"``. rapid-mlx accepts and
+    # echoes the requested value back on the response envelope; the
+    # engine-level truncation behaviour is a no-op in this release (the
+    # context-length gate already rejects oversized prompts upstream).
+    # NOTE: implement actual auto-truncation in a follow-up — operator
+    # preference (0.8 dogfood r4) is to echo + no-op so migrating
+    # clients don't see a silent drop while the implementation lands.
+    truncation: str | None = None
     # Per-request cap on reasoning tokens — see ``ChatCompletionRequest``
     # for the full semantic. ``None`` = no cap. Validated >= 1 by the
     # post-init validator below; the Responses route forwards this to
@@ -209,12 +218,19 @@ class ResponsesOutputContent(BaseModel):
 class ResponsesOutputItem(BaseModel):
     """An item in the ``output`` array of a non-streaming response.
 
-    Two shapes the shim emits:
+    Four shapes the shim emits:
     - ``message`` — assistant text reply, content array of output_text
     - ``function_call`` — one per tool call the model produced
+    - ``reasoning`` — top-level reasoning summary (Yuki F4 / R10);
+      emitted alongside ``message`` when the model produced reasoning
+      (cross-lane parity with /v1/chat/completions ``message.reasoning_content``).
+    - ``computer_call`` — UI-TARS / Computer-Use action call (Ana C-06);
+      emitted instead of ``function_call`` when the request supplied
+      ``tools=[{type:"computer_20251022", ...}]`` and the underlying
+      parser surfaced a ``computer``-tool call.
     """
 
-    type: str  # "message" | "function_call"
+    type: str  # "message" | "function_call" | "reasoning" | "computer_call"
     id: str
     status: str = "completed"
     # message
@@ -224,6 +240,18 @@ class ResponsesOutputItem(BaseModel):
     call_id: str | None = None
     name: str | None = None
     arguments: str | None = None
+    # reasoning — OpenAI Responses spec, output[i].type=="reasoning":
+    #   {"type":"reasoning","id":"rs_...","summary":[{"type":"summary_text","text":"..."}]}
+    # ``encrypted_content`` is omitted unless include=["reasoning.encrypted_content"]
+    # is requested AND the backend produces one. rapid-mlx is stateless,
+    # so the field is always absent today.
+    summary: list[dict] | None = None
+    encrypted_content: str | None = None
+    # computer_call — Computer-Use action shape, populated by translating
+    # the UI-TARS tool_call (``name="computer"``, JSON arguments) into the
+    # OpenAI ``computer_call`` envelope.
+    action: dict | None = None
+    pending_safety_checks: list[dict] | None = None
 
 
 class ResponsesResponse(BaseModel):
@@ -243,3 +271,12 @@ class ResponsesResponse(BaseModel):
     metadata: dict | None = None
     instructions: str | None = None
     previous_response_id: str | None = None
+    # Yuki R6 / R7 (0.8.5 dogfood): the OpenAI Responses spec exposes
+    # ``truncation`` and ``service_tier`` as response-envelope fields.
+    # ``truncation`` is echoed (today no-op'd at the engine level — see
+    # ``_convert_truncation`` in the adapter), ``service_tier`` is
+    # echoed as the requested value so clients see the contract round-
+    # trip. Both default to ``None`` so non-strict SDKs that ignore
+    # them keep working.
+    truncation: str | None = None
+    service_tier: str | None = None

--- a/vllm_mlx/routes/responses.py
+++ b/vllm_mlx/routes/responses.py
@@ -1613,11 +1613,46 @@ async def _stream_responses(
         # ``response.output_item.added`` event of type ``function_call``
         # (or ``computer_call`` for Computer-Use), honouring the
         # OpenAI ``tool_call guaranteed`` contract on the streaming
-        # surface too. Raises 422 for multi-tool ``required`` with no
-        # model call (parity with chat.py).
-        tool_calls = _enforce_responses_tool_choice(
-            parsed_tool_calls, responses_request, openai_request
-        )
+        # surface too. Codex r2 BLOCKING (PR #817): the non-stream
+        # path raises 422 for multi-tool ``required`` with no model
+        # call, but we cannot raise mid-stream after SSE headers
+        # are out — emit a ``response.failed`` event with the same
+        # error envelope instead so the client sees a clean shutdown
+        # signal.
+        try:
+            tool_calls = _enforce_responses_tool_choice(
+                parsed_tool_calls, responses_request, openai_request
+            )
+        except HTTPException as forced_choice_err:
+            # Drop any deferred buffered text — the request failed
+            # under forced choice, the deferred prose has no
+            # legitimate destination on the wire.
+            deferred_text.clear()
+            err_detail = forced_choice_err.detail
+            if isinstance(err_detail, dict):
+                err_envelope = err_detail.get("error", {})
+                err_code = err_envelope.get("code", "tool_choice_unfulfilled")
+                err_msg = err_envelope.get(
+                    "message", "tool_choice could not be fulfilled"
+                )
+            else:
+                err_code = "tool_choice_unfulfilled"
+                err_msg = str(err_detail)
+            yield _sse(
+                "response.failed",
+                {
+                    "type": "response.failed",
+                    "response": {
+                        "id": response_id,
+                        "status": "failed",
+                        "error": {
+                            "code": err_code,
+                            "message": err_msg,
+                        },
+                    },
+                },
+            )
+            return
         # Codex r1 BLOCKING #2 (PR #817): under forced choice the
         # ``deferred_text`` buffer holds text deltas we held back. Flush
         # them ONLY if synthesis won't fire — i.e. the model produced

--- a/vllm_mlx/routes/responses.py
+++ b/vllm_mlx/routes/responses.py
@@ -141,6 +141,40 @@ def _enforce_responses_tool_choice(
     tc = responses_request.tool_choice
     if tc is None or not openai_request.tools:
         return tool_calls
+    # Codex r3 BLOCKING #1 (PR #817): for the named-function form,
+    # validate that EVERY model-produced tool_call targets the pinned
+    # name. A model that called a different tool (``ping`` when
+    # ``pong`` was pinned) violates the contract just as much as a
+    # text-only response — raise 422 with the same diagnostic
+    # chat.py uses (~L1969-L1978).
+    if tool_calls and isinstance(tc, dict) and tc.get("type") == "function":
+        _named_target = tc.get("name") or (tc.get("function") or {}).get("name")
+        if _named_target:
+            mismatched = [
+                tc_obj
+                for tc_obj in tool_calls
+                if (tc_obj.function.name or "") != _named_target
+            ]
+            if mismatched:
+                _names = [m.function.name for m in mismatched]
+                raise HTTPException(
+                    status_code=422,
+                    detail={
+                        "error": {
+                            "message": (
+                                f"tool_choice pinned function "
+                                f"{_named_target!r} but the model emitted "
+                                f"calls to {_names}. Local inference "
+                                "cannot decoder-enforce a specific "
+                                "function; retry with a more direct "
+                                "user message."
+                            ),
+                            "type": "invalid_request_error",
+                            "code": "tool_choice_named_mismatch",
+                            "param": "tool_choice.name",
+                        }
+                    },
+                )
     # Only coerce when the model surfaced NO calls — a real model
     # response that called the right tool already satisfies the
     # contract.

--- a/vllm_mlx/routes/responses.py
+++ b/vllm_mlx/routes/responses.py
@@ -1652,6 +1652,14 @@ async def _stream_responses(
                     },
                 },
             )
+            # ``response.failed`` IS the terminal event for the
+            # OpenAI Responses SSE spec — there is no ``data: [DONE]``
+            # sentinel on this surface (see module docstring + the
+            # ``_sse`` helper docstring). Codex r2 reviewer flagged a
+            # missing ``[DONE]`` but that's chat-completions-only;
+            # Responses-API clients (Codex CLI, openai-python) detect
+            # stream end via the terminal event type, not a sentinel
+            # data line.
             return
         # Codex r1 BLOCKING #2 (PR #817): under forced choice the
         # ``deferred_text`` buffer holds text deltas we held back. Flush

--- a/vllm_mlx/routes/responses.py
+++ b/vllm_mlx/routes/responses.py
@@ -127,13 +127,14 @@ def _enforce_responses_tool_choice(
 
     Synthesis rules (parity with chat.py ~L1880):
       * ``"required"`` + exactly one tool → synthesise a call to it
+      * ``"required"`` + multiple tools + no model call → 422 with the
+        same diagnostic chat.py uses (codex r1 BLOCKING #1 on PR #817).
+        Silently degrading to ``auto`` would let a multi-tool ``required``
+        request return zero tool_calls and break the contract this PR
+        claims to restore.
       * ``{"type":"function","name":X}`` + X in submitted tools →
         synthesise a call to X
-      * Otherwise: return ``tool_calls`` unchanged. The post-parse 422
-        branch from chat.py is intentionally NOT mirrored here — the
-        Responses surface caller would see a confusing 422 mid-flight,
-        and the chat-completions lane's own gate already covers the
-        contract from the underlying engine path.
+      * ``auto`` / ``none`` / unrecognised shapes → pass through.
     """
     from ..routes.chat import _synthesize_forced_tool_call
 
@@ -157,7 +158,31 @@ def _enforce_responses_tool_choice(
                     name,
                 )
                 return [_synthesize_forced_tool_call(name)]
-        return tool_calls
+        # Multi-tool ``required`` with no model call — local inference
+        # cannot guess which of N tools the user intended. Chat.py
+        # raises 422 in the same situation (~L1891-1902); mirror that
+        # so the Responses surface does not silently violate the
+        # tool_call-guaranteed contract.
+        raise HTTPException(
+            status_code=422,
+            detail={
+                "error": {
+                    "message": (
+                        'tool_choice="required" but the model returned a '
+                        "text response with no tool_calls. Local "
+                        "inference has no decoder-level constraint; the "
+                        "system-prompt enforcement was insufficient for "
+                        "this prompt. Retry with a more concrete user "
+                        "message or use tool_choice="
+                        '{"type":"function","name":...} to pin a '
+                        "specific tool."
+                    ),
+                    "type": "invalid_request_error",
+                    "code": "tool_choice_required_unfulfilled",
+                    "param": "tool_choice",
+                }
+            },
+        )
     if isinstance(tc, dict) and tc.get("type") == "function":
         target = tc.get("name") or (tc.get("function") or {}).get("name")
         if not target:
@@ -991,6 +1016,33 @@ async def _stream_responses(
         accumulated_structured_tool_calls: list[dict] = []
         tool_filter = StreamingToolCallFilter()
 
+        # Yuki F6 codex r1 BLOCKING #2 (PR #817): when the request
+        # forces a tool_choice (``required`` or named-function), the
+        # message item MUST NOT be emitted if synthesis fires after
+        # generation — otherwise the client sees both an
+        # ``output_text`` message AND a synthesised tool_call, which
+        # violates the OpenAI Responses ``tool_call-guaranteed``
+        # contract. Solution: buffer text deltas in ``deferred_text``
+        # under forced-choice mode; at end-of-stream, decide to either
+        # flush them (model produced a real tool_call so synthesis won't
+        # fire) or drop them (synthesis will fire — message item is
+        # suppressed entirely). For non-forced choice, the legacy
+        # streaming path is preserved (lazy message-item open on first
+        # delta).
+        _forced_tc = responses_request.tool_choice
+        _forced_choice_active = (
+            openai_request.tools is not None
+            and openai_request.tools
+            and (
+                _forced_tc == "required"
+                or (
+                    isinstance(_forced_tc, dict)
+                    and _forced_tc.get("type") == "function"
+                )
+            )
+        )
+        deferred_text: list[str] = []
+
         _tokenizer = engine.tokenizer
         _chat_template = ""
         if _tokenizer and hasattr(_tokenizer, "chat_template"):
@@ -1137,9 +1189,18 @@ async def _stream_responses(
             ]
 
         async def _emit_text_delta(delta: str) -> AsyncIterator[str]:
-            """Yield the message item-added event (lazily) + a text delta."""
+            """Yield the message item-added event (lazily) + a text delta.
+
+            Under forced-choice mode (Yuki F6 codex r1 BLOCKING #2), the
+            delta is BUFFERED in ``deferred_text`` instead of being
+            yielded — final flush decision happens after the engine
+            stream completes and we know whether synthesis is needed.
+            """
             nonlocal accumulated_text
             if not delta:
+                return
+            if _forced_choice_active:
+                deferred_text.append(delta)
                 return
             if not message_open:
                 for ev in await _open_message_item():
@@ -1153,6 +1214,44 @@ async def _stream_responses(
                     "output_index": message_output_index,
                     "content_index": 0,
                     "delta": delta,
+                },
+            )
+
+        async def _flush_deferred_text_if_no_synthesis(
+            will_synthesise: bool,
+        ) -> AsyncIterator[str]:
+            """Forced-choice deferred-text resolution (codex r1 BLOCKING #2).
+
+            Called after the model finished and we know whether
+            ``_enforce_responses_tool_choice`` will synthesise. If
+            synthesis WILL fire, the deferred text is dropped (and the
+            message item never opens — no spurious assistant content
+            ships before the tool_call). If synthesis won't fire (the
+            model returned a real tool_call, or no forced choice was
+            set), the buffered deltas are emitted as a single
+            ``output_text.delta`` so the client still sees the
+            assistant's actual text content.
+            """
+            nonlocal accumulated_text
+            if will_synthesise or not deferred_text:
+                deferred_text.clear()
+                return
+            joined = "".join(deferred_text)
+            deferred_text.clear()
+            if not joined:
+                return
+            if not message_open:
+                for ev in await _open_message_item():
+                    yield ev
+            accumulated_text += joined
+            yield _sse(
+                "response.output_text.delta",
+                {
+                    "type": "response.output_text.delta",
+                    "item_id": message_item_id,
+                    "output_index": message_output_index,
+                    "content_index": 0,
+                    "delta": joined,
                 },
             )
 
@@ -1493,6 +1592,43 @@ async def _stream_responses(
                     async for ev in _emit_text_delta(content):
                         yield ev
 
+        # Parse tool_calls FIRST so the forced-choice deferred-text
+        # resolution (Yuki F6 codex r1 BLOCKING #2) can decide whether
+        # the message item should open at all.
+        # Pass `accumulated_raw` (pre-filter model output) not
+        # `accumulated_text` (post-filter user-visible text) — tool_filter
+        # rightly suppresses `<tool_call>...</tool_call>` XML from
+        # `accumulated_text`, but the post-loop parser needs that XML
+        # to extract structured tool_calls. Without this swap, the
+        # text-parser path returned zero tool_calls and Codex's agent
+        # loop silently terminated with no items emitted.
+        _, parsed_tool_calls = _parse_tool_calls_with_parser(
+            accumulated_raw,
+            openai_request,
+            structured_tool_calls=accumulated_structured_tool_calls or None,
+        )
+
+        # Yuki F6 (0.8.5 dogfood): mirror the non-stream synthesis so
+        # ``tool_choice="required"`` / named-function always produce a
+        # ``response.output_item.added`` event of type ``function_call``
+        # (or ``computer_call`` for Computer-Use), honouring the
+        # OpenAI ``tool_call guaranteed`` contract on the streaming
+        # surface too. Raises 422 for multi-tool ``required`` with no
+        # model call (parity with chat.py).
+        tool_calls = _enforce_responses_tool_choice(
+            parsed_tool_calls, responses_request, openai_request
+        )
+        # Codex r1 BLOCKING #2 (PR #817): under forced choice the
+        # ``deferred_text`` buffer holds text deltas we held back. Flush
+        # them ONLY if synthesis won't fire — i.e. the model produced
+        # a real tool_call, so the assistant's prose is legitimate
+        # context. When synthesis WILL fire (model only emitted text),
+        # drop the deferred text so the client doesn't see both a
+        # message AND a synthesised tool_call.
+        _synthesis_fired = bool(tool_calls) and not parsed_tool_calls
+        async for ev in _flush_deferred_text_if_no_synthesis(_synthesis_fired):
+            yield ev
+
         # Close the message item if we ever opened it.
         if message_open:
             # Yuki F8 (0.8.5 dogfood): emit ``response.output_text.done``
@@ -1546,30 +1682,6 @@ async def _stream_responses(
                     },
                 },
             )
-
-        # Emit function_call items for every tool call we saw.
-        # Pass `accumulated_raw` (pre-filter model output) not
-        # `accumulated_text` (post-filter user-visible text) — tool_filter
-        # rightly suppresses `<tool_call>...</tool_call>` XML from
-        # `accumulated_text`, but the post-loop parser needs that XML
-        # to extract structured tool_calls. Without this swap, the
-        # text-parser path returned zero tool_calls and Codex's agent
-        # loop silently terminated with no items emitted.
-        _, tool_calls = _parse_tool_calls_with_parser(
-            accumulated_raw,
-            openai_request,
-            structured_tool_calls=accumulated_structured_tool_calls or None,
-        )
-
-        # Yuki F6 (0.8.5 dogfood): mirror the non-stream synthesis so
-        # ``tool_choice="required"`` / named-function always produce a
-        # ``response.output_item.added`` event of type ``function_call``
-        # (or ``computer_call`` for Computer-Use), honouring the
-        # OpenAI ``tool_call guaranteed`` contract on the streaming
-        # surface too.
-        tool_calls = _enforce_responses_tool_choice(
-            tool_calls, responses_request, openai_request
-        )
 
         # Ana C-06 (0.8.5 dogfood): when the request used Computer-Use,
         # translate ``function.name == "computer"`` tool_calls into the

--- a/vllm_mlx/routes/responses.py
+++ b/vllm_mlx/routes/responses.py
@@ -34,7 +34,13 @@ from ..api.response_format_metrics import (
     incr_strict_request,
     incr_strict_violation,
 )
-from ..api.responses_adapter import openai_to_responses, responses_to_openai
+from ..api.responses_adapter import (
+    openai_to_responses,
+    request_uses_computer_use,
+    responses_to_openai,
+    validate_responses_tool_choice,
+    validate_responses_tool_types,
+)
 from ..api.responses_models import ResponsesRequest
 from ..api.tool_calling import (
     check_schema_validity,
@@ -106,6 +112,71 @@ def _should_start_in_thinking(chat_template: str, enable_thinking: bool | None) 
     return "<think>" in chat_template and "add_generation_prompt" in chat_template
 
 
+def _enforce_responses_tool_choice(
+    tool_calls: list | None,
+    responses_request: ResponsesRequest,
+    openai_request: ChatCompletionRequest,
+) -> list | None:
+    """Mirror of the chat-route post-parse forced-choice synthesis.
+
+    The chat route synthesises a stub tool_call when the model produces
+    text under ``tool_choice="required"`` (single-tool case) or under
+    the named-function form (target unambiguous). The /v1/responses
+    lane skipped this step, so Yuki F6 saw zero ``function_call`` items
+    even though the contract guarantees one.
+
+    Synthesis rules (parity with chat.py ~L1880):
+      * ``"required"`` + exactly one tool → synthesise a call to it
+      * ``{"type":"function","name":X}`` + X in submitted tools →
+        synthesise a call to X
+      * Otherwise: return ``tool_calls`` unchanged. The post-parse 422
+        branch from chat.py is intentionally NOT mirrored here — the
+        Responses surface caller would see a confusing 422 mid-flight,
+        and the chat-completions lane's own gate already covers the
+        contract from the underlying engine path.
+    """
+    from ..routes.chat import _synthesize_forced_tool_call
+
+    tc = responses_request.tool_choice
+    if tc is None or not openai_request.tools:
+        return tool_calls
+    # Only coerce when the model surfaced NO calls — a real model
+    # response that called the right tool already satisfies the
+    # contract.
+    if tool_calls:
+        return tool_calls
+    if tc == "required":
+        if len(openai_request.tools) == 1:
+            name = openai_request.tools[0].function.get("name")
+            if name:
+                logger.info(
+                    "tool_choice='required' on /v1/responses produced no "
+                    "tool_calls; synthesising a call to the sole "
+                    "available tool %r to honour the OpenAI tool_call-"
+                    "guaranteed contract (Yuki F6).",
+                    name,
+                )
+                return [_synthesize_forced_tool_call(name)]
+        return tool_calls
+    if isinstance(tc, dict) and tc.get("type") == "function":
+        target = tc.get("name") or (tc.get("function") or {}).get("name")
+        if not target:
+            return tool_calls
+        submitted = {
+            t.function.get("name") for t in openai_request.tools if t.type == "function"
+        }
+        if target in submitted:
+            logger.info(
+                "tool_choice pinned function %r on /v1/responses produced "
+                "no tool_calls; synthesising a call with empty arguments "
+                "to honour the OpenAI tool_call-guaranteed contract "
+                "(Yuki F6).",
+                target,
+            )
+            return [_synthesize_forced_tool_call(target)]
+    return tool_calls
+
+
 @router.post(
     "/v1/responses",
     dependencies=[
@@ -144,6 +215,22 @@ async def create_response(request: Request):
                 "full conversation history in the `input` field each turn."
             ),
         )
+
+    # Yuki F13 (0.8.5 dogfood): pre-engine tool-type allowlist. Anything
+    # outside ``SUPPORTED_RESPONSES_TOOL_TYPES`` 400s with a clear
+    # envelope BEFORE we admit a scheduler slot — pre-0.8.5 the route
+    # silently accepted ``web_search`` / ``computer_20251022`` /
+    # ``file_search`` and the client thought the tool was being invoked.
+    validate_responses_tool_types(responses_request.tools)
+    # Yuki F6 (0.8.5 dogfood): mirror the chat-completions tool_choice
+    # gate so ``required`` / named-function tool_choice REJECTS shapes
+    # that cannot be honoured (e.g. ``required`` with empty tools, named
+    # function not in tools). The post-parse synthesis path below
+    # COERCES a tool_call when the model didn't emit one — without it,
+    # the named-function form silently degraded to ``auto``.
+    validate_responses_tool_choice(
+        responses_request.tool_choice, responses_request.tools
+    )
 
     # Reuse the Claude-Code / Codex bypass from #557: ``claude-*``,
     # ``gpt-*`` model names pass through to the loaded engine instead of
@@ -632,6 +719,17 @@ async def _non_stream(
     cleaned_text, tool_calls = _parse_tool_calls_with_parser(
         output.text, openai_request, structured_tool_calls=engine_tool_calls
     )
+
+    # Yuki F6 (0.8.5 dogfood): mirror the chat-route ``tool_choice``
+    # coercion. The local engine has no decoder-level FSM constraint, so
+    # ``required`` / named-function ``tool_choice`` rely on post-parse
+    # synthesis to honour the OpenAI ``tool_call guaranteed`` contract.
+    # Without this, both shapes silently degraded to ``auto`` and Yuki
+    # F6 saw zero tool_calls on the wire.
+    tool_calls = _enforce_responses_tool_choice(
+        tool_calls, responses_request, openai_request
+    )
+
     cleaned_text, reasoning_text = _finalize_content_and_reasoning(
         raw_text=output.raw_text or output.text,
         cleaned_text=cleaned_text,
@@ -717,6 +815,105 @@ def _sse(event: str, data: dict) -> str:
     that sentinel is chat-completions-only.
     """
     return f"event: {event}\ndata: {json.dumps(data)}\n\n"
+
+
+async def _emit_function_call_item(tc, output_index: int) -> AsyncIterator[str]:
+    """Stream the SSE event triplet for a single ``function_call`` item.
+
+    Sequence: ``response.output_item.added`` →
+    ``response.function_call_arguments.delta`` →
+    ``response.output_item.done``. Args are sent in a single delta
+    because the underlying engine doesn't surface per-token tool-call
+    streaming yet (Codex CLI concatenates either way).
+    """
+    fc_id = f"fc_{uuid.uuid4().hex[:24]}"
+    yield _sse(
+        "response.output_item.added",
+        {
+            "type": "response.output_item.added",
+            "output_index": output_index,
+            "item": {
+                "type": "function_call",
+                "id": fc_id,
+                "call_id": tc.id,
+                "name": tc.function.name,
+                "arguments": "",
+                "status": "in_progress",
+            },
+        },
+    )
+    yield _sse(
+        "response.function_call_arguments.delta",
+        {
+            "type": "response.function_call_arguments.delta",
+            "item_id": fc_id,
+            "output_index": output_index,
+            "delta": tc.function.arguments or "",
+        },
+    )
+    yield _sse(
+        "response.output_item.done",
+        {
+            "type": "response.output_item.done",
+            "output_index": output_index,
+            "item": {
+                "type": "function_call",
+                "id": fc_id,
+                "call_id": tc.id,
+                "name": tc.function.name,
+                "arguments": tc.function.arguments or "",
+                "status": "completed",
+            },
+        },
+    )
+
+
+async def _emit_computer_call_item(tc, output_index: int) -> AsyncIterator[str]:
+    """Stream the SSE event pair for one Computer-Use ``computer_call``
+    item (Ana C-06, 0.8.5 dogfood).
+
+    Sequence: ``response.output_item.added`` →
+    ``response.output_item.done``. There is no per-token args delta
+    event for ``computer_call`` in the OpenAI spec — the entire
+    ``action`` envelope ships in the ``done`` payload.
+    """
+    # Lazy import to avoid the route module circular-importing the
+    # adapter at module load time (the adapter imports types from
+    # ``responses_models`` which the route also imports).
+    from ..api.responses_adapter import _parse_computer_action
+
+    cu_id = f"cu_{uuid.uuid4().hex[:24]}"
+    action = _parse_computer_action(tc.function.arguments or "")
+    yield _sse(
+        "response.output_item.added",
+        {
+            "type": "response.output_item.added",
+            "output_index": output_index,
+            "item": {
+                "type": "computer_call",
+                "id": cu_id,
+                "call_id": tc.id,
+                "status": "in_progress",
+                "action": action,
+                "pending_safety_checks": [],
+            },
+        },
+    )
+    yield _sse(
+        "response.output_item.done",
+        {
+            "type": "response.output_item.done",
+            "output_index": output_index,
+            "item": {
+                "type": "computer_call",
+                "id": cu_id,
+                "call_id": tc.id,
+                "status": "completed",
+                "action": action,
+                "pending_safety_checks": [],
+            },
+        },
+    )
 
 
 async def _stream_responses(
@@ -880,31 +1077,64 @@ async def _stream_responses(
             _reasoning_cap_hit = True
             return text[:keep_chars], text[keep_chars:], True
 
-        async def _open_message_item() -> str:
-            """Emit response.output_item.added for the assistant message.
+        # Yuki F8 (0.8.5 dogfood): track whether the content_part has
+        # been opened so the streaming sequence emits
+        # ``response.content_part.added`` exactly once per message item
+        # (before the first text delta).
+        content_part_open = False
 
-            Returns the event string so callers can yield it; the bookkeeping
-            for ``message_open`` lives here so the open/close pair stays
-            symmetric.
+        async def _open_message_item() -> list[str]:
+            """Emit response.output_item.added + response.content_part.added.
+
+            Returns the event strings so callers can yield them in order.
+            The bookkeeping for ``message_open`` / ``content_part_open``
+            lives here so the open/close pair stays symmetric.
+
+            Yuki F8: the OpenAI Responses SSE spec puts
+            ``response.content_part.added`` between the message item-
+            added event and the first text delta. Pre-0.8.5 this event
+            was missing; clients gating UI state on it never saw the
+            ``output_text`` block open.
             """
-            nonlocal message_item_id, message_output_index, message_open
+            nonlocal \
+                message_item_id, \
+                message_output_index, \
+                message_open, \
+                content_part_open
             message_item_id = f"msg_{uuid.uuid4().hex[:24]}"
             message_output_index = 0
             message_open = True
-            return _sse(
-                "response.output_item.added",
-                {
-                    "type": "response.output_item.added",
-                    "output_index": message_output_index,
-                    "item": {
-                        "type": "message",
-                        "id": message_item_id,
-                        "status": "in_progress",
-                        "role": "assistant",
-                        "content": [],
+            content_part_open = True
+            return [
+                _sse(
+                    "response.output_item.added",
+                    {
+                        "type": "response.output_item.added",
+                        "output_index": message_output_index,
+                        "item": {
+                            "type": "message",
+                            "id": message_item_id,
+                            "status": "in_progress",
+                            "role": "assistant",
+                            "content": [],
+                        },
                     },
-                },
-            )
+                ),
+                _sse(
+                    "response.content_part.added",
+                    {
+                        "type": "response.content_part.added",
+                        "item_id": message_item_id,
+                        "output_index": message_output_index,
+                        "content_index": 0,
+                        "part": {
+                            "type": "output_text",
+                            "text": "",
+                            "annotations": [],
+                        },
+                    },
+                ),
+            ]
 
         async def _emit_text_delta(delta: str) -> AsyncIterator[str]:
             """Yield the message item-added event (lazily) + a text delta."""
@@ -912,7 +1142,8 @@ async def _stream_responses(
             if not delta:
                 return
             if not message_open:
-                yield await _open_message_item()
+                for ev in await _open_message_item():
+                    yield ev
             accumulated_text += delta
             yield _sse(
                 "response.output_text.delta",
@@ -1264,6 +1495,37 @@ async def _stream_responses(
 
         # Close the message item if we ever opened it.
         if message_open:
+            # Yuki F8 (0.8.5 dogfood): emit ``response.output_text.done``
+            # AND ``response.content_part.done`` BEFORE the message item
+            # ``done`` event so clients gating UI on those events
+            # actually see them — pre-0.8.5 only the broader
+            # ``response.output_item.done`` fired.
+            if content_part_open:
+                yield _sse(
+                    "response.output_text.done",
+                    {
+                        "type": "response.output_text.done",
+                        "item_id": message_item_id,
+                        "output_index": message_output_index,
+                        "content_index": 0,
+                        "text": accumulated_text,
+                    },
+                )
+                yield _sse(
+                    "response.content_part.done",
+                    {
+                        "type": "response.content_part.done",
+                        "item_id": message_item_id,
+                        "output_index": message_output_index,
+                        "content_index": 0,
+                        "part": {
+                            "type": "output_text",
+                            "text": accumulated_text,
+                            "annotations": [],
+                        },
+                    },
+                )
+                content_part_open = False
             yield _sse(
                 "response.output_item.done",
                 {
@@ -1299,53 +1561,30 @@ async def _stream_responses(
             structured_tool_calls=accumulated_structured_tool_calls or None,
         )
 
+        # Yuki F6 (0.8.5 dogfood): mirror the non-stream synthesis so
+        # ``tool_choice="required"`` / named-function always produce a
+        # ``response.output_item.added`` event of type ``function_call``
+        # (or ``computer_call`` for Computer-Use), honouring the
+        # OpenAI ``tool_call guaranteed`` contract on the streaming
+        # surface too.
+        tool_calls = _enforce_responses_tool_choice(
+            tool_calls, responses_request, openai_request
+        )
+
+        # Ana C-06 (0.8.5 dogfood): when the request used Computer-Use,
+        # translate ``function.name == "computer"`` tool_calls into the
+        # ``computer_call`` envelope so SDK consumers walking
+        # ``output_item.type`` for ``computer_call`` find them.
+        uses_computer_use = request_uses_computer_use(responses_request)
+
         tool_output_index = (message_output_index + 1) if message_open else 0
         for tc in tool_calls or []:
-            fc_id = f"fc_{uuid.uuid4().hex[:24]}"
-            yield _sse(
-                "response.output_item.added",
-                {
-                    "type": "response.output_item.added",
-                    "output_index": tool_output_index,
-                    "item": {
-                        "type": "function_call",
-                        "id": fc_id,
-                        "call_id": tc.id,
-                        "name": tc.function.name,
-                        "arguments": "",
-                        "status": "in_progress",
-                    },
-                },
-            )
-            # Codex CLI accepts the args as a single delta — we don't
-            # have token-by-token streaming for tool_call arguments in
-            # the underlying engine yet, so emit the whole JSON string
-            # at once. Codex concatenates these the same way regardless
-            # of chunk count.
-            yield _sse(
-                "response.function_call_arguments.delta",
-                {
-                    "type": "response.function_call_arguments.delta",
-                    "item_id": fc_id,
-                    "output_index": tool_output_index,
-                    "delta": tc.function.arguments or "",
-                },
-            )
-            yield _sse(
-                "response.output_item.done",
-                {
-                    "type": "response.output_item.done",
-                    "output_index": tool_output_index,
-                    "item": {
-                        "type": "function_call",
-                        "id": fc_id,
-                        "call_id": tc.id,
-                        "name": tc.function.name,
-                        "arguments": tc.function.arguments or "",
-                        "status": "completed",
-                    },
-                },
-            )
+            if uses_computer_use and (tc.function.name or "") == "computer":
+                async for ev in _emit_computer_call_item(tc, tool_output_index):
+                    yield ev
+            else:
+                async for ev in _emit_function_call_item(tc, tool_output_index):
+                    yield ev
             tool_output_index += 1
 
         # H-06 (codex r2): the streaming /v1/responses path is


### PR DESCRIPTION
## Summary

Fixes the 0.8.5 dogfood ``/v1/responses`` lane bundle from Yuki + Ana (`0.8TODO.md` r4 section, `/tmp/dogfood-085/yuki-r{1,2}.md`, `/tmp/dogfood-085/ana-r1.md`).

### Findings closed

- **Yuki F4 / R10 (HIGH)** — top-level `reasoning` output item never emitted on `/v1/responses` even when `usage.output_tokens_details.reasoning_tokens > 0`. Adapter now emits `output[i].type=="reasoning"` ahead of the `message` item with `message.reasoning_content` verbatim in `summary[0].text`. Restores cross-lane parity with `/v1/chat/completions` `message.reasoning_content` (Yuki R10).

- **Yuki F6 (HIGH)** — `tool_choice="required"` and `{type:"function","name":X}` silently degraded to `auto`. Mirror the chat-route post-parse synthesis (`_synthesize_forced_tool_call`) so the Responses surface honours the OpenAI `tool_call-guaranteed` contract on BOTH non-stream and streaming paths.

- **Ana C-06 (CRIT)** — UI-TARS unreachable via `/v1/responses`. `tools=[{type:"computer_20251022", ...}]` is now accepted (translated to a synthetic `computer` function tool so the UI-TARS parser engages), and `function.name=="computer"` tool_calls are translated to `computer_call` output items with the OpenAI Computer-Use `action` envelope (`{type: <verb>, ...kwargs}`). Both non-stream and streaming paths emit the `computer_call` shape.

- **Yuki F8 (MED)** — streaming pipeline now emits `response.content_part.added` + `response.output_text.done` (and the matching `response.content_part.done`) per OpenAI Responses SSE spec.

- **Yuki R6 / R7 (MED)** — `truncation="auto"` and `service_tier` echoed on the response envelope. Truncation is a no-op at the engine level for this release (operator preference, documented in `ResponsesRequest` docstring NOTE — context-length gate already rejects oversized prompts upstream).

- **Yuki F13 (MED)** — `web_search` / `file_search` / `code_interpreter` / `image_generation` now return a 400 with allowlist message instead of silent 200. `SUPPORTED_RESPONSES_TOOL_TYPES` is the single source of truth (route + adapter + tests, no per-route regex band-aids).

### What shipped

- `vllm_mlx/api/responses_models.py` — added `reasoning` + `computer_call` shapes to `ResponsesOutputItem` (`summary`, `encrypted_content`, `action`, `pending_safety_checks`), added `truncation` field to `ResponsesRequest`, added `truncation` + `service_tier` echo fields to `ResponsesResponse`.
- `vllm_mlx/api/responses_adapter.py` — `SUPPORTED_RESPONSES_TOOL_TYPES` allowlist + `validate_responses_tool_types` + `validate_responses_tool_choice` + `request_uses_computer_use` helpers; `_convert_tools` now translates `computer_20251022` → synthetic `computer` function tool with screen geometry hints; `openai_to_responses` now emits a `reasoning` output item from `message.reasoning_content`, and translates `function.name=="computer"` to `computer_call` when the request used Computer-Use.
- `vllm_mlx/routes/responses.py` — F13 + F6 pre-engine validation; `_enforce_responses_tool_choice` post-parse synthesis (parity with `chat.py` ~L1880); streaming path emits `response.content_part.added` + `response.output_text.done` + `response.content_part.done` events; `_emit_function_call_item` + `_emit_computer_call_item` SSE helpers for both branches; F6/C-06 also enforced in streaming output.
- `tests/test_responses_bundle.py` (new, 21 tests) — covers F4, R10, F6, C-06, F8, R6, R7, F13.
- `tests/test_responses_adapter.py` — updated the prior `test_drops_non_function_tools` test to the new F13 contract (400 instead of silent drop).

## Test plan

- [x] All 21 new bundle tests pass (`tests/test_responses_bundle.py`)
- [x] All 49 existing adapter tests pass (`tests/test_responses_adapter.py`) — updated 1
- [x] All 22 existing route tests pass (`tests/test_responses_route.py`)
- [x] Combined `pytest -k 'responses'` = 145 passing, 0 failing
- [x] `ruff check` clean, `ruff format` applied
- [x] No version bump (`skip-version-bump` label expected)
- [x] No interactions with the in-flight R-01 F3 truncation-marker fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)