### PR TITLE
fix(tool-parser): prevent deepseek_v3 binding to non-V3 Qwen2 distills + warn on misbind (S-1 verification)

### DIFF
--- a/tests/test_model_auto_config.py
+++ b/tests/test_model_auto_config.py
@@ -1135,3 +1135,34 @@ class TestWarnMisboundDeepseekV3Parser:
         assert msg is not None
         assert "Auto-detect would pick 'deepseek'" in msg
         assert "Drop the explicit" in msg
+
+    # Codex r5 follow-up nit: even when auto-detect's pick is a
+    # DIFFERENT V3-family parser than the one bound (so the suggestion
+    # would have fired under the r5 same-parser-only gate), suppress
+    # it for out-of-lineage models because auto-detect was fooled by a
+    # parent dir — endorsing a different-but-still-V3 parser would
+    # nudge the user toward another wrong-family choice.
+    def test_no_suggestion_when_auto_picks_other_v3_for_out_of_lineage(self):
+        # Parent dir is ``DeepSeek-V3.1`` so auto-detect picks
+        # ``deepseek_v31``. User bound ``deepseek_v3``. Tail name is
+        # ``qwen-model`` — out-of-lineage. Even though auto-detect's
+        # pick differs from the bound parser, the suggestion must be
+        # suppressed (both V3-family picks would be wrong).
+        msg = warn_misbound_deepseek_v3_parser(
+            "/models/DeepSeek-V3.1/qwen-model", "deepseek_v3"
+        )
+        assert msg is not None
+        assert "Auto-detect would pick" not in msg
+        # The hermes-pinning remediation kicks in instead.
+        assert "hermes" in msg
+
+    # The cross-sub-family auto-detect suggestion MUST still fire on
+    # real V3-template checkpoints (template != None). Codex r5's
+    # original wins must not regress.
+    def test_cross_sub_family_suggestion_still_fires_on_real_v3_template(self):
+        msg = warn_misbound_deepseek_v3_parser(
+            "mlx-community/DeepSeek-R1-0528-Qwen3-8B-4bit", "deepseek_v31"
+        )
+        assert msg is not None
+        # Auto-detect correctly picks ``deepseek_v3`` for R1-0528.
+        assert "Auto-detect would pick 'deepseek_v3'" in msg

--- a/tests/test_model_auto_config.py
+++ b/tests/test_model_auto_config.py
@@ -1102,3 +1102,36 @@ class TestWarnMisboundDeepseekV3Parser:
             f"with {parser!r} must still warn — classifier must scope to "
             "the model-name component, not the full path."
         )
+
+    # Codex round-5 P2 regression: when auto-detect would ALSO pick a
+    # V3-family parser for the same path (because its regex still runs
+    # against the full path and the parent dir matches the family),
+    # surfacing "Auto-detect would pick 'deepseek_v3'" + "Drop the flag
+    # to let auto-detect choose" creates a contradiction — auto-detect
+    # would silently keep the same wrong parser. The warning must
+    # suppress the auto-detect suggestion in that case AND switch the
+    # remediation to "Pass --tool-call-parser hermes" (since dropping
+    # the flag wouldn't help).
+    def test_no_contradiction_when_auto_detect_also_misclassifies(self):
+        msg = warn_misbound_deepseek_v3_parser(
+            "/models/DeepSeek-V3/qwen-model", "deepseek_v3"
+        )
+        assert msg is not None
+        # No "Auto-detect would pick 'deepseek_v3'" — suppressed.
+        assert "Auto-detect would pick" not in msg
+        # No "drop the explicit ... flag to let auto-detect choose" —
+        # would silently keep the wrong parser. The replacement
+        # remediation pins to hermes.
+        assert "Drop the explicit" not in msg
+        assert "hermes" in msg
+
+    # Sanity check that the suggestion path still fires for the common
+    # case (non-V3-named parent, R1-Distill family, auto suggests the
+    # legacy ``deepseek`` parser).
+    def test_suggestion_still_fires_when_auto_picks_non_v3(self):
+        msg = warn_misbound_deepseek_v3_parser(
+            "mlx-community/DeepSeek-R1-Distill-Qwen-1.5B-4bit", "deepseek_v3"
+        )
+        assert msg is not None
+        assert "Auto-detect would pick 'deepseek'" in msg
+        assert "Drop the explicit" in msg

--- a/tests/test_model_auto_config.py
+++ b/tests/test_model_auto_config.py
@@ -990,14 +990,27 @@ class TestWarnMisboundDeepseekV3Parser:
 
     # Unknown models (no regex match) still get a warning when bound to
     # a V3-family parser, but the message degrades gracefully (no
-    # auto-detect suggestion).
+    # auto-detect suggestion, AND the "drop the flag" advice is
+    # replaced with an explicit hermes pin — codex r6 PR-validate NIT,
+    # because dropping the flag on an unknown model leaves the user
+    # with no tool parser at all).
     def test_warn_on_unknown_model_no_suggestion(self):
         msg = warn_misbound_deepseek_v3_parser(
             "brand-new-org/MysteryModel-2026-7B", "deepseek_v3"
         )
         assert msg is not None
         # No `auto-detect would pick 'X'` blurb when there's no match.
-        # The actionable nudge is still present (drop the flag).
+        assert "Auto-detect would pick" not in msg
+        # No "Drop the explicit ... flag" — auto-detect has nothing to
+        # fall back to. The remediation must explicitly recommend
+        # ``hermes``.
+        assert "Drop the explicit" not in msg
+        assert "hermes" in msg
+        # Must call out that auto-detect has no fallback so the user
+        # understands why the standard remediation doesn't apply.
+        assert "no fallback" in msg.lower() or "unknown" in msg.lower()
+        # Still mentions the bound parser so the user can locate the
+        # offending flag.
         assert "deepseek_v3" in msg
 
     # Codex round-2 P2 regression: when the user serves a built-in

--- a/tests/test_model_auto_config.py
+++ b/tests/test_model_auto_config.py
@@ -9,6 +9,7 @@ from vllm_mlx.model_auto_config import (
     format_profile_summary,
     format_profile_table,
     get_profile,
+    warn_misbound_deepseek_v3_parser,
 )
 
 
@@ -301,6 +302,41 @@ class TestDetectModelConfig:
         config = detect_model_config("deepseek-ai/DeepSeek-R1")
         assert config is not None
         assert config.tool_call_parser == "deepseek"
+        assert config.reasoning_parser == "deepseek_r1"
+
+    # R12-S1 (Sven r12 HIGH-1 verdict): DeepSeek-R1-Distill-* checkpoints
+    # are Qwen2 / Llama2-arch SFTs whose tokenizers do NOT carry the
+    # V3 fullwidth-pipe special tokens — they emit the V2-style envelope
+    # the legacy ``deepseek`` parser handles, NOT the V3 fenced-JSON
+    # envelope ``deepseek_v3`` expects. The regex ordering MUST keep
+    # these models on the legacy parser; if a future edit flipped them
+    # to ``deepseek_v3`` (because the family name still contains "r1"),
+    # Sven's HIGH-1 would re-surface as a default-config regression
+    # rather than a wrong-flag misbind.
+    @pytest.mark.parametrize(
+        "model_path",
+        [
+            "mlx-community/DeepSeek-R1-Distill-Qwen-1.5B-4bit",
+            "mlx-community/DeepSeek-R1-Distill-Qwen-7B-4bit",
+            "mlx-community/DeepSeek-R1-Distill-Qwen-14B-4bit",
+            "mlx-community/DeepSeek-R1-Distill-Qwen-32B-4bit",
+            "mlx-community/DeepSeek-R1-Distill-Llama-8B-4bit",
+            "mlx-community/DeepSeek-R1-Distill-Llama-70B-4bit",
+            "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B",
+            "deepseek-ai/DeepSeek-R1-Distill-Llama-8B",
+        ],
+    )
+    def test_deepseek_r1_distill_routes_to_legacy_parser(self, model_path):
+        config = detect_model_config(model_path)
+        assert config is not None
+        # MUST be the legacy ``deepseek`` parser, NOT ``deepseek_v3`` —
+        # the distills cannot emit the V3 wire shape.
+        assert config.tool_call_parser == "deepseek", (
+            f"{model_path}: tool_call_parser must be 'deepseek' (legacy), "
+            f"got {config.tool_call_parser!r}. R1-Distill family is "
+            "Qwen2/Llama2-arch SFT and cannot emit the V3 fenced-JSON "
+            "envelope. See Sven r12 dogfood HIGH-1 verdict (R12-S1)."
+        )
         assert config.reasoning_parser == "deepseek_r1"
 
     # DeepSeek V2.5 (and older non-R1) → legacy ``deepseek`` parser.
@@ -801,3 +837,131 @@ class TestGetProfile:
         cfg = get_profile("mystery-model", HybridStub())
         assert cfg.is_hybrid is True
         assert cfg.supports_spec_decode is False
+
+
+class TestWarnMisboundDeepseekV3Parser:
+    """R12-S1: cover the misbind-warning helper added in response to
+    Sven r12 dogfood HIGH-1. The auto-detect path already routes the
+    R1-distill family to the legacy ``deepseek`` parser (covered by
+    ``test_deepseek_r1_distill_routes_to_legacy_parser`` above); this
+    helper exists so an EXPLICIT override (``--tool-call-parser
+    deepseek_v3``) on a non-V3 model surfaces a loud startup warning
+    instead of silently shipping ``arguments="{}"`` tool calls.
+    """
+
+    # No warning when no parser is bound at all.
+    def test_no_warn_when_parser_unset(self):
+        assert (
+            warn_misbound_deepseek_v3_parser(
+                "mlx-community/DeepSeek-R1-Distill-Qwen-1.5B-4bit", None
+            )
+            is None
+        )
+
+    # No warning for non-V3 parsers (hermes, deepseek, llama, etc.) —
+    # the helper only fires on the V3-family parsers it knows about.
+    @pytest.mark.parametrize(
+        "parser",
+        [
+            "hermes",
+            "deepseek",
+            "deepseek_r1",
+            "llama",
+            "mistral",
+            "kimi",
+            "auto",
+        ],
+    )
+    def test_no_warn_for_non_v3_family_parsers(self, parser):
+        # Even on a model whose name would otherwise look suspicious to a
+        # naive substring matcher, the helper should not warn unless the
+        # bound parser is in the V3 family.
+        assert (
+            warn_misbound_deepseek_v3_parser(
+                "mlx-community/DeepSeek-R1-Distill-Qwen-1.5B-4bit", parser
+            )
+            is None
+        )
+
+    # In-spec: V3 / V3.1 / R1-0528 / V4 / V5 checkpoints DO emit the V3
+    # wire shape, so a deepseek_v3-family parser binding is legitimate.
+    # No warning.
+    @pytest.mark.parametrize(
+        "model_path,parser",
+        [
+            ("mlx-community/DeepSeek-R1-0528-Qwen3-8B-4bit", "deepseek_v3"),
+            ("mlx-community/DeepSeek-R1-0528-Qwen3-8B-4bit", "deepseek_r1_0528"),
+            ("deepseek-ai/DeepSeek-V3-0324", "deepseek_v3"),
+            ("mlx-community/DeepSeek-V3-0324-4bit", "deepseek_v3"),
+            ("deepseek-ai/DeepSeek-V3.1-0324", "deepseek_v31"),
+            ("mlx-community/DeepSeek-V3.1-MLX-4bit", "deepseek_v31"),
+            # Forward-cover V4 / V5 — same V3 template lineage. The
+            # helper should accept these without warning.
+            ("deepseek-ai/DeepSeek-V4", "deepseek_v3"),
+            ("mlx-community/DeepSeek-V5-MLX-4bit", "deepseek_v3"),
+        ],
+    )
+    def test_no_warn_for_real_v3_shape_models(self, model_path, parser):
+        assert warn_misbound_deepseek_v3_parser(model_path, parser) is None
+
+    # The Sven HIGH-1 repro: forcing deepseek_v3 on an R1-Distill (Qwen2
+    # arch) MUST surface a warning. Covers every common distill flavour
+    # (1.5B, 7B, 14B, 32B Qwen + 8B/70B Llama) and every V3-family
+    # parser alias the user might pick.
+    @pytest.mark.parametrize(
+        "model_path",
+        [
+            "mlx-community/DeepSeek-R1-Distill-Qwen-1.5B-4bit",
+            "mlx-community/DeepSeek-R1-Distill-Qwen-7B-4bit",
+            "mlx-community/DeepSeek-R1-Distill-Qwen-14B-4bit",
+            "mlx-community/DeepSeek-R1-Distill-Qwen-32B-4bit",
+            "mlx-community/DeepSeek-R1-Distill-Llama-8B-4bit",
+            "mlx-community/DeepSeek-R1-Distill-Llama-70B-4bit",
+            "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B",
+            "deepseek-ai/DeepSeek-R1-Distill-Llama-8B",
+        ],
+    )
+    @pytest.mark.parametrize(
+        "parser",
+        ["deepseek_v3", "deepseek_v31", "deepseek_r1_0528"],
+    )
+    def test_warn_on_r1_distill_misbind(self, model_path, parser):
+        msg = warn_misbound_deepseek_v3_parser(model_path, parser)
+        assert msg is not None
+        # Must name the offending flag and the model so the user can
+        # locate the misconfiguration without grepping the source.
+        assert parser in msg
+        assert model_path in msg
+        # Must point at the auto-detected suggestion (``deepseek`` for
+        # the R1-distill family) so the fix is one flag-flip away.
+        assert "deepseek" in msg
+        # Must mention the actionable remediation — drop the flag or
+        # switch to hermes for Qwen/Llama-arch SFTs.
+        assert "auto-detect" in msg.lower() or "hermes" in msg.lower()
+
+    # Also warn on V2.x and bare Qwen/Llama paths that someone might
+    # explicitly try to coerce to the V3 parser.
+    @pytest.mark.parametrize(
+        "model_path",
+        [
+            "mlx-community/DeepSeek-V2.5-4bit",
+            "mlx-community/Qwen3-0.6B-MLX-4bit",
+            "mlx-community/Meta-Llama-3.1-8B-Instruct-4bit",
+        ],
+    )
+    def test_warn_on_non_v3_explicit_override(self, model_path):
+        msg = warn_misbound_deepseek_v3_parser(model_path, "deepseek_v3")
+        assert msg is not None
+        assert model_path in msg
+
+    # Unknown models (no regex match) still get a warning when bound to
+    # a V3-family parser, but the message degrades gracefully (no
+    # auto-detect suggestion).
+    def test_warn_on_unknown_model_no_suggestion(self):
+        msg = warn_misbound_deepseek_v3_parser(
+            "brand-new-org/MysteryModel-2026-7B", "deepseek_v3"
+        )
+        assert msg is not None
+        # No `auto-detect would pick 'X'` blurb when there's no match.
+        # The actionable nudge is still present (drop the flag).
+        assert "deepseek_v3" in msg

