### PR TITLE
fix(api): SSE keepalive boundary + reject null content (R15 0.9-must-fix)

### DIFF
--- a/tests/test_anthropic_route_thinking_gate.py
+++ b/tests/test_anthropic_route_thinking_gate.py
@@ -583,6 +583,13 @@ def test_stream_route_wire_format_event_prefix_and_terminator():
         # multi-line ``data:`` framing remain valid SSE shapes that a
         # future legitimate change might introduce.
         assert lines, f"empty SSE chunk: {raw!r}"
+        # R15 #291: the SSE disconnect-guard injects a single
+        # ``: keepalive`` comment line right after the first real
+        # chunk (Vlad 8k-prompt boundary fix). Comments are no-ops
+        # per WHATWG SSE §9.2.6 — skip them for the event-framing
+        # check (they have neither ``event:`` nor ``data:`` lines).
+        if all(line.startswith(":") for line in lines):
+            continue
         assert lines[0].startswith("event: "), (
             f"first SSE line must start with 'event: ': {lines[0]!r}"
         )

--- a/tests/test_api_models.py
+++ b/tests/test_api_models.py
@@ -160,6 +160,87 @@ class TestMessage:
         msg = Message(role="assistant", content=None)
         assert msg.content is None
 
+    @pytest.mark.parametrize("role", ["user", "system", "developer"])
+    def test_null_content_rejected_for_input_roles(self, role):
+        """R15 #175 item 3 (adversarial fuzz a9c828): a request body
+        carrying ``{"role":"user","content":null}`` (or "system" /
+        "developer") used to return HTTP 200 with garbled output (the
+        chat-template flattened ``None`` to the literal string
+        ``"None"`` on some templates, dropped the turn on others).
+        Post-fix the schema layer rejects with a clear error pointing
+        at the content field, so the route surfaces 400 via the
+        ``RequestValidationError`` envelope handler."""
+        with pytest.raises(ValidationError) as excinfo:
+            Message(role=role, content=None)
+        # Field path is surfaced so the OpenAI-shaped envelope can
+        # populate ``error.param`` with ``content``.
+        assert "content" in str(excinfo.value)
+        # Error mentions the role so a single-message-array client
+        # knows which turn to fix.
+        assert role in str(excinfo.value)
+
+    def test_null_content_allowed_for_assistant(self):
+        """OpenAI spec allows assistant ``content=null`` when
+        ``tool_calls`` is present (the response IS the call). We also
+        preserve the pre-fix behaviour for plain assistant turns —
+        the #175 fuzz only exposed the user-role case, and tightening
+        the assistant path would break the response→follow-up
+        roundtrip where THIS server's AssistantMessage shape (which
+        emits ``content=null`` for reasoning-only turns) gets re-sent
+        as a Message."""
+        msg = Message(role="assistant", content=None)
+        assert msg.content is None
+        msg_tc = Message(
+            role="assistant",
+            content=None,
+            tool_calls=[
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "noop"},
+                }
+            ],
+        )
+        assert msg_tc.content is None
+        assert msg_tc.tool_calls is not None
+
+    def test_null_content_allowed_for_tool(self):
+        """The route-layer F-111 validator already normalises tool
+        ``content=null`` to an empty string. Keep the schema-layer
+        gate loose so the existing normalization path keeps working."""
+        msg = Message(role="tool", content=None, tool_call_id="call_1")
+        assert msg.content is None
+
+    def test_empty_string_content_allowed(self):
+        """An empty string is a legitimate empty turn — OpenAI accepts
+        it and downstream chat templates handle it gracefully."""
+        msg = Message(role="user", content="")
+        assert msg.content == ""
+
+    def test_empty_list_content_allowed(self):
+        """An empty multimodal array is legitimate: the engine decides
+        whether to skip the turn or surface a validation error. The
+        schema layer must NOT reject ``[]`` — only the explicit null
+        shape that the fuzz exposed."""
+        msg = Message(role="user", content=[])
+        assert msg.content == []
+
+    def test_multimodal_content_allowed_with_image_only(self):
+        """A multimodal user turn with only an image_url part — no
+        text — must pass. R15 #175 fix gates on ``content is None``
+        not on list contents."""
+        msg = Message(
+            role="user",
+            content=[
+                ContentPart(
+                    type="image_url",
+                    image_url=ImageUrl(url="https://example.com/x.png"),
+                )
+            ],
+        )
+        assert isinstance(msg.content, list)
+        assert len(msg.content) == 1
+
 
 class TestToolCalling:
     """Tests for tool calling models."""

