### PR TITLE
fix(ui-tars): auto-prepend sysprompt + honor tool_choice=none + normalize point keys + streaming Thought: hold-back + cross-lane coord parity (C-05+C-07+parser bundle)

### DIFF
--- a/tests/test_ui_tars_fixes.py
+++ b/tests/test_ui_tars_fixes.py
@@ -423,6 +423,35 @@ class TestHotkeyNormalization:
         args = _decode_args(r.tool_calls[0])
         assert args == {"action": "hotkey", "key": "ctrl+c"}
 
+    # codex r5 NIT #2: modifier-scoped rewrite. Single-key names that
+    # contain a space — ``"page down"``, ``"arrow up"``, ``"caps lock"``
+    # — are NOT chords and must pass through unchanged.
+    @pytest.mark.parametrize(
+        "key_in",
+        ["page down", "arrow up", "caps lock", "num lock", "scroll lock"],
+    )
+    def test_non_chord_space_key_preserved(self, key_in: str):
+        args = _normalize_action("hotkey", {"key": key_in})
+        # No ``+`` rewrite — these are key names, not chord modifiers.
+        assert args == {"action": "hotkey", "key": key_in}
+
+    @pytest.mark.parametrize(
+        "modifier,expected",
+        [
+            ("cmd v", "cmd+v"),
+            ("command v", "command+v"),
+            ("shift tab", "shift+tab"),
+            ("alt f4", "alt+f4"),
+            ("option a", "option+a"),
+            ("meta l", "meta+l"),
+            ("win e", "win+e"),
+            ("super space", "super+space"),
+        ],
+    )
+    def test_known_modifiers_rewritten(self, modifier: str, expected: str):
+        args = _normalize_action("hotkey", {"key": modifier})
+        assert args == {"action": "hotkey", "key": expected}
+
 
 # ---------------------------------------------------------------------------
 # Streaming Thought:/Action: hold-back (F-R1-04)
@@ -534,6 +563,45 @@ class TestStreamingThoughtHoldback:
         assert "Thought:" in reasoning
         assert "Action:" not in reasoning
         assert "Action:" in content
+
+    # codex r5 BLOCKING: EOF flush. If the stream ends mid-opener-
+    # prefix (truncation by ``max_tokens``, or the model genuinely
+    # output bare ``"Thought"`` text), the held bytes must surface
+    # as content at EOF — not silently dropped.
+
+    def test_finalize_emits_held_opener_prefix_as_content(self):
+        # Stream ``"Thought"`` and never see the colon. Mid-stream
+        # event is None (held). ``finalize_streaming`` MUST return
+        # the held bytes as ``content`` so the wire stream is
+        # byte-complete.
+        events = self._stream(["Thought"])
+        assert events == []
+        # The accumulated text is what the parser saw — same as
+        # the prev+delta sum in ``_stream``.
+        final = self.p.finalize_streaming("Thought")
+        assert final is not None
+        assert final.content == "Thought"
+        assert final.reasoning is None
+
+    def test_finalize_noop_after_reasoning_started(self):
+        # Once a reasoning event has fired, we're past the hold-back
+        # phase — finalize must NOT re-emit anything (else
+        # double-emission).
+        events = self._stream(["Thought: hi.\n"])
+        assert any(e.reasoning for e in events)
+        final = self.p.finalize_streaming("Thought: hi.\n")
+        assert final is None
+
+    def test_finalize_noop_after_content_started(self):
+        # Same invariant on the content branch.
+        events = self._stream(["Hello, world!\n"])
+        assert any(e.content for e in events)
+        final = self.p.finalize_streaming("Hello, world!\n")
+        assert final is None
+
+    def test_finalize_noop_on_empty_text(self):
+        final = self.p.finalize_streaming("")
+        assert final is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_ui_tars_fixes.py
+++ b/tests/test_ui_tars_fixes.py
@@ -36,6 +36,7 @@ Bugs covered:
 
 from __future__ import annotations
 
+import ast
 import json
 from typing import Any
 
@@ -600,69 +601,133 @@ class TestLaneInjectionParity:
         assert oai_out[0]["content"] == UI_TARS_COMPUTER_USE_SYSTEM_PROMPT
         assert oai_out[1] == {"role": "system", "content": "Be concise."}
 
-    def test_chat_route_actually_invokes_helper(self):
-        # Codex r3 BLOCKING #1: the helper-layer parity asserts above
-        # can't catch a route that STOPPED calling the helper. Pin
-        # the wiring by inspecting the route module source for the
-        # call. Source-grep is brittle vs imports moving, but the
-        # alternative — driving the full route with a stub engine
-        # — pulls the entire MLX runtime into the unit-test path
-        # which is structurally infeasible on a non-Apple-Silicon
-        # CI runner. Source-grep is the cheapest gate that fails
-        # loud if either route accidentally drops the inject.
+    @staticmethod
+    def _find_helper_calls(module) -> list[ast.Call]:
+        """Return every ``Call`` node in ``module`` whose call target
+        ultimately resolves to ``maybe_inject_ui_tars_system_prompt``.
+
+        Tolerates:
+        - ``from .ui_tars_tool_parser import maybe_inject_ui_tars_system_prompt as X``
+          followed by ``X(...)``.
+        - ``import vllm_mlx.tool_parsers.ui_tars_tool_parser as X``
+          followed by ``X.maybe_inject_ui_tars_system_prompt(...)``.
+        - The direct unaliased ``maybe_inject_ui_tars_system_prompt(...)``.
+
+        Pinning at the AST level (rather than source substring) is
+        codex r4's requirement — a dead ``import`` or a literal in a
+        comment / docstring no longer satisfies the assertion. The
+        test fails when (and only when) the route actually drops the
+        live call site.
+        """
         import inspect
 
+        src = inspect.getsource(module)
+        tree = ast.parse(src)
+        target_name = "maybe_inject_ui_tars_system_prompt"
+        # Step 1: walk imports to learn what local names refer to
+        # the helper (direct or aliased).
+        local_aliases: set[str] = set()
+        module_aliases: set[str] = set()  # ``X`` when ``import … as X``
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom):
+                # ``from … import maybe_inject_ui_tars_system_prompt
+                # [as ALIAS]``
+                for n in node.names:
+                    if n.name == target_name:
+                        local_aliases.add(n.asname or n.name)
+            elif isinstance(node, ast.Import):
+                # ``import vllm_mlx.tool_parsers.ui_tars_tool_parser
+                # as X`` — record ``X`` so we can match
+                # ``X.maybe_inject_ui_tars_system_prompt(...)``.
+                for n in node.names:
+                    if "ui_tars_tool_parser" in n.name:
+                        module_aliases.add(n.asname or n.name.split(".")[-1])
+        # Step 2: walk the tree looking for Call nodes whose callable
+        # resolves to the helper.
+        calls: list[ast.Call] = []
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            callee = node.func
+            if isinstance(callee, ast.Name) and callee.id in local_aliases:
+                calls.append(node)
+            elif isinstance(callee, ast.Attribute):
+                if (
+                    callee.attr == target_name
+                    and isinstance(callee.value, ast.Name)
+                    and callee.value.id in module_aliases
+                ):
+                    calls.append(node)
+        return calls
+
+    @staticmethod
+    def _call_kwarg_value_source(call: ast.Call, kwarg_name: str) -> str | None:
+        """Return ``ast.unparse`` of the kwarg's value expression, or None."""
+        for kw in call.keywords:
+            if kw.arg == kwarg_name:
+                return ast.unparse(kw.value)
+        return None
+
+    def test_chat_route_actually_invokes_helper(self):
+        # Codex r4 BLOCKING: walk the route's AST and assert a real
+        # ``Call`` node to the helper exists. A dead ``import`` no
+        # longer satisfies this — only a live call site counts.
         from vllm_mlx.routes import chat as chat_route
 
