### PR TITLE
fix(pr_validate): SupplyChain runs before TestEnvCheck + skip auto-install on dep-file PRs (#275)

### DIFF
--- a/scripts/pr_validate/README.md
+++ b/scripts/pr_validate/README.md
@@ -25,9 +25,9 @@ python3.12 -m scripts.pr_validate <PR#> -v
 | 0 | `fetch` | always (fail-fast) | ~3s |
 | 0.5 | `test_plan_check` | always | <1s |
 | 0.7 | `cl_description_quality` | always (skip via `PR_VALIDATE_SKIP_DESC=1`) | <1s |
+| 0.75 | `supply_chain` | always | ~5s |
 | 0.8 | `test_env_check` | always (auto-install opt-out: `PR_VALIDATE_NO_AUTO_INSTALL=1`) | <1s (≈10s if install runs) |
 | 6 | `codex_review` | always (skip if codex CLI missing / not logged in) | 30–180s |
-| 1 | `supply_chain` | always | ~5s |
 | 2 | `lint` | when diff has .py | ~3s |
 | 3 | `targeted_tests` | when diff has .py | 30s–3min |
 | 4 | `full_unit` | blast ≥ medium | ~25s |
@@ -37,6 +37,44 @@ python3.12 -m scripts.pr_validate <PR#> -v
 thinking *before* spending 10 minutes on tests. The two cheapest
 description-quality gates run first so a bad title or empty body
 fails in under a second without burning the codex budget.)
+
+## Threat model (#275)
+
+`pr_validate` itself executes inside a venv that has the project
+installed. Two of its steps are capable of *executing PR-controlled
+code on the validator host*:
+
+1. **`test_env_check`** may run `pip install '.[test]'` from the PR's
+   working tree to recover a missing pytest plugin. That install
+   evaluates `pyproject.toml` (including build hooks like
+   `[build-system].build-backend`) and any `setup.py` shim.
+2. **`targeted_tests` / `full_unit`** run `pytest`, which evaluates
+   `conftest.py` and any plugin entrypoints registered by deps
+   declared in `pyproject.toml`.
+
+The validator can't trust the PR's `pyproject.toml` until the
+supply-chain scan has had a chance to flag it. Therefore the step
+order is **non-negotiable**:
+
+* `supply_chain` runs at index ≈ 0.75 — BEFORE any
+  auto-installing step. Any modification to `pyproject.toml`,
+  `requirements*.txt`, `setup.py`, `setup.cfg`, `conftest.py`,
+  `.github/workflows/`, `Makefile`, `.pre-commit-config.yaml`, or
+  `Formula/` from an external author is `[BLOCKING]`.
+* `test_env_check` runs at index ≈ 0.8 — AFTER `supply_chain`.
+  Its `pip install '.[test]'` fallback is also gated: if the PR
+  diff touches any dep-declaration file, the project-extras path
+  is REFUSED and the step falls back to installing a hardcoded,
+  version-pinned set of trusted plugins (`TRUSTED_TEST_PINS` in
+  `_test_env.py`) directly from PyPI. That set never reads the
+  PR's working tree.
+
+The invariant is locked in by
+`tests/test_pr_validate_runner.py::test_supply_chain_runs_before_auto_installing_steps`.
+
+If you add a future step that auto-installs anything, put it AFTER
+`supply_chain` and gate it on `pr_touches_dep_files(ctx.files_changed)`
+the same way `test_env_check` does.
 
 ## Verdict
 
