### PR TITLE
fix(api,tools): r10-G+H — wire-scrub completion + validation bundle (R10-C8 + R10-M4 + R10-H2..H6)

### DIFF
--- a/tests/test_completions_response_format_json_schema.py
+++ b/tests/test_completions_response_format_json_schema.py
@@ -189,6 +189,53 @@ def test_sync_json_object_still_works_after_r10_j_rejection():
     assert body["choices"][0]["text"] == _CLEAN_TEXT
 
 
+def test_sync_response_format_plus_echo_rejected_with_400():
+    """r10-J round-3 (codex r3 MED #4): the route accepted
+    ``response_format=json_object`` + ``echo=true`` and silently
+    skipped the fence-strip (the prompt prefix is NOT JSON). Caller
+    received prompt-prefixed text in ``choices[0].text`` while
+    believing it had opted into structured output. Reject the
+    combination with a 400 (same envelope shape as the logprobs
+    reject)."""
+    client = _make_client()
+    resp = client.post(
+        "/v1/completions",
+        json={
+            "model": "test-model",
+            "prompt": "hi",
+            "max_tokens": 16,
+            "response_format": {"type": "json_object"},
+            "echo": True,
+        },
+    )
+    assert resp.status_code == 400, resp.text
+    body = resp.json()
+    err = body["error"]
+    assert err["type"] == "invalid_request_error"
+    assert err["code"] == "unsupported_combination"
+    assert err["param"] == "response_format"
+    assert "echo" in err["message"]
+
+
+def test_stream_response_format_plus_echo_rejected_with_400():
+    """Streaming twin of the sync echo+json_object reject (codex r3
+    MED #4 calls out completions.py:693 too — the streaming branch
+    has the same bypass)."""
+    client = _make_client()
+    resp = client.post(
+        "/v1/completions",
+        json={
+            "model": "test-model",
+            "prompt": "hi",
+            "max_tokens": 16,
+            "stream": True,
+            "response_format": {"type": "json_object"},
+            "echo": True,
+        },
+    )
+    assert resp.status_code == 400, resp.text
+
+
 def test_json_schema_plus_logprobs_400_still_fires_for_combination_rule():
     """Cross-check: ``response_format + logprobs`` was already
     rejected by the r10-G/H r1 fix. Make sure r10-J's earlier-in-the-

--- a/tests/test_completions_response_format_json_schema.py
+++ b/tests/test_completions_response_format_json_schema.py
@@ -1,0 +1,219 @@
+# SPDX-License-Identifier: Apache-2.0
+"""r10-J — codex r10-G/H round-2 HIGH #1 (json_schema on /v1/completions).
+
+The r10-H4 ``response_format`` wiring on ``/v1/completions`` accepted
+``{"type": "json_schema", "json_schema": {...}}`` and post-processed the
+generated text through ``extract_json_from_response`` — which strips
+markdown fences but does NOT enforce the schema. A caller setting
+``json_schema.strict=true`` therefore got HTTP 200 back with JSON that
+could violate the schema (silent corruption of the OpenAI strict
+contract).
+
+The chat lane (``routes/chat.py``) already owns the strict path via
+``is_strict_json_schema`` / ``extract_json_schema_for_guided`` plus
+guided-generation. The legacy completions lane never had FSM
+constraints; wiring guided generation there is a separate refactor.
+
+The conservative spec-correct fix is to reject ``json_schema`` on
+``/v1/completions`` with a 400 envelope that points callers at chat.
+``json_object`` keeps working — fence-strip alone is sufficient for
+loose JSON, no schema to validate — so this is a surgical close of the
+strict gap.
+
+The three tests below pin the contract:
+
+1. ``stream=false`` + ``response_format=json_schema`` (any strictness) → 400
+2. ``stream=true``  + ``response_format=json_schema`` (any strictness) → 400
+3. ``stream=false`` + ``response_format=json_object``                  → 200
+   (regression test — ``json_object`` must keep working post-r10-J,
+   else we over-corrected and broke loose-JSON callers).
+"""
+
+from __future__ import annotations
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from vllm_mlx.config import reset_config
+from vllm_mlx.engine.base import GenerationOutput
+from vllm_mlx.middleware.exception_handlers import install_exception_handlers
+from vllm_mlx.routes.completions import router as completions_router
+
+_FENCED_TEXT = 'Just the JSON.\n```json\n{"answer": 42}\n```'
+_CLEAN_TEXT = '{"answer": 42}'
+
+_JSON_SCHEMA_STRICT = {
+    "type": "json_schema",
+    "json_schema": {
+        "name": "answer_envelope",
+        "strict": True,
+        "schema": {
+            "type": "object",
+            "properties": {"answer": {"type": "integer"}},
+            "required": ["answer"],
+            "additionalProperties": False,
+        },
+    },
+}
+
+_JSON_SCHEMA_LOOSE = {
+    "type": "json_schema",
+    "json_schema": {
+        "name": "answer_envelope",
+        "schema": {
+            "type": "object",
+            "properties": {"answer": {"type": "integer"}},
+        },
+    },
+}
+
+
+class _FencedCompletionEngine:
+    preserve_native_tool_format = False
+    is_mllm = False
+    supports_guided_generation = False
+    tokenizer = None
+
+    async def generate(self, prompt, **kwargs):
+        return GenerationOutput(
+            text=_FENCED_TEXT,
+            prompt_tokens=8,
+            completion_tokens=12,
+            finished=True,
+            finish_reason="stop",
+        )
+
+    async def stream_generate(self, prompt, **kwargs):
+        yield GenerationOutput(
+            text=_FENCED_TEXT,
+            new_text=_FENCED_TEXT,
+            prompt_tokens=8,
+            completion_tokens=12,
+            finished=True,
+            finish_reason="stop",
+        )
+
+
+def _make_client() -> TestClient:
+    cfg = reset_config()
+    cfg.engine = _FencedCompletionEngine()
+    cfg.model_name = "test-model"
+    cfg.model_registry = None
+    cfg.no_thinking = True
+    app = FastAPI()
+    install_exception_handlers(app)
+    app.include_router(completions_router)
+    return TestClient(app)
+
+
+def _assert_400_envelope(resp) -> None:
+    assert resp.status_code == 400, resp.text
+    body = resp.json()
+    err = body["error"]
+    assert err["type"] == "invalid_request_error"
+    assert err["code"] == "unsupported_response_format"
+    assert err["param"] == "response_format"
+    assert "json_schema" in err["message"]
+    assert "/v1/chat/completions" in err["message"]
+
+
+def test_sync_json_schema_strict_rejected_with_400():
+    """Strict path: pre-fix the route returned 200 with the
+    fence-stripped JSON but never validated it against the schema —
+    silent ``strict=true`` violation. Post-fix: 400 invalid_request."""
+    client = _make_client()
+    resp = client.post(
+        "/v1/completions",
+        json={
+            "model": "test-model",
+            "prompt": "hi",
+            "max_tokens": 16,
+            "response_format": _JSON_SCHEMA_STRICT,
+        },
+    )
+    _assert_400_envelope(resp)
+
+
+def test_sync_json_schema_loose_also_rejected_with_400():
+    """Defense-in-depth: even ``strict`` omitted, ``json_schema``
+    semantics imply schema enforcement; this route doesn't do that,
+    so reject the whole ``type=json_schema`` shape — don't try to
+    guess intent. Callers needing loose JSON use ``json_object``."""
+    client = _make_client()
+    resp = client.post(
+        "/v1/completions",
+        json={
+            "model": "test-model",
+            "prompt": "hi",
+            "max_tokens": 16,
+            "response_format": _JSON_SCHEMA_LOOSE,
+        },
+    )
+    _assert_400_envelope(resp)
+
+
+def test_stream_json_schema_rejected_with_400():
+    """Streaming path: the reject runs BEFORE the SSE
+    StreamingResponse commits, so the client sees a 400 envelope
+    instead of an EventSource that emits unconstrained text."""
+    client = _make_client()
+    resp = client.post(
+        "/v1/completions",
+        json={
+            "model": "test-model",
+            "prompt": "hi",
+            "max_tokens": 16,
+            "stream": True,
+            "response_format": _JSON_SCHEMA_STRICT,
+        },
+    )
+    _assert_400_envelope(resp)
+
+
+def test_sync_json_object_still_works_after_r10_j_rejection():
+    """Regression guard for over-correction: ``json_object`` (loose,
+    no schema) must keep working post-r10-J. The wire ``text`` should
+    be fence-stripped per r10-H4 chat-lane parity."""
+    client = _make_client()
+    resp = client.post(
+        "/v1/completions",
+        json={
+            "model": "test-model",
+            "prompt": "hi",
+            "max_tokens": 16,
+            "response_format": {"type": "json_object"},
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["choices"][0]["text"] == _CLEAN_TEXT
+
+
+def test_json_schema_plus_logprobs_400_still_fires_for_combination_rule():
+    """Cross-check: ``response_format + logprobs`` was already
+    rejected by the r10-G/H r1 fix. Make sure r10-J's earlier-in-the-
+    pipeline reject of ``json_schema`` doesn't accidentally mask
+    that combination error — the matrix has two orthogonal 400
+    rules, and either firing is acceptable as long as the request
+    is rejected."""
+    client = _make_client()
+    resp = client.post(
+        "/v1/completions",
+        json={
+            "model": "test-model",
+            "prompt": "hi",
+            "max_tokens": 16,
+            "response_format": _JSON_SCHEMA_STRICT,
+            "logprobs": 2,
+        },
+    )
+    assert resp.status_code == 400, resp.text
+    body = resp.json()
+    err = body["error"]
+    assert err["type"] == "invalid_request_error"
+    assert err["param"] == "response_format"
+    # Either rule fired — both are correct 400s for this matrix cell.
+    assert err["code"] in {
+        "unsupported_response_format",
+        "unsupported_combination",
+    }

--- a/tests/test_completions_response_format_logprobs.py
+++ b/tests/test_completions_response_format_logprobs.py
@@ -1,0 +1,248 @@
+# SPDX-License-Identifier: Apache-2.0
+"""r10-G/H follow-up — codex round-1 MED #4 / #5.
+
+The R10-H4 ``response_format=json_object`` fix on ``/v1/completions``
+was incomplete: ``logprobs`` undid the fence-strip on the non-stream
+path (the post-cleanup ``final_text`` was overwritten by the token
+concatenation) and silently bypassed it on the streaming path (the
+``_json_mode`` gate explicitly excluded ``want_logprobs``). The two
+contracts are incompatible — ``text_offset`` is a per-token byte
+cursor against ``text``, and a fence-stripped ``text`` no longer
+aligns with the raw token concatenation.
+
+Rather than ship a half-correct hybrid (silent corruption vs silent
+bypass) we reject the combination with a 400 envelope on BOTH
+synchronous and streaming paths. Either knob alone keeps working.
+
+The four tests below pin all four matrix cells:
+
+1. ``stream=false`` + ``response_format=json_object`` + ``logprobs=2`` → 400
+2. ``stream=false`` + ``response_format=json_object`` (no logprobs)  → 200,
+   wire ``text`` is fence-stripped (positive-path coverage so a future
+   refactor that *also* skips the strip on logprobs=None is caught).
+3. ``stream=true``  + ``response_format=json_object`` + ``logprobs=2`` → 400
+4. ``stream=true``  + ``response_format=json_object`` (no logprobs)  → 200,
+   the single buffered text delta is fence-stripped.
+"""
+
+from __future__ import annotations
+
+import json
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from vllm_mlx.config import reset_config
+from vllm_mlx.engine.base import GenerationOutput
+from vllm_mlx.middleware.exception_handlers import install_exception_handlers
+from vllm_mlx.routes.completions import router as completions_router
+
+# A fenced-JSON output that vlad r10-R1 / bo r10-R1 reproduced on the
+# wire. The fence-strip helper (``extract_json_from_response``) must
+# peel the markdown wrapper and the "Just the JSON.\n…" preamble down
+# to the bare ``{"answer": 42}`` JSON object.
+_FENCED_TEXT = 'Just the JSON.\nAnswer:\n```json\n{"answer": 42}\n```'
+_CLEAN_TEXT = '{"answer": 42}'
+
+
+class _FencedCompletionEngine:
+    """Mock completion engine that emits the fenced-JSON shape r10-H4
+    was wired to clean up. Implements both ``generate`` (sync) and
+    ``stream_generate`` (SSE) so both code paths can be exercised
+    without a real model load.
+    """
+
+    preserve_native_tool_format = False
+    is_mllm = False
+    supports_guided_generation = False
+    tokenizer = None
+
+    async def generate(self, prompt, **kwargs):
+        return GenerationOutput(
+            text=_FENCED_TEXT,
+            prompt_tokens=8,
+            completion_tokens=12,
+            finished=True,
+            finish_reason="stop",
+        )
+
+    async def stream_generate(self, prompt, **kwargs):
+        # Single chunk carrying the full fenced text. The streaming
+        # json-mode buffer accumulates ``new_text`` across chunks and
+        # runs the strip once at finalize, so one chunk is enough to
+        # exercise the wire-output contract.
+        yield GenerationOutput(
+            text=_FENCED_TEXT,
+            new_text=_FENCED_TEXT,
+            prompt_tokens=8,
+            completion_tokens=12,
+            finished=True,
+            finish_reason="stop",
+        )
+
+
+def _make_client() -> TestClient:
+    cfg = reset_config()
+    cfg.engine = _FencedCompletionEngine()
+    cfg.model_name = "test-model"
+    cfg.model_registry = None
+    cfg.no_thinking = True
+    app = FastAPI()
+    # ``install_exception_handlers`` is what unwraps
+    # ``HTTPException(detail={"error": ...})`` into a flat top-level
+    # ``error`` body. Without it FastAPI emits the legacy
+    # ``{"detail": {...}}`` shape and the structured envelope assertions
+    # below would mis-aim (the tests would still pass on a regression
+    # that returned a bare-string detail with the wrong status code).
+    install_exception_handlers(app)
+    app.include_router(completions_router)
+    return TestClient(app)
+
+
+def _parse_sse_events(text: str) -> list[dict]:
+    events: list[dict] = []
+    for line in text.splitlines():
+        line = line.strip()
+        if not line.startswith("data:"):
+            continue
+        payload = line.removeprefix("data:").strip()
+        if payload == "[DONE]":
+            continue
+        events.append(json.loads(payload))
+    return events
+
+
+# ---------------------------------------------------------------------------
+# Synchronous /v1/completions
+# ---------------------------------------------------------------------------
+
+
+def test_sync_response_format_plus_logprobs_rejected_with_400():
+    """Codex r1 MED #4: pre-fix the route returned 200 with raw fenced
+    text in ``choices[0].text`` (the ``want_logprobs`` branch reset
+    ``final_text`` to the token concat, undoing the strip at L404).
+    Post-fix the combination is rejected with the standard
+    OpenAI-shaped invalid_request envelope so the caller picks one
+    knob per request."""
+    client = _make_client()
+
+    resp = client.post(
+        "/v1/completions",
+        json={
+            "model": "test-model",
+            "prompt": "hi",
+            "max_tokens": 16,
+            "response_format": {"type": "json_object"},
+            "logprobs": 2,
+        },
+    )
+
+    assert resp.status_code == 400, resp.text
+    body = resp.json()
+    err = body["error"]
+    assert err["type"] == "invalid_request_error"
+    assert err["code"] == "unsupported_combination"
+    assert err["param"] == "response_format"
+    # Message names BOTH knobs so a caller skimming the error string
+    # immediately sees the resolution.
+    assert "response_format" in err["message"]
+    assert "logprobs" in err["message"]
+
+
+def test_sync_response_format_without_logprobs_still_strips_fences():
+    """Positive-path control: with ``logprobs`` omitted, the
+    sync ``/v1/completions`` route returns 200 and the wire ``text``
+    is the fence-stripped JSON (chat-lane parity per r10-H4).
+
+    Catches a future refactor that over-corrects MED #4 by skipping the
+    strip whenever ``response_format`` is set."""
+    client = _make_client()
+
+    resp = client.post(
+        "/v1/completions",
+        json={
+            "model": "test-model",
+            "prompt": "hi",
+            "max_tokens": 16,
+            "response_format": {"type": "json_object"},
+        },
+    )
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["choices"][0]["text"] == _CLEAN_TEXT
+    # Logprobs branch was not taken; payload must be absent.
+    assert body["choices"][0].get("logprobs") is None
+
+
+# ---------------------------------------------------------------------------
+# Streaming /v1/completions
+# ---------------------------------------------------------------------------
+
+
+def test_stream_response_format_plus_logprobs_rejected_with_400():
+    """Codex r1 MED #5: pre-fix the route returned 200 with raw fenced
+    SSE deltas (the streaming ``_json_mode`` gate at L601 explicitly
+    excluded ``want_logprobs``, silently bypassing the buffered fence
+    strip). Post-fix the combination is rejected BEFORE the SSE
+    StreamingResponse commits, so the caller sees a 400 envelope
+    instead of an EventSource that emits unscrubbed text."""
+    client = _make_client()
+
+    resp = client.post(
+        "/v1/completions",
+        json={
+            "model": "test-model",
+            "prompt": "hi",
+            "max_tokens": 16,
+            "stream": True,
+            "response_format": {"type": "json_object"},
+            "logprobs": 2,
+        },
+    )
+
+    assert resp.status_code == 400, resp.text
+    body = resp.json()
+    err = body["error"]
+    assert err["type"] == "invalid_request_error"
+    assert err["code"] == "unsupported_combination"
+    assert err["param"] == "response_format"
+
+
+def test_stream_response_format_without_logprobs_strips_fences_in_buffered_chunk():
+    """Positive-path control for streaming: with ``logprobs`` omitted,
+    the route returns 200 and the buffered single-chunk emit carries
+    the fence-stripped JSON in ``choices[0].text``.
+
+    Asserts on the consolidated chunk the json-mode branch emits at
+    finalize (per the r10-H4 design note in ``completions.py`` —
+    structured-output clients don't pipeline partial JSON, so legacy
+    completions trade per-token granularity for a clean wire payload).
+    """
+    client = _make_client()
+
+    resp = client.post(
+        "/v1/completions",
+        json={
+            "model": "test-model",
+            "prompt": "hi",
+            "max_tokens": 16,
+            "stream": True,
+            "response_format": {"type": "json_object"},
+        },
+    )
+
+    assert resp.status_code == 200, resp.text
+    events = _parse_sse_events(resp.text)
+    text_chunks = [
+        e for e in events if e.get("choices") and e["choices"][0].get("text")
+    ]
+    assert len(text_chunks) >= 1, (
+        f"expected at least one text-carrying chunk; got events={events!r}"
+    )
+    # The buffered emit is the LAST text-carrying chunk; its text
+    # field must be the fence-stripped payload.
+    final = text_chunks[-1]
+    assert final["choices"][0]["text"] == _CLEAN_TEXT
+    # Finish reason is on the same buffered chunk in json-mode.
+    assert final["choices"][0]["finish_reason"] == "stop"

--- a/tests/test_r10_scrub_validation_bundle.py
+++ b/tests/test_r10_scrub_validation_bundle.py
@@ -1,0 +1,586 @@
+# SPDX-License-Identifier: Apache-2.0
+"""r10 G/H bundle — wire-scrub completion + validation tests.
+
+Covers the six findings the bundle PR landed:
+
+* **R10-C8** (Mira r10-R1): UI-TARS-style ``"Tool: <name>\\nParameters: ..."``
+  prose preamble leaked into ``delta.content`` before the structured
+  ``delta.tool_calls`` chunk. The streaming postprocessor now buffers
+  content matching the tool-prose prefix pattern and discards the
+  buffer when a tool_call event arrives.
+* **R10-M4** (Mira r10-R1): trailing ``\\n\\n`` whitespace after the
+  scrubbed ``<tool_call>`` literal leaked into ``delta.content``. The
+  tool-prose hold-back folds the whitespace into the prose buffer so
+  the same tool_call discard takes care of it.
+* **R10-H2** (Sven r10-R1): forced ``tool_choice={"type":"function",
+  "function":{"name":X}}`` admitted two tool_call indices with
+  distinct ``call_id`` values on qwen3 streaming. Single-call
+  enforcement now drops every anchor after the first under the
+  forced-name latch.
+* **R10-H3** (Sven r10-R1): ``tool_choice="required"`` streamed raw
+  token-sequence ``arguments`` (``"20230805"``) that violated the
+  declared JSON-object schema. The forced-tool-choice filter now
+  applies the same arguments-must-be-object gate to ``required``
+  mode.
+* **R10-H4** (Vlad r10-R1 / Bo r10-R1, R9-H2 carry):
+  ``/v1/completions`` with ``response_format={"type":"json_object"}``
+  silently dropped the field on both sync and streaming paths. The
+  field is now declared on ``CompletionRequest`` and the route
+  applies the same ``extract_json_from_response`` peel the chat lane
+  uses.
+* **R10-H5** (Sven r10-R1 / Vlad r10-R1, R9-H3 carry):
+  ``reasoning_effort`` accepted any value (int, list, null,
+  ``"banana"``) with HTTP 200 because the field was undeclared. The
+  field is now ``Literal[...]``-enforced on both
+  ``/v1/chat/completions`` AND ``/v1/responses`` (including the
+  nested ``reasoning.effort`` shape on Responses).
+* **R10-H6** (Mira r10-R1, R9-H4 carry): chat-lane
+  ``tools=[{"type":"computer_use"}]`` shorthand 400'd because
+  ``ToolDefinition`` required the ``function`` field. The model
+  validator now synthesises the canonical ``computer`` function
+  tool when ``type`` is a Computer-Use alias — parity with the
+  ``/v1/responses`` ``_convert_tools`` normalisation.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from vllm_mlx.api.models import (
+    ChatCompletionRequest,
+    CompletionRequest,
+    ToolDefinition,
+)
+from vllm_mlx.api.responses_models import ResponsesRequest
+
+# ---------------------------------------------------------------------------
+# R10-H5 — reasoning_effort enum on chat + responses
+# ---------------------------------------------------------------------------
+
+
+def _base_chat_kwargs():
+    return {"model": "m", "messages": [{"role": "user", "content": "hi"}]}
+
+
+@pytest.mark.parametrize(
+    "value",
+    ["none", "minimal", "low", "medium", "high"],
+)
+def test_r10_h5_chat_reasoning_effort_valid(value):
+    """Every documented effort string is accepted on /v1/chat/completions."""
+    req = ChatCompletionRequest(**_base_chat_kwargs(), reasoning_effort=value)
+    assert req.reasoning_effort == value
+
+
+def test_r10_h5_chat_reasoning_effort_null_accepted():
+    """``reasoning_effort=None`` (the field default) is the unset signal."""
+    req = ChatCompletionRequest(**_base_chat_kwargs(), reasoning_effort=None)
+    assert req.reasoning_effort is None
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        "banana",
+        "NONE",  # case variant; OpenAI spec uses lowercase only
+        "Low",
+        42,
+        [],
+        {},
+        True,  # bool is an int subclass; must still 400
+    ],
+)
+def test_r10_h5_chat_reasoning_effort_invalid_rejected(bad):
+    """Sven r10-R1 + Vlad r10-R1: garbage values must 400 with the spec set."""
+    with pytest.raises(ValidationError) as excinfo:
+        ChatCompletionRequest(**_base_chat_kwargs(), reasoning_effort=bad)
+    msg = str(excinfo.value)
+    assert "reasoning_effort" in msg
+
+
+@pytest.mark.parametrize(
+    "value",
+    ["none", "minimal", "low", "medium", "high"],
+)
+def test_r10_h5_responses_top_level_reasoning_effort_valid(value):
+    """The top-level shorthand surface accepts the same set as chat."""
+    req = ResponsesRequest(model="m", input="hi", reasoning_effort=value)
+    assert req.reasoning_effort == value
+
+
+@pytest.mark.parametrize(
+    "bad",
+    ["banana", 42, [], {}, True],
+)
+def test_r10_h5_responses_top_level_reasoning_effort_invalid_rejected(bad):
+    with pytest.raises(ValidationError):
+        ResponsesRequest(model="m", input="hi", reasoning_effort=bad)
+
+
+@pytest.mark.parametrize(
+    "value",
+    ["none", "minimal", "low", "medium", "high"],
+)
+def test_r10_h5_responses_nested_reasoning_effort_valid(value):
+    """Canonical OpenAI Responses spec uses ``reasoning.effort`` (nested)."""
+    req = ResponsesRequest(model="m", input="hi", reasoning={"effort": value})
+    assert req.reasoning == {"effort": value}
+
+
+@pytest.mark.parametrize(
+    "bad",
+    ["banana", 42, [], True],
+)
+def test_r10_h5_responses_nested_reasoning_effort_invalid_rejected(bad):
+    with pytest.raises(ValidationError) as excinfo:
+        ResponsesRequest(model="m", input="hi", reasoning={"effort": bad})
+    assert "reasoning.effort" in str(excinfo.value)
+
+
+def test_r10_h5_responses_reasoning_dict_without_effort_passes():
+    """Other ``reasoning`` keys (``summary``, ``encrypted_content``) flow."""
+    req = ResponsesRequest(
+        model="m",
+        input="hi",
+        reasoning={"summary": "auto"},
+    )
+    assert req.reasoning == {"summary": "auto"}
+
+
+# ---------------------------------------------------------------------------
+# R10-H6 — chat-lane computer_use shorthand
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "alias",
+    ["computer_use", "computer_use_preview", "computer_20251022"],
+)
+def test_r10_h6_computer_use_shorthand_accepted(alias):
+    """Mira r10-R1: chat-lane ToolDefinition now mirrors the Responses
+    alias map. The shorthand is normalised to a synthetic ``computer``
+    function tool so the UI-TARS tool parser sees a matching entry.
+    """
+    t = ToolDefinition.model_validate({"type": alias})
+    assert t.type == "function"
+    assert isinstance(t.function, dict)
+    assert t.function["name"] == "computer"
+    assert "parameters" in t.function
+
+
+def test_r10_h6_computer_use_shorthand_preserves_geometry_hints():
+    """``display_width`` / ``display_height`` / ``environment`` flow into
+    the synthetic function's ``parameters._computer_use`` block — same
+    plumbing the Responses lane uses.
+    """
+    t = ToolDefinition.model_validate(
+        {
+            "type": "computer_use_preview",
+            "display_width": 1280,
+            "display_height": 800,
+            "environment": "linux",
+        }
+    )
+    cu = t.function["parameters"]["_computer_use"]
+    assert cu == {
+        "display_width": 1280,
+        "display_height": 800,
+        "environment": "linux",
+    }
+
+
+def test_r10_h6_function_classic_still_required():
+    """The canonical ``{"type":"function","function":{"name":"x"}}`` shape
+    keeps working (F-035 contract preserved).
+    """
+    t = ToolDefinition.model_validate(
+        {"type": "function", "function": {"name": "x", "parameters": {}}}
+    )
+    assert t.function["name"] == "x"
+
+
+def test_r10_h6_missing_function_for_function_type_rejected():
+    """``{"type":"function"}`` with no ``function`` field still 400s."""
+    with pytest.raises(ValidationError):
+        ToolDefinition.model_validate({"type": "function"})
+
+
+def test_r10_h6_in_chat_completion_request():
+    """End-to-end: shorthand inside a request parses without 400."""
+    req = ChatCompletionRequest(
+        **_base_chat_kwargs(),
+        tools=[{"type": "computer_use_preview", "display_width": 1024}],
+    )
+    assert req.tools is not None
+    assert len(req.tools) == 1
+    assert req.tools[0].function["name"] == "computer"
+
+
+# ---------------------------------------------------------------------------
+# R10-H4 — /v1/completions response_format declared + validated
+# ---------------------------------------------------------------------------
+
+
+def test_r10_h4_completions_response_format_json_object_accepted():
+    """Vlad r10-R1: the field was previously silently dropped."""
+    req = CompletionRequest(
+        model="m", prompt="hi", response_format={"type": "json_object"}
+    )
+    assert req.response_format is not None
+    # Typed arm wins because of the union arm dispatch.
+    assert getattr(req.response_format, "type", None) == "json_object"
+
+
+def test_r10_h4_completions_response_format_invalid_type_rejected():
+    """Same closed-set check the chat lane runs."""
+    with pytest.raises(ValidationError):
+        CompletionRequest(
+            model="m", prompt="hi", response_format={"type": "xml"}
+        )
+
+
+def test_r10_h4_completions_response_format_missing_type_rejected():
+    with pytest.raises(ValidationError):
+        CompletionRequest(model="m", prompt="hi", response_format={})
+
+
+# ---------------------------------------------------------------------------
+# R10-H2 + R10-H3 — forced tool_choice single-call + args-must-be-object
+# ---------------------------------------------------------------------------
+
+
+def _make_postprocessor(*, tool_choice):
+    """Build a StreamingPostProcessor with a minimal ServerConfig shim."""
+    from vllm_mlx.service.postprocessor import StreamingPostProcessor
+
+    class _Cfg:
+        reasoning_parser_name = None
+        reasoning_parser = None
+        tool_call_parser = None
+        tool_parser_instance = None
+        enable_auto_tool_choice = False
+        engine = None
+        no_thinking = False
+
+    req = {
+        "tool_choice": tool_choice,
+        "tools": [
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            }
+        ],
+    }
+    return StreamingPostProcessor(_Cfg(), tools_requested=True, request=req)
+
+
+def test_r10_h2_forced_named_choice_single_call_enforced():
+    """Sven r10-R1: forced named choice on qwen3 admitted index 0 AND
+    index 1 with two distinct call_ids. The single-call latch now drops
+    every anchor after the first.
+    """
+    pp = _make_postprocessor(
+        tool_choice={"type": "function", "function": {"name": "get_weather"}}
+    )
+    anchors = [
+        {
+            "index": 0,
+            "id": "call_0d8c5338",
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "arguments": '{"location": "Paris"}',
+            },
+        },
+        {
+            "index": 1,
+            "id": "call_fbe75ec9",
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "arguments": '{"location": "Paris"}',
+            },
+        },
+    ]
+    filtered = pp._apply_forced_tool_choice_filter(anchors)
+    assert len(filtered) == 1
+    assert filtered[0]["id"] == "call_0d8c5338"
+
+
+def test_r10_h2_forced_named_choice_continuation_fragments_pass():
+    """Argument-fragment deltas (no anchor metadata) STILL flow through —
+    they belong to the admitted call so its arguments JSON can complete.
+    """
+    pp = _make_postprocessor(
+        tool_choice={"type": "function", "function": {"name": "get_weather"}}
+    )
+    # First the anchor lands.
+    pp._apply_forced_tool_choice_filter(
+        [
+            {
+                "index": 0,
+                "id": "call_a",
+                "type": "function",
+                "function": {"name": "get_weather"},
+            }
+        ]
+    )
+    # Then a continuation arrives in a separate batch.
+    continuations = [
+        {"index": 0, "function": {"arguments": '"Paris"}'}},
+    ]
+    out = pp._apply_forced_tool_choice_filter(continuations)
+    assert len(out) == 1
+
+
+def test_r10_h3_required_mode_arguments_must_be_json_object():
+    """Sven r10-R1: ``tool_choice="required"`` streamed raw token-sequence
+    ``arguments="20230805"`` — valid JSON, but NOT a JSON object, so the
+    declared tool schema can never be satisfied. Drop the anchor.
+    """
+    pp = _make_postprocessor(tool_choice="required")
+    anchors = [
+        {
+            "index": 0,
+            "id": "call_a",
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "arguments": "20230805",  # bare integer; non-object root
+            },
+        }
+    ]
+    filtered = pp._apply_forced_tool_choice_filter(anchors)
+    assert filtered == []
+
+
+def test_r10_h3_required_mode_object_args_pass():
+    pp = _make_postprocessor(tool_choice="required")
+    anchors = [
+        {
+            "index": 0,
+            "id": "call_a",
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "arguments": '{"location": "Paris"}',
+            },
+        }
+    ]
+    filtered = pp._apply_forced_tool_choice_filter(anchors)
+    assert len(filtered) == 1
+
+
+def test_r10_h3_required_mode_allows_parallel_calls():
+    """``required`` mode does NOT trigger the single-call latch (parallel
+    multi-tool dispatch is legal). Forced NAMED choice IS capped — see
+    test_r10_h2_forced_named_choice_single_call_enforced.
+    """
+    pp = _make_postprocessor(tool_choice="required")
+    anchors = [
+        {
+            "index": 0,
+            "id": "call_a",
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "arguments": '{"location": "Paris"}',
+            },
+        },
+        {
+            "index": 1,
+            "id": "call_b",
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "arguments": '{"location": "Berlin"}',
+            },
+        },
+    ]
+    filtered = pp._apply_forced_tool_choice_filter(anchors)
+    assert len(filtered) == 2
+
+
+# ---------------------------------------------------------------------------
+# R10-C8 + R10-M4 — tool-prose prefix + trailing whitespace scrub
+# ---------------------------------------------------------------------------
+
+
+def _content_chunks(events):
+    from vllm_mlx.domain.events import StreamEvent  # noqa: F401
+
+    return [ev.content for ev in events if ev.type == "content" and ev.content]
+
+
+def test_r10_c8_tool_prose_prefix_is_buffered():
+    """Mira r10-R1 evidence: when a request declares tools, content
+    starting with ``Tool: <name>`` MUST be held back. The buffer is
+    discarded when a tool_call event arrives later in the same turn.
+    """
+    pp = _make_postprocessor(tool_choice="auto")
+    from vllm_mlx.domain.events import StreamEvent
+
+    # Simulate the 12 prose chunks Mira observed.
+    held = pp._filter_events_for_tool_prose(
+        [StreamEvent(type="content", content="Tool")]
+    )
+    assert _content_chunks(held) == []
+    held = pp._filter_events_for_tool_prose(
+        [StreamEvent(type="content", content=":")]
+    )
+    assert _content_chunks(held) == []
+    held = pp._filter_events_for_tool_prose(
+        [StreamEvent(type="content", content=" get_weather")]
+    )
+    assert _content_chunks(held) == []
+
+
+def test_r10_c8_tool_call_discards_buffered_prose():
+    """When the parser surfaces a tool_call, the buffered prose IS
+    discarded — clients see only the structured call, never the
+    preamble.
+    """
+    pp = _make_postprocessor(tool_choice="auto")
+    from vllm_mlx.domain.events import StreamEvent
+
+    pp._filter_events_for_tool_prose(
+        [StreamEvent(type="content", content="Tool: get_weather\n")]
+    )
+    pp._filter_events_for_tool_prose(
+        [StreamEvent(type="content", content="Parameters: location=Paris\n")]
+    )
+    # Now the structured tool_call arrives.
+    out = pp._filter_events_for_tool_prose(
+        [
+            StreamEvent(
+                type="tool_call",
+                content=None,
+                tool_calls=[{"index": 0, "id": "call_x"}],
+            )
+        ]
+    )
+    # The tool_call passes through; no content leaked.
+    assert any(ev.type == "tool_call" for ev in out)
+    assert _content_chunks(out) == []
+    # Buffer cleared.
+    assert pp._tool_prose_buffer == ""
+
+
+def test_r10_m4_trailing_whitespace_folded_into_prose_buffer():
+    """The `\\n\\n` trailing whitespace Mira called out is folded into the
+    buffer; when the tool_call lands, the whitespace is discarded too.
+    """
+    pp = _make_postprocessor(tool_choice="auto")
+    from vllm_mlx.domain.events import StreamEvent
+
+    pp._filter_events_for_tool_prose(
+        [StreamEvent(type="content", content="Tool: get_weather\n\n")]
+    )
+    assert "\n\n" in pp._tool_prose_buffer
+    pp._filter_events_for_tool_prose(
+        [
+            StreamEvent(
+                type="tool_call",
+                content=None,
+                tool_calls=[{"index": 0, "id": "call_x"}],
+            )
+        ]
+    )
+    assert pp._tool_prose_buffer == ""
+
+
+def test_r10_c8_non_prose_content_passes_through():
+    """A request that legitimately starts with ``"Hello"`` is NOT held —
+    only the narrow ``Tool|Action|Function:`` prefix triggers the
+    buffer. Defense against over-eager censoring.
+    """
+    pp = _make_postprocessor(tool_choice="auto")
+    from vllm_mlx.domain.events import StreamEvent
+
+    out = pp._filter_events_for_tool_prose(
+        [StreamEvent(type="content", content="Hello there!")]
+    )
+    assert _content_chunks(out) == ["Hello there!"]
+
+
+def test_r10_c8_no_op_when_tools_not_requested():
+    """If the client never declared tools, the filter is a pass-through.
+    Non-tool requests pay zero overhead.
+    """
+    pp = _make_postprocessor(tool_choice="auto")
+    pp.tools_requested = False  # simulate a tool-less request
+    from vllm_mlx.domain.events import StreamEvent
+
+    out = pp._filter_events_for_tool_prose(
+        [StreamEvent(type="content", content="Tool: foo")]
+    )
+    assert _content_chunks(out) == ["Tool: foo"]
+
+
+def test_r10_c8_held_buffer_released_at_stream_end_without_tool_call():
+    """If the model legitimately ended the turn with ``Tool:`` prose AND
+    no tool_call was detected, the buffer IS released (silent drop
+    would be wrong).
+    """
+    pp = _make_postprocessor(tool_choice="auto")
+    from vllm_mlx.domain.events import StreamEvent
+
+    pp._filter_events_for_tool_prose(
+        [StreamEvent(type="content", content="Tool:")]
+    )
+    # No tool_calls_detected yet.
+    flushed = pp._flush_tool_prose_buffer()
+    assert flushed == "Tool:"
+
+
+def test_r10_c8_held_buffer_dropped_at_stream_end_with_tool_call():
+    """If a tool_call WAS detected, the held buffer IS dropped at
+    finalize — it was the dispatch preamble.
+    """
+    pp = _make_postprocessor(tool_choice="auto")
+    from vllm_mlx.domain.events import StreamEvent
+
+    pp._filter_events_for_tool_prose(
+        [StreamEvent(type="content", content="Tool: get_weather")]
+    )
+    pp.tool_calls_detected = True
+    flushed = pp._flush_tool_prose_buffer()
+    assert flushed == ""
+
+
+def test_r10_c8_buffer_releases_when_growing_past_cap():
+    """Soft cap protects against indefinite hold on a model legitimately
+    discussing the word ``Tool:`` in long prose.
+    """
+    pp = _make_postprocessor(tool_choice="auto")
+    from vllm_mlx.domain.events import StreamEvent
+
+    long_text = "Tool: " + "x" * (pp._TOOL_PROSE_MAX_HOLD + 8)
+    out = pp._filter_events_for_tool_prose(
+        [StreamEvent(type="content", content=long_text)]
+    )
+    # The buffer is released as content.
+    assert any(ev.type == "content" and ev.content for ev in out)
+    assert pp._tool_prose_buffer == ""
+
+
+# ---------------------------------------------------------------------------
+# Cross-cut: full request shape still validates
+# ---------------------------------------------------------------------------
+
+
+def test_r10_bundle_full_request_with_all_fields_accepted():
+    """One request exercising every new field at once."""
+    req = ChatCompletionRequest(
+        **_base_chat_kwargs(),
+        reasoning_effort="low",
+        tools=[{"type": "computer_use_preview", "display_width": 1280}],
+        tool_choice={"type": "function", "function": {"name": "computer"}},
+    )
+    assert req.reasoning_effort == "low"
+    assert req.tools[0].function["name"] == "computer"
+    assert req.tool_choice == {"type": "function", "function": {"name": "computer"}}

