### PR TITLE
fix(reasoning): #344 tool_call promotion — codex r2-r5 follow-ups (5 BLOCKING)

### DIFF
--- a/tests/test_tool_call_promotion.py
+++ b/tests/test_tool_call_promotion.py
@@ -397,6 +397,45 @@ class TestStreamingPromotion:
         assert "<function=f>" in content
         assert "Done." in content
 
+    def test_stream_carry_then_single_delta_shortcut_preserves_reasoning(self, parser):
+        """Regression for the single-delta promotion shortcut: when a
+        prior delta withheld a partial ``<tool_call>`` opener in
+        ``_reasoning_carry`` and the NEXT delta arrives with both
+        reasoning AND content (the post-think segment), the shortcut
+        must NOT bypass ``_absorb_reasoning_chunk`` — otherwise the
+        carried prefix is silently dropped from the wire.
+
+        Setup: chunk_size 5 splits ``<tool_call>`` across the boundary
+        so a carry is set, then the trailing chunk completes the tag
+        AND closes ``</think>`` plus post-think content in the same
+        delta. The streaming output must be byte-equivalent to the
+        non-streaming extract for the same text."""
+        text = (
+            "<think>R\n"
+            "<tool_call>\n"
+            "<function=f><parameter=x>1</parameter></function>\n"
+            "</tool_call>\n"
+            "</think>\nPost."
+        )
+        # Non-streaming reference shape.
+        ref_reasoning, ref_content = parser.extract_reasoning(text)
+        # Try several chunk sizes that force partial-opener carries.
+        for cs in (3, 5, 7, 11):
+            stream_reasoning, stream_content = _stream(parser, text, chunk_size=cs)
+            assert stream_content is not None, cs
+            assert "<function=f>" in stream_content, cs
+            assert "Post." in stream_content, cs
+            # The carried "<tool_ca…" prefix must not disappear: the
+            # reasoning prefix ``R\n`` survives, and ``<tool_call>``
+            # never leaks into reasoning.
+            assert stream_reasoning is not None, cs
+            assert "R" in stream_reasoning, cs
+            assert "<tool_call>" not in stream_reasoning, cs
+            # Same wire shape (modulo whitespace) as non-streaming.
+            assert ("<function=f>" in (ref_content or "")) == (
+                "<function=f>" in stream_content
+            ), cs
+
 
 # ── Multi-family parity ─────────────────────────────────────────────
 

--- a/tests/test_tool_call_promotion.py
+++ b/tests/test_tool_call_promotion.py
@@ -335,23 +335,67 @@ class TestStreamingPromotion:
         assert "The answer is 42." in content
 
     def test_stream_prose_mention_not_promoted_at_finalize(self, parser):
-        """When the bare ``<tool_call>`` mention appears mid-reasoning
-        but never closes AND no closer arrives by stream end, the
-        streaming buffer eventually flushes via finalize. The buffer
-        contents are surfaced (matches upstream's stream-end flush
-        contract); the structural guard only applies to the
-        non-streaming promoter."""
+        """Bare ``<tool_call>`` prose mention inside reasoning is NOT
+        promoted in the streaming path either — the structural guard
+        (parity with non-streaming ``_TOOL_CALL_UNCLOSED_RE``) skips
+        the buffer entry when the next non-whitespace byte after the
+        opener is not ``{`` or ``<``. The prose tail must stay in
+        reasoning; post-think content must remain clean."""
         text = (
             "<think>The model should use <tool_call> to invoke functions. "
             "Then it should verify.</think>\n"
             "The answer is 42."
         )
         reasoning, content = _stream(parser, text)
-        # Even if the bare ``<tool_call>`` substring was buffered, the
-        # post-think content delta flushes it. The actual post-think
-        # content must still appear in content.
+        # Bare ``<tool_call>`` must NOT have triggered promotion — the
+        # prose tail "to invoke functions. Then it should verify."
+        # stays in reasoning, not content.
+        assert reasoning is not None
+        assert "to invoke functions" in reasoning
         assert content is not None
         assert "The answer is 42." in content
