### PR TITLE
fix(0.9.5): emit 'Resolved alias profile' once per process

### DIFF
--- a/tests/test_model_auto_config.py
+++ b/tests/test_model_auto_config.py
@@ -1,9 +1,12 @@
 """Tests for model auto-config detection."""
 
+import logging
+
 import pytest
 
 from vllm_mlx.model_auto_config import (
     ModelConfig,
+    _reset_resolution_log_cache,
     detect_model_config,
     enrich_model_config,
     format_profile_summary,
@@ -1463,3 +1466,55 @@ class TestWarnMisboundDeepseekV3Parser:
         )
         assert parser in msg
         assert model_path in msg
+
+
+class TestResolutionLogOnce:
+    """0.9.5 dogfood: detect_model_config() is called 2-4 times per
+    `rapid-mlx serve` boot (cli, server, engine_core, pflash). Without
+    de-dup, the user sees the same multi-line INFO 2-4 times. Log-once
+    contract — one emit per unique model_path per process.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _clear_cache(self):
+        _reset_resolution_log_cache()
+        yield
+        _reset_resolution_log_cache()
+
+    def _resolution_records(self, records):
+        return [
+            r
+            for r in records
+            if "Resolved alias profile" in r.message
+            or "Auto-detected model family" in r.message
+        ]
+
+    def test_alias_path_logs_exactly_once_across_repeats(self, caplog):
+        caplog.set_level(logging.INFO)
+        for _ in range(4):
+            cfg = detect_model_config("qwen3.5-9b-4bit")
+            assert cfg is not None
+        emits = self._resolution_records(caplog.records)
+        assert len(emits) == 1
+        assert "qwen3.5-9b-4bit" in emits[0].message
+
+    def test_regex_fallback_path_logs_exactly_once_across_repeats(self, caplog):
+        caplog.set_level(logging.INFO)
+        path = "lmstudio-community/Qwen3-Random-Forest-MLX-4bit"
+        for _ in range(3):
+            detect_model_config(path)
+        emits = self._resolution_records(caplog.records)
+        assert len(emits) == 1
+        assert "Auto-detected model family" in emits[0].message
+
+    def test_distinct_models_each_log_once(self, caplog):
+        caplog.set_level(logging.INFO)
+        detect_model_config("qwen3.5-9b-4bit")
+        detect_model_config("qwen3.5-9b-4bit")
+        detect_model_config("qwen3.5-4b-4bit")
+        detect_model_config("qwen3.5-4b-4bit")
+        emits = self._resolution_records(caplog.records)
+        assert len(emits) == 2
+        messages = " | ".join(r.message for r in emits)
+        assert "qwen3.5-9b-4bit" in messages
+        assert "qwen3.5-4b-4bit" in messages

--- a/vllm_mlx/model_auto_config.py
+++ b/vllm_mlx/model_auto_config.py
@@ -567,6 +567,27 @@ _MODEL_PATTERNS: list[tuple[re.Pattern, ModelConfig]] = [
 ]
 
 
+# Resolution log de-dup. detect_model_config() is called from cli.py,
+# server.py, engine_core.py, and pflash.py during a single ``serve`` boot;
+# without this gate the user sees the same multi-line INFO 2-4 times
+# back-to-back. Keyed on model_path so distinct models still each log
+# once. Process-local — a fresh worker process logs anew, which is what
+# we want.
+_logged_resolutions: set[str] = set()
+
+
+def _reset_resolution_log_cache() -> None:
+    """Test hook: clear the de-dup set between cases."""
+    _logged_resolutions.clear()
+
+
+def _log_resolution_once(model_path: str, message: str) -> None:
+    if model_path in _logged_resolutions:
+        return
+    _logged_resolutions.add(model_path)
+    logger.info(message)
+
+
 def detect_model_config(model_path: str) -> ModelConfig | None:
     """Detect optimal parser config from model name/path.
 
@@ -589,14 +610,15 @@ def detect_model_config(model_path: str) -> ModelConfig | None:
     """
     profile = resolve_profile(model_path)
     if profile is not None:
-        logger.info(
+        _log_resolution_once(
+            model_path,
             f"Resolved alias profile for '{model_path}' → "
             f"tool_call_parser={profile.tool_call_parser}, "
             f"reasoning_parser={profile.reasoning_parser}, "
             f"is_hybrid={profile.is_hybrid}, "
             f"supports_spec_decode={profile.supports_spec_decode}, "
             f"suffix_tier={profile.suffix_decoding_tier}, "
-            f"pflash_tier={profile.pflash_tier}"
+            f"pflash_tier={profile.pflash_tier}",
         )
         # AliasProfile stores the bench dict as a sorted tuple (frozen
         # dataclasses must avoid mutable shared state). Materialize a
@@ -624,12 +646,13 @@ def detect_model_config(model_path: str) -> ModelConfig | None:
 
     for pattern, config in _MODEL_PATTERNS:
         if pattern.search(model_path):
-            logger.info(
+            _log_resolution_once(
+                model_path,
                 f"Auto-detected model family '{pattern.pattern}' → "
                 f"tool_call_parser={config.tool_call_parser}, "
                 f"reasoning_parser={config.reasoning_parser}, "
                 f"is_hybrid={config.is_hybrid}, "
-                f"supports_spec_decode={config.supports_spec_decode}"
+                f"supports_spec_decode={config.supports_spec_decode}",
             )
             return config
     return None


### PR DESCRIPTION
## Summary
Dogfood-driven UX win: ``detect_model_config()`` is called 2-4 times per ``rapid-mlx serve`` boot (cli.serve_command, server.build_app, engine_core, pflash). Each call previously fired the same multi-line INFO so users saw the same block 2-4× in a row — looks like a bug, dilutes signal.

## Before / After

```
# before — 0.9.4
INFO ... Resolved alias profile for 'qwen3.5-9b-4bit' → tool_call_parser=hermes, reasoning_parser=qwen3, is_hybrid=False, ...
INFO ... Resolved alias profile for 'qwen3.5-9b-4bit' → tool_call_parser=hermes, reasoning_parser=qwen3, is_hybrid=False, ...
INFO ... Resolved alias profile for 'qwen3.5-9b-4bit' → tool_call_parser=hermes, reasoning_parser=qwen3, is_hybrid=False, ...

# after — 0.9.5
INFO ... Resolved alias profile for 'qwen3.5-9b-4bit' → tool_call_parser=hermes, reasoning_parser=qwen3, is_hybrid=False, ...
```

## Implementation
- Module-level ``_logged_resolutions: set[str]`` keyed on ``model_path``
- Tiny ``_log_resolution_once()`` helper wraps the two existing emit sites (alias hit + regex fallback)
- ``_reset_resolution_log_cache()`` exported for test isolation
- Process-local — a fresh worker logs anew, which is desirable

## Test plan
- [x] 3 new tests in ``TestResolutionLogOnce`` (alias path 4 calls → 1 emit, regex fallback 3 calls → 1 emit, two distinct models → 2 emits)
- [x] 255/255 green across ``test_model_auto_config.py`` + ``test_suffix_decoding_tier.py`` + ``test_dflash_eligibility.py``

## Post-merge sequence (not gating)
Ships as 0.9.5 via a separate bump-only PR after merge — release SOP. Skip-version-bump label on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)