### PR TITLE
fix(reasoning): r5-D — parser finalize-on-truncation must not dup or misclassify open-think buffer

### DIFF
--- a/tests/test_reasoning_parser_truncation_finalize.py
+++ b/tests/test_reasoning_parser_truncation_finalize.py
@@ -40,6 +40,7 @@ from __future__ import annotations
 
 import pytest
 
+from vllm_mlx.api.utils import clean_output_text, strip_thinking_tags
 from vllm_mlx.reasoning import finalize_truncation
 from vllm_mlx.reasoning.deepseek_r1_parser import (
     DeepSeekR1ReasoningParser,
@@ -49,7 +50,6 @@ from vllm_mlx.reasoning.gemma4_parser import Gemma4ReasoningParser
 from vllm_mlx.reasoning.glm4_parser import Glm4ReasoningParser
 from vllm_mlx.reasoning.minimax_parser import MiniMaxReasoningParser
 from vllm_mlx.reasoning.qwen3_parser import Qwen3ReasoningParser
-from vllm_mlx.api.utils import clean_output_text, strip_thinking_tags
 from vllm_mlx.service.helpers import (
     _finalize_content_and_reasoning,
     _rescue_silent_drop_from_reasoning,
@@ -128,16 +128,14 @@ class TestIsOpenInThink:
     def test_gemma4_closed_thought_then_content(self):
         p = Gemma4ReasoningParser()
         text = (
-            "<|channel>thought\nThinking<channel|>"
-            "<|channel>content\nThe answer is 42."
+            "<|channel>thought\nThinking<channel|><|channel>content\nThe answer is 42."
         )
         assert p.is_open_in_think(text) is False
 
     def test_gemma4_multi_block_trailing_open(self):
         p = Gemma4ReasoningParser()
         text = (
-            "<|channel>thought\nFirst round<channel|>"
-            "<|channel>thought\nSecond unclosed"
+            "<|channel>thought\nFirst round<channel|><|channel>thought\nSecond unclosed"
         )
         assert p.is_open_in_think(text) is True
 
@@ -205,8 +203,7 @@ class TestExtractReasoningMidThink:
     def test_gemma4_mid_thought_with_prior_closed_block(self):
         p = Gemma4ReasoningParser()
         text = (
-            "<|channel>thought\nFirst round<channel|>"
-            "<|channel>thought\nSecond unclosed"
+            "<|channel>thought\nFirst round<channel|><|channel>thought\nSecond unclosed"
         )
         reasoning, content = p.extract_reasoning(text)
         assert reasoning is not None
@@ -365,7 +362,10 @@ class TestRouteFinalizeOnTruncation:
         # no closer) so the helper sees ``(reasoning, None)`` and
         # the truncated-think plug fires.
         assert reasoning_text is not None
-        assert raw in reasoning_text or "step by step about Tokyo's history" in reasoning_text
+        assert (
+            raw in reasoning_text
+            or "step by step about Tokyo's history" in reasoning_text
+        )
         # ``content`` must NOT carry the raw scratchpad bytes.
         assert raw not in (cleaned_text or "")
 
@@ -501,8 +501,7 @@ class TestRouteFinishReasonLengthAfterClose:
         # got truncated. The truncated content body must STAY in
         # ``content``, never get rerouted to reasoning.
         raw = (
-            "<|channel>thought\nReasoning here<channel|>"
-            "<|channel>content\nPartial ans"
+            "<|channel>thought\nReasoning here<channel|><|channel>content\nPartial ans"
         )
         parser = Gemma4ReasoningParser()
         cleaned_text, reasoning_text = _finalize_content_and_reasoning(
@@ -645,9 +644,7 @@ class TestEndToEndRouteContract:
 
     def test_gemma4_end_to_end_no_dup(self):
         raw = "<|channel>thought\nMid-thought reasoning that was cut short"
-        content, reasoning = _route_end_to_end(
-            Gemma4ReasoningParser(), raw, "length"
-        )
+        content, reasoning = _route_end_to_end(Gemma4ReasoningParser(), raw, "length")
         assert content is None
         assert reasoning is not None
         assert "Mid-thought reasoning" in reasoning
@@ -656,9 +653,7 @@ class TestEndToEndRouteContract:
 
     def test_minimax_end_to_end_no_dup(self):
         raw = "<think>Mid-thought reasoning that was cut short"
-        content, reasoning = _route_end_to_end(
-            MiniMaxReasoningParser(), raw, "length"
-        )
+        content, reasoning = _route_end_to_end(MiniMaxReasoningParser(), raw, "length")
         assert content is None
         assert reasoning is not None
         assert "Mid-thought reasoning" in reasoning
@@ -666,9 +661,7 @@ class TestEndToEndRouteContract:
 
     def test_glm4_end_to_end_no_dup(self):
         raw = "<think>Mid-thought reasoning that was cut short"
-        content, reasoning = _route_end_to_end(
-            Glm4ReasoningParser(), raw, "length"
-        )
+        content, reasoning = _route_end_to_end(Glm4ReasoningParser(), raw, "length")
         assert content is None
         assert reasoning is not None
         assert "Mid-thought reasoning" in reasoning
@@ -676,9 +669,7 @@ class TestEndToEndRouteContract:
 
     def test_qwen3_end_to_end_no_dup(self):
         raw = "<think>Mid-thought reasoning that was cut short"
-        content, reasoning = _route_end_to_end(
-            Qwen3ReasoningParser(), raw, "length"
-        )
+        content, reasoning = _route_end_to_end(Qwen3ReasoningParser(), raw, "length")
         assert content is None
         assert reasoning is not None
         assert "Mid-thought reasoning" in reasoning
@@ -701,17 +692,13 @@ class TestEndToEndRouteContract:
             "<|channel>thought\nReasoning here<channel|>"
             "<|channel>content\nThe answer is 42.<channel|>"
         )
-        content, reasoning = _route_end_to_end(
-            Gemma4ReasoningParser(), raw, "stop"
-        )
+        content, reasoning = _route_end_to_end(Gemma4ReasoningParser(), raw, "stop")
         assert content == "The answer is 42."
         assert reasoning == "Reasoning here"
 
     def test_qwen3_end_to_end_clean_split_finish_stop(self):
         raw = "<think>Reasoning</think>The answer is 42."
-        content, reasoning = _route_end_to_end(
-            Qwen3ReasoningParser(), raw, "stop"
-        )
+        content, reasoning = _route_end_to_end(Qwen3ReasoningParser(), raw, "stop")
         assert content == "The answer is 42."
         assert reasoning == "Reasoning"
 
@@ -771,3 +758,124 @@ class TestGlm4AutonomousModeRoute:
         # "non-thinking response truncated" on text alone.
         assert cleaned_text == raw
         assert reasoning_text is None
+
+
+# ---------------------------------------------------------------------
+# r5-D codex r1 BLOCKING follow-up: legitimate content containing a
+# LITERAL ``<|channel>thought`` / ``<think>`` substring must NOT be
+# reclassified as reasoning by the new finalize-on-truncation gates.
+#
+# Mirrors the contract pinned by
+# ``test_literal_closed_think_in_answer_preserved_non_streaming`` in
+# ``tests/test_reasoning_parsers.py`` (PR #722 codex r3) for the two
+# parsers whose new finalize branches missed the substring-vs-structural
+# distinction.
+# ---------------------------------------------------------------------
+
+
+class TestLiteralSubstringPreservedInContent:
+    """The codex r1 BLOCKING contract for PR #825: the new
+    finalize-on-truncation branches in gemma4 and minimax must NOT
+    fire when the literal opener bytes appear inside what is otherwise
+    legitimate answer content (already-closed thought block + answer
+    that mentions the tag verbatim, or plain answer that mentions
+    the tag verbatim).
+
+    Fix shape:
+    * gemma4 ``is_open_in_think`` requires no
+      ``<|channel>content`` / ``<|channel>final`` marker between the
+      last ``<|channel>thought`` and end-of-text.
+    * minimax finalize branch requires
+      ``model_output.lstrip().startswith("<think>")`` (true mid-think
+      shape, matching the existing ``_sweep_residual_think_tags``
+      conservative scope).
+    """
+
+    def test_gemma4_literal_channel_thought_in_content_preserved_stop(self):
+        """``finish_reason="stop"``: properly closed thought block,
+        then content channel whose answer text literally mentions
+        ``<|channel>thought``. Must round-trip the answer verbatim
+        and surface the actual thought as reasoning."""
+        p = Gemma4ReasoningParser()
+        raw = (
+            "<|channel>thought\nR<channel|>"
+            "<|channel>content\nThe gemma4 format uses <|channel>thought tag"
+        )
+        reasoning, content = p.extract_reasoning(raw)
+        assert reasoning == "R", (
+            f"reasoning must be the actual thought, not the literal "
+            f"substring or a concatenation: {reasoning!r}"
+        )
+        assert content == "The gemma4 format uses <|channel>thought tag", (
+            f"content with literal <|channel>thought must survive verbatim: {content!r}"
+        )
+
+    def test_gemma4_literal_channel_thought_in_content_preserved_length(self):
+        """``finish_reason="length"`` mid-content: closed thought,
+        content channel opened, answer mentions the literal substring,
+        then truncated. The route must still split correctly — the
+        thought stays as reasoning, the partial answer stays as
+        content (literal substring preserved)."""
+        p = Gemma4ReasoningParser()
+        raw = (
+            "<|channel>thought\nR<channel|>"
+            "<|channel>content\nThe gemma4 format uses <|channel>thought tag"
+        )
+        cleaned_text, reasoning_text = _finalize_content_and_reasoning(
+            raw_text=raw,
+            cleaned_text=raw,
+            tool_calls=[],
+            reasoning_parser=p,
+            engine_reasoning_text="",
+            finish_reason="length",
+        )
+        assert reasoning_text == "R", (
+            f"on length truncation in-content, reasoning must remain "
+            f"the closed thought: {reasoning_text!r}"
+        )
+        assert cleaned_text is not None
+        assert "The gemma4 format uses <|channel>thought tag" in cleaned_text, (
+            f"content with literal <|channel>thought must survive on "
+            f"length truncation in-content: {cleaned_text!r}"
+        )
+
+    def test_minimax_literal_think_substring_in_answer_preserved_stop(self):
+        """``finish_reason="stop"``: a normal answer that literally
+        mentions ``<think>`` must NOT be reclassified as reasoning.
+        Pre-fix, the new finalize branch fired on any ``<think>``
+        substring; the conservative gate is ``lstrip().startswith``."""
+        p = MiniMaxReasoningParser()
+        raw = "The model uses <think> tags for reasoning"
+        reasoning, content = p.extract_reasoning(raw)
+        assert reasoning is None, (
+            f"literal <think> in answer must NOT promote answer to "
+            f"reasoning: {reasoning!r}"
+        )
+        assert content == raw, (
+            f"literal <think> substring must survive verbatim in content: {content!r}"
+        )
+
+    def test_minimax_literal_think_substring_in_answer_preserved_length(self):
+        """``finish_reason="length"`` on the same shape — the route
+        must NOT promote the partial answer to reasoning just because
+        it contains the substring."""
+        p = MiniMaxReasoningParser()
+        raw = "The model uses <think> tags for reasoning"
+        cleaned_text, reasoning_text = _finalize_content_and_reasoning(
+            raw_text=raw,
+            cleaned_text=raw,
+            tool_calls=[],
+            reasoning_parser=p,
+            engine_reasoning_text="",
+            finish_reason="length",
+        )
+        # The conservative gate keeps the buffer as content.
+        # ``<think>`` substring is preserved verbatim — never split.
+        assert reasoning_text is None, (
+            f"length truncation on answer with literal <think> must "
+            f"NOT route to reasoning: {reasoning_text!r}"
+        )
+        assert cleaned_text == raw, (
+            f"length truncation on answer with literal <think> must "
+            f"preserve content verbatim: {cleaned_text!r}"
+        )

--- a/tests/test_reasoning_parser_truncation_finalize.py
+++ b/tests/test_reasoning_parser_truncation_finalize.py
@@ -1,0 +1,773 @@
+# SPDX-License-Identifier: Apache-2.0
+"""r5-D — reasoning-parser finalize-on-truncation contract tests.
+
+Pins the parser-side fix for F-DGF-V080-B-7 (gemma4 dup-into-both-fields)
+and F-DGF-V080-B-9 (glm4 leak-into-content) on the non-streaming
+``/v1/chat/completions`` aggregator's finalize-on-truncation path.
+
+Bug shape:
+
+* When ``finish_reason="length"`` truncates the model mid-think (the
+  closing ``</think>`` / ``<channel|>`` sentinel never arrives), the
+  pre-r5-D non-streaming aggregator misclassified the unclosed buffer:
+  - gemma4 duplicated the raw scratchpad into BOTH ``content`` and
+    ``reasoning_content`` (when the engine's token-level OutputRouter
+    also populated ``engine_reasoning_text``).
+  - glm4 / minimax leaked the raw scratchpad into ``content`` with
+    ``reasoning_content=null``.
+
+Fix (shared finalize-on-truncation):
+
+* Each parser implements ``is_open_in_think(text)`` (default False) so
+  the route knows whether the unclosed buffer should be classified
+  as reasoning.
+* A shared ``finalize_truncation(open_in_think, buffer)`` helper in
+  ``vllm_mlx/reasoning/base.py`` routes the buffer parser-agnostically.
+* The non-streaming aggregator
+  ``vllm_mlx/service/helpers.py::_finalize_content_and_reasoning``
+  invokes the helper when ``finish_reason="length"`` is reported AND
+  the parser's first pass returned the leak shape.
+* Each parser's own ``extract_reasoning`` ALSO routes correctly on the
+  parser-side so unit-test callers that don't go through the helper
+  see the right behaviour.
+
+The no-regression contract: ``finish_reason="stop"`` (or
+``finish_reason="length"`` with the buffer already closed —
+``</think>answer``) splits cleanly, byte-identical pre/post.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from vllm_mlx.reasoning import finalize_truncation
+from vllm_mlx.reasoning.deepseek_r1_parser import (
+    DeepSeekR1ReasoningParser,
+    VibeThinkerReasoningParser,
+)
+from vllm_mlx.reasoning.gemma4_parser import Gemma4ReasoningParser
+from vllm_mlx.reasoning.glm4_parser import Glm4ReasoningParser
+from vllm_mlx.reasoning.minimax_parser import MiniMaxReasoningParser
+from vllm_mlx.reasoning.qwen3_parser import Qwen3ReasoningParser
+from vllm_mlx.api.utils import clean_output_text, strip_thinking_tags
+from vllm_mlx.service.helpers import (
+    _finalize_content_and_reasoning,
+    _rescue_silent_drop_from_reasoning,
+)
+
+
+def _route_end_to_end(parser, raw, finish_reason):
+    """Mini-route harness: ``_finalize_content_and_reasoning`` →
+    ``clean_output_text`` + ``strip_thinking_tags`` →
+    ``_rescue_silent_drop_from_reasoning``. Matches the chat-route
+    finalize flow (chat.py:~2007–2115) but does not exercise tool
+    parsing or response_format. Returns the user-facing
+    ``(content, reasoning_content)`` pair the route would ship.
+    """
+    cleaned_text, reasoning_text = _finalize_content_and_reasoning(
+        raw_text=raw,
+        cleaned_text=raw,
+        tool_calls=[],
+        reasoning_parser=parser,
+        engine_reasoning_text="",
+        finish_reason=finish_reason,
+    )
+    final_content = None
+    if cleaned_text:
+        final_content = strip_thinking_tags(clean_output_text(cleaned_text))
+    rescued = _rescue_silent_drop_from_reasoning(
+        final_content,
+        reasoning_text,
+        tool_calls=[],
+        finish_reason=finish_reason,
+        raw_text=raw,
+        reasoning_is_case4=False,
+    )
+    return rescued, reasoning_text
+
+
+# ---------------------------------------------------------------------
+# Shared helper contract
+# ---------------------------------------------------------------------
+
+
+class TestFinalizeTruncationHelper:
+    """``finalize_truncation`` is the single source of truth for the
+    parser-agnostic open-in-think → (reasoning, content) routing."""
+
+    def test_open_in_think_routes_to_reasoning(self):
+        reasoning, content = finalize_truncation(True, "step 1 of my thought")
+        assert reasoning == "step 1 of my thought"
+        assert content is None
+
+    def test_not_open_in_think_routes_to_content(self):
+        reasoning, content = finalize_truncation(False, "final answer body")
+        assert reasoning is None
+        assert content == "final answer body"
+
+    def test_empty_buffer_routes_to_none(self):
+        assert finalize_truncation(True, "") == (None, None)
+        assert finalize_truncation(False, "") == (None, None)
+        assert finalize_truncation(True, None) == (None, None)
+        assert finalize_truncation(False, None) == (None, None)
+
+
+# ---------------------------------------------------------------------
+# Per-parser ``is_open_in_think`` contract
+# ---------------------------------------------------------------------
+
+
+class TestIsOpenInThink:
+    """Each thinking parser correctly identifies its own unclosed-think
+    state from accumulated text. Non-think parsers default to False."""
+
+    def test_gemma4_open_in_think(self):
+        p = Gemma4ReasoningParser()
+        assert p.is_open_in_think("<|channel>thought\nReasoning so far") is True
+
+    def test_gemma4_closed_thought_then_content(self):
+        p = Gemma4ReasoningParser()
+        text = (
+            "<|channel>thought\nThinking<channel|>"
+            "<|channel>content\nThe answer is 42."
+        )
+        assert p.is_open_in_think(text) is False
+
+    def test_gemma4_multi_block_trailing_open(self):
+        p = Gemma4ReasoningParser()
+        text = (
+            "<|channel>thought\nFirst round<channel|>"
+            "<|channel>thought\nSecond unclosed"
+        )
+        assert p.is_open_in_think(text) is True
+
+    def test_gemma4_no_marker_at_all(self):
+        p = Gemma4ReasoningParser()
+        assert p.is_open_in_think("plain content") is False
+
+    def test_glm4_open_in_think(self):
+        p = Glm4ReasoningParser()
+        assert p.is_open_in_think("<think>Reasoning so far") is True
+
+    def test_glm4_closed(self):
+        p = Glm4ReasoningParser()
+        assert p.is_open_in_think("<think>R</think>The answer is 42.") is False
+
+    def test_glm4_autonomous_no_tag(self):
+        """GLM-4 in autonomous mode (no tag): cannot detect from text
+        alone — the route plug handles this via ``engine_reasoning_text``.
+        The parser conservatively returns False."""
+        p = Glm4ReasoningParser()
+        assert p.is_open_in_think("Okay let me reason step by step") is False
+
+    def test_qwen3_open_in_think(self):
+        p = Qwen3ReasoningParser()
+        assert p.is_open_in_think("<think>Reasoning so far") is True
+
+    def test_qwen3_closed(self):
+        p = Qwen3ReasoningParser()
+        assert p.is_open_in_think("<think>R</think>answer") is False
+
+    def test_deepseek_r1_open_in_think(self):
+        p = DeepSeekR1ReasoningParser()
+        assert p.is_open_in_think("<think>R") is True
+
+    def test_minimax_open_in_think(self):
+        p = MiniMaxReasoningParser()
+        assert p.is_open_in_think("<think>R") is True
+
+    def test_minimax_no_tag_returns_false(self):
+        """MiniMax routes the no-tag heuristic preamble via its own
+        ``_REASONING_START_RE`` matcher; the open-in-think hook is
+        only the explicit-tag fast path."""
+        p = MiniMaxReasoningParser()
+        assert p.is_open_in_think("The user asks about Tokyo") is False
+
+
+# ---------------------------------------------------------------------
+# Per-parser ``extract_reasoning`` finalize-on-truncation contract
+# ---------------------------------------------------------------------
+
+
+class TestExtractReasoningMidThink:
+    """The parser-side fix: ``extract_reasoning`` on a buffer that
+    ends inside an unclosed think tag must return
+    ``(reasoning=buffer, content=None)``. Pre-fix gemma4 / minimax
+    leaked the buffer into ``content``."""
+
+    def test_gemma4_mid_thought(self):
+        p = Gemma4ReasoningParser()
+        text = "<|channel>thought\nLet me think about this. The answer involves"
+        reasoning, content = p.extract_reasoning(text)
+        assert reasoning == "Let me think about this. The answer involves"
+        assert content is None
+
+    def test_gemma4_mid_thought_with_prior_closed_block(self):
+        p = Gemma4ReasoningParser()
+        text = (
+            "<|channel>thought\nFirst round<channel|>"
+            "<|channel>thought\nSecond unclosed"
+        )
+        reasoning, content = p.extract_reasoning(text)
+        assert reasoning is not None
+        assert "First round" in reasoning
+        assert "Second unclosed" in reasoning
+        assert content is None
+
+    def test_minimax_mid_thought(self):
+        p = MiniMaxReasoningParser()
+        text = "<think>Reasoning so far"
+        reasoning, content = p.extract_reasoning(text)
+        assert reasoning == "Reasoning so far"
+        assert content is None
+
+    def test_glm4_mid_thought_with_think_opener(self):
+        """glm4 with autonomous ``<think>`` already routed correctly
+        pre-r5-D via the base class's Case-3 fallback; pin it here so
+        the no-regression contract holds when we refactor."""
+        p = Glm4ReasoningParser()
+        text = "<think>Reasoning so far"
+        reasoning, content = p.extract_reasoning(text)
+        assert reasoning == "Reasoning so far"
+        assert content is None
+
+    def test_qwen3_mid_thought_with_think_opener(self):
+        p = Qwen3ReasoningParser()
+        reasoning, content = p.extract_reasoning("<think>Reasoning so far")
+        assert reasoning == "Reasoning so far"
+        assert content is None
+
+    def test_deepseek_r1_mid_thought_with_think_opener(self):
+        p = DeepSeekR1ReasoningParser()
+        reasoning, content = p.extract_reasoning("<think>Reasoning so far")
+        assert reasoning == "Reasoning so far"
+        assert content is None
+
+
+class TestExtractReasoningClosedStop:
+    """No-regression: ``finish_reason="stop"`` happy-path (think
+    properly closed with answer following) must split cleanly,
+    byte-identical pre/post."""
+
+    def test_gemma4_clean_split(self):
+        p = Gemma4ReasoningParser()
+        text = (
+            "<|channel>thought\nReasoning here<channel|>"
+            "<|channel>content\nThe answer is 42.<channel|>"
+        )
+        reasoning, content = p.extract_reasoning(text)
+        assert reasoning == "Reasoning here"
+        assert content == "The answer is 42."
+
+    def test_glm4_clean_split(self):
+        p = Glm4ReasoningParser()
+        reasoning, content = p.extract_reasoning(
+            "<think>Reasoning</think>The answer is 42."
+        )
+        assert reasoning == "Reasoning"
+        assert content == "The answer is 42."
+
+    def test_qwen3_clean_split(self):
+        p = Qwen3ReasoningParser()
+        reasoning, content = p.extract_reasoning(
+            "<think>Reasoning</think>The answer is 42."
+        )
+        assert reasoning == "Reasoning"
+        assert content == "The answer is 42."
+
+    def test_deepseek_r1_clean_split(self):
+        p = DeepSeekR1ReasoningParser()
+        reasoning, content = p.extract_reasoning(
+            "<think>Reasoning</think>The answer is 42."
+        )
+        assert reasoning == "Reasoning"
+        assert content == "The answer is 42."
+
+    def test_minimax_clean_split(self):
+        p = MiniMaxReasoningParser()
+        reasoning, content = p.extract_reasoning(
+            "<think>Reasoning</think>The answer is 42."
+        )
+        assert reasoning == "Reasoning"
+        assert content == "The answer is 42."
+
+    def test_gemma4_no_tags_pure_content(self):
+        """``finish_reason="stop"`` for a non-thinking turn: plain
+        content with no markers should pass through as content."""
+        p = Gemma4ReasoningParser()
+        reasoning, content = p.extract_reasoning("Hello, the answer is 42.")
+        assert reasoning is None
+        assert content == "Hello, the answer is 42."
+
+
+# ---------------------------------------------------------------------
+# Route-level finalize plug: ``_finalize_content_and_reasoning``
+# integration with ``finish_reason``
+# ---------------------------------------------------------------------
+
+
+class TestRouteFinalizeOnTruncation:
+    """The shared finalize-on-truncation plug in
+    ``_finalize_content_and_reasoning`` covers the gaps each parser's
+    ``extract_reasoning`` cannot detect from text alone (notably
+    glm4 autonomous mode — no ``<think>`` tag emitted)."""
+
+    def test_gemma4_length_truncation_routes_to_reasoning(self):
+        """B-7 fix: gemma4 mid-thought with ``finish_reason="length"``
+        must surface as reasoning_content, NOT content (NOT both)."""
+        raw = "<|channel>thought\nMid-thought reasoning that was cut short"
+        parser = Gemma4ReasoningParser()
+        cleaned_text, reasoning_text = _finalize_content_and_reasoning(
+            raw_text=raw,
+            cleaned_text=raw,
+            tool_calls=[],
+            reasoning_parser=parser,
+            engine_reasoning_text="",
+            finish_reason="length",
+        )
+        assert cleaned_text == "" or cleaned_text is None
+        assert reasoning_text is not None
+        assert "Mid-thought reasoning that was cut short" in reasoning_text
+        # Critical: ``content`` and ``reasoning_content`` must NOT be
+        # byte-identical (the F-DGF-V080-B-7 dup repro).
+        assert cleaned_text != reasoning_text
+
+    def test_glm4_autonomous_length_truncation_via_engine_signal(self):
+        """B-9 fix: glm4 autonomous mode (no tag) with
+        ``finish_reason="length"`` AND engine-router evidence
+        (``engine_reasoning_text`` populated, indicating the token-level
+        ``OutputRouter`` saw think tokens) must route the buffer to
+        reasoning_content."""
+        # glm4's autonomous-mode shape: model emitted plain text without
+        # a ``<think>`` opener but the engine's OutputRouter
+        # token-classified the bytes as reasoning. The route-level plug
+        # honours the engine signal and re-classifies.
+        raw = "Okay let me reason step by step about Tokyo's history"
+        parser = Glm4ReasoningParser()
+        # NOTE: the route-level plug only kicks in via the
+        # post-parser path; the engine-routed branch returns earlier.
+        # Pin the parser-only path for B-9: when parser returns
+        # ``(None, raw)`` and ``finish_reason="length"``, the route
+        # must NOT leak the buffer into content. The engine-routed
+        # case is covered by the existing F-041 plug; for the no-
+        # engine-signal case we rely on the parser's own behaviour
+        # (glm4 with ``<think>`` opener routes correctly).
+        cleaned_text, reasoning_text = _finalize_content_and_reasoning(
+            raw_text="<think>" + raw,  # raw_text DOES retain the think token
+            cleaned_text="<think>" + raw,
+            tool_calls=[],
+            reasoning_parser=parser,
+            engine_reasoning_text="",
+            finish_reason="length",
+        )
+        # Parser-side fix catches this: glm4 inherits the
+        # BaseThinkingReasoningParser Case-3 fallback (only opener,
+        # no closer) so the helper sees ``(reasoning, None)`` and
+        # the truncated-think plug fires.
+        assert reasoning_text is not None
+        assert raw in reasoning_text or "step by step about Tokyo's history" in reasoning_text
+        # ``content`` must NOT carry the raw scratchpad bytes.
+        assert raw not in (cleaned_text or "")
+
+    def test_minimax_length_truncation_routes_to_reasoning(self):
+        """Cross-parser sweep: minimax mid-think on ``finish_reason="length"``
+        must NOT leak ``<think>...`` bytes into content."""
+        raw = "<think>Reasoning mid-thought that was cut short"
+        parser = MiniMaxReasoningParser()
+        cleaned_text, reasoning_text = _finalize_content_and_reasoning(
+            raw_text=raw,
+            cleaned_text=raw,
+            tool_calls=[],
+            reasoning_parser=parser,
+            engine_reasoning_text="",
+            finish_reason="length",
+        )
+        assert reasoning_text is not None
+        assert "Reasoning mid-thought that was cut short" in reasoning_text
+        # Critical: ``<think>`` tag bytes must NOT leak into content.
+        assert "<think>" not in (cleaned_text or "")
+        # And content must NOT byte-equal reasoning_content.
+        assert cleaned_text != reasoning_text
+
+    def test_qwen3_length_truncation_routes_to_reasoning(self):
+        """Cross-parser sweep: qwen3 mid-think on ``finish_reason="length"``
+        must route to reasoning_content. Existing Case-3 fallback
+        already handled this — pin it for no-regression."""
+        raw = "<think>Reasoning mid-thought"
+        parser = Qwen3ReasoningParser()
+        cleaned_text, reasoning_text = _finalize_content_and_reasoning(
+            raw_text=raw,
+            cleaned_text=raw,
+            tool_calls=[],
+            reasoning_parser=parser,
+            engine_reasoning_text="",
+            finish_reason="length",
+        )
+        assert reasoning_text is not None
+        assert "Reasoning mid-thought" in reasoning_text
+        assert "<think>" not in (cleaned_text or "")
+
+    def test_deepseek_r1_length_truncation_routes_to_reasoning(self):
+        """Cross-parser sweep: deepseek-r1 mid-think — existing Case-3
+        fallback already handled this — pin it for no-regression."""
+        raw = "<think>Reasoning mid-thought"
+        parser = DeepSeekR1ReasoningParser()
+        cleaned_text, reasoning_text = _finalize_content_and_reasoning(
+            raw_text=raw,
+            cleaned_text=raw,
+            tool_calls=[],
+            reasoning_parser=parser,
+            engine_reasoning_text="",
+            finish_reason="length",
+        )
+        assert reasoning_text is not None
+        assert "Reasoning mid-thought" in reasoning_text
+        assert "<think>" not in (cleaned_text or "")
+
+
+class TestRouteFinishReasonStopNoRegression:
+    """``finish_reason="stop"`` (clean close) MUST split cleanly,
+    byte-identical pre/post-r5-D. This is the most important
+    regression-prevention check — desktop clients have been seeing
+    correct behaviour on the happy path and we must not disturb it."""
+
+    def test_gemma4_clean_split_finish_stop(self):
+        raw = (
+            "<|channel>thought\nReasoning here<channel|>"
+            "<|channel>content\nThe answer is 42.<channel|>"
+        )
+        parser = Gemma4ReasoningParser()
+        cleaned_text, reasoning_text = _finalize_content_and_reasoning(
+            raw_text=raw,
+            cleaned_text=raw,
+            tool_calls=[],
+            reasoning_parser=parser,
+            engine_reasoning_text="",
+            finish_reason="stop",
+        )
+        assert reasoning_text == "Reasoning here"
+        assert cleaned_text == "The answer is 42."
+
+    def test_glm4_clean_split_finish_stop(self):
+        raw = "<think>Reasoning</think>The answer is 42."
+        parser = Glm4ReasoningParser()
+        cleaned_text, reasoning_text = _finalize_content_and_reasoning(
+            raw_text=raw,
+            cleaned_text=raw,
+            tool_calls=[],
+            reasoning_parser=parser,
+            engine_reasoning_text="",
+            finish_reason="stop",
+        )
+        assert reasoning_text == "Reasoning"
+        assert cleaned_text == "The answer is 42."
+
+    def test_qwen3_clean_split_finish_stop(self):
+        raw = "<think>Reasoning</think>The answer is 42."
+        parser = Qwen3ReasoningParser()
+        cleaned_text, reasoning_text = _finalize_content_and_reasoning(
+            raw_text=raw,
+            cleaned_text=raw,
+            tool_calls=[],
+            reasoning_parser=parser,
+            engine_reasoning_text="",
+            finish_reason="stop",
+        )
+        assert reasoning_text == "Reasoning"
+        assert cleaned_text == "The answer is 42."
+
+    def test_minimax_clean_split_finish_stop(self):
+        raw = "<think>Reasoning</think>The answer is 42."
+        parser = MiniMaxReasoningParser()
+        cleaned_text, reasoning_text = _finalize_content_and_reasoning(
+            raw_text=raw,
+            cleaned_text=raw,
+            tool_calls=[],
+            reasoning_parser=parser,
+            engine_reasoning_text="",
+            finish_reason="stop",
+        )
+        assert reasoning_text == "Reasoning"
+        assert cleaned_text == "The answer is 42."
+
+
+class TestRouteFinishReasonLengthAfterClose:
+    """``finish_reason="length"`` AFTER ``</think>`` closed and content
+    started: the buffer is partial CONTENT, not reasoning. Must NOT
+    re-route the content into reasoning."""
+
+    def test_gemma4_length_after_close(self):
+        # gemma4 sees a closed thought block, content started, then
+        # got truncated. The truncated content body must STAY in
+        # ``content``, never get rerouted to reasoning.
+        raw = (
+            "<|channel>thought\nReasoning here<channel|>"
+            "<|channel>content\nPartial ans"
+        )
+        parser = Gemma4ReasoningParser()
+        cleaned_text, reasoning_text = _finalize_content_and_reasoning(
+            raw_text=raw,
+            cleaned_text=raw,
+            tool_calls=[],
+            reasoning_parser=parser,
+            engine_reasoning_text="",
+            finish_reason="length",
+        )
+        assert reasoning_text == "Reasoning here"
+        # Partial answer body in content (the unclosed content
+        # channel may have leftover marker tokens stripped).
+        assert cleaned_text is not None
+        assert "Partial ans" in cleaned_text
+
+    def test_glm4_length_after_close(self):
+        raw = "<think>Reasoning</think>Partial answer that was cut"
+        parser = Glm4ReasoningParser()
+        cleaned_text, reasoning_text = _finalize_content_and_reasoning(
+            raw_text=raw,
+            cleaned_text=raw,
+            tool_calls=[],
+            reasoning_parser=parser,
+            engine_reasoning_text="",
+            finish_reason="length",
+        )
+        assert reasoning_text == "Reasoning"
+        assert cleaned_text == "Partial answer that was cut"
+
+    def test_qwen3_length_after_close(self):
+        raw = "<think>Reasoning</think>Partial answer that was cut"
+        parser = Qwen3ReasoningParser()
+        cleaned_text, reasoning_text = _finalize_content_and_reasoning(
+            raw_text=raw,
+            cleaned_text=raw,
+            tool_calls=[],
+            reasoning_parser=parser,
+            engine_reasoning_text="",
+            finish_reason="length",
+        )
+        assert reasoning_text == "Reasoning"
+        assert cleaned_text == "Partial answer that was cut"
+
+
+class TestNoDuplicationOfBuffer:
+    """The original B-7 bug: gemma4 dup'd the same bytes into BOTH
+    fields. The post-fix contract is that ``content`` and
+    ``reasoning_content`` MUST NEVER be byte-identical when both are
+    non-empty (modulo the edge case where reasoning ends with the
+    same suffix the content starts with, which is structurally
+    distinct from a full-buffer dup)."""
+
+    @pytest.mark.parametrize(
+        "parser_cls,raw",
+        [
+            (
+                Gemma4ReasoningParser,
+                "<|channel>thought\nReasoning that was truncated mid-flight",
+            ),
+            (
+                MiniMaxReasoningParser,
+                "<think>Reasoning that was truncated mid-flight",
+            ),
+            (
+                Glm4ReasoningParser,
+                "<think>Reasoning that was truncated mid-flight",
+            ),
+            (
+                Qwen3ReasoningParser,
+                "<think>Reasoning that was truncated mid-flight",
+            ),
+            (
+                DeepSeekR1ReasoningParser,
+                "<think>Reasoning that was truncated mid-flight",
+            ),
+            (
+                VibeThinkerReasoningParser,
+                "<think>Reasoning that was truncated mid-flight",
+            ),
+        ],
+    )
+    def test_no_dup_on_length_truncation(self, parser_cls, raw):
+        parser = parser_cls()
+        cleaned_text, reasoning_text = _finalize_content_and_reasoning(
+            raw_text=raw,
+            cleaned_text=raw,
+            tool_calls=[],
+            reasoning_parser=parser,
+            engine_reasoning_text="",
+            finish_reason="length",
+        )
+        # If both are non-empty, they MUST NOT be byte-identical.
+        if cleaned_text and reasoning_text:
+            assert cleaned_text != reasoning_text, (
+                f"{parser_cls.__name__} duplicated buffer into both "
+                f"content and reasoning_content: {cleaned_text[:80]!r}"
+            )
+
+
+class TestVibeThinkerLengthTruncation:
+    """VibeThinker is a DeepSeek-R1 variant — its truncated-think
+    behaviour was already pinned by the live-test plug
+    (``first_parse_was_truncated_think``). Pin it again here under
+    the r5-D contract so the plug ordering doesn't drift."""
+
+    def test_vibethinker_mid_think(self):
+        raw = "<think>Reasoning so far"
+        parser = VibeThinkerReasoningParser()
+        cleaned_text, reasoning_text = _finalize_content_and_reasoning(
+            raw_text=raw,
+            cleaned_text=raw,
+            tool_calls=[],
+            reasoning_parser=parser,
+            engine_reasoning_text="",
+            finish_reason="length",
+        )
+        assert reasoning_text is not None
+        assert "Reasoning so far" in reasoning_text
+        assert "<think>" not in (cleaned_text or "")
+
+
+class TestEndToEndRouteContract:
+    """End-to-end mini-route harness — exercises
+    ``_finalize_content_and_reasoning`` → ``clean_output_text`` /
+    ``strip_thinking_tags`` → ``_rescue_silent_drop_from_reasoning``.
+
+    The bug repro at the route layer: even when the parser-side fix
+    produces ``reasoning_text=<thought>`` and ``cleaned_text=""``, the
+    silent-drop rescue can re-surface the reasoning bytes as
+    ``content`` and re-introduce the dup-into-both-fields shape (the
+    B-7 132/128/512-char identical-dup repro). The rescue's
+    truncated-``<think>`` gate handles the qwen3/glm4 family but
+    misses gemma4's channel format — the r5-D plug adds the gemma4
+    analog.
+
+    Contract: ``finish_reason="length"`` mid-think → ``content=None``,
+    ``reasoning_content=<thought>``, NEVER byte-identical.
+    """
+
+    def test_gemma4_end_to_end_no_dup(self):
+        raw = "<|channel>thought\nMid-thought reasoning that was cut short"
+        content, reasoning = _route_end_to_end(
+            Gemma4ReasoningParser(), raw, "length"
+        )
+        assert content is None
+        assert reasoning is not None
+        assert "Mid-thought reasoning" in reasoning
+        # The original B-7 repro shape: NEVER ship the same bytes.
+        assert content != reasoning
+
+    def test_minimax_end_to_end_no_dup(self):
+        raw = "<think>Mid-thought reasoning that was cut short"
+        content, reasoning = _route_end_to_end(
+            MiniMaxReasoningParser(), raw, "length"
+        )
+        assert content is None
+        assert reasoning is not None
+        assert "Mid-thought reasoning" in reasoning
+        assert content != reasoning
+
+    def test_glm4_end_to_end_no_dup(self):
+        raw = "<think>Mid-thought reasoning that was cut short"
+        content, reasoning = _route_end_to_end(
+            Glm4ReasoningParser(), raw, "length"
+        )
+        assert content is None
+        assert reasoning is not None
+        assert "Mid-thought reasoning" in reasoning
+        assert content != reasoning
+
+    def test_qwen3_end_to_end_no_dup(self):
+        raw = "<think>Mid-thought reasoning that was cut short"
+        content, reasoning = _route_end_to_end(
+            Qwen3ReasoningParser(), raw, "length"
+        )
+        assert content is None
+        assert reasoning is not None
+        assert "Mid-thought reasoning" in reasoning
+        assert content != reasoning
+
+    def test_deepseek_r1_end_to_end_no_dup(self):
+        raw = "<think>Mid-thought reasoning that was cut short"
+        content, reasoning = _route_end_to_end(
+            DeepSeekR1ReasoningParser(), raw, "length"
+        )
+        assert content is None
+        assert reasoning is not None
+        assert "Mid-thought reasoning" in reasoning
+        assert content != reasoning
+
+    def test_gemma4_end_to_end_clean_split_finish_stop(self):
+        """No-regression: ``finish_reason="stop"`` clean split must
+        deliver both content AND reasoning_content correctly."""
+        raw = (
+            "<|channel>thought\nReasoning here<channel|>"
+            "<|channel>content\nThe answer is 42.<channel|>"
+        )
+        content, reasoning = _route_end_to_end(
+            Gemma4ReasoningParser(), raw, "stop"
+        )
+        assert content == "The answer is 42."
+        assert reasoning == "Reasoning here"
+
+    def test_qwen3_end_to_end_clean_split_finish_stop(self):
+        raw = "<think>Reasoning</think>The answer is 42."
+        content, reasoning = _route_end_to_end(
+            Qwen3ReasoningParser(), raw, "stop"
+        )
+        assert content == "The answer is 42."
+        assert reasoning == "Reasoning"
+
+
+class TestGlm4AutonomousModeRoute:
+    """B-9 specific: glm4's chat template does NOT pre-inject
+    ``<think>``, so a model that decided not to emit the tag and got
+    truncated mid-thought leaves no tag in ``cleaned_text``. The
+    parser returns ``(None, raw)`` and the standard truncated-think
+    plug doesn't fire (no ``<think>`` in text). The route-level fix
+    leans on the engine's token-level ``OutputRouter`` evidence
+    (``engine_reasoning_text`` populated) to detect this case.
+    """
+
+    def test_glm4_autonomous_engine_signal_routes_to_reasoning(self):
+        """B-9 fix: engine token-router populated
+        ``engine_reasoning_text`` (token-classifier saw think tokens),
+        ``cleaned_text`` carries the raw scratchpad, no ``<think>``
+        tag in raw_text → route the buffer to reasoning, blank
+        cleaned_text."""
+        raw = "Okay let me reason step by step about the user question"
+        parser = Glm4ReasoningParser()
+        cleaned_text, reasoning_text = _finalize_content_and_reasoning(
+            raw_text=raw,
+            cleaned_text=raw,
+            tool_calls=[],
+            reasoning_parser=parser,
+            engine_reasoning_text=raw,  # engine routed the buffer
+            finish_reason="length",
+        )
+        assert cleaned_text == ""
+        assert reasoning_text == raw
+        # The B-9 dup repro must NOT happen.
+        assert cleaned_text != reasoning_text
+
+    def test_glm4_no_engine_signal_no_route_change(self):
+        """When the engine has no token-router evidence
+        (``engine_reasoning_text`` empty), we cannot infer
+        open-in-think from text alone for an autonomous-mode glm4
+        response. The parser conservatively returns ``(None, raw)``
+        and the route preserves cleaned_text as content — this is
+        the documented limitation of autonomous-mode without
+        out-of-band signal."""
+        raw = "Okay let me reason step by step about the user question"
+        parser = Glm4ReasoningParser()
+        cleaned_text, reasoning_text = _finalize_content_and_reasoning(
+            raw_text=raw,
+            cleaned_text=raw,
+            tool_calls=[],
+            reasoning_parser=parser,
+            engine_reasoning_text="",  # no engine signal
+            finish_reason="length",
+        )
+        # Without the engine signal, the route falls back to the
+        # conservative "treat as content" path. The parser cannot
+        # distinguish "autonomous-mode reasoning truncated" from
+        # "non-thinking response truncated" on text alone.
+        assert cleaned_text == raw
+        assert reasoning_text is None

--- a/tests/test_silent_drop_rescue_569.py
+++ b/tests/test_silent_drop_rescue_569.py
@@ -207,17 +207,22 @@ def test_rescue_noop_when_tool_calls_empty_list():
 # ── Integration: parser-level repro of the truncated thought ─────────
 
 
-def test_gemma4_parser_returns_no_reasoning_on_unterminated_thought():
-    """Pins the upstream surface: the Gemma 4 reasoning parser's
-    ``extract_reasoning`` returns ``(None, raw_text_with_marker)``
-    when the thought channel never closed. This is what feeds the
-    silent-drop path — the parser bails, the route then drops content.
+def test_gemma4_parser_returns_reasoning_on_unterminated_thought():
+    """Pins the post-r5-D contract: the Gemma 4 reasoning parser's
+    ``extract_reasoning`` returns ``(reasoning_buffer, None)`` when
+    the thought channel never closed. The shared finalize-on-
+    truncation helper (``vllm_mlx.reasoning.finalize_truncation``)
+    routes the unclosed buffer to ``reasoning_content`` instead of
+    leaking it into ``content`` (the F-DGF-V080-B-7 dup-into-both-
+    fields repro).
 
-    The parser behavior itself is correct (it can't infer where a
-    missing close marker SHOULD have been); the route-layer rescue
-    is what protects clients from the consequence. This test pins
-    the parser's behavior so future parser changes don't silently
-    bypass the rescue's reason for existing.
+    Pre-r5-D the parser fell through to the "no thinking tags —
+    all content" branch and the route then either duplicated the
+    bytes into both fields (when the engine OutputRouter also
+    populated ``engine_reasoning_text``) OR surfaced the raw
+    scratchpad as the assistant's answer. The fix is parser-side
+    so every caller benefits, not just the non-streaming chat
+    route.
     """
     p = Gemma4ReasoningParser()
     truncated = (
@@ -225,14 +230,13 @@ def test_gemma4_parser_returns_no_reasoning_on_unterminated_thought():
         "I should call get_weather with city=SF. But first let me check"
     )
     reasoning, content = p.extract_reasoning(truncated)
-    assert reasoning is None, (
-        "parser must not pretend it extracted reasoning from an "
-        f"unterminated thought; got {reasoning!r}"
+    # r5-D: the unclosed thought buffer routes to reasoning,
+    # NOT content.
+    assert reasoning is not None and "Let me think" in reasoning
+    assert content is None, (
+        "post-r5-D: gemma4 must NOT leak the unclosed thought into "
+        f"content; got {content!r}"
     )
-    # Content is the raw text (markers preserved). The route's
-    # ``clean_output_text`` + ``strip_thinking_tags`` will collapse
-    # this; the rescue handles the resulting empty content.
-    assert content is not None and "Let me think" in content
 
 
 # ── Integration: full _finalize + rescue chain on engine-routed input ──

--- a/vllm_mlx/reasoning/__init__.py
+++ b/vllm_mlx/reasoning/__init__.py
@@ -24,7 +24,7 @@ Usage:
             ...
 """
 
-from .base import DeltaMessage, ReasoningParser
+from .base import DeltaMessage, ReasoningParser, finalize_truncation
 from .think_parser import BaseThinkingReasoningParser
 
 # Parser registry
@@ -119,4 +119,6 @@ __all__ = [
     "register_parser",
     "get_parser",
     "list_parsers",
+    # r5-D shared finalize-on-truncation helper
+    "finalize_truncation",
 ]

--- a/vllm_mlx/reasoning/base.py
+++ b/vllm_mlx/reasoning/base.py
@@ -135,3 +135,70 @@ class ReasoningParser(ABC):
             DeltaMessage correction chunk, or None if no correction needed.
         """
         pass
+
+    # ------------------------------------------------------------------
+    # r5-D — finalize-on-truncation hook (shared across parser families)
+    # ------------------------------------------------------------------
+    #
+    # When the non-streaming aggregator finishes with
+    # ``finish_reason="length"`` and the parser was still mid-think (the
+    # closing sentinel — ``</think>``, ``<channel|>``, harmony
+    # ``<|end|>`` — never arrived), the default ``extract_reasoning``
+    # routing on several parsers leaked the in-progress thought into
+    # ``content`` (glm4 autonomous, minimax <think>-opener) or duplicated
+    # it across both fields (gemma4 ``<|channel>thought``). Each parser
+    # SHOULD return True from ``is_open_in_think`` when its accumulated
+    # buffer indicates a not-yet-closed reasoning state so the route's
+    # finalize layer can re-classify the buffer as ``reasoning_content``
+    # and set ``content=None``. The default implementation returns False
+    # so non-thinking parsers (ui_tars, models that never opened a think
+    # span) keep current behaviour.
+    #
+    # See ``finalize_truncation`` below for the shared router and the
+    # ``gemma4`` / ``glm4`` / ``minimax`` / ``think_parser`` overrides
+    # for the family-specific marker checks.
+    def is_open_in_think(self, accumulated_text: str) -> bool:  # noqa: B027
+        """Return True iff ``accumulated_text`` ends inside an
+        unclosed reasoning span this parser would route as reasoning.
+
+        Default: ``False`` (no-think / safe fallback). Subclasses with
+        explicit think markers (``<think>``, ``<|channel>thought``,
+        Harmony analysis) override and inspect their own tags.
+        """
+        del accumulated_text  # noqa: F841 — default is no-think
+        return False
+
+
+def finalize_truncation(
+    open_in_think: bool, buffer: str | None
+) -> tuple[str | None, str | None]:
+    """Route an unclosed reasoning buffer at ``finish_reason="length"``.
+
+    Shared finalize-on-truncation helper invoked by the non-streaming
+    aggregator (``vllm_mlx/service/helpers.py::_finalize_content_and_reasoning``)
+    when a reasoning parser's first-pass ``extract_reasoning`` would
+    otherwise emit ``(None, buffer)`` (content leak) or
+    ``(buffer, buffer)`` (duplication). Each parser exposes the
+    family-specific open-in-think check via ``is_open_in_think``; the
+    router itself is parser-agnostic.
+
+    The contract is symmetric:
+
+    * ``open_in_think=True``  → ``(reasoning_content=buffer,
+      content=None)`` — everything in the buffer was inside the
+      think tag.
+    * ``open_in_think=False`` → ``(reasoning_content=None,
+      content=buffer)`` — think already closed (or never opened);
+      the buffer is plain content.
+
+    Empty / ``None`` buffer short-circuits to ``(None, None)`` so
+    callers do not need to guard the empty case at the call site.
+
+    Returns ``(reasoning_content, final_content)``. Either may be
+    ``None``.
+    """
+    if not buffer:
+        return None, None
+    if open_in_think:
+        return buffer, None
+    return None, buffer

--- a/vllm_mlx/reasoning/gemma4_parser.py
+++ b/vllm_mlx/reasoning/gemma4_parser.py
@@ -51,6 +51,57 @@ class Gemma4ReasoningParser(ReasoningParser):
         if not model_output:
             return None, model_output
 
+        # r5-D finalize-on-truncation (F-DGF-V080-B-7): when the model
+        # is cut mid-thought by ``finish_reason="length"`` the closing
+        # ``<channel|>`` sentinel never arrives, so ``_THOUGHT_BLOCK``
+        # (which only matches CLOSED blocks) misses the in-progress
+        # buffer entirely. Pre-fix the "no thinking tags — all content"
+        # fall-through returned the raw scratchpad as ``content`` AND
+        # — when the engine's token-level OutputRouter ALSO populated
+        # ``engine_reasoning_text`` from the same bytes — the route
+        # then duplicated those bytes into ``reasoning_content`` for
+        # the desktop client (identical 132/128/512-char repro).
+        #
+        # Detect via ``is_open_in_think`` (shared finalize-on-truncation
+        # contract — see ``base.finalize_truncation``) and route the
+        # post-opener body as reasoning instead. Strip the opener
+        # marker bytes so the reasoning surface is clean.
+        if self.is_open_in_think(model_output):
+            last_open = model_output.rfind("<|channel>thought")
+            before = model_output[:last_open]
+            after = model_output[last_open + len("<|channel>thought") :]
+            # Strip the leading newline that follows the opener.
+            after = after.lstrip("\n")
+            # When ``before`` contains a prior CLOSED ``thought`` block
+            # (multi-block truncation shape), surface that as reasoning
+            # too so we don't lose the earlier reasoning round; then
+            # concatenate the trailing unclosed buffer. When ``before``
+            # is empty (the common single-block truncation shape) this
+            # collapses to ``(after, None)``. ``content`` is None on
+            # truncation — the buffer was inside the think tag at EOS,
+            # never the user-visible answer.
+            prior_reasoning: str | None = None
+            if before:
+                prior_thought_blocks = _THOUGHT_BLOCK.findall(before)
+                if prior_thought_blocks:
+                    parts = []
+                    for block in prior_thought_blocks:
+                        inner = (
+                            block.replace("<|channel>thought\n", "")
+                            .replace("<channel|>", "")
+                            .strip()
+                        )
+                        if inner:
+                            parts.append(inner)
+                    if parts:
+                        prior_reasoning = "".join(parts)
+            trailing_reasoning = after.strip() or None
+            merged_reasoning = (
+                "\n".join(p for p in (prior_reasoning, trailing_reasoning) if p)
+                or None
+            )
+            return merged_reasoning, None
+
         # Extract thought blocks as reasoning
         thought_blocks = _THOUGHT_BLOCK.findall(model_output)
         if not thought_blocks:
@@ -176,3 +227,38 @@ class Gemma4ReasoningParser(ReasoningParser):
     def finalize_streaming(self, accumulated_text: str) -> DeltaMessage | None:
         """Handle end of stream — emit any remaining content."""
         return None
+
+    def is_open_in_think(self, accumulated_text: str) -> bool:
+        """r5-D — gemma4 unclosed-thought-channel detection.
+
+        Gemma 4's channel grammar opens with ``<|channel>thought\\n``
+        and closes the channel with ``<channel|>``. When
+        ``finish_reason="length"`` truncates before the closer arrives
+        (max_tokens cut mid-thought), the non-streaming first-pass
+        ``extract_reasoning`` runs ``_THOUGHT_BLOCK.findall`` which
+        only matches CLOSED thought blocks, finds nothing, and falls
+        through to the "all content" branch — leaking the raw
+        scratchpad bytes into ``content`` and (when the engine's
+        token-level OutputRouter has ALSO populated
+        ``engine_reasoning_text``) duplicating the same bytes into
+        both ``content`` and ``reasoning_content`` for the desktop
+        client (the F-DGF-V080-B-7 132/128/512-char identical-dup
+        repro).
+
+        Open-in-think signal:
+
+        * Saw an opener (``<|channel>thought``) AND
+        * No closer (``<channel|>``) appears AFTER the latest opener.
+
+        Multi-block resilience: ``rfind`` on the opener and ``find``
+        past that position handles both single-block and multi-block
+        truncation shapes (closed thought → content channel → second
+        thought opener with no closer still reads open-in-think).
+        """
+        if not accumulated_text:
+            return False
+        last_open = accumulated_text.rfind("<|channel>thought")
+        if last_open < 0:
+            return False
+        # Any close marker AFTER the latest opener?
+        return "<channel|>" not in accumulated_text[last_open:]

--- a/vllm_mlx/reasoning/gemma4_parser.py
+++ b/vllm_mlx/reasoning/gemma4_parser.py
@@ -97,8 +97,7 @@ class Gemma4ReasoningParser(ReasoningParser):
                         prior_reasoning = "".join(parts)
             trailing_reasoning = after.strip() or None
             merged_reasoning = (
-                "\n".join(p for p in (prior_reasoning, trailing_reasoning) if p)
-                or None
+                "\n".join(p for p in (prior_reasoning, trailing_reasoning) if p) or None
             )
             return merged_reasoning, None
 
@@ -257,8 +256,37 @@ class Gemma4ReasoningParser(ReasoningParser):
         """
         if not accumulated_text:
             return False
+        # Codex r1 BLOCKING on PR #825: the pre-fix ``rfind`` gate
+        # mis-fired on a legitimate answer that mentions the literal
+        # ``<|channel>thought`` substring inside an already-opened
+        # content/final channel — ``rfind`` lands on the literal
+        # substring inside the answer, the tail is short, and the
+        # closer-not-found check spuriously returns True. The
+        # extracted ``cleaned_text`` path also tripped the gate
+        # because the upstream content opener had already been
+        # stripped by ``extract_reasoning`` before the route probed
+        # the buffer.
+        #
+        # Systematic fix — three conservative guards:
+        # 1. Buffer must START (modulo whitespace) with
+        #    ``<|channel>thought``. This is the only shape where the
+        #    EOS-was-mid-think interpretation is unambiguous,
+        #    matching the minimax ``lstrip().startswith("<think>")``
+        #    guard and the ``_sweep_residual_think_tags`` scope from
+        #    PR #722 codex r3.
+        # 2. No ``<|channel>content`` / ``<|channel>final`` opener
+        #    appears — once content opens, any further
+        #    ``<|channel>thought`` bytes are literal answer text in
+        #    Gemma 4's single-round grammar.
+        # 3. No ``<channel|>`` close after the (only) opener.
+        if not accumulated_text.lstrip().startswith("<|channel>thought"):
+            return False
+        if (
+            "<|channel>content" in accumulated_text
+            or "<|channel>final" in accumulated_text
+        ):
+            return False
         last_open = accumulated_text.rfind("<|channel>thought")
         if last_open < 0:
             return False
-        # Any close marker AFTER the latest opener?
         return "<channel|>" not in accumulated_text[last_open:]

--- a/vllm_mlx/reasoning/minimax_parser.py
+++ b/vllm_mlx/reasoning/minimax_parser.py
@@ -143,6 +143,20 @@ class MiniMaxReasoningParser(ReasoningParser):
                 reasoning = parts[0].replace("<think>", "").strip()
                 content = parts[1].strip() if len(parts) > 1 else None
                 return reasoning or None, content or None
+            # r5-D finalize-on-truncation: ``<think>`` opener but no
+            # closer — model was cut mid-thought by
+            # ``finish_reason="length"``. Pre-fix, the buffer fell
+            # through to the heuristic checks below which neither
+            # matched ``_DIRECT_CONTENT_RE`` (no code-fence/JSON
+            # opener) nor ``_REASONING_START_RE`` (the literal
+            # ``<think>`` is not in the bare-text alternation), so
+            # the parser returned ``(None, model_output)`` — leaking
+            # the scratchpad (with the ``<think>`` tag bytes) into
+            # ``content``. Strip the opener and route to reasoning.
+            if "<think>" in model_output:
+                _, _, after = model_output.partition("<think>")
+                reasoning = after.strip() or None
+                return reasoning, None
 
         # Check for direct content (no reasoning)
         if self._DIRECT_CONTENT_RE.match(model_output):
@@ -277,6 +291,30 @@ class MiniMaxReasoningParser(ReasoningParser):
         self._transition_pos = max(0, len(self._buffer) - 20)
         # Flush entire buffer as reasoning
         return DeltaMessage(reasoning=current_text)
+
+    def is_open_in_think(self, accumulated_text: str) -> bool:
+        """r5-D — minimax unclosed-``<think>`` detection.
+
+        MiniMax sometimes emits an explicit ``<think>…</think>`` block
+        (see the explicit-handling branch in ``extract_reasoning``).
+        When ``finish_reason="length"`` truncates before the closer
+        arrives, the non-streaming first-pass routes everything to
+        ``content`` because the heuristic ``_REASONING_START_RE``
+        does not match a literal ``<think>``-leading buffer and the
+        ``_DIRECT_CONTENT_RE`` does not list it either — leaking the
+        scratchpad bytes verbatim (including the tag bytes) into
+        ``content``.
+
+        Open-in-think signal: an explicit opener with no matching
+        closer. The MiniMax heuristic preamble shape (no tag, just
+        "The user asks…") is intentionally NOT routed here — the
+        parser's normal heuristic split owns that case and the route
+        cannot distinguish a chatty answer-opener from a thought
+        preamble without the explicit tag.
+        """
+        if not accumulated_text:
+            return False
+        return "<think>" in accumulated_text and "</think>" not in accumulated_text
 
     def finalize_streaming(self, accumulated_text: str) -> DeltaMessage | None:
         """

--- a/vllm_mlx/reasoning/minimax_parser.py
+++ b/vllm_mlx/reasoning/minimax_parser.py
@@ -153,7 +153,15 @@ class MiniMaxReasoningParser(ReasoningParser):
             # the parser returned ``(None, model_output)`` — leaking
             # the scratchpad (with the ``<think>`` tag bytes) into
             # ``content``. Strip the opener and route to reasoning.
-            if "<think>" in model_output:
+            #
+            # Codex r1 BLOCKING on PR #825: bare ``"<think>" in``
+            # mis-fires on legitimate answers that mention the
+            # literal substring (e.g. "The model uses <think> tags
+            # for reasoning"). Gate to the true mid-think shape —
+            # the buffer must START (modulo whitespace) with the
+            # opener — matching the conservative scope of
+            # ``_sweep_residual_think_tags`` from PR #722 codex r3.
+            if model_output.lstrip().startswith("<think>"):
                 _, _, after = model_output.partition("<think>")
                 reasoning = after.strip() or None
                 return reasoning, None
@@ -314,7 +322,16 @@ class MiniMaxReasoningParser(ReasoningParser):
         """
         if not accumulated_text:
             return False
-        return "<think>" in accumulated_text and "</think>" not in accumulated_text
+        # Codex r1 BLOCKING on PR #825: bare ``"<think>" in`` mis-fires
+        # on legitimate answers that mention the literal substring
+        # (e.g. "The model uses <think> tags for reasoning"). Gate
+        # to the true mid-think shape — the buffer must START (modulo
+        # whitespace) with the opener — matching the same conservative
+        # guard now in ``extract_reasoning`` and the
+        # ``_sweep_residual_think_tags`` scope from PR #722 codex r3.
+        if not accumulated_text.lstrip().startswith("<think>"):
+            return False
+        return "</think>" not in accumulated_text
 
     def finalize_streaming(self, accumulated_text: str) -> DeltaMessage | None:
         """

--- a/vllm_mlx/reasoning/think_parser.py
+++ b/vllm_mlx/reasoning/think_parser.py
@@ -72,6 +72,36 @@ class BaseThinkingReasoningParser(ReasoningParser):
         self._held_tag_suffix_len = 0
         self._streaming_phase = None
 
+    def is_open_in_think(self, accumulated_text: str) -> bool:
+        """Return True iff the accumulated text shows an opened but
+        not-yet-closed ``<think>``-style block (the truncation-mid-think
+        shape).
+
+        r5-D shared finalize-on-truncation contract: the route invokes
+        this on ``finish_reason="length"`` to decide whether the
+        unclosed buffer should be routed to ``reasoning_content``
+        (open-in-think) or kept as ``content`` (think already closed
+        OR never opened). The classic shape is
+        ``<think>…``-without-``</think>`` — either the model emitted
+        the start token autonomously (``<think>`` at the head) OR the
+        chat template pre-injected it and we are observing an implicit
+        unclosed thought.
+
+        Note: explicit-start callers — qwen3 / deepseek-r1 / glm4 /
+        vibethinker — share this implementation. Subclasses that only
+        need a different policy for the no-tag autonomous-think shape
+        (Qwen3 ``enable_thinking=True`` Case-4) can override and
+        consult their own out-of-band signal.
+        """
+        if not accumulated_text:
+            return False
+        if self.start_token in accumulated_text and (
+            self.end_token not in accumulated_text
+        ):
+            # Classic mid-think: opener arrived but closer never did.
+            return True
+        return False
+
     def extract_reasoning(
         self,
         model_output: str,

--- a/vllm_mlx/routes/anthropic.py
+++ b/vllm_mlx/routes/anthropic.py
@@ -964,6 +964,10 @@ async def create_anthropic_message(
             # the OpenAI-side request, so it propagates uniformly across
             # all three API surfaces.
             reasoning_max_tokens=getattr(openai_request, "reasoning_max_tokens", None),
+            # r5-D shared finalize-on-truncation plug — see chat.py
+            # for the rationale. Forwarded so the Anthropic surface
+            # gets the same gemma4 / glm4 / minimax fixes.
+            finish_reason=getattr(output, "finish_reason", None),
         )
 
         final_content = None

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -2027,6 +2027,12 @@ async def _create_chat_completion_impl(
         # Per-request reasoning cap (upstream vLLM PR #20859 backport).
         # None → back-compat no-op.
         reasoning_max_tokens=getattr(request, "reasoning_max_tokens", None),
+        # r5-D — finalize-on-truncation shared plug needs to know if
+        # generation was cut short so it can re-classify an unclosed
+        # think buffer as ``reasoning_content`` instead of leaking it
+        # into ``content``. ``None`` keeps the pre-r5-D behaviour on
+        # any caller that hasn't been threaded yet.
+        finish_reason=getattr(output, "finish_reason", None),
     )
 
     # Process response_format if specified (after reasoning parser cleaned the text)

--- a/vllm_mlx/routes/responses.py
+++ b/vllm_mlx/routes/responses.py
@@ -802,6 +802,10 @@ async def _non_stream(
         # Forwarded from ``ResponsesRequest.reasoning_max_tokens`` via
         # the Responses → OpenAI adapter. None → no cap (back-compat).
         reasoning_max_tokens=getattr(openai_request, "reasoning_max_tokens", None),
+        # r5-D shared finalize-on-truncation plug — see chat.py for
+        # the rationale. Forwarded so the /v1/responses path picks up
+        # the same gemma4 / glm4 / minimax fixes.
+        finish_reason=getattr(output, "finish_reason", None),
     )
 
     final_content = None

--- a/vllm_mlx/service/helpers.py
+++ b/vllm_mlx/service/helpers.py
@@ -163,6 +163,7 @@ def _finalize_content_and_reasoning(
     engine_reasoning_text: str = "",
     enable_thinking: bool | None = None,
     reasoning_max_tokens: int | None = None,
+    finish_reason: str | None = None,
 ) -> tuple[str, str | None]:
     """Compute final ``content`` + ``reasoning_text`` after tool parsing.
 
@@ -273,6 +274,47 @@ def _finalize_content_and_reasoning(
             return cleaned_text or "", _truncate_reasoning_only(
                 engine_reasoning_text, reasoning_max_tokens
             )
+        # r5-D autonomous-mode plug (F-DGF-V080-B-9, 2026-06-21):
+        # ``engine_reasoning_text`` populated + ``finish_reason="length"``
+        # + parser sees the buffer as ``is_open_in_think`` OR the parser
+        # decided the buffer is autonomous-think (no tag in
+        # ``cleaned_text`` but engine token-router classified the bytes
+        # as reasoning) → route ``cleaned_text`` to nothing; the engine
+        # reasoning is already in ``engine_reasoning_text``. Pre-fix
+        # the cleaned_text was passed through verbatim and the same
+        # bytes shipped as BOTH ``content`` and ``reasoning_content``
+        # (the B-9 leak repro for glm4 autonomous mode).
+        #
+        # Gate carefully so we don't blank legitimate post-think
+        # answers: when the engine routes reasoning AND ``cleaned_text``
+        # still carries reasoning-shaped bytes (parser indicates
+        # ``is_open_in_think`` OR engine reasoning literally appears
+        # as a prefix of cleaned_text), it's the autonomous-mode
+        # leak.
+        if (
+            finish_reason == "length"
+            and cleaned_text
+            and cleaned_text.strip()
+            and reasoning_parser is not None
+        ):
+            is_open_in_think_attr = getattr(
+                reasoning_parser, "is_open_in_think", None
+            )
+            parser_open = False
+            if callable(is_open_in_think_attr):
+                try:
+                    parser_open = bool(is_open_in_think_attr(cleaned_text))
+                except Exception:
+                    parser_open = False
+            engine_prefix_match = bool(
+                engine_reasoning_text
+                and isinstance(engine_reasoning_text, str)
+                and cleaned_text.strip() == engine_reasoning_text.strip()
+            )
+            if parser_open or engine_prefix_match:
+                return "", _truncate_reasoning_only(
+                    engine_reasoning_text, reasoning_max_tokens
+                )
         return _apply_reasoning_cap(
             cleaned_text,
             engine_reasoning_text,
@@ -402,6 +444,105 @@ def _finalize_content_and_reasoning(
         # route.)
         if new_cleaned is not None:
             cleaned_text = new_cleaned
+        # r5-D shared finalize-on-truncation plug (F-DGF-V080-B-7 /
+        # F-DGF-V080-B-9, 2026-06-21). When the model was cut by
+        # ``finish_reason="length"`` AND the parser's first pass
+        # routed the buffer as ``(None, buffer)`` (the leak shape)
+        # AND the parser's family-specific ``is_open_in_think`` says
+        # the buffer ended inside an unclosed reasoning span, route
+        # the buffer to ``reasoning_content`` via the shared
+        # ``finalize_truncation`` helper. This catches the
+        # parser-side gaps the per-parser plugs above (#575 /
+        # truncated-``<think>``) miss because their gates differ:
+        #
+        # * gemma4 (B-7): channel-token format. Pre-fix
+        #   ``extract_reasoning`` fell through to "no thinking tags
+        #   — all content" and the route's downstream rescue
+        #   duplicated the same bytes into both fields (the
+        #   132/128/512-char identical-dup repro). gemma4's own
+        #   ``extract_reasoning`` now routes correctly on the
+        #   parser-side (see ``gemma4_parser.py``); this branch is
+        #   the route-side safety net.
+        # * glm4 autonomous mode (B-9): glm4's chat template does
+        #   NOT pre-inject ``<think>``, so a model that decided not
+        #   to emit the tag and got truncated mid-thought leaves no
+        #   tag in ``cleaned_text``. The parser returns ``(None,
+        #   buffer)`` and ``first_parse_was_truncated_think``
+        #   (which requires ``<think>`` in text_to_parse) does NOT
+        #   fire. The engine's token-level ``OutputRouter`` may
+        #   have populated ``engine_reasoning_text`` from the
+        #   structural think tokens though — that's the
+        #   out-of-band signal we use here.
+        # * minimax (cross-sweep): same explicit-``<think>``-opener
+        #   gap as gemma4; the parser-side fix handles the common
+        #   case and this branch is the safety net.
+        #
+        # The plug is gated to fire ONLY on ``finish_reason ==
+        # "length"`` so happy-path ``finish_reason="stop"`` flows
+        # are byte-identical pre/post. The
+        # ``first_parse_was_truncated_think`` plug below still
+        # owns its explicit-``<think>``-in-cleaned-text case.
+        if (
+            finish_reason == "length"
+            and cleaned_text
+            and not first_parse_was_truncated_think
+        ):
+            is_open_in_think = getattr(
+                reasoning_parser, "is_open_in_think", None
+            )
+            open_in_think = False
+            if callable(is_open_in_think):
+                try:
+                    # Probe the FRESH cleaned_text. When the parser
+                    # returned ``(reasoning, None)`` (e.g. gemma4 mid-
+                    # thought, fixed parser-side), ``cleaned_text`` is
+                    # still the raw text including the unclosed
+                    # opener — exactly the buffer ``is_open_in_think``
+                    # is designed to inspect. When the parser returned
+                    # ``(None, raw)`` (glm4 autonomous mode), the
+                    # ``cleaned_text`` is also the raw buffer (the
+                    # ``new_cleaned`` assignment above doesn't
+                    # alter it).
+                    open_in_think = bool(is_open_in_think(cleaned_text))
+                except Exception:
+                    # Third-party parser threw on the probe — fall
+                    # back to "not open-in-think" so we don't
+                    # introduce a regression vs. the old leak shape
+                    # (which clients are at least used to seeing).
+                    open_in_think = False
+            # Out-of-band engine-router evidence: a populated
+            # ``engine_reasoning_text`` here is impossible because
+            # the engine-routed branch returned early at the top of
+            # the function — but we DEFENSIVELY honour the signal
+            # so future re-orderings of this function don't silently
+            # regress the glm4 autonomous-mode rescue.
+            if not open_in_think and engine_reasoning_text:
+                open_in_think = True
+            if open_in_think:
+                from ..reasoning import finalize_truncation
+
+                # When the parser already extracted reasoning (e.g.
+                # gemma4 mid-thought parser-side fix), it stripped the
+                # marker bytes and placed the clean buffer in
+                # ``reasoning_text``. Prefer that over rerouting the
+                # raw ``cleaned_text`` (which still has the marker
+                # bytes). Only when ``reasoning_text`` is empty do we
+                # fall back to rerouting the raw buffer through the
+                # helper.
+                if reasoning_text:
+                    cleaned_text = ""
+                else:
+                    routed_reasoning, routed_content = finalize_truncation(
+                        True, cleaned_text
+                    )
+                    cleaned_text = routed_content or ""
+                    reasoning_text = routed_reasoning or reasoning_text
+                # Drop overflow rather than re-leak into content —
+                # see ``_truncate_reasoning_only`` for the rationale
+                # mirroring the explicit truncated-think plug.
+                return cleaned_text, _truncate_reasoning_only(
+                    reasoning_text, reasoning_max_tokens
+                )
         # #575 leak-plug: when ``enable_thinking=True`` AND the
         # parser's FIRST parse routed the whole no-tag output to
         # reasoning (Case-4 fallback path), the original
@@ -704,6 +845,24 @@ def _rescue_silent_drop_from_reasoning(
     ):
         return final_content
     if finish_reason == "length" and reasoning_is_case4:
+        return final_content
+    # r5-D (F-DGF-V080-B-7, 2026-06-21): gemma4 channel-token analog
+    # of the truncated-``<think>`` gate above. When generation is cut
+    # mid-thought-channel (``<|channel>thought\n…``-without-
+    # ``<channel|>``), the reasoning trace is NOT the final answer —
+    # surfacing it as ``content`` per the #569 rescue would feed the
+    # desktop client the SAME bytes as ``reasoning_content`` (the
+    # 132/128/512-char identical-dup repro that this PR closes).
+    # Skip the rescue and let the client see ``content=null`` so it
+    # can detect "model ran out of budget mid-thought" via
+    # ``finish_reason="length"`` — symmetric with the
+    # truncated-``<think>`` and D-HARMONY-LEAK gates.
+    if (
+        finish_reason == "length"
+        and raw_text
+        and "<|channel>thought" in raw_text
+        and "<channel|>" not in raw_text[raw_text.rfind("<|channel>thought") :]
+    ):
         return final_content
     # D-HARMONY-LEAK (2026-06-21): harmony-channel analog of the
     # truncated-``<think>`` gate above. The gpt-oss family (and any

--- a/vllm_mlx/service/helpers.py
+++ b/vllm_mlx/service/helpers.py
@@ -297,9 +297,7 @@ def _finalize_content_and_reasoning(
             and cleaned_text.strip()
             and reasoning_parser is not None
         ):
-            is_open_in_think_attr = getattr(
-                reasoning_parser, "is_open_in_think", None
-            )
+            is_open_in_think_attr = getattr(reasoning_parser, "is_open_in_think", None)
             parser_open = False
             if callable(is_open_in_think_attr):
                 try:
@@ -487,9 +485,7 @@ def _finalize_content_and_reasoning(
             and cleaned_text
             and not first_parse_was_truncated_think
         ):
-            is_open_in_think = getattr(
-                reasoning_parser, "is_open_in_think", None
-            )
+            is_open_in_think = getattr(reasoning_parser, "is_open_in_think", None)
             open_in_think = False
             if callable(is_open_in_think):
                 try:


### PR DESCRIPTION
## Why

When ``finish_reason=\"length\"`` truncates a reasoning model mid-think (the closing ``</think>`` / ``<channel|>`` sentinel never arrives), the **non-streaming aggregator's finalize-on-truncation path** has misclassified the unclosed buffer on multiple parsers — desktop client surfaces the model's raw internal scratchpad as the assistant's answer.

Cycle DGF-v080 agent-B confirmed:

* **F-DGF-V080-B-7 — gemma4 (P1)**: duplicates the unclosed thinking buffer into BOTH ``content`` AND ``reasoning_content`` (3 prompts verified at 132 / 128 / 512-char identical-dup) on ``finish_reason=length``. ``finish_reason=stop`` splits cleanly — bug is **only** on length-truncation.
* **F-DGF-V080-B-9 — glm4 (P1)**: dumps the unclosed thinking buffer into ``content`` with ``reasoning_content=null``. Different failure mode from gemma4 — glm4 puts everything in the wrong field.

## What changed

**Shared finalize helper** (``vllm_mlx/reasoning/base.py::finalize_truncation``) routes the truncated buffer based on whether the parser observed a think-close sentinel before EOS:

- ``open_in_think=True`` → ``reasoning_content=buffer, content=None``
- ``open_in_think=False`` → ``content=buffer, reasoning_content=None``

Each parser exposes ``is_open_in_think(text)`` (family-specific marker check; default ``False`` for non-think parsers). The non-streaming aggregator ``_finalize_content_and_reasoning`` invokes the helper when ``finish_reason=\"length\"`` is reported and the parser's first pass returned the leak shape. Threaded through the chat / responses / anthropic routes so every non-streaming surface gets the fix.

**Parser-side fixes** (defense in depth — every caller, not just the route):

- ``gemma4``: ``extract_reasoning`` detects unclosed ``<|channel>thought`` via ``is_open_in_think`` and routes the post-opener body as reasoning. Multi-block resilient (prior closed thought + trailing unclosed opener handled).
- ``minimax``: explicit-``<think>``-opener-without-closer case now strips the tag and routes the body to reasoning.
- ``BaseThinkingReasoningParser``: shared ``is_open_in_think`` for qwen3 / deepseek-r1 / glm4 / vibethinker (already routed correctly via existing Case-3 path; the new hook unifies the open-in-think contract for the helper).

**Route-side fixes**:

- ``_finalize_content_and_reasoning`` calls the shared helper when parser + ``finish_reason`` indicate the leak shape; covers gaps the per-parser plugs (#575 Case-4, ``first_parse_was_truncated_think``) miss.
- **glm4 autonomous-mode rescue**: when the engine's token-level ``OutputRouter`` populated ``engine_reasoning_text`` (saw think tokens) but the chat template did NOT inject ``<think>`` (autonomous model decision), the route blanks ``cleaned_text`` and surfaces the trace as ``reasoning_content`` instead of letting the same bytes ship in both fields.
- ``_rescue_silent_drop_from_reasoning``: new gemma4 channel-token analog of the truncated-``<think>`` gate so the rescue doesn't re-surface the reasoning bytes as ``content`` (the original B-7 dup repro).

**Cross-parser sweep** verified gemma4 / qwen3 / deepseek-r1 / vibethinker / minimax / glm4(explicit-think) / glm4(autonomous via engine signal). Harmony / gpt_oss already handled via existing D-HARMONY-LEAK and Case-3 fallbacks.

## No-regression contract

``finish_reason=\"stop\"`` happy-path (closed think + answer split) is byte-identical pre/post — pinned by 16 contract tests in ``test_reasoning_parser_truncation_finalize.py`` (``TestExtractReasoningClosedStop``, ``TestRouteFinishReasonStopNoRegression``, ``TestEndToEndRouteContract::test_*_clean_split_finish_stop``, ``TestRouteFinishReasonLengthAfterClose``).

## Test plan

- [x] ``pytest tests/test_reasoning_parser_truncation_finalize.py`` — 55 tests, all green
- [x] ``pytest tests/test_reasoning_parsers.py tests/test_reasoning_parser.py tests/test_silent_drop_rescue_569.py tests/test_minimax_reasoning_parser.py tests/test_finalize_harmony_raw_text.py tests/test_truncation_no_synthetic_text.py tests/test_per_request_thinking_budget.py tests/test_reasoning_content_null_rescue.py tests/test_anthropic_stream_reasoning.py tests/test_streaming_reasoning_with_structured_output.py tests/test_chat_route_tool_tag_leak.py tests/test_streaming_think_router.py tests/test_harmony_finalize.py tests/test_paired_compat.py tests/test_postprocessor.py tests/test_anthropic_streaming_reasoning.py tests/test_stream_forced_tool_reasoning.py`` — 943 tests, all green
- [x] Broad reasoning + harmony + anthropic test surface (``pytest -k \"reasoning or truncat or finalize or rescue or gemma4 or glm4 or qwen3 or minimax or thinking or harmony or anthropic\"``) — 2131 tests pass, 1 pre-existing unrelated failure (``test_anthropic_tool_usage_d.py::test_nonstream_tool_choice_named_still_routes_to_specific_tool``, confirmed failing on ``origin/main`` baseline)
- [x] Updated ``tests/test_silent_drop_rescue_569.py::test_gemma4_parser_returns_no_reasoning_on_unterminated_thought`` to ``test_gemma4_parser_returns_reasoning_on_unterminated_thought`` — pinned the new (correct) contract; old test pinned the buggy behaviour the rescue was working around

🤖 Generated with [Claude Code](https://claude.com/claude-code)