### PR TITLE
feat(guardrail): warn on MoE+MXFP4+multi-device cliff (mlx#3402, #297)

### DIFF
--- a/tests/test_mxfp4_moe_guardrail.py
+++ b/tests/test_mxfp4_moe_guardrail.py
@@ -323,9 +323,7 @@ def test_ring_backend_three_tuple_fires_e2e(monkeypatch, tmp_path, caplog):
     assert "world_size=2" in joined
 
 
-def test_world_size_uses_max_across_signals_not_first_match(
-    monkeypatch, tmp_path
-):
+def test_world_size_uses_max_across_signals_not_first_match(monkeypatch, tmp_path):
     """Codex round 7 BLOCKING: a stale env var must not mask a larger signal.
 
     Upstream ``mlx/distributed_run.py`` preserves the parent env when
@@ -611,9 +609,7 @@ def test_render_prometheus_lines_exposes_both_counters():
     assert "rapid_mlx_nvfp4_moe_warnings_total" in body
     # Counter type discoverable via TYPE line — required by Prometheus
     # exposition format spec.
-    assert (
-        "# TYPE rapid_mlx_mxfp4_moe_distributed_warnings_total counter" in body
-    )
+    assert "# TYPE rapid_mlx_mxfp4_moe_distributed_warnings_total counter" in body
     assert "# TYPE rapid_mlx_nvfp4_moe_warnings_total counter" in body
     # Values were both bumped to 1.
     assert "rapid_mlx_mxfp4_moe_distributed_warnings_total 1" in body

--- a/tests/test_mxfp4_moe_guardrail.py
+++ b/tests/test_mxfp4_moe_guardrail.py
@@ -323,40 +323,45 @@ def test_ring_backend_three_tuple_fires_e2e(monkeypatch, tmp_path, caplog):
     assert "world_size=2" in joined
 
 
-def test_world_size_never_calls_mlx_distributed_init(monkeypatch):
-    """Codex #297 BLOCKING regression: the probe must NOT call init().
+def test_guardrail_module_never_references_mx_distributed_init():
+    """Codex #297 BLOCKING regression: the guardrail must NOT call init().
 
     ``mx.distributed.init()`` creates the global communication group and
     can block while a backend handshakes — calling it from a warning-only
     guardrail would be a real side effect on the engine that follows.
-    Pin the contract: replace ``init`` with a sentinel that explodes if
-    invoked, then exercise the probe under each branch.
+
+    We pin the contract by **static source inspection** rather than a
+    runtime monkeypatch on the live ``mlx.core`` module. Importing
+    ``mlx.core`` purely for the patch reintroduced a heavy MLX import
+    into an otherwise pure guardrail test (codex round 5); on a host
+    with MLX installed but no usable Metal device, ``import mlx.core``
+    can abort the process with ``NSRangeException``. Reading the
+    source text instead is cheap, robust across hosts, and
+    semantically equivalent to "the code doesn't call init()".
     """
-    import mlx.core as mx
+    import inspect
+    import re
 
-    sentinel_called = []
-
-    def _explode(*args, **kwargs):  # pragma: no cover — must NOT run
-        sentinel_called.append(True)
-        raise AssertionError(
-            "mx.distributed.init() called from guardrail probe — "
-            "see codex review on #297 BLOCKING #1"
-        )
-
-    monkeypatch.setattr(mx.distributed, "init", _explode)
-    # Probe with no env set — must return 1 without touching init.
-    for v in (
-        "MLX_WORLD_SIZE",
-        "OMPI_COMM_WORLD_SIZE",
-        "PMI_SIZE",
-        "MLX_HOSTFILE",
-    ):
-        monkeypatch.delenv(v, raising=False)
-    assert g._detect_distributed_world_size() == 1
-    # And with an env set — same contract.
-    monkeypatch.setenv("MLX_WORLD_SIZE", "4")
-    assert g._detect_distributed_world_size() == 4
-    assert sentinel_called == []
+    src = inspect.getsource(g)
+    # Strip comments and docstrings: triple-quoted strings + ``# ...``
+    # tails. The contract is "no executable call to .init(", so
+    # documentation mentioning ``mx.distributed.init()`` (the entire
+    # raison d'être of the guardrail) must not trip the check.
+    stripped = re.sub(r'"""[\s\S]*?"""', "", src)
+    stripped = re.sub(r"#.*", "", stripped)
+    # The forbidden pattern is any executable call to ``.init(`` on
+    # mx.distributed / mlx.core.distributed. Plain ``distributed.init``
+    # without an open paren is harmless (it's just an attribute ref
+    # passed to e.g. monkeypatch.setattr in test scaffolding, which
+    # this production module never does).
+    forbidden = re.compile(r"distributed\s*\.\s*init\s*\(")
+    matches = forbidden.findall(stripped)
+    assert matches == [], (
+        f"Guardrail module must not call mx.distributed.init() "
+        f"(see codex review on #297 BLOCKING #1) — found "
+        f"{len(matches)} match(es) in source after docstring/comment "
+        f"strip."
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_mxfp4_moe_guardrail.py
+++ b/tests/test_mxfp4_moe_guardrail.py
@@ -165,6 +165,72 @@ def test_counters_monotonic_across_repeated_fires():
 
 
 # ---------------------------------------------------------------------------
+# _detect_distributed_world_size — env-var-based, non-mutating
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "env_var",
+    ["MLX_WORLD_SIZE", "OMPI_COMM_WORLD_SIZE", "PMI_SIZE"],
+)
+def test_world_size_reads_launcher_env_vars(monkeypatch, env_var):
+    """Each launcher env var on its own should be enough to report > 1."""
+    # Make sure none of the *other* launcher vars leak through from the
+    # test runner's environment.
+    for v in ("MLX_WORLD_SIZE", "OMPI_COMM_WORLD_SIZE", "PMI_SIZE"):
+        monkeypatch.delenv(v, raising=False)
+    monkeypatch.setenv(env_var, "8")
+    assert g._detect_distributed_world_size() == 8
+
+
+def test_world_size_defaults_to_one_when_no_env(monkeypatch):
+    """No launcher vars set → assume single-device (size 1)."""
+    for v in ("MLX_WORLD_SIZE", "OMPI_COMM_WORLD_SIZE", "PMI_SIZE"):
+        monkeypatch.delenv(v, raising=False)
+    assert g._detect_distributed_world_size() == 1
+
+
+def test_world_size_ignores_garbage(monkeypatch):
+    """Non-integer values fall through to the next var / default."""
+    for v in ("MLX_WORLD_SIZE", "OMPI_COMM_WORLD_SIZE", "PMI_SIZE"):
+        monkeypatch.delenv(v, raising=False)
+    monkeypatch.setenv("MLX_WORLD_SIZE", "not-an-int")
+    monkeypatch.setenv("OMPI_COMM_WORLD_SIZE", "4")
+    assert g._detect_distributed_world_size() == 4
+
+
+def test_world_size_never_calls_mlx_distributed_init(monkeypatch):
+    """Codex #297 BLOCKING regression: the probe must NOT call init().
+
+    ``mx.distributed.init()`` creates the global communication group and
+    can block while a backend handshakes — calling it from a warning-only
+    guardrail would be a real side effect on the engine that follows.
+    Pin the contract: replace ``init`` with a sentinel that explodes if
+    invoked, then exercise the probe under each branch.
+    """
+    import mlx.core as mx
+
+    sentinel_called = []
+
+    def _explode(*args, **kwargs):  # pragma: no cover — must NOT run
+        sentinel_called.append(True)
+        raise AssertionError(
+            "mx.distributed.init() called from guardrail probe — "
+            "see codex review on #297 BLOCKING #1"
+        )
+
+    monkeypatch.setattr(mx.distributed, "init", _explode)
+    # Probe with no env set — must return 1 without touching init.
+    for v in ("MLX_WORLD_SIZE", "OMPI_COMM_WORLD_SIZE", "PMI_SIZE"):
+        monkeypatch.delenv(v, raising=False)
+    assert g._detect_distributed_world_size() == 1
+    # And with an env set — same contract.
+    monkeypatch.setenv("MLX_WORLD_SIZE", "4")
+    assert g._detect_distributed_world_size() == 4
+    assert sentinel_called == []
+
+
+# ---------------------------------------------------------------------------
 # check_from_profile — adapter from server.load_model() call site
 # ---------------------------------------------------------------------------
 

--- a/tests/test_mxfp4_moe_guardrail.py
+++ b/tests/test_mxfp4_moe_guardrail.py
@@ -323,6 +323,69 @@ def test_ring_backend_three_tuple_fires_e2e(monkeypatch, tmp_path, caplog):
     assert "world_size=2" in joined
 
 
+def test_world_size_uses_max_across_signals_not_first_match(
+    monkeypatch, tmp_path
+):
+    """Codex round 7 BLOCKING: a stale env var must not mask a larger signal.
+
+    Upstream ``mlx/distributed_run.py`` preserves the parent env when
+    spawning ring workers and then adds ``MLX_HOSTFILE``. A developer
+    who exports ``MLX_WORLD_SIZE=1`` in their shell (or who inherited
+    it from a previous single-host run) would, under a "first match
+    wins" probe, see the hostfile silently masked at 1 — exactly the
+    case the guardrail is supposed to catch.
+
+    Fix: probe returns ``max(candidates)``. Set up a stale env var of
+    1 alongside a real 4-host hostfile, and assert the probe returns
+    4, not 1.
+    """
+    import json
+
+    for v in (
+        "MLX_WORLD_SIZE",
+        "OMPI_COMM_WORLD_SIZE",
+        "PMI_SIZE",
+        "MLX_HOSTFILE",
+    ):
+        monkeypatch.delenv(v, raising=False)
+    # Stale single-device env var leaked in from a parent shell.
+    monkeypatch.setenv("MLX_WORLD_SIZE", "1")
+    # Real ring hostfile says 4 nodes.
+    hostfile = tmp_path / "hosts.json"
+    hostfile.write_text(
+        json.dumps(
+            [
+                {"ssh": "node-0", "ips": ["10.0.0.1"]},
+                {"ssh": "node-1", "ips": ["10.0.0.2"]},
+                {"ssh": "node-2", "ips": ["10.0.0.3"]},
+                {"ssh": "node-3", "ips": ["10.0.0.4"]},
+            ]
+        )
+    )
+    monkeypatch.setenv("MLX_HOSTFILE", str(hostfile))
+    # Max-of-signals semantics: 1 (env) max 4 (hostfile) == 4.
+    assert g._detect_distributed_world_size() == 4
+
+
+def test_world_size_max_picks_largest_env_var(monkeypatch):
+    """Multiple env vars with different values → take the max.
+
+    Defends against scenarios where an MPI shim leaves ``PMI_SIZE=1``
+    while the NCCL launcher set ``MLX_WORLD_SIZE=8``.
+    """
+    for v in (
+        "MLX_WORLD_SIZE",
+        "OMPI_COMM_WORLD_SIZE",
+        "PMI_SIZE",
+        "MLX_HOSTFILE",
+    ):
+        monkeypatch.delenv(v, raising=False)
+    monkeypatch.setenv("PMI_SIZE", "1")
+    monkeypatch.setenv("MLX_WORLD_SIZE", "8")
+    monkeypatch.setenv("OMPI_COMM_WORLD_SIZE", "4")
+    assert g._detect_distributed_world_size() == 8
+
+
 def test_guardrail_module_never_references_mx_distributed_init():
     """Codex #297 BLOCKING regression: the guardrail must NOT call init().
 

--- a/tests/test_mxfp4_moe_guardrail.py
+++ b/tests/test_mxfp4_moe_guardrail.py
@@ -177,7 +177,12 @@ def test_world_size_reads_launcher_env_vars(monkeypatch, env_var):
     """Each launcher env var on its own should be enough to report > 1."""
     # Make sure none of the *other* launcher vars leak through from the
     # test runner's environment.
-    for v in ("MLX_WORLD_SIZE", "OMPI_COMM_WORLD_SIZE", "PMI_SIZE"):
+    for v in (
+        "MLX_WORLD_SIZE",
+        "OMPI_COMM_WORLD_SIZE",
+        "PMI_SIZE",
+        "MLX_HOSTFILE",
+    ):
         monkeypatch.delenv(v, raising=False)
     monkeypatch.setenv(env_var, "8")
     assert g._detect_distributed_world_size() == 8
@@ -185,18 +190,137 @@ def test_world_size_reads_launcher_env_vars(monkeypatch, env_var):
 
 def test_world_size_defaults_to_one_when_no_env(monkeypatch):
     """No launcher vars set → assume single-device (size 1)."""
-    for v in ("MLX_WORLD_SIZE", "OMPI_COMM_WORLD_SIZE", "PMI_SIZE"):
+    for v in (
+        "MLX_WORLD_SIZE",
+        "OMPI_COMM_WORLD_SIZE",
+        "PMI_SIZE",
+        "MLX_HOSTFILE",
+    ):
         monkeypatch.delenv(v, raising=False)
     assert g._detect_distributed_world_size() == 1
 
 
 def test_world_size_ignores_garbage(monkeypatch):
     """Non-integer values fall through to the next var / default."""
-    for v in ("MLX_WORLD_SIZE", "OMPI_COMM_WORLD_SIZE", "PMI_SIZE"):
+    for v in (
+        "MLX_WORLD_SIZE",
+        "OMPI_COMM_WORLD_SIZE",
+        "PMI_SIZE",
+        "MLX_HOSTFILE",
+    ):
         monkeypatch.delenv(v, raising=False)
     monkeypatch.setenv("MLX_WORLD_SIZE", "not-an-int")
     monkeypatch.setenv("OMPI_COMM_WORLD_SIZE", "4")
     assert g._detect_distributed_world_size() == 4
+
+
+def test_world_size_from_mlx_hostfile_ring_backend(monkeypatch, tmp_path):
+    """Ring backend (Apple Silicon default) — count entries in MLX_HOSTFILE.
+
+    The ring backend is the precise target of mlx#3402. Upstream
+    ``mlx/distributed_run.py`` sets ``MLX_HOSTFILE`` (path to a JSON
+    array of host descriptors) but NOT ``MLX_WORLD_SIZE`` on the ring
+    path. The guardrail must still report world_size > 1 here.
+    """
+    import json
+
+    for v in (
+        "MLX_WORLD_SIZE",
+        "OMPI_COMM_WORLD_SIZE",
+        "PMI_SIZE",
+        "MLX_HOSTFILE",
+    ):
+        monkeypatch.delenv(v, raising=False)
+    # Match the upstream hostfile format from
+    # ``mlx.distributed_run.parse_hostfile``: a JSON array of
+    # ``{ssh, ips}`` host objects.
+    hostfile = tmp_path / "hosts.json"
+    hostfile.write_text(
+        json.dumps(
+            [
+                {"ssh": "node-0", "ips": ["10.0.0.1"]},
+                {"ssh": "node-1", "ips": ["10.0.0.2"]},
+                {"ssh": "node-2", "ips": ["10.0.0.3"]},
+            ]
+        )
+    )
+    monkeypatch.setenv("MLX_HOSTFILE", str(hostfile))
+    assert g._detect_distributed_world_size() == 3
+
+
+def test_world_size_from_mlx_hostfile_single_host(monkeypatch, tmp_path):
+    """A single-host hostfile reports 1 — not multi-device."""
+    import json
+
+    for v in (
+        "MLX_WORLD_SIZE",
+        "OMPI_COMM_WORLD_SIZE",
+        "PMI_SIZE",
+        "MLX_HOSTFILE",
+    ):
+        monkeypatch.delenv(v, raising=False)
+    hostfile = tmp_path / "hosts.json"
+    hostfile.write_text(json.dumps([{"ssh": "node-0", "ips": ["10.0.0.1"]}]))
+    monkeypatch.setenv("MLX_HOSTFILE", str(hostfile))
+    assert g._detect_distributed_world_size() == 1
+
+
+def test_world_size_unreadable_hostfile_falls_through(monkeypatch):
+    """A garbage / missing hostfile path is silently treated as size 1."""
+    for v in (
+        "MLX_WORLD_SIZE",
+        "OMPI_COMM_WORLD_SIZE",
+        "PMI_SIZE",
+        "MLX_HOSTFILE",
+    ):
+        monkeypatch.delenv(v, raising=False)
+    monkeypatch.setenv("MLX_HOSTFILE", "/nonexistent/path/that/should/not/be/here")
+    assert g._detect_distributed_world_size() == 1
+
+
+def test_ring_backend_three_tuple_fires_e2e(monkeypatch, tmp_path, caplog):
+    """End-to-end: ring backend hostfile + MoE + MXFP4 → cliff warning.
+
+    This is the exact scenario mlx#3402 documents (M3 Ultra distributed
+    GLM-5.1 / DeepSeek-V3.2), so it's the most important guardrail case
+    to cover end-to-end through the adapter.
+    """
+    import json
+    import logging
+
+    caplog.set_level(logging.WARNING, logger=g.logger.name)
+    for v in (
+        "MLX_WORLD_SIZE",
+        "OMPI_COMM_WORLD_SIZE",
+        "PMI_SIZE",
+        "MLX_HOSTFILE",
+    ):
+        monkeypatch.delenv(v, raising=False)
+    hostfile = tmp_path / "hosts.json"
+    hostfile.write_text(
+        json.dumps(
+            [
+                {"ssh": "node-0", "ips": ["10.0.0.1"]},
+                {"ssh": "node-1", "ips": ["10.0.0.2"]},
+            ]
+        )
+    )
+    monkeypatch.setenv("MLX_HOSTFILE", str(hostfile))
+
+    class _RingProfile:
+        # Inline stand-in for AliasProfile so this test stays
+        # self-contained (the broader _FakeProfile is defined below).
+        hf_path = "nightmedia/Qwen3.5-122B-A10B-Text-mxfp4-mlx"
+        is_moe = True
+
+    fired = g.check_from_profile(
+        model_name="qwen3.5-122b-mxfp4",
+        profile=_RingProfile(),
+        alias="qwen3.5-122b-mxfp4",
+    )
+    assert fired == ["mxfp4_moe_distributed"]
+    joined = " ".join(r.message for r in caplog.records)
+    assert "world_size=2" in joined
 
 
 def test_world_size_never_calls_mlx_distributed_init(monkeypatch):
@@ -221,7 +345,12 @@ def test_world_size_never_calls_mlx_distributed_init(monkeypatch):
 
     monkeypatch.setattr(mx.distributed, "init", _explode)
     # Probe with no env set — must return 1 without touching init.
-    for v in ("MLX_WORLD_SIZE", "OMPI_COMM_WORLD_SIZE", "PMI_SIZE"):
+    for v in (
+        "MLX_WORLD_SIZE",
+        "OMPI_COMM_WORLD_SIZE",
+        "PMI_SIZE",
+        "MLX_HOSTFILE",
+    ):
         monkeypatch.delenv(v, raising=False)
     assert g._detect_distributed_world_size() == 1
     # And with an env set — same contract.

--- a/tests/test_mxfp4_moe_guardrail.py
+++ b/tests/test_mxfp4_moe_guardrail.py
@@ -437,9 +437,34 @@ def test_check_from_profile_nvfp4_moe(monkeypatch, caplog):
 # ---------------------------------------------------------------------------
 
 
+class _StubCfg:
+    """Tiny duck-typed stand-in for ServerConfig used by /metrics tests.
+
+    Built locally to keep this test file independent of the global
+    ServerConfig singleton — codex round 3 flagged that pulling
+    ``vllm_mlx.config.get_config()`` widens the import surface beyond
+    the guardrail module itself (the route module pulls in BaseEngine,
+    which is harmless on a dev box but unwelcome for a focused unit
+    test). The renderer only ever reads ``cfg.engine`` and
+    ``cfg.model_name`` from the cfg parameter, so a struct with those
+    two attributes is enough to drive it.
+    """
+
+    engine = None
+    model_name = "stub-model"
+
+
 def test_metrics_endpoint_exposes_guardrail_counters():
-    """The Prometheus exposition format must carry both new counters."""
-    from vllm_mlx.config import get_config
+    """The Prometheus exposition format must carry both new counters.
+
+    Drives the renderer with a stub cfg so the test is independent of
+    the global ServerConfig singleton (codex round 3). The
+    ``cfg.engine is None`` branch of ``_render_prometheus`` still emits
+    the build_info + response_format + guardrail counters because each
+    of those blocks lives BEFORE the engine-None early return in
+    ``routes/metrics.py`` — which is exactly the contract we're
+    asserting.
+    """
     from vllm_mlx.routes import metrics as metrics_module
 
     # Trip both counters once each so the rendered body shows non-zero
@@ -455,8 +480,7 @@ def test_metrics_endpoint_exposes_guardrail_counters():
         alias="b",
     )
 
-    cfg = get_config()
-    body = metrics_module._render_prometheus(cfg)
+    body = metrics_module._render_prometheus(_StubCfg())
 
     assert "rapid_mlx_mxfp4_moe_distributed_warnings_total" in body
     assert "rapid_mlx_nvfp4_moe_warnings_total" in body
@@ -469,3 +493,23 @@ def test_metrics_endpoint_exposes_guardrail_counters():
     # Values were both bumped to 1.
     assert "rapid_mlx_mxfp4_moe_distributed_warnings_total 1" in body
     assert "rapid_mlx_nvfp4_moe_warnings_total 1" in body
+
+
+def test_metrics_guardrail_counters_visible_before_engine_ready():
+    """Counters MUST surface before the engine-None early return.
+
+    Operators alerting on the cliff need the metric series visible
+    from process startup, BEFORE the first model load completes — the
+    guardrail fires AT load time, so by the time the engine is
+    ``ready=True`` the warning event has already passed. The renderer
+    early-returns when ``cfg.engine is None``, so the guardrail
+    counters must be emitted above that return.
+    """
+    from vllm_mlx.routes import metrics as metrics_module
+
+    # engine=None branch — the renderer's "no engine yet" path.
+    body = metrics_module._render_prometheus(_StubCfg())
+    # Both counters are visible (HELP + TYPE lines emitted), even
+    # though the counter VALUES are 0 in this freshly-reset state.
+    assert "# TYPE rapid_mlx_mxfp4_moe_distributed_warnings_total counter" in body
+    assert "# TYPE rapid_mlx_nvfp4_moe_warnings_total counter" in body

--- a/tests/test_mxfp4_moe_guardrail.py
+++ b/tests/test_mxfp4_moe_guardrail.py
@@ -437,36 +437,16 @@ def test_check_from_profile_nvfp4_moe(monkeypatch, caplog):
 # ---------------------------------------------------------------------------
 
 
-class _StubCfg:
-    """Tiny duck-typed stand-in for ServerConfig used by /metrics tests.
+def test_render_prometheus_lines_exposes_both_counters():
+    """The pure render helper emits HELP/TYPE/sample for both counters.
 
-    Built locally to keep this test file independent of the global
-    ServerConfig singleton — codex round 3 flagged that pulling
-    ``vllm_mlx.config.get_config()`` widens the import surface beyond
-    the guardrail module itself (the route module pulls in BaseEngine,
-    which is harmless on a dev box but unwelcome for a focused unit
-    test). The renderer only ever reads ``cfg.engine`` and
-    ``cfg.model_name`` from the cfg parameter, so a struct with those
-    two attributes is enough to drive it.
+    This test deliberately calls ``render_prometheus_lines()`` directly
+    instead of going through ``vllm_mlx.routes.metrics``. The route
+    module's transitive import closure pulls in ``vllm_mlx.config`` →
+    ``BaseEngine`` → the engine stack, which codex rounds 3/4 flagged
+    as too heavy for a focused unit test. The new pure helper lives
+    in the guardrail module so a single ``import`` is enough.
     """
