### PR TITLE
fix(ui-tars): r6-B codex r4 follow-up — trailing-prefix isolation + narrow plain-chat Thought: EOS

### DIFF
--- a/tests/test_ui_tars_lane_parity.py
+++ b/tests/test_ui_tars_lane_parity.py
@@ -639,6 +639,67 @@ class TestR6M1ReasoningGateDecoupling:
         assert reasoning is None
         assert content == "Just a regular response with no thought."
 
+    def test_thought_followed_by_newline_prose_does_not_overcapture(self):
+        # Codex r4 MEDIUM: pre-fix, the plain-chat ``Thought:`` branch
+        # ended at either ``\s*\n\s*\n`` OR ``\s*\Z`` under
+        # ``re.DOTALL``. With the lazy body and ``\Z`` alternative,
+        # a response like ``"Thought: A.\nB."`` (single newline, no
+        # blank line) lazy-matched the body up to ``\Z`` and
+        # classified the WHOLE response as reasoning, dropping the
+        # model's answer. Fix: the EOS branch is now restricted to
+        # bodies with NO embedded newlines (single-line truncated
+        # thoughts only); multi-line plain prose without a blank-line
+        # boundary falls through to "no preamble" and the entire
+        # text is routed to content.
+        from vllm_mlx.reasoning.ui_tars_parser import UiTarsReasoningParser
+
+        parser = UiTarsReasoningParser()
+        reasoning, content = parser.extract_reasoning(
+            "Thought: I should answer directly.\nThe answer is 4."
+        )
+        # No blank-line boundary AND the body has an embedded newline
+        # — neither shape #4 nor shape #4b matches; the entire response
+        # routes to content.
+        assert reasoning is None
+        assert content == "Thought: I should answer directly.\nThe answer is 4."
+
+    def test_thought_eos_single_line_still_works(self):
+        # Positive control for the restricted shape #4b: a single-line
+        # truncated thought (no newline at all) still surfaces as
+        # reasoning. This is the EOS branch the codex r4 fix narrows.
+        from vllm_mlx.reasoning.ui_tars_parser import UiTarsReasoningParser
+
+        parser = UiTarsReasoningParser()
+        reasoning, content = parser.extract_reasoning("Thought: I'm uncertain.")
+        assert reasoning == "Thought: I'm uncertain."
+        assert not content
+
+    def test_thought_eos_with_trailing_whitespace_still_works(self):
+        # Edge case: single-line thought with trailing whitespace
+        # (typical when the model emits ``Thought: ...\n`` and the
+        # response is truncated before any follow-up). The
+        # ``[^\n]*?`` body matches the line, then ``\s*\Z`` consumes
+        # the trailing newline / whitespace.
+        from vllm_mlx.reasoning.ui_tars_parser import UiTarsReasoningParser
+
+        parser = UiTarsReasoningParser()
+        reasoning, content = parser.extract_reasoning("Thought: I'm uncertain.\n")
+        assert reasoning == "Thought: I'm uncertain."
+        assert not content
+
+    def test_thought_blank_line_boundary_multi_line_thought(self):
+        # Multi-line thought body terminated by a real blank-line
+        # boundary still works — shape #4 (not #4b) handles this.
+        from vllm_mlx.reasoning.ui_tars_parser import UiTarsReasoningParser
+
+        parser = UiTarsReasoningParser()
+        reasoning, content = parser.extract_reasoning(
+            "Thought: Step 1.\nStep 2.\n\nThe answer is 4."
+        )
+        # Body up to the blank line is reasoning; bytes after are content.
+        assert reasoning == "Thought: Step 1.\nStep 2."
+        assert content == "The answer is 4."
+
 
 # ---------------------------------------------------------------------------
 # r6-B R6-M2: Anthropic + Responses lanes translate point → coordinate

--- a/tests/test_ui_tars_stream_action_holdback.py
+++ b/tests/test_ui_tars_stream_action_holdback.py
@@ -615,3 +615,117 @@ class TestCodexR3HasPendingSemantics:
     def test_open_paren_no_close_pending(self, parser):
         # Existing contract — verb+paren commit but no close.
         assert parser.has_pending_tool_call("Action: click(") is True
