### PR TITLE
feat(aliases): add Tmax-9B + Tmax-27B MLX aliases (mlx-community first-mover)

### DIFF
--- a/scripts/tmax_strip_vision.py
+++ b/scripts/tmax_strip_vision.py
@@ -30,11 +30,10 @@ from __future__ import annotations
 
 import argparse
 import json
-import os
 import shutil
 import sys
+from collections.abc import Iterable
 from pathlib import Path
-from typing import Iterable
 
 try:
     from safetensors import safe_open
@@ -97,7 +96,7 @@ def _strip_shard(shard_path: Path, prefixes: Iterable[str]) -> tuple[int, int]:
     dropped: list[str] = []
     kept_keys: list[str] = []
     with safe_open(str(shard_path), framework="numpy") as f:
-        for k in f.keys():
+        for k in f:
             if _key_has_vision_prefix(k, prefixes):
                 dropped.append(k)
             else:
@@ -137,7 +136,9 @@ def _prune_index(index_path: Path, prefixes: Iterable[str], dir_path: Path) -> b
     return True
 
 
-def strip(snapshot_dir: Path, prefixes: Iterable[str] = DEFAULT_VISION_PREFIXES) -> dict:
+def strip(
+    snapshot_dir: Path, prefixes: Iterable[str] = DEFAULT_VISION_PREFIXES
+) -> dict:
     snapshot_dir = Path(snapshot_dir)
     report: dict = {"dir": str(snapshot_dir), "shards": []}
 