--- a/tests/test_model_auto_config.py
+++ b/tests/test_model_auto_config.py
@@ -883,9 +883,10 @@ class TestWarnMisboundDeepseekV3Parser:
             is None
         )
 
-    # In-spec: V3 / V3.1 / R1-0528 / V4 / V5 checkpoints DO emit the V3
-    # wire shape, so a deepseek_v3-family parser binding is legitimate.
-    # No warning.
+    # In-spec: V3-line checkpoints (V3 / R1-0528 / V4 / V5) emit the V3
+    # fenced-JSON body, matched by deepseek_v3 / deepseek_r1_0528.
+    # V3.1-line checkpoints emit the V3.1 plain-JSON body, matched by
+    # deepseek_v31. Matching combos warn nothing.
     @pytest.mark.parametrize(
         "model_path,parser",
         [
@@ -895,14 +896,47 @@ class TestWarnMisboundDeepseekV3Parser:
             ("mlx-community/DeepSeek-V3-0324-4bit", "deepseek_v3"),
             ("deepseek-ai/DeepSeek-V3.1-0324", "deepseek_v31"),
             ("mlx-community/DeepSeek-V3.1-MLX-4bit", "deepseek_v31"),
-            # Forward-cover V4 / V5 — same V3 template lineage. The
-            # helper should accept these without warning.
+            # Forward-cover V4 / V5 — V3 template lineage per upstream
+            # V4 card. The helper should accept these without warning.
             ("deepseek-ai/DeepSeek-V4", "deepseek_v3"),
             ("mlx-community/DeepSeek-V5-MLX-4bit", "deepseek_v3"),
         ],
     )
-    def test_no_warn_for_real_v3_shape_models(self, model_path, parser):
+    def test_no_warn_for_matching_sub_family(self, model_path, parser):
         assert warn_misbound_deepseek_v3_parser(model_path, parser) is None
+
+    # Cross-sub-family misbind (codex r1 P2): V3.1 model + V3 parser, or
+    # V3 model + V3.1 parser. Both ends sit inside the V3 template
+    # lineage so the outer envelope matches, but the per-block body
+    # shapes are incompatible — same empty-args failure as the
+    # out-of-lineage case. The warning MUST fire here too.
+    @pytest.mark.parametrize(
+        "model_path,parser",
+        [
+            # V3.1 model + V3 body parser → blocks dropped, empty args.
+            ("deepseek-ai/DeepSeek-V3.1-0324", "deepseek_v3"),
+            ("mlx-community/DeepSeek-V3.1-MLX-4bit", "deepseek_v3"),
+            ("deepseek-ai/DeepSeek-V3.1-0324", "deepseek_r1_0528"),
+            # V3-line model + V3.1 body parser → same.
+            ("mlx-community/DeepSeek-R1-0528-Qwen3-8B-4bit", "deepseek_v31"),
+            ("deepseek-ai/DeepSeek-V3-0324", "deepseek_v31"),
+            ("deepseek-ai/DeepSeek-V4", "deepseek_v31"),
+        ],
+    )
+    def test_warn_on_cross_sub_family_misbind(self, model_path, parser):
+        msg = warn_misbound_deepseek_v3_parser(model_path, parser)
+        assert msg is not None, (
+            f"cross-sub-family misbind {parser} on {model_path} must warn"
+        )
+        # Must name the offending flag, the model, and reference the
+        # body-shape mismatch so the user knows it's not the same as the
+        # out-of-lineage case.
+        assert parser in msg
+        assert model_path in msg
+        # Cross-sub-family messages mention the chat-template family
+        # (V3.0 or V3.1) rather than the generic "non-V3" framing used
+        # by the out-of-lineage warning.
+        assert ("V3.0" in msg) or ("V3.1" in msg)
 
     # The Sven HIGH-1 repro: forcing deepseek_v3 on an R1-Distill (Qwen2
     # arch) MUST surface a warning. Covers every common distill flavour

--- a/tests/test_model_auto_config.py
+++ b/tests/test_model_auto_config.py
@@ -1179,3 +1179,97 @@ class TestWarnMisboundDeepseekV3Parser:
         assert msg is not None
         # Auto-detect correctly picks ``deepseek_v3`` for R1-0528.
         assert "Auto-detect would pick 'deepseek_v3'" in msg
+
+    # PR-validate codex r6 BLOCKING (HF cache layout): a HuggingFace
+    # cache path resolves the model name to ``<sha>`` if you naively
+    # take the last segment. The classifier must walk past ``snapshots``
+    # / ``blobs`` / ``refs`` markers and SHA-shaped segments, then
+    # unpack the ``models--<org>--<name>`` flat-org form to recover the
+    # canonical model name.
+    @pytest.mark.parametrize(
+        "model_path,parser",
+        [
+            # V3-line model in HF cache, V3 parser → no warn (in-spec).
+            (
+                "models--mlx-community--DeepSeek-R1-0528-Qwen3-8B-4bit/snapshots/abc123def456",
+                "deepseek_v3",
+            ),
+            # Full absolute HF cache path.
+            (
+                "/Users/me/.cache/huggingface/hub/models--mlx-community--DeepSeek-R1-0528-Qwen3-8B-4bit/snapshots/0123456789abcdef",
+                "deepseek_v3",
+            ),
+            # V3.1 model in HF cache, V3.1 parser → no warn.
+            (
+                "models--deepseek-ai--DeepSeek-V3.1-0324/snapshots/cafebabe1234567890",
+                "deepseek_v31",
+            ),
+        ],
+    )
+    def test_no_warn_on_hf_cache_layout_with_matching_parser(self, model_path, parser):
+        assert warn_misbound_deepseek_v3_parser(model_path, parser) is None
+
+    # Counterpart: HF cache paths still WARN when the canonical model
+    # name is non-V3 (e.g. an R1-Distill model whose cache layout
+    # buries the model name under ``snapshots/<sha>``).
+    @pytest.mark.parametrize(
+        "model_path",
+        [
+            "models--mlx-community--DeepSeek-R1-Distill-Qwen-1.5B-4bit/snapshots/abc123def456",
+            "/home/me/.cache/huggingface/hub/models--mlx-community--DeepSeek-R1-Distill-Llama-8B-4bit/snapshots/0badc0ffee",
+        ],
+    )
+    def test_warn_on_hf_cache_layout_when_name_is_distill(self, model_path):
+        msg = warn_misbound_deepseek_v3_parser(model_path, "deepseek_v3")
+        assert msg is not None, (
+            f"HF cache path with R1-Distill name component ({model_path!r}) "
+            "must still warn — the classifier must look past "
+            "``snapshots/<sha>`` to the canonical name."
+        )
+
+    # PR-validate codex r6 BLOCKING (V4/V5 boundary): the original
+    # ``v[45]`` regex had no boundary, so future variants like
+    # ``DeepSeek-V40-*`` or ``DeepSeek-V5Beta-*`` would silently match
+    # the V3-template lineage and SUPPRESS the misbind warning. The
+    # boundary must require end-of-string OR a separator after the
+    # version token.
+    @pytest.mark.parametrize(
+        "model_path",
+        [
+            # Hypothetical V40 / V5Beta variants — must NOT match V3
+            # lineage (we have no evidence about their chat template).
+            "mlx-community/DeepSeek-V40-Special-4bit",
+            "mlx-community/DeepSeek-V5Beta-Special-4bit",
+            "mlx-community/DeepSeek-V42-MoE-4bit",
+            # V3Beta hallucination — V3 pattern needs the same boundary.
+            "mlx-community/DeepSeek-V3Beta-Special",
+            "mlx-community/DeepSeek-V30Special-4bit",
+        ],
+    )
+    def test_warn_on_hallucinated_version_variants(self, model_path):
+        # If these are NOT classified as V3 lineage, the misbind warning
+        # fires for the deepseek_v3 parser binding — which is correct
+        # because we don't know the wire shape of a hypothetical
+        # ``DeepSeek-V40`` or ``DeepSeek-V5Beta`` checkpoint.
+        msg = warn_misbound_deepseek_v3_parser(model_path, "deepseek_v3")
+        assert msg is not None, (
+            f"hallucinated version variant ({model_path!r}) must NOT "
+            "silently match V3-template lineage — the version tokens "
+            "need a boundary to keep ``v[345]`` from matching ``v40``, "
+            "``v5beta``, ``v3beta``, etc."
+        )
+
+    # Counterpart: real V3 / V3.1 / V4 / V5 variants STILL match
+    # after the boundary tightening.
+    @pytest.mark.parametrize(
+        "model_path,parser",
+        [
+            ("mlx-community/DeepSeek-V4-Flash-4bit", "deepseek_v3"),
+            ("deepseek-ai/DeepSeek-V4", "deepseek_v3"),
+            ("deepseek-ai/DeepSeek-V5", "deepseek_v3"),
+            ("deepseek-ai/DeepSeek-V3-0324", "deepseek_v3"),
+            ("deepseek-ai/DeepSeek-V3.1-0324", "deepseek_v31"),
+        ],
+    )
+    def test_no_warn_on_real_versioned_variants(self, model_path, parser):
+        assert warn_misbound_deepseek_v3_parser(model_path, parser) is None

--- a/tests/test_model_auto_config.py
+++ b/tests/test_model_auto_config.py
@@ -999,3 +999,36 @@ class TestWarnMisboundDeepseekV3Parser:
         # No `auto-detect would pick 'X'` blurb when there's no match.
         # The actionable nudge is still present (drop the flag).
         assert "deepseek_v3" in msg
+
+    # Codex round-2 P2 regression: when the user serves a built-in
+    # alias (``deepseek-r1-8b-4bit``) whose name itself does not carry
+    # the ``0528`` / ``v3`` marker but whose ``hf_path`` resolves to a
+    # V3-template checkpoint, the bare-text classifier returns ``None``
+    # — and the auto-detect path sets ``args.tool_call_parser`` to
+    # ``deepseek_v3``. Without resolving the alias here, the misbind
+    # warning fires falsely on a perfectly correct default serve. The
+    # helper MUST resolve aliases before classifying.
+    def test_no_warn_on_v3_alias_with_v3_parser(self):
+        # The alias name has no V3 marker — only the resolved HF path
+        # (``mlx-community/DeepSeek-R1-0528-Qwen3-8B-4bit``) does.
+        # The helper must do the alias lookup itself.
+        assert (
+            warn_misbound_deepseek_v3_parser("deepseek-r1-8b-4bit", "deepseek_v3")
+            is None
+        )
+        # The matching ``deepseek_r1_0528`` alias on the same parser
+        # family is also in-spec.
+        assert (
+            warn_misbound_deepseek_v3_parser("deepseek-r1-8b-4bit", "deepseek_r1_0528")
+            is None
+        )
+
+    # Conversely, when the user serves the same V3 alias with a V3.1
+    # parser (cross-sub-family), the warning MUST still fire — the alias
+    # resolution is informational, not a free pass.
+    def test_warn_on_v3_alias_with_v31_parser(self):
+        msg = warn_misbound_deepseek_v3_parser("deepseek-r1-8b-4bit", "deepseek_v31")
+        assert msg is not None
+        # Cross-sub-family framing: the helper recognised the alias as
+        # a V3.0 (not V3.1) checkpoint.
+        assert "V3.0" in msg

