### PR TITLE
fix(runtime): r8-B codex r3 follow-up — case-insensitive Origin check on probe fast-path

### DIFF
--- a/tests/test_probe_fastpath.py
+++ b/tests/test_probe_fastpath.py
@@ -551,6 +551,53 @@ class TestFastPathServesRequest:
         assert captured[0]["status"] == 200
         assert json.loads(captured[1]["body"]) == {"status": "alive"}
 
+    def test_fastpath_origin_check_is_case_insensitive(self):
+        """Codex r3 BLOCKING #1: an ASGI server / harness that ships
+        ``b"Origin"`` (capital) instead of the spec-mandated lowercase
+        must still trigger the CORS fall-through. Pre-fix the
+        comparison ``name == b"origin"`` missed the capital case and
+        would have served the fast-path 200 to a cross-origin browser
+        request — silently bypassing CORS.
+        """
+        inner_calls: list[dict] = []
+
+        async def _inner(scope, receive, send):
+            inner_calls.append(scope)
+            await send(
+                {
+                    "type": "http.response.start",
+                    "status": 200,
+                    "headers": [(b"content-type", b"application/json")],
+                }
+            )
+            await send({"type": "http.response.body", "body": b"{}"})
+
+        mw = ProbeFastPathMiddleware(_inner)
+
+        async def _send(msg):
+            pass
+
+        async def _receive():
+            return {"type": "http.request", "body": b"", "more_body": False}
+
+        # Try every plausible casing a non-conforming ASGI adapter
+        # might ship.
+        for header_name in (b"origin", b"Origin", b"ORIGIN", b"OrIgIn"):
+            inner_calls.clear()
+            scope = {
+                "type": "http",
+                "method": "GET",
+                "path": "/healthz",
+                "raw_path": b"/healthz",
+                "headers": [(header_name, b"https://browser.example")],
+                "query_string": b"",
+            }
+            asyncio.run(mw(scope, _receive, _send))
+            assert len(inner_calls) == 1, (
+                f"Origin header cased {header_name!r} must trigger CORS "
+                f"fall-through; got {len(inner_calls)} inner-app calls"
+            )
+
     def test_fastpath_delegates_to_inner_app_on_origin_header(self):
         """A request with Origin must fall through so the (outer) CORS
         middleware can attach ACAO. Pin this by recording inner-app

--- a/vllm_mlx/middleware/probe_fastpath.py
+++ b/vllm_mlx/middleware/probe_fastpath.py
@@ -132,9 +132,18 @@ def _has_origin(scope: dict[str, Any]) -> bool:
     ``Access-Control-Allow-Origin`` header. Trading a few microseconds
     of fast-path for spec-compliant CORS on the cross-origin slice is
     the right call.
+
+    Codex r3 BLOCKING #1: the ASGI spec (PEP 3333 / ASGI 2.x) requires
+    headers to be lowercased before they reach app code, but not every
+    ASGI server or test harness enforces this — uvicorn does, h11 with
+    a custom scope adapter may not, and TestClient's manual scope
+    construction is operator-dependent. Lowercasing defensively here
+    avoids a silent CORS-bypass failure mode where the fast-path
+    serves a 200 to a cross-origin browser request that should have
+    received ACAO from the outer CORS middleware.
     """
     for name, _value in scope.get("headers", ()):
-        if name == b"origin":
+        if name.lower() == b"origin":
             return True
     return False
 

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -595,17 +595,33 @@ from .middleware.body_size import install_request_body_limit_middleware  # noqa:
 
 install_request_body_limit_middleware(app)
 
