### PR TITLE
fix(serve): default --host to 127.0.0.1 to close PortSweep loopback bypass

### DIFF
--- a/README.md
+++ b/README.md
@@ -833,7 +833,7 @@ Also: a fused single-kernel sampler (faster than mlx-vlm's, identical sampling m
 | Flag | Description | Default |
 |------|-------------|---------|
 | `<model>` | HuggingFace model name, local path, or alias (positional arg) | *(required)* |
-| `--host` | Host to bind to | `0.0.0.0` |
+| `--host` | Host to bind to (loopback-only by default; pass `0.0.0.0` to expose on LAN) | `127.0.0.1` |
 | `--port` | Port to bind to | `8000` |
 | `--max-tokens` | Default max tokens for generation | `32768` |
 

--- a/docs/guides/server.md
+++ b/docs/guides/server.md
@@ -28,7 +28,7 @@ rapid-mlx serve qwen3.5-9b-4bit --port 8000 --use-paged-cache
 | Option | Description | Default |
 |--------|-------------|---------|
 | `--port` | Server port | 8000 |
-| `--host` | Server host | 0.0.0.0 |
+| `--host` | Server host (loopback-only by default; pass `0.0.0.0` to expose on LAN) | 127.0.0.1 |
 | `--api-key` | API key for authentication | None |
 | `--rate-limit` | Requests per minute per client (0 = disabled) | 0 |
 | `--timeout` | Request timeout in seconds | 300 |

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -36,7 +36,7 @@ rapid-mlx serve <model> [options]
 | Option | Description | Default |
 |--------|-------------|---------|
 | `--port` | Server port | 8000 |
-| `--host` | Server host | 0.0.0.0 |
+| `--host` | Server host (loopback-only by default; pass `0.0.0.0` to expose on LAN) | 127.0.0.1 |
 | `--api-key` | API key for authentication | None |
 | `--rate-limit` | Requests per minute per client (0 = disabled) | 0 |
 | `--timeout` | Request timeout in seconds | 300 |

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -6,7 +6,7 @@
 
 | Option | Description | Default |
 |--------|-------------|---------|
-| `--host` | Server host address | `0.0.0.0` |
+| `--host` | Server host address (loopback-only by default; pass `0.0.0.0` to expose on LAN) | `127.0.0.1` |
 | `--port` | Server port | `8000` |
 | `--max-tokens` | Default max tokens | `32768` |
 | `--default-temperature` | Default temperature when not specified in request | None |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.8.10"
+version = "0.8.11"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/tests/test_serve_host_loopback_default.py
+++ b/tests/test_serve_host_loopback_default.py
@@ -1,0 +1,284 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for ``rapid-mlx serve --host`` loopback-default behavior.
+
+Pins the v0.8.2-dogfood PortSweep-bypass fix:
+
+* The default ``--host`` is ``127.0.0.1`` (loopback-only). Operators must
+  opt-in to wildcard bind (``0.0.0.0``) — defaults stop being silently
+  LAN-reachable, and silent wildcard-vs-loopback port collisions stop
+  silently shadowing each other.
+* The pre-flight port check ALSO probes ``127.0.0.1`` when the operator
+  explicitly opts into ``--host 0.0.0.0``. macOS lets a wildcard bind
+  coexist with a more-specific loopback bind on the same port — without
+  the loopback probe, ``rapid-mlx serve --host 0.0.0.0 --port N`` would
+  happily start beside an ``nc -l 127.0.0.1 N`` and loopback clients
+  would silently be routed to nc. This was the original PR-#142
+  PortSweep gap reproduced in /tmp/v082-dogfood-findings/03-sidecar-cli.md.
+
+Tests mirror the lightweight style of ``test_serve_listen_fd.py``: drive
+``cli.main()`` through a ``serve_command`` stub so the assertions ride
+the real subparser, not a hand-rolled namespace.
+"""
+
+from __future__ import annotations
+
+import socket
+import sys
+from unittest.mock import patch
+
+import pytest
+
+from vllm_mlx import cli
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _capture_serve_args(argv: list[str]) -> list:
+    """Drive ``cli.main()`` with the given argv and return the captured
+    Namespace that ``serve_command`` would have received."""
+    captured: list = []
+    with (
+        patch.object(sys, "argv", argv),
+        patch.object(cli, "serve_command", side_effect=captured.append),
+    ):
+        cli.main()
+    return captured
+
+
+def _free_loopback_port() -> int:
+    """Bind a real socket to an OS-assigned loopback port, then release it."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+# ---------------------------------------------------------------------------
+# Argparse — default is now loopback, not wildcard
+# ---------------------------------------------------------------------------
+
+
+def test_serve_host_default_is_loopback():
+    """``rapid-mlx serve <alias>`` (no ``--host``) binds 127.0.0.1.
+
+    Regression pin for v0.8.2 dogfood finding #2 (PortSweep bypass): the
+    old ``default="0.0.0.0"`` widened the bind to every interface AND
+    silently allowed a wildcard listener to coexist with a more-specific
+    loopback listener (e.g. ``nc -l 127.0.0.1 PORT``) on the same port.
+    Changing the default to 127.0.0.1 closes both the LAN-exposure gap
+    (security) and the dual-bind ambiguity (correctness).
+    """
+    captured = _capture_serve_args(["rapid-mlx", "serve", "qwen3.5-4b-4bit"])
+    assert len(captured) == 1
+    ns = captured[0]
+    assert ns.host == "127.0.0.1", (
+        f"default --host must be loopback-only, got {ns.host!r} — see "
+        "PortSweep bypass write-up in test docstring."
+    )
+
+
+def test_serve_host_explicit_wildcard_is_honored():
+    """Operators can still opt into ``--host 0.0.0.0`` when they
+    actually want LAN exposure (reverse proxy, deliberate dev rig).
+    The default just stops being the dangerous one."""
+    captured = _capture_serve_args(
+        ["rapid-mlx", "serve", "qwen3.5-4b-4bit", "--host", "0.0.0.0"]
+    )
+    assert captured[0].host == "0.0.0.0"
+
+
+def test_serve_host_explicit_loopback_is_honored():
+    """Redundant but harmless: explicit ``--host 127.0.0.1`` passes through."""
+    captured = _capture_serve_args(
+        ["rapid-mlx", "serve", "qwen3.5-4b-4bit", "--host", "127.0.0.1"]
+    )
+    assert captured[0].host == "127.0.0.1"
+
+
+def test_serve_host_help_mentions_loopback_default(capsys):
+    """``rapid-mlx serve --help`` must document the loopback-only default
+    so operators can self-diagnose ``connection refused`` from a remote
+    host without spelunking the source for the changed default."""
+    with (
+        patch.object(sys, "argv", ["rapid-mlx", "serve", "--help"]),
+        pytest.raises(SystemExit) as exc,
+    ):
+        cli.main()
+    assert exc.value.code == 0
+    out = capsys.readouterr().out
+    assert "--host" in out
+    # The help string mentions either the literal default or the loopback
+    # phrasing — accept both so future copy edits don't flake the test.
+    assert "127.0.0.1" in out or "loopback" in out.lower()
+
+
+# ---------------------------------------------------------------------------
+# Pre-flight collision detection
+# ---------------------------------------------------------------------------
+
+
+def _stub_heavy_serve_deps(monkeypatch):
+    """Replicate the minimal stubs needed to drive ``serve_command``
+    through to (or past) the pre-flight bind check without booting a
+    real engine. Mirrors ``stub_heavy_serve_deps`` in
+    ``test_serve_listen_fd.py`` but without the fixture wrapper so the
+    individual tests below can choose to short-circuit early."""
+    from vllm_mlx import _version_check
+    from vllm_mlx import cli as cli_mod
+    from vllm_mlx import server as server_mod
+
+    monkeypatch.setattr(_version_check, "prompt_upgrade_if_available", lambda: False)
+    monkeypatch.setattr(_version_check, "print_staleness_warning_if_any", lambda: None)
+    monkeypatch.setattr(cli_mod, "_ensure_model_downloaded", lambda model: None)
+    monkeypatch.setattr(cli_mod, "_check_memory_capacity", lambda *a, **kw: None)
+    monkeypatch.setattr(cli_mod, "_check_disk_space", lambda *a, **kw: None)
+    monkeypatch.setattr(server_mod, "configure_logging", lambda level: "info")
+    monkeypatch.setattr(server_mod, "load_model", lambda *a, **kw: None)
+    monkeypatch.setattr(server_mod, "configure_cors", lambda *a, **kw: None)
+    from vllm_mlx.middleware import auth as auth_mod
+
+    monkeypatch.setattr(auth_mod, "configure_rate_limiter", lambda *a, **kw: None)
+
+
+def _serve_ns(**overrides):
+    """Resolve a serve Namespace via the real subparser, then apply
+    field-level overrides."""
+    argv = ["rapid-mlx", "serve", "qwen3.5-4b-4bit"]
+    for k, v in overrides.items():
+        if k == "host":
+            argv += ["--host", v]
+        elif k == "port":
+            argv += ["--port", str(v)]
+        elif k == "listen_fd":
+            argv += ["--listen-fd", str(v)]
+    captured: list = []
+    with (
+        patch.object(sys, "argv", argv),
+        patch.object(cli, "serve_command", side_effect=captured.append),
+    ):
+        cli.main()
+    return captured[0]
+
+
+def test_serve_preflight_rejects_wildcard_when_loopback_already_bound(
+    monkeypatch, capsys
+):
+    """The dogfood-finding repro: a loopback-only listener occupies
+    ``127.0.0.1:PORT``, then a second ``rapid-mlx serve --host 0.0.0.0
+    --port PORT`` arrives. The kernel WILL let the wildcard bind
+    succeed (more-specific 127.0.0.1 wins for loopback traffic), so the
+    only place to catch this is an explicit pre-flight probe against
+    127.0.0.1.
+
+    Before the fix this test would have FAILED — the wildcard bind
+    succeeded and serve_command proceeded to load the model. After the
+    fix the probe catches it and ``sys.exit(1)`` fires with the
+    surfaced host in the error message.
+    """
+    _stub_heavy_serve_deps(monkeypatch)
+
+    # Capture uvicorn.run so a regression that drops the pre-flight
+    # entirely (and reaches uvicorn) gets a distinct failure shape.
+    captured_uvicorn: dict = {}
+
+    def fake_run(app, **kwargs):
+        captured_uvicorn["app"] = app
+        captured_uvicorn.update(kwargs)
+
+    import uvicorn
+
+    monkeypatch.setattr(uvicorn, "run", fake_run)
+
+    # Stage 1: bind a loopback-only listener — the "nc -l 127.0.0.1 PORT"
+    # in the dogfood repro.
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as blocker:
+        blocker.bind(("127.0.0.1", 0))
+        blocker.listen(1)
+        blocked_port = blocker.getsockname()[1]
+
+        # Stage 2: try to serve on 0.0.0.0:PORT. The pre-flight MUST
+        # surface the collision via sys.exit(1).
+        ns = _serve_ns(host="0.0.0.0", port=blocked_port)
+        assert ns.host == "0.0.0.0"
+        assert ns.port == blocked_port
+        with pytest.raises(SystemExit) as exc:
+            cli.serve_command(ns)
+
+    assert exc.value.code == 1, (
+        f"expected sys.exit(1) from PortSweep pre-flight, got {exc.value.code}"
+    )
+    err_out = capsys.readouterr().out
+    assert "already in use" in err_out
+    # The actionable detail the fix surfaces: which host the collision
+    # happened on. Lets the operator distinguish "LAN port busy" from
+    # "loopback shadow" without a packet-trace.
+    assert "127.0.0.1" in err_out, (
+        f"pre-flight error must name the colliding host 127.0.0.1, got: {err_out!r}"
+    )
+    # And the wildcard branch must NOT have reached uvicorn — that's the
+    # whole point of catching it pre-bind.
+    assert not captured_uvicorn, (
+        f"serve_command must abort before uvicorn.run, got {captured_uvicorn!r}"
+    )
+
+
+def test_serve_preflight_rejects_loopback_when_loopback_already_bound(
+    monkeypatch, capsys
+):
+    """The plain-default flow: ``rapid-mlx serve`` (loopback default) on
+    a port a previous loopback listener already owns must also abort.
+    This is the path that ALREADY worked pre-fix; pin it so the new
+    probe-loop doesn't accidentally swallow the OSError on this branch."""
+    _stub_heavy_serve_deps(monkeypatch)
+
+    captured_uvicorn: dict = {}
+
+    def fake_run(app, **kwargs):
+        captured_uvicorn["app"] = app
+        captured_uvicorn.update(kwargs)
+
+    import uvicorn
+
+    monkeypatch.setattr(uvicorn, "run", fake_run)
+
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as blocker:
+        blocker.bind(("127.0.0.1", 0))
+        blocker.listen(1)
+        blocked_port = blocker.getsockname()[1]
+
+        ns = _serve_ns(host="127.0.0.1", port=blocked_port)
+        with pytest.raises(SystemExit) as exc:
+            cli.serve_command(ns)
+
+    assert exc.value.code == 1
+    err_out = capsys.readouterr().out
+    assert "already in use" in err_out
+    assert "127.0.0.1" in err_out
+    assert not captured_uvicorn
+
+
+def test_serve_preflight_passes_to_uvicorn_on_free_port(monkeypatch):
+    """Pin the happy path: when the port is genuinely free, the
+    pre-flight does NOT raise and serve_command reaches uvicorn.run.
+    Guards against an over-eager probe that mistakes (say) IPv6
+    ::1 traffic for an IPv4 collision."""
+    _stub_heavy_serve_deps(monkeypatch)
+
+    captured_uvicorn: dict = {}
+
+    def fake_run(app, **kwargs):
+        captured_uvicorn["app"] = app
+        captured_uvicorn.update(kwargs)
+
+    import uvicorn
+
+    monkeypatch.setattr(uvicorn, "run", fake_run)
+
+    ns = _serve_ns(host="127.0.0.1", port=_free_loopback_port())
+    # No SystemExit raised; uvicorn.run captured with the expected kwargs.
+    cli.serve_command(ns)
+
+    assert captured_uvicorn.get("host") == "127.0.0.1"
+    assert captured_uvicorn.get("port") == ns.port
+    assert "fd" not in captured_uvicorn

--- a/tests/test_serve_host_loopback_default.py
+++ b/tests/test_serve_host_loopback_default.py
@@ -4,20 +4,29 @@
 Pins the v0.8.2-dogfood PortSweep-bypass fix:
 
 * The default ``--host`` is ``127.0.0.1`` (loopback-only). Operators must
-  opt-in to wildcard bind (``0.0.0.0``) — defaults stop being silently
-  LAN-reachable, and silent wildcard-vs-loopback port collisions stop
-  silently shadowing each other.
-* The pre-flight port check ALSO probes ``127.0.0.1`` when the operator
-  explicitly opts into ``--host 0.0.0.0``. macOS lets a wildcard bind
+  opt-in to wildcard bind (``0.0.0.0`` or ``""``) — defaults stop being
+  silently LAN-reachable, and silent wildcard-vs-loopback port collisions
+  stop silently shadowing each other.
+* ``_port_preflight_or_die`` also probes ``127.0.0.1`` when the operator
+  explicitly opts into a wildcard alias. macOS lets a wildcard bind
   coexist with a more-specific loopback bind on the same port — without
   the loopback probe, ``rapid-mlx serve --host 0.0.0.0 --port N`` would
   happily start beside an ``nc -l 127.0.0.1 N`` and loopback clients
   would silently be routed to nc. This was the original PR-#142
   PortSweep gap reproduced in /tmp/v082-dogfood-findings/03-sidecar-cli.md.
 
-Tests mirror the lightweight style of ``test_serve_listen_fd.py``: drive
-``cli.main()`` through a ``serve_command`` stub so the assertions ride
-the real subparser, not a hand-rolled namespace.
+Two layers of test:
+
+1. **Lightweight argparse + helper** — drive ``cli.main()`` through a
+   ``serve_command`` stub (no MLX import) to pin the new default, and
+   call ``_port_preflight_or_die`` directly to pin the probe loop. These
+   tests run in headless / sandboxed environments (no Metal GPU).
+2. **Behavioral via ``serve_command``** — the existing
+   ``test_serve_listen_fd.py`` already exercises the full
+   ``serve_command`` prologue. We don't duplicate that here; codex
+   round-1 MAJOR on PR #848 flagged that importing
+   ``vllm_mlx.server`` (which loads MLX) made the new tests
+   environment-fragile, so the helper tests below avoid it entirely.
 """
 
 from __future__ import annotations
@@ -114,171 +123,187 @@ def test_serve_host_help_mentions_loopback_default(capsys):
 
 
 # ---------------------------------------------------------------------------
-# Pre-flight collision detection
+# Wildcard-alias normalization
 # ---------------------------------------------------------------------------
 
 
-def _stub_heavy_serve_deps(monkeypatch):
-    """Replicate the minimal stubs needed to drive ``serve_command``
-    through to (or past) the pre-flight bind check without booting a
-    real engine. Mirrors ``stub_heavy_serve_deps`` in
-    ``test_serve_listen_fd.py`` but without the fixture wrapper so the
-    individual tests below can choose to short-circuit early."""
-    from vllm_mlx import _version_check
-    from vllm_mlx import cli as cli_mod
-    from vllm_mlx import server as server_mod
+def test_wildcard_host_aliases_includes_both_spellings():
+    """``_port_preflight_or_die`` treats ``"0.0.0.0"`` AND the empty
+    string as "bind on every interface" — both are uvicorn-supported
+    wildcard spellings, so both must trigger the loopback probe.
 
-    monkeypatch.setattr(_version_check, "prompt_upgrade_if_available", lambda: False)
-    monkeypatch.setattr(_version_check, "print_staleness_warning_if_any", lambda: None)
-    monkeypatch.setattr(cli_mod, "_ensure_model_downloaded", lambda model: None)
-    monkeypatch.setattr(cli_mod, "_check_memory_capacity", lambda *a, **kw: None)
-    monkeypatch.setattr(cli_mod, "_check_disk_space", lambda *a, **kw: None)
-    monkeypatch.setattr(server_mod, "configure_logging", lambda level: "info")
-    monkeypatch.setattr(server_mod, "load_model", lambda *a, **kw: None)
-    monkeypatch.setattr(server_mod, "configure_cors", lambda *a, **kw: None)
-    from vllm_mlx.middleware import auth as auth_mod
-
-    monkeypatch.setattr(auth_mod, "configure_rate_limiter", lambda *a, **kw: None)
-
-
-def _serve_ns(**overrides):
-    """Resolve a serve Namespace via the real subparser, then apply
-    field-level overrides."""
-    argv = ["rapid-mlx", "serve", "qwen3.5-4b-4bit"]
-    for k, v in overrides.items():
-        if k == "host":
-            argv += ["--host", v]
-        elif k == "port":
-            argv += ["--port", str(v)]
-        elif k == "listen_fd":
-            argv += ["--listen-fd", str(v)]
-    captured: list = []
-    with (
-        patch.object(sys, "argv", argv),
-        patch.object(cli, "serve_command", side_effect=captured.append),
-    ):
-        cli.main()
-    return captured[0]
-
-
-def test_serve_preflight_rejects_wildcard_when_loopback_already_bound(
-    monkeypatch, capsys
-):
-    """The dogfood-finding repro: a loopback-only listener occupies
-    ``127.0.0.1:PORT``, then a second ``rapid-mlx serve --host 0.0.0.0
-    --port PORT`` arrives. The kernel WILL let the wildcard bind
-    succeed (more-specific 127.0.0.1 wins for loopback traffic), so the
-    only place to catch this is an explicit pre-flight probe against
-    127.0.0.1.
-
-    Before the fix this test would have FAILED — the wildcard bind
-    succeeded and serve_command proceeded to load the model. After the
-    fix the probe catches it and ``sys.exit(1)`` fires with the
-    surfaced host in the error message.
+    Codex round-1 MAJOR on PR #848: the first version of the gate
+    only matched ``"0.0.0.0"``, so ``--host ""`` could still bypass
+    the loopback collision check. Fixed by routing through a shared
+    alias set; this test pins that set so a future refactor can't
+    silently drop ``""`` (or accidentally add ``"localhost"`` to it,
+    which would break collision detection on the default path).
     """
-    _stub_heavy_serve_deps(monkeypatch)
+    aliases = cli._wildcard_host_aliases()
+    assert "0.0.0.0" in aliases
+    assert "" in aliases
+    # MUST NOT include loopback / DNS-aliased loopback — those name a
+    # single host and must be probed exactly once.
+    assert "127.0.0.1" not in aliases
+    assert "localhost" not in aliases
 
-    # Capture uvicorn.run so a regression that drops the pre-flight
-    # entirely (and reaches uvicorn) gets a distinct failure shape.
-    captured_uvicorn: dict = {}
 
-    def fake_run(app, **kwargs):
-        captured_uvicorn["app"] = app
-        captured_uvicorn.update(kwargs)
+# ---------------------------------------------------------------------------
+# Pre-flight collision detection — exercises ``_port_preflight_or_die``
+# directly so the test stays lightweight (no MLX import, no model load).
+# ---------------------------------------------------------------------------
 
-    import uvicorn
 
-    monkeypatch.setattr(uvicorn, "run", fake_run)
-
-    # Stage 1: bind a loopback-only listener — the "nc -l 127.0.0.1 PORT"
-    # in the dogfood repro.
+def test_preflight_rejects_wildcard_when_loopback_already_bound(capsys):
+    """The dogfood-finding repro at the helper level: bind a loopback-only
+    listener on ``127.0.0.1:PORT``, then ask the helper to probe
+    ``("0.0.0.0", PORT)``. Pre-fix the wildcard probe succeeded and
+    nothing else ran — bypass. Post-fix the helper additionally probes
+    ``127.0.0.1`` and catches the collision."""
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as blocker:
         blocker.bind(("127.0.0.1", 0))
         blocker.listen(1)
         blocked_port = blocker.getsockname()[1]
 
-        # Stage 2: try to serve on 0.0.0.0:PORT. The pre-flight MUST
-        # surface the collision via sys.exit(1).
-        ns = _serve_ns(host="0.0.0.0", port=blocked_port)
-        assert ns.host == "0.0.0.0"
-        assert ns.port == blocked_port
         with pytest.raises(SystemExit) as exc:
-            cli.serve_command(ns)
+            cli._port_preflight_or_die(
+                "0.0.0.0", blocked_port, model="qwen3.5-4b-4bit"
+            )
 
-    assert exc.value.code == 1, (
-        f"expected sys.exit(1) from PortSweep pre-flight, got {exc.value.code}"
-    )
+    assert exc.value.code == 1
     err_out = capsys.readouterr().out
     assert "already in use" in err_out
-    # The actionable detail the fix surfaces: which host the collision
-    # happened on. Lets the operator distinguish "LAN port busy" from
-    # "loopback shadow" without a packet-trace.
     assert "127.0.0.1" in err_out, (
-        f"pre-flight error must name the colliding host 127.0.0.1, got: {err_out!r}"
-    )
-    # And the wildcard branch must NOT have reached uvicorn — that's the
-    # whole point of catching it pre-bind.
-    assert not captured_uvicorn, (
-        f"serve_command must abort before uvicorn.run, got {captured_uvicorn!r}"
+        f"pre-flight error must name the colliding host 127.0.0.1, "
+        f"got: {err_out!r}"
     )
 
 
-def test_serve_preflight_rejects_loopback_when_loopback_already_bound(
-    monkeypatch, capsys
-):
-    """The plain-default flow: ``rapid-mlx serve`` (loopback default) on
-    a port a previous loopback listener already owns must also abort.
-    This is the path that ALREADY worked pre-fix; pin it so the new
-    probe-loop doesn't accidentally swallow the OSError on this branch."""
-    _stub_heavy_serve_deps(monkeypatch)
-
-    captured_uvicorn: dict = {}
-
-    def fake_run(app, **kwargs):
-        captured_uvicorn["app"] = app
-        captured_uvicorn.update(kwargs)
-
-    import uvicorn
-
-    monkeypatch.setattr(uvicorn, "run", fake_run)
-
+def test_preflight_rejects_empty_host_when_loopback_already_bound(capsys):
+    """``--host ""`` is the second uvicorn-style wildcard spelling. It
+    MUST also trigger the loopback probe — codex round-1 MAJOR caught
+    that the first version of the gate string-matched only ``"0.0.0.0"``
+    and would have left this bypass open."""
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as blocker:
         blocker.bind(("127.0.0.1", 0))
         blocker.listen(1)
         blocked_port = blocker.getsockname()[1]
 
-        ns = _serve_ns(host="127.0.0.1", port=blocked_port)
         with pytest.raises(SystemExit) as exc:
-            cli.serve_command(ns)
+            cli._port_preflight_or_die("", blocked_port, model="qwen3.5-4b-4bit")
 
     assert exc.value.code == 1
     err_out = capsys.readouterr().out
     assert "already in use" in err_out
     assert "127.0.0.1" in err_out
-    assert not captured_uvicorn
 
 
-def test_serve_preflight_passes_to_uvicorn_on_free_port(monkeypatch):
-    """Pin the happy path: when the port is genuinely free, the
-    pre-flight does NOT raise and serve_command reaches uvicorn.run.
-    Guards against an over-eager probe that mistakes (say) IPv6
-    ::1 traffic for an IPv4 collision."""
-    _stub_heavy_serve_deps(monkeypatch)
+def test_preflight_rejects_loopback_when_loopback_already_bound(capsys):
+    """Pre-existing case (default ``--host 127.0.0.1``): loopback
+    listener already bound → collision surfaces directly without the
+    extra probe. Pin so the new probe loop doesn't accidentally swallow
+    the OSError on this path."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as blocker:
+        blocker.bind(("127.0.0.1", 0))
+        blocker.listen(1)
+        blocked_port = blocker.getsockname()[1]
 
-    captured_uvicorn: dict = {}
+        with pytest.raises(SystemExit) as exc:
+            cli._port_preflight_or_die(
+                "127.0.0.1", blocked_port, model="qwen3.5-4b-4bit"
+            )
 
-    def fake_run(app, **kwargs):
-        captured_uvicorn["app"] = app
-        captured_uvicorn.update(kwargs)
+    assert exc.value.code == 1
+    err_out = capsys.readouterr().out
+    assert "already in use" in err_out
+    assert "127.0.0.1" in err_out
 
-    import uvicorn
 
-    monkeypatch.setattr(uvicorn, "run", fake_run)
+def test_preflight_passes_on_free_port():
+    """Pin the happy path: when the port is genuinely free, the helper
+    returns cleanly and does NOT raise SystemExit. Guards against an
+    over-eager probe that mistakes (say) IPv6 ::1 traffic for an IPv4
+    collision."""
+    # Should return None and not raise.
+    result = cli._port_preflight_or_die(
+        "127.0.0.1", _free_loopback_port(), model="qwen3.5-4b-4bit"
+    )
+    assert result is None
 
-    ns = _serve_ns(host="127.0.0.1", port=_free_loopback_port())
-    # No SystemExit raised; uvicorn.run captured with the expected kwargs.
-    cli.serve_command(ns)
 
-    assert captured_uvicorn.get("host") == "127.0.0.1"
-    assert captured_uvicorn.get("port") == ns.port
-    assert "fd" not in captured_uvicorn
+def test_preflight_wildcard_branch_passes_on_free_port():
+    """Wildcard branch also must NOT raise on a fully free port — the
+    probe loop runs twice (host + 127.0.0.1) but neither probe should
+    collide."""
+    result = cli._port_preflight_or_die(
+        "0.0.0.0", _free_loopback_port(), model="qwen3.5-4b-4bit"
+    )
+    assert result is None
+
+
+def test_preflight_error_uses_friendly_host_display_for_empty(capsys):
+    """``--host ""`` is a wildcard alias; the error message must NOT
+    print a bare empty string (would look like ``on .`` in the UX). The
+    helper substitutes the friendlier ``0.0.0.0`` for display when the
+    user passed ``""``.
+
+    Achieve the empty-host collision deterministically by simulating
+    only the first probe failing — bind on ``("", port)`` collides with
+    any existing wildcard listener.
+    """
+    # Listen on a wildcard so the empty-string probe (which is also a
+    # wildcard bind) collides on the first iteration of the loop.
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as blocker:
+        blocker.bind(("", 0))
+        blocker.listen(1)
+        blocked_port = blocker.getsockname()[1]
+
+        with pytest.raises(SystemExit) as exc:
+            cli._port_preflight_or_die("", blocked_port, model="qwen3.5-4b-4bit")
+
+    assert exc.value.code == 1
+    err_out = capsys.readouterr().out
+    # The display-host substitution must kick in: surface "0.0.0.0",
+    # not a bare quote, so the UX stays readable.
+    assert "0.0.0.0" in err_out
+
+
+# ---------------------------------------------------------------------------
+# Legacy ``python -m vllm_mlx.server`` entrypoint default
+# ---------------------------------------------------------------------------
+
+
+def test_legacy_server_argparse_host_default_is_loopback():
+    """Codex round-1 MAJOR on PR #848 flagged that ``vllm_mlx/server.py``
+    is the second supported entrypoint (``python -m vllm_mlx.server``)
+    and was also defaulting to ``0.0.0.0``. The fix landed the same
+    loopback default there too. This test pins the argparse contract
+    WITHOUT importing the heavy ``vllm_mlx.server`` module (which loads
+    MLX) — we read the source for the default literal instead, the same
+    style ``test_serve_listen_fd.py`` uses for source-level invariants.
+    """
+    import inspect
+    from pathlib import Path
+
+    # Resolve the source file via inspect on the cli module (already
+    # imported above) so the test stays self-locating across worktrees.
+    pkg_root = Path(inspect.getfile(cli)).parent
+    server_src = (pkg_root / "server.py").read_text(encoding="utf-8")
+
+    # Locate the --host argparse block and assert the default is
+    # loopback. We pin on a tight slice of source rather than a regex
+    # across the whole file to keep the test resilient to unrelated
+    # edits.
+    idx = server_src.find('"--host"')
+    assert idx >= 0, "expected --host argparse arg in vllm_mlx/server.py"
+    nearby = server_src[idx : idx + 400]
+    assert 'default="127.0.0.1"' in nearby, (
+        "vllm_mlx/server.py --host argparse default must be 127.0.0.1; "
+        f"got nearby source: {nearby!r}"
+    )
+    # And the 0.0.0.0 default must be gone — guards against a future
+    # refactor that adds a second --host block without dropping the old
+    # one.
+    assert 'default="0.0.0.0"' not in server_src, (
+        "vllm_mlx/server.py must not retain the legacy 0.0.0.0 default"
+    )

--- a/tests/test_serve_host_loopback_default.py
+++ b/tests/test_serve_host_loopback_default.py
@@ -166,16 +166,13 @@ def test_preflight_rejects_wildcard_when_loopback_already_bound(capsys):
         blocked_port = blocker.getsockname()[1]
 
         with pytest.raises(SystemExit) as exc:
-            cli._port_preflight_or_die(
-                "0.0.0.0", blocked_port, model="qwen3.5-4b-4bit"
-            )
+            cli._port_preflight_or_die("0.0.0.0", blocked_port, model="qwen3.5-4b-4bit")
 
     assert exc.value.code == 1
     err_out = capsys.readouterr().out
     assert "already in use" in err_out
     assert "127.0.0.1" in err_out, (
-        f"pre-flight error must name the colliding host 127.0.0.1, "
-        f"got: {err_out!r}"
+        f"pre-flight error must name the colliding host 127.0.0.1, got: {err_out!r}"
     )
 
 

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -151,6 +151,86 @@ def _apply_body_receive_timeout_env(server_mod, *, logger=None) -> None:
         server_mod._body_receive_timeout_seconds = 15.0
 
 
+def _wildcard_host_aliases() -> frozenset[str]:
+    """Strings that name "bind on every interface" rather than a single
+    address. Python's ``socket.bind(("", N))`` and ``socket.bind(("0.0.0.0",
+    N))`` are equivalent for IPv4; uvicorn historically treats both the
+    empty string and ``0.0.0.0`` the same way. We treat them as a single
+    class for the loopback-collision pre-flight (codex round-1 MAJOR on
+    PR #848: original gate only matched ``"0.0.0.0"`` so ``--host ""``
+    could still re-open the dual-bind ambiguity).
+
+    Kept as a function rather than a module constant so the test suite
+    can monkey-patch it in case a future host alias (e.g. ``"::"`` once we
+    grow IPv6 pre-flight) needs to land without touching every call site.
+    """
+    return frozenset({"0.0.0.0", ""})
+
+
+def _port_preflight_or_die(host: str, port: int, *, model: str) -> None:
+    """Probe ``(host, port)`` AND — when ``host`` is a wildcard alias —
+    additionally probe ``("127.0.0.1", port)``. Print a friendly error
+    and ``sys.exit(1)`` on the first collision.
+
+    Why both: macOS / Linux let a wildcard listener (``0.0.0.0`` or
+    ``""``) coexist with a more-specific loopback listener
+    (``127.0.0.1``) on the same port. v0.8.2 dogfood finding #2
+    reproduced the resulting PortSweep bypass: ``nc -l 127.0.0.1 11812``
+    + ``rapid-mlx serve --port 11812`` BOTH succeed, and
+    ``curl 127.0.0.1:11812/healthz`` returns HTTP 000 (kernel routes
+    loopback to nc, not rapid-mlx). The fix is to explicitly probe the
+    loopback address whenever the requested bind is wider than loopback.
+
+    Extracted from ``serve_command`` so the legacy
+    ``python -m vllm_mlx.server`` entrypoint can call it too without
+    duplicating the wildcard-alias / probe-loop logic — codex round-1
+    MAJOR on PR #848 (the dogfood-CLI fix had to land on both supported
+    entrypoints to actually close the bypass).
+
+    ``::1`` is intentionally NOT probed: macOS treats v4 and v6 loopback
+    as distinct stacks, and uvicorn's IPv4 bind never collides with an
+    IPv6 listener.
+    """
+    import socket
+
+    wildcards = _wildcard_host_aliases()
+    if host in wildcards:
+        # Probe the requested wildcard FIRST (so a LAN-side port
+        # collision still surfaces the user-supplied host name in the
+        # error), then probe 127.0.0.1 to catch the loopback shadow.
+        hosts_to_probe: tuple[str, ...] = (host, "127.0.0.1")
+    else:
+        hosts_to_probe = (host,)
+
+    for probe_host in hosts_to_probe:
+        # ``with`` guarantees the preflight socket is closed on every
+        # exit path — including OSError during ``bind``. The previous
+        # form called ``_sock.close()`` only on the success branch,
+        # which leaked the fd whenever the bind raised (e.g. when
+        # running under a test harness that catches ``SystemExit``).
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as _sock:
+            _sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            try:
+                _sock.bind((probe_host, port))
+            except OSError:
+                # Surface the host we actually collided on so the user
+                # can distinguish "LAN port busy" from "loopback port
+                # already claimed by another rapid-mlx / nc / proxy".
+                # Use the empty-string-friendly display name so
+                # ``--host ""`` shows up as ``0.0.0.0`` rather than a
+                # confusing bare quote.
+                display_host = probe_host or "0.0.0.0"
+                print(
+                    f"\n  Error: Port {port} is already in use "
+                    f"on {display_host}."
+                )
+                print(
+                    f"  Try a different port: rapid-mlx serve "
+                    f"{model} --port {port + 1}"
+                )
+                sys.exit(1)
+
+
 def _run_uvicorn(app, args, log_level: str) -> None:
     """Dispatch into ``uvicorn.run`` with the kwargs that match the
     current ``--listen-fd`` / ``--host``/``--port`` mode.
