### PR TITLE
chore: bump version to 0.8.15

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.8.14"
+version = "0.8.15"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## R12 fix wave bundle — 0.8.15

5 fix PRs landed on top of 0.8.14:

| # | PR | Subject |
|---|----|---------|
| 1 | #870 | feat(cli): rapid-mlx launch <client> — one-shot IDE bootstrap (Cline / Claude Code / Continue / Cursor) |
| 2 | #872 | fix(chat): always emit content key on assistant message (D-MISSING-CONTENT-KEY) |
| 3 | #874 | fix(tool-parser): add deepseek_v3 variant for R1-0528 family (D-DSV31) |
| 4 | #875 | fix(reasoning): rescue tail to content on finish_reason=length (H-01, closes 8-round design carry #259) |
| 5 | #873 | fix(json-schema): enforce strict mode via post-generate validation + repair retry (H-06, closes #423) |

Subject matches auto-release.yml regex; release will publish 0.8.15 to PyPI on merge.