### PR TITLE
fix(info): surface DFlash opt-in for DFlash-eligible aliases

### DIFF
--- a/tests/test_model_auto_config.py
+++ b/tests/test_model_auto_config.py
@@ -798,6 +798,25 @@ class TestVisibility:
         assert "✗ disabled (hybrid arch)" not in table
         assert "pure attention" in table
 
+    def test_table_for_dflash_alias_surfaces_opt_in_flag(self):
+        # 0.9.1 dogfood follow-up. ``qwen3.5-27b-8bit`` is the operator-
+        # shipped DFlash flagship (1.85× code median, 0.9.0 release
+        # notes). Its alias has ``supports_spec_decode=False`` (no MTP
+        # head) BUT ``supports_dflash=True`` with the drafter registered.
+        # Before 0.9.2 the Spec-decode row claimed
+        # ``(no MTP/drafter trained)`` — actively misleading because the
+        # DFlash drafter IS registered and the user can opt in. Surface
+        # the actionable flag instead.
+        cfg = detect_model_config("mlx-community/Qwen3.5-27B-8bit")
+        assert cfg is not None
+        assert cfg.is_hybrid is False
+        assert cfg.supports_spec_decode is False
+        assert cfg.supports_dflash is True
+        table = format_profile_table("mlx-community/Qwen3.5-27B-8bit", cfg)
+        assert "✗ MTP off — try --enable-dflash" in table
+        assert "no MTP/drafter trained" not in table
+        assert "hybrid arch" not in table
+
     def test_table_for_unknown_shows_defaults(self):
         table = format_profile_table("some-new-model", None)
         assert "no pattern matched" in table

--- a/vllm_mlx/model_auto_config.py
+++ b/vllm_mlx/model_auto_config.py
@@ -98,6 +98,15 @@ class ModelConfig:
     # CLI ``--pflash`` still wins. See VALID_PFLASH_TIERS for the enum.
     pflash_tier: str = "unknown"
 
+    # DFlash block-diffusion speculative decoding eligibility (#264, 0.9.0
+    # operator-shipped via ``--enable-dflash`` for ``qwen3.5-27b-8bit``).
+    # Mirrors ``AliasProfile.supports_dflash`` so ``rapid-mlx info`` can
+    # call out the DFlash opt-in path in the ``Spec decode`` row instead
+    # of mis-leading the user with ``(no MTP/drafter trained)`` when an
+    # alias has the DFlash drafter registered. 0.9.1 dogfood found the
+    # 27B-8bit alias hitting exactly that mismatch.
+    supports_dflash: bool = False
+
 
 # DEPRECATED dispatch surface — see ``vllm_mlx/reasoning/think_detector.py``.
 #
@@ -610,6 +619,7 @@ def detect_model_config(model_path: str) -> ModelConfig | None:
             suffix_decoding_tier=profile.suffix_decoding_tier,
             suffix_bench_speedup=speedup,
             pflash_tier=profile.pflash_tier,
+            supports_dflash=profile.supports_dflash,
         )
 
     for pattern, config in _MODEL_PATTERNS:
@@ -1330,6 +1340,15 @@ def format_profile_table(model_path: str, cfg: "ModelConfig | None") -> str:
             spec = "✓ supported"
         elif cfg.is_hybrid:
             spec = "✗ disabled (hybrid arch)"
+        elif cfg.supports_dflash:
+            # 0.9.1 dogfood follow-up: ``qwen3.5-27b-8bit`` is THE
+            # flagship DFlash alias (code median 1.85× per 0.9.0 release
+            # notes), but its alias has ``supports_spec_decode=False``
+            # because no MTP head is trained. Pre-0.9.2 the row claimed
+            # ``(no MTP/drafter trained)`` — half-true but actively
+            # misleading because the DFlash drafter IS registered.
+            # Surface the actionable opt-in instead.
+            spec = "✗ MTP off — try --enable-dflash"
         else:
             # 0.9.0 dogfood: non-hybrid + spec-off was rendering
             # ``hybrid arch`` next to ``Architecture: pure attention``.


### PR DESCRIPTION
## Summary

0.9.1 dogfood follow-up. After 0.9.1 fixed the ``(hybrid arch)`` lie on dense aliases, `info qwen3.5-27b-8bit` — THE flagship DFlash alias (1.85× code median per 0.9.0 release notes) — now rendered:

```
Spec decode      : ✗ disabled (no MTP/drafter trained)
```

Half-true: no MTP head exists. But the row ignored that the DFlash drafter IS registered (`z-lab/Qwen3.5-27B-DFlash`) and is exactly the opt-in path the user should be pointed at from this surface.

After this PR:

```
Spec decode      : ✗ MTP off — try --enable-dflash
```

## Mechanics

1. Add `supports_dflash: bool = False` to `ModelConfig`.
2. Propagate from `AliasProfile.supports_dflash` in `detect_model_config`, same plumbing as `pflash_tier`.
3. In `format_profile_table`'s branch tree for the `Spec decode` row, surface the actionable flag when `supports_spec_decode is False AND supports_dflash is True`. Falls back to the 0.9.1 `(no MTP/drafter trained)` text when the drafter isn't registered.

## Tests

- `TestVisibility.test_table_for_dflash_alias_surfaces_opt_in_flag` — pins the actionable text on the operator-shipped flagship.
- Existing `test_table_for_dense_no_drafter_shows_honest_reason` (qwen3.5-4b-4bit) still passes — that path remains the fallback.

Smoke:
```
$ rapid-mlx info qwen3.5-27b-8bit          # Spec decode: ✗ MTP off — try --enable-dflash
$ rapid-mlx info qwen3.5-4b-4bit           # Spec decode: ✗ disabled (no MTP/drafter trained)   (unchanged 0.9.1 text)
$ rapid-mlx info qwen3.5-35b-4bit          # Spec decode: ✗ disabled (hybrid arch)              (unchanged hybrid text)
```

Bump-only PR will follow per the release SOP — this PR is fix-only and tagged `skip-version-bump`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)