### PR TITLE
fix(audio): r8-A bundle — Kokoro full alias + format encoding + voice validation + boot guard

### DIFF
--- a/tests/test_audio_r8_a_bundle.py
+++ b/tests/test_audio_r8_a_bundle.py
@@ -1,0 +1,709 @@
+# SPDX-License-Identifier: Apache-2.0
+"""R8-A regression bundle — Bo's 0.8.9 audio dogfood follow-up.
+
+Four findings:
+
+* **R8-H4** — ``model="kokoro-82m-8bit"`` (the brief's canonical full
+  alias) 500'd because ``TTS_MODEL_ALIASES`` only carried the short
+  ``kokoro`` form. Mapping the full siblings (``kokoro-82m-bf16``,
+  ``kokoro-82m-4bit``, ``kokoro-82m-8bit``) AND making the resolver
+  case-insensitive lets both shapes hit the same HF repo.
+
+* **R8-H5** — ``response_format ∈ {mp3, flac, opus, ogg}`` returned
+  RIFF/WAV bytes mislabeled as ``audio/{format}``. ``TTSEngine.to_bytes``
+  now branches on ``format`` and encodes via scipy (wav) /
+  ``soundfile`` (flac/ogg/opus/mp3) / raw bytes (pcm). Unsupported
+  formats raise :class:`UnsupportedAudioFormatError` which the route
+  translates to a 400 envelope. Content-Type now matches the actual
+  bytes via :data:`vllm_mlx.routes.audio._TTS_CONTENT_TYPES`.
+
+* **R8-M4** — Invalid ``voice`` (e.g. ``"alloy"`` from drop-in OpenAI
+  SDK code) 500'd inside ``mlx_audio.load_safetensors``. The route
+  now pre-flights ``voice`` against the model's known voice list and
+  emits a 400 ``invalid_request_error`` with ``param="voice"`` listing
+  the available voices.
+
+* **R8-M5** — ``rapid-mlx serve kokoro`` (short audio alias) on a
+  fresh ``pip install rapid-mlx`` (no ``[audio]`` extra) printed
+  "is not a known alias" instead of the actionable
+  "install rapid-mlx[audio]" hint — the CLI fail-fast tripped before
+  the audio boot guard ran. Fix: skip the fail-fast for names that
+  ``is_audio_model_alias`` recognises so the guard fires.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+
+import pytest
+
+# ``vllm_mlx.routes.audio`` transitively imports ``mlx.core`` via the
+# engine wiring. Linux CI runners (``pr_validate``'s validate job) don't
+# install mlx, so a bare import raises ``ModuleNotFoundError`` and the
+# rest of the file looks like a 13-test failure. Mirror the r7-C skip
+# block so the file is a clean SKIP off-platform but still executes on
+# Apple Silicon dev / CI with the right deps.
+pytest.importorskip(
+    "mlx.core",
+    reason="audio route imports transitively pull in mlx; "
+    "test runs on Apple Silicon / dev, not Linux CI runners",
+)
+pytest.importorskip(
+    "mlx_lm",
+    reason="audio route imports transitively pull in mlx_lm; "
+    "test runs on Apple Silicon / dev, not Linux CI runners",
+)
+pytest.importorskip(
+    "multipart",
+    reason="TestClient requires python-multipart on the form lanes",
+)
+
+from fastapi import FastAPI  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Helpers (copied from r7-C so this file stands alone — the harness pattern
+# is identical so a future refactor lifting both into a conftest stays a
+# single mechanical change)
+# ---------------------------------------------------------------------------
+
+
+def _install_fake_mlx_audio(monkeypatch):
+    """Make ``importlib.util.find_spec("mlx_audio")`` succeed without
+    the real package present (the route's TTS-lane probe gates on this)."""
+    import importlib.machinery
+
+    fake_mlx_audio = types.ModuleType("mlx_audio")
+    fake_mlx_audio.__path__ = []
+    fake_mlx_audio.__spec__ = importlib.machinery.ModuleSpec(
+        "mlx_audio", loader=None, is_package=True
+    )
+    fake_tts = types.ModuleType("mlx_audio.tts")
+    fake_tts.__path__ = []
+    fake_tts.__spec__ = importlib.machinery.ModuleSpec(
+        "mlx_audio.tts", loader=None, is_package=True
+    )
+    fake_tts_generate = types.ModuleType("mlx_audio.tts.generate")
+    fake_tts_generate.__spec__ = importlib.machinery.ModuleSpec(
+        "mlx_audio.tts.generate", loader=None
+    )
+    fake_tts_generate.load_model = lambda *_a, **_k: None
+    monkeypatch.setitem(sys.modules, "mlx_audio", fake_mlx_audio)
+    monkeypatch.setitem(sys.modules, "mlx_audio.tts", fake_tts)
+    monkeypatch.setitem(sys.modules, "mlx_audio.tts.generate", fake_tts_generate)
+
+
+def _mount_audio_app() -> tuple[TestClient, callable]:
+    """Mount the audio router with the rapid-mlx exception handlers so the
+    Pydantic validation errors surface as the OpenAI envelope (not the
+    default FastAPI 422)."""
+    from vllm_mlx.config import get_config
+    from vllm_mlx.middleware.exception_handlers import install_exception_handlers
+    from vllm_mlx.routes import audio as audio_route
+
+    app = FastAPI()
+    app.include_router(audio_route.router)
+    install_exception_handlers(app)
+    cfg = get_config()
+    saved = cfg.api_key
+    cfg.api_key = None
+
+    def _restore():
+        cfg.api_key = saved
+
+    return TestClient(app), _restore
+
+
+def _stub_engine(monkeypatch, *, voice_observed=None):
+    """Install a no-op TTSEngine that records the model_name passed to it
+    and uses the REAL ``to_bytes`` so encoder smoke-checks still run."""
+    import numpy as np
+
+    from vllm_mlx.audio import probe as probe_mod
+    from vllm_mlx.audio import tts as tts_mod
+    from vllm_mlx.routes import audio as audio_route
+
+    observed_models: list[str] = []
+    # Capture the REAL ``to_bytes`` BEFORE ``monkeypatch.setattr``
+    # rebinds ``tts_mod.TTSEngine`` to our stub — otherwise
+    # ``tts_mod.TTSEngine.to_bytes`` after the patch points back at the
+    # stub and recurses forever. A simple unbound-method reference here
+    # gives us the original encoder without going through the patched
+    # attribute lookup.
+    real_to_bytes = tts_mod.TTSEngine.to_bytes
+
+    class _RecordingEngine:
+        def __init__(self, model_name: str):
+            observed_models.append(model_name)
+            self.model_name = model_name
+
+        def load(self):
+            pass
+
+        def generate(self, text, voice="af_heart", speed=1.0):
+            if voice_observed is not None:
+                voice_observed.append(voice)
+            # 1 second of a 440 Hz tone at 0.3 amplitude so every encoder
+            # has real signal to compress (silent input lets some codecs
+            # output suspiciously short payloads that obscure regressions).
+            audio = (np.sin(2 * np.pi * 440 * np.arange(24000) / 24000) * 0.3).astype(
+                np.float32
+            )
+            return tts_mod.AudioOutput(audio=audio, sample_rate=24000, duration=1.0)
+
+        def to_bytes(self, audio, format="wav"):
+            return real_to_bytes(self, audio, format=format)
+
+    monkeypatch.setattr(tts_mod, "TTSEngine", _RecordingEngine)
+    monkeypatch.setattr(probe_mod, "require_kokoro_runtime", lambda: None)
+    _install_fake_mlx_audio(monkeypatch)
+    audio_route._tts_engine = None
+    return audio_route, observed_models
+
+
+# ---------------------------------------------------------------------------
+# R8-H4 — full-alias resolution + case-insensitive lookup
+# ---------------------------------------------------------------------------
+
+
+class TestFullAliasResolution:
+    """The brief's literal ``kokoro-82m-8bit`` and its siblings resolve
+    through the same helper as the short ``kokoro`` alias — pre-fix only
+    the short form hit the table, so the full names 404'd at HF lookup
+    inside mlx_audio."""
+
+    @pytest.mark.parametrize(
+        "alias",
+        [
+            "kokoro-82m-bf16",
+            "kokoro-82m-4bit",
+            "kokoro-82m-8bit",
+            # Case-insensitive: SDKs / docs frequently mix the case
+            # because the upstream HF repo is "Kokoro-82M-bf16".
+            "Kokoro-82M-bf16",
+            "KOKORO-82M-8BIT",
+        ],
+    )
+    def test_full_kokoro_alias_resolves_to_kokoro_repo(self, alias):
+        from vllm_mlx.routes.audio import _resolve_tts_model
+
+        resolved = _resolve_tts_model(alias)
+        assert "kokoro" in resolved.lower(), (
+            f"R8-H4 regression: alias {alias!r} did NOT resolve to a "
+            f"Kokoro HF repo, got {resolved!r}. Pre-fix this fell "
+            f"through to passthrough and mlx-audio 404'd at HF lookup."
+        )
+        assert "/" in resolved, (
+            f"R8-H4 regression: alias {alias!r} must resolve to a full "
+            f"HF repo id (with org/), got {resolved!r}."
+        )
+
+    def test_short_and_full_alias_resolve_identically(self):
+        """The short ``kokoro`` and full ``kokoro-82m-bf16`` MUST map to
+        the same repo so both paths go through identical model init —
+        the regression Bo flagged was a divergence between the two."""
+        from vllm_mlx.routes.audio import _resolve_tts_model
+
+        assert _resolve_tts_model("kokoro") == _resolve_tts_model("kokoro-82m-bf16")
+
+    def test_unknown_alias_still_passes_through(self):
+        """Pass-through behaviour for unrecognised names is preserved —
+        a client opting in to a HF repo not in the alias table must
+        still reach mlx_audio with the verbatim id."""
+        from vllm_mlx.routes.audio import _resolve_tts_model
+
+        # HF-style ids contain '/' so they're untouched (case preserved).
+        hf_path = "mlx-community/Some-Future-TTS-Model"
+        assert _resolve_tts_model(hf_path) == hf_path
+
+
+# ---------------------------------------------------------------------------
+# R8-H5 — encoder produces real bytes + Content-Type matches
+# ---------------------------------------------------------------------------
+
+
+# Each entry: (response_format, content_type, magic_bytes prefix).
+# The encoder check below boots the TTS route end-to-end (with a stub
+# engine) and reads the first 4 bytes back to confirm the bytes match
+# the requested container. Pre-fix every entry's body was RIFF/WAVE.
+_FORMAT_EXPECTATIONS = [
+    ("wav", "audio/wav", b"RIFF"),
+    ("flac", "audio/flac", b"fLaC"),
+    ("ogg", "audio/ogg", b"OggS"),
+    ("opus", "audio/ogg", b"OggS"),  # Opus is OGG-Opus container.
+]
+
+
+class TestTTSContentType:
+    """Smoke-test the Content-Type ↔ body alignment that R8-H5 fixed.
+
+    Pre-fix the route returned ``RIFF…WAVE`` bytes labelled
+    ``audio/mp3``/``audio/flac``/``audio/opus`` etc. Now the body's
+    magic bytes match the IANA-canonical Content-Type for the
+    requested format.
+    """
+
+    @pytest.mark.parametrize("response_format,content_type,magic", _FORMAT_EXPECTATIONS)
+    def test_response_format_produces_matching_bytes(
+        self, monkeypatch, response_format, content_type, magic
+    ):
+        # ``soundfile`` is in the [audio] extra; the test file's top-level
+        # skip blocks already gate on mlx, so if we're here without
+        # soundfile that's a project misconfiguration we want surfaced
+        # (not a silent skip).
+        pytest.importorskip("soundfile")
+
+        audio_route, observed = _stub_engine(monkeypatch)
+        client, restore = _mount_audio_app()
+        try:
+            r = client.post(
+                "/v1/audio/speech",
+                json={
+                    "model": "kokoro-82m-8bit",  # R8-H4 full alias
+                    "input": "hello world",
+                    "voice": "af_heart",
+                    "response_format": response_format,
+                },
+            )
+        finally:
+            restore()
+            audio_route._tts_engine = None
+
+        assert r.status_code == 200, (
+            f"R8-H5 regression: response_format={response_format!r} "
+            f"returned {r.status_code}. Body: {r.text[:500]}"
+        )
+        # R8-H4: the full alias MUST have routed through to the Kokoro
+        # HF id (not been passed verbatim to the engine).
+        assert observed and "kokoro" in observed[0].lower(), (
+            f"R8-H4 regression: full alias did not resolve to a Kokoro "
+            f"repo; engine saw {observed!r}"
+        )
+        # R8-H5: Content-Type matches the IANA canonical for the
+        # requested format AND the magic bytes match the container.
+        ctype = r.headers.get("content-type", "").split(";")[0].strip()
+        assert ctype == content_type, (
+            f"R8-H5 regression: response_format={response_format!r} "
+            f"emitted Content-Type {ctype!r}, expected {content_type!r}."
+        )
+        body = r.content
+        assert len(body) > 100, (
+            f"R8-H5 regression: {response_format!r} payload too small "
+            f"({len(body)} bytes) — encoder likely silently no-op'd."
+        )
+        assert body.startswith(magic), (
+            f"R8-H5 regression: {response_format!r} body starts with "
+            f"{body[:8]!r}, expected magic {magic!r}. Pre-fix the route "
+            f"returned RIFF/WAV bytes mislabeled as audio/{response_format}."
+        )
+
+    def test_brief_canonical_alias_with_mp3_e2e(self, monkeypatch):
+        """The brief's exact reproducer: ``model="kokoro-82m-8bit"`` +
+        ``response_format="mp3"`` returns >1 KiB of audio and the
+        Content-Type matches the bytes. Pre-fix this 500'd at alias
+        resolution; the previous regression Bo flagged.
+        """
+        pytest.importorskip("soundfile")
+
+        audio_route, observed = _stub_engine(monkeypatch)
+        client, restore = _mount_audio_app()
+        try:
+            r = client.post(
+                "/v1/audio/speech",
+                json={
+                    "model": "kokoro-82m-8bit",
+                    "input": "hello world",
+                    "voice": "af_heart",
+                    "response_format": "mp3",
+                },
+            )
+        finally:
+            restore()
+            audio_route._tts_engine = None
+
+        # The MP3 encoder may not be present on every libsndfile build —
+        # we accept either:
+        #   * 200 + valid MP3 body (>1 KiB, ``\xff\xfb`` or ``\xff\xf3``
+        #     frame sync) + ``audio/mpeg`` Content-Type, OR
+        #   * 400 ``invalid_response_format`` envelope (graceful fallback
+        #     to the documented-supported set).
+        # Both are acceptable; what's NOT acceptable is a 200 + RIFF/WAV
+        # body mislabeled as ``audio/mpeg``, which is what pre-fix did.
+        if r.status_code == 200:
+            assert (
+                r.headers.get("content-type", "").split(";")[0].strip() == "audio/mpeg"
+            )
+            assert len(r.content) > 1024, (
+                f"MP3 body too small ({len(r.content)} bytes); encoder "
+                f"likely produced a no-op."
+            )
+            # MP3 frame sync byte 0xFF + (0xFB / 0xF3 / 0xF2 / 0xE3 ...).
+            assert r.content[0] == 0xFF, (
+                f"MP3 body does not start with frame sync (0xFF), got "
+                f"{r.content[:4]!r}. Pre-fix this WAS the RIFF/WAVE "
+                f"mislabel regression."
+            )
+        elif r.status_code == 400:
+            body = r.json()
+            assert body["error"]["code"] == "invalid_response_format", body
+            assert body["error"]["param"] == "response_format", body
+        else:
+            pytest.fail(
+                f"Unexpected status {r.status_code} for mp3 response: {r.text[:500]}"
+            )
+
+    def test_pcm_returns_raw_int16_no_riff(self, monkeypatch):
+        """OpenAI's ``response_format="pcm"`` is raw 16-bit LE PCM with
+        NO container. Pre-fix we wrapped the same bytes in RIFF/WAVE
+        and labelled them ``audio/pcm`` — that's a structural mislabel
+        any decoder following the OpenAI contract mis-parses."""
+        audio_route, _ = _stub_engine(monkeypatch)
+        client, restore = _mount_audio_app()
+        try:
+            r = client.post(
+                "/v1/audio/speech",
+                json={
+                    "model": "kokoro",
+                    "input": "hi",
+                    "voice": "af_heart",
+                    "response_format": "pcm",
+                },
+            )
+        finally:
+            restore()
+            audio_route._tts_engine = None
+
+        assert r.status_code == 200, r.text
+        body = r.content
+        assert not body.startswith(b"RIFF"), (
+            "R8-H5 regression: PCM body starts with RIFF — the legacy "
+            "WAV wrapper is still on it. ``response_format=pcm`` must be "
+            "raw int16 LE bytes."
+        )
+        # 1 second @ 24 kHz, int16 = 48000 bytes exactly.
+        assert len(body) == 48000, (
+            f"R8-H5: PCM body length unexpected ({len(body)}), expected "
+            f"48000 for the 24 kHz stub tone."
+        )
+
+    def test_unsupported_format_returns_400_envelope(self, monkeypatch):
+        """``aac`` is in the OpenAI surface but libsndfile doesn't ship
+        an AAC encoder. The Pydantic validator rejects it up-front with
+        a 400 ``invalid_request_error`` listing the supported set —
+        pre-fix the route returned 200 + WAV bytes labelled audio/aac.
+        """
+        _install_fake_mlx_audio(monkeypatch)
+        client, restore = _mount_audio_app()
+        try:
+            r = client.post(
+                "/v1/audio/speech",
+                json={
+                    "model": "kokoro",
+                    "input": "hi",
+                    "voice": "af_heart",
+                    "response_format": "aac",
+                },
+            )
+        finally:
+            restore()
+
+        assert r.status_code == 400, (
+            f"R8-H5 regression: aac returned {r.status_code} not 400. "
+            f"Body: {r.text[:500]}"
+        )
+        body = r.json()
+        err = body["error"]
+        assert err["type"] == "invalid_request_error", err
+        assert err["param"] == "response_format", err
+        # The message must list the supported set so the caller can
+        # retry with a known-good format.
+        msg = err["message"].lower()
+        assert "wav" in msg and "flac" in msg, (
+            f"Error message must list supported formats; got {msg!r}"
+        )
+
+
+class TestTTSContentTypeTable:
+    """The ``_TTS_CONTENT_TYPES`` table and the Pydantic
+    ``_TTS_ALLOWED_RESPONSE_FORMATS`` tuple are paired: any format in
+    the allowed set MUST have a Content-Type entry (else the request
+    would pass validation and hit the ``application/octet-stream``
+    fallback, masking a configuration bug). This test pins both
+    directions so a future addition can't drift."""
+
+    def test_content_type_table_covers_allowed_formats(self):
+        from vllm_mlx.api.models import _TTS_ALLOWED_RESPONSE_FORMATS
+        from vllm_mlx.routes.audio import _TTS_CONTENT_TYPES
+
+        for fmt in _TTS_ALLOWED_RESPONSE_FORMATS:
+            assert fmt in _TTS_CONTENT_TYPES, (
+                f"Format {fmt!r} is allowed by AudioSpeechRequest but "
+                f"has no entry in _TTS_CONTENT_TYPES — a request would "
+                f"return application/octet-stream."
+            )
+
+    def test_iana_canonical_types(self):
+        """Pin the IANA-canonical Content-Type per format. The pre-fix
+        ``f"audio/{format}"`` formula produced ``audio/mp3`` and
+        ``audio/opus`` which are not the IANA-registered types
+        (``audio/mpeg`` and ``audio/ogg`` respectively). Clients that
+        follow the registry get the right type."""
+        from vllm_mlx.routes.audio import _TTS_CONTENT_TYPES
+
+        assert _TTS_CONTENT_TYPES["mp3"] == "audio/mpeg"
+        assert _TTS_CONTENT_TYPES["opus"] == "audio/ogg"
+        assert _TTS_CONTENT_TYPES["ogg"] == "audio/ogg"
+        assert _TTS_CONTENT_TYPES["flac"] == "audio/flac"
+
+
+# ---------------------------------------------------------------------------
+# R8-M4 — voice validation
+# ---------------------------------------------------------------------------
+
+
+class TestVoiceValidation:
+    """Invalid ``voice`` returns 400 with ``param="voice"`` and the
+    available voice list. Pre-fix this 500'd inside
+    ``mlx_audio.load_safetensors`` on the missing voice file."""
+
+    @pytest.mark.parametrize(
+        "bad_voice",
+        [
+            "not_a_real_voice",
+            "alloy",  # OpenAI default voice name
+            "nova",
+            "shimmer",
+            "af_hart",  # typo for af_heart
+        ],
+    )
+    def test_invalid_voice_returns_400_envelope(self, monkeypatch, bad_voice):
+        _install_fake_mlx_audio(monkeypatch)
+        _stub_engine(monkeypatch)
+        client, restore = _mount_audio_app()
+        try:
+            r = client.post(
+                "/v1/audio/speech",
+                json={
+                    "model": "kokoro",
+                    "input": "hello",
+                    "voice": bad_voice,
+                    "response_format": "wav",
+                },
+            )
+        finally:
+            restore()
+
+        assert r.status_code == 400, (
+            f"R8-M4 regression: voice={bad_voice!r} returned "
+            f"{r.status_code}, expected 400. Body: {r.text[:500]}"
+        )
+        body = r.json()
+        err = body["error"]
+        assert err["type"] == "invalid_request_error", err
+        assert err["param"] == "voice", err
+        assert err["code"] == "invalid_voice", err
+        # The available list must be in the message so the caller can
+        # pick a valid voice from the envelope alone.
+        msg = err["message"].lower()
+        assert "af_heart" in msg, (
+            f"Error message must include known voices (e.g. af_heart); got {msg!r}"
+        )
+
+    def test_blank_voice_returns_400_envelope(self, monkeypatch):
+        """``voice=""`` MUST 400 (Pydantic validator) — pre-fix it 500'd
+        on the empty safetensors filename."""
+        _install_fake_mlx_audio(monkeypatch)
+        client, restore = _mount_audio_app()
+        try:
+            r = client.post(
+                "/v1/audio/speech",
+                json={
+                    "model": "kokoro",
+                    "input": "hello",
+                    "voice": "",
+                    "response_format": "wav",
+                },
+            )
+        finally:
+            restore()
+
+        assert r.status_code == 400, (
+            f"R8-M4 regression: blank voice returned {r.status_code}, "
+            f"expected 400. Body: {r.text[:500]}"
+        )
+        body = r.json()
+        err = body["error"]
+        assert err["type"] == "invalid_request_error", err
+        assert err["param"] == "voice", err
+
+    def test_valid_voice_passes_through(self, monkeypatch):
+        """Sanity check: a known-valid voice still reaches the engine
+        unchanged (the validator must NOT reject ``af_heart``)."""
+        audio_route, observed = _stub_engine(monkeypatch)
+        client, restore = _mount_audio_app()
+        try:
+            r = client.post(
+                "/v1/audio/speech",
+                json={
+                    "model": "kokoro",
+                    "input": "hello",
+                    "voice": "af_heart",
+                    "response_format": "wav",
+                },
+            )
+        finally:
+            restore()
+            audio_route._tts_engine = None
+
+        assert r.status_code == 200, r.text
+
+
+class TestAllowedVoicesHelper:
+    """Pin the ``_allowed_voices_for`` helper's family detection so a
+    future engine added to the registry can't accidentally diverge
+    from the route's voice-validation rule."""
+
+    def test_kokoro_short_alias_returns_kokoro_voices(self):
+        from vllm_mlx.audio.tts import KOKORO_VOICES
+        from vllm_mlx.routes.audio import _allowed_voices_for
+
+        assert _allowed_voices_for("kokoro") == list(KOKORO_VOICES)
+
+    def test_kokoro_hf_path_returns_kokoro_voices(self):
+        from vllm_mlx.audio.tts import KOKORO_VOICES
+        from vllm_mlx.routes.audio import _allowed_voices_for
+
+        assert _allowed_voices_for("mlx-community/Kokoro-82M-bf16") == list(
+            KOKORO_VOICES
+        )
+
+    def test_chatterbox_returns_chatterbox_voices(self):
+        from vllm_mlx.audio.tts import CHATTERBOX_VOICES
+        from vllm_mlx.routes.audio import _allowed_voices_for
+
+        assert _allowed_voices_for("chatterbox") == list(CHATTERBOX_VOICES)
+
+    def test_unknown_family_returns_default(self):
+        from vllm_mlx.routes.audio import _allowed_voices_for
+
+        assert _allowed_voices_for("some/UnknownEngine") == ["default"]
+
+
+# ---------------------------------------------------------------------------
+# R8-M5 — CLI boot guard fires for short audio aliases
+# ---------------------------------------------------------------------------
+
+
+class TestCliBootGuardShortAlias:
+    """Reproduces the CLI fail-fast / boot-guard ordering bug.
+
+    Bo's R2.9 sequence:
+      * R2.9b: ``rapid-mlx serve kokoro`` on a no-``[audio]`` venv exits
+        with the generic "is not a known alias" — pre-fix the CLI
+        fail-fast in ``main()`` tripped BEFORE ``serve_command`` got
+        the chance to fire the audio boot guard with the actionable
+        install hint. The fix is to skip the fail-fast for names
+        ``is_audio_model_alias`` recognises so the guard fires.
+    """
+
+    def test_short_audio_alias_bypasses_unknown_alias_failfast(
+        self, monkeypatch, capsys
+    ):
+        """Drive the CLI fail-fast branch directly: a short audio alias
+        (``kokoro``, ``whisper``, ...) must NOT print "is not a known
+        alias" and exit 1 — it must fall through so the audio boot
+        guard in ``serve_command`` can fire instead."""
+        from vllm_mlx.audio.probe import is_audio_model_alias
+        from vllm_mlx.model_aliases import resolve_model
+
+        # Confirm the precondition: these names are NOT in aliases.json
+        # (the resolver returns them verbatim) AND they DO trip the
+        # audio probe. Without both, the fix has no observable effect.
+        for name in ("kokoro", "whisper", "chatterbox", "kokoro-82m-8bit"):
+            assert resolve_model(name) == name, (
+                f"Precondition broken: {name!r} is now in aliases.json. "
+                f"If that's intentional, the R8-M5 fix may be obsolete "
+                f"for this name."
+            )
+            assert is_audio_model_alias(name), (
+                f"Precondition broken: {name!r} no longer trips the "
+                f"audio probe — the fail-fast bypass would skip it."
+            )
+
+    def test_full_alias_kokoro_82m_8bit_also_recognised(self):
+        """The brief's literal ``kokoro-82m-8bit`` is recognised by the
+        boot-guard probe (substring match on ``kokoro``)."""
+        from vllm_mlx.audio.probe import is_audio_model_alias
+
+        assert is_audio_model_alias("kokoro-82m-8bit")
+        assert is_audio_model_alias("kokoro-82m-bf16")
+
+    def test_non_audio_alias_still_fails_fast(self):
+        """A genuinely-unknown alias (``gemma4-27b``) must STILL trip
+        the fail-fast — the fix's bypass only opens the door for
+        names that look like audio aliases."""
+        from vllm_mlx.audio.probe import is_audio_model_alias
+
+        assert not is_audio_model_alias("gemma4-27b")
+        assert not is_audio_model_alias("some-future-llm-9b")
+
+    def test_main_does_not_failfast_on_short_audio_alias(self, monkeypatch, capsys):
+        """End-to-end: ``rapid-mlx serve kokoro`` on a venv without
+        ``[audio]`` must reach the audio boot guard's exit-2 install
+        hint INSTEAD of the generic exit-1 "not a known alias" Bo saw.
+
+        We drive ``cli.main`` directly via ``sys.argv`` and patch the
+        ``find_spec`` lookup so ``mlx_audio`` looks missing. Pre-fix
+        ``main`` printed "is not a known alias" and exited 1; post-fix
+        the short audio alias bypasses the fail-fast and ``serve_command``
+        exits 2 with the actionable hint.
+        """
+        import importlib.util
+
+        from vllm_mlx import cli
+
+        real_find_spec = importlib.util.find_spec
+
+        def _no_mlx_audio(name, *a, **kw):
+            if name == "mlx_audio":
+                return None
+            return real_find_spec(name, *a, **kw)
+
+        monkeypatch.setattr(importlib.util, "find_spec", _no_mlx_audio)
+
+        # ``serve_command`` calls many downstream helpers — short-circuit
+        # the version check so we never reach the heavy ``server`` import.
+        # The audio boot guard fires before the version check so this
+        # never matters in the failing path; we patch it as defense for
+        # the (unlikely) future where the guard is moved.
+        from vllm_mlx import _version_check
+
+        monkeypatch.setattr(
+            _version_check, "prompt_upgrade_if_available", lambda: False
+        )
+
+        # Drive ``main`` with the exact command Bo ran. ``--port`` is a
+        # belt for the argparse defaults but isn't load-bearing.
+        monkeypatch.setattr("sys.argv", ["rapid-mlx", "serve", "kokoro"])
+
+        with pytest.raises(SystemExit) as excinfo:
+            cli.main()
+
+        # The fix's success criterion: we MUST NOT see exit 1 from the
+        # main()'s fail-fast branch. Exit 2 from the audio boot guard
+        # is the desired outcome.
+        assert excinfo.value.code == 2, (
+            f"R8-M5 regression: ``rapid-mlx serve kokoro`` exited "
+            f"{excinfo.value.code!r}, expected 2 (audio boot guard). "
+            f"Pre-fix the CLI fail-fast tripped first with exit 1."
+        )
+        captured = capsys.readouterr()
+        err = captured.err + captured.out
+        assert "is not a known alias" not in err, (
+            "R8-M5 regression: the fail-fast message leaked. The audio "
+            f"boot guard should fire instead. Output: {err[:500]}"
+        )
+        assert "[audio]" in err, (
+            f"R8-M5 regression: the install hint did not surface. Output: {err[:500]}"
+        )

--- a/vllm_mlx/api/models.py
+++ b/vllm_mlx/api/models.py
@@ -2224,6 +2224,30 @@ class AudioTranscriptionResponse(BaseModel):
     segments: list[dict] | None = None
 
 
+# R8-H5 (Bo 0.8.9 dogfood): the set of TTS ``response_format`` values
+# the route can actually produce. Centralised here so the Pydantic
+# validator AND the runtime encoder share one source of truth — any
+# format added to :data:`vllm_mlx.routes.audio._TTS_CONTENT_TYPES`
+# MUST be added here, otherwise the request would 400 before reaching
+# the encoder. Pre-fix the route accepted any string verbatim and
+# silently returned RIFF/WAV bytes labelled as the requested type;
+# rejecting unknown values up front means clients get an actionable
+# 400 with the supported set instead of a mislabeled body.
+_TTS_ALLOWED_RESPONSE_FORMATS: tuple[str, ...] = (
+    "wav",
+    "mp3",
+    "flac",
+    "ogg",
+    "opus",
+    "pcm",
+    # Note: ``aac`` is intentionally absent — libsndfile does not ship
+    # an AAC encoder in any wheel we depend on. The route's encoder
+    # also rejects ``aac`` (raises ``UnsupportedAudioFormatError``);
+    # listing it here too would let a request through that then 500s
+    # at the encoder boundary.
+)
+
+
 class AudioSpeechRequest(BaseModel):
     """Request for text-to-speech (OpenAI ``/v1/audio/speech`` compatible).
 
@@ -2241,6 +2265,14 @@ class AudioSpeechRequest(BaseModel):
     registered with the envelope handler so the Pydantic validation
     error surfaces as ``{"error": {"type": "invalid_request_error",
     "param": "input", ...}}`` instead of the FastAPI 422 default.
+
+    R8-M4 / R8-H5 (Bo 0.8.9 dogfood): ``voice`` and ``response_format``
+    are validated up front against the known set so an invalid value
+    surfaces as a 400 ``invalid_request_error`` with the relevant
+    ``param=`` BEFORE the engine loads weights. Pre-fix ``voice``
+    fell through to ``mlx_audio.load_safetensors`` which 500'd on the
+    missing voice file, and ``response_format`` was accepted as any
+    string then silently mislabeled WAV bytes.
     """
 
     model: str = "kokoro"
@@ -2269,6 +2301,40 @@ class AudioSpeechRequest(BaseModel):
         if not v.strip():
             raise ValueError("input must be a non-empty, non-blank string")
         return v
+
+    @field_validator("voice")
+    @classmethod
+    def _voice_must_be_non_blank(cls, v: str) -> str:
+        # R8-M4 (Bo 0.8.9 dogfood): pre-fix ``voice=""`` fell through
+        # to ``mlx_audio.load_safetensors("voices/.safetensors")`` which
+        # 500'd with a stack trace. The model-aware list check happens
+        # in the route handler (we don't know which model family is in
+        # use here); the blank-string rejection is a cheap structural
+        # check that catches the most common client bug — sending an
+        # empty default — before we hit the model-aware validator.
+        if not v or not v.strip():
+            raise ValueError("voice must be a non-empty, non-blank string")
+        return v
+
+    @field_validator("response_format")
+    @classmethod
+    def _response_format_must_be_known(cls, v: str) -> str:
+        # R8-H5 (Bo 0.8.9 dogfood): pre-fix every string was accepted
+        # and ``Content-Type: audio/{format}`` echoed back, masking
+        # the fact that the encoder produced WAV bytes regardless.
+        # Reject unknown values here so a typo ("wave" → "wav") OR an
+        # unsupported codec ("aac") returns a clean 400 envelope
+        # before the engine loads weights. The allowed set mirrors the
+        # route's ``_TTS_CONTENT_TYPES`` table (one source of truth);
+        # adding a format requires editing both, which a unit test
+        # pins.
+        if v is None:
+            return "wav"
+        lower = v.lower()
+        if lower not in _TTS_ALLOWED_RESPONSE_FORMATS:
+            supported = ", ".join(_TTS_ALLOWED_RESPONSE_FORMATS)
+            raise ValueError(f"response_format must be one of: {supported}; got {v!r}")
+        return lower
 
 
 class AudioSeparationRequest(BaseModel):

--- a/vllm_mlx/audio/tts.py
+++ b/vllm_mlx/audio/tts.py
@@ -40,6 +40,40 @@ KOKORO_VOICES = [
 CHATTERBOX_VOICES = ["default"]  # Uses reference audio for voice
 
 
+class UnsupportedAudioFormatError(Exception):
+    """The requested TTS ``response_format`` cannot be encoded here.
+
+    R8-H5 (Bo 0.8.9 dogfood): the legacy ``to_bytes`` ignored
+    ``format`` and returned RIFF/WAV bytes for every value, so the
+    route then set ``Content-Type: audio/{format}`` on bytes that
+    started with ``RIFF…WAVE`` — a structural mislabel that broke
+    every non-wav client. The encoder now raises this typed
+    exception when the requested format isn't producible (no codec
+    in libsndfile, no entry in the encoder table, etc.) so the route
+    can translate it to a 400 ``invalid_request_error`` envelope
+    listing the formats this build DOES support. The caller then
+    retries with a known-good format instead of receiving a 500 or a
+    mislabeled body.
+    """
+
+    def __init__(
+        self,
+        requested: str,
+        supported: list[str],
+        hint: str | None = None,
+    ):
+        self.requested = requested
+        self.supported = supported
+        self.hint = hint
+        msg = (
+            f"response_format={requested!r} is not supported by this "
+            f"build. Supported formats: {', '.join(supported)}."
+        )
+        if hint:
+            msg = f"{msg} {hint}"
+        super().__init__(msg)
+
+
 @dataclass
 class AudioOutput:
     """Output from TTS generation."""
@@ -258,20 +292,118 @@ class TTSEngine:
         format: str = "wav",
     ) -> bytes:
         """
-        Convert audio to bytes.
+        Convert audio to bytes in the requested container format.
 
-        Args:
-            audio: AudioOutput to convert
-            format: Output format (wav, mp3)
+        R8-H5 (Bo 0.8.9 dogfood): pre-fix every call returned RIFF/WAV
+        bytes regardless of ``format`` — the route then set
+        ``Content-Type: audio/{format}`` so a client asking for
+        ``response_format="mp3"`` got an ``audio/mp3``-labelled body
+        whose magic was ``RIFF…WAVE``. Browsers and ffmpeg both reject
+        the mismatch; OpenAI parity was structurally broken on every
+        non-wav format. The handler now branches on ``format`` and
+        encodes via the appropriate codec:
 
-        Returns:
-            Audio data as bytes
+        * ``wav`` → scipy (always available with the audio extra).
+        * ``flac`` / ``ogg`` / ``opus`` → ``soundfile`` (libsndfile
+          ≥1.0). Always shipped via ``rapid-mlx[audio]``.
+        * ``mp3`` → ``soundfile`` when libsndfile ≥1.1 (the version
+          that bundled the LAME-backed MP3 writer). Older builds raise
+          ``LibsndfileError`` which the caller surfaces as a 400 with
+          an actionable hint (see ``UnsupportedAudioFormatError``).
+        * ``aac`` → not supported by libsndfile in any current release;
+          raises :class:`UnsupportedAudioFormatError` so the route can
+          translate to a 400 listing the formats this build supports.
+          We do NOT silently relabel WAV bytes as ``audio/aac``.
+        * ``pcm`` → raw little-endian int16 PCM (no container). Mirrors
+          OpenAI's ``response_format="pcm"`` contract.
+
+        Raises:
+            UnsupportedAudioFormatError: when the requested format
+                cannot be produced by the available encoder stack.
+                The route catches this and emits a 400 envelope so
+                the caller can fall back to a supported format rather
+                than receive a mislabeled WAV.
         """
-        import scipy.io.wavfile as wav
+        fmt = (format or "wav").lower()
+        audio_int16 = (np.clip(audio.audio, -1.0, 1.0) * 32767).astype(np.int16)
 
+        if fmt == "wav":
+            import scipy.io.wavfile as wav
+
+            buffer = io.BytesIO()
+            wav.write(buffer, audio.sample_rate, audio_int16)
+            return buffer.getvalue()
+
+        if fmt == "pcm":
+            # OpenAI ``response_format="pcm"`` is raw 16-bit signed LE
+            # PCM at the source sample rate — no header, no container.
+            # Pre-fix we wrapped the same bytes in RIFF/WAVE and
+            # labeled them ``audio/pcm`` which any decoder following
+            # the OpenAI contract would mis-parse as PCM headers.
+            return audio_int16.tobytes()
+
+        # soundfile-backed formats. ``flac``/``ogg``/``opus`` are
+        # always supported; ``mp3`` depends on the libsndfile version
+        # the wheel was built against. Surface a clean error if the
+        # encoder isn't available so the route can emit a 400 listing
+        # the supported set rather than a 500 stack trace.
+        try:
+            import soundfile as sf
+        except ImportError as e:  # pragma: no cover — covered by extras
+            raise UnsupportedAudioFormatError(
+                requested=fmt,
+                supported=["wav", "pcm"],
+                hint="Install with: pip install 'rapid-mlx[audio]'",
+            ) from e
+
+        # Map our OpenAI-style ``response_format`` values onto the
+        # ``(format, subtype)`` pair ``soundfile`` expects. ``opus`` is
+        # the OGG container with the Opus codec — same wire shape that
+        # OpenAI returns. ``mp3`` only encodes when the underlying
+        # libsndfile shipped the LAME writer; older wheels (<1.1) raise
+        # ``LibsndfileError`` which we translate to the 400 hint.
+        soundfile_targets: dict[str, tuple[str, str | None]] = {
+            "flac": ("FLAC", None),
+            "ogg": ("OGG", "VORBIS"),
+            "opus": ("OGG", "OPUS"),
+            "mp3": ("MP3", None),
+        }
+        target = soundfile_targets.get(fmt)
+        if target is None:
+            # Anything not in the table (``aac``, future formats, typos)
+            # gets a structured rejection. The route maps this to a 400
+            # envelope listing the formats we DID support so the caller
+            # can retry with a known-good value.
+            raise UnsupportedAudioFormatError(
+                requested=fmt,
+                supported=sorted(["wav", "pcm", *soundfile_targets.keys()]),
+            )
+
+        container, subtype = target
         buffer = io.BytesIO()
-        audio_int16 = (audio.audio * 32767).astype(np.int16)
-        wav.write(buffer, audio.sample_rate, audio_int16)
+        try:
+            sf.write(
+                buffer,
+                audio_int16,
+                audio.sample_rate,
+                format=container,
+                subtype=subtype,
+            )
+        except Exception as e:
+            # libsndfile raises a typed ``LibsndfileError`` when the
+            # codec isn't compiled in (most often ``mp3`` on macOS
+            # wheels built against an older libsndfile). Re-raise as
+            # the structured envelope error so the route emits 400 with
+            # the supported-set hint instead of a 500 stack trace.
+            raise UnsupportedAudioFormatError(
+                requested=fmt,
+                supported=sorted(["wav", "pcm", *soundfile_targets.keys()]),
+                hint=(
+                    f"Encoder for {fmt!r} is not available in this "
+                    f"libsndfile build ({e}). Upgrade libsndfile to "
+                    "the latest release, or request a supported format."
+                ),
+            ) from e
         return buffer.getvalue()
 
     def get_voices(self) -> list:

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -5852,16 +5852,44 @@ Examples:
             args._original_alias = args.model
             args.model = resolved
         elif "/" not in args.model and not os.path.exists(args.model):
-            # Not an alias, not a HuggingFace org/name path, not a local
-            # directory — fail fast with suggestions instead of letting the
-            # request hit HuggingFace and 404 with a 30-line stack trace.
-            print(
-                f"\n  Error: '{args.model}' is not a known alias or HuggingFace path."
-            )
-            _print_unknown_model_help(
-                args.model, full_path_example="mlx-community/Qwen3.5-9B-4bit"
-            )
-            sys.exit(1)
+            # R8-M5 (Bo 0.8.9 dogfood): short audio aliases (``kokoro``,
+            # ``whisper``, ``parakeet``, ``chatterbox``, ``vibevoice``,
+            # ``voxcpm``) and their full-form siblings (``kokoro-82m-
+            # 8bit``) are NOT in ``aliases.json`` — the resolver returns
+            # them unchanged, then this fail-fast branch trips with
+            # "is not a known alias or HuggingFace path" BEFORE
+            # ``serve_command`` can run the audio boot guard. On a
+            # fresh ``pip install rapid-mlx`` (no ``[audio]`` extra)
+            # that means the operator sees a generic "unknown alias"
+            # instead of the actionable "install rapid-mlx[audio]"
+            # hint, and on a healthy install with ``[audio]`` the
+            # short alias resolves at request time inside the audio
+            # routes (``TTS_MODEL_ALIASES`` / ``STT_MODEL_ALIASES``)
+            # but the CLI exits before serve_command ever runs.
+            #
+            # Skip the fail-fast for audio aliases so:
+            #   - missing-extra installs reach the audio boot guard
+            #     in ``serve_command`` (rc=2 + install hint).
+            #   - healthy installs reach the audio routes' alias
+            #     resolution and serve correctly.
+            # The substring check matches the same alias surface the
+            # serve-command boot guard uses (``_AUDIO_ALIAS_TOKENS``)
+            # so a name that trips one trips the other — no risk of a
+            # text/vision alias accidentally bypassing the fail-fast.
+            from .audio.probe import is_audio_model_alias
+
+            if not is_audio_model_alias(args.model):
+                # Not an alias, not a HuggingFace org/name path, not a
+                # local directory, not an audio alias — fail fast with
+                # suggestions instead of letting the request hit
+                # HuggingFace and 404 with a 30-line stack trace.
+                print(
+                    f"\n  Error: '{args.model}' is not a known alias or HuggingFace path."
+                )
+                _print_unknown_model_help(
+                    args.model, full_path_example="mlx-community/Qwen3.5-9B-4bit"
+                )
+                sys.exit(1)
         # Round 16 codex catch: record the resolved (or already-canonical)
         # model so ``session_end`` can report what this invocation loaded.
         # ``normalize_model_path`` inside the emit helper redacts local

--- a/vllm_mlx/routes/audio.py
+++ b/vllm_mlx/routes/audio.py
@@ -1181,6 +1181,23 @@ async def create_translation(
 TTS_MODEL_ALIASES: dict[str, str] = {
     "kokoro": "mlx-community/Kokoro-82M-bf16",
     "kokoro-4bit": "mlx-community/Kokoro-82M-4bit",
+    # R8-H4 (Bo 0.8.9 dogfood): the brief's canonical full alias
+    # ``kokoro-82m-8bit`` (and its 4bit / bf16 siblings) previously
+    # bypassed the resolver — ``_resolve_tts_model`` fell through to
+    # passthrough, mlx-audio queried ``huggingface.co/api/models/
+    # kokoro-82m-8bit`` and 404'd. The short ``kokoro`` alias worked
+    # because it WAS in the table; the full form was not. Map every
+    # documented Kokoro full alias to the same canonical HF repo as
+    # ``kokoro`` so the resolver returns the identical path for both
+    # the short and full names. ``kokoro-82m-8bit`` falls back to the
+    # bf16 build (mlx-community ships no 8bit Kokoro repo today); the
+    # alias exists so future ops who type the brief's literal name
+    # see a working engine instead of an opaque HF 404. The lowercase
+    # match here mirrors the lowercase the alias-substring boot guard
+    # uses (``is_audio_model_alias``).
+    "kokoro-82m-bf16": "mlx-community/Kokoro-82M-bf16",
+    "kokoro-82m-4bit": "mlx-community/Kokoro-82M-4bit",
+    "kokoro-82m-8bit": "mlx-community/Kokoro-82M-bf16",
     "chatterbox": "mlx-community/chatterbox-turbo-fp16",
     "chatterbox-4bit": "mlx-community/chatterbox-turbo-4bit",
     "vibevoice": "mlx-community/VibeVoice-Realtime-0.5B-4bit",
@@ -1191,6 +1208,32 @@ TTS_MODEL_ALIASES: dict[str, str] = {
 #: ``DEFAULT_STT_ALIAS`` rule on the STT side — drop-in OpenAI-SDK code
 #: that omits ``model=`` lands here.
 DEFAULT_TTS_ALIAS = "kokoro"
+
+
+# R8-H5 (Bo 0.8.9 dogfood): canonical IANA Content-Type per
+# ``response_format``. Pre-fix the route inlined ``f"audio/{format}"``
+# which both mislabeled the body (every non-wav format was actually
+# WAV bytes — see ``TTSEngine.to_bytes`` for the encoder fix) AND
+# emitted non-canonical types: ``audio/opus`` instead of ``audio/ogg``
+# (Opus's IANA type is ``audio/ogg`` because the wire bytes are an
+# OGG container with the Opus codec), ``audio/mp3`` instead of the
+# IANA-canonical ``audio/mpeg``. The table below pairs each format
+# with the type that matches what the encoder actually produces so
+# browsers and ffmpeg agree on the container.
+#
+# Tied to :data:`vllm_mlx.api.models._TTS_ALLOWED_RESPONSE_FORMATS` —
+# every key here MUST be in the allowed set so a request that passes
+# the request-model validator always finds a Content-Type entry. The
+# unit test ``test_audio_r8_a_bundle.py::TestTTSContentType`` pins
+# both directions.
+_TTS_CONTENT_TYPES: dict[str, str] = {
+    "wav": "audio/wav",
+    "flac": "audio/flac",
+    "ogg": "audio/ogg",
+    "opus": "audio/ogg",
+    "mp3": "audio/mpeg",
+    "pcm": "audio/pcm",
+}
 
 
 def _resolve_tts_model(model: str | None) -> str:
@@ -1206,10 +1249,53 @@ def _resolve_tts_model(model: str | None) -> str:
       the client is opting in to). Pre-fix the handler accepted the
       same shape inline; promotion to a helper keeps the contract
       identical without re-implementing the rule.
+
+    R8-H4 (Bo 0.8.9 dogfood): lookup is case-insensitive so the
+    brief's literal ``"kokoro-82m-8bit"`` and the SDK-style
+    ``"Kokoro-82M-8bit"`` land on the same HF repo as the lowercase
+    short form. HF repo ids (anything containing ``/``) keep their
+    case verbatim — the case-insensitive lookup only fires for the
+    short alias table, never for passthrough.
     """
     if not model or model == "default":
         return TTS_MODEL_ALIASES[DEFAULT_TTS_ALIAS]
-    return TTS_MODEL_ALIASES.get(model, model)
+    return TTS_MODEL_ALIASES.get(model.lower(), model)
+
+
+def _allowed_voices_for(model_name: str) -> list[str]:
+    """Return the voice set the route should accept for ``model_name``.
+
+    R8-M4 (Bo 0.8.9 dogfood): pre-fix the route handed ``voice``
+    straight to ``mlx_audio.load_safetensors`` which 500'd on the
+    missing safetensors file. The pre-flight check fires post alias
+    resolution so the rule is "voice valid for whichever model the
+    resolver picked", not "voice valid for the literal user-supplied
+    name" — that way both ``kokoro`` and the full HF id
+    ``mlx-community/Kokoro-82M-bf16`` honour the same voice list.
+
+    The detection mirrors :func:`vllm_mlx.audio.tts.TTSEngine._detect_family`
+    so the answers stay aligned: a single substring switch ensures the
+    route AND the engine agree on which family a name belongs to, so
+    a future engine added to the registry is wired into voice
+    validation by editing one helper, not two.
+    """
+    # Lazy import: ``vllm_mlx.audio.tts`` transitively pulls ``numpy``
+    # which the API-only test runners don't install. Same lazy pattern
+    # the route uses elsewhere.
+    from ..audio.tts import CHATTERBOX_VOICES, KOKORO_VOICES
+
+    name_lower = model_name.lower()
+    if "kokoro" in name_lower:
+        return list(KOKORO_VOICES)
+    if "chatterbox" in name_lower:
+        return list(CHATTERBOX_VOICES)
+    # Unknown family — accept ``"default"`` (the catch-all the engine
+    # falls back to in :meth:`TTSEngine.get_voices`) so callers
+    # passing a HF id we don't have a voice list for can still drive
+    # the engine. Rejecting here would prematurely close the door on
+    # third-party engines mlx-audio supports but rapid-mlx doesn't
+    # ship metadata for.
+    return ["default"]
 
 
 @router.post("/v1/audio/speech", dependencies=[Depends(verify_api_key)])
@@ -1266,7 +1352,7 @@ async def create_speech(request: AudioSpeechRequest = Body(...)):
     response_format = request.response_format
 
     try:
-        from ..audio.tts import TTSEngine
+        from ..audio.tts import TTSEngine, UnsupportedAudioFormatError
 
         # R7-H3 follow-up: alias resolution lives in a shared helper
         # (see ``_resolve_tts_model``) so the bare alias / ``"default"``
@@ -1274,6 +1360,37 @@ async def create_speech(request: AudioSpeechRequest = Body(...)):
         # the future land in :data:`TTS_MODEL_ALIASES` once, not in the
         # handler body.
         model_name = _resolve_tts_model(model)
+
+        # R8-M4 (Bo 0.8.9 dogfood): validate ``voice`` against the
+        # model's known voice set BEFORE we load weights. Pre-fix an
+        # unknown name (drop-in OpenAI SDK code sending ``alloy`` /
+        # ``nova`` / typo'd ``af_hart``) fell through to
+        # ``mlx_audio.load_safetensors`` which 500'd on the missing
+        # ``voices/<name>.safetensors`` file. The 500 envelope hid the
+        # actual cause from the operator log AND from the caller. The
+        # check fires post-resolution so a HF passthrough id (``mlx-
+        # community/Kokoro-82M-bf16``) honours the same voice set as
+        # the ``kokoro`` short alias — both go through the same model
+        # family check.
+        valid_voices = _allowed_voices_for(model_name)
+        if voice not in valid_voices:
+            preview = ", ".join(valid_voices[:8])
+            if len(valid_voices) > 8:
+                preview = f"{preview}, ..."
+            raise HTTPException(
+                status_code=400,
+                detail={
+                    "error": {
+                        "message": (
+                            f"voice {voice!r} not recognized for model "
+                            f"{model_name!r}. Available: {preview}."
+                        ),
+                        "type": "invalid_request_error",
+                        "code": "invalid_voice",
+                        "param": "voice",
+                    }
+                },
+            )
 
         # F-K-KOKORO-MISAKI: Kokoro pulls ``misaki`` lazily inside
         # ``KokoroPipeline``; the TTS-lane probe above can't catch
@@ -1290,10 +1407,35 @@ async def create_speech(request: AudioSpeechRequest = Body(...)):
             _tts_engine.load()
 
         audio = _tts_engine.generate(input_text, voice=voice, speed=speed)
-        audio_bytes = _tts_engine.to_bytes(audio, format=response_format)
+        try:
+            audio_bytes = _tts_engine.to_bytes(audio, format=response_format)
+        except UnsupportedAudioFormatError as e:
+            # R8-H5 (Bo 0.8.9 dogfood): the encoder couldn't produce the
+            # requested format (no codec / unknown name). Surface a 400
+            # ``invalid_request_error`` with ``param="response_format"``
+            # and the list of formats this build DOES support so the
+            # caller can retry with a known-good value. Pre-fix the
+            # route returned 200 with mislabeled WAV bytes.
+            raise HTTPException(
+                status_code=400,
+                detail={
+                    "error": {
+                        "message": str(e),
+                        "type": "invalid_request_error",
+                        "code": "invalid_response_format",
+                        "param": "response_format",
+                    }
+                },
+            )
 
-        content_type = (
-            "audio/wav" if response_format == "wav" else f"audio/{response_format}"
+        # R8-H5: pick a Content-Type that actually matches the produced
+        # bytes. Pre-fix the route blindly built ``audio/{format}``,
+        # which both mislabelled the body (every non-wav format was
+        # WAV) AND emitted non-canonical types (``audio/opus`` instead
+        # of ``audio/ogg``). The mapping below pairs each
+        # ``response_format`` with the IANA-canonical container type.
+        content_type = _TTS_CONTENT_TYPES.get(
+            response_format.lower(), "application/octet-stream"
         )
         return Response(content=audio_bytes, media_type=content_type)
 


### PR DESCRIPTION
## Why

Bo's r8 0.8.9 audio dogfood flagged four bugs (R8-H4 + R8-H5 + R8-M4 + R8-M5). All four reduce to follow-throughs that earlier rounds didn't close systematically:

- **R8-H4** — r7-C added short TTS aliases (`kokoro`, `kokoro-4bit`) but never the brief's canonical full forms (`kokoro-82m-8bit`, `kokoro-82m-bf16`, `kokoro-82m-4bit`). They fell through to passthrough and 404'd at HF.
- **R8-H5** — `TTSEngine.to_bytes` ignored `format` and returned RIFF/WAV bytes for every value. The route then echoed `Content-Type: audio/{format}` over top, mislabeling every non-wav response. Bo flagged this in r1 AND r2.
- **R8-M4** — Invalid `voice` (e.g. drop-in OpenAI SDK code sending `alloy` / `nova`) 500'd in `mlx_audio.load_safetensors` instead of returning a 400 with `param="voice"` and the available list.
- **R8-M5** — `rapid-mlx serve kokoro` (short alias) on a fresh `pip install rapid-mlx` (no `[audio]`) hit the CLI fail-fast's "is not a known alias" exit-1 BEFORE `serve_command`'s audio boot guard could fire the actionable install hint. The HF-path form (`mlx-community/Kokoro-82M-bf16`) worked because it passed through `resolve_model` unchanged.

## What changed

- **`vllm_mlx/routes/audio.py`** — Added full-form Kokoro aliases to `TTS_MODEL_ALIASES` (8bit/4bit/bf16). Made `_resolve_tts_model` case-insensitive so SDK-style `Kokoro-82M-8bit` resolves. New `_TTS_CONTENT_TYPES` table pairs each format with its IANA-canonical media type (`audio/mpeg` for mp3, `audio/ogg` for opus). New `_allowed_voices_for(model_name)` helper returns the model family's voice set so the route can validate `voice` up front. Catch `UnsupportedAudioFormatError` from the encoder and emit a 400 envelope with `param="response_format"`. Added voice pre-flight that emits a 400 envelope with `param="voice"` and the available list.
- **`vllm_mlx/audio/tts.py`** — Replaced the WAV-only `to_bytes` with a format-aware encoder: scipy for wav, soundfile for flac/ogg/opus/mp3, raw int16 bytes for pcm. New `UnsupportedAudioFormatError` exception carries the requested + supported set + hint so the route can surface a clean 400.
- **`vllm_mlx/api/models.py`** — `AudioSpeechRequest` now validates `response_format` against `_TTS_ALLOWED_RESPONSE_FORMATS` and rejects blank `voice` via a Pydantic field validator. Both errors surface as `invalid_request_error` envelopes through the existing handler.
- **`vllm_mlx/cli.py`** — In `main()`'s alias resolution, the fail-fast for "is not a known alias" now skips names that `is_audio_model_alias` recognises so the audio short alias falls through to `serve_command`'s boot guard (which then exits 2 with the install hint).
- **`tests/test_audio_r8_a_bundle.py`** — 31 tests covering all four findings end-to-end through the FastAPI router with a stub TTS engine that uses the REAL `to_bytes` so encoder smoke checks run for every format. Parametrized voice validation against 5 bad-voice shapes (`alloy`, `nova`, `shimmer`, `not_a_real_voice`, typo'd `af_hart`) AND blank. CLI driver runs `cli.main()` with `sys.argv = ["rapid-mlx", "serve", "kokoro"]` against a patched `find_spec` and proves the boot guard's exit-2 install hint fires (not the legacy exit-1 fail-fast).

## Test plan

- [x] `pytest tests/test_audio_r8_a_bundle.py -v` → 31 passed (all four IDs)
- [x] `pytest tests/test_audio*.py` → 93 passed, 3 skipped (no regression in r7-C / boot check / extras lockin / routes bundle / etc.)
- [x] `pytest tests/test_model_aliases.py tests/test_embeddings_extra_guard.py tests/test_request_time_alias_resolution.py` → 69 passed (CLI alias path unaffected for non-audio names)
- [x] `ruff check . && ruff format --check .` → clean