### PR TITLE
fix(responses): plumb chat_template_kwargs through ResponsesRequest (M-2)

### DIFF
--- a/tests/test_responses_chat_template_kwargs.py
+++ b/tests/test_responses_chat_template_kwargs.py
@@ -415,3 +415,164 @@ class TestStrictAutoDisableThinking:
         # the engine.chat kwargs: enable_thinking is False (injected),
         # which proves the merge ran.
         assert engine.chat_calls[0]["kwargs"].get("enable_thinking") is False
+
+
+# ---------------------------------------------------------------------------
+# (4) Engine-level: BatchedEngine.generate_with_schema honors enable_thinking
+# ---------------------------------------------------------------------------
+#
+# Codex round-1 P2 follow-up. Pre-fix, the route-level injection of
+# ``chat_template_kwargs.enable_thinking=False`` flowed into
+# ``chat_kwargs`` and was passed to ``engine.generate_with_schema`` —
+# but the method hard-coded ``shared_apply_chat_template(..., enable_thinking=None)``
+# so the override silently dropped at the prompt-render step on the
+# real ``BatchedEngine``. The route tests above only proved the kwarg
+# REACHED the engine call; this test pins that the engine consumes
+# it and threads it into the chat-template render.
+
+
+class TestBatchedEngineGuidedHonorsEnableThinking:
+    def test_generate_with_schema_pops_enable_thinking_and_forwards_to_render(
+        self,
+    ):
+        """Pin the engine-level contract: ``enable_thinking`` is
+        popped from ``**kwargs`` BEFORE the prompt render and passed
+        through to ``shared_apply_chat_template`` identically to the
+        non-guided ``chat()`` path. Pre-fix the value was hard-coded
+        to None, defeating the route-level auto-disable."""
+        from unittest.mock import MagicMock, patch
+
+        from vllm_mlx.engine.batched import BatchedEngine
+
+        # Build a minimal stub that satisfies the guard rails so we
+        # reach the ``shared_apply_chat_template`` call. We patch the
+        # method itself instead of constructing a full engine — the
+        # contract under test is the kwarg plumbing, not engine init.
+        engine = BatchedEngine.__new__(BatchedEngine)
+        engine._loaded = True
+        engine._is_mllm = False
+        engine._model_name = "qwen3-test"
+        engine._tokenizer = MagicMock()
+        engine._processor = None
+        # Force the supports_guided_generation gate to pass; the real
+        # property reads HAS_GUIDED + ``_is_mllm``. Override on the
+        # instance so the test does not depend on the optional
+        # [guided] extra being installed.
+        type(engine).supports_guided_generation = property(lambda self: True)
+
+        captured: dict = {}
+
+        def _fake_render(tok, messages, *, tools, enable_thinking, model_name):
+            captured["enable_thinking"] = enable_thinking
+            return "PROMPT"
+
+        # Patch BOTH the prompt render and the heavy ``_run_guided_generation``
+        # so the test never has to spin up outlines / mlx.
+        with (
+            patch(
+                "vllm_mlx.engine.batched.shared_apply_chat_template",
+                side_effect=_fake_render,
+            ),
+            patch.object(
+                engine,
+                "_run_guided_generation",
+                return_value=GenerationOutput(
+                    text="{}",
+                    new_text="{}",
+                    prompt_tokens=1,
+                    completion_tokens=1,
+                    finished=True,
+                    finish_reason="stop",
+                    channel=None,
+                ),
+            ),
+            patch(
+                "asyncio.to_thread",
+                side_effect=lambda fn, **kw: _sync_run(fn, **kw),
+            ),
+        ):
+            # ``_model_load_executor`` None forces the to_thread branch
+            engine._model_load_executor = None
+            import asyncio
+
+            asyncio.run(
+                engine.generate_with_schema(
+                    messages=[{"role": "user", "content": "hi"}],
+                    json_schema={"type": "object"},
+                    enable_thinking=False,
+                )
+            )
+
+        assert captured.get("enable_thinking") is False, (
+            "BatchedEngine.generate_with_schema must thread "
+            "enable_thinking from kwargs into shared_apply_chat_template"
+        )
+
+    def test_generate_with_schema_default_enable_thinking_none(self):
+        """Back-compat: when caller passes no ``enable_thinking`` kwarg,
+        the render still receives ``None`` (template default)."""
+        from unittest.mock import MagicMock, patch
+
+        from vllm_mlx.engine.batched import BatchedEngine
+
+        engine = BatchedEngine.__new__(BatchedEngine)
+        engine._loaded = True
+        engine._is_mllm = False
+        engine._model_name = "qwen3-test"
+        engine._tokenizer = MagicMock()
+        engine._processor = None
+        type(engine).supports_guided_generation = property(lambda self: True)
+
+        captured: dict = {}
+
+        def _fake_render(tok, messages, *, tools, enable_thinking, model_name):
+            captured["enable_thinking"] = enable_thinking
+            return "PROMPT"
+
+        with (
+            patch(
+                "vllm_mlx.engine.batched.shared_apply_chat_template",
+                side_effect=_fake_render,
+            ),
+            patch.object(
+                engine,
+                "_run_guided_generation",
+                return_value=GenerationOutput(
+                    text="{}",
+                    new_text="{}",
+                    prompt_tokens=1,
+                    completion_tokens=1,
+                    finished=True,
+                    finish_reason="stop",
+                    channel=None,
+                ),
+            ),
+            patch(
+                "asyncio.to_thread",
+                side_effect=lambda fn, **kw: _sync_run(fn, **kw),
+            ),
+        ):
+            engine._model_load_executor = None
+            import asyncio
+
+            asyncio.run(
+                engine.generate_with_schema(
+                    messages=[{"role": "user", "content": "hi"}],
+                    json_schema={"type": "object"},
+                )
+            )
+
+        assert captured.get("enable_thinking") is None, (
+            "Default enable_thinking must be None (template default)"
+        )
+
+
+async def _sync_run(fn, **kw):
+    """Run a sync callable as if it were threaded.
+
+    Returns the result via an ``async def`` so the awaiting site in
+    ``BatchedEngine.generate_with_schema`` (``await asyncio.to_thread(
+    ...)``) receives a coroutine identical in shape to the real
+    ``asyncio.to_thread``.
+    """
+    return fn(**kw)

--- a/tests/test_responses_chat_template_kwargs.py
+++ b/tests/test_responses_chat_template_kwargs.py
@@ -432,6 +432,97 @@ class TestStrictAutoDisableThinking:
 
 
 class TestBatchedEngineGuidedHonorsEnableThinking:
+    def _build_engine_stub(self):
+        """Build a ``BatchedEngine`` instance that exits the guard
+        rails and reaches ``shared_apply_chat_template`` without
+        loading a real model.
+
+        ``BatchedEngine.__new__`` is used so we don't run ``__init__``
+        (which loads weights + spins up a step thread). The test
+        then assigns the minimal private fields the method reads
+        (``_loaded``, ``_is_mllm``, ``_tokenizer``, ``_processor``,
+        ``_model_name``, ``_model_load_executor``).
+
+        The guard the method enters first is ``supports_guided_generation``
+        which is a ``@property`` on the class — we patch it at the
+        class level INSIDE a ``with patch.object(...)`` block (the
+        caller is responsible for the patch) so the override is
+        scoped to the test and does NOT pollute later tests. Codex
+        round-2 P2 caught this — an unscoped class mutation would
+        make MLLM / no-[guided] tests downstream observe guided
+        support as always enabled, producing order-dependent failures.
+        """
+        from unittest.mock import MagicMock
+
+        from vllm_mlx.engine.batched import BatchedEngine
+
+        engine = BatchedEngine.__new__(BatchedEngine)
+        engine._loaded = True
+        engine._is_mllm = False
+        engine._model_name = "qwen3-test"
+        engine._tokenizer = MagicMock()
+        engine._processor = None
+        engine._model_load_executor = None
+        return engine, BatchedEngine
+
+    def _run_engine_with_capture(
+        self, engine, engine_cls, *, enable_thinking=...,
+    ):
+        """Drive ``engine.generate_with_schema`` with prompt-render +
+        ``_run_guided_generation`` stubbed; return the captured
+        ``enable_thinking`` value the renderer saw."""
+        import asyncio
+        from unittest.mock import patch
+
+        captured: dict = {}
+
+        def _fake_render(tok, messages, *, tools, enable_thinking, model_name):
+            captured["enable_thinking"] = enable_thinking
+            return "PROMPT"
+
+        kwargs = {}
+        if enable_thinking is not ...:
+            kwargs["enable_thinking"] = enable_thinking
+
+        # ``patch.object(engine_cls, ...)`` scopes the property override
+        # to this ``with`` block — codex round-2 P2 fix.
+        with (
+            patch.object(
+                engine_cls,
+                "supports_guided_generation",
+                new_callable=lambda: property(lambda self: True),
+            ),
+            patch(
+                "vllm_mlx.engine.batched.shared_apply_chat_template",
+                side_effect=_fake_render,
+            ),
+            patch.object(
+                engine,
+                "_run_guided_generation",
+                return_value=GenerationOutput(
+                    text="{}",
+                    new_text="{}",
+                    prompt_tokens=1,
+                    completion_tokens=1,
+                    finished=True,
+                    finish_reason="stop",
+                    channel=None,
+                ),
+            ),
+            patch(
+                "asyncio.to_thread",
+                side_effect=_sync_run,
+            ),
+        ):
+            asyncio.run(
+                engine.generate_with_schema(
+                    messages=[{"role": "user", "content": "hi"}],
+                    json_schema={"type": "object"},
+                    **kwargs,
+                )
+            )
+        return captured
+
     def test_generate_with_schema_pops_enable_thinking_and_forwards_to_render(
         self,
     ):
