### PR TITLE
fix(model_auto_config): align V4/V5 routing with classifier (#893 follow-up)

### DIFF
--- a/tests/test_model_auto_config.py
+++ b/tests/test_model_auto_config.py
@@ -1379,10 +1379,32 @@ class TestWarnMisboundDeepseekV3Parser:
                 f"{cfg.tool_call_parser!r} — the two layers disagree."
             )
         else:
-            # Out-of-lineage today: auto-detect's parser (whatever it is)
-            # is the source of truth. The classifier MUST NOT promise
-            # something the registry will not deliver.
-            assert family is None
+            # Out-of-lineage today (codex r1 BLOCKING): the classifier
+            # MUST NOT promise V3-template lineage AND auto-detect MUST
+            # pin the legacy ``deepseek`` parser the registry currently
+            # ships for V4 / V5 — otherwise the test would still pass
+            # if a future regression flipped EITHER the registry back
+            # to a V3-family parser (the original #893 bug) OR the
+            # classifier back to ``"v3"``. Both halves of the alignment
+            # need an explicit assertion.
+            assert family is None, (
+                f"V4 / V5 classifier must return None today (no upstream "
+                f"V3-template tool envelope) — got {family!r} for "
+                f"{model_path!r}."
+            )
+            assert cfg is not None, (
+                f"auto-detect must still resolve {model_path!r} via the "
+                "DeepSeek regex chain — got None."
+            )
+            assert cfg.tool_call_parser == "deepseek", (
+                f"V4 / V5 must route to the legacy 'deepseek' parser "
+                f"today (V4 chat template is tool-less per deepseek-ai "
+                f"discussion #16) — got {cfg.tool_call_parser!r} for "
+                f"{model_path!r}. If this is intentional, BOTH the "
+                f"registry AND the classifier need to be updated "
+                f"together (see #893 codex MED rationale)."
+            )
+            assert cfg.tool_call_parser not in _DEEPSEEK_V3_FAMILY_PARSERS
 
     @pytest.mark.parametrize(
         "model_path",

--- a/tests/test_model_auto_config.py
+++ b/tests/test_model_auto_config.py
@@ -883,10 +883,22 @@ class TestWarnMisboundDeepseekV3Parser:
             is None
         )
 
-    # In-spec: V3-line checkpoints (V3 / R1-0528 / V4 / V5) emit the V3
-    # fenced-JSON body, matched by deepseek_v3 / deepseek_r1_0528.
-    # V3.1-line checkpoints emit the V3.1 plain-JSON body, matched by
-    # deepseek_v31. Matching combos warn nothing.
+    # In-spec: V3-line checkpoints (V3 / R1-0528) emit the V3 fenced-JSON
+    # body, matched by deepseek_v3 / deepseek_r1_0528. V3.1-line
+    # checkpoints emit the V3.1 plain-JSON body, matched by deepseek_v31.
+    # Matching combos warn nothing.
+    #
+    # Note (#893 codex MED): V4 / V5 are intentionally NOT in this table.
+    # An earlier revision included them under a "forward-cover" reading
+    # of the upstream V4 model card, but the actual ``_MODEL_PATTERNS``
+    # entry routes V4 / V4-Flash to the LEGACY ``deepseek`` parser
+    # (V4 is chat-only with no tools today). So a user explicitly
+    # binding ``--tool-call-parser=deepseek_v3`` to a V4 / V5 path is
+    # making a real misbind — the helper should warn, not stay silent.
+    # When V4 / V5 ship a V3 fenced-JSON tool envelope upstream, update
+    # both layers together (the ``_MODEL_PATTERNS`` registry AND
+    # ``_classify_deepseek_template_name``) and add V4 / V5 entries
+    # here.
     @pytest.mark.parametrize(
         "model_path,parser",
         [
@@ -896,10 +908,6 @@ class TestWarnMisboundDeepseekV3Parser:
             ("mlx-community/DeepSeek-V3-0324-4bit", "deepseek_v3"),
             ("deepseek-ai/DeepSeek-V3.1-0324", "deepseek_v31"),
             ("mlx-community/DeepSeek-V3.1-MLX-4bit", "deepseek_v31"),
-            # Forward-cover V4 / V5 — V3 template lineage per upstream
-            # V4 card. The helper should accept these without warning.
-            ("deepseek-ai/DeepSeek-V4", "deepseek_v3"),
-            ("mlx-community/DeepSeek-V5-MLX-4bit", "deepseek_v3"),
         ],
     )
     def test_no_warn_for_matching_sub_family(self, model_path, parser):
