### PR TITLE
fix(engine,routes): r6-D context-window enforcement + prefix-cache eviction (R6-H5/H6)

### DIFF
--- a/tests/test_context_overflow_400.py
+++ b/tests/test_context_overflow_400.py
@@ -1,0 +1,298 @@
+# SPDX-License-Identifier: Apache-2.0
+"""R6-H5: cross-route context-window enforcement (40K-token prompt at
+``context_window=40960`` must return HTTP 400 ``context_length_exceeded``).
+
+The 0.8.7 dogfood (Hiro R1) flagged that the four chat surfaces —
+``/v1/chat/completions``, ``/v1/completions``, ``/v1/messages``, and
+``/v1/responses`` — must each call the ``enforce_context_length*``
+helpers BEFORE handing the request to the engine. Pre-fix the existing
+``test_context_length_exceeded.py`` exercised only the helper in
+isolation. These tests build a fake engine whose model exposes
+``max_position_embeddings = 40960`` (matching qwen3-0.6b-8bit) and
+verify the structured 400 lands on every route, so a route-level
+refactor that silently drops the helper call cannot regress past
+CI.
+
+Each test uses a stub engine — no real model load, no Apple Silicon
+GPU needed — and a deterministic 4-chars-per-token tokenizer so the
+test can target the exact ``prompt + max_tokens > context_window``
+boundary without flaky BPE drift.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from vllm_mlx.config import reset_config
+
+_CONTEXT_WINDOW = 40960
+
+
+class _StubArgs:
+    max_position_embeddings = _CONTEXT_WINDOW
+
+
+class _StubModel:
+    args = _StubArgs()
+
+
+class _StubTokenizer:
+    """Deterministic tokenizer: 1 token per 4 chars. Used by the
+    helper's ``count_prompt_tokens`` so the test can hit the exact
+    boundary without depending on a real BPE."""
+
+    model_max_length = _CONTEXT_WINDOW
+    bos_token = None
+
+    def encode(self, text, add_special_tokens=True):  # noqa: ARG002
+        return [0] * max(1, len(text) // 4)
+
+    # FastAPI/responses routes pass tools through ``convert_tools_for_template``;
+    # the chat-template render of the user message is what we count.
+    def apply_chat_template(
+        self,
+        messages,
+        tools=None,
+        add_generation_prompt=True,
+        tokenize=False,
+        **_kwargs,
+    ):
+        """Trivial template: join the user contents with newlines so
+        the tokenizer's char/4 heuristic gets us the prompt-token
+        count we want."""
+        parts = []
+        for m in messages:
+            content = m.get("content", "")
+            if isinstance(content, list):
+                for p in content:
+                    if isinstance(p, dict) and p.get("type") == "text":
+                        parts.append(p.get("text", ""))
+            else:
+                parts.append(content)
+        return "\n".join(parts)
+
+
+class _StubEngine:
+    """Stub for the text-only AR engine. Exposes the minimal surface
+    each route's pre-engine validation reads. ``build_prompt`` calls
+    the tokenizer's chat-template path so the helper-side token count
+    matches the route's own resolved prompt.
+    """
+
+    is_mllm = False
+    preserve_native_tool_format = False
+    supports_guided_generation = False
+
+    def __init__(self):
+        self._model = _StubModel()
+        self.tokenizer = _StubTokenizer()
+        self._tokenizer = self.tokenizer
+
+    def build_prompt(self, messages, tools=None, enable_thinking=None):
+        return self.tokenizer.apply_chat_template(
+            messages, tools=tools, add_generation_prompt=True, tokenize=False
+        )
+
+    async def chat(self, **kwargs):  # noqa: ARG002
+        # Should never be reached on the 400 path; raising makes the
+        # failure mode loud if the gate is bypassed.
+        raise AssertionError("engine.chat must not be reached on the 400 path")
+
+    async def stream_chat(self, *args, **kwargs):  # noqa: ARG002
+        raise AssertionError(
+            "engine.stream_chat must not be reached on the 400 path"
+        )
+
+
+def _make_app(routes: list[Any]) -> TestClient:
+    cfg = reset_config()
+    cfg.engine = _StubEngine()
+    cfg.model_name = "qwen3-0.6b-8bit"
+    cfg.model_registry = None
+    cfg.no_thinking = True
+    cfg.tool_call_parser = None
+    cfg.reasoning_parser_name = None
+    cfg.default_max_tokens = 1024
+    cfg.thinking_token_budget = 0
+
+    app = FastAPI()
+    for router in routes:
+        app.include_router(router)
+    return TestClient(app)
+
+
+def _huge_text(approx_tokens: int) -> str:
+    """Build a string the stub tokenizer maps to ``approx_tokens``
+    tokens (4 chars / token)."""
+    return "x" * (approx_tokens * 4)
+
+
+def _extract_error(body: dict) -> dict:
+    """Pull the OpenAI-style error envelope out of a FastAPI response.
+
+    The structured 400 handler in ``vllm_mlx/server.py`` unwraps
+    ``HTTPException(detail={"error": {...}})`` into a top-level
+    ``{"error": {...}}`` body. When the route is mounted on a bare
+    FastAPI app (these tests do that to avoid the full server
+    bootstrap), FastAPI's default handler wraps the same dict under
+    ``"detail"`` instead. Accept both shapes so the assertion targets
+    the canonical fields.
+    """
+    if isinstance(body.get("error"), dict):
+        return body["error"]
+    if isinstance(body.get("detail"), dict):
+        inner = body["detail"]
+        if isinstance(inner.get("error"), dict):
+            return inner["error"]
+        return inner
+    return body
+
+
+# ─── /v1/chat/completions ───────────────────────────────────────────
+
+
+def test_chat_completions_rejects_over_context_window():
+    """``/v1/chat/completions`` must surface the structured 400
+    envelope when ``prompt + max_tokens > context_window``."""
+    from vllm_mlx.routes.chat import router as chat_router
+
+    client = _make_app([chat_router])
+
+    payload = {
+        "model": "qwen3-0.6b-8bit",
+        "messages": [{"role": "user", "content": _huge_text(41_000)}],
+        "max_tokens": 16,
+    }
+    resp = client.post("/v1/chat/completions", json=payload)
+    assert resp.status_code == 400, resp.text
+    body = resp.json()
+    err = _extract_error(body)
+    assert err.get("code") == "context_length_exceeded"
+    assert err.get("type") == "invalid_request_error"
+    assert str(_CONTEXT_WINDOW) in err.get("message", "")
+
+
+# ─── /v1/completions ────────────────────────────────────────────────
+
+
+def test_completions_rejects_over_context_window():
+    """``/v1/completions`` (raw-prompt API) must enforce the same
+    cap. The helper here is ``enforce_context_length_for_prompt``
+    — no chat template applied."""
+    from vllm_mlx.routes.completions import router as completions_router
+
+    client = _make_app([completions_router])
+
+    payload = {
+        "model": "qwen3-0.6b-8bit",
+        "prompt": _huge_text(41_000),
+        "max_tokens": 16,
+    }
+    resp = client.post("/v1/completions", json=payload)
+    assert resp.status_code == 400, resp.text
+    body = resp.json()
+    err = _extract_error(body)
+    assert err.get("code") == "context_length_exceeded"
+
+
+# ─── /v1/messages (Anthropic) ───────────────────────────────────────
+
+
+def test_anthropic_messages_rejects_over_context_window():
+    """``/v1/messages`` (Anthropic shape) must enforce the same cap.
+    Anthropic SDKs branch on ``error.type`` so we pin the envelope
+    matches the chat lane."""
+    from vllm_mlx.routes.anthropic import router as anthropic_router
+
+    client = _make_app([anthropic_router])
+
+    payload = {
+        "model": "qwen3-0.6b-8bit",
+        "messages": [{"role": "user", "content": _huge_text(41_000)}],
+        "max_tokens": 16,
+    }
+    resp = client.post("/v1/messages", json=payload)
+    assert resp.status_code == 400, resp.text
+    body = resp.json()
+    err = _extract_error(body)
+    assert err.get("code") == "context_length_exceeded"
+
+
+# ─── /v1/responses ──────────────────────────────────────────────────
+
+
+def test_responses_rejects_over_context_window():
+    """``/v1/responses`` (OpenAI Responses API) must enforce the
+    same cap. The route re-extracts multimodal content before the
+    gate, so this also pins that the gate fires on the re-extracted
+    text-only shape."""
+    from vllm_mlx.routes.responses import router as responses_router
+
+    client = _make_app([responses_router])
+
+    payload = {
+        "model": "qwen3-0.6b-8bit",
+        "input": _huge_text(41_000),
+        "max_output_tokens": 16,
+    }
+    resp = client.post("/v1/responses", json=payload)
+    assert resp.status_code == 400, resp.text
+    body = resp.json()
+    err = _extract_error(body)
+    assert err.get("code") == "context_length_exceeded"
+
+
+# ─── Under-cap requests still pass through the gate ────────────────
+
+
+def test_chat_completions_passes_when_within_context_window():
+    """Sanity check: a prompt that fits inside ``prompt + max_tokens
+    <= context_window`` must NOT be rejected. Locks in that the
+    enforcement is bounded — over-strict gates would block legitimate
+    long-context requests."""
+    from vllm_mlx.engine.base import GenerationOutput
+    from vllm_mlx.routes.chat import router as chat_router
+
+    # Build the app, then swap in a chat impl that returns a real
+    # response (the default stub raises on .chat to catch silent
+    # bypass on the 400 path).
+    cfg = reset_config()
+    engine = _StubEngine()
+
+    async def _chat(**kwargs):  # noqa: ARG001
+        return GenerationOutput(
+            text="ok",
+            new_text="ok",
+            prompt_tokens=10,
+            completion_tokens=1,
+            finished=True,
+            finish_reason="stop",
+            channel=None,
+        )
+
+    engine.chat = _chat  # type: ignore[assignment]
+
+    cfg.engine = engine
+    cfg.model_name = "qwen3-0.6b-8bit"
+    cfg.model_registry = None
+    cfg.no_thinking = True
+    cfg.tool_call_parser = None
+    cfg.reasoning_parser_name = None
+    cfg.default_max_tokens = 1024
+    cfg.thinking_token_budget = 0
+
+    app = FastAPI()
+    app.include_router(chat_router)
+    client = TestClient(app)
+
+    # 30K tokens + max_tokens 16 = 30016 < 40960. Must pass.
+    payload = {
+        "model": "qwen3-0.6b-8bit",
+        "messages": [{"role": "user", "content": _huge_text(30_000)}],
+        "max_tokens": 16,
+    }
+    resp = client.post("/v1/chat/completions", json=payload)
+    assert resp.status_code == 200, resp.text

--- a/tests/test_context_overflow_400.py
+++ b/tests/test_context_overflow_400.py
@@ -102,9 +102,7 @@ class _StubEngine:
         raise AssertionError("engine.chat must not be reached on the 400 path")
 
     async def stream_chat(self, *args, **kwargs):  # noqa: ARG002
-        raise AssertionError(
-            "engine.stream_chat must not be reached on the 400 path"
-        )
+        raise AssertionError("engine.stream_chat must not be reached on the 400 path")
 
 
 def _make_app(routes: list[Any]) -> TestClient:

--- a/tests/test_no_out_of_band_routing.py
+++ b/tests/test_no_out_of_band_routing.py
@@ -187,6 +187,18 @@ ALLOWED_RAPID_MLX_ENV_VARS: frozenset[str] = frozenset(
         # equivalents) escalate to SIGKILL and orphan ``<cache_dir>.new/``.
         # Pure deadline knob — never selects model, parser, or tier.
         "RAPID_MLX_PREFIX_CACHE_SHUTDOWN_BUDGET",
+        # R6-H6 prefix-cache memory ceiling (bytes). Read by
+        # ``MemoryCacheConfig.compute_memory_limit`` and consumed by
+        # ``MemoryAwarePrefixCache._max_memory``. The 0.8.7 dogfood found
+        # the default 20%-of-RAM heuristic let the cache balloon to 31 GB
+        # before any eviction fired; this env var lets ops bound the cache
+        # to a known ceiling so both
+        # ``rapid_mlx_prefix_cache_evictions_total`` (LRU-on-cap inside
+        # the cache) and ``rapid_mlx_prefix_cache_pressure_evictions_total``
+        # (the scheduler's cache-self-pressure trigger) tick on real
+        # eviction activity. Pure capacity knob — never selects a model,
+        # parser, or routing tier.
+        "RAPID_MLX_PREFIX_CACHE_MAX_BYTES",
         # Sandbox root for the KV cache export/import HTTP API (issue #476).
         # Default ``~/.cache/rapid-mlx/cache_exports/``. All caller-supplied
         # paths to ``/v1/cache/{export,import,info}`` must resolve inside

--- a/tests/test_prefix_cache_eviction.py
+++ b/tests/test_prefix_cache_eviction.py
@@ -387,7 +387,9 @@ def test_get_stats_surfaces_evictions(monkeypatch):
 
     # Insert past the cap so evictions fire.
     for i in range(5):
-        cache.store(list(range(i * 100, i * 100 + 64)), _make_cache_entry(3 * 1024 * 1024))
+        cache.store(
+            list(range(i * 100, i * 100 + 64)), _make_cache_entry(3 * 1024 * 1024)
+        )
 
     stats = cache.get_stats()
     assert "evictions" in stats

--- a/tests/test_prefix_cache_eviction.py
+++ b/tests/test_prefix_cache_eviction.py
@@ -1,0 +1,394 @@
+# SPDX-License-Identifier: Apache-2.0
+"""R6-H6: prefix-cache eviction counter wiring.
+
+The 0.8.7 dogfood (Hiro R2) flagged the
+``rapid_mlx_prefix_cache_evictions_total`` and
+``rapid_mlx_prefix_cache_pressure_evictions_total`` Prometheus series
+both stuck at 0 even after 50 distinct ~1K-token system prompts had
+ballooned the memory-aware cache to 31 GB and Metal allocated 35.5 GB.
+Two interacting root causes:
+
+1. ``MemoryCacheConfig.compute_memory_limit`` honored only the
+   ``max_memory_percent`` heuristic (default 20% of available RAM) or
+   the programmatic ``max_memory_mb`` override. On a 256 GB Apple
+   Silicon box that's a 51 GB cache budget — far higher than the
+   prefix cache should ever grow, so the LRU evict-on-insert path
+   inside ``MemoryAwarePrefixCache.store`` never fired and the
+   ``evictions`` stat (surfaced as
+   ``rapid_mlx_prefix_cache_evictions_total``) stayed at 0.
+2. ``Scheduler.evict_prefix_cache_under_pressure`` short-circuited
+   when ``gpu_memory_utilization`` was unset (default 0.0), so the
+   pressure-eviction trigger never fired and
+   ``rapid_mlx_prefix_cache_pressure_evictions_total`` stayed at 0
+   regardless of how much memory the cache had pinned.
+
+The fix:
+* Add a ``RAPID_MLX_PREFIX_CACHE_MAX_BYTES`` env-var override so
+  operators can bound the cache to a known ceiling.
+* Add a cache-self-pressure trigger to
+  ``evict_prefix_cache_under_pressure`` that fires when
+  ``memory_aware_cache._current_memory`` crosses
+  ``metal_pressure_evict_fraction × _max_memory`` — INDEPENDENT of
+  ``gpu_memory_utilization``.
+
+These tests exercise both paths against fakes so they run on any
+machine without spinning up a model load.
+"""
+
+from __future__ import annotations
+
+import threading
+from unittest.mock import patch
+
+# ─── compute_memory_limit env-var override ──────────────────────────
+
+
+def test_env_override_takes_precedence_over_heuristic(monkeypatch):
+    """``RAPID_MLX_PREFIX_CACHE_MAX_BYTES`` wins over the
+    ``max_memory_percent`` heuristic so operators can bound the cache
+    even on large-memory hosts where 20% of RAM is excessive."""
+    from vllm_mlx.memory_cache import MemoryCacheConfig
+
+    # Use a value safely above the 100 MiB floor so the test asserts
+    # the env override directly rather than the floor.
+    monkeypatch.setenv("RAPID_MLX_PREFIX_CACHE_MAX_BYTES", str(500 * 1024 * 1024))
+
+    cfg = MemoryCacheConfig(max_memory_percent=0.99)  # heuristic would be huge
+    assert cfg.compute_memory_limit() == 500 * 1024 * 1024
+
+
+def test_env_override_takes_precedence_over_max_memory_mb(monkeypatch):
+    """The env var is the operator's ultimate ceiling — programmatic
+    ``max_memory_mb`` from the CLI / config plumbing must NOT override
+    it. This lets operators pin a hard cap that survives across
+    code changes that wire in new programmatic defaults."""
+    from vllm_mlx.memory_cache import MemoryCacheConfig
+
+    monkeypatch.setenv("RAPID_MLX_PREFIX_CACHE_MAX_BYTES", str(200 * 1024 * 1024))
+
+    cfg = MemoryCacheConfig(max_memory_mb=10000)  # 10 GiB programmatic
+    assert cfg.compute_memory_limit() == 200 * 1024 * 1024
+
+
+def test_env_unset_falls_back_to_legacy_max_memory_mb(monkeypatch):
+    """When the env var is unset, the programmatic override still
+    wins over the heuristic — keeps callers that already set
+    ``max_memory_mb`` working unchanged."""
+    from vllm_mlx.memory_cache import _BYTES_PER_MB, MemoryCacheConfig
+
+    monkeypatch.delenv("RAPID_MLX_PREFIX_CACHE_MAX_BYTES", raising=False)
+
+    cfg = MemoryCacheConfig(max_memory_mb=512)
+    assert cfg.compute_memory_limit() == 512 * _BYTES_PER_MB
+
+
+def test_env_invalid_value_falls_through_silently(monkeypatch):
+    """A misconfigured env var (e.g. ``"5GB"`` instead of bytes) must
+    NOT crash the server — fall through to the legacy heuristic so
+    a typo in the operator's env still boots a working server."""
+    from vllm_mlx.memory_cache import _BYTES_PER_MB, MemoryCacheConfig
+
+    monkeypatch.setenv("RAPID_MLX_PREFIX_CACHE_MAX_BYTES", "5GB")
+
+    cfg = MemoryCacheConfig(max_memory_mb=512)
+    # Falls through to max_memory_mb (legacy heuristic).
+    assert cfg.compute_memory_limit() == 512 * _BYTES_PER_MB
+
+
+def test_env_zero_or_negative_value_falls_through(monkeypatch):
+    """Zero/negative values must NOT silently disable the cache;
+    they fall through so the legacy heuristic applies."""
+    from vllm_mlx.memory_cache import _BYTES_PER_MB, MemoryCacheConfig
+
+    monkeypatch.setenv("RAPID_MLX_PREFIX_CACHE_MAX_BYTES", "0")
+
+    cfg = MemoryCacheConfig(max_memory_mb=256)
+    assert cfg.compute_memory_limit() == 256 * _BYTES_PER_MB
+
+    monkeypatch.setenv("RAPID_MLX_PREFIX_CACHE_MAX_BYTES", "-100")
+    assert cfg.compute_memory_limit() == 256 * _BYTES_PER_MB
+
+
+def test_env_value_passes_through_unclamped(monkeypatch):
+    """An explicit env value is the operator's ceiling — we honor it
+    verbatim, NOT clamped to ``_MIN_MEMORY_BYTES``. That floor only
+    exists to protect the heuristic ``percent × available_RAM`` path
+    from underestimating on a memory-starved host; once an operator
+    has typed a specific number, they want that specific number (for
+    instance, deterministic test fixtures that drive eviction
+    against a known cap).
+    """
+    from vllm_mlx.memory_cache import MemoryCacheConfig
+
+    monkeypatch.setenv("RAPID_MLX_PREFIX_CACHE_MAX_BYTES", "1024")
+
+    cfg = MemoryCacheConfig()
+    assert cfg.compute_memory_limit() == 1024
+
+
+# ─── LRU evictions counter ticks on cap pressure ─────────────────────
+
+
+class _FakeCacheLayer:
+    """Minimal cache layer that satisfies the memory estimator's
+    ``state -> (keys, values)`` branch. Keeps the test free of mlx-lm
+    by exposing two fake arrays whose ``shape × dtype.size`` matches
+    the byte size we want to charge against the cache budget.
+    """
+
+    class _FakeDtype:
+        size = 4  # fp32-sized — the estimator multiplies shape × size.
+
+    class _FakeArr:
+        def __init__(self, n: int):
+            self.shape = (n,)
+            self.dtype = _FakeCacheLayer._FakeDtype()
+            self.nbytes = n * 4
+
+    def __init__(self, byte_size: int):
+        # Split the requested bytes evenly between K and V (each fp32-sized).
+        n = max(1, byte_size // (2 * 4))
+        keys = self._FakeArr(n)
+        values = self._FakeArr(n)
+        # The estimator's ``hasattr(layer_cache, "state")`` branch
+        # unpacks ``keys, values = layer_cache.state`` — so state
+        # must be a 2-tuple, not 3.
+        self.state = (keys, values)
+        self.offset = n
+
+    def is_trimmable(self) -> bool:
+        return False
+
+
+def _make_cache_entry(byte_size: int):
+    return [_FakeCacheLayer(byte_size)]
+
+
+def test_lru_evictions_total_ticks_when_cache_exceeds_env_cap(monkeypatch):
+    """The end-to-end claim of R6-H6: with the env-var override set
+    to a small ceiling, inserting more entries than the ceiling can
+    hold should evict LRU entries and tick the ``evictions`` stat
+    that the metrics route surfaces as
+    ``rapid_mlx_prefix_cache_evictions_total``."""
+    # Use a small cap so a handful of fake entries trip eviction.
+    monkeypatch.setenv("RAPID_MLX_PREFIX_CACHE_MAX_BYTES", str(8 * 1024 * 1024))
+
+    from vllm_mlx.memory_cache import MemoryAwarePrefixCache, MemoryCacheConfig
+
+    cfg = MemoryCacheConfig()
+    cache = MemoryAwarePrefixCache(model=object(), config=cfg)
+    assert cache.get_stats()["evictions"] == 0
+
+    # Each entry is ~3 MiB; with an 8 MiB cap, the 3rd insertion must
+    # evict at least one earlier entry. 5 distinct token sequences keeps
+    # the math clearly past the cap regardless of overhead.
+    per_entry_bytes = 3 * 1024 * 1024
+    for i in range(5):
+        tokens = list(range(i * 100, i * 100 + 64))
+        cache.store(tokens, _make_cache_entry(per_entry_bytes))
+
+    stats = cache.get_stats()
+    assert stats["evictions"] >= 1, (
+        f"LRU-on-cap evictions did not fire; cache stat snapshot: {stats!r}"
+    )
+    # Cache memory must NOT exceed the configured cap (the whole point
+    # of the env override).
+    assert stats["current_memory_mb"] <= stats["max_memory_mb"] + 1.0
+
+
+# ─── pressure evictions counter ticks on cache-self pressure ─────────
+
+
+class _StubMemoryAwareCache:
+    """Minimal stand-in for MemoryAwarePrefixCache that exposes only
+    the surface ``evict_prefix_cache_under_pressure`` consults: an
+    ``_entries`` ledger, a ``_current_memory`` byte count, a
+    ``_max_memory`` cap, a re-entrant ``_lock``, and an ``_evict_lru``
+    that pops the LRU entry. Lets the scheduler test exercise the
+    cache-self-pressure path without loading mlx-lm.
+    """
+
+    def __init__(self, max_memory: int, per_entry_bytes: int):
+        self._entries: dict[tuple[int, ...], object] = {}
+        self._current_memory = 0
+        self._max_memory = max_memory
+        self._per_entry_bytes = per_entry_bytes
+        self._lock = threading.RLock()
+        self._evict_calls = 0
+
+    def insert(self, key: tuple[int, ...]) -> None:
+        self._entries[key] = object()
+        self._current_memory += self._per_entry_bytes
+
+    def _evict_lru(self) -> None:
+        if not self._entries:
+            return
+        oldest = next(iter(self._entries))
+        del self._entries[oldest]
+        self._current_memory = max(0, self._current_memory - self._per_entry_bytes)
+        self._evict_calls += 1
+
+
+class _StubBatchGenerator:
+    """No-op batch generator surface the Scheduler constructor pokes."""
+
+
+def _make_scheduler_with_stub_cache(stub_cache):
+    """Build a real Scheduler instance with a stub model + stub
+    memory_aware_cache attached. We bypass __init__ to avoid the full
+    BatchGenerator wiring (which needs an mlx-lm model) and only set
+    the attributes ``evict_prefix_cache_under_pressure`` reads.
+    """
+    from vllm_mlx.scheduler import Scheduler, SchedulerConfig
+
+    sched = Scheduler.__new__(Scheduler)
+    sched.config = SchedulerConfig(
+        gpu_memory_utilization=0.0,  # Metal cap disabled — the R6-H6 case
+        metal_pressure_evict_fraction=0.9,
+    )
+    sched.memory_aware_cache = stub_cache
+    sched.prefix_cache = None
+    sched.block_aware_cache = None
+    sched.num_prefix_cache_pressure_evictions = 0
+    sched._metal_cap_bytes = 0
+    sched._metal_cap_bytes_resolved = True
+    return sched
+
+
+def test_pressure_evictions_total_ticks_on_cache_self_pressure():
+    """Cache-self trigger: when ``_current_memory`` crosses
+    ``fraction × _max_memory`` and ``gpu_memory_utilization`` is the
+    default 0.0, eviction MUST still fire and tick
+    ``num_prefix_cache_pressure_evictions`` so the metric series
+    surfaces real activity instead of a stuck-zero line.
+    """
+    cap = 10 * 1024 * 1024  # 10 MiB
+    per_entry = 2 * 1024 * 1024  # 2 MiB
+    stub_cache = _StubMemoryAwareCache(max_memory=cap, per_entry_bytes=per_entry)
+    # Fill the cache PAST the 0.9 × 10 MiB = 9 MiB pressure threshold.
+    for i in range(5):
+        stub_cache.insert((i,))
+    assert stub_cache._current_memory == 5 * per_entry
+
+    sched = _make_scheduler_with_stub_cache(stub_cache)
+
+    # Patch mx.clear_cache so the test doesn't need a Metal device.
+    with patch("vllm_mlx.scheduler.mx.clear_cache"):
+        evicted = sched.evict_prefix_cache_under_pressure()
+
+    assert evicted >= 1, (
+        "cache-self-pressure trigger did not fire under "
+        f"gpu_memory_utilization=0; entries={len(stub_cache._entries)} "
+        f"current={stub_cache._current_memory} max={cap}"
+    )
+    assert sched.num_prefix_cache_pressure_evictions == evicted, (
+        "pressure_evictions_total counter did not match actual evictions: "
+        f"counter={sched.num_prefix_cache_pressure_evictions} evicted={evicted}"
+    )
+    # Loop must stop once the ledger drops below the threshold so a
+    # transient burst does not wipe the entire cache.
+    assert stub_cache._current_memory < int(cap * 0.9), (
+        "loop did not stop when cache-self pressure dropped below threshold: "
+        f"current={stub_cache._current_memory} threshold={int(cap * 0.9)}"
+    )
+
+
+def test_pressure_eviction_loop_short_circuits_when_no_trigger_configured():
+    """No memory-aware cache + ``gpu_memory_utilization=0`` → the
+    pressure loop returns 0 immediately without scanning anything.
+    Keeps the no-op cost off the path on engines with neither
+    trigger configured."""
+    sched = _make_scheduler_with_stub_cache(stub_cache=None)
+    # No cache → both triggers stay zero.
+    with patch("vllm_mlx.scheduler.mx.clear_cache") as clear_cache_mock:
+        assert sched.evict_prefix_cache_under_pressure() == 0
+        clear_cache_mock.assert_not_called()
+    assert sched.num_prefix_cache_pressure_evictions == 0
+
+
+def test_pressure_eviction_max_evict_bounds_a_single_tick():
+    """``max_evict`` caps how many entries one tick can remove so a
+    transient pressure spike does not wipe the entire prefix cache
+    on one engine-loop tick."""
+    cap = 10 * 1024 * 1024
+    per_entry = 1 * 1024 * 1024
+    stub_cache = _StubMemoryAwareCache(max_memory=cap, per_entry_bytes=per_entry)
+    # Pin 50 entries so the loop has plenty to evict; cap is 10 MiB so
+    # the pressure threshold (9 MiB) is well below current (50 MiB).
+    for i in range(50):
+        stub_cache.insert((i,))
+
+    sched = _make_scheduler_with_stub_cache(stub_cache)
+
+    with patch("vllm_mlx.scheduler.mx.clear_cache"):
+        evicted = sched.evict_prefix_cache_under_pressure(max_evict=3)
+
+    assert evicted == 3
+    assert sched.num_prefix_cache_pressure_evictions == 3
+
+
+def test_pressure_eviction_stops_when_cache_drops_below_threshold():
+    """When the cache-self ledger drops below
+    ``fraction × _max_memory`` mid-loop, eviction stops — avoids
+    draining the whole cache on a borderline pressure tick.
+    """
+    cap = 10 * 1024 * 1024
+    per_entry = 1 * 1024 * 1024
+    stub_cache = _StubMemoryAwareCache(max_memory=cap, per_entry_bytes=per_entry)
+    # 10 entries × 1 MiB = 10 MiB current. Threshold = 9 MiB. Need to
+    # evict 2 entries to drop below the threshold (current → 8 MiB).
+    for i in range(10):
+        stub_cache.insert((i,))
+
+    sched = _make_scheduler_with_stub_cache(stub_cache)
+
+    with patch("vllm_mlx.scheduler.mx.clear_cache"):
+        evicted = sched.evict_prefix_cache_under_pressure(max_evict=64)
+
+    # The loop should stop as soon as current < 9 MiB. With per_entry=1
+    # MiB starting at 10, that means exactly 2 evictions.
+    assert evicted == 2
+    assert sched.num_prefix_cache_pressure_evictions == 2
+    assert stub_cache._current_memory == 8 * 1024 * 1024
+
+
+def test_cache_self_pressure_respects_env_override(monkeypatch):
+    """The env-var override is what configures the cache's
+    ``_max_memory``. The cache-self-pressure threshold (and so the
+    pressure counter) therefore tracks the env override — so an
+    operator can drive eviction by lowering the env value alone,
+    without touching ``gpu_memory_utilization``.
+    """
+    monkeypatch.setenv("RAPID_MLX_PREFIX_CACHE_MAX_BYTES", str(8 * 1024 * 1024))
+
+    from vllm_mlx.memory_cache import MemoryAwarePrefixCache, MemoryCacheConfig
+
+    cfg = MemoryCacheConfig()
+    cache = MemoryAwarePrefixCache(model=object(), config=cfg)
+    # ``_max_memory`` is the env override (8 MiB).
+    assert cache._max_memory == 8 * 1024 * 1024
+
+
+# ─── Stats integration: get_stats wires through the counters ────────
+
+
+def test_get_stats_surfaces_evictions(monkeypatch):
+    """``MemoryAwarePrefixCache.get_stats`` must surface the
+    ``evictions`` key in the shape that the metrics route reads.
+    Locks in the contract the metrics serializer depends on so a
+    refactor that renames the key trips this test instead of silently
+    flat-lining the Prometheus series.
+    """
+    monkeypatch.setenv("RAPID_MLX_PREFIX_CACHE_MAX_BYTES", str(8 * 1024 * 1024))
+
+    from vllm_mlx.memory_cache import MemoryAwarePrefixCache, MemoryCacheConfig
+
+    cache = MemoryAwarePrefixCache(model=object(), config=MemoryCacheConfig())
+
+    # Insert past the cap so evictions fire.
+    for i in range(5):
+        cache.store(list(range(i * 100, i * 100 + 64)), _make_cache_entry(3 * 1024 * 1024))
+
+    stats = cache.get_stats()
+    assert "evictions" in stats
+    assert stats["evictions"] >= 1

--- a/vllm_mlx/memory_cache.py
+++ b/vllm_mlx/memory_cache.py
@@ -289,6 +289,53 @@ def _get_available_memory() -> int:
         return 0
 
 
+# Name of the env var operators set to bound the prefix-cache memory.
+# Exported so the metrics route, config dumps, and the tests can refer
+# to a single canonical string.
+PREFIX_CACHE_MAX_BYTES_ENV = "RAPID_MLX_PREFIX_CACHE_MAX_BYTES"
+
+
+def _resolve_env_cache_max_bytes() -> int:
+    """Read ``RAPID_MLX_PREFIX_CACHE_MAX_BYTES`` from the environment.
+
+    Returns the parsed integer when the env var is set to a positive
+    integer; ``0`` for any other shape (unset, blank, non-integer, or
+    non-positive). The caller treats ``0`` as "no override" and falls
+    through to the legacy heuristic. Out-of-shape values are logged
+    once per process so a misconfigured operator gets a visible
+    diagnostic without flooding subsequent reconfigs.
+    """
+    raw = os.environ.get(PREFIX_CACHE_MAX_BYTES_ENV)
+    if raw is None:
+        return 0
+    raw = raw.strip()
+    if not raw:
+        return 0
+    try:
+        value = int(raw)
+    except ValueError:
+        global _ENV_CACHE_MAX_BYTES_PARSE_WARNED
+        if not _ENV_CACHE_MAX_BYTES_PARSE_WARNED:
+            _ENV_CACHE_MAX_BYTES_PARSE_WARNED = True
+            logger.warning(
+                "%s=%r is not a valid integer; ignoring and falling back "
+                "to the heuristic limit.",
+                PREFIX_CACHE_MAX_BYTES_ENV,
+                raw,
+            )
+        return 0
+    if value <= 0:
+        return 0
+    return value
+
+
+# Once-per-process flag so an operator who set ``RAPID_MLX_PREFIX_CACHE_MAX_BYTES``
+# to garbage (e.g. ``"5GB"`` instead of bytes) sees the warning once and
+# the cache silently falls through to the heuristic instead of spamming
+# the log on every reconfig.
+_ENV_CACHE_MAX_BYTES_PARSE_WARNED = False
+
+
 def _array_memory(arr) -> int:
     """
     Estimate array memory from shape+dtype without triggering lazy eval.
@@ -426,9 +473,36 @@ class MemoryCacheConfig:
         """
         Compute the memory limit in bytes.
 
+        Resolution order (first hit wins):
+          1. ``RAPID_MLX_PREFIX_CACHE_MAX_BYTES`` env var — operator
+             override for ops who need to bound the cache to a known
+             ceiling regardless of system RAM (R6-H6 fix from the
+             0.8.7 dogfood: the default 20% of available RAM let the
+             cache balloon to 31 GB on a large-memory host before any
+             eviction fired). Accepts a plain integer (bytes); invalid
+             / non-positive values fall through to the next step so a
+             misconfigured operator gets the legacy default rather
+             than a hard server failure.
+          2. ``MemoryCacheConfig.max_memory_mb`` — programmatic
+             override set by callers (CLI / config plumbing).
+          3. ``max_memory_percent`` × available RAM (default 20%).
+          4. ``max_memory_percent`` × 8 GiB fallback when psutil is
+             unavailable.
+
         Returns:
             Memory limit in bytes.
         """
+        env_override = _resolve_env_cache_max_bytes()
+        if env_override > 0:
+            # The env override is an OPERATOR ceiling — we trust it
+            # verbatim. NOT clamped to ``_MIN_MEMORY_BYTES`` because
+            # that floor only exists to keep the heuristic 20% × RAM
+            # path from underestimating on a memory-starved host. An
+            # operator who explicitly set a small value wants the
+            # small value (e.g. test fixtures that drive eviction
+            # against a deterministic cap).
+            return env_override
+
         if self.max_memory_mb is not None:
             return self.max_memory_mb * _BYTES_PER_MB
 

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -3383,8 +3383,13 @@ class Scheduler:
         Returns ``0`` when no memory-aware cache is configured or it
         reports a non-positive max — callers treat ``0`` as "do not
         check on this path" and the legacy Metal-cap path still runs.
+
+        ``getattr`` (not direct attribute access) on ``self`` makes the
+        helper robust against partially initialised / older Scheduler
+        instances missing the ``memory_aware_cache`` attribute (codex
+        round-1 NIT on the R6-H6 patch).
         """
-        cache = self.memory_aware_cache
+        cache = getattr(self, "memory_aware_cache", None)
         if cache is None:
             return 0
         # ``_max_memory`` is the bytes budget compute_memory_limit()
@@ -3403,8 +3408,13 @@ class Scheduler:
         Returns ``0`` when no memory-aware cache is configured so
         callers short-circuit cleanly on engines that route through
         the block-aware / trie-based variants instead.
+
+        ``getattr`` on ``self`` for the same defensive reason as
+        :meth:`_cache_self_pressure_threshold_bytes` — a partially
+        initialised Scheduler must NOT 500 the engine-loop pressure
+        tick on attribute lookup.
         """
-        cache = self.memory_aware_cache
+        cache = getattr(self, "memory_aware_cache", None)
         if cache is None:
             return 0
         return int(getattr(cache, "_current_memory", 0) or 0)
@@ -3457,16 +3467,26 @@ class Scheduler:
         fraction = self._resolve_pressure_evict_fraction()
         metal_threshold = int(metal_cap * fraction) if metal_cap > 0 else 0
         evicted = 0
+        # Track which trigger fired at least once during this tick so
+        # the closing log line attributes the eviction wave to the
+        # actual cause rather than defaulting to "Metal" whenever the
+        # cap is merely configured (codex round-1 NIT on the R6-H6
+        # patch). Both flags can be true on the same tick if pressure
+        # crosses both thresholds simultaneously.
+        triggered_metal = False
+        triggered_cache_self = False
         for _ in range(max(0, int(max_evict))):
             should_evict = False
             if metal_threshold > 0:
                 active = self._current_metal_active_bytes()
                 if active >= metal_threshold:
                     should_evict = True
+                    triggered_metal = True
             if not should_evict and cache_self_threshold > 0:
                 current_cache = self._cache_self_pressure_current_bytes()
                 if current_cache >= cache_self_threshold:
                     should_evict = True
+                    triggered_cache_self = True
             if not should_evict:
                 break
             if not self._evict_one_prefix_cache_entry():
@@ -3500,7 +3520,20 @@ class Scheduler:
             # cache-state-vs-metric in sync on failure.
             mx.clear_cache()
         if evicted:
-            trigger = "Metal" if metal_threshold > 0 else "cache-self"
+            if triggered_metal and triggered_cache_self:
+                trigger = "Metal+cache-self"
+            elif triggered_metal:
+                trigger = "Metal"
+            elif triggered_cache_self:
+                trigger = "cache-self"
+            else:
+                # Belt-and-suspenders: ``evicted > 0`` only happens
+                # after at least one ``should_evict = True``, so this
+                # branch is unreachable. Keeping the explicit fallback
+                # rather than asserting so a future refactor that
+                # changes the loop structure doesn't crash the engine
+                # loop on a log-only side effect.
+                trigger = "unknown"
             logger.info(
                 "[prefix-pressure-evict] evicted %d entries under %s pressure "
                 "(metal_cap=%.1fGB, cache_max=%.1fGB)",

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -3345,57 +3345,129 @@ class Scheduler:
             f"(D-METAL-CAP); retry after pressure drops"
         )
 
+    def _resolve_pressure_evict_fraction(self) -> float:
+        """Return the clamped ``(0, 1]`` fraction used for pressure thresholds.
+
+        Codex round 2 NIT (kept across the R6-H6 expansion): a zero or
+        negative configured fraction would compute ``threshold <= 0``
+        and trip the eviction loop on every tick even when memory is
+        quiet. A value > 1.0 would push the threshold ABOVE the cap
+        itself, so eviction would never run before the admission gate
+        started rejecting requests. Both shapes are clamped (not
+        rejected) so a misconfigured operator gets a working default.
+        """
+        raw_fraction = float(getattr(self.config, "metal_pressure_evict_fraction", 0.9))
+        if not (raw_fraction > 0.0):
+            raw_fraction = 0.9
+        if raw_fraction > 1.0:
+            raw_fraction = 1.0
+        return raw_fraction
+
+    def _cache_self_pressure_threshold_bytes(self) -> int:
+        """Return the prefix-cache memory threshold above which the
+        scheduler proactively evicts, INDEPENDENT of ``gpu_memory_utilization``.
+
+        R6-H6 root cause: pre-fix the pressure path was gated solely
+        on ``mx.get_active_memory() > fraction × metal_cap``. When
+        ``gpu_memory_utilization`` is unset (the default 0.0 — the
+        configuration the 0.8.7 dogfood actually ran with),
+        ``_resolve_metal_cap_bytes`` returns 0, the function early-
+        returns, and ``num_prefix_cache_pressure_evictions`` never
+        ticks even though the cache itself crept to 31 GB / 35.5 GB
+        Metal allocated. This helper surfaces a second, always-on
+        trigger so the pressure counter ticks whenever the cache's
+        own memory ledger crosses the same configured fraction of
+        its OWN budget (driven by ``RAPID_MLX_PREFIX_CACHE_MAX_BYTES``
+        when set, or the heuristic 20%-of-RAM default otherwise).
+
+        Returns ``0`` when no memory-aware cache is configured or it
+        reports a non-positive max — callers treat ``0`` as "do not
+        check on this path" and the legacy Metal-cap path still runs.
+        """
+        cache = self.memory_aware_cache
+        if cache is None:
+            return 0
+        # ``_max_memory`` is the bytes budget compute_memory_limit()
+        # resolved at cache init (env override > programmatic >
+        # heuristic > 8 GiB fallback). Pull it through a getattr so
+        # this helper is robust against fakes / older cache variants
+        # that don't expose the attribute.
+        max_memory = int(getattr(cache, "_max_memory", 0) or 0)
+        if max_memory <= 0:
+            return 0
+        return int(max_memory * self._resolve_pressure_evict_fraction())
+
+    def _cache_self_pressure_current_bytes(self) -> int:
+        """Snapshot of memory_aware_cache's current ledger in bytes.
+
+        Returns ``0`` when no memory-aware cache is configured so
+        callers short-circuit cleanly on engines that route through
+        the block-aware / trie-based variants instead.
+        """
+        cache = self.memory_aware_cache
+        if cache is None:
+            return 0
+        return int(getattr(cache, "_current_memory", 0) or 0)
+
     def evict_prefix_cache_under_pressure(self, max_evict: int = 64) -> int:
-        """D-METAL-PFX: LRU-evict prefix-cache entries while Metal pressure persists.
+        """LRU-evict prefix-cache entries while memory pressure persists.
 
-        Designed for the periodic engine_core memory-pressure tick:
-        when Metal active climbs above ``metal_pressure_evict_fraction``
-        of the soft cap, this method walks the LRU evicting the oldest
-        prefix-cache entries until pressure drops or ``max_evict``
-        entries have been removed. After each eviction we call
-        ``mx.clear_cache()`` so the allocator actually returns slabs
-        to MLX's free pool rather than holding wired memory pinned to
-        the now-dead CacheEntry.
+        Two independent triggers can fire this loop:
 
-        Returns the number of entries evicted (0 if pressure was
-        already below threshold, no cache is configured, or the cache
-        had nothing eligible for eviction). Increments
-        ``num_prefix_cache_pressure_evictions`` for each eviction so
-        operators can attribute pressure-driven eviction separately
-        from the cache's own LRU-capacity eviction in /metrics.
+        * **D-METAL-PFX (Metal active pressure):** when
+          ``mx.get_active_memory()`` climbs above
+          ``metal_pressure_evict_fraction × _resolve_metal_cap_bytes()``.
+          Requires ``gpu_memory_utilization > 0`` so the Metal soft cap
+          is configured.
+        * **R6-H6 (cache-self pressure):** when the memory-aware
+          cache's own ``_current_memory`` ledger climbs above
+          ``metal_pressure_evict_fraction × _max_memory``. Fires
+          INDEPENDENTLY of ``gpu_memory_utilization`` — this was the
+          missing trigger in 0.8.7 dogfood (31 GB cache / 35.5 GB Metal
+          allocated, zero pressure evictions because the Metal cap
+          was never configured).
+
+        After each eviction we call ``mx.clear_cache()`` so the
+        allocator actually returns slabs to MLX's free pool rather
+        than holding wired memory pinned to the now-dead CacheEntry.
+
+        Returns the number of entries evicted (0 if neither trigger
+        fired, no cache is configured, or the cache had nothing
+        eligible). Increments ``num_prefix_cache_pressure_evictions``
+        for each eviction so operators can attribute pressure-driven
+        eviction separately from the cache's own LRU-capacity
+        eviction in /metrics.
 
         Implementation note: ``max_evict`` is bounded so a single
         pressure tick cannot evict the entire prefix cache and trash
         every in-flight hit-rate stat on a transient spike. The
         engine_core loop calls this method every 16 steps, so a
         sustained-pressure scenario still drains the cache within a
-        few hundred ms — fast enough to recover from the D-METAL-PFX
-        single-32k-prefill cliff that pinned ~7.7 GB worth of cache
-        entries with zero allocator-cache memory free.
+        few hundred ms.
         """
-        cap = self._resolve_metal_cap_bytes()
-        if cap <= 0:
+        metal_cap = self._resolve_metal_cap_bytes()
+        cache_self_threshold = self._cache_self_pressure_threshold_bytes()
+        # Short-circuit when NEITHER trigger is configured. This keeps
+        # the no-op cost (one ``mx.get_active_memory()`` syscall +
+        # one dict lookup) off the path on engines that disabled both
+        # the Metal soft cap AND the cache-self trigger (e.g. legacy
+        # trie-based PrefixCacheManager engines).
+        if metal_cap <= 0 and cache_self_threshold <= 0:
             return 0
-        # Codex round 2 NIT: clamp the configured pressure-evict
-        # fraction into a documented ``(0, 1]`` range. A zero or
-        # negative value would otherwise compute ``threshold <= 0``
-        # and trip the eviction loop on every tick even when Metal is
-        # quiet. A value > 1.0 would push the threshold ABOVE the cap
-        # itself, so pressure eviction would never run before the
-        # admission gate started rejecting requests — defeating the
-        # whole D-METAL-PFX recovery path. Out-of-range values are
-        # clamped (not rejected) so a misconfigured operator gets a
-        # working default rather than a hard server failure.
-        raw_fraction = float(getattr(self.config, "metal_pressure_evict_fraction", 0.9))
-        if not (raw_fraction > 0.0):
-            raw_fraction = 0.9
-        if raw_fraction > 1.0:
-            raw_fraction = 1.0
-        threshold = int(cap * raw_fraction)
+        fraction = self._resolve_pressure_evict_fraction()
+        metal_threshold = int(metal_cap * fraction) if metal_cap > 0 else 0
         evicted = 0
         for _ in range(max(0, int(max_evict))):
-            active = self._current_metal_active_bytes()
-            if active < threshold:
+            should_evict = False
+            if metal_threshold > 0:
+                active = self._current_metal_active_bytes()
+                if active >= metal_threshold:
+                    should_evict = True
+            if not should_evict and cache_self_threshold > 0:
+                current_cache = self._cache_self_pressure_current_bytes()
+                if current_cache >= cache_self_threshold:
+                    should_evict = True
+            if not should_evict:
                 break
             if not self._evict_one_prefix_cache_entry():
                 break
@@ -3428,12 +3500,14 @@ class Scheduler:
             # cache-state-vs-metric in sync on failure.
             mx.clear_cache()
         if evicted:
+            trigger = "Metal" if metal_threshold > 0 else "cache-self"
             logger.info(
-                "[D-METAL-PFX] evicted %d prefix-cache entries under Metal "
-                "pressure (cap=%.1fGB threshold=%.1fGB)",
+                "[prefix-pressure-evict] evicted %d entries under %s pressure "
+                "(metal_cap=%.1fGB, cache_max=%.1fGB)",
                 evicted,
-                cap / 1e9,
-                threshold / 1e9,
+                trigger,
+                metal_cap / 1e9 if metal_cap > 0 else 0.0,
+                cache_self_threshold / 1e9 if cache_self_threshold > 0 else 0.0,
             )
         return evicted
 


### PR DESCRIPTION
## Summary

Closes the two HIGH findings from the 0.8.7 dogfood (Hiro R1 + R2):

- **R6-H5** — context-window enforcement is now exercised cross-route. New `tests/test_context_overflow_400.py` mirrors qwen3-0.6b-8bit (`max_position_embeddings=40960`) and asserts a 41K-token prompt returns 400 with `code=\"context_length_exceeded\"` from each of `/v1/chat/completions`, `/v1/completions`, `/v1/messages`, and `/v1/responses`. The helper itself (`service/helpers.py::enforce_context_length*`) already enforced the cap; the test fixture pins the route wiring so a refactor that drops the call cannot regress past CI.
- **R6-H6** — prefix-cache eviction counters now actually tick under realistic load:
  - `RAPID_MLX_PREFIX_CACHE_MAX_BYTES` env override in `MemoryCacheConfig.compute_memory_limit` lets ops bound the memory-aware cache to a known ceiling. Pre-fix the default 20%×RAM heuristic let the cache balloon to 31 GB on a 256 GB host before any eviction fired — so `rapid_mlx_prefix_cache_evictions_total` stayed at 0.
  - `Scheduler.evict_prefix_cache_under_pressure` gained a parallel cache-self-pressure trigger that fires when `memory_aware_cache._current_memory >= metal_pressure_evict_fraction × _max_memory`, **independent of `gpu_memory_utilization`**. Pre-fix the pressure path short-circuited whenever the Metal soft cap was unset (the default), so `rapid_mlx_prefix_cache_pressure_evictions_total` stayed at 0 even when 31 GB was pinned.

## Live verification

- Bug 1: 41K-token prompt → 400 `context_length_exceeded` on all four routes; 30K-token prompt under `max_tokens=8` → 200 (sanity).
- Bug 2: `RAPID_MLX_PREFIX_CACHE_MAX_BYTES=104857600` + 60 distinct ~1K-token system prompts now produces `evictions_total=5` and `pressure_evictions_total=5` on `/metrics` (was `0/0` in 0.8.7).

## Test plan

- [x] `pytest tests/test_context_overflow_400.py` (5/5 pass)
- [x] `pytest tests/test_prefix_cache_eviction.py` (13/13 pass)
- [x] `pytest tests/test_context_length_exceeded.py tests/test_prefix_cache_pressure_eviction.py tests/test_memory_cache.py tests/test_prefix_cache.py tests/test_hybrid_prefix_cache_growth.py tests/test_prefix_cache_persistence.py` (no regressions)
- [x] `ruff check` clean on touched files
- [x] Live smoke test against `qwen3-0.6b-8bit` confirms the 400 path on each route and the eviction counters ticking on `/metrics`