### PR TITLE
fix(serve): parent-PID watchdog defeats orphaned sidecar after supervisor SIGKILL (rapid-desktop #449)

### DIFF
--- a/tests/test_parent_watchdog.py
+++ b/tests/test_parent_watchdog.py
@@ -293,7 +293,7 @@ class TestInternalSpawnersStampWatchdog:
         start = source.index("def _spawn_chat_server(")
         end = source.find("\ndef ", start + 1)
         body = source[start : end if end != -1 else len(source)]
-        assert 'RAPID_MLX_WATCHDOG_PPID' in body, (
+        assert "RAPID_MLX_WATCHDOG_PPID" in body, (
             "rapid-desktop #449 sibling regression: _spawn_chat_server "
             "no longer stamps RAPID_MLX_WATCHDOG_PPID on the child env. "
             "Without it, SIGKILL of `rapid-mlx chat` orphans the serve "
@@ -304,13 +304,10 @@ class TestInternalSpawnersStampWatchdog:
         from pathlib import Path
 
         share_file = (
-            Path(__file__).resolve().parents[1]
-            / "vllm_mlx"
-            / "share"
-            / "cli.py"
+            Path(__file__).resolve().parents[1] / "vllm_mlx" / "share" / "cli.py"
         )
         source = share_file.read_text()
-        assert 'RAPID_MLX_WATCHDOG_PPID' in source, (
+        assert "RAPID_MLX_WATCHDOG_PPID" in source, (
             "rapid-desktop #449 sibling regression: rapid-mlx share's "
             "serve-spawn no longer stamps RAPID_MLX_WATCHDOG_PPID on the "
             "child env. Without it, SIGKILL of `rapid-mlx share` leaves "
@@ -324,9 +321,11 @@ class TestDefaultOnOrphan:
         """Dogfood postmortems grep for the single marker line. Pin the
         string so a future refactor that changes the wording also
         updates whatever log scraper depends on it."""
-        with patch.object(pwd.os, "kill") as mock_kill, patch.object(
-            pwd.time, "sleep"
-        ), patch.object(pwd.os, "_exit") as mock_exit:
+        with (
+            patch.object(pwd.os, "kill") as mock_kill,
+            patch.object(pwd.time, "sleep"),
+            patch.object(pwd.os, "_exit") as mock_exit,
+        ):
             # ``_exit`` is what terminates the call; we patch it so the
             # test runner survives. The function would normally never
             # return.
@@ -352,11 +351,13 @@ class TestDefaultOnOrphan:
         def fake_kill(pid, sig):
             kills.append(sig)
 
-        with patch.object(pwd.os, "kill", side_effect=fake_kill), patch.object(
-            pwd.time, "sleep"
-        ) as mock_sleep, patch.object(pwd.os, "_exit", side_effect=SystemExit(0)):
-            with pytest.raises(SystemExit):
-                pwd._default_on_orphan(expected_ppid=9999, observed_ppid=1)
+        with (
+            patch.object(pwd.os, "kill", side_effect=fake_kill),
+            patch.object(pwd.time, "sleep") as mock_sleep,
+            patch.object(pwd.os, "_exit", side_effect=SystemExit(0)),
+            pytest.raises(SystemExit),
+        ):
+            pwd._default_on_orphan(expected_ppid=9999, observed_ppid=1)
         assert kills == [_signal.SIGTERM, _signal.SIGKILL]
         # Exactly 5 s of sleep between SIGTERM and SIGKILL.
         assert any(args[0] == 5.0 for args, _ in mock_sleep.call_args_list)

--- a/tests/test_parent_watchdog.py
+++ b/tests/test_parent_watchdog.py
@@ -315,6 +315,64 @@ class TestInternalSpawnersStampWatchdog:
             "env stamp."
         )
 
+    def test_bench_serve_spawn_stamps_watchdog_ppid(self):
+        """Codex r2 MAJOR: ``rapid-mlx bench --tier ...`` boots a
+        serve child via ``vllm_mlx/bench/_server.py``. Same SIGKILL-of-
+        supervisor orphan story applies; pin the env stamp here too."""
+        from pathlib import Path
+
+        bench_file = (
+            Path(__file__).resolve().parents[1] / "vllm_mlx" / "bench" / "_server.py"
+        )
+        source = bench_file.read_text()
+        assert "RAPID_MLX_WATCHDOG_PPID" in source, (
+            "rapid-desktop #449 sibling regression: bench/_server.py "
+            "no longer stamps RAPID_MLX_WATCHDOG_PPID on the spawned "
+            "serve child. SIGKILL of `rapid-mlx bench` would orphan "
+            "the model server. Restore the env stamp."
+        )
+
+    def test_all_internal_spawners_use_direct_assignment_not_setdefault(self):
+        """Codex r2 MAJOR: ``setdefault`` is the wrong primitive for
+        the watchdog stamp.
+
+        If the parent CLI invocation was itself launched under a
+        supervisor that exported ``RAPID_MLX_WATCHDOG_PPID=<gp_pid>``,
+        ``setdefault`` would preserve the grandparent's PID. The serve
+        child would then compare ``os.getppid()`` (= our immediate
+        PID) against the grandparent's PID, mismatch on the FIRST
+        poll, and self-terminate the freshly-booted server. The
+        spawner owns the watchdog relationship for the child it just
+        spawned — overwrite (direct ``env[KEY] = ...``) is the only
+        correct shape."""
+        from pathlib import Path
+
+        repo_root = Path(__file__).resolve().parents[1]
+        offenders: list[str] = []
+        for spawner in (
+            repo_root / "vllm_mlx" / "cli.py",
+            repo_root / "vllm_mlx" / "share" / "cli.py",
+            repo_root / "vllm_mlx" / "bench" / "_server.py",
+        ):
+            source = spawner.read_text()
+            # We only care about the watchdog stamp itself, not any
+            # other ``setdefault`` calls in the file. Grep for both
+            # forms on the same key, skipping comment lines (which
+            # legitimately mention ``setdefault`` in the rationale).
+            for line in source.splitlines():
+                stripped = line.strip()
+                if stripped.startswith("#"):
+                    continue
+                if "setdefault" in stripped and "RAPID_MLX_WATCHDOG_PPID" in stripped:
+                    offenders.append(f"{spawner.name}: {stripped}")
+        assert not offenders, (
+            "rapid-desktop #449 sibling regression: a spawner used "
+            "setdefault for the watchdog stamp. A grandparent's stale "
+            "RAPID_MLX_WATCHDOG_PPID would be inherited and the serve "
+            "child would self-terminate immediately. Use direct "
+            "assignment instead. Offending lines:\n  " + "\n  ".join(offenders)
+        )
+
 
 class TestDefaultOnOrphan:
     def test_writes_canonical_marker_to_stderr(self, capsys):

--- a/tests/test_parent_watchdog.py
+++ b/tests/test_parent_watchdog.py
@@ -204,6 +204,121 @@ class TestInstallParentWatchdog:
         assert call_count["n"] == 1
 
 
+class TestServeCommandWiring:
+    """Source-pinned contract tests for the CLI wiring.
+
+    Codex round-1 MAJOR #3: the helper itself is well-tested, but a
+    future refactor that drops the ``install_parent_watchdog`` call
+    from ``serve_command`` OR moves it AFTER the multi-minute model
+    download would silently re-introduce the orphan-during-download
+    bug. Source-grep the contract so the regression has to walk
+    through this test on the way out.
+    """
+
+    def _serve_command_body(self) -> str:
+        from pathlib import Path
+
+        cli_file = Path(__file__).resolve().parents[1] / "vllm_mlx" / "cli.py"
+        source = cli_file.read_text()
+        start = source.index("def serve_command(")
+        end = source.find("\ndef ", start + 1)
+        return source[start : end if end != -1 else len(source)]
+
+    def test_serve_command_installs_watchdog(self):
+        body = self._serve_command_body()
+        assert "install_parent_watchdog(" in body, (
+            "serve_command no longer calls install_parent_watchdog — the "
+            "orphan-sidecar mitigation for rapid-desktop #449 is gone. "
+            "Restore the helper invocation at the top of serve_command."
+        )
+
+    def test_watchdog_installs_before_model_download(self):
+        """The install MUST happen BEFORE ``_ensure_model_downloaded`` so
+        an operator who kills the supervisor while the (possibly multi-
+        minute) HF snapshot download is in flight still gets a clean
+        reap. Pre-install, the orphan would hold both the partial download
+        AND the future model RAM."""
+        body = self._serve_command_body()
+        idx_install = body.find("install_parent_watchdog(")
+        idx_download = body.find("_ensure_model_downloaded(")
+        assert idx_install != -1, (
+            "install_parent_watchdog missing from serve_command — see "
+            "test_serve_command_installs_watchdog for the actionable hint."
+        )
+        assert idx_download != -1, (
+            "_ensure_model_downloaded fixture moved; update this test."
+        )
+        assert idx_install < idx_download, (
+            "rapid-desktop #449 regression: install_parent_watchdog fires "
+            "AFTER _ensure_model_downloaded. Move the install to the TOP "
+            "of serve_command so it arms before the model download starts."
+        )
+
+    def test_watchdog_installs_before_audio_mode_fork(self):
+        """Same invariant for the audio-mode fork — ``_serve_audio_mode``
+        returns out of ``serve_command`` without re-installing the
+        watchdog, so the install MUST happen above the
+        ``_resolve_audio_model_for_serve`` branch or audio-only
+        operators get no orphan protection at all."""
+        body = self._serve_command_body()
+        idx_install = body.find("install_parent_watchdog(")
+        idx_audio = body.find("_resolve_audio_model_for_serve(")
+        assert idx_install != -1
+        if idx_audio != -1:
+            assert idx_install < idx_audio, (
+                "rapid-desktop #449 regression: install_parent_watchdog "
+                "fires AFTER the audio-mode fork — audio aliases (kokoro, "
+                "whisper, etc.) would skip the watchdog install entirely. "
+                "Move the install to the TOP of serve_command."
+            )
+
+
+class TestInternalSpawnersStampWatchdog:
+    """Source-pinned contract tests for in-tree supervisors that
+    themselves spawn ``rapid-mlx serve`` children (codex round-1 MAJOR
+    #1+#2): ``rapid-mlx share`` and ``rapid-mlx chat``. Without the
+    stamp, a SIGKILL on the parent CLI invocation leaves the child
+    serve as an orphan — the exact bug rapid-desktop #449 reports for
+    the desktop case, applied to the local CLI."""
+
+    def test_chat_spawn_stamps_watchdog_ppid(self):
+        from pathlib import Path
+
+        cli_file = Path(__file__).resolve().parents[1] / "vllm_mlx" / "cli.py"
+        source = cli_file.read_text()
+        # Locate _spawn_chat_server body. The function is small (~150
+        # lines) so a single-window scan is enough; pin the marker on
+        # the env-dict write so a refactor that splits the function
+        # still trips this test.
+        start = source.index("def _spawn_chat_server(")
+        end = source.find("\ndef ", start + 1)
+        body = source[start : end if end != -1 else len(source)]
+        assert 'RAPID_MLX_WATCHDOG_PPID' in body, (
+            "rapid-desktop #449 sibling regression: _spawn_chat_server "
+            "no longer stamps RAPID_MLX_WATCHDOG_PPID on the child env. "
+            "Without it, SIGKILL of `rapid-mlx chat` orphans the serve "
+            "subprocess. Restore the env stamp."
+        )
+
+    def test_share_spawn_stamps_watchdog_ppid(self):
+        from pathlib import Path
+
+        share_file = (
+            Path(__file__).resolve().parents[1]
+            / "vllm_mlx"
+            / "share"
+            / "cli.py"
+        )
+        source = share_file.read_text()
+        assert 'RAPID_MLX_WATCHDOG_PPID' in source, (
+            "rapid-desktop #449 sibling regression: rapid-mlx share's "
+            "serve-spawn no longer stamps RAPID_MLX_WATCHDOG_PPID on the "
+            "child env. Without it, SIGKILL of `rapid-mlx share` leaves "
+            "an orphan serve holding the bearer-gated port. Restore the "
+            "env stamp."
+        )
+
+
 class TestDefaultOnOrphan:
     def test_writes_canonical_marker_to_stderr(self, capsys):
         """Dogfood postmortems grep for the single marker line. Pin the

--- a/tests/test_parent_watchdog.py
+++ b/tests/test_parent_watchdog.py
@@ -1,0 +1,247 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the parent-PID watchdog (rapid-desktop issue #449).
+
+Covers:
+
+  * ``resolve_expected_ppid`` precedence (CLI > env > None) and the
+    ``ppid <= 1`` early-out that keeps the watchdog safe to install
+    unconditionally.
+  * Install-time short-circuit: if the live PPID is already wrong at
+    install time (supervisor died between spawn and serve_command),
+    the orphan callback fires SYNCHRONOUSLY and no thread is created.
+  * Loop-time detection: when the simulated live PPID flips mid-loop,
+    the watchdog fires the callback exactly once and the thread exits.
+  * Default ``on_orphan`` writes the canonical marker so dogfood log
+    scrapers can grep one consistent string.
+
+Test isolation
+--------------
+
+The default ``on_orphan`` SIGKILLs the test runner, so every test that
+exercises the loop substitutes a no-op callback. ``ENV_VAR`` is
+restored via ``monkeypatch`` so the suite doesn't leak watchdog state
+into later tests in the same pytest process.
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+import time
+from unittest.mock import patch
+
+import pytest
+
+from vllm_mlx import _parent_watchdog as pwd
+
+
+class TestResolveExpectedPpid:
+    def test_returns_none_when_neither_source_set(self, monkeypatch):
+        monkeypatch.delenv(pwd.ENV_VAR, raising=False)
+        assert pwd.resolve_expected_ppid(None) is None
+
+    def test_cli_flag_wins_over_env(self, monkeypatch):
+        monkeypatch.setenv(pwd.ENV_VAR, "1234")
+        assert pwd.resolve_expected_ppid(9999) == 9999
+
+    def test_env_used_when_cli_omitted(self, monkeypatch):
+        monkeypatch.setenv(pwd.ENV_VAR, "5678")
+        assert pwd.resolve_expected_ppid(None) == 5678
+
+    def test_zero_or_negative_cli_is_noop(self, monkeypatch):
+        monkeypatch.delenv(pwd.ENV_VAR, raising=False)
+        assert pwd.resolve_expected_ppid(0) is None
+        assert pwd.resolve_expected_ppid(-5) is None
+        assert pwd.resolve_expected_ppid(1) is None  # launchd/init — no parent to watch
+
+    def test_malformed_env_ignored(self, monkeypatch):
+        monkeypatch.setenv(pwd.ENV_VAR, "not-a-number")
+        assert pwd.resolve_expected_ppid(None) is None
+
+    def test_empty_env_ignored(self, monkeypatch):
+        monkeypatch.setenv(pwd.ENV_VAR, "")
+        assert pwd.resolve_expected_ppid(None) is None
+
+
+class TestInstallParentWatchdog:
+    def test_noop_when_expected_ppid_is_none(self):
+        assert pwd.install_parent_watchdog(None) is None
+
+    def test_noop_when_expected_ppid_is_pid_1(self):
+        # PID 1 (launchd / init) is the "no real parent" sentinel —
+        # comparing getppid() against 1 would either always-match
+        # (we're already a launchd grandchild and there's no death to
+        # detect) or never-match (we have a real parent but the caller
+        # accidentally passed 1). Either way, refusing to install is
+        # the safe move.
+        assert pwd.install_parent_watchdog(1) is None
+
+    def test_fires_synchronously_when_install_time_ppid_already_wrong(self):
+        """Catch the race where the supervisor died between spawn and
+        install. The watchdog must NOT silently wait for the next poll —
+        the operator already has no answer for "where did my server go"
+        and a 2 s blind spot would make the marker line look like it
+        appeared spontaneously."""
+        fired: list[tuple[int, int]] = []
+        # Expected PPID is "the real PPID + 1" so the comparison fails
+        # immediately. Using getppid() + 1 keeps the test portable: any
+        # CI host that happens to have PID 1 as the test runner's parent
+        # (containerized pytest) is still covered.
+        real_ppid = os.getppid()
+        wrong_ppid = real_ppid + 1
+        # Guard against the (extremely unlikely) case that wrong_ppid
+        # happens to equal the live PPID after wraparound — bump again.
+        if wrong_ppid <= 1:
+            wrong_ppid = real_ppid + 2
+
+        result = pwd.install_parent_watchdog(
+            wrong_ppid, on_orphan=lambda exp, obs: fired.append((exp, obs))
+        )
+        assert result is None  # synchronous fire, no thread
+        assert len(fired) == 1
+        assert fired[0][0] == wrong_ppid
+        assert fired[0][1] == real_ppid
+
+    def test_loop_detects_ppid_change(self, monkeypatch):
+        """Simulate the post-SIGKILL re-parent: live PPID flips to 1
+        (launchd) while the expected PPID stays at the supervisor's old
+        PID. The watchdog must fire on the very next poll."""
+        real_ppid = os.getppid()
+        fired = threading.Event()
+        captured: list[tuple[int, int]] = []
+
+        # Toggle: getppid() first returns the real value (so install
+        # succeeds), then returns 1 after the flip to simulate launchd
+        # adopting the orphan.
+        call_count = {"n": 0}
+
+        def fake_getppid():
+            call_count["n"] += 1
+            # First call happens inside install_parent_watchdog's
+            # install-time short-circuit check. Return real_ppid so the
+            # install proceeds to spawning a thread. Subsequent calls
+            # (from the loop body) return 1 to simulate the orphan.
+            if call_count["n"] == 1:
+                return real_ppid
+            return 1
+
+        def on_orphan(expected, observed):
+            captured.append((expected, observed))
+            fired.set()
+
+        with patch.object(pwd.os, "getppid", side_effect=fake_getppid):
+            thread = pwd.install_parent_watchdog(
+                real_ppid, interval=0.05, on_orphan=on_orphan
+            )
+            assert thread is not None
+            # The loop fires immediately on the second poll (no initial
+            # sleep). 2 s ceiling guards against runaway tests on
+            # severely overloaded CI; in practice this resolves in <50 ms.
+            assert fired.wait(timeout=2.0), "watchdog never fired"
+        # Thread is daemon — even if join times out the suite proceeds.
+        thread.join(timeout=1.0)
+        assert not thread.is_alive(), "watchdog thread did not exit after firing"
+        assert len(captured) == 1
+        assert captured[0] == (real_ppid, 1)
+
+    def test_loop_exits_when_stop_event_set(self):
+        """The thread exposes a ``_rapid_mlx_stop_event`` attribute so
+        a graceful-shutdown caller (or test) can disarm the watchdog
+        without waiting for the next poll OR triggering the orphan
+        path. Important for the future ``execve`` self-replacement
+        scenario (e.g. socket-activation handoff)."""
+        real_ppid = os.getppid()
+        thread = pwd.install_parent_watchdog(
+            real_ppid, interval=0.05, on_orphan=lambda e, o: None
+        )
+        assert thread is not None
+        try:
+            stop_event = thread._rapid_mlx_stop_event  # type: ignore[attr-defined]
+            assert isinstance(stop_event, threading.Event)
+            stop_event.set()
+            thread.join(timeout=2.0)
+            assert not thread.is_alive()
+        finally:
+            # Defensive — make sure the thread cannot outlive the test
+            # even if assertions above raise.
+            if thread.is_alive():
+                getattr(thread, "_rapid_mlx_stop_event", threading.Event()).set()
+                thread.join(timeout=1.0)
+
+    def test_callback_runs_only_once_per_install(self):
+        """Once the orphan callback fires, the loop returns — no spam
+        on subsequent poll intervals. Pre-fix a buggy implementation
+        could call the supervisor 100x while the lifespan drain ran."""
+        real_ppid = os.getppid()
+        fired = threading.Event()
+        call_count = {"n": 0}
+
+        def on_orphan(expected, observed):
+            call_count["n"] += 1
+            fired.set()
+
+        # Simulate the always-orphan condition: after install-time
+        # check, getppid always returns 1.
+        getppid_calls = {"n": 0}
+
+        def fake_getppid():
+            getppid_calls["n"] += 1
+            if getppid_calls["n"] == 1:
+                return real_ppid
+            return 1
+
+        with patch.object(pwd.os, "getppid", side_effect=fake_getppid):
+            thread = pwd.install_parent_watchdog(
+                real_ppid, interval=0.02, on_orphan=on_orphan
+            )
+            assert thread is not None
+            assert fired.wait(timeout=2.0)
+            # Give the loop a chance to (incorrectly) fire again. If it
+            # had been written without an exit-after-fire, this 200 ms
+            # window at 20 ms cadence would record ~10 extra fires.
+            time.sleep(0.2)
+        thread.join(timeout=1.0)
+        assert call_count["n"] == 1
+
+
+class TestDefaultOnOrphan:
+    def test_writes_canonical_marker_to_stderr(self, capsys):
+        """Dogfood postmortems grep for the single marker line. Pin the
+        string so a future refactor that changes the wording also
+        updates whatever log scraper depends on it."""
+        with patch.object(pwd.os, "kill") as mock_kill, patch.object(
+            pwd.time, "sleep"
+        ), patch.object(pwd.os, "_exit") as mock_exit:
+            # ``_exit`` is what terminates the call; we patch it so the
+            # test runner survives. The function would normally never
+            # return.
+            mock_exit.side_effect = SystemExit(0)
+            with pytest.raises(SystemExit):
+                pwd._default_on_orphan(expected_ppid=12345, observed_ppid=1)
+        err = capsys.readouterr().err
+        assert "[rapid-mlx] parent watchdog" in err
+        assert "12345" in err
+        assert "observed PPID 1" in err
+        # SIGTERM first, SIGKILL second (matches the rapid-desktop
+        # terminationGrace contract).
+        assert mock_kill.call_count >= 1
+
+    def test_sigkill_after_grace_window(self):
+        """Defense against a lifespan drain that hangs: the second kill
+        is the un-catchable SIGKILL, sent after the same 5 s grace the
+        desktop side waits on its own terminateChild path."""
+        import signal as _signal
+
+        kills: list[int] = []
+
+        def fake_kill(pid, sig):
+            kills.append(sig)
+
+        with patch.object(pwd.os, "kill", side_effect=fake_kill), patch.object(
+            pwd.time, "sleep"
+        ) as mock_sleep, patch.object(pwd.os, "_exit", side_effect=SystemExit(0)):
+            with pytest.raises(SystemExit):
+                pwd._default_on_orphan(expected_ppid=9999, observed_ppid=1)
+        assert kills == [_signal.SIGTERM, _signal.SIGKILL]
+        # Exactly 5 s of sleep between SIGTERM and SIGKILL.
+        assert any(args[0] == 5.0 for args, _ in mock_sleep.call_args_list)

--- a/vllm_mlx/_parent_watchdog.py
+++ b/vllm_mlx/_parent_watchdog.py
@@ -1,0 +1,247 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Parent-PID watchdog for embedded ``rapid-mlx serve`` children.
+
+Problem (rapid-desktop issue #449)
+----------------------------------
+
+Desktop apps that spawn ``rapid-mlx serve`` as a subprocess hold a 20-30 GB
+model weight in unified memory. When the parent (Rapid-MLX Desktop, ``rapid``
+CLI wrapper, ...) is killed with SIGKILL — macOS app hang force-quit, kernel
+OOM kill, panic, ``kill -9`` from a watchdog — the kernel re-parents the
+sidecar to launchd (PID 1) and the sidecar keeps running forever:
+
+  * listening on the same port the next launch will try to bind, so the next
+    launch sees "port in use" until the orphan is reaped by hand,
+  * holding the full model in RAM, so two crashes can stack 60+ GB of phantom
+    resident memory the operator did not notice they had.
+
+The desktop side has a PortSweep (rapid-desktop PR #170) that reaps detected
+orphans on the *next* launch, but if the operator does not relaunch (closes
+the lid, walks away), the orphan persists indefinitely.
+
+Mitigation
+----------
+
+The supervisor passes its own PID as ``--watchdog-ppid`` (or
+``RAPID_MLX_WATCHDOG_PPID`` env). A background thread polls
+``os.getppid()`` every ``interval`` seconds. When the live PPID stops
+matching the expected one — POSIX guarantees the child is re-parented
+the instant its parent dies, so on macOS/Linux the live PPID flips to 1
+(launchd / init) — the watchdog sends SIGTERM to itself for a clean
+shutdown, then SIGKILL after ``grace`` seconds if the lifespan drain
+hangs.
+
+Design notes
+------------
+
+* The thread is a daemon — never blocks interpreter exit and never holds
+  a reference to user-supplied state.
+* The check is intentionally PPID-comparison (not ``kill(ppid, 0)``):
+  ``kill(pid, 0)`` can race against PID-recycle (the kernel could
+  re-assign the dead parent's PID to an unrelated process before our
+  next poll, giving a false negative). ``os.getppid()`` is authoritative
+  for "who owns me right now".
+* The ``expected_ppid <= 1`` early-out keeps the helper safe for the
+  pathological cases (caller passed 0, or the supervisor was launchd
+  itself). It also keeps unit tests / direct invocations from foot-gunning
+  themselves on a never-fire-condition.
+* No-op when the platform lacks ``os.getppid`` (Windows on older Python).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import signal
+import sys
+import threading
+import time
+from collections.abc import Callable
+
+logger = logging.getLogger(__name__)
+
+
+# Public env var name the rapid-desktop spawn helper (or any future
+# supervisor) can stamp instead of passing the CLI flag. Kept in sync
+# with ``rapid-desktop/Sources/Rapid/Server/ServerManager.swift``'s
+# ``serveEnvironmentAdditions`` writer. The CLI ``--watchdog-ppid``
+# flag wins when both are set.
+ENV_VAR = "RAPID_MLX_WATCHDOG_PPID"
+
+
+def resolve_expected_ppid(cli_value: int | None) -> int | None:
+    """Resolve the expected parent PID from CLI flag + env var.
+
+    Precedence: ``--watchdog-ppid`` (CLI) > ``RAPID_MLX_WATCHDOG_PPID`` (env).
+
+    Returns ``None`` if neither source supplied a positive integer
+    (the watchdog is a no-op in that case — there is no expected parent
+    to compare against). A malformed env value is ignored with a
+    DEBUG log; the caller is the supervisor, not the operator, so
+    malformed input here is a programming bug worth surfacing in DEBUG
+    but not loud enough to spam the operator's terminal.
+    """
+    if cli_value is not None:
+        return cli_value if cli_value > 1 else None
+    raw = os.environ.get(ENV_VAR)
+    if not raw:
+        return None
+    try:
+        parsed = int(raw)
+    except ValueError:
+        logger.debug(
+            "ignoring malformed %s=%r (not an integer)",
+            ENV_VAR,
+            raw,
+        )
+        return None
+    return parsed if parsed > 1 else None
+
+
+def _default_on_orphan(expected_ppid: int, observed_ppid: int) -> None:
+    """Default orphan reaction: log + SIGTERM self + SIGKILL after grace.
+
+    The lifespan ``shutdown`` hook in ``server.py`` runs on SIGTERM and
+    is responsible for flushing the prefix cache, finalising telemetry,
+    and emitting the ``Application shutdown complete.`` banner. We give
+    it the same ~5 s wall-clock window the rapid-desktop side hands its
+    ``terminateChild`` SIGTERM grace before escalating to SIGKILL —
+    keeps the two halves of the kill protocol symmetric (see
+    ``ServerManager.swift`` ``terminationGrace``).
+    """
+    # Single-line marker so log scrapers / dogfood postmortems can grep
+    # one consistent string. Print AND log: the logger may not be set up
+    # yet for a sidecar that died before ``configure_logging`` ran (or
+    # was deliberately set to ERROR), and the user-visible "why did my
+    # server vanish" answer must reach stderr unconditionally.
+    msg = (
+        f"[rapid-mlx] parent watchdog: expected PPID {expected_ppid} but "
+        f"observed PPID {observed_ppid} (parent died, re-parented to "
+        f"launchd/init); shutting down to release model weights and port"
+    )
+    try:
+        sys.stderr.write(msg + "\n")
+        sys.stderr.flush()
+    except Exception:  # pragma: no cover — defensive against broken stderr
+        pass
+    try:
+        logger.warning(msg)
+    except Exception:  # pragma: no cover — defensive
+        pass
+
+    pid = os.getpid()
+    # First, polite SIGTERM — uvicorn / FastAPI lifespan drain.
+    try:
+        os.kill(pid, signal.SIGTERM)
+    except OSError:  # pragma: no cover — defensive
+        os._exit(0)
+
+    # Give lifespan shutdown ~5 s, then escalate. The desktop side
+    # waits the same window before SIGKILL on ``terminateChild``, so
+    # this mirrors the contract from both directions.
+    time.sleep(5.0)
+    try:
+        os.kill(pid, signal.SIGKILL)
+    except OSError:  # pragma: no cover
+        pass
+    os._exit(0)
+
+
+def _watchdog_loop(
+    expected_ppid: int,
+    interval: float,
+    on_orphan: Callable[[int, int], None],
+    stop_event: threading.Event,
+) -> None:
+    """Body of the watchdog daemon thread.
+
+    Loops until ``stop_event`` is set OR an orphan condition is detected
+    (which fires ``on_orphan`` and is normally terminal — but tests can
+    inject a non-terminating ``on_orphan`` for assertions).
+    """
+    # Initial poll runs immediately (not after a sleep) so a supervisor
+    # that died between spawn and the first interval is still caught.
+    while not stop_event.is_set():
+        try:
+            observed = os.getppid()
+        except OSError:  # pragma: no cover — extremely unusual
+            return
+        if observed != expected_ppid:
+            try:
+                on_orphan(expected_ppid, observed)
+            except SystemExit:
+                raise
+            except Exception:  # pragma: no cover — defensive
+                logger.exception("parent watchdog on_orphan callback failed")
+            # Default ``_default_on_orphan`` does not return; a custom
+            # callback might. In either case, stop polling: the orphan
+            # decision was made, repeated firings would just spam the log.
+            return
+        stop_event.wait(interval)
+
+
+def install_parent_watchdog(
+    expected_ppid: int | None,
+    *,
+    interval: float = 2.0,
+    on_orphan: Callable[[int, int], None] | None = None,
+) -> threading.Thread | None:
+    """Start a daemon thread that terminates this process when its parent dies.
+
+    Parameters
+    ----------
+    expected_ppid:
+        The PID the supervisor expects to be our parent. Pass the result
+        of :func:`resolve_expected_ppid` to honour both ``--watchdog-ppid``
+        and ``RAPID_MLX_WATCHDOG_PPID``. ``None`` (or any value ``<= 1``)
+        is a no-op so the helper is safe to call unconditionally from
+        ``serve_command``.
+    interval:
+        Seconds between polls. Default 2 s — that matches the rapid-desktop
+        ``runtimeHealthInterval`` cadence so the two halves of the lifecycle
+        watchdog tick at the same frequency. Floor of 0.1 s in case a test
+        wants tighter polling.
+    on_orphan:
+        Override the default "SIGTERM self then SIGKILL" reaction. Tests
+        substitute a no-op + flag-flip so they can drive the loop without
+        terminating the test runner. Production callers always want the
+        default.
+
+    Returns
+    -------
+    The watchdog thread, or ``None`` if the configuration was a no-op
+    (no ``expected_ppid``, or the current PPID already matches PID 1 —
+    the daemon-launched case has no parent to watch). Tests can ``join``
+    the thread after setting ``stop_event``; production callers can
+    ignore the return value.
+    """
+    if expected_ppid is None or expected_ppid <= 1:
+        return None
+
+    # If the current PPID is ALREADY != expected_ppid at install time,
+    # we missed the death (the supervisor died between spawn and now).
+    # Fire the callback synchronously so the operator sees the same
+    # marker as the in-flight case, then return None (no thread).
+    try:
+        live_ppid = os.getppid()
+    except OSError:  # pragma: no cover
+        return None
+    callback = on_orphan or _default_on_orphan
+    if live_ppid != expected_ppid:
+        callback(expected_ppid, live_ppid)
+        return None
+
+    stop_event = threading.Event()
+    thread = threading.Thread(
+        target=_watchdog_loop,
+        name="rapid-mlx-parent-watchdog",
+        args=(expected_ppid, max(0.1, float(interval)), callback, stop_event),
+        daemon=True,
+    )
+    # Expose the stop event on the thread so tests (and any future
+    # graceful-shutdown caller that wants to disarm the watchdog before
+    # an intentional execve) can stop the loop without waiting for the
+    # next poll interval.
+    thread._rapid_mlx_stop_event = stop_event  # type: ignore[attr-defined]
+    thread.start()
+    return thread

--- a/vllm_mlx/bench/_server.py
+++ b/vllm_mlx/bench/_server.py
@@ -125,13 +125,23 @@ def serve(
         log_fh = open(tmp_log, "w")
     try:
         t_spawn = time.perf_counter()
+        # Parent-PID watchdog (rapid-desktop #449 sibling fix). A
+        # SIGKILL of the bench process before ``_terminate(proc)`` runs
+        # would otherwise leave the spawned serve as an orphan holding
+        # the model in RAM. The watchdog inside the child polls
+        # ``os.getppid()`` and exits when it stops matching this PID.
+        # Direct assignment (NOT setdefault) so an inherited / stale
+        # env value from a grandparent supervisor cannot mis-target
+        # the watchdog at the wrong PID.
+        spawn_env = os.environ.copy()
+        spawn_env["RAPID_MLX_WATCHDOG_PPID"] = str(os.getpid())
         proc = subprocess.Popen(  # noqa: S603 — args constructed by us
             cmd,
             cwd=REPO_ROOT,
             stdin=subprocess.DEVNULL,
             stdout=log_fh,
             stderr=subprocess.STDOUT,
-            env=os.environ.copy(),
+            env=spawn_env,
             # New process group so we can signal the whole tree on
             # teardown (uvicorn + worker children). POSIX-only; we
             # don't run on win.

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -3916,9 +3916,18 @@ def _spawn_chat_server(
     # outlive ``rapid-mlx chat`` and keep the model + port locked. The
     # watchdog inside the child polls ``os.getppid()`` every 2 s and
     # self-terminates the moment the live PPID stops matching this
-    # stamp. ``setdefault`` so an explicit operator export (e.g. tests
-    # that want to disable the watchdog) wins.
-    child_env.setdefault("RAPID_MLX_WATCHDOG_PPID", str(os.getpid()))
+    # stamp.
+    #
+    # Direct assignment (NOT setdefault). Codex r2 MAJOR: if the chat
+    # REPL itself was launched under a supervisor that already exported
+    # ``RAPID_MLX_WATCHDOG_PPID=<grandparent_pid>``, ``setdefault``
+    # would carry the grandparent's PID into the child env. The
+    # watchdog would then compare ``os.getppid()`` (= chat REPL's PID,
+    # the IMMEDIATE parent) against the grandparent PID, mismatch on
+    # first poll, and self-terminate the freshly-booted server. The
+    # spawner owns the watchdog relationship for the spawn it just
+    # created — overwrite is correct.
+    child_env["RAPID_MLX_WATCHDOG_PPID"] = str(os.getpid())
     # Atomic critical section: block SIGTERM/SIGINT delivery around
     # the whole ``Popen()`` + register + attribute-set + ``release()``
     # sequence. We use ``pthread_sigmask(SIG_BLOCK, ...)`` so the

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -1453,9 +1453,7 @@ def serve_command(args):
     # was passed (default).
     from ._parent_watchdog import install_parent_watchdog, resolve_expected_ppid
 
-    install_parent_watchdog(
-        resolve_expected_ppid(getattr(args, "watchdog_ppid", None))
-    )
+    install_parent_watchdog(resolve_expected_ppid(getattr(args, "watchdog_ppid", None)))
 
     _arg_max_tokens = getattr(args, "max_tokens", None)
     _max_tokens_is_explicit = _arg_max_tokens is not None

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -3912,6 +3912,15 @@ def _spawn_chat_server(
     # see a stdin pipe and re-evaluate against a potentially-stale cache.
     child_env = os.environ.copy()
     child_env["RAPID_MLX_CHAT_SPAWN"] = "1"
+    # Parent-PID watchdog (rapid-desktop #449 sibling fix). The
+    # SIGTERM-handler + atexit pair installed below cannot fire under
+    # SIGKILL of the chat REPL — the spawned ``serve`` would otherwise
+    # outlive ``rapid-mlx chat`` and keep the model + port locked. The
+    # watchdog inside the child polls ``os.getppid()`` every 2 s and
+    # self-terminates the moment the live PPID stops matching this
+    # stamp. ``setdefault`` so an explicit operator export (e.g. tests
+    # that want to disable the watchdog) wins.
+    child_env.setdefault("RAPID_MLX_WATCHDOG_PPID", str(os.getpid()))
     # Atomic critical section: block SIGTERM/SIGINT delivery around
     # the whole ``Popen()`` + register + attribute-set + ``release()``
     # sequence. We use ``pthread_sigmask(SIG_BLOCK, ...)`` so the

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -1439,6 +1439,24 @@ def serve_command(args):
     import os
     import sys
 
+    # Parent-PID watchdog (rapid-desktop issue #449): if the supervisor
+    # passed its own PID via ``--watchdog-ppid`` or
+    # ``$RAPID_MLX_WATCHDOG_PPID``, spawn a daemon thread that polls
+    # ``os.getppid()`` every 2 s. When the parent dies (re-parented to
+    # launchd / init), the watchdog sends SIGTERM to ourselves so the
+    # FastAPI lifespan can flush + release the model — falling back to
+    # SIGKILL after a 5 s grace. Installed at the top of serve_command
+    # so it covers BOTH the text-LM path and the audio-mode fork below,
+    # AND so it arms before the (potentially multi-minute) model
+    # download — an operator who kills the desktop mid-download still
+    # gets a clean reap on the sidecar. No-op when no supervisor PID
+    # was passed (default).
+    from ._parent_watchdog import install_parent_watchdog, resolve_expected_ppid
+
+    install_parent_watchdog(
+        resolve_expected_ppid(getattr(args, "watchdog_ppid", None))
+    )
+
     _arg_max_tokens = getattr(args, "max_tokens", None)
     _max_tokens_is_explicit = _arg_max_tokens is not None
     effective_max_tokens = _arg_max_tokens if _arg_max_tokens is not None else 32768
@@ -6482,6 +6500,26 @@ Examples:
             "Pre-load an embedding model at startup (e.g. "
             "mlx-community/embeddinggemma-300m-6bit). Requires the "
             "[embeddings] extra: pip install 'rapid-mlx[embeddings]'."
+        ),
+    )
+    # Parent-PID watchdog (rapid-desktop issue #449). When set, the
+    # sidecar polls ``os.getppid()`` every 2 s and self-terminates if
+    # the parent dies (re-parent to launchd / init on macOS/Linux). The
+    # supervisor passes its own PID at spawn so a SIGKILL on the desktop
+    # cannot leave a 30 GB orphan holding the model + port. ``0`` /
+    # negative / unset disables. The ``RAPID_MLX_WATCHDOG_PPID`` env var
+    # is honoured as a fallback when the CLI flag is omitted; the flag
+    # wins when both are present.
+    serve_parser.add_argument(
+        "--watchdog-ppid",
+        type=int,
+        default=None,
+        metavar="PID",
+        help=(
+            "Self-terminate when the parent with this PID dies (defeats "
+            "orphan-sidecar after SIGKILL on the supervisor). Honors "
+            "$RAPID_MLX_WATCHDOG_PPID as a fallback. Set to 0 / unset to "
+            "disable."
         ),
     )
     # PFlash long-prompt prefill compression (#287). Off by default; see

--- a/vllm_mlx/share/cli.py
+++ b/vllm_mlx/share/cli.py
@@ -389,6 +389,15 @@ def _spawn_serve(
     ]
     env = dict(os.environ)
     env["RAPID_MLX_API_KEY"] = api_key
+    # Parent-PID watchdog (rapid-desktop #449 sibling fix). A SIGKILL
+    # of ``rapid-mlx share`` (the supervisor) re-parents the spawned
+    # ``serve`` to launchd / init; without this stamp the child would
+    # outlive the frp tunnel teardown and keep the bearer-gated port
+    # bound. The watchdog inside the child checks ``os.getppid()`` and
+    # exits the moment it stops matching this PID. No-op if the operator
+    # already exported the env var to a different value — that's an
+    # explicit override.
+    env.setdefault("RAPID_MLX_WATCHDOG_PPID", str(os.getpid()))
     log_fp = log_path.open("ab", buffering=0)
     # Tighten permissions: log files default to umask-derived modes
     # (often 644 = world-readable). If serve ever logs the key as part

--- a/vllm_mlx/share/cli.py
+++ b/vllm_mlx/share/cli.py
@@ -394,10 +394,15 @@ def _spawn_serve(
     # ``serve`` to launchd / init; without this stamp the child would
     # outlive the frp tunnel teardown and keep the bearer-gated port
     # bound. The watchdog inside the child checks ``os.getppid()`` and
-    # exits the moment it stops matching this PID. No-op if the operator
-    # already exported the env var to a different value — that's an
-    # explicit override.
-    env.setdefault("RAPID_MLX_WATCHDOG_PPID", str(os.getpid()))
+    # exits the moment it stops matching this PID.
+    #
+    # Direct assignment (NOT setdefault). Codex r2 MAJOR: a stale
+    # ``RAPID_MLX_WATCHDOG_PPID`` inherited from a grandparent
+    # supervisor would otherwise be forwarded into the child, and the
+    # child would compare against the WRONG PID (the grandparent's,
+    # not ``rapid-mlx share``'s) and self-terminate immediately. The
+    # spawner owns the watchdog relationship — overwrite is correct.
+    env["RAPID_MLX_WATCHDOG_PPID"] = str(os.getpid())
     log_fp = log_path.open("ab", buffering=0)
     # Tighten permissions: log files default to umask-derived modes
     # (often 644 = world-readable). If serve ever logs the key as part


### PR DESCRIPTION
## Summary

Closes the orphan-sidecar leak rapid-desktop's [Persona 3 dogfood](https://github.com/machinefi/rapid-desktop/issues/449) caught: when the desktop is SIGKILL'd (force-quit, OOM, panic), the bundled \`rapid-mlx serve\` child is reparented to launchd (PID 1) and keeps running indefinitely — holding 20-30 GB of model weights and the loopback port the next launch wants to bind. Two crashes can stack 60+ GB phantom RSS the operator never notices, and the next launch sees \"port in use\".

The desktop's [PortSweep](https://github.com/machinefi/rapid-desktop/pull/170) reaps orphans on the *next* launch, but if the user closes the lid the orphan lives forever. Atexit on the supervisor side is a no-op under SIGKILL — the only fix that works mid-session is a self-suicide path on the sidecar side.

## Approach

- **\`vllm_mlx/_parent_watchdog.py\`** — daemon thread polls \`os.getppid()\` every 2 s; when the live PPID stops matching the supervisor's, SIGTERM self for clean lifespan drain then SIGKILL after a 5 s grace (mirrors the desktop's \`terminationGrace\`).
- **\`--watchdog-ppid <PID>\` CLI flag** + **\`RAPID_MLX_WATCHDOG_PPID\` env fallback** (CLI wins). No-op when unset / 0 / 1 so existing standalone \`rapid-mlx serve\` users see zero change.
- Wired in at the TOP of \`serve_command\` so it covers text-LM, audio-mode, embedding-mode, and DFlash forks AND arms BEFORE the multi-minute model download (kill mid-download still gets a clean reap).
- PPID comparison (not \`kill(pid, 0)\`) is authoritative: \`getppid()\` cannot race PID recycling. Install-time synchronous fire catches the race where the supervisor died between spawn and \`serve_command\` boot.

## Test plan

- [x] 14 unit tests (\`tests/test_parent_watchdog.py\`) covering CLI/env precedence, the \`expected_ppid <= 1\` early-out, install-time synchronous fire, loop-time detection, single-fire-then-exit, the \`_rapid_mlx_stop_event\` disarm hook, and the canonical stderr marker dogfood postmortems grep for.
- [x] CLI plumbing: \`rapid-mlx serve --help\` lists \`--watchdog-ppid PID\` with the env-fallback hint.
- [x] Full CLI test suite (162 tests) green.
- [x] Integration verified by hand: Python parent spawning a sidecar with \`RAPID_MLX_WATCHDOG_PPID=\$\$\`, \`kill -9\` the parent, sidecar reaped within 7 s. Baseline run without the env var confirmed the orphan persists.

## Follow-up

rapid-desktop's \`ServerManager.serveEnvironmentAdditions\` (or \`serveArguments\`) needs to stamp the env var / flag at spawn — that lands in a follow-up rapid-desktop PR behind a submodule bump to this commit. The two-PR shape keeps the bundled-default opt-in: only consumers that ask for parent-watch get the suicide thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)