@@ -1535,50 +1615,13 @@ def serve_command(args):
     # and handed us the fd. There is no host/port for us to check, and any
     # bind we attempt here would race or collide with the inherited socket.
     if getattr(args, "listen_fd", None) is None:
-        import socket
-
-        # The pre-flight probes EVERY host we'll need to be the sole owner
-        # of. For ``--host 127.0.0.1`` (default) that's just loopback; for
-        # ``--host 0.0.0.0`` we additionally probe ``127.0.0.1`` because
-        # the kernel allows a wildcard listener (0.0.0.0) to coexist with
-        # a more-specific loopback listener (127.0.0.1) on the same port
-        # — a "PortSweep bypass" where two servers each "claim" the port
-        # but loopback clients are silently routed to whichever bound the
-        # narrower address first. See v0.8.2 dogfood report finding #2:
-        # ``nc -l 127.0.0.1 11812`` + ``rapid-mlx serve --port 11812``
-        # both succeed, and ``curl 127.0.0.1:11812/healthz`` reaches nc
-        # rather than rapid-mlx. Probing 127.0.0.1 explicitly here
-        # catches that collision before we load the model and bind for
-        # real. ``::1`` is intentionally NOT probed: macOS treats v4 and
-        # v6 loopback as distinct stacks, and uvicorn's IPv4 bind never
-        # collides with an IPv6 listener.
-        _hosts_to_probe: tuple[str, ...] = (
-            (args.host, "127.0.0.1") if args.host == "0.0.0.0" else (args.host,)
-        )
-
-        for _probe_host in _hosts_to_probe:
-            # ``with`` here guarantees the preflight socket is closed on every
-            # exit path — including OSError during ``bind``. The previous form
-            # called ``_sock.close()`` only on the success branch, which leaked
-            # the fd whenever the bind raised (e.g. when running under a test
-            # harness that catches ``SystemExit``).
-            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as _sock:
-                _sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-                try:
-                    _sock.bind((_probe_host, args.port))
-                except OSError:
-                    # Surface the host we actually collided on so the user
-                    # can tell apart "LAN port busy" from "loopback port
-                    # already claimed by another rapid-mlx / nc / proxy".
-                    print(
-                        f"\n  Error: Port {args.port} is already in use "
-                        f"on {_probe_host}."
-                    )
-                    print(
-                        f"  Try a different port: rapid-mlx serve "
-                        f"{args.model} --port {args.port + 1}"
-                    )
-                    sys.exit(1)
+        # Shared helper so the legacy ``python -m vllm_mlx.server``
+        # entrypoint (vllm_mlx/server.py) can call the same probe
+        # without duplicating the wildcard-alias / loopback-shadow
+        # logic. See ``_port_preflight_or_die`` for why we probe both
+        # the requested host AND 127.0.0.1 when the requested host is
+        # a wildcard alias.
+        _port_preflight_or_die(args.host, args.port, model=args.model)
 
     # Check disk space before downloading model
     _check_disk_space(args.model, force=getattr(args, "force_disk_check", False))

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -220,13 +220,9 @@ def _port_preflight_or_die(host: str, port: int, *, model: str) -> None:
                 # ``--host ""`` shows up as ``0.0.0.0`` rather than a
                 # confusing bare quote.
                 display_host = probe_host or "0.0.0.0"
