### PR TITLE
chore: bump version to 0.9.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.9.0"
+version = "0.9.1"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## Summary
Patch bump 0.9.0 → 0.9.1 for the dogfood-driven UX fixes that landed in #930.

## Highlights since v0.9.0
- **`rapid-mlx info` no longer self-contradicts** (#930) — dense (non-hybrid) aliases with `supports_spec_decode=False` previously claimed `(hybrid arch)` as the reason next to `Architecture: pure attention`. Now shows `(no MTP/drafter trained)`.
- **`rapid-mlx ps` no longer double-counts servers** (#930) — the `caffeinate -is rapid-mlx serve …` sleep-prevention wrapper used to render as a second row with the same port. Filtered out by `os.path.basename(cmd[0])`.

## Pre-merge verification
- [x] auto-release.yml subject regex passes `chore: bump version to 0.9.1`
- [x] pyproject.toml on disk = `0.9.1`
- [x] Release branch from synced origin/main (PR #930 already merged into base)
- [x] Single-commit bump, no other changes

## Post-merge sequence (not gating)
auto-release.yml tags `v0.9.1` + publishes GitHub release; publish.yml fans out to PyPI + Homebrew.

🤖 Generated with [Claude Code](https://claude.com/claude-code)