@@ -910,6 +918,12 @@ class TestWarnMisboundDeepseekV3Parser:
     # lineage so the outer envelope matches, but the per-block body
     # shapes are incompatible — same empty-args failure as the
     # out-of-lineage case. The warning MUST fire here too.
+    #
+    # Note (#893 codex MED): V4 is no longer treated as V3-template
+    # lineage by the classifier — see ``test_no_warn_for_matching_sub_family``
+    # rationale above. V4 + ``deepseek_v31`` is covered by the
+    # out-of-lineage warning path
+    # (``test_warn_v4_v5_on_explicit_v3_family_override`` below).
     @pytest.mark.parametrize(
         "model_path,parser",
         [
@@ -920,7 +934,6 @@ class TestWarnMisboundDeepseekV3Parser:
             # V3-line model + V3.1 body parser → same.
             ("mlx-community/DeepSeek-R1-0528-Qwen3-8B-4bit", "deepseek_v31"),
             ("deepseek-ai/DeepSeek-V3-0324", "deepseek_v31"),
-            ("deepseek-ai/DeepSeek-V4", "deepseek_v31"),
         ],
     )
     def test_warn_on_cross_sub_family_misbind(self, model_path, parser):
@@ -1303,17 +1316,91 @@ class TestWarnMisboundDeepseekV3Parser:
             "``v5beta``, ``v3beta``, etc."
         )
 
-    # Counterpart: real V3 / V3.1 / V4 / V5 variants STILL match
-    # after the boundary tightening.
+    # Counterpart: real V3 / V3.1 variants STILL match after the
+    # boundary tightening. V4 / V5 are NOT in this table — see #893
+    # codex MED follow-up: V4 / V5 are out-of-lineage from the V3
+    # template family today (the classifier returns ``None`` for them,
+    # matching the legacy ``deepseek`` parser the registry pins), so a
+    # ``deepseek_v3`` binding on V4 / V5 is a real misbind that MUST
+    # warn (covered by ``test_warn_v4_v5_on_explicit_v3_family_override``
+    # below).
     @pytest.mark.parametrize(
         "model_path,parser",
         [
-            ("mlx-community/DeepSeek-V4-Flash-4bit", "deepseek_v3"),
-            ("deepseek-ai/DeepSeek-V4", "deepseek_v3"),
-            ("deepseek-ai/DeepSeek-V5", "deepseek_v3"),
             ("deepseek-ai/DeepSeek-V3-0324", "deepseek_v3"),
             ("deepseek-ai/DeepSeek-V3.1-0324", "deepseek_v31"),
         ],
     )
     def test_no_warn_on_real_versioned_variants(self, model_path, parser):
         assert warn_misbound_deepseek_v3_parser(model_path, parser) is None
+
+    # #893 codex MED — V4 / V5 classifier alignment with auto-detect.
+    # An earlier revision of ``_classify_deepseek_template_name`` returned
+    # ``"v3"`` for V4 / V5 paths (a "forward-cover" guess about future
+    # chat templates), but ``_MODEL_PATTERNS`` routed V4 / V4-Flash to
+    # the LEGACY ``deepseek`` parser AND the V4-Flash alias entries in
+    # ``aliases.json`` pin the same legacy parser. The two layers
+    # disagreed — and the disagreement was invisible to the misbind
+    # warning because the classifier "vouched" for the V3 family. This
+    # test pins the corrected contract: V4 / V5 are out-of-lineage
+    # today, so:
+    #
+    #   1. The classifier-vs-auto-detect parser must agree (no silent
+    #      forward-cover that the registry contradicts).
+    #   2. An explicit ``--tool-call-parser=deepseek_v3`` /
+    #      ``=deepseek_v31`` / ``=deepseek_r1_0528`` on a V4 / V5 path
+    #      MUST surface the out-of-lineage misbind warning.
+    @pytest.mark.parametrize(
+        "model_path",
+        [
+            "deepseek-ai/DeepSeek-V4",
+            "deepseek-ai/DeepSeek-V4-Flash",
+            "mlx-community/DeepSeek-V4-Flash-4bit",
+            "deepseek-ai/DeepSeek-V5",
+            "mlx-community/DeepSeek-V5-MLX-4bit",
+        ],
+    )
+    def test_v4_v5_classifier_matches_auto_detect_parser(self, model_path):
+        from vllm_mlx.model_auto_config import (
+            _DEEPSEEK_V3_FAMILY_PARSERS,
+            _classify_deepseek_template_name,
+        )
+
+        cfg = detect_model_config(model_path)
+        family = _classify_deepseek_template_name(model_path)
+        # The two layers must agree: if the classifier asserts a V3-template
+        # sub-family, auto-detect MUST pin a parser inside that family —
+        # otherwise ``rapid-mlx serve`` silently binds the wrong parser.
+        if family in {"v3", "v31"}:
+            assert cfg is not None
+            assert cfg.tool_call_parser in _DEEPSEEK_V3_FAMILY_PARSERS, (
+                f"classifier says {model_path} is V3-template family "
+                f"({family!r}) but auto-detect picks "
+                f"{cfg.tool_call_parser!r} — the two layers disagree."
+            )
+        else:
+            # Out-of-lineage today: auto-detect's parser (whatever it is)
+            # is the source of truth. The classifier MUST NOT promise
+            # something the registry will not deliver.
+            assert family is None
+
+    @pytest.mark.parametrize(
+        "model_path",
+        [
+            "deepseek-ai/DeepSeek-V4",
+            "mlx-community/DeepSeek-V4-Flash-4bit",
+            "deepseek-ai/DeepSeek-V5",
+        ],
+    )
+    @pytest.mark.parametrize(
+        "parser",
+        ["deepseek_v3", "deepseek_v31", "deepseek_r1_0528"],
+    )
+    def test_warn_v4_v5_on_explicit_v3_family_override(self, model_path, parser):
+        msg = warn_misbound_deepseek_v3_parser(model_path, parser)
+        assert msg is not None, (
+            f"V4 / V5 are not V3-template lineage today — explicit "
+            f"--tool-call-parser={parser!r} on {model_path!r} must warn."
+        )
+        assert parser in msg
+        assert model_path in msg

