### PR TITLE
fix(audio): r10-A — audio-serve-mode + comprehensive alias registry (R10-C1)

### DIFF
--- a/docs/guides/audio.md
+++ b/docs/guides/audio.md
@@ -3,8 +3,62 @@
 rapid-mlx supports audio processing using [mlx-audio](https://github.com/Blaizzy/mlx-audio), providing:
 
 - **STT (Speech-to-Text)**: Whisper, Parakeet
-- **TTS (Text-to-Speech)**: Kokoro, Chatterbox, VibeVoice, VoxCPM
+- **TTS (Text-to-Speech)**: Kokoro, Chatterbox, VibeVoice, VoxCPM, Dia
 - **Audio Processing**: SAM-Audio (voice separation)
+
+## Supported Aliases (R10-C1)
+
+`rapid-mlx serve <alias>` recognizes the audio alias surface below and routes the request to the audio engines (skipping the text-LM loader). Both the short alias and the full HuggingFace id work — pasting a full HF id from `mlx-community/...` of an audio model takes the audio path automatically.
+
+| Alias | Type | HuggingFace id |
+| --- | --- | --- |
+| `kokoro` (aka `kokoro-82m`, `kokoro-82m-bf16`) | TTS | `mlx-community/Kokoro-82M-bf16` |
+| `kokoro-4bit` / `kokoro-82m-4bit` | TTS | `mlx-community/Kokoro-82M-4bit` |
+| `kokoro-8bit` / `kokoro-82m-8bit` | TTS | `mlx-community/Kokoro-82M-8bit` |
+| `chatterbox` | TTS | `mlx-community/chatterbox-turbo-fp16` |
+| `chatterbox-4bit` | TTS | `mlx-community/chatterbox-turbo-4bit` |
+| `vibevoice` / `vibevoice-realtime` | TTS | `mlx-community/VibeVoice-Realtime-0.5B-4bit` |
+| `voxcpm` | TTS | `mlx-community/VoxCPM1.5` |
+| `dia` | TTS | `mlx-community/Dia-1.6B-4bit` |
+| `whisper` / `whisper-1` / `whisper-large-v3` | STT | `mlx-community/whisper-large-v3-mlx` |
+| `whisper-large-v3-turbo` | STT | `mlx-community/whisper-large-v3-turbo` |
+| `whisper-medium` / `-small` / `-base` / `-tiny` | STT | `mlx-community/whisper-{size}-mlx` |
+| `parakeet` / `parakeet-tdt-0.6b` | STT | `mlx-community/parakeet-tdt-0.6b-v2` |
+| `parakeet-v3` / `parakeet-tdt-0.6b-v3` | STT | `mlx-community/parakeet-tdt-0.6b-v3` |
+
+Run `rapid-mlx models` to see the full live list (the section header reads "Audio models" with `[audio:tts]` / `[audio:stt]` tags).
+
+Audio engines load lazily on the first `/v1/audio/*` request — `rapid-mlx serve` returns as soon as the FastAPI app is bound, with no boot-time weight download.
+
+### TTS quick start
+
+```bash
+# Boot the server with Kokoro
+rapid-mlx serve kokoro
+# Synthesize speech (OpenAI-compatible)
+curl -s http://localhost:8000/v1/audio/speech \
+  -H "Content-Type: application/json" \
+  -d '{"model": "kokoro", "input": "Hello from rapid-mlx", "voice": "af_heart"}' \
+  --output hello.wav
+```
+
+### STT quick start
+
+```bash
+# Boot with Whisper
+rapid-mlx serve whisper-large-v3
+# Transcribe (OpenAI-compatible)
+curl -s http://localhost:8000/v1/audio/transcriptions \
+  -F "model=whisper-large-v3" \
+  -F "file=@speech.mp3"
+```
+
+If `mlx-audio` is missing, the boot guard exits with rc=2 and the install hint:
+
+```
+error: model 'kokoro' is an audio alias and requires the optional `mlx-audio` dependency (shipped with the [audio] extra).
+Install with: pip install 'rapid-mlx[audio]'
+```
 
 ## Installation
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -97,7 +97,17 @@ rapid-mlx serve qwen3.5-9b-4bit \
   --api-key your-secret-key \
   --rate-limit 60 \
   --timeout 120
+
+# Audio models (requires the [audio] extra) — see docs/guides/audio.md
+rapid-mlx serve kokoro                    # TTS via /v1/audio/speech
+rapid-mlx serve whisper-large-v3          # STT via /v1/audio/transcriptions
+rapid-mlx serve parakeet                  # English STT (NVIDIA Parakeet)
+rapid-mlx serve mlx-community/Kokoro-82M-bf16   # Full HF id also routes to audio
 ```
+
+#### Audio aliases (R10-C1)
+
+Pass any of the audio aliases listed in `rapid-mlx models` (the "Audio models" section) to serve the audio-only `/v1/audio/*` endpoints. The audio path skips the text-LM loader entirely — engines load lazily on the first request. See the [audio guide](../guides/audio.md) for the full TTS / STT alias matrix and quickstart examples.
 
 ### Security
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.8.11"
+version = "0.8.12"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/tests/test_audio_alias_registry.py
+++ b/tests/test_audio_alias_registry.py
@@ -1,0 +1,538 @@
+# SPDX-License-Identifier: Apache-2.0
+"""R10-C1 — audio alias registry + audio-serve-mode dispatch.
+
+Bo r10-R1 found 0/8 audio aliases boot on 0.8.11. Root cause traced
+to ``vllm_mlx.cli.serve_command``:
+
+* Short aliases (``kokoro``, ``whisper``, ``parakeet``...) had no
+  resolution at all in serve, so ``_ensure_model_downloaded`` queried
+  HuggingFace for ``hf.co/kokoro`` and 404'd.
+* Full HF ids of audio repos (``mlx-community/Kokoro-82M-bf16``)
+  downloaded fine but then crashed inside ``mlx_lm.load_model``
+  because audio repos don't ship safetensors.
+
+Codex r8-A r3 predicted this exact regression; Bo r9 + r10 confirmed
+it stayed broken across 2 releases.
+
+R10-C1 introduces a single source of truth (``vllm_mlx/audio/aliases.json``)
+and an audio-serve-mode fork in ``serve_command`` that routes audio
+names to the audio engines and skips the text-LM loader entirely.
+
+These tests pin the contract:
+
+* Registry resolution covers every documented major audio alias.
+* HF-id reverse lookup works (full ids are first-class).
+* serve_command forks BEFORE the text-LM loader runs.
+* ``rapid-mlx models`` advertises the audio alias surface.
+* The boot guard still fires for missing-extra installs (no
+  regression of R6-H4).
+* Text models do NOT trip the audio path (no regression of the
+  ~80 text aliases).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from argparse import Namespace
+from unittest.mock import patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# A) Registry resolution table
+# ---------------------------------------------------------------------------
+
+
+class TestAudioAliasRegistry:
+    """The registry is the single source of truth — every documented
+    short alias and major HF id must resolve correctly.
+    """
+
+    @pytest.mark.parametrize(
+        "alias,expected_type,expected_hf_id",
+        [
+            # Kokoro family — TTS.
+            ("kokoro", "tts", "mlx-community/Kokoro-82M-bf16"),
+            ("kokoro-82m", "tts", "mlx-community/Kokoro-82M-bf16"),
+            ("kokoro-82m-bf16", "tts", "mlx-community/Kokoro-82M-bf16"),
+            ("kokoro-82m-4bit", "tts", "mlx-community/Kokoro-82M-4bit"),
+            ("kokoro-82m-8bit", "tts", "mlx-community/Kokoro-82M-8bit"),
+            ("kokoro-4bit", "tts", "mlx-community/Kokoro-82M-4bit"),
+            ("kokoro-8bit", "tts", "mlx-community/Kokoro-82M-8bit"),
+            # Chatterbox.
+            ("chatterbox", "tts", "mlx-community/chatterbox-turbo-fp16"),
+            ("chatterbox-4bit", "tts", "mlx-community/chatterbox-turbo-4bit"),
+            # VibeVoice.
+            ("vibevoice", "tts", "mlx-community/VibeVoice-Realtime-0.5B-4bit"),
+            (
+                "vibevoice-realtime",
+                "tts",
+                "mlx-community/VibeVoice-Realtime-0.5B-4bit",
+            ),
+            # VoxCPM.
+            ("voxcpm", "tts", "mlx-community/VoxCPM1.5"),
+            # Dia.
+            ("dia", "tts", "mlx-community/Dia-1.6B-4bit"),
+            # Whisper family — STT.
+            ("whisper", "stt", "mlx-community/whisper-large-v3-mlx"),
+            ("whisper-1", "stt", "mlx-community/whisper-large-v3-mlx"),
+            ("whisper-large-v3", "stt", "mlx-community/whisper-large-v3-mlx"),
+            (
+                "whisper-large-v3-turbo",
+                "stt",
+                "mlx-community/whisper-large-v3-turbo",
+            ),
+            ("whisper-medium", "stt", "mlx-community/whisper-medium-mlx"),
+            ("whisper-small", "stt", "mlx-community/whisper-small-mlx"),
+            ("whisper-base", "stt", "mlx-community/whisper-base-mlx"),
+            ("whisper-tiny", "stt", "mlx-community/whisper-tiny-mlx"),
+            # Parakeet.
+            ("parakeet", "stt", "mlx-community/parakeet-tdt-0.6b-v2"),
+            ("parakeet-tdt-0.6b", "stt", "mlx-community/parakeet-tdt-0.6b-v2"),
+            (
+                "parakeet-tdt-0.6b-v2",
+                "stt",
+                "mlx-community/parakeet-tdt-0.6b-v2",
+            ),
+            ("parakeet-v3", "stt", "mlx-community/parakeet-tdt-0.6b-v3"),
+            (
+                "parakeet-tdt-0.6b-v3",
+                "stt",
+                "mlx-community/parakeet-tdt-0.6b-v3",
+            ),
+        ],
+    )
+    def test_alias_resolves_to_expected_hf_id(
+        self, alias, expected_type, expected_hf_id
+    ):
+        from vllm_mlx.audio.registry import resolve_audio_alias
+
+        entry = resolve_audio_alias(alias)
+        assert entry is not None, (
+            f"R10-C1 regression: alias {alias!r} returned None from "
+            f"the registry — the audio-serve-mode dispatcher in "
+            f"serve_command relies on this lookup to fork off the "
+            f"text path."
+        )
+        assert entry.type == expected_type, (
+            f"alias {alias!r} resolved to type {entry.type!r}, expected "
+            f"{expected_type!r}."
+        )
+        assert entry.hf_id == expected_hf_id, (
+            f"alias {alias!r} resolved to hf_id {entry.hf_id!r}, "
+            f"expected {expected_hf_id!r}."
+        )
+
+    @pytest.mark.parametrize(
+        "alias",
+        [
+            "KOKORO",
+            "Kokoro",
+            "WHISPER-LARGE-V3",
+            "Whisper-Tiny",
+            "PARAKEET",
+        ],
+    )
+    def test_alias_lookup_is_case_insensitive(self, alias):
+        """SDKs / docs frequently mix the case (the upstream HF repo
+        is ``Kokoro-82M-bf16``); both forms must resolve."""
+        from vllm_mlx.audio.registry import resolve_audio_alias
+
+        entry = resolve_audio_alias(alias)
+        assert entry is not None, alias
+
+    @pytest.mark.parametrize(
+        "hf_id",
+        [
+            "mlx-community/Kokoro-82M-bf16",
+            "mlx-community/Kokoro-82M-4bit",
+            "mlx-community/Kokoro-82M-8bit",
+            "mlx-community/whisper-large-v3-mlx",
+            "mlx-community/whisper-large-v3-turbo",
+            "mlx-community/whisper-tiny-mlx",
+            "mlx-community/whisper-base-mlx",
+            "mlx-community/parakeet-tdt-0.6b-v2",
+            "mlx-community/parakeet-tdt-0.6b-v3",
+            "mlx-community/chatterbox-turbo-fp16",
+            "mlx-community/chatterbox-turbo-4bit",
+            "mlx-community/VibeVoice-Realtime-0.5B-4bit",
+            "mlx-community/VoxCPM1.5",
+            "mlx-community/Dia-1.6B-4bit",
+        ],
+    )
+    def test_full_hf_id_resolves_to_audio_entry(self, hf_id):
+        """A user pasting ``mlx-community/Kokoro-82M-bf16`` into
+        ``rapid-mlx serve`` MUST be routed to audio mode (not text)
+        — pre-R10 this downloaded the repo successfully and then
+        crashed in ``mlx_lm.load_model`` because there's no
+        safetensors. The reverse-index canonical-alias choice is
+        intentionally NOT pinned (multiple aliases can map to the
+        same HF id; first-alias-wins is implementation detail), only
+        that resolution happens AT ALL and lands on a matching entry."""
+        from vllm_mlx.audio.registry import resolve_audio_alias
+
+        entry = resolve_audio_alias(hf_id)
+        assert entry is not None, (
+            f"Full HF id {hf_id!r} did NOT resolve — the audio-serve-"
+            f"mode dispatcher would fall through to the text loader, "
+            f"which is the exact Bo r10-R1 failure."
+        )
+        assert entry.hf_id == hf_id, (
+            f"HF id {hf_id!r} resolved to entry with hf_id "
+            f"{entry.hf_id!r} — reverse index returned the wrong entry."
+        )
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "",
+            None,
+            "qwen3.6-27b-4bit",
+            "qwen3.5-122b-mxfp4",
+            "ui-tars-1.5-7b-4bit",
+            "gemma-3-27b-4bit",
+            "embeddinggemma-300m-6bit",
+            "mlx-community/Qwen3.6-27B-4bit",
+            "mlx-community/Llama-3.3-70B-Instruct",
+        ],
+    )
+    def test_non_audio_names_return_none(self, name):
+        """Text + vision aliases MUST NOT resolve through the audio
+        registry — over-eager matching would route text models to
+        the audio loader."""
+        from vllm_mlx.audio.registry import resolve_audio_alias
+
+        assert resolve_audio_alias(name) is None, name
+
+    def test_registry_has_expected_minimum_size(self):
+        """The audio surface must cover the major models the brief
+        called out. Pinning the count prevents an accidental delete
+        from silently shrinking the surface."""
+        from vllm_mlx.audio.registry import list_audio_aliases
+
+        entries = list_audio_aliases()
+        assert len(entries) >= 20, (
+            f"audio registry shrunk to {len(entries)} aliases — "
+            f"R10-C1 contract requires the major TTS/STT families."
+        )
+
+    def test_registry_separates_tts_and_stt(self):
+        """Every entry has a ``type`` that's either 'tts' or 'stt'."""
+        from vllm_mlx.audio.registry import list_audio_aliases
+
+        kinds = {e.type for e in list_audio_aliases()}
+        assert kinds == {"tts", "stt"}, kinds
+
+    def test_route_alias_tables_built_from_registry(self):
+        """The STT/TTS alias maps in routes.audio mirror the registry
+        — a single JSON edit must reach every consumer.
+        """
+        from vllm_mlx.audio.registry import stt_aliases, tts_aliases
+        from vllm_mlx.routes.audio import STT_MODEL_ALIASES, TTS_MODEL_ALIASES
+
+        assert STT_MODEL_ALIASES == stt_aliases()
+        assert TTS_MODEL_ALIASES == tts_aliases()
+
+
+# ---------------------------------------------------------------------------
+# B) is_audio_model_alias — registry-first contract
+# ---------------------------------------------------------------------------
+
+
+class TestIsAudioModelAlias:
+    """Boot guard classifier must recognise every registered audio
+    alias AND maintain the legacy substring fallback for HF ids of
+    third-party audio engines that haven't been added to the registry
+    yet."""
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            # Registry hits.
+            "kokoro",
+            "kokoro-82m-bf16",
+            "kokoro-82m-8bit",
+            "whisper",
+            "whisper-1",
+            "parakeet",
+            "parakeet-tdt-0.6b",
+            "chatterbox",
+            "vibevoice",
+            "voxcpm",
+            "dia",
+            # Full HF ids.
+            "mlx-community/Kokoro-82M-bf16",
+            "mlx-community/whisper-tiny-mlx",
+            "mlx-community/parakeet-tdt-0.6b-v2",
+            # Substring-fallback (not in registry but contains an
+            # audio token — third-party ports must still trip the
+            # boot guard).
+            "mlx-community/whisper-japanese-asr",
+            "someuser/Kokoro-cantonese-fork",
+        ],
+    )
+    def test_audio_names_recognised(self, name):
+        from vllm_mlx.audio.probe import is_audio_model_alias
+
+        assert is_audio_model_alias(name), name
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "qwen3.6-27b-4bit",
+            "ui-tars-1.5-7b-4bit",
+            "mlx-community/Llama-3.3-70B-Instruct",
+            "",
+            None,
+        ],
+    )
+    def test_non_audio_names_ignored(self, name):
+        from vllm_mlx.audio.probe import is_audio_model_alias
+
+        assert not is_audio_model_alias(name), name
+
+
+# ---------------------------------------------------------------------------
+# C) Audio-serve-mode dispatch in serve_command
+# ---------------------------------------------------------------------------
+
+
+def _make_serve_args(model: str) -> Namespace:
+    return Namespace(
+        model=model,
+        embedding_model=None,
+        no_mllm=True,
+        mllm=False,
+        max_tokens=None,
+        api_key=None,
+        timeout=60,
+        max_request_bytes=None,
+        cors_origins=None,
+        rate_limit=0,
+        log_level="INFO",
+        host="127.0.0.1",
+        port=8000,
+        listen_fd=None,
+    )
+
+
+class TestAudioServeModeDispatch:
+    """``rapid-mlx serve kokoro`` (and every other audio alias /
+    audio HF id) MUST route to the audio path, skipping the text
+    loader. This is the headline R10-C1 fix.
+    """
+
+    def test_serve_kokoro_short_alias_routes_to_audio_mode(self):
+        """``serve kokoro`` -> _serve_audio_mode, NEVER touches
+        _ensure_model_downloaded with the unresolved alias."""
+        from vllm_mlx import cli
+
+        with patch.object(cli, "_serve_audio_mode") as mock_audio, patch.object(
+            cli, "_ensure_model_downloaded"
+        ) as mock_download, patch("vllm_mlx.server.load_model") as mock_load:
+            args = _make_serve_args("kokoro")
+            cli.serve_command(args)
+
+        assert mock_audio.called, (
+            "R10-C1 regression: serve_command did NOT route the "
+            "``kokoro`` alias to _serve_audio_mode. Pre-R10 the alias "
+            "fell through to _ensure_model_downloaded (HF 404)."
+        )
+        assert not mock_download.called, (
+            "Audio-mode must skip _ensure_model_downloaded — the audio "
+            "loader pulls weights on demand via the route handlers."
+        )
+        assert not mock_load.called, (
+            "Audio-mode must skip the text-LM load_model — calling it "
+            "with an audio repo crashes in mlx_lm because audio repos "
+            "don't ship safetensors."
+        )
+
+    @pytest.mark.parametrize(
+        "alias",
+        [
+            "kokoro",
+            "kokoro-82m",
+            "kokoro-82m-bf16",
+            "kokoro-82m-8bit",
+            "whisper",
+            "whisper-1",
+            "whisper-large-v3",
+            "whisper-tiny",
+            "parakeet",
+            "chatterbox",
+            "vibevoice",
+            "voxcpm",
+            # Full HF ids of audio models — same audio routing.
+            "mlx-community/Kokoro-82M-bf16",
+            "mlx-community/whisper-tiny-mlx",
+            "mlx-community/parakeet-tdt-0.6b-v2",
+        ],
+    )
+    def test_every_audio_name_takes_the_audio_fork(self, alias):
+        from vllm_mlx import cli
+
+        with patch.object(cli, "_serve_audio_mode") as mock_audio, patch.object(
+            cli, "_ensure_model_downloaded"
+        ) as mock_download:
+            args = _make_serve_args(alias)
+            cli.serve_command(args)
+
+        assert mock_audio.called, alias
+        assert not mock_download.called, alias
+
+    def test_serve_audio_mode_resolves_alias_to_hf_id(self):
+        """The audio fork stamps args.model with the resolved HF id
+        so audio routes / telemetry see a real repo path."""
+        from vllm_mlx import cli
+
+        captured = {}
+
+        def _capture(args, entry):
+            captured["args_model"] = args.model
+            captured["original_alias"] = args._original_alias
+            captured["entry_hf_id"] = entry.hf_id
+            captured["entry_type"] = entry.type
+
+        with patch.object(cli, "_serve_audio_mode", side_effect=_capture):
+            args = _make_serve_args("kokoro")
+            cli.serve_command(args)
+
+        assert captured["args_model"] == "mlx-community/Kokoro-82M-bf16"
+        assert captured["original_alias"] == "kokoro"
+        assert captured["entry_hf_id"] == "mlx-community/Kokoro-82M-bf16"
+        assert captured["entry_type"] == "tts"
+
+
+# ---------------------------------------------------------------------------
+# D) Text-model boot path must NOT regress
+# ---------------------------------------------------------------------------
+
+
+class TestTextBootDoesNotRegress:
+    """The most important negative test: text aliases must STILL
+    reach the text loader. A bug in the audio fork that routed every
+    model through audio would silently break ~80 text aliases.
+    """
+
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "qwen3.6-27b-4bit",
+            "qwen3.5-122b-mxfp4",
+            "gemma-3-27b-4bit",
+            "ui-tars-1.5-7b-4bit",
+            "mlx-community/Qwen3.6-27B-4bit",
+            "mlx-community/Llama-3.3-70B-Instruct",
+        ],
+    )
+    def test_text_model_does_not_take_audio_fork(self, model):
+        from vllm_mlx import cli
+
+        with patch.object(cli, "_serve_audio_mode") as mock_audio, patch(
+            "vllm_mlx._version_check.prompt_upgrade_if_available",
+            side_effect=SystemExit(0),
+        ):
+            args = _make_serve_args(model)
+            with pytest.raises(SystemExit):
+                cli.serve_command(args)
+
+        assert not mock_audio.called, (
+            f"Text alias {model!r} accidentally took the audio fork — "
+            f"this would break every text-LM boot."
+        )
+
+
+# ---------------------------------------------------------------------------
+# E) Boot guard install hint still fires when [audio] missing
+# ---------------------------------------------------------------------------
+
+
+class TestBootGuardStillFires:
+    """R6-H4 contract: when ``mlx_audio`` is missing, an audio alias
+    must exit 2 with the install hint BEFORE the audio fork runs.
+    R10-C1 must not weaken this guard."""
+
+    def test_missing_extra_exits_2_for_kokoro(self, monkeypatch, capsys):
+        real_find_spec = importlib.util.find_spec
+
+        def _find_spec(name, *a, **kw):
+            if name == "mlx_audio":
+                return None
+            return real_find_spec(name, *a, **kw)
+
+        monkeypatch.setattr(importlib.util, "find_spec", _find_spec)
+        # Reset the lane cache so the test sees the fresh probe.
+        from vllm_mlx.audio import probe
+
+        probe._reset_probe_cache()
+
+        from vllm_mlx import cli
+
+        args = _make_serve_args("kokoro")
+        with pytest.raises(SystemExit) as excinfo:
+            cli.serve_command(args)
+
+        assert excinfo.value.code == 2
+        err = capsys.readouterr().err
+        assert "kokoro" in err
+        assert "[audio]" in err
+        assert "pip install" in err
+
+
+# ---------------------------------------------------------------------------
+# F) rapid-mlx models advertises the audio surface
+# ---------------------------------------------------------------------------
+
+
+class TestModelsCommandListsAudio:
+    """``rapid-mlx models`` must surface the audio aliases so users
+    can discover them without reading the docs site. Pre-R10 the
+    listing was text-only (audio surface was zero rows)."""
+
+    def test_models_lists_kokoro_and_whisper_and_parakeet(self, capsys):
+        from argparse import Namespace
+
+        from vllm_mlx import cli
+
+        args = Namespace(cached=False)
+        cli.models_command(args)
+
+        out = capsys.readouterr().out
+        # Each of the registry's headline aliases shows up.
+        for alias in (
+            "kokoro",
+            "whisper-large-v3",
+            "parakeet",
+            "chatterbox",
+            "vibevoice",
+            "voxcpm",
+        ):
+            assert alias in out, (
+                f"R10-C1 regression: ``rapid-mlx models`` did not list "
+                f"the audio alias {alias!r}. The audio surface must be "
+                f"discoverable in-tool, not docs-only."
+            )
+
+        # The audio kind tag is present.
+        assert "[audio:tts]" in out
+        assert "[audio:stt]" in out
+        # The audio section header.
+        assert "Audio models" in out
+
+    def test_models_still_lists_text_aliases(self, capsys):
+        """Adding the audio section must not displace the text listing."""
+        from argparse import Namespace
+
+        from vllm_mlx import cli
+
+        args = Namespace(cached=False)
+        cli.models_command(args)
+
+        out = capsys.readouterr().out
+        # Sample text alias — pick a well-known one from aliases.json.
+        assert "qwen3.6" in out.lower() or "qwen3.5" in out.lower(), (
+            "Text alias listing disappeared after the audio section "
+            "was added — both must coexist."
+        )

--- a/tests/test_audio_alias_registry.py
+++ b/tests/test_audio_alias_registry.py
@@ -487,7 +487,94 @@ class TestBootGuardStillFires:
 
 
 # ---------------------------------------------------------------------------
-# F) rapid-mlx models advertises the audio surface
+# F) audio-serve-mode must sync server globals into ServerConfig
+# ---------------------------------------------------------------------------
+
+
+class TestAudioServeModeSyncsServerConfig:
+    """Codex r1 HIGH #1: ``_serve_audio_mode`` MUST call
+    ``server._sync_config()`` so the ``ServerConfig`` singleton that
+    the auth middleware reads from is populated with ``_api_key``,
+    ``_max_request_bytes``, ``_model_name``, etc. — exactly what
+    ``server.load_model`` does on the text path. Skipping this sync
+    means ``rapid-mlx serve kokoro --api-key SECRET`` would silently
+    accept unauthenticated /v1/audio/* requests because the
+    middleware reads ``cfg.api_key`` (still ``None``) instead of
+    ``server._api_key``.
+    """
+
+    def test_api_key_propagates_to_server_config(self):
+        """``--api-key`` must reach ``ServerConfig.api_key`` in audio mode."""
+        from vllm_mlx import cli, server
+        from vllm_mlx.config import get_config
+
+        # Clear any inherited state.
+        cfg = get_config()
+        cfg.api_key = None
+        server._api_key = None
+
+        with (
+            patch.object(cli, "_run_uvicorn"),
+            patch.object(cli, "_port_preflight_or_die"),
+        ):
+            args = _make_serve_args("kokoro")
+            args.api_key = "SECRET-r10c1"
+            cli.serve_command(args)
+
+        # The middleware reads from get_config(), not from server._api_key.
+        assert get_config().api_key == "SECRET-r10c1", (
+            "R10-C1 audio-serve-mode regression: ``--api-key`` did "
+            "NOT reach ``ServerConfig.api_key`` — the auth middleware "
+            "reads from the config singleton, so the audio endpoints "
+            "would be effectively unauthenticated. Codex r1 HIGH #1."
+        )
+
+    def test_model_name_propagates_to_server_config(self):
+        """``/v1/models`` reads ``cfg.model_name`` / ``cfg.model_alias``
+        — audio mode must populate both so the audio model shows up
+        in the listing."""
+        from vllm_mlx import cli, server
+        from vllm_mlx.config import get_config
+
+        cfg = get_config()
+        cfg.model_name = None
+        cfg.model_alias = None
+        server._model_name = None
+        server._model_alias = None
+
+        with (
+            patch.object(cli, "_run_uvicorn"),
+            patch.object(cli, "_port_preflight_or_die"),
+        ):
+            args = _make_serve_args("kokoro")
+            cli.serve_command(args)
+
+        # model_name = resolved HF id, model_alias = friendly short name.
+        assert get_config().model_name == "mlx-community/Kokoro-82M-bf16"
+        assert get_config().model_alias == "kokoro"
+
+    def test_max_request_bytes_propagates_to_server_config(self):
+        """``--max-request-bytes`` must reach the config singleton."""
+        from vllm_mlx import cli, server
+        from vllm_mlx.config import get_config
+
+        cfg = get_config()
+        cfg.max_request_bytes = 8 * 1024 * 1024  # default
+        server._max_request_bytes = 8 * 1024 * 1024
+
+        with (
+            patch.object(cli, "_run_uvicorn"),
+            patch.object(cli, "_port_preflight_or_die"),
+        ):
+            args = _make_serve_args("kokoro")
+            args.max_request_bytes = 16 * 1024 * 1024
+            cli.serve_command(args)
+
+        assert get_config().max_request_bytes == 16 * 1024 * 1024
+
+
+# ---------------------------------------------------------------------------
+# G) rapid-mlx models advertises the audio surface
 # ---------------------------------------------------------------------------
 
 

--- a/tests/test_audio_alias_registry.py
+++ b/tests/test_audio_alias_registry.py
@@ -38,7 +38,6 @@ from unittest.mock import patch
 
 import pytest
 
-
 # ---------------------------------------------------------------------------
 # A) Registry resolution table
 # ---------------------------------------------------------------------------
@@ -231,8 +230,8 @@ class TestAudioAliasRegistry:
         from vllm_mlx.audio.registry import stt_aliases, tts_aliases
         from vllm_mlx.routes.audio import STT_MODEL_ALIASES, TTS_MODEL_ALIASES
 
-        assert STT_MODEL_ALIASES == stt_aliases()
-        assert TTS_MODEL_ALIASES == tts_aliases()
+        assert stt_aliases() == STT_MODEL_ALIASES
+        assert tts_aliases() == TTS_MODEL_ALIASES
 
 
 # ---------------------------------------------------------------------------
@@ -328,9 +327,11 @@ class TestAudioServeModeDispatch:
         _ensure_model_downloaded with the unresolved alias."""
         from vllm_mlx import cli
 
-        with patch.object(cli, "_serve_audio_mode") as mock_audio, patch.object(
-            cli, "_ensure_model_downloaded"
-        ) as mock_download, patch("vllm_mlx.server.load_model") as mock_load:
+        with (
+            patch.object(cli, "_serve_audio_mode") as mock_audio,
+            patch.object(cli, "_ensure_model_downloaded") as mock_download,
+            patch("vllm_mlx.server.load_model") as mock_load,
+        ):
             args = _make_serve_args("kokoro")
             cli.serve_command(args)
 
@@ -373,9 +374,10 @@ class TestAudioServeModeDispatch:
     def test_every_audio_name_takes_the_audio_fork(self, alias):
         from vllm_mlx import cli
 
-        with patch.object(cli, "_serve_audio_mode") as mock_audio, patch.object(
-            cli, "_ensure_model_downloaded"
-        ) as mock_download:
+        with (
+            patch.object(cli, "_serve_audio_mode") as mock_audio,
+            patch.object(cli, "_ensure_model_downloaded") as mock_download,
+        ):
             args = _make_serve_args(alias)
             cli.serve_command(args)
 
@@ -430,9 +432,12 @@ class TestTextBootDoesNotRegress:
     def test_text_model_does_not_take_audio_fork(self, model):
         from vllm_mlx import cli
 
-        with patch.object(cli, "_serve_audio_mode") as mock_audio, patch(
-            "vllm_mlx._version_check.prompt_upgrade_if_available",
-            side_effect=SystemExit(0),
+        with (
+            patch.object(cli, "_serve_audio_mode") as mock_audio,
+            patch(
+                "vllm_mlx._version_check.prompt_upgrade_if_available",
+                side_effect=SystemExit(0),
+            ),
         ):
             args = _make_serve_args(model)
             with pytest.raises(SystemExit):

--- a/vllm_mlx/audio/aliases.json
+++ b/vllm_mlx/audio/aliases.json
@@ -1,0 +1,192 @@
+{
+  "_comment": "R10-C1 audio alias registry. Single source of truth for short alias -> HuggingFace repo id mapping. Every entry's hf_id has been verified resolvable on https://huggingface.co/api/models/<id> at registry-introduction time. Add new entries by hand, then run tests/test_audio_alias_registry.py::test_every_hf_id_resolves locally (network-gated) to confirm before merging.",
+
+  "kokoro": {
+    "type": "tts",
+    "hf_id": "mlx-community/Kokoro-82M-bf16",
+    "family": "kokoro",
+    "default_voice": "af_heart",
+    "notes": "Default Kokoro 82M (bf16). Drop-in OpenAI-style TTS."
+  },
+  "kokoro-82m": {
+    "type": "tts",
+    "hf_id": "mlx-community/Kokoro-82M-bf16",
+    "family": "kokoro",
+    "default_voice": "af_heart",
+    "notes": "Long-form alias for ``kokoro`` — same HF id."
+  },
+  "kokoro-82m-bf16": {
+    "type": "tts",
+    "hf_id": "mlx-community/Kokoro-82M-bf16",
+    "family": "kokoro",
+    "default_voice": "af_heart",
+    "notes": "Explicit bf16 quant of Kokoro 82M."
+  },
+  "kokoro-82m-4bit": {
+    "type": "tts",
+    "hf_id": "mlx-community/Kokoro-82M-4bit",
+    "family": "kokoro",
+    "default_voice": "af_heart",
+    "notes": "4-bit quant of Kokoro 82M — smaller download, mild quality drop."
+  },
+  "kokoro-82m-8bit": {
+    "type": "tts",
+    "hf_id": "mlx-community/Kokoro-82M-8bit",
+    "family": "kokoro",
+    "default_voice": "af_heart",
+    "notes": "8-bit quant of Kokoro 82M."
+  },
+  "kokoro-4bit": {
+    "type": "tts",
+    "hf_id": "mlx-community/Kokoro-82M-4bit",
+    "family": "kokoro",
+    "default_voice": "af_heart",
+    "notes": "Short-form 4-bit alias."
+  },
+  "kokoro-8bit": {
+    "type": "tts",
+    "hf_id": "mlx-community/Kokoro-82M-8bit",
+    "family": "kokoro",
+    "default_voice": "af_heart",
+    "notes": "Short-form 8-bit alias."
+  },
+
+  "chatterbox": {
+    "type": "tts",
+    "hf_id": "mlx-community/chatterbox-turbo-fp16",
+    "family": "chatterbox",
+    "default_voice": "default",
+    "notes": "Multilingual expressive TTS. Voice cloning via reference audio."
+  },
+  "chatterbox-4bit": {
+    "type": "tts",
+    "hf_id": "mlx-community/chatterbox-turbo-4bit",
+    "family": "chatterbox",
+    "default_voice": "default",
+    "notes": "4-bit quant of Chatterbox Turbo."
+  },
+
+  "vibevoice": {
+    "type": "tts",
+    "hf_id": "mlx-community/VibeVoice-Realtime-0.5B-4bit",
+    "family": "vibevoice",
+    "default_voice": "default",
+    "notes": "Realtime low-latency TTS, 0.5B 4bit."
+  },
+  "vibevoice-realtime": {
+    "type": "tts",
+    "hf_id": "mlx-community/VibeVoice-Realtime-0.5B-4bit",
+    "family": "vibevoice",
+    "default_voice": "default",
+    "notes": "Long-form alias for ``vibevoice``."
+  },
+
+  "voxcpm": {
+    "type": "tts",
+    "hf_id": "mlx-community/VoxCPM1.5",
+    "family": "voxcpm",
+    "default_voice": "default",
+    "notes": "Chinese/English high-quality TTS (CPM-based)."
+  },
+
+  "dia": {
+    "type": "tts",
+    "hf_id": "mlx-community/Dia-1.6B-4bit",
+    "family": "dia",
+    "default_voice": "default",
+    "notes": "Dia 1.6B multi-speaker dialogue TTS (4-bit). Best-effort — covered by the audio probe but mlx_audio support is experimental; report bugs upstream if synth fails."
+  },
+
+  "whisper": {
+    "type": "stt",
+    "hf_id": "mlx-community/whisper-large-v3-mlx",
+    "family": "whisper",
+    "languages": "multilingual",
+    "notes": "Bare ``whisper`` -> largest-v3. Matches OpenAI's ``whisper-1`` placeholder."
+  },
+  "whisper-1": {
+    "type": "stt",
+    "hf_id": "mlx-community/whisper-large-v3-mlx",
+    "family": "whisper",
+    "languages": "multilingual",
+    "notes": "OpenAI-spec id from the legacy Whisper API. Same destination as ``whisper-large-v3``."
+  },
+  "whisper-large-v3": {
+    "type": "stt",
+    "hf_id": "mlx-community/whisper-large-v3-mlx",
+    "family": "whisper",
+    "languages": "multilingual",
+    "notes": "Whisper large-v3 (multilingual, 99+ languages)."
+  },
+  "whisper-large-v3-turbo": {
+    "type": "stt",
+    "hf_id": "mlx-community/whisper-large-v3-turbo",
+    "family": "whisper",
+    "languages": "multilingual",
+    "notes": "Whisper large-v3 turbo (faster decode, slight quality drop)."
+  },
+  "whisper-medium": {
+    "type": "stt",
+    "hf_id": "mlx-community/whisper-medium-mlx",
+    "family": "whisper",
+    "languages": "multilingual",
+    "notes": "Whisper medium."
+  },
+  "whisper-small": {
+    "type": "stt",
+    "hf_id": "mlx-community/whisper-small-mlx",
+    "family": "whisper",
+    "languages": "multilingual",
+    "notes": "Whisper small."
+  },
+  "whisper-base": {
+    "type": "stt",
+    "hf_id": "mlx-community/whisper-base-mlx",
+    "family": "whisper",
+    "languages": "multilingual",
+    "notes": "Whisper base."
+  },
+  "whisper-tiny": {
+    "type": "stt",
+    "hf_id": "mlx-community/whisper-tiny-mlx",
+    "family": "whisper",
+    "languages": "multilingual",
+    "notes": "Whisper tiny (smallest, fastest, lowest accuracy)."
+  },
+
+  "parakeet": {
+    "type": "stt",
+    "hf_id": "mlx-community/parakeet-tdt-0.6b-v2",
+    "family": "parakeet",
+    "languages": "en",
+    "notes": "NVIDIA Parakeet TDT 0.6B v2 (English, fastest STT)."
+  },
+  "parakeet-tdt-0.6b": {
+    "type": "stt",
+    "hf_id": "mlx-community/parakeet-tdt-0.6b-v2",
+    "family": "parakeet",
+    "languages": "en",
+    "notes": "Long-form alias for ``parakeet``."
+  },
+  "parakeet-tdt-0.6b-v2": {
+    "type": "stt",
+    "hf_id": "mlx-community/parakeet-tdt-0.6b-v2",
+    "family": "parakeet",
+    "languages": "en",
+    "notes": "Parakeet TDT 0.6B v2."
+  },
+  "parakeet-v3": {
+    "type": "stt",
+    "hf_id": "mlx-community/parakeet-tdt-0.6b-v3",
+    "family": "parakeet",
+    "languages": "en",
+    "notes": "Parakeet TDT 0.6B v3."
+  },
+  "parakeet-tdt-0.6b-v3": {
+    "type": "stt",
+    "hf_id": "mlx-community/parakeet-tdt-0.6b-v3",
+    "family": "parakeet",
+    "languages": "en",
+    "notes": "Parakeet TDT 0.6B v3."
+  }
+}

--- a/vllm_mlx/audio/probe.py
+++ b/vllm_mlx/audio/probe.py
@@ -514,9 +514,31 @@ def is_audio_model_alias(model_name: str | None) -> bool:
     A non-string / empty value short-circuits to False so the boot
     guard never crashes the CLI on a missing ``args.model`` (the
     serve command rejects that case earlier with its own error).
+
+    R10-C1: registry-first. :mod:`vllm_mlx.audio.registry` is the
+    authoritative source of truth (every entry's HF id was verified
+    on hf.co at registry-introduction time). The legacy substring
+    match against :data:`_AUDIO_ALIAS_TOKENS` is preserved as a
+    fallback for HF ids of audio engines that haven't yet been added
+    to the registry (third-party Whisper / Parakeet ports, future
+    mlx-community uploads). Both checks are case-insensitive.
     """
     if not isinstance(model_name, str) or not model_name:
         return False
+    # Registry hit — authoritative, no substring guessing required.
+    # Late-import so a base install that never reaches the audio path
+    # doesn't pay the JSON read at module import time.
+    try:
+        from .registry import is_audio_name
+
+        if is_audio_name(model_name):
+            return True
+    except Exception:
+        # Registry load failed (malformed JSON, missing file in a
+        # partial install). Fall through to the substring fallback so
+        # a busted registry doesn't deafen the boot guard — the legacy
+        # surface still catches the common aliases.
+        pass
     lc = model_name.lower()
     return any(tok in lc for tok in _AUDIO_ALIAS_TOKENS)
 

--- a/vllm_mlx/audio/registry.py
+++ b/vllm_mlx/audio/registry.py
@@ -1,0 +1,248 @@
+# SPDX-License-Identifier: Apache-2.0
+"""R10-C1 audio model registry — single source of truth.
+
+Pre-fix the audio alias surface was fragmented across three places:
+
+* ``vllm_mlx.routes.audio.STT_MODEL_ALIASES`` / ``TTS_MODEL_ALIASES`` —
+  request-time resolution for the route handlers.
+* ``vllm_mlx.audio.probe._AUDIO_ALIAS_TOKENS`` — boot-guard substring
+  classifier.
+* ``vllm_mlx.cli.serve_command`` — no resolution at all; the alias
+  fell through to ``_ensure_model_downloaded`` (HF 404) and then into
+  ``mlx_lm.load_model`` (no safetensors). Every short alias 100% broken
+  on 0.8.11 — Bo r10-R1 finding, predicted by codex r8-A r3.
+
+R10-C1 consolidates the alias table into ``aliases.json`` and gives
+every callsite the SAME lookup contract:
+
+* :func:`resolve_audio_alias` — alias / HF id -> :class:`AudioAliasEntry`
+  or ``None`` (for non-audio names).
+* :func:`is_audio_name` — boolean form, used by ``serve_command`` to
+  decide whether to fork into audio-mode.
+* :func:`list_audio_aliases` — ordered alias listing for the
+  ``rapid-mlx models`` table.
+
+The registry is the ONLY place a new audio model lands. The route
+alias tables (``STT_MODEL_ALIASES`` / ``TTS_MODEL_ALIASES``) are now
+built from this registry at import time so a single JSON edit reaches
+every consumer.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from dataclasses import dataclass
+from typing import Literal
+
+logger = logging.getLogger(__name__)
+
+AudioType = Literal["tts", "stt"]
+
+
+@dataclass(frozen=True)
+class AudioAliasEntry:
+    """Resolved metadata for an audio alias.
+
+    Fields:
+
+    * ``alias`` — the registry key (short alias name, lowercase).
+    * ``type`` — ``"tts"`` (text -> speech) or ``"stt"``
+      (speech -> text). Drives the route binding decision in
+      ``serve_command`` and the capability tag in ``rapid-mlx models``.
+    * ``hf_id`` — the HuggingFace repo id the audio engine should
+      load. Always single-slash org/name shape. Verified at registry
+      introduction time via the HF API.
+    * ``family`` — engine family (``kokoro`` / ``chatterbox`` /
+      ``vibevoice`` / ``voxcpm`` / ``whisper`` / ``parakeet`` / ...).
+      Used by the TTS lane to pick the voice list.
+    * ``default_voice`` — TTS-only; first-choice voice for the engine.
+      ``None`` for STT entries.
+    * ``languages`` — STT-only; ``"multilingual"`` or a comma-separated
+      ISO list. ``None`` for TTS entries.
+    * ``notes`` — free-form operator-facing description (shown in
+      ``rapid-mlx info <alias>``).
+    """
+
+    alias: str
+    type: AudioType
+    hf_id: str
+    family: str
+    default_voice: str | None = None
+    languages: str | None = None
+    notes: str = ""
+
+
+# Lazy cache. Populated on first call to :func:`_load_registry`; reset
+# via :func:`_reset_registry_cache` for tests that mutate the JSON.
+_REGISTRY: dict[str, AudioAliasEntry] | None = None
+# Reverse index: HF id (lowercase) -> alias key. Built alongside the
+# forward index so :func:`resolve_audio_alias` can answer for full HF
+# ids the same way it answers for short aliases.
+_HF_ID_INDEX: dict[str, str] = {}
+
+
+def _reset_registry_cache() -> None:
+    """Test hook: clear the registry cache.
+
+    Tests that swap the JSON file or patch the loader call this in
+    their fixture so the next ``_load_registry`` call re-reads from
+    disk. Production code never calls this.
+    """
+    global _REGISTRY
+    _REGISTRY = None
+    _HF_ID_INDEX.clear()
+
+
+def _registry_path() -> str:
+    return os.path.join(os.path.dirname(__file__), "aliases.json")
+
+
+def _load_registry() -> dict[str, AudioAliasEntry]:
+    """Parse ``aliases.json`` and return the alias -> entry map.
+
+    The JSON file is committed alongside this module so the registry
+    is read-only at runtime. Malformed entries fail fast at load time
+    rather than at the first request — a typo'd ``hf_id`` would
+    otherwise surface as a 404 deep in the audio loader.
+
+    Keys beginning with ``_`` (e.g. ``_comment``) are skipped so the
+    JSON file can carry inline documentation without polluting the
+    alias surface.
+    """
+    global _REGISTRY
+    if _REGISTRY is not None:
+        return _REGISTRY
+
+    path = _registry_path()
+    with open(path) as f:
+        raw = json.load(f)
+
+    entries: dict[str, AudioAliasEntry] = {}
+    for key, value in raw.items():
+        if key.startswith("_"):
+            # Inline doc / comment key — skip so it doesn't accidentally
+            # register as an alias.
+            continue
+        if not isinstance(value, dict):
+            raise ValueError(
+                f"audio aliases.json: entry {key!r} must be an object, "
+                f"got {type(value).__name__}"
+            )
+        try:
+            kind = value["type"]
+            hf_id = value["hf_id"]
+            family = value["family"]
+        except KeyError as e:
+            raise ValueError(
+                f"audio aliases.json: entry {key!r} missing required "
+                f"field {e.args[0]!r}"
+            ) from e
+        if kind not in ("tts", "stt"):
+            raise ValueError(
+                f"audio aliases.json: entry {key!r} has invalid type "
+                f"{kind!r}; must be 'tts' or 'stt'"
+            )
+        if "/" not in hf_id:
+            raise ValueError(
+                f"audio aliases.json: entry {key!r}.hf_id={hf_id!r} "
+                "must be a HuggingFace ``org/name`` repo id"
+            )
+        entries[key] = AudioAliasEntry(
+            alias=key,
+            type=kind,
+            hf_id=hf_id,
+            family=family,
+            default_voice=value.get("default_voice"),
+            languages=value.get("languages"),
+            notes=value.get("notes", ""),
+        )
+
+    _REGISTRY = entries
+    # Reverse index keyed on the lowercased HF id so ``serve_command``
+    # can route a request like ``rapid-mlx serve mlx-community/Kokoro-
+    # 82M-bf16`` directly back to its registry entry (HF id case varies
+    # across mlx-community uploads).
+    _HF_ID_INDEX.clear()
+    for alias, entry in entries.items():
+        _HF_ID_INDEX.setdefault(entry.hf_id.lower(), alias)
+    return entries
+
+
+def resolve_audio_alias(name: str | None) -> AudioAliasEntry | None:
+    """Return the registry entry for ``name``, or ``None`` if not audio.
+
+    Resolution order (first hit wins):
+
+    1. Direct short-alias lookup (case-insensitive) — ``kokoro``,
+       ``whisper-large-v3``, ``parakeet-tdt-0.6b-v2``, ...
+    2. Reverse HF-id lookup (case-insensitive) — ``mlx-community/
+       Kokoro-82M-bf16`` returns the ``kokoro`` entry so audio-mode
+       fires for full HF ids of audio models too. This is critical
+       because users (and `rapid-mlx pull mlx-community/Kokoro-82M-bf16`
+       output) routinely paste the full HF id into ``serve``.
+
+    Non-audio names (text aliases, vision aliases, unknown HF ids)
+    return ``None`` — the caller falls back to the text/vision path.
+
+    Empty / non-string inputs short-circuit to ``None`` so callers
+    don't need to defensively type-check before delegating.
+    """
+    if not isinstance(name, str) or not name:
+        return None
+    registry = _load_registry()
+    lc = name.lower()
+    # Short-alias direct hit.
+    entry = registry.get(lc)
+    if entry is not None:
+        return entry
+    # HF-id reverse lookup. ``_HF_ID_INDEX`` was populated alongside
+    # ``_REGISTRY`` so the lookup is O(1) and case-insensitive.
+    alias = _HF_ID_INDEX.get(lc)
+    if alias is not None:
+        return registry[alias]
+    return None
+
+
+def is_audio_name(name: str | None) -> bool:
+    """Return True iff ``name`` resolves to a registered audio entry.
+
+    Convenience wrapper around :func:`resolve_audio_alias` for the
+    common boolean predicate. Used by ``serve_command`` to gate the
+    audio-mode fork, and by the boot-time alias classifier as a
+    REGISTRY-FIRST check (substring fallback still applies for HF ids
+    of audio models that haven't been added to the registry yet —
+    those route to the legacy substring path via
+    :func:`vllm_mlx.audio.probe.is_audio_model_alias`).
+    """
+    return resolve_audio_alias(name) is not None
+
+
+def list_audio_aliases() -> list[AudioAliasEntry]:
+    """Return all audio aliases, sorted by name.
+
+    Used by ``rapid-mlx models`` to render the audio section of the
+    alias table. The sort is alphabetical so the ``kokoro*`` /
+    ``whisper*`` / ``parakeet*`` groups cluster together visually.
+    """
+    return sorted(_load_registry().values(), key=lambda e: e.alias)
+
+
+def stt_aliases() -> dict[str, str]:
+    """Return ``{alias: hf_id}`` for every STT entry.
+
+    Used by :mod:`vllm_mlx.routes.audio` to build its
+    ``STT_MODEL_ALIASES`` table without duplicating the data. Bare
+    ``dict`` rather than ``AudioAliasEntry`` so the route's existing
+    consumers don't need to change shape.
+    """
+    return {e.alias: e.hf_id for e in _load_registry().values() if e.type == "stt"}
+
+
+def tts_aliases() -> dict[str, str]:
+    """Return ``{alias: hf_id}`` for every TTS entry.
+
+    Counterpart to :func:`stt_aliases`. Same shape contract.
+    """
+    return {e.alias: e.hf_id for e in _load_registry().values() if e.type == "tts"}

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -2962,9 +2962,7 @@ def models_command(args):
         print(f"  Audio models ({len(audio_entries)} aliases)")
         audio_sep = "  " + "─" * width
         print(audio_sep)
-        audio_header = (
-            f"  {'Alias':<24} {'Kind':<10} {'Family':<12} {'HF id':<40}"
-        )
+        audio_header = f"  {'Alias':<24} {'Kind':<10} {'Family':<12} {'HF id':<40}"
         print(audio_header)
         print(audio_sep)
         for entry in audio_entries:

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -424,6 +424,176 @@ def _resolve_embedding_alias(name: str) -> tuple[str, bool]:
     return resolved, resolved != name
 
 
+def _resolve_audio_model_for_serve(model_name: str):
+    """Resolve a model name to an audio registry entry, if it's audio.
+
+    R10-C1: pre-fix ``serve_command`` had a boot guard (rc=2 when
+    ``[audio]`` extra missing) but ZERO resolution logic for audio
+    aliases. Short aliases like ``kokoro``/``whisper`` then fell into
+    ``_ensure_model_downloaded`` and 404'd at HF, while full HF ids
+    of audio models (``mlx-community/Kokoro-82M-bf16``) downloaded
+    successfully but crashed in ``mlx_lm.load_model`` because they
+    have no safetensors. Bo r10-R1: 0/8 audio aliases boot on 0.8.11.
+
+    The fix routes audio names through a SEPARATE serve path that
+    skips the text-model loader entirely. This helper returns the
+    resolved registry entry (so the dispatcher knows the HF id, type,
+    family, voice list) or ``None`` if the name isn't audio. ``None``
+    falls through to the legacy text path unchanged — text-model boot
+    paths must not regress.
+    """
+    from .audio.registry import resolve_audio_alias
+
+    return resolve_audio_alias(model_name)
+
+
+def _serve_audio_mode(args, entry) -> None:
+    """Bind the audio-only serve path for a resolved registry entry.
+
+    R10-C1 audio-serve-mode. Pre-fix every ``rapid-mlx serve kokoro``
+    crash-looped because the text-model boot path was the ONLY path:
+
+    1. ``_ensure_model_downloaded(args.model)`` queried HF for the
+       short alias and 404'd — there's no ``hf.co/kokoro`` repo.
+    2. Even when the user supplied a full HF id, ``load_model``
+       (text path) called ``mlx_lm.load_model`` which expects
+       safetensors. Audio repos ship npz/mlx weights, so the loader
+       crashed with "no safetensors found".
+    3. ``pflash.validate_model_support`` and the parser auto-detection
+       both consult ``args.model`` assuming it's a text-LM alias —
+       a wrong tool for audio.
+
+    The audio-serve-mode bypasses all of the above:
+
+    * Print the resolved alias -> HF id banner so the operator sees
+      the same alias-resolution UX they get for text models.
+    * Stamp the resolved HF id on ``args.model`` so the audio routes
+      treat it as a known engine (``STT_MODEL_ALIASES`` /
+      ``TTS_MODEL_ALIASES`` map both the short and full forms).
+    * Capture the alias on ``server._model_alias`` so ``/v1/models``
+      advertises it.
+    * Configure server security knobs (api-key, body-size cap, CORS)
+      the SAME way the text path does — audio endpoints share the
+      same middleware stack.
+    * Skip the text-LM loader. The audio engines are loaded LAZILY
+      on the first request by the route handlers (``STTEngine.load``
+      / ``TTSEngine.load``), so there's nothing to boot at startup —
+      and a Kokoro/Whisper weight download mid-boot would only add
+      cold-start latency without buying anything.
+    * Run uvicorn with the same FastAPI ``app`` text models use; the
+      ``/v1/audio/*`` routes are already mounted on it.
+    """
+    import os
+    import sys
+
+    # Late imports — audio mode runs on the lighter base install +
+    # ``[audio]`` extra; we don't want the text-LM engine machinery to
+    # boot until / unless it's actually needed.
+    from . import server
+    from .middleware.auth import configure_rate_limiter
+    from .server import app
+
+    uvicorn_log_level = server.configure_logging(args.log_level)
+
+    # Stamp the resolved model id so the audio routes find the same
+    # alias mapping the registry has. ``server._model_alias`` is read
+    # by ``/v1/models`` to surface the operator-facing alias name.
+    if hasattr(args, "_original_alias"):
+        server._model_alias = args._original_alias
+    else:
+        # No prior alias hop (e.g. user passed a full HF id). Use the
+        # short alias from the registry so /v1/models still shows the
+        # friendly name, not the bare HF path.
+        server._model_alias = entry.alias
+
+    # Mirror the text path's security configuration. Audio routes use
+    # the SAME middleware stack as chat/embeddings — the same env vars
+    # and CLI flags govern auth + body-size caps + CORS. Diverging
+    # here would silently weaken the deployment posture for anyone who
+    # added ``--api-key`` to their ``rapid-mlx serve kokoro`` command.
+    server._api_key = server._resolve_api_key(args.api_key)
+    server._default_timeout = args.timeout
+
+    _max_body_arg = getattr(args, "max_request_bytes", None)
+    if _max_body_arg is not None:
+        server._max_request_bytes = max(0, int(_max_body_arg))
+    else:
+        _env = os.environ.get("RAPID_MLX_MAX_REQUEST_BYTES", "").strip()
+        if _env:
+            try:
+                server._max_request_bytes = max(0, int(_env))
+            except ValueError:
+                server._max_request_bytes = 8 * 1024 * 1024
+
+    # Body-receive timeout — same env-driven hook the text path uses.
+    _apply_body_receive_timeout_env(server)
+
+    # CORS — same friendly default the text path uses.
+    server.configure_cors_from_env(args.cors_origins)
+    if args.rate_limit > 0:
+        server._rate_limiter = configure_rate_limiter(args.rate_limit, enabled=True)
+
+    # Print the resolution banner so the operator sees what loaded.
+    family_tag = f"[audio:{entry.type}]"
+    shown_alias = getattr(args, "_original_alias", args.model)
+    print()
+    print(f"  Audio mode: {shown_alias} → {entry.hf_id} {family_tag}")
+    if entry.type == "tts" and entry.default_voice:
+        print(f"  Default voice: {entry.default_voice}")
+    if entry.type == "stt" and entry.languages:
+        print(f"  Languages: {entry.languages}")
+    print(
+        "  Audio engines load lazily on the first /v1/audio/* request "
+        "(no boot-time weight download)."
+    )
+
+    # Stamp the bind source-of-truth so the lifespan "Ready:" banner
+    # prints the right URL. Mirrors the text-path block.
+    host_display = "localhost" if args.host == "0.0.0.0" else args.host
+    listen_fd = getattr(args, "listen_fd", None)
+
+    # Port preflight — same friendly "port already in use" probe the
+    # text path runs. Skip in --listen-fd mode (the supervisor owns
+    # the socket; binding here would race). Mirrors the rationale on
+    # the text-path call site.
+    if listen_fd is None:
+        _port_preflight_or_die(args.host, args.port, model=args.model)
+
+    if listen_fd is not None:
+        print(
+            f"  Starting server on inherited fd {listen_fd} "
+            "(audio routes ready immediately)"
+        )
+    else:
+        print(
+            f"  Starting server on http://{host_display}:{args.port} "
+            "(audio routes ready immediately)"
+        )
+
+    from vllm_mlx._version_check import print_staleness_warning_if_any
+    from vllm_mlx.config import get_config
+
+    print_staleness_warning_if_any()
+    print()
+
+    _cfg = get_config()
+    _cfg.bind_host = None
+    _cfg.bind_port = None
+    _cfg.bind_listen_fd = None
+    if listen_fd is None:
+        _cfg.bind_host = host_display
+        _cfg.bind_port = args.port
+    else:
+        _cfg.bind_listen_fd = listen_fd
+
+    # Use sys.stdout.flush so the banner lands before uvicorn's own
+    # startup logs interleave — operators expect to see the audio
+    # banner FIRST.
+    sys.stdout.flush()
+
+    _run_uvicorn(app, args, uvicorn_log_level)
+
+
 def _load_embedding_model_or_exit(args, load_fn) -> None:
     """Pre-load ``--embedding-model`` with the H-08 install guard and
     the D-EMBED-ALIAS alias-resolution + clean error-wrapping path.
@@ -1030,6 +1200,37 @@ def serve_command(args):
 
     if is_audio_model_alias(getattr(args, "model", None)):
         require_audio_or_exit(args.model)
+
+    # R10-C1: AUDIO-SERVE-MODE FORK. The boot guard above only checks
+    # that the ``[audio]`` extra is installed — it doesn't route the
+    # alias anywhere. Pre-R10 every short alias (``kokoro``, ``whisper``,
+    # ``parakeet``...) fell through to ``_ensure_model_downloaded``
+    # and 404'd at HF, while full HF ids of audio models downloaded
+    # successfully but then crashed inside ``mlx_lm.load_model``
+    # because audio repos don't ship safetensors. Bo r10-R1: 0/8 audio
+    # aliases boot on 0.8.11 (codex r8-A r3 predicted this exact shape).
+    #
+    # The fix is a clean fork: if the registry resolves the model to
+    # an audio entry, route to ``_serve_audio_mode`` (which skips
+    # ``_ensure_model_downloaded``, the text loader, pflash, parser
+    # detection, etc.) and return. Everything below this block remains
+    # untouched for the text path so text-model boot does NOT regress.
+    audio_entry = _resolve_audio_model_for_serve(getattr(args, "model", None))
+    if audio_entry is not None:
+        # Stamp the alias hop so /v1/models, telemetry, and the banner
+        # all show the same name pair. ``_original_alias`` is set by
+        # the main() alias resolver for text models; we mirror that
+        # contract here for audio.
+        if not hasattr(args, "_original_alias") or args._original_alias is None:
+            args._original_alias = args.model
+        # Replace the alias on args.model with the resolved HF id so
+        # any downstream code that reads ``args.model`` (eg. session
+        # telemetry, ps_command) sees a real repo path. The audio
+        # routes still accept both forms because the registry's
+        # reverse HF-id index covers full ids too.
+        args.model = audio_entry.hf_id
+        _serve_audio_mode(args, audio_entry)
+        return
 
     # Interactive auto-upgrade prompt — when serve runs interactively and a
     # newer release is available, ask once before booting the model. Honors
@@ -2738,11 +2939,49 @@ def models_command(args):
         print(row)
 
     print(sep)
+
+    # R10-C1: audio alias section. Pre-R10 ``rapid-mlx models`` listed
+    # zero audio aliases because they don't live in ``aliases.json``
+    # (which only carries text-LM profiles). Users had no in-tool way
+    # to discover ``kokoro`` / ``whisper-large-v3`` / ``parakeet`` —
+    # they had to read the docs site. Now the audio registry
+    # (vllm_mlx/audio/aliases.json) feeds the same table so
+    # ``rapid-mlx models`` is the canonical "what can I serve?" view
+    # across every lane.
+    try:
+        from vllm_mlx.audio.registry import list_audio_aliases
+
+        audio_entries = list_audio_aliases()
+    except Exception:
+        # A malformed audio registry must NOT break the text alias
+        # listing — silently degrade by skipping the audio section.
+        audio_entries = []
+
+    if audio_entries:
+        print()
+        print(f"  Audio models ({len(audio_entries)} aliases)")
+        audio_sep = "  " + "─" * width
+        print(audio_sep)
+        audio_header = (
+            f"  {'Alias':<24} {'Kind':<10} {'Family':<12} {'HF id':<40}"
+        )
+        print(audio_header)
+        print(audio_sep)
+        for entry in audio_entries:
+            kind_tag = f"[audio:{entry.type}]"
+            print(
+                f"  {entry.alias:<24} {kind_tag:<10} "
+                f"{entry.family:<12} {entry.hf_id:<40}"
+            )
+        print(audio_sep)
+
     print()
     print("  Tip: `rapid-mlx info <alias>` for the full per-model profile")
     print("       `rapid-mlx pull <alias>` to download")
     print("       `rapid-mlx chat <alias>` for an interactive REPL")
     print("       `rapid-mlx serve <alias>` for an OpenAI-compatible server")
+    if audio_entries:
+        print("       `rapid-mlx serve kokoro|whisper-large-v3|parakeet` for audio")
     print()
 
 

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -497,14 +497,19 @@ def _serve_audio_mode(args, entry) -> None:
 
     # Stamp the resolved model id so the audio routes find the same
     # alias mapping the registry has. ``server._model_alias`` is read
-    # by ``/v1/models`` to surface the operator-facing alias name.
-    if hasattr(args, "_original_alias"):
+    # by ``/v1/models`` to surface the operator-facing alias name;
+    # ``server._model_name`` / ``server._model_path`` populate
+    # ``ServerConfig.model_name`` / ``model_path`` so /v1/models lists
+    # the served audio model (codex r1 HIGH #1 follow-up).
+    if hasattr(args, "_original_alias") and args._original_alias is not None:
         server._model_alias = args._original_alias
     else:
         # No prior alias hop (e.g. user passed a full HF id). Use the
         # short alias from the registry so /v1/models still shows the
         # friendly name, not the bare HF path.
         server._model_alias = entry.alias
+    server._model_name = entry.hf_id
+    server._model_path = entry.hf_id
 
     # Mirror the text path's security configuration. Audio routes use
     # the SAME middleware stack as chat/embeddings — the same env vars
@@ -532,6 +537,17 @@ def _serve_audio_mode(args, entry) -> None:
     server.configure_cors_from_env(args.cors_origins)
     if args.rate_limit > 0:
         server._rate_limiter = configure_rate_limiter(args.rate_limit, enabled=True)
+
+    # CRITICAL: copy the just-set server globals into the
+    # ServerConfig singleton the middleware actually reads.
+    # ``server.load_model`` does this on the text path (calls
+    # ``_sync_config`` after wiring globals); the audio path skips
+    # ``load_model`` so we must call it explicitly here. Without this
+    # sync the auth middleware reads ``cfg.api_key`` (still ``None``
+    # because nothing populated it) instead of ``server._api_key``,
+    # so ``rapid-mlx serve kokoro --api-key SECRET`` would silently
+    # accept unauthenticated /v1/audio/* requests. Codex r1 HIGH #1.
+    server._sync_config()
 
     # Print the resolution banner so the operator sees what loaded.
     family_tag = f"[audio:{entry.type}]"

--- a/vllm_mlx/routes/audio.py
+++ b/vllm_mlx/routes/audio.py
@@ -36,27 +36,20 @@ _tts_engine = None
 # ``STTEngine.load`` failed deep inside mlx-audio. Mirror the
 # ``/v1/chat/completions`` and ``/v1/responses`` contract: validate the
 # model name first and surface 404 with a distinct error type.
-STT_MODEL_ALIASES: dict[str, str] = {
-    "whisper-large-v3": "mlx-community/whisper-large-v3-mlx",
-    "whisper-large-v3-turbo": "mlx-community/whisper-large-v3-turbo",
-    "whisper-medium": "mlx-community/whisper-medium-mlx",
-    "whisper-small": "mlx-community/whisper-small-mlx",
-    "parakeet": "mlx-community/parakeet-tdt-0.6b-v2",
-    "parakeet-v3": "mlx-community/parakeet-tdt-0.6b-v3",
-    # R7-M9 (Bo 0.8.8 dogfood): short ``whisper`` (no size suffix) is the
-    # OpenAI-canonical id that callers reach for first ("just give me
-    # Whisper"). Pre-fix this 404'd because the alias map only listed
-    # the size-suffixed siblings. The chat lane resolves short aliases
-    # at request-time via the registry; STT now matches that contract
-    # by routing bare ``whisper`` to the largest supported variant.
-    # Mirrors OpenAI's ``whisper-1`` placeholder semantics — same
-    # destination as ``whisper-large-v3``.
-    "whisper": "mlx-community/whisper-large-v3-mlx",
-    # OpenAI-spec id from the legacy Whisper API. Some SDKs still ship
-    # ``whisper-1`` by default; map it to the largest supported variant
-    # so drop-in OpenAI code doesn't 404 on the alias check.
-    "whisper-1": "mlx-community/whisper-large-v3-mlx",
-}
+# R10-C1: the STT alias table is now sourced from the central
+# ``vllm_mlx.audio.registry`` (aliases.json). Pre-R10 this dict was
+# inlined here and the boot path in ``serve_command`` had no resolver
+# at all — short aliases like ``whisper-1`` 404'd at HF before reaching
+# the audio engine. The registry is the SINGLE place a new audio
+# model lands; ``rapid-mlx models`` and the boot guard read from the
+# same JSON file.
+#
+# We freeze a snapshot here at import time so the route's hot path
+# avoids the JSON round-trip per request. The registry is read-only at
+# runtime so the snapshot can never drift from the file.
+from ..audio.registry import stt_aliases as _stt_aliases_from_registry
+
+STT_MODEL_ALIASES: dict[str, str] = dict(_stt_aliases_from_registry())
 
 # F-210: model strings must canonicalize to either a bare alias name
 # (matches an entry in ``STT_MODEL_ALIASES``) or a single-slash
@@ -1178,31 +1171,15 @@ async def create_translation(
 # unit tests can pin the table without crawling the handler body.
 # Mirrors ``STT_MODEL_ALIASES`` (R-04 contract). Any future engine
 # addition lands here once, not in the handler.
-TTS_MODEL_ALIASES: dict[str, str] = {
-    "kokoro": "mlx-community/Kokoro-82M-bf16",
-    "kokoro-4bit": "mlx-community/Kokoro-82M-4bit",
-    # R8-H4 (Bo 0.8.9 dogfood): the brief's canonical full alias
-    # ``kokoro-82m-8bit`` (and its 4bit / bf16 siblings) previously
-    # bypassed the resolver — ``_resolve_tts_model`` fell through to
-    # passthrough, mlx-audio queried ``huggingface.co/api/models/
-    # kokoro-82m-8bit`` and 404'd. The short ``kokoro`` alias worked
-    # because it WAS in the table; the full form was not. Map every
-    # documented Kokoro full alias to the same canonical HF repo as
-    # ``kokoro`` so the resolver returns the identical path for both
-    # the short and full names. ``kokoro-82m-8bit`` falls back to the
-    # bf16 build (mlx-community ships no 8bit Kokoro repo today); the
-    # alias exists so future ops who type the brief's literal name
-    # see a working engine instead of an opaque HF 404. The lowercase
-    # match here mirrors the lowercase the alias-substring boot guard
-    # uses (``is_audio_model_alias``).
-    "kokoro-82m-bf16": "mlx-community/Kokoro-82M-bf16",
-    "kokoro-82m-4bit": "mlx-community/Kokoro-82M-4bit",
-    "kokoro-82m-8bit": "mlx-community/Kokoro-82M-bf16",
-    "chatterbox": "mlx-community/chatterbox-turbo-fp16",
-    "chatterbox-4bit": "mlx-community/chatterbox-turbo-4bit",
-    "vibevoice": "mlx-community/VibeVoice-Realtime-0.5B-4bit",
-    "voxcpm": "mlx-community/VoxCPM1.5",
-}
+# R10-C1: TTS alias table now sourced from the central audio
+# registry — same rationale as ``STT_MODEL_ALIASES`` above. The JSON
+# file ships the verified HF id for every entry (including a real
+# ``mlx-community/Kokoro-82M-8bit`` which now exists; pre-R10 we
+# silently aliased it to the bf16 build because there was no 8bit
+# repo at that time).
+from ..audio.registry import tts_aliases as _tts_aliases_from_registry
+
+TTS_MODEL_ALIASES: dict[str, str] = dict(_tts_aliases_from_registry())
 
 #: Default TTS alias for empty / ``"default"`` requests. Mirrors the
 #: ``DEFAULT_STT_ALIAS`` rule on the STT side — drop-in OpenAI-SDK code


### PR DESCRIPTION
## Why

**Bo r10-R1 finding**: 0/8 audio aliases boot on 0.8.11. Every TTS/STT user is broken:

- Short aliases (`kokoro`, `kokoro-82m`, `kokoro-82m-bf16`, `kokoro-82m-8bit`, `whisper`, `whisper-1`): all 404 on HuggingFace because `serve_command` treats the alias as an HF repo id and hands it straight to `_ensure_model_downloaded`.
- Full HF ids (`mlx-community/Kokoro-82M-bf16`, `mlx-community/whisper-tiny-mlx`): download OK but crash inside the TEXT loader (`mlx_lm.load_model: No safetensors found`) because audio repos ship `.npz` weights, not safetensors.

**Codex r8-A r3** predicted this exact regression. **Bo r9 + r10** confirmed it stayed broken across two releases.

Root cause in `vllm_mlx/cli.py::serve_command`:
1. The audio boot guard (R6-H4) only checked that the `[audio]` extra is installed — it did NOT route the alias anywhere.
2. `_ensure_model_downloaded(args.model)` was called with the unresolved alias.
3. `load_model(args.model)` then called `mlx_lm.load_model` instead of an audio loader.

Also: `rapid-mlx models` listed 0 audio aliases — no registry, surface was docs-only.

## Summary

- **`vllm_mlx/audio/aliases.json`** — single source of truth. 26 entries covering Kokoro (incl. the real 8bit build mlx-community now ships), Chatterbox, VibeVoice, VoxCPM, Dia, Whisper (full size range incl. base/tiny), Parakeet v2/v3. Every HF id verified resolvable on hf.co.
- **`vllm_mlx/audio/registry.py`** — resolver. Handles both short alias and full HF id (reverse index) — so `rapid-mlx serve mlx-community/Kokoro-82M-bf16` routes to audio too.
- **`serve_command` audio-serve-mode fork** — when the registry resolves the model to an audio entry, dispatch to `_serve_audio_mode` which skips `_ensure_model_downloaded`, the text-LM loader, pflash/parser detection. Audio engines load lazily inside the route handlers. The text path is untouched for non-audio names.
- **Server config sync (codex r1 HIGH #1)** — audio path now calls `server._sync_config()` after wiring the globals so `--api-key`, `--max-request-bytes`, etc. actually reach the `ServerConfig` singleton the auth middleware reads. Pre-fix, `rapid-mlx serve kokoro --api-key SECRET` would silently accept unauthenticated requests.
- **`rapid-mlx models`** — adds an "Audio models" section (was 0 rows).
- **`STT_MODEL_ALIASES` / `TTS_MODEL_ALIASES`** in `routes/audio.py` now built from the same registry — a single JSON edit reaches every consumer.
- **`is_audio_model_alias`** — registry-first; legacy substring fallback preserved for HF ids of third-party audio engines.
- **107 new tests** in `tests/test_audio_alias_registry.py` covering registry resolution, audio-serve-mode dispatch (asserts text loader is NOT called), text-model boot non-regression, server-config sync (api_key + model_name + max_request_bytes), boot-guard rc=2 on missing `[audio]` extra, and `rapid-mlx models` listing.
- **Docs** — `docs/guides/audio.md` + `docs/reference/cli.md` alias matrix + curl quickstart for TTS and STT.

## Boot matrix (Bo r10-R1 reproducer)

| Model name                          | 0.8.11 | This PR        |
| ----------------------------------- | ------ | -------------- |
| kokoro                              | 404    | AUDIO PATH OK |
| kokoro-82m                          | 404    | AUDIO PATH OK |
| kokoro-82m-bf16                     | 404    | AUDIO PATH OK |
| kokoro-82m-8bit                     | 404    | AUDIO PATH OK |
| whisper                             | 404    | AUDIO PATH OK |
| whisper-1                           | 404    | AUDIO PATH OK |
| mlx-community/Kokoro-82M-bf16       | text 500 | AUDIO PATH OK |
| mlx-community/whisper-tiny-mlx      | text 500 | AUDIO PATH OK |

8/8 fixed.

## Test plan

- [x] 107 new tests in `tests/test_audio_alias_registry.py` pass
- [x] All 291 existing audio / CLI / serve tests still pass
- [x] Text-model boot path does not regress (parametrized over 6 representative text aliases)
- [x] Boot guard still fires rc=2 for missing `[audio]` extra (R6-H4 contract)
- [x] `rapid-mlx models` lists the 26 audio aliases with `[audio:tts]` / `[audio:stt]` tags
- [x] Each registry HF id verified resolvable on hf.co at PR open time
- [x] Codex r1 review — addressed HIGH #1 (server config sync), filed as separate follow-up commit. Other findings (HIGH #2 missing AGENTS.md, HIGH #3 oversized modules, MEDIUM #4-7) are repo-scale concerns, not R10-C1-introduced regressions
- [x] CI green on full test matrix (lint, type-check, test-matrix 3.10/3.11/3.12, test-apple-silicon, check) — `validate` gate satisfied after addressing test-plan check