### PR TITLE
fix(audio): Whisper STT 500 + Kokoro misaki extras + /v1/audio/translations route + deeper-than-import capability probe (F-K bundle)

### DIFF
--- a/tests/test_audio_routes_bundle.py
+++ b/tests/test_audio_routes_bundle.py
@@ -558,6 +558,172 @@ class TestTranslationsRoute:
         err = body["detail"]["error"]
         assert err["type"] == "model_not_found_error", err
 
+    def test_translations_rejects_parakeet_with_400(
+        self, monkeypatch, _reset_audio_probe
+    ):
+        """Codex r6 NIT: non-Whisper engines ignore ``task=translate``
+        and silently emit source-language text. /v1/audio/translations
+        promises English output, so non-Whisper aliases must 400 BEFORE
+        the request reaches the STT engine — otherwise the client gets
+        a 200 with non-translated audio and no signal anything went
+        wrong.
+
+        Cover both the alias (``parakeet``) and the resolved HF id
+        (``mlx-community/parakeet-tdt-0.6b-v2``) so a caller that
+        bypasses the alias map by passing the repo path directly still
+        hits the gate.
+        """
+        from vllm_mlx.routes import audio as audio_route
+
+        audio_route._stt_engine = None
+
+        for parakeet_name in (
+            "parakeet",
+            "parakeet-v3",
+            "mlx-community/parakeet-tdt-0.6b-v2",
+        ):
+            client, restore = _mount_audio_app()
+            try:
+                r = client.post(
+                    "/v1/audio/translations",
+                    data={"model": parakeet_name},
+                    files={"file": ("tone.wav", _make_tone_wav(), "audio/wav")},
+                )
+            finally:
+                restore()
+                audio_route._stt_engine = None
+
+            assert r.status_code == 400, (
+                f"Codex r6 NIT: /v1/audio/translations must reject "
+                f"non-Whisper model `{parakeet_name}` with 400, "
+                f"got {r.status_code}: {r.text}"
+            )
+            err = r.json()["detail"]["error"]
+            assert err["code"] == "invalid_model_for_translation", err
+            assert err["type"] == "invalid_request_error", err
+            assert err["param"] == "model", err
+            # The error message should be actionable — mention Whisper
+            # or transcriptions so the caller knows how to fix the call.
+            msg = err["message"].lower()
+            assert "whisper" in msg or "transcriptions" in msg, err
+
+    def test_transcriptions_still_accepts_parakeet(
+        self, monkeypatch, _reset_audio_probe
+    ):
+        """The Whisper-only gate added for translations must NOT leak
+        into transcriptions. /v1/audio/transcriptions has always
+        accepted Parakeet (English-only source-language output is the
+        contract); a regression here would break F-165."""
+        from vllm_mlx.audio import stt as stt_mod
+        from vllm_mlx.routes import audio as audio_route
+
+        fake_model = _FakeParakeetModel()
+
+        def _fake_load_model(model_path, **kwargs):
+            return fake_model
+
+        fake_mlx_audio_stt_utils = types.SimpleNamespace(load_model=_fake_load_model)
+        monkeypatch.setitem(
+            sys.modules, "mlx_audio.stt.utils", fake_mlx_audio_stt_utils
+        )
+        # No transformers stub — Parakeet path mustn't touch processor.
+
+        audio_route._stt_engine = None
+        # Sanity: confirm the STT engine flags Parakeet correctly so
+        # the test exercises the right code path.
+        eng = stt_mod.STTEngine("mlx-community/parakeet-tdt-0.6b-v2")
+        assert eng._is_parakeet is True
+        assert eng._is_whisper is False
+
+        client, restore = _mount_audio_app()
+        try:
+            r = client.post(
+                "/v1/audio/transcriptions",
+                data={"model": "parakeet"},
+                files={"file": ("tone.wav", _make_tone_wav(), "audio/wav")},
+            )
+        finally:
+            restore()
+            audio_route._stt_engine = None
+
+        assert r.status_code == 200, (
+            f"Transcriptions must still accept Parakeet — codex r6 NIT "
+            f"gate is translations-only. Got {r.status_code}: {r.text}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Codex r6 BLOCKING — _ensure_whisper_processor must NOT touch non-Whisper engines
+# ---------------------------------------------------------------------------
+
+
+class TestWhisperProcessorPatchIsWhisperOnly:
+    """Codex r6 BLOCKING: the patch helper previously ran for any
+    non-Parakeet engine, which would attach a WhisperProcessor to
+    Voxtral / future STT backends whose model object happens to expose
+    a None-valued ``_processor`` attribute.
+
+    The gate must now be POSITIVE: ``_is_whisper`` true. Anything else
+    — including a hypothetical non-Parakeet, non-Whisper engine — must
+    leave the model untouched.
+    """
+
+    def test_non_whisper_engine_does_not_get_processor_attached(
+        self, monkeypatch, _reset_audio_probe
+    ):
+        """Simulate a future STT engine (``voxtral``) whose model
+        object exposes ``_processor=None``. The patch helper must skip
+        it entirely so the upstream engine's own error path fires
+        without rapid-mlx stapling a Whisper processor on top.
+        """
+        from vllm_mlx.audio import stt as stt_mod
+
+        class _FakeVoxtralModel:
+            def __init__(self):
+                # This is the trap from codex r6: a non-Whisper engine
+                # could expose _processor=None and the old gate would
+                # have wrongly attached a WhisperProcessor.
+                self._processor = None
+
+        fake_model = _FakeVoxtralModel()
+
+        def _fake_load_model(model_path, **kwargs):
+            return fake_model
+
+        class _FakeProcessor:
+            calls = 0
+
+            @staticmethod
+            def from_pretrained(name):
+                _FakeProcessor.calls += 1
+                return object()
+
+        fake_mlx_audio_stt_utils = types.SimpleNamespace(load_model=_fake_load_model)
+        monkeypatch.setitem(
+            sys.modules, "mlx_audio.stt.utils", fake_mlx_audio_stt_utils
+        )
+        fake_transformers = types.SimpleNamespace(WhisperProcessor=_FakeProcessor)
+        monkeypatch.setitem(sys.modules, "transformers", fake_transformers)
+
+        # Use a clearly-non-Whisper, non-Parakeet model id so the
+        # positive Whisper gate is what skips the patch.
+        engine = stt_mod.STTEngine("mlx-community/voxtral-mini-3b-mlx")
+        assert engine._is_whisper is False
+        assert engine._is_parakeet is False
+        engine.load()
+
+        assert _FakeProcessor.calls == 0, (
+            "Codex r6 BLOCKING: _ensure_whisper_processor must NOT run "
+            "for non-Whisper engines. The positive ``_is_whisper`` gate "
+            "is the load-time guard that prevents accidental processor "
+            "attachment to Voxtral / future STT backends."
+        )
+        # And the fake model's _processor stays None — rapid-mlx did
+        # not mutate a non-Whisper engine.
+        assert fake_model._processor is None, (
+            "Patch must not have attached a processor to a non-Whisper engine."
+        )
+
 
 # ---------------------------------------------------------------------------
 # F-K-KOKORO-MISAKI — clean 503 when misaki is missing

--- a/tests/test_audio_routes_bundle.py
+++ b/tests/test_audio_routes_bundle.py
@@ -636,9 +636,18 @@ class TestKokoroMisakiGate:
         """The Kokoro misaki gate must NOT trip for Chatterbox/etc. —
         ``misaki`` is Kokoro-specific. Pre-fix there was no per-family
         gate; making the dep check global would break Chatterbox-only
-        installs."""
+        installs.
+
+        Codex r3 NIT #3: drop the source-grep pin (brittle to
+        refactors / formatting). Assert the actual behaviour: with
+        ``misaki`` absent, the Kokoro probe raises but a Chatterbox
+        request must NOT invoke it. We patch ``require_kokoro_runtime``
+        to record invocations and confirm the speech route skips it
+        on non-Kokoro model strings.
+        """
         import importlib.util
 
+        from vllm_mlx.audio import probe as probe_mod
         from vllm_mlx.audio.probe import require_kokoro_runtime
 
         real_find_spec = importlib.util.find_spec
@@ -646,31 +655,99 @@ class TestKokoroMisakiGate:
         def _fake_find_spec(name, *args, **kwargs):
             if name == "misaki":
                 return None
-            return real_find_spec(name, *args, **kwargs)
+            try:
+                return real_find_spec(name, *args, **kwargs)
+            except ValueError:
+                if name == "mlx_audio":
+                    return object()
+                raise
 
         monkeypatch.setattr(importlib.util, "find_spec", _fake_find_spec)
 
-        # The Kokoro gate itself must raise.
+        # 1. The Kokoro gate itself MUST still raise when misaki is missing —
+        # otherwise the test couldn't distinguish "gate-not-called" from
+        # "gate-called-but-passed".
         from fastapi import HTTPException
 
         with pytest.raises(HTTPException) as exc:
             require_kokoro_runtime()
         assert exc.value.status_code == 503
 
-        # But the speech route's own Kokoro branch only fires when
-        # ``"kokoro" in model_name.lower()`` — non-Kokoro paths skip
-        # the misaki probe entirely. Source-pin this so a refactor
-        # that drops the conditional gets caught.
-        from pathlib import Path
+        # 2. Behavioural assertion: route a NON-Kokoro TTS request and
+        # confirm ``require_kokoro_runtime`` is never invoked. Wrap the
+        # probe so we can observe calls; the wrapper raises if invoked
+        # on the non-Kokoro path so the test fails clearly on
+        # regression.
+        call_count = {"n": 0}
 
-        route_file = (
-            Path(__file__).resolve().parents[1] / "vllm_mlx" / "routes" / "audio.py"
+        def _tracking_require_kokoro():
+            call_count["n"] += 1
+
+        monkeypatch.setattr(
+            probe_mod, "require_kokoro_runtime", _tracking_require_kokoro
         )
-        source = route_file.read_text()
-        assert 'if "kokoro" in model_name.lower():' in source, (
-            "Kokoro misaki gate must be conditional on the model family; "
-            "global gating would 503 Chatterbox/VibeVoice/VoxCPM users."
+        # The audio route does ``from ..audio.probe import
+        # require_kokoro_runtime`` lazily inside the handler, so the
+        # monkeypatch on the source module IS visible — confirmed by
+        # the assertion below. If a future refactor hoists the import
+        # to module-top, this comment + an additional patch on
+        # ``audio_route.require_kokoro_runtime`` would be required.
+
+        # Provide a fake mlx_audio so the TTS lane probe passes, and a
+        # fake TTSEngine so we don't load real weights. The TTS engine
+        # itself never gets called — the misaki gate would have fired
+        # first if it were going to.
+        _install_fake_mlx_audio(monkeypatch)
+
+        from vllm_mlx.audio import tts as tts_mod
+
+        class _NoopTTSEngine:
+            def __init__(self, model_name):
+                self.model_name = model_name
+
+            def load(self):
+                pass
+
+            def generate(self, *args, **kwargs):
+                return types.SimpleNamespace(
+                    audio=[0.0] * 100,
+                    sample_rate=24000,
+                    duration=0.01,
+                )
+
+            def to_bytes(self, *args, **kwargs):
+                return b"\x00" * 100
+
+        monkeypatch.setattr(tts_mod, "TTSEngine", _NoopTTSEngine)
+
+        from vllm_mlx.routes import audio as audio_route
+
+        audio_route._tts_engine = None
+
+        client, restore = _mount_audio_app()
+        try:
+            # The route declares ``model: str = "kokoro"`` without an
+            # explicit ``Body(...)`` / ``Form(...)`` annotation, so
+            # FastAPI treats it as a QUERY parameter. Sending it in
+            # the JSON body would silently leave ``model`` at the
+            # default "kokoro" and the test would trip the gate
+            # unrelated to the family-check logic. Send via query.
+            r = client.post(
+                "/v1/audio/speech?model=chatterbox&input=hi&voice=default",
+            )
+        finally:
+            restore()
+            audio_route._tts_engine = None
+
+        # Behaviour pin: chatterbox MUST not have tripped the Kokoro
+        # misaki gate. A 200 confirms the gate was skipped; a 503 with
+        # ``call_count > 0`` would mean the family check regressed.
+        assert call_count["n"] == 0, (
+            f"Kokoro misaki gate fired on a non-Kokoro request "
+            f"({call_count['n']} calls). Family-scoped gating regression."
         )
+        # The response itself should be 200 (fake engine returns bytes).
+        assert r.status_code == 200, r.text
 
 
 # ---------------------------------------------------------------------------
@@ -857,6 +934,72 @@ class TestDeepProbeSurfacesDegradedLane:
 # ---------------------------------------------------------------------------
 # Route registration: middleware guards the translations path too
 # ---------------------------------------------------------------------------
+
+
+class TestSTTEngineSignatureAcceptsTask:
+    """Pin that ``STTEngine.transcribe`` accepts a ``task`` kwarg so
+    the route's ``_run_stt_request(..., task=task)`` call cannot
+    regress to ``TypeError: unexpected keyword argument 'task'``.
+
+    Codex r3 BLOCKING #1 noted that route tests using a fake engine
+    with ``**kwargs`` wouldn't catch a real-engine signature mismatch.
+    This test uses the REAL ``STTEngine`` (not a fake) and inspects
+    the signature directly.
+    """
+
+    def test_transcribe_signature_has_task_kwarg(self):
+        import inspect
+
+        from vllm_mlx.audio.stt import STTEngine
+
+        sig = inspect.signature(STTEngine.transcribe)
+        assert "task" in sig.parameters, (
+            "STTEngine.transcribe must accept a `task` kwarg — the "
+            "transcriptions/translations route shares the helper and "
+            "passes task='translate' for translations. Without the "
+            "kwarg, real requests fail with TypeError."
+        )
+        # Default must be ``transcribe`` so existing callers don't break.
+        assert sig.parameters["task"].default == "transcribe", (
+            "STTEngine.transcribe default for `task` must be 'transcribe' "
+            "so calling without the kwarg preserves the original behaviour."
+        )
+
+    def test_transcribe_forwards_task_to_model_generate(self, monkeypatch):
+        """When task='translate' is passed through, the underlying
+        ``model.generate`` call must receive ``task='translate'`` so
+        Whisper actually emits English output. Pins the integration
+        between STTEngine and the broken-model fake without going
+        through the route."""
+        from vllm_mlx.audio import stt as stt_mod
+
+        observed: dict = {}
+
+        class _CapturingModel:
+            _processor = object()  # non-None so we skip the F-K-WHISPER-500 patch path
+
+            def generate(self, audio_path, **kwargs):
+                observed.update(kwargs)
+                return types.SimpleNamespace(
+                    text="bonjour", segments=None, language="fr"
+                )
+
+        def _fake_load_model(model_path, **kwargs):
+            return _CapturingModel()
+
+        fake_mlx_audio_stt_utils = types.SimpleNamespace(load_model=_fake_load_model)
+        monkeypatch.setitem(
+            sys.modules, "mlx_audio.stt.utils", fake_mlx_audio_stt_utils
+        )
+
+        engine = stt_mod.STTEngine("mlx-community/whisper-large-v3-mlx")
+        result = engine.transcribe("ignored.wav", task="translate")
+
+        assert observed.get("task") == "translate", (
+            f"STTEngine.transcribe(task='translate') must forward "
+            f"task='translate' to model.generate. Captured kwargs: {observed}"
+        )
+        assert result.text == "bonjour"
 
 
 class TestAudioBodyLimitCoversTranslations:

--- a/tests/test_audio_routes_bundle.py
+++ b/tests/test_audio_routes_bundle.py
@@ -1,0 +1,801 @@
+# SPDX-License-Identifier: Apache-2.0
+"""F-K-* regression tests — Karim's audio routes bundle (0.8.5 dogfood).
+
+Four findings from Karim's r1/r2 probe runs:
+
+* **F-K-WHISPER-500** — ``/v1/audio/transcriptions`` with
+  ``model=whisper-large-v3`` 500'd because the mlx-community Whisper
+  repos ship only ``weights.npz``/``config.json`` — no processor files
+  — so ``mlx_audio.stt.models.whisper.Model.post_load_hook`` silently
+  set ``_processor=None`` and the first transcribe raised
+  ``ValueError: Processor not found``. The integration-layer fix loads
+  the WhisperProcessor from the OpenAI counterpart repo.
+
+* **F-K-KOKORO-MISAKI** — ``/v1/audio/speech`` with Kokoro 503'd
+  because Kokoro's lazy ``misaki`` G2P import fails on installs without
+  the ``[audio]`` extra. The fix gates the missing extra at the route
+  boundary so the 503 fires BEFORE weight load.
+
+* **F-K-TRANSLATIONS-MISSING** — ``/v1/audio/translations`` 404'd
+  because the route was never registered. The fix mirrors the
+  transcriptions route via a shared helper, forcing ``task="translate"``.
+
+* **F-K-CAPABILITIES-OMIT-AUDIO** — the per-lane probe only checked
+  that ``mlx_audio`` imports; a torn backend (Whisper without
+  processor, Kokoro without misaki) still mounted the route then 5xx'd
+  on first use. The fix adds an opt-in deep probe that runs a dry-run
+  inference per lane and surfaces the verdict via ``/v1/models``.
+
+Tests stub mlx_audio at the integration layer so they don't need real
+weights and run fast in CI.
+"""
+
+from __future__ import annotations
+
+import io
+import struct
+import sys
+import types
+import wave
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+# ---------------------------------------------------------------------------
+# Test fixtures: synthetic WAV + mlx_audio stub
+# ---------------------------------------------------------------------------
+
+
+def _make_tone_wav(duration_s: float = 0.25, freq_hz: float = 440.0) -> bytes:
+    """Return a tiny mono 16-kHz WAV — small enough to keep test
+    fixtures in-memory without disk I/O."""
+    sample_rate = 16000
+    n_samples = int(sample_rate * duration_s)
+    buf = io.BytesIO()
+    with wave.open(buf, "wb") as w:
+        w.setnchannels(1)
+        w.setsampwidth(2)
+        w.setframerate(sample_rate)
+        import math
+
+        for i in range(n_samples):
+            sample = int(8000 * math.sin(2 * math.pi * freq_hz * i / sample_rate))
+            w.writeframes(struct.pack("<h", sample))
+    return buf.getvalue()
+
+
+def _install_fake_mlx_audio(monkeypatch):
+    """Install a fake ``mlx_audio`` package + sub-modules in
+    ``sys.modules`` so the shallow probe's ``find_spec("mlx_audio")``
+    succeeds without crashing on a missing ``__spec__``. Used by tests
+    that need the shallow lane probe to pass while exercising deeper
+    behaviour (Kokoro-misaki gate, deep probe degraded state)."""
+    import importlib.machinery
+
+    fake_mlx_audio = types.ModuleType("mlx_audio")
+    fake_mlx_audio.__path__ = []
+    fake_mlx_audio.__spec__ = importlib.machinery.ModuleSpec(
+        "mlx_audio", loader=None, is_package=True
+    )
+    fake_stt = types.ModuleType("mlx_audio.stt")
+    fake_stt.__path__ = []
+    fake_stt.__spec__ = importlib.machinery.ModuleSpec(
+        "mlx_audio.stt", loader=None, is_package=True
+    )
+    fake_stt_utils = types.ModuleType("mlx_audio.stt.utils")
+    fake_stt_utils.__spec__ = importlib.machinery.ModuleSpec(
+        "mlx_audio.stt.utils", loader=None
+    )
+    fake_stt_utils.load_model = lambda *_args, **_kw: None
+    fake_tts = types.ModuleType("mlx_audio.tts")
+    fake_tts.__path__ = []
+    fake_tts.__spec__ = importlib.machinery.ModuleSpec(
+        "mlx_audio.tts", loader=None, is_package=True
+    )
+    fake_tts_generate = types.ModuleType("mlx_audio.tts.generate")
+    fake_tts_generate.__spec__ = importlib.machinery.ModuleSpec(
+        "mlx_audio.tts.generate", loader=None
+    )
+    fake_tts_generate.load_model = lambda *_args, **_kw: None
+    monkeypatch.setitem(sys.modules, "mlx_audio", fake_mlx_audio)
+    monkeypatch.setitem(sys.modules, "mlx_audio.stt", fake_stt)
+    monkeypatch.setitem(sys.modules, "mlx_audio.stt.utils", fake_stt_utils)
+    monkeypatch.setitem(sys.modules, "mlx_audio.tts", fake_tts)
+    monkeypatch.setitem(sys.modules, "mlx_audio.tts.generate", fake_tts_generate)
+
+
+@pytest.fixture
+def _reset_audio_probe():
+    """Clear cached probe verdicts + recorded lane statuses between tests."""
+    from vllm_mlx.audio import probe
+
+    probe._reset_probe_cache()
+    yield
+    probe._reset_probe_cache()
+
+
+def _mount_audio_app() -> tuple[TestClient, callable]:
+    """Mount the audio router on a bare FastAPI app, bypassing auth."""
+    from vllm_mlx.config import get_config
+    from vllm_mlx.routes import audio as audio_route
+
+    app = FastAPI()
+    app.include_router(audio_route.router)
+    cfg = get_config()
+    saved = cfg.api_key
+    cfg.api_key = None
+
+    def _restore():
+        cfg.api_key = saved
+
+    return TestClient(app), _restore
+
+
+def _mount_models_app() -> tuple[TestClient, callable]:
+    """Mount the models router on a bare FastAPI app, bypassing auth."""
+    from vllm_mlx.config import get_config
+    from vllm_mlx.routes import models as models_route
+
+    app = FastAPI()
+    app.include_router(models_route.router)
+    cfg = get_config()
+    saved_api = cfg.api_key
+    saved_name = cfg.model_name
+    saved_alias = cfg.model_alias
+    cfg.api_key = None
+    cfg.model_name = "test-alias"
+    cfg.model_alias = "test-alias"
+
+    def _restore():
+        cfg.api_key = saved_api
+        cfg.model_name = saved_name
+        cfg.model_alias = saved_alias
+
+    return TestClient(app), _restore
+
+
+class _FakeWhisperResult:
+    text = "hello world"
+    language = "en"
+    segments = None
+
+
+class _FakeWhisperModel:
+    """Mimics the surface ``vllm_mlx.audio.stt.STTEngine`` touches.
+
+    Pre-fix the real mlx_audio Whisper model had ``_processor=None`` at
+    load time (because mlx-community repos lack processor files), so
+    ``generate`` raised ``ValueError: Processor not found``. The fake
+    mirrors that broken state until the integration layer attaches a
+    real processor (the F-K-WHISPER-500 fix) — then ``generate``
+    succeeds. This lets us validate the patch helper without needing
+    real weights or a network round-trip to HuggingFace.
+    """
+
+    def __init__(self):
+        self._processor = None  # The bug: processor wasn't attached.
+
+    def generate(self, audio_path, **kwargs):
+        if self._processor is None:
+            raise ValueError(
+                "Processor not found. Make sure the model was loaded "
+                "with a HuggingFace processor."
+            )
+        return _FakeWhisperResult()
+
+
+class _FakeParakeetResult:
+    text = ""
+    language = None
+    segments = None
+
+
+class _FakeParakeetModel:
+    def generate(self, audio_path, **kwargs):
+        return _FakeParakeetResult()
+
+
+# ---------------------------------------------------------------------------
+# F-K-WHISPER-500 — integration-layer processor patch
+# ---------------------------------------------------------------------------
+
+
+class TestWhisperProcessorPatch:
+    """The STT engine attaches a WhisperProcessor from the OpenAI repo
+    when mlx_audio's own post_load_hook left ``_processor=None``."""
+
+    def test_processor_patched_when_post_load_hook_failed(
+        self, monkeypatch, _reset_audio_probe
+    ):
+        """Simulate the F-K-WHISPER-500 shape: ``load_model`` returns
+        a Whisper model with ``_processor=None``. After ``STTEngine.load``
+        the processor should be attached (via the OpenAI counterpart
+        repo) and ``generate`` should succeed.
+        """
+        from vllm_mlx.audio import stt as stt_mod
+
+        fake_model = _FakeWhisperModel()
+        sentinel_processor = object()
+
+        def _fake_load_model(model_path, **kwargs):
+            return fake_model
+
+        # Stub the transformers WhisperProcessor.from_pretrained so the
+        # test doesn't reach the network. We treat the returned
+        # sentinel as opaque — only the *attachment* is under test.
+        class _FakeProcessor:
+            @staticmethod
+            def from_pretrained(name):
+                # Verify the integration layer requested the OpenAI repo,
+                # not the broken mlx-community one. This is the
+                # behavioral pin.
+                assert name.startswith("openai/whisper"), (
+                    f"Expected OpenAI counterpart, got {name!r}"
+                )
+                return sentinel_processor
+
+        # Inject our fakes into the stt module's lazy-import sites.
+        fake_mlx_audio_stt_utils = types.SimpleNamespace(load_model=_fake_load_model)
+        monkeypatch.setitem(
+            sys.modules, "mlx_audio.stt.utils", fake_mlx_audio_stt_utils
+        )
+        fake_transformers = types.SimpleNamespace(WhisperProcessor=_FakeProcessor)
+        monkeypatch.setitem(sys.modules, "transformers", fake_transformers)
+
+        engine = stt_mod.STTEngine("mlx-community/whisper-large-v3-mlx")
+        engine.load()
+
+        assert engine._loaded is True
+        assert fake_model._processor is sentinel_processor, (
+            "F-K-WHISPER-500: STTEngine.load must attach a WhisperProcessor "
+            "from the OpenAI repo when mlx_audio's post_load_hook left "
+            "_processor=None. Pre-fix, _processor stayed None and "
+            "transcribe() 500'd with `Processor not found`."
+        )
+
+        # Now transcribe should NOT raise.
+        result = engine.transcribe("ignored-path.wav")
+        assert result.text == "hello world"
+
+    def test_processor_not_overwritten_when_already_present(
+        self, monkeypatch, _reset_audio_probe
+    ):
+        """If mlx_audio's post_load_hook DID attach a processor (e.g.
+        a future mlx-community upload ships processor files), the
+        patch helper must be a no-op — overwriting would be incorrect."""
+        from vllm_mlx.audio import stt as stt_mod
+
+        existing_processor = object()
+        fake_model = _FakeWhisperModel()
+        fake_model._processor = existing_processor  # post_load_hook succeeded.
+
+        def _fake_load_model(model_path, **kwargs):
+            return fake_model
+
+        class _FakeProcessor:
+            calls = 0
+
+            @staticmethod
+            def from_pretrained(name):
+                _FakeProcessor.calls += 1
+                return object()
+
+        fake_mlx_audio_stt_utils = types.SimpleNamespace(load_model=_fake_load_model)
+        monkeypatch.setitem(
+            sys.modules, "mlx_audio.stt.utils", fake_mlx_audio_stt_utils
+        )
+        fake_transformers = types.SimpleNamespace(WhisperProcessor=_FakeProcessor)
+        monkeypatch.setitem(sys.modules, "transformers", fake_transformers)
+
+        engine = stt_mod.STTEngine("mlx-community/whisper-large-v3-mlx")
+        engine.load()
+
+        assert fake_model._processor is existing_processor, (
+            "Patch helper must not overwrite a processor that mlx_audio "
+            "already attached — that would mask a future fix upstream."
+        )
+        assert _FakeProcessor.calls == 0, (
+            "Patch helper must not call WhisperProcessor.from_pretrained "
+            "when a processor is already present."
+        )
+
+    def test_parakeet_skipped_by_patch(self, monkeypatch, _reset_audio_probe):
+        """Parakeet engines don't use ``_processor`` — the patch helper
+        must skip them (no spurious network fetch)."""
+        from vllm_mlx.audio import stt as stt_mod
+
+        fake_model = _FakeParakeetModel()
+
+        def _fake_load_model(model_path, **kwargs):
+            return fake_model
+
+        class _FakeProcessor:
+            calls = 0
+
+            @staticmethod
+            def from_pretrained(name):
+                _FakeProcessor.calls += 1
+                return object()
+
+        fake_mlx_audio_stt_utils = types.SimpleNamespace(load_model=_fake_load_model)
+        monkeypatch.setitem(
+            sys.modules, "mlx_audio.stt.utils", fake_mlx_audio_stt_utils
+        )
+        fake_transformers = types.SimpleNamespace(WhisperProcessor=_FakeProcessor)
+        monkeypatch.setitem(sys.modules, "transformers", fake_transformers)
+
+        engine = stt_mod.STTEngine("mlx-community/parakeet-tdt-0.6b-v2")
+        engine.load()
+
+        assert _FakeProcessor.calls == 0, (
+            "Parakeet path must not invoke the Whisper processor patch."
+        )
+
+
+# ---------------------------------------------------------------------------
+# F-K-WHISPER-500 — transcriptions route degrades cleanly when patch fails
+# ---------------------------------------------------------------------------
+
+
+class TestTranscriptionsCleanEnvelopeOnProcessorFailure:
+    """When the Whisper backend can't find a processor (e.g. the
+    OpenAI fallback fetch failed too), the route must return a 503
+    ``backend_unavailable`` envelope instead of a generic 500
+    ``transcription_failed``.
+
+    Pre-fix the user saw 500 with a vague body — same envelope as a
+    genuinely-broken audio file — and couldn't tell whether to retry
+    with a different model or re-encode the audio.
+    """
+
+    def test_processor_not_found_returns_clean_503(
+        self, monkeypatch, _reset_audio_probe
+    ):
+        from vllm_mlx.routes import audio as audio_route
+
+        # Force a Whisper model with _processor=None to slip past the
+        # integration-layer patch (e.g. the OpenAI fetch failed).
+        fake_model = _FakeWhisperModel()
+
+        def _fake_load_model(model_path, **kwargs):
+            return fake_model
+
+        fake_mlx_audio_stt_utils = types.SimpleNamespace(load_model=_fake_load_model)
+        monkeypatch.setitem(
+            sys.modules, "mlx_audio.stt.utils", fake_mlx_audio_stt_utils
+        )
+
+        # Make the WhisperProcessor fetch fail so _processor stays None.
+        class _BrokenProcessor:
+            @staticmethod
+            def from_pretrained(name):
+                raise OSError("simulated network failure to openai/whisper-large-v3")
+
+        fake_transformers = types.SimpleNamespace(WhisperProcessor=_BrokenProcessor)
+        monkeypatch.setitem(sys.modules, "transformers", fake_transformers)
+
+        # Force-clear any module-level _stt_engine cached from a prior test.
+        audio_route._stt_engine = None
+
+        client, restore = _mount_audio_app()
+        try:
+            r = client.post(
+                "/v1/audio/transcriptions",
+                data={"model": "whisper-large-v3"},
+                files={"file": ("tone.wav", _make_tone_wav(), "audio/wav")},
+            )
+        finally:
+            restore()
+            audio_route._stt_engine = None
+
+        assert r.status_code == 503, (
+            f"Expected 503 backend_unavailable envelope when Whisper "
+            f"processor is missing, got {r.status_code}: {r.text}"
+        )
+        body = r.json()
+        assert "error" in body.get("detail", {}), body
+        err = body["detail"]["error"]
+        assert err["type"] == "backend_unavailable_error", err
+        assert err["code"] == "backend_unavailable", err
+        # Actionable hint mentions parakeet as fallback.
+        assert "parakeet" in err["message"].lower(), err
+
+
+# ---------------------------------------------------------------------------
+# F-K-WHISPER-500 — transcriptions succeed end-to-end through the route
+# ---------------------------------------------------------------------------
+
+
+class TestTranscriptionsRouteEndToEnd:
+    """Happy-path: a Whisper model with a patched processor produces
+    a 200 ``{"text": ..., "language": ..., "duration": ...}`` from
+    ``/v1/audio/transcriptions``."""
+
+    def test_transcriptions_returns_200_with_text(
+        self, monkeypatch, _reset_audio_probe
+    ):
+        from vllm_mlx.routes import audio as audio_route
+
+        fake_model = _FakeWhisperModel()
+        sentinel = object()
+
+        def _fake_load_model(model_path, **kwargs):
+            return fake_model
+
+        class _FakeProcessor:
+            @staticmethod
+            def from_pretrained(name):
+                return sentinel
+
+        fake_mlx_audio_stt_utils = types.SimpleNamespace(load_model=_fake_load_model)
+        monkeypatch.setitem(
+            sys.modules, "mlx_audio.stt.utils", fake_mlx_audio_stt_utils
+        )
+        fake_transformers = types.SimpleNamespace(WhisperProcessor=_FakeProcessor)
+        monkeypatch.setitem(sys.modules, "transformers", fake_transformers)
+
+        audio_route._stt_engine = None
+
+        client, restore = _mount_audio_app()
+        try:
+            r = client.post(
+                "/v1/audio/transcriptions",
+                data={"model": "whisper-large-v3"},
+                files={"file": ("tone.wav", _make_tone_wav(), "audio/wav")},
+            )
+        finally:
+            restore()
+            audio_route._stt_engine = None
+
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["text"] == "hello world"
+        assert body["language"] == "en"
+
+
+# ---------------------------------------------------------------------------
+# F-K-TRANSLATIONS-MISSING — route is registered + behaves like transcriptions
+# ---------------------------------------------------------------------------
+
+
+class TestTranslationsRoute:
+    """/v1/audio/translations exists and mirrors transcriptions with
+    ``task="translate"``. The wire-level OpenAI contract differs only
+    in that ``language`` is not accepted (output is always English)."""
+
+    def test_translations_route_registered(self):
+        """The OpenAPI/router should advertise the route.
+
+        Pre-fix this 404'd at the FastAPI routing layer because the
+        decorator was never written.
+        """
+        from vllm_mlx.routes import audio as audio_route
+
+        paths = {r.path for r in audio_route.router.routes}
+        assert "/v1/audio/translations" in paths, (
+            "F-K-TRANSLATIONS-MISSING regression: /v1/audio/translations "
+            "is not registered. OpenAI spec requires it for Whisper "
+            "translation-to-English."
+        )
+
+    def test_translations_returns_200_with_text(self, monkeypatch, _reset_audio_probe):
+        from vllm_mlx.routes import audio as audio_route
+
+        fake_model = _FakeWhisperModel()
+
+        def _fake_load_model(model_path, **kwargs):
+            return fake_model
+
+        class _FakeProcessor:
+            @staticmethod
+            def from_pretrained(name):
+                return object()
+
+        # Capture the ``task`` kwarg the engine receives so we can pin
+        # that the translations route forces ``translate``.
+        observed_tasks: list[str] = []
+
+        def _generate(audio_path, **kwargs):
+            observed_tasks.append(kwargs.get("task"))
+            return _FakeWhisperResult()
+
+        fake_model.generate = _generate
+
+        fake_mlx_audio_stt_utils = types.SimpleNamespace(load_model=_fake_load_model)
+        monkeypatch.setitem(
+            sys.modules, "mlx_audio.stt.utils", fake_mlx_audio_stt_utils
+        )
+        fake_transformers = types.SimpleNamespace(WhisperProcessor=_FakeProcessor)
+        monkeypatch.setitem(sys.modules, "transformers", fake_transformers)
+
+        audio_route._stt_engine = None
+
+        client, restore = _mount_audio_app()
+        try:
+            r = client.post(
+                "/v1/audio/translations",
+                data={"model": "whisper-large-v3"},
+                files={"file": ("tone.wav", _make_tone_wav(), "audio/wav")},
+            )
+        finally:
+            restore()
+            audio_route._stt_engine = None
+
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert "text" in body, body
+        assert body["text"] == "hello world"
+
+        # The engine MUST have received task="translate", not "transcribe".
+        assert "translate" in observed_tasks, (
+            "F-K-TRANSLATIONS-MISSING: /v1/audio/translations must pass "
+            f"task='translate' to the STT engine. Saw: {observed_tasks}"
+        )
+
+    def test_translations_returns_404_for_unknown_model(
+        self, monkeypatch, _reset_audio_probe
+    ):
+        """Model validation should fire on translations the same way it
+        fires on transcriptions — unknown alias → clean 404."""
+        from vllm_mlx.routes import audio as audio_route
+
+        audio_route._stt_engine = None
+
+        client, restore = _mount_audio_app()
+        try:
+            r = client.post(
+                "/v1/audio/translations",
+                data={"model": "no-such-model"},
+                files={"file": ("tone.wav", _make_tone_wav(), "audio/wav")},
+            )
+        finally:
+            restore()
+            audio_route._stt_engine = None
+
+        assert r.status_code == 404, r.text
+        body = r.json()
+        err = body["detail"]["error"]
+        assert err["type"] == "model_not_found_error", err
+
+
+# ---------------------------------------------------------------------------
+# F-K-KOKORO-MISAKI — clean 503 when misaki is missing
+# ---------------------------------------------------------------------------
+
+
+class TestKokoroMisakiGate:
+    """When ``misaki`` is missing, /v1/audio/speech with a Kokoro model
+    must return a clean 503 envelope BEFORE the weight load — the
+    existing route's catch-all 503 fired only after the engine
+    constructor raised ``ImportError``, which still pulled the 300 MB
+    weights from HF on every failed attempt.
+    """
+
+    def test_kokoro_request_503s_cleanly_when_misaki_missing(
+        self, monkeypatch, _reset_audio_probe
+    ):
+        # Pretend misaki isn't installed. ``find_spec("mlx_audio")``
+        # may walk the spec of an already-loaded mlx_audio module —
+        # if a previous test imported mlx_audio without preserving its
+        # __spec__, find_spec raises. Filter our fake to only intercept
+        # the misaki probe so the real mlx_audio path keeps working.
+        import importlib.util
+
+        real_find_spec = importlib.util.find_spec
+
+        def _fake_find_spec(name, *args, **kwargs):
+            if name == "misaki":
+                return None
+            try:
+                return real_find_spec(name, *args, **kwargs)
+            except ValueError:
+                # ``mlx_audio.__spec__ is not set`` — happens when a
+                # test stub overwrote sys.modules['mlx_audio'] without
+                # a spec. Return a sentinel spec so the shallow probe
+                # treats mlx_audio as present.
+                if name == "mlx_audio":
+                    return object()
+                raise
+
+        monkeypatch.setattr(importlib.util, "find_spec", _fake_find_spec)
+
+        # Ensure mlx_audio appears available so the TTS-lane probe passes
+        # — we want to exercise the Kokoro-specific gate, not the lane
+        # gate. Stub the sub-module to satisfy the lazy import inside
+        # the probe. ``__spec__`` is set so ``find_spec`` walks cleanly.
+        _install_fake_mlx_audio(monkeypatch)
+
+        client, restore = _mount_audio_app()
+        try:
+            r = client.post(
+                "/v1/audio/speech",
+                json={"model": "kokoro", "input": "hello", "voice": "af_heart"},
+            )
+        finally:
+            restore()
+
+        assert r.status_code == 503, r.text
+        body = r.json()
+        # detail is either a string (legacy envelope shape) or a dict.
+        detail = body.get("detail", "")
+        if isinstance(detail, dict):
+            detail = detail.get("error", {}).get("message", "")
+        detail_lower = detail.lower()
+        assert "misaki" in detail_lower, (
+            f"503 envelope should mention misaki. Got: {detail}"
+        )
+        # Install hint is actionable.
+        assert "rapid-mlx[audio]" in detail_lower or "pip install" in detail_lower, (
+            f"503 envelope should include an install hint. Got: {detail}"
+        )
+
+    def test_non_kokoro_tts_does_not_require_misaki(
+        self, monkeypatch, _reset_audio_probe
+    ):
+        """The Kokoro misaki gate must NOT trip for Chatterbox/etc. —
+        ``misaki`` is Kokoro-specific. Pre-fix there was no per-family
+        gate; making the dep check global would break Chatterbox-only
+        installs."""
+        import importlib.util
+
+        from vllm_mlx.audio.probe import require_kokoro_runtime
+
+        real_find_spec = importlib.util.find_spec
+
+        def _fake_find_spec(name, *args, **kwargs):
+            if name == "misaki":
+                return None
+            return real_find_spec(name, *args, **kwargs)
+
+        monkeypatch.setattr(importlib.util, "find_spec", _fake_find_spec)
+
+        # The Kokoro gate itself must raise.
+        from fastapi import HTTPException
+
+        with pytest.raises(HTTPException) as exc:
+            require_kokoro_runtime()
+        assert exc.value.status_code == 503
+
+        # But the speech route's own Kokoro branch only fires when
+        # ``"kokoro" in model_name.lower()`` — non-Kokoro paths skip
+        # the misaki probe entirely. Source-pin this so a refactor
+        # that drops the conditional gets caught.
+        from pathlib import Path
+
+        route_file = (
+            Path(__file__).resolve().parents[1] / "vllm_mlx" / "routes" / "audio.py"
+        )
+        source = route_file.read_text()
+        assert 'if "kokoro" in model_name.lower():' in source, (
+            "Kokoro misaki gate must be conditional on the model family; "
+            "global gating would 503 Chatterbox/VibeVoice/VoxCPM users."
+        )
+
+
+# ---------------------------------------------------------------------------
+# F-K-CAPABILITIES-OMIT-AUDIO — deep probe surfaces degraded backends
+# ---------------------------------------------------------------------------
+
+
+class TestDeepProbeSurfacesDegradedLane:
+    """The deep probe runs a dry-run inference per lane and records
+    ``degraded`` when the dry-run raises. ``/v1/models`` surfaces the
+    verdict via ``audio_lanes``.
+
+    Pre-fix the per-lane probe only checked ``mlx_audio`` importability;
+    a Whisper backend with a missing processor would pass the probe,
+    mount the route, and 500 on every real request. The deep probe
+    catches that shape at boot.
+    """
+
+    def test_dry_run_failure_marks_lane_degraded(self, monkeypatch, _reset_audio_probe):
+        from vllm_mlx.audio import probe
+        from vllm_mlx.audio import stt as stt_mod
+
+        # Stub STTEngine to raise inside transcribe (mimics
+        # F-K-WHISPER-500 — model loads, generate raises).
+        class _BrokenEngine:
+            def __init__(self, model_name):
+                self.model_name = model_name
+
+            def load(self):
+                pass
+
+            def transcribe(self, *args, **kwargs):
+                raise RuntimeError("simulated processor-missing failure")
+
+        monkeypatch.setattr(stt_mod, "STTEngine", _BrokenEngine)
+
+        # Pretend mlx_audio is available so the shallow probe passes.
+        # Use real ``ModuleType`` instances so ``find_spec`` doesn't
+        # raise on a missing ``__spec__``.
+        _install_fake_mlx_audio(monkeypatch)
+
+        status = probe.deep_probe_audio_lane("stt")
+        assert status["status"] == "degraded", status
+        assert "simulated processor-missing failure" in (status["reason"] or ""), status
+
+    def test_dry_run_success_marks_lane_ok(self, monkeypatch, _reset_audio_probe):
+        from vllm_mlx.audio import probe
+        from vllm_mlx.audio import stt as stt_mod
+
+        class _OKEngine:
+            def __init__(self, model_name):
+                self.model_name = model_name
+
+            def load(self):
+                pass
+
+            def transcribe(self, *args, **kwargs):
+                return types.SimpleNamespace(
+                    text="", language=None, duration=None, segments=None
+                )
+
+        monkeypatch.setattr(stt_mod, "STTEngine", _OKEngine)
+
+        _install_fake_mlx_audio(monkeypatch)
+
+        status = probe.deep_probe_audio_lane("stt")
+        assert status["status"] == "ok", status
+        assert status["reason"] is None
+
+    def test_models_endpoint_surfaces_lane_status(
+        self, monkeypatch, _reset_audio_probe
+    ):
+        """/v1/models entries carry ``audio_lanes`` once the deep probe
+        has recorded a verdict — pre-fix this was invisible."""
+        from vllm_mlx.audio import probe
+
+        probe._record_lane_status("stt", "degraded", "simulated")
+        probe._record_lane_status("tts", "ok", None)
+
+        client, restore = _mount_models_app()
+        try:
+            r = client.get("/v1/models")
+        finally:
+            restore()
+
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["data"], body
+        entry = body["data"][0]
+        assert "audio_lanes" in entry, entry
+        assert entry["audio_lanes"] == {"stt": "degraded", "tts": "ok"}, entry
+
+    def test_models_endpoint_omits_lane_status_when_probe_never_ran(
+        self, _reset_audio_probe
+    ):
+        """When the deep probe is disabled (default), the field is
+        ``None`` so the wire shape is unchanged for existing clients."""
+        client, restore = _mount_models_app()
+        try:
+            r = client.get("/v1/models")
+        finally:
+            restore()
+
+        assert r.status_code == 200, r.text
+        body = r.json()
+        entry = body["data"][0]
+        assert entry["audio_lanes"] is None, entry
+
+
+# ---------------------------------------------------------------------------
+# Route registration: middleware guards the translations path too
+# ---------------------------------------------------------------------------
+
+
+class TestAudioBodyLimitCoversTranslations:
+    """The 25 MB upload cap middleware must guard the new translations
+    route — without it, an attacker can send 1 GB to translations and
+    exhaust the worker."""
+
+    def test_translations_in_guarded_paths(self):
+        from vllm_mlx.routes import audio as audio_route
+
+        guarded = audio_route.AudioBodyLimitMiddleware._GUARDED_PATHS
+        assert "/v1/audio/translations" in guarded, (
+            "F-K-TRANSLATIONS-MISSING regression: the AudioBodyLimitMiddleware "
+            "must include /v1/audio/translations in _GUARDED_PATHS so the "
+            "25 MB upload cap covers both transcription endpoints."
+        )

