### PR TITLE
fix(tools/llama): balanced-brace scan for nested arguments in python_tag parser (R15 0.9-must-fix)

### DIFF
--- a/tests/test_tool_calling.py
+++ b/tests/test_tool_calling.py
@@ -522,3 +522,115 @@ class TestValidateJsonSchema:
 
         assert is_valid is False
         assert error is not None
+
+
+class TestLlamaPythonTagNestedArguments:
+    """R15 #312 — Llama ``<|python_tag|>`` parser must balanced-brace scan.
+
+    The pre-fix parser used a non-greedy ``\\{.*?\\}`` regex which
+    terminated at the FIRST nested ``}`` and dropped the call entirely,
+    leaking ``}`` (or worse) into ``cleaned_text``. Every Llama 3.x
+    model with tools enabled hit this on common nested schemas
+    (``filters``, ``options``, ``config`` sub-objects).
+    """
+
+    def test_dogfood_repro_two_level_nesting(self):
+        """The exact repro from the dogfood triage."""
+        text = (
+            '<|python_tag|>{"name":"search","parameters":'
+            '{"query":"x","filters":{"lang":"en"}}}'
+        )
+        cleaned, tool_calls = parse_tool_calls(text)
+
+        assert tool_calls is not None, (
+            "regex parser silently failed on nested args — R15 #312 regression"
+        )
+        assert len(tool_calls) == 1
+        assert tool_calls[0].function.name == "search"
+        assert json.loads(tool_calls[0].function.arguments) == {
+            "query": "x",
+            "filters": {"lang": "en"},
+        }
+        assert cleaned == "", (
+            f"residual leak after fixing nested-brace scan: {cleaned!r}"
+        )
+
+    def test_three_level_nesting(self):
+        """Deeper nesting (3 levels) must still close at the right brace."""
+        text = '<|python_tag|>{"name":"f","parameters":{"a":{"b":{"c":1}}}}'
+        cleaned, tool_calls = parse_tool_calls(text)
+
+        assert tool_calls is not None
+        assert len(tool_calls) == 1
+        assert json.loads(tool_calls[0].function.arguments) == {"a": {"b": {"c": 1}}}
+        assert cleaned == ""
+
+    def test_braces_inside_string_literal(self):
+        """``{`` / ``}`` inside a JSON string must not affect depth."""
+        text = '<|python_tag|>{"name":"f","parameters":{"q":"what\'s {this} for?"}}'
+        cleaned, tool_calls = parse_tool_calls(text)
+
+        assert tool_calls is not None
+        assert len(tool_calls) == 1
+        assert json.loads(tool_calls[0].function.arguments) == {
+            "q": "what's {this} for?"
+        }
+        assert cleaned == ""
+
+    def test_two_consecutive_python_tag_calls(self):
+        """Back-to-back ``<|python_tag|>{...}`` blocks must both emit."""
+        text = (
+            '<|python_tag|>{"name":"a","parameters":{"x":1}}'
+            '<|python_tag|>{"name":"b","parameters":{"y":{"z":2}}}'
+        )
+        cleaned, tool_calls = parse_tool_calls(text)
+
+        assert tool_calls is not None
+        assert len(tool_calls) == 2
+        assert [tc.function.name for tc in tool_calls] == ["a", "b"]
+        assert json.loads(tool_calls[1].function.arguments) == {"y": {"z": 2}}
+        assert cleaned == ""
+
+    def test_flat_arguments_regression(self):
+        """Simple flat ``parameters`` dict must still parse (regression)."""
+        text = '<|python_tag|>{"name":"f","parameters":{"q":"x"}}'
+        cleaned, tool_calls = parse_tool_calls(text)
+
+        assert tool_calls is not None
+        assert len(tool_calls) == 1
+        assert tool_calls[0].function.name == "f"
+        assert json.loads(tool_calls[0].function.arguments) == {"q": "x"}
+        assert cleaned == ""
+
+    def test_malformed_json_is_graceful(self):
+        """Unbalanced JSON after ``<|python_tag|>`` must not crash.
+
+        Expect ``tool_calls is None`` and the original text returned as
+        residual content so the client at least sees what the model
+        produced rather than a 500 / a half-stripped span.
+        """
+        text = "<|python_tag|>{not json"
+        cleaned, tool_calls = parse_tool_calls(text)
+
+        assert tool_calls is None
+        # Either the raw text or a stripped equivalent — both acceptable
+        # as long as nothing was silently dropped.
+        assert text.split("<|python_tag|>")[1].strip("{ ") in cleaned or (
+            cleaned == text
+        )
+
+    def test_prefix_prose_is_preserved(self):
+        """A prose preface before ``<|python_tag|>`` must stay in cleaned."""
+        text = (
+            'Let me search.<|python_tag|>{"name":"f","parameters":'
+            '{"q":"x","f":{"k":"v"}}}'
+        )
+        cleaned, tool_calls = parse_tool_calls(text)
+
+        assert tool_calls is not None
+        assert len(tool_calls) == 1
+        assert json.loads(tool_calls[0].function.arguments) == {
+            "q": "x",
+            "f": {"k": "v"},
+        }
+        assert cleaned == "Let me search."

