### PR TITLE
fix(responses): honor RAPID_MLX_STRICT_JSON_SCHEMA=off on non-guided path (H-06 #267a)

### DIFF
--- a/tests/test_response_format_json_schema_strict.py
+++ b/tests/test_response_format_json_schema_strict.py
@@ -1886,6 +1886,74 @@ def test_responses_strict_true_with_tools_returns_400(_rate_limiter_state):
     assert engine.chat_calls == []
 
 
+def test_responses_strict_true_guided_unavailable_disable_flag_skips_enforcement(
+    monkeypatch, _rate_limiter_state
+):
+    """R12-T1F-267-a (PR #878 codex review follow-up): the
+    ``RAPID_MLX_STRICT_JSON_SCHEMA=off`` escape hatch must restore
+    legacy pass-through behavior on /v1/responses too — not just on
+    /v1/chat/completions. Pre-fix the route correctly skipped the
+    non-guided post-generate validation block, then immediately
+    tripped the UNGATED post-decode validator below it and
+    returned 502 regardless. Schema-violating output with the
+    disable flag set must come back as 200 + zero violation /
+    repair counters (parity with
+    ``test_strict_true_guided_unavailable_disable_flag_skips_enforcement``
+    on the chat route).
+    """
+    monkeypatch.setenv("RAPID_MLX_STRICT_JSON_SCHEMA", "off")
+    engine = _Engine(
+        supports_guided=False,
+        chat_text=_INVALID_PAYLOAD_OUT_OF_RANGE,
+    )
+    client = _make_responses_client(engine, _rate_limiter_state)
+    resp = client.post("/v1/responses", json=_responses_payload(strict=True))
+    assert resp.status_code == 200, resp.text
+    # Counter still ticks (operator observability) but no violation or
+    # repair attempt — the disable flag short-circuits enforcement.
+    snap = response_format_metrics.snapshot()
+    assert snap["strict_requests_total"] == 1
+    assert snap["strict_violations_total"] == 0
+    assert snap["strict_repairs_attempted_total"] == 0
+    # The unconstrained chat path was used (no guided dispatch).
+    assert len(engine.chat_calls) == 1
+    assert engine.guided_calls == []
+
+
+def test_responses_strict_true_guided_unavailable_default_on_invalid_returns_422(
+    _rate_limiter_state,
+):
+    """R12-T1F-267-a — positive regression for the default
+    enforcement path. With ``RAPID_MLX_STRICT_JSON_SCHEMA`` unset
+    (default = on) and the engine reporting
+    ``supports_guided_generation=False``, invalid output MUST
+    surface as 422 ``json_schema_violation`` (NOT 502
+    ``strict_schema_violation``) — the same canonical envelope
+    chat.py emits via its R12-4 post-generate validation block.
+    The fix in this PR (gating the unconditional post-decode
+    validator to the guided path) must not regress this case: the
+    422 here comes from the non-guided ``use_strict_postgen_validation``
+    branch at the TOP of the function, NOT from the post-decode
+    502 gate below.
+    """
+    engine = _Engine(
+        supports_guided=False,
+        chat_text=_INVALID_PAYLOAD_OUT_OF_RANGE,
+    )
+    client = _make_responses_client(engine, _rate_limiter_state)
+    resp = client.post("/v1/responses", json=_responses_payload(strict=True))
+    # Canonical non-guided enforcement envelope: 422 (parity with chat).
+    assert resp.status_code == 422, resp.text
+    body = resp.json()
+    assert body["error"]["code"] == "json_schema_violation"
+    assert body["error"]["type"] == "validation_error"
+    snap = response_format_metrics.snapshot()
+    assert snap["strict_requests_total"] == 1
+    assert snap["strict_violations_total"] == 1
+    # Repair was attempted (single retry) — parity with chat.
+    assert snap["strict_repairs_attempted_total"] == 1
+
+
 def test_strict_helper_composition_extract_returns_none_for_empty_schema():
     """Unit-level pin on the ``strict_mode AND no schema`` shape.
 

--- a/vllm_mlx/routes/responses.py
+++ b/vllm_mlx/routes/responses.py
@@ -1146,7 +1146,26 @@ async def _non_stream(
     # OpenAI's ``strict=true`` semantics. Counter ticks for ops
     # visibility, then 502 so the client sees the contract breach
     # instead of silently consuming garbage.
-    if _strict_schema and output is not None:
+    #
+    # R12-T1F-267-a (PR #878 codex follow-up): this gate must mirror
+    # chat.py's ``if strict_mode and use_guided and json_schema and
+    # output is not None:`` — i.e. it ONLY fires on the
+    # CONSTRAINED-DECODING (guided) path. When the engine does NOT
+    # support guided generation, the unconstrained path has its own
+    # post-decode validator + repair retry block ABOVE (gated by
+    # ``strict_enforcement_enabled()`` at line ~937), and the
+    # ``RAPID_MLX_STRICT_JSON_SCHEMA=off`` escape hatch correctly
+    # short-circuits that block. Without the ``supports_guided_generation``
+    # gate here, the disable flag was effectively ignored — the
+    # non-guided branch logged "falling through to prompt-injection
+    # only" and then the unconditional 502 at this site fired
+    # regardless, breaking parity with /v1/chat/completions. Match
+    # chat's gate exactly: only the guided path runs this validator.
+    if (
+        _strict_schema
+        and engine.supports_guided_generation
+        and output is not None
+    ):
         ok, err = validate_output_against_schema(output.text or "", _strict_schema)
         if not ok:
             incr_strict_violation()

--- a/vllm_mlx/routes/responses.py
+++ b/vllm_mlx/routes/responses.py
@@ -1161,11 +1161,7 @@ async def _non_stream(
     # only" and then the unconditional 502 at this site fired
     # regardless, breaking parity with /v1/chat/completions. Match
     # chat's gate exactly: only the guided path runs this validator.
-    if (
-        _strict_schema
-        and engine.supports_guided_generation
-        and output is not None
-    ):
+    if _strict_schema and engine.supports_guided_generation and output is not None:
         ok, err = validate_output_against_schema(output.text or "", _strict_schema)
         if not ok:
             incr_strict_violation()


### PR DESCRIPTION
## Repro

```
RAPID_MLX_STRICT_JSON_SCHEMA=off
engine.supports_guided_generation = False
POST /v1/responses {text.format: {type: json_schema, strict: true, schema: {...}}}
model emits schema-invalid JSON  →  502 strict_schema_violation  (expected: 200)
```

Parity check: same request shape on `/v1/chat/completions` correctly returns 200 because the chat route's post-decode validator is gated on `use_guided`. The Responses route gate had drifted.

```
Strict json_schema on /v1/responses requested without [guided] AND
RAPID_MLX_STRICT_JSON_SCHEMA=off — falling through to prompt-injection only.
Strict json_schema response failed post-decode validation on /v1/responses:
  schema violation: 200 is greater than the maximum of 100
STATUS: 502
```

## Root cause (gate parity gap with chat)

`vllm_mlx/routes/responses.py:1149`

```python
if _strict_schema and output is not None:   # ← UNGATED
    ok, err = validate_output_against_schema(output.text or "", _strict_schema)
    if not ok:
        raise HTTPException(status_code=502, ...)   # strict_schema_violation
```

The earlier non-guided block at `responses.py:934` already gates correctly on `strict_enforcement_enabled()`, so with the disable flag set it falls through emitting only the warning log. Then this post-decode block fires unconditionally and 502s.

Chat parity reference (`vllm_mlx/routes/chat.py:2760`):

```python
if strict_mode and use_guided and json_schema and output is not None:
    # ← gated on use_guided = engine.supports_guided_generation
```

The chat 502 contract is a HARD invariant of the **constrained-decoding (guided) path only** — it means "the guided grammar engine emitted output that failed to validate." On the non-guided path, the contract is "validate → 1 repair retry → 422", owned by the `use_strict_postgen_validation` block above, which honors the disable flag.

## Systematic fix

Mirror the chat gate exactly — add `engine.supports_guided_generation`:

```python
if (
    _strict_schema
    and engine.supports_guided_generation
    and output is not None
):
    ok, err = validate_output_against_schema(output.text or "", _strict_schema)
    ...
```

No new gating semantics invented; the helper centralization wasn't necessary here because both routes already converge on `engine.supports_guided_generation` as the single source of truth.

## Test plan

- [x] Add `test_responses_strict_true_guided_unavailable_disable_flag_skips_enforcement` — RAPID_MLX_STRICT_JSON_SCHEMA=off, supports_guided=False, invalid output → 200 + no violation/repair counters
- [x] Add `test_responses_strict_true_guided_unavailable_default_on_invalid_returns_422` — default (on), supports_guided=False, invalid output → 422 `json_schema_violation` (canonical non-guided envelope, parity with chat)
- [x] Full `tests/test_response_format_json_schema_strict.py` suite — 67 passed
- [x] Full strict-related suites (`test_response_format_strict_types`, `test_r12_4_strict_json_schema_*`, `test_completions_response_format_json_schema`, `test_content_block_strict_types`) — 210 passed
- [x] All `response`-keyed tests — 627 passed, 7 skipped

## Refs

- Codex review on PR #878 (H-06 follow-up): "RAPID_MLX_STRICT_JSON_SCHEMA=off does not actually restore legacy pass-through behavior on /v1/responses"
- PR #873 (H-06 original): `f1e71f9 fix(json-schema): enforce strict mode via post-generate validation + repair retry`

🤖 Generated with [Claude Code](https://claude.com/claude-code)