### PR TITLE
fix(ui-tars): r6-B — streaming parser hold-back + reasoning gate + Anthropic input key

### DIFF
--- a/tests/test_ui_tars_fixes.py
+++ b/tests/test_ui_tars_fixes.py
@@ -913,20 +913,25 @@ class TestLaneInjectionParity:
 
 
 # ---------------------------------------------------------------------------
-# Anthropic adapter: tool_use.input carries the spec'd ``point`` shape
+# Anthropic adapter: tool_use.input carries the spec ``coordinate`` shape (R6-M2)
 # ---------------------------------------------------------------------------
 
 
 class TestAnthropicAdapterPointShape:
-    """The Anthropic adapter ``openai_to_anthropic`` just ``json.loads``
+    """The Anthropic adapter ``openai_to_anthropic`` ``json.loads``
     the OAI tool_call arguments and stuffs them into ``tool_use.input``.
-    With our parser-level rename, the Anthropic ``tool_use.input``
-    naturally carries ``point`` / ``start_point`` / ``end_point``
-    instead of ``start_box`` / ``end_box`` — closing dogfood F-R1-02
-    for the Anthropic lane.
+
+    Pre-r6-B: parser-level rename collapsed ``start_box`` → ``point``
+    on the UI-TARS canonical key set; the Anthropic lane then carried
+    ``point`` verbatim — but Anthropic's Computer-Use spec actually
+    requires ``coordinate``. R6-M2 (Aki R1) fix: the Anthropic adapter
+    now translates UI-TARS canonical ``point`` to spec ``coordinate``
+    on the ``/v1/messages`` boundary, gated on ``name=="computer"``
+    so vanilla function tools whose arguments happen to carry a
+    ``point`` key are untouched.
     """
 
-    def test_click_tool_use_input_uses_point_not_start_box(self):
+    def test_click_tool_use_input_uses_coordinate_not_point_or_start_box(self):
         from vllm_mlx.api.anthropic_adapter import openai_to_anthropic
         from vllm_mlx.api.models import (
             AssistantMessage,
@@ -964,9 +969,12 @@ class TestAnthropicAdapterPointShape:
         tool_use_blocks = [b for b in anth.content if b.type == "tool_use"]
         assert len(tool_use_blocks) == 1
         assert tool_use_blocks[0].name == "computer"
-        # Anthropic ``tool_use.input`` carries the spec key.
+        # R6-M2: Anthropic ``tool_use.input`` carries the spec ``coordinate``
+        # key, not the UI-TARS-native ``point`` (and certainly not the
+        # UI-TARS-1.5 ``start_box``).
         assert tool_use_blocks[0].input == {
             "action": "click",
-            "point": [128, 128],
+            "coordinate": [128, 128],
         }
+        assert "point" not in tool_use_blocks[0].input
         assert "start_box" not in tool_use_blocks[0].input

--- a/tests/test_ui_tars_lane_parity.py
+++ b/tests/test_ui_tars_lane_parity.py
@@ -650,15 +650,21 @@ class TestR6M2CoordinateKeyTranslation:
     ``start_point`` / ``end_point`` keys (PR #812 contract; chat
     completions OpenAI lane stays bytes-faithful to that). The
     Anthropic ``/v1/messages`` lane and the OpenAI ``/v1/responses``
-    lane both follow specs that require ``coordinate`` (and
-    ``start_coordinate`` / ``end_coordinate`` for two-point verbs).
+    lane both follow Computer-Use specs that use ``coordinate`` for
+    single-point verbs.
+
+    Two-point ``drag`` diverges between the specs:
+    - Anthropic uses ``start_coordinate`` + ``coordinate`` (end).
+    - OpenAI Responses uses ``path=[{"x":x,"y":y}, ...]``.
 
     Pre-r6-B: both adapters surfaced the UI-TARS-native ``point`` key
     verbatim. Anthropic-strict consumers (claude-agent-sdk, Computer-
-    Use harnesses) rejected the shape. Fixed by a centralized
-    ``translate_to_spec_coordinate_keys`` helper that lives next to
-    the parser and is called from both adapters' tool_use / computer_call
-    builders so the two surfaces can't drift on key naming.
+    Use harnesses) rejected the shape. Fixed by per-lane translator
+    helpers (``translate_to_anthropic_spec_keys`` /
+    ``translate_to_responses_spec_keys``) that live next to the parser
+    and are called from each adapter's tool_use / computer_call builder
+    so the two surfaces can't drift on key naming AND so each lane
+    matches its own spec for drag.
     """
 
     def _click_chat_response(self, args_payload: dict):
@@ -711,7 +717,9 @@ class TestR6M2CoordinateKeyTranslation:
         assert tu.input == {"action": "click", "coordinate": [500, 300]}
         assert "point" not in tu.input
 
-    def test_anthropic_drag_emits_start_end_coordinate(self):
+    def test_anthropic_drag_emits_start_coordinate_and_coordinate(self):
+        # Anthropic Computer-Use spec: drag uses ``start_coordinate``
+        # plus ``coordinate`` (the END point). NOT ``end_coordinate``.
         from vllm_mlx.api.anthropic_adapter import openai_to_anthropic
 
         chat_resp = self._click_chat_response(
@@ -724,12 +732,16 @@ class TestR6M2CoordinateKeyTranslation:
         anth = openai_to_anthropic(chat_resp, model="ui-tars-1.5-7b-4bit")
         tool_uses = [b for b in anth.content if getattr(b, "type", None) == "tool_use"]
         assert len(tool_uses) == 1
-        # Two-point verb → start_coordinate / end_coordinate.
+        # Spec: ``start_coordinate`` + ``coordinate`` (the END).
         assert tool_uses[0].input == {
             "action": "drag",
             "start_coordinate": [10, 20],
-            "end_coordinate": [100, 200],
+            "coordinate": [100, 200],
         }
+        # Defensive: no ``end_coordinate`` key (that would be the wrong
+        # name per the spec).
+        assert "end_coordinate" not in tool_uses[0].input
+        assert "point" not in tool_uses[0].input
 
     def test_anthropic_non_computer_tool_input_untouched(self):
         # Vanilla function tool whose arguments happen to carry a
@@ -826,29 +838,121 @@ class TestR6M2CoordinateKeyTranslation:
         assert args == {"action": "click", "point": [500, 300]}
         assert "coordinate" not in args
 
+    # --- Responses drag (codex r1 HIGH 2) --------------------------------
+
+    def test_responses_drag_emits_path_array(self):
+        # OpenAI Responses Computer-Use spec: drag uses
+        # ``path=[{"x":x1,"y":y1}, {"x":x2,"y":y2}]``, NOT the
+        # ``start_coordinate`` / ``end_coordinate`` shape Anthropic
+        # uses. Codex r1 HIGH 2 flagged that an earlier draft
+        # surfaced the Anthropic shape on the Responses lane — a
+        # behavior regression for drag.
+        from vllm_mlx.api.responses_adapter import openai_to_responses
+        from vllm_mlx.api.responses_models import ResponsesRequest
+
+        chat_resp = self._click_chat_response(
+            {
+                "action": "drag",
+                "start_point": [10, 20],
+                "end_point": [100, 200],
+            }
+        )
+        req = ResponsesRequest(
+            model="ui-tars-1.5-7b-4bit",
+            input="Drag from (10,20) to (100,200).",
+            tools=[
+                {
+                    "type": "computer_20251022",
+                    "display_width": 1280,
+                    "display_height": 800,
+                }
+            ],
+        )
+        resp = openai_to_responses(
+            chat_resp, model="ui-tars-1.5-7b-4bit", request=req, created_at=1
+        )
+        computer_calls = [
+            o for o in resp.output if getattr(o, "type", None) == "computer_call"
+        ]
+        assert len(computer_calls) == 1
+        cc = computer_calls[0]
+        # R6-M2: Responses-spec ``path`` array shape.
+        assert cc.action == {
+            "type": "drag",
+            "path": [{"x": 10, "y": 20}, {"x": 100, "y": 200}],
+        }
+        # Defensive: NO Anthropic-style start_coordinate / end_coordinate.
+        assert "start_coordinate" not in cc.action
+        assert "end_coordinate" not in cc.action
+
     # --- Helper-level test ------------------------------------------------
 
-    def test_translate_helper_is_idempotent(self):
+    def test_anthropic_translator_is_idempotent_on_single_point(self):
         # The mapper must be safe to call twice — already-translated
         # keys stay translated (defense-in-depth for a future
         # double-translation refactor).
         from vllm_mlx.tool_parsers.ui_tars_tool_parser import (
-            translate_to_spec_coordinate_keys,
+            translate_to_anthropic_spec_keys,
         )
 
-        once = translate_to_spec_coordinate_keys({"action": "click", "point": [1, 2]})
-        twice = translate_to_spec_coordinate_keys(once)
+        once = translate_to_anthropic_spec_keys({"action": "click", "point": [1, 2]})
+        twice = translate_to_anthropic_spec_keys(once)
         assert once == twice == {"action": "click", "coordinate": [1, 2]}
 
-    def test_translate_helper_preserves_non_coord_kwargs(self):
+    def test_anthropic_translator_preserves_non_coord_kwargs(self):
         # Non-coord kwargs (action, content, key, direction, …)
         # pass through verbatim.
         from vllm_mlx.tool_parsers.ui_tars_tool_parser import (
-            translate_to_spec_coordinate_keys,
+            translate_to_anthropic_spec_keys,
         )
 
-        out = translate_to_spec_coordinate_keys({"action": "type", "content": "hello"})
+        out = translate_to_anthropic_spec_keys({"action": "type", "content": "hello"})
         assert out == {"action": "type", "content": "hello"}
 
-        out = translate_to_spec_coordinate_keys({"action": "hotkey", "key": "ctrl+c"})
+        out = translate_to_anthropic_spec_keys({"action": "hotkey", "key": "ctrl+c"})
         assert out == {"action": "hotkey", "key": "ctrl+c"}
+
+    def test_responses_translator_folds_drag_into_path(self):
+        # Direct probe of the helper: point pair → spec path array.
+        from vllm_mlx.tool_parsers.ui_tars_tool_parser import (
+            translate_to_responses_spec_keys,
+        )
+
+        out = translate_to_responses_spec_keys(
+            {
+                "action": "drag",
+                "start_point": [10, 20],
+                "end_point": [100, 200],
+            }
+        )
+        assert out == {
+            "action": "drag",
+            "path": [{"x": 10, "y": 20}, {"x": 100, "y": 200}],
+        }
+
+    def test_responses_translator_preserves_malformed_drag(self):
+        # Codex r1 — defensive: if only ONE of start_point / end_point
+        # is present (malformed drag), the present key falls through
+        # as the UI-TARS-native name so the downstream consumer can
+        # detect the gap rather than receive a truncated single-point
+        # ``path`` that looks valid.
+        from vllm_mlx.tool_parsers.ui_tars_tool_parser import (
+            translate_to_responses_spec_keys,
+        )
+
+        out = translate_to_responses_spec_keys(
+            {"action": "drag", "start_point": [10, 20]}
+        )
+        # No ``path``; the lone start_point falls through.
+        assert "path" not in out
+        assert out["start_point"] == [10, 20]
+
+    def test_responses_translator_handles_single_point_verb(self):
+        # Single-point verb on the Responses lane: ``point`` →
+        # ``coordinate``, same as the Anthropic translator.
+        from vllm_mlx.tool_parsers.ui_tars_tool_parser import (
+            translate_to_responses_spec_keys,
+        )
+
+        out = translate_to_responses_spec_keys({"action": "click", "point": [500, 300]})
+        assert out == {"action": "click", "coordinate": [500, 300]}

--- a/tests/test_ui_tars_lane_parity.py
+++ b/tests/test_ui_tars_lane_parity.py
@@ -469,7 +469,9 @@ class TestResponsesLaneComputerCallEmission:
         ]
         cc = computer_calls[0]
         # Action verb mapped from "action" → "type".
-        assert cc.action == {"type": "click", "point": [500, 300]}
+        # R6-M2: ``point`` is the UI-TARS parser's canonical key; the
+        # Responses lane translates to OpenAI's spec ``coordinate``.
+        assert cc.action == {"type": "click", "coordinate": [500, 300]}
         # No function_call in output (would be the C-10 regression).
         assert not [
             o for o in resp.output if getattr(o, "type", None) == "function_call"
@@ -548,3 +550,305 @@ class TestR09PinnedComputerToolChoice:
             tools=tools,
         )
         assert out == messages