--- a/tests/test_audio_routes_bundle.py
+++ b/tests/test_audio_routes_bundle.py
@@ -779,6 +779,80 @@ class TestDeepProbeSurfacesDegradedLane:
         entry = body["data"][0]
         assert entry["audio_lanes"] is None, entry
 
+    def test_stt_dry_run_defaults_to_whisper_not_parakeet(
+        self, monkeypatch, _reset_audio_probe
+    ):
+        """Codex r2 BLOCKING #1+#2: the STT dry-run must default to
+        the Whisper engine, not Parakeet — the WHOLE POINT of
+        F-K-CAPABILITIES-OMIT-AUDIO is to catch the Whisper-specific
+        processor wiring failure. Parakeet bypasses the broken code
+        path (its tokenizer is bundled), so probing it would always
+        report ``ok`` even when ``whisper-large-v3`` requests are
+        silently 500'ing.
+        """
+        from vllm_mlx.audio import probe
+        from vllm_mlx.audio import stt as stt_mod
+        from vllm_mlx.audio.stt import DEFAULT_WHISPER_MODEL
+
+        observed: list[str] = []
+
+        class _RecordingEngine:
+            def __init__(self, model_name):
+                observed.append(model_name)
+                self.model_name = model_name
+
+            def load(self):
+                pass
+
+            def transcribe(self, *args, **kwargs):
+                return types.SimpleNamespace(
+                    text="", language=None, duration=None, segments=None
+                )
+
+        monkeypatch.setattr(stt_mod, "STTEngine", _RecordingEngine)
+        _install_fake_mlx_audio(monkeypatch)
+
+        probe.deep_probe_audio_lane("stt")
+
+        assert observed, "STT dry-run should have instantiated an engine"
+        assert observed[0] == DEFAULT_WHISPER_MODEL, (
+            f"F-K-CAPABILITIES-OMIT-AUDIO regression: STT dry-run probed "
+            f"{observed[0]!r} but must default to {DEFAULT_WHISPER_MODEL!r} "
+            "so the Whisper-specific processor failure is caught at boot. "
+            "Codex r2 BLOCKING #1+#2."
+        )
+
+    def test_missing_mlx_audio_marks_lane_missing(
+        self, monkeypatch, _reset_audio_probe
+    ):
+        """Codex r2 NIT #3: when ``mlx_audio`` isn't installed,
+        ``deep_probe_audio_lane`` must record ``missing`` status so
+        ``/v1/models`` surfaces the missing-extra state instead of
+        leaving ``audio_lanes`` as ``null``.
+        """
+        import importlib.util
+
+        from vllm_mlx.audio import probe
+
+        real_find_spec = importlib.util.find_spec
+
+        def _fake_find_spec(name, *args, **kwargs):
+            if name == "mlx_audio":
+                return None
+            return real_find_spec(name, *args, **kwargs)
+
+        monkeypatch.setattr(importlib.util, "find_spec", _fake_find_spec)
+
+        # Drop any already-imported mlx_audio so the shallow probe
+        # genuinely sees a missing extra.
+        for name in list(sys.modules):
+            if name == "mlx_audio" or name.startswith("mlx_audio."):
+                monkeypatch.delitem(sys.modules, name, raising=False)
+
+        status = probe.deep_probe_audio_lane("stt")
+        assert status["status"] == "missing", status
+        assert "not installed" in (status["reason"] or "").lower(), status
+
 
 # ---------------------------------------------------------------------------
 # Route registration: middleware guards the translations path too

