### PR TITLE
chore: bump version to 0.8.19

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.8.18"
+version = "0.8.19"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## Summary

Release 0.8.19 — rollup of fixes merged after 0.8.18:

- #902 `fix(aliases)`: set `is_hybrid: true` on Tmax-27B variants
- #903 `fix(model_auto_config)`: align DeepSeek V4/V5 routing with classifier (#893 follow-up)
- #904 `fix(responses)`: default input item type to `"message"` when role+content present (R11-E user-facing 400)
- #905 `fix(serve)`: exit non-zero on port-already-in-use (R13 Sven B1 — supervisors now detect failed start)
- #906 `fix(chat,responses)`: thread `enable_thinking` into prompt accounting (#891 follow-up — eliminates spurious request rejection)
- #907 `test(infra)`: fix pr_validate full_unit flakes on macOS uv-managed Python (deterministic dyld @rpath SIGABRT + correlated signal-test flake)

## Test plan
- [x] All 6 PRs above had GitHub CI green (test-matrix 3.10/3.11/3.12 + test-apple-silicon)
- [x] Each PR passed codex review (1-3 rounds)
- [x] No runtime regressions across changes — surface-level fixes only

Triggers auto-release.yml → tag v0.8.19 → GitHub Release → PyPI + Homebrew publish.