### PR TITLE
fix(chat): always emit content key on assistant message (D-MISSING-CONTENT-KEY)

### DIFF
--- a/tests/test_api_models.py
+++ b/tests/test_api_models.py
@@ -789,24 +789,34 @@ class TestModelSerialization:
         data = schema.model_dump(by_alias=True)
         assert "schema" in data
 
-    # F-040 regression: ``content`` MUST always be present on the wire,
-    # even when the route serializes the response with ``exclude_none=True``
-    # and the underlying value is ``None`` (e.g. reasoning consumed the
-    # whole budget and we truncated mid-``<think>``). Standard OpenAI
-    # clients read ``resp["choices"][0]["message"]["content"]`` and crash
-    # with ``KeyError: 'content'`` if the field is missing.
+    # F-040 / D-MISSING-CONTENT-KEY regression: ``content`` MUST always
+    # be present on the wire, even when the route serializes the response
+    # with ``exclude_none=True`` and the underlying value is ``None``
+    # (e.g. reasoning consumed the whole budget and we truncated
+    # mid-``<think>``, or the model produced empty content +
+    # ``finish_reason=stop``). Standard OpenAI clients read
+    # ``resp["choices"][0]["message"]["content"]`` and crash with
+    # ``KeyError: 'content'`` if the field is missing. D-MISSING-CONTENT-KEY
+    # additionally enforces that the fill-in value is the empty string
+    # ``""`` (not ``null``) so the wire-level ``string`` type
+    # discriminator is preserved — Swift Codable / Rust serde decode
+    # cleanly into a non-Optional ``String``.
     def test_assistant_message_content_always_present_in_json(self):
-        """``content`` is REQUIRED in OpenAI's chat.completion schema (string|null)."""
+        """``content`` is REQUIRED in OpenAI's chat.completion schema (string|null|array)."""
         msg = AssistantMessage(
             content=None,
             reasoning_content="I was thinking but ran out of budget mid-thought.",
         )
         data = json.loads(msg.model_dump_json(exclude_none=True))
         assert "content" in data, (
-            "F-040: 'content' must always appear on the wire (OpenAI spec); "
-            "any standard SDK client crashes with KeyError otherwise."
+            "F-040 / D-MISSING-CONTENT-KEY: 'content' must always appear "
+            "on the wire (OpenAI spec); any standard SDK client crashes "
+            "with KeyError otherwise."
         )
-        assert data["content"] is None
+        # D-MISSING-CONTENT-KEY (r12-7): empty string, not null, so the
+        # wire ``string`` type discriminator survives strongly-typed
+        # decoders (Swift Codable, pydantic strict, Rust serde).
+        assert data["content"] == ""
         # r10-B R10-C2: only ``reasoning_content`` is emitted; the
         # deprecation-window ``reasoning`` alias (r7-A R7-H2) was the
         # byte-for-byte root cause of R9-CRIT3 (openai-agents
@@ -821,7 +831,8 @@ class TestModelSerialization:
         msg = AssistantMessage(content=None, reasoning_content="…")
         data = msg.model_dump(exclude_none=True)
         assert "content" in data
