### PR TITLE
fix(audio/vibevoice): dynamic voice enumeration + correct default voice (R11-B-F1)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.8.13"
+version = "0.8.12"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.8.12"
+version = "0.8.13"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/tests/test_audio_r8_a_bundle.py
+++ b/tests/test_audio_r8_a_bundle.py
@@ -664,9 +664,7 @@ class TestAllowedVoicesDynamicEnumeration:
             assert filename == "config.json"
             return str(snapshot / "config.json")
 
-        monkeypatch.setattr(
-            "huggingface_hub.try_to_load_from_cache", fake_cache_lookup
-        )
+        monkeypatch.setattr("huggingface_hub.try_to_load_from_cache", fake_cache_lookup)
 
         from vllm_mlx.audio.tts import _list_snapshot_voices
 
@@ -721,9 +719,7 @@ class TestAllowedVoicesDynamicEnumeration:
             captured["repo_id"] = repo_id
             return str(snapshot / "config.json")
 
-        monkeypatch.setattr(
-            "huggingface_hub.try_to_load_from_cache", fake_cache_lookup
-        )
+        monkeypatch.setattr("huggingface_hub.try_to_load_from_cache", fake_cache_lookup)
 
         from vllm_mlx.audio.tts import _list_snapshot_voices
 
@@ -846,9 +842,7 @@ class TestVibevoiceDefaultSentinelResolves:
         self._patch_static_fallback(monkeypatch)
         for alias in ("voxcpm", "dia"):
             voices_seen: list[str] = []
-            audio_route, _models = _stub_engine(
-                monkeypatch, voice_observed=voices_seen
-            )
+            audio_route, _models = _stub_engine(monkeypatch, voice_observed=voices_seen)
             client, restore = _mount_audio_app()
             try:
                 r = client.post(

--- a/tests/test_audio_r8_a_bundle.py
+++ b/tests/test_audio_r8_a_bundle.py
@@ -870,6 +870,90 @@ class TestVibevoiceDefaultSentinelResolves:
             )
             assert voices_seen == ["default"], (alias, voices_seen)
 
+    def test_vibevoice_voice_omitted_remaps_to_registry_default(self, monkeypatch):
+        # Codex r1 MEDIUM (Diff): pre-fix the Pydantic model defaulted
+        # ``voice`` to ``"af_heart"`` so a request body like
+        # ``{"model":"vibevoice","input":"hi"}`` (no ``voice`` key)
+        # 400'd because ``af_heart`` isn't a real VibeVoice voice.
+        # The omitted-voice shape MUST resolve to the registry default
+        # ``en-Grace_woman``, same as the explicit ``"default"``
+        # sentinel.
+        self._patch_static_fallback(monkeypatch)
+        voices_seen: list[str] = []
+        audio_route, _models = _stub_engine(monkeypatch, voice_observed=voices_seen)
+        client, restore = _mount_audio_app()
+        try:
+            r = client.post(
+                "/v1/audio/speech",
+                json={
+                    "model": "vibevoice",
+                    "input": "hello",
+                    # voice deliberately omitted
+                    "response_format": "wav",
+                },
+            )
+        finally:
+            restore()
+            audio_route._tts_engine = None
+
+        assert r.status_code == 200, (
+            f"R11-B-F1 / codex r1 regression: vibevoice with omitted "
+            f"voice returned {r.status_code}; expected 200 after remap "
+            f"to registry default. Body: {r.text[:500]}"
+        )
+        assert voices_seen == ["en-Grace_woman"], voices_seen
+
+    def test_chatterbox_voice_omitted_remaps_to_default(self, monkeypatch):
+        # Chatterbox's registry default is ``"default"`` — the remap
+        # IS the canonical path because pre-fix this 400'd with
+        # ``voice='af_heart' not recognized for model 'mlx-community/
+        # chatterbox-turbo-fp16'`` whenever a client omitted ``voice``.
+        self._patch_static_fallback(monkeypatch)
+        voices_seen: list[str] = []
+        audio_route, _models = _stub_engine(monkeypatch, voice_observed=voices_seen)
+        client, restore = _mount_audio_app()
+        try:
+            r = client.post(
+                "/v1/audio/speech",
+                json={
+                    "model": "chatterbox",
+                    "input": "hello",
+                    # voice deliberately omitted
+                },
+            )
+        finally:
+            restore()
+            audio_route._tts_engine = None
+
+        assert r.status_code == 200, r.text
+        assert voices_seen == ["default"], voices_seen
+
+    def test_explicit_af_heart_respected_against_kokoro(self, monkeypatch):
+        # Codex r1 MEDIUM regression-guard: an EXPLICIT
+        # ``voice="af_heart"`` from the client must NOT be rewritten
+        # — only the Pydantic-default omitted-voice case routes through
+        # the registry. This pins the boundary between "user said
+        # nothing" and "user explicitly requested af_heart".
+        self._patch_static_fallback(monkeypatch)
+        voices_seen: list[str] = []
+        audio_route, _models = _stub_engine(monkeypatch, voice_observed=voices_seen)
+        client, restore = _mount_audio_app()
+        try:
+            r = client.post(
+                "/v1/audio/speech",
+                json={
+                    "model": "kokoro",
+                    "input": "hello",
+                    "voice": "af_heart",  # explicit
+                },
+            )
+        finally:
+            restore()
+            audio_route._tts_engine = None
+
+        assert r.status_code == 200, r.text
+        assert voices_seen == ["af_heart"], voices_seen
+
     def test_kokoro_default_remaps_to_af_heart(self, monkeypatch):
         # Kokoro's registry ``default_voice`` is ``"af_heart"`` so a
         # request that explicitly sends ``voice="default"`` must be

