### PR TITLE
fix(responses): emit leading items before message in stream (M-3 ordering)

### DIFF
--- a/tests/test_r12_m3_responses_stream_leading_items_order.py
+++ b/tests/test_r12_m3_responses_stream_leading_items_order.py
@@ -348,17 +348,32 @@ class TestLeadingItemOrdering:
         client = make_client.set(_EngineEmptyReasoning())
         events = _stream_and_parse(client, _stream_payload())
 
-        # Pull added events keyed by output_index.
+        # Pull added events keyed by output_index. R12-M3 codex r1 NIT:
+        # guard against duplicate output_index emissions — each wire
+        # ``output_item.added`` must own a unique ``output_index``; the
+        # terminal ``response.output[]`` is indexed in the same space,
+        # so duplicates would silently mask wire bugs.
         added_by_idx: dict[int, str] = {}
         for name, data in events:
             if name != "response.output_item.added":
                 continue
-            added_by_idx[data["output_index"]] = data["item"]["type"]
+            idx = data["output_index"]
+            assert idx not in added_by_idx, (
+                f"duplicate output_index={idx} in response.output_item.added "
+                f"events: existing={added_by_idx[idx]}, new={data['item']['type']}"
+            )
+            added_by_idx[idx] = data["item"]["type"]
 
         # Terminal completed payload.
         completed = [d for (n, d) in events if n == "response.completed"]
         assert completed, "missing response.completed event"
         output_arr = completed[0]["response"]["output"]