-        assert data["content"] is None
+        # D-MISSING-CONTENT-KEY: parity with the wire shape — ``""``.
+        assert data["content"] == ""
 
     def test_chat_completion_response_content_always_present(self):
         """Parent ``ChatCompletionResponse.model_dump_json(exclude_none=True)``
@@ -842,20 +853,67 @@ class TestModelSerialization:
         payload = json.loads(resp.model_dump_json(exclude_none=True))
         message = payload["choices"][0]["message"]
         assert "content" in message
-        assert message["content"] is None
+        # D-MISSING-CONTENT-KEY: ``""`` (preferred), not ``null``.
+        assert message["content"] == ""
         # Make sure we did not regress the role / reasoning shape.
         assert message["role"] == "assistant"
         assert message["reasoning_content"] == "Truncated mid-think."
 
-    def test_chunk_delta_terminal_with_reasoning_has_content_null(self):
-        """F-040 (streaming): the terminal chunk delta for a reasoning-only
-        finish must expose ``content: null`` so clients reading
-        ``chunk.choices[0].delta.content`` on the last chunk do not crash.
+    def test_assistant_message_empty_stop_emits_empty_content_key(self):
+        """D-MISSING-CONTENT-KEY (r12-7) reproducer: empty generation +
+        ``finish_reason="stop"`` — the OpenAI canonical shape REQUIRES
+        ``content`` to be present (Swift Codable, pydantic strict, Rust
+        serde all hard-fail on a missing required key). The serializer
+        emits ``content: ""`` (preferred over ``null``)."""
+        resp = ChatCompletionResponse(
+            model="granite4-h-micro-4bit",
+            choices=[
+                ChatCompletionChoice(
+                    message=AssistantMessage(content=None),
+                    finish_reason="stop",
+                )
+            ],
+        )
+        payload = json.loads(resp.model_dump_json(exclude_none=True))
+        message = payload["choices"][0]["message"]
+        assert "content" in message, (
+            "D-MISSING-CONTENT-KEY: empty completion + stop MUST still "
+            "carry the ``content`` key (regression of 0.8TODO r12-7)."
+        )
+        assert message["content"] == ""
+        assert message["role"] == "assistant"
+        # No reasoning, no tool_calls — exact wire shape is the
+        # canonical "{role,content}" doublet.
+        assert set(message.keys()) == {"role", "content"}
+
+    def test_assistant_message_tool_calls_only_emits_empty_content(self):
+        """D-MISSING-CONTENT-KEY (r12-7): tool-call-only assistant
+        messages serialize as ``{role,tool_calls,content:""}`` — the
+        canonical OpenAI tool-call envelope. Without the explicit
+        ``content`` key strict clients reject the message shape."""
+        tc = ToolCall(
+            id="call_1",
+            type="function",
+            function={"name": "get_weather", "arguments": "{}"},
+        )
+        msg = AssistantMessage(content=None, tool_calls=[tc])
+        data = json.loads(msg.model_dump_json(exclude_none=True))
+        assert "content" in data
+        assert data["content"] == ""
+        assert data["tool_calls"][0]["id"] == "call_1"
+        assert data["role"] == "assistant"
+
+    def test_chunk_delta_terminal_with_reasoning_has_content_empty(self):
+        """F-040 / D-MISSING-CONTENT-KEY (streaming): the terminal chunk
+        delta for a reasoning-only finish must expose ``content: ""``
+        so clients reading ``chunk.choices[0].delta.content`` on the
+        last chunk do not crash.
         """
         delta = ChatCompletionChunkDelta(reasoning_content="…", content=None)
         data = json.loads(delta.model_dump_json(exclude_none=True))
         assert "content" in data