+
+
+class TestCodexR4TrailingPrefixIsolated:
+    """Codex r4 BLOCKING: ``_trailing_action_prefix_len`` used to
+    short-circuit with ``if _ACTION_TOKEN in text: return 0``, which
+    disabled trailing-prefix holdback for the entire buffer once any
+    full ``Action:`` token appeared earlier. That re-opened R6-C3 for
+    streams that mix prior prose/completed actions with a new split
+    action opener — the trailing strict prefix leaked as content
+    BEFORE the structured ``tool_calls`` flush.
+
+    Fix: evaluate only the tail overlap; earlier ``Action:`` tokens
+    (completed or prose) must not suppress holding a later trailing
+    strict prefix.
+    """
+
+    def test_prose_action_then_split_real_action_holds_prefix(self, parser):
+        # Codex r4 BLOCKING repro #1: ``["Action: is required.\nAc",
+        # "tion: wait()"]``. The trailing ``Ac`` must be held on
+        # delta 1 so chunk 2's ``tion: wait()`` resolves into the
+        # structured tool_call without ``Ac`` leaking as content.
+        parser.reset()
+        chunks = ["Action: is required.\nAc", "tion: wait()"]
+        content_parts: list[str] = []
+        tool_calls: list[dict] = []
+        previous = ""
+        for delta in chunks:
+            current = previous + delta
+            result = parser.extract_tool_calls_streaming(
+                previous_text=previous,
+                current_text=current,
+                delta_text=delta,
+                request=None,
+            )
+            if result and result.get("content"):
+                content_parts.append(result["content"])
+            if result and result.get("tool_calls"):
+                tool_calls.extend(result["tool_calls"])
+            previous = current
+        final_content = "".join(content_parts)
+        # The trailing ``Ac`` must NOT have leaked between deltas
+        # — on chunk 1 the streaming parser should hold the strict
+        # prefix; on chunk 2 the real action resolves.
+        assert final_content == "Action: is required.\n", (
+            f"unexpected content: {final_content!r}"
+        )
+        assert len(tool_calls) == 1
+        assert '"action": "wait"' in tool_calls[0]["function"]["arguments"]
+
+    def test_completed_action_then_split_real_action_holds_prefix(self, parser):
+        # Codex r4 BLOCKING repro #2: ``["Action: wait() Ac",
+        # "tion: click(point='<point>10 20</point>')"]``. The prior
+        # completed action must not disable trailing-prefix holdback —
+        # ``Ac`` is held until chunk 2 resolves it into the real
+        # second tool_call.
+        parser.reset()
+        chunks = [
+            "Action: wait() Ac",
+            "tion: click(point='<point>10 20</point>')",
+        ]
+        content_parts: list[str] = []
+        tool_calls: list[dict] = []
+        previous = ""
+        for delta in chunks:
+            current = previous + delta
+            result = parser.extract_tool_calls_streaming(
+                previous_text=previous,
+                current_text=current,
+                delta_text=delta,
+                request=None,
+            )
+            if result and result.get("content"):
+                content_parts.append(result["content"])
+            if result and result.get("tool_calls"):
+                tool_calls.extend(result["tool_calls"])
+            previous = current
+        final_content = "".join(content_parts)
+        # ``Ac`` must not appear; only the inter-action whitespace
+        # surfaces as content.
+        assert "Ac" not in final_content, f"trailing Ac leaked: {final_content!r}"
+        assert final_content == " ", f"unexpected content: {final_content!r}"
+        assert len(tool_calls) == 2
+        assert '"action": "wait"' in tool_calls[0]["function"]["arguments"]
+        assert '"action": "click"' in tool_calls[1]["function"]["arguments"]
+
+    def test_trailing_prefix_helper_does_not_short_circuit_on_earlier_token(self):
+        # Direct unit-level check of the fix — verify
+        # ``_trailing_action_prefix_len`` ignores earlier full tokens
+        # and only inspects the tail.
+        from vllm_mlx.tool_parsers.ui_tars_tool_parser import (
+            _trailing_action_prefix_len,
+        )
+
+        # Earlier completed action — trailing ``Ac`` still held.
+        assert _trailing_action_prefix_len("Action: wait() Ac") == 2
+        # Earlier prose ``Action:`` — trailing ``Acti`` still held.
+        assert _trailing_action_prefix_len("Action: is required.\nActi") == 4
+        # No trailing strict prefix — returns 0 even with earlier token.
+        assert _trailing_action_prefix_len("Action: wait() done") == 0
+
+    def test_trailing_prefix_with_no_earlier_token_still_works(self):
+        # Pre-existing behavior preserved for the simple case.
+        from vllm_mlx.tool_parsers.ui_tars_tool_parser import (
+            _trailing_action_prefix_len,
+        )
+
+        assert _trailing_action_prefix_len("hello\nAc") == 2
+        assert _trailing_action_prefix_len("hello\nAction") == 6
+        # Word-boundary gate still active: 'A' AFTER a word char (no
+        # whitespace separation) isn't a candidate-opener.
+        assert _trailing_action_prefix_len("PlanA") == 0
+        # 'A' after a non-word char IS a candidate-opener — same word-
+        # boundary semantics the streaming parser uses for ``\bAction:``.
+        assert _trailing_action_prefix_len("Plan A") == 1