+        # Post-think content channel must NOT contain the prose tail.
+        assert "to invoke functions" not in content
+
+    @pytest.mark.parametrize("chunk_size", [1, 3, 7, 13, 25])
+    def test_stream_chunked_prose_mention_not_promoted(self, parser, chunk_size):
+        """Regression: chunked streaming of a bare ``<tool_call>``
+        prose mention must NOT promote prose into content, regardless
+        of where SSE boundaries fall (mid-tag, after-tag-whitespace,
+        mid-prose). Exercises the carry-forward case where the
+        discriminating non-whitespace byte arrives in a later chunk."""
+        text = (
+            "<think>The model should use <tool_call> to invoke functions. "
+            "Then it should verify.</think>\n"
+            "The answer is 42."
+        )
+        reasoning, content = _stream(parser, text, chunk_size=chunk_size)
+        assert reasoning is not None
+        assert "to invoke functions" in reasoning
+        assert content is not None
+        assert "The answer is 42." in content
+        assert "to invoke functions" not in content
+
+    def test_stream_chunked_real_tool_call_after_prose_mention(self, parser):
+        """A bare prose ``<tool_call>`` followed later by a real
+        structural ``<tool_call>{json}</tool_call>`` must keep the
+        prose in reasoning AND promote the real call. Verifies the
+        structural-guard loop continues scanning past the prose tag."""
+        text = (
+            "<think>I might use <tool_call> if needed.\n"
+            "<tool_call>\n"
+            "<function=f><parameter=x>1</parameter></function>\n"
+            "</tool_call>\n"
+            "</think>\nDone."
+        )
+        reasoning, content = _stream(parser, text, chunk_size=4)
+        assert reasoning is not None
+        assert "if needed" in reasoning
+        assert content is not None
+        # The structural ``<tool_call>`` (followed by ``<function=…``)
+        # must have been promoted.
+        assert "<function=f>" in content
+        assert "Done." in content
 
 
 # ── Multi-family parity ─────────────────────────────────────────────

--- a/tests/test_tool_call_promotion.py
+++ b/tests/test_tool_call_promotion.py
@@ -234,6 +234,37 @@ class TestNonStreamingPromotion:
         assert "<tool_call>" in content
         assert "Done thinking." not in content
 
+    def test_unclosed_pretty_printed_json_not_truncated_at_value_line(self, parser):
+        """Codex round-4 finding #8: an unclosed multi-line JSON
+        ``<tool_call>`` body where some inner lines are pretty-printed
+        JSON values (no ``<``, ``{`` or ``}`` on the line) must NOT
+        be truncated by the prose-boundary heuristic. The heuristic
+        is JSON-aware: while ``{…}`` brace depth is > 0 every line is
+        body, not prose. Pre-fix, the inner ``"name": "get_weather",``
+        line would have been treated as prose and the promoted block
+        would have collapsed to just ``<tool_call>\\n{`` leaving the
+        rest of the JSON in reasoning."""
+        output = (
+            "<think>Calling.\n"
+            "<tool_call>\n"
+            "{\n"
+            '  "name": "get_weather",\n'
+            '  "arguments": {\n'
+            '    "city": "Tokyo",\n'
+            '    "units": "metric"\n'
+            "  }\n"
+            "</think>"
+        )
+        reasoning, content = parser.extract_reasoning(output)
+        assert content is not None
+        # The full JSON body must survive in content, not get split
+        # at the ``"name": "get_weather",`` line.
+        assert '"name": "get_weather"' in content
+        assert '"city": "Tokyo"' in content
+        assert '"units": "metric"' in content
+        # Reasoning must still contain the pre-call prose.
+        assert "Calling." in (reasoning or "")
+
 
 # ── Streaming promotion ─────────────────────────────────────────────
 
@@ -321,6 +352,86 @@ class TestStreamingPromotion:
         assert "<tool_call>" in final.content
         # Exactly one occurrence — no duplication.
         assert final.content.count("<tool_call>") == 1
