### PR TITLE
fix(0.9.7): rm — confirmation prompt + freed-space summary + --yes flag

### DIFF
--- a/tests/test_rm_command.py
+++ b/tests/test_rm_command.py
@@ -1,0 +1,216 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for ``rapid-mlx rm <model>``.
+
+Pre-0.9.7 ``rm`` deleted gigabytes of model weights silently — no
+confirmation, no freed-space summary. This file pins the new contract:
+
+* default: prompt ``Remove <model> (X.Y GiB)? [y/N]``, default ``N``;
+* empty input (just Enter) → ``Aborted.`` and exit 0;
+* EOF (non-TTY / ctrl-D) → ``Aborted.`` and exit 0;
+* ``-y / --yes`` → no prompt, runs the delete;
+* on success a ``Freed X.Y GiB`` line is printed.
+
+The actual HF cache strategy is mocked — these tests must never delete
+real files. Size suffix matches ``vllm_mlx.cli._format_bytes`` (GiB).
+"""
+
+from __future__ import annotations
+
+import io
+import sys
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from vllm_mlx import cli
+
+# ----- helpers --------------------------------------------------------------
+
+
+def _make_repo(
+    repo_id: str = "mlx-community/Qwen3.5-9B-MLX-4bit", size_on_disk: int = 6 * 1024**3
+) -> MagicMock:
+    """Build a fake ``CachedRepoInfo`` matching the surface ``rm_command`` uses."""
+    rev = SimpleNamespace(commit_hash="deadbeef")
+    repo = MagicMock()
+    repo.repo_id = repo_id
+    repo.repo_type = "model"
+    repo.size_on_disk = size_on_disk
+    repo.revisions = [rev]
+    return repo
+
+
+def _patched_scan(repo: MagicMock | None) -> MagicMock:
+    """Build a fake ``scan_cache_dir()`` return-value with a no-op strategy.
+
+    ``strategy.execute()`` is what actually deletes files on disk, so the
+    mock no-ops it — guaranteeing the test suite can never wipe a real
+    HF cache even if the test logic regresses.
+    """
+    cache = MagicMock()
+    cache.repos = [repo] if repo is not None else []
+    strategy = MagicMock()
+    strategy.expected_freed_size_str = "6.0 GiB"
+    cache.delete_revisions.return_value = strategy
+    return cache, strategy
+
+
+def _invoke_rm(
+    model: str, yes: bool, stdin_text: str | None
+) -> tuple[str, int, MagicMock]:
+    """Run ``cli.rm_command`` against a mocked HF cache.
+
+    Returns ``(stdout, exit_code, strategy_mock)``. ``exit_code == 0`` for
+    normal returns; on ``sys.exit(N)`` it propagates ``N``. ``stdin_text=None``
+    simulates EOF (e.g. piped stdin closed, ctrl-D).
+    """
+    repo = _make_repo()
+    cache, strategy = _patched_scan(repo)
+
+    if stdin_text is None:
+
+        def fake_input(_prompt: str) -> str:
+            raise EOFError
+    else:
+
+        def fake_input(_prompt: str) -> str:
+            return stdin_text
+
+    args = SimpleNamespace(model=model, yes=yes)
+    buf = io.StringIO()
+
+    with (
+        patch("huggingface_hub.scan_cache_dir", return_value=cache),
+        patch("builtins.input", side_effect=fake_input),
+        patch.object(sys, "stdout", buf),
+    ):
+        try:
+            cli.rm_command(args)
+            code = 0
+        except SystemExit as e:
+            code = int(e.code) if e.code is not None else 0
+
+    return buf.getvalue(), code, strategy
+
+
+# ----- prompt path ---------------------------------------------------------
+
+
+def test_default_prompts_and_n_aborts() -> None:
+    """``n`` at the prompt aborts cleanly: exit 0, no delete, ``Aborted.`` printed."""
+    out, code, strategy = _invoke_rm(
+        "mlx-community/Qwen3.5-9B-MLX-4bit", yes=False, stdin_text="n"
+    )
+    assert code == 0, f"abort path must exit 0, got {code}"
+    assert "Aborted." in out, f"expected 'Aborted.' marker, got:\n{out}"
+    strategy.execute.assert_not_called()
+    # ``Freed`` summary is the success marker — must NOT appear on abort.
+    assert "Freed" not in out
+
+
+def test_empty_input_aborts() -> None:
+    """Pressing Enter without typing accepts the [y/N] default — N — and aborts."""
+    out, code, strategy = _invoke_rm(
+        "mlx-community/Qwen3.5-9B-MLX-4bit", yes=False, stdin_text=""
+    )
+    assert code == 0
+    assert "Aborted." in out
+    strategy.execute.assert_not_called()
+
+
+def test_eof_aborts() -> None:
+    """EOF on stdin (piped / ctrl-D) is treated as cancel, not silent-accept."""
+    out, code, strategy = _invoke_rm(
+        "mlx-community/Qwen3.5-9B-MLX-4bit", yes=False, stdin_text=None
+    )
+    assert code == 0
+    assert "Aborted." in out
+    strategy.execute.assert_not_called()
+
+
+def test_y_at_prompt_proceeds_and_prints_freed() -> None:
+    """Typing ``y`` at the prompt runs the delete and prints ``Freed X.Y GiB``."""
+    out, code, strategy = _invoke_rm(
+        "mlx-community/Qwen3.5-9B-MLX-4bit", yes=False, stdin_text="y"
+    )
+    assert code == 0
+    strategy.execute.assert_called_once()
+    assert "Freed" in out, f"expected 'Freed' summary on success, got:\n{out}"
+    assert "GiB" in out, f"expected GiB suffix from _format_bytes, got:\n{out}"
+
+
+# ----- --yes path ----------------------------------------------------------
+
+
+def test_yes_flag_skips_prompt() -> None:
+    """``--yes`` must never call ``input()`` — proves it via a side-effect that
+    would raise on call."""
+    repo = _make_repo()
+    cache, strategy = _patched_scan(repo)
+    args = SimpleNamespace(model="mlx-community/Qwen3.5-9B-MLX-4bit", yes=True)
+    buf = io.StringIO()
+
+    def boom(_prompt: str) -> str:
+        raise AssertionError("input() must not be called when --yes is set")
+
+    with (
+        patch("huggingface_hub.scan_cache_dir", return_value=cache),
+        patch("builtins.input", side_effect=boom),
+        patch.object(sys, "stdout", buf),
+    ):
+        cli.rm_command(args)
+
+    strategy.execute.assert_called_once()
+    out = buf.getvalue()
+    assert "Freed" in out
+    assert "GiB" in out
+
+
+# ----- not-cached path -----------------------------------------------------
+
+
+def test_missing_model_exits_1_without_prompt() -> None:
+    """When the model isn't in the cache there's nothing to confirm — the
+    command must short-circuit before ``input()`` and exit 1."""
+    cache, _ = _patched_scan(None)  # empty repos
+    args = SimpleNamespace(model="mlx-community/Nope", yes=False)
+    buf = io.StringIO()
+
+    def boom(_prompt: str) -> str:
+        raise AssertionError("input() must not be called when repo is missing")
+
+    with (
+        patch("huggingface_hub.scan_cache_dir", return_value=cache),
+        patch("builtins.input", side_effect=boom),
+        patch.object(sys, "stdout", buf),
+        pytest.raises(SystemExit) as exc,
+    ):
+        cli.rm_command(args)
+
+    assert exc.value.code == 1
+    out = buf.getvalue()
+    assert "not in the HuggingFace cache" in out
+
+
+# ----- size formatting ----------------------------------------------------
+
+
+def test_size_uses_format_bytes_suffix() -> None:
+    """The prompt + freed line use the same suffix convention as the rest of
+    the CLI (``_format_bytes`` → GiB/MiB/KiB), so users don't see ``5.0 G``
+    in one place and ``5.0 GiB`` in another for the same model."""
+    repo = _make_repo(size_on_disk=int(6.5 * 1024**3))
+    cache, strategy = _patched_scan(repo)
+    args = SimpleNamespace(model="mlx-community/Qwen3.5-9B-MLX-4bit", yes=True)
+    buf = io.StringIO()
+
+    with (
+        patch("huggingface_hub.scan_cache_dir", return_value=cache),
+        patch.object(sys, "stdout", buf),
+    ):
+        cli.rm_command(args)
+
+    out = buf.getvalue()
+    # ``_format_bytes`` renders 6.5 GiB as ``6.5 GiB`` (1-decimal IEC).
+    assert "6.5 GiB" in out, f"expected '6.5 GiB' in Freed line, got:\n{out}"

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -3706,7 +3706,14 @@ def pull_command(args):
 
 
 def rm_command(args):
-    """Remove a model from the HuggingFace cache."""
+    """Remove a model from the HuggingFace cache.
+
+    Default flow prompts for confirmation, defaulting to N — a real user
+    typo (``rapid-mlx rm qwn3.5-9b-4bit`` → matches a 6 GB model) could
+    silently nuke gigabytes of weights pre-0.9.7. EOF (non-TTY pipe,
+    ctrl-D) also cancels rather than being treated as accept-by-default.
+    ``-y/--yes`` skips the prompt for scripts.
+    """
     from huggingface_hub import scan_cache_dir
 
     repo_id = args.model
@@ -3722,11 +3729,24 @@ def rm_command(args):
         sys.exit(1)
 
     repo = matching[0]
+    size_str = _format_bytes(repo.size_on_disk)
+
+    if not getattr(args, "yes", False):
+        try:
+            response = input(f"Remove {repo_id} ({size_str})? [y/N] ").strip().lower()
+        except EOFError:
+            # Non-TTY (piped stdin, ctrl-D) — treat as cancel, never as
+            # silent-yes. Matches ``apt`` / ``brew`` muscle memory.
+            print("Aborted.")
+            sys.exit(0)
+        if response not in ("y", "yes"):
+            print("Aborted.")
+            sys.exit(0)
+
     revisions = [rev.commit_hash for rev in repo.revisions]
     strategy = cache.delete_revisions(*revisions)
-    print(f"\n  Removing {repo_id} ({strategy.expected_freed_size_str}) ...")
     strategy.execute()
-    print("  Done.")
+    print(f"Freed {size_str}")
 
 
 def ps_command(_args):
@@ -6709,6 +6729,12 @@ Examples:
     rm_parser.add_argument(
         "model", help="Model alias (e.g. qwen3.5-4b-4bit) or HF repo (org/name)"
     ).completer = alias_completer
+    rm_parser.add_argument(
+        "-y",
+        "--yes",
+        action="store_true",
+        help="Skip the confirmation prompt and remove the model immediately.",
+    )
     subparsers.add_parser("ps", help="List running rapid-mlx servers")
 
     # Upgrade — detect install method and run the right upgrade command


### PR DESCRIPTION
## Summary

The `rm` subcommand is currently the highest-risk UX gap in the CLI — `rapid-mlx rm qwen3.5-9b-4bit` silently deletes ~6 GB of weights with no prompt, no progress, no summary. A typo (`qwn3.5-9b-4bit`) could nuke 40 GB without recourse. This PR adds the apt/brew-style confirmation, a `--yes` escape hatch for scripts, and a `Freed X.Y GiB` summary on success.

- Default flow now prompts `Remove <model> (X.Y GiB)? [y/N]`. Default is `N`; Enter, EOF (non-TTY / ctrl-D), or any non-`y/yes` answer prints `Aborted.` and exits 0.
- New `-y / --yes` flag on the `rm` subparser skips the prompt for CI / scripts.
- Success path prints `Freed X.Y GiB`, using the same `_format_bytes` IEC suffix the rest of the CLI uses (`ls --cached`, B2 confirmation prompt) so users never see two different unit strings for the same model.
- No `pyproject.toml` bump in this PR — `skip-version-bump` label applied so version-check CI passes.

## Before / After

**Before (0.9.6):**
```
$ rapid-mlx rm mlx-community/Qwen3.5-9B-MLX-4bit

  Removing mlx-community/Qwen3.5-9B-MLX-4bit (5.4G) ...
  Done.
```
No confirmation step at all — a typo on the model arg silently destroys gigabytes.

**After (0.9.7):**
```
$ rapid-mlx rm mlx-community/Qwen3.5-9B-MLX-4bit
Remove mlx-community/Qwen3.5-9B-MLX-4bit (5.4 GiB)? [y/N] n
Aborted.

$ rapid-mlx rm mlx-community/Qwen3.5-9B-MLX-4bit
Remove mlx-community/Qwen3.5-9B-MLX-4bit (5.4 GiB)? [y/N] y
Freed 5.4 GiB

$ rapid-mlx rm -y mlx-community/Qwen3.5-9B-MLX-4bit
Freed 5.4 GiB
```

## Test plan

- [x] `tests/test_rm_command.py` — 7 tests pin: default prompt + `n` aborts; empty input aborts; EOF aborts; `y` proceeds + prints `Freed`; `--yes` skips `input()` entirely; missing-model short-circuits with exit 1 (no prompt); size suffix is `GiB` (matches `_format_bytes`).
- [x] `strategy.execute()` is mocked in every test — the suite physically cannot delete real HF cache files.
- [x] `ruff format` + `ruff check` clean on `vllm_mlx/cli.py` and `tests/test_rm_command.py`.
- [x] No `pyproject.toml` bump; `skip-version-bump` label applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)