--- a/tests/test_r10_scrub_validation_bundle.py
+++ b/tests/test_r10_scrub_validation_bundle.py
@@ -235,9 +235,7 @@ def test_r10_h4_completions_response_format_json_object_accepted():
 def test_r10_h4_completions_response_format_invalid_type_rejected():
     """Same closed-set check the chat lane runs."""
     with pytest.raises(ValidationError):
-        CompletionRequest(
-            model="m", prompt="hi", response_format={"type": "xml"}
-        )
+        CompletionRequest(model="m", prompt="hi", response_format={"type": "xml"})
 
 
 def test_r10_h4_completions_response_format_missing_type_rejected():
@@ -429,9 +427,7 @@ def test_r10_c8_tool_prose_prefix_is_buffered():
         [StreamEvent(type="content", content="Tool")]
     )
     assert _content_chunks(held) == []
-    held = pp._filter_events_for_tool_prose(
-        [StreamEvent(type="content", content=":")]
-    )
+    held = pp._filter_events_for_tool_prose([StreamEvent(type="content", content=":")])
     assert _content_chunks(held) == []
     held = pp._filter_events_for_tool_prose(
         [StreamEvent(type="content", content=" get_weather")]
@@ -529,9 +525,7 @@ def test_r10_c8_held_buffer_released_at_stream_end_without_tool_call():
     pp = _make_postprocessor(tool_choice="auto")
     from vllm_mlx.domain.events import StreamEvent
 
-    pp._filter_events_for_tool_prose(
-        [StreamEvent(type="content", content="Tool:")]
-    )
+    pp._filter_events_for_tool_prose([StreamEvent(type="content", content="Tool:")])
     # No tool_calls_detected yet.
     flushed = pp._flush_tool_prose_buffer()
     assert flushed == "Tool:"

--- a/tests/test_serve_host_loopback_default.py
+++ b/tests/test_serve_host_loopback_default.py
@@ -304,3 +304,88 @@ def test_legacy_server_argparse_host_default_is_loopback():
     assert 'default="0.0.0.0"' not in server_src, (
         "vllm_mlx/server.py must not retain the legacy 0.0.0.0 default"
     )
+
+
+# ---------------------------------------------------------------------------
+# IPv6 preflight — codex round-1 MED #6 on PR #855
+# ---------------------------------------------------------------------------
+
+
+def _ipv6_loopback_supported() -> bool:
+    """Skip-guard for IPv6-disabled environments.
+
+    GH Actions runners sometimes disable IPv6 entirely; we don't want a
+    real environment limitation to flake the test. A trivial ``::1``
+    bind probe tells us whether the family is usable.
+    """
+    try:
+        with socket.socket(socket.AF_INET6, socket.SOCK_STREAM) as s:
+            s.bind(("::1", 0))
+        return True
+    except OSError:
+        return False
+
+
+@pytest.mark.skipif(
+    not _ipv6_loopback_supported(), reason="IPv6 loopback not available"
+)
+def test_preflight_passes_for_ipv6_loopback_on_free_port():
+    """Codex round-1 MED #6 on PR #855: pre-fix the IPv4-only preflight
+    always opened an ``AF_INET`` socket, so ``--host ::1`` raised
+    ``OSError`` from ``socket.bind`` and was misreported as "port
+    already in use" — blocking a configuration uvicorn otherwise
+    supports.
+
+    Post-fix the helper detects IPv6 literals and switches the probe
+    family to ``AF_INET6``. On a free port the call must return cleanly
+    (no SystemExit) just like the IPv4 happy path."""
+    # OS-assigned IPv6 loopback port.
+    with socket.socket(socket.AF_INET6, socket.SOCK_STREAM) as s:
+        s.bind(("::1", 0))
+        free_port = s.getsockname()[1]
+
+    result = cli._port_preflight_or_die("::1", free_port, model="qwen3.5-4b-4bit")
+    assert result is None
+
+
+@pytest.mark.skipif(
+    not _ipv6_loopback_supported(), reason="IPv6 loopback not available"
+)
+def test_preflight_passes_for_ipv6_wildcard_on_free_port():
+    """``--host ::`` is the IPv6 wildcard spelling. Same regression as
+    ``::1``: pre-fix the AF_INET socket raised ``EAFNOSUPPORT``/
+    ``EADDRNOTAVAIL`` and the helper printed "port already in use,"
+    masking the real (no-collision) state.
+
+    Note: ``::`` is NOT in ``_wildcard_host_aliases()`` because the
+    loopback-shadow probe is IPv4-specific (macOS treats v4 and v6
+    loopback as distinct stacks, per the helper's docstring). So the
+    fix is family-only — IPv6 wildcards probe themselves once with
+    AF_INET6 and don't trigger the secondary 127.0.0.1 probe."""
+    # OS-assigned IPv6 port via a transient bind, then release it.
+    with socket.socket(socket.AF_INET6, socket.SOCK_STREAM) as s:
+        s.bind(("::", 0))
+        free_port = s.getsockname()[1]
+
+    result = cli._port_preflight_or_die("::", free_port, model="qwen3.5-4b-4bit")
+    assert result is None
+
+
+def test_ipv6_host_detector_matches_literals_only():
+    """Pin the colon-based heuristic ``_is_ipv6_host`` uses.
+
+    IPv6 literals always contain ``:``; IPv4 literals, wildcards
+    (``0.0.0.0``, ``""``), and DNS names (``localhost``) never do.
+    Keep the detector purely lexical so scoped literals
+    (``fe80::1%en0``) that uvicorn accepts still route through the
+    AF_INET6 branch (a stricter ``ipaddress.ip_address`` parse would
+    reject them)."""
+    assert cli._is_ipv6_host("::") is True
+    assert cli._is_ipv6_host("::1") is True
+    assert cli._is_ipv6_host("2001:db8::1") is True
+    assert cli._is_ipv6_host("fe80::1%en0") is True
+
+    assert cli._is_ipv6_host("0.0.0.0") is False
+    assert cli._is_ipv6_host("127.0.0.1") is False
+    assert cli._is_ipv6_host("") is False
+    assert cli._is_ipv6_host("localhost") is False

--- a/tests/test_stream_forced_tool_reasoning.py
+++ b/tests/test_stream_forced_tool_reasoning.py
@@ -365,16 +365,78 @@ class TestForcedToolChoiceFilter:
         )
         assert pp._no_index_last_dropped is True
 
