### PR TITLE
fix(reasoning): rescue tail to content on finish_reason=length (H-01, closes 8-round D-carry #259)

### DIFF
--- a/tests/test_no_out_of_band_routing.py
+++ b/tests/test_no_out_of_band_routing.py
@@ -256,21 +256,28 @@ ALLOWED_RAPID_MLX_ENV_VARS: frozenset[str] = frozenset(
         "RAPID_MLX_CORS_ALLOW_HEADERS",
         "RAPID_MLX_CORS_MAX_AGE",
         "RAPID_MLX_CORS_ALLOW_CREDENTIALS",
-        # Cutoff sentinel opt-OUT (issue #858, restoring PR #802 /
-        # H-01 semantics after the R-01 (#815) opt-in flip caused
-        # empty-bubble regressions in GUI clients). Pure UX knob —
-        # default ON so clients that render only ``message.content``
+        # Reasoning-cutoff RESCUE opt-OUT (R12-8 / issue #259, the
+        # 8-round D-carry that extended PR #802 / #860 from a bare
+        # sentinel to ``sentinel + tail-of-reasoning``). Pure UX knob
+        # — default ON so clients that render only ``message.content``
         # see the literal cue ``[truncated — reasoning incomplete;
-        # raise max_tokens]`` on length-cut mid-think. Power callers
-        # that want the strict-null shape (relying on the structured
-        # ``finish_reason="length"`` / ``status="incomplete"`` /
-        # ``stop_reason="max_tokens"`` cue alone) opt out via
-        # ``RAPID_MLX_REASONING_CUTOFF_NOTICE=disabled`` (or
-        # ``0`` / ``false`` / ``no`` / ``off``). Never selects a
-        # model, parser, or routing tier; consumed only by
+        # raise max_tokens]`` PLUS the last ``RESCUE_TAIL_LENGTH``
+        # chars of the reasoning trace on length-cut mid-think. Power
+        # callers that want the strict-null shape (relying on the
+        # structured ``finish_reason="length"`` / ``status="incomplete"``
+        # / ``stop_reason="max_tokens"`` cue alone) opt out via
+        # ``RAPID_MLX_REASONING_RESCUE=off`` (or ``0`` / ``false`` /
+        # ``no`` / ``disabled``). Never selects a model, parser, or
+        # routing tier; consumed only by
         # ``vllm_mlx.service.helpers._cutoff_notice_enabled`` to decide
-        # whether the sentinel notice is surfaced. See PR
-        # fix/length-stop-rescue-stub-858.
+        # whether the rescue payload is surfaced. See PR
+        # fix/r12-8-reasoning-content-rescue.
+        "RAPID_MLX_REASONING_RESCUE",
+        # Legacy alias for the rescue opt-out (PR #802 / #860 / issue
+        # #858, pre-R12-8). Still honoured so existing rapid-desktop
+        # deployments and operator runbooks that already reference this
+        # name keep working without a rebuild. Identical semantics +
+        # call-site to ``RAPID_MLX_REASONING_RESCUE``.
         "RAPID_MLX_REASONING_CUTOFF_NOTICE",
         # F-K-CAPABILITIES-OMIT-AUDIO opt-in deep audio probe (boolean
         # flag). When set to a truthy value, the lifespan hook runs a

--- a/tests/test_reasoning_content_null_rescue.py
+++ b/tests/test_reasoning_content_null_rescue.py
@@ -558,6 +558,78 @@ class TestR12_8RescuePayloadShape:
             f"all-markup tail must degrade to bare sentinel; got {result!r}"
         )
 
+    @pytest.mark.parametrize(
+        "real_content,description",
+        [
+            (
+                "[truncated — reasoning incomplete; raise max_tokens] is the "
+                "literal text the server uses for the rescue.",
+                "model echoes sentinel inline as part of an explanation",
+            ),
+            (
+                "[truncated — reasoning incomplete; raise max_tokens] - see "
+                "docs for opt-out.",
+                "model echoes sentinel followed by a space-then-dash, NOT \\n\\n",
+            ),
+            (
+                "[truncated — reasoning incomplete; raise max_tokens]extra",
+                "sentinel immediately followed by non-whitespace (no separator)",
+            ),
+        ],
+    )
+    def test_rescue_shape_gate_does_not_misclassify_legitimate_content(
+        self, real_content, description
+    ):
+        """Codex pr_validate r1 (R12-8): the rescue-detection gate must
+        be tighter than ``startswith(SENTINEL)``. A legitimate model
+        response that starts with the sentinel literal but is NOT in
+        the rescue shape (bare sentinel OR ``sentinel + \\n\\n + tail``)
+        must NOT be misclassified as a synthetic rescue payload.
+        ``is_rescue_payload`` returns False for these false-positives.
+        """
+        from vllm_mlx.api.constants import is_rescue_payload
+
+        assert is_rescue_payload(real_content) is False, (
+            f"{description}: should NOT be classified as rescue; "
+            f"got is_rescue_payload({real_content!r})=True"
+        )
+
+    @pytest.mark.parametrize(
+        "rescue_content,description",
+        [
+            (
+                "[truncated — reasoning incomplete; raise max_tokens]",
+                "bare sentinel (sanitizer stripped the tail)",
+            ),
+            (
+                "[truncated — reasoning incomplete; raise max_tokens]\n\nsome tail",
+                "sentinel + \\n\\n + non-empty tail (normal rescue shape)",
+            ),
+        ],
+    )
+    def test_rescue_shape_gate_recognizes_real_rescue_payloads(
+        self, rescue_content, description
+    ):
+        """Both rescue-payload shapes produced by
+        ``_build_reasoning_rescue_payload`` MUST be recognized by
+        ``is_rescue_payload`` so the non-stream Responses adapter
+        correctly excludes them from ``downstream_output_seen``."""
+        from vllm_mlx.api.constants import is_rescue_payload
+
+        assert is_rescue_payload(rescue_content) is True, (
+            f"{description}: should be classified as rescue; "
+            f"got is_rescue_payload({rescue_content!r})=False"
+        )
+
+    def test_rescue_shape_gate_handles_none_and_empty(self):
+        """``is_rescue_payload(None)`` and ``is_rescue_payload("")`` MUST
+        return False — the rescue helper always returns at least the
+        sentinel, so an empty/None content is never a rescue."""
+        from vllm_mlx.api.constants import is_rescue_payload
+
+        assert is_rescue_payload(None) is False
+        assert is_rescue_payload("") is False
+
 
 class TestR12_8RescueEnvVar:
     """R12-8 / issue #259: the primary env var is

--- a/tests/test_reasoning_content_null_rescue.py
+++ b/tests/test_reasoning_content_null_rescue.py
@@ -42,9 +42,37 @@ import pytest
 
 from vllm_mlx.service.helpers import (
     REASONING_CUTOFF_SENTINEL,
+    RESCUE_TAIL_LENGTH,
     _apply_reasoning_cutoff_notice,
     _rescue_silent_drop_from_reasoning,
 )
+
+
+def _assert_is_rescue(
+    result: str | None, reasoning_text: str, *, msg: str = ""
+) -> None:
+    """R12-8: the rescue payload is ``sentinel + "\\n\\n" + tail``.
+
+    Centralised here so every assertion in this file pins the same
+    contract — the sentinel anchors the opening (pattern-matchable
+    by agentic auto-retry) and the trailing ``RESCUE_TAIL_LENGTH``
+    chars of ``reasoning_text`` give a human reader a glimpse of the
+    partial conclusion. This shape replaces the pre-R12-8 bare
+    sentinel return — see ``_build_reasoning_rescue_payload``.
+    """
+    assert result is not None, f"rescue must fire: {msg}"
+    assert result.startswith(REASONING_CUTOFF_SENTINEL), (
+        f"rescue must open with the literal sentinel; got {result!r}: {msg}"
+    )
+    expected_tail = reasoning_text.rstrip()[-RESCUE_TAIL_LENGTH:]
+    assert result.endswith(expected_tail), (
+        f"rescue must end with last {RESCUE_TAIL_LENGTH} chars of "
+        f"reasoning; expected tail {expected_tail!r}, got {result!r}: {msg}"
+    )
+    assert "\n\n" in result, (
+        f"rescue must separate sentinel from tail with a blank line; got {result!r}: {msg}"
+    )
+
 
 # ──────────────────────────────────────────────────────────────────────
 # Unit tests for the helper itself
@@ -89,15 +117,19 @@ class TestApplyReasoningCutoffNotice:
         back to PR #802 (H-01) semantics: default ON, opt-out via
         ``RAPID_MLX_REASONING_CUTOFF_NOTICE=disabled``."""
         monkeypatch.delenv("RAPID_MLX_REASONING_CUTOFF_NOTICE", raising=False)
+        monkeypatch.delenv("RAPID_MLX_REASONING_RESCUE", raising=False)
+        reasoning = "<incomplete thought>"
         result = _apply_reasoning_cutoff_notice(
             final_content=None,
-            reasoning_text="<incomplete thought>",
+            reasoning_text=reasoning,
             tool_calls=None,
             finish_reason="length",
         )
-        assert result == REASONING_CUTOFF_SENTINEL, (
-            f"issue #858: unset env var must enable the sentinel "
-            f"(default ON, PR #802 behaviour restored); got {result!r}"
+        _assert_is_rescue(
+            result,
+            reasoning,
+            msg="issue #858: unset env var must enable the rescue "
+            "(default ON, PR #802 / #860 behaviour restored)",
         )
 
     @pytest.mark.parametrize(
@@ -114,14 +146,17 @@ class TestApplyReasoningCutoffNotice:
         that want to be explicit about the on-state regardless of
         future default flips."""
         monkeypatch.setenv("RAPID_MLX_REASONING_CUTOFF_NOTICE", enable_alias)
+        reasoning = "Let me think about 17*23... 17*20=340, 17*3="
         result = _apply_reasoning_cutoff_notice(
             final_content=None,
-            reasoning_text="Let me think about 17*23... 17*20=340, 17*3=",
+            reasoning_text=reasoning,
             tool_calls=None,
             finish_reason="length",
         )
-        assert result == REASONING_CUTOFF_SENTINEL, (
-            f"explicit enable alias {enable_alias!r} must keep the sentinel on"
+        _assert_is_rescue(
+            result,
+            reasoning,
+            msg=f"explicit enable alias {enable_alias!r} must keep the rescue on",
         )
 
     @pytest.mark.parametrize(
@@ -163,14 +198,17 @@ class TestApplyReasoningCutoffNotice:
         sentinel ENABLED (default-on). This is the safe default for
         GUI clients."""
         monkeypatch.setenv("RAPID_MLX_REASONING_CUTOFF_NOTICE", unknown_value)
+        reasoning = "<truncated thought>"
         result = _apply_reasoning_cutoff_notice(
             final_content=None,
-            reasoning_text="<truncated thought>",
+            reasoning_text=reasoning,
             tool_calls=None,
             finish_reason="length",
         )
-        assert result == REASONING_CUTOFF_SENTINEL, (
-            f"env value {unknown_value!r} must leave the sentinel enabled"
+        _assert_is_rescue(
+            result,
+            reasoning,
+            msg=f"env value {unknown_value!r} must leave the rescue enabled",
         )
 
     # ----- enabled branch: the H-01 / issue #858 truth table -----
@@ -187,26 +225,28 @@ class TestApplyReasoningCutoffNotice:
         ``content`` + non-empty reasoning + no tool calls. The sentinel
         surfaces in ``content``; reasoning stays as-is."""
         monkeypatch.setenv("RAPID_MLX_REASONING_CUTOFF_NOTICE", "1")
+        reasoning = "Let me think about 17*23... 17*20=340, 17*3="
         result = _apply_reasoning_cutoff_notice(
             final_content=None,
-            reasoning_text="Let me think about 17*23... 17*20=340, 17*3=",
+            reasoning_text=reasoning,
             tool_calls=None,
             finish_reason="length",
         )
-        assert result == REASONING_CUTOFF_SENTINEL
+        _assert_is_rescue(result, reasoning)
 
     def test_enabled_fires_when_content_is_empty_string(self, monkeypatch):
         """Empty-string ``content`` (downstream sanitization collapsed
         the buffer to ``""``) is treated the same as ``None`` with the
         sentinel enabled — clients render an empty bubble either way."""
         monkeypatch.setenv("RAPID_MLX_REASONING_CUTOFF_NOTICE", "1")
+        reasoning = "<incomplete thought>"
         result = _apply_reasoning_cutoff_notice(
             final_content="",
-            reasoning_text="<incomplete thought>",
+            reasoning_text=reasoning,
             tool_calls=None,
             finish_reason="length",
         )
-        assert result == REASONING_CUTOFF_SENTINEL
+        _assert_is_rescue(result, reasoning)
 
     def test_enabled_fires_when_content_is_whitespace_only(self, monkeypatch):
         """Whitespace-only ``content`` looks identical to clients with
@@ -214,13 +254,14 @@ class TestApplyReasoningCutoffNotice:
         same semantics as the silent-drop helper's whitespace-only
         check."""
         monkeypatch.setenv("RAPID_MLX_REASONING_CUTOFF_NOTICE", "1")
+        reasoning = "<incomplete thought>"
         result = _apply_reasoning_cutoff_notice(
             final_content="   \n\t",
-            reasoning_text="<incomplete thought>",
+            reasoning_text=reasoning,
             tool_calls=None,
             finish_reason="length",
         )
-        assert result == REASONING_CUTOFF_SENTINEL
+        _assert_is_rescue(result, reasoning)
 
     def test_enabled_noop_when_content_is_populated(self, monkeypatch):
         """Happy path with sentinel enabled: model produced a real
@@ -302,6 +343,346 @@ class TestApplyReasoningCutoffNotice:
             finish_reason="length",
         )
         assert result is None
+
+
+# ──────────────────────────────────────────────────────────────────────
+# R12-8 (issue #259): rescue-payload shape + RAPID_MLX_REASONING_RESCUE
+# env knob + back-compat alias coverage.
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestR12_8RescuePayloadShape:
+    """R12-8 / issue #259: the rescue payload format is
+    ``sentinel + "\\n\\n" + reasoning_text[-RESCUE_TAIL_LENGTH:]``.
+
+    Six independent reviewers reopened H-01 across 8 rounds because
+    the bare PR #802 sentinel still felt like "the model didn't
+    answer". R12-8 keeps the literal-sentinel prefix (agentic clients
+    can still pattern-match it for auto-retry) and appends the
+    trailing window of ``reasoning_content`` so a human reader sees a
+    glimpse of what the model was working on when the budget ran out.
+
+    These tests pin the payload shape exhaustively so a future drift
+    (e.g. tail trimmed too aggressively, sentinel demoted to suffix,
+    separator collapsed) fails here first.
+    """
+
+    def test_rescue_starts_with_sentinel_prefix(self, monkeypatch):
+        """Agentic auto-retry clients pattern-match the sentinel prefix
+        to decide whether to re-issue the request with a higher
+        ``max_tokens``. The sentinel MUST anchor the opening of the
+        payload regardless of the tail content."""
+        monkeypatch.delenv("RAPID_MLX_REASONING_CUTOFF_NOTICE", raising=False)
+        monkeypatch.delenv("RAPID_MLX_REASONING_RESCUE", raising=False)
+        reasoning = "x" * 500
+        result = _apply_reasoning_cutoff_notice(
+            final_content=None,
+            reasoning_text=reasoning,
+            tool_calls=None,
+            finish_reason="length",
+        )
+        assert result is not None
+        assert result.startswith(REASONING_CUTOFF_SENTINEL), (
+            f"sentinel must anchor the rescue prefix; got {result!r}"
+        )
+
+    def test_rescue_ends_with_last_n_chars_of_reasoning(self, monkeypatch):
+        """The tail MUST be the LAST ``RESCUE_TAIL_LENGTH`` characters
+        of the reasoning trace (taken from the END because the partial
+        conclusion lives at the tail in every parser dialect).
+        """
+        monkeypatch.delenv("RAPID_MLX_REASONING_RESCUE", raising=False)
+        # Build reasoning with a unique early prefix that won't recur
+        # in the tail — so we can pin "early text doesn't bleed into
+        # the rescue payload".
+        prefix_marker = "UNIQUE-EARLY-PREFIX-MARKER"
+        prefix_part = prefix_marker + ("." * (RESCUE_TAIL_LENGTH * 3))
+        tail_part = (
+            " ...so 17 * 23 = 17 * (20 + 3) = 340 + 51 = 391, then 391 - 5 = 386"
+        )
+        reasoning = prefix_part + tail_part
+        assert len(reasoning) > RESCUE_TAIL_LENGTH
+        result = _apply_reasoning_cutoff_notice(
+            final_content=None,
+            reasoning_text=reasoning,
+            tool_calls=None,
+            finish_reason="length",
+        )
+        assert result is not None
+        expected_tail = reasoning[-RESCUE_TAIL_LENGTH:]
+        assert result.endswith(expected_tail), (
+            f"rescue must end with the LAST {RESCUE_TAIL_LENGTH} chars of "
+            f"reasoning; expected suffix {expected_tail!r}, got {result!r}"
+        )
+        assert prefix_marker not in result, (
+            f"rescue must NOT carry the unique early prefix marker — only "
+            f"the trailing window; got {result!r}"
+        )
+
+    def test_rescue_separates_sentinel_from_tail_with_blank_line(self, monkeypatch):
+        """``sentinel\\n\\ntail`` — a literal blank line separates the
+        machine-readable prefix from the human-readable tail. Lets a
+        chat UI render the sentinel as a separate paragraph above the
+        reasoning excerpt."""
+        monkeypatch.delenv("RAPID_MLX_REASONING_RESCUE", raising=False)
+        reasoning = "Some partial reasoning trace that ends here"
+        result = _apply_reasoning_cutoff_notice(
+            final_content=None,
+            reasoning_text=reasoning,
+            tool_calls=None,
+            finish_reason="length",
+        )
+        assert result is not None
+        expected = f"{REASONING_CUTOFF_SENTINEL}\n\n{reasoning}"
+        assert result == expected, (
+            f"rescue payload must be exactly 'sentinel\\n\\ntail'; got {result!r}"
+        )
+
+    def test_rescue_short_reasoning_appended_in_full(self, monkeypatch):
+        """When ``reasoning_text`` is shorter than ``RESCUE_TAIL_LENGTH``,
+        the entire trace is appended — there is no minimum-length gate
+        beyond non-empty. A 5-char thought still surfaces the rescue."""
+        monkeypatch.delenv("RAPID_MLX_REASONING_RESCUE", raising=False)
+        short = "Hmm."
+        assert len(short) < RESCUE_TAIL_LENGTH
+        result = _apply_reasoning_cutoff_notice(
+            final_content=None,
+            reasoning_text=short,
+            tool_calls=None,
+            finish_reason="length",
+        )
+        assert result == f"{REASONING_CUTOFF_SENTINEL}\n\n{short}", (
+            f"short reasoning must be appended in full; got {result!r}"
+        )
+
+    def test_rescue_strips_trailing_whitespace_before_slicing_tail(self, monkeypatch):
+        """Trailing whitespace on the reasoning trace is stripped
+        BEFORE the tail slice so the rescue doesn't dribble out a
+        partial newline / blank tail. The tail window is content-only."""
+        monkeypatch.delenv("RAPID_MLX_REASONING_RESCUE", raising=False)
+        reasoning = "thinking... let me compute the result   \n\n\t  "
+        result = _apply_reasoning_cutoff_notice(
+            final_content=None,
+            reasoning_text=reasoning,
+            tool_calls=None,
+            finish_reason="length",
+        )
+        assert result is not None
+        assert result.endswith("compute the result"), (
+            f"rescue tail must strip trailing whitespace; got {result!r}"
+        )
+        assert not result.endswith(" "), (
+            f"rescue must NOT end with whitespace; got {result!r}"
+        )
+
+    def test_rescue_preserves_reasoning_content_unchanged(self, monkeypatch):
+        """R12-8 contract: the rescue NEVER mutates ``reasoning_text`` —
+        it only writes to ``content``. Pin via helper-level call: the
+        caller's reasoning string is identity-preserved across the
+        rescue path (the helper is pure on its reasoning argument).
+        """
+        monkeypatch.delenv("RAPID_MLX_REASONING_RESCUE", raising=False)
+        reasoning = "trace that must survive identity-preserved"
+        original = reasoning  # snapshot
+        _apply_reasoning_cutoff_notice(
+            final_content=None,
+            reasoning_text=reasoning,
+            tool_calls=None,
+            finish_reason="length",
+        )
+        assert reasoning == original, (
+            f"helper must not mutate reasoning text; got {reasoning!r}"
+        )
+
+
+class TestR12_8RescueEnvVar:
+    """R12-8 / issue #259: the primary env var is
+    ``RAPID_MLX_REASONING_RESCUE`` (legacy
+    ``RAPID_MLX_REASONING_CUTOFF_NOTICE`` is still honoured as an
+    alias for back-compat).
+    """
+
+    def test_primary_env_off_disables_rescue(self, monkeypatch):
+        """``RAPID_MLX_REASONING_RESCUE=off`` — the R12-8 task spec —
+        disables the rescue. ``content`` stays untouched (strict-null
+        contract)."""
+        monkeypatch.delenv("RAPID_MLX_REASONING_CUTOFF_NOTICE", raising=False)
+        monkeypatch.setenv("RAPID_MLX_REASONING_RESCUE", "off")
+        result = _apply_reasoning_cutoff_notice(
+            final_content=None,
+            reasoning_text="some reasoning trace",
+            tool_calls=None,
+            finish_reason="length",
+        )
+        assert result is None, (
+            f"RAPID_MLX_REASONING_RESCUE=off must disable rescue; got {result!r}"
+        )
+
+    def test_primary_env_on_enables_rescue(self, monkeypatch):
+        """Explicit ``RAPID_MLX_REASONING_RESCUE=on`` — though default
+        is already on, an explicit ``on`` MUST keep the rescue active.
+        Lets operators be defensive about default flips."""
+        monkeypatch.delenv("RAPID_MLX_REASONING_CUTOFF_NOTICE", raising=False)
+        monkeypatch.setenv("RAPID_MLX_REASONING_RESCUE", "on")
+        reasoning = "some reasoning trace"
+        result = _apply_reasoning_cutoff_notice(
+            final_content=None,
+            reasoning_text=reasoning,
+            tool_calls=None,
+            finish_reason="length",
+        )
+        _assert_is_rescue(result, reasoning)
+
+    @pytest.mark.parametrize(
+        "disable_value",
+        ["0", "false", "no", "off", "disabled", "OFF", "False"],
+    )
+    def test_primary_env_disable_spellings(self, monkeypatch, disable_value):
+        """Every documented disable spelling on the PRIMARY env var
+        opts out of the rescue."""
+        monkeypatch.delenv("RAPID_MLX_REASONING_CUTOFF_NOTICE", raising=False)
+        monkeypatch.setenv("RAPID_MLX_REASONING_RESCUE", disable_value)
+        result = _apply_reasoning_cutoff_notice(
+            final_content=None,
+            reasoning_text="trace",
+            tool_calls=None,
+            finish_reason="length",
+        )
+        assert result is None, (
+            f"RAPID_MLX_REASONING_RESCUE={disable_value!r} must disable; got {result!r}"
+        )
+
+    def test_legacy_alias_still_honoured(self, monkeypatch):
+        """Back-compat: ``RAPID_MLX_REASONING_CUTOFF_NOTICE=disabled``
+        from PR #802 / #860 / issue #858 still disables the rescue
+        even when the new primary env var is unset. Operators that
+        already shipped scripts referencing the legacy name don't need
+        to re-deploy."""
+        monkeypatch.delenv("RAPID_MLX_REASONING_RESCUE", raising=False)
+        monkeypatch.setenv("RAPID_MLX_REASONING_CUTOFF_NOTICE", "disabled")
+        result = _apply_reasoning_cutoff_notice(
+            final_content=None,
+            reasoning_text="trace",
+            tool_calls=None,
+            finish_reason="length",
+        )
+        assert result is None, (
+            f"legacy alias must still disable the rescue; got {result!r}"
+        )
+
+    def test_either_env_disabling_wins(self, monkeypatch):
+        """When BOTH env vars are set and EITHER carries a disable
+        value, the rescue is off. Operator intent: "I do not want
+        the injection", regardless of which name was used."""
+        # Legacy off, primary on (or unset, semantically equivalent here)
+        monkeypatch.setenv("RAPID_MLX_REASONING_CUTOFF_NOTICE", "disabled")
+        monkeypatch.setenv("RAPID_MLX_REASONING_RESCUE", "on")
+        result = _apply_reasoning_cutoff_notice(
+            final_content=None,
+            reasoning_text="trace",
+            tool_calls=None,
+            finish_reason="length",
+        )
+        assert result is None, (
+            f"legacy=disabled must win even when primary=on; got {result!r}"
+        )
+        # Primary off, legacy explicitly on
+        monkeypatch.setenv("RAPID_MLX_REASONING_RESCUE", "off")
+        monkeypatch.setenv("RAPID_MLX_REASONING_CUTOFF_NOTICE", "1")
+        result = _apply_reasoning_cutoff_notice(
+            final_content=None,
+            reasoning_text="trace",
+            tool_calls=None,
+            finish_reason="length",
+        )
+        assert result is None, (
+            f"primary=off must win even when legacy=1; got {result!r}"
+        )
+
+    def test_both_unset_defaults_to_on(self, monkeypatch):
+        """With both env vars unset, the rescue is ON (the issue #858
+        default that R12-8 inherits)."""
+        monkeypatch.delenv("RAPID_MLX_REASONING_RESCUE", raising=False)
+        monkeypatch.delenv("RAPID_MLX_REASONING_CUTOFF_NOTICE", raising=False)
+        reasoning = "trace"
+        result = _apply_reasoning_cutoff_notice(
+            final_content=None,
+            reasoning_text=reasoning,
+            tool_calls=None,
+            finish_reason="length",
+        )
+        _assert_is_rescue(result, reasoning)
+
+
+class TestR12_8AntiRegressionGates:
+    """R12-8 anti-regression: the rescue's extended payload must NOT
+    fire on legitimate stop-empty turns, non-length finish, populated
+    content, or tool-call turns. The 8-round D-carry kept these gates
+    in scope — pinning them with the new payload shape so future
+    refactors can't re-break them."""
+
+    def test_no_rescue_on_finish_stop_even_if_content_empty(self, monkeypatch):
+        """``finish_reason="stop"`` + empty content is a legitimate
+        model decision (the model chose to say nothing, possibly after
+        a tool call elsewhere in the turn). R12-8 must NOT inject the
+        rescue here — D-STOP-THINK contract holds."""
+        monkeypatch.delenv("RAPID_MLX_REASONING_RESCUE", raising=False)
+        result = _apply_reasoning_cutoff_notice(
+            final_content=None,
+            reasoning_text="model thought about it but chose not to answer",
+            tool_calls=None,
+            finish_reason="stop",
+        )
+        assert result is None, (
+            f"finish_reason=stop must NEVER trigger rescue; got {result!r}"
+        )
+
+    def test_no_rescue_when_content_already_present(self, monkeypatch):
+        """Coordination with r12-7 (D-MISSING-CONTENT-KEY): r12-7 may
+        emit ``content=""`` or a real string; this test pins that the
+        rescue only fires when content is empty/whitespace AND the
+        gate fires — populated content is left alone."""
+        monkeypatch.delenv("RAPID_MLX_REASONING_RESCUE", raising=False)
+        result = _apply_reasoning_cutoff_notice(
+            final_content="The answer is 391.",
+            reasoning_text="17*23 = 391",
+            tool_calls=None,
+            finish_reason="length",
+        )
+        assert result == "The answer is 391.", (
+            f"populated content must pass through unmodified; got {result!r}"
+        )
+
+    def test_no_rescue_when_reasoning_empty(self, monkeypatch):
+        """Empty reasoning + empty content + length finish — the model
+        emitted nothing semantically. That's a different bug class
+        (zero-token generation) and shouldn't get a "raise max_tokens"
+        cue."""
+        monkeypatch.delenv("RAPID_MLX_REASONING_RESCUE", raising=False)
+        result = _apply_reasoning_cutoff_notice(
+            final_content=None,
+            reasoning_text="",
+            tool_calls=None,
+            finish_reason="length",
+        )
+        assert result is None, (
+            f"empty reasoning must NOT trigger rescue; got {result!r}"
+        )
+
+    def test_no_rescue_when_tool_calls_present_on_length_finish(self, monkeypatch):
+        """Tool-call turns ship ``content=None`` per OpenAI spec, even
+        when ``finish_reason="length"`` interrupts a long tool-call
+        argument. R12-8 must NOT inject the rescue."""
+        monkeypatch.delenv("RAPID_MLX_REASONING_RESCUE", raising=False)
+        result = _apply_reasoning_cutoff_notice(
+            final_content=None,
+            reasoning_text="planning the call...",
+            tool_calls=[{"id": "x", "type": "function"}],
+            finish_reason="length",
+        )
+        assert result is None, (
+            f"tool-call turns must not trigger rescue; got {result!r}"
+        )
 
 
 # ──────────────────────────────────────────────────────────────────────
@@ -549,11 +930,23 @@ class TestParserWideLengthCutMidThinkEnabled:
             reasoning_parser=parser_case["parser"],
             finish_reason="length",
         )
-        assert content == REASONING_CUTOFF_SENTINEL, (
-            f"enabled [{parser_case['name']}]: length-cut mid-think must "
-            f"surface sentinel; got content={content!r}"
+        # R12-8: rescue is ``sentinel + tail-of-reasoning``. Sentinel
+        # anchors the prefix (parser-independent); the tail is the
+        # parser-specific reasoning trace's last RESCUE_TAIL_LENGTH
+        # chars.
+        assert content is not None, (
+            f"enabled [{parser_case['name']}]: rescue must fire; got None"
+        )
+        assert content.startswith(REASONING_CUTOFF_SENTINEL), (
+            f"enabled [{parser_case['name']}]: rescue must open with the "
+            f"sentinel; got content={content!r}"
         )
         assert reasoning is not None and "17" in reasoning
+        # Tail must be the trailing window of the parser's reasoning text.
+        assert content.endswith(reasoning.rstrip()[-RESCUE_TAIL_LENGTH:]), (
+            f"enabled [{parser_case['name']}]: rescue must end with the "
+            f"reasoning tail; got content={content!r}, reasoning={reasoning!r}"
+        )
 
 
 # ──────────────────────────────────────────────────────────────────────
@@ -581,13 +974,14 @@ class TestGemma4HarmonyEngineRouted:
 
     def test_default_on_surfaces_sentinel_on_empty_cleaned_text(self, monkeypatch):
         monkeypatch.setenv("RAPID_MLX_REASONING_CUTOFF_NOTICE", "1")
+        reasoning = "The user wants to know about the weather. Let me think"
         content = _apply_reasoning_cutoff_notice(
             final_content=None,
-            reasoning_text=("The user wants to know about the weather. Let me think"),
+            reasoning_text=reasoning,
             tool_calls=None,
             finish_reason="length",
         )
-        assert content == REASONING_CUTOFF_SENTINEL
+        _assert_is_rescue(content, reasoning)
 
     def test_harmony_analysis_only_opt_out(self, monkeypatch):
         monkeypatch.setenv("RAPID_MLX_REASONING_CUTOFF_NOTICE", "disabled")
@@ -808,9 +1202,17 @@ def test_streaming_enabled_emits_sentinel_in_terminal_chunk(monkeypatch):
     assert terminal_events
     terminal = terminal_events[-1]
     delta = terminal["choices"][0].get("delta", {})
-    assert delta.get("content") == REASONING_CUTOFF_SENTINEL, (
-        f"enabled streaming: terminal chunk must carry sentinel; "
-        f"got {delta.get('content')!r}"
+    # R12-8: rescue is ``sentinel + tail``; the terminal chunk carries
+    # the full payload as a single SSE event (NOT split per token —
+    # see ``test_streaming_enabled_sentinel_is_single_event_not_per_token``).
+    terminal_content = delta.get("content")
+    assert terminal_content is not None, (
+        f"enabled streaming: terminal chunk must carry rescue payload; "
+        f"got {terminal_content!r}"
+    )
+    assert terminal_content.startswith(REASONING_CUTOFF_SENTINEL), (
+        f"enabled streaming: terminal chunk must open with the sentinel; "
+        f"got {terminal_content!r}"
     )
 
 
@@ -832,9 +1234,16 @@ def test_streaming_enabled_sentinel_is_single_event_not_per_token(monkeypatch):
             if d.get("content"):
                 sentinel_chunks.append(d["content"])
 
-    assert sentinel_chunks == [REASONING_CUTOFF_SENTINEL], (
-        f"sentinel must surface as exactly one final-chunk content "
-        f"delta carrying the literal sentinel string; got {sentinel_chunks!r}"
+    # R12-8: rescue is one chunk (not per-token), but its payload now
+    # carries ``sentinel + tail`` rather than the bare sentinel —
+    # ``len(sentinel_chunks) == 1`` is the invariant we pin here.
+    assert len(sentinel_chunks) == 1, (
+        f"rescue must surface as exactly ONE final-chunk content "
+        f"delta (single event, not per-token split); got {sentinel_chunks!r}"
+    )
+    assert sentinel_chunks[0].startswith(REASONING_CUTOFF_SENTINEL), (
+        f"the single rescue chunk must open with the literal sentinel "
+        f"prefix; got {sentinel_chunks[0]!r}"
     )
 
 
@@ -1118,10 +1527,20 @@ def test_chat_route_enabled_surfaces_sentinel_on_length_cut(monkeypatch):
         assert resp.status_code == 200, resp.text
         payload = resp.json()
         msg = payload["choices"][0]["message"]
-        assert msg.get("content") == REASONING_CUTOFF_SENTINEL, (
-            "enabled (env=1): chat non-stream must surface sentinel "
-            f"on length-cut mid-think; got content={msg.get('content')!r}"
+        content = msg.get("content")
+        assert content is not None and content.startswith(REASONING_CUTOFF_SENTINEL), (
+            "enabled (env=1): chat non-stream must surface rescue payload "
+            f"opening with the sentinel; got content={content!r}"
         )
+        # R12-8: rescue payload also embeds the reasoning tail so users
+        # see what the model was working on. The mock engine produces a
+        # short ``<think>`` body — verify the last chars are appended.
+        reasoning = msg.get("reasoning_content") or ""
+        if reasoning:
+            assert content.endswith(reasoning.rstrip()[-RESCUE_TAIL_LENGTH:]), (
+                f"R12-8: rescue must end with the reasoning tail; "
+                f"got content={content!r}, reasoning={reasoning!r}"
+            )
         assert payload["choices"][0]["finish_reason"] == "length"
     finally:
         reset_config()
@@ -1140,6 +1559,7 @@ def test_chat_route_default_env_surfaces_sentinel_regression_858(monkeypatch):
     end-to-end and asserts the envelope shape clients see.
     """
     monkeypatch.delenv("RAPID_MLX_REASONING_CUTOFF_NOTICE", raising=False)
+    monkeypatch.delenv("RAPID_MLX_REASONING_RESCUE", raising=False)
     from fastapi import FastAPI
     from fastapi.testclient import TestClient
 
@@ -1165,14 +1585,15 @@ def test_chat_route_default_env_surfaces_sentinel_regression_858(monkeypatch):
         assert resp.status_code == 200, resp.text
         payload = resp.json()
         msg = payload["choices"][0]["message"]
-        assert msg.get("content") == REASONING_CUTOFF_SENTINEL, (
-            f"issue #858 e2e: default env must inject sentinel into "
-            f"message.content on length-cut mid-think; got "
-            f"content={msg.get('content')!r}"
+        content = msg.get("content")
+        assert content is not None and content.startswith(REASONING_CUTOFF_SENTINEL), (
+            f"issue #858 e2e: default env must inject rescue payload "
+            f"opening with the sentinel into message.content on length-cut "
+            f"mid-think; got content={content!r}"
         )
         assert payload["choices"][0]["finish_reason"] == "length"
         assert msg.get("reasoning_content"), (
-            "reasoning_content must remain populated alongside the sentinel"
+            "reasoning_content must remain populated alongside the rescue"
         )
     finally:
         reset_config()

--- a/tests/test_reasoning_content_null_rescue.py
+++ b/tests/test_reasoning_content_null_rescue.py
@@ -535,13 +535,10 @@ class TestR12_8RescuePayloadShape:
             f"sanitized rescue must keep the sentinel prefix; got {result!r}"
         )
         assert marker not in result, (
-            f"sanitizer must strip {marker!r} from the rescue payload; "
-            f"got {result!r}"
+            f"sanitizer must strip {marker!r} from the rescue payload; got {result!r}"
         )
 
-    def test_rescue_falls_back_to_sentinel_when_tail_is_pure_markup(
-        self, monkeypatch
-    ):
+    def test_rescue_falls_back_to_sentinel_when_tail_is_pure_markup(self, monkeypatch):
         """Edge case for the sanitizer: if the tail is ENTIRELY
         special-token markup (``sanitize_output`` returns ``None``
         because everything was stripped), the rescue degrades

--- a/tests/test_reasoning_content_null_rescue.py
+++ b/tests/test_reasoning_content_null_rescue.py
@@ -494,6 +494,73 @@ class TestR12_8RescuePayloadShape:
             f"helper must not mutate reasoning text; got {reasoning!r}"
         )
 
+    @pytest.mark.parametrize(
+        "marker",
+        [
+            "</think>",
+            "<|im_start|>",
+            "<|im_end|>",
+            "<|channel|>final<|message|>",
+            "</tool_call>",
+            "<|endoftext|>",
+        ],
+    )
+    def test_rescue_tail_is_sanitized_before_injection(self, monkeypatch, marker):
+        """Codex r1 (R12-8): the rescue tail MUST flow through
+        ``sanitize_output`` before being written into user-visible
+        ``content``. Without the sanitizer, leaked reasoning-parser
+        markers (``</think>``, harmony channel markers, etc.) would
+        surface to ``content`` consumers that rely on the canonical
+        sanitizer to strip them — bypassing the same defense every
+        other content-emit site uses.
+
+        Pin: any marker in ``reasoning_text`` MUST NOT appear in the
+        rescue payload, but the sentinel + a non-empty cleaned tail
+        MUST still be present (the rescue is not silently dropped
+        when the only special token is mid-tail).
+        """
+        monkeypatch.delenv("RAPID_MLX_REASONING_RESCUE", raising=False)
+        reasoning = f"the answer is 42 {marker} and that wraps it"
+        result = _apply_reasoning_cutoff_notice(
+            final_content=None,
+            reasoning_text=reasoning,
+            tool_calls=None,
+            finish_reason="length",
+        )
+        assert result is not None, (
+            "rescue must still fire when reasoning has special tokens; "
+            "sanitization is not a kill-switch"
+        )
+        assert result.startswith(REASONING_CUTOFF_SENTINEL), (
+            f"sanitized rescue must keep the sentinel prefix; got {result!r}"
+        )
+        assert marker not in result, (
+            f"sanitizer must strip {marker!r} from the rescue payload; "
+            f"got {result!r}"
+        )
+
+    def test_rescue_falls_back_to_sentinel_when_tail_is_pure_markup(
+        self, monkeypatch
+    ):
+        """Edge case for the sanitizer: if the tail is ENTIRELY
+        special-token markup (``sanitize_output`` returns ``None``
+        because everything was stripped), the rescue degrades
+        gracefully to the bare sentinel — never an empty content,
+        never a half-stripped fragment. The user still sees the
+        retry signal; we just can't show a useful excerpt.
+        """
+        monkeypatch.delenv("RAPID_MLX_REASONING_RESCUE", raising=False)
+        reasoning = "<|im_start|></think><|im_end|></tool_call>"
+        result = _apply_reasoning_cutoff_notice(
+            final_content=None,
+            reasoning_text=reasoning,
+            tool_calls=None,
+            finish_reason="length",
+        )
+        assert result == REASONING_CUTOFF_SENTINEL, (
+            f"all-markup tail must degrade to bare sentinel; got {result!r}"
+        )
+
 
 class TestR12_8RescueEnvVar:
     """R12-8 / issue #259: the primary env var is

--- a/tests/test_responses_budget_exhaust_streaming.py
+++ b/tests/test_responses_budget_exhaust_streaming.py
@@ -134,6 +134,45 @@ class _ReasoningCutoffEngine:
             )
 
 
+class _StubbedShortReasoningEngine:
+    """Codex r1 (R12-8): emits reasoning text but reports
+    ``completion_tokens=0`` throughout the stream — the stubbed-short /
+    speculative-decode-empty edge case where the engine streams
+    reasoning bytes but the token accountant hasn't credited any
+    output. Used to pin the invariant that ``reasoning_tokens`` MUST
+    NOT exceed ``output_tokens`` even when both are zero.
+    """
+
+    preserve_native_tool_format = False
+
+    def __init__(self):
+        self.tokenizer = _Tokenizer()
+
+    async def chat(self, messages, **kwargs):
+        full = "".join(_REASONING_CHUNKS)
+        return _GenerationOutput(
+            text="",
+            raw_text=full,
+            reasoning_text=full,
+            prompt_tokens=4,
+            completion_tokens=0,
+            finish_reason="length",
+        )
+
+    async def stream_chat(self, messages, **kwargs):
+        accumulated = ""
+        for i, chunk in enumerate(_REASONING_CHUNKS):
+            accumulated += chunk
+            is_last = i == len(_REASONING_CHUNKS) - 1
+            yield _GenerationOutput(
+                text=accumulated,
+                new_text=chunk,
+                prompt_tokens=4 if i == 0 else 0,
+                completion_tokens=0,
+                finish_reason="length" if is_last else None,
+            )
+
+
 # Reasoning-then-message engine for codex r1 HIGH #1 regression: the
 # model closes ``</think>`` mid-stream then emits an assistant message
 # and STILL hits ``finish_reason="length"`` before finishing the
@@ -799,6 +838,94 @@ class TestStreamingBudgetExhaustEmitsReasoningItem:
             f"reasoning_tokens={reasoning_tokens} but reasoning text was "
             f"accumulated — usage credit missing."
         )
+
+    def test_reasoning_tokens_not_credited_when_completion_tokens_zero(
+        self, monkeypatch
+    ):
+        """Codex r1 (R12-8) MED: when an engine streams reasoning text
+        but the token accountant reports ``completion_tokens=0`` (the
+        stubbed-short / spec-decode-empty edge case), the streaming
+        path MUST emit ``reasoning_tokens=0`` — NOT ``reasoning_tokens=1``
+        with ``output_tokens=0``. The invariant ``reasoning_tokens <=
+        output_tokens`` is what SDK consumers depend on for usage
+        arithmetic.
+
+        Pre-fix the clamp lived inside the ``if completion_tokens:``
+        branch, so the zero-completion case skipped clamping entirely
+        and emitted ``output_tokens: 0`` + ``reasoning_tokens: 1``.
+        """
+        previous_modules = {n: sys.modules.get(n, _MISSING) for n in _IMPORTED}
+        previous_attrs = {}
+        for module_name, attr in _PARENT_ATTRS:
+            module = sys.modules.get(module_name)
+            previous_attrs[(module_name, attr)] = (
+                getattr(module, attr, _MISSING) if module is not None else _MISSING
+            )
+        _install_lightweight_engine_modules(monkeypatch)
+        from vllm_mlx.config import reset_config
+        from vllm_mlx.middleware.auth import rate_limiter
+        from vllm_mlx.middleware.exception_handlers import install_exception_handlers
+        from vllm_mlx.routes.responses import router
+
+        cfg = reset_config()
+        cfg.api_key = "test-secret"
+        cfg.engine = _StubbedShortReasoningEngine()
+        cfg.model_name = "test-model"
+        cfg.model_registry = None
+        cfg.reasoning_parser_name = "qwen3"
+        cfg.reasoning_parser = "qwen3"
+        rate_limiter.enabled = False
+        rate_limiter.requests_per_minute = 60
+        rate_limiter._requests.clear()
+        app = FastAPI()
+        install_exception_handlers(app)
+        app.include_router(router)
+        client = TestClient(app)
+
+        try:
+            with client.stream(
+                "POST",
+                "/v1/responses",
+                json=_stream_payload(),
+                headers=HEADERS,
+            ) as resp:
+                body = "".join(resp.iter_text())
+            events = _parse_sse(body)
+            completed = next(d for n, d in events if n == "response.completed")
+            usage = completed["response"]["usage"]
+            output_tokens = usage["output_tokens"]
+            reasoning_tokens = usage["output_tokens_details"]["reasoning_tokens"]
+            assert output_tokens == 0, (
+                f"engine reported completion_tokens=0; expected "
+                f"output_tokens=0, got {output_tokens}"
+            )
+            assert reasoning_tokens <= output_tokens, (
+                f"invariant violated: reasoning_tokens={reasoning_tokens} > "
+                f"output_tokens={output_tokens}"
+            )
+            assert reasoning_tokens == 0, (
+                f"with completion_tokens=0 the reasoning credit must be 0; "
+                f"got {reasoning_tokens}"
+            )
+        finally:
+            reset_config()
+            rate_limiter.enabled = False
+            rate_limiter.requests_per_minute = 60
+            rate_limiter._requests.clear()
+            for name, previous in previous_modules.items():
+                if previous is _MISSING:
+                    sys.modules.pop(name, None)
+                else:
+                    sys.modules[name] = previous
+            for (module_name, attr), previous in previous_attrs.items():
+                module = sys.modules.get(module_name)
+                if module is None:
+                    continue
+                if previous is _MISSING:
+                    if hasattr(module, attr):
+                        delattr(module, attr)
+                else:
+                    setattr(module, attr, previous)
 
 
 # =============================================================================

--- a/tests/test_responses_budget_exhaust_streaming.py
+++ b/tests/test_responses_budget_exhaust_streaming.py
@@ -839,6 +839,75 @@ class TestStreamingBudgetExhaustEmitsReasoningItem:
             f"accumulated — usage credit missing."
         )
 
+    def test_streaming_responses_emits_rescue_output_text_under_cutoff(
+        self, responses_client, monkeypatch
+    ):
+        """Codex r2 (R12-8) MED #4: cross-path parity. Non-stream
+        Responses materializes the H-01 rescue text into an
+        ``output_text`` message item via ``openai_to_responses``.
+        The streaming surface must mirror this — emit a synthetic
+        message item carrying the rescue payload so clients that
+        render only ``output_text`` see the same retry signal +
+        reasoning tail the non-stream surface ships. Pre-fix the
+        streaming surface only emitted the reasoning item (status
+        incomplete) and silently dropped the rescue text.
+        """
+        monkeypatch.delenv("RAPID_MLX_REASONING_RESCUE", raising=False)
+        monkeypatch.delenv("RAPID_MLX_REASONING_CUTOFF_NOTICE", raising=False)
+        with responses_client.client.stream(
+            "POST",
+            "/v1/responses",
+            json=_stream_payload(),
+            headers=HEADERS,
+        ) as resp:
+            body = "".join(resp.iter_text())
+        events = _parse_sse(body)
+        # The completed.response.output[] must carry BOTH the reasoning
+        # item AND a synthetic message item with the rescue payload.
+        completed = next(d for n, d in events if n == "response.completed")
+        output = completed["response"]["output"]
+        types = [item["type"] for item in output]
+        assert "reasoning" in types, (
+            f"reasoning item missing from output; got types={types}"
+        )
+        assert "message" in types, (
+            f"streaming rescue message item missing; got types={types} "
+            f"(non-stream surface emits one for the same cutoff shape)"
+        )
+        message_item = next(item for item in output if item["type"] == "message")
+        assert message_item["content"], "rescue message must have content"
+        rescue_text = message_item["content"][0]["text"]
+        from vllm_mlx.service.helpers import REASONING_CUTOFF_SENTINEL
+
+        assert rescue_text.startswith(REASONING_CUTOFF_SENTINEL), (
+            f"rescue message must lead with the sentinel; got {rescue_text!r}"
+        )
+        # And the SSE ladder MUST emit the canonical message-item
+        # event sequence — added → content_part.added → output_text.delta
+        # → output_text.done → content_part.done → output_item.done.
+        event_types_after_reasoning_done = []
+        seen_reasoning_done = False
+        for name, _ in events:
+            if name == "response.output_item.done" and not seen_reasoning_done:
+                seen_reasoning_done = True
+                continue
+            if seen_reasoning_done:
+                event_types_after_reasoning_done.append(name)
+                if name == "response.output_item.done":
+                    break
+        canonical_ladder = [
+            "response.output_item.added",
+            "response.content_part.added",
+            "response.output_text.delta",
+            "response.output_text.done",
+            "response.content_part.done",
+            "response.output_item.done",
+        ]
+        assert event_types_after_reasoning_done == canonical_ladder, (
+            f"rescue message ladder missing or out-of-order; expected "
+            f"{canonical_ladder}, got {event_types_after_reasoning_done}"
+        )
+
     def test_reasoning_tokens_not_credited_when_completion_tokens_zero(
         self, monkeypatch
     ):

--- a/vllm_mlx/api/constants.py
+++ b/vllm_mlx/api/constants.py
@@ -19,3 +19,35 @@ environments depend on this.
 #: ``service.helpers`` re-exports this name as the public symbol so
 #: existing callers (route helpers + their tests) need not change.
 REASONING_CUTOFF_SENTINEL = "[truncated — reasoning incomplete; raise max_tokens]"
+
+
+def is_rescue_payload(content: str | None) -> bool:
+    """Return True iff ``content`` is a rescue payload produced by
+    ``_build_reasoning_rescue_payload`` (R12-8 / H-01).
+
+    The rescue payload has exactly one of two literal shapes:
+
+    1. ``REASONING_CUTOFF_SENTINEL`` (bare) — sanitizer stripped the
+       entire reasoning tail; only the sentinel remains.
+    2. ``REASONING_CUTOFF_SENTINEL + "\\n\\n" + <sanitized tail>`` —
+       normal case. The separator is a literal ``\\n\\n`` because
+       ``_build_reasoning_rescue_payload`` joins the two parts with
+       exactly that string.
+
+    Tighter than ``content.startswith(SENTINEL)`` because a real model
+    response starting with the sentinel literal but NOT followed by
+    ``\\n\\n`` (e.g. ``"[truncated ...] also see notes."`` typed by a
+    model echoing the sentinel as part of a longer reply) is correctly
+    classified as real downstream output. Codex pr_validate r1 raised
+    the false-positive risk; this shape gate addresses it without
+    needing a structured per-request flag plumbed through the wire.
+
+    ``None`` and empty strings are NOT rescue payloads (the rescue
+    helper always returns at least the sentinel).
+    """
+    if not content:
+        return False
+    if content == REASONING_CUTOFF_SENTINEL:
+        return True
+    prefix = REASONING_CUTOFF_SENTINEL + "\n\n"
+    return content.startswith(prefix) and len(content) > len(prefix)

--- a/vllm_mlx/api/responses_adapter.py
+++ b/vllm_mlx/api/responses_adapter.py
@@ -509,7 +509,7 @@ def openai_to_responses(
             # ``reasoning_block_closed`` predicate (which never sees
             # the sentinel because streaming injects it as a terminal
             # delta, never as the parser's content channel).
-            content_for_downstream_check = (choice.message.content or "")
+            content_for_downstream_check = choice.message.content or ""
             if content_for_downstream_check.startswith(REASONING_CUTOFF_SENTINEL):
                 content_for_downstream_check = ""
             downstream_output_seen = bool(

--- a/vllm_mlx/api/responses_adapter.py
+++ b/vllm_mlx/api/responses_adapter.py
@@ -18,7 +18,7 @@ import uuid
 
 from fastapi import HTTPException
 
-from .constants import REASONING_CUTOFF_SENTINEL
+from .constants import REASONING_CUTOFF_SENTINEL, is_rescue_payload
 from .models import (
     ChatCompletionRequest,
     ChatCompletionResponse,
@@ -502,15 +502,22 @@ def openai_to_responses(
             # partial conclusion — but it's still a UX rescue, NOT
             # "real downstream output" from the model, so it must not
             # flip ``reasoning_item_status`` from ``incomplete`` to
-            # ``completed``. Use ``startswith`` (not exact-match) so
-            # the gate catches both the pre-R12-8 bare-sentinel shape
-            # AND the R12-8 sentinel+tail shape. This brings the non-
-            # stream surface into parity with the streaming surface's
+            # ``completed``. This brings the non-stream surface into
+            # parity with the streaming surface's
             # ``reasoning_block_closed`` predicate (which never sees
             # the sentinel because streaming injects it as a terminal
             # delta, never as the parser's content channel).
+            #
+            # Codex pr_validate r1 (R12-8): the original ``startswith``
+            # check would also flag a legitimate model response that
+            # happens to begin with the sentinel literal but is NOT a
+            # rescue payload (e.g. a model echoing the sentinel text in
+            # its real reply). Use the exact two-shape gate exposed by
+            # :func:`is_rescue_payload` — bare sentinel OR sentinel +
+            # ``\n\n`` + non-empty tail — both of which can ONLY be
+            # produced by ``_build_reasoning_rescue_payload``.
             content_for_downstream_check = choice.message.content or ""
-            if content_for_downstream_check.startswith(REASONING_CUTOFF_SENTINEL):
+            if is_rescue_payload(content_for_downstream_check):
                 content_for_downstream_check = ""
             downstream_output_seen = bool(
                 content_for_downstream_check.strip() or choice.message.tool_calls

--- a/vllm_mlx/api/responses_adapter.py
+++ b/vllm_mlx/api/responses_adapter.py
@@ -18,7 +18,7 @@ import uuid
 
 from fastapi import HTTPException
 
-from .constants import REASONING_CUTOFF_SENTINEL, is_rescue_payload
+from .constants import is_rescue_payload
 from .models import (
     ChatCompletionRequest,
     ChatCompletionResponse,

--- a/vllm_mlx/api/responses_adapter.py
+++ b/vllm_mlx/api/responses_adapter.py
@@ -491,25 +491,29 @@ def openai_to_responses(
             # text OR tool_calls) — this brings the non-stream
             # surface into parity.
             #
-            # Issue #858 → PR #860 followup: the chat-route helper
-            # ``_apply_reasoning_cutoff_notice`` is called BEFORE this
-            # adapter on the non-stream path; when the env default
-            # restored the sentinel, ``message.content`` carried the
-            # literal ``REASONING_CUTOFF_SENTINEL`` text on every
-            # mid-think length cutoff. That sentinel is a UX fallback
-            # for clients that only render output_text — it is NOT
+            # Issue #858 → PR #860 followup + R12-8 / H-01 parity:
+            # the chat-route helper ``_apply_reasoning_cutoff_notice``
+            # is called BEFORE this adapter on the non-stream path;
+            # when the env default restored the sentinel, ``message.content``
+            # carried the literal ``REASONING_CUTOFF_SENTINEL`` text on
+            # every mid-think length cutoff. R12-8 (issue #259) extends
+            # the rescue payload from a bare sentinel to ``sentinel +
+            # tail-of-reasoning`` so the user sees a glimpse of the
+            # partial conclusion — but it's still a UX rescue, NOT
             # "real downstream output" from the model, so it must not
             # flip ``reasoning_item_status`` from ``incomplete`` to
-            # ``completed``. Strip the sentinel before the empty check
-            # so the non-stream surface matches the streaming surface's
+            # ``completed``. Use ``startswith`` (not exact-match) so
+            # the gate catches both the pre-R12-8 bare-sentinel shape
+            # AND the R12-8 sentinel+tail shape. This brings the non-
+            # stream surface into parity with the streaming surface's
             # ``reasoning_block_closed`` predicate (which never sees
             # the sentinel because streaming injects it as a terminal
             # delta, never as the parser's content channel).
-            content_for_downstream_check = (choice.message.content or "").strip()
-            if content_for_downstream_check == REASONING_CUTOFF_SENTINEL:
+            content_for_downstream_check = (choice.message.content or "")
+            if content_for_downstream_check.startswith(REASONING_CUTOFF_SENTINEL):
                 content_for_downstream_check = ""
             downstream_output_seen = bool(
-                content_for_downstream_check or choice.message.tool_calls
+                content_for_downstream_check.strip() or choice.message.tool_calls
             )
             reasoning_item_status = (
                 "incomplete"

--- a/vllm_mlx/routes/responses.py
+++ b/vllm_mlx/routes/responses.py
@@ -2327,11 +2327,7 @@ async def _stream_responses(
             # output_text.done → content_part.done → output_item.done
             # ladder. Gating mirrors `_apply_reasoning_cutoff_notice` —
             # message_open + tool_calls already preclude rescue.
-            if (
-                mid_think_cutoff
-                and not message_open
-                and not tool_calls
-            ):
+            if mid_think_cutoff and not message_open and not tool_calls:
                 rescue_text = _apply_reasoning_cutoff_notice(
                     final_content=None,
                     reasoning_text=accumulated_reasoning_text,

--- a/vllm_mlx/routes/responses.py
+++ b/vllm_mlx/routes/responses.py
@@ -2313,6 +2313,116 @@ async def _stream_responses(
             )
             completed_output.append(reasoning_item_payload_done)
 
+            # R12-8 codex r2 #4: streaming Responses parity with non-stream.
+            # Non-stream Responses runs `_apply_reasoning_cutoff_notice` via
+            # the chat layer, then `openai_to_responses` materializes the
+            # rescue text into an `output_text` message item. The streaming
+            # path emits the reasoning item with status=incomplete (above)
+            # but never surfaces the rescue payload — clients rendering only
+            # text output see empty output despite the reasoning being
+            # available. Mirror the non-stream shape: when the mid-think
+            # cutoff fired AND no real downstream output was seen, build the
+            # rescue payload and emit a synthetic message item using the
+            # canonical added → content_part.added → output_text.delta →
+            # output_text.done → content_part.done → output_item.done
+            # ladder. Gating mirrors `_apply_reasoning_cutoff_notice` —
+            # message_open + tool_calls already preclude rescue.
+            if (
+                mid_think_cutoff
+                and not message_open
+                and not tool_calls
+            ):
+                rescue_text = _apply_reasoning_cutoff_notice(
+                    final_content=None,
+                    reasoning_text=accumulated_reasoning_text,
+                    tool_calls=None,
+                    finish_reason=last_finish_reason,
+                )
+                if rescue_text:
+                    rescue_output_index = len(completed_output)
+                    rescue_item_id = f"msg_{uuid.uuid4().hex[:24]}"
+                    rescue_part = {
+                        "type": "output_text",
+                        "text": rescue_text,
+                        "annotations": [],
+                    }
+                    yield _emit(
+                        "response.output_item.added",
+                        {
+                            "type": "response.output_item.added",
+                            "output_index": rescue_output_index,
+                            "item": {
+                                "type": "message",
+                                "id": rescue_item_id,
+                                "status": "in_progress",
+                                "role": "assistant",
+                                "content": [],
+                            },
+                        },
+                    )
+                    yield _emit(
+                        "response.content_part.added",
+                        {
+                            "type": "response.content_part.added",
+                            "item_id": rescue_item_id,
+                            "output_index": rescue_output_index,
+                            "content_index": 0,
+                            "part": {
+                                "type": "output_text",
+                                "text": "",
+                                "annotations": [],
+                            },
+                        },
+                    )
+                    yield _emit(
+                        "response.output_text.delta",
+                        {
+                            "type": "response.output_text.delta",
+                            "item_id": rescue_item_id,
+                            "output_index": rescue_output_index,
+                            "content_index": 0,
+                            "delta": rescue_text,
+                            "logprobs": [],
+                        },
+                    )
+                    yield _emit(
+                        "response.output_text.done",
+                        {
+                            "type": "response.output_text.done",
+                            "item_id": rescue_item_id,
+                            "output_index": rescue_output_index,
+                            "content_index": 0,
+                            "text": rescue_text,
+                            "logprobs": [],
+                        },
+                    )
+                    yield _emit(
+                        "response.content_part.done",
+                        {
+                            "type": "response.content_part.done",
+                            "item_id": rescue_item_id,
+                            "output_index": rescue_output_index,
+                            "content_index": 0,
+                            "part": rescue_part,
+                        },
+                    )
+                    rescue_message_done = {
+                        "type": "message",
+                        "id": rescue_item_id,
+                        "status": "completed",
+                        "role": "assistant",
+                        "content": [rescue_part],
+                    }
+                    yield _emit(
+                        "response.output_item.done",
+                        {
+                            "type": "response.output_item.done",
+                            "output_index": rescue_output_index,
+                            "item": rescue_message_done,
+                        },
+                    )
+                    completed_output.append(rescue_message_done)
+
         # Ana C-06 (0.8.5 dogfood): when the request used Computer-Use,
         # translate ``function.name == "computer"`` tool_calls into the
         # ``computer_call`` envelope so SDK consumers walking

--- a/vllm_mlx/routes/responses.py
+++ b/vllm_mlx/routes/responses.py
@@ -2515,11 +2515,19 @@ async def _stream_responses(
         # — a stubbed-short engine (or a model that emits one literal
         # token of long reasoning text) could otherwise report
         # ``reasoning_tokens > output_tokens`` and break SDK arithmetic.
+        # Codex r1 (R12-8): require completion_tokens > 0 to credit
+        # ANY reasoning. Previously the clamp only ran inside the
+        # ``if completion_tokens:`` branch, so a stubbed-short engine
+        # streaming reasoning text with completion_tokens==0 emitted
+        # ``output_tokens: 0`` + ``reasoning_tokens: 1`` — violating
+        # the invariant ``reasoning_tokens <= output_tokens`` that
+        # SDK consumers rely on for usage arithmetic.
         reasoning_token_credit = 0
-        if accumulated_reasoning_text:
-            reasoning_token_credit = max(1, len(accumulated_reasoning_text) // 4)
-            if completion_tokens:
-                reasoning_token_credit = min(reasoning_token_credit, completion_tokens)
+        if accumulated_reasoning_text and completion_tokens:
+            reasoning_token_credit = min(
+                max(1, len(accumulated_reasoning_text) // 4),
+                completion_tokens,
+            )
         usage_payload = {
             "input_tokens": prompt_tokens,
             "output_tokens": completion_tokens,

--- a/vllm_mlx/service/helpers.py
+++ b/vllm_mlx/service/helpers.py
@@ -1065,47 +1065,109 @@ def _rescue_silent_drop_from_reasoning(
 # no token-by-token leak of the sentinel string itself.)
 
 
-#: Env var values that EXPLICITLY DISABLE the sentinel notice (issue #858
-#: revert of R-01: default is now back to ON, matching the original H-01 /
-#: PR #802 behaviour). GUI clients (rapid-desktop ChatView, OpenAI-SDK
-#: consumers, etc.) render blank message bubbles when ``content`` is
-#: ``None`` even though ``finish_reason="length"`` is set — the literal
-#: sentinel is the user-facing signal that ``max_tokens`` was too low.
-#: Power callers that prefer the strict-null shape can opt out via
-#: ``RAPID_MLX_REASONING_CUTOFF_NOTICE=disabled`` (or ``0`` / ``false`` /
-#: ``no`` / ``off``).
+#: How many trailing characters of ``reasoning_content`` to copy into
+#: the rescue ``content`` after the sentinel prefix. Chosen empirically:
+#: ~200 chars is roughly the last 2-3 sentences of typical qwen3 /
+#: deepseek_r1 chain-of-thought, which is the granularity a human user
+#: needs to recognise what the model was working on without dumping the
+#: whole trace into ``content`` (which would re-introduce the
+#: D-STOP-THINK / D-HARMONY-LEAK byte-identical leak shape). The tail
+#: is added AFTER the sentinel so the literal cue still anchors the
+#: opening of the rescue string — agentic auto-retry clients can match
+#: on the sentinel prefix regardless of the tail content.
+RESCUE_TAIL_LENGTH = 200
+
+#: Env var values that EXPLICITLY DISABLE the rescue notice. The
+#: primary knob is ``RAPID_MLX_REASONING_RESCUE`` (R12-8 / issue #259);
+#: the legacy ``RAPID_MLX_REASONING_CUTOFF_NOTICE`` (PR #802 / #815 /
+#: #860) is still honoured as a back-compat alias so existing
+#: rapid-desktop / agent deployments don't break on upgrade.
+#:
+#: GUI clients (rapid-desktop ChatView, OpenAI-SDK consumers, etc.)
+#: render blank message bubbles when ``content`` is ``None`` even
+#: though ``finish_reason="length"`` is set — the rescue string is the
+#: user-facing signal that ``max_tokens`` was too low PLUS a glimpse of
+#: the truncated thought trace. Power callers that prefer the strict-
+#: null shape can opt out with any of the listed spellings on either
+#: env var.
 _CUTOFF_NOTICE_DISABLED_VALUES = frozenset({"0", "false", "no", "off", "disabled"})
+
+#: Primary R12-8 env var. ``RAPID_MLX_REASONING_RESCUE=off`` disables
+#: the rescue; default is ``on``. Both this name and the legacy alias
+#: below are read; if either is set to a disable value, the rescue is
+#: off (operator intent: "I do not want the literal text injection").
+_RESCUE_ENV_PRIMARY = "RAPID_MLX_REASONING_RESCUE"
+#: Legacy alias from PR #802 / #860 (issue #858). Kept for back-compat
+#: so callers that already set ``RAPID_MLX_REASONING_CUTOFF_NOTICE=disabled``
+#: don't need to re-deploy when they upgrade to the R12-8 build.
+_RESCUE_ENV_LEGACY = "RAPID_MLX_REASONING_CUTOFF_NOTICE"
 
 
 def _cutoff_notice_enabled() -> bool:
-    """Whether the cutoff sentinel is enabled for this process.
+    """Whether the cutoff rescue is enabled for this process.
 
-    Issue #858 revert: default is ON, matching PR #802 (H-01) semantics.
-    The R-01 flip-to-OFF (PR #815) caused a GUI regression — clients
-    that only render the ``content`` text block (rapid-desktop
-    ChatView, OpenWebUI-compat layers, vanilla OpenAI SDK consumers)
-    show an empty bubble even though ``finish_reason="length"`` is
-    set, and have no in-text cue that ``max_tokens`` was too low.
-    Restoring the literal sentinel by default fixes that without
-    affecting the structured truncation fields every transport already
-    carries.
+    R12-8 / issue #259 expands the rescue from a bare sentinel string
+    to ``sentinel + tail-of-reasoning`` (the 8-round carry kept getting
+    reopened because the bare sentinel still felt like "the model
+    didn't answer" to six independent reviewers). The default-on /
+    opt-out policy is unchanged from PR #860 — only the rescue payload
+    grew. Issue #858 revert (PR #860) settled the default-on question:
+    GUI clients that only render ``content`` showed empty bubbles
+    under R-01's default-off, and that ships as a user-visible bug.
 
-    Reads the env var on each call so test harnesses can flip the gate
-    per-request via ``monkeypatch.setenv`` without restarting the
+    Reads the env vars on each call so test harnesses can flip the
+    gate per-request via ``monkeypatch.setenv`` without restarting the
     process. The cost is negligible (``os.environ.get`` is a dict
     lookup) and matches how every other ``RAPID_MLX_*`` env-gated knob
     is read in this module.
 
-    Accepted disable values (case-insensitive, surrounding whitespace
-    stripped): ``"0"`` / ``"false"`` / ``"no"`` / ``"off"`` /
-    ``"disabled"``. Anything else — including unset, the empty string,
-    ``"1"``, ``"true"``, ``"on"``, ``"yes"``, ``"enabled"``, or any
-    arbitrary unrecognised value — leaves the sentinel enabled.
+    Two env vars are honoured (in this priority order):
+
+    * ``RAPID_MLX_REASONING_RESCUE`` — R12-8 primary name. Easier to
+      discover than the legacy alias (``RESCUE`` is what the operator
+      thinks of it as) and aligns with the task spec.
+    * ``RAPID_MLX_REASONING_CUTOFF_NOTICE`` — legacy alias from PR
+      #802 / #860 (issue #858). Still honoured so existing
+      rapid-desktop deployments and operator runbooks that already
+      reference this name keep working without a rebuild.
+
+    The rescue is DISABLED when EITHER env var is set to a disable
+    spelling (``"0"`` / ``"false"`` / ``"no"`` / ``"off"`` /
+    ``"disabled"``, case-insensitive, whitespace-stripped). Operator
+    intent: "I do not want the rescue", regardless of which name was
+    used. Anything else — including unset, the empty string,
+    ``"1"`` / ``"true"`` / ``"on"`` / ``"yes"`` / ``"enabled"``, or
+    any arbitrary unrecognised value — leaves the rescue enabled.
     """
-    raw = os.environ.get("RAPID_MLX_REASONING_CUTOFF_NOTICE")
-    if raw is None:
-        return True  # issue #858: default ON (PR #802 behaviour restored)
-    return raw.strip().lower() not in _CUTOFF_NOTICE_DISABLED_VALUES
+    for env_name in (_RESCUE_ENV_PRIMARY, _RESCUE_ENV_LEGACY):
+        raw = os.environ.get(env_name)
+        if raw is None:
+            continue
+        if raw.strip().lower() in _CUTOFF_NOTICE_DISABLED_VALUES:
+            return False
+    return True
+
+
+def _build_reasoning_rescue_payload(reasoning_text: str) -> str:
+    """Build the rescue ``content`` string for R12-8.
+
+    Layout: ``"<sentinel>\\n\\n<tail-of-reasoning>"``. The sentinel
+    anchors the opening (agentic auto-retry clients pattern-match the
+    prefix), then a blank line, then the LAST ``RESCUE_TAIL_LENGTH``
+    chars of the reasoning trace so a human sees the partial
+    conclusion. The tail is taken from the END of ``reasoning_text``
+    because that's where the partial answer lives in every reasoning
+    parser dialect we ship (qwen3, deepseek_r1, glm4, vibethinker,
+    harmony — all build the answer at the tail of the thought).
+
+    Trailing whitespace on the reasoning trace is stripped before the
+    slice so the rescue doesn't end on a partial newline. The caller
+    has already verified ``reasoning_text`` is non-empty + non-
+    whitespace (see ``_apply_reasoning_cutoff_notice``), so an empty
+    tail is impossible by construction.
+    """
+    tail = reasoning_text.rstrip()[-RESCUE_TAIL_LENGTH:]
+    return f"{REASONING_CUTOFF_SENTINEL}\n\n{tail}"
 
 
 def _apply_reasoning_cutoff_notice(
@@ -1114,34 +1176,45 @@ def _apply_reasoning_cutoff_notice(
     tool_calls: list | None,
     finish_reason: str | None,
 ) -> str | None:
-    """H-01: surface a clearly-marked sentinel when generation was cut
-    short mid-think and the strict rescue path left ``content`` empty.
+    """R12-8 / H-01: rescue ``content`` when generation was cut short
+    mid-think and the strict rescue path left it empty.
 
     Runs AFTER ``_rescue_silent_drop_from_reasoning`` — its job is the
     UX rescue for the cases the silent-drop rescue deliberately
     SUPPRESSED (truncated ``<think>``, harmony analysis-without-final,
     Case-4 no-tag fallback). All those cases share the same observable
     shape: ``finish_reason="length"`` + empty content + non-empty
-    reasoning + no tool calls. The sentinel is parser-independent
-    literal text, so promoting it can NEVER re-introduce the
-    D-STOP-THINK / D-HARMONY-LEAK leak (we are NOT mirroring the
-    reasoning trace — that's the explicit anti-pattern those PRs
-    closed).
+    reasoning + no tool calls.
+
+    R12-8 (issue #259, 8-round D-carry) extends PR #802 / #860: the
+    rescue is now ``sentinel + tail-of-reasoning`` rather than the bare
+    sentinel, because six independent reviewers kept reopening the H-01
+    carry — the bare sentinel still felt like "the model didn't
+    answer". The tail is the LAST ``RESCUE_TAIL_LENGTH`` chars of the
+    reasoning trace — that gives a human reader a glimpse of the
+    partial conclusion without dumping the whole trace into
+    ``content`` (which would re-introduce the D-STOP-THINK /
+    D-HARMONY-LEAK byte-identical leak shape the rescue is allowed to
+    exist alongside). ``reasoning_content`` is NEVER touched — the
+    full original trace stays addressable to clients that walk both
+    fields.
 
     Returns ``final_content`` unchanged when:
-    * the env var disables the notice
+    * the env var disables the rescue (``RAPID_MLX_REASONING_RESCUE=off``
+      or the legacy ``RAPID_MLX_REASONING_CUTOFF_NOTICE=disabled``)
     * ``finish_reason`` is anything other than ``"length"`` (stop-string
       cut mid-think hits the D-STOP-THINK regression guard — strict
-      null wins)
+      null wins; a clean ``"stop"`` finish on an empty answer is a
+      legitimate model decision and gets no "raise max_tokens" hint)
     * ``final_content`` already carries a non-whitespace payload
     * ``tool_calls`` were extracted (OpenAI-spec ``content=None`` path)
     * ``reasoning_text`` is empty / whitespace (nothing to signal — the
       model produced nothing semantically, which is a different bug
       class and shouldn't get a "raise max_tokens" hint)
 
-    Otherwise returns the sentinel constant. The caller writes it into
-    ``message.content`` (non-stream) or the final SSE
-    ``delta.content`` chunk (stream).
+    Otherwise returns ``sentinel + "\\n\\n" + reasoning_text[-RESCUE_TAIL_LENGTH:]``.
+    The caller writes it into ``message.content`` (non-stream) or the
+    final SSE ``delta.content`` chunk (stream).
     """
     if not _cutoff_notice_enabled():
         return final_content
@@ -1153,7 +1226,7 @@ def _apply_reasoning_cutoff_notice(
         return final_content
     if not reasoning_text or not reasoning_text.strip():
         return final_content
-    return REASONING_CUTOFF_SENTINEL
+    return _build_reasoning_rescue_payload(reasoning_text)
 
 
 # OpenAI-spec closed enum for ``response_format.type``. Any value outside

--- a/vllm_mlx/service/helpers.py
+++ b/vllm_mlx/service/helpers.py
@@ -41,6 +41,7 @@ from ..api.models import (
     Usage,
 )
 from ..api.tool_calling import parse_tool_calls
+from ..api.utils import sanitize_output
 from ..config import get_config
 from ..engine import BaseEngine, GenerationOutput
 from ..tool_parsers import ToolParserManager
@@ -1165,9 +1166,22 @@ def _build_reasoning_rescue_payload(reasoning_text: str) -> str:
     has already verified ``reasoning_text`` is non-empty + non-
     whitespace (see ``_apply_reasoning_cutoff_notice``), so an empty
     tail is impossible by construction.
+
+    The tail is run through :func:`sanitize_output` BEFORE injection
+    so any leaked special-token markers (``</think>``, ``<|...|>``,
+    harmony channel markers, ``</tool_call>``, etc.) that a reasoning
+    parser may have left in the trace are stripped on the way to
+    user-visible ``content``. ``reasoning_content`` keeps the full
+    original trace addressable for clients that walk both fields.
+    Codex r1 (R12-8): the rescue path previously bypassed the
+    sanitizer that ``content`` consumers rely on; reasoning markers
+    must not surface in the user-rendered field.
     """
     tail = reasoning_text.rstrip()[-RESCUE_TAIL_LENGTH:]
-    return f"{REASONING_CUTOFF_SENTINEL}\n\n{tail}"
+    sanitized = sanitize_output(tail)
+    if not sanitized:
+        return REASONING_CUTOFF_SENTINEL
+    return f"{REASONING_CUTOFF_SENTINEL}\n\n{sanitized}"
 
 
 def _apply_reasoning_cutoff_notice(


### PR DESCRIPTION
## Why

8-round design carry — six personas (Sarah r1, Theo r2, Astrid r3, Vlad R7-M5, Sven R8-H1, R10-C4) independently reopened H-01 because the bare-sentinel rescue (`[truncated — reasoning incomplete; raise max_tokens]` alone) still felt like "the model didn't answer". This PR extends the rescue to `sentinel + tail-of-reasoning` so a human reader sees the partial conclusion the model was working on when its budget ran out — without exposing reasoning to clients that don't ask for it (the legacy bare-sentinel and the strict-null opt-out paths are preserved).

Closes issue #259 (the 8-round DESIGN carry).

## Behavior

Default-on. Fires when:
- `finish_reason == "length"` AND
- `content` is empty/whitespace AND
- `reasoning_content` is non-empty AND
- no `tool_calls` were extracted

Payload: `"[truncated — reasoning incomplete; raise max_tokens]\n\n<sanitized last 200 chars of reasoning>"`.

`reasoning_content` is **never** mutated — clients that walk both fields still see the full original trace.

## Opt-out

```bash
RAPID_MLX_REASONING_RESCUE=off          # primary R12-8 knob
RAPID_MLX_REASONING_CUTOFF_NOTICE=off   # legacy alias from PR #802 / #860 (still honoured)
```

## Surfaces covered

1. `/v1/chat/completions` non-stream — rescue text in `message.content`
2. `/v1/chat/completions` stream — rescue text in the final `delta.content` chunk
3. `/v1/responses` non-stream — rescue text materializes into an `output_text` message item via `openai_to_responses`
4. `/v1/responses` stream (codex r2 fix) — synthetic message item via the canonical SSE ladder (`output_item.added → content_part.added → output_text.delta → output_text.done → content_part.done → output_item.done`)
5. Anthropic `/v1/messages` — no special handling needed; `content: []` is the spec-compliant empty path

## Codex review

3 rounds to convergence:
- **r1** (11 findings, 2 diff): HIGH #1 rescue tail bypassing `sanitize_output` → fixed by routing the tail through the canonical sanitizer (degrades to bare sentinel if everything was markup); MED #3 streaming `reasoning_token_credit` invariant violation when `completion_tokens=0` → fixed by requiring both `accumulated_reasoning_text AND completion_tokens > 0` as the gate.
- **r2** (8 findings, 1 diff): MED #4 streaming Responses missed the rescue text → fixed by emitting a synthetic message item via the canonical SSE ladder after the reasoning item is emitted on mid-think cutoff.
- **r3** (8 findings, 0 diff): converged on diff. All remaining findings are repo-wide holistic (missing AGENTS.md, oversized modules, dual config sources of truth, stale telemetry/arch docs, weak mypy) — out of scope for this PR.

Codex r2's backup-file-permission finding was security category, skipped per standing rule.

## Tests

282-test sweep (all green):
- 91 r12-8 rescue tests + 6 new sanitization parametrizations (over `</think>`, `<|im_start|>`, `<|im_end|>`, harmony channel marker, `</tool_call>`, `<|endoftext|>`) + all-markup-degrades-to-sentinel
- New `_StubbedShortReasoningEngine` fixture + test pinning `reasoning_tokens <= output_tokens` invariant when `completion_tokens=0`
- New streaming Responses probe asserting BOTH reasoning AND message items appear in `response.completed.response.output[]`, message starts with sentinel, full 6-event SSE ladder fires in order
- Existing tests across harmony / silent-drop / truncation / no-out-of-band-routing / responses bundle / SSE event order — no regressions

## Rebased on main

Pulled in #869 (`fix(responses): exclude REASONING_CUTOFF_SENTINEL from downstream_output_seen`) which independently shipped the parity gate for the pre-r12-8 bare-sentinel shape. The merged version uses exact-match (`content == SENTINEL`) which would miss the post-r12-8 `SENTINEL\n\nTAIL` shape, so the rebase merge resolution widens the check to `startswith(SENTINEL)`.

## Skip-version-bump

0.8.14 already bumped in #871. Adding `skip-version-bump` label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)