### PR TITLE
chore: bump version to 0.8.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.8.6"
+version = "0.8.7"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## Why

Cuts 0.8.7 covering the **r5 fix wave** that landed since 0.8.6:

- **r5-A (#826)** — Anthropic `/v1/messages` streaming bundle: C-08 phantom-text-on-thinking-truncation suppressed via byte-faithful duplicate detection; R-06 `stop_reason` now mapped from real `finish_reason` (`length`→`max_tokens`); R-07 synthetic empty `content_block` pair when `/no_think + max_tokens` exhausts budget; R-08 progressive `input_json_delta` per-key fragments for Computer-Use.
- **r5-B (#823)** — UI-TARS architectural fix: Computer-Use system prompt now **tool-coupled** (only injects when the request declares a Computer-Use tool), not lane-coupled. Resolves C-09 (chat-lane phantom clicks on plain prompts), C-10 (`/v1/responses` `computer_call` emission), C-11 (cross-lane intent parity), R-09 (pinned `tool_choice` 422).
- **r5-C (#822)** — `/v1/completions` legacy lane now sanitizes `prompt_preview` like the chat lane (R-05 secret-in-INFO-logs); `mlx-vlm` boot-time guard fires before model download with actionable install hint (R-10 first-time UI-TARS install crash).
- **r5-D (#825)** — Reasoning parser truncation finalize: gemma4 + glm4 + cross-parser sweep no longer dup or misclassify unclosed thinking buffer on `finish_reason="length"` (per-parser P1 deception class). Includes remediation round closing 2 codex BLOCKINGs around literal-substring content preservation.
- **r5-E (#824)** — Validation tightening + gemma4 tool-call recovery: `top_k` upper-bound, `seed ≥ 0`, `stream_options.include_usage` strict bool, plus prose-fallback `tool_calls` recovery for gemma4.

Standalone bump per release SOP so `auto-release.yml` fires on the exact subject `chore: bump version to 0.8.7`.

## Test plan

- [x] All 5 fix waves landed and merged to `main` with their own CI green
- [x] Subject line matches `auto-release.yml` trigger regex

🤖 Generated with [Claude Code](https://claude.com/claude-code)