### PR TITLE
fix(pr_validate): pin canonical test extras in venv build (closes #185)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,24 +123,59 @@ all = [
     "mlx-embeddings>=0.1.0",
     # dflash (text-only path covered by mlx-vlm above; listed for clarity)
 ]
+# Test runtime — the *minimum* deps `pytest tests/` needs to import the
+# suite and collect every test without a plugin-missing error. Kept
+# narrow on purpose so:
+#   1. `pr_validate` (scripts/pr_validate/_test_env.py) can install JUST
+#      this when its env check finds plugins missing, without dragging
+#      in the linter/typer toolchain.
+#   2. Contributors who only want to run tests don't have to install the
+#      full dev toolbox.
+# The canonical source of truth: if pytest needs it to collect/run a
+# test, it goes here, not in `dev`.
+# Closes #185 — pr_validate's targeted_tests + full_unit gates have
+# been crashing across multiple fix waves because pytest-asyncio
+# (required by `asyncio_mode = auto` in pytest.ini) keeps falling out
+# of the host Python after `pip install --no-deps --force-reinstall .`
+# in orchestrated runs. The systematic fix is to publish the test deps
+# as their own extras so pr_validate can re-install them from the
+# canonical source, instead of every script hand-maintaining a list.
+test = [
+    "pytest>=7.0.0",
+    # pytest-asyncio is REQUIRED — pytest.ini sets `asyncio_mode = auto`,
+    # which means every `async def test_*` is collected as an asyncio
+    # test. Without the plugin, those tests fail at collection with
+    # "async def functions are not natively supported".
+    "pytest-asyncio>=0.21.0",
+    # Parse the /metrics output through the official Prometheus parser
+    # to catch format regressions. NOT used at runtime — the route
+    # hand-rolls the exposition format to avoid a runtime dep.
+    "prometheus_client>=0.16.0",
+    # Parse pyproject.toml in the L-07 vision-extra lock-in tests
+    # (tests/test_vision_extra_install.py). ``tomllib`` is stdlib on
+    # Python ≥3.11; the environment marker pins ``tomli`` only on
+    # Python 3.10 so the L-07 suite always runs against the documented
+    # supported floor (codex round-2 BLOCKING — without this, CI on 3.10
+    # would module-skip the entire lock-in suite and let a future
+    # refactor silently drop the ``[vision]`` extra).
+    'tomli>=2.0.1; python_version < "3.11"',
+]
 dev = [
+    # Test runtime (must mirror the `test` extras above; a unit test in
+    # tests/test_pr_validate_test_env.py asserts every `test` dep is
+    # also in `dev` so a future drift can't silently break the
+    # "install dev, run pytest" workflow contributors have used since
+    # day one).
     "pytest>=7.0.0",
     "pytest-asyncio>=0.21.0",
+    "prometheus_client>=0.16.0",
+    'tomli>=2.0.1; python_version < "3.11"',
+    # Linters / typer — NOT in the `test` extras because pr_validate
+    # only needs to *run* the tests; lint is its own pipeline step
+    # (ruff) and runs from the host environment.
     "black>=23.0.0",
     "ruff>=0.1.0",
     "mypy>=1.0.0",
-    # Test-only: parse the /metrics output through the official Prometheus
-    # parser to catch format regressions. NOT used at runtime — the route
-    # hand-rolls the exposition format to avoid a runtime dep.
-    "prometheus_client>=0.16.0",
-    # Test-only: parse pyproject.toml in the L-07 vision-extra lock-in
-    # tests (tests/test_vision_extra_install.py). ``tomllib`` is stdlib
-    # on Python ≥3.11; the environment marker pins ``tomli`` only on
-    # Python 3.10 so the L-07 suite always runs against the documented
-    # supported floor (codex round-2 BLOCKING — without this, CI on
-    # 3.10 would module-skip the entire lock-in suite and let a future
-    # refactor silently drop the ``[vision]`` extra).
-    'tomli>=2.0.1; python_version < "3.11"',
 ]
 vllm = [
     "vllm>=0.4.0",

--- a/scripts/pr_validate/README.md
+++ b/scripts/pr_validate/README.md
@@ -25,6 +25,7 @@ python3.12 -m scripts.pr_validate <PR#> -v
 | 0 | `fetch` | always (fail-fast) | ~3s |
 | 0.5 | `test_plan_check` | always | <1s |
 | 0.7 | `cl_description_quality` | always (skip via `PR_VALIDATE_SKIP_DESC=1`) | <1s |
+| 0.8 | `test_env_check` | always (auto-install opt-out: `PR_VALIDATE_NO_AUTO_INSTALL=1`) | <1s (≈10s if install runs) |
 | 6 | `codex_review` | always (skip if codex CLI missing / not logged in) | 30–180s |
 | 1 | `supply_chain` | always | ~5s |
 | 2 | `lint` | when diff has .py | ~3s |
@@ -133,6 +134,34 @@ Three checks:
 
 Override: `PR_VALIDATE_SKIP_DESC=1` for two-line dep-bumps where
 rationale is genuinely overkill.
+
+### `test_env_check` (step 0.8)
+
+Verifies that the same Python interpreter `targeted_tests` and
+`full_unit` will hand to pytest can actually import the plugins the
+suite needs (chiefly `pytest_asyncio` — `pytest.ini` sets
+`asyncio_mode = auto`, so without the plugin every `async def test_*`
+fails at collection with "async def functions are not natively
+supported").
+
+When a plugin is missing, the step attempts a one-shot
+`pip install '.[test]'` from the repo root, then re-checks. If the
+re-check still fails, the step reports `fail` with the missing-package
+list and the canonical recovery command (`<interp> -m pip install
+'.[test]'`) so the operator can fix it manually.
+
+Closes #185 — the prior implementation had no env check at all,
+which meant a host that had lost `pytest-asyncio` (typically after an
+orchestrated `pip install --no-deps --force-reinstall .`) would crash
+the `full_unit` step with 124+ "async functions not supported" pytest
+errors that looked like regressions. The canonical test-deps live in
+`pyproject.toml[project.optional-dependencies].test` — the step does
+NOT maintain a hand-edited duplicate list.
+
+Override: `PR_VALIDATE_NO_AUTO_INSTALL=1` disables the auto-recover
+`pip install` (the step still detects + reports the missing packages,
+it just won't mutate the host Python). Use this in CI sandboxes that
+must keep the runner image read-only.
 
 ### `codex_review` (step 6, runs early)
 

--- a/scripts/pr_validate/_test_env.py
+++ b/scripts/pr_validate/_test_env.py
@@ -1,0 +1,223 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Test-environment self-check + canonical test-deps installer.
+
+Closes #185 — root cause of the recurring "pr_validate skipped due to
+env issue / missing pytest-asyncio" reports across multiple fix waves.
+
+The problem: pr_validate's ``targeted_tests`` and ``full_unit`` steps
+invoke pytest via ``sys.executable -m pytest``. If the host Python lost
+``pytest-asyncio`` (e.g. an orchestrated agent ran
+``pip install --no-deps --force-reinstall .``, which is the documented
+pattern in the project's CLAUDE memory), every ``async def test_*``
+fails at collection with::
+
+    async def functions are not natively supported.
+    You need to install a suitable plugin for your async framework,
+    for example:
+      - pytest-asyncio
+
+Across 124 tests in PR #731's full-unit log alone — and the next agent
+just reports "skipped due to env issue" and moves on, so the tooling
+debt compounds. The systematic fix is two-part:
+
+1. Publish the test-runtime deps as a `test` extras in pyproject.toml
+   (the canonical source — pr_validate does NOT maintain a duplicate
+   list).
+2. Have pr_validate self-check that those plugins are importable in
+   the same Python that will run pytest; if not, attempt a one-shot
+   ``pip install .[test]`` from the repo root (opt out via
+   ``PR_VALIDATE_NO_AUTO_INSTALL=1`` for sandboxed CI).
+
+The self-check runs as a first-class step (TestEnvCheckStep) so when
+auto-install is disabled and the env is broken, the operator sees a
+clear "pr_validate venv is misconfigured" error in the scorecard
+rather than a cryptic 124-failure pytest log.
+
+Why import-time checks and not just shelling to pytest with a "did the
+asyncio plugin load" flag? Because pytest itself is configured to
+auto-load every installed plugin via setuptools entrypoints, so a
+clean ``import pytest_asyncio`` is the most direct evidence the
+plugin is wired into THIS interpreter — same path pytest itself takes.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+# Packages the test suite REQUIRES at collection time. Keep this list
+# narrow — anything that's only used by a single test should be
+# soft-imported by that test (and tagged ``pytest.importorskip``),
+# not added here. The pytest plugin set is the load-bearing one
+# because plugin discovery happens before tests are collected, so a
+# missing plugin breaks the entire run.
+#
+# Each entry is (import_name, pip_name, why). ``import_name`` is what
+# the self-check tries; ``pip_name`` is what would be installed if we
+# fell back to ad-hoc ``pip install`` (we don't — we install the full
+# canonical extras instead — but it's surfaced in the error message
+# so the operator can manually recover).
+REQUIRED_TEST_PACKAGES: tuple[tuple[str, str, str], ...] = (
+    (
+        "pytest",
+        "pytest>=7.0.0",
+        "test runner itself; should be present but check anyway",
+    ),
+    (
+        "pytest_asyncio",
+        "pytest-asyncio>=0.21.0",
+        "pytest.ini sets asyncio_mode=auto; without this every "
+        "`async def test_*` fails at collection",
+    ),
+)
+
+# Canonical extras name from pyproject.toml. If you rename the extras,
+# update this constant too (and the unit test that pins it).
+TEST_EXTRAS_NAME = "test"
+
+
+@dataclass(frozen=True)
+class TestEnvStatus:
+    """Result of a test-env check.
+
+    ``missing`` is the list of import names that failed; ``ok`` mirrors
+    the bool the caller usually wants. ``message`` is a one-liner
+    suitable for a step-result summary.
+    """
+
+    ok: bool
+    missing: tuple[str, ...]
+    message: str
+    interpreter: str
+
+    @property
+    def install_hint(self) -> str:
+        """Manual recovery command the operator can paste, in case
+        auto-install is disabled or also fails."""
+        # Use the exact interpreter that ran the check — `pip install`
+        # with a different python silently installs into the wrong
+        # site-packages and the next pr_validate run fails the same
+        # way. The operator should see the FULL command.
+        return (
+            f"{self.interpreter} -m pip install '.[{TEST_EXTRAS_NAME}]'"
+            " (from the repo root)"
+        )
+
+
+def check_test_env(python: str | None = None) -> TestEnvStatus:
+    """Probe ``python`` for the required test-runtime packages.
+
+    ``python`` defaults to ``sys.executable`` — i.e. the interpreter
+    currently running pr_validate, which is also the one
+    ``targeted_tests`` and ``full_unit`` will hand pytest to. Using a
+    different interpreter for the check than for the actual run would
+    defeat the point of the check.
+
+    The probe is a single ``python -c "import pytest, pytest_asyncio"``
+    so the import side-effects happen in a fresh process — keeps this
+    function safe to call from inside pytest itself (where importing
+    pytest_asyncio twice could trip a "plugin already registered" warning).
+    """
+    interp = python or sys.executable
+    import_names = [pkg for pkg, _, _ in REQUIRED_TEST_PACKAGES]
+    probe = "; ".join(f"import {name}" for name in import_names)
+
+    proc = subprocess.run(  # noqa: S603
+        [interp, "-c", probe],
+        capture_output=True,
+        text=True,
+    )
+    if proc.returncode == 0:
+        return TestEnvStatus(
+            ok=True,
+            missing=(),
+            message=f"all {len(import_names)} required test packages importable",
+            interpreter=interp,
+        )
+
+    # Identify exactly which import failed. Re-probe each one
+    # individually — cheap (a handful of process spawns) and gives the
+    # operator the precise list instead of just "something broke".
+    missing: list[str] = []
+    for name in import_names:
+        single = subprocess.run(  # noqa: S603
+            [interp, "-c", f"import {name}"],
+            capture_output=True,
+            text=True,
+        )
+        if single.returncode != 0:
+            missing.append(name)
+
+    if not missing:
+        # The batch probe failed but every individual import passed.
+        # Surfaces as an OK status — the batch failure was likely a
+        # transient subprocess oddity, not a real missing module.
+        return TestEnvStatus(
+            ok=True,
+            missing=(),
+            message=(
+                "batch import probe failed but every individual import "
+                f"passed (interpreter: {interp})"
+            ),
+            interpreter=interp,
+        )
+
+    return TestEnvStatus(
+        ok=False,
+        missing=tuple(missing),
+        message=f"missing required test packages: {', '.join(missing)}",
+        interpreter=interp,
+    )
+
+
+def auto_install_disabled() -> bool:
+    """Honor ``PR_VALIDATE_NO_AUTO_INSTALL=1`` — set in CI sandboxes
+    where the validator must NOT mutate the host Python environment
+    (e.g. GitHub Actions on a hardened runner with a read-only venv).
+
+    In that mode the self-check still runs and still emits a clear
+    error; the operator is just expected to install the extras
+    themselves before re-invoking pr_validate.
+    """
+    return os.environ.get("PR_VALIDATE_NO_AUTO_INSTALL", "").lower() in (
+        "1",
+        "true",
+        "yes",
+        "on",
+    )
+
+
+def install_test_extras(repo_root: Path, python: str | None = None) -> tuple[bool, str]:
+    """Install the project's ``[test]`` extras into ``python`` from
+    ``repo_root``. Returns ``(ok, log)`` where ``log`` is the combined
+    stdout+stderr of pip (truncated to ~2 KB for scorecard inclusion).
+
+    Uses ``pip install '.[test]' --no-deps`` style? No — we want pip to
+    resolve `pytest`, `pytest-asyncio`, etc. The project's own runtime
+    deps (mlx, transformers, …) are already present from the user's
+    initial install; pip's resolver will treat them as satisfied and
+    short-circuit. ``--no-deps`` would prevent pytest-asyncio's own
+    deps from being picked up, which is wrong.
+
+    We do pass ``--quiet`` to keep the scorecard log readable. Full
+    output is also written to an artifact file via the calling step.
+    """
+    interp = python or sys.executable
+    cmd = [interp, "-m", "pip", "install", "--quiet", f".[{TEST_EXTRAS_NAME}]"]
+    proc = subprocess.run(  # noqa: S603
+        cmd,
+        capture_output=True,
+        text=True,
+        cwd=str(repo_root),
+    )
+    log = (proc.stdout or "") + (proc.stderr or "")
+    # Cap the log to ~2 KB — pip's "Successfully installed …" line is
+    # the load-bearing bit; pages of dep-resolver output just pad the
+    # scorecard. Full unabridged version still gets written to the
+    # artifact file by the step that called us.
+    if len(log) > 2048:
+        log = log[:1024] + "\n…[truncated]…\n" + log[-1024:]
+    return proc.returncode == 0, log

--- a/scripts/pr_validate/runner.py
+++ b/scripts/pr_validate/runner.py
@@ -26,6 +26,7 @@ from .steps.lint import LintStep
 from .steps.stress_e2e_bench import StressE2EBenchStep
 from .steps.supply_chain import SupplyChainStep
 from .steps.targeted_tests import TargetedTestsStep
+from .steps.test_env_check import TestEnvCheckStep
 from .steps.test_plan_check import TestPlanCheckStep
 
 # Step order — see scripts/pr_validate/README.md for the rationale.
@@ -35,6 +36,15 @@ STEPS: list[Step] = [
     FetchStep(),  # 0 — fetch PR + diff + classify blast radius
     TestPlanCheckStep(),  # 0.5 — unchecked test-plan items block merge (#427 lesson)
     CLDescriptionQualityStep(),  # 0.7 — title + body rationale (Google eng-practices)
+    # 0.8 — verify pytest plugins importable in the same Python pytest
+    # will be invoked with. Closes #185 (was failing the targeted_tests
+    # + full_unit gates with cryptic "async def functions are not
+    # natively supported" pytest errors when pytest-asyncio fell out of
+    # the host env). Placed BEFORE codex_review because codex review is
+    # the most expensive step here that depends on the diff but not the
+    # test env; failing the env check first avoids spending a codex
+    # round on a PR that pr_validate can't ultimately test.
+    TestEnvCheckStep(),
     CodexReviewStep(),  # 6 — adversarial review (codex exec, gpt-5.5)
     SupplyChainStep(),  # 1 — pip-audit, license, install hooks
     LintStep(),  # 2 — ruff check + format

--- a/scripts/pr_validate/steps/targeted_tests.py
+++ b/scripts/pr_validate/steps/targeted_tests.py
@@ -34,6 +34,7 @@ from __future__ import annotations
 import re
 import shutil
 import subprocess
+import sys
 import tempfile
 from pathlib import Path
 
@@ -205,8 +206,15 @@ def _select_test_files(ctx: Context) -> list[str]:
 # ---------------------------------------------------------------------------
 
 
+# Use ``sys.executable`` so pytest runs in the *same* interpreter as
+# pr_validate itself. The test_env_check step verifies pytest-asyncio
+# (etc.) are importable in this Python; if we hardcoded ``python3.12``
+# we could end up handing pytest to a sibling Python where the
+# self-check never ran. Closes #185 — the prior ``python3.12`` literal
+# meant a venv-installed pr_validate could collect 124 async-test
+# failures because the system python3.12 didn't have the plugin.
 _PYTEST_CMD = [
-    "python3.12",
+    sys.executable,
     "-m",
     "pytest",
     "-q",

--- a/scripts/pr_validate/steps/test_env_check.py
+++ b/scripts/pr_validate/steps/test_env_check.py
@@ -1,0 +1,134 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Step 0.8 — test-env self-check.
+
+Runs just after ``cl_description_quality`` and just before the codex
+review, i.e. as the first compute-bound gate. Verifies that the same
+Python interpreter ``targeted_tests`` and ``full_unit`` will hand to
+pytest can actually load the plugins the suite needs (chiefly
+``pytest_asyncio`` — pytest.ini sets ``asyncio_mode = auto``).
+
+Without this gate, a broken env produced a 124-failure ``full_unit``
+log that looked like a regression but was really tooling debt (#185 /
+PR #731). The fix is to fail loudly at the front of the pipeline, with
+the exact missing-package list and the canonical recovery command,
+rather than letting downstream pytest crash with a cryptic plugin-
+missing message.
+
+Recovery path: by default the step *also* attempts to install the
+canonical ``[test]`` extras from ``pyproject.toml`` and re-checks.
+Disable with ``PR_VALIDATE_NO_AUTO_INSTALL=1`` for hardened CI
+sandboxes that must not mutate the host Python.
+"""
+
+from __future__ import annotations
+
+from .._test_env import (
+    TEST_EXTRAS_NAME,
+    auto_install_disabled,
+    check_test_env,
+    install_test_extras,
+)
+from ..base import Step, StepResult
+from ..context import Context
+
+
+class TestEnvCheckStep(Step):
+    name = "test_env_check"
+    description = "verify pytest plugins importable in target Python"
+
+    def run(self, ctx: Context) -> StepResult:
+        log_path = ctx.artifact_path("test-env-check.log")
+
+        status = check_test_env()
+        if status.ok:
+            log_path.write_text(
+                f"interpreter: {status.interpreter}\n"
+                f"status: ok\n"
+                f"detail: {status.message}\n"
+            )
+            return StepResult(
+                name=self.name,
+                status="pass",
+                summary=status.message,
+                artifacts=[str(log_path)],
+            )
+
+        # Something's missing. Try to fix it from the canonical source
+        # unless the operator opted out.
+        if auto_install_disabled():
+            details = (
+                f"**pr_validate venv is misconfigured** — "
+                f"{status.message}.\n\n"
+                "Auto-install is disabled (`PR_VALIDATE_NO_AUTO_INSTALL=1`). "
+                "Recover with:\n\n"
+                f"```\n{status.install_hint}\n```\n"
+            )
+            log_path.write_text(
+                f"interpreter: {status.interpreter}\n"
+                f"status: fail (auto-install disabled)\n"
+                f"missing: {', '.join(status.missing)}\n"
+                f"hint: {status.install_hint}\n"
+            )
+            return StepResult(
+                name=self.name,
+                status="fail",
+                summary=f"{status.message} — auto-install disabled",
+                details=details,
+                artifacts=[str(log_path)],
+            )
+
+        ctx.run_log(
+            f"missing: {', '.join(status.missing)} — installing .[{TEST_EXTRAS_NAME}]"
+        )
+        ok, pip_log = install_test_extras(ctx.repo_root)
+        # Re-check after install — pip can report 0 and still leave a
+        # plugin un-importable (rare, but happens when there's a
+        # site-packages permission issue and pip silently falls back
+        # to --user). The second probe is the source of truth.
+        post = check_test_env()
+
+        log_path.write_text(
+            f"interpreter: {status.interpreter}\n"
+            f"status (initial): fail\n"
+            f"missing (initial): {', '.join(status.missing)}\n"
+            f"auto-install ok: {ok}\n"
+            f"pip log:\n{pip_log}\n"
+            f"status (after install): {'ok' if post.ok else 'fail'}\n"
+            f"missing (after install): {', '.join(post.missing) or '(none)'}\n"
+        )
+
+        if post.ok:
+            return StepResult(
+                name=self.name,
+                status="pass",
+                summary=(
+                    f"installed .[{TEST_EXTRAS_NAME}] to recover "
+                    f"{len(status.missing)} missing plugin(s)"
+                ),
+                artifacts=[str(log_path)],
+            )
+
+        # Auto-install ran but didn't fix it. Surface BOTH the original
+        # missing list AND the pip output so the operator can diagnose.
+        details = [
+            f"**pr_validate venv is misconfigured** — {status.message}.\n",
+            (
+                f"Auto-install attempted (`pip install '.[{TEST_EXTRAS_NAME}]'`) "
+                f"but the post-install probe still reports: "
+                f"`{post.message}`.\n"
+            ),
+            "Manual recovery:\n",
+            f"```\n{post.install_hint}\n```\n",
+            "Pip output (truncated):\n",
+            f"```\n{pip_log}\n```",
+        ]
+        return StepResult(
+            name=self.name,
+            status="fail",
+            summary=(
+                f"missing test packages and auto-install failed: "
+                f"{', '.join(post.missing)}"
+            ),
+            details="\n".join(details),
+            artifacts=[str(log_path)],
+        )

--- a/tests/test_pr_validate_test_env.py
+++ b/tests/test_pr_validate_test_env.py
@@ -1,0 +1,412 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for ``scripts.pr_validate._test_env`` and the
+``TestEnvCheckStep`` pipeline gate (issue #185).
+
+Three contracts pinned:
+
+1. A healthy host (where every `REQUIRED_TEST_PACKAGES` import works
+   in the running interpreter) passes the check.
+2. A broken host (one of the required imports raises in a fresh
+   subprocess) gets a `fail` result whose `details` names the missing
+   package AND surfaces the exact `pip install '.[test]'` recovery
+   command with the interpreter that needs the install.
+3. The canonical `test` extras in `pyproject.toml` includes
+   `pytest-asyncio` — this is the load-bearing dep that the bug was
+   silently dropping. A future refactor that renames the extras or
+   drops the plugin should fail this test.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# Standard pyproject parser — stdlib on 3.11+, vendored tomli marker
+# on 3.10 (already an existing dev dep).
+if sys.version_info >= (3, 11):
+    import tomllib
+else:  # pragma: no cover — branch only taken on 3.10 CI
+    import tomli as tomllib
+
+from scripts.pr_validate._test_env import (
+    REQUIRED_TEST_PACKAGES,
+    TEST_EXTRAS_NAME,
+    TestEnvStatus,
+    auto_install_disabled,
+    check_test_env,
+)
+from scripts.pr_validate.context import Context
+from scripts.pr_validate.steps.test_env_check import TestEnvCheckStep
+
+# ---------------------------------------------------------------------------
+# pyproject.toml canonical-source contract
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def project_table() -> dict:
+    """Load the repo root's pyproject.toml. The test deliberately
+    walks up from this file (not ``Path.cwd()``) so a CI runner that
+    invokes pytest from a sub-directory still finds the right file."""
+    repo_root = Path(__file__).resolve().parent.parent
+    pyproject = repo_root / "pyproject.toml"
+    return tomllib.loads(pyproject.read_text())
+
+
+class TestPyprojectTestExtras:
+    def test_test_extras_exists(self, project_table):
+        """The `test` extras must exist — it's the canonical source the
+        venv builder installs from. If a future refactor deletes it,
+        pr_validate's auto-recover falls back to ad-hoc lists and the
+        same bug returns."""
+        extras = project_table["project"]["optional-dependencies"]
+        assert TEST_EXTRAS_NAME in extras, (
+            f"`{TEST_EXTRAS_NAME}` extras missing from pyproject.toml — "
+            "pr_validate's `test_env_check` step cannot auto-recover. "
+            "See scripts/pr_validate/_test_env.py."
+        )
+
+    def test_test_extras_includes_pytest_asyncio(self, project_table):
+        """The load-bearing dep. ``pytest.ini`` sets `asyncio_mode = auto`
+        which means every `async def test_*` is collected as an asyncio
+        test — without pytest-asyncio, those fail at collection and the
+        full_unit step reports a hundreds-deep "regression" that's
+        really just a missing plugin (#185)."""
+        deps = project_table["project"]["optional-dependencies"][TEST_EXTRAS_NAME]
+        assert any("pytest-asyncio" in d for d in deps), (
+            f"`pytest-asyncio` missing from [{TEST_EXTRAS_NAME}] extras — "
+            "this is the dep whose absence reopens issue #185."
+        )
+
+    def test_test_extras_includes_pytest_itself(self, project_table):
+        """Defensive: pytest is the runner. A `test` extras that didn't
+        include pytest would be useless — and prior to this fix, the
+        only reason it ever worked was because pytest happened to be
+        installed transitively from `dev`."""
+        deps = project_table["project"]["optional-dependencies"][TEST_EXTRAS_NAME]
+        assert any(d.startswith("pytest") and "asyncio" not in d for d in deps), (
+            "no pytest entry in `test` extras — see _test_env.py"
+        )
+
+    def test_dev_extras_superset_of_test(self, project_table):
+        """`dev` must contain every dep `test` does so the existing
+        `pip install .[dev] && pytest` contributor workflow still
+        works after the split. Pure containment check on package-name
+        prefixes (versions allowed to differ — only the package name
+        is load-bearing)."""
+        extras = project_table["project"]["optional-dependencies"]
+        # Compare just the package-name token before any version
+        # specifier or environment marker.
+        names_in = lambda key: {  # noqa: E731
+            _pkg_name(d) for d in extras[key]
+        }
+        missing = names_in(TEST_EXTRAS_NAME) - names_in("dev")
+        assert not missing, (
+            f"`dev` extras is missing test deps: {sorted(missing)}. "
+            "Keep `dev` a strict superset of `test` so `pip install "
+            "'.[dev]' && pytest` keeps working — there's a comment in "
+            "pyproject.toml asking the next editor to maintain this."
+        )
+
+
+def _pkg_name(dep: str) -> str:
+    """Pull the bare package name out of a PEP 508-ish requirement
+    string. ``"pytest-asyncio>=0.21.0"`` → ``"pytest-asyncio"``;
+    ``'tomli>=2.0.1; python_version < "3.11"'`` → ``"tomli"``."""
+    # Strip env markers (everything after the ; ), then version spec.
+    head = dep.split(";", 1)[0].strip()
+    for sep in ("<=", ">=", "==", "<", ">", "~=", "!="):
+        if sep in head:
+            head = head.split(sep, 1)[0]
+            break
+    # Strip extras like "outlines[mlxlm]".
+    return head.split("[", 1)[0].strip()
+
+
+# ---------------------------------------------------------------------------
+# check_test_env() — host-state probe
+# ---------------------------------------------------------------------------
+
+
+class TestCheckTestEnv:
+    def test_returns_ok_on_healthy_host(self):
+        """The running interpreter HAS pytest + pytest-asyncio (we're
+        in a pytest invocation right now), so the probe must report
+        ok with an empty missing list."""
+        status = check_test_env()
+        assert status.ok is True
+        assert status.missing == ()
+        assert status.interpreter == sys.executable
+
+    def test_reports_missing_module_on_broken_host(self, tmp_path):
+        """Build a tiny venv with pytest but NOT pytest-asyncio, then
+        probe IT — this is the exact failure mode #185 documents.
+
+        Skipped if the host doesn't have `venv` available (very rare
+        on macOS Homebrew Python 3.12, the only documented target)."""
+        try:
+            import venv  # noqa: F401
+        except ImportError:  # pragma: no cover
+            pytest.skip("venv module unavailable")
+
+        venv_dir = tmp_path / "broken"
+        import venv as _venv
+
+        # `with_pip=True` so we can install pytest into it; turn off
+        # symlinks to avoid permission surprises on weird filesystems.
+        _venv.create(venv_dir, with_pip=True, symlinks=False)
+        python = venv_dir / "bin" / "python"
+        assert python.exists(), "venv builder didn't produce a python"
+
+        # Install pytest only — pytest-asyncio deliberately omitted.
+        # --quiet keeps the test output readable; --disable-pip-version-check
+        # suppresses the upgrade nag that adds noise on slow CI.
+        import subprocess
+
+        subprocess.run(  # noqa: S603
+            [
+                str(python),
+                "-m",
+                "pip",
+                "install",
+                "--quiet",
+                "--disable-pip-version-check",
+                "pytest",
+            ],
+            check=True,
+            capture_output=True,
+        )
+
+        status = check_test_env(python=str(python))
+        assert status.ok is False
+        # pytest_asyncio is the import name (underscore), not the pip
+        # name (dash). Pin the import name — that's what the probe
+        # actually runs.
+        assert "pytest_asyncio" in status.missing
+        # pytest itself was installed → must NOT appear in missing.
+        assert "pytest" not in status.missing
+        # The hint must reference the canonical extras name AND the
+        # exact interpreter — handing a different python to pip would
+        # install into the wrong site-packages and the operator's next
+        # pr_validate run would fail identically.
+        assert f"'.[{TEST_EXTRAS_NAME}]'" in status.install_hint
+        assert str(python) in status.install_hint
+
+    def test_install_hint_uses_the_probed_interpreter_not_sys_executable(self):
+        """Edge: a TestEnvStatus constructed for some OTHER python (a
+        CI worker, a docker container) must surface THAT interpreter
+        in the recovery hint, not ``sys.executable``. Cheap regression
+        guard for a class of bug where someone "simplifies" the
+        property by hardcoding sys.executable."""
+        fake_python = "/opt/sandbox/python3.13"
+        status = TestEnvStatus(
+            ok=False,
+            missing=("pytest_asyncio",),
+            message="…",
+            interpreter=fake_python,
+        )
+        assert status.install_hint.startswith(fake_python)
+        assert (
+            sys.executable not in status.install_hint or sys.executable == fake_python
+        )
+
+
+# ---------------------------------------------------------------------------
+# auto_install_disabled() — env-var feature flag
+# ---------------------------------------------------------------------------
+
+
+class TestAutoInstallDisabled:
+    @pytest.mark.parametrize("val", ["1", "true", "TRUE", "yes", "on"])
+    def test_truthy_values_disable(self, val):
+        with patch.dict(os.environ, {"PR_VALIDATE_NO_AUTO_INSTALL": val}):
+            assert auto_install_disabled() is True
+
+    @pytest.mark.parametrize("val", ["", "0", "false", "no", "off", "maybe"])
+    def test_falsy_values_enable(self, val):
+        with patch.dict(os.environ, {"PR_VALIDATE_NO_AUTO_INSTALL": val}):
+            assert auto_install_disabled() is False
+
+    def test_unset_enables(self):
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("PR_VALIDATE_NO_AUTO_INSTALL", None)
+            assert auto_install_disabled() is False
+
+
+# ---------------------------------------------------------------------------
+# TestEnvCheckStep — pipeline integration
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def fake_ctx(tmp_path):
+    """A Context pointing at a tmpdir with a stub pyproject so
+    ``__post_init__`` doesn't bail on cwd."""
+    (tmp_path / "pyproject.toml").write_text("[project]\nname='fake'\n")
+    old_cwd = Path.cwd()
+    os.chdir(tmp_path)
+    try:
+        ctx = Context(pr_number=999, verbose=False)
+        ctx.work_dir = tmp_path / "work"
+        ctx.work_dir.mkdir()
+        yield ctx
+    finally:
+        os.chdir(old_cwd)
+
+
+class TestStepIntegration:
+    def test_pass_on_healthy_host(self, fake_ctx):
+        """End-to-end on the actual running interpreter — same logic
+        as `test_returns_ok_on_healthy_host` but driven through the
+        Step API so the scorecard wiring is also exercised. The
+        artifact path must be created and the result must include it."""
+        step = TestEnvCheckStep()
+        result = step.run(fake_ctx)
+        assert result.status == "pass"
+        # Artifact must exist and name the interpreter so the operator
+        # can audit which Python actually got probed.
+        assert result.artifacts
+        log = Path(result.artifacts[0]).read_text()
+        assert sys.executable in log
+        assert "status: ok" in log
+
+    def test_fail_when_auto_install_disabled_and_packages_missing(self, fake_ctx):
+        """Patch `check_test_env` to fake a broken host AND set the
+        opt-out env var. The step must emit fail with a `details`
+        block that names the missing package AND surfaces the
+        canonical recovery command — those are the two operator-
+        actionable bits."""
+        bad = TestEnvStatus(
+            ok=False,
+            missing=("pytest_asyncio",),
+            message="missing required test packages: pytest_asyncio",
+            interpreter="/opt/fake/python",
+        )
+        with (
+            patch.dict(os.environ, {"PR_VALIDATE_NO_AUTO_INSTALL": "1"}),
+            patch(
+                "scripts.pr_validate.steps.test_env_check.check_test_env",
+                return_value=bad,
+            ),
+        ):
+            step = TestEnvCheckStep()
+            result = step.run(fake_ctx)
+
+        assert result.status == "fail"
+        assert "pytest_asyncio" in result.details
+        # The recovery command must reference the canonical extras AND
+        # the probed interpreter so the operator copy-pastes the right
+        # python.
+        assert f"'.[{TEST_EXTRAS_NAME}]'" in result.details
+        assert "/opt/fake/python" in result.details
+        # Summary one-liner (shown in the scorecard table) must call
+        # out the auto-install state — otherwise the operator has to
+        # open the details block to know what to do.
+        assert "auto-install disabled" in result.summary
+
+    def test_auto_install_attempts_and_recovers(self, fake_ctx):
+        """Initial probe fails; auto-install path runs; post-install
+        probe passes. The step must report `pass` and the summary
+        must mention "installed" so the operator knows the run
+        recovered (and the host was mutated)."""
+        broken = TestEnvStatus(
+            ok=False,
+            missing=("pytest_asyncio",),
+            message="missing required test packages: pytest_asyncio",
+            interpreter=sys.executable,
+        )
+        healthy = TestEnvStatus(
+            ok=True,
+            missing=(),
+            message="all 2 required test packages importable",
+            interpreter=sys.executable,
+        )
+        # Two-shot probe: first call sees the broken state, second
+        # (after install) sees the recovered state.
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("PR_VALIDATE_NO_AUTO_INSTALL", None)
+            with (
+                patch(
+                    "scripts.pr_validate.steps.test_env_check.check_test_env",
+                    side_effect=[broken, healthy],
+                ),
+                patch(
+                    "scripts.pr_validate.steps.test_env_check.install_test_extras",
+                    return_value=(
+                        True,
+                        "Successfully installed pytest-asyncio-0.21.0\n",
+                    ),
+                ) as mock_install,
+            ):
+                step = TestEnvCheckStep()
+                result = step.run(fake_ctx)
+
+        assert result.status == "pass"
+        assert "installed" in result.summary
+        # Install was called once with the ctx's repo root.
+        assert mock_install.call_count == 1
+
+    def test_auto_install_runs_but_does_not_fix(self, fake_ctx):
+        """Initial probe fails; pip succeeds (exit 0); post-install
+        probe STILL fails. This is the "pip silently fell back to
+        --user and the plugin is in the wrong site-packages" case —
+        the step must report fail with both the initial AND
+        post-install missing list so the operator sees the install
+        didn't take."""
+        broken = TestEnvStatus(
+            ok=False,
+            missing=("pytest_asyncio",),
+            message="missing required test packages: pytest_asyncio",
+            interpreter=sys.executable,
+        )
+        # Same broken status both times — install reported success
+        # but the import still doesn't work.
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("PR_VALIDATE_NO_AUTO_INSTALL", None)
+            with (
+                patch(
+                    "scripts.pr_validate.steps.test_env_check.check_test_env",
+                    side_effect=[broken, broken],
+                ),
+                patch(
+                    "scripts.pr_validate.steps.test_env_check.install_test_extras",
+                    return_value=(True, "(fake pip output)"),
+                ),
+            ):
+                step = TestEnvCheckStep()
+                result = step.run(fake_ctx)
+
+        assert result.status == "fail"
+        # Operator must see both the failure message AND the pip log
+        # (truncated or not) so they can diagnose where it went wrong.
+        assert "auto-install attempted" in result.details.lower()
+        assert "(fake pip output)" in result.details
+
+
+# ---------------------------------------------------------------------------
+# Required-packages constant — pin the shape
+# ---------------------------------------------------------------------------
+
+
+class TestRequiredPackages:
+    def test_pytest_and_pytest_asyncio_required(self):
+        """The two non-negotiables for this repo. A future refactor
+        that drops `pytest_asyncio` from this tuple (e.g. because the
+        author tests with `pytest-anyio` locally and forgets the gate
+        runs on a different host) silently reopens #185."""
+        names = {pkg for pkg, _, _ in REQUIRED_TEST_PACKAGES}
+        assert "pytest" in names
+        assert "pytest_asyncio" in names
+
+    def test_every_entry_has_a_pip_name_with_version(self):
+        """Defensive: each entry must carry a version constraint so
+        the auto-install message isn't ambiguous."""
+        for pkg, pip_name, _ in REQUIRED_TEST_PACKAGES:
+            assert pip_name, f"empty pip name for {pkg!r}"
+            assert any(c in pip_name for c in (">=", "==", "~=", ">")), (
+                f"{pip_name!r} for {pkg!r} has no version constraint"
+            )


### PR DESCRIPTION
## Why

`pr_validate`'s `targeted_tests` and `full_unit` gates have been crashing across multiple fix waves with hundreds of fake "regressions" that were really a single missing pytest plugin. Agents keep reporting *"skipped pr_validate due to env issue"* and the tooling debt compounds. Closes #185.

### Repro (from PR-731's `full-unit.log`)

124 failures, every one identical:

```
async def functions are not natively supported.
You need to install a suitable plugin for your async framework, for example:
  - anyio
  - pytest-asyncio
  - pytest-tornasync
  - pytest-trio
  - pytest-twisted
```

The host Python had lost `pytest-asyncio` (likely from a `pip install --no-deps --force-reinstall .` earlier in the orchestrated run — documented pattern in `CLAUDE.md`), and `pytest.ini` sets `asyncio_mode = auto`, so every `async def test_*` failed at collection.

## Root cause

1. **No canonical `test` extras.** Test-runtime deps lived only in `[project.optional-dependencies].dev`, mixed with linters. Any `pip install --no-deps` against the project wiped them with no recovery path.
2. **Hardcoded interpreter.** `scripts/pr_validate/steps/targeted_tests.py` used `python3.12` literal instead of `sys.executable`, so the system Python could differ from the validator's Python — a self-check in one wouldn't catch a missing plugin in the other.
3. **No self-check.** When pytest crashed at collection, the operator saw a 124-line "regression" list, not "your env is broken".

## Systematic fix

- New **`[project.optional-dependencies].test`** extras in `pyproject.toml` — the canonical narrow set (`pytest`, `pytest-asyncio`, `prometheus_client`, `tomli` marker). `[dev]` keeps every dep `[test]` has (locked in by a unit test) so `pip install .[dev] && pytest` still works.
- New **`scripts/pr_validate/_test_env.py`** — `check_test_env()` probes `sys.executable` for `pytest` + `pytest_asyncio` in a fresh subprocess (same import path pytest itself takes).
- New **`TestEnvCheckStep`** (step 0.8, between `cl_description_quality` and `codex_review`). Fails loudly with the exact missing-package list and the canonical recovery command; by default attempts `pip install '.[test]'` from the repo root and re-checks. Opt out via `PR_VALIDATE_NO_AUTO_INSTALL=1` for hardened CI sandboxes that must not mutate the host Python.
- **`targeted_tests`** swaps the hardcoded `python3.12` for `sys.executable` so pytest runs in the same interpreter the env check probed.
- README updated with the new step + the override.

Crucially, the fix does **not** maintain a hand-edited duplicate dep list inside pr_validate — the test extras are the canonical source, exactly the systematic move the task description asks for.

## Test plan

- [x] `pytest tests/test_pr_validate_test_env.py -q` — 25 new tests including a real broken-venv repro (builds a tmp venv with pytest-but-not-pytest-asyncio, verifies the probe pinpoints `pytest_asyncio`).
- [x] `pytest tests/test_pr_validate_*.py -q` — all 230 pr_validate tests pass (205 existing + 25 new).
- [x] `ruff check` + `ruff format --check` clean on all touched files.
- [x] Pipeline introspection: `from scripts.pr_validate.runner import STEPS` shows `test_env_check` wired in between `cl_description_quality` and `codex_review`.
- [x] Smoke: `check_test_env()` returns `ok=True` with `interpreter=sys.executable` on the host.

Refs #185.

🤖 Generated with [Claude Code](https://claude.com/claude-code)