-    def test_drops_continuation_with_bare_unquoted_text(self):
-        """Same gate, bare unquoted text variant (the codex r2
-        BLOCKING #1 / phi-4 ``<think>`` panic shape applied at the
-        continuation level)."""
+    def test_passes_bare_text_continuation_for_merge_layer(self):
+        """r10-J round-5 trade-off (codex r5 HIGH #1).
+
+        Round-3 wrongly dropped bare unquoted text continuations at
+        the streaming-gate layer. Round-5 narrowed the continuation
+        predicate to ONLY drop on confirmed JSON non-object roots —
+        bare prose ``Paris output output`` fails ``json.loads`` and
+        is therefore indistinguishable at this layer from a middle
+        fragment of a legitimate split JSON string. We must pass it
+        through so split-arg streams aren't truncated.
+
+        Safety net: the cap+merge layer assembles fragments back
+        into the full ``arguments`` string of the admitted anchor,
+        and the finalized-anchor gate runs at finalize time over
+        that assembled string. If the merged result is still bare
+        prose (no closing brace ever arrived), the finalize-side
+        ``_forced_tool_choice_arguments_violate_object_root`` (which
+        retains the strict balanced-but-broken classifier) drops
+        the full call before it ships to the client. Coverage of
+        that finalize-side drop lives in the cross-format fallback
+        tests under TestStreamForcedReasoningEndToEnd below.
+        """
         pp = StreamingPostProcessor(_make_cfg(), request=_forced_request("get_weather"))
         out = pp._apply_forced_tool_choice_filter(
             [{"function": {"arguments": "Paris output output"}}]
         )