--- a/tests/test_model_auto_config.py
+++ b/tests/test_model_auto_config.py
@@ -1073,3 +1073,32 @@ class TestWarnMisboundDeepseekV3Parser:
         msg = warn_misbound_deepseek_v3_parser(model_path, "deepseek_v3")
         assert msg is not None
         assert model_path in msg
+
+    # Codex round-4 BLOCKING regression: the r3 fix scoped the
+    # ``distill`` REJECT to the tail segment but left the V3 / V3.1 /
+    # R1-0528 / V4-V5 POSITIVE classifiers running against the full
+    # path. That falsely classified a non-V3 checkpoint as v3/v31 when
+    # an unrelated parent directory carried the family marker — e.g.
+    # ``/models/DeepSeek-V3/qwen-model`` resolved to ``"v3"`` and
+    # SUPPRESSED the misbind warning even with the wrong parser. All
+    # classifiers must scope to the model-name component.
+    @pytest.mark.parametrize(
+        "model_path,parser",
+        [
+            ("/models/DeepSeek-V3/qwen-model", "deepseek_v3"),
+            ("/models/DeepSeek-V3.1/qwen-model", "deepseek_v31"),
+            ("/models/DeepSeek-R1-0528/random-model", "deepseek_v3"),
+            ("/models/DeepSeek-V4/qwen-model", "deepseek_v3"),
+        ],
+    )
+    def test_warn_when_only_parent_dir_carries_v3_marker(self, model_path, parser):
+        # The model-NAME component is a non-V3 checkpoint (``qwen-model``
+        # / ``random-model``). The misbind warning must fire even when
+        # the parent dir is named after a V3 family — the parent dir
+        # tells us nothing about the actual checkpoint.
+        msg = warn_misbound_deepseek_v3_parser(model_path, parser)
+        assert msg is not None, (
+            f"non-V3 checkpoint under V3-named parent ({model_path!r}) "
+            f"with {parser!r} must still warn — classifier must scope to "
+            "the model-name component, not the full path."
+        )

--- a/tests/test_model_auto_config.py
+++ b/tests/test_model_auto_config.py
@@ -1032,3 +1032,44 @@ class TestWarnMisboundDeepseekV3Parser:
         # Cross-sub-family framing: the helper recognised the alias as
         # a V3.0 (not V3.1) checkpoint.
         assert "V3.0" in msg
+
+    # Codex round-3 P3 regression: when a user serves a legitimate V3 or
+    # V3.1 checkpoint from a local path whose PARENT DIRECTORY contains
+    # ``distill`` / ``distillations`` / ``distilled``, the substring
+    # check used to short-circuit on the full path and falsely classify
+    # the model as a non-V3 checkpoint — emitting a misbind warning on
+    # a perfectly correct serve. The distill reject must be scoped to
+    # the model-name component (last path segment) only.
+    @pytest.mark.parametrize(
+        "model_path,parser",
+        [
+            (
+                "/models/distillations/deepseek-ai/DeepSeek-V3.1-0324",
+                "deepseek_v31",
+            ),
+            ("/tmp/distilled/DeepSeek-V3-0324", "deepseek_v3"),
+            (
+                "/home/me/distilled-set/deepseek-ai/DeepSeek-R1-0528-Qwen3-8B",
+                "deepseek_v3",
+            ),
+        ],
+    )
+    def test_no_warn_when_parent_dir_only_contains_distill(self, model_path, parser):
+        # Tail segment is a real V3 / V3.1 checkpoint name; the parent
+        # ``distill*`` directory must NOT trip the rejection gate.
+        assert warn_misbound_deepseek_v3_parser(model_path, parser) is None
+
+    # Counterpart: when the model-name component itself carries
+    # ``distill`` (the actual R1-Distill family), the rejection still
+    # fires regardless of how deep the parent path goes.
+    @pytest.mark.parametrize(
+        "model_path",
+        [
+            "/home/me/random/dir/DeepSeek-R1-Distill-Qwen-1.5B-4bit",
+            "/var/cache/mlx-community/DeepSeek-R1-Distill-Llama-8B",
+        ],
+    )
+    def test_warn_when_name_component_contains_distill(self, model_path):
+        msg = warn_misbound_deepseek_v3_parser(model_path, "deepseek_v3")
+        assert msg is not None
+        assert model_path in msg

--- a/tests/test_model_auto_config.py
+++ b/tests/test_model_auto_config.py
@@ -1227,6 +1227,50 @@ class TestWarnMisboundDeepseekV3Parser:
             "``snapshots/<sha>`` to the canonical name."
         )
 
+    # PR-validate codex r8 BLOCKING: the prior SHA-skipping heuristic
+    # was triggered on ANY all-hex segment >=7 chars regardless of
+    # path context. A legitimate local model directory whose final
+    # name happens to be all-hex (e.g. ``/models/abcdef1234``) had
+    # its name silently dropped and the parent dir classified instead.
+    # The SHA-skip must be gated on the path actually being an HF
+    # cache layout (containing ``snapshots`` / ``blobs`` / ``refs``).
+    @pytest.mark.parametrize(
+        "model_path,parser",
+        [
+            # All-hex local directories — NOT HF cache, so no SHA
+            # skipping. Classifier returns None (unknown family) and
+            # the misbind warning fires as out-of-lineage.
+            ("/models/abcdef1234", "deepseek_v3"),
+            ("/home/me/checkpoints/0123456789abcdef", "deepseek_v3"),
+            # A regular path whose final component is hex but where
+            # NO HF cache marker is present must still classify based
+            # on the (hex) tail, not the parent dir.
+            ("/some/random/parent/deadbeef1234567", "deepseek_v3"),
+        ],
+    )
+    def test_warn_on_local_hex_named_dirs_not_in_hf_cache(self, model_path, parser):
+        # These should warn because the helper classifies the hex
+        # tail as out-of-lineage (not a V3 checkpoint). Critically,
+        # the warning should NOT mention the V3-family parent dir
+        # via a fooled classifier.
+        msg = warn_misbound_deepseek_v3_parser(model_path, parser)
+        assert msg is not None
+        # The exact tail (hex name) appears in the message — proving
+        # the classifier saw the tail, not the parent.
+        assert model_path in msg
+
+    # Same hex-style tail BUT under an HF cache layout: the SHA
+    # skipping IS safe and the canonical name is recovered.
+    def test_no_warn_on_hex_sha_under_hf_cache(self):
+        # SHA sits under ``snapshots`` — gate triggers.
+        assert (
+            warn_misbound_deepseek_v3_parser(
+                "models--mlx-community--DeepSeek-R1-0528-Qwen3-8B-4bit/snapshots/deadbeef1234567",
+                "deepseek_v3",
+            )
+            is None
+        )
+
     # PR-validate codex r6 BLOCKING (V4/V5 boundary): the original
     # ``v[45]`` regex had no boundary, so future variants like
     # ``DeepSeek-V40-*`` or ``DeepSeek-V5Beta-*`` would silently match

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -1457,44 +1457,56 @@ def serve_command(args):
             "Reasoning parser auto-detection disabled via --no-reasoning-parser"
         )
 
-    # R12-S1: surface a startup warning when the user explicitly bound a
-    # ``deepseek_v3`` / ``deepseek_v31`` / ``deepseek_r1_0528`` parser to
-    # a model whose checkpoint cannot emit the V3 fenced-JSON wire shape
-    # (notably the R1-distill family, which is Qwen2-/Llama2-arch SFT).
-    # See Sven r12 dogfood HIGH-1: forcing ``--tool-call-parser
+    # R12-S1: surface a startup warning when ``args.tool_call_parser``
+    # is a ``deepseek_v3`` / ``deepseek_v31`` / ``deepseek_r1_0528``
+    # binding but the model can't emit the matching V3 fenced-JSON wire
+    # shape. See Sven r12 dogfood HIGH-1: forcing ``--tool-call-parser
     # deepseek_v3`` on ``DeepSeek-R1-Distill-Qwen-1.5B-4bit`` lands tool
     # calls with ``arguments="{}"`` because the parser correctly refuses
     # to parse the non-V3 prose the model emits.
     #
-    # Scope: ONLY explicit overrides (codex r5 follow-up via
-    # ``_user_explicit_tool_call_parser`` snapshot). Auto-detect
-    # mis-picks are a separate bug class — they belong in
-    # ``detect_model_config`` (whose regex still runs against the full
-    # path, so a parent dir like ``/models/DeepSeek-V3/qwen-model``
-    # would silently pick ``deepseek_v3``). Warning on those would be
-    # mis-targeted noise that doesn't help the user fix the root cause
-    # — the cli print would say "you bound the wrong parser" when the
-    # user bound nothing. Auto-detect regex tightening is tracked
-    # separately as future work; the warning here stays scoped to the
-    # case where the user's declared intent is the load-bearing
-    # signal we can actually surface.
-    if _user_explicit_tool_call_parser:
-        try:
-            from .model_auto_config import warn_misbound_deepseek_v3_parser
+    # Runs on BOTH explicit overrides AND auto-detected bindings,
+    # because ``detect_model_config`` still scans the full path — a
+    # parent dir like ``/models/DeepSeek-V3/qwen-model`` can fool
+    # auto-detect into ``deepseek_v3`` even though the tail model name
+    # is out-of-lineage (pr-validate codex r7 BLOCKING). The helper's
+    # canonical model-name classification catches that mis-pick that
+    # auto-detect missed. Whether the user explicitly bound the flag is
+    # tracked in ``_user_explicit_tool_call_parser`` and threaded into
+    # the warning so the operator can tell who to blame: a misbound
+    # flag (user error) vs. a fooled auto-detect (regex needs
+    # tightening — tracked as follow-up so this PR stays scoped).
+    try:
+        from .model_auto_config import warn_misbound_deepseek_v3_parser
 
-            misbind_warning = warn_misbound_deepseek_v3_parser(
-                args.model, args.tool_call_parser
-            )
-            if misbind_warning:
-                # ``logger.warning`` so the message lands in any
-                # structured log sink AND surfaces in the terminal at
-                # the default ``WARNING`` level (no stderr-print
-                # needed). ``stacklevel=2`` so log frameworks
-                # attribute the call site to the CLI entry rather
-                # than the helper module.
-                logger.warning(misbind_warning, stacklevel=2)
-        except Exception as e:  # noqa: BLE001
-            logger.debug(f"deepseek_v3 misbind check failed (non-fatal): {e}")
+        misbind_warning = warn_misbound_deepseek_v3_parser(
+            args.model, args.tool_call_parser
+        )
+        if misbind_warning:
+            # ``logger.warning`` so the message lands in any structured
+            # log sink AND surfaces in the terminal at the default
+            # ``WARNING`` level (no stderr-print needed).
+            # ``stacklevel=2`` so log frameworks attribute the call
+            # site to the CLI entry rather than the helper module.
+            logger.warning(misbind_warning, stacklevel=2)
+            if not _user_explicit_tool_call_parser:
+                # Auto-detect mis-pick. Emit a second WARNING line so
+                # the operator knows the user didn't bind anything —
+                # the ``detect_model_config`` regex was fooled by the
+                # path. Forces the user to add an explicit
+                # ``--tool-call-parser hermes`` (or similar) to recover
+                # tool-call capability, which is the actually-correct
+                # action for an out-of-lineage checkpoint.
+                logger.warning(
+                    "  ↳ This binding came from AUTO-DETECT, not an "
+                    "explicit --tool-call-parser flag. The "
+                    "detect_model_config() regex was fooled by the "
+                    "path. Override with --tool-call-parser hermes "
+                    "(or whatever your checkpoint actually emits) to "
+                    "recover tool-call capability."
+                )
+    except Exception as e:  # noqa: BLE001
+        logger.debug(f"deepseek_v3 misbind check failed (non-fatal): {e}")
 
     # Pass alias info to server (for /v1/models)
     server._model_alias = getattr(args, "_original_alias", None)

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -1447,6 +1447,35 @@ def serve_command(args):
             "Reasoning parser auto-detection disabled via --no-reasoning-parser"
         )
 
+    # R12-S1: surface a startup warning when the user explicitly bound a
+    # ``deepseek_v3`` / ``deepseek_v31`` / ``deepseek_r1_0528`` parser to
+    # a model whose checkpoint cannot emit the V3 fenced-JSON wire shape
+    # (notably the R1-distill family, which is Qwen2-/Llama2-arch SFT).
+    # See Sven r12 dogfood HIGH-1: forcing ``--tool-call-parser
+    # deepseek_v3`` on ``DeepSeek-R1-Distill-Qwen-1.5B-4bit`` lands tool
+    # calls with ``arguments="{}"`` because the parser correctly refuses
+    # to parse the non-V3 prose the model emits. The auto-detect path
+    # (above) routes the distill family to the legacy ``deepseek`` parser
+    # by default, so this warning only fires when the user explicitly
+    # overrides — preserving the override as the user's declared intent
+    # while loudly surfacing the mismatch so agent SDK builders stop
+    # blaming the parser when the model is the wrong target.
+    try:
+        from .model_auto_config import warn_misbound_deepseek_v3_parser
+
+        misbind_warning = warn_misbound_deepseek_v3_parser(
+            args.model, args.tool_call_parser
+        )
+        if misbind_warning:
+            # ``logger.warning`` so the message lands in any structured
+            # log sink AND surfaces in the terminal at the default
+            # ``WARNING`` level (no stderr-print needed). ``stacklevel=2``
+            # so log frameworks attribute the call site to the CLI entry
+            # rather than the helper module.
+            logger.warning(misbind_warning, stacklevel=2)
+    except Exception as e:  # noqa: BLE001
+        logger.debug(f"deepseek_v3 misbind check failed (non-fatal): {e}")
+
     # Pass alias info to server (for /v1/models)
     server._model_alias = getattr(args, "_original_alias", None)
 

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -1410,6 +1410,16 @@ def serve_command(args):
             file=sys.stderr,
         )
         sys.exit(2)
