### PR TITLE
fix(spec-decode): route --spec-decode dflash to working --enable-dflash bridge (#318)

### DIFF
--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -35,6 +35,8 @@
     "is_hybrid_explicit": true,
     "is_moe": false,
     "supports_spec_decode": false,
+    "supports_dflash": true,
+    "dflash_draft_model": "z-lab/Qwen3.5-9B-DFlash",
     "pflash_tier": "verified"
   },
   "qwen3.5-27b-4bit": {

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -1931,6 +1931,31 @@ def serve_command(args):
     else:
         server._reasoning_parser = None
 
+    # R15-P1 #313 follow-up (#318): ``--spec-decode dflash`` routes to
+    # the prod path. The originally vendored BatchedEngine adapter at
+    # ``vllm_mlx/spec_decode/dflash/drafter.py:275`` called
+    # ``drafter.draft_block(prefix_tokens, current_position)`` with 2 args,
+    # but mlx-vlm 0.5.0's ``DFlashDraftModel.draft_block`` requires 6 args:
+    # ``(last_bonus, hidden, cache, block_size, sampler, token_dtype)``.
+    # The BatchedEngine adapter never wired the verifier→drafter hidden-
+    # state + cache + sampler thread, so the new --spec-decode dflash
+    # flag was 100% broken at first request — never validated end-to-end.
+    # The OLD ``--enable-dflash`` flag (``vllm_mlx/speculative/dflash/`` +
+    # mlx-vlm's ``_dflash_rounds``) IS the prod-tested path. We unify the
+    # CLI surface by routing ``--spec-decode dflash`` to
+    # ``--enable-dflash`` so users hit the working bridge. The
+    # ``spec_decode/dflash/{generator,drafter,verifier}.py`` modules
+    # remain importable but inert; the ``accept_counter`` /
+    # ``drafter_registry`` siblings stay active for metric scaffolding.
+    if getattr(args, "spec_decode", "none") == "dflash":
+        args.enable_dflash = True
+        args.spec_decode = "none"
+        print(
+            "Spec-decode: --spec-decode dflash routed to --enable-dflash "
+            "(mlx-vlm bridge; BatchedEngine integration deferred to 0.10).",
+            file=sys.stderr,
+        )
+
     # DFlash mutual-exclusion gate fires BEFORE the startup banner so
     # the user sees a clean error instead of an optimistic "Features:
     # dflash" line immediately followed by an exit. The deeper SchedulerConfig
@@ -2350,53 +2375,11 @@ def serve_command(args):
             sys.exit(2)
         print(f"Spec-decode: mtp ({eligibility.value})")
 
-    # R15-P1 #313: DFlash boot-time eligibility check. Same architecture
-    # gate as MTP (Qwen3.5 / 3.6) but a different drafter binding gate
-    # (side-registry or --dflash-drafter-path override). Rejects at boot
-    # so an operator on a non-Qwen model sees a clear error rather than
-    # discovering the mismatch at first decode.
-    if getattr(args, "spec_decode", "none") == "dflash":
-        from vllm_mlx.spec_decode.dflash import (
-            DFlashEligibility,
-            detect_dflash_eligibility,
-        )
-
-        try:
-            hf_cfg_eligibility, _ = _gather_kv_cache_dtype_inputs(args.model)
-        except Exception:  # pragma: no cover — best-effort
-            hf_cfg_eligibility = None
-        eligibility = detect_dflash_eligibility(
-            hf_cfg_eligibility,
-            alias=args.model,
-            drafter_override=getattr(args, "dflash_drafter_path", "") or None,
-        )
-        if eligibility is DFlashEligibility.NONE:
-            print(
-                "error: --spec-decode dflash requires a Qwen3.5 / Qwen3.6 "
-                "model AND a bound DFlash drafter. Register one via "
-                "vllm_mlx.spec_decode.dflash.register_dflash_drafter() "
-                "or pass --dflash-drafter-path <hf_id_or_local_path>.",
-                file=sys.stderr,
-            )
-            sys.exit(2)
-        print(f"Spec-decode: dflash ({eligibility.value})")
-        # Warn (don't reject) on the K8V4 vs --kv-cache-dtype int4
-        # interaction. The lossless contract holds for both, but the
-        # accept rate drops empirically because the verifier and
-        # drafter see DIFFERENT KV quantization paths (drafter stays
-        # at bf16, verifier writes through TurboQuant K8V4 — this
-        # mismatches the paper bench setup). Operators who explicitly
-        # WANT the combo can ignore the warning; we just surface the
-        # caveat so a 20% accept-rate regression doesn't get blamed
-        # on rapid-mlx.
-        if getattr(args, "kv_cache_turboquant", False):
-            print(
-                "warning: --spec-decode dflash + --kv-cache-turboquant "
-                "(K8V4) is a non-paper config — accept rate may drop "
-                "vs --kv-cache-dtype bf16 / int4. The lossless "
-                "contract still holds.",
-                file=sys.stderr,
-            )
+    # ``--spec-decode dflash`` is normalized to ``--enable-dflash`` near
+    # the top of serve_command (#318 redirect); by the time we reach
+    # here, args.spec_decode is "none" for dflash callers. The
+    # speculative.dflash gate at the start of serve_command runs the
+    # actual eligibility + drafter-binding checks via the prod bridge.
     if args.suffix_decoding:
         print(
             f"SuffixDecoding: enabled, max_draft={args.suffix_max_draft}, "

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -2475,9 +2475,17 @@ def serve_command(args):
         assert _profile is not None and _profile.supports_dflash, (
             f"DFlash profile invariant violated for {_alias_name!r}"
         )
+        # ``--dflash-drafter-path`` override stays valid through both
+        # ``--enable-dflash`` and the ``--spec-decode dflash`` redirect
+        # path (#318): an operator-supplied path wins over the profile
+        # default. Empty string / missing attr falls back to the alias
+        # registry entry (validated non-None by _coerce_alias_dflash).
+        _dflash_drafter_override = (
+            getattr(args, "dflash_drafter_path", "") or ""
+        ).strip()
         run_dflash_server(
             main_model_repo=_profile.hf_path,
-            drafter_repo=_profile.dflash_draft_model,  # validated non-None by _coerce
+            drafter_repo=_dflash_drafter_override or _profile.dflash_draft_model,
             host=args.host,
             port=args.port,
             served_model_name=args.served_model_name or _alias_name,

--- a/vllm_mlx/spec_decode/dflash/__init__.py
+++ b/vllm_mlx/spec_decode/dflash/__init__.py
@@ -46,14 +46,21 @@ runtimes:
 * :mod:`vllm_mlx.speculative.dflash` — the original PoC bridge that
   calls into ``mlx-vlm 0.5.0+``'s built-in drafter loader. Lives next to
   the SuffixDecoding / prompt-lookup speculative paths. Driven by the
-  ``--enable-dflash`` flag.
+  ``--enable-dflash`` flag. **This is the only production-working DFlash
+  path in 0.9.x** (paper-bench-verified ≥3.5× on 27B int4+bf16-KV).
 * :mod:`vllm_mlx.spec_decode.dflash` (THIS module) — the R15-P1 #313
-  vendored backend that integrates with the standardized
-  ``--spec-decode {none,mtp,dflash}`` interface so a future ablation /
-  benchmark layer can swap between MTP and DFlash without touching the
-  call site. Under the hood the drafter forward delegates to the same
-  mlx-vlm bridge when available, but the verifier and accept-counter
-  scaffolding lives here.
+  vendored scaffolding for the standardized
+  ``--spec-decode {none,mtp,dflash}`` interface. The accept counter, the
+  drafter registry, and the eligibility detector are stable and used by
+  metrics + the CLI banner. The drafter/verifier/generator integration
+  with BatchedEngine is **DEFERRED to 0.10** — the original adapter
+  (``drafter.py:275``) called ``DFlashDraftModel.draft_block(prefix,
+  position)`` against an mlx-vlm 0.5.0 signature that requires
+  ``(last_bonus, hidden, cache, block_size, sampler, token_dtype)``.
+
+For 0.9, ``--spec-decode dflash`` on the CLI redirects to
+``--enable-dflash`` (see :mod:`vllm_mlx.cli`) so operators still get a
+working DFlash path through the unified flag surface.
 
 Both paths share the lossless contract: byte-identical output to the
 no-spec-decode path (rejection always emits the verify model's pred at


### PR DESCRIPTION
## What broke

`vllm_mlx/spec_decode/dflash/drafter.py:275` calls

```python
drafter.draft_block(prefix_tokens, current_position)
```

But the upstream `mlx_vlm 0.5.0` `DFlashDraftModel.draft_block` signature is

```python
draft_block(self, last_bonus, hidden, cache: List[KVCache], block_size: int, sampler, token_dtype=mx.int32)
```

— 6 positional args, not 2. The R15-P1 #313 BatchedEngine adapter never threaded the verifier→drafter `hidden / cache / sampler / last_bonus` arguments through the pipeline, so the new `--spec-decode dflash` flag was **100% broken at first request** — it was never validated end-to-end against the real `mlx_vlm` runtime.

The bench command from the PR description (`bench/bench_spec_decode_dflash.py`) crashes with:

```
TypeError: DFlashDraftModel.draft_block() missing 3 required positional arguments: 'cache', 'block_size', and 'sampler'
```

The OLD `--enable-dflash` path (`vllm_mlx/speculative/dflash/` + mlx-vlm's internal `_dflash_rounds` orchestrator) IS production-tested and is the DFlash path operators should be hitting (paper-bench-verified ≥3.5× on 27B int4 + bf16-KV).

## What this PR does

1. **Adds a top-of-`serve_command` redirect**: if a caller passes `--spec-decode dflash`, we set `args.enable_dflash = True` and `args.spec_decode = "none"`, then emit a one-line stderr notice. The CLI flag surface stays valid; operators just transparently hit the working bridge.
2. **Removes the now-dead eligibility / K8V4-warning block** (the same eligibility check already exists inside the `--enable-dflash` mutex gate earlier in `serve_command`).
3. **Marks `spec_decode/dflash/__init__.py`'s docstring honest**: accept counter + drafter registry + eligibility detector are stable scaffolding (used by metrics + CLI banner), but the drafter/verifier/generator integration with BatchedEngine is **DEFERRED to 0.10**.
4. **Adds `qwen3.5-9b-8bit` → `dflash_draft_model: z-lab/Qwen3.5-9B-DFlash`** in `aliases.json` so the unified flag surface can route the 9B-8bit alias through the working bridge. (DFlash structurally regresses on 4-bit target weights, so we deliberately don't expose 4-bit aliases.)

## Test plan

- [x] `pytest tests/test_dflash_spec_decode.py` — 50/50 pass (accept-counter, drafter-registry, eligibility-detector in isolation against stub drafters, all independent of the broken adapter).
- [x] `ruff check vllm_mlx/cli.py` clean.
- [x] `python -c "import vllm_mlx.cli"` — no import-time errors.
- [x] codex review (2 rounds) — flagged 1 P2 ( override drop), fixed in follow-up commit; re-review clean.

## Post-merge verification (tracked in 0.9 release sequence, issue #317)

End-to-end DFlash boot via the unified CLI flag will be verified as part of the 0.9 release bench wave on the GPU host: `rapid-mlx serve --model qwen3.5-9b-8bit --spec-decode dflash` must print the routing notice and boot via the `--enable-dflash` path. This step is intentionally NOT a pre-merge gate because the local CI image lacks GPU access to actually boot the model.

## What's intentionally NOT in this PR

- BatchedEngine-native DFlash integration (the proper `_dflash_rounds`-style threading of `hidden / cache / sampler / last_bonus`). That's the 0.10 work item; #318 keeps scope to "unblock 0.9 release without shipping broken code".
- `bench/bench_spec_decode_dflash.py` is left in place but un-fixable on the current adapter; it will be replaced when the 0.10 integration lands.

Closes #318.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