--- a/vllm_mlx/reasoning/ui_tars_parser.py
+++ b/vllm_mlx/reasoning/ui_tars_parser.py
@@ -24,7 +24,8 @@ from .base import DeltaMessage, ReasoningParser
 #   1. "Thought: ...\nAction: ..."         (default UI-TARS Computer-Use prompt)
 #   2. "Reflection: ...\nAction_Summary: ...\nAction: ..."  (1.5 reflective shape)
 #   3. "Action_Summary: ...\nAction: ..."  (1.5 minimal-reflection shape)
-#   4. "Thought: ...\n\n<plain-chat answer>" (plain chat lane — R6-M1)
+#   4. "Thought: ...\n\n<plain-chat answer>" (plain chat lane, blank-line boundary — R6-M1)
+#   4b. "Thought: <single-line>$"          (plain chat lane, EOS-only — R6-M1)
 #   5. "<think>...</think><plain-chat answer>"  (generic think-tag fallback — R6-M1)
 #
 # R6-M1 fix (Aki R1, 2026-06-21): pre-fix the regex required ``(?=\s*Action:)``
@@ -41,10 +42,19 @@ from .base import DeltaMessage, ReasoningParser
 # Boundary semantics:
 # - For shape #1/#2/#3 (Action lane): the rest-after-preamble is consumed
 #   by the tool parser as ``content``.
-# - For shape #4 (plain Thought boundary): the boundary is the first blank
-#   line (``\n\s*\n``) OR end-of-string. Allowing end-of-string handles
-#   the case where the model never emitted a follow-up answer — the entire
-#   buffer is reasoning, ``content`` is empty.
+# - For shape #4 (plain Thought, blank-line boundary): the boundary is the
+#   first ``\n\s*\n`` — bytes before are reasoning, bytes after are content.
+# - For shape #4b (plain Thought, EOS only): when the model emitted a
+#   single-line ``Thought:`` and nothing else (no follow-up answer), the
+#   entire buffer is reasoning. Codex r4 MEDIUM — pre-fix this branch
+#   was ``\s*\Z`` with ``re.DOTALL``, which lazy-matched up to EOS even
+#   when the body spanned multiple lines of plain prose (e.g.
+#   ``"Thought: I should answer directly.\nThe answer is 4."`` was
+#   classified as 100 % reasoning, dropping the model's answer). The
+#   restricted body ``[^\n]*?`` bans embedded newlines so the EOS branch
+#   only fires for genuinely single-line truncated thoughts; multi-line
+#   plain prose without a blank-line boundary falls through to "no
+#   preamble" and the whole text is routed to content.
 # - For shape #5 (think-tag): the boundary is the literal ``</think>``.
 #
 # Non-greedy bodies prevent a runaway thought trace from swallowing