@@ -440,69 +531,10 @@ class TestBatchedEngineGuidedHonorsEnableThinking:
         through to ``shared_apply_chat_template`` identically to the
         non-guided ``chat()`` path. Pre-fix the value was hard-coded
         to None, defeating the route-level auto-disable."""
-        from unittest.mock import MagicMock, patch
-
-        from vllm_mlx.engine.batched import BatchedEngine
-
-        # Build a minimal stub that satisfies the guard rails so we
-        # reach the ``shared_apply_chat_template`` call. We patch the
-        # method itself instead of constructing a full engine — the
-        # contract under test is the kwarg plumbing, not engine init.
-        engine = BatchedEngine.__new__(BatchedEngine)
-        engine._loaded = True
-        engine._is_mllm = False
-        engine._model_name = "qwen3-test"
-        engine._tokenizer = MagicMock()
-        engine._processor = None
-        # Force the supports_guided_generation gate to pass; the real
-        # property reads HAS_GUIDED + ``_is_mllm``. Override on the
-        # instance so the test does not depend on the optional
-        # [guided] extra being installed.
-        type(engine).supports_guided_generation = property(lambda self: True)
-
-        captured: dict = {}
-
-        def _fake_render(tok, messages, *, tools, enable_thinking, model_name):
-            captured["enable_thinking"] = enable_thinking
-            return "PROMPT"
-
-        # Patch BOTH the prompt render and the heavy ``_run_guided_generation``
-        # so the test never has to spin up outlines / mlx.
-        with (
-            patch(
-                "vllm_mlx.engine.batched.shared_apply_chat_template",
-                side_effect=_fake_render,
-            ),
-            patch.object(
-                engine,
-                "_run_guided_generation",
-                return_value=GenerationOutput(
-                    text="{}",
-                    new_text="{}",
-                    prompt_tokens=1,
-                    completion_tokens=1,
-                    finished=True,
-                    finish_reason="stop",
-                    channel=None,
-                ),
-            ),
-            patch(
-                "asyncio.to_thread",
-                side_effect=lambda fn, **kw: _sync_run(fn, **kw),
-            ),
-        ):
-            # ``_model_load_executor`` None forces the to_thread branch
-            engine._model_load_executor = None
-            import asyncio
-
-            asyncio.run(
-                engine.generate_with_schema(
-                    messages=[{"role": "user", "content": "hi"}],
-                    json_schema={"type": "object"},
-                    enable_thinking=False,
-                )
-            )
-
+        engine, engine_cls = self._build_engine_stub()
+        captured = self._run_engine_with_capture(
+            engine, engine_cls, enable_thinking=False
+        )
         assert captured.get("enable_thinking") is False, (
             "BatchedEngine.generate_with_schema must thread "
             "enable_thinking from kwargs into shared_apply_chat_template"
@@ -511,59 +543,69 @@ class TestBatchedEngineGuidedHonorsEnableThinking:
     def test_generate_with_schema_default_enable_thinking_none(self):
         """Back-compat: when caller passes no ``enable_thinking`` kwarg,
         the render still receives ``None`` (template default)."""
-        from unittest.mock import MagicMock, patch
+        engine, engine_cls = self._build_engine_stub()
+        captured = self._run_engine_with_capture(engine, engine_cls)
+        assert captured.get("enable_thinking") is None, (
+            "Default enable_thinking must be None (template default)"
+        )
 
-        from vllm_mlx.engine.batched import BatchedEngine
+    def test_generate_with_schema_preserves_enable_thinking_on_guided_fallback(
+        self,
+    ):
+        """Codex round-2 P2 fix: when ``_run_guided_generation``
+        returns ``None`` and ``raise_on_failure`` is False (the
+        non-strict path), the method falls back to
+        ``self.chat(messages=..., **kwargs)``. The pre-fix code path
+        popped ``enable_thinking`` out of kwargs without re-injecting,
+        so an explicit client preference (or the R12-M2 route-level
+        auto-disable) was silently dropped on the fallback. This
+        test pins the re-injection: ``self.chat`` receives the
+        explicit value in its kwargs."""
+        import asyncio
+        from unittest.mock import patch
 
-        engine = BatchedEngine.__new__(BatchedEngine)
-        engine._loaded = True
-        engine._is_mllm = False
-        engine._model_name = "qwen3-test"
-        engine._tokenizer = MagicMock()
-        engine._processor = None
-        type(engine).supports_guided_generation = property(lambda self: True)
+        engine, engine_cls = self._build_engine_stub()
+        chat_kwargs_seen: dict = {}
 
-        captured: dict = {}
-
-        def _fake_render(tok, messages, *, tools, enable_thinking, model_name):
-            captured["enable_thinking"] = enable_thinking
-            return "PROMPT"
+        async def _fake_chat(*, messages, **kwargs):
+            chat_kwargs_seen.update(kwargs)
+            return GenerationOutput(
+                text="{}",
+                new_text="{}",
+                prompt_tokens=1,
+                completion_tokens=1,
+                finished=True,
+                finish_reason="stop",
+                channel=None,
+            )
 
         with (
+            patch.object(
+                engine_cls,
+                "supports_guided_generation",
+                new_callable=lambda: property(lambda self: True),
+            ),
             patch(
                 "vllm_mlx.engine.batched.shared_apply_chat_template",
-                side_effect=_fake_render,
+                return_value="PROMPT",
             ),
             patch.object(
-                engine,
-                "_run_guided_generation",
-                return_value=GenerationOutput(
-                    text="{}",
-                    new_text="{}",
-                    prompt_tokens=1,
-                    completion_tokens=1,
-                    finished=True,
-                    finish_reason="stop",
-                    channel=None,
-                ),
+                engine, "_run_guided_generation", return_value=None
             ),
-            patch(
-                "asyncio.to_thread",
-                side_effect=lambda fn, **kw: _sync_run(fn, **kw),
-            ),
+            patch.object(engine, "chat", side_effect=_fake_chat),
+            patch("asyncio.to_thread", side_effect=_sync_run),
         ):
-            engine._model_load_executor = None
-            import asyncio
-
             asyncio.run(
                 engine.generate_with_schema(
                     messages=[{"role": "user", "content": "hi"}],
                     json_schema={"type": "object"},
+                    enable_thinking=False,
                 )
             )
 
-        assert captured.get("enable_thinking") is None, (
-            "Default enable_thinking must be None (template default)"
+        assert chat_kwargs_seen.get("enable_thinking") is False, (
+            "Guided fallback to self.chat must preserve the client's "
+            "enable_thinking choice (codex round-2 P2)"
         )
 
 

--- a/tests/test_responses_chat_template_kwargs.py
+++ b/tests/test_responses_chat_template_kwargs.py
@@ -47,11 +47,7 @@ from vllm_mlx.api.responses_models import ResponsesRequest
 from vllm_mlx.config import reset_config
 from vllm_mlx.engine.base import GenerationOutput
 from vllm_mlx.middleware.exception_handlers import install_exception_handlers
-from vllm_mlx.service.helpers import (
-    _extract_thinking_from_request,
-    _resolve_enable_thinking,
-)
-
+from vllm_mlx.service.helpers import _resolve_enable_thinking
 
 # ---------------------------------------------------------------------------
 # (1) Pydantic-model parity — fields are no longer silently dropped
@@ -270,7 +266,7 @@ def _strict_responses_payload(
 ) -> dict:
     body: dict = {
         "model": "test-model",
-        "input": "Return {\"age\":25}",
+        "input": 'Return {"age":25}',
         "text": {
             "format": {
                 "type": "json_schema",
@@ -288,9 +284,7 @@ def _strict_responses_payload(
 
 
 class TestStrictAutoDisableThinking:
-    def test_strict_with_explicit_disable_kwarg_returns_200(
-        self, _rate_limiter_state
-    ):
+    def test_strict_with_explicit_disable_kwarg_returns_200(self, _rate_limiter_state):
         """Probe-3a parity: strict + valid prompt + explicit
         ``chat_template_kwargs={"enable_thinking":false}`` → 200 with
         valid JSON. Pre-fix the kwarg was silently dropped and the
@@ -365,7 +359,7 @@ class TestStrictAutoDisableThinking:
         assert engine.chat_calls, "engine.chat was not called"
         assert engine.chat_calls[0]["kwargs"].get("enable_thinking") is True
 
-    def test_non_strict_request_does_NOT_auto_disable(self, _rate_limiter_state):
+    def test_non_strict_request_does_not_auto_disable(self, _rate_limiter_state):  # noqa: N802
         """Auto-disable is scoped strictly to strict json_schema. A
         plain prompt (no response_format) must reach the engine with
         whatever the client expressed (None here)."""
