### PR TITLE
fix(chat,responses): re-check context length before strict_json_schema repair retry (H-06 #267b)

### DIFF
--- a/tests/test_r12_h06_repair_context_guard.py
+++ b/tests/test_r12_h06_repair_context_guard.py
@@ -38,6 +38,7 @@ from vllm_mlx.config import reset_config
 from vllm_mlx.engine.base import GenerationOutput
 from vllm_mlx.middleware.exception_handlers import install_exception_handlers
 from vllm_mlx.routes.chat import router as chat_router
+from vllm_mlx.routes.responses import router as responses_router
 
 # ---------------------------------------------------------------------------
 # Stubs — modelled after the constraint-matrix file but with a real
@@ -159,6 +160,34 @@ def _client(*, body: str, max_position_embeddings: int):
     return TestClient(app), engine
 
 
+def _responses_client(*, body: str, max_position_embeddings: int):
+    """Same fixture as ``_client`` but mounts the /v1/responses
+    router. Both routes call into the SAME centralized helper
+    (``service.helpers.repair_messages_fit_context``), so we exercise
+    the responses surface end-to-end to make sure the wiring at
+    ``responses.py:963`` is identical to ``chat.py``.
+    """
+    from vllm_mlx.middleware.auth import rate_limiter
+
+    engine = _StubEngine(body=body, max_position_embeddings=max_position_embeddings)
+    cfg = reset_config()
+    cfg.engine = engine
+    cfg.model_name = "test-model"
+    cfg.model_registry = None
+    cfg.no_thinking = True
+
+    # /v1/responses is gated by the global rate-limiter; the strict
+    # repair-overflow test file pins counter behaviour and must not
+    # be perturbed by 429s.
+    rate_limiter.enabled = False
+    rate_limiter._requests.clear()
+
+    app = FastAPI()
+    install_exception_handlers(app)
+    app.include_router(responses_router)
+    return TestClient(app), engine
+
+
 # ---------------------------------------------------------------------------
 # Boundary fixtures
 # ---------------------------------------------------------------------------
@@ -186,6 +215,26 @@ def _payload(*, messages: list[dict] | None = None) -> dict:
                 "schema": _SCHEMA_MINIMUM,
                 "strict": True,
             },
+        },
+    }
+
+
+def _responses_payload() -> dict:
+    """``/v1/responses`` shape — schema carried under ``text.format``
+    instead of ``response_format``. Mirrors the test in
+    ``test_response_format_json_schema_strict.py``.
+    """
+    return {
+        "model": "test-model",
+        "input": "produce something",
+        "max_output_tokens": 64,
+        "text": {
+            "format": {
+                "type": "json_schema",
+                "name": "AgeCheck",
+                "schema": _SCHEMA_MINIMUM,
+                "strict": True,
+            }
         },
     }
 
@@ -378,3 +427,105 @@ def test_repair_fits_helper_returns_true_when_build_prompt_missing():
     assert repair_messages_fit_context(
         _NoBuildPrompt(), [{"role": "user", "content": "x"}]
     )
+
+
+# ---------------------------------------------------------------------------
+# /v1/responses parity — codex r1 #2: the chat suite above proves the
+# centralized helper is wired into chat.py, but the /v1/responses
+# call site (responses.py:963) has its own envelope, its own request-
+# disconnect path, and its own ``max_output_tokens`` plumbing. Pin
+# the SAME overflow contract end-to-end on the responses surface so a
+# future refactor that only edits the chat route cannot regress
+# /v1/responses without an obvious test failure.
+# ---------------------------------------------------------------------------
+
+
+def test_responses_repair_skipped_when_repair_prompt_exceeds_context():
+    """``/v1/responses`` parity for Test 2 (chat-side).
+
+    Tight context window: the initial prompt fits but the post-build
+    repair prompt does not. Pre-#267b /v1/responses would have
+    surfaced this as ``502 strict_repair_engine_failure``. Post-fix
+    the route MUST short-circuit, leave ``attempts == 1``, and
+    surface the original ``422 json_schema_violation`` envelope.
+
+    Pinned observable contract on the responses surface:
+      * status_code == 422 (NOT 502)
+      * error.code == "json_schema_violation"
+      * error.param == "text.format" (responses-specific envelope)
+      * engine.chat called exactly once
+      * strict_repairs_skipped_context_overflow_total ticks by 1
+      * strict_repairs_attempted_total does NOT tick
+    """
+    # Sizing on /v1/responses (4 chars/token stub tokenizer):
+    #   * Unlike /v1/chat/completions, the responses route does NOT
+    #     inject a ``build_json_system_prompt`` instruction into the
+    #     initial messages (chat.py:1919 has no responses-side
+    #     parallel). The initial prompt is therefore just the user
+    #     "produce something" message → a few tokens; trivially fits.
+    #   * The REPAIR prompt (instructions + schema + failed-output
+    #     quote + retry hint) ≈ 188 tokens. With ``max_output_tokens=64``
+    #     → 252 total. Setting the cap to 200 puts the repair 52
+    #     tokens over the limit so the gate MUST fire while the
+    #     initial pass still succeeds.
+    client, engine = _responses_client(
+        body=_VIOLATING_BODY, max_position_embeddings=200
+    )
+
+    resp = client.post("/v1/responses", json=_responses_payload())
+    # The critical assertion: NOT 502 (no opaque server-side error).
+    assert resp.status_code == 422, (
+        f"/v1/responses expected 422 (deterministic validation outcome), "
+        f"got {resp.status_code}: {resp.text}"
+    )
+    body = resp.json()
+    assert body["error"]["code"] == "json_schema_violation", body
+    assert body["error"]["type"] == "validation_error", body
+    # Responses surface carries ``text.format`` in the envelope —
+    # distinct from chat's ``response_format`` param.
+    assert body["error"].get("param") == "text.format", body
+
+    # Engine MUST NOT have been called a second time.
+    assert len(engine.chat_calls) == 1, (
+        f"/v1/responses repair was skipped → expected 1 chat call, "
+        f"got {len(engine.chat_calls)}"
+    )
+
+    snap = response_format_metrics.snapshot()
+    # Skip counter ticked exactly once — same counter as chat.py.
+    assert snap["strict_repairs_skipped_context_overflow_total"] == 1, snap
+    # Attempt counter did NOT tick — repair was skipped, not run.
+    assert snap["strict_repairs_attempted_total"] == 0, snap
+    # The violation still ticks because the client sees a 422.
+    assert snap["strict_violations_total"] == 1, snap
+
+
+def test_responses_repair_runs_when_both_initial_and_repair_fit_context():
+    """``/v1/responses`` parity for Test 1 (chat-side).
+
+    Sanity-check the responses surface on the HAPPY path: with a
+    generous context window the repair runs, ``attempts == 2``, and
+    the skip counter does NOT tick. Without this companion test, a
+    regression that wedged the responses skip path "always-skip"
+    could pass the overflow test above on its own. Pinning the
+    happy path here ensures the gate only fires when it should.
+    """
+    client, engine = _responses_client(
+        body=_VIOLATING_BODY, max_position_embeddings=1_048_576
+    )
+
+    resp = client.post("/v1/responses", json=_responses_payload())
+    # Repair fires, validation still fails → 422 with attempts=2.
+    assert resp.status_code == 422, resp.text
+    body = resp.json()
+    assert body["error"]["code"] == "json_schema_violation", body
+    # Engine called twice — initial + repair retry.
+    assert len(engine.chat_calls) == 2, (
+        f"/v1/responses repair should have run → expected 2 chat calls, "
+        f"got {len(engine.chat_calls)}"
+    )
+
+    snap = response_format_metrics.snapshot()
+    # Repair was attempted; skip counter did NOT tick.
+    assert snap["strict_repairs_attempted_total"] == 1, snap
+    assert snap["strict_repairs_skipped_context_overflow_total"] == 0, snap

