### PR TITLE
fix(0.9.7): doctor — rip vestigial checks + add DFlash extras row

### DIFF
--- a/tests/test_doctor_extras.py
+++ b/tests/test_doctor_extras.py
@@ -1,0 +1,209 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the 0.9.7 doctor cleanup:
+
+1. ``YouTube/HF cookies`` (Trio-project leakage) is gone from the Network
+   section — rapid-mlx has nothing to do with YouTube.
+2. ``anthropic SDK`` row (irrelevant for an MLX inference server) is gone
+   from the Optional Tools section.
+3. A dedicated ``mlx-vlm 0.5.0+ (dflash extras)`` row exists in the
+   Optional Packages section, gated on the actual installed mlx-vlm
+   version — the headline 0.9.x feature deserves an explicit check.
+
+These tests pin the user-facing output. A future drive-by that brings
+either ripped row back will turn these red and force a conscious
+re-litigation of the decision.
+"""
+
+from __future__ import annotations
+
+from unittest import mock
+
+from vllm_mlx.doctor import env_health as eh
+
+# ---------------------------------------------------------------------------
+# Rip 1: YouTube cookies row removed from Network section
+# ---------------------------------------------------------------------------
+
+
+def test_youtube_cookie_check_is_gone_from_network_section(monkeypatch):
+    """The Network section must not mention YouTube — that was Trio-project
+    leakage. The HF reachability probe is the only row this section owns."""
+    # Clear every YOUTUBE_COOKIES* variant so an env leak from the host
+    # session can't mask a regression where the row sneaks back in.
+    for name in (
+        "YOUTUBE_COOKIES",
+        "YOUTUBE_COOKIES_1",
+        "YOUTUBE_COOKIES_2",
+        "YOUTUBE_COOKIES_3",
+        "YOUTUBE_COOKIES_4",
+        "YOUTUBE_COOKIES_5",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+    def fake_probe() -> tuple[eh.CheckStatus, str]:
+        return eh.CheckStatus.OK, "HTTP 200"
+
+    section = eh.section_network(probe=fake_probe)
+
+    for c in section.checks:
+        assert "YouTube" not in c.label, (
+            f"Network section still mentions YouTube: {c.label!r}. "
+            "0.9.7 ripped this vestigial Trio-project check."
+        )
+        assert "youtube" not in (c.detail or "").lower(), (
+            f"Network section detail still mentions youtube: {c.detail!r}"
+        )
+
+
+def test_youtube_cookie_check_gone_even_when_env_var_is_set(monkeypatch):
+    """Setting ``YOUTUBE_COOKIES_1`` must NOT resurrect the row — the env-var
+    handling itself was ripped, not just the WARN branch."""
+    monkeypatch.setenv("YOUTUBE_COOKIES_1", "fake-cookie-content")
+
+    def fake_probe() -> tuple[eh.CheckStatus, str]:
+        return eh.CheckStatus.OK, "HTTP 200"
+
+    section = eh.section_network(probe=fake_probe)
+    assert not any("YouTube" in c.label for c in section.checks)
+
+
+# ---------------------------------------------------------------------------
+# Rip 2: anthropic SDK row removed from Optional Tools section
+# ---------------------------------------------------------------------------
+
+
+def test_anthropic_sdk_check_is_gone_from_optional_tools():
+    """Optional Tools must not probe for the anthropic SDK — irrelevant for
+    an MLX inference server. The codex CLI row is the only optional-tool
+    row this section owns post-0.9.7."""
+    section = eh.section_optional_tools(which=lambda _name: None)
+
+    for c in section.checks:
+        assert "anthropic" not in c.label.lower(), (
+            f"Optional Tools still mentions anthropic: {c.label!r}. "
+            "0.9.7 ripped this — agent-harness use case is too niche."
+        )
+
+
+def test_anthropic_sdk_check_gone_even_when_installed():
+    """Even if anthropic happens to be importable, no row should surface —
+    the check itself was ripped, not just the WARN branch."""
+    # _safe_version is the only path through which a value could surface;
+    # forcing it to always return a string proves the call site is gone.
+    with mock.patch.object(eh, "_safe_version", return_value="1.99.0"):
+        section = eh.section_optional_tools(which=lambda _name: None)
+    assert not any("anthropic" in c.label.lower() for c in section.checks)
+
+
+# ---------------------------------------------------------------------------
+# Add: DFlash extras row in Optional Packages section
+# ---------------------------------------------------------------------------
+
+
+def test_dflash_row_ok_when_mlx_vlm_at_min_version():
+    """``mlx-vlm == 0.5.0`` exactly → ✓ DFlash row."""
+
+    def fake_ver(dist: str) -> str | None:
+        return "0.5.0" if dist == "mlx-vlm" else "1.0.0"
+
+    with mock.patch.object(eh, "_safe_version", side_effect=fake_ver):
+        section = eh.section_optional_packages()
+
+    dflash = next((c for c in section.checks if "dflash" in c.label), None)
+    assert dflash is not None, (
+        "Optional Packages section is missing the DFlash row — "
+        f"got rows: {[c.label for c in section.checks]}"
+    )
+    assert dflash.status is eh.CheckStatus.OK, (
+        f"DFlash row should be OK at mlx-vlm 0.5.0; got {dflash.status!r}"
+    )
+    assert "0.5.0+" in dflash.label and "dflash extras" in dflash.label
+
+
+def test_dflash_row_ok_when_mlx_vlm_above_min_version():
+    """``mlx-vlm == 1.2.3`` → ✓ DFlash row (version comparison handles
+    multi-component bumps, not just exact-match)."""
+
+    def fake_ver(dist: str) -> str | None:
+        return "1.2.3" if dist == "mlx-vlm" else "1.0.0"
+
+    with mock.patch.object(eh, "_safe_version", side_effect=fake_ver):
+        section = eh.section_optional_packages()
+
+    dflash = next(c for c in section.checks if "dflash" in c.label)
+    assert dflash.status is eh.CheckStatus.OK
+
+
+def test_dflash_row_warns_when_mlx_vlm_too_old():
+    """``mlx-vlm == 0.4.9`` → ⚠ DFlash row with the current version
+    surfaced in the label so the user can see exactly how far they're
+    behind without digging through `pip show`."""
+
+    def fake_ver(dist: str) -> str | None:
+        return "0.4.9" if dist == "mlx-vlm" else "1.0.0"
+
+    with mock.patch.object(eh, "_safe_version", side_effect=fake_ver):
+        section = eh.section_optional_packages()
+
+    dflash = next(c for c in section.checks if "dflash" in c.label)
+    assert dflash.status is eh.CheckStatus.WARN
+    assert "current: 0.4.9" in dflash.label
+    assert "need: 0.5.0+" in dflash.label
+
+
+def test_dflash_row_warns_when_mlx_vlm_missing():
+    """``mlx-vlm`` not installed at all → ⚠ DFlash row labelled
+    ``current: not installed``."""
+
+    def fake_ver(dist: str) -> str | None:
+        return None if dist == "mlx-vlm" else "1.0.0"
+
+    with mock.patch.object(eh, "_safe_version", side_effect=fake_ver):
+        section = eh.section_optional_packages()
+
+    dflash = next(c for c in section.checks if "dflash" in c.label)
+    assert dflash.status is eh.CheckStatus.WARN
+    assert "current: not installed" in dflash.label
+
+
+# ---------------------------------------------------------------------------
+# _version_at_least helper — pinpoint coverage so a future "simplification"
+# can't silently break the version gate.
+# ---------------------------------------------------------------------------
+
+
+def test_version_at_least_accepts_exact_floor():
+    assert eh._version_at_least("0.5.0", (0, 5, 0)) is True
+
+
+def test_version_at_least_accepts_higher():
+    assert eh._version_at_least("0.5.1", (0, 5, 0)) is True
+    assert eh._version_at_least("1.0.0", (0, 5, 0)) is True
+    assert eh._version_at_least("0.10.0", (0, 5, 0)) is True
+
+
+def test_version_at_least_rejects_lower():
+    assert eh._version_at_least("0.4.9", (0, 5, 0)) is False
+    assert eh._version_at_least("0.0.1", (0, 5, 0)) is False
+
+
+def test_version_at_least_handles_pep440_suffixes():
+    """PEP 440 pre-release / local-version suffixes must be stripped —
+    ``0.5.0rc1`` and ``0.5.0+local`` both clear the (0,5,0) floor."""
+    assert eh._version_at_least("0.5.0rc1", (0, 5, 0)) is True
+    assert eh._version_at_least("0.5.0+local.1", (0, 5, 0)) is True
+
+
+def test_version_at_least_handles_short_version_strings():
+    """``"1"`` and ``"1.0"`` must compare correctly against a 3-tuple
+    floor — short versions get zero-padded."""
+    assert eh._version_at_least("1", (0, 5, 0)) is True
+    assert eh._version_at_least("1.0", (0, 5, 0)) is True
+    assert eh._version_at_least("0.5", (0, 5, 0)) is True
+
+
+def test_version_at_least_malformed_returns_false():
+    """A non-numeric version string returns False — safer to nudge the
+    user to upgrade than to silently pass."""
+    assert eh._version_at_least("not-a-version", (0, 5, 0)) is False
+    assert eh._version_at_least("", (0, 5, 0)) is False

--- a/vllm_mlx/doctor/env_health.py
+++ b/vllm_mlx/doctor/env_health.py
@@ -425,6 +425,36 @@ def _safe_version(dist: str) -> str | None:
         return None
 
 
+def _version_at_least(ver: str, minimum: tuple[int, ...]) -> bool:
+    """Compare a PEP 440 version string against a ``(major, minor, patch)``
+    floor using leading-numeric tuple semantics.
+
+    Pre-release/local-version suffixes are stripped — ``"0.5.0rc1"`` and
+    ``"0.5.0+local"`` both compare equal to ``(0, 5, 0)``. We don't need
+    full PEP 440 ordering here; the only floor we care about is the DFlash
+    bump (``mlx-vlm >= 0.5.0``). A malformed version returns ``False`` —
+    safer to nudge the user to upgrade than to silently pass.
+    """
+    parts: list[int] = []
+    for raw in ver.split("."):
+        # Stop at the first non-numeric chunk (e.g. "0rc1", "5+local").
+        digits = ""
+        for ch in raw:
+            if ch.isdigit():
+                digits += ch
+            else:
+                break
+        if not digits:
+            break
+        parts.append(int(digits))
+    if not parts:
+        return False
+    # Pad to the shape of ``minimum`` so the tuple comparison is well-defined.
+    while len(parts) < len(minimum):
+        parts.append(0)
+    return tuple(parts[: len(minimum)]) >= minimum
+
+
 def section_required_packages() -> Section:
     s = Section("Required Packages")
     for dist, label in REQUIRED_PACKAGES:
@@ -460,6 +490,29 @@ def section_optional_packages() -> Section:
                 CheckStatus.WARN,
                 detail=f"distribution={dist} hint={hint}",
             )
+
+    # DFlash is the headline 0.9.x feature and is gated on mlx-vlm >= 0.5.0.
+    # The plain optional-package row above only reports presence/version —
+    # it cannot say "you have mlx-vlm but it's too old for [dflash]". This
+    # extra row makes the gate explicit so a fresh-install user knows whether
+    # `pip install 'rapid-mlx[dflash]'` will actually work.
+    dflash_min = (0, 5, 0)
+    vlm_ver = _safe_version("mlx-vlm")
+    if vlm_ver and _version_at_least(vlm_ver, dflash_min):
+        s.add(
+            "mlx-vlm 0.5.0+ (dflash extras)",
+            CheckStatus.OK,
+            detail=f"distribution=mlx-vlm version={vlm_ver}",
+        )
+    else:
+        current = vlm_ver or "not installed"
+        s.add(
+            f"mlx-vlm 0.5.0+ (dflash extras) not installed or too old "
+            f"(current: {current}, need: 0.5.0+)",
+            CheckStatus.WARN,
+            detail="pip install 'rapid-mlx[dflash]'",
+        )
+
     return s
 
 
@@ -610,35 +663,6 @@ def section_network(
             detail=detail,
         )
 
-    # Cookie hint — not a probe, just an informational warning aligned with
-    # the project's documented mitigation for HF/YouTube rate limits.
-    # Env-var names are spelled out as literals so the routing-shape audit
-    # (tests/test_no_out_of_band_routing.py) can statically prove no
-    # routing decision is composed at the call site.
-    has_cookies = any(
-        os.environ.get(name)
-        for name in (
-            "YOUTUBE_COOKIES",
-            "YOUTUBE_COOKIES_1",
-            "YOUTUBE_COOKIES_2",
-            "YOUTUBE_COOKIES_3",
-            "YOUTUBE_COOKIES_4",
-            "YOUTUBE_COOKIES_5",
-        )
-    )
-    if has_cookies:
-        s.add(
-            "YouTube/HF cookies configured",
-            CheckStatus.OK,
-            detail="YOUTUBE_COOKIES* env var set",
-        )
-    else:
-        s.add(
-            "No YouTube/HF cookies configured (rate-limit risk on heavy downloads)",
-            CheckStatus.WARN,
-            detail="set YOUTUBE_COOKIES_1..5 to enable cookie rotation",
-        )
-
     return s
 
 
@@ -772,20 +796,6 @@ def section_optional_tools(
             "codex CLI not installed (relevant if using codex agent harness)",
             CheckStatus.WARN,
             detail="npm install -g @openai/codex",
-        )
-
-    anth_ver = _safe_version("anthropic")
-    if anth_ver:
-        s.add(
-            f"anthropic SDK {anth_ver}",
-            CheckStatus.OK,
-            detail=f"version={anth_ver}",
-        )
-    else:
-        s.add(
-            "anthropic SDK not installed (relevant if using anthropic agent harness)",
-            CheckStatus.WARN,
-            detail="pip install anthropic",
         )
 
     return s


### PR DESCRIPTION
## Summary

Three small polish items on the fresh-install user-journey for `rapid-mlx doctor`. Part of the 0.9.7 batched-release wave. Theme: small, beautiful, simple, practical.

### What changed

1. **Ripped: `YouTube/HF cookies` row from the Network section.**
   Vestigial Trio-project leakage. rapid-mlx has nothing to do with YouTube — the `YOUTUBE_COOKIES_1..5` env-var probe (and its WARN row for fresh installs) had no business being in an MLX inference-server's doctor output. The whole `has_cookies` block in `section_network` is gone.

2. **Ripped: `anthropic SDK` row from the Optional Tools section.**
   The agent-harness use case it served is too niche for the doctor's headline output. Leaving it WARNs every fresh install for a workflow the user almost certainly isn't running. The `_safe_version("anthropic")` block in `section_optional_tools` is gone.

3. **Added: `mlx-vlm 0.5.0+ (dflash extras)` row to the Optional Packages section.**
   DFlash is the headline 0.9.x feature and is gated on `mlx-vlm >= 0.5.0`. The plain optional-package row above already reports presence/version of `mlx-vlm` but cannot say "you have mlx-vlm but it's too old for `[dflash]`". The new row makes that gate explicit.

   Rendered output matches the existing visual style:
   - `✓ mlx-vlm 0.5.0+ (dflash extras)` when installed and >= 0.5.0
   - `⚠ mlx-vlm 0.5.0+ (dflash extras) not installed or too old (current: X.Y.Z, need: 0.5.0+)` otherwise

### Implementation choice

Chose option (b) from the brief: kept `OPTIONAL_PACKAGES` tuple untouched and added a single dedicated DFlash block at the end of `section_optional_packages`. Smaller than extending the tuple machinery to carry an optional min-version.

Added a tiny tuple-based `_version_at_least()` helper next to `_safe_version()` — no `packaging` dep needed; PEP 440 suffixes (`rc1`, `+local.1`) are stripped and short version strings (`"1"`, `"1.0"`) get zero-padded against the floor.

### Tests

`tests/test_doctor_extras.py` (14 tests) pins:
- YouTube cookie check no longer appears in the rendered output (even when `YOUTUBE_COOKIES_1` is set in the env)
- anthropic SDK check no longer appears (even when `_safe_version` returns a value)
- DFlash row appears with the correct ✓ / ⚠ based on `mlx-vlm` version, including the at-floor / above-floor / too-old / missing branches
- `_version_at_least` helper handles exact-match, higher, lower, PEP 440 suffixes, short version strings, and malformed input

All 55 existing doctor tests still pass.

### Out of scope
- No `pyproject.toml` bump — version bump is its own commit per the release SOP.
- No drive-by refactors.
- No changes to unrelated files.

## Test plan
- [x] Lint clean: `ruff format` + `ruff check` pass on changed files
- [x] New tests pass: `tests/test_doctor_extras.py` 14/14
- [x] No regressions: `tests/test_doctor_env_health.py` + `tests/test_doctor_runner.py` + `tests/test_doctor_no_model_load.py` all 55 pass
- [x] Grep sweep: no orphan references to `YOUTUBE_COOKIES` / `anth_ver` / "anthropic SDK" remain in `vllm_mlx/` or `tests/`