--- a/vllm_mlx/model_auto_config.py
+++ b/vllm_mlx/model_auto_config.py
@@ -761,18 +761,38 @@ def _classify_deepseek_template_name(s: str) -> str | None:
     # R1-0528 — the R1 retrain on the V3 chat template.
     if re.search(r"deepseek.*r1[-_]?0528", name):
         return "v3"
-    # Forward-cover V4 / V5 (per upstream V4 card both inherit the V3
-    # template). Require the ``v4`` / ``v5`` token to be terminated by
-    # end-of-string OR a separator character (``-``, ``_``, ``/``, ``.``,
-    # space) so future variants like ``DeepSeek-V40-*``,
-    # ``DeepSeek-V5Beta-*``, or ``DeepSeek-V42-MoE-*`` don't get
-    # silently classified as V3-template just because they share the
-    # ``v4`` / ``v5`` prefix (pr-validate codex r6 BLOCKING — the
-    # missing boundary was a real false-negative path). ``DeepSeek-V4``
-    # and ``DeepSeek-V4-Flash`` still match because the boundary is
-    # satisfied by end-of-string or ``-`` respectively.
-    if re.search(r"deepseek[-_]*v[45](?=[-_/.\s]|$)", name):
-        return "v3"
+    # NOTE on V4 / V5: an earlier revision of this classifier returned
+    # ``"v3"`` for ``DeepSeek-V[45]*`` as a "forward-cover" — the V4
+    # upstream model card mentioned the V3 chat template lineage, and
+    # the intent was to make the misbind warning suggest ``deepseek_v3``
+    # for users who pinned the wrong parser.
+    #
+    # That forward-cover was wrong in practice (#893 codex MED). The
+    # actual ``_MODEL_PATTERNS`` entry for V4 routes V4 / V4-Flash to
+    # the legacy ``deepseek`` parser (chat-only, no tools today — see
+    # the deepseek-ai discussion #16 referenced inline above), and the
+    # ``aliases.json`` entries for the MLX V4-Flash quants pin the same
+    # legacy parser. With the classifier returning ``"v3"`` but auto-
+    # detect picking ``"deepseek"``, the two layers contradicted:
+    #
+    #   * ``rapid-mlx serve deepseek-ai/DeepSeek-V4`` would silently bind
+    #     the legacy parser even though the classifier "knew" V4 should
+    #     be V3-family. The two answers disagreed and there was no
+    #     warning surface.
+    #   * ``--tool-call-parser=deepseek_v3`` on a V4 path returned no
+    #     misbind warning either — the in-spec gate at
+    #     ``warn_misbound_deepseek_v3_parser`` saw ``template == "v3"``
+    #     and the parser inside ``_DEEPSEEK_V3_BODY_PARSERS`` and
+    #     concluded "matching", even though the V4 wire shape is the
+    #     legacy V2.x envelope today.
+    #
+    # The honest minimal fix is to NOT speculate about V4 / V5 here at
+    # all. When V4 / V5 ship a tool-emitting chat template that does
+    # match the V3 fenced-JSON body shape, update BOTH layers
+    # simultaneously: the ``_MODEL_PATTERNS`` registry entry above, and
+    # this classifier. The misbind warning gate keys off the actual
+    # auto-detect parser, so the two stay aligned when they move
+    # together.
     return None
 
 