--- a/tests/test_r12_h06_repair_context_guard.py
+++ b/tests/test_r12_h06_repair_context_guard.py
@@ -1,0 +1,383 @@
+# SPDX-License-Identifier: Apache-2.0
+"""H-06 #267b — strict json_schema repair-retry context-length guard.
+
+Codex review on PR #878 surfaced that the R12-4 strict-mode repair
+retry built a strictly LARGER prompt than the initial request
+(prepended repair instructions, repeated schema, up to 4 KiB of
+failed output) but **never re-checked the context-length gate
+before re-calling the engine**. A request that passed the initial
+``enforce_context_length_for_messages`` could blow context only on
+the repair attempt and surface as ``502 strict_repair_engine_failure``
+rather than a deterministic ``422 json_schema_violation``.
+
+These tests pin the systemic fix:
+
+    1. Initial fits AND repair fits  → repair runs as before.
+    2. Initial fits, repair does NOT fit → SKIP repair, return the
+       ORIGINAL 422 envelope (NOT 502). The skip counter ticks.
+    3. Edge: repair is exactly ONE token over the model's context
+       window → skip cleanly with the same 422 surface and counter.
+
+The same gate is applied at both call sites (chat.py:2806 and
+responses.py:899) via the centralized
+``service.helpers.repair_messages_fit_context`` helper so the
+behavior cannot drift between surfaces — a single bug class to
+guard against rather than two.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from vllm_mlx.api import response_format_metrics
+from vllm_mlx.config import reset_config
+from vllm_mlx.engine.base import GenerationOutput
+from vllm_mlx.middleware.exception_handlers import install_exception_handlers
+from vllm_mlx.routes.chat import router as chat_router
+
+
+# ---------------------------------------------------------------------------
+# Stubs — modelled after the constraint-matrix file but with a real
+# tokenizer + a tunable max-context window so we can hit the H-06
+# boundary deterministically.
+# ---------------------------------------------------------------------------
+
+
+class _StubArgs:
+    """Surface for ``model.args.max_position_embeddings`` resolution."""
+
+    def __init__(self, max_position_embeddings: int):
+        self.max_position_embeddings = max_position_embeddings
+
+
+class _StubModel:
+    def __init__(self, max_position_embeddings: int):
+        self.args = _StubArgs(max_position_embeddings)
+
+
+class _StubTokenizer:
+    """Deterministic tokenizer: 1 token per 4 characters.
+
+    The H-06 fix relies on ``count_prompt_tokens`` returning a real
+    integer — the helper short-circuits on tokenizer-returned-zero,
+    so we cannot stub the count to 0. We use a fixed chars-per-token
+    ratio so the test can place a tiny budget at the byte boundary
+    where the repair prompt exceeds context but the initial prompt
+    does not.
+    """
+
+    bos_token = None
+
+    def __init__(self, chars_per_token: int = 4):
+        self._cpt = chars_per_token
+
+    def encode(self, text, add_special_tokens=True):  # noqa: ARG002
+        return [0] * max(1, len(text) // self._cpt)
+
+
+class _StubEngine:
+    """Deterministic engine that returns a fixed body for each chat
+    call AND exposes a configurable context window via ``_model``
+    so the H-06 repair-fit gate can be exercised end-to-end."""
+
+    preserve_native_tool_format = False
+    is_mllm = False
+    supports_guided_generation = False
+
+    def __init__(self, *, body: str, max_position_embeddings: int):
+        self._body = body
+        self._model = _StubModel(max_position_embeddings)
+        self._tokenizer = _StubTokenizer()
+        self.chat_calls: list[dict] = []
+
+    @property
+    def tokenizer(self):
+        return self._tokenizer
+
+    def build_prompt(self, messages, tools=None, enable_thinking=None):
+        # Render messages as concatenated text so the prompt length
+        # scales with the repair-hint + schema + failed-output
+        # payload. The exact format doesn't matter as long as more
+        # messages → more characters → more tokens.
+        parts: list[str] = []
+        for m in messages:
+            content = m.get("content", "")
+            if isinstance(content, str):
+                parts.append(content)
+            else:
+                # Multipart content blocks — keep the text parts.
+                for p in content or []:
+                    if isinstance(p, dict) and p.get("type") == "text":
+                        parts.append(str(p.get("text", "")))
+        return "\n".join(parts)
+
+    async def chat(self, *, messages, **kwargs):
+        self.chat_calls.append({"messages": messages, "kwargs": kwargs})
+        return GenerationOutput(
+            text=self._body,
+            new_text=self._body,
+            prompt_tokens=4,
+            completion_tokens=5,
+            finished=True,
+            finish_reason="stop",
+            channel=None,
+        )
+
+    async def stream_chat(self, messages, **kwargs):  # pragma: no cover
+        yield GenerationOutput(
+            text=self._body,
+            new_text=self._body,
+            prompt_tokens=4,
+            completion_tokens=5,
+            finished=True,
+            finish_reason="stop",
+            channel=None,
+        )
+
+
+@pytest.fixture(autouse=True)
+def _reset_metrics_between_tests():
+    response_format_metrics.reset_for_tests()
+    yield
+    response_format_metrics.reset_for_tests()
+
+
+def _client(*, body: str, max_position_embeddings: int):
+    engine = _StubEngine(body=body, max_position_embeddings=max_position_embeddings)
+    cfg = reset_config()
+    cfg.engine = engine
+    cfg.model_name = "test-model"
+    cfg.model_registry = None
+    cfg.no_thinking = True
+
+    app = FastAPI()
+    install_exception_handlers(app)
+    app.include_router(chat_router)
+    return TestClient(app), engine
+
+
+# ---------------------------------------------------------------------------
+# Boundary fixtures
+# ---------------------------------------------------------------------------
+
+# Schema that triggers a deterministic ``minimum`` violation — the
+# constraint-matrix file already pins that every constraint family
+# tripping ``422`` works, so we reuse the simplest row.
+_SCHEMA_MINIMUM = {
+    "type": "object",
+    "properties": {"age": {"type": "integer", "minimum": 18}},
+    "required": ["age"],
+}
+_VIOLATING_BODY = json.dumps({"age": 5})
+
+
+def _payload(*, messages: list[dict] | None = None) -> dict:
+    return {
+        "model": "test-model",
+        "messages": messages or [{"role": "user", "content": "produce something"}],
+        "max_tokens": 64,
+        "response_format": {
+            "type": "json_schema",
+            "json_schema": {
+                "name": "AgeCheck",
+                "schema": _SCHEMA_MINIMUM,
+                "strict": True,
+            },
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Test 1 — initial fits AND repair fits → repair runs.
+# ---------------------------------------------------------------------------
+
+
+def test_repair_runs_when_both_initial_and_repair_fit_context():
+    """Generous context window: both the initial prompt and the
+    repair prompt fit. Behaviour MUST be identical to the
+    pre-#267b path — engine.chat called twice, 422 returned with
+    ``attempts=2``, ``strict_repairs_attempted_total`` ticks, and
+    the skip-counter does NOT tick.
+    """
+    # 1 048 576 tokens — comfortably larger than the repair prompt
+    # (instructions + schema + ~50 char failed output ≈ a few
+    # hundred tokens at 4 chars/token).
+    client, engine = _client(
+        body=_VIOLATING_BODY, max_position_embeddings=1_048_576
+    )
+
+    resp = client.post("/v1/chat/completions", json=_payload())
+    assert resp.status_code == 422, resp.text
+    body = resp.json()
+    details = body["error"]["details"]
+    # Repair retry must have fired.
+    assert details["attempts"] == 2
+    assert len(engine.chat_calls) == 2
+
+    snap = response_format_metrics.snapshot()
+    assert snap["strict_repairs_attempted_total"] == 1
+    # Skip counter does NOT tick on the happy path.
+    assert snap["strict_repairs_skipped_context_overflow_total"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Test 2 — initial fits, repair does NOT fit → skip repair, return
+# the original 422 (NOT 502), skip counter ticks.
+# ---------------------------------------------------------------------------
+
+
+def test_repair_skipped_when_repair_prompt_exceeds_context():
+    """Tight context window: initial prompt (small user message)
+    fits, but the repair prompt — which prepends instructions,
+    repeats the schema, and quotes the failed output — exceeds the
+    cap. Pre-#267b this surfaced as ``502
+    strict_repair_engine_failure``. Post-fix, the route must SKIP
+    the retry and return the ORIGINAL ``422 json_schema_violation``
+    envelope so the client sees a deterministic outcome.
+
+    Concretely:
+      * status_code == 422 (NOT 502)
+      * envelope code == "json_schema_violation"
+      * attempts == 1 (single generation, no retry)
+      * engine.chat called exactly once (the initial attempt)
+      * strict_repairs_skipped_context_overflow_total ticks by 1
+      * strict_repairs_attempted_total does NOT tick (no retry
+        was attempted)
+    """
+    # Sizing (4 chars/token stub tokenizer):
+    #   * INITIAL prompt (injected JSON system + user msg) = ~116 tokens.
+    #     With ``max_tokens=64`` → requested_total = 180 ≤ 256 → fits.
+    #   * REPAIR prompt (repair instructions + schema dup + failed
+    #     output quote + user retry) = ~302 tokens. With
+    #     ``max_tokens=64`` → requested_total = 366 > 256 → fails.
+    # 256 is the cleanest "initial passes, repair fails" cap.
+    client, engine = _client(body=_VIOLATING_BODY, max_position_embeddings=256)
+
+    resp = client.post("/v1/chat/completions", json=_payload())
+    # Critical: NOT 502.
+    assert resp.status_code == 422, (
+        f"expected 422 (deterministic validation outcome), got {resp.status_code}: "
+        f"{resp.text}"
+    )
+    body = resp.json()
+    assert body["error"]["code"] == "json_schema_violation"
+    assert body["error"]["type"] == "validation_error"
+    details = body["error"]["details"]
+    # Only ONE generation attempt because the repair was skipped.
+    assert details["attempts"] == 1
+    # The original validation failure (NOT the made-up
+    # ``initial_failure`` payload from the 502 path) is preserved.
+    assert details.get("reason") == "schema_violation"
+
+    # Engine MUST NOT have been called a second time.
+    assert len(engine.chat_calls) == 1, (
+        f"repair was skipped → expected 1 chat call, got {len(engine.chat_calls)}"
+    )
+
+    snap = response_format_metrics.snapshot()
+    # Skip counter ticked exactly once.
+    assert snap["strict_repairs_skipped_context_overflow_total"] == 1, snap
+    # Attempt counter did NOT tick — we never called the engine for the retry.
+    assert snap["strict_repairs_attempted_total"] == 0, snap
+    # The violation still ticks because the client sees a 422.
+    assert snap["strict_violations_total"] == 1, snap
+
+
+# ---------------------------------------------------------------------------
+# Test 3 — edge: initial barely fits, repair is exactly one token
+# over → skip cleanly with the same 422 surface and counter.
+# ---------------------------------------------------------------------------
+
+
+def test_repair_skipped_at_exact_one_token_overflow():
+    """Edge of the gate: pick a context window such that the
+    initial prompt fits (with room for ``max_tokens=64``
+    completion) but the repair prompt — at ``count_prompt_tokens``
+    + completion budget — is exactly one token over the cap.
+
+    The boundary is checked with ``<=`` (request <= max_context),
+    so "exactly one over" must fail cleanly. We do NOT need to
+    compute the exact token count — we ratchet the cap up to a
+    value that we KNOW the initial passes but the repair fails on,
+    and we assert the same observable contract as Test 2:
+
+      * 422 (NOT 502)
+      * single chat call
+      * skip counter == 1, attempt counter == 0
+
+    This is the "one token over" boundary because we already
+    proved (Test 1) that a much-larger cap allows the repair, and
+    we now sit at the smallest cap that still excludes the repair
+    prompt. Concretely: 128 tokens is tight enough that the
+    several-hundred-character repair prompt (instructions +
+    schema + failed-output quote) at 4 chars/token cannot fit.
+    """
+    # Sizing math (4 chars/token stub tokenizer):
+    #   * REPAIR prompt tokens (concat of all repair messages) = 302.
+    #   * ``max_tokens=64`` completion budget.
+    #   * ``requested_total = 302 + 64 = 366``.
+    # The gate's check is ``requested_total <= max_context``. Setting
+    # ``max_position_embeddings=365`` puts the repair exactly one
+    # token over the cap — boundary case. The initial prompt
+    # (~116+64=180 tokens) still fits trivially.
+    client, engine = _client(body=_VIOLATING_BODY, max_position_embeddings=365)
+
+    resp = client.post("/v1/chat/completions", json=_payload())
+    assert resp.status_code == 422, resp.text
+    body = resp.json()
+    assert body["error"]["code"] == "json_schema_violation"
+    details = body["error"]["details"]
+    assert details["attempts"] == 1
+    assert len(engine.chat_calls) == 1
+
+    snap = response_format_metrics.snapshot()
+    assert snap["strict_repairs_skipped_context_overflow_total"] == 1, snap
+    assert snap["strict_repairs_attempted_total"] == 0, snap
+
+
+# ---------------------------------------------------------------------------
+# Bonus — pin the helper's permissive-skip contract.
+# ---------------------------------------------------------------------------
+
+
+def test_repair_fits_helper_returns_true_when_engine_is_mllm():
+    """``repair_messages_fit_context`` is intentionally permissive
+    on the MLLM path — same as
+    ``enforce_context_length_for_messages``. The MLLM scheduler
+    handles its own context accounting (multimodal token costs are
+    not visible to the text-only tokenizer), so the helper returns
+    ``True`` and lets the engine surface its own error if the prompt
+    really is too large.
+
+    This pins that contract so a future "tighten the MLLM path"
+    refactor doesn't accidentally also tighten the repair gate and
+    introduce a regression on the multimodal surface.
+    """
+    from vllm_mlx.service.helpers import repair_messages_fit_context
+
+    class _MLLM:
+        is_mllm = True
+
+    assert repair_messages_fit_context(_MLLM(), [{"role": "user", "content": "x"}])
+
+
+def test_repair_fits_helper_returns_true_when_build_prompt_missing():
+    """If the engine doesn't expose ``build_prompt`` (route stub,
+    half-loaded engine) the helper cannot compute the prompt size
+    and falls through to ``True`` — exact mirror of the
+    permissive-skip path in
+    ``enforce_context_length_for_messages``. The downstream
+    scheduler's own validation still applies.
+    """
+    from vllm_mlx.service.helpers import repair_messages_fit_context
+
+    class _NoBuildPrompt:
+        is_mllm = False
+
+    assert repair_messages_fit_context(
+        _NoBuildPrompt(), [{"role": "user", "content": "x"}]
+    )

--- a/tests/test_r12_h06_repair_context_guard.py
+++ b/tests/test_r12_h06_repair_context_guard.py
@@ -39,7 +39,6 @@ from vllm_mlx.engine.base import GenerationOutput
 from vllm_mlx.middleware.exception_handlers import install_exception_handlers
 from vllm_mlx.routes.chat import router as chat_router
 
-
 # ---------------------------------------------------------------------------
 # Stubs — modelled after the constraint-matrix file but with a real
 # tokenizer + a tunable max-context window so we can hit the H-06
@@ -206,9 +205,7 @@ def test_repair_runs_when_both_initial_and_repair_fit_context():
     # 1 048 576 tokens — comfortably larger than the repair prompt
     # (instructions + schema + ~50 char failed output ≈ a few
     # hundred tokens at 4 chars/token).
-    client, engine = _client(
-        body=_VIOLATING_BODY, max_position_embeddings=1_048_576
-    )
+    client, engine = _client(body=_VIOLATING_BODY, max_position_embeddings=1_048_576)
 
     resp = client.post("/v1/chat/completions", json=_payload())
     assert resp.status_code == 422, resp.text

--- a/tests/test_r12_h06_repair_context_guard.py
+++ b/tests/test_r12_h06_repair_context_guard.py
@@ -146,6 +146,35 @@ def _reset_metrics_between_tests():
     response_format_metrics.reset_for_tests()
 
 
+@pytest.fixture
+def _rate_limiter_state():
+    """Snapshot + restore the global ``rate_limiter`` state for tests
+    that mount ``/v1/responses``.
+
+    The /v1/responses router is gated by the global ``rate_limiter``;
+    disabling it without restoring leaks state into later tests in the
+    same pytest process — codex pr_validate r1 BLOCKING flagged that
+    pre-fix the responses tests in this file would silently fail or
+    pass downstream tests like
+    ``test_no_routing_shaped_rapid_mlx_env_vars`` based purely on
+    pytest collection order. Mirrors the same fixture pattern in
+    ``tests/test_response_format_json_schema_strict.py``.
+    """
+    from vllm_mlx.middleware.auth import rate_limiter
+
+    saved_enabled = rate_limiter.enabled
+    saved_rpm = rate_limiter.requests_per_minute
+    saved_requests = dict(rate_limiter._requests)
+    rate_limiter.enabled = False
+    rate_limiter.requests_per_minute = 60
+    rate_limiter._requests.clear()
+    yield rate_limiter
+    rate_limiter.enabled = saved_enabled
+    rate_limiter.requests_per_minute = saved_rpm
+    rate_limiter._requests.clear()
+    rate_limiter._requests.update(saved_requests)
+
+
 def _client(*, body: str, max_position_embeddings: int):
     engine = _StubEngine(body=body, max_position_embeddings=max_position_embeddings)
     cfg = reset_config()
@@ -166,21 +195,18 @@ def _responses_client(*, body: str, max_position_embeddings: int):
     (``service.helpers.repair_messages_fit_context``), so we exercise
     the responses surface end-to-end to make sure the wiring at
     ``responses.py:963`` is identical to ``chat.py``.
-    """
-    from vllm_mlx.middleware.auth import rate_limiter
 
