### PR TITLE
chore: bump version to 0.8.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.8.8"
+version = "0.8.9"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## Why

Cuts 0.8.9 to roll out the r7 fix wave (4 PRs that all merged after 0.8.8):

- **r7-A** (#834 `92bc908`) — UI-TARS chat-lane `coordinate` parity + streaming `delta.reasoning` field-name parity + Responses `computer_use_preview` tool-type alias (R7-H1 + R7-H2 + R7-M6).
- **r7-B** (#837 `eddee33`) — cross-route validation hardening: `stream_options.include_usage` strict-bool, legacy `response_format.json_schema.strict` `[guided]` gate, shared `>=1` `max_*_tokens` validator, fence-strip on non-stream json_object (R7-H4 + R7-H5 + R7-M3 + R7-M4 + codex-MED follow-up: non-bool `strict` rejected on both nesting positions).
- **r7-C** (#835 `98a5cc8`) — audio bundle depth: pinned `mlx-audio<0.4.4` to kill the Kokoro istftnet 500 regression, Pydantic-bound TTS empty-input → 400 `param=input`, `whisper`/`whisper-1` short aliases on STT + translations (R7-H3 + R7-M8 + R7-M9).
- **r7-D** (#836 `0151b5f`) — runtime guardrails: SIGHUP "dump-and-stay-alive" semantic restored (CRIT regression in 0.8.8), `/healthz` fast-path (p99 target ≤50ms), prefix-cache LRU-on-cap-full admission, `rapid_mlx_prefix_cache_{cap,current}_bytes` gauges (R7-C1 + R7-H7 + R7-H8 + R7-M1).

Plus an r6-B codex round-4 follow-up that landed between 0.8.8 and now: `a16d8c8` tightens UI-TARS streaming trailing-prefix holdback.

Standard release: bump-only commit, auto-release.yml fires on subject match. All 4 r7 fix PRs were merged with pr_validate green and codex review converged on diff.

## Test plan

- [x] All 4 r7 fix PRs merged with pr_validate green + codex review converged on diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)