--- a/tests/test_audio_upload_size_limit.py
+++ b/tests/test_audio_upload_size_limit.py
@@ -76,7 +76,12 @@ class _FakeSTTEngine:
     def load(self) -> None:
         self.loaded = True
 
-    def transcribe(self, path: str, language: str | None = None) -> _FakeResult:
+    def transcribe(
+        self, path: str, language: str | None = None, **kwargs
+    ) -> _FakeResult:
+        # **kwargs absorbs new keyword arguments the route adds over
+        # time (e.g. ``task`` for F-K-TRANSLATIONS-MISSING) without
+        # forcing every consumer of this fake to update in lockstep.
         self.transcribed_paths.append(path)
         return _FakeResult()
 

--- a/tests/test_no_out_of_band_routing.py
+++ b/tests/test_no_out_of_band_routing.py
@@ -247,6 +247,17 @@ ALLOWED_RAPID_MLX_ENV_VARS: frozenset[str] = frozenset(
         # whether the sentinel notice is surfaced on a single envelope
         # field. See PR fix/h-01-reasoning-content-null-rescue.
         "RAPID_MLX_REASONING_CUTOFF_NOTICE",
+        # F-K-CAPABILITIES-OMIT-AUDIO opt-in deep audio probe (boolean
+        # flag). When set to a truthy value, the lifespan hook runs a
+        # tiny dry-run inference on each audio lane (STT + TTS) so
+        # ``/v1/models`` can surface ``audio_lanes`` status reflecting
+        # the real backend health (a degraded Whisper backend that
+        # 500s at first request would otherwise look healthy on the
+        # listing). Pure observability/health knob — never selects a
+        # model, parser, or routing tier. Consumed only by
+        # ``vllm_mlx/server.py``'s lifespan to decide whether to fire
+        # the deep probe at boot.
+        "RAPID_MLX_AUDIO_DEEP_PROBE",
     }
 )
 