+    # R12-S1: snapshot whether the user explicitly passed
+    # ``--tool-call-parser`` BEFORE auto-detect mutates ``args``. The
+    # misbind warning below only consults this snapshot — auto-detected
+    # bindings are guaranteed to match the model family by construction
+    # (the auto path picks the same parser the helper would suggest), so
+    # warning on them would be a contradictory "drop the flag" nudge
+    # against a flag the user never passed. (Codex r4 NIT — keeps the
+    # warning grounded in user intent even if a helper-side regression
+    # ever started flagging in-spec cases.)
+    _user_explicit_tool_call_parser = bool(args.tool_call_parser)
     if not args.tool_call_parser or not args.reasoning_parser:
         try:
             from .model_auto_config import detect_model_config
@@ -1456,25 +1466,29 @@ def serve_command(args):
     # calls with ``arguments="{}"`` because the parser correctly refuses
     # to parse the non-V3 prose the model emits. The auto-detect path
     # (above) routes the distill family to the legacy ``deepseek`` parser
-    # by default, so this warning only fires when the user explicitly
-    # overrides — preserving the override as the user's declared intent
-    # while loudly surfacing the mismatch so agent SDK builders stop
-    # blaming the parser when the model is the wrong target.
-    try:
-        from .model_auto_config import warn_misbound_deepseek_v3_parser
+    # by default — so this warning is intentionally gated on
+    # ``_user_explicit_tool_call_parser`` (snapshotted before auto-detect
+    # mutated ``args``). Skipping auto-detected bindings preserves the
+    # warning as a "your declared intent doesn't match the model" nudge
+    # rather than ever blaming a default serve (codex r4 NIT — guards
+    # against future helper-side regressions warning on the auto path).
+    if _user_explicit_tool_call_parser:
+        try:
+            from .model_auto_config import warn_misbound_deepseek_v3_parser
 
-        misbind_warning = warn_misbound_deepseek_v3_parser(
-            args.model, args.tool_call_parser
-        )
-        if misbind_warning:
-            # ``logger.warning`` so the message lands in any structured
-            # log sink AND surfaces in the terminal at the default
-            # ``WARNING`` level (no stderr-print needed). ``stacklevel=2``
-            # so log frameworks attribute the call site to the CLI entry
-            # rather than the helper module.
-            logger.warning(misbind_warning, stacklevel=2)
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"deepseek_v3 misbind check failed (non-fatal): {e}")
+            misbind_warning = warn_misbound_deepseek_v3_parser(
+                args.model, args.tool_call_parser
+            )
+            if misbind_warning:
+                # ``logger.warning`` so the message lands in any
+                # structured log sink AND surfaces in the terminal at
+                # the default ``WARNING`` level (no stderr-print
+                # needed). ``stacklevel=2`` so log frameworks attribute
+                # the call site to the CLI entry rather than the helper
+                # module.
+                logger.warning(misbind_warning, stacklevel=2)
+        except Exception as e:  # noqa: BLE001
+            logger.debug(f"deepseek_v3 misbind check failed (non-fatal): {e}")
 
     # Pass alias info to server (for /v1/models)
     server._model_alias = getattr(args, "_original_alias", None)

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -1457,57 +1457,44 @@ def serve_command(args):
             "Reasoning parser auto-detection disabled via --no-reasoning-parser"
         )
 
-    # R12-S1: surface a startup warning when ``args.tool_call_parser`` is
-    # a ``deepseek_v3`` / ``deepseek_v31`` / ``deepseek_r1_0528`` binding
-    # but the model cannot emit the matching V3 fenced-JSON wire shape.
+    # R12-S1: surface a startup warning when the user explicitly bound a
+    # ``deepseek_v3`` / ``deepseek_v31`` / ``deepseek_r1_0528`` parser to
+    # a model whose checkpoint cannot emit the V3 fenced-JSON wire shape
+    # (notably the R1-distill family, which is Qwen2-/Llama2-arch SFT).
     # See Sven r12 dogfood HIGH-1: forcing ``--tool-call-parser
     # deepseek_v3`` on ``DeepSeek-R1-Distill-Qwen-1.5B-4bit`` lands tool
     # calls with ``arguments="{}"`` because the parser correctly refuses
     # to parse the non-V3 prose the model emits.
     #
-    # The check runs on BOTH explicit (``args.tool_call_parser`` set
-    # before auto-detect) AND auto-detected bindings, because the
-    # auto-detect regex still runs against the FULL path —
-    # ``/models/DeepSeek-V3/qwen-model`` would be auto-detected as
-    # ``deepseek_v3`` even though the tail name is non-V3 (codex r5
-    # follow-up — closing the silent-boot gap). The misbind helper
-    # itself is a pure-function classifier that returns ``None`` on
-    # legitimate in-spec cases, so running it on the auto-detected
-    # binding does no harm in the common path — the warning still only
-    # surfaces when the model's tail name genuinely doesn't match the
-    # parser family. ``_user_explicit_tool_call_parser`` is no longer
-    # gating this — the auto-detect mis-pick is the same class of bug
-    # the warning is meant to surface.
-    try:
-        from .model_auto_config import warn_misbound_deepseek_v3_parser
+    # Scope: ONLY explicit overrides (codex r5 follow-up via
+    # ``_user_explicit_tool_call_parser`` snapshot). Auto-detect
+    # mis-picks are a separate bug class — they belong in
+    # ``detect_model_config`` (whose regex still runs against the full
+    # path, so a parent dir like ``/models/DeepSeek-V3/qwen-model``
+    # would silently pick ``deepseek_v3``). Warning on those would be
+    # mis-targeted noise that doesn't help the user fix the root cause
+    # — the cli print would say "you bound the wrong parser" when the
+    # user bound nothing. Auto-detect regex tightening is tracked
+    # separately as future work; the warning here stays scoped to the
+    # case where the user's declared intent is the load-bearing
+    # signal we can actually surface.
+    if _user_explicit_tool_call_parser:
+        try:
+            from .model_auto_config import warn_misbound_deepseek_v3_parser
 
-        misbind_warning = warn_misbound_deepseek_v3_parser(
-            args.model, args.tool_call_parser
-        )
-        if misbind_warning:
-            # ``logger.warning`` so the message lands in any structured
-            # log sink AND surfaces in the terminal at the default
-            # ``WARNING`` level (no stderr-print needed).
-            # ``stacklevel=2`` so log frameworks attribute the call
-            # site to the CLI entry rather than the helper module.
-            logger.warning(misbind_warning, stacklevel=2)
-            if not _user_explicit_tool_call_parser:
-                # Auto-detect mis-pick: surface the snapshot so an
-                # operator reading the log knows the user did NOT pass
-                # the flag — the project's regex was fooled by the
-                # path. Tracked separately so the operator can file an
-                # auto-detect regex tightening rather than mis-blaming
-                # the user's CLI invocation.
-                logger.warning(
-                    "deepseek_v3 misbind warning fired on AUTO-DETECTED "
-                    "parser (no --tool-call-parser flag was passed). The "
-                    "auto-detect regex matched a parent dir family marker "
-                    "but the tail model name is out-of-lineage. Override "
-                    "with --tool-call-parser hermes (or whatever your "
-                    "checkpoint actually emits)."
-                )
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"deepseek_v3 misbind check failed (non-fatal): {e}")
+            misbind_warning = warn_misbound_deepseek_v3_parser(
+                args.model, args.tool_call_parser
+            )
+            if misbind_warning:
+                # ``logger.warning`` so the message lands in any
+                # structured log sink AND surfaces in the terminal at
+                # the default ``WARNING`` level (no stderr-print
+                # needed). ``stacklevel=2`` so log frameworks
+                # attribute the call site to the CLI entry rather
+                # than the helper module.
+                logger.warning(misbind_warning, stacklevel=2)
+        except Exception as e:  # noqa: BLE001
+            logger.debug(f"deepseek_v3 misbind check failed (non-fatal): {e}")
 
     # Pass alias info to server (for /v1/models)
     server._model_alias = getattr(args, "_original_alias", None)

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -1498,12 +1498,12 @@ def serve_command(args):
                 # tool-call capability, which is the actually-correct
                 # action for an out-of-lineage checkpoint.
                 logger.warning(
-                    "  ↳ This binding came from AUTO-DETECT, not an "
-                    "explicit --tool-call-parser flag. The "
-                    "detect_model_config() regex was fooled by the "
-                    "path. Override with --tool-call-parser hermes "
-                    "(or whatever your checkpoint actually emits) to "
-                    "recover tool-call capability."
+                    "  Auto-detect note: this binding came from "
+                    "AUTO-DETECT, not an explicit --tool-call-parser "
+                    "flag. The detect_model_config() regex was fooled "
+                    "by the path. Override with --tool-call-parser "
+                    "hermes (or whatever your checkpoint actually "
+                    "emits) to recover tool-call capability."
                 )
     except Exception as e:  # noqa: BLE001
         logger.debug(f"deepseek_v3 misbind check failed (non-fatal): {e}")

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -1457,38 +1457,57 @@ def serve_command(args):
             "Reasoning parser auto-detection disabled via --no-reasoning-parser"
         )
 
-    # R12-S1: surface a startup warning when the user explicitly bound a
-    # ``deepseek_v3`` / ``deepseek_v31`` / ``deepseek_r1_0528`` parser to
-    # a model whose checkpoint cannot emit the V3 fenced-JSON wire shape
-    # (notably the R1-distill family, which is Qwen2-/Llama2-arch SFT).
+    # R12-S1: surface a startup warning when ``args.tool_call_parser`` is
+    # a ``deepseek_v3`` / ``deepseek_v31`` / ``deepseek_r1_0528`` binding
+    # but the model cannot emit the matching V3 fenced-JSON wire shape.
     # See Sven r12 dogfood HIGH-1: forcing ``--tool-call-parser
     # deepseek_v3`` on ``DeepSeek-R1-Distill-Qwen-1.5B-4bit`` lands tool
     # calls with ``arguments="{}"`` because the parser correctly refuses
-    # to parse the non-V3 prose the model emits. The auto-detect path
-    # (above) routes the distill family to the legacy ``deepseek`` parser
-    # by default — so this warning is intentionally gated on
-    # ``_user_explicit_tool_call_parser`` (snapshotted before auto-detect
-    # mutated ``args``). Skipping auto-detected bindings preserves the
-    # warning as a "your declared intent doesn't match the model" nudge
-    # rather than ever blaming a default serve (codex r4 NIT — guards
-    # against future helper-side regressions warning on the auto path).
-    if _user_explicit_tool_call_parser:
-        try:
-            from .model_auto_config import warn_misbound_deepseek_v3_parser
+    # to parse the non-V3 prose the model emits.
+    #
+    # The check runs on BOTH explicit (``args.tool_call_parser`` set
+    # before auto-detect) AND auto-detected bindings, because the
+    # auto-detect regex still runs against the FULL path —
+    # ``/models/DeepSeek-V3/qwen-model`` would be auto-detected as
+    # ``deepseek_v3`` even though the tail name is non-V3 (codex r5
+    # follow-up — closing the silent-boot gap). The misbind helper
+    # itself is a pure-function classifier that returns ``None`` on
+    # legitimate in-spec cases, so running it on the auto-detected
+    # binding does no harm in the common path — the warning still only
+    # surfaces when the model's tail name genuinely doesn't match the
+    # parser family. ``_user_explicit_tool_call_parser`` is no longer
+    # gating this — the auto-detect mis-pick is the same class of bug
+    # the warning is meant to surface.
+    try:
+        from .model_auto_config import warn_misbound_deepseek_v3_parser
 
