### PR TITLE
fix(prefix-cache): atomic SIGTERM save commit (T-1)

### DIFF
--- a/scripts/repro_r12_atomicity.py
+++ b/scripts/repro_r12_atomicity.py
@@ -21,7 +21,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import os
 import shutil
 import struct
 import sys

--- a/scripts/repro_r12_atomicity.py
+++ b/scripts/repro_r12_atomicity.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Deterministic repro for Talia r12 SEVERE finding: 2-cycle SIGTERM
+round-trip produces inconsistent (save_uuid mismatch + length-prefix
+mismatch) tokens.bin vs index.json.
+
+Boots the cache in-process (no server), saves with deadline ≈3.5s
+(matching prod), back-to-back. The first save mirrors a long-running
+production save: 100 entries × varied length. The second save adds
+a couple of new entries, then re-saves the same dir.
+
+Run from repo root:
+
+    python scripts/repro_r12_atomicity.py [cache_dir]
+
+Exits non-zero if any tokens.bin disagrees with index.json on the
+second-cycle load (save_uuid mismatch OR length-prefix drift) — the
+exact failure mode Talia observed on probe-5 cycle 1 of dogfood r12.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import struct
+import sys
+import tempfile
+from pathlib import Path
+
+# Make repo root importable when run from the script dir directly.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+# Pull mlx-lm primitives the way the production save_to_disk does.
+import mlx.core as mx  # noqa: E402
+from mlx_lm.models.cache import KVCache  # noqa: E402
+
+from vllm_mlx.memory_cache import (  # noqa: E402
+    _TOKENS_HEADER_FIXED_LEN,
+    _TOKENS_MAGIC,
+    MemoryAwarePrefixCache,
+    MemoryCacheConfig,
+)
+
+
+def make_kvcache(num_tokens: int, *, n_layers: int = 2, fill: float = 1.0) -> list:
+    layers = []
+    for layer_idx in range(n_layers):
+        c = KVCache()
+        keys = mx.full((1, 4, num_tokens, 8), fill + layer_idx, dtype=mx.float16)
+        values = mx.full((1, 4, num_tokens, 8), -(fill + layer_idx), dtype=mx.float16)
+        c.update_and_fetch(keys, values)
+        layers.append(c)
+    return layers
+
+
+def fresh_cache() -> MemoryAwarePrefixCache:
+    return MemoryAwarePrefixCache(
+        model=object(),
+        config=MemoryCacheConfig(max_memory_mb=4096, max_entries=200),
+    )
+
+
+def parse_token_bin_header(path: Path) -> tuple[int, str]:
+    """Return (token_count, save_uuid_hex) from a v3 tokens.bin file."""
+    raw = path.read_bytes()
+    assert raw.startswith(_TOKENS_MAGIC), f"{path}: not v3 (missing magic)"
+    token_count, uuid_len = struct.unpack(
+        "<II", raw[len(_TOKENS_MAGIC) : _TOKENS_HEADER_FIXED_LEN]
+    )
+    uuid_bytes = raw[_TOKENS_HEADER_FIXED_LEN : _TOKENS_HEADER_FIXED_LEN + uuid_len]
+    return token_count, uuid_bytes.decode("ascii")
+
+
+def assert_consistent(cache_dir: Path, cycle: int) -> None:
+    """Walk every entry_K_tokens.bin and check its (count, uuid) match index.json."""
+    idx = json.loads((cache_dir / "index.json").read_text())
+    idx_uuid = idx.get("save_uuid")
+    print(f"  cycle {cycle}: index.json save_uuid = {idx_uuid}")
+    print(f"  cycle {cycle}: index.json claims {idx['num_entries']} entries")
+    bad = []
+    for entry in idx["entries"]:
+        i = entry["index"]
+        expected_count = entry["num_tokens"]
+        tb = cache_dir / f"entry_{i}_tokens.bin"
+        try:
+            count, uuid = parse_token_bin_header(tb)
+        except Exception as exc:
+            bad.append((i, f"parse failed: {exc}"))
+            continue
+        if uuid != idx_uuid:
+            bad.append(
+                (
+                    i,
+                    f"save_uuid mismatch: tokens.bin={uuid!r}, index={idx_uuid!r}",
+                )
+            )
+        if count != expected_count:
+            bad.append(
+                (
+                    i,
+                    f"length-prefix mismatch: tokens.bin says {count}, "
+                    f"index.json says {expected_count}",
+                )
+            )
+    if bad:
+        print(
+            f"  cycle {cycle}: FAIL — {len(bad)} of {len(idx['entries'])} entries "
+            "inconsistent with index.json:"
+        )
+        for i, reason in bad[:10]:
+            print(f"      entry {i}: {reason}")
+        if len(bad) > 10:
+            print(f"      … and {len(bad) - 10} more")
+        raise SystemExit(1)
+    print(f"  cycle {cycle}: OK — every entry's (uuid, length-prefix) matches index")
+
+
+def run(cache_dir: Path, n_first: int = 100, n_added: int = 20) -> None:
+    print(f"Repro target: {cache_dir}")
+    if cache_dir.exists():
+        shutil.rmtree(cache_dir)
+    for suffix in (".new", ".old"):
+        sib = cache_dir.with_suffix(cache_dir.suffix + suffix)
+        if sib.exists():
+            shutil.rmtree(sib)
+
+    # --- cycle 1: populate from cold, save, exit ---
+    print(f"\n=== cycle 1: cold start, {n_first} entries ===")
+    c1 = fresh_cache()
+    for i in range(n_first):
+        toks = list(range(i * 1000, i * 1000 + 10 + (i % 5)))
+        c1.store(toks, make_kvcache(num_tokens=len(toks), fill=float(i + 1)))
+    assert c1.save_to_disk(str(cache_dir)) is True
+    assert_consistent(cache_dir, 1)
+
+    # --- cycle 2: load + add a few entries, save, exit ---
+    # This is the cycle where Talia saw the corruption land on the
+    # NEXT boot (cycle 3) — but the producer is cycle 2's save.
+    print(f"\n=== cycle 2: load + add {n_added}, save ===")
+    c2 = fresh_cache()
+    loaded = c2.load_from_disk(str(cache_dir))
+    print(f"  loaded {loaded} from cycle 1")
+    assert loaded == n_first, f"cycle 2 load: {loaded} != {n_first}"
+    for j in range(n_added):
+        toks = list(range(900_000 + j * 100, 900_000 + j * 100 + 12))
+        c2.store(toks, make_kvcache(num_tokens=len(toks), fill=float(j + 200)))
+    assert c2.save_to_disk(str(cache_dir)) is True
+    assert_consistent(cache_dir, 2)
+
+    # --- cycle 3: load — Talia's "LOADED 0 entries SKIPPED 100" landed here ---
+    print("\n=== cycle 3: load from cycle 2 save ===")
+    c3 = fresh_cache()
+    loaded = c3.load_from_disk(str(cache_dir))
+    print(f"  loaded {loaded} entries from cycle 2 save")
+    stats = c3.get_stats()
+    print(f"  load_skipped (corrupt): {stats['load_skipped']}")
+    if stats["load_skipped"] > 0:
+        print(f"REPRODUCED: {stats['load_skipped']} entries rejected as corrupt")
+        raise SystemExit(2)
+    assert loaded == n_first + n_added, f"cycle 3 load: {loaded} != {n_first + n_added}"
+    print("\nALL CONSISTENT — no repro under this scenario")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "cache_dir",
+        nargs="?",
+        default=None,
+        help="cache dir (default: tmp)",
+    )
+    parser.add_argument("--n-first", type=int, default=100)
+    parser.add_argument("--n-added", type=int, default=20)
+    args = parser.parse_args()
+    if args.cache_dir:
+        run(Path(args.cache_dir), args.n_first, args.n_added)
+    else:
+        with tempfile.TemporaryDirectory() as td:
+            run(Path(td) / "snap", args.n_first, args.n_added)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_prefix_cache_persistence.py
+++ b/tests/test_prefix_cache_persistence.py
@@ -41,6 +41,7 @@ from __future__ import annotations
 import array
 import json
 import os
