### PR TITLE
fix(responses): exclude REASONING_CUTOFF_SENTINEL from downstream_output_seen (regression from #860)

### DIFF
--- a/tests/test_responses_adapter.py
+++ b/tests/test_responses_adapter.py
@@ -875,6 +875,134 @@ class TestOpenaiToResponses:
         assert resp.instructions == "be brief"
 
 
+class TestReasoningCutoffSentinelDoesNotMaskIncomplete:
+    """Regression for the PR #860 → v0.8.13/v0.8.14 cutoff-sentinel /
+    Responses-adapter parity bug.
+
+    PR #860 (closes #858) restored ``REASONING_CUTOFF_SENTINEL`` injection
+    into ``message.content`` by default for length-stopped reasoning
+    generations. The chat / anthropic / responses non-stream routes call
+    ``_apply_reasoning_cutoff_notice`` BEFORE handing the
+    ``ChatCompletionResponse`` to ``openai_to_responses``. The adapter
+    then computes ``downstream_output_seen`` from ``message.content`` —
+    so the sentinel injection was being mis-classified as "the model
+    produced real downstream output", flipping
+    ``output[0].reasoning.status`` from ``"incomplete"`` to
+    ``"completed"`` on the non-stream surface only. The streaming surface
+    uses its own ``reasoning_block_closed`` predicate (the parser's own
+    content channel signal, never the sentinel) so the streaming side
+    still reported ``"incomplete"`` — visible as a cross-path parity
+    breakage caught by
+    ``test_responses_budget_exhaust_streaming.py::TestStreamingNonStreamingParity::test_same_output_shape_under_cutoff``.
+
+    These tests pin the contract at the adapter boundary so a future
+    refactor of either ``_apply_reasoning_cutoff_notice`` or the
+    adapter's ``downstream_output_seen`` predicate can't silently
+    reintroduce the regression.
+    """
+
+    def _chat_response_with_reasoning(
+        self,
+        *,
+        text: str | None,
+        reasoning_text: str,
+        finish_reason: str,
+        tool_calls: list[ToolCall] | None = None,
+    ) -> ChatCompletionResponse:
+        return ChatCompletionResponse(
+            model="test-model",
+            choices=[
+                ChatCompletionChoice(
+                    message=AssistantMessage(
+                        content=text,
+                        reasoning_content=reasoning_text,
+                        tool_calls=tool_calls,
+                    ),
+                    finish_reason=finish_reason,
+                )
+            ],
+            usage=Usage(prompt_tokens=10, completion_tokens=5, total_tokens=15),
+        )
+
+    def test_sentinel_in_content_keeps_reasoning_incomplete_on_length(self):
+        from vllm_mlx.service.helpers import REASONING_CUTOFF_SENTINEL
+
+        chat_resp = self._chat_response_with_reasoning(
+            text=REASONING_CUTOFF_SENTINEL,
+            reasoning_text="Hmm, let me think about this carefully...",
+            finish_reason="length",
+        )
+        resp = openai_to_responses(
+            chat_resp, model="test-model", request=_bare_request(), created_at=0
+        )
+        assert len(resp.output) >= 1
+        assert resp.output[0].type == "reasoning"
+        assert resp.output[0].status == "incomplete", (
+            "REASONING_CUTOFF_SENTINEL injected by the chat route helper "
+            "must NOT flip reasoning_item_status to 'completed' — it is a "
+            "UX fallback, not real downstream output."
+        )
+
+    def test_real_downstream_content_still_marks_reasoning_completed(self):
+        chat_resp = self._chat_response_with_reasoning(
+            text="Here is the actual answer to your question.",
+            reasoning_text="Hmm, let me think about this carefully...",
+            finish_reason="length",
+        )
+        resp = openai_to_responses(
+            chat_resp, model="test-model", request=_bare_request(), created_at=0
+        )
+        assert len(resp.output) >= 1
+        assert resp.output[0].type == "reasoning"
+        assert resp.output[0].status == "completed", (
+            "Real model content (not the sentinel) IS downstream output — "
+            "reasoning has closed and the cutoff scope shrinks to the "
+            "message body, so reasoning_item_status must be 'completed'."
+        )
+
+    def test_tool_call_after_thinking_still_marks_reasoning_completed(self):
+        chat_resp = self._chat_response_with_reasoning(
+            text=None,
+            reasoning_text="Hmm, I should call the search tool.",
+            finish_reason="length",
+            tool_calls=[
+                ToolCall(
+                    id="call_sentinel_regression",
+                    function=FunctionCall(name="search", arguments='{"q":"x"}'),
+                )
+            ],
+        )
+        resp = openai_to_responses(
+            chat_resp, model="test-model", request=_bare_request(), created_at=0
+        )
+        assert len(resp.output) >= 1
+        assert resp.output[0].type == "reasoning"
+        assert resp.output[0].status == "completed", (
+            "Closed-</think> + tool_call shape: reasoning IS complete, "
+            "only tool args were truncated — same contract as before "
+            "the sentinel parity fix."
+        )
+
+    def test_sentinel_with_no_finish_length_keeps_reasoning_completed(self):
+        from vllm_mlx.service.helpers import REASONING_CUTOFF_SENTINEL
+
+        chat_resp = self._chat_response_with_reasoning(
+            text=REASONING_CUTOFF_SENTINEL,
+            reasoning_text="Hmm, let me think...",
+            finish_reason="stop",
+        )
+        resp = openai_to_responses(
+            chat_resp, model="test-model", request=_bare_request(), created_at=0
+        )
+        assert len(resp.output) >= 1
+        assert resp.output[0].type == "reasoning"
+        assert resp.output[0].status == "completed", (
+            "The 'incomplete' branch requires finish_reason='length'; the "
+            "sentinel-exclusion fix must not over-extend to non-length "
+            "completions."
+        )
+
+
 # ---------------------------------------------------------------------------
 # Round-trip — request → chat → response keeps Codex's invariants
 # ---------------------------------------------------------------------------

--- a/tests/test_responses_adapter.py
+++ b/tests/test_responses_adapter.py
@@ -925,7 +925,7 @@ class TestReasoningCutoffSentinelDoesNotMaskIncomplete:
         )
 
     def test_sentinel_in_content_keeps_reasoning_incomplete_on_length(self):
