### PR TITLE
fix(anthropic): sanitize <think> + dedupe rescue tail in /v1/messages (M-1b)

### DIFF
--- a/tests/test_anthropic_think_leak_r12_m1b.py
+++ b/tests/test_anthropic_think_leak_r12_m1b.py
@@ -9,12 +9,16 @@ canonical sanitizer that together close Mira r12 R-3 SEVERE finding on
   prompt-template-injected ``<think>`` opener was the only token the
   reasoning parser saw at ``max_tokens=1`` on a thinking model and it
   ended up verbatim in BOTH the ``thinking`` AND the ``text`` content
-  blocks. The canonical :func:`sanitize_output` now strips both the
-  opener and the closer (only ``</think>`` was stripped before), and
-  the Anthropic adapter routes the ``thinking`` block content through
-  the sanitizer so the leak is closed on every entry path (chat /
-  responses / messages, stream + non-stream all share the same
-  canonical sanitizer + adapter).
+  blocks. Fixed by routing reasoning-channel bytes (Anthropic
+  ``thinking`` block + rescue tail) through the new
+  :func:`strip_reasoning_channel_markup`, which strips BOTH the
+  ``<think>`` opener AND ``</think>`` closer. The canonical
+  :func:`sanitize_output` intentionally STILL preserves the bare
+  ``<think>`` opener on content-channel bytes — that opener is
+  sometimes legit there (Nemotron prefix injection, literal-tag prose
+  like ``"use the <think> tag in HTML"``), and stripping it would
+  regress ``TestStreamingPostProcessorNemotron::test_thinking_prefix_injected``
+  + the ``test_streaming_reasoning_split_r8c.py`` literal-tag pin.
 
 * **Bug #2 — rescue tail duplicated across content blocks**. With
   ``max_tokens=40`` on a thinking model, the H-01 (PR #802 / R12-8 PR

--- a/tests/test_anthropic_think_leak_r12_m1b.py
+++ b/tests/test_anthropic_think_leak_r12_m1b.py
@@ -576,3 +576,89 @@ class TestThinkingBlockContentHelper:
         reasoning = "my full thought process"
         text = "the answer"
         assert _thinking_block_content(reasoning, text) == reasoning
+
+
+class TestMarkupOnlyDelta:
+    """Codex r1 P2 (R12-M1b): the markup-only-delta dupe case.
+
+    When ``reasoning_text`` and ``text`` differ ONLY by reasoning-channel
+    markup (e.g. ``reasoning_text="<think>done</think>"`` and
+    ``text="done"``), the channel-aware sanitizer normalizes the
+    thinking payload to the same bytes the text block already carries.
+    The pre-fix gate ``reasoning_text != text`` was a True predicate
+    (the strings DO differ), so both blocks emitted with the same
+    visible bytes — exactly the duplicate-block failure mode this
+    suppression was supposed to prevent.
+
+    Fix: gate on ``thinking_body != text`` (post-sanitize).
+    """
+
+    def test_markup_only_delta_does_not_emit_duplicate_thinking_block(self):
+        """``reasoning_text`` is just the wrapped form of ``text`` — the
+        adapter must NOT emit a thinking block that, after sanitization,
+        contains the same visible bytes as the text block.
+        """
+        reasoning_text = "<think>done</think>"
+        text = "done"
+        resp = ChatCompletionResponse(
+            model="qwen3-0.6b-bf16",
+            choices=[
+                ChatCompletionChoice(
+                    index=0,
+                    message=AssistantMessage(
+                        role="assistant",
+                        content=text,
+                        reasoning_content=reasoning_text,
+                        tool_calls=None,
+                    ),
+                    finish_reason="stop",
+                )
+            ],
+            usage=Usage(prompt_tokens=5, completion_tokens=5, total_tokens=10),
+        )
+        anth = openai_to_anthropic(resp, "qwen3-0.6b-bf16", reasoning_enabled=True)
+        # The text block must carry the answer.
+        text_blocks = [b for b in anth.content if b.type == "text"]
+        assert len(text_blocks) == 1
+        assert text_blocks[0].text == "done"
+        # The thinking block MUST be suppressed — emitting it would
+        # render the same visible bytes twice (Codex r1 P2 dupe).
+        thinking_blocks = [b for b in anth.content if b.type == "thinking"]
+        assert thinking_blocks == [], (
+            "thinking block must be suppressed when its post-sanitize "
+            "payload equals the text block (markup-only delta dupe); "
+            f"got {[b.thinking for b in thinking_blocks]!r}"
+        )
+
+    def test_markup_only_delta_with_distinct_reasoning_still_emits_thinking(self):
+        """Pin the inverse: when the post-sanitize thinking payload is
+        genuinely DIFFERENT from the text block (the normal happy path),
+        the adapter MUST emit the thinking block. Guards against an
+        over-aggressive fix that suppresses the thinking block for
+        every case where reasoning + content share a non-empty suffix.
+        """
+        reasoning_text = "<think>let me think about this carefully</think>"
+        text = "the answer"
+        resp = ChatCompletionResponse(
+            model="qwen3-0.6b-bf16",
+            choices=[
+                ChatCompletionChoice(
+                    index=0,
+                    message=AssistantMessage(
+                        role="assistant",
+                        content=text,
+                        reasoning_content=reasoning_text,
+                        tool_calls=None,
+                    ),
+                    finish_reason="stop",
+                )
+            ],
+            usage=Usage(prompt_tokens=5, completion_tokens=10, total_tokens=15),
+        )
+        anth = openai_to_anthropic(resp, "qwen3-0.6b-bf16", reasoning_enabled=True)
+        thinking_blocks = [b for b in anth.content if b.type == "thinking"]
+        text_blocks = [b for b in anth.content if b.type == "text"]
+        assert len(thinking_blocks) == 1
+        assert thinking_blocks[0].thinking == "let me think about this carefully"
+        assert len(text_blocks) == 1
+        assert text_blocks[0].text == "the answer"

--- a/tests/test_anthropic_think_leak_r12_m1b.py
+++ b/tests/test_anthropic_think_leak_r12_m1b.py
@@ -705,6 +705,56 @@ class TestMarkupOnlyDelta:
         assert len(text_blocks) == 1
         assert text_blocks[0].text == "the answer"
 
+    def test_unsanitised_text_with_removable_markup_still_dedupes(self):
+        """Codex r3 BLOCKING (R12-M1b): the dedupe gate must compare
+        ``thinking_body`` against ``text`` POST-sanitize on BOTH sides,
+        not just one. Hostile shape:
+
+        * ``reasoning_text="<think>done</think>"`` — channel-aware
+          sanitizer normalizes the thinking payload to ``"done"``.
+        * ``text="done</think>"`` — the canonical content-channel
+          ``sanitize_output`` collapses this to ``"done"`` too.
+
+        The Anthropic route layer runs ``sanitize_output`` on
+        ``final_content`` before handing it to ``openai_to_anthropic``,
+        so the in-route path normally never exhibits this shape. BUT
+        if a non-route caller (test helper, future SSE finalize path,
+        a future internal route that forgets the route's sanitization
+        step) hands the adapter a raw ``text`` carrying removable
+        markup, the dedupe gate must STILL refuse to render the same
+        visible bytes twice. Gate on post-sanitize equality on both
+        sides closes the hole regardless of upstream sanitization
+        state.
+        """
+        reasoning_text = "<think>done</think>"
+        text = "done</think>"  # carries removable markup
+        resp = ChatCompletionResponse(
+            model="qwen3-0.6b-bf16",
+            choices=[
+                ChatCompletionChoice(
+                    index=0,
+                    message=AssistantMessage(
+                        role="assistant",
+                        content=text,
+                        reasoning_content=reasoning_text,
+                        tool_calls=None,
+                    ),
+                    finish_reason="stop",
+                )
+            ],
+            usage=Usage(prompt_tokens=5, completion_tokens=5, total_tokens=10),
+        )
+        anth = openai_to_anthropic(resp, "qwen3-0.6b-bf16", reasoning_enabled=True)
+        thinking_blocks = [b for b in anth.content if b.type == "thinking"]
+        # The thinking block MUST be suppressed: post-sanitize, both
+        # sides reduce to ``"done"`` — emitting both would render the
+        # answer twice on the wire (codex r3 BLOCKING dupe shape).
+        assert thinking_blocks == [], (
+            "thinking block must be suppressed when its post-sanitize "
+            "payload equals the post-sanitize text payload (codex r3 "
+            f"BLOCKING dupe shape); got {[b.thinking for b in thinking_blocks]!r}"
+        )
+
 
 class TestSliceBisectsThinkTag:
     """Codex r3 P2 (R12-M1b): the slice-bisects-tag boundary case.

--- a/tests/test_anthropic_think_leak_r12_m1b.py
+++ b/tests/test_anthropic_think_leak_r12_m1b.py
@@ -85,12 +85,19 @@ def _make_rescue_payload(reasoning_text: str) -> str:
     same layout the helper writes — without importing the helper
     itself. ``sanitized_tail`` runs through both stages of the
     channel-aware sanitizer (matching
-    ``_build_reasoning_rescue_payload``). When the tail collapses to
-    empty after sanitization, the rescue is just the bare sentinel
-    (matching the helper's all-markup fallback).
+    ``_build_reasoning_rescue_payload``).
+
+    Strip-before-slice order mirrors the helper (codex r3 P2 fix):
+    sanitizing channel markup before choosing the tail boundary
+    means a ``<think>`` tag straddling the slice can't leak a
+    partial fragment into the rescue tail.
+
+    When the tail collapses to empty after sanitization, the rescue
+    is just the bare sentinel (matching the helper's all-markup
+    fallback).
     """
-    tail = reasoning_text.rstrip()[-RESCUE_TAIL_LENGTH:]
-    tail = strip_reasoning_channel_markup(tail)
+    stripped = strip_reasoning_channel_markup(reasoning_text.rstrip())
+    tail = stripped[-RESCUE_TAIL_LENGTH:]
     sanitized = sanitize_output(tail)
     if not sanitized:
         return REASONING_CUTOFF_SENTINEL
@@ -697,3 +704,89 @@ class TestMarkupOnlyDelta:
         assert thinking_blocks[0].thinking == "let me think about this carefully"
         assert len(text_blocks) == 1
         assert text_blocks[0].text == "the answer"
+
+
+class TestSliceBisectsThinkTag:
+    """Codex r3 P2 (R12-M1b): the slice-bisects-tag boundary case.
+
+    When ``reasoning_text`` is just slightly longer than
+    ``RESCUE_TAIL_LENGTH`` and contains a ``<think>`` tag near the
+    boundary, a naive ``reasoning_text.rstrip()[-RESCUE_TAIL_LENGTH:]``
+    slice can bisect the tag, leaving an orphan ``<th`` /  ``ink>``
+    fragment that the regex stripper no longer matches.
+
+    Fix: strip channel markup BEFORE choosing the tail boundary so
+    the slice operates on the clean, in-channel byte stream — no
+    tags left to bisect by construction.
+    """
+
+    @pytest.mark.parametrize(
+        "prefix_len,total_len",
+        [
+            # Reasoning lengths that force ``<think>`` to straddle
+            # the L - RESCUE_TAIL_LENGTH boundary. Each pinning shape
+            # gets tested under both the rescue helper (text block)
+            # and the adapter dedupe (thinking block) — symmetric
+            # because both helpers now strip-before-slice.
+            (1, 203),  # '<think>' at positions 1-7, boundary at 3
+            (3, 205),  # '<think>' at positions 3-9, boundary at 5
+            (5, 207),  # '<think>' at positions 5-11, boundary at 7
+        ],
+    )
+    def test_no_partial_think_fragment_in_any_block(
+        self, prefix_len: int, total_len: int
+    ):
+        """Slice-bisects-``<think>`` pinning: NO ``<th`` / ``ink>``
+        fragment may appear in the rescue payload OR in the thinking
+        block. Parametrized over multiple boundary alignments so the
+        invariant is enforced uniformly across slice positions.
+        """
+        prefix = "A" * prefix_len
+        # The total reasoning length is fixed; fill remaining with B's
+        body_len = total_len - prefix_len - len("<think>")
+        reasoning = prefix + "<think>" + "B" * body_len
+        assert len(reasoning) == total_len, "test setup invariant"
+
+        rescue_text = _make_rescue_payload(reasoning)
+
+        resp = ChatCompletionResponse(
+            model="qwen3-0.6b-bf16",
+            choices=[
+                ChatCompletionChoice(
+                    index=0,
+                    message=AssistantMessage(
+                        role="assistant",
+                        content=rescue_text,
+                        reasoning_content=reasoning,
+                        tool_calls=None,
+                    ),
+                    finish_reason="length",
+                )
+            ],
+            usage=Usage(
+                prompt_tokens=10,
+                completion_tokens=total_len,
+                total_tokens=10 + total_len,
+            ),
+        )
+        anth = openai_to_anthropic(resp, "qwen3-0.6b-bf16", reasoning_enabled=True)
+
+        # No partial think fragment in either block on the wire.
+        for block in anth.content:
+            body = block.thinking if block.type == "thinking" else (block.text or "")
+            assert "<think>" not in (body or ""), (
+                f"<think> literal leaked into {block.type}: {body!r}"
+            )
+            assert "</think>" not in (body or ""), (
+                f"</think> literal leaked into {block.type}: {body!r}"
+            )
+            # The partial-fragment failure mode: regex misses the
+            # bisected tail / head bytes.
+            assert "ink>" not in (body or ""), (
+                f"orphan 'ink>' fragment leaked into {block.type} "
+                f"(slice bisected '<think>' tag): {body!r}"
+            )
+            assert "<th" not in (body or ""), (
+                f"orphan '<th' fragment leaked into {block.type} "
+                f"(slice bisected '<think>' tag): {body!r}"
+            )

--- a/tests/test_anthropic_think_leak_r12_m1b.py
+++ b/tests/test_anthropic_think_leak_r12_m1b.py
@@ -58,7 +58,44 @@ from vllm_mlx.api.models import (
     Usage,
 )
 from vllm_mlx.api.utils import sanitize_output, strip_reasoning_channel_markup
-from vllm_mlx.service.helpers import _apply_reasoning_cutoff_notice
+
+# ---------------------------------------------------------------------------
+# Pure-API rescue-payload reconstruction.
+#
+# Codex r2 P1 (R12-M1b): the test file previously imported
+# ``_apply_reasoning_cutoff_notice`` from ``vllm_mlx.service.helpers``,
+# which transitively pulls the engine layer into pytest collection.
+# Existing route-helper tests already follow that pattern (see
+# ``tests/test_reasoning_content_null_rescue.py``) and the CI test
+# matrices stay green, but keeping THIS file pure-API removes a class
+# of headless-environment failure modes by construction.
+#
+# The rescue payload shape is the public contract documented in
+# ``api.constants.is_rescue_payload`` and the
+# ``service.helpers._build_reasoning_rescue_payload`` docstring; we
+# reconstruct it here against those same public symbols so the test
+# pins the wire shape rather than the helper's call signature.
+# ---------------------------------------------------------------------------
+
+
+def _make_rescue_payload(reasoning_text: str) -> str:
+    """Reconstruct the canonical rescue payload from public symbols.
+
+    Pins the wire shape ``sentinel + "\\n\\n" + sanitized_tail`` —
+    same layout the helper writes — without importing the helper
+    itself. ``sanitized_tail`` runs through both stages of the
+    channel-aware sanitizer (matching
+    ``_build_reasoning_rescue_payload``). When the tail collapses to
+    empty after sanitization, the rescue is just the bare sentinel
+    (matching the helper's all-markup fallback).
+    """
+    tail = reasoning_text.rstrip()[-RESCUE_TAIL_LENGTH:]
+    tail = strip_reasoning_channel_markup(tail)
+    sanitized = sanitize_output(tail)
+    if not sanitized:
+        return REASONING_CUTOFF_SENTINEL
+    return f"{REASONING_CUTOFF_SENTINEL}\n\n{sanitized}"
+
 
 # ---------------------------------------------------------------------------
 # Bug #1 — ``<think>`` literal does NOT appear in ANY content block at
@@ -136,12 +173,7 @@ class TestThinkLiteralLeak:
         # Enable the rescue (default-on, but pin for hermetic test).
         monkeypatch.setenv("RAPID_MLX_REASONING_RESCUE", "on")
         reasoning_text = "<think>"
-        final_content = _apply_reasoning_cutoff_notice(
-            None,  # final_content empty (parser routed everything to reasoning)
-            reasoning_text,
-            None,  # no tool calls
-            "length",  # cut by max_tokens budget
-        )
+        final_content = _make_rescue_payload(reasoning_text)
         # Build the OpenAI-side response that the route hands to the
         # adapter (matches the call shape in routes/anthropic.py).
         resp = ChatCompletionResponse(
@@ -181,9 +213,7 @@ class TestThinkLiteralLeak:
         """
         monkeypatch.setenv("RAPID_MLX_REASONING_RESCUE", "on")
         reasoning_text = "<think>"
-        final_content = _apply_reasoning_cutoff_notice(
-            None, reasoning_text, None, "length"
-        )
+        final_content = _make_rescue_payload(reasoning_text)
         resp = ChatCompletionResponse(
             model="qwen3-0.6b-bf16",
             choices=[
@@ -236,9 +266,7 @@ class TestRescueTailNoDuplication:
         prefix = "A" * (RESCUE_TAIL_LENGTH * 2)  # 400 chars of filler
         tail_marker = "UNIQUE_TAIL_MARKER_XYZ"
         reasoning_text = prefix + " ... " + tail_marker + " conclusion."
-        final_content = _apply_reasoning_cutoff_notice(
-            None, reasoning_text, None, "length"
-        )
+        final_content = _make_rescue_payload(reasoning_text)
         # Confirm the marker landed in the rescue payload (sanity).
         assert tail_marker in final_content, (
             "test setup invariant: marker must be inside the rescue tail slice"
@@ -288,9 +316,7 @@ class TestRescueTailNoDuplication:
         """
         monkeypatch.setenv("RAPID_MLX_REASONING_RESCUE", "on")
         reasoning_text = "X" * 500 + " final partial conclusion."
-        final_content = _apply_reasoning_cutoff_notice(
-            None, reasoning_text, None, "length"
-        )
+        final_content = _make_rescue_payload(reasoning_text)
         # Extract the tail substring from the rescue payload.
         separator = "\n\n"
         rescue_tail = final_content.split(separator, 1)[1]
@@ -345,9 +371,7 @@ class TestRescueTailNoDuplication:
         monkeypatch.setenv("RAPID_MLX_REASONING_RESCUE", "on")
         prefix = "BEGINNING THOUGHT PROCESS HERE. "
         reasoning_text = prefix + "X" * (RESCUE_TAIL_LENGTH + 50)
-        final_content = _apply_reasoning_cutoff_notice(
-            None, reasoning_text, None, "length"
-        )
+        final_content = _make_rescue_payload(reasoning_text)
         resp = ChatCompletionResponse(
             model="qwen3-0.6b-bf16",
             choices=[
@@ -385,9 +409,7 @@ class TestRescueTailNoDuplication:
         assert len(reasoning_text) <= RESCUE_TAIL_LENGTH, (
             "test invariant: reasoning must be shorter than the tail length"
         )
-        final_content = _apply_reasoning_cutoff_notice(
-            None, reasoning_text, None, "length"
-        )
+        final_content = _make_rescue_payload(reasoning_text)
         resp = ChatCompletionResponse(
             model="qwen3-0.6b-bf16",
             choices=[
@@ -442,9 +464,7 @@ class TestRescueSurfacesToAnthropic:
     ):
         monkeypatch.setenv("RAPID_MLX_REASONING_RESCUE", "on")
         reasoning_text = "Mid-think reasoning that got cut by max_tokens."
-        final_content = _apply_reasoning_cutoff_notice(
-            None, reasoning_text, None, "length"
-        )
+        final_content = _make_rescue_payload(reasoning_text)
         resp = ChatCompletionResponse(
             model="qwen3-0.6b-bf16",
             choices=[
@@ -476,18 +496,23 @@ class TestRescueSurfacesToAnthropic:
             f"rescue text block payload failed the canonical shape gate: {text_payload!r}"
         )
 
-    def test_rescue_does_not_fire_when_opted_out(self, monkeypatch):
-        """The rescue is opt-out via either env var; when the operator
-        disables it, the text block must be empty / suppressed and
-        the thinking block carries the (sanitized) reasoning trace.
+    def test_opt_out_path_adapter_emits_only_thinking_block(self):
+        """When the operator opts out of the rescue (the route helper
+        returns ``content=None`` instead of the sentinel-prefixed
+        payload), the adapter must:
+          * NOT emit a text block (no rescue cue)
+          * emit the thinking block carrying the full sanitized
+            reasoning trace (no dedupe — ``content`` is None, so
+            ``is_rescue_payload(content)`` is False and no suffix is
+            trimmed)
+        Mirrors the wire shape ``routes/anthropic.py`` produces when
+        ``RAPID_MLX_REASONING_RESCUE=off`` /
+        ``RAPID_MLX_REASONING_CUTOFF_NOTICE=disabled``.
         """
-        monkeypatch.setenv("RAPID_MLX_REASONING_RESCUE", "off")
+        # No env var manipulation needed — we drive the adapter with
+        # ``content=None`` directly, which is what the helper would
+        # return on the opt-out branch.
         reasoning_text = "Mid-think reasoning."
-        final_content = _apply_reasoning_cutoff_notice(
-            None, reasoning_text, None, "length"
-        )
-        # With rescue off, helper returns the original empty content.
-        assert final_content is None
         resp = ChatCompletionResponse(
             model="qwen3-0.6b-bf16",
             choices=[
@@ -495,7 +520,7 @@ class TestRescueSurfacesToAnthropic:
                     index=0,
                     message=AssistantMessage(
                         role="assistant",
-                        content=final_content,
+                        content=None,
                         reasoning_content=reasoning_text,
                         tool_calls=None,
                     ),
@@ -507,8 +532,14 @@ class TestRescueSurfacesToAnthropic:
         anth = openai_to_anthropic(resp, "qwen3-0.6b-bf16", reasoning_enabled=True)
         # No text block (no rescue), thinking block carries reasoning.
         thinking_blocks = [b for b in anth.content if b.type == "thinking"]
+        text_blocks = [b for b in anth.content if b.type == "text"]
         assert len(thinking_blocks) == 1
         assert reasoning_text in (thinking_blocks[0].thinking or "")
+        # No rescue → no non-empty text block. (The adapter always adds
+        # a zero-length placeholder text block when content_blocks is
+        # otherwise empty, but the thinking block above prevents that.)
+        non_empty_text_blocks = [b for b in text_blocks if (b.text or "").strip()]
+        assert non_empty_text_blocks == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_anthropic_think_leak_r12_m1b.py
+++ b/tests/test_anthropic_think_leak_r12_m1b.py
@@ -582,13 +582,14 @@ class TestThinkingBlockContentHelper:
         assert _thinking_block_content(reasoning, text) == expected
 
     def test_dedupes_rescue_tail_from_thinking_block(self):
-        """When ``text`` is a rescue payload, trim the matching suffix
-        from the thinking block content so the tail surfaces on exactly
-        one block.
+        """When ``text`` is a rescue payload AND ``finish_reason`` is
+        ``"length"`` (the only condition under which the route helper
+        injects a rescue), trim the matching suffix from the thinking
+        block content so the tail surfaces on exactly one block.
         """
         reasoning = "PREFIX_KEEP_ME " + "Y" * (RESCUE_TAIL_LENGTH + 10)
         text = REASONING_CUTOFF_SENTINEL + "\n\n" + "Y" * RESCUE_TAIL_LENGTH
-        out = _thinking_block_content(reasoning, text)
+        out = _thinking_block_content(reasoning, text, finish_reason="length")
         assert out is not None
         assert "PREFIX_KEEP_ME" in out, (
             f"prefix lost when deduping rescue tail: {out!r}"
@@ -606,7 +607,7 @@ class TestThinkingBlockContentHelper:
         """
         reasoning = "all of it fits in the tail"
         text = REASONING_CUTOFF_SENTINEL + "\n\n" + reasoning
-        assert _thinking_block_content(reasoning, text) is None
+        assert _thinking_block_content(reasoning, text, finish_reason="length") is None
 
     def test_non_rescue_text_does_not_trigger_dedupe(self):
         """When ``text`` is a normal model answer (not a rescue
@@ -618,6 +619,28 @@ class TestThinkingBlockContentHelper:
         reasoning = "my full thought process"
         text = "the answer"
         assert _thinking_block_content(reasoning, text) == reasoning
+
+    def test_dedupe_skipped_on_non_length_finish_even_if_text_matches_shape(self):
+        """Codex r4 P3 (R12-M1b): the dedupe must be gated on BOTH
+        the rescue-payload shape AND ``finish_reason == "length"``.
+        Without the finish-reason gate, a model that legitimately
+        echoes the literal sentinel followed by ``\\n\\n`` and more
+        prose on a clean ``stop`` finish would have its thinking
+        block silently truncated.
+        """
+        reasoning = "PREFIX_KEEP_ME " + "Y" * (RESCUE_TAIL_LENGTH + 10)
+        # Same byte shape as a rescue payload, but it's the model's
+        # genuine answer on a clean ``stop`` finish.
+        text = REASONING_CUTOFF_SENTINEL + "\n\n" + "echo of the sentinel"
+        # finish_reason="stop" → no dedupe even though the shape matches.
+        out = _thinking_block_content(reasoning, text, finish_reason="stop")
+        # Full thinking trace must be preserved (no truncation).
+        assert out is not None
+        assert "PREFIX_KEEP_ME" in out
+        assert ("Y" * RESCUE_TAIL_LENGTH) in out, (
+            "thinking block was incorrectly truncated on a non-length "
+            f"finish even though the rescue helper never fired: {out!r}"
+        )
 
 
 class TestMarkupOnlyDelta:

--- a/tests/test_anthropic_think_leak_r12_m1b.py
+++ b/tests/test_anthropic_think_leak_r12_m1b.py
@@ -769,6 +769,7 @@ class TestMarkupOnlyDelta:
         )
         anth = openai_to_anthropic(resp, "qwen3-0.6b-bf16", reasoning_enabled=True)
         thinking_blocks = [b for b in anth.content if b.type == "thinking"]
+        text_blocks = [b for b in anth.content if b.type == "text"]
         # The thinking block MUST be suppressed: post-sanitize, both
         # sides reduce to ``"done"`` — emitting both would render the
         # answer twice on the wire (codex r3 BLOCKING dupe shape).
@@ -776,6 +777,18 @@ class TestMarkupOnlyDelta:
             "thinking block must be suppressed when its post-sanitize "
             "payload equals the post-sanitize text payload (codex r3 "
             f"BLOCKING dupe shape); got {[b.thinking for b in thinking_blocks]!r}"
+        )
+        # Codex r4 medium (R12-M1b): the text block emission must
+        # ALSO go through the adapter-level sanitizer — half the gate
+        # only suppresses the duplicate; the other half must scrub the
+        # removable markup so ``</think>`` never reaches the wire.
+        assert len(text_blocks) == 1
+        assert text_blocks[0].text == "done", (
+            "text block must carry the sanitized payload, not the raw "
+            f"input with markup; got {text_blocks[0].text!r}"
+        )
+        assert "</think>" not in (text_blocks[0].text or ""), (
+            f"</think> leaked into text block: {text_blocks[0].text!r}"
         )
 
 

--- a/tests/test_anthropic_think_leak_r12_m1b.py
+++ b/tests/test_anthropic_think_leak_r12_m1b.py
@@ -1,0 +1,578 @@
+# SPDX-License-Identifier: Apache-2.0
+"""R12-M1b regression tests — Anthropic /v1/messages content-block contract.
+
+Pins three invariants on the OpenAI-to-Anthropic adapter and the
+canonical sanitizer that together close Mira r12 R-3 SEVERE finding on
+``/v1/messages``:
+
+* **Bug #1 — ``<think>`` literal leak at ``max_tokens=1``**. The
+  prompt-template-injected ``<think>`` opener was the only token the
+  reasoning parser saw at ``max_tokens=1`` on a thinking model and it
+  ended up verbatim in BOTH the ``thinking`` AND the ``text`` content
+  blocks. The canonical :func:`sanitize_output` now strips both the
+  opener and the closer (only ``</think>`` was stripped before), and
+  the Anthropic adapter routes the ``thinking`` block content through
+  the sanitizer so the leak is closed on every entry path (chat /
+  responses / messages, stream + non-stream all share the same
+  canonical sanitizer + adapter).
+
+* **Bug #2 — rescue tail duplicated across content blocks**. With
+  ``max_tokens=40`` on a thinking model, the H-01 (PR #802 / R12-8 PR
+  #875) rescue payload (``sentinel + "\\n\\n" + tail-of-reasoning``)
+  was emitted into the ``text`` block, AND the same tail bytes
+  remained the suffix of the ``reasoning_text`` that became the
+  ``thinking`` block — so the same partial sentence rendered twice on
+  the Anthropic envelope. The adapter now trims the matching
+  RESCUE_TAIL_LENGTH suffix from the ``thinking`` block when the
+  ``text`` carries a rescue payload, so each reasoning byte surfaces
+  on exactly one content block.
+
+* **Design preservation — rescue surfaces to Anthropic**. PR #802 /
+  issue #858 explicitly chose to surface the H-01 rescue to the
+  Anthropic surface (GUI clients that render only text bubbles benefit
+  from the literal cue). This test pins that the rescue ``text`` block
+  still carries the sentinel + tail — only the duplication is fixed.
+
+Mira r12 dogfood report path:
+  ``/tmp/dogfood-0815/mira-r12.md`` (R-3 section)
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from vllm_mlx.api.anthropic_adapter import _thinking_block_content, openai_to_anthropic
+from vllm_mlx.api.constants import (
+    REASONING_CUTOFF_SENTINEL,
+    RESCUE_TAIL_LENGTH,
+    is_rescue_payload,
+)
+from vllm_mlx.api.models import (
+    AssistantMessage,
+    ChatCompletionChoice,
+    ChatCompletionResponse,
+    Usage,
+)
+from vllm_mlx.api.utils import sanitize_output, strip_reasoning_channel_markup
+from vllm_mlx.service.helpers import _apply_reasoning_cutoff_notice
+
+# ---------------------------------------------------------------------------
+# Bug #1 — ``<think>`` literal does NOT appear in ANY content block at
+# max_tokens=1 on a thinking model. Covers both the canonical sanitizer
+# and the Anthropic adapter's per-block sanitization.
+# ---------------------------------------------------------------------------
+
+
+class TestThinkLiteralLeak:
+    """Mira r12 R-3 bonus regression — ``<think>`` literal leak."""
+
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            # bare opener — only token seen at max_tokens=1
+            ("<think>", ""),
+            # opener as first chars of a longer string
+            ("<think>hello", "hello"),
+            # opener mid-string
+            ("hello <think> world", "hello  world"),
+            # closer (already stripped by ``sanitize_output`` pre-fix —
+            # this helper now strips it ALSO so the two routes share
+            # the same channel-aware strip semantics)
+            ("</think>", ""),
+            # both
+            ("<think>x</think>", "x"),
+            # trailing whitespace / newlines after opener — kept as-is
+            # (helper is byte-level; surrounding callers handle
+            # whitespace-only collapse via their own predicates)
+            ("   <think>   ", "      "),
+            ("<think>\n", "\n"),
+        ],
+    )
+    def test_strip_reasoning_channel_markup_strips_both_tags(self, raw: str, expected):
+        """The reasoning-channel sanitizer strips BOTH ``<think>`` and
+        ``</think>``. This is distinct from the canonical
+        ``sanitize_output`` (which only strips the closer) because the
+        opener is sometimes legit ``content``-channel text (Nemotron
+        prefix injection, literal-tag prose) and we MUST NOT erase
+        those — but on the reasoning channel the wrapping tags are
+        always structural parser artifact.
+        """
+        assert strip_reasoning_channel_markup(raw) == expected
+
+    def test_sanitize_output_does_not_strip_think_opener(self):
+        """The canonical ``sanitize_output`` MUST NOT strip the bare
+        ``<think>`` opener — that would erase legitimate Nemotron
+        prefix injection in the standard streaming path
+        (``TestStreamingPostProcessorNemotron::test_thinking_prefix_injected``)
+        and silently swallow legitimate literal-tag prose like
+        ``"use the <think> tag in HTML"`` (covered by
+        ``test_streaming_reasoning_split_r8c.py``). The opener strip
+        lives in the channel-aware helper instead — see
+        :func:`strip_reasoning_channel_markup`.
+        """
+        # Bare opener passes through unchanged (no special-token chars
+        # other than the angle brackets — fast-path also returns as-is).
+        assert sanitize_output("<think>") == "<think>"
+        assert sanitize_output("use the <think> tag") == "use the <think> tag"
+        # Closer is still stripped by the canonical sanitizer (legacy
+        # contract preserved — pre-R12-M1b behaviour).
+        assert sanitize_output("</think>") is None
+
+    def test_max_tokens_1_no_think_leak_in_any_block(self, monkeypatch):
+        """Top-of-stack repro: ``max_tokens=1`` on a thinking model
+        leaves ``reasoning_text="<think>"`` (the prompt template's
+        pre-injected opener is the only token the parser sees) and
+        ``content=None``. The rescue fires on ``finish_reason="length"``
+        and produces a sentinel-prefixed rescue payload.
+
+        Invariant: the literal ``<think>`` MUST NOT appear in either
+        the ``thinking`` content block OR the ``text`` content block
+        on the Anthropic envelope.
+        """
+        # Enable the rescue (default-on, but pin for hermetic test).
+        monkeypatch.setenv("RAPID_MLX_REASONING_RESCUE", "on")
+        reasoning_text = "<think>"
+        final_content = _apply_reasoning_cutoff_notice(
+            None,  # final_content empty (parser routed everything to reasoning)
+            reasoning_text,
+            None,  # no tool calls
+            "length",  # cut by max_tokens budget
+        )
+        # Build the OpenAI-side response that the route hands to the
+        # adapter (matches the call shape in routes/anthropic.py).
+        resp = ChatCompletionResponse(
+            model="qwen3-0.6b-bf16",
+            choices=[
+                ChatCompletionChoice(
+                    index=0,
+                    message=AssistantMessage(
+                        role="assistant",
+                        content=final_content,
+                        reasoning_content=reasoning_text,
+                        tool_calls=None,
+                    ),
+                    finish_reason="length",
+                )
+            ],
+            usage=Usage(prompt_tokens=10, completion_tokens=1, total_tokens=11),
+        )
+        anth = openai_to_anthropic(resp, "qwen3-0.6b-bf16", reasoning_enabled=True)
+        # Walk every content block — the literal must not survive on
+        # either the thinking field or the text field.
+        for block in anth.content:
+            if block.type == "thinking":
+                assert "<think>" not in (block.thinking or ""), (
+                    f"<think> literal leaked into thinking block: {block.thinking!r}"
+                )
+            elif block.type == "text":
+                assert "<think>" not in (block.text or ""), (
+                    f"<think> literal leaked into text block: {block.text!r}"
+                )
+
+    def test_max_tokens_1_thinking_block_suppressed_when_all_markup(self, monkeypatch):
+        """When the entire ``reasoning_text`` collapses to nothing after
+        sanitization (``<think>`` only), the adapter must NOT emit an
+        empty/whitespace thinking block — symmetric with the existing
+        whitespace-only guard in the pre-R12-M1b code path.
+        """
+        monkeypatch.setenv("RAPID_MLX_REASONING_RESCUE", "on")
+        reasoning_text = "<think>"
+        final_content = _apply_reasoning_cutoff_notice(
+            None, reasoning_text, None, "length"
+        )
+        resp = ChatCompletionResponse(
+            model="qwen3-0.6b-bf16",
+            choices=[
+                ChatCompletionChoice(
+                    index=0,
+                    message=AssistantMessage(
+                        role="assistant",
+                        content=final_content,
+                        reasoning_content=reasoning_text,
+                        tool_calls=None,
+                    ),
+                    finish_reason="length",
+                )
+            ],
+            usage=Usage(prompt_tokens=10, completion_tokens=1, total_tokens=11),
+        )
+        anth = openai_to_anthropic(resp, "qwen3-0.6b-bf16", reasoning_enabled=True)
+        thinking_blocks = [b for b in anth.content if b.type == "thinking"]
+        assert thinking_blocks == [], (
+            f"thinking block should be suppressed when all reasoning is markup; "
+            f"got {[b.thinking for b in thinking_blocks]!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Bug #2 — Rescue tail must appear in EXACTLY ONE block (the text block).
+# ---------------------------------------------------------------------------
+
+
+class TestRescueTailNoDuplication:
+    """Mira r12 R-3 dupe arm — rescue tail must not appear in BOTH blocks."""
+
+    def test_rescue_tail_in_text_block_not_thinking_block(self, monkeypatch):
+        """``max_tokens=40`` repro: a thinking model emits a long
+        reasoning trace and gets cut by length. The rescue payload
+        (``sentinel + "\\n\\n" + tail-of-reasoning``) goes into the
+        text block. The same tail bytes WERE also the suffix of the
+        ``reasoning_text`` that became the thinking block — Mira saw
+        the same partial sentence twice in the Anthropic envelope.
+
+        Pin: the rescue tail (last RESCUE_TAIL_LENGTH chars of
+        ``reasoning_text``) appears in the ``text`` block but NOT
+        anywhere in the ``thinking`` block.
+        """
+        monkeypatch.setenv("RAPID_MLX_REASONING_RESCUE", "on")
+        # Long enough reasoning that the tail slice is a strict
+        # suffix (longer than RESCUE_TAIL_LENGTH). Uses a unique
+        # marker substring inside the tail slice so the assertion
+        # has a precise anchor.
+        prefix = "A" * (RESCUE_TAIL_LENGTH * 2)  # 400 chars of filler
+        tail_marker = "UNIQUE_TAIL_MARKER_XYZ"
+        reasoning_text = prefix + " ... " + tail_marker + " conclusion."
+        final_content = _apply_reasoning_cutoff_notice(
+            None, reasoning_text, None, "length"
+        )
+        # Confirm the marker landed in the rescue payload (sanity).
+        assert tail_marker in final_content, (
+            "test setup invariant: marker must be inside the rescue tail slice"
+        )
+        resp = ChatCompletionResponse(
+            model="qwen3-0.6b-bf16",
+            choices=[
+                ChatCompletionChoice(
+                    index=0,
+                    message=AssistantMessage(
+                        role="assistant",
+                        content=final_content,
+                        reasoning_content=reasoning_text,
+                        tool_calls=None,
+                    ),
+                    finish_reason="length",
+                )
+            ],
+            usage=Usage(prompt_tokens=10, completion_tokens=40, total_tokens=50),
+        )
+        anth = openai_to_anthropic(resp, "qwen3-0.6b-bf16", reasoning_enabled=True)
+        text_blocks = [b for b in anth.content if b.type == "text"]
+        thinking_blocks = [b for b in anth.content if b.type == "thinking"]
+        assert len(text_blocks) == 1, (
+            f"expected exactly one text block: {anth.content!r}"
+        )
+        assert len(thinking_blocks) == 1, (
+            f"expected exactly one thinking block: {anth.content!r}"
+        )
+        # The marker must be in the text block …
+        assert tail_marker in (text_blocks[0].text or ""), (
+            f"rescue tail marker missing from text block: {text_blocks[0].text!r}"
+        )
+        # … and MUST NOT appear in the thinking block (the dedupe).
+        assert tail_marker not in (thinking_blocks[0].thinking or ""), (
+            f"rescue tail leaked into thinking block (duplication): "
+            f"{thinking_blocks[0].thinking!r}"
+        )
+
+    def test_rescue_tail_appears_in_exactly_one_block(self, monkeypatch):
+        """Cross-block uniqueness: the rescue payload's tail
+        substring (everything after the sentinel + ``\\n\\n``
+        separator) must appear in EXACTLY one of the content blocks.
+        Parametrized over the per-block role pin (which one) is the
+        ``text`` block — matches the PR #802 / R12-8 design where the
+        rescue surfaces to ``text``.
+        """
+        monkeypatch.setenv("RAPID_MLX_REASONING_RESCUE", "on")
+        reasoning_text = "X" * 500 + " final partial conclusion."
+        final_content = _apply_reasoning_cutoff_notice(
+            None, reasoning_text, None, "length"
+        )
+        # Extract the tail substring from the rescue payload.
+        separator = "\n\n"
+        rescue_tail = final_content.split(separator, 1)[1]
+        assert rescue_tail, "test invariant: rescue tail must be non-empty"
+
+        resp = ChatCompletionResponse(
+            model="qwen3-0.6b-bf16",
+            choices=[
+                ChatCompletionChoice(
+                    index=0,
+                    message=AssistantMessage(
+                        role="assistant",
+                        content=final_content,
+                        reasoning_content=reasoning_text,
+                        tool_calls=None,
+                    ),
+                    finish_reason="length",
+                )
+            ],
+            usage=Usage(prompt_tokens=10, completion_tokens=200, total_tokens=210),
+        )
+        anth = openai_to_anthropic(resp, "qwen3-0.6b-bf16", reasoning_enabled=True)
+        # Count occurrences of the tail substring across blocks.
+        text_hits = sum(
+            1
+            for b in anth.content
+            if b.type == "text" and rescue_tail in (b.text or "")
+        )
+        thinking_hits = sum(
+            1
+            for b in anth.content
+            if b.type == "thinking" and rescue_tail in (b.thinking or "")
+        )
+        # The text block has the tail (rescue) AND no thinking block carries it.
+        assert text_hits == 1, (
+            f"rescue tail must surface in exactly one text block; got {text_hits}"
+        )
+        assert thinking_hits == 0, (
+            f"rescue tail must NOT appear in any thinking block; got {thinking_hits}"
+        )
+
+    def test_thinking_block_carries_prefix_when_reasoning_longer_than_tail(
+        self, monkeypatch
+    ):
+        """When ``reasoning_text`` is longer than ``RESCUE_TAIL_LENGTH``,
+        the thinking block should carry the PREFIX (everything except
+        the last RESCUE_TAIL_LENGTH chars). Reading both blocks
+        reconstructs the full reasoning trace contextually — the
+        sentinel anchors the rescue tail, the thinking block has the
+        leading thought process.
+        """
+        monkeypatch.setenv("RAPID_MLX_REASONING_RESCUE", "on")
+        prefix = "BEGINNING THOUGHT PROCESS HERE. "
+        reasoning_text = prefix + "X" * (RESCUE_TAIL_LENGTH + 50)
+        final_content = _apply_reasoning_cutoff_notice(
+            None, reasoning_text, None, "length"
+        )
+        resp = ChatCompletionResponse(
+            model="qwen3-0.6b-bf16",
+            choices=[
+                ChatCompletionChoice(
+                    index=0,
+                    message=AssistantMessage(
+                        role="assistant",
+                        content=final_content,
+                        reasoning_content=reasoning_text,
+                        tool_calls=None,
+                    ),
+                    finish_reason="length",
+                )
+            ],
+            usage=Usage(prompt_tokens=10, completion_tokens=300, total_tokens=310),
+        )
+        anth = openai_to_anthropic(resp, "qwen3-0.6b-bf16", reasoning_enabled=True)
+        thinking_blocks = [b for b in anth.content if b.type == "thinking"]
+        assert len(thinking_blocks) == 1
+        # Prefix marker must survive in the thinking block.
+        assert "BEGINNING THOUGHT PROCESS HERE." in thinking_blocks[0].thinking, (
+            f"thinking block lost the prefix: {thinking_blocks[0].thinking!r}"
+        )
+
+    def test_thinking_block_suppressed_when_reasoning_entirely_in_rescue_tail(
+        self, monkeypatch
+    ):
+        """When ``reasoning_text`` is shorter than ``RESCUE_TAIL_LENGTH``,
+        the entire trace lives inside the rescue payload's tail.
+        Emitting the thinking block would be a byte-for-byte duplicate
+        of what's already in the text block. Suppress it.
+        """
+        monkeypatch.setenv("RAPID_MLX_REASONING_RESCUE", "on")
+        reasoning_text = "short reasoning trace under the tail length"
+        assert len(reasoning_text) <= RESCUE_TAIL_LENGTH, (
+            "test invariant: reasoning must be shorter than the tail length"
+        )
+        final_content = _apply_reasoning_cutoff_notice(
+            None, reasoning_text, None, "length"
+        )
+        resp = ChatCompletionResponse(
+            model="qwen3-0.6b-bf16",
+            choices=[
+                ChatCompletionChoice(
+                    index=0,
+                    message=AssistantMessage(
+                        role="assistant",
+                        content=final_content,
+                        reasoning_content=reasoning_text,
+                        tool_calls=None,
+                    ),
+                    finish_reason="length",
+                )
+            ],
+            usage=Usage(prompt_tokens=10, completion_tokens=20, total_tokens=30),
+        )
+        anth = openai_to_anthropic(resp, "qwen3-0.6b-bf16", reasoning_enabled=True)
+        thinking_blocks = [b for b in anth.content if b.type == "thinking"]
+        text_blocks = [b for b in anth.content if b.type == "text"]
+        assert thinking_blocks == [], (
+            "thinking block must be suppressed when the whole reasoning trace "
+            f"already lives in the rescue tail; got {[b.thinking for b in thinking_blocks]!r}"
+        )
+        # The text block still carries the full reasoning via the rescue.
+        assert text_blocks
+        assert reasoning_text in (text_blocks[0].text or "")
+
+
+# ---------------------------------------------------------------------------
+# Design preservation — PR #802 / issue #858 explicitly surfaces the
+# rescue to /v1/messages. A future contributor should NOT regress this
+# behaviour without an explicit operator-policy decision. The positive
+# test below pins the design so the dedupe fix above can never grow
+# into "remove the rescue from Anthropic entirely".
+# ---------------------------------------------------------------------------
+
+
+class TestRescueSurfacesToAnthropic:
+    """Pin PR #802 / issue #858 — the H-01 rescue surfaces to Anthropic.
+
+    Mira r12's spec said the rescue should NOT touch Anthropic content
+    blocks; the operator-approved design (PR #802 / #875) is that it
+    DOES, because GUI clients that only render text blocks need a
+    user-visible cue when ``max_tokens`` was too low. This test exists
+    so a future contributor reading the dedupe fix above doesn't
+    interpret it as "remove rescue from Anthropic" and silently drop
+    the operator-blessed behaviour.
+    """
+
+    def test_rescue_text_block_carries_sentinel_when_length_cut_mid_think(
+        self, monkeypatch
+    ):
+        monkeypatch.setenv("RAPID_MLX_REASONING_RESCUE", "on")
+        reasoning_text = "Mid-think reasoning that got cut by max_tokens."
+        final_content = _apply_reasoning_cutoff_notice(
+            None, reasoning_text, None, "length"
+        )
+        resp = ChatCompletionResponse(
+            model="qwen3-0.6b-bf16",
+            choices=[
+                ChatCompletionChoice(
+                    index=0,
+                    message=AssistantMessage(
+                        role="assistant",
+                        content=final_content,
+                        reasoning_content=reasoning_text,
+                        tool_calls=None,
+                    ),
+                    finish_reason="length",
+                )
+            ],
+            usage=Usage(prompt_tokens=10, completion_tokens=30, total_tokens=40),
+        )
+        anth = openai_to_anthropic(resp, "qwen3-0.6b-bf16", reasoning_enabled=True)
+        text_blocks = [b for b in anth.content if b.type == "text"]
+        assert text_blocks, "rescue text block must be present (PR #802 design)"
+        text_payload = text_blocks[0].text or ""
+        assert text_payload.startswith(REASONING_CUTOFF_SENTINEL), (
+            f"rescue text block must start with the sentinel "
+            f"(PR #802 design — agentic auto-retry pattern-matches the prefix); "
+            f"got {text_payload!r}"
+        )
+        # Verify it is in fact the rescue payload shape (sentinel +
+        # \\n\\n + tail) and not just a model echo of the sentinel.
+        assert is_rescue_payload(text_payload), (
+            f"rescue text block payload failed the canonical shape gate: {text_payload!r}"
+        )
+
+    def test_rescue_does_not_fire_when_opted_out(self, monkeypatch):
+        """The rescue is opt-out via either env var; when the operator
+        disables it, the text block must be empty / suppressed and
+        the thinking block carries the (sanitized) reasoning trace.
+        """
+        monkeypatch.setenv("RAPID_MLX_REASONING_RESCUE", "off")
+        reasoning_text = "Mid-think reasoning."
+        final_content = _apply_reasoning_cutoff_notice(
+            None, reasoning_text, None, "length"
+        )
+        # With rescue off, helper returns the original empty content.
+        assert final_content is None
+        resp = ChatCompletionResponse(
+            model="qwen3-0.6b-bf16",
+            choices=[
+                ChatCompletionChoice(
+                    index=0,
+                    message=AssistantMessage(
+                        role="assistant",
+                        content=final_content,
+                        reasoning_content=reasoning_text,
+                        tool_calls=None,
+                    ),
+                    finish_reason="length",
+                )
+            ],
+            usage=Usage(prompt_tokens=10, completion_tokens=10, total_tokens=20),
+        )
+        anth = openai_to_anthropic(resp, "qwen3-0.6b-bf16", reasoning_enabled=True)
+        # No text block (no rescue), thinking block carries reasoning.
+        thinking_blocks = [b for b in anth.content if b.type == "thinking"]
+        assert len(thinking_blocks) == 1
+        assert reasoning_text in (thinking_blocks[0].thinking or "")
+
+
+# ---------------------------------------------------------------------------
+# Unit tests on the per-block sanitizer helper directly. Keeps the
+# adapter-level integration tests above focused on observable wire shape
+# and the helper-level tests focused on the contract.
+# ---------------------------------------------------------------------------
+
+
+class TestThinkingBlockContentHelper:
+    """Unit tests on :func:`_thinking_block_content`."""
+
+    @pytest.mark.parametrize(
+        "reasoning,text,expected",
+        [
+            # No reasoning → no block
+            (None, None, None),
+            ("", None, None),
+            ("   ", None, None),
+            # Plain reasoning, no rescue → sanitized passthrough
+            ("normal reasoning trace.", None, "normal reasoning trace."),
+            # Special-token leak in reasoning → sanitized
+            ("<think>", None, None),
+            ("<think>kept</think>", None, "kept"),
+            (
+                "real thought <|im_end|> trailing markup",
+                None,
+                "real thought  trailing markup",
+            ),
+        ],
+    )
+    def test_sanitizes_thinking_content(self, reasoning, text, expected):
+        assert _thinking_block_content(reasoning, text) == expected
+
+    def test_dedupes_rescue_tail_from_thinking_block(self):
+        """When ``text`` is a rescue payload, trim the matching suffix
+        from the thinking block content so the tail surfaces on exactly
+        one block.
+        """
+        reasoning = "PREFIX_KEEP_ME " + "Y" * (RESCUE_TAIL_LENGTH + 10)
+        text = REASONING_CUTOFF_SENTINEL + "\n\n" + "Y" * RESCUE_TAIL_LENGTH
+        out = _thinking_block_content(reasoning, text)
+        assert out is not None
+        assert "PREFIX_KEEP_ME" in out, (
+            f"prefix lost when deduping rescue tail: {out!r}"
+        )
+        # The trimmed suffix should NOT appear in the thinking block.
+        assert ("Y" * RESCUE_TAIL_LENGTH) not in out, (
+            f"rescue tail still present in thinking block (dedupe failed): {out!r}"
+        )
+
+    def test_dedupes_to_none_when_reasoning_fits_in_tail(self):
+        """If ``reasoning`` is shorter than RESCUE_TAIL_LENGTH and the
+        text block carries the rescue, the entire trace is already in
+        the text block — return None so the thinking block is
+        suppressed.
+        """
+        reasoning = "all of it fits in the tail"
+        text = REASONING_CUTOFF_SENTINEL + "\n\n" + reasoning
+        assert _thinking_block_content(reasoning, text) is None
+
+    def test_non_rescue_text_does_not_trigger_dedupe(self):
+        """When ``text`` is a normal model answer (not a rescue
+        payload), the thinking block must keep the full sanitized
+        reasoning. The dedupe is gated on
+        :func:`is_rescue_payload` so a legit response that happens to
+        share a suffix with reasoning is not silently truncated.
+        """
+        reasoning = "my full thought process"
+        text = "the answer"
+        assert _thinking_block_content(reasoning, text) == reasoning

--- a/vllm_mlx/api/anthropic_adapter.py
+++ b/vllm_mlx/api/anthropic_adapter.py
@@ -23,6 +23,10 @@ from .anthropic_models import (
     AnthropicToolDef,
     AnthropicUsage,
 )
+from .constants import (
+    RESCUE_TAIL_LENGTH,
+    is_rescue_payload,
+)
 from .models import (
     ChatCompletionRequest,
     ChatCompletionResponse,
@@ -31,6 +35,7 @@ from .models import (
     ResponseFormatJsonSchema,
     ToolDefinition,
 )
+from .utils import sanitize_output, strip_reasoning_channel_markup
 
 # F9: Anthropic's public spec uses ``id="toolu_<hex>"`` on every
 # ``tool_use`` block (and every matching ``tool_result.tool_use_id``).
@@ -233,6 +238,98 @@ def _resolve_reasoning_max_tokens(request: AnthropicRequest) -> int | None:
     return None
 
 
+def _sanitize_reasoning_channel(text: str | None) -> str | None:
+    """Run the reasoning-channel two-stage sanitizer on ``text``.
+
+    Stage 1 — :func:`strip_reasoning_channel_markup` strips the
+    ``<think>`` opener + closer (the canonical reasoning-channel
+    parser artifact that the catch-all :func:`sanitize_output`
+    intentionally leaves alone — see ``api.utils`` docstring).
+
+    Stage 2 — :func:`sanitize_output` strips the rest of the special-
+    token catch-all (``<|im_end|>``, harmony channel markers,
+    ``</tool_call>``, …).
+
+    Returns ``None`` when the result is empty / whitespace-only so the
+    caller can suppress the surrounding channel emission.
+    """
+    if not text:
+        return None
+    stripped = strip_reasoning_channel_markup(text)
+    sanitized = sanitize_output(stripped)
+    if not sanitized or not sanitized.strip():
+        return None
+    return sanitized
+
+
+def _thinking_block_content(
+    reasoning_text: str | None,
+    text: str | None,
+) -> str | None:
+    """Compute the body of the Anthropic ``thinking`` content block.
+
+    Two systematic invariants on top of the raw ``reasoning_text``:
+
+    1. **Sanitization (R12-M1b fix #1)** — strips the ``<think>`` /
+       ``</think>`` tags that the reasoning parser may have left in
+       the trace, then runs the canonical :func:`sanitize_output` for
+       the rest of the special-token catch-all. Mira r12 R-3 bonus
+       regression: at ``max_tokens=1`` on a thinking model, the prompt
+       template's pre-injected ``<think>`` is the only token seen by
+       the parser and it ended up as the literal ``thinking`` block
+       content; routing through the channel-aware sanitizer closes
+       that without disturbing the ``content`` channel (where the
+       opener can be legit Nemotron prefix injection or literal-tag
+       prose).
+
+    2. **Rescue-tail dedupe (R12-M1b fix #2)** — when ``content``
+       carries the R12-8 / H-01 rescue payload
+       (``sentinel + "\\n\\n" + tail-of-reasoning``), the LAST
+       ``RESCUE_TAIL_LENGTH`` chars of the reasoning trace have already
+       been published to the user via the ``text`` block. Re-emitting
+       the same slice as the suffix of the ``thinking`` block makes
+       the same partial sentence render twice (Mira r12 R-3 dupe arm).
+       Trim that suffix off the ``thinking`` body so each byte of the
+       reasoning trace surfaces on EXACTLY one Anthropic content block.
+
+       The full original ``reasoning_content`` is unchanged on the
+       OpenAI-side ``AssistantMessage`` field (the Anthropic envelope
+       does not surface it, but the OpenAI-side response — which the
+       adapter is being called on — keeps the full trace for
+       cross-route observability). PR #802's intentional design
+       (rescue surfaces to Anthropic) is preserved: the sentinel +
+       tail remain in the ``text`` block; only the duplication is
+       fixed.
+
+    Returns ``None`` when sanitization + trimming leave nothing —
+    callers MUST treat ``None`` as "do not emit a thinking block",
+    matching the existing whitespace-only guard.
+    """
+    if not reasoning_text:
+        return None
+    # Dedupe rescue tail FIRST so the trim works on the raw
+    # reasoning_text bytes (matching the same slice boundary the
+    # rescue helper used in ``_build_reasoning_rescue_payload``).
+    # ``_build_reasoning_rescue_payload`` does
+    # ``reasoning_text.rstrip()[-RESCUE_TAIL_LENGTH:]`` then sanitizes
+    # — so we trim the same suffix on the rstripped reasoning and
+    # sanitize the prefix that remains.
+    if is_rescue_payload(text):
+        stripped = reasoning_text.rstrip()
+        prefix = (
+            stripped[:-RESCUE_TAIL_LENGTH] if len(stripped) > RESCUE_TAIL_LENGTH else ""
+        )
+        if not prefix:
+            # Entire reasoning trace already surfaces in the rescue
+            # ``text`` block — suppress the ``thinking`` block so the
+            # tail is not duplicated. The text block alone carries the
+            # truncated reasoning excerpt; clients still see the full
+            # structural truncation signal via ``stop_reason="max_tokens"``.
+            return None
+        return _sanitize_reasoning_channel(prefix)
+    return _sanitize_reasoning_channel(reasoning_text)
+
+
 def openai_to_anthropic(
     response: ChatCompletionResponse,
     model: str,
@@ -303,11 +400,21 @@ def openai_to_anthropic(
         # Codex r1 NIT on PR #705.
         reasoning_text = choice.message.reasoning_content
         text = choice.message.content
+        # R12-M1b: route the thinking block content through the
+        # canonical sanitizer + rescue-tail dedupe helper. This:
+        #   * strips ``<think>`` / ``</think>`` / ``<|...|>`` leaks
+        #     that the reasoning parser may have left in the trace
+        #     (Mira r12 R-3 ``<think>`` literal at ``max_tokens=1``)
+        #   * trims the trailing slice that already surfaces in the
+        #     rescue ``text`` block, so the same partial sentence is
+        #     never rendered on BOTH content blocks (Mira r12 R-3
+        #     duped-rescue-tail arm)
+        # Returns ``None`` when sanitization + trimming leave nothing,
+        # which signals "do not emit a thinking block" (same shape as
+        # the previous whitespace-only guard).
+        thinking_body = _thinking_block_content(reasoning_text, text)
         emit_thinking = (
-            reasoning_enabled
-            and bool(reasoning_text)
-            and reasoning_text.strip() != ""
-            and reasoning_text != text
+            reasoning_enabled and thinking_body is not None and reasoning_text != text
         )
         # Add thinking block FIRST so it appears before the answer text,
         # matching Anthropic's extended-thinking SDK convention. Without
@@ -317,7 +424,7 @@ def openai_to_anthropic(
             content.append(
                 AnthropicResponseContentBlock(
                     type="thinking",
-                    thinking=reasoning_text,
+                    thinking=thinking_body,
                 )
             )
 

--- a/vllm_mlx/api/anthropic_adapter.py
+++ b/vllm_mlx/api/anthropic_adapter.py
@@ -484,12 +484,27 @@ def openai_to_anthropic(
                 )
             )
 
-        # Add text content
-        if text:
+        # Add text content. Emit the SAME ``sanitized_text`` used by
+        # the dedupe gate above — keeping a single normalised payload
+        # avoids the asymmetry codex r4 flagged: the prior
+        # implementation gated on ``sanitize_output(text)`` but emitted
+        # raw ``text``, so a non-route caller passing ``text="done</think>"``
+        # could still leak ``</think>`` into the Anthropic text block
+        # even after the gate correctly suppressed the duplicate
+        # thinking block. The in-route path's upstream
+        # ``sanitize_output(final_content)`` in ``routes/anthropic.py``
+        # remains in place; this is defense-in-depth at the adapter
+        # boundary so non-route callers (test helpers, future SSE
+        # finalize paths, hypothetical internal routes) also see
+        # sanitised bytes on the Anthropic wire. ``sanitized_text`` is
+        # ``None`` only when ``text`` itself collapsed to empty after
+        # sanitization (all-markup input); in that case the text block
+        # is suppressed.
+        if sanitized_text:
             content.append(
                 AnthropicResponseContentBlock(
                     type="text",
-                    text=text,
+                    text=sanitized_text,
                 )
             )
 

--- a/vllm_mlx/api/anthropic_adapter.py
+++ b/vllm_mlx/api/anthropic_adapter.py
@@ -265,6 +265,7 @@ def _sanitize_reasoning_channel(text: str | None) -> str | None:
 def _thinking_block_content(
     reasoning_text: str | None,
     text: str | None,
+    finish_reason: str | None = None,
 ) -> str | None:
     """Compute the body of the Anthropic ``thinking`` content block.
 
@@ -301,6 +302,17 @@ def _thinking_block_content(
        tail remain in the ``text`` block; only the duplication is
        fixed.
 
+       Gated on ``finish_reason == "length"`` (codex r4 P3 R12-M1b):
+       the R12-8 rescue helper only fires on length-cut truncation
+       (see ``_apply_reasoning_cutoff_notice``), so a content payload
+       that looks like a rescue payload on a non-length finish (e.g.
+       a model legitimately echoing the literal sentinel followed by
+       ``\\n\\n`` and more text) is NOT a rescue artifact and the
+       dedupe must not fire. Defaults to ``None`` for back-compat
+       with external callers that don't pass the field; in that case
+       only the shape gate applies (matching the pre-r4 behaviour
+       for any tests or third-party adapter callers).
+
     Returns ``None`` when sanitization + trimming leave nothing —
     callers MUST treat ``None`` as "do not emit a thinking block",
     matching the existing whitespace-only guard.
@@ -318,7 +330,17 @@ def _thinking_block_content(
     # first means the slice operates on the clean, in-channel byte
     # stream and can never bisect a tag because there are no tags
     # left to bisect.
-    if is_rescue_payload(text):
+    #
+    # Codex r4 P3 (R12-M1b): gate the dedupe on
+    # ``finish_reason == "length"`` AND the rescue-payload shape. The
+    # rescue helper only fires on length-cut truncation, so a content
+    # body that happens to look like a rescue payload on a clean
+    # ``stop`` finish (e.g. a model echoing the literal sentinel
+    # followed by ``\n\n`` and more text) is NOT a rescue artifact.
+    # The shape gate alone would still false-positive in that case
+    # and silently drop a legit thinking block.
+    is_length_cut = finish_reason == "length"
+    if is_length_cut and is_rescue_payload(text):
         stripped = strip_reasoning_channel_markup(reasoning_text.rstrip())
         prefix = (
             stripped[:-RESCUE_TAIL_LENGTH] if len(stripped) > RESCUE_TAIL_LENGTH else ""
@@ -421,7 +443,9 @@ def openai_to_anthropic(
         # Returns ``None`` when sanitization + trimming leave nothing,
         # which signals "do not emit a thinking block" (same shape as
         # the previous whitespace-only guard).
-        thinking_body = _thinking_block_content(reasoning_text, text)
+        thinking_body = _thinking_block_content(
+            reasoning_text, text, finish_reason=choice.finish_reason
+        )
         # Compare BOTH sides post-sanitize so visible-byte equality
         # decides the duplicate-block gate. Codex r1 P2 + r3 BLOCKING
         # on R12-M1b: the prior implementation compared the sanitized

--- a/vllm_mlx/api/anthropic_adapter.py
+++ b/vllm_mlx/api/anthropic_adapter.py
@@ -308,10 +308,15 @@ def _thinking_block_content(
        that looks like a rescue payload on a non-length finish (e.g.
        a model legitimately echoing the literal sentinel followed by
        ``\\n\\n`` and more text) is NOT a rescue artifact and the
-       dedupe must not fire. Defaults to ``None`` for back-compat
-       with external callers that don't pass the field; in that case
-       only the shape gate applies (matching the pre-r4 behaviour
-       for any tests or third-party adapter callers).
+       dedupe must not fire. ``finish_reason`` defaults to ``None``
+       for back-compat with external callers that don't pass the
+       field; in that case the dedupe is SKIPPED entirely (the full
+       sanitized reasoning trace is preserved in the thinking block).
+       This is the safe default: when the caller can't tell us
+       whether the truncation was a length-cut, we MUST NOT silently
+       drop a legitimate suffix of the reasoning trace. Direct
+       callers that intend to trigger the dedupe MUST pass
+       ``finish_reason="length"``.
 
     Returns ``None`` when sanitization + trimming leave nothing —
     callers MUST treat ``None`` as "do not emit a thinking block",

--- a/vllm_mlx/api/anthropic_adapter.py
+++ b/vllm_mlx/api/anthropic_adapter.py
@@ -307,15 +307,19 @@ def _thinking_block_content(
     """
     if not reasoning_text:
         return None
-    # Dedupe rescue tail FIRST so the trim works on the raw
-    # reasoning_text bytes (matching the same slice boundary the
-    # rescue helper used in ``_build_reasoning_rescue_payload``).
-    # ``_build_reasoning_rescue_payload`` does
-    # ``reasoning_text.rstrip()[-RESCUE_TAIL_LENGTH:]`` then sanitizes
-    # — so we trim the same suffix on the rstripped reasoning and
-    # sanitize the prefix that remains.
+    # Dedupe rescue tail: strip channel markup FIRST so the trim
+    # boundary aligns with the rescue builder's slice boundary (which
+    # ALSO strips first — see
+    # ``service.helpers._build_reasoning_rescue_payload``). Codex r3
+    # P2 (R12-M1b): if we slice the raw reasoning bytes, a
+    # ``<think>`` tag that straddles the slice boundary leaves an
+    # orphaned ``<th`` / ``ink>`` fragment in the thinking block (the
+    # regex stripper no longer matches the orphaned partial). Stripping
+    # first means the slice operates on the clean, in-channel byte
+    # stream and can never bisect a tag because there are no tags
+    # left to bisect.
     if is_rescue_payload(text):
-        stripped = reasoning_text.rstrip()
+        stripped = strip_reasoning_channel_markup(reasoning_text.rstrip())
         prefix = (
             stripped[:-RESCUE_TAIL_LENGTH] if len(stripped) > RESCUE_TAIL_LENGTH else ""
         )
@@ -326,7 +330,12 @@ def _thinking_block_content(
             # truncated reasoning excerpt; clients still see the full
             # structural truncation signal via ``stop_reason="max_tokens"``.
             return None
-        return _sanitize_reasoning_channel(prefix)
+        # Channel markup already stripped above; only the general
+        # special-token catch-all remains.
+        sanitized = sanitize_output(prefix)
+        if not sanitized or not sanitized.strip():
+            return None
+        return sanitized
     return _sanitize_reasoning_channel(reasoning_text)
 
 
@@ -413,22 +422,31 @@ def openai_to_anthropic(
         # which signals "do not emit a thinking block" (same shape as
         # the previous whitespace-only guard).
         thinking_body = _thinking_block_content(reasoning_text, text)
-        # Compare the POST-sanitize thinking payload against ``text`` —
-        # not the raw ``reasoning_text``. Codex r1 P2 on R12-M1b: when
-        # ``reasoning_text="<think>done</think>"`` and ``text="done"``,
-        # the channel-aware sanitizer normalizes the thinking payload
-        # to ``"done"`` (correctly stripping the reasoning-channel
-        # tags), but the raw byte comparison ``reasoning_text != text``
-        # is True — so both blocks would emit with the same visible
-        # bytes (``thinking="done"`` AND ``text="done"``), which is
-        # exactly the duplicate-block case this gate was supposed to
-        # prevent. Gating on ``thinking_body != text`` collapses the
-        # markup-only-delta case correctly while preserving the
-        # original intent on the raw-equality case (the rescue path,
-        # which the dedupe helper above already handles, returns a
-        # trimmed prefix so ``thinking_body != text`` holds there too).
+        # Compare BOTH sides post-sanitize so visible-byte equality
+        # decides the duplicate-block gate. Codex r1 P2 + r3 BLOCKING
+        # on R12-M1b: the prior implementation compared the sanitized
+        # ``thinking_body`` against the raw ``text``. That left a
+        # second markup-only-delta hole — when ``text`` itself carries
+        # removable markup that the canonical content-channel
+        # sanitizer collapses to the same visible bytes as
+        # ``thinking_body`` (e.g. ``text="done</think>"`` which the
+        # Anthropic route's ``sanitize_output`` pass on ``final_content``
+        # already strips to ``"done"`` upstream, OR a non-route caller
+        # of ``openai_to_anthropic`` that hasn't sanitized ``text``
+        # before passing it in), the raw comparison would report
+        # "different" and both blocks would render the same VISIBLE
+        # bytes to the client. Normalising ``text`` with the canonical
+        # content-channel ``sanitize_output`` here makes the gate
+        # robust regardless of how much upstream sanitization has
+        # already run. The rescue path is unaffected:
+        # ``_thinking_block_content`` already trims the rescue-tail
+        # suffix from ``thinking_body`` before this gate runs, so the
+        # comparison stays True there.
+        sanitized_text = sanitize_output(text) if text else text
         emit_thinking = (
-            reasoning_enabled and thinking_body is not None and thinking_body != text
+            reasoning_enabled
+            and thinking_body is not None
+            and thinking_body != sanitized_text
         )
         # Add thinking block FIRST so it appears before the answer text,
         # matching Anthropic's extended-thinking SDK convention. Without

--- a/vllm_mlx/api/anthropic_adapter.py
+++ b/vllm_mlx/api/anthropic_adapter.py
@@ -413,8 +413,22 @@ def openai_to_anthropic(
         # which signals "do not emit a thinking block" (same shape as
         # the previous whitespace-only guard).
         thinking_body = _thinking_block_content(reasoning_text, text)
+        # Compare the POST-sanitize thinking payload against ``text`` —
+        # not the raw ``reasoning_text``. Codex r1 P2 on R12-M1b: when
+        # ``reasoning_text="<think>done</think>"`` and ``text="done"``,
+        # the channel-aware sanitizer normalizes the thinking payload
+        # to ``"done"`` (correctly stripping the reasoning-channel
+        # tags), but the raw byte comparison ``reasoning_text != text``
+        # is True — so both blocks would emit with the same visible
+        # bytes (``thinking="done"`` AND ``text="done"``), which is
+        # exactly the duplicate-block case this gate was supposed to
+        # prevent. Gating on ``thinking_body != text`` collapses the
+        # markup-only-delta case correctly while preserving the
+        # original intent on the raw-equality case (the rescue path,
+        # which the dedupe helper above already handles, returns a
+        # trimmed prefix so ``thinking_body != text`` holds there too).
         emit_thinking = (
-            reasoning_enabled and thinking_body is not None and reasoning_text != text
+            reasoning_enabled and thinking_body is not None and thinking_body != text
         )
         # Add thinking block FIRST so it appears before the answer text,
         # matching Anthropic's extended-thinking SDK convention. Without

--- a/vllm_mlx/api/constants.py
+++ b/vllm_mlx/api/constants.py
@@ -20,6 +20,16 @@ environments depend on this.
 #: existing callers (route helpers + their tests) need not change.
 REASONING_CUTOFF_SENTINEL = "[truncated — reasoning incomplete; raise max_tokens]"
 
+#: R12-8 rescue tail length — how many trailing characters of
+#: ``reasoning_content`` get copied into ``content`` after the sentinel
+#: prefix when ``_build_reasoning_rescue_payload`` fires. Lives in
+#: ``api.constants`` so the Anthropic adapter (also lower-layer) can
+#: trim the matching suffix from the ``thinking`` content block without
+#: importing ``service.helpers`` (which would invert the layering rule).
+#: ``service.helpers`` re-exports this as the public symbol so existing
+#: callers (route helpers + tests) need not change.
+RESCUE_TAIL_LENGTH = 200
+
 
 def is_rescue_payload(content: str | None) -> bool:
     """Return True iff ``content`` is a rescue payload produced by

--- a/vllm_mlx/api/utils.py
+++ b/vllm_mlx/api/utils.py
@@ -95,12 +95,22 @@ _FINAL_SANITIZER = re.compile(
 #: Reasoning-channel sanitizer — strips ``<think>`` opener + closer
 #: BOTH. Distinct from ``_FINAL_SANITIZER`` (which leaves the opener
 #: alone so legit Nemotron prefix injection and literal-tag prose
-#: survive). This regex is applied ONLY to bytes destined for the
-#: reasoning channel (``reasoning_content`` field, Anthropic
-#: ``thinking`` content block, ``/v1/responses`` reasoning item) and to
-#: the rescue-tail copy of the reasoning trace that surfaces in
-#: ``content``. In those contexts the ``<think>`` opener is structural
-#: parser artifact, never legit user-visible text.
+#: survive). Current consumers (R12-M1b):
+#:
+#: * the Anthropic ``thinking`` content block (via
+#:   ``_thinking_block_content`` in ``api.anthropic_adapter``)
+#: * the rescue-tail copy of the reasoning trace that surfaces in
+#:   ``content`` (via ``_build_reasoning_rescue_payload`` in
+#:   ``service.helpers``)
+#:
+#: OpenAI ``message.reasoning_content`` and ``/v1/responses`` reasoning
+#: items intentionally DO NOT route through this regex in this PR; if
+#: the same ``<think>`` opener leakage is observed on those surfaces,
+#: wire the helper through ``strip_reasoning_channel_markup`` at the
+#: matching emit site rather than expanding the regex itself. In every
+#: reasoning-channel context the ``<think>`` opener is a structural
+#: parser artifact, never legit user-visible text — so the channel-
+#: aware strip is always safe where it is wired in.
 _REASONING_CHANNEL_TAG_RE = re.compile(r"</?think>")
 
 

--- a/vllm_mlx/api/utils.py
+++ b/vllm_mlx/api/utils.py
@@ -108,10 +108,19 @@ def strip_reasoning_channel_markup(text: str) -> str:
     """Strip ``<think>`` / ``</think>`` tags that the reasoning parser
     may have left in the reasoning channel.
 
-    Used by surfaces that emit reasoning content as a discrete field
-    (Anthropic ``thinking`` block, ``/v1/responses`` reasoning item,
-    OpenAI ``reasoning_content``) and by ``_build_reasoning_rescue_payload``
-    which surfaces a tail of the reasoning trace into ``content``.
+    Current call sites (R12-M1b):
+
+    * ``api.anthropic_adapter._thinking_block_content`` — sanitizes
+      bytes destined for the Anthropic ``thinking`` content block.
+    * ``service.helpers._build_reasoning_rescue_payload`` — sanitizes
+      the rescue tail that surfaces a slice of the reasoning trace
+      into the user-visible ``content`` channel.
+
+    The OpenAI ``reasoning_content`` field and the ``/v1/responses``
+    reasoning item DO NOT currently route through this helper — they
+    surface the raw parser output. Wire them through here too if a
+    future report shows the same ``<think>`` opener leakage on those
+    surfaces.
 
     Why this isn't in ``sanitize_output``: the canonical sanitizer is
     applied to ``content``-channel bytes too, where the bare ``<think>``

--- a/vllm_mlx/api/utils.py
+++ b/vllm_mlx/api/utils.py
@@ -54,6 +54,25 @@ def strip_special_tokens(text: str) -> str:
 # - All <|..|> symmetric tokens (Qwen, GPT-OSS style)
 # - [Calling tool:...] text-format tool calls
 # - Stray </think>, </tool_call>, etc.
+#
+# IMPORTANT — what is NOT stripped here:
+# The bare ``<think>`` OPENER is intentionally NOT in this regex. The
+# streaming postprocessor legitimately prepends ``<think>`` to the first
+# content chunk on Nemotron-family models, and the standard / chat path
+# routes that chunk through ``sanitize_output`` — stripping the opener
+# here would erase the prefix injection (broke
+# ``TestStreamingPostProcessorNemotron::test_thinking_prefix_injected``
+# during the R12-M1b first pass). Models that legitimately mention the
+# literal ``<think>`` tag in prose (e.g. "use the <think> tag in HTML")
+# must also pass through unchanged.
+#
+# Reasoning-channel leaks of the opener (Mira r12 R-3 bonus regression:
+# ``reasoning_text="<think>"`` at ``max_tokens=1`` because the prompt
+# template's pre-injected opener was the only token the parser saw) are
+# handled at the REASONING-channel layer instead — see
+# ``api.anthropic_adapter._thinking_block_content`` and
+# ``service.helpers._build_reasoning_rescue_payload``, both of which
+# call the dedicated ``strip_reasoning_channel_markup`` helper below.
 # =============================================================================
 
 _FINAL_SANITIZER = re.compile(
@@ -71,6 +90,47 @@ _FINAL_SANITIZER = re.compile(
     r"|</think>|</tool_call>",
     re.DOTALL,
 )
+
+
+#: Reasoning-channel sanitizer — strips ``<think>`` opener + closer
+#: BOTH. Distinct from ``_FINAL_SANITIZER`` (which leaves the opener
+#: alone so legit Nemotron prefix injection and literal-tag prose
+#: survive). This regex is applied ONLY to bytes destined for the
+#: reasoning channel (``reasoning_content`` field, Anthropic
+#: ``thinking`` content block, ``/v1/responses`` reasoning item) and to
+#: the rescue-tail copy of the reasoning trace that surfaces in
+#: ``content``. In those contexts the ``<think>`` opener is structural
+#: parser artifact, never legit user-visible text.
+_REASONING_CHANNEL_TAG_RE = re.compile(r"</?think>")
+
+
+def strip_reasoning_channel_markup(text: str) -> str:
+    """Strip ``<think>`` / ``</think>`` tags that the reasoning parser
+    may have left in the reasoning channel.
+
+    Used by surfaces that emit reasoning content as a discrete field
+    (Anthropic ``thinking`` block, ``/v1/responses`` reasoning item,
+    OpenAI ``reasoning_content``) and by ``_build_reasoning_rescue_payload``
+    which surfaces a tail of the reasoning trace into ``content``.
+
+    Why this isn't in ``sanitize_output``: the canonical sanitizer is
+    applied to ``content``-channel bytes too, where the bare ``<think>``
+    opener is sometimes legitimate (Nemotron prefix injection, literal-
+    tag prose). Splitting the strip rule by channel keeps both
+    invariants intact:
+
+    * ``content`` channel — opener passes through, closer is stripped
+      (existing pre-R12-M1b behaviour, no regression risk).
+    * ``reasoning_content`` / ``thinking`` channel — both opener and
+      closer are stripped, because the channel itself MEANS "this is
+      the model's thought trace" so wrapping tags are redundant /
+      structural noise.
+
+    Empty / None input returns the input unchanged.
+    """
+    if not text:
+        return text
+    return _REASONING_CHANNEL_TAG_RE.sub("", text)
 
 
 def sanitize_output(text: str) -> str:

--- a/vllm_mlx/service/helpers.py
+++ b/vllm_mlx/service/helpers.py
@@ -1246,13 +1246,22 @@ def _apply_reasoning_cutoff_notice(
 
     Otherwise returns the rescue payload produced by
     :func:`_build_reasoning_rescue_payload` — the canonical shape is
-    ``sentinel + "\\n\\n" + sanitized_tail``, where ``sanitized_tail``
-    is ``reasoning_text.rstrip()[-RESCUE_TAIL_LENGTH:]`` run through
-    :func:`strip_reasoning_channel_markup` (channel-aware ``<think>`` /
-    ``</think>`` strip) and :func:`sanitize_output` (general special-
-    token catch-all). When that sanitization collapses the tail to
-    empty (e.g. ``reasoning_text="<think>"`` at ``max_tokens=1``), the
-    rescue builder returns the bare sentinel — clients still see the
+    ``sentinel + "\\n\\n" + sanitized_tail``. The builder applies
+    operations in this order (codex r3 P2 strip-before-slice):
+
+    1. :func:`strip_reasoning_channel_markup` on
+       ``reasoning_text.rstrip()`` — strips ``<think>`` / ``</think>``
+       on the FULL trace so the next slice operates on a clean,
+       in-channel byte stream. Doing it before the slice means a tag
+       straddling the ``L - RESCUE_TAIL_LENGTH`` boundary can never
+       leave an orphan ``<th`` / ``ink>`` fragment in the tail.
+    2. ``[-RESCUE_TAIL_LENGTH:]`` slice on the stripped trace.
+    3. :func:`sanitize_output` on the slice — general special-token
+       catch-all (``<|...|>``, harmony markers, ``</tool_call>``, …).
+
+    When sanitization collapses the tail to empty (e.g.
+    ``reasoning_text="<think>"`` at ``max_tokens=1``), the rescue
+    builder returns the bare sentinel — clients still see the
     structural truncation signal without a stray markup byte in
     ``content``. The caller writes the returned string into
     ``message.content`` (non-stream) or the final SSE ``delta.content``

--- a/vllm_mlx/service/helpers.py
+++ b/vllm_mlx/service/helpers.py
@@ -1167,24 +1167,35 @@ def _build_reasoning_rescue_payload(reasoning_text: str) -> str:
     whitespace (see ``_apply_reasoning_cutoff_notice``), so an empty
     tail is impossible by construction.
 
-    The tail is run through :func:`strip_reasoning_channel_markup`
-    (strips ``<think>`` opener + closer — both, because the rescue
-    tail is sourced from the reasoning channel) and then through
+    The reasoning trace is stripped of channel markup BEFORE the
+    tail slice is chosen, then the slice runs through
     :func:`sanitize_output` (general special-token catch-all:
-    ``<|...|>``, harmony channel markers, ``</tool_call>``, etc.)
-    BEFORE injection. ``reasoning_content`` keeps the full original
-    trace addressable for clients that walk both fields. Codex r1
-    (R12-8): the rescue path previously bypassed the sanitizer that
-    ``content`` consumers rely on. R12-M1b (Mira r12 R-3 bonus
-    regression): also strip the ``<think>`` OPENER from the rescue
-    tail — at ``max_tokens=1`` the reasoning trace IS the literal
-    opener, and ``sanitize_output`` deliberately leaves the opener
-    alone on the ``content`` channel (where it can be legit Nemotron
-    prefix injection or literal-tag prose). The rescue tail is from
-    the reasoning channel, so the channel-aware strip applies.
+    ``<|...|>``, harmony channel markers, ``</tool_call>``, etc.).
+    The strip-before-slice order matters: a naive slice of the raw
+    reasoning bytes can bisect a structural ``<think>`` /
+    ``</think>`` tag (codex r3 P2: when reasoning is just slightly
+    longer than ``RESCUE_TAIL_LENGTH`` and starts with ``<think>``,
+    the raw slice begins ``hink>...`` and the regex stripper no
+    longer matches the orphaned fragment — so the literal ``ink>``
+    bytes leak into ``content``). Stripping channel markup first
+    means the slice operates on the clean, in-channel byte stream
+    and can never bisect a tag because there are no tags left to
+    bisect.
+    ``reasoning_content`` keeps the full original trace addressable
+    for clients that walk both fields. Codex r1 (R12-8): the rescue
+    path previously bypassed the sanitizer that ``content``
+    consumers rely on. R12-M1b (Mira r12 R-3 bonus regression):
+    also strip the ``<think>`` OPENER — at ``max_tokens=1`` the
+    reasoning trace IS the literal opener, and ``sanitize_output``
+    deliberately leaves the opener alone on the ``content`` channel
+    (where it can be legit Nemotron prefix injection or literal-tag
+    prose). The rescue tail is from the reasoning channel, so the
+    channel-aware strip applies.
     """
-    tail = reasoning_text.rstrip()[-RESCUE_TAIL_LENGTH:]
-    tail = strip_reasoning_channel_markup(tail)
+    # Strip BEFORE slicing — see docstring for the bisection
+    # regression this order closes.
+    stripped = strip_reasoning_channel_markup(reasoning_text.rstrip())
+    tail = stripped[-RESCUE_TAIL_LENGTH:]
     sanitized = sanitize_output(tail)
     if not sanitized:
         return REASONING_CUTOFF_SENTINEL

--- a/vllm_mlx/service/helpers.py
+++ b/vllm_mlx/service/helpers.py
@@ -1233,9 +1233,19 @@ def _apply_reasoning_cutoff_notice(
       model produced nothing semantically, which is a different bug
       class and shouldn't get a "raise max_tokens" hint)
 
-    Otherwise returns ``sentinel + "\\n\\n" + reasoning_text[-RESCUE_TAIL_LENGTH:]``.
-    The caller writes it into ``message.content`` (non-stream) or the
-    final SSE ``delta.content`` chunk (stream).
+    Otherwise returns the rescue payload produced by
+    :func:`_build_reasoning_rescue_payload` — the canonical shape is
+    ``sentinel + "\\n\\n" + sanitized_tail``, where ``sanitized_tail``
+    is ``reasoning_text.rstrip()[-RESCUE_TAIL_LENGTH:]`` run through
+    :func:`strip_reasoning_channel_markup` (channel-aware ``<think>`` /
+    ``</think>`` strip) and :func:`sanitize_output` (general special-
+    token catch-all). When that sanitization collapses the tail to
+    empty (e.g. ``reasoning_text="<think>"`` at ``max_tokens=1``), the
+    rescue builder returns the bare sentinel — clients still see the
+    structural truncation signal without a stray markup byte in
+    ``content``. The caller writes the returned string into
+    ``message.content`` (non-stream) or the final SSE ``delta.content``
+    chunk (stream).
     """
     if not _cutoff_notice_enabled():
         return final_content

--- a/vllm_mlx/service/helpers.py
+++ b/vllm_mlx/service/helpers.py
@@ -21,16 +21,20 @@ from collections.abc import AsyncIterator
 from fastapi import HTTPException
 from starlette.requests import Request
 
-# Re-export of the wire-level sentinel literal. Single source of truth
-# lives in :mod:`vllm_mlx.api.constants` to preserve the layering rule
-# (api is the lower layer that service depends on, not the reverse) so
-# the Responses adapter can exclude this sentinel from its
-# ``downstream_output_seen`` check (issue #858 → PR #860 follow-up)
-# without dragging the engine into the adapter's import graph. The name
-# is re-exported through this module so existing callers that import
-# ``REASONING_CUTOFF_SENTINEL`` from ``vllm_mlx.service.helpers``
-# (route helpers + their tests) continue to work unchanged.
-from ..api.constants import REASONING_CUTOFF_SENTINEL  # noqa: F401
+# Re-export of the wire-level sentinel literal + rescue-tail length.
+# Single source of truth lives in :mod:`vllm_mlx.api.constants` to
+# preserve the layering rule (api is the lower layer that service
+# depends on, not the reverse) so the Responses adapter and the
+# Anthropic adapter can both consume them without dragging the engine
+# into the adapter's import graph. The names are re-exported through
+# this module so existing callers that import
+# ``REASONING_CUTOFF_SENTINEL`` / ``RESCUE_TAIL_LENGTH`` from
+# ``vllm_mlx.service.helpers`` (route helpers + their tests) continue
+# to work unchanged.
+from ..api.constants import (  # noqa: F401
+    REASONING_CUTOFF_SENTINEL,
+    RESCUE_TAIL_LENGTH,
+)
 from ..api.models import (
     CompletionTokensDetails,
     FunctionCall,
@@ -41,7 +45,7 @@ from ..api.models import (
     Usage,
 )
 from ..api.tool_calling import parse_tool_calls
-from ..api.utils import sanitize_output
+from ..api.utils import sanitize_output, strip_reasoning_channel_markup
 from ..config import get_config
 from ..engine import BaseEngine, GenerationOutput
 from ..tool_parsers import ToolParserManager
@@ -1066,17 +1070,13 @@ def _rescue_silent_drop_from_reasoning(
 # no token-by-token leak of the sentinel string itself.)
 
 
-#: How many trailing characters of ``reasoning_content`` to copy into
-#: the rescue ``content`` after the sentinel prefix. Chosen empirically:
-#: ~200 chars is roughly the last 2-3 sentences of typical qwen3 /
-#: deepseek_r1 chain-of-thought, which is the granularity a human user
-#: needs to recognise what the model was working on without dumping the
-#: whole trace into ``content`` (which would re-introduce the
-#: D-STOP-THINK / D-HARMONY-LEAK byte-identical leak shape). The tail
-#: is added AFTER the sentinel so the literal cue still anchors the
-#: opening of the rescue string — agentic auto-retry clients can match
-#: on the sentinel prefix regardless of the tail content.
-RESCUE_TAIL_LENGTH = 200
+#: ``RESCUE_TAIL_LENGTH`` is re-exported above from
+#: :mod:`vllm_mlx.api.constants` — kept at module scope so existing
+#: callers (route helpers + tests) continue to import it from
+#: ``vllm_mlx.service.helpers``. The Anthropic adapter consumes the
+#: SAME constant from the lower-layer ``api.constants`` to compute the
+#: matching suffix it must trim from the ``thinking`` content block
+#: (R12-M1b dedupe fix).
 
 #: Env var values that EXPLICITLY DISABLE the rescue notice. The
 #: primary knob is ``RAPID_MLX_REASONING_RESCUE`` (R12-8 / issue #259);
@@ -1167,17 +1167,24 @@ def _build_reasoning_rescue_payload(reasoning_text: str) -> str:
     whitespace (see ``_apply_reasoning_cutoff_notice``), so an empty
     tail is impossible by construction.
 
-    The tail is run through :func:`sanitize_output` BEFORE injection
-    so any leaked special-token markers (``</think>``, ``<|...|>``,
-    harmony channel markers, ``</tool_call>``, etc.) that a reasoning
-    parser may have left in the trace are stripped on the way to
-    user-visible ``content``. ``reasoning_content`` keeps the full
-    original trace addressable for clients that walk both fields.
-    Codex r1 (R12-8): the rescue path previously bypassed the
-    sanitizer that ``content`` consumers rely on; reasoning markers
-    must not surface in the user-rendered field.
+    The tail is run through :func:`strip_reasoning_channel_markup`
+    (strips ``<think>`` opener + closer — both, because the rescue
+    tail is sourced from the reasoning channel) and then through
+    :func:`sanitize_output` (general special-token catch-all:
+    ``<|...|>``, harmony channel markers, ``</tool_call>``, etc.)
+    BEFORE injection. ``reasoning_content`` keeps the full original
+    trace addressable for clients that walk both fields. Codex r1
+    (R12-8): the rescue path previously bypassed the sanitizer that
+    ``content`` consumers rely on. R12-M1b (Mira r12 R-3 bonus
+    regression): also strip the ``<think>`` OPENER from the rescue
+    tail — at ``max_tokens=1`` the reasoning trace IS the literal
+    opener, and ``sanitize_output`` deliberately leaves the opener
+    alone on the ``content`` channel (where it can be legit Nemotron
+    prefix injection or literal-tag prose). The rescue tail is from
+    the reasoning channel, so the channel-aware strip applies.
     """
     tail = reasoning_text.rstrip()[-RESCUE_TAIL_LENGTH:]
+    tail = strip_reasoning_channel_markup(tail)
     sanitized = sanitize_output(tail)
     if not sanitized:
         return REASONING_CUTOFF_SENTINEL


### PR DESCRIPTION
## Summary

R12-M1b — fixes two BUG sub-issues of Mira's r12 dogfood SEVERE finding on `/v1/messages`. The third "rescue surfaces to Anthropic at all" sub-issue is **out of scope** — it is operator-approved design per PR #802 / issue #858 and is **preserved** by this PR.

Mira r12 dogfood report: `/tmp/dogfood-0815/mira-r12.md` (R-3 section).

### Bug #1 — `<think>` literal leak at `max_tokens=1`

**Repro:**
```bash
curl -X POST :8091/v1/messages \
  -d '{"model":"mlx-community/Qwen3-0.6B-bf16","max_tokens":1,
       "thinking":{"type":"enabled"},
       "messages":[{"role":"user","content":"solve 12 * 7"}]}'
# content[0].thinking begins with the literal "<think>"
# content[1].text begins with sentinel + "\n\n<think>"
```

**Root cause:** the canonical `sanitize_output` deliberately leaves the bare `<think>` opener alone — stripping it would erase Nemotron prefix injection in the standard streaming path (`TestStreamingPostProcessorNemotron::test_thinking_prefix_injected`) and silently swallow legit literal-tag prose like `"use the <think> tag in HTML"` (covered by `test_streaming_reasoning_split_r8c.py`).

**Fix:** introduce `api.utils.strip_reasoning_channel_markup` — a dedicated channel-aware strip that handles both `<think>` and `</think>`. The Anthropic adapter and the rescue-payload builder both apply it on bytes destined for the reasoning channel (thinking block + rescue tail) BEFORE `sanitize_output`. The split-by-channel design keeps the canonical sanitizer's `content`-channel contract intact (no Nemotron / literal-tag regressions).

### Bug #2 — rescue tail duplicated across content blocks

**Repro:**
```bash
curl -X POST :8091/v1/messages \
  -d '{"model":"mlx-community/Qwen3-0.6B-bf16","max_tokens":40,
       "thinking":{"type":"enabled"},
       "messages":[{"role":"user","content":"solve 12 * 7"}]}'
# Same partial sentence appears in BOTH content[0].thinking AND
# content[1].text (the rescue-tail copy).
```

**Root cause:** `openai_to_anthropic` emitted the raw `reasoning_text` into the thinking block without knowing the trailing `RESCUE_TAIL_LENGTH` chars had already been published via the rescue `text` block.

**Fix:** when the `text` block carries a rescue payload (gated via the canonical `is_rescue_payload` shape check in `api.constants`), trim the matching `reasoning_text.rstrip()[-RESCUE_TAIL_LENGTH:]` suffix off the thinking block content. The trim uses the SAME `RESCUE_TAIL_LENGTH` constant the rescue builder uses (moved to `api.constants` so both layers consume it without an inverted layering dependency). Each reasoning byte now surfaces on EXACTLY one content block.

### PR #802 / issue #858 design preserved

Mira's r12 spec said the rescue should NOT touch the Anthropic surface; the operator-approved design (PR #802 / #875) is that it DOES — GUI clients that only render text blocks need the literal cue when `max_tokens` was too low. **This PR preserves that design.** The rescue `text` block still carries `sentinel + tail`; only the duplication and the special-token leak are fixed. A positive test `TestRescueSurfacesToAnthropic` pins the design so a future contributor reading the dedupe fix doesn't interpret it as "remove rescue from Anthropic" and silently regress.

## Test plan

- [x] `strip_reasoning_channel_markup` strips both `<think>` and `</think>` (parametrized over opener / closer / both / mid-string / whitespace variations)
- [x] `sanitize_output` does NOT strip the bare opener (pins the `content`-channel contract — Nemotron + literal-prose tests stay green)
- [x] At `max_tokens=1`: `<think>` literal absent from ALL content blocks; thinking block suppressed when entire reasoning is markup
- [x] At `max_tokens=40`: rescue tail in EXACTLY one block (text); thinking block carries the prefix; thinking suppressed when reasoning entirely fits in the rescue tail; happy-path non-rescue text does not trigger the dedupe
- [x] Design pin: rescue text block carries the sentinel when length-cut mid-think; opt-out via `RAPID_MLX_REASONING_RESCUE=off` behaves correctly
- [x] 26 new tests in `tests/test_anthropic_think_leak_r12_m1b.py` — all green
- [x] 209-test `test_reasoning_content_null_rescue.py` suite — green
- [x] 78-test `test_anthropic_*` + `test_truncation_*` + `test_silent_drop_rescue_569.py` suite — green
- [x] Full 9608-test regression sweep (134s wall-clock) — green
- [x] ruff check + ruff format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)