### PR TITLE
chore: bump version to 0.9.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.9.2"
+version = "0.9.3"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## Summary
- Bumps `pyproject.toml` 0.9.2 → 0.9.3 (single-commit subject matches `auto-release.yml` regex)
- Follow-on to #934 (DFlash extras fast-fail hoist)

## Why a separate PR
Per repo SOP: bumps inside feature/fix PRs silently skip `auto-release.yml`. This is a dedicated single-commit bump.

## What 0.9.3 ships
- **#934** — `--enable-dflash` / `--spec-decode dflash` now fast-fails at boot with an installable hint (`pip install 'rapid-mlx[dflash]'`) instead of dying mid-init.

## Test plan
- [x] `auto-release.yml` subject regex matches `chore: bump version to 0.9.3`
- [x] 252/252 targeted tests green on #934
- [x] Live smoke: `rapid-mlx serve qwen3.5-27b-8bit --enable-dflash` exits 1 with the new hint (mlx-vlm 0.5.0 absent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)