@@ -58,11 +68,15 @@ _PREAMBLE_RE = re.compile(
     r"|(?:Reflection:\s*(?:.*?)\s*Action_Summary:\s*(?:.*?))"
     r"|(?:Action_Summary:\s*(?:.*?))"
     r")(?=\s*Action:)"
-    # 4 — plain-chat ``Thought:`` boundary: blank line OR end-of-string.
-    # ``Action:`` would have matched shape #1 already; reaching here
-    # means the model's ``Thought:`` is followed by prose, not a
-    # Computer-Use action.
-    r"|(?:Thought:\s*(?:.*?))(?=\s*\n\s*\n|\s*\Z)"
+    # 4 — plain-chat ``Thought:`` with blank-line boundary. The bytes
+    # before the blank line are reasoning; bytes after are content.
+    r"|(?:Thought:\s*(?:.*?))(?=\s*\n\s*\n)"
+    # 4b — plain-chat ``Thought:`` ending at EOS with NO embedded
+    # newline. Single-line truncated thoughts (e.g. ``"Thought: I'm
+    # uncertain."``) surface as reasoning. Multi-line plain prose
+    # WITHOUT a blank-line boundary falls through to no-match —
+    # ``extract_reasoning`` then routes the entire buffer to content.
+    r"|(?:Thought:[^\n]*?)(?=\s*\Z)"
     # 5 — generic ``<think>...</think>`` tag. The tag itself is part of
     # the matched preamble; the post-match content (``model_output[m.end():]``)
     # is the user-facing answer.

--- a/vllm_mlx/tool_parsers/ui_tars_tool_parser.py
+++ b/vllm_mlx/tool_parsers/ui_tars_tool_parser.py
@@ -906,18 +906,26 @@ def _trailing_action_prefix_len(text: str) -> int:
     tool-parser side of the hand-off so a leak that snuck past the
     reasoning parser's gate (e.g. via the postprocessor's fast-path
     short-circuit on ``<``/``[``-free deltas) is still suppressed.
+
+    Codex r4 BLOCKING — pre-fix, an early-return ``if _ACTION_TOKEN in
+    text: return 0`` disabled trailing-prefix holdback for the entire
+    buffer once any full ``Action:`` appeared anywhere earlier. Shapes
+    like ``["Action: is required.\\nAc", "tion: wait()"]`` or
+    ``["Action: wait() Ac", "tion: click(...)"]`` then leaked the
+    trailing ``"Ac"`` as content BEFORE the structured ``tool_calls``
+    flush. The fix evaluates only the TAIL overlap — a full ``Action:``
+    earlier in the buffer (whether completed or prose) must not
+    suppress holding a later trailing strict prefix.
     """
     if not text:
         return 0
-    # If the full token is already present anywhere in the buffer,
-    # the strict-prefix check is moot — the streaming consumer should
-    # handle the completed-action accounting and emit the residual.
-    if _ACTION_TOKEN in text:
-        return 0
     # Longest non-empty suffix of ``text`` that matches a strict prefix
     # of ``_ACTION_TOKEN``. We scan from longest-to-shortest so that a
-    # single delta containing ``"....Acti"`` returns 4, not 1.
-    max_overlap = len(_ACTION_TOKEN) - 1  # 6 bytes (we already excluded full token)
+    # single delta containing ``"....Acti"`` returns 4, not 1. The
+    # candidate cannot be the full token itself (handled by the
+    # completed-action / signature-gate paths upstream); we cap at
+    # ``len(_ACTION_TOKEN) - 1``.
+    max_overlap = len(_ACTION_TOKEN) - 1  # 6 bytes (strict prefix only)
     for k in range(min(max_overlap, len(text)), 0, -1):
         candidate = text[-k:]
         if not _ACTION_TOKEN.startswith(candidate):


### PR DESCRIPTION
## Summary

Follow-up to merged PR #829. Codex round 4 found two issues that landed in main with #829:

- **BLOCKING (reopens R6-C3)** — \`_trailing_action_prefix_len\` had an early-return \`if _ACTION_TOKEN in text: return 0\` that disabled trailing-prefix holdback for the ENTIRE buffer once any full \`Action:\` token appeared earlier (whether completed or prose). Streams like \`["Action: is required.\nAc", "tion: wait()"]\` or \`["Action: wait() Ac", "tion: click(...)"]\` leaked the trailing \`Ac\` as content BEFORE the structured \`tool_calls\` flush.

  **Fix**: evaluate only the tail overlap; earlier \`Action:\` tokens (completed or prose) must not suppress holding a later trailing strict prefix.

- **MEDIUM (R6-M1 over-capture)** — the plain-chat \`Thought:\` regex branch (shape #4) used \`(?=\s*\n\s*\n|\s*\Z)\` under \`re.DOTALL\`. With the lazy body and the \`\Z\` alternative, a response like \`"Thought: I should answer directly.\nThe answer is 4."\` (single newline, no blank line) lazy-matched the body up to EOS and classified the WHOLE response as reasoning, dropping the model's answer.

  **Fix**: split shape #4 into two — shape #4 (blank-line boundary required, multi-line thought OK) and shape #4b (EOS-only, body restricted to \`[^\n]*?\` so single-line truncated thoughts still surface as reasoning, but multi-line plain prose without a blank-line boundary falls through to "no preamble" and the entire text routes to content).

## Test plan

- [x] 4 new \`TestCodexR4TrailingPrefixIsolated\` tests covering prose+split, completed+split, helper-direct isolation, and word-boundary positive control.
- [x] 4 new \`TestR6M1ReasoningGateDecoupling\` cases: newline-prose-no-overcapture, EOS single-line still works, EOS-with-trailing-whitespace, blank-line multi-line thought.
- [x] All 199 UI-TARS suite tests pass (parser + lane parity + stream holdback).
- [x] No regressions on existing R6-C3 / R6-M1 / R6-M2 contracts.
- [x] Does not touch \`/v1/responses\` (r6-A), audio (r6-C), or cache (r6-D) lanes.

skip-version-bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)