### PR TITLE
chore: bump version to 0.9.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.8.19"
+version = "0.9.0"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## Summary
Bump pyproject.toml from 0.8.19 → 0.9.0 to cut the **rapid-mlx 0.9.0** release.

Single-commit, no code changes — auto-release.yml will tag `v0.9.0` and publish the GitHub Release on merge. Release notes (体感 dashboard reconciliation, honest pass/fail per row) will be injected post-merge via `gh release edit`.

## Highlights since v0.8.16

**Speculative decoding**
- DFlash spec decode for `qwen3.5-27b-8bit` (PR #313, #927, #928) — code median **1.85×**, opt-in via `--enable-dflash`
- Adapter API mismatch fix for `--spec-decode dflash` flag (PR #318/#927) — now redirects to the working `--enable-dflash` bridge
- Aliases honestly reconciled (PR #928) — only `qwen3.5-27b-8bit` ships DFlash-on; 9B-8bit & 3.6-27B-8bit flipped to `supports_dflash: false` after bench (chat regression 0.41–0.57×)
- MTP scaffolding (PR #302) — cited upstream mlx-lm PR #990 (1.57× headline)

**KV cache + memory**
- `--kv-cache-dtype int4` (TurboQuant K8V4) default-on (PR #300) — measured **1.01×** decode tok/s vs bf16 baseline ≥ 0.95× target
- Arbitrary `position_ids` support (PR #301) — unblocks all tree spec decode
- Disk-backed KV checkpointing (PR #296) — LM Studio MIT port
- MXFP4 + MoE + multi-device guardrail (PR #297)

**Routes + reliability**
- `/healthz` returns 200 during drain (PR #306)
- Port collision exits non-zero (PR #307)
- 8k-prompt streaming dead zone fix (PR #308 — keepalive 20s → 10s)
- `/v1/completions` streaming multi-prompt fix (PR #310)
- `logprobs=true` without `top_logprobs` returns logprobs (PR #311)
- Llama python_tag tool-call parser fix (PR #312)
- Audio routes hidden on text-only servers (PR #292)
- `/v1/responses` `response_format: json_schema` honored (PR #293)

**Aliases**
- GLM-5.2-REAP50 (PR #298)
- Kimi K2.6, Holo3.1-35B-A3B (PR #299)
- Mistral-Small-4-119B-2603 (PR #304)
- Bare `qwen3` 0.6b/1.7b (PR #290)
- Tmax-9B `is_hybrid: true` (PR #926)

**Docs**
- Hero model curation + per-page template (PR #305)
- rapidmlx.com per-alias DFlash bench tables (rapidmlx.com PR #39)

## Pre-merge verification

- [x] auto-release.yml subject regex passes `chore: bump version to 0.9.0`
- [x] pyproject.toml on disk = `0.9.0` (verified with `grep ^version`)
- [x] Release branch from synced origin/main (no stale diff)

## Post-merge sequence (not gating)

Auto-release.yml handles tag creation; release notes (drafted at `/tmp/v0.9.0-release-notes.md` with the honest 体感 dashboard reconciliation) get injected via `gh release edit v0.9.0 --notes-file`; PyPI + Homebrew fan out via publish.yml on the `release: published` event. These are operator-driven follow-ups, not pre-merge gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)