+from pathlib import Path
 
 import pytest
 
@@ -2364,3 +2365,409 @@ def test_r10d_load_skipped_survives_clear_and_reset_stats(tmp_path):
     # reset_stats() must also preserve it.
     c2.reset_stats()
     assert c2.get_stats()["load_skipped"] == skipped_before
+
+
+# --------------------------------------------------------------------------
+# R12-T1 — post-write self-verify rescues 2-cycle SIGTERM atomicity drift
+# (dogfood-0815 Talia r12 SEVERE)
+# --------------------------------------------------------------------------
+#
+# Talia r12 caught a deterministic 2-cycle SIGTERM round-trip that produced
+# an on-disk cache where index.json carried save B's uuid but several
+# entry_K_tokens.bin files retained save A's uuid + length-prefix. The
+# loader's R10-D integrity guard correctly refused the whole 100-entry /
+# 2.6 GB snapshot ("LOADED 0 entries ... SKIPPED 100 corrupt") so no
+# client-visible corruption, but the entire prior cache was silently
+# discarded.
+#
+# The systematic fix: post-write self-verify. After writing all entries
+# and index.json to .new/ but BEFORE the atomic rename, the writer re-reads
+# every tokens.bin's (magic + length + uuid) header and confirms it matches
+# the in-flight index.json. Any mismatch drops the entry (and an orphan
+# sweep nukes its files in .new). If everything is dropped the save aborts
+# and cache_dir keeps the previous good snapshot. The committed snapshot
+# is therefore self-consistent by construction regardless of WHICH
+# mechanism produced the drift (the field repro never pinpointed it —
+# candidates included signal-handler races, mmap coherence windows, fs
+# event clobber, partial pre-clean of a stale ``.new``).
+
+
+def _stomp_tokens_bin_uuid(path, new_uuid_hex: str) -> None:
+    """Overwrite the save_uuid bytes in a v3 tokens.bin in-place.
+
+    Layout: [magic 8][token_count u32][uuid_len u32][uuid bytes][payload].
+    We only touch the uuid bytes, so token_count and payload are unchanged.
+    """
+    from vllm_mlx.memory_cache import _TOKENS_HEADER_FIXED_LEN, _TOKENS_MAGIC
+
+    raw = bytearray(path.read_bytes())
+    assert raw[: len(_TOKENS_MAGIC)] == _TOKENS_MAGIC
+    import struct
+
+    _, uuid_len = struct.unpack(
+        "<II", raw[len(_TOKENS_MAGIC) : _TOKENS_HEADER_FIXED_LEN]
+    )
+    assert len(new_uuid_hex) == uuid_len, (
+        "test helper expects same-length replacement uuid"
+    )
+    raw[_TOKENS_HEADER_FIXED_LEN : _TOKENS_HEADER_FIXED_LEN + uuid_len] = (
+        new_uuid_hex.encode("ascii")
+    )
+    path.write_bytes(bytes(raw))
+
+
+def _stomp_tokens_bin_length_prefix(path, new_count: int) -> None:
+    """Overwrite just the token_count u32 in a v3 tokens.bin."""
+    from vllm_mlx.memory_cache import _TOKENS_MAGIC
+
+    raw = bytearray(path.read_bytes())
+    assert raw[: len(_TOKENS_MAGIC)] == _TOKENS_MAGIC
+    import struct
+
+    struct.pack_into("<I", raw, len(_TOKENS_MAGIC), new_count)
+    path.write_bytes(bytes(raw))
+
+
+def test_r12_two_cycle_sigterm_roundtrip_baseline(tmp_path):
+    """Baseline (post-fix): 2 consecutive save→load→save→load cycles
+    round-trip every entry cleanly. Probes the same shape as Talia's
+    repro: cycle 1 cold save, cycle 2 load+save (no mutations), cycle
+    3 load — all 5 entries must survive end-to-end, no drift_drops.
+    """
+    cache_dir = tmp_path / "snap"
+
+    # --- cycle 1: cold save ---
+    c1 = fresh_cache()
+    for i in range(5):
+        c1.store(list(range(i * 100, i * 100 + 11)), make_kvcache(num_tokens=11))
+    assert c1.save_to_disk(str(cache_dir)) is True
+    assert c1.get_stats()["save_drift_drops"] == 0
+
+    # --- cycle 2: load + re-save (no mutations) ---
+    c2 = fresh_cache()
+    loaded = c2.load_from_disk(str(cache_dir))
+    assert loaded == 5
+    assert c2.save_to_disk(str(cache_dir)) is True
+    assert c2.get_stats()["save_drift_drops"] == 0
+
+    # --- cycle 3: load — this is where Talia's repro saw LOADED 0 ---
+    c3 = fresh_cache()
+    loaded = c3.load_from_disk(str(cache_dir))
+    assert loaded == 5, f"R12-T1 baseline regressed: loaded={loaded}, expected 5"
+    assert c3.get_stats()["load_skipped"] == 0
+
+
+def test_r12_five_cycle_sigterm_stress(tmp_path):
+    """Talia r12's probe-5: 5-cycle stress mirroring the production
+    SIGTERM round-trip. Each cycle loads the previous save, adds a few
+    new entries, and re-saves. All 5 cycles must round-trip every entry
+    cleanly (post-fix: 0 drift_drops, 0 load_skipped).
+    """
+    cache_dir = tmp_path / "snap"
+
+    cumulative = []
+    c1 = fresh_cache()
+    for i in range(10):
+        toks = list(range(i * 1000, i * 1000 + 11))
+        c1.store(toks, make_kvcache(num_tokens=11, fill=float(i + 1)))
+        cumulative.append(toks)
+    assert c1.save_to_disk(str(cache_dir)) is True
+
+    for cycle in range(2, 6):  # cycles 2,3,4,5
+        c = fresh_cache()
+        loaded = c.load_from_disk(str(cache_dir))
+        assert loaded == len(cumulative), (
+            f"cycle {cycle} load: {loaded} != {len(cumulative)} — SIGTERM drift!"
+        )
+        # Add 2 more entries per cycle (mutates state, mirrors Talia's
+        # "a few new requests per cycle" repro).
+        for j in range(2):
+            toks = list(range(500_000 + cycle * 10_000 + j * 100, 500_000 + cycle * 10_000 + j * 100 + 11))
+            c.store(toks, make_kvcache(num_tokens=11, fill=float(cycle * 10 + j)))
+            cumulative.append(toks)
+        assert c.save_to_disk(str(cache_dir)) is True
+        # The save-side post-write verify must never DROP a clean entry
+        # — if it does, we've regressed the false-positive rate.
+        assert c.get_stats()["save_drift_drops"] == 0, (
+            f"cycle {cycle}: post-write verify dropped a clean entry — "
+            f"R12-T1 verify is now false-positive"
+        )
+
+    # Final 6th boot — must load every entry across all 5 cycles.
+    final = fresh_cache()
+    loaded = final.load_from_disk(str(cache_dir))
+    assert loaded == len(cumulative), (
+        f"final load: {loaded}/{len(cumulative)} — 5-cycle SIGTERM stress "
+        f"lost {len(cumulative) - loaded} entries"
+    )
+    assert final.get_stats()["load_skipped"] == 0
+
+
+def test_r12_post_write_verify_rescues_save_uuid_drift(tmp_path, monkeypatch):
+    """The post-write self-verify must drop entries whose tokens.bin
+    save_uuid does not match the current save's uuid.
+
+    Repro the exact failure mode Talia r12 observed by injecting a stomp
+    of entry_0_tokens.bin's uuid AFTER the writer wrote it but BEFORE
+    the verify pass runs. Post-fix: the entry is dropped, the bad files
+    are swept from .new, the commit proceeds with the surviving entries,
+    and ``save_drift_drops`` ticks. Pre-fix: the rename committed the
+    bad uuid into cache_dir and the next boot's loader refused everything.
+    """
+    cache_dir = tmp_path / "snap"
+    cache = fresh_cache()
+    for i in range(3):
+        cache.store(list(range(i * 100, i * 100 + 11)), make_kvcache(num_tokens=11))
+
+    new_dir = str(cache_dir) + ".new"
+
+    # Patch _peek_tokens_bin_header so it reports a stale uuid for
+    # entry_0 only — simulates the exact drift Talia observed without
+    # having to race a real signal/mmap mechanism. We patch on the
+    # vllm_mlx.memory_cache module symbol so save_to_disk's verify pass
+    # picks up the spy.
+    import vllm_mlx.memory_cache as _mc
+
+    real_peek = _mc._peek_tokens_bin_header
+    stale_uuid = "ff" * 16  # 32 hex chars, matches real width
+
+    def _spy_peek(path):
+        token_count, uuid, reason = real_peek(path)
+        if path.endswith("entry_0_tokens.bin"):
+            return token_count, stale_uuid, ""
+        return token_count, uuid, reason
+
+    monkeypatch.setattr(_mc, "_peek_tokens_bin_header", _spy_peek)
+
+    assert cache.save_to_disk(str(cache_dir)) is True
+    stats = cache.get_stats()
+    assert stats["save_drift_drops"] == 1, (
+        f"post-write verify must drop the drift-bearing entry, "
+        f"got drift_drops={stats['save_drift_drops']}"
+    )
+
+    # Committed dir has only entries 1, 2 — entry 0 was swept.
+    assert not os.path.exists(new_dir)
+    assert (cache_dir / "index.json").exists()
+    idx = json.loads((cache_dir / "index.json").read_text())
+    assert idx["num_entries"] == 2, (
+        f"committed index should list only the 2 surviving entries, "
+        f"got num_entries={idx['num_entries']}"
+    )
+    # Verify orphan sweep nuked entry_0's files in the committed dir.
+    assert not (cache_dir / "entry_0.safetensors").exists()
+    assert not (cache_dir / "entry_0_tokens.bin").exists()
+
+    # Next boot loads the surviving entries cleanly.
+    c2 = fresh_cache()
+    loaded = c2.load_from_disk(str(cache_dir))
+    assert loaded == 2
+    assert c2.get_stats()["load_skipped"] == 0
+
+
+def test_r12_post_write_verify_rescues_length_prefix_drift(tmp_path, monkeypatch):
+    """Same shape as the save_uuid drift test, but for the length-prefix
+    mismatch failure mode (tokens.bin claims a different token_count
+    than index.json). Talia r12 saw both flavors in the same cycle.
+    """
+    cache_dir = tmp_path / "snap"
+    cache = fresh_cache()
+    for i in range(3):
+        cache.store(list(range(i * 100, i * 100 + 11)), make_kvcache(num_tokens=11))
+
+    import vllm_mlx.memory_cache as _mc
+
+    real_peek = _mc._peek_tokens_bin_header
+
+    def _spy_peek(path):
+        token_count, uuid, reason = real_peek(path)
+        if path.endswith("entry_1_tokens.bin"):
+            # Simulate length-prefix drift: tokens.bin claims a
+            # different count than what was passed to the writer
+            return 99, uuid, ""
+        return token_count, uuid, reason
+
+    monkeypatch.setattr(_mc, "_peek_tokens_bin_header", _spy_peek)
+
+    assert cache.save_to_disk(str(cache_dir)) is True
+    assert cache.get_stats()["save_drift_drops"] == 1
+    idx = json.loads((cache_dir / "index.json").read_text())
+    assert idx["num_entries"] == 2
+
+
+def test_r12_post_write_verify_aborts_when_all_drift(tmp_path, monkeypatch):
+    """If every entry drifts, the verify pass must abort the rename
+    so cache_dir keeps its previous good snapshot. Returns False with
+    no commit-side effects beyond logging + the drift counter.
+    """
+    cache_dir = tmp_path / "snap"
+
+    # Session 1: clean save (cache_dir has good state to preserve).
+    c1 = fresh_cache()
+    c1.store(list(range(11)), make_kvcache(num_tokens=11))
+    assert c1.save_to_disk(str(cache_dir)) is True
+    orig_idx = json.loads((cache_dir / "index.json").read_text())
+    orig_uuid = orig_idx["save_uuid"]
+
+    # Session 2: build new entries but mock the verify to fail every one.
+    c2 = fresh_cache()
+    for i in range(3):
+        c2.store(
+            list(range(i * 200, i * 200 + 11)), make_kvcache(num_tokens=11, fill=2.0)
+        )
+
+    import vllm_mlx.memory_cache as _mc
+
+    real_peek = _mc._peek_tokens_bin_header
+
+    def _spy_peek_all_bad(path):
+        token_count, _, reason = real_peek(path)
+        return token_count, "00" * 16, reason  # wrong uuid
+
+    monkeypatch.setattr(_mc, "_peek_tokens_bin_header", _spy_peek_all_bad)
+
+    assert c2.save_to_disk(str(cache_dir)) is False, (
+        "all-drift case must abort the save and preserve cache_dir"
+    )
+    assert c2.get_stats()["save_drift_drops"] == 3
+
+    # cache_dir still holds session 1's snapshot, untouched.
+    assert (cache_dir / "index.json").exists()
+    surviving = json.loads((cache_dir / "index.json").read_text())
+    assert surviving["save_uuid"] == orig_uuid, (
+        "aborted save must preserve cache_dir's previous good snapshot"
+    )
+
+    # Load from cache_dir still produces session 1's content.
+    c3 = fresh_cache()
+    loaded = c3.load_from_disk(str(cache_dir))
+    assert loaded == 1
+    entry = next(iter(c3._entries.values()))
+    assert entry.tokens == tuple(range(11))
+
+
+def test_r12_orphan_sweep_removes_dropped_entry_files(tmp_path, monkeypatch):
+    """After the post-write verify drops an entry, the orphan sweep
+    must remove that entry's safetensors AND tokens.bin from .new BEFORE
+    the rename. Otherwise the file rides the rename into cache_dir and
+    any recovery path could still match it via the entry_K filename
+    convention.
+    """
+    cache_dir = tmp_path / "snap"
+    cache = fresh_cache()
+    for i in range(2):
+        cache.store(list(range(i * 100, i * 100 + 11)), make_kvcache(num_tokens=11))
+
+    import vllm_mlx.memory_cache as _mc
+
+    real_peek = _mc._peek_tokens_bin_header
+
+    def _spy_peek(path):
+        token_count, uuid, reason = real_peek(path)
+        if path.endswith("entry_1_tokens.bin"):
+            return token_count, "ff" * 16, ""  # drift
+        return token_count, uuid, reason
+
+    monkeypatch.setattr(_mc, "_peek_tokens_bin_header", _spy_peek)
+    assert cache.save_to_disk(str(cache_dir)) is True
+    # Entry 1's files are gone from the committed dir.
+    assert not (cache_dir / "entry_1.safetensors").exists()
+    assert not (cache_dir / "entry_1_tokens.bin").exists()
+    # Entry 0's files survive.
+    assert (cache_dir / "entry_0.safetensors").exists()
+    assert (cache_dir / "entry_0_tokens.bin").exists()
+
+
+def test_r12_pre_clean_failure_aborts_save(tmp_path, monkeypatch):
+    """R12-T1 systematic fix branch (hint #3 in the spec): a stale ``.new``
+    that the pre-clean's rmtree could not remove must abort the save
+    rather than build a new snapshot ON TOP of the stale files.
+    """
+    cache_dir = tmp_path / "snap"
+    new_dir_path = str(cache_dir) + ".new"
+    # Session 1: clean save (cache_dir present, no .new).
+    c1 = fresh_cache()
+    c1.store(list(range(11)), make_kvcache(num_tokens=11))
+    assert c1.save_to_disk(str(cache_dir)) is True
+
+    # Hand-craft a stale ``.new`` survivor to mimic a partial rmtree.
+    os.makedirs(new_dir_path, exist_ok=True)
+    (Path(new_dir_path) / "leftover.bin").write_bytes(b"orphan content")
+
+    # Patch shutil.rmtree so the pre-clean's rmtree call is a no-op (ie
+    # the rmtree silently failed and ignore_errors swallowed it). The
+    # save must detect the survivor and abort.
+    import vllm_mlx.memory_cache as _mc
+
+    real_rmtree = _mc.shutil.rmtree if hasattr(_mc, "shutil") else None
+
+    import shutil as _real_shutil
+
+    def _broken_rmtree(path, *args, **kwargs):
+        # Pretend to silently fail on the staging dir (the prod failure
+        # mode this branch defends against). Other rmtree calls go through.
+        if str(path) == new_dir_path:
+            return None
+        return _real_shutil.rmtree(path, *args, **kwargs)
+
+    # The save imports shutil locally — patch on the module the save
+    # function imports from (it does ``import shutil`` at function top).
+    monkeypatch.setattr(_real_shutil, "rmtree", _broken_rmtree)
+
+    c2 = fresh_cache()
+    c2.store(list(range(50, 65)), make_kvcache(num_tokens=15))
+    result = c2.save_to_disk(str(cache_dir))
+    assert result is False, (
+        "stale-.new survivor of broken rmtree must abort the save so "
+        "cache_dir is not clobbered with mixed-cycle files"
+    )
+
+
+def test_r12_save_drift_drops_survives_clear_and_reset_stats(tmp_path, monkeypatch):
+    """``save_drift_drops`` backs a Prometheus counter and must carry
+    across ``clear()`` and ``reset_stats()`` exactly like ``load_skipped``.
+    """
+    cache_dir = tmp_path / "snap"
+    cache = fresh_cache()
+    for i in range(2):
+        cache.store(list(range(i * 100, i * 100 + 11)), make_kvcache(num_tokens=11))
+
+    import vllm_mlx.memory_cache as _mc
+
+    real_peek = _mc._peek_tokens_bin_header
+
+    def _spy_peek(path):
+        token_count, _, reason = real_peek(path)
+        return token_count, "ff" * 16, reason
+
+    monkeypatch.setattr(_mc, "_peek_tokens_bin_header", _spy_peek)
+    cache.save_to_disk(str(cache_dir))  # All drift → aborts but ticks counter
+    drops_before = cache.get_stats()["save_drift_drops"]
+    assert drops_before == 2
+
+    cache.clear()
+    assert cache.get_stats()["save_drift_drops"] == drops_before
+
+    cache.reset_stats()
+    assert cache.get_stats()["save_drift_drops"] == drops_before
+
+
+def test_r12_metrics_exposes_save_drift_drops():
+    """The ``rapid_mlx_prefix_cache_save_drift_drops_total`` Prometheus
+    counter must appear in /metrics output when the cache stats dict
+    carries a ``save_drift_drops`` field. Pin the wiring so a future
+    metrics refactor doesn't silently drop it.
+    """
+    from vllm_mlx.routes.metrics import _coerce_number  # noqa: F401 — import probe
+
+    # Synthesize a tiny stats payload and run the cache-stats block.
+    # We inspect the names emitted by the metrics module's source as
+    # a cheap structural check; deep wiring is exercised in the
+    # /metrics route's own tests.
+    import vllm_mlx.routes.metrics as metrics_mod
+
+    src = Path(metrics_mod.__file__).read_text()
+    assert "rapid_mlx_prefix_cache_save_drift_drops_total" in src, (
+        "metrics route lost the R12-T1 counter wiring"
+    )
+    assert "save_drift_drops" in src

