### PR TITLE
fix(pr_validate): treat batch-fail+individual-pass as broken env (#185 codex r1)

### DIFF
--- a/scripts/pr_validate/_test_env.py
+++ b/scripts/pr_validate/_test_env.py
@@ -153,14 +153,24 @@ def check_test_env(python: str | None = None) -> TestEnvStatus:
 
     if not missing:
         # The batch probe failed but every individual import passed.
-        # Surfaces as an OK status — the batch failure was likely a
-        # transient subprocess oddity, not a real missing module.
+        # This is a real condition pytest will hit at startup — plugin
+        # registration order / "plugin already registered" / a sys.path
+        # mutation by one import that breaks the next. Codex r1
+        # BLOCKING: returning ok=True here let a broken env masquerade
+        # as healthy, exactly the failure mode #185 is about.
+        # Surface the batch stderr so the operator can diagnose
+        # without re-running by hand.
+        batch_err = (proc.stderr or proc.stdout or "").strip() or (
+            "(no diagnostic output from the failing import batch — "
+            f"exit code: {proc.returncode})"
+        )
         return TestEnvStatus(
-            ok=True,
-            missing=(),
+            ok=False,
+            missing=tuple(import_names),
             message=(
-                "batch import probe failed but every individual import "
-                f"passed (interpreter: {interp})"
+                "batch import probe failed (every individual import "
+                "passed, but the combined load order pytest takes is "
+                f"broken). Diagnostic: {batch_err[:512]}"
             ),
             interpreter=interp,
         )

--- a/tests/test_pr_validate_test_env.py
+++ b/tests/test_pr_validate_test_env.py
@@ -196,6 +196,53 @@ class TestCheckTestEnv:
         assert f"'.[{TEST_EXTRAS_NAME}]'" in status.install_hint
         assert str(python) in status.install_hint
 
+    def test_batch_fail_with_individual_passes_is_treated_as_fail(self, tmp_path):
+        """Codex r1 BLOCKING: previously a batch-import failure that
+        re-probed clean per-module returned ``ok=True``. That hides a
+        real failure mode pytest hits at startup (plugin registration
+        order, sys.path mutation by one import that breaks the next).
+        We simulate it by patching subprocess.run so the batch probe
+        exits non-zero with a recognizable stderr while each
+        individual probe exits 0 — the helper must report
+        ``ok=False`` and surface the batch stderr."""
+        import subprocess
+
+        from scripts.pr_validate import _test_env as mod
+
+        # The batch probe is the FIRST call (one combined "import X;
+        # import Y" command); individual probes are subsequent calls.
+        # We construct a side_effect list that returns a non-zero
+        # CompletedProcess for the batch and zero for each individual.
+        batch_stderr = (
+            "Traceback (most recent call last):\n"
+            "  File '<string>', line 1, in <module>\n"
+            "RuntimeError: simulated plugin-order collision\n"
+        )
+        n_packages = len(mod.REQUIRED_TEST_PACKAGES)
+        results = [
+            subprocess.CompletedProcess(
+                args=[], returncode=1, stdout="", stderr=batch_stderr
+            ),
+            *[
+                subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+                for _ in range(n_packages)
+            ],
+        ]
+        with patch("scripts.pr_validate._test_env.subprocess.run", side_effect=results):
+            status = mod.check_test_env(python="/fake/python")
+
+        assert status.ok is False, (
+            "batch-fail+individual-pass must report broken, not ok — the "
+            "combined import is the order pytest will actually take"
+        )
+        # The diagnostic surfaces the batch stderr so the operator can
+        # see WHY the batch failed without re-running by hand.
+        assert "simulated plugin-order collision" in status.message
+        # `missing` should be populated (the helper marks every package
+        # as suspect when it can't pinpoint which one breaks the batch)
+        # so downstream auto-install still has something to act on.
+        assert len(status.missing) == n_packages
+
     def test_install_hint_uses_the_probed_interpreter_not_sys_executable(self):
         """Edge: a TestEnvStatus constructed for some OTHER python (a
         CI worker, a docker container) must surface THAT interpreter


### PR DESCRIPTION
## Why

Follow-up to PR #885 (closes #185). Codex round-1 review on #885 flagged a real correctness bug that landed because the parent PR was merged before the review feedback cycle completed.

`check_test_env()` returned `ok=True` when the batched `import pytest; import pytest_asyncio` probe failed but each individual probe passed. That's the wrong conclusion — the batch is the exact load order pytest itself takes at startup (plugin registration, sys.path mutation by one import that breaks the next), so a batch failure indicates a real broken env that pytest will hit.

## What changed

- `scripts/pr_validate/_test_env.py`: in the batch-fail / all-individual-pass branch, report `ok=False` with `missing=tuple(import_names)` and surface the batch's stderr (truncated to 512 chars) in the status message.
- `tests/test_pr_validate_test_env.py`: new test that patches `subprocess.run` to simulate the batch-fail / individual-pass case and asserts the new behavior.

## Test plan

- [x] `pytest tests/test_pr_validate_test_env.py -q` — 26 tests pass (added 1).
- [x] `pytest tests/test_pr_validate_*.py -q` — all 231 pr_validate tests pass.
- [x] `ruff check` + `ruff format --check` clean.

Refs #185.

🤖 Generated with [Claude Code](https://claude.com/claude-code)