### PR TITLE
chore: bump version to 0.8.18

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.8.17"
+version = "0.8.18"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## Release 0.8.18

Cuts a tag for the merged feature work below.

## What lands in 0.8.18

- #893 codex follow-ups (HIGH+P2)
- #894 audio `_serve_audio_mode` honors `--embedding-model` + `--served-model-name`
- #896 reasoning think_parser tool_call promotion (closes #344)
- #891 chat/responses auto-disable thinking when tools provided
- #897 audio text-mode AST contract harness
- #898 reasoning #344 codex r2-r5 BLOCKING fixes
- #895 chat/responses auto-disable thinking on casual chat completions
- #899 Tmax-9B + Tmax-27B MLX aliases (mlx-community first-mover)

## SOP note

Bump kept as its own commit (per release SOP: `auto-release.yml` only fires when the squash subject is exactly `chore: bump version to X.Y.Z`).

The `skip-version-bump` label is set because this PR only touches `pyproject.toml`; `version-check.yml` would otherwise reject pyproject-only PRs without a paired user-facing change.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>