### PR TITLE
fix(validation): r7-B cross-route hardening (R7-H4/H5/M3/M4)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -281,6 +281,7 @@ ignore = [
 # ``Model`` so the test body reads naturally (``Model(model="x", ...)``);
 # renaming would lose readability across many tests.
 "tests/test_param_validation_r5e.py" = ["N803"]
+"tests/test_param_validation_r7b.py" = ["N803"]
 
 [tool.mypy]
 python_version = "3.10"

--- a/tests/test_param_validation_r7b.py
+++ b/tests/test_param_validation_r7b.py
@@ -245,6 +245,115 @@ class TestResponseFormatStrictOuterLevel:
 
 
 # ---------------------------------------------------------------------------
+# R7-B codex MED follow-up: non-bool strict rejected at PARSE time
+# ---------------------------------------------------------------------------
+
+
+class TestResponseFormatStrictNonBoolRejectedAtParse:
+    """Codex r7-B MED: ``ResponseFormat.strict`` and
+    ``ResponseFormatJsonSchema.strict`` must reject non-bool wire forms
+    at parse time, on BOTH the typed-model arm and the bare-dict arm
+    of the ``ResponseFormat | dict`` union.
+
+    Pre-fix the typed arm declared ``strict: bool | None`` (Pydantic v2
+    in default lax mode coerces ``"true"`` → ``True``), and
+    ``_validate_response_format_raw`` did not inspect ``strict`` at
+    all — so ``{"strict":"true",...}`` slipped through the dict arm
+    silently and ``is_strict_json_schema`` (which uses identity
+    ``is True``) returned False, downgrading the request to
+    unconstrained generation.
+    """
+
+    _SCHEMA = {"type": "object", "properties": {"x": {"type": "string"}}}
+
+    @pytest.mark.parametrize(
+        "bad_strict",
+        ["true", "false", "yes", "no", 1, 0, [], {}],
+    )
+    def test_typed_outer_strict_non_bool_rejected(self, bad_strict):
+        """Typed arm: ``StrictBool`` raises at parse time."""
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            ResponseFormat(
+                type="json_schema",
+                strict=bad_strict,
+                json_schema={"name": "p", "schema": self._SCHEMA},
+            )
+
+    @pytest.mark.parametrize("bad_strict", ["true", "false", 1, 0, [], {}])
+    def test_typed_inner_strict_non_bool_rejected(self, bad_strict):
+        """Typed inner ``ResponseFormatJsonSchema.strict`` is ``StrictBool``
+        too — same rejection."""
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            ResponseFormat(
+                type="json_schema",
+                json_schema={
+                    "name": "p",
+                    "strict": bad_strict,
+                    "schema": self._SCHEMA,
+                },
+            )
+
+    @pytest.mark.parametrize("bad_strict", ["true", "false", "yes", 1, 0, [], {}])
+    def test_chat_request_outer_strict_non_bool_rejected(self, bad_strict):
+        """End-to-end via ``ChatCompletionRequest`` — the dict-arm
+        validator closes the union escape hatch so the same wire form
+        that the typed arm rejects also 400's the dict arm."""
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            ChatCompletionRequest(
+                model="x",
+                messages=_user_msg(),
+                response_format={
+                    "type": "json_schema",
+                    "strict": bad_strict,
+                    "json_schema": {"name": "p", "schema": self._SCHEMA},
+                },
+            )
+
+    @pytest.mark.parametrize("bad_strict", ["true", "false", "yes", 1, 0, [], {}])
+    def test_chat_request_inner_strict_non_bool_rejected(self, bad_strict):
+        """End-to-end via ``ChatCompletionRequest`` — nested
+        ``json_schema.strict`` rejected on the dict arm too."""
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            ChatCompletionRequest(
+                model="x",
+                messages=_user_msg(),
+                response_format={
+                    "type": "json_schema",
+                    "json_schema": {
+                        "name": "p",
+                        "strict": bad_strict,
+                        "schema": self._SCHEMA,
+                    },
+                },
+            )
+
+    def test_typed_outer_strict_true_still_accepted(self):
+        """Sanity: ``strict=True`` (proper bool) still passes."""
+        rf = ResponseFormat(
+            type="json_schema",
+            strict=True,
+            json_schema={"name": "p", "schema": self._SCHEMA},
+        )
+        assert rf.strict is True
+
+    def test_typed_outer_strict_false_still_accepted(self):
+        rf = ResponseFormat(
+            type="json_schema",
+            strict=False,
+            json_schema={"name": "p", "schema": self._SCHEMA},
+        )
+        assert rf.strict is False
+
+
+# ---------------------------------------------------------------------------
 # R7-M3: shared >= 1 gate on max_tokens / max_output_tokens / max_completion_tokens
 # ---------------------------------------------------------------------------
 

--- a/tests/test_param_validation_r7b.py
+++ b/tests/test_param_validation_r7b.py
@@ -1,0 +1,371 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+r7-B cross-route validation hardening (R7-H4 / R7-H5 / R7-M3 / R7-M4).
+
+Vlad r7 (rapid-desktop /tmp/dogfood-088/vlad/vlad-r1.md, vlad-r2.md)
+surfaced four validation-gap bugs on v0.8.8. r5-E (PR #824) had
+already hardened the top-level chat / completions surfaces but
+``/v1/responses`` and ``/v1/messages`` slipped through. The fixes
+are systemic — shared validators + shared types — so the four
+schema-level tests below exercise the four request models directly
+via Pydantic, the same gate every route hits before the handler
+runs.
+
+  * **R7-H4** (``stream_options.include_usage`` accepts any value on
+    /v1/responses + /v1/messages): the bypass was a missing field
+    declaration on ``ResponsesRequest`` / ``AnthropicRequest`` — the
+    chat + completions models DECLARED ``StreamOptions`` (whose
+    ``StrictBool`` field validator catches the truthy-string form);
+    Responses/Anthropic silently dropped the unknown field and
+    HTTP-200'd. Fix declares the same shared ``StreamOptions`` type
+    on both surfaces so the strict-bool gate runs through one
+    validator.
+
+  * **R7-H5** (legacy chat ``response_format`` strict bypass when
+    ``strict`` is at the OUTER level): pre-fix
+    ``is_strict_json_schema`` only inspected the canonical
+    ``response_format.json_schema.strict`` slot. Clients writing
+    against the Responses-API ``text.format.strict`` shape and then
+    pointing at /v1/chat/completions kept ``strict`` at the OUTER
+    level (a sibling of ``type``). Pydantic silently dropped the
+    unknown field on the typed ``ResponseFormat`` model, and the
+    legacy chat path HTTP-200'd without the [guided]-required gate
+    ever firing. Fix declares ``strict`` as an outer-level field on
+    ``ResponseFormat`` and extends ``is_strict_json_schema`` to fire
+    on either nesting position.
+
+  * **R7-M3** (``max_output_tokens=-5`` silently accepted on
+    /v1/responses; ``max_tokens=-5`` on /v1/completions and
+    /v1/messages): only the chat route had a hand-rolled
+    ``max_tokens < 1`` guard; the schema layer accepted any int.
+    Fix consolidates a shared ``_validate_positive_int`` validator
+    + ``mode="before"`` field-validator on every numeric token-budget
+    field across all four request models so the rejection is
+    schema-layer, uniform, and route-independent.
+
+  * **R7-M4** (``response_format={"type":"json_object"}`` wraps body
+    in markdown fence on /v1/responses): the chat route's
+    ``extract_json_from_response`` fence-strip was never wired into
+    the /v1/responses non-stream path. Fix calls the same helper
+    after ``sanitize_output`` so the same model+prompt produces a
+    consistently-stripped body on both surfaces. The schema layer
+    test below covers the strict-mode contract; the fence-strip
+    helper itself has direct coverage in
+    ``test_api_utils.py``.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from vllm_mlx.api.anthropic_models import AnthropicRequest
+from vllm_mlx.api.models import (
+    ChatCompletionRequest,
+    CompletionRequest,
+    ResponseFormat,
+    StreamOptions,
+)
+from vllm_mlx.api.responses_models import ResponsesRequest
+from vllm_mlx.api.tool_calling import is_strict_json_schema
+from vllm_mlx.api.utils import extract_json_from_response
+
+
+def _user_msg():
+    return [{"role": "user", "content": "hi"}]
+
+
+# ---------------------------------------------------------------------------
+# R7-H4: stream_options.include_usage strict-bool across ALL request surfaces
+# ---------------------------------------------------------------------------
+
+
+class TestStreamOptionsIncludeUsageCrossRoute:
+    """The strict-bool gate must fire from every OpenAI-compat surface
+    (chat / completions / responses / messages). r5-E (B-9) closed the
+    chat + completions arms; r7-B closes the Responses + Anthropic arms
+    by declaring the SAME shared ``StreamOptions`` field on those models.
+    """
+
+    # The four request surfaces in one matrix — parametrize so a future
+    # surface (or a regression on any of these) is one test line, not a
+    # new copy-paste class. Each entry: (Model, required-kwargs).
+    _SURFACES = [
+        (ChatCompletionRequest, {"messages": _user_msg()}),
+        (CompletionRequest, {"prompt": "hi"}),
+        (ResponsesRequest, {"input": "hi"}),
+        (AnthropicRequest, {"messages": _user_msg(), "max_tokens": 5}),
+    ]
+
+    @pytest.mark.parametrize("Model,extra", _SURFACES)
+    @pytest.mark.parametrize(
+        "bad_value",
+        ["yes", "true", "no", "false", "1", "0", "on", "off", 1, 0],
+    )
+    def test_non_bool_include_usage_rejected_every_route(self, Model, extra, bad_value):
+        with pytest.raises(ValidationError) as excinfo:
+            Model(
+                model="x",
+                stream_options={"include_usage": bad_value},
+                **extra,
+            )
+        msg = str(excinfo.value)
+        # Field name is in either loc or msg — both are fine for a
+        # client surfacing the error.
+        assert "include_usage" in msg
+
+    @pytest.mark.parametrize("Model,extra", _SURFACES)
+    @pytest.mark.parametrize("good_value", [True, False])
+    def test_proper_bool_include_usage_accepted_every_route(
+        self, Model, extra, good_value
+    ):
+        req = Model(
+            model="x",
+            stream_options={"include_usage": good_value},
+            **extra,
+        )
+        assert req.stream_options is not None
+        assert req.stream_options.include_usage is good_value
+
+    @pytest.mark.parametrize("Model,extra", _SURFACES)
+    def test_stream_options_omitted_accepted_every_route(self, Model, extra):
+        """The field is optional — omitting it is the spec default and
+        MUST NOT 4xx (no regression on existing clients)."""
+        req = Model(model="x", **extra)
+        assert req.stream_options is None
+
+    @pytest.mark.parametrize("Model,extra", _SURFACES)
+    def test_one_shared_stream_options_type_every_route(self, Model, extra):
+        """The validator is consolidated by SHARING the same
+        ``StreamOptions`` type across all four surfaces — otherwise the
+        next surface added would silently bypass the gate. This pin
+        guards against accidental schema duplication on a future
+        refactor."""
+        req = Model(
+            model="x",
+            stream_options={"include_usage": True},
+            **extra,
+        )
+        # All routes' stream_options field is the SAME class.
+        assert isinstance(req.stream_options, StreamOptions)
+
+
+# ---------------------------------------------------------------------------
+# R7-H5: outer-level strict on legacy chat response_format
+# ---------------------------------------------------------------------------
+
+
+class TestResponseFormatStrictOuterLevel:
+    """``response_format = {"type":"json_schema","strict":true,
+    "json_schema":{"name":"x","schema":{...}}}`` — strict at the OUTER
+    level, the Responses-API ``text.format.strict`` shape clients
+    sometimes carry over to /v1/chat/completions. Pre-r7-B Pydantic
+    dropped the unknown field and ``is_strict_json_schema`` returned
+    False — silent 200 with no [guided]-required gate. Post-fix the
+    field is declared on ``ResponseFormat`` AND
+    ``is_strict_json_schema`` recognizes it on the typed-model arm
+    too.
+    """
+
+    _SCHEMA = {
+        "type": "object",
+        "properties": {"name": {"type": "string"}},
+    }
+
+    def test_typed_response_format_outer_strict_recognized(self):
+        rf = ResponseFormat(
+            type="json_schema",
+            strict=True,
+            json_schema={"name": "p", "schema": self._SCHEMA},
+        )
+        # Pre-r7 this was silently dropped (Pydantic ignored the unknown
+        # field). Post-r7 it round-trips as a typed field.
+        assert rf.strict is True
+        assert is_strict_json_schema(rf) is True
+
+    def test_typed_response_format_inner_strict_recognized(self):
+        """Canonical OpenAI nesting — must still work (no regression)."""
+        rf = ResponseFormat(
+            type="json_schema",
+            json_schema={"name": "p", "strict": True, "schema": self._SCHEMA},
+        )
+        assert is_strict_json_schema(rf) is True
+
+    def test_typed_response_format_no_strict_anywhere_not_strict(self):
+        rf = ResponseFormat(
+            type="json_schema",
+            json_schema={"name": "p", "schema": self._SCHEMA},
+        )
+        # Neither outer nor inner — non-strict mode.
+        assert rf.strict is None
+        assert is_strict_json_schema(rf) is False
+
+    def test_dict_response_format_outer_strict_recognized(self):
+        """Bare-dict arm of the ``ResponseFormat | dict`` union — same
+        contract: outer-level strict fires the gate."""
+        rf_dict = {
+            "type": "json_schema",
+            "strict": True,
+            "json_schema": {"name": "p", "schema": self._SCHEMA},
+        }
+        assert is_strict_json_schema(rf_dict) is True
+
+    def test_dict_response_format_outer_strict_string_not_strict(self):
+        """``strict:"true"`` (string, NOT bool) must NOT enable strict
+        mode — codex r1 NIT precedent: ``strict is True`` identity
+        check, not ``bool(strict)``."""
+        rf_dict = {
+            "type": "json_schema",
+            "strict": "true",  # malformed payload
+            "json_schema": {"name": "p", "schema": self._SCHEMA},
+        }
+        assert is_strict_json_schema(rf_dict) is False
+
+    def test_chat_request_outer_strict_passes_to_strict_detector(self):
+        """End-to-end: a /v1/chat/completions request body with
+        outer-level strict reaches the detector as strict. Pre-r7 this
+        was the silent-bypass path."""
+        req = ChatCompletionRequest(
+            model="x",
+            messages=_user_msg(),
+            response_format={
+                "type": "json_schema",
+                "strict": True,
+                "json_schema": {"name": "p", "schema": self._SCHEMA},
+            },
+        )
+        assert is_strict_json_schema(req.response_format) is True
+
+    def test_json_object_outer_strict_not_a_constraint_path(self):
+        """``response_format.type == "json_object"`` with outer-level
+        ``strict:true`` is nonsensical (json_object has no schema to
+        enforce strictly) but must NOT trip the json_schema gate —
+        return False so the route doesn't 400 on a degenerate-but-
+        harmless payload."""
+        rf = ResponseFormat(type="json_object", strict=True)
+        assert is_strict_json_schema(rf) is False
+
+
+# ---------------------------------------------------------------------------
+# R7-M3: shared >= 1 gate on max_tokens / max_output_tokens / max_completion_tokens
+# ---------------------------------------------------------------------------
+
+
+class TestPositiveIntGenerationBudget:
+    """The token-budget fields (``max_tokens`` on chat / completions /
+    messages, ``max_output_tokens`` on /v1/responses,
+    ``max_completion_tokens`` on chat) all share one validator now so
+    the contract is uniform across surfaces. Pre-r7 only the chat
+    route had a route-level guard; the schema layer accepted -5 and
+    HTTP-200'd with a single token (or status="incomplete" on
+    /v1/responses). Mirrors the seed validator's cross-route shape.
+    """
+
+    # Each entry: (Model, required-kwargs, token-field-name).
+    _FIELD_MATRIX = [
+        (ChatCompletionRequest, {"messages": _user_msg()}, "max_tokens"),
+        (
+            ChatCompletionRequest,
+            {"messages": _user_msg()},
+            "max_completion_tokens",
+        ),
+        (CompletionRequest, {"prompt": "hi"}, "max_tokens"),
+        (ResponsesRequest, {"input": "hi"}, "max_output_tokens"),
+        (AnthropicRequest, {"messages": _user_msg()}, "max_tokens"),
+    ]
+
+    @pytest.mark.parametrize("Model,extra,field", _FIELD_MATRIX)
+    @pytest.mark.parametrize("bad_value", [-1, -5, -(2**31), 0])
+    def test_non_positive_token_budget_rejected_every_route(
+        self, Model, extra, field, bad_value
+    ):
+        with pytest.raises(ValidationError) as excinfo:
+            Model(model="x", **{**extra, field: bad_value})
+        msg = str(excinfo.value)
+        assert field in msg
+        assert ">= 1" in msg or "must be >= 1" in msg
+
+    @pytest.mark.parametrize("Model,extra,field", _FIELD_MATRIX)
+    @pytest.mark.parametrize("good_value", [1, 5, 1024])
+    def test_positive_token_budget_accepted_every_route(
+        self, Model, extra, field, good_value
+    ):
+        req = Model(model="x", **{**extra, field: good_value})
+        assert getattr(req, field) == good_value
+
+    @pytest.mark.parametrize("Model,extra,field", _FIELD_MATRIX)
+    def test_token_budget_bool_rejected_every_route(self, Model, extra, field):
+        """``True``/``False`` are int subclasses in Python — without
+        the ``mode="before"`` gate Pydantic would coerce ``True`` → 1
+        and ``False`` → 0 silently. Both must 4xx (bool is a
+        serialization mistake on a numeric field, same family as the
+        ``n: true`` / ``seed: true`` footguns)."""
+        with pytest.raises(ValidationError):
+            Model(model="x", **{**extra, field: True})
+        with pytest.raises(ValidationError):
+            Model(model="x", **{**extra, field: False})
+
+    @pytest.mark.parametrize("Model,extra,field", _FIELD_MATRIX)
+    def test_token_budget_string_rejected_every_route(self, Model, extra, field):
+        """JSON-string ints (``"100"``) are a wire-form bug — every
+        spec lists the field as a plain integer, and the schema must
+        4xx rather than lax-coerce."""
+        with pytest.raises(ValidationError):
+            Model(model="x", **{**extra, field: "100"})
+
+    @pytest.mark.parametrize(
+        "Model,extra,field",
+        [
+            (ChatCompletionRequest, {"messages": _user_msg()}, "max_tokens"),
+            (
+                ChatCompletionRequest,
+                {"messages": _user_msg()},
+                "max_completion_tokens",
+            ),
+            (CompletionRequest, {"prompt": "hi"}, "max_tokens"),
+            (ResponsesRequest, {"input": "hi"}, "max_output_tokens"),
+        ],
+    )
+    def test_token_budget_omitted_accepted_every_route(self, Model, extra, field):
+        """Token budget is optional on the OpenAI-compat surfaces;
+        absent means "server default". Anthropic surface excluded —
+        ``max_tokens`` is REQUIRED per the upstream spec, the absence
+        case is covered by the type-checker (``int``, not ``int | None``).
+        """
+        req = Model(model="x", **extra)
+        assert getattr(req, field) is None
+
+
+# ---------------------------------------------------------------------------
+# R7-M4: fence-strip helper covers ```json fenced bodies (the systemic
+# load-bearing piece). The /v1/responses route now calls the SAME helper
+# the chat route already uses — so the cross-route inconsistency is closed.
+# ---------------------------------------------------------------------------
+
+
+class TestFenceStripHelper:
+    """``extract_json_from_response`` is the single fence-strip
+    helper the chat + responses routes both call when a structured
+    response_format was requested. Direct coverage so a future
+    refactor that drops the fence-detection branch trips CI before
+    it lands."""
+
+    def test_json_fence_peeled(self):
+        fenced = '```json\n{"name": "Alice"}\n```'
+        assert extract_json_from_response(fenced) == '{"name": "Alice"}'
+
+    def test_plain_fence_peeled(self):
+        fenced = '```\n{"name": "Alice"}\n```'
+        assert extract_json_from_response(fenced) == '{"name": "Alice"}'
+
+    def test_unfenced_json_passthrough(self):
+        unfenced = '{"name": "Alice"}'
+        assert extract_json_from_response(unfenced) == unfenced
+
+    def test_no_json_passthrough(self):
+        """The helper is a defensive normalizer — when the text has
+        no JSON to peel, it returns the input unchanged so a
+        non-structured-output response is never mangled."""
+        plain = "Hello, world!"
+        assert extract_json_from_response(plain) == plain
+
+    def test_empty_input_returns_empty(self):
+        assert extract_json_from_response("") == ""

--- a/vllm_mlx/api/anthropic_models.py
+++ b/vllm_mlx/api/anthropic_models.py
@@ -14,10 +14,12 @@ from pydantic import BaseModel, Field, field_validator, model_validator
 
 from .models import (
     _TOP_K_SENTINEL_CAP,
+    StreamOptions,
     _enforce_max_generation_tokens_ceiling,
     _scrub_nonfinite_sampling_raw,
     _validate_finite_in_range,
     _validate_nonnegative_int,
+    _validate_positive_int,
 )
 
 # =============================================================================
@@ -357,6 +359,20 @@ class AnthropicRequest(BaseModel):
     messages: list[AnthropicMessage] = Field(..., min_length=1)
     system: str | list[dict] | None = None
     max_tokens: int  # Required in Anthropic API
+    # R7-H4: cross-route parity — Anthropic clients sometimes forward
+    # the OpenAI ``stream_options.include_usage`` field (the
+    # Anthropic-compat shim is a drop-in for OpenAI SDKs that use the
+    # Anthropic SDK's transport). Pre-R7-H4 the field was undeclared
+    # so Pydantic silently dropped any value; that gave
+    # ``stream_options={"include_usage":"yes"}`` an HTTP-200 free
+    # pass while the chat / completions surfaces correctly 422'd.
+    # Declaring with the shared ``StreamOptions`` model routes the
+    # strict-bool gate through one validator. The Anthropic route
+    # does not emit a trailing-usage SSE chunk on its own
+    # ``message_delta`` shape (usage is in-band); the field is
+    # accepted-but-ignored, parity with ``metadata``. The strict-
+    # bool gate is the load-bearing piece for the r7 sweep.
+    stream_options: StreamOptions | None = None
     # H-10: Anthropic spec narrows ``temperature`` to ``[0, 1]`` (the
     # OpenAI ``[0, 2]`` range is a different surface). Pre-H-10 this
     # field had no Field bound AND no finite check — a NaN ``temperature``
@@ -437,6 +453,30 @@ class AnthropicRequest(BaseModel):
         return _validate_nonnegative_int(
             v, max_value=_TOP_K_SENTINEL_CAP, field_name="top_k"
         )
+
+    # R7-M3: shared ``>= 1`` gate on the (required) ``max_tokens``
+    # field. Pre-R7-M3 the Anthropic schema typed it ``int`` (no
+    # ``ge=`` bound) so wire values like ``-5`` slipped through to
+    # the engine, which produced one token and stopped — silent-
+    # correctness hazard same shape as ``seed=-1``. The Anthropic
+    # public API rejects ``max_tokens <= 0`` (400
+    # ``invalid_request_error``) so this matches the upstream
+    # contract. The downstream ``_enforce_max_generation_tokens_ceiling``
+    # model_validator already covers the upper-bound gate when
+    # ``RAPID_MLX_MAX_GENERATION_TOKENS`` is set.
+    @field_validator("max_tokens", mode="before")
+    @classmethod
+    def _validate_max_tokens(cls, v) -> int:
+        out = _validate_positive_int(v, field_name="max_tokens")
+        # Anthropic spec: ``max_tokens`` is REQUIRED. ``None`` is not
+        # a legal wire form (the field is declared as a bare ``int``).
+        # ``_validate_positive_int`` permits ``None`` for parity with
+        # the optional-field cases (chat / completions), but on this
+        # surface we must keep that out of the typed slot so Pydantic
+        # surfaces the standard "field required" error if absent.
+        if out is None:
+            raise ValueError("max_tokens is required on /v1/messages")
+        return out
 
     # M-03 (#742 follow-up): the Anthropic Messages spec only accepts
     # four ``tool_choice.type`` values — ``auto``, ``any``, ``tool``,

--- a/vllm_mlx/api/models.py
+++ b/vllm_mlx/api/models.py
@@ -288,6 +288,58 @@ def _validate_nonnegative_int(
     return v
 
 
+def _validate_positive_int(
+    v,
+    *,
+    max_value: int | None = None,
+    field_name: str = "value",
+):
+    """Integer with a strict ``>= 1`` lower bound (R7-M3 systemic gate).
+
+    Used by the generation-budget fields — ``max_tokens`` (chat /
+    completions / messages) and ``max_output_tokens`` (responses) — so
+    every OpenAI-compat surface 4xx's negative / zero / bool / float
+    wire forms at the schema layer instead of letting them slip
+    through to the route. Pre-R7-M3 the validator coverage was
+    asymmetric: the chat route's hand-rolled
+    ``max_tokens must be at least 1`` check was the ONLY gate, so
+    legacy ``/v1/completions``, Anthropic ``/v1/messages``, and
+    OpenAI ``/v1/responses`` silently accepted ``max_tokens=-5`` (HTTP
+    200 with one token / ``status="incomplete"``) — a silent-correctness
+    hazard the same shape as ``seed=-1``.
+
+    The validator's contract mirrors ``_validate_nonnegative_int``
+    (same bool / float-integer-coercion / NaN-inf handling) but with
+    a strict ``>= 1`` floor so ``max_tokens=0`` is rejected too —
+    pointing at the right OpenAI escape hatch (``stream=true`` with
+    no limit + finish_reason=stop is how clients ask for "unlimited
+    tokens"; ``max_tokens=0`` has no spec meaning and was previously
+    a silent no-token request).
+    """
+    if v is None:
+        return None
+    if isinstance(v, bool):
+        raise ValueError(f"{field_name} must be an integer when set (got bool)")
+    if isinstance(v, float):
+        if not math.isfinite(v):
+            raise ValueError(f"{field_name} must be a finite integer (not NaN or inf)")
+        if not v.is_integer():
+            raise ValueError(f"{field_name} must be an integer when set (got {v})")
+        v = int(v)
+    elif not isinstance(v, int):
+        raise ValueError(
+            f"{field_name} must be an integer when set (got {type(v).__name__})"
+        )
+    if v < 1:
+        raise ValueError(
+            f"{field_name} must be >= 1 when set (got {v}); omit the field to "
+            "use the server default."
+        )
+    if max_value is not None and v > max_value:
+        raise ValueError(f"{field_name} must be <= {max_value} (got {v})")
+    return v
+
+
 def _validate_logit_bias_finite(
     v: dict | None, *, field_name: str = "logit_bias"
 ) -> dict | None:
@@ -1052,6 +1104,24 @@ class ResponseFormat(BaseModel):
     # request model.
     type: Literal["text", "json_object", "json_schema"] = "text"
     json_schema: ResponseFormatJsonSchema | None = None
+    # R7-H5 (Vlad r7 — 0.8.8 sweep): the OpenAI Responses API uses a
+    # ``text.format = {"type":"json_schema","strict":true,"schema":{...},
+    # "name":"..."}`` shape where ``strict`` is a SIBLING of ``type``
+    # (not nested inside ``json_schema``). Clients writing against the
+    # Responses surface and then pointing at the legacy chat endpoint
+    # routinely keep the outer-level nesting — pre-R7 the unknown
+    # field was silently dropped by Pydantic, so the chat path saw
+    # a non-strict request, skipped the ``[guided]``-required gate,
+    # and HTTP-200'd with no constraint enforcement. Declaring the
+    # field here means BOTH nesting positions reach
+    # ``is_strict_json_schema`` and the centralized gate fires
+    # regardless of which nesting position the client used. The chat
+    # route's existing strict-mode handling sees the same boolean
+    # whichever wire form was sent. ``None`` is preserved as the
+    # absent default; the dict-arm validator mirrors this so an
+    # outer-level ``"strict":"true"`` (string) is rejected with a
+    # clean 422 too.
+    strict: bool | None = None
 
 
 # =============================================================================
@@ -1482,6 +1552,25 @@ class ChatCompletionRequest(BaseModel):
     def _validate_logit_bias(cls, v):
         return _validate_logit_bias_finite(v, field_name="logit_bias")
 
+    # R7-M3: shared ``>= 1`` gate on the generation-budget fields so the
+    # whole OpenAI-compat surface (chat / completions / messages /
+    # responses) rejects ``max_tokens <= 0`` at the schema layer instead
+    # of relying on the chat route's hand-rolled check. The chat route
+    # used to be the only path with a ``max_tokens < 1`` guard — Vlad's
+    # r7 sweep surfaced ``max_output_tokens=-5`` on /v1/responses,
+    # ``max_tokens=-5`` on /v1/completions and /v1/messages all
+    # returning 200. Schema-layer validator means the contract is
+    # uniform regardless of which route handler runs.
+    @field_validator("max_tokens", mode="before")
+    @classmethod
+    def _validate_max_tokens(cls, v) -> int | None:
+        return _validate_positive_int(v, field_name="max_tokens")
+
+    @field_validator("max_completion_tokens", mode="before")
+    @classmethod
+    def _validate_max_completion_tokens(cls, v) -> int | None:
+        return _validate_positive_int(v, field_name="max_completion_tokens")
+
     @model_validator(mode="after")
     def _normalize_max_completion_tokens(self) -> "ChatCompletionRequest":
         if self.max_completion_tokens is not None:
@@ -1818,6 +1907,16 @@ class CompletionRequest(BaseModel):
         return _validate_nonnegative_int(
             v, max_value=_TOP_K_SENTINEL_CAP, field_name="top_k"
         )
+
+    # R7-M3: shared ``>= 1`` gate on ``max_tokens`` — mirror of the
+    # chat surface. Pre-R7-M3 the legacy completions surface silently
+    # accepted ``max_tokens=-5`` (HTTP 200 with a single token)
+    # because no route-level gate ran; the schema layer now closes
+    # the bypass for every OpenAI-compat surface.
+    @field_validator("max_tokens", mode="before")
+    @classmethod
+    def _validate_max_tokens(cls, v) -> int | None:
+        return _validate_positive_int(v, field_name="max_tokens")
 
     # F-155: enforce ``n == 1`` at parse time, mirroring the chat
     # surface. The route already 400's ``n > 1``; the schema layer

--- a/vllm_mlx/api/models.py
+++ b/vllm_mlx/api/models.py
@@ -969,7 +969,13 @@ class ResponseFormatJsonSchema(BaseModel):
     name: str
     description: str | None = None
     schema_: dict = Field(alias="schema")  # JSON Schema specification
-    strict: bool | None = False
+    # R7-B codex MED follow-up: ``StrictBool`` so non-bool wire forms
+    # like ``"strict":"true"`` are rejected at parse time instead of
+    # being coerced or silently treated as falsey by downstream
+    # ``is_strict_json_schema``. Paired with the explicit dict-arm
+    # check in ``_validate_response_format_raw`` so the bare-dict
+    # union arm can't bypass either.
+    strict: StrictBool | None = False
 
     class Config:
         populate_by_name = True
@@ -1039,6 +1045,21 @@ def _validate_response_format_raw(value):
         raise ValueError(
             "response_format.type must be 'text', 'json_object', or 'json_schema'"
         )
+    # R7-B codex MED follow-up: ``strict`` is a strict boolean on BOTH
+    # nesting positions. Pre-fix, ``{"type":"json_schema","strict":"true",
+    # "json_schema":{...}}`` and the nested form
+    # ``{"json_schema":{"strict":"true",...}}`` fell through the
+    # bare-dict union arm with no strict check — ``is_strict_json_schema``
+    # then treated the truthy string as falsey and the ``[guided]`` gate
+    # silently downgraded the request to unconstrained generation. The
+    # typed arm uses ``StrictBool`` so the same wire forms parse-fail
+    # there; mirror the same wire-form rejection on the dict arm so the
+    # ``ResponseFormat | dict`` union has no escape hatch.
+    if "strict" in value and not isinstance(value["strict"], bool):
+        raise ValueError(
+            "response_format.strict must be a boolean "
+            f"(got {type(value['strict']).__name__})"
+        )
     if rf_type == "json_schema":
         json_schema_field = value.get("json_schema")
         if not json_schema_field:
@@ -1048,6 +1069,13 @@ def _validate_response_format_raw(value):
             )
         if not isinstance(json_schema_field, dict):
             raise ValueError("response_format.json_schema must be an object")
+        if "strict" in json_schema_field and not isinstance(
+            json_schema_field["strict"], bool
+        ):
+            raise ValueError(
+                "response_format.json_schema.strict must be a boolean "
+                f"(got {type(json_schema_field['strict']).__name__})"
+            )
         # Mirror the typed ``ResponseFormatJsonSchema.name: str``
         # required field on the dict arm — codex round-1 BLOCKING
         # follow-up. The bare-dict union arm would otherwise swallow
@@ -1121,7 +1149,11 @@ class ResponseFormat(BaseModel):
     # absent default; the dict-arm validator mirrors this so an
     # outer-level ``"strict":"true"`` (string) is rejected with a
     # clean 422 too.
-    strict: bool | None = None
+    # R7-B codex MED follow-up: ``StrictBool`` rejects non-bool wire
+    # forms at parse time on the typed arm; the dict arm is closed by
+    # the explicit ``strict``-shape check in
+    # ``_validate_response_format_raw`` below.
+    strict: StrictBool | None = None
 
 
 # =============================================================================

--- a/vllm_mlx/api/responses_models.py
+++ b/vllm_mlx/api/responses_models.py
@@ -20,7 +20,9 @@ from pydantic import BaseModel, Field, field_validator, model_validator
 
 from .models import (
     _TOP_K_SENTINEL_CAP,
+    StreamOptions,
     _validate_nonnegative_int,
+    _validate_positive_int,
     _validate_seed,
 )
 
@@ -91,6 +93,22 @@ class ResponsesRequest(BaseModel):
     parallel_tool_calls: bool | None = None
     reasoning: dict | None = None  # {"effort": "low|medium|high", "summary": ...}
     stream: bool = False
+    # R7-H4: OpenAI streaming-spec parity — Responses API also accepts
+    # ``stream_options.include_usage`` per OpenAI SDK ``stream_options``
+    # shape. Pre-R7-H4 the field was undeclared on this surface, so
+    # Pydantic silently dropped any value the client sent; that gave
+    # ``stream_options={"include_usage":"yes"}`` an HTTP-200 free pass
+    # while the chat / completions surfaces (which DO declare the field
+    # via ``StreamOptions`` with a ``StrictBool``) correctly 422'd.
+    # Declaring it here with the SAME shared ``StreamOptions`` model
+    # routes the strict-bool gate through the same validator so the
+    # contract is uniform across all four routes (chat / completions /
+    # messages / responses). The Responses route does not currently
+    # emit a trailing-usage SSE chunk — the field is accepted-but-
+    # ignored on this surface (parity with ``previous_response_id`` /
+    # ``store`` / ``include`` etc.); the strict-bool gate is the
+    # load-bearing piece for the r7 sweep.
+    stream_options: StreamOptions | None = None
     store: bool | None = None
     include: list[str] | None = None
     service_tier: str | None = None
@@ -167,6 +185,18 @@ class ResponsesRequest(BaseModel):
         return _validate_nonnegative_int(
             v, max_value=_TOP_K_SENTINEL_CAP, field_name="top_k"
         )
+
+    # R7-M3: shared ``>= 1`` gate on ``max_output_tokens``. Pre-R7-M3
+    # ``max_output_tokens=-5`` HTTP-200'd on /v1/responses with
+    # ``status="incomplete"`` — silent-correctness hazard same shape
+    # as ``seed=-1`` (which DOES 400). The chat route had its own
+    # hand-rolled ``max_tokens < 1`` check; the schema-level
+    # validator means /v1/responses / /v1/completions / /v1/messages
+    # all share one contract now.
+    @field_validator("max_output_tokens", mode="before")
+    @classmethod
+    def _validate_max_output_tokens(cls, v) -> int | None:
+        return _validate_positive_int(v, field_name="max_output_tokens")
 
     @model_validator(mode="before")
     @classmethod

--- a/vllm_mlx/api/tool_calling.py
+++ b/vllm_mlx/api/tool_calling.py
@@ -1054,9 +1054,26 @@ def is_strict_json_schema(
     only consulted by ``build_json_system_prompt`` for the prompt-injection
     fallback, never to drive an enforcement decision.
 
-    A request is "strict" iff:
-    * ``response_format.type == "json_schema"``
-    * ``response_format.json_schema.strict`` is truthy
+    A request is "strict" iff ``response_format.type == "json_schema"``
+    AND either of:
+    * ``response_format.json_schema.strict`` is the literal ``True``
+      (OpenAI canonical nesting — Python SDK + REST docs).
+    * ``response_format.strict`` is the literal ``True`` (the OFF-SPEC
+      "outer-level strict" wire form — see R7-H5 rationale below).
+
+    R7-H5 (Vlad r7 — 0.8.8 sweep): the OpenAI Responses API exposes
+    ``text.format = {"type":"json_schema","strict":true,"name":"...",
+    "schema":{...}}`` — the strict flag is a SIBLING of ``type``. When
+    that same client points at the legacy chat endpoint and sends
+    ``response_format = {"type":"json_schema","strict":true,
+    "json_schema":{"schema":{...}}}`` (outer-level strict), the pre-R7
+    detector only inspected the nested ``json_schema.strict`` slot and
+    returned False — the request HTTP-200'd with no guided-decoding
+    enforcement (``[guided]`` extra not required, strict contract
+    silently downgraded). Per Vlad: "the guard must be on the JSON-
+    schema CONSTRAINT detection, not on a particular key." Recognizing
+    EITHER nesting position closes the bypass on both surfaces with
+    one validator — no whack-a-mole per route.
 
     Returns ``False`` for every other shape (``None``, ``"text"``,
     ``"json_object"``, ``json_schema`` with ``strict=false`` or absent).
@@ -1070,6 +1087,13 @@ def is_strict_json_schema(
     if isinstance(response_format, ResponseFormat):
         if response_format.type != "json_schema":
             return False
+        # R7-H5: ResponseFormat now carries an outer-level ``strict``
+        # field so the off-spec wire shape (sibling of ``type``, the
+        # Responses-API ``text.format.strict`` nesting) reaches us
+        # without being silently dropped. Either nesting position
+        # being ``True`` means the strict contract was requested.
+        if response_format.strict is True:
+            return True
         if response_format.json_schema is None:
             return False
         # Pydantic coerces ``"true"`` / ``"false"`` strings to the
@@ -1082,6 +1106,14 @@ def is_strict_json_schema(
     if isinstance(response_format, dict):
         if response_format.get("type") != "json_schema":
             return False
+        # R7-H5: detect outer-level ``strict=true`` first — this is the
+        # off-spec form Vlad's r7 sweep surfaced. On the raw-dict path
+        # we deliberately require ``strict is True`` rather than
+        # ``bool(strict)``: a malformed payload like ``"strict":"false"``
+        # (string) is truthy under ``bool()`` and would silently enable
+        # enforcement on a client that intended to opt out.
+        if response_format.get("strict") is True:
+            return True
         spec = response_format.get("json_schema") or {}
         if not isinstance(spec, dict):
             return False

--- a/vllm_mlx/routes/responses.py
+++ b/vllm_mlx/routes/responses.py
@@ -53,6 +53,7 @@ from ..api.utils import (
     StreamingThinkRouter,
     StreamingToolCallFilter,
     clean_output_text,
+    extract_json_from_response,
     extract_multimodal_content,
     sanitize_output,
     strip_special_tokens,
@@ -924,6 +925,23 @@ async def _non_stream(
     if cleaned_text:
         final_content = strip_thinking_tags(clean_output_text(cleaned_text))
         final_content = sanitize_output(final_content)
+        # R7-M4 (Vlad r7 — 0.8.8 sweep): mirror the chat-route fence-strip
+        # so a model that wraps a ``json_object`` / ``json_schema`` body
+        # in a ```json ... ``` markdown fence has the fence peeled off
+        # BEFORE the body is handed to the Responses adapter. Pre-R7
+        # the chat surface ran ``extract_json_from_response`` after
+        # ``response_format`` was set (chat.py L2076) but the Responses
+        # surface called ``engine.chat()`` directly and skipped the
+        # post-processor entirely, so the same model + prompt produced
+        # a clean JSON body on /v1/chat/completions but a fenced body
+        # on /v1/responses — a cross-route inconsistency the r7 sweep
+        # surfaced as M-02 fence-strip not covering this route.
+        # Defensive: only strips when a JSON-structure response_format
+        # was requested (parity with chat.py); plain text responses are
+        # untouched.
+        rf = getattr(openai_request, "response_format", None)
+        if rf is not None and final_content:
+            final_content = extract_json_from_response(final_content)
 
     finish_reason = "tool_calls" if tool_calls else output.finish_reason
 


### PR DESCRIPTION
## Why

Vlad r7 sweep against rapid-mlx 0.8.8 (`/tmp/dogfood-088/vlad/vlad-r1.md`, `vlad-r2.md`) surfaced four validation-gap bugs where the chat / completions surfaces correctly rejected malformed inputs (r5-E PR #824) but the same payloads HTTP-200'd through `/v1/responses` and `/v1/messages`. All four are systemic — "missing field declaration / missing shared validator" — so the fixes consolidate validators across the four request models instead of whack-a-mole'ing each route.

## What changed

### R7-H4 — `stream_options.include_usage` truthy-string bypass on Responses + Anthropic
- `ResponsesRequest` + `AnthropicRequest` now declare the SHARED `StreamOptions` field; the existing `StrictBool` gate (r5-E B-9) catches `"yes"`/`"true"`/`"on"` etc. on all four request surfaces.
- Accepted-but-ignored on Responses/Anthropic (parity with `metadata` / `previous_response_id`); the strict-bool gate is the load-bearing piece.

### R7-H5 — legacy chat `response_format` with strict at OUTER level bypassed `[guided]` gate
- Pre-fix, Pydantic dropped the unknown `strict` field on the typed `ResponseFormat` model, and `is_strict_json_schema` only inspected the canonical nested `json_schema.strict` slot — clients using the Responses-style `{type, strict, json_schema}` nesting against `/v1/chat/completions` silently downgraded.
- Fix declares `strict: bool | None` as an outer-level field on `ResponseFormat` AND extends `is_strict_json_schema` to fire on either nesting position. Per Vlad: "the guard must be on the JSON-schema CONSTRAINT detection, not on a particular key."

### R7-M3 — `max_output_tokens=-5` (Responses) / `max_tokens=-5` (Completions / Messages) silently accepted
- Only the chat route had a hand-rolled `max_tokens < 1` guard; the schema layer accepted any int.
- New shared `_validate_positive_int` helper (>= 1; bool/non-int/NaN/inf all 4xx; mirrors `_validate_nonnegative_int` discipline) attached via `mode="before"` field_validator to:
  - `ChatCompletionRequest.max_tokens` + `max_completion_tokens`
  - `CompletionRequest.max_tokens`
  - `ResponsesRequest.max_output_tokens`
  - `AnthropicRequest.max_tokens`
- Contract is now uniform across the four request models and route-independent (mirrors the seed/top_k cross-route shape from r5-E).

### R7-M4 — `response_format=json_object` wrapped body in markdown fence on `/v1/responses`
- The chat route's `extract_json_from_response` fence-strip (M-02 / PR #769) was wired into the chat non-stream path only.
- `/v1/responses` non-stream finalize path now calls the same helper when a structured `response_format` was requested — both surfaces share one post-decode normalization.

## Test plan

Automated (`tests/test_param_validation_r7b.py`, 117 parametrized cross-route cases):

- [x] `TestStreamOptionsIncludeUsageCrossRoute` — strict-bool gate fires from every OpenAI-compat surface; the four request models share ONE `StreamOptions` type (regression-pin against future schema duplication).
- [x] `TestResponseFormatStrictOuterLevel` — both typed and bare-dict arms of `ResponseFormat` recognize outer-level + nested strict; string `"true"` still rejected (codex r1 NIT identity-check precedent); json_object + outer-level strict is non-strict (degenerate but harmless).
- [x] `TestPositiveIntGenerationBudget` — cross-route matrix for `max_tokens` / `max_output_tokens` / `max_completion_tokens` rejecting -1 / -5 / -(2**31) / 0; accepting 1 / 5 / 1024; rejecting bool + JSON-string ints; preserving omit-as-default.
- [x] `TestFenceStripHelper` — direct coverage of `extract_json_from_response` (json-fence, plain-fence, passthrough on unfenced JSON, passthrough on no-JSON, empty input) so a future refactor that drops the fence-detection branch trips CI before it lands.

Regression sweep: `pytest tests/test_param_validation_r5e.py tests/test_api_models.py tests/test_responses_param_validation.py tests/test_response_format_*.py tests/test_api_validation_bundle.py tests/test_d_anthro_validation.py tests/test_anthropic_models.py tests/test_sampling_validation.py tests/test_responses_route.py tests/test_responses_adapter.py tests/test_responses_bundle.py tests/test_responses_engine_failure_envelope.py tests/test_responses_sse_event_order.py tests/test_anthropic_route_thinking_gate.py tests/test_anthropic_streaming_reasoning.py` — 763 passed, 0 failures.

Lint/format: `ruff check + ruff format --check` on all touched files — clean.