--- a/tests/test_audio_r8_a_bundle.py
+++ b/tests/test_audio_r8_a_bundle.py
@@ -562,7 +562,31 @@ class TestVoiceValidation:
 class TestAllowedVoicesHelper:
     """Pin the ``_allowed_voices_for`` helper's family detection so a
     future engine added to the registry can't accidentally diverge
-    from the route's voice-validation rule."""
+    from the route's voice-validation rule.
+
+    R11-B-F1 (Bo 0.8.12 dogfood) refactored the helper to enumerate
+    the snapshot's ``voices/`` dir at request time and fall back to
+    the per-family static list when the snapshot isn't cached locally.
+    The cold-start (fallback) path is the contract pinned here —
+    monkeypatching ``_list_snapshot_voices`` to ``[]`` forces the
+    static branch so the assertions stay deterministic regardless of
+    the test runner's HuggingFace cache state.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _force_static_fallback(self, monkeypatch):
+        # Pin the static-fallback branch by forcing the dynamic
+        # enumeration to return empty. The dynamic-success path is
+        # covered by ``TestAllowedVoicesDynamicEnumeration`` below.
+        import vllm_mlx.routes.audio as audio_route
+
+        # ``_allowed_voices_for`` calls ``_list_snapshot_voices`` via
+        # a lazy ``from ..audio.tts import ...`` inside the helper, so
+        # the monkeypatch lands on the source attribute.
+        from vllm_mlx.audio import tts as tts_module
+
+        monkeypatch.setattr(tts_module, "_list_snapshot_voices", lambda _name: [])
+        yield audio_route  # nothing for the tests to consume
 
     def test_kokoro_short_alias_returns_kokoro_voices(self):
         from vllm_mlx.audio.tts import KOKORO_VOICES
@@ -584,10 +608,295 @@ class TestAllowedVoicesHelper:
 
         assert _allowed_voices_for("chatterbox") == list(CHATTERBOX_VOICES)
 
+    def test_vibevoice_returns_seeded_english_voices(self):
+        # R11-B-F1: pre-fix the helper hard-coded ``["default"]`` for
+        # every non-kokoro/non-chatterbox family. The new cold-start
+        # fallback for VibeVoice seeds the English voice set so the
+        # 400 envelope's ``Available:`` preview is informative even
+        # before the snapshot has been downloaded — and so a request
+        # carrying ``voice="en-Grace_woman"`` (the registry default)
+        # passes voice validation on the first call.
+        from vllm_mlx.routes.audio import _allowed_voices_for
+
+        voices = _allowed_voices_for("vibevoice")
+        assert "en-Grace_woman" in voices, (
+            "VibeVoice cold-start fallback must include en-Grace_woman "
+            f"(registry default). Got: {voices}"
+        )
+        # Pre-fix this would have included only ``"default"``, which
+        # is precisely the value VibeVoice does NOT ship.
+        assert "default" not in voices, (
+            "VibeVoice has no default.safetensors in its snapshot — "
+            "the cold-start fallback MUST NOT advertise it as a valid "
+            f"voice. Got: {voices}"
+        )
+
     def test_unknown_family_returns_default(self):
         from vllm_mlx.routes.audio import _allowed_voices_for
 
         assert _allowed_voices_for("some/UnknownEngine") == ["default"]