-        src = inspect.getsource(chat_route)
-        # The route MUST import the helper and call it on the
-        # ``messages`` list. We don't pin the exact import shape
-        # (``from … import`` vs ``import …``) — just that the
-        # symbol name appears in source.
-        assert "maybe_inject_ui_tars_system_prompt" in src, (
-            "routes/chat.py must call maybe_inject_ui_tars_system_prompt"
-            " — dogfood C-05 regression"
+        calls = self._find_helper_calls(chat_route)
+        assert len(calls) >= 1, (
+            "routes/chat.py must contain at least one Call node to"
+            " maybe_inject_ui_tars_system_prompt — dogfood C-05"
         )
 
     def test_anthropic_route_actually_invokes_helper(self):
-        # Symmetric pin for the Anthropic lane (dogfood F-R2-04
-        # lane-parity fix).
-        import inspect
-
         from vllm_mlx.routes import anthropic as anthropic_route
 
-        src = inspect.getsource(anthropic_route)
-        assert "maybe_inject_ui_tars_system_prompt" in src, (
-            "routes/anthropic.py must call"
-            " maybe_inject_ui_tars_system_prompt — dogfood F-R2-04"
-            " regression"
+        calls = self._find_helper_calls(anthropic_route)
+        assert len(calls) >= 1, (
+            "routes/anthropic.py must contain at least one Call node"
+            " to maybe_inject_ui_tars_system_prompt — dogfood F-R2-04"
         )
 
-    def test_chat_route_invokes_helper_with_request_tool_choice(self):
-        # Stronger pin: the chat route must pass BOTH
-        # ``tool_call_parser`` AND ``tool_choice`` to the helper —
-        # otherwise the ``tool_choice="none"`` skip (C-07) would
-        # silently regress without the helper-side guard catching
-        # it.
-        import inspect
-
+    def test_chat_route_invokes_helper_with_parser_and_tool_choice(self):
+        # Codex r4 BLOCKING: assert the helper call's kwargs
+        # specifically pass the server config's ``tool_call_parser``
+        # and the request's ``tool_choice`` — not just that those
+        # tokens appear anywhere in the source. AST-level check
+        # over the actual ``Call`` node's keyword arguments.
         from vllm_mlx.routes import chat as chat_route
 
-        src = inspect.getsource(chat_route)
-        # Look for the call shape — the source has a multi-line
-        # invocation. We tolerate whitespace by checking for the
-        # named kwargs on adjacent lines.
-        assert "tool_call_parser=cfg.tool_call_parser" in src
-        assert "tool_choice=tc" in src
+        calls = self._find_helper_calls(chat_route)
+        assert calls, "routes/chat.py must call the helper"
+        # Pick the first live call (route only has one).
+        call = calls[0]
+        parser_expr = self._call_kwarg_value_source(call, "tool_call_parser")
+        tc_expr = self._call_kwarg_value_source(call, "tool_choice")
+        assert parser_expr is not None, "tool_call_parser= kwarg missing"
+        assert tc_expr is not None, "tool_choice= kwarg missing"
+        # Pin the EXACT expressions — refactors that move config or
+        # rename the resolved variable should re-evaluate this test
+        # on purpose, not accidentally regress C-05 / C-07.
+        assert "cfg.tool_call_parser" in parser_expr
+        # ``tc`` is the route's local for ``request.tool_choice``;
+        # accept either the local or the explicit dotted form so
+        # a future cleanup that drops the local doesn't false-fail.
+        assert tc_expr in ("tc", "request.tool_choice")
 
-    def test_anthropic_route_invokes_helper_with_request_tool_choice(self):
-        import inspect
-
+    def test_anthropic_route_invokes_helper_with_parser_and_tool_choice(self):
         from vllm_mlx.routes import anthropic as anthropic_route
 
-        src = inspect.getsource(anthropic_route)
-        assert "tool_call_parser=" in src
-        assert "tool_choice=openai_request.tool_choice" in src
+        calls = self._find_helper_calls(anthropic_route)
+        assert calls, "routes/anthropic.py must call the helper"
+        call = calls[0]
+        parser_expr = self._call_kwarg_value_source(call, "tool_call_parser")
+        tc_expr = self._call_kwarg_value_source(call, "tool_choice")
+        assert parser_expr is not None
+        assert tc_expr is not None
+        # Anthropic route uses a local cfg snapshot — accept either
+        # the local snapshot or the direct ``get_config().``-shape.
+        assert parser_expr.endswith("tool_call_parser")
+        assert tc_expr == "openai_request.tool_choice"
 
     def test_inject_parity_skips_on_tool_choice_none(self):
         # ``tool_choice="none"`` short-circuit fires identically on

--- a/tests/test_ui_tars_fixes.py
+++ b/tests/test_ui_tars_fixes.py
@@ -600,6 +600,70 @@ class TestLaneInjectionParity:
         assert oai_out[0]["content"] == UI_TARS_COMPUTER_USE_SYSTEM_PROMPT
         assert oai_out[1] == {"role": "system", "content": "Be concise."}
 
+    def test_chat_route_actually_invokes_helper(self):
+        # Codex r3 BLOCKING #1: the helper-layer parity asserts above
+        # can't catch a route that STOPPED calling the helper. Pin
+        # the wiring by inspecting the route module source for the
+        # call. Source-grep is brittle vs imports moving, but the
+        # alternative — driving the full route with a stub engine
+        # — pulls the entire MLX runtime into the unit-test path
+        # which is structurally infeasible on a non-Apple-Silicon
+        # CI runner. Source-grep is the cheapest gate that fails
+        # loud if either route accidentally drops the inject.
+        import inspect
+
+        from vllm_mlx.routes import chat as chat_route
+
+        src = inspect.getsource(chat_route)
+        # The route MUST import the helper and call it on the
+        # ``messages`` list. We don't pin the exact import shape
+        # (``from … import`` vs ``import …``) — just that the
+        # symbol name appears in source.
+        assert "maybe_inject_ui_tars_system_prompt" in src, (
+            "routes/chat.py must call maybe_inject_ui_tars_system_prompt"
+            " — dogfood C-05 regression"
+        )
+
+    def test_anthropic_route_actually_invokes_helper(self):
+        # Symmetric pin for the Anthropic lane (dogfood F-R2-04
+        # lane-parity fix).
+        import inspect
+
+        from vllm_mlx.routes import anthropic as anthropic_route
+
+        src = inspect.getsource(anthropic_route)
+        assert "maybe_inject_ui_tars_system_prompt" in src, (
+            "routes/anthropic.py must call"
+            " maybe_inject_ui_tars_system_prompt — dogfood F-R2-04"
+            " regression"
+        )
+
+    def test_chat_route_invokes_helper_with_request_tool_choice(self):
+        # Stronger pin: the chat route must pass BOTH
+        # ``tool_call_parser`` AND ``tool_choice`` to the helper —
+        # otherwise the ``tool_choice="none"`` skip (C-07) would
+        # silently regress without the helper-side guard catching
+        # it.
+        import inspect
+
+        from vllm_mlx.routes import chat as chat_route
+
+        src = inspect.getsource(chat_route)
+        # Look for the call shape — the source has a multi-line
+        # invocation. We tolerate whitespace by checking for the
+        # named kwargs on adjacent lines.
+        assert "tool_call_parser=cfg.tool_call_parser" in src
+        assert "tool_choice=tc" in src
+
+    def test_anthropic_route_invokes_helper_with_request_tool_choice(self):
+        import inspect
+
+        from vllm_mlx.routes import anthropic as anthropic_route
+
+        src = inspect.getsource(anthropic_route)
+        assert "tool_call_parser=" in src
+        assert "tool_choice=openai_request.tool_choice" in src
+
     def test_inject_parity_skips_on_tool_choice_none(self):
         # ``tool_choice="none"`` short-circuit fires identically on
         # both lanes — neither gets a UI-TARS sysprompt, so the

--- a/tests/test_ui_tars_fixes.py
+++ b/tests/test_ui_tars_fixes.py
@@ -1,0 +1,548 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression coverage for 0.8.5 UI-TARS dogfood findings (Ana R1+R2).
+
+Bugs covered:
+- C-05 (CRIT): UI-TARS Computer-Use system prompt not auto-prepended on
+  the chat lane; parser silently no-ops on raw model output. Fixed by
+  ``maybe_inject_ui_tars_system_prompt`` wired into ``routes/chat.py``
+  and ``routes/anthropic.py``.
+- C-07 (CRIT): ``tool_choice="none"`` ignored — UI-TARS still emits a
+  ``computer`` tool_call. Fixed by (a) skipping the sysprompt inject
+  when ``tool_choice="none"`` (REQUEST-time) and (b) defensive
+  short-circuit in the parser (RESPONSE-time) so even an
+  operator-supplied sysprompt path produces no ``tool_calls``.
+- F-R1-02 (HIGH): Parser emits ``start_box``/``end_box`` instead of
+  spec ``point``/``start_point``/``end_point``. Fixed by verb-aware
+  key normalization in ``_normalize_action`` / ``_spec_key_for``.
+- F-R1-04 (HIGH): Streaming OpenAI lane leaks ``Thought:`` / ``Action:``
+  markers into ``delta.content`` while non-streaming strips them.
+  Fixed by tightening the partial-opener hold-back gate in the
+  streaming reasoning parser (``"Thought"`` prefix no longer flips
+  to content when buffer reaches 7 chars).
+- F-R1-06 (HIGH): ``hotkey.key`` emitted as space-separated chord
+  (``"ctrl c"``) instead of plus-form (``"ctrl+c"``). Fixed by
+  normalizing the chord at the parser boundary.
+- F-R2-04 (HIGH): OpenAI lane and Anthropic lane produce different
+  coords on identical input. Root cause: only the OAI lane was
+  injecting the canonical UI-TARS sysprompt — the Anthropic lane
+  never did, so the model received different prompts and emitted
+  different coords. Fixed by wiring the SAME shared helper into
+  BOTH routes (parser-level emit identity assert kept here; the
+  end-to-end cross-lane assert lives in the dogfood replay).
+- F-R2-05 (HIGH): ``[SSE-TC]`` INFO log leaked tool_call arguments
+  (user-action coords) into the server log on every Computer-Use
+  turn. Dropped to DEBUG so the PII path is opt-in.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from vllm_mlx.reasoning.ui_tars_parser import UiTarsReasoningParser
+from vllm_mlx.tool_parsers import UiTarsToolParser
+from vllm_mlx.tool_parsers.ui_tars_tool_parser import (
+    UI_TARS_COMPUTER_USE_SYSTEM_PROMPT,
+    _is_tool_choice_none,
+    _normalize_action,
+    has_ui_tars_system_prompt,
+    maybe_inject_ui_tars_system_prompt,
+)
+
+# ---------------------------------------------------------------------------
+# C-05: sysprompt auto-wire
+# ---------------------------------------------------------------------------
+
+
+class TestSysPromptAutoWire:
+    def test_canonical_sysprompt_contains_action_space(self):
+        # Sanity check that the canonical sysprompt actually mentions
+        # the action-API contract the model is post-trained on.
+        assert "## Action Space" in UI_TARS_COMPUTER_USE_SYSTEM_PROMPT
+        assert "## Output Format" in UI_TARS_COMPUTER_USE_SYSTEM_PROMPT
+        assert "Thought: ..." in UI_TARS_COMPUTER_USE_SYSTEM_PROMPT
+        assert "Action: ..." in UI_TARS_COMPUTER_USE_SYSTEM_PROMPT
+        assert "click(point=" in UI_TARS_COMPUTER_USE_SYSTEM_PROMPT
+        assert "drag(start_point=" in UI_TARS_COMPUTER_USE_SYSTEM_PROMPT
+
+    def test_inject_when_no_user_sysprompt(self):
+        # C-05 repro: a UI-TARS request with no system message — the
+        # canonical sysprompt MUST be prepended so the parser actually
+        # sees the ``Action:`` lines the model is post-trained on.
+        messages = [{"role": "user", "content": "Click the search button."}]
+        out = maybe_inject_ui_tars_system_prompt(
+            messages, tool_call_parser="ui_tars", tool_choice=None
+        )
+        assert out[0]["role"] == "system"
+        assert out[0]["content"] == UI_TARS_COMPUTER_USE_SYSTEM_PROMPT
+        assert out[1]["role"] == "user"
+        # Original list was NOT mutated in place — caller can keep
+        # using their own reference safely.
+        assert len(messages) == 1
+        assert messages[0]["role"] == "user"
+
+    def test_inject_with_user_sysprompt_lands_first(self):
+        # When the user ALSO supplies a system message, the auto-
+        # injected sysprompt lands FIRST and the user content is
+        # preserved verbatim AFTER (additive, not overriding).
+        # Operator design choice — extends, doesn't override.
+        messages = [
+            {"role": "system", "content": "Be concise."},
+            {"role": "user", "content": "Click search."},
+        ]
+        out = maybe_inject_ui_tars_system_prompt(
+            messages, tool_call_parser="ui_tars", tool_choice=None
+        )
+        # Auto-injected sysprompt FIRST, user system PRESERVED.
+        assert out[0]["content"] == UI_TARS_COMPUTER_USE_SYSTEM_PROMPT
+        assert out[1] == {"role": "system", "content": "Be concise."}
+        assert out[2]["role"] == "user"
+
+    def test_skip_inject_when_user_pasted_canonical(self):
+        # If the operator already pasted (a variant of) the canonical
+        # sysprompt, we DON'T double-inject — respect their wording.
+        user_sys = "You are a GUI agent. Custom action space follows..."
+        messages = [
+            {"role": "system", "content": user_sys},
+            {"role": "user", "content": "Click."},
+        ]
+        out = maybe_inject_ui_tars_system_prompt(
+            messages, tool_call_parser="ui_tars", tool_choice=None
+        )
+        # No new sysprompt prepended.
+        assert out == messages
+        assert len(out) == 2
+
+    @pytest.mark.parametrize(
+        "marker",
+        [
+            "## Output Format",
+            "## Action Space",
+            "click(point=",
+            "click(start_box=",
+            "You are a GUI agent — custom variant.",
+        ],
+    )
+    def test_detect_canonical_via_any_marker(self, marker: str):
+        # Detection is permissive: any of these markers in a system
+        # message marks the operator as "already pasted (a variant of)
+        # the canonical sysprompt". Skips double-inject.
+        messages = [{"role": "system", "content": f"prefix\n{marker}\nsuffix"}]
+        assert has_ui_tars_system_prompt(messages) is True
+
+    def test_skip_inject_when_parser_is_not_ui_tars(self):
+        # Wrong model family — no inject. Avoids polluting
+        # non-UI-TARS aliases (every Qwen / Hermes / etc.) with the
+        # Computer-Use action-API contract.
+        messages = [{"role": "user", "content": "Hi."}]
+        out = maybe_inject_ui_tars_system_prompt(
+            messages, tool_call_parser="hermes", tool_choice=None
+        )
+        assert out == messages
+
+    def test_skip_inject_when_tool_choice_none(self):
+        # C-07: when ``tool_choice="none"`` the caller is opting OUT
+        # of tool emission. Skip the sysprompt inject so the model
+        # produces plain prose, NOT ``Action: ...`` lines.
+        messages = [{"role": "user", "content": "What time is it?"}]
+        out = maybe_inject_ui_tars_system_prompt(
+            messages, tool_call_parser="ui_tars", tool_choice="none"
+        )
+        assert out == messages
+
+    def test_anthropic_shape_system_content_blocks_detected(self):
+        # System message with Anthropic-style content blocks must
+        # also flow through the detector — otherwise the
+        # multimodal Anthropic lane would double-inject.
+        messages = [
+            {
+                "role": "system",
+                "content": [
+                    {"type": "text", "text": "## Action Space\nclick(point=...)"}
+                ],
+            }
+        ]
+        assert has_ui_tars_system_prompt(messages) is True
+
+
+# ---------------------------------------------------------------------------
+# C-07: tool_choice="none" honored
+# ---------------------------------------------------------------------------
+
+
+def _decode_args(tool_call: dict[str, Any]) -> dict[str, Any]:
+    return json.loads(tool_call["arguments"])
+
+
+class TestToolChoiceNone:
+    def setup_method(self) -> None:
+        self.p = UiTarsToolParser()
+
+    def test_helper_recognizes_string_none(self):
+        assert _is_tool_choice_none({"tool_choice": "none"}) is True
+        assert _is_tool_choice_none({"tool_choice": "auto"}) is False
+        assert _is_tool_choice_none({"tool_choice": None}) is False
+        assert _is_tool_choice_none(None) is False
+
+    def test_non_streaming_suppresses_tool_calls(self):
+        # Ana F-R2-02 repro: model output contains ``Action: click(...)``
+        # but the request specified ``tool_choice="none"``. Per OpenAI
+        # spec the response MUST be text-only with no ``tool_calls``.
+        text = "Thought: Want to click.\nAction: click(point='<point>100 200</point>')"
+        r = self.p.extract_tool_calls(text, request={"tool_choice": "none"})
+        assert r.tools_called is False
+        assert r.tool_calls == []
+        # Raw bytes surface as content so the caller still sees the
+        # model output (no silent drop).
+        assert "Action: click" in (r.content or "")
+
+    def test_non_streaming_emits_tool_calls_for_auto(self):
+        # Same input, ``tool_choice="auto"`` → tool_call emitted.
+        text = "Action: click(point='<point>100 200</point>')"
+        r = self.p.extract_tool_calls(text, request={"tool_choice": "auto"})
+        assert r.tools_called is True
+        assert len(r.tool_calls) == 1
+        assert _decode_args(r.tool_calls[0]) == {
+            "action": "click",
+            "point": [100, 200],
+        }
+
+    def test_streaming_suppresses_tool_calls(self):
+        # Streaming variant: deltas with Action: bytes get passed
+        # through as content (not tool_call deltas).
+        delta = "Action: click(point='<point>10 20</point>')"
+        result = self.p.extract_tool_calls_streaming(
+            previous_text="",
+            current_text=delta,
+            delta_text=delta,
+            request={"tool_choice": "none"},
+        )
+        assert result is not None
+        assert "tool_calls" not in result
+        assert result.get("content") == delta
+
+
+# ---------------------------------------------------------------------------
+# Parser key normalization: start_box → point, end_box → end_point
+# ---------------------------------------------------------------------------
+
+
+class TestParserKeyNormalization:
+    def setup_method(self) -> None:
+        self.p = UiTarsToolParser()
+
+    def test_click_start_box_renamed_to_point(self):
+        # Ana F-R1-02: model emits ``start_box`` for single-point
+        # verbs; the spec says ``point``. Parser renames.
+        text = "Action: click(start_box='(112,126)')"
+        r = self.p.extract_tool_calls(text)
+        args = _decode_args(r.tool_calls[0])
+        assert args == {"action": "click", "point": [112, 126]}
+        assert "start_box" not in args
+
+    def test_left_double_start_box_renamed_to_point(self):
+        text = "Action: left_double(start_box='(100,200)')"
+        r = self.p.extract_tool_calls(text)
+        args = _decode_args(r.tool_calls[0])
+        assert args["action"] == "left_double"
+        assert args["point"] == [100, 200]
+
+    def test_right_single_start_box_renamed_to_point(self):
+        text = "Action: right_single(start_box='(50,75)')"
+        r = self.p.extract_tool_calls(text)
+        args = _decode_args(r.tool_calls[0])
+        assert args["action"] == "right_single"
+        assert args["point"] == [50, 75]
+
+    def test_scroll_start_box_renamed_to_point(self):
+        text = "Action: scroll(start_box='(500,400)', direction='down')"
+        r = self.p.extract_tool_calls(text)
+        args = _decode_args(r.tool_calls[0])
+        assert args == {
+            "action": "scroll",
+            "point": [500, 400],
+            "direction": "down",
+        }
+
+    def test_drag_start_box_end_box_renamed_to_start_end_point(self):
+        # Two-point verb: spec is ``start_point`` / ``end_point``,
+        # NOT ``start_box`` / ``end_box``.
+        text = "Action: drag(start_box='(100,100)', end_box='(300,500)')"
+        r = self.p.extract_tool_calls(text)
+        args = _decode_args(r.tool_calls[0])
+        assert args == {
+            "action": "drag",
+            "start_point": [100, 100],
+            "end_point": [300, 500],
+        }
+        assert "start_box" not in args
+        assert "end_box" not in args
+
+    def test_drag_native_start_end_point_pass_through(self):
+        # UI-TARS-1.0 already emits ``start_point`` / ``end_point`` —
+        # pass through unchanged.
+        text = (
+            "Action: drag(start_point='<point>1 2</point>', "
+            "end_point='<point>3 4</point>')"
+        )
+        r = self.p.extract_tool_calls(text)
+        args = _decode_args(r.tool_calls[0])
+        assert args == {
+            "action": "drag",
+            "start_point": [1, 2],
+            "end_point": [3, 4],
+        }
+
+    def test_box_sentinel_renamed_per_verb(self):
+        # UI-TARS-1.5 sentinel-token form: ``start_box='<|box_start|>
+        # (x,y)<|box_end|>'`` — same rename per verb applies.
+        text = "Action: click(start_box='<|box_start|>(233,45)<|box_end|>')"
+        r = self.p.extract_tool_calls(text)
+        args = _decode_args(r.tool_calls[0])
+        assert args == {"action": "click", "point": [233, 45]}
+
+
+# ---------------------------------------------------------------------------
+# hotkey.key normalization: "ctrl c" → "ctrl+c"
+# ---------------------------------------------------------------------------
+
+
+class TestHotkeyNormalization:
+    def setup_method(self) -> None:
+        self.p = UiTarsToolParser()
+
+    def test_space_form_normalized_to_plus(self):
+        # Ana F-R1-06: UI-TARS trains on space form; spec is plus.
+        args = _normalize_action("hotkey", {"key": "ctrl c"})
+        assert args == {"action": "hotkey", "key": "ctrl+c"}
+
+    def test_multi_modifier_chord(self):
+        args = _normalize_action("hotkey", {"key": "ctrl shift v"})
+        assert args == {"action": "hotkey", "key": "ctrl+shift+v"}
+
+    def test_already_plus_form_preserved(self):
+        # If the model already emitted plus form (rare), preserve.
+        args = _normalize_action("hotkey", {"key": "ctrl+c"})
+        assert args == {"action": "hotkey", "key": "ctrl+c"}
+
+    def test_single_key_no_chord(self):
+        # Single-key "hotkey" stays as-is (no spaces to collapse).
+        args = _normalize_action("hotkey", {"key": "enter"})
+        assert args == {"action": "hotkey", "key": "enter"}
+
+    def test_full_pipeline_via_extract_tool_calls(self):
+        text = "Action: hotkey(key='ctrl c')"
+        r = self.p.extract_tool_calls(text)
+        args = _decode_args(r.tool_calls[0])
+        assert args == {"action": "hotkey", "key": "ctrl+c"}
+
+
+# ---------------------------------------------------------------------------
+# Streaming Thought:/Action: hold-back (F-R1-04)
+# ---------------------------------------------------------------------------
+
+
+class TestStreamingThoughtHoldback:
+    """Cover the regression where the 7-char heuristic flipped the parser
+    to content on ``"Thought"`` (still a prefix of ``"Thought:"``) and
+    leaked the entire ``Thought:`` preamble into ``delta.content`` instead
+    of routing it to ``reasoning_content`` (dogfood F-R1-04).
+    """
+
+    def setup_method(self) -> None:
+        self.p = UiTarsReasoningParser()
+
+    def _stream(self, deltas: list[str]):
+        prev = ""
+        out = []
+        for d in deltas:
+            cur = prev + d
+            msg = self.p.extract_reasoning_streaming(prev, cur, d)
+            if msg is not None:
+                out.append(msg)
+            prev = cur
+        return out
+
+    def test_thought_7chars_no_colon_yet_holds(self):
+        # Token-by-token simulation of the live SSE stream: the model
+        # emits ``"Thought"`` (7 chars) BEFORE the colon arrives in
+        # the next delta. Old parser flipped to content here and
+        # leaked. New parser holds.
+        events = self._stream(["Thought"])
+        # Held back: no events emitted yet.
+        assert events == []
+
+    def test_thought_held_then_released_as_reasoning(self):
+        # Once the colon arrives the held bytes flow to reasoning
+        # alongside the new delta (not lost, not content-leaked).
+        events = self._stream(
+            [
+                "Thought",
+                ":",
+                " I need to click.\n",
+                "Action: ",
+                "click(point='<point>1 2</point>')",
+            ]
+        )
+        reasoning = "".join(e.reasoning or "" for e in events)
+        content = "".join(e.content or "" for e in events)
+        # The full Thought: preamble lands in reasoning, NOT content.
+        assert "Thought:" in reasoning
+        assert "I need to click" in reasoning
+        assert "Thought:" not in content
+        # Action: arrives in content for the tool parser.
+        assert "Action:" in content
+        # No bytes dropped.
+        assert reasoning + content == (
+            "Thought: I need to click.\nAction: click(point='<point>1 2</point>')"
+        )
+
+    @pytest.mark.parametrize(
+        "opener_prefix",
+        ["Thought", "Reflection", "Action_Summa"],
+    )
+    def test_opener_prefix_at_seven_chars_does_not_leak(self, opener_prefix: str):
+        # Any opener prefix that's longer than ``"Action:"`` (7 chars)
+        # — ``"Thought"`` 7, ``"Reflection"`` 10, ``"Action_Summa"`` 12 —
+        # must stay held until the disambiguating colon arrives.
+        # Pre-fix the 7-char gate flipped to content at this exact
+        # boundary.
+        events = self._stream([opener_prefix])
+        # Held — no events. No content leak.
+        assert events == []
+
+    def test_truly_non_opener_seven_char_buffer_flips_to_content(self):
+        # ``"Hello, w"`` is 8 chars, not a prefix of any opener — must
+        # flip to content immediately so non-preamble responses don't
+        # stall forever waiting for an opener that will never come.
+        events = self._stream(["Hello, w"])
+        assert len(events) == 1
+        assert events[0].content == "Hello, w"
+        assert events[0].reasoning is None
+
+    def test_thought_complete_in_single_delta_routes_to_reasoning(self):
+        # The fast path: a single delta carries the entire
+        # ``Thought: ...`` preamble plus the ``Action:`` boundary.
+        # All Thought bytes go to reasoning; Action bytes go to
+        # content for the tool parser.
+        events = self._stream(["Thought: I want to click.\nAction: click()"])
+        reasoning = "".join(e.reasoning or "" for e in events)
+        content = "".join(e.content or "" for e in events)
+        assert "Thought:" in reasoning
+        assert "Action:" not in reasoning
+        assert content.startswith("Action:")
+
+    def test_no_token_dropped_under_partial_opener_holdback(self):
+        # End-to-end invariant: every byte the model emitted ends up
+        # in EITHER ``reasoning`` OR ``content`` (never lost,
+        # never duplicated). Mirrors the dogfood replay where the
+        # streamed text was concatenated and asserted byte-for-byte
+        # against the non-streaming response.
+        chunks = ["Th", "oug", "ht", ":", " ok.\n", "Ac", "tion", ":", " wait()"]
+        full = "".join(chunks)
+        events = self._stream(chunks)
+        reasoning = "".join(e.reasoning or "" for e in events)
+        content = "".join(e.content or "" for e in events)
+        assert reasoning + content == full
+        assert "Thought:" in reasoning
+        assert "Action:" not in reasoning
+        assert "Action:" in content
+
+
+# ---------------------------------------------------------------------------
+# Lane parity (parser-level): same emit shape regardless of caller
+# ---------------------------------------------------------------------------
+
+
+class TestLaneParserEmitParity:
+    """The parser is shared by OAI and Anthropic lanes. As long as both
+    routes feed it the SAME messages (achieved by the shared
+    ``maybe_inject_ui_tars_system_prompt`` helper), the emitted
+    arguments are identical.
+
+    The end-to-end coord-parity assertion (different image embed paths
+    producing different model coords) is exercised by the dogfood
+    replay; here we verify the parser layer alone is lane-agnostic.
+    """
+
+    def setup_method(self) -> None:
+        self.p = UiTarsToolParser()
+
+    def test_same_raw_output_emits_same_tool_call_on_both_lanes(self):
+        raw = (
+            "Thought: Want to click the search button.\n"
+            "Action: click(start_box='(128,128)')"
+        )
+        # Two parser invocations represent the two lane paths; both
+        # go through the same code path. Verifying that the bytes
+        # emitted are byte-identical.
+        oai_result = self.p.extract_tool_calls(raw)
+        anth_result = self.p.extract_tool_calls(raw)
+        assert (
+            oai_result.tool_calls[0]["arguments"]
+            == anth_result.tool_calls[0]["arguments"]
+        )
+        args = _decode_args(oai_result.tool_calls[0])
+        assert args == {"action": "click", "point": [128, 128]}
+
+
+# ---------------------------------------------------------------------------
+# Anthropic adapter: tool_use.input carries the spec'd ``point`` shape
+# ---------------------------------------------------------------------------
+
+
+class TestAnthropicAdapterPointShape:
+    """The Anthropic adapter ``openai_to_anthropic`` just ``json.loads``
+    the OAI tool_call arguments and stuffs them into ``tool_use.input``.
+    With our parser-level rename, the Anthropic ``tool_use.input``
+    naturally carries ``point`` / ``start_point`` / ``end_point``
+    instead of ``start_box`` / ``end_box`` — closing dogfood F-R1-02
+    for the Anthropic lane.
+    """
+
+    def test_click_tool_use_input_uses_point_not_start_box(self):
+        from vllm_mlx.api.anthropic_adapter import openai_to_anthropic
+        from vllm_mlx.api.models import (
+            AssistantMessage,
+            ChatCompletionChoice,
+            ChatCompletionResponse,
+            FunctionCall,
+            ToolCall,
+        )
+
+        tc = ToolCall(
+            id="call_abc12345",
+            type="function",
+            function=FunctionCall(
+                name="computer",
+                arguments=json.dumps({"action": "click", "point": [128, 128]}),
+            ),
+        )
+        response = ChatCompletionResponse(
+            id="chatcmpl-test",
+            object="chat.completion",
+            created=1,
+            model="ui-tars-1.5-7b-4bit",
+            choices=[
+                ChatCompletionChoice(
+                    index=0,
+                    message=AssistantMessage(
+                        role="assistant", content="", tool_calls=[tc]
+                    ),
+                    finish_reason="tool_calls",
+                )
+            ],
+        )
+        anth = openai_to_anthropic(response, model="ui-tars-1.5-7b-4bit")
+        # Find the tool_use block.
+        tool_use_blocks = [b for b in anth.content if b.type == "tool_use"]
+        assert len(tool_use_blocks) == 1
+        assert tool_use_blocks[0].name == "computer"
+        # Anthropic ``tool_use.input`` carries the spec key.
+        assert tool_use_blocks[0].input == {
+            "action": "click",
+            "point": [128, 128],
+        }
+        assert "start_box" not in tool_use_blocks[0].input

--- a/tests/test_ui_tars_fixes.py
+++ b/tests/test_ui_tars_fixes.py
@@ -152,6 +152,30 @@ class TestSysPromptAutoWire:
         )
         assert out == messages
 
+    def test_inject_matches_message_object_shape(self):
+        # Codex r1 BLOCKING #1: when ``messages`` is a list of
+        # pydantic Message objects (defensive — production code
+        # paths normalize to dicts via ``extract_multimodal_content``,
+        # but some test paths and future surfaces may not), the
+        # helper must NOT prepend a plain dict that would produce a
+        # mixed-shape list downstream. Mirror the object shape via
+        # ``model_copy(update=...)`` when available.
+        from vllm_mlx.api.models import Message
+
+        msgs = [Message(role="user", content="Click.")]
+        out = maybe_inject_ui_tars_system_prompt(
+            msgs, tool_call_parser="ui_tars", tool_choice="auto"
+        )
+        assert len(out) == 2
+        # Inserted message is a Message object (same shape as the
+        # original list entries), NOT a plain dict.
+        assert isinstance(out[0], Message)
+        assert out[0].role == "system"
+        assert out[0].content == UI_TARS_COMPUTER_USE_SYSTEM_PROMPT
+        # Original user message preserved.
+        assert isinstance(out[1], Message)
+        assert out[1].role == "user"
+
     def test_anthropic_shape_system_content_blocks_detected(self):
         # System message with Anthropic-style content blocks must
         # also flow through the detector — otherwise the
@@ -294,6 +318,26 @@ class TestParserKeyNormalization:
             "start_point": [1, 2],
             "end_point": [3, 4],
         }
