### PR TITLE
chore: bump version to 0.8.14

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.8.13"
+version = "0.8.14"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## Why this PR exists

Cuts **v0.8.14** to ship PR #860 + #868 + #869 to PyPI + Homebrew + the rapid-desktop bundled sidecar. v0.8.13 was tagged 2026-06-24 04:09Z; three landings have followed and need a release vehicle.

## What landed since v0.8.13

| PR | Squash | Severity | What |
|---|---|---|---|
| #860 | `dcf4f47b` | HIGH (regression) | `fix(chat): restore length-stop rescue stub for reasoning models (closes #858)`. PR #815 (v0.8.5) inadvertently flipped `_cutoff_notice_enabled()` from default-ON to default-OPT-IN, so `/v1/chat/completions` started returning `content: null` on length-stopped reasoning generations — GUI clients render empty bubbles. Filed via rapid-desktop v0.8.3 dogfood. Opt-out preserved via `RAPID_MLX_REASONING_CUTOFF_NOTICE=disabled`. |
| #868 | `661bc936` | docs | `docs(readme): document 0.8.13 audio support (TTS+STT, 26 aliases)`. README catches up to the audio surfaces shipped in v0.8.12 + v0.8.13. |
| #869 | `8c52b7a7` | HIGH (regression) | `fix(responses): exclude REASONING_CUTOFF_SENTINEL from downstream_output_seen (regression from #860)`. PR #860's default-on flip caused the chat helper to inject the sentinel into `message.content`, which the `openai_to_responses` adapter then treated as "real downstream output" — flipping `output[0].reasoning.status` from `incomplete` to `completed` on `/v1/responses` non-stream surface. Caught by `test_responses_budget_exhaust_streaming.py::TestStreamingNonStreamingParity::test_same_output_shape_under_cutoff` (PASSED at v0.8.13, FAILED on PR #860 HEAD). Fix moves sentinel literal to `vllm_mlx/api/constants.py` (preserves api/service layering) + adds 4 adapter-boundary regression pins. 3 codex rounds → converged. |

## Pre-release validation (all GREEN, on `chore/bump-0.8.14` after rebase onto main)

| Gate | Result |
|---|---|
| 1. `make release-smoke` (clean-room install+import) | **PASS** — 5/5 release surfaces import on PyPI-deps-only venv |
| 2. `ruff check vllm_mlx/ tests/` + `ruff format --check vllm_mlx/ tests/` | **PASS** — 0 errors, 536 files already formatted |
| 3. Codex review × 3 rounds on #869 + × 2 rounds on this PR | **converged** (0 BLOCKING + 0 MAJOR + 0 NIT each) |
| 4. `scripts/audit_cli_config_fidelity.py` | **PASS** — exit 0 |
| 5. Full pytest unit suite | **PASS** — 9206 passed, 21 skipped, 212 deselected, 6 xfailed in 124.73s |
| 6–10. Live boot + #858 e2e | **PASS** (verified before rebase, behaviour unchanged by #868 docs + #869 layering move): default env → `content="[truncated — reasoning incomplete; raise max_tokens]"`, finish_reason="length", reasoning_content non-empty; `RAPID_MLX_REASONING_CUTOFF_NOTICE=disabled` → `content=null` strict contract preserved. qwen3.5-4b-4bit port 11860. |
| 11. MLX-version-bump gate | **N/A** — `mlx` / `mlx-lm` / `mlx-vlm` / `mlx-metal` pins unchanged |
| 12. Auto-detection escape-hatch gate | **N/A** — no auto-routing change |

## Diff

```
 pyproject.toml | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
```

Pure version bump — every behaviour change is already on `main` via the merged PRs above.

## Test plan

- [x] release-smoke GREEN on rebased HEAD
- [x] Scoped ruff check + format GREEN (`vllm_mlx/` + `tests/`)
- [x] CLI/Config fidelity audit GREEN
- [x] Full unit pytest run GREEN (9206/9206)
- [x] #858 e2e default rescue stub + opt-out null both verified live
- [x] Adapter-boundary cross-path parity pin (#869) GREEN

## Post-merge follow-up (verified after tag push, tracked separately)

1. release.yml builds wheel + publishes to PyPI on `v0.8.14` tag push
2. Homebrew formula bump dispatched via `repository-dispatch` to `raullenchai/homebrew-rapid-mlx`
3. `pip install rapid-mlx==0.8.14` resolves on PyPI (~5min after publish)
4. rapid-desktop submodule bump 0.8.13 → 0.8.14 for desktop v0.8.4 cut

🤖 Generated with [Claude Code](https://claude.com/claude-code)
