### PR TITLE
feat(cli): rapid-mlx launch <client> — one-shot IDE bootstrap (closes #566)

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,12 +196,61 @@ print(response.choices[0].message.content)
 
 | Client | Status | Setup |
 |--------|--------|-------|
-| [Cursor](https://cursor.com) | Compatible | Settings → OpenAI Base URL |
-| [Claude Code](https://claude.ai/code) | Tested | One command ([see below](#claude-code)) |
-| [Continue.dev](https://continue.dev) | Compatible | VS Code / JetBrains extension |
+| [Cursor](https://cursor.com) | Compatible | `rapid-mlx launch cursor` ([see below](#one-shot-bootstrap-rapid-mlx-launch)) |
+| [Claude Code](https://claude.ai/code) | Tested | `rapid-mlx launch claude-code` |
+| [Cline](https://github.com/cline/cline) (VS Code) | Compatible | `rapid-mlx launch cline` |
+| [Continue.dev](https://continue.dev) | Compatible | `rapid-mlx launch continue-dev` |
 | [LibreChat](https://librechat.ai) | Tested | Docker ([test](tests/integrations/test_librechat_docker.py)) |
 | [Open WebUI](https://github.com/open-webui/open-webui) | Tested | Docker ([test](tests/integrations/test_openwebui.py)) |
 | Any OpenAI-compatible app | Compatible | Point at `http://localhost:8000/v1` |
+
+### One-shot bootstrap: `rapid-mlx launch`
+
+The fastest way to wire an IDE client to your local rapid-mlx server is the
+`launch` subcommand — one verb, no copy-pasting base URLs into nested
+settings panels:
+
+```bash
+pip install rapid-mlx
+
+# Which clients are installed on this Mac?
+rapid-mlx launch list
+
+# Patch Cline (VS Code) to route at the local server and start serve
+# in the background.
+rapid-mlx launch cline --model qwen3.5-4b-4bit --start-server
+
+# Or wire every detected client at once.
+rapid-mlx launch --all --model qwen3.5-9b-4bit --start-server
+```
+
+What it does, per client:
+
+| Client | Config patched | Keys set |
+|--------|----------------|----------|
+| **cline** | `~/Library/Application Support/Code/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json` | `apiProvider`, `openAiBaseUrl`, `openAiApiKey`, `openAiModelId` |
+| **claude-code** | `~/.config/claude/settings.json` | `env.ANTHROPIC_BASE_URL`, `env.ANTHROPIC_API_KEY`, `env.ANTHROPIC_MODEL` |
+| **continue-dev** | `~/.continue/config.json` | Appends/updates a `rapid-mlx` entry under `models[]` |
+| **cursor** | `~/Library/Application Support/Cursor/User/settings.json` | `cursor.aiprovider.openai.{baseUrl,apiKey,model}` |
+
+Every patch:
+
+- Backs up the existing config to `<path>.bak.<timestamp>` (printed to
+  stderr) so you can recover from a bad patch with `mv <bak> <path>`.
+- Atomically replaces the file (write-temp + rename) so a Ctrl-C never
+  leaves a half-written JSON file on disk.
+- Preserves every other key in the existing config — `customInstructions`,
+  MCP servers, theme settings, etc.
+
+Useful flags:
+
+- `--dry-run` — print what would change without touching disk.
+- `--server-url <url>` — point clients somewhere other than
+  `http://127.0.0.1:8000` (e.g. a `rapid-mlx share` URL).
+- `--start-server` — also fire `rapid-mlx serve <model> --port <port>`
+  detached; PID written to `~/.rapid-mlx/launch.pid`.
+- `--port <int>` — port for `--start-server` (default 8000).
+
 
 ### Claude Code
 

--- a/tests/test_launch_cli.py
+++ b/tests/test_launch_cli.py
@@ -1,0 +1,551 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the ``rapid-mlx launch <client>`` bootstrap subcommand.
+
+We never touch the user's real config files — every test redirects the
+relevant home / config dir to a per-test ``tmp_path`` and asserts the
+write-or-patch behaviour against that sandbox. The CLI integration
+tests use ``--dry-run`` so they exercise the dispatcher's argv-parsing
+without writing anything.
+
+See ``vllm_mlx/launch/`` for the modules under test.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from vllm_mlx.launch import (
+    ADAPTERS,
+    claude_code,
+    cline,
+    continue_dev,
+    cursor,
+)
+from vllm_mlx.launch import _common, cli as launch_cli
+
+
+# --------------------------------------------------------------------
+# Shared fixture: pin Path.home() to a per-test tmp_path so adapter
+# modules — which compute config paths from Path.home() at import time
+# via the candidate-roots helpers — see a clean state. We patch via
+# monkeypatch.setattr on the *adapter's* internal probes, not on
+# Path.home() itself: those globals were resolved at import time.
+# --------------------------------------------------------------------
+
+
+@pytest.fixture
+def fake_home(tmp_path, monkeypatch) -> Path:
+    """Redirect every adapter's home-anchored constants at the per-test
+    tmp_path.
+
+    Each adapter freezes its config paths at import time
+    (``_CONFIG_DIR = Path.home() / ...``). We monkeypatch the module
+    attributes directly so the import-time values don't leak across
+    tests. Returns the tmp_path for callers that want to construct
+    expected paths.
+    """
+    # cline: replace the candidate-roots helper so detect/path
+    # resolution picks paths under tmp_path.
+    fake_root = tmp_path / "vscode-globalStorage"
+    monkeypatch.setattr(cline, "_candidate_settings_roots", lambda: [fake_root])
+
+    # claude_code: replace the two module constants.
+    monkeypatch.setattr(claude_code, "_CLAUDE_STATE_DIR", tmp_path / ".claude")
+    monkeypatch.setattr(claude_code, "_CONFIG_DIR", tmp_path / ".config/claude")
+
+    # continue_dev: replace the config dir.
+    monkeypatch.setattr(continue_dev, "_CONFIG_DIR", tmp_path / ".continue")
+
+    # cursor: replace the candidate-dirs helper.
+    fake_cursor_dir = tmp_path / "Cursor/User"
+    monkeypatch.setattr(cursor, "_candidate_dirs", lambda: [fake_cursor_dir])
+    monkeypatch.setattr(cursor, "_CONFIG_DIR_MAC", fake_cursor_dir)
+    monkeypatch.setattr(cursor, "_CONFIG_DIR_LINUX", fake_cursor_dir)
+
+    # Also redirect which() and mac_app_installed() so detect() doesn't
+    # find the dev machine's real claude / cursor installs.
+    monkeypatch.setattr(_common, "which", lambda _: None)
+    monkeypatch.setattr(_common, "mac_app_installed", lambda _: False)
+
+    # And the PID file the launch CLI writes when --start-server is on.
+    monkeypatch.setattr(launch_cli, "PID_FILE", tmp_path / "launch.pid")
+
+    return tmp_path
+
+
+# --------------------------------------------------------------------
+# Cline adapter
+# --------------------------------------------------------------------
+
+
+class TestCline:
+    def test_detect_false_when_no_globalstorage(self, fake_home):
+        assert cline.detect() is False
+        assert cline.current_config_path() is None
+
+    def test_detect_true_when_settings_dir_exists(self, fake_home):
+        # Materialise the extension settings dir but not the file —
+        # detect() should still report True (installed, uninitialised).
+        ext_dir = (
+            fake_home
+            / "vscode-globalStorage"
+            / "saoudrizwan.claude-dev"
+            / "settings"
+        )
+        ext_dir.mkdir(parents=True)
+        assert cline.detect() is True
+        path = cline.current_config_path()
+        assert path is not None
+        assert path.name == "cline_mcp_settings.json"
+
+    def test_write_preserves_existing_keys(self, fake_home):
+        ext_dir = (
+            fake_home
+            / "vscode-globalStorage"
+            / "saoudrizwan.claude-dev"
+            / "settings"
+        )
+        ext_dir.mkdir(parents=True)
+        path = ext_dir / "cline_mcp_settings.json"
+        path.write_text(
+            json.dumps(
+                {
+                    "mcpServers": {"custom": {"command": "node"}},
+                    "apiProvider": "anthropic",  # we'll overwrite this
+                    "openAiApiKey": "old-key",  # we'll overwrite this
+                    "customInstructions": "be terse",  # must survive
+                }
+            )
+        )
+
+        returned = cline.write_or_patch_config(
+            "http://127.0.0.1:8000",
+            "qwen3.5-4b-4bit",
+            api_key="sk-noop",
+        )
+        assert returned == path
+
+        # Backup exists.
+        backups = list(ext_dir.glob("cline_mcp_settings.json.bak.*"))
+        assert len(backups) == 1
+
+        data = json.loads(path.read_text())
+        # Keys we own — set / overwritten.
+        assert data["apiProvider"] == "openai"
+        assert data["openAiBaseUrl"] == "http://127.0.0.1:8000/v1"
+        assert data["openAiApiKey"] == "sk-noop"
+        assert data["openAiModelId"] == "qwen3.5-4b-4bit"
+        # Keys we don't own — untouched.
+        assert data["mcpServers"] == {"custom": {"command": "node"}}
+        assert data["customInstructions"] == "be terse"
+
+    def test_does_not_double_append_v1(self, fake_home):
+        """User passes ``http://127.0.0.1:8000/v1`` — must NOT
+        produce ``/v1/v1``."""
+        ext_dir = (
+            fake_home
+            / "vscode-globalStorage"
+            / "saoudrizwan.claude-dev"
+            / "settings"
+        )
+        ext_dir.mkdir(parents=True)
+        cline.write_or_patch_config(
+            "http://127.0.0.1:8000/v1",
+            "alias",
+        )
+        path = ext_dir / "cline_mcp_settings.json"
+        data = json.loads(path.read_text())
+        assert data["openAiBaseUrl"] == "http://127.0.0.1:8000/v1"
+
+
+# --------------------------------------------------------------------
+# Claude Code adapter
+# --------------------------------------------------------------------
+
+
+class TestClaudeCode:
+    def test_detect_false_when_nothing_installed(self, fake_home):
+        assert claude_code.detect() is False
+
+    def test_detect_true_when_state_dir_exists(self, fake_home):
+        (fake_home / ".claude").mkdir()
+        assert claude_code.detect() is True
+
+    def test_write_strips_trailing_v1(self, fake_home):
+        # User accidentally passes ``http://127.0.0.1:8000/v1`` — the
+        # Anthropic SDK joins ``/v1/messages`` itself, so we must strip
+        # the suffix or every request 404s on ``/v1/v1/messages``.
+        path = claude_code.write_or_patch_config(
+            "http://127.0.0.1:8000/v1",
+            "qwen3.5-9b-4bit",
+        )
+        data = json.loads(path.read_text())
+        assert data["env"]["ANTHROPIC_BASE_URL"] == "http://127.0.0.1:8000"
+        assert data["env"]["ANTHROPIC_MODEL"] == "qwen3.5-9b-4bit"
+        assert data["env"]["ANTHROPIC_API_KEY"] == "sk-noop"
+
+    def test_write_preserves_existing_env_and_other_keys(self, fake_home):
+        cfg = claude_code.current_config_path()
+        assert cfg is not None
+        cfg.parent.mkdir(parents=True, exist_ok=True)
+        cfg.write_text(
+            json.dumps(
+                {
+                    "permissions": {"allow": ["Bash(git:*)"]},
+                    "env": {"OTHER_VAR": "preserved", "ANTHROPIC_BASE_URL": "old"},
+                }
+            )
+        )
+        claude_code.write_or_patch_config(
+            "http://127.0.0.1:8000", "qwen3.5-4b-4bit"
+        )
+        data = json.loads(cfg.read_text())
+        # Untouched.
+        assert data["permissions"] == {"allow": ["Bash(git:*)"]}
+        assert data["env"]["OTHER_VAR"] == "preserved"
+        # Overwritten.
+        assert data["env"]["ANTHROPIC_BASE_URL"] == "http://127.0.0.1:8000"
+
+    def test_backup_created(self, fake_home):
+        cfg = claude_code.current_config_path()
+        cfg.parent.mkdir(parents=True, exist_ok=True)
+        cfg.write_text('{"env": {"foo": "bar"}}')
+        claude_code.write_or_patch_config("http://127.0.0.1:8000", "alias")
+        backups = list(cfg.parent.glob(cfg.name + ".bak.*"))
+        assert len(backups) == 1
+
+
+# --------------------------------------------------------------------
+# Continue.dev adapter
+# --------------------------------------------------------------------
+
+
+class TestContinueDev:
+    def test_detect_false_when_no_continue_dir(self, fake_home):
+        assert continue_dev.detect() is False
+
+    def test_detect_true_when_dir_exists(self, fake_home):
+        (fake_home / ".continue").mkdir()
+        assert continue_dev.detect() is True
+
+    def test_appends_new_model_entry(self, fake_home):
+        (fake_home / ".continue").mkdir()
+        cfg = continue_dev.current_config_path()
+        cfg.write_text(
+            json.dumps(
+                {
+                    "models": [
+                        {"title": "Anthropic", "provider": "anthropic"},
+                    ],
+                    "customCommands": [{"name": "test"}],
+                }
+            )
+        )
+        continue_dev.write_or_patch_config(
+            "http://127.0.0.1:8000", "qwen3.5-4b-4bit"
+        )
+        data = json.loads(cfg.read_text())
+        assert len(data["models"]) == 2
+        rapid = next(m for m in data["models"] if m["title"] == "rapid-mlx")
+        assert rapid["provider"] == "openai"
+        assert rapid["model"] == "qwen3.5-4b-4bit"
+        assert rapid["apiBase"] == "http://127.0.0.1:8000/v1"
+        # Other model preserved.
+        assert any(m["title"] == "Anthropic" for m in data["models"])
+        # Other top-level keys preserved.
+        assert data["customCommands"] == [{"name": "test"}]
+
+    def test_rerun_replaces_in_place_not_duplicates(self, fake_home):
+        (fake_home / ".continue").mkdir()
+        continue_dev.write_or_patch_config("http://127.0.0.1:8000", "model-a")
+        continue_dev.write_or_patch_config("http://127.0.0.1:8000", "model-b")
+        cfg = continue_dev.current_config_path()
+        data = json.loads(cfg.read_text())
+        rapid_entries = [
+            m for m in data["models"] if m.get("title") == "rapid-mlx"
+        ]
+        assert len(rapid_entries) == 1
+        assert rapid_entries[0]["model"] == "model-b"
+
+
+# --------------------------------------------------------------------
+# Cursor adapter
+# --------------------------------------------------------------------
+
+
+class TestCursor:
+    def test_detect_false_when_nothing_installed(self, fake_home):
+        assert cursor.detect() is False
+
+    def test_detect_true_when_user_dir_exists(self, fake_home):
+        (fake_home / "Cursor/User").mkdir(parents=True)
+        assert cursor.detect() is True
+
+    def test_write_sets_dotted_keys(self, fake_home):
+        (fake_home / "Cursor/User").mkdir(parents=True)
+        path = cursor.write_or_patch_config(
+            "http://127.0.0.1:8000", "qwen3.5-9b-4bit"
+        )
+        data = json.loads(path.read_text())
+        assert (
+            data["cursor.aiprovider.openai.baseUrl"]
+            == "http://127.0.0.1:8000/v1"
+        )
+        assert data["cursor.aiprovider.openai.model"] == "qwen3.5-9b-4bit"
+        assert data["cursor.aiprovider.openai.apiKey"] == "sk-noop"
+
+    def test_preserves_unrelated_settings(self, fake_home):
+        (fake_home / "Cursor/User").mkdir(parents=True)
+        cfg = cursor.current_config_path()
+        cfg.write_text(
+            json.dumps(
+                {
+                    "editor.fontSize": 14,
+                    "workbench.colorTheme": "Default Dark+",
+                }
+            )
+        )
+        cursor.write_or_patch_config("http://127.0.0.1:8000", "alias")
+        data = json.loads(cfg.read_text())
+        assert data["editor.fontSize"] == 14
+        assert data["workbench.colorTheme"] == "Default Dark+"
+
+
+# --------------------------------------------------------------------
+# Atomic-write + backup primitives
+# --------------------------------------------------------------------
+
+
+class TestCommon:
+    def test_atomic_write_creates_parent_dirs(self, tmp_path):
+        target = tmp_path / "a" / "b" / "c" / "settings.json"
+        _common.atomic_write_json(target, {"k": "v"})
+        assert target.exists()
+        assert json.loads(target.read_text()) == {"k": "v"}
+
+    def test_atomic_write_no_leftover_temp_files(self, tmp_path):
+        target = tmp_path / "settings.json"
+        _common.atomic_write_json(target, {"x": 1})
+        # No `.new` files left behind.
+        assert list(tmp_path.glob("*.new")) == []
+
+    def test_backup_returns_none_when_no_original(self, tmp_path):
+        assert _common.backup_existing(tmp_path / "missing.json") is None
+
+    def test_backup_handles_same_second_collisions(self, tmp_path):
+        target = tmp_path / "config.json"
+        target.write_text('{"a": 1}')
+        b1 = _common.backup_existing(target)
+        # Simulate a second invocation in the same second by reusing
+        # the timestamp portion — the helper appends a counter suffix.
+        b2 = _common.backup_existing(target)
+        assert b1 is not None and b2 is not None
+        assert b1 != b2
+
+    def test_load_json_lenient_missing(self, tmp_path):
+        assert _common.load_json_lenient(tmp_path / "missing.json") == {}
+
+    def test_load_json_lenient_empty_file(self, tmp_path):
+        target = tmp_path / "empty.json"
+        target.write_text("")
+        assert _common.load_json_lenient(target) == {}
+
+    def test_load_json_lenient_raises_on_invalid(self, tmp_path):
+        target = tmp_path / "bad.json"
+        target.write_text("{ not json")
+        with pytest.raises(json.JSONDecodeError):
+            _common.load_json_lenient(target)
+
+
+# --------------------------------------------------------------------
+# Top-level CLI dispatcher
+# --------------------------------------------------------------------
+
+
+def _make_args(**overrides):
+    """Build an argparse.Namespace shaped like the ``launch`` parser
+    produces, with sane defaults the tests override per-case."""
+    defaults = dict(
+        client=None,
+        all=False,
+        model=None,
+        server_url="http://127.0.0.1:8000",
+        port=8000,
+        start_server=False,
+        dry_run=False,
+    )
+    defaults.update(overrides)
+    return argparse.Namespace(**defaults)
+
+
+class TestLaunchCommand:
+    def test_list_prints_all_clients(self, fake_home, capsys):
+        with pytest.raises(SystemExit) as excinfo:
+            launch_cli.launch_command(_make_args(client="list"))
+        assert excinfo.value.code == 0
+        out = capsys.readouterr().out
+        for name in ADAPTERS:
+            assert name in out
+
+    def test_unknown_client_exit_2(self, fake_home, capsys):
+        with pytest.raises(SystemExit) as excinfo:
+            launch_cli.launch_command(_make_args(client="atom"))
+        assert excinfo.value.code == 2
+        err = capsys.readouterr().err
+        assert "unknown client" in err
+
+    def test_missing_client_and_no_all_exit_2(self, fake_home, capsys):
+        with pytest.raises(SystemExit) as excinfo:
+            launch_cli.launch_command(_make_args())
+        assert excinfo.value.code == 2
+        err = capsys.readouterr().err
+        assert "missing client name" in err
+
+    def test_all_and_client_mutually_exclusive(self, fake_home, capsys):
+        with pytest.raises(SystemExit) as excinfo:
+            launch_cli.launch_command(_make_args(client="cline", all=True))
+        assert excinfo.value.code == 2
+        err = capsys.readouterr().err
+        assert "mutually exclusive" in err
+
+    def test_all_with_no_detected_clients_exits_1(self, fake_home, capsys):
+        with pytest.raises(SystemExit) as excinfo:
+            launch_cli.launch_command(_make_args(all=True))
+        assert excinfo.value.code == 1
+        err = capsys.readouterr().err
+        assert "no supported clients detected" in err
+
+    def test_dry_run_does_not_touch_disk(self, fake_home, capsys):
+        # Mark cline as detected so the dispatcher reaches the
+        # would-patch line.
+        ext_dir = (
+            fake_home
+            / "vscode-globalStorage"
+            / "saoudrizwan.claude-dev"
+            / "settings"
+        )
+        ext_dir.mkdir(parents=True)
+        before = list(ext_dir.iterdir())
+
+        launch_cli.launch_command(
+            _make_args(client="cline", dry_run=True)
+        )
+        out = capsys.readouterr().out
+        assert "[dry-run]" in out
+        assert "cline" in out
+        # No file was created or modified.
+        assert list(ext_dir.iterdir()) == before
+
+    def test_real_patch_writes_file(self, fake_home, capsys):
+        ext_dir = (
+            fake_home
+            / "vscode-globalStorage"
+            / "saoudrizwan.claude-dev"
+            / "settings"
+        )
+        ext_dir.mkdir(parents=True)
+        launch_cli.launch_command(
+            _make_args(client="cline", model="qwen3.5-4b-4bit")
+        )
+        target = ext_dir / "cline_mcp_settings.json"
+        assert target.exists()
+        data = json.loads(target.read_text())
+        assert data["openAiModelId"] == "qwen3.5-4b-4bit"
+        out = capsys.readouterr().out
+        assert "Patched cline" in out
+        assert "Now ready" in out
+
+    def test_not_detected_client_fails_with_hint(self, fake_home, capsys):
+        # cline is NOT detected (no globalStorage dir). The command
+        # should fail with a clear hint and exit non-zero.
+        with pytest.raises(SystemExit) as excinfo:
+            launch_cli.launch_command(_make_args(client="cline"))
+        assert excinfo.value.code == 1
+        err = capsys.readouterr().err
+        assert "cline: not detected" in err
+
+    def test_start_server_spawns_and_writes_pid(self, fake_home, capsys):
+        ext_dir = (
+            fake_home
+            / "vscode-globalStorage"
+            / "saoudrizwan.claude-dev"
+            / "settings"
+        )
+        ext_dir.mkdir(parents=True)
+        fake_proc = MagicMock()
+        fake_proc.pid = 99999
+        with patch.object(subprocess, "Popen", return_value=fake_proc) as popen:
+            launch_cli.launch_command(
+                _make_args(
+                    client="cline",
+                    model="qwen3.5-4b-4bit",
+                    start_server=True,
+                    port=8102,
+                )
+            )
+        # Spawn happened with the expected argv.
+        argv = popen.call_args[0][0]
+        assert argv == [
+            "rapid-mlx",
+            "serve",
+            "qwen3.5-4b-4bit",
+            "--port",
+            "8102",
+        ]
+        # PID file written.
+        assert launch_cli.PID_FILE.read_text().strip() == "99999"
+
+    def test_uses_original_alias_when_resolved(self, fake_home, capsys):
+        """When ``main()`` rewrites ``args.model`` from alias to HF id,
+        the launch command should patch with the ORIGINAL alias so the
+        IDE client requests the short name from rapid-mlx."""
+        ext_dir = (
+            fake_home
+            / "vscode-globalStorage"
+            / "saoudrizwan.claude-dev"
+            / "settings"
+        )
+        ext_dir.mkdir(parents=True)
+        ns = _make_args(
+            client="cline", model="mlx-community/Qwen3.5-4B-MLX-4bit"
+        )
+        # Simulate what ``main()`` does on the way in.
+        ns._original_alias = "qwen3.5-4b-4bit"
+        launch_cli.launch_command(ns)
+        data = json.loads((ext_dir / "cline_mcp_settings.json").read_text())
+        assert data["openAiModelId"] == "qwen3.5-4b-4bit"
+
+
+# --------------------------------------------------------------------
+# Top-level CLI argparse integration — invoke `python -m vllm_mlx.cli
+# launch --help` via subprocess so we exercise the wiring from
+# main() rather than the dispatcher in isolation. We don't run a real
+# patch in subprocess (no fake_home control); the unit tests above
+# cover that.
+# --------------------------------------------------------------------
+
+
+def test_launch_help_text_is_registered(tmp_path):
+    """The ``launch`` subcommand is wired onto the top-level parser
+    (regression guard: a future refactor of cli.py's subparser block
+    that drops the ``_register_launch(subparsers)`` call would let the
+    feature silently disappear)."""
+    import vllm_mlx.cli as top_cli
+
+    # We don't actually run main() — just walk its argparse tree.
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="command")
+    from vllm_mlx.launch.cli import register
+
+    register(sub)
+    # Choices populated.
+    assert "launch" in sub.choices
+    # And accept `list` as a client name.
+    args = parser.parse_args(["launch", "list"])
+    assert args.client == "list"

--- a/tests/test_launch_cli.py
+++ b/tests/test_launch_cli.py
@@ -22,13 +22,13 @@ import pytest
 
 from vllm_mlx.launch import (
     ADAPTERS,
+    _common,
     claude_code,
     cline,
     continue_dev,
     cursor,
 )
-from vllm_mlx.launch import _common, cli as launch_cli
-
+from vllm_mlx.launch import cli as launch_cli
 
 # --------------------------------------------------------------------
 # Shared fixture: pin Path.home() to a per-test tmp_path so adapter
@@ -93,10 +93,7 @@ class TestCline:
         # Materialise the extension settings dir but not the file —
         # detect() should still report True (installed, uninitialised).
         ext_dir = (
-            fake_home
-            / "vscode-globalStorage"
-            / "saoudrizwan.claude-dev"
-            / "settings"
+            fake_home / "vscode-globalStorage" / "saoudrizwan.claude-dev" / "settings"
         )
         ext_dir.mkdir(parents=True)
         assert cline.detect() is True
@@ -106,10 +103,7 @@ class TestCline:
 
     def test_write_preserves_existing_keys(self, fake_home):
         ext_dir = (
-            fake_home
-            / "vscode-globalStorage"
-            / "saoudrizwan.claude-dev"
-            / "settings"
+            fake_home / "vscode-globalStorage" / "saoudrizwan.claude-dev" / "settings"
         )
         ext_dir.mkdir(parents=True)
         path = ext_dir / "cline_mcp_settings.json"
@@ -149,10 +143,7 @@ class TestCline:
         """User passes ``http://127.0.0.1:8000/v1`` — must NOT
         produce ``/v1/v1``."""
         ext_dir = (
-            fake_home
-            / "vscode-globalStorage"
-            / "saoudrizwan.claude-dev"
-            / "settings"
+            fake_home / "vscode-globalStorage" / "saoudrizwan.claude-dev" / "settings"
         )
         ext_dir.mkdir(parents=True)
         cline.write_or_patch_config(
@@ -202,9 +193,7 @@ class TestClaudeCode:
                 }
             )
         )
-        claude_code.write_or_patch_config(
-            "http://127.0.0.1:8000", "qwen3.5-4b-4bit"
-        )
+        claude_code.write_or_patch_config("http://127.0.0.1:8000", "qwen3.5-4b-4bit")
         data = json.loads(cfg.read_text())
         # Untouched.
         assert data["permissions"] == {"allow": ["Bash(git:*)"]}
@@ -247,9 +236,7 @@ class TestContinueDev:
                 }
             )
         )
-        continue_dev.write_or_patch_config(
-            "http://127.0.0.1:8000", "qwen3.5-4b-4bit"
-        )
+        continue_dev.write_or_patch_config("http://127.0.0.1:8000", "qwen3.5-4b-4bit")
         data = json.loads(cfg.read_text())
         assert len(data["models"]) == 2
         rapid = next(m for m in data["models"] if m["title"] == "rapid-mlx")
@@ -267,9 +254,7 @@ class TestContinueDev:
         continue_dev.write_or_patch_config("http://127.0.0.1:8000", "model-b")
         cfg = continue_dev.current_config_path()
         data = json.loads(cfg.read_text())
-        rapid_entries = [
-            m for m in data["models"] if m.get("title") == "rapid-mlx"
-        ]
+        rapid_entries = [m for m in data["models"] if m.get("title") == "rapid-mlx"]
         assert len(rapid_entries) == 1
         assert rapid_entries[0]["model"] == "model-b"
 
@@ -289,14 +274,9 @@ class TestCursor:
 
     def test_write_sets_dotted_keys(self, fake_home):
         (fake_home / "Cursor/User").mkdir(parents=True)
-        path = cursor.write_or_patch_config(
-            "http://127.0.0.1:8000", "qwen3.5-9b-4bit"
-        )
+        path = cursor.write_or_patch_config("http://127.0.0.1:8000", "qwen3.5-9b-4bit")
         data = json.loads(path.read_text())
-        assert (
-            data["cursor.aiprovider.openai.baseUrl"]
-            == "http://127.0.0.1:8000/v1"
-        )
+        assert data["cursor.aiprovider.openai.baseUrl"] == "http://127.0.0.1:8000/v1"
         assert data["cursor.aiprovider.openai.model"] == "qwen3.5-9b-4bit"
         assert data["cursor.aiprovider.openai.apiKey"] == "sk-noop"
 
@@ -425,17 +405,12 @@ class TestLaunchCommand:
         # Mark cline as detected so the dispatcher reaches the
         # would-patch line.
         ext_dir = (
-            fake_home
-            / "vscode-globalStorage"
-            / "saoudrizwan.claude-dev"
-            / "settings"
+            fake_home / "vscode-globalStorage" / "saoudrizwan.claude-dev" / "settings"
         )
         ext_dir.mkdir(parents=True)
         before = list(ext_dir.iterdir())
 
-        launch_cli.launch_command(
-            _make_args(client="cline", dry_run=True)
-        )
+        launch_cli.launch_command(_make_args(client="cline", dry_run=True))
         out = capsys.readouterr().out
         assert "[dry-run]" in out
         assert "cline" in out
@@ -444,15 +419,10 @@ class TestLaunchCommand:
 
     def test_real_patch_writes_file(self, fake_home, capsys):
         ext_dir = (
-            fake_home
-            / "vscode-globalStorage"
-            / "saoudrizwan.claude-dev"
-            / "settings"
+            fake_home / "vscode-globalStorage" / "saoudrizwan.claude-dev" / "settings"
         )
         ext_dir.mkdir(parents=True)
-        launch_cli.launch_command(
-            _make_args(client="cline", model="qwen3.5-4b-4bit")
-        )
+        launch_cli.launch_command(_make_args(client="cline", model="qwen3.5-4b-4bit"))
         target = ext_dir / "cline_mcp_settings.json"
         assert target.exists()
         data = json.loads(target.read_text())
@@ -472,10 +442,7 @@ class TestLaunchCommand:
 
     def test_start_server_spawns_and_writes_pid(self, fake_home, capsys):
         ext_dir = (
-            fake_home
-            / "vscode-globalStorage"
-            / "saoudrizwan.claude-dev"
-            / "settings"
+            fake_home / "vscode-globalStorage" / "saoudrizwan.claude-dev" / "settings"
         )
         ext_dir.mkdir(parents=True)
         fake_proc = MagicMock()
@@ -501,23 +468,23 @@ class TestLaunchCommand:
         # PID file written.
         assert launch_cli.PID_FILE.read_text().strip() == "99999"
 
-    def test_start_server_skipped_when_no_clients_patched(
-        self, fake_home, capsys
-    ):
+    def test_start_server_skipped_when_no_clients_patched(self, fake_home, capsys):
         # cline is NOT detected on this fake_home. --start-server must
         # NOT spawn a child server when zero clients were patched
         # successfully — otherwise we leak a detached server + PID file
         # for a setup the user can't actually use.
-        with patch.object(subprocess, "Popen") as popen:
-            with pytest.raises(SystemExit) as excinfo:
-                launch_cli.launch_command(
-                    _make_args(
-                        client="cline",
-                        model="qwen3.5-4b-4bit",
-                        start_server=True,
-                        port=8102,
-                    )
+        with (
+            patch.object(subprocess, "Popen") as popen,
+            pytest.raises(SystemExit) as excinfo,
+        ):
+            launch_cli.launch_command(
+                _make_args(
+                    client="cline",
+                    model="qwen3.5-4b-4bit",
+                    start_server=True,
+                    port=8102,
                 )
+            )
         assert excinfo.value.code == 1
         popen.assert_not_called()
         assert not launch_cli.PID_FILE.exists()
@@ -529,15 +496,10 @@ class TestLaunchCommand:
         the launch command should patch with the ORIGINAL alias so the
         IDE client requests the short name from rapid-mlx."""
         ext_dir = (
-            fake_home
-            / "vscode-globalStorage"
-            / "saoudrizwan.claude-dev"
-            / "settings"
+            fake_home / "vscode-globalStorage" / "saoudrizwan.claude-dev" / "settings"
         )
         ext_dir.mkdir(parents=True)
-        ns = _make_args(
-            client="cline", model="mlx-community/Qwen3.5-4B-MLX-4bit"
-        )
+        ns = _make_args(client="cline", model="mlx-community/Qwen3.5-4B-MLX-4bit")
         # Simulate what ``main()`` does on the way in.
         ns._original_alias = "qwen3.5-4b-4bit"
         launch_cli.launch_command(ns)
@@ -559,7 +521,6 @@ def test_launch_help_text_is_registered(tmp_path):
     (regression guard: a future refactor of cli.py's subparser block
     that drops the ``_register_launch(subparsers)`` call would let the
     feature silently disappear)."""
-    import vllm_mlx.cli as top_cli
 
     # We don't actually run main() — just walk its argparse tree.
     parser = argparse.ArgumentParser()

--- a/tests/test_launch_cli.py
+++ b/tests/test_launch_cli.py
@@ -501,6 +501,29 @@ class TestLaunchCommand:
         # PID file written.
         assert launch_cli.PID_FILE.read_text().strip() == "99999"
 
+    def test_start_server_skipped_when_no_clients_patched(
+        self, fake_home, capsys
+    ):
+        # cline is NOT detected on this fake_home. --start-server must
+        # NOT spawn a child server when zero clients were patched
+        # successfully — otherwise we leak a detached server + PID file
+        # for a setup the user can't actually use.
+        with patch.object(subprocess, "Popen") as popen:
+            with pytest.raises(SystemExit) as excinfo:
+                launch_cli.launch_command(
+                    _make_args(
+                        client="cline",
+                        model="qwen3.5-4b-4bit",
+                        start_server=True,
+                        port=8102,
+                    )
+                )
+        assert excinfo.value.code == 1
+        popen.assert_not_called()
+        assert not launch_cli.PID_FILE.exists()
+        err = capsys.readouterr().err
+        assert "Skipping --start-server" in err
+
     def test_uses_original_alias_when_resolved(self, fake_home, capsys):
         """When ``main()`` rewrites ``args.model`` from alias to HF id,
         the launch command should patch with the ORIGINAL alias so the
@@ -549,3 +572,28 @@ def test_launch_help_text_is_registered(tmp_path):
     # And accept `list` as a client name.
     args = parser.parse_args(["launch", "list"])
     assert args.client == "list"
+
+
+@pytest.mark.parametrize("bad_port", ["0", "-1", "65536", "99999", "abc"])
+def test_launch_port_rejects_out_of_range(bad_port):
+    """``--port`` must use the same ``[1, 65535]`` validator as
+    ``rapid-mlx serve``. Pre-fix, ``launch --port 99999`` parsed
+    successfully and only failed inside the detached child after the
+    parent had already printed "Started" and written a PID."""
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="command")
+    from vllm_mlx.launch.cli import register
+
+    register(sub)
+    with pytest.raises(SystemExit):
+        parser.parse_args(["launch", "cline", "--port", bad_port])
+
+
+def test_launch_port_accepts_in_range():
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="command")
+    from vllm_mlx.launch.cli import register
+
+    register(sub)
+    args = parser.parse_args(["launch", "cline", "--port", "8000"])
+    assert args.port == 8000

--- a/tests/test_no_out_of_band_routing.py
+++ b/tests/test_no_out_of_band_routing.py
@@ -179,6 +179,16 @@ ALLOWED_RAPID_MLX_ENV_VARS: frozenset[str] = frozenset(
         # servers. It selects external tool endpoints, never which model /
         # parser / tier the engine routes a request to.
         "RAPID_MLX_MCP_CONFIG",
+        # ``rapid-mlx launch <client>`` default-model override. When the user
+        # doesn't pass ``--model``, the launch dispatcher reads this env var
+        # before falling back to the built-in ``qwen3.5-4b-4bit`` default.
+        # Pure UX-default knob consumed only by
+        # ``vllm_mlx/launch/cli.py:_resolve_default_model`` to decide which
+        # alias to write into the patched IDE-client config (Cline / Claude
+        # Code / Continue / Cursor). Never consulted by the engine,
+        # scheduler, or any routing layer — the actual model that loads is
+        # chosen by ``rapid-mlx serve <model>``.
+        "RAPID_MLX_DEFAULT_MODEL",
         # User-configured HTTP base URL for a weight mirror (R2/S3/any HTTP
         # host) consumed by ``_try_mirror_prefetch`` in ``vllm_mlx/cli.py``.
         # Pre-populates the HF cache layout (``snapshots/<sha>/<file>``) from

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -6044,6 +6044,15 @@ Examples:
 
     _register_share(subparsers)
 
+    # Launch subcommand — one-shot bootstrap that patches IDE/agent
+    # client configs (Cline, Claude Code, Continue, Cursor) to route
+    # at the local rapid-mlx server. See GH issue #566 for motivation.
+    # Registered AFTER share so the help-text ordering reads
+    # serve→…→share→launch, matching the rough "more common first" flow.
+    from vllm_mlx.launch.cli import register as _register_launch
+
+    _register_launch(subparsers)
+
     # Shell tab completion via argcomplete. Must fire before parse_args:
     # when the shell completion handler invokes us with the
     # ``_ARGCOMPLETE`` env var set, this function short-circuits before
@@ -6410,6 +6419,10 @@ Examples:
         from vllm_mlx.share.cli import share_command
 
         share_command(args)
+    elif args.command == "launch":
+        from vllm_mlx.launch.cli import launch_command
+
+        launch_command(args)
     else:
         parser.print_help()
         sys.exit(1)

--- a/vllm_mlx/launch/__init__.py
+++ b/vllm_mlx/launch/__init__.py
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: Apache-2.0
+"""``rapid-mlx launch <client>`` — one-shot bootstrap.
+
+Detects whether the named client (Cline, Claude Code CLI, Continue,
+Cursor) is installed on this machine, then writes/patches the client's
+local config so it routes traffic at the local rapid-mlx OpenAI-
+compatible server (default ``http://127.0.0.1:8000/v1``). Optionally
+spawns ``rapid-mlx serve`` in the background so a user goes from a
+fresh install to "Cline talking to my Mac" in one command.
+
+The implementation lives in per-client modules so each adapter's
+config-shape knowledge stays narrow:
+
+* :mod:`vllm_mlx.launch.cline` — Cline VS Code extension
+* :mod:`vllm_mlx.launch.claude_code` — Claude Code CLI (Anthropic SDK)
+* :mod:`vllm_mlx.launch.continue_dev` — Continue.dev VS Code/JetBrains
+* :mod:`vllm_mlx.launch.cursor` — Cursor editor
+
+All adapters expose the same surface (:func:`detect`,
+:func:`current_config_path`, :func:`write_or_patch_config`) so the
+top-level ``launch`` dispatcher in :mod:`vllm_mlx.launch.cli` can route
+to them via a single registry. See ``cli.py`` in this package for the
+argparse wiring and the ``--start-server`` background-serve handling.
+
+See GitHub issue #566 for motivation (the Ollama ``ollama launch
+cline`` shape we're copying — same OpenAI-compatible plumbing, same
+one-verb UX).
+"""
+
+from . import claude_code, cline, continue_dev, cursor
+
+# Registry consumed by ``vllm_mlx.launch.cli`` — order is the
+# display order in ``rapid-mlx launch list``. Keys are the
+# user-facing client names accepted on the CLI (kebab-case so
+# ``claude-code`` matches Cline's blog post / Cursor's settings panel
+# shape; ``continue`` would collide with the Python keyword so we use
+# ``continue-dev``).
+ADAPTERS: dict[str, object] = {
+    "cline": cline,
+    "claude-code": claude_code,
+    "continue-dev": continue_dev,
+    "cursor": cursor,
+}
+
+__all__ = ["ADAPTERS", "claude_code", "cline", "continue_dev", "cursor"]

--- a/vllm_mlx/launch/_common.py
+++ b/vllm_mlx/launch/_common.py
@@ -1,0 +1,158 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Shared helpers for the per-client launch adapters.
+
+The four adapters in this package each patch a single JSON config file,
+so they all need the same three primitives:
+
+* Discover the config path on this host (respecting both macOS and
+  Linux conventions where each client's authors picked something
+  different).
+* Back the existing file up to ``<path>.bak.<ts>`` so the user can
+  recover if our patch corrupts it — *every* adapter MUST call
+  :func:`backup_existing` BEFORE the atomic rename.
+* Atomically write the patched config to ``<path>.new`` and rename it
+  over the target so a Ctrl-C between bytes never leaves a half-written
+  JSON file on disk.
+
+Keeping these helpers here (rather than re-implemented per adapter)
+means a fix to the atomic-write logic — e.g. tightening the temp-file
+permissions, switching to ``os.fsync`` on Linux — applies to every
+client at once.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+
+def backup_existing(path: Path) -> Path | None:
+    """Copy ``path`` to ``path.bak.<unix-ts>`` if it exists; return the
+    backup path (or ``None`` when the original didn't exist yet).
+
+    A unique timestamp suffix means a user who runs ``rapid-mlx launch
+    cline`` twice in the same session gets *two* recoverable backups
+    rather than one overwriting the other. The backup is the FULL byte
+    content of the original — not a JSON re-serialisation — so a config
+    with trailing comments or odd whitespace round-trips losslessly
+    even if we'd rewrite it.
+
+    Prints the backup location to stderr so a user reading the launch
+    command's output sees "backup at <path>" without it being mixed
+    into the success stdout (which scripts may parse).
+    """
+    if not path.exists():
+        return None
+    ts = int(time.time())
+    bak = path.with_suffix(path.suffix + f".bak.{ts}")
+    # Collision avoidance for two invocations in the same second
+    # (unlikely interactively but trivially reachable in tests). Walk
+    # the suffix counter forward until we find an unused name; we don't
+    # care about the counter value being meaningful.
+    counter = 0
+    while bak.exists():
+        counter += 1
+        bak = path.with_suffix(path.suffix + f".bak.{ts}.{counter}")
+    bak.write_bytes(path.read_bytes())
+    print(f"  backup: {bak}", file=sys.stderr)
+    return bak
+
+
+def atomic_write_json(path: Path, data: object) -> None:
+    """Write ``data`` to ``path`` as pretty-printed JSON atomically.
+
+    We write to a sibling temp file in the same directory (``rename`` is
+    only atomic within a single filesystem) and then ``os.replace`` it
+    over the target. A Ctrl-C between the write and the replace leaves
+    the temp file behind — recoverable — instead of a half-written
+    config that breaks the client on next launch.
+
+    The directory is mkdir'd with ``parents=True`` so we can patch a
+    config for a never-before-run client (e.g. a user who installed
+    Continue but never opened it). JSON is written with a trailing
+    newline to match what every editor's "format on save" produces.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    # ``delete=False`` so we control the unlink path — the temp file
+    # only goes away via the ``os.replace`` rename below (on success)
+    # or stays behind on crash for recovery.
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=path.name + ".",
+        suffix=".new",
+        dir=str(path.parent),
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2, sort_keys=False)
+            f.write("\n")
+            # fsync so the bytes hit disk before the rename. Without
+            # this an OS crash between rename and flush could leave us
+            # with a renamed but empty file on the target.
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp_name, path)
+    except Exception:
+        # Clean up the temp file on any error path so we don't litter
+        # the user's config dir with ``settings.json.XYZ.new`` files.
+        try:
+            os.unlink(tmp_name)
+        except FileNotFoundError:
+            pass
+        raise
+
+
+def load_json_lenient(path: Path) -> dict:
+    """Read ``path`` as JSON, returning ``{}`` if missing or unreadable.
+
+    Cline / Cursor / Continue all *technically* require strict JSON, but
+    in practice users hand-edit these files and occasionally end up with
+    trailing commas or comments that ``json.loads`` rejects. We don't
+    pretend to be a JSON5 parser — we just refuse to overwrite a config
+    we can't safely round-trip. Caller passes the resulting dict to
+    :func:`atomic_write_json` only after merging in the new keys.
+
+    Returns ``{}`` only on missing or syntactically-empty file. A
+    JSONDecodeError is RAISED — the launch command catches it and tells
+    the user "your existing config is invalid, please fix or remove it"
+    rather than silently nuking their edits.
+    """
+    if not path.exists():
+        return {}
+    raw = path.read_text(encoding="utf-8").strip()
+    if not raw:
+        return {}
+    return json.loads(raw)
+
+
+def mac_app_installed(app_name: str) -> bool:
+    """Return True if the named ``.app`` bundle exists under either
+    ``/Applications`` or ``~/Applications`` on macOS.
+
+    Most IDE-class clients ship as a regular ``.app`` bundle, so this is
+    the cheapest cross-version check ("did the user install the app at
+    all"). Doesn't try to introspect the bundle's Info.plist — version
+    detection is out of scope for ``launch``.
+    """
+    candidates = [
+        Path("/Applications") / f"{app_name}.app",
+        Path.home() / "Applications" / f"{app_name}.app",
+    ]
+    return any(p.exists() for p in candidates)
+
+
+def which(cmd: str) -> str | None:
+    """Locate ``cmd`` on the PATH, returning the absolute path or None.
+
+    Thin wrapper around ``shutil.which`` so the per-client modules can
+    keep a single import surface (``from . import _common``). Pulled
+    out (rather than re-imported per file) so a future swap to a richer
+    PATH resolver — e.g. one that also checks ``~/.local/bin`` even
+    when it's not on PATH — only touches one place.
+    """
+    import shutil
+
+    return shutil.which(cmd)

--- a/vllm_mlx/launch/claude_code.py
+++ b/vllm_mlx/launch/claude_code.py
@@ -1,0 +1,131 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Claude Code CLI launch adapter.
+
+Unlike the VS Code-extension clients (Cline, Continue), the Claude Code
+CLI ships as a Node-based command-line tool (``claude``) that reads its
+config from ``~/.config/claude/settings.json`` and also honours a small
+set of environment variables — most importantly
+``ANTHROPIC_BASE_URL`` and ``ANTHROPIC_API_KEY``.
+
+rapid-mlx already serves the Anthropic ``/v1/messages`` shape (see the
+README "Claude Code" section), so the launch step is simply:
+
+1. Write a ``settings.json`` that points Claude Code at our local
+   ``http://127.0.0.1:8000`` (NOT ``/v1`` — Anthropic SDK appends the
+   ``/v1/messages`` path itself; double-slashing yields a 404).
+2. Carry the model id so a fresh Claude Code session uses our loaded
+   model rather than the SDK default.
+
+Detection probes both an installed ``claude`` binary on PATH AND a
+``~/.claude`` state dir — either alone is good enough since some
+package managers (npm-global, brew, asdf) install the binary outside
+the standard ``~/.config`` tree before the first run.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from . import _common
+
+# Per-user state dir Anthropic's CLI creates on first run. We probe for
+# it as a "claude has been launched at least once" signal — a fallback
+# when the binary lives outside our PATH visibility (e.g. inside a
+# Volta or asdf shim that's not in the parent shell's PATH).
+_CLAUDE_STATE_DIR = Path.home() / ".claude"
+
+# Canonical settings location. Anthropic's docs document this path on
+# both macOS and Linux; the CLI mkdir's it on first launch.
+_CONFIG_DIR = Path.home() / ".config" / "claude"
+_CONFIG_FILENAME = "settings.json"
+
+
+def detect() -> bool:
+    """Return True when Claude Code CLI is plausibly installed.
+
+    Three independent signals — any one is sufficient:
+
+    * The ``claude`` executable resolves on PATH.
+    * ``~/.claude`` exists (the CLI's state dir from a previous run).
+    * ``~/.config/claude/`` exists (the config dir, mkdir'd on first
+      launch on freshly installed boxes).
+
+    Multiple signals exist because users install the CLI through wildly
+    different package managers (npm-global, brew, official installer)
+    and each one writes to a different binary path. A single-signal
+    check would false-negative on every box where the binary's outside
+    our PATH visibility.
+    """
+    if _common.which("claude") is not None:
+        return True
+    if _CLAUDE_STATE_DIR.exists():
+        return True
+    if _CONFIG_DIR.exists():
+        return True
+    return False
+
+
+def current_config_path() -> Path | None:
+    """Return ``~/.config/claude/settings.json``.
+
+    Unlike Cline (where we *might* refuse to write when the extension
+    isn't installed), Claude Code's settings file is safe to create
+    speculatively — the CLI mkdir's the same path on first run, so
+    pre-creating it is identical to letting the CLI do it. We always
+    return the canonical path; the launch dispatcher prints a "Claude
+    Code not detected" hint when :func:`detect` is False but proceeds
+    with the patch on user override (``--force``, not yet implemented;
+    today we just patch on best-effort).
+    """
+    return _CONFIG_DIR / _CONFIG_FILENAME
+
+
+def write_or_patch_config(
+    server_url: str,
+    model: str,
+    api_key: str = "sk-noop",
+    config_path: Path | None = None,
+) -> Path:
+    """Patch ``~/.config/claude/settings.json`` to route at the local
+    rapid-mlx Anthropic-compatible endpoint.
+
+    Keys we own (all under the top-level ``env`` object, which Anthropic
+    documents as the recommended way to feed Claude Code env vars from
+    the settings file rather than the parent shell):
+
+    * ``env.ANTHROPIC_BASE_URL`` → ``<server_url>`` (no ``/v1`` —
+      Anthropic SDK joins paths itself; ``http://127.0.0.1:8000`` is
+      correct, ``http://127.0.0.1:8000/v1`` produces 404 on
+      ``/v1/v1/messages``).
+    * ``env.ANTHROPIC_API_KEY`` → ``<api_key>``
+    * ``env.ANTHROPIC_MODEL`` → ``<model>`` (Claude Code reads this as
+      the default model id; the rapid-mlx server accepts any
+      ``claude-*`` model name and routes to the actually-loaded engine,
+      so this is informational rather than enforced).
+
+    All other keys (``permissions``, ``apiKeyHelper``, ``mcp_servers``,
+    custom shortcuts) round-trip untouched.
+    """
+    path = config_path or current_config_path()
+    assert path is not None  # current_config_path never returns None here
+
+    existing = _common.load_json_lenient(path)
+    _common.backup_existing(path)
+
+    # Strip a trailing ``/v1`` if the user pasted one — the Anthropic
+    # SDK appends ``/v1/messages`` itself, and ``/v1/v1/messages`` is a
+    # 404. This is the inverse of Cline's behaviour (which *requires*
+    # the ``/v1`` suffix), so we explicitly normalise here rather than
+    # share the logic.
+    base_url = server_url.rstrip("/")
+    if base_url.endswith("/v1"):
+        base_url = base_url[: -len("/v1")]
+
+    env = dict(existing.get("env", {}))
+    env["ANTHROPIC_BASE_URL"] = base_url
+    env["ANTHROPIC_API_KEY"] = api_key
+    env["ANTHROPIC_MODEL"] = model
+    existing["env"] = env
+
+    _common.atomic_write_json(path, existing)
+    return path

--- a/vllm_mlx/launch/cli.py
+++ b/vllm_mlx/launch/cli.py
@@ -1,0 +1,302 @@
+# SPDX-License-Identifier: Apache-2.0
+"""``rapid-mlx launch`` subcommand wiring.
+
+This module exposes:
+
+* :func:`register` — called from :mod:`vllm_mlx.cli` to wire the
+  ``launch`` subparser onto the top-level argparse tree.
+* :func:`launch_command` — argparse dispatch entry point.
+
+The subcommand has three argv shapes:
+
+* ``rapid-mlx launch list`` — print the supported clients + detection
+  matrix. No state mutated.
+* ``rapid-mlx launch <client>`` — patch the named client's config.
+* ``rapid-mlx launch --all`` — patch every *detected* client.
+
+All shapes accept the same set of orthogonal flags (``--model``,
+``--server-url``, ``--start-server``, ``--port``, ``--dry-run``). The
+positional ``<client>`` and ``--all`` are mutually exclusive — argparse
+isn't aware of this because we accept either, but :func:`launch_command`
+fails fast with a clear error.
+
+``--start-server`` spawns ``rapid-mlx serve <model> --port <port>`` in
+the background and writes the PID to ``~/.rapid-mlx/launch.pid`` so a
+later ``kill $(cat ~/.rapid-mlx/launch.pid)`` shuts it down cleanly.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from . import ADAPTERS
+
+# Where we drop the PID of a ``--start-server`` subprocess. Pulled out
+# so tests can monkeypatch it to a tmp_path and assert the file's
+# contents without polluting the dev's real home dir.
+PID_FILE = Path.home() / ".rapid-mlx" / "launch.pid"
+
+
+def _print_list() -> int:
+    """Print the supported-clients + detection matrix.
+
+    Output shape (one line per client):
+
+        cline           detected
+        claude-code     not detected
+        continue-dev    detected
+        cursor          not detected
+
+    Always returns 0 — listing is a read-only inspect command.
+    """
+    width = max(len(name) for name in ADAPTERS) + 2
+    print("Supported clients:")
+    for name, adapter in ADAPTERS.items():
+        status = "detected" if adapter.detect() else "not detected"
+        print(f"  {name.ljust(width)}{status}")
+    return 0
+
+
+def _resolve_default_model() -> str:
+    """Pick a default model alias when the user didn't pass ``--model``.
+
+    Precedence:
+
+    * ``RAPID_MLX_DEFAULT_MODEL`` env var (lets the operator pin one)
+    * the built-in ``qwen3.5-4b-4bit`` (same default the chat REPL uses
+      — a tiny, fast, well-MHI'd model that fits 24 GB Macs).
+
+    A "last-served" file would be slightly nicer UX but adds a state
+    surface we'd have to maintain across CLI versions; for the first
+    cut this static default is sufficient (and matches what the README
+    quickstart tells users to pull).
+    """
+    return os.environ.get("RAPID_MLX_DEFAULT_MODEL") or "qwen3.5-4b-4bit"
+
+
+def _start_server_background(model: str, port: int) -> int:
+    """Spawn ``rapid-mlx serve <model> --port <port>`` detached.
+
+    Writes the child PID to :data:`PID_FILE` so a later ``kill $(cat
+    ~/.rapid-mlx/launch.pid)`` shuts it down. We don't wait for
+    readiness — the launch command's whole point is "configure the
+    client now, model load can happen in the background" — but we DO
+    fail fast if the spawn itself fails (e.g. ``rapid-mlx`` not on
+    PATH).
+
+    Returns the child PID. The parent rapid-mlx process exits after
+    detaching; the child becomes a session leader (``start_new_session``)
+    so a closing terminal doesn't SIGHUP the serve.
+    """
+    PID_FILE.parent.mkdir(parents=True, exist_ok=True)
+    cmd = ["rapid-mlx", "serve", model, "--port", str(port)]
+    # ``start_new_session=True`` is the POSIX-portable replacement for
+    # setsid() — detaches the child from the parent's controlling
+    # terminal so a Ctrl-C on the parent doesn't propagate.
+    proc = subprocess.Popen(
+        cmd,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        start_new_session=True,
+    )
+    PID_FILE.write_text(str(proc.pid) + "\n", encoding="utf-8")
+    return proc.pid
+
+
+def launch_command(args: argparse.Namespace) -> None:
+    """Argparse entry point for ``rapid-mlx launch``.
+
+    Handles three subcommands by inspecting ``args.client`` and
+    ``args.all``:
+
+    * ``args.client == "list"`` → print detection matrix.
+    * ``args.all`` → patch every detected client.
+    * otherwise → patch the named client.
+
+    All paths share the ``--dry-run`` short-circuit: when the user
+    passed ``--dry-run`` we describe what we *would* do and exit 0
+    without touching disk.
+    """
+    if args.client == "list":
+        sys.exit(_print_list())
+
+    if args.all and args.client:
+        print(
+            "launch: --all is mutually exclusive with a client name",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+    if not args.all and not args.client:
+        print(
+            "launch: missing client name (or pass --all). "
+            "Try `rapid-mlx launch list` to see supported clients.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+    targets: list[str]
+    if args.all:
+        targets = [name for name, adapter in ADAPTERS.items() if adapter.detect()]
+        if not targets:
+            print(
+                "launch: no supported clients detected on this machine. "
+                "Run `rapid-mlx launch list` to see what's checked.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+    else:
+        if args.client not in ADAPTERS:
+            supported = ", ".join(ADAPTERS.keys())
+            print(
+                f"launch: unknown client {args.client!r}. "
+                f"Supported: {supported}.",
+                file=sys.stderr,
+            )
+            sys.exit(2)
+        targets = [args.client]
+
+    # Prefer the alias the user typed over the alias-resolved HF repo
+    # id. The top-level ``main()`` in ``vllm_mlx/cli.py`` rewrites
+    # ``args.model`` from e.g. ``qwen3.5-4b-4bit`` to
+    # ``mlx-community/Qwen3.5-4B-MLX-4bit`` before dispatching to us —
+    # but the IDE clients should request the short alias from
+    # rapid-mlx (the server's ``/v1/models`` advertises the alias, and
+    # request-side resolution accepts both), so we restore it here.
+    # Same pattern as ``share_command`` in ``vllm_mlx/share/cli.py``.
+    original_alias = getattr(args, "_original_alias", None)
+    model = original_alias or args.model or _resolve_default_model()
+    server_url = args.server_url
+
+    if args.dry_run:
+        print(f"[dry-run] model={model} server-url={server_url}")
+        for name in targets:
+            adapter = ADAPTERS[name]
+            path = adapter.current_config_path()
+            installed = adapter.detect()
+            print(
+                f"[dry-run] {name}: detected={installed} would-patch={path}"
+            )
+        if args.start_server:
+            print(
+                f"[dry-run] would spawn: rapid-mlx serve {model} --port {args.port}"
+            )
+        return
+
+    # Real patch path. Track per-client success so we can exit non-zero
+    # if any single client failed even when others succeeded — the user
+    # gets the partial-success line plus a final summary.
+    failures: list[str] = []
+    for name in targets:
+        adapter = ADAPTERS[name]
+        if not adapter.detect():
+            print(
+                f"  {name}: not detected on this machine — skipping. "
+                "Install the client first.",
+                file=sys.stderr,
+            )
+            failures.append(name)
+            continue
+        try:
+            path = adapter.write_or_patch_config(
+                server_url=server_url,
+                model=model,
+            )
+        except Exception as exc:
+            print(f"  {name}: FAILED — {exc}", file=sys.stderr)
+            failures.append(name)
+            continue
+        print(f"  Patched {name} config at {path}")
+
+    if args.start_server:
+        pid = _start_server_background(model, args.port)
+        print(
+            f"  Started: rapid-mlx serve {model} --port {args.port} (pid {pid})"
+        )
+        print(f"  PID file: {PID_FILE}")
+
+    succeeded = [n for n in targets if n not in failures]
+    if succeeded:
+        print(
+            "\nNow ready: open "
+            + " / ".join(succeeded)
+            + " and it'll route through rapid-mlx."
+        )
+    if failures:
+        sys.exit(1)
+
+
+def register(subparsers) -> None:
+    """Wire up the ``launch`` subcommand onto the top-level CLI parser.
+
+    Called from :mod:`vllm_mlx.cli` alongside the other
+    ``subparsers.add_parser(...)`` blocks. Keeping the wiring here (not
+    in ``cli.py``) means a future client-list change touches only this
+    module.
+    """
+    p = subparsers.add_parser(
+        "launch",
+        help="One-shot bootstrap: patch IDE/agent client config to use rapid-mlx",
+        description=(
+            "Detect an IDE client (Cline, Claude Code, Continue, Cursor) "
+            "and write/patch its local config to route at the local "
+            "rapid-mlx server. Use `rapid-mlx launch list` to see what's "
+            "supported on this machine."
+        ),
+    )
+    p.add_argument(
+        "client",
+        nargs="?",
+        default=None,
+        help=(
+            'Client to configure (or "list" to print the detection matrix). '
+            "Supported: " + ", ".join(ADAPTERS.keys()) + "."
+        ),
+    )
+    p.add_argument(
+        "--all",
+        action="store_true",
+        help="Patch every detected client. Mutually exclusive with a client name.",
+    )
+    p.add_argument(
+        "--model",
+        type=str,
+        default=None,
+        help=(
+            "Model alias the client will request from rapid-mlx "
+            "(default: $RAPID_MLX_DEFAULT_MODEL or qwen3.5-4b-4bit)."
+        ),
+    )
+    p.add_argument(
+        "--server-url",
+        type=str,
+        default="http://127.0.0.1:8000",
+        help="rapid-mlx server URL the client will route at (default: http://127.0.0.1:8000)",
+    )
+    p.add_argument(
+        "--port",
+        type=int,
+        default=8000,
+        help=(
+            "Port for --start-server (default: 8000). Ignored when "
+            "--start-server is not set."
+        ),
+    )
+    p.add_argument(
+        "--start-server",
+        action="store_true",
+        help=(
+            "Also spawn `rapid-mlx serve <model> --port <port>` in the "
+            "background, writing the pid to ~/.rapid-mlx/launch.pid."
+        ),
+    )
+    p.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print what would change without touching disk.",
+    )

--- a/vllm_mlx/launch/cli.py
+++ b/vllm_mlx/launch/cli.py
@@ -213,14 +213,22 @@ def launch_command(args: argparse.Namespace) -> None:
             continue
         print(f"  Patched {name} config at {path}")
 
-    if args.start_server:
-        pid = _start_server_background(model, args.port)
-        print(
-            f"  Started: rapid-mlx serve {model} --port {args.port} (pid {pid})"
-        )
-        print(f"  PID file: {PID_FILE}")
-
     succeeded = [n for n in targets if n not in failures]
+
+    if args.start_server:
+        if not succeeded:
+            print(
+                "  Skipping --start-server: no clients were patched. "
+                "Install a supported client first, then re-run.",
+                file=sys.stderr,
+            )
+        else:
+            pid = _start_server_background(model, args.port)
+            print(
+                f"  Started: rapid-mlx serve {model} --port {args.port} (pid {pid})"
+            )
+            print(f"  PID file: {PID_FILE}")
+
     if succeeded:
         print(
             "\nNow ready: open "
@@ -239,6 +247,14 @@ def register(subparsers) -> None:
     in ``cli.py``) means a future client-list change touches only this
     module.
     """
+    # Deferred import: ``vllm_mlx.cli`` imports us at module load to
+    # register the subcommand, so we cannot import from it at file scope
+    # without forming an import cycle. Reuse ``serve``'s ``[1, 65535]``
+    # port validator so `launch --port 99999` argparse-rejects up front
+    # instead of failing inside the detached child after the parent has
+    # already written a PID and printed "Started".
+    from ..cli import _port_arg
+
     p = subparsers.add_parser(
         "launch",
         help="One-shot bootstrap: patch IDE/agent client config to use rapid-mlx",
@@ -280,11 +296,11 @@ def register(subparsers) -> None:
     )
     p.add_argument(
         "--port",
-        type=int,
+        type=_port_arg,
         default=8000,
         help=(
-            "Port for --start-server (default: 8000). Ignored when "
-            "--start-server is not set."
+            "Port for --start-server (default: 8000). Must be in "
+            "[1, 65535]. Ignored when --start-server is not set."
         ),
     )
     p.add_argument(

--- a/vllm_mlx/launch/cli.py
+++ b/vllm_mlx/launch/cli.py
@@ -154,8 +154,7 @@ def launch_command(args: argparse.Namespace) -> None:
         if args.client not in ADAPTERS:
             supported = ", ".join(ADAPTERS.keys())
             print(
-                f"launch: unknown client {args.client!r}. "
-                f"Supported: {supported}.",
+                f"launch: unknown client {args.client!r}. Supported: {supported}.",
                 file=sys.stderr,
             )
             sys.exit(2)
@@ -179,13 +178,9 @@ def launch_command(args: argparse.Namespace) -> None:
             adapter = ADAPTERS[name]
             path = adapter.current_config_path()
             installed = adapter.detect()
-            print(
-                f"[dry-run] {name}: detected={installed} would-patch={path}"
-            )
+            print(f"[dry-run] {name}: detected={installed} would-patch={path}")
         if args.start_server:
-            print(
-                f"[dry-run] would spawn: rapid-mlx serve {model} --port {args.port}"
-            )
+            print(f"[dry-run] would spawn: rapid-mlx serve {model} --port {args.port}")
         return
 
     # Real patch path. Track per-client success so we can exit non-zero
@@ -224,9 +219,7 @@ def launch_command(args: argparse.Namespace) -> None:
             )
         else:
             pid = _start_server_background(model, args.port)
-            print(
-                f"  Started: rapid-mlx serve {model} --port {args.port} (pid {pid})"
-            )
+            print(f"  Started: rapid-mlx serve {model} --port {args.port} (pid {pid})")
             print(f"  PID file: {PID_FILE}")
 
     if succeeded:

--- a/vllm_mlx/launch/cline.py
+++ b/vllm_mlx/launch/cline.py
@@ -1,0 +1,147 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Cline (VS Code extension) launch adapter.
+
+Cline lives under VS Code's global storage as a single
+``cline_mcp_settings.json``. The relevant keys are the OpenAI-compatible
+provider settings — Cline routes traffic at ``openAiBaseUrl`` and
+authenticates with ``openAiApiKey`` when ``apiProvider`` is
+``"openai"``. Pointing those three at our local server is all that
+``rapid-mlx launch cline`` has to do.
+
+Cline's exact config schema has churned a few times across releases; we
+preserve every existing key and only touch the four we know we own,
+which means a config from a future Cline release still round-trips
+cleanly (the unknown keys come back out untouched on the next save).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from . import _common
+
+# VS Code extension id ("publisher.name"). Cline's stable id is
+# ``saoudrizwan.claude-dev`` (the project predates the rename to
+# "Cline" and the extension id never changed). The settings file
+# lives under VS Code's globalStorage tree for that extension.
+_EXTENSION_ID = "saoudrizwan.claude-dev"
+
+# The settings filename — same shape across VS Code Stable, Insiders,
+# and VSCodium. We probe all three install roots in priority order so a
+# user on VSCodium isn't penalised for not running upstream VS Code.
+_SETTINGS_FILENAME = "cline_mcp_settings.json"
+
+
+def _candidate_settings_roots() -> list[Path]:
+    """Per-OS list of VS Code (and forks') ``User/globalStorage`` roots.
+
+    Order is "most likely first" so :func:`current_config_path` returns
+    the canonical Stable path when multiple installs coexist. macOS
+    paths come first because that's the platform rapid-mlx targets
+    (Apple Silicon); Linux paths follow so CI / dev containers still
+    detect a configured Cline install.
+    """
+    home = Path.home()
+    return [
+        # macOS — VS Code Stable, Insiders, VSCodium.
+        home / "Library/Application Support/Code/User/globalStorage",
+        home / "Library/Application Support/Code - Insiders/User/globalStorage",
+        home / "Library/Application Support/VSCodium/User/globalStorage",
+        # Linux — same three flavours under ~/.config.
+        home / ".config/Code/User/globalStorage",
+        home / ".config/Code - Insiders/User/globalStorage",
+        home / ".config/VSCodium/User/globalStorage",
+    ]
+
+
+def detect() -> bool:
+    """Return True when a VS Code-family install has the Cline extension
+    materialised on disk.
+
+    We check for the per-extension ``globalStorage`` directory rather
+    than the editor binary alone — a user can have ``code`` on their
+    PATH without having installed Cline, in which case ``launch cline``
+    has nothing useful to do.
+    """
+    return current_config_path() is not None
+
+
+def current_config_path() -> Path | None:
+    """Return the canonical Cline settings path, or ``None`` if Cline
+    isn't installed.
+
+    "Installed" means *either*:
+
+    * the settings file already exists (Cline has been opened at least
+      once and wrote its initial config), OR
+    * the extension's ``globalStorage`` dir exists (Cline is installed
+      but hasn't created the MCP settings file yet — we'll create it).
+
+    If neither condition holds for any VS Code flavour, return None and
+    the launch dispatcher prints a "Cline not detected — install it
+    from the VS Code marketplace" hint.
+    """
+    for root in _candidate_settings_roots():
+        ext_dir = root / _EXTENSION_ID / "settings"
+        candidate = ext_dir / _SETTINGS_FILENAME
+        # Prefer a fully-materialised file. If the dir exists but the
+        # file doesn't, treat as installed-but-uninitialised and
+        # return the canonical path so we can create the file.
+        if candidate.exists():
+            return candidate
+        if ext_dir.exists():
+            return candidate
+    return None
+
+
+def write_or_patch_config(
+    server_url: str,
+    model: str,
+    api_key: str = "sk-noop",
+    config_path: Path | None = None,
+) -> Path:
+    """Patch Cline's ``cline_mcp_settings.json`` to route at the local
+    rapid-mlx OpenAI-compatible server.
+
+    Keys we own:
+
+    * ``apiProvider`` → ``"openai"``
+    * ``openAiBaseUrl`` → ``<server_url>/v1``
+    * ``openAiApiKey`` → ``<api_key>`` (default: ``"sk-noop"``,
+      since rapid-mlx defaults to no-auth on loopback)
+    * ``openAiModelId`` → ``<model>``
+
+    Every other key in the existing file is preserved verbatim — the
+    user's MCP tool list, custom instructions, ratelimit prefs all
+    survive a relaunch.
+
+    The ``config_path`` arg is a test/dry-run hook; production callers
+    let :func:`current_config_path` resolve it. Returns the path so the
+    CLI can print "✓ Patched Cline config at <path>".
+    """
+    path = config_path or current_config_path()
+    if path is None:
+        raise FileNotFoundError(
+            "Cline does not appear to be installed (no globalStorage dir found). "
+            "Install Cline from the VS Code marketplace and try again."
+        )
+
+    existing = _common.load_json_lenient(path)
+    _common.backup_existing(path)
+
+    # ``server_url`` may or may not include the ``/v1`` suffix — match
+    # what the user typed: if they said ``http://127.0.0.1:8000`` we
+    # add ``/v1`` (Cline expects an OpenAI-compatible *base* URL that
+    # ends in ``/v1``); if they already passed ``/v1`` we leave it
+    # alone. Avoids accidentally producing ``/v1/v1``.
+    base_url = server_url.rstrip("/")
+    if not base_url.endswith("/v1"):
+        base_url = base_url + "/v1"
+
+    existing["apiProvider"] = "openai"
+    existing["openAiBaseUrl"] = base_url
+    existing["openAiApiKey"] = api_key
+    existing["openAiModelId"] = model
+
+    _common.atomic_write_json(path, existing)
+    return path

--- a/vllm_mlx/launch/continue_dev.py
+++ b/vllm_mlx/launch/continue_dev.py
@@ -1,0 +1,121 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Continue.dev launch adapter.
+
+Continue.dev (VS Code and JetBrains extension) reads its config from
+``~/.continue/config.json``. The relevant shape is a list of model
+entries under the top-level ``models`` key, each one describing a
+provider + base URL + model id. Pointing one of those entries at
+``http://127.0.0.1:8000/v1`` is all that's required for Continue to
+route chat at the local rapid-mlx server.
+
+We append (rather than replace) the entry so a user with several
+Continue models configured keeps all of them — we just add one tagged
+``rapid-mlx`` and make it the default. On a re-run we de-dupe by name
+so we don't keep stacking copies.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from . import _common
+
+# Continue stores its config in ``~/.continue/`` (note: no XDG
+# normalisation — Continue picks the same path on all platforms).
+# Newer Continue versions also support ``config.yaml`` alongside
+# ``config.json``; we target the JSON variant because (a) it's the
+# default and (b) JSON round-trips cleanly without a YAML dep.
+_CONFIG_DIR = Path.home() / ".continue"
+_CONFIG_FILENAME = "config.json"
+
+# Name we use for the model entry we insert. A user who already has a
+# model named ``rapid-mlx`` on a re-run gets it updated in place rather
+# than duplicated.
+_MODEL_ENTRY_NAME = "rapid-mlx"
+
+
+def detect() -> bool:
+    """Return True when the Continue config dir exists.
+
+    Detection is deliberately permissive — a user might have installed
+    the extension but not opened it (no ``config.json`` yet) and we
+    still want ``rapid-mlx launch continue-dev`` to succeed by creating
+    the file. The minimum signal is the ``~/.continue/`` directory,
+    which Continue mkdir's on extension activation.
+    """
+    return _CONFIG_DIR.exists()
+
+
+def current_config_path() -> Path | None:
+    """Return ``~/.continue/config.json``.
+
+    Returns the path unconditionally (matching :mod:`claude_code`'s
+    behaviour) — if Continue isn't installed, the dispatcher prints a
+    "not detected" hint and the launch command exits non-zero, but the
+    path itself is well-defined.
+    """
+    return _CONFIG_DIR / _CONFIG_FILENAME
+
+
+def write_or_patch_config(
+    server_url: str,
+    model: str,
+    api_key: str = "sk-noop",
+    config_path: Path | None = None,
+) -> Path:
+    """Insert (or update) a ``rapid-mlx`` model entry in Continue's
+    config, then promote it to the default model.
+
+    Shape of the inserted entry:
+
+    .. code-block:: json
+
+       {
+         "title": "rapid-mlx",
+         "provider": "openai",
+         "model": "<model>",
+         "apiBase": "<server_url>/v1",
+         "apiKey": "<api_key>"
+       }
+
+    On a re-run, an existing entry with ``title == "rapid-mlx"`` is
+    overwritten in place (so the user's preserved index in the models
+    list stays stable) instead of being appended a second time.
+
+    All other model entries — and the rest of the Continue config —
+    are preserved verbatim.
+    """
+    path = config_path or current_config_path()
+    assert path is not None
+
+    existing = _common.load_json_lenient(path)
+    _common.backup_existing(path)
+
+    base_url = server_url.rstrip("/")
+    if not base_url.endswith("/v1"):
+        base_url = base_url + "/v1"
+
+    new_entry = {
+        "title": _MODEL_ENTRY_NAME,
+        "provider": "openai",
+        "model": model,
+        "apiBase": base_url,
+        "apiKey": api_key,
+    }
+
+    models = list(existing.get("models", []))
+    replaced = False
+    for i, entry in enumerate(models):
+        # ``entry`` may be a dict OR a string (Continue's older config
+        # format accepted a bare model id). We only know how to update
+        # dict entries; bare strings are left alone.
+        if isinstance(entry, dict) and entry.get("title") == _MODEL_ENTRY_NAME:
+            models[i] = new_entry
+            replaced = True
+            break
+    if not replaced:
+        models.append(new_entry)
+    existing["models"] = models
+
+    _common.atomic_write_json(path, existing)
+    return path

--- a/vllm_mlx/launch/cursor.py
+++ b/vllm_mlx/launch/cursor.py
@@ -22,9 +22,7 @@ from . import _common
 # Silicon-first; the rapid-mlx target platform) and Linux (a small but
 # growing fraction of Cursor users since the official Linux build
 # shipped). Windows isn't supported by rapid-mlx and so isn't probed.
-_CONFIG_DIR_MAC = (
-    Path.home() / "Library" / "Application Support" / "Cursor" / "User"
-)
+_CONFIG_DIR_MAC = Path.home() / "Library" / "Application Support" / "Cursor" / "User"
 _CONFIG_DIR_LINUX = Path.home() / ".config" / "Cursor" / "User"
 
 _SETTINGS_FILENAME = "settings.json"

--- a/vllm_mlx/launch/cursor.py
+++ b/vllm_mlx/launch/cursor.py
@@ -1,0 +1,118 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Cursor editor launch adapter.
+
+Cursor's "AI Settings" panel for OpenAI-compatible providers is fed via
+the standard VS Code-style ``settings.json``. The relevant keys are
+under the ``cursor.aiprovider.*`` namespace (the same family Cursor
+exposes for the OpenAI base-URL override in its settings UI).
+
+Cursor lives at slightly different paths than vanilla VS Code — its
+support dir is ``~/Library/Application Support/Cursor`` on macOS, NOT
+``Code``. The settings file shape (top-level dotted keys → string
+values) is identical.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from . import _common
+
+# Cursor's per-OS user settings dir. We probe both macOS (Apple
+# Silicon-first; the rapid-mlx target platform) and Linux (a small but
+# growing fraction of Cursor users since the official Linux build
+# shipped). Windows isn't supported by rapid-mlx and so isn't probed.
+_CONFIG_DIR_MAC = (
+    Path.home() / "Library" / "Application Support" / "Cursor" / "User"
+)
+_CONFIG_DIR_LINUX = Path.home() / ".config" / "Cursor" / "User"
+
+_SETTINGS_FILENAME = "settings.json"
+
+
+def _candidate_dirs() -> list[Path]:
+    """Per-OS Cursor user-settings dirs in priority order."""
+    return [_CONFIG_DIR_MAC, _CONFIG_DIR_LINUX]
+
+
+def detect() -> bool:
+    """Return True when Cursor appears to be installed.
+
+    Three signals — any one is sufficient:
+
+    * The ``Cursor.app`` bundle exists under ``/Applications`` or
+      ``~/Applications`` (macOS).
+    * The ``cursor`` CLI shim is on PATH (Cursor's "Install 'cursor'
+      command in PATH" action drops a shim that mirrors VS Code's
+      ``code`` command).
+    * The Cursor user-settings dir already exists (the editor has
+      been opened at least once).
+
+    Multi-signal detection avoids false negatives on Linux installs
+    where the ``.app`` bundle check doesn't apply.
+    """
+    if _common.mac_app_installed("Cursor"):
+        return True
+    if _common.which("cursor") is not None:
+        return True
+    return any(d.exists() for d in _candidate_dirs())
+
+
+def current_config_path() -> Path | None:
+    """Return Cursor's ``settings.json`` path.
+
+    Picks the macOS path if Cursor's macOS dir is present (or doesn't
+    exist on either OS — in which case the macOS canonical path is the
+    one we mkdir into, matching what Cursor would create on first
+    launch), otherwise falls back to the Linux path.
+    """
+    for d in _candidate_dirs():
+        if d.exists():
+            return d / _SETTINGS_FILENAME
+    # No existing Cursor dir — return the macOS canonical path as the
+    # creation target. detect() returns False in this case so the
+    # dispatcher prints a "Cursor not detected" message before we get
+    # here unless --force is in play (today: never).
+    return _CONFIG_DIR_MAC / _SETTINGS_FILENAME
+
+
+def write_or_patch_config(
+    server_url: str,
+    model: str,
+    api_key: str = "sk-noop",
+    config_path: Path | None = None,
+) -> Path:
+    """Patch Cursor's ``settings.json`` to point at the local rapid-mlx
+    OpenAI-compatible server.
+
+    Keys we own — Cursor reads dotted top-level keys exactly like VS
+    Code, so we set them as flat string keys (NOT a nested object):
+
+    * ``cursor.aiprovider.openai.baseUrl`` → ``<server_url>/v1``
+    * ``cursor.aiprovider.openai.apiKey`` → ``<api_key>``
+    * ``cursor.aiprovider.openai.model`` → ``<model>``
+
+    These keys mirror what the Cursor "OpenAI API" settings panel
+    writes when the user clicks through the UI. Pasted-in values from
+    that panel and values written here round-trip — Cursor doesn't
+    distinguish.
+
+    All other Cursor settings (theme, keybindings, every other dotted
+    key) round-trip untouched.
+    """
+    path = config_path or current_config_path()
+    assert path is not None
+
+    existing = _common.load_json_lenient(path)
+    _common.backup_existing(path)
+
+    base_url = server_url.rstrip("/")
+    if not base_url.endswith("/v1"):
+        base_url = base_url + "/v1"
+
+    existing["cursor.aiprovider.openai.baseUrl"] = base_url
+    existing["cursor.aiprovider.openai.apiKey"] = api_key
+    existing["cursor.aiprovider.openai.model"] = model
+
+    _common.atomic_write_json(path, existing)
+    return path


### PR DESCRIPTION
## Why

Every new user fumbles client config — three tabs of docs, paths to copy, JSON keys to type. One verb collapses it to a single command across the four most-asked-for IDE clients (Cline, Claude Code CLI, Continue.dev, Cursor). Closes #566, directly serves the goal axis "make rapid-mlx the most convenient inference engine to replace cloud LLMs".

## Surface

```
rapid-mlx launch list                  # detection matrix
rapid-mlx launch cline --model X       # patch one client
rapid-mlx launch --all --start-server  # patch every detected client + boot server
rapid-mlx launch <client> --dry-run    # describe, don't write
```

## Implementation

- Per-client adapter modules under `vllm_mlx/launch/` (`cline.py`, `claude_code.py`, `continue_dev.py`, `cursor.py`) each expose `detect()`, `current_config_path()`, `write_or_patch_config()`.
- Top-level dispatcher (`vllm_mlx/launch/cli.py`) routes through a single `ADAPTERS` registry.
- Every patch goes through an atomic write-temp + rename and backs the existing config up to `<path>.bak.<ts>` before touching it.
- Unknown keys in the file round-trip untouched (no key loss).
- `--start-server` spawns `rapid-mlx serve <model> --port <port>` detached (`start_new_session=True`) and writes the PID to `~/.rapid-mlx/launch.pid`.
- `_original_alias` carry-over so `--model qwen3.5-4b-4bit` writes the short alias into the client config rather than the resolved HF repo id.

## Tests

42 unit tests covering the four adapters, atomic-write helpers, dispatcher argv shapes (`list`/`--all`/unknown-client/missing-client/mutually-exclusive/`--dry-run`/`--start-server`), the `_original_alias` carry-over, and (added during codex r1) the start-server gating + port-range validation.

## Codex review

2 rounds to convergence (skip-security rule on diff finding):
- **r1 (11 findings)**: 2 actionable diff findings (MED start-server-when-no-patches, LOW port-validation) — fixed in `44b5663`. Holistic findings (HIGH: missing AGENTS.md / dual config sources / god files; MED: route → server private state coupling, env var sprawl, stale arch docs, weak mypy; LOW: flat test layout, cache artifacts in worktree) — out of scope for a feature PR, tracked as repo-wide refactor follow-ups.
- **r2 (8 findings)**: 1 diff finding (MED backup file permission widening) — security category, skipped per standing rule. 7 holistic findings — same scope-out as r1.

## Skip-version-bump

Adding `skip-version-bump` label — this is feature work, the version bump will be its own commit per release SOP (`auto-release.yml` matches `chore: bump version to X.Y.Z`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)