### PR TITLE
fix(reasoning,ui-tars): r10-F — accumulator-anchor + honor enable_thinking=false (R10-C7 + R10-M1)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.8.11"
+version = "0.8.12"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/tests/test_streaming_reasoning_split_r8c.py
+++ b/tests/test_streaming_reasoning_split_r8c.py
@@ -350,6 +350,81 @@ class TestR8M2ToolChoiceAutoThinkLeak:
         # in the singleton path doesn't drag a stale latch).
         assert pp._explicit_think_seen is False
 
+    def test_r10c7_plain_then_standalone_think_chunk_does_not_latch(self):
+        """R10-C7 (Mira r10-R1, 2026-06-23): the r8-C anchor used
+        ``self.accumulated_text + delta_text`` and required ``<think>``
+        at the buffer HEAD to latch. But ``_process_standard`` (the
+        path used while the bypass is active) does NOT mutate
+        ``accumulated_text`` — only ``_process_with_reasoning`` does
+        (postprocessor.py:2158/2163). So a plain answer that emits
+        chunk #1 of clean content followed by chunk #2 starting with
+        a literal ``<think>`` token would see ``probe = "" +
+        "<think>..."``, match ``head.startswith("<think>")``, and latch
+        ``_explicit_think_seen`` — rerouting the rest of the answer to
+        ``delta.reasoning`` and hiding the body.
+
+        Post-fix the ``_standard_content_observed`` latch refuses any
+        mid-content ``<think>`` promotion once the bypass has emitted
+        plain content for this request. The historic happy paths
+        (first-token ``<think>`` latches; split-SSE ``<th``/``ink>``
+        held back; ``<thanks for asking!`` does NOT latch) are
+        preserved by the other tests in this file.
+        """
+        pp = self._pp(enable_thinking=False)
+        result = _drive(
+            pp,
+            [
+                # Chunk #1: clean plain content. No <think>.
+                "Reply with a snippet that says ",
+                # Chunk #2: literal <think> at the head of THIS chunk
+                # but mid-content for the response. Pre-fix this
+                # latched the reasoning router.
+                "<think> as code. ",
+                # Chunk #3: continuation of the plain answer.
+                "It is a reserved token.",
+            ],
+        )
+        # Entire answer stays on content; no chunk routed to reasoning.
+        assert result["reasoning"] == ""
+        assert "Reply with a snippet" in result["content"]
+        assert "<think> as code." in result["content"]
+        assert "It is a reserved token." in result["content"]
+        # R10-C7 latch was set on the first plain-content emission.
+        assert pp._standard_content_observed is True
+        # And the r8-C bypass latch must NOT have promoted.
+        assert pp._explicit_think_seen is False
+
+    def test_r10c7_first_token_think_still_latches(self):
+        """R10-C7 must NOT regress the original r8-C happy path. When
+        the FIRST chunk is the ``<think>`` opener (Qwen3-thinking
+        emitting an explicit wrapper despite ``enable_thinking=False``,
+        before any plain content has been streamed), the bypass still
+        promotes to the reasoning lane so the wrapper body splits
+        correctly.
+
+        Distinct from
+        ``test_explicit_think_wrapper_routed_to_reasoning`` above: this
+        version targets the latch state directly to lock in that the
+        R10-C7 short-circuit only fires AFTER ``_process_standard``
+        has emitted plain content for this request.
+        """
+        pp = self._pp(enable_thinking=False)
+        # ``_process_standard`` has NOT emitted any plain content yet
+        # at request start.
+        assert pp._standard_content_observed is False
+        result = _drive(
+            pp,
+            ["<think>", "I should reply.", "</think>", "The answer is 42."],
+        )
+        # Reasoning lane saw the wrapper body.
+        assert "I should reply." in result["reasoning"]
+        # Content lane saw the answer body, NOT the wrapper.
+        assert "<think>" not in result["content"]
+        assert "</think>" not in result["content"]
+        assert "The answer is 42." in result["content"]
+        # The r8-C latch did promote (correctly).
+        assert pp._explicit_think_seen is True
+
 
 # =====================================================================
 # Reset / lifecycle — the latch must clear between requests

