### PR TITLE
chore: bump version to 0.9.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.9.1"
+version = "0.9.2"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## Summary
Patch bump 0.9.1 → 0.9.2 for the DFlash-eligible info refinement that landed in #932.

## Highlights since v0.9.1
- **`rapid-mlx info qwen3.5-27b-8bit` now surfaces the opt-in flag** (#932) — the operator-shipped DFlash flagship (1.85× code median per 0.9.0 release notes) used to render `✗ disabled (no MTP/drafter trained)` even though the DFlash drafter IS registered. Now shows `✗ MTP off — try --enable-dflash` so the user discovers the opt-in path from this surface.

## Pre-merge verification
- [x] auto-release.yml subject regex passes `chore: bump version to 0.9.2`
- [x] pyproject.toml on disk = `0.9.2`
- [x] Release branch from synced origin/main (PR #932 already merged into base)
- [x] Single-commit bump

## Post-merge sequence (not gating)
auto-release.yml tags `v0.9.2` + publishes GitHub release; publish.yml fans out to PyPI + Homebrew.

🤖 Generated with [Claude Code](https://claude.com/claude-code)