-        assert out == []
-        assert pp._no_index_last_dropped is True
+        assert len(out) == 1
+        assert pp._no_index_last_dropped is False
+
+    def test_passes_closing_fragment_of_split_args(self):
+        """r10-J round-5 — codex r5 HIGH #1 regression guard.
+
+        Streaming parsers commonly split JSON arguments across
+        deltas: first ``{"city":"Pa``, then ``ris"}``. The opening
+        fragment has more ``{`` than ``}`` and the round-3 helper
+        passes it through (unbalanced = partial). The CLOSING
+        fragment has more ``}`` than ``{`` — the pre-round-5 helper
+        wrongly classified it as "balanced-but-broken garbage" and
+        dropped it, truncating an otherwise-valid forced or
+        required tool call.
+
+        Post-round-5: continuations use the narrower
+        ``_continuation_arguments_definitively_non_object`` predicate
+        which only drops on confirmed JSON-non-object roots. Both
+        halves of a split must pass through.
+        """
+        pp = StreamingPostProcessor(_make_cfg(), request=_forced_request("get_weather"))
+        # Opening fragment — { > } — already-known-good.
+        out_open = pp._apply_forced_tool_choice_filter(
+            [{"function": {"arguments": '{"city":"Pa'}}]
+        )
+        assert len(out_open) == 1, "opening fragment wrongly dropped"
+        # Closing fragment — } > { — REGRESSION from round-3 if dropped.
+        out_close = pp._apply_forced_tool_choice_filter(
+            [{"function": {"arguments": 'ris"}'}}]
+        )
+        assert len(out_close) == 1, (
+            "closing fragment of split JSON args wrongly dropped — the "
+            "continuation predicate must not over-rotate balanced-but-"
+            "broken garbage onto legitimate split-JSON continuations "
+            "(codex r10-J r5 HIGH #1)."
+        )
+
+    def test_passes_middle_fragment_of_three_way_split(self):
+        """Defense-in-depth: a middle fragment like ``"PARI`` (no
+        braces at all, bare bytes mid-string) must also pass — the
+        cap+merge layer is what reassembles the full string."""
+        pp = StreamingPostProcessor(_make_cfg(), request=_forced_request("get_weather"))
+        out = pp._apply_forced_tool_choice_filter(
+            [{"function": {"arguments": '"PARI'}}]
+        )
+        assert len(out) == 1
 
     def test_drops_continuation_with_array_root_arguments(self):
         """Array-root variant — ``[1,2,3]`` parses as JSON but the

--- a/tests/test_stream_forced_tool_reasoning.py
+++ b/tests/test_stream_forced_tool_reasoning.py
@@ -689,6 +689,61 @@ class TestStreamForcedReasoningEndToEnd:
         assert isinstance(parsed, dict)
         assert parsed.get("city") == "Paris"
 
+    def test_finalize_extract_drops_primitive_args_under_required_mode(self):
+        """r10-J round-4 finalize-path coverage (codex r6 LOW #6).
+
+        Required-mode twin of
+        ``test_finalize_extract_drops_same_name_primitive_args`` above.
+        Pre-round-4 the finalize ``extract_tool_calls`` branch only
+        applied the object-root gate when ``_forced_tool_choice_name``
+        was set. For ``tool_choice="required"`` the forced name is
+        None and the gate was disabled, so fallback-recovered calls
+        with primitive args reached the client.
+
+        Pin that after round-4 the required-mode arm of the
+        finalize ``extract_tool_calls`` branch drops the scratch
+        call and keeps only the real one.
+        """
+        cfg = _make_cfg(tool_call_parser="hermes", reasoning_parser_name=None)
+        required_request = {
+            "tool_choice": "required",
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "get_weather",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {"city": {"type": "string"}},
+                            "required": ["city"],
+                        },
+                    },
+                }
+            ],
+        }
+        pp = StreamingPostProcessor(cfg, request=required_request)
+        pp.reset()
+        # Buffer carries BOTH the scratch primitive-args call AND the
+        # real object-args call — mirrors the forced-name case.
+        pp.tool_accumulated_text = (
+            '<tool_call>\n{"name": "get_weather", "arguments": 1234567890}\n</tool_call>\n'
+            '<tool_call>\n{"name": "get_weather", "arguments": {"city": "Paris"}}\n</tool_call>'
+        )
+        events = pp.finalize()
+        all_calls = [
+            tc
+            for ev in events
+            if ev.type == "tool_call"
+            for tc in (ev.tool_calls or [])
+        ]
+        assert len(all_calls) == 1, (
+            f"required-mode finalize leaked a scratch call: {all_calls!r}"
+        )
+        fn = all_calls[0].get("function") or {}
+        parsed = json.loads(fn["arguments"])
+        assert isinstance(parsed, dict)
+        assert parsed.get("city") == "Paris"
+
     def test_non_reasoning_stream_forced_keeps_call(self):
         """Hermes parser without a reasoning parser (e.g. qwen3-instruct):
         forced ``tool_choice`` + stream still surfaces the call with

--- a/tests/test_stream_forced_tool_reasoning.py
+++ b/tests/test_stream_forced_tool_reasoning.py
@@ -398,6 +398,91 @@ class TestForcedToolChoiceFilter:
         out = pp._apply_forced_tool_choice_filter(calls)
         assert out == calls
 
+
+class TestRequiredModeFilter:
+    """r10-J round-4 — codex r4 HIGH #1.
+
+    Required-mode (``tool_choice="required"``) admits any tool but
+    every recovered call must still produce a JSON-object
+    ``arguments`` string. Pre-fix the streaming filter caught this
+    via ``_apply_forced_tool_choice_filter`` (object-root gate
+    bypasses ``forced_name is None``), but the finalize fallback
+    paths in ``postprocessor.py:3061+`` only applied the gate when
+    ``_forced_tool_choice_name()`` returned a named function — so
+    fallback-recovered ``arguments="20230805"`` reached the client
+    despite required semantics.
+
+    Round-4 added a ``_is_tool_choice_required()`` arm to BOTH the
+    ``extract_tool_calls`` recovery branch and the cross-format
+    fallback branch. These tests pin both with direct calls to
+    ``_apply_forced_tool_choice_filter`` (the streaming twin of the
+    finalize gate, sharing the same object-root helper) — full
+    finalize-path coverage is exercised by the broader integration
+    suite.
+    """
+
+    @staticmethod
+    def _required_request():
+        return {
+            "tool_choice": "required",
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "get_weather",
+                        "parameters": {"type": "object"},
+                    },
+                },
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "search",
+                        "parameters": {"type": "object"},
+                    },
+                },
+            ],
+        }
+
+    def test_required_mode_helper_detects_required(self):
+        pp = StreamingPostProcessor(_make_cfg(), request=self._required_request())
+        assert pp._is_tool_choice_required() is True
+
+    def test_required_mode_helper_skips_auto(self):
+        pp = StreamingPostProcessor(_make_cfg(), request=_auto_request())
+        assert pp._is_tool_choice_required() is False
+
+    def test_required_mode_drops_primitive_arguments_via_streaming_gate(self):
+        """The streaming gate (``_apply_forced_tool_choice_filter``)
+        already drops primitive-args calls under required mode — this
+        is the contract the finalize fallback now mirrors. Pins that
+        the gate engaged via the object-root check is intact regardless
+        of whether the call carries a name (required allows ANY name).
+        """
+        pp = StreamingPostProcessor(_make_cfg(), request=self._required_request())
+        out = pp._apply_forced_tool_choice_filter(
+            [
+                # Required mode, bare-string args — drop.
+                {"function": {"name": "search", "arguments": '"20230805"'}},
+                # Required mode, object args — keep.
+                {"function": {"name": "search", "arguments": '{"q":"x"}'}},
+            ]
+        )
+        assert len(out) == 1
+        assert out[0]["function"]["arguments"] == '{"q":"x"}'
+
+    def test_required_mode_continuation_finalized_non_object_dropped(self):
+        """Continuation fragment with FINALIZED non-object root under
+        required mode — round-3 already extended the
+        anchor_name=None branch to drop these. Pin under required-mode
+        request shape (codex r4 specifically called out required as the
+        forced_name-None case)."""
+        pp = StreamingPostProcessor(_make_cfg(), request=self._required_request())
+        out = pp._apply_forced_tool_choice_filter(
+            [{"function": {"arguments": '"20230805"'}}]
+        )
+        assert out == []
+        assert pp._no_index_last_dropped is True
+
     def test_passes_anchor_with_no_arguments_yet(self):
         """First chunk often carries just ``name`` + ``id`` with empty
         / missing arguments — body streams in later fragments. Must

--- a/tests/test_stream_forced_tool_reasoning.py
+++ b/tests/test_stream_forced_tool_reasoning.py
@@ -336,6 +336,57 @@ class TestForcedToolChoiceFilter:
         )
         assert len(out) == 1
 
+    def test_drops_continuation_with_finalized_non_object_arguments(self):
+        """r10-J round-3 — codex r3 HIGH #1.
+
+        Pre-fix the ``anchor_name is None`` branch passed every
+        continuation fragment through unconditionally. Some streaming
+        parsers admit a name-only anchor first and then send the
+        arguments in a follow-up continuation as a *finalized
+        non-object* root (e.g. ``"20230805"``, a bare date string).
+        The cap layer routed those into the admitted anchor,
+        delivering schema-violating ``arguments`` to clients despite
+        ``tool_choice="required"`` (or a forced named choice).
+
+        Post-fix: the same object-root gate the finalized-anchor branch
+        uses now fires on continuation fragments too. Partial-fragment
+        JSON (unbalanced braces) is still passed through — covered by
+        ``test_passes_argument_fragment_continuation`` above.
+        """
+        pp = StreamingPostProcessor(_make_cfg(), request=_forced_request("get_weather"))
+        # Continuation delta with FULLY-FORMED non-object JSON. Pre-fix
+        # this passed through; post-fix it must be dropped.
+        out = pp._apply_forced_tool_choice_filter(
+            [{"index": 0, "function": {"arguments": '"20230805"'}}]
+        )
+        assert out == [], (
+            "Finalized non-object continuation arguments must be dropped "
+            "(codex r10-J r3 HIGH #1)."
+        )
+        assert pp._no_index_last_dropped is True
+
+    def test_drops_continuation_with_bare_unquoted_text(self):
+        """Same gate, bare unquoted text variant (the codex r2
+        BLOCKING #1 / phi-4 ``<think>`` panic shape applied at the
+        continuation level)."""
+        pp = StreamingPostProcessor(_make_cfg(), request=_forced_request("get_weather"))
+        out = pp._apply_forced_tool_choice_filter(
+            [{"function": {"arguments": "Paris output output"}}]
+        )
+        assert out == []
+        assert pp._no_index_last_dropped is True
+
+    def test_drops_continuation_with_array_root_arguments(self):
+        """Array-root variant — ``[1,2,3]`` parses as JSON but the
+        spec requires an object. Continuation fragments with array
+        roots must be dropped just like finalized anchors with array
+        roots are (covered earlier in this class)."""
+        pp = StreamingPostProcessor(_make_cfg(), request=_forced_request("get_weather"))
+        out = pp._apply_forced_tool_choice_filter(
+            [{"function": {"arguments": "[1,2,3]"}}]
+        )
+        assert out == []
+
     def test_no_op_when_no_forced_choice(self):
         """``auto`` mode — the filter MUST be a no-op so multi-call
         flows and other tools still work."""

--- a/vllm_mlx/api/models.py
+++ b/vllm_mlx/api/models.py
@@ -458,6 +458,64 @@ def _validate_seed(v) -> int | None:
     return v
 
 
+# R10-H5 (R9-H3 carry) — closed set of values accepted by OpenAI's
+# ``reasoning_effort`` parameter. Pre-fix BOTH ``/v1/chat/completions``
+# and ``/v1/responses`` silently accepted any value (string, int, list,
+# null, garbage like ``"banana"``) with HTTP 200 — the field was
+# undeclared on the request schema, so Pydantic dropped it before the
+# adapter or postprocessor saw it (sven r10-R1 + vlad r10-R1). That
+# means clients passing ``reasoning_effort="none"`` to suppress thinking
+# (IDE assistants on low-token budgets) got the silent no-op + 32-token
+# reasoning_tokens regression Sven called out as R10-CRIT3. Declaring
+# the field with this closed-set validator now means:
+#
+#   * valid value → flows through to the request body for downstream
+#     consumers (today still a no-op at the engine layer; future work
+#     translates it into ``reasoning_max_tokens`` headroom);
+#   * invalid value → clean 400 with the supported set listed.
+#
+# The set mirrors OpenAI's public docs (gpt-5/o-series spec): ``minimal``
+# was added Aug 2025 alongside ``low``/``medium``/``high``; ``none`` is
+# the rapid-mlx-specific "suppress thinking entirely" alias that the
+# desktop UI surfaces, kept here so SDK clients that learned it don't
+# 400. Anthropic Claude's ``thinking.type`` enum is intentionally NOT
+# included — that's a different surface (the Anthropic adapter handles
+# its own translation).
+_VALID_REASONING_EFFORTS: tuple[str, ...] = (
+    "none",
+    "minimal",
+    "low",
+    "medium",
+    "high",
+)
+
+
+def _validate_reasoning_effort(v):
+    """Pin ``reasoning_effort`` to the OpenAI-spec closed set.
+
+    Accepts ``None`` (the field's default — no preference signalled)
+    unchanged. Any other shape (int, list, dict, ``True``/``False``,
+    case-variant strings, garbage strings) raises ``ValueError`` so
+    Pydantic surfaces a 400. The route layer is free to translate the
+    accepted string into a ``reasoning_max_tokens`` cap or a system-
+    prompt hint — that translation lives outside the schema layer.
+
+    Codex-pattern note: bool is a subclass of int, so the ``isinstance(v,
+    bool)`` check has to run BEFORE the string check (no risk here
+    because the string check is first in the chain). The error message
+    enumerates the legal set so SDK consumers see exactly what to send.
+    """
+    if v is None:
+        return None
+    if isinstance(v, str) and v in _VALID_REASONING_EFFORTS:
+        return v
+    raise ValueError(
+        "reasoning_effort must be one of "
+        f"{list(_VALID_REASONING_EFFORTS)} or null "
+        f"(got {type(v).__name__}={v!r})."
+    )
+
+
 # Fields that must reject NaN / ±inf BEFORE pydantic coerces them onto a
 # typed ``float | None`` slot. Pydantic v2's default ``ValidationError``
 # embeds ``input_value`` in the error dict; when the bad value is
@@ -887,11 +945,103 @@ class ToolCall(BaseModel):
 _FUNCTION_NAME_PATTERN = re.compile(r"^[a-zA-Z0-9_-]{1,64}$")
 
 
+# R10-H6 (R9-H4 carry) — accepted ``type`` aliases for the Computer-Use
+# tool surface on the chat lane. Mirrors the Responses-lane alias map
+# (``vllm_mlx/api/responses_adapter.py``) so the SDK-shorthand
+# ``tools=[{"type":"computer_use"}]`` works on /v1/chat/completions
+# too — pre-fix only /v1/responses normalised the alias and chat
+# 400'd with ``tools.0.function: Field required`` (Mira r10-R1
+# R10-HIGH3, vlad r10-R1 R10-HIGH3). The canonical Computer-Use shape
+# is a synthetic ``function`` tool named ``computer`` so the UI-TARS
+# tool parser (which always emits ``function.name == "computer"``)
+# sees a matching entry; ``_synthesize_computer_use_function`` runs
+# the same translation the Responses adapter applies at
+# ``_convert_tools``.
+_COMPUTER_USE_TYPE_ALIASES: frozenset[str] = frozenset(
+    {
+        "computer_use",
+        "computer_use_preview",
+        "computer_20251022",
+    }
+)
+
+
+def _synthesize_computer_use_function(tool_data: dict) -> dict:
+    """Build the canonical ``function`` dict for a Computer-Use shorthand
+    tool entry. Mirror of the Responses-lane translation in
+    ``responses_adapter._convert_tools`` so downstream chat-route code
+    sees ONE shape regardless of which alias the client sent.
+
+    ``display_width`` / ``display_height`` / ``environment`` hints are
+    placed under ``_computer_use`` on the parameters dict — the chat
+    template / system-prompt builder picks them up to ground the model
+    on the actual screen geometry, matching the Responses lane.
+    """
+    geometry: dict = {
+        "type": "object",
+        "properties": {
+            "display_width": {"type": "integer"},
+            "display_height": {"type": "integer"},
+            "environment": {"type": "string"},
+        },
+        "_computer_use": {
+            "display_width": tool_data.get("display_width"),
+            "display_height": tool_data.get("display_height"),
+            "environment": tool_data.get("environment"),
+        },
+    }
+    return {
+        "name": "computer",
+        "description": "Computer-Use (UI-TARS) GUI action tool",
+        "parameters": geometry,
+    }
+
+
 class ToolDefinition(BaseModel):
     """Definition of a tool that can be called by the model."""
 
     type: str = "function"
-    function: dict
+    # R10-H6: ``function`` is optional at the wire level so the
+    # Computer-Use shorthand (``{"type":"computer_use_preview"}``)
+    # parses. The ``_normalize_computer_use_shorthand`` model_validator
+    # below synthesises the canonical function dict when ``type`` is
+    # a Computer-Use alias, so downstream code (``ToolDefinition.function``,
+    # parser, chat-route) reads exactly one shape. For the canonical
+    # ``type == "function"`` path, the function field is still required —
+    # the ``_validate_function_name`` validator below raises when it's
+    # missing/empty (preserving the F-035 contract).
+    function: dict | None = None
+
+    # R10-H6 (R9-H4 carry) — Computer-Use shorthand normalisation.
+    # Runs BEFORE ``_validate_function_name`` so the synthetic
+    # ``function`` dict the F-035 regex check sees is the canonical
+    # ``computer`` shape, not the missing-field shape the client sent.
+    # ``mode="before"`` would require returning a dict; the
+    # ``model_validator(mode="after")`` style would re-run after
+    # ``_validate_function_name`` 422'd. The cleanest split is a
+    # ``mode="before"`` raw-dict normaliser PLUS the canonical-path
+    # name validator below — see test_tool_definition_computer_use_shorthand
+    # in tests/test_chat_route_tool_choice_enforcement.py for the
+    # parity matrix.
+    @model_validator(mode="before")
+    @classmethod
+    def _normalize_computer_use_shorthand(cls, data):
+        if not isinstance(data, dict):
+            return data
+        ttype = data.get("type")
+        if (
+            isinstance(ttype, str)
+            and ttype in _COMPUTER_USE_TYPE_ALIASES
+            and not data.get("function")
+        ):
+            # Canonicalise the type so downstream readers (engine
+            # plumbing, postprocessor, finalize path) see exactly
+            # ``"function"`` — mirrors the Responses adapter's
+            # ``_canonicalize_tool_type`` + ``_convert_tools`` pair.
+            data = dict(data)
+            data["type"] = "function"
+            data["function"] = _synthesize_computer_use_function(data)
+        return data
 
     # F-035 / F-146: reject malformed ``function.name`` at the schema
     # layer. Pre-fix:
@@ -1368,6 +1518,18 @@ class ChatCompletionRequest(BaseModel):
     # think before answering. Distinct from ``max_tokens`` (which caps the
     # overall completion length). ``None`` = no cap, model decides.
     reasoning_max_tokens: int | None = None
+    # R10-H5 (R9-H3 carry) — OpenAI ``reasoning_effort`` knob. Declared
+    # so Pydantic stops silently dropping it (sven r10-R1 + vlad r10-R1
+    # both confirmed every value 200'd because the field was undeclared).
+    # Validated against ``_VALID_REASONING_EFFORTS`` via the
+    # ``_validate_reasoning_effort_field`` validator below so int / list
+    # / null / case-variant / garbage strings produce a clean 400.
+    # Today the value is accepted-but-not-yet-translated at the engine
+    # layer (a follow-up wires ``"none"`` through to ``enable_thinking
+    # =False`` and ``low/medium/high`` to ``reasoning_max_tokens``
+    # tiers); the schema-layer validation is the hard surface so SDK
+    # clients see the contract round-trip.
+    reasoning_effort: str | None = None
     # Number of completions (only n=1 supported). F-155: the route used
     # to reject ``n > 1`` only, so ``n=0`` / ``n=-1`` slipped through
     # and HTTP 200'd with a single choice — asymmetric with the
@@ -1543,6 +1705,18 @@ class ChatCompletionRequest(BaseModel):
     @classmethod
     def _validate_seed_field(cls, v) -> int | None:
         return _validate_seed(v)
+
+    # R10-H5 (R9-H3 carry) — closed-set gate on ``reasoning_effort``.
+    # ``mode="before"`` so non-string wire forms (int, list, dict,
+    # bool, null) are rejected with a clear envelope BEFORE Pydantic's
+    # union dispatch surfaces a generic "Input should be a valid
+    # string" error pointing at the wrong arm. Mirrored on the
+    # Responses surface (``ResponsesRequest._validate_reasoning_effort``)
+    # so /v1/chat/completions and /v1/responses share one contract.
+    @field_validator("reasoning_effort", mode="before")
+    @classmethod
+    def _validate_reasoning_effort_field(cls, v):
+        return _validate_reasoning_effort(v)
 
     # Belt-and-braces: catches non-finite values that bypass the
     # raw-dict path (e.g. ``ChatCompletionRequest(temperature=nan)``
@@ -1912,6 +2086,19 @@ class CompletionRequest(BaseModel):
     # Unbounded at the request layer (codex round-6); backend uint32
     # narrowing happens in ``make_seeded_sampler``.
     seed: int | None = None
+    # R10-H4 (R9-H2 carry) — ``response_format`` on legacy completions.
+    # Vlad r10-R1 + Bo r10-R1: ``/v1/completions`` with
+    # ``response_format={"type":"json_object"}`` silently accepted the
+    # field then ignored it (HTTP 200 with markdown ``` ```json `` fences
+    # in the ``text`` reply); PR #844's streaming-fence path only ran on
+    # ``/v1/chat/completions``. Declaring the field here means Pydantic
+    # stops dropping it AND the field_validator below catches malformed
+    # shapes via the same ``_validate_response_format_raw`` helper the
+    # chat lane uses, so /v1/completions and /v1/chat/completions share
+    # one schema contract. The route layer (``routes/completions.py``)
+    # consumes this field and runs the chat-style fence-strip /
+    # JSON-extraction on both the sync and streaming output paths.
+    response_format: ResponseFormat | dict | None = None
 
     # F-011: NaN/inf scrub + finite belt-and-braces, exactly mirroring
     # ChatCompletionRequest. See the rationale block at the top of
@@ -1920,6 +2107,12 @@ class CompletionRequest(BaseModel):
     @classmethod
     def _scrub_nonfinite_sampling(cls, data):
         return _scrub_nonfinite_sampling_raw(data)
+
+    # R10-H4: response_format validation shares one helper with chat.
+    @field_validator("response_format", mode="before")
+    @classmethod
+    def _validate_response_format(cls, v):
+        return _validate_response_format_raw(v)
 
     @field_validator(
         "temperature",

--- a/vllm_mlx/api/responses_models.py
+++ b/vllm_mlx/api/responses_models.py
@@ -20,9 +20,11 @@ from pydantic import BaseModel, Field, field_validator, model_validator
 
 from .models import (
     _TOP_K_SENTINEL_CAP,
+    _VALID_REASONING_EFFORTS,
     StreamOptions,
     _validate_nonnegative_int,
     _validate_positive_int,
+    _validate_reasoning_effort,
     _validate_seed,
 )
 
@@ -173,11 +175,57 @@ class ResponsesRequest(BaseModel):
     # three OpenAI-surface lanes (chat / responses / legacy completions)
     # under one contract — no copy-pasted thresholds to drift.
     top_k: int | None = None
+    # R10-H5 (R9-H3 carry) — OpenAI Responses spec exposes
+    # ``reasoning.effort`` (nested under the ``reasoning`` dict). Some
+    # SDK clients also send the chat-completions-shape top-level
+    # ``reasoning_effort`` field; declare it here so Pydantic stops
+    # silently dropping it. Both surfaces are validated by the
+    # ``_validate_reasoning_effort_*`` validators below — the top-level
+    # field via field_validator (closed-set string), and the nested
+    # ``reasoning.effort`` via a model_validator (mode="before") that
+    # runs the same check on the dict member. Sven r10-R1 + vlad
+    # r10-R1: every value (int / list / null / case-variant / garbage
+    # string) 200'd on this surface pre-fix.
+    reasoning_effort: str | None = None
 
     @field_validator("seed", mode="before")
     @classmethod
     def _validate_seed_field(cls, v) -> int | None:
         return _validate_seed(v)
+
+    # R10-H5 (R9-H3 carry) — mirror of
+    # ``ChatCompletionRequest._validate_reasoning_effort_field``. Closed
+    # set; nulls flow through.
+    @field_validator("reasoning_effort", mode="before")
+    @classmethod
+    def _validate_reasoning_effort_field(cls, v):
+        return _validate_reasoning_effort(v)
+
+    # R10-H5 (R9-H3 carry) — canonical Responses-spec surface validates
+    # ``reasoning.effort`` (nested). Runs in ``mode="before"`` so the
+    # raw payload is gated BEFORE the ``reasoning`` dict is coerced
+    # onto the schema. Closed-set ``_VALID_REASONING_EFFORTS`` matches
+    # the top-level shorthand so both wire forms accept the same set.
+    @model_validator(mode="before")
+    @classmethod
+    def _validate_reasoning_dict_effort(cls, data):
+        if not isinstance(data, dict):
+            return data
+        reasoning = data.get("reasoning")
+        if not isinstance(reasoning, dict):
+            return data
+        if "effort" not in reasoning:
+            return data
+        effort = reasoning["effort"]
+        if effort is None:
+            return data
+        if isinstance(effort, str) and effort in _VALID_REASONING_EFFORTS:
+            return data
+        raise ValueError(
+            "reasoning.effort must be one of "
+            f"{list(_VALID_REASONING_EFFORTS)} or null "
+            f"(got {type(effort).__name__}={effort!r})."
+        )
 
     @field_validator("top_k", mode="before")
     @classmethod

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -189,6 +189,22 @@ def _wildcard_host_aliases() -> frozenset[str]:
     return frozenset({"0.0.0.0", ""})
 
 
+def _is_ipv6_host(host: str) -> bool:
+    """Detect IPv6 literal hosts (``::``, ``::1``, ``2001:db8::1`` ...).
+
+    Codex round-1 MED #6 on PR #855: the IPv4-only preflight always
+    created an ``AF_INET`` socket, so any valid uvicorn IPv6 bind
+    (``--host ::1``, ``--host ::``, etc.) failed ``socket.bind`` and got
+    misreported as "port already in use." Detection is colon-based:
+    every IPv6 literal contains at least one ``:``, no IPv4 literal /
+    DNS name does (``localhost`` is the canonical non-IPv6 with no
+    colon). We deliberately keep this purely lexical — a stricter
+    ``ipaddress.ip_address`` parse would reject scoped literals
+    (``fe80::1%en0``) that uvicorn happily accepts.
+    """
+    return ":" in host
+
+
 def _port_preflight_or_die(host: str, port: int, *, model: str) -> None:
     """Probe ``(host, port)`` AND — when ``host`` is a wildcard alias —
     additionally probe ``("127.0.0.1", port)``. Print a friendly error
@@ -209,9 +225,13 @@ def _port_preflight_or_die(host: str, port: int, *, model: str) -> None:
     MAJOR on PR #848 (the dogfood-CLI fix had to land on both supported
     entrypoints to actually close the bypass).
 