+
+    def test_single_point_verb_with_end_box_collapses_to_point(self):
+        # Codex r1 BLOCKING #2: a defensively-emitted ``end_box`` on a
+        # single-point verb (model variance; rare but observed) MUST
+        # collapse to the spec ``point`` key — never leak the
+        # two-point-only ``end_point`` key on a single-point verb.
+        args = _normalize_action("click", {"end_box": "(100,200)"})
+        assert args == {"action": "click", "point": [100, 200]}
+        assert "end_point" not in args
+        assert "end_box" not in args
+
+    def test_single_point_verb_first_write_wins(self):
+        # If the model emits BOTH ``point`` and ``start_box`` on a
+        # single-point verb, the first-write-wins semantics keep
+        # the dict-iteration-first kwarg and drop the duplicate.
+        args = _normalize_action(
+            "click",
+            {"point": "(50,60)", "start_box": "(70,80)"},
+        )
+        assert args == {"action": "click", "point": [50, 60]}
 
     def test_box_sentinel_renamed_per_verb(self):
         # UI-TARS-1.5 sentinel-token form: ``start_box='<|box_start|>
@@ -456,36 +500,78 @@ class TestStreamingThoughtHoldback:
 # ---------------------------------------------------------------------------
 
 
-class TestLaneParserEmitParity:
-    """The parser is shared by OAI and Anthropic lanes. As long as both
-    routes feed it the SAME messages (achieved by the shared
-    ``maybe_inject_ui_tars_system_prompt`` helper), the emitted
-    arguments are identical.
+class TestLaneInjectionParity:
+    """Dogfood F-R2-04 root-cause: pre-fix the OAI and Anthropic lanes
+    received DIFFERENT prompts (only the OAI lane saw a UI-TARS
+    sysprompt — and only when the test client pasted it themselves),
+    so the model emitted different coords across surfaces.
 