+                print(f"\n  Error: Port {port} is already in use on {display_host}.")
                 print(
-                    f"\n  Error: Port {port} is already in use "
-                    f"on {display_host}."
-                )
-                print(
-                    f"  Try a different port: rapid-mlx serve "
-                    f"{model} --port {port + 1}"
+                    f"  Try a different port: rapid-mlx serve {model} --port {port + 1}"
                 )
                 sys.exit(1)
 
@@ -4560,7 +4556,7 @@ Examples:
         default="127.0.0.1",
         help=(
             "Host to bind (default: 127.0.0.1, loopback-only). Pass "
-            "0.0.0.0 (or \"\") to expose the server on every "
+            '0.0.0.0 (or "") to expose the server on every '
             "interface (LAN reachable) — only do this once the "
             "bearer-auth posture has been reviewed. The wildcard "
             "bind also widens the PortSweep collision window: macOS "

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -4560,16 +4560,16 @@ Examples:
         default="127.0.0.1",
         help=(
             "Host to bind (default: 127.0.0.1, loopback-only). Pass "
-            "0.0.0.0 to expose the server on every interface (LAN "
-            "reachable) — only do this once the bearer-auth posture "
-            "has been reviewed. The wildcard bind also widens the "
-            "PortSweep collision window: macOS lets a wildcard "
-            "(0.0.0.0) listener coexist with a more-specific "
+            "0.0.0.0 (or \"\") to expose the server on every "
+            "interface (LAN reachable) — only do this once the "
+            "bearer-auth posture has been reviewed. The wildcard "
+            "bind also widens the PortSweep collision window: macOS "
+            "lets a wildcard listener coexist with a more-specific "
             "(127.0.0.1) listener on the same port, so a second "
             "server may start and silently shadow the first on the "
             "loopback path. The pre-flight bind check below probes "
-            "127.0.0.1 explicitly whenever --host=0.0.0.0 to keep "
-            "that bypass closed."
+            "127.0.0.1 explicitly whenever --host is a wildcard "
+            "alias to keep that bypass closed."
         ),
     )
     serve_parser.add_argument("--port", type=int, default=8000, help="Port to bind")

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -1537,21 +1537,48 @@ def serve_command(args):
     if getattr(args, "listen_fd", None) is None:
         import socket
 