--- a/vllm_mlx/api/models.py
+++ b/vllm_mlx/api/models.py
@@ -1903,6 +1903,19 @@ class ModelInfo(BaseModel):
     # lie the desktop happily believed. Empty list (rather than
     # ``None``) means "we've thought about it; nothing applies".
     capabilities: list[str] = Field(default_factory=list)
+    # F-K-CAPABILITIES-OMIT-AUDIO: per-lane audio backend status
+    # surfaced when the deep audio probe has been run
+    # (``RAPID_MLX_AUDIO_DEEP_PROBE=1``). ``None`` means the deep
+    # probe never ran on this server, so we can't make any claim
+    # about lane health beyond what ``capabilities`` already says.
+    # ``{"stt": "ok", "tts": "degraded", ...}`` callers can read to
+    # surface a "backend degraded" UX before sending a real audio
+    # request. ``"degraded"`` means the lane imported cleanly but
+    # the dry-run inference raised (F-K-WHISPER-500-shape failure —
+    # a Whisper model whose processor never attached, a Kokoro
+    # install missing ``misaki``, etc.). Values:
+    # ``"ok"``, ``"degraded"``, ``"missing"``, ``"unknown"``.
+    audio_lanes: dict[str, str] | None = None
 
 
 class ModelsResponse(BaseModel):

--- a/vllm_mlx/audio/probe.py
+++ b/vllm_mlx/audio/probe.py
@@ -224,18 +224,22 @@ def _dry_run_stt(model_name: str | None) -> tuple[bool, str | None]:
     Catches the F-K-WHISPER-500 shape: a Whisper model that loads
     but has no processor wired. The dry-run reaches the same
     ``get_tokenizer()`` branch the real request hits.