@@ -466,7 +460,11 @@ class TestBatchedEngineGuidedHonorsEnableThinking:
         return engine, BatchedEngine
 
     def _run_engine_with_capture(
-        self, engine, engine_cls, *, enable_thinking=...,
+        self,
+        engine,
+        engine_cls,
+        *,
+        enable_thinking=...,
     ):
         """Drive ``engine.generate_with_schema`` with prompt-render +
         ``_run_guided_generation`` stubbed; return the captured
@@ -589,9 +587,7 @@ class TestBatchedEngineGuidedHonorsEnableThinking:
                 "vllm_mlx.engine.batched.shared_apply_chat_template",
                 return_value="PROMPT",
             ),
-            patch.object(
-                engine, "_run_guided_generation", return_value=None
-            ),
+            patch.object(engine, "_run_guided_generation", return_value=None),
             patch.object(engine, "chat", side_effect=_fake_chat),
             patch("asyncio.to_thread", side_effect=_sync_run),
         ):

--- a/tests/test_responses_chat_template_kwargs.py
+++ b/tests/test_responses_chat_template_kwargs.py
@@ -391,23 +391,59 @@ class TestStrictAutoDisableThinking:
     def test_extra_chat_template_kwargs_keys_survive_auto_disable_merge(
         self, _rate_limiter_state
     ):
-        """If the client passes ``chat_template_kwargs`` with keys
-        OTHER than enable_thinking (e.g. a forward-compat extension),
-        the auto-disable must merge — not replace — so the unknown
-        keys survive."""
+        """Codex round-3 BLOCKING: pin that the future-compat key
+        ``future_key`` ACTUALLY survives the auto-disable merge on
+        the materialized ``ChatCompletionRequest``. Pre-fix the
+        previous version of this test only asserted
+        ``enable_thinking`` reached the engine — it would have
+        passed even if production REPLACED ``chat_template_kwargs``
+        with only ``{"enable_thinking": False}``.
+
+        Strategy: spy on ``_resolve_enable_thinking`` (called by the
+        route immediately AFTER the auto-disable injection) and
+        snapshot the request's ``chat_template_kwargs`` at that
+        instant — which is the post-merge state. Asserting both
+        ``enable_thinking=False`` AND ``future_key="x"`` are
+        present pins the merge contract.
+        """
         engine = _Engine(supports_guided=False, chat_text=_VALID_PAYLOAD)
         client = _make_responses_client(engine)
-        body = _strict_responses_payload(
-            strict=True,
-            chat_template_kwargs={"future_key": "x"},
-        )
-        resp = client.post("/v1/responses", json=body)
+        captured_ctk: list[dict | None] = []
+
+        # The route calls ``_resolve_enable_thinking(openai_request)``
+        # MULTIPLE times after the injection (context-length gate
+        # first, then chat_kwargs build). Snapshot the request's
+        # chat_template_kwargs at the first call — that's the
+        # post-merge state.
+        import vllm_mlx.routes.responses as _responses_mod
+
+        original = _responses_mod._resolve_enable_thinking
+
+        def _spy(openai_request):
+            ctk = getattr(openai_request, "chat_template_kwargs", None)
+            # ``dict(ctk)`` to snapshot — later code might mutate.
+            captured_ctk.append(dict(ctk) if ctk is not None else None)
+            return original(openai_request)
+
+        with patch.object(_responses_mod, "_resolve_enable_thinking", side_effect=_spy):
+            body = _strict_responses_payload(
+                strict=True,
+                chat_template_kwargs={"future_key": "x"},
+            )
+            resp = client.post("/v1/responses", json=body)
+
         assert resp.status_code == 200, resp.text
-        # The injection set enable_thinking=False, but future_key must
-        # have survived on the materialized ChatCompletionRequest.
-        # We can't observe the request from here, but we can observe
-        # the engine.chat kwargs: enable_thinking is False (injected),
-        # which proves the merge ran.
+        # The spy must have been called at least once (route always
+        # calls _resolve_enable_thinking).
+        assert captured_ctk, "_resolve_enable_thinking was never called"
+        first_seen = captured_ctk[0]
+        # Both the auto-injected key and the client-supplied
+        # ``future_key`` must be on the merged dict.
+        assert first_seen == {"future_key": "x", "enable_thinking": False}, (
+            "auto-disable merge dropped the client's forward-compat "
+            f"key: got {first_seen}"
+        )
+        # Independent sanity: the engine receives the resolved value too.
         assert engine.chat_calls[0]["kwargs"].get("enable_thinking") is False
 
 

--- a/tests/test_responses_chat_template_kwargs.py
+++ b/tests/test_responses_chat_template_kwargs.py
@@ -1,0 +1,417 @@
+# SPDX-License-Identifier: Apache-2.0
+"""R12-M2 — ``chat_template_kwargs`` / ``enable_thinking`` on /v1/responses.
+
+Pins Mira r12 finding R-1 + R-2: pre-fix the ``ResponsesRequest`` pydantic
+model declared neither knob, so a client sending the OpenAI-extension
+shape ``chat_template_kwargs={"enable_thinking":false}`` had the key
+silently dropped, ``_resolve_enable_thinking`` returned ``None``, and
+the Qwen3 / DeepSeek-R1 chat template pre-injected ``<think>``. On the
+strict-json_schema path the model then exhausted ``max_output_tokens``
+inside ``<think>`` before emitting JSON, so the strict-postgen
+validator surfaced 422 ``reason:"invalid_json"`` even on a perfectly
+valid happy-path prompt — making strict json_schema unusable on
+thinking models from /v1/responses.
+
+This test file pins four contracts:
+
+  1. The two fields round-trip on ``ResponsesRequest`` (parity with
+     ``ChatCompletionRequest``).
+  2. ``responses_to_openai`` forwards both fields onto the
+     materialized ``ChatCompletionRequest`` so the existing
+     ``_resolve_enable_thinking`` helper sees them.
+  3. Auto-disable behavior: when strict json_schema is requested AND
+     the client did NOT pin either knob, the route injects
+     ``chat_template_kwargs.enable_thinking=False`` onto the
+     materialized request so thinking models do not burn the budget
+     inside ``<think>``. Strict + valid prompt + thinking model →
+     HTTP 200 with valid JSON.
+  4. Explicit-override is preserved: a client that sets
+     ``enable_thinking=True`` on a strict request gets thinking on
+     and accepts the budget risk — the auto-disable does NOT
+     override their explicit choice.
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from vllm_mlx.api import response_format_metrics
+from vllm_mlx.api.responses_adapter import responses_to_openai
+from vllm_mlx.api.responses_models import ResponsesRequest
+from vllm_mlx.config import reset_config
+from vllm_mlx.engine.base import GenerationOutput
+from vllm_mlx.middleware.exception_handlers import install_exception_handlers
+from vllm_mlx.service.helpers import (
+    _extract_thinking_from_request,
+    _resolve_enable_thinking,
+)
+
+
+# ---------------------------------------------------------------------------
+# (1) Pydantic-model parity — fields are no longer silently dropped
+# ---------------------------------------------------------------------------
+
+
+class TestResponsesRequestFields:
+    def test_chat_template_kwargs_field_accepted(self):
+        """Pre-fix: this dict was silently dropped on parse, then
+        ``_resolve_enable_thinking`` returned None and the template
+        pre-injected ``<think>``."""
+        r = ResponsesRequest(
+            model="qwen3",
+            input="hi",
+            chat_template_kwargs={"enable_thinking": False},
+        )
+        assert r.chat_template_kwargs == {"enable_thinking": False}
+
+    def test_enable_thinking_top_level_field_accepted(self):
+        """Top-level convenience knob round-trips like the chat surface."""
+        r = ResponsesRequest(model="qwen3", input="hi", enable_thinking=False)
+        assert r.enable_thinking is False
+
+    def test_both_fields_default_to_none(self):
+        r = ResponsesRequest(model="qwen3", input="hi")
+        assert r.chat_template_kwargs is None
+        assert r.enable_thinking is None
+
+    def test_chat_template_kwargs_arbitrary_keys_preserved(self):
+        """Forward-compat: unknown keys round-trip untouched."""
+        r = ResponsesRequest(
+            model="qwen3",
+            input="hi",
+            chat_template_kwargs={"enable_thinking": True, "future_key": "x"},
+        )
+        assert r.chat_template_kwargs == {"enable_thinking": True, "future_key": "x"}
+
+
+# ---------------------------------------------------------------------------
+# (2) Adapter forwards both knobs onto the materialized ChatCompletionRequest
+# ---------------------------------------------------------------------------
+
+
+class TestAdapterForwarding:
+    def test_chat_template_kwargs_forwarded_to_chat_request(self):
+        r = ResponsesRequest(
+            model="qwen3",
+            input="hi",
+            chat_template_kwargs={"enable_thinking": False},
+        )
+        chat = responses_to_openai(r)
+        assert chat.chat_template_kwargs == {"enable_thinking": False}
+
+    def test_enable_thinking_forwarded_to_chat_request(self):
+        r = ResponsesRequest(model="qwen3", input="hi", enable_thinking=True)
+        chat = responses_to_openai(r)
+        assert chat.enable_thinking is True
+
+    def test_resolve_sees_forwarded_chat_template_kwargs(self):
+        """End-to-end: the materialized ChatCompletionRequest must be
+        readable by ``_resolve_enable_thinking`` (which is what
+        routes/responses.py calls). Pre-fix this resolved to ``None``
+        because the adapter never knew about the field."""
+        r = ResponsesRequest(
+            model="qwen3",
+            input="hi",
+            chat_template_kwargs={"enable_thinking": False},
+        )
+        chat = responses_to_openai(r)
+        with patch(
+            "vllm_mlx.service.helpers.get_config",
+            return_value=SimpleNamespace(no_thinking=False),
+        ):
+            assert _resolve_enable_thinking(chat) is False
+
+    def test_resolve_sees_top_level_when_no_ctk(self):
+        r = ResponsesRequest(model="qwen3", input="hi", enable_thinking=True)
+        chat = responses_to_openai(r)
+        with patch(
+            "vllm_mlx.service.helpers.get_config",
+            return_value=SimpleNamespace(no_thinking=False),
+        ):
+            assert _resolve_enable_thinking(chat) is True
+
+    def test_resolve_returns_none_when_neither_set(self):
+        """Default path — template-default applies downstream."""
+        r = ResponsesRequest(model="qwen3", input="hi")
+        chat = responses_to_openai(r)
+        with patch(
+            "vllm_mlx.service.helpers.get_config",
+            return_value=SimpleNamespace(no_thinking=False),
+        ):
+            assert _resolve_enable_thinking(chat) is None
+
+
+# ---------------------------------------------------------------------------
+# (3) Route-level: strict json_schema auto-disable behavior on /v1/responses
+# ---------------------------------------------------------------------------
+
+
+_VALID_SCHEMA = {
+    "type": "object",
+    "properties": {"age": {"type": "integer", "minimum": 0}},
+    "required": ["age"],
+    "additionalProperties": False,
+}
+_VALID_PAYLOAD = json.dumps({"age": 25})
+
+
+class _Engine:
+    """Thinking-model-shaped mock.
+
+    Captures the ``enable_thinking`` kwarg the route passes to
+    ``engine.chat`` / ``generate_with_schema`` so tests can pin
+    whether the auto-disable fired.
+    """
+
+    preserve_native_tool_format = False
+    is_mllm = False
+    tokenizer = None
+
+    def __init__(
+        self,
+        *,
+        supports_guided: bool = False,
+        chat_text: str = _VALID_PAYLOAD,
+        guided_text: str = _VALID_PAYLOAD,
+    ):
+        self.supports_guided_generation = supports_guided
+        self._chat_text = chat_text
+        self._guided_text = guided_text
+        self.chat_calls: list[dict] = []
+        self.guided_calls: list[dict] = []
+
+    def build_prompt(self, messages, tools=None, enable_thinking=None):
+        return "PROMPT"
+
+    async def chat(self, *, messages, **kwargs):
+        self.chat_calls.append({"messages": messages, "kwargs": kwargs})
+        return GenerationOutput(
+            text=self._chat_text,
+            new_text=self._chat_text,
+            prompt_tokens=4,
+            completion_tokens=5,
+            finished=True,
+            finish_reason="stop",
+            channel=None,
+        )
+
+    async def generate_with_schema(self, *, messages, json_schema, **kwargs):
+        self.guided_calls.append(
+            {"messages": messages, "json_schema": json_schema, "kwargs": kwargs}
+        )
+        return GenerationOutput(
+            text=self._guided_text,
+            new_text=self._guided_text,
+            prompt_tokens=4,
+            completion_tokens=5,
+            finished=True,
+            finish_reason="stop",
+            channel=None,
+        )
+
+
+@pytest.fixture
+def _rate_limiter_state():
+    """Mirror of the strict-test fixture — save/restore the global
+    rate-limiter so tests don't leak disabled state across the suite."""
+    from vllm_mlx.middleware.auth import rate_limiter
+
+    saved_enabled = rate_limiter.enabled
+    saved_rpm = rate_limiter.requests_per_minute
+    saved_requests = dict(rate_limiter._requests)
+    rate_limiter.enabled = False
+    rate_limiter.requests_per_minute = 60
+    rate_limiter._requests.clear()
+    yield rate_limiter
+    rate_limiter.enabled = saved_enabled
+    rate_limiter.requests_per_minute = saved_rpm
+    rate_limiter._requests.clear()
+    rate_limiter._requests.update(saved_requests)
+
+
+@pytest.fixture(autouse=True)
+def _reset_metrics_between_tests():
+    response_format_metrics.reset_for_tests()
+    yield
+    response_format_metrics.reset_for_tests()
+
+
+def _make_responses_client(engine: _Engine) -> TestClient:
+    """Mount /v1/responses with the shared cfg / metrics surface.
+
+    Note: ``cfg.no_thinking = False`` — we want to exercise the
+    request-level resolution path, NOT the operator-level kill switch.
+    """
+    from vllm_mlx.routes.responses import router as responses_router
+
+    cfg = reset_config()
+    cfg.engine = engine
+    cfg.model_name = "test-model"
+    cfg.model_registry = None
+    cfg.no_thinking = False
+
+    app = FastAPI()
+    install_exception_handlers(app)
+    app.include_router(responses_router)
+    return TestClient(app)
+
+
+def _strict_responses_payload(
+    *,
+    strict: bool = True,
+    chat_template_kwargs: dict | None = None,
+    enable_thinking: bool | None = None,
+) -> dict:
+    body: dict = {
+        "model": "test-model",
+        "input": "Return {\"age\":25}",
+        "text": {
+            "format": {
+                "type": "json_schema",
+                "name": "p",
+                "schema": _VALID_SCHEMA,
+                "strict": strict,
+            }
+        },
+    }
+    if chat_template_kwargs is not None:
+        body["chat_template_kwargs"] = chat_template_kwargs
+    if enable_thinking is not None:
+        body["enable_thinking"] = enable_thinking
+    return body
+
+
+class TestStrictAutoDisableThinking:
+    def test_strict_with_explicit_disable_kwarg_returns_200(
+        self, _rate_limiter_state
+    ):
+        """Probe-3a parity: strict + valid prompt + explicit
+        ``chat_template_kwargs={"enable_thinking":false}`` → 200 with
+        valid JSON. Pre-fix the kwarg was silently dropped and the
+        request 422'd."""
+        engine = _Engine(supports_guided=False, chat_text=_VALID_PAYLOAD)
+        client = _make_responses_client(engine)
+        resp = client.post(
+            "/v1/responses",
+            json=_strict_responses_payload(
+                strict=True,
+                chat_template_kwargs={"enable_thinking": False},
+            ),
+        )
+        assert resp.status_code == 200, resp.text
+        # The forwarded kwarg must have reached engine.chat
+        assert engine.chat_calls, "engine.chat was not called"
+        assert engine.chat_calls[0]["kwargs"].get("enable_thinking") is False
+
+    def test_strict_with_no_thinking_preference_auto_disables(
+        self, _rate_limiter_state
+    ):
+        """R12-M2 auto-disable: strict + no client preference →
+        thinking is auto-disabled so the model doesn't burn the
+        budget. Net effect: HTTP 200 on a thinking model + happy-path
+        prompt, even though the client did NOT pass any thinking
+        kwarg."""
+        engine = _Engine(supports_guided=False, chat_text=_VALID_PAYLOAD)
+        client = _make_responses_client(engine)
+        resp = client.post(
+            "/v1/responses",
+            json=_strict_responses_payload(strict=True),
+        )
+        assert resp.status_code == 200, resp.text
+        # The injection must have flowed through to engine.chat
+        assert engine.chat_calls, "engine.chat was not called"
+        assert engine.chat_calls[0]["kwargs"].get("enable_thinking") is False
+
+    def test_strict_with_explicit_enable_thinking_true_is_preserved(
+        self, _rate_limiter_state
+    ):
+        """An explicit ``enable_thinking=true`` on a strict request
+        is NOT overridden by the auto-disable — the client opted in
+        and accepts the budget risk. The mock here returns valid
+        JSON regardless, so we still 200; the asserted invariant is
+        the forwarded kwarg shape."""
+        engine = _Engine(supports_guided=False, chat_text=_VALID_PAYLOAD)
+        client = _make_responses_client(engine)
+        resp = client.post(
+            "/v1/responses",
+            json=_strict_responses_payload(strict=True, enable_thinking=True),
+        )
+        assert resp.status_code == 200, resp.text
+        assert engine.chat_calls, "engine.chat was not called"
+        # User's explicit True is preserved end-to-end.
+        assert engine.chat_calls[0]["kwargs"].get("enable_thinking") is True
+
+    def test_strict_with_explicit_chat_template_kwargs_true_is_preserved(
+        self, _rate_limiter_state
+    ):
+        """OpenAI-extension shape mirrors the top-level field: an
+        explicit ``True`` on the nested kwarg is not auto-overridden."""
+        engine = _Engine(supports_guided=False, chat_text=_VALID_PAYLOAD)
+        client = _make_responses_client(engine)
+        resp = client.post(
+            "/v1/responses",
+            json=_strict_responses_payload(
+                strict=True,
+                chat_template_kwargs={"enable_thinking": True},
+            ),
+        )
+        assert resp.status_code == 200, resp.text
+        assert engine.chat_calls, "engine.chat was not called"
+        assert engine.chat_calls[0]["kwargs"].get("enable_thinking") is True
+
+    def test_non_strict_request_does_NOT_auto_disable(self, _rate_limiter_state):
+        """Auto-disable is scoped strictly to strict json_schema. A
+        plain prompt (no response_format) must reach the engine with
+        whatever the client expressed (None here)."""
+        engine = _Engine(supports_guided=False, chat_text="hi back")
+        client = _make_responses_client(engine)
+        resp = client.post(
+            "/v1/responses",
+            json={"model": "test-model", "input": "hi"},
+        )
+        assert resp.status_code == 200, resp.text
+        # No injection on the non-strict path.
+        assert engine.chat_calls, "engine.chat was not called"
+        assert "enable_thinking" not in engine.chat_calls[0]["kwargs"]
+
+    def test_strict_via_guided_path_also_auto_disables(self, _rate_limiter_state):
+        """Auto-disable fires whether the engine has [guided] or not —
+        the injection happens BEFORE the guided / fallback split.
+        Asserted on the guided_calls kwargs."""
+        engine = _Engine(supports_guided=True, guided_text=_VALID_PAYLOAD)
+        client = _make_responses_client(engine)
+        resp = client.post(
+            "/v1/responses",
+            json=_strict_responses_payload(strict=True),
+        )
+        assert resp.status_code == 200, resp.text
+        assert engine.guided_calls, "engine.generate_with_schema was not called"
+        assert engine.guided_calls[0]["kwargs"].get("enable_thinking") is False
+
+    def test_extra_chat_template_kwargs_keys_survive_auto_disable_merge(
+        self, _rate_limiter_state
+    ):
+        """If the client passes ``chat_template_kwargs`` with keys
+        OTHER than enable_thinking (e.g. a forward-compat extension),
+        the auto-disable must merge — not replace — so the unknown
+        keys survive."""
+        engine = _Engine(supports_guided=False, chat_text=_VALID_PAYLOAD)
+        client = _make_responses_client(engine)
+        body = _strict_responses_payload(
+            strict=True,
+            chat_template_kwargs={"future_key": "x"},
+        )
+        resp = client.post("/v1/responses", json=body)
+        assert resp.status_code == 200, resp.text
+        # The injection set enable_thinking=False, but future_key must
+        # have survived on the materialized ChatCompletionRequest.
+        # We can't observe the request from here, but we can observe
+        # the engine.chat kwargs: enable_thinking is False (injected),
+        # which proves the merge ran.
+        assert engine.chat_calls[0]["kwargs"].get("enable_thinking") is False

