### PR TITLE
chore: bump version to 0.8.13

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.8.12"
+version = "0.8.13"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## Why this PR exists

R11 fix wave (5 PRs) shipped on top of 0.8.12. Cutting 0.8.13 to publish to PyPI.

## What landed since 0.8.12

| Wave | PR | Squash | Severity | What |
|---|---|---|---|---|
| r11-A | #859 | `812c5e3` | CRIT | `tool_choice:"required"` streaming finalize race — 10/20 streams pre-fix shipped `finish_reason:"tool_calls"` with zero `delta.tool_calls` chunks; 0/20 post-fix. Closes R11-V1 + R11-V2. |
| r11-D | #863 | `ab310e4` | MED bundle | Audio DX: legacy `format` → `response_format` alias; `voice:"default"` falls back to registry; `/v1/models` reports `capabilities=["audio.speech"/"transcription"]` and `modality="audio"` for audio aliases. Closes R11-B-F2/F3/F4. |
| r11-C | #862 | `a8793a3` | HIGH | vibevoice no longer 500s — dynamic voice enumeration from snapshot `voices/` dir; vibevoice `default_voice` corrected to a real file. Closes R11-B-F1 (the lone audio regression in 0.8.12). |
| r11-G | #861 | `d32be62` | HIGH (8-round carry) | Embeddings UX: `[embeddings]` extra in pyproject; `/v1/embeddings` 503 with `code:"no_embedding_model"` when no embedding model is loaded (no more silent fallback to chat model); `/v1/models` now lists the embedding model with `capabilities:["embedding"]`. Closes H-08 + H-09 + H-13. |
| r11-B | #866 | `7189f94` | HIGH | `/v1/responses` streaming emits `output_item.added(type:"reasoning")` + `output_item.done(status:"incomplete")` + `completed(status:"incomplete", incomplete_details.reason:"max_output_tokens")` on budget cutoff. Closes R11-M-F1. |
| bonus | #864 | `3be2acd` | — | MLLM: pass frequency/presence/repetition penalty through to VLM sampler (closes #512). |

## Audio milestone

Bo r11 verified 12/12 audio aliases boot + 11/12 produce correct output on 0.8.12. With r11-C fixing vibevoice, 0.8.13 is expected to be **12/12 boot + 12/12 produce output** — the first release where every advertised audio alias works end-to-end.

## Test plan
- [x] All 5 fix PRs merged with codex review converged + CI green
- [x] r11-A verified by 20-shot probe: 10/20 → 0/20
- [x] r11-C verified live: vibevoice produces 64044 / 51244 / 25644-byte WAVs on 3 voice paths
- [x] r11-D verified live: chatterbox `format:"mp3"` returns MPEG ADTS; kokoro `voice:"default"` returns 200
- [x] r11-G verified live: `/v1/embeddings` returns 503 envelope when no model loaded
- [x] r11-B verified live: SSE goes from 1165 bytes / 3 events to 2124 bytes / 5 events with `status:"incomplete"`