+
+    Codex r2 BLOCKING #1+#2: defaults to the Whisper engine, not
+    Parakeet — the WHOLE POINT of the deep probe is to catch the
+    Whisper-specific processor wiring failure. Parakeet bypasses
+    the broken code path (its tokenizer is bundled), so probing it
+    would always report ``ok`` even when ``whisper-large-v3``
+    requests are silently 500'ing. Operators serving a non-Whisper
+    STT model can pass ``model_name`` explicitly to probe their
+    configured engine instead.
     """
     try:
         import tempfile
         import wave
 
-        from ..audio.stt import DEFAULT_PARAKEET_MODEL, STTEngine
+        from ..audio.stt import DEFAULT_WHISPER_MODEL, STTEngine
 
-        # Synthesize 1 second of mono 16 kHz silence in a tempfile.
-        # ``parakeet`` is the cheapest engine to probe (no processor
-        # download); operators who care specifically about Whisper
-        # health can re-call ``deep_probe_audio_lane`` with the
-        # whisper model name to validate that specific lane.
         with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as tmp:
             wav_path = tmp.name
         try:
@@ -244,7 +248,7 @@ def _dry_run_stt(model_name: str | None) -> tuple[bool, str | None]:
                 w.setsampwidth(2)
                 w.setframerate(16000)
                 w.writeframes(b"\x00\x00" * 16000)
-            engine = STTEngine(model_name or DEFAULT_PARAKEET_MODEL)
+            engine = STTEngine(model_name or DEFAULT_WHISPER_MODEL)
             engine.load()
             result = engine.transcribe(wav_path)
             # An empty string is a valid transcription of silence.

--- a/vllm_mlx/audio/probe.py
+++ b/vllm_mlx/audio/probe.py
@@ -73,8 +73,14 @@ def _reset_probe_cache() -> None:
     would mask a monkeypatched failure in the next test. Tests that
     swap ``builtins.__import__`` or otherwise simulate a broken
     ``mlx_audio`` call this helper in their fixture to force re-probe.
+
+    Also clears the per-lane deep-probe status recorded by
+    :func:`deep_probe_audio_lane` so tests don't leak ``degraded``
+    state across cases.
     """
     _cached_verdict.clear()
+    _LANE_STATUS.clear()
+    _LANE_REASON.clear()
 
 
 # Sub-modules each route actually needs to load. Split per lane so a
@@ -85,6 +91,232 @@ _LANE_SUBMODULES: dict[str, str] = {
     "tts": "mlx_audio.tts.generate",  # /v1/audio/speech, voices
     "stt": "mlx_audio.stt.utils",  # /v1/audio/transcriptions
 }
+
+# F-K-KOKORO-MISAKI: Kokoro's tokenizer transitively depends on
+# ``misaki`` (the G2P / phonemizer package). ``mlx_audio.tts.generate``
+# imports cleanly without ``misaki`` because the dependency is loaded
+# lazily inside ``KokoroPipeline``; the failure only surfaces on the
+# FIRST ``generate()`` call.
+#
+# We expose a Kokoro-specific helper that's called from the speech
+# route when the requested model is the Kokoro family. The lane probe
+# stays Kokoro-agnostic so installs that only use Chatterbox/VibeVoice/
+# VoxCPM aren't 503'd by a missing G2P package they don't need.
+#
+# The check IS NOT gated by a config flag — missing ``misaki`` is a
+# deterministic hard failure for every Kokoro request, so a probe
+# that lets the request through and 503s deep inside the engine
+# leaks a stack-trace-shaped envelope. Catching the missing-extra at
+# the route boundary keeps the envelope clean and the failure cheap
+# (no model load, no audio synthesis kicked off).
+_KOKORO_EXTRA_DEP = "misaki"
+_KOKORO_EXTRA_HINT = (
+    "Kokoro TTS requires the optional `misaki` G2P package, which is "
+    "not installed. Reinstall with `pip install 'rapid-mlx[audio]'` "
+    "to pull every audio dep, or `pip install misaki` for a "
+    "minimal Kokoro-only install."
+)
+
+
+# F-K-CAPABILITIES-OMIT-AUDIO: D-CAPABILITIES-DETECTION's existing
+# per-lane probe (``mlx_audio_available``) only checks that the
+# sub-module imports — it doesn't validate that the engine can
+# generate output. A model loadable at boot can still 500/503 on
+# the first inference (F-K-WHISPER-500 was exactly this shape).
+#
+# ``deep_probe_audio_lane`` runs a tiny dry-run BEYOND the import
+# check: for STT, decode 1 s of silence; for TTS, synthesize a
+# single character. If the dry-run raises, the lane is marked
+# ``degraded`` and that fact is surfaced via :func:`audio_lane_status`
+# so the ``/v1/models`` listing (and any operator-side observability)
+# can advertise the broken backend without a real user having to be
+# the canary.
+#
+# Cost: STT dry-run is ~1 s on M2 (mostly model-load); TTS Kokoro
+# dry-run is ~2 s. Gated behind the ``deep`` probe-depth setting so
+# operators on tight cold-start budgets can opt out via
+# ``RAPID_MLX_AUDIO_PROBE_DEPTH=shallow``. Default is ``deep`` —
+# the goal of D-CAPABILITIES-DETECTION is to catch backend defects
+# at boot, not at first user request.
+
+_LANE_STATUS: dict[str, str] = {}
+# Status values: "ok" | "degraded" | "missing" | "unknown"
+_LANE_REASON: dict[str, str] = {}
+
+
+def audio_lane_status(lane: str) -> dict[str, str | None]:
+    """Return the current status snapshot for ``lane``.
+
+    Used by ``/v1/models`` to decorate audio models with a
+    capability tag. ``status`` is one of:
+
+    * ``"ok"`` — import succeeded AND the deep dry-run (if it ran)
+      produced output;
+    * ``"degraded"`` — import succeeded but the dry-run failed —
+      the route will 503 on real requests;
+    * ``"missing"`` — ``mlx_audio`` (or the lane sub-module) is not
+      importable;
+    * ``"unknown"`` — no probe has run yet (deep probe disabled,
+      lane never exercised).
+
+    ``reason`` carries the failure string when status != ``"ok"``.
+    """
+    status = _LANE_STATUS.get(lane, "unknown")
+    reason = _LANE_REASON.get(lane)
+    return {"status": status, "reason": reason}
+
+
+def _record_lane_status(lane: str, status: str, reason: str | None) -> None:
+    _LANE_STATUS[lane] = status
+    if reason is None:
+        _LANE_REASON.pop(lane, None)
+    else:
+        _LANE_REASON[lane] = reason
+
+
+def deep_probe_audio_lane(
+    lane: str, model_name: str | None = None
+) -> dict[str, str | None]:
+    """Run a deeper-than-import dry-run for ``lane`` and record the result.
+
+    F-K-CAPABILITIES-OMIT-AUDIO: callers (the boot-time capability
+    probe, the test harness, the ``/v1/models`` capability decorator
+    refresh) use this to validate that the configured audio engine
+    can actually generate output, not just import. Returns the
+    recorded :func:`audio_lane_status` snapshot.
+
+    ``model_name`` is the engine the operator configured for the
+    lane (defaults to the package-level defaults). Failures during
+    the dry-run are CAUGHT — the function never raises. This is
+    deliberate: the boot-time probe must not crash the server if
+    one audio lane is broken; the only side effect is a recorded
+    ``degraded`` status that downstream callers act on.
+
+    The function is idempotent — re-calling it re-runs the dry-run.
+    Tests use that to validate degraded-status surfacing without
+    polluting the per-process import cache.
+    """
+    # First, the shallow probe — if the lane fails to import, deep
+    # probing is meaningless. Record the same verdict and return.
+    verdict = _probe_lane(lane)
+    if not verdict.ok:
+        _record_lane_status(lane, "missing", verdict.reason)
+        return audio_lane_status(lane)
+
+    if lane == "stt":
+        ok, reason = _dry_run_stt(model_name)
+    elif lane == "tts":
+        ok, reason = _dry_run_tts(model_name)
+    else:
+        _record_lane_status(lane, "unknown", f"unknown audio lane {lane!r}")
+        return audio_lane_status(lane)
+
+    if ok:
+        _record_lane_status(lane, "ok", None)
+    else:
+        _record_lane_status(lane, "degraded", reason)
+    return audio_lane_status(lane)
+
+
+def _dry_run_stt(model_name: str | None) -> tuple[bool, str | None]:
+    """Decode 1 s of silence through the STT engine.
+
+    Catches the F-K-WHISPER-500 shape: a Whisper model that loads
+    but has no processor wired. The dry-run reaches the same
+    ``get_tokenizer()`` branch the real request hits.
+    """
+    try:
+        import tempfile
+        import wave
+
+        from ..audio.stt import DEFAULT_PARAKEET_MODEL, STTEngine
+
+        # Synthesize 1 second of mono 16 kHz silence in a tempfile.
+        # ``parakeet`` is the cheapest engine to probe (no processor
+        # download); operators who care specifically about Whisper
+        # health can re-call ``deep_probe_audio_lane`` with the
+        # whisper model name to validate that specific lane.
+        with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as tmp:
+            wav_path = tmp.name
+        try:
+            with wave.open(wav_path, "wb") as w:
+                w.setnchannels(1)
+                w.setsampwidth(2)
+                w.setframerate(16000)
+                w.writeframes(b"\x00\x00" * 16000)
+            engine = STTEngine(model_name or DEFAULT_PARAKEET_MODEL)
+            engine.load()
+            result = engine.transcribe(wav_path)
+            # An empty string is a valid transcription of silence.
+            if not hasattr(result, "text"):
+                return False, "STT result missing `text` attribute"
+        finally:
+            import os as _os
+
+            try:
+                _os.unlink(wav_path)
+            except OSError:
+                pass
+        return True, None
+    except Exception as e:  # noqa: BLE001
+        return False, f"STT dry-run failed: {type(e).__name__}: {e}"
+
+
+def _dry_run_tts(model_name: str | None) -> tuple[bool, str | None]:
+    """Synthesize a single character through the TTS engine.
+
+    Catches the F-K-KOKORO-MISAKI shape: Kokoro loads cleanly but
+    the misaki G2P pulls in lazily and fails on first generate.
+    """
+    try:
+        from ..audio.tts import DEFAULT_TTS_MODEL, TTSEngine
+
+        engine = TTSEngine(model_name or DEFAULT_TTS_MODEL)
+        engine.load()
+        # Synthesizing a single character keeps the probe fast (<1 s).
+        # Failure modes (missing misaki, broken pipeline) raise inside
+        # ``generate()`` — we catch them and report degraded.
+        result = engine.generate("a", voice="af_heart")
+        if not hasattr(result, "audio") or len(result.audio) == 0:
+            return False, "TTS result is empty (no audio produced)"
+        return True, None
+    except Exception as e:  # noqa: BLE001
+        return False, f"TTS dry-run failed: {type(e).__name__}: {e}"
+
+
+def _reset_lane_status() -> None:
+    """Test hook: clear recorded lane statuses."""
+    _LANE_STATUS.clear()
+    _LANE_REASON.clear()
+
+
+def require_kokoro_runtime() -> None:
+    """Raise an HTTP 503 when the Kokoro TTS runtime is incomplete.
+
+    F-K-KOKORO-MISAKI: ``mlx_audio.tts.generate.load_model`` succeeds
+    for Kokoro even when ``misaki`` is absent (the G2P import happens
+    lazily inside the pipeline's first ``generate`` call), so the
+    shared TTS-lane probe can't catch this. Called explicitly by
+    ``/v1/audio/speech`` when the requested model resolves to a
+    Kokoro family member. Surfaces the missing extra as a clean 503
+    BEFORE we load weights, attempt synthesis, or hit the runtime
+    ``Kokoro requires the optional 'misaki' package`` error inside
+    mlx_audio.
+
+    The check is intentionally narrow — Chatterbox / VibeVoice /
+    VoxCPM don't depend on misaki, so this helper isn't called for
+    those families. The TTS lane probe still gates them all the same.
+    """
+    import importlib.util
+
+    from fastapi import HTTPException
+
+    if importlib.util.find_spec(_KOKORO_EXTRA_DEP) is not None:
+        return
+    raise HTTPException(
+        status_code=503,
+        detail=f"{_KOKORO_EXTRA_HINT}",
+    )
 
 
 def _probe_lane(lane: str) -> _Verdict:

--- a/vllm_mlx/audio/stt.py
+++ b/vllm_mlx/audio/stt.py
@@ -191,6 +191,15 @@ class STTEngine:
         self,
         audio_path: str | Path,
         language: str | None = None,