-
-    engine = None
-    model_name = "stub-model"
-
-
-def test_metrics_endpoint_exposes_guardrail_counters():
-    """The Prometheus exposition format must carry both new counters.
-
-    Drives the renderer with a stub cfg so the test is independent of
-    the global ServerConfig singleton (codex round 3). The
-    ``cfg.engine is None`` branch of ``_render_prometheus`` still emits
-    the build_info + response_format + guardrail counters because each
-    of those blocks lives BEFORE the engine-None early return in
-    ``routes/metrics.py`` — which is exactly the contract we're
-    asserting.
-    """
-    from vllm_mlx.routes import metrics as metrics_module
-
     # Trip both counters once each so the rendered body shows non-zero
     # values rather than just the HELP/TYPE lines.
     g.check_load_time_guardrails(
@@ -480,7 +460,8 @@ def test_metrics_endpoint_exposes_guardrail_counters():
         alias="b",
     )
 
-    body = metrics_module._render_prometheus(_StubCfg())
+    lines = g.render_prometheus_lines()
+    body = "\n".join(lines)
 
     assert "rapid_mlx_mxfp4_moe_distributed_warnings_total" in body
     assert "rapid_mlx_nvfp4_moe_warnings_total" in body
@@ -495,21 +476,15 @@ def test_metrics_endpoint_exposes_guardrail_counters():
     assert "rapid_mlx_nvfp4_moe_warnings_total 1" in body
 
 
