### PR TITLE
fix(aliases): set is_hybrid: true on Tmax-27B variants

### DIFF
--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -121,7 +121,7 @@
   "tmax-27b": {
     "hf_path": "mlx-community/Tmax-27B-MLX-4bit",
     "tool_call_parser": "qwen3_xml",
-    "is_hybrid": false,
+    "is_hybrid": true,
     "is_hybrid_explicit": true,
     "is_moe": false,
     "supports_spec_decode": false,
@@ -130,7 +130,7 @@
   "tmax-27b-6bit": {
     "hf_path": "mlx-community/Tmax-27B-MLX-6bit",
     "tool_call_parser": "qwen3_xml",
-    "is_hybrid": false,
+    "is_hybrid": true,
     "is_hybrid_explicit": true,
     "is_moe": false,
     "supports_spec_decode": false,
@@ -139,7 +139,7 @@
   "tmax-27b-8bit": {
     "hf_path": "mlx-community/Tmax-27B-MLX-8bit",
     "tool_call_parser": "qwen3_xml",
-    "is_hybrid": false,
+    "is_hybrid": true,
     "is_hybrid_explicit": true,
     "is_moe": false,
     "supports_spec_decode": false,


### PR DESCRIPTION
## Summary
- Tmax-27B-MLX-{4,6,8}bit are hybrid Gated-DeltaNet models like Tmax-9B
- aliases.json was missing is_hybrid/is_hybrid_explicit on the 27B entries
- Loader detects hybrid at warmup via ArraysCache check so runtime was correct,
  but /v1/models and model_auto_config classification reported is_hybrid=false
- Cosmetic fix to align alias classification with reality

## Test plan
- [x] tests/test_aliases_contract.py
- [x] /v1/models reports is_hybrid: true after change