+
+    def test_stream_finalize_dedup_keeps_earlier_completed_tool_call(self):
+        """Codex round-4 BLOCKING finding #7: the dedup substring
+        strip must use trailing-position match, not first-occurrence
+        ``replace``. With an earlier COMPLETED ``<tool_call>`` block
+        sharing the same prefix as the trailing in-progress buffered
+        call, a naive ``replace(span, '', 1)`` could remove or
+        corrupt the EARLIER block instead of stripping the
+        duplicated trailing buffered span. The fix uses ``rfind``
+        and only strips when the match is at the END (modulo
+        trailing whitespace)."""
+        cls = get_parser("qwen3")
+        p = cls()
+        p.reset_state()
+        # Two tool_call blocks: first is COMPLETED (with content),
+        # second is in-progress (will be buffered at stream end and
+        # flushed by finalize). They share the same opener prefix.
+        text = (
+            "<think>\n"
+            "<tool_call>\n"
+            "<function=a><parameter=x>1</parameter></function>\n"
+            "</tool_call>\n"
+            "<tool_call>\n"
+            "<function=b><parameter=y>2</parameter></function>\n"
+        )
+        accumulated = ""
+        for ch in [text]:
+            previous = accumulated
+            accumulated += ch
+            p.extract_reasoning_streaming(previous, accumulated, ch)
+        final = finalize_streaming_compat(
+            p, accumulated, finish_reason=None, matched_stop=None
+        )
+        assert final is not None
+        assert final.content is not None
+        # Both completed-and-in-progress calls must appear in content
+        # — the first must NOT have been mistakenly stripped by the
+        # dedup logic.
+        assert "<function=a>" in final.content
+        assert "<function=b>" in final.content
+        # Each opener appears exactly twice (one per call), not three
+        # times (would indicate duplication) or once (would indicate
+        # the first was clobbered).
+        assert final.content.count("<tool_call>") == 2
+
+    def test_deepseek_threshold_crossing_with_buffered_tool_call(self):
+        """Codex round-4 BLOCKING finding #1: the DeepSeek no-tag
+        threshold path emits ``DeltaMessage(content=delta_text)``
+        once the stream crosses ``NO_TAG_CONTENT_THRESHOLD``. If a
+        structural ``<tool_call>`` opened the buffer while still
+        under the threshold (the parser routed under-threshold
+        bytes to reasoning), the buffered prefix must be flushed
+        with the threshold-crossing delta — otherwise the bytes
+        are stranded and never reach the wire."""
+        cls = get_parser("deepseek_r1")
+        p = cls()
+        p.reset_state()
+        # Open a tool_call buffer with reasoning bytes (under threshold).
+        under_threshold = "<tool_call>\n<func"
+        accumulated = ""
+        previous = accumulated
+        accumulated += under_threshold
+        p.extract_reasoning_streaming(previous, accumulated, under_threshold)
+        # Now push past NO_TAG_CONTENT_THRESHOLD (64) so the
+        # next delta hits the threshold-crossing branch.
+        crossing = "tion=f><parameter=x>1</parameter></function>"
+        crossing_pad = "x" * (max(0, 65 - len(accumulated + crossing)))
+        crossing_full = crossing + crossing_pad
+        previous = accumulated
+        accumulated += crossing_full
+        result = p.extract_reasoning_streaming(previous, accumulated, crossing_full)
+        # The buffered ``<tool_call>\n<func`` prefix must be present
+        # in the emitted content — not silently dropped from the
+        # wire by the threshold-crossing early-return.
+        assert result is not None
+        content_seen = result.content or ""
+        # Buffer should have been flushed: the under-threshold
+        # ``<tool_call>`` opener bytes appear in content.
+        assert "<tool_call>" in content_seen
+        assert "<function=f>" in content_seen
 
     def test_stream_multiple_tool_calls(self, parser):
         text = (

--- a/tests/test_tool_call_promotion.py
+++ b/tests/test_tool_call_promotion.py
@@ -234,6 +234,32 @@ class TestNonStreamingPromotion:
         assert "<tool_call>" in content
         assert "Done thinking." not in content
 
+    def test_unclosed_json_with_braces_in_string_not_truncated(self, parser):
+        """Codex round-5 finding #4: the JSON-aware brace counter must
+        ignore ``{`` / ``}`` inside JSON string literals — otherwise
+        a valid argument like ``"pattern": "}}"`` would drive the
+        depth to zero early and the next value line would be
+        misclassified as trailing prose.
+        """
+        output = (
+            "<think>Calling.\n"
+            "<tool_call>\n"
+            "{\n"
+            '  "name": "match",\n'
+            '  "arguments": {\n'
+            '    "pattern": "}}",\n'
+            '    "input": "abc"\n'
+            "</think>"
+        )
+        reasoning, content = parser.extract_reasoning(output)
+        assert content is not None
+        # The full JSON body must survive — the ``}}`` inside the
+        # string must not have closed the brace depth and triggered
+        # a premature prose-boundary cut.
+        assert '"pattern"' in content
+        assert '"input"' in content
+        assert '"abc"' in content
+
     def test_unclosed_pretty_printed_json_not_truncated_at_value_line(self, parser):
         """Codex round-4 finding #8: an unclosed multi-line JSON
         ``<tool_call>`` body where some inner lines are pretty-printed
@@ -396,6 +422,42 @@ class TestStreamingPromotion:
         # times (would indicate duplication) or once (would indicate
         # the first was clobbered).
         assert final.content.count("<tool_call>") == 2
+
+    def test_deepseek_threshold_crossing_with_reasoning_carry(self):
+        """Codex round-5 BLOCKING finding #1: when ``<tool_call>`` is
+        SPLIT across the NO_TAG_CONTENT_THRESHOLD boundary (e.g. the
+        opener arrives as ``<tool_ca`` under threshold and the rest
+        ``ll>...`` after), the under-threshold partial-opener is
+        held in ``_reasoning_carry``. The threshold-crossing content
+        delta must prepend that carry so the opener reassembles on
+        the wire — otherwise the prefix is silently dropped or
+        emitted as reasoning later by finalize."""
+        cls = get_parser("deepseek_r1")
+        p = cls()
+        p.reset_state()
+        # Build text that places the ``<tool_call>`` opener so it
+        # straddles the threshold (64). Under-threshold step
+        # populates ``_reasoning_carry`` with the partial opener;
+        # the next step crosses the threshold.
+        accumulated = ""
+        under_chunk = "x" * 48 + "<tool_ca"  # 56 chars: under 64
+        previous = accumulated
+        accumulated += under_chunk
+        p.extract_reasoning_streaming(previous, accumulated, under_chunk)
+        # Carry should now hold the partial opener.
+        assert p._reasoning_carry == "<tool_ca"
+        # Now the rest of the opener + body crosses the threshold.
+        rest = "ll>\n<function=f><parameter=x>1</parameter></function>"
+        previous = accumulated
+        accumulated += rest
+        result = p.extract_reasoning_streaming(previous, accumulated, rest)
+        assert result is not None
+        content_seen = result.content or ""
+        # The reassembled opener must be on the wire.
+        assert "<tool_call>" in content_seen
+        assert "<function=f>" in content_seen
+        # Carry should have been drained.
+        assert p._reasoning_carry == ""
 
     def test_deepseek_threshold_crossing_with_buffered_tool_call(self):
         """Codex round-4 BLOCKING finding #1: the DeepSeek no-tag

--- a/tests/test_tool_call_promotion.py
+++ b/tests/test_tool_call_promotion.py
@@ -272,13 +272,55 @@ class TestStreamingPromotion:
         assert "<tool_call>" in content
 
     def test_stream_finalize_with_buffered_tool_call(self, parser):
-        """Stream ends mid-tool-call — flushed by finalize as content."""
+        """Stream ends mid-tool-call — flushed by finalize as content,
+        NOT duplicated. Codex round-3 BLOCKING regression: the
+        subclass ``finalize_streaming`` (Qwen3 natural-EOS path)
+        re-derives content from ``accumulated_text`` which includes
+        the buffered ``<tool_call>`` bytes; the merge in
+        ``finalize_streaming_compat`` must strip them before
+        appending the flush, otherwise the tool-call XML appears
+        TWICE on the wire."""
         text = (
             "<think>\n<tool_call>\n<function=f><parameter=x>1</parameter></function>\n"
         )
         reasoning, content = _stream(parser, text)
         assert content is not None
         assert "<tool_call>" in content
+        # Exactly one tool_call block — no duplication.
+        assert content.count("<tool_call>") == 1
+        assert content.count("<function=f>") == 1
+
+    def test_stream_finalize_buffered_tool_call_no_reasoning_leak(self):
+        """Codex round-3 BLOCKING regression: when ``finish_reason=
+        "length"`` truncates a stream mid-``<tool_call>``, Qwen3's
+        ``finalize_streaming`` returns the cleaned trace as
+        ``reasoning`` (D-STOP-THINK suppression). Without dedup, the
+        same buffered ``<tool_call>`` bytes leak into BOTH reasoning
+        AND content — the merge must strip them from reasoning so the
+        flush owns the tool_call wire emission and the channel is
+        clean."""
+        cls = get_parser("qwen3")
+        p = cls()
+        p.reset_state()
+        text = (
+            "<think>\n<tool_call>\n<function=f><parameter=x>1</parameter></function>\n"
+        )
+        accumulated = ""
+        for ch in [text]:
+            previous = accumulated
+            accumulated += ch
+            p.extract_reasoning_streaming(previous, accumulated, ch)
+        final = finalize_streaming_compat(
+            p, accumulated, finish_reason="length", matched_stop=None
+        )
+        assert final is not None
+        # Tool call must not appear in reasoning — that's a wire leak.
+        assert "<tool_call>" not in (final.reasoning or "")
+        # Tool call must appear in content (flushed by promotion).
+        assert final.content is not None
+        assert "<tool_call>" in final.content
+        # Exactly one occurrence — no duplication.
+        assert final.content.count("<tool_call>") == 1
 
     def test_stream_multiple_tool_calls(self, parser):
         text = (

--- a/vllm_mlx/reasoning/base.py
+++ b/vllm_mlx/reasoning/base.py
@@ -256,16 +256,53 @@ def finalize_streaming_compat(
             if msg is None:
                 return flush
             # Merge: subclass content + flushed tool_call; subclass
-            # reasoning preserved (the flush is a content-only emit).
+            # reasoning preserved (the flush is a content-only emit
+            # for the tool-call buffer plus an optional reasoning-only
+            # emit for an unresolved ``_reasoning_carry``).
+            #
+            # Dedup guard (codex round-3 BLOCKING): the subclass
+            # ``finalize_streaming`` re-derives its emission from
+            # ``accumulated_text`` and has no knowledge of the
+            # streaming filter's buffered state. For Qwen3 at natural
+            # EOS the override returns ``DeltaMessage(content=cleaned)``
+            # where ``cleaned`` already includes the buffered
+            # ``<tool_call>`` bytes; at ``finish_reason="length"`` it
+            # returns ``DeltaMessage(reasoning=cleaned)`` with the
+            # buffered bytes routed to reasoning. Appending
+            # ``flush.content`` blindly would duplicate the tool_call
+            # block (natural EOS) or leak it into BOTH channels
+            # (length truncation). Strip the exact buffered span from
+            # ``msg.content``/``msg.reasoning`` before merging — the
+            # flush owns the wire emission of the tool-call buffer.
+            subclass_content = msg.content
+            subclass_reasoning = msg.reasoning
+            if flush.content:
+                # The flush content is the buffered tool-call XML/JSON
+                # block (always trailing). ``rstrip`` reaches it
+                # whether it sits at the end of content or reasoning.
+                if subclass_content and flush.content in subclass_content:
+                    subclass_content = (
+                        subclass_content.replace(flush.content, "", 1) or None
+                    )
+                if subclass_reasoning and flush.content in subclass_reasoning:
+                    subclass_reasoning = (
+                        subclass_reasoning.replace(flush.content, "", 1) or None
+                    )
             merged_content_parts: list[str] = []
-            if msg.content:
-                merged_content_parts.append(msg.content)
+            if subclass_content:
+                merged_content_parts.append(subclass_content)
             if flush.content:
                 merged_content_parts.append(flush.content)
             merged_content = "".join(merged_content_parts) or None
+            merged_reasoning_parts: list[str] = []
+            if subclass_reasoning:
+                merged_reasoning_parts.append(subclass_reasoning)
+            if flush.reasoning:
+                merged_reasoning_parts.append(flush.reasoning)
+            merged_reasoning = "".join(merged_reasoning_parts) or None
             return DeltaMessage(
                 role=msg.role,
-                reasoning=msg.reasoning,
+                reasoning=merged_reasoning,
                 content=merged_content,
             )
     return msg

--- a/vllm_mlx/reasoning/base.py
+++ b/vllm_mlx/reasoning/base.py
@@ -278,15 +278,31 @@ def finalize_streaming_compat(
             subclass_reasoning = msg.reasoning
             if flush.content:
                 # The flush content is the buffered tool-call XML/JSON
-                # block (always trailing). ``rstrip`` reaches it
-                # whether it sits at the end of content or reasoning.
-                if subclass_content and flush.content in subclass_content:
-                    subclass_content = (
-                        subclass_content.replace(flush.content, "", 1) or None
-                    )
-                if subclass_reasoning and flush.content in subclass_reasoning:
-                    subclass_reasoning = (
-                        subclass_reasoning.replace(flush.content, "", 1) or None
+                # block — ALWAYS the trailing in-progress call (the
+                # only unclosed one at stream end). Use ``rfind`` and
+                # only strip when the match is at the END of the
+                # subclass output (modulo trailing whitespace). An
+                # earlier completed call may share the same prefix
+                # (e.g. two ``<tool_call>\n{"name": "f"…`` blocks);
+                # a first-occurrence ``replace`` could corrupt that
+                # earlier block instead of removing the trailing
+                # buffered duplicate — codex round-4 finding #7.
+                def _strip_trailing(buf: str, span: str) -> str | None:
+                    idx = buf.rfind(span)
+                    if idx < 0:
+                        return buf or None
+                    # Trailing modulo whitespace: any chars after the
+                    # match must be only whitespace.
+                    if buf[idx + len(span) :].strip() != "":
+                        return buf or None
+                    stripped = buf[:idx] + buf[idx + len(span) :]
+                    return stripped or None
+
+                if subclass_content:
+                    subclass_content = _strip_trailing(subclass_content, flush.content)
+                if subclass_reasoning:
+                    subclass_reasoning = _strip_trailing(
+                        subclass_reasoning, flush.content
                     )
             merged_content_parts: list[str] = []
             if subclass_content:

--- a/vllm_mlx/reasoning/deepseek_r1_parser.py
+++ b/vllm_mlx/reasoning/deepseek_r1_parser.py
@@ -120,10 +120,23 @@ class DeepSeekR1ReasoningParser(BaseThinkingReasoningParser):
         # Check if any tags are in the current text
         has_tags = self.start_token in current_text or self.end_token in current_text
 
-        # No tags seen yet and past threshold → treat as content
+        # No tags seen yet and past threshold → treat as content.
+        # Codex round-4 BLOCKING finding #1: if the under-threshold
+        # phase already opened the tool_call buffer (a structural
+        # ``<tool_call>`` arrived while we were routing to reasoning),
+        # we must flush that buffer FIRST so the buffered prefix
+        # reaches the wire as content before the new content-channel
+        # delta. Bare-returning here would strand the buffered prefix
+        # and the post-threshold bytes would skip promotion entirely.
         if not has_tags and not self._saw_any_tag:
             if len(current_text) >= self.NO_TAG_CONTENT_THRESHOLD:
-                return DeltaMessage(content=delta_text)
+                flushed_prefix: str | None = None
+                if self._in_tool_call and self._tool_call_buffer:
+                    flushed_prefix = self._tool_call_buffer
+                    self._tool_call_buffer = ""
+                    self._in_tool_call = False
+                merged_content = (flushed_prefix or "") + delta_text
+                return DeltaMessage(content=merged_content)
             # Under threshold: delegate to base (defaults to reasoning
             # for early implicit mode, will be corrected by finalize)
 

--- a/vllm_mlx/reasoning/deepseek_r1_parser.py
+++ b/vllm_mlx/reasoning/deepseek_r1_parser.py
@@ -121,21 +121,24 @@ class DeepSeekR1ReasoningParser(BaseThinkingReasoningParser):
         has_tags = self.start_token in current_text or self.end_token in current_text
 
         # No tags seen yet and past threshold → treat as content.
-        # Codex round-4 BLOCKING finding #1: if the under-threshold
-        # phase already opened the tool_call buffer (a structural
-        # ``<tool_call>`` arrived while we were routing to reasoning),
-        # we must flush that buffer FIRST so the buffered prefix
-        # reaches the wire as content before the new content-channel
-        # delta. Bare-returning here would strand the buffered prefix
-        # and the post-threshold bytes would skip promotion entirely.
+        # Codex round-4 BLOCKING finding #1 + round-5 finding #1:
+        # the under-threshold phase may have opened the tool_call
+        # buffer OR withheld a partial ``<tool_call>`` opener in
+        # ``_reasoning_carry`` when an opener straddled the
+        # threshold boundary. Both must be reattached to the
+        # threshold-crossing content delta so no buffered bytes
+        # are stranded and a split opener reassembles correctly.
         if not has_tags and not self._saw_any_tag:
             if len(current_text) >= self.NO_TAG_CONTENT_THRESHOLD:
-                flushed_prefix: str | None = None
+                prefix_parts: list[str] = []
+                if self._reasoning_carry:
+                    prefix_parts.append(self._reasoning_carry)
+                    self._reasoning_carry = ""
                 if self._in_tool_call and self._tool_call_buffer:
-                    flushed_prefix = self._tool_call_buffer
+                    prefix_parts.append(self._tool_call_buffer)
                     self._tool_call_buffer = ""
                     self._in_tool_call = False
-                merged_content = (flushed_prefix or "") + delta_text
+                merged_content = "".join(prefix_parts) + delta_text
                 return DeltaMessage(content=merged_content)
             # Under threshold: delegate to base (defaults to reasoning
             # for early implicit mode, will be corrected by finalize)

--- a/vllm_mlx/reasoning/think_parser.py
+++ b/vllm_mlx/reasoning/think_parser.py
@@ -62,6 +62,14 @@ def _split_unclosed_at_prose_boundary(unclosed_block: str) -> tuple[str, str]:
     ``(promoted_block, trailing_prose)`` where ``trailing_prose``
     begins with the prose line (and is empty when the entire body
     is tool-call-shaped).
+
+    JSON-aware (codex round-4 finding #8): once an unmatched ``{``
+    opens a JSON body, track brace depth and DO NOT treat
+    pretty-printed JSON content lines (e.g. ``"name": "get_weather",``)
+    as prose even when they contain none of ``<``, ``{``, ``}``.
+    Only after the brace depth returns to zero — i.e. the JSON object
+    has closed — can a subsequent bare-text line be classified as
+    trailing prose.
     """
     # Strip the ``<tool_call>`` opener for inspection — the opener
     # itself must always go into the promoted block.
@@ -75,6 +83,7 @@ def _split_unclosed_at_prose_boundary(unclosed_block: str) -> tuple[str, str]:
     promoted_lines: list[str] = []
     trailing_lines: list[str] = []
     boundary_hit = False
+    json_depth = 0  # net {…} depth across processed lines
     for line in lines:
         if boundary_hit:
             trailing_lines.append(line)
@@ -85,7 +94,16 @@ def _split_unclosed_at_prose_boundary(unclosed_block: str) -> tuple[str, str]:
             promoted_lines.append(line)
             continue
         if "<" in stripped or "{" in stripped or "}" in stripped:
-            # XML/JSON-ish — still inside the tool_call body.
+            # XML/JSON-ish — still inside the tool_call body. Update
+            # net brace depth so subsequent pretty-printed JSON value
+            # lines are recognised as still-inside-body even though
+            # they have no structural chars.
+            json_depth += stripped.count("{") - stripped.count("}")
+            promoted_lines.append(line)
+            continue
+        if json_depth > 0:
+            # Pretty-printed JSON value line inside an open ``{…}`` —
+            # NOT prose. Keep it in the promoted block.
             promoted_lines.append(line)
             continue
         # Pure prose line — boundary.

--- a/vllm_mlx/reasoning/think_parser.py
+++ b/vllm_mlx/reasoning/think_parser.py
@@ -95,10 +95,11 @@ def _split_unclosed_at_prose_boundary(unclosed_block: str) -> tuple[str, str]:
             continue
         if "<" in stripped or "{" in stripped or "}" in stripped:
             # XML/JSON-ish — still inside the tool_call body. Update
-            # net brace depth so subsequent pretty-printed JSON value
-            # lines are recognised as still-inside-body even though
-            # they have no structural chars.
-            json_depth += stripped.count("{") - stripped.count("}")
+            # net brace depth using a string-aware scan so braces
+            # inside JSON string literals (e.g. ``"pattern": "}}"``)
+            # don't close the body prematurely — codex round-5
+            # finding #4.
+            json_depth += _net_brace_delta_outside_strings(stripped)
             promoted_lines.append(line)
             continue
         if json_depth > 0:
@@ -114,6 +115,40 @@ def _split_unclosed_at_prose_boundary(unclosed_block: str) -> tuple[str, str]:
     if trailing_prose:
         trailing_prose = "\n" + trailing_prose
     return promoted_block, trailing_prose
+
+
+def _net_brace_delta_outside_strings(text: str) -> int:
+    """Net ``{ vs }`` delta in ``text``, ignoring chars inside JSON
+    string literals.
+
+    Tracks a tiny string-state machine: characters inside a
+    double-quoted JSON string are skipped (including escaped quotes
+    via ``\\"``). Only braces outside strings count toward the depth.
+    This prevents string contents like ``"pattern": "}}"`` from
+    artificially closing the JSON body — codex round-5 finding #4.
+    """
+    delta = 0
+    in_string = False
+    escape = False
+    for ch in text:
+        if in_string:
+            if escape:
+                escape = False
+                continue
+            if ch == "\\":
+                escape = True
+                continue
+            if ch == '"':
+                in_string = False
+            continue
+        if ch == '"':
+            in_string = True
+            continue
+        if ch == "{":
+            delta += 1
+        elif ch == "}":
+            delta -= 1
+    return delta
 
 
 def _partial_tool_call_open_suffix(text: str) -> int:

--- a/vllm_mlx/reasoning/think_parser.py
+++ b/vllm_mlx/reasoning/think_parser.py
@@ -1438,7 +1438,39 @@ class BaseThinkingReasoningParser(ReasoningParser):
                 else:
                     out_reasoning.append(remaining)
                 return
-            # Emit prefix as reasoning, start buffering from opener.
+            # Structural guard — parity with non-streaming
+            # ``_TOOL_CALL_UNCLOSED_RE`` (``<tool_call>\s*[\{<]``).
+            # A real tool_call body starts with ``{`` (JSON) or ``<``
+            # (XML opener) after the tag and optional whitespace.
+            # A prose mention like ``use <tool_call> to invoke ...``
+            # has no structural opener after the tag and must NOT be
+            # promoted — otherwise the prose tail leaks into the
+            # content channel via the buffer.
+            after_start = start_idx + len(_TOOL_CALL_START)
+            probe = remaining[after_start:]
+            # Skip whitespace looking for the first non-ws byte.
+            j = 0
+            while j < len(probe) and probe[j] in (" ", "\t", "\n", "\r"):
+                j += 1
+            if j == len(probe):
+                # All whitespace (or empty) after the opener — the
+                # discriminating byte hasn't arrived yet. Emit the
+                # prefix as reasoning and carry the tag + trailing
+                # whitespace so the next chunk reveals whether this
+                # is a real tool_call or a prose mention.
+                if start_idx > 0:
+                    out_reasoning.append(remaining[:start_idx])
+                self._reasoning_carry = remaining[start_idx:]
+                return
+            if probe[j] not in ("{", "<"):
+                # Prose mention — emit up to AND INCLUDING the bare
+                # ``<tool_call>`` tag as reasoning and keep scanning
+                # ``remaining`` past the opener for another candidate.
+                out_reasoning.append(remaining[:after_start])
+                remaining = remaining[after_start:]
+                continue
+            # Real tool_call: emit prefix as reasoning, start buffering
+            # from the opener.
             if start_idx > 0:
                 out_reasoning.append(remaining[:start_idx])
             self._in_tool_call = True

--- a/vllm_mlx/reasoning/think_parser.py
+++ b/vllm_mlx/reasoning/think_parser.py
@@ -1325,8 +1325,16 @@ class BaseThinkingReasoningParser(ReasoningParser):
         # streaming wire shape matches the non-streaming wire shape
         # exactly. This is upstream's ``_transition_to_content``
         # catch-all in spirit, recast in our wrapper.
+        #
+        # The shortcut is ONLY safe when no prior chunk left a partial
+        # ``<tool_call>`` opener carry — otherwise delegating to the
+        # non-streaming promoter would see only ``r_in`` and silently
+        # drop ``self._reasoning_carry``. When a carry exists, fall
+        # through to the per-channel state machine so
+        # ``_absorb_reasoning_chunk`` re-prepends the carry first.
         if (
             not self._in_tool_call
+            and not self._reasoning_carry
             and r_in
             and c_in is not None
             and _TOOL_CALL_START in r_in


### PR DESCRIPTION
## Summary

PR #896 was merged before the codex review-loop completed; this follow-up addresses 5 BLOCKING diff findings the review surfaced over rounds 2-5. All fixes are in the `<tool_call>` promotion code paths (streaming filter, finalize merge, DeepSeek threshold, prose-trim heuristic).

* **r2 — structural guard for streaming path** (medium): `_absorb_reasoning_chunk` entered the buffer on any `<tool_call>` substring, unlike the non-streaming `_TOOL_CALL_UNCLOSED_RE` which requires `\s*[\{<]`. Chunked SSE delivery of a prose mention like `use <tool_call> to invoke functions` leaked the prose tail into content. Fix: peek next non-whitespace byte; carry tag forward if discriminating byte hasn't arrived yet.

* **r2 — single-delta promotion shortcut ignored `_reasoning_carry`** (medium): the catch-all at the top of `extract_reasoning_streaming` ran even with a carried partial opener, silently dropping the carried prefix. Fix: gate on `not self._reasoning_carry`.

* **r3 — finalize duplicates / leaks buffered tool_call** (medium): `finalize_streaming_compat` appended `_flush_pending_tool_call()` output without removing the same buffered bytes from `msg.content`/`msg.reasoning`. Natural EOS → duplicated `<tool_call>` block; `finish_reason="length"` → tool_call appeared in BOTH reasoning AND content. Fix: strip trailing buffered span from both channels using `rfind`-position (not first-occurrence `replace`, which the r4 review correctly flagged could corrupt an earlier completed block).

* **r4 — DeepSeek no-tag threshold bypassed promotion** (high): the `NO_TAG_CONTENT_THRESHOLD` early-return emitted `DeltaMessage(content=delta_text)` and stranded any open `_tool_call_buffer` / `_reasoning_carry`. r5 review then surfaced that the original r4 fix only flushed the buffer — the carry was still dropped. Fix: drain both buffer AND carry into the threshold-crossing content delta.

* **r4 — prose-boundary heuristic truncated pretty-printed JSON** (medium): a line lacking `<`, `{`, `}` was classified as prose, splitting valid multi-line JSON tool calls at the first value line. Fix: track `{…}` net depth with a string-aware scanner that ignores braces inside JSON string literals (r5 caught the string-aware part).

## Test plan

- [x] `pytest tests/test_tool_call_promotion.py` — 42 pass (was 29 on the merged PR; +13 regression tests covering the five fixes above + chunked-streaming parametrizations)
- [x] Broader sweep: `pytest tests/ -k 'reasoning or think_parser or tool_call_promotion or anthropic or responses'` — 1921 pass
- [x] `ruff format --check` + `ruff check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)