### PR TITLE
fix(mllm): pass frequency/presence/repetition penalty through to VLM sampler (closes #512)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
 dependencies = [
     # Core — these are all you need for `rapid-mlx serve <text-model>`
     "mlx>=0.29.0",
-    "mlx-lm>=0.31.0",  # 0.31+ required for ArraysCache native batching (hybrid models)
+    "mlx-lm>=0.31.1",  # 0.31.1+ required for presence_penalty/frequency_penalty kwargs on make_logits_processors (#512); 0.31.0 only had repetition_penalty
     # mlx-vlm is opt-in via [vision] extras (saves ~322 MB for text-only users)
     "transformers>=5.0.0",  # mlx-lm 0.30.5+ requires transformers 5.0 (rc3 bug fixed in stable)
     "tokenizers>=0.19.0",

--- a/tests/test_mllm_penalty_passthrough.py
+++ b/tests/test_mllm_penalty_passthrough.py
@@ -23,7 +23,7 @@ This module pins behaviour at three layers:
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import mlx.core as mx
 import pytest

--- a/tests/test_mllm_penalty_passthrough.py
+++ b/tests/test_mllm_penalty_passthrough.py
@@ -1,0 +1,237 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for #512 — MLLM scheduler penalty passthrough.
+
+Before the fix, ``MLLMScheduler.add_request`` constructed ``SamplingParams``
+with only ``max_tokens`` / ``temperature`` / ``top_p``, so
+``repetition_penalty`` / ``presence_penalty`` / ``frequency_penalty`` were
+silently dropped from every OpenAI request routed to a vision model. The
+LLM scheduler wires these via ``mlx_lm.sample_utils.make_logits_processors``
+(see ``scheduler.py:4147``) — the MLLM path had no analogue.
+
+This module pins behaviour at three layers:
+
+  1. Logits-processor application — ``_maybe_apply_penalty_processors``
+     mutates the row for non-neutral knobs and is a true no-op for the
+     neutral defaults (allocation-free fast path preserved).
+  2. Scheduler plumbing — ``MLLMScheduler.add_request`` reads the three
+     penalty kwargs and stamps them onto ``SamplingParams`` (and from there
+     onto ``MLLMBatchRequest`` at schedule time).
+  3. Engine plumbing — ``BatchedEngine`` MLLM branch in ``generate()`` /
+     ``stream_generate()`` forwards the three keys out of ``**kwargs`` into
+     the scheduler (mirroring the LLM branch's ``_sp_kwargs`` block).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import mlx.core as mx
+import pytest
+
+from vllm_mlx.mllm_batch_generator import (
+    MLLMBatchRequest,
+    _maybe_apply_penalty_processors,
+)
+
+
+# =============================================================================
+# Layer 1 — logits-processor application
+# =============================================================================
+
+
+def _make_req(**overrides) -> MLLMBatchRequest:
+    kwargs = dict(uid=0, request_id="r0", prompt="hi")
+    kwargs.update(overrides)
+    return MLLMBatchRequest(**kwargs)
+
+
+def test_neutral_defaults_skip_processor_allocation():
+    """All-neutral knobs must take the early-return fast path with zero
+    allocation: no processor list cached on the request and the logits
+    tensor returned unchanged. Pre-#512 every MLLM step paid this cost
+    once allocation was added defensively; we keep the fast path."""
+    req = _make_req()  # all penalties at neutral defaults
+    logits = mx.ones((1, 8))
+    before = mx.array(logits)
+    _maybe_apply_penalty_processors(req, logits, 0)
+    assert mx.array_equal(logits, before), "neutral knobs must not touch logits"
+    assert not hasattr(req, "_cached_penalty_processors"), (
+        "neutral defaults must not allocate processor cache"
+    )
+
+
+def test_repetition_penalty_suppresses_already_seen_tokens():
+    """``repetition_penalty=2.0`` divides logits of tokens that already
+    appear in ``output_tokens`` by 2 (mlx-lm semantics for positive logits).
+    Pre-fix this knob never reached the VLM sampler."""
+    req = _make_req(repetition_penalty=2.0)
+    req.output_tokens.extend([0, 1])  # tokens "already generated"
+    logits = mx.array([[10.0, 10.0, 10.0]])  # row of three positive logits
+    _maybe_apply_penalty_processors(req, logits, 0)
+    vals = logits.tolist()[0]
+    # Seen tokens (0, 1) penalised; unseen token (2) untouched.
+    assert vals[0] == pytest.approx(5.0), "seen token 0 should be /2"
+    assert vals[1] == pytest.approx(5.0), "seen token 1 should be /2"
+    assert vals[2] == pytest.approx(10.0), "unseen token must be unchanged"
+
+
+def test_presence_penalty_subtracts_constant_from_seen_tokens():
+    """``presence_penalty=0.5`` subtracts 0.5 from every token that has
+    appeared in the history. Confirms the OpenAI-spec wiring (additive,
+    not multiplicative — the multiplicative one is repetition_penalty)."""
+    req = _make_req(presence_penalty=0.5)
+    req.output_tokens.append(2)
+    logits = mx.array([[1.0, 1.0, 1.0]])
+    _maybe_apply_penalty_processors(req, logits, 0)
+    vals = logits.tolist()[0]
+    assert vals[0] == pytest.approx(1.0)
+    assert vals[1] == pytest.approx(1.0)
+    assert vals[2] == pytest.approx(0.5)
+
+
+def test_frequency_penalty_scales_with_occurrence_count():
+    """``frequency_penalty`` subtracts ``penalty`` for EACH occurrence
+    of the token in the history (mlx-lm uses ``.at[].subtract`` which
+    accumulates duplicates). Confirms the wiring picks the
+    occurrence-counting processor, not the presence-counting one."""
+    req = _make_req(frequency_penalty=0.25)
+    req.output_tokens.extend([1, 1, 1])  # token 1 seen 3x
+    logits = mx.array([[2.0, 2.0]])
+    _maybe_apply_penalty_processors(req, logits, 0)
+    vals = logits.tolist()[0]
+    assert vals[0] == pytest.approx(2.0)
+    assert vals[1] == pytest.approx(2.0 - 0.25 * 3)
+
+
+def test_processor_cache_reused_across_steps():
+    """The processor list must be memoised on the request so subsequent
+    steps don't re-build it. Pre-fix would have re-allocated on every
+    token; this keeps the per-token overhead at one dict-lookup."""
+    req = _make_req(presence_penalty=0.5)
+    req.output_tokens.append(0)
+    logits = mx.array([[1.0, 1.0]])
+    _maybe_apply_penalty_processors(req, logits, 0)
+    first_cache = req._cached_penalty_processors
+    _maybe_apply_penalty_processors(req, logits, 0)
+    assert req._cached_penalty_processors is first_cache, "cache must be reused"
+
+
+def test_first_token_no_history_is_unchanged():
+    """The first sampled token from the VLM prefill happens before any
+    output_tokens accumulate; mlx-lm processors no-op on empty history.
+    Confirms our gate doesn't accidentally penalise the prefill token."""
+    req = _make_req(repetition_penalty=2.0, presence_penalty=0.5, frequency_penalty=0.5)
+    # output_tokens is empty (first generated token, no history yet)
+    logits = mx.array([[3.0, 3.0]])
+    before = mx.array(logits)
+    _maybe_apply_penalty_processors(req, logits, 0)
+    assert mx.array_equal(logits, before)
+
+
+# =============================================================================
+# Layer 2 — MLLMScheduler.add_request stamps SamplingParams + BatchRequest
+# =============================================================================
+
+
+def _stub_scheduler():
+    """Construct a scheduler with all I/O dependencies stubbed out so we can
+    drive ``add_request`` synchronously without booting Metal/VLM."""
+    from vllm_mlx.mllm_scheduler import MLLMScheduler, MLLMSchedulerConfig
+
+    scheduler = MLLMScheduler.__new__(MLLMScheduler)
+    scheduler.config = MLLMSchedulerConfig()
+    scheduler.requests = {}
+    scheduler.waiting = __import__("collections").deque()
+    scheduler.running = {}
+    scheduler.request_id_to_uid = {}
+    scheduler.uid_to_request_id = {}
+    scheduler._cancelled_request_ids = set()
+    scheduler._disconnect_abort_ids = set()
+    scheduler._pending_abort_ids = set()
+    scheduler.num_requests_cancelled = 0
+    scheduler.num_requests_cancelled_via_disconnect = 0
+
+    import threading
+
+    scheduler._cancel_counter_lock = threading.Lock()
+    return scheduler
+
+
+def test_scheduler_add_request_stamps_penalties_on_sampling_params():
+    """``MLLMScheduler.add_request`` must thread the three penalty kwargs
+    onto ``SamplingParams`` so ``_schedule_waiting`` can copy them onto
+    ``MLLMBatchRequest``. Pre-fix the SamplingParams() constructor was
+    called with only max_tokens/temperature/top_p — the three penalty
+    fields stayed at their dataclass defaults regardless of caller input."""
+    scheduler = _stub_scheduler()
+    rid = scheduler.add_request(
+        prompt="hi",
+        max_tokens=8,
+        repetition_penalty=2.5,
+        presence_penalty=0.75,
+        frequency_penalty=-0.5,
+    )
+    req = scheduler.requests[rid]
+    assert req.sampling_params.repetition_penalty == 2.5
+    assert req.sampling_params.presence_penalty == 0.75
+    assert req.sampling_params.frequency_penalty == -0.5
+
+
+def test_scheduler_add_request_defaults_neutral_when_omitted():
+    """Callers that don't pass the penalty kwargs (everyone pre-#512) must
+    keep getting the neutral defaults so ``_maybe_apply_penalty_processors``
+    stays on its allocation-free fast path."""
+    scheduler = _stub_scheduler()
+    rid = scheduler.add_request(prompt="hi", max_tokens=8)
+    req = scheduler.requests[rid]
+    assert req.sampling_params.repetition_penalty == 1.0
+    assert req.sampling_params.presence_penalty == 0.0
+    assert req.sampling_params.frequency_penalty == 0.0
+
+
+# =============================================================================
+# Layer 3 — BatchedEngine MLLM branch forwards the kwargs
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_engine_stream_generate_mllm_forwards_penalty_kwargs():
+    """``BatchedEngine.stream_generate``'s MLLM branch must pop the three
+    penalty keys from ``**kwargs`` and forward them to
+    ``_mllm_scheduler.add_request_async``. Pre-fix they stayed in
+    ``**kwargs`` and were silently discarded by the scheduler
+    signature, so the route-layer cascade
+    (``build_extended_sampling_kwargs`` → ``chat_kwargs`` →
+    ``engine.stream_chat`` → ``engine.stream_generate``) bottomed out
+    here for vision models."""
+    from vllm_mlx.engine.batched import BatchedEngine
+
+    engine = BatchedEngine.__new__(BatchedEngine)
+    engine._loaded = True
+    engine._is_mllm = True
+    engine._mllm_scheduler = MagicMock()
+    captured: dict = {}
+
+    async def _fake_add(**kw):
+        captured.update(kw)
+        return "rid"
+
+    async def _empty_stream(*_a, **_kw):
+        if False:
+            yield None  # pragma: no cover
+
+    engine._mllm_scheduler.add_request_async = _fake_add
+    engine._mllm_scheduler.stream_outputs = _empty_stream
+
+    async for _ in engine.stream_generate(
+        prompt="hi",
+        max_tokens=8,
+        repetition_penalty=1.7,
+        presence_penalty=0.3,
+        frequency_penalty=0.4,
+    ):
+        pass
+
+    assert captured["repetition_penalty"] == 1.7
+    assert captured["presence_penalty"] == 0.3
+    assert captured["frequency_penalty"] == 0.4

--- a/tests/test_mllm_penalty_passthrough.py
+++ b/tests/test_mllm_penalty_passthrough.py
@@ -51,10 +51,9 @@ def test_neutral_defaults_skip_processor_allocation():
     tensor returned unchanged. Pre-#512 every MLLM step paid this cost
     once allocation was added defensively; we keep the fast path."""
     req = _make_req()  # all penalties at neutral defaults
-    logits = mx.ones((1, 8))
-    before = mx.array(logits)
-    _maybe_apply_penalty_processors(req, logits, 0)
-    assert mx.array_equal(logits, before), "neutral knobs must not touch logits"
+    row = mx.ones((1, 8))
+    out = _maybe_apply_penalty_processors(req, row)
+    assert out is row, "neutral knobs must return the input row unchanged"
     assert not hasattr(req, "_cached_penalty_processors"), (
         "neutral defaults must not allocate processor cache"
     )
@@ -66,9 +65,9 @@ def test_repetition_penalty_suppresses_already_seen_tokens():
     Pre-fix this knob never reached the VLM sampler."""
     req = _make_req(repetition_penalty=2.0)
     req.output_tokens.extend([0, 1])  # tokens "already generated"
-    logits = mx.array([[10.0, 10.0, 10.0]])  # row of three positive logits
-    _maybe_apply_penalty_processors(req, logits, 0)
-    vals = logits.tolist()[0]
+    row = mx.array([[10.0, 10.0, 10.0]])  # row of three positive logits
+    out = _maybe_apply_penalty_processors(req, row)
+    vals = out.tolist()[0]
     # Seen tokens (0, 1) penalised; unseen token (2) untouched.
     assert vals[0] == pytest.approx(5.0), "seen token 0 should be /2"
     assert vals[1] == pytest.approx(5.0), "seen token 1 should be /2"
@@ -81,9 +80,9 @@ def test_presence_penalty_subtracts_constant_from_seen_tokens():
     not multiplicative — the multiplicative one is repetition_penalty)."""
     req = _make_req(presence_penalty=0.5)
     req.output_tokens.append(2)
-    logits = mx.array([[1.0, 1.0, 1.0]])
-    _maybe_apply_penalty_processors(req, logits, 0)
-    vals = logits.tolist()[0]
+    row = mx.array([[1.0, 1.0, 1.0]])
+    out = _maybe_apply_penalty_processors(req, row)
+    vals = out.tolist()[0]
     assert vals[0] == pytest.approx(1.0)
     assert vals[1] == pytest.approx(1.0)
     assert vals[2] == pytest.approx(0.5)
@@ -96,9 +95,9 @@ def test_frequency_penalty_scales_with_occurrence_count():
     occurrence-counting processor, not the presence-counting one."""
     req = _make_req(frequency_penalty=0.25)
     req.output_tokens.extend([1, 1, 1])  # token 1 seen 3x
-    logits = mx.array([[2.0, 2.0]])
-    _maybe_apply_penalty_processors(req, logits, 0)
-    vals = logits.tolist()[0]
+    row = mx.array([[2.0, 2.0]])
+    out = _maybe_apply_penalty_processors(req, row)
+    vals = out.tolist()[0]
     assert vals[0] == pytest.approx(2.0)
     assert vals[1] == pytest.approx(2.0 - 0.25 * 3)
 
@@ -109,10 +108,10 @@ def test_processor_cache_reused_across_steps():
     token; this keeps the per-token overhead at one dict-lookup."""
     req = _make_req(presence_penalty=0.5)
     req.output_tokens.append(0)
-    logits = mx.array([[1.0, 1.0]])
-    _maybe_apply_penalty_processors(req, logits, 0)
+    row = mx.array([[1.0, 1.0]])
+    _maybe_apply_penalty_processors(req, row)
     first_cache = req._cached_penalty_processors
-    _maybe_apply_penalty_processors(req, logits, 0)
+    _maybe_apply_penalty_processors(req, row)
     assert req._cached_penalty_processors is first_cache, "cache must be reused"
 
 
@@ -122,10 +121,9 @@ def test_first_token_no_history_is_unchanged():
     Confirms our gate doesn't accidentally penalise the prefill token."""
     req = _make_req(repetition_penalty=2.0, presence_penalty=0.5, frequency_penalty=0.5)
     # output_tokens is empty (first generated token, no history yet)
-    logits = mx.array([[3.0, 3.0]])
-    before = mx.array(logits)
-    _maybe_apply_penalty_processors(req, logits, 0)
-    assert mx.array_equal(logits, before)
+    row = mx.array([[3.0, 3.0]])
+    out = _maybe_apply_penalty_processors(req, row)
+    assert mx.array_equal(out, mx.array([[3.0, 3.0]]))
 
 
 # =============================================================================
@@ -185,6 +183,29 @@ def test_scheduler_add_request_defaults_neutral_when_omitted():
     rid = scheduler.add_request(prompt="hi", max_tokens=8)
     req = scheduler.requests[rid]
     assert req.sampling_params.repetition_penalty == 1.0
+    assert req.sampling_params.presence_penalty == 0.0
+    assert req.sampling_params.frequency_penalty == 0.0
+
+
+def test_scheduler_add_request_preserves_explicit_zero_values():
+    """Codex r1 MAJOR #2 guard: an explicit ``repetition_penalty=0.0``
+    is a legitimate (if extreme) request the API schema accepts and the
+    LLM path preserves on ``SamplingParams``. The earlier
+    ``kwargs.pop(...) or NEUTRAL`` pattern silently rewrote ``0.0`` to
+    ``1.0`` for ``repetition_penalty`` because ``0.0 or 1.0`` is ``1.0``
+    in Python. Only ``None`` (absent kwarg) may collapse to neutral."""
+    scheduler = _stub_scheduler()
+    rid = scheduler.add_request(
+        prompt="hi",
+        max_tokens=8,
+        repetition_penalty=0.0,
+        presence_penalty=0.0,
+        frequency_penalty=0.0,
+    )
+    req = scheduler.requests[rid]
+    assert req.sampling_params.repetition_penalty == 0.0, (
+        "explicit repetition_penalty=0.0 must NOT be coerced to 1.0"
+    )
     assert req.sampling_params.presence_penalty == 0.0
     assert req.sampling_params.frequency_penalty == 0.0
 

--- a/tests/test_mllm_penalty_passthrough.py
+++ b/tests/test_mllm_penalty_passthrough.py
@@ -33,7 +33,6 @@ from vllm_mlx.mllm_batch_generator import (
     _maybe_apply_penalty_processors,
 )
 
-
 # =============================================================================
 # Layer 1 — logits-processor application
 # =============================================================================

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -1021,6 +1021,18 @@ class BatchedEngine(BaseEngine):
             # fallback because the parser sees only the model
             # continuation, not the prefixed envelope).
             mllm_assistant_text_prefix = kwargs.pop("_assistant_text_prefix", "") or ""
+            # OpenAI-spec penalty passthrough (#512). Mirror the LLM
+            # branch below: pop the three penalty knobs out of kwargs
+            # and forward to the MLLM scheduler so the route-layer
+            # cascade (chat / completions / responses / anthropic) reaches
+            # the per-request logits processors inside the VLM batch
+            # generator. ``top_k`` / ``min_p`` / ``seed`` MLLM passthrough
+            # is intentionally NOT in scope here — see #512 follow-ups.
+            _mllm_penalty_kwargs = {
+                k: kwargs.pop(k)
+                for k in ("repetition_penalty", "presence_penalty", "frequency_penalty")
+                if k in kwargs
+            }
             output = await self._mllm_scheduler.generate(
                 prompt=prompt,
                 images=images,
@@ -1031,6 +1043,7 @@ class BatchedEngine(BaseEngine):
                 stop=stop,
                 video_fps=kwargs.pop("video_fps", None),
                 video_max_frames=kwargs.pop("video_max_frames", None),
+                **_mllm_penalty_kwargs,
             )
             mllm_full_text = output.output_text or ""
             if mllm_assistant_text_prefix:
@@ -1199,6 +1212,13 @@ class BatchedEngine(BaseEngine):
 
         if self._is_mllm and self._mllm_scheduler:
             # Use MLLM scheduler for all streaming when model is multimodal
+            # OpenAI-spec penalty passthrough (#512) — see ``generate()``
+            # MLLM branch above for the rationale.
+            _mllm_penalty_kwargs = {
+                k: kwargs.pop(k)
+                for k in ("repetition_penalty", "presence_penalty", "frequency_penalty")
+                if k in kwargs
+            }
             request_id = await self._mllm_scheduler.add_request_async(
                 prompt=prompt,
                 images=images,
@@ -1209,6 +1229,7 @@ class BatchedEngine(BaseEngine):
                 stop=stop,
                 video_fps=kwargs.pop("video_fps", None),
                 video_max_frames=kwargs.pop("video_max_frames", None),
+                **_mllm_penalty_kwargs,
             )
             # C-01 force-abort: publish the scheduler request id so the
             # route's disconnect_guard can call abort_request directly.

--- a/vllm_mlx/mllm_batch_generator.py
+++ b/vllm_mlx/mllm_batch_generator.py
@@ -34,7 +34,7 @@ from . import _mlx_compat as _mlx_compat
 
 _mlx_compat.install()
 
-from mlx_lm.sample_utils import make_sampler  # noqa: E402
+from mlx_lm.sample_utils import make_logits_processors, make_sampler  # noqa: E402
 
 from .multimodal_processor import MultimodalProcessor  # noqa: E402
 from .vision_embedding_cache import VisionEmbeddingCache  # noqa: E402
@@ -59,6 +59,15 @@ class MLLMBatchRequest:
     max_tokens: int = 256
     temperature: float = 0.7
     top_p: float = 0.9
+    # OpenAI-spec penalties (#512) — wired into mlx-lm's
+    # ``make_logits_processors`` inside ``_step``. ``repetition_penalty`` is
+    # a rapid-mlx extension (mlx-lm-native semantics); ``presence_penalty``
+    # and ``frequency_penalty`` follow the OpenAI spec. Defaults match the
+    # neutral values that ``make_logits_processors`` treats as "disabled"
+    # so the homogeneous-default fast path stays a no-op.
+    repetition_penalty: float = 1.0
+    presence_penalty: float = 0.0
+    frequency_penalty: float = 0.0
     video_fps: float | None = None  # Caller-specified video FPS
     video_max_frames: int | None = None  # Caller-specified max video frames
 
@@ -288,6 +297,47 @@ def _left_pad_prompts(
     if max_length is None:
         max_length = max(len(p) for p in prompts)
     return mx.array([[0] * (max_length - len(p)) + list(p) for p in prompts])
+
+
+def _maybe_apply_penalty_processors(
+    req: MLLMBatchRequest, logits: mx.array, row: int
+) -> None:
+    """Mutate ``logits[row:row+1]`` in-place with the request's penalty processors (#512).
+
+    Builds and memoises a list of ``mlx_lm.sample_utils.make_logits_processors``
+    callables on the request when at least one of ``repetition_penalty`` /
+    ``presence_penalty`` / ``frequency_penalty`` is non-neutral. The neutral
+    fast path returns immediately with zero allocation so default-sampling
+    batches keep the pre-#512 step time. Tokens-history is the request's
+    own ``output_tokens`` (mlx-lm processors no-op on empty history, so the
+    first generated token from the VLM prefill — sampled before any
+    output_tokens accumulate — is unaffected). Matches the LLM scheduler's
+    OpenAI-spec context-size policy (``scheduler.py:4124``).
+    """
+    rep = req.repetition_penalty
+    pres = req.presence_penalty
+    freq = req.frequency_penalty
+    if rep == 1.0 and pres == 0.0 and freq == 0.0:
+        return
+    cached = getattr(req, "_cached_penalty_processors", None)
+    key = (rep, pres, freq)
+    if cached is None or cached[0] != key:
+        processors = make_logits_processors(
+            repetition_penalty=rep if rep != 1.0 else None,
+            presence_penalty=pres if pres != 0.0 else None,
+            presence_context_size=4096,
+            frequency_penalty=freq if freq != 0.0 else None,
+            frequency_context_size=4096,
+        )
+        cached = (key, processors)
+        req._cached_penalty_processors = cached
+    if not cached[1]:
+        return
+    row_logits = logits[row : row + 1]
+    tokens = req.output_tokens
+    for processor in cached[1]:
+        row_logits = processor(tokens, row_logits)
+    logits[row : row + 1] = row_logits
 
 
 class MLLMBatchGenerator:
@@ -1000,6 +1050,27 @@ class MLLMBatchGenerator:
 
         logits = logits[:, -1, :]
 
+        # Apply per-request OpenAI-spec penalty processors (#512) BEFORE
+        # the softmax → sampler chain. The outer ``any(...)`` gate keeps
+        # the neutral-default path allocation-free AND skip the per-row
+        # Python loop entirely so default-sampling batches retain the
+        # pre-#512 step time. The per-request helper mutates
+        # ``logits[i:i+1]`` using each request's own generated-token
+        # history (``req.output_tokens``), so the cross-request batch
+        # layout is preserved — same shape, same dtype.
+        if (
+            requests
+            and len(requests) == logits.shape[0]
+            and any(
+                r.repetition_penalty != 1.0
+                or r.presence_penalty != 0.0
+                or r.frequency_penalty != 0.0
+                for r in requests
+            )
+        ):
+            for i, req in enumerate(requests):
+                _maybe_apply_penalty_processors(req, logits, i)
+
         # Sample per-request with correct temperature/top_p.
         # Fast path: when all requests in the batch share (temp, top_p),
         # invoke a single batched sampler on [B, vocab] instead of B
@@ -1011,7 +1082,8 @@ class MLLMBatchGenerator:
         #
         # WARNING: ``_shared_batch_sampler`` is keyed only on
         # ``(temperature, top_p)``. If we ever add per-request sampling
-        # knobs (top_k, min_p, repetition_penalty) to ``MLLMBatchRequest``,
+        # knobs (top_k, min_p) that change the sampler's *shape* (not just
+        # the per-row logits, which the penalty processors above handle),
         # the key MUST grow accordingly — otherwise homogeneous-looking
         # batches would silently share an incorrect sampler. The single
         # ``MLLMScheduler`` worker thread (see mlx-lm 0.31.3+ stream

--- a/vllm_mlx/mllm_batch_generator.py
+++ b/vllm_mlx/mllm_batch_generator.py
@@ -300,25 +300,31 @@ def _left_pad_prompts(
 
 
 def _maybe_apply_penalty_processors(
-    req: MLLMBatchRequest, logits: mx.array, row: int
-) -> None:
-    """Mutate ``logits[row:row+1]`` in-place with the request's penalty processors (#512).
+    req: MLLMBatchRequest, row_logits: mx.array
+) -> mx.array:
+    """Return ``row_logits`` after applying the request's penalty processors (#512).
 
     Builds and memoises a list of ``mlx_lm.sample_utils.make_logits_processors``
     callables on the request when at least one of ``repetition_penalty`` /
     ``presence_penalty`` / ``frequency_penalty`` is non-neutral. The neutral
-    fast path returns immediately with zero allocation so default-sampling
-    batches keep the pre-#512 step time. Tokens-history is the request's
-    own ``output_tokens`` (mlx-lm processors no-op on empty history, so the
-    first generated token from the VLM prefill — sampled before any
-    output_tokens accumulate — is unaffected). Matches the LLM scheduler's
-    OpenAI-spec context-size policy (``scheduler.py:4124``).
+    fast path returns the input row unchanged (no allocation, no work) so
+    default-sampling batches keep the pre-#512 step time. Tokens-history is
+    the request's own ``output_tokens`` (mlx-lm processors no-op on empty
+    history, so the first generated token from the VLM prefill — sampled
+    before any output_tokens accumulate — is unaffected). Matches the LLM
+    scheduler's OpenAI-spec context-size policy (``scheduler.py:4124``).
+
+    Returns a fresh row array (not an in-place mutation) so the caller can
+    build a concatenated ``[B, vocab]`` tensor without depending on
+    ``mx.array.__setitem__`` reflection semantics. Mirrors the LLM path's
+    ``scheduler.py:944-952`` shape — accumulate processed rows, then
+    ``mx.concatenate(rows, axis=0)``.
     """
     rep = req.repetition_penalty
     pres = req.presence_penalty
     freq = req.frequency_penalty
     if rep == 1.0 and pres == 0.0 and freq == 0.0:
-        return
+        return row_logits
     cached = getattr(req, "_cached_penalty_processors", None)
     key = (rep, pres, freq)
     if cached is None or cached[0] != key:
@@ -332,12 +338,11 @@ def _maybe_apply_penalty_processors(
         cached = (key, processors)
         req._cached_penalty_processors = cached
     if not cached[1]:
-        return
-    row_logits = logits[row : row + 1]
+        return row_logits
     tokens = req.output_tokens
     for processor in cached[1]:
         row_logits = processor(tokens, row_logits)
-    logits[row : row + 1] = row_logits
+    return row_logits
 
 
 class MLLMBatchGenerator:
@@ -1052,12 +1057,14 @@ class MLLMBatchGenerator:
 
         # Apply per-request OpenAI-spec penalty processors (#512) BEFORE
         # the softmax → sampler chain. The outer ``any(...)`` gate keeps
-        # the neutral-default path allocation-free AND skip the per-row
+        # the neutral-default path allocation-free AND skips the per-row
         # Python loop entirely so default-sampling batches retain the
-        # pre-#512 step time. The per-request helper mutates
-        # ``logits[i:i+1]`` using each request's own generated-token
-        # history (``req.output_tokens``), so the cross-request batch
-        # layout is preserved — same shape, same dtype.
+        # pre-#512 step time. When at least one request carries a
+        # non-neutral penalty we build a fresh ``[B, vocab]`` tensor via
+        # ``mx.concatenate`` of per-row results — mirrors the LLM-path
+        # pattern at ``scheduler.py:944-952`` and avoids depending on
+        # ``mx.array.__setitem__`` reflection semantics across MLX
+        # versions (codex r1 MAJOR #1).
         if (
             requests
             and len(requests) == logits.shape[0]
@@ -1068,8 +1075,12 @@ class MLLMBatchGenerator:
                 for r in requests
             )
         ):
+            processed_rows = []
             for i, req in enumerate(requests):
-                _maybe_apply_penalty_processors(req, logits, i)
+                processed_rows.append(
+                    _maybe_apply_penalty_processors(req, logits[i : i + 1])
+                )
+            logits = mx.concatenate(processed_rows, axis=0)
 
         # Sample per-request with correct temperature/top_p.
         # Fast path: when all requests in the batch share (temp, top_p),

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -428,10 +428,21 @@ class MLLMScheduler:
                 f"(currently {len(self.requests)} in-flight)"
             )
 
+        # OpenAI-spec penalty passthrough (#512). Pop with the same defaults
+        # ``SamplingParams`` uses so the MLLM path matches the LLM path's
+        # "absence == neutral" contract. Callers that never set these keys
+        # (every non-OpenAI MLLM caller pre-#512) get the no-op fast path
+        # inside ``_maybe_apply_penalty_processors``.
+        repetition_penalty = float(kwargs.pop("repetition_penalty", 1.0) or 1.0)
+        presence_penalty = float(kwargs.pop("presence_penalty", 0.0) or 0.0)
+        frequency_penalty = float(kwargs.pop("frequency_penalty", 0.0) or 0.0)
         sampling_params = SamplingParams(
             max_tokens=max_tokens,
             temperature=temperature,
             top_p=top_p,
+            repetition_penalty=repetition_penalty,
+            presence_penalty=presence_penalty,
+            frequency_penalty=frequency_penalty,
         )
 
         request = MLLMRequest(
@@ -650,6 +661,11 @@ class MLLMScheduler:
                 max_tokens=request.sampling_params.max_tokens,
                 temperature=request.sampling_params.temperature,
                 top_p=request.sampling_params.top_p,
+                # OpenAI-spec penalty passthrough (#512). Default neutral
+                # values are no-ops inside ``_maybe_apply_penalty_processors``.
+                repetition_penalty=request.sampling_params.repetition_penalty,
+                presence_penalty=request.sampling_params.presence_penalty,
+                frequency_penalty=request.sampling_params.frequency_penalty,
                 video_fps=request.video_fps,
                 video_max_frames=request.video_max_frames,
             )

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -433,9 +433,19 @@ class MLLMScheduler:
         # "absence == neutral" contract. Callers that never set these keys
         # (every non-OpenAI MLLM caller pre-#512) get the no-op fast path
         # inside ``_maybe_apply_penalty_processors``.
-        repetition_penalty = float(kwargs.pop("repetition_penalty", 1.0) or 1.0)
-        presence_penalty = float(kwargs.pop("presence_penalty", 0.0) or 0.0)
-        frequency_penalty = float(kwargs.pop("frequency_penalty", 0.0) or 0.0)
+        #
+        # Default only on ``None`` (not falsy numeric values) — the API
+        # schema accepts ``repetition_penalty=0.0`` (a legitimate, if
+        # extreme, value) and the LLM path preserves it on the
+        # ``SamplingParams``; collapsing via ``or 1.0`` would silently
+        # rewrite that to neutral (codex r1 MAJOR #2).
+        def _pop_penalty(name: str, neutral: float) -> float:
+            raw = kwargs.pop(name, None)
+            return neutral if raw is None else float(raw)
+
+        repetition_penalty = _pop_penalty("repetition_penalty", 1.0)
+        presence_penalty = _pop_penalty("presence_penalty", 0.0)
+        frequency_penalty = _pop_penalty("frequency_penalty", 0.0)
         sampling_params = SamplingParams(
             max_tokens=max_tokens,
             temperature=temperature,


### PR DESCRIPTION
## Summary

Fixes #512 — ``MLLMScheduler`` silently dropped ``repetition_penalty`` / ``presence_penalty`` / ``frequency_penalty`` on every OpenAI request routed to a vision model. The LLM scheduler wires these through mlx-lm's ``make_logits_processors`` (see ``scheduler.py:4147``); the MLLM path had no analogue, so the route-layer cascade (``build_extended_sampling_kwargs``) bottomed out at ``BatchedEngine.{generate,stream_generate}`` without reaching the VLM batch generator's sampling site.

## Root cause (three layers)

| Layer | File | Pre-fix symptom |
|---|---|---|
| 1 | ``engine/batched.py`` | MLLM branches in ``generate()`` / ``stream_generate()`` forwarded only ``max_tokens / temperature / top_p / stop``; the three penalty keys stayed in ``**kwargs`` and were silently discarded by the scheduler signature. |
| 2 | ``mllm_scheduler.py`` | ``add_request()`` built ``SamplingParams(max_tokens, temperature, top_p)``; penalty fields stayed at dataclass defaults regardless of caller input. |
| 3 | ``mllm_batch_generator.py`` | ``MLLMBatchRequest`` carried no penalty fields; ``_step()`` had no ``make_logits_processors`` call site. |

## Fix shape

Mirrors the LLM-path: per-request lazy processor construction via ``mlx_lm.sample_utils.make_logits_processors`` applied to per-row logits BEFORE the softmax → sampler chain. The outer ``any(...)`` gate in ``_step`` keeps the default-sampling path allocation-free AND skips the per-row Python loop entirely, so no-penalty batches retain the pre-fix step time. Processor lists are memoised on the request to avoid per-token rebuild.

Penalty processors no-op on empty ``output_tokens`` (mlx-lm contract), so the first sampled token from the VLM prefill is unaffected — only the per-token completion-phase sampling is penalty-adjusted, matching LLM-path behaviour.

## Before / after (deterministic logits)

The included ``test_repetition_penalty_suppresses_already_seen_tokens`` pins the exact numerical contract:

- input: ``logits=[[10.0, 10.0, 10.0]]``, ``output_tokens=[0, 1]``, ``repetition_penalty=2.0``
- pre-fix: ``[10.0, 10.0, 10.0]`` (penalty silently dropped → all argmax-tied)
- post-fix: ``[5.0, 5.0, 10.0]`` (seen tokens halved; argmax → unseen token 2)

Same shape for ``presence_penalty`` (subtract constant from seen tokens) and ``frequency_penalty`` (subtract penalty × occurrence-count). Live VLM repro was not run because no compact VLM is cached locally (per agent constraints — avoid bandwidth races with sibling fix agents); the behaviour-level tests cover the wiring + processor application end-to-end across all three layers.

## Out of scope (intentional)

- ``top_k`` / ``min_p`` / ``seed`` MLLM passthrough — issue #512 names only the three penalty knobs. The LLM path already supports them; MLLM extension is a clean follow-up.
- ``recommended_sampling`` cascade hook into MLLM scheduler.

## Test plan

- [x] ``tests/test_mllm_penalty_passthrough.py`` — 9 new behaviour-level tests across three layers (processor application, scheduler stamping, engine forwarding). All passing.
- [x] ``tests/test_mllm_*`` + ``tests/test_sampling_params_passthrough.py`` — 102 tests, no regressions.
- [x] Full suite (skipping flaky ``test_batched_faster_than_sequential`` perf threshold + ``test_event_loop_*`` which require live :8000) — 9298 passed, 21 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)