@@ -144,11 +182,28 @@ suite needs (chiefly `pytest_asyncio` — `pytest.ini` sets
 fails at collection with "async def functions are not natively
 supported").
 
-When a plugin is missing, the step attempts a one-shot
-`pip install '.[test]'` from the repo root, then re-checks. If the
-re-check still fails, the step reports `fail` with the missing-package
-list and the canonical recovery command (`<interp> -m pip install
-'.[test]'`) so the operator can fix it manually.
+When a plugin is missing, the step's recovery path runs in two
+attempts:
+
+1. **Trusted pins (always tried first).** Installs
+   `TRUSTED_TEST_PINS` (a hardcoded, version-pinned set defined in
+   `_test_env.py` — currently `pytest>=7,<9`,
+   `pytest-asyncio>=0.21,<1`) from PyPI directly with
+   `pip install --isolated`. This bypasses the PR's `pyproject.toml`
+   entirely so a malicious PR cannot poison the validator's runtime
+   (#275).
+2. **Project extras (gated).** If the trusted-pins install doesn't
+   resolve everything AND the PR's diff does NOT touch any
+   dep-declaration file (`pyproject.toml`, `requirements*.txt`,
+   `setup.py`, `setup.cfg`), falls back to `pip install '.[test]'`
+   from the repo root. If the PR touches a dep file, the
+   project-extras path is REFUSED — the step reports `fail` and the
+   operator is asked to review the diff before installing manually.
+
+If both attempts still leave a plugin missing, the step reports
+`fail` with the missing-package list and the canonical recovery
+command (`<interp> -m pip install '.[test]'`) so the operator can
+fix it manually.
 
 Closes #185 — the prior implementation had no env check at all,
 which meant a host that had lost `pytest-asyncio` (typically after an
@@ -210,10 +265,16 @@ Replaces the previous DeepSeek V4 Pro step. See the
 switched — DeepSeek is asymptotic across rounds; codex converges in a
 small bounded number.
 
-### `supply_chain` (step 1)
+### `supply_chain` (step 0.75)
 
-* Flags any modification to install hooks, CI workflows, Makefile,
-  Homebrew tap (BLOCKING for external authors, warning for collaborators).
+Runs BEFORE any auto-installing step so a malicious PR can't get its
+build-hook executed inside the validator venv before the scan flags
+it (see "Threat model" above, #275).
+
+* Flags any modification to install hooks (`pyproject.toml`,
+  `requirements*.txt`, `setup.py`, `setup.cfg`, `conftest.py`,
+  CI workflows, Makefile, Homebrew tap, pre-commit config):
+  BLOCKING for external authors, warning for collaborators.
 * Greps added lines for suspicious patterns (`eval`, `exec`,
   `pickle.loads`, `subprocess(... shell=True)`, hardcoded URLs/IPs,
   large hex/base64 blobs).

--- a/scripts/pr_validate/README.md
+++ b/scripts/pr_validate/README.md
@@ -58,9 +58,14 @@ order is **non-negotiable**:
 
 * `supply_chain` runs at index ≈ 0.75 — BEFORE any
   auto-installing step. Any modification to `pyproject.toml`,
-  `requirements*.txt`, `setup.py`, `setup.cfg`, `conftest.py`,
-  `.github/workflows/`, `Makefile`, `.pre-commit-config.yaml`, or
-  `Formula/` from an external author is `[BLOCKING]`.
+  any repo-root `requirements*.txt` (the prefix matcher catches
+  `requirements-dev.txt`, `requirements-test.txt`,
+  `requirements-pin.txt`, … without enumeration), `setup.py`,
+  `setup.cfg`, `conftest.py`, `.github/workflows/`, `Makefile`,
+  `.pre-commit-config.yaml`, or `Formula/` from an external author
+  is `[BLOCKING]`. Detection delegates to
+  `_test_env.is_dep_declaration_file()` so the supply-chain step
+  and `test_env_check` share one source of truth.
 * `test_env_check` runs at index ≈ 0.8 — AFTER `supply_chain`.
   Its `pip install '.[test]'` (project-extras) fallback is gated:
   if the PR diff touches any dep-declaration file, the

--- a/scripts/pr_validate/README.md
+++ b/scripts/pr_validate/README.md
@@ -62,12 +62,19 @@ order is **non-negotiable**:
   `.github/workflows/`, `Makefile`, `.pre-commit-config.yaml`, or
   `Formula/` from an external author is `[BLOCKING]`.
 * `test_env_check` runs at index ≈ 0.8 — AFTER `supply_chain`.
-  Its `pip install '.[test]'` fallback is also gated: if the PR
-  diff touches any dep-declaration file, the project-extras path
-  is REFUSED and the step falls back to installing a hardcoded,
-  version-pinned set of trusted plugins (`TRUSTED_TEST_PINS` in
-  `_test_env.py`) directly from PyPI. That set never reads the
-  PR's working tree.
+  Its `pip install '.[test]'` (project-extras) fallback is gated:
+  if the PR diff touches any dep-declaration file, the
+  project-extras path is REFUSED.
+* The `test_env_check` step instead **always tries trusted-pins
+  first**: a hardcoded, version-pinned set (`TRUSTED_TEST_PINS` in
+  `_test_env.py`) installed from PyPI with `pip install --isolated`.
+  That install path is intentionally allowed even on dep-file PRs —
+  it does not read the PR's working tree and the install target list
+  is grep-able in `_test_env.py`, so a malicious `pyproject.toml`
+  cannot influence what gets installed. The opt-out
+  `PR_VALIDATE_NO_AUTO_INSTALL=1` disables BOTH stages (trusted-pins
+  AND project-extras) for hardened CI sandboxes that must not mutate
+  the host Python at all.
 
 The invariant is locked in by
 `tests/test_pr_validate_runner.py::test_supply_chain_runs_before_auto_installing_steps`.

--- a/scripts/pr_validate/_test_env.py
+++ b/scripts/pr_validate/_test_env.py
@@ -78,6 +78,39 @@ REQUIRED_TEST_PACKAGES: tuple[tuple[str, str, str], ...] = (
 # update this constant too (and the unit test that pins it).
 TEST_EXTRAS_NAME = "test"
 
+# Files whose modification by an external PR makes the auto-install
+# path UNSAFE — installing from the PR's working tree would let the
+# attacker's build hook / fake package source run inside the
+# validator venv. Detection is conservative: if ANY of these paths
+# show up in ``ctx.files_changed`` we refuse to auto-install and
+# require the operator to either install manually (after reading the
+# diff) or re-run with the dep-file change rolled back. See
+# scripts/pr_validate/README.md "Threat model".
+DEP_DECLARATION_FILES_DENYLIST: tuple[str, ...] = (
+    "pyproject.toml",
+    "setup.py",
+    "setup.cfg",
+    "requirements.txt",
+    "requirements-dev.txt",
+    "requirements-pin.txt",  # pr_validate's own pin list
+)
+
+# Hardcoded, version-pinned set of pytest plugins pr_validate needs
+# IN ITS OWN venv to run ``targeted_tests`` / ``full_unit`` reliably.
+# Installed from PyPI directly (not from the PR's working tree) so a
+# malicious PR that ships a typo-squat or replaces ``pytest-asyncio``
+# in pyproject.toml CANNOT subvert the validator's runtime. Keep this
+# list tiny and pinned to a narrow range: the goal is "validator
+# always boots", not "validator can run every test in every PR".
+#
+# Versions chosen to track the project's ``[test]`` extras at the
+# time of pinning (#275). A bump here is a deliberate operator
+# decision; pr_validate refuses to silently follow a PR's lead.
+TRUSTED_TEST_PINS: tuple[str, ...] = (
+    "pytest>=7.0.0,<9",
+    "pytest-asyncio>=0.21.0,<1",
+)
+
 
 @dataclass(frozen=True)
 class TestEnvStatus:
@@ -198,6 +231,64 @@ def auto_install_disabled() -> bool:
         "yes",
         "on",
     )
+
+
+def pr_touches_dep_files(files_changed: list[str]) -> list[str]:
+    """Return the subset of ``files_changed`` that overlaps with
+    ``DEP_DECLARATION_FILES_DENYLIST``.
+
+    Returning the (possibly empty) list rather than a bool lets the
+    caller surface the exact filenames in the warning the operator
+    sees — "skipped because the PR touches pyproject.toml" is much
+    more actionable than just "skipped". An empty list means the
+    auto-install path is safe to take.
+
+    Matching is exact-path (no prefix). pr_validate doesn't try to be
+    clever about renames or symlinks — anything fancier is a manual
+    review case anyway.
+    """
+    denylist = set(DEP_DECLARATION_FILES_DENYLIST)
+    return [f for f in files_changed if f in denylist]
+
+
+def install_trusted_pins(python: str | None = None) -> tuple[bool, str]:
+    """Install ``TRUSTED_TEST_PINS`` from PyPI into ``python``.
+
+    Bypasses the PR's pyproject.toml entirely — the pin list is
+    hardcoded above and version-bounded so a malicious PR cannot
+    influence what gets installed into the validator venv. Used as
+    the recovery path when ``pr_touches_dep_files`` reports the PR
+    has modified dep-declaration files (in which case
+    ``install_test_extras`` is unsafe).
+
+    Returns ``(ok, log)`` mirroring ``install_test_extras``. ``--no-deps``
+    is intentionally NOT passed — pytest-asyncio needs its own
+    transitive deps and those come from PyPI too, not the PR.
+
+    ``--isolated`` blocks the user's pip.conf from injecting a
+    malicious index URL via ``--extra-index-url``; combined with the
+    pinned versions this gives the validator a stable install path.
+    """
+    interp = python or sys.executable
+    cmd = [
+        interp,
+        "-m",
+        "pip",
+        "install",
+        "--quiet",
+        "--isolated",
+        "--disable-pip-version-check",
+        *TRUSTED_TEST_PINS,
+    ]
+    proc = subprocess.run(  # noqa: S603
+        cmd,
+        capture_output=True,
+        text=True,
+    )
+    log = (proc.stdout or "") + (proc.stderr or "")
+    if len(log) > 2048:
+        log = log[:1024] + "\n…[truncated]…\n" + log[-1024:]
+    return proc.returncode == 0, log
 
 
 def install_test_extras(repo_root: Path, python: str | None = None) -> tuple[bool, str]:

--- a/scripts/pr_validate/_test_env.py
+++ b/scripts/pr_validate/_test_env.py
@@ -86,14 +86,52 @@ TEST_EXTRAS_NAME = "test"
 # require the operator to either install manually (after reading the
 # diff) or re-run with the dep-file change rolled back. See
 # scripts/pr_validate/README.md "Threat model".
+#
+# Two parts: exact-path matches and a prefix-glob list. The prefix
+# list catches every ``requirements*.txt`` variant a contributor
+# might invent (``requirements-test.txt``, ``requirements-prod.txt``,
+# etc.) without us having to enumerate them — codex r2 BLOCKING was
+# that ``requirements-test.txt`` slipped through.
 DEP_DECLARATION_FILES_DENYLIST: tuple[str, ...] = (
     "pyproject.toml",
     "setup.py",
     "setup.cfg",
-    "requirements.txt",
-    "requirements-dev.txt",
-    "requirements-pin.txt",  # pr_validate's own pin list
 )
+
+# Filename prefixes whose ``.txt`` (or no-extension) variants at the
+# repo root all count as dep-declaration files. Kept here so the
+# supply-chain step can import the same source of truth via
+# ``is_dep_declaration_file()`` — see ``steps/supply_chain.py``
+# ``HOOK_PATHS`` for the install-hook matcher that also uses this.
+DEP_DECLARATION_FILE_PREFIXES: tuple[str, ...] = (
+    "requirements",  # requirements.txt, requirements-dev.txt, requirements-test.txt, …
+)
+
+
+def is_dep_declaration_file(path: str) -> bool:
+    """Return True iff ``path`` (a repo-relative file name) is a
+    dep-declaration file that an external PR must NOT be allowed to
+    influence the validator's install from.
+
+    Exact match against ``DEP_DECLARATION_FILES_DENYLIST`` OR
+    starts-with match against ``DEP_DECLARATION_FILE_PREFIXES`` for
+    repo-root ``.txt`` files. Subdirectory files (e.g.
+    ``vendor/requirements.txt``) are intentionally NOT matched —
+    they don't drive pr_validate's ``pip install '.[test]'``.
+
+    Public so the supply-chain step can share the matcher.
+    """
+    if path in DEP_DECLARATION_FILES_DENYLIST:
+        return True
+    # Only match the repo root — subdirectory files don't drive the
+    # validator's recovery install. Strip path separators to test.
+    if "/" in path:
+        return False
+    for prefix in DEP_DECLARATION_FILE_PREFIXES:
+        if path.startswith(prefix) and (path.endswith(".txt") or path == prefix):
+            return True
+    return False
+
 
 # Hardcoded, version-pinned set of pytest plugins pr_validate needs
 # IN ITS OWN venv to run ``targeted_tests`` / ``full_unit`` reliably.
@@ -234,8 +272,8 @@ def auto_install_disabled() -> bool:
 
 
 def pr_touches_dep_files(files_changed: list[str]) -> list[str]:
-    """Return the subset of ``files_changed`` that overlaps with
-    ``DEP_DECLARATION_FILES_DENYLIST``.
+    """Return the subset of ``files_changed`` that ``is_dep_declaration_file``
+    flags.
 
     Returning the (possibly empty) list rather than a bool lets the
     caller surface the exact filenames in the warning the operator
@@ -243,12 +281,12 @@ def pr_touches_dep_files(files_changed: list[str]) -> list[str]:
     more actionable than just "skipped". An empty list means the
     auto-install path is safe to take.
 
-    Matching is exact-path (no prefix). pr_validate doesn't try to be
-    clever about renames or symlinks — anything fancier is a manual
-    review case anyway.
+    Matching delegates to ``is_dep_declaration_file`` so the supply-
+    chain step and this guard share a single source of truth. Catches
+    every repo-root ``requirements*.txt`` variant — codex r2
+    BLOCKING was an under-enumeration here.
     """
-    denylist = set(DEP_DECLARATION_FILES_DENYLIST)
-    return [f for f in files_changed if f in denylist]
+    return [f for f in files_changed if is_dep_declaration_file(f)]
 
 
 def install_trusted_pins(python: str | None = None) -> tuple[bool, str]:

--- a/scripts/pr_validate/runner.py
+++ b/scripts/pr_validate/runner.py
@@ -32,21 +32,38 @@ from .steps.test_plan_check import TestPlanCheckStep
 # Step order — see scripts/pr_validate/README.md for the rationale.
 # Codex review goes early so cheap critical thinking happens before
 # we spend 10 minutes on tests.
+#
+# ORDERING INVARIANT (#275 / codex review on #885): SupplyChainStep
+# must run BEFORE any step that auto-installs from the PR's working
+# tree (currently only TestEnvCheckStep). Otherwise an external PR
+# that adds a malicious build hook or a fake package source to
+# ``pyproject.toml`` would get its code executed inside the validator
+# venv before the supply-chain scan ever flagged the change. The
+# ``test_supply_chain_runs_before_auto_installing_steps`` invariant
+# test in ``tests/test_pr_validate_runner.py`` pins this order so a
+# future refactor can't silently regress it.
 STEPS: list[Step] = [
     FetchStep(),  # 0 — fetch PR + diff + classify blast radius
     TestPlanCheckStep(),  # 0.5 — unchecked test-plan items block merge (#427 lesson)
     CLDescriptionQualityStep(),  # 0.7 — title + body rationale (Google eng-practices)
+    # 0.75 — supply-chain scan must run BEFORE any step that might
+    # ``pip install`` from the PR's working tree. Otherwise a
+    # malicious build hook / fake package source in pyproject.toml
+    # would execute inside the validator venv before the gate that
+    # was supposed to flag it. See #275.
+    SupplyChainStep(),
     # 0.8 — verify pytest plugins importable in the same Python pytest
     # will be invoked with. Closes #185 (was failing the targeted_tests
     # + full_unit gates with cryptic "async def functions are not
     # natively supported" pytest errors when pytest-asyncio fell out of
-    # the host env). Placed BEFORE codex_review because codex review is
-    # the most expensive step here that depends on the diff but not the
-    # test env; failing the env check first avoids spending a codex
-    # round on a PR that pr_validate can't ultimately test.
+    # the host env). MUST run AFTER ``supply_chain`` because this step
+    # may ``pip install '.[test]'`` to auto-recover a missing plugin,
+    # and that install would execute attacker-controlled code from a
+    # tampered pyproject.toml. The auto-install path is also disabled
+    # when the diff touches dep-declaration files — see ``_test_env.py``
+    # for the gate.
     TestEnvCheckStep(),
     CodexReviewStep(),  # 6 — adversarial review (codex exec, gpt-5.5)
-    SupplyChainStep(),  # 1 — pip-audit, license, install hooks
     LintStep(),  # 2 — ruff check + format
     TargetedTestsStep(),  # 3 — diff-aware test selection + neg control
     FullUnitStep(),  # 4 — full pytest, gated on blast radius

--- a/scripts/pr_validate/steps/supply_chain.py
+++ b/scripts/pr_validate/steps/supply_chain.py
@@ -36,29 +36,22 @@ import shutil
 import subprocess
 from pathlib import Path
 
+from .._test_env import is_dep_declaration_file
 from ..base import Step, StepResult
 from ..context import Context
 
 # Files that gain code-execution capability when modified — install
 # hooks, CI config, anything that runs unattended. ``pyproject.toml``
-# and ``requirements*.txt`` are here because pr_validate's own
-# ``TestEnvCheckStep`` may ``pip install '.[test]'`` to recover a
-# missing pytest plugin; if a malicious PR adds a build-hook or fake
-# package source, that install would execute the attacker's code in
-# the validator's interpreter. Flagging the file as a hook means an
-# external-author PR that touches it is [BLOCKING] at this step BEFORE
-# any auto-installing step downstream runs — see threat-model section
-# of scripts/pr_validate/README.md.
+# and the ``requirements*.txt`` family are NOT listed here directly;
+# they're matched via ``_test_env.is_dep_declaration_file`` (shared
+# truth source — codex r2 BLOCKING was that diverging lists let
+# ``requirements-test.txt`` through this step but not the
+# ``test_env_check`` gate). The combined ``_is_hook_file`` matcher
+# below is what the SupplyChainStep uses. External-author PRs
+# touching any of these get [BLOCKING] BEFORE any downstream
+# auto-installing step runs — see threat-model section of
+# ``scripts/pr_validate/README.md``.
 HOOK_PATHS = (
-    "setup.py",
-    "setup.cfg",
-    "pyproject.toml",
-    "requirements.txt",
-    "requirements-dev.txt",
-    # pr_validate's own pin list (TRUSTED_TEST_PINS materialized as a
-    # file in some downstream uses) — kept in sync with the dep-file
-    # denylist in ``scripts/pr_validate/_test_env.py``.
-    "requirements-pin.txt",
     "conftest.py",  # runs on every `pytest`
     "tests/conftest.py",
     ".github/workflows/",
@@ -68,7 +61,24 @@ HOOK_PATHS = (
     "homebrew-rapid-mlx/",
 )
 
-# Files that declare project deps. Any addition gets pip-audited.
+
+def _is_hook_file(path: str) -> bool:
+    """Combined matcher: dep-declaration files (shared with
+    ``_test_env.is_dep_declaration_file``) PLUS the explicit
+    ``HOOK_PATHS`` set. Centralized so we never again have two lists
+    that drift apart."""
+    if is_dep_declaration_file(path):
+        return True
+    return any(path == p or path.startswith(p) for p in HOOK_PATHS)
+
+
+# Backwards-compatibility alias — the dep-declaration matcher now
+# lives in ``_test_env.is_dep_declaration_file`` (shared with
+# ``test_env_check``); kept as a constant here so existing call
+# sites keep working until they're migrated to the matcher. New
+# code should call ``is_dep_declaration_file(path)`` directly so
+# the ``requirements*.txt`` prefix coverage is picked up
+# automatically.
 DEP_DECLARATION_FILES = (
     "pyproject.toml",
     "requirements.txt",
@@ -135,11 +145,10 @@ class SupplyChainStep(Step):
         # 1. Hook-file modifications get an automatic flag — not a
         # FAIL on its own (legitimate workflow updates exist), but
         # surfaced loudly so the human knows to read carefully.
-        hook_files = [
-            f
-            for f in ctx.files_changed
-            if any(f == p or f.startswith(p) for p in HOOK_PATHS)
-        ]
+        # ``_is_hook_file`` unifies HOOK_PATHS with the dep-
+        # declaration matcher from ``_test_env`` so the two lists
+        # can't drift (codex r2 BLOCKING).
+        hook_files = [f for f in ctx.files_changed if _is_hook_file(f)]
         if hook_files:
             # Even an "innocent-looking" hook change is worth surfacing.
             # External-author + hook change = strong reason to read.
@@ -274,8 +283,13 @@ def _extract_added_deps(diff: str, files_changed: list[str]) -> list[str]:
     """Naive but cautious: find lines in dep-declaration files that
     look like `name = "version"` or `name>=ver` and weren't there
     before. We don't try to parse pyproject.toml fully — too many
-    formats. Just regex the additions."""
-    if not any(f in DEP_DECLARATION_FILES for f in files_changed):
+    formats. Just regex the additions.
+
+    Uses ``is_dep_declaration_file`` so every ``requirements*.txt``
+    variant gets pip-audited, not just the three legacy names —
+    codex r2 BLOCKING was that ``requirements-test.txt`` slipped
+    through the previous exact-match list."""
+    if not any(is_dep_declaration_file(f) for f in files_changed):
         return []
 
     deps: list[str] = []
@@ -283,7 +297,7 @@ def _extract_added_deps(diff: str, files_changed: list[str]) -> list[str]:
     for line in diff.splitlines():
         if line.startswith("+++ b/"):
             path = line[6:]
-            in_dep_file = path in DEP_DECLARATION_FILES
+            in_dep_file = is_dep_declaration_file(path)
             continue
         if not in_dep_file or not line.startswith("+"):
             continue

--- a/scripts/pr_validate/steps/supply_chain.py
+++ b/scripts/pr_validate/steps/supply_chain.py
@@ -55,6 +55,10 @@ HOOK_PATHS = (
     "pyproject.toml",
     "requirements.txt",
     "requirements-dev.txt",
+    # pr_validate's own pin list (TRUSTED_TEST_PINS materialized as a
+    # file in some downstream uses) — kept in sync with the dep-file
+    # denylist in ``scripts/pr_validate/_test_env.py``.
+    "requirements-pin.txt",
     "conftest.py",  # runs on every `pytest`
     "tests/conftest.py",
     ".github/workflows/",

--- a/scripts/pr_validate/steps/supply_chain.py
+++ b/scripts/pr_validate/steps/supply_chain.py
@@ -40,10 +40,21 @@ from ..base import Step, StepResult
 from ..context import Context
 
 # Files that gain code-execution capability when modified — install
-# hooks, CI config, anything that runs unattended.
+# hooks, CI config, anything that runs unattended. ``pyproject.toml``
+# and ``requirements*.txt`` are here because pr_validate's own
+# ``TestEnvCheckStep`` may ``pip install '.[test]'`` to recover a
+# missing pytest plugin; if a malicious PR adds a build-hook or fake
+# package source, that install would execute the attacker's code in
+# the validator's interpreter. Flagging the file as a hook means an
+# external-author PR that touches it is [BLOCKING] at this step BEFORE
+# any auto-installing step downstream runs — see threat-model section
+# of scripts/pr_validate/README.md.
 HOOK_PATHS = (
     "setup.py",
     "setup.cfg",
+    "pyproject.toml",
+    "requirements.txt",
+    "requirements-dev.txt",
     "conftest.py",  # runs on every `pytest`
     "tests/conftest.py",
     ".github/workflows/",

--- a/scripts/pr_validate/steps/test_env_check.py
+++ b/scripts/pr_validate/steps/test_env_check.py
@@ -1,8 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 """Step 0.8 — test-env self-check.
 
-Runs just after ``cl_description_quality`` and just before the codex
-review, i.e. as the first compute-bound gate. Verifies that the same
+Runs just after ``supply_chain`` and just before the codex review,
+i.e. as the first compute-bound gate AFTER the supply-chain scan has
+had a chance to flag a malicious PR (#275). Verifies that the same
 Python interpreter ``targeted_tests`` and ``full_unit`` will hand to
 pytest can actually load the plugins the suite needs (chiefly
 ``pytest_asyncio`` — pytest.ini sets ``asyncio_mode = auto``).
@@ -15,7 +16,23 @@ rather than letting downstream pytest crash with a cryptic plugin-
 missing message.
 
 Recovery path: by default the step *also* attempts to install the
-canonical ``[test]`` extras from ``pyproject.toml`` and re-checks.
+required plugins so the rest of the pipeline can run:
+
+* **Trusted-pins path (default + safe).** When the PR has not
+  modified any dep-declaration file (``pyproject.toml``,
+  ``requirements*.txt``, ``setup.py``, ``setup.cfg``), the step
+  installs ``TRUSTED_TEST_PINS`` directly from PyPI (hardcoded
+  version-pinned set) — bypasses the PR's working tree entirely.
+* **Project-extras path.** Falls back to ``pip install '.[test]'``
+  ONLY if the trusted-pins install didn't cover what's missing AND
+  the PR has not touched any dep file. This path executes
+  ``pyproject.toml`` build hooks, so it's gated on the PR being
+  "trustworthy by file scope" — see #275 for the threat model.
+* **Skip auto-install.** When the PR touched a dep file (so the
+  project-extras path is unsafe) the step refuses to auto-install
+  and emits a MERGE-UNSAFE-flavored warning naming the offending
+  file(s) and the canonical manual recovery command.
+
 Disable with ``PR_VALIDATE_NO_AUTO_INSTALL=1`` for hardened CI
 sandboxes that must not mutate the host Python.
 """
@@ -27,6 +44,8 @@ from .._test_env import (
     auto_install_disabled,
     check_test_env,
     install_test_extras,
+    install_trusted_pins,
+    pr_touches_dep_files,
 )
 from ..base import Step, StepResult
 from ..context import Context
@@ -77,8 +96,88 @@ class TestEnvCheckStep(Step):
                 artifacts=[str(log_path)],
             )
 
+        # Supply-chain integrity gate (#275): if the PR has modified
+        # any dep-declaration file we MUST NOT run
+        # ``pip install '.[test]'`` from the PR's working tree —
+        # build hooks in a tampered pyproject.toml would execute
+        # inside the validator venv. Try the trusted-pins path first
+        # (PyPI-only, hardcoded versions); if that doesn't resolve
+        # everything we still skip the project-extras path and let the
+        # operator decide.
+        touched_dep_files = pr_touches_dep_files(ctx.files_changed)
+
         ctx.run_log(
-            f"missing: {', '.join(status.missing)} — installing .[{TEST_EXTRAS_NAME}]"
+            f"missing: {', '.join(status.missing)} — installing trusted pins from PyPI"
+        )
+        pins_ok, pins_log = install_trusted_pins()
+        post_pins = check_test_env()
+        if post_pins.ok:
+            log_path.write_text(
+                f"interpreter: {status.interpreter}\n"
+                f"status (initial): fail\n"
+                f"missing (initial): {', '.join(status.missing)}\n"
+                f"trusted-pins install ok: {pins_ok}\n"
+                f"trusted-pins pip log:\n{pins_log}\n"
+                f"status (after trusted pins): ok\n"
+            )
+            return StepResult(
+                name=self.name,
+                status="pass",
+                summary=(
+                    f"installed trusted-pins ({len(status.missing)} "
+                    f"missing plugin(s) recovered)"
+                ),
+                artifacts=[str(log_path)],
+            )
+
+        # Trusted pins didn't cover it. The fallback is the PR's own
+        # ``.[test]`` extras — but that's exactly the path #275 says
+        # is unsafe when the PR has touched a dep-declaration file.
+        if touched_dep_files:
+            details = (
+                f"**pr_validate venv is misconfigured** — "
+                f"{status.message}.\n\n"
+                "Auto-install via `pip install '.[test]'` was **refused**: "
+                f"this PR modifies dep-declaration file(s) "
+                f"`{', '.join(touched_dep_files)}` and installing from the "
+                "PR's working tree would execute build hooks / fake "
+                "package sources from the diff inside the validator "
+                "venv. See #275 / the threat-model section of "
+                "scripts/pr_validate/README.md.\n\n"
+                "Trusted-pins install (PyPI-only, hardcoded versions) "
+                f"also did not resolve everything: `{post_pins.message}`.\n\n"
+                "Manual recovery — review the PR diff first, then run:\n\n"
+                f"```\n{post_pins.install_hint}\n```\n\n"
+                "Pip output (trusted-pins, truncated):\n\n"
+                f"```\n{pins_log}\n```\n"
+            )
+            log_path.write_text(
+                f"interpreter: {status.interpreter}\n"
+                f"status: fail (auto-install refused — PR touches dep files)\n"
+                f"touched dep files: {', '.join(touched_dep_files)}\n"
+                f"missing (initial): {', '.join(status.missing)}\n"
+                f"trusted-pins install ok: {pins_ok}\n"
+                f"trusted-pins pip log:\n{pins_log}\n"
+                f"status (after trusted pins): "
+                f"{'ok' if post_pins.ok else 'fail'}\n"
+                f"missing (after trusted pins): "
+                f"{', '.join(post_pins.missing) or '(none)'}\n"
+            )
+            return StepResult(
+                name=self.name,
+                status="fail",
+                summary=(
+                    f"missing test packages; project-extras install "
+                    f"refused (PR touches "
+                    f"{', '.join(touched_dep_files)})"
+                ),
+                details=details,
+                artifacts=[str(log_path)],
+            )
+
+        ctx.run_log(
+            f"trusted pins insufficient ({post_pins.message}) — "
+            f"falling back to .[{TEST_EXTRAS_NAME}]"
         )
         ok, pip_log = install_test_extras(ctx.repo_root)
         # Re-check after install — pip can report 0 and still leave a
@@ -91,8 +190,12 @@ class TestEnvCheckStep(Step):
             f"interpreter: {status.interpreter}\n"
             f"status (initial): fail\n"
             f"missing (initial): {', '.join(status.missing)}\n"
-            f"auto-install ok: {ok}\n"
-            f"pip log:\n{pip_log}\n"
+            f"trusted-pins install ok: {pins_ok}\n"
+            f"trusted-pins pip log:\n{pins_log}\n"
+            f"status (after trusted pins): "
+            f"{'ok' if post_pins.ok else 'fail'}\n"
+            f"project-extras auto-install ok: {ok}\n"
+            f"project-extras pip log:\n{pip_log}\n"
             f"status (after install): {'ok' if post.ok else 'fail'}\n"
             f"missing (after install): {', '.join(post.missing) or '(none)'}\n"
         )

--- a/scripts/pr_validate/steps/test_env_check.py
+++ b/scripts/pr_validate/steps/test_env_check.py
@@ -16,25 +16,34 @@ rather than letting downstream pytest crash with a cryptic plugin-
 missing message.
 
 Recovery path: by default the step *also* attempts to install the
-required plugins so the rest of the pipeline can run:
+required plugins so the rest of the pipeline can run. Two-stage:
 
-* **Trusted-pins path (default + safe).** When the PR has not
-  modified any dep-declaration file (``pyproject.toml``,
-  ``requirements*.txt``, ``setup.py``, ``setup.cfg``), the step
-  installs ``TRUSTED_TEST_PINS`` directly from PyPI (hardcoded
-  version-pinned set) — bypasses the PR's working tree entirely.
-* **Project-extras path.** Falls back to ``pip install '.[test]'``
-  ONLY if the trusted-pins install didn't cover what's missing AND
-  the PR has not touched any dep file. This path executes
-  ``pyproject.toml`` build hooks, so it's gated on the PR being
-  "trustworthy by file scope" — see #275 for the threat model.
-* **Skip auto-install.** When the PR touched a dep file (so the
-  project-extras path is unsafe) the step refuses to auto-install
-  and emits a MERGE-UNSAFE-flavored warning naming the offending
-  file(s) and the canonical manual recovery command.
+* **Stage 1 — trusted-pins (always tried first when enabled).**
+  Installs ``TRUSTED_TEST_PINS`` directly from PyPI with
+  ``pip install --isolated`` (hardcoded version-pinned set —
+  ``pytest>=7,<9``, ``pytest-asyncio>=0.21,<1`` at time of writing).
+  The pin list lives in ``_test_env.py``, NOT in the PR's working
+  tree, so a malicious ``pyproject.toml`` cannot influence what gets
+  installed. This stage is intentionally allowed even when the PR
+  has touched a dep-declaration file: it does not read the PR's tree
+  and the install target list is grep-able. The only way it mutates
+  the validator's environment is to bring in known-good pytest
+  plugins from PyPI.
 
-Disable with ``PR_VALIDATE_NO_AUTO_INSTALL=1`` for hardened CI
-sandboxes that must not mutate the host Python.
+* **Stage 2 — project-extras (gated on PR scope).** Falls back to
+  ``pip install '.[test]'`` from ``ctx.repo_root`` if and only if
+  (a) trusted pins didn't fully recover the missing-plugin set AND
+  (b) the PR's diff has NOT touched any dep-declaration file
+  (``pyproject.toml``, ``requirements*.txt``, ``setup.py``,
+  ``setup.cfg``, ``requirements-pin.txt``). This stage evaluates
+  ``pyproject.toml`` build hooks, so it's the unsafe path #275
+  describes; it is refused on dep-file PRs and the step reports
+  ``fail`` with the offending file names + a manual-recovery
+  command.
+
+Disable BOTH stages with ``PR_VALIDATE_NO_AUTO_INSTALL=1`` for
+hardened CI sandboxes that must not mutate the host Python — the
+self-check still runs and still reports the missing-package list.
 """
 
 from __future__ import annotations

--- a/tests/test_pr_validate_test_env.py
+++ b/tests/test_pr_validate_test_env.py
@@ -401,7 +401,13 @@ class TestStepIntegration:
                 result = step.run(fake_ctx)
 
         assert result.status == "pass"
-        assert "trusted-pins" in result.summary or "installed" in result.summary
+        # Pin the exact trusted-pins wording — codex r2 NIT was that
+        # the previous loose ``or "installed"`` matcher would also
+        # accept a summary from the old project-extras path, masking
+        # a regression that flipped the order.
+        assert "trusted-pins" in result.summary, (
+            f"expected 'trusted-pins' in summary, got: {result.summary!r}"
+        )
         # Trusted-pins path runs exactly once.
         assert mock_pins.call_count == 1
         # Project-extras path MUST NOT run when trusted pins recover —
@@ -522,6 +528,80 @@ class TestSupplyChainIntegrity:
         for dep_file in DEP_DECLARATION_FILES_DENYLIST:
             assert pr_touches_dep_files([dep_file]) == [dep_file], (
                 f"{dep_file!r} not detected by pr_touches_dep_files"
+            )
+
+    def test_pr_touches_dep_files_catches_arbitrary_requirements_variants(self):
+        """Codex r2 BLOCKING: the previous exact-match list let
+        ``requirements-test.txt`` / ``requirements-prod.txt`` through
+        the gate. The matcher is now prefix-based for repo-root
+        ``requirements*.txt`` files, so every variant a contributor
+        might invent is caught without us enumerating them."""
+        from scripts.pr_validate._test_env import (
+            is_dep_declaration_file,
+            pr_touches_dep_files,
+        )
+
+        # Variants that MUST be flagged (the regression cases).
+        for variant in (
+            "requirements.txt",
+            "requirements-dev.txt",
+            "requirements-test.txt",
+            "requirements-prod.txt",
+            "requirements-pin.txt",
+            "requirements-ci.txt",
+        ):
+            assert is_dep_declaration_file(variant), (
+                f"{variant!r} not flagged by is_dep_declaration_file"
+            )
+            assert pr_touches_dep_files([variant]) == [variant]
+
+        # Negative cases — subdirectory requirements files don't drive
+        # pr_validate's recovery install and should NOT trip the gate.
+        # (Their contents may still be supply-chain interesting via
+        # other means, but they don't enable the #275 attack vector.)
+        for safe in (
+            "vendor/requirements.txt",
+            "tests/fixtures/requirements.txt",
+            "docs/requirements.md",  # not .txt
+            "requirements.yaml",  # not .txt
+        ):
+            assert not is_dep_declaration_file(safe), (
+                f"{safe!r} incorrectly flagged by is_dep_declaration_file"
+            )
+
+    def test_supply_chain_hook_matcher_catches_arbitrary_requirements_variants(self):
+        """Codex r2 BLOCKING: supply-chain's hook matcher and the
+        test-env-check matcher previously had divergent lists. Now
+        they share ``is_dep_declaration_file`` so any new
+        ``requirements*.txt`` variant is BLOCKING for external authors
+        at the supply-chain step too."""
+        from scripts.pr_validate.steps.supply_chain import _is_hook_file
+
+        for variant in (
+            "pyproject.toml",
+            "setup.py",
+            "setup.cfg",
+            "requirements.txt",
+            "requirements-dev.txt",
+            "requirements-test.txt",
+            "requirements-pin.txt",
+            "requirements-anything.txt",
+            ".github/workflows/ci.yml",
+            "conftest.py",
+        ):
+            assert _is_hook_file(variant), (
+                f"{variant!r} not flagged by supply_chain._is_hook_file"
+            )
+
+        # Negative: source files and docs MUST NOT be flagged or
+        # every PR would trip supply-chain.
+        for safe in (
+            "vllm_mlx/scheduler.py",
+            "docs/foo.md",
+            "tests/test_foo.py",
+        ):
+            assert not _is_hook_file(safe), (
+                f"{safe!r} incorrectly flagged by supply_chain._is_hook_file"
             )
 
     def test_auto_install_refused_when_pr_touches_pyproject(self, fake_ctx):

--- a/tests/test_pr_validate_test_env.py
+++ b/tests/test_pr_validate_test_env.py
@@ -356,10 +356,15 @@ class TestStepIntegration:
         assert "auto-install disabled" in result.summary
 
     def test_auto_install_attempts_and_recovers(self, fake_ctx):
-        """Initial probe fails; auto-install path runs; post-install
-        probe passes. The step must report `pass` and the summary
-        must mention "installed" so the operator knows the run
-        recovered (and the host was mutated)."""
+        """Initial probe fails; the trusted-pins install path (added
+        for #275) runs first and recovers — the step must report
+        ``pass`` with a summary mentioning "trusted-pins" so the
+        operator knows the PyPI-only path (not the PR's working
+        tree) was the source.
+
+        Critically, ``install_test_extras`` must NOT be called when
+        trusted pins suffice — that's the whole #275 fix.
+        """
         broken = TestEnvStatus(
             ok=False,
             missing=("pytest_asyncio",),
@@ -373,7 +378,7 @@ class TestStepIntegration:
             interpreter=sys.executable,
         )
         # Two-shot probe: first call sees the broken state, second
-        # (after install) sees the recovered state.
+        # (after the trusted-pins install) sees the recovered state.
         with patch.dict(os.environ, {}, clear=False):
             os.environ.pop("PR_VALIDATE_NO_AUTO_INSTALL", None)
             with (
@@ -382,42 +387,54 @@ class TestStepIntegration:
                     side_effect=[broken, healthy],
                 ),
                 patch(
-                    "scripts.pr_validate.steps.test_env_check.install_test_extras",
+                    "scripts.pr_validate.steps.test_env_check.install_trusted_pins",
                     return_value=(
                         True,
                         "Successfully installed pytest-asyncio-0.21.0\n",
                     ),
+                ) as mock_pins,
+                patch(
+                    "scripts.pr_validate.steps.test_env_check.install_test_extras",
                 ) as mock_install,
             ):
                 step = TestEnvCheckStep()
                 result = step.run(fake_ctx)
 
         assert result.status == "pass"
-        assert "installed" in result.summary
-        # Install was called once with the ctx's repo root.
-        assert mock_install.call_count == 1
+        assert "trusted-pins" in result.summary or "installed" in result.summary
+        # Trusted-pins path runs exactly once.
+        assert mock_pins.call_count == 1
+        # Project-extras path MUST NOT run when trusted pins recover —
+        # that's the supply-chain integrity guarantee.
+        assert mock_install.call_count == 0
 
     def test_auto_install_runs_but_does_not_fix(self, fake_ctx):
-        """Initial probe fails; pip succeeds (exit 0); post-install
-        probe STILL fails. This is the "pip silently fell back to
-        --user and the plugin is in the wrong site-packages" case —
-        the step must report fail with both the initial AND
-        post-install missing list so the operator sees the install
-        didn't take."""
+        """Initial probe fails; trusted-pins succeed but don't fix
+        everything; project-extras install runs (PR didn't touch dep
+        files); post-install probe STILL fails. This is the "pip
+        silently fell back to --user and the plugin is in the wrong
+        site-packages" case — the step must report fail with both
+        the initial AND post-install missing list so the operator
+        sees the install didn't take."""
         broken = TestEnvStatus(
             ok=False,
             missing=("pytest_asyncio",),
             message="missing required test packages: pytest_asyncio",
             interpreter=sys.executable,
         )
-        # Same broken status both times — install reported success
-        # but the import still doesn't work.
+        # Three probes: initial (broken), after trusted-pins
+        # (still broken — so we fall through to project-extras), and
+        # after project-extras (still broken — install didn't take).
         with patch.dict(os.environ, {}, clear=False):
             os.environ.pop("PR_VALIDATE_NO_AUTO_INSTALL", None)
             with (
                 patch(
                     "scripts.pr_validate.steps.test_env_check.check_test_env",
-                    side_effect=[broken, broken],
+                    side_effect=[broken, broken, broken],
+                ),
+                patch(
+                    "scripts.pr_validate.steps.test_env_check.install_trusted_pins",
+                    return_value=(True, "(fake trusted-pins output)"),
                 ),
                 patch(
                     "scripts.pr_validate.steps.test_env_check.install_test_extras",
@@ -457,3 +474,336 @@ class TestRequiredPackages:
             assert any(c in pip_name for c in (">=", "==", "~=", ">")), (
                 f"{pip_name!r} for {pkg!r} has no version constraint"
             )
+
+
+# ---------------------------------------------------------------------------
+# Supply-chain integrity (#275 / codex review on PR #885)
+# ---------------------------------------------------------------------------
+
+
+class TestSupplyChainIntegrity:
+    """Pin the #275 fix: the test_env_check step MUST NOT auto-install
+    from the PR's working tree when the PR has touched a dep-declaration
+    file, because the install would execute attacker-controlled build
+    hooks inside the validator venv.
+
+    The trusted-pins path (hardcoded version-pinned PyPI install) is the
+    safe substitute; the project-extras path is the unsafe one.
+    """
+
+    def test_pr_touches_dep_files_flags_pyproject_toml(self):
+        """The canonical case — a PR that modifies pyproject.toml is
+        the exact threat #275 describes."""
+        from scripts.pr_validate._test_env import pr_touches_dep_files
+
+        assert pr_touches_dep_files(["pyproject.toml"]) == ["pyproject.toml"]
+        assert pr_touches_dep_files(["docs/foo.md", "pyproject.toml"]) == [
+            "pyproject.toml"
+        ]
+
+    def test_pr_touches_dep_files_returns_empty_for_safe_diffs(self):
+        """A diff that only touches docs / source must NOT trip the
+        safety gate — otherwise every non-trivial PR would block at
+        test_env_check."""
+        from scripts.pr_validate._test_env import pr_touches_dep_files
+
+        assert pr_touches_dep_files(["docs/foo.md"]) == []
+        assert pr_touches_dep_files(["vllm_mlx/server.py"]) == []
+        assert pr_touches_dep_files([]) == []
+
+    def test_pr_touches_dep_files_catches_all_dep_files(self):
+        """Every entry in DEP_DECLARATION_FILES_DENYLIST must be
+        detectable — a typo there would silently disable the gate."""
+        from scripts.pr_validate._test_env import (
+            DEP_DECLARATION_FILES_DENYLIST,
+            pr_touches_dep_files,
+        )
+
+        for dep_file in DEP_DECLARATION_FILES_DENYLIST:
+            assert pr_touches_dep_files([dep_file]) == [dep_file], (
+                f"{dep_file!r} not detected by pr_touches_dep_files"
+            )
+
+    def test_auto_install_refused_when_pr_touches_pyproject(self, fake_ctx):
+        """The headline #275 test: when the PR modifies pyproject.toml
+        and the trusted-pins install doesn't fully recover, the step
+        REFUSES to fall back to ``pip install '.[test]'`` and reports
+        ``fail`` with the offending file named in the warning."""
+        broken = TestEnvStatus(
+            ok=False,
+            missing=("pytest_asyncio",),
+            message="missing required test packages: pytest_asyncio",
+            interpreter=sys.executable,
+        )
+        fake_ctx.files_changed = ["pyproject.toml", "scripts/foo.py"]
+
+        install_called = {"yes": False}
+
+        def fail_if_install_runs(*_args, **_kwargs):
+            install_called["yes"] = True
+            return (True, "ATTACK: build hook ran from pyproject.toml")
+
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("PR_VALIDATE_NO_AUTO_INSTALL", None)
+            with (
+                patch(
+                    "scripts.pr_validate.steps.test_env_check.check_test_env",
+                    side_effect=[broken, broken],
+                ),
+                patch(
+                    "scripts.pr_validate.steps.test_env_check.install_trusted_pins",
+                    return_value=(True, "trusted-pins partial recovery"),
+                ),
+                patch(
+                    "scripts.pr_validate.steps.test_env_check.install_test_extras",
+                    side_effect=fail_if_install_runs,
+                ),
+            ):
+                step = TestEnvCheckStep()
+                result = step.run(fake_ctx)
+
+        assert result.status == "fail"
+        # The offending file MUST be named in the warning so the
+        # operator knows what to scrutinize before installing manually.
+        assert "pyproject.toml" in result.details
+        # Summary must call out the refusal so it's visible without
+        # opening the details block.
+        assert (
+            "refused" in result.summary.lower()
+            or "project-extras" in result.summary.lower()
+        )
+        # The unsafe install path MUST NOT have run.
+        assert install_called["yes"] is False, (
+            "install_test_extras ran despite the PR touching pyproject.toml — "
+            "this is the supply-chain integrity bug #275 is supposed to fix"
+        )
+
+    def test_auto_install_proceeds_when_pr_does_not_touch_dep_files(self, fake_ctx):
+        """No regression on happy path: a PR that doesn't touch any
+        dep file still gets the project-extras fallback when trusted
+        pins don't fully recover."""
+        broken = TestEnvStatus(
+            ok=False,
+            missing=("pytest_asyncio",),
+            message="missing required test packages: pytest_asyncio",
+            interpreter=sys.executable,
+        )
+        healthy = TestEnvStatus(
+            ok=True,
+            missing=(),
+            message="all 2 required test packages importable",
+            interpreter=sys.executable,
+        )
+        # Pure source-only change — must NOT be flagged.
+        fake_ctx.files_changed = ["vllm_mlx/scheduler.py", "tests/test_scheduler.py"]
+
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("PR_VALIDATE_NO_AUTO_INSTALL", None)
+            with (
+                patch(
+                    "scripts.pr_validate.steps.test_env_check.check_test_env",
+                    side_effect=[broken, broken, healthy],
+                ),
+                patch(
+                    "scripts.pr_validate.steps.test_env_check.install_trusted_pins",
+                    return_value=(True, "trusted-pins partial"),
+                ),
+                patch(
+                    "scripts.pr_validate.steps.test_env_check.install_test_extras",
+                    return_value=(True, "Successfully installed"),
+                ) as mock_install,
+            ):
+                step = TestEnvCheckStep()
+                result = step.run(fake_ctx)
+
+        assert result.status == "pass"
+        # The project-extras path DID run since trusted pins were
+        # insufficient and the PR was clean.
+        assert mock_install.call_count == 1
+
+    def test_trusted_pins_path_used_first_even_on_clean_pr(self, fake_ctx):
+        """Trusted-pins runs FIRST regardless of whether the PR is
+        clean. That's the design — never install from the PR's working
+        tree unless we have to. A clean PR is just allowed to fall
+        through to the project-extras path if trusted pins fall short."""
+        broken = TestEnvStatus(
+            ok=False,
+            missing=("pytest_asyncio",),
+            message="missing required test packages: pytest_asyncio",
+            interpreter=sys.executable,
+        )
+        healthy = TestEnvStatus(
+            ok=True,
+            missing=(),
+            message="all 2 required test packages importable",
+            interpreter=sys.executable,
+        )
+        fake_ctx.files_changed = ["vllm_mlx/scheduler.py"]
+
+        call_order: list[str] = []
+
+        def trusted_pins(*_args, **_kwargs):
+            call_order.append("trusted_pins")
+            return (True, "trusted")
+
+        def project_extras(*_args, **_kwargs):
+            call_order.append("project_extras")
+            return (True, "extras")
+
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("PR_VALIDATE_NO_AUTO_INSTALL", None)
+            with (
+                patch(
+                    "scripts.pr_validate.steps.test_env_check.check_test_env",
+                    side_effect=[broken, healthy],
+                ),
+                patch(
+                    "scripts.pr_validate.steps.test_env_check.install_trusted_pins",
+                    side_effect=trusted_pins,
+                ),
+                patch(
+                    "scripts.pr_validate.steps.test_env_check.install_test_extras",
+                    side_effect=project_extras,
+                ),
+            ):
+                step = TestEnvCheckStep()
+                step.run(fake_ctx)
+
+        assert call_order[0] == "trusted_pins", (
+            "trusted_pins must run BEFORE project_extras"
+        )
+
+    def test_trusted_pins_uses_isolated_pip_flag(self):
+        """``--isolated`` blocks a user-level ``pip.conf`` from injecting
+        a malicious ``--extra-index-url`` while the validator's
+        recovery install is running. Pin the flag so a "simplification"
+        refactor can't quietly drop it."""
+        import subprocess as _sub
+
+        from scripts.pr_validate import _test_env as mod
+
+        captured: dict = {}
+
+        def fake_run(cmd, **kwargs):
+            captured["cmd"] = cmd
+            return _sub.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+        with patch.object(mod.subprocess, "run", side_effect=fake_run):
+            ok, _ = mod.install_trusted_pins()
+
+        assert ok is True
+        assert "--isolated" in captured["cmd"], (
+            "pip must run with --isolated to block user-level config injection"
+        )
+        # Every TRUSTED_TEST_PINS entry must appear in the install command —
+        # if a future edit drops one, the validator silently degrades.
+        for pin in mod.TRUSTED_TEST_PINS:
+            assert pin in captured["cmd"]
+
+    def test_supply_chain_runs_before_auto_installing_steps(self):
+        """ORDERING INVARIANT (#275): ``supply_chain`` MUST appear in
+        ``STEPS`` before ``test_env_check`` and before any other step
+        that may ``pip install`` from the PR's working tree.
+
+        Otherwise a malicious PR can get its build hook executed inside
+        the validator venv before the supply-chain scan flags it. This
+        test exists so the invariant is preserved across future
+        refactors — a `grep`able guarantee, not a code-review hope."""
+        from scripts.pr_validate.runner import STEPS
+
+        names = [s.name for s in STEPS]
+        assert "supply_chain" in names
+        assert "test_env_check" in names
+
+        sc_idx = names.index("supply_chain")
+        tec_idx = names.index("test_env_check")
+        assert sc_idx < tec_idx, (
+            f"supply_chain (idx {sc_idx}) must run BEFORE test_env_check "
+            f"(idx {tec_idx}) — see scripts/pr_validate/README.md "
+            "'Threat model' (#275)"
+        )
+
+    def test_malicious_pyproject_blocked_at_supply_chain_before_test_env(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        """End-to-end simulation of the #275 attack: an external-author
+        PR whose diff adds a build-hook to ``pyproject.toml``. The
+        supply-chain step MUST flag it [BLOCKING] BEFORE
+        test_env_check has a chance to run ``pip install '.[test]'``."""
+        from scripts.pr_validate.runner import run_pipeline
+        from scripts.pr_validate.steps.supply_chain import SupplyChainStep
+        from scripts.pr_validate.steps.test_env_check import TestEnvCheckStep
+
+        # Build a fake repo root so Context.__post_init__ is happy.
+        (tmp_path / "pyproject.toml").write_text("[project]\nname='fake'\n")
+        monkeypatch.chdir(tmp_path)
+
+        # Malicious diff: external PR adds a build hook in pyproject.toml.
+        # Note the `+++ b/` path, a hunk header, and an added line that
+        # would execute on `pip install` (a fake build-backend swap).
+        diff_path = tmp_path / "pr.diff"
+        diff_path.write_text(
+            "diff --git a/pyproject.toml b/pyproject.toml\n"
+            "--- a/pyproject.toml\n"
+            "+++ b/pyproject.toml\n"
+            "@@ -1,3 +1,4 @@\n"
+            " [build-system]\n"
+            "+requires = ['evil-build-backend @ file:///tmp/attack']\n"
+            ' build-backend = "setuptools.build_meta"\n'
+        )
+
+        # Stand-in fetch step that wires up the Context fields the
+        # supply-chain + test-env steps read.
+        from scripts.pr_validate.base import Step, StepResult
+
+        class _MaliciousFetch(Step):
+            name = "fetch"
+            description = "fake malicious PR fetch"
+
+            def run(self, ctx):  # type: ignore[no-untyped-def]
+                ctx.pr_title = "innocent looking title"
+                ctx.pr_author = "untrusted-contributor"
+                ctx.head_sha = "deadbeef"
+                ctx.diff_path = str(diff_path)
+                ctx.files_changed = ["pyproject.toml"]
+                ctx.pr_is_external = True  # critical: external author
+                return StepResult(name=self.name, status="pass", summary="ok")
+
+        # Sentinel: if test_env_check EVER calls install_test_extras
+        # in this scenario, the bug is back.
+        install_ran = {"yes": False}
+
+        def trap_install(*_args, **_kwargs):
+            install_ran["yes"] = True
+            return (True, "PWNED — build hook would have run here")
+
+        monkeypatch.setattr(
+            "scripts.pr_validate.steps.test_env_check.install_test_extras",
+            trap_install,
+        )
+
+        # Use a real SupplyChainStep + TestEnvCheckStep so we exercise
+        # the actual ordering invariant.
+        steps = [_MaliciousFetch(), SupplyChainStep(), TestEnvCheckStep()]
+        rc = run_pipeline(pr_number=275, fail_fast=True, steps=steps)
+        captured = capsys.readouterr()
+
+        # 1. Pipeline exits non-zero because supply_chain blocked.
+        assert rc == 1, (
+            f"pipeline should have BLOCKED, got rc={rc}. stdout:\n"
+            f"{captured.out}\nstderr:\n{captured.err}"
+        )
+        # 2. supply_chain ran and flagged the change.
+        assert "## [supply_chain]" in captured.err
+        # 3. With fail_fast=True, test_env_check should NOT have run
+        # AFTER supply_chain failed.
+        assert "## [test_env_check]" not in captured.err, (
+            "test_env_check ran after supply_chain failed — fail-fast "
+            "should have stopped the pipeline before the unsafe install"
+        )
+        # 4. The unsafe install path was never invoked.
+        assert install_ran["yes"] is False, (
+            "install_test_extras was called from a malicious-pyproject PR — "
+            "this is the exact #275 bug; supply_chain must run first AND "
+            "block AND test_env_check's auto-install must be gated"
+        )

--- a/tests/test_pr_validate_test_env.py
+++ b/tests/test_pr_validate_test_env.py
@@ -625,7 +625,14 @@ class TestSupplyChainIntegrity:
         """Trusted-pins runs FIRST regardless of whether the PR is
         clean. That's the design — never install from the PR's working
         tree unless we have to. A clean PR is just allowed to fall
-        through to the project-extras path if trusted pins fall short."""
+        through to the project-extras path if trusted pins fall short.
+
+        Hardened (codex r1 NIT, #275 follow-up): the test exercises
+        BOTH paths by leaving the post-trusted-pins probe broken so
+        the step is forced through the project-extras fallback. A
+        future refactor that flipped the order (or dropped the
+        fallback) would break ``call_order == ["trusted_pins",
+        "project_extras"]``, not just the first element."""
         broken = TestEnvStatus(
             ok=False,
             missing=("pytest_asyncio",),
@@ -644,18 +651,21 @@ class TestSupplyChainIntegrity:
 
         def trusted_pins(*_args, **_kwargs):
             call_order.append("trusted_pins")
-            return (True, "trusted")
+            return (True, "trusted partial")
 
         def project_extras(*_args, **_kwargs):
             call_order.append("project_extras")
-            return (True, "extras")
+            return (True, "extras recovered")
 
         with patch.dict(os.environ, {}, clear=False):
             os.environ.pop("PR_VALIDATE_NO_AUTO_INSTALL", None)
             with (
                 patch(
                     "scripts.pr_validate.steps.test_env_check.check_test_env",
-                    side_effect=[broken, healthy],
+                    # initial → broken; after trusted-pins → STILL
+                    # broken (forces fallback); after project-extras
+                    # → healthy.
+                    side_effect=[broken, broken, healthy],
                 ),
                 patch(
                     "scripts.pr_validate.steps.test_env_check.install_trusted_pins",
@@ -667,10 +677,11 @@ class TestSupplyChainIntegrity:
                 ),
             ):
                 step = TestEnvCheckStep()
-                step.run(fake_ctx)
+                result = step.run(fake_ctx)
 
-        assert call_order[0] == "trusted_pins", (
-            "trusted_pins must run BEFORE project_extras"
+        assert result.status == "pass"
+        assert call_order == ["trusted_pins", "project_extras"], (
+            f"expected trusted_pins THEN project_extras, got: {call_order}"
         )
 
     def test_trusted_pins_uses_isolated_pip_flag(self):


### PR DESCRIPTION
## Why

Codex review on PR #885 ([review comment](https://github.com/raullenchai/Rapid-MLX/pull/885)) found:

> `TestEnvCheckStep` auto-runs `pip install .[test]` from `ctx.repo_root` before the `SupplyChainStep` runs. In the runner (`scripts/pr_validate/runner.py:47`), `TestEnvCheckStep()` is ordered before `SupplyChainStep()`, so an external or unreviewed PR that changes `pyproject.toml`, build hooks, or test extras can cause pip/build-backend code or newly declared packages to execute/install before the validator's supply-chain scan has flagged them.

This is a **`pr_validate` self-integrity** bug, not a generic security finding — every agent fix wave runs through `pr_validate`, so a malicious external PR could subvert the validator's own runtime before the tool flagged it. Fixing it is in scope under the operator's standing rules.

## Threat model

`pr_validate` runs in a venv with the project installed. Two of its steps can execute PR-controlled code on the validator host:

1. **`test_env_check`** may run `pip install '.[test]'` from the PR's working tree → evaluates `pyproject.toml` build hooks and any `setup.py` shim.
2. **`targeted_tests` / `full_unit`** run `pytest` → evaluates `conftest.py` and plugin entrypoints registered by pyproject-declared deps.

Pre-#275 ordering: `test_env_check` (idx 3) ran **BEFORE** `supply_chain` (idx 5). An external PR that added a malicious build hook or fake package source in `pyproject.toml` would have its code executed inside the validator venv **before** the supply-chain scan ever saw it.

## Systematic fix

1. **Reorder steps in `runner.py`.** `SupplyChainStep` moved to index 3, BEFORE `TestEnvCheckStep` (idx 4). Codex review still runs after both — but cheap-but-critical supply-chain flagging now precedes any unattended `pip install`. New ordering invariant test (`test_supply_chain_runs_before_auto_installing_steps`) asserts `STEPS.index('supply_chain') < STEPS.index('test_env_check')` so a future refactor can't silently regress.

2. **Refuse unsafe auto-install in `test_env_check`.** New helper `pr_touches_dep_files(ctx.files_changed)` returns the subset of `ctx.files_changed` that intersects `DEP_DECLARATION_FILES_DENYLIST` (`pyproject.toml`, `requirements.txt`, `requirements-dev.txt`, `setup.py`, `setup.cfg`, `requirements-pin.txt`). When non-empty, the project-extras path (`pip install '.[test]'`) is **REFUSED** and the step reports `fail` with the offending file names in the warning + a manual-recovery instruction.

3. **Trusted-pins recovery path.** New `TRUSTED_TEST_PINS = ("pytest>=7,<9", "pytest-asyncio>=0.21,<1")` constant — a hardcoded, version-pinned set of the validator's own plugin deps. Installed from PyPI with `pip install --isolated --disable-pip-version-check` (no user-level pip config injection). This path runs **FIRST** regardless of PR trustworthiness, so the validator's runtime is recovered from a known-good source even on clean PRs. The project-extras path is now only used as a fallback when trusted pins don't cover the missing plugin set AND the PR is clean.

4. **`pyproject.toml` + `requirements*.txt` added to `HOOK_PATHS`** in `supply_chain.py`. External-author PRs touching these files now get `[BLOCKING]` automatically at the supply-chain step, which combined with the new ordering means the pipeline halts before `test_env_check` even runs (with `--fail-fast`).

5. **Threat model documented** in `scripts/pr_validate/README.md` — new "Threat model (#275)" section explains why the order matters so a future contributor can't accidentally regress it. README also reflects the new step ordering and the dual-path test-env recovery.

## Test plan

- [x] `pytest tests/test_pr_validate_test_env.py -q` — 35 tests pass (26 existing + 9 new for #275).
- [x] `pytest tests/test_pr_validate_*.py -q` — all **240 pr_validate tests pass**, including the existing runner ordering / fail-fast / skip-steps contracts.
- [x] **New invariant test** `test_supply_chain_runs_before_auto_installing_steps` asserts `STEPS.index('supply_chain') < STEPS.index('test_env_check')` in the production `STEPS` list.
- [x] **End-to-end malicious-PR simulation** `test_malicious_pyproject_blocked_at_supply_chain_before_test_env`:
  - Builds a fake PR diff that adds an evil build hook to `pyproject.toml` (`requires = ['evil-build-backend @ file:///tmp/attack']`).
  - Fakes an external author (`pr_is_external=True`).
  - Runs the real `SupplyChainStep` + `TestEnvCheckStep` through `run_pipeline()` with `fail_fast=True`.
  - Asserts the unsafe `install_test_extras` path is **never** invoked (sentinel check).
  - Asserts the pipeline exits non-zero with `supply_chain` blocking and `test_env_check` never running.
- [x] **Dep-file gate tests** for the auto-install refusal path:
  - `test_auto_install_refused_when_pr_touches_pyproject` — happy negative case.
  - `test_auto_install_proceeds_when_pr_does_not_touch_dep_files` — no regression on clean PRs.
  - `test_trusted_pins_path_used_first_even_on_clean_pr` — pin the order.
  - `test_trusted_pins_uses_isolated_pip_flag` — pin the `--isolated` flag so a "simplification" can't drop it.
  - `test_pr_touches_dep_files_*` — three tests pinning the helper's truth-table.
- [x] `ruff check` + `ruff format --check` clean on all touched files.
- [x] Dogfood: this PR runs through `pr_validate` itself; the new `supply_chain`-first ordering executes cleanly on a non-dep-file diff (the gate guards a `pyproject.toml` touch — this PR doesn't touch `pyproject.toml`).

Refs codex review on PR #885, task R12-T2F #275.

🤖 Generated with [Claude Code](https://claude.com/claude-code)