### PR TITLE
chore: bump version to 0.9.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.9.3"
+version = "0.9.4"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## Summary
- Bumps pyproject.toml 0.9.3 → 0.9.4 (single-commit subject matches auto-release.yml regex)
- Follow-on to #936 (rapid-mlx upgrade --dry-run)

## What 0.9.4 ships
- **#936** — ``rapid-mlx upgrade --dry-run`` now prints the install plan and exits 0 without invoking subprocess, matching Homebrew muscle memory.

## Test plan
- [x] pf1-subject-regex green (matches ``^chore: bump version to ...``)
- [x] 48/48 green on #936's tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)