+    Callers MUST hold the ``_rate_limiter_state`` fixture so the
+    global rate-limiter is restored on teardown — otherwise this
+    function disables it and never re-enables, polluting later tests
+    in the same pytest process (pr_validate r1 BLOCKING).
+    """
     engine = _StubEngine(body=body, max_position_embeddings=max_position_embeddings)
     cfg = reset_config()
     cfg.engine = engine
     cfg.model_name = "test-model"
     cfg.model_registry = None
     cfg.no_thinking = True
-
-    # /v1/responses is gated by the global rate-limiter; the strict
-    # repair-overflow test file pins counter behaviour and must not
-    # be perturbed by 429s.
-    rate_limiter.enabled = False
-    rate_limiter._requests.clear()
 
     app = FastAPI()
     install_exception_handlers(app)
@@ -440,7 +466,9 @@ def test_repair_fits_helper_returns_true_when_build_prompt_missing():
 # ---------------------------------------------------------------------------
 
 
-def test_responses_repair_skipped_when_repair_prompt_exceeds_context():
+def test_responses_repair_skipped_when_repair_prompt_exceeds_context(
+    _rate_limiter_state,
+):
     """``/v1/responses`` parity for Test 2 (chat-side).
 
     Tight context window: the initial prompt fits but the post-build
