### PR TITLE
fix(0.9.7): pull — print size + duration summary on success

### DIFF
--- a/tests/test_pull_summary.py
+++ b/tests/test_pull_summary.py
@@ -1,0 +1,165 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the 0.9.7 ``rapid-mlx pull`` post-download summary line.
+
+A ~6 GB pull that succeeds silently leaves the user wondering "did
+that actually finish, and how much disk did I just burn?". The
+summary line printed by ``pull_command`` answers both in one line:
+
+    Downloaded <repo_id> — <size with units> in <duration with units>
+
+These tests pin three things and three things only:
+
+1. The summary line is emitted on the HuggingFace-fallback success
+   path (the common case once R2 misses).
+2. The summary line is emitted on the R2 mirror success path.
+3. The summary line is NOT emitted when the pull fails with a 404 —
+   we exit before we'd otherwise mislead the user.
+
+The actual HuggingFace download (``snapshot_download``) and the R2
+prefetch (``_try_mirror_prefetch``) are mocked; we only exercise the
+summary code path in ``pull_command``.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from vllm_mlx import cli
+
+
+def _make_fake_snapshot(root: Path, total_bytes: int) -> Path:
+    """Create a snapshot dir on disk with one file of ``total_bytes`` bytes."""
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "model.safetensors").write_bytes(b"\x00" * total_bytes)
+    return root
+
+
+def _looks_like_size(token: str) -> bool:
+    """Loose acceptance of either SI (``GB``) or IEC (``GiB``) suffixes.
+
+    The task spec says ``X.Y GB`` but the project's shared
+    ``_format_bytes`` helper renders IEC (``GiB``); we reuse it per
+    the "do not invent a new size formatter" rule, so the test
+    accepts whichever the helper produces.
+    """
+    return any(
+        unit in token
+        for unit in ("B", "KB", "KiB", "MB", "MiB", "GB", "GiB", "TB", "TiB")
+    )
+
+
+def _summary_line(captured: str) -> str:
+    for line in captured.splitlines():
+        if "Downloaded" in line and "in" in line:
+            return line
+    raise AssertionError(f"summary line missing from stdout, got:\n{captured!r}")
+
+
+def test_summary_printed_on_hf_success(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """HF-fallback path prints ``Downloaded ... — <size> in <duration>``."""
+    snapshot_dir = _make_fake_snapshot(tmp_path / "snap", total_bytes=2048)
+
+    args = argparse.Namespace(model="mlx-community/Qwen3-0.6B-4bit")
+
+    with (
+        patch.object(cli, "_try_mirror_prefetch", return_value=False),
+        patch(
+            "huggingface_hub.snapshot_download",
+            return_value=str(snapshot_dir),
+        ),
+    ):
+        cli.pull_command(args)
+
+    out = capsys.readouterr().out
+    line = _summary_line(out)
+
+    # Model name appears verbatim.
+    assert "mlx-community/Qwen3-0.6B-4bit" in line
+    # Some size token with a recognized unit.
+    parts = line.split()
+    assert any(_looks_like_size(p) for p in parts), line
+    # Some duration token ending in 's' (e.g. ``4.2s`` or ``1m 23s``).
+    assert any(p.endswith("s") and p[0].isdigit() for p in parts), line
+
+
+def test_summary_printed_on_mirror_success(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """R2-mirror success path also prints the summary line.
+
+    We point the HF cache root at ``tmp_path`` via the ``HF_HUB_CACHE``
+    constant so ``pull_command`` resolves the snapshot dir under our
+    fixture and our seeded file shows up in the size sum.
+    """
+    repo_id = "mlx-community/Qwen3-0.6B-4bit"
+    revision = "abc123" * 6  # 36 hex chars; shape doesn't matter for the test
+
+    cache_root = tmp_path / "hub"
+    repo_root = cache_root / "models--mlx-community--Qwen3-0.6B-4bit"
+    refs_dir = repo_root / "refs"
+    refs_dir.mkdir(parents=True, exist_ok=True)
+    (refs_dir / "main").write_text(revision)
+    snapshot_dir = repo_root / "snapshots" / revision
+    _make_fake_snapshot(snapshot_dir, total_bytes=4096)
+
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
+
+    args = argparse.Namespace(model=repo_id)
+
+    with patch.object(cli, "_try_mirror_prefetch", return_value=True):
+        cli.pull_command(args)
+
+    out = capsys.readouterr().out
+    line = _summary_line(out)
+    assert repo_id in line
+    parts = line.split()
+    assert any(_looks_like_size(p) for p in parts), line
+    assert any(p.endswith("s") and p[0].isdigit() for p in parts), line
+
+
+def test_summary_not_printed_on_404(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A 404 must bail before the summary — we don't lie about success.
+
+    ``pull_command`` matches 404 via either ``RepositoryNotFoundError``
+    isinstance OR a ``"404" / "not found"`` substring on the exception
+    string, so a plain ``Exception("404 Client Error")`` is enough to
+    drive the error branch without constructing HF's response-bound
+    exception class.
+    """
+    args = argparse.Namespace(model="mlx-community/does-not-exist")
+
+    with (
+        patch.object(cli, "_try_mirror_prefetch", return_value=False),
+        patch(
+            "huggingface_hub.snapshot_download",
+            side_effect=Exception("404 Client Error"),
+        ),
+        pytest.raises(SystemExit) as excinfo,
+    ):
+        cli.pull_command(args)
+
+    assert excinfo.value.code == 1
+    out = capsys.readouterr().out
+    assert "Downloaded" not in out, out
+
+
+def test_format_pull_duration_units() -> None:
+    """Sub-minute keeps decimals; ``>=60s`` switches to ``m`` + ``s``."""
+    assert cli._format_pull_duration(0.0) == "0.0s"
+    assert cli._format_pull_duration(4.2) == "4.2s"
+    assert cli._format_pull_duration(59.9) == "59.9s"
+    assert cli._format_pull_duration(60.0) == "1m 0s"
+    assert cli._format_pull_duration(125.0) == "2m 5s"
+    # Rounding rule: 119.9s reads as 2m 0s, not 1m 59s.
+    assert cli._format_pull_duration(119.9) == "2m 0s"

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -3641,13 +3641,69 @@ def models_command(args):
     print()
 
 
+def _format_pull_duration(seconds: float) -> str:
+    """Render a duration as ``Xs`` (< 60s) or ``Xm Ys`` (>= 60s).
+
+    Sub-minute keeps one decimal so a 4.2s pull doesn't read as ``4s``;
+    once we cross a minute the decimals are noise. ``round`` (not
+    ``int``) on the whole-second branch means ``119.9s`` reads as
+    ``2m 0s`` instead of ``1m 59s``.
+    """
+    if seconds < 0:
+        seconds = 0.0
+    if seconds < 60:
+        return f"{seconds:.1f}s"
+    total = int(round(seconds))
+    minutes, secs = divmod(total, 60)
+    return f"{minutes}m {secs}s"
+
+
+def _snapshot_size_bytes(path) -> int:
+    """Sum file sizes under ``path`` (recursively, following symlinks).
+
+    The HF cache stores ``snapshots/<rev>/<file>`` as symlinks into
+    ``blobs/<sha>``; ``stat()`` follows the link so the byte count is
+    the real on-disk weight, matching what the user just downloaded.
+    Quietly tolerates partial / missing trees so the summary line is
+    a print, not a crash, in degenerate cache states.
+    """
+    from pathlib import Path
+
+    root = Path(path)
+    if not root.exists():
+        return 0
+    total = 0
+    try:
+        for entry in root.rglob("*"):
+            try:
+                if entry.is_file():
+                    total += entry.stat().st_size
+            except OSError:
+                continue
+    except OSError:
+        pass
+    return total
+
+
+def _print_pull_summary(repo_id: str, snapshot_dir, elapsed: float) -> None:
+    """Emit the one-line ``Downloaded ... — <size> in <duration>`` summary."""
+    size = _snapshot_size_bytes(snapshot_dir)
+    print(
+        f"  Downloaded {repo_id} — {_format_bytes(size)} in "
+        f"{_format_pull_duration(elapsed)}"
+    )
+
+
 def pull_command(args):
     """Download a model to the HuggingFace cache without serving."""
+    import time
+
     from huggingface_hub import snapshot_download
     from huggingface_hub.errors import HFValidationError
     from huggingface_hub.utils import RepositoryNotFoundError
 
     repo_id = args.model  # already alias-resolved by main()
+    t0 = time.monotonic()
 
     # R2-first / HuggingFace-fallback per file. Default mirror is
     # ``https://models.rapidmlx.com``; set ``RAPID_MLX_MODEL_MIRROR=""``
@@ -3665,9 +3721,12 @@ def pull_command(args):
         repo_root = cache_root / f"models--{owner}--{repo}"
         try:
             rev = (repo_root / "refs" / "main").read_text().strip()
-            print(f"  Cached at: {repo_root / 'snapshots' / rev}")
+            snapshot_dir = repo_root / "snapshots" / rev
+            print(f"  Cached at: {snapshot_dir}")
         except OSError:
+            snapshot_dir = repo_root
             print(f"  Cached at: {repo_root}")
+        _print_pull_summary(repo_id, snapshot_dir, time.monotonic() - t0)
         return
     # Mirror returned False — fall through to plain snapshot_download.
     # Either the catalog was unreachable, the alias isn't catalog-listed,
@@ -3703,6 +3762,7 @@ def pull_command(args):
             sys.exit(1)
         raise
     print(f"  Cached at: {path}")
+    _print_pull_summary(repo_id, path, time.monotonic() - t0)
 
 
 def rm_command(args):


### PR DESCRIPTION
## Summary

`rapid-mlx pull <alias>` ends a multi-GB download with just the cache path. For a 6 GB Qwen3.5-9B-4bit pull the user has no signal "how much did I actually download, how long did it take, is it really done." This adds a single post-download line.

## Before

```
$ rapid-mlx pull qwen3.5-9b-4bit

  Pulling mlx-community/Qwen3.5-9B-4bit from HuggingFace ...
  [tqdm progress from huggingface_hub ...]
  Cached at: /Users/me/.cache/huggingface/hub/models--mlx-community--Qwen3.5-9B-4bit/snapshots/abc123
$
```

## After

```
$ rapid-mlx pull qwen3.5-9b-4bit

  Pulling mlx-community/Qwen3.5-9B-4bit from HuggingFace ...
  [tqdm progress from huggingface_hub ...]
  Cached at: /Users/me/.cache/huggingface/hub/models--mlx-community--Qwen3.5-9B-4bit/snapshots/abc123
  Downloaded mlx-community/Qwen3.5-9B-4bit — 5.4 GiB in 1m 23s
$
```

## Details

- Hooked into both code paths: the R2-mirror success branch and the HuggingFace `snapshot_download` fallback.
- Reuses the existing `_format_bytes` helper (IEC suffixes — same convention `ls --cached` already uses, so byte counts read consistently across the CLI).
- Small new `_format_pull_duration` helper: sub-minute keeps one decimal (`4.2s`); past 60s switches to `Xm Ys` with `round`-based rollover (`119.9s` reads as `2m 0s`, not `1m 59s`).
- Failure paths (404, `HFValidationError`) exit before the summary — we don't claim a successful download that didn't happen.

## Test plan

- [x] `tests/test_pull_summary.py` — summary printed on HF success
- [x] `tests/test_pull_summary.py` — summary printed on mirror success
- [x] `tests/test_pull_summary.py` — summary NOT printed on 404
- [x] `tests/test_pull_summary.py` — duration formatter unit table
- [x] `ruff format` + `ruff check` clean on touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)