### PR TITLE
[codex] Harden stress validation attribution

### DIFF
--- a/scripts/pr_validate/runner.py
+++ b/scripts/pr_validate/runner.py
@@ -9,8 +9,11 @@ a step: write the module under ``steps/``, import it here, append to
 
 from __future__ import annotations
 
+import os
 import sys
+import time
 from collections.abc import Sequence
+from datetime import UTC, datetime
 
 from .base import Step
 from .context import Context
@@ -83,7 +86,13 @@ def run_pipeline(
         pipeline = [s for s in pipeline if s.name not in dropped]
 
     ctx = Context(pr_number=pr_number, verbose=verbose)
-    ctx.work_dir = ctx.work_dir / f"pr-{pr_number}"
+    run_id = (
+        f"run-{datetime.now(UTC).strftime('%Y%m%dT%H%M%SZ')}-"
+        f"{os.getpid()}-{time.time_ns()}"
+    )
+    # Use a unique run directory instead of reusing / deleting pr-<n>.
+    # Reuse leaves stale failure logs; deletion can corrupt a concurrent run.
+    ctx.work_dir = ctx.work_dir / f"pr-{pr_number}" / run_id
     ctx.work_dir.mkdir(parents=True, exist_ok=True)
 
     print(f"# PR #{pr_number} validation", file=sys.stderr)

--- a/scripts/pr_validate/steps/stress_e2e_bench.py
+++ b/scripts/pr_validate/steps/stress_e2e_bench.py
@@ -32,6 +32,7 @@ import re
 import shutil
 import socket
 import subprocess
+import tempfile
 import time
 from contextlib import contextmanager
 from dataclasses import dataclass
@@ -146,21 +147,32 @@ class StressE2EBenchStep(Step):
 
         all_findings: list[str] = []
         all_artifacts: list[str] = []
+        manifest: list[dict[str, Any]] = []
         any_fail = False
+        preexisting_count = 0
 
         for choice in choices:
             ctx.run_log(f"--- {choice.family} ({choice.model_id}) ---")
+            pending_failures: list[
+                tuple[str, dict[str, Any], dict[str, Any] | None]
+            ] = []
             try:
                 with _server(choice, ctx) as server_log:
                     all_artifacts.append(server_log)
                     # Stress.
-                    stress_result = _run_stress(ctx, choice)
-                    if stress_result["status"] != "pass":
-                        any_fail = True
-                        all_findings.append(
-                            f"[BLOCKING] stress on {choice.model_id}: "
-                            + stress_result["summary"]
-                        )
+                    stress_result = _capture_runner(
+                        "stress", lambda choice=choice: _run_stress(ctx, choice)
+                    )
+                    _record_manifest(
+                        manifest,
+                        kind="stress",
+                        choice=choice,
+                        status=stress_result["status"],
+                        summary=stress_result["summary"],
+                        artifact=stress_result.get("artifact"),
+                    )
+                    if _is_blocking_status(stress_result["status"]):
+                        pending_failures.append(("stress", stress_result, None))
                     if stress_result.get("artifact"):
                         all_artifacts.append(stress_result["artifact"])
 
@@ -170,22 +182,58 @@ class StressE2EBenchStep(Step):
                         if choice.quality_tier == "smoke" and agent.get(
                             "skip_for_smoke"
                         ):
+                            _record_manifest(
+                                manifest,
+                                kind="agent",
+                                choice=choice,
+                                status="skip",
+                                agent=agent["name"],
+                                summary="skipped for smoke-tier candidate",
+                            )
                             continue
                         if choice.model_id in skip_for_models:
-                            continue
-                        ag_result = _run_agent(ctx, choice, agent)
-                        if ag_result["status"] != "pass":
-                            any_fail = True
-                            all_findings.append(
-                                f"[BLOCKING] {agent['name']} on "
-                                f"{choice.model_id}: " + ag_result["summary"]
+                            _record_manifest(
+                                manifest,
+                                kind="agent",
+                                choice=choice,
+                                status="skip",
+                                agent=agent["name"],
+                                summary="skipped for this model",
                             )
+                            continue
+                        ag_result = _capture_runner(
+                            agent["name"],
+                            lambda choice=choice, agent=agent: _run_agent(
+                                ctx, choice, agent
+                            ),
+                        )
+                        _record_manifest(
+                            manifest,
+                            kind="agent",
+                            choice=choice,
+                            status=ag_result["status"],
+                            agent=agent["name"],
+                            summary=ag_result["summary"],
+                            artifact=ag_result.get("artifact"),
+                        )
+                        if _is_blocking_status(ag_result["status"]):
+                            pending_failures.append(("agent", ag_result, agent))
                         if ag_result.get("artifact"):
                             all_artifacts.append(ag_result["artifact"])
 
                     # Bench.
-                    bench_result = _run_bench(ctx, choice)
-                    if bench_result["status"] != "pass":
+                    bench_result = _capture_runner(
+                        "bench", lambda choice=choice: _run_bench(ctx, choice)
+                    )
+                    _record_manifest(
+                        manifest,
+                        kind="bench",
+                        choice=choice,
+                        status=bench_result["status"],
+                        summary=bench_result["summary"],
+                        artifact=bench_result.get("artifact"),
+                    )
+                    if _is_blocking_status(bench_result["status"]):
                         any_fail = True
                         all_findings.append(
                             f"[BLOCKING] bench on {choice.model_id}: "
@@ -196,15 +244,61 @@ class StressE2EBenchStep(Step):
 
             except _ServerStartError as e:
                 any_fail = True
+                _record_manifest(
+                    manifest,
+                    kind="server",
+                    choice=choice,
+                    status="fail",
+                    summary=str(e),
+                )
                 all_findings.append(
                     f"[BLOCKING] could not boot server with {choice.model_id}: {e}"
                 )
                 continue
 
+            for kind, pr_result, agent in pending_failures:
+                base_result = _run_base_check(ctx, choice, kind, agent)
+                _record_manifest(
+                    manifest,
+                    kind=kind,
+                    choice=choice,
+                    status=base_result["status"],
+                    agent=agent["name"] if agent else None,
+                    summary=base_result["summary"],
+                    artifact=base_result.get("artifact"),
+                    lane="base",
+                )
+                if base_result.get("artifact"):
+                    all_artifacts.append(base_result["artifact"])
+                if base_result.get("server_artifact"):
+                    all_artifacts.append(base_result["server_artifact"])
+
+                label = _failure_label(kind, agent)
+                if base_result["status"] == "fail" and base_result.get("executed"):
+                    preexisting_count += 1
+                    all_findings.append(
+                        f"[PRE-EXISTING] {label} on {choice.model_id}: "
+                        f"PR={pr_result['summary']}; base={base_result['summary']}"
+                    )
+                else:
+                    any_fail = True
+                    all_findings.append(
+                        f"[BLOCKING] {label} on {choice.model_id}: "
+                        f"{pr_result['summary']} "
+                        f"(base {base_result['status']}: {base_result['summary']})"
+                    )
+
+        manifest_path = ctx.artifact_path("stress-e2e-manifest.json")
+        manifest_path.write_text(json.dumps(manifest, indent=2))
+        all_artifacts.append(str(manifest_path))
+
         status = "fail" if any_fail else "pass"
+        verdict_text = "see findings" if any_fail else "PASSED"
+        if preexisting_count and not any_fail:
+            verdict_text = f"PASSED ({preexisting_count} pre-existing noted)"
         summary = (
             f"matrix {len(choices)}×{len([a for a in registry['agents']])}, "
-            f"{'PASSED' if not any_fail else 'see findings'}"
+            f"{verdict_text}"
         )
         return StepResult(
             name=self.name,
@@ -330,6 +424,19 @@ class _ServerStartError(RuntimeError):
 
 @contextmanager
 def _server(choice: ModelChoice, ctx: Context):
+    with _server_in_repo(choice, ctx, repo_root=ctx.repo_root) as server_log:
+        yield server_log
+
+
+@contextmanager
+def _server_in_repo(
+    choice: ModelChoice,
+    ctx: Context,
+    *,
+    repo_root: Path,
+    artifact_prefix: str = "",
+    isolate_pythonpath: bool = False,
+):
     """Start a rapid-mlx server with `choice.model_id` on BENCH_PORT.
     Yield the path to its log file. Stop on context exit. Refuses to
     proceed if BENCH_PORT is already bound."""
@@ -338,7 +445,9 @@ def _server(choice: ModelChoice, ctx: Context):
             f"port {BENCH_PORT} already in use — refusing to clobber"
         )
 
-    log_path = ctx.artifact_path(f"server-{_safe_name(choice.model_id)}.log")
+    log_path = ctx.artifact_path(
+        f"{artifact_prefix}server-{_safe_name(choice.model_id)}.log"
+    )
     cmd = [
         "python3.12",
         "-m",
@@ -356,7 +465,11 @@ def _server(choice: ModelChoice, ctx: Context):
     try:
         log_f = open(log_path, "w")  # noqa: SIM115 — explicit close in finally
         proc = subprocess.Popen(  # noqa: S603
-            cmd, stdout=log_f, stderr=subprocess.STDOUT, cwd=str(ctx.repo_root)
+            cmd,
+            stdout=log_f,
+            stderr=subprocess.STDOUT,
+            cwd=str(repo_root),
+            env=_repo_python_env(repo_root, isolate_existing=isolate_pythonpath),
         )
         if not _wait_for_server(BENCH_PORT, SERVER_BOOT_TIMEOUT_S):
             raise _ServerStartError(
@@ -481,13 +594,24 @@ def _effective_stress_timeout(choice: ModelChoice) -> int:
     return choice.stress_timeout_s or DEFAULT_STRESS_TIMEOUT_S
 
 
-def _run_stress(ctx: Context, choice: ModelChoice) -> dict[str, Any]:
-    log = ctx.artifact_path(f"stress-{_safe_name(choice.model_id)}.log")
+def _run_stress(
+    ctx: Context,
+    choice: ModelChoice,
+    *,
+    repo_root: Path | None = None,
+    artifact_prefix: str = "",
+    isolate_pythonpath: bool = False,
+) -> dict[str, Any]:
+    run_root = repo_root or ctx.repo_root
+    log = ctx.artifact_path(
+        f"{artifact_prefix}stress-{_safe_name(choice.model_id)}.log"
+    )
     proc = subprocess.run(  # noqa: S603
         ["python3.12", "scripts/stress_test.py", "--port", str(BENCH_PORT)],
         capture_output=True,
         text=True,
-        cwd=str(ctx.repo_root),
+        cwd=str(run_root),
+        env=_repo_python_env(run_root, isolate_existing=isolate_pythonpath),
         timeout=_effective_stress_timeout(choice),
     )
     log.write_text((proc.stdout or "") + (proc.stderr or ""))
@@ -496,19 +620,33 @@ def _run_stress(ctx: Context, choice: ModelChoice) -> dict[str, Any]:
         "status": "pass" if proc.returncode == 0 else "fail",
         "summary": summary or f"exit {proc.returncode}",
         "artifact": str(log),
+        "executed": True,
     }
 
 
 def _run_agent(
-    ctx: Context, choice: ModelChoice, agent: dict[str, Any]
+    ctx: Context,
+    choice: ModelChoice,
+    agent: dict[str, Any],
+    *,
+    repo_root: Path | None = None,
+    artifact_prefix: str = "",
+    isolate_pythonpath: bool = False,
 ) -> dict[str, Any]:
-    log = ctx.artifact_path(f"agent-{agent['name']}-{_safe_name(choice.model_id)}.log")
-    script = ctx.repo_root / agent["script"]
+    log = ctx.artifact_path(
+        f"{artifact_prefix}agent-{agent['name']}-{_safe_name(choice.model_id)}.log"
+    )
+    run_root = repo_root or ctx.repo_root
+    script = run_root / agent["script"]
     if not script.exists():
-        return {"status": "skip", "summary": f"script missing: {agent['script']}"}
+        return {
+            "status": "skip",
+            "summary": f"script missing: {agent['script']}",
+            "executed": False,
+        }
 
     env = {
-        **os.environ,
+        **_repo_python_env(run_root, isolate_existing=isolate_pythonpath),
         "RAPID_MLX_BASE_URL": f"http://127.0.0.1:{BENCH_PORT}/v1",
     }
     # 1800s (30 min) per agent script. 1200s used to be enough for
@@ -527,7 +665,7 @@ def _run_agent(
         capture_output=True,
         text=True,
         env=env,
-        cwd=str(ctx.repo_root),
+        cwd=str(run_root),
         timeout=1800,
     )
     log.write_text((proc.stdout or "") + (proc.stderr or ""))
@@ -536,7 +674,191 @@ def _run_agent(
         "status": "pass" if proc.returncode == 0 else "fail",
         "summary": summary or f"exit {proc.returncode}",
         "artifact": str(log),
+        "executed": True,
     }
+
+
+def _run_base_check(
+    ctx: Context,
+    choice: ModelChoice,
+    kind: str,
+    agent: dict[str, Any] | None,
+) -> dict[str, Any]:
+    """Re-run a failing stress/agent case on the PR base ref."""
+    base_ref = ctx.base_sha or ctx.base_branch
+    if not base_ref:
+        return {
+            "status": "error",
+            "summary": "base check failed: base ref unavailable",
+            "server_artifact": None,
+            "executed": False,
+        }
+    tmp = Path(tempfile.mkdtemp(prefix="pr_validate_stress_base_"))
+    tmp.rmdir()
+    server_artifact: str | None = None
+    try:
+        subprocess.run(  # noqa: S603
+            ["git", "worktree", "add", "--detach", str(tmp), base_ref],
+            cwd=str(ctx.repo_root),
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=120,
+        )
+        label = _artifact_label(kind, agent)
+        with _server_in_repo(
+            choice,
+            ctx,
+            repo_root=tmp,
+            artifact_prefix=f"base-{label}-",
+            isolate_pythonpath=True,
+        ) as server_log:
+            server_artifact = server_log
+            if kind == "stress":
+                result = _run_stress(
+                    ctx,
+                    choice,
+                    repo_root=tmp,
+                    artifact_prefix=f"base-{label}-",
+                    isolate_pythonpath=True,
+                )
+            elif kind == "agent" and agent is not None:
+                result = _run_agent(
+                    ctx,
+                    choice,
+                    agent,
+                    repo_root=tmp,
+                    artifact_prefix="base-",
+                    isolate_pythonpath=True,
+                )
+            else:
+                result = {
+                    "status": "error",
+                    "summary": f"unknown base check {kind}",
+                    "executed": False,
+                }
+            result["server_artifact"] = server_artifact
+            return result
+    except subprocess.CalledProcessError as e:
+        details = _tail_text((e.stderr or "") + (e.stdout or ""))
+        return {
+            "status": "error",
+            "summary": (
+                f"base check failed: git worktree add exited {e.returncode}"
+                + (f": {details}" if details else "")
+            ),
+            "server_artifact": server_artifact,
+            "executed": False,
+        }
+    except Exception as e:  # noqa: BLE001
+        return {
+            "status": "error",
+            "summary": f"base check failed: {type(e).__name__}: {e}",
+            "server_artifact": server_artifact,
+            "executed": False,
+        }
+    finally:
+        try:
+            remove = subprocess.run(  # noqa: S603
+                ["git", "worktree", "remove", "--force", str(tmp)],
+                cwd=str(ctx.repo_root),
+                capture_output=True,
+                text=True,
+                timeout=120,
+            )
+            if remove.returncode != 0:
+                subprocess.run(  # noqa: S603
+                    ["git", "worktree", "prune"],
+                    cwd=str(ctx.repo_root),
+                    capture_output=True,
+                    text=True,
+                    timeout=120,
+                )
+        except Exception:
+            try:
+                subprocess.run(  # noqa: S603
+                    ["git", "worktree", "prune"],
+                    cwd=str(ctx.repo_root),
+                    capture_output=True,
+                    text=True,
+                    timeout=120,
+                )
+            except Exception:
+                pass
+        shutil.rmtree(tmp, ignore_errors=True)
+
+
+def _record_manifest(
+    manifest: list[dict[str, Any]],
+    *,
+    kind: str,
+    choice: ModelChoice,
+    status: str,
+    summary: str,
+    agent: str | None = None,
+    artifact: str | None = None,
+    lane: str = "pr",
+) -> None:
+    item: dict[str, Any] = {
+        "lane": lane,
+        "kind": kind,
+        "family": choice.family,
+        "model": choice.model_id,
+        "status": status,
+        "summary": summary,
+    }
+    if agent:
+        item["agent"] = agent
+    if artifact:
+        item["artifact"] = artifact
+    manifest.append(item)
+
+
+def _failure_label(kind: str, agent: dict[str, Any] | None) -> str:
+    if kind == "agent" and agent is not None:
+        return str(agent["name"])
+    return kind
+
+
+def _artifact_label(kind: str, agent: dict[str, Any] | None) -> str:
+    return _safe_name(_failure_label(kind, agent))
+
+
+def _is_blocking_status(status: str) -> bool:
+    return status not in {"pass", "skip"}
+
+
+def _capture_runner(label: str, fn) -> dict[str, Any]:  # type: ignore[no-untyped-def]
+    try:
+        return fn()
+    except Exception as e:  # noqa: BLE001
+        return {
+            "status": "error",
+            "summary": f"{label} crashed: {type(e).__name__}: {e}",
+            "executed": False,
+        }
+
+
+def _tail_text(text: str, *, limit: int = 300) -> str:
+    normalized = " ".join(text.strip().split())
+    if len(normalized) <= limit:
+        return normalized
+    tail = normalized[-limit:]
+    if " " in tail:
+        tail = tail.split(" ", 1)[1]
+    return f"... {tail}"
+
+
+def _repo_python_env(
+    repo_root: Path, *, isolate_existing: bool = False
+) -> dict[str, str]:
+    env = dict(os.environ)
+    current = env.get("PYTHONPATH")
+    if isolate_existing or not current:
+        env["PYTHONPATH"] = str(repo_root)
+    else:
+        env["PYTHONPATH"] = str(repo_root) + os.pathsep + current
+    return env
 
 
 def _run_bench(ctx: Context, choice: ModelChoice) -> dict[str, Any]:
@@ -622,6 +944,7 @@ def _run_bench(ctx: Context, choice: ModelChoice) -> dict[str, Any]:
                 f"— no baseline, recorded for next run"
             ),
             "artifact": str(bench_path),
+            "executed": True,
         }
 
     baseline = json.loads(baseline_path.read_text())
@@ -649,6 +972,7 @@ def _run_bench(ctx: Context, choice: ModelChoice) -> dict[str, Any]:
                 f"vs baseline (threshold {BENCH_THRESHOLD_PCT}%)"
             ),
             "artifact": str(bench_path),
+            "executed": True,
         }
     return {
         "status": "pass",
@@ -657,6 +981,7 @@ def _run_bench(ctx: Context, choice: ModelChoice) -> dict[str, Any]:
             f"vs baseline (within {BENCH_THRESHOLD_PCT}%)"
         ),
         "artifact": str(bench_path),
