### PR TITLE
fix(logging+deps): r5-C — /v1/completions log sanitize + UI-TARS boot guard

### DIFF
--- a/tests/test_completions_log_redaction.py
+++ b/tests/test_completions_log_redaction.py
@@ -1,0 +1,212 @@
+# SPDX-License-Identifier: Apache-2.0
+"""R-05 — ``/v1/completions`` must not leak the request body at INFO level.
+
+PyPI 0.8.6 dogfood (liang-r2 L2-001): a request to ``/v1/completions``
+with prompt ``"my secret password is hunter2"`` produced a server log
+line at INFO level containing
+``prompt_preview="my secret password is hunter2"``. The chat /
+anthropic / responses lanes already split metadata at INFO and content
+preview at DEBUG; legacy completions skipped the parity, so anyone with
+log-aggregator read access could harvest credentials posted to that
+route.
+
+This module pins the fix:
+
+* INFO records for ``/v1/completions`` contain only metadata (counts,
+  lengths, model id, sampling knobs) — no prompt body.
+* The body preview, when emitted, lands at DEBUG (operator opt-in via
+  ``--log-level debug``), matching the chat lane's
+  ``logger.debug("[REQUEST] last user message preview: ...")``.
+* The metadata still includes ``prompt_chars`` (length) so operators
+  can still detect oversized prompts without reading the body.
+"""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+SENTINEL = "my secret password is hunter2"
+
+
+@pytest.fixture()
+def client_with_completions_route(monkeypatch):
+    """Wire just enough of the production stack to hit
+    ``create_completion`` and observe its log output.
+
+    We monkeypatch the engine + admission helpers so the route does
+    NOT try to load a real model; the goal is purely to drive the
+    request-logging path with caplog.
+    """
+    from vllm_mlx.routes import completions as completions_mod
+
+    # Fake engine that returns a deterministic empty completion. The
+    # body-redaction log line runs BEFORE the engine is touched, but
+    # the helpers below still need plausible return values so the
+    # response path completes without error.
+    fake_engine = MagicMock()
+    fake_engine.generate = AsyncMock(
+        return_value=MagicMock(
+            text="",
+            finish_reason="stop",
+            completion_tokens=0,
+            prompt_tokens=0,
+            cached_tokens=0,
+        )
+    )
+
+    monkeypatch.setattr(completions_mod, "get_engine", lambda _name: fake_engine)
+    monkeypatch.setattr(completions_mod, "_check_admission_or_503", lambda _eng: None)
+    monkeypatch.setattr(
+        completions_mod, "_release_admission_unless_committed", lambda *a, **kw: None
+    )
+    monkeypatch.setattr(
+        completions_mod,
+        "enforce_context_length_for_prompt",
+        lambda *a, **kw: None,
+    )
+    monkeypatch.setattr(
+        completions_mod, "_validate_model_name", lambda _m: None
+    )
+    monkeypatch.setattr(
+        completions_mod, "_resolve_model_name", lambda m: m
+    )
+    monkeypatch.setattr(
+        completions_mod, "_resolve_max_tokens", lambda m: m or 16
+    )
+    monkeypatch.setattr(
+        completions_mod, "_resolve_temperature", lambda t: t
+    )
+    monkeypatch.setattr(completions_mod, "_resolve_top_p", lambda p: p)
+    monkeypatch.setattr(
+        completions_mod, "build_extended_sampling_kwargs", lambda _r: {}
+    )
+
+    async def _passthrough(coro, *_a, **_kw):
+        return await coro
+
+    monkeypatch.setattr(completions_mod, "_wait_with_disconnect", _passthrough)
+
+    # No-op auth + rate limit so the request reaches the body of the
+    # handler without hitting either middleware.
+    with patch(
+        "vllm_mlx.middleware.auth.verify_api_key", new=lambda *a, **kw: None
+    ), patch(
+        "vllm_mlx.middleware.auth.check_rate_limit", new=lambda *a, **kw: None
+    ):
+        app = FastAPI()
+        app.include_router(completions_mod.router)
+        yield TestClient(app)
+
+
+def _records_at_or_above(caplog, level: int) -> list[logging.LogRecord]:
+    return [r for r in caplog.records if r.levelno >= level]
+
+
+def test_info_log_does_not_leak_prompt_body(
+    client_with_completions_route, caplog
+):
+    """R-05 repro: send a prompt containing a 'secret' sentinel,
+    assert it does NOT appear in any INFO-or-higher log record."""
+    # Capture every level so we can also positively assert the DEBUG
+    # preview behaviour later.
+    # Note: the runtime log-namespace rebrand (vllm_mlx -> rapid_mlx)
+    # rewrites the record.name AFTER emit, but caplog filters by the
+    # logger we configure — set both to be safe.
+    caplog.set_level(logging.DEBUG)
+
+    resp = client_with_completions_route.post(
+        "/v1/completions",
+        json={
+            "model": "qwen3-0.6b-8bit",
+            "prompt": SENTINEL,
+            "max_tokens": 8,
+        },
+    )
+    assert resp.status_code == 200, resp.text
+
+    info_records = _records_at_or_above(caplog, logging.INFO)
+    leaked = [r for r in info_records if SENTINEL in r.getMessage()]
+    assert not leaked, (
+        "R-05 regression: /v1/completions INFO log carried the prompt "
+        f"body. Offending records: {[r.getMessage() for r in leaked]}"
+    )
+
+
+def test_info_log_carries_metadata_only(
+    client_with_completions_route, caplog
+):
+    """INFO line must still surface request metadata (model id, token
+    counts, sampling) so operators can debug without reading bodies."""
+    caplog.set_level(logging.INFO)
+
+    resp = client_with_completions_route.post(
+        "/v1/completions",
+        json={
+            "model": "qwen3-0.6b-8bit",
+            "prompt": SENTINEL,
+            "max_tokens": 8,
+        },
+    )
+    assert resp.status_code == 200, resp.text
+
+    info_msgs = [
+        r.getMessage()
+        for r in caplog.records
+        if r.levelno == logging.INFO
+        and r.name.endswith("routes.completions")
+    ]
+    request_lines = [m for m in info_msgs if "[REQUEST]" in m]
+    assert request_lines, f"no [REQUEST] log line found in {info_msgs!r}"
+
+    line = request_lines[0]
+    # Metadata must remain present (no body, but counts/sampling/model).
+    assert "/v1/completions" in line
+    assert "prompt_chars=" in line
+    assert "n_prompts=" in line
+    assert "max_tokens=" in line
+    # And the secret sentinel must be absent from this specific record.
+    assert SENTINEL not in line
+
+
+def test_debug_log_carries_redacted_preview(
+    client_with_completions_route, caplog
+):
+    """The body preview moved from INFO to DEBUG. Operators who flip
+    the log level to DEBUG still get a 300-char preview for local
+    debugging — but it's behind an explicit opt-in, not the production
+    default."""
+    # Note: the runtime log-namespace rebrand (vllm_mlx -> rapid_mlx)
+    # rewrites the record.name AFTER emit, but caplog filters by the
+    # logger we configure — set both to be safe.
+    caplog.set_level(logging.DEBUG)
+
+    resp = client_with_completions_route.post(
+        "/v1/completions",
+        json={
+            "model": "qwen3-0.6b-8bit",
+            "prompt": SENTINEL,
+            "max_tokens": 8,
+        },
+    )
+    assert resp.status_code == 200, resp.text
+
+    debug_msgs = [
+        r.getMessage()
+        for r in caplog.records
+        if r.levelno == logging.DEBUG
+        and r.name.endswith("routes.completions")
+    ]
+    preview_lines = [m for m in debug_msgs if "prompt preview" in m]
+    assert preview_lines, (
+        "DEBUG preview line missing — the body still has to be reachable "
+        f"for local debugging, just not at INFO. debug_msgs={debug_msgs!r}"
+    )
+    # The sentinel CAN appear at DEBUG (that's the whole point of the
+    # opt-in preview); the regression we guard against is INFO-level
+    # leakage.
+    assert SENTINEL in preview_lines[0]