+        # F-K-TRANSLATIONS-MISSING: ``task`` is forwarded by both
+        # ``/v1/audio/transcriptions`` (``task="transcribe"``) and
+        # ``/v1/audio/translations`` (``task="translate"``). For
+        # Whisper engines the value flows through to ``model.generate``
+        # so the underlying decoder emits English when translating
+        # and source-language text when transcribing. Parakeet engines
+        # ignore the kwarg (English-only). This kwarg was present
+        # pre-bundle; the comment is here so the call sites are
+        # discoverable from the function definition.
         task: str = "transcribe",
     ) -> TranscriptionResult:
         """
@@ -199,7 +208,9 @@ class STTEngine:
         Args:
             audio_path: Path to audio file (mp3, wav, m4a, etc.)
             language: Language code (e.g., "en", "es"). Auto-detected if None.
-            task: "transcribe" or "translate" (translate to English)
+            task: "transcribe" or "translate" (translate to English).
+                Forwarded to ``model.generate`` for Whisper engines;
+                ignored by Parakeet (which is English-only).
 
         Returns:
             TranscriptionResult with text and metadata

--- a/vllm_mlx/audio/stt.py
+++ b/vllm_mlx/audio/stt.py
@@ -92,6 +92,14 @@ class STTEngine:
         self.model = None
         self._loaded = False
         self._is_parakeet = "parakeet" in model_name.lower()
+        # Codex r6 BLOCKING: ``_ensure_whisper_processor`` previously
+        # ran for every non-Parakeet engine, which would attach a
+        # WhisperProcessor to Voxtral/other future STT engines whose
+        # model object happens to expose a None-valued ``_processor``
+        # attribute. Gate on a positive Whisper id check so the patch
+        # only fires for actual Whisper backends — non-Whisper engines
+        # surface their own load-time errors unmodified.
+        self._is_whisper = "whisper" in model_name.lower()
 
     def load(self) -> None:
         """Load the STT model."""
@@ -107,7 +115,15 @@ class STTEngine:
             # mlx_audio's own post_load_hook, so if that succeeded
             # (e.g. a future repo upload includes processor files)
             # this is a no-op.
-            if not self._is_parakeet:
+            #
+            # Codex r6 BLOCKING: gate POSITIVELY on the Whisper id
+            # (``self._is_whisper``) rather than negatively on
+            # Parakeet. Any future STT engine (Voxtral, Wav2Vec, etc.)
+            # whose model object exposes ``_processor=None`` would
+            # otherwise get a Whisper processor stapled on by mistake.
+            # Belt-and-braces — even the helper double-checks model
+            # type via ``hasattr/_processor`` before doing anything.
+            if self._is_whisper:
                 self._ensure_whisper_processor()
             self._loaded = True
             logger.info(f"STT model loaded: {self.model_name}")

--- a/vllm_mlx/audio/stt.py
+++ b/vllm_mlx/audio/stt.py
@@ -18,6 +18,39 @@ DEFAULT_WHISPER_MODEL = "mlx-community/whisper-large-v3-mlx"
 DEFAULT_PARAKEET_MODEL = "mlx-community/parakeet-tdt-0.6b-v2"
 
 
+# F-K-WHISPER-500: every mlx-community Whisper repo ships ONLY
+# ``weights.npz`` + ``config.json`` — no ``preprocessor_config.json``,
+# no tokenizer files. ``mlx_audio.stt.models.whisper.Model.post_load_hook``
+# therefore swallows the ``WhisperProcessor.from_pretrained(model_path)``
+# failure (warns), sets ``model._processor = None``, and the first
+# transcription request 500s with ``ValueError: Processor not found``.
+#
+# Fix at the rapid-mlx integration layer: after ``load_model`` returns,
+# if the model is Whisper and ``_processor`` is None, manually attach a
+# ``WhisperProcessor`` loaded from the OpenAI counterpart repo (which
+# ships every processor file the tokenizer wrapper needs). The fallback
+# is keyed off the mlx-community alias so unknown repos still get an
+# attempt at ``openai/whisper-large-v3`` (the v3 tokenizer matches all
+# v3 mlx variants because the language vocabulary is identical).
+#
+# This is the smallest possible fix that doesn't require uploading
+# processor files to the mlx-community side or pinning a specific
+# mlx_audio version. It's belt-and-braces — if a future mlx-community
+# upload ships processor files, the post_load_hook's own loader
+# succeeds first and ``_processor`` is already non-None on entry to
+# the patch helper below.
+_WHISPER_PROCESSOR_SOURCE_MAP: dict[str, str] = {
+    # mlx-community model id  →  openai counterpart that ships processor
+    "mlx-community/whisper-large-v3-mlx": "openai/whisper-large-v3",
+    "mlx-community/whisper-large-v3-turbo": "openai/whisper-large-v3-turbo",
+    "mlx-community/whisper-medium-mlx": "openai/whisper-medium",
+    "mlx-community/whisper-small-mlx": "openai/whisper-small",
+    "mlx-community/whisper-base-mlx": "openai/whisper-base",
+    "mlx-community/whisper-tiny-mlx": "openai/whisper-tiny",
+}
+_DEFAULT_WHISPER_PROCESSOR_FALLBACK = "openai/whisper-large-v3"
+
+
 @dataclass
 class TranscriptionResult:
     """Result from audio transcription."""
@@ -69,6 +102,13 @@ class STTEngine:
             from mlx_audio.stt.utils import load_model
 
             self.model = load_model(self.model_name)
+            # F-K-WHISPER-500: patch up the missing WhisperProcessor
+            # mlx-community Whisper repos don't ship. Runs AFTER
+            # mlx_audio's own post_load_hook, so if that succeeded
+            # (e.g. a future repo upload includes processor files)
+            # this is a no-op.
+            if not self._is_parakeet:
+                self._ensure_whisper_processor()
             self._loaded = True
             logger.info(f"STT model loaded: {self.model_name}")
         except ImportError as e:
@@ -76,6 +116,76 @@ class STTEngine:
             raise ImportError(
                 "mlx-audio is required for STT. Install with: pip install mlx-audio"
             ) from e
+
+    def _ensure_whisper_processor(self) -> None:
+        """Attach a ``WhisperProcessor`` if mlx_audio didn't.
+
+        F-K-WHISPER-500: ``mlx_audio.stt.models.whisper.Model.post_load_hook``
+        attempts ``WhisperProcessor.from_pretrained(model_path)`` and
+        swallows the failure (warns, sets ``_processor=None``). Every
+        ``mlx-community/whisper-*-mlx`` repo lacks processor files, so
+        the first ``transcribe`` call 500s with ``ValueError: Processor
+        not found``. Patch the gap by loading the processor from the
+        OpenAI counterpart repo whose files are public.
+
+        No-op when:
+          * the model already has a non-None ``_processor`` (a future
+            mlx-community upload could ship them);
+          * the model object doesn't expose a ``_processor`` attribute
+            (non-Whisper STT engines load through different code paths
+            and either already have a tokenizer or surface their own
+            error envelope on missing-processor);
+          * ``transformers`` isn't installed (extremely unlikely
+            because ``mlx_audio`` itself requires it, but we keep this
+            tolerant rather than crash the load — the missing processor
+            will surface as the same upstream ``ValueError`` at first
+            inference, which the route now converts to a clean 503
+            envelope).
+        """
+        # Non-Whisper engines (Parakeet, Voxtral, etc.) don't use
+        # ``_processor`` — they ship their own tokenizer infrastructure.
+        if self.model is None:
+            return
+        if not hasattr(self.model, "_processor"):
+            return
+        if getattr(self.model, "_processor", None) is not None:
+            return
+
+        # Pick the OpenAI counterpart by exact alias match, then fall
+        # back to the v3-large processor (vocab is identical for every
+        # v3 variant; this is the most permissive fallback).
+        processor_source = _WHISPER_PROCESSOR_SOURCE_MAP.get(
+            self.model_name, _DEFAULT_WHISPER_PROCESSOR_FALLBACK
+        )
+        try:
+            from transformers import WhisperProcessor
+        except ImportError:
+            logger.warning(
+                "transformers not installed; Whisper processor patch skipped — "
+                "transcription will fail with the upstream `Processor not found`."
+            )
+            return
+
+        try:
+            processor = WhisperProcessor.from_pretrained(processor_source)
+        except Exception as e:  # noqa: BLE001
+            # Network failure, gated repo, unsupported revision — log
+            # and bail. The upstream ValueError surfaces at first
+            # transcribe; the route wraps it in a clean 5xx envelope.
+            logger.warning(
+                "WhisperProcessor.from_pretrained(%r) failed: %s — "
+                "transcription will still fail until the processor is wired.",
+                processor_source,
+                e,
+            )
+            return
+
+        self.model._processor = processor
+        logger.info(
+            "Attached WhisperProcessor from %r to %r (F-K-WHISPER-500 fix).",
+            processor_source,
+            self.model_name,
+        )
 
     def transcribe(
         self,

--- a/vllm_mlx/routes/audio.py
+++ b/vllm_mlx/routes/audio.py
@@ -185,6 +185,64 @@ def _resolve_stt_model(model: str) -> str:
     )
 
 
+def _reject_non_whisper_for_translation(model: str) -> None:
+    """Codex r6 NIT: ``/v1/audio/translations`` promises English output.
+
+    Only Whisper engines honor ``task="translate"`` (mlx_audio's
+    Parakeet path ignores the kwarg and emits source-language text).
+    Accepting a non-Whisper alias here would silently break the
+    translations contract. Inspect the alias (after resolution to its
+    upstream id, if applicable) and reject anything that is
+    recognizably non-Whisper with a 400 distinct from the 404
+    ``model_not_found`` envelope (the model is real, it's just the
+    wrong engine for this route).
+
+    Routing order: this helper handles ONLY models we positively
+    recognize as non-Whisper (Parakeet aliases, or HF ids with
+    ``parakeet``/other-engine markers). Unknown bare strings fall
+    through to ``_resolve_stt_model``'s 404 ``model_not_found_error``
+    so the envelope matches transcriptions. Empty / non-string ``model``
+    likewise falls through to the 400 envelope ``_resolve_stt_model``
+    emits.
+    """
+    if not isinstance(model, str) or not model:
+        return
+    # Resolve aliases first so callers that pass ``parakeet`` (alias)
+    # vs ``mlx-community/parakeet-tdt-0.6b-v2`` (HF id) get the same
+    # verdict.
+    resolved = STT_MODEL_ALIASES.get(model, model)
+    resolved_lc = resolved.lower()
+    # Whisper-shaped → accept; the engine honors task=translate.
+    if "whisper" in resolved_lc:
+        return
+    # Bare alias not in STT_MODEL_ALIASES → leave for _resolve_stt_model
+    # to 404 (so the envelope matches transcriptions' unknown-model
+    # path). HF-shaped ids (containing a ``/``) are pass-through in
+    # _resolve_stt_model, so we MUST classify here: a parakeet/voxtral/
+    # other-engine HF id would otherwise reach the engine and produce
+    # source-language output.
+    if "/" not in model and model not in STT_MODEL_ALIASES:
+        return
+    raise HTTPException(
+        status_code=400,
+        detail={
+            "error": {
+                "message": (
+                    f"The model `{model}` cannot perform translation. "
+                    "`/v1/audio/translations` requires a Whisper engine "
+                    "(only Whisper honors `task=translate`). Use "
+                    "`/v1/audio/transcriptions` for source-language "
+                    "output, or pass a Whisper alias such as "
+                    "`whisper-large-v3`."
+                ),
+                "type": "invalid_request_error",
+                "code": "invalid_model_for_translation",
+                "param": "model",
+            }
+        },
+    )
+
+
 class AudioBodyLimitMiddleware:
     """ASGI middleware that bounds the request body of audio-upload
     routes BEFORE Starlette's multipart parser can spool it.
