### PR TITLE
chore: bump version to 0.9.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.9.5"
+version = "0.9.6"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## Summary
- Bumps pyproject.toml 0.9.5 → 0.9.6
- Follow-on to #940 (dynamic alias-column width in `rapid-mlx models`)

## What 0.9.6 ships
- **#940** — alias column auto-sizes from data with a 24-char floor; `deepseek-coder-v2-lite-16b-4bit` and any future long aliases stay aligned with the rest of their row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)