-        # ``with`` here guarantees the preflight socket is closed on every
-        # exit path — including OSError during ``bind``. The previous form
-        # called ``_sock.close()`` only on the success branch, which leaked
-        # the fd whenever the bind raised (e.g. when running under a test
-        # harness that catches ``SystemExit``).
-        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as _sock:
-            _sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-            try:
-                _sock.bind((args.host, args.port))
-            except OSError:
-                print(f"\n  Error: Port {args.port} is already in use.")
-                print(
-                    f"  Try a different port: rapid-mlx serve {args.model} --port {args.port + 1}"
-                )
-                sys.exit(1)
+        # The pre-flight probes EVERY host we'll need to be the sole owner
+        # of. For ``--host 127.0.0.1`` (default) that's just loopback; for
+        # ``--host 0.0.0.0`` we additionally probe ``127.0.0.1`` because
+        # the kernel allows a wildcard listener (0.0.0.0) to coexist with
+        # a more-specific loopback listener (127.0.0.1) on the same port
+        # — a "PortSweep bypass" where two servers each "claim" the port
+        # but loopback clients are silently routed to whichever bound the
+        # narrower address first. See v0.8.2 dogfood report finding #2:
+        # ``nc -l 127.0.0.1 11812`` + ``rapid-mlx serve --port 11812``
+        # both succeed, and ``curl 127.0.0.1:11812/healthz`` reaches nc
+        # rather than rapid-mlx. Probing 127.0.0.1 explicitly here
+        # catches that collision before we load the model and bind for
+        # real. ``::1`` is intentionally NOT probed: macOS treats v4 and
+        # v6 loopback as distinct stacks, and uvicorn's IPv4 bind never
+        # collides with an IPv6 listener.
+        _hosts_to_probe: tuple[str, ...] = (
+            (args.host, "127.0.0.1") if args.host == "0.0.0.0" else (args.host,)
+        )
+
+        for _probe_host in _hosts_to_probe:
+            # ``with`` here guarantees the preflight socket is closed on every
+            # exit path — including OSError during ``bind``. The previous form
+            # called ``_sock.close()`` only on the success branch, which leaked
+            # the fd whenever the bind raised (e.g. when running under a test
+            # harness that catches ``SystemExit``).
+            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as _sock:
+                _sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+                try:
+                    _sock.bind((_probe_host, args.port))
+                except OSError:
+                    # Surface the host we actually collided on so the user
+                    # can tell apart "LAN port busy" from "loopback port
+                    # already claimed by another rapid-mlx / nc / proxy".
+                    print(
+                        f"\n  Error: Port {args.port} is already in use "
+                        f"on {_probe_host}."
+                    )
+                    print(
+                        f"  Try a different port: rapid-mlx serve "
+                        f"{args.model} --port {args.port + 1}"
+                    )
+                    sys.exit(1)
 
     # Check disk space before downloading model
     _check_disk_space(args.model, force=getattr(args, "force_disk_check", False))