-    ``::1`` is intentionally NOT probed: macOS treats v4 and v6 loopback
-    as distinct stacks, and uvicorn's IPv4 bind never collides with an
-    IPv6 listener.
+    ``::1`` is intentionally NOT probed when the user binds an IPv4
+    wildcard: macOS treats v4 and v6 loopback as distinct stacks, and
+    uvicorn's IPv4 bind never collides with an IPv6 listener. When the
+    user EXPLICITLY binds an IPv6 host, we switch the probe family to
+    ``AF_INET6`` so the bind doesn't spuriously fail (codex round-1
+    MED #6 on PR #855 — pre-fix ``--host ::1`` raised ``OSError`` from
+    the ``AF_INET`` socket and was misreported as "port already in use").
     """
     import socket
 
@@ -225,12 +245,19 @@ def _port_preflight_or_die(host: str, port: int, *, model: str) -> None:
         hosts_to_probe = (host,)
 
     for probe_host in hosts_to_probe:
+        # Pick the address family that matches the host string. IPv6
+        # literals (``::``, ``::1``, etc.) need ``AF_INET6`` or the bind
+        # raises before we can detect a real collision (codex r1 MED #6
+        # on PR #855). Everything else — IPv4 literals, wildcards
+        # (``0.0.0.0``, ``""``), the loopback-shadow probe ``127.0.0.1``
+        # — stays on ``AF_INET``.
+        family = socket.AF_INET6 if _is_ipv6_host(probe_host) else socket.AF_INET
         # ``with`` guarantees the preflight socket is closed on every
         # exit path — including OSError during ``bind``. The previous
         # form called ``_sock.close()`` only on the success branch,
         # which leaked the fd whenever the bind raised (e.g. when
         # running under a test harness that catches ``SystemExit``).
-        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as _sock:
+        with socket.socket(family, socket.SOCK_STREAM) as _sock:
             _sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
             try:
                 _sock.bind((probe_host, port))

--- a/vllm_mlx/routes/completions.py
+++ b/vllm_mlx/routes/completions.py
@@ -193,6 +193,51 @@ async def create_completion(request: CompletionRequest, raw_request: Request):
                     }
                 },
             )
+    # R10-J (codex r10-G/H r2 HIGH #1): ``response_format={"type":
+    # "json_schema"}`` on the legacy ``/v1/completions`` lane is NOT
+    # actually enforced. The route only post-strips fences via
+    # ``extract_json_from_response`` (R10-H4); it does NOT route through
+    # guided generation (``extract_json_schema_for_guided``) and does
+    # NOT validate the output against the schema. A caller setting
+    # ``json_schema.strict=true`` therefore gets HTTP 200 with
+    # schema-INVALID text — the silent ``strict=true`` violation class
+    # the chat lane already 400s on (see ``routes/chat.py`` r3
+    # BLOCKING #2 + ``is_strict_json_schema`` enforcement).
+    #
+    # Wiring guided generation through the legacy completions lane is
+    # a separate refactor (the lane never had FSM constraints; chat
+    # owns the strict path). The conservative, spec-correct fix is to
+    # reject ``json_schema`` here with a 400 that points callers at
+    # the chat lane. ``json_object`` keeps working — it has no schema
+    # to validate, the fence-strip is sufficient — so this is a
+    # surgical close of the strict-schema gap only.
+    if request.response_format is not None and request.logprobs is None:
+        rf_type = (
+            getattr(request.response_format, "type", None)
+            if not isinstance(request.response_format, dict)
+            else request.response_format.get("type")
+        )
+        if rf_type == "json_schema":
+            raise HTTPException(
+                status_code=400,
+                detail={
+                    "error": {
+                        "message": (
+                            "response_format=json_schema is not supported "
+                            "on the legacy /v1/completions lane: this "
+                            "route does not route through guided "
+                            "generation and cannot enforce strict=true "
+                            "schema validation. Use /v1/chat/completions "
+                            "for json_schema (it owns the strict path), "
+                            "or send response_format=json_object on "
+                            "/v1/completions if loose JSON is acceptable."
+                        ),
+                        "type": "invalid_request_error",
+                        "code": "unsupported_response_format",
+                        "param": "response_format",
+                    }
+                },
+            )
     engine = get_engine(request.model)
 
     # Pre-flight admission gate (C4). Reservation is released by the

--- a/vllm_mlx/routes/completions.py
+++ b/vllm_mlx/routes/completions.py
@@ -193,6 +193,45 @@ async def create_completion(request: CompletionRequest, raw_request: Request):
                     }
                 },
             )
+    # R10-J round-3 (codex r3 MED #4): ``response_format=json_object``
+    # / ``json_schema`` combined with ``echo=true`` is a contradiction.
+    # The finalize-time fence-strip only runs when ``not request.echo``
+    # (lines L491 / L693) — by design, since the prompt prefix is NOT
+    # JSON and stripping fences out of it would corrupt the echoed
+    # text. But that means the request is accepted as "yes, JSON
+    # cleanup will run" and then silently returns prompt-prefixed
+    # fenced text, breaking the structured-output contract callers
+    # explicitly opted into. Reject the combination with a 400 so
+    # they pick exactly one knob per request (same pattern as the
+    # response_format + logprobs reject below).
+    if (
+        request.response_format is not None
+        and request.echo
+    ):
+        rf_type = (
+            getattr(request.response_format, "type", None)
+            if not isinstance(request.response_format, dict)
+            else request.response_format.get("type")
+        )
+        if rf_type in ("json_object", "json_schema"):
+            raise HTTPException(
+                status_code=400,
+                detail={
+                    "error": {
+                        "message": (
+                            "response_format is not supported with "
+                            "echo=true on /v1/completions: echo returns "
+                            "the prompt prefix verbatim and JSON "
+                            "cleanup cannot run on prompt text. Send "
+                            "response_format and echo in separate "
+                            "requests."
+                        ),
+                        "type": "invalid_request_error",
+                        "code": "unsupported_combination",
+                        "param": "response_format",
+                    }
+                },
+            )
     # R10-J (codex r10-G/H r2 HIGH #1): ``response_format={"type":
     # "json_schema"}`` on the legacy ``/v1/completions`` lane is NOT
     # actually enforced. The route only post-strips fences via

--- a/vllm_mlx/routes/completions.py
+++ b/vllm_mlx/routes/completions.py
@@ -151,6 +151,48 @@ async def create_completion(request: CompletionRequest, raw_request: Request):
                 "request returns the generated-token distributions)."
             ),
         )
+    # R10-H4 follow-up (codex r1 MED #4 / #5): ``response_format``
+    # (json_object / json_schema) cleanup strips markdown fences and
+    # the legacy "Just the JSON.\n…" preamble from the wire text. But
+    # ``logprobs`` on the same request is a per-generated-token cursor
+    # that's byte-aligned to the EMITTED text (we pin ``text =
+    # "".join(tokens_arr)`` post-decode so ``text_offset`` stays
+    # spec-correct). The two contracts are incompatible: a fence-stripped
+    # ``text`` no longer matches the per-token concatenation, so either
+    #   (a) ``text_offset`` mis-aligns against ``text`` (silent
+    #       corruption — the original codex finding),
+    #   (b) ``text`` is rebuilt from the raw tokens (undoing the strip —
+    #       what the pre-fix non-stream branch did), OR
+    #   (c) the streaming branch silently skips JSON cleanup when
+    #       logprobs is requested (the pre-fix streaming branch).
+    # None of those are spec-correct. Reject the combination with a 400
+    # so callers pick exactly one knob per request (mirrors how we
+    # already reject ``echo + logprobs`` above).
+    if request.response_format is not None and request.logprobs is not None:
+        rf_type = (
+            getattr(request.response_format, "type", None)
+            if not isinstance(request.response_format, dict)
+            else request.response_format.get("type")
+        )
+        if rf_type in ("json_object", "json_schema"):
+            raise HTTPException(
+                status_code=400,
+                detail={
+                    "error": {
+                        "message": (
+                            "response_format=json_object is not supported "
+                            "with logprobs on /v1/completions: the fence/"
+                            "preamble strip rewrites the wire text, which "
+                            "would mis-align text_offset against the per-"
+                            "token cursor. Send response_format and "
+                            "logprobs in separate requests."
+                        ),
+                        "type": "invalid_request_error",
+                        "code": "unsupported_combination",
+                        "param": "response_format",
+                    }
+                },
+            )
     engine = get_engine(request.model)
 
     # Pre-flight admission gate (C4). Reservation is released by the
@@ -597,6 +639,11 @@ async def stream_completion(
     # bypass this scrub: echo prepends the raw prompt (not JSON), and
     # legacy logprobs needs per-chunk text alignment with the tokens
     # array — both are incompatible with the post-hoc fence-strip.
+    # ``want_logprobs`` is left in the gate as defense-in-depth: the
+    # route-entry validator already 400s ``response_format + logprobs``,
+    # so this branch is unreachable on the wire. Keep it so a future
+    # refactor that loosens the upstream gate doesn't silently re-open
+    # the streaming bypass codex r1 MED #5 originally flagged.
     _json_mode = False
     if request.response_format and not request.echo and not want_logprobs:
         rf_type = (

--- a/vllm_mlx/routes/completions.py
+++ b/vllm_mlx/routes/completions.py
@@ -19,6 +19,7 @@ from ..api.models import (
     PromptTokensDetails,
     Usage,
 )
+from ..api.utils import extract_json_from_response
 from ..config import get_config
 from ..middleware.auth import check_rate_limit, verify_api_key
 from ..service.helpers import (
@@ -387,6 +388,28 @@ async def create_completion(request: CompletionRequest, raw_request: Request):
             if request.echo:
                 final_text = prompt + final_text
 
+            # R10-H4 (R9-H2 carry) — chat-lane parity for
+            # ``response_format=json_object`` / ``json_schema`` on the
+            # sync ``/v1/completions`` path. Pre-fix the field was
+            # silently dropped (PR #844 wired the streaming fence-strip
+            # only on /v1/chat/completions); vlad r10-R1 + bo r10-R1
+            # confirmed the leak with markdown ``` ```json `` fences in
+            # the ``text`` reply. The chat lane peels the wrapper via
+            # ``extract_json_from_response`` at finalize time; mirror
+            # that here BEFORE the legacy-logprobs alignment block so
+            # the ``text_offset`` cursor lines up against the wire-
+            # canonical (post-fence-strip) ``text`` field. Echo
+            # responses are passed through unchanged because the prompt
+            # prefix is NOT JSON.
+            if request.response_format and final_text and not request.echo:
+                rf_type = (
+                    getattr(request.response_format, "type", None)
+                    if not isinstance(request.response_format, dict)
+                    else request.response_format.get("type")
+                )
+                if rf_type in ("json_object", "json_schema"):
+                    final_text = extract_json_from_response(final_text)
+
             # Build the legacy logprobs payload per OpenAI spec: four
             # parallel arrays keyed positionally per generated token.
             # ``echo + logprobs`` is rejected upstream (see route
@@ -559,6 +582,32 @@ async def stream_completion(
     # down at the chunk-build site.
     _final_usage = None
 
+    # R10-H4 (R9-H2 carry) — chat-lane parity for json-mode streaming.
+    # Pre-fix the streaming path emitted raw tokens that decoded as
+    # ``Just the JSON.\nAnswer:\n{"answer":42}\n\n```json\n{"answer":42}\n``` ``
+    # joined on the wire (vlad r10-R1 + bo r10-R1). The chat lane runs
+    # a full state-machine fence-strip in ``StreamingPostProcessor``;
+    # the legacy completions surface uses a simpler model — buffer the
+    # text chunks AND run ``extract_json_from_response`` at finalize,
+    # emitting one consolidated content delta + the finish marker.
+    # Trade-off: clients lose per-token streaming granularity in
+    # json-mode (acceptable; structured-output clients don't pipeline
+    # partial JSON anyway), but they ALSO never see the markdown
+    # wrapper that the non-stream path strips. Echo / logprobs flows
+    # bypass this scrub: echo prepends the raw prompt (not JSON), and
+    # legacy logprobs needs per-chunk text alignment with the tokens
+    # array — both are incompatible with the post-hoc fence-strip.
+    _json_mode = False
+    if request.response_format and not request.echo and not want_logprobs:
+        rf_type = (
+            getattr(request.response_format, "type", None)
+            if not isinstance(request.response_format, dict)
+            else request.response_format.get("type")
+        )
+        _json_mode = rf_type in ("json_object", "json_schema")
+    _buffered_text = ""
+    _buffered_finish_reason: str | None = None
+
     async for output in engine.stream_generate(
         prompt=prompt,
         max_tokens=_resolve_max_tokens(request.max_tokens),
@@ -567,6 +616,13 @@ async def stream_completion(
         stop=request.stop,
         **extended_kwargs,
     ):
+        if _json_mode:
+            # Buffer the text and finish_reason; emit at stream end.
+            _buffered_text += output.new_text or ""
+            if output.finished:
+                _final_usage = get_usage(output)
+                _buffered_finish_reason = output.finish_reason
+            continue
         choice = {
             "index": 0,
             "text": output.new_text,
@@ -629,6 +685,33 @@ async def stream_completion(
         if output.finished:
             _final_usage = get_usage(output)
         yield f"data: {json.dumps(data)}\n\n"
+
+    # R10-H4: json-mode buffered emit. Run ``extract_json_from_response``
+    # on the assembled text (mirrors the non-stream sync path), then
+    # ship a single consolidated text delta followed by a finish
+    # marker. The chat lane's streaming state-machine variant is
+    # overkill here — legacy completions has no reasoning/tool channel
+    # and clients consuming json-mode don't expect partial-JSON
+    # streaming anyway.
+    if _json_mode:
+        cleaned = extract_json_from_response(_buffered_text) if _buffered_text else ""
+        # Emit content + finish in a single chunk for symmetry with
+        # the non-stream sync path; if the buffer is empty (model
+        # produced no output), still emit a finish-only chunk so the
+        # client sees the terminal marker.
+        final_choice = {
+            "index": 0,
+            "text": cleaned,
+            "finish_reason": _buffered_finish_reason or "stop",
+        }
+        final_data = {
+            "id": completion_id,
+            "object": "text_completion",
+            "created": created_ts,
+            "model": model_name,
+            "choices": [final_choice],
+        }
+        yield f"data: {json.dumps(final_data)}\n\n"
 
     # Dedicated trailing usage chunk (OpenAI spec — empty ``choices``,
     # populated ``usage``). Only emitted when the caller opted in via

--- a/vllm_mlx/routes/completions.py
+++ b/vllm_mlx/routes/completions.py
@@ -204,10 +204,7 @@ async def create_completion(request: CompletionRequest, raw_request: Request):
     # explicitly opted into. Reject the combination with a 400 so
     # they pick exactly one knob per request (same pattern as the
     # response_format + logprobs reject below).
-    if (
-        request.response_format is not None
-        and request.echo
-    ):
+    if request.response_format is not None and request.echo:
         rf_type = (
             getattr(request.response_format, "type", None)
             if not isinstance(request.response_format, dict)

--- a/vllm_mlx/service/postprocessor.py
+++ b/vllm_mlx/service/postprocessor.py
@@ -1666,15 +1666,34 @@ class StreamingPostProcessor:
         finalized-anchor gate at the end of the stream catches any
         genuine non-object root after the full string is assembled.
 
-        Trade-off acknowledged: a stream that emits a *finalized*
-        bare-string ``"20230805"`` AS a continuation (no name on the
-        delta) will pass through this gate — but the streaming
-        finalized-anchor branch already caught that case in the
-        prior delta that carried the name, and the multi-round
-        finalize fallback (round-4) covers any recovery path. The
-        cost of being conservative here is a possible duplicate
-        sanity-check by the merge layer; the cost of being strict
-        is silently truncating valid split-JSON streams.
+        What this predicate DOES still drop at the continuation
+        layer (so the streaming wire stays clean and ``_no_index_
+        last_dropped`` propagates to the cap layer immediately):
+
+        * Bare integer ``"1234567890"`` — parses, root is int, drop.
+        * Bare JSON-quoted string ``'"20230805"'`` — parses, root
+          is str, drop.
+        * Array root ``"[1,2,3]"`` — parses, root is list, drop.
+
+        What it now passes through (the round-5 widening):
+
+        * Partial JSON ``'{"city":"Pa'`` — parse fails, pass.
+        * Closing fragment ``'ris"}'`` of a split — parse fails
+          (close > open in isolation), pass.
+        * Middle fragment ``'"PARI'`` of a three-way split —
+          parse fails, pass.
+        * Bare unquoted prose ``'Paris output output'`` — parse
+          fails (no quotes, not JSON at all), pass. The merge
+          layer assembles fragments back into the full arguments
+          string and the finalized-anchor gate (the strict twin)
+          re-validates it at finalize time, so bare-prose leaks
+          are caught one layer up rather than here.
+
+        Trade-off: the strict-twin already covers each finalized
+        case once the cap+merge layer has assembled the full args
+        string, so passing partial-looking continuations through
+        is safe; over-rotating split-JSON would silently truncate
+        legitimate forced/required tool calls.
         """
         if not args_str or not args_str.strip():
             return False