-        assert data["content"] is None
+        # D-MISSING-CONTENT-KEY: parity with the non-stream surface.
+        assert data["content"] == ""
 
     def test_chunk_delta_pure_content_stays_lean(self):
         """Per-token content-only deltas keep their minimal shape — we do

--- a/tests/test_responses_adapter.py
+++ b/tests/test_responses_adapter.py
@@ -745,6 +745,7 @@ def _chat_response(
     *,
     text: str | None = "",
     tool_calls: list[ToolCall] | None = None,
+    reasoning_content: str | None = None,
     finish_reason: str = "stop",
     prompt_tokens: int = 10,
     completion_tokens: int = 5,
@@ -761,7 +762,11 @@ def _chat_response(
         model="test-model",
         choices=[
             ChatCompletionChoice(
-                message=AssistantMessage(content=text, tool_calls=tool_calls),
+                message=AssistantMessage(
+                    content=text,
+                    tool_calls=tool_calls,
+                    reasoning_content=reasoning_content,
+                ),
                 finish_reason=finish_reason,
             )
         ],
@@ -806,6 +811,51 @@ class TestOpenaiToResponses:
         )
         assert len(resp.output) == 1
         assert resp.output[0].type == "function_call"
+
+    def test_empty_stop_emits_empty_message_item(self):
+        """D-MISSING-CONTENT-KEY (r12-7): an empty completion +
+        ``finish_reason="stop"`` (granite4-h-micro repro: "Reply with
+        only the letter A." + ``max_tokens=3``, model emits nothing
+        visible) MUST still surface a well-formed ``message`` item with
+        ``content: [{type:"output_text", text:""}]`` so /v1/responses
+        callers walking ``output[i].content[0].text`` keep their happy
+        path. Pre-fix the ``output`` array was empty and clients
+        crashed with IndexError / KeyError."""
+        chat_resp = _chat_response(text=None, finish_reason="stop")
+        resp = openai_to_responses(
+            chat_resp, model="granite4-h-micro-4bit", request=_bare_request(), created_at=0
+        )
+        assert len(resp.output) == 1, (
+            "D-MISSING-CONTENT-KEY: empty stop must surface an assistant "
+            "message item, not an empty output array."
+        )
+        item = resp.output[0]
+        assert item.type == "message"
+        assert item.role == "assistant"
+        assert item.content is not None and len(item.content) == 1
+        assert item.content[0].type == "output_text"
+        assert item.content[0].text == ""
+
+    def test_reasoning_only_does_not_emit_empty_message_item(self):
+        """D-MISSING-CONTENT-KEY (r12-7): a reasoning-only turn (closed
+        thought block, no answer text) keeps the OpenAI-spec shape —
+        only the ``reasoning`` item is emitted; no empty message item
+        is synthesized. The reasoning item itself represents the
+        assistant's structured signal for this turn."""
+        chat_resp = _chat_response(
+            text=None,
+            reasoning_content="Let me think... 17 * 23 =",
+            finish_reason="stop",
+        )
+        resp = openai_to_responses(
+            chat_resp, model="reasoning-model", request=_bare_request(), created_at=0
+        )
+        types = [item.type for item in resp.output]
+        # Only reasoning, no synthesized empty message item.
+        assert types == ["reasoning"], (
+            "D-MISSING-CONTENT-KEY: reasoning-only turn must NOT "
+            f"synthesize an empty message item; got output types {types!r}."
+        )
 
     def test_text_then_tool_call_ordering(self):
         chat_resp = _chat_response(

--- a/tests/test_responses_adapter.py
+++ b/tests/test_responses_adapter.py
@@ -823,7 +823,10 @@ class TestOpenaiToResponses:
         crashed with IndexError / KeyError."""
         chat_resp = _chat_response(text=None, finish_reason="stop")
         resp = openai_to_responses(
-            chat_resp, model="granite4-h-micro-4bit", request=_bare_request(), created_at=0
+            chat_resp,
+            model="granite4-h-micro-4bit",
+            request=_bare_request(),
+            created_at=0,
         )
         assert len(resp.output) == 1, (
             "D-MISSING-CONTENT-KEY: empty stop must surface an assistant "

--- a/tests/test_silent_drop_rescue_569.py
+++ b/tests/test_silent_drop_rescue_569.py
@@ -686,25 +686,30 @@ def test_streaming_rescue_noop_when_reasoning_is_whitespace_only():
         # the list is empty; any non-null emission at all
         # (whitespace, empty string, real text) is a regression.
         #
-        # F-040: ``content: null`` is now an INTENTIONAL part of the
+        # F-040 / D-MISSING-CONTENT-KEY: ``content: ""`` (and prior
+        # ``content: null``) is now an INTENTIONAL part of the
         # streaming shape on reasoning-only deltas (so clients reading
         # ``delta.content`` on the terminal chunk don't crash with a
         # KeyError). The original test caught any presence of the
         # ``content`` key including ``None``; we tighten the check to
-        # only flag actual *promotions* (a non-null value), which is
-        # the regression we care about here.
+        # only flag actual *promotions* (a non-null, non-empty value
+        # — i.e. real promoted text), which is the regression we
+        # care about here. D-MISSING-CONTENT-KEY flipped the
+        # placeholder from ``null`` to ``""`` for strongly-typed
+        # client parity, so we also filter out empty strings here.
         content_values = [
             (choice.get("delta") or {}).get("content")
             for ev in events
             for choice in ev.get("choices", [])
             if "content" in (choice.get("delta") or {})
             and (choice.get("delta") or {}).get("content") is not None
+            and (choice.get("delta") or {}).get("content") != ""
         ]
         assert content_values == [], (
             "#676 round-4 BLOCKING (streaming): whitespace-only "
             "accumulated reasoning must NOT promote to delta.content "
-            "on any SSE chunk; expected zero non-null content emissions "
-            f"but got {content_values!r}"
+            "on any SSE chunk; expected zero non-empty content "
+            f"promotions but got {content_values!r}"
         )
     finally:
         reset_config()

--- a/tests/test_silent_drop_rescue_569.py
+++ b/tests/test_silent_drop_rescue_569.py
@@ -674,29 +674,32 @@ def test_streaming_rescue_noop_when_reasoning_is_whitespace_only():
         events = _parse_sse(resp.text)
         assert events, "expected at least one SSE chunk"
 
-        # Codex round-4 BLOCKING on #676: collect EVERY non-null
+        # Codex round-4 BLOCKING on #676: collect EVERY promoted
         # ``delta.content`` value without stripping, so an
         # incorrectly-emitted whitespace-only payload (``"   \n\t  "``)
         # is caught instead of being silently coerced to empty by
         # ``.strip()``. Pre-fix this assertion was
         # ``not streamed_content.strip()``, which would still pass
         # under the exact regression we're guarding against — a
-        # self-defeating test. The new shape lists every raw
+        # self-defeating test. The new shape lists every PROMOTED
         # ``delta.content`` value emitted on any chunk and asserts
-        # the list is empty; any non-null emission at all
-        # (whitespace, empty string, real text) is a regression.
+        # the list is empty; any non-empty, non-null emission
+        # (whitespace, real text) is a regression.
         #
         # F-040 / D-MISSING-CONTENT-KEY: ``content: ""`` (and prior
         # ``content: null``) is now an INTENTIONAL part of the
-        # streaming shape on reasoning-only deltas (so clients reading
-        # ``delta.content`` on the terminal chunk don't crash with a
-        # KeyError). The original test caught any presence of the
-        # ``content`` key including ``None``; we tighten the check to
-        # only flag actual *promotions* (a non-null, non-empty value
-        # — i.e. real promoted text), which is the regression we
-        # care about here. D-MISSING-CONTENT-KEY flipped the
-        # placeholder from ``null`` to ``""`` for strongly-typed
-        # client parity, so we also filter out empty strings here.
+        # streaming shape on reasoning-only / tool-call-only deltas
+        # (so clients reading ``delta.content`` on the terminal chunk
+        # don't crash with a KeyError). The original test caught any
+        # presence of the ``content`` key including ``None``; we
+        # tighten the check to only flag actual *promotions* (a
+        # non-null AND non-empty value — i.e. real promoted text),
+        # which is the regression we care about here.
+        # D-MISSING-CONTENT-KEY flipped the placeholder from ``null``
+        # to ``""`` for strongly-typed client parity (Swift Codable /
+        # Rust serde / pydantic strict decode cleanly into a
+        # non-Optional ``String``), so the filter below also drops
+        # ``""`` alongside ``None``.
         content_values = [
             (choice.get("delta") or {}).get("content")
             for ev in events

--- a/vllm_mlx/api/models.py
+++ b/vllm_mlx/api/models.py
@@ -1914,16 +1914,37 @@ class AssistantMessage(BaseModel):
         """Always emit ``content`` on the wire.
 
         Per OpenAI's ``chat.completion`` schema, ``message.content`` is a
-        REQUIRED field that is ``string`` or ``null`` — never absent. When
-        a reasoning model truncates inside ``<think>`` the parser yields
-        ``content=None`` and our callers serialize the response with
-        ``model_dump_json(exclude_none=True)``; pydantic then drops the
-        ``content`` key entirely and clients that read
-        ``resp["choices"][0]["message"]["content"]`` (the standard
-        OpenAI SDK pattern) crash with ``KeyError: 'content'``. This
-        wrap-mode serializer runs AFTER ``exclude_none`` pruning, so we
-        can put the field back as an explicit ``None`` (→ JSON ``null``)
-        regardless of how the parent was dumped.
+        REQUIRED field — never absent. When a reasoning model truncates
+        inside ``<think>`` or extract-tool-calls drains the visible text
+        away the parser yields ``content=None`` and our callers serialize
+        the response with ``model_dump_json(exclude_none=True)``; pydantic
+        then drops the ``content`` key entirely and strongly-typed
+        clients crash:
+
+        * **Swift Codable**: ``decoder.container(keyedBy:)`` fails on
+          missing required keys.
+        * **Python pydantic** with ``extra="forbid"`` or ``content: str``
+          on a strict response model.
+        * **Rust serde**: a non-``Option`` field decode is a hard error.
+        * **openai-python SDK**: ``resp.choices[0].message.content`` walks
+          a Python dataclass that expects the key to be addressable.
+
+        This wrap-mode serializer runs AFTER ``exclude_none`` pruning so
+        we can put the field back regardless of how the parent was
+        dumped.
+
+        D-MISSING-CONTENT-KEY (r12-7, 0.8.14): switched the
+        fill-in value from ``None`` (→ JSON ``null``) to the empty
+        string ``""``. Both are spec-legal per the OpenAI canonical
+        shape (``content: "" | string | null | array``), but ``""`` is
+        what OpenAI's production API actually returns for the
+        finish_reason="stop" + empty-completion case AND it preserves
+        the wire-level ``string`` type discriminator so Swift Codable
+        decodes cleanly into ``String`` (a ``null`` would force
+        callers to model the field as ``String?``). Tool-call-only
+        assistant messages now also serialize as
+        ``{"role":"assistant","tool_calls":[...],"content":""}`` —
+        same canonical shape OpenAI emits for tool-call turns.
 
         r10-B R10-C2 — emit ONLY ``reasoning_content``. r7-A R7-H2
         had additionally surfaced a duplicate ``reasoning`` alias as a
@@ -1935,9 +1956,12 @@ class AssistantMessage(BaseModel):
         ``reasoning`` key on chat-completion messages.
         """
         d = handler(self)
-        # OpenAI contract: ``content`` is always present (string|null).
+        # OpenAI contract: ``content`` is always present. Prefer ``""``
+        # over ``null`` per D-MISSING-CONTENT-KEY (matches OpenAI's
+        # production envelope; null is spec-legal but less common and
+        # forces strongly-typed clients into an Optional/Nullable shape).
         if "content" not in d:
-            d["content"] = None
+            d["content"] = ""
         return d
 
     def model_dump(self, **kwargs) -> dict:
@@ -1952,8 +1976,10 @@ class AssistantMessage(BaseModel):
         d = super().model_dump(**kwargs)
         # Belt-and-braces: ensure ``content`` is always present, matching
         # the OpenAI-spec invariant enforced by the wrap-mode serializer.
+        # D-MISSING-CONTENT-KEY: prefer ``""`` over ``None`` so the
+        # dict view matches the wire view (string type discriminator).
         if "content" not in d:
-            d["content"] = None
+            d["content"] = ""
         return d
 
 
@@ -2717,13 +2743,23 @@ class ChatCompletionChunkDelta(BaseModel):
         terminal chunk (the standard OpenAI SDK pattern; see the
         non-stream counterpart on ``AssistantMessage``).
 
-        Mirror the OpenAI on-the-wire shape: surface ``content: null``
+        Mirror the OpenAI on-the-wire shape: surface ``content: ""``
         on any delta that carries ``reasoning_content`` (or
         ``tool_calls``) but no visible content, so the field is
         addressable on every reasoning-bearing delta — including the
         final one. Normal pure-content / pure-role / empty deltas keep
         their current minimal shape, so the per-token streaming budget
         is unchanged for non-reasoning paths.
+
+        D-MISSING-CONTENT-KEY (r12-7, 0.8.14): the fill-in value was
+        flipped from ``None`` to ``""`` for parity with the
+        non-streaming ``AssistantMessage`` serializer. When the
+        OpenAI streaming SDK reduces deltas into a final-state
+        message (the canonical ``ChatCompletion`` aggregator pattern),
+        the resulting ``message.content`` is a string, not a
+        sometimes-None sometimes-string union — so strongly-typed
+        Swift / Rust clients decoding the aggregated message keep
+        their happy path.
 
         r10-B R10-C2 — emit ONLY ``reasoning_content`` on the wire.
         r7-A R7-H2 had also emitted a duplicate ``reasoning`` alias
@@ -2736,7 +2772,7 @@ class ChatCompletionChunkDelta(BaseModel):
         """
         d = handler(self)
         if "content" not in d and ("reasoning_content" in d or "tool_calls" in d):
-            d["content"] = None
+            d["content"] = ""
         return d
 
 

--- a/vllm_mlx/api/responses_adapter.py
+++ b/vllm_mlx/api/responses_adapter.py
@@ -523,7 +523,29 @@ def openai_to_responses(
             )
 
         text = choice.message.content or ""
-        if text:
+        # D-MISSING-CONTENT-KEY (r12-7): emit the assistant message
+        # item whenever the turn produced ANY visible text-side signal
+        # (non-empty content) OR there is NO other structured output
+        # (no reasoning, no tool_calls) representing the assistant's
+        # reply. The empty-completion + ``finish_reason=stop`` case
+        # (granite4-h-micro repro) lands here: pre-fix the entire
+        # ``output`` array was empty so /v1/responses callers walking
+        # ``output[i].content[0].text`` crashed on an out-of-bounds
+        # index; post-fix a single ``message`` item with
+        # ``content:[{type:"output_text",text:""}]`` is emitted so the
+        # canonical shape walker stays addressable.
+        #
+        # Reasoning-only turns (closed thought → no answer) keep their
+        # OpenAI-spec shape: only the ``reasoning`` item is emitted,
+        # no empty message item. Tool-call-only turns likewise keep
+        # their ``function_call``/``computer_call`` items as the
+        # primary signal — the empty message item is only added when
+        # NEITHER reasoning NOR tool_calls represent the assistant's
+        # reply.
+        has_tool_calls = bool(choice.message.tool_calls)
+        has_reasoning = bool(reasoning_text)
+        emit_message_item = bool(text) or not (has_tool_calls or has_reasoning)
+        if emit_message_item:
             output.append(
                 ResponsesOutputItem(
                     type="message",


### PR DESCRIPTION
## Why

OpenAI ``/v1/chat/completions`` was OMITTING the ``content`` key entirely (not ``null``, not ``\"\"``) on assistant messages with empty completion + ``finish_reason=stop``. Strongly-typed clients hard-fail on a missing required key:

* **Swift Codable** — ``decoder.container(keyedBy:)`` errors on missing keys
* **Python pydantic** with ``extra=\"forbid\"`` or ``content: str`` on a strict response model
* **Rust serde** — non-``Option`` field decode is an error
* **openai-python SDK** — walks a dataclass that expects ``content`` to be addressable

The OpenAI canonical shape is ``content: \"\" | string | null | array``; the KEY must be present (D-MISSING-CONTENT-KEY in 0.8TODO r12-7). The 0.8TODO repro is ``granite4-h-micro-4bit`` + ``\"Reply with only the letter A.\"`` + ``max_tokens=3`` — pre-fix wire-emit was ``{\"role\":\"assistant\"}`` with no ``content`` key.

## What changed

1. **``AssistantMessage._serialize_assistant_message``** (non-stream chat) — the existing F-040 wrap-mode serializer was already filling the always-present ``content`` slot but with ``None`` (→ JSON ``null``). Flipped to ``\"\"``: both are spec-legal but ``\"\"`` matches OpenAI's production envelope AND preserves the wire-level ``string`` type discriminator (Swift ``String``, Rust ``String``, pydantic ``content: str`` decode cleanly without an Optional/Nullable shape).

2. **``ChatCompletionChunkDelta._serialize_chunk_delta``** (streaming) — same flip, so the canonical OpenAI streaming SDK aggregator (which reduces deltas into a final-state message) yields ``message.content: \"\"`` not ``message.content: None`` on reasoning-only / tool-call-only finishes.

3. **``openai_to_responses``** (/v1/responses non-stream) — widened the message-item emit gate. Pre-fix an empty completion + ``finish_reason=stop`` with no reasoning / no tool_calls produced an EMPTY ``output`` array, so SDK consumers walking ``output[i].content[0].text`` crashed with IndexError. Post-fix a single ``message`` item with ``content:[{type:\"output_text\",text:\"\"}]`` is emitted. Reasoning-only / tool-call-only turns are unchanged (the reasoning / function_call items represent the assistant's reply for those turns).

The Anthropic ``/v1/messages`` surface was already emitting ``content: []`` on empty turns (pydantic ``list[Block]`` field, no exclude_none drop), so no fix is needed there.

## Before / after

Live server on port 8106, ``RAPID_MLX_REASONING_CUTOFF_NOTICE=disabled`` to expose the strict empty path:

```diff
 \"choices\": [{
   \"index\": 0,
   \"message\": {
     \"role\": \"assistant\",
     \"reasoning_content\": \"Okay\",
-    \"content\": null
+    \"content\": \"\"
   },
   \"finish_reason\": \"length\"
 }]
```

Streaming terminal chunk (same prompt, ``stream=true``):

```diff
 \"delta\": {
   \"reasoning_content\": \"Okay\",
-  \"content\": null
+  \"content\": \"\"
 },
 \"finish_reason\": \"length\"
```

## Test plan

- [x] ``tests/test_api_models.py`` — empty stop, tool-call-only, reasoning-only mid-think cutoff (all pin ``content == \"\"``)
- [x] ``tests/test_responses_adapter.py`` — empty stop emits 1 message item with ``text=\"\"``; reasoning-only does NOT synthesize an empty message item; tool-call-only still skips the message item
- [x] ``tests/test_silent_drop_rescue_569.py`` — #676 whitespace-rescue test updated to filter ``\"\"`` alongside ``None`` (the regression we guard against is non-empty whitespace promotion, not the new placeholder)
- [x] Live server: before / after snapshots saved to ``/tmp/r12-7-probe/{before,after}.json``
- [x] Codex review converged at round 2 (1 NIT in r1, addressed in 59fbe66; 0 findings in r2)

## Coordination

- r12-6 (D-SSE-USAGE) touches ``routes/chat.py`` streaming chunk-build site — no overlap with this PR (which only touches ``vllm_mlx/api/models.py`` serializers + ``responses_adapter.py``).
- r12-8 (H-01) may touch the same ``AssistantMessage`` shape if it picks the \"mirror reasoning_content tail into content\" rescue option. This PR is a strict superset: it just guarantees the key exists with ``\"\"`` placeholder; H-01's content-rescue logic (if landed) writes a real string there instead, which is wire-compatible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)