### PR TITLE
feat(aliases): 9 community-curated quant variants for Qwen3.5/3.6 family

### DIFF
--- a/tests/test_model_profiles_ssot.py
+++ b/tests/test_model_profiles_ssot.py
@@ -335,7 +335,7 @@ def test_qwen35_family_split_dense_vs_moe_hybrid_flag() -> None:
     """
     profiles = list_profiles()
     family = {a: p for a, p in profiles.items() if a.startswith("qwen3.5-")}
-    assert len(family) == 10
+    assert len(family) == 15
     # supports_spec_decode is uniformly False across the entire
     # qwen3.5-* family — that contract is unchanged.
     assert {p.supports_spec_decode for p in family.values()} == {False}, (

--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -18,6 +18,15 @@
     "supports_spec_decode": false,
     "pflash_tier": "verified"
   },
+  "qwen3.5-4b-6bit": {
+    "hf_path": "mlx-community/Qwen3.5-4B-6bit",
+    "tool_call_parser": "hermes",
+    "reasoning_parser": "qwen3",
+    "is_hybrid": false,
+    "is_hybrid_explicit": true,
+    "is_moe": false,
+    "supports_spec_decode": false
+  },
   "qwen3.5-9b-4bit": {
     "hf_path": "mlx-community/Qwen3.5-9B-4bit",
     "tool_call_parser": "hermes",
@@ -37,6 +46,15 @@
     "supports_spec_decode": false,
     "supports_dflash": false,
     "pflash_tier": "verified"
+  },
+  "qwen3.5-9b-6bit": {
+    "hf_path": "mlx-community/Qwen3.5-9B-6bit",
+    "tool_call_parser": "hermes",
+    "reasoning_parser": "qwen3",
+    "is_hybrid": false,
+    "is_hybrid_explicit": true,
+    "is_moe": false,
+    "supports_spec_decode": false
   },
   "qwen3.5-27b-4bit": {
     "hf_path": "mlx-community/Qwen3.5-27B-4bit",
@@ -65,6 +83,14 @@
     "is_moe": true,
     "pflash_tier": "verified"
   },
+  "qwen3.5-35b-6bit": {
+    "hf_path": "mlx-community/Qwen3.5-35B-A3B-6bit",
+    "tool_call_parser": "hermes",
+    "reasoning_parser": "qwen3",
+    "is_hybrid": true,
+    "supports_spec_decode": false,
+    "is_moe": true
+  },
   "qwen3.5-122b-mxfp4": {
     "hf_path": "nightmedia/Qwen3.5-122B-A10B-Text-mxfp4-mlx",
     "tool_call_parser": "hermes",
@@ -82,6 +108,14 @@
     "supports_spec_decode": false,
     "is_moe": true,
     "pflash_tier": "verified"
+  },
+  "qwen3.5-122b-6bit": {
+    "hf_path": "mlx-community/Qwen3.5-122B-A10B-6bit",
+    "tool_call_parser": "hermes",
+    "reasoning_parser": "qwen3",
+    "is_hybrid": true,
+    "supports_spec_decode": false,
+    "is_moe": true
   },
   "tmax-9b": {
     "hf_path": "mlx-community/Tmax-9B-MLX-4bit",
@@ -158,6 +192,15 @@
     "dflash_draft_model": "z-lab/Qwen3.5-27B-DFlash",
     "pflash_tier": "verified"
   },
+  "qwen3.5-27b-6bit": {
+    "hf_path": "mlx-community/Qwen3.5-27B-6bit",
+    "tool_call_parser": "hermes",
+    "reasoning_parser": "qwen3",
+    "is_hybrid": false,
+    "is_hybrid_explicit": true,
+    "is_moe": false,
+    "supports_spec_decode": false
+  },
   "qwen3.6-27b-4bit": {
     "hf_path": "mlx-community/Qwen3.6-27B-4bit",
     "tool_call_parser": "qwen3_coder_xml",
@@ -177,6 +220,14 @@
     "supports_dflash": false,
     "pflash_tier": "verified"
   },
+  "qwen3.6-27b-6bit": {
+    "hf_path": "lmstudio-community/Qwen3.6-27B-MLX-6bit",
+    "tool_call_parser": "qwen3_coder_xml",
+    "reasoning_parser": "qwen3",
+    "is_hybrid": false,
+    "is_hybrid_explicit": true,
+    "supports_spec_decode": false
+  },
   "qwen3.6-27b-ud": {
     "hf_path": "unsloth/Qwen3.6-27B-UD-MLX-4bit",
     "tool_call_parser": "qwen3_coder_xml",
@@ -185,6 +236,14 @@
     "is_hybrid_explicit": true,
     "supports_spec_decode": false,
     "pflash_tier": "verified"
+  },
+  "qwen3.6-27b-mxfp4-ud": {
+    "hf_path": "unsloth/Qwen3.6-27B-UD-MLX-MXFP4",
+    "tool_call_parser": "qwen3_coder_xml",
+    "reasoning_parser": "qwen3",
+    "is_hybrid": false,
+    "is_hybrid_explicit": true,
+    "supports_spec_decode": false
   },
   "qwen3.6-35b-4bit": {
     "hf_path": "mlx-community/Qwen3.6-35B-A3B-4bit",
@@ -230,6 +289,22 @@
     "supports_spec_decode": false,
     "is_moe": true,
     "pflash_tier": "verified"
+  },
+  "qwen3.6-35b-mxfp4": {
+    "hf_path": "mlx-community/Qwen3.6-35B-A3B-mxfp4",
+    "tool_call_parser": "qwen3_coder_xml",
+    "reasoning_parser": "qwen3",
+    "is_hybrid": true,
+    "supports_spec_decode": false,
+    "is_moe": true
+  },
+  "qwen3.6-35b-nvfp4": {
+    "hf_path": "mlx-community/Qwen3.6-35B-A3B-nvfp4",
+    "tool_call_parser": "qwen3_coder_xml",
+    "reasoning_parser": "qwen3",
+    "is_hybrid": true,
+    "supports_spec_decode": false,
+    "is_moe": true
   },
   "deepseek-v4-flash-2bit": {
     "hf_path": "mlx-community/DeepSeek-V4-Flash-2bit-DQ",

--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -237,14 +237,6 @@
     "supports_spec_decode": false,
     "pflash_tier": "verified"
   },
-  "qwen3.6-27b-mxfp4-ud": {
-    "hf_path": "unsloth/Qwen3.6-27B-UD-MLX-MXFP4",
-    "tool_call_parser": "qwen3_coder_xml",
-    "reasoning_parser": "qwen3",
-    "is_hybrid": false,
-    "is_hybrid_explicit": true,
-    "supports_spec_decode": false
-  },
   "qwen3.6-35b-4bit": {
     "hf_path": "mlx-community/Qwen3.6-35B-A3B-4bit",
     "tool_call_parser": "qwen3_coder_xml",

--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -226,6 +226,7 @@
     "reasoning_parser": "qwen3",
     "is_hybrid": false,
     "is_hybrid_explicit": true,
+    "is_moe": false,
     "supports_spec_decode": false
   },
   "qwen3.6-27b-ud": {


### PR DESCRIPTION
## Summary

Adds 8 community-curated quant aliases (6-bit dense + mxfp4/nvfp4) for the Qwen3.5/3.6 hero families. Pure alias additions; no engine code touched besides one test-count adjustment.

| Alias | HF path | Notes |
|---|---|---|
| `qwen3.5-4b-6bit` | `mlx-community/Qwen3.5-4B-6bit` | Pareto sweet spot (PPL knee per spike data) |
| `qwen3.5-9b-6bit` | `mlx-community/Qwen3.5-9B-6bit` | |
| `qwen3.5-27b-6bit` | `mlx-community/Qwen3.5-27B-6bit` | |
| `qwen3.5-35b-6bit` | `mlx-community/Qwen3.5-35B-A3B-6bit` | MoE |
| `qwen3.5-122b-6bit` | `mlx-community/Qwen3.5-122B-A10B-6bit` | MoE |
| `qwen3.6-27b-6bit` | `lmstudio-community/Qwen3.6-27B-MLX-6bit` | **874K downloads — single largest community gap** |
| `qwen3.6-35b-mxfp4` | `mlx-community/Qwen3.6-35B-A3B-mxfp4` | MoE |
| `qwen3.6-35b-nvfp4` | `mlx-community/Qwen3.6-35B-A3B-nvfp4` | MoE |

### Removed: qwen3.6-27b-mxfp4-ud (dropped to keep PR pure)

The 9th candidate (`unsloth/Qwen3.6-27B-UD-MLX-MXFP4`, 34K dl) was dropped from this PR. It's dense (is_moe=false), but `test_all_mxfp4_aliases_carry_is_moe_metadata` enforces a blanket "all mxfp4 = MoE" rule so the mlx#3402 guardrail will fire. Loosening that guardrail to allowlist dense mxfp4 is a defensible but separate change; will follow up in a dedicated PR.

### Rationale

Comes out of the SpinQuant/QuaRot evaluation spike on `spike/spinquant-eval`. The honest takeaway from that work was: rather than build SOTA rotation-based quant in-engine (KILLed on three independent reasons — see spike `REPORT.md`), curate the community variants that already deliver the Pareto wins users care about. Concretely:

- The spike's own PPL data confirmed 6-bit dense is the quality knee for Qwen3.5-4B (4bit→6bit improves 0.115 PPL; 6bit→8bit is noise at 0.004). Family fill-out below.
- A separate scout of HuggingFace community variants found `lmstudio-community/Qwen3.6-27B-MLX-6bit` at 874K downloads vs our 1.4K aliased mlx-community equivalent — a 600× community-trust gap we were missing.
- Same scout flagged mxfp4 as the rising "smallest acceptable" format for Qwen3.6 35b A3B MoE (~3.3K dl each on mxfp4/nvfp4).

### Tier

Schema-clean (closed-key fields preserved); no `pflash_tier` set on the new entries. They ship as **candidate aliases**, not as hero `verified` aliases — those promotions require an actual probe run (download + boot + measured baseline). Operator can promote individually after probe. The corresponding rapidmlx.com website + manifest update will land as a separate PR in that repo (pre-arranged direct-merge scope).

## Test plan

- [x] `aliases.json` JSON-loads cleanly
- [x] 289 alias-related tests pass (`test_model_profiles_ssot`, `test_mxfp4_moe_guardrail`, `test_request_time_alias_resolution`, `test_model_auto_config`)
- [x] `git diff --stat` shows only +66 net lines: `vllm_mlx/aliases.json` (+67/-8) + `tests/test_model_profiles_ssot.py` (+1/-1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)