+        # Index space must be 1:1 between wire-added and completed[].
+        assert len(added_by_idx) == len(output_arr), (
+            f"wire emitted {len(added_by_idx)} added events but completed "
+            f"has {len(output_arr)} entries: added={added_by_idx}, "
+            f"completed={[it['type'] for it in output_arr]}"
+        )
         for i, item in enumerate(output_arr):
             assert added_by_idx.get(i) == item["type"], (
                 f"Index mismatch at position {i}: added_by_idx={added_by_idx}, "

--- a/tests/test_r12_m3_responses_stream_leading_items_order.py
+++ b/tests/test_r12_m3_responses_stream_leading_items_order.py
@@ -1,0 +1,375 @@
+# SPDX-License-Identifier: Apache-2.0
+"""R12-M3 regression guard — streaming ``/v1/responses`` MUST emit the
+``reasoning`` output item BEFORE the ``message`` output item, even when
+the reasoning text is empty.
+
+Mira r12 dogfood (R-4): the streaming surface emits the empty/short
+``reasoning`` item AFTER the message item, so SDK clients that expect
+reasoning-before-message see message first and may discard the late
+reasoning item or treat the stream as malformed. The OpenAI Responses
+reference implementation always emits a ``reasoning`` item (possibly
+with empty content) BEFORE the message item — this test pins that
+invariant on the rapid-mlx streaming wire.
+
+The invariant tested here:
+  1. ``response.output_item.added`` events for "leading" items (currently
+     just ``reasoning``) MUST land before the ``response.output_item.added``
+     for the ``message`` item.
+  2. Even when the model produces zero reasoning text, a ``reasoning``
+     item with empty ``summary`` MUST still be emitted before the
+     ``message`` item.
+  3. Output indices in the wire events MUST be monotonically increasing
+     and consistent with the final ``response.completed.response.output[]``
+     array ordering.
+"""
+
+import json
+import sys
+import types
+from dataclasses import dataclass, field
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+class _Tokenizer:
+    chat_template = ""
+
+    def encode(self, text: str) -> list[int]:
+        return list(range(len(text)))
+
+
+class _BaseEngine:
+    pass
+
+
+@dataclass
+class _GenerationOutput:
+    text: str
+    raw_text: str = ""
+    tokens: list[int] = field(default_factory=list)
+    prompt_tokens: int = 0
+    completion_tokens: int = 0
+    finish_reason: str | None = "stop"
+    new_text: str = ""
+    finished: bool = True
+    logprobs: Any = None
+    channel: str | None = None
+    tool_calls: list | None = None
+    reasoning_text: str = ""
+
+
+class _EngineEmptyReasoning:
+    """Engine that produces ONLY non-reasoning content (no reasoning bytes).
+
+    Reproduces the M-3 bug: when reasoning is empty, the legacy code
+    skipped the post-loop reasoning emit entirely, so the message item
+    was the only ``output_item.added``. Post-fix, a reasoning item with
+    empty summary MUST still be emitted BEFORE the message item.
+    """
+
+    preserve_native_tool_format = False
+
+    def __init__(self):
+        self.tokenizer = _Tokenizer()
+
+    async def chat(self, messages, **kwargs):
+        return _GenerationOutput(
+            text="hi",
+            prompt_tokens=3,
+            completion_tokens=1,
+            finish_reason="stop",
+        )
+
+    async def stream_chat(self, messages, **kwargs):
+        chunks = ["hi"]
+        for i, c in enumerate(chunks):
+            yield _GenerationOutput(
+                text="".join(chunks[: i + 1]),
+                new_text=c,
+                prompt_tokens=3 if i == 0 else 0,
+                completion_tokens=i + 1,
+                finish_reason=None if i < len(chunks) - 1 else "stop",
+            )
+
+
+class _EngineWithReasoning:
+    """Engine that emits reasoning via the harmony-style ``channel`` field."""
+
+    preserve_native_tool_format = False
+
+    def __init__(self):
+        self.tokenizer = _Tokenizer()
+
+    async def chat(self, messages, **kwargs):
+        return _GenerationOutput(
+            text="hello",
+            prompt_tokens=3,
+            completion_tokens=2,
+            finish_reason="stop",
+        )
+
+    async def stream_chat(self, messages, **kwargs):
+        # First a reasoning chunk, then the actual answer.
+        yield _GenerationOutput(
+            text="",
+            new_text="thinking step",
+            prompt_tokens=3,
+            completion_tokens=0,
+            channel="reasoning",
+            finish_reason=None,
+        )
+        yield _GenerationOutput(
+            text="hello",
+            new_text="hello",
+            prompt_tokens=0,
+            completion_tokens=2,
+            channel="content",
+            finish_reason="stop",
+        )
+
+
+_IMPORTED = (
+    "vllm_mlx.config",
+    "vllm_mlx.config.server_config",
+    "vllm_mlx.engine",
+    "vllm_mlx.engine.base",
+    "vllm_mlx.middleware.auth",
+    "vllm_mlx.service.helpers",
+    "vllm_mlx.routes.responses",
+)
+_PARENT_ATTRS = (
+    ("vllm_mlx", "config"),
+    ("vllm_mlx", "engine"),
+    ("vllm_mlx.config", "server_config"),
+    ("vllm_mlx.engine", "base"),
+    ("vllm_mlx.middleware", "auth"),
+    ("vllm_mlx.service", "helpers"),
+    ("vllm_mlx.routes", "responses"),
+)
+_MISSING = object()
+
+
+def _install_lightweight_engine_modules(monkeypatch):
+    engine_pkg = types.ModuleType("vllm_mlx.engine")
+    engine_pkg.BaseEngine = _BaseEngine
+    engine_pkg.GenerationOutput = _GenerationOutput
+
+    base_mod = types.ModuleType("vllm_mlx.engine.base")
+    base_mod.BaseEngine = _BaseEngine
+    base_mod.GenerationOutput = _GenerationOutput
+
+    monkeypatch.setitem(sys.modules, "vllm_mlx.engine", engine_pkg)
+    monkeypatch.setitem(sys.modules, "vllm_mlx.engine.base", base_mod)
+
+
+@pytest.fixture
+def make_client(monkeypatch):
+    """Yields a factory that swaps the engine and returns a TestClient."""
+    previous_modules = {n: sys.modules.get(n, _MISSING) for n in _IMPORTED}
+    previous_attrs = {}
+    for module_name, attr in _PARENT_ATTRS:
+        module = sys.modules.get(module_name)
+        previous_attrs[(module_name, attr)] = (
+            getattr(module, attr, _MISSING) if module is not None else _MISSING
+        )
+
+    _install_lightweight_engine_modules(monkeypatch)
+
+    from vllm_mlx.config import reset_config
+    from vllm_mlx.middleware.auth import rate_limiter
+    from vllm_mlx.middleware.exception_handlers import install_exception_handlers
+    from vllm_mlx.routes.responses import router
+
+    cfg = reset_config()
+    cfg.api_key = "test-secret"
+    cfg.model_name = "test-model"
+    cfg.model_registry = None
+
+    rate_limiter.enabled = False
+    rate_limiter.requests_per_minute = 60
+    rate_limiter._requests.clear()
+
+    app = FastAPI()
+    install_exception_handlers(app)
+    app.include_router(router)
+    client = TestClient(app)
+
+    def _set(engine):
+        cfg.engine = engine
+        return client
+
+    yield SimpleNamespace(set=_set, client=client)
+
+    reset_config()
+    rate_limiter.enabled = False
+    rate_limiter.requests_per_minute = 60
+    rate_limiter._requests.clear()
+
+    for name, previous in previous_modules.items():
+        if previous is _MISSING:
+            sys.modules.pop(name, None)
+        else:
+            sys.modules[name] = previous
+
+    for (module_name, attr), previous in previous_attrs.items():
+        module = sys.modules.get(module_name)
+        if module is None:
+            continue
+        if previous is _MISSING:
+            if hasattr(module, attr):
+                delattr(module, attr)
+        else:
+            setattr(module, attr, previous)
+
+
+HEADERS = {"Authorization": "Bearer test-secret"}
+
+
+def _parse_sse(body_text: str) -> list[tuple[str, dict]]:
+    events: list[tuple[str, dict]] = []
+    for block in body_text.split("\n\n"):
+        block = block.strip()
+        if not block:
+            continue
+        event_name = None
+        data_text = None
+        for line in block.split("\n"):
+            if line.startswith("event:"):
+                event_name = line[len("event:") :].strip()
+            elif line.startswith("data:"):
+                data_text = line[len("data:") :].strip()
+        if event_name and data_text is not None:
+            events.append((event_name, json.loads(data_text)))
+    return events
+
+
+def _stream_payload(**overrides):
+    base = {"model": "test-model", "input": "Hello, world", "stream": True}
+    base.update(overrides)
+    return base
+
+
+def _stream_and_parse(client, payload):
+    with client.stream(
+        "POST",
+        "/v1/responses",
+        json=payload,
+        headers=HEADERS,
+    ) as resp:
+        assert resp.status_code == 200
+        body = "".join(resp.iter_text())
+    return _parse_sse(body)
+
+
+def _assert_leading_items_before_message(events):
+    """Shared monotonic-ordering assertion helper.
+
+    Walks the ``response.output_item.added`` events and asserts that any
+    ``reasoning`` / ``function_call`` / ``computer_call`` item comes
+    BEFORE the ``message`` item. Returns the ordered list of (type, idx)
+    tuples so callers can do additional shape assertions.
+    """
+    added_items: list[tuple[str, int]] = []
+    message_added_idx: int | None = None
+    for idx, (name, data) in enumerate(events):
+        if name != "response.output_item.added":
+            continue
+        item = data.get("item", {})
+        item_type = item.get("type")
+        added_items.append((item_type, idx))
+        if item_type == "message" and message_added_idx is None:
+            message_added_idx = idx
+
+    for item_type, idx in added_items:
+        if item_type in ("reasoning", "function_call", "computer_call"):
+            if message_added_idx is not None:
+                assert idx < message_added_idx, (
+                    f"Ordering violation: leading {item_type!r} item at "
+                    f"event#{idx} arrived AFTER message item at "
+                    f"event#{message_added_idx}. OpenAI Responses spec "
+                    f"requires all leading items before the message item."
+                )
+    return added_items
+
+
+class TestLeadingItemOrdering:
+    def test_empty_reasoning_still_emits_reasoning_before_message(self, make_client):
+        """M-3 root case: model produces NO reasoning bytes. The fix must
+        still emit an empty ``reasoning`` item BEFORE the message item,
+        matching the OpenAI reference implementation."""
+        client = make_client.set(_EngineEmptyReasoning())
+        events = _stream_and_parse(client, _stream_payload())
+        added = _assert_leading_items_before_message(events)
+
+        added_types = [t for t, _ in added]
+        assert "message" in added_types, (
+            f"No message item emitted — events: {[n for n, _ in events]}"
+        )
+        assert "reasoning" in added_types, (
+            "Empty-reasoning case: reasoning item MUST still be emitted "
+            "before the message item per OpenAI Responses spec. "
+            f"Items added (in order): {added_types}"
+        )
+        # Reasoning must be FIRST.
+        assert added_types[0] == "reasoning", (
+            f"reasoning must be the first output_item.added event; "
+            f"got order: {added_types}"
+        )
+
+    def test_non_empty_reasoning_emitted_before_message(self, make_client):
+        """Existing-behaviour parity: when the model DOES produce
+        reasoning, reasoning-first ordering is also preserved."""
+        client = make_client.set(_EngineWithReasoning())
+        events = _stream_and_parse(client, _stream_payload())
+        added = _assert_leading_items_before_message(events)
+        added_types = [t for t, _ in added]
+        assert added_types[0] == "reasoning"
+        assert "message" in added_types
+
+        # The reasoning summary must carry the model's chain-of-thought.
+        reasoning_done = [
+            d
+            for (n, d) in events
+            if n == "response.output_item.done"
+            and d.get("item", {}).get("type") == "reasoning"
+        ]
+        assert reasoning_done
+        summary = reasoning_done[0]["item"].get("summary", [])
+        assert summary and summary[0]["text"]
+
+    def test_completed_output_index_matches_wire_indices(self, make_client):
+        """The ``output_index`` on every ``output_item.added`` event must
+        match the position of that item in the terminal
+        ``response.completed.response.output[]`` array."""
+        client = make_client.set(_EngineEmptyReasoning())
+        events = _stream_and_parse(client, _stream_payload())
+
+        # Pull added events keyed by output_index.
+        added_by_idx: dict[int, str] = {}
+        for name, data in events:
+            if name != "response.output_item.added":
+                continue
+            added_by_idx[data["output_index"]] = data["item"]["type"]
+
+        # Terminal completed payload.
+        completed = [d for (n, d) in events if n == "response.completed"]
+        assert completed, "missing response.completed event"
+        output_arr = completed[0]["response"]["output"]
+        for i, item in enumerate(output_arr):
+            assert added_by_idx.get(i) == item["type"], (
+                f"Index mismatch at position {i}: added_by_idx={added_by_idx}, "
+                f"output[i].type={item['type']}"
+            )
+
+    def test_assert_monotonic_helper(self, make_client):
+        """The helper itself: a stream with reasoning-first ordering must
+        pass the assertion. Sanity-check the helper so future tests can
+        reuse it confidently."""
+        client = make_client.set(_EngineWithReasoning())
+        events = _stream_and_parse(client, _stream_payload())
+        # Should not raise.
+        _assert_leading_items_before_message(events)

--- a/tests/test_responses_route.py
+++ b/tests/test_responses_route.py
@@ -926,9 +926,15 @@ class TestResponsesStreamR10C3:
 
     def test_completed_payload_carries_output_array(self, responses_client):
         """``response.completed.response.output`` must be a non-empty list
-        whose first item is the assistant message with the concatenated
-        delta text — Sven r10-R1 saw this field MISSING entirely on 0.8.11
-        and the openai-python SDK raised on Response.output validation."""
+        carrying the assistant message with the concatenated delta text —
+        Sven r10-R1 saw this field MISSING entirely on 0.8.11 and the
+        openai-python SDK raised on Response.output validation.
+
+        R12-M3 (Mira r12 R-4): the OpenAI Responses spec requires the
+        ``reasoning`` item to land BEFORE the ``message`` item on the
+        wire, so the assistant message item now sits at ``output[1]`` with
+        the leading reasoning item at ``output[0]``.
+        """
         client = responses_client.client
 
         with client.stream(
@@ -949,20 +955,28 @@ class TestResponsesStreamR10C3:
         )
         output = response_obj["output"]
         assert isinstance(output, list)
-        assert len(output) >= 1
-        first_item = output[0]
-        assert first_item["type"] == "message"
-        assert first_item["status"] == "completed"
-        assert first_item["role"] == "assistant"
-        assert first_item["content"][0]["type"] == "output_text"
-        assert first_item["content"][0]["text"] == "Hello from rapid"
+        assert len(output) >= 2  # reasoning + message (R12-M3)
+        # R12-M3: leading reasoning item at index 0.
+        assert output[0]["type"] == "reasoning"
+        # Message item now at index 1, preserving its prior shape.
+        message_item = next(item for item in output if item["type"] == "message")
+        assert message_item["status"] == "completed"
+        assert message_item["role"] == "assistant"
+        assert message_item["content"][0]["type"] == "output_text"
+        assert message_item["content"][0]["text"] == "Hello from rapid"
 
     def test_completed_output_text_equals_concatenated_deltas(self, responses_client):
         """The concatenated ``response.output_text.delta`` payloads MUST
-        equal ``response.completed.response.output[0].content[0].text``.
-        This pins the streaming-vs-completed invariant — the streaming
-        payload reconstructs the same final response object the non-
-        streaming path returns."""
+        equal the assistant message's ``content[0].text`` in
+        ``response.completed.response.output[]``. This pins the
+        streaming-vs-completed invariant — the streaming payload
+        reconstructs the same final response object the non-streaming
+        path returns.
+
+        R12-M3 (Mira r12 R-4): the message item is no longer guaranteed
+        to sit at ``output[0]`` (a leading ``reasoning`` item lands first
+        per spec), so the lookup is by ``type=="message"``.
+        """
         client = responses_client.client
 
         with client.stream(
@@ -978,7 +992,12 @@ class TestResponsesStreamR10C3:
             d["delta"] for (n, d) in events if n == "response.output_text.delta"
         )
         completed = next(d for (n, d) in events if n == "response.completed")
-        final_text = completed["response"]["output"][0]["content"][0]["text"]
+        message_item = next(
+            item
+            for item in completed["response"]["output"]
+            if item["type"] == "message"
+        )
+        final_text = message_item["content"][0]["text"]
         assert deltas == final_text == "Hello from rapid"
 
     def test_stream_event_payloads_validate_against_sdk_event_models(

--- a/vllm_mlx/routes/responses.py
+++ b/vllm_mlx/routes/responses.py
@@ -2704,101 +2704,107 @@ async def _stream_responses(
         # output_text.done → content_part.done → output_item.done
         # ladder. Gating mirrors `_apply_reasoning_cutoff_notice` —
         # message_open + tool_calls already preclude rescue.
-        # R12-M3: only meaningful when reasoning text exists; preserve
-        # original semantics (rescue is the recovery path for mid-think
-        # cut-offs with reasoning bytes).
-        if accumulated_reasoning_text:
-            if mid_think_cutoff and not message_open and not tool_calls:
-                rescue_text = _apply_reasoning_cutoff_notice(
-                    final_content=None,
-                    reasoning_text=accumulated_reasoning_text,
-                    tool_calls=None,
-                    finish_reason=last_finish_reason,
+        # R12-M3 codex r2 BLOCKING: gate the rescue path on
+        # ``mid_think_cutoff`` directly (the single source of truth for
+        # "model was still mid-think when cut off"), not on a redundant
+        # ``accumulated_reasoning_text`` check. ``mid_think_cutoff``
+        # itself already requires ``bool(accumulated_reasoning_text)``
+        # above, so this is equivalent today, but the structural change
+        # ensures that any future widening of the rescue trigger (e.g.,
+        # rescue on a different cap signal) routes through the same
+        # invariant rather than getting silently skipped because the
+        # outer text gate was forgotten.
+        if mid_think_cutoff and not message_open and not tool_calls:
+            rescue_text = _apply_reasoning_cutoff_notice(
+                final_content=None,
+                reasoning_text=accumulated_reasoning_text,
+                tool_calls=None,
+                finish_reason=last_finish_reason,
+            )
+            if rescue_text:
+                rescue_output_index = len(completed_output)
+                rescue_item_id = f"msg_{uuid.uuid4().hex[:24]}"
+                rescue_part = {
+                    "type": "output_text",
+                    "text": rescue_text,
+                    "annotations": [],
+                }
+                yield _emit(
+                    "response.output_item.added",
+                    {
+                        "type": "response.output_item.added",
+                        "output_index": rescue_output_index,
+                        "item": {
+                            "type": "message",
+                            "id": rescue_item_id,
+                            "status": "in_progress",
+                            "role": "assistant",
+                            "content": [],
+                        },
+                    },
                 )
-                if rescue_text:
-                    rescue_output_index = len(completed_output)
-                    rescue_item_id = f"msg_{uuid.uuid4().hex[:24]}"
-                    rescue_part = {
-                        "type": "output_text",
+                yield _emit(
+                    "response.content_part.added",
+                    {
+                        "type": "response.content_part.added",
+                        "item_id": rescue_item_id,
+                        "output_index": rescue_output_index,
+                        "content_index": 0,
+                        "part": {
+                            "type": "output_text",
+                            "text": "",
+                            "annotations": [],
+                        },
+                    },
+                )
+                yield _emit(
+                    "response.output_text.delta",
+                    {
+                        "type": "response.output_text.delta",
+                        "item_id": rescue_item_id,
+                        "output_index": rescue_output_index,
+                        "content_index": 0,
+                        "delta": rescue_text,
+                        "logprobs": [],
+                    },
+                )
+                yield _emit(
+                    "response.output_text.done",
+                    {
+                        "type": "response.output_text.done",
+                        "item_id": rescue_item_id,
+                        "output_index": rescue_output_index,
+                        "content_index": 0,
                         "text": rescue_text,
-                        "annotations": [],
-                    }
-                    yield _emit(
-                        "response.output_item.added",
-                        {
-                            "type": "response.output_item.added",
-                            "output_index": rescue_output_index,
-                            "item": {
-                                "type": "message",
-                                "id": rescue_item_id,
-                                "status": "in_progress",
-                                "role": "assistant",
-                                "content": [],
-                            },
-                        },
-                    )
-                    yield _emit(
-                        "response.content_part.added",
-                        {
-                            "type": "response.content_part.added",
-                            "item_id": rescue_item_id,
-                            "output_index": rescue_output_index,
-                            "content_index": 0,
-                            "part": {
-                                "type": "output_text",
-                                "text": "",
-                                "annotations": [],
-                            },
-                        },
-                    )
-                    yield _emit(
-                        "response.output_text.delta",
-                        {
-                            "type": "response.output_text.delta",
-                            "item_id": rescue_item_id,
-                            "output_index": rescue_output_index,
-                            "content_index": 0,
-                            "delta": rescue_text,
-                            "logprobs": [],
-                        },
-                    )
-                    yield _emit(
-                        "response.output_text.done",
-                        {
-                            "type": "response.output_text.done",
-                            "item_id": rescue_item_id,
-                            "output_index": rescue_output_index,
-                            "content_index": 0,
-                            "text": rescue_text,
-                            "logprobs": [],
-                        },
-                    )
-                    yield _emit(
-                        "response.content_part.done",
-                        {
-                            "type": "response.content_part.done",
-                            "item_id": rescue_item_id,
-                            "output_index": rescue_output_index,
-                            "content_index": 0,
-                            "part": rescue_part,
-                        },
-                    )
-                    rescue_message_done = {
-                        "type": "message",
-                        "id": rescue_item_id,
-                        "status": "completed",
-                        "role": "assistant",
-                        "content": [rescue_part],
-                    }
-                    yield _emit(
-                        "response.output_item.done",
-                        {
-                            "type": "response.output_item.done",
-                            "output_index": rescue_output_index,
-                            "item": rescue_message_done,
-                        },
-                    )
-                    completed_output.append(rescue_message_done)
+                        "logprobs": [],
+                    },
+                )
+                yield _emit(
+                    "response.content_part.done",
+                    {
+                        "type": "response.content_part.done",
+                        "item_id": rescue_item_id,
+                        "output_index": rescue_output_index,
+                        "content_index": 0,
+                        "part": rescue_part,
+                    },
+                )
+                rescue_message_done = {
+                    "type": "message",
+                    "id": rescue_item_id,
+                    "status": "completed",
+                    "role": "assistant",
+                    "content": [rescue_part],
+                }
+                yield _emit(
+                    "response.output_item.done",
+                    {
+                        "type": "response.output_item.done",
+                        "output_index": rescue_output_index,
+                        "item": rescue_message_done,
+                    },
+                )
+                completed_output.append(rescue_message_done)
 
         # Ana C-06 (0.8.5 dogfood): when the request used Computer-Use,
         # translate ``function.name == "computer"`` tool_calls into the

--- a/vllm_mlx/routes/responses.py
+++ b/vllm_mlx/routes/responses.py
@@ -1416,16 +1416,26 @@ async def _stream_responses(
 
     Event order Codex expects:
       1. ``response.created`` — once, before any deltas
-      2. ``response.output_item.added`` (message item) — when first text
+      2. ``response.in_progress`` — lifecycle transition (R10-C3 / R6-H7)
+      3. ``response.output_item.added`` (reasoning item, leading — R12-M3) —
+         flushed immediately before the message item. Carries an empty
+         ``summary`` at open; the matching ``response.output_item.done``
+         (with the accumulated chain-of-thought) ships after the message
+         item closes. The reasoning item ALWAYS leads the message on the
+         wire — matching the OpenAI Responses reference even when the
+         reasoning text is empty.
+      4. ``response.output_item.added`` (message item) — when first text
          delta arrives
-      3. ``response.output_text.delta`` — each chunk of assistant text
-      4. ``response.output_item.done`` (message item) — when text ends,
-         before any tool_calls
-      5. For each tool call:
+      5. ``response.output_text.delta`` — each chunk of assistant text
+      6. ``response.output_item.done`` (message item) — when text ends,
+         before the leading reasoning item's ``done`` event
+      7. ``response.output_item.done`` (reasoning item) — closes the
+         leading item with the accumulated summary
+      8. For each tool call:
          ``response.output_item.added`` (function_call item) +
          ``response.function_call_arguments.delta`` (full JSON args) +
          ``response.output_item.done`` (function_call item)
-      6. ``response.completed`` — terminal event, carries final usage
+      9. ``response.completed`` — terminal event, carries final usage
 
     Errors emit ``response.failed`` then close. Codex treats
     stream-close-without-``response.completed`` as a hard failure, so
@@ -1634,6 +1644,36 @@ async def _stream_responses(
         # part and the final ``response.completed`` consumer raises.
         content_part_open = False
 
+        # R12-M3 (Mira r12 dogfood, R-4): the OpenAI Responses SSE spec
+        # requires "leading" items (``reasoning``, and any pre-message
+        # tool-call/function-call items) to land on the wire BEFORE the
+        # ``message`` item — even when the leading item is empty. Pre-fix
+        # the streaming surface emitted the ``reasoning`` item AFTER the
+        # message item in the post-loop block, so SDK clients that index
+        # the stream by item order saw ``message`` first and either
+        # discarded the late ``reasoning`` event or rejected the stream as
+        # malformed. The OpenAI reference implementation always emits a
+        # ``reasoning`` item (possibly with empty ``summary``) before the
+        # first ``message`` item, so we match that contract here.
+        #
+        # Mechanism: pre-allocate the reasoning item id + index, then have
+        # ``_open_message_item`` flush the leading reasoning ``added`` event
+        # FIRST so the message ``added`` event always lands at a strictly
+        # later index. The post-loop reasoning emitter then ships only the
+        # ``done`` event (with the accumulated chain-of-thought) instead of
+        # the full added → done pair. When the turn has neither a message
+        # item nor any reasoning text (pure-tool-call shape), the leading
+        # reasoning item is suppressed to keep the non-stream parity:
+        # the non-stream ``openai_to_responses`` shim only emits a
+        # ``reasoning`` item when reasoning text exists.
+        reasoning_item_id: str | None = None
+        reasoning_output_index: int | None = None
+        # Whether the leading reasoning ``added`` event has been emitted.
+        # Set by ``_emit_pending_leading_items`` (called from
+        # ``_open_message_item``) so the post-loop reasoning emitter
+        # knows whether it still needs to ship ``added`` or only ``done``.
+        reasoning_item_added = False
+
         # Per-request reasoning parser instance (matches anthropic.py).
         reasoning_parser = None
         if cfg.reasoning_parser_name:
@@ -1699,6 +1739,49 @@ async def _stream_responses(
             _reasoning_cap_hit = True
             return text[:keep_chars], text[keep_chars:], True
 
+        def _emit_pending_leading_items() -> list[str]:
+            """Emit any "leading" output items that MUST land before the
+            message item per the OpenAI Responses SSE spec.
+
+            Today the only leading item is ``reasoning`` (Mira r12 R-4:
+            even when the model produced no reasoning text, the canonical
+            /v1/responses surface emits an empty ``reasoning`` item BEFORE
+            the message). Future leading-item kinds (e.g. pre-message
+            ``function_call`` items for parallel tool calls) hook in here.
+
+            Idempotent: subsequent calls return ``[]`` once the leading
+            items have been emitted. The reasoning ``done`` event is shipped
+            from the post-loop emitter with the accumulated chain-of-thought,
+            so this helper only opens the item (status="in_progress",
+            summary=[]).
+            """
+            nonlocal reasoning_item_id, reasoning_output_index, reasoning_item_added
+            events: list[str] = []
+            if not reasoning_item_added:
+                reasoning_item_id = f"rs_{uuid.uuid4().hex[:24]}"
+                # Leading items occupy the lowest output indices. The
+                # message item (and any post-message tool_call items)
+                # take strictly later indices, computed in
+                # ``_open_message_item`` and the tool_call loop.
+                reasoning_output_index = 0
+                reasoning_item_added = True
+                events.append(
+                    _emit(
+                        "response.output_item.added",
+                        {
+                            "type": "response.output_item.added",
+                            "output_index": reasoning_output_index,
+                            "item": {
+                                "type": "reasoning",
+                                "id": reasoning_item_id,
+                                "status": "in_progress",
+                                "summary": [],
+                            },
+                        },
+                    )
+                )
+            return events
+
         async def _open_message_item() -> list[str]:
             """Emit response.output_item.added + response.content_part.added.
 
@@ -1712,17 +1795,35 @@ async def _stream_responses(
             the openai-python SDK's ``AsyncResponseStreamManager`` therefore
             never materialized the ``output_text`` content part and the
             terminal ``response.completed`` consumer raised on missing state.
+
+            R12-M3 (Mira r12 R-4): leading items (currently just
+            ``reasoning``) MUST be flushed BEFORE the message ``added``
+            event. The ``_emit_pending_leading_items`` call below is the
+            ordering-invariant fix — the message item's wire ``output_index``
+            is computed AFTER any leading items have been claimed, so the
+            indices stay monotonically consistent with the terminal
+            ``response.completed.response.output[]`` array.
             """
             nonlocal \
                 message_item_id, \
                 message_output_index, \
                 message_open, \
                 content_part_open
+            # Flush any leading items first — the ordering invariant.
+            leading_events = _emit_pending_leading_items()
             message_item_id = f"msg_{uuid.uuid4().hex[:24]}"
-            message_output_index = 0
+            # Leading-item count drives the message's output_index. Today
+            # the only leading item is reasoning (index 0 when emitted), so
+            # the message lands at index 1; pre-fix (and when no leading
+            # items ship, e.g. nothing else to come) it stays at 0. The
+            # latter never happens in the lazy-open path today but the
+            # arithmetic stays correct if a future leading-item kind opts
+            # out of emission.
+            message_output_index = 1 if reasoning_item_added else 0
             message_open = True
             content_part_open = True
             return [
+                *leading_events,
                 _emit(
                     "response.output_item.added",
                     {
@@ -2367,7 +2468,25 @@ async def _stream_responses(
         # because ``Response.output`` is a required list field. Mirror what the
         # non-streaming path emits via ``openai_to_responses`` so streaming
         # and non-streaming consumers see the same final shape.
+        #
+        # R12-M3 (Mira r12 R-4): the array is built in spec order
+        # ``reasoning → message → function_call/computer_call`` so the wire
+        # ``output_index`` (claimed in ``_emit_pending_leading_items`` /
+        # ``_open_message_item`` / the tool_call loop) lines up 1:1 with
+        # the array position. Reasoning is reserved at index 0 whenever
+        # the leading item was emitted on the wire.
         completed_output: list[dict] = []
+        # Reserve the reasoning slot at index 0 with a placeholder so the
+        # message/tool-call append calls below put items at the correct
+        # subsequent indices. The placeholder is overwritten in the
+        # post-loop reasoning emitter; if the reasoning leading item was
+        # NOT emitted on the wire (no message and no reasoning text — a
+        # pure-tool-call shape), the placeholder is dropped before
+        # ``response.completed`` ships so the terminal array stays
+        # consistent with what the wire actually showed.
+        _reasoning_slot_reserved = reasoning_item_added
+        if _reasoning_slot_reserved:
+            completed_output.append({})  # placeholder filled below
 
         # Close the message item if we ever opened it.
         if message_open:
@@ -2425,63 +2544,102 @@ async def _stream_responses(
             )
             completed_output.append(message_item_payload)
 
-        # R11-B (R11-M-F1): emit a ``reasoning`` output item carrying any
-        # accumulated chain-of-thought. Pre-fix the streaming path dropped
-        # every reasoning delta on the floor — so when ``max_output_tokens``
-        # cut the model off WHILE STILL inside ``<think>...</think>`` the
-        # message item never opened, ``completed_output`` shipped empty,
-        # and the terminal ``response.completed`` ran with ``output:[]`` +
-        # ``status:"completed"`` (the wire shape Mira R1 F1 captured).
-        # The non-streaming path always surfaced this same input as a
-        # ``reasoning`` item + ``status:"incomplete"`` via
-        # ``openai_to_responses``; this block closes the cross-path parity
-        # gap.
+        # R11-B (R11-M-F1) + R12-M3 (Mira r12 R-4): emit / finalize the
+        # ``reasoning`` output item carrying any accumulated chain-of-thought.
+        #
+        # Two cases:
+        #
+        # 1. ``reasoning_item_added`` (R12-M3 leading slot was already
+        #    flushed by ``_open_message_item``): the wire already saw the
+        #    ``response.output_item.added`` event at ``output_index=0``
+        #    BEFORE the message item. Here we only ship the matching
+        #    ``response.output_item.done`` event with the accumulated
+        #    summary (empty if the model produced no reasoning bytes —
+        #    matches the OpenAI reference, which always emits a reasoning
+        #    item before the message).
+        #
+        # 2. ``not reasoning_item_added`` (the leading slot was never
+        #    claimed — no message was emitted): if reasoning text exists,
+        #    emit BOTH added + done at the next available output_index
+        #    (preserves pre-R12-M3 behaviour for pure-tool-call shapes
+        #    with reasoning). If reasoning text is empty AND no message
+        #    was emitted, suppress the reasoning item entirely to match
+        #    the non-stream ``openai_to_responses`` shape (reasoning-only
+        #    or tool-only turns don't get a phantom empty reasoning item).
         #
         # Item status mirrors the non-stream convention:
         # ``incomplete`` when the engine reported ``finish_reason=="length"``
-        # (the model was still mid-think when its budget ran out), else
-        # ``completed``. The reasoning text itself is delivered verbatim
-        # in ``summary[0].summary_text`` — rapid-mlx does not run a
-        # separate summarization model, matching ``_build_reasoning_output_item``
-        # on the non-stream side.
-        # R11-B codex r1 HIGH #1: ``output_index`` is the position in
-        # the terminal ``Response.output[]`` array, not just an SSE
-        # ordinal. The earlier draft inserted the reasoning item at
-        # ``completed_output[0]`` to mirror non-stream order BUT kept
-        # the wire ``output_index`` at ``(message_output_index + 1)``
-        # — that broke SDK consumers (openai-python) that index events
-        # against the final array. It also collided with the
-        # tool-call ``tool_output_index`` computed below. Fix: append
-        # reasoning AT THE END of ``completed_output`` and use the
-        # NEXT available index. Cross-path text ordering (reasoning →
-        # message in the non-stream surface) is not strictly required
-        # on the streaming wire — SDK consumers iterate ``output[]``
-        # by type, not by literal index. The non-stream
-        # ``openai_to_responses`` still ships reasoning-first; this
-        # streaming compromise keeps the wire indices consistent with
-        # the final array.
-        if accumulated_reasoning_text:
+        # AND no downstream output was seen (the model was still mid-think
+        # when its budget ran out), else ``completed``.
+        #
+        # Pre-fix the streaming path dropped every reasoning delta on the
+        # floor — so when ``max_output_tokens`` cut the model off WHILE
+        # STILL inside ``<think>...</think>`` the message item never
+        # opened, ``completed_output`` shipped empty, and the terminal
+        # ``response.completed`` ran with ``output:[]`` + ``status:"completed"``
+        # (the wire shape Mira R1 F1 captured). The non-streaming path
+        # always surfaced this same input as a ``reasoning`` item +
+        # ``status:"incomplete"`` via ``openai_to_responses``; both R11-B
+        # and R12-M3 close cross-path parity gaps.
+        # R11-B codex r7 BLOCKING: ``reasoning_block_closed`` is
+        # the precise signal — set ONLY when the parser/router
+        # emitted a TRUE content/tool channel chunk. We can't use
+        # ``accumulated_text`` here because reasoning-cap overflow
+        # bytes also land in ``accumulated_text`` via
+        # ``_emit_text_delta``, but the parser may still be
+        # logically mid-think (overflow only promotes after a
+        # successful ``</think>`` flip). ``reasoning_block_closed``
+        # is true whenever the parser's OWN content/text channel
+        # emitted; tool_calls is the orthogonal "closed-then-tool-emit"
+        # signal. Message_open is also a downstream-output signal
+        # (R12-M3: the leading reasoning slot fires alongside the
+        # message ``added`` event — so by the time we reach this
+        # post-loop block with ``message_open=True``, the model
+        # definitionally produced downstream content).
+        downstream_output_seen = bool(
+            reasoning_block_closed or tool_calls or message_open
+        )
+        mid_think_cutoff = last_finish_reason == "length" and not downstream_output_seen
+        reasoning_status = "incomplete" if mid_think_cutoff else "completed"
+
+        if reasoning_item_added:
+            # Case 1 (R12-M3): leading slot was flushed pre-message. Ship
+            # only the matching ``done`` event using the pre-allocated id +
+            # index, then overwrite the placeholder slot reserved at index 0
+            # of ``completed_output``.
+            reasoning_item_payload_done = {
+                "type": "reasoning",
+                "id": reasoning_item_id,
+                "status": reasoning_status,
+                "summary": (
+                    [
+                        {
+                            "type": "summary_text",
+                            "text": accumulated_reasoning_text,
+                        }
+                    ]
+                    if accumulated_reasoning_text
+                    else []
+                ),
+            }
+            yield _emit(
+                "response.output_item.done",
+                {
+                    "type": "response.output_item.done",
+                    "output_index": reasoning_output_index,
+                    "item": reasoning_item_payload_done,
+                },
+            )
+            completed_output[reasoning_output_index] = reasoning_item_payload_done
+        elif accumulated_reasoning_text:
+            # Case 2 (legacy R11-B path): the leading slot was never
+            # claimed (no message was emitted), but the model did
+            # produce reasoning bytes — emit added + done at the next
+            # available index. R11-B codex r1 HIGH #1: ``output_index``
+            # is the position in the terminal ``Response.output[]``
+            # array, not just an SSE ordinal, so use ``len(completed_output)``.
             reasoning_output_index = len(completed_output)
             reasoning_item_id = f"rs_{uuid.uuid4().hex[:24]}"
-            # R11-B codex r7 BLOCKING: ``reasoning_block_closed`` is
-            # the precise signal — set ONLY when the parser/router
-            # emitted a TRUE content/tool channel chunk. We can't use
-            # ``accumulated_text`` here because reasoning-cap overflow
-            # bytes also land in ``accumulated_text`` via
-            # ``_emit_text_delta``, but the parser may still be
-            # logically mid-think (overflow only promotes after a
-            # successful ``</think>`` flip). The previous r5 gate
-            # (``accumulated_text or tool_calls or message_open``)
-            # therefore mis-classified a mid-think length cutoff
-            # AFTER a reasoning-cap overflow as a clean completion.
-            # ``reasoning_block_closed`` is true whenever the
-            # parser's OWN content/text channel emitted; tool_calls
-            # is the orthogonal "closed-then-tool-emit" signal.
-            downstream_output_seen = bool(reasoning_block_closed or tool_calls)
-            mid_think_cutoff = (
-                last_finish_reason == "length" and not downstream_output_seen
-            )
-            reasoning_status = "incomplete" if mid_think_cutoff else "completed"
             reasoning_item_payload_added = {
                 "type": "reasoning",
                 "id": reasoning_item_id,
@@ -2517,20 +2675,24 @@ async def _stream_responses(
             )
             completed_output.append(reasoning_item_payload_done)
 
-            # R12-8 codex r2 #4: streaming Responses parity with non-stream.
-            # Non-stream Responses runs `_apply_reasoning_cutoff_notice` via
-            # the chat layer, then `openai_to_responses` materializes the
-            # rescue text into an `output_text` message item. The streaming
-            # path emits the reasoning item with status=incomplete (above)
-            # but never surfaces the rescue payload — clients rendering only
-            # text output see empty output despite the reasoning being
-            # available. Mirror the non-stream shape: when the mid-think
-            # cutoff fired AND no real downstream output was seen, build the
-            # rescue payload and emit a synthetic message item using the
-            # canonical added → content_part.added → output_text.delta →
-            # output_text.done → content_part.done → output_item.done
-            # ladder. Gating mirrors `_apply_reasoning_cutoff_notice` —
-            # message_open + tool_calls already preclude rescue.
+        # R12-8 codex r2 #4: streaming Responses parity with non-stream.
+        # Non-stream Responses runs `_apply_reasoning_cutoff_notice` via
+        # the chat layer, then `openai_to_responses` materializes the
+        # rescue text into an `output_text` message item. The streaming
+        # path emits the reasoning item with status=incomplete (above)
+        # but never surfaces the rescue payload — clients rendering only
+        # text output see empty output despite the reasoning being
+        # available. Mirror the non-stream shape: when the mid-think
+        # cutoff fired AND no real downstream output was seen, build the
+        # rescue payload and emit a synthetic message item using the
+        # canonical added → content_part.added → output_text.delta →
+        # output_text.done → content_part.done → output_item.done
+        # ladder. Gating mirrors `_apply_reasoning_cutoff_notice` —
+        # message_open + tool_calls already preclude rescue.
+        # R12-M3: only meaningful when reasoning text exists; preserve
+        # original semantics (rescue is the recovery path for mid-think
+        # cut-offs with reasoning bytes).
+        if accumulated_reasoning_text:
             if mid_think_cutoff and not message_open and not tool_calls:
                 rescue_text = _apply_reasoning_cutoff_notice(
                     final_content=None,

--- a/vllm_mlx/routes/responses.py
+++ b/vllm_mlx/routes/responses.py
@@ -2599,7 +2599,22 @@ async def _stream_responses(
         downstream_output_seen = bool(
             reasoning_block_closed or tool_calls or message_open
         )
-        mid_think_cutoff = last_finish_reason == "length" and not downstream_output_seen
+        # R12-M3 codex r1 BLOCKING: ``mid_think_cutoff`` is the
+        # "cut off while still inside ``<think>``" signal; it must
+        # additionally require reasoning bytes actually accumulated.
+        # Without this guard, a length-cut response that never produced
+        # reasoning bytes but DID open the message could in principle
+        # flip to ``incomplete`` on a future refactor of
+        # ``downstream_output_seen`` — making the explicit text-gate
+        # an invariant that mirrors the semantic ("mid-think" implies
+        # "produced think tokens"). Today ``message_open`` already
+        # contributes to ``downstream_output_seen`` so the outcome is
+        # the same, but the guard pins the contract.
+        mid_think_cutoff = (
+            last_finish_reason == "length"
+            and not downstream_output_seen
+            and bool(accumulated_reasoning_text)
+        )
         reasoning_status = "incomplete" if mid_think_cutoff else "completed"
 
         if reasoning_item_added:


### PR DESCRIPTION
## Why

SDK clients that consume `/v1/responses` SSE index output items by emission order to reconstruct the response. Emitting `message` before `reasoning` (or skipping reasoning entirely on empty-reasoning models) breaks the OpenAI Responses contract — clients either discard the late-arriving reasoning item or treat the stream as malformed. This PR fixes the wire ordering so `reasoning` always lands before `message`, matching the OpenAI reference, because downstream SDKs (Mira r12 dogfood R-4) regressed against the legacy 0.8.16 stream order.

## Repro

Mira r12 dogfood (`/tmp/dogfood-0815/mira-r12.md` R-4): on `/v1/responses` streaming, the `reasoning` output item lands AFTER the `message` item when reasoning text is empty (and the order is also wrong for non-empty reasoning). The OpenAI Responses reference always emits a `reasoning` item (possibly with empty `summary`) BEFORE the message item.

**Live capture against `mlx-community/Qwen3-0.6B-bf16` on :8097**

Pre-fix (legacy 0.8.16): `response.output_item.added` (message) → text deltas → `response.output_item.done` (message) → `response.output_item.added` (reasoning) → `response.output_item.done` (reasoning).

Post-fix wire (`{"input":"say hi","stream":true,"max_output_tokens":256}`):

```
event: response.created
event: response.in_progress
event: response.output_item.added       # reasoning, output_index=0, summary=[]
event: response.output_item.added       # message, output_index=1
event: response.content_part.added
event: response.output_text.delta ×N
event: response.output_text.done
event: response.content_part.done
event: response.output_item.done        # message
event: response.output_item.done        # reasoning, with final summary
event: response.completed               # output: [reasoning, message]
```

Empty-reasoning case (`chat_template_kwargs.enable_thinking=false`): same ordering, reasoning item closes with `summary=[]` instead of being skipped entirely.

## Root cause

`_open_message_item` opened the message item lazily on the first text delta, but reasoning emission was deferred to the post-loop block under `if accumulated_reasoning_text:`. So when reasoning was empty the reasoning item was skipped entirely; when non-empty it was appended AFTER the message item closed. SDK clients indexing the stream by item order saw message-first and either discarded the late reasoning item or treated the stream as malformed.

## Systematic fix (item ordering invariant)

Centralise the "leading items before message" guarantee in the emitter.

- Pre-allocate `reasoning_item_id` + `reasoning_output_index=0`.
- `_emit_pending_leading_items()` ships `response.output_item.added` for the reasoning item (status=in_progress, summary=[]) — idempotent, future leading-item kinds (e.g. pre-message function_call) hook in here.
- `_open_message_item` flushes pending leading items FIRST, then opens the message item at `output_index=1`.
- Post-loop reasoning emitter ships only the matching `output_item.done` for the pre-opened reasoning item (with the accumulated summary, or empty summary if the model produced no reasoning bytes). The legacy added+done path is preserved only for the pure-tool-call-with-reasoning shape where the message item never opens.
- `completed_output` is built in spec order (reasoning → message → tool_calls) with a reserved index-0 slot the post-loop reasoning emit fills.

Decision call per the spec: even for non-thinking models the canonical `/v1/responses` always emits a reasoning item (possibly empty) before the message — this PR matches that.

## Test plan

- [x] **Empty-reasoning case (M-3 root)**: reasoning item emitted FIRST with empty summary, message item lands AFTER (new test `tests/test_r12_m3_responses_stream_leading_items_order.py::test_empty_reasoning_still_emits_reasoning_before_message`).
- [x] **Non-empty reasoning case**: reasoning leads message (existing behaviour preserved, pin by new test `test_non_empty_reasoning_emitted_before_message`).
- [x] **Index alignment**: `response.completed.response.output[i].type` matches every wire `output_item.added.output_index` 1:1 (new test `test_completed_output_index_matches_wire_indices`).
- [x] **Assert-monotonic-ordering helper**: shared in test file for future regression guards.
- [x] **Live smoke** against `mlx-community/Qwen3-0.6B-bf16` on :8097, both thinking-on and `enable_thinking=false`.
- [x] Existing 9732 unit tests still pass (12 connection-refused failures are pre-existing infra tests requiring a live server on :8000).
- [x] `test_responses_route.py::test_completed_payload_carries_output_array` + `test_completed_output_text_equals_concatenated_deltas` updated for the new `reasoning at output[0]` shape; the Sven r10-R1 invariant (`response.output[]` present and consistent with deltas) is preserved.

## Cites

Mira r12 dogfood R-4 / M-3 (`/tmp/dogfood-0815/mira-r12.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
