### PR TITLE
fix(cli): hoist --enable-dflash [dflash]-extra probe to boot-guard tier

### DIFF
--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -1504,6 +1504,35 @@ def serve_command(args):
     if is_audio_model_alias(getattr(args, "model", None)):
         require_audio_or_exit(args.model)
 
+    # 0.9.2 dogfood (parallels the [embeddings]/[vision]/[audio] guards
+    # immediately above): ``--enable-dflash`` and the equivalent
+    # ``--spec-decode dflash`` both depend on the optional ``mlx-vlm``
+    # bridge that ships in the ``[dflash]`` extra. Pre-0.9.3 the missing-
+    # runtime error only surfaced ~50 lines into serve_command, AFTER:
+    #   - alias profile resolved (logged twice via pflash)
+    #   - tool/reasoning parsers auto-configured
+    #   - CORS allow-origin warning printed
+    # so the operator saw five INFO lines and a banner before the
+    # actionable ``Install with: pip install 'rapid-mlx[dflash]'`` line,
+    # matching Diego's earlier ``[embeddings]`` regression shape exactly.
+    # Hoist the cheap ``have_runtime()`` probe to the same boot-guard tier
+    # as the other extras so the error lands FIRST. ``importlib.util.
+    # find_spec("mlx_vlm")`` doesn't trigger a load — safe to run on the
+    # hot CLI path.
+    _wants_dflash = getattr(args, "enable_dflash", False) or (
+        getattr(args, "spec_decode", "none") == "dflash"
+    )
+    if _wants_dflash:
+        from .speculative.dflash.eligibility import have_runtime
+
+        if not have_runtime():
+            print(
+                "\n  Error: --enable-dflash (and --spec-decode dflash) "
+                "requires mlx-vlm 0.5.0+ for the DFlash drafter hooks. "
+                "Install with: ``pip install 'rapid-mlx[dflash]'``.\n"
+            )
+            sys.exit(1)
+
     # R10-C1: AUDIO-SERVE-MODE FORK. The boot guard above only checks
     # that the ``[audio]`` extra is installed — it doesn't route the
     # alias anywhere. Pre-R10 every short alias (``kokoro``, ``whisper``,
@@ -1976,8 +2005,9 @@ def serve_command(args):
     if args.enable_dflash:
         from .model_aliases import resolve_profile
         from .speculative.dflash import DFlashUnavailable, check
-        from .speculative.dflash.eligibility import have_runtime
 
+        # ``have_runtime()`` validated at the top-of-function boot-guard
+        # tier — see the 0.9.2 dogfood comment near the audio probe.
         _alias_name = getattr(args, "_original_alias", None) or args.model
         _profile = resolve_profile(_alias_name)
         if _profile is None:
@@ -1993,13 +2023,12 @@ def serve_command(args):
         except DFlashUnavailable as e:
             print(f"\n  Error: {e}\n")
             sys.exit(1)
-        if not have_runtime():
-            print(
-                "\n  Error: --enable-dflash requires mlx-vlm 0.5.0+ for the "
-                "DFlash drafter hooks. Install with: "
-                "``pip install 'rapid-mlx[dflash]'``.\n"
-            )
-            sys.exit(1)
+        # ``have_runtime()`` is already validated by the boot-guard tier
+        # at the top of ``serve_command`` — see the 0.9.2 dogfood comment
+        # there. We keep the import + the deeper DFlashUnavailable / alias
+        # check here because they need the resolved profile, but the
+        # extras-not-installed branch is unreachable by the time control
+        # reaches this point.
 
         # Warn about flags that BatchedEngine honours but the DFlash
         # server doesn't — better to surface this once at startup than


### PR DESCRIPTION
## Summary

0.9.2 dogfood. A fresh `pip install rapid-mlx==0.9.2` (no `[dflash]` extra) running the operator-published flagship demo — `rapid-mlx serve qwen3.5-27b-8bit --enable-dflash` — surfaces the missing-runtime error only ~50 lines into `serve_command`, AFTER:

```
INFO:rapid_mlx.model_auto_config:Resolved alias profile for ...
INFO:rapid_mlx.pflash:PFlash default: alias '...' is pflash_tier=verified ...
INFO:rapid_mlx.model_auto_config:Resolved alias profile for ...   (DUPLICATE)
INFO:rapid_mlx.cli:Auto-configured --tool-call-parser hermes
INFO:rapid_mlx.cli:Auto-configured --reasoning-parser qwen3
INFO:rapid_mlx.server:CORS allow-origin defaulting to wildcard '*' ...
INFO:rapid_mlx.cli:Reasoning parser enabled: qwen3
  Alias: qwen3.5-27b-8bit → mlx-community/Qwen3.5-27B-8bit

  Error: --enable-dflash requires mlx-vlm 0.5.0+ for the DFlash drafter hooks.
  Install with: ``pip install 'rapid-mlx[dflash]'``.
```

Same failure shape Diego logged for `[embeddings]` in 0.8.x and Bo / Eva logged for `[vision]` / `[audio]`: the operator sees a startup banner, optimistic INFO lines, and a CORS warning BEFORE the actionable `Install with: …` line, which reads as "boot succeeded, then broke." `serve_command` already has identical fast-fail boot guards for the other three extras at the very top — just add the missing fourth.

## After

```
$ rapid-mlx serve qwen3.5-27b-8bit --enable-dflash --port 18801

  Alias: qwen3.5-27b-8bit → mlx-community/Qwen3.5-27B-8bit

  Error: --enable-dflash (and --spec-decode dflash) requires mlx-vlm 0.5.0+ for
  the DFlash drafter hooks. Install with: ``pip install 'rapid-mlx[dflash]'``.

$ echo $?
1
```

No INFO noise. No CORS warning. No banner. Just the alias resolve hop + actionable error + exit 1.

## Mechanics

1. Add a `have_runtime()` boot guard immediately after the `[audio]` guard at the top of `serve_command`. The probe is an `importlib.util.find_spec("mlx_vlm")` — no module load, safe on the hot CLI path.
2. Trip on BOTH `--enable-dflash` AND `--spec-decode dflash` (the latter is the alias the v0.9.0 release notes called out, rewritten to `--enable-dflash` later in the function).
3. Keep the downstream eligibility block at the original site — its alias-resolve + `DFlashUnavailable` check needs the resolved profile — but drop the now-unreachable `have_runtime()` branch and its unused import.

## Test plan

- [x] `pytest tests/test_model_auto_config.py tests/test_suffix_decoding_tier.py tests/test_dflash_eligibility.py` — 252/252 pass.
- [x] Live smoke: `python -m vllm_mlx.cli serve qwen3.5-27b-8bit --enable-dflash` → exits 1 with tight error, no banner / INFO / CORS preamble.

Bump-only PR will follow per the release SOP — this PR is fix-only and tagged `skip-version-bump`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)