### PR TITLE
fix(0.9.1): honest info spec-decode reason + dedup ps caffeinate wrapper

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.9.1"
+version = "0.9.0"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.9.0"
+version = "0.9.1"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/tests/test_model_auto_config.py
+++ b/tests/test_model_auto_config.py
@@ -780,6 +780,24 @@ class TestVisibility:
         assert "✓ supported" in table
         assert "✗ not needed" in table
 
+    def test_table_for_dense_no_drafter_shows_honest_reason(self):
+        # 0.9.0 dogfood regression guard. ``qwen3.5-4b-4bit`` has
+        # ``supports_spec_decode=False`` (no MTP head trained) but is
+        # NOT hybrid. Before 0.9.1 the Spec-decode row claimed
+        # ``(hybrid arch)`` as the reason, contradicting the
+        # ``Architecture: pure attention`` row two lines above. Now we
+        # surface the actual reason — no MTP/drafter trained for this
+        # alias — so the user can act on it (or stop expecting a flag
+        # to flip).
+        cfg = detect_model_config("mlx-community/Qwen3.5-4B-MLX-4bit")
+        assert cfg is not None
+        assert cfg.is_hybrid is False
+        assert cfg.supports_spec_decode is False
+        table = format_profile_table("mlx-community/Qwen3.5-4B-MLX-4bit", cfg)
+        assert "✗ disabled (no MTP/drafter trained)" in table
+        assert "✗ disabled (hybrid arch)" not in table
+        assert "pure attention" in table
+
     def test_table_for_unknown_shows_defaults(self):
         table = format_profile_table("some-new-model", None)
         assert "no pattern matched" in table

--- a/tests/test_suffix_decoding_tier.py
+++ b/tests/test_suffix_decoding_tier.py
@@ -214,6 +214,23 @@ class TestProfileTableCell:
         assert cell == "n/a (hybrid arch — spec decode off)"
         assert "…" not in cell
 
+    def test_dense_no_drafter_tier_cell_does_not_lie_about_hybrid(self):
+        """0.9.0 dogfood regression guard.
+
+        Pure-attention aliases with no MTP/drafter (e.g. qwen3.5-4b-4bit)
+        had ``supports_spec_decode=False`` rendered with the hybrid-arch
+        reason, contradicting the ``Architecture: pure attention`` row.
+        Surface the actual reason instead.
+        """
+        cfg = ModelConfig(supports_spec_decode=False, is_hybrid=False)
+        cell = _suffix_tier_cell(cfg, max_width=41)
+        # Width-fit to the 41-char ``info`` value column without
+        # triggering the truncator (no trailing ``…)``).
+        assert cell == "n/a (no MTP/drafter — spec decode off)"
+        assert "hybrid arch" not in cell
+        assert "…" not in cell
+        assert len(cell) <= 41
+
     def test_table_rows_all_same_width_for_long_avoid(self):
         """Box-frame alignment invariant: every bordered row must end at
         the same column. Pre-fix the ``Suffix tier`` row for an alias

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -3707,6 +3707,17 @@ def ps_command(_args):
         ):
             continue
 
+        # 0.9.0 dogfood: ``rapid-mlx serve`` runs under a ``caffeinate
+        # -is rapid-mlx serve ...`` wrapper on macOS to prevent sleep.
+        # The wrapper's argv carries the same ``rapid-mlx`` / ``serve``
+        # tokens as the real server, so the substring match above
+        # double-counts it as a second row (same port, different PID).
+        # The wrapper is never the actual server — its argv[0] basename
+        # is the only reliable way to filter it out without missing the
+        # case where caffeinate is launched via an absolute path.
+        if cmd and os.path.basename(cmd[0]) == "caffeinate":
+            continue
+
         # Extract model arg and --port flag. argparse accepts options
         # before positionals, so the model is the first non-flag token
         # after `serve` whose prior token isn't a value-taking flag.

--- a/vllm_mlx/model_auto_config.py
+++ b/vllm_mlx/model_auto_config.py
@@ -1189,7 +1189,20 @@ def _suffix_tier_cell(cfg: "ModelConfig", max_width: int | None = None) -> str:
     with ``…)`` instead of ``)``.
     """
     if not cfg.supports_spec_decode:
-        text = "n/a (hybrid arch — spec decode off)"
+        # ``supports_spec_decode=False`` covers two cases: hybrid arches
+        # (Mamba / linear-attention — the runtime gates spec decode off)
+        # and dense models where no MTP/drafter checkpoint is registered.
+        # Surfacing the right reason is load-bearing for ``rapid-mlx info``
+        # — 0.9.0 dogfood found we were reporting ``hybrid arch`` for
+        # pure-attention Qwen3.5/3.6 dense aliases, which contradicts the
+        # ``Architecture: pure attention`` row two lines above.
+        if cfg.is_hybrid:
+            text = "n/a (hybrid arch — spec decode off)"
+        else:
+            # Tight enough to fit the 41-char ``info`` value column
+            # (``inner=60 − 17-char key − 2-char ": "``) so the row
+            # renders without ``_truncate_tier_note`` clipping.
+            text = "n/a (no MTP/drafter — spec decode off)"
     else:
         tier = cfg.suffix_decoding_tier
         speedup = cfg.suffix_bench_speedup or {}
@@ -1313,7 +1326,14 @@ def format_profile_table(model_path: str, cfg: "ModelConfig | None") -> str:
             ),
         ]
     else:
-        spec = "✓ supported" if cfg.supports_spec_decode else "✗ disabled (hybrid arch)"
+        if cfg.supports_spec_decode:
+            spec = "✓ supported"
+        elif cfg.is_hybrid:
+            spec = "✗ disabled (hybrid arch)"
+        else:
+            # 0.9.0 dogfood: non-hybrid + spec-off was rendering
+            # ``hybrid arch`` next to ``Architecture: pure attention``.
+            spec = "✗ disabled (no MTP/drafter trained)"
         throttle = "✓ 200ms gap" if cfg.is_hybrid else "✗ not needed"
         rows = [
             ("Tool format", cfg.tool_call_parser or "(none)"),


### PR DESCRIPTION
## Summary
v0.9.0 dogfood (simulated first-time-user journey on a fresh `pip install rapid-mlx==0.9.0`) surfaced two user-visible UX bugs in `rapid-mlx info` and `rapid-mlx ps`. Both are tight, low-risk fixes plus a `0.9.0 → 0.9.1` bump.

### Bug 1 — `info` lies about *why* spec decode is off (self-contradiction)
```
│ Architecture     : pure attention                            │
│ Spec decode      : ✗ disabled (hybrid arch)                  │   <-- contradicts the line above
```
`supports_spec_decode=False` covers two distinct cases — hybrid arches (Mamba / linear-attention) AND dense models with no MTP/drafter registered — but the reason text hardcoded the hybrid one. Every `qwen3.5-*` / `qwen3.6-*` dense alias in `aliases.json` has `supports_spec_decode=False` and tripped this lie.

Fix: branch on `cfg.is_hybrid` and surface the honest reason. New text:
- hybrid → `✗ disabled (hybrid arch)` (unchanged)
- dense → `✗ disabled (no MTP/drafter trained)`

Same fix in the `Suffix tier` row (`_suffix_tier_cell`) — width-tight to fit the 41-char `info` value column without truncation.

### Bug 2 — `ps` shows two rows per server
```
PID     PORT    MODEL              UPTIME
24121   8801    qwen3-vl-30b-4bit  1h43m
24129   8801    qwen3-vl-30b-4bit  1h43m   <-- same port, same model, different PID
```
The second row is the `caffeinate -is rapid-mlx serve …` sleep-prevention wrapper. Its argv carries the same `rapid-mlx` / `serve` tokens as the real server, so the substring filter double-counts it. Two processes on the same port is a physical impossibility — confusing UX.

Fix: skip `caffeinate` wrappers by `os.path.basename(cmd[0])`.

## Tests
- `TestVisibility.test_table_for_dense_no_drafter_shows_honest_reason` — pins new reason text on the canonical dogfood repro (`qwen3.5-4b-4bit`).
- `TestProfileTableCell.test_dense_no_drafter_tier_cell_does_not_lie_about_hybrid` — pins Suffix tier row fits the 41-char value column without truncation.

## Test plan
- [x] `pytest tests/test_model_auto_config.py::TestVisibility tests/test_suffix_decoding_tier.py tests/test_api_validation_bundle.py::TestPsCommandPortParsing` (41/41 pass)
- [x] Live smoke: `rapid-mlx info qwen3.5-4b-4bit` shows the honest reason
- [x] Live smoke: `rapid-mlx ps` shows 1 row instead of 2 for the running qwen3-vl server

🤖 Generated with [Claude Code](https://claude.com/claude-code)