+
+
+# ---------------------------------------------------------------------------
+# r6-B R6-M1: reasoning channel populates on plain chat lane
+# ---------------------------------------------------------------------------
+
+
+class TestR6M1ReasoningGateDecoupling:
+    """The reasoning emission gate must fire whenever the model
+    produces a thought block — NOT only when the Computer-Use
+    sysprompt was auto-injected.
+
+    Pre-r6-B: ``_PREAMBLE_RE`` required ``(?=\\s*Action:)`` lookahead,
+    so a plain-chat response (no Computer-Use tool declared, so r5-B's
+    tool-coupled gate skipped sysprompt injection) that still emitted
+    ``Thought: ...`` (because the UI-TARS checkpoint is post-trained
+    on the format) silently routed the entire buffer to ``content``.
+
+    Fixed by decoupling the reasoning extraction from the
+    sysprompt-injection presence: the regex now accepts three
+    additional shapes — ``Thought:`` with a blank-line boundary,
+    ``Thought:`` ending the buffer (no follow-up answer), and the
+    generic ``<think>...</think>`` tag.
+    """
+
+    def test_plain_chat_thought_blank_line_surfaces_as_reasoning(self):
+        # Plain chat lane: no Action: anywhere, blank line separates
+        # the thought from the follow-up answer.
+        from vllm_mlx.reasoning.ui_tars_parser import UiTarsReasoningParser
+
+        parser = UiTarsReasoningParser()
+        reasoning, content = parser.extract_reasoning(
+            "Thought: I should respond directly.\n\nThe answer is 4."
+        )
+        assert reasoning == "Thought: I should respond directly."
+        assert content == "The answer is 4."
+
+    def test_plain_chat_thought_end_of_buffer_surfaces_as_reasoning(self):
+        # Edge case: the model emitted only a Thought: block, no
+        # follow-up answer (truncated / cut off). The reasoning
+        # channel still surfaces it.
+        from vllm_mlx.reasoning.ui_tars_parser import UiTarsReasoningParser
+
+        parser = UiTarsReasoningParser()
+        reasoning, content = parser.extract_reasoning("Thought: I'm uncertain.")
+        assert reasoning == "Thought: I'm uncertain."
+        # No follow-up — content empty / None.
+        assert not content
+
+    def test_plain_chat_think_tag_surfaces_as_reasoning(self):
+        # Generic ``<think>...</think>`` tag (a model checkpoint that
+        # learned both UI-TARS Thought: AND the standard think-tag
+        # convention may emit either). Both should populate reasoning.
+        from vllm_mlx.reasoning.ui_tars_parser import UiTarsReasoningParser
+
+        parser = UiTarsReasoningParser()
+        reasoning, content = parser.extract_reasoning(
+            "<think>The user asked for 2+2.</think>The answer is 4."
+        )
+        # The structural <think>/</think> wrapper is stripped — the
+        # reasoning channel surfaces the human-readable thought only.
+        assert reasoning == "The user asked for 2+2."
+        assert content == "The answer is 4."
+
+    def test_action_lane_reasoning_still_works(self):
+        # Positive control: pre-r6-B contract is preserved — the
+        # Action lane still routes the Thought: preamble to
+        # reasoning and everything from ``Action:`` onward to content.
+        from vllm_mlx.reasoning.ui_tars_parser import UiTarsReasoningParser
+
+        parser = UiTarsReasoningParser()
+        reasoning, content = parser.extract_reasoning(
+            "Thought: Click the OK button.\nAction: click(point='<point>500 300</point>')"
+        )
+        assert reasoning == "Thought: Click the OK button."
+        assert content == "Action: click(point='<point>500 300</point>')"
+
+    def test_no_preamble_routes_all_to_content(self):
+        # Defense-in-depth: a response with NO thought block at all
+        # routes the entire buffer to content (no spurious reasoning).
+        from vllm_mlx.reasoning.ui_tars_parser import UiTarsReasoningParser
+
+        parser = UiTarsReasoningParser()
+        reasoning, content = parser.extract_reasoning(
+            "Just a regular response with no thought."
+        )
+        assert reasoning is None
+        assert content == "Just a regular response with no thought."
+
+
+# ---------------------------------------------------------------------------
+# r6-B R6-M2: Anthropic + Responses lanes translate point → coordinate
+# ---------------------------------------------------------------------------
+
+
+class TestR6M2CoordinateKeyTranslation:
+    """The UI-TARS parser emits the canonical ``point`` /
+    ``start_point`` / ``end_point`` keys (PR #812 contract; chat
+    completions OpenAI lane stays bytes-faithful to that). The
+    Anthropic ``/v1/messages`` lane and the OpenAI ``/v1/responses``
+    lane both follow specs that require ``coordinate`` (and
+    ``start_coordinate`` / ``end_coordinate`` for two-point verbs).
+
+    Pre-r6-B: both adapters surfaced the UI-TARS-native ``point`` key
+    verbatim. Anthropic-strict consumers (claude-agent-sdk, Computer-
+    Use harnesses) rejected the shape. Fixed by a centralized
+    ``translate_to_spec_coordinate_keys`` helper that lives next to
+    the parser and is called from both adapters' tool_use / computer_call
+    builders so the two surfaces can't drift on key naming.
+    """
+
+    def _click_chat_response(self, args_payload: dict):
+        """Synthesize the OAI chat response a UI-TARS click would
+        produce; reused across the Anthropic + Responses asserts.
+        """
+        from vllm_mlx.api.models import (
+            AssistantMessage,
+            ChatCompletionChoice,
+            ChatCompletionResponse,
+            FunctionCall,
+            ToolCall,
+            Usage,
+        )
+
+        tc = ToolCall(
+            id="call_abc12345",
+            type="function",
+            function=FunctionCall(name="computer", arguments=json.dumps(args_payload)),
+        )
+        return ChatCompletionResponse(
+            id="chatcmpl-test",
+            object="chat.completion",
+            created=1,
+            model="ui-tars-1.5-7b-4bit",
+            choices=[
+                ChatCompletionChoice(
+                    index=0,
+                    message=AssistantMessage(
+                        role="assistant", content="", tool_calls=[tc]
+                    ),
+                    finish_reason="tool_calls",
+                )
+            ],
+            usage=Usage(prompt_tokens=10, completion_tokens=5, total_tokens=15),
+        )
+
+    # --- Anthropic /v1/messages ------------------------------------------
+
+    def test_anthropic_click_emits_coordinate_not_point(self):
+        from vllm_mlx.api.anthropic_adapter import openai_to_anthropic
+
+        chat_resp = self._click_chat_response({"action": "click", "point": [500, 300]})
+        anth = openai_to_anthropic(chat_resp, model="ui-tars-1.5-7b-4bit")
+        tool_uses = [b for b in anth.content if getattr(b, "type", None) == "tool_use"]
+        assert len(tool_uses) == 1
+        tu = tool_uses[0]
+        assert tu.name == "computer"
+        # R6-M2: spec key is ``coordinate``, NOT ``point``.
+        assert tu.input == {"action": "click", "coordinate": [500, 300]}
+        assert "point" not in tu.input
+
+    def test_anthropic_drag_emits_start_end_coordinate(self):
+        from vllm_mlx.api.anthropic_adapter import openai_to_anthropic
+
+        chat_resp = self._click_chat_response(
+            {
+                "action": "drag",
+                "start_point": [10, 20],
+                "end_point": [100, 200],
+            }
+        )
+        anth = openai_to_anthropic(chat_resp, model="ui-tars-1.5-7b-4bit")
+        tool_uses = [b for b in anth.content if getattr(b, "type", None) == "tool_use"]
+        assert len(tool_uses) == 1
+        # Two-point verb → start_coordinate / end_coordinate.
+        assert tool_uses[0].input == {
+            "action": "drag",
+            "start_coordinate": [10, 20],
+            "end_coordinate": [100, 200],
+        }
+
+    def test_anthropic_non_computer_tool_input_untouched(self):
+        # Vanilla function tool whose arguments happen to carry a
+        # ``point`` key — the gated translation MUST NOT rewrite it.
+        from vllm_mlx.api.anthropic_adapter import openai_to_anthropic
+        from vllm_mlx.api.models import (
+            AssistantMessage,
+            ChatCompletionChoice,
+            ChatCompletionResponse,
+            FunctionCall,
+            ToolCall,
+            Usage,
+        )
+
+        tc = ToolCall(
+            id="call_abc12345",
+            type="function",
+            function=FunctionCall(
+                name="get_pixel_color",
+                arguments=json.dumps({"point": [500, 300]}),
+            ),
+        )
+        chat_resp = ChatCompletionResponse(
+            id="chatcmpl-test",
+            object="chat.completion",
+            created=1,
+            model="non-ui-tars-model",
+            choices=[
+                ChatCompletionChoice(
+                    index=0,
+                    message=AssistantMessage(
+                        role="assistant", content="", tool_calls=[tc]
+                    ),
+                    finish_reason="tool_calls",
+                )
+            ],
+            usage=Usage(prompt_tokens=10, completion_tokens=5, total_tokens=15),
+        )
+        anth = openai_to_anthropic(chat_resp, model="non-ui-tars-model")
+        tool_uses = [b for b in anth.content if getattr(b, "type", None) == "tool_use"]
+        # Non-``computer`` tool — translation gate skipped.
+        assert tool_uses[0].input == {"point": [500, 300]}
+        assert "coordinate" not in tool_uses[0].input
+
+    # --- OpenAI /v1/responses ---------------------------------------------
+
+    def test_responses_click_emits_coordinate_not_point(self):
+        from vllm_mlx.api.responses_adapter import openai_to_responses
+        from vllm_mlx.api.responses_models import ResponsesRequest
+
+        chat_resp = self._click_chat_response({"action": "click", "point": [500, 300]})
+        req = ResponsesRequest(
+            model="ui-tars-1.5-7b-4bit",
+            input="Click OK.",
+            tools=[
+                {
+                    "type": "computer_20251022",
+                    "display_width": 1280,
+                    "display_height": 800,
+                }
+            ],
+        )
+        resp = openai_to_responses(
+            chat_resp, model="ui-tars-1.5-7b-4bit", request=req, created_at=1
+        )
+        computer_calls = [
+            o for o in resp.output if getattr(o, "type", None) == "computer_call"
+        ]
+        assert len(computer_calls) == 1
+        cc = computer_calls[0]
+        # R6-M2: spec key is ``coordinate``, NOT ``point``.
+        assert cc.action == {"type": "click", "coordinate": [500, 300]}
+        assert "point" not in cc.action
+
+    # --- Chat Completions OpenAI lane stays on point ----------------------
+
+    def test_chat_completions_lane_still_emits_native_point(self):
+        # Defense-in-depth: the OpenAI ``/v1/chat/completions`` lane
+        # must stay bytes-faithful to the UI-TARS parser's native
+        # ``point`` key per PR #812 — only the Anthropic + Responses
+        # lanes do the spec translation. A SDK consumer that round-
+        # trips the chat-completions arguments → JSON → back will see
+        # ``point`` (the parser's bytes-faithful contract).
+        from vllm_mlx.tool_parsers.ui_tars_tool_parser import UiTarsToolParser
+
+        parser = UiTarsToolParser(tokenizer=None)
+        parser.reset()
+        text = "Action: click(point='<point>500 300</point>')"
+        result = parser.extract_tool_calls(text, request=None)
+        assert result.tools_called is True
+        assert len(result.tool_calls) == 1
+        args = json.loads(result.tool_calls[0]["arguments"])
+        # Chat-completions OpenAI lane: parser-native ``point`` key.
+        assert args == {"action": "click", "point": [500, 300]}
+        assert "coordinate" not in args
+
+    # --- Helper-level test ------------------------------------------------
+
+    def test_translate_helper_is_idempotent(self):
+        # The mapper must be safe to call twice — already-translated
+        # keys stay translated (defense-in-depth for a future
+        # double-translation refactor).
+        from vllm_mlx.tool_parsers.ui_tars_tool_parser import (
+            translate_to_spec_coordinate_keys,
+        )
+
+        once = translate_to_spec_coordinate_keys({"action": "click", "point": [1, 2]})
+        twice = translate_to_spec_coordinate_keys(once)
+        assert once == twice == {"action": "click", "coordinate": [1, 2]}
+
+    def test_translate_helper_preserves_non_coord_kwargs(self):
+        # Non-coord kwargs (action, content, key, direction, …)
+        # pass through verbatim.
+        from vllm_mlx.tool_parsers.ui_tars_tool_parser import (
+            translate_to_spec_coordinate_keys,
+        )
+
+        out = translate_to_spec_coordinate_keys({"action": "type", "content": "hello"})
+        assert out == {"action": "type", "content": "hello"}
+
+        out = translate_to_spec_coordinate_keys({"action": "hotkey", "key": "ctrl+c"})
+        assert out == {"action": "hotkey", "key": "ctrl+c"}

--- a/tests/test_ui_tars_parser.py
+++ b/tests/test_ui_tars_parser.py
@@ -808,7 +808,9 @@ class TestAnthropicAdapter:
         assert len(tool_use_blocks) == 1
         tu = tool_use_blocks[0]
         assert tu.name == "computer"
-        assert tu.input == {"action": "click", "point": [200, 300]}
+        # R6-M2: Anthropic adapter translates UI-TARS canonical ``point``
+        # to spec ``coordinate`` on the ``/v1/messages`` boundary.
+        assert tu.input == {"action": "click", "coordinate": [200, 300]}
 
     def test_multi_action_emits_multiple_tool_use_blocks(self):
         from vllm_mlx.api.anthropic_adapter import openai_to_anthropic

