### PR TITLE
fix(audio): r7-C — pin mlx-audio<0.4.4 + TTS input validation + STT short whisper alias

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -151,7 +151,19 @@ guided = [
 ]
 # Audio dependencies for TTS/STT (mlx-audio)
 audio = [
-    "mlx-audio>=0.2.9",
+    # R7-H3 (Bo 0.8.8 dogfood): pin BELOW 0.4.4. The 0.4.4 release
+    # regressed ``mlx_audio.tts.models.kokoro.istftnet.SineGen`` so the
+    # internal interpolation step produces an off-by-one length mismatch
+    # versus the noise tensor — every Kokoro request ends with
+    # ``[broadcast_shapes] Shapes (1,36600,1) and (1,36900,9) cannot be
+    # broadcast`` deep inside the istftnet generator. The rapid-mlx
+    # route's catch-all collapsed that into the opaque ``No audio
+    # generated`` 500 (the chunk loop swallowed the upstream raise).
+    # 0.4.3 (and earlier) does NOT have the regression — the same
+    # request returns a 73 KB WAV. Cap the upper bound until upstream
+    # ships a fix so every fresh ``pip install rapid-mlx[audio]``
+    # works out of the box.
+    "mlx-audio>=0.2.9,<0.4.4",
     "sounddevice>=0.4.0",
     "soundfile>=0.12.0",
     "scipy>=1.10.0",

--- a/tests/test_audio_r7_c_bundle.py
+++ b/tests/test_audio_r7_c_bundle.py
@@ -1,0 +1,600 @@
+# SPDX-License-Identifier: Apache-2.0
+"""R7-C regression bundle — Bo's 0.8.8 dogfood follow-up to r6-C.
+
+Three findings:
+
+* **R7-H3** — ``/v1/audio/speech`` with Kokoro returned 500 ``No audio
+  generated``. Root cause (verified by direct in-process probe) is the
+  ``mlx_audio==0.4.4`` ``istftnet.SineGen`` regression: an off-by-one
+  in the upsample interpolation produces ``noise_amp`` shape
+  ``(1, 36600, 1)`` while ``sine_waves`` is ``(1, 36900, 9)`` —
+  ``noise = noise_amp * mx.random.normal(sine_waves.shape)`` then
+  raises ``[broadcast_shapes] ... cannot be broadcast``. ``mlx-audio
+  ==0.4.3`` does NOT have the regression. Fix pins the dep to
+  ``<0.4.4``. The catch-all also now logs the FULL traceback at
+  ``exception`` level so future incidents are diagnosable from the
+  operator log (the pre-fix log had only the leaf message).
+
+* **R7-M8** — ``/v1/audio/speech`` with ``input=""`` (or no ``input``
+  key, or whitespace-only) 500'd with ``No audio generated``. The
+  route declared ``input: str = ""`` as a bare query parameter, so
+  JSON bodies were silently dropped AND there was nowhere to attach a
+  validation constraint. Fix binds a Pydantic
+  :class:`vllm_mlx.api.models.AudioSpeechRequest` body model with
+  ``input: str = Field(..., min_length=1)`` and a non-blank validator.
+  The envelope handler (registered for ``/v1/audio/speech``) emits a
+  400 ``invalid_request_error`` with ``param="input"``.
+
+* **R7-M9** — ``/v1/audio/transcriptions`` with ``model="whisper"``
+  (no size suffix) 404'd with ``model_not_found_error``. The chat lane
+  resolves short aliases at request-time; STT didn't. Fix adds
+  ``whisper`` (and ``whisper-1``) to ``STT_MODEL_ALIASES`` pointing at
+  the largest supported variant. ``/v1/audio/transcriptions`` AND
+  ``/v1/audio/translations`` both pick this up via the shared
+  ``_run_stt_request`` helper.
+"""
+
+from __future__ import annotations
+
+import io
+import struct
+import sys
+import types
+import wave
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+# ---------------------------------------------------------------------------
+# Helpers (copied from test_audio_routes_bundle.py so this file stands alone)
+# ---------------------------------------------------------------------------
+
+
+def _make_tone_wav(duration_s: float = 0.25, freq_hz: float = 440.0) -> bytes:
+    sample_rate = 16000
+    n_samples = int(sample_rate * duration_s)
+    buf = io.BytesIO()
+    with wave.open(buf, "wb") as w:
+        w.setnchannels(1)
+        w.setsampwidth(2)
+        w.setframerate(sample_rate)
+        import math
+
+        for i in range(n_samples):
+            sample = int(8000 * math.sin(2 * math.pi * freq_hz * i / sample_rate))
+            w.writeframes(struct.pack("<h", sample))
+    return buf.getvalue()
+
+
+def _install_fake_mlx_audio(monkeypatch):
+    """Install a fake ``mlx_audio`` package so the shallow probe's
+    ``find_spec`` succeeds without the real package present."""
+    import importlib.machinery
+
+    fake_mlx_audio = types.ModuleType("mlx_audio")
+    fake_mlx_audio.__path__ = []
+    fake_mlx_audio.__spec__ = importlib.machinery.ModuleSpec(
+        "mlx_audio", loader=None, is_package=True
+    )
+    fake_stt = types.ModuleType("mlx_audio.stt")
+    fake_stt.__path__ = []
+    fake_stt.__spec__ = importlib.machinery.ModuleSpec(
+        "mlx_audio.stt", loader=None, is_package=True
+    )
+    fake_stt_utils = types.ModuleType("mlx_audio.stt.utils")
+    fake_stt_utils.__spec__ = importlib.machinery.ModuleSpec(
+        "mlx_audio.stt.utils", loader=None
+    )
+    fake_stt_utils.load_model = lambda *_a, **_k: None
+    fake_tts = types.ModuleType("mlx_audio.tts")
+    fake_tts.__path__ = []
+    fake_tts.__spec__ = importlib.machinery.ModuleSpec(
+        "mlx_audio.tts", loader=None, is_package=True
+    )
+    fake_tts_generate = types.ModuleType("mlx_audio.tts.generate")
+    fake_tts_generate.__spec__ = importlib.machinery.ModuleSpec(
+        "mlx_audio.tts.generate", loader=None
+    )
+    fake_tts_generate.load_model = lambda *_a, **_k: None
+    monkeypatch.setitem(sys.modules, "mlx_audio", fake_mlx_audio)
+    monkeypatch.setitem(sys.modules, "mlx_audio.stt", fake_stt)
+    monkeypatch.setitem(sys.modules, "mlx_audio.stt.utils", fake_stt_utils)
+    monkeypatch.setitem(sys.modules, "mlx_audio.tts", fake_tts)
+    monkeypatch.setitem(sys.modules, "mlx_audio.tts.generate", fake_tts_generate)
+
+
+def _mount_audio_app() -> tuple[TestClient, callable]:
+    """Mount the audio router on a bare FastAPI app with the rapid-mlx
+    exception handlers wired in. The handlers are what turn the
+    Pydantic validation error into the OpenAI envelope shape — without
+    them the test would see the default FastAPI 422.
+    """
+    from vllm_mlx.config import get_config
+    from vllm_mlx.middleware.exception_handlers import install_exception_handlers
+    from vllm_mlx.routes import audio as audio_route
+
+    app = FastAPI()
+    app.include_router(audio_route.router)
+    install_exception_handlers(app)
+    cfg = get_config()
+    saved = cfg.api_key
+    cfg.api_key = None
+
+    def _restore():
+        cfg.api_key = saved
+
+    return TestClient(app), _restore
+
+
+# ---------------------------------------------------------------------------
+# R7-M9 — STT short alias resolution
+# ---------------------------------------------------------------------------
+
+
+class TestSTTShortWhisperAlias:
+    """``model="whisper"`` resolves through the alias map instead of
+    404'ing — R-04 contract parity with the chat lane.
+    """
+
+    def test_whisper_short_alias_resolves(self):
+        """The alias map MUST contain ``whisper`` → the largest Whisper
+        repo so a bare ``model="whisper"`` request from drop-in OpenAI
+        SDK code lands on the supported variant.
+        """
+        from vllm_mlx.routes.audio import STT_MODEL_ALIASES, _resolve_stt_model
+
+        # The mapping must exist…
+        assert "whisper" in STT_MODEL_ALIASES, (
+            "R7-M9 regression: 'whisper' is not in STT_MODEL_ALIASES. "
+            "Bo's r2-T6 finding required this short alias to resolve "
+            "to the largest supported variant for drop-in OpenAI SDK "
+            "compatibility."
+        )
+        # …and resolve via the shared helper (the same helper STT and
+        # translations call).
+        resolved = _resolve_stt_model("whisper")
+        assert "whisper-large-v3" in resolved.lower(), (
+            f"Expected `whisper` to resolve to the largest variant, got {resolved!r}"
+        )
+
+    def test_whisper_1_legacy_alias_resolves(self):
+        """OpenAI's legacy ``whisper-1`` placeholder maps to the same
+        Whisper variant so legacy SDKs don't 404."""
+        from vllm_mlx.routes.audio import STT_MODEL_ALIASES, _resolve_stt_model
+
+        assert "whisper-1" in STT_MODEL_ALIASES, (
+            "Legacy ``whisper-1`` placeholder must be accepted; some "
+            "OpenAI SDKs still emit it as the default."
+        )
+        assert "whisper-large-v3" in _resolve_stt_model("whisper-1").lower()
+
+    def test_whisper_short_alias_through_transcriptions_route(self, monkeypatch):
+        """End-to-end through ``/v1/audio/transcriptions``: a
+        ``model="whisper"`` form field must NOT trip the 404
+        ``model_not_found_error`` envelope. Pre-fix Bo saw 404; post-
+        fix the route reaches the engine (we stub the engine so we
+        observe the resolved model name).
+        """
+        from vllm_mlx.audio import stt as stt_mod
+        from vllm_mlx.routes import audio as audio_route
+
+        observed: list[str] = []
+
+        class _RecordingEngine:
+            def __init__(self, model_name: str):
+                observed.append(model_name)
+                self.model_name = model_name
+
+            def load(self):
+                pass
+
+            def transcribe(self, *_a, **_k):
+                return types.SimpleNamespace(
+                    text="hi", language="en", duration=0.1, segments=None
+                )
+
+        monkeypatch.setattr(stt_mod, "STTEngine", _RecordingEngine)
+        _install_fake_mlx_audio(monkeypatch)
+
+        audio_route._stt_engine = None
+
+        client, restore = _mount_audio_app()
+        try:
+            r = client.post(
+                "/v1/audio/transcriptions",
+                data={"model": "whisper"},
+                files={"file": ("tone.wav", _make_tone_wav(), "audio/wav")},
+            )
+        finally:
+            restore()
+            audio_route._stt_engine = None
+
+        assert r.status_code == 200, (
+            f"R7-M9 regression: model='whisper' returned {r.status_code} "
+            f"(expected 200 after alias map resolves the short id). "
+            f"Body: {r.text}"
+        )
+        # The engine MUST have been instantiated with the resolved HF
+        # path, not the literal short alias — confirms the alias map
+        # is wired into ``_resolve_stt_model``.
+        assert observed, "STT engine was never instantiated"
+        assert "whisper-large-v3" in observed[0].lower(), (
+            f"Expected the alias map to resolve 'whisper' to the "
+            f"largest variant, but the engine saw {observed[0]!r}"
+        )
+
+    def test_whisper_short_alias_through_translations_route(self, monkeypatch):
+        """The same alias map is shared with ``/v1/audio/translations``
+        via ``_run_stt_request`` so both routes resolve short aliases
+        identically. Codex r6 NIT requires the model to remain a
+        Whisper engine; ``whisper`` → whisper-large-v3 satisfies that.
+        """
+        from vllm_mlx.audio import stt as stt_mod
+        from vllm_mlx.routes import audio as audio_route
+
+        observed: list[str] = []
+
+        class _RecordingEngine:
+            def __init__(self, model_name: str):
+                observed.append(model_name)
+                self.model_name = model_name
+
+            def load(self):
+                pass
+
+            def transcribe(self, *_a, **_k):
+                return types.SimpleNamespace(
+                    text="hi", language="en", duration=0.1, segments=None
+                )
+
+        monkeypatch.setattr(stt_mod, "STTEngine", _RecordingEngine)
+        _install_fake_mlx_audio(monkeypatch)
+
+        audio_route._stt_engine = None
+
+        client, restore = _mount_audio_app()
+        try:
+            r = client.post(
+                "/v1/audio/translations",
+                data={"model": "whisper"},
+                files={"file": ("tone.wav", _make_tone_wav(), "audio/wav")},
+            )
+        finally:
+            restore()
+            audio_route._stt_engine = None
+
+        assert r.status_code == 200, (
+            f"R7-M9 regression on translations: model='whisper' "
+            f"returned {r.status_code}, expected 200. Body: {r.text}"
+        )
+        assert observed and "whisper-large-v3" in observed[0].lower()
+
+
+# ---------------------------------------------------------------------------
+# R7-M8 — empty / blank ``input`` → 400 ``invalid_request_error``
+# ---------------------------------------------------------------------------
+
+
+class TestSpeechInputValidation:
+    """Empty / missing / whitespace ``input`` raises the OpenAI 400
+    envelope BEFORE the synthesis engine runs. Pre-fix every shape
+    collapsed into the engine's ``No audio generated`` 500.
+    """
+
+    def test_empty_input_returns_400_envelope(self, monkeypatch):
+        _install_fake_mlx_audio(monkeypatch)
+
+        client, restore = _mount_audio_app()
+        try:
+            r = client.post(
+                "/v1/audio/speech",
+                json={"model": "kokoro", "input": "", "voice": "af_heart"},
+            )
+        finally:
+            restore()
+
+        assert r.status_code == 400, (
+            f"R7-M8 regression: empty input returned {r.status_code} "
+            f"(expected 400). Body: {r.text}"
+        )
+        body = r.json()
+        err = body["error"]
+        assert err["type"] == "invalid_request_error", err
+        assert err["param"] == "input", err
+        # The message must point at the ``input`` field so a caller
+        # can fix the request without server-side investigation.
+        assert "input" in err["message"].lower(), err
+
+    def test_missing_input_key_returns_400_envelope(self, monkeypatch):
+        """Pre-fix the route declared ``input: str = ""`` as a query
+        parameter, so a JSON body without ``input`` silently fell back
+        to the empty-string default. The bound Pydantic model now makes
+        ``input`` required — a missing key MUST 400.
+        """
+        _install_fake_mlx_audio(monkeypatch)
+
+        client, restore = _mount_audio_app()
+        try:
+            r = client.post(
+                "/v1/audio/speech",
+                json={"model": "kokoro", "voice": "af_heart"},
+            )
+        finally:
+            restore()
+
+        assert r.status_code == 400, (
+            f"R7-M8 regression: missing input key returned "
+            f"{r.status_code} (expected 400). Body: {r.text}"
+        )
+        body = r.json()
+        err = body["error"]
+        assert err["type"] == "invalid_request_error", err
+        assert err["param"] == "input", err
+
+    def test_whitespace_only_input_returns_400_envelope(self, monkeypatch):
+        """``min_length=1`` doesn't catch whitespace-only input because
+        ``"   "`` is three characters. The model's custom validator
+        rejects blank strings so the wire contract is "non-blank text"
+        and the empty-phoneme 500 cannot fire.
+        """
+        _install_fake_mlx_audio(monkeypatch)
+
+        client, restore = _mount_audio_app()
+        try:
+            r = client.post(
+                "/v1/audio/speech",
+                json={"model": "kokoro", "input": "   ", "voice": "af_heart"},
+            )
+        finally:
+            restore()
+
+        assert r.status_code == 400, (
+            f"R7-M8 regression: whitespace input returned "
+            f"{r.status_code} (expected 400). Body: {r.text}"
+        )
+        body = r.json()
+        err = body["error"]
+        assert err["type"] == "invalid_request_error", err
+        assert err["param"] == "input", err
+        # The message must mention non-empty so callers understand the
+        # rejection rule (vs. a generic "validation error").
+        msg = err["message"].lower()
+        assert "non-empty" in msg or "non-blank" in msg or "blank" in msg, err
+
+
+# ---------------------------------------------------------------------------
+# R7-M8 — ``input`` reaches the synthesis engine when valid
+# ---------------------------------------------------------------------------
+
+
+class TestSpeechBodyHonored:
+    """The Pydantic Body model means JSON requests actually reach the
+    handler — pre-fix the bare query params silently dropped the JSON
+    body so a non-empty ``input`` was still ``""`` at the engine."""
+
+    def test_json_body_input_reaches_engine(self, monkeypatch):
+        from vllm_mlx.audio import tts as tts_mod
+        from vllm_mlx.audio.probe import require_kokoro_runtime  # noqa: F401
+        from vllm_mlx.routes import audio as audio_route
+
+        observed: list[str] = []
+
+        class _NoopEngine:
+            def __init__(self, model_name: str):
+                self.model_name = model_name
+
+            def load(self):
+                pass
+
+            def generate(self, text: str, voice: str = "af_heart", speed: float = 1.0):
+                observed.append(text)
+                import numpy as np
+
+                return types.SimpleNamespace(
+                    audio=np.zeros(2400, dtype=np.float32),
+                    sample_rate=24000,
+                    duration=0.1,
+                )
+
+            def to_bytes(self, audio, format: str = "wav") -> bytes:
+                return b"\x00" * 1234
+
+        monkeypatch.setattr(tts_mod, "TTSEngine", _NoopEngine)
+        # Skip the misaki gate — we're not testing that path here.
+        from vllm_mlx.audio import probe as probe_mod
+
+        monkeypatch.setattr(probe_mod, "require_kokoro_runtime", lambda: None)
+        _install_fake_mlx_audio(monkeypatch)
+
+        audio_route._tts_engine = None
+
+        client, restore = _mount_audio_app()
+        try:
+            r = client.post(
+                "/v1/audio/speech",
+                json={
+                    "model": "kokoro",
+                    "input": "hello world",
+                    "voice": "af_heart",
+                },
+            )
+        finally:
+            restore()
+            audio_route._tts_engine = None
+
+        assert r.status_code == 200, r.text
+        assert observed == ["hello world"], (
+            f"R7-M8 regression: the JSON body ``input`` field did not "
+            f"reach the engine. Observed text: {observed}. Pre-fix the "
+            "route's bare query params silently dropped the body."
+        )
+
+
+# ---------------------------------------------------------------------------
+# R7-H3 — catch-all logs full traceback + emits OpenAI envelope
+# ---------------------------------------------------------------------------
+
+
+class TestSpeechCatchAllShape:
+    """When the synthesis engine raises a backend error (mlx_audio
+    regression, weight load failure, etc.) the catch-all must:
+
+    1. Log the FULL traceback via ``logger.exception`` so operators
+       can root-cause from the log alone.
+    2. Surface an OpenAI 500 envelope with ``type="api_error"`` /
+       ``code="tts_generation_failed"`` so SDK error branches can
+       pattern-match instead of seeing a bare-string ``detail``.
+    """
+
+    def test_engine_failure_emits_openai_envelope(self, monkeypatch, caplog):
+        import logging
+
+        from vllm_mlx.audio import tts as tts_mod
+        from vllm_mlx.routes import audio as audio_route
+
+        class _BoomEngine:
+            def __init__(self, model_name: str):
+                self.model_name = model_name
+
+            def load(self):
+                pass
+
+            def generate(self, *_a, **_k):
+                # Simulate the R7-H3 root-cause shape verbatim — the
+                # exact istftnet broadcast error mlx-audio 0.4.4 raised.
+                raise ValueError(
+                    "[broadcast_shapes] Shapes (1,36600,1) and "
+                    "(1,36900,9) cannot be broadcast."
+                )
+
+            def to_bytes(self, *_a, **_k):
+                return b""
+
+        monkeypatch.setattr(tts_mod, "TTSEngine", _BoomEngine)
+        from vllm_mlx.audio import probe as probe_mod
+
+        monkeypatch.setattr(probe_mod, "require_kokoro_runtime", lambda: None)
+        _install_fake_mlx_audio(monkeypatch)
+
+        audio_route._tts_engine = None
+
+        client, restore = _mount_audio_app()
+        with caplog.at_level(logging.ERROR, logger="rapid_mlx.routes.audio"):
+            try:
+                r = client.post(
+                    "/v1/audio/speech",
+                    json={
+                        "model": "kokoro",
+                        "input": "hello",
+                        "voice": "af_heart",
+                    },
+                )
+            finally:
+                restore()
+                audio_route._tts_engine = None
+
+        assert r.status_code == 500, r.text
+        body = r.json()
+        err = body["error"]
+        assert err["type"] == "api_error", err
+        assert err["code"] == "tts_generation_failed", err
+
+        # ``logger.exception`` writes the traceback into the
+        # LogRecord.exc_info tuple — assert that's populated for at
+        # least one record (it wasn't pre-fix; the legacy
+        # ``logger.error(f"...: {e}")`` left exc_info=None and the
+        # operator only saw the leaf message).
+        had_traceback = any(
+            "TTS generation failed" in rec.getMessage() and rec.exc_info is not None
+            for rec in caplog.records
+        )
+        assert had_traceback, (
+            "R7-H3 regression: the TTS catch-all must log the full "
+            "traceback via ``logger.exception`` so operators can "
+            "root-cause from the log. Found records: "
+            f"{[(r.getMessage(), r.exc_info is not None) for r in caplog.records]}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# R7-H3 — pyproject pins mlx-audio<0.4.4
+# ---------------------------------------------------------------------------
+
+
+class TestMlxAudioVersionPin:
+    """The R7-H3 fix is upstream — mlx-audio 0.4.4 broke
+    ``istftnet.SineGen``. Pin the dep below 0.4.4 in pyproject.toml so
+    a fresh ``pip install rapid-mlx[audio]`` doesn't pull the broken
+    release. The test parses pyproject.toml verbatim so a future
+    contributor that loosens the bound trips CI.
+    """
+
+    def test_mlx_audio_upper_bound_pins_below_0_4_4(self):
+        from pathlib import Path
+
+        try:
+            import tomllib  # 3.11+
+        except ImportError:  # pragma: no cover — keep 3.10 fallback
+            import tomli as tomllib  # type: ignore[import-not-found]
+
+        root = Path(__file__).resolve().parents[1]
+        with (root / "pyproject.toml").open("rb") as f:
+            cfg = tomllib.load(f)
+        audio_deps = cfg["project"]["optional-dependencies"]["audio"]
+        mlx_audio_specs = [d for d in audio_deps if d.startswith("mlx-audio")]
+        assert len(mlx_audio_specs) == 1, (
+            f"Expected exactly one mlx-audio pin, found {mlx_audio_specs}"
+        )
+        spec = mlx_audio_specs[0]
+        # Both the floor AND the upper-bound matter. The floor is
+        # historical; the upper-bound is the R7-H3 fix.
+        assert "<0.4.4" in spec, (
+            f"R7-H3 regression: mlx-audio must be pinned ``<0.4.4`` to "
+            f"avoid the istftnet SineGen broadcast_shapes regression. "
+            f"Current pin: {spec!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# R7-H3 — TTS alias map is module-level + shared helper
+# ---------------------------------------------------------------------------
+
+
+class TestTTSAliasResolver:
+    """The TTS alias resolution rule lives in a module-level helper
+    (``_resolve_tts_model``) so adding an engine lands in one place
+    and tests can pin the contract without going through the handler.
+    Mirrors the STT lane's ``_resolve_stt_model`` shape — R-04 contract
+    parity across audio routes.
+    """
+
+    def test_tts_alias_map_includes_canonical_engines(self):
+        from vllm_mlx.routes.audio import TTS_MODEL_ALIASES
+
+        for alias in ("kokoro", "chatterbox", "vibevoice", "voxcpm"):
+            assert alias in TTS_MODEL_ALIASES, (
+                f"R7-H3 follow-up: TTS_MODEL_ALIASES is missing "
+                f"canonical engine {alias!r}. The handler used to "
+                "inline this map; promotion to module-level requires "
+                "all pre-existing aliases stay."
+            )
+
+    def test_tts_default_alias_resolves(self):
+        from vllm_mlx.routes.audio import _resolve_tts_model
+
+        # ``None``, ``""``, and ``"default"`` all map to the default
+        # alias's HF path — drop-in OpenAI SDK compatibility (R-03).
+        for placeholder in (None, "", "default"):
+            resolved = _resolve_tts_model(placeholder)
+            assert "kokoro" in resolved.lower(), (
+                f"_resolve_tts_model({placeholder!r}) must default to "
+                f"the Kokoro alias, got {resolved!r}"
+            )
+
+    def test_tts_pass_through_for_full_hf_path(self):
+        """A HuggingFace-shaped id passes through verbatim so callers
+        can opt in to repos not in the alias map."""
+        from vllm_mlx.routes.audio import _resolve_tts_model
+
+        hf_path = "mlx-community/Kokoro-82M-bf16"
+        assert _resolve_tts_model(hf_path) == hf_path

--- a/tests/test_audio_r7_c_bundle.py
+++ b/tests/test_audio_r7_c_bundle.py
@@ -42,8 +42,34 @@ import sys
 import types
 import wave
 
-from fastapi import FastAPI
-from fastapi.testclient import TestClient
+import pytest
+
+# ``vllm_mlx.routes.audio`` transitively imports ``mlx.core`` via the
+# engine wiring. Linux CI runners (``pr_validate``'s validate job) don't
+# install mlx, so a bare import raises ``ModuleNotFoundError`` and 13
+# unrelated tests look like regressions. ``importorskip`` short-circuits
+# the file with a clean SKIP so it stays out of the negative-control set
+# AND still executes anywhere with the right deps (Apple Silicon CI +
+# any dev machine with ``[audio]`` installed). Mirrors the
+# ``test_audio_upload_size_limit.py`` skip block — same trap.
+pytest.importorskip(
+    "mlx.core",
+    reason="audio route imports transitively pull in mlx; "
+    "test runs on Apple Silicon / dev, not Linux CI runners",
+)
+pytest.importorskip(
+    "mlx_lm",
+    reason="audio route imports transitively pull in mlx_lm; "
+    "test runs on Apple Silicon / dev, not Linux CI runners",
+)
+pytest.importorskip(
+    "multipart",
+    reason="TestClient(files=...) requires python-multipart; "
+    "skip on minimal-deps runners (CI pr-validate)",
+)
+
+from fastapi import FastAPI  # noqa: E402 — keep skips at top
+from fastapi.testclient import TestClient  # noqa: E402
 
 # ---------------------------------------------------------------------------
 # Helpers (copied from test_audio_routes_bundle.py so this file stands alone)

--- a/tests/test_audio_routes_bundle.py
+++ b/tests/test_audio_routes_bundle.py
@@ -892,14 +892,15 @@ class TestKokoroMisakiGate:
 
         client, restore = _mount_audio_app()
         try:
-            # The route declares ``model: str = "kokoro"`` without an
-            # explicit ``Body(...)`` / ``Form(...)`` annotation, so
-            # FastAPI treats it as a QUERY parameter. Sending it in
-            # the JSON body would silently leave ``model`` at the
-            # default "kokoro" and the test would trip the gate
-            # unrelated to the family-check logic. Send via query.
+            # R7-M8: the route now binds a Pydantic Body model
+            # (``AudioSpeechRequest``) so the body MUST be JSON. The
+            # pre-r7-C query-param shape silently lost the body; the
+            # current contract puts ``input`` on the JSON body, which
+            # is the OpenAI-canonical shape and what Bo's dogfood
+            # repro emitted.
             r = client.post(
-                "/v1/audio/speech?model=chatterbox&input=hi&voice=default",
+                "/v1/audio/speech",
+                json={"model": "chatterbox", "input": "hi", "voice": "default"},
             )
         finally:
             restore()

--- a/vllm_mlx/api/models.py
+++ b/vllm_mlx/api/models.py
@@ -2094,13 +2094,50 @@ class AudioTranscriptionResponse(BaseModel):
 
 
 class AudioSpeechRequest(BaseModel):
-    """Request for text-to-speech."""
+    """Request for text-to-speech (OpenAI ``/v1/audio/speech`` compatible).
+
+    R7-M8 (Bo 0.8.8 dogfood): ``input`` must reject empty / whitespace-
+    only strings BEFORE we reach the synthesis engine. Pre-fix the
+    route declared ``input: str = ""`` as a bare query parameter, so
+    JSON bodies were silently dropped and an empty/missing ``input``
+    collapsed into the generic 500 ``No audio generated`` envelope
+    (the engine looped over an empty phoneme list and rapid-mlx's
+    chunk-collector raised). Both shapes are CLIENT errors and should
+    surface a 400 with ``param="input"`` so callers can fix their
+    request payload without an opaque 500 round-trip.
+
+    ``input`` carries an explicit ``min_length=1``; the bound model is
+    registered with the envelope handler so the Pydantic validation
+    error surfaces as ``{"error": {"type": "invalid_request_error",
+    "param": "input", ...}}`` instead of the FastAPI 422 default.
+    """
 
     model: str = "kokoro"
-    input: str
+    # min_length=1 catches the ``input=""`` shape Bo reported. The
+    # ``model_validator`` below catches the whitespace-only shape that
+    # slips past Pydantic's length check (``" "`` is one char) — both
+    # produce empty phoneme lists downstream so both must 400.
+    input: str = Field(..., min_length=1)
     voice: str = "af_heart"
-    speed: float = 1.0
+    # OpenAI bounds: 0.25..4.0. Out-of-range values silently no-op
+    # inside mlx_audio in some lanes; reject up front so the envelope
+    # matches the documented contract.
+    speed: float = Field(default=1.0, ge=0.25, le=4.0)
     response_format: str = "wav"
+
+    @field_validator("input")
+    @classmethod
+    def _input_must_be_non_blank(cls, v: str) -> str:
+        # ``min_length=1`` only checks character count — ``"   "`` is
+        # length 3 and still passes, but it produces an empty phoneme
+        # list downstream and trips the same 500 ``No audio generated``
+        # the empty-string case did. Reject here too so the wire
+        # contract is "non-blank text" and the param= envelope stays
+        # consistent. We raise ``ValueError`` so Pydantic packages it as
+        # the same ``value_error`` shape the field handler emits.
+        if not v.strip():
+            raise ValueError("input must be a non-empty, non-blank string")
+        return v
 
 
 class AudioSeparationRequest(BaseModel):

--- a/vllm_mlx/middleware/exception_handlers.py
+++ b/vllm_mlx/middleware/exception_handlers.py
@@ -985,6 +985,7 @@ def _register_canonical_request_models() -> None:
     try:
         from ..api.anthropic_models import AnthropicRequest
         from ..api.models import (
+            AudioSpeechRequest,
             ChatCompletionRequest,
             CompletionRequest,
             EmbeddingRequest,
@@ -1003,6 +1004,12 @@ def _register_canonical_request_models() -> None:
         EmbeddingRequest,
         AnthropicRequest,
         ResponsesRequest,
+        # R7-M8: AudioSpeechRequest binds the TTS request body and
+        # enforces ``input`` non-blank at the schema layer. Registering
+        # here lets the envelope handler walk the loc against the
+        # actual model fields so ``error.param`` is populated
+        # (``"input"``) instead of collapsing to ``<field>``.
+        AudioSpeechRequest,
     ):
         register_request_model(cls)
     # Route-path → root-model bindings. Walked in declaration order, so
@@ -1016,6 +1023,12 @@ def _register_canonical_request_models() -> None:
     register_request_path("/v1/embeddings", EmbeddingRequest)
     register_request_path("/v1/messages", AnthropicRequest)
     register_request_path("/v1/responses", ResponsesRequest)
+    # R7-M8: ``input`` lives on three different request models
+    # (ResponsesRequest, EmbeddingRequest, AudioSpeechRequest); the
+    # path-based pin makes ``/v1/audio/speech`` resolve to the TTS
+    # body model so the envelope's ``param`` slot points at the
+    # right ``input`` field.
+    register_request_path("/v1/audio/speech", AudioSpeechRequest)
 
 
 def install_exception_handlers(app: FastAPI) -> None:

--- a/vllm_mlx/routes/audio.py
+++ b/vllm_mlx/routes/audio.py
@@ -6,9 +6,10 @@ import os
 import re
 import tempfile
 
-from fastapi import APIRouter, Depends, Form, HTTPException, Query, UploadFile
+from fastapi import APIRouter, Body, Depends, Form, HTTPException, Query, UploadFile
 from starlette.responses import PlainTextResponse, Response
 
+from ..api.models import AudioSpeechRequest
 from ..middleware.auth import verify_api_key
 
 logger = logging.getLogger(__name__)
@@ -42,6 +43,19 @@ STT_MODEL_ALIASES: dict[str, str] = {
     "whisper-small": "mlx-community/whisper-small-mlx",
     "parakeet": "mlx-community/parakeet-tdt-0.6b-v2",
     "parakeet-v3": "mlx-community/parakeet-tdt-0.6b-v3",
+    # R7-M9 (Bo 0.8.8 dogfood): short ``whisper`` (no size suffix) is the
+    # OpenAI-canonical id that callers reach for first ("just give me
+    # Whisper"). Pre-fix this 404'd because the alias map only listed
+    # the size-suffixed siblings. The chat lane resolves short aliases
+    # at request-time via the registry; STT now matches that contract
+    # by routing bare ``whisper`` to the largest supported variant.
+    # Mirrors OpenAI's ``whisper-1`` placeholder semantics — same
+    # destination as ``whisper-large-v3``.
+    "whisper": "mlx-community/whisper-large-v3-mlx",
+    # OpenAI-spec id from the legacy Whisper API. Some SDKs still ship
+    # ``whisper-1`` by default; map it to the largest supported variant
+    # so drop-in OpenAI code doesn't 404 on the alias check.
+    "whisper-1": "mlx-community/whisper-large-v3-mlx",
 }
 
 # F-210: model strings must canonicalize to either a bare alias name
@@ -1158,23 +1172,76 @@ async def create_translation(
     )
 
 
+# R7-H3 (Bo 0.8.8 dogfood): TTS short-alias → HF repo map. Promoted
+# from the inline ``model_map`` inside ``create_speech`` to a module-
+# level constant so STT and TTS aliases live side-by-side and the
+# unit tests can pin the table without crawling the handler body.
+# Mirrors ``STT_MODEL_ALIASES`` (R-04 contract). Any future engine
+# addition lands here once, not in the handler.
+TTS_MODEL_ALIASES: dict[str, str] = {
+    "kokoro": "mlx-community/Kokoro-82M-bf16",
+    "kokoro-4bit": "mlx-community/Kokoro-82M-4bit",
+    "chatterbox": "mlx-community/chatterbox-turbo-fp16",
+    "chatterbox-4bit": "mlx-community/chatterbox-turbo-4bit",
+    "vibevoice": "mlx-community/VibeVoice-Realtime-0.5B-4bit",
+    "voxcpm": "mlx-community/VoxCPM1.5",
+}
+
+#: Default TTS alias for empty / ``"default"`` requests. Mirrors the
+#: ``DEFAULT_STT_ALIAS`` rule on the STT side — drop-in OpenAI-SDK code
+#: that omits ``model=`` lands here.
+DEFAULT_TTS_ALIAS = "kokoro"
+
+
+def _resolve_tts_model(model: str | None) -> str:
+    """Map a TTS request-time alias to its HF repo id.
+
+    Recognises:
+
+    * ``None`` / ``""`` / ``"default"`` → :data:`DEFAULT_TTS_ALIAS`'s
+      mapped HF id (R-03 OpenAI-canonical placeholder).
+    * A short alias listed in :data:`TTS_MODEL_ALIASES` → its mapped
+      HF id.
+    * Anything else → pass through verbatim (a HuggingFace repo id
+      the client is opting in to). Pre-fix the handler accepted the
+      same shape inline; promotion to a helper keeps the contract
+      identical without re-implementing the rule.
+    """
+    if not model or model == "default":
+        return TTS_MODEL_ALIASES[DEFAULT_TTS_ALIAS]
+    return TTS_MODEL_ALIASES.get(model, model)
+
+
 @router.post("/v1/audio/speech", dependencies=[Depends(verify_api_key)])
-async def create_speech(
-    model: str = "kokoro",
-    input: str = "",
-    voice: str = "af_heart",
-    speed: float = 1.0,
-    response_format: str = "wav",
-):
+async def create_speech(request: AudioSpeechRequest = Body(...)):
     """Generate speech from text (OpenAI TTS API compatible).
+
+    R7-M8 (Bo 0.8.8 dogfood): Bind a Pydantic :class:`AudioSpeechRequest`
+    body model so the route honors the OpenAI JSON-body contract AND
+    so empty / blank ``input`` raises a 400 ``invalid_request_error``
+    with ``param="input"`` BEFORE the synthesis engine runs.
+    Pre-fix the handler declared each field as a bare query parameter,
+    which meant:
+
+    * The JSON body Bo (and every OpenAI SDK) sends was silently
+      dropped — ``input`` always fell back to its empty-string default,
+      so every request synthesized the empty phoneme list and 500'd
+      with ``No audio generated``.
+    * There was nowhere to attach a ``min_length=1`` constraint,
+      so the conflation with "engine genuinely failed" was structural.
 
     F-D05: probe ``mlx_audio`` availability through the shared
     :func:`vllm_mlx.audio.probe.require_mlx_audio` helper so this
     route's 503 envelope matches ``/v1/audio/voices`` and
-    ``/v1/audio/transcriptions``. Pre-fix each audio route hand-rolled
-    its own check; the voices route never probed at all, the speech
-    route only saw the ImportError, and operators couldn't tell from
-    one endpoint that the others were also broken.
+    ``/v1/audio/transcriptions``.
+
+    R7-H3 (Bo 0.8.8 dogfood): the catch-all now logs at ``exception``
+    level (full traceback) and surfaces an OpenAI-shape envelope with
+    ``type="api_error"``, ``code="tts_generation_failed"``. Pre-fix
+    the catch-all collapsed every backend failure to a single-line
+    ``logger.error`` + bare-string ``detail`` — the operator couldn't
+    diagnose the upstream ``mlx_audio==0.4.4`` istftnet regression
+    because the traceback never reached the log.
     """
     global _tts_engine
 
@@ -1190,26 +1257,23 @@ async def create_speech(
 
     require_mlx_audio_tts()
 
+    # Pydantic already validated min_length / non-blank — past this
+    # point the input is safe to forward.
+    model = request.model
+    input_text = request.input
+    voice = request.voice
+    speed = request.speed
+    response_format = request.response_format
+
     try:
         from ..audio.tts import TTSEngine
 
-        model_map = {
-            "kokoro": "mlx-community/Kokoro-82M-bf16",
-            "kokoro-4bit": "mlx-community/Kokoro-82M-4bit",
-            "chatterbox": "mlx-community/chatterbox-turbo-fp16",
-            "chatterbox-4bit": "mlx-community/chatterbox-turbo-4bit",
-            "vibevoice": "mlx-community/VibeVoice-Realtime-0.5B-4bit",
-            "voxcpm": "mlx-community/VoxCPM1.5",
-        }
-        # R-03: ``"default"`` is the OpenAI-spec placeholder LangChain /
-        # LlamaIndex / openai-python emit when the caller hasn't picked
-        # a specific model id. Map it to the same alias as omitting the
-        # field entirely (``kokoro`` — the route signature's default
-        # value) so drop-in OpenAI-SDK code works without a manual
-        # ``model=`` override.
-        if model == "default":
-            model = "kokoro"
-        model_name = model_map.get(model, model)
+        # R7-H3 follow-up: alias resolution lives in a shared helper
+        # (see ``_resolve_tts_model``) so the bare alias / ``"default"``
+        # / HF-path passthrough rule is one code path. Engines added in
+        # the future land in :data:`TTS_MODEL_ALIASES` once, not in the
+        # handler body.
+        model_name = _resolve_tts_model(model)
 
         # F-K-KOKORO-MISAKI: Kokoro pulls ``misaki`` lazily inside
         # ``KokoroPipeline``; the TTS-lane probe above can't catch
@@ -1225,7 +1289,7 @@ async def create_speech(
             _tts_engine = TTSEngine(model_name)
             _tts_engine.load()
 
-        audio = _tts_engine.generate(input, voice=voice, speed=speed)
+        audio = _tts_engine.generate(input_text, voice=voice, speed=speed)
         audio_bytes = _tts_engine.to_bytes(audio, format=response_format)
 
         content_type = (
@@ -1250,8 +1314,33 @@ async def create_speech(
             ),
         )
     except Exception as e:
-        logger.error(f"TTS generation failed: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
+        # R7-H3: ``logger.exception`` writes the FULL traceback to the
+        # operator log so future regressions in mlx_audio (or any other
+        # upstream backend) leave enough breadcrumbs to root-cause from
+        # the log alone. The pre-fix ``logger.error(f"...: {e}")`` only
+        # captured the leaf exception's str() — operators chasing the
+        # 0.4.4 istftnet shape mismatch never saw which istftnet line
+        # raised, only the catch-all's ``No audio generated`` (which was
+        # in fact the inner ``tts.py`` raise, NOT the upstream
+        # broadcast_shapes error). Two-source confusion that the
+        # traceback solves on its own.
+        logger.exception("TTS generation failed: %s", e)
+        # Replace the legacy bare-string ``detail`` with the OpenAI
+        # envelope so clients can pattern-match on
+        # ``error.type=="api_error"`` and ``error.code=="tts_generation_failed"``.
+        # Mirrors the transcriptions ``code="transcription_failed"``
+        # convention so cross-lane error handling stays uniform.
+        raise HTTPException(
+            status_code=500,
+            detail={
+                "error": {
+                    "message": "Audio speech synthesis failed",
+                    "type": "api_error",
+                    "code": "tts_generation_failed",
+                    "param": None,
+                }
+            },
+        )
 
 
 @router.get("/v1/audio/voices", dependencies=[Depends(verify_api_key)])


### PR DESCRIPTION
## Why

Three findings from Bo's 0.8.8 r1/r2 dogfood (r6-C follow-ups + 2 hygiene gaps):

| ID | Finding | Sev |
| -- | ------- | --- |
| R7-H3 | Kokoro TTS still 500 with generic `No audio generated` (root cause: upstream `mlx-audio==0.4.4` istftnet regression — verified in-process) | HIGH |
| R7-M8 | `/v1/audio/speech` with empty / missing / whitespace `input` returns 500 instead of OpenAI 400 envelope | MED |
| R7-M9 | `/v1/audio/transcriptions` with short alias `model="whisper"` returns 404 (chat lane resolves short aliases, STT didn't) | MED |

## What changed

**R7-H3 (TTS Kokoro 500):**
- Pinned `mlx-audio>=0.2.9,<0.4.4` in `pyproject.toml`. The 0.4.4 release regressed `mlx_audio.tts.models.kokoro.istftnet.SineGen` so the upsample step produces `noise_amp (1,36600,1)` versus `sine_waves (1,36900,9)` and the broadcast multiply raises `[broadcast_shapes] Shapes ... cannot be broadcast`. 0.4.3 does not have the regression — same in-process probe returns a 73 KB WAV.
- TTS route catch-all now uses `logger.exception` (full traceback to operator log instead of just the leaf message) and emits the OpenAI envelope `{"error":{"type":"api_error","code":"tts_generation_failed","param":null,...}}` instead of bare-string `detail`.

**R7-M8 (empty TTS input):**
- Bound a Pydantic `AudioSpeechRequest` body model with `input: Field(..., min_length=1)` plus a non-blank validator (`"   "` is one char but still empty for the synthesis pipeline).
- Registered the model with the envelope handler (per-path map → `AudioSpeechRequest`) so the 400 carries `param="input"` and the OpenAI shape instead of the FastAPI 422 default.
- Side effect: JSON bodies now actually reach the handler — pre-fix the route's bare query params silently dropped the body, so even a non-empty `input` was lost.

**R7-M9 (whisper short alias):**
- Added `whisper` and `whisper-1` (legacy OpenAI placeholder) to `STT_MODEL_ALIASES`, both pointing at the largest supported variant.
- The shared `_resolve_stt_model` helper is already called from `_run_stt_request`, so both `/v1/audio/transcriptions` and `/v1/audio/translations` pick up the new short aliases.
- Promoted the inline TTS `model_map` to a module-level `TTS_MODEL_ALIASES` constant plus a `_resolve_tts_model` helper — matches the STT lane shape, so adding engines lands in one place and tests can pin the contract without going through the handler.

## Test plan

- [x] Reproduced R7-H3 root cause in-process: `mlx-audio==0.4.4` → `ValueError: [broadcast_shapes] Shapes (1,36600,1) and (1,36900,9) cannot be broadcast` deep inside istftnet line 620. Same probe with `mlx-audio==0.4.3` returns 73 KB WAV.
- [x] Confirmed end-to-end through the route (with `install_exception_handlers` mounted): `POST /v1/audio/speech {model:"kokoro", input:"hello world", voice:"af_heart"}` → 200 + 73 KB audio/wav.
- [x] `tests/test_audio_r7_c_bundle.py` — 13 new tests, all passing.
- [x] `tests/test_audio_routes_bundle.py` — full suite still passes (1 test updated to use JSON body now that the route binds Pydantic).
- [x] `tests/test_audio*.py`, `tests/test_exception_handlers.py`, `tests/test_envelope_field_extraction.py`, `tests/test_d_anthro_validation.py`, `tests/test_request_time_alias_resolution.py` — all pass.
- [x] Wider audio/alias-related sweep: 1874 passed, 9 skipped (no regressions).
- [x] `ruff check` / `ruff format --check` on touched files — clean. Pre-existing errors elsewhere in repo (evals/, scripts/) are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)