--- a/vllm_mlx/api/responses_adapter.py
+++ b/vllm_mlx/api/responses_adapter.py
@@ -384,6 +384,18 @@ def responses_to_openai(request: ResponsesRequest) -> ChatCompletionRequest:
         # parse, validate, and stop here — the ChatCompletionRequest
         # the rest of the pipeline reads would carry None.
         seed=request.seed,
+        # R12-M2 (Mira r12 / finding R-1) — forward the two
+        # thinking-control knobs so ``_resolve_enable_thinking``
+        # (which the rest of the /v1/responses pipeline calls on the
+        # materialized ``ChatCompletionRequest``) sees the client's
+        # explicit choice. Without these the Responses surface had
+        # no way to opt thinking models out of pre-injecting
+        # ``<think>``, which made strict json_schema unusable on
+        # thinking models (every request 422'd with
+        # ``reason:"invalid_json"`` because the model exhausted the
+        # token budget inside ``<think>`` before emitting JSON).
+        chat_template_kwargs=request.chat_template_kwargs,
+        enable_thinking=request.enable_thinking,
     )
 
 

--- a/vllm_mlx/api/responses_models.py
+++ b/vllm_mlx/api/responses_models.py
@@ -187,6 +187,36 @@ class ResponsesRequest(BaseModel):
     # r10-R1: every value (int / list / null / case-variant / garbage
     # string) 200'd on this surface pre-fix.
     reasoning_effort: str | None = None
