### PR TITLE
chore: bump version to 0.9.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.9.6"
+version = "0.9.7"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## Summary
Bumps pyproject.toml 0.9.6 → 0.9.7. Single bump commit closes the 0.9.7 dogfood polish wave.

## What 0.9.7 ships
- **#942** — `serve` parent-PID watchdog defeats orphaned sidecar after rapid-desktop SIGKILL (rapid-desktop #449)
- **#943** — `help <typo>` suggests closest match via `difflib.get_close_matches`
- **#944** — `rm` confirmation prompt + `--yes` flag + freed-space summary (prevents accidental 40GB+ deletions)
- **#945** — `doctor` rips vestigial YouTube/anthropic checks + adds DFlash extras row
- **#946** — `pull` prints size + duration summary on success

Theme: 小而美 — small, beautiful, simple, practical UX polish from the dogfood loop.

## Test plan
- [x] pf1-subject-regex green
- [x] All 5 underlying PRs (#942-#946) merged with `validate=pass`

🤖 Generated with [Claude Code](https://claude.com/claude-code)