--- a/vllm_mlx/service/postprocessor.py
+++ b/vllm_mlx/service/postprocessor.py
@@ -3059,12 +3059,33 @@ class StreamingPostProcessor:
                 # (codex r1 BLOCKING: filtering by name alone leaks
                 # a same-name scratch call with primitive args).
                 _forced_name = self._forced_tool_choice_name()
+                _required_mode = self._is_tool_choice_required()
                 if _forced_name:
                     _filtered_calls = [
                         tc
                         for tc in result.tool_calls
                         if tc.get("name") == _forced_name
                         and not self._forced_tool_choice_arguments_violate_object_root(
+                            tc.get("arguments")
+                        )
+                    ]
+                elif _required_mode:
+                    # r10-J round-4 (codex r4 HIGH #1): for
+                    # ``tool_choice="required"`` ``_forced_tool_choice_name``
+                    # returns None (no specific function pinned), so the
+                    # pre-fix branch passed every recovered call through.
+                    # That reopened the malformed-args leak the streaming
+                    # ``_apply_forced_tool_choice_filter`` was meant to
+                    # close — finalize-recovered calls with
+                    # ``arguments="20230805"`` (bare-string root) reached
+                    # the client despite ``required`` semantics. Apply
+                    # the same object-root gate here. No name constraint
+                    # in required mode (multi-tool parallel is legal),
+                    # only the schema-shape gate.
+                    _filtered_calls = [
+                        tc
+                        for tc in result.tool_calls
+                        if not self._forced_tool_choice_arguments_violate_object_root(
                             tc.get("arguments")
                         )
                     ]
@@ -3108,12 +3129,27 @@ class StreamingPostProcessor:
                     # same-name scratch calls with primitive / list
                     # ``arguments`` leak through.
                     _forced_name = self._forced_tool_choice_name()
+                    _required_mode = self._is_tool_choice_required()
                     if _forced_name:
                         fb_tcs = [
                             tc
                             for tc in fb_tcs
                             if tc.function.name == _forced_name
                             and not self._forced_tool_choice_arguments_violate_object_root(
+                                tc.function.arguments
+                            )
+                        ]
+                    elif _required_mode:
+                        # r10-J round-4 — twin of the
+                        # ``extract_tool_calls`` recovery branch above:
+                        # cross-format fallback under ``required`` must
+                        # also drop primitive-args recovered calls so
+                        # the contract is symmetric across the two
+                        # finalize recovery paths.
+                        fb_tcs = [
+                            tc
+                            for tc in fb_tcs
+                            if not self._forced_tool_choice_arguments_violate_object_root(
                                 tc.function.arguments
                             )
                         ]

--- a/vllm_mlx/service/postprocessor.py
+++ b/vllm_mlx/service/postprocessor.py
@@ -1701,11 +1701,47 @@ class StreamingPostProcessor:
             flat_name = tc.get("name") if isinstance(tc.get("name"), str) else None
             anchor_name = wrapped_name or flat_name
             if anchor_name is None:
-                # Continuation fragment — defer to cap-layer routing.
-                # When the prior anchor for this forced choice was
-                # dropped (wrong name, schema-violating args, or
+                # Continuation fragment — usually defer to cap-layer
+                # routing. When the prior anchor for this forced choice
+                # was dropped (wrong name, schema-violating args, or
                 # single-call cap hit), ``_no_index_last_dropped`` is
                 # set and the cap layer suppresses these fragments too.
+                #
+                # r10-J round-3 (codex r3 HIGH #1): the deferral was
+                # incomplete. Some streaming parsers admit a valid
+                # name-only anchor first and then send the ARGUMENTS
+                # in a follow-up continuation that carries
+                # ``{"function": {"arguments": "20230805"}}`` — a
+                # schema-violating non-object root. The prior anchor
+                # was admitted (so ``_no_index_last_dropped`` is False)
+                # and the cap layer happily passes the continuation
+                # through, leaking the malformed-args contract the
+                # finalized-anchor branch below was meant to close.
+                #
+                # Mirror the object-root gate here: if the continuation
+                # carries args AND those args parse to a non-object
+                # root, drop it and tell the cap layer to drop the
+                # rest. Partial-fragment JSON (unbalanced braces) is
+                # passed through unchanged — the helper already returns
+                # False for those, so the legitimate
+                # name-then-fragmented-args streaming pattern keeps
+                # working.
+                wrapped_args = (
+                    fn.get("arguments")
+                    if fn and isinstance(fn.get("arguments"), str)
+                    else None
+                )
+                flat_args = (
+                    tc.get("arguments")
+                    if isinstance(tc.get("arguments"), str)
+                    else None
+                )
+                cont_args = wrapped_args if wrapped_args is not None else flat_args
+                if self._forced_tool_choice_arguments_violate_object_root(
+                    cont_args
+                ):
+                    self._no_index_last_dropped = True
+                    continue
                 filtered.append(tc)
                 continue
             if forced_name and anchor_name != forced_name:

--- a/vllm_mlx/service/postprocessor.py
+++ b/vllm_mlx/service/postprocessor.py
@@ -1642,6 +1642,48 @@ class StreamingPostProcessor:
             return True
         return not isinstance(parsed, dict)
 