-# R8-H6: ASGI fast-path for ``GET /healthz`` + ``GET /livez``. Installed
-# AFTER the body-size + body-depth + audio middlewares so it sits
-# OUTERMOST among those three (Starlette stacks user middleware in
-# reverse install order — last install runs first per request). CORS
-# (installed later from ``cli.configure_cors_from_env``) ends up
-# OUTSIDE the fast-path; that's fine — Starlette's CORSMiddleware is a
-# no-op when the request carries no ``Origin`` header (the slice
-# k8s/supervisord/Docker probes are in), so the fast-path still wins
-# the p99 budget for those callers. Browser cross-origin hits with
-# ``Origin`` fall through to the normal stack so CORS attaches its
-# ACAO header.
+# R8-H6: ASGI fast-path for ``GET /healthz`` + ``GET /livez``.
+#
+# Stack ordering note (codex r3 NIT clarification): Starlette stacks
+# user middleware in REVERSE install order — last install runs FIRST
+# per request. The fast-path is installed here (after the body-size +
+# body-depth + audio middlewares), so it sits OUTSIDE those three at
+# request time. ``cli.configure_cors_from_env`` runs LATER (at boot,
+# after this module loads) and ALSO uses ``app.add_middleware``, so
+# CORS lands OUTSIDE the fast-path when it's enabled. That ordering
+# is intentional + acceptable:
+#
+#   * Starlette's CORSMiddleware short-circuits with a single
+#     ``await self.app(scope, receive, send)`` when the request
+#     carries no ``Origin`` header — and k8s / supervisord / Docker /
+#     systemd probes do not send Origin. So for the probe slice that
+#     this fast-path targets, the CORS layer is effectively a
+#     1-microsecond pass-through; the fast-path still answers the
+#     probe without touching the router, dependency graph, or
+#     response serialization.
+#   * Browser cross-origin hits (which DO carry Origin) take the
+#     fall-through path inside the fast-path (``_has_origin`` returns
+#     True), reach CORSMiddleware on the way back out via the inner
+#     app's response, and ship with the correct ACAO header.
+#
+# Among the body-size + body-depth + audio middlewares, the fast-path
+# IS outermost — and those middlewares already early-return for GET
+# requests anyway, so the probe path was never paying for them.
 from .middleware.probe_fastpath import install_probe_fastpath_middleware  # noqa: E402
 
 install_probe_fastpath_middleware(app)


### PR DESCRIPTION
## Why

PR #840 landed with the codex round-3 BLOCKING finding still outstanding because auto-merge raced ahead while the follow-up commit was still queued. Filing the round-3 fix as a follow-up so main converges with codex.

**Codex r3 BLOCKING #1**: `vllm_mlx/middleware/probe_fastpath.py::_has_origin` compared header names to `b"origin"` case-sensitively. The ASGI spec mandates lowercase header names before they reach app code, but not every ASGI server / test harness enforces this — uvicorn does, h11 with a custom scope adapter may not, and TestClient's manual scope construction is operator-dependent. A non-conforming adapter shipping `b"Origin"` would have silently caused the fast-path to 200 a cross-origin browser request, bypassing CORSMiddleware's ACAO.

**Codex r3 NIT**: the install comment in `server.py` claimed the fast-path "sits OUTERMOST," but `cli.configure_cors_from_env` runs LATER (at boot, after this module loads) and ALSO uses `app.add_middleware`, so CORS actually lands OUTSIDE the fast-path under Starlette's reverse-wrapping. The probe slice still wins the p99 budget because CORSMiddleware short-circuits in microseconds when Origin is absent (the slice k8s / supervisord / Docker / systemd probes are in) — but the comment was misleading.

## What changed

- `vllm_mlx/middleware/probe_fastpath.py::_has_origin` — lowercase header name defensively before comparing to `b"origin"`.
- `tests/test_probe_fastpath.py` — new `test_fastpath_origin_check_is_case_insensitive` test that drives `b"origin"`, `b"Origin"`, `b"ORIGIN"`, `b"OrIgIn"` through the middleware via the inner-app recorder shape and asserts each casing triggers CORS fall-through.
- `vllm_mlx/server.py` — correct the install comment to accurately describe the actual middleware stack ordering (CORS outermost when enabled, fast-path inside) and explain why the p99 win is preserved despite that.

## Test plan

- [x] `pytest tests/test_probe_fastpath.py` — 17 tests pass (16 pre-existing from PR #840 + 1 new case-insensitive Origin test).
- [x] `pytest tests/test_prefix_cache_persistence.py` — 51 tests pass.
- [x] `ruff check` + `ruff format --check` clean on all touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)