-            misbind_warning = warn_misbound_deepseek_v3_parser(
-                args.model, args.tool_call_parser
-            )
-            if misbind_warning:
-                # ``logger.warning`` so the message lands in any
-                # structured log sink AND surfaces in the terminal at
-                # the default ``WARNING`` level (no stderr-print
-                # needed). ``stacklevel=2`` so log frameworks attribute
-                # the call site to the CLI entry rather than the helper
-                # module.
-                logger.warning(misbind_warning, stacklevel=2)
-        except Exception as e:  # noqa: BLE001
-            logger.debug(f"deepseek_v3 misbind check failed (non-fatal): {e}")
+        misbind_warning = warn_misbound_deepseek_v3_parser(
+            args.model, args.tool_call_parser
+        )
+        if misbind_warning:
+            # ``logger.warning`` so the message lands in any structured
+            # log sink AND surfaces in the terminal at the default
+            # ``WARNING`` level (no stderr-print needed).
+            # ``stacklevel=2`` so log frameworks attribute the call
+            # site to the CLI entry rather than the helper module.
+            logger.warning(misbind_warning, stacklevel=2)
+            if not _user_explicit_tool_call_parser:
+                # Auto-detect mis-pick: surface the snapshot so an
+                # operator reading the log knows the user did NOT pass
+                # the flag — the project's regex was fooled by the
+                # path. Tracked separately so the operator can file an
+                # auto-detect regex tightening rather than mis-blaming
+                # the user's CLI invocation.
+                logger.warning(
+                    "deepseek_v3 misbind warning fired on AUTO-DETECTED "
+                    "parser (no --tool-call-parser flag was passed). The "
+                    "auto-detect regex matched a parent dir family marker "
+                    "but the tail model name is out-of-lineage. Override "
+                    "with --tool-call-parser hermes (or whatever your "
+                    "checkpoint actually emits)."
+                )
+    except Exception as e:  # noqa: BLE001
+        logger.debug(f"deepseek_v3 misbind check failed (non-fatal): {e}")
 
     # Pass alias info to server (for /v1/models)
     server._model_alias = getattr(args, "_original_alias", None)

--- a/vllm_mlx/model_auto_config.py
+++ b/vllm_mlx/model_auto_config.py
@@ -852,19 +852,34 @@ def warn_misbound_deepseek_v3_parser(
         )
 
     # Out-of-lineage (Sven r12 HIGH-1 case). The remediation depends on
