### PR TITLE
fix(0.9.7): help — suggest closest match for unknown subcommand

### DIFF
--- a/tests/test_help_fuzzy.py
+++ b/tests/test_help_fuzzy.py
@@ -1,0 +1,56 @@
+"""End-to-end pins for the `help <typo>` fuzzy-match suggestion.
+
+When a user runs `rapid-mlx help serv`, difflib should nudge them toward
+`serve` — but only when there's a plausibly close match.  No close match
+falls back to the original "Run `rapid-mlx help` ..." message.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _run_cli(*cli_args: str) -> subprocess.CompletedProcess[str]:
+    """Drive `python -m vllm_mlx.cli` against THIS worktree's source.
+
+    Forcing ``PYTHONPATH=.`` keeps the child Python from picking up an
+    editable install that lives at the original (non-worktree) checkout.
+    """
+    env = {**os.environ, "PYTHONPATH": str(REPO_ROOT)}
+    return subprocess.run(
+        [sys.executable, "-m", "vllm_mlx.cli", *cli_args],
+        capture_output=True,
+        text=True,
+        cwd=str(REPO_ROOT),
+        env=env,
+    )
+
+
+def test_help_typo_serv_suggests_serve() -> None:
+    result = _run_cli("help", "serv")
+    assert result.returncode == 1
+    assert "Unknown subcommand: serv" in result.stdout
+    assert "Did you mean:" in result.stdout
+    assert "serve" in result.stdout
+    assert "Run `rapid-mlx help` for the list of subcommands." in result.stdout
+
+
+def test_help_typo_mdls_suggests_models() -> None:
+    result = _run_cli("help", "mdls")
+    assert result.returncode == 1
+    assert "Unknown subcommand: mdls" in result.stdout
+    assert "Did you mean:" in result.stdout
+    assert "models" in result.stdout
+
+
+def test_help_no_close_match_omits_suggestion() -> None:
+    result = _run_cli("help", "zzzzz")
+    assert result.returncode == 1
+    assert "Unknown subcommand: zzzzz" in result.stdout
+    assert "Did you mean:" not in result.stdout
+    assert "Run `rapid-mlx help` for the list of subcommands." in result.stdout

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -7298,7 +7298,14 @@ Examples:
         elif target in subparsers.choices:
             subparsers.choices[target].print_help()
         else:
+            import difflib
+
             print(f"Unknown subcommand: {target}")
+            matches = difflib.get_close_matches(
+                target, list(subparsers.choices.keys()), n=3, cutoff=0.6
+            )
+            if matches:
+                print(f"  Did you mean: {', '.join(matches)}?")
             print("Run `rapid-mlx help` for the list of subcommands.")
             sys.exit(1)
     elif args.command == "pull":


### PR DESCRIPTION
## Summary

Tiny dogfood polish: `rapid-mlx help <typo>` now nudges the user toward the closest real subcommand using `difflib.get_close_matches`. When nothing's close enough, output is unchanged.

One import, three lines of logic — true to the *小而美* theme.

## Before / After

**Before**
```
$ rapid-mlx help serv
Unknown subcommand: serv
Run `rapid-mlx help` for the list of subcommands.
```

**After**
```
$ rapid-mlx help serv
Unknown subcommand: serv
  Did you mean: serve?
Run `rapid-mlx help` for the list of subcommands.
```

**No close match still works**
```
$ rapid-mlx help zzzzz
Unknown subcommand: zzzzz
Run `rapid-mlx help` for the list of subcommands.
```

## Test plan

- [x] `tests/test_help_fuzzy.py` pins `serv → serve`, `mdls → models`, and `zzzzz → no suggestion` end-to-end via `python -m vllm_mlx.cli` subprocess
- [x] `ruff format` + `ruff check` clean on both touched files
- [x] Manual smoke: `rapid-mlx help serv`, `rapid-mlx help mdls`, `rapid-mlx help zzzzz`

🤖 Generated with [Claude Code](https://claude.com/claude-code)