### PR TITLE
test(infra): fix pr_validate full_unit flakes on macOS uv-managed Python

### DIFF
--- a/tests/test_pr_validate_test_env.py
+++ b/tests/test_pr_validate_test_env.py
@@ -156,9 +156,17 @@ class TestCheckTestEnv:
         venv_dir = tmp_path / "broken"
         import venv as _venv
 
-        # `with_pip=True` so we can install pytest into it; turn off
-        # symlinks to avoid permission surprises on weird filesystems.
-        _venv.create(venv_dir, with_pip=True, symlinks=False)
+        # ``with_pip=True`` so we can install pytest into it. Use
+        # ``symlinks=True`` (the POSIX default) — on macOS with a
+        # uv-managed CPython the python binary is dynamically linked
+        # against ``@rpath/libpython3.12.dylib``; with ``symlinks=False``
+        # the copied bin/python3.12 can't resolve the dylib and
+        # ensurepip's ``_call_new_python`` aborts with SIGABRT during
+        # venv bootstrap. The original comment about "permission
+        # surprises on weird filesystems" doesn't apply on tmp_path
+        # (always a real fs the test runner created itself), so the
+        # default-symlinks shape is both safer and correct here.
+        _venv.create(venv_dir, with_pip=True, symlinks=True)
         python = venv_dir / "bin" / "python"
         assert python.exists(), "venv builder didn't produce a python"
 

--- a/tests/test_signal_observability.py
+++ b/tests/test_signal_observability.py
@@ -54,7 +54,25 @@ def _read_ready_with_timeout(proc: subprocess.Popen, *, timeout: float = 10.0) -
             f"subprocess did not emit READY within {timeout:.1f}s;"
             f" stdout-tail={out_tail!r}, stderr-tail={err_tail!r}"
         )
-    return proc.stdout.readline()
+    line = proc.stdout.readline()
+    if line == "":
+        # EOF on stdout — the subprocess died before printing READY.
+        # ``select`` returns ready on EOF too, so we hit this branch
+        # without a timeout. Surface stderr so the operator sees the
+        # actual crash reason instead of a cryptic ``assert '' ==
+        # 'READY'`` with no diagnostic context. This is the only
+        # signal-test mode where we get an empty readline; under
+        # normal operation the child writes ``READY\n`` exactly once
+        # before any signal can land.
+        try:
+            err_tail = proc.stderr.read() or ""
+        except (OSError, ValueError):
+            err_tail = "<stderr read failed>"
+        raise AssertionError(
+            "subprocess died before emitting READY;"
+            f" returncode={proc.returncode!r}, stderr={err_tail!r}"
+        )
+    return line
 
 
 def test_install_is_idempotent_and_saves_prior_handlers():


### PR DESCRIPTION
## Summary

Two pre-existing test-only flakes block `pr_validate`'s `full_unit` gate for every PR on macOS Apple Silicon with uv-managed CPython. Both root-caused and fixed:

### Fix 1 — `tests/test_pr_validate_test_env.py:161` (deterministic SIGABRT)
- `venv.create(..., symlinks=False)` copies python binary; uv-managed cpython-3.12.13 is linked against `@rpath/libpython3.12.dylib` → @rpath no longer resolves → ensurepip dies with SIGABRT during bootstrap
- Fix: `symlinks=True` (POSIX default). Original comment about "weird filesystems" doesn't apply on pytest `tmp_path` (always real fs)
- Verified: deterministic SIGABRT reproduces + fix clears it. Full suite passes twice clean

### Fix 2 — `tests/test_signal_observability.py:_read_ready_with_timeout` (correlated flake + diagnostic)
- Helper silently returns `""` on EOF; caller's `assert '' == 'READY'` fires with no diagnostic
- Strong hypothesis: macOS ReportCrash contention from Fix-1 SIGABRTs causes fork pressure for the SIGHUP subprocess test (3 pr_validate sub-runs → ~6 ReportCrash invocations). Fixing Fix 1 eliminates the contention
- Defensive helper improvement: surface stderr on EOF so any next failure has real diagnostic
- Verified: full suite passes 4-for-4 after Fix 1; helper change is happy-path-neutral

Both changes are tests-only — **zero runtime impact**.

Confidence: 100% on Fix 1 (deterministic, fully understood). ~70% Fix 2's flake is correlated and goes with Fix 1; defensive change ensures any residual flake is diagnosable.

## Test plan
- [x] `uv run pytest tests/test_pr_validate_test_env.py -v` passes
- [x] `uv run pytest tests/test_signal_observability.py -v` passes (10/10)
- [x] Full suite passes (10104 tests) 4-for-4 in worktree post-fix
- [x] CI matrix (3.10/3.11/3.12 + Apple Silicon)