--- a/scripts/tmax_strip_vision.py
+++ b/scripts/tmax_strip_vision.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""
+Idempotent vision-strip scrubber for Tmax (Qwen3.5 multimodal) bases.
+
+Tmax 9B/27B bases ship with `model_type: qwen3_5` (multimodal) but currently
+contain ZERO vision-tower tensors in their safetensors. The plan is to publish
+text-only MLX variants. This script makes a snapshot directory loadable by
+`mlx_lm` (which already drops `vision_tower`/`model.visual` keys in its
+`qwen3_5.Model.sanitize`) and by quantizers that don't expect a vision config.
+
+Operations (all skipped if already done):
+
+1. Strip `vision_config`, `image_token_id`, `video_token_id`,
+   `vision_start_token_id`, `vision_end_token_id` from `config.json`.
+   If `architectures` is `Qwen3_5ForConditionalGeneration`, rewrite to
+   `Qwen3_5ForCausalLM` (text-only equivalent).
+2. For every safetensors shard: drop any tensor whose key starts with a
+   probed vision prefix (default: `vision_tower.`, `model.visual.`, `visual.`).
+   In Tmax bases there are NONE — this is a defensive no-op.
+3. If `model.safetensors.index.json` exists, prune the weight_map and recompute
+   `metadata.total_size`.
+
+Usage:
+    python scripts/tmax_strip_vision.py <snapshot_dir> [--prefix vision_tower. ...]
+
+The script is idempotent: running it twice is a no-op the second time.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import sys
+from pathlib import Path
+from typing import Iterable
+
+try:
+    from safetensors import safe_open
+    from safetensors.numpy import save_file as save_numpy  # type: ignore
+except ImportError:  # pragma: no cover
+    safe_open = None
+    save_numpy = None
+
+DEFAULT_VISION_PREFIXES = ("vision_tower.", "model.visual.", "visual.")
+VISION_CONFIG_KEYS = (
+    "vision_config",
+    "image_token_id",
+    "video_token_id",
+    "vision_start_token_id",
+    "vision_end_token_id",
+)
+
+
+def _strip_config(cfg_path: Path) -> bool:
+    cfg = json.loads(cfg_path.read_text())
+    changed = False
+    for k in VISION_CONFIG_KEYS:
+        if k in cfg:
+            cfg.pop(k)
+            changed = True
+    archs = cfg.get("architectures") or []
+    new_archs = []
+    for a in archs:
+        if a == "Qwen3_5ForConditionalGeneration":
+            new_archs.append("Qwen3_5ForCausalLM")
+            changed = True
+        else:
+            new_archs.append(a)
+    if new_archs != archs:
+        cfg["architectures"] = new_archs
+    # language_model_only is a hint flag — drop it if present, it's no longer needed
+    if "language_model_only" in cfg:
+        cfg.pop("language_model_only")
+        changed = True
+    if changed:
+        cfg_path.write_text(json.dumps(cfg, indent=2))
+    return changed
+
+
+def _key_has_vision_prefix(key: str, prefixes: Iterable[str]) -> bool:
+    return any(key.startswith(p) for p in prefixes)
+
+
+def _strip_shard(shard_path: Path, prefixes: Iterable[str]) -> tuple[int, int]:
+    """Return (kept_count, dropped_count). Rewrites in place only if drops > 0.
+
+    Uses safetensors' numpy framework so we don't need a torch dependency just
+    to drop tensors. Note: bf16 round-trips via numpy's view-as-bytes path that
+    safetensors handles internally, but to avoid any dtype coercion we only
+    rewrite when we actually need to drop tensors.
+    """
+    if safe_open is None or save_numpy is None:
+        raise RuntimeError("safetensors (with numpy) not installed")
+    # First pass: just list keys to decide whether we even need to rewrite.
+    dropped: list[str] = []
+    kept_keys: list[str] = []
+    with safe_open(str(shard_path), framework="numpy") as f:
+        for k in f.keys():
+            if _key_has_vision_prefix(k, prefixes):
+                dropped.append(k)
+            else:
+                kept_keys.append(k)
+    if not dropped:
+        return (len(kept_keys), 0)
+    # Need to rewrite. Load only the kept tensors (numpy view) and save out.
+    kept: dict = {}
+    with safe_open(str(shard_path), framework="numpy") as f:
+        for k in kept_keys:
+            kept[k] = f.get_tensor(k)
+    tmp = shard_path.with_suffix(".safetensors.tmp")
+    save_numpy(kept, str(tmp))
+    shutil.move(str(tmp), str(shard_path))
+    return (len(kept_keys), len(dropped))
+
+
+def _prune_index(index_path: Path, prefixes: Iterable[str], dir_path: Path) -> bool:
+    idx = json.loads(index_path.read_text())
+    wm = idx.get("weight_map", {})
+    new_wm = {k: v for k, v in wm.items() if not _key_has_vision_prefix(k, prefixes)}
+    if new_wm == wm:
+        return False
+    idx["weight_map"] = new_wm
+    # recompute total_size
+    total = 0
+    seen_shards: set[str] = set()
+    for shard in new_wm.values():
+        if shard in seen_shards:
+            continue
+        seen_shards.add(shard)
+        total += (dir_path / shard).stat().st_size
+    if "metadata" not in idx:
+        idx["metadata"] = {}
+    idx["metadata"]["total_size"] = total
+    index_path.write_text(json.dumps(idx, indent=2))
+    return True
+
+
+def strip(snapshot_dir: Path, prefixes: Iterable[str] = DEFAULT_VISION_PREFIXES) -> dict:
+    snapshot_dir = Path(snapshot_dir)
+    report: dict = {"dir": str(snapshot_dir), "shards": []}
+
+    cfg = snapshot_dir / "config.json"
+    if cfg.exists():
+        report["config_changed"] = _strip_config(cfg)
+    else:
+        report["config_changed"] = False
+
+    shards = sorted(snapshot_dir.glob("*.safetensors"))
+    total_dropped = 0
+    for shard in shards:
+        kept, dropped = _strip_shard(shard, prefixes)
+        total_dropped += dropped
+        report["shards"].append({"shard": shard.name, "kept": kept, "dropped": dropped})
+    report["total_dropped"] = total_dropped
+
+    idx = snapshot_dir / "model.safetensors.index.json"
+    if idx.exists():
+        report["index_changed"] = _prune_index(idx, prefixes, snapshot_dir)
+    else:
+        report["index_changed"] = False
+
+    return report
+
+
+def main(argv=None):
+    p = argparse.ArgumentParser()
+    p.add_argument("snapshot_dir")
+    p.add_argument(
+        "--prefix",
+        action="append",
+        default=None,
+        help="Vision tensor key prefix (repeatable). Default: vision_tower. model.visual. visual.",
+    )
+    args = p.parse_args(argv)
+    prefixes = args.prefix or list(DEFAULT_VISION_PREFIXES)
+    rep = strip(Path(args.snapshot_dir), prefixes)
+    print(json.dumps(rep, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -82,6 +82,69 @@
     "is_moe": true,
     "pflash_tier": "verified"
   },
+  "tmax-9b": {
+    "hf_path": "mlx-community/Tmax-9B-MLX-4bit",
+    "tool_call_parser": "qwen3_xml",
+    "is_hybrid": false,
+    "is_hybrid_explicit": true,
+    "is_moe": false,
+    "supports_spec_decode": false,
+    "pflash_tier": "unknown"
+  },
+  "tmax-9b-6bit": {
+    "hf_path": "mlx-community/Tmax-9B-MLX-6bit",
+    "tool_call_parser": "qwen3_xml",
+    "is_hybrid": false,
+    "is_hybrid_explicit": true,
+    "is_moe": false,
+    "supports_spec_decode": false,
+    "pflash_tier": "unknown"
+  },
+  "tmax-9b-8bit": {
+    "hf_path": "mlx-community/Tmax-9B-MLX-8bit",
+    "tool_call_parser": "qwen3_xml",
+    "is_hybrid": false,
+    "is_hybrid_explicit": true,
+    "is_moe": false,
+    "supports_spec_decode": false,
+    "pflash_tier": "unknown"
+  },
+  "tmax-9b-bf16": {
+    "hf_path": "mlx-community/Tmax-9B-MLX-bf16",
+    "tool_call_parser": "qwen3_xml",
+    "is_hybrid": false,
+    "is_hybrid_explicit": true,
+    "is_moe": false,
+    "supports_spec_decode": false,
+    "pflash_tier": "unknown"
+  },
+  "tmax-27b": {
+    "hf_path": "mlx-community/Tmax-27B-MLX-4bit",
+    "tool_call_parser": "qwen3_xml",
+    "is_hybrid": false,
+    "is_hybrid_explicit": true,
+    "is_moe": false,
+    "supports_spec_decode": false,
+    "pflash_tier": "unknown"
+  },
+  "tmax-27b-6bit": {
+    "hf_path": "mlx-community/Tmax-27B-MLX-6bit",
+    "tool_call_parser": "qwen3_xml",
+    "is_hybrid": false,
+    "is_hybrid_explicit": true,
+    "is_moe": false,
+    "supports_spec_decode": false,
+    "pflash_tier": "unknown"
+  },
+  "tmax-27b-8bit": {
+    "hf_path": "mlx-community/Tmax-27B-MLX-8bit",
+    "tool_call_parser": "qwen3_xml",
+    "is_hybrid": false,
+    "is_hybrid_explicit": true,
+    "is_moe": false,
+    "supports_spec_decode": false,
+    "pflash_tier": "unknown"
+  },
   "qwen3.5-27b-8bit": {
     "hf_path": "mlx-community/Qwen3.5-27B-8bit",
     "tool_call_parser": "hermes",


### PR DESCRIPTION
## Summary

Adds 7 new aliases for the freshly-published `mlx-community/Tmax-{9B,27B}-MLX-*` text-only MLX conversions of `allenai/tmax-9b` and `allenai/tmax-27b`. These are first-mover uploads — there were no MLX conversions of either base before this PR.

### Alias table

| alias | repo | tool_call_parser |
| --- | --- | --- |
| `tmax-9b` (default) | https://huggingface.co/mlx-community/Tmax-9B-MLX-4bit | `qwen3_xml` |
| `tmax-9b-6bit` | https://huggingface.co/mlx-community/Tmax-9B-MLX-6bit | `qwen3_xml` |
| `tmax-9b-8bit` | https://huggingface.co/mlx-community/Tmax-9B-MLX-8bit | `qwen3_xml` |
| `tmax-9b-bf16` | https://huggingface.co/mlx-community/Tmax-9B-MLX-bf16 | `qwen3_xml` |
| `tmax-27b` (default) | https://huggingface.co/mlx-community/Tmax-27B-MLX-4bit | `qwen3_xml` |
| `tmax-27b-6bit` | https://huggingface.co/mlx-community/Tmax-27B-MLX-6bit | `qwen3_xml` |
| `tmax-27b-8bit` | https://huggingface.co/mlx-community/Tmax-27B-MLX-8bit | `qwen3_xml` |

All entries bind `tool_call_parser="qwen3_xml"` and intentionally omit `reasoning_parser`. The Tmax bases are RL-tuned descendants of Qwen3.5 and therefore inherit Qwen3.5's layer-type mix (24× linear_attention + 8× full_attention per their `config.json::layer_types`). They emit `<tool_call>{json}</tool_call>` XML — they share the qwen tool-format wire but lack the per-token think-tag scaffolding that the upstream Qwen3 reasoning parser keys on. The 27B in particular emits `<think>\n\n</think>` as an empty marker even on short prompts, which the qwen3 reasoning parser would interpret as live CoT to strip.

### Hybrid flag convention (intentional, mirrors Qwen3.5 / Qwen3.6 dense aliases)

Despite the underlying 24+8 layer mix, all 7 Tmax aliases ship with `is_hybrid: false` and `is_hybrid_explicit: true`. This is **deliberate** and mirrors the established convention used by the existing dense `qwen3.5-4b-4bit`, `qwen3.5-9b-*`, `qwen3.5-27b-*`, and `qwen3.6-27b-*` aliases.

The reason is documented in `vllm_mlx/model_auto_config.py` around line 999: `enrich_model_config`'s runtime ArraysCache probe was silently re-promoting these dense Qwen3.5 / Qwen3.6 aliases to `is_hybrid=true` at boot — which is the path that **wedges `metal::malloc` on the Qwen3.5-4B variant**. The fix (R6-C1) was to honor `is_hybrid_explicit=True` from the alias profile as authoritative and suppress the probe's promotion. Tmax inherits the same Qwen3.5 layer topology, so it requires the same treatment.

Evidence the runtime path is correct on this convention:
- `tests/test_aliases_contract.py` — 1240 tests pass, including the constraint that pins this exact `is_hybrid=false + is_hybrid_explicit=true` shape for the Qwen3.5/3.6 dense family.
- Smoke-tested locally on `rapid-mlx serve tmax-9b`: chat returned coherent thinking (`Paris.`), `get_weather({"city":"Paris"})` tool call fired with `finish_reason: tool_calls`, `qwen3_xml` parser bound correctly. No `metal::malloc` wedge.

`pflash_tier` is `"unknown"` for all 7 entries — promotion to `"verified"` is gated on bench data (the existing `test_aliases_contract::test_pflash_verified_aliases_are_qwen35_or_qwen36` enforces this).

### Vision-strip scrubber

Also adds `scripts/tmax_strip_vision.py` — the idempotent scrubber used during conversion. The upstream tmax bases ship with `Qwen3_5ForConditionalGeneration` (a multimodal arch) but contain **zero** vision-tower tensors in their safetensors. The script:

- removes `vision_config`, `image_token_id`, `video_token_id`, `vision_start_token_id`, `vision_end_token_id`, and `language_model_only` from `config.json`,
- rewrites `architectures` from `Qwen3_5ForConditionalGeneration` to `Qwen3_5ForCausalLM`,
- defensively drops any tensor under `vision_tower.*` / `model.visual.*` / `visual.*` (currently a no-op for Tmax),
- updates `model.safetensors.index.json` total_size when shards change.

This is what makes `mlx_lm.load()` succeed on the downloaded snapshot without needing a vision tower the weights don't contain.

### Conversion tooling note

The mlx-community uploads were quantized with `mlx-lm 0.31.3` rather than `mlx-vlm 0.3.12`: `mlx_vlm.qwen3_5.Model` always instantiates a `VisionModel(config.vision_config)` and will crash on these text-pure checkpoints. `mlx_lm/models/qwen3_5.py` already handles the same arch in text-only mode (its `Model.sanitize` drops `vision_tower.*` keys defensively), so it's the natural target.

## Test plan

- [x] `pytest tests/test_aliases_contract.py` — 1240 passed
- [x] All 7 HF repos verified end-to-end (create_repo → upload → list_repo_files → byte-count match)
- [x] Sanity-load `Paris.` prompt against every variant before push; all returned coherent text
- [x] Smoke-test `rapid-mlx serve tmax-9b` locally — chat (Paris/coherent thinking) and tool-call (`get_weather` with `{"city":"Paris"}`, `finish_reason: tool_calls`) both 200/sane; `qwen3_xml` parser bound correctly
- [x] Deferred — `pflash_tier` ships as `"unknown"` for all 7 entries; bench keep_ratio=0.20 is a prerequisite for promoting to `"verified"` in a follow-up, not a merge gate for this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