-def test_metrics_guardrail_counters_visible_before_engine_ready():
-    """Counters MUST surface before the engine-None early return.
+def test_render_prometheus_lines_zero_state():
+    """At fresh state both counters render as 0 (Prometheus contract).
 
     Operators alerting on the cliff need the metric series visible
-    from process startup, BEFORE the first model load completes — the
-    guardrail fires AT load time, so by the time the engine is
-    ``ready=True`` the warning event has already passed. The renderer
-    early-returns when ``cfg.engine is None``, so the guardrail
-    counters must be emitted above that return.
+    from process startup, BEFORE any guardrail has fired. The pure
+    renderer must always emit both series with at-least-zero values.
     """
-    from vllm_mlx.routes import metrics as metrics_module
-
-    # engine=None branch — the renderer's "no engine yet" path.
-    body = metrics_module._render_prometheus(_StubCfg())
-    # Both counters are visible (HELP + TYPE lines emitted), even
-    # though the counter VALUES are 0 in this freshly-reset state.
-    assert "# TYPE rapid_mlx_mxfp4_moe_distributed_warnings_total counter" in body
-    assert "# TYPE rapid_mlx_nvfp4_moe_warnings_total counter" in body
+    # Counters reset by the autouse fixture, so call render directly.
+    lines = g.render_prometheus_lines()
+    body = "\n".join(lines)
+    assert "rapid_mlx_mxfp4_moe_distributed_warnings_total 0" in body
+    assert "rapid_mlx_nvfp4_moe_warnings_total 0" in body

--- a/tests/test_mxfp4_moe_guardrail.py
+++ b/tests/test_mxfp4_moe_guardrail.py
@@ -442,6 +442,82 @@ def test_check_from_profile_nvfp4_moe(monkeypatch, caplog):
 # ---------------------------------------------------------------------------
 
 
+# ---------------------------------------------------------------------------
+# Real-aliases regression: every MXFP4/NVFP4 alias must carry is_moe so the
+# guardrail actually fires in production (codex round 6 BLOCKING).
+# ---------------------------------------------------------------------------
+
+
+def test_all_mxfp4_aliases_carry_is_moe_metadata():
+    """Every MXFP4 alias in ``aliases.json`` MUST have ``is_moe: true``.
+
+    Codex round 6 BLOCKING: ``gpt-oss-20b-mxfp4-q8`` and
+    ``minimax-m2.7-mxfp4`` were shipped with implicit ``is_moe=false``
+    (the field defaulted) even though both are MoE architectures
+    (gpt-oss is the OpenAI mixture-of-experts family; MiniMax-Text is
+    ~456B total / ~46B active). With ``is_moe=false`` the guardrail
+    returns BEFORE the warning, leaving production alerts inert on the
+    exact aliases the cliff most affects.
+
+    This test walks every alias whose HF path embeds the ``mxfp4``
+    token (case-insensitive) and asserts ``is_moe=True`` is wired
+    through ``resolve_profile`` — the same code path
+    ``server.load_model()`` uses at runtime. Any future MXFP4 alias
+    added without ``is_moe: true`` will trip this test, so the
+    guardrail can never silently regress to inert again.
+    """
+    from vllm_mlx.model_aliases import list_profiles, resolve_profile
+
+    mxfp4_aliases: list[str] = []
+    for alias, profile in list_profiles().items():
+        if "mxfp4" in profile.hf_path.lower():
+            mxfp4_aliases.append(alias)
+
+    # Defensive — if the alias registry no longer carries any MXFP4
+    # entries (all retired), the test would silently pass. Pin a floor
+    # so the test still catches the regression next time someone adds
+    # an MXFP4 alias.
+    assert mxfp4_aliases, (
+        "Expected at least one MXFP4 alias in the registry; if all are "
+        "retired, remove this test along with the rest of the guardrail."
+    )
+
+    for alias in mxfp4_aliases:
+        profile = resolve_profile(alias)
+        assert profile is not None
+        assert profile.is_moe, (
+            f"alias {alias!r} (hf_path={profile.hf_path!r}) is an MXFP4 "
+            f"variant but ``is_moe=False`` — the mlx#3402 guardrail will "
+            f"NEVER fire for this alias. Set ``is_moe: true`` in "
+            f"aliases.json."
+        )
+
+
+def test_all_nvfp4_aliases_carry_is_moe_metadata():
+    """Every NVFP4 alias must also carry ``is_moe: true`` for mlx#2962.
+
+    Symmetric counterpart to the MXFP4 test. There are currently no
+    NVFP4 aliases shipped, but a future one added without ``is_moe``
+    would silently bypass the dynamic-range-loss warning.
+    """
+    from vllm_mlx.model_aliases import list_profiles, resolve_profile
+
+    nvfp4_aliases = [
+        alias
+        for alias, profile in list_profiles().items()
+        if "nvfp4" in profile.hf_path.lower()
+    ]
+
+    for alias in nvfp4_aliases:
+        profile = resolve_profile(alias)
+        assert profile is not None
+        assert profile.is_moe, (
+            f"alias {alias!r} (hf_path={profile.hf_path!r}) is an NVFP4 "
+            f"variant but ``is_moe=False`` — the mlx#2962 guardrail will "
+            f"NEVER fire. Set ``is_moe: true`` in aliases.json."
+        )
+
+
 def test_render_prometheus_lines_exposes_both_counters():
     """The pure render helper emits HELP/TYPE/sample for both counters.
 