--- a/tests/test_completions_log_redaction.py
+++ b/tests/test_completions_log_redaction.py
@@ -69,18 +69,10 @@ def client_with_completions_route(monkeypatch):
         "enforce_context_length_for_prompt",
         lambda *a, **kw: None,
     )
-    monkeypatch.setattr(
-        completions_mod, "_validate_model_name", lambda _m: None
-    )
-    monkeypatch.setattr(
-        completions_mod, "_resolve_model_name", lambda m: m
-    )
-    monkeypatch.setattr(
-        completions_mod, "_resolve_max_tokens", lambda m: m or 16
-    )
-    monkeypatch.setattr(
-        completions_mod, "_resolve_temperature", lambda t: t
-    )
+    monkeypatch.setattr(completions_mod, "_validate_model_name", lambda _m: None)
+    monkeypatch.setattr(completions_mod, "_resolve_model_name", lambda m: m)
+    monkeypatch.setattr(completions_mod, "_resolve_max_tokens", lambda m: m or 16)
+    monkeypatch.setattr(completions_mod, "_resolve_temperature", lambda t: t)
     monkeypatch.setattr(completions_mod, "_resolve_top_p", lambda p: p)
     monkeypatch.setattr(
         completions_mod, "build_extended_sampling_kwargs", lambda _r: {}
@@ -93,10 +85,9 @@ def client_with_completions_route(monkeypatch):
 
     # No-op auth + rate limit so the request reaches the body of the
     # handler without hitting either middleware.
-    with patch(
-        "vllm_mlx.middleware.auth.verify_api_key", new=lambda *a, **kw: None
-    ), patch(
-        "vllm_mlx.middleware.auth.check_rate_limit", new=lambda *a, **kw: None
+    with (
+        patch("vllm_mlx.middleware.auth.verify_api_key", new=lambda *a, **kw: None),
+        patch("vllm_mlx.middleware.auth.check_rate_limit", new=lambda *a, **kw: None),
     ):
         app = FastAPI()
         app.include_router(completions_mod.router)
@@ -107,9 +98,7 @@ def _records_at_or_above(caplog, level: int) -> list[logging.LogRecord]:
     return [r for r in caplog.records if r.levelno >= level]
 
 
-def test_info_log_does_not_leak_prompt_body(
-    client_with_completions_route, caplog
-):
+def test_info_log_does_not_leak_prompt_body(client_with_completions_route, caplog):
     """R-05 repro: send a prompt containing a 'secret' sentinel,
     assert it does NOT appear in any INFO-or-higher log record."""
     # Capture every level so we can also positively assert the DEBUG
@@ -137,9 +126,7 @@ def test_info_log_does_not_leak_prompt_body(
     )
 
 
-def test_info_log_carries_metadata_only(
-    client_with_completions_route, caplog
-):
+def test_info_log_carries_metadata_only(client_with_completions_route, caplog):
     """INFO line must still surface request metadata (model id, token
     counts, sampling) so operators can debug without reading bodies."""
     caplog.set_level(logging.INFO)
@@ -157,8 +144,7 @@ def test_info_log_carries_metadata_only(
     info_msgs = [
         r.getMessage()
         for r in caplog.records
-        if r.levelno == logging.INFO
-        and r.name.endswith("routes.completions")
+        if r.levelno == logging.INFO and r.name.endswith("routes.completions")
     ]
     request_lines = [m for m in info_msgs if "[REQUEST]" in m]
     assert request_lines, f"no [REQUEST] log line found in {info_msgs!r}"
@@ -173,9 +159,7 @@ def test_info_log_carries_metadata_only(
     assert SENTINEL not in line
 
 
-def test_debug_log_carries_redacted_preview(
-    client_with_completions_route, caplog
-):
+def test_debug_log_carries_redacted_preview(client_with_completions_route, caplog):
     """The body preview moved from INFO to DEBUG. Operators who flip
     the log level to DEBUG still get a 300-char preview for local
     debugging — but it's behind an explicit opt-in, not the production
@@ -198,8 +182,7 @@ def test_debug_log_carries_redacted_preview(
     debug_msgs = [
         r.getMessage()
         for r in caplog.records
-        if r.levelno == logging.DEBUG
-        and r.name.endswith("routes.completions")
+        if r.levelno == logging.DEBUG and r.name.endswith("routes.completions")
     ]
     preview_lines = [m for m in debug_msgs if "prompt preview" in m]
     assert preview_lines, (

--- a/tests/test_uitars_boot_check.py
+++ b/tests/test_uitars_boot_check.py
@@ -1,0 +1,183 @@
+# SPDX-License-Identifier: Apache-2.0
+"""R-10 — boot-time guard for UI-TARS / VLM aliases when ``mlx-vlm`` missing.
+
+PyPI 0.8.6 dogfood: a first-time ``pip install rapid-mlx`` user (no
+``[vision]`` extra) running ``rapid-mlx serve ui-tars-1.5-7b-4bit``
+crashed deep inside the engine's MLLM load path with a confusing
+``ImportError: No module named 'mlx_vlm'`` traceback — minutes of
+wall-clock noise (alias resolution + weight download via the R2
+mirror) before the actionable error surfaced.
+
+Fix shape (matches the ``--embedding-model`` /
+:func:`require_mlx_embeddings_or_exit` pattern at the top of
+``serve_command``):
+
+* Add :func:`mlx_vlm_available` (importlib-spec probe, no actual import).
+* Add :func:`require_mlx_vlm_or_exit` — print actionable install hint to
+  stderr and ``sys.exit(2)`` (argparse usage-error code).
+* Wire it into ``cli.serve_command`` BEFORE the multi-minute model
+  download, gated on ``is_mllm_model(args.model) or args.mllm`` and
+  bypassable via the existing ``--no-mllm`` escape hatch.
+
+This module pins:
+
+* The probe returns False when ``mlx_vlm`` is masked from importlib.
+* The probe returns True when ``mlx_vlm`` is installed (no-op in
+  installed envs).
+* The exit helper prints the actionable hint AND raises SystemExit(2).
+* The hint message names ``rapid-mlx[vision]`` so the user can copy-
+  paste straight from stderr.
+* The hint message names the offending model id so the user knows
+  WHY the boot failed (not just "vision needed").
+* :func:`_require_mlx_vlm` (the engine-side last-line-of-defence)
+  still raises a friendly :class:`ImportError` when called directly,
+  so library callers that skipped the CLI guard still get an
+  actionable message.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+
+import pytest
+
+
+def _mask_mlx_vlm(monkeypatch):
+    """Make ``importlib.util.find_spec("mlx_vlm")`` return None and
+    any direct ``import mlx_vlm`` raise ``ImportError`` — the exact
+    state of a fresh ``pip install rapid-mlx`` without the
+    ``[vision]`` extra."""
+    real_find_spec = importlib.util.find_spec
+
+    def _fake_find_spec(name, *args, **kwargs):
+        if name == "mlx_vlm" or name.startswith("mlx_vlm."):
+            return None
+        return real_find_spec(name, *args, **kwargs)
+
+    monkeypatch.setattr(importlib.util, "find_spec", _fake_find_spec)
+    # Also poison sys.modules so a direct import would fail. We can't
+    # just delete mlx_vlm from sys.modules (it may not be present), so
+    # we install a finder that refuses it.
+
+    class _BlockMlxVlm:
+        def find_spec(self, name, path=None, target=None):
+            if name == "mlx_vlm" or name.startswith("mlx_vlm."):
+                raise ImportError("mocked: mlx_vlm masked for R-10 test")
+            return None
+
+    # Insert before any other finders so our refusal wins.
+    monkeypatch.setattr(
+        sys, "meta_path", [_BlockMlxVlm(), *sys.meta_path], raising=False
+    )
+    # Drop any cached entry so a fresh import is forced.
+    sys.modules.pop("mlx_vlm", None)
+
+
+def test_mlx_vlm_available_returns_false_when_missing(monkeypatch):
+    """R-10 probe must return False on a base install with no extras."""
+    from vllm_mlx.models.mllm import mlx_vlm_available
+
+    _mask_mlx_vlm(monkeypatch)
+    assert mlx_vlm_available() is False
+
+
+def test_require_mlx_vlm_or_exit_prints_hint_and_exits(
+    monkeypatch, capsys
+):
+    """R-10 fix: boot guard must emit the actionable install hint to
+    stderr and ``sys.exit(2)`` — same shape as
+    :func:`require_mlx_embeddings_or_exit`."""
+    from vllm_mlx.models.mllm import require_mlx_vlm_or_exit
+
+    _mask_mlx_vlm(monkeypatch)
+
+    with pytest.raises(SystemExit) as exc_info:
+        require_mlx_vlm_or_exit("ui-tars-1.5-7b-4bit")
+
+    assert exc_info.value.code == 2
+
+    captured = capsys.readouterr()
+    err = captured.err
+    # User-facing hint must include the canonical install command,
+    # the offending model name, and a "vision" marker so the message
+    # is searchable in support threads.
+    assert "ui-tars-1.5-7b-4bit" in err, (
+        f"hint must name the offending model id, got: {err!r}"
+    )
+    assert "rapid-mlx[vision]" in err or "rapid-mlx[vision]" in err.replace(
+        "'", ""
+    ), f"hint must name the [vision] extra install path, got: {err!r}"
+    assert "mlx-vlm" in err, f"hint must name the dep, got: {err!r}"
+
+
+def test_require_mlx_vlm_or_exit_is_noop_when_installed(monkeypatch):
+    """When ``mlx_vlm`` IS installed (or its spec is fakable), the
+    guard returns silently — no SystemExit, no stderr output."""
+    from vllm_mlx.models.mllm import require_mlx_vlm_or_exit
+
+    # Force the probe to report True without touching sys.modules.
+    monkeypatch.setattr(
+        "vllm_mlx.models.mllm.mlx_vlm_available", lambda: True
+    )
+
+    # Must not raise SystemExit.
+    require_mlx_vlm_or_exit("ui-tars-1.5-7b-4bit")
+
+
+def test_engine_side_require_mlx_vlm_still_raises_importerror(
+    monkeypatch,
+):
+    """The pre-existing engine-side guard (:func:`_require_mlx_vlm`)
+    must remain an ``ImportError`` raiser — library callers that
+    skip the CLI guard (test harnesses, direct ``MLXMultimodalLM``
+    use) still need an actionable message rather than a raw
+    ``ModuleNotFoundError`` from deep inside the load path."""
+    from vllm_mlx.models.mllm import _require_mlx_vlm
+
+    _mask_mlx_vlm(monkeypatch)
+
+    with pytest.raises(ImportError) as exc_info:
+        _require_mlx_vlm()
+
+    # Same actionable hint surface as the CLI guard.
+    msg = str(exc_info.value)
+    assert "rapid-mlx[vision]" in msg
+    assert "mlx-vlm" in msg
+
+
+def test_vision_extra_pulls_in_mlx_vlm():
+    """L-07 lock-in: the ``[vision]`` extra in pyproject.toml MUST
+    declare ``mlx-vlm`` so ``pip install rapid-mlx[vision]`` is a
+    complete fix without needing a separate ``pip install mlx-vlm``."""
+    try:
+        import tomllib
+    except ImportError:  # pragma: no cover — Python 3.10 path
+        import tomli as tomllib
+
+    from pathlib import Path
+
+    pyproject_path = (
+        Path(__file__).resolve().parent.parent / "pyproject.toml"
+    )
+    data = tomllib.loads(pyproject_path.read_text())
+
+    extras = data["project"]["optional-dependencies"]
+    assert "vision" in extras, "[vision] extra missing entirely"
+    vision_deps = " ".join(extras["vision"])
+    assert "mlx-vlm" in vision_deps, (
+        "[vision] extra must declare mlx-vlm so the install hint in "
+        "require_mlx_vlm_or_exit actually fixes the missing dep — "
+        f"got vision = {extras['vision']!r}"
+    )
+    # `[all]` mirrors `[vision]` content directly (the comment in
+    # pyproject explains why a recursive self-dep breaks editable
+    # installs); the `[all]` extra must also include mlx-vlm so the
+    # ``pip install rapid-mlx[all]`` shortcut covers UI-TARS users.
+    all_deps = " ".join(extras["all"])
+    assert "mlx-vlm" in all_deps, (
+        "[all] extra must also include mlx-vlm — pre-fix this drift "
+        "was the secondary footgun (users following the docs to "
+        "`pip install rapid-mlx[all]` got everything EXCEPT the vision "
+        f"runtime). got all = {extras['all']!r}"
+    )

--- a/tests/test_uitars_boot_check.py
+++ b/tests/test_uitars_boot_check.py
@@ -82,9 +82,7 @@ def test_mlx_vlm_available_returns_false_when_missing(monkeypatch):
     assert mlx_vlm_available() is False
 
 
-def test_require_mlx_vlm_or_exit_prints_hint_and_exits(
-    monkeypatch, capsys
-):
+def test_require_mlx_vlm_or_exit_prints_hint_and_exits(monkeypatch, capsys):
     """R-10 fix: boot guard must emit the actionable install hint to
     stderr and ``sys.exit(2)`` — same shape as
     :func:`require_mlx_embeddings_or_exit`."""
@@ -105,9 +103,9 @@ def test_require_mlx_vlm_or_exit_prints_hint_and_exits(
     assert "ui-tars-1.5-7b-4bit" in err, (
         f"hint must name the offending model id, got: {err!r}"
     )
-    assert "rapid-mlx[vision]" in err or "rapid-mlx[vision]" in err.replace(
-        "'", ""
-    ), f"hint must name the [vision] extra install path, got: {err!r}"
+    assert "rapid-mlx[vision]" in err or "rapid-mlx[vision]" in err.replace("'", ""), (
+        f"hint must name the [vision] extra install path, got: {err!r}"
+    )
     assert "mlx-vlm" in err, f"hint must name the dep, got: {err!r}"
 
 
@@ -117,9 +115,7 @@ def test_require_mlx_vlm_or_exit_is_noop_when_installed(monkeypatch):
     from vllm_mlx.models.mllm import require_mlx_vlm_or_exit
 
     # Force the probe to report True without touching sys.modules.
-    monkeypatch.setattr(
-        "vllm_mlx.models.mllm.mlx_vlm_available", lambda: True
-    )
+    monkeypatch.setattr("vllm_mlx.models.mllm.mlx_vlm_available", lambda: True)
 
     # Must not raise SystemExit.
     require_mlx_vlm_or_exit("ui-tars-1.5-7b-4bit")
@@ -157,9 +153,7 @@ def test_vision_extra_pulls_in_mlx_vlm():
 
     from pathlib import Path
 
-    pyproject_path = (
-        Path(__file__).resolve().parent.parent / "pyproject.toml"
-    )
+    pyproject_path = Path(__file__).resolve().parent.parent / "pyproject.toml"
     data = tomllib.loads(pyproject_path.read_text())
 
     extras = data["project"]["optional-dependencies"]

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -888,6 +888,25 @@ def serve_command(args):
 
         require_mlx_embeddings_or_exit()
 
+    # R-10 (PyPI 0.8.6 dogfood): same boot-guard shape for vision /
+    # multimodal aliases. ``mlx-vlm`` lives behind the ``[vision]``
+    # extra, but ``rapid-mlx serve ui-tars-1.5-7b-4bit`` on a fresh
+    # ``pip install rapid-mlx`` previously fell into the engine load
+    # path BEFORE the missing-dep error surfaced (deep ImportError
+    # after weight download + alias resolution). Probe here so the
+    # operator sees an actionable hint before the long download starts.
+    # Honors ``--mllm`` force-on AND the alias-name / HF-path probe
+    # used downstream by ``pflash.validate_model_support``. The
+    # ``--no-mllm`` escape hatch (force_text in load_model) bypasses
+    # this guard, matching the engine-side semantics.
+    if not getattr(args, "no_mllm", False):
+        from .api.utils import is_mllm_model as _boot_is_mllm
+
+        if getattr(args, "mllm", False) or _boot_is_mllm(args.model):
+            from .models.mllm import require_mlx_vlm_or_exit
+
+            require_mlx_vlm_or_exit(args.model)
+
     # Interactive auto-upgrade prompt — when serve runs interactively and a
     # newer release is available, ask once before booting the model. Honors
     # RAPID_MLX_DISABLE_VERSION_CHECK, CI=1, and non-TTY stdin. Cached

--- a/vllm_mlx/models/mllm.py
+++ b/vllm_mlx/models/mllm.py
@@ -18,6 +18,7 @@ import base64
 import logging
 import math
 import os
+import sys
 import tempfile
 import threading
 from collections.abc import Iterator
@@ -33,17 +34,69 @@ from vllm_mlx.mllm_cache import MLLMPrefixCacheManager
 logger = logging.getLogger(__name__)
 
 
+VLM_EXTRA_INSTALL_HINT = (
+    "Install it with:\n"
+    "    pip install 'rapid-mlx[vision]'\n"
+    "or directly:\n"
+    "    pip install 'mlx-vlm>=0.6.3'"
+)
+
+
+def mlx_vlm_available() -> bool:
+    """Return True iff the optional ``mlx-vlm`` package can be imported.
+
+    Mirrors :func:`vllm_mlx.embedding.mlx_embeddings_available` so the
+    cli-side ``--mllm`` / vision-alias boot guard
+    (:func:`require_mlx_vlm_or_exit`) can probe presence without
+    actually importing the dependency at module top-level. ``mlx-vlm``
+    lives behind the ``[vision]`` extra; a plain
+    ``pip install rapid-mlx`` will not have it.
+    """
+    import importlib.util
+
+    return importlib.util.find_spec("mlx_vlm") is not None
+
+
+def require_mlx_vlm_or_exit(model_name: str) -> None:
+    """CLI-side boot guard for vision/multimodal aliases.
+
+    R-10 (PyPI 0.8.6 dogfood): a first-time ``pip install rapid-mlx``
+    user running ``rapid-mlx serve ui-tars-1.5-7b-4bit`` got a deep,
+    confusing ImportError mid-load because ``mlx-vlm`` lives behind the
+    ``[vision]`` extra. The existing :func:`_require_mlx_vlm` raises an
+    actionable ``ImportError`` only after the alias has been resolved,
+    weights downloaded, and the engine handed control to the MLLM
+    code path — minutes of wall-clock noise before the actionable
+    message. Probe at flag-parse / serve_command entry instead and
+    exit ``2`` (argparse usage-error code) with the same install hint
+    on stderr — matches :func:`require_mlx_embeddings_or_exit` shape.
+    """
+    if mlx_vlm_available():
+        return
+    print(
+        f"error: model {model_name!r} is a vision/multimodal alias and "
+        f"requires the optional `mlx-vlm` dependency (shipped with the "
+        f"[vision] extra).\n" + VLM_EXTRA_INSTALL_HINT,
+        file=sys.stderr,
+    )
+    sys.exit(2)
+
+
 def _require_mlx_vlm() -> None:
-    """Verify mlx-vlm is installed; raise actionable error if not."""
+    """Verify mlx-vlm is installed; raise actionable error if not.
+
+    Engine-side last-line-of-defence: ``rapid-mlx serve`` is supposed
+    to short-circuit at :func:`require_mlx_vlm_or_exit` before this
+    runs, but library callers (``MLXMultimodalLM`` used directly,
+    benchmark/eval harnesses) still need an actionable error if they
+    skipped the CLI guard.
+    """
     try:
         import mlx_vlm  # noqa: F401
     except ImportError as e:
         raise ImportError(
-            "Vision/multimodal models require the optional `mlx-vlm` dependency.\n"
-            "Install it with:\n"
-            "    pip install 'rapid-mlx[vision]'\n"
-            "or directly:\n"
-            "    pip install 'mlx-vlm>=0.4.4'"
+            "Vision/multimodal models require the optional `mlx-vlm` "
+            "dependency.\n" + VLM_EXTRA_INSTALL_HINT
         ) from e
 
 

--- a/vllm_mlx/routes/completions.py
+++ b/vllm_mlx/routes/completions.py
@@ -141,13 +141,28 @@ async def create_completion(request: CompletionRequest, raw_request: Request):
         )
 
         # --- Detailed request logging ---
-        prompt_preview = prompts[0][:200] if prompts else "(empty)"
+        # R-05 (PyPI 0.8.6 dogfood, liang-r2 L2-001): INFO-level logs
+        # MUST NOT carry user prompt content. Pre-fix this line emitted
+        # ``prompt_preview="my secret password is hunter2"`` straight to
+        # the INFO stream — anyone with log-aggregator read access could
+        # harvest credentials. The chat / anthropic / responses lanes
+        # already split metadata (counts) at INFO and the content
+        # preview at DEBUG; legacy completions just skipped the parity.
+        # Match the chat lane: INFO carries counts only, DEBUG carries
+        # a 300-char preview behind the operator-controlled log-level
+        # dial. (Server's default level is INFO, so the preview no
+        # longer reaches production log aggregators without an explicit
+        # opt-in.)
+        n_prompts = len(prompts)
         prompt_len = sum(len(p) for p in prompts)
         logger.info(
             f"[REQUEST] POST /v1/completions stream={request.stream} "
-            f"max_tokens={request.max_tokens} temp={request.temperature} "
-            f"prompt_chars={prompt_len} prompt_preview={prompt_preview!r}"
+            f"model={request.model!r} max_tokens={request.max_tokens} "
+            f"temp={request.temperature} n_prompts={n_prompts} "
+            f"prompt_chars={prompt_len}"
         )
+        prompt_preview = prompts[0][:300] if prompts else "(empty)"
+        logger.debug(f"[REQUEST] prompt preview: {prompt_preview!r}")
 
         # Context-length pre-check — same DoS gate the chat/anthropic/
         # responses routes enforce. Raw-prompt API skips chat templating


### PR DESCRIPTION
## Why

PyPI 0.8.6 dogfood (liang-r2) surfaced two unrelated but small ergonomic regressions on the legacy completions lane and the first-time UI-TARS install path:

### R-05 — \`/v1/completions\` legacy lane leaked prompt body at INFO

A request like \`POST /v1/completions {\"prompt\": \"my secret password is hunter2\"}\` produced a server log line at INFO level containing \`prompt_preview=\"my secret password is hunter2\"\` — full prompt body in the production log stream. The chat / anthropic / responses lanes already split metadata at INFO and a content preview at DEBUG; legacy completions just skipped the parity.

Fix matches the chat lane: INFO records carry metadata only (counts, lengths, model id, sampling knobs), the 300-char preview moves to DEBUG behind \`--log-level debug\`.

### R-10 — first-time UI-TARS startup hit ImportError after weight download

\`pip install rapid-mlx\` (no \`[vision]\` extra) followed by \`rapid-mlx serve ui-tars-1.5-7b-4bit\` previously fell into the engine load path, downloaded the model via the R2 mirror, then crashed with a deep \`ImportError\` because \`mlx-vlm\` lives behind the \`[vision]\` extra. The existing \`_require_mlx_vlm()\` was the engine-side last-line-of-defence — it fired AFTER alias resolution + multi-minute download.

Fix mirrors the existing \`--embedding-model\` / \`require_mlx_embeddings_or_exit\` pattern: probe at the top of \`serve_command\`, exit \`2\` with an actionable install hint to stderr BEFORE the download starts. \`mlx-vlm\` is already declared in the \`[vision]\` and \`[all]\` extras (verified by a new lock-in test).

## What changed

- \`vllm_mlx/routes/completions.py\` — split metadata (INFO) from preview (DEBUG), matches chat lane
- \`vllm_mlx/models/mllm.py\` — new \`mlx_vlm_available()\` + \`require_mlx_vlm_or_exit(model)\` helpers
- \`vllm_mlx/cli.py\` — wire boot-time guard into \`serve_command\` right next to the embeddings guard
- \`tests/test_completions_log_redaction.py\` — caplog regression (3 tests)
- \`tests/test_uitars_boot_check.py\` — boot-guard regression + pyproject extra lock-in (5 tests)

## Discipline

- Reproduced R-10 in a fresh venv (\`pip install -e .\` without \`[vision]\`) → confirmed pre-fix crashed deep, post-fix exits \`2\` with the actionable hint before any download. Venv deleted.
- No changes to streaming (R5-A) or UI-TARS architecture (R5-B).
- Existing \`_require_mlx_vlm()\` stays as a library-caller safety net.

## Test plan

- [x] \`pytest tests/test_completions_log_redaction.py tests/test_uitars_boot_check.py\` → 8 pass
- [x] \`pytest tests/test_ui_tars_fixes.py tests/test_no_mllm_flag.py tests/test_vision_extra_install.py tests/test_completions_spec_parity.py tests/test_serve_listen_fd.py tests/test_envelope_field_extraction.py\` → 182 pass
- [x] Fresh-venv repro of R-10 in \`/tmp/venv-r5c\` (deleted)
- [x] \`ruff check\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)