-    The end-to-end coord-parity assertion (different image embed paths
-    producing different model coords) is exercised by the dogfood
-    replay; here we verify the parser layer alone is lane-agnostic.
+    The fix is the SHARED ``maybe_inject_ui_tars_system_prompt``
+    helper wired into both ``routes/chat.py`` AND
+    ``routes/anthropic.py``. So long as both routes feed the helper
+    the same UI-TARS-bound request, the prompts they pass to the
+    engine are byte-identical AT the sysprompt level.
+
+    Codex r1 NIT #3: the prior draft of this test ran the same
+    parser instance twice on the same raw bytes — which can't
+    catch a route/adapter regression, only a parser-state
+    regression. Replace with a helper-layer test that proves both
+    routes prepend byte-identical sysprompts; end-to-end image-
+    embed parity is out of unit scope (needs a live MLX engine
+    running the actual checkpoint, covered by the dogfood replay).
     """
 
-    def setup_method(self) -> None:
-        self.p = UiTarsToolParser()
+    def test_both_lanes_get_identical_sysprompt(self):
+        # Simulate the two route paths' first call: both routes
+        # produce the SAME extracted-message dict shape via the
+        # shared ``extract_multimodal_content`` upstream. The
+        # helper produces the SAME prepended messages,
+        # byte-for-byte, on both calls.
+        user_msg = {"role": "user", "content": "Click the search button."}
+        oai_inputs = [user_msg]
+        anth_inputs = [user_msg]
+        oai_out = maybe_inject_ui_tars_system_prompt(
+            oai_inputs, tool_call_parser="ui_tars", tool_choice="auto"
+        )
+        anth_out = maybe_inject_ui_tars_system_prompt(
+            anth_inputs, tool_call_parser="ui_tars", tool_choice="auto"
+        )
+        assert oai_out == anth_out
+        assert oai_out[0]["role"] == "system"
+        assert oai_out[0]["content"] == UI_TARS_COMPUTER_USE_SYSTEM_PROMPT
 
-    def test_same_raw_output_emits_same_tool_call_on_both_lanes(self):
-        raw = (
-            "Thought: Want to click the search button.\n"
-            "Action: click(start_box='(128,128)')"
+    def test_inject_parity_under_user_sysprompt(self):
+        # Operator extends with a custom system message: same
+        # injection on both lanes — auto-injected sysprompt FIRST,
+        # user system PRESERVED, no double-injection.
+        msgs = [
+            {"role": "system", "content": "Be concise."},
+            {"role": "user", "content": "Click."},
+        ]
+        oai_out = maybe_inject_ui_tars_system_prompt(
+            list(msgs), tool_call_parser="ui_tars", tool_choice="auto"
         )
-        # Two parser invocations represent the two lane paths; both
-        # go through the same code path. Verifying that the bytes
-        # emitted are byte-identical.
-        oai_result = self.p.extract_tool_calls(raw)
-        anth_result = self.p.extract_tool_calls(raw)
-        assert (
-            oai_result.tool_calls[0]["arguments"]
-            == anth_result.tool_calls[0]["arguments"]
+        anth_out = maybe_inject_ui_tars_system_prompt(
+            list(msgs), tool_call_parser="ui_tars", tool_choice="auto"
         )
-        args = _decode_args(oai_result.tool_calls[0])
-        assert args == {"action": "click", "point": [128, 128]}
+        assert oai_out == anth_out
+        # Three messages: auto-injected + user system + user.
+        assert len(oai_out) == 3
+        assert oai_out[0]["content"] == UI_TARS_COMPUTER_USE_SYSTEM_PROMPT
+        assert oai_out[1] == {"role": "system", "content": "Be concise."}
+
+    def test_inject_parity_skips_on_tool_choice_none(self):
+        # ``tool_choice="none"`` short-circuit fires identically on
+        # both lanes — neither gets a UI-TARS sysprompt, so the
+        # model emits plain prose with no Action: lines.
+        msgs = [{"role": "user", "content": "What time is it?"}]
+        oai_out = maybe_inject_ui_tars_system_prompt(
+            list(msgs), tool_call_parser="ui_tars", tool_choice="none"
+        )
+        anth_out = maybe_inject_ui_tars_system_prompt(
+            list(msgs), tool_call_parser="ui_tars", tool_choice="none"
+        )
+        assert oai_out == anth_out == msgs
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_ui_tars_fixes.py
+++ b/tests/test_ui_tars_fixes.py
@@ -103,7 +103,12 @@ class TestSysPromptAutoWire:
     def test_skip_inject_when_user_pasted_canonical(self):
         # If the operator already pasted (a variant of) the canonical
         # sysprompt, we DON'T double-inject — respect their wording.
-        user_sys = "You are a GUI agent. Custom action space follows..."
+        # Detection requires a STRONG UI-TARS-specific marker (codex
+        # r2): use the canonical ``## Action Space`` heading here.
+        user_sys = (
+            "You are a GUI agent.\n## Action Space\n"
+            "click(point='<point>x y</point>')\nfinished()"
+        )
         messages = [
             {"role": "system", "content": user_sys},
             {"role": "user", "content": "Click."},
@@ -118,19 +123,54 @@ class TestSysPromptAutoWire:
     @pytest.mark.parametrize(
         "marker",
         [
-            "## Output Format",
+            # Header-level marker — unique to UI-TARS-class prompts.
             "## Action Space",
+            # Action-verb call signatures — model-API kwarg shape.
             "click(point=",
             "click(start_box=",
-            "You are a GUI agent — custom variant.",
+            "drag(start_point=",
+            "drag(start_box=",
+            # Joint Output Format / Action skeleton — catches
+            # forks that strip the markdown headers.
+            "Thought: ...\nAction: ...",
         ],
     )
-    def test_detect_canonical_via_any_marker(self, marker: str):
-        # Detection is permissive: any of these markers in a system
-        # message marks the operator as "already pasted (a variant of)
-        # the canonical sysprompt". Skips double-inject.
+    def test_detect_canonical_via_strong_marker(self, marker: str):
+        # Detection requires a STRONG, UI-TARS-specific marker:
+        # either the canonical section heading
+        # (``## Action Space``), a model-API kwarg call signature
+        # (``click(point=`` etc.), or the joint Output-Format
+        # skeleton. Generic markers were rejected per codex r2.
         messages = [{"role": "system", "content": f"prefix\n{marker}\nsuffix"}]
         assert has_ui_tars_system_prompt(messages) is True
+
+    @pytest.mark.parametrize(
+        "generic_sys",
+        [
+            # Codex r2 BLOCKING regression: a generic system
+            # prompt that happens to mention ``## Output Format``
+            # for JSON / markdown formatting MUST NOT skip the
+            # UI-TARS auto-inject — the pre-tightening detector
+            # would have falsely treated this as "operator already
+            # pasted UI-TARS sysprompt".
+            "## Output Format\nReturn answers as JSON.",
+            "You are a GUI agent for browser-based tasks.",
+            # A generic system prompt about agents / instructions
+            # without the UI-TARS structural markers.
+            "Follow the user's instructions step by step.",
+            "## Tools available\nclick, drag, scroll",
+        ],
+    )
+    def test_generic_system_prompt_does_not_false_positive(self, generic_sys: str):
+        messages = [{"role": "system", "content": generic_sys}]
+        assert has_ui_tars_system_prompt(messages) is False
+        # And the auto-inject still fires for a UI-TARS request that
+        # carries one of these generic system messages.
+        out = maybe_inject_ui_tars_system_prompt(
+            messages, tool_call_parser="ui_tars", tool_choice="auto"
+        )
+        assert len(out) == 2
+        assert out[0]["content"] == UI_TARS_COMPUTER_USE_SYSTEM_PROMPT
 
     def test_skip_inject_when_parser_is_not_ui_tars(self):
         # Wrong model family — no inject. Avoids polluting

--- a/tests/test_ui_tars_parser.py
+++ b/tests/test_ui_tars_parser.py
@@ -218,8 +218,21 @@ class TestNormalizeAction:
         }
 
     def test_hotkey_passthrough(self):
+        # Dogfood F-R1-06 fix: UI-TARS trains on space-separated chord
+        # syntax (``"ctrl c"``) but the documented Computer-Use spec —
+        # and every downstream computer-use runtime (xdotool,
+        # pyautogui, the Anthropic computer-tool harness) — expects
+        # plus form (``"ctrl+c"``). Normalize at the parser boundary
+        # so SDK consumers don't have to.
         args = _normalize_action("hotkey", {"key": "ctrl c"})
-        assert args == {"action": "hotkey", "key": "ctrl c"}
+        assert args == {"action": "hotkey", "key": "ctrl+c"}
+
+    def test_hotkey_plus_form_preserved(self):
+        # Already plus-shaped chord (rare — model usually emits space
+        # form) stays untouched so a runtime that accepts BOTH forms
+        # keeps working.
+        args = _normalize_action("hotkey", {"key": "ctrl+c"})
+        assert args == {"action": "hotkey", "key": "ctrl+c"}
 
     def test_unknown_verb_emitted_verbatim(self):
         # Future UI-TARS verb — preserve so we don't silently drop calls.
@@ -322,8 +335,11 @@ class TestToolParserComplete:
 
     def test_hotkey(self):
         text = "Action: hotkey(key='ctrl c')"
+        # Dogfood F-R1-06 fix: parser normalizes space-form chord to
+        # plus-form so downstream computer-use runtimes receive the
+        # spec shape.
         r = self.p.extract_tool_calls(text)
-        assert _decode(r.tool_calls[0]) == {"action": "hotkey", "key": "ctrl c"}
+        assert _decode(r.tool_calls[0]) == {"action": "hotkey", "key": "ctrl+c"}
 
     def test_type(self):
         text = "Action: type(content='hello world\\n')"
@@ -402,11 +418,16 @@ class TestToolParserComplete:
         # UI-TARS-1.5 emits ``start_box='<|box_start|>(x,y)<|box_end|>'``
         # — verified against the live mlx-community/UI-TARS-1.5-7B-4bit
         # checkpoint (2026-06-21). Coords are absolute pixel offsets.
+        # Dogfood F-R1-02 fix: the parser renames the verb-specific
+        # ``start_box`` (UI-TARS-1.5 internal) → spec ``point`` for
+        # single-point verbs like ``click``, so downstream consumers
+        # see the documented PR #812 contract regardless of which
+        # UI-TARS checkpoint produced the bytes.
         text = "Action: click(start_box='<|box_start|>(233,45)<|box_end|>')"
         r = self.p.extract_tool_calls(text)
         assert _decode(r.tool_calls[0]) == {
             "action": "click",
-            "start_box": [233, 45],
+            "point": [233, 45],
         }
 
     def test_nested_action_in_string_arg_not_double_parsed(self):

--- a/vllm_mlx/reasoning/ui_tars_parser.py
+++ b/vllm_mlx/reasoning/ui_tars_parser.py
@@ -150,6 +150,18 @@ class UiTarsReasoningParser(ReasoningParser):
                 return None
             if any(stripped.startswith(p) for p in self._PREAMBLE_OPENERS):
                 self._in_reasoning = True
+                # Dogfood F-R1-04 follow-up: bytes from PRIOR deltas
+                # that we held back (returned ``None`` for) live in
+                # ``previous_text``. Now that the opener has resolved,
+                # release them through the reasoning channel alongside
+                # this delta — otherwise the held prefix bytes would
+                # be silently dropped from the SSE stream.
+                if previous_text:
+                    # Use the slice of ``current_text`` that contains
+                    # the full opener-bearing prefix (i.e. everything
+                    # the parser has seen) so the emitted reasoning
+                    # text starts from the actual model-output start.
+                    return DeltaMessage(reasoning=previous_text + delta_text)
                 # FALLTHROUGH to the reasoning branch below — first delta
                 # of the preamble emits as reasoning.
             elif stripped.startswith("Action:"):
@@ -166,19 +178,45 @@ class UiTarsReasoningParser(ReasoningParser):
                     return DeltaMessage(content=previous_text + delta_text)
                 return DeltaMessage(content=delta_text)
             else:
-                # Buffer doesn't yet match any opener. Use the SHORTEST
-                # disambiguating prefix length — once ``len(stripped) >=
-                # len("Action:")`` (7), we know it can't be a preamble
-                # whose opener starts with ``T``/``R``/``A`` because
-                # those would have matched above. Flip to content and
-                # flush any previously held bytes alongside this delta.
-                if len(stripped) >= len("Action:"):
-                    self._in_content = True
-                    if previous_text:
-                        return DeltaMessage(content=previous_text + delta_text)
-                    return DeltaMessage(content=delta_text)
-                # Hold off — the next delta might complete a preamble.
-                return None
+                # Buffer doesn't yet match any opener. We need to wait
+                # until ``stripped`` is either long enough that NO
+                # opener prefix can match anymore, OR ``stripped`` is
+                # not even a prefix of any opener — only then can we
+                # safely flip to content.
+                #
+                # Dogfood F-R1-04 fix (Ana 2026-06-21): the previous
+                # heuristic ``len(stripped) >= len("Action:")`` was 7
+                # chars, but ``"Thought"`` is ALSO 7 chars — and at
+                # exactly that length the buffer is still the strict
+                # prefix of ``"Thought:"`` (waiting for the colon on
+                # the next delta). The old code flipped to content
+                # there and leaked ``Thought: ...`` into
+                # ``delta.content`` instead of routing it to the
+                # reasoning channel. Same hazard for ``"Reflection"``
+                # (10 chars, prefix of ``Reflection:``) and
+                # ``"Action_Summa"`` (12 chars, prefix of
+                # ``Action_Summary:``).
+                #
+                # Correct gate: flip to content ONLY when ``stripped``
+                # is NOT a prefix of any known opener AND not a prefix
+                # of ``"Action:"`` (which means it's regular content).
+                # Otherwise keep buffering — the next delta will land
+                # the colon and the opener-match branch above fires.
+                _OPENERS_PLUS_ACTION = self._PREAMBLE_OPENERS + ("Action:",)
+                still_could_be_opener = any(
+                    op.startswith(stripped) for op in _OPENERS_PLUS_ACTION
+                )
+                if still_could_be_opener:
+                    # Hold off — the next delta might complete the
+                    # opener (e.g. ``"Thought"`` → ``"Thought:"``).
+                    return None
+                # ``stripped`` is no longer a prefix of any opener —
+                # this is regular content. Flip to content and flush
+                # any previously held bytes alongside this delta.
+                self._in_content = True
+                if previous_text:
+                    return DeltaMessage(content=previous_text + delta_text)
+                return DeltaMessage(content=delta_text)
 
         # In reasoning channel. Look for the ``Action:`` boundary inside
         # this delta to decide whether to split.

--- a/vllm_mlx/reasoning/ui_tars_parser.py
+++ b/vllm_mlx/reasoning/ui_tars_parser.py
@@ -322,3 +322,35 @@ class UiTarsReasoningParser(ReasoningParser):
     def reset_state(self) -> None:
         self._in_reasoning = False
         self._in_content = False
+
+    def finalize_streaming(self, accumulated_text: str) -> DeltaMessage | None:
+        """Flush held opener-prefix bytes at end-of-stream.
+
+        Codex r5 BLOCKING: the opener-prefix hold-back loop returns
+        ``None`` when the buffer is a strict prefix of any known
+        opener (``"Thought"``, ``"Reflection"``, etc.) — waiting for
+        the disambiguating colon on a future delta. But if the
+        stream ENDS while a prefix is still held (model produced
+        plain text ``"Thought"`` with no colon, or got cut off
+        mid-token), those bytes are silently dropped.
+
+        At end-of-stream:
+        - If we never flipped channels (``_in_reasoning ==
+          _in_content == False``), every byte the model emitted is
+          still held. Flush as ``content`` — by definition the
+          buffer is NOT a complete opener (else the live loop
+          would have flipped to reasoning), so the held bytes are
+          plain text content.
+        - If we're already in a channel, the live loop has already
+          emitted everything; nothing to flush.
+        """
+        if self._in_reasoning or self._in_content:
+            return None
+        if not accumulated_text:
+            return None
+        # All emitted as content — the in-flight loop never
+        # disambiguated to an opener, so by end-of-stream this is
+        # plain content. Flip the latch so a subsequent finalize
+        # call is a no-op.
+        self._in_content = True
+        return DeltaMessage(content=accumulated_text)

--- a/vllm_mlx/routes/anthropic.py
+++ b/vllm_mlx/routes/anthropic.py
@@ -690,6 +690,25 @@ async def create_anthropic_message(
             openai_request.messages,
             preserve_native_format=engine.preserve_native_tool_format,
         )
+        # Dogfood C-05 / F-R2-04 lane parity: auto-prepend the canonical
+        # UI-TARS Computer-Use sysprompt on the Anthropic lane too so
+        # the two surfaces produce the SAME prompt for the SAME model.
+        # Pre-fix the OAI lane had the sysprompt the operator pasted
+        # (or not), and the Anthropic lane never injected anything —
+        # so the same model + image + user text produced different
+        # coordinates across surfaces (Ana F-R2-04). Single shared
+        # helper, single canonical sysprompt, single coordinate space.
+        from ..tool_parsers.ui_tars_tool_parser import (
+            maybe_inject_ui_tars_system_prompt as _maybe_inject_ui_tars_sysprompt,
+        )
+
+        _cfg_for_ui_tars = get_config()
+        messages = _maybe_inject_ui_tars_sysprompt(
+            messages,
+            tool_call_parser=_cfg_for_ui_tars.tool_call_parser,
+            tool_choice=openai_request.tool_choice,
+        )
+
         _inject_tool_use_required_suffix(
             messages,
             openai_request.tool_choice,

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -960,6 +960,23 @@ async def _create_chat_completion_impl(
             else:
                 m.role = "system"
 
+    # Dogfood C-05 fix: auto-prepend the canonical UI-TARS Computer-Use
+    # action-API system prompt for the ``ui_tars`` parser family. PR
+    # #812 wired the parser by alias regex but never injected the
+    # sysprompt the model is post-trained on — so the parser silently
+    # no-op'd on raw output. The helper is idempotent (skips when the
+    # user already pasted the sysprompt) and honors ``tool_choice=
+    # "none"`` (skips so the model emits plain prose — dogfood C-07).
+    from ..tool_parsers.ui_tars_tool_parser import (
+        maybe_inject_ui_tars_system_prompt as _maybe_inject_ui_tars_sysprompt,
+    )
+
+    messages = _maybe_inject_ui_tars_sysprompt(
+        messages,
+        tool_call_parser=cfg.tool_call_parser,
+        tool_choice=tc,
+    )
+
     # Auto-inject system prompt suffix for tool use and/or reasoning control.
     # ``tool_choice="required"`` (and the specific-function form) gets a
     # stricter suffix than the default tool-use one — the OpenAI spec
@@ -2363,7 +2380,15 @@ async def stream_chat_completion(
                         usage=None,
                     )
                     _tc_sse = f"data: {chunk.model_dump_json(exclude_none=True)}\n\n"
-                    logger.info(f"[SSE-TC] {_tc_sse.strip()[:300]}")
+                    # Dogfood F-R2-05: previously emitted at INFO, which
+                    # leaked user-action coords + tool_call JSON into the
+                    # server log on every Computer-Use turn (UI-TARS,
+                    # Anthropic computer tool, etc.). Drop to DEBUG so
+                    # the PII / telemetry path is opt-in and not on by
+                    # default. Plain INFO observability is preserved by
+                    # the existing per-request summary log at the route
+                    # tail; the per-chunk dump is debugging-only.
+                    logger.debug(f"[SSE-TC] {_tc_sse.strip()[:300]}")
                     yield _tc_sse
 
                 elif event.type == "finish":

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -2380,15 +2380,23 @@ async def stream_chat_completion(
                         usage=None,
                     )
                     _tc_sse = f"data: {chunk.model_dump_json(exclude_none=True)}\n\n"
-                    # Dogfood F-R2-05: previously emitted at INFO, which
-                    # leaked user-action coords + tool_call JSON into the
-                    # server log on every Computer-Use turn (UI-TARS,
-                    # Anthropic computer tool, etc.). Drop to DEBUG so
-                    # the PII / telemetry path is opt-in and not on by
-                    # default. Plain INFO observability is preserved by
-                    # the existing per-request summary log at the route
-                    # tail; the per-chunk dump is debugging-only.
-                    logger.debug(f"[SSE-TC] {_tc_sse.strip()[:300]}")
+                    # Dogfood F-R2-05 + codex r5 NIT #3: previously
+                    # emitted at INFO, which leaked user-action coords
+                    # + tool_call JSON into the server log on every
+                    # Computer-Use turn (UI-TARS, Anthropic computer
+                    # tool, etc.). Now DEBUG, AND redacted: log only
+                    # the chunk metadata (tool_call count + finish
+                    # reason), never the raw ``arguments`` JSON.
+                    # Operators who need full payloads can capture
+                    # the wire stream upstream; the application log
+                    # should not be a covert PII channel.
+                    _tc_count = len(event.tool_calls or [])
+                    _tc_finish = event.finish_reason or "-"
+                    logger.debug(
+                        "[SSE-TC] tool_calls.count=%d finish_reason=%s",
+                        _tc_count,
+                        _tc_finish,
+                    )
                     yield _tc_sse
 
                 elif event.type == "finish":

--- a/vllm_mlx/service/postprocessor.py
+++ b/vllm_mlx/service/postprocessor.py
@@ -2648,6 +2648,41 @@ class StreamingPostProcessor:
                     )
                     self.tool_calls_detected = True
 
+        # Dogfood F-R1-04 (codex r5 BLOCKING): UI-TARS reasoning
+        # parser-specific EOF flush. The opener-prefix hold-back
+        # logic returns ``None`` (no event) while the buffer is a
+        # strict prefix of a known opener — ``"Thought"`` waiting
+        # for the colon, ``"Reflection"`` waiting, etc. If the
+        # stream ends mid-prefix (e.g. ``max_tokens`` truncation
+        # mid-token, or the model genuinely produced bare
+        # ``"Thought"`` text), those bytes are otherwise silently
+        # dropped at EOF. Mirror the ``tool_parser.flush_held_content``
+        # pattern below but scope it to the UI-TARS reasoning
+        # parser specifically — other reasoning parsers
+        # (``qwen3`` / ``deepseek_r1`` / ``gemma4``) have their own
+        # ``finalize_streaming`` semantics tied to specific call
+        # sites that this generic hook would clash with.
+        if (
+            self.reasoning_parser is not None
+            and self.accumulated_text
+            and type(self.reasoning_parser).__name__ == "UiTarsReasoningParser"
+        ):
+            try:
+                final_msg = self.reasoning_parser.finalize_streaming(
+                    self.accumulated_text
+                )
+            except Exception as e:
+                logger.warning(
+                    "UI-TARS finalize_streaming raised: %s — any held "
+                    "trailing bytes will not be flushed for this request",
+                    e,
+                )
+                final_msg = None
+            if final_msg is not None:
+                final_content = getattr(final_msg, "content", None)
+                if isinstance(final_content, str) and final_content:
+                    events.append(StreamEvent(type="content", content=final_content))
+
         # Release any prefix-held content trailing the stream. Hermes
         # and harmony streaming parsers hold back partial sentinel
         # suffixes (``<``, ``<|``, ``<func``...) so per-char streaming

--- a/vllm_mlx/service/postprocessor.py
+++ b/vllm_mlx/service/postprocessor.py
@@ -2679,6 +2679,11 @@ class StreamingPostProcessor:
                 )
                 final_msg = None
             if final_msg is not None:
+                final_reasoning = getattr(final_msg, "reasoning", None)
+                if isinstance(final_reasoning, str) and final_reasoning:
+                    events.append(
+                        StreamEvent(type="reasoning", reasoning=final_reasoning)
+                    )
                 final_content = getattr(final_msg, "content", None)
                 if isinstance(final_content, str) and final_content:
                     events.append(StreamEvent(type="content", content=final_content))

--- a/vllm_mlx/tool_parsers/ui_tars_tool_parser.py
+++ b/vllm_mlx/tool_parsers/ui_tars_tool_parser.py
@@ -172,11 +172,34 @@ def maybe_inject_ui_tars_system_prompt(
     if has_ui_tars_system_prompt(messages):
         return messages
 
-    sys_msg = {"role": "system", "content": UI_TARS_COMPUTER_USE_SYSTEM_PROMPT}
-    # Find the FIRST non-system slot — auto-injected sysprompt lands
-    # BEFORE any user-supplied system message so it primes the model
-    # FIRST and the user's content extends (rather than overrides) the
-    # action-API contract. If no system is present, insert at index 0.
+    # Codex r1 BLOCKING #1: build the inserted message in the SAME
+    # shape as the existing list so we don't produce a mixed
+    # ``dict``/Message-object collection downstream. Production code
+    # path always normalizes ``messages`` to dicts before reaching
+    # this helper (``extract_multimodal_content`` returns dicts on
+    # both lanes), but the developer→system normalization in
+    # ``routes/chat.py`` has a defensive object-handling branch —
+    # we mirror that defense here. ``model_copy`` is preferred over
+    # type construction so a pydantic subclass (custom Message
+    # variant) round-trips its own type.
+    sys_msg: Any
+    if messages and not isinstance(messages[0], dict):
+        first = messages[0]
+        first_copy = getattr(first, "model_copy", None)
+        if callable(first_copy):
+            sys_msg = first_copy(
+                update={"role": "system", "content": UI_TARS_COMPUTER_USE_SYSTEM_PROMPT}
+            )
+        else:
+            sys_msg = {
+                "role": "system",
+                "content": UI_TARS_COMPUTER_USE_SYSTEM_PROMPT,
+            }
+    else:
+        sys_msg = {"role": "system", "content": UI_TARS_COMPUTER_USE_SYSTEM_PROMPT}
+    # Auto-injected sysprompt lands at index 0 so it primes the model
+    # FIRST and any user-supplied system message extends (rather than
+    # overrides) the action-API contract.
     return [sys_msg, *messages]
 
 
@@ -587,15 +610,16 @@ def _spec_key_for(verb: str, model_key: str) -> str:
       won't get its kwargs silently renamed).
     """
     if verb in _SINGLE_POINT_VERBS:
-        if model_key in ("start_box", "start_point"):
-            return "point"
-        if model_key in ("end_box", "end_point"):
-            # Unusual but possible: model emitted both. Don't
-            # collide with an already-renamed ``point`` — drop the
-            # ``end_*`` for single-point verbs. The caller filters
-            # this case (preserves first-write-wins semantics).
-            return "end_point"
-        return model_key  # ``point`` passes through.
+        # Codex r1 BLOCKING #2: single-point verbs ALWAYS emit the
+        # spec ``point`` key. The earlier draft mapped
+        # ``end_box``/``end_point`` to ``end_point`` for single-point
+        # verbs — but the spec says single-point verbs MUST NOT carry
+        # a two-point key. Coalesce every coord kwarg to ``point``;
+        # the caller's first-write-wins guard then keeps the most
+        # informative value (model rarely emits both, but if it does
+        # the FIRST kwarg in dict-iteration order wins — typically
+        # ``point`` > ``start_box`` > ``end_box``).
+        return "point"
     if verb in _TWO_POINT_VERBS:
         if model_key == "start_box":
             return "start_point"

--- a/vllm_mlx/tool_parsers/ui_tars_tool_parser.py
+++ b/vllm_mlx/tool_parsers/ui_tars_tool_parser.py
@@ -111,19 +111,49 @@ UI_TARS_COMPUTER_USE_SYSTEM_PROMPT = (
 )
 
 