--- a/tests/test_mxfp4_moe_guardrail.py
+++ b/tests/test_mxfp4_moe_guardrail.py
@@ -1,0 +1,276 @@
+# SPDX-License-Identifier: Apache-2.0
+"""R15 task #297 — load-time guardrail for the MoE+MXFP4+multi-device cliff.
+
+Covers the detection matrix for the two upstream MLX issues exposed by
+``vllm_mlx/_mxfp4_moe_guardrail.py``:
+
+* mlx#3402 — MoE + MXFP4 + multi-device throughput cliff
+  (3-of-3 → fire; any 2-of-3 → silent).
+* mlx#2962 — MoE + NVFP4 dynamic-range loss
+  (fires regardless of device count, MoE required).
+
+The tests are pure: every signal is constructed by hand via
+:class:`GuardrailSignal`, so we don't pull any MoE weights from disk
+just to exercise the guardrail (per the task disk-hygiene constraint).
+The mlx.distributed probe is exercised through ``check_from_profile``
+with monkeypatched detectors so we don't need a real MPI run either.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from vllm_mlx import _mxfp4_moe_guardrail as g
+
+
+@pytest.fixture(autouse=True)
+def _reset_guardrail_state():
+    """Zero the module counters around every test for isolation."""
+    g.reset_for_tests()
+    yield
+    g.reset_for_tests()
+
+
+# ---------------------------------------------------------------------------
+# _detect_quant_format — path-name heuristic
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "hf_path,expected",
+    [
+        ("mlx-community/MiniMax-M2.7-4bit-mxfp4", "mxfp4"),
+        ("nightmedia/Qwen3.5-122B-A10B-Text-mxfp4-mlx", "mxfp4"),
+        ("mlx-community/gpt-oss-20b-MXFP4-Q8", "mxfp4"),  # case-insensitive
+        ("vendor/Some-Model-NVFP4", "nvfp4"),
+        ("vendor/some-nvfp4-moe", "nvfp4"),
+        ("mlx-community/Qwen3-7B-4bit", None),
+        ("mlx-community/DeepSeek-R1-0528-Qwen3-8B-4bit", None),
+        ("", None),
+        (None, None),
+    ],
+)
+def test_detect_quant_format(hf_path, expected):
+    """Path-name heuristic detects mxfp4/nvfp4 case-insensitively."""
+    assert g._detect_quant_format(hf_path) == expected
+
+
+def test_detect_quant_format_mxfp4_wins_over_nvfp4():
+    """When both tokens are present, the louder mxfp4 warning wins."""
+    # Synthetic — no real model carries both, but the priority matters.
+    assert g._detect_quant_format("vendor/weird-mxfp4-nvfp4") == "mxfp4"
+
+
+# ---------------------------------------------------------------------------
+# check_load_time_guardrails — the 3-flag matrix
+# ---------------------------------------------------------------------------
+
+
+def _signal(is_moe, quant, world):
+    return g.GuardrailSignal(
+        is_moe=is_moe,
+        quant_format=quant,
+        distributed_world_size=world,
+    )
+
+
+def test_three_tuple_fires_mxfp4_moe_distributed_warning(caplog):
+    """The full 3-of-3 match fires the cliff warning and bumps the counter."""
+    caplog.set_level(logging.WARNING, logger=g.logger.name)
+    fired = g.check_load_time_guardrails(
+        _signal(is_moe=True, quant="mxfp4", world=2),
+        hf_path="vendor/some-moe-mxfp4",
+        alias="some-alias",
+    )
+    assert fired == ["mxfp4_moe_distributed"]
+    assert g.snapshot()["mxfp4_moe_distributed_warnings_total"] == 1
+    assert g.snapshot()["nvfp4_moe_warnings_total"] == 0
+    # Warning carries the upstream issue link so operators can self-route.
+    joined = " ".join(r.message for r in caplog.records)
+    assert g.MLX_3402_URL in joined
+    assert "mxfp4" in joined.lower() or "MXFP4" in joined
+
+
+@pytest.mark.parametrize(
+    "is_moe,quant,world,label",
+    [
+        # 2-of-3 misses: MoE off
+        (False, "mxfp4", 4, "no_moe"),
+        # 2-of-3 misses: quant off
+        (True, None, 4, "no_mxfp4"),
+        (True, "int4", 4, "wrong_quant"),
+        # 2-of-3 misses: single-device
+        (True, "mxfp4", 1, "single_device"),
+        # 1-of-3 / 0-of-3
+        (False, None, 1, "none"),
+        (False, "mxfp4", 1, "mxfp4_only"),
+        (True, None, 1, "moe_only"),
+        (False, None, 4, "distributed_only"),
+    ],
+)
+def test_two_of_three_does_not_fire_cliff(is_moe, quant, world, label):
+    """Any 2-of-3 combo stays silent for the cliff guardrail."""
+    fired = g.check_load_time_guardrails(
+        _signal(is_moe=is_moe, quant=quant, world=world),
+        hf_path=f"vendor/{label}",
+        alias=label,
+    )
+    # The MoE+NVFP4 guardrail is independent — it must not fire for any
+    # of these cases either (none of them carry nvfp4).
+    assert "mxfp4_moe_distributed" not in fired
+    assert "nvfp4_moe" not in fired
+    assert g.snapshot()["mxfp4_moe_distributed_warnings_total"] == 0
+    assert g.snapshot()["nvfp4_moe_warnings_total"] == 0
+
+
+def test_nvfp4_moe_fires_regardless_of_device_count(caplog):
+    """mlx#2962 dynamic-range loss bites even single-device."""
+    caplog.set_level(logging.WARNING, logger=g.logger.name)
+    for world in (1, 2, 8):
+        g.reset_for_tests()
+        caplog.clear()
+        fired = g.check_load_time_guardrails(
+            _signal(is_moe=True, quant="nvfp4", world=world),
+            hf_path="vendor/nvfp4-moe",
+            alias="alias-x",
+        )
+        assert fired == ["nvfp4_moe"], f"world={world}"
+        assert g.snapshot()["nvfp4_moe_warnings_total"] == 1
+        joined = " ".join(r.message for r in caplog.records)
+        assert g.MLX_2962_URL in joined
+
+
+def test_nvfp4_without_moe_silent():
+    """NVFP4 + dense (non-MoE) does not trip the guardrail."""
+    fired = g.check_load_time_guardrails(
+        _signal(is_moe=False, quant="nvfp4", world=4),
+        hf_path="vendor/dense-nvfp4",
+        alias=None,
+    )
+    assert fired == []
+    assert g.snapshot()["nvfp4_moe_warnings_total"] == 0
+
+
+def test_counters_monotonic_across_repeated_fires():
+    """Counters must accumulate across repeated three-tuple loads."""
+    for _ in range(3):
+        g.check_load_time_guardrails(
+            _signal(is_moe=True, quant="mxfp4", world=2),
+            hf_path="vendor/x",
+            alias="x",
+        )
+    assert g.snapshot()["mxfp4_moe_distributed_warnings_total"] == 3
+
+
+# ---------------------------------------------------------------------------
+# check_from_profile — adapter from server.load_model() call site
+# ---------------------------------------------------------------------------
+
+
+class _FakeProfile:
+    """Minimal stand-in for AliasProfile — just is_moe + hf_path."""
+
+    def __init__(self, *, hf_path, is_moe):
+        self.hf_path = hf_path
+        self.is_moe = is_moe
+
+
+def test_check_from_profile_three_tuple(monkeypatch, caplog):
+    """Adapter path: AliasProfile + mocked distributed size triggers the cliff."""
+    caplog.set_level(logging.WARNING, logger=g.logger.name)
+    monkeypatch.setattr(g, "_detect_distributed_world_size", lambda: 4)
+    profile = _FakeProfile(
+        hf_path="nightmedia/Qwen3.5-122B-A10B-Text-mxfp4-mlx",
+        is_moe=True,
+    )
+    fired = g.check_from_profile(
+        model_name="qwen3.5-122b-mxfp4",
+        profile=profile,
+        alias="qwen3.5-122b-mxfp4",
+    )
+    assert fired == ["mxfp4_moe_distributed"]
+    assert g.snapshot()["mxfp4_moe_distributed_warnings_total"] == 1
+
+
+def test_check_from_profile_single_device_silent(monkeypatch):
+    """Adapter path: single-device default (world=1) stays silent on MoE+MXFP4."""
+    monkeypatch.setattr(g, "_detect_distributed_world_size", lambda: 1)
+    profile = _FakeProfile(
+        hf_path="nightmedia/Qwen3.5-122B-A10B-Text-mxfp4-mlx",
+        is_moe=True,
+    )
+    fired = g.check_from_profile(
+        model_name="qwen3.5-122b-mxfp4",
+        profile=profile,
+    )
+    assert fired == []
+    assert g.snapshot()["mxfp4_moe_distributed_warnings_total"] == 0
+
+
+def test_check_from_profile_no_profile_treated_as_non_moe(monkeypatch):
+    """A bare HF path with no alias is conservatively treated as non-MoE."""
+    monkeypatch.setattr(g, "_detect_distributed_world_size", lambda: 4)
+    # Path carries mxfp4 + we're distributed, but profile=None → no is_moe
+    # signal, so the guardrail stays silent. The conservative bias is
+    # documented in the module docstring.
+    fired = g.check_from_profile(
+        model_name="some/unknown-mxfp4-model",
+        profile=None,
+    )
+    assert fired == []
+
+
+def test_check_from_profile_nvfp4_moe(monkeypatch, caplog):
+    """Adapter path: NVFP4 + MoE fires regardless of mocked device count."""
+    caplog.set_level(logging.WARNING, logger=g.logger.name)
+    monkeypatch.setattr(g, "_detect_distributed_world_size", lambda: 1)
+    profile = _FakeProfile(
+        hf_path="vendor/some-nvfp4-moe",
+        is_moe=True,
+    )
+    fired = g.check_from_profile(
+        model_name="vendor/some-nvfp4-moe",
+        profile=profile,
+    )
+    assert fired == ["nvfp4_moe"]
+
+
+# ---------------------------------------------------------------------------
+# /metrics rendering — counters surface in Prometheus output
+# ---------------------------------------------------------------------------
+
+
+def test_metrics_endpoint_exposes_guardrail_counters():
+    """The Prometheus exposition format must carry both new counters."""
+    from vllm_mlx.config import get_config
+    from vllm_mlx.routes import metrics as metrics_module
+
+    # Trip both counters once each so the rendered body shows non-zero
+    # values rather than just the HELP/TYPE lines.
+    g.check_load_time_guardrails(
+        _signal(is_moe=True, quant="mxfp4", world=2),
+        hf_path="vendor/a",
+        alias="a",
+    )
+    g.check_load_time_guardrails(
+        _signal(is_moe=True, quant="nvfp4", world=1),
+        hf_path="vendor/b",
+        alias="b",
+    )
+
+    cfg = get_config()
+    body = metrics_module._render_prometheus(cfg)
+
+    assert "rapid_mlx_mxfp4_moe_distributed_warnings_total" in body
+    assert "rapid_mlx_nvfp4_moe_warnings_total" in body
+    # Counter type discoverable via TYPE line — required by Prometheus
+    # exposition format spec.
+    assert (
+        "# TYPE rapid_mlx_mxfp4_moe_distributed_warnings_total counter" in body
+    )
+    assert "# TYPE rapid_mlx_nvfp4_moe_warnings_total counter" in body
+    # Values were both bumped to 1.
+    assert "rapid_mlx_mxfp4_moe_distributed_warnings_total 1" in body
+    assert "rapid_mlx_nvfp4_moe_warnings_total 1" in body

