### PR TITLE
feat(aliases): add GLM-5.2-REAP50 alias (R15 #298)

### DIFF
--- a/tests/test_aliases_contract.py
+++ b/tests/test_aliases_contract.py
@@ -1421,3 +1421,59 @@ def test_bare_qwen3_short_aliases_follow_family_precedent(alias: str) -> None:
         f"{alias}: vanilla Qwen3 0.6B/1.7B is dense (only A3B/A10B/A22B "
         f"siblings are MoE)."
     )
+
+
+def test_glm_5_2_reap50_alias_resolves_to_pipenetwork_4bit() -> None:
+    """R15 Phase 6 #298 — GLM-5.2-REAP50 alias for the 256GB Mac Studio
+    MoE-fit story (体感 1).
+
+    The Cerebras REAP-pruned variant of GLM-5.2 drops the lowest-saliency
+    half of the 256 routed experts (down to ``n_routed_experts=128``).
+    Combined with mlx-community / pipenetwork 4-bit affine quantization
+    this lands at ~214 GB on disk and fits a 256GB Mac Studio with KV
+    headroom — the FIRST realistically-Mac-runnable GLM-5.2 variant.
+
+    Pinned here so a future bulk edit can't silently re-route the alias
+    to a different REAP pruning ratio (REAP25 / REAP75 land at different
+    disk sizes and DIFFERENT quality budgets — operators picked this
+    alias name expecting the 50% prune specifically) or flip routing
+    flags. The model_type at HF (``glm_moe_dsa``) shares the same chat
+    template + tool envelope family as GLM-4.5 / 4.7, so the existing
+    glm47 / glm4 parsers apply unchanged.
+
+    HF: https://huggingface.co/pipenetwork/GLM-5.2-REAP50-MLX-4bit
+    """
+    profile = list_profiles()["glm-5.2-reap50"]
+    assert profile.hf_path == "pipenetwork/GLM-5.2-REAP50-MLX-4bit", (
+        f"glm-5.2-reap50: hf_path drifted. The alias name carries the "
+        f"50% expert-prune semantics; pointing at REAP25 / REAP75 / "
+        f"non-REAP would silently change disk size + quality. "
+        f"Got {profile.hf_path!r}."
+    )
+    assert profile.is_moe is True, (
+        "glm-5.2-reap50: GLM-5.2 is sparse-expert (n_routed_experts=128 "
+        "after REAP-50% prune, num_experts_per_tok=8). Mis-tagging as "
+        "dense would mis-route DFlash / spec-decode gates."
+    )
+    assert profile.is_hybrid is False, (
+        "glm-5.2-reap50: pure-attention (glm_moe_dsa backbone), not hybrid."
+    )
+    assert profile.tool_call_parser == "glm47", (
+        f"glm-5.2-reap50: GLM-5.2 shares the GLM-4.7 ``<tool_call>...`` "
+        f"tool envelope. Got {profile.tool_call_parser!r}."
+    )
+    assert profile.reasoning_parser == "glm4", (
+        f"glm-5.2-reap50: GLM-5.2 chat template autonomously emits "
+        f"`<think>...</think>` blocks (same as GLM-4.5/4.7) — route "
+        f"through ``glm4`` so the trace lands in reasoning_content. "
+        f"Got {profile.reasoning_parser!r}."
+    )
+    assert profile.supports_spec_decode is False, (
+        "glm-5.2-reap50: 214 GB MoE — spec-decode drafter overhead "
+        "swamps the win at this size (same call as Kimi K2.6)."
+    )
+    assert profile.supports_dflash is False, (
+        "glm-5.2-reap50: sparse-expert MoE — DFlash drafter hidden-state "
+        "fusion misfires on expert-routing churn (see "
+        "test_dflash_excludes_moe_architectures)."
+    )

--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -1245,5 +1245,14 @@
     "is_hybrid": false,
     "is_moe": false,
     "supports_spec_decode": true
+  },
+  "glm-5.2-reap50": {
+    "hf_path": "pipenetwork/GLM-5.2-REAP50-MLX-4bit",
+    "tool_call_parser": "glm47",
+    "reasoning_parser": "glm4",
+    "is_hybrid": false,
+    "is_moe": true,
+    "supports_spec_decode": false,
+    "supports_dflash": false
   }
 }


### PR DESCRIPTION
## Summary

R15 Phase 6 #298 — adds the `glm-5.2-reap50` alias pointing at [`pipenetwork/GLM-5.2-REAP50-MLX-4bit`](https://huggingface.co/pipenetwork/GLM-5.2-REAP50-MLX-4bit) (~214 GB on disk, 4-bit affine MoE, n_routed_experts=128 after Cerebras REAP-50% prune).

**Rationale (体感 1 — Mac 上跑得动 700B+ MoE):** the REAP-50% prune drops the lowest-saliency half of the 256 routed experts, landing GLM-5.2 at 214 GB. Combined with `mlx-community` / `pipenetwork` 4-bit affine quant, this is the FIRST realistically-Mac-runnable GLM-5.2 variant — fits a 256GB Mac Studio with KV headroom. The full 4-bit GLM-5.2 (~430 GB) does NOT fit.

**Routing flags** (modeled after `kimi-k2.6`, which is the closest 4-bit MoE neighbor):
- `tool_call_parser=glm47` / `reasoning_parser=glm4` — GLM-5.2 (`model_type: glm_moe_dsa`) shares the GLM-4.5/4.7 `<tool_call>...` envelope and autonomous `<think>...</think>` block emission.
- `is_moe=true`, `is_hybrid=false` — sparse-expert pure-attention.
- `supports_spec_decode=false`, `supports_dflash=false` — 214 GB MoE: drafter overhead swamps spec-decode at this size, sparse-expert routing churn misfires DFlash hidden-state fusion.
- Quantization is `mode: affine` 4-bit (NOT MXFP4), so the `mxfp4_moe_distributed` guardrail correctly does NOT fire on this alias.

## Test plan

- [x] `rapid-mlx models | grep glm-5.2-reap50` → `glm-5.2-reap50 glm47 glm4 ✗ unknown —` (alias count grew 119 → 120).
- [x] `rapid-mlx info glm-5.2-reap50` → `Alias: glm-5.2-reap50 → pipenetwork/GLM-5.2-REAP50-MLX-4bit`, profile table prints, DFlash eligibility correctly shows ineligible (MoE + 4-bit).
- [x] Boot smoke with `rapid-mlx serve qwen3-0.6b --port 18750` (small model — the 214 GB REAP50 weights are out of agent timebox); the server boots, `/v1/chat/completions` returns a valid response, confirming the alias-load codepath is healthy.
- [x] New regression test `test_glm_5_2_reap50_alias_resolves_to_pipenetwork_4bit` in `tests/test_aliases_contract.py` pins hf_path, is_moe, is_hybrid, both parsers, and the disabled spec_decode / DFlash gates. Full `tests/test_aliases_contract.py` suite (1369 cases) green.

**Deferred to release-time hardware verification:** actual 214 GB weight download + boot on a 256GB Mac Studio. The alias surface and routing flags are landed; operator will run the first-token + decode bench on real hardware to close the 体感 1 row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)