-# Sentinel substrings that, if present in any user-supplied system
-# message, mark the operator as already having pasted (a variant of)
-# the canonical UI-TARS sysprompt — in which case we DO NOT prepend
-# the built-in one. Detection is intentionally permissive ("did the
-# operator mention the Action Space at all?") because every UI-TARS
-# fork in the wild carries one of these tokens. A strict match would
-# fail-open for benign reshuffles of the same prompt.
+# Sentinel substrings used to detect that an operator-supplied system
+# message ALREADY carries (a variant of) the canonical UI-TARS
+# sysprompt — in which case the auto-prepend is a no-op so we don't
+# double-inject.
+#
+# Codex r2 BLOCKING (2026-06-21): the earlier draft accepted
+# ``"## Output Format"`` or ``"You are a GUI agent"`` as evidence
+# alone — both are too generic. A non-UI-TARS request whose system
+# message happened to say "## Output Format: ...JSON..." would skip
+# the inject and regress to raw prose / no tool calls.
+#
+# Tightened contract: detection requires BOTH a header-level marker
+# (``"## Action Space"`` — present in every fork of the canonical
+# UI-TARS prompt, and a phrase no general-purpose system message
+# carries) OR a literal action-verb call signature
+# (``click(point=``, ``click(start_box=``, ``drag(start_point=``)
+# whose presence is mechanically the model-API kwarg shape.
+# Header-alone hits + verb-alone hits both qualify; we don't AND
+# them, because UI-TARS forks come in two flavors: full-prompt
+# variants ship the ``## Action Space`` header; minimal variants
+# ship only the verb-list table without the markdown headers.
 _UI_TARS_SYSPROMPT_MARKERS: tuple[str, ...] = (
+    # Header-level marker — unique to UI-TARS-class prompts; the
+    # exact heading appears in every upstream fork of
+    # ``codes/ui_tars/prompt.py``. Generic markdown formatting
+    # instructions don't write this section heading.
     "## Action Space",
-    "## Output Format",
+    # Action-verb call signatures: structural model-API kwarg
+    # shapes that only a UI-TARS sysprompt would carry verbatim.
+    # The space-and-paren forms make these robust against shuffled
+    # whitespace.
     "click(point=",
     "click(start_box=",
-    "You are a GUI agent",
+    "drag(start_point=",
+    "drag(start_box=",
+    # Joint check — the canonical opener PLUS the next-line
+    # ``Action`` keyword from the ``Output Format`` block. This
+    # AND-shape catches forks that strip the ``## Action Space``
+    # header but keep the ``Thought: ... / Action: ...`` skeleton.
+    # (Implemented as substring of the joint phrase rather than a
+    # boolean AND because string-contains is O(1) per marker and
+    # keeps the detector single-pass.)
+    "Thought: ...\nAction: ...",
 )
 
 

--- a/vllm_mlx/tool_parsers/ui_tars_tool_parser.py
+++ b/vllm_mlx/tool_parsers/ui_tars_tool_parser.py
@@ -70,6 +70,147 @@ logger = logging.getLogger(__name__)
 COMPUTER_TOOL_NAME = "computer"
 
 