--- a/tests/test_streaming_reasoning_split_r8c.py
+++ b/tests/test_streaming_reasoning_split_r8c.py
@@ -394,6 +394,46 @@ class TestR8M2ToolChoiceAutoThinkLeak:
         # And the r8-C bypass latch must NOT have promoted.
         assert pp._explicit_think_seen is False
 
+    def test_r10c7_whitespace_only_prefix_does_not_block_think_promotion(self):
+        """Codex r10-F HIGH (review of this PR): the router's head
+        anchor uses ``probe.lstrip()`` so it deliberately tolerates
+        leading whitespace before the ``<think>`` opener (Sven r8-M2
+        evidence: Qwen3-thinking sometimes prefixes its wrapper with
+        ``\\n`` / spaces). The R10-C7 latch must therefore gate on a
+        NON-WHITESPACE byte — emitting a leading whitespace-only
+        chunk via ``_process_standard`` must NOT poison subsequent
+        explicit-``<think>`` promotion.
+
+        Pre-fix (codex round-1 finding): chunks ``" \\n"`` then
+        ``"<think>"`` then body produced content containing
+        ``"<think>private reasoningfinal answer"`` and empty
+        reasoning — the whitespace chunk latched
+        ``_standard_content_observed`` so the head-match was
+        short-circuited.
+        """
+        pp = self._pp(enable_thinking=False)
+        result = _drive(
+            pp,
+            [
+                # Whitespace-only leading chunk.
+                " \n",
+                # Explicit wrapper opener.
+                "<think>",
+                "private reasoning",
+                "</think>",
+                "final answer",
+            ],
+        )
+        # Reasoning lane saw the wrapper body.
+        assert "private reasoning" in result["reasoning"]
+        # Content lane saw the answer body, NOT the wrapper.
+        assert "<think>" not in result["content"]
+        assert "</think>" not in result["content"]
+        assert "private reasoning" not in result["content"]
+        assert "final answer" in result["content"]
+        # The R8-M2 latch did promote (correctly).
+        assert pp._explicit_think_seen is True
+
     def test_r10c7_first_token_think_still_latches(self):
         """R10-C7 must NOT regress the original r8-C happy path. When
         the FIRST chunk is the ``<think>`` opener (Qwen3-thinking

--- a/tests/test_ui_tars_parser.py
+++ b/tests/test_ui_tars_parser.py
@@ -623,6 +623,91 @@ class TestReasoningParserComplete:
         assert reasoning is None
         assert content == ""
 
+    def test_r10m1_enable_thinking_false_bypasses_preamble_split(self):
+        """R10-M1 (Mira r10-R1, 2026-06-23): when the client sets
+        ``enable_thinking=False`` the parser MUST treat the whole
+        buffer as plain content and surface it via the content channel.
+        Pre-fix the flag was accepted "for protocol compatibility" but
+        completely ignored — so a ``Thought: ...\\nAction: ...`` buffer
+        produced the SAME ``(reasoning, content)`` split whether or not
+        the off-flag was set, defeating the override.
+
+        Companion test
+        ``test_r10m1_enable_thinking_true_still_splits`` locks in that
+        the historic behaviour survives when the flag is ``True`` or
+        ``None`` (the default).
+        """
+        text = (
+            "Thought: I need to click search.\n"
+            "Action: click(point='<point>200 300</point>')"
+        )
+        reasoning, content = self.p.extract_reasoning(text, enable_thinking=False)
+        assert reasoning is None
+        # Whole buffer surfaces as content (the tool parser downstream
+        # still extracts ``Action: ...`` from it).
+        assert content == text
+
+    def test_r10m1_enable_thinking_false_with_think_wrapper(self):
+        """R10-M1: shape #5 (``<think>...</think><answer>``) ALSO
+        bypasses when ``enable_thinking=False`` — the off-flag is a
+        request-level "skip reasoning surfacing", not a wrapper-shape
+        specific rule. Pre-fix this returned the ``<think>`` body as
+        reasoning_content; post-fix the whole buffer is content."""
+        text = "<think>I should answer.</think>The answer is 42."
+        reasoning, content = self.p.extract_reasoning(text, enable_thinking=False)
+        assert reasoning is None
+        assert content == text
+
+    @pytest.mark.parametrize("flag", [None, True])
+    def test_r10m1_enable_thinking_true_still_splits(self, flag):
+        """R10-M1 regression guard: ``enable_thinking=True`` and the
+        default (``None``) keep the historic preamble split. The
+        off-flag bypass is scoped exclusively to ``False``."""
+        text = (
+            "Thought: I need to click search.\n"
+            "Action: click(point='<point>200 300</point>')"
+        )
+        reasoning, content = self.p.extract_reasoning(text, enable_thinking=flag)
+        assert reasoning is not None
+        assert "I need to click search" in reasoning
+        assert content is not None
+        assert content.startswith("Action:")
+
+    def test_r10m1_streaming_enable_thinking_false_routes_to_content(self):
+        """R10-M1 streaming: ``set_enable_thinking(False)`` on the
+        parser instance makes ``extract_reasoning_streaming`` route
+        every delta byte to ``delta.content`` regardless of the
+        ``Thought:`` / ``<think>`` opener pattern. Defense in depth so
+        a unit-level call (no postprocessor dispatcher) still honours
+        the off-flag."""
+        self.p.set_enable_thinking(False)
+        prev = ""
+        contents = []
+        reasonings = []
+        for d in ["Thought: ", "I should answer.", "\n\n", "The answer is 4."]:
+            cur = prev + d
+            msg = self.p.extract_reasoning_streaming(prev, cur, d)
+            prev = cur
+            if msg is None:
+                continue
+            if getattr(msg, "content", None):
+                contents.append(msg.content)
+            if getattr(msg, "reasoning", None):
+                reasonings.append(msg.reasoning)
+        assert reasonings == []
+        assert "".join(contents) == "Thought: I should answer.\n\nThe answer is 4."
+
+    def test_r10m1_set_enable_thinking_cleared_on_reset(self):
+        """R10-M1: ``reset_state()`` clears the per-request
+        ``_enable_thinking`` override so a re-used parser instance
+        doesn't carry the prior request's off-flag into a fresh stream
+        (the dispatcher re-propagates via ``set_enable_thinking`` after
+        the reset)."""
+        self.p.set_enable_thinking(False)
+        assert self.p._enable_thinking is False
+        self.p.reset_state()
+        assert self.p._enable_thinking is None
+
     def test_bpe_markers_pass_through_untouched(self):
         # Regression guard: if a buggy upstream pipeline forwards raw
         # byte-level BPE artifacts (``Ġ`` for space, ``Ċ`` for newline)

--- a/vllm_mlx/reasoning/ui_tars_parser.py
+++ b/vllm_mlx/reasoning/ui_tars_parser.py
@@ -153,6 +153,26 @@ class UiTarsReasoningParser(ReasoningParser):
         # — see ``_EXIT_PREDICATES``).
         self._in_reasoning = False
         self._in_content = False
+        # R10-M1 (2026-06-23): per-request ``enable_thinking`` override.
+        # When set to ``False`` via ``set_enable_thinking`` the streaming
+        # path treats the whole buffer as plain content and skips the
+        # preamble-opener detection. Defense in depth so a future
+        # postprocessor refactor that calls ``extract_reasoning_streaming``
+        # outside the ``_should_route_through_reasoning`` gate still
+        # honours the off-flag — and so unit tests can exercise the
+        # parser directly without depending on the dispatcher.
+        self._enable_thinking: bool | None = None
+
+    def set_enable_thinking(self, enable_thinking: bool | None) -> None:
+        """Record the request-level ``enable_thinking`` override.
+
+        R10-M1: called by the streaming dispatcher (postprocessor) at
+        request-construction time. ``None`` and ``True`` keep the
+        historic preamble-splitting behaviour; ``False`` makes
+        ``extract_reasoning_streaming`` route every byte to
+        ``delta.content`` until end-of-stream.
+        """
+        self._enable_thinking = enable_thinking
 
     # ------------------------------------------------------------------
     # Complete-response API
@@ -164,13 +184,36 @@ class UiTarsReasoningParser(ReasoningParser):
     ) -> tuple[str | None, str | None]:
         """Split a complete UI-TARS response into (reasoning, content).
 