+
+
+class TestAllowedVoicesDynamicEnumeration:
+    """R11-B-F1: when the snapshot is cached locally the helper must
+    enumerate the actual ``voices/`` dir, not the per-family static
+    list. Covers the warm-path: chatterbox/voxcpm/dia all ship a
+    single ``default.safetensors`` so the enumeration returns the
+    same ``["default"]`` the static list had; kokoro / vibevoice
+    ship richer voice sets and the enumeration must surface them."""
+
+    def test_enumeration_strips_safetensors_extension(self, tmp_path, monkeypatch):
+        # Build a fake snapshot dir matching the real HF cache shape.
+        snapshot = tmp_path / "snapshot"
+        (snapshot / "voices").mkdir(parents=True)
+        (snapshot / "voices" / "en-Grace_woman.safetensors").write_bytes(b"x")
+        (snapshot / "voices" / "en-Mike_man.safetensors").write_bytes(b"x")
+        # A non-safetensors sibling MUST be ignored — VibeVoice ships
+        # neither but kokoro snapshots include ``.pt`` mirrors of every
+        # voice.
+        (snapshot / "voices" / "en-Grace_woman.pt").write_bytes(b"x")
+        # The helper uses ``config.json`` as the cache probe.
+        (snapshot / "config.json").write_bytes(b"{}")
+
+        from huggingface_hub import try_to_load_from_cache as real_helper  # noqa: F401
+
+        def fake_cache_lookup(repo_id, filename):
+            assert filename == "config.json"
+            return str(snapshot / "config.json")
+
+        monkeypatch.setattr(
+            "huggingface_hub.try_to_load_from_cache", fake_cache_lookup
+        )
+
+        from vllm_mlx.audio.tts import _list_snapshot_voices
+
+        result = _list_snapshot_voices("mlx-community/VibeVoice-Realtime-0.5B-4bit")
+        assert result == ["en-Grace_woman", "en-Mike_man"], result
+
+    def test_enumeration_returns_empty_when_snapshot_missing(self, monkeypatch):
+        # Local-only lookup: ``try_to_load_from_cache`` returns ``None``
+        # for a repo not on disk. We MUST NOT trigger a download from
+        # inside the voice-validation path.
+        monkeypatch.setattr(
+            "huggingface_hub.try_to_load_from_cache",
+            lambda repo_id, filename: None,
+        )
+
+        from vllm_mlx.audio.tts import _list_snapshot_voices
+
+        assert _list_snapshot_voices("mlx-community/Nonexistent-Repo") == []
+
+    def test_enumeration_returns_empty_when_voices_dir_missing(
+        self, tmp_path, monkeypatch
+    ):
+        # Snapshot cached but no ``voices/`` dir — engines that pull
+        # voices from a different layout (or no per-voice files at
+        # all) must NOT crash the enumeration. The caller falls back
+        # to the per-family static list.
+        snapshot = tmp_path / "snapshot"
+        snapshot.mkdir()
+        (snapshot / "config.json").write_bytes(b"{}")
+
+        monkeypatch.setattr(
+            "huggingface_hub.try_to_load_from_cache",
+            lambda repo_id, filename: str(snapshot / "config.json"),
+        )
+
+        from vllm_mlx.audio.tts import _list_snapshot_voices
+
+        assert _list_snapshot_voices("mlx-community/Whatever") == []
+
+    def test_alias_short_form_resolves_via_registry(self, tmp_path, monkeypatch):
+        # A short alias (``"vibevoice"``) must map to its HF id via
+        # the registry before the cache lookup — that way the alias
+        # AND the full HF id resolve to the same snapshot.
+        snapshot = tmp_path / "snapshot"
+        (snapshot / "voices").mkdir(parents=True)
+        (snapshot / "voices" / "en-Grace_woman.safetensors").write_bytes(b"x")
+        (snapshot / "config.json").write_bytes(b"{}")
+
+        captured = {}
+
+        def fake_cache_lookup(repo_id, filename):
+            captured["repo_id"] = repo_id
+            return str(snapshot / "config.json")
+
+        monkeypatch.setattr(
+            "huggingface_hub.try_to_load_from_cache", fake_cache_lookup
+        )
+
+        from vllm_mlx.audio.tts import _list_snapshot_voices
+
+        result = _list_snapshot_voices("vibevoice")
+        assert captured["repo_id"] == "mlx-community/VibeVoice-Realtime-0.5B-4bit"
+        assert result == ["en-Grace_woman"]
+
+
+class TestVibevoiceDefaultSentinelResolves:
+    """R11-B-F1: a request carrying ``voice="default"`` against an
+    alias whose registry ``default_voice`` is something else (here
+    VibeVoice's ``"en-Grace_woman"``) must be remapped to the registry
+    default BEFORE voice validation. Pre-fix the literal ``"default"``
+    would hit the static voice list which only contained ``"default"``,
+    then fall through to ``mlx_audio.tts.models.vibevoice.Model.load
+    _voice("default")`` which 500'd with ``FileNotFoundError: Voice
+    cache not found: .../voices/default.safetensors``.
+
+    Engines whose registry ``default_voice`` IS ``"default"``
+    (chatterbox / voxcpm / dia) must keep their current behaviour —
+    the remap is a no-op there.
+    """
+
+    def _patch_static_fallback(self, monkeypatch):
+        # The test harness may run on a workstation whose HF cache
+        # already has the VibeVoice / chatterbox snapshot. Force
+        # ``_list_snapshot_voices`` to ``[]`` so the assertions pin
+        # the cold-start fallback path deterministically.
+        from vllm_mlx.audio import tts as tts_module
+
+        monkeypatch.setattr(tts_module, "_list_snapshot_voices", lambda _name: [])
+
+    def test_vibevoice_default_remaps_to_registry_default(self, monkeypatch):
+        self._patch_static_fallback(monkeypatch)
+        voices_seen: list[str] = []
+        audio_route, _models = _stub_engine(monkeypatch, voice_observed=voices_seen)
+        client, restore = _mount_audio_app()
+        try:
+            r = client.post(
+                "/v1/audio/speech",
+                json={
+                    "model": "vibevoice",
+                    "input": "hello",
+                    "voice": "default",
+                    "response_format": "wav",
+                },
+            )
+        finally:
+            restore()
+            audio_route._tts_engine = None
+
+        assert r.status_code == 200, (
+            f"R11-B-F1 regression: vibevoice voice=default returned "
+            f"{r.status_code}; expected 200 after remap to "
+            f"registry default_voice. Body: {r.text[:500]}"
+        )
+        # Engine receives the remapped voice, not the literal sentinel.
+        assert voices_seen == ["en-Grace_woman"], voices_seen
+
+    def test_chatterbox_default_stays_default(self, monkeypatch):
+        # Chatterbox's registry ``default_voice`` IS ``"default"`` —
+        # the remap is structurally a no-op. Regression guard for the
+        # opposite direction (we don't want to accidentally rewrite
+        # ``"default"`` to ``"af_heart"`` or anything else).
+        self._patch_static_fallback(monkeypatch)
+        voices_seen: list[str] = []
+        audio_route, _models = _stub_engine(monkeypatch, voice_observed=voices_seen)
+        client, restore = _mount_audio_app()
+        try:
+            r = client.post(
+                "/v1/audio/speech",
+                json={
+                    "model": "chatterbox",
+                    "input": "hello",
+                    "voice": "default",
+                    "response_format": "wav",
+                },
+            )
+        finally:
+            restore()
+            audio_route._tts_engine = None
+
+        assert r.status_code == 200, r.text
+        assert voices_seen == ["default"], voices_seen
+
+    def test_vibevoice_explicit_voice_is_respected(self, monkeypatch):
+        # Explicit non-sentinel voices bypass the remap branch. A
+        # client that explicitly asks for ``en-Mike_man`` must reach
+        # the engine with exactly that string.
+        # The dynamic enumeration would return ``[]`` here (no real
+        # snapshot in the test harness) so the cold-start fallback
+        # list must include ``en-Mike_man`` for validation to pass.
+        self._patch_static_fallback(monkeypatch)
+        voices_seen: list[str] = []
+        audio_route, _models = _stub_engine(monkeypatch, voice_observed=voices_seen)
+        client, restore = _mount_audio_app()
+        try:
+            r = client.post(
+                "/v1/audio/speech",
+                json={
+                    "model": "vibevoice",
+                    "input": "hello",
+                    "voice": "en-Mike_man",
+                    "response_format": "wav",
+                },
+            )
+        finally:
+            restore()
+            audio_route._tts_engine = None
+
+        assert r.status_code == 200, r.text
+        assert voices_seen == ["en-Mike_man"], voices_seen
+
+    def test_voxcpm_and_dia_default_still_accepted(self, monkeypatch):
+        # Regression guard: voxcpm and dia ship a single
+        # ``default.safetensors``; their registry ``default_voice`` is
+        # ``"default"`` so the remap is a no-op AND the static
+        # fallback ``["default"]`` accepts the request. Pre-R11-B-F1
+        # path stays alive.
+        self._patch_static_fallback(monkeypatch)
+        for alias in ("voxcpm", "dia"):
+            voices_seen: list[str] = []
+            audio_route, _models = _stub_engine(
+                monkeypatch, voice_observed=voices_seen
+            )
+            client, restore = _mount_audio_app()
+            try:
+                r = client.post(
+                    "/v1/audio/speech",
+                    json={
+                        "model": alias,
+                        "input": "hello",
+                        "voice": "default",
+                        "response_format": "wav",
+                    },
+                )
+            finally:
+                restore()
+                audio_route._tts_engine = None
+
+            assert r.status_code == 200, (
+                f"{alias} voice=default returned {r.status_code}; "
+                f"expected 200. Body: {r.text[:500]}"
+            )
+            assert voices_seen == ["default"], (alias, voices_seen)
+
+    def test_kokoro_default_remaps_to_af_heart(self, monkeypatch):
+        # Kokoro's registry ``default_voice`` is ``"af_heart"`` so a
+        # request that explicitly sends ``voice="default"`` must be
+        # remapped — same contract as vibevoice. This is the codepath
+        # the task brief calls out as "Bo confirmed kokoro fallback
+        # works"; pre-fix it actually 400'd here because ``"default"``
+        # wasn't in ``KOKORO_VOICES``.
+        self._patch_static_fallback(monkeypatch)
+        voices_seen: list[str] = []
+        audio_route, _models = _stub_engine(monkeypatch, voice_observed=voices_seen)
+        client, restore = _mount_audio_app()
+        try:
+            r = client.post(
+                "/v1/audio/speech",
+                json={
+                    "model": "kokoro",
+                    "input": "hello",
+                    "voice": "default",
+                    "response_format": "wav",
+                },
+            )
+        finally:
+            restore()
+            audio_route._tts_engine = None
+
+        assert r.status_code == 200, r.text
+        assert voices_seen == ["af_heart"], voices_seen
 
 
 # ---------------------------------------------------------------------------

