### PR TITLE
fix(responses): honor response_format strict json_schema (#293)

### DIFF
--- a/tests/test_responses_adapter.py
+++ b/tests/test_responses_adapter.py
@@ -735,6 +735,152 @@ class TestResponsesToOpenai:
         assert chat.response_format is not None
         assert chat.response_format.type == "json_schema"
 
+    # ------------------------------------------------------------------
+    # R14 task #293 — chat-style response_format migration shim
+    # ------------------------------------------------------------------
+
+    def test_chat_style_response_format_json_schema_strict_plumbed(self):
+        """Chat-style ``response_format`` with strict json_schema is
+        forwarded onto the materialized ``ChatCompletionRequest`` so the
+        engine's guided-decoding gate fires identically to
+        /v1/chat/completions. Pre-fix, ResponsesRequest silently dropped
+        the field and the engine ran unconstrained.
+        """
+        req = ResponsesRequest(
+            model="gpt-5",
+            input="give me a movie",
+            response_format={
+                "type": "json_schema",
+                "json_schema": {
+                    "name": "Movie",
+                    "strict": True,
+                    "schema": {
+                        "type": "object",
+                        "properties": {"title": {"type": "string"}},
+                        "required": ["title"],
+                    },
+                },
+            },
+        )
+        chat = responses_to_openai(req)
+        assert chat.response_format is not None
+        assert chat.response_format.type == "json_schema"
+        assert chat.response_format.json_schema is not None
+        assert chat.response_format.json_schema.name == "Movie"
+        assert chat.response_format.json_schema.strict is True
+        assert chat.response_format.json_schema.schema_ == {
+            "type": "object",
+            "properties": {"title": {"type": "string"}},
+            "required": ["title"],
+        }
+
+    def test_chat_style_response_format_json_object_plumbed(self):
+        """``response_format={"type":"json_object"}`` (JSON mode, no
+        schema) is also forwarded — same migration shim coverage."""
+        req = ResponsesRequest(
+            model="gpt-5",
+            input="x",
+            response_format={"type": "json_object"},
+        )
+        chat = responses_to_openai(req)
+        assert chat.response_format is not None
+        assert chat.response_format.type == "json_object"
+
+    def test_chat_style_response_format_text_type_is_inert(self):
+        """``type=text`` is the no-structure default and should not
+        block the engine from sampling normally — it forwards as-is
+        and the route's strict gate (is_strict_json_schema) returns
+        False, so the unconstrained path runs."""
+        req = ResponsesRequest(
+            model="gpt-5",
+            input="x",
+            response_format={"type": "text"},
+        )
+        chat = responses_to_openai(req)
+        # The field is forwarded but ``type=text`` is functionally a
+        # no-op — is_strict_json_schema returns False, the route's
+        # strict gate skips, and the engine runs unconstrained.
+        assert chat.response_format is not None
+        assert chat.response_format.type == "text"
+
+    def test_text_format_wins_over_response_format(self):
+        """When BOTH ``text.format`` and chat-style ``response_format``
+        are set, the canonical Responses-spec ``text.format`` wins.
+        This mirrors OpenAI cloud behaviour — clients that mix both
+        shapes get the spec-canonical answer."""
+        req = ResponsesRequest(
+            model="gpt-5",
+            input="x",
+            text={
+                "format": {
+                    "type": "json_schema",
+                    "name": "FromText",
+                    "schema": {"type": "object"},
+                }
+            },
+            response_format={
+                "type": "json_schema",
+                "json_schema": {
+                    "name": "FromResponseFormat",
+                    "strict": True,
+                    "schema": {"type": "object"},
+                },
+            },
+        )
+        chat = responses_to_openai(req)
+        assert chat.response_format is not None
+        assert chat.response_format.json_schema is not None
+        assert chat.response_format.json_schema.name == "FromText"
+
+    def test_response_format_absent_keeps_engine_unconstrained(self):
+        """Sanity: no response_format and no text.format → the
+        materialized ChatCompletionRequest carries None and the engine
+        samples freely. Pinning this in case the shim's None-fallback
+        ever flips."""
+        req = ResponsesRequest(model="gpt-5", input="x")
+        chat = responses_to_openai(req)
+        assert chat.response_format is None
+
+    def test_chat_style_response_format_strict_must_be_bool(self):
+        """The shared ``_validate_response_format_raw`` rejects
+        ``strict:"true"`` (string) on this surface too — parity with
+        chat / completions / messages. Pre-fix the field was undeclared
+        so the validator never ran and the string truthy-but-not-bool
+        silently passed."""
+        with pytest.raises(Exception) as exc_info:
+            ResponsesRequest(
+                model="gpt-5",
+                input="x",
+                response_format={
+                    "type": "json_schema",
+                    "json_schema": {
+                        "name": "X",
+                        "strict": "true",  # string, not bool
+                        "schema": {"type": "object"},
+                    },
+                },
+            )
+        assert "strict" in str(exc_info.value).lower()
+
+    def test_chat_style_response_format_empty_schema_rejected(self):
+        """Empty ``json_schema.schema={}`` is rejected at parse time
+        on this surface (same gate as chat / completions / messages).
+        Closes the F-103 silent-200 hazard for the Responses surface."""
+        with pytest.raises(Exception) as exc_info:
+            ResponsesRequest(
+                model="gpt-5",
+                input="x",
+                response_format={
+                    "type": "json_schema",
+                    "json_schema": {
+                        "name": "X",
+                        "strict": True,
+                        "schema": {},
+                    },
+                },
+            )
+        assert "schema" in str(exc_info.value).lower()
+
 
 # ---------------------------------------------------------------------------
 # openai_to_responses — full response shape

--- a/vllm_mlx/api/responses_adapter.py
+++ b/vllm_mlx/api/responses_adapter.py
@@ -349,7 +349,17 @@ def responses_to_openai(request: ResponsesRequest) -> ChatCompletionRequest:
 
     tools = _convert_tools(request.tools)
     tool_choice = _convert_tool_choice(request.tool_choice)
+    # R14 task #293: ``text.format`` is the canonical Responses-spec
+    # shape for structured output and wins when both are set; the
+    # chat-style ``response_format`` field is the migration shim for
+    # SDK clients that re-use the same payload across chat / responses
+    # (openai-python, langchain, instructor, ell, llama-index).
+    # Pre-fix, ``response_format`` was undeclared on ResponsesRequest
+    # so Pydantic silently dropped it and the engine ran unconstrained
+    # — the silent-correctness hazard the r5-E sweep exists to close.
     response_format = _convert_text_format(request.text)
+    if response_format is None and request.response_format is not None:
+        response_format = request.response_format
 
     return ChatCompletionRequest(
         model=request.model,

--- a/vllm_mlx/api/responses_models.py
+++ b/vllm_mlx/api/responses_models.py
@@ -21,10 +21,12 @@ from pydantic import BaseModel, Field, field_validator, model_validator
 from .models import (
     _TOP_K_SENTINEL_CAP,
     _VALID_REASONING_EFFORTS,
+    ResponseFormat,
     StreamOptions,
     _validate_nonnegative_int,
     _validate_positive_int,
     _validate_reasoning_effort,
+    _validate_response_format_raw,
     _validate_seed,
 )
 
@@ -165,6 +167,35 @@ class ResponsesRequest(BaseModel):
     service_tier: str | None = None
     prompt_cache_key: str | None = None
     text: dict | None = None  # {"format": {...}, "verbosity": ...}
+    # R14 task #293 (Talia fuzz wave) — chat-style ``response_format``
+    # accepted on /v1/responses as a migration shim.
+    #
+    # The canonical Responses-spec shape for structured-output sampling
+    # is ``text.format = {"type":"json_schema", "strict":true,
+    # "schema":{...}, "name":"..."}``. The chat surface uses a
+    # differently-nested ``response_format = {"type":"json_schema",
+    # "json_schema":{"strict":true, "schema":{...}, "name":"..."}}``.
+    # Codex CLI uses the canonical Responses shape; the
+    # openai-python SDK + many community clients (langchain, ell,
+    # instructor, llama-index) reuse the SAME chat-style payload across
+    # both surfaces because they share one ``response_format`` argument
+    # in their high-level API. Pre-fix, those clients sent
+    # ``response_format`` on /v1/responses and Pydantic silently dropped
+    # it (the field was undeclared); the engine then generated
+    # unconstrained text and clients saw schema violations they could
+    # not explain — the exact silent-correctness hazard the r5-E sweep
+    # exists to close.
+    #
+    # Declaring the field here makes the chat-style payload first-class
+    # on this surface. ``responses_to_openai`` merges it with
+    # ``text.format`` in the adapter, with ``text.format`` winning when
+    # both are set (canonical Responses-spec field has precedence, same
+    # rule OpenAI cloud applies). Validation reuses the shared
+    # ``_validate_response_format_raw`` helper so the strict-bool,
+    # schema-shape, and json_schema.name gates already enforced on
+    # /v1/chat/completions and /v1/completions fire identically here —
+    # one contract across all four OpenAI-compat surfaces.
+    response_format: ResponseFormat | dict | None = None
     metadata: dict | None = None
     previous_response_id: str | None = None  # 400 if set; this shim is stateless
     max_output_tokens: int | None = None
@@ -271,6 +302,18 @@ class ResponsesRequest(BaseModel):
     @classmethod
     def _validate_seed_field(cls, v) -> int | None:
         return _validate_seed(v)
+
+    # R14 task #293: share the same response_format dict-arm validator
+    # the chat / completions surfaces use so the shape gates (strict
+    # must be bool, json_schema.schema must be a non-empty dict,
+    # json_schema.name must be a string) fire identically across all
+    # four OpenAI-compat lanes (chat / completions / messages /
+    # responses). See ``_validate_response_format_raw`` in models.py
+    # for the rationale block.
+    @field_validator("response_format", mode="before")
+    @classmethod
+    def _validate_response_format_field(cls, v):
+        return _validate_response_format_raw(v)
 
     # R10-H5 (R9-H3 carry) — mirror of
     # ``ChatCompletionRequest._validate_reasoning_effort_field``. Closed


### PR DESCRIPTION
## Why

R14 Talia fuzz wave (rapid-mlx task #293) reported a silent-correctness hazard on ``POST /v1/responses``: chat-style ``response_format`` with strict ``json_schema`` was dropped at parse time and the engine generated unconstrained tokens. SDK clients (openai-python, langchain, instructor, ell, llama-index) re-use one ``response_format`` payload across ``/v1/chat/completions`` and ``/v1/responses``; on the former it worked, on the latter the schema was silently bypassed. Closes the gap so both surfaces honour the same contract.

Refs #293.

## Symptom

```json
POST /v1/responses
{
  "model": "...",
  "input": "...",
  "response_format": {
    "type": "json_schema",
    "json_schema": {"strict": true, "schema": {...}, "name": "..."}
  }
}
```

Returned free-form text instead of guaranteed-schema-conforming JSON. The same payload on ``/v1/chat/completions`` honoured the constraint.

## Root cause

``ResponsesRequest`` (in ``vllm_mlx/api/responses_models.py``) declared ``text: dict | None`` (the canonical Responses-spec ``text.format`` shape) but had no ``response_format`` field. Pydantic's default ``extra="ignore"`` silently dropped the chat-style payload at parse time. The route's strict gate (``responses.py:377``) reads ``getattr(openai_request, "response_format", None)`` AFTER ``responses_to_openai`` materializes a ``ChatCompletionRequest`` — but the adapter only consulted ``request.text`` to populate that field, so chat-style ``response_format`` never reached the gate.

## What got wired

1. **``ResponsesRequest.response_format``** (``api/responses_models.py``): new ``ResponseFormat | dict | None`` field with the shared ``_validate_response_format_raw`` validator (strict-bool gate, ``json_schema.name`` required, ``json_schema.schema`` non-empty dict — one contract across all four OpenAI-compat surfaces).
2. **``responses_to_openai``** (``api/responses_adapter.py``): when ``text.format`` is unset, fall back to ``request.response_format``. ``text.format`` wins when both are set — canonical Responses-spec field has precedence, matching OpenAI cloud behaviour.
3. **No route changes needed** because the existing strict gate (``responses.py:377``), the strict+tools / strict+stream / invalid-schema gates, the guided-decoding dispatch (``responses.py:818+``), and the post-decode validator all key off ``openai_request.response_format``. Once the adapter wires the field, every gate fires identically for chat-style and canonical-shape clients.

Both ``type=json_schema`` (strict + non-strict) and ``type=json_object`` were affected by the same drop and both modes are restored by this single shim. ``type=text`` (default) is unchanged.

## Test plan

Unit tests added in ``tests/test_responses_adapter.py``:

- [x] ``test_chat_style_response_format_json_schema_strict_plumbed`` — strict ``json_schema`` with full schema reaches ``ChatCompletionRequest.response_format`` with ``strict=True``
- [x] ``test_chat_style_response_format_json_object_plumbed`` — JSON mode (no schema) is forwarded
- [x] ``test_chat_style_response_format_text_type_is_inert`` — ``type=text`` forwards but ``is_strict_json_schema`` returns False so the unconstrained path runs
- [x] ``test_text_format_wins_over_response_format`` — when both are set, ``text.format`` (canonical) wins
- [x] ``test_response_format_absent_keeps_engine_unconstrained`` — sanity: no fallback when neither is set
- [x] ``test_chat_style_response_format_strict_must_be_bool`` — shared validator rejects ``strict:"true"`` (string), parity with chat
- [x] ``test_chat_style_response_format_empty_schema_rejected`` — empty ``schema={}`` rejected at parse time (closes F-103 silent-200 for this surface)
- [x] ``pytest tests/test_responses_adapter.py tests/test_responses_route.py tests/test_responses_param_validation.py tests/test_responses_bundle.py tests/test_chat_*.py`` — all green (one pre-existing failure in ``test_strict_true_with_outlines_module_faked_absent`` is env-dependent — ``outlines`` not installed locally; reproduces on main without these changes)
- [x] ``ruff check vllm_mlx/ tests/`` + ``ruff format --check vllm_mlx/ tests/`` both clean
- [x] Operator validation: smoke-tested locally 2026-06-25 against `qwen3-0.6b-4bit` on port 18102. POST /v1/responses with `response_format={"type":"json_schema","json_schema":{"strict":true,...}}` for a PersonRecord schema (name:string, age:integer, city:string, additionalProperties=false). Output: `{"name":"Alice","age":30,"city":"Paris"}` — strict-conforming JSON, exactly 3 required keys, no extras, age is integer (not string). Before this PR, the Responses API silently dropped `response_format` at the Pydantic-parse layer and returned free-form text. End-to-end wiring `ResponsesRequest → responses_to_openai → engine guided_json_schema → schema-constrained sampling` verified.

## Standing rule

**Do not merge** — operator merges after seeing codex clean + CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