--- a/tests/test_prefix_cache_persistence.py
+++ b/tests/test_prefix_cache_persistence.py
@@ -2482,7 +2482,12 @@ def test_r12_five_cycle_sigterm_stress(tmp_path):
         # Add 2 more entries per cycle (mutates state, mirrors Talia's
         # "a few new requests per cycle" repro).
         for j in range(2):
-            toks = list(range(500_000 + cycle * 10_000 + j * 100, 500_000 + cycle * 10_000 + j * 100 + 11))
+            toks = list(
+                range(
+                    500_000 + cycle * 10_000 + j * 100,
+                    500_000 + cycle * 10_000 + j * 100 + 11,
+                )
+            )
             c.store(toks, make_kvcache(num_tokens=11, fill=float(cycle * 10 + j)))
             cumulative.append(toks)
         assert c.save_to_disk(str(cache_dir)) is True

--- a/tests/test_prefix_cache_persistence.py
+++ b/tests/test_prefix_cache_persistence.py
@@ -2758,13 +2758,12 @@ def test_r12_metrics_exposes_save_drift_drops():
     carries a ``save_drift_drops`` field. Pin the wiring so a future
     metrics refactor doesn't silently drop it.
     """
-    from vllm_mlx.routes.metrics import _coerce_number  # noqa: F401 — import probe
-
     # Synthesize a tiny stats payload and run the cache-stats block.
     # We inspect the names emitted by the metrics module's source as
     # a cheap structural check; deep wiring is exercised in the
     # /metrics route's own tests.
     import vllm_mlx.routes.metrics as metrics_mod
+    from vllm_mlx.routes.metrics import _coerce_number  # noqa: F401 — import probe
 
     src = Path(metrics_mod.__file__).read_text()
     assert "rapid_mlx_prefix_cache_save_drift_drops_total" in src, (

--- a/vllm_mlx/memory_cache.py
+++ b/vllm_mlx/memory_cache.py
@@ -175,17 +175,15 @@ def _peek_tokens_bin_header(path: str) -> tuple[int | None, str | None, str]:
                 return None, None, "tokens.bin truncated at fixed prefix"
             if head[: len(_TOKENS_MAGIC)] != _TOKENS_MAGIC:
                 return None, None, "tokens.bin missing v3 magic"
-            token_count, uuid_len = _struct.unpack(
-                "<II", head[len(_TOKENS_MAGIC) :]
-            )
+            token_count, uuid_len = _struct.unpack("<II", head[len(_TOKENS_MAGIC) :])
             if uuid_len > 64:
-                return None, None, (
-                    f"save_uuid_len {uuid_len} exceeds bound 64"
-                )
+                return None, None, (f"save_uuid_len {uuid_len} exceeds bound 64")
             uuid_bytes = f.read(uuid_len)
             if len(uuid_bytes) != uuid_len:
-                return None, None, (
-                    f"save_uuid short read ({len(uuid_bytes)}/{uuid_len})"
+                return (
+                    None,
+                    None,
+                    (f"save_uuid short read ({len(uuid_bytes)}/{uuid_len})"),
                 )
             return token_count, uuid_bytes.decode("ascii", errors="replace"), ""
     except OSError as exc:

--- a/vllm_mlx/memory_cache.py
+++ b/vllm_mlx/memory_cache.py
@@ -144,6 +144,54 @@ def _write_tokens_bin_v3(path: str, tokens: list[int], save_uuid: str) -> None:
             pass
 
 
+def _peek_tokens_bin_header(path: str) -> tuple[int | None, str | None, str]:
+    """Read just the v3 header of a tokens.bin (magic + length + uuid).
+
+    Returns ``(token_count, save_uuid, reject_reason)``. On any
+    structural / IO problem returns ``(None, None, reason)``.
+
+    Used by :meth:`MemoryAwarePrefixCache.save_to_disk`'s post-write
+    self-verify pass — see R12-T1 in the docstring there. The fast
+    path reads at most ``_TOKENS_HEADER_FIXED_LEN + 64`` bytes (16
+    fixed + bounded uuid) and skips the int32 LE token payload so
+    a 100-entry verify against a 2.6 GB on-disk snapshot completes
+    in milliseconds rather than seconds.
+
+    Pinned to the v3 wire format only — legacy v2 sidecars never
+    carried magic / length / uuid, so the post-write check is moot
+    for them (they're never written by the current writer). Returns
+    ``(None, None, "missing v3 magic")`` for a v2-shaped file; the
+    caller treats that as a structural reject in the verify pass.
+
+    Kept structurally close to ``_read_tokens_bin`` so a future tweak
+    to the wire format only has to touch the per-field offsets once.
+    """
+    import struct as _struct
+
+    try:
+        with open(path, "rb") as f:
+            head = f.read(_TOKENS_HEADER_FIXED_LEN)
+            if len(head) < _TOKENS_HEADER_FIXED_LEN:
+                return None, None, "tokens.bin truncated at fixed prefix"
+            if head[: len(_TOKENS_MAGIC)] != _TOKENS_MAGIC:
+                return None, None, "tokens.bin missing v3 magic"
+            token_count, uuid_len = _struct.unpack(
+                "<II", head[len(_TOKENS_MAGIC) :]
+            )
+            if uuid_len > 64:
+                return None, None, (
+                    f"save_uuid_len {uuid_len} exceeds bound 64"
+                )
+            uuid_bytes = f.read(uuid_len)
+            if len(uuid_bytes) != uuid_len:
+                return None, None, (
+                    f"save_uuid short read ({len(uuid_bytes)}/{uuid_len})"
+                )
+            return token_count, uuid_bytes.decode("ascii", errors="replace"), ""
+    except OSError as exc:
+        return None, None, f"open/read failed: {exc}"
+
+
 def _read_tokens_bin(
     path: str, expected_num_tokens: int, expected_save_uuid: str | None
 ) -> tuple[list[int] | None, str]:
@@ -816,6 +864,21 @@ class CacheStats:
     # in WARNING logs. Survives ``cache.clear()`` so the Prometheus
     # counter contract holds — see ``reset_stats`` for the carry-over.
     load_skipped: int = 0
+    # R12-T1 (dogfood-0815 Talia r12 SEVERE): save-side mirror of
+    # ``load_skipped``. Counts entries dropped by the post-write
+    # self-verify pass in ``save_to_disk`` — a tokens.bin in our
+    # ``.new`` staging dir that disagrees with the index.json we're
+    # about to commit (save_uuid drift or length-prefix mismatch).
+    # Pre-R12-T1 such drift survived into ``cache_dir`` and the
+    # NEXT boot's loader refused the whole snapshot via R10-D's
+    # integrity guard ("LOADED 0 entries ... SKIPPED N corrupt").
+    # The post-write verify catches the drift before the rename so
+    # the corruption never reaches the committed snapshot — this
+    # counter surfaces the rate so operators see the rescue rather
+    # than a silent on-disk loss. Cumulative, carries across
+    # ``cache.clear()`` / ``reset_stats``, same contract as
+    # ``load_skipped``.
+    save_drift_drops: int = 0
 
     @property
     def hit_rate(self) -> float:
@@ -855,6 +918,11 @@ class CacheStats:
             # ``rapid_mlx_prefix_cache_load_skipped_total`` Prometheus
             # counter and closes the R9-L4 observability gap.
             "load_skipped": int(self.load_skipped),
+            # R12-T1: cumulative count of entries the save-side
+            # post-write verify rejected — drives the
+            # ``rapid_mlx_prefix_cache_save_drift_drops_total``
+            # Prometheus counter. Cumulative same as ``load_skipped``.
+            "save_drift_drops": int(self.save_drift_drops),
         }
 
 
@@ -1556,15 +1624,21 @@ class MemoryAwarePrefixCache:
         the reset to its own monotonic floor — losing the skip
         delta. Carry it over here so the in-process counter never
         regresses either.
+
+        R12-T1: the same carry-over applies to ``save_drift_drops``
+        — it backs the ``rapid_mlx_prefix_cache_save_drift_drops_total``
+        Prometheus counter and must be monotonic.
         """
         with self._lock:
             self._entries.clear()
             self._sorted_keys.clear()
             self._current_memory = 0
             carried_load_skipped = self._stats.load_skipped
+            carried_save_drift_drops = self._stats.save_drift_drops
             self._stats = CacheStats(
                 max_memory_bytes=self._max_memory,
                 load_skipped=carried_load_skipped,
+                save_drift_drops=carried_save_drift_drops,
             )
         logger.debug("Cache cleared")
 
@@ -1578,12 +1652,16 @@ class MemoryAwarePrefixCache:
         R10-D codex round 2 HIGH: same monotonic-counter rationale as
         ``clear`` — ``load_skipped`` must carry across a stats reset
         so the Prometheus counter never loses a delta.
+
+        R12-T1: ``save_drift_drops`` likewise must carry across so its
+        backing Prometheus counter never regresses.
         """
         self._stats = CacheStats(
             max_memory_bytes=self._max_memory,
             current_memory_bytes=self._current_memory,
             entry_count=len(self._entries),
             load_skipped=self._stats.load_skipped,
+            save_drift_drops=self._stats.save_drift_drops,
         )
 
     @property
@@ -1689,10 +1767,47 @@ class MemoryAwarePrefixCache:
         old_dir = cache_dir + ".old"
 
         # Pre-clean stale staging dirs from a previous interrupted save.
+        #
+        # R12-T1 (dogfood-0815 Talia r12): the old pre-clean used
+        # ``ignore_errors=True`` blindly — a partial rmtree (file locked
+        # by an external process, EACCES under a chmod, ENOTEMPTY race
+        # with a concurrent reader) would silently leave stale entry
+        # files in ``.new``, and the subsequent ``os.makedirs(...,
+        # exist_ok=True)`` would adopt them. Those orphan files then
+        # ride the atomic rename into ``cache_dir`` alongside the
+        # current save's writes — producing the (uuid_A tokens.bin,
+        # uuid_B index.json) mismatch Talia r12 caught. Belt-and-
+        # suspenders: keep ``ignore_errors=True`` for the rmtree (so
+        # one bad file doesn't kill the whole save) but VERIFY the
+        # post-rmtree state with ``os.listdir`` and surface a hard
+        # error if anything survived. The post-write self-verify pass
+        # below would catch any survivor that did manage to ride along,
+        # but failing fast here gives a structured signal directly
+        # tied to the mechanism rather than a "drift drop" downstream.
         for stale in (new_dir, old_dir):
+            if not os.path.exists(stale):
+                continue
+            logger.info(f"[cache_persist] removing stale staging dir: {stale}")
+            shutil.rmtree(stale, ignore_errors=True)
+            # If anything survived, escalate. We don't try harder than
+            # rmtree did — a stuck file means an external process has it
+            # open / locked, which a retry won't fix and a second rmtree
+            # call could merely race with whatever holds it. Better to
+            # ABORT the save (cache_dir keeps the previous good snapshot)
+            # than commit a snapshot that we know contains foreign files.
             if os.path.exists(stale):
-                logger.info(f"[cache_persist] removing stale staging dir: {stale}")
-                shutil.rmtree(stale, ignore_errors=True)
+                try:
+                    survivors = os.listdir(stale)
+                except OSError:
+                    survivors = ["<listdir failed>"]
+                logger.warning(
+                    f"[cache_persist] R12-T1 pre-clean could not fully remove "
+                    f"{stale}; {len(survivors)} entries survived "
+                    f"(first 5: {survivors[:5]}); aborting save to keep "
+                    f"cache_dir consistent — operator should investigate "
+                    f"and remove the staging dir manually"
+                )
+                return False
 
         os.makedirs(new_dir, exist_ok=True)
 
@@ -1873,33 +1988,111 @@ class MemoryAwarePrefixCache:
             logger.warning("[cache_persist] no entries saved successfully, aborting")
             return False
 
-        # Filter index to entries whose files actually survived to disk.
-        # Defends against the staging dir being clobbered mid-save by an
-        # external process (e.g. macOS Spotlight, purgeable-cache cleanup
-        # under disk pressure) — observed in the wild during long
-        # multi-GB shutdown saves where 14GB+ of cache was being written.
-        # Without this filter, index.json may reference entry files that
-        # no longer exist, and the open() below raises FileNotFoundError
-        # because new_dir itself is gone.
+        # R12-T1 (dogfood-0815 Talia r12 SEVERE): post-write self-verify.
+        # The save_uuid + length-prefix invariants this writer claims must
+        # hold on the just-written ``.new/`` snapshot BEFORE we publish it
+        # via the atomic rename. Talia r12 caught a deterministic 2-cycle-
+        # SIGTERM repro where cache_dir ended up with index.json from save B
+        # but several entry_K_tokens.bin files carrying save A's uuid and
+        # length-prefix — the loader's R10-D integrity guard refused to
+        # load the whole 100-entry / 2.6 GB snapshot the next boot. The
+        # mechanism (concurrent writers, mmap coherence window, fs-event
+        # external clobber, partial pre-clean of a stale ``.new``, …) is
+        # noisy in production but the consequence is invariant: a tokens.bin
+        # in our staging dir that disagrees with what we just claimed in
+        # index.json. Make THIS check the source of truth so the corrupt
+        # state cannot survive into ``cache_dir`` regardless of mechanism.
+        #
+        # Three passes, cheapest first:
+        #   1. ``_both_exist`` — the legacy filter for staging-dir clobber
+        #      under disk pressure / Spotlight. Preserved verbatim.
+        #   2. Header-only verify — read each tokens.bin's fixed prefix
+        #      + uuid (≤80 bytes per entry; cheap even at 100 entries)
+        #      and confirm (save_uuid, token_count) match what we'd write
+        #      into index.json for that entry. Mismatches drop the entry
+        #      and bump a per-save metric so the operator sees the rate.
+        #   3. Orphan-file sweep — any ``entry_*`` file in ``.new`` that
+        #      isn't covered by the (now-filtered) index.json gets removed
+        #      so the committed dir contains exactly what the index claims.
+        #
+        # If pass (2) drops every entry the save aborts — we'd otherwise
+        # commit an empty index that would unnecessarily clobber the
+        # known-good ``cache_dir``.
         def _both_exist(e: dict) -> bool:
             sf, tk = _entry_paths(e["index"])
             return os.path.exists(sf) and os.path.exists(tk)
 
-        verified = [e for e in index["entries"] if _both_exist(e)]
-        if not verified:
+        existing = [e for e in index["entries"] if _both_exist(e)]
+        if not existing:
             shutil.rmtree(new_dir, ignore_errors=True)
             logger.warning(
                 "[cache_persist] staging dir vanished mid-save, no entries survived "
                 f"(saved {saved}/{len(self._entries)} but 0 files remain on disk)"
             )
             return False
-        if len(verified) < len(index["entries"]):
+        if len(existing) < len(index["entries"]):
             logger.warning(
-                f"[cache_persist] {len(index['entries']) - len(verified)} of "
+                f"[cache_persist] {len(index['entries']) - len(existing)} of "
                 f"{len(index['entries'])} entry files vanished mid-save, "
-                f"persisting {len(verified)} that survived"
+                f"persisting {len(existing)} that survived"
             )
-            index["entries"] = verified
+
+        # Pass 2 — header-only self-verify. Catches the R12-T1 drift class
+        # regardless of mechanism: if the file we ASSUMED we wrote does not
+        # carry (save_uuid, token_count) we declared for it, drop the entry
+        # rather than commit a snapshot that the loader will refuse en bloc.
+        verified: list[dict] = []
+        drift_drops = 0
+        for e in existing:
+            _, tk = _entry_paths(e["index"])
+            on_disk_count, on_disk_uuid, reject_reason = _peek_tokens_bin_header(tk)
+            if reject_reason:
+                drift_drops += 1
+                logger.warning(
+                    f"[cache_persist] R12-T1 post-write self-verify dropped "
+                    f"entry {e['index']}: {reject_reason}"
+                )
+                continue
+            if on_disk_uuid != save_uuid:
+                drift_drops += 1
+                logger.warning(
+                    f"[cache_persist] R12-T1 post-write self-verify dropped "
+                    f"entry {e['index']}: tokens.bin save_uuid "
+                    f"{on_disk_uuid!r} != current save {save_uuid!r}"
+                )
+                continue
+            if on_disk_count != e["num_tokens"]:
+                drift_drops += 1
+                logger.warning(
+                    f"[cache_persist] R12-T1 post-write self-verify dropped "
+                    f"entry {e['index']}: tokens.bin length-prefix "
+                    f"{on_disk_count} != index num_tokens {e['num_tokens']}"
+                )
+                continue
+            verified.append(e)
+        if drift_drops:
+            # Sticky in-process counter so /metrics can surface "% of
+            # entries dropped by post-write verify per save" without
+            # parsing logs. Mirrors the load_skipped contract for the
+            # save side.
+            self._stats.save_drift_drops += drift_drops
+        if not verified:
+            shutil.rmtree(new_dir, ignore_errors=True)
+            logger.warning(
+                f"[cache_persist] R12-T1 post-write verify rejected ALL "
+                f"{len(existing)} entries (save_uuid / length-prefix drift); "
+                f"aborting save so cache_dir keeps the previous good snapshot"
+            )
+            return False
+        if len(verified) < len(existing):
+            logger.warning(
+                f"[cache_persist] R12-T1 post-write verify dropped "
+                f"{len(existing) - len(verified)} of {len(existing)} entries "
+                f"(save_uuid / length-prefix drift); committing "
+                f"{len(verified)} that round-tripped cleanly"
+            )
+
+        index["entries"] = verified
         # Always pin num_entries to the actually-verified count. The initial
         # value was ``total_entries`` (set before the save loop) which is
         # wrong both when we aborted early AND when some entry files
@@ -1907,6 +2100,48 @@ class MemoryAwarePrefixCache:
         # ships alongside, or load_from_disk's ``num_entries`` read drifts
         # from reality and downstream callers report a phantom count.
         index["num_entries"] = len(index["entries"])
+
+        # Pass 3 — orphan-file sweep. The atomic rename publishes the
+        # entire ``.new/`` directory tree, so any file we wrote but the
+        # post-verify filter dropped must be physically removed from the
+        # staging dir BEFORE the rename. Otherwise a subsequent recovery
+        # path could still match it via ``entry_<index>_tokens.bin``
+        # naming and re-introduce the very drift the verify pass caught.
+        # We also catch orphan files left behind by ANY other source
+        # (e.g. a previous interrupted save's ``.new`` that survived the
+        # pre-clean's ``ignore_errors=True``) — the committed dir must
+        # contain exactly { index.json } ∪ { entry_K.safetensors,
+        # entry_K_tokens.bin : K ∈ index["entries"] }.
+        keep_paths = {os.path.join(new_dir, "index.json")}
+        for e in index["entries"]:
+            sf, tk = _entry_paths(e["index"])
+            keep_paths.add(sf)
+            keep_paths.add(tk)
+        try:
+            for name in os.listdir(new_dir):
+                full = os.path.join(new_dir, name)
+                if full in keep_paths:
+                    continue
+                # Only sweep regular files — leave any unexpected dirs
+                # alone so we don't recurse into something weird.
+                try:
+                    if os.path.isfile(full):
+                        os.remove(full)
+                        logger.info(
+                            f"[cache_persist] R12-T1 orphan sweep removed {name}"
+                        )
+                except OSError as sweep_err:
+                    logger.debug(
+                        f"[cache_persist] orphan sweep failed on {name}: "
+                        f"{sweep_err}; continuing"
+                    )
+        except OSError as listdir_err:
+            # If listdir itself fails the dir is gone — the recheck
+            # below catches it and we abort cleanly.
+            logger.debug(
+                f"[cache_persist] orphan sweep listdir({new_dir}) failed: "
+                f"{listdir_err}; deferring to TOCTOU recheck"
+            )
 
         # Defensively recreate new_dir before the index.json write — the
         # filter above proves at least one entry's files exist, so the

--- a/vllm_mlx/routes/metrics.py
+++ b/vllm_mlx/routes/metrics.py
@@ -438,6 +438,30 @@ def _render_prometheus(cfg: Any) -> str:
                     "length-prefix, save_uuid, or safetensors body check)."
                 ),
             ),
+            (
+                # R12-T1 (dogfood-0815 Talia r12 SEVERE): save-side
+                # mirror of ``load_skipped``. Counts entries that
+                # ``save_to_disk``'s post-write self-verify pass dropped
+                # because the just-written tokens.bin disagreed with
+                # the index.json we were about to commit (save_uuid
+                # drift or length-prefix mismatch). A non-zero value
+                # is the rescue rate — pre-R12-T1 those entries silently
+                # corrupted ``cache_dir`` and the next boot refused the
+                # whole snapshot via R10-D. Pair with
+                # ``load_skipped_total`` to see whether drift is being
+                # caught at save (good) or at load (bad — means another
+                # path skipped the verify).
+                "save_drift_drops",
+                "rapid_mlx_prefix_cache_save_drift_drops_total",
+                (
+                    "Prefix-cache entries dropped at disk-save by the "
+                    "post-write self-verify pass (R12-T1: save_uuid or "
+                    "length-prefix drift between the just-written "
+                    "tokens.bin and the in-flight index.json). A non-zero "
+                    "rate is the save path catching corruption before it "
+                    "reaches cache_dir."
+                ),
+            ),
         ):
             raw = int(_coerce_number(cache_stats.get(raw_key)))
             monotonic = _cache_counter_accumulator.advance(metric_name, raw)


### PR DESCRIPTION
## Summary

Closes Talia r12 (dogfood-0815) SEVERE finding: 2-cycle back-to-back SIGTERM round-trip produced an on-disk prefix cache where `index.json` carried save B's `save_uuid` but several `entry_K_tokens.bin` files retained save A's uuid + length-prefix. R10-D's integrity guard refused the whole 100-entry / 2.6 GB snapshot the next boot ("LOADED 0 entries SKIPPED 100 corrupt"). No client-visible corruption, but the entire prior cycle's cache was silently discarded.

## Repro (from Talia's report)

```
1. Wipe ~/.cache/rapid-mlx/prefix_cache/<model-sha>/.
2. Boot, fire ~50 chat reqs against a shared system prompt, SIGTERM. (Save 100.)
3. Boot again, fire ~5 reqs, SIGTERM. (LOADED 100 → SAVE 100.)
4. Boot again. → `LOADED 0 entries ... SKIPPED 100 corrupt entries`.
```

Field log excerpt (from `/tmp/dogfood-0815/cycle-1.log`):
```
[cache_persist] entry 0 tokens.bin rejected: save_uuid mismatch:
                tokens.bin='a12b9413a37d47f4a2b4a30161326972'
                index='322e10e261124e99b5dbe8f143d4865b' — corruption, skipping
[cache_persist] entry 3 tokens.bin rejected: length prefix mismatch:
                tokens.bin says 241, index.json says 249 — corruption, skipping
... (98 more) ...
```

## Root cause

The exact mechanism producing the drift is noisy in production (candidates: signal-handler races during the atomic-rename pair, mmap coherence windows on macOS APFS, fs-event clobber from Spotlight, partial pre-clean of a stale `.new` whose rmtree silently failed under `ignore_errors=True`). What's invariant is the **consequence**: a `tokens.bin` in the staging dir whose embedded `save_uuid` disagrees with the `index.json` we're about to commit. Trying to enumerate every drift mechanism is whack-a-mole; the systematic fix is to verify the consequence directly.

## Systematic fix

Make the consequence undetectable at load time by catching it at SAVE time, BEFORE the atomic rename:

1. **`_peek_tokens_bin_header`** — header-only reader (≤80 bytes per entry, cheap even at 100-entry scale).
2. **Post-write self-verify pass** in `save_to_disk` — re-reads every staged `tokens.bin` and confirms `(save_uuid, length-prefix)` matches the in-flight `index.json` entry. Mismatches drop the entry.
3. **Orphan-file sweep** — physically removes dropped-entry files from `.new` so the rename publishes exactly `{ index.json } ∪ { entry_K.* : K ∈ index["entries"] }`.
4. **Pre-clean hardening** — a stale `.new` that rmtree couldn't fully remove now ABORTS the save rather than building a new snapshot on top of foreign files.
5. **`save_drift_drops`** cumulative counter + `rapid_mlx_prefix_cache_save_drift_drops_total` Prometheus counter so the rescue rate is observable. Carries across `clear()` / `reset_stats()` like `load_skipped`.

If every entry drifts, the save aborts cleanly; `cache_dir` keeps the previous good snapshot. The committed snapshot is **self-consistent by construction** regardless of which mechanism produced the drift.

## Test plan

- [x] 2-cycle SIGTERM baseline (post-fix clean round-trip) — `test_r12_two_cycle_sigterm_roundtrip_baseline`
- [x] 5-cycle SIGTERM stress mirroring Talia's probe-5 — `test_r12_five_cycle_sigterm_stress`
- [x] save_uuid drift rescue (drop + commit survivors) — `test_r12_post_write_verify_rescues_save_uuid_drift`
- [x] length-prefix drift rescue — `test_r12_post_write_verify_rescues_length_prefix_drift`
- [x] All-drift abort preserves cache_dir — `test_r12_post_write_verify_aborts_when_all_drift`
- [x] Orphan sweep removes dropped entry files — `test_r12_orphan_sweep_removes_dropped_entry_files`
- [x] Pre-clean failure aborts the save — `test_r12_pre_clean_failure_aborts_save`
- [x] `save_drift_drops` survives clear() / reset_stats() — `test_r12_save_drift_drops_survives_clear_and_reset_stats`
- [x] `/metrics` exposes the new counter — `test_r12_metrics_exposes_save_drift_drops`
- [x] All 62 existing `test_prefix_cache_persistence.py` tests still pass (no regressions)
- [x] 518 wider cache/persist tests pass

Plus `scripts/repro_r12_atomicity.py` — manual repro harness for Talia / future dogfooders.

Reported by Talia r12 dogfood; report at `/tmp/dogfood-0815/talia-r12.md`