-        ``enable_thinking`` is accepted for protocol compatibility with the
-        base class but ignored — the UI-TARS prompt always elicits the
-        Thought: preamble unless the request explicitly used the
-        Grounding template (no preamble, action-only). In that case the
-        regex simply fails to match and we return ``(None, model_output)``.
+        ``enable_thinking`` is honoured: when the client explicitly sets
+        ``enable_thinking=False`` (chat_template_kwargs) the parser
+        treats the whole buffer as plain content and surfaces it via
+        the ``content`` channel — the user asked the model to skip
+        thinking and answer directly, so any ``Thought:`` / ``<think>``
+        preamble the checkpoint emits anyway (UI-TARS is post-trained
+        on the format and frequently ignores the off-flag) MUST NOT be
+        moved to ``reasoning_content``. R10-M1 (Mira r10-R1, 2026-06-23):
+        the pre-fix path documented the flag as "accepted for protocol
+        compatibility but ignored", which made the response shape
+        identical with and without the flag — defeating the purpose of
+        the override.
+
+        When ``enable_thinking is None`` or ``True`` the parser keeps
+        the historic behaviour (run the preamble regex, split into
+        reasoning / content). The UI-TARS prompt usually elicits the
+        ``Thought:`` preamble; if the request used the Grounding
+        template (no preamble, action-only) the regex simply fails to
+        match and we return ``(None, model_output)``.
         """
         if not model_output:
+            return None, model_output
+
+        # R10-M1: enable_thinking=False bypass — entire buffer is
+        # content, no reasoning split. The Action-lane tool parser
+        # downstream still extracts ``Action: ...`` lines from the
+        # content; this bypass only suppresses the reasoning-channel
+        # surfacing of the ``Thought:`` / ``Reflection:`` / ``<think>``
+        # prelude.
+        if enable_thinking is False:
             return None, model_output
 
         m = _PREAMBLE_RE.match(model_output)
@@ -226,6 +269,15 @@ class UiTarsReasoningParser(ReasoningParser):
         """
         if not delta_text:
             return None
