### PR TITLE
chore: bump version to 0.8.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.8.7"
+version = "0.8.8"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## Why

Cuts 0.8.8 covering the **r6 fix wave** that landed since 0.8.7:

- **r6-A (#831, `f6dc45c`)** — Responses lane + alias registry hygiene: R6-C1 `qwen3.5-4b-4bit` was mis-classified `is_hybrid=True` causing `metal::malloc 499000` wedge on every generation; flag corrected + heuristic tightened. R6-C2 engine failures now propagate as Responses `status="failed"` + populated `error` block instead of silent 200/incomplete/usage=0. R6-H7 `response.in_progress` SSE event now emitted between `response.created` and `response.output_item.added` per OpenAI spec. R6-H8 r5-E top_k/seed validator extracted to shared module and wired into `/v1/responses` (was bypassed).
- **r6-B (#829, `ee380b1`)** — UI-TARS streaming parser: R6-C3 streaming `delta.content` no longer leaks raw `"Action: <verb>"` text before `tool_calls` flush; parser hold-back now extended to stream path. R6-M1 `reasoning` channel emission decoupled from sysprompt-injection gate; plain chat (no Computer-Use tool) surfaces the model's thought block again. R6-M2 Anthropic `tool_use.input` and Responses `computer_call.action` now use spec `coordinate` key instead of UI-TARS native `point`.
- **r6-C (#828, `e76a8bd`)** — Audio bundle: R6-H1 `[audio]` extra now pins `espeakng-loader` + `phonemizer-fork` (regression of #819 Kokoro TTS unusable on fresh install). R6-H2 STT `response_format` honored across json/text/srt/vtt/verbose_json. R6-H3 STT decode errors map to 400 with OpenAI-shape envelope instead of 500. R6-H4 audio model alias triggers boot-time `require_audio_or_exit` guard mirroring r5-C UI-TARS pattern.
- **r6-D (#830, `c3028de`)** — Engine guardrails: R6-H5 prompt + max_tokens validated against `model.context_window` cross-route; over-budget returns 400 with `code=context_length_exceeded`. R6-H6 prefix cache `evict_under_pressure` now fires when allocated cache memory exceeds `RAPID_MLX_PREFIX_CACHE_MAX_BYTES` (default = 70% of available unified memory); eviction counters now tick (previously stuck at 0 with 31 GB cache mem).

Standalone bump per release SOP so `auto-release.yml` fires on the exact subject `chore: bump version to 0.8.8`.

## Test plan

- [x] All 4 r6 fix waves landed and merged to `main` with their own CI green
- [x] Subject line matches `auto-release.yml` trigger regex

🤖 Generated with [Claude Code](https://claude.com/claude-code)