### PR TITLE
fix(streaming): tool_choice=auto/required returns empty body on hermes parser (#447)

### DIFF
--- a/tests/test_447_stream_tool_choice_auto.py
+++ b/tests/test_447_stream_tool_choice_auto.py
@@ -133,6 +133,68 @@ class TestNemotronShapeEnvelopeReachesParser:
     envelope reaches the tool parser intact and the structured call
     surfaces on ``delta.tool_calls``."""
 
+    def test_split_outer_opener_does_not_leak(self):
+        """Codex r2 MAJOR (PR #948): when the tokenizer chunks the
+        outer ``<tool_call>`` opener into ``<`` then ``tool_call>``,
+        the bare ``<`` used to be eaten by the reasoning-lane
+        split-prefix rescue (``<`` is a strict prefix of ``<think>``).
+        The next chunk (``tool_call>``) would then arrive without a
+        leading ``<``, miss the standard-path tool detection, and the
+        reasoning parser would release the buffered ``<tool_call>``
+        as plain ``delta.content`` once the tag failed to complete.
+
+        After the round-2 fix, ambiguous prefixes (``<``, ``<t``) that
+        also start a tool envelope opener are deferred to the standard
+        path so the tool parser's held-back machinery can buffer the
+        partial sentinel safely. The full envelope reaches the parser
+        intact and the call surfaces on ``delta.tool_calls`` — no
+        ``tool_call>`` leak in either content or reasoning channel."""
+        pp = _pp(enable_thinking=False)
+        result = _drive(
+            pp,
+            [
+                "<",
+                "tool_call>",
+                "\n",
+                '{"name":"get_weather","arguments":{"location":"SF"}}',
+                "\n",
+                "</tool_call>",
+            ],
+        )
+        # The outer opener must not have leaked.
+        assert "tool_call>" not in result["content"], (
+            "split outer opener leaked into content channel: "
+            f"{result['content']!r}"
+        )
+        assert "tool_call>" not in result["reasoning"], (
+            "split outer opener leaked into reasoning channel: "
+            f"{result['reasoning']!r}"
+        )
+        # And the structured call must surface.
+        assert len(result["tool_calls"]) == 1
+        assert result["tool_calls"][0]["function"]["name"] == "get_weather"
+
+    def test_split_outer_opener_two_byte_prefix(self):
+        """Same race, but the tokenizer chunks as ``<t`` + ``ool_call>``.
+        ``<t`` is a strict prefix of BOTH ``<think>`` AND ``<tool_call>``
+        so it must also be deferred to the standard path."""
+        pp = _pp(enable_thinking=False)
+        result = _drive(
+            pp,
+            [
+                "<t",
+                "ool_call>",
+                "\n",
+                '{"name":"foo","arguments":{}}',
+                "\n",
+                "</tool_call>",
+            ],
+        )
+        assert "ool_call>" not in result["content"]
+        assert "ool_call>" not in result["reasoning"]
+        assert len(result["tool_calls"]) == 1
+        assert result["tool_calls"][0]["function"]["name"] == "foo"
+
     def test_full_nemotron_envelope_emits_tool_call(self):
         """Exact chunk sequence from the live qwen3.5-4b-4bit repro
         (BatchedEngine emits one tokenizer-token per delta)."""

--- a/tests/test_447_stream_tool_choice_auto.py
+++ b/tests/test_447_stream_tool_choice_auto.py
@@ -262,3 +262,213 @@ class TestToolEnvelopeInFlightHelper:
         pp = _pp(enable_thinking=False)
         pp.tool_accumulated_text = '<minimax:tool_call><invoke name="x">'
         assert pp._tool_envelope_in_flight() is True
+
+
+# =====================================================================
+# Streaming synth fallback — chat.py route-level branch (codex r1 NIT #2)
+# =====================================================================
+#
+# Direct unit-level coverage for the new ``stream_chat_completion``
+# synthesis gate: forced ``tool_choice`` finishes with zero wire
+# tool_calls AND the parser saw nothing → synthesise; forced
+# ``tool_choice`` finishes with zero wire tool_calls but the parser DID
+# see a different tool (dropped by the forced-name filter) → do NOT
+# synthesise (mirrors non-stream ``_mismatched`` 422 case rather than
+# silently replacing the model's intent — codex r1 MAJOR #1).
+#
+# Drives ``stream_chat_completion`` end-to-end against a fake engine so
+# the SSE-level shape is asserted (not just the postprocessor state).
+
+
+import asyncio
+import json
+
+import pytest
+
+from vllm_mlx.api.models import ChatCompletionRequest
+
+
+class _FakeStreamingOutput:
+    """Minimal ``GenerationOutput`` shim for the streaming loop."""
+
+    def __init__(self, new_text: str, finished: bool):
+        self.new_text = new_text
+        self.text = new_text
+        self.finished = finished
+        self.finish_reason = "stop" if finished else None
+        self.channel = None
+        self.prompt_tokens = 10
+        self.completion_tokens = 5
+        self.cached_tokens = 0
+        self.tokens = []
+        self.logprobs = None
+        self.tool_calls = None
+        self.matched_stop = None
+        self.raw_text = new_text
+
+
+class _FakeEngine:
+    """Minimal engine shim — yields a fixed delta sequence."""
+
+    def __init__(self, deltas: list[str]):
+        self._deltas = deltas
+        self.tokenizer = None
+        self.is_mllm = False
+        self.supports_tool_calls = True
+        self.supports_guided_generation = False
+
+    async def stream_chat(self, **kwargs):
+        for i, d in enumerate(self._deltas):
+            yield _FakeStreamingOutput(d, finished=(i == len(self._deltas) - 1))
+
+    def build_prompt(self, *args, **kwargs):
+        return "prompt"
+
+    def estimate_new_tokens(self, *args, **kwargs):
+        return (10, 5)
+
+
+def _drive_stream(engine, request) -> tuple[list[dict], str | None]:
+    """Run ``stream_chat_completion`` against the fake engine, collect
+    parsed SSE chunks (skipping ``[DONE]`` and keepalives).
+
+    Returns ``(chunks, final_finish_reason)``.
+    """
+    from vllm_mlx.routes.chat import stream_chat_completion
+
+    chunks: list[dict] = []
+
+    async def _run():
+        gen = stream_chat_completion(engine, [{"role": "user", "content": "hi"}], request)
+        async for sse in gen:
+            line = sse.strip()
+            if not line.startswith("data: "):
+                continue
+            body = line[len("data: "):]
+            if body == "[DONE]":
+                break
+            try:
+                chunks.append(json.loads(body))
+            except json.JSONDecodeError:
+                continue
+
+    asyncio.run(_run())
+    finish = None
+    for c in reversed(chunks):
+        choices = c.get("choices") or []
+        if choices and choices[0].get("finish_reason"):
+            finish = choices[0]["finish_reason"]
+            break
+    return chunks, finish
+
+
+class TestStreamSynthForcedToolChoice:
+    """Route-level: forced tool_choice produced no parser-detected call
+    → synth fires; forced tool_choice produced a DIFFERENT call (filter
+    dropped it) → synth must NOT fire (non-stream parity)."""
+
+    def _request(self, tool_choice):
+        return ChatCompletionRequest(
+            model="test",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=[
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "get_weather",
+                        "description": "x",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {"location": {"type": "string"}},
+                            "required": ["location"],
+                        },
+                    },
+                }
+            ],
+            tool_choice=tool_choice,
+            stream=True,
+            max_tokens=50,
+            chat_template_kwargs={"enable_thinking": False},
+        )
+
+    @pytest.fixture(autouse=True)
+    def _patch_cfg(self, monkeypatch):
+        """Wire a minimal ServerConfig + StreamingPostProcessor that
+        matches the qwen3 + hermes production shape."""
+        from vllm_mlx.config import server_config
+
+        cfg = server_config.get_config()
+        # The cfg singleton is mutated to reflect the qwen3 + hermes
+        # path; restore the pre-test value at teardown via monkeypatch.
+        monkeypatch.setattr(cfg, "tool_call_parser", "hermes", raising=False)
+        monkeypatch.setattr(cfg, "reasoning_parser_name", "qwen3", raising=False)
+        monkeypatch.setattr(cfg, "enable_auto_tool_choice", True, raising=False)
+        monkeypatch.setattr(cfg, "cloud_router", None, raising=False)
+        monkeypatch.setattr(cfg, "gc_control", False, raising=False)
+        yield
+
+    def test_synth_fires_when_parser_saw_nothing(self):
+        """``required`` + 1 tool + zero parser-detected call shapes →
+        terminal chunk carries a synthesised ``delta.tool_calls`` with
+        ``finish_reason="tool_calls"``."""
+        # The model emits a hybrid wire shape (Nemotron closers after a
+        # JSON prefix injection) that neither shape regex matches; the
+        # parser never sets ``tool_calls_detected``.
+        deltas = ["0", "}", "\n", "</parameter>", "\n", "</function>", "\n", "</tool_call>"]
+        chunks, finish = _drive_stream(_FakeEngine(deltas), self._request("required"))
+        # Look for a tool_calls delta in any chunk.
+        emitted_tcs = []
+        for c in chunks:
+            for ch in c.get("choices") or []:
+                tcs = (ch.get("delta") or {}).get("tool_calls")
+                if tcs:
+                    emitted_tcs.extend(tcs)
+        assert emitted_tcs, "synth must emit a delta.tool_calls"
+        assert emitted_tcs[0]["function"]["name"] == "get_weather"
+        assert finish == "tool_calls"
+
+    def test_synth_does_not_fire_when_parser_saw_a_call(self):
+        """Codex r1 MAJOR #1: a parser that detected a tool call
+        (``tool_calls_detected=True``) but had every entry dropped by
+        the forced-name filter / parallel cap (``_tool_calls_emitted_to
+        _wire == 0``) must NOT trigger the synth — that case mirrors
+        the non-stream ``_mismatched`` 422 path, not the
+        ``not _names`` synth path. Synth here would silently replace
+        the model's wrong-tool call with the pinned target."""
+        from vllm_mlx.service import postprocessor as pp_mod
+
+        # Simulate the filter-dropped state by wrapping ``reset()`` (the
+        # route calls ``processor.reset()`` before the stream loop, so an
+        # ``__init__`` patch would be wiped). After ``reset`` only
+        # ``process_chunk`` runs on plain text (which won't touch the
+        # flag here because no tool envelope appears in the wire).
+        original_reset = pp_mod.StreamingPostProcessor.reset
+
+        def _patched_reset(self):
+            original_reset(self)
+            # Pre-set the filter-dropped state: parser detected a call
+            # but every entry was filtered out before reaching the wire.
+            self.tool_calls_detected = True
+
+        pp_mod.StreamingPostProcessor.reset = _patched_reset
+        try:
+            deltas = ["plain ", "answer", "."]
+            chunks, finish = _drive_stream(
+                _FakeEngine(deltas),
+                self._request({"type": "function", "function": {"name": "get_weather"}}),
+            )
+        finally:
+            pp_mod.StreamingPostProcessor.reset = original_reset
+        emitted_tcs = []
+        for c in chunks:
+            for ch in c.get("choices") or []:
+                tcs = (ch.get("delta") or {}).get("tool_calls")
+                if tcs:
+                    emitted_tcs.extend(tcs)
+        # Synth MUST NOT fire when the parser already saw a (different) call.
+        assert not emitted_tcs, (
+            "synth must not fire when tool_calls_detected=True; would "
+            "silently replace the model's intended call"
+        )
+        # And the wire envelope must still close cleanly.
+        assert finish in ("stop", "tool_calls", None) or finish is None

--- a/tests/test_447_stream_tool_choice_auto.py
+++ b/tests/test_447_stream_tool_choice_auto.py
@@ -208,6 +208,40 @@ class TestNemotronShapeEnvelopeReachesParser:
                 f"reasoning channel: {result['reasoning']!r}"
             )
 
+    def test_held_ambiguous_prefix_flushed_on_empty_finish_only_chunk(self):
+        """Codex r4 NIT (PR #948): if the stream emits an ambiguous
+        head (``<`` / ``<t``) on a non-finished chunk and then an
+        EMPTY finish-only chunk, the held byte was previously dropped
+        because the ``not delta_text`` early-return ran before the
+        hold-buffer replay. After the round-4 finish-flush, the held
+        prefix is replayed through the normal routing path so it
+        reaches the wire as content (the only correct outcome for a
+        terminal sequence with no disambiguating second chunk)."""
+        pp = _pp(enable_thinking=False)
+        # Drive deltas manually so we can emit an empty-text finish
+        # chunk; the ``_drive`` helper marks the last delta as
+        # ``finished=True`` instead, which is a different shape.
+        events = list(pp.process_chunk(_make_output("<", finished=False)))
+        # Held — no events.
+        assert events == [], (
+            f"expected ambiguous head to be held, got {events!r}"
+        )
+        # Now an empty finish-only chunk — the held ``<`` must flush.
+        events += list(pp.process_chunk(_make_output("", finished=True)))
+        # Find any content that reached the wire.
+        wire_content = "".join(
+            (getattr(e, "content", "") or "")
+            for e in events
+            if e.type in ("content", "finish")
+        )
+        # The held ``<`` must have surfaced — either as a content event
+        # or merged into the finish event — and NOT been silently
+        # dropped.
+        assert "<" in wire_content, (
+            f"held ambiguous prefix was dropped on empty finish-only "
+            f"chunk; wire_content={wire_content!r} events={events!r}"
+        )
+
     def test_split_outer_opener_two_byte_prefix(self):
         """Same race, but the tokenizer chunks as ``<t`` + ``ool_call>``.
         ``<t`` is a strict prefix of BOTH ``<think>`` AND ``<tool_call>``

--- a/tests/test_447_stream_tool_choice_auto.py
+++ b/tests/test_447_stream_tool_choice_auto.py
@@ -163,12 +163,10 @@ class TestNemotronShapeEnvelopeReachesParser:
         )
         # The outer opener must not have leaked.
         assert "tool_call>" not in result["content"], (
-            "split outer opener leaked into content channel: "
-            f"{result['content']!r}"
+            f"split outer opener leaked into content channel: {result['content']!r}"
         )
         assert "tool_call>" not in result["reasoning"], (
-            "split outer opener leaked into reasoning channel: "
-            f"{result['reasoning']!r}"
+            f"split outer opener leaked into reasoning channel: {result['reasoning']!r}"
         )
         # And the structured call must surface.
         assert len(result["tool_calls"]) == 1

--- a/tests/test_447_stream_tool_choice_auto.py
+++ b/tests/test_447_stream_tool_choice_auto.py
@@ -1,0 +1,264 @@
+# SPDX-License-Identifier: Apache-2.0
+"""rapid-desktop#447 — streaming + tool_choice=auto/required must emit
+tool_call deltas on hermes parser + qwen3 model family.
+
+The reported failure mode (v0.8.18 / v0.9.6): a model that streams
+the Nemotron-shape envelope
+
+    <tool_call>
+    <function=NAME>
+    <parameter=K>V</parameter>
+    </function>
+    </tool_call>
+
+under ``enable_thinking=False`` (the auto-disable injected when ``tools``
+are present and the client did not pin a thinking preference) used to
+finish with zero ``delta.tool_calls`` and ``finish_reason="stop"`` — the
+default OpenAI SDK / LangChain / LiteLLM streaming-tool-call pattern saw
+"the model never says anything".
+
+Root cause: ``StreamingPostProcessor._should_route_through_reasoning``
+tentatively re-routed any chunk whose head was a strict prefix of
+``<think>`` into the reasoning lane (R8-M2 safety net for SSE-split
+``<think>`` tags). With ``enable_thinking=False`` and an in-flight
+``<tool_call>`` envelope, the next ``<`` byte (the opener of an inner
+``<function=...>`` / ``<parameter=...>`` tag) matched ``<`` as a strict
+prefix of ``<think>``, was eaten into the reasoning lane, and never
+reached the tool parser's ``tool_accumulated_text``. The assembled body
+read ``<tool_call>\nfunction=...\n<parameter=...`` — outer ``<function=``
+corrupted, Nemotron regex failed, ``has_incomplete`` stayed True until
+end-of-stream, and the stream finished with ``finish_reason="stop"``.
+
+Fix: when the tool parser is mid-block on an unclosed
+``<tool_call>``-style envelope, skip the split-prefix ``<think>``
+rescue. The tool parser owns its own held-back machinery
+(``hermes._safe_content_prefix``) so the ``<`` lands in the tool parser
+and is correctly assembled with the rest of the inner tag.
+
+Secondary fix: ``tool_choice="required"`` (single tool) and
+``tool_choice={"type":"function",...}`` inject a JSON-shape
+``forced_assistant_prefix`` (``<tool_call>\n{"name":..., "arguments": ``)
+that misaligns with qwen3-family Nemotron-native output and produces a
+hybrid wire shape neither parser branch can recover. The non-stream
+chat route falls back to ``_synthesize_forced_tool_call`` for parity
+with channel-routed paths; the streaming route now does the same so
+``stream=true`` clients see the OpenAI tool_call-guaranteed contract
+honored on both surfaces.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from vllm_mlx.service.postprocessor import StreamingPostProcessor
+
+
+def _make_cfg(**overrides):
+    cfg = MagicMock()
+    cfg.engine = None
+    cfg.reasoning_parser = None
+    cfg.reasoning_parser_name = None
+    cfg.enable_auto_tool_choice = False
+    cfg.tool_call_parser = None
+    cfg.tool_parser_instance = None
+    for k, v in overrides.items():
+        setattr(cfg, k, v)
+    return cfg
+
+
+def _make_output(text: str = "", finished: bool = False):
+    out = MagicMock()
+    out.new_text = text
+    out.finished = finished
+    out.channel = None
+    out.finish_reason = "stop" if finished else None
+    out.prompt_tokens = 10
+    out.completion_tokens = 5
+    out.tokens = []
+    out.logprobs = None
+    out.tool_calls = None
+    return out
+
+
+def _drive(pp: StreamingPostProcessor, deltas: list[str]) -> dict:
+    """Drive deltas through the postprocessor and return the SSE-level
+    reasoning / content / tool_calls aggregate."""
+    all_events = []
+    for i, d in enumerate(deltas):
+        finished = i == len(deltas) - 1
+        all_events.extend(pp.process_chunk(_make_output(d, finished=finished)))
+    reasoning = "".join(
+        getattr(e, "reasoning", "") or "" for e in all_events if e.type == "reasoning"
+    )
+    content = "".join(
+        getattr(e, "content", "") or ""
+        for e in all_events
+        if e.type in ("content", "finish")
+    )
+    tool_calls: list = []
+    for e in all_events:
+        if e.type == "tool_call" and e.tool_calls:
+            tool_calls.extend(e.tool_calls)
+    return {
+        "reasoning": reasoning,
+        "content": content,
+        "tool_calls": tool_calls,
+        "events": all_events,
+    }
+
+
+def _pp(enable_thinking=False):
+    cfg = _make_cfg(
+        reasoning_parser_name="qwen3",
+        enable_auto_tool_choice=True,
+        tool_call_parser="hermes",
+    )
+    pp = StreamingPostProcessor(
+        cfg, tools_requested=True, enable_thinking=enable_thinking
+    )
+    pp.reset()
+    return pp
+
+
+# =====================================================================
+# Primary repro — auto + Nemotron-shape envelope (no forced_prefix)
+# =====================================================================
+
+
+class TestNemotronShapeEnvelopeReachesParser:
+    """The bug-#447 wire shape: qwen3.5-4b under ``enable_thinking=False``
+    + ``tool_choice="auto"`` streams a Nemotron-shape envelope. Each
+    inner ``<`` (of ``<function=`` / ``<parameter=``) used to be eaten
+    by the reasoning-lane split-prefix rescue. After the fix the
+    envelope reaches the tool parser intact and the structured call
+    surfaces on ``delta.tool_calls``."""
+
+    def test_full_nemotron_envelope_emits_tool_call(self):
+        """Exact chunk sequence from the live qwen3.5-4b-4bit repro
+        (BatchedEngine emits one tokenizer-token per delta)."""
+        pp = _pp(enable_thinking=False)
+        result = _drive(
+            pp,
+            [
+                "<tool_call>",
+                "\n",
+                "<",
+                "function",
+                "=get",
+                "_weather",
+                ">",
+                "\n",
+                "<",
+                "parameter",
+                "=",
+                "location",
+                ">",
+                "\n",
+                "SF",
+                "\n",
+                "</",
+                "parameter",
+                ">",
+                "\n",
+                "</",
+                "function",
+                ">",
+                "\n",
+                "</tool_call>",
+            ],
+        )
+        assert len(result["tool_calls"]) == 1
+        tc = result["tool_calls"][0]
+        assert tc["function"]["name"] == "get_weather"
+        # arguments JSON encodes the recovered parameter dict.
+        assert "location" in tc["function"]["arguments"]
+        assert "SF" in tc["function"]["arguments"]
+        # The wrapper bytes must NOT have leaked into content or
+        # reasoning channels.
+        assert "<tool_call>" not in result["content"]
+        assert "<function=" not in result["content"]
+        assert "<parameter=" not in result["content"]
+        assert "<tool_call>" not in result["reasoning"]
+
+
+# =====================================================================
+# Regression guards — pre-existing happy paths
+# =====================================================================
+
+
+class TestPreFixHappyPathsPreserved:
+    def test_explicit_think_wrapper_still_routed_to_reasoning(self):
+        """The R8-M2 explicit-wrapper rescue must STILL fire when no
+        tool envelope is in flight."""
+        pp = _pp(enable_thinking=False)
+        result = _drive(
+            pp,
+            [
+                "<think>",
+                "I will call get_weather.",
+                "</think>",
+                '<tool_call>{"name":"get_weather","arguments":{"location":"NYC"}}</tool_call>',
+            ],
+        )
+        assert "I will call" in result["reasoning"]
+        assert "<think>" not in result["content"]
+        # The JSON-shape tool_call still extracts.
+        assert len(result["tool_calls"]) == 1
+        assert result["tool_calls"][0]["function"]["name"] == "get_weather"
+
+    def test_split_think_tag_no_leak_still_works(self):
+        """The SSE-split ``<th`` + ``ink>`` opener case must still
+        route correctly when there is no preceding tool envelope —
+        the gate only skips the split-prefix rescue when an envelope
+        is in flight."""
+        pp = _pp(enable_thinking=False)
+        result = _drive(
+            pp,
+            [
+                "<th",
+                "ink>",
+                "thinking step one.",
+                "</think>",
+                '<tool_call>{"name":"foo","arguments":{}}</tool_call>',
+            ],
+        )
+        assert "thinking step one" in result["reasoning"]
+        assert "<th" not in result["content"]
+        assert "ink>" not in result["content"]
+
+    def test_plain_prose_with_lt_byte_unchanged(self):
+        """A plain-text answer with a bare ``<`` byte must continue to
+        flow through ``_process_standard`` unchanged (no envelope ⇒
+        no in-flight gate)."""
+        pp = _pp(enable_thinking=False)
+        result = _drive(pp, ["The answer is ", "x < y, ", "always."])
+        assert "x < y" in result["content"]
+        assert result["reasoning"] == ""
+
+
+# =====================================================================
+# Direct unit-level coverage for the new helper
+# =====================================================================
+
+
+class TestToolEnvelopeInFlightHelper:
+    def test_empty_buffer_returns_false(self):
+        pp = _pp(enable_thinking=False)
+        assert pp._tool_envelope_in_flight() is False
+
+    def test_open_envelope_returns_true(self):
+        pp = _pp(enable_thinking=False)
+        pp.tool_accumulated_text = "<tool_call>\n{"
+        assert pp._tool_envelope_in_flight() is True
+
+    def test_closed_envelope_returns_false(self):
+        pp = _pp(enable_thinking=False)
+        pp.tool_accumulated_text = (
+            '<tool_call>{"name":"foo","arguments":{}}</tool_call>'
+        )
+        assert pp._tool_envelope_in_flight() is False
+
+    def test_minimax_envelope_in_flight(self):
+        pp = _pp(enable_thinking=False)
+        pp.tool_accumulated_text = '<minimax:tool_call><invoke name="x">'
+        assert pp._tool_envelope_in_flight() is True

--- a/tests/test_447_stream_tool_choice_auto.py
+++ b/tests/test_447_stream_tool_choice_auto.py
@@ -223,9 +223,7 @@ class TestNemotronShapeEnvelopeReachesParser:
         # ``finished=True`` instead, which is a different shape.
         events = list(pp.process_chunk(_make_output("<", finished=False)))
         # Held — no events.
-        assert events == [], (
-            f"expected ambiguous head to be held, got {events!r}"
-        )
+        assert events == [], f"expected ambiguous head to be held, got {events!r}"
         # Now an empty finish-only chunk — the held ``<`` must flush.
         events += list(pp.process_chunk(_make_output("", finished=True)))
         # Find any content that reached the wire.

--- a/tests/test_447_stream_tool_choice_auto.py
+++ b/tests/test_447_stream_tool_choice_auto.py
@@ -172,6 +172,42 @@ class TestNemotronShapeEnvelopeReachesParser:
         assert len(result["tool_calls"]) == 1
         assert result["tool_calls"][0]["function"]["name"] == "get_weather"
 
+    def test_split_think_opener_still_routes_to_reasoning_with_tools(self):
+        """Codex r3 MAJOR (PR #948): the round-2 unconditional defer
+        of ``<`` / ``<t`` to the standard path regressed the R8-M2
+        split-``<think>`` rescue. After the round-3 hold-forward fix,
+        a stream that splits the ``<think>`` opener as ``<`` +
+        ``think>`` (or ``<t`` + ``hink>``) under
+        ``enable_thinking=False`` + tools enabled must STILL route
+        the wrapper to the reasoning lane and not leak into
+        ``delta.content``."""
+        for first, second in (("<", "think>"), ("<t", "hink>")):
+            pp = _pp(enable_thinking=False)
+            result = _drive(
+                pp,
+                [
+                    first,
+                    second,
+                    "abc",
+                    "</think>",
+                    "answer",
+                ],
+            )
+            # The opener and the reasoning body must not have leaked.
+            assert "<think>" not in result["content"], (
+                f"split={first!r}+{second!r}: <think> leaked into content: "
+                f"{result['content']!r}"
+            )
+            assert "abc" not in result["content"], (
+                f"split={first!r}+{second!r}: reasoning body 'abc' leaked: "
+                f"{result['content']!r}"
+            )
+            # And the reasoning lane must carry the body.
+            assert "abc" in result["reasoning"], (
+                f"split={first!r}+{second!r}: reasoning body missing from "
+                f"reasoning channel: {result['reasoning']!r}"
+            )
+
     def test_split_outer_opener_two_byte_prefix(self):
         """Same race, but the tokenizer chunks as ``<t`` + ``ool_call>``.
         ``<t`` is a strict prefix of BOTH ``<think>`` AND ``<tool_call>``

--- a/tests/test_447_stream_tool_choice_auto.py
+++ b/tests/test_447_stream_tool_choice_auto.py
@@ -339,12 +339,14 @@ def _drive_stream(engine, request) -> tuple[list[dict], str | None]:
     chunks: list[dict] = []
 
     async def _run():
-        gen = stream_chat_completion(engine, [{"role": "user", "content": "hi"}], request)
+        gen = stream_chat_completion(
+            engine, [{"role": "user", "content": "hi"}], request
+        )
         async for sse in gen:
             line = sse.strip()
             if not line.startswith("data: "):
                 continue
-            body = line[len("data: "):]
+            body = line[len("data: ") :]
             if body == "[DONE]":
                 break
             try:
@@ -414,7 +416,16 @@ class TestStreamSynthForcedToolChoice:
         # The model emits a hybrid wire shape (Nemotron closers after a
         # JSON prefix injection) that neither shape regex matches; the
         # parser never sets ``tool_calls_detected``.
-        deltas = ["0", "}", "\n", "</parameter>", "\n", "</function>", "\n", "</tool_call>"]
+        deltas = [
+            "0",
+            "}",
+            "\n",
+            "</parameter>",
+            "\n",
+            "</function>",
+            "\n",
+            "</tool_call>",
+        ]
         chunks, finish = _drive_stream(_FakeEngine(deltas), self._request("required"))
         # Look for a tool_calls delta in any chunk.
         emitted_tcs = []
@@ -455,7 +466,9 @@ class TestStreamSynthForcedToolChoice:
             deltas = ["plain ", "answer", "."]
             chunks, finish = _drive_stream(
                 _FakeEngine(deltas),
-                self._request({"type": "function", "function": {"name": "get_weather"}}),
+                self._request(
+                    {"type": "function", "function": {"name": "get_weather"}}
+                ),
             )
         finally:
             pp_mod.StreamingPostProcessor.reset = original_reset

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -3899,6 +3899,92 @@ async def stream_chat_completion(
                 finalize_content_parts.append(event.content)
         finalize_content = "".join(finalize_content_parts)
 
+        # #447 streaming-parity synthesis (2026-06-26). The non-stream
+        # chat path at chat.py:~3147 / ~3215 falls back to
+        # ``_synthesize_forced_tool_call`` when a forced ``tool_choice``
+        # (``"required"`` with a single tool, or
+        # ``{"type":"function","function":{"name":...}}``) finishes
+        # without the parser surfacing any tool_call — restoring the
+        # OpenAI "tool_call guaranteed" contract symmetry with
+        # channel-routed paths (harmony / gemma4). The streaming path
+        # previously had no equivalent: a qwen3-family model emitting
+        # the Nemotron-shape ``<tool_call><function=NAME>...</function>
+        # </tool_call>`` body under a hermes JSON-shape
+        # ``forced_assistant_prefix`` (``<tool_call>\n{"name":...,
+        # "arguments": ``) produces a hybrid wire shape that neither
+        # the streaming nor the cross-format extract path can parse,
+        # and ``stream=true`` finishes with zero ``tool_call`` deltas
+        # plus ``finish_reason="stop"``. The non-stream branch synth-
+        # recovers; the stream branch left clients with an empty turn
+        # (rapid-desktop#447).
+        #
+        # Gating identical to the non-stream synthesis: forced choice +
+        # the target function is the sole submitted tool (required +
+        # 1-tool collapses unambiguously) OR a named function is
+        # explicitly pinned AND the pinned name is in
+        # ``request.tools`` (defense-in-depth from PR #675 codex r1).
+        # The synth is only applied when NOTHING ELSE recovered a
+        # call — fallback_tool_calls empty AND the streaming path
+        # itself did not emit a tool_call (``_tool_calls_emitted_to
+        # _wire`` is the wire-truth counter).
+        if (
+            not fallback_tool_calls
+            and processor._tool_calls_emitted_to_wire == 0
+            and request.tools
+            and request.tool_choice is not None
+        ):
+            _synth_target: str | None = None
+            if (
+                isinstance(request.tool_choice, dict)
+                and request.tool_choice.get("type") == "function"
+            ):
+                _pinned = (request.tool_choice.get("function") or {}).get("name")
+                _submitted = {
+                    t.function.get("name")
+                    for t in request.tools
+                    if getattr(t, "type", None) == "function"
+                }
+                if _pinned and _pinned in _submitted:
+                    _synth_target = _pinned
+            elif (
+                request.tool_choice == "required" and len(request.tools) == 1
+            ):
+                _synth_target = request.tools[0].function.get("name")
+            if _synth_target:
+                _raw_text = (
+                    processor.tool_accumulated_text
+                    or processor.accumulated_text
+                    or ""
+                )
+                _synth_call = _synthesize_forced_tool_call(
+                    _synth_target, raw_text=_raw_text
+                )
+                # Convert the ``ToolCall`` pydantic object into the
+                # streaming-shape dict the terminal-merge path expects
+                # (``{"index","id","type","function":{"name","arguments"}}``)
+                # so it serializes identically to the parser-emitted
+                # deltas. ``index=0`` is the canonical singleton-call
+                # index used elsewhere in the streaming postprocessor.
+                fallback_tool_calls.append(
+                    {
+                        "index": 0,
+                        "id": _synth_call.id,
+                        "type": "function",
+                        "function": {
+                            "name": _synth_call.function.name,
+                            "arguments": _synth_call.function.arguments,
+                        },
+                    }
+                )
+                logger.info(
+                    "[SSE-FORCED-SYNTH-#447] forced tool_choice produced no "
+                    "tool_call deltas; synthesizing terminal call to %r "
+                    "(args recovered from raw text where possible) to honor "
+                    "the OpenAI tool_call-guaranteed contract — mirrors the "
+                    "non-stream synthesis path.",
+                    _synth_target,
+                )
+
         # Emit the terminal chunk. Three cases:
         #   (a) Streaming parser already emitted tool_calls during the
         #       loop → buffered_finish has finish_reason="tool_calls"

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -3963,15 +3963,11 @@ async def stream_chat_completion(
                 }
                 if _pinned and _pinned in _submitted:
                     _synth_target = _pinned
-            elif (
-                request.tool_choice == "required" and len(request.tools) == 1
-            ):
+            elif request.tool_choice == "required" and len(request.tools) == 1:
                 _synth_target = request.tools[0].function.get("name")
             if _synth_target:
                 _raw_text = (
-                    processor.tool_accumulated_text
-                    or processor.accumulated_text
-                    or ""
+                    processor.tool_accumulated_text or processor.accumulated_text or ""
                 )
                 _synth_call = _synthesize_forced_tool_call(
                     _synth_target, raw_text=_raw_text

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -3918,18 +3918,35 @@ async def stream_chat_completion(
         # recovers; the stream branch left clients with an empty turn
         # (rapid-desktop#447).
         #
-        # Gating identical to the non-stream synthesis: forced choice +
-        # the target function is the sole submitted tool (required +
-        # 1-tool collapses unambiguously) OR a named function is
-        # explicitly pinned AND the pinned name is in
-        # ``request.tools`` (defense-in-depth from PR #675 codex r1).
-        # The synth is only applied when NOTHING ELSE recovered a
-        # call — fallback_tool_calls empty AND the streaming path
-        # itself did not emit a tool_call (``_tool_calls_emitted_to
-        # _wire`` is the wire-truth counter).
+        # Gating identical to the non-stream synthesis at chat.py:~3197 /
+        # ~3207: forced choice + the target function is the sole
+        # submitted tool (``required`` + 1-tool collapses unambiguously)
+        # OR a named function is explicitly pinned AND the pinned name
+        # is in ``request.tools`` (defense-in-depth from PR #675 codex
+        # r1). The synth fires ONLY when:
+        #
+        # (a) No ``delta.tool_calls`` chunk reached the wire AND
+        #     ``finalize()`` recovered nothing — the wire-truth
+        #     ``_tool_calls_emitted_to_wire`` counter + the empty
+        #     ``fallback_tool_calls`` together pin the
+        #     "zero-tool-calls-shipped" state.
+        #
+        # (b) The PARSER also did not detect any tool-call shape at all
+        #     (``processor.tool_calls_detected is False``). Mirrors the
+        #     non-stream ``not _names`` predicate. Codex r1 MAJOR #1
+        #     (PR #948 review): without this guard, the synth would
+        #     silently REPLACE the model's intended call when the parser
+        #     saw a different tool that the forced-``tool_choice`` /
+        #     parallel-cap filter dropped (``tool_calls_detected=True``,
+        #     ``_tool_calls_emitted_to_wire=0``). The non-stream path
+        #     treats "model called a different tool than the pinned
+        #     target" as the ``_mismatched`` 422 case, NOT as a synth
+        #     trigger — it surfaces the conflict instead of fabricating
+        #     a call the model didn't make. Keep streaming aligned.
         if (
             not fallback_tool_calls
             and processor._tool_calls_emitted_to_wire == 0
+            and not processor.tool_calls_detected
             and request.tools
             and request.tool_choice is not None
         ):
@@ -3976,6 +3993,13 @@ async def stream_chat_completion(
                         },
                     }
                 )
+                # Codex r1 NIT #1 (PR #948): bump the wire-truth counter
+                # so the PR #859 "finish_reason=tool_calls ⇒ ≥1 tool_call
+                # delta on the wire" invariant holds — the terminal merge
+                # at chat.py:~4280 IS about to emit a ``delta.tool_calls``
+                # chunk for this synth, so the counter must reflect that
+                # for any downstream gate / log that reads it.
+                processor._tool_calls_emitted_to_wire += 1
                 logger.info(
                     "[SSE-FORCED-SYNTH-#447] forced tool_choice produced no "
                     "tool_call deltas; synthesizing terminal call to %r "

--- a/vllm_mlx/service/postprocessor.py
+++ b/vllm_mlx/service/postprocessor.py
@@ -1499,6 +1499,34 @@ class StreamingPostProcessor:
         if head and self._THINK_OPEN_TOKEN.startswith(head):
             if self._tool_envelope_in_flight():
                 return False
+            # #447 round-2 MAJOR (PR #948): when ``head`` is ALSO a strict
+            # prefix of one of the tool envelope openers, routing it to
+            # reasoning leaks the outer opener. Concrete failure on Qwen3
+            # + hermes when the tokenizer chunks the opener as ``<`` then
+            # ``tool_call>``: the bare ``<`` matches ``<think>`` prefix,
+            # gets held by the reasoning parser, and is released as plain
+            # ``delta.content`` once the next chunk (``tool_call>``) fails
+            # to complete the ``<think>`` tag. By that point the standard
+            # path no longer sees a leading ``<`` so the tool parser
+            # never accumulates the envelope, the assistant message ships
+            # ``tool_call>\n<function=...`` to the client, and downstream
+            # tool execution breaks.
+            #
+            # Fix: defer ambiguous prefixes (``<`` or ``<t`` — strict
+            # prefixes of BOTH ``<think>`` AND ``<tool_call>``/``<minimax:
+            # tool_call>``) to the standard path. The hermes tool parser's
+            # ``_safe_content_prefix`` (and equivalents on other tool
+            # parsers) hold back partial sentinels just like the
+            # reasoning parser does, so deferring is safe: the byte
+            # accumulates into ``tool_accumulated_text``, gets bound to
+            # the envelope on the next chunk, and the full ``<tool_call>``
+            # body reaches the parser intact. Unambiguous prefixes (``<th``
+            # / ``<thi`` / ``<thin`` / ``<think`` / ``<think>``) still
+            # route through reasoning as before — they share no prefix
+            # with any tool envelope opener.
+            for opener, _closer in self._TOOL_ENVELOPE_OPENERS:
+                if opener.startswith(head):
+                    return False
             return True
         return False
 

--- a/vllm_mlx/service/postprocessor.py
+++ b/vllm_mlx/service/postprocessor.py
@@ -373,6 +373,15 @@ class StreamingPostProcessor:
         # Both fields are no-ops when ``tools_requested`` is False.
         self._tool_prose_buffer: str = ""
         self._tool_prose_active: bool = False
+        # #447 round-3 (PR #948): 1-chunk hold-forward buffer for
+        # ambiguous routing heads (``<`` or ``<t`` — strict prefix of
+        # BOTH ``<think>`` AND ``<tool_call>``). Populated by
+        # ``process_chunk`` when ``enable_thinking is False`` and the
+        # head can't yet be disambiguated; prepended to the next chunk
+        # so the merged head routes unambiguously. Cleared by every
+        # successful flush + by ``reset()``. No-op when reasoning is
+        # disabled or thinking is on by default.
+        self._ambiguous_prefix_held: str = ""
         # Monotonic counter for structured tool-call indices across the
         # whole response. Each TOOL_CALL channel ``GenerationOutput`` may
         # carry a single structured call; if multiple chunks fire
@@ -1499,34 +1508,6 @@ class StreamingPostProcessor:
         if head and self._THINK_OPEN_TOKEN.startswith(head):
             if self._tool_envelope_in_flight():
                 return False
-            # #447 round-2 MAJOR (PR #948): when ``head`` is ALSO a strict
-            # prefix of one of the tool envelope openers, routing it to
-            # reasoning leaks the outer opener. Concrete failure on Qwen3
-            # + hermes when the tokenizer chunks the opener as ``<`` then
-            # ``tool_call>``: the bare ``<`` matches ``<think>`` prefix,
-            # gets held by the reasoning parser, and is released as plain
-            # ``delta.content`` once the next chunk (``tool_call>``) fails
-            # to complete the ``<think>`` tag. By that point the standard
-            # path no longer sees a leading ``<`` so the tool parser
-            # never accumulates the envelope, the assistant message ships
-            # ``tool_call>\n<function=...`` to the client, and downstream
-            # tool execution breaks.
-            #
-            # Fix: defer ambiguous prefixes (``<`` or ``<t`` — strict
-            # prefixes of BOTH ``<think>`` AND ``<tool_call>``/``<minimax:
-            # tool_call>``) to the standard path. The hermes tool parser's
-            # ``_safe_content_prefix`` (and equivalents on other tool
-            # parsers) hold back partial sentinels just like the
-            # reasoning parser does, so deferring is safe: the byte
-            # accumulates into ``tool_accumulated_text``, gets bound to
-            # the envelope on the next chunk, and the full ``<tool_call>``
-            # body reaches the parser intact. Unambiguous prefixes (``<th``
-            # / ``<thi`` / ``<thin`` / ``<think`` / ``<think>``) still
-            # route through reasoning as before — they share no prefix
-            # with any tool envelope opener.
-            for opener, _closer in self._TOOL_ENVELOPE_OPENERS:
-                if opener.startswith(head):
-                    return False
             return True
         return False
 
@@ -2305,6 +2286,10 @@ class StreamingPostProcessor:
         # doesn't ship the prior turn's buffered preamble bytes.
         self._tool_prose_buffer = ""
         self._tool_prose_active = False
+        # #447 round-3 (PR #948): clear the ambiguous-prefix hold-buffer
+        # so a re-used processor doesn't prepend the prior turn's held
+        # ``<`` / ``<t`` into the new stream's first delta.
+        self._ambiguous_prefix_held = ""
         self._think_prefix_sent = False
         self._json_preamble_stripped = False
         self._json_preamble_buffer = ""
@@ -2421,6 +2406,48 @@ class StreamingPostProcessor:
             if hasattr(output, "text"):
                 output.text = tail
             delta_text = tail
+
+        # #447 round-3 MAJOR (PR #948): ambiguous-prefix hold-forward.
+        # When ``enable_thinking is False`` AND a delta head reduces to
+        # ``<`` or ``<t`` (strict prefix of BOTH ``<think>`` AND
+        # ``<tool_call>``/``<minimax:tool_call>``), neither routing
+        # choice is safe — eager routing to reasoning leaks the outer
+        # opener when the next chunk completes ``<tool_call>`` (codex
+        # r2 reproducer), and eager routing to the standard path leaks
+        # ``<think>`` into ``delta.content`` when the next chunk
+        # completes ``<think>`` (codex r3 reproducer).
+        #
+        # Hold the ambiguous prefix for exactly one chunk, prepend it
+        # to the next delta, and re-evaluate. When the next chunk
+        # arrives, the merged head is unambiguous in one direction:
+        # ``<th...`` only matches ``<think>`` (reasoning lane);
+        # ``<to...`` / ``<m...`` only matches a tool envelope (standard
+        # lane). On the rare terminal-only chunk that carries the
+        # ambiguous head (``output.finished`` True), flush the buffer
+        # through the standard path so the wire envelope still closes.
+        # Skipped entirely when ``enable_thinking is not False`` —
+        # the default-route policy at the top of
+        # ``_should_route_through_reasoning`` already locks reasoning.
+        if self._ambiguous_prefix_held:
+            delta_text = self._ambiguous_prefix_held + delta_text
+            self._ambiguous_prefix_held = ""
+            output.new_text = delta_text
+            if hasattr(output, "text"):
+                output.text = delta_text
+        if (
+            self.enable_thinking is False
+            and self.reasoning_parser is not None
+            and not output.finished
+        ):
+            _probe_head = (self.accumulated_text + delta_text).lstrip()
+            if _probe_head and self._THINK_OPEN_TOKEN.startswith(_probe_head):
+                # Head is a strict prefix of ``<think>``. If it is
+                # ALSO a strict prefix of any tool envelope opener,
+                # the routing choice is ambiguous — hold and wait.
+                for _opener, _ in self._TOOL_ENVELOPE_OPENERS:
+                    if _opener.startswith(_probe_head):
+                        self._ambiguous_prefix_held = delta_text
+                        return []
 
         # Step 1: Separate content from reasoning
         if output.channel is not None:

--- a/vllm_mlx/service/postprocessor.py
+++ b/vllm_mlx/service/postprocessor.py
@@ -1472,8 +1472,71 @@ class StreamingPostProcessor:
         # arrived yet. Route this chunk through the reasoning parser
         # so a split-SSE tag doesn't pre-leak as content. Don't latch
         # — we'll re-evaluate next chunk once more bytes arrive.
+        #
+        # #447 (2026-06-26): suppress the tentative re-route when a
+        # tool-call envelope is already in flight (the tool parser is
+        # mid-block accumulating an unclosed ``<tool_call>`` body).
+        # Reproduction: ``enable_thinking=False`` + ``tool_choice="auto"``
+        # on hermes + Qwen3 streams the Nemotron-shape envelope
+        # ``<tool_call>\n<function=NAME>\n<parameter=K>V</parameter>\n
+        # </function>\n</tool_call>``. After the opening ``<tool_call>``
+        # chunk lands in the tool parser, the standalone ``<`` of the
+        # inner ``<function=`` tag matches the split-prefix branch (``<``
+        # is a strict prefix of ``<think>``), gets re-routed to the
+        # reasoning lane, and is held back by the reasoning parser's
+        # partial-tag withhold. The byte is then NEVER fed to the tool
+        # parser's ``tool_accumulated_text``, so the assembled body
+        # reads ``<tool_call>\nfunction=...\n<parameter=...`` — the
+        # outer ``<function=`` opener is corrupted, the Nemotron regex
+        # fails to match, and the whole envelope is suppressed as an
+        # in-flight tool block until end-of-stream finishes with a
+        # bare ``finish_reason="stop"`` and zero tool_calls. The
+        # tool-parser path has its own held-back machinery for partial
+        # sentinels (``hermes._safe_content_prefix``) so deferring
+        # routing here is safe — the ``<`` lands in the tool parser,
+        # is held until enough bytes arrive to commit, and the
+        # downstream tool-envelope detection completes normally.
         if head and self._THINK_OPEN_TOKEN.startswith(head):
+            if self._tool_envelope_in_flight():
+                return False
             return True
+        return False
+
+    # Common ``<tool_call>``-style envelope openers shared across the
+    # text-parser families (hermes / qwen3_xml / glm47 / minimax / nemotron).
+    # Used by ``_tool_envelope_in_flight`` to detect that the tool parser
+    # is mid-accumulation so the split-prefix ``<think>`` rescue
+    # (``_should_route_through_reasoning``) does not eat the next ``<``
+    # byte into the reasoning lane (#447).
+    _TOOL_ENVELOPE_OPENERS: tuple[tuple[str, str], ...] = (
+        ("<tool_call>", "</tool_call>"),
+        ("<minimax:tool_call>", "</minimax:tool_call>"),
+    )
+
+    def _tool_envelope_in_flight(self) -> bool:
+        """Return True iff the tool parser is mid-block on an unclosed
+        ``<tool_call>``-style envelope.
+
+        Consulted by the ``_should_route_through_reasoning`` split-prefix
+        branch to decide whether a bare ``<`` (ambiguous between the
+        start of ``<think>`` and the start of an inner Nemotron-shape
+        ``<function=...>`` / ``<parameter=...>`` tag) should be allowed
+        to re-route into the reasoning lane. The default-true behaviour
+        is correct for plain prose; the false override here only fires
+        once the tool parser has already accepted an unclosed envelope
+        opener and the next ``<`` is overwhelmingly an inner tag (see
+        comment at the call site for the failure mode).
+
+        Cheap O(envelope_count) scan over ``tool_accumulated_text``;
+        ``_TOOL_ENVELOPE_OPENERS`` keeps the openers/closers paired so
+        a future wire format can be added in one place.
+        """
+        buf = self.tool_accumulated_text
+        if not buf:
+            return False
+        for opener, closer in self._TOOL_ENVELOPE_OPENERS:
+            if buf.count(opener) > buf.count(closer):
+                return True
         return False
 
     def _consume_reasoning_budget(self, reasoning_text: str) -> tuple[str, str]:

--- a/vllm_mlx/service/postprocessor.py
+++ b/vllm_mlx/service/postprocessor.py
@@ -2363,6 +2363,36 @@ class StreamingPostProcessor:
         if not delta_text:
             # Handle finish-only chunks
             if output.finished:
+                # #447 round-4 NIT (PR #948): if a stream emitted an
+                # ambiguous head (``<`` / ``<t``) on a non-finished
+                # chunk and then an EMPTY finish-only chunk, the held
+                # byte was previously dropped because this early
+                # ``not delta_text`` branch ran before the hold-replay
+                # logic in the main path. Without a disambiguating
+                # second chunk we can't resolve to reasoning or tool
+                # routing — flush the held bytes as plain content on
+                # the FINISH event itself so the wire still receives
+                # the model's literal tail. ``_make_finish_event``
+                # supports an optional ``content`` payload; merging
+                # here keeps the terminal chunk count unchanged.
+                if self._ambiguous_prefix_held:
+                    flush = self._ambiguous_prefix_held
+                    self._ambiguous_prefix_held = ""
+                    finish_event = self._make_finish_event(output)
+                    # Prepend the held bytes to whatever content the
+                    # finish event already carries (usually empty) so
+                    # downstream finalize() merges keep working.
+                    existing = finish_event.content or ""
+                    finish_event = StreamEvent(
+                        type=finish_event.type,
+                        content=flush + existing,
+                        reasoning=finish_event.reasoning,
+                        tool_calls=finish_event.tool_calls,
+                        finish_reason=finish_event.finish_reason,
+                        tool_calls_detected=finish_event.tool_calls_detected,
+                        metadata=finish_event.metadata,
+                    )
+                    return [finish_event]
                 return [self._make_finish_event(output)]
             return []
 


### PR DESCRIPTION
## Summary

Fixes [rapid-desktop#447](https://github.com/machinefi/rapid-desktop/issues/447): a streaming chat completion with `tool_choice=\"auto\"` (or `\"required\"`) on hermes parser + qwen3 family finishes with **zero `delta.tool_calls` and `finish_reason=\"stop\"`** — the default OpenAI SDK / LangChain / LiteLLM streaming-tool-call shape. Non-streaming + same body works.

## Root cause

Two contributing bugs surfaced through the same observable symptom:

### 1. Reasoning-lane split-prefix rescue eats inner `<` bytes

`StreamingPostProcessor._should_route_through_reasoning` tentatively re-routes any chunk whose head is a strict prefix of `<think>` into the reasoning lane (R8-M2 safety net for SSE-split `<think>` tags). With `enable_thinking=False` (the auto-disable injected when tools are present and the client did not pin a thinking preference) AND a `<tool_call>` envelope already in flight, the next bare `<` byte — the opener of an inner Nemotron `<function=…>` / `<parameter=…>` tag — matches as a strict prefix of `<think>`, gets eaten into the reasoning lane, and never reaches the tool parser's `tool_accumulated_text`. The assembled body reads `<tool_call>\nfunction=…\n<parameter=…` — outer `<function=` corrupted, the Nemotron regex (`<tool_call>\s*<function=…`) fails to match, `_has_incomplete_structured_block` stays True until end-of-stream, and the stream finishes with `finish_reason=\"stop\"`.

### 2. Forced `tool_choice` streaming path lacked the non-stream synthesis fallback

`tool_choice=\"required\"` (single tool) and `tool_choice={\"type\":\"function\",…}` inject a JSON-shape `forced_assistant_prefix` (`<tool_call>\n{\"name\":…, \"arguments\": `). On qwen3-family models trained to emit Nemotron-shape natively, the prefix injection produces a hybrid wire body (`<tool_call>\n{\"name\":…, \"arguments\": 0}\n</parameter>\n</function>\n</tool_call>`) that neither the streaming nor the cross-format extract path can parse. The non-stream chat route falls back to `_synthesize_forced_tool_call` (returns the target with `arguments=\"{}\"`) to honor OpenAI's tool_call-guaranteed contract; the streaming route had no equivalent.

## Repro

```bash
python3.12 -m vllm_mlx.cli serve --port 18504 --host 127.0.0.1 qwen3.5-4b-4bit
# in another shell:
curl -s http://127.0.0.1:18504/v1/chat/completions \
  -H 'Content-Type: application/json' \
  -d '{\"model\":\"qwen3.5-4b-4bit\",\"messages\":[{\"role\":\"user\",\"content\":\"What is the weather in SF? Use the get_weather tool.\"}],\"tools\":[{\"type\":\"function\",\"function\":{\"name\":\"get_weather\",\"description\":\"Get current weather for a location\",\"parameters\":{\"type\":\"object\",\"properties\":{\"location\":{\"type\":\"string\"}},\"required\":[\"location\"]}}}],\"tool_choice\":\"auto\",\"max_tokens\":150,\"stream\":true,\"chat_template_kwargs\":{\"enable_thinking\":false}}'
```

Pre-fix: 2 SSE chunks (role + finish=stop) + DONE. Post-fix: tool_calls delta + finish=tool_calls.

## Fix summary

| File | Change |
|---|---|
| `vllm_mlx/service/postprocessor.py` | New `_tool_envelope_in_flight()` helper; split-prefix rescue defers to the standard path when an unclosed `<tool_call>` envelope is in the tool parser's accumulator. |
| `vllm_mlx/routes/chat.py` | Streaming `stream_chat_completion` synthesizes a fallback tool_call when forced `tool_choice` (`\"required\"` + 1 tool, or named function) finished with zero `delta.tool_calls` and `finalize()` recovered nothing — mirrors the non-stream synthesis path. |
| `tests/test_447_stream_tool_choice_auto.py` | New: primary repro of the Nemotron envelope reaching the parser, regression guards for the R8-M2 happy paths, unit coverage for `_tool_envelope_in_flight()`. |

## Verified matrix (live curl on bundled qwen3.5-4b-4bit + hermes + thinking-off)

| tool_choice | stream=false | stream=true (pre-fix) | stream=true (post-fix) |
|---|---|---|---|
| `\"auto\"` | OK — real call | **BROKEN** — 0 deltas + stop | OK — real call `{\"location\":\"SF\"}` |
| `\"required\"` | OK — synth `{}` | **BROKEN** — 0 deltas + stop | OK — synth `{}` (non-stream parity) |
| explicit `{type:function, …}` | OK — synth `{}` | **BROKEN** — 0 deltas + stop | OK — synth `{}` (non-stream parity) |
| `\"none\"` | OK | OK | OK (unchanged) |

## Test plan

- [x] `tests/test_447_stream_tool_choice_auto.py` — 8 new tests, all pass
- [x] `tests/test_streaming_reasoning_split_r8c.py` — all 18 R8-M2 / R10-C7 tests still pass (regression guard)
- [x] `python3.12 -m pytest tests/ -k \"tool_choice or stream\" --ignore=tests/integrations -x` → 1559 passed, 2 xfailed
- [x] `python3.12 -m pytest tests/test_postprocessor.py tests/test_chat_route_*.py -x` → 190 passed
- [x] Live curl matrix on local qwen3.5-4b-4bit (all 4 tool_choice forms × stream/non-stream)

🤖 Generated with [Claude Code](https://claude.com/claude-code)