### PR TITLE
feat(kv-cache): support arbitrary position_ids in cache update (R15 #301)

### DIFF
--- a/tests/test_kv_cache_position_ids.py
+++ b/tests/test_kv_cache_position_ids.py
@@ -1,0 +1,433 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for arbitrary ``position_ids`` KV-cache writes (R15 task #301).
+
+These tests pin the contract for :mod:`vllm_mlx.positioned_kv_cache`,
+which is the foundational unlock for every tree-based speculative decode
+pipeline (EAGLE-3, DFlash, DDTree, MTP — Phase 5 of the 0.9-TODO) and
+DSA per-token gather. The tree decoders depend on:
+
+* **Bit-identical backward compat** when ``position_ids=None`` — the
+  existing monotonic-offset path must not move.
+* **Last-writer-wins by source-index order** for duplicate positions —
+  the tree verifier orders branch candidates so the accepted branch is
+  the last row in ``keys``; the cache write must keep that one.
+* **Sparse position support** ([3, 5, 7]) — DSA gather emits sparse
+  positions and expects the in-between slots to retain whatever was
+  previously there (zero on a fresh cache).
+* **Quantized parity** — ``--kv-cache-dtype int4`` is the default after
+  R15 #300 / #910; the positioned write must behave identically on the
+  quantized path.
+* **Validation** — shape mismatch / negative ids / empty ids reject
+  loudly so a buggy speculative-decode tree builder can't silently
+  corrupt the cache.
+
+Run with::
+
+    pytest tests/test_kv_cache_position_ids.py
+"""
+
+from __future__ import annotations
+
+import pytest
+
+mx = pytest.importorskip("mlx.core")
+
+from mlx_lm.models.cache import KVCache, QuantizedKVCache  # noqa: E402
+
+from vllm_mlx.positioned_kv_cache import (  # noqa: E402
+    PositionedKVCache,
+    PositionedQuantizedKVCache,
+    positioned_update_and_fetch,
+)
+
+
+# ---------------------------------------------------------------------------
+# Test fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_keys_values(seq: int, *, head_dim: int = 8, n_kv: int = 2, seed: int = 0):
+    """Return deterministic ``(keys, values)`` of the requested seq length."""
+    keys = mx.random.normal((1, n_kv, seq, head_dim), key=mx.random.key(seed))
+    values = mx.random.normal((1, n_kv, seq, head_dim), key=mx.random.key(seed + 1))
+    return keys, values
+
+
+def _make_marked_keys_values(values_seq, *, head_dim: int = 8, n_kv: int = 2):
+    """Return ``(keys, values)`` with each row filled with the matching marker.
+
+    Used by the dedup / last-writer-wins tests so a single ``[0]`` element
+    inspection identifies which source row landed in a given slot.
+    """
+    k_rows = [mx.full((1, n_kv, head_dim), float(v)) for v in values_seq]
+    v_rows = [mx.full((1, n_kv, head_dim), float(v) + 1000.0) for v in values_seq]
+    return mx.stack(k_rows, axis=2), mx.stack(v_rows, axis=2)
+
+
+# ---------------------------------------------------------------------------
+# Backward compatibility — no position_ids → bit-identical to upstream
+# ---------------------------------------------------------------------------
+
+
+def test_unquantized_no_position_ids_is_bit_identical_to_upstream():
+    """``position_ids=None`` must yield the EXACT same (keys, values, offset)
+    as the upstream ``KVCache.update_and_fetch`` — bit-identical, not just
+    close. This is the backward-compat anchor for every existing caller.
+    """
+    upstream = KVCache()
+    positioned = PositionedKVCache()
+    k, v = _make_keys_values(5)
+    out_u_k, out_u_v = upstream.update_and_fetch(k, v)
+    out_p_k, out_p_v = positioned.update_and_fetch(k, v)
+    assert upstream.offset == positioned.offset == 5
+    assert mx.array_equal(out_u_k, out_p_k).item()
+    assert mx.array_equal(out_u_v, out_p_v).item()
+
+
+def test_unquantized_monotonic_position_ids_match_default_append():
+    """Passing ``[5, 6, 7]`` to a cache already at offset 5 is the same
+    contract as the default monotonic append; the cache state must be
+    bit-identical to a vanilla ``KVCache`` that consumed the same rows.
+    """
+    upstream = KVCache()
+    positioned = PositionedKVCache()
+    k0, v0 = _make_keys_values(5, seed=2)
+    upstream.update_and_fetch(k0, v0)
+    positioned.update_and_fetch(k0, v0)
+    k1, v1 = _make_keys_values(3, seed=4)
+    out_u_k, out_u_v = upstream.update_and_fetch(k1, v1)
+    out_p_k, out_p_v = positioned.update_and_fetch(
+        k1, v1, position_ids=[5, 6, 7]
+    )
+    assert upstream.offset == positioned.offset == 8
+    assert mx.array_equal(out_u_k, out_p_k).item()
+    assert mx.array_equal(out_u_v, out_p_v).item()
+
+
+def test_standalone_helper_matches_upstream_when_position_ids_omitted():
+    """The standalone ``positioned_update_and_fetch`` helper must be the
+    same as the method form when ``position_ids=None`` — it's the API the
+    radix prefix cache / disk-backed KV path will call into without
+    needing to swap the cache subclass.
+    """
+    upstream = KVCache()
+    helper_cache = KVCache()
+    k, v = _make_keys_values(4, seed=7)
+    out_u_k, out_u_v = upstream.update_and_fetch(k, v)
+    out_h_k, out_h_v = positioned_update_and_fetch(helper_cache, k, v)
+    assert helper_cache.offset == upstream.offset
+    assert mx.array_equal(out_u_k, out_h_k).item()
+    assert mx.array_equal(out_u_v, out_h_v).item()
+
+
+# ---------------------------------------------------------------------------
+# Tree spec decode case — non-monotonic positions with duplicates
+# ---------------------------------------------------------------------------
+
+
+def test_unquantized_tree_duplicate_positions_last_writer_wins():
+    """Tree case: cache at offset 5, write positions ``[6, 6, 7]`` (two
+    branch candidates at depth 6, one at depth 7).
+
+    Contract:
+      * Position 6 holds the LAST source row at that position (last-writer
+        wins by source-index order — matches MLX scatter semantics).
+      * Position 7 holds the single source row at that position.
+      * Offset advances to ``max(prev_offset, max(positions)+1) = 8``.
+    """
+    cache = PositionedKVCache()
+    # Warm the cache to offset 5 with a known prefill.
+    prefill_k, prefill_v = _make_keys_values(5, seed=11)
+    cache.update_and_fetch(prefill_k, prefill_v)
+    assert cache.offset == 5
+
+    # 3 candidate rows; markers 1.0, 2.0, 3.0 so we can identify which
+    # row landed where after the write.
+    k_tree, v_tree = _make_marked_keys_values([1.0, 2.0, 3.0])
+    cache.update_and_fetch(k_tree, v_tree, position_ids=[6, 6, 7])
+
+    assert cache.offset == 8
+    # Position 6 must hold the LAST source row mapped to it (2.0).
+    assert cache.keys[0, 0, 6, 0].item() == pytest.approx(2.0)
+    assert cache.values[0, 0, 6, 0].item() == pytest.approx(1002.0)
+    # Position 7 holds the single source row at that position.
+    assert cache.keys[0, 0, 7, 0].item() == pytest.approx(3.0)
+    assert cache.values[0, 0, 7, 0].item() == pytest.approx(1003.0)
+
+
+def test_unquantized_tree_non_adjacent_duplicate_positions():
+    """Tree case where the duplicate position is not adjacent in the
+    ``position_ids`` array: ``[6, 7, 6]`` with markers ``[10, 20, 30]``.
+
+    Position 6 must hold ``30`` (the LAST source row mapped to it);
+    position 7 must hold ``20``. This guards the operator's expectation
+    that the verifier can place the accepted branch at any index in the
+    tree as long as it's the LAST occurrence of that depth.
+    """
+    cache = PositionedKVCache()
+    k_tree, v_tree = _make_marked_keys_values([10.0, 20.0, 30.0])
+    cache.update_and_fetch(k_tree, v_tree, position_ids=[6, 7, 6])
+    assert cache.offset == 8
+    assert cache.keys[0, 0, 6, 0].item() == pytest.approx(30.0)
+    assert cache.keys[0, 0, 7, 0].item() == pytest.approx(20.0)
+
+
+def test_unquantized_dsa_sparse_positions_preserves_gaps():
+    """DSA-like sparse positions ``[3, 5, 7]`` — the slots in between
+    (4, 6) must retain whatever was there before (zero on a fresh
+    cache). This is the contract DSA per-token gather depends on.
+    """
+    cache = PositionedKVCache()
+    k_sparse, v_sparse = _make_marked_keys_values([100.0, 200.0, 300.0])
+    cache.update_and_fetch(k_sparse, v_sparse, position_ids=[3, 5, 7])
+
+    assert cache.offset == 8
+    # Written slots
+    assert cache.keys[0, 0, 3, 0].item() == pytest.approx(100.0)
+    assert cache.keys[0, 0, 5, 0].item() == pytest.approx(200.0)
+    assert cache.keys[0, 0, 7, 0].item() == pytest.approx(300.0)
+    # Gap slots must be zero (fresh cache, never written)
+    assert cache.keys[0, 0, 4, 0].item() == pytest.approx(0.0)
+    assert cache.keys[0, 0, 6, 0].item() == pytest.approx(0.0)
+    # Slots below the lowest position are also fresh-zero
+    assert cache.keys[0, 0, 0, 0].item() == pytest.approx(0.0)
+
+
+def test_unquantized_backward_write_does_not_rewind_offset():
+    """Writing into a position BELOW the current offset must overwrite
+    the slot but NOT rewind the offset — the radix prefix cache (#303)
+    and disk-backed KV checkpointing (#296) rely on monotonic offset
+    growth even when tree branches retroactively rewrite earlier slots.
+    """
+    cache = PositionedKVCache()
+    k0, v0 = _make_keys_values(8, seed=23)
+    cache.update_and_fetch(k0, v0)
+    assert cache.offset == 8
+
+    k_back, v_back = _make_marked_keys_values([42.0])
+    cache.update_and_fetch(k_back, v_back, position_ids=[3])
+    assert cache.offset == 8  # NOT rewound
+    assert cache.keys[0, 0, 3, 0].item() == pytest.approx(42.0)
+
+
+# ---------------------------------------------------------------------------
+# Quantized (int4 / int8) path — the production default after R15 #300
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("bits", [4, 8])
+def test_quantized_no_position_ids_is_bit_identical_to_upstream(bits):
+    """Backward compat anchor for the quantized path. Locks the contract
+    that ``--kv-cache-dtype int4`` (the new default) keeps the same wire
+    output as the upstream ``QuantizedKVCache`` when ``position_ids`` is
+    not provided.
+    """
+    upstream = QuantizedKVCache(group_size=64, bits=bits)
+    positioned = PositionedQuantizedKVCache(group_size=64, bits=bits)
+    k, v = _make_keys_values(5, head_dim=64)
+    out_u_k, out_u_v = upstream.update_and_fetch(k, v)
+    out_p_k, out_p_v = positioned.update_and_fetch(k, v)
+    assert upstream.offset == positioned.offset == 5
+    # Quantized state is a tuple (packed, scales, biases) — compare all
+    # three members for both keys and values.
+    for i in range(3):
+        assert mx.array_equal(out_u_k[i], out_p_k[i]).item()
+        assert mx.array_equal(out_u_v[i], out_p_v[i]).item()
+
+
+@pytest.mark.parametrize("bits", [4, 8])
+def test_quantized_monotonic_position_ids_match_default_append(bits):
+    """The ``[5, 6, 7]`` monotonic path must produce the same quantized
+    state as the upstream default append. The quant op is non-trivial
+    (uint32 packing + scales/biases), so this catches any drift between
+    the positioned write path and the upstream blob layout.
+    """
+    upstream = QuantizedKVCache(group_size=64, bits=bits)
+    positioned = PositionedQuantizedKVCache(group_size=64, bits=bits)
+    k0, v0 = _make_keys_values(5, head_dim=64, seed=31)
+    upstream.update_and_fetch(k0, v0)
+    positioned.update_and_fetch(k0, v0)
+    k1, v1 = _make_keys_values(3, head_dim=64, seed=33)
+    out_u_k, out_u_v = upstream.update_and_fetch(k1, v1)
+    out_p_k, out_p_v = positioned.update_and_fetch(
+        k1, v1, position_ids=[5, 6, 7]
+    )
+    assert upstream.offset == positioned.offset == 8
+    for i in range(3):
+        assert mx.array_equal(out_u_k[i], out_p_k[i]).item()
+        assert mx.array_equal(out_u_v[i], out_p_v[i]).item()
+
+
+def test_quantized_tree_duplicate_positions_last_writer_wins():
+    """Quantized tree case — same contract as the unquantized version
+    but exercising the int4 wrapper. Compared via dequantized values
+    because the packed uint32 representation isn't directly
+    interpretable.
+    """
+    cache = PositionedQuantizedKVCache(group_size=64, bits=4)
+    prefill_k, prefill_v = _make_keys_values(5, head_dim=64, seed=41)
+    cache.update_and_fetch(prefill_k, prefill_v)
+    assert cache.offset == 5
+
+    k_tree, v_tree = _make_marked_keys_values(
+        [1.0, 2.0, 3.0], head_dim=64
+    )
+    cache.update_and_fetch(k_tree, v_tree, position_ids=[6, 6, 7])
+    assert cache.offset == 8
+
+    # Dequantize and inspect the slots. Each row was filled with a
+    # constant value, so a single column ``[0]`` is enough to identify.
+    packed_k, scales_k, biases_k = cache.keys
+    deq_k = mx.dequantize(
+        packed_k, scales_k, biases_k, group_size=64, bits=4
+    )
+    # int4 dequantization introduces small rounding, so use approx with
+    # a generous tolerance — we only care that the correct source row
+    # landed in the slot.
+    assert deq_k[0, 0, 6, 0].item() == pytest.approx(2.0, abs=0.1)
+    assert deq_k[0, 0, 7, 0].item() == pytest.approx(3.0, abs=0.1)
+
+
+def test_quantized_dsa_sparse_positions_preserves_gaps():
+    """Quantized DSA sparse case — exercises the int4 scatter path with
+    non-contiguous positions. Gap slots must remain zero (fresh cache),
+    written slots dequantize to the marker value within int4 tolerance.
+    """
+    cache = PositionedQuantizedKVCache(group_size=64, bits=4)
+    k_sparse, v_sparse = _make_marked_keys_values(
+        [100.0, 200.0, 300.0], head_dim=64
+    )
+    cache.update_and_fetch(k_sparse, v_sparse, position_ids=[3, 5, 7])
+    assert cache.offset == 8
+
+    packed_k, scales_k, biases_k = cache.keys
+    deq_k = mx.dequantize(
+        packed_k, scales_k, biases_k, group_size=64, bits=4
+    )
+    # Written slots — int4 has limited dynamic range; the marker values
+    # 100/200/300 are well outside [-1, 1] but still distinguishable
+    # within rough tolerance after dequant.
+    assert deq_k[0, 0, 3, 0].item() == pytest.approx(100.0, rel=0.05)
+    assert deq_k[0, 0, 5, 0].item() == pytest.approx(200.0, rel=0.05)
+    assert deq_k[0, 0, 7, 0].item() == pytest.approx(300.0, rel=0.05)
+    # Gap slots — the fresh capacity is zero-initialized, and "zero
+    # quantized" stays zero after dequant.
+    assert deq_k[0, 0, 4, 0].item() == pytest.approx(0.0, abs=1e-3)
+    assert deq_k[0, 0, 6, 0].item() == pytest.approx(0.0, abs=1e-3)
+
+
+# ---------------------------------------------------------------------------
+# Validation — bad inputs must reject loudly
+# ---------------------------------------------------------------------------
+
+
+def test_position_ids_length_mismatch_rejects():
+    """A buggy tree builder that emits the wrong number of positions
+    must trip the validator, not silently corrupt the cache.
+    """
+    cache = PositionedKVCache()
+    k, v = _make_keys_values(3)
+    with pytest.raises(ValueError, match="position_ids length"):
+        cache.update_and_fetch(k, v, position_ids=[0, 1, 2, 3])
+    with pytest.raises(ValueError, match="position_ids length"):
+        cache.update_and_fetch(k, v, position_ids=[0, 1])
+
+
+def test_position_ids_negative_rejects():
+    """Negative positions are nonsensical for a 0-indexed cache slot;
+    reject loudly so the speculative decode tree builder can't smuggle
+    a sign-bit bug into production.
+    """
+    cache = PositionedKVCache()
+    k, v = _make_keys_values(2)
+    with pytest.raises(ValueError, match="non-negative"):
+        cache.update_and_fetch(k, v, position_ids=[0, -1])
+
+
+def test_position_ids_empty_rejects():
+    """An empty position_ids array is almost certainly a tree-builder
+    bug — fail loud, not silent.
+    """
+    cache = PositionedKVCache()
+    k, v = _make_keys_values(0)
+    with pytest.raises(ValueError, match="empty"):
+        cache.update_and_fetch(k, v, position_ids=[])
+
+
+def test_unsupported_cache_type_rejects():
+    """The R15 #301 scope is plain ``KVCache`` + ``QuantizedKVCache``.
+    Rotating / chunked / batch caches deliberately raise so callers know
+    they need to either upgrade those classes or stick with the
+    monotonic path.
+    """
+    from mlx_lm.models.cache import RotatingKVCache
+
+    rot = RotatingKVCache(max_size=64)
+    k, v = _make_keys_values(3)
+    with pytest.raises(TypeError, match="only supports KVCache"):
+        positioned_update_and_fetch(rot, k, v, position_ids=[0, 1, 2])
+
+
+# ---------------------------------------------------------------------------
+# Cache growth — capacity must expand past the upstream step boundary
+# ---------------------------------------------------------------------------
+
+
+def test_unquantized_growth_past_step_boundary():
+    """A sparse write that lands beyond the current capacity (the
+    upstream step is 256) must grow the buffer to fit. Without this,
+    the scatter assignment trips an IndexError on the first tree write
+    that emits a high-index position.
+    """
+    cache = PositionedKVCache()
+    k, v = _make_marked_keys_values([7.0])
+    cache.update_and_fetch(k, v, position_ids=[500])
+    assert cache.offset == 501
+    # Capacity rounds up to a multiple of step (256) — at minimum 512.
+    assert cache.keys.shape[2] >= 501
+    assert cache.keys[0, 0, 500, 0].item() == pytest.approx(7.0)
+
+
+def test_quantized_growth_past_step_boundary():
+    """Same growth contract on the quantized path. The triple
+    ``(packed, scales, biases)`` must expand in lock-step; if any
+    member lags, the next scatter is misaligned.
+    """
+    cache = PositionedQuantizedKVCache(group_size=64, bits=4)
+    k, v = _make_marked_keys_values([7.0], head_dim=64)
+    cache.update_and_fetch(k, v, position_ids=[500])
+    assert cache.offset == 501
+    assert cache.keys[0].shape[2] >= 501
+    assert cache.keys[1].shape[2] >= 501
+    assert cache.keys[2].shape[2] >= 501
+
+
+# ---------------------------------------------------------------------------
+# Helper-form parity — the standalone function and the subclass method
+# must produce the same state for the same inputs.
+# ---------------------------------------------------------------------------
+
+
+def test_helper_function_and_subclass_method_produce_same_state():
+    """The radix prefix cache will likely call the standalone helper
+    (no need to swap cache types). The subclass method is a sugar
+    wrapper; the two must produce identical state for the same
+    sequence of operations.
+    """
+    via_subclass = PositionedKVCache()
+    via_helper = KVCache()
+    k0, v0 = _make_keys_values(5, seed=51)
+    via_subclass.update_and_fetch(k0, v0)
+    positioned_update_and_fetch(via_helper, k0, v0)
+
+    k1, v1 = _make_marked_keys_values([1.0, 2.0, 3.0])
+    via_subclass.update_and_fetch(k1, v1, position_ids=[6, 6, 7])
+    positioned_update_and_fetch(via_helper, k1, v1, position_ids=[6, 6, 7])
+
+    assert via_subclass.offset == via_helper.offset == 8
+    assert mx.array_equal(
+        via_subclass.keys[..., :8, :], via_helper.keys[..., :8, :]
+    ).item()
+    assert mx.array_equal(
+        via_subclass.values[..., :8, :], via_helper.values[..., :8, :]
+    ).item()

--- a/tests/test_kv_cache_position_ids.py
+++ b/tests/test_kv_cache_position_ids.py
@@ -40,7 +40,6 @@ from vllm_mlx.positioned_kv_cache import (  # noqa: E402
     positioned_update_and_fetch,
 )
 
-
 # ---------------------------------------------------------------------------
 # Test fixtures
 # ---------------------------------------------------------------------------
@@ -96,9 +95,7 @@ def test_unquantized_monotonic_position_ids_match_default_append():
     positioned.update_and_fetch(k0, v0)
     k1, v1 = _make_keys_values(3, seed=4)
     out_u_k, out_u_v = upstream.update_and_fetch(k1, v1)
-    out_p_k, out_p_v = positioned.update_and_fetch(
-        k1, v1, position_ids=[5, 6, 7]
-    )
+    out_p_k, out_p_v = positioned.update_and_fetch(k1, v1, position_ids=[5, 6, 7])
     assert upstream.offset == positioned.offset == 8
     assert mx.array_equal(out_u_k, out_p_k).item()
     assert mx.array_equal(out_u_v, out_p_v).item()
@@ -249,9 +246,7 @@ def test_quantized_monotonic_position_ids_match_default_append(bits):
     positioned.update_and_fetch(k0, v0)
     k1, v1 = _make_keys_values(3, head_dim=64, seed=33)
     out_u_k, out_u_v = upstream.update_and_fetch(k1, v1)
-    out_p_k, out_p_v = positioned.update_and_fetch(
-        k1, v1, position_ids=[5, 6, 7]
-    )
+    out_p_k, out_p_v = positioned.update_and_fetch(k1, v1, position_ids=[5, 6, 7])
     assert upstream.offset == positioned.offset == 8
     for i in range(3):
         assert mx.array_equal(out_u_k[i], out_p_k[i]).item()
@@ -269,18 +264,14 @@ def test_quantized_tree_duplicate_positions_last_writer_wins():
     cache.update_and_fetch(prefill_k, prefill_v)
     assert cache.offset == 5
 
-    k_tree, v_tree = _make_marked_keys_values(
-        [1.0, 2.0, 3.0], head_dim=64
-    )
+    k_tree, v_tree = _make_marked_keys_values([1.0, 2.0, 3.0], head_dim=64)
     cache.update_and_fetch(k_tree, v_tree, position_ids=[6, 6, 7])
     assert cache.offset == 8
 
     # Dequantize and inspect the slots. Each row was filled with a
     # constant value, so a single column ``[0]`` is enough to identify.
     packed_k, scales_k, biases_k = cache.keys
-    deq_k = mx.dequantize(
-        packed_k, scales_k, biases_k, group_size=64, bits=4
-    )
+    deq_k = mx.dequantize(packed_k, scales_k, biases_k, group_size=64, bits=4)
     # int4 dequantization introduces small rounding, so use approx with
     # a generous tolerance — we only care that the correct source row
     # landed in the slot.
@@ -294,16 +285,12 @@ def test_quantized_dsa_sparse_positions_preserves_gaps():
     written slots dequantize to the marker value within int4 tolerance.
     """
     cache = PositionedQuantizedKVCache(group_size=64, bits=4)
-    k_sparse, v_sparse = _make_marked_keys_values(
-        [100.0, 200.0, 300.0], head_dim=64
-    )
+    k_sparse, v_sparse = _make_marked_keys_values([100.0, 200.0, 300.0], head_dim=64)
     cache.update_and_fetch(k_sparse, v_sparse, position_ids=[3, 5, 7])
     assert cache.offset == 8
 
     packed_k, scales_k, biases_k = cache.keys
-    deq_k = mx.dequantize(
-        packed_k, scales_k, biases_k, group_size=64, bits=4
-    )
+    deq_k = mx.dequantize(packed_k, scales_k, biases_k, group_size=64, bits=4)
     # Written slots — int4 has limited dynamic range; the marker values
     # 100/200/300 are well outside [-1, 1] but still distinguishable
     # within rough tolerance after dequant.

--- a/vllm_mlx/positioned_kv_cache.py
+++ b/vllm_mlx/positioned_kv_cache.py
@@ -1,0 +1,426 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Arbitrary-``position_ids`` KV-cache write path (R15 task #301).
+
+The upstream ``mlx_lm.models.cache.KVCache`` /
+``mlx_lm.models.cache.QuantizedKVCache`` implementations grow strictly
+monotonically: every call to :py:meth:`KVCache.update_and_fetch` writes
+``keys`` / ``values`` into slots ``[offset, offset+S)`` and bumps
+``offset += S``. That contract is fine for vanilla prefill + decode, but
+it is incompatible with every tree-based speculative decode pipeline
+(EAGLE-3, DFlash, DDTree, MTP) and with DSA-style sparse gather.
+
+A draft tree emits **non-monotonic** position ids — e.g. positions
+``[10, 11, 11, 12, 12, 13, 13]`` while the verifier checks three
+alternative branches at depths 11/12/13 — and the verifier picks one
+branch at the end. The cache must support writing those branch
+candidates into explicit slots so the verifier can later overwrite or
+discard them; without that, no tree spec decode is even possible.
+
+This module is the **purely additive** capability that unlocks Phase 5
+of the 0.9 TODO (#302 MTP, DFlash-MLX, DDTree-MLX) and #296 disk-backed
+KV checkpointing. It does NOT change the upstream class signatures and
+does NOT touch the on-disk cache format used by ``save_prompt_cache`` /
+the radix prefix cache (#303).
+
+Design choices
+--------------
+
+* The capability is offered two ways: a standalone function
+  :func:`positioned_update_and_fetch` that operates on any vanilla
+  ``KVCache`` / ``QuantizedKVCache`` instance, AND thin subclasses
+  :class:`PositionedKVCache` / :class:`PositionedQuantizedKVCache` that
+  expose ``update_and_fetch(keys, values, position_ids=None)`` as the
+  natural method-level extension. Callers that already hold a vanilla
+  cache (the common case for spec decode that swaps the cache in
+  per-request) can use the function; new callers that want the method
+  signature can construct the subclass directly.
+* Duplicate position ids resolve to **last-writer-wins by source-index
+  order**. We pre-dedup ``position_ids`` Python-side and pass MLX the
+  ``(position, last_source_index)`` pair set — without the dedup, MLX
+  scatter into duplicate indices is racy (verified empirically on
+  ``mlx.core 0.31.3`` — same-position writes land non-deterministically
+  across heads). The dedup keeps the LAST occurrence of each position,
+  so a tree verifier that places the accepted branch last in the
+  ``keys`` tensor gets exactly that branch in the cache.
+* ``self.offset`` advances to ``max(prev_offset, max(position_ids)+1)``
+  so subsequent monotonic decode steps continue to read the correct
+  causal window. Backward writes (positions below ``prev_offset``) do
+  **not** rewind the offset.
+* When ``position_ids is None`` the implementation delegates straight to
+  the upstream ``update_and_fetch``; backward compatibility is
+  bit-identical (locked by ``tests/test_kv_cache_position_ids.py``).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import mlx.core as mx
+from mlx_lm.models.cache import KVCache, QuantizedKVCache
+
+__all__ = [
+    "PositionedKVCache",
+    "PositionedQuantizedKVCache",
+    "positioned_update_and_fetch",
+]
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _coerce_position_ids(
+    position_ids: Any,
+) -> tuple[list[int], list[int], int]:
+    """Normalize ``position_ids`` and pre-dedup to last-writer-wins order.
+
+    Returns ``(unique_positions, source_indices, max_position)`` where:
+
+    * ``unique_positions`` is the deduplicated, order-preserving list of
+      cache slots to write into.
+    * ``source_indices`` is the parallel list of source-row indices into
+      ``keys`` / ``values``. For each unique position we keep the LAST
+      occurrence in the original ``position_ids`` — this is the
+      last-writer-wins semantics the tree verifier depends on.
+    * ``max_position`` is ``max(unique_positions)``, used to size the
+      cache buffer.
+
+    Why we don't pass the raw ``mx.array`` directly to MLX scatter:
+    ``mlx.core 0.31.3`` scatter assignment into duplicate destination
+    indices is non-deterministic (the racing writes land in any order
+    across heads). Pre-deduping Python-side makes the write trivially
+    deterministic at the cost of one host-side dict pass — negligible
+    on the spec-decode tree size (~64 candidates).
+
+    Accepts an ``mx.array``, a Python list/tuple, or any iterable of
+    ints.
+    """
+    if position_ids is None:  # pragma: no cover — caller guarded
+        raise ValueError("position_ids must not be None")
+
+    if isinstance(position_ids, mx.array):
+        if position_ids.ndim != 1:
+            raise ValueError(
+                f"position_ids must be 1-D (got shape {position_ids.shape})"
+            )
+        # ``.tolist()`` forces a sync, but the dedup needs host-side
+        # ints anyway so the eval is unavoidable.
+        raw = [int(p) for p in position_ids.tolist()]
+    else:
+        raw = [int(p) for p in position_ids]
+
+    if not raw:
+        raise ValueError("position_ids must not be empty")
+    for p in raw:
+        if p < 0:
+            raise ValueError(
+                f"position_ids must be non-negative (got {p})"
+            )
+
+    # Dedup: keep the LAST source index for each unique position. ``dict``
+    # preserves insertion order on Python 3.7+, so iterating ``last.items()``
+    # gives a stable order.
+    last: dict[int, int] = {}
+    for i, p in enumerate(raw):
+        last[p] = i  # overwrite — final assignment wins
+
+    unique_positions = list(last.keys())
+    source_indices = list(last.values())
+    return unique_positions, source_indices, max(unique_positions)
+
+
+def _validate_seq_dim(
+    keys: mx.array, values: mx.array, raw_pos_len: int
+) -> None:
+    """Ensure ``position_ids`` length matches the seq dim of keys/values.
+
+    ``raw_pos_len`` is the length of the original (pre-dedup)
+    ``position_ids`` array. The validator is intentionally strict — a
+    tree builder that emits the wrong number of positions has a real bug
+    and must fail loud, not silently scatter into the wrong slots.
+    """
+    if keys.ndim != 4 or values.ndim != 4:
+        raise ValueError(
+            "keys and values must be 4-D (B, n_kv_heads, S, head_dim); got "
+            f"keys.ndim={keys.ndim}, values.ndim={values.ndim}"
+        )
+    if keys.shape[2] != raw_pos_len:
+        raise ValueError(
+            f"position_ids length {raw_pos_len} does not match keys seq dim "
+            f"{keys.shape[2]}"
+        )
+    if values.shape[2] != raw_pos_len:
+        raise ValueError(
+            f"position_ids length {raw_pos_len} does not match values seq dim "
+            f"{values.shape[2]}"
+        )
+
+
+def _grow_kv_cache(cache: KVCache, keys: mx.array, values: mx.array, required: int) -> None:
+    """Grow a plain ``KVCache`` so its buffer covers at least ``required`` slots.
+
+    Mirrors the upstream allocation logic in
+    :py:meth:`KVCache.update_and_fetch` but sized to ``required`` rather
+    than ``offset + S``. The cache buffer is rounded up to a multiple of
+    :py:attr:`KVCache.step` to match the upstream allocation pattern;
+    that keeps allocation noise off the hot path when many positioned
+    writes land within the same allocation chunk.
+    """
+    step = cache.step
+    if cache.keys is None:
+        B, n_kv_heads, _, k_head_dim = keys.shape
+        v_head_dim = values.shape[3]
+        n_steps = (step + required - 1) // step
+        capacity = n_steps * step
+        cache.keys = mx.zeros((B, n_kv_heads, capacity, k_head_dim), keys.dtype)
+        cache.values = mx.zeros((B, n_kv_heads, capacity, v_head_dim), values.dtype)
+        return
+
+    current = cache.keys.shape[2]
+    if required <= current:
+        return
+
+    # Trim any allocation slack past the current offset before growing —
+    # mirrors upstream's ``prev % step != 0`` trim. Keeps capacity tight
+    # and matches the layout the offset-based fast path expects.
+    if cache.offset % step != 0 and cache.offset < current:
+        cache.keys = cache.keys[..., : cache.offset, :]
+        cache.values = cache.values[..., : cache.offset, :]
+
+    deficit = required - cache.keys.shape[2]
+    n_steps = (step + deficit - 1) // step
+    pad = n_steps * step
+    B, n_kv_heads, _, k_head_dim = cache.keys.shape
+    v_head_dim = cache.values.shape[3]
+    new_k = mx.zeros((B, n_kv_heads, pad, k_head_dim), cache.keys.dtype)
+    new_v = mx.zeros((B, n_kv_heads, pad, v_head_dim), cache.values.dtype)
+    cache.keys = mx.concatenate([cache.keys, new_k], axis=2)
+    cache.values = mx.concatenate([cache.values, new_v], axis=2)
+
+
+def _grow_quant_cache(
+    cache: QuantizedKVCache, keys: mx.array, values: mx.array, required: int
+) -> None:
+    """Grow a ``QuantizedKVCache`` so its buffer covers at least ``required`` slots.
+
+    The quantized cache stores ``(packed_uint32, scales, biases)`` triples
+    rather than a single tensor. Growth has to expand each member of the
+    triple in lock-step. Capacity rounds up to a multiple of ``step`` to
+    match the upstream allocation pattern.
+    """
+    step = cache.step
+    bits = cache.bits
+    group_size = cache.group_size
+    el_per_int = 8 * mx.uint32.size // bits
+
+    if cache.keys is None:
+        B, n_kv_heads, _, k_head_dim = keys.shape
+        v_head_dim = values.shape[3]
+        n_steps = (step + required - 1) // step
+        capacity = n_steps * step
+
+        def init(dim: int):
+            return (
+                mx.zeros((B, n_kv_heads, capacity, dim // el_per_int), dtype=mx.uint32),
+                mx.zeros((B, n_kv_heads, capacity, dim // group_size), dtype=keys.dtype),
+                mx.zeros((B, n_kv_heads, capacity, dim // group_size), dtype=keys.dtype),
+            )
+
+        cache.keys = init(k_head_dim)
+        cache.values = init(v_head_dim)
+        return
+
+    current = cache.keys[0].shape[2]
+    if required <= current:
+        return
+
+    # Trim any allocation slack the same way upstream does in
+    # ``QuantizedKVCache.update_and_fetch``.
+    prev = cache.offset
+    if prev % step != 0 and prev < current:
+        def _trim(x):
+            return x[..., :prev, :]
+        cache.keys = tuple(_trim(x) for x in cache.keys)
+        cache.values = tuple(_trim(x) for x in cache.values)
+
+    deficit = required - cache.keys[0].shape[2]
+    n_steps = (step + deficit - 1) // step
+    pad = n_steps * step
+    B, n_kv_heads, _, _ = cache.keys[0].shape
+
+    def expand(triple):
+        return tuple(
+            mx.concatenate(
+                [x, mx.zeros((B, n_kv_heads, pad, x.shape[-1]), dtype=x.dtype)],
+                axis=2,
+            )
+            for x in triple
+        )
+
+    cache.keys = expand(cache.keys)
+    cache.values = expand(cache.values)
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def positioned_update_and_fetch(
+    cache: KVCache | QuantizedKVCache,
+    keys: mx.array,
+    values: mx.array,
+    position_ids: mx.array | list[int] | tuple[int, ...] | None = None,
+):
+    """Scatter ``keys`` / ``values`` into ``cache`` at explicit positions.
+
+    Args:
+        cache: A vanilla :class:`KVCache` or :class:`QuantizedKVCache`.
+            Subclasses inherit the same behaviour; rotating/chunked/batch
+            caches are out of scope and raise :class:`TypeError`.
+        keys: Shape ``(B, n_kv_heads, S, k_head_dim)`` — the new key rows.
+        values: Shape ``(B, n_kv_heads, S, v_head_dim)`` — matching V.
+        position_ids: ``None`` to delegate to the upstream monotonic
+            update_and_fetch path (bit-identical backward compat); or a
+            length-``S`` 1-D ``mx.array`` / list of non-negative ints
+            giving the explicit cache slot for each row. Duplicate
+            positions resolve to "last-writer-wins by source-index order"
+            (matches ``mlx.core`` scatter semantics).
+
+    Returns:
+        The same ``(keys_view, values_view)`` tuple the upstream method
+        returns, sliced to ``[:cache.offset]``. For the quantized cache
+        the views are 3-tuples ``(packed, scales, biases)`` matching the
+        upstream contract.
+
+    Raises:
+        TypeError: If ``cache`` is neither :class:`KVCache` nor
+            :class:`QuantizedKVCache` (or a subclass thereof).
+        ValueError: If ``position_ids`` has the wrong shape, contains
+            negative values, is empty, or its length does not match the
+            seq dim of ``keys`` / ``values``.
+    """
+    if position_ids is None:
+        # Delegate to the upstream method on the matching base class —
+        # NOT to ``cache.update_and_fetch`` directly, which would recurse
+        # back through the subclass override.
+        if isinstance(cache, QuantizedKVCache):
+            return QuantizedKVCache.update_and_fetch(cache, keys, values)
+        if isinstance(cache, KVCache):
+            return KVCache.update_and_fetch(cache, keys, values)
+        raise TypeError(
+            "positioned_update_and_fetch only supports KVCache and "
+            f"QuantizedKVCache; got {type(cache).__name__}."
+        )
+
+    # Compute raw length BEFORE dedup so the validator catches "wrong
+    # number of positions for this many rows" cleanly.
+    if isinstance(position_ids, mx.array):
+        raw_len = int(position_ids.shape[0]) if position_ids.ndim == 1 else -1
+    else:
+        try:
+            raw_len = len(position_ids)
+        except TypeError:
+            raw_len = -1
+    if raw_len < 0:
+        raw_len = keys.shape[2]  # fall back; validator will still catch shape
+
+    unique_positions, source_indices, max_pos = _coerce_position_ids(position_ids)
+    _validate_seq_dim(keys, values, raw_len)
+
+    # ``mlx.core 0.31.3`` scatter assignment into duplicate destination
+    # indices is non-deterministic. ``unique_positions`` is already
+    # deduplicated; gather the matching source rows so the destination
+    # write has no duplicates.
+    pos_arr = mx.array(unique_positions, dtype=mx.int32)
+    src_arr = mx.array(source_indices, dtype=mx.int32)
+    required = max(cache.offset, max_pos + 1)
+
+    if isinstance(cache, QuantizedKVCache):
+        _grow_quant_cache(cache, keys, values, required)
+        # Quantize the new rows in the same dtype/group/bits the cache
+        # was built with, then scatter each member of the triple. We
+        # quantize the full ``keys`` tensor (cheap on tree-size inputs)
+        # and gather the deduplicated source rows from the quantized
+        # output, rather than quantizing twice.
+        q_keys = mx.quantize(keys, group_size=cache.group_size, bits=cache.bits)
+        q_values = mx.quantize(values, group_size=cache.group_size, bits=cache.bits)
+        new_keys = list(cache.keys)
+        new_values = list(cache.values)
+        for i in range(3):
+            # ``mx.take(x, src_arr, axis=2)`` is the cheap gather; it
+            # produces a tensor whose seq dim matches ``pos_arr``.
+            new_keys[i][..., pos_arr, :] = mx.take(q_keys[i], src_arr, axis=2)
+            new_values[i][..., pos_arr, :] = mx.take(q_values[i], src_arr, axis=2)
+        cache.keys = tuple(new_keys)
+        cache.values = tuple(new_values)
+        cache.offset = required
+        view = tuple(x[..., : cache.offset, :] for x in cache.keys)
+        v_view = tuple(x[..., : cache.offset, :] for x in cache.values)
+        return view, v_view
+
+    if isinstance(cache, KVCache):
+        _grow_kv_cache(cache, keys, values, required)
+        cache.keys[..., pos_arr, :] = mx.take(keys, src_arr, axis=2)
+        cache.values[..., pos_arr, :] = mx.take(values, src_arr, axis=2)
+        cache.offset = required
+        return (
+            cache.keys[..., : cache.offset, :],
+            cache.values[..., : cache.offset, :],
+        )
+
+    raise TypeError(
+        "positioned_update_and_fetch only supports KVCache and "
+        f"QuantizedKVCache; got {type(cache).__name__}. Rotating/chunked/"
+        "batch caches are out of scope for R15 #301 — file a follow-up if "
+        "a tree spec decode pipeline needs them."
+    )
+
+
+class PositionedKVCache(KVCache):
+    """``KVCache`` with an optional ``position_ids`` argument on update.
+
+    Backward-compat note: when callers omit ``position_ids`` the result
+    is bit-identical to ``KVCache.update_and_fetch`` (the implementation
+    delegates straight to the parent). When provided, the new rows are
+    scattered via :func:`positioned_update_and_fetch`.
+
+    Persistence note: this subclass is NOT a drop-in replacement for the
+    cache type registered with ``mlx_lm.models.cache.save_prompt_cache`` —
+    the on-disk format records ``type(c).__name__`` and the loader looks
+    that name up in the upstream module globals. Use the standalone
+    :func:`positioned_update_and_fetch` for callers that interleave with
+    the radix prefix cache / disk-backed KV checkpointing (#296, #303).
+    """
+
+    def update_and_fetch(  # type: ignore[override]
+        self,
+        keys: mx.array,
+        values: mx.array,
+        position_ids: mx.array | list[int] | tuple[int, ...] | None = None,
+    ):
+        return positioned_update_and_fetch(self, keys, values, position_ids)
+
+
+class PositionedQuantizedKVCache(QuantizedKVCache):
+    """``QuantizedKVCache`` with an optional ``position_ids`` on update.
+
+    Same contract as :class:`PositionedKVCache` but for the int4/int8
+    quantized path. ``--kv-cache-dtype int4`` is the default after R15
+    #300 / #910, so this subclass is the one most callers will end up
+    using when threading tree spec decode through production.
+
+    Persistence note: same caveat as :class:`PositionedKVCache` — the
+    on-disk format records the class name and the upstream loader does
+    not know about this subclass. Use :func:`positioned_update_and_fetch`
+    for callers that interleave with the radix prefix cache.
+    """
+
+    def update_and_fetch(  # type: ignore[override]
+        self,
+        keys: mx.array,
+        values: mx.array,
+        position_ids: mx.array | list[int] | tuple[int, ...] | None = None,
+    ):
+        return positioned_update_and_fetch(self, keys, values, position_ids)

--- a/vllm_mlx/positioned_kv_cache.py
+++ b/vllm_mlx/positioned_kv_cache.py
@@ -114,9 +114,7 @@ def _coerce_position_ids(
         raise ValueError("position_ids must not be empty")
     for p in raw:
         if p < 0:
-            raise ValueError(
-                f"position_ids must be non-negative (got {p})"
-            )
+            raise ValueError(f"position_ids must be non-negative (got {p})")
 
     # Dedup: keep the LAST source index for each unique position. ``dict``
     # preserves insertion order on Python 3.7+, so iterating ``last.items()``
@@ -130,9 +128,7 @@ def _coerce_position_ids(
     return unique_positions, source_indices, max(unique_positions)
 
 
-def _validate_seq_dim(
-    keys: mx.array, values: mx.array, raw_pos_len: int
-) -> None:
+def _validate_seq_dim(keys: mx.array, values: mx.array, raw_pos_len: int) -> None:
     """Ensure ``position_ids`` length matches the seq dim of keys/values.
 
     ``raw_pos_len`` is the length of the original (pre-dedup)
@@ -157,7 +153,9 @@ def _validate_seq_dim(
         )
 
 
-def _grow_kv_cache(cache: KVCache, keys: mx.array, values: mx.array, required: int) -> None:
+def _grow_kv_cache(
+    cache: KVCache, keys: mx.array, values: mx.array, required: int
+) -> None:
     """Grow a plain ``KVCache`` so its buffer covers at least ``required`` slots.
 
     Mirrors the upstream allocation logic in
@@ -223,8 +221,12 @@ def _grow_quant_cache(
         def init(dim: int):
             return (
                 mx.zeros((B, n_kv_heads, capacity, dim // el_per_int), dtype=mx.uint32),
-                mx.zeros((B, n_kv_heads, capacity, dim // group_size), dtype=keys.dtype),
-                mx.zeros((B, n_kv_heads, capacity, dim // group_size), dtype=keys.dtype),
+                mx.zeros(
+                    (B, n_kv_heads, capacity, dim // group_size), dtype=keys.dtype
+                ),
+                mx.zeros(
+                    (B, n_kv_heads, capacity, dim // group_size), dtype=keys.dtype
+                ),
             )
 
         cache.keys = init(k_head_dim)
@@ -239,8 +241,10 @@ def _grow_quant_cache(
     # ``QuantizedKVCache.update_and_fetch``.
     prev = cache.offset
     if prev % step != 0 and prev < current:
+
         def _trim(x):
             return x[..., :prev, :]
+
         cache.keys = tuple(_trim(x) for x in cache.keys)
         cache.values = tuple(_trim(x) for x in cache.values)
 


### PR DESCRIPTION
## Rationale

Foundational unlock for Phase 5 of the 0.9-TODO. The upstream
`mlx_lm.models.cache.KVCache` / `QuantizedKVCache` only grow
monotonically (`offset += S` on every update), which is incompatible
with every tree-based speculative decode pipeline:

- **#302 MTP** spec decode (1.57x decode on Qwen3.5-27B-w4) needs to write branch
  candidates into specific cache slots so the verifier can pick the
  accepted branch and discard the rest.
- **DFlash-MLX** (4.37x lossless on Qwen3.5-9B-w4) emits non-monotonic
  position ids like `[10, 11, 11, 12, 12, 13, 13]` (three branches at depths 11/12/13).
- **DDTree-MLX for Tmax** same shape.
- **#296 disk-backed KV checkpointing** needs to restore caches at
  arbitrary positions.
- **DSA per-token gather** needs sparse position writes.

This PR is the cache-internal capability that lets all four land — none
of them are even possible without it.

## API change

Two equivalent entry points (both purely additive — no upstream class
or scheduler call site moves):

```python
# Standalone helper — works on any vanilla KVCache / QuantizedKVCache
from vllm_mlx.positioned_kv_cache import positioned_update_and_fetch
positioned_update_and_fetch(cache, keys, values, position_ids=None)  # backward-compat
positioned_update_and_fetch(cache, keys, values, position_ids=[6, 6, 7])  # tree write

# Subclass — sugar for code paths that want the method signature
from vllm_mlx.positioned_kv_cache import PositionedKVCache, PositionedQuantizedKVCache
cache = PositionedQuantizedKVCache(group_size=64, bits=4)
cache.update_and_fetch(keys, values)  # bit-identical to upstream
cache.update_and_fetch(keys, values, position_ids=[3, 5, 7])  # DSA sparse write
```

`position_ids=None` (the default) delegates straight to the upstream
method — bit-identical backward compat, locked by unit test.

### Semantics

- `position_ids.shape[-1]` must equal `keys.shape[2]` / `values.shape[2]`
  (validator raises `ValueError` otherwise).
- Duplicate positions resolve to **last-writer-wins by source-index
  order** (tree verifier places the accepted branch last). `mlx.core
  0.31.3` scatter into duplicate destinations is non-deterministic —
  verified empirically — so we pre-dedup Python-side and pass MLX a
  unique-position set.
- Sparse positions ([3, 5, 7]) leave the gap slots (4, 6) at whatever
  was previously there (zero on a fresh cache).
- Backward writes (positions below current offset) overwrite the slot
  but do NOT rewind `offset` — the prefix cache and disk-backed KV
  paths rely on monotonic offset growth.
- Offset advances to `max(prev_offset, max(position_ids) + 1)`.

## Scope guard

Rotating / chunked / batch caches are out of scope and raise `TypeError`
loudly — none of the Phase 5 spec decoders use them, and a half-baked
sliding-window implementation would risk corrupting the rotating buffer
boundaries.

The on-disk cache format used by `save_prompt_cache` and the radix
prefix cache (#303) is unchanged — the `PositionedKVCache` subclasses
are runtime-only and the helper function operates on vanilla caches.

## Test plan

- [x] Unit tests for monotonic position_ids backward-compat
  (`test_unquantized_no_position_ids_is_bit_identical_to_upstream`,
  `test_unquantized_monotonic_position_ids_match_default_append`,
  `test_standalone_helper_matches_upstream_when_position_ids_omitted`,
  + 2 quantized parametrized cases)
- [x] Unit tests for tree (non-monotonic) position_ids
  (`test_unquantized_tree_duplicate_positions_last_writer_wins`,
  `test_unquantized_tree_non_adjacent_duplicate_positions`,
  `test_unquantized_dsa_sparse_positions_preserves_gaps`,
  `test_unquantized_backward_write_does_not_rewind_offset`)
- [x] Unit tests for quantized cache path
  (`test_quantized_no_position_ids_is_bit_identical_to_upstream[4]`,
  `test_quantized_no_position_ids_is_bit_identical_to_upstream[8]`,
  `test_quantized_monotonic_position_ids_match_default_append[4]`,
  `test_quantized_monotonic_position_ids_match_default_append[8]`,
  `test_quantized_tree_duplicate_positions_last_writer_wins`,
  `test_quantized_dsa_sparse_positions_preserves_gaps`,
  `test_quantized_growth_past_step_boundary`)
- [x] No regression in adjacent KV-cache tests
  (`pytest tests/test_kv_cache_*` → **63 passed**, including 20 new +
  43 pre-existing; full adjacent suite
  `tests/test_kv_cache_* tests/test_prefix_cache* tests/test_paged_cache*
  tests/test_memory_cache.py tests/test_prompt_cache_snapshot.py` →
  **328 passed**)

## What this unblocks

- #302 MTP spec decode (Qwen3.5-27B-w4)
- DFlash-MLX (Qwen3.5-9B-w4)
- DDTree-MLX for Tmax
- #296 disk-backed KV checkpointing