+# Canonical UI-TARS Computer-Use action-API system prompt. Sourced
+# verbatim (with the ``{language}`` / ``{instruction}`` placeholders
+# stripped — we render only the static action-space contract so the
+# user-supplied turn stays intact) from upstream
+# https://github.com/bytedance/UI-TARS/blob/main/codes/ui_tars/prompt.py
+# ``COMPUTER_USE_DOUBAO``. The model is post-trained on this exact
+# wire format — without it the parser silently no-ops on raw output
+# (dogfood C-05). Auto-prepended on the chat lane when the loaded
+# alias's ``tool_call_parser == "ui_tars"`` AND the request didn't
+# already include a UI-TARS preamble. Users CAN extend by supplying
+# their own ``system`` message — the auto-injected sysprompt lands
+# FIRST and the user's system content is appended (operator default:
+# auto-injected sysprompt wins; user system is additive).
+UI_TARS_COMPUTER_USE_SYSTEM_PROMPT = (
+    "You are a GUI agent. You are given a task and your action history, "
+    "with screenshots. You need to perform the next action to complete the task.\n\n"
+    "## Output Format\n"
+    "```\n"
+    "Thought: ...\n"
+    "Action: ...\n"
+    "```\n\n"
+    "## Action Space\n"
+    "click(point='<point>x1 y1</point>')\n"
+    "left_double(point='<point>x1 y1</point>')\n"
+    "right_single(point='<point>x1 y1</point>')\n"
+    "drag(start_point='<point>x1 y1</point>', end_point='<point>x2 y2</point>')\n"
+    "hotkey(key='ctrl c')\n"
+    "type(content='xxx') # Use escape characters \\\\', \\\\\", and \\\\n in content "
+    "part to ensure we can parse the content in normal python string format. "
+    "If you want to submit your input, use \\\\n at the end of content.\n"
+    "scroll(point='<point>x1 y1</point>', direction='down or up or right or left')\n"
+    "wait() # Sleep for 5s and take a screenshot to check for any changes.\n"
+    "finished(content='xxx') # Use escape characters \\\\', \\\\\", and \\\\n in content "
+    "part to ensure we can parse the content in normal python string format.\n\n"
+    "## Note\n"
+    "- Use English in `Thought` part.\n"
+    "- Write a small plan and finally summarize your next action (with its target "
+    "element) in one sentence in `Thought` part."
+)
+
+
+# Sentinel substrings that, if present in any user-supplied system
+# message, mark the operator as already having pasted (a variant of)
+# the canonical UI-TARS sysprompt — in which case we DO NOT prepend
+# the built-in one. Detection is intentionally permissive ("did the
+# operator mention the Action Space at all?") because every UI-TARS
+# fork in the wild carries one of these tokens. A strict match would
+# fail-open for benign reshuffles of the same prompt.
+_UI_TARS_SYSPROMPT_MARKERS: tuple[str, ...] = (
+    "## Action Space",
+    "## Output Format",
+    "click(point=",
+    "click(start_box=",
+    "You are a GUI agent",
+)
+
+
+def maybe_inject_ui_tars_system_prompt(
+    messages: list,
+    *,
+    tool_call_parser: str | None,
+    tool_choice: Any = None,
+) -> list:
+    """Auto-prepend the canonical UI-TARS sysprompt to ``messages`` when needed.
+
+    Dogfood C-05 fix: PR #812 auto-wired the ``ui_tars`` parser to the
+    UI-TARS alias family but the chat-completions / messages routes
+    never injected the canonical action-API system prompt. The parser
+    then silently no-op'd on raw model output because the model never
+    saw the ``## Output Format`` / ``## Action Space`` contract it was
+    post-trained on. This helper closes the gap: every UI-TARS request
+    (parser == ``"ui_tars"``) gets the canonical sysprompt prepended.
+
+    Operator design choice: auto-injected sysprompt wins; a user-
+    supplied ``system`` message is preserved as-is and APPENDED after
+    the auto-injected one (additive, not overriding). This matches the
+    PR #812 contract that "the alias just works" while leaving the
+    operator a knob to extend / constrain the action space.
+
+    Skip conditions (no injection):
+    1. ``tool_call_parser != "ui_tars"`` — wrong model family.
+    2. ``tool_choice == "none"`` — dogfood C-07 fix: the caller is
+       requesting a text-only turn (e.g. for planning / debugging /
+       asking the user). Prepending the action-API sysprompt would
+       prime the model to emit ``Action: ...`` lines anyway, which
+       the parser would then surface as a tool_call — violating
+       OpenAI spec for ``tool_choice="none"``. Skipping the inject
+       collapses the model into plain prose mode.
+    3. The user already pasted (a variant of) the canonical
+       sysprompt — ``has_ui_tars_system_prompt`` returns True. We
+       respect the operator's preferred wording verbatim.
+
+    Returns the (possibly prepended) ``messages`` list. The caller's
+    reference is mutated only when a new message is inserted.
+    """
+    if tool_call_parser != "ui_tars":
+        return messages
+    if tool_choice == "none":
+        return messages
+    if has_ui_tars_system_prompt(messages):
+        return messages
+
+    sys_msg = {"role": "system", "content": UI_TARS_COMPUTER_USE_SYSTEM_PROMPT}
+    # Find the FIRST non-system slot — auto-injected sysprompt lands
+    # BEFORE any user-supplied system message so it primes the model
+    # FIRST and the user's content extends (rather than overrides) the
+    # action-API contract. If no system is present, insert at index 0.
+    return [sys_msg, *messages]
+
+
+def has_ui_tars_system_prompt(messages: list) -> bool:
+    """Return True if any ``system`` message already contains a UI-TARS preamble.
+
+    Used by the chat / anthropic routes to decide whether to prepend the
+    canonical sysprompt. The detector inspects ``str`` content directly
+    and stringifies list-of-blocks content (Anthropic shape) so a
+    multimodal system message with ``[{"type":"text","text":...}]``
+    is still scanned.
+    """
+    for m in messages:
+        role = m.get("role") if isinstance(m, dict) else getattr(m, "role", None)
+        if role != "system":
+            continue
+        content = m.get("content") if isinstance(m, dict) else getattr(m, "content", "")
+        if isinstance(content, list):
+            for block in content:
+                text = (
+                    block.get("text")
+                    if isinstance(block, dict)
+                    else getattr(block, "text", "")
+                )
+                if isinstance(text, str) and any(
+                    marker in text for marker in _UI_TARS_SYSPROMPT_MARKERS
+                ):
+                    return True
+        elif isinstance(content, str):
+            if any(marker in content for marker in _UI_TARS_SYSPROMPT_MARKERS):
+                return True
+    return False
+
+
 # Verbs UI-TARS may emit. The set is a superset of the desktop
 # (``COMPUTER_USE_DOUBAO``) and mobile (``MOBILE_USE_DOUBAO``) action
 # spaces in ``codes/ui_tars/prompt.py``. Verbs not in this set are still