--- a/vllm_mlx/_mxfp4_moe_guardrail.py
+++ b/vllm_mlx/_mxfp4_moe_guardrail.py
@@ -36,9 +36,14 @@ What the guardrail does at load time:
    ``aliases.json`` already names these variants
    (``qwen3.5-122b-mxfp4``, ``minimax-m2.7-mxfp4``, etc.) and stays
    robust without parsing each ``config.json`` quant block at load time.
-3. Detect multi-device dispatch via ``mlx.core.distributed.init().size()``
-   — the default group is size 1 on a single-host run, > 1 when
-   ``mpirun`` / ``mlx-launcher`` has wired up multiple devices.
+3. Detect multi-device dispatch via the launcher env vars
+   (``MLX_WORLD_SIZE`` / ``OMPI_COMM_WORLD_SIZE`` / ``PMI_SIZE``).
+   The env vars are authoritative because the launcher sets them
+   before the worker spawns and later passes them into
+   ``mlx.distributed.init()``. We avoid calling ``init()`` ourselves
+   because it has side effects (creates the global communication
+   group, can block while a backend handshakes) and a warning-only
+   guardrail must never mutate engine state.
 4. On the full three-tuple match, log a loud WARNING with the issue
    link and bump ``rapid_mlx_mxfp4_moe_distributed_warnings_total``.
 5. On a MoE + NVFP4 match (any device count — mlx#2962 dynamic-range
@@ -124,26 +129,44 @@ def _detect_quant_format(hf_path: str | None) -> Optional[str]:
 def _detect_distributed_world_size() -> int:
     """Return the active MLX distributed world size, or 1 as a safe default.
 
-    ``mlx.core.distributed.init()`` is idempotent — it returns the
-    current (or default) Group. On a vanilla single-host run the size
-    is 1; under ``mpirun`` / ``mlx-launcher`` it reflects the wired-up
-    device count.
+    **Non-mutating probe.** We deliberately do NOT call
+    ``mlx.core.distributed.init()`` here even though it would give the
+    exact group size, because ``init()`` is documented as creating the
+    global communication group — calling it purely for a metric/warning
+    probe would either (a) initialize an unwanted singleton group on
+    single-host runs or (b) block during startup if the distributed
+    environment is present but not yet ready (codex review #297).
+    Worse, ``backend="any"`` makes the first successful backend the
+    *global* group, which is a real side-effect on the engine that
+    follows.
 
-    Any import / probe failure returns 1 so the guardrail never blocks
-    load on a build that lacks the distributed module. Guardrails are
-    advisory, not enforcing.
+    Instead, we read the environment variables that ``mlx-launcher`` /
+    ``mlx.distributed_run`` and the common MPI launchers set before
+    they spawn the worker process:
+
+    * ``MLX_WORLD_SIZE`` — set by ``mlx-launcher`` / ``distributed_run``.
+    * ``OMPI_COMM_WORLD_SIZE`` — set by OpenMPI's ``mpirun``.
+    * ``PMI_SIZE`` — set by MPICH/Intel MPI launchers.
+
+    These variables are authoritative because they are what the launcher
+    later passes into ``init()``; if any of them is set to a value > 1
+    we are running under a multi-device dispatch regardless of whether
+    ``init()`` has been called yet. On a vanilla single-host run none
+    are set and we report 1.
     """
-    try:
-        import mlx.core as mx
+    import os
 
-        group = mx.distributed.init()
-        return int(group.size())
-    except Exception:  # pragma: no cover — defensive
-        logger.debug(
-            "mlx.distributed.init() probe failed; assuming size=1",
-            exc_info=True,
-        )
-        return 1
+    for env_var in ("MLX_WORLD_SIZE", "OMPI_COMM_WORLD_SIZE", "PMI_SIZE"):
+        raw = os.environ.get(env_var)
+        if not raw:
+            continue
+        try:
+            size = int(raw)
+        except ValueError:
+            continue
+        if size >= 1:
+            return size
+    return 1
 
 
 def _emit_mxfp4_moe_distributed_warning(

--- a/vllm_mlx/_mxfp4_moe_guardrail.py
+++ b/vllm_mlx/_mxfp4_moe_guardrail.py
@@ -169,6 +169,17 @@ def _detect_distributed_world_size() -> int:
     import json
     import os
 
+    # Compute the **max** across all available signals rather than
+    # returning the first non-empty one. Codex round 7 BLOCKING: the
+    # upstream ring launcher preserves the parent env and then ADDS
+    # ``MLX_HOSTFILE``; a stale / inherited ``MLX_WORLD_SIZE=1`` (or
+    # ``OMPI_COMM_WORLD_SIZE=1`` / ``PMI_SIZE=1``) from a developer's
+    # shell would otherwise short-circuit at 1 and mask a true
+    # multi-host hostfile that says 8. The max is the only reading
+    # that is robust against that env contamination AND gives the
+    # right answer when only one signal is present.
+    candidates: list[int] = [1]  # always include the single-device baseline
+
     # Direct integer env vars (NCCL + MPI launchers).
     for env_var in ("MLX_WORLD_SIZE", "OMPI_COMM_WORLD_SIZE", "PMI_SIZE"):
         raw = os.environ.get(env_var)
@@ -179,7 +190,7 @@ def _detect_distributed_world_size() -> int:
         except ValueError:
             continue
         if size >= 1:
-            return size
+            candidates.append(size)
 
     # Ring backend (Apple Silicon default) — count entries in the
     # JSON hostfile. The file is a JSON array of ``{ssh, ips}`` host
@@ -191,7 +202,7 @@ def _detect_distributed_world_size() -> int:
             with open(hostfile_path) as fp:
                 hosts = json.load(fp)
             if isinstance(hosts, list) and len(hosts) >= 1:
-                return len(hosts)
+                candidates.append(len(hosts))
         except Exception:  # pragma: no cover — defensive
             logger.debug(
                 "MLX_HOSTFILE=%s present but unreadable; treating as size 1",
@@ -199,7 +210,7 @@ def _detect_distributed_world_size() -> int:
                 exc_info=True,
             )
 
-    return 1
+    return max(candidates)
 
 
 def _emit_mxfp4_moe_distributed_warning(

--- a/vllm_mlx/_mxfp4_moe_guardrail.py
+++ b/vllm_mlx/_mxfp4_moe_guardrail.py
@@ -348,6 +348,52 @@ def snapshot() -> dict[str, int]:
         }
 
 
+# Help/TYPE/sample lines for the two counters, exposed as a pure helper
+# so unit tests can verify rendering WITHOUT importing
+# ``vllm_mlx.routes.metrics`` (which transitively imports the whole
+# engine stack via ``vllm_mlx.config`` → ``BaseEngine``).
+#
+# ``routes/metrics.py:_render_mxfp4_moe_guardrail_counters`` is a thin
+# wrapper that calls into this helper plus the shared formatting
+# primitives — so the rendered output stays bit-identical regardless of
+# which entry point the test uses.
+_MXFP4_MOE_HELP = (
+    "Load-time warnings fired for the MoE + MXFP4 + multi-device "
+    "throughput cliff (upstream mlx#3402). Any non-zero value means an "
+    "operator started a model matching the three-tuple; expect "
+    "~0.27 tok/s vs ~16 tok/s until upstream lands a fix."
+)
+_NVFP4_MOE_HELP = (
+    "Load-time warnings fired for the MoE + NVFP4 dynamic-range loss "
+    "(upstream mlx#2962, signed E4M3 scales instead of Blackwell "
+    "unsigned UE4M3 -> ~137x dynamic-range loss). Fires regardless of "
+    "device count because the dynamic-range loss bites even on "
+    "single-device serving."
+)
+
+
+def render_prometheus_lines() -> list[str]:
+    """Render the guardrail counters as Prometheus text-exposition lines.
+
+    Pure helper — does not touch the engine, does not import the route
+    module, does not depend on the global ``ServerConfig`` singleton.
+    Returns the standard HELP / TYPE / sample triplet for each counter
+    in stable order so dashboards / tests can pattern-match against the
+    output.
+    """
+    stats = snapshot()
+    mxfp4 = int(stats.get("mxfp4_moe_distributed_warnings_total", 0))
+    nvfp4 = int(stats.get("nvfp4_moe_warnings_total", 0))
+    return [
+        f"# HELP rapid_mlx_mxfp4_moe_distributed_warnings_total {_MXFP4_MOE_HELP}",
+        "# TYPE rapid_mlx_mxfp4_moe_distributed_warnings_total counter",
+        f"rapid_mlx_mxfp4_moe_distributed_warnings_total {mxfp4}",
+        f"# HELP rapid_mlx_nvfp4_moe_warnings_total {_NVFP4_MOE_HELP}",
+        "# TYPE rapid_mlx_nvfp4_moe_warnings_total counter",
+        f"rapid_mlx_nvfp4_moe_warnings_total {nvfp4}",
+    ]
+
+
 def reset_for_tests() -> None:
     """Test-only hook: zero the counters between cases.
 

--- a/vllm_mlx/_mxfp4_moe_guardrail.py
+++ b/vllm_mlx/_mxfp4_moe_guardrail.py
@@ -36,14 +36,21 @@ What the guardrail does at load time:
    ``aliases.json`` already names these variants
    (``qwen3.5-122b-mxfp4``, ``minimax-m2.7-mxfp4``, etc.) and stays
    robust without parsing each ``config.json`` quant block at load time.
-3. Detect multi-device dispatch via the launcher env vars
-   (``MLX_WORLD_SIZE`` / ``OMPI_COMM_WORLD_SIZE`` / ``PMI_SIZE``).
-   The env vars are authoritative because the launcher sets them
-   before the worker spawns and later passes them into
-   ``mlx.distributed.init()``. We avoid calling ``init()`` ourselves
-   because it has side effects (creates the global communication
-   group, can block while a backend handshakes) and a warning-only
-   guardrail must never mutate engine state.
+3. Detect multi-device dispatch via launcher state set BEFORE the
+   worker spawns. We use a multi-signal probe because upstream
+   ``mlx.distributed_run`` uses different vars per backend:
+   * ``MLX_WORLD_SIZE`` — NCCL backend only (CUDA hosts).
+   * ``OMPI_COMM_WORLD_SIZE`` / ``PMI_SIZE`` — MPI launchers.
+   * ``MLX_HOSTFILE`` — ring backend (Apple Silicon default,
+     and the precise target of the mlx#3402 cliff). We open the
+     hostfile and count its JSON entries — read-only, no side
+     effects.
+
+   We deliberately do NOT call ``mlx.distributed.init()`` for the
+   probe because it creates the global communication group, can
+   block while a backend handshakes, and ``backend="any"`` would
+   make the first successful backend the *global* group. A
+   warning-only guardrail must never mutate engine state.
 4. On the full three-tuple match, log a loud WARNING with the issue
    link and bump ``rapid_mlx_mxfp4_moe_distributed_warnings_total``.
 5. On a MoE + NVFP4 match (any device count — mlx#2962 dynamic-range
@@ -135,27 +142,34 @@ def _detect_distributed_world_size() -> int:
     global communication group — calling it purely for a metric/warning
     probe would either (a) initialize an unwanted singleton group on
     single-host runs or (b) block during startup if the distributed
-    environment is present but not yet ready (codex review #297).
+    environment is present but not yet ready (codex review #297 round 1).
     Worse, ``backend="any"`` makes the first successful backend the
     *global* group, which is a real side-effect on the engine that
     follows.
 
-    Instead, we read the environment variables that ``mlx-launcher`` /
-    ``mlx.distributed_run`` and the common MPI launchers set before
-    they spawn the worker process:
+    Instead, we read launcher state via env vars set by ``mlx-launcher``
+    / ``mlx.distributed_run`` and common MPI launchers BEFORE they spawn
+    the worker. Multiple signals are checked because the upstream
+    launcher uses a *different* set of vars per backend (codex review
+    #297 round 2):
 
-    * ``MLX_WORLD_SIZE`` — set by ``mlx-launcher`` / ``distributed_run``.
-    * ``OMPI_COMM_WORLD_SIZE`` — set by OpenMPI's ``mpirun``.
-    * ``PMI_SIZE`` — set by MPICH/Intel MPI launchers.
+    * ``MLX_WORLD_SIZE`` — set ONLY for the NCCL backend (CUDA hosts).
+      The ring backend, which is the Apple Silicon default and the
+      precise target of the mlx#3402 cliff, does NOT set this.
+    * ``OMPI_COMM_WORLD_SIZE`` — OpenMPI's ``mpirun``.
+    * ``PMI_SIZE`` — MPICH / Intel MPI launchers.
+    * ``MLX_HOSTFILE`` — set by the ring backend (Apple Silicon
+      default). Points to a JSON array of host descriptors; its length
+      IS the world size. We open the file and count entries — read-only,
+      cannot mutate engine state.
 
-    These variables are authoritative because they are what the launcher
-    later passes into ``init()``; if any of them is set to a value > 1
-    we are running under a multi-device dispatch regardless of whether
-    ``init()`` has been called yet. On a vanilla single-host run none
-    are set and we report 1.
+    If any of these signals reports a multi-device run we return it;
+    otherwise we report 1 (single device).
     """
+    import json
     import os
 
+    # Direct integer env vars (NCCL + MPI launchers).
     for env_var in ("MLX_WORLD_SIZE", "OMPI_COMM_WORLD_SIZE", "PMI_SIZE"):
         raw = os.environ.get(env_var)
         if not raw:
@@ -166,6 +180,25 @@ def _detect_distributed_world_size() -> int:
             continue
         if size >= 1:
             return size
+
+    # Ring backend (Apple Silicon default) — count entries in the
+    # JSON hostfile. The file is a JSON array of ``{ssh, ips}`` host
+    # objects; ``len(hosts)`` is the world size as constructed by
+    # ``mlx/distributed_run.py``. Read-only — no side effects.
+    hostfile_path = os.environ.get("MLX_HOSTFILE")
+    if hostfile_path:
+        try:
+            with open(hostfile_path) as fp:
+                hosts = json.load(fp)
+            if isinstance(hosts, list) and len(hosts) >= 1:
+                return len(hosts)
+        except Exception:  # pragma: no cover — defensive
+            logger.debug(
+                "MLX_HOSTFILE=%s present but unreadable; treating as size 1",
+                hostfile_path,
+                exc_info=True,
+            )
+
     return 1
 
 

--- a/vllm_mlx/_mxfp4_moe_guardrail.py
+++ b/vllm_mlx/_mxfp4_moe_guardrail.py
@@ -1,0 +1,305 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Load-time guardrail for the MoE + MXFP4 + multi-device throughput cliff.
+
+Background — task #297, R15 quantization + Metal + MoE scout findings:
+
+* **mlx#3402** (still open as of 2026-06): the three-tuple MoE
+  architecture + MXFP4 quantization + multi-device dispatch hits a 60×
+  throughput cliff on M3 Ultra distributed runs. GLM-5.1 / DeepSeek-V3.2
+  measured **0.27 tok/s vs expected ~16 tok/s**. The bug lives in
+  ``mlx.core``'s MXFP4 quantization kernels — the gather/scatter pattern
+  used by MoE expert routing fights the inter-device packing scheme.
+
+* **mlx#2962** (still open): MLX NVFP4 uses signed E4M3 scales instead
+  of Blackwell's unsigned UE4M3, costing ~137× dynamic range. MoE
+  weights stored as NVFP4 silently fall off the cliff long before the
+  user notices token-quality regressions.
+
+Without a guardrail, the next big MoE drop (GLM-5.x, DeepSeek V4 family,
+Kimi K2.7) will surface as a customer-visible throughput regression
+that operators cannot self-diagnose — the symptom is "serving is slow"
+and the only person who can correlate it back to the three-tuple is
+someone who's already read both upstream issues.
+
+Decision (v1) — **warn only**. Auto-routing to a non-MXFP4 variant is
+deferred because we don't yet have a clean "fallback alias for X" map
+across the registry. Operators see the warning, click the issue link,
+and can pick a fallback themselves. The follow-up to auto-route lands
+once we have a curated quant-variant map per alias family.
+
+What the guardrail does at load time:
+
+1. Detect MoE-ness from the alias profile (``is_moe`` flag from
+   ``aliases.json``).
+2. Detect quant format from the HF path string (``mxfp4`` / ``nvfp4``
+   token, case-insensitive). The path-based heuristic matches the way
+   ``aliases.json`` already names these variants
+   (``qwen3.5-122b-mxfp4``, ``minimax-m2.7-mxfp4``, etc.) and stays
+   robust without parsing each ``config.json`` quant block at load time.
+3. Detect multi-device dispatch via ``mlx.core.distributed.init().size()``
+   — the default group is size 1 on a single-host run, > 1 when
+   ``mpirun`` / ``mlx-launcher`` has wired up multiple devices.
+4. On the full three-tuple match, log a loud WARNING with the issue
+   link and bump ``rapid_mlx_mxfp4_moe_distributed_warnings_total``.
+5. On a MoE + NVFP4 match (any device count — mlx#2962 dynamic-range
+   loss bites even single-device), log a separate WARNING and bump
+   ``rapid_mlx_nvfp4_moe_warnings_total``.
+
+Process-local counters mirror the pattern already used by
+``api/response_format_metrics.py`` — hand-rolled module-level ints
+behind a ``threading.Lock`` rather than ``prometheus_client``, so we
+keep the metrics surface uniform with the rest of rapid-mlx and avoid
+the global default registry that fights multi-engine tests.
+
+Counters never decrease for the lifetime of the process. Tests use
+:func:`reset_for_tests` to zero them between cases.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from dataclasses import dataclass
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+# ---- Module-level Prometheus counters --------------------------------
+# Same pattern as ``api/response_format_metrics.py``: plain ints behind
+# a lock, snapshot exposed to ``routes/metrics.py``. Counters never
+# decrease for the process lifetime — Prometheus contract.
+_lock = threading.Lock()
+_mxfp4_moe_distributed_warnings_total = 0
+_nvfp4_moe_warnings_total = 0
+
+
+# Single canonical issue link, hoisted to a constant so tests can assert
+# the warning carries the upstream pointer and so a future link change
+# touches one line.
+MLX_3402_URL = "https://github.com/ml-explore/mlx/issues/3402"
+MLX_2962_URL = "https://github.com/ml-explore/mlx/issues/2962"
+
+
+@dataclass(frozen=True)
+class GuardrailSignal:
+    """Detection inputs used by :func:`check_load_time_guardrails`.
+
+    Captured as a small frozen dataclass so the call site in
+    ``server.load_model()`` constructs it once and the detection helper
+    stays pure / unit-testable without poking at server globals.
+    """
+
+    is_moe: bool
+    quant_format: Optional[str]  # "mxfp4", "nvfp4", or None
+    distributed_world_size: int
+
+
+def _detect_quant_format(hf_path: str | None) -> Optional[str]:
+    """Best-effort quant-format detection from the HF path string.
+
+    rapid-mlx's ``aliases.json`` names mxfp4 / nvfp4 variants with the
+    quant token embedded in the alias and the HF path (e.g.
+    ``mlx-community/MiniMax-M2.7-4bit-mxfp4``). That naming convention
+    is the single load-time signal we trust — parsing every model's
+    ``config.json`` quant block at load time would be both heavier and
+    less reliable (uploaders are inconsistent about that field).
+
+    Returns ``"mxfp4"`` / ``"nvfp4"`` if the corresponding token appears
+    anywhere in the path (case-insensitive). Returns ``None`` when the
+    path is missing or carries neither token. ``mxfp4`` wins over
+    ``nvfp4`` if both somehow appear — the three-tuple cliff is the
+    more severe of the two issues so the warning that fires should be
+    the louder one.
+    """
+    if not hf_path:
+        return None
+    lowered = hf_path.lower()
+    if "mxfp4" in lowered:
+        return "mxfp4"
+    if "nvfp4" in lowered:
+        return "nvfp4"
+    return None
+
+
+def _detect_distributed_world_size() -> int:
+    """Return the active MLX distributed world size, or 1 as a safe default.
+
+    ``mlx.core.distributed.init()`` is idempotent — it returns the
+    current (or default) Group. On a vanilla single-host run the size
+    is 1; under ``mpirun`` / ``mlx-launcher`` it reflects the wired-up
+    device count.
+
+    Any import / probe failure returns 1 so the guardrail never blocks
+    load on a build that lacks the distributed module. Guardrails are
+    advisory, not enforcing.
+    """
+    try:
+        import mlx.core as mx
+
+        group = mx.distributed.init()
+        return int(group.size())
+    except Exception:  # pragma: no cover — defensive
+        logger.debug(
+            "mlx.distributed.init() probe failed; assuming size=1",
+            exc_info=True,
+        )
+        return 1
+
+
+def _emit_mxfp4_moe_distributed_warning(
+    *,
+    hf_path: str | None,
+    alias: str | None,
+    world_size: int,
+) -> None:
+    """Log the WARNING and bump the counter for the three-tuple cliff."""
+    global _mxfp4_moe_distributed_warnings_total
+    with _lock:
+        _mxfp4_moe_distributed_warnings_total += 1
+    logger.warning(
+        "MoE + MXFP4 + multi-device throughput cliff detected "
+        "(mlx#3402, ~0.27 tok/s observed on M3 Ultra distributed vs "
+        "~16 tok/s expected). model=%s alias=%s world_size=%d. "
+        "Consider switching to a non-MXFP4 variant (e.g. 4-bit integer) "
+        "or single-device serving until upstream fix lands. "
+        "Details: %s",
+        hf_path or "<unknown>",
+        alias or "<none>",
+        world_size,
+        MLX_3402_URL,
+    )
+
+
+def _emit_nvfp4_moe_warning(
+    *,
+    hf_path: str | None,
+    alias: str | None,
+) -> None:
+    """Log the WARNING and bump the counter for MoE + NVFP4 dynamic-range loss."""
+    global _nvfp4_moe_warnings_total
+    with _lock:
+        _nvfp4_moe_warnings_total += 1
+    logger.warning(
+        "MoE + NVFP4 dynamic-range loss detected "
+        "(mlx#2962, signed E4M3 scales instead of Blackwell unsigned UE4M3 "
+        "→ ~137x dynamic-range loss). model=%s alias=%s. "
+        "MoE expert routing is especially sensitive to the lost range; "
+        "expect silent token-quality regressions before throughput drops. "
+        "Consider a 4-bit integer or non-NVFP4 variant. Details: %s",
+        hf_path or "<unknown>",
+        alias or "<none>",
+        MLX_2962_URL,
+    )
+
+
+def check_load_time_guardrails(
+    signal: GuardrailSignal,
+    *,
+    hf_path: str | None = None,
+    alias: str | None = None,
+) -> list[str]:
+    """Run the load-time guardrails against ``signal``.
+
+    Returns the list of guardrail names that fired (empty when none did).
+    Always returns — never raises and never blocks the load. The intent
+    is operator visibility, not enforcement; an over-eager enforcer
+    would refuse to load a model that works fine outside the upstream
+    bug's three-tuple corner.
+
+    Guardrails:
+        * ``"mxfp4_moe_distributed"`` — the full three-tuple cliff
+          (mlx#3402).
+        * ``"nvfp4_moe"`` — MoE + NVFP4 dynamic-range loss (mlx#2962).
+          Fires regardless of device count because the dynamic-range
+          loss bites even on single-device serving.
+
+    Importantly, the three-tuple gate strictly requires all three
+    inputs — any 2-of-3 leaves the cliff inactive and we stay silent.
+    That's covered by the test matrix; see
+    ``tests/test_mxfp4_moe_guardrail.py``.
+    """
+    fired: list[str] = []
+
+    if not signal.is_moe:
+        # Both guardrails gate on MoE. Bail early — keeps the path
+        # noise-free for the >95% of aliases that aren't MoE.
+        return fired
+
+    quant = signal.quant_format
+    is_distributed = signal.distributed_world_size > 1
+
+    if quant == "mxfp4" and is_distributed:
+        _emit_mxfp4_moe_distributed_warning(
+            hf_path=hf_path,
+            alias=alias,
+            world_size=signal.distributed_world_size,
+        )
+        fired.append("mxfp4_moe_distributed")
+    elif quant == "nvfp4":
+        _emit_nvfp4_moe_warning(hf_path=hf_path, alias=alias)
+        fired.append("nvfp4_moe")
+
+    return fired
+
+
+def check_from_profile(
+    *,
+    model_name: str,
+    profile,  # AliasProfile | None — annotated loosely to avoid an import cycle
+    alias: str | None = None,
+) -> list[str]:
+    """Convenience adapter that bridges ``server.load_model()`` to the guardrail.
+
+    Pulls ``is_moe`` from the resolved ``AliasProfile`` (False when no
+    profile was found — bare HF paths are conservatively treated as
+    non-MoE because we have no metadata to infer expert count without
+    cracking ``config.json``). The HF path used for quant detection is
+    ``profile.hf_path`` when available, else the raw ``model_name`` the
+    operator passed (which is the HF path itself in the no-alias case).
+
+    Kept in this module so ``server.py`` stays a one-line call site —
+    matches the seam style used by other defensive load-time checks
+    (e.g. ``_version_check``, ``_download_gate``).
+    """
+    is_moe = bool(getattr(profile, "is_moe", False))
+    hf_path = (
+        getattr(profile, "hf_path", None)
+        if profile is not None
+        else model_name
+    )
+    quant_format = _detect_quant_format(hf_path or model_name)
+    world_size = _detect_distributed_world_size()
+    signal = GuardrailSignal(
+        is_moe=is_moe,
+        quant_format=quant_format,
+        distributed_world_size=world_size,
+    )
+    return check_load_time_guardrails(
+        signal,
+        hf_path=hf_path or model_name,
+        alias=alias,
+    )
+
+
+def snapshot() -> dict[str, int]:
+    """Return a consistent snapshot of the guardrail counters for ``/metrics``."""
+    with _lock:
+        return {
+            "mxfp4_moe_distributed_warnings_total": (
+                _mxfp4_moe_distributed_warnings_total
+            ),
+            "nvfp4_moe_warnings_total": _nvfp4_moe_warnings_total,
+        }
+
+
+def reset_for_tests() -> None:
+    """Test-only hook: zero the counters between cases.
+
+    Production code MUST NOT call this — Prometheus counters are
+    contractually monotonic for the process lifetime.
+    """
+    global _mxfp4_moe_distributed_warnings_total
+    global _nvfp4_moe_warnings_total
+    with _lock:
+        _mxfp4_moe_distributed_warnings_total = 0
+        _nvfp4_moe_warnings_total = 0

--- a/vllm_mlx/_mxfp4_moe_guardrail.py
+++ b/vllm_mlx/_mxfp4_moe_guardrail.py
@@ -72,7 +72,6 @@ from __future__ import annotations
 import logging
 import threading
 from dataclasses import dataclass
-from typing import Optional
 
 logger = logging.getLogger(__name__)
 
@@ -102,11 +101,11 @@ class GuardrailSignal:
     """
 
     is_moe: bool
-    quant_format: Optional[str]  # "mxfp4", "nvfp4", or None
+    quant_format: str | None  # "mxfp4", "nvfp4", or None
     distributed_world_size: int
 
 
-def _detect_quant_format(hf_path: str | None) -> Optional[str]:
+def _detect_quant_format(hf_path: str | None) -> str | None:
     """Best-effort quant-format detection from the HF path string.
 
     rapid-mlx's ``aliases.json`` names mxfp4 / nvfp4 variants with the
@@ -329,11 +328,7 @@ def check_from_profile(
     (e.g. ``_version_check``, ``_download_gate``).
     """
     is_moe = bool(getattr(profile, "is_moe", False))
-    hf_path = (
-        getattr(profile, "hf_path", None)
-        if profile is not None
-        else model_name
-    )
+    hf_path = getattr(profile, "hf_path", None) if profile is not None else model_name
     quant_format = _detect_quant_format(hf_path or model_name)
     world_size = _detect_distributed_world_size()
     signal = GuardrailSignal(

--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -650,6 +650,7 @@
     "tool_call_parser": "harmony",
     "reasoning_parser": "harmony",
     "is_hybrid": false,
+    "is_moe": true,
     "supports_spec_decode": true
   },
   "minimax-m2.5-4bit": {
@@ -657,6 +658,7 @@
     "tool_call_parser": "minimax",
     "reasoning_parser": "minimax",
     "is_hybrid": false,
+    "is_moe": true,
     "supports_spec_decode": true
   },
   "minimax-m2.7-mxfp4": {
@@ -664,6 +666,7 @@
     "tool_call_parser": "minimax",
     "reasoning_parser": "minimax",
     "is_hybrid": false,
+    "is_moe": true,
     "supports_spec_decode": true
   },
   "deepseek-r1-8b-4bit": {

--- a/vllm_mlx/routes/metrics.py
+++ b/vllm_mlx/routes/metrics.py
@@ -274,6 +274,58 @@ def _render_response_format_counters() -> list[str]:
     return out
 
 
+def _render_mxfp4_moe_guardrail_counters() -> list[str]:
+    """Render the R15 #297 MoE+MXFP4 / MoE+NVFP4 load-time guardrail counters.
+
+    Process-local state in ``vllm_mlx/_mxfp4_moe_guardrail.py`` —
+    independent of engine availability for the same reason the
+    response_format counters live above the engine-None early return:
+    the guardrail fires at ``load_model()`` time, BEFORE the engine
+    object reaches its ready state, so we must surface the counters
+    even when ``cfg.engine`` is None.
+    """
+    try:
+        from .._mxfp4_moe_guardrail import snapshot as _guardrail_snapshot
+
+        gr_stats = _guardrail_snapshot()
+    except Exception:
+        gr_stats = {
+            "mxfp4_moe_distributed_warnings_total": 0,
+            "nvfp4_moe_warnings_total": 0,
+        }
+    out: list[str] = []
+    out.extend(
+        _fmt_metric(
+            "rapid_mlx_mxfp4_moe_distributed_warnings_total",
+            "counter",
+            (
+                "Load-time warnings fired for the MoE + MXFP4 + "
+                "multi-device throughput cliff (upstream mlx#3402). "
+                "Any non-zero value means an operator started a model "
+                "matching the three-tuple; expect ~0.27 tok/s vs ~16 "
+                "tok/s until upstream lands a fix."
+            ),
+            int(gr_stats.get("mxfp4_moe_distributed_warnings_total", 0)),
+        )
+    )
+    out.extend(
+        _fmt_metric(
+            "rapid_mlx_nvfp4_moe_warnings_total",
+            "counter",
+            (
+                "Load-time warnings fired for the MoE + NVFP4 "
+                "dynamic-range loss (upstream mlx#2962, signed E4M3 "
+                "scales instead of Blackwell unsigned UE4M3 → ~137x "
+                "dynamic-range loss). Fires regardless of device count "
+                "because the dynamic-range loss bites even on "
+                "single-device serving."
+            ),
+            int(gr_stats.get("nvfp4_moe_warnings_total", 0)),
+        )
+    )
+    return out
+
+
 def _render_prometheus(cfg: Any) -> str:
     """Render the full /metrics body for a snapshot of cfg.engine state."""
     lines: list[str] = []
@@ -298,6 +350,14 @@ def _render_prometheus(cfg: Any) -> str:
     # engine-None / get_stats-failure early returns so dashboards see
     # the series even between restarts.
     lines.extend(_render_response_format_counters())
+
+    # R15 #297 MoE+MXFP4 / MoE+NVFP4 load-time guardrail counters —
+    # same engine-independence rationale: the guardrail fires at
+    # ``load_model()``, so the counter MUST be visible to scrapers
+    # before the engine reaches its ready state. Otherwise an operator
+    # whose model trips the cliff at startup has no metric series to
+    # alert on until the FIRST request lands.
+    lines.extend(_render_mxfp4_moe_guardrail_counters())
 
     if cfg.engine is None:
         # No engine yet — return build info + response_format counters

--- a/vllm_mlx/routes/metrics.py
+++ b/vllm_mlx/routes/metrics.py
@@ -277,53 +277,34 @@ def _render_response_format_counters() -> list[str]:
 def _render_mxfp4_moe_guardrail_counters() -> list[str]:
     """Render the R15 #297 MoE+MXFP4 / MoE+NVFP4 load-time guardrail counters.
 
-    Process-local state in ``vllm_mlx/_mxfp4_moe_guardrail.py`` —
-    independent of engine availability for the same reason the
-    response_format counters live above the engine-None early return:
-    the guardrail fires at ``load_model()`` time, BEFORE the engine
-    object reaches its ready state, so we must surface the counters
-    even when ``cfg.engine`` is None.
+    Delegates to ``_mxfp4_moe_guardrail.render_prometheus_lines()`` so
+    the rendering logic lives next to the counter state (and tests can
+    exercise it without importing the route module's heavier transitive
+    closure — see codex round 3/4 review on #297). On any import error
+    we synthesize an all-zero block via the same helper symbol space so
+    /metrics always exposes the series, even if the guardrail module
+    fails to load for some reason.
     """
     try:
-        from .._mxfp4_moe_guardrail import snapshot as _guardrail_snapshot
+        from .._mxfp4_moe_guardrail import render_prometheus_lines
 
-        gr_stats = _guardrail_snapshot()
+        return render_prometheus_lines()
     except Exception:
-        gr_stats = {
-            "mxfp4_moe_distributed_warnings_total": 0,
-            "nvfp4_moe_warnings_total": 0,
-        }
-    out: list[str] = []
-    out.extend(
-        _fmt_metric(
-            "rapid_mlx_mxfp4_moe_distributed_warnings_total",
-            "counter",
-            (
-                "Load-time warnings fired for the MoE + MXFP4 + "
-                "multi-device throughput cliff (upstream mlx#3402). "
-                "Any non-zero value means an operator started a model "
-                "matching the three-tuple; expect ~0.27 tok/s vs ~16 "
-                "tok/s until upstream lands a fix."
-            ),
-            int(gr_stats.get("mxfp4_moe_distributed_warnings_total", 0)),
-        )
-    )
-    out.extend(
-        _fmt_metric(
-            "rapid_mlx_nvfp4_moe_warnings_total",
-            "counter",
-            (
-                "Load-time warnings fired for the MoE + NVFP4 "
-                "dynamic-range loss (upstream mlx#2962, signed E4M3 "
-                "scales instead of Blackwell unsigned UE4M3 → ~137x "
-                "dynamic-range loss). Fires regardless of device count "
-                "because the dynamic-range loss bites even on "
-                "single-device serving."
-            ),
-            int(gr_stats.get("nvfp4_moe_warnings_total", 0)),
-        )
-    )
-    return out
+        # Counters never decrease but they may legitimately be missing
+        # if the guardrail module fails to import — surface a 0-valued
+        # series so dashboards still see the metric name and operators
+        # can alert on rapid_mlx_mxfp4_moe_distributed_warnings_total
+        # > 0 regardless of import state.
+        return [
+            "# HELP rapid_mlx_mxfp4_moe_distributed_warnings_total "
+            "Load-time warnings for MoE+MXFP4+multi-device cliff (mlx#3402).",
+            "# TYPE rapid_mlx_mxfp4_moe_distributed_warnings_total counter",
+            "rapid_mlx_mxfp4_moe_distributed_warnings_total 0",
+            "# HELP rapid_mlx_nvfp4_moe_warnings_total "
+            "Load-time warnings for MoE+NVFP4 dynamic-range loss (mlx#2962).",
+            "# TYPE rapid_mlx_nvfp4_moe_warnings_total counter",
+            "rapid_mlx_nvfp4_moe_warnings_total 0",
+        ]
 
 
 def _render_prometheus(cfg: Any) -> str:

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -1248,6 +1248,21 @@ def load_model(
         gen_cfg = {}
     _generation_config_sampling = gen_cfg or None
 
+    # R15 task #297: warn loudly when the operator's three-tuple matches
+    # the MoE + MXFP4 + multi-device throughput cliff (mlx#3402) or the
+    # MoE + NVFP4 dynamic-range loss (mlx#2962). Best-effort — wrapped
+    # in a try so a guardrail bug can NEVER prevent model load.
+    try:
+        from ._mxfp4_moe_guardrail import check_from_profile
+
+        check_from_profile(
+            model_name=model_name,
+            profile=_profile,
+            alias=_model_alias,
+        )
+    except Exception as _e:  # pragma: no cover — defensive belt-and-suspenders
+        logger.debug(f"mxfp4/moe guardrail probe failed (non-fatal): {_e}")
+
     # Initialize cloud router if --cloud-model is set
     if cloud_model:
         from .cloud_router import CloudRouter


### PR DESCRIPTION
## Summary

Lands task #297 from the rapid-mlx 0.9.x TODO — a load-time defensive guardrail for the MLX MoE+MXFP4+multi-device 60x throughput cliff documented in [mlx#3402](https://github.com/ml-explore/mlx/issues/3402), plus the MoE+NVFP4 dynamic-range loss in [mlx#2962](https://github.com/ml-explore/mlx/issues/2962).

### Why
- **mlx#3402**: MoE + MXFP4 + multi-device hits a 60x throughput cliff. M3 Ultra distributed GLM-5.1 / DeepSeek-V3.2 measured **0.27 tok/s vs ~16 tok/s expected**.
- **mlx#2962**: MLX NVFP4 uses signed E4M3 scales instead of Blackwell unsigned UE4M3 → ~137x dynamic-range loss.

Without this guardrail, the next big MoE drop (GLM-5.x, DeepSeek V4, Kimi K2.7) produces a customer-visible regression operators cannot self-diagnose.

### What
- **`vllm_mlx/_mxfp4_moe_guardrail.py`** — detection module. Pure functions plus a small `GuardrailSignal` dataclass. Detects MoE via the alias `is_moe` flag, quant format via the HF path string (`mxfp4`/`nvfp4`, case-insensitive), and multi-device via **launcher env vars** (`MLX_WORLD_SIZE` / `OMPI_COMM_WORLD_SIZE` / `PMI_SIZE`) and the **ring-backend `MLX_HOSTFILE`** (parses JSON, counts host entries). Takes `max()` across all signals so a stale env var can't mask a real multi-host hostfile. Deliberately never calls `mx.distributed.init()` — that's a mutating probe (creates the global communication group, can block).
- **`vllm_mlx/server.py:load_model()`** — single-line call site right after `resolve_profile()`, wrapped in try/except so a guardrail bug can never block model load.
- **`vllm_mlx/routes/metrics.py`** — exposes two new Prometheus counters surfaced ABOVE the engine-None early return:
  - `rapid_mlx_mxfp4_moe_distributed_warnings_total`
  - `rapid_mlx_nvfp4_moe_warnings_total`
- **`vllm_mlx/aliases.json`** — fixes `is_moe=true` on 3 shipped MXFP4 MoE aliases that were defaulting to false (`gpt-oss-20b-mxfp4-q8`, `minimax-m2.5-4bit`, `minimax-m2.7-mxfp4`).
- **`tests/test_mxfp4_moe_guardrail.py`** — 42 tests covering the 3-flag matrix, every 2-of-3 silent case, NVFP4 device-count-independence, env-var vs MLX_HOSTFILE vs max-of-signals, the no-`init()` contract (via static source inspection so the test never imports mlx.core), real-aliases regression so future MoE+MXFP4 aliases can't ship with `is_moe=false`, and end-to-end Prometheus rendering.

### v1 scope
Warn-only. Auto-routing to a non-MXFP4 variant is deferred until we have a curated quant-variant map per alias family.

### Convergence
Drove pr_validate (codex `gpt-5.5`) review loop to **7 rounds**, addressing all BLOCKING findings:
1. `mx.distributed.init()` side effects → env-var probing.
2. Ring backend (Apple Silicon default) MLX_HOSTFILE missed → hostfile parser.
3. Test imported global ServerConfig → stub cfg.
4. Test imported routes/metrics heavy chain → pure `render_prometheus_lines()` helper in guardrail module.
5. Test imported `mlx.core` for sentinel → static source-inspection contract.
6. Shipped MXFP4 MoE aliases had `is_moe=false` → flipped + real-alias regression test.
7. First-env-var-wins masked larger MLX_HOSTFILE → `max(candidates)` across all signals.

Round 8: codex returned "no blockers".

## Test plan

- [x] `pytest tests/test_mxfp4_moe_guardrail.py -q` — 42/42 pass, 80ms total (no MLX import).
- [x] Full suite: `pytest tests/ -q --ignore=tests/integrations --ignore=tests/test_event_loop.py --ignore=tests/test_batching_deterministic.py` — **10185 passed**, 21 skipped, 17 deselected, 6 xfailed.
- [x] Alias contract + hybrid classification tests still pass against modified `aliases.json`.
- [x] Codex adversarial review: 7 rounds of fixes, round 8 reports no blockers.
- [x] Operator validation: smoke-tested locally 2026-06-25 against `gpt-oss-20b-mxfp4-q8` (a shipped MXFP4 MoE alias from this PR's `is_moe=true` fix; substituted for `qwen3.5-122b-mxfp4` which isn't available locally) with `MLX_HOSTFILE=/tmp/test-mlx-hostfile-911.json` containing 2 host entries. Boot log shows `WARNING:rapid_mlx._mxfp4_moe_guardrail:MoE + MXFP4 + multi-device throughput cliff detected ... world_size=2`. `curl http://127.0.0.1:18101/metrics` returns `rapid_mlx_mxfp4_moe_distributed_warnings_total 1` (and `nvfp4_moe_warnings_total 0`, correctly silent because the model is MXFP4 not NVFP4). End-to-end wiring `load_model() → check_from_profile() → counter.inc() → /metrics` verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
