### PR TITLE
chore: bump version to 0.9.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.9.4"
+version = "0.9.5"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## Summary
- Bumps pyproject.toml 0.9.4 → 0.9.5 (single-commit subject matches auto-release.yml regex)
- Follow-on to #938 (log-once "Resolved alias profile")

## What 0.9.5 ships
- **#938** — ``detect_model_config()`` now emits its "Resolved alias profile" INFO once per unique model_path per process instead of 2-4× per ``rapid-mlx serve`` boot.

## Test plan
- [x] pf1-subject-regex green
- [x] 255/255 green on #938 across auto_config + suffix + dflash-eligibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)