### PR DESCRIPTION
## Summary

PR #893 codex MED finding: `_classify_deepseek_template_name` returned `"v3"` for `DeepSeek-V[45]*` paths (a "forward-cover" guess), but `_MODEL_PATTERNS` routed V4 / V4-Flash to the legacy `deepseek` parser AND the MLX V4-Flash alias entries pinned the same legacy parser. The two layers silently disagreed:

1. **Result A** — `rapid-mlx serve deepseek-ai/DeepSeek-V4` bound the legacy `deepseek` parser even though the classifier "knew" V4 should be V3-template. No warning surface.
2. **Result B** — `--tool-call-parser=deepseek_v3` on a V4 / V5 path returned no misbind warning (PR #887's gate is bypassed). The in-spec gate saw `template == "v3"` and the parser inside `_DEEPSEEK_V3_BODY_PARSERS` and concluded "matching", even though V4's wire shape is the legacy V2.x envelope today.

## Path taken — B (honest minimal fix)

The V4/V5 forward-cover was speculation. The upstream V4 model card says the chat template is currently chat-only with no tools (deepseek-ai discussion #16), and BOTH `_MODEL_PATTERNS` AND `aliases.json` pin the legacy `deepseek` parser. Path A (aligning the registry up to `deepseek_v3`) would commit the project to a wire-shape that V4 doesn't emit today — that lies just in the other direction.

Removing V4 / V5 from `_classify_deepseek_template_name`:

- Stops the cross-layer contradiction. `detect_model_config` is now the single source of truth for V4 / V5 routing.
- Re-enables the PR #887 misbind warning for explicit `--tool-call-parser=deepseek_v3|v31|r1_0528` on V4 / V5 paths via the out-of-lineage branch (Result B fixed).
- Result A also fixed: there's no longer a hidden "classifier says X, registry does Y" mismatch — they both say "legacy `deepseek`" for V4 / V5 today.
- Does NOT touch the registry, the V4-Flash alias entries, or sprinkle V4/V5 special-cases anywhere. Single-layer fix.

When V4 / V5 ship a V3-template tool envelope upstream, update BOTH layers together (the `_MODEL_PATTERNS` entry AND the classifier) so they stay aligned.

## Verification (before the fix, on `main`)

```
deepseek-ai/DeepSeek-V4   classifier='v3'   auto_parser='deepseek'   <-- contradiction
deepseek-ai/DeepSeek-V5   classifier='v3'   auto_parser='deepseek'   <-- contradiction
warn_misbound_deepseek_v3_parser('deepseek-ai/DeepSeek-V4', 'deepseek_v3') -> None  <-- BUG
```

After the fix:

```
deepseek-ai/DeepSeek-V4   classifier=None   auto_parser='deepseek'   <-- aligned
warn_misbound_deepseek_v3_parser('deepseek-ai/DeepSeek-V4', 'deepseek_v3') -> "--tool-call-parser='deepseek_v3' is bound to 'deepseek-ai/DeepSeek-V4', which is NOT a DeepSeek-V3 chat-template checkpoint. [...]"
```

V3 / V3.1 / R1-0528 in-spec paths unchanged.

## Test plan

- [x] New `test_v4_v5_classifier_matches_auto_detect_parser` — pins the "classifier and auto-detect must agree on V3-family routing" invariant for V4 / V5 paths (the task spec test).
- [x] New `test_warn_v4_v5_on_explicit_v3_family_override` — asserts the misbind warning fires for every V3-family parser (`deepseek_v3`, `deepseek_v31`, `deepseek_r1_0528`) on V4 / V5 paths.
- [x] Removed V4 / V5 entries from `test_no_warn_for_matching_sub_family` and `test_no_warn_on_real_versioned_variants` tables — they encoded the bug.
- [x] `test_model_auto_config.py`: 201 / 201 pass
- [x] Wider `deepseek|v3|v4|v5|misbind|auto_config|aliases` sweep: 1769 / 1769 pass
- [x] `test_deepseek_v4` regex routing test still passes — V4 still routes to legacy `deepseek` parser, behavior preserved.

## Out of scope

- No version bump (will land in a separate release commit per SOP).
- No alias JSON edits.
- No CLI surface changes — `warn_misbound_deepseek_v3_parser` already emits the corrected message via existing copy.