### PR TITLE
fix(0.9.4): add upgrade --dry-run for install-plan preview

### DIFF
--- a/tests/test_upgrade_cli.py
+++ b/tests/test_upgrade_cli.py
@@ -1,0 +1,89 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the `rapid-mlx upgrade --dry-run` flag.
+
+Dogfood-driven: a real user typing the Homebrew-muscle-memory `--dry-run`
+on 0.9.3 hit `error: unrecognized arguments`. 0.9.4 adds the flag and
+this test pins the contract — printed plan, no subprocess.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from vllm_mlx import _version_check as vc
+from vllm_mlx.cli import upgrade_command
+
+
+def _stub_brew_with_upgrade_available(monkeypatch):
+    monkeypatch.setattr(vc, "_installed_version", lambda: "0.9.3")
+    monkeypatch.setattr(vc, "get_latest_version", lambda force_refresh=False: "0.9.4")
+    monkeypatch.setattr(
+        vc,
+        "detect_install_method",
+        lambda: vc.InstallInfo(
+            method="brew",
+            binary_path="/opt/homebrew/bin/rapid-mlx",
+            upgrade_command="brew upgrade raullenchai/rapid-mlx/rapid-mlx",
+            upgrade_argv=["brew", "upgrade", "raullenchai/rapid-mlx/rapid-mlx"],
+        ),
+    )
+
+
+def test_dry_run_does_not_invoke_subprocess(monkeypatch, capsys):
+    _stub_brew_with_upgrade_available(monkeypatch)
+    args = SimpleNamespace(yes=False, dry_run=True)
+    with (
+        patch("subprocess.run") as run,
+        patch("builtins.input") as inp,
+    ):
+        upgrade_command(args)
+        run.assert_not_called()
+        inp.assert_not_called()
+    out = capsys.readouterr().out
+    assert "Current:  rapid-mlx 0.9.3" in out
+    assert "Latest:   rapid-mlx 0.9.4" in out
+    assert "brew upgrade raullenchai/rapid-mlx/rapid-mlx" in out
+    assert "(dry-run — not executed" in out
+
+
+def test_dry_run_short_circuits_before_yes_prompt(monkeypatch, capsys):
+    """`--dry-run -y` is well-defined: dry-run wins (no surprise mutation)."""
+    _stub_brew_with_upgrade_available(monkeypatch)
+    args = SimpleNamespace(yes=True, dry_run=True)
+    with patch("subprocess.run") as run:
+        upgrade_command(args)
+        run.assert_not_called()
+
+
+def test_non_dry_run_still_calls_subprocess(monkeypatch):
+    """Regression guard: adding --dry-run must not skip the real path."""
+    _stub_brew_with_upgrade_available(monkeypatch)
+    args = SimpleNamespace(yes=True, dry_run=False)
+    fake_result = MagicMock(returncode=0)
+    with (
+        patch("subprocess.run", return_value=fake_result) as run,
+        pytest.raises(SystemExit) as exc,
+    ):
+        upgrade_command(args)
+    run.assert_called_once_with(
+        ["brew", "upgrade", "raullenchai/rapid-mlx/rapid-mlx"], check=False
+    )
+    assert exc.value.code == 0
+
+
+def test_dry_run_returns_silently_when_already_up_to_date(monkeypatch, capsys):
+    """If current == latest, upgrade_command returns before consulting
+    install method. --dry-run should not change that — still a clean
+    return, no subprocess."""
+    monkeypatch.setattr(vc, "_installed_version", lambda: "0.9.4")
+    monkeypatch.setattr(vc, "get_latest_version", lambda force_refresh=False: "0.9.4")
+    args = SimpleNamespace(yes=False, dry_run=True)
+    with patch("subprocess.run") as run:
+        upgrade_command(args)
+        run.assert_not_called()
+    out = capsys.readouterr().out
+    assert "Already up to date" in out
+    assert "dry-run" not in out  # no point printing dry-run if there's nothing to do

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -5408,6 +5408,10 @@ def upgrade_command(args):
         )
         return
 
+    if getattr(args, "dry_run", False):
+        print("  (dry-run — not executed; rerun without --dry-run to apply.)\n")
+        return
+
     if args.yes:
         confirmed = True
     else:
@@ -6707,6 +6711,14 @@ Examples:
         "--yes",
         action="store_true",
         help="Skip the confirmation prompt and run the upgrade immediately.",
+    )
+    upgrade_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help=(
+            "Print the detected install method and the upgrade command, "
+            "then exit without running it."
+        ),
     )
 
     # Chat — interactive REPL backed by a (spawned or existing) server.


### PR DESCRIPTION
## Summary
Dogfood-driven UX win from a real 0.9.3 user journey: ``rapid-mlx upgrade --dry-run`` (Homebrew muscle memory) exited 2 with argparse's default ``unrecognized arguments`` error instead of printing the install plan.

## Before / After

```
# before — 0.9.3
$ rapid-mlx upgrade --dry-run
rapid-mlx: error: unrecognized arguments: --dry-run

# after — 0.9.4
$ rapid-mlx upgrade --dry-run
  Current:  rapid-mlx 0.9.3
  Latest:   rapid-mlx 0.9.4
  Install:  brew (/opt/homebrew/bin/rapid-mlx)
  Command:  brew upgrade raullenchai/rapid-mlx/rapid-mlx
  (dry-run — not executed; rerun without --dry-run to apply.)
```

## Test plan
- [x] 4 new unit tests in ``tests/test_upgrade_cli.py`` (no-subprocess, ``-y`` doesn't override dry-run, regression guard, up-to-date short-circuit)
- [x] 48/48 green: ``pytest tests/test_upgrade_cli.py tests/test_version_check.py``
- [x] Live smoke: ``python -m vllm_mlx.cli upgrade --help`` shows the new flag, dry-run prints expected plan, no subprocess fired

## Post-merge sequence (not gating)
Ships as 0.9.4 via a separate bump-only PR after merge — see release SOP. Skip-version-bump label on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)