+    # R12-M2 (Mira r12 / finding R-1) — surface parity with
+    # ``ChatCompletionRequest`` for the two thinking-control knobs.
+    # Pre-fix /v1/responses had no declared field for either, so a
+    # client sending ``chat_template_kwargs={"enable_thinking":false}``
+    # (the OpenAI-extension shape Qwen / DeepSeek-R1 honor) had the key
+    # silently dropped by Pydantic, then the route's
+    # ``_resolve_enable_thinking`` consult returned ``None`` (template
+    # default = True for the Qwen3 family) and the model burned the
+    # whole token budget inside ``<think>`` before emitting JSON. The
+    # strict-json_schema path then 422'd with ``reason:"invalid_json"``
+    # on a perfectly valid happy-path prompt — a soft-broken state
+    # for SDK consumers because the envelope incorrectly suggests
+    # their schema is at fault. Declaring the fields here makes the
+    # passthrough first-class on this surface (parity with chat) and
+    # ``responses_to_openai`` forwards them onto the materialized
+    # ``ChatCompletionRequest`` so the existing
+    # ``_resolve_enable_thinking`` helper resolves them identically
+    # to /v1/chat/completions.
+    #
+    # ``chat_template_kwargs`` is intentionally typed as a dict — the
+    # only key rapid-mlx consumes today is ``enable_thinking`` (other
+    # keys round-trip but no-op), and the chat surface uses the same
+    # unconstrained ``dict`` shape (api/models.py line 1511) so the
+    # two routes share one contract.
+    chat_template_kwargs: dict | None = None
+    # ``enable_thinking`` is the rapid-mlx convenience top-level knob;
+    # the OpenAI-extension shape ``chat_template_kwargs.enable_thinking``
+    # wins when both are set (see service/helpers.py
+    # ``_extract_thinking_from_request`` precedence).
+    enable_thinking: bool | None = None
 
     @field_validator("seed", mode="before")
     @classmethod

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -2142,6 +2142,22 @@ class BatchedEngine(BaseEngine):
         if not self._loaded:
             await self.start()
 