@@ -632,13 +690,12 @@ async def create_translation(
     the form body. The underlying mlx-audio path is identical: Whisper
     accepts ``task="translate"`` which forces English emission.
 
-    Parakeet aliases (``parakeet``, ``parakeet-v3``) are accepted to
-    keep the model-validation envelope consistent with transcriptions,
-    but the STT engine ignores the task flag for non-Whisper engines
-    so the response will be source-language (typically English for
-    Parakeet's training set). That's the closest correct behavior we
-    can offer without a separate translation model; the client can
-    still verify by passing ``model="whisper-large-v3"``.
+    Codex r6 NIT: non-Whisper engines (Parakeet, future Voxtral, etc.)
+    ignore the ``task="translate"`` flag, so accepting them here would
+    silently return source-language audio under a contract that
+    promises English. Reject non-Whisper aliases at the route boundary
+    with a 400 ``invalid_model_for_translation`` so callers get a
+    distinct, actionable error instead of mislabeled output.
     """
     model = (
         model_form
@@ -650,6 +707,16 @@ async def create_translation(
         if response_format_form is not None
         else (response_format_query if response_format_query is not None else "json")
     )
+
+    # Codex r6 NIT: the translations contract guarantees English
+    # output. Only Whisper engines honor ``task="translate"``; any
+    # other STT alias would silently fall through to source-language
+    # output. Reject up front with a clear envelope so callers know to
+    # switch models (or fall back to /v1/audio/transcriptions if they
+    # only need source-language text). Performed BEFORE the body probe
+    # so a clearly-misrouted Parakeet request fails without touching
+    # mlx_audio at all.
+    _reject_non_whisper_for_translation(model)
 
     # F-D05: STT-lane audio dep probe (kept inside the route body so
     # the source-grep regression guard in

--- a/vllm_mlx/routes/audio.py
+++ b/vllm_mlx/routes/audio.py
@@ -220,7 +220,16 @@ class AudioBodyLimitMiddleware:
     means.
     """
 
-    _GUARDED_PATHS: tuple[str, ...] = ("/v1/audio/transcriptions",)
+    _GUARDED_PATHS: tuple[str, ...] = (
+        "/v1/audio/transcriptions",
+        # F-K-TRANSLATIONS-MISSING: the translations route mirrors the
+        # transcriptions multipart contract — multipart parsing happens
+        # the same way, so the body cap must guard both paths. Without
+        # this entry an attacker could send a 1 GB ``.wav`` to
+        # ``/v1/audio/translations`` and exhaust the worker before the
+        # streaming cap inside the handler kicks in.
+        "/v1/audio/translations",
+    )
 
     def __init__(self, app):
         self.app = app
@@ -383,6 +392,143 @@ async def _stream_upload_to_tempfile(file: UploadFile, tmp) -> None:
         tmp.write(chunk)
 
 
+async def _run_stt_request(
+    file: UploadFile,
+    model: str,
+    language: str | None,
+    response_format: str,
+    task: str,
+):
+    """Shared STT pipeline used by both ``/v1/audio/transcriptions`` and
+    ``/v1/audio/translations``.
+
+    The two OpenAI endpoints have IDENTICAL multipart contracts — the
+    only difference is the destination language: transcriptions keeps
+    the source language (``task="transcribe"``), translations forces
+    English output (``task="translate"``). Factoring the body into a
+    helper keeps the size/probe/resolve/cleanup/envelope wiring in one
+    place so a future fix to either path lands on both.
+
+    F-K-TRANSLATIONS-MISSING: previously only the transcriptions route
+    existed; ``/v1/audio/translations`` 404'd. Mirror the route via
+    this helper and pass ``task="translate"`` so Whisper emits English.
+
+    NOTE: callers are responsible for invoking ``require_mlx_audio_stt()``
+    BEFORE this helper so the F-D05 source-grep regression guard
+    (``test_audio_probe_consistency.py``) sees the probe call inside
+    each route function body. Defense-in-depth: the helper also gates
+    on the model alias resolver, which raises 4xx before any model
+    load, so a missing probe call still fails closed — just not with
+    the uniform 503 envelope the probe emits.
+    """
+    global _stt_engine
+
+    # Resolve / validate the requested model BEFORE draining the upload.
+    # Previously every failure mode (unknown alias, missing mlx-audio,
+    # bad audio bytes) collapsed into a 500 "could not open/decode
+    # file" because ``STTEngine.load`` for a bogus name raised generic
+    # ``Exception`` caught by the catch-all below. Move the alias check
+    # up front so unknown ``model`` form fields fail fast with a 404
+    # "model_not_found_error" and never trigger a model load (F-165).
+    model_name = _resolve_stt_model(model)
+
+    tmp_path: str | None = None
+    try:
+        # SECURITY: Stream the upload to a bounded temp file *before* doing
+        # anything expensive. Even a client that lies about / omits
+        # Content-Length cannot force model load or import — they will hit
+        # the streaming cap inside _stream_upload_to_tempfile() and get a
+        # 413 long before the STTEngine block below runs.
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".wav") as tmp:
+            tmp_path = tmp.name
+            await _stream_upload_to_tempfile(file, tmp)
+
+        from ..audio.stt import STTEngine
+
+        if _stt_engine is None or _stt_engine.model_name != model_name:
+            _stt_engine = STTEngine(model_name)
+            _stt_engine.load()
+
+        result = _stt_engine.transcribe(tmp_path, language=language, task=task)
+
+        if response_format == "text":
+            return result.text
+
+        return {
+            "text": result.text,
+            "language": result.language,
+            "duration": result.duration,
+        }
+
+    except ImportError:
+        raise HTTPException(
+            status_code=503,
+            detail="mlx-audio not installed. Install with: pip install mlx-audio",
+        )
+    except HTTPException:
+        # Preserve our own status codes (e.g. 413 for oversized uploads,
+        # 404 for unknown STT alias) instead of downgrading them to 500
+        # via the catch-all below.
+        raise
+    except Exception as e:
+        # Full traceback goes to the operator log; the client sees a
+        # generic message so we don't leak filesystem paths or
+        # mlx-audio internals (mirrors the global server handler).
+        logger.exception("STT %s failed: %s", task, e)
+        # F-K-WHISPER-500: when mlx_audio reports a structural
+        # backend defect (missing processor wiring, broken model state)
+        # surface 503 ``backend_unavailable`` instead of the generic
+        # 500 ``transcription_failed``. The former tells clients the
+        # backend is unhealthy and they should fall back to another
+        # model; the latter implies the audio file was the problem.
+        msg = str(e)
+        if "Processor not found" in msg or "_processor" in msg:
+            raise HTTPException(
+                status_code=503,
+                detail={
+                    "error": {
+                        "message": (
+                            "Whisper backend is unhealthy: the configured "
+                            f"model `{model_name}` could not load a "
+                            "tokenizer/processor. Try `parakeet` or "
+                            "`parakeet-v3` for the STT lane on this install, "
+                            "or pin a Whisper variant whose mlx-community "
+                            "repo ships processor files."
+                        ),
+                        "type": "backend_unavailable_error",
+                        "code": "backend_unavailable",
+                        "param": "model",
+                    }
+                },
+            )
+        code = "transcription_failed" if task == "transcribe" else "translation_failed"
+        raise HTTPException(
+            status_code=500,
+            detail={
+                "error": {
+                    "message": (
+                        "Audio transcription failed"
+                        if task == "transcribe"
+                        else "Audio translation failed"
+                    ),
+                    "type": "api_error",
+                    "code": code,
+                    "param": None,
+                }
+            },
+        )
+    finally:
+        if tmp_path is not None:
+            try:
+                os.unlink(tmp_path)
+            except FileNotFoundError:
+                pass
+            except OSError as cleanup_err:
+                logger.warning(
+                    "Failed to unlink temp audio file %s: %s", tmp_path, cleanup_err
+                )
+
+
 @router.post("/v1/audio/transcriptions", dependencies=[Depends(verify_api_key)])
 async def create_transcription(
     file: UploadFile,
@@ -427,8 +573,6 @@ async def create_transcription(
     The 25 MB ceiling matches OpenAI's Whisper API and bounds the
     worst-case STT inference cost.
     """
-    global _stt_engine
-
     # Form wins over query when both are present (form is the OpenAI
     # contract; query is the pre-F-165 internal contract we're keeping
     # for back-compat). Defaults match the original signature.
@@ -447,85 +591,81 @@ async def create_transcription(
     # F-D05: STT-lane audio dep probe — same envelope as the TTS
     # lane shares. Fires BEFORE we spool any upload bytes so a broken
     # ``mlx_audio.stt`` install rejects cheaply (no temp file, no
-    # read loop). Codex r3 BLOCKING: probe the STT lane SPECIFICALLY
-    # so a torn TTS install doesn't 503 transcriptions and vice versa.
+    # read loop). Probed here (not inside ``_run_stt_request``) so
+    # the source-grep guard in test_audio_probe_consistency.py sees
+    # the ``require_mlx_audio`` call directly inside the route body.
     from ..audio.probe import require_mlx_audio_stt
 
     require_mlx_audio_stt()
 
-    # Resolve / validate the requested model BEFORE draining the upload.
-    # Previously every failure mode (unknown alias, missing mlx-audio,
-    # bad audio bytes) collapsed into a 500 "could not open/decode
-    # file" because ``STTEngine.load`` for a bogus name raised generic
-    # ``Exception`` caught by the catch-all below. Move the alias check
-    # up front so unknown ``model`` form fields fail fast with a 404
-    # "model_not_found_error" and never trigger a model load (F-165).
-    model_name = _resolve_stt_model(model)
+    return await _run_stt_request(
+        file=file,
+        model=model,
+        language=language,
+        response_format=response_format,
+        task="transcribe",
+    )
 
-    tmp_path: str | None = None
-    try:
-        # SECURITY: Stream the upload to a bounded temp file *before* doing
-        # anything expensive. Even a client that lies about / omits
-        # Content-Length cannot force model load or import — they will hit
-        # the streaming cap inside _stream_upload_to_tempfile() and get a
-        # 413 long before the STTEngine block below runs.
-        with tempfile.NamedTemporaryFile(delete=False, suffix=".wav") as tmp:
-            tmp_path = tmp.name
-            await _stream_upload_to_tempfile(file, tmp)
 
-        from ..audio.stt import STTEngine
+@router.post("/v1/audio/translations", dependencies=[Depends(verify_api_key)])
+async def create_translation(
+    file: UploadFile,
+    # OpenAI's translations endpoint mirrors transcriptions but
+    # OMITS the ``language`` field — the destination language is
+    # always English. We still accept it on the form for clients
+    # that share request-shaping code with transcriptions; it gets
+    # ignored downstream because Whisper's ``translate`` task
+    # always emits English regardless of the source-language hint.
+    # F-K-TRANSLATIONS-MISSING.
+    model_form: str | None = Form(None, alias="model"),
+    response_format_form: str | None = Form(None, alias="response_format"),
+    model_query: str | None = Query(None, alias="model"),
+    response_format_query: str | None = Query(None, alias="response_format"),
+):
+    """Translate audio to English (OpenAI Whisper API compatible).
 
-        if _stt_engine is None or _stt_engine.model_name != model_name:
-            _stt_engine = STTEngine(model_name)
-            _stt_engine.load()
+    F-K-TRANSLATIONS-MISSING: pre-fix this route was absent and
+    OpenAI-SDK clients calling ``client.audio.translations.create(...)``
+    saw a 404. Spec parity requires both transcriptions (source-
+    language output) and translations (always-English output) — the
+    only wire difference is that translations omits ``language`` from
+    the form body. The underlying mlx-audio path is identical: Whisper
+    accepts ``task="translate"`` which forces English emission.
 
-        result = _stt_engine.transcribe(tmp_path, language=language)
+    Parakeet aliases (``parakeet``, ``parakeet-v3``) are accepted to
+    keep the model-validation envelope consistent with transcriptions,
+    but the STT engine ignores the task flag for non-Whisper engines
+    so the response will be source-language (typically English for
+    Parakeet's training set). That's the closest correct behavior we
+    can offer without a separate translation model; the client can
+    still verify by passing ``model="whisper-large-v3"``.
+    """
+    model = (
+        model_form
+        if model_form is not None
+        else (model_query if model_query is not None else "whisper-large-v3")
+    )
+    response_format = (
+        response_format_form
+        if response_format_form is not None
+        else (response_format_query if response_format_query is not None else "json")
+    )
 
-        if response_format == "text":
-            return result.text
+    # F-D05: STT-lane audio dep probe (kept inside the route body so
+    # the source-grep regression guard in
+    # test_audio_probe_consistency.py picks it up — both the
+    # transcriptions and translations routes share the STT lane).
+    from ..audio.probe import require_mlx_audio_stt
 
-        return {
-            "text": result.text,
-            "language": result.language,
-            "duration": result.duration,
-        }
+    require_mlx_audio_stt()
 
-    except ImportError:
-        raise HTTPException(
-            status_code=503,
-            detail="mlx-audio not installed. Install with: pip install mlx-audio",
-        )
-    except HTTPException:
-        # Preserve our own status codes (e.g. 413 for oversized uploads,
-        # 404 for unknown STT alias) instead of downgrading them to 500
-        # via the catch-all below.
-        raise
-    except Exception as e:
-        # Full traceback goes to the operator log; the client sees a
-        # generic message so we don't leak filesystem paths or
-        # mlx-audio internals (mirrors the global server handler).
-        logger.exception("Transcription failed: %s", e)
-        raise HTTPException(
-            status_code=500,
-            detail={
-                "error": {
-                    "message": "Audio transcription failed",
-                    "type": "api_error",
-                    "code": "transcription_failed",
-                    "param": None,
-                }
-            },
-        )
-    finally:
-        if tmp_path is not None:
-            try:
-                os.unlink(tmp_path)
-            except FileNotFoundError:
-                pass
-            except OSError as cleanup_err:
-                logger.warning(
-                    "Failed to unlink temp audio file %s: %s", tmp_path, cleanup_err
-                )
+    return await _run_stt_request(
+        file=file,
+        model=model,
+        language=None,
+        response_format=response_format,
+        task="translate",
+    )
 
 
 @router.post("/v1/audio/speech", dependencies=[Depends(verify_api_key)])
@@ -556,7 +696,7 @@ async def create_speech(
     # NOT 503 this route — the lane separation closes the codex r3
     # regression where a broken STT install would mask TTS-usable
     # installs as fully broken.
-    from ..audio.probe import require_mlx_audio_tts
+    from ..audio.probe import require_kokoro_runtime, require_mlx_audio_tts
 
     require_mlx_audio_tts()
 
@@ -572,6 +712,16 @@ async def create_speech(
             "voxcpm": "mlx-community/VoxCPM1.5",
         }
         model_name = model_map.get(model, model)
+
+        # F-K-KOKORO-MISAKI: Kokoro pulls ``misaki`` lazily inside
+        # ``KokoroPipeline``; the TTS-lane probe above can't catch
+        # the missing extra because ``mlx_audio.tts.generate``
+        # imports cleanly without it. Gate the missing-extra at
+        # this boundary so the request 503s with a clean envelope
+        # BEFORE any weight load (mlx-community/Kokoro-82M-bf16 is
+        # ~300 MB) or pipeline construction kicks off.
+        if "kokoro" in model_name.lower():
+            require_kokoro_runtime()
 
         if _tts_engine is None or _tts_engine.model_name != model_name:
             _tts_engine = TTSEngine(model_name)

--- a/vllm_mlx/routes/models.py
+++ b/vllm_mlx/routes/models.py
@@ -330,6 +330,41 @@ def _reported_modality_for_embedding(locked_id: str) -> str:
     return "text"
 
 
+def _audio_lane_snapshot() -> dict[str, str] | None:
+    """Return the current per-lane audio status, or ``None`` when no
+    deep probe has run.
+
+    F-K-CAPABILITIES-OMIT-AUDIO: surfaces the recorded outcome of
+    :func:`vllm_mlx.audio.probe.deep_probe_audio_lane` on every
+    ``ModelInfo`` returned by ``/v1/models``. Pre-fix, audio lane
+    health was invisible — a Whisper backend that 500'd on every
+    request still advertised the same ``capabilities`` list as a
+    healthy one. Now a degraded lane shows up as
+    ``audio_lanes: {"stt": "degraded", ...}`` so dashboards / the
+    desktop can warn before sending real traffic.
+
+    The function is intentionally tolerant: any failure resolving
+    the probe module (e.g. ``[audio]`` extra not installed, so the
+    probe module isn't even reachable) returns ``None`` rather than
+    raising. ``/v1/models`` MUST stay 200 even when the audio probe
+    is broken.
+    """
+    try:
+        from ..audio import probe as _audio_probe
+    except Exception:  # noqa: BLE001
+        return None
+    snapshot: dict[str, str] = {}
+    for lane in ("stt", "tts"):
+        try:
+            entry = _audio_probe.audio_lane_status(lane)
+        except Exception:  # noqa: BLE001
+            continue
+        status = entry.get("status") if isinstance(entry, dict) else None
+        if status and status != "unknown":
+            snapshot[lane] = status
+    return snapshot or None
+
+
 def _build_model_info(model_id: str) -> ModelInfo:
     """Construct a ``ModelInfo`` for ``model_id``, filling vendor
     extension fields from the alias registry when the id resolves.
@@ -351,6 +386,13 @@ def _build_model_info(model_id: str) -> ModelInfo:
     # failures fall through to ``None`` and the client uses its own
     # per-family fallback. See ``_resolve_context_window`` docstring.
     context_window = _resolve_context_window(model_id)
+    # F-K-CAPABILITIES-OMIT-AUDIO: per-lane audio status snapshot, or
+    # ``None`` when the deep probe never ran (e.g.
+    # ``RAPID_MLX_AUDIO_DEEP_PROBE`` unset). Identical value is
+    # attached to every entry — the listing's role is to advertise
+    # SERVER-WIDE backend health, not per-model audio capability
+    # (which would require a separate dry-run per audio alias).
+    audio_lanes = _audio_lane_snapshot()
 
     locked = _locked_embedding_id()
     if locked is not None and model_id == locked:
@@ -367,6 +409,7 @@ def _build_model_info(model_id: str) -> ModelInfo:
                 modality=_reported_modality_for_embedding(locked),
                 capabilities=["embedding"],
                 context_window=context_window,
+                audio_lanes=audio_lanes,
             )
         sampling = (
             dict(profile.recommended_sampling)
@@ -383,6 +426,7 @@ def _build_model_info(model_id: str) -> ModelInfo:
             modality=_reported_modality_for_embedding(locked),
             capabilities=["embedding"],
             context_window=context_window,
+            audio_lanes=audio_lanes,
         )
 
     if profile is None:
@@ -404,6 +448,7 @@ def _build_model_info(model_id: str) -> ModelInfo:
                     modality="image",
                     capabilities=capabilities,
                     context_window=context_window,
+                    audio_lanes=audio_lanes,
                 )
         except Exception:  # noqa: BLE001
             pass
@@ -411,6 +456,7 @@ def _build_model_info(model_id: str) -> ModelInfo:
             id=model_id,
             capabilities=capabilities,
             context_window=context_window,
+            audio_lanes=audio_lanes,
         )
     # ``recommended_sampling`` lives on the dataclass as a tuple of
     # ``(key, value)`` pairs (frozen-dataclass requirement); convert
@@ -438,6 +484,7 @@ def _build_model_info(model_id: str) -> ModelInfo:
         modality=_reported_modality(model_id, profile.modality),
         capabilities=capabilities,
         context_window=context_window,
+        audio_lanes=audio_lanes,
     )
 
 

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -431,7 +431,11 @@ async def lifespan(app: FastAPI):
     # health. ``deep_probe_audio_lane`` already runs the shallow
     # presence check internally and records the missing-extra
     # status via the same code path the route's 503 envelope uses.
-    _audio_deep_probe = os.environ.get("RAPID_MLX_AUDIO_DEEP_PROBE", "").strip()
+    # Codex r3 NIT #2: lowercase the env value before comparing so
+    # ``RAPID_MLX_AUDIO_DEEP_PROBE=False`` (capital F) and ``NO``
+    # (uppercase) are treated as falsy, not truthy. Mirrors the
+    # convention used by every other ``RAPID_MLX_*`` boolean knob.
+    _audio_deep_probe = os.environ.get("RAPID_MLX_AUDIO_DEEP_PROBE", "").strip().lower()
     if _audio_deep_probe and _audio_deep_probe not in ("0", "false", "no"):
         try:
             from .audio.probe import deep_probe_audio_lane as _deep_probe

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -419,24 +419,31 @@ async def lifespan(app: FastAPI):
     # turn on via ``RAPID_MLX_AUDIO_DEEP_PROBE=1`` when running an
     # audio-serving build. The dry-run is non-fatal: any failure is
     # caught inside ``deep_probe_audio_lane`` and recorded as
-    # ``degraded``; the lifespan completes regardless so a torn
-    # audio backend doesn't block server boot.
+    # ``degraded`` / ``missing``; the lifespan completes regardless
+    # so a torn audio backend doesn't block server boot.
+    #
+    # Codex r2 NIT #3: call ``deep_probe_audio_lane`` unconditionally
+    # (even when ``mlx_audio`` is missing) so ``/v1/models`` carries
+    # ``audio_lanes={"stt":"missing","tts":"missing"}`` on bare
+    # installs. The prior branch short-circuited on ``find_spec``
+    # and ``audio_lanes`` came back ``null``, hiding the "no audio
+    # extra installed" state from operators using the field for
+    # health. ``deep_probe_audio_lane`` already runs the shallow
+    # presence check internally and records the missing-extra
+    # status via the same code path the route's 503 envelope uses.
     _audio_deep_probe = os.environ.get("RAPID_MLX_AUDIO_DEEP_PROBE", "").strip()
     if _audio_deep_probe and _audio_deep_probe not in ("0", "false", "no"):
         try:
-            import importlib.util as _audio_ilu
+            from .audio.probe import deep_probe_audio_lane as _deep_probe
 
-            if _audio_ilu.find_spec("mlx_audio") is not None:
-                from .audio.probe import deep_probe_audio_lane as _deep_probe
-
-                logger.info("Running deep audio probe (STT + TTS dry-run)...")
-                _stt_status = _deep_probe("stt")
-                _tts_status = _deep_probe("tts")
-                logger.info(
-                    "Audio lane status — stt=%s, tts=%s",
-                    _stt_status.get("status"),
-                    _tts_status.get("status"),
-                )
+            logger.info("Running deep audio probe (STT + TTS dry-run)...")
+            _stt_status = _deep_probe("stt")
+            _tts_status = _deep_probe("tts")
+            logger.info(
+                "Audio lane status — stt=%s, tts=%s",
+                _stt_status.get("status"),
+                _tts_status.get("status"),
+            )
         except Exception as _audio_err:  # noqa: BLE001
             logger.warning("Deep audio probe failed (non-fatal): %s", _audio_err)
 

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -408,6 +408,38 @@ async def lifespan(app: FastAPI):
     if mcp_config:
         await init_mcp(mcp_config)
 
+    # F-K-CAPABILITIES-OMIT-AUDIO: run a deep audio-lane dry-run so
+    # the per-lane status surfaces on ``/v1/models`` capability tags
+    # BEFORE the first user request lands on a degraded backend. The
+    # existing shallow probe only checks ``mlx_audio`` importability;
+    # a model that loads but can't generate output (F-K-WHISPER-500
+    # shape) still passed the shallow probe and 500'd at first use.
+    #
+    # Off by default to keep cold-start fast for text-only deploys —
+    # turn on via ``RAPID_MLX_AUDIO_DEEP_PROBE=1`` when running an
+    # audio-serving build. The dry-run is non-fatal: any failure is
+    # caught inside ``deep_probe_audio_lane`` and recorded as
+    # ``degraded``; the lifespan completes regardless so a torn
+    # audio backend doesn't block server boot.
+    _audio_deep_probe = os.environ.get("RAPID_MLX_AUDIO_DEEP_PROBE", "").strip()
+    if _audio_deep_probe and _audio_deep_probe not in ("0", "false", "no"):
+        try:
+            import importlib.util as _audio_ilu
+
+            if _audio_ilu.find_spec("mlx_audio") is not None:
+                from .audio.probe import deep_probe_audio_lane as _deep_probe
+
+                logger.info("Running deep audio probe (STT + TTS dry-run)...")
+                _stt_status = _deep_probe("stt")
+                _tts_status = _deep_probe("tts")
+                logger.info(
+                    "Audio lane status — stt=%s, tts=%s",
+                    _stt_status.get("status"),
+                    _tts_status.get("status"),
+                )
+        except Exception as _audio_err:  # noqa: BLE001
+            logger.warning("Deep audio probe failed (non-fatal): %s", _audio_err)
+
     # All slow startup work done. Flip the readiness flag so /health/ready
     # starts returning 200. Anything that races a request before this point
     # would otherwise hit a not-yet-warmed engine.


### PR DESCRIPTION
## Summary

Karim's 0.8.5 dogfood (r1 + r2) surfaced four CRIT/HIGH defects on the audio routes. All fixed at the rapid-mlx integration layer — no changes to mlx_audio itself, no pinning required.

- **F-K-WHISPER-500** (CRIT): `/v1/audio/transcriptions?model=whisper-large-v3` returned 500. Root cause: every `mlx-community/whisper-*-mlx` repo ships only `weights.npz` + `config.json` (no processor files), so `mlx_audio.stt.models.whisper.Model.post_load_hook` silently sets `_processor=None` and `transcribe` raises `ValueError: Processor not found`. Fix: `STTEngine.load` detects the missing processor and attaches a `WhisperProcessor` loaded from the OpenAI counterpart repo. If the fallback fetch also fails, the route returns a 503 `backend_unavailable` envelope steering the user toward Parakeet — not a generic 500.
- **F-K-KOKORO-MISAKI** (CRIT): `/v1/audio/speech` with Kokoro 503'd deep inside the engine because the `misaki` G2P package is missing on the default install. `misaki` IS in `[audio]` extras but Kokoro pulls it lazily so the existing TTS-lane probe doesn't catch it. Fix: added `require_kokoro_runtime()` to `vllm_mlx.audio.probe` — the speech route calls it whenever the resolved model is Kokoro-family, so missing-extra fails BEFORE the 300 MB weight download. The check is family-scoped: Chatterbox/VibeVoice/VoxCPM don't pull misaki and aren't 503'd by its absence.
- **F-K-TRANSLATIONS-MISSING** (HIGH): `/v1/audio/translations` 404'd. Route registered as a thin wrapper that mirrors `/v1/audio/transcriptions` but forces `task="translate"` so Whisper emits English. Both routes share `_run_stt_request` so future fixes land on both. The `AudioBodyLimitMiddleware` 25 MB cap now also guards the new path.
- **F-K-CAPABILITIES-OMIT-AUDIO** (HIGH): D-CAPABILITIES-DETECTION's per-lane probe only checked `mlx_audio` importability — a Whisper backend loadable at boot still 500'd at first request. Added an opt-in deep probe (`RAPID_MLX_AUDIO_DEEP_PROBE=1`) that runs a tiny dry-run inference per lane during lifespan startup; failures are caught and surfaced via the new `audio_lanes` field on `/v1/models` entries (e.g. `{"stt": "ok", "tts": "degraded"}`). Non-fatal — a degraded lane never blocks boot.

Skipped F-K-ANTHROPIC-LEAK per operator's "skip security/auth" instruction.

## Evidence — live repro after fix

```
$ curl -s -X POST http://127.0.0.1:9194/v1/audio/transcriptions \
    -F file=@/tmp/karim-tone.wav -F model=whisper-large-v3
{"text":"","language":"en","duration":null}                 # 200, was 500 pre-fix

$ curl -s -X POST http://127.0.0.1:9194/v1/audio/translations \
    -F file=@/tmp/karim-tone.wav -F model=whisper-large-v3
{"text":"","language":"en","duration":null}                 # 200, was 404 pre-fix

$ curl -s -X POST http://127.0.0.1:9194/v1/audio/speech \
    -H 'Content-Type: application/json' \
    -d '{"model":"kokoro","input":"hello","voice":"af_heart"}'
{"error":{"message":"Kokoro TTS requires the optional `misaki` G2P package... pip install 'rapid-mlx[audio]' ..."}}
                                                            # clean 503 envelope with install hint

$ RAPID_MLX_AUDIO_DEEP_PROBE=1 rapid-mlx serve qwen3-0.6b-8bit ...
INFO:rapid_mlx.server:Running deep audio probe (STT + TTS dry-run)...
INFO:rapid_mlx.server:Audio lane status — stt=ok, tts=degraded
$ curl -s http://127.0.0.1:9194/v1/models | jq '.data[0].audio_lanes'
{"stt": "ok", "tts": "degraded"}                            # surfaced on /v1/models
```

## Test plan

- [x] `python -m pytest tests/test_audio_routes_bundle.py` — 15 new tests pass
- [x] `python -m pytest tests/ -k 'audio or stt or tts or transcription or translation or whisper or kokoro'` — 88 pass, 3 skip, 0 fail (existing audio suite + new bundle)
- [x] `python -m pytest tests/ -k 'envelope or capabilit or model_listing'` — 122 pass, 0 fail (probes the `/v1/models` shape change)
- [x] `ruff check vllm_mlx/ tests/` — clean
- [x] `ruff format vllm_mlx/ tests/` — clean
- [x] Live repro against `rapid-mlx serve qwen3-0.6b-8bit --port 9194` confirms Karim's r1/r2 probes now pass: Whisper 200, translations 200, Kokoro clean 503, deep probe records `tts=degraded` on `/v1/models`
- [x] Test-then-delete: WAV fixture (`/tmp/karim-tone.wav`) and server log (`/tmp/audio-server.log`) cleaned up after repro

## Notes

- Version bump intentionally omitted; tagged `skip-version-bump` on this PR.
- Coordinate with R-03+R-04 fix-agent (alias resolution) — they may touch `/v1/audio/*` too; will rebase before merge if needed.