@@ -500,7 +528,9 @@ def test_responses_repair_skipped_when_repair_prompt_exceeds_context():
     assert snap["strict_violations_total"] == 1, snap
 
 
-def test_responses_repair_runs_when_both_initial_and_repair_fit_context():
+def test_responses_repair_runs_when_both_initial_and_repair_fit_context(
+    _rate_limiter_state,
+):
     """``/v1/responses`` parity for Test 1 (chat-side).
 
     Sanity-check the responses surface on the HAPPY path: with a

--- a/vllm_mlx/api/response_format_metrics.py
+++ b/vllm_mlx/api/response_format_metrics.py
@@ -32,6 +32,7 @@ _strict_requests_total = 0
 _strict_violations_total = 0
 _strict_repairs_attempted_total = 0
 _strict_repairs_succeeded_total = 0
+_strict_repairs_skipped_context_overflow_total = 0
 
 
 def incr_strict_request() -> None:
@@ -84,6 +85,27 @@ def incr_strict_repair_success() -> None:
         _strict_repairs_succeeded_total += 1
 
 
+def incr_strict_repair_skipped_context_overflow() -> None:
+    """Increment the strict-mode repair-skip counter (H-06 #267b).
+
+    Ticks when the route was about to re-call the engine for the
+    R12-4 repair retry but the post-build repair prompt (which
+    prepends repair instructions, repeats the schema, and includes
+    up to 4 KiB of the failed output) would have exceeded the
+    engine's context window. The route skips the retry and surfaces
+    the ORIGINAL 422 ``json_schema_violation`` envelope — not a 502
+    — so the client sees a deterministic validation outcome instead
+    of an opaque server-side context-overflow.
+
+    Operators alert on a non-zero rate as a signal that the repair
+    prompt template + failed-output budget is too large for the
+    deployed model's context window.
+    """
+    global _strict_repairs_skipped_context_overflow_total
+    with _lock:
+        _strict_repairs_skipped_context_overflow_total += 1
+
+
 def snapshot() -> dict[str, int]:
     """Return a consistent snapshot of all counters for ``/metrics``."""
     with _lock:
@@ -92,6 +114,9 @@ def snapshot() -> dict[str, int]:
             "strict_violations_total": _strict_violations_total,
             "strict_repairs_attempted_total": _strict_repairs_attempted_total,
             "strict_repairs_succeeded_total": _strict_repairs_succeeded_total,
+            "strict_repairs_skipped_context_overflow_total": (
+                _strict_repairs_skipped_context_overflow_total
+            ),
         }
 
 
@@ -103,8 +128,10 @@ def reset_for_tests() -> None:
     """
     global _strict_requests_total, _strict_violations_total
     global _strict_repairs_attempted_total, _strict_repairs_succeeded_total
+    global _strict_repairs_skipped_context_overflow_total
     with _lock:
         _strict_requests_total = 0
         _strict_violations_total = 0
         _strict_repairs_attempted_total = 0
         _strict_repairs_succeeded_total = 0
+        _strict_repairs_skipped_context_overflow_total = 0

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -29,6 +29,7 @@ from ..api.models import (
 )
 from ..api.response_format_metrics import (
     incr_strict_repair_attempt,
+    incr_strict_repair_skipped_context_overflow,
     incr_strict_repair_success,
     incr_strict_request,
     incr_strict_violation,
@@ -95,6 +96,7 @@ from ..service.helpers import (
     enable_thinking_warning_header,
     enforce_context_length_for_messages,
     get_engine,
+    repair_messages_fit_context,
 )
 
 logger = logging.getLogger(__name__)
@@ -2797,13 +2799,6 @@ async def _create_chat_completion_impl(
         ok, failure_details = validate_and_envelope(output.text or "", json_schema)
         attempts = 1
         if not ok and repair_retry_enabled():
-            incr_strict_repair_attempt()
-            attempts = 2
-            logger.info(
-                "R12-4 strict json_schema first attempt failed "
-                "validation (%s); attempting single repair retry.",
-                failure_details.get("reason") if failure_details else "?",
-            )
             repair_messages = build_repair_messages(
                 messages,
                 output.text or "",
@@ -2833,58 +2828,95 @@ async def _create_chat_completion_impl(
                 "top_logprobs",
             ):
                 repair_kwargs.pop(_k, None)
-            try:
-                repair_output = await _wait_with_disconnect(
-                    engine.chat(messages=repair_messages, **repair_kwargs),
-                    raw_request,
-                    timeout=timeout,
-                )
-            except HTTPException:
-                raise
-            except (TimeoutError, asyncio.TimeoutError, asyncio.CancelledError):
-                raise
-            except Exception as repair_err:
-                # Codex r1 #3: a non-timeout, non-disconnect engine
-                # exception during the repair turn is a SERVER failure
-                # (the engine couldn't produce ANY output for the
-                # retry), NOT a client schema-validation failure.
-                # Pre-fix, this branch swallowed the exception and
-                # surfaced a 422 ``json_schema_violation`` using the
-                # ORIGINAL validation failure — misleading the client
-                # into believing their schema was the problem when the
-                # actual fault was a server-side generation error.
-                # Surface as 502 with the engine-error shape so the
-                # operator sees the real cause; the original validation
-                # failure is preserved in ``details.initial_failure``
-                # for postmortem context.
+            # H-06 #267b: re-check the context-length gate AGAINST the
+            # POST-BUILD repair prompt. ``build_repair_messages`` builds a
+            # strictly larger prompt than the initial request (prepended
+            # instructions, repeated schema, up to 4 KiB of failed output),
+            # so a request that passed the initial gate can blow context
+            # only on the repair attempt — pre-fix that surfaced as the
+            # opaque ``502 strict_repair_engine_failure`` instead of a
+            # deterministic ``422 json_schema_violation``. The helper
+            # mirrors ``enforce_context_length_for_messages`` and is
+            # centralized so chat + responses share one gate.
+            _repair_fits = repair_messages_fit_context(
+                engine,
+                repair_messages,
+                tools=None,
+                max_tokens=repair_kwargs.get("max_tokens"),
+            )
+            repair_output = None
+            if not _repair_fits:
+                incr_strict_repair_skipped_context_overflow()
                 logger.warning(
-                    "R12-4 strict json_schema repair retry raised %s: %s; "
-                    "surfacing as 502 (server-side generation failure, "
-                    "NOT a schema-validation contract breach).",
-                    type(repair_err).__name__,
-                    repair_err,
+                    "R12-4 strict json_schema repair retry SKIPPED: "
+                    "post-build repair prompt would exceed model context "
+                    "window. Surfacing the ORIGINAL 422 json_schema_"
+                    "violation envelope instead of attempting a retry "
+                    "that would either 502 or truncate."
                 )
-                raise HTTPException(
-                    status_code=502,
-                    detail={
-                        "error": {
-                            "message": (
-                                "Strict json_schema repair retry failed: the "
-                                f"engine raised {type(repair_err).__name__} "
-                                "during the second generation attempt. The "
-                                "initial output had also failed schema "
-                                "validation; investigate server logs."
-                            ),
-                            "type": "api_error",
-                            "code": "strict_repair_engine_failure",
-                            "param": "response_format.json_schema",
-                            "details": {
-                                "initial_failure": failure_details,
-                                "repair_exception": type(repair_err).__name__,
-                            },
-                        }
-                    },
-                ) from repair_err
+                # Fall through to the existing ``if not ok:`` block
+                # below — ``attempts == 1`` so the envelope reports the
+                # single attempt the client actually saw.
+            else:
+                incr_strict_repair_attempt()
+                attempts = 2
+                logger.info(
+                    "R12-4 strict json_schema first attempt failed "
+                    "validation (%s); attempting single repair retry.",
+                    failure_details.get("reason") if failure_details else "?",
+                )
+                try:
+                    repair_output = await _wait_with_disconnect(
+                        engine.chat(messages=repair_messages, **repair_kwargs),
+                        raw_request,
+                        timeout=timeout,
+                    )
+                except HTTPException:
+                    raise
+                except (TimeoutError, asyncio.TimeoutError, asyncio.CancelledError):
+                    raise
+                except Exception as repair_err:
+                    # Codex r1 #3: a non-timeout, non-disconnect engine
+                    # exception during the repair turn is a SERVER failure
+                    # (the engine couldn't produce ANY output for the
+                    # retry), NOT a client schema-validation failure.
+                    # Pre-fix, this branch swallowed the exception and
+                    # surfaced a 422 ``json_schema_violation`` using the
+                    # ORIGINAL validation failure — misleading the client
+                    # into believing their schema was the problem when the
+                    # actual fault was a server-side generation error.
+                    # Surface as 502 with the engine-error shape so the
+                    # operator sees the real cause; the original validation
+                    # failure is preserved in ``details.initial_failure``
+                    # for postmortem context.
+                    logger.warning(
+                        "R12-4 strict json_schema repair retry raised %s: %s; "
+                        "surfacing as 502 (server-side generation failure, "
+                        "NOT a schema-validation contract breach).",
+                        type(repair_err).__name__,
+                        repair_err,
+                    )
+                    raise HTTPException(
+                        status_code=502,
+                        detail={
+                            "error": {
+                                "message": (
+                                    "Strict json_schema repair retry failed: the "
+                                    f"engine raised {type(repair_err).__name__} "
+                                    "during the second generation attempt. The "
+                                    "initial output had also failed schema "
+                                    "validation; investigate server logs."
+                                ),
+                                "type": "api_error",
+                                "code": "strict_repair_engine_failure",
+                                "param": "response_format.json_schema",
+                                "details": {
+                                    "initial_failure": failure_details,
+                                    "repair_exception": type(repair_err).__name__,
+                                },
+                            }
+                        },
+                    ) from repair_err
             if repair_output is not None:
                 ok2, failure2 = validate_and_envelope(
                     repair_output.text or "", json_schema

--- a/vllm_mlx/routes/metrics.py
+++ b/vllm_mlx/routes/metrics.py
@@ -190,6 +190,7 @@ def _render_response_format_counters() -> list[str]:
             "strict_violations_total": 0,
             "strict_repairs_attempted_total": 0,
             "strict_repairs_succeeded_total": 0,
+            "strict_repairs_skipped_context_overflow_total": 0,
         }
     out: list[str] = []
     out.extend(
@@ -250,6 +251,24 @@ def _render_response_format_counters() -> list[str]:
                 "client's schema is too restrictive for the model."
             ),
             int(rf_stats.get("strict_repairs_succeeded_total", 0)),
+        )
+    )
+    out.extend(
+        _fmt_metric(
+            "rapid_mlx_strict_repair_skipped_context_overflow_total",
+            "counter",
+            (
+                "H-06 #267b strict-mode repair-retry skips. Ticks when "
+                "the post-build repair prompt (instructions + schema + "
+                "up to 4 KiB of failed output) would have exceeded the "
+                "engine's context window. The route skips the retry and "
+                "surfaces the ORIGINAL 422 json_schema_violation envelope "
+                "instead of 502 strict_repair_engine_failure, so clients "
+                "see a deterministic validation outcome. A non-zero rate "
+                "signals the repair prompt template is too large for the "
+                "deployed model's context window."
+            ),
+            int(rf_stats.get("strict_repairs_skipped_context_overflow_total", 0)),
         )
     )
     return out

--- a/vllm_mlx/routes/metrics.py
+++ b/vllm_mlx/routes/metrics.py
@@ -255,7 +255,7 @@ def _render_response_format_counters() -> list[str]:
     )
     out.extend(
         _fmt_metric(
-            "rapid_mlx_strict_repair_skipped_context_overflow_total",
+            "rapid_mlx_response_format_strict_repairs_skipped_context_overflow_total",
             "counter",
             (
                 "H-06 #267b strict-mode repair-retry skips. Ticks when "

--- a/vllm_mlx/routes/responses.py
+++ b/vllm_mlx/routes/responses.py
@@ -32,6 +32,7 @@ from ..api.models import (
 )
 from ..api.response_format_metrics import (
     incr_strict_repair_attempt,
+    incr_strict_repair_skipped_context_overflow,
     incr_strict_repair_success,
     incr_strict_request,
     incr_strict_violation,
@@ -95,6 +96,7 @@ from ..service.helpers import (
     build_extended_sampling_kwargs,
     enforce_context_length_for_messages,
     get_engine,
+    repair_messages_fit_context,
 )
 
 logger = logging.getLogger(__name__)
@@ -939,13 +941,6 @@ async def _non_stream(
         ok, failure_details = validate_and_envelope(output.text or "", _strict_schema)
         attempts = 1
         if not ok and repair_retry_enabled():
-            incr_strict_repair_attempt()
-            attempts = 2
-            logger.info(
-                "R12-4 strict json_schema first attempt failed on "
-                "/v1/responses (%s); attempting repair retry.",
-                (failure_details or {}).get("reason", "?"),
-            )
             repair_messages = build_repair_messages(
                 messages,
                 output.text or "",
@@ -955,53 +950,90 @@ async def _non_stream(
             repair_kwargs = dict(chat_kwargs)
             for _k in ("tools", "tool_choice", "logprobs", "top_logprobs"):
                 repair_kwargs.pop(_k, None)
-            try:
-                repair_output = await _wait_with_disconnect(
-                    engine.chat(messages=repair_messages, **repair_kwargs),
-                    request,
-                    timeout=timeout,
-                )
-            except HTTPException:
-                raise
-            except (TimeoutError, asyncio.TimeoutError, asyncio.CancelledError):
-                raise
-            except Exception as repair_err:
-                # Codex r1 #4 parity with chat.py: a non-timeout,
-                # non-disconnect engine exception during the repair
-                # turn is a SERVER failure, not a client schema-
-                # validation failure. Surface as 502 instead of
-                # swallowing into a 422 ``json_schema_violation``
-                # that would mislead the client into thinking their
-                # schema was the problem.
+            # H-06 #267b: re-check context-length AGAINST the post-build
+            # repair prompt. ``build_repair_messages`` builds a strictly
+            # larger prompt than the initial request (prepended
+            # instructions, repeated schema, up to 4 KiB of failed
+            # output), so a request that passed the initial gate can
+            # blow context only on the repair attempt — pre-fix that
+            # surfaced as the opaque ``502 strict_repair_engine_failure``
+            # instead of a deterministic ``422 json_schema_violation``.
+            # Centralized helper shared with chat.py keeps the gate
+            # logic from drifting between the two surfaces.
+            _repair_fits = repair_messages_fit_context(
+                engine,
+                repair_messages,
+                tools=None,
+                max_tokens=repair_kwargs.get("max_tokens"),
+            )
+            repair_output = None
+            if not _repair_fits:
+                incr_strict_repair_skipped_context_overflow()
                 logger.warning(
-                    "R12-4 /v1/responses strict repair retry raised %s: %s; "
-                    "surfacing as 502 (server-side generation failure, "
-                    "NOT a schema-validation contract breach).",
-                    type(repair_err).__name__,
-                    repair_err,
+                    "R12-4 /v1/responses strict json_schema repair retry "
+                    "SKIPPED: post-build repair prompt would exceed model "
+                    "context window. Surfacing the ORIGINAL 422 "
+                    "json_schema_violation envelope instead of attempting "
+                    "a retry that would either 502 or truncate."
                 )
-                raise HTTPException(
-                    status_code=502,
-                    detail={
-                        "error": {
-                            "message": (
-                                "Strict json_schema repair retry failed on "
-                                "/v1/responses: the engine raised "
-                                f"{type(repair_err).__name__} during the "
-                                "second generation attempt. The initial "
-                                "output had also failed schema validation; "
-                                "investigate server logs."
-                            ),
-                            "type": "api_error",
-                            "code": "strict_repair_engine_failure",
-                            "param": "text.format",
-                            "details": {
-                                "initial_failure": failure_details,
-                                "repair_exception": type(repair_err).__name__,
-                            },
-                        }
-                    },
-                ) from repair_err
+                # Fall through to the existing ``if not ok:`` below with
+                # ``attempts == 1`` so the envelope reflects the single
+                # generation attempt the client actually saw.
+            else:
+                incr_strict_repair_attempt()
+                attempts = 2
+                logger.info(
+                    "R12-4 strict json_schema first attempt failed on "
+                    "/v1/responses (%s); attempting repair retry.",
+                    (failure_details or {}).get("reason", "?"),
+                )
+                try:
+                    repair_output = await _wait_with_disconnect(
+                        engine.chat(messages=repair_messages, **repair_kwargs),
+                        request,
+                        timeout=timeout,
+                    )
+                except HTTPException:
+                    raise
+                except (TimeoutError, asyncio.TimeoutError, asyncio.CancelledError):
+                    raise
+                except Exception as repair_err:
+                    # Codex r1 #4 parity with chat.py: a non-timeout,
+                    # non-disconnect engine exception during the repair
+                    # turn is a SERVER failure, not a client schema-
+                    # validation failure. Surface as 502 instead of
+                    # swallowing into a 422 ``json_schema_violation``
+                    # that would mislead the client into thinking their
+                    # schema was the problem.
+                    logger.warning(
+                        "R12-4 /v1/responses strict repair retry raised %s: %s; "
+                        "surfacing as 502 (server-side generation failure, "
+                        "NOT a schema-validation contract breach).",
+                        type(repair_err).__name__,
+                        repair_err,
+                    )
+                    raise HTTPException(
+                        status_code=502,
+                        detail={
+                            "error": {
+                                "message": (
+                                    "Strict json_schema repair retry failed on "
+                                    "/v1/responses: the engine raised "
+                                    f"{type(repair_err).__name__} during the "
+                                    "second generation attempt. The initial "
+                                    "output had also failed schema validation; "
+                                    "investigate server logs."
+                                ),
+                                "type": "api_error",
+                                "code": "strict_repair_engine_failure",
+                                "param": "text.format",
+                                "details": {
+                                    "initial_failure": failure_details,
+                                    "repair_exception": type(repair_err).__name__,
+                                },
+                            }
+                        },
+                    ) from repair_err
             if repair_output is not None:
                 ok2, failure2 = validate_and_envelope(
                     repair_output.text or "", _strict_schema

--- a/vllm_mlx/service/helpers.py
+++ b/vllm_mlx/service/helpers.py
@@ -3677,6 +3677,70 @@ def enforce_context_length_for_messages(
     return prompt_tokens
 
 
+def repair_messages_fit_context(
+    engine,
+    repair_messages: list,
+    *,
+    tools: list | None = None,
+    max_tokens: int | None = None,
+) -> bool:
+    """Re-check the context-length gate for the R12-4 strict-mode
+    repair-retry prompt (H-06 #267b).
+
+    Codex review on PR #878 surfaced that ``build_repair_messages``
+    builds a strictly LARGER prompt than the initial request — it
+    prepends repair instructions, repeats the schema, and includes
+    up to 4 KiB of the failed output. A request that passed the
+    initial ``enforce_context_length_for_messages`` gate can therefore
+    blow the context window only on the repair attempt and surface
+    as ``502 strict_repair_engine_failure`` instead of a deterministic
+    422 validation outcome.
+
+    This helper mirrors :func:`enforce_context_length_for_messages`
+    but RETURNS a boolean (``True`` = fits, ``False`` = does not
+    fit) rather than raising. The caller skips the retry when this
+    returns ``False`` and returns the ORIGINAL 422 envelope it would
+    have returned without the retry — so the client always sees a
+    consistent json-schema-violation outcome.
+
+    On permissive-skip paths (MLLM engine, missing ``build_prompt``,
+    empty rendered prompt, tokenizer-returned-zero) this returns
+    ``True`` to preserve the existing behavior — the initial-request
+    gate also skips those paths so the repair gate should not be
+    stricter than the initial one. The strict-mode + tools combo is
+    already rejected upstream by ``strict_with_tools_unsupported``,
+    so for repair-prompt accounting the ``tools`` argument is
+    effectively always ``None``; we still thread it through for
+    contract symmetry with the initial gate.
+
+    Used by ``routes/chat.py`` and ``routes/responses.py`` so the
+    same gate logic is applied at both call sites and cannot drift.
+    """
+    if getattr(engine, "is_mllm", False):
+        return True
+    build_prompt = getattr(engine, "build_prompt", None)
+    if build_prompt is None:
+        return True
+    try:
+        prompt = build_prompt(repair_messages, tools=tools)
+    except Exception:
+        # If the repair prompt can't even be rendered, we can't make
+        # a useful "fits" judgement — defer to the engine error path
+        # (the existing 502 ``strict_repair_engine_failure`` handler
+        # already covers an unrenderable repair turn). Return ``True``
+        # so the existing surface is preserved; do NOT raise here.
+        return True
+    if not prompt:
+        return True
+    prompt_tokens = count_prompt_tokens(engine, prompt)
+    if prompt_tokens <= 0:
+        return True
+    max_context = get_model_max_context(engine)
+    completion = int(max_tokens) if max_tokens else 0
+    requested_total = int(prompt_tokens) + max(0, completion)
+    return requested_total <= max_context
+
+
 def enforce_context_length_for_prompt(
     engine,
     prompt,


### PR DESCRIPTION
## Why

The strict_json_schema repair retry could turn a deterministic 422 (json_schema_violation) into an opaque 502 (strict_repair_engine_failure) whenever the repair prompt — instructions + duplicated schema + up to 4 KiB of failed output — pushed the conversation over the model's context window. The initial request passed the context gate, but the repair attempt silently bypassed it. This PR closes that gap by re-running the context-length check before the repair retry, so we either repair cleanly or fall back to the existing 422 envelope. Refs #267.

## Repro

Boot rapid-mlx with a tiny-context model (e.g. 2 048-tok ctx), then construct a request that:

1. Passes the initial ``enforce_context_length_for_messages`` gate (small user prompt + injected JSON schema system instruction).
2. Produces invalid JSON (e.g. schema requires ``minimum: 18`` but model emits ``{\"age\": 5}``).
3. Sits in the narrow band where the **repair** prompt — instructions + repeated schema + up to 4 KiB of failed output — pushes the total over the context window.

Pre-fix → ``502 strict_repair_engine_failure``.
A slightly smaller version of the same request → clean ``422 json_schema_violation``.

## Root cause

``vllm_mlx/routes/chat.py:2806`` and ``vllm_mlx/routes/responses.py:899`` build a strictly LARGER prompt via ``build_repair_messages(...)`` (system-injected instructions, duplicated schema, JSON-encoded failed output up to 4 KB) and then call ``engine.chat`` **without** running the context-length gate the initial request passed. Codex review on PR #878 surfaced that this turned an inherent contract limit into an opaque 502.

## Systematic fix

1. **Centralized helper.** New ``service.helpers.repair_messages_fit_context(engine, messages, *, tools, max_tokens)`` mirrors ``enforce_context_length_for_messages`` but RETURNS a bool instead of raising. Tools / MLLM / missing ``build_prompt`` permissive-skip paths preserved.
2. **Single gate, both routes.** ``chat.py`` and ``responses.py`` each call the helper AFTER ``build_repair_messages`` and BEFORE ``engine.chat``. The two surfaces share the gate so they cannot drift.
3. **Skip → original 422.** When the repair won't fit, the route skips the retry, leaves ``attempts == 1`` and the original ``failure_details`` intact, and falls through to the existing ``if not ok:`` 422 envelope. **No new error code.**
4. **New counter.** ``rapid_mlx_strict_repair_skipped_context_overflow_total`` (also exposed in ``snapshot()`` and ``/metrics``) so operators can alert when the repair prompt template is too large for the deployed model.

## Test plan

- [x] All 111 existing ``test_response_format_json_schema_strict.py`` + ``test_r12_4_strict_json_schema_*`` tests pass unchanged.
- [x] New ``tests/test_r12_h06_repair_context_guard.py`` adds 3 boundary tests:
  - [x] Initial fits AND repair fits → repair runs, ``attempts == 2``, 2 chat calls, skip counter == 0.
  - [x] Initial fits, repair does NOT fit → skip, 422 (NOT 502), ``attempts == 1``, 1 chat call, skip counter == 1, attempt counter == 0.
  - [x] Edge: repair exactly one token over the cap → same clean skip.
- [x] 2 helper unit tests pin permissive-skip paths (MLLM engine, missing ``build_prompt``).
- [x] Full suite: 9 733 passed, 29 skipped, 2 failures are unrelated server-required event-loop tests.

## Reference

Codex review on PR #878:
> The strict JSON schema repair retry builds a larger prompt by prepending repair instructions, repeating the schema, and including up to 4 KB of failed output, but it is not rechecked against the context-length guard before calling the engine. A request can pass the initial context check and then fail or overrun only on the repair attempt, surfacing as ``502 strict_repair_engine_failure`` rather than a deterministic validation outcome.