+        "executed": True,
     }
 
 

--- a/tests/integrations/test_langchain.py
+++ b/tests/integrations/test_langchain.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+from collections.abc import Mapping
 
 import httpx as _httpx
 from langchain_core.messages import HumanMessage, SystemMessage
@@ -31,6 +32,27 @@ llm = ChatOpenAI(
 # load path with an empty mapping and the gate reporting "No test results
 # found (missing 'results' dict or all tests skipped)".
 results: dict[str, str] = {}
+
+
+def _is_guided_extra_required_error(exc: BaseException) -> bool:
+    """Return true for rapid-mlx's structured-output capability error."""
+    response = getattr(exc, "response", None)
+    if response is None:
+        return False
+    try:
+        payload = response.json()
+    except Exception:
+        return False
+    if not isinstance(payload, Mapping):
+        return False
+    error = payload.get("error")
+    if not isinstance(error, Mapping):
+        return False
+    return error.get("code") == "guided_extra_required"
+
+
+def _is_ok_result(value: str) -> bool:
+    return value == "PASS" or value == "SKIP: rapid-mlx[guided] not installed"
 
 
 def _run_tests() -> None:
@@ -156,13 +178,22 @@ def _run_tests() -> None:
         print(f"PASS: {r}")
         results["6_structured"] = "PASS"
     except Exception as e:
-        print(f"FAIL: {e}")
-        results["6_structured"] = f"FAIL: {str(e)[:120]}"
+        if _is_guided_extra_required_error(e):
+            message = "SKIP: rapid-mlx[guided] not installed"
+            print(message)
+            results["6_structured"] = message
+        else:
+            print(f"FAIL: {e}")
+            results["6_structured"] = f"FAIL: {str(e)[:120]}"
 
     # === Summary ===
     print("\n" + "=" * 50)
     passed = sum(1 for v in results.values() if v == "PASS")
-    print(f"LangChain: {passed}/{len(results)} passed")
+    skipped = sum(1 for v in results.values() if v.startswith("SKIP:"))
+    if skipped:
+        print(f"LangChain: {passed}/{len(results)} passed, {skipped} skipped")
+    else:
+        print(f"LangChain: {passed}/{len(results)} passed")
     for k, v in results.items():
         print(f"  {k}: {v[:120]}")
 
@@ -178,5 +209,4 @@ _UNDER_PYTEST = "_pytest" in sys.modules or "PYTEST_CURRENT_TEST" in os.environ
 if not _UNDER_PYTEST:
     _run_tests()
     if __name__ == "__main__":
-        _passed = sum(1 for v in results.values() if v == "PASS")
-        exit(0 if _passed == len(results) else 1)
+        exit(0 if all(_is_ok_result(v) for v in results.values()) else 1)

--- a/tests/test_pr_validate_runner.py
+++ b/tests/test_pr_validate_runner.py
@@ -16,11 +16,14 @@ data over the network and is not unit-testable here.
 
 from __future__ import annotations
 
+import subprocess
+from contextlib import contextmanager
 from pathlib import Path
 
 import pytest
 
 from scripts.pr_validate.base import Step, StepResult
+from scripts.pr_validate.context import Context
 from scripts.pr_validate.runner import run_pipeline
 from scripts.pr_validate.steps.fetch import FetchStep
 
@@ -190,6 +193,32 @@ class TestFailFast:
         assert rc == 0
         assert "## [step_a]" in captured.err
         assert "## [step_b]" in captured.err
+
+    def test_run_pipeline_uses_unique_artifact_dir(
+        self, repo_root_cwd, tmp_path, monkeypatch, capsys
+    ):
+        """Repeated runs for the same PR must not read old failure logs."""
+        from scripts.pr_validate import runner as runner_mod
+
+        work_root = tmp_path / "pr_validate"
+        stale_dir = work_root / "pr-999"
+        stale_dir.mkdir(parents=True, exist_ok=True)
+        stale_file = stale_dir / "agent-old-failure.log"
+        stale_file.write_text("FAIL: stale previous run\n")
+
+        def fake_context(*args, **kwargs):
+            ctx = Context(*args, **kwargs)
+            ctx.work_dir = work_root
+            return ctx
+
+        monkeypatch.setattr(runner_mod, "Context", fake_context)
+
+        rc = run_pipeline(pr_number=999, steps=_fake_pipeline([("step_a", "pass")]))
+        captured = capsys.readouterr()
+
+        assert rc == 0
+        assert stale_file.exists()
+        assert f"artifacts → {work_root}/pr-999/run-" in captured.err
 
     def test_skip_steps_can_drop_fetch_but_pipeline_still_runs(
         self, repo_root_cwd, capsys
@@ -452,3 +481,460 @@ class TestSelectModels:
 
         assert model_id in agents["anthropic_sdk"].get("skip_for_models", [])
         assert model_id in agents["langchain"].get("skip_for_models", [])
+
+
+class TestStressPreexistingClassification:
+    @staticmethod
+    def _ctx(tmp_path: Path, monkeypatch) -> Context:
+        (tmp_path / "pyproject.toml").write_text("[project]\nname = 'fake'\n")
+        monkeypatch.chdir(tmp_path)
+        ctx = Context(pr_number=123)
+        ctx.work_dir = tmp_path / "artifacts"
+        ctx.work_dir.mkdir()
+        ctx.base_sha = "base-sha"
+        return ctx
+
+    @staticmethod
+    def _registry() -> dict:
+        return {
+            "families": [
+                {
+                    "family": "toy",
+                    "candidates": [
+                        {
+                            "id": "toy/model",
+                            "ram_gb_required": 1,
+                            "quality_tier": "golden",
+                        }
+                    ],
+                }
+            ],
+            "agents": [],
+        }
+
+    @staticmethod
+    @contextmanager
+    def _fake_server(choice, ctx):  # type: ignore[no-untyped-def]
+        yield str(ctx.artifact_path(f"server-{choice.model_id.replace('/', '--')}.log"))
+
+    def test_pr_stress_failure_is_nonblocking_when_base_also_fails(
+        self, tmp_path, monkeypatch
+    ):
+        from scripts.pr_validate.steps import stress_e2e_bench as step_mod
+
+        monkeypatch.setattr(step_mod, "_load_registry", self._registry)
+        monkeypatch.setattr(step_mod, "_available_ram_gb", lambda: 64.0)
+        monkeypatch.setattr(step_mod, "_server", self._fake_server)
+        monkeypatch.setattr(
+            step_mod,
+            "_run_stress",
+            lambda _ctx, _choice: {
+                "status": "fail",
+                "summary": "7/8 passed",
+                "artifact": "stress.log",
+            },
+        )
+        monkeypatch.setattr(
+            step_mod,
+            "_run_base_check",
+            lambda _ctx, _choice, _kind, _agent: {
+                "status": "fail",
+                "summary": "7/8 passed on base",
+                "artifact": "base-stress.log",
+                "executed": True,
+            },
+        )
+        monkeypatch.setattr(
+            step_mod,
+            "_run_bench",
+            lambda _ctx, _choice: {
+                "status": "pass",
+                "summary": "bench ok",
+                "artifact": "bench.json",
+            },
+        )
+
+        result = step_mod.StressE2EBenchStep().run(self._ctx(tmp_path, monkeypatch))
+
+        assert result.status == "pass"
+        assert "pre-existing" in result.summary
+        assert any("[PRE-EXISTING] stress on toy/model" in f for f in result.findings)
+        assert not any("[BLOCKING] stress on toy/model" in f for f in result.findings)
+
+    def test_pr_stress_failure_blocks_when_base_passes(self, tmp_path, monkeypatch):
+        from scripts.pr_validate.steps import stress_e2e_bench as step_mod
+
+        monkeypatch.setattr(step_mod, "_load_registry", self._registry)
+        monkeypatch.setattr(step_mod, "_available_ram_gb", lambda: 64.0)
+        monkeypatch.setattr(step_mod, "_server", self._fake_server)
+        monkeypatch.setattr(
+            step_mod,
+            "_run_stress",
+            lambda _ctx, _choice: {
+                "status": "fail",
+                "summary": "7/8 passed",
+                "artifact": "stress.log",
+            },
+        )
+        monkeypatch.setattr(
+            step_mod,
+            "_run_base_check",
+            lambda _ctx, _choice, _kind, _agent: {
+                "status": "pass",
+                "summary": "8/8 passed on base",
+                "artifact": "base-stress.log",
+                "executed": True,
+            },
+        )
+        monkeypatch.setattr(
+            step_mod,
+            "_run_bench",
+            lambda _ctx, _choice: {
+                "status": "pass",
+                "summary": "bench ok",
+                "artifact": "bench.json",
+            },
+        )
+
+        result = step_mod.StressE2EBenchStep().run(self._ctx(tmp_path, monkeypatch))
+
+        assert result.status == "fail"
+        assert any("[BLOCKING] stress on toy/model" in f for f in result.findings)
+
+    def test_base_skip_is_inconclusive_and_blocks(self, tmp_path, monkeypatch):
+        from scripts.pr_validate.steps import stress_e2e_bench as step_mod
+
+        monkeypatch.setattr(step_mod, "_load_registry", self._registry)
+        monkeypatch.setattr(step_mod, "_available_ram_gb", lambda: 64.0)
+        monkeypatch.setattr(step_mod, "_server", self._fake_server)
+        monkeypatch.setattr(
+            step_mod,
+            "_run_stress",
+            lambda _ctx, _choice: {
+                "status": "fail",
+                "summary": "7/8 passed",
+                "artifact": "stress.log",
+                "executed": True,
+            },
+        )
+        monkeypatch.setattr(
+            step_mod,
+            "_run_base_check",
+            lambda _ctx, _choice, _kind, _agent: {
+                "status": "skip",
+                "summary": "script missing",
+                "executed": False,
+            },
+        )
+        monkeypatch.setattr(
+            step_mod,
+            "_run_bench",
+            lambda _ctx, _choice: {
+                "status": "pass",
+                "summary": "bench ok",
+                "artifact": "bench.json",
+                "executed": True,
+            },
+        )
+
+        result = step_mod.StressE2EBenchStep().run(self._ctx(tmp_path, monkeypatch))
+
+        assert result.status == "fail"
+        assert any("base skip: script missing" in f for f in result.findings)
+
+    def test_collected_failures_are_attributed_when_bench_crashes(
+        self, tmp_path, monkeypatch
+    ):
+        from scripts.pr_validate.steps import stress_e2e_bench as step_mod
+
+        monkeypatch.setattr(step_mod, "_load_registry", self._registry)
+        monkeypatch.setattr(step_mod, "_available_ram_gb", lambda: 64.0)
+        monkeypatch.setattr(step_mod, "_server", self._fake_server)
+        monkeypatch.setattr(
+            step_mod,
+            "_run_stress",
+            lambda _ctx, _choice: {
+                "status": "fail",
+                "summary": "7/8 passed",
+                "artifact": "stress.log",
+                "executed": True,
+            },
+        )
+        monkeypatch.setattr(
+            step_mod,
+            "_run_base_check",
+            lambda _ctx, _choice, _kind, _agent: {
+                "status": "fail",
+                "summary": "7/8 passed on base",
+                "artifact": "base-stress.log",
+                "executed": True,
+            },
+        )
+
+        def crashing_bench(_ctx, _choice):
+            raise RuntimeError("boom")
+
+        monkeypatch.setattr(step_mod, "_run_bench", crashing_bench)
+
+        result = step_mod.StressE2EBenchStep().run(self._ctx(tmp_path, monkeypatch))
+
+        assert result.status == "fail"
+        assert any("[PRE-EXISTING] stress on toy/model" in f for f in result.findings)
+        assert any("[BLOCKING] bench on toy/model" in f for f in result.findings)
+
+    def test_agent_skip_is_not_sent_to_base_check(self, tmp_path, monkeypatch):
+        from scripts.pr_validate.steps import stress_e2e_bench as step_mod
+
+        registry = self._registry()
+        registry["agents"] = [{"name": "missing", "script": "missing.py"}]
+
+        def fail_if_called(*_args, **_kwargs):
+            raise AssertionError("skip must not trigger base check")
+
+        monkeypatch.setattr(step_mod, "_load_registry", lambda: registry)
+        monkeypatch.setattr(step_mod, "_available_ram_gb", lambda: 64.0)
+        monkeypatch.setattr(step_mod, "_server", self._fake_server)
+        monkeypatch.setattr(
+            step_mod,
+            "_run_stress",
+            lambda _ctx, _choice: {
+                "status": "pass",
+                "summary": "8/8 passed",
+                "artifact": "stress.log",
+            },
+        )
+        monkeypatch.setattr(step_mod, "_run_base_check", fail_if_called)
+        monkeypatch.setattr(
+            step_mod,
+            "_run_bench",
+            lambda _ctx, _choice: {
+                "status": "pass",
+                "summary": "bench ok",
+                "artifact": "bench.json",
+            },
+        )
+
+        result = step_mod.StressE2EBenchStep().run(self._ctx(tmp_path, monkeypatch))
+
+        assert result.status == "pass"
+
+    def test_run_base_check_uses_base_worktree_cwd_and_pythonpath(
+        self, tmp_path, monkeypatch
+    ):
+        from scripts.pr_validate.steps import stress_e2e_bench as step_mod
+
+        ctx = self._ctx(tmp_path, monkeypatch)
+        choice = step_mod.ModelChoice(
+            family="toy",
+            model_id="toy/model",
+            ram_gb_required=1,
+            quality_tier="golden",
+            extra_args=[],
+        )
+        subprocess_calls = []
+        captured = {}
+
+        def fake_run(cmd, **kwargs):
+            subprocess_calls.append((cmd, kwargs))
+            if cmd[:3] == ["git", "worktree", "add"]:
+                assert not Path(cmd[4]).exists()
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+        @contextmanager
+        def fake_server(
+            _choice, _ctx, *, repo_root, artifact_prefix="", isolate_pythonpath=False
+        ):
+            captured["server_repo_root"] = repo_root
+            captured["server_prefix"] = artifact_prefix
+            captured["server_isolated"] = isolate_pythonpath
+            yield "base-server.log"
+
+        def fake_stress(
+            _ctx,
+            _choice,
+            *,
+            repo_root=None,
+            artifact_prefix="",
+            isolate_pythonpath=False,
+        ):
+            captured["stress_repo_root"] = repo_root
+            captured["stress_prefix"] = artifact_prefix
+            captured["stress_isolated"] = isolate_pythonpath
+            return {"status": "pass", "summary": "8/8 passed", "artifact": "base.log"}
+
+        monkeypatch.setattr(step_mod.subprocess, "run", fake_run)
+        monkeypatch.setattr(step_mod, "_server_in_repo", fake_server)
+        monkeypatch.setattr(step_mod, "_run_stress", fake_stress)
+
+        result = step_mod._run_base_check(ctx, choice, "stress", None)
+
+        assert result["status"] == "pass"
+        assert subprocess_calls[0][0][:3] == ["git", "worktree", "add"]
+        assert subprocess_calls[0][1]["cwd"] == str(ctx.repo_root)
+        assert captured["server_repo_root"] == captured["stress_repo_root"]
+        assert captured["server_repo_root"].name.startswith("pr_validate_stress_base_")
+        assert captured["server_prefix"] == "base-stress-"
+        assert captured["stress_prefix"] == "base-stress-"
+        assert captured["server_isolated"] is True
+        assert captured["stress_isolated"] is True
+
+    def test_run_base_check_without_base_ref_is_inconclusive(
+        self, tmp_path, monkeypatch
+    ):
+        from scripts.pr_validate.steps import stress_e2e_bench as step_mod
+
+        ctx = self._ctx(tmp_path, monkeypatch)
+        ctx.base_sha = None
+        ctx.base_branch = None
+
+        def fail_if_called(*_args, **_kwargs):
+            raise AssertionError("missing base ref must not create a worktree")
+
+        monkeypatch.setattr(step_mod.subprocess, "run", fail_if_called)
+
+        choice = step_mod.ModelChoice(
+            family="toy",
+            model_id="toy/model",
+            ram_gb_required=1,
+            quality_tier="golden",
+            extra_args=[],
+        )
+        result = step_mod._run_base_check(ctx, choice, "stress", None)
+
+        assert result["status"] == "error"
+        assert result["summary"] == "base check failed: base ref unavailable"
+        assert result["executed"] is False
+
+    def test_run_base_check_prunes_if_worktree_remove_fails(
+        self, tmp_path, monkeypatch
+    ):
+        from scripts.pr_validate.steps import stress_e2e_bench as step_mod
+
+        ctx = self._ctx(tmp_path, monkeypatch)
+        choice = step_mod.ModelChoice(
+            family="toy",
+            model_id="toy/model",
+            ram_gb_required=1,
+            quality_tier="golden",
+            extra_args=[],
+        )
+        commands = []
+
+        def fake_run(cmd, **kwargs):
+            commands.append(cmd)
+            if cmd[:3] == ["git", "worktree", "remove"]:
+                return subprocess.CompletedProcess(cmd, 1, stdout="", stderr="stale")
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+        @contextmanager
+        def fake_server(*_args, **_kwargs):
+            yield "base-server.log"
+
+        monkeypatch.setattr(step_mod.subprocess, "run", fake_run)
+        monkeypatch.setattr(step_mod, "_server_in_repo", fake_server)
+        monkeypatch.setattr(
+            step_mod,
+            "_run_stress",
+            lambda *_args, **_kwargs: {
+                "status": "pass",
+                "summary": "8/8 passed",
+                "artifact": "base.log",
+                "executed": True,
+            },
+        )
+
+        result = step_mod._run_base_check(ctx, choice, "stress", None)
+
+        assert result["status"] == "pass"
+        assert ["git", "worktree", "prune"] in commands
+
+    def test_repo_python_env_prefers_supplied_worktree(self, tmp_path, monkeypatch):
+        from scripts.pr_validate.steps import stress_e2e_bench as step_mod
+
+        monkeypatch.setenv("PYTHONPATH", "/existing/path")
+
+        env = step_mod._repo_python_env(tmp_path)
+
+        assert env["PYTHONPATH"].split(":")[:2] == [str(tmp_path), "/existing/path"]
+
+    def test_repo_python_env_can_isolate_existing_pythonpath(
+        self, tmp_path, monkeypatch
+    ):
+        from scripts.pr_validate.steps import stress_e2e_bench as step_mod
+
+        monkeypatch.setenv("PYTHONPATH", "/pr/checkout:/dependency/path")
+
+        env = step_mod._repo_python_env(tmp_path, isolate_existing=True)
+
+        assert env["PYTHONPATH"] == str(tmp_path)
+
+    def test_run_stress_uses_isolated_pythonpath_for_base_worktree(
+        self, tmp_path, monkeypatch
+    ):
+        from scripts.pr_validate.steps import stress_e2e_bench as step_mod
+
+        ctx = self._ctx(tmp_path, monkeypatch)
+        base_tree = tmp_path / "base-tree"
+        base_tree.mkdir()
+        captured = {}
+
+        def fake_run(cmd, **kwargs):
+            captured["cmd"] = cmd
+            captured["cwd"] = kwargs["cwd"]
+            captured["pythonpath"] = kwargs["env"]["PYTHONPATH"]
+            return subprocess.CompletedProcess(cmd, 0, stdout="8/8 passed\n", stderr="")
+
+        monkeypatch.setenv("PYTHONPATH", "/pr/checkout:/dependency/path")
+        monkeypatch.setattr(step_mod.subprocess, "run", fake_run)
+
+        choice = step_mod.ModelChoice(
+            family="toy",
+            model_id="toy/model",
+            ram_gb_required=1,
+            quality_tier="golden",
+            extra_args=[],
+        )
+        result = step_mod._run_stress(
+            ctx,
+            choice,
+            repo_root=base_tree,
+            isolate_pythonpath=True,
+        )
+
+        assert result["status"] == "pass"
+        assert captured["cmd"][:2] == ["python3.12", "scripts/stress_test.py"]
+        assert captured["cwd"] == str(base_tree)
+        assert captured["pythonpath"] == str(base_tree)
+
+    def test_tail_text_truncates_at_word_boundary(self):
+        from scripts.pr_validate.steps import stress_e2e_bench as step_mod
+
+        text = "alpha beta gamma delta epsilon"
+
+        assert step_mod._tail_text(text, limit=18) == "... delta epsilon"
+        assert step_mod._tail_text("short text", limit=50) == "short text"
+
+
+class TestLangChainGuidedCapabilityHandling:
+    def test_guided_extra_error_is_skip_eligible(self):
+        from tests.integrations import test_langchain
+
+        class _Response:
+            @staticmethod
+            def json():
+                return {"error": {"code": "guided_extra_required"}}
+
+        class _GuidedExtraError(Exception):
+            response = _Response()
+
+        assert test_langchain._is_guided_extra_required_error(_GuidedExtraError())
+        assert test_langchain._is_ok_result("SKIP: rapid-mlx[guided] not installed")
+        assert not test_langchain._is_ok_result("SKIP: unrelated future check")
+
+    def test_unrelated_langchain_error_still_fails(self):
+        from tests.integrations import test_langchain
+
+        assert not test_langchain._is_guided_extra_required_error(
+            RuntimeError("guided_extra_required appeared in unrelated text")
+        )
+        assert not test_langchain._is_ok_result("FAIL: schema mismatch")


### PR DESCRIPTION
## Summary

Fixes the stress/pr_validate failure-attribution issues found while reviewing the pre-existing stress failures:

- write each validation attempt into a unique `/tmp/pr_validate/pr-<n>/run-*` directory so stale agent/stress logs cannot be mistaken for the current verdict, without deleting concurrent runs
- write `stress-e2e-manifest.json` with every stress/agent/bench item that actually ran or was skipped
- when a stress or agent check fails on the PR, re-run the same failing item on the PR base ref in a temporary git worktree
- classify failures that reproduce on base as `[PRE-EXISTING]` and keep the stress step non-blocking for those; continue blocking when base passes or the base check is inconclusive
- run base rechecks with `PYTHONPATH` pointed at the base worktree so import resolution does not accidentally use the PR checkout/package
- make the LangChain structured-output smoke capability-aware: only the exact `guided_extra_required` response code is reported as a skip when the validation environment lacks `rapid-mlx[guided]`; unrelated structured-output errors still fail

## Root Cause

The old artifact layout reused one directory per PR. That made skipped or no-longer-running matrix entries leave old `FAIL` logs behind, which confused post-run triage. Separately, stress failures had no automatic main/base comparison, so a known model/environment failure looked the same as a PR regression until manually investigated.

## Validation

- `python3.12 -m pytest tests/test_pr_validate_runner.py tests/test_pr_validate_stress_timeout.py -q` (`37 passed`)
- `python3.12 -m ruff format scripts/pr_validate/runner.py scripts/pr_validate/steps/stress_e2e_bench.py tests/integrations/test_langchain.py tests/test_pr_validate_runner.py`
- `python3.12 -m ruff check scripts/pr_validate/runner.py scripts/pr_validate/steps/stress_e2e_bench.py tests/integrations/test_langchain.py tests/test_pr_validate_runner.py`
- `git diff --check`
- `python3.12 -m py_compile scripts/pr_validate/runner.py scripts/pr_validate/steps/stress_e2e_bench.py tests/integrations/test_langchain.py`
- `python3.12 -m scripts.pr_validate 846 -v --fail-fast` (`MERGE-SAFE`; Codex review no blocking issues; targeted tests `50 passed`; full unit `9044 passed, 21 skipped, 16 deselected, 7 xfailed`; stress gate skipped because blast radius is medium)
