### PR TITLE
fix(cli,audio): _serve_audio_mode honors --embedding-model + --served-model-name (closes R11-K #258)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.8.16"
+version = "0.8.17"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/tests/test_audio_alias_registry.py
+++ b/tests/test_audio_alias_registry.py
@@ -301,6 +301,7 @@ def _make_serve_args(model: str) -> Namespace:
     return Namespace(
         model=model,
         embedding_model=None,
+        served_model_name=None,
         no_mllm=True,
         mllm=False,
         max_tokens=None,
@@ -627,4 +628,313 @@ class TestModelsCommandListsAudio:
         assert "qwen3.6" in out.lower() or "qwen3.5" in out.lower(), (
             "Text alias listing disappeared after the audio section "
             "was added — both must coexist."
+        )
+
+
+# ---------------------------------------------------------------------------
+# H) R11-K / task #258 — audio serve honors --served-model-name +
+#    --embedding-model (deferred R10-I carry).
+# ---------------------------------------------------------------------------
+
+
+class TestAudioServeHonorsServedModelName:
+    """Pre-fix ``_serve_audio_mode`` silently dropped
+    ``--served-model-name``: ``server._model_name`` was always
+    ``entry.hf_id``, so operators wrapping ``rapid-mlx serve kokoro``
+    behind a gateway with a fixed ``model_name`` saw the raw HF id on
+    ``/v1/models`` and the gateway's allowlist 404'd.
+
+    The text path's contract (see ``server.load_model``:
+    ``_model_name = served_model_name or model_name``) must mirror
+    1:1 on the audio path. ``_model_alias`` must still surface the
+    friendly short alias so ``/v1/models`` lists BOTH the custom name
+    and the alias — same wire shape as text.
+    """
+
+    def test_served_model_name_overrides_audio_model_name(self):
+        """``--served-model-name custom-tts`` -> ``cfg.model_name`` == ``custom-tts``."""
+        from vllm_mlx import cli, server
+        from vllm_mlx.config import get_config
+
+        cfg = get_config()
+        cfg.model_name = None
+        cfg.model_alias = None
+        cfg.model_path = None
+        server._model_name = None
+        server._model_alias = None
+        server._model_path = None
+
+        with (
+            patch.object(cli, "_run_uvicorn"),
+            patch.object(cli, "_port_preflight_or_die"),
+        ):
+            args = _make_serve_args("kokoro")
+            args.served_model_name = "custom-tts"
+            cli.serve_command(args)
+
+        cfg = get_config()
+        # The custom name lands on the primary id (what /v1/models'
+        # first row reports) — same contract as text mode.
+        assert cfg.model_name == "custom-tts", (
+            "R11-K / #258 regression: audio --served-model-name was "
+            "ignored. ``cfg.model_name`` should hold the operator's "
+            "custom name, not the underlying HF id."
+        )
+        # Friendly alias still exposed so the alias->custom mapping
+        # is discoverable on /v1/models.
+        assert cfg.model_alias == "kokoro"
+        # The underlying HF id remains the engine's input — used as
+        # the cache dir and (not affected by --served-model-name).
+        assert cfg.model_path == "mlx-community/Kokoro-82M-bf16"
+
+    def test_no_served_model_name_keeps_hf_id_as_model_name(self):
+        """Default (no flag) behavior must NOT regress — alias mapping
+        stays as it was before R11-K. This guards the 12-alias Bo r12
+        dogfood: every alias must still boot with the same wire shape."""
+        from vllm_mlx import cli, server
+        from vllm_mlx.config import get_config
+
+        cfg = get_config()
+        cfg.model_name = None
+        cfg.model_alias = None
+        cfg.model_path = None
+        server._model_name = None
+        server._model_alias = None
+        server._model_path = None
+
+        with (
+            patch.object(cli, "_run_uvicorn"),
+            patch.object(cli, "_port_preflight_or_die"),
+        ):
+            args = _make_serve_args("kokoro")
+            # served_model_name is None (default) — fixture is r11-K aware.
+            cli.serve_command(args)
+
+        cfg = get_config()
+        # Same pre-fix shape: HF id as the primary, alias as the secondary.
+        assert cfg.model_name == "mlx-community/Kokoro-82M-bf16"
+        assert cfg.model_alias == "kokoro"
+
+    @pytest.mark.parametrize(
+        "alias",
+        [
+            # 12 Bo r12 dogfood aliases — must keep booting cleanly.
+            "kokoro",
+            "kokoro-4bit",
+            "chatterbox",
+            "vibevoice",
+            "voxcpm",
+            "dia",
+            "whisper",
+            "whisper-1",
+            "whisper-tiny",
+            "whisper-base",
+            "parakeet",
+            "parakeet-v3",
+        ],
+    )
+    def test_all_r12_audio_aliases_boot_with_served_model_name(self, alias):
+        """No-regression: all 12 Bo r12 audio aliases must still take
+        the audio fork AND honor ``--served-model-name``."""
+        from vllm_mlx import cli, server
+        from vllm_mlx.config import get_config
+
+        cfg = get_config()
+        cfg.model_name = None
+        cfg.model_alias = None
+        server._model_name = None
+        server._model_alias = None
+
+        with (
+            patch.object(cli, "_run_uvicorn"),
+            patch.object(cli, "_port_preflight_or_die"),
+        ):
+            args = _make_serve_args(alias)
+            args.served_model_name = f"gateway/{alias}"
+            cli.serve_command(args)
+
+        assert get_config().model_name == f"gateway/{alias}", alias
+        assert get_config().model_alias is not None, alias
+
+
+class TestTextServeServedModelNameDoesNotRegress:
+    """The text-mode ``--served-model-name`` contract is fixed at
+    ``server.load_model`` (``_model_name = served_model_name or
+    model_name``). The R11-K fix only touches the audio dispatcher;
+    the text-mode wiring at ``serve_command`` must NOT shift.
+
+    Brittleness note: running ``serve_command`` end-to-end for a
+    text alias requires mocking ~40 SchedulerConfig / engine knobs.
+    Instead we pin the contract at the two call sites that matter
+    (DFlash + load_model) via source-level inspection — the text
+    fix lives there, and any refactor that drops the ``args.served_model_name``
+    forwarding will be caught by this static check.
+    """
+
+    def test_load_model_call_site_threads_served_model_name(self):
+        """``serve_command`` forwards ``args.served_model_name``
+        verbatim to ``load_model`` and ``run_dflash_server``. Pin
+        BOTH call sites — a refactor that drops either silently
+        regresses the text-mode contract."""
+        import inspect
+
+        from vllm_mlx import cli
+
+        src = inspect.getsource(cli.serve_command)
+        # load_model call site (non-DFlash text path).
+        assert "served_model_name=args.served_model_name" in src, (
+            "text-mode regression: serve_command no longer forwards "
+            "args.served_model_name to load_model. The audio R11-K "
+            "fix MUST NOT touch this contract."
+        )
+        # DFlash call site (text path with --enable-dflash).
+        assert "served_model_name=args.served_model_name or _alias_name" in src, (
+            "text-mode (DFlash) regression: serve_command no longer "
+            "forwards args.served_model_name to run_dflash_server."
+        )
+
+    def test_server_load_model_still_maps_served_to_model_name(self):
+        """``server.load_model``: ``_model_name = served_model_name
+        or model_name``. The audio dispatcher mirrors this exact
+        contract (with ``entry.hf_id`` as the model_name fallback);
+        if the text-side semantics shift the audio mirror would
+        drift."""
+        import inspect
+
+        from vllm_mlx import server
+
+        src = inspect.getsource(server.load_model)
+        # The fallback expression — same shape audio mirror uses.
+        assert "served_model_name or model_name" in src, (
+            "server.load_model no longer assigns "
+            "``_model_name = served_model_name or model_name``. "
+            "The audio dispatcher mirrors this exact expression "
+            "with entry.hf_id; if the text side changes shape, the "
+            "audio mirror must change in lockstep — failing this "
+            "test signals both sides need to be re-aligned."
+        )
+
+
+class TestAudioServeHonorsEmbeddingModel:
+    """R11-K decision call: audio + embedding compose cleanly via
+    ``_load_embedding_model_or_exit`` (intentionally orthogonal to
+    the text-LM engine). Audio engines stay lazy on /v1/audio/*,
+    the embeddings sidecar serves /v1/embeddings on the same app.
+    The helper's docstring explicitly anticipated this audio
+    integration."""
+
+    def test_embedding_model_pre_loads_in_audio_mode(self):
+        """``--embedding-model bge`` on audio serve calls the shared
+        helper exactly the same way text mode does."""
+        from vllm_mlx import cli, server
+
+        calls = []
+
+        def _capture(name, lock=False):
+            calls.append((name, lock))
+
+        with (
+            patch.object(cli, "_run_uvicorn"),
+            patch.object(cli, "_port_preflight_or_die"),
+            patch.object(server, "load_embedding_model", side_effect=_capture),
+            patch("vllm_mlx.embedding.require_mlx_embeddings_or_exit"),
+        ):
+            args = _make_serve_args("kokoro")
+            args.embedding_model = "mlx-community/all-MiniLM-L6-v2-4bit"
+            cli.serve_command(args)
+
+        assert calls, (
+            "R11-K / #258 regression: audio --embedding-model did "
+            "NOT pre-load via server.load_embedding_model. Audio + "
+            "embedding compose cleanly; the helper must be invoked "
+            "the same way text mode invokes it."
+        )
+        # First positional arg is the model id; lock=True mirrors text mode.
+        assert calls[0][0] == "mlx-community/all-MiniLM-L6-v2-4bit"
+        assert calls[0][1] is True
+
+    def test_audio_mode_without_embedding_does_not_call_loader(self):
+        """No-regression: ``serve kokoro`` (no --embedding-model) must
+        NOT trigger the embeddings install guard or loader. The
+        embedding loader must stay strictly opt-in."""
+        from vllm_mlx import cli, server
+
+        calls = []
+
+        def _capture(name, lock=False):
+            calls.append((name, lock))
+
+        with (
+            patch.object(cli, "_run_uvicorn"),
+            patch.object(cli, "_port_preflight_or_die"),
+            patch.object(server, "load_embedding_model", side_effect=_capture),
+        ):
+            args = _make_serve_args("kokoro")
+            # embedding_model stays None (fixture default).
+            cli.serve_command(args)
+
+        assert not calls, (
+            "Audio mode pre-loaded an embedding model without "
+            "--embedding-model — the loader must be strictly opt-in."
+        )
+
+
+class TestAudioServeArgparseAcceptsBothFlags:
+    """Argparse-level smoke test: both flags are REGISTERED on the
+    serve subparser (they were before the fix, the bug was downstream
+    in ``_serve_audio_mode``), so ``rapid-mlx serve kokoro
+    --embedding-model ... --served-model-name ...`` parses without
+    an argparse error. Guards against an accidental subparser
+    refactor that drops these flags."""
+
+    def test_both_flags_parse_on_audio_alias(self, monkeypatch):
+        """``rapid-mlx serve kokoro --embedding-model ... --served-model-name ...``
+        must parse without an argparse error and forward both flags
+        to ``serve_command``. ``main()`` reads sys.argv, so we patch
+        argv and stub the dispatch.
+
+        Both flags WERE registered on the serve subparser before
+        R11-K (the bug was downstream in ``_serve_audio_mode``); this
+        guards against an accidental subparser refactor that drops
+        them and makes the audio invocation fail at argparse time.
+        """
+        import sys as _sys
+
+        from vllm_mlx import cli as _cli
+
+        captured = {}
+
+        def _capture(args):
+            captured["served_model_name"] = args.served_model_name
+            captured["embedding_model"] = args.embedding_model
+            captured["model"] = args.model
+
+        monkeypatch.setattr(
+            _sys,
+            "argv",
+            [
+                "rapid-mlx",
+                "serve",
+                "kokoro",
+                "--embedding-model",
+                "mlx-community/embeddinggemma-300m-6bit",
+                "--served-model-name",
+                "my-tts",
+                "--port",
+                "8102",
+            ],
+        )
+        with patch.object(_cli, "serve_command", side_effect=_capture):
+            try:
+                _cli.main()
+            except SystemExit:
+                # ``main()`` may sys.exit(0) on consent / version
+                # paths even when the parse succeeded; we only need
+                # the captured-args dict populated.
+                pass
+
+        assert captured.get("model") == "kokoro"
+        assert captured.get("served_model_name") == "my-tts"
+        assert (
+            captured.get("embedding_model") == "mlx-community/embeddinggemma-300m-6bit"
         )

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -535,7 +535,18 @@ def _serve_audio_mode(args, entry) -> None:
         # short alias from the registry so /v1/models still shows the
         # friendly name, not the bare HF path.
         server._model_alias = entry.alias
-    server._model_name = entry.hf_id
+    # R11-K / task #258: honor ``--served-model-name`` on the audio
+    # path, mirroring the text-mode contract at ``server.load_model``
+    # (``_model_name = served_model_name or model_name``). Pre-fix the
+    # audio dispatcher ignored the flag, so operators wrapping
+    # ``rapid-mlx serve kokoro`` behind a gateway with a stable
+    # ``model_name`` saw the raw HF id on ``/v1/models`` and the
+    # gateway's model-id allowlist 404'd. The underlying HF id stays
+    # on ``_model_path`` (cache dir / engine input), and the friendly
+    # short alias stays on ``_model_alias`` so ``/v1/models`` lists
+    # both the custom name AND the alias — same wire shape as text.
+    _served_name = getattr(args, "served_model_name", None)
+    server._model_name = _served_name or entry.hf_id
     server._model_path = entry.hf_id
 
     # Mirror the text path's security configuration. Audio routes use
@@ -589,6 +600,22 @@ def _serve_audio_mode(args, entry) -> None:
         "  Audio engines load lazily on the first /v1/audio/* request "
         "(no boot-time weight download)."
     )
+
+    # R11-K / task #258: honor ``--embedding-model`` on the audio
+    # path. The shared helper (``_load_embedding_model_or_exit``) is
+    # intentionally orthogonal to the text-LM engine — it only goes
+    # through ``server.load_embedding_model`` — so audio + embedding
+    # compose cleanly: the audio engines stay lazy on /v1/audio/*
+    # while the embeddings sidecar serves /v1/embeddings from the
+    # same FastAPI app. Mirrors the text-mode call site at
+    # ``serve_command`` (post-``load_model``); see the helper's
+    # docstring "Audio-mode integration" note (R11-K coordination)
+    # — single source of truth for the install + alias + error wrap.
+    # Ordered after the banner so the operator sees the audio model
+    # banner FIRST (matches the text-mode visual ordering where the
+    # ``Model:`` line prints before ``Pre-loading embedding model:``).
+    if getattr(args, "embedding_model", None):
+        _load_embedding_model_or_exit(args, server.load_embedding_model)
 
     # Stamp the bind source-of-truth so the lifespan "Ready:" banner
     # prints the right URL. Mirrors the text-path block.


### PR DESCRIPTION
## Repro

```bash
rapid-mlx serve kokoro --embedding-model some-embed --served-model-name my-tts --port 8102
# Pre-fix: BOTH flags silently ignored.
#   - cfg.model_name == 'mlx-community/Kokoro-82M-bf16' (NOT 'my-tts')
#   - cfg.model_alias == 'kokoro'
#   - embedding model NOT pre-loaded (no log line, helper never invoked)
```

Compare with text-mode (worked pre-fix):

```bash
rapid-mlx serve qwen3.5-4b-4bit --embedding-model bge-large --served-model-name custom-name --port 8103
#   - cfg.model_name == 'custom-name'    (honored)
#   - embedding pre-loaded               (honored)
```

## Root cause

\`_serve_audio_mode\` (\`vllm_mlx/cli.py:477\`) hardcoded
\`server._model_name = entry.hf_id\` and never invoked the shared
embedding pre-load helper. The argparse subparser DID register both
flags (\`--served-model-name\` at \`cli.py:5047\`, \`--embedding-model\`
at \`cli.py:5762\`) so they parsed cleanly, but the audio dispatcher
dropped them downstream. R10-I review deferred fixing the audio
path; #258 is the carry.

## Systematic fix (mirrors text-mode 1:1)

* \`_model_name = served_model_name or entry.hf_id\` — same shape as
  \`server.load_model\`'s \`_model_name = served_model_name or model_name\`.
  \`_model_alias\` still holds the friendly short alias so \`/v1/models\`
  lists BOTH the custom name AND the alias (same wire shape as text).
  \`_model_path\` keeps the underlying HF id (engine input / cache dir).
* If \`--embedding-model\` is set, call \`_load_embedding_model_or_exit\`
  — the helper's docstring already anticipates this R11-K
  coordination as a single source of truth for install guard + alias
  resolve + error-wrap. Audio path calls it post-\`_sync_config()\`,
  mirroring text-mode which calls it post-\`load_model()\`.

## Decision call: \`--embedding-model\` + audio composition

**Option (a) — ALLOW.** The helper \`_load_embedding_model_or_exit\`
is intentionally orthogonal to the text-LM engine (only goes
through \`server.load_embedding_model\`). Audio + embedding compose
cleanly with zero invasive wiring:

* Audio engines stay lazy on \`/v1/audio/*\`.
* Embeddings sidecar serves \`/v1/embeddings\` on the same FastAPI app.
* Existing install-extra guard at \`serve_command:1236\` fires BEFORE
  the audio fork, so missing \`[embeddings]\` extra still exits 2 with
  the install hint (no regression of H-08).

Option (b) would have required a rejection guard that diverges from
the helper's own forward-looking design — invasive without benefit.

## Test plan

- [x] \`TestAudioServeHonorsServedModelName\` — \`cfg.model_name\` ==
      custom-name when flag set; \`cfg.model_alias\` still 'kokoro';
      \`cfg.model_path\` still HF id.
- [x] \`TestAudioServeHonorsServedModelName.test_no_served_model_name_keeps_hf_id_as_model_name\`
      — fixture default (\`None\`) preserves pre-R11-K shape.
- [x] \`test_all_r12_audio_aliases_boot_with_served_model_name\` — all
      12 Bo r12 audio aliases (kokoro, kokoro-4bit, chatterbox,
      vibevoice, voxcpm, dia, whisper, whisper-1, whisper-tiny,
      whisper-base, parakeet, parakeet-v3) honor the flag and stay
      green on the audio fork.
- [x] \`TestAudioServeHonorsEmbeddingModel\` — embedding helper called
      with \`(name, lock=True)\` exactly like text mode; loader NOT
      called when flag absent (strict opt-in).
- [x] \`TestAudioServeArgparseAcceptsBothFlags\` — \`rapid-mlx serve
      kokoro --embedding-model ... --served-model-name ...\` parses
      without argparse error and forwards both flags.
- [x] \`TestTextServeServedModelNameDoesNotRegress\` — pins the
      text-mode \`serve_command\` call sites (load_model + DFlash) AND
      the \`server.load_model\` semantics by source-level inspection.
      Audio mirror drift is caught the moment text shape shifts.
- [x] All 311 existing audio tests pass (0 regressions).
- [x] All 101 wider CLI tests pass (\`test_cli_embeddings_extra\`,
      \`test_serve_listen_fd\`, \`test_body_receive_timeout\`,
      \`test_uitars_boot_check\`, \`test_embeddings_extra_guard\`,
      \`test_cli_config_fidelity\`, etc.).

## References

- Closes #258 (R11-K deferred carry from R10-I review).
- Helper docstring at \`cli.py:667-676\` explicitly anticipated this
  audio integration — \"\_serve_audio_mode ever needs to honour
  --embedding-model ... MUST route through this helper rather than
  duplicate the guard logic\". Single source of truth preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)