+    @staticmethod
+    def _continuation_arguments_definitively_non_object(args_str: str | None) -> bool:
+        """Narrower twin of
+        ``_forced_tool_choice_arguments_violate_object_root`` for
+        argument-only continuation fragments.
+
+        Continuations carry partial bytes — the FULL ``arguments``
+        string is built across multiple deltas by the cap+merge layer.
+        A finalized-anchor predicate (which treats "close >= open"
+        as garbage to drop) is too strict here: a legitimate closing
+        fragment such as ``ris"}`` of the split ``{"city":"Pa`` /
+        ``ris"}`` pair has more ``}`` than ``{`` and the
+        finalized-anchor helper would WRONGLY drop it — truncating an
+        otherwise-valid forced/required tool call. Codex r10-J r5
+        HIGH #1 caught the regression.
+
+        Continuations get the conservative predicate: drop ONLY when
+        the fragment ALONE parses as valid JSON AND its root is
+        non-object. Every parse-failure case (partial, balanced-but-
+        broken, bare prose) passes through — the cap layer routes
+        the fragment into the admitted anchor, and the
+        finalized-anchor gate at the end of the stream catches any
+        genuine non-object root after the full string is assembled.
+
+        Trade-off acknowledged: a stream that emits a *finalized*
+        bare-string ``"20230805"`` AS a continuation (no name on the
+        delta) will pass through this gate — but the streaming
+        finalized-anchor branch already caught that case in the
+        prior delta that carried the name, and the multi-round
+        finalize fallback (round-4) covers any recovery path. The
+        cost of being conservative here is a possible duplicate
+        sanity-check by the merge layer; the cost of being strict
+        is silently truncating valid split-JSON streams.
+        """
+        if not args_str or not args_str.strip():
+            return False
+        try:
+            parsed = json.loads(args_str)
+        except (ValueError, TypeError):
+            return False
+        return not isinstance(parsed, dict)
+
     def _apply_forced_tool_choice_filter(self, tool_calls: list[dict]) -> list[dict]:
         """Suppress streaming tool_calls deltas that violate the
         ``tool_choice`` contract (forced named, or ``"required"``).
@@ -1737,7 +1779,16 @@ class StreamingPostProcessor:
                     else None
                 )
                 cont_args = wrapped_args if wrapped_args is not None else flat_args
-                if self._forced_tool_choice_arguments_violate_object_root(cont_args):
+                # r10-J round-5 (codex r5 HIGH #1): use the narrower
+                # continuation-specific predicate, NOT the finalized-
+                # anchor one. The finalized-anchor predicate treats
+                # "balanced-but-broken" / "more } than {" as garbage
+                # to drop, which over-rotates a legitimate split-JSON
+                # closing fragment (``ris"}`` half of ``{"city":"Pa``
+                # / ``ris"}``) into "drop". The continuation helper
+                # only drops when the fragment ALONE parses as a
+                # confirmed JSON non-object root.
+                if self._continuation_arguments_definitively_non_object(cont_args):
                     self._no_index_last_dropped = True
                     continue
                 filtered.append(tc)

--- a/vllm_mlx/service/postprocessor.py
+++ b/vllm_mlx/service/postprocessor.py
@@ -12,6 +12,7 @@ import copy
 import json
 import logging
 import os
+import re
 import uuid
 from typing import TYPE_CHECKING
 from unittest.mock import Mock
@@ -297,6 +298,23 @@ class StreamingPostProcessor:
         self.accumulated_reasoning = ""
         self.tool_calls_detected = False
         self.tool_markup_possible = False
+        # R10-C8 (Mira r10-R1): tool-prose-prefix hold-back. When the
+        # request declares ``tools`` and the model emits a UI-TARS-style
+        # natural-language preamble like ``"Tool: get_weather\n
+        # Parameters: location=Paris\n"`` BEFORE the structured
+        # ``delta.tool_calls`` chunk, those prose tokens used to leak
+        # into ``delta.content`` and clients rendering content live saw
+        # garbage prefixing the tool dispatch. Buffer content events
+        # that match the ``^(Tool|Action|Function):`` prefix pattern;
+        # release the buffer either when a tool_call arrives (discard,
+        # because the model just confirmed it was tool-prose) OR when
+        # the buffer grows past ``_TOOL_PROSE_MAX_HOLD`` bytes (release
+        # as legitimate prose so a model legitimately discussing the
+        # word "Tool:" isn't censored). ``_tool_prose_buffer`` is the
+        # staging area; ``_tool_prose_active`` is the state latch.
+        # Both fields are no-ops when ``tools_requested`` is False.
+        self._tool_prose_buffer: str = ""
+        self._tool_prose_active: bool = False
         # Monotonic counter for structured tool-call indices across the
         # whole response. Each TOOL_CALL channel ``GenerationOutput`` may
         # carry a single structured call; if multiple chunks fire
@@ -333,6 +351,35 @@ class StreamingPostProcessor:
         # cleared on ``reset()``.
         self._no_index_admitted_id: str | None = None
         self._no_index_admitted_name: str | None = None
+        # R10-H2 (Sven r10-R1): single-call enforcement under forced
+        # ``tool_choice={"type":"function","function":{"name":X}}``.
+        # The OpenAI spec mandates that a forced named tool_choice
+        # produces exactly ONE tool_call for the chosen function;
+        # pre-fix the streaming postprocessor admitted every anchor
+        # that matched the forced name, so models that re-emitted the
+        # same call shape across two chunks (qwen3-bf16 reasoning
+        # scratch + final emit) shipped TWO indices to the wire with
+        # different ``call_id`` values for the same function. Agent
+        # loops then executed the tool twice.
+        #
+        # State: ``_forced_anchor_admitted_id`` records the id of the
+        # FIRST admitted anchor for the forced choice. Subsequent
+        # anchors whose ``id`` matches are re-emissions of the same
+        # call (cumulative-arguments parsers — same call_id, growing
+        # arguments JSON) and pass through. Subsequent anchors with
+        # DIFFERENT ``id`` values are duplicate calls — dropped per
+        # the OpenAI single-call spec. ``None`` value means "no
+        # forced anchor admitted yet"; once set, the latch is
+        # monotonic for the rest of the request. Reset only at
+        # ``reset()`` between requests.
+        #
+        # When an admitted anchor has no ``id`` field at all (some
+        # parsers emit only ``index``+``function.name``), we use the
+        # sentinel ``""`` to record "admitted but identity unknown"
+        # — the next anchor without an id matches by sentinel; an
+        # anchor WITH an id but a different value is treated as a
+        # new call (cap-violating).
+        self._forced_anchor_admitted_id: str | None = None
         # Tracks whether the MOST RECENT anchor delta (one carrying a
         # fresh ``id`` / function ``name`` / new ``index``) was DROPPED
         # because the cap was full. Subsequent argument-only no-index
@@ -1056,6 +1103,166 @@ class StreamingPostProcessor:
         self._json_fence_tail = ""
         return tail
 
+    # R10-C8 (Mira r10-R1) — UI-TARS-style tool-prose-prefix scrubber.
+    #
+    # Mira's r10 dogfood evidence (E SSE) shows the chat lane streaming
+    # 12 plain-content chunks like ``"Tool"``, ``":"``, ``" get"``,
+    # ``"_weather"``, ``"\n"``, ``"Parameters"``, ``":"``, ``" location"``,
+    # ``"="``, ``"Paris"``, ``"\n"`` BEFORE the single structured
+    # ``delta.tool_calls`` chunk. A client rendering ``delta.content``
+    # live shows garbage prefixing the actual tool call. The wire-scrub
+    # from PR #806 only filters ``<tool_call>...</tool_call>`` literal
+    # spans; the UI-TARS action parser's natural-language preamble
+    # falls through to the standard content path.
+    #
+    # Strategy: lightweight buffer-and-emit state machine. When tools
+    # are requested AND a content event matches a tool-prose-prefix
+    # pattern, hold it back. Discard the buffer when a tool_call event
+    # arrives in the same stream (the model just confirmed the prose
+    # was a tool-dispatch preamble). Release the buffer back to the
+    # wire when the buffer exceeds the cap (a model legitimately
+    # discussing ``"Tool: foo"`` in prose isn't censored). Active
+    # ONLY when ``tools_requested`` is True so non-tool requests pay
+    # zero overhead.
+    #
+    # The pattern set is intentionally narrow — only the UI-TARS /
+    # function-calling stylesheet prefixes that have NO other plausible
+    # plain-prose use at the start of a streamed reply. Each entry is
+    # a compiled regex that must match the FULL leading content
+    # buffer (re.match anchored at position 0).
+    _TOOL_PROSE_PREFIX_RES: tuple = (
+        # ``Tool: <name>\nParameters: ...`` (UI-TARS evidence — Mira E)
+        re.compile(r"^(?:Tool|Action|Function)\s*:\s*[A-Za-z_][A-Za-z0-9_-]*", re.DOTALL),
+        # Bare ``Tool:`` / ``Action:`` / ``Function:`` with no name yet —
+        # the prose hasn't progressed to the name token yet but the
+        # opener is unambiguous.
+        re.compile(r"^(?:Tool|Action|Function)\s*:\s*$", re.DOTALL),
+        # Partial prefix while the name token is still streaming
+        # (chunk boundary split ``"Tool"`` ``":"`` ``" get_weather"``).
+        re.compile(r"^(?:Tool|Action|Function)$", re.DOTALL),
+        re.compile(r"^(?:Tool|Action|Function)\s*$", re.DOTALL),
+    )
+    # Soft cap on buffer growth. The longest plausible UI-TARS preamble
+    # is ``Tool: <name>\nParameters: <kv-pairs>\n`` — for a 64-char name
+    # plus 256 chars of param prose that's ~330 bytes. 512 leaves slack
+    # for parser variants without holding back legitimate prose
+    # indefinitely.
+    _TOOL_PROSE_MAX_HOLD: int = 512
+
+    def _matches_tool_prose_prefix(self, text: str) -> bool:
+        """True iff ``text`` matches a tool-dispatch prose preamble.
+
+        Used to gate hold-back: a buffer that no longer matches any of
+        the patterns is released back to the wire because the model
+        moved on to legitimate content. A buffer that grows past
+        ``_TOOL_PROSE_MAX_HOLD`` is also released (the tool parser
+        clearly isn't going to consume it).
+        """
+        if not text:
+            return False
+        for pattern in self._TOOL_PROSE_PREFIX_RES:
+            if pattern.match(text):
+                return True
+        return False
+
+    def _filter_events_for_tool_prose(
+        self, events: list[StreamEvent]
+    ) -> list[StreamEvent]:
+        """Hold back tool-prose-prefix content events; discard on tool_call.
+
+        Walks the event list once. ``content`` events extend the
+        prose buffer when (a) the buffer is empty and the content
+        matches a prose-prefix pattern, OR (b) the buffer is non-
+        empty (we're already inside a hold). ``tool_call`` events
+        clear the buffer (the model confirmed the prose was a tool-
+        dispatch preamble — discard so it never reaches the wire,
+        matching the R10-M4 ``\\n\\n`` trailing whitespace requirement).
+        Other event types pass through unchanged.
+
+        When the held buffer grows past ``_TOOL_PROSE_MAX_HOLD`` OR no
+        longer matches any prefix pattern (the model moved on to
+        legitimate prose), flush it as a single content event in the
+        position the LAST content event would have occupied. This
+        preserves event ordering for downstream consumers.
+
+        No-op when ``tools_requested`` is False — non-tool requests
+        pay zero cost. R10-M4 trailing-whitespace handling: when the
+        buffer trails with ``\\n\\n`` AND a tool_call is later detected,
+        the buffer (including the trailing whitespace) is discarded
+        as part of the prose preamble — no separate scrubber needed.
+        """
+        if not self.tools_requested:
+            return events
+
+        from dataclasses import replace as _dc_replace
+
+        out: list[StreamEvent] = []
+        for ev in events:
+            if ev.type == "tool_call":
+                # Tool call confirmed — every byte we held was a
+                # dispatch preamble. Discard the buffer and pass the
+                # tool_call through. ``_tool_prose_active`` stays
+                # latched True so later content events in the same
+                # turn (e.g. an explanatory tail the parser surfaces)
+                # also get the prefix check, but most parsers go
+                # straight to ``finish`` after the call so this is a
+                # short-lived state.
+                self._tool_prose_buffer = ""
+                out.append(ev)
+                continue
+            if ev.type != "content":
+                out.append(ev)
+                continue
+            chunk = ev.content or ""
+            # R10-M4: when the prose buffer is non-empty AND this
+            # chunk is just trailing whitespace, fold it into the
+            # buffer so a later tool_call discards it too. The
+            # alternative (emit ``"\\n\\n"`` to the wire) is the
+            # exact leak r10-R1 surfaced on the canonical-tag scrub.
+            combined = self._tool_prose_buffer + chunk
+            if self._tool_prose_active or self._matches_tool_prose_prefix(combined):
+                self._tool_prose_active = True
+                self._tool_prose_buffer = combined
+                # Soft cap — release as legitimate prose if we held
+                # too much. A model legitimately discussing the word
+                # ``Tool:`` in prose passes through here.
+                if (
+                    len(self._tool_prose_buffer) > self._TOOL_PROSE_MAX_HOLD
+                    or not self._matches_tool_prose_prefix(self._tool_prose_buffer)
+                ):
+                    released = self._tool_prose_buffer
+                    self._tool_prose_buffer = ""
+                    self._tool_prose_active = False
+                    out.append(_dc_replace(ev, content=released))
+                # Else: keep holding; emit nothing for this chunk.
+                continue
+            out.append(ev)
+        return out
+
+    def _flush_tool_prose_buffer(self) -> str:
+        """Drain the tool-prose buffer at stream end.
+
+        Called from ``finalize()`` so a held buffer that never saw a
+        matching tool_call IS released to the client (the model
+        legitimately ended a turn with ``"Tool: ...\\n"`` prose —
+        rare, but censoring it would be a silent drop).
+        """
+        if not self.tools_requested:
+            return ""
+        # If a tool_call was detected this turn, every byte we held
+        # was a dispatch preamble — drop it silently. This is the
+        # canonical R10-C8 + R10-M4 path: model emitted the prose
+        # preamble, parser surfaced the structured call, prose is
+        # discarded as wire residue.
+        if self.tool_calls_detected:
+            self._tool_prose_buffer = ""
+            self._tool_prose_active = False
+            return ""
+        tail = self._tool_prose_buffer
+        self._tool_prose_buffer = ""
+        self._tool_prose_active = False
+        return tail
+
     @staticmethod
     def _create_reasoning_parser(cfg: ServerConfig):
         """Create a per-request reasoning parser instance."""
@@ -1347,6 +1554,32 @@ class StreamingPostProcessor:
         name = _get(fn, "name")
         return name if isinstance(name, str) and name else None
 
+    def _is_tool_choice_required(self) -> bool:
+        """Return True iff the request set ``tool_choice="required"``.
+
+        R10-H3 (Sven r10-R1): under ``tool_choice="required"`` the model
+        is forced to emit at least one tool_call, but the OpenAI spec
+        still requires every emitted call's ``arguments`` to be a JSON-
+        object-encoded string. Pre-fix the streaming postprocessor
+        applied no argument validation in this mode, so reasoning
+        models occasionally streamed raw token sequences (``"20230805"``,
+        ``"☉ Paris"``) into the ``arguments`` field. Clients running
+        ``json.loads(arguments)`` then bailed mid-agent-loop.
+
+        Helper kept SEPARATE from ``_forced_tool_choice_name`` so the
+        forced-named-choice path (single-call enforcement, name match)
+        and the ``required``-but-flexible path (any tool, args must
+        still be objects) don't conflate.
+        """
+        req = self.request
+        if req is None:
+            return False
+        if isinstance(req, dict):
+            tc = req.get("tool_choice")
+        else:
+            tc = getattr(req, "tool_choice", None)
+        return tc == "required"
+
     @staticmethod
     def _forced_tool_choice_arguments_violate_object_root(args_str: str | None) -> bool:
         """Return True when a finalized anchor's ``arguments`` value
@@ -1407,37 +1640,51 @@ class StreamingPostProcessor:
         return not isinstance(parsed, dict)
 
     def _apply_forced_tool_choice_filter(self, tool_calls: list[dict]) -> list[dict]:
-        """Suppress streaming tool_calls deltas that violate a forced
-        ``tool_choice`` named-function contract.
+        """Suppress streaming tool_calls deltas that violate the
+        ``tool_choice`` contract (forced named, or ``"required"``).
 
-        Two drop conditions, both required by the OpenAI spec:
+        Drop conditions enforced per the OpenAI spec:
 
-        1. **Wrong function**: an anchor delta naming a function other
-           than the forced choice. This catches harmony / gemma4
-           channel-routed calls to other tools the model speculated
-           on but the client never requested.
+        1. **Wrong function** (forced-name mode only): an anchor delta
+           naming a function other than the forced choice. This catches
+           harmony / gemma4 channel-routed calls to other tools the
+           model speculated on but the client never requested.
 
-        2. **Schema-violating arguments**: an anchor whose
-           ``arguments`` is non-empty AND does not parse as a JSON
-           OBJECT. The OpenAI spec mandates ``arguments`` be a JSON-
-           encoded string and tool schemas are object-shaped
+        2. **Schema-violating arguments** (forced-name AND required): an
+           anchor whose ``arguments`` is non-empty AND does not parse
+           as a JSON OBJECT. The OpenAI spec mandates ``arguments`` be
+           a JSON-encoded string and tool schemas are object-shaped
            (``{"type":"object","properties":{…}}``); a bare integer
-           ``"1234567890"`` or string ``"☉ Paris output"`` is the
-           model's scratch-pad — not a real call. Captures the
+           ``"1234567890"`` / ``"20230805"`` or string ``"☉ Paris output"``
+           is the model's scratch-pad — not a real call. Captures the
            F-200 reasoning-model scratch leak that the MiniMax tool-
-           markup redirect promoted into structured deltas.
+           markup redirect promoted into structured deltas, AND the
+           R10-H3 (Sven r10-R1) ``tool_choice="required"`` token-string
+           leak on qwen3-bf16.
+
+        3. **Single-call cap** (forced-name mode only): once an anchor
+           has been admitted for the forced choice, every subsequent
+           anchor is dropped. R10-H2 (Sven r10-R1) — pre-fix, qwen3
+           streaming sometimes emitted two anchor deltas with the same
+           function name and DIFFERENT ``call_id`` values; openai-agents
+           and claude-agents loops then executed the tool twice. The
+           OpenAI spec for forced named-function mode is "exactly one
+           tool_call for the named function". ``tool_choice="required"``
+           is NOT subject to this cap (parallel multi-tool dispatch is
+           legal there); the argument-shape gate above still applies.
 
         Argument-fragment continuation deltas (no name, no id) pass
         through unconditionally — the parallel-cap layer already
         tracks ``_no_index_last_dropped`` so fragments routed to a
         dropped anchor are suppressed.
 
-        No-op when no forced ``tool_choice`` name is set: the request
-        is in auto / required / unset mode, and multi-tool and
-        flexible-argument flows must keep working.
+        No-op when ``tool_choice`` is unset / ``"auto"`` / ``"none"``:
+        the auto-mode flows must keep working without per-anchor
+        post-filtering.
         """
         forced_name = self._forced_tool_choice_name()
-        if not forced_name:
+        required_mode = self._is_tool_choice_required()
+        if not forced_name and not required_mode:
             return tool_calls
         filtered: list[dict] = []
         for tc in tool_calls:
@@ -1452,9 +1699,13 @@ class StreamingPostProcessor:
             anchor_name = wrapped_name or flat_name
             if anchor_name is None:
                 # Continuation fragment — defer to cap-layer routing.
+                # When the prior anchor for this forced choice was
+                # dropped (wrong name, schema-violating args, or
+                # single-call cap hit), ``_no_index_last_dropped`` is
+                # set and the cap layer suppresses these fragments too.
                 filtered.append(tc)
                 continue
-            if anchor_name != forced_name:
+            if forced_name and anchor_name != forced_name:
                 # Wrong function — suppress this anchor and tell the
                 # cap layer to drop its fragment continuations.
                 self._no_index_last_dropped = True
@@ -1475,11 +1726,63 @@ class StreamingPostProcessor:
             )
             args_str = wrapped_args if wrapped_args is not None else flat_args
             if self._forced_tool_choice_arguments_violate_object_root(args_str):
-                # F-200 root case: ``arguments`` parsed as JSON but
-                # the root type is not ``object``. Schema-violating —
-                # drop the anchor and route fragments to drop.
+                # F-200 root case + R10-H3 (Sven r10-R1): ``arguments``
+                # parsed as JSON but the root type is not ``object``
+                # (raw token sequence ``"20230805"``, bare integer,
+                # bare string). Schema-violating — drop the anchor and
+                # route fragments to drop. Equally important under
+                # forced ``tool_choice``: surfacing a malformed call
+                # to clients causes their ``json.loads(arguments)`` to
+                # break the agent loop. Silent drop here is preferred
+                # over surfacing a broken contract.
                 self._no_index_last_dropped = True
                 continue
+            # R10-H2 (Sven r10-R1): single-call enforcement under
+            # forced ``tool_choice={"type":"function","function":
+            # {"name":X}}``. Once an anchor for the forced choice has
+            # been admitted, every NEW anchor (different ``id``) is
+            # dropped — the OpenAI spec mandates exactly one tool_call
+            # for a forced named choice. Pre-fix qwen3 / hermes
+            # streaming sometimes emitted the same call shape twice
+            # (scratch + final) with two distinct ``call_id`` values
+            # and agent loops (openai-agents, claude-agents) executed
+            # the tool twice.
+            #
+            # The latch keys on the admitted ``id``: cumulative
+            # argument-update parsers re-emit the same anchor
+            # (same ``id``, growing arguments JSON) on every delta;
+            # those re-emissions MUST pass through so the parallel-
+            # cap layer can route them as continuations of the
+            # admitted call. Round-10 of the parallel-cap codex review
+            # already wired the no-index re-emission path; the
+            # forced-choice latch mirrors that contract by id-match.
+            #
+            # ``tool_choice="required"`` is NOT subject to the
+            # single-call latch: the spec only mandates "at least one
+            # tool call", so multi-tool parallel dispatch is legal in
+            # that mode. The argument-shape gate above still fires for
+            # required, but the count gate stays open.
+            if forced_name and self._forced_anchor_admitted_id is not None:
+                anchor_id = (
+                    tc.get("id")
+                    if isinstance(tc.get("id"), str) and tc.get("id")
+                    else ""
+                )
+                if anchor_id != self._forced_anchor_admitted_id:
+                    # Duplicate call — different id from the admitted
+                    # one. Drop the anchor and route its fragment
+                    # continuations to drop via the cap layer.
+                    self._no_index_last_dropped = True
+                    continue
+                # Same id — cumulative re-emission of the admitted
+                # call's growing arguments JSON. Pass through.
+            elif forced_name:
+                anchor_id = (
+                    tc.get("id")
+                    if isinstance(tc.get("id"), str) and tc.get("id")
+                    else ""
+                )
+                self._forced_anchor_admitted_id = anchor_id
             filtered.append(tc)
         return filtered
 
@@ -1725,6 +2028,10 @@ class StreamingPostProcessor:
         self.accumulated_reasoning = ""
         self.tool_calls_detected = False
         self.tool_markup_possible = False
+        # R10-C8: clear the tool-prose hold-back so a re-used processor
+        # doesn't ship the prior turn's buffered preamble bytes.
+        self._tool_prose_buffer = ""
+        self._tool_prose_active = False
         self._think_prefix_sent = False
         self._json_preamble_stripped = False
         self._json_preamble_buffer = ""
@@ -1754,6 +2061,10 @@ class StreamingPostProcessor:
         self._no_index_admitted_id = None
         self._no_index_admitted_name = None
         self._no_index_last_dropped = False
+        # R10-H2: clear the forced-anchor latch on reset so a re-used
+        # processor doesn't carry the prior request's admit state into
+        # the next forced-choice stream.
+        self._forced_anchor_admitted_id = None
         # Per-request reasoning-cap counters reset to baseline. The
         # configured cap itself (``self._reasoning_max_tokens``) is
         # immutable — it was set at __init__ from the request.
@@ -1857,7 +2168,16 @@ class StreamingPostProcessor:
         # short-circuit there. Tool-call deltas and reasoning_content
         # are untouched (the fence only ever shows up in plain content
         # for json_mode requests).
-        return self._filter_events_for_json_fence(events)
+        events = self._filter_events_for_json_fence(events)
+        # R10-C8 (Mira r10-R1) — UI-TARS-style tool-prose-prefix
+        # hold-back. Runs AFTER the json-fence filter so the two
+        # buffers can't interfere; runs BEFORE the caller's wire
+        # emission so prose preambles like ``"Tool: get_weather\n
+        # Parameters: location=Paris\n"`` are suppressed when the
+        # parser surfaces the structured call in the same turn.
+        # No-op when ``tools_requested`` is False.
+        events = self._filter_events_for_tool_prose(events)
+        return events
 
     def _process_channel_routed(
         self, delta_text: str, output: GenerationOutput
@@ -2853,6 +3173,31 @@ class StreamingPostProcessor:
         # the LAST content/finish event in this batch so JSON bytes
         # never sit after a terminal marker (codex r4 BLOCKING #2).
         events = self._filter_events_for_json_fence(events, drain_tail=True)
+
+        # R10-C8: run the tool-prose-prefix filter on the finalize
+        # events too — the route's mid-stream emitter has already
+        # decided whether to ship structured tool_calls, so the
+        # buffer's discard/release predicate is now fully informed.
+        # ``_flush_tool_prose_buffer`` drops the buffer when
+        # ``tool_calls_detected`` (the buffer was a dispatch preamble)
+        # and otherwise releases it as legitimate trailing prose.
+        events = self._filter_events_for_tool_prose(events)
+        tail = self._flush_tool_prose_buffer()
+        if tail:
+            # Merge into the last finish/content event so the prose
+            # tail doesn't sit AFTER a terminal marker. Same shape
+            # as the json-fence drain merge above.
+            from dataclasses import replace as _dc_replace
+
+            merged = False
+            for i in range(len(events) - 1, -1, -1):
+                if events[i].type in ("finish", "content"):
+                    prev = events[i].content or ""
+                    events[i] = _dc_replace(events[i], content=prev + tail)
+                    merged = True
+                    break
+            if not merged:
+                events.append(StreamEvent(type="content", content=tail))
 
         return events
 

--- a/vllm_mlx/service/postprocessor.py
+++ b/vllm_mlx/service/postprocessor.py
@@ -1737,9 +1737,7 @@ class StreamingPostProcessor:
                     else None
                 )
                 cont_args = wrapped_args if wrapped_args is not None else flat_args
-                if self._forced_tool_choice_arguments_violate_object_root(
-                    cont_args
-                ):
+                if self._forced_tool_choice_arguments_violate_object_root(cont_args):
                     self._no_index_last_dropped = True
                     continue
                 filtered.append(tc)

--- a/vllm_mlx/service/postprocessor.py
+++ b/vllm_mlx/service/postprocessor.py
@@ -1132,7 +1132,9 @@ class StreamingPostProcessor:
     # buffer (re.match anchored at position 0).
     _TOOL_PROSE_PREFIX_RES: tuple = (
         # ``Tool: <name>\nParameters: ...`` (UI-TARS evidence — Mira E)
-        re.compile(r"^(?:Tool|Action|Function)\s*:\s*[A-Za-z_][A-Za-z0-9_-]*", re.DOTALL),
+        re.compile(
+            r"^(?:Tool|Action|Function)\s*:\s*[A-Za-z_][A-Za-z0-9_-]*", re.DOTALL
+        ),
         # Bare ``Tool:`` / ``Action:`` / ``Function:`` with no name yet —
         # the prose hasn't progressed to the name token yet but the
         # opener is unambiguous.
@@ -1226,9 +1228,10 @@ class StreamingPostProcessor:
                 # Soft cap — release as legitimate prose if we held
                 # too much. A model legitimately discussing the word
                 # ``Tool:`` in prose passes through here.
-                if (
-                    len(self._tool_prose_buffer) > self._TOOL_PROSE_MAX_HOLD
-                    or not self._matches_tool_prose_prefix(self._tool_prose_buffer)
+                if len(
+                    self._tool_prose_buffer
+                ) > self._TOOL_PROSE_MAX_HOLD or not self._matches_tool_prose_prefix(
+                    self._tool_prose_buffer
                 ):
                     released = self._tool_prose_buffer
                     self._tool_prose_buffer = ""


### PR DESCRIPTION
## Why

Six related r10 dogfood findings — all in a small area (api/models + service/postprocessor + routes/completions). Bundled to land as one PR:

- **R10-C8** (CRIT — mira r10-R1): UI-TARS prose preamble ``\"Tool: <name>\\nParameters: ...\"`` leaks into ``delta.content`` before the structured ``delta.tool_calls`` chunk. Fix: streaming hold-back buffer that discards on tool_call confirmation.
- **R10-M4** (MED — mira r10-R1): trailing ``\\n\\n`` whitespace also leaks after the scrubbed ``<tool_call>`` literal. Same hold-back covers it.
- **R10-H2** (HIGH — sven r10-R1): forced ``tool_choice={\"type\":\"function\",...}`` admits two ``tool_calls`` indices with distinct ``call_id``s → agent loops execute the tool twice. Fix: ``_apply_forced_tool_choice_filter`` enforces single-call latch keyed on admitted ``call_id`` (same-id re-emissions still pass).
- **R10-H3** (HIGH — sven r10-R1): ``tool_choice=\"required\"`` streams raw token-sequence ``arguments=\"20230805\"`` (non-object JSON root). Fix: extend the JSON-object-root gate to ``required`` mode too.
- **R10-H4** (HIGH — vlad/bo r10-R1, R9-H2 carry): ``/v1/completions`` silently drops ``response_format=json_object``; PR #844's fence-strip path was only on chat. Fix: declare the field on ``CompletionRequest`` + apply ``extract_json_from_response`` on sync, buffered-then-stripped emit on streaming.
- **R10-H5** (HIGH — sven/vlad r10-R1, R9-H3 carry): ``reasoning_effort`` accepts any value on both /v1/chat/completions and /v1/responses. Fix: ``Literal[\"none\",\"minimal\",\"low\",\"medium\",\"high\"] | None`` on the chat top-level field, the responses top-level shorthand, and the canonical nested ``reasoning.effort``.
- **R10-H6** (HIGH — mira r10-R1, R9-H4 carry): chat-lane ``tools=[{\"type\":\"computer_use\"}]`` shorthand 400s. Fix: ``ToolDefinition`` model_validator synthesises the canonical ``computer`` function tool from the alias (mirrors ``responses_adapter._convert_tools``).

## What changed

- ``vllm_mlx/api/models.py`` — adds shared ``_validate_reasoning_effort`` + ``_COMPUTER_USE_TYPE_ALIASES`` normaliser; ``ToolDefinition`` accepts the computer-use shorthand; ``CompletionRequest`` declares + validates ``response_format``; ``ChatCompletionRequest`` declares + validates ``reasoning_effort``.
- ``vllm_mlx/api/responses_models.py`` — declares + validates ``reasoning_effort`` (top-level shorthand) AND the canonical nested ``reasoning.effort``.
- ``vllm_mlx/service/postprocessor.py`` — adds tool-prose hold-back state + ``_filter_events_for_tool_prose`` / ``_flush_tool_prose_buffer``; extends ``_apply_forced_tool_choice_filter`` with single-call latch (forced-name) and ``required`` mode coverage.
- ``vllm_mlx/routes/completions.py`` — sync path runs ``extract_json_from_response``; streaming path buffers in json-mode and emits one fence-stripped chunk.
- ``tests/test_r10_scrub_validation_bundle.py`` — 57 new tests covering every finding's repro + parity invariant.

## Test plan

- [x] 57 new tests in ``tests/test_r10_scrub_validation_bundle.py`` pass.
- [x] All landed PR #806 forced ``tool_choice`` enforcement tests still pass (``test_tool_choice_enforcement.py`` 76/76, ``test_stream_forced_tool_reasoning.py`` 20/20).
- [x] All landed PR #844 streaming-fence tests still pass (``test_response_format_streaming_fence_strip.py`` 32/32).
- [x] Broader suite: 9067 tests pass (skipped flaky perf test ``test_batched_faster_than_sequential`` + infrastructure-dependent ``test_event_loop.py``).

🤖 Generated with [Claude Code](https://claude.com/claude-code)