--- a/vllm_mlx/audio/aliases.json
+++ b/vllm_mlx/audio/aliases.json
@@ -70,14 +70,14 @@
     "type": "tts",
     "hf_id": "mlx-community/VibeVoice-Realtime-0.5B-4bit",
     "family": "vibevoice",
-    "default_voice": "default",
-    "notes": "Realtime low-latency TTS, 0.5B 4bit."
+    "default_voice": "en-Grace_woman",
+    "notes": "Realtime low-latency TTS, 0.5B 4bit. Per-language voice caches; en-Grace_woman is the canonical English-female default. Full set: en-{Grace_woman,Mike_man,Carter_man,Davis_man,Frank_man,Emma_woman} + de/fr/it/jp/kr/nl/pl/pt/sp Spk0/Spk1 pairs + in-Samuel_man."
   },
   "vibevoice-realtime": {
     "type": "tts",
     "hf_id": "mlx-community/VibeVoice-Realtime-0.5B-4bit",
     "family": "vibevoice",
-    "default_voice": "default",
+    "default_voice": "en-Grace_woman",
     "notes": "Long-form alias for ``vibevoice``."
   },
 

--- a/vllm_mlx/audio/tts.py
+++ b/vllm_mlx/audio/tts.py
@@ -40,6 +40,104 @@ KOKORO_VOICES = [
 CHATTERBOX_VOICES = ["default"]  # Uses reference audio for voice
 
 
+def _list_snapshot_voices(model_name: str) -> list[str]:
+    """Return the safetensors voice files cached for ``model_name``.
+
+    R11-B-F1 (Bo 0.8.12 dogfood): pre-fix the route hard-coded a
+    static voice list per family — ``["default"]`` for everything
+    except kokoro / chatterbox. VibeVoice's HF repo ships per-language
+    voice caches (``en-Grace_woman.safetensors``, ``en-Mike_man.safe
+    tensors``, the eight non-English ``Spk0/Spk1`` pairs, ...) and NO
+    ``default.safetensors`` — so EVERY ``/v1/audio/speech`` call 500'd:
+    ``voice="default"`` -> ``FileNotFoundError`` deep in
+    ``mlx_audio.tts.models.vibevoice.Model.load_voice``; a real name
+    like ``en-Grace_woman`` -> the route's 400 ``invalid_voice``
+    because the static list only contained ``"default"``.
+
+    The fix is structural — enumerate the snapshot's ``voices/`` dir at
+    validation time and use THAT list, instead of pinning a per-family
+    constant. The helper:
+
+    * Returns ``[]`` when the snapshot isn't cached locally — the
+      caller falls back to the static list so the FIRST request (which
+      triggers the download via ``load_model``) still proceeds. Once
+      the snapshot is on disk every subsequent request validates
+      against the true voice set.
+    * Accepts both short aliases (``"vibevoice"``) and HF ids
+      (``"mlx-community/VibeVoice-Realtime-0.5B-4bit"``) by going
+      through ``huggingface_hub.try_to_load_from_cache`` on
+      ``config.json`` to resolve the snapshot path. We never trigger a
+      download here — this is a synchronous request-path call and
+      blocking on a 500 MB pull would convert "validate voice" into
+      "wait two minutes".
+    * Strips the ``.safetensors`` suffix and sorts the result so the
+      400 envelope's ``Available:`` preview is deterministic.
+
+    Applies UNIFORMLY to every TTS family (kokoro, chatterbox,
+    voxcpm, dia, vibevoice, ...). Chatterbox/voxcpm/dia ship a single
+    ``default.safetensors`` so the enumeration returns ``["default"]``
+    — same behaviour as the pre-fix static list. Kokoro's snapshot
+    actually ships 50+ voice files (the pre-fix static list named only
+    11), so the enumeration is a strict superset there.
+
+    Local-only by design (``local_files_only=True``): we MUST NOT
+    issue an HTTP roundtrip from inside ``_allowed_voices_for`` — the
+    pre-flight 400 lookup runs before any weight load and a network
+    stall would convert "client sent invalid voice" into "server
+    appears to hang then times out".
+    """
+    # Local imports keep ``vllm_mlx.audio.tts`` cheap to import on
+    # API-only runners that don't install huggingface_hub (the audio
+    # extras pin it, but the boot-guard path probes this module
+    # without the extras).
+    try:
+        from huggingface_hub import try_to_load_from_cache
+    except ImportError:  # pragma: no cover — covered by ``[audio]``
+        return []
+
+    # Strip a leading registry alias to its HF id so both shapes
+    # resolve to the same snapshot. The lazy import avoids a hard
+    # circular: registry doesn't import this module.
+    try:
+        from .registry import resolve_audio_alias
+    except ImportError:
+        resolve_audio_alias = None  # type: ignore[assignment]
+
+    hf_id = model_name
+    if resolve_audio_alias is not None:
+        entry = resolve_audio_alias(model_name)
+        if entry is not None:
+            hf_id = entry.hf_id
+
+    # ``/`` is the HF-id separator — a bare alias that didn't resolve
+    # in the registry (e.g. a typo) won't be in the cache either, so
+    # short-circuit to ``[]`` and let the caller fall back to its
+    # static list. The same guard catches HF passthrough ids that
+    # haven't been downloaded yet.
+    if "/" not in hf_id:
+        return []
+
+    # Pick a small file every snapshot has so ``try_to_load_from
+    # _cache`` returns the snapshot's resolved path without triggering
+    # a download. ``config.json`` is universal across mlx-audio TTS
+    # repos (kokoro / chatterbox / vibevoice / voxcpm / dia all ship
+    # one at the snapshot root).
+    cached = try_to_load_from_cache(repo_id=hf_id, filename="config.json")
+    if not cached or not isinstance(cached, str):
+        # Snapshot not on disk yet — caller falls back to static.
+        return []
+
+    voices_dir = Path(cached).parent / "voices"
+    if not voices_dir.is_dir():
+        return []
+
+    # ``.stem`` strips the ``.safetensors`` suffix; the registry
+    # advertises voices by their bare name. Sorting makes the
+    # ``Available:`` 400 preview deterministic so doc snapshots and
+    # operator scripts don't churn.
+    return sorted(p.stem for p in voices_dir.glob("*.safetensors"))
+
+
 class UnsupportedAudioFormatError(Exception):
     """The requested TTS ``response_format`` cannot be encoded here.
 

--- a/vllm_mlx/routes/audio.py
+++ b/vllm_mlx/routes/audio.py
@@ -1291,22 +1291,75 @@ def _allowed_voices_for(model_name: str) -> list[str]:
     name" — that way both ``kokoro`` and the full HF id
     ``mlx-community/Kokoro-82M-bf16`` honour the same voice list.
 
-    The detection mirrors :func:`vllm_mlx.audio.tts.TTSEngine._detect_family`
-    so the answers stay aligned: a single substring switch ensures the
-    route AND the engine agree on which family a name belongs to, so
-    a future engine added to the registry is wired into voice
-    validation by editing one helper, not two.
+    R11-B-F1 (Bo 0.8.12 dogfood): pre-fix the per-family branch hard-
+    coded the voice list to ``["default"]`` for everything except
+    kokoro / chatterbox. That collapsed two real bugs into one
+    end-to-end 500:
+
+    * VibeVoice ships per-language voice caches (``en-Grace_woman.
+      safetensors``, ``en-Mike_man.safetensors``, the eight non-
+      English ``Spk0/Spk1`` pairs) and NO ``default.safetensors``,
+      so ``voice="default"`` 500'd in
+      ``mlx_audio.tts.models.vibevoice.Model.load_voice``.
+    * A real file name like ``en-Grace_woman`` 400'd here because
+      the static list only contained ``"default"``.
+
+    The fix is to enumerate the snapshot's ``voices/`` dir at
+    request time and use THAT list — see
+    :func:`vllm_mlx.audio.tts._list_snapshot_voices`. This applies
+    uniformly to every TTS family: chatterbox / voxcpm / dia ship a
+    single ``default.safetensors`` so the enumeration returns the
+    same ``["default"]`` the pre-fix static list had; kokoro ships
+    50+ voice files (the pre-fix static list listed only 11) so the
+    enumeration is a strict superset.
+
+    Fallback path: when the snapshot isn't cached locally (first
+    request, fresh install) the enumeration returns ``[]`` and we
+    fall back to the per-family static list. That way the FIRST
+    ``/v1/audio/speech`` call — which triggers the snapshot download
+    via ``load_model`` — still passes voice validation against the
+    registry default. After the snapshot lands the next request
+    validates against the true voice set. The registry's
+    ``default_voice`` MUST be a real voice that exists in the
+    upstream snapshot so the cold-start path doesn't 500.
     """
     # Lazy import: ``vllm_mlx.audio.tts`` transitively pulls ``numpy``
     # which the API-only test runners don't install. Same lazy pattern
     # the route uses elsewhere.
-    from ..audio.tts import CHATTERBOX_VOICES, KOKORO_VOICES
+    from ..audio.tts import (
+        CHATTERBOX_VOICES,
+        KOKORO_VOICES,
+        _list_snapshot_voices,
+    )
+
+    # Preferred path: enumerate the snapshot. Returns ``[]`` if the
+    # repo isn't cached yet (local-only lookup; no HTTP). Falling back
+    # to the static list keeps the first request alive — the engine
+    # will pull the snapshot on ``load_model`` and subsequent calls
+    # then validate against the true set.
+    dynamic = _list_snapshot_voices(model_name)
+    if dynamic:
+        return dynamic
 
     name_lower = model_name.lower()
     if "kokoro" in name_lower:
         return list(KOKORO_VOICES)
     if "chatterbox" in name_lower:
         return list(CHATTERBOX_VOICES)
+    if "vibevoice" in name_lower:
+        # Cold-start fallback for VibeVoice — the canonical English
+        # default is ``en-Grace_woman`` (per the upstream repo's
+        # voice manifest). Listed alongside the other English voices
+        # so the 400 envelope's ``Available:`` preview is informative
+        # even before the snapshot has been downloaded.
+        return [
+            "en-Grace_woman",
+            "en-Mike_man",
+            "en-Carter_man",
+            "en-Davis_man",
+            "en-Emma_woman",
+            "en-Frank_man",
+        ]
     # Unknown family — accept ``"default"`` (the catch-all the engine
     # falls back to in :meth:`TTSEngine.get_voices`) so callers
     # passing a HF id we don't have a voice list for can still drive
@@ -1379,14 +1432,29 @@ async def create_speech(request: AudioSpeechRequest = Body(...)):
         # handler body.
         model_name = _resolve_tts_model(model)
 
-        # R11-B-F3 (Bo 0.8.12 dogfood): translate the literal
+        # R11-B-F3 (Bo 0.8.12 dogfood, PR #863): translate the literal
         # ``voice="default"`` to the registry's ``default_voice`` BEFORE
         # the allowlist check below. Pre-fix the obvious naive caller
         # value (``"default"``) was rejected by the kokoro allowlist
         # even though the registry already advertises
-        # ``default_voice="af_heart"`` for it. The omitted-voice path
-        # (Pydantic default ``"af_heart"``) is unaffected — this hook
-        # only fires when the literal ``"default"`` is on the wire.
+        # ``default_voice="af_heart"`` for it.
+        #
+        # R11-B-F1 (Bo 0.8.12 dogfood, this PR): the same resolver also
+        # fires when ``voice`` was OMITTED from the JSON body. The
+        # Pydantic model defaults ``voice`` to ``"af_heart"`` (kokoro's
+        # canonical voice) for OpenAI-SDK parity. That default is
+        # correct for kokoro but wrong for VibeVoice (no
+        # ``af_heart.safetensors``) and Chatterbox/VoxCPM/Dia (expect
+        # ``"default"``). The omitted-voice shape arrives here as
+        # ``voice="af_heart"`` and 400'd against every non-kokoro
+        # family. Treat the omitted-voice case the same way as the
+        # literal ``"default"`` sentinel — both resolve to the registry
+        # default. A client that EXPLICITLY sends ``voice="af_heart"``
+        # against vibevoice keeps that value (the validator then
+        # surfaces the 400 with the real available list).
+        voice_omitted = "voice" not in request.model_fields_set
+        if voice_omitted:
+            voice = "default"
         voice = _resolve_default_voice_literal(model_name, voice)
 
         # R8-M4 (Bo 0.8.9 dogfood): validate ``voice`` against the
@@ -1538,11 +1606,12 @@ async def list_voices(model: str = "kokoro"):
 
     require_mlx_audio_tts()
 
-    from ..audio.tts import CHATTERBOX_VOICES, KOKORO_VOICES
-
-    if "kokoro" in model.lower():
-        return {"voices": KOKORO_VOICES}
-    elif "chatterbox" in model.lower():
-        return {"voices": CHATTERBOX_VOICES}
-    else:
-        return {"voices": ["default"]}
+    # R11-B-F1: route the listing through the SAME helper the
+    # speech-route's voice validator uses, so a snapshot that ships
+    # ``en-Grace_woman.safetensors`` doesn't show up as ``["default"]``
+    # on ``/v1/audio/voices`` and then 400 with ``invalid_voice`` on
+    # ``/v1/audio/speech``. The helper resolves the alias to its HF id
+    # via the registry and falls back to the per-family static list
+    # when the snapshot isn't cached locally — same contract as the
+    # speech route.
+    return {"voices": _allowed_voices_for(model)}


### PR DESCRIPTION
## Why

**R11-B-F1 (HIGH, blocks 0.8.13)** — the lone broken audio alias in 0.8.12. `vibevoice` boots fine but every `/v1/audio/speech` call fails end-to-end:

- `voice="default"` → 500 `FileNotFoundError: Voice cache not found: .../voices/default.safetensors`
- `voice="en-Grace_woman"` (a real file) → 400 `voice 'en-Grace_woman' not recognized for model ...'. Available: default.`
- Omitting `voice` (Pydantic default `af_heart` kicks in) → 400 `voice 'af_heart' not recognized for model ...'.`

Root cause is two-layered:

1. **Registry** — `vllm_mlx/audio/aliases.json` advertised `default_voice="default"` for vibevoice, but the upstream HF repo `mlx-community/VibeVoice-Realtime-0.5B-4bit` ships per-language voice caches (`en-Grace_woman.safetensors`, `en-Mike_man.safetensors`, eight non-English `Spk0`/`Spk1` pairs) and **no** `default.safetensors`.
2. **Validator** — `_allowed_voices_for` hard-coded the allowlist to `["default"]` for every family except kokoro / chatterbox.

11/12 audio aliases work; vibevoice was the only outlier because the others ship a real `default.safetensors`.

## Repro snapshot (after first request lands the model)

```
$ ls ~/.cache/huggingface/hub/models--mlx-community--VibeVoice-Realtime-0.5B-4bit/snapshots/*/voices/
de-Spk0_man.safetensors      en-Frank_man.safetensors     jp-Spk1_woman.safetensors    pt-Spk0_woman.safetensors
de-Spk1_woman.safetensors    en-Grace_woman.safetensors   kr-Spk0_woman.safetensors    pt-Spk1_man.safetensors
en-Carter_man.safetensors    en-Mike_man.safetensors      kr-Spk1_man.safetensors      sp-Spk0_woman.safetensors
en-Davis_man.safetensors     fr-Spk0_man.safetensors      nl-Spk0_man.safetensors      sp-Spk1_man.safetensors
en-Emma_woman.safetensors    fr-Spk1_woman.safetensors    nl-Spk1_woman.safetensors
                             in-Samuel_man.safetensors    pl-Spk0_man.safetensors
                             it-Spk0_woman.safetensors    pl-Spk1_woman.safetensors
                             it-Spk1_man.safetensors      jp-Spk0_man.safetensors
```

25 voices, **no `default`**.

## Before / after on local dogfood (port 8097)

**Before:**
```
voice=default          -> HTTP 500 "Audio speech synthesis failed" (FileNotFoundError under mlx_audio.tts.models.vibevoice.Model.load_voice)
voice=en-Grace_woman   -> HTTP 400 invalid_voice (only "default" advertised)
voice omitted (af_heart) -> HTTP 400 invalid_voice
```

**After:**
```
voice=default          -> HTTP 200, 38444 bytes, audio/wav  (remapped to en-Grace_woman via registry)
voice=en-Grace_woman   -> HTTP 200, 76844 bytes, audio/wav
voice=en-Mike_man      -> HTTP 200, 44844 bytes, audio/wav
voice omitted          -> HTTP 200, 38444 bytes, audio/wav  (Pydantic default rewritten via model_fields_set)
voice=alloy            -> HTTP 400 with REAL voice list in error: "Available: de-Spk0_man, de-Spk1_woman, en-Carter_man, en-Davis_man, en-Emma_woman, en-Frank_man, en-Grace_woman, en-Mike_man, ..."

GET /v1/audio/voices?model=vibevoice -> ["de-Spk0_man", ..., "en-Grace_woman", ..., "sp-Spk1_man"]  (25 voices)
```

All `.bin` outputs verified by `file` as `RIFF WAVE 16-bit PCM 24000 Hz mono`.

## Fix

**Layer 1 — registry (`vllm_mlx/audio/aliases.json`):**
- `vibevoice` and `vibevoice-realtime` `default_voice` -> `en-Grace_woman` (canonical English-female per the upstream voice manifest).
- All other entries unchanged.

**Layer 2 — validator (`vllm_mlx/audio/tts.py`, `vllm_mlx/routes/audio.py`):**
- New helper `_list_snapshot_voices(model_name)` enumerates `<snapshot>/voices/*.safetensors` via `huggingface_hub.try_to_load_from_cache` (local-only, **no HTTP** from inside voice validation). Returns `[]` when the snapshot isn't cached locally so the cold-start request that triggers the download still passes voice validation.
- `_allowed_voices_for` now prefers the dynamic list and falls back to a per-family static set (kokoro / chatterbox / vibevoice / unknown). The vibevoice fallback seeds the English voice family so even the very first request's 400 envelope has informative `Available:` hints.
- Applied uniformly: chatterbox / voxcpm / dia ship a single `default.safetensors` so the dynamic list is `["default"]` — same as the pre-fix static list. Kokoro's snapshot ships 50+ files (pre-fix static list listed only 11) so the enumeration is a strict superset.
- `/v1/audio/voices` routes through the same helper so the listed set matches what `/v1/audio/speech` accepts.

**Layer 3 — sentinel + omitted-voice resolution (`vllm_mlx/routes/audio.py`):**
- `voice="default"` is remapped to `_registry_default_voice(model_name)` BEFORE validation. Same contract `_resolve_tts_model` has for `model="default"`.
- `voice` omitted from the JSON body (detected via Pydantic's `model_fields_set`) goes through the same remap. The Pydantic default `"af_heart"` is correct for kokoro but breaks every other family; rewriting only the implicit default keeps explicit user choice (`voice="af_heart"` against vibevoice) honoured.

Chatterbox / voxcpm / dia (registry `default_voice` IS `"default"`) keep the current path — the remap is a no-op there. Codex r1 medium finding (omitted-voice gap) was addressed before merge.

## Test plan

- [x] Reproduced 500 + 400 on 0.8.12 base before any changes (logs above).
- [x] All 270 audio tests pass: `test_audio_alias_registry.py`, `test_audio_boot_check.py`, `test_audio_extras_lockin.py`, `test_audio_path_shaped_model.py`, `test_audio_probe_consistency.py`, `test_audio_r7_c_bundle.py`, `test_audio_r8_a_bundle.py`, `test_audio_routes_bundle.py`, `test_audio_upload_size_limit.py`, `test_audio.py`.
- [x] New unit tests in `test_audio_r8_a_bundle.py`:
  - `TestAllowedVoicesHelper.test_vibevoice_returns_seeded_english_voices` — cold-start fallback contract.
  - `TestAllowedVoicesDynamicEnumeration` (4 tests) — dynamic enumeration against tmpdir snapshots, strips `.safetensors`, ignores `.pt`, handles missing-snapshot / missing-voices-dir gracefully, resolves short aliases through the registry.
  - `TestVibevoiceDefaultSentinelResolves` (7 tests) — sentinel + omitted-voice remap for vibevoice / kokoro / chatterbox / voxcpm / dia; boundary guard for explicit `voice="af_heart"` not being rewritten.
- [x] End-to-end curl probe against `rapid-mlx serve vibevoice` on 127.0.0.1:8097 — 4 happy paths return WAV bytes, 1 invalid voice returns 400 with the real voice list in the envelope.
- [x] Smoke-checked the other 4 TTS families resolve their registry defaults correctly (`kokoro→af_heart`, `chatterbox→default`, `voxcpm→default`, `dia→default`, `vibevoice→en-Grace_woman`).
- [x] Codex review rounds: 2 (converged — no new findings on the audio diff after r1 follow-up).

Closes R11-B-F1 (per `/tmp/dogfood-0812/bo-r1.md`).