### PR TITLE
fix(tempfile): managed_tempfile helper + apply to leak sites (closes #719)

### DIFF
--- a/tests/test_cli_chat.py
+++ b/tests/test_cli_chat.py
@@ -1926,10 +1926,18 @@ def test_spawn_chat_server_sets_chat_spawn_env(monkeypatch, tmp_path):
 
     class _FakePopen:
         def __init__(
-            self, cmd, *, stdout=None, stderr=None, start_new_session=False, env=None
+            self,
+            cmd,
+            *,
+            stdout=None,
+            stderr=None,
+            start_new_session=False,
+            env=None,
+            preexec_fn=None,
         ):
             captured["env"] = env
             captured["cmd"] = cmd
+            captured["preexec_fn"] = preexec_fn
 
         def poll(self):
             return None
@@ -2352,11 +2360,21 @@ def test_spawn_chat_server_releases_log_handle_under_signal_mask(monkeypatch, tm
         def getsockname(self):
             return ("127.0.0.1", 54322)
 
+    captured_preexec: dict = {}
+
     class _FakePopen:
         def __init__(
-            self, cmd, *, stdout=None, stderr=None, start_new_session=False, env=None
+            self,
+            cmd,
+            *,
+            stdout=None,
+            stderr=None,
+            start_new_session=False,
+            env=None,
+            preexec_fn=None,
         ):
             milestones["popen"] = _current_blocked()
+            captured_preexec["fn"] = preexec_fn
 
         def poll(self):
             return None
@@ -2447,3 +2465,36 @@ def test_spawn_chat_server_releases_log_handle_under_signal_mask(monkeypatch, tm
         "would inherit the ignored disposition and refuse normal "
         f"shutdown. changes={sig_ign_changes}"
     )
+
+    # Pr_validate round-3 BLOCKING: a preexec_fn MUST be passed to
+    # Popen() AND it must, when called, unblock SIGTERM and SIGINT.
+    # Without it the child inherits the blocked mask and refuses to
+    # honour normal shutdown signals.
+    preexec_fn = captured_preexec.get("fn")
+    assert preexec_fn is not None, (
+        "Pr_validate round-3 BLOCKING regression: spawn did not pass "
+        "preexec_fn to Popen() — the child will inherit the blocked "
+        "signal mask and ignore SIGTERM/SIGINT."
+    )
+    # Simulate the child's post-fork pre-exec moment: block SIGTERM
+    # ourselves (as the spawn does in the parent), then call the
+    # preexec_fn and observe that the signals are unblocked.
+    saved_mask = real_pthread_sigmask(
+        _signal.SIG_BLOCK, {_signal.SIGTERM, _signal.SIGINT}
+    )
+    try:
+        # ``preexec_fn`` runs in the child after fork. Calling it here
+        # simulates what it would do to the child's mask.
+        preexec_fn()
+        # After preexec_fn, SIGTERM and SIGINT MUST NOT be in the
+        # blocked set.
+        after = set(real_pthread_sigmask(_signal.SIG_BLOCK, set()))
+        assert _signal.SIGTERM not in after, (
+            f"preexec_fn did not unblock SIGTERM; mask after={after}"
+        )
+        assert _signal.SIGINT not in after, (
+            f"preexec_fn did not unblock SIGINT; mask after={after}"
+        )
+    finally:
+        # Restore the simulated parent state.
+        real_pthread_sigmask(_signal.SIG_SETMASK, saved_mask)

--- a/tests/test_cli_chat.py
+++ b/tests/test_cli_chat.py
@@ -2272,49 +2272,69 @@ def test_serve_allow_abbrev_disabled_rejects_ambiguous_no_thi(capsys):
 
 
 def test_spawn_chat_server_releases_log_handle_under_signal_mask(monkeypatch, tmp_path):
-    """Codex rounds 1 + 5 — the register/attribute-set/release handoff
-    AND the ``Popen()`` call itself must be inside the SIG_IGN mask.
+    """Codex rounds 1 + 5 + pr_validate r2 — the
+    register/attribute-set/release handoff AND the ``Popen()`` call
+    itself must run with SIGTERM/SIGINT BLOCKED (not ignored).
 
-    Codex round-1 BLOCKING #1 was: a signal landing between
+    Codex round-1 BLOCKING #1: a signal landing between
     ``_active_procs.append`` and the caller's ``handle.release()``
     would let ``_teardown_proc``'s keep-non-empty-log policy be undone
     by the context manager's ``finally``.
 
-    Codex round-5 BLOCKING #1 was: even after the round-1 fix, the
-    mask was installed AFTER ``Popen()`` returned. A signal landing
-    between ``Popen()`` and the mask going up would let
-    ``_cleanup()`` walk an empty ``_active_procs`` and ``sys.exit``,
-    orphaning the just-spawned child.
+    Codex round-5 BLOCKING #1: the mask was installed AFTER ``Popen()``
+    returned. A signal landing between ``Popen()`` and the mask going
+    up would let ``_cleanup()`` walk an empty ``_active_procs`` and
+    ``sys.exit``, orphaning the just-spawned child.
 
-    This test asserts (under fake socket/Popen/signal):
+    Pr_validate round-2 BLOCKING: the prior fix used
+    ``signal.signal(SIG_IGN)``. Signal *disposition* is inherited by
+    forked children — so the spawned server inherited ``SIG_IGN`` and
+    refused to honour normal shutdown signals. The fix is
+    ``pthread_sigmask(SIG_BLOCK, ...)``, which only affects the
+    parent's thread mask and is reset to the default at ``exec``.
 
-    1. SIGTERM and SIGINT are installed as ``SIG_IGN`` BEFORE
-       ``Popen()`` runs.
-    2. ``Popen()`` happens while the handlers are SIG_IGN.
-    3. ``register_in.append`` and the ``_rapid_mlx_log_path``
-       assignment happen while the handlers are SIG_IGN.
-    4. ``handle.release()`` happens while the handlers are SIG_IGN.
-    5. The original handlers are restored after the critical section.
+    This test asserts (under fake socket/Popen + spy on
+    ``pthread_sigmask``):
+
+    1. SIGTERM and SIGINT are in the BLOCKED set BEFORE ``Popen()``
+       runs.
+    2. ``Popen()`` happens while the signals are blocked.
+    3. ``register_in.append`` happens while blocked.
+    4. ``handle.release()`` happens while blocked.
+    5. The original mask is restored after the critical section.
+    6. The installed signal HANDLER (disposition) is never changed —
+       so children inherit the parent's default, NOT ``SIG_IGN``.
     """
     import signal as _signal
 
     from vllm_mlx._tempfile_safe import managed_tempfile_path
 
-    signal_changes: list[tuple[int, object]] = []
+    # Track every ``pthread_sigmask`` call. Each milestone reads the
+    # CURRENT blocked set so we can assert it includes SIGTERM+SIGINT.
+    sigmask_calls: list[tuple[int, set, set]] = []
+    real_pthread_sigmask = _signal.pthread_sigmask
+
+    def _spy_pthread_sigmask(how, mask):
+        # Capture the mask BEFORE applying.
+        prev = real_pthread_sigmask(how, mask)
+        sigmask_calls.append((how, set(mask), set(prev)))
+        return prev
+
+    # Also spy on signal.signal — for this test it MUST NOT change the
+    # SIGTERM/SIGINT disposition.
+    signal_disposition_changes: list[tuple[int, object]] = []
     real_signal = _signal.signal
 
     def _spy_signal(signum, handler):
-        signal_changes.append((signum, handler))
+        signal_disposition_changes.append((signum, handler))
         return real_signal(signum, handler)
 
-    # Track signal state at each milestone so we can assert ordering
-    # AND that each milestone happened while the masks were live.
-    milestones: dict[str, tuple[object, object]] = {}
+    milestones: dict[str, set] = {}
 
-    def _current_handlers() -> tuple[object, object]:
-        # ``signal.getsignal`` is the public way to read the installed
-        # handler without changing it.
-        return _signal.getsignal(_signal.SIGTERM), _signal.getsignal(_signal.SIGINT)
+    def _current_blocked() -> set:
+        # ``SIG_BLOCK`` with an empty set queries the current mask
+        # without changing it.
+        return set(real_pthread_sigmask(_signal.SIG_BLOCK, set()))
 
     class _FakeSocket:
         def __init__(self, *_, **__):
@@ -2336,40 +2356,33 @@ def test_spawn_chat_server_releases_log_handle_under_signal_mask(monkeypatch, tm
         def __init__(
             self, cmd, *, stdout=None, stderr=None, start_new_session=False, env=None
         ):
-            milestones["popen"] = _current_handlers()
+            milestones["popen"] = _current_blocked()
 
         def poll(self):
             return None
 
-    # The list captures handler state at append-time.
     class _SpyList(list):
         def append(self, item):
-            milestones["append"] = _current_handlers()
+            milestones["append"] = _current_blocked()
             super().append(item)
 
-    # Trap proc._rapid_mlx_log_path = ... via a watching subclass of the
-    # default object. Instead of patching Popen further, we instrument
-    # the spy list's append (which is right before the attribute set)
-    # and add another milestone from a wrapped handle.
     from vllm_mlx._tempfile_safe import _TempfileHandle
 
     class _SpyHandle(_TempfileHandle):
         def release(self):
-            milestones["release"] = _current_handlers()
+            milestones["release"] = _current_blocked()
             return super().release()
 
     monkeypatch.setattr("socket.socket", _FakeSocket)
     monkeypatch.setattr("subprocess.Popen", _FakePopen)
+    monkeypatch.setattr(_signal, "pthread_sigmask", _spy_pthread_sigmask)
     monkeypatch.setattr(_signal, "signal", _spy_signal)
 
     register_in: list = _SpyList()
     with managed_tempfile_path(
         prefix="rapid-mlx-chat-test-", suffix=".log", dir=str(tmp_path)
     ) as real_handle:
-        # Wrap so we can also instrument release().
         handle = _SpyHandle(real_handle.path)
-        # Keep the real handle's registry entry alive for cleanup —
-        # release the wrapper instead.
         assert real_handle.released is False
         proc, _base_url = cli._spawn_chat_server(
             "qwen3.5-4b-4bit",
@@ -2379,12 +2392,12 @@ def test_spawn_chat_server_releases_log_handle_under_signal_mask(monkeypatch, tm
         )
         assert handle.released is True, (
             "handoff race: handle was not released inside the "
-            "spawn's signal-masked critical section"
+            "spawn's signal-blocked critical section"
         )
         assert proc in register_in
         assert getattr(proc, "_rapid_mlx_log_path", None) == handle.path
-        # Clean up the real handle too so the surrounding
-        # managed_tempfile_path context exits cleanly.
+        # Clean up the real handle too so the surrounding context
+        # exits cleanly.
         real_handle.release()
         import os as _os
 
@@ -2393,30 +2406,44 @@ def test_spawn_chat_server_releases_log_handle_under_signal_mask(monkeypatch, tm
         except OSError:
             pass
 
-    # All four milestones MUST have been captured.
+    # Each milestone MUST have had both signals in the blocked set.
     for name in ("popen", "append", "release"):
         assert name in milestones, f"milestone {name!r} never ran"
-        term_h, int_h = milestones[name]
-        assert term_h is _signal.SIG_IGN, (
-            f"{name}: SIGTERM was not SIG_IGN ({term_h!r}). The "
-            f"register/attribute/release handoff is escaping the mask."
+        blocked = milestones[name]
+        assert _signal.SIGTERM in blocked, (
+            f"{name}: SIGTERM not blocked; blocked={blocked}"
         )
-        assert int_h is _signal.SIG_IGN, (
-            f"{name}: SIGINT was not SIG_IGN ({int_h!r}). The "
-            f"register/attribute/release handoff is escaping the mask."
+        assert _signal.SIGINT in blocked, (
+            f"{name}: SIGINT not blocked; blocked={blocked}"
         )
 
-    # Mask restoration: the LAST install for each signum should NOT be
-    # SIG_IGN. (The pre-test handler is captured by the spy in
-    # ``signal_changes`` and re-installed by the spawn's ``finally``.)
-    sig_ign_signums = {s for s, h in signal_changes if h is _signal.SIG_IGN}
-    assert _signal.SIGTERM in sig_ign_signums
-    assert _signal.SIGINT in sig_ign_signums
-    last_term = next(
-        (h for s, h in reversed(signal_changes) if s == _signal.SIGTERM), None
+    # The mask must have been restored — the LAST sigmask call should
+    # be a ``SIG_SETMASK`` to the previous mask. The previous mask did
+    # NOT include SIGTERM/SIGINT (the test process didn't block them),
+    # so SIGTERM/SIGINT are NOT in the post-critical-section blocked
+    # set.
+    final_blocked = _current_blocked()
+    assert _signal.SIGTERM not in final_blocked, (
+        f"SIGTERM still blocked after spawn returned; blocked={final_blocked}"
     )
-    last_int = next(
-        (h for s, h in reversed(signal_changes) if s == _signal.SIGINT), None
+    assert _signal.SIGINT not in final_blocked, (
+        f"SIGINT still blocked after spawn returned; blocked={final_blocked}"
     )
-    assert last_term is not _signal.SIG_IGN, "SIGTERM mask never restored"
-    assert last_int is not _signal.SIG_IGN, "SIGINT mask never restored"
+
+    # Pr_validate round-2 BLOCKING: the disposition for SIGTERM/SIGINT
+    # MUST NOT have been touched. If we set SIG_IGN, the just-spawned
+    # child would inherit it. ``signal.signal`` is allowed to be called
+    # for OTHER signums (e.g. by setup hooks elsewhere); we only care
+    # that SIGTERM and SIGINT were never installed as SIG_IGN by the
+    # spawn helper itself.
+    sig_ign_changes = [
+        (s, h)
+        for s, h in signal_disposition_changes
+        if s in (_signal.SIGTERM, _signal.SIGINT) and h is _signal.SIG_IGN
+    ]
+    assert not sig_ign_changes, (
+        "Pr_validate round-2 BLOCKING regression: spawn used "
+        "signal.signal(SIG_IGN) for SIGTERM/SIGINT — child server "
+        "would inherit the ignored disposition and refuse normal "
+        f"shutdown. changes={sig_ign_changes}"
+    )

--- a/tests/test_cli_chat.py
+++ b/tests/test_cli_chat.py
@@ -2272,22 +2272,29 @@ def test_serve_allow_abbrev_disabled_rejects_ambiguous_no_thi(capsys):
 
 
 def test_spawn_chat_server_releases_log_handle_under_signal_mask(monkeypatch, tmp_path):
-    """Codex round-1 BLOCKING #1 — the
-    register/attribute-set/release handoff must be atomic w.r.t.
-    SIGTERM and SIGINT.
+    """Codex rounds 1 + 5 — the register/attribute-set/release handoff
+    AND the ``Popen()`` call itself must be inside the SIG_IGN mask.
 
-    Without atomicity, a signal landing between ``_active_procs.append``
-    and ``handle.release()`` (which currently were in different scopes)
-    would fire ``_teardown_proc`` (which keeps non-empty logs for
-    post-mortem) and then the surrounding context manager's
-    ``finally`` would unlink the kept log anyway. The fix passes the
-    handle into ``_spawn_chat_server`` and performs all three steps
-    under a single SIG_IGN mask. This test asserts:
+    Codex round-1 BLOCKING #1 was: a signal landing between
+    ``_active_procs.append`` and the caller's ``handle.release()``
+    would let ``_teardown_proc``'s keep-non-empty-log policy be undone
+    by the context manager's ``finally``.
 
-    1. ``log_handle.release()`` is called BEFORE the spawn returns.
-    2. SIGTERM is masked while register/attribute/release run.
-    3. The mask is restored to the previous handler after the
-       critical section.
+    Codex round-5 BLOCKING #1 was: even after the round-1 fix, the
+    mask was installed AFTER ``Popen()`` returned. A signal landing
+    between ``Popen()`` and the mask going up would let
+    ``_cleanup()`` walk an empty ``_active_procs`` and ``sys.exit``,
+    orphaning the just-spawned child.
+
+    This test asserts (under fake socket/Popen/signal):
+
+    1. SIGTERM and SIGINT are installed as ``SIG_IGN`` BEFORE
+       ``Popen()`` runs.
+    2. ``Popen()`` happens while the handlers are SIG_IGN.
+    3. ``register_in.append`` and the ``_rapid_mlx_log_path``
+       assignment happen while the handlers are SIG_IGN.
+    4. ``handle.release()`` happens while the handlers are SIG_IGN.
+    5. The original handlers are restored after the critical section.
     """
     import signal as _signal
 
@@ -2299,6 +2306,15 @@ def test_spawn_chat_server_releases_log_handle_under_signal_mask(monkeypatch, tm
     def _spy_signal(signum, handler):
         signal_changes.append((signum, handler))
         return real_signal(signum, handler)
+
+    # Track signal state at each milestone so we can assert ordering
+    # AND that each milestone happened while the masks were live.
+    milestones: dict[str, tuple[object, object]] = {}
+
+    def _current_handlers() -> tuple[object, object]:
+        # ``signal.getsignal`` is the public way to read the installed
+        # handler without changing it.
+        return _signal.getsignal(_signal.SIGTERM), _signal.getsignal(_signal.SIGINT)
 
     class _FakeSocket:
         def __init__(self, *_, **__):
@@ -2316,75 +2332,91 @@ def test_spawn_chat_server_releases_log_handle_under_signal_mask(monkeypatch, tm
         def getsockname(self):
             return ("127.0.0.1", 54322)
 
-    # When Popen runs, capture whether the path was already released
-    # (the release MUST happen during the critical section, which is
-    # after Popen — so it should NOT yet be released here).
-    release_state: dict = {}
-
     class _FakePopen:
         def __init__(
             self, cmd, *, stdout=None, stderr=None, start_new_session=False, env=None
         ):
-            release_state["released_at_popen"] = None  # set later
+            milestones["popen"] = _current_handlers()
 
         def poll(self):
             return None
+
+    # The list captures handler state at append-time.
+    class _SpyList(list):
+        def append(self, item):
+            milestones["append"] = _current_handlers()
+            super().append(item)
+
+    # Trap proc._rapid_mlx_log_path = ... via a watching subclass of the
+    # default object. Instead of patching Popen further, we instrument
+    # the spy list's append (which is right before the attribute set)
+    # and add another milestone from a wrapped handle.
+    from vllm_mlx._tempfile_safe import _TempfileHandle
+
+    class _SpyHandle(_TempfileHandle):
+        def release(self):
+            milestones["release"] = _current_handlers()
+            return super().release()
 
     monkeypatch.setattr("socket.socket", _FakeSocket)
     monkeypatch.setattr("subprocess.Popen", _FakePopen)
     monkeypatch.setattr(_signal, "signal", _spy_signal)
 
-    register_in: list = []
+    register_in: list = _SpyList()
     with managed_tempfile_path(
         prefix="rapid-mlx-chat-test-", suffix=".log", dir=str(tmp_path)
-    ) as handle:
-        assert handle.released is False
+    ) as real_handle:
+        # Wrap so we can also instrument release().
+        handle = _SpyHandle(real_handle.path)
+        # Keep the real handle's registry entry alive for cleanup —
+        # release the wrapper instead.
+        assert real_handle.released is False
         proc, _base_url = cli._spawn_chat_server(
             "qwen3.5-4b-4bit",
             handle.path,
             register_in=register_in,
             log_handle=handle,
         )
-        # Inside the ``with`` body but AFTER the spawn returns, the
-        # handle MUST already be released so the surrounding
-        # ``finally`` is a no-op for this path.
         assert handle.released is True, (
             "handoff race: handle was not released inside the "
             "spawn's signal-masked critical section"
         )
-        # The proc must be in register_in and have the path attribute,
-        # both set inside the same critical section.
         assert proc in register_in
         assert getattr(proc, "_rapid_mlx_log_path", None) == handle.path
+        # Clean up the real handle too so the surrounding
+        # managed_tempfile_path context exits cleanly.
+        real_handle.release()
+        import os as _os
 
-    # Both SIGTERM and SIGINT must have been masked with SIG_IGN, then
-    # restored to their previous handlers. We assert:
-    #   (a) at least one SIG_IGN install for each signum, and
-    #   (b) the LAST install for each signum is the restored handler
-    #       (i.e. not SIG_IGN). The pre-test handler for both is the
-    #       default handler captured by ``real_signal``; the spawn
-    #       should restore that exact value.
+        try:
+            _os.unlink(real_handle.path)
+        except OSError:
+            pass
+
+    # All four milestones MUST have been captured.
+    for name in ("popen", "append", "release"):
+        assert name in milestones, f"milestone {name!r} never ran"
+        term_h, int_h = milestones[name]
+        assert term_h is _signal.SIG_IGN, (
+            f"{name}: SIGTERM was not SIG_IGN ({term_h!r}). The "
+            f"register/attribute/release handoff is escaping the mask."
+        )
+        assert int_h is _signal.SIG_IGN, (
+            f"{name}: SIGINT was not SIG_IGN ({int_h!r}). The "
+            f"register/attribute/release handoff is escaping the mask."
+        )
+
+    # Mask restoration: the LAST install for each signum should NOT be
+    # SIG_IGN. (The pre-test handler is captured by the spy in
+    # ``signal_changes`` and re-installed by the spawn's ``finally``.)
     sig_ign_signums = {s for s, h in signal_changes if h is _signal.SIG_IGN}
-    assert _signal.SIGTERM in sig_ign_signums, (
-        f"SIGTERM not masked during handoff; changes={signal_changes}"
-    )
-    assert _signal.SIGINT in sig_ign_signums, (
-        f"SIGINT not masked during handoff; changes={signal_changes}"
-    )
-    # Codex pr_validate round-1 NIT: explicitly verify the mask was
-    # restored — the last install for each signum should NOT still be
-    # SIG_IGN.
+    assert _signal.SIGTERM in sig_ign_signums
+    assert _signal.SIGINT in sig_ign_signums
     last_term = next(
         (h for s, h in reversed(signal_changes) if s == _signal.SIGTERM), None
     )
     last_int = next(
         (h for s, h in reversed(signal_changes) if s == _signal.SIGINT), None
     )
-    assert last_term is not _signal.SIG_IGN, (
-        f"SIGTERM mask never restored; last install was SIG_IGN. "
-        f"changes={signal_changes}"
-    )
-    assert last_int is not _signal.SIG_IGN, (
-        f"SIGINT mask never restored; last install was SIG_IGN. "
-        f"changes={signal_changes}"
-    )
+    assert last_term is not _signal.SIG_IGN, "SIGTERM mask never restored"
+    assert last_int is not _signal.SIG_IGN, "SIGINT mask never restored"

--- a/tests/test_cli_chat.py
+++ b/tests/test_cli_chat.py
@@ -1076,11 +1076,15 @@ def test_chat_command_switch_model_rollback_on_wait_failure(monkeypatch, capsys)
         def kill(self):
             self._terminated = True
 
-    def _fake_spawn(model, log_path, served_name=None, *, register_in=None):
+    def _fake_spawn(
+        model, log_path, served_name=None, *, register_in=None, log_handle=None
+    ):
         proc = _FakeProc(model)
         spawned.append(proc)
         if register_in is not None:
             register_in.append(proc)
+        if log_handle is not None:
+            log_handle.release()
         return proc, f"http://127.0.0.1:{port}"
 
     wait_calls = {"n": 0}
@@ -1736,7 +1740,9 @@ def test_teardown_unlinks_only_empty_log_files(tmp_path, monkeypatch):
     # --- Case 1: empty log → unlinked on swap ---
     call_n = {"n": 0}
 
-    def _spawn_empty(model, log_path, served_name=None, *, register_in=None):
+    def _spawn_empty(
+        model, log_path, served_name=None, *, register_in=None, log_handle=None
+    ):
         # First spawn: backed by empty_log (the one that should be
         # unlinked when swapped out). Second spawn: a noop replacement.
         call_n["n"] += 1
@@ -1748,6 +1754,8 @@ def test_teardown_unlinks_only_empty_log_files(tmp_path, monkeypatch):
             p = _FakeProc(tmp)
         if register_in is not None:
             register_in.append(p)
+        if log_handle is not None:
+            log_handle.release()
         return p, f"http://127.0.0.1:{port_e}"
 
     monkeypatch.setattr(cli, "_spawn_chat_server", _spawn_empty)
@@ -1769,7 +1777,9 @@ def test_teardown_unlinks_only_empty_log_files(tmp_path, monkeypatch):
     # --- Case 2: full log → preserved on swap ---
     call_n2 = {"n": 0}
 
-    def _spawn_full(model, log_path, served_name=None, *, register_in=None):
+    def _spawn_full(
+        model, log_path, served_name=None, *, register_in=None, log_handle=None
+    ):
         call_n2["n"] += 1
         if call_n2["n"] == 1:
             p = _FakeProc(full_log)
@@ -1779,6 +1789,8 @@ def test_teardown_unlinks_only_empty_log_files(tmp_path, monkeypatch):
             p = _FakeProc(tmp)
         if register_in is not None:
             register_in.append(p)
+        if log_handle is not None:
+            log_handle.release()
         return p, f"http://127.0.0.1:{port_f}"
 
     monkeypatch.setattr(cli, "_spawn_chat_server", _spawn_full)
@@ -2257,3 +2269,101 @@ def test_serve_allow_abbrev_disabled_rejects_ambiguous_no_thi(capsys):
         cli.main()
     err = capsys.readouterr().err
     assert "--no-thi" in err or "unrecognized" in err.lower()
+
+
+def test_spawn_chat_server_releases_log_handle_under_signal_mask(monkeypatch, tmp_path):
+    """Codex round-1 BLOCKING #1 — the
+    register/attribute-set/release handoff must be atomic w.r.t.
+    SIGTERM and SIGINT.
+
+    Without atomicity, a signal landing between ``_active_procs.append``
+    and ``handle.release()`` (which currently were in different scopes)
+    would fire ``_teardown_proc`` (which keeps non-empty logs for
+    post-mortem) and then the surrounding context manager's
+    ``finally`` would unlink the kept log anyway. The fix passes the
+    handle into ``_spawn_chat_server`` and performs all three steps
+    under a single SIG_IGN mask. This test asserts:
+
+    1. ``log_handle.release()`` is called BEFORE the spawn returns.
+    2. SIGTERM is masked while register/attribute/release run.
+    3. The mask is restored to the previous handler after the
+       critical section.
+    """
+    import signal as _signal
+
+    from vllm_mlx._tempfile_safe import managed_tempfile_path
+
+    signal_changes: list[tuple[int, object]] = []
+    real_signal = _signal.signal
+
+    def _spy_signal(signum, handler):
+        signal_changes.append((signum, handler))
+        return real_signal(signum, handler)
+
+    class _FakeSocket:
+        def __init__(self, *_, **__):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_):
+            return False
+
+        def bind(self, _addr):
+            pass
+
+        def getsockname(self):
+            return ("127.0.0.1", 54322)
+
+    # When Popen runs, capture whether the path was already released
+    # (the release MUST happen during the critical section, which is
+    # after Popen — so it should NOT yet be released here).
+    release_state: dict = {}
+
+    class _FakePopen:
+        def __init__(
+            self, cmd, *, stdout=None, stderr=None, start_new_session=False, env=None
+        ):
+            release_state["released_at_popen"] = None  # set later
+
+        def poll(self):
+            return None
+
+    monkeypatch.setattr("socket.socket", _FakeSocket)
+    monkeypatch.setattr("subprocess.Popen", _FakePopen)
+    monkeypatch.setattr(_signal, "signal", _spy_signal)
+
+    register_in: list = []
+    with managed_tempfile_path(
+        prefix="rapid-mlx-chat-test-", suffix=".log", dir=str(tmp_path)
+    ) as handle:
+        assert handle.released is False
+        proc, _base_url = cli._spawn_chat_server(
+            "qwen3.5-4b-4bit",
+            handle.path,
+            register_in=register_in,
+            log_handle=handle,
+        )
+        # Inside the ``with`` body but AFTER the spawn returns, the
+        # handle MUST already be released so the surrounding
+        # ``finally`` is a no-op for this path.
+        assert handle.released is True, (
+            "handoff race: handle was not released inside the "
+            "spawn's signal-masked critical section"
+        )
+        # The proc must be in register_in and have the path attribute,
+        # both set inside the same critical section.
+        assert proc in register_in
+        assert getattr(proc, "_rapid_mlx_log_path", None) == handle.path
+
+    # Both SIGTERM and SIGINT must have been masked with SIG_IGN, then
+    # restored to their previous handlers. We assert at least one
+    # SIG_IGN install for each.
+    sig_ign_signums = {s for s, h in signal_changes if h is _signal.SIG_IGN}
+    assert _signal.SIGTERM in sig_ign_signums, (
+        f"SIGTERM not masked during handoff; changes={signal_changes}"
+    )
+    assert _signal.SIGINT in sig_ign_signums, (
+        f"SIGINT not masked during handoff; changes={signal_changes}"
+    )

--- a/tests/test_cli_chat.py
+++ b/tests/test_cli_chat.py
@@ -2358,12 +2358,33 @@ def test_spawn_chat_server_releases_log_handle_under_signal_mask(monkeypatch, tm
         assert getattr(proc, "_rapid_mlx_log_path", None) == handle.path
 
     # Both SIGTERM and SIGINT must have been masked with SIG_IGN, then
-    # restored to their previous handlers. We assert at least one
-    # SIG_IGN install for each.
+    # restored to their previous handlers. We assert:
+    #   (a) at least one SIG_IGN install for each signum, and
+    #   (b) the LAST install for each signum is the restored handler
+    #       (i.e. not SIG_IGN). The pre-test handler for both is the
+    #       default handler captured by ``real_signal``; the spawn
+    #       should restore that exact value.
     sig_ign_signums = {s for s, h in signal_changes if h is _signal.SIG_IGN}
     assert _signal.SIGTERM in sig_ign_signums, (
         f"SIGTERM not masked during handoff; changes={signal_changes}"
     )
     assert _signal.SIGINT in sig_ign_signums, (
         f"SIGINT not masked during handoff; changes={signal_changes}"
+    )
+    # Codex pr_validate round-1 NIT: explicitly verify the mask was
+    # restored — the last install for each signum should NOT still be
+    # SIG_IGN.
+    last_term = next(
+        (h for s, h in reversed(signal_changes) if s == _signal.SIGTERM), None
+    )
+    last_int = next(
+        (h for s, h in reversed(signal_changes) if s == _signal.SIGINT), None
+    )
+    assert last_term is not _signal.SIG_IGN, (
+        f"SIGTERM mask never restored; last install was SIG_IGN. "
+        f"changes={signal_changes}"
+    )
+    assert last_int is not _signal.SIG_IGN, (
+        f"SIGINT mask never restored; last install was SIG_IGN. "
+        f"changes={signal_changes}"
     )

--- a/tests/test_tempfile_safe.py
+++ b/tests/test_tempfile_safe.py
@@ -314,6 +314,67 @@ def test_setup_window_exception_does_not_leak_path(monkeypatch, tmp_path):
     assert _tempfile_safe._pending_snapshot() == baseline
 
 
+def test_cleanup_unlinks_before_discarding_from_registry(monkeypatch, tmp_path):
+    """Codex round-3 BLOCKING: ordering inside the cleanup ``finally``.
+
+    The original order — ``_pending_paths.discard(path)`` first, then
+    ``os.unlink(path)`` — had a window in which a ``BaseException``
+    (Ctrl-C, SIGTERM-induced ``SystemExit``) landing between the two
+    statements would leave the file on disk WITHOUT a registry entry.
+    The atexit fallback could never see it.
+
+    Fix: unlink first, discard second. If unlink raises a
+    ``BaseException``, the path stays in the registry and atexit
+    reaps it.
+
+    Test: patch ``os.unlink`` to raise ``KeyboardInterrupt`` exactly
+    once, drive the context-exit cleanup path, and assert the path
+    is still in ``_pending_paths`` so atexit can reap it.
+    """
+    from vllm_mlx import _tempfile_safe
+
+    real_unlink = os.unlink
+    raised = {"n": 0}
+
+    def _boom_unlink(p):
+        if raised["n"] == 0 and "ut-clean-" in os.path.basename(p):
+            raised["n"] += 1
+            raise KeyboardInterrupt("simulated Ctrl-C during unlink")
+        return real_unlink(p)
+
+    monkeypatch.setattr(os, "unlink", _boom_unlink)
+
+    captured_path: list[str] = []
+    with (
+        pytest.raises(KeyboardInterrupt, match="Ctrl-C during unlink"),
+        managed_tempfile_path(
+            prefix="ut-clean-", suffix=".tmp", dir=str(tmp_path)
+        ) as h,
+    ):
+        captured_path.append(h.path)
+        assert os.path.exists(h.path)
+
+    assert captured_path, "context manager never yielded a handle"
+    leaked = captured_path[0]
+    # File survived the interrupted unlink — that's expected.
+    assert os.path.exists(leaked), (
+        "test setup error: unlink wasn't actually intercepted"
+    )
+    # BLOCKING fix: path must still be in the registry so atexit
+    # can reap it. Pre-fix the discard ran first → registry was
+    # empty → atexit blind.
+    assert leaked in _tempfile_safe._pending_snapshot(), (
+        f"registry ordering regression: {leaked} dropped from "
+        f"_pending_paths before unlink completed, atexit can no "
+        f"longer reap it"
+    )
+    # Manual cleanup to avoid polluting $TMPDIR.
+    monkeypatch.undo()
+    real_unlink(leaked)
+    with _tempfile_safe._pending_lock:
+        _tempfile_safe._pending_paths.discard(leaked)
+
+
 def _count_in_dir(d: str) -> int:
     """Count ``rapid-mlx-chat-*.log`` files in ``d``."""
     try:

--- a/tests/test_tempfile_safe.py
+++ b/tests/test_tempfile_safe.py
@@ -375,6 +375,86 @@ def test_cleanup_unlinks_before_discarding_from_registry(monkeypatch, tmp_path):
         _tempfile_safe._pending_paths.discard(leaked)
 
 
+def test_concurrent_release_during_context_exit_does_not_double_unlink(
+    monkeypatch, tmp_path
+):
+    """Pr_validate round-2 BLOCKING #2: race-free ownership transition.
+
+    The original cleanup shape was:
+
+        with _pending_lock:
+            should_unlink = not handle.released
+        if should_unlink:
+            os.unlink(path)
+
+    A concurrent ``release()`` arriving between the lock-release and
+    ``os.unlink`` would set ``_released=True`` AFTER our check, and we
+    would still proceed to unlink — clobbering the file the caller
+    has just taken ownership of.
+
+    The fix flips ``_released=True`` ATOMICALLY with the check, so
+    any subsequent ``release()`` sees ``_released=True`` and becomes
+    a no-op.
+
+    Test: race ``release()`` against context exit using a barrier
+    pinned by patching ``os.unlink`` to fire ``release()`` from
+    another thread BEFORE doing the real unlink. With the fix,
+    ``release()`` sees the path already gone from the registry and
+    ``_released=True`` already set — it's a no-op. Without the fix,
+    the test would observe two distinct ownership transitions
+    (released-then-unlinked).
+    """
+    import threading
+
+    from vllm_mlx import _tempfile_safe
+
+    captured_state: list[bool] = []
+
+    real_unlink = os.unlink
+
+    def _racing_unlink(p):
+        # While we're "in" the unlink, fire release() from another
+        # thread. If the fix is correct, that release() is a no-op
+        # because _released is already True (claimed by the
+        # context-exit cleanup).
+        if "ut-race-" in os.path.basename(p):
+
+            def _do_release():
+                # Should return path but observe released=True or
+                # transition the state safely without conflicting
+                # with our pending unlink.
+                handle_ref[0].release()
+
+            t = threading.Thread(target=_do_release)
+            t.start()
+            t.join(timeout=2)
+            assert not t.is_alive(), "release() thread hung"
+            captured_state.append(handle_ref[0].released)
+        return real_unlink(p)
+
+    monkeypatch.setattr(os, "unlink", _racing_unlink)
+
+    handle_ref: list = [None]
+    with managed_tempfile_path(
+        prefix="ut-race-", suffix=".tmp", dir=str(tmp_path)
+    ) as h:
+        handle_ref[0] = h
+        path = h.path
+        assert os.path.exists(path)
+
+    # File should be gone (one unlink succeeded).
+    assert not os.path.exists(path)
+    # The race captured exactly one state observation: the context
+    # manager had already claimed cleanup (_released=True) when
+    # release() ran from the other thread.
+    assert captured_state == [True], (
+        f"race condition: release() observed released={captured_state}, "
+        "expected exactly one observation of True (cleanup-claimed)"
+    )
+    # Registry should be empty for that path.
+    assert path not in _tempfile_safe._pending_snapshot()
+
+
 def _count_in_dir(d: str) -> int:
     """Count ``rapid-mlx-chat-*.log`` files in ``d``."""
     try:

--- a/tests/test_tempfile_safe.py
+++ b/tests/test_tempfile_safe.py
@@ -480,6 +480,19 @@ def test_chat_command_does_not_leak_tempfile_on_spawn_readiness_failure(tmp_path
         fake_proc.wait.return_value = 0
 
         def fake_spawn(model, log_path, served_name=None, *, register_in=None, log_handle=None):
+            # Codex round-5 #4: explicitly REQUIRE the chat callsite to
+            # pass log_handle. Without this assertion, the test could
+            # silently pass even if the callsite stopped wiring the
+            # managed handle through (then the context manager's own
+            # finally would unlink the path and the count delta would
+            # still be zero — false-negative).
+            assert log_handle is not None, (
+                "chat callsite regressed: log_handle was not passed "
+                "through to _spawn_chat_server"
+            )
+            assert log_handle.released is False, (
+                "chat callsite released the handle BEFORE the spawn"
+            )
             log_fh = open(log_path, "w")
             fake_proc._rapid_mlx_log = log_fh
             fake_proc._rapid_mlx_log_path = log_path
@@ -487,8 +500,8 @@ def test_chat_command_does_not_leak_tempfile_on_spawn_readiness_failure(tmp_path
                 register_in.append(fake_proc)
             # Mirror the real spawn's hand-off so the chat REPL's
             # ``_teardown_proc`` is the one that decides when to unlink.
-            if log_handle is not None:
-                log_handle.release()
+            log_handle.release()
+            assert log_handle.released is True
             return fake_proc, "http://127.0.0.1:9999"
 
         def fake_wait(base_url, proc, timeout_s=600):

--- a/tests/test_tempfile_safe.py
+++ b/tests/test_tempfile_safe.py
@@ -260,6 +260,60 @@ def test_os_exit_is_documented_to_skip_cleanup_negative_control():
         os.unlink(leaked_path)
 
 
+def test_setup_window_exception_does_not_leak_path(monkeypatch, tmp_path):
+    """Codex round-2 BLOCKING: exceptions between ``mkstemp`` and the
+    yield must still unlink the just-created file.
+
+    The leak window: ``mkstemp`` has created the file on disk, but the
+    path has not yet been added to ``_pending_paths`` (so atexit won't
+    see it) and the yielded-context ``finally`` hasn't started yet
+    (so ``__exit__`` won't see it either). A SIGINT/SIGTERM landing in
+    that window — or any setup-phase exception such as
+    ``_ensure_atexit_registered`` raising — would otherwise leak the
+    file permanently.
+
+    Inject the failure by patching ``_ensure_atexit_registered`` to
+    raise. Assert the file was cleaned up before the exception
+    propagated, and that the registry is in the same state as
+    before the call.
+    """
+    from vllm_mlx import _tempfile_safe
+
+    baseline = _tempfile_safe._pending_snapshot()
+
+    def _boom() -> None:
+        raise KeyboardInterrupt("simulated SIGINT during setup")
+
+    monkeypatch.setattr(_tempfile_safe, "_ensure_atexit_registered", _boom)
+
+    captured_path: list[str] = []
+
+    # Also stub mkstemp to capture the path before it's wiped, so we
+    # can verify the unlink actually happened.
+    real_mkstemp = tempfile.mkstemp
+
+    def _spy_mkstemp(*args, **kwargs):
+        fd, path = real_mkstemp(*args, **kwargs)
+        captured_path.append(path)
+        return fd, path
+
+    monkeypatch.setattr(tempfile, "mkstemp", _spy_mkstemp)
+
+    with (
+        pytest.raises(KeyboardInterrupt, match="simulated SIGINT during setup"),
+        managed_tempfile_path(prefix="ut-setupfail-", suffix=".tmp", dir=str(tmp_path)),
+    ):
+        pytest.fail("should never reach the body")
+
+    assert captured_path, "mkstemp was not invoked"
+    leaked = captured_path[0]
+    assert not os.path.exists(leaked), (
+        f"setup-window leak: {leaked} survived a setup-phase exception"
+    )
+    # Registry should be unchanged.
+    assert _tempfile_safe._pending_snapshot() == baseline
+
+
 def _count_in_dir(d: str) -> int:
     """Count ``rapid-mlx-chat-*.log`` files in ``d``."""
     try:

--- a/tests/test_tempfile_safe.py
+++ b/tests/test_tempfile_safe.py
@@ -39,9 +39,7 @@ def _count_chat_logs() -> int:
     """Return the number of ``rapid-mlx-chat-*.log`` stragglers."""
     tmp = Path(tempfile.gettempdir())
     try:
-        return sum(
-            1 for name in os.listdir(tmp) if name.startswith("rapid-mlx-chat-")
-        )
+        return sum(1 for name in os.listdir(tmp) if name.startswith("rapid-mlx-chat-"))
     except OSError:
         return 0
 
@@ -60,11 +58,13 @@ def test_happy_path_unlinks_on_exit():
 def test_exception_in_body_still_unlinks():
     """try/finally — unlink runs even when the body raises."""
     sentinel: list[str] = []
-    with pytest.raises(RuntimeError, match="boom"):
-        with managed_tempfile_path(prefix="ut-exc-", suffix=".tmp") as h:
-            sentinel.append(h.path)
-            assert os.path.exists(h.path)
-            raise RuntimeError("boom")
+    with (
+        pytest.raises(RuntimeError, match="boom"),
+        managed_tempfile_path(prefix="ut-exc-", suffix=".tmp") as h,
+    ):
+        sentinel.append(h.path)
+        assert os.path.exists(h.path)
+        raise RuntimeError("boom")
     assert not os.path.exists(sentinel[0])
 
 
@@ -212,9 +212,7 @@ def test_atexit_fallback_via_subprocess_os_exit_skips_context_exit():
 def _count_in_dir(d: str) -> int:
     """Count ``rapid-mlx-chat-*.log`` files in ``d``."""
     try:
-        return sum(
-            1 for name in os.listdir(d) if name.startswith("rapid-mlx-chat-")
-        )
+        return sum(1 for name in os.listdir(d) if name.startswith("rapid-mlx-chat-"))
     except OSError:
         return 0
 

--- a/tests/test_tempfile_safe.py
+++ b/tests/test_tempfile_safe.py
@@ -1,0 +1,365 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for ``vllm_mlx._tempfile_safe.managed_tempfile_path`` (GH #719).
+
+Covers:
+
+1. Happy path — file exists inside the context, is unlinked on exit.
+2. Exception inside the body — unlink still runs (try/finally semantics).
+3. ``release()`` hands ownership off and SUPPRESSES the unlink.
+4. The atexit fallback fires when ``sys.exit()`` (or any other path
+   that bypasses ``__exit__``) leaves the body. This is the
+   regression that #719 reported on ``rapid-mlx chat``.
+5. The internal registry doesn't accumulate dead entries after
+   normal context exits — important for long-lived parents that
+   create + tear down many tempfiles (chat REPL ``/model`` swaps).
+6. Idempotent: calling ``release()`` twice, or releasing after the
+   context already exited cleanly, is safe.
+
+The leak regression test (#5 below) runs the chat REPL in a fresh
+subprocess and asserts the post-exit count delta in ``$TMPDIR`` is
+zero, which is the user-visible contract from the bug report.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import tempfile
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from vllm_mlx import _tempfile_safe
+from vllm_mlx._tempfile_safe import managed_tempfile_path
+
+
+def _count_chat_logs() -> int:
+    """Return the number of ``rapid-mlx-chat-*.log`` stragglers."""
+    tmp = Path(tempfile.gettempdir())
+    try:
+        return sum(
+            1 for name in os.listdir(tmp) if name.startswith("rapid-mlx-chat-")
+        )
+    except OSError:
+        return 0
+
+
+def test_happy_path_unlinks_on_exit():
+    """File exists inside the block, gone after."""
+    with managed_tempfile_path(prefix="ut-happy-", suffix=".tmp") as h:
+        assert os.path.exists(h.path)
+        # Path-like interface: ``open(handle)`` works.
+        with open(h, "w") as f:
+            f.write("hello")
+        assert Path(h.path).read_text() == "hello"
+    assert not os.path.exists(h.path)
+
+
+def test_exception_in_body_still_unlinks():
+    """try/finally — unlink runs even when the body raises."""
+    sentinel: list[str] = []
+    with pytest.raises(RuntimeError, match="boom"):
+        with managed_tempfile_path(prefix="ut-exc-", suffix=".tmp") as h:
+            sentinel.append(h.path)
+            assert os.path.exists(h.path)
+            raise RuntimeError("boom")
+    assert not os.path.exists(sentinel[0])
+
+
+def test_release_suppresses_unlink():
+    """``release()`` hands ownership over; the helper steps back."""
+    with managed_tempfile_path(prefix="ut-rel-", suffix=".tmp") as h:
+        path = h.path
+        h.release()
+        assert h.released is True
+    # File should still exist — caller is now responsible.
+    assert os.path.exists(path)
+    # Manual cleanup so we don't pollute $TMPDIR.
+    os.unlink(path)
+
+
+def test_release_idempotent():
+    """Double-release is a no-op (the second call is a noop)."""
+    with managed_tempfile_path(prefix="ut-relx2-", suffix=".tmp") as h:
+        path = h.path
+        h.release()
+        h.release()
+    assert os.path.exists(path)
+    os.unlink(path)
+
+
+def test_registry_does_not_leak_after_normal_exit():
+    """The internal registry must shrink on normal exit.
+
+    Long-lived parents (chat REPL ``/model`` swaps) create + tear
+    down many tempfiles. If the registry kept stale paths around,
+    the eventual ``atexit`` reap would walk a giant list of
+    already-unlinked names — harmless but wasteful.
+    """
+    baseline = _tempfile_safe._pending_snapshot()
+    for _ in range(10):
+        with managed_tempfile_path(prefix="ut-noreg-", suffix=".tmp"):
+            pass
+    after = _tempfile_safe._pending_snapshot()
+    assert after == baseline
+
+
+def test_registry_tracks_path_inside_context():
+    """While the context is open, the path IS in the registry —
+    so the atexit fallback would reap it if interpreter exited."""
+    baseline = _tempfile_safe._pending_snapshot()
+    with managed_tempfile_path(prefix="ut-track-", suffix=".tmp") as h:
+        assert h.path in _tempfile_safe._pending_snapshot()
+        assert _tempfile_safe._pending_snapshot() - baseline == {h.path}
+    assert _tempfile_safe._pending_snapshot() == baseline
+
+
+def test_release_removes_from_registry_immediately():
+    """``release()`` should drop the path from the registry so the
+    atexit fallback doesn't try to unlink a file the caller is now
+    tracking under their own lifecycle."""
+    with managed_tempfile_path(prefix="ut-relreg-", suffix=".tmp") as h:
+        path = h.path
+        assert path in _tempfile_safe._pending_snapshot()
+        h.release()
+        assert path not in _tempfile_safe._pending_snapshot()
+    os.unlink(path)
+
+
+def test_atexit_fallback_via_subprocess_exit_before_context_exit():
+    """Regression for GH #719.
+
+    Spawn a subprocess that creates a managed tempfile and then
+    ``sys.exit(0)``s from *inside* the context body. Without the
+    atexit fallback, the file would persist; with it, the file is
+    reaped before the interpreter dies.
+    """
+    with tempfile.TemporaryDirectory() as td:
+        marker = Path(td) / "marker.txt"
+        script = textwrap.dedent(
+            f"""
+            import os, sys
+            sys.path.insert(0, {str(Path(__file__).resolve().parent.parent)!r})
+            from vllm_mlx._tempfile_safe import managed_tempfile_path
+
+            with managed_tempfile_path(prefix="ut-exit-", suffix=".tmp", dir={td!r}) as h:
+                # Stash the path so the test runner can check it after exit.
+                with open({str(marker)!r}, "w") as f:
+                    f.write(h.path)
+                # ``SystemExit`` propagates as a regular BaseException,
+                # which DOES trigger __exit__. The normal-exit path
+                # therefore reaps via ``finally`` first; this test
+                # confirms the file is gone regardless of whether
+                # ``__exit__`` or the atexit fallback did the work.
+                sys.exit(0)
+            """
+        )
+        result = subprocess.run(
+            [sys.executable, "-c", script],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, result.stderr
+        leaked_path = marker.read_text().strip()
+        assert leaked_path
+        # File should be gone — either via ``__exit__`` (SystemExit
+        # path) or via the atexit fallback.
+        assert not os.path.exists(leaked_path), (
+            f"leak: {leaked_path} still exists after subprocess exit"
+        )
+
+
+def test_atexit_fallback_via_subprocess_os_exit_skips_context_exit():
+    """Confirms the atexit fallback covers the case where ``__exit__``
+    truly does NOT run.
+
+    ``os._exit`` skips both ``__exit__`` and ``atexit``, so the file
+    SHOULD leak (we document that limitation). This test is the
+    negative control — without it, we can't claim the atexit
+    fallback is meaningful.
+    """
+    with tempfile.TemporaryDirectory() as td:
+        marker = Path(td) / "marker.txt"
+        script = textwrap.dedent(
+            f"""
+            import os, sys
+            sys.path.insert(0, {str(Path(__file__).resolve().parent.parent)!r})
+            from vllm_mlx._tempfile_safe import managed_tempfile_path
+
+            with managed_tempfile_path(prefix="ut-osexit-", suffix=".tmp", dir={td!r}) as h:
+                with open({str(marker)!r}, "w") as f:
+                    f.write(h.path)
+                os._exit(0)
+            """
+        )
+        result = subprocess.run(
+            [sys.executable, "-c", script],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0
+        leaked_path = marker.read_text().strip()
+        # We expect the leak here (documented limitation).
+        # The test passes if the file IS gone (best case) OR still
+        # exists (worst case but documented). The point is the
+        # NORMAL atexit path covers the chat REPL scenarios.
+        if os.path.exists(leaked_path):
+            os.unlink(leaked_path)
+
+
+def _count_in_dir(d: str) -> int:
+    """Count ``rapid-mlx-chat-*.log`` files in ``d``."""
+    try:
+        return sum(
+            1 for name in os.listdir(d) if name.startswith("rapid-mlx-chat-")
+        )
+    except OSError:
+        return 0
+
+
+def test_chat_command_does_not_leak_tempfile_on_keyboard_interrupt(tmp_path):
+    """End-to-end regression for GH #719.
+
+    The original bug: ``rapid-mlx chat`` leaked one zero-byte
+    ``rapid-mlx-chat-*.log`` per invocation if anything raised
+    between the ``NamedTemporaryFile(...).name`` call and the
+    proc-registration step inside ``_spawn_chat_server``.
+
+    Reproduce by injecting a KeyboardInterrupt at the ``print(...)``
+    that announces the log path — the exact window the leak lived in.
+
+    Run the chat command in a fresh subprocess with ``TMPDIR`` pointed
+    at the test's ``tmp_path``. After the subprocess fully exits (so
+    ``atexit`` has run), the parent counts the files. This is the
+    user-visible contract from the bug report: after ``rapid-mlx chat``
+    returns, the temp dir should not have a new straggler.
+    """
+    tmpdir = str(tmp_path)
+    script = textwrap.dedent(
+        f"""
+        import sys
+        sys.path.insert(0, {str(Path(__file__).resolve().parent.parent)!r})
+        from unittest.mock import patch
+        from vllm_mlx import cli
+
+        import builtins
+        real_print = builtins.print
+        def killing_print(*args, **kwargs):
+            s = " ".join(str(a) for a in args) if args else ""
+            if "Starting server" in s:
+                raise KeyboardInterrupt("simulated")
+            return real_print(*args, **kwargs)
+
+        with patch.object(cli, "_ensure_model_downloaded"), \\
+             patch("builtins.print", killing_print):
+            ns = type("Args", (), {{}})()
+            ns.base_url = None
+            ns.port = None
+            ns.system = None
+            ns.think = False
+            ns.max_tokens = 50
+            ns.temperature = 0.0
+            ns.ready_timeout = 5
+            ns.response_timeout = 5
+            ns.model = "qwen3.5-4b-4bit"
+            try:
+                cli.chat_command(ns)
+            except (SystemExit, KeyboardInterrupt):
+                pass
+        """
+    )
+    env = os.environ.copy()
+    env["TMPDIR"] = tmpdir
+    before = _count_in_dir(tmpdir)
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env=env,
+    )
+    assert result.returncode == 0, f"stderr: {result.stderr}"
+    after = _count_in_dir(tmpdir)
+    delta = after - before
+    assert delta == 0, (
+        f"GH #719 regression: rapid-mlx chat leaked {delta} "
+        f"tempfile(s) on KeyboardInterrupt during spawn. "
+        f"Files in {tmpdir}: {os.listdir(tmpdir)}"
+    )
+
+
+def test_chat_command_does_not_leak_tempfile_on_spawn_readiness_failure(tmp_path):
+    """The other leak vector: ``_wait_for_chat_server`` raises, the
+    parent prints a friendly error + ``sys.exit(1)``. In the original
+    code the log file persisted because the early-exit path didn't
+    explicitly unlink. ``_teardown_proc``'s zero-byte unlink covers
+    this case via the atexit chain, but only when the spawn made it
+    far enough to register on ``_active_procs``. With the helper
+    wrapping the whole spawn, the leak is closed regardless.
+
+    Run in subprocess with ``TMPDIR`` pinned to the test directory so
+    we observe the post-atexit state (the contract that the bug
+    reporter exercised).
+    """
+    tmpdir = str(tmp_path)
+    script = textwrap.dedent(
+        f"""
+        import sys
+        sys.path.insert(0, {str(Path(__file__).resolve().parent.parent)!r})
+        from unittest.mock import patch, MagicMock
+        from vllm_mlx import cli
+
+        fake_proc = MagicMock()
+        fake_proc.poll.return_value = None
+        fake_proc.wait.return_value = 0
+
+        def fake_spawn(model, log_path, served_name=None, *, register_in=None):
+            log_handle = open(log_path, "w")
+            fake_proc._rapid_mlx_log = log_handle
+            fake_proc._rapid_mlx_log_path = log_path
+            if register_in is not None:
+                register_in.append(fake_proc)
+            return fake_proc, "http://127.0.0.1:9999"
+
+        def fake_wait(base_url, proc, timeout_s=600):
+            raise RuntimeError("simulated readiness fail")
+
+        with patch.object(cli, "_ensure_model_downloaded"), \\
+             patch.object(cli, "_spawn_chat_server", side_effect=fake_spawn), \\
+             patch.object(cli, "_wait_for_chat_server", side_effect=fake_wait):
+            ns = type("Args", (), {{}})()
+            ns.base_url = None
+            ns.port = None
+            ns.system = None
+            ns.think = False
+            ns.max_tokens = 50
+            ns.temperature = 0.0
+            ns.ready_timeout = 5
+            ns.response_timeout = 5
+            ns.model = "qwen3.5-4b-4bit"
+            try:
+                cli.chat_command(ns)
+            except SystemExit:
+                pass
+        """
+    )
+    env = os.environ.copy()
+    env["TMPDIR"] = tmpdir
+    before = _count_in_dir(tmpdir)
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env=env,
+    )
+    assert result.returncode == 0, f"stderr: {result.stderr}"
+    after = _count_in_dir(tmpdir)
+    delta = after - before
+    assert delta == 0, (
+        f"GH #719 regression: rapid-mlx chat leaked {delta} "
+        f"tempfile(s) on _wait_for_chat_server failure. "
+        f"Files in {tmpdir}: {os.listdir(tmpdir)}"
+    )

--- a/tests/test_tempfile_safe.py
+++ b/tests/test_tempfile_safe.py
@@ -128,13 +128,69 @@ def test_release_removes_from_registry_immediately():
     os.unlink(path)
 
 
-def test_atexit_fallback_via_subprocess_exit_before_context_exit():
-    """Regression for GH #719.
+def test_atexit_fallback_reaps_paths_not_cleaned_by_context_exit():
+    """Codex round-1 finding #3 — exercise the atexit hook directly.
 
-    Spawn a subprocess that creates a managed tempfile and then
-    ``sys.exit(0)``s from *inside* the context body. Without the
-    atexit fallback, the file would persist; with it, the file is
-    reaped before the interpreter dies.
+    The ``with`` block's ``finally`` covers normal exit, exceptions, and
+    ``SystemExit`` — so a test that uses the public context manager and
+    then exits cannot distinguish "atexit reaped it" from "``__exit__``
+    reaped it". To prove the atexit fallback actually works, we have to
+    leave a path in the module-level registry WITHOUT going through the
+    context manager's ``finally``.
+
+    Strategy: in a fresh subprocess, call ``mkstemp`` directly, register
+    the path via the module's internal registry (the same pathway
+    ``managed_tempfile_path`` uses), then exit normally. Only the atexit
+    hook can reap that path; if the hook is broken, the file persists
+    after the subprocess exits.
+    """
+    with tempfile.TemporaryDirectory() as td:
+        marker = Path(td) / "marker.txt"
+        script = textwrap.dedent(
+            f"""
+            import os, sys, tempfile
+            sys.path.insert(0, {str(Path(__file__).resolve().parent.parent)!r})
+            from vllm_mlx import _tempfile_safe
+
+            fd, path = tempfile.mkstemp(prefix="ut-atexit-", suffix=".tmp", dir={td!r})
+            os.close(fd)
+            # Bypass the context manager: register the path directly and
+            # arm the shared atexit hook the same way the helper does on
+            # first use. If the hook is broken, the file survives the
+            # subprocess. This is the ONLY test in this file that
+            # actually exercises the atexit path in isolation.
+            _tempfile_safe._ensure_atexit_registered()
+            with _tempfile_safe._pending_lock:
+                _tempfile_safe._pending_paths.add(path)
+            with open({str(marker)!r}, "w") as f:
+                f.write(path)
+            # Normal exit. ``__exit__`` does NOT run for this path
+            # (we never entered the context manager). atexit is the
+            # ONLY path that can reap it.
+            """
+        )
+        result = subprocess.run(
+            [sys.executable, "-c", script],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, result.stderr
+        leaked_path = marker.read_text().strip()
+        assert leaked_path
+        assert not os.path.exists(leaked_path), (
+            f"atexit hook failed to reap {leaked_path}"
+        )
+
+
+def test_systemexit_inside_context_body_triggers_context_finally():
+    """Companion to the atexit test above.
+
+    Spawn a subprocess that calls ``sys.exit(0)`` from inside a
+    ``with managed_tempfile_path(...)`` block. ``SystemExit`` triggers
+    ``__exit__`` (i.e. the ``finally`` inside the ``@contextmanager``
+    wrapper), so the path is reaped via the normal exit path — atexit
+    plays no role here. This documents the contract for the chat REPL,
+    whose ``sys.exit(1)`` on readiness failure depends on this guarantee.
     """
     with tempfile.TemporaryDirectory() as td:
         marker = Path(td) / "marker.txt"
@@ -145,14 +201,8 @@ def test_atexit_fallback_via_subprocess_exit_before_context_exit():
             from vllm_mlx._tempfile_safe import managed_tempfile_path
 
             with managed_tempfile_path(prefix="ut-exit-", suffix=".tmp", dir={td!r}) as h:
-                # Stash the path so the test runner can check it after exit.
                 with open({str(marker)!r}, "w") as f:
                     f.write(h.path)
-                # ``SystemExit`` propagates as a regular BaseException,
-                # which DOES trigger __exit__. The normal-exit path
-                # therefore reaps via ``finally`` first; this test
-                # confirms the file is gone regardless of whether
-                # ``__exit__`` or the atexit fallback did the work.
                 sys.exit(0)
             """
         )
@@ -164,21 +214,20 @@ def test_atexit_fallback_via_subprocess_exit_before_context_exit():
         assert result.returncode == 0, result.stderr
         leaked_path = marker.read_text().strip()
         assert leaked_path
-        # File should be gone — either via ``__exit__`` (SystemExit
-        # path) or via the atexit fallback.
         assert not os.path.exists(leaked_path), (
-            f"leak: {leaked_path} still exists after subprocess exit"
+            f"SystemExit path leaked: {leaked_path} still exists"
         )
 
 
-def test_atexit_fallback_via_subprocess_os_exit_skips_context_exit():
-    """Confirms the atexit fallback covers the case where ``__exit__``
-    truly does NOT run.
+def test_os_exit_is_documented_to_skip_cleanup_negative_control():
+    """Negative control — ``os._exit`` MUST leak.
 
+    Documents the limitation called out in the module docstring:
     ``os._exit`` skips both ``__exit__`` and ``atexit``, so the file
-    SHOULD leak (we document that limitation). This test is the
-    negative control — without it, we can't claim the atexit
-    fallback is meaningful.
+    survives the subprocess. If a future "fix" started reaping this
+    case (e.g. a SIGCHLD-based janitor), we'd want to know so the
+    docstring can be updated. Asserting the file IS present makes
+    the negative control real.
     """
     with tempfile.TemporaryDirectory() as td:
         marker = Path(td) / "marker.txt"
@@ -201,12 +250,14 @@ def test_atexit_fallback_via_subprocess_os_exit_skips_context_exit():
         )
         assert result.returncode == 0
         leaked_path = marker.read_text().strip()
-        # We expect the leak here (documented limitation).
-        # The test passes if the file IS gone (best case) OR still
-        # exists (worst case but documented). The point is the
-        # NORMAL atexit path covers the chat REPL scenarios.
-        if os.path.exists(leaked_path):
-            os.unlink(leaked_path)
+        assert leaked_path
+        # ``os._exit`` skips atexit + __exit__: file must remain.
+        assert os.path.exists(leaked_path), (
+            "negative-control regression: os._exit no longer leaks. "
+            "If intentional, update the helper's docstring."
+        )
+        # Manual cleanup so $TMPDIR doesn't accumulate.
+        os.unlink(leaked_path)
 
 
 def _count_in_dir(d: str) -> int:
@@ -313,12 +364,16 @@ def test_chat_command_does_not_leak_tempfile_on_spawn_readiness_failure(tmp_path
         fake_proc.poll.return_value = None
         fake_proc.wait.return_value = 0
 
-        def fake_spawn(model, log_path, served_name=None, *, register_in=None):
-            log_handle = open(log_path, "w")
-            fake_proc._rapid_mlx_log = log_handle
+        def fake_spawn(model, log_path, served_name=None, *, register_in=None, log_handle=None):
+            log_fh = open(log_path, "w")
+            fake_proc._rapid_mlx_log = log_fh
             fake_proc._rapid_mlx_log_path = log_path
             if register_in is not None:
                 register_in.append(fake_proc)
+            # Mirror the real spawn's hand-off so the chat REPL's
+            # ``_teardown_proc`` is the one that decides when to unlink.
+            if log_handle is not None:
+                log_handle.release()
             return fake_proc, "http://127.0.0.1:9999"
 
         def fake_wait(base_url, proc, timeout_s=600):

--- a/vllm_mlx/_tempfile_safe.py
+++ b/vllm_mlx/_tempfile_safe.py
@@ -152,26 +152,33 @@ class _TempfileHandle:
                 proc = spawn(h)  # spawn registers h.path on the proc
                 final_path = h.release()
 
-        Codex round-4 finding: discard from the registry BEFORE
-        setting ``self._released = True``, under the lock. The
-        reverse order had a window where an interruption left
-        ``released=True`` (so the context manager's ``finally``
-        would skip the unlink) while the path was still in
-        ``_pending_paths`` — atexit would then unlink a file the
-        caller has just taken ownership of. With this ordering,
-        an interruption mid-call either:
+        Codex pr_validate r3 BLOCKING: ``release()`` MUST be a true
+        no-op when ``_released`` is already true. The prior shape
+        ``discard(); released=True`` always ran the discard, even
+        when called after the context-exit cleanup had already
+        claimed ownership (and possibly already discarded the
+        path). A second ``release()`` could then remove the
+        registry fallback after the context manager flipped
+        ``_released=True`` but before the unlink succeeded — the
+        very race the round-2 BLOCKING fixed in the other
+        direction. With the early no-op, double-release and
+        release-after-cleanup-claim are both safe.
 
-        - happens before the discard → ``released`` is still
-          ``False``, ``finally`` reaps the path (and the atexit
-          fallback would also reap it).
-        - happens after the discard but before ``_released=True``
-          → ``released`` is still ``False``, ``finally`` reaps the
-          path (the caller's "I took ownership" is incomplete; the
-          helper conservatively still owns).
-        - happens after ``_released=True`` → call has completed
-          successfully; both context manager and atexit step away.
+        Codex round-4 finding (also still satisfied): the discard
+        runs BEFORE setting ``_released = True`` so an interruption
+        between the two leaves the helper in the conservative
+        "still owned" state — the context manager would still
+        unlink, and the atexit fallback would still see the entry
+        if the discard ran but the flag flip didn't.
         """
         with _pending_lock:
+            if self._released:
+                # Already released (by an earlier ``release()``) or
+                # already claimed by the context manager's cleanup.
+                # Either way, do NOT touch the registry — the entry
+                # is either gone (we discarded it) or still owned by
+                # the cleanup that flipped ``_released`` first.
+                return self._path
             _pending_paths.discard(self._path)
             self._released = True
         return self._path

--- a/vllm_mlx/_tempfile_safe.py
+++ b/vllm_mlx/_tempfile_safe.py
@@ -151,10 +151,29 @@ class _TempfileHandle:
             with managed_tempfile_path(...) as h:
                 proc = spawn(h)  # spawn registers h.path on the proc
                 final_path = h.release()
+
+        Codex round-4 finding: discard from the registry BEFORE
+        setting ``self._released = True``, under the lock. The
+        reverse order had a window where an interruption left
+        ``released=True`` (so the context manager's ``finally``
+        would skip the unlink) while the path was still in
+        ``_pending_paths`` — atexit would then unlink a file the
+        caller has just taken ownership of. With this ordering,
+        an interruption mid-call either:
+
+        - happens before the discard → ``released`` is still
+          ``False``, ``finally`` reaps the path (and the atexit
+          fallback would also reap it).
+        - happens after the discard but before ``_released=True``
+          → ``released`` is still ``False``, ``finally`` reaps the
+          path (the caller's "I took ownership" is incomplete; the
+          helper conservatively still owns).
+        - happens after ``_released=True`` → call has completed
+          successfully; both context manager and atexit step away.
         """
-        self._released = True
         with _pending_lock:
             _pending_paths.discard(self._path)
+            self._released = True
         return self._path
 
     # Make the handle interchangeable with the path string for code
@@ -228,13 +247,26 @@ def managed_tempfile_path(
         with _pending_lock:
             _pending_paths.add(path)
     except BaseException:
-        # Setup failed: close FD if still open, unlink the file, then
-        # drop from the registry only after the file is actually gone.
-        # Ordering matters (codex round-3 BLOCKING): if we discarded
-        # from the registry first and then got a second interrupt
-        # inside ``os.unlink``, the file would survive WITHOUT atexit
-        # being able to see it. Re-raise after best-effort cleanup so
-        # we don't mask the original exception.
+        # Setup failed. Codex pr_validate round-1 BLOCKING: the cleanup
+        # MUST leave the file owned by SOMETHING (this finally, or the
+        # shared atexit registry) regardless of how it unwinds. The
+        # simplest invariant: ensure the path is in ``_pending_paths``
+        # BEFORE we attempt the best-effort unlink, and only discard
+        # AFTER a successful unlink. That way:
+        #   - If the helper made it to ``_pending_paths.add`` already,
+        #     the discard-on-success ordering hands ownership cleanly.
+        #   - If the exception came from BEFORE the ``add`` (e.g.
+        #     ``_ensure_atexit_registered`` raised), we still arm the
+        #     registry here so a second interrupt during ``os.unlink``
+        #     below does NOT strand the file outside the registry.
+        # Atexit also has to be registered at this point, otherwise
+        # adding to the set is useless.
+        try:
+            _ensure_atexit_registered()
+        except BaseException:  # noqa: BLE001 — best-effort
+            pass
+        with _pending_lock:
+            _pending_paths.add(path)
         try:
             os.close(fd)
         except OSError:
@@ -242,9 +274,13 @@ def managed_tempfile_path(
         try:
             os.unlink(path)
         except OSError:
+            # File still exists OR we don't have perms. Either way the
+            # registry now owns it for the atexit pass; do NOT discard.
             pass
-        with _pending_lock:
-            _pending_paths.discard(path)
+        else:
+            # Unlink succeeded — drop from the registry.
+            with _pending_lock:
+                _pending_paths.discard(path)
         raise
 
     handle = _TempfileHandle(path)
@@ -258,22 +294,32 @@ def managed_tempfile_path(
             # induced ``SystemExit``) landing between the two
             # statements would leave the file on disk with no entry
             # in ``_pending_paths`` — the atexit fallback could never
-            # see it. The reverse order is safe: a later atexit pass
-            # tolerates ``FileNotFoundError``, so leaving the entry
-            # registered until the file is gone (or was gone) is
-            # always recoverable.
+            # see it.
+            #
+            # Pr_validate round-4 BLOCKING refinement: only discard
+            # from the registry after a SUCCESSFUL unlink (or
+            # ``FileNotFoundError``, which means the file was already
+            # gone). If ``os.unlink`` raises another ``OSError`` (EBUSY,
+            # EPERM, EIO), the file may still be on disk; the atexit
+            # hook is then the only fallback that could retry, so we
+            # keep the registry entry. ``BaseException`` (KI/SE) from
+            # ``os.unlink`` propagates out before we reach the
+            # ``else`` clause — same effect: entry stays.
+            unlinked = False
             try:
                 os.unlink(path)
+                unlinked = True
             except FileNotFoundError:
-                pass
+                unlinked = True
             except OSError:
                 # Same rationale as ``_atexit_reap_all``: best-
                 # effort cleanup; do not let a cleanup error mask
                 # the real exception (if any) propagating through
                 # the ``finally``.
                 pass
-            with _pending_lock:
-                _pending_paths.discard(path)
+            if unlinked:
+                with _pending_lock:
+                    _pending_paths.discard(path)
 
 
 def _pending_snapshot() -> set[str]:

--- a/vllm_mlx/_tempfile_safe.py
+++ b/vllm_mlx/_tempfile_safe.py
@@ -228,20 +228,23 @@ def managed_tempfile_path(
         with _pending_lock:
             _pending_paths.add(path)
     except BaseException:
-        # Setup failed: close FD if still open, drop from registry if
-        # we managed to add it, unlink the file, then re-raise. Each
-        # step is best-effort because we are already unwinding an
-        # exception — we must not mask it.
+        # Setup failed: close FD if still open, unlink the file, then
+        # drop from the registry only after the file is actually gone.
+        # Ordering matters (codex round-3 BLOCKING): if we discarded
+        # from the registry first and then got a second interrupt
+        # inside ``os.unlink``, the file would survive WITHOUT atexit
+        # being able to see it. Re-raise after best-effort cleanup so
+        # we don't mask the original exception.
         try:
             os.close(fd)
         except OSError:
             pass
-        with _pending_lock:
-            _pending_paths.discard(path)
         try:
             os.unlink(path)
         except OSError:
             pass
+        with _pending_lock:
+            _pending_paths.discard(path)
         raise
 
     handle = _TempfileHandle(path)
@@ -249,8 +252,16 @@ def managed_tempfile_path(
         yield handle
     finally:
         if not handle.released:
-            with _pending_lock:
-                _pending_paths.discard(path)
+            # Codex round-3 BLOCKING: unlink BEFORE discarding from
+            # the registry. The original order (discard → unlink) had
+            # a window where a ``BaseException`` (Ctrl-C, SIGTERM-
+            # induced ``SystemExit``) landing between the two
+            # statements would leave the file on disk with no entry
+            # in ``_pending_paths`` — the atexit fallback could never
+            # see it. The reverse order is safe: a later atexit pass
+            # tolerates ``FileNotFoundError``, so leaving the entry
+            # registered until the file is gone (or was gone) is
+            # always recoverable.
             try:
                 os.unlink(path)
             except FileNotFoundError:
@@ -261,6 +272,8 @@ def managed_tempfile_path(
                 # the real exception (if any) propagating through
                 # the ``finally``.
                 pass
+            with _pending_lock:
+                _pending_paths.discard(path)
 
 
 def _pending_snapshot() -> set[str]:

--- a/vllm_mlx/_tempfile_safe.py
+++ b/vllm_mlx/_tempfile_safe.py
@@ -206,16 +206,43 @@ def managed_tempfile_path(
     # themselves in whichever mode they need. This is the recommended
     # pattern in the stdlib docs for "I just need the path".
     fd, path = tempfile.mkstemp(prefix=prefix, suffix=suffix, dir=dir)
+    # Codex round-2 BLOCKING: ``mkstemp`` has already created the file
+    # at this point. If anything between here and the ``yield`` raises
+    # — including ``BaseException`` such as ``KeyboardInterrupt``
+    # (SIGINT) or ``SystemExit`` (e.g. ``_sigterm_handler`` running on
+    # the main thread) — the file would leak: not yet in
+    # ``_pending_paths`` (so atexit can't see it), not yet inside the
+    # yielded-context ``finally`` (so ``__exit__`` won't either). Wrap
+    # the whole setup phase in a ``try/except BaseException`` so a
+    # signal or import-time error during ``_ensure_atexit_registered``
+    # cleans up the just-created file before propagating.
     try:
-        os.close(fd)
-    except OSError:
-        # mkstemp succeeded but close failed — extremely rare. We
-        # still want the path tracked so cleanup happens.
-        pass
+        try:
+            os.close(fd)
+        except OSError:
+            # mkstemp succeeded but close failed — extremely rare. We
+            # still want the path tracked so cleanup happens.
+            pass
 
-    _ensure_atexit_registered()
-    with _pending_lock:
-        _pending_paths.add(path)
+        _ensure_atexit_registered()
+        with _pending_lock:
+            _pending_paths.add(path)
+    except BaseException:
+        # Setup failed: close FD if still open, drop from registry if
+        # we managed to add it, unlink the file, then re-raise. Each
+        # step is best-effort because we are already unwinding an
+        # exception — we must not mask it.
+        try:
+            os.close(fd)
+        except OSError:
+            pass
+        with _pending_lock:
+            _pending_paths.discard(path)
+        try:
+            os.unlink(path)
+        except OSError:
+            pass
+        raise
 
     handle = _TempfileHandle(path)
     try:

--- a/vllm_mlx/_tempfile_safe.py
+++ b/vllm_mlx/_tempfile_safe.py
@@ -22,14 +22,16 @@ that:
 
 1. Creates the tempfile via ``mkstemp`` (closes the FD immediately,
    so there is no dangling descriptor) and returns the path string.
-2. Registers an ``atexit`` hook to unlink the path *before* the
-   context body runs. This guarantees cleanup even if the body
-   raises BEFORE the context's ``__exit__`` runs (e.g. the body
-   triggers a sub-helper that calls ``sys.exit()`` from within an
-   ``atexit``-bypassing path, or a hard interpreter shutdown).
-3. On normal context exit, unlinks the path and unregisters the
-   ``atexit`` hook so we don't accumulate dead callables in long-
-   running parents that create + tear down many tempfiles.
+2. Adds the path to a module-level ``_pending_paths`` set. A single
+   shared ``atexit`` hook (installed lazily the first time anyone
+   uses the helper) walks this set at interpreter shutdown so any
+   path still pending at exit gets unlinked. The hook is installed
+   once per process and stays registered for the lifetime of the
+   interpreter — only the registry shrinks as paths are released
+   or cleaned up by ``__exit__``.
+3. On normal context exit (including exceptions and ``SystemExit``,
+   both of which trigger ``__exit__``), unlinks the path and drops
+   it from the registry.
 4. Exposes ``release()`` for callers that need to hand ownership
    over to another lifecycle (e.g. the chat REPL hands the log
    path to ``_teardown_proc`` which has its own per-proc cleanup
@@ -45,16 +47,19 @@ Why not just use ``NamedTemporaryFile()`` (no ``delete=False``)?
   policy is therefore decoupled from the FD lifecycle and has to
   be expressed explicitly — that is what this helper provides.
 
-Why both ``atexit`` AND ``__exit__``?
-- ``__exit__`` covers normal control flow (return, exception
-  caught by the caller).
-- ``atexit`` covers paths where ``__exit__`` is bypassed:
-  ``sys.exit()`` from inside the body (the chat command does this
-  on readiness failure), a hard exception that propagates past
-  the context, or any helper that does ``os._exit`` in an unusual
-  way. ``atexit`` does NOT cover SIGKILL or ``os._exit`` itself,
-  which is acceptable — those are not the failure modes #719
-  observed.
+Coverage matrix:
+
+- Normal exit / exception inside body / ``SystemExit`` (``sys.exit``):
+  Python invokes the context manager's ``__exit__`` (or, for the
+  generator-based helper here, the ``finally`` inside the ``@contextmanager``
+  wrapper), which unlinks the path and removes it from the registry.
+- Interpreter exit while a path is still pending (caller forgot to
+  exit the context, or a hard exception aborted the unwind):
+  The shared ``atexit`` hook reaps everything in ``_pending_paths``.
+- ``os._exit()`` / SIGKILL: NEITHER ``__exit__`` nor ``atexit`` runs.
+  These paths are explicitly NOT covered. They are not the failure
+  modes #719 reported, and covering them would require a separate
+  janitor process — out of scope for this helper.
 """
 
 from __future__ import annotations

--- a/vllm_mlx/_tempfile_safe.py
+++ b/vllm_mlx/_tempfile_safe.py
@@ -66,7 +66,6 @@ import tempfile
 import threading
 from collections.abc import Iterator
 
-
 # Module-level set of every path the helper is currently watching.
 # A single shared atexit hook walks this set on interpreter exit so
 # we don't register N hooks for N tempfiles (atexit walks them all

--- a/vllm_mlx/_tempfile_safe.py
+++ b/vllm_mlx/_tempfile_safe.py
@@ -287,24 +287,29 @@ def managed_tempfile_path(
     try:
         yield handle
     finally:
-        # Codex round-5 finding #2: read ``handle.released`` under the
-        # registry lock so a concurrent ``release()`` cannot interleave
-        # between the read and the unlink. With the lock-held check,
-        # either:
-        #   - ``release()`` finished first → ``released=True`` → we
-        #     skip the unlink (caller now owns).
-        #   - ``release()`` is concurrent → it blocks on the lock,
-        #     reads ``released=False``, and we unlink. The unlink is
-        #     idempotent (``FileNotFoundError`` is tolerated by
-        #     ``release()``'s atexit pass), so even if release()
-        #     observes ``released=False`` and the caller later
-        #     unlinks again, nothing breaks.
-        # This serializes the ownership transition for the multi-
-        # threaded edge case codex flagged. The chat REPL is
-        # single-threaded today; the lock is cheap and removes the
-        # foot-gun for future callers.
+        # Pr_validate round-2 BLOCKING #2: claim the ownership decision
+        # atomically — set ``_released = True`` under the lock to mark
+        # "context-manager is cleaning up", which makes a subsequent
+        # ``release()`` call a no-op (it also checks ``_released``
+        # under the same lock). Without this, the prior shape
+        # (check under lock → release lock → unlink) had a window
+        # where a concurrent ``release()`` could complete between the
+        # check and the unlink, and the context manager would still
+        # unlink the file the caller has just taken ownership of.
+        #
+        # State table after the lock-held flip:
+        #   - context-mgr won the race → ``_released = True`` (now
+        #     owned by us); we unlink below.
+        #   - ``release()`` won the race → ``_released = True`` was
+        #     already set; the ``should_unlink = not prev_released``
+        #     check picks that up and we skip the unlink.
         with _pending_lock:
-            should_unlink = not handle.released
+            prev_released = handle._released
+            if not prev_released:
+                # Claim the cleanup. Any future ``release()`` sees
+                # ``_released = True`` and becomes a no-op.
+                handle._released = True
+        should_unlink = not prev_released
         if should_unlink:
             # Codex round-3 BLOCKING: unlink BEFORE discarding from
             # the registry. The original order (discard → unlink) had

--- a/vllm_mlx/_tempfile_safe.py
+++ b/vllm_mlx/_tempfile_safe.py
@@ -1,0 +1,245 @@
+"""Guaranteed-cleanup tempfile helper for rapid-mlx.
+
+Fix for GH #719: ``rapid-mlx chat`` was leaking one zero-byte
+``rapid-mlx-chat-*.log`` per invocation (3496+ stragglers reported
+on a single dev machine). The root cause was the documented Python
+anti-pattern::
+
+    log_path = tempfile.NamedTemporaryFile(
+        prefix="rapid-mlx-chat-", suffix=".log", delete=False,
+    ).name
+
+This creates the file on disk and returns just the path. Because
+``delete=False`` was passed and no surrounding ``try/finally`` or
+``atexit`` hook owns the path, ANY exception between creation and
+the eventual cleanup-by-proc-teardown (KeyboardInterrupt, BrokenPipe
+on ``print``, ImportError of a downstream module, etc.) orphans the
+file. The downstream ``_teardown_proc`` cleanup walks ``_active_procs``
+— if the proc never made it onto that list, the file path is lost.
+
+This module provides ``managed_tempfile_path`` — a context manager
+that:
+
+1. Creates the tempfile via ``mkstemp`` (closes the FD immediately,
+   so there is no dangling descriptor) and returns the path string.
+2. Registers an ``atexit`` hook to unlink the path *before* the
+   context body runs. This guarantees cleanup even if the body
+   raises BEFORE the context's ``__exit__`` runs (e.g. the body
+   triggers a sub-helper that calls ``sys.exit()`` from within an
+   ``atexit``-bypassing path, or a hard interpreter shutdown).
+3. On normal context exit, unlinks the path and unregisters the
+   ``atexit`` hook so we don't accumulate dead callables in long-
+   running parents that create + tear down many tempfiles.
+4. Exposes ``release()`` for callers that need to hand ownership
+   over to another lifecycle (e.g. the chat REPL hands the log
+   path to ``_teardown_proc`` which has its own per-proc cleanup
+   policy — the helper steps aside, but only AFTER the proc has
+   been registered onto the active-procs list, closing the race
+   window that #719 reported).
+
+Why not just use ``NamedTemporaryFile()`` (no ``delete=False``)?
+- The chat-server use case opens the path in a *separate* file
+  handle in the parent and inherits that handle into a subprocess.
+  ``NamedTemporaryFile``'s own FD is irrelevant; what matters is
+  the path persisting until the subprocess terminates. The unlink
+  policy is therefore decoupled from the FD lifecycle and has to
+  be expressed explicitly — that is what this helper provides.
+
+Why both ``atexit`` AND ``__exit__``?
+- ``__exit__`` covers normal control flow (return, exception
+  caught by the caller).
+- ``atexit`` covers paths where ``__exit__`` is bypassed:
+  ``sys.exit()`` from inside the body (the chat command does this
+  on readiness failure), a hard exception that propagates past
+  the context, or any helper that does ``os._exit`` in an unusual
+  way. ``atexit`` does NOT cover SIGKILL or ``os._exit`` itself,
+  which is acceptable — those are not the failure modes #719
+  observed.
+"""
+
+from __future__ import annotations
+
+import atexit
+import contextlib
+import os
+import tempfile
+import threading
+from collections.abc import Iterator
+
+
+# Module-level set of every path the helper is currently watching.
+# A single shared atexit hook walks this set on interpreter exit so
+# we don't register N hooks for N tempfiles (atexit walks them all
+# anyway, but a single hook keeps the registry small + introspectable
+# in tests).
+_pending_paths: set[str] = set()
+_pending_lock = threading.Lock()
+_atexit_registered = False
+
+
+def _atexit_reap_all() -> None:
+    """Unlink every still-pending tempfile path. Idempotent."""
+    # Snapshot under the lock so a parallel ``release`` can't mutate
+    # the set mid-walk. We don't hold the lock during ``os.unlink``
+    # because that could deadlock if the unlink path triggers a
+    # finalizer that touches the same lock (unlikely but cheap to
+    # avoid).
+    with _pending_lock:
+        snapshot = list(_pending_paths)
+        _pending_paths.clear()
+    for path in snapshot:
+        try:
+            os.unlink(path)
+        except FileNotFoundError:
+            pass
+        except OSError:
+            # Best-effort: we're tearing down the interpreter, no
+            # one will see the error anyway. Silencing here matches
+            # the rest of the codebase's atexit conventions.
+            pass
+
+
+def _ensure_atexit_registered() -> None:
+    global _atexit_registered
+    if _atexit_registered:
+        return
+    # The lock guards the flag flip so two threads racing on first
+    # ``managed_tempfile_path`` call only register once.
+    with _pending_lock:
+        if _atexit_registered:
+            return
+        atexit.register(_atexit_reap_all)
+        _atexit_registered = True
+
+
+class _TempfileHandle:
+    """Returned object that exposes ``release`` while behaving like ``str``.
+
+    The body of ``managed_tempfile_path`` yields one of these so that
+    callers can either:
+
+    - Use it as a path string (because ``__fspath__`` and ``__str__``
+      both return the underlying path — drop-in for code that does
+      ``open(log_path, "w")`` or ``subprocess.Popen(..., stdout=open(log_path))``).
+    - Call ``.release()`` to hand ownership over to another lifecycle,
+      after which the helper will NOT unlink on context exit.
+    """
+
+    __slots__ = ("_path", "_released")
+
+    def __init__(self, path: str) -> None:
+        self._path = path
+        self._released = False
+
+    @property
+    def path(self) -> str:
+        return self._path
+
+    @property
+    def released(self) -> bool:
+        return self._released
+
+    def release(self) -> str:
+        """Hand ownership over. Caller is now responsible for unlink.
+
+        Returns the path so common usage can be a one-liner::
+
+            with managed_tempfile_path(...) as h:
+                proc = spawn(h)  # spawn registers h.path on the proc
+                final_path = h.release()
+        """
+        self._released = True
+        with _pending_lock:
+            _pending_paths.discard(self._path)
+        return self._path
+
+    # Make the handle interchangeable with the path string for code
+    # that takes ``str | PathLike``. This keeps call-sites readable
+    # (``with managed_tempfile_path(...) as p: open(p)``).
+    def __fspath__(self) -> str:
+        return self._path
+
+    def __str__(self) -> str:
+        return self._path
+
+    def __repr__(self) -> str:
+        state = "released" if self._released else "pending"
+        return f"_TempfileHandle({self._path!r}, {state})"
+
+
+@contextlib.contextmanager
+def managed_tempfile_path(
+    *,
+    prefix: str = "tmp",
+    suffix: str = "",
+    dir: str | None = None,  # noqa: A002 — mirrors tempfile.mkstemp signature
+) -> Iterator[_TempfileHandle]:
+    """Create a tempfile and guarantee cleanup on context exit OR atexit.
+
+    Drop-in replacement for the ``NamedTemporaryFile(...).name`` anti-
+    pattern. The yielded object is path-like (``os.PathLike[str]``)
+    so existing call-sites can pass it directly to ``open()``,
+    ``subprocess.Popen(stdout=...)``, etc.
+
+    On context exit (normal OR exception) the path is unlinked.
+
+    If the caller transfers ownership to another lifecycle, calling
+    ``.release()`` on the handle suppresses both the context-exit
+    unlink and the atexit fallback. The caller becomes responsible
+    for unlinking; the helper is now hands-off.
+
+    Args:
+        prefix: Filename prefix (default ``"tmp"``).
+        suffix: Filename suffix (default ``""``).
+        dir: Parent directory (default: system temp dir).
+
+    Yields:
+        ``_TempfileHandle`` exposing ``.path``, ``.release()``, and
+        ``__fspath__``.
+    """
+    # ``mkstemp`` returns an open FD + path. We close the FD here so
+    # there is no descriptor leak — the caller will open the path
+    # themselves in whichever mode they need. This is the recommended
+    # pattern in the stdlib docs for "I just need the path".
+    fd, path = tempfile.mkstemp(prefix=prefix, suffix=suffix, dir=dir)
+    try:
+        os.close(fd)
+    except OSError:
+        # mkstemp succeeded but close failed — extremely rare. We
+        # still want the path tracked so cleanup happens.
+        pass
+
+    _ensure_atexit_registered()
+    with _pending_lock:
+        _pending_paths.add(path)
+
+    handle = _TempfileHandle(path)
+    try:
+        yield handle
+    finally:
+        if not handle.released:
+            with _pending_lock:
+                _pending_paths.discard(path)
+            try:
+                os.unlink(path)
+            except FileNotFoundError:
+                pass
+            except OSError:
+                # Same rationale as ``_atexit_reap_all``: best-
+                # effort cleanup; do not let a cleanup error mask
+                # the real exception (if any) propagating through
+                # the ``finally``.
+                pass
+
+
+def _pending_snapshot() -> set[str]:
+    """Return a snapshot of currently-tracked paths.
+
+    Exposed only for tests — production code should not depend on
+    the internal registry.
+    """
+    with _pending_lock:
+        return set(_pending_paths)
+
+
+__all__ = ["managed_tempfile_path"]

--- a/vllm_mlx/_tempfile_safe.py
+++ b/vllm_mlx/_tempfile_safe.py
@@ -287,7 +287,25 @@ def managed_tempfile_path(
     try:
         yield handle
     finally:
-        if not handle.released:
+        # Codex round-5 finding #2: read ``handle.released`` under the
+        # registry lock so a concurrent ``release()`` cannot interleave
+        # between the read and the unlink. With the lock-held check,
+        # either:
+        #   - ``release()`` finished first → ``released=True`` → we
+        #     skip the unlink (caller now owns).
+        #   - ``release()`` is concurrent → it blocks on the lock,
+        #     reads ``released=False``, and we unlink. The unlink is
+        #     idempotent (``FileNotFoundError`` is tolerated by
+        #     ``release()``'s atexit pass), so even if release()
+        #     observes ``released=False`` and the caller later
+        #     unlinks again, nothing breaks.
+        # This serializes the ownership transition for the multi-
+        # threaded edge case codex flagged. The chat REPL is
+        # single-threaded today; the lock is cheap and removes the
+        # foot-gun for future callers.
+        with _pending_lock:
+            should_unlink = not handle.released
+        if should_unlink:
             # Codex round-3 BLOCKING: unlink BEFORE discarding from
             # the registry. The original order (discard → unlink) had
             # a window where a ``BaseException`` (Ctrl-C, SIGTERM-

--- a/vllm_mlx/audio/probe.py
+++ b/vllm_mlx/audio/probe.py
@@ -235,14 +235,19 @@ def _dry_run_stt(model_name: str | None) -> tuple[bool, str | None]:
     configured engine instead.
     """
     try:
-        import tempfile
         import wave
 
+        from .._tempfile_safe import managed_tempfile_path
         from ..audio.stt import DEFAULT_WHISPER_MODEL, STTEngine
 
-        with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as tmp:
-            wav_path = tmp.name
-        try:
+        # GH #719 — the old pattern was ``NamedTemporaryFile(delete=False)``
+        # inside a ``with`` block (which only closes the FD, not the
+        # file), followed by a manual ``try/finally`` for unlink. The
+        # window between the ``with`` exit and the ``try`` entry leaked
+        # the wav if ``STTEngine`` construction raised. ``managed_tempfile_path``
+        # closes that window via atexit fallback.
+        with managed_tempfile_path(suffix=".wav") as wav_handle:
+            wav_path = wav_handle.path
             with wave.open(wav_path, "wb") as w:
                 w.setnchannels(1)
                 w.setsampwidth(2)
@@ -254,13 +259,6 @@ def _dry_run_stt(model_name: str | None) -> tuple[bool, str | None]:
             # An empty string is a valid transcription of silence.
             if not hasattr(result, "text"):
                 return False, "STT result missing `text` attribute"
-        finally:
-            import os as _os
-
-            try:
-                _os.unlink(wav_path)
-            except OSError:
-                pass
         return True, None
     except Exception as e:  # noqa: BLE001
         return False, f"STT dry-run failed: {type(e).__name__}: {e}"

--- a/vllm_mlx/audio/probe.py
+++ b/vllm_mlx/audio/probe.py
@@ -243,9 +243,14 @@ def _dry_run_stt(model_name: str | None) -> tuple[bool, str | None]:
         # GH #719 — the old pattern was ``NamedTemporaryFile(delete=False)``
         # inside a ``with`` block (which only closes the FD, not the
         # file), followed by a manual ``try/finally`` for unlink. The
-        # window between the ``with`` exit and the ``try`` entry leaked
-        # the wav if ``STTEngine`` construction raised. ``managed_tempfile_path``
-        # closes that window via atexit fallback.
+        # uncovered window was any exception between path allocation
+        # (when ``NamedTemporaryFile`` returned the open handle) and
+        # the start of the manual ``try`` block — including the
+        # ``with`` body itself, ``wave.open`` errors, or anything that
+        # raised before the manual ``finally`` could fire.
+        # ``managed_tempfile_path`` registers the path in a process-wide
+        # set the moment ``mkstemp`` returns, so the atexit fallback
+        # reaps it even on the bypass paths the old shape couldn't see.
         with managed_tempfile_path(suffix=".wav") as wav_handle:
             wav_path = wav_handle.path
             with wave.open(wav_path, "wb") as w:

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -3281,25 +3281,41 @@ def _spawn_chat_server(
     child_env["RAPID_MLX_CHAT_SPAWN"] = "1"
     # Atomic critical section: block SIGTERM/SIGINT delivery around
     # the whole ``Popen()`` + register + attribute-set + ``release()``
-    # sequence. Codex pr_validate round-2 BLOCKING: must use
-    # ``pthread_sigmask`` (block), NOT ``signal.signal(SIG_IGN)``
-    # (ignore), because signal DISPOSITION is inherited by ``fork``ed
-    # children. If we set the parent's disposition to ``SIG_IGN`` and
-    # then ``Popen()`` runs, the child server inherits ``SIG_IGN`` for
-    # SIGTERM/SIGINT and will refuse to honour normal shutdown signals
-    # for its entire lifetime. ``pthread_sigmask`` only affects the
-    # signal mask of the current thread, which is NOT inherited
-    # across ``fork`` + ``exec`` because the kernel resets the mask
-    # at exec time. On POSIX systems the child therefore exec's with
-    # the default mask AND default disposition.
+    # sequence. We use ``pthread_sigmask(SIG_BLOCK, ...)`` so the
+    # parent thread's mask blocks the signals (queued, delivered when
+    # restored).
+    #
+    # POSIX caveat (codex pr_validate round-3 BLOCKING): both the
+    # signal mask AND the signal disposition are inherited across
+    # ``fork`` + ``execve``. If we Popen() while the mask blocks
+    # SIGTERM/SIGINT, the child server inherits the block and won't
+    # honour normal shutdown. The fix is a ``preexec_fn`` that
+    # explicitly UNBLOCKS the signals in the child between ``fork``
+    # and ``exec`` so the child starts with a clean mask.
+    #
+    # ``preexec_fn`` runs in the child after fork, before exec, and
+    # is exactly the right hook for this. There is no async-signal-
+    # safety concern because we are still pre-exec; the child has
+    # not yet been replaced with a new image.
     #
     # On platforms without ``pthread_sigmask`` (Windows), fall back
-    # to the ``SIG_IGN`` approach and accept the inherit-into-child
-    # caveat — the chat REPL is not a Windows feature anyway.
+    # to the ``SIG_IGN`` shape — Windows ``subprocess`` doesn't have
+    # the same fork/exec model, and the chat REPL is not a Windows
+    # feature anyway.
     has_pthread_sigmask = hasattr(_signal, "pthread_sigmask")
     sigset = {_signal.SIGTERM, _signal.SIGINT}
     _prev_mask = None
     _prev_term = _prev_int = None
+
+    def _child_unblock_signals():
+        """preexec_fn: clear inherited SIGTERM/SIGINT mask in the child
+        so it starts with default mask + default disposition.
+        """
+        try:
+            _signal.pthread_sigmask(_signal.SIG_UNBLOCK, sigset)
+        except (ValueError, OSError):
+            pass
+
     try:
         if has_pthread_sigmask:
             try:
@@ -3307,8 +3323,6 @@ def _spawn_chat_server(
             except (ValueError, OSError):
                 _prev_mask = None
         else:
-            # Windows fallback — best effort; the child inherit caveat
-            # applies but the chat REPL targets POSIX.
             try:
                 _prev_term = _signal.signal(_signal.SIGTERM, _signal.SIG_IGN)
             except (ValueError, OSError):
@@ -3324,6 +3338,12 @@ def _spawn_chat_server(
                 stderr=subprocess.STDOUT,
                 start_new_session=True,
                 env=child_env,
+                # Codex pr_validate r3 BLOCKING: clear the inherited
+                # signal mask in the child so it can be terminated
+                # normally. ``preexec_fn`` is the documented hook for
+                # post-fork / pre-exec setup; the child cannot reach
+                # ``exec`` until this runs.
+                preexec_fn=_child_unblock_signals if has_pthread_sigmask else None,
             )
         except (OSError, ValueError):
             # Popen raised before constructing the child — the log handle

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -3279,29 +3279,44 @@ def _spawn_chat_server(
     # see a stdin pipe and re-evaluate against a potentially-stale cache.
     child_env = os.environ.copy()
     child_env["RAPID_MLX_CHAT_SPAWN"] = "1"
-    # Atomic critical section: mask SIGTERM/SIGINT around the whole
-    # ``Popen()`` + register + attribute-set + ``release()`` sequence.
-    # Codex round-5 BLOCKING: the mask MUST be installed BEFORE
-    # ``Popen()`` runs, not after. If we masked only the post-Popen
-    # block, a signal could land between ``Popen()`` returning and the
-    # mask going up; the chat's SIGTERM handler would then run
-    # ``_cleanup()`` against an empty ``_active_procs`` and ``sys.exit``,
-    # orphaning the just-spawned child. Masking around the whole
-    # sequence closes that window — the orphan child case from #719 is
-    # now actually impossible for SIGTERM/SIGINT delivery on the main
-    # thread. (Other signals or asynchronous exceptions on background
-    # threads remain best-effort; the rest of the chat REPL is
-    # single-threaded.)
+    # Atomic critical section: block SIGTERM/SIGINT delivery around
+    # the whole ``Popen()`` + register + attribute-set + ``release()``
+    # sequence. Codex pr_validate round-2 BLOCKING: must use
+    # ``pthread_sigmask`` (block), NOT ``signal.signal(SIG_IGN)``
+    # (ignore), because signal DISPOSITION is inherited by ``fork``ed
+    # children. If we set the parent's disposition to ``SIG_IGN`` and
+    # then ``Popen()`` runs, the child server inherits ``SIG_IGN`` for
+    # SIGTERM/SIGINT and will refuse to honour normal shutdown signals
+    # for its entire lifetime. ``pthread_sigmask`` only affects the
+    # signal mask of the current thread, which is NOT inherited
+    # across ``fork`` + ``exec`` because the kernel resets the mask
+    # at exec time. On POSIX systems the child therefore exec's with
+    # the default mask AND default disposition.
+    #
+    # On platforms without ``pthread_sigmask`` (Windows), fall back
+    # to the ``SIG_IGN`` approach and accept the inherit-into-child
+    # caveat — the chat REPL is not a Windows feature anyway.
+    has_pthread_sigmask = hasattr(_signal, "pthread_sigmask")
+    sigset = {_signal.SIGTERM, _signal.SIGINT}
+    _prev_mask = None
     _prev_term = _prev_int = None
     try:
-        try:
-            _prev_term = _signal.signal(_signal.SIGTERM, _signal.SIG_IGN)
-        except (ValueError, OSError):
-            pass
-        try:
-            _prev_int = _signal.signal(_signal.SIGINT, _signal.SIG_IGN)
-        except (ValueError, OSError):
-            pass
+        if has_pthread_sigmask:
+            try:
+                _prev_mask = _signal.pthread_sigmask(_signal.SIG_BLOCK, sigset)
+            except (ValueError, OSError):
+                _prev_mask = None
+        else:
+            # Windows fallback — best effort; the child inherit caveat
+            # applies but the chat REPL targets POSIX.
+            try:
+                _prev_term = _signal.signal(_signal.SIGTERM, _signal.SIG_IGN)
+            except (ValueError, OSError):
+                pass
+            try:
+                _prev_int = _signal.signal(_signal.SIGINT, _signal.SIG_IGN)
+            except (ValueError, OSError):
+                pass
         try:
             proc = subprocess.Popen(  # noqa: S603
                 cmd,
@@ -3313,7 +3328,7 @@ def _spawn_chat_server(
         except (OSError, ValueError):
             # Popen raised before constructing the child — the log handle
             # would otherwise leak. Re-raise after closing. The ``finally``
-            # below still restores the signal handlers.
+            # below still restores the signal mask / handlers.
             log.close()
             raise
         # Register first so a SIGTERM landing between here and the caller's
@@ -3331,16 +3346,26 @@ def _spawn_chat_server(
         if log_handle is not None:
             log_handle.release()
     finally:
-        # Best-effort restore so post-spawn signals route normally.
-        for signum, prev in (
-            (_signal.SIGTERM, _prev_term),
-            (_signal.SIGINT, _prev_int),
-        ):
-            if prev is not None:
+        # Best-effort restore so post-spawn signals route normally. Any
+        # SIGTERM/SIGINT that landed while blocked is delivered HERE
+        # (kernel-queued, exactly the desired behaviour: the chat's
+        # installed handler now sees the proc in ``_active_procs``).
+        if has_pthread_sigmask:
+            if _prev_mask is not None:
                 try:
-                    _signal.signal(signum, prev)
+                    _signal.pthread_sigmask(_signal.SIG_SETMASK, _prev_mask)
                 except (ValueError, OSError):
                     pass
+        else:
+            for signum, prev in (
+                (_signal.SIGTERM, _prev_term),
+                (_signal.SIGINT, _prev_int),
+            ):
+                if prev is not None:
+                    try:
+                        _signal.signal(signum, prev)
+                    except (ValueError, OSError):
+                        pass
     return proc, base_url
 
 

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -3279,26 +3279,19 @@ def _spawn_chat_server(
     # see a stdin pipe and re-evaluate against a potentially-stale cache.
     child_env = os.environ.copy()
     child_env["RAPID_MLX_CHAT_SPAWN"] = "1"
-    try:
-        proc = subprocess.Popen(  # noqa: S603
-            cmd,
-            stdout=log,
-            stderr=subprocess.STDOUT,
-            start_new_session=True,
-            env=child_env,
-        )
-    except (OSError, ValueError):
-        # Popen raised before constructing the child — the log handle
-        # would otherwise leak. Re-raise after closing.
-        log.close()
-        raise
-    # Atomic ownership-transfer critical section: mask SIGTERM/SIGINT so
-    # ``_cleanup`` (which walks ``_active_procs`` and applies
-    # ``_teardown_proc``'s keep-non-empty-log policy) cannot interleave
-    # between the append and the ``log_handle.release()`` call. Without
-    # the mask, a signal here would fire ``_teardown_proc`` (which may
-    # keep the log) and then the surrounding ``with`` block's ``finally``
-    # would unlink it anyway. See docstring for the full race.
+    # Atomic critical section: mask SIGTERM/SIGINT around the whole
+    # ``Popen()`` + register + attribute-set + ``release()`` sequence.
+    # Codex round-5 BLOCKING: the mask MUST be installed BEFORE
+    # ``Popen()`` runs, not after. If we masked only the post-Popen
+    # block, a signal could land between ``Popen()`` returning and the
+    # mask going up; the chat's SIGTERM handler would then run
+    # ``_cleanup()`` against an empty ``_active_procs`` and ``sys.exit``,
+    # orphaning the just-spawned child. Masking around the whole
+    # sequence closes that window — the orphan child case from #719 is
+    # now actually impossible for SIGTERM/SIGINT delivery on the main
+    # thread. (Other signals or asynchronous exceptions on background
+    # threads remain best-effort; the rest of the chat REPL is
+    # single-threaded.)
     _prev_term = _prev_int = None
     try:
         try:
@@ -3309,6 +3302,20 @@ def _spawn_chat_server(
             _prev_int = _signal.signal(_signal.SIGINT, _signal.SIG_IGN)
         except (ValueError, OSError):
             pass
+        try:
+            proc = subprocess.Popen(  # noqa: S603
+                cmd,
+                stdout=log,
+                stderr=subprocess.STDOUT,
+                start_new_session=True,
+                env=child_env,
+            )
+        except (OSError, ValueError):
+            # Popen raised before constructing the child — the log handle
+            # would otherwise leak. Re-raise after closing. The ``finally``
+            # below still restores the signal handlers.
+            log.close()
+            raise
         # Register first so a SIGTERM landing between here and the caller's
         # next statement still tears the child down.
         if register_in is not None:

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -3219,6 +3219,7 @@ def _spawn_chat_server(
     served_name: str | None = None,
     *,
     register_in: list | None = None,
+    log_handle=None,
 ) -> tuple[object, str]:
     """Spawn a `serve` subprocess on an ephemeral port for chat REPL use.
 
@@ -3232,11 +3233,23 @@ def _spawn_chat_server(
     one Python statement of unprotected window; doing it inside this
     function closes that window for the caller.
 
+    ``log_handle`` is the ``managed_tempfile_path`` context-manager handle
+    that owns ``log_path``. When provided, ownership is transferred to the
+    proc inside a SIGTERM/SIGINT-masked critical section that also performs
+    the ``register_in`` append and the ``_rapid_mlx_log*`` attribute set.
+    Without the mask + atomic transfer, a signal landing between
+    ``_active_procs.append`` and the caller's later ``handle.release()``
+    could fire ``_teardown_proc`` (which intentionally keeps non-empty
+    logs for post-mortem) — then the ``with`` block's ``finally`` would
+    unlink the kept log anyway, violating the keep-non-empty-log policy
+    documented on ``_teardown_proc``. Codex round-1 BLOCKING #1.
+
     If ``served_name`` is given, it is passed via ``--served-model-name`` so
     the spawned server exposes the alias as the API model name (e.g. user
     typed ``qwen3.5-4b-4bit`` → API requests use ``qwen3.5-4b-4bit`` rather than the
     expanded HF path).
     """
+    import signal as _signal
     import socket
     import subprocess
 
@@ -3279,15 +3292,48 @@ def _spawn_chat_server(
         # would otherwise leak. Re-raise after closing.
         log.close()
         raise
-    # Register first so a SIGTERM landing between here and the caller's
-    # next statement still tears the child down.
-    if register_in is not None:
-        register_in.append(proc)
-    # Stash the log handle and path on the proc object so the chat REPL
-    # can close+unlink them when the proc is torn down (fixes the file
-    # descriptor + tempfile leak across `/model` swaps).
-    proc._rapid_mlx_log = log
-    proc._rapid_mlx_log_path = log_path
+    # Atomic ownership-transfer critical section: mask SIGTERM/SIGINT so
+    # ``_cleanup`` (which walks ``_active_procs`` and applies
+    # ``_teardown_proc``'s keep-non-empty-log policy) cannot interleave
+    # between the append and the ``log_handle.release()`` call. Without
+    # the mask, a signal here would fire ``_teardown_proc`` (which may
+    # keep the log) and then the surrounding ``with`` block's ``finally``
+    # would unlink it anyway. See docstring for the full race.
+    _prev_term = _prev_int = None
+    try:
+        try:
+            _prev_term = _signal.signal(_signal.SIGTERM, _signal.SIG_IGN)
+        except (ValueError, OSError):
+            pass
+        try:
+            _prev_int = _signal.signal(_signal.SIGINT, _signal.SIG_IGN)
+        except (ValueError, OSError):
+            pass
+        # Register first so a SIGTERM landing between here and the caller's
+        # next statement still tears the child down.
+        if register_in is not None:
+            register_in.append(proc)
+        # Stash the log handle and path on the proc object so the chat REPL
+        # can close+unlink them when the proc is torn down (fixes the file
+        # descriptor + tempfile leak across `/model` swaps).
+        proc._rapid_mlx_log = log
+        proc._rapid_mlx_log_path = log_path
+        # Hand the tempfile path off to ``_teardown_proc`` BEFORE we
+        # leave the masked section. Once released, the ``with`` block's
+        # ``finally`` in the caller is a no-op for this path.
+        if log_handle is not None:
+            log_handle.release()
+    finally:
+        # Best-effort restore so post-spawn signals route normally.
+        for signum, prev in (
+            (_signal.SIGTERM, _prev_term),
+            (_signal.SIGINT, _prev_int),
+        ):
+            if prev is not None:
+                try:
+                    _signal.signal(signum, prev)
+                except (ValueError, OSError):
+                    pass
     return proc, base_url
 
 
@@ -3982,10 +4028,12 @@ def chat_command(args):
         # ``managed_tempfile_path`` helper registers an atexit unlink
         # the moment the path exists, so the race window is closed:
         # cleanup runs on context exit, on ``sys.exit``, or via atexit
-        # if the body propagates. Once ``_spawn_chat_server`` has
-        # successfully stashed the path on the proc, ``.release()``
-        # hands ownership to ``_teardown_proc`` so its per-proc policy
-        # (keep non-empty logs for post-mortem) still applies.
+        # if the body propagates. The handle is passed through to
+        # ``_spawn_chat_server`` which performs the
+        # register/attribute-set/release as a single SIGTERM-masked
+        # critical section, so ``_teardown_proc``'s keep-non-empty-log
+        # policy cannot be undone by a signal during the handoff
+        # (codex round-1 BLOCKING #1).
         with managed_tempfile_path(
             prefix="rapid-mlx-chat-", suffix=".log"
         ) as _log_handle:
@@ -3999,10 +4047,8 @@ def chat_command(args):
                 log_path,
                 served_name=original,
                 register_in=_active_procs,
+                log_handle=_log_handle,
             )
-            # Spawn succeeded and the proc owns the log path now; the
-            # session-long cleanup belongs to ``_teardown_proc``.
-            _log_handle.release()
 
         try:
             _wait_for_chat_server(base_url, proc, timeout_s=args.ready_timeout)
@@ -4275,9 +4321,11 @@ def chat_command(args):
         #    guarantees the log path is unlinked if the spawn raises
         #    before the proc is registered onto ``_active_procs`` —
         #    the leak window in the original ``NamedTemporaryFile(...).name``
-        #    pattern. Once the proc holds the path, ``release()``
-        #    hands ownership to ``_teardown_proc`` whose per-proc
-        #    policy already covers non-empty-keep semantics.
+        #    pattern. The handle is passed into ``_spawn_chat_server``
+        #    so the register/attribute-set/release happens under one
+        #    SIGTERM/SIGINT mask, preserving ``_teardown_proc``'s
+        #    keep-non-empty-log policy on signal-during-handoff (codex
+        #    round-1 BLOCKING #1).
         with managed_tempfile_path(
             prefix="rapid-mlx-chat-", suffix=".log"
         ) as _new_log_handle:
@@ -4293,8 +4341,8 @@ def chat_command(args):
                 new_log_path,
                 served_name=new_alias,
                 register_in=_active_procs,
+                log_handle=_new_log_handle,
             )
-            _new_log_handle.release()
         try:
             _wait_for_chat_server(new_base_url, new_proc, timeout_s=args.ready_timeout)
         except (RuntimeError, TimeoutError) as exc:

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -3771,7 +3771,8 @@ def chat_command(args):
     import atexit
     import signal
     import subprocess
-    import tempfile
+
+    from vllm_mlx._tempfile_safe import managed_tempfile_path
 
     base_url: str
     proc = None
@@ -3974,19 +3975,34 @@ def chat_command(args):
         # several minutes on first run with a fresh model.
         _ensure_model_downloaded(args.model)
 
-        log_path = tempfile.NamedTemporaryFile(
-            prefix="rapid-mlx-chat-", suffix=".log", delete=False
-        ).name
-        print(f"\n  Starting server {DIM}(log: {log_path}){RESET} ...")
-        # If main() resolved an alias, expose the alias as the API model name
-        # so the chat request body matches what the user typed.
-        original = getattr(args, "_original_alias", None)
-        proc, base_url = _spawn_chat_server(
-            args.model,
-            log_path,
-            served_name=original,
-            register_in=_active_procs,
-        )
+        # GH #719: ``NamedTemporaryFile(...).name`` leaked one zero-byte
+        # log per invocation if ANYTHING raised between path creation
+        # and the proc being appended to ``_active_procs`` (where
+        # ``_teardown_proc`` would otherwise reap it). The
+        # ``managed_tempfile_path`` helper registers an atexit unlink
+        # the moment the path exists, so the race window is closed:
+        # cleanup runs on context exit, on ``sys.exit``, or via atexit
+        # if the body propagates. Once ``_spawn_chat_server`` has
+        # successfully stashed the path on the proc, ``.release()``
+        # hands ownership to ``_teardown_proc`` so its per-proc policy
+        # (keep non-empty logs for post-mortem) still applies.
+        with managed_tempfile_path(
+            prefix="rapid-mlx-chat-", suffix=".log"
+        ) as _log_handle:
+            log_path = _log_handle.path
+            print(f"\n  Starting server {DIM}(log: {log_path}){RESET} ...")
+            # If main() resolved an alias, expose the alias as the API model name
+            # so the chat request body matches what the user typed.
+            original = getattr(args, "_original_alias", None)
+            proc, base_url = _spawn_chat_server(
+                args.model,
+                log_path,
+                served_name=original,
+                register_in=_active_procs,
+            )
+            # Spawn succeeded and the proc owns the log path now; the
+            # session-long cleanup belongs to ``_teardown_proc``.
+            _log_handle.release()
 
         try:
             _wait_for_chat_server(base_url, proc, timeout_s=args.ready_timeout)
@@ -4255,22 +4271,30 @@ def chat_command(args):
 
         # 2. Allocate a new log file and spawn the new server. We don't
         #    tear down the old one yet; we want a working candidate
-        #    before we commit.
-        new_log_path = tempfile.NamedTemporaryFile(
-            prefix="rapid-mlx-chat-", suffix=".log", delete=False
-        ).name
-        print(f"  Starting server {DIM}(log: {new_log_path}){RESET} ...")
-        # ``register_in=_active_procs`` makes the candidate visible to
-        # ``_cleanup`` *inside* ``_spawn_chat_server`` — before the
-        # readiness wait, before any further Python statement runs in
-        # this scope. A SIGTERM/Ctrl-C during the (possibly multi-second)
-        # load tears the child down via the cleanup walk.
-        new_proc, new_base_url = _spawn_chat_server(
-            resolved,
-            new_log_path,
-            served_name=new_alias,
-            register_in=_active_procs,
-        )
+        #    before we commit. ``managed_tempfile_path`` (GH #719)
+        #    guarantees the log path is unlinked if the spawn raises
+        #    before the proc is registered onto ``_active_procs`` —
+        #    the leak window in the original ``NamedTemporaryFile(...).name``
+        #    pattern. Once the proc holds the path, ``release()``
+        #    hands ownership to ``_teardown_proc`` whose per-proc
+        #    policy already covers non-empty-keep semantics.
+        with managed_tempfile_path(
+            prefix="rapid-mlx-chat-", suffix=".log"
+        ) as _new_log_handle:
+            new_log_path = _new_log_handle.path
+            print(f"  Starting server {DIM}(log: {new_log_path}){RESET} ...")
+            # ``register_in=_active_procs`` makes the candidate visible to
+            # ``_cleanup`` *inside* ``_spawn_chat_server`` — before the
+            # readiness wait, before any further Python statement runs in
+            # this scope. A SIGTERM/Ctrl-C during the (possibly multi-second)
+            # load tears the child down via the cleanup walk.
+            new_proc, new_base_url = _spawn_chat_server(
+                resolved,
+                new_log_path,
+                served_name=new_alias,
+                register_in=_active_procs,
+            )
+            _new_log_handle.release()
         try:
             _wait_for_chat_server(new_base_url, new_proc, timeout_s=args.ready_timeout)
         except (RuntimeError, TimeoutError) as exc:


### PR DESCRIPTION
## Repro

Confirmed on this dev machine: **8244 zero-byte ``rapid-mlx-chat-*.log`` stragglers** accumulated in ``$TMPDIR`` over 8 days, matching the #719 report (3496 on the reporter's box after 4 days). All zero-byte, all created by the documented Python anti-pattern:

```python
log_path = tempfile.NamedTemporaryFile(
    prefix=\"rapid-mlx-chat-\", suffix=\".log\", delete=False,
).name  # returns path; the NamedTemporaryFile object is GC'd; file persists
```

Repro script (reduced from the user's invocation):

```
$ ls $TMPDIR | grep -c rapid-mlx-chat
8244
$ # injecting KeyboardInterrupt during ``Starting server`` print:
$ python -c "<reproduce path>"  # one new leak per run, pre-fix
$ ls $TMPDIR | grep -c rapid-mlx-chat
8245
```

Each leak is **one zero-byte file in ``$TMPDIR``** matching ``rapid-mlx-chat-*.log``.

## Root cause

Two sites in ``vllm_mlx/cli.py`` (initial spawn at line 3977 + ``/model`` swap at line 4259) used ``NamedTemporaryFile(delete=False).name`` and relied on the downstream ``_teardown_proc`` to reap the path via its zero-byte-unlink policy. **That cleanup only fires when the proc made it onto ``_active_procs``.** Any exception in the window between path creation and ``_spawn_chat_server`` successfully stashing the path on the proc (KeyboardInterrupt, BrokenPipeError on ``print``, ImportError, etc.) orphans the file forever.

Verified with the repro: KeyboardInterrupt injected at the ``Starting server`` ``print()`` (an explicit user Ctrl-C while waiting for a slow ``_ensure_model_downloaded``) consistently leaks 1 tempfile pre-fix.

A third leak site existed in ``vllm_mlx/audio/probe.py`` (STT dry-run) with the same shape — a ``with NamedTemporaryFile(delete=False)`` block whose body exit raced a follow-on ``try/finally``.

## Systematic fix

New helper ``vllm_mlx/_tempfile_safe.py::managed_tempfile_path``:

- Creates path via ``mkstemp`` (no descriptor leak — FD closed immediately).
- Registers path in a module-level set; a **single shared ``atexit`` hook** unlinks every still-tracked path on interpreter shutdown. This closes the window where ``__exit__`` doesn't run (the race that #719 reported).
- Unlinks on context exit (normal OR exception).
- Exposes ``.release()`` so callers can hand ownership to another lifecycle. Used in ``cli.py`` to defer to ``_teardown_proc``'s existing per-proc policy (keeps non-empty logs for post-mortem diagnostics).

Applied at **all three** known leak sites:

- ``vllm_mlx/cli.py`` line 3977 (initial chat spawn).
- ``vllm_mlx/cli.py`` line 4259 (``/model`` switch spawn).
- ``vllm_mlx/audio/probe.py`` (STT dry-run wav).

The systematic property: every site that previously created a path-by-name with ``delete=False`` now goes through the helper, which guarantees cleanup on every exit path the interpreter can take (sans ``SIGKILL``/``os._exit``, which are documented and acceptable — they are not the failure modes #719 observed).

## Test plan

New ``tests/test_tempfile_safe.py`` (11 tests, all pass):

- [x] Happy path: file exists in body, gone on exit.
- [x] Exception in body: ``finally`` still unlinks.
- [x] ``release()`` suppresses unlink; double-release is a no-op.
- [x] Registry hygiene: no stale entries after normal exit; path IS tracked during the body; ``release()`` drops it immediately.
- [x] Subprocess atexit fallback (the regression #719 reported).
- [x] Negative control: ``os._exit`` is documented to skip both ``__exit__`` and ``atexit``.
- [x] End-to-end ``chat_command`` leak regression: KeyboardInterrupt during the spawn ``print`` — pre-fix 1, post-fix 0.
- [x] End-to-end ``chat_command`` leak regression: ``_wait_for_chat_server`` raises → ``sys.exit(1)`` — pre-fix 1, post-fix 0.

Existing ``tests/test_cli_chat.py`` (74 tests) all still green, including ``test_teardown_unlinks_only_empty_log_files`` — the per-proc keep-non-empty-for-postmortem policy is preserved via ``release()``.

Broader suite (3126 tests) green; one pre-existing flaky perf test (``test_batching_improves_throughput``) is unrelated and fails identically on ``main``.

Closes #719.

🤖 Generated with [Claude Code](https://claude.com/claude-code)