+        # R12-M2 (codex round-1 P2 follow-up to Mira r12 R-1/R-2):
+        # honour ``enable_thinking`` on the guided path. Pre-fix this
+        # call hard-coded ``enable_thinking=None``, which silently
+        # discarded the route-level auto-disable on strict json_schema
+        # AND any explicit ``chat_template_kwargs={"enable_thinking":
+        # false}`` the client passed. On Qwen3 / DeepSeek-R1 thinking
+        # models the template then pre-injected ``<think>`` and the
+        # model burned the entire ``max_tokens`` budget inside
+        # ``<think>`` before reaching the guided JSON grammar — the
+        # exact half-broken state Mira r12 R-2 documented, just shifted
+        # from the fallback path to the [guided]-installed path.
+        # Pull the kwarg out of ``**kwargs`` BEFORE the prompt render
+        # so the upstream caller's choice (None / True / False) flows
+        # into ``shared_apply_chat_template`` identically to the
+        # non-guided ``chat()`` path.
+        enable_thinking = kwargs.pop("enable_thinking", None)
         # Build prompt from messages. Route through the central
         # ``shared_apply_chat_template`` wrapper so the role-marker
         # sanitisation runs on user/tool message content here too —
@@ -2153,7 +2169,7 @@ class BatchedEngine(BaseEngine):
             tokenizer,
             messages,
             tools=None,
-            enable_thinking=None,
+            enable_thinking=enable_thinking,
             model_name=getattr(self, "_model_name", "") or "",
         )
 

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -2224,6 +2224,21 @@ class BatchedEngine(BaseEngine):
             logger.warning(
                 "Guided generation failed, falling back to regular generation"
             )
+            # R12-M2 (codex round-2 P2): re-inject enable_thinking
+            # into the fallback kwargs. We popped it out above so the
+            # guided prompt render could consume it explicitly; the
+            # fallback ``self.chat(...)`` runs its own prompt render
+            # (via ``_apply_chat_template``) and reads
+            # ``enable_thinking`` off ``**kwargs`` (batched.py L1439).
+            # Without this re-injection an explicit
+            # ``enable_thinking=False`` (or the R12-M2 route-level
+            # auto-disable on strict json_schema) would be lost on
+            # the fallback path, reverting to the template default.
+            # Non-strict json_schema callers leave ``raise_on_failure``
+            # at its default ``False`` so this is a reachable code
+            # path, not a defense-in-depth nit.
+            if enable_thinking is not None:
+                kwargs["enable_thinking"] = enable_thinking
             return await self.chat(messages=messages, max_tokens=max_tokens, **kwargs)
 
         # Tokenize for completion count

--- a/vllm_mlx/routes/responses.py
+++ b/vllm_mlx/routes/responses.py
@@ -82,6 +82,7 @@ from ..service.helpers import (
     _check_admission_or_503,
     _disconnect_guard,
     _effective_enable_thinking,
+    _extract_thinking_from_request,
     _finalize_content_and_reasoning,
     _parse_tool_calls_with_parser,
     _release_admission_unless_committed,
@@ -496,6 +497,55 @@ async def create_response(request: Request):
                         "[guided] — engaging R12-4 post-generate "
                         "validation + repair retry."
                     )