-    # whether auto-detect would ALSO mis-pick a V3-family parser (codex
-    # r5: a parent dir like ``/models/DeepSeek-V3/qwen-model`` fools the
-    # full-path regex even though the checkpoint name itself is
-    # non-V3). When auto-detect is fooled too, "drop the flag" is
-    # actively bad advice — pin to ``hermes`` instead.
-    auto_in_v3_family = auto_parser in _DEEPSEEK_V3_FAMILY_PARSERS
-    remediation = (
-        "Pass --tool-call-parser hermes for this Qwen/Llama-arch model."
-        if auto_in_v3_family
-        else "Drop the explicit --tool-call-parser flag to let "
-        "auto-detect choose, or use --tool-call-parser hermes for "
-        "Qwen/Llama-arch distills."
-    )
+    # what auto-detect would do for this same path. Three cases:
+    #
+    #   1. ``auto_parser`` is a V3-family parser (codex r5): a parent
+    #      dir like ``/models/DeepSeek-V3/qwen-model`` fools the
+    #      full-path regex even though the checkpoint name itself is
+    #      non-V3. "Drop the flag" is actively bad advice — pin to
+    #      ``hermes`` directly.
+    #   2. ``auto_parser is None`` (codex r6 PR-validate NIT): unknown
+    #      model, no regex match. "Drop the flag" leaves the user with
+    #      no tool parser at all, which is worse than the current
+    #      misbind. Pin explicitly to ``hermes`` for the typical
+    #      Qwen/Llama-arch case.
+    #   3. ``auto_parser`` is a non-V3 family parser: the auto-detect
+    #      knows the right answer (e.g. ``deepseek`` for R1-Distill).
+    #      Dropping the flag is the right call.
+    if auto_parser in _DEEPSEEK_V3_FAMILY_PARSERS:
+        remediation = "Pass --tool-call-parser hermes for this Qwen/Llama-arch model."
+    elif auto_parser is None:
+        remediation = (
+            "Pass --tool-call-parser hermes for this Qwen/Llama-arch model "
+            "(auto-detect has no fallback for unknown checkpoints)."
+        )
+    else:
+        remediation = (
+            "Drop the explicit --tool-call-parser flag to let auto-detect "
+            "choose, or use --tool-call-parser hermes for Qwen/Llama-arch "
+            "distills."
+        )
     return (
         f"--tool-call-parser={tool_call_parser!r} is bound to "
         f"{model_path!r}, which is NOT a DeepSeek-V3 chat-template "

--- a/vllm_mlx/model_auto_config.py
+++ b/vllm_mlx/model_auto_config.py
@@ -799,12 +799,23 @@ def warn_misbound_deepseek_v3_parser(
     # parser by mistake. Critically, this also lights up the
     # cross-sub-family case: ``deepseek_v31`` parser on R1-0528 will see
     # auto suggest ``deepseek_v3`` here, which is the correct fix.
+    #
+    # Codex r5 P2: ``detect_model_config`` runs its regexes against the
+    # FULL path, so a non-V3 checkpoint under a V3-marker parent dir
+    # (e.g. ``/models/DeepSeek-V3/qwen-model``) would have auto-detect
+    # ALSO pick a V3-family parser — and if it picked the SAME parser
+    # the user is already binding, the suggestion turns into a
+    # contradiction ("drop the flag; auto-detect would pick the same
+    # wrong parser"). Suppress the suggestion in that exact case; the
+    # remaining "drop the flag, use hermes" remediation still applies.
+    # The cross-sub-family case (auto suggests a DIFFERENT V3-family
+    # parser than the one bound) is still useful so we keep it.
     auto = detect_model_config(model_path)
-    suggestion = (
-        f" Auto-detect would pick '{auto.tool_call_parser}' for this model."
-        if auto is not None and auto.tool_call_parser
-        else ""
-    )
+    auto_parser = auto.tool_call_parser if auto is not None else None
+    if auto_parser and auto_parser != tool_call_parser:
+        suggestion = f" Auto-detect would pick '{auto_parser}' for this model."
+    else:
+        suggestion = ""
 
     # Tailor the diagnosis to the failure class so the message is
     # actionable instead of generic.
@@ -825,7 +836,20 @@ def warn_misbound_deepseek_v3_parser(
             "auto-detect pick the matching V3-family parser."
         )
 
-    # Out-of-lineage (Sven r12 HIGH-1 case).
+    # Out-of-lineage (Sven r12 HIGH-1 case). The remediation depends on
+    # whether auto-detect would ALSO mis-pick a V3-family parser (codex
+    # r5: a parent dir like ``/models/DeepSeek-V3/qwen-model`` fools the
+    # full-path regex even though the checkpoint name itself is
+    # non-V3). When auto-detect is fooled too, "drop the flag" is
+    # actively bad advice — pin to ``hermes`` instead.
+    auto_in_v3_family = auto_parser in _DEEPSEEK_V3_FAMILY_PARSERS
+    remediation = (
+        "Pass --tool-call-parser hermes for this Qwen/Llama-arch model."
+        if auto_in_v3_family
+        else "Drop the explicit --tool-call-parser flag to let "
+        "auto-detect choose, or use --tool-call-parser hermes for "
+        "Qwen/Llama-arch distills."
+    )
     return (
         f"--tool-call-parser={tool_call_parser!r} is bound to "
         f"{model_path!r}, which is NOT a DeepSeek-V3 chat-template "
@@ -833,9 +857,7 @@ def warn_misbound_deepseek_v3_parser(
         "`<｜tool▁calls▁begin｜>function<｜tool▁sep｜>NAME\\n```json\\n{…}\\n```` "
         "envelope; non-V3 checkpoints (R1-Distill-Qwen/-Llama, V2.x, "
         "Qwen2/Llama-arch SFTs) cannot emit it and tool calls will "
-        f"have empty arguments.{suggestion} Drop the explicit "
-        "--tool-call-parser flag to let auto-detect choose, or use "
-        "--tool-call-parser hermes for Qwen/Llama-arch distills."
+        f"have empty arguments.{suggestion} {remediation}"
     )
 
 

--- a/vllm_mlx/model_auto_config.py
+++ b/vllm_mlx/model_auto_config.py
@@ -655,21 +655,74 @@ _DEEPSEEK_V31_BODY_PARSERS = frozenset({"deepseek_v31"})
 _DEEPSEEK_V3_FAMILY_PARSERS = _DEEPSEEK_V3_BODY_PARSERS | _DEEPSEEK_V31_BODY_PARSERS
 
 
+# HF cache layout components that must be stripped before the
+# tail-segment classifier runs. Real layouts:
+#   ~/.cache/huggingface/hub/models--<org>--<name>/snapshots/<sha>/...
+# A bare ``parts[-1]`` would resolve to ``<sha>`` or ``blobs`` and
+# completely miss the model name. Strip these intermediate segments
+# so the classifier sees the canonical model name component.
+_HF_CACHE_INTERMEDIATE_SEGMENTS = frozenset({"snapshots", "blobs", "refs"})
+
+
+def _extract_model_name_segment(path: str) -> str:
+    """Pick the canonical model-name segment from a path that may include
+    HF cache layout intermediates.
+
+    Real-world inputs covered:
+      * ``mlx-community/DeepSeek-R1-0528-Qwen3-8B-4bit`` → tail = name
+      * ``/abs/path/mlx-community/DeepSeek-V3-0324`` → tail = name
+      * ``models--mlx-community--DeepSeek-R1-0528-Qwen3-8B-4bit/snapshots/<sha>``
+        → must skip the SHA segment AND the ``snapshots`` marker, then
+        unpack the ``models--<org>--<name>`` form to recover the name.
+      * ``alias-name`` (single token) → tail = name
+    """
+    parts = [p for p in path.rstrip("/").split("/") if p]
+    if not parts:
+        return path
+    # Walk from the end, skipping HF cache intermediate segments and
+    # bare-hex SHA fragments. Once a segment that isn't one of those
+    # is reached, that's our candidate name component.
+    candidate = None
+    for seg in reversed(parts):
+        if seg in _HF_CACHE_INTERMEDIATE_SEGMENTS:
+            continue
+        # Skip 40-char hex SHAs (HF snapshot revision dirs) and short
+        # bare-hex aliases (``refs/main`` etc become just ``main`` so
+        # those don't match this guard). Bounded length check keeps
+        # the heuristic narrow — anything 7+ hex chars is almost
+        # certainly a commit SHA.
+        if len(seg) >= 7 and all(c in "0123456789abcdef" for c in seg.lower()):
+            continue
+        candidate = seg
+        break
+    if candidate is None:
+        candidate = parts[-1]
+    # HF cache flattens ``<org>/<name>`` into ``models--<org>--<name>``.
+    # Pull the original name out so the classifier sees the same string
+    # it would see on a direct HF-path serve.
+    if candidate.startswith("models--") and "--" in candidate[len("models--") :]:
+        candidate = candidate.rsplit("--", 1)[-1]
+    return candidate
+
+
 def _classify_deepseek_template_name(s: str) -> str | None:
     """Inner name-pattern classifier — see ``_deepseek_template_family``
     for the public contract. Pulled out so the public helper can run the
     classifier on BOTH the user-supplied path AND the alias-resolved HF
     path without duplicating the pattern logic.
 
-    All pattern matches are scoped to the model-name component (last
-    non-empty path segment) rather than the full path, so:
+    All pattern matches are scoped to the model-name component
+    (extracted via ``_extract_model_name_segment`` so HF cache layouts
+    like ``models--<org>--<name>/snapshots/<sha>`` resolve to the
+    canonical name and not the SHA), so:
 
     * The R1-Distill reject (codex r3 P3) is not tripped by a
       ``distillations`` parent dir.
     * The V3 / V3.1 / R1-0528 / V4-V5 positive classifiers do not fire
       on a parent dir like ``/models/DeepSeek-V3/qwen-model`` whose
-      checkpoint is actually a Qwen variant (codex r4 BLOCKING — the
-      r3 fix only scoped the reject, not the positive classifiers).
+      checkpoint is actually a Qwen variant (codex r4 BLOCKING).
+    * HF cache snapshot layouts don't get false-negative classified
+      because the tail segment is a SHA (pr-validate codex r6 BLOCKING).
 
     Single-segment scoping works for genuine HF paths because every
     DeepSeek checkpoint's MODEL NAME carries its own family marker:
@@ -679,11 +732,7 @@ def _classify_deepseek_template_name(s: str) -> str | None:
     and never load-bearing for sub-family identification.
     """
     s = s.lower()
-    # Extract the model-name component (last non-empty path segment).
-    # Empty or all-slash inputs collapse to the full string so the
-    # classifier still produces ``None`` rather than crashing.
-    parts = [p for p in s.rstrip("/").split("/") if p]
-    name = parts[-1] if parts else s
+    name = _extract_model_name_segment(s)
     # R1-Distill family is V2 / Qwen2-arch, NOT V3. Explicit reject for
     # BOTH sub-families.
     if "distill" in name:
@@ -693,16 +742,26 @@ def _classify_deepseek_template_name(s: str) -> str | None:
     # substring after the dot is stripped by the loose regex).
     if re.search(r"deepseek[-_]*v3\.\d", name):
         return "v31"
-    # V3 vanilla — V3-0324 etc.
-    if re.search(r"deepseek[-_]*v3(?![._\d])", name):
+    # V3 vanilla — V3-0324 etc. Require ``v3`` to be terminated by
+    # end-of-string or a separator so ``V30``, ``V31`` (which would have
+    # matched V3.1 above anyway), ``V3Beta``, and ``V300`` don't get
+    # mis-classified. ``V3-0324`` matches via the ``-`` boundary.
+    if re.search(r"deepseek[-_]*v3(?=[-_/.\s]|$)", name):
         return "v3"
     # R1-0528 — the R1 retrain on the V3 chat template.
     if re.search(r"deepseek.*r1[-_]?0528", name):
         return "v3"
     # Forward-cover V4 / V5 (per upstream V4 card both inherit the V3
-    # template; cheap to include and avoids a future regression when a
-    # user serves a V4 checkpoint with ``--tool-call-parser deepseek_v3``).
-    if re.search(r"deepseek[-_]*v[45]", name):
+    # template). Require the ``v4`` / ``v5`` token to be terminated by
+    # end-of-string OR a separator character (``-``, ``_``, ``/``, ``.``,
+    # space) so future variants like ``DeepSeek-V40-*``,
+    # ``DeepSeek-V5Beta-*``, or ``DeepSeek-V42-MoE-*`` don't get
+    # silently classified as V3-template just because they share the
+    # ``v4`` / ``v5`` prefix (pr-validate codex r6 BLOCKING — the
+    # missing boundary was a real false-negative path). ``DeepSeek-V4``
+    # and ``DeepSeek-V4-Flash`` still match because the boundary is
+    # satisfied by end-of-string or ``-`` respectively.
+    if re.search(r"deepseek[-_]*v[45](?=[-_/.\s]|$)", name):
         return "v3"
     return None
 

--- a/vllm_mlx/model_auto_config.py
+++ b/vllm_mlx/model_auto_config.py
@@ -625,6 +625,107 @@ def detect_model_config(model_path: str) -> ModelConfig | None:
     return None
 
 
+# DeepSeek-V3 wire-shape parsers — they expect the
+# ``<｜tool▁calls▁begin｜>…function<｜tool▁sep｜>NAME\n``\`json\n{…}\n``\`…``
+# envelope emitted by the V3 chat template (R1-0528-Qwen3-8B, vanilla
+# V3-0324, V3.1). Models that did NOT inherit the V3 chat template
+# cannot honour this wire shape — most importantly the original
+# R1-distill family (DeepSeek-R1-Distill-Qwen-*, -Llama-*) which are
+# Qwen2 / Llama2-arch SFTs whose tokenizers do not carry the V3
+# fullwidth-pipe special tokens. Binding any of these parsers to such
+# a model produces ``arguments="{}"`` because the model emits prose
+# (or hallucinated wire-token glyphs) that the parser correctly
+# refuses to parse — the parser is working as designed.
+#
+# This set is the ground truth for the misbind warning below. Keep in
+# sync with the @ToolParserManager.register_module(...) aliases on
+# DeepSeekV3ToolParser and DeepSeekV31ToolParser.
+_DEEPSEEK_V3_FAMILY_PARSERS = frozenset(
+    {"deepseek_v3", "deepseek_r1_0528", "deepseek_v31"}
+)
+
+
+def _model_emits_deepseek_v3_wire(model_path: str) -> bool:
+    """True iff ``model_path`` names a checkpoint that inherits the V3
+    chat template (and therefore can emit the V3 fenced-JSON wire shape
+    a ``deepseek_v3``-family parser expects).
+
+    Authoritative list (all matched case-insensitively as substrings of
+    the HF path / alias name):
+      * DeepSeek-V3 / V3.1 / V3.x       — vanilla V3-line checkpoints
+      * DeepSeek-R1-0528                — R1 retrained on the V3 template
+      * DeepSeek-V4 / V5 (forward-cover) — same V3 template lineage
+        per the upstream V4 model card
+
+    The original R1 distill family (``DeepSeek-R1-Distill-Qwen-*``,
+    ``-Llama-*``) is EXCLUDED — those are SFTs on Qwen2 / Llama2 base
+    tokenizers that do not carry the V3 special tokens. Same for the
+    legacy V2.x line (predates the V3 template).
+    """
+    s = model_path.lower()
+    # R1-Distill family is V2 / Qwen2-arch, NOT V3. Explicit reject.
+    if "distill" in s:
+        return False
+    # V3 / V3.1 / V3.x — vanilla
+    if re.search(r"deepseek[-_/]*v3(?:\.\d+)?", s):
+        return True
+    # R1-0528 — the R1 retrain on the V3 chat template.
+    if re.search(r"deepseek.*r1[-_]?0528", s):
+        return True
+    # Forward-cover V4 / V5 (per upstream V4 card both inherit the V3
+    # template; cheap to include and avoids a future regression when a
+    # user serves a V4 checkpoint with ``--tool-call-parser deepseek_v3``).
+    if re.search(r"deepseek[-_/]*v[45]", s):
+        return True
+    return False
+
+
+def warn_misbound_deepseek_v3_parser(
+    model_path: str, tool_call_parser: str | None
+) -> str | None:
+    """If the user explicitly bound a deepseek_v3-family parser to a
+    model that cannot emit the V3 wire shape, return a single-line
+    warning string. Return ``None`` for the in-spec cases (no warning).
+
+    Caller (cli.py / serve entrypoint) decides whether to logger.warning
+    or stderr.print; this helper is pure so the boundary is unit-
+    testable without an active logger and a clean stderr to assert
+    against.
+
+    Why warn instead of reject: the parser-flag override is the user's
+    declared intent. The historical D-DSV31 hotfix exists *because* a
+    user knew their checkpoint emitted the V3 shape under a non-obvious
+    HF path. Hard-rejecting would lock that door. The warning surfaces
+    the mismatch loudly (so agent SDKs / dogfood reports stop blaming
+    the parser when the model is the wrong target) without blocking
+    the explicit override.
+    """
+    if tool_call_parser not in _DEEPSEEK_V3_FAMILY_PARSERS:
+        return None
+    if _model_emits_deepseek_v3_wire(model_path):
+        return None
+    # Suggest the auto-detected parser if one would have applied — that's
+    # the most actionable nudge for the typical user who picked the V3
+    # parser by mistake.
+    auto = detect_model_config(model_path)
+    suggestion = (
+        f" Auto-detect would pick '{auto.tool_call_parser}' for this model."
+        if auto is not None and auto.tool_call_parser
+        else ""
+    )
+    return (
+        f"--tool-call-parser={tool_call_parser!r} is bound to "
+        f"{model_path!r}, which is NOT a DeepSeek-V3 chat-template "
+        "checkpoint. The V3-family parsers expect the "
+        "`<｜tool▁calls▁begin｜>function<｜tool▁sep｜>NAME\\n```json\\n{…}\\n```` "
+        "envelope; non-V3 checkpoints (R1-Distill-Qwen/-Llama, V2.x, "
+        "Qwen2/Llama-arch SFTs) cannot emit it and tool calls will "
+        f"have empty arguments.{suggestion} Drop the explicit "
+        "--tool-call-parser flag to let auto-detect choose, or use "
+        "--tool-call-parser hermes for Qwen/Llama-arch distills."
+    )
+
+
 def enrich_model_config(cfg: ModelConfig | None, model: Any) -> ModelConfig:
     """Runtime-enrich a ``ModelConfig`` from a loaded mlx-lm model.
 

--- a/vllm_mlx/model_auto_config.py
+++ b/vllm_mlx/model_auto_config.py
@@ -655,25 +655,13 @@ _DEEPSEEK_V31_BODY_PARSERS = frozenset({"deepseek_v31"})
 _DEEPSEEK_V3_FAMILY_PARSERS = _DEEPSEEK_V3_BODY_PARSERS | _DEEPSEEK_V31_BODY_PARSERS
 
 
-def _deepseek_template_family(model_path: str) -> str | None:
-    """Identify which DeepSeek chat-template sub-family a checkpoint
-    belongs to, by name pattern.
-
-    Returns one of:
-      * ``"v3"``     — V3 chat template (vanilla V3, R1-0528, V4, V5)
-                       → emits the V3 fenced-JSON body shape
-      * ``"v31"``    — V3.1 chat template (DeepSeek-V3.1-*)
-                       → emits the V3.1 plain-JSON body shape
-      * ``None``     — not a V3-template checkpoint (R1-Distill family,
-                       V2.x, Qwen2/Llama-arch SFTs, unknowns).
-
-    The R1-distill family (``DeepSeek-R1-Distill-Qwen-*``,
-    ``-Llama-*``) is EXCLUDED from both V3 sub-families because those
-    are SFTs on Qwen2 / Llama2 base tokenizers that do not carry the V3
-    fullwidth-pipe special tokens, and binding either V3-family parser
-    to them lands ``arguments="{}"`` (Sven r12 HIGH-1).
+def _classify_deepseek_template_name(s: str) -> str | None:
+    """Inner name-pattern classifier — see ``_deepseek_template_family``
+    for the public contract. Pulled out so the public helper can run the
+    classifier on BOTH the user-supplied path AND the alias-resolved HF
+    path without duplicating the pattern logic.
     """
-    s = model_path.lower()
+    s = s.lower()
     # R1-Distill family is V2 / Qwen2-arch, NOT V3. Explicit reject for
     # BOTH sub-families.
     if "distill" in s:
@@ -695,6 +683,51 @@ def _deepseek_template_family(model_path: str) -> str | None:
     if re.search(r"deepseek[-_/]*v[45]", s):
         return "v3"
     return None
+
+
+def _deepseek_template_family(model_path: str) -> str | None:
+    """Identify which DeepSeek chat-template sub-family a checkpoint
+    belongs to, by name pattern.
+
+    Returns one of:
+      * ``"v3"``     — V3 chat template (vanilla V3, R1-0528, V4, V5)
+                       → emits the V3 fenced-JSON body shape
+      * ``"v31"``    — V3.1 chat template (DeepSeek-V3.1-*)
+                       → emits the V3.1 plain-JSON body shape
+      * ``None``     — not a V3-template checkpoint (R1-Distill family,
+                       V2.x, Qwen2/Llama-arch SFTs, unknowns).
+
+    The R1-distill family (``DeepSeek-R1-Distill-Qwen-*``,
+    ``-Llama-*``) is EXCLUDED from both V3 sub-families because those
+    are SFTs on Qwen2 / Llama2 base tokenizers that do not carry the V3
+    fullwidth-pipe special tokens, and binding either V3-family parser
+    to them lands ``arguments="{}"`` (Sven r12 HIGH-1).
+
+    Codex r2 P2 fix: also classify by the alias-resolved HF path when
+    the user-supplied name is an alias whose textual form alone doesn't
+    encode the family (e.g. ``deepseek-r1-8b-4bit`` resolves to
+    ``mlx-community/DeepSeek-R1-0528-Qwen3-8B-4bit`` — the alias name
+    contains no ``0528`` marker, so the bare-text classifier would
+    return ``None`` and the misbind warning would fire falsely on a
+    perfectly correct default serve).
+    """
+    # First pass: classify by the user-supplied string itself. This
+    # covers HF paths and any alias whose name already carries a family
+    # marker.
+    family = _classify_deepseek_template_name(model_path)
+    if family is not None:
+        return family
+    # Second pass: resolve as an alias and classify the canonical HF
+    # path. Pulled in lazily so a degraded ``model_aliases`` import
+    # cannot kill the warning path (the helper falls back to the
+    # name-only classification, which is the previous behaviour).
+    try:
+        profile = resolve_profile(model_path)
+    except Exception:  # noqa: BLE001
+        return None
+    if profile is None:
+        return None
+    return _classify_deepseek_template_name(profile.hf_path)
 
 
 def warn_misbound_deepseek_v3_parser(

--- a/vllm_mlx/model_auto_config.py
+++ b/vllm_mlx/model_auto_config.py
@@ -660,11 +660,24 @@ def _classify_deepseek_template_name(s: str) -> str | None:
     for the public contract. Pulled out so the public helper can run the
     classifier on BOTH the user-supplied path AND the alias-resolved HF
     path without duplicating the pattern logic.
+
+    Codex r3 P3 fix: the R1-Distill reject is scoped to the model-name
+    component (last path segment) rather than the full path, because a
+    legitimate local serve like
+    ``/models/distillations/deepseek-ai/DeepSeek-V3.1-0324`` carries
+    ``distill`` in the parent directory but the checkpoint itself is a
+    valid V3.1 model. A full-path substring match would warn falsely
+    there even on the correct ``deepseek_v31`` parser.
     """
     s = s.lower()
+    # Extract the model-name component (last non-empty path segment).
+    # Empty or all-slash inputs collapse to the full string so the
+    # classifier still produces ``None`` rather than crashing.
+    tail = s.rstrip("/").rsplit("/", 1)[-1] or s
     # R1-Distill family is V2 / Qwen2-arch, NOT V3. Explicit reject for
-    # BOTH sub-families.
-    if "distill" in s:
+    # BOTH sub-families. Scoped to ``tail`` so a ``distillations``
+    # parent dir doesn't trip the gate.
+    if "distill" in tail:
         return None
     # V3.1 — distinct chat template, ordered BEFORE the bare V3 check
     # so the more specific pattern wins (V3.1 contains "v3" as a

--- a/vllm_mlx/model_auto_config.py
+++ b/vllm_mlx/model_auto_config.py
@@ -679,19 +679,29 @@ def _extract_model_name_segment(path: str) -> str:
     parts = [p for p in path.rstrip("/").split("/") if p]
     if not parts:
         return path
-    # Walk from the end, skipping HF cache intermediate segments and
-    # bare-hex SHA fragments. Once a segment that isn't one of those
-    # is reached, that's our candidate name component.
+    # SHA-skipping is gated on the path actually being an HF cache
+    # layout (codex r8 BLOCKING). Without this gate, a legitimate
+    # local-model directory whose final name happens to be all-hex
+    # (e.g. ``/models/abcdef1234``) would have its name silently
+    # dropped and the parent classified instead — false-misbind on a
+    # perfectly valid checkpoint. We look for any HF cache
+    # intermediate marker (``snapshots`` / ``blobs`` / ``refs``)
+    # anywhere in the path; if present, the path IS HF cache and
+    # SHA-shaped segments below the marker can be safely skipped.
+    in_hf_cache_layout = any(p in _HF_CACHE_INTERMEDIATE_SEGMENTS for p in parts)
     candidate = None
     for seg in reversed(parts):
         if seg in _HF_CACHE_INTERMEDIATE_SEGMENTS:
             continue
-        # Skip 40-char hex SHAs (HF snapshot revision dirs) and short
-        # bare-hex aliases (``refs/main`` etc become just ``main`` so
-        # those don't match this guard). Bounded length check keeps
-        # the heuristic narrow — anything 7+ hex chars is almost
-        # certainly a commit SHA.
-        if len(seg) >= 7 and all(c in "0123456789abcdef" for c in seg.lower()):
+        # Only skip SHA-shaped segments when we KNOW the path is an HF
+        # cache layout. ``len(seg) >= 7`` is the conventional minimum
+        # abbreviated-SHA width; ``all hex`` keeps the heuristic
+        # narrow enough to not eat real model names.
+        if (
+            in_hf_cache_layout
+            and len(seg) >= 7
+            and all(c in "0123456789abcdef" for c in seg.lower())
+        ):
             continue
         candidate = seg
         break
@@ -894,11 +904,16 @@ def warn_misbound_deepseek_v3_parser(
     # Tailor the diagnosis to the failure class so the message is
     # actionable instead of generic.
     if template in {"v3", "v31"}:
-        # Cross-sub-family inside the V3 template lineage.
+        # Cross-sub-family inside the V3 template lineage. Use single
+        # backticks around the V3.1 body but plain quotes around the V3
+        # body example because the latter contains literal backticks
+        # (the JSON fence) — wrapping it in another backtick produced a
+        # confusing four-backtick tail (codex r8 NIT). Plain quotes
+        # render cleanly in every log sink.
         expected_body = (
             "`NAME<｜tool▁sep｜>{…json…}`"
             if template == "v31"
-            else "`function<｜tool▁sep｜>NAME\\n```json\\n{…}\\n````"
+            else "function<｜tool▁sep｜>NAME\\n```json\\n{…}\\n```"
         )
         return (
             f"--tool-call-parser={tool_call_parser!r} is bound to "
@@ -943,7 +958,7 @@ def warn_misbound_deepseek_v3_parser(
         f"--tool-call-parser={tool_call_parser!r} is bound to "
         f"{model_path!r}, which is NOT a DeepSeek-V3 chat-template "
         "checkpoint. The V3-family parsers expect the "
-        "`<｜tool▁calls▁begin｜>function<｜tool▁sep｜>NAME\\n```json\\n{…}\\n```` "
+        "<｜tool▁calls▁begin｜>function<｜tool▁sep｜>NAME\\n```json\\n{…}\\n``` "
         "envelope; non-V3 checkpoints (R1-Distill-Qwen/-Llama, V2.x, "
         "Qwen2/Llama-arch SFTs) cannot emit it and tool calls will "
         f"have empty arguments.{suggestion} {remediation}"

--- a/vllm_mlx/model_auto_config.py
+++ b/vllm_mlx/model_auto_config.py
@@ -800,22 +800,37 @@ def warn_misbound_deepseek_v3_parser(
     # cross-sub-family case: ``deepseek_v31`` parser on R1-0528 will see
     # auto suggest ``deepseek_v3`` here, which is the correct fix.
     #
-    # Codex r5 P2: ``detect_model_config`` runs its regexes against the
-    # FULL path, so a non-V3 checkpoint under a V3-marker parent dir
-    # (e.g. ``/models/DeepSeek-V3/qwen-model``) would have auto-detect
-    # ALSO pick a V3-family parser — and if it picked the SAME parser
-    # the user is already binding, the suggestion turns into a
-    # contradiction ("drop the flag; auto-detect would pick the same
-    # wrong parser"). Suppress the suggestion in that exact case; the
-    # remaining "drop the flag, use hermes" remediation still applies.
-    # The cross-sub-family case (auto suggests a DIFFERENT V3-family
-    # parser than the one bound) is still useful so we keep it.
+    # Codex r5 + r5-followup P2: ``detect_model_config`` runs its
+    # regexes against the FULL path, so a non-V3 checkpoint under a
+    # V3-marker parent dir (e.g. ``/models/DeepSeek-V3/qwen-model``)
+    # would have auto-detect ALSO pick a V3-family parser — fooled by
+    # the same parent dir the tail-segment classifier above correctly
+    # ignored. Surfacing that fooled auto-detect as a suggestion is
+    # actively harmful: it nudges the user toward the same wrong family
+    # the warning is about. Suppress the suggestion whenever the model
+    # is out-of-lineage (template is None) AND auto-detect would pick
+    # any V3-family parser — including a DIFFERENT one than the one
+    # the user bound, because the suggestion's framing
+    # ("auto-detect would pick X for this model") implies endorsement
+    # that doesn't hold when auto-detect itself is fooled. The
+    # cross-sub-family case (template in {"v3","v31"}) is unaffected
+    # — there the model genuinely is V3-template and auto-detect's
+    # other-V3 suggestion is the actually-correct fix.
     auto = detect_model_config(model_path)
     auto_parser = auto.tool_call_parser if auto is not None else None
-    if auto_parser and auto_parser != tool_call_parser:
-        suggestion = f" Auto-detect would pick '{auto_parser}' for this model."
-    else:
-        suggestion = ""
+    suppress_suggestion = (
+        not auto_parser
+        # Same parser the user bound — contradiction.
+        or auto_parser == tool_call_parser
+        # Out-of-lineage + auto also fooled into V3 family — endorses
+        # the same wrong-family class.
+        or (template is None and auto_parser in _DEEPSEEK_V3_FAMILY_PARSERS)
+    )
+    suggestion = (
+        ""
+        if suppress_suggestion
+        else f" Auto-detect would pick '{auto_parser}' for this model."
+    )
 
     # Tailor the diagnosis to the failure class so the message is
     # actionable instead of generic.

--- a/vllm_mlx/model_auto_config.py
+++ b/vllm_mlx/model_auto_config.py
@@ -625,72 +625,102 @@ def detect_model_config(model_path: str) -> ModelConfig | None:
     return None
 
 
-# DeepSeek-V3 wire-shape parsers — they expect the
-# ``<｜tool▁calls▁begin｜>…function<｜tool▁sep｜>NAME\n``\`json\n{…}\n``\`…``
-# envelope emitted by the V3 chat template (R1-0528-Qwen3-8B, vanilla
-# V3-0324, V3.1). Models that did NOT inherit the V3 chat template
-# cannot honour this wire shape — most importantly the original
-# R1-distill family (DeepSeek-R1-Distill-Qwen-*, -Llama-*) which are
-# Qwen2 / Llama2-arch SFTs whose tokenizers do not carry the V3
-# fullwidth-pipe special tokens. Binding any of these parsers to such
-# a model produces ``arguments="{}"`` because the model emits prose
-# (or hallucinated wire-token glyphs) that the parser correctly
-# refuses to parse — the parser is working as designed.
+# DeepSeek V3-template wire-shape parsers, by the sub-family each one
+# OWNS. The V3 chat template and the V3.1 chat template emit DIFFERENT
+# tool-call bodies inside the same outer envelope:
 #
-# This set is the ground truth for the misbind warning below. Keep in
-# sync with the @ToolParserManager.register_module(...) aliases on
-# DeepSeekV3ToolParser and DeepSeekV31ToolParser.
-_DEEPSEEK_V3_FAMILY_PARSERS = frozenset(
-    {"deepseek_v3", "deepseek_r1_0528", "deepseek_v31"}
-)
+#   * ``deepseek_v3`` / ``deepseek_r1_0528`` (DeepSeekV3ToolParser):
+#       body = ``function<｜tool▁sep｜>NAME\n``\`json\n{…}\n``\```
+#       emitted by V3-line checkpoints whose ``chat_template.jinja`` is
+#       the V3 template — vanilla V3-0324, R1-0528 (R1 retrained on V3),
+#       and the forward-cover V4 / V5 family per the upstream V4 card.
+#
+#   * ``deepseek_v31`` (DeepSeekV31ToolParser):
+#       body = ``NAME<｜tool▁sep｜>{…json…}``
+#       emitted by V3.1-line checkpoints — DeepSeek-V3.1-0324 etc.
+#
+# The two parsers were intentionally split in PR #874 (R12-5) so each
+# one owns exactly one wire shape, removing the cross-shape blast radius
+# the unified V3.1 parser carried. Crossing the streams — binding
+# ``deepseek_v3`` to a V3.1 checkpoint, or ``deepseek_v31`` to a V3
+# checkpoint — IS the same class of silent-empty-args failure this
+# warning is meant to surface, even though both ends of the misbind sit
+# inside the V3-template lineage (codex round 1 follow-up). Track the
+# sub-family ownership explicitly so cross-family misbinds warn too.
+#
+# Keep in sync with the ``@ToolParserManager.register_module(...)``
+# aliases on the two parser classes.
+_DEEPSEEK_V3_BODY_PARSERS = frozenset({"deepseek_v3", "deepseek_r1_0528"})
+_DEEPSEEK_V31_BODY_PARSERS = frozenset({"deepseek_v31"})
+_DEEPSEEK_V3_FAMILY_PARSERS = _DEEPSEEK_V3_BODY_PARSERS | _DEEPSEEK_V31_BODY_PARSERS
 
 
-def _model_emits_deepseek_v3_wire(model_path: str) -> bool:
-    """True iff ``model_path`` names a checkpoint that inherits the V3
-    chat template (and therefore can emit the V3 fenced-JSON wire shape
-    a ``deepseek_v3``-family parser expects).
+def _deepseek_template_family(model_path: str) -> str | None:
+    """Identify which DeepSeek chat-template sub-family a checkpoint
+    belongs to, by name pattern.
 
-    Authoritative list (all matched case-insensitively as substrings of
-    the HF path / alias name):
-      * DeepSeek-V3 / V3.1 / V3.x       — vanilla V3-line checkpoints
-      * DeepSeek-R1-0528                — R1 retrained on the V3 template
-      * DeepSeek-V4 / V5 (forward-cover) — same V3 template lineage
-        per the upstream V4 model card
+    Returns one of:
+      * ``"v3"``     — V3 chat template (vanilla V3, R1-0528, V4, V5)
+                       → emits the V3 fenced-JSON body shape
+      * ``"v31"``    — V3.1 chat template (DeepSeek-V3.1-*)
+                       → emits the V3.1 plain-JSON body shape
+      * ``None``     — not a V3-template checkpoint (R1-Distill family,
+                       V2.x, Qwen2/Llama-arch SFTs, unknowns).
 
-    The original R1 distill family (``DeepSeek-R1-Distill-Qwen-*``,
-    ``-Llama-*``) is EXCLUDED — those are SFTs on Qwen2 / Llama2 base
-    tokenizers that do not carry the V3 special tokens. Same for the
-    legacy V2.x line (predates the V3 template).
+    The R1-distill family (``DeepSeek-R1-Distill-Qwen-*``,
+    ``-Llama-*``) is EXCLUDED from both V3 sub-families because those
+    are SFTs on Qwen2 / Llama2 base tokenizers that do not carry the V3
+    fullwidth-pipe special tokens, and binding either V3-family parser
+    to them lands ``arguments="{}"`` (Sven r12 HIGH-1).
     """
     s = model_path.lower()
-    # R1-Distill family is V2 / Qwen2-arch, NOT V3. Explicit reject.
+    # R1-Distill family is V2 / Qwen2-arch, NOT V3. Explicit reject for
+    # BOTH sub-families.
     if "distill" in s:
-        return False
-    # V3 / V3.1 / V3.x — vanilla
-    if re.search(r"deepseek[-_/]*v3(?:\.\d+)?", s):
-        return True
+        return None
+    # V3.1 — distinct chat template, ordered BEFORE the bare V3 check
+    # so the more specific pattern wins (V3.1 contains "v3" as a
+    # substring after the dot is stripped by the loose regex).
+    if re.search(r"deepseek[-_/]*v3\.\d", s):
+        return "v31"
+    # V3 vanilla — V3-0324 etc.
+    if re.search(r"deepseek[-_/]*v3(?![._\d])", s):
+        return "v3"
     # R1-0528 — the R1 retrain on the V3 chat template.
     if re.search(r"deepseek.*r1[-_]?0528", s):
-        return True
+        return "v3"
     # Forward-cover V4 / V5 (per upstream V4 card both inherit the V3
     # template; cheap to include and avoids a future regression when a
     # user serves a V4 checkpoint with ``--tool-call-parser deepseek_v3``).
     if re.search(r"deepseek[-_/]*v[45]", s):
-        return True
-    return False
+        return "v3"
+    return None
 
 
 def warn_misbound_deepseek_v3_parser(
     model_path: str, tool_call_parser: str | None
 ) -> str | None:
-    """If the user explicitly bound a deepseek_v3-family parser to a
-    model that cannot emit the V3 wire shape, return a single-line
-    warning string. Return ``None`` for the in-spec cases (no warning).
+    """If the user explicitly bound a DeepSeek V3-template-family parser
+    to a model that cannot emit the matching wire shape, return a
+    single-line warning string. Return ``None`` for in-spec cases.
+
+    Two failure classes are covered:
+      1. **Out-of-lineage** — V3-family parser bound to a model that
+         isn't a V3-template checkpoint at all (R1-Distill, V2.x,
+         Qwen/Llama-arch SFTs). Emits the V2-style envelope or prose;
+         the V3-family parser refuses → ``arguments="{}"``. This is the
+         Sven r12 HIGH-1 case.
+      2. **Cross-sub-family** — V3 parser bound to a V3.1 checkpoint, or
+         V3.1 parser bound to a V3-line checkpoint. Both ends sit inside
+         the V3-template lineage so the outer envelope matches, but the
+         per-block body shape differs (V3 wraps the args in a fenced
+         JSON code block, V3.1 emits raw ``NAME<sep>{json}``). The
+         parser whose body regex doesn't match drops the block silently
+         → same empty-args failure (codex r1 P2 on this PR).
 
     Caller (cli.py / serve entrypoint) decides whether to logger.warning
     or stderr.print; this helper is pure so the boundary is unit-
-    testable without an active logger and a clean stderr to assert
-    against.
+    testable without an active logger.
 
     Why warn instead of reject: the parser-flag override is the user's
     declared intent. The historical D-DSV31 hotfix exists *because* a
@@ -702,17 +732,45 @@ def warn_misbound_deepseek_v3_parser(
     """
     if tool_call_parser not in _DEEPSEEK_V3_FAMILY_PARSERS:
         return None
-    if _model_emits_deepseek_v3_wire(model_path):
+    template = _deepseek_template_family(model_path)
+    # In-spec cases — parser matches the model's chat-template sub-family.
+    if tool_call_parser in _DEEPSEEK_V3_BODY_PARSERS and template == "v3":
         return None
+    if tool_call_parser in _DEEPSEEK_V31_BODY_PARSERS and template == "v31":
+        return None
+
     # Suggest the auto-detected parser if one would have applied — that's
-    # the most actionable nudge for the typical user who picked the V3
-    # parser by mistake.
+    # the most actionable nudge for the typical user who picked the wrong
+    # parser by mistake. Critically, this also lights up the
+    # cross-sub-family case: ``deepseek_v31`` parser on R1-0528 will see
+    # auto suggest ``deepseek_v3`` here, which is the correct fix.
     auto = detect_model_config(model_path)
     suggestion = (
         f" Auto-detect would pick '{auto.tool_call_parser}' for this model."
         if auto is not None and auto.tool_call_parser
         else ""
     )
+
+    # Tailor the diagnosis to the failure class so the message is
+    # actionable instead of generic.
+    if template in {"v3", "v31"}:
+        # Cross-sub-family inside the V3 template lineage.
+        expected_body = (
+            "`NAME<｜tool▁sep｜>{…json…}`"
+            if template == "v31"
+            else "`function<｜tool▁sep｜>NAME\\n```json\\n{…}\\n````"
+        )
+        return (
+            f"--tool-call-parser={tool_call_parser!r} is bound to "
+            f"{model_path!r}, which inherits the DeepSeek-V3.{('1' if template == 'v31' else '0')}"
+            f" chat template (body shape {expected_body}). The bound "
+            "parser expects a DIFFERENT body shape — tool-call blocks "
+            f"will be dropped and arguments will be empty.{suggestion} "
+            "Drop the explicit --tool-call-parser flag to let "
+            "auto-detect pick the matching V3-family parser."
+        )
+
+    # Out-of-lineage (Sven r12 HIGH-1 case).
     return (
         f"--tool-call-parser={tool_call_parser!r} is bound to "
         f"{model_path!r}, which is NOT a DeepSeek-V3 chat-template "

--- a/vllm_mlx/model_auto_config.py
+++ b/vllm_mlx/model_auto_config.py
@@ -661,39 +661,48 @@ def _classify_deepseek_template_name(s: str) -> str | None:
     classifier on BOTH the user-supplied path AND the alias-resolved HF
     path without duplicating the pattern logic.
 
-    Codex r3 P3 fix: the R1-Distill reject is scoped to the model-name
-    component (last path segment) rather than the full path, because a
-    legitimate local serve like
-    ``/models/distillations/deepseek-ai/DeepSeek-V3.1-0324`` carries
-    ``distill`` in the parent directory but the checkpoint itself is a
-    valid V3.1 model. A full-path substring match would warn falsely
-    there even on the correct ``deepseek_v31`` parser.
+    All pattern matches are scoped to the model-name component (last
+    non-empty path segment) rather than the full path, so:
+
+    * The R1-Distill reject (codex r3 P3) is not tripped by a
+      ``distillations`` parent dir.
+    * The V3 / V3.1 / R1-0528 / V4-V5 positive classifiers do not fire
+      on a parent dir like ``/models/DeepSeek-V3/qwen-model`` whose
+      checkpoint is actually a Qwen variant (codex r4 BLOCKING — the
+      r3 fix only scoped the reject, not the positive classifiers).
+
+    Single-segment scoping works for genuine HF paths because every
+    DeepSeek checkpoint's MODEL NAME carries its own family marker:
+    ``DeepSeek-V3-0324``, ``DeepSeek-V3.1-0324``,
+    ``DeepSeek-R1-0528-Qwen3-8B``, ``DeepSeek-R1-Distill-Qwen-1.5B-4bit``.
+    The ``deepseek-ai`` / ``mlx-community`` org segment is informational
+    and never load-bearing for sub-family identification.
     """
     s = s.lower()
     # Extract the model-name component (last non-empty path segment).
     # Empty or all-slash inputs collapse to the full string so the
     # classifier still produces ``None`` rather than crashing.
-    tail = s.rstrip("/").rsplit("/", 1)[-1] or s
+    parts = [p for p in s.rstrip("/").split("/") if p]
+    name = parts[-1] if parts else s
     # R1-Distill family is V2 / Qwen2-arch, NOT V3. Explicit reject for
-    # BOTH sub-families. Scoped to ``tail`` so a ``distillations``
-    # parent dir doesn't trip the gate.
-    if "distill" in tail:
+    # BOTH sub-families.
+    if "distill" in name:
         return None
     # V3.1 — distinct chat template, ordered BEFORE the bare V3 check
     # so the more specific pattern wins (V3.1 contains "v3" as a
     # substring after the dot is stripped by the loose regex).
-    if re.search(r"deepseek[-_/]*v3\.\d", s):
+    if re.search(r"deepseek[-_]*v3\.\d", name):
         return "v31"
     # V3 vanilla — V3-0324 etc.
-    if re.search(r"deepseek[-_/]*v3(?![._\d])", s):
+    if re.search(r"deepseek[-_]*v3(?![._\d])", name):
         return "v3"
     # R1-0528 — the R1 retrain on the V3 chat template.
-    if re.search(r"deepseek.*r1[-_]?0528", s):
+    if re.search(r"deepseek.*r1[-_]?0528", name):
         return "v3"
     # Forward-cover V4 / V5 (per upstream V4 card both inherit the V3
     # template; cheap to include and avoids a future regression when a
     # user serves a V4 checkpoint with ``--tool-call-parser deepseek_v3``).
-    if re.search(r"deepseek[-_/]*v[45]", s):
+    if re.search(r"deepseek[-_]*v[45]", name):
         return "v3"
     return None
 


### PR DESCRIPTION
## Summary

**Sven r12 dogfood HIGH-1 verdict: WRONG-MODEL ARTIFACT** (not a parser bug).

Reproduced Sven's exact case (`DeepSeek-R1-Distill-Qwen-1.5B-4bit` + `--tool-call-parser deepseek_v3` + `tool_choice=required` → `arguments="{}"`) and confirmed the auto-detect path already routes the R1-distill family correctly to the legacy `deepseek` parser. The empty-args bug fires only when the user **explicitly overrides** with a V3-family parser on a Qwen2/Llama2-arch checkpoint that physically cannot emit the V3 fenced-JSON wire shape.

Parser is working as designed. The actionable improvement is making the mismatch loud so agent-SDK integrators stop blaming the parser when the model is the wrong target.

## Verification

| Case | Auto-detect | With `--tool-call-parser deepseek_v3` |
| ---- | ----------- | ------------------------------------- |
| `DeepSeek-R1-Distill-Qwen-1.5B-4bit` | → `deepseek` (legacy, correct) | Hallucinates V3 envelope, parser refuses, `arguments="{}"` |
| `DeepSeek-R1-0528-Qwen3-8B-4bit` | → `deepseek_v3` (correct) | Same wire shape the parser expects (in-spec, no warning) |

Sven's tested model `mlx-community/DeepSeek-R1-Distill-Qwen-1.5B-4bit` is a Qwen2-arch SFT — its tokenizer does NOT carry the V3 fullwidth-pipe special tokens (`<｜tool▁calls▁begin｜>` etc.), so the forced-tool-call prefix injection produces wire-token glyphs the model has no trained semantic for. It either emits prose or hallucinates the closing tokens; the parser correctly returns empty args.

## Changes

* **`vllm_mlx/model_auto_config.py`** — new pure helper `warn_misbound_deepseek_v3_parser(model_path, parser)` returns a single-line warning when the bound parser is in `{deepseek_v3, deepseek_v31, deepseek_r1_0528}` AND the model is NOT a V3 chat-template checkpoint (V3 / V3.1 / R1-0528 / forward-cover V4 + V5). The `*Distill*` substring is explicitly rejected so the R1-Distill family always lands in the warn path.
* **`vllm_mlx/cli.py`** — wires the helper into the serve entrypoint after the parser auto-detect block. Uses `logger.warning(msg, stacklevel=2)` so structured-log sinks attribute the call to the CLI. Try/except-bounded so a helper-side regression cannot block boot.
* **`tests/test_model_auto_config.py`** — new `TestWarnMisboundDeepseekV3Parser` class (25+ parametrized cases) plus `test_deepseek_r1_distill_routes_to_legacy_parser` pinning the auto-detect contract for 8 common distill flavours (1.5B/7B/14B/32B Qwen + 8B/70B Llama) so a future regex edit that flipped them to `deepseek_v3` would re-surface Sven's HIGH-1 as a default-config regression rather than a misbind.

## Live engine smoke test

```
# WARN — bound but model can't emit V3
$ rapid-mlx serve mlx-community/DeepSeek-R1-Distill-Qwen-1.5B-4bit \
    --enable-auto-tool-choice --tool-call-parser deepseek_v3 --reasoning-parser deepseek_r1
WARNING:rapid_mlx.cli:--tool-call-parser='deepseek_v3' is bound to
  'mlx-community/DeepSeek-R1-Distill-Qwen-1.5B-4bit', which is NOT a
  DeepSeek-V3 chat-template checkpoint. ... Auto-detect would pick
  'deepseek' for this model. Drop the explicit --tool-call-parser flag
  to let auto-detect choose, or use --tool-call-parser hermes for
  Qwen/Llama-arch distills.

# NO WARN — auto-detect picks 'deepseek' (legacy parser)
$ rapid-mlx serve mlx-community/DeepSeek-R1-Distill-Qwen-1.5B-4bit
INFO:rapid_mlx.cli:Auto-configured --tool-call-parser deepseek

# NO WARN — real V3 model with V3 parser is in-spec
$ rapid-mlx serve mlx-community/DeepSeek-R1-0528-Qwen3-8B-4bit \
    --enable-auto-tool-choice --tool-call-parser deepseek_v3 --reasoning-parser deepseek_r1
(no misbind warning)
```

## Test plan

- [x] `pytest tests/test_model_auto_config.py` (153 → 187 passing, +34)
- [x] `pytest tests/test_deepseek_v3_tool_parser.py tests/test_deepseek_v3_dedicated_parser.py tests/test_tool_choice_enforcement.py tests/test_tool_parser_coverage.py tests/test_tool_parsers.py tests/test_tool_call_streaming_parity.py` (447 passing, no regressions)
- [x] `pytest tests/test_cli_argcomplete.py tests/test_cli_config_fidelity.py tests/test_cli_info.py` (26 passing)
- [x] `ruff check` + `ruff format --check` clean on changed files
- [x] Live serve smoke: warning fires on misbind, NOT on default path, NOT on legitimate V3 model

🤖 Generated with [Claude Code](https://claude.com/claude-code)