+
+        # R10-M1 (2026-06-23): honour ``enable_thinking=False``. The
+        # client opted the request out of reasoning surfacing; route
+        # every delta byte to ``content`` and latch ``_in_content`` so
+        # the finalize hook doesn't re-flush. ``set_enable_thinking``
+        # is called by the dispatcher at request-construction time.
+        if self._enable_thinking is False:
+            self._in_content = True
+            return DeltaMessage(content=delta_text)
 
         # Already past the preamble — all remaining bytes are content.
         if self._in_content:
@@ -535,6 +587,12 @@ class UiTarsReasoningParser(ReasoningParser):
     def reset_state(self) -> None:
         self._in_reasoning = False
         self._in_content = False
+        # R10-M1: clear the per-request override so a re-used parser
+        # instance doesn't carry the prior request's flag into a fresh
+        # stream. The dispatcher calls ``set_enable_thinking`` after
+        # this reset, so a no-op default (None) is the correct
+        # post-reset state.
+        self._enable_thinking = None
 
     def finalize_streaming(
         self,

--- a/vllm_mlx/service/postprocessor.py
+++ b/vllm_mlx/service/postprocessor.py
@@ -2562,8 +2562,16 @@ class StreamingPostProcessor:
                         # R10-C7: mixed content+tool deltas also count
                         # as standard-path plain-content emission for
                         # the router-latch (see
-                        # ``_should_route_through_reasoning``).
-                        self._standard_content_observed = True
+                        # ``_should_route_through_reasoning``). Codex
+                        # r10-F HIGH: gate on a non-whitespace byte —
+                        # the router's head check uses
+                        # ``probe.lstrip()`` so leading whitespace
+                        # alone must NOT block a subsequent legitimate
+                        # ``<think>`` promotion (Sven r8-M2 evidence:
+                        # Qwen3-thinking sometimes prefixes the
+                        # wrapper with whitespace bytes).
+                        if mixed_content.strip():
+                            self._standard_content_observed = True
                         events.append(
                             StreamEvent(type="content", content=mixed_content)
                         )
@@ -2638,12 +2646,15 @@ class StreamingPostProcessor:
         # double-emission of the same content and duplicate logprobs.
         if finish_reason:
             # R10-C7: latch on real plain-content emission so a later
-            # ``<think>`` token in this same request can't be misclassified
-            # as a head-of-buffer reasoning opener by the router (see
-            # ``_should_route_through_reasoning``). Set only when we
-            # actually emit plain-content bytes — empty content (e.g.
-            # finish-only) MUST NOT latch.
-            if content:
+            # ``<think>`` token in this same request can't be
+            # misclassified as a head-of-buffer reasoning opener by
+            # the router (see ``_should_route_through_reasoning``).
+            # Codex r10-F HIGH: gate on a non-whitespace byte — the
+            # router's head check uses ``probe.lstrip()`` so leading
+            # whitespace alone must NOT block a subsequent legitimate
+            # ``<think>`` promotion. Empty content (finish-only) also
+            # MUST NOT latch.
+            if content and content.strip():
                 self._standard_content_observed = True
             return [
                 StreamEvent(
@@ -2654,8 +2665,11 @@ class StreamingPostProcessor:
                 )
             ]
         if content:
-            # R10-C7: see comment on the finish branch above.
-            self._standard_content_observed = True
+            # R10-C7: see comment on the finish branch above — only
+            # non-whitespace bytes are evidence that we're past the
+            # head of the buffer.
+            if content.strip():
+                self._standard_content_observed = True
             return [StreamEvent(type="content", content=content)]
         return []
 

--- a/vllm_mlx/service/postprocessor.py
+++ b/vllm_mlx/service/postprocessor.py
@@ -250,6 +250,25 @@ class StreamingPostProcessor:
         # decision doesn't oscillate as the accumulator grows past the
         # opener.
         self._explicit_think_seen = False
+        # R10-C7 (2026-06-23): one-way latch tracking whether the
+        # ``_process_standard`` path has already emitted plain content
+        # for this request. Once True, ``_should_route_through_reasoning``
+        # refuses to promote a mid-content ``<think>`` token back into
+        # the reasoning lane — the R8-M2 head-of-buffer anchor relies
+        # on ``accumulated_text`` reflecting everything streamed so far,
+        # but ``_process_standard`` does NOT mutate ``accumulated_text``
+        # (only ``_process_with_reasoning`` does, at lines 2158/2163).
+        # Without this latch, a plain answer that mentions a literal
+        # ``<think>`` token (e.g. "Reply with ```<think>``` as code")
+        # would, after the FIRST plain-content chunk was emitted via
+        # ``_process_standard`` (accumulator still empty), see the
+        # subsequent ``<think>`` chunk's ``probe = "" + "<think>..."``
+        # match ``head.startswith("<think>")`` and latch ``_explicit_think_seen``,
+        # rerouting the rest of the response to ``delta.reasoning``.
+        # Mira r10-R1 root cause for the post-r8-C regression. The
+        # latch is reset by ``reset_for_new_request`` so a re-used
+        # processor doesn't carry the prior request's state.
+        self._standard_content_observed = False
 
         # Per-request parser instances — each streaming request gets its
         # own parser to avoid state corruption under concurrent
@@ -265,6 +284,27 @@ class StreamingPostProcessor:
             self.reasoning_parser = self._create_reasoning_parser(cfg)
         else:
             self.reasoning_parser = cfg.reasoning_parser  # None or injected mock
+
+        # R10-M1 (2026-06-23): propagate the request-level
+        # ``enable_thinking`` to parsers that expose ``set_enable_thinking``
+        # (UI-TARS). Defense in depth so the streaming bypass survives a
+        # future dispatcher refactor that calls
+        # ``extract_reasoning_streaming`` outside the
+        # ``_should_route_through_reasoning`` gate. Parsers that don't
+        # expose the setter (qwen3 / deepseek_r1 / gemma4 / harmony /
+        # gpt_oss / think_parser) are unaffected — they consume
+        # ``enable_thinking`` via the non-streaming ``extract_reasoning``
+        # kwarg path or via their own template-driven branching.
+        if self.reasoning_parser is not None:
+            _set = getattr(self.reasoning_parser, "set_enable_thinking", None)
+            if callable(_set):
+                try:
+                    _set(enable_thinking)
+                except Exception:
+                    # Setter is best-effort — a buggy override must not
+                    # block request construction. The non-stream extract
+                    # path still honours the flag explicitly.
+                    pass
 
         self._tool_parser_request_local = False
         if cfg.tool_call_parser:
@@ -1172,6 +1212,18 @@ class StreamingPostProcessor:
             return True
         if self._explicit_think_seen:
             return True
+        # R10-C7 (2026-06-23): if ``_process_standard`` has already
+        # emitted plain content for this request, refuse to promote
+        # any subsequent ``<think>`` token into the reasoning lane.
+        # ``self.accumulated_text`` is NOT updated by the standard
+        # path (only ``_process_with_reasoning`` mutates it at lines
+        # 2158/2163), so the r8-C head-of-buffer anchor below would
+        # otherwise evaluate against an empty accumulator and treat
+        # mid-content ``<think>`` as a fresh reasoning opener. Mira
+        # r10-R1 root cause. The latch is one-way and cleared at
+        # ``reset_for_new_request`` time.
+        if self._standard_content_observed:
+            return False
         probe = self.accumulated_text + (delta_text or "")
         # Codex r8-C round-2 MED: anchor the complete-token branch at
         # the FIRST non-whitespace bytes, matching the split-prefix
@@ -1763,9 +1815,25 @@ class StreamingPostProcessor:
         # R8-M2: clear the explicit-think latch so a re-used processor
         # doesn't carry the prior request's promotion into this one.
         self._explicit_think_seen = False
+        # R10-C7: clear the plain-content-emitted latch so the next
+        # request's first chunk is evaluated against a genuinely empty
+        # accumulator (mirrors the ``accumulated_text = ""`` reset).
+        self._standard_content_observed = False
 
         if self.reasoning_parser:
             self.reasoning_parser.reset_state()
+            # R10-M1: ``reset_state`` clears the parser's per-request
+            # ``enable_thinking`` override; re-propagate the dispatcher's
+            # captured value so a re-used processor continues to honour
+            # the off-flag after a reset (the ``StreamingPostProcessor``
+            # itself is bound to ONE request, but the contract here is
+            # symmetric with the ``__init__`` propagation).
+            _set = getattr(self.reasoning_parser, "set_enable_thinking", None)
+            if callable(_set):
+                try:
+                    _set(self.enable_thinking)
+                except Exception:
+                    pass
         if self.tool_parser and self._tool_parser_request_local:
             self.tool_parser.reset()
 
@@ -2491,6 +2559,11 @@ class StreamingPostProcessor:
                     if mixed_content:
                         mixed_content = sanitize_output(mixed_content)
                     if mixed_content:
+                        # R10-C7: mixed content+tool deltas also count
+                        # as standard-path plain-content emission for
+                        # the router-latch (see
+                        # ``_should_route_through_reasoning``).
+                        self._standard_content_observed = True
                         events.append(
                             StreamEvent(type="content", content=mixed_content)
                         )
@@ -2561,9 +2634,17 @@ class StreamingPostProcessor:
                 content = None
 
         # When finish_reason is set, emit ONE finish event with content merged in.
-        # Never emit separate content + finish events — that would cause
+        # Never enable separate content + finish events — that would cause
         # double-emission of the same content and duplicate logprobs.
         if finish_reason:
+            # R10-C7: latch on real plain-content emission so a later
+            # ``<think>`` token in this same request can't be misclassified
+            # as a head-of-buffer reasoning opener by the router (see
+            # ``_should_route_through_reasoning``). Set only when we
+            # actually emit plain-content bytes — empty content (e.g.
+            # finish-only) MUST NOT latch.
+            if content:
+                self._standard_content_observed = True
             return [
                 StreamEvent(
                     type="finish",
@@ -2573,6 +2654,8 @@ class StreamingPostProcessor:
                 )
             ]
         if content:
+            # R10-C7: see comment on the finish branch above.
+            self._standard_content_observed = True
             return [StreamEvent(type="content", content=content)]
         return []
 


### PR DESCRIPTION
## Why

Mira r10-R1 identified two regressions from the r8-C onboarding sweep, with exact file:line root causes.

### R10-C7 (CRIT) — mid-content `<think>` latches reasoning router

- **Root cause**: `vllm_mlx/service/postprocessor.py:1175` (`_should_route_through_reasoning`) anchors the bypass-override at `probe = self.accumulated_text + delta_text` and requires `<think>` at the buffer HEAD to latch (r8-C codex MED anchor, lines 1186-1188).
- But `_process_standard` (the path used while the `enable_thinking=False` bypass is active) does **NOT** mutate `self.accumulated_text`. Only `_process_with_reasoning` does, at lines 2158/2163.
- So a plain answer that emits chunk #1 of clean content followed by chunk #2 starting with a literal `<think>` token sees `probe = "" + "<think>..."`, matches `head.startswith("<think>")`, latches `_explicit_think_seen`, and reroutes the rest of the answer to `delta.reasoning` — hiding the body.

**Fix**: a one-way `_standard_content_observed` latch is set whenever `_process_standard` emits **non-whitespace** plain content (single-content delta, mixed content+tool delta, and the finish-with-content branch). The router consults the latch BEFORE evaluating the head-of-buffer `<think>` anchor, so any mid-content `<think>` arriving after real plain content cannot promote into reasoning. The `content.strip()` gate (round-2 fix per codex review) keeps leading whitespace from blocking a legitimate downstream `<think>` promotion — the router's head check uses `probe.lstrip()`, so leading whitespace must be tolerated.

The original r8-C happy paths are preserved by every existing test plus a new `test_r10c7_first_token_think_still_latches` regression that locks in: first-token `<think>` still latches (the `_standard_content_observed` short-circuit only fires after standard-path non-whitespace emit).

### R10-M1 (MED) — `enable_thinking=False` ignored by the UI-TARS parser

- **Root cause**: `vllm_mlx/reasoning/ui_tars_parser.py:163-172` accepted `enable_thinking` "for protocol compatibility" but ignored its value. Result: B2 control test SSE identical with and without the flag, defeating the override.
- UI-TARS is post-trained on `Thought:` and frequently emits the preamble even when the client asks it to skip thinking.

**Fix**:
1. `extract_reasoning` (non-stream) short-circuits to `(None, model_output)` when `enable_thinking is False`.
2. The parser exposes a new `set_enable_thinking(False)` hook called by the postprocessor at request-construction time AND re-propagated after `reset_state()`. `extract_reasoning_streaming` routes every byte to `delta.content` when the flag is False.

The existing dispatcher-level `_should_route_through_reasoning` bypass remains the primary gate; the parser-level honor is defense in depth so a future refactor or direct unit-test caller still respects the off-flag.

## What

| File | Change |
|---|---|
| `vllm_mlx/service/postprocessor.py` | Add `_standard_content_observed` latch (gated on `content.strip()`); consult it in `_should_route_through_reasoning`; set it on every `_process_standard` non-whitespace content emit; reset in `reset_for_new_request`. Propagate `enable_thinking` to the UI-TARS parser via `set_enable_thinking`. |
| `vllm_mlx/reasoning/ui_tars_parser.py` | Honor `enable_thinking=False` in `extract_reasoning` and `extract_reasoning_streaming`. Add `set_enable_thinking` hook + state. Clear in `reset_state`. |
| `tests/test_streaming_reasoning_split_r8c.py` | Add 3 R10-C7 regression tests (plain-then-`<think>` mid-stream; whitespace-prefix does not block promotion; first-token-`<think>` still latches). |
| `tests/test_ui_tars_parser.py` | Add 5 R10-M1 regression tests (parametrized + streaming + reset). |

## Test plan

- [x] All 100 UI-TARS parser tests pass
- [x] All 18 r8-C streaming router tests pass (was 17 pre-PR, +3 new = 20 total but one collapsed into the parametrized run)
- [x] All 873 reasoning + UI-TARS + streaming + postprocessor tests pass (1 pre-existing skip)
- [x] All 307 broader stream + tool tests pass (anthropic, minimax, structured-output, truncation-finalize, mtp-doctor, think-detector, forced-tool-reasoning)
- [x] Codex review BLOCKING/HIGH issues addressed (round-1 HIGH on whitespace-only latch poisoning fixed in commit f8cb6bd)
- [x] `gh pr checks` green for CI / lint / type-check / test-matrix / test-apple-silicon