--- a/vllm_mlx/api/tool_calling.py
+++ b/vllm_mlx/api/tool_calling.py
@@ -161,6 +161,98 @@ def _serialize_tool_arguments(
     return json.dumps(arguments, ensure_ascii=False)
 
 
+def _find_balanced_json_object(text: str, start: int = 0) -> tuple[int, int] | None:
+    """Find the first balanced ``{...}`` block starting at or after ``start``.
+
+    Returns ``(begin, end_exclusive)`` of the JSON span, or ``None`` if
+    no balanced object is found. Brace-counting is string-literal aware
+    so a ``"}"`` inside a JSON string doesn't terminate the object
+    early — same contract as ``vllm_mlx.tool_parsers.llama_tool_parser
+    ._find_top_level_json_object``. Inlined here (not imported) to avoid
+    a circular import: ``tool_parsers/__init__.py`` eagerly loads
+    ``qwen3coder_tool_parser`` which in turn imports back from this
+    module.
+    """
+    n = len(text)
+    i = start
+    while i < n and text[i] != "{":
+        i += 1
+    if i >= n:
+        return None
+
+    depth = 0
+    in_str = False
+    escape = False
+    begin = i
+    while i < n:
+        ch = text[i]
+        if in_str:
+            if escape:
+                escape = False
+            elif ch == "\\":
+                escape = True
+            elif ch == '"':
+                in_str = False
+        else:
+            if ch == '"':
+                in_str = True
+            elif ch == "{":
+                depth += 1
+            elif ch == "}":
+                depth -= 1
+                if depth == 0:
+                    return begin, i + 1
+        i += 1
+    return None
+
+
+def _iter_python_tag_tool_calls(text: str):
+    """Yield ``<|python_tag|>{...}`` tool-call spans with balanced JSON.
+
+    Yields ``(span_start, span_end_exclusive, payload_dict)`` for each
+    ``<|python_tag|>`` prefix followed by a balanced top-level JSON
+    object that decodes successfully. Earlier code used a non-greedy
+    regex ``\\{.*?\\}`` here — that terminated at the first nested
+    ``}`` and corrupted both the parsed arguments and the residual
+    ``cleaned_text``. Common nested schemas (``filters``, ``options``,
+    ``config`` sub-objects) hit this on every call. R15 #312.
+    """
+    marker = "<|python_tag|>"
+    search_from = 0
+    while True:
+        marker_idx = text.find(marker, search_from)
+        if marker_idx == -1:
+            return
+        json_start = marker_idx + len(marker)
+        # Allow whitespace between the marker and the opening brace.
+        j = json_start
+        while j < len(text) and text[j].isspace():
+            j += 1
+        if j >= len(text) or text[j] != "{":
+            # Marker without a following object — skip past and keep
+            # scanning so a later valid marker can still match.
+            search_from = json_start
+            continue
+        span = _find_balanced_json_object(text, j)
+        if span is None:
+            # Unbalanced — bail out for this marker, advance past it so
+            # we don't loop forever, and let the caller leave the bytes
+            # as residual content (graceful malformed-JSON handling).
+            search_from = json_start
+            continue
+        begin, end = span
+        try:
+            payload = json.loads(text[begin:end])
+        except (json.JSONDecodeError, ValueError):
+            search_from = end
+            continue
+        if not isinstance(payload, dict):
+            search_from = end
+            continue
+        yield marker_idx, end, payload
+        search_from = end
+
+
 def _iter_calling_tool_calls(text: str):
     """Yield Qwen-style `Calling tool: name({...})` spans with balanced JSON args."""
     marker = "Calling tool:"
@@ -484,9 +576,6 @@ def parse_tool_calls(
     # Format 2: <|python_tag|>{"name": "func", "parameters": {...}}
     llama_pattern = r"<function=(\w+)>\s*(\{.*?\})\s*</function>"
     llama_matches = re.findall(llama_pattern, cleaned_text, re.DOTALL)
-    if not llama_matches:
-        llama_pattern = r'<\|python_tag\|>\s*\{\s*"name"\s*:\s*"([^"]+)"\s*,\s*"parameters"\s*:\s*(\{.*?\})\s*\}'
-        llama_matches = re.findall(llama_pattern, cleaned_text, re.DOTALL)
 
     for name, args_str in llama_matches:
         try:
@@ -513,12 +602,48 @@ def parse_tool_calls(
             cleaned_text,
             flags=re.DOTALL,
         )
-        cleaned_text = re.sub(
-            r'<\|python_tag\|>\s*\{\s*"name"\s*:\s*"[^"]+"\s*,\s*"parameters"\s*:\s*\{.*?\}\s*\}',
-            "",
-            cleaned_text,
-            flags=re.DOTALL,
+        cleaned_text = cleaned_text.strip()
+
+    # Format 2: <|python_tag|>{"name": "func", "parameters": {...}}
+    # Use a balanced-brace scanner instead of a non-greedy regex so
+    # nested ``parameters`` dicts (``filters``, ``options``, ``config``
+    # sub-objects) don't terminate the scan at the FIRST nested ``}``.
+    # The regex variant silently leaked ``}`` as residual content and
+    # dropped the tool call — see R15 #312.
+    python_tag_matches = list(_iter_python_tag_tool_calls(cleaned_text))
+    valid_python_tag_spans: list[tuple[int, int]] = []
+    for start, end, payload in python_tag_matches:
+        name = payload.get("name")
+        if not isinstance(name, str) or not name.strip():
+            continue
+        # Llama 3.1 chat template emits ``parameters``; some
+        # quantizations drift to OpenAI's ``arguments`` alias. Accept
+        # either so tool routing doesn't silently fail.
+        if "parameters" in payload:
+            arguments = payload["parameters"]
+        elif "arguments" in payload:
+            arguments = payload["arguments"]
+        else:
+            continue
+        tool_calls.append(
+            ToolCall(
+                id=f"call_{uuid.uuid4().hex[:8]}",
+                type="function",
+                function=FunctionCall(
+                    name=name.strip(),
+                    arguments=_serialize_tool_arguments(
+                        arguments, name.strip(), request
+                    ),
+                ),
+            )
         )
+        valid_python_tag_spans.append((start, end))
+
+    # Splice out matched ``<|python_tag|>{...}`` spans (in reverse so
+    # earlier offsets stay valid).
+    if valid_python_tag_spans:
+        for start, end in reversed(valid_python_tag_spans):
+            cleaned_text = cleaned_text[:start] + cleaned_text[end:]
         cleaned_text = cleaned_text.strip()
 
     # Note: We keep  tags for reasoning models


### PR DESCRIPTION
## Summary

- The Llama `<|python_tag|>{...}` parser in `vllm_mlx/api/tool_calling.py` used a non-greedy `\{.*?\}` regex on the `parameters` value. On nested schemas (`filters`, `options`, `config` sub-objects) the scan terminated at the FIRST nested `}`, `json.loads` raised, the entire tool call was dropped, and a lone `}` leaked into the cleaned content — silent failure on every Llama 3.x model with tools enabled and a common nested schema.
- Fix: vendor the same string-aware balanced-brace scanner that `vllm_mlx/tool_parsers/llama_tool_parser.py` already uses (`_find_top_level_json_object`). Inlined here as `_find_balanced_json_object` to avoid a circular import — `tool_parsers/__init__.py` eagerly loads `qwen3coder_tool_parser`, which imports back from `vllm_mlx.api.tool_calling`. New `_iter_python_tag_tool_calls` walks each marker, finds the next `{`, depth-scans through the matching `}` while respecting `"`-strings and `\\` escapes, `json.loads`, and emits `(start, end_exclusive, payload)` so residual text is spliced precisely.
- Accepts both the official `parameters` key and the OpenAI `arguments` alias some quantizations drift to. R15 #312.

Repro (was: `('}', None)`, now: cleaned `""` + one nested-args ToolCall):

```python
parse_tool_calls('<|python_tag|>{"name":"search","parameters":{"query":"x","filters":{"lang":"en"}}}')
```

Changes:
- `vllm_mlx/api/tool_calling.py` — added `_find_balanced_json_object` (≈40 LOC) + `_iter_python_tag_tool_calls` (≈50 LOC); refactored Format 2 branch in `parse_tool_calls` to use them.
- `tests/test_tool_calling.py` — new `TestLlamaPythonTagNestedArguments` class, 7 cases.

## Test plan

- [x] Repro case now parses + cleaned_text is empty (`test_dogfood_repro_two_level_nesting`)
- [x] Nested + string-internal braces (6 unit tests pass — `TestLlamaPythonTagNestedArguments`, 7 total in the new class)
- [x] No regression in adjacent llama tool parser tests (1722 passed across `tests/ -k tool --ignore=tests/integrations`; full `tests/test_tool_calling.py` + `tests/test_llama_tool_parser_bare_json.py` = 107 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)