--- a/tests/test_ui_tars_stream_action_holdback.py
+++ b/tests/test_ui_tars_stream_action_holdback.py
@@ -1,0 +1,272 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression coverage for r6-B R6-C3 streaming Action: hold-back.
+
+Bug fixed: the streaming UI-TARS tool parser used to leak raw
+``Action: <verb>`` bytes into ``delta.content`` BEFORE the structured
+``delta.tool_calls`` flush. Two leak vectors:
+
+1. ``has_pending_tool_call("Action: type")`` returned ``False`` because
+   the strict ``_ACTION_LINE`` regex requires ``(``. The streaming
+   postprocessor's fast-path then short-circuited the delta as plain
+   ``content`` — leaking the bare ``Action: <verb>`` bytes.
+2. ``extract_tool_calls_streaming`` returned ``{"content": delta_text}``
+   when ``"Action:" not in current_text``, even when the trailing bytes
+   were a STRICT PREFIX of ``Action:`` (e.g. delta ended with ``"\\nAc"``).
+   The next delta resolved the token but those candidate-opener bytes
+   had already left the wire.
+
+R6-C3 fix: parser-level hold-back state machine.
+
+* ``has_pending_tool_call`` now returns True for bare ``Action:``
+  (no verb / parens yet) AND for trailing strict-prefix of ``Action:``
+  at the buffer tail.
+* ``extract_tool_calls_streaming`` clips off the trailing partial-opener
+  candidate before flushing the safe prefix as content.
+
+Repro: dogfood-087 R2-6 (Aki r2.md) — chat completions streaming with
+UI-TARS + computer tool + click prompt; streamed chunks contained
+``delta.content="Action: type"`` raw text BEFORE the ``delta.tool_calls``
+event fired with the structured action.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from vllm_mlx.tool_parsers.ui_tars_tool_parser import UiTarsToolParser
+
+
+@pytest.fixture
+def parser():
+    p = UiTarsToolParser(tokenizer=None)
+    p.reset()
+    return p
+
+
+def _drive_stream(parser, deltas):
+    """Drive the streaming parser through ``deltas`` (list of str) and
+    return ``(events, accumulated_content, tool_calls)``.
+
+    ``events`` is the list of parser return values per delta;
+    ``accumulated_content`` is the concatenation of every emitted
+    content chunk (the bytes that would be surfaced on
+    ``delta.content`` SSE events); ``tool_calls`` is the list of
+    structured tool_call dicts emitted across the stream.
+    """
+    events: list = []
+    accumulated_content_parts: list[str] = []
+    tool_calls: list = []
+    previous = ""
+    for delta in deltas:
+        current = previous + delta
+        result = parser.extract_tool_calls_streaming(
+            previous_text=previous,
+            current_text=current,
+            delta_text=delta,
+            request=None,
+        )
+        events.append(result)
+        if result is None:
+            previous = current
+            continue
+        if "content" in result and result["content"]:
+            accumulated_content_parts.append(result["content"])
+        if "tool_calls" in result and result["tool_calls"]:
+            tool_calls.extend(result["tool_calls"])
+        previous = current
+    return events, "".join(accumulated_content_parts), tool_calls
+
+
+# ---------------------------------------------------------------------------
+# Bug 1 — has_pending_tool_call covers bare Action: + trailing prefix
+# ---------------------------------------------------------------------------
+
+
+class TestHasPendingToolCall:
+    """The fast-path gate that decides whether the postprocessor
+    routes the delta through the full streaming parser. Pre-r6-B,
+    the only "pending" signal was the strict ``_ACTION_LINE`` regex
+    (``Action: verb(``); a delta carrying the bare ``Action: <verb>``
+    token (no ``(`` yet) hit the False arm and was leaked as content.
+    """
+
+    def test_action_with_open_paren_still_pending(self, parser):
+        # Original contract: open paren, no balanced close → pending.
+        assert parser.has_pending_tool_call("Action: click(") is True
+
+    def test_action_with_completed_call_not_pending(self, parser):
+        # Original contract: balanced close → not pending.
+        assert parser.has_pending_tool_call("Action: wait()") is False
+
+    def test_bare_action_with_verb_pending(self, parser):
+        # R6-C3 NEW: ``Action: type`` (no paren) MUST be pending so
+        # the postprocessor's fast-path routes through the streaming
+        # parser instead of leaking the bytes as content.
+        assert parser.has_pending_tool_call("Action: type") is True
+
+    def test_bare_action_no_verb_pending(self, parser):
+        # ``Action:`` with no verb yet — about to emit a verb on the
+        # next delta. Hold the buffer.
+        assert parser.has_pending_tool_call("Action:") is True
+        assert parser.has_pending_tool_call("Action: ") is True
+
+    @pytest.mark.parametrize(
+        "tail",
+        ["A", "Ac", "Act", "Acti", "Actio", "Action"],
+    )
+    def test_trailing_action_prefix_pending(self, parser, tail):
+        # R6-C3 NEW: trailing strict-prefix of ``Action:`` at the
+        # buffer tail. e.g. ``"Thought: do X.\\nAc"`` — the next delta
+        # might land ``"tion: click(...)"`` and we MUST hold the
+        # candidate-opener bytes off the wire until then.
+        text = f"Some prose.\n{tail}"
+        assert parser.has_pending_tool_call(text) is True
+
+    def test_trailing_non_action_prefix_not_pending(self, parser):
+        # Trailing bytes that are NOT a prefix of ``Action:``. Plain
+        # content — fast-path should let it through.
+        assert parser.has_pending_tool_call("Thought: I'm done.") is False
+        assert parser.has_pending_tool_call("Some prose ending in xyz.") is False
+
+    def test_no_action_signal_not_pending(self, parser):
+        # No Action: bytes anywhere, no trailing prefix candidate.
+        assert parser.has_pending_tool_call("") is False
+        assert parser.has_pending_tool_call("Thought: hi") is False
+        assert parser.has_pending_tool_call("Hello world!") is False
+
+
+# ---------------------------------------------------------------------------
+# Bug 1 — streaming parser content channel never leaks Action: prefix
+# ---------------------------------------------------------------------------
+
+
+class TestStreamingActionHoldback:
+    """The streaming parser's content channel — ``delta.content`` —
+    must NEVER carry raw bytes that are about to become the prefix of
+    a structured ``Action: verb(...)`` tool_call.
+    """
+
+    def test_no_action_prefix_leaks_into_content_single_chunk(self, parser):
+        # The dogfood R2-6 shape: model emits ``"Action: type"`` in
+        # one chunk then completes the args on the next. Pre-r6-B
+        # the parser returned None (correctly held), but the
+        # postprocessor's fast-path bypass leaked the bytes via
+        # ``has_pending_tool_call`` returning False.
+        deltas = ["Action: type", "(content='hi')"]
+        events, content, tool_calls = _drive_stream(parser, deltas)
+        assert "Action:" not in content, (
+            f"delta.content leaked the Action: prefix: {content!r}"
+        )
+        assert len(tool_calls) == 1
+        assert tool_calls[0]["function"]["name"] == "computer"
+        assert '"action": "type"' in tool_calls[0]["function"]["arguments"]
+
+    def test_no_action_prefix_leaks_token_by_token(self, parser):
+        # Sub-character deltas around the Action: token. Each prefix
+        # ``"A"``, ``"Ac"``, … must be held until the colon resolves.
+        deltas = [
+            "A",
+            "c",
+            "t",
+            "i",
+            "o",
+            "n",
+            ":",
+            " ",
+            "click",
+            "(point='<point>10 20</point>')",
+        ]
+        events, content, tool_calls = _drive_stream(parser, deltas)
+        assert "Action" not in content, (
+            f"delta.content leaked Action prefix bytes: {content!r}"
+        )
+        assert "Acti" not in content
+        assert len(tool_calls) == 1
+
+    def test_no_action_prefix_leaks_with_prior_content(self, parser):
+        # Plain content arrives first, THEN the partial Action prefix
+        # accumulates on the tail. Only the trailing candidate-opener
+        # bytes must be held; the preceding plain-content bytes pass
+        # through normally.
+        deltas = ["Some prose.\n", "Ac", "tion: wait()"]
+        events, content, tool_calls = _drive_stream(parser, deltas)
+        # The "Some prose.\n" must reach delta.content; the "Ac"
+        # bytes must NOT (they're the held opener candidate).
+        assert "Some prose." in content
+        assert "Action" not in content
+        assert len(tool_calls) == 1
+        assert '"action": "wait"' in tool_calls[0]["function"]["arguments"]
+
+    def test_action_completes_before_tool_calls_event(self, parser):
+        # End-to-end: structured tool_calls event MUST fire by stream
+        # end, and the accumulated content MUST be free of any
+        # Action: bytes.
+        deltas = [
+            "Action: click",
+            "(point='<point>500 300</point>')",
+        ]
+        events, content, tool_calls = _drive_stream(parser, deltas)
+        assert "Action:" not in content
+        assert len(tool_calls) == 1
+        assert tool_calls[0]["function"]["name"] == "computer"
+        assert '"action": "click"' in tool_calls[0]["function"]["arguments"]
+        assert '"coordinate"' not in tool_calls[0]["function"]["arguments"]
+        # Chat-completions OpenAI lane stays on the parser's native
+        # ``point`` key (the Anthropic / Responses lanes do the
+        # translation to ``coordinate``).
+        assert '"point": [500, 300]' in tool_calls[0]["function"]["arguments"]
+
+    def test_action_after_thought_no_leak(self, parser):
+        # Realistic UI-TARS Computer-Use stream: ``Thought:`` preamble
+        # → blank line → ``Action: verb(...)``. The reasoning parser
+        # routes the Thought block to the reasoning channel BEFORE
+        # the tool parser sees it, so the tool parser's input here is
+        # whatever falls in the content channel — the ``Action:`` line
+        # and its arguments. Both vectors must be held until the
+        # tool_call fires.
+        deltas = ["Action: ", "click", "(point='<point>500 300</point>')"]
+        events, content, tool_calls = _drive_stream(parser, deltas)
+        assert "Action:" not in content
+        assert "click" not in content
+        assert len(tool_calls) == 1
+
+    def test_tool_choice_none_passthrough_unchanged(self, parser):
+        # Defense-in-depth: tool_choice="none" short-circuit is the
+        # OpenAI spec contract — even if the model emits ``Action:``
+        # bytes, no tool_call event is allowed. The bytes ARE allowed
+        # to leak through delta.content because the route documented
+        # that as the contracted shape (text-only turn).
+        deltas = ["Action: click()"]
+        previous = ""
+        result = parser.extract_tool_calls_streaming(
+            previous_text=previous,
+            current_text=deltas[0],
+            delta_text=deltas[0],
+            request={"tool_choice": "none"},
+        )
+        # No tool_calls; bytes pass through as content per the
+        # tool_choice="none" contract.
+        assert result == {"content": "Action: click()"}
+
+
+# ---------------------------------------------------------------------------
+# Bug 1 — non-streaming path stays clean (regression guard)
+# ---------------------------------------------------------------------------
+
+
+class TestNonStreamingActionParity:
+    """The non-streaming path already fully consumes the prefix before
+    emitting; the r6-B fix is to bring the streaming path to parity.
+    Test that the non-streaming path still works correctly so the
+    fix didn't accidentally break it.
+    """
+
+    def test_non_stream_strips_action_prefix(self, parser):
+        text = "Action: click(point='<point>10 20</point>')"
+        result = parser.extract_tool_calls(text, request=None)
+        assert result.tools_called is True
+        assert len(result.tool_calls) == 1
+        assert result.tool_calls[0]["name"] == "computer"
+        # Residual content is empty / None — the Action: prefix was
+        # fully consumed.
+        assert not result.content

--- a/tests/test_ui_tars_stream_action_holdback.py
+++ b/tests/test_ui_tars_stream_action_holdback.py
@@ -367,3 +367,145 @@ class TestCodexHighWordBoundaryGate:
         events, content, tool_calls = _drive_stream(parser, ["PlanA"])
         assert content == "PlanA"
         assert tool_calls == []
+
+
+# ---------------------------------------------------------------------------
+# Codex r2 BLOCKING — bare Action: + non-signature prose released as content
+# ---------------------------------------------------------------------------
+
+
+class TestCodexR2BareActionProseRelease:
+    """Codex r2 BLOCKING: pre-fix, the streaming path treated every
+    ``Action:`` occurrence as "in-flight action — hold buffer." That
+    meant streams whose ``Action:`` token was followed by non-signature
+    prose (``"Action: is required."``, ``["Act", "ion: item"]``) held
+    the bytes indefinitely; ``len(cur_actions) <= len(prev_actions)``
+    returned ``None`` forever and the postprocessor never received the
+    bytes.
+
+    The fix is two-layered:
+
+    1. Mid-stream, ``_action_signature_could_complete`` discriminates
+       "this Action: could still become Action: verb(" (held)
+       from "this Action: is now provably prose" (released as content).
+    2. At stream end, ``flush_held_content`` releases ANY still-held
+       suffix — by definition the model committed to "no more tokens"
+       so the held bytes are plain content.
+    """
+
+    def test_action_followed_by_prose_releases_mid_stream(self, parser):
+        # ``Action: is required.`` — after ``Action: ``, the model emits
+        # ``is required.`` which IS a valid ident (``is``) but then a
+        # SPACE before any open-paren. Signature can't complete →
+        # release.
+        events, content, tool_calls = _drive_stream(parser, ["Action: is required."])
+        assert content == "Action: is required."
+        assert tool_calls == []
+
+    def test_action_followed_by_punctuation_releases_mid_stream(self, parser):
+        # ``Action: !`` — after the colon and whitespace, ``!`` is NOT
+        # a valid ident start. Signature can never complete → release.
+        events, content, tool_calls = _drive_stream(parser, ["Action: !"])
+        assert content == "Action: !"
+        assert tool_calls == []
+
+    def test_action_followed_by_digit_releases_mid_stream(self, parser):
+        # Digit can't start a verb-ident (Python rules) → release.
+        events, content, tool_calls = _drive_stream(parser, ["Action: 42 items"])
+        assert content == "Action: 42 items"
+        assert tool_calls == []
+
+    def test_bare_action_split_across_deltas_held_until_finalize(self, parser):
+        # ``["Act", "ion: item"]`` — after delta 2 the buffer is
+        # ``"Action: item"``. The signature "Action: item" could
+        # still complete (no terminating char yet — ``item`` could
+        # extend or the next char could be ``(``). Mid-stream MUST
+        # hold; the postprocessor's ``finalize()`` calls
+        # ``flush_held_content`` to release at stream end.
+        accumulated_text = ""
+        content_parts: list[str] = []
+        previous = ""
+        for delta in ["Act", "ion: item"]:
+            current = previous + delta
+            result = parser.extract_tool_calls_streaming(
+                previous_text=previous,
+                current_text=current,
+                delta_text=delta,
+                request=None,
+            )
+            if result and result.get("content"):
+                content_parts.append(result["content"])
+            previous = current
+            accumulated_text = current
+        # Mid-stream emit: nothing — bytes were held.
+        assert content_parts == []
+        # Finalize releases.
+        held = parser.flush_held_content(accumulated_text)
+        assert held == "Action: item"
+
+    def test_action_with_completed_verb_paren_still_holds(self, parser):
+        # Positive control: ``Action: type(`` mid-stream MUST stay held
+        # — the signature DID commit to a real action, just no balanced
+        # close yet. flush_held_content releases at stream end too
+        # (the action is incomplete bytes, but we don't drop them).
+        events, content, tool_calls = _drive_stream(parser, ["Action: type("])
+        assert content == ""
+        assert tool_calls == []
+        # At finalize, the partial action bytes flush as content
+        # (no balanced close → no structured tool_call to surface).
+        held = parser.flush_held_content("Action: type(")
+        assert held == "Action: type("
+
+    def test_safe_emit_end_helper(self):
+        from vllm_mlx.tool_parsers.ui_tars_tool_parser import _safe_emit_end
+
+        # No Action: anywhere → safe_end is at end (or before trailing prefix).
+        assert _safe_emit_end("Hello world!") == len("Hello world!")
+        # Trailing prefix: safe_end clips the partial-opener.
+        assert _safe_emit_end("Hello\nAc") == len("Hello\n")
+        # Action: with non-signature prose → safe_end at end (no hold).
+        text = "Action: is required."
+        assert _safe_emit_end(text) == len(text)
+        # Action: with completable signature → safe_end at Action: start.
+        text = "prose. Action: clic"
+        assert _safe_emit_end(text) == len("prose. ")
+        # Completed Action: verb(...) — handled by tool_calls path,
+        # safe_end is at end of the completed action.
+        text = "prose. Action: wait() done"
+        # The completed action span ends at ``Action: wait()`` close;
+        # bytes ``" done"`` after are residual content. safe_end
+        # should be at len(text) — no in-flight signal AND no
+        # trailing prefix.
+        assert _safe_emit_end(text) == len(text)
+
+
+class TestCodexR2FlushHeldContent:
+    """End-of-stream flush hook: ``flush_held_content`` returns the
+    suffix of the accumulated text that the streaming parser was still
+    holding when the stream finished. Without this hook, the bytes
+    held mid-stream would be permanently dropped from the response.
+    """
+
+    def test_no_action_no_held_bytes(self, parser):
+        assert parser.flush_held_content("Plain content.") == ""
+
+    def test_trailing_prefix_flushed_at_eos(self, parser):
+        # Stream ended with ``"...thing\nAc"`` — the trailing prefix
+        # never resolved, so flush as content.
+        assert parser.flush_held_content("Hello\nAc") == "Ac"
+
+    def test_inflight_action_flushed_at_eos(self, parser):
+        # Stream ended with ``"Action: cli"`` — partial in-flight
+        # action that didn't get the open paren. flush_held_content
+        # releases the held bytes as content.
+        assert parser.flush_held_content("Action: cli") == "Action: cli"
+
+    def test_completed_action_does_not_flush_as_content(self, parser):
+        # Completed action bytes are emitted as structured tool_calls,
+        # NOT as content via flush_held_content.
+        assert parser.flush_held_content("Action: wait()") == ""
+
+    def test_prose_action_does_not_flush_as_content(self, parser):
+        # ``Action:`` followed by definitely-non-signature prose was
+        # already released mid-stream — flush returns empty.
+        assert parser.flush_held_content("Action: is required.") == ""

--- a/tests/test_ui_tars_stream_action_holdback.py
+++ b/tests/test_ui_tars_stream_action_holdback.py
@@ -509,3 +509,109 @@ class TestCodexR2FlushHeldContent:
         # ``Action:`` followed by definitely-non-signature prose was
         # already released mid-stream — flush returns empty.
         assert parser.flush_held_content("Action: is required.") == ""
+
+
+# ---------------------------------------------------------------------------
+# Codex r3 BLOCKING — held prefix + new action in same delta
+# ---------------------------------------------------------------------------
+
+
+class TestCodexR3HeldPrefixPlusNewAction:
+    """Codex r3 BLOCKING: when a held trailing prefix later disambiguates
+    in the SAME chunk that also completes a real action, the resolved
+    prose-prefix MUST be emitted as content alongside the structured
+    ``tool_calls`` event. Pre-fix, the new-action branch only walked
+    the delta-window (``delta_start_in_current`` cursor) and never
+    folded in the previously-held bytes — ``["Ac", "me Action: wait()"]``
+    lost the ``"Ac"`` entirely.
+
+    Fix: the residual walk now starts from ``prev_safe_end`` (the
+    cursor up to which prior calls have already emitted) and ends at
+    ``cur_safe_end`` (the new safe-emit boundary), folding the
+    prev-held bytes into the content slice between the prior emit
+    and the first new action.
+    """
+
+    def test_held_prefix_released_alongside_new_action(self, parser):
+        # The codex repro shape: "Ac" held, then "me " disambiguates
+        # to plain prose AND "Action: wait()" completes a tool call
+        # all in the same second chunk.
+        events, content, tool_calls = _drive_stream(parser, ["Ac", "me Action: wait()"])
+        assert content == "Acme ", (
+            f"Held 'Ac' was dropped when new action fired: events={events!r}"
+        )
+        assert len(tool_calls) == 1
+        assert tool_calls[0]["function"]["name"] == "computer"
+        assert '"action": "wait"' in tool_calls[0]["function"]["arguments"]
+
+    def test_held_prefix_with_action_in_third_delta(self, parser):
+        # Multi-step: held "Ac" → resolved "Acme " → real action.
+        events, content, tool_calls = _drive_stream(
+            parser, ["Ac", "me ", "Action: wait()"]
+        )
+        assert content == "Acme "
+        assert len(tool_calls) == 1
+
+    def test_held_prefix_resolves_via_real_action_token(self, parser):
+        # Held "Ac" actually IS the start of a real Action: token.
+        # No prose to release — all held bytes get folded into the
+        # tool_call's span.
+        events, content, tool_calls = _drive_stream(parser, ["Ac", "tion: wait()"])
+        assert content == ""
+        assert len(tool_calls) == 1
+        assert '"action": "wait"' in tool_calls[0]["function"]["arguments"]
+
+    def test_prev_held_prose_action_followed_by_real_action(self, parser):
+        # Prev buffer had a prose-Action; new delta adds a real one.
+        # The prose-Action bytes should already have flushed as content
+        # on the first delta (because the signature was provably
+        # incomplete), and the second delta only flushes the new
+        # action.
+        events, content, tool_calls = _drive_stream(
+            parser, ["Action: is required.\n", "Action: wait()"]
+        )
+        assert content == "Action: is required.\n"
+        assert len(tool_calls) == 1
+
+
+# ---------------------------------------------------------------------------
+# Codex r3 HIGH — has_pending_tool_call no longer reports prose as pending
+# ---------------------------------------------------------------------------
+
+
+class TestCodexR3HasPendingSemantics:
+    """Codex r3 HIGH: ``has_pending_tool_call`` used to return True for
+    every bare ``Action:`` in the buffer, even when the post-``Action:``
+    tail was provably non-signature prose. The streaming parser
+    already releases those bytes via ``_safe_emit_end`` (so it wasn't a
+    data-loss bug after the r2 fix), but the public helper's contract
+    was stale — the postprocessor's fast-path stayed on the slow
+    route unnecessarily.
+
+    Fix: case 2 of ``has_pending_tool_call`` now also runs
+    ``_action_signature_could_complete`` and only reports True when
+    the bare ``Action:`` could still become a real action signature.
+    """
+
+    def test_prose_action_not_pending(self, parser):
+        # Codex r3 HIGH repro: provably-non-signature prose.
+        assert parser.has_pending_tool_call("Action: is required.") is False
+        assert parser.has_pending_tool_call("Action: !") is False
+        assert parser.has_pending_tool_call("Action: 42 items") is False
+
+    def test_real_in_flight_action_still_pending(self, parser):
+        # Bare ``Action:`` whose signature COULD complete — held.
+        assert parser.has_pending_tool_call("Action:") is True
+        assert parser.has_pending_tool_call("Action: ") is True
+        assert parser.has_pending_tool_call("Action: cli") is True
+        # Verb fully written but no paren yet — held.
+        assert parser.has_pending_tool_call("Action: click") is True
+
+    def test_completed_action_not_pending(self, parser):
+        # Existing contract preserved — completed action means
+        # the tool_call has fired already.
+        assert parser.has_pending_tool_call("Action: wait()") is False
+
+    def test_open_paren_no_close_pending(self, parser):
+        # Existing contract — verb+paren commit but no close.
+        assert parser.has_pending_tool_call("Action: click(") is True

--- a/tests/test_ui_tars_stream_action_holdback.py
+++ b/tests/test_ui_tars_stream_action_holdback.py
@@ -270,3 +270,100 @@ class TestNonStreamingActionParity:
         # Residual content is empty / None — the Action: prefix was
         # fully consumed.
         assert not result.content
+
+
+# ---------------------------------------------------------------------------
+# Codex r1 BLOCKING + HIGH — replay + word-boundary gate
+# ---------------------------------------------------------------------------
+
+
+class TestCodexBlockingHeldBytesReplayed:
+    """Codex r1 BLOCKING: when a held trailing prefix DOES NOT become
+    ``Action:`` on the next delta (the model emitted a non-action
+    follow-up byte), the previously-held bytes MUST be released as
+    content so the SSE stream stays bytes-equivalent to the model's
+    output. Pre-fix the streaming parser dropped the held bytes
+    permanently — e.g. ``["Ac", "me"]`` lost the ``"Ac"``.
+    """
+
+    @pytest.mark.parametrize(
+        ("chunks", "expected_content"),
+        [
+            # The codex example: "Ac" then "me" → "Acme" content,
+            # no tool_calls.
+            (["Ac", "me"], "Acme"),
+            # Longer prefix that resolves to non-action prose.
+            (["Actio", "n is required."], "Action is required."),
+            # Held single byte → resolved to non-action.
+            (["A", "n answer"], "An answer"),
+            # Prose then short partial prefix then continuation.
+            (["Hello\nA", "B test"], "Hello\nAB test"),
+            # Multi-stage hold + release across many deltas.
+            (["Act", "io", "ns help"], "Actions help"),
+        ],
+    )
+    def test_held_prefix_released_on_non_action_disambiguation(
+        self, parser, chunks, expected_content
+    ):
+        events, content, tool_calls = _drive_stream(parser, chunks)
+        assert tool_calls == []
+        assert content == expected_content, (
+            f"Held bytes were dropped: events={events!r}, "
+            f"content={content!r}, expected={expected_content!r}"
+        )
+
+    def test_held_prefix_resolved_into_real_action(self, parser):
+        # Held bytes that DO become Action: stay held until the
+        # structured tool_calls event flushes them.
+        chunks = ["Act", "ion: ", "wait()"]
+        events, content, tool_calls = _drive_stream(parser, chunks)
+        # No Action: bytes leak as content.
+        assert "Action" not in content
+        assert len(tool_calls) == 1
+        assert '"action": "wait"' in tool_calls[0]["function"]["arguments"]
+
+
+class TestCodexHighWordBoundaryGate:
+    """Codex r1 HIGH: the trailing-prefix hold-back must be
+    word-boundary aware. The action grammar is ``\\bAction:`` so a
+    candidate-opener tail that ISN'T at a word boundary (e.g.
+    ``"PlanA"`` — trailing ``"A"`` preceded by ``"n"``) can never
+    become a real action and must not be held. Pre-fix the hold-back
+    didn't check the preceding char's word-class.
+    """
+
+    @pytest.mark.parametrize(
+        ("text", "expected_held"),
+        [
+            # Word-boundary-aligned candidates: SHOULD hold.
+            ("Ac", 2),  # start of text
+            ("\nAc", 2),  # preceded by \n — non-word
+            (" Ac", 2),  # preceded by space — non-word
+            ("Plan Acti", 4),  # space before "Acti" — non-word
+            ("(Acti", 4),  # paren — non-word
+            # Non-word-boundary candidates: MUST NOT hold.
+            ("PlanA", 0),  # preceded by 'n' — word char
+            ("123A", 0),  # preceded by '3' — word char
+            ("foo_Ac", 0),  # preceded by '_' — word char
+            # Pure non-prefix tails: not held regardless.
+            ("China", 0),
+            ("banana", 0),
+            ("hello world", 0),
+        ],
+    )
+    def test_trailing_prefix_word_boundary(self, text, expected_held):
+        from vllm_mlx.tool_parsers.ui_tars_tool_parser import (
+            _trailing_action_prefix_len,
+        )
+
+        assert _trailing_action_prefix_len(text) == expected_held, (
+            f"text={text!r}: hold-back grammar regressed"
+        )
+
+    def test_streaming_passthrough_for_non_word_boundary_prefix(self, parser):
+        # End-to-end: a stream that ends with a non-word-boundary
+        # candidate (``"PlanA"``) MUST flush as plain content with no
+        # hold-back, no replay, no leak.
+        events, content, tool_calls = _drive_stream(parser, ["PlanA"])
+        assert content == "PlanA"
+        assert tool_calls == []

--- a/vllm_mlx/api/anthropic_adapter.py
+++ b/vllm_mlx/api/anthropic_adapter.py
@@ -342,19 +342,20 @@ def openai_to_anthropic(
                 # parser whose ``computer`` tool emits the canonical
                 # ``point`` / ``start_point`` / ``end_point`` keys) the
                 # Anthropic ``tool_use.input`` MUST surface the spec
-                # ``coordinate`` / ``start_coordinate`` / ``end_coordinate``
-                # keys per Anthropic's Computer-Use docs. Anthropic-strict
-                # consumers (claude-agent-sdk, Computer-Use harnesses)
-                # reject the ``point`` shape. Translation is gated on
-                # ``name == "computer"`` so vanilla function tools whose
-                # arguments happen to carry a key named ``point`` are
-                # untouched.
+                # ``coordinate`` / ``start_coordinate`` keys per
+                # Anthropic's Computer-Use docs (single-point verbs use
+                # ``coordinate``; drag uses ``start_coordinate`` +
+                # ``coordinate`` for the end). Anthropic-strict consumers
+                # (claude-agent-sdk, Computer-Use harnesses) reject the
+                # ``point`` shape. Translation is gated on ``name ==
+                # "computer"`` so vanilla function tools whose arguments
+                # happen to carry a key named ``point`` are untouched.
                 if tc.function.name == "computer" and isinstance(tool_input, dict):
                     from ..tool_parsers.ui_tars_tool_parser import (
-                        translate_to_spec_coordinate_keys,
+                        translate_to_anthropic_spec_keys,
                     )
 
-                    tool_input = translate_to_spec_coordinate_keys(tool_input)
+                    tool_input = translate_to_anthropic_spec_keys(tool_input)
 
                 content.append(
                     AnthropicResponseContentBlock(

--- a/vllm_mlx/api/anthropic_adapter.py
+++ b/vllm_mlx/api/anthropic_adapter.py
@@ -338,6 +338,24 @@ def openai_to_anthropic(
                 except (json.JSONDecodeError, AttributeError):
                     tool_input = {}
 
+                # R6-M2: when the upstream parser is UI-TARS (the only
+                # parser whose ``computer`` tool emits the canonical
+                # ``point`` / ``start_point`` / ``end_point`` keys) the
+                # Anthropic ``tool_use.input`` MUST surface the spec
+                # ``coordinate`` / ``start_coordinate`` / ``end_coordinate``
+                # keys per Anthropic's Computer-Use docs. Anthropic-strict
+                # consumers (claude-agent-sdk, Computer-Use harnesses)
+                # reject the ``point`` shape. Translation is gated on
+                # ``name == "computer"`` so vanilla function tools whose
+                # arguments happen to carry a key named ``point`` are
+                # untouched.
+                if tc.function.name == "computer" and isinstance(tool_input, dict):
+                    from ..tool_parsers.ui_tars_tool_parser import (
+                        translate_to_spec_coordinate_keys,
+                    )
+
+                    tool_input = translate_to_spec_coordinate_keys(tool_input)
+
                 content.append(
                     AnthropicResponseContentBlock(
                         type="tool_use",

--- a/vllm_mlx/api/responses_adapter.py
+++ b/vllm_mlx/api/responses_adapter.py
@@ -534,18 +534,21 @@ def _parse_computer_action(arguments: str) -> dict:
     if "type" not in out:
         return {"type": "unknown", "raw": arguments}
     # R6-M2: OpenAI's Responses Computer-Use spec uses ``coordinate``
-    # for the single-point verbs and ``start_coordinate`` /
-    # ``end_coordinate`` for two-point verbs. The UI-TARS parser emits
-    # the canonical ``point`` / ``start_point`` / ``end_point`` keys
-    # (PR #812 contract — chat-completions OpenAI lane stays on those
-    # for bytes-faithfulness with downstream OpenAI tool_call shape).
-    # Centralized key-mapper lives in the parser module so the
-    # Anthropic + Responses adapters can't drift on key naming.
+    # for the single-point verbs and ``path=[{"x":x,"y":y}, ...]`` for
+    # ``drag`` (two-point). The UI-TARS parser emits the canonical
+    # ``point`` / ``start_point`` / ``end_point`` keys (PR #812
+    # contract — chat-completions OpenAI lane stays on those for
+    # bytes-faithfulness with downstream OpenAI tool_call shape). The
+    # Responses-lane translator folds the point-pair into the spec
+    # ``path`` array shape. Anthropic's lane uses a different drag
+    # shape (``start_coordinate`` + ``coordinate``); the per-lane
+    # translators live next to the parser so the two adapters can't
+    # drift.
     from ..tool_parsers.ui_tars_tool_parser import (
-        translate_to_spec_coordinate_keys,
+        translate_to_responses_spec_keys,
     )
 
-    return translate_to_spec_coordinate_keys(out)
+    return translate_to_responses_spec_keys(out)
 
 
 # ---------------------------------------------------------------------------

--- a/vllm_mlx/api/responses_adapter.py
+++ b/vllm_mlx/api/responses_adapter.py
@@ -533,7 +533,19 @@ def _parse_computer_action(arguments: str) -> dict:
     # back to the sentinel so the dispatcher can detect the gap.
     if "type" not in out:
         return {"type": "unknown", "raw": arguments}
-    return out
+    # R6-M2: OpenAI's Responses Computer-Use spec uses ``coordinate``
+    # for the single-point verbs and ``start_coordinate`` /
+    # ``end_coordinate`` for two-point verbs. The UI-TARS parser emits
+    # the canonical ``point`` / ``start_point`` / ``end_point`` keys
+    # (PR #812 contract — chat-completions OpenAI lane stays on those
+    # for bytes-faithfulness with downstream OpenAI tool_call shape).
+    # Centralized key-mapper lives in the parser module so the
+    # Anthropic + Responses adapters can't drift on key naming.
+    from ..tool_parsers.ui_tars_tool_parser import (
+        translate_to_spec_coordinate_keys,
+    )
+
+    return translate_to_spec_coordinate_keys(out)
 
 
 # ---------------------------------------------------------------------------

--- a/vllm_mlx/reasoning/ui_tars_parser.py
+++ b/vllm_mlx/reasoning/ui_tars_parser.py
@@ -20,21 +20,54 @@ from .base import DeltaMessage, ReasoningParser
 # Anchor at start-of-output so a mid-response mention of "Thought:" inside
 # a user-supplied screenshot caption doesn't get misclassified.
 #
-# Three preamble shapes are recognized (one match per response):
-#   1. "Thought: ...\nAction: ..."         (default UI-TARS prompt)
+# Five preamble shapes are recognized (one match per response):
+#   1. "Thought: ...\nAction: ..."         (default UI-TARS Computer-Use prompt)
 #   2. "Reflection: ...\nAction_Summary: ...\nAction: ..."  (1.5 reflective shape)
 #   3. "Action_Summary: ...\nAction: ..."  (1.5 minimal-reflection shape)
+#   4. "Thought: ...\n\n<plain-chat answer>" (plain chat lane — R6-M1)
+#   5. "<think>...</think><plain-chat answer>"  (generic think-tag fallback — R6-M1)
 #
-# Non-greedy up to the first ``Action:`` literal so a runaway thought
-# trace doesn't swallow the entire response.
+# R6-M1 fix (Aki R1, 2026-06-21): pre-fix the regex required ``(?=\s*Action:)``
+# so shapes #4/#5 silently failed to match. On the plain chat lane (no
+# Computer-Use tool declared, so r5-B's tool-coupled gate skipped the
+# action-API sysprompt injection) the model still emitted ``Thought: ...``
+# preambles — because the UI-TARS checkpoint is post-trained on the format
+# — but the reasoning channel returned ``None``. The decoupling: the
+# reasoning emission gate triggers on the parser-detected preamble shape,
+# NOT on the presence of any auto-injected sysprompt. The Action: lookahead
+# was a coincidence of the C-05 dogfood scenario, not a structural
+# requirement.
+#
+# Boundary semantics:
+# - For shape #1/#2/#3 (Action lane): the rest-after-preamble is consumed
+#   by the tool parser as ``content``.
+# - For shape #4 (plain Thought boundary): the boundary is the first blank
+#   line (``\n\s*\n``) OR end-of-string. Allowing end-of-string handles
+#   the case where the model never emitted a follow-up answer — the entire
+#   buffer is reasoning, ``content`` is empty.
+# - For shape #5 (think-tag): the boundary is the literal ``</think>``.
+#
+# Non-greedy bodies prevent a runaway thought trace from swallowing
+# legitimate downstream content / action lines.
 _PREAMBLE_RE = re.compile(
     r"^\s*"
     r"(?P<thought>"
+    # 1+2+3 — Action-lane preambles. Body up to the ``Action:`` lookahead.
+    r"(?:"
     r"(?:Thought:\s*(?:.*?))"
     r"|(?:Reflection:\s*(?:.*?)\s*Action_Summary:\s*(?:.*?))"
     r"|(?:Action_Summary:\s*(?:.*?))"
-    r")"
-    r"(?=\s*Action:)",
+    r")(?=\s*Action:)"
+    # 4 — plain-chat ``Thought:`` boundary: blank line OR end-of-string.
+    # ``Action:`` would have matched shape #1 already; reaching here
+    # means the model's ``Thought:`` is followed by prose, not a
+    # Computer-Use action.
+    r"|(?:Thought:\s*(?:.*?))(?=\s*\n\s*\n|\s*\Z)"
+    # 5 — generic ``<think>...</think>`` tag. The tag itself is part of
+    # the matched preamble; the post-match content (``model_output[m.end():]``)
+    # is the user-facing answer.
+    r"|(?:<think>\s*(?:.*?)</think>)"
+    r")",
     re.DOTALL,
 )
 
@@ -102,7 +135,20 @@ class UiTarsReasoningParser(ReasoningParser):
             # still extract the actions.
             return None, model_output
 
-        thought = m.group("thought").strip() or None
+        raw_thought = m.group("thought")
+        # R6-M1: shape #5 captures the ``<think>...</think>`` tag wrapper
+        # inside the named group. Strip the structural tags so the
+        # reasoning channel surfaces only the human-readable thought,
+        # matching how every other reasoning parser in the codebase
+        # (qwen3, think_parser, deepseek_r1) handles their own opener
+        # tokens.
+        thought_text = raw_thought
+        if thought_text.lstrip().startswith("<think>"):
+            inner = thought_text.lstrip()[len("<think>") :]
+            if inner.endswith("</think>"):
+                inner = inner[: -len("</think>")]
+            thought_text = inner
+        thought = thought_text.strip() or None
         rest = model_output[m.end() :].lstrip()
         return thought, (rest if rest else None)
 

--- a/vllm_mlx/routes/anthropic.py
+++ b/vllm_mlx/routes/anthropic.py
@@ -2758,10 +2758,10 @@ async def _stream_anthropic_messages(
                 tool_input = {}
 
             # R6-M2: Anthropic Computer-Use spec uses ``coordinate``
-            # for single-point verbs and ``start_coordinate`` /
-            # ``end_coordinate`` for two-point verbs. The UI-TARS
-            # parser emits the canonical ``point`` / ``start_point``
-            # / ``end_point`` keys (PR #812 contract — chat-completions
+            # for single-point verbs and ``start_coordinate`` +
+            # ``coordinate`` (the end) for drag. The UI-TARS parser
+            # emits the canonical ``point`` / ``start_point`` /
+            # ``end_point`` keys (PR #812 contract — chat-completions
             # OpenAI lane stays bytes-faithful to that). Translate on
             # the streaming ``/v1/messages`` boundary so a client
             # correlating non-stream + stream sees the same spec key
@@ -2771,10 +2771,10 @@ async def _stream_anthropic_messages(
             # ``point`` are untouched.
             if tc.function.name == "computer" and isinstance(tool_input, dict):
                 from ..tool_parsers.ui_tars_tool_parser import (
-                    translate_to_spec_coordinate_keys,
+                    translate_to_anthropic_spec_keys,
                 )
 
-                tool_input = translate_to_spec_coordinate_keys(tool_input)
+                tool_input = translate_to_anthropic_spec_keys(tool_input)
 
             # F9: normalize the ``tool_use.id`` once per call. The
             # current loop only references ``tc.id`` inside the

--- a/vllm_mlx/routes/anthropic.py
+++ b/vllm_mlx/routes/anthropic.py
@@ -2757,6 +2757,25 @@ async def _stream_anthropic_messages(
             except (json.JSONDecodeError, AttributeError):
                 tool_input = {}
 
+            # R6-M2: Anthropic Computer-Use spec uses ``coordinate``
+            # for single-point verbs and ``start_coordinate`` /
+            # ``end_coordinate`` for two-point verbs. The UI-TARS
+            # parser emits the canonical ``point`` / ``start_point``
+            # / ``end_point`` keys (PR #812 contract — chat-completions
+            # OpenAI lane stays bytes-faithful to that). Translate on
+            # the streaming ``/v1/messages`` boundary so a client
+            # correlating non-stream + stream sees the same spec key
+            # (the non-stream adapter ``openai_to_anthropic`` applies
+            # the same mapping). Gated on ``name=="computer"`` so
+            # vanilla function tools whose args happen to carry
+            # ``point`` are untouched.
+            if tc.function.name == "computer" and isinstance(tool_input, dict):
+                from ..tool_parsers.ui_tars_tool_parser import (
+                    translate_to_spec_coordinate_keys,
+                )
+
+                tool_input = translate_to_spec_coordinate_keys(tool_input)
+
             # F9: normalize the ``tool_use.id`` once per call. The
             # current loop only references ``tc.id`` inside the
             # ``content_block_start`` event, but if a future patch adds

--- a/vllm_mlx/tool_parsers/ui_tars_tool_parser.py
+++ b/vllm_mlx/tool_parsers/ui_tars_tool_parser.py
@@ -887,13 +887,18 @@ def _trailing_action_prefix_len(text: str) -> int:
     """Return how many trailing bytes of ``text`` could be a prefix of ``Action:``.
 
     Used by the streaming hold-back path. If ``text`` ends with a
-    non-empty strict prefix of the literal ``"Action:"`` token (e.g.
-    ``"...thing.\\nAc"`` → trailing ``"Ac"`` is the 2-byte prefix of
-    ``"Action:"``), return that prefix length so the streaming path
-    can keep those trailing bytes buffered until the next delta
-    resolves the token. Returns 0 if no such overlap exists, OR if
-    ``text`` contains the full ``"Action:"`` token already (in which
-    case the full-action consumer / strict-prefix branch handles it).
+    non-empty strict prefix of the literal ``"Action:"`` token AT A
+    WORD BOUNDARY (the ``_ACTION_LINE`` grammar is anchored on
+    ``\\bAction:``, so the candidate-opener match must start on a
+    word-boundary just like the real action would), return that
+    prefix length so the streaming path can keep those trailing bytes
+    buffered until the next delta resolves the token. Returns 0 if no
+    such overlap exists, OR if ``text`` contains the full ``"Action:"``
+    token already (the full-action consumer / strict-prefix branch
+    handles that), OR if the candidate tail is NOT word-boundary aligned
+    (codex r1 HIGH — pre-fix, trailing prose like ``"Plan A"`` /
+    ``"China"`` held the ``"A"`` / ``"Ac"`` tail incorrectly because
+    the lookahead ignored the preceding char's word-class).
 
     This is the symmetric counterpart to the reasoning parser's
     ``_compute_partial_action_hold`` — same purpose (don't ship a
@@ -914,8 +919,28 @@ def _trailing_action_prefix_len(text: str) -> int:
     # single delta containing ``"....Acti"`` returns 4, not 1.
     max_overlap = len(_ACTION_TOKEN) - 1  # 6 bytes (we already excluded full token)
     for k in range(min(max_overlap, len(text)), 0, -1):
-        if _ACTION_TOKEN.startswith(text[-k:]):
-            return k
+        candidate = text[-k:]
+        if not _ACTION_TOKEN.startswith(candidate):
+            continue
+        # Word-boundary gate: the candidate is the trailing edge of a
+        # potential ``\\bAction:`` match, so the char BEFORE the candidate
+        # must be a non-word char (or the candidate must be at start of
+        # text). Without this gate, ordinary trailing letters in prose —
+        # ``"Plan A"`` (trailing ``"A"``), ``"China"`` (trailing ``"a"``
+        # which isn't a prefix of ``Action:`` so doesn't trigger here, but
+        # consider ``"banana"`` where the trailing ``"a"`` IS a prefix of
+        # ``Actio**n**:``... no, ``"a"`` is NOT a prefix of ``"Action:"``,
+        # but ``"A"`` is) hold incorrectly, adding latency and risking
+        # downstream consumer cues. By requiring word-boundary alignment
+        # we restrict the hold to the genuine action-opener candidate.
+        if len(text) > k:
+            prev_char = text[-k - 1]
+            # Word boundary: prev_char is non-word (matches Python re's
+            # \\b definition — word chars are [a-zA-Z0-9_]).
+            if prev_char.isalnum() or prev_char == "_":
+                continue
+        # Either prev_char is non-word OR candidate is at start of text.
+        return k
     return 0
 
 
@@ -958,59 +983,130 @@ def _iter_actions(text: str) -> list[tuple[int, int, str, dict[str, Any]]]:
     return actions
 
 
-# Spec-key translation map for the Anthropic ``/v1/messages`` and OpenAI
+# Spec-key translation maps for the Anthropic ``/v1/messages`` and OpenAI
 # ``/v1/responses`` lanes. The UI-TARS parser emits its CANONICAL key set
 # (``point`` / ``start_point`` / ``end_point``) so the chat-completions
 # lane stays bytes-faithful to PR #812's contract; the adapters then
 # remap to each spec's documented key.
 #
-# Anthropic Computer-Use spec
-# (https://docs.anthropic.com/en/docs/agents-and-tools/computer-use):
-# ``coordinate=[x, y]`` for single-point verbs; two-point verbs are
-# expressed via separate ``start_coordinate`` / ``end_coordinate``
-# fields (matches the spec's ``screenshot`` / ``cursor_position`` shape).
+# Anthropic Computer-Use spec (https://platform.claude.com/docs/en/agents-
+# and-tools/tool-use/computer-use-tool): ``coordinate=[x, y]`` for
+# single-point verbs (``click`` / ``scroll`` / …); two-point ``drag``
+# uses ``start_coordinate`` plus ``coordinate`` (the end). We surface
+# both as ``start_coordinate`` + ``coordinate`` per spec.
 #
 # OpenAI Responses Computer-Use spec
-# (https://platform.openai.com/docs/api-reference/responses-streaming/output_item):
+# (https://developers.openai.com/api/docs/guides/tools-computer-use):
 # ``computer_call.action.coordinate=[x, y]`` for single-point; two-point
-# ``drag`` action uses ``path=[{x, y}, ...]`` — but a pragmatic translation
-# emits ``start_coordinate`` / ``end_coordinate`` mirroring the Anthropic
-# shape so a single key-mapper covers both surfaces. The Responses lane
-# would otherwise have NO drag shape because the parser emits the
-# Anthropic-compatible point-pair, not OpenAI's path list. Centralized
+# ``drag`` action uses ``path=[{"x": x, "y": y}, ...]`` (start, end as
+# a 2-element path). Cross-lane shape divergence is real — the two
+# Computer-Use specs don't share a drag wire format, so the single
+# key-mapping pass below has lane-specific drag handling. Centralized
 # here so the two adapters can't drift on key naming.
+
+# Single-point key rename (shared across Anthropic + Responses). The
+# UI-TARS-native ``point`` → spec ``coordinate``. ``start_point`` /
+# ``end_point`` are intentionally OMITTED from this map because the
+# two-point handling is lane-aware (see ``translate_to_*`` helpers).
 _UI_TARS_TO_SPEC_KEY_MAP: dict[str, str] = {
     "point": "coordinate",
-    "start_point": "start_coordinate",
-    "end_point": "end_coordinate",
 }
 
 
-def translate_to_spec_coordinate_keys(args: dict[str, Any]) -> dict[str, Any]:
-    """Translate UI-TARS canonical coord keys to Anthropic/Responses spec keys.
+def translate_to_anthropic_spec_keys(args: dict[str, Any]) -> dict[str, Any]:
+    """Translate UI-TARS canonical coord keys to Anthropic spec keys.
 
-    The parser output (``arguments`` JSON for the ``computer`` tool call)
-    uses UI-TARS native keys ``point`` / ``start_point`` / ``end_point``
-    because that's the contract PR #812 documented and the chat-completions
-    OpenAI lane is already on. But the Anthropic ``/v1/messages`` lane
-    (``tool_use.input``) and the OpenAI ``/v1/responses`` lane
-    (``computer_call.action``) both follow specs that use ``coordinate``
-    (and ``start_coordinate`` / ``end_coordinate`` for two-point verbs).
+    Anthropic Computer-Use spec:
+    - single-point verbs (``click`` / ``scroll`` / …): ``coordinate=[x,y]``
+    - two-point ``drag`` (and aliases): ``start_coordinate=[x,y]`` plus
+      ``coordinate=[x,y]`` (the spec uses ``coordinate`` for the END
+      point of a drag, not ``end_coordinate``).
 
-    Returns a shallow-copied dict with the keys remapped per
-    ``_UI_TARS_TO_SPEC_KEY_MAP``; non-coord keys (``action``, ``content``,
-    ``key``, ``direction``, …) pass through verbatim. Caller mutates only
-    the copy.
+    The parser emits ``point`` / ``start_point`` / ``end_point``; this
+    helper renames per the above. Non-coord kwargs (``action``,
+    ``content``, ``key``, ``direction``, …) pass through verbatim.
+    Returns a fresh dict; caller mutates only the copy.
 
     Idempotent: applying twice produces the same result (already-translated
-    keys aren't in the map and are passed through).
+    keys aren't in the renames and pass through unchanged).
     """
     if not args:
         return args
     out: dict[str, Any] = {}
     for k, v in args.items():
-        out[_UI_TARS_TO_SPEC_KEY_MAP.get(k, k)] = v
+        if k == "point":
+            out["coordinate"] = v
+        elif k == "start_point":
+            out["start_coordinate"] = v
+        elif k == "end_point":
+            # Anthropic's spec uses ``coordinate`` for the drag END.
+            out["coordinate"] = v
+        else:
+            out[k] = v
     return out
+
+
+def translate_to_responses_spec_keys(args: dict[str, Any]) -> dict[str, Any]:
+    """Translate UI-TARS canonical coord keys to OpenAI Responses spec keys.
+
+    OpenAI Responses Computer-Use spec:
+    - single-point verbs (``click`` / ``scroll`` / …): ``coordinate=[x,y]``
+    - two-point ``drag``: ``path=[{"x": x1, "y": y1}, {"x": x2, "y": y2}]``
+      (the spec uses an array of ``{x, y}`` objects, not separate
+      ``start_coordinate`` / ``end_coordinate`` fields).
+
+    The parser emits ``point`` / ``start_point`` / ``end_point``; this
+    helper folds ``start_point`` + ``end_point`` into the spec ``path``
+    array when both are present. Defensive: if only one of the two is
+    present (malformed drag), the present key falls through as the
+    UI-TARS-native name so the downstream consumer can detect the
+    incomplete shape and surface a clear error rather than emit a
+    truncated single-element path that looks valid.
+
+    Non-coord kwargs pass through verbatim.
+
+    Idempotent on the single-point ``point → coordinate`` rename.
+    NOT idempotent on the two-point ``start_point + end_point → path``
+    fold (applying twice on the already-folded shape would emit just
+    the ``path`` key, which is correct). The two-point fold is only
+    safe to run ONCE per parser output.
+    """
+    if not args:
+        return args
+    out: dict[str, Any] = {}
+    sp = args.get("start_point")
+    ep = args.get("end_point")
+    folded_path = False
+    if (
+        isinstance(sp, (list, tuple))
+        and isinstance(ep, (list, tuple))
+        and (len(sp) >= 2 and len(ep) >= 2)
+    ):
+        # Fold the point pair into the Responses ``path`` array per spec.
+        out["path"] = [
+            {"x": sp[0], "y": sp[1]},
+            {"x": ep[0], "y": ep[1]},
+        ]
+        folded_path = True
+    for k, v in args.items():
+        if k == "point":
+            out["coordinate"] = v
+        elif k in ("start_point", "end_point"):
+            if folded_path:
+                continue  # consumed into ``path``
+            # Malformed drag — surface the present key verbatim so the
+            # downstream consumer can detect the shape gap.
+            out[k] = v
+        else:
+            out[k] = v
+    return out
+
+
+# Legacy alias preserved for any external callers that import the
+# pre-codex-review symbol; the Anthropic translator IS the canonical
+# behavior for shared single-point cases. Slated for removal after a
+# deprecation cycle.
+translate_to_spec_coordinate_keys = translate_to_anthropic_spec_keys
 
 
 @ToolParserManager.register_module(["ui_tars", "ui-tars", "uitars"])
@@ -1159,21 +1255,45 @@ class UiTarsToolParser(ToolParser):
             # window; the next delta that resolves the token (either
             # by completing ``Action:`` or by emitting a disambiguating
             # byte) releases them through the appropriate channel.
-            held = _trailing_action_prefix_len(current_text)
-            if held == 0:
-                return {"content": delta_text}
-            # Compute how much of THIS delta is in the held window vs.
-            # the safely-emittable prefix.
-            delta_start_in_current = len(previous_text)
-            held_window_start = len(current_text) - held
-            if held_window_start <= delta_start_in_current:
-                # Every byte of this delta is in the partial-opener
-                # window — emit nothing. The reasoning-parser side
-                # already buffered any prior held prefix bytes; the
-                # next disambiguating delta releases them all.
+            #
+            # codex r1 BLOCKING — replay any previously-held bytes that
+            # are no longer candidate-opener. Pre-fix, a stream like
+            # ``["Ac", "me"]`` would hold ``"Ac"`` on delta 1 (returns
+            # None) then on delta 2 emit only ``"me"`` — the held ``"Ac"``
+            # was permanently dropped because the streaming parser is
+            # stateless across calls. Fix: compare the prefix-window of
+            # ``previous_text`` (what was held last time) with the
+            # prefix-window of ``current_text`` (what remains held now).
+            # Bytes that fall OUT of the held window between calls must
+            # be replayed as content alongside this delta.
+            # Compute the "emit window" for this delta. Every byte of
+            # ``current_text`` is in exactly one of three buckets:
+            #
+            # 1. Already-emitted   : ``current_text[:prev_safe_end]``
+            #    — the prefix that prior calls flushed as content.
+            # 2. Emit-this-turn    : ``current_text[prev_safe_end:cur_safe_end]``
+            #    — what this call returns.
+            # 3. Still-held        : ``current_text[cur_safe_end:]``
+            #    — the trailing partial-opener candidate to release later.
+            #
+            # ``prev_safe_end = len(previous_text) - prev_held`` is the
+            # offset up to which prior calls emitted (everything they
+            # held back lives in bucket 3 or 2 of THIS call).
+            # ``cur_safe_end = len(current_text) - cur_held`` is the
+            # offset up to which it's safe to emit now (bytes after that
+            # are this call's still-held tail).
+            cur_held = _trailing_action_prefix_len(current_text)
+            prev_held = (
+                _trailing_action_prefix_len(previous_text) if previous_text else 0
+            )
+            prev_safe_end = len(previous_text) - prev_held
+            cur_safe_end = len(current_text) - cur_held
+            if cur_safe_end <= prev_safe_end:
+                # Held window grew (or stayed the same) — nothing new
+                # to emit this delta. Postprocessor's per-event buffer
+                # keeps the bytes until a future delta resolves them.
                 return None
-            split = held_window_start - delta_start_in_current
-            return {"content": delta_text[:split]}
+            return {"content": current_text[prev_safe_end:cur_safe_end]}
 
         prev_actions = _iter_actions(previous_text) if previous_text else []
         cur_actions = _iter_actions(current_text)

--- a/vllm_mlx/tool_parsers/ui_tars_tool_parser.py
+++ b/vllm_mlx/tool_parsers/ui_tars_tool_parser.py
@@ -411,6 +411,21 @@ _KNOWN_VERBS: frozenset[str] = frozenset(
 # parens inside string args.
 _ACTION_LINE = re.compile(r"\bAction:\s*([A-Za-z_][A-Za-z0-9_]*)\s*\(", re.MULTILINE)
 
+# Bare ``Action:`` token marker (no verb / paren required). Used by the
+# streaming hold-back path to detect that an in-flight delta has STARTED
+# the action prefix even though the verb/parens haven't arrived yet.
+# Without this, ``has_pending_tool_call("Action: type")`` returned False
+# (the strict ``_ACTION_LINE`` regex needs ``(``) and the postprocessor
+# fast-path leaked the bare ``Action: <verb>`` bytes into ``delta.content``
+# BEFORE the structured ``tool_calls`` flush (R6-C3, dogfood-087/R2-6).
+_ACTION_PREFIX = re.compile(r"\bAction:", re.MULTILINE)
+
+# Sentinel string the streaming parser hangs onto when a trailing
+# delta tail is a STRICT prefix of ``Action:``. e.g. delta ends with
+# ``"\nActi"`` → could become ``"\nAction:"`` on the next chunk, so we
+# hold back those 4 bytes rather than leaking them as ``content``.
+_ACTION_TOKEN = "Action:"
+
 # Reasoning-channel preamble at the start of a UI-TARS response. When the
 # tool parser is run on its own (no separate reasoning parser configured),
 # we strip this preamble out of ``content`` so the same chain-of-thought
@@ -868,6 +883,42 @@ def _normalize_action(verb: str, kwargs: dict[str, Any]) -> dict[str, Any]:
     return out
 
 
+def _trailing_action_prefix_len(text: str) -> int:
+    """Return how many trailing bytes of ``text`` could be a prefix of ``Action:``.
+
+    Used by the streaming hold-back path. If ``text`` ends with a
+    non-empty strict prefix of the literal ``"Action:"`` token (e.g.
+    ``"...thing.\\nAc"`` → trailing ``"Ac"`` is the 2-byte prefix of
+    ``"Action:"``), return that prefix length so the streaming path
+    can keep those trailing bytes buffered until the next delta
+    resolves the token. Returns 0 if no such overlap exists, OR if
+    ``text`` contains the full ``"Action:"`` token already (in which
+    case the full-action consumer / strict-prefix branch handles it).
+
+    This is the symmetric counterpart to the reasoning parser's
+    ``_compute_partial_action_hold`` — same purpose (don't ship a
+    candidate-opener prefix until disambiguation), but operates on the
+    tool-parser side of the hand-off so a leak that snuck past the
+    reasoning parser's gate (e.g. via the postprocessor's fast-path
+    short-circuit on ``<``/``[``-free deltas) is still suppressed.
+    """
+    if not text:
+        return 0
+    # If the full token is already present anywhere in the buffer,
+    # the strict-prefix check is moot — the streaming consumer should
+    # handle the completed-action accounting and emit the residual.
+    if _ACTION_TOKEN in text:
+        return 0
+    # Longest non-empty suffix of ``text`` that matches a strict prefix
+    # of ``_ACTION_TOKEN``. We scan from longest-to-shortest so that a
+    # single delta containing ``"....Acti"`` returns 4, not 1.
+    max_overlap = len(_ACTION_TOKEN) - 1  # 6 bytes (we already excluded full token)
+    for k in range(min(max_overlap, len(text)), 0, -1):
+        if _ACTION_TOKEN.startswith(text[-k:]):
+            return k
+    return 0
+
+
 def _iter_actions(text: str) -> list[tuple[int, int, str, dict[str, Any]]]:
     """Find every ``Action: verb(...)`` block in left-to-right order.
 
@@ -905,6 +956,61 @@ def _iter_actions(text: str) -> list[tuple[int, int, str, dict[str, Any]]]:
         actions.append((m.start(), close + 1, verb, kwargs))
         cursor = close + 1
     return actions
+
+
+# Spec-key translation map for the Anthropic ``/v1/messages`` and OpenAI
+# ``/v1/responses`` lanes. The UI-TARS parser emits its CANONICAL key set
+# (``point`` / ``start_point`` / ``end_point``) so the chat-completions
+# lane stays bytes-faithful to PR #812's contract; the adapters then
+# remap to each spec's documented key.
+#
+# Anthropic Computer-Use spec
+# (https://docs.anthropic.com/en/docs/agents-and-tools/computer-use):
+# ``coordinate=[x, y]`` for single-point verbs; two-point verbs are
+# expressed via separate ``start_coordinate`` / ``end_coordinate``
+# fields (matches the spec's ``screenshot`` / ``cursor_position`` shape).
+#
+# OpenAI Responses Computer-Use spec
+# (https://platform.openai.com/docs/api-reference/responses-streaming/output_item):
+# ``computer_call.action.coordinate=[x, y]`` for single-point; two-point
+# ``drag`` action uses ``path=[{x, y}, ...]`` — but a pragmatic translation
+# emits ``start_coordinate`` / ``end_coordinate`` mirroring the Anthropic
+# shape so a single key-mapper covers both surfaces. The Responses lane
+# would otherwise have NO drag shape because the parser emits the
+# Anthropic-compatible point-pair, not OpenAI's path list. Centralized
+# here so the two adapters can't drift on key naming.
+_UI_TARS_TO_SPEC_KEY_MAP: dict[str, str] = {
+    "point": "coordinate",
+    "start_point": "start_coordinate",
+    "end_point": "end_coordinate",
+}
+
+
+def translate_to_spec_coordinate_keys(args: dict[str, Any]) -> dict[str, Any]:
+    """Translate UI-TARS canonical coord keys to Anthropic/Responses spec keys.
+
+    The parser output (``arguments`` JSON for the ``computer`` tool call)
+    uses UI-TARS native keys ``point`` / ``start_point`` / ``end_point``
+    because that's the contract PR #812 documented and the chat-completions
+    OpenAI lane is already on. But the Anthropic ``/v1/messages`` lane
+    (``tool_use.input``) and the OpenAI ``/v1/responses`` lane
+    (``computer_call.action``) both follow specs that use ``coordinate``
+    (and ``start_coordinate`` / ``end_coordinate`` for two-point verbs).
+
+    Returns a shallow-copied dict with the keys remapped per
+    ``_UI_TARS_TO_SPEC_KEY_MAP``; non-coord keys (``action``, ``content``,
+    ``key``, ``direction``, …) pass through verbatim. Caller mutates only
+    the copy.
+
+    Idempotent: applying twice produces the same result (already-translated
+    keys aren't in the map and are passed through).
+    """
+    if not args:
+        return args
+    out: dict[str, Any] = {}
+    for k, v in args.items():
+        out[_UI_TARS_TO_SPEC_KEY_MAP.get(k, k)] = v
+    return out
 
 
 @ToolParserManager.register_module(["ui_tars", "ui-tars", "uitars"])
@@ -1043,7 +1149,31 @@ class UiTarsToolParser(ToolParser):
         if _is_tool_choice_none(request):
             return {"content": delta_text}
         if "Action:" not in current_text:
-            return {"content": delta_text}
+            # R6-C3 hold-back: the trailing bytes of ``current_text``
+            # might be a STRICT prefix of the ``Action:`` token (e.g.
+            # ``current_text`` ends with ``"\nAc"``). If we emit
+            # ``delta_text`` verbatim those candidate-opener bytes leak
+            # into ``delta.content`` BEFORE the structured tool_calls
+            # flush — the dogfood R2-6 leak. Hold back any trailing
+            # bytes of THIS delta that fall inside the partial-opener
+            # window; the next delta that resolves the token (either
+            # by completing ``Action:`` or by emitting a disambiguating
+            # byte) releases them through the appropriate channel.
+            held = _trailing_action_prefix_len(current_text)
+            if held == 0:
+                return {"content": delta_text}
+            # Compute how much of THIS delta is in the held window vs.
+            # the safely-emittable prefix.
+            delta_start_in_current = len(previous_text)
+            held_window_start = len(current_text) - held
+            if held_window_start <= delta_start_in_current:
+                # Every byte of this delta is in the partial-opener
+                # window — emit nothing. The reasoning-parser side
+                # already buffered any prior held prefix bytes; the
+                # next disambiguating delta releases them all.
+                return None
+            split = held_window_start - delta_start_in_current
+            return {"content": delta_text[:split]}
 
         prev_actions = _iter_actions(previous_text) if previous_text else []
         cur_actions = _iter_actions(current_text)
@@ -1106,18 +1236,60 @@ class UiTarsToolParser(ToolParser):
         return result
 
     def has_pending_tool_call(self, text: str) -> bool:
-        """Return True if text contains an unfinished ``Action: verb(`` block.
+        """Return True if text contains (or could complete to) an unfinished action.
 
-        The ``finalize()`` postprocessor uses this to decide whether to
-        hold delta bytes back vs. flush them as content at end-of-stream.
-        For UI-TARS we conservatively say "pending" iff an ``Action:``
-        token appears with no balanced ``)`` after it — that's the only
-        case where a late-arriving byte could change parser output.
+        Used by the streaming postprocessor's fast-path: when ``False``
+        the postprocessor short-circuits the delta into ``content``;
+        when ``True`` the full streaming path is engaged so the parser
+        can buffer / suppress / emit structured ``tool_calls`` instead
+        of leaking raw bytes.
+
+        Pre-r6-B contract was "Action: verb( with no balanced )" only.
+        The R6-C3 dogfood leak (R2-6) showed that an in-flight delta
+        carrying the bare ``Action: <verb>`` token (no ``(`` yet) hit
+        the False arm and leaked into ``delta.content`` BEFORE the
+        structured ``tool_calls`` arrived. Tightened contract — three
+        cases now return True:
+
+        1. The strict ``_ACTION_LINE`` regex (``Action: verb(``) matched
+           and has no balanced close — the original case.
+        2. The bare ``Action:`` token appears in ``text`` (verb /
+           parens not yet emitted) — a few more decode steps will
+           complete the action signature, so hold the buffer.
+        3. ``text`` ends with a non-empty STRICT prefix of ``Action:``
+           (e.g. ``"...thing.\\nAc"``) — the next delta might land the
+           rest of the token, so the trailing bytes must NOT be flushed
+           through the fast-path; the streaming parser's hold-back
+           logic clips them.
+
+        Pure-False only when the buffer has no in-flight action signal
+        and no trailing partial-opener candidate.
         """
-        if "Action:" not in text:
-            return False
+        # Case 1: full ``Action: verb(`` line whose ``)`` hasn't arrived.
+        # Note: when an action HAS completed (balanced close found) we
+        # still return False here — the streaming consumer will surface
+        # the completed tool_call on the next delta-resolving step; we
+        # don't claim "pending" for an already-resolved action.
+        line_starts: list[int] = []
         for m in _ACTION_LINE.finditer(text):
+            line_starts.append(m.start())
             close = _find_balanced_close(text, m.end())
             if close == -1:
                 return True
-        return False
+        # Case 2: bare ``Action:`` token whose verb / open-paren hasn't
+        # arrived yet (i.e. an ``Action:`` occurrence that is NOT the
+        # head of any matched ``_ACTION_LINE``). The classic dogfood
+        # leak shape is ``"Action: type"`` where the ``(`` is in a
+        # pending decode step — the postprocessor's fast-path used
+        # to short-circuit the delta as plain ``content`` because
+        # ``_ACTION_LINE.search`` requires the open paren. Holding
+        # the buffer keeps the bare prefix bytes off the wire until
+        # the verb + body resolve on subsequent deltas.
+        for pm in _ACTION_PREFIX.finditer(text):
+            if pm.start() not in line_starts:
+                return True
+        # Case 3: trailing strict-prefix of ``Action:`` at the buffer
+        # tail (e.g. ``"...end.\\nAc"``). Holding back keeps the
+        # candidate-opener bytes off the wire until the next delta
+        # either completes the token or disambiguates them as content.
+        return _trailing_action_prefix_len(text) > 0

--- a/vllm_mlx/tool_parsers/ui_tars_tool_parser.py
+++ b/vllm_mlx/tool_parsers/ui_tars_tool_parser.py
@@ -944,6 +944,134 @@ def _trailing_action_prefix_len(text: str) -> int:
     return 0
 
 
+def _safe_emit_end(text: str) -> int:
+    """Return the offset up to which bytes of ``text`` are safe to flush as content.
+
+    This is the unified hold-back computation used by the streaming
+    parser. Every byte in ``text[:safe_end]`` has been "resolved" —
+    either it's plain prose (no in-flight action signal touches it) or
+    it's a fully-completed ``Action: verb(...)`` line whose
+    ``_iter_actions`` path will surface as a structured tool_call. Every
+    byte in ``text[safe_end:]`` is HELD because:
+
+    * it's part of an in-flight ``Action: verb(`` whose balanced close
+      hasn't arrived yet (the ``_iter_actions`` path won't emit until
+      then), OR
+    * it's a bare ``Action:`` whose verb / paren is in a pending
+      decode step (signature still consistent), OR
+    * it's a trailing strict-prefix of the literal ``Action:`` token at
+      the buffer tail (e.g. ``"...thing.\\nAc"``).
+
+    Returns ``len(text)`` when no in-flight signal is present — every
+    byte is safe to flush. Codex r2 BLOCKING — this collapses the
+    previously-divergent "Action: in text" and "Action: not in text"
+    branches into one rule, closing the data-loss case where a bare
+    ``Action:`` followed by non-signature prose
+    (``"Action: is required."``, ``["Act", "ion: item"]``) held the
+    bytes indefinitely and never flushed.
+    """
+    n = len(text)
+    in_flight_starts: list[int] = []
+    # Walk every ``Action:`` occurrence in left-to-right order. For each:
+    # decide whether the post-``Action:`` tail could complete a real
+    # action signature (``\\s*[A-Za-z_][A-Za-z0-9_]*\\s*\\(``). When it
+    # could AND no balanced close has arrived yet, hold from that
+    # occurrence onward. When it can't, the occurrence is plain prose —
+    # ignore it.
+    for m in _ACTION_PREFIX.finditer(text):
+        # Resolve whether this ``Action:`` has a verb+paren+close
+        # already. The ``_ACTION_LINE`` regex requires the verb-paren
+        # signature; check if THIS offset matches.
+        line_match = _ACTION_LINE.match(text, m.start())
+        if line_match is not None:
+            close = _find_balanced_close(text, line_match.end())
+            if close == -1:
+                # In-flight action — verb and paren present but body
+                # still streaming. Hold from this start offset.
+                in_flight_starts.append(m.start())
+            # else: completed action — ``_iter_actions`` will surface
+            # this; don't claim it as "held".
+            continue
+        # No ``_ACTION_LINE`` match here. Check whether the bare token
+        # could still complete to one.
+        if _action_signature_could_complete(text, m.end()):
+            in_flight_starts.append(m.start())
+        # else: bare ``Action:`` followed by non-signature prose. Codex
+        # r2 fix — pre-fix, ALL bare-Action: occurrences were treated
+        # as held; with the signature gate, a non-completing one is
+        # plain content and doesn't constrain the safe-end.
+    if in_flight_starts:
+        # Hold from the earliest in-flight action's start offset.
+        return min(in_flight_starts)
+    # No in-flight action signal — the only hold candidate is the
+    # trailing strict-prefix of ``Action:`` at the buffer tail.
+    return n - _trailing_action_prefix_len(text)
+
+
+def _action_signature_could_complete(text: str, action_end: int) -> bool:
+    """Return True if the tail starting at ``action_end`` could still
+    complete a valid ``Action: verb(`` signature.
+
+    ``action_end`` is the index immediately AFTER the ``Action:`` token
+    in ``text``. The grammar after that point is::
+
+        \\s*           — optional leading whitespace
+        [A-Za-z_]      — verb ident start (one char)
+        [A-Za-z0-9_]*  — verb ident continuation
+        \\s*           — optional whitespace before paren
+        \\(            — open paren commits to the call
+
+    Codex r2 BLOCKING — the prior streaming path treated EVERY ``Action:``
+    occurrence as "in-flight action, hold the buffer." Streams like
+    ``["Act", "ion: item"]`` (verb-like ``item`` but never a paren, so
+    real prose ``"Action: item"``) and ``["Action: is required."]`` had
+    the bytes held indefinitely and dropped because no ``tool_calls``
+    ever fired and no content-release path executed.
+
+    Three exit states:
+
+    * **Consistent + still possible** — every char examined so far
+      respects the grammar AND we haven't seen the ``(`` yet → hold.
+    * **Consistent + complete** — we saw ``(`` (the full signature
+      committed) → hold (the existing ``_iter_actions`` path will pick
+      it up on a future delta when the balanced ``)`` arrives).
+    * **Inconsistent** — a char violates the grammar (e.g. a
+      whitespace WITHIN the verb-ident, a non-ident-non-paren char
+      after the ident, …) → DEFINITELY-NOT-an-action. Return False so
+      the caller can flush the bytes as plain content.
+
+    Reaching end-of-text in a consistent state still returns True (the
+    next delta might land the missing chars).
+    """
+    n = len(text)
+    i = action_end
+    # Phase 1: leading whitespace.
+    while i < n and text[i].isspace():
+        i += 1
+    if i >= n:
+        return True  # still consistent, waiting for verb start
+    # Phase 2: first verb-ident char.
+    if not (text[i].isalpha() or text[i] == "_"):
+        return False  # e.g. ``Action: 1foo(``, ``Action: is...`` (passes here),
+        # ``Action: !`` — wait, ``is`` starts with ``i`` (alpha) so it does pass
+        # phase 2. The disambiguation happens in phase 4 below.
+    i += 1
+    # Phase 3: verb-ident continuation.
+    while i < n and (text[i].isalnum() or text[i] == "_"):
+        i += 1
+    if i >= n:
+        return True  # still consistent, ident might continue or end
+    # Phase 4: optional whitespace then ``(``. Any other char rules out
+    # the action signature — e.g. ``Action: is required.`` reaches here
+    # with i pointing at ``" "`` (the space after ``"is"``), then we'd
+    # consume the whitespace and find ``"required"`` — NOT ``(``.
+    while i < n and text[i].isspace():
+        i += 1
+    if i >= n:
+        return True  # waiting for ``(``
+    return text[i] == "("
+
+
 def _iter_actions(text: str) -> list[tuple[int, int, str, dict[str, Any]]]:
     """Find every ``Action: verb(...)`` block in left-to-right order.
 
@@ -1244,62 +1372,42 @@ class UiTarsToolParser(ToolParser):
         """
         if _is_tool_choice_none(request):
             return {"content": delta_text}
-        if "Action:" not in current_text:
-            # R6-C3 hold-back: the trailing bytes of ``current_text``
-            # might be a STRICT prefix of the ``Action:`` token (e.g.
-            # ``current_text`` ends with ``"\nAc"``). If we emit
-            # ``delta_text`` verbatim those candidate-opener bytes leak
-            # into ``delta.content`` BEFORE the structured tool_calls
-            # flush — the dogfood R2-6 leak. Hold back any trailing
-            # bytes of THIS delta that fall inside the partial-opener
-            # window; the next delta that resolves the token (either
-            # by completing ``Action:`` or by emitting a disambiguating
-            # byte) releases them through the appropriate channel.
-            #
-            # codex r1 BLOCKING — replay any previously-held bytes that
-            # are no longer candidate-opener. Pre-fix, a stream like
-            # ``["Ac", "me"]`` would hold ``"Ac"`` on delta 1 (returns
-            # None) then on delta 2 emit only ``"me"`` — the held ``"Ac"``
-            # was permanently dropped because the streaming parser is
-            # stateless across calls. Fix: compare the prefix-window of
-            # ``previous_text`` (what was held last time) with the
-            # prefix-window of ``current_text`` (what remains held now).
-            # Bytes that fall OUT of the held window between calls must
-            # be replayed as content alongside this delta.
-            # Compute the "emit window" for this delta. Every byte of
-            # ``current_text`` is in exactly one of three buckets:
-            #
-            # 1. Already-emitted   : ``current_text[:prev_safe_end]``
-            #    — the prefix that prior calls flushed as content.
-            # 2. Emit-this-turn    : ``current_text[prev_safe_end:cur_safe_end]``
-            #    — what this call returns.
-            # 3. Still-held        : ``current_text[cur_safe_end:]``
-            #    — the trailing partial-opener candidate to release later.
-            #
-            # ``prev_safe_end = len(previous_text) - prev_held`` is the
-            # offset up to which prior calls emitted (everything they
-            # held back lives in bucket 3 or 2 of THIS call).
-            # ``cur_safe_end = len(current_text) - cur_held`` is the
-            # offset up to which it's safe to emit now (bytes after that
-            # are this call's still-held tail).
-            cur_held = _trailing_action_prefix_len(current_text)
-            prev_held = (
-                _trailing_action_prefix_len(previous_text) if previous_text else 0
-            )
-            prev_safe_end = len(previous_text) - prev_held
-            cur_safe_end = len(current_text) - cur_held
-            if cur_safe_end <= prev_safe_end:
-                # Held window grew (or stayed the same) — nothing new
-                # to emit this delta. Postprocessor's per-event buffer
-                # keeps the bytes until a future delta resolves them.
-                return None
-            return {"content": current_text[prev_safe_end:cur_safe_end]}
+
+        # R6-C3 / codex r1+r2 unified hold-back: ``_safe_emit_end``
+        # collapses the "Action: in text" and "Action: not in text"
+        # branches into one rule. Every byte of ``current_text`` is in
+        # exactly one of three buckets relative to the streaming
+        # contract:
+        #
+        # 1. Already-emitted : ``current_text[:prev_safe_end]``  — the
+        #    prefix prior calls flushed as content.
+        # 2. Emit-this-turn  : ``current_text[prev_safe_end:cur_safe_end]``
+        #    — what this call returns as ``content``.
+        # 3. Still-held      : ``current_text[cur_safe_end:]``  — the
+        #    in-flight ``Action:`` body / trailing partial-opener
+        #    candidate to release on a future delta.
+        #
+        # Plus the orthogonal ``tool_calls`` channel: when one or more
+        # actions COMPLETED in ``current_text`` since ``previous_text``,
+        # emit them; their byte span is folded into bucket 2 of the
+        # safe-end computation so the residual content slice excludes
+        # the action body.
+        cur_safe_end = _safe_emit_end(current_text)
+        prev_safe_end = _safe_emit_end(previous_text) if previous_text else 0
 
         prev_actions = _iter_actions(previous_text) if previous_text else []
         cur_actions = _iter_actions(current_text)
 
         if len(cur_actions) <= len(prev_actions):
-            return None
+            # No new tool_call this turn. Emit any newly-resolved
+            # content bytes (codex r2 BLOCKING — release bytes when
+            # the safe-end advances even with ``Action:`` in the
+            # buffer; the pre-r2 code unconditionally returned None
+            # whenever a bare ``Action:`` was present, dropping prose
+            # like ``"Action: is required."``).
+            if cur_safe_end <= prev_safe_end:
+                return None
+            return {"content": current_text[prev_safe_end:cur_safe_end]}
 
         new_actions = cur_actions[len(prev_actions) :]
         tool_calls = []
@@ -1413,3 +1521,36 @@ class UiTarsToolParser(ToolParser):
         # candidate-opener bytes off the wire until the next delta
         # either completes the token or disambiguates them as content.
         return _trailing_action_prefix_len(text) > 0
+
+    def flush_held_content(self, full_text: str) -> str:
+        """Return the suffix of ``full_text`` still held at end-of-stream.
+
+        The streaming parser holds bytes whenever a bare ``Action:``
+        token (or its trailing prefix) is in flight — those bytes might
+        be the start of a real ``Action: verb(...)`` call OR plain prose
+        like ``"Action: is required."``. Mid-stream the parser can't
+        decide; at end-of-stream the parser KNOWS no further tokens are
+        coming, so the held tail is by definition plain content and
+        must be flushed.
+
+        Codex r2 BLOCKING — pre-fix, a stream ending on
+        ``["Act", "ion: item"]`` held the entire ``"Action: item"`` and
+        the postprocessor never received those bytes (no tool_call
+        fired, no content event ever flushed). The postprocessor's
+        ``finalize()`` calls this method to drain the held suffix; we
+        return ``full_text[safe_end:]`` so the SSE stream's final
+        content event carries the leaked bytes verbatim.
+
+        Returns the empty string when nothing is held — the default
+        contract from ``abstract_tool_parser``.
+        """
+        if not full_text:
+            return ""
+        safe_end = _safe_emit_end(full_text)
+        # If any action COMPLETED in the buffer, ``extract_tool_calls``
+        # is the right path — the route's finalize path checks
+        # ``has_pending_tool_call`` first. We only flush genuinely-held
+        # bytes (the strict tail past the safe-end).
+        if safe_end >= len(full_text):
+            return ""
+        return full_text[safe_end:]

--- a/vllm_mlx/tool_parsers/ui_tars_tool_parser.py
+++ b/vllm_mlx/tool_parsers/ui_tars_tool_parser.py
@@ -1425,37 +1425,37 @@ class UiTarsToolParser(ToolParser):
                 }
             )
 
-        # codex r2 BLOCKING #1: a single delta can contain a completed
-        # action plus trailing/leading non-action text — e.g. delta
-        # ``Action: wait() done`` where `` done`` is regular content the
-        # model emitted after the action. Without explicit handling, the
-        # original implementation only returned ``{"tool_calls": ...}``
-        # and the trailing bytes were silently dropped from the response.
+        # codex r2 BLOCKING #1 + codex r3 BLOCKING — a single delta can
+        # contain a completed action plus trailing/leading non-action
+        # text — e.g. delta ``Action: wait() done`` where `` done`` is
+        # regular content the model emitted after the action. AND a
+        # delta can complete an action AFTER a prior delta that held
+        # candidate-opener bytes which the new chunk now disambiguates
+        # to plain content. e.g. ``["Ac", "me Action: wait()"]`` — the
+        # ``"Ac"`` was held on delta 1, but on delta 2 the trailing
+        # ``"me "`` resolves it to ``"Acme "`` before the real
+        # ``Action: wait()`` fires. Without joining the prev-held
+        # bytes into the residual emit, ``"Ac"`` is dropped permanently.
         #
-        # Recover those bytes by computing the residual portion of THIS
-        # delta that falls outside any newly completed action span. We
-        # operate on offsets into ``current_text`` and clip to the slice
-        # that this specific delta contributed.
-        delta_start_in_current = len(previous_text)
+        # Recover the residual content by walking from the
+        # PREV_SAFE_END boundary (the cursor up to which prior calls
+        # have already emitted) rather than from ``delta_start_in_current``.
+        # The residual window is the union of:
+        #   1. ``current_text[prev_safe_end:earliest_action.start]`` —
+        #      the bytes between prior emits and the first new action.
+        #   2. ``current_text[action.end : next_action.start]`` for
+        #      each gap between consecutive actions.
+        #   3. ``current_text[last_action.end : cur_safe_end]`` — the
+        #      bytes between the last new action and the current
+        #      safe-emit boundary (anything past is still held).
         residual_pieces: list[str] = []
-        cursor = delta_start_in_current
+        cursor = prev_safe_end
         for start, end, _verb, _kwargs in new_actions:
-            # Bytes from the prior cursor up to the action's start that
-            # fall inside this delta's window are residual content.
             if start > cursor:
-                # Clip to [delta_start_in_current, len(current_text))
-                piece_start = max(cursor, delta_start_in_current)
-                piece_end = min(start, len(current_text))
-                if piece_end > piece_start:
-                    residual_pieces.append(current_text[piece_start:piece_end])
+                residual_pieces.append(current_text[cursor:start])
             cursor = end
-        # Trailing bytes after the last newly completed action that fall
-        # inside this delta's window.
-        if cursor < len(current_text):
-            piece_start = max(cursor, delta_start_in_current)
-            piece_end = len(current_text)
-            if piece_end > piece_start:
-                residual_pieces.append(current_text[piece_start:piece_end])
+        if cursor < cur_safe_end:
+            residual_pieces.append(current_text[cursor:cur_safe_end])
 
         residual = "".join(residual_pieces)
         result: dict[str, Any] = {"tool_calls": tool_calls}
@@ -1498,23 +1498,26 @@ class UiTarsToolParser(ToolParser):
         # still return False here — the streaming consumer will surface
         # the completed tool_call on the next delta-resolving step; we
         # don't claim "pending" for an already-resolved action.
-        line_starts: list[int] = []
+        line_starts: set[int] = set()
         for m in _ACTION_LINE.finditer(text):
-            line_starts.append(m.start())
+            line_starts.add(m.start())
             close = _find_balanced_close(text, m.end())
             if close == -1:
                 return True
         # Case 2: bare ``Action:`` token whose verb / open-paren hasn't
-        # arrived yet (i.e. an ``Action:`` occurrence that is NOT the
-        # head of any matched ``_ACTION_LINE``). The classic dogfood
-        # leak shape is ``"Action: type"`` where the ``(`` is in a
-        # pending decode step — the postprocessor's fast-path used
-        # to short-circuit the delta as plain ``content`` because
-        # ``_ACTION_LINE.search`` requires the open paren. Holding
-        # the buffer keeps the bare prefix bytes off the wire until
-        # the verb + body resolve on subsequent deltas.
+        # arrived yet AND the signature could still complete (codex
+        # r3 HIGH — pre-fix, ANY bare ``Action:`` was reported as
+        # pending, including the prose case ``"Action: is required."``
+        # that ``_action_signature_could_complete`` rules out. The
+        # streaming parser releases those bytes anyway via
+        # ``_safe_emit_end``, but the public ``has_pending_tool_call``
+        # helper's semantic was stale and kept the postprocessor on
+        # the slow path. Tighten the signature check here so the
+        # fast-path can short-circuit non-action prose.).
         for pm in _ACTION_PREFIX.finditer(text):
-            if pm.start() not in line_starts:
+            if pm.start() in line_starts:
+                continue
+            if _action_signature_could_complete(text, pm.end()):
                 return True
         # Case 3: trailing strict-prefix of ``Action:`` at the buffer
         # tail (e.g. ``"...end.\\nAc"``). Holding back keeps the


### PR DESCRIPTION
## Why

UI-TARS dogfood-087 (Aki r1/r2) surfaced three follow-ups to the r5-B / C-05+C-07 architectural fix:

- **R6-C3 (CRIT)** — chat-completions streaming with UI-TARS + computer tool: streamed chunks leaked `delta.content="Action: type"` raw text BEFORE the structured `delta.tool_calls` event fired. Non-stream path was clean — the architectural fix shipped in PR #818/#823 but the streaming side's content-suppression hold-back wasn't extended to cover the `Action:` prefix.
- **R6-M1 (MED)** — plain `/v1/chat/completions` request to a UI-TARS model (no tools) came back with populated `content` but empty `reasoning`. Inside Computer-Use flows the reasoning DID populate. r5-B coupled the reasoning emission gate to the sysprompt-injection path; this turn surfaced the coupling as a regression.
- **R6-M2 (MED)** — `/v1/messages` UI-TARS click produced `tool_use.input={"action":"click","point":[x,y]}` but Anthropic's Computer-Use spec requires `coordinate=[x,y]`. Anthropic-strict consumers (claude-agent-sdk, Computer-Use harnesses) rejected. Same shape leaked to `/v1/responses computer_call.action`.

Systematic fixes (no regex hacks):

1. **Streaming hold-back state machine.** New `_trailing_action_prefix_len` helper + tightened `has_pending_tool_call` (bare `Action:`, trailing strict-prefix tail) + tightened `extract_tool_calls_streaming` (clip the trailing partial-opener candidate before flushing content). Both leak vectors closed — the postprocessor fast-path AND the in-parser passthrough.
2. **Reasoning gate decoupling.** `_PREAMBLE_RE` extended with two more shapes: `Thought: ...` followed by blank-line / EOF boundary, AND generic `<think>...</think>` tag. The Action lookahead was a coincidence of the C-05 scenario, not a structural requirement.
3. **Centralized key-name translator.** `translate_to_spec_coordinate_keys` lives next to the parser; both `openai_to_anthropic` (non-stream + stream) and `_parse_computer_action` (Responses) call it. Chat-completions OpenAI lane stays bytes-faithful to the parser's native `point` per PR #812.

Gated on `name == "computer"` so vanilla function tools whose args happen to carry a key called `point` are untouched.

## Test plan

- [x] `tests/test_ui_tars_stream_action_holdback.py` — 19 new tests covering bare `Action:`, sub-character delta prefixes, prior-content + tail-prefix, end-to-end no-leak invariants, `tool_choice="none"` passthrough, non-stream parity.
- [x] `tests/test_ui_tars_lane_parity.py` extended — 13 new tests: plain chat reasoning population, `<think>` tag, lane translation parity (chat lane native `point`; Anthropic + Responses `coordinate`), idempotency, non-computer tools untouched.
- [x] `tests/test_ui_tars_fixes.py` + `tests/test_ui_tars_parser.py` updated — pre-existing Anthropic assertions now require spec `coordinate`.
- [x] Full UI-TARS + adapter suite: 353 tests pass.
- [x] Reasoning + UI-TARS suite: 1047 tests pass.
- [x] ruff check + format: clean.

skip-version-bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)