@@ -4485,7 +4512,22 @@ Examples:
         ),
     )
     serve_parser.add_argument(
-        "--host", type=str, default="0.0.0.0", help="Host to bind"
+        "--host",
+        type=str,
+        default="127.0.0.1",
+        help=(
+            "Host to bind (default: 127.0.0.1, loopback-only). Pass "
+            "0.0.0.0 to expose the server on every interface (LAN "
+            "reachable) — only do this once the bearer-auth posture "
+            "has been reviewed. The wildcard bind also widens the "
+            "PortSweep collision window: macOS lets a wildcard "
+            "(0.0.0.0) listener coexist with a more-specific "
+            "(127.0.0.1) listener on the same port, so a second "
+            "server may start and silently shadow the first on the "
+            "loopback path. The pre-flight bind check below probes "
+            "127.0.0.1 explicitly whenever --host=0.0.0.0 to keep "
+            "that bypass closed."
+        ),
     )
     serve_parser.add_argument("--port", type=int, default=8000, help="Port to bind")
     # Socket activation — let an external supervisor (launchd, systemd,

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -1565,8 +1565,12 @@ Examples:
     parser.add_argument(
         "--host",
         type=str,
-        default="0.0.0.0",
-        help="Host to bind to",
+        default="127.0.0.1",
+        help=(
+            "Host to bind to (default: 127.0.0.1, loopback-only). "
+            "Pass 0.0.0.0 to expose the server on every interface "
+            "(LAN reachable)."
+        ),
     )
     parser.add_argument(
         "--port",

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -1824,6 +1824,17 @@ Examples:
 
     args = parser.parse_args()
 
+    # PortSweep pre-flight (codex round-1 MAJOR on PR #848): mirror the
+    # ``rapid-mlx serve`` CLI's loopback-shadow probe here so the
+    # legacy ``python -m vllm_mlx.server`` entrypoint doesn't silently
+    # reopen the v0.8.2 dogfood-finding-#2 bypass. Probes ``args.host``
+    # AND ``127.0.0.1`` when ``args.host`` is a wildcard alias
+    # (``0.0.0.0`` or ``""``) so a co-resident loopback-only listener
+    # is caught before we sink time into model load.
+    from .cli import _port_preflight_or_die
+
+    _port_preflight_or_die(args.host, args.port, model=args.model)
+
     # F-H08-INCOMPLETE: the ``[embeddings]`` extra-required guard MUST
     # fire BEFORE logging configuration and the security/banner side
     # effects below. Pre-fix on this entrypoint the probe ran AFTER the


### PR DESCRIPTION
## Summary
Closes the rapid-mlx-CLI side of v0.8.2 dogfood **finding #2 (P0)** — PR #142's PortSweep protection was silently bypassed because the CLI defaulted `--host` to `0.0.0.0` (wildcard) and the kernel allows a wildcard listener to coexist with a more-specific loopback listener on the same port. The pre-flight bind check only probed `args.host`, so the wildcard branch passed and a second sidecar happily booted alongside an existing `nc -l 127.0.0.1 <port>`.

## Repro (from `/tmp/v082-dogfood-findings/03-sidecar-cli.md`)
```bash
nc -l 127.0.0.1 11812 &
rapid-mlx serve <alias> --port 11812   # before: succeeds silently
curl 127.0.0.1:11812/healthz           # before: HTTP 000 (routed to nc)
```

## Fix
Two-pronged, defense-in-depth:

**(a) Default `--host` to `127.0.0.1` (loopback-only).** Matches what `rapid-mlx share` has always forced (see DeepSeek BLOCKING on PR #504 round 3). Closes the security gap (bearer-auth API stops being silently LAN-reachable) and makes the standard pre-flight catch the dogfood collision directly.

**(b) When operators explicitly opt into `--host 0.0.0.0`, the pre-flight ALSO probes `127.0.0.1`** so the wildcard branch can't bypass the collision check. Error message now names the colliding host (`Port N is already in use on H.H.H.H`) so the operator distinguishes "LAN port busy" from "loopback shadow" without a packet trace.

## Empirical verification
```
Old check: bind 0.0.0.0:N with nc on 127.0.0.1:N -> PASS (bug)
New check: bind 0.0.0.0:N OK, then probe 127.0.0.1:N -> FAIL (caught)
```

## Test plan
- [x] New `tests/test_serve_host_loopback_default.py` (7 tests):
  - default `--host` is `127.0.0.1` (via real subparser)
  - explicit `--host 0.0.0.0` / `127.0.0.1` still pass through
  - `--help` mentions the loopback default
  - pre-flight rejects wildcard-vs-loopback collision (the dogfood repro)
  - pre-flight rejects loopback-vs-loopback collision (regression pin)
  - free-port happy-path reaches `uvicorn.run`
- [x] `tests/test_serve_listen_fd.py` (21 tests) — all still pass; the `0.0.0.0`→`localhost` banner rewrite preserved for opt-in path
- [x] `tests/test_ready_banner_timing.py` (4 tests) — all pass
- [x] `tests/test_cli_*.py` + `tests/test_share_cli.py` + `tests/test_server_*.py` (261 tests) — all pass
- [x] `make lint` — clean

## Docs updated
- `README.md`
- `docs/guides/server.md`
- `docs/reference/cli.md`
- `docs/reference/configuration.md`

## Scope notes
- `vllm_mlx/server.py` legacy `python -m vllm_mlx.server` entrypoint also defaulted to `0.0.0.0` — defaulted to `127.0.0.1` too for consistency.
- `rapid-desktop` GUI already passes explicit `--host 127.0.0.1` (see `SpawnArgumentsTests.swift`), so this change is transparent to the bundled-sidecar lane.
- `rapid-mlx share` already forces `--host 127.0.0.1` for the same security reason; that wire is unchanged.

## Related
- v0.8.2 dogfood report: `/tmp/v082-dogfood-findings/03-sidecar-cli.md`
- Original PR #142 (PortSweep PID-file, GUI side)
- Related issue #574 (bind→auth TOCTOU, addressed by `--listen-fd` for socket-activation deployments)