### PR TITLE
chore: bump version to 0.8.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.8.9"
+version = "0.8.10"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## Why

Cuts 0.8.10 to roll out the r8 fix wave (3 PRs that merged after 0.8.9):

- **r8-A** (#839 `7df21f0`) — audio bundle: full Kokoro alias (`kokoro-82m-8bit/4bit/bf16` + case-insensitive resolver), real format encoding via soundfile (mp3/flac/ogg/opus/pcm), model-aware voice validation with 400 envelope, CLI fail-fast bypass for short audio aliases so the boot guard install hint fires (R8-H4 + R8-H5 + R8-M4 + R8-M5).
- **r8-B** (#840 `b3556a6`) — runtime: healthz fast-path (further hot-path work moved off the request loop, p99 target ≤50ms) + cache-persist commit-phase hardening so SIGTERM no longer races the staging-dir rename (R8-H6 + R8-M7).
- **r8-C** (#841 `266fff1`) — reasoning streaming: UI-TARS-native `Thought:`/`Answer:` blank-line split routes the answer to `delta.content` (parity with non-stream r6-B follow-up `a16d8c8`); `tool_choice="auto"` + thinking-on stream no longer leaks `<think>` text via `delta.content`; codex r2 MED follow-up: `<think>` complete-token detection anchored at first non-whitespace bytes so literal mid-content mentions don't latch the bypass (R8-M6 + R8-M2 + codex-MED).

All r7 fixes (r7-A/B/C/D verified shipped in 0.8.9 — see r8 dogfood scorecard in 0.8TODO.md).

Standard release: bump-only commit, auto-release.yml fires on subject match. All r8 fix PRs merged with pr_validate green and codex review converged on diff.

## Test plan

- [x] All 3 r8 fix PRs merged with pr_validate green + codex review converged on diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)