-        from vllm_mlx.service.helpers import REASONING_CUTOFF_SENTINEL
+        from vllm_mlx.api.constants import REASONING_CUTOFF_SENTINEL
 
         chat_resp = self._chat_response_with_reasoning(
             text=REASONING_CUTOFF_SENTINEL,
@@ -984,7 +984,7 @@ class TestReasoningCutoffSentinelDoesNotMaskIncomplete:
         )
 
     def test_sentinel_with_no_finish_length_keeps_reasoning_completed(self):
-        from vllm_mlx.service.helpers import REASONING_CUTOFF_SENTINEL
+        from vllm_mlx.api.constants import REASONING_CUTOFF_SENTINEL
 
         chat_resp = self._chat_response_with_reasoning(
             text=REASONING_CUTOFF_SENTINEL,

--- a/vllm_mlx/api/constants.py
+++ b/vllm_mlx/api/constants.py
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Wire-level constants shared across the api / service layers.
+
+Lives in ``vllm_mlx.api`` to preserve the layering rule that
+``vllm_mlx.api`` is the lower layer (no engine / MLX imports) and
+``vllm_mlx.service`` may depend on it. Constants placed here must
+remain pure-literal so that importing this module never pulls in
+MLX, Metal, or any engine code — adapter unit tests in headless
+environments depend on this.
+"""
+
+#: Literal sentinel surfaced to ``content`` on ``finish_reason="length"``
+#: when generation is cut short mid-think (default ON; opt out via
+#: ``RAPID_MLX_REASONING_CUTOFF_NOTICE=disabled``). Defined here so the
+#: ``api/responses_adapter`` can exclude it from its
+#: ``downstream_output_seen`` check (issue #858 → PR #860 follow-up)
+#: without dragging the engine into the adapter's import graph.
+#: ``service.helpers`` re-exports this name as the public symbol so
+#: existing callers (route helpers + their tests) need not change.
+REASONING_CUTOFF_SENTINEL = "[truncated — reasoning incomplete; raise max_tokens]"

--- a/vllm_mlx/api/responses_adapter.py
+++ b/vllm_mlx/api/responses_adapter.py
@@ -18,6 +18,13 @@ import uuid
 
 from fastapi import HTTPException
 
+# Issue #858 → PR #860 enabled the in-band reasoning cutoff sentinel by
+# default; this constant is also injected into ``message.content`` by
+# the chat / anthropic / responses non-stream paths. The adapter must
+# exclude it from the ``downstream_output_seen`` check below — see
+# ``_compute_reasoning_status``.
+from vllm_mlx.service.helpers import REASONING_CUTOFF_SENTINEL
+
 from .models import (
     ChatCompletionRequest,
     ChatCompletionResponse,
@@ -489,8 +496,26 @@ def openai_to_responses(
             # the wider check (``downstream_output_seen`` covers
             # text OR tool_calls) — this brings the non-stream
             # surface into parity.
+            #
+            # Issue #858 → PR #860 followup: the chat-route helper
+            # ``_apply_reasoning_cutoff_notice`` is called BEFORE this
+            # adapter on the non-stream path; when the env default
+            # restored the sentinel, ``message.content`` carried the
+            # literal ``REASONING_CUTOFF_SENTINEL`` text on every
+            # mid-think length cutoff. That sentinel is a UX fallback
+            # for clients that only render output_text — it is NOT
+            # "real downstream output" from the model, so it must not
+            # flip ``reasoning_item_status`` from ``incomplete`` to
+            # ``completed``. Strip the sentinel before the empty check
+            # so the non-stream surface matches the streaming surface's
+            # ``reasoning_block_closed`` predicate (which never sees
+            # the sentinel because streaming injects it as a terminal
+            # delta, never as the parser's content channel).
+            content_for_downstream_check = (choice.message.content or "").strip()
+            if content_for_downstream_check == REASONING_CUTOFF_SENTINEL:
+                content_for_downstream_check = ""
             downstream_output_seen = bool(
-                (choice.message.content or "").strip() or choice.message.tool_calls
+                content_for_downstream_check or choice.message.tool_calls
             )
             reasoning_item_status = (
                 "incomplete"

--- a/vllm_mlx/api/responses_adapter.py
+++ b/vllm_mlx/api/responses_adapter.py
@@ -18,13 +18,7 @@ import uuid
 
 from fastapi import HTTPException
 
-# Issue #858 → PR #860 enabled the in-band reasoning cutoff sentinel by
-# default; this constant is also injected into ``message.content`` by
-# the chat / anthropic / responses non-stream paths. The adapter must
-# exclude it from the ``downstream_output_seen`` check below — see
-# ``_compute_reasoning_status``.
-from vllm_mlx.service.helpers import REASONING_CUTOFF_SENTINEL
-
+from .constants import REASONING_CUTOFF_SENTINEL
 from .models import (
     ChatCompletionRequest,
     ChatCompletionResponse,

--- a/vllm_mlx/service/helpers.py
+++ b/vllm_mlx/service/helpers.py
@@ -21,6 +21,16 @@ from collections.abc import AsyncIterator
 from fastapi import HTTPException
 from starlette.requests import Request
 
+# Re-export of the wire-level sentinel literal. Single source of truth
+# lives in :mod:`vllm_mlx.api.constants` to preserve the layering rule
+# (api is the lower layer that service depends on, not the reverse) so
+# the Responses adapter can exclude this sentinel from its
+# ``downstream_output_seen`` check (issue #858 → PR #860 follow-up)
+# without dragging the engine into the adapter's import graph. The name
+# is re-exported through this module so existing callers that import
+# ``REASONING_CUTOFF_SENTINEL`` from ``vllm_mlx.service.helpers``
+# (route helpers + their tests) continue to work unchanged.
+from ..api.constants import REASONING_CUTOFF_SENTINEL  # noqa: F401
 from ..api.models import (
     CompletionTokensDetails,
     FunctionCall,
@@ -1054,12 +1064,6 @@ def _rescue_silent_drop_from_reasoning(
 # sentinel as one final-chunk ``delta.content`` event, not per-token, so
 # no token-by-token leak of the sentinel string itself.)
 
-#: Literal sentinel surfaced to ``content`` on ``finish_reason="length"``
-#: when generation is cut short mid-think (default ON; opt out via the
-#: env var documented below). Kept short and unambiguous so agentic
-#: clients can pattern-match if they want to auto-retry with a larger
-#: ``max_tokens``.
-REASONING_CUTOFF_SENTINEL = "[truncated — reasoning incomplete; raise max_tokens]"
 
 #: Env var values that EXPLICITLY DISABLE the sentinel notice (issue #858
 #: revert of R-01: default is now back to ON, matching the original H-01 /


### PR DESCRIPTION
## Summary

Cross-path parity regression on `/v1/responses` introduced by PR #860 (#858 fix, on HEAD since v0.8.13). The non-stream surface ships `output[0].reasoning.status="completed"` on mid-think length cutoff while the streaming surface correctly ships `"incomplete"` — exact symmetry breakage R11-M-F1 was designed to prevent.

## Root cause

PR #860 flipped `REASONING_CUTOFF_SENTINEL` (`"[truncated — reasoning incomplete; raise max_tokens]"`) from opt-in to default-on. The chat / anthropic / responses non-stream routes call `_apply_reasoning_cutoff_notice` BEFORE handing the response to `openai_to_responses`. The adapter's `downstream_output_seen` check at `api/responses_adapter.py:492` then treats the injected sentinel as "real downstream output":

```python
downstream_output_seen = bool(
    (choice.message.content or "").strip() or choice.message.tool_calls
)
reasoning_item_status = (
    "incomplete"
    if (choice.finish_reason == "length" and not downstream_output_seen)
    else "completed"
)
```

The streaming surface (`routes/responses.py:2276`) uses its own `reasoning_block_closed or tool_calls` predicate — the parser's content channel signal, NOT the post-rescue-stub content. Streaming therefore reports `incomplete`, non-stream reports `completed`, parity breaks.

## Caught by

```
tests/test_responses_budget_exhaust_streaming.py::
  TestStreamingNonStreamingParity::test_same_output_shape_under_cutoff
```

| commit | result |
|---|---|
| `v0.8.13` (15e9062a — last release tag) | PASSED |
| HEAD = `dcf4f47b` (after PR #860 merged) | FAILED `assert 'completed' == 'incomplete'` |

A/B classified at the v0.8.13 tag boundary BEFORE proposing the fix per the project-local `feedback_pr_scope_ab_classify_first` rule. This is a real regression, not a pre-existing pin.

## Fix

`vllm_mlx/api/responses_adapter.py` — strip `REASONING_CUTOFF_SENTINEL` from `message.content` before the empty check used to compute `downstream_output_seen`. The sentinel is a UX fallback for clients that only render `output_text` — it is NOT real model output and must not flip the structured `status` semantics that SDK consumers walk via `output[i].status` / `usage.output_tokens_details.reasoning_tokens`.

```python
content_for_downstream_check = (choice.message.content or "").strip()
if content_for_downstream_check == REASONING_CUTOFF_SENTINEL:
    content_for_downstream_check = ""
downstream_output_seen = bool(
    content_for_downstream_check or choice.message.tool_calls
)
```

## Tests (pin at the adapter boundary)

Added `TestReasoningCutoffSentinelDoesNotMaskIncomplete` in `tests/test_responses_adapter.py` — 4 unit tests covering the contract so a future refactor of either `_apply_reasoning_cutoff_notice` or `downstream_output_seen` can't silently reintroduce the regression:

1. `test_sentinel_in_content_keeps_reasoning_incomplete_on_length` — the primary pin: sentinel + `finish_reason="length"` → `reasoning_item_status="incomplete"`.
2. `test_real_downstream_content_still_marks_reasoning_completed` — real content IS downstream output; preserves the closed-`</think>` + content shape contract from R11-B codex r6.
3. `test_tool_call_after_thinking_still_marks_reasoning_completed` — preserves the tool-call shape contract from the same r6 round.
4. `test_sentinel_with_no_finish_length_keeps_reasoning_completed` — guards against over-extension: sentinel exclusion only applies on the `finish_reason="length"` path.

## Test plan

- [x] Failing test from `test_responses_budget_exhaust_streaming.py` PASSED post-fix (1 → 0 failures in that file: 12/12 PASS)
- [x] 4 new adapter-boundary regression pins all GREEN
- [x] `ruff format` + `ruff check` GREEN (isort auto-fix applied)
- [x] Full unit suite GREEN: **9206 passed**, 21 skipped, 212 deselected, 6 xfailed in 122s (up from 9201 + 1 fixed + 4 new)
- [x] No mlx / mlx-lm / mlx-vlm / mlx-metal version bump (gate #10 N/A)
- [x] No auto-routing change (gate #11 N/A)

## Release coupling

Blocks the v0.8.14 cut: PR #860 is the headline change in v0.8.14 and would ship this regression to PyPI + Homebrew + the rapid-desktop bundled sidecar. The bump-version PR depends on this fix landing first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