@@ -144,6 +285,20 @@ _BBOX_TAGGED = re.compile(
 _BOX_SENTINEL = re.compile(
     r"<\|box_start\|>\s*(\([^)]+\)(?:\s*,\s*\([^)]+\))?)\s*<\|box_end\|>"
 )
+
+
+def _is_tool_choice_none(request: dict[str, Any] | None) -> bool:
+    """Return True if ``request.tool_choice`` is OpenAI's ``"none"`` sentinel.
+
+    The parser uses this to short-circuit tool emission for both the
+    non-streaming and streaming paths so a model that still produced
+    ``Action: ...`` text (e.g. operator-supplied UI-TARS sysprompt,
+    quantization variance) doesn't bypass the OpenAI spec for
+    ``tool_choice="none"``. Dogfood C-07.
+    """
+    if not isinstance(request, dict):
+        return False
+    return request.get("tool_choice") == "none"
 
 
 def _generate_tool_id() -> str:
@@ -368,6 +523,91 @@ def _parse_kwargs_lenient(body: str) -> dict[str, Any]:
     return out
 
 
+# Coordinate kwargs the model may emit. Both upstream UI-TARS-1.0
+# (``point`` / ``start_point`` / ``end_point``) and UI-TARS-1.5
+# (``start_box`` / ``end_box``) are accepted on input; the parser
+# normalizes everything to the SPEC keys on output (``point`` for
+# single-point verbs, ``start_point`` / ``end_point`` for two-point
+# verbs). This decouples downstream consumers from per-checkpoint
+# kwarg drift — same OpenAI/Anthropic tool_call shape regardless of
+# which UI-TARS variant produced the bytes.
+_COORD_KEYS: tuple[str, ...] = (
+    "point",
+    "start_point",
+    "end_point",
+    "start_box",
+    "end_box",
+)
+
+# Verbs that take a SINGLE point argument. All single-point variants
+# (whether the model wrote ``point=`` or ``start_box=``) collapse to
+# the spec ``point`` key. Verbs not in this set and not in the
+# two-point set below preserve whatever key the model emitted (after
+# the box→point rename below).
+_SINGLE_POINT_VERBS: frozenset[str] = frozenset(
+    {
+        "click",
+        "left_double",
+        "right_single",
+        "scroll",
+        "hover",
+        "tap",
+        "long_press",
+    }
+)
+
+# Verbs that take a TWO-point (start + end) argument. Both
+# ``start_box`` / ``end_box`` and ``start_point`` / ``end_point``
+# inputs collapse to the spec ``start_point`` / ``end_point`` keys.
+_TWO_POINT_VERBS: frozenset[str] = frozenset({"drag", "select", "swipe"})
+
+
+def _spec_key_for(verb: str, model_key: str) -> str:
+    """Translate a model-emitted coord kwarg name to the SPEC key.
+
+    The model speaks ``start_box`` / ``end_box`` (UI-TARS-1.5) OR
+    ``point`` / ``start_point`` / ``end_point`` (UI-TARS-1.0). The
+    spec — and PR #812's contract — is ``point`` / ``start_point`` /
+    ``end_point``. We rename based on the verb so the OpenAI/Anthropic
+    consumer sees a single canonical shape regardless of model
+    variant.
+
+    Renames applied (verb-aware):
+    - Single-point verbs (``click`` / ``scroll`` / …):
+      ``start_box`` → ``point``; ``point`` and ``start_point`` are
+      kept as ``point``; ``end_box`` / ``end_point`` are dropped to
+      ``point`` only if no single ``point`` was already present
+      (defensive — these shouldn't appear on single-point verbs).
+    - Two-point verbs (``drag`` / ``select`` / …):
+      ``start_box`` → ``start_point``; ``end_box`` → ``end_point``;
+      ``point`` → ``start_point`` (lone-point form for two-point
+      verbs — model variant; rare).
+    - Other / unknown verbs: preserve the model's choice (rare
+      future-proofing — a UI-TARS-2.0 verb we haven't enumerated
+      won't get its kwargs silently renamed).
+    """
+    if verb in _SINGLE_POINT_VERBS:
+        if model_key in ("start_box", "start_point"):
+            return "point"
+        if model_key in ("end_box", "end_point"):
+            # Unusual but possible: model emitted both. Don't
+            # collide with an already-renamed ``point`` — drop the
+            # ``end_*`` for single-point verbs. The caller filters
+            # this case (preserves first-write-wins semantics).
+            return "end_point"
+        return model_key  # ``point`` passes through.
+    if verb in _TWO_POINT_VERBS:
+        if model_key == "start_box":
+            return "start_point"
+        if model_key == "end_box":
+            return "end_point"
+        if model_key == "point":
+            return "start_point"
+        return model_key  # ``start_point`` / ``end_point`` pass through.
+    # Unknown verb: emit whatever the model said.
+    return model_key
+
+
 def _normalize_action(verb: str, kwargs: dict[str, Any]) -> dict[str, Any]:
     """Map a parsed (verb, kwargs) pair to the canonical computer-tool args.
 
@@ -375,17 +615,53 @@ def _normalize_action(verb: str, kwargs: dict[str, Any]) -> dict[str, Any]:
 
     Point-bearing kwargs (``point``, ``start_point``, ``end_point``,
     ``start_box``, ``end_box``) are normalized to integer lists when the
-    coordinate body parses cleanly. Other kwargs pass through untouched.
-    Unknown verbs are NOT rejected — emit them verbatim so a future
-    UI-TARS-2.0 verb doesn't get dropped during the upgrade window.
+    coordinate body parses cleanly. Coord KEYS are renamed via
+    ``_spec_key_for`` so single-point verbs emit ``point`` and two-point
+    verbs emit ``start_point`` / ``end_point`` — independent of which
+    UI-TARS checkpoint generated the wire bytes (PR #812 contract).
+
+    The ``hotkey`` ``key`` argument is also normalized: UI-TARS emits
+    space-separated chords (``"ctrl c"``) but the documented spec — and
+    every downstream computer-use runtime — expects plus-separated
+    chords (``"ctrl+c"``). The translation is lossless and reversible
+    so a runtime that ALSO accepts the space form keeps working.
+
+    Other kwargs pass through untouched. Unknown verbs are NOT
+    rejected — emit them verbatim so a future UI-TARS-2.0 verb doesn't
+    get dropped during the upgrade window.
     """
     out: dict[str, Any] = {"action": verb}
-    _COORD_KEYS = ("point", "start_point", "end_point", "start_box", "end_box")
+    # Track which spec keys have already been written so a model that
+    # emits BOTH ``point=...`` and ``start_box=...`` on a single-point
+    # verb doesn't double-write the same canonical key (first-wins).
+    written: set[str] = set()
     for key, value in kwargs.items():
-        if key in _COORD_KEYS and isinstance(value, str):
-            parsed = _parse_point(value)
-            if parsed is not None:
-                out[key] = parsed
+        if key in _COORD_KEYS:
+            spec_key = _spec_key_for(verb, key)
+            if spec_key in written:
+                # Already populated by an earlier (typically more
+                # canonical) kwarg. Don't clobber.
+                continue
+            if isinstance(value, str):
+                parsed = _parse_point(value)
+                if parsed is not None:
+                    out[spec_key] = parsed
+                    written.add(spec_key)
+                    continue
+            out[spec_key] = value
+            written.add(spec_key)
+            continue
+        # ``hotkey.key``: rewrite space-separated chord to plus-form
+        # so downstream computer-use runtimes (xdotool, pyautogui,
+        # the Anthropic computer-tool harness) receive the documented
+        # shape. The model trained on space form, so normalization
+        # happens at the parser boundary, not on the model side.
+        if verb == "hotkey" and key == "key" and isinstance(value, str):
+            stripped = value.strip()
+            if stripped and "+" not in stripped:
+                # Collapse runs of whitespace into a single ``+``
+                # (matches how xdotool / pyautogui name keys).
+                out[key] = "+".join(stripped.split())
                 continue
         out[key] = value
     return out
@@ -463,8 +739,21 @@ class UiTarsToolParser(ToolParser):
         Empty / no-action input passes through with ``tools_called=False``
         and the original text as ``content`` so non-action prose
         (e.g. ``call_user()`` rejection messages) isn't lost.
+
+        Dogfood C-07: when ``request.tool_choice == "none"`` the caller
+        is opting OUT of tool emission. Even if the model still
+        produced an ``Action:`` line (e.g. because the operator pasted
+        the UI-TARS sysprompt and the route-level skip didn't fire),
+        suppress the tool_call shape and surface the raw bytes as
+        ``content`` so the OpenAI spec contract — "no tool_calls on
+        tool_choice=none" — holds.
         """
         if not model_output or "Action:" not in model_output:
+            return ExtractedToolCallInformation(
+                tools_called=False, tool_calls=[], content=model_output
+            )
+
+        if _is_tool_choice_none(request):
             return ExtractedToolCallInformation(
                 tools_called=False, tool_calls=[], content=model_output
             )
@@ -532,7 +821,15 @@ class UiTarsToolParser(ToolParser):
         - No ``Action:`` seen yet — passthrough delta as content so the
           ``Thought:`` preamble streams to the reasoning channel via the
           reasoning parser (which sees the same delta).
+
+        Dogfood C-07: ``tool_choice=none`` short-circuits to
+        passthrough — never emit a streaming ``tool_calls`` chunk so
+        the OpenAI streaming spec for ``tool_choice=none`` ("no
+        tool_calls in any delta") holds even if the model still emits
+        ``Action:`` bytes.
         """
+        if _is_tool_choice_none(request):
+            return {"content": delta_text}
         if "Action:" not in current_text:
             return {"content": delta_text}
 

--- a/vllm_mlx/tool_parsers/ui_tars_tool_parser.py
+++ b/vllm_mlx/tool_parsers/ui_tars_tool_parser.py
@@ -614,6 +614,28 @@ _SINGLE_POINT_VERBS: frozenset[str] = frozenset(
 # inputs collapse to the spec ``start_point`` / ``end_point`` keys.
 _TWO_POINT_VERBS: frozenset[str] = frozenset({"drag", "select", "swipe"})
 
+# Known chord-modifier prefixes. ``_normalize_action`` uses this set
+# to decide whether to rewrite ``hotkey(key='X Y')`` → ``"X+Y"``.
+# Only ``"<modifier> <key>"`` forms get the rewrite; single key names
+# that contain a space (``"page down"``, ``"arrow up"``, ``"caps
+# lock"``) are pass-through. Codex r5 NIT #2.
+_HOTKEY_MODIFIERS: frozenset[str] = frozenset(
+    {
+        "ctrl",
+        "control",
+        "shift",
+        "alt",
+        "option",
+        "opt",
+        "cmd",
+        "command",
+        "meta",
+        "win",
+        "super",
+        "fn",
+    }
+)
+
 
 def _spec_key_for(verb: str, model_key: str) -> str:
     """Translate a model-emitted coord kwarg name to the SPEC key.
@@ -715,13 +737,22 @@ def _normalize_action(verb: str, kwargs: dict[str, Any]) -> dict[str, Any]:
         # the Anthropic computer-tool harness) receive the documented
         # shape. The model trained on space form, so normalization
         # happens at the parser boundary, not on the model side.
+        #
+        # codex r5 NIT #2: only rewrite when the first whitespace
+        # token is a known modifier — ``"ctrl c"``, ``"shift tab"``,
+        # ``"alt f4"``, etc. — so single-key names that contain a
+        # space (``"page down"``, ``"arrow up"``, ``"caps lock"``)
+        # are passed through unchanged. The chord form ALWAYS leads
+        # with a modifier; single key names never do.
         if verb == "hotkey" and key == "key" and isinstance(value, str):
             stripped = value.strip()
             if stripped and "+" not in stripped:
-                # Collapse runs of whitespace into a single ``+``
-                # (matches how xdotool / pyautogui name keys).
-                out[key] = "+".join(stripped.split())
-                continue
+                tokens = stripped.split()
+                if len(tokens) > 1 and tokens[0].lower() in _HOTKEY_MODIFIERS:
+                    # Collapse runs of whitespace into a single ``+``
+                    # (matches how xdotool / pyautogui name keys).
+                    out[key] = "+".join(tokens)
+                    continue
         out[key] = value
     return out
 

--- a/vllm_mlx/tool_parsers/ui_tars_tool_parser.py
+++ b/vllm_mlx/tool_parsers/ui_tars_tool_parser.py
@@ -197,7 +197,12 @@ def maybe_inject_ui_tars_system_prompt(
     """
     if tool_call_parser != "ui_tars":
         return messages
-    if tool_choice == "none":
+    # Codex r5 NIT #2: accept both raw string and request-dict shapes.
+    # _is_tool_choice_none handles the request-dict path; mirror its
+    # string-arm here so both call shapes converge on the same check.
+    if tool_choice == "none" or _is_tool_choice_none(
+        tool_choice if isinstance(tool_choice, dict) else None
+    ):
         return messages
     if has_ui_tars_system_prompt(messages):
         return messages

--- a/vllm_mlx/tool_parsers/ui_tars_tool_parser.py
+++ b/vllm_mlx/tool_parsers/ui_tars_tool_parser.py
@@ -655,9 +655,14 @@ def _spec_key_for(verb: str, model_key: str) -> str:
             return "start_point"
         if model_key == "end_box":
             return "end_point"
-        if model_key == "point":
-            return "start_point"
-        return model_key  # ``start_point`` / ``end_point`` pass through.
+        # Codex r3 NIT: do NOT silently rename a lone ``point=`` on a
+        # two-point verb (``drag``, ``select``) to ``start_point``.
+        # That would turn a malformed ``drag(point='...')`` (missing
+        # the end target) into a valid-looking partial drag, masking
+        # an upstream validation opportunity. Preserve ``point`` so
+        # the downstream consumer can detect the malformed shape and
+        # surface a clear error.
+        return model_key  # ``start_point`` / ``end_point`` / ``point`` pass through.
     # Unknown verb: emit whatever the model said.
     return model_key
 
@@ -802,12 +807,23 @@ class UiTarsToolParser(ToolParser):
         ``content`` so the OpenAI spec contract — "no tool_calls on
         tool_choice=none" — holds.
         """
-        if not model_output or "Action:" not in model_output:
+        # Codex r3 BLOCKING #2: ``_is_tool_choice_none`` check MUST
+        # run BEFORE the ``"Action:" not in model_output`` early
+        # return — otherwise a case-variant ``action:`` (lowercase)
+        # or a malformed marker the early-return branch already
+        # accepts as "no tool calls" would skip the no-tools
+        # contract and slip through the original semantics rather
+        # than explicitly enforcing it. Promote the C-07 short-
+        # circuit to the FIRST decision so the contract holds for
+        # every shape of model output.
+        if _is_tool_choice_none(request):
             return ExtractedToolCallInformation(
-                tools_called=False, tool_calls=[], content=model_output
+                tools_called=False,
+                tool_calls=[],
+                content=model_output or "",
             )
 
-        if _is_tool_choice_none(request):
+        if not model_output or "Action:" not in model_output:
             return ExtractedToolCallInformation(
                 tools_called=False, tool_calls=[], content=model_output
             )


### PR DESCRIPTION
Closes the five UI-TARS regressions Ana surfaced in the 0.8.5 dogfood (`/tmp/dogfood-085/ana-r1.md` + `ana-r2.md`).

## Summary

- **C-05 (CRIT)** — UI-TARS Computer-Use system prompt is now auto-prepended on both the OpenAI chat lane and the Anthropic `/v1/messages` lane. PR #812 wired the parsers but never injected the action-API contract the model is post-trained on, so the parser silently no-op'd on raw model output. The shared `maybe_inject_ui_tars_system_prompt` helper handles idempotency (skips when the operator already pasted a variant of the canonical sysprompt) and the additive-extend operator policy (auto-injected sysprompt wins; user system message is appended).
- **C-07 (CRIT)** — `tool_choice="none"` is now honored. Two-layer fix: (a) REQUEST-time, the sysprompt helper skips inject so the model produces plain prose instead of `Action:` lines; (b) RESPONSE-time, a defensive parser short-circuit so even an operator-pasted-sysprompt path produces `tool_calls=[]` and surfaces raw bytes as `content`.
- **Parser keys** — `start_box` → `point` (single-point verbs: `click`, `left_double`, `right_single`, `scroll`, …); `start_box` / `end_box` → `start_point` / `end_point` (two-point verbs: `drag`, `select`, `swipe`). The verb-aware rename closes the PR #812 spec contract regardless of which UI-TARS checkpoint produced the wire bytes (1.0 native `point` form passes through untouched). Single-point verbs ALWAYS collapse every coord kwarg to `point` (codex r1 BLOCKING #2 — even a defensively-emitted `end_box` on `click` lands as `point`).
- **Streaming Thought: leak** — the partial-opener hold-back gate is now opener-prefix-aware. Pre-fix the 7-char heuristic flipped the parser to content on `"Thought"` (still a strict prefix of `"Thought:"` waiting for the colon), leaking `Thought: ...` and `Action:` markers into `delta.content`. The new gate holds until `stripped` is no longer a prefix of any known opener (`Thought:` / `Reflection:` / `Action_Summary:` / `Action:`).
- **Lane coord parity** — same fix as C-05. Pre-fix only the OAI lane saw the sysprompt (when the test client pasted it manually); the Anthropic lane never injected anything. The shared helper now runs on BOTH routes so the model receives the same prompt regardless of which adapter wraps the call.
- **`hotkey.key`** — UI-TARS trains on space form (`"ctrl c"`); spec is plus form (`"ctrl+c"`). Lossless rewrite at the parser boundary so xdotool / pyautogui / Anthropic computer-tool harness all receive the documented shape.
- **`[SSE-TC]` log leak** — dropped from INFO to DEBUG. The per-chunk dump echoed user-action coords into the server log on every Computer-Use turn (PII).

## Architecture

- Sysprompt + helpers live in `vllm_mlx/tool_parsers/ui_tars_tool_parser.py` (single source of truth: parser, sysprompt constant, detection, injection helper).
- `routes/chat.py` and `routes/anthropic.py` both call the SAME `maybe_inject_ui_tars_system_prompt` immediately after multimodal extraction, BEFORE the forced-tool-suffix injection — so the canonical sysprompt is the first system message and the existing `tool_choice="required"` suffix logic continues to layer on top.
- The parser's verb-aware key rename runs in `_normalize_action` for both the non-streaming and streaming code paths; the spec-key contract is independent of which UI-TARS variant emitted the bytes.
- Streaming reasoning parser's opener-prefix-aware hold-back replaces the brittle `len(stripped) >= 7` heuristic with `any(opener.startswith(stripped) for opener in OPENERS+(Action:,))` — a precise statement of "this MIGHT still resolve to an opener; wait for more bytes." No per-string regex band-aids.
- `tool_choice="none"` short-circuit in the parser checks `request.get("tool_choice")` directly — the request dict is already plumbed through `extract_tool_calls(..., request=request_dict)` and `extract_tool_calls_streaming(..., request=self.request)`, so no plumbing churn.
- Helper preserves message-list shape: when `messages` carries pydantic Message objects (defensive — production paths normalize to dicts) the inserted system entry is built via `model_copy(update=…)` so the list stays type-uniform (codex r1 BLOCKING #1).

## Evidence

- `/tmp/dogfood-085/ana-r1.md` — F-R1-01 (C-05), F-R1-02 (parser keys), F-R1-04 (streaming leak), F-R1-06 (hotkey chord), F-R1-08 (Thought: prefix in thinking block).
- `/tmp/dogfood-085/ana-r2.md` — F-R2-02 (C-07), F-R2-04 (lane coord parity), F-R2-05 (SSE-TC log leak).
- `/tmp/dogfood-085/ana/r1_probe.py`, `r1_followup.py`, `r1_followup2.py`, `r2_probe.py` — probe scripts used to surface each finding.

## Test plan

- [x] 43 new tests at `tests/test_ui_tars_fixes.py` cover each finding individually: sysprompt auto-wire idempotency, `tool_choice="none"` honor (non-stream + stream), parser key rename per verb, single-point verb collapsing for defensive variant kwargs, message-object shape parity, hotkey chord rewrite, streaming Thought/Reflection/Action_Summary partial-opener hold-back, lane-injection parity, Anthropic adapter `tool_use.input` shape.
- [x] 94 existing `tests/test_ui_tars_parser.py` tests still pass (3 updated to assert the new spec keys: `start_box` → `point`; `ctrl c` → `ctrl+c`).
- [x] `tests/test_tool_parser_coverage.py` + `tests/test_tool_call_streaming_parity.py` + `tests/test_anthropic_adapter.py` (89 tests total) all clean — no regressions on the cross-parser audit.
- [x] `ruff check vllm_mlx/ tests/` + `ruff format` clean.
- [x] End-to-end live-server replay tracked separately via the dogfood replay harness (requires Apple Silicon + UI-TARS 4-bit weights; out of unit-test scope, covered by Ana's R3 follow-up probe).

🤖 Generated with [Claude Code](https://claude.com/claude-code)