--- a/tests/test_sse_keepalive.py
+++ b/tests/test_sse_keepalive.py
@@ -54,9 +54,13 @@ def test_sse_response_headers_constant_matches_anti_buffering_contract():
 def test_disconnect_guard_passes_through_chunks_unchanged():
     """Positive control: with the upstream generator firing quickly
     (faster than the keepalive interval), the guard MUST NOT inject
-    any ``: keepalive`` comments — only the real chunks reach the
-    client. Otherwise a fast-streaming model would get its bandwidth
-    inflated with no-op comments."""
+    any ``: keepalive`` comments BETWEEN real chunks — only the real
+    chunks reach the client (modulo the single post-first-chunk
+    keepalive added in R15 #291, which lands AFTER the first chunk
+    but BEFORE any subsequent ones).
+
+    Otherwise a fast-streaming model would get its bandwidth inflated
+    with no-op comments at every token boundary."""
     from vllm_mlx.service.helpers import _disconnect_guard
 
     async def _generator():
@@ -81,9 +85,20 @@ def test_disconnect_guard_passes_through_chunks_unchanged():
         return out
 
     chunks = asyncio.run(_run())
-    assert chunks == ["data: a\n\n", "data: b\n\n", "data: c\n\n"]
-    # And critically, NO keepalive comments leaked in.
-    assert not any(c.startswith(": keepalive") for c in chunks)
+    # R15 #291: a single keepalive comment lands immediately after the
+    # role-equivalent first chunk. Subsequent fast-streaming chunks
+    # MUST NOT carry interleaved comments.
+    assert chunks == [
+        "data: a\n\n",
+        ": keepalive\n\n",
+        "data: b\n\n",
+        "data: c\n\n",
+    ]
+    keepalives = [c for c in chunks if c.startswith(": keepalive")]
+    assert len(keepalives) == 1, (
+        f"R15 #291 contract: at most one keepalive on fast streams "
+        f"(the post-first-chunk emit). Got {len(keepalives)}: {chunks}"
+    )
 
 
 def test_disconnect_guard_emits_keepalive_when_generator_stalls():
@@ -279,18 +294,25 @@ def test_disconnect_guard_does_not_eagerly_prefetch_after_yield():
         async def is_disconnected(self) -> bool:
             return False
 
-    consumer_pulls = 0
-    upstream_at_consume = []
+    real_chunk_pulls = 0
+    upstream_at_consume: list[int] = []
 
     async def _run():
-        nonlocal consumer_pulls
+        nonlocal real_chunk_pulls
         agen = _disconnect_guard(
             _instrumented_generator(),
             _FakeRequest(),
             keepalive_seconds=60.0,
         )
         async for chunk in agen:
-            consumer_pulls += 1
+            # R15 #291: the wrapper also emits a one-shot keepalive
+            # right after the first real chunk. That keepalive is
+            # generated entirely inside the wrapper, with no upstream
+            # ``__anext__`` involvement, so the prefetch invariant we
+            # care about is sampled only on REAL data chunks.
+            if chunk.startswith(": keepalive"):
+                continue
+            real_chunk_pulls += 1
             # Sample the upstream's pull counter at the moment the
             # consumer received a chunk. A regression that re-introduces
             # eager prefetch would have ``upstream_pulls`` jump ahead
@@ -306,8 +328,160 @@ def test_disconnect_guard_does_not_eagerly_prefetch_after_yield():
 
     # Consumer pulled 3 real chunks (a/b/c). Upstream MUST not be
     # ahead — every snapshot equals the consumer count at that point.
-    assert consumer_pulls == 3, consumer_pulls
+    assert real_chunk_pulls == 3, real_chunk_pulls
     assert upstream_at_consume == [1, 2, 3], upstream_at_consume
+
+
+def test_disconnect_guard_emits_keepalive_immediately_after_first_chunk():
+    """R15 #291 / #308 (Vlad 8k-prompt boundary fix): the very first
+    real upstream chunk on chat-completions SSE is a synthetic
+    ``role`` delta that fires almost instantly (~30 ms). The next
+    chunk is the first content token, which is gated on prefill
+    completion. Pre-fix, on prompts whose prefill takes ~``keepalive_seconds``
+    (the 8 k-token boundary case), ``asyncio.wait`` saw ``anext_task``
+    complete in the ``done`` set and SKIPPED the keepalive branch:
+    client got the role chunk, then ``keepalive_seconds`` of silence,
+    then the first content delta. Any HTTP client with idle timeout <
+    ``keepalive_seconds`` tore the connection down mid-prefill.
+
+    Post-fix the guard emits a single SSE comment line IMMEDIATELY
+    after the first real chunk. Comments are spec no-ops, so SDK
+    parsers ignore them — but TCP-level proxies / EventSource pools
+    see the bytes and reset their idle timer."""
+    from vllm_mlx.service.helpers import _disconnect_guard
+
+    role_chunk = 'data: {"choices":[{"delta":{"role":"assistant"}}]}\n\n'
+    content_chunk = 'data: {"choices":[{"delta":{"content":"hi"}}]}\n\n'
+
+    async def _role_then_long_prefill():
+        # The role chunk fires fast (mirror real upstream's ~30 ms).
+        yield role_chunk
+        # Then the upstream stalls (= prefill in progress). We park
+        # well under the ``keepalive_seconds`` boundary on purpose:
+        # the post-role-chunk keepalive must fire from the FIRST-CHUNK
+        # branch, NOT from the stall-timeout branch. If we relied only
+        # on the stall-timeout branch, this assertion would never fire
+        # because the second chunk arrives before the timer ticks.
+        await asyncio.sleep(0.05)
+        yield content_chunk
+
+    class _FakeRequest:
+        async def is_disconnected(self) -> bool:
+            return False
+
+    async def _run():
+        out = []
+        events_t = []
+        t0 = time.monotonic()
+        # ``keepalive_seconds`` is LONGER than the upstream's ~50 ms
+        # stall — so the stall-timeout branch CANNOT contribute the
+        # observed keepalive. Only the post-first-chunk emit can.
+        async for chunk in _disconnect_guard(
+            _role_then_long_prefill(),
+            _FakeRequest(),
+            keepalive_seconds=10.0,
+        ):
+            out.append(chunk)
+            events_t.append(time.monotonic() - t0)
+        return out, events_t
+
+    chunks, event_times = asyncio.run(_run())
+
+    # Sequence MUST be: role chunk, keepalive comment, content chunk.
+    assert chunks[0] == role_chunk, chunks
+    assert chunks[1] == ": keepalive\n\n", chunks
+    assert chunks[2] == content_chunk, chunks
+
+    # The keepalive must land within 1 s of the role chunk — pre-fix
+    # it could be ``keepalive_seconds`` (20 s default) away.
+    delay_role_to_keepalive = event_times[1] - event_times[0]
+    assert delay_role_to_keepalive < 1.0, (
+        f"keepalive lagged {delay_role_to_keepalive:.3f} s behind role "
+        f"chunk; R15 #291 contract requires <1 s"
+    )
+
+
+def test_disconnect_guard_post_role_keepalive_respects_disable_knob():
+    """Operator escape hatch contract: with
+    ``RAPID_MLX_SSE_KEEPALIVE_SECONDS=0`` (``keepalive_seconds=0``),
+    the post-role-chunk keepalive emit must ALSO be suppressed.
+    Otherwise an operator who explicitly opted out of heartbeats
+    still pays the per-stream extra frame, contradicting the F-070
+    disable contract."""
+    from vllm_mlx.service.helpers import _disconnect_guard
+
+    async def _two_chunks():
+        yield "data: a\n\n"
+        await asyncio.sleep(0.05)
+        yield "data: b\n\n"
+
+    class _FakeRequest:
+        async def is_disconnected(self) -> bool:
+            return False
+
+    async def _run():
+        out = []
+        async for chunk in _disconnect_guard(
+            _two_chunks(), _FakeRequest(), keepalive_seconds=0.0
+        ):
+            out.append(chunk)
+        return out
+
+    chunks = asyncio.run(_run())
+    assert chunks == ["data: a\n\n", "data: b\n\n"], chunks
+    assert not any(c.startswith(": keepalive") for c in chunks)
+
+
+def test_disconnect_guard_16k_long_stall_keepalive_cadence_regression():
+    """R15 #291 regression guard: the longer-prefill case (16 k-prompt
+    equivalent in this test — multiple stall windows past the
+    keepalive interval) must STILL produce one keepalive per stall
+    window. Pre-fix this worked already; the #291 fix must not
+    inadvertently change the steady-state cadence into "one and done".
+
+    Models the 16 k case: the upstream stalls for ~4×``keepalive_seconds``
+    before producing the first content token. We expect:
+      * 1 post-first-chunk keepalive (R15 #291 fix)
+      * >=3 stall-timeout keepalives (steady-state F-070 cadence)
+    """
+    from vllm_mlx.service.helpers import _disconnect_guard
+
+    async def _role_then_very_long_prefill():
+        yield "data: role\n\n"
+        # ~4 keepalive periods of stall — mirrors the 16 k case where
+        # multiple cadence ticks fire before first content.
+        await asyncio.sleep(0.4)
+        yield "data: first_content\n\n"
+
+    class _FakeRequest:
+        async def is_disconnected(self) -> bool:
+            return False
+
+    async def _run():
+        out = []
+        async for chunk in _disconnect_guard(
+            _role_then_very_long_prefill(),
+            _FakeRequest(),
+            keepalive_seconds=0.1,
+        ):
+            out.append(chunk)
+        return out
+
+    chunks = asyncio.run(_run())
+    keepalives = [c for c in chunks if c.startswith(": keepalive")]
+    # At least 4 keepalives: 1 from the post-first-chunk emit + ~3
+    # from the stall-timeout branch (0.4 s / 0.1 s = 4 ticks, minus
+    # scheduling jitter).
+    assert len(keepalives) >= 4, (
+        f"expected >=4 keepalives (1 post-role + >=3 cadence); "
+        f"got {len(keepalives)}: {chunks}"
+    )
+    # Real frames still made it through.
+    assert "data: role\n\n" in chunks
+    assert "data: first_content\n\n" in chunks
+    # First emission order is preserved: role then keepalive.
+    assert chunks[0] == "data: role\n\n"
+    assert chunks[1] == ": keepalive\n\n"
 
 
 def test_disconnect_guard_keepalive_does_not_break_disconnect_detection():

--- a/vllm_mlx/api/models.py
+++ b/vllm_mlx/api/models.py
@@ -851,6 +851,58 @@ class Message(BaseModel):
     tool_call_id: str | None = None
 
     @model_validator(mode="after")
+    def _validate_content_not_null(self) -> "Message":
+        """Reject ``content: null`` on roles where the OpenAI spec
+        requires content (R15 #175 item 3 / fuzz a9c828).
+
+        OpenAI chat-completions spec: ``content`` is REQUIRED for
+        ``role:"user" | "system" | "developer"``. Only ``role:"assistant"``
+        may carry ``content=null`` — and only when ``tool_calls`` is
+        present (the model's response is the call, not text).
+        ``role:"tool"`` is policed by the route-level F-111 validator
+        which already accepts ``None`` and normalises to ``""``
+        downstream; we preserve that contract here.
+
+        Pre-fix the schema accepted any of {None, str, list[ContentPart],
+        list[dict]} for every role. A user message with ``content=null``
+        returned HTTP 200 with garbled output (the chat-template
+        renderer flattened ``None`` to the literal string ``"None"`` or
+        skipped the turn outright, depending on the model). Adversarial
+        fuzz a9c828 reproduced it on Qwen3-0.6B; same shape silently
+        passed on every other model.
+
+        Empty list ``[]`` and empty string ``""`` are both accepted —
+        multimodal user turns can legitimately send ``content=[]`` (e.g.
+        the only relevant part is sourced via a tool the model called
+        on the previous turn). The engine decides how to render an
+        empty-list turn; the schema layer only rejects the ``null``
+        shape that the fuzz exposed.
+        """
+        if self.content is not None:
+            return self
+        # ``content is None`` past this point.
+        #
+        # Allow assistant ``content=null`` regardless of ``tool_calls``:
+        # the OpenAI spec technically requires ``tool_calls`` to license
+        # the null, but many existing clients (and the response shape
+        # of THIS server when it emits AssistantMessage back into a
+        # follow-up request) send assistant turns with null content
+        # without tool_calls. Tightening that path is out of scope for
+        # the #175 fix — the fuzz only exposed the user-role case.
+        if self.role == "assistant":
+            return self
+        # ``role:"tool"`` content = None is normalised by the route's
+        # F-111 validator to an empty string. Preserve that path so we
+        # don't double-reject what an existing layer already cleans up.
+        if self.role == "tool":
+            return self
+        raise ValueError(
+            "content must be a string or a content-parts array, not null "
+            f"(role={self.role!r}); send '' for an empty turn or [] "
+            "for an empty multimodal turn"
+        )
+
+    @model_validator(mode="after")
     def _validate_media_url_types(self) -> "Message":
         """Reject non-string ``url`` inside multimodal-content payloads
         (F-066).

--- a/vllm_mlx/service/helpers.py
+++ b/vllm_mlx/service/helpers.py
@@ -3558,6 +3558,41 @@ async def _disconnect_guard(
                     f"[disconnect_guard] first chunk arrived, elapsed={_elapsed()}"
                 )
             yield chunk
+            # R15 #291 / #308 (Vlad 8k-prompt boundary): the very first
+            # upstream chunk on chat-completions SSE is the synthetic
+            # ``role`` delta, which fires almost instantly (~30 ms).
+            # The next chunk is the FIRST CONTENT TOKEN — gated on
+            # prefill completion. For prompts near the ``keepalive_seconds``
+            # boundary (~8 k tokens at ~20 s default keepalive), prefill
+            # lands at or just before the keepalive timer's first tick:
+            # ``asyncio.wait`` sees ``anext_task`` complete in the
+            # ``done`` set and skips the keepalive branch entirely. The
+            # client gets the role chunk at t=30 ms, then 20 s of silence,
+            # then the first content delta. Any HTTP client with an
+            # idle timeout < ``keepalive_seconds`` (browser EventSource
+            # ~45 s, but proxies + custom SDK pools as low as 10 s)
+            # tears the connection down mid-prefill.
+            #
+            # Fix: emit a one-time SSE comment line IMMEDIATELY after
+            # the first real chunk. Comments are spec-defined no-ops
+            # (WHATWG SSE §9.2.6 / RFC: every client strips them), so
+            # downstream parsers are unaffected. The cost is a single
+            # 14-byte frame per stream. We do NOT change the steady-
+            # state cadence — subsequent stalls still wait the full
+            # ``keepalive_seconds`` window, preserving the F-070
+            # bandwidth contract.
+            #
+            # Gated on ``keepalive_enabled`` so the
+            # ``RAPID_MLX_SSE_KEEPALIVE_SECONDS=0`` escape hatch keeps
+            # the post-role-chunk frame off the wire too — an operator
+            # that opted out of heartbeats opted ALL THE WAY out.
+            if chunk_count == 1 and keepalive_enabled:
+                keepalive_count += 1
+                logger.info(
+                    f"[disconnect_guard] post-first-chunk keepalive "
+                    f"(R15 #291), elapsed={_elapsed()}"
+                )
+                yield ": keepalive\n\n"
             # Loop top will re-create the anext_task now that the
             # consumer has pulled this chunk. Do NOT eagerly schedule
             # the next ``__anext__`` here — see the docstring at loop


### PR DESCRIPTION
## Summary

Two small route-layer correctness fixes from the R15 0.9 must-fix triage:

- **R15 #291 / #308 — SSE keepalive boundary on 8 k-prompt streams** (Vlad).
  `_disconnect_guard` previously only emitted heartbeats when the upstream generator stalled longer than `keepalive_seconds` (20 s default). For prompts whose prefill lands at or just before that boundary (~8 k tokens), `asyncio.wait` saw `anext_task` complete in the `done` set and skipped the keepalive branch — client got the role chunk at t=30 ms, then 20 s of silence, then the first content delta, so HTTP clients with idle timeouts under `keepalive_seconds` tore the connection down mid-prefill. Fix: emit one `: keepalive\n\n` comment immediately after the first real chunk. Steady-state cadence unchanged; gated on `keepalive_enabled` so `RAPID_MLX_SSE_KEEPALIVE_SECONDS=0` still suppresses ALL heartbeats.

- **R15 #175 item 3 — `{role:"user", content:null}` silently accepted** (fuzz a9c828). `Message.content=null` for `role:"user" | "system" | "developer"` used to return HTTP 200 with garbled output (some templates flattened `None` to the literal string `"None"`). Fix: new `Message._validate_content_not_null` Pydantic validator rejects null content for input roles and surfaces a 400 with `error.param="content"`. Preserves `role:"assistant"` (response→follow-up roundtrip) and `role:"tool"` (route-layer F-111 already normalises `None`→`""`). Empty string `""` and empty list `[]` remain accepted.

Anthropic stream-framing test was updated to skip pure-comment chunks per WHATWG SSE §9.2.6 — the new post-role-chunk keepalive is a valid no-op frame downstream parsers ignore.

## Test plan

- [x] SSE keepalive emits within 1 s of role chunk (unit test) — `test_disconnect_guard_emits_keepalive_immediately_after_first_chunk` asserts the keepalive lands <1 s after the role chunk on `keepalive_seconds=10`
- [x] 16k-prompt keepalive cadence regression test — `test_disconnect_guard_16k_long_stall_keepalive_cadence_regression` verifies >=4 keepalives (1 post-role + >=3 cadence) over ~4 keepalive periods of stall
- [x] HTTP 400 on `{content: null}` with field path — `test_null_content_rejected_for_input_roles` (parametrised over user/system/developer) asserts the `content` field name and role appear in the validation error
- [x] No regression in adjacent chat-completions tests (paste pass count) — full suite excluding `integrations/`: **10508 passed, 22 failed (all 22 pre-exist on `main`; verified by stashing the diff and re-running — same 22 audio-route / MTP / mlx-compat / no-out-of-band-routing failures appear on baseline)**

## Files

- `vllm_mlx/service/helpers.py` — `_disconnect_guard` post-first-chunk keepalive emit
- `vllm_mlx/api/models.py` — `Message._validate_content_not_null`
- `tests/test_sse_keepalive.py` — +3 new tests, 2 existing tests updated for new contract
- `tests/test_api_models.py` — +6 new tests for null/empty/multimodal content
- `tests/test_anthropic_route_thinking_gate.py` — wire-format check skips comment-only chunks

## Constraints respected

- No `default_stream` shim removal
- No NaN-validator changes (no float schemas touched)
- No `aliases.json` changes
- Reinstalled from worktree before testing; `vllm_mlx.__file__` points to worktree
- `ruff check --fix` + `ruff format` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)