### PR TITLE
chore: bump version to 0.8.16

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.8.15"
+version = "0.8.16"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## Summary

Release 0.8.16 — R12 fix wave on top of 0.8.15 dogfood findings.

### Merged since 0.8.15

| PR | SHA | Fix |
|---|---|---|
| #877 | `3fc52e5` | **M-2** (HIGH): plumb `chat_template_kwargs` + `enable_thinking` through `ResponsesRequest`; auto-disable thinking on strict json_schema. |
| #878 | `e5b029b` | **V-1+S-2** (MED): `/v1/models` surfaces effective `tool_call_parser` / `reasoning_parser` per-entry from live state. |
| #880 | `15567ea` | **T-1** (SEVERE): atomic SIGTERM prefix-cache save — post-write self-verify drops drifted entries before rename so snapshot is self-consistent by construction. |
| #881 | `f2d68ce` | **V-2** (MED): centralized reasoning_content sanitizer via Pydantic `@field_validator` — eliminates per-call-site leaks of `<|im_start|>` / `</think>` etc. |
| #882 | `8885dc1` | **M-1b** (SEVERE): `/v1/messages` `<think>` leak at `max_tokens=1` + reasoning-tail duplication; channel-aware sanitizer + `is_rescue_payload AND finish_reason=length` dedupe gate. PR #802 design preserved via positive regression test. |

### Triggers

This subject (`chore: bump version to X.Y.Z`) matches the `auto-release.yml` regex; merging will publish 0.8.16 to PyPI.

## Test plan

- [x] All 5 R12 fix PRs CI-green and codex-converged
- [x] T-1 systematic fix verified with 9 new tests (2-cycle + 5-cycle stress)
- [x] M-1b PR #802 design preserved via `TestRescueSurfacesToAnthropic` positive test
- [x] V-2 centralized sanitization at Pydantic validator layer (single source of truth)