+
+            # R12-M2 (Mira r12 / finding R-2) — auto-disable thinking
+            # on the strict json_schema path WHEN the client did not
+            # express a preference. The chat surface lets users opt
+            # out via ``chat_template_kwargs={"enable_thinking":false}``;
+            # R12-M2 wires that knob through to /v1/responses too
+            # (finding R-1). But operator preference is "convenience
+            # for agents" — most strict-json callers care about the
+            # final JSON, not the chain-of-thought, and on thinking
+            # models (Qwen3 / DeepSeek-R1) the default-on
+            # ``<think>`` channel routinely exhausts the token budget
+            # before the schema-conformant body is emitted, turning
+            # every strict request into a 422 ``invalid_json`` on the
+            # happy path. So under strict json_schema we flip the
+            # default from "template default (= thinking on)" to
+            # "thinking off" — same shape OpenAI's structured-output
+            # mode uses (reasoning is off unless the caller asks for
+            # it).
+            #
+            # Gated on _both_ knobs being unset: when the client
+            # EXPLICITLY set ``chat_template_kwargs.enable_thinking``
+            # (either True or False) or the top-level
+            # ``enable_thinking`` field, we honor their choice and do
+            # NOT override (a strict caller who deliberately wants
+            # thinking-on can ask for it and accept the budget risk —
+            # they just have to raise ``max_output_tokens``). We
+            # express the override by injecting
+            # ``chat_template_kwargs.enable_thinking=False`` onto the
+            # materialized ``ChatCompletionRequest`` so every
+            # downstream consult (the token-budget gate immediately
+            # below, ``engine.chat`` / ``generate_with_schema``,
+            # ``_finalize_content_and_reasoning``) sees the same
+            # resolved choice.
+            if _extract_thinking_from_request(openai_request) is None:
+                existing_ctk = openai_request.chat_template_kwargs or {}
+                # Merge rather than replace so any non-thinking keys
+                # the client passed survive (forward-compat).
+                merged_ctk = dict(existing_ctk)
+                merged_ctk["enable_thinking"] = False
+                openai_request.chat_template_kwargs = merged_ctk
+                logger.info(
+                    "R12-M2 auto-disable: strict json_schema on "
+                    "/v1/responses with no client-set thinking "
+                    "preference — injecting "
+                    "chat_template_kwargs.enable_thinking=False so "
+                    "thinking models do not burn the token budget "
+                    "inside <think>. Set chat_template_kwargs."
+                    "enable_thinking=true to opt back in."
+                )
 
         try:
             validate_content_blocks_for_capabilities(


### PR DESCRIPTION
## Summary

Mira r12 dogfood reported HIGH finding R-1 + R-2: strict json_schema on `/v1/responses` is half-broken because `ResponsesRequest` lacks `chat_template_kwargs` / `enable_thinking` fields. Thinking models exhaust the token budget inside `<think>` before emitting JSON, so every strict request 422s with `reason:"invalid_json"` — even on valid happy-path prompts. The chat surface already exposes the knob (which is why #873 strict works on `/v1/chat/completions` with `chat_template_kwargs={"enable_thinking":false}`); the Responses surface dropped it.

## Repro

```bash
# Pre-fix on rapid-mlx 0.8.15 with mlx-community/Qwen3-0.6B-bf16
curl -X POST :8091/v1/responses \
  -d '{"model":"mlx-community/Qwen3-0.6B-bf16","input":"Return {\"age\":25}",
       "max_output_tokens":200,
       "chat_template_kwargs":{"enable_thinking":false},
       "text":{"format":{"type":"json_schema","name":"p","strict":true,
       "schema":{"type":"object","properties":{"age":{"type":"integer","minimum":18}},
       "required":["age"],"additionalProperties":false}}}}'
# Got: 422 reason:invalid_json (kwarg was silently dropped; <think> ate the budget)
```

Same payload on `/v1/chat/completions` → HTTP 200 with `{"age": 25}`. Mira-r12 status matrix probes 3a–3c + 3-valid all reproduce. See `/tmp/dogfood-0815/mira-r12.md`.

## Root cause (parity gap with chat surface)

* `ResponsesRequest` declared neither `chat_template_kwargs` nor `enable_thinking`, so Pydantic silently dropped both fields on parse.
* `_resolve_enable_thinking(openai_request)` then returned `None` (template default).
* The Qwen3 chat template treats `None` as "thinking on" and pre-injects `<think>`.
* On the strict-json_schema path the model exhausted `max_output_tokens` inside `<think>` before emitting JSON, and the strict-postgen validator surfaced 422 `reason:"invalid_json"`.

`ChatCompletionRequest` already declares both fields (`api/models.py` L1506+L1511); this PR mirrors them onto the Responses surface and threads the values through `responses_to_openai` so all downstream consults see the same resolved choice.

## Systematic fix

1. **`vllm_mlx/api/responses_models.py`** — declare `chat_template_kwargs: dict | None = None` and `enable_thinking: bool | None = None` on `ResponsesRequest`. Same dict-shape contract as the chat surface (no nested validator — the OpenAI extension is unconstrained).
2. **`vllm_mlx/api/responses_adapter.py`** — `responses_to_openai` forwards both fields onto the materialized `ChatCompletionRequest` so `_resolve_enable_thinking(openai_request)` works identically across surfaces.
3. **`vllm_mlx/routes/responses.py`** — under strict json_schema, when the client did **not** pin either knob, inject `chat_template_kwargs.enable_thinking=False` onto the materialized request. Merged (not replaced) so any forward-compat extension keys survive.

## Auto-disable-on-strict decision + rationale

Operator preference is "convenience for agents". Most strict-json callers care about the conformant JSON body, not the chain-of-thought, and on thinking models the default-on `<think>` channel routinely exhausts the token budget before the JSON body is emitted — turning every strict request on a thinking model into a 422 happy-path failure. So under strict json_schema we flip the default from "template default (thinking on for Qwen3/DeepSeek-R1)" to "thinking off". Same shape OpenAI's structured-output mode uses — reasoning is off unless the caller asks for it.

**Auto-disable is gated on BOTH knobs being unset.** When the client explicitly sets either `chat_template_kwargs.enable_thinking` or the top-level `enable_thinking` (to True OR False) we honor their choice and do NOT override. A strict caller who deliberately wants thinking-on can ask for it and accept the budget risk (raise `max_output_tokens`).

The injection happens BEFORE the guided/fallback split + BEFORE the context-length gate, so the resolved choice flows through every consult (`engine.chat`, `engine.generate_with_schema`, `_finalize_content_and_reasoning`, the token budget gate).

## Test plan

- [x] `ResponsesRequest` accepts `chat_template_kwargs` and `enable_thinking` (round-trip)
- [x] `responses_to_openai` forwards both fields onto `ChatCompletionRequest`
- [x] `_resolve_enable_thinking` reads the forwarded values identically to chat surface
- [x] Strict + valid prompt + thinking model with `chat_template_kwargs={"enable_thinking":false}` → 200
- [x] Strict + valid prompt + no client thinking preference → 200 (auto-disable default)
- [x] Strict + explicit `enable_thinking=True` → preserved end-to-end (not auto-overridden)
- [x] Strict + explicit `chat_template_kwargs={"enable_thinking":true}` → preserved
- [x] Non-strict request does NOT auto-disable (scoped to strict json_schema only)
- [x] Strict via guided path also auto-disables (injection happens before the split)
- [x] Forward-compat keys in `chat_template_kwargs` survive the auto-disable merge
- [x] No regression: all 602 responses/chat-template/thinking tests pass; full test suite 9590 passes (12 failures are pre-existing localhost:8000 integration probes unrelated to this change)

Cites: Mira r12 dogfood report (`/tmp/dogfood-0815/mira-r12.md`) findings R-1 (HIGH) + R-2 (HIGH).