### PR TITLE
fix(validation+gemma4): r5-E - tighten top_k/seed/include_usage + gemma4 prose-fallback tool_call recovery

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -251,6 +251,10 @@ ignore = [
 # Tensor-shape parameter names (B, H, N, D) follow ML literature
 # convention; N803 lowercase rule is incompatible.
 "scripts/bench_attention.py" = ["N803"]
+# Pytest parametrize convention: the Pydantic *class* is passed as
+# ``Model`` so the test body reads naturally (``Model(model="x", ...)``);
+# renaming would lose readability across many tests.
+"tests/test_param_validation_r5e.py" = ["N803"]
 
 [tool.mypy]
 python_version = "3.10"

--- a/tests/test_gemma4_prose_fallback.py
+++ b/tests/test_gemma4_prose_fallback.py
@@ -1,0 +1,217 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+r5-E F-DGF-V080-B-8: gemma-4-12b-4bit tool-call regression.
+
+Trace verdict (see commit body):
+  Neither parser-pattern miss NOR template tool-injection miss. The
+  chat template renders ``<|tool>declaration:NAME{...}<tool|>`` for
+  every tool in the request (verified against
+  ``mlx-community/gemma-4-12B-it-4bit`` 4bit), and the existing
+  structured pattern catches every emission that hits the
+  ``<|tool_call>`` channel form. The intermittent failure is a model
+  decoding edge case — at low temperature (~0.1) the model
+  occasionally describes the tool intent in prose ("I should call
+  the `add` tool with a=13 and b=29.") instead of channel-routing
+  through ``<|tool_call>``.
+
+Defence-in-depth fix: ``_try_prose_recover_tool_call`` runs after a
+structured-match miss and recovers a tool call from prose when:
+
+  1. The request carried a ``tools`` array.
+  2. The prose mentions a tool by its exact name.
+  3. The prose includes ``key=value`` (or ``key: value``) assignments
+     for EVERY required parameter on that tool.
+
+Recovery returns the standard structured shape; a miss leaves the
+prose in ``content`` unchanged. The conservative gating means a
+chat that just discusses ``add`` and an unrelated ``a=`` mention is
+NOT falsely recovered.
+"""
+import json
+
+import pytest
+
+from vllm_mlx.tool_parsers.gemma4_tool_parser import (
+    Gemma4ToolParser,
+    _try_prose_recover_tool_call,
+)
+
+ADD_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "add",
+        "description": "Add two integers and return their sum.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "a": {"type": "integer"},
+                "b": {"type": "integer"},
+            },
+            "required": ["a", "b"],
+        },
+    },
+}
+
+WEATHER_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "get_weather",
+        "description": "Get current weather.",
+        "parameters": {
+            "type": "object",
+            "properties": {"location": {"type": "string"}},
+            "required": ["location"],
+        },
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# Direct prose-recovery helper
+# ---------------------------------------------------------------------------
+
+
+def test_prose_recovers_canonical_dogfood_case():
+    """Exact verbatim prose from the cycle-DGF-v080 agent-B B-8 repro."""
+    prose = (
+        "The user wants to add 13 and 29 using the `add` tool. "
+        "I should call the `add` tool with a=13 and b=29."
+    )
+    out = _try_prose_recover_tool_call(prose, [ADD_TOOL])
+    assert out is not None
+    assert out["name"] == "add"
+    args = json.loads(out["arguments"])
+    assert args == {"a": 13, "b": 29}
+
+
+def test_prose_recovers_with_colon_assignments():
+    """Some prose variants use ``a: 13`` not ``a=13``."""
+    prose = "Calling add with a: 13, b: 29."
+    out = _try_prose_recover_tool_call(prose, [ADD_TOOL])
+    assert out is not None
+    assert json.loads(out["arguments"]) == {"a": 13, "b": 29}
+
+
+def test_prose_recovers_quoted_string_value():
+    prose = 'I will call get_weather with location="Palo Alto".'
+    out = _try_prose_recover_tool_call(prose, [WEATHER_TOOL])
+    assert out is not None
+    assert out["name"] == "get_weather"
+    assert json.loads(out["arguments"]) == {"location": "Palo Alto"}
+
+
+def test_prose_recovers_backticked_value():
+    prose = "I should call get_weather with location=`Tokyo`."
+    out = _try_prose_recover_tool_call(prose, [WEATHER_TOOL])
+    assert out is not None
+    assert json.loads(out["arguments"]) == {"location": "Tokyo"}
+
+
+def test_prose_no_tool_named_returns_none():
+    """Tool name absent from the prose → don't recover."""
+    prose = "I should compute the sum a=13 and b=29."
+    out = _try_prose_recover_tool_call(prose, [ADD_TOOL])
+    assert out is None
+
+
+def test_prose_partial_required_params_returns_none():
+    """Required param missing → confidence too low, leave as content."""
+    prose = "I'll call the `add` tool with a=13."
+    out = _try_prose_recover_tool_call(prose, [ADD_TOOL])
+    assert out is None
+
+
+def test_prose_no_tools_in_request_returns_none():
+    """Empty tools list → no recovery (gate condition 1)."""
+    prose = "I should call the `add` tool with a=13 and b=29."
+    out = _try_prose_recover_tool_call(prose, [])
+    assert out is None
+
+
+def test_prose_unrelated_natural_text_returns_none():
+    """A normal chat reply that doesn't mention the tool's name
+    must not be collaterally captured even with assignments
+    elsewhere."""
+    prose = "Sure! The answer is 42."
+    out = _try_prose_recover_tool_call(prose, [ADD_TOOL])
+    assert out is None
+
+
+def test_prose_first_value_wins_on_self_correction():
+    """``a=13 ... a=14`` → take the earliest commitment (the model's
+    initial reasoning, not a later "correction" mid-thought)."""
+    prose = "I'll call the `add` tool with a=13 and b=29 (or maybe a=14)."
+    out = _try_prose_recover_tool_call(prose, [ADD_TOOL])
+    assert out is not None
+    assert json.loads(out["arguments"]) == {"a": 13, "b": 29}
+
+
+def test_prose_multiple_tools_first_named_wins():
+    """When both tools are mentioned, the earliest mention wins."""
+    prose = (
+        "I considered get_weather but actually I should call the `add` "
+        "tool with a=13 and b=29."
+    )
+    out = _try_prose_recover_tool_call(prose, [ADD_TOOL, WEATHER_TOOL])
+    # ``get_weather`` is mentioned first but its required ``location``
+    # has no assignment in the prose, so it falls through to ``add``.
+    assert out is not None
+    assert out["name"] == "add"
+
+
+# ---------------------------------------------------------------------------
+# extract_tool_calls integration — runs the full parser path
+# ---------------------------------------------------------------------------
+
+
+def test_extract_tool_calls_recovers_prose_with_request_tools():
+    parser = Gemma4ToolParser()
+    prose = (
+        "The user wants to add 13 and 29 using the `add` tool. "
+        "I should call the `add` tool with a=13 and b=29."
+    )
+    request = {"tools": [ADD_TOOL]}
+    res = parser.extract_tool_calls(prose, request)
+    assert res.tools_called is True
+    assert len(res.tool_calls) == 1
+    tc = res.tool_calls[0]
+    assert tc["name"] == "add"
+    assert json.loads(tc["arguments"]) == {"a": 13, "b": 29}
+    # Content is dropped — OpenAI spec is content OR tool_calls
+    # on a single response choice, not both verbatim.
+    assert res.content is None
+
+
+def test_extract_tool_calls_recovery_skipped_without_tools():
+    """No ``tools`` in the request → recovery never fires; prose
+    stays in content (existing pre-fix contract on the non-tools
+    path)."""
+    parser = Gemma4ToolParser()
+    prose = "I should call the `add` tool with a=13 and b=29."
+    res = parser.extract_tool_calls(prose, request=None)
+    assert res.tools_called is False
+    assert res.tool_calls == []
+    assert res.content == prose
+
+
+def test_extract_tool_calls_recovery_skipped_when_structured_form_present():
+    """When the model DOES emit the structured form, the recovery
+    must not also fire — the recovery is a fallback path."""
+    parser = Gemma4ToolParser()
+    structured = "<|tool_call>call:add{a:13,b:29}<tool_call|>"
+    request = {"tools": [ADD_TOOL]}
+    res = parser.extract_tool_calls(structured, request)
+    assert res.tools_called is True
+    assert len(res.tool_calls) == 1
+    assert json.loads(res.tool_calls[0]["arguments"]) == {"a": 13, "b": 29}
+
+
+def test_extract_tool_calls_no_recovery_on_natural_chat():
+    """Pure natural-language reply with no tool name mention → no
+    recovery, content preserved."""
+    parser = Gemma4ToolParser()
+    text = "Hello! How can I help you today?"
+    request = {"tools": [ADD_TOOL]}
+    res = parser.extract_tool_calls(text, request)
+    assert res.tools_called is False
+    assert res.content == text

--- a/tests/test_gemma4_prose_fallback.py
+++ b/tests/test_gemma4_prose_fallback.py
@@ -215,3 +215,67 @@ def test_extract_tool_calls_no_recovery_on_natural_chat():
     res = parser.extract_tool_calls(text, request)
     assert res.tools_called is False
     assert res.content == text
+
+
+# ---------------------------------------------------------------------------
+# codex pr_validate round-2 regression — additional guards
+# ---------------------------------------------------------------------------
+
+
+def test_prose_required_args_split_across_two_sentences():
+    """Round-2 BLOCKING-2: ``call add with a=13. b=29.`` had only
+    ``a=13`` in the first clipped sentence; recovery must walk to
+    the next sentence boundary (within PROSE_WINDOW_BYTES) before
+    declaring "required missing"."""
+    prose = "call add with a=13. b=29."
+    out = _try_prose_recover_tool_call(prose, [ADD_TOOL])
+    assert out is not None
+    assert out["name"] == "add"
+    assert json.loads(out["arguments"]) == {"a": 13, "b": 29}
+
+
+def test_prose_name_does_not_match_suffix():
+    """Round-2 NIT: a tool named ``add`` must NOT match ``foo_add``
+    or ``my-add`` (leading negative lookbehind ``(?<![\\w-])``)."""
+    prose = "I called foo_add earlier with a=13 and b=29."
+    out = _try_prose_recover_tool_call(prose, [ADD_TOOL])
+    assert out is None
+    # And a real ``add`` mention with hyphenated lookbehind also blocked.
+    prose2 = "Use my-add helper with a=13 and b=29."
+    out2 = _try_prose_recover_tool_call(prose2, [ADD_TOOL])
+    assert out2 is None
+
+
+def test_prose_far_later_sentence_still_rejected():
+    """The bounded-window walk must NOT enlarge so far that an
+    unrelated multi-sentence ramble after the tool mention is
+    silently turned into a tool call."""
+    # ``add`` mention, then a LONG (>300 char) unrelated paragraph,
+    # then args far past the window cap. Should NOT recover.
+    prose = (
+        "I considered the `add` tool. "
+        + ("Long unrelated discussion about the weather. " * 8)
+        + "Eventually a=42 and b=99."
+    )
+    out = _try_prose_recover_tool_call(prose, [ADD_TOOL])
+    assert out is None
+
+
+def test_prose_only_schema_declared_keys_kept():
+    """Round-1 BLOCKING-2: schema-undeclared keys in prose
+    (``result=42``) must be dropped from recovered arguments."""
+    prose = "call add with a=13, b=29, result=42."
+    out = _try_prose_recover_tool_call(prose, [ADD_TOOL])
+    assert out is not None
+    args = json.loads(out["arguments"])
+    assert args == {"a": 13, "b": 29}
+    assert "result" not in args
+
+
+def test_prose_case_sensitive_name_match():
+    """Round-1 NIT-5: function names are case-sensitive per OpenAI
+    spec — a model writing ``ADD`` when the registered tool is
+    ``add`` is NOT a confident call."""
+    prose = "I should call ADD with a=13 and b=29."
+    out = _try_prose_recover_tool_call(prose, [ADD_TOOL])
+    assert out is None

--- a/tests/test_gemma4_prose_fallback.py
+++ b/tests/test_gemma4_prose_fallback.py
@@ -29,8 +29,6 @@ NOT falsely recovered.
 """
 import json
 
-import pytest
-
 from vllm_mlx.tool_parsers.gemma4_tool_parser import (
     Gemma4ToolParser,
     _try_prose_recover_tool_call,

--- a/tests/test_gemma4_prose_fallback.py
+++ b/tests/test_gemma4_prose_fallback.py
@@ -27,6 +27,7 @@ prose in ``content`` unchanged. The conservative gating means a
 chat that just discusses ``add`` and an unrelated ``a=`` mention is
 NOT falsely recovered.
 """
+
 import json
 
 from vllm_mlx.tool_parsers.gemma4_tool_parser import (

--- a/tests/test_param_validation_r5e.py
+++ b/tests/test_param_validation_r5e.py
@@ -119,9 +119,21 @@ class TestTopKUpperBound:
 
     def test_top_k_negative_still_rejected_no_regression(self):
         """H-10's negative-int gate still fires — r5-E's upper cap is
-        an additive tightening, NOT a relaxation of the lower gate."""
-        with pytest.raises(ValidationError):
-            ChatCompletionRequest(messages=_user_msg(), top_k=-5)
+        an additive tightening, NOT a relaxation of the lower gate.
+
+        Pass ``model="x"`` and all other required fields so the only
+        possible source of ``ValidationError`` is the ``top_k`` validator
+        (codex pr_validate BLOCKING-4: previously this test could have
+        passed for the wrong reason — missing-``model`` error — even
+        if the negative ``top_k`` gate had been removed).
+        """
+        with pytest.raises(ValidationError) as excinfo:
+            ChatCompletionRequest(model="x", messages=_user_msg(), top_k=-5)
+        # Assert the validation error specifically cites top_k.
+        errors = excinfo.value.errors()
+        assert any("top_k" in err.get("loc", ()) for err in errors), (
+            f"Expected top_k validation error, got: {errors}"
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_param_validation_r5e.py
+++ b/tests/test_param_validation_r5e.py
@@ -19,6 +19,7 @@ All three reproduce on the request-model layer, so the tests below
 exercise the Pydantic models directly — that's the same gate every
 route hits before request handlers run.
 """
+
 import pytest
 from pydantic import ValidationError
 
@@ -237,9 +238,7 @@ class TestStreamOptionsIncludeUsageStrict:
             (CompletionRequest, {"prompt": "hi"}),
         ],
     )
-    @pytest.mark.parametrize(
-        "bad_value", ["yes", "true", "false", "on", "1", 1, 0]
-    )
+    @pytest.mark.parametrize("bad_value", ["yes", "true", "false", "on", "1", 1, 0])
     def test_request_nested_include_usage_rejected(self, Model, extra, bad_value):
         """The same gate must fire through the parent request model."""
         with pytest.raises(ValidationError):

--- a/tests/test_param_validation_r5e.py
+++ b/tests/test_param_validation_r5e.py
@@ -1,0 +1,268 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+r5-E validation-gap tightenings (B-7 / B-8 / B-9).
+
+Three Pydantic-schema fixes confirmed open against v0.8.6 by the
+DGF-v080 sweep (rapid-desktop/.claude/loop/bug_report.md):
+
+  * **B-7 / F-DGF-V080-C-4**: ``top_k`` upper-bound silent accept
+    (``999999999`` / ``2**63-1`` returned HTTP 200).
+  * **B-8**: ``seed=-1`` silently accepted (silent-correctness — the
+    backend folds the value to a valid uint32 PRNG key, so a caller
+    that thought they passed a sentinel actually pinned a fixed
+    state).
+  * **B-9 / F-DGF-V080-V1**: ``stream_options.include_usage:"yes"``
+    truthy-string silently treated as ``true`` (lax-mode bool
+    coercion).
+
+All three reproduce on the request-model layer, so the tests below
+exercise the Pydantic models directly — that's the same gate every
+route hits before request handlers run.
+"""
+import pytest
+from pydantic import ValidationError
+
+from vllm_mlx.api.anthropic_models import AnthropicRequest
+from vllm_mlx.api.models import (
+    _TOP_K_SENTINEL_CAP,
+    ChatCompletionRequest,
+    CompletionRequest,
+    StreamOptions,
+)
+from vllm_mlx.api.responses_models import ResponsesRequest
+
+
+def _user_msg():
+    return [{"role": "user", "content": "hi"}]
+
+
+# ---------------------------------------------------------------------------
+# B-7: top_k upper bound
+# ---------------------------------------------------------------------------
+
+
+class TestTopKUpperBound:
+    @pytest.mark.parametrize(
+        "Model,extra",
+        [
+            (ChatCompletionRequest, {"messages": _user_msg()}),
+            (CompletionRequest, {"prompt": "hi"}),
+        ],
+    )
+    @pytest.mark.parametrize("bad_value", [999_999_999, 2**63 - 1])
+    def test_top_k_above_sentinel_cap_rejected(self, Model, extra, bad_value):
+        with pytest.raises(ValidationError) as excinfo:
+            Model(model="x", top_k=bad_value, **extra)
+        # Error message must name the field AND the cap so the client
+        # can act on it without guessing.
+        msg = str(excinfo.value)
+        assert "top_k" in msg
+        assert str(_TOP_K_SENTINEL_CAP) in msg
+
+    @pytest.mark.parametrize(
+        "Model,extra",
+        [
+            (ChatCompletionRequest, {"messages": _user_msg()}),
+            (CompletionRequest, {"prompt": "hi"}),
+        ],
+    )
+    def test_top_k_zero_accepted_by_design(self, Model, extra):
+        """``top_k=0`` means "disabled" on mlx-lm — must NOT 4xx
+        (v0.8.2 own error string read "use 0 to disable")."""
+        req = Model(model="x", top_k=0, **extra)
+        assert req.top_k == 0
+
+    @pytest.mark.parametrize(
+        "Model,extra",
+        [
+            (ChatCompletionRequest, {"messages": _user_msg()}),
+            (CompletionRequest, {"prompt": "hi"}),
+        ],
+    )
+    @pytest.mark.parametrize("good_value", [1, 64, 128, 100_000])
+    def test_top_k_typical_values_accepted(self, Model, extra, good_value):
+        req = Model(model="x", top_k=good_value, **extra)
+        assert req.top_k == good_value
+
+    @pytest.mark.parametrize(
+        "Model,extra",
+        [
+            (ChatCompletionRequest, {"messages": _user_msg()}),
+            (CompletionRequest, {"prompt": "hi"}),
+        ],
+    )
+    def test_top_k_at_sentinel_cap_accepted(self, Model, extra):
+        """The cap itself (``2**20``) is inclusive — wide enough to
+        cover every shipped vocab size (Gemma 3 at 262144 is the
+        widest)."""
+        req = Model(model="x", top_k=_TOP_K_SENTINEL_CAP, **extra)
+        assert req.top_k == _TOP_K_SENTINEL_CAP
+
+    def test_top_k_anthropic_surface_also_capped(self):
+        """Anthropic ``/v1/messages`` shares the same validator — the
+        fix must mirror across surfaces."""
+        with pytest.raises(ValidationError):
+            AnthropicRequest(
+                model="x",
+                messages=_user_msg(),
+                max_tokens=10,
+                top_k=999_999_999,
+            )
+        # at-cap accepted
+        req = AnthropicRequest(
+            model="x",
+            messages=_user_msg(),
+            max_tokens=10,
+            top_k=_TOP_K_SENTINEL_CAP,
+        )
+        assert req.top_k == _TOP_K_SENTINEL_CAP
+
+    def test_top_k_negative_still_rejected_no_regression(self):
+        """H-10's negative-int gate still fires — r5-E's upper cap is
+        an additive tightening, NOT a relaxation of the lower gate."""
+        with pytest.raises(ValidationError):
+            ChatCompletionRequest(messages=_user_msg(), top_k=-5)
+
+
+# ---------------------------------------------------------------------------
+# B-8: seed=-1 silent accept
+# ---------------------------------------------------------------------------
+
+
+class TestSeedNonNegative:
+    @pytest.mark.parametrize(
+        "Model,extra",
+        [
+            (ChatCompletionRequest, {"messages": _user_msg()}),
+            (CompletionRequest, {"prompt": "hi"}),
+            (ResponsesRequest, {"input": "hi"}),
+        ],
+    )
+    @pytest.mark.parametrize("bad_value", [-1, -42, -(2**31)])
+    def test_negative_seed_rejected(self, Model, extra, bad_value):
+        with pytest.raises(ValidationError) as excinfo:
+            Model(model="x", seed=bad_value, **extra)
+        msg = str(excinfo.value)
+        assert "seed" in msg
+        assert ">= 0" in msg or "non-negative" in msg
+
+    @pytest.mark.parametrize(
+        "Model,extra",
+        [
+            (ChatCompletionRequest, {"messages": _user_msg()}),
+            (CompletionRequest, {"prompt": "hi"}),
+            (ResponsesRequest, {"input": "hi"}),
+        ],
+    )
+    def test_seed_zero_accepted(self, Model, extra):
+        """``seed=0`` is a legitimate PRNG key used by every eval
+        harness — preserve it."""
+        req = Model(model="x", seed=0, **extra)
+        assert req.seed == 0
+
+    @pytest.mark.parametrize(
+        "Model,extra",
+        [
+            (ChatCompletionRequest, {"messages": _user_msg()}),
+            (CompletionRequest, {"prompt": "hi"}),
+            (ResponsesRequest, {"input": "hi"}),
+        ],
+    )
+    def test_seed_omitted_accepted(self, Model, extra):
+        """No seed → ``None`` (process-global PRNG)."""
+        req = Model(model="x", **extra)
+        assert req.seed is None
+
+    @pytest.mark.parametrize(
+        "Model,extra",
+        [
+            (ChatCompletionRequest, {"messages": _user_msg()}),
+            (CompletionRequest, {"prompt": "hi"}),
+        ],
+    )
+    def test_seed_large_positive_still_accepted(self, Model, extra):
+        """64-bit positive seeds must pass — backend uint32 fold is
+        downstream of validation (codex round-6 contract)."""
+        req = Model(model="x", seed=2**63 - 1, **extra)
+        assert req.seed == 2**63 - 1
+
+    @pytest.mark.parametrize(
+        "Model,extra",
+        [
+            (ChatCompletionRequest, {"messages": _user_msg()}),
+            (CompletionRequest, {"prompt": "hi"}),
+            (ResponsesRequest, {"input": "hi"}),
+        ],
+    )
+    def test_seed_bool_still_rejected_no_regression(self, Model, extra):
+        """``seed=True`` still 4xx's (H-11's contract) — r5-E is
+        additive."""
+        with pytest.raises(ValidationError):
+            Model(model="x", seed=True, **extra)
+
+
+# ---------------------------------------------------------------------------
+# B-9: stream_options.include_usage strict bool
+# ---------------------------------------------------------------------------
+
+
+class TestStreamOptionsIncludeUsageStrict:
+    @pytest.mark.parametrize(
+        "bad_value",
+        ["yes", "true", "no", "false", "1", "0", "on", "off", 1, 0],
+    )
+    def test_non_bool_include_usage_rejected_direct(self, bad_value):
+        """StreamOptions itself must 4xx on non-bool wire values."""
+        with pytest.raises(ValidationError) as excinfo:
+            StreamOptions(include_usage=bad_value)
+        msg = str(excinfo.value)
+        assert "include_usage" in msg or "boolean" in msg
+
+    @pytest.mark.parametrize(
+        "Model,extra",
+        [
+            (ChatCompletionRequest, {"messages": _user_msg()}),
+            (CompletionRequest, {"prompt": "hi"}),
+        ],
+    )
+    @pytest.mark.parametrize(
+        "bad_value", ["yes", "true", "false", "on", "1", 1, 0]
+    )
+    def test_request_nested_include_usage_rejected(self, Model, extra, bad_value):
+        """The same gate must fire through the parent request model."""
+        with pytest.raises(ValidationError):
+            Model(
+                model="x",
+                stream_options={"include_usage": bad_value},
+                **extra,
+            )
+
+    @pytest.mark.parametrize(
+        "Model,extra",
+        [
+            (ChatCompletionRequest, {"messages": _user_msg()}),
+            (CompletionRequest, {"prompt": "hi"}),
+        ],
+    )
+    @pytest.mark.parametrize("good_value", [True, False])
+    def test_proper_bool_include_usage_accepted(self, Model, extra, good_value):
+        req = Model(
+            model="x",
+            stream_options={"include_usage": good_value},
+            **extra,
+        )
+        assert req.stream_options is not None
+        assert req.stream_options.include_usage is good_value
+
+    @pytest.mark.parametrize(
+        "Model,extra",
+        [
+            (ChatCompletionRequest, {"messages": _user_msg()}),
+            (CompletionRequest, {"prompt": "hi"}),
+        ],
+    )
+    def test_omitted_stream_options_accepted(self, Model, extra):
+        """No ``stream_options`` → None (legacy default — no usage on
+        the wire)."""
+        req = Model(model="x", **extra)
+        assert req.stream_options is None

--- a/tests/test_seed_reproducibility.py
+++ b/tests/test_seed_reproducibility.py
@@ -122,17 +122,22 @@ def test_responses_request_rejects_bool_seed():
         ResponsesRequest(model="qwen3-0.6b-8bit", input="hi", seed=True)
 
 
-def test_responses_request_accepts_negative_seed():
-    """Codex round-6 BLOCKING regression guard. The OpenAI Responses
-    API surface accepts any integer ``seed``; rapid-mlx must not 422
-    on negative seeds (or 64-bit positive ones) — that would break
-    compatibility with clients passing the documented unbounded
-    integer range. Narrowing to mlx-core's uint32 happens later in
-    ``make_seeded_sampler``."""
+def test_responses_request_rejects_negative_seed():
+    """r5-E B-8 tightening. Codex round-6's "any integer" contract was
+    too permissive for the silent-correctness hazard the DGF-v080
+    sweep caught: a caller that passes ``seed=-1`` as a sentinel
+    actually pins ``seed=0xFFFFFFFF`` after the downstream bit-fold,
+    so two requests with "no seed" intent produce identical sequences.
+
+    The r5-E B-8 fix keeps the codex round-6 upper-end contract
+    intact (64-bit positive seeds still pass — see
+    ``test_responses_request_accepts_above_uint32_seed`` below) and
+    only rejects the negative form. Same fix on chat / completions /
+    responses for cross-surface parity."""
     from vllm_mlx.api.responses_models import ResponsesRequest
 
-    req = ResponsesRequest(model="qwen3-0.6b-8bit", input="hi", seed=-1)
-    assert req.seed == -1
+    with pytest.raises(ValidationError):
+        ResponsesRequest(model="qwen3-0.6b-8bit", input="hi", seed=-1)
 
 
 def test_responses_request_accepts_above_uint32_seed():
@@ -159,26 +164,30 @@ def test_seed_accepts_zero():
     assert req.seed == 0
 
 
-def test_seed_accepts_negative():
-    """Codex round-6 BLOCKING regression guard.
+def test_seed_rejects_negative():
+    """r5-E B-8 tightening.
 
-    OpenAI's spec documents ``seed`` as an unbounded integer (their
-    Python SDK ships ``seed: Optional[int]`` with no range), so the
-    request-model layer must NOT 422 on negative seeds. Backend
-    narrowing to mlx-core's uint32 PRNG key range is applied
-    deterministically downstream in ``make_seeded_sampler`` via
-    ``seed & 0xFFFFFFFF`` — Python's well-defined ``int.__and__`` on
-    negatives makes the fold round-trip cleanly.
+    Codex round-6 originally accepted negative seeds and folded them
+    via ``seed & 0xFFFFFFFF`` in ``make_seeded_sampler``. That kept
+    compatibility with clients passing arbitrary 64-bit ints — but
+    silently mapped ``seed=-1`` (a common sentinel for "no
+    determinism guarantee" in third-party SDKs) onto the perfectly
+    valid uint32 key ``0xFFFFFFFF``. Two requests with the same "no
+    seed" intent therefore produced identical sequences, the exact
+    silent-correctness hazard ``cycle-DGF-v080`` (V2 sweep) flagged.
 
-    Pre-fix (round 5): ``Field(ge=0)`` rejected this with a 422 and
-    broke compatibility for the OpenAI-documented surface.
-    """
-    req = ChatCompletionRequest(
-        model="qwen3-0.6b-8bit",
-        messages=[{"role": "user", "content": "hi"}],
-        seed=-1,
-    )
-    assert req.seed == -1
+    The r5-E fix narrows the request-layer accept envelope to ``int
+    >= 0 | None`` while keeping every other codex round-6 promise
+    (large positive seeds still pass — see
+    ``test_seed_accepts_above_uint32`` — and the downstream uint32
+    fold is unchanged for positive values). Negative seeds now 422
+    instead of silently mapping to a different state."""
+    with pytest.raises(ValidationError):
+        ChatCompletionRequest(
+            model="qwen3-0.6b-8bit",
+            messages=[{"role": "user", "content": "hi"}],
+            seed=-1,
+        )
 
 
 def test_seed_accepts_above_uint32():

--- a/vllm_mlx/api/anthropic_models.py
+++ b/vllm_mlx/api/anthropic_models.py
@@ -13,6 +13,7 @@ from typing import Any, Literal
 from pydantic import BaseModel, Field, field_validator, model_validator
 
 from .models import (
+    _TOP_K_SENTINEL_CAP,
     _enforce_max_generation_tokens_ceiling,
     _scrub_nonfinite_sampling_raw,
     _validate_finite_in_range,
@@ -429,10 +430,13 @@ class AnthropicRequest(BaseModel):
         )
 
     # H-10: ``top_k`` range gate — mirrors the OpenAI surfaces.
+    # r5-E B-7: upper-bound sentinel cap (see ``models._TOP_K_SENTINEL_CAP``).
     @field_validator("top_k", mode="before")
     @classmethod
     def _validate_top_k(cls, v) -> int | None:
-        return _validate_nonnegative_int(v, field_name="top_k")
+        return _validate_nonnegative_int(
+            v, max_value=_TOP_K_SENTINEL_CAP, field_name="top_k"
+        )
 
     # M-03 (#742 follow-up): the Anthropic Messages spec only accepts
     # four ``tool_choice.type`` values — ``auto``, ``any``, ``tool``,

--- a/vllm_mlx/api/models.py
+++ b/vllm_mlx/api/models.py
@@ -19,6 +19,7 @@ from pydantic import (
     BaseModel,
     ConfigDict,
     Field,
+    StrictBool,
     StrictInt,
     StrictStr,
     field_validator,
@@ -206,6 +207,26 @@ def _validate_finite_in_range(
     return v
 
 
+# r5-E B-7 / F-DGF-V080-C-4: ``top_k`` upper-bound cap. Pre-fix,
+# ``top_k=999999999`` and ``top_k=2**63-1`` slid through with HTTP 200
+# even though no vocabulary in the catalog has more than ~256K entries
+# (Gemma 3 sits at 262144; Qwen3 at 151936; Llama 3 at 128256). The
+# request-time gate cannot consult the resolved model's vocab_size
+# because route validation runs before model selection in the engine
+# (and ``model`` is a free-form alias that may not even be loaded yet).
+# We instead use a generous sentinel cap of 2**20 (~1 M tokens) — wider
+# than any vocab we anticipate shipping while still rejecting the
+# pathological 999M / 2^63 forms that produce silent-overflow inside
+# mlx-lm's top-k kernel. The backend kernel does its own ``min(top_k,
+# vocab_size)`` clamp at sample time, so a request with ``top_k=500_000``
+# on a model with a 128K vocab still works exactly like ``top_k=128_000``;
+# the cap here is purely a defence-in-depth ceiling against the obviously-
+# invalid forms. ``top_k=0`` is documented as "disabled" by mlx-lm and
+# is preserved as a legal value (the v0.8.2 validator's own error string
+# read "use 0 to disable" — the by-design escape hatch).
+_TOP_K_SENTINEL_CAP: int = 1 << 20  # 1_048_576
+
+
 def _validate_nonnegative_int(
     v,
     *,
@@ -320,23 +341,23 @@ def _validate_logit_bias_finite(
 
 
 def _validate_seed(v) -> int | None:
-    """Reject bool / non-integer values on ``seed`` (H-11).
+    """Reject bool / non-integer / negative values on ``seed`` (H-11 + r5-E B-8).
 
-    OpenAI's spec documents ``seed`` as an unbounded integer (their
-    Python SDK ships ``seed: Optional[int]`` with no range), so the
-    request-model layer accepts the FULL public range. The backend-
-    specific narrowing to mlx-core's ``uint32`` ``mx.random.key`` is
-    applied LATER, in ``make_seeded_sampler``, via a deterministic
-    bit-fold (``seed & 0xFFFFFFFF``). That keeps OpenAI-compatible
-    clients passing 64-bit / negative seeds working: same input value
-    always maps to the same backend key, so reproducibility is
-    preserved within rapid-mlx (the OpenAI spec only promises
-    within-engine determinism — "we cannot guarantee determinism
-    across model versions or backends"). Codex round-6 BLOCKING fix
-    on the original ``le=0xFFFFFFFF`` Field bound that 422'd valid
-    OpenAI seed values.
+    OpenAI's spec documents ``seed`` as an integer; their Python SDK
+    ships ``seed: Optional[int]`` with no documented range, but every
+    real-world usage in their docs and examples uses non-negative
+    integers (the canonical example is ``seed=12345``). The mlx-core
+    backend key is a ``uint32``: a negative seed has no natural
+    meaning in that space and ``-1`` is almost always a sentinel from a
+    misbehaving SDK (Python ``random.randint(0, sys.maxsize)`` returning
+    ``-1`` on overflow, ``np.int32(-1)`` from a probe). Accepting it
+    silently and then bit-folding via ``& 0xFFFFFFFF`` maps ``-1`` →
+    ``0xFFFFFFFF`` (a perfectly valid backend key) — which means the
+    user thinks they passed a sentinel but actually pinned a fixed PRNG
+    state. That mismatch is the exact silent-correctness hazard
+    r5-E B-8 / cycle-DGF-V080-V2 surfaced; we close it with a 400.
 
-    What we DO still reject at the request layer:
+    What we reject at the request layer:
 
       * ``bool`` — Pydantic v2 silently coerces ``True`` → 1 / ``False``
         → 0 on an ``int | None`` field, but ``seed=True`` is almost
@@ -346,6 +367,19 @@ def _validate_seed(v) -> int | None:
       * Non-integer types — strings, floats, dicts. The OpenAI spec
         is unambiguous that ``seed`` is an integer; a float seed is
         a serialization bug, not a legitimate request.
+      * Negative integers — see the rationale block above. ``seed=0``
+        is preserved as a legal value (a fixed PRNG key, common in
+        evaluation harnesses).
+
+    Upper bound is unbounded by design: 64-bit / very-large seeds are
+    accepted and folded to the backend's uint32 PRNG key range in
+    ``make_seeded_sampler`` via a deterministic ``seed & 0xFFFFFFFF``
+    bit-fold. Same input value always maps to the same backend key, so
+    reproducibility is preserved within rapid-mlx (OpenAI's spec only
+    promises within-engine determinism — "we cannot guarantee
+    determinism across model versions or backends"). Codex round-6
+    BLOCKING fix on the original ``le=0xFFFFFFFF`` Field bound that
+    422'd valid OpenAI seed values.
 
     Returns ``None`` unchanged so the field's optional contract is
     preserved (no value → no per-request seed → process-global
@@ -358,10 +392,17 @@ def _validate_seed(v) -> int | None:
         raise ValueError("seed must be an integer (not bool)")
     if not isinstance(v, int):
         raise ValueError("seed must be an integer")
-    # No range check — see the docstring. Any Python int (positive,
-    # negative, or larger than uint32) is accepted at the API layer;
-    # ``make_seeded_sampler`` folds it to the backend's uint32 PRNG
-    # key range at sampler construction.
+    # r5-E B-8: reject negative seeds at the request layer. The
+    # downstream ``& 0xFFFFFFFF`` fold maps ``-1`` to ``0xFFFFFFFF``
+    # (a valid uint32 key), which silently pins a fixed PRNG state
+    # for a caller that thought they were passing a sentinel.
+    # ``seed=0`` is a legitimate PRNG key (used by every eval
+    # harness) and is preserved.
+    if v < 0:
+        raise ValueError(
+            f"seed must be >= 0 (got {v}); use a non-negative integer "
+            "or omit the field for no determinism guarantee."
+        )
     return v
 
 
@@ -1068,7 +1109,53 @@ class LegacyCompletionLogProbs(BaseModel):
 class StreamOptions(BaseModel):
     """Options for streaming responses."""
 
-    include_usage: bool = False  # Include usage stats in final chunk
+    # r5-E B-9 / F-DGF-V080-V1: strict bool, no coercion. Pre-fix,
+    # Pydantic v2's default ``bool`` field happily coerced
+    # ``include_usage:"yes"`` / ``"true"`` / ``1`` to ``True`` (lax-mode
+    # coercion). The OpenAI spec is unambiguous that the wire shape is
+    # a JSON ``true``/``false`` literal — a truthy string is a
+    # client-side serialization bug and silently rewriting it to
+    # ``True`` masks the bug AND diverges from real OpenAI which
+    # 400's the same payload. Use ``StrictBool`` so a non-bool wire
+    # value 422s at the schema layer; the ``_validate_include_usage``
+    # mode="before" validator below flattens the Pydantic union-error
+    # noise into a single human-readable message naming the field.
+    include_usage: StrictBool = False  # Include usage stats in final chunk
+
+    @field_validator("include_usage", mode="before")
+    @classmethod
+    def _validate_include_usage(cls, v):
+        """Reject non-bool wire values BEFORE Pydantic's StrictBool gate.
+
+        Without this, Pydantic v2's default ``StrictBool`` error reads
+        ``"Input should be a valid boolean"`` (loc=include_usage),
+        which is correct but doesn't pin the spec hint that callers
+        most need (the wire shape MUST be a JSON literal, not a
+        truthy string like ``"yes"`` / ``"on"`` / ``"1"``).
+        Running the type check ourselves with ``mode="before"`` lets
+        us return a message a client can act on AND keeps the
+        contract identical to Pydantic's strict-mode behavior
+        (booleans pass through unchanged; everything else 4xx's).
+        """
+        if v is None:
+            # ``None`` is not a valid value for StrictBool; let the
+            # field's default-False semantics handle the absent case
+            # via field_validator returning None which Pydantic then
+            # rejects with a clean "missing"/"none" error. Callers
+            # that want the default should omit the field entirely.
+            raise ValueError(
+                "stream_options.include_usage must be a boolean "
+                "(true or false); got null. Omit the field for the "
+                "default (false) instead."
+            )
+        if not isinstance(v, bool):
+            raise ValueError(
+                "stream_options.include_usage must be a boolean "
+                "(JSON true or false); got "
+                f"{type(v).__name__}={v!r}. Truthy strings such as "
+                "'yes'/'on'/'1' are NOT accepted per OpenAI spec."
+            )
+        return v
 
 
 class ChatCompletionRequest(BaseModel):
@@ -1381,7 +1468,9 @@ class ChatCompletionRequest(BaseModel):
     @field_validator("top_k", mode="before")
     @classmethod
     def _validate_top_k(cls, v) -> int | None:
-        return _validate_nonnegative_int(v, field_name="top_k")
+        return _validate_nonnegative_int(
+            v, max_value=_TOP_K_SENTINEL_CAP, field_name="top_k"
+        )
 
     # H-10: defensive finite-check on ``logit_bias`` values. The chat
     # route already 4xx's non-empty ``logit_bias`` (see ``routes/chat.py``
@@ -1726,7 +1815,9 @@ class CompletionRequest(BaseModel):
     @field_validator("top_k", mode="before")
     @classmethod
     def _validate_top_k(cls, v) -> int | None:
-        return _validate_nonnegative_int(v, field_name="top_k")
+        return _validate_nonnegative_int(
+            v, max_value=_TOP_K_SENTINEL_CAP, field_name="top_k"
+        )
 
     # F-155: enforce ``n == 1`` at parse time, mirroring the chat
     # surface. The route already 400's ``n > 1``; the schema layer

--- a/vllm_mlx/tool_parsers/gemma4_tool_parser.py
+++ b/vllm_mlx/tool_parsers/gemma4_tool_parser.py
@@ -230,8 +230,12 @@ def _try_prose_recover_tool_call(
         # case-sensitive identifiers, so a model writing ``ADD`` when
         # the registered tool is ``add`` is NOT a confident call.
         # (codex pr_validate NIT-5)
+        # Leading negative lookbehind ``(?<![\w-])``: prevent a tool
+        # named ``add`` from matching suffixes like ``foo_add`` or
+        # ``my-add`` if their identifier text happens to sit near
+        # unrelated ``a=`` / ``b=`` prose. (codex round-2 NIT.)
         name_re = re.compile(
-            r"(?:`|\"|')?" + re.escape(name) + r"(?:`|\"|')?\b",
+            r"(?<![\w-])(?:`|\"|')?" + re.escape(name) + r"(?:`|\"|')?\b",
         )
         matches = list(name_re.finditer(text))
         if not matches:
@@ -246,7 +250,7 @@ def _try_prose_recover_tool_call(
             props = params.get("properties")
             if isinstance(props, dict):
                 allowed_keys = {
-                    k for k in props.keys() if isinstance(k, str)
+                    k for k in props if isinstance(k, str)
                 }
         for match in matches:
             candidates.append(
@@ -268,36 +272,25 @@ def _try_prose_recover_tool_call(
     # mentions an unrelated ``a=…`` many sentences later.
     PROSE_WINDOW_BYTES = 300
 
-    for name_start, fn, name, required, allowed_keys in candidates:
-        # Search a BOUNDED window after the name mention, clipped at
-        # the first sentence-end (period/question/exclamation followed
-        # by whitespace) or PROSE_WINDOW_BYTES, whichever is smaller.
-        # Forward-only scanning preserves the "call X with args"
-        # ordering AND avoids dragging in unrelated key=value pairs.
-        window_end = min(len(text), name_start + PROSE_WINDOW_BYTES)
-        window = text[name_start:window_end]
-        # Clip at first sentence boundary if one exists in the window.
-        # This handles "call add with a=13 and b=29. Earlier I noted
-        # result=42." — we keep only the first sentence so the
-        # ``result=42`` from a later sentence does not leak into the
-        # recovered call.
-        sentence_match = re.search(r"[.!?](?:\s|$)", window)
-        if sentence_match is not None:
-            # Include the punctuation so "a=29." still captures the 29.
-            window = window[: sentence_match.end()]
+    # Helper — scan ``window`` for declared key=value pairs, dropping
+    # the tool name itself and any key not in ``allowed_keys`` (when
+    # the schema declares properties). Returns the recovered
+    # ``{key: value}`` dict for THIS window.
+    def _scan_window(window: str, name: str, allowed_keys: set[str] | None):
         found: dict[str, Any] = {}
         for kv in GEMMA4_PROSE_KV_PATTERN.finditer(window):
             key = kv.group(1)
             value = _coerce_prose_value(kv.groups()[1:])
             # Skip captures whose "key" is actually the tool name
-            # itself (``name=add``) — that's the name mention, not an
-            # argument assignment.
+            # itself (``name=add``) — that's the name mention, not
+            # an argument assignment.
             if key.lower() == name.lower():
                 continue
             # Drop keys not declared in the tool schema. (codex
-            # pr_validate BLOCKING-2: strict tool servers reject
+            # pr_validate r1 BLOCKING-2: strict tool servers reject
             # unknown args, so silently filter here rather than
-            # forward `result=42` from `call add with a=13, result=42`.)
+            # forward `result=42` from `call add with a=13,
+            # result=42`.)
             if allowed_keys is not None and key not in allowed_keys:
                 continue
             # First mention wins: a prose like "a=13" then later
@@ -306,13 +299,60 @@ def _try_prose_recover_tool_call(
             # intent (the prose is the model's reasoning, so the
             # earliest commitment is the most reliable).
             found.setdefault(key, value)
+        return found
+
+    for name_start, fn, name, required, allowed_keys in candidates:
+        # Search a BOUNDED window after the name mention, capped at
+        # PROSE_WINDOW_BYTES. Forward-only scanning preserves the
+        # "call X with args" ordering AND avoids dragging in
+        # unrelated key=value pairs far from the call site.
+        window_end = min(len(text), name_start + PROSE_WINDOW_BYTES)
+        bounded = text[name_start:window_end]
+
+        # Walk sentence boundaries within the bounded window. Start
+        # with the first sentence; if required args are still missing
+        # AND we are still under PROSE_WINDOW_BYTES, extend to the
+        # next sentence boundary, up to a small max-sentence cap.
+        # This handles the codex round-2 BLOCKING case
+        # ``call add with a=13. b=29.``: the first sentence has only
+        # ``a=13`` and we need to peek into the next sentence to find
+        # ``b=29``. Capping at 3 sentences keeps the conservative
+        # behaviour: "..mentioned add. Long unrelated paragraph.
+        # ...a=42, b=99." still won't recover because the boundary
+        # walk stops well before the later sentence.
+        MAX_SENTENCES = 3
+        sentence_ends = [
+            m.end() for m in re.finditer(r"[.!?](?:\s|$)", bounded)
+        ]
+        # Always include the full bounded window as the final
+        # fallback so a single-sentence prose without trailing
+        # punctuation (``call add with a=13 and b=29``) still works.
+        if not sentence_ends or sentence_ends[-1] < len(bounded):
+            sentence_ends.append(len(bounded))
+        # Cap.
+        sentence_ends = sentence_ends[:MAX_SENTENCES]
+
+        found: dict[str, Any] = {}
+        for window_end_idx in sentence_ends:
+            window = bounded[:window_end_idx]
+            found = _scan_window(window, name, allowed_keys)
+            # If all required args have been collected — accept now.
+            if required and all(r in found for r in required):
+                break
+            # If no required args (schema doesn't declare any) and we
+            # found at least one key — accept (the prose did commit
+            # to a key=value, that's enough for a free-form tool).
+            if not required and found:
+                break
+
         if required and not all(r in found for r in required):
-            # Required params missing — not a confident recovery on
-            # THIS mention. Continue to later mentions (e.g. the
-            # canonical "using the `add` tool. I should call the
-            # `add` tool with a=13 and b=29." has TWO `add` mentions;
-            # the second one has the args, so we skip the first and
-            # succeed on the second).
+            # Required params missing across ALL sentence-expansion
+            # attempts — not a confident recovery on THIS mention.
+            # Continue to later mentions (e.g. the canonical "using
+            # the `add` tool. I should call the `add` tool with
+            # a=13 and b=29." has TWO `add` mentions; the second one
+            # has the args, so we skip the first and succeed on the
+            # second).
             continue
         if not found:
             continue

--- a/vllm_mlx/tool_parsers/gemma4_tool_parser.py
+++ b/vllm_mlx/tool_parsers/gemma4_tool_parser.py
@@ -175,9 +175,7 @@ def _coerce_prose_value(quoted: tuple) -> Any:
     return ""
 
 
-def _try_prose_recover_tool_call(
-    text: str, tools: list[dict]
-) -> dict | None:
+def _try_prose_recover_tool_call(text: str, tools: list[dict]) -> dict | None:
     r"""Recover a structured tool call from prose like
     ``"I should call the \`add\` tool with a=13 and b=29."`` (r5-E
     F-DGF-V080-B-8). Returns ``{"id","name","arguments"}`` on hit, or
@@ -210,9 +208,7 @@ def _try_prose_recover_tool_call(
     # from ``parameters.properties`` (None means "schema doesn't
     # declare properties — accept anything", which preserves
     # behaviour for tools defined with a free-form schema).
-    candidates: list[
-        tuple[int, dict, str, list[str], set[str] | None]
-    ] = []
+    candidates: list[tuple[int, dict, str, list[str], set[str] | None]] = []
     for tool in tools:
         fn = tool.get("function") if isinstance(tool, dict) else None
         if not isinstance(fn, dict):
@@ -249,13 +245,9 @@ def _try_prose_recover_tool_call(
                 required = [r for r in req if isinstance(r, str)]
             props = params.get("properties")
             if isinstance(props, dict):
-                allowed_keys = {
-                    k for k in props if isinstance(k, str)
-                }
+                allowed_keys = {k for k in props if isinstance(k, str)}
         for match in matches:
-            candidates.append(
-                (match.start(), fn, name, required, allowed_keys)
-            )
+            candidates.append((match.start(), fn, name, required, allowed_keys))
 
     if not candidates:
         return None
@@ -321,9 +313,7 @@ def _try_prose_recover_tool_call(
         # ...a=42, b=99." still won't recover because the boundary
         # walk stops well before the later sentence.
         MAX_SENTENCES = 3
-        sentence_ends = [
-            m.end() for m in re.finditer(r"[.!?](?:\s|$)", bounded)
-        ]
+        sentence_ends = [m.end() for m in re.finditer(r"[.!?](?:\s|$)", bounded)]
         # Always include the full bounded window as the final
         # fallback so a single-sentence prose without trailing
         # punctuation (``call add with a=13 and b=29``) still works.

--- a/vllm_mlx/tool_parsers/gemma4_tool_parser.py
+++ b/vllm_mlx/tool_parsers/gemma4_tool_parser.py
@@ -46,6 +46,44 @@ GEMMA4_QUOTED_VAL_PATTERN = re.compile(r'<\|"\|>(.*?)<\|"\|>', re.DOTALL)
 # Match a bare key:value pair (key, then anything up to , or end-of-string)
 GEMMA4_KV_BARE_PATTERN = re.compile(r"(\w+)\s*:\s*([^,]+?)(?=\s*,|\s*$)")
 
+# r5-E F-DGF-V080-B-8: prose-fallback recovery patterns. Gemma 4 at
+# low temperature (~0.1) intermittently emits prose describing the
+# tool intent ("I should call the `add` tool with a=13 and b=29.")
+# instead of emitting the structured ``<|tool_call>call:NAME{...}<tool_call|>``
+# wire form. Trace verdict (see commit body): NEITHER parser pattern
+# miss (the regex above correctly catches every structured emission)
+# NOR template tool injection miss (the chat template renders
+# ``<|tool>declaration:NAME{...}<tool|>`` verbatim and the model has
+# the schema). The model just chose to think-aloud through the
+# ``<|channel>thought`` channel without ever transitioning to the
+# tool_call channel — pure LLM decoding edge case.
+#
+# Defence-in-depth: when the structured form misses AND the request
+# carried a ``tools`` array, look for the model's tool-intent prose
+# and recover the call. The matcher is gated on three conjunctive
+# checks (every false alarm we measured was caught by at least one):
+#
+#   1. The prose mentions a tool name FROM THE REQUEST (verbatim,
+#      with optional backticks/quotes). Natural prose almost never
+#      names an arbitrary user-supplied identifier exactly.
+#   2. The prose contains ``key=value`` (or ``key: value``)
+#      assignments for EVERY required parameter on that tool. This
+#      is the strong signal — the model lays out the args even
+#      when it forgets to wrap them in the channel form.
+#   3. The whole prose passage stays inside a single sentence /
+#      80-char window of the tool-name mention so a long natural
+#      paragraph that happens to contain ``add`` and an unrelated
+#      ``a=`` assignment elsewhere is not collaterally captured.
+#
+# A miss leaves the prose in ``content`` unchanged — there's no
+# silent degradation if the recovery doesn't fire.
+GEMMA4_PROSE_KV_PATTERN = re.compile(
+    r"(\b\w+)\s*[=:]\s*"
+    # value: quoted string, numeric, or bare token up to comma /
+    # whitespace boundary. Backticked / quoted strings are unwrapped.
+    r"(?:`([^`]+)`|\"([^\"]*)\"|'([^']*)'|(-?\d+(?:\.\d+)?)|([A-Za-z_][\w-]*))"
+)
+
 
 def _parse_gemma4_args(args_str: str) -> dict[str, Any]:
     """Parse Gemma 4's argument format into a dict.
@@ -92,6 +130,148 @@ def _generate_tool_id() -> str:
     return f"call_{uuid.uuid4().hex[:8]}"
 
 
+def _extract_request_tools(request: Any) -> list[dict]:
+    """Pull the ``tools`` list off a request in either dict or attr form.
+
+    The parser is called from two paths: the non-streaming finalize
+    (request is a ``ChatCompletionRequest`` model_dump dict, see
+    ``vllm_mlx/service/helpers.py``) and a few unit-test paths that pass
+    raw dicts. Returns ``[]`` when no usable tools list is found.
+    """
+    if request is None:
+        return []
+    tools = None
+    if isinstance(request, dict):
+        tools = request.get("tools")
+    else:
+        tools = getattr(request, "tools", None)
+    if not isinstance(tools, list):
+        return []
+    return [t for t in tools if isinstance(t, dict)]
+
+
+def _coerce_prose_value(quoted: tuple) -> Any:
+    """Convert a ``GEMMA4_PROSE_KV_PATTERN`` value capture tuple into
+    a JSON-friendly Python value.
+
+    The tuple positions are ``(backtick, dquote, squote, number, bare)``
+    — at most one is non-empty per match. Numerics are parsed as JSON
+    literals so ``a=3`` becomes ``int(3)``, ``rate=0.5`` becomes
+    ``float(0.5)``; everything else is returned as a string so the
+    JSON emitted to the wire stays valid.
+    """
+    backtick, dquote, squote, number, bare = quoted
+    if number:
+        try:
+            return json.loads(number)
+        except (json.JSONDecodeError, ValueError):
+            return number
+    # Each alternation arm is either ``None`` (didn't match) or a
+    # captured string (matched). Walk the priority order and return
+    # the FIRST non-None piece.
+    for piece in (backtick, dquote, squote, bare):
+        if piece is not None:
+            return piece
+    return ""
+
+
+def _try_prose_recover_tool_call(
+    text: str, tools: list[dict]
+) -> dict | None:
+    r"""Recover a structured tool call from prose like
+    ``"I should call the \`add\` tool with a=13 and b=29."`` (r5-E
+    F-DGF-V080-B-8). Returns ``{"id","name","arguments"}`` on hit, or
+    ``None`` on miss / no clear winner.
+
+    Conservative gating (see the rationale block above
+    ``GEMMA4_PROSE_KV_PATTERN``):
+
+      * The text must mention a tool by its exact name (within a
+        wrapper of optional backticks / single / double quotes).
+      * The text must contain a ``key=value`` (or ``key: value``)
+        assignment for every required parameter on that tool — a
+        partial match is treated as ``None`` (model probably hadn't
+        finished the call, or the parameters are unrelated).
+      * On multiple candidate tools, take the one whose name appears
+        first AND whose required-params are all matched in the
+        window after the name. Ambiguity → return None.
+
+    Returns the structured form the caller (``extract_tool_calls``)
+    expects: ``{"id": <str>, "name": <str>, "arguments": <json str>}``.
+    """
+    if not tools or not text:
+        return None
+    text_lower = text.lower()
+    candidates: list[tuple[int, dict, str, list[str]]] = []
+    for tool in tools:
+        fn = tool.get("function") if isinstance(tool, dict) else None
+        if not isinstance(fn, dict):
+            continue
+        name = fn.get("name")
+        if not isinstance(name, str) or not name:
+            continue
+        # Match the name as a standalone token (after optional
+        # backticks / quotes). Don't use a plain substring search:
+        # that would match a parameter called ``add`` inside an
+        # unrelated tool's signature.
+        # Allow surrounding ``\`add\```, ``"add"``, ``'add'``, or
+        # the bare word at a word boundary.
+        name_re = re.compile(
+            r"(?:`|\"|')?" + re.escape(name) + r"(?:`|\"|')?\b",
+            re.IGNORECASE,
+        )
+        match = name_re.search(text)
+        if match is None:
+            continue
+        params = fn.get("parameters") if isinstance(fn, dict) else None
+        required = []
+        if isinstance(params, dict):
+            req = params.get("required")
+            if isinstance(req, list):
+                required = [r for r in req if isinstance(r, str)]
+        candidates.append((match.start(), fn, name, required))
+
+    if not candidates:
+        return None
+    # Prefer the earliest tool-name mention. If two tools tie on
+    # start position (unlikely — names would have to be identical),
+    # the first one in ``tools`` wins.
+    candidates.sort(key=lambda c: c[0])
+
+    for name_start, fn, name, required in candidates:
+        # Search a window AFTER the name mention up to the end of the
+        # text (gemma4 prose is short — usually < 300 chars). Scanning
+        # forward only ensures the "call X with args" ordering rather
+        # than picking up an unrelated ``a=`` from an earlier sentence.
+        window = text[name_start:]
+        found: dict[str, Any] = {}
+        for kv in GEMMA4_PROSE_KV_PATTERN.finditer(window):
+            key = kv.group(1)
+            value = _coerce_prose_value(kv.groups()[1:])
+            # Skip captures whose "key" is actually the tool name
+            # itself (``name=add``) — that's the name mention, not an
+            # argument assignment.
+            if key.lower() == name.lower():
+                continue
+            # First mention wins: a prose like "a=13" then later
+            # "a=14" most likely the second is a correction; pick
+            # the first, which matches the model's earliest stated
+            # intent (the prose is the model's reasoning, so the
+            # earliest commitment is the most reliable).
+            found.setdefault(key, value)
+        if required and not all(r in found for r in required):
+            # Required params missing — not a confident recovery.
+            continue
+        if not found:
+            continue
+        return {
+            "id": _generate_tool_id(),
+            "name": name,
+            "arguments": json.dumps(found),
+        }
+    return None
+
+
 @ToolParserManager.register_module(["gemma4", "gemma_4"])
 class Gemma4ToolParser(ToolParser):
     """
@@ -131,6 +311,35 @@ class Gemma4ToolParser(ToolParser):
         matches = list(GEMMA4_TOOL_PATTERN.finditer(model_output))
 
         if not matches:
+            # r5-E F-DGF-V080-B-8: structured form missed. Try the
+            # prose-fallback recovery before giving up — gemma4 at
+            # low temperature intermittently describes the tool
+            # intent in prose ("I should call the `add` tool with
+            # a=13 and b=29.") instead of emitting the
+            # ``<|tool_call>`` channel form. The recovery is gated
+            # by ``request.tools`` so an unrelated chat that happens
+            # to contain ``a=13`` prose cannot trigger a false
+            # tool_call.
+            recovered = _try_prose_recover_tool_call(
+                model_output, _extract_request_tools(request)
+            )
+            if recovered is not None:
+                return ExtractedToolCallInformation(
+                    tools_called=True,
+                    tool_calls=[recovered],
+                    # Drop the prose content — keeping it would
+                    # double-render the model's stated intent as
+                    # both ``message.content`` and the tool call,
+                    # surfacing as ``"I should call..."`` text +
+                    # the call in the OpenAI response shape. That
+                    # shape is wrong: the OpenAI spec is content OR
+                    # tool_calls, not both verbatim. (The route
+                    # layer ``parallel_tool_calls=false`` and
+                    # ``finish_reason=tool_calls`` invariants both
+                    # assume ``content`` is empty / falsy on a
+                    # tool-call path.)
+                    content=None,
+                )
             return ExtractedToolCallInformation(
                 tools_called=False, tool_calls=[], content=model_output
             )

--- a/vllm_mlx/tool_parsers/gemma4_tool_parser.py
+++ b/vllm_mlx/tool_parsers/gemma4_tool_parser.py
@@ -201,8 +201,18 @@ def _try_prose_recover_tool_call(
     """
     if not tools or not text:
         return None
-    text_lower = text.lower()
-    candidates: list[tuple[int, dict, str, list[str]]] = []
+    # Carry per-mention: (name_start, fn, name, required[], allowed_keys_or_None)
+    # We index by EVERY name occurrence (not just the first) so a
+    # prose like "using the `add` tool. I should call the `add` tool
+    # with a=13 and b=29." can recover from the SECOND mention even
+    # when the first mention's bounded window has no key=value pairs.
+    # ``allowed_keys_or_None`` is the set of declared parameter keys
+    # from ``parameters.properties`` (None means "schema doesn't
+    # declare properties — accept anything", which preserves
+    # behaviour for tools defined with a free-form schema).
+    candidates: list[
+        tuple[int, dict, str, list[str], set[str] | None]
+    ] = []
     for tool in tools:
         fn = tool.get("function") if isinstance(tool, dict) else None
         if not isinstance(fn, dict):
@@ -216,34 +226,65 @@ def _try_prose_recover_tool_call(
         # unrelated tool's signature.
         # Allow surrounding ``\`add\```, ``"add"``, ``'add'``, or
         # the bare word at a word boundary.
+        # Case-sensitive: OpenAI tool spec says function names are
+        # case-sensitive identifiers, so a model writing ``ADD`` when
+        # the registered tool is ``add`` is NOT a confident call.
+        # (codex pr_validate NIT-5)
         name_re = re.compile(
             r"(?:`|\"|')?" + re.escape(name) + r"(?:`|\"|')?\b",
-            re.IGNORECASE,
         )
-        match = name_re.search(text)
-        if match is None:
+        matches = list(name_re.finditer(text))
+        if not matches:
             continue
         params = fn.get("parameters") if isinstance(fn, dict) else None
-        required = []
+        required: list[str] = []
+        allowed_keys: set[str] | None = None
         if isinstance(params, dict):
             req = params.get("required")
             if isinstance(req, list):
                 required = [r for r in req if isinstance(r, str)]
-        candidates.append((match.start(), fn, name, required))
+            props = params.get("properties")
+            if isinstance(props, dict):
+                allowed_keys = {
+                    k for k in props.keys() if isinstance(k, str)
+                }
+        for match in matches:
+            candidates.append(
+                (match.start(), fn, name, required, allowed_keys)
+            )
 
     if not candidates:
         return None
-    # Prefer the earliest tool-name mention. If two tools tie on
-    # start position (unlikely — names would have to be identical),
-    # the first one in ``tools`` wins.
+    # Try mentions in document order. If two tools tie on start
+    # position (unlikely — names would have to be identical), the
+    # first one in ``tools`` wins.
     candidates.sort(key=lambda c: c[0])
 
-    for name_start, fn, name, required in candidates:
-        # Search a window AFTER the name mention up to the end of the
-        # text (gemma4 prose is short — usually < 300 chars). Scanning
-        # forward only ensures the "call X with args" ordering rather
-        # than picking up an unrelated ``a=`` from an earlier sentence.
-        window = text[name_start:]
+    # Window bound — codex pr_validate BLOCKING-1: scanning to
+    # end-of-text turned multi-sentence answers into false positives.
+    # 300 chars after the name mention covers any realistic gemma4
+    # tool prose (e.g. "call `add` with a=13 and b=29") while
+    # rejecting ramble that mentions ``add`` once and later
+    # mentions an unrelated ``a=…`` many sentences later.
+    PROSE_WINDOW_BYTES = 300
+
+    for name_start, fn, name, required, allowed_keys in candidates:
+        # Search a BOUNDED window after the name mention, clipped at
+        # the first sentence-end (period/question/exclamation followed
+        # by whitespace) or PROSE_WINDOW_BYTES, whichever is smaller.
+        # Forward-only scanning preserves the "call X with args"
+        # ordering AND avoids dragging in unrelated key=value pairs.
+        window_end = min(len(text), name_start + PROSE_WINDOW_BYTES)
+        window = text[name_start:window_end]
+        # Clip at first sentence boundary if one exists in the window.
+        # This handles "call add with a=13 and b=29. Earlier I noted
+        # result=42." — we keep only the first sentence so the
+        # ``result=42`` from a later sentence does not leak into the
+        # recovered call.
+        sentence_match = re.search(r"[.!?](?:\s|$)", window)
+        if sentence_match is not None:
+            # Include the punctuation so "a=29." still captures the 29.
+            window = window[: sentence_match.end()]
         found: dict[str, Any] = {}
         for kv in GEMMA4_PROSE_KV_PATTERN.finditer(window):
             key = kv.group(1)
@@ -253,6 +294,12 @@ def _try_prose_recover_tool_call(
             # argument assignment.
             if key.lower() == name.lower():
                 continue
+            # Drop keys not declared in the tool schema. (codex
+            # pr_validate BLOCKING-2: strict tool servers reject
+            # unknown args, so silently filter here rather than
+            # forward `result=42` from `call add with a=13, result=42`.)
+            if allowed_keys is not None and key not in allowed_keys:
+                continue
             # First mention wins: a prose like "a=13" then later
             # "a=14" most likely the second is a correction; pick
             # the first, which matches the model's earliest stated
@@ -260,7 +307,12 @@ def _try_prose_recover_tool_call(
             # earliest commitment is the most reliable).
             found.setdefault(key, value)
         if required and not all(r in found for r in required):
-            # Required params missing — not a confident recovery.
+            # Required params missing — not a confident recovery on
+            # THIS mention. Continue to later mentions (e.g. the
+            # canonical "using the `add` tool. I should call the
+            # `add` tool with a=13 and b=29." has TWO `add` mentions;
+            # the second one has the args, so we skip the first and
+            # succeed on the second).
             continue
         if not found:
             continue


### PR DESCRIPTION
## Why

`cycle-DGF-v080` sweep (V1/V2/V3 against bundled rapid-mlx 0.8.6 — see `~/work/rapid-mlx/v0.8-TODO.md`) surfaced four bugs the validation / parser layers silently accepted. Three are validation gaps where Pydantic lax-mode coercion / missing-range checks let footgun inputs through; one is a model-decoding edge case on gemma-4 tool-calling that needs a parser-side defence-in-depth fallback.

Closed in this PR:

- **B-7 / F-DGF-V080-C-4** — `top_k=999999999` and `top_k=2**63-1` returned HTTP 200 even though no shipped vocab exceeds 262144 (Gemma 3 widest). Added `_TOP_K_SENTINEL_CAP = 1 << 20` and threaded through every route's `_validate_nonnegative_int` call. `top_k=0` (mlx-lm "disabled") still ACCEPTED — the v0.8.2 own error message read "use 0 to disable", so the by-design escape hatch is preserved.

- **B-8** — `seed=-1` slipped past the request layer. The downstream `seed & 0xFFFFFFFF` fold mapped `-1` → `0xFFFFFFFF`, so a caller passing `-1` as a "no seed" sentinel actually pinned a fixed PRNG state. Silent-correctness hazard. Now `_validate_seed` rejects negatives; `seed=0` (eval-harness default) preserved; large positive 64-bit seeds still pass (codex round-6 upper-end contract unchanged).

- **B-9 / F-DGF-V080-V1** — `stream_options.include_usage:"yes"` lax-coerced to `True`. Switched the field to `StrictBool` with a `mode="before"` validator that flattens Pydantic's union-error noise into a single human-readable message naming the offending field. Truthy strings (`"yes"`, `"true"`, `"on"`, `"1"`) and integer 1/0 now 4xx.

- **F-DGF-V080-B-8 (gemma-4-12b-4bit tool-call regression)** — trace verdict in commit body: NEITHER parser pattern miss NOR template injection miss. Verified against `mlx-community/gemma-4-12B-it-4bit`:
  1. Template renders `<|tool>declaration:NAME{...}<tool|>` for every request tool (the model has the schema).
  2. At temperature=1.0 the model emits the structured `<|tool_call>call:add{a:13,b:29}<tool_call|>` form correctly.
  3. At temperature=0.1 the model INTERMITTENTLY emits prose ("The user wants to add 13 and 29 using the \`add\` tool. I should call the \`add\` tool with a=13 and b=29.") instead of channel-routing through `<|tool_call>`. Pure LLM decoding edge case.

  Fix: `_try_prose_recover_tool_call` runs after a structured-form miss inside `Gemma4ToolParser.extract_tool_calls`. Conservative gating prevents false positives — request must carry `tools`, prose must mention a tool by exact name, prose must contain `key=value` (or `key: value`) assignments for every required parameter on that tool. A miss leaves the prose in `content` unchanged.

## Live verification

`gemma-4-12b-4bit`, 15 trials at `temperature=0.1`:
- pre-fix: ~1/5 trials emit prose → no tool_call surfaced
- post-fix: 15/15 trials surface structured tool_calls (either directly or via prose recovery)

## Cross-route coverage

| Surface | top_k cap | seed >= 0 | include_usage strict bool |
|---|---|---|---|
| `/v1/chat/completions` (ChatCompletionRequest) | yes | yes | yes |
| `/v1/completions` (CompletionRequest) | yes | yes | yes |
| `/v1/responses` (ResponsesRequest) | n/a (no top_k) | yes (via shared `_validate_seed`) | n/a (no stream_options) |
| `/v1/messages` (AnthropicRequest) | yes (via shared `_validate_nonnegative_int`) | n/a (no seed) | n/a (no stream_options) |

The three Pydantic helpers (`_TOP_K_SENTINEL_CAP`, `_validate_seed`, `StreamOptions._validate_include_usage`) live in `vllm_mlx/api/models.py` and are imported by every other surface so all four routes share one source of truth — there's nowhere for the contract to drift.

## Test plan

- [x] `tests/test_param_validation_r5e.py` (68 cases) — top_k upper bound on chat+completions+anthropic, seed negative on chat+completions+responses, include_usage strict bool on StreamOptions direct + nested through chat/completions, plus positive cases preserving the by-design escape hatches (`top_k=0`, `seed=0`, `seed=None`, `seed=2**63-1`, omitted `stream_options`).
- [x] `tests/test_gemma4_prose_fallback.py` (14 cases) — canonical DGF-v080 prose verbatim, `key=value` / `key: value` / quoted / backticked variants, conservative gating (no tools, partial required params, unrelated chat, first-value-wins on self-correction), no-regression on the structured wire form.
- [x] `tests/test_seed_reproducibility.py` updated — flipped two codex round-6 "accept any int" tests to pin the r5-E "reject negative" contract while preserving the 64-bit-positive path.
- [x] No regression: `tests/test_gemma4_tool_parser.py` (26 cases), `tests/test_anthropic_tool_param_validation.py` (3 cases), `tests/test_api_validation_bundle.py` (42 cases) all still pass.
- [x] Live `/v1/chat/completions` against gemma-4-12b-4bit confirms all four bugs fixed (15/15 tool_call success at temp=0.1, validation gates fire with clean messages).

## Report row IDs covered

- B-7 / F-DGF-V080-C-4 (input validation table)
- B-8 (input validation table)
- B-9 / F-DGF-V080-V1 (SSE / streaming wire-shape table)
- F-DGF-V080-B-8 (model behavior / parser side table — gemma-4-12b-4bit tool_call regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
## Codex review acknowledgements

`pr_validate` has surfaced 3 rounds of codex review. Round-1 / round-2 / round-3 findings are all addressed (see commits `981f674`, `95f40e1`, `9dbdea5` — bounded prose window + sentence-walk + leading-boundary regex + schema-key filter + call-intent gate + required-keys allowlist).

One codex objection is **intentionally not addressed**: codex flags the new `seed >= 0` Pydantic validator as a breaking change. This is **exactly the contract tightening the bug spec asks for** (`v0.8-TODO.md` B-8: "Pydantic validator: `seed: int >= 0 | None`. Reject negative."). A negative seed was silently folded via `& 0xFFFFFFFF` to `0xFFFFFFFF` at the kernel boundary, pinning a fixed PRNG state for a caller that thought they were passing a sentinel — a real silent-correctness hazard. The validator docstring documents this as an intentional breaking change. `seed=None` (no determinism, default) and `seed=0` (eval-harness default) are preserved.

3 pre-existing `full_unit` failures (`test_anthropic_tool_usage_d::test_nonstream_tool_choice_named_still_routes_to_specific_tool`, `test_no_out_of_band_routing::test_no_routing_shaped_rapid_mlx_env_vars`, `test_route_engine_contract::test_no_hasattr_engine_guard[completions.py]`) are reproduced identically on a clean `origin/main` shallow clone — orthogonal landed bugs, out of scope for this PR.

Stress-bench partial pass rates (5/6 pydantic_ai, 7/8 stress, 3/5 anthropic_sdk, 3/6 langchain) are model-quality / perf-threshold flakes on heavy models. Grep confirms no stress log touches any file changed by this PR (`gemma4_tool_parser | StreamOptions | include_usage | seed.*negative | top_k.*sentinel`).
