### PR TITLE
fix(spec_decode/mtp): port quantize + load_weights from qwen3_next_mtp; bench 1.0-1.15x on 9B

### DIFF
--- a/bench/bench_spec_decode_mtp.py
+++ b/bench/bench_spec_decode_mtp.py
@@ -210,10 +210,14 @@ def _parse_args() -> argparse.Namespace:
 # Map from common base aliases / HF paths to their matching MTP sidecar.
 # The sidecar repo holds the MTP head only (no embed_tokens, no
 # backbone layers) — see ``mlx-community/Qwen3.5-9B-MTP-4bit`` README.
+# Keys are normalized to lowercase; ``_resolve_mtp_sidecar`` lowers
+# the incoming alias before lookup so case variants
+# (``Qwen3.5-9B-4bit`` vs ``qwen3.5-9b-4bit`` vs full
+# ``mlx-community/Qwen3.5-9B-4bit``) all hit the same default.
 _DEFAULT_MTP_SIDECAR: dict[str, str] = {
     "qwen3.5-9b-4bit": "mlx-community/Qwen3.5-9B-MTP-4bit",
-    "mlx-community/Qwen3.5-9B-4bit": "mlx-community/Qwen3.5-9B-MTP-4bit",
-    "mlx-community/Qwen3.5-9B-MLX-4bit": "mlx-community/Qwen3.5-9B-MTP-4bit",
+    "mlx-community/qwen3.5-9b-4bit": "mlx-community/Qwen3.5-9B-MTP-4bit",
+    "mlx-community/qwen3.5-9b-mlx-4bit": "mlx-community/Qwen3.5-9B-MTP-4bit",
 }
 
 
@@ -221,13 +225,15 @@ def _resolve_mtp_sidecar(model_alias: str, explicit: str | None) -> str | None:
     """Pick the MTP sidecar for ``model_alias``.
 
     Explicit ``--mtp-sidecar`` always wins. Otherwise look up the
-    alias in ``_DEFAULT_MTP_SIDECAR``. Return ``None`` if no default
-    is known — the inject will then fall back to a no-op load and
-    log a warning.
+    alias in ``_DEFAULT_MTP_SIDECAR`` after lowercasing — codex
+    flagged on PR #954 that without normalization,
+    ``Qwen3.5-9B-4bit`` (case variant of the dict key) missed the
+    documented default. Return ``None`` if no default is known —
+    the inject will then fall back to a no-op load and log a warning.
     """
     if explicit is not None:
         return explicit
-    return _DEFAULT_MTP_SIDECAR.get(model_alias)
+    return _DEFAULT_MTP_SIDECAR.get(model_alias.lower())
 
 
 def _planned_matrix(args: argparse.Namespace) -> dict[str, Any]:

--- a/bench/bench_spec_decode_mtp.py
+++ b/bench/bench_spec_decode_mtp.py
@@ -181,7 +181,53 @@ def _parse_args() -> argparse.Namespace:
             "cost of reduced workload coverage."
         ),
     )
+    parser.add_argument(
+        "--mtp-sidecar",
+        default=None,
+        help=(
+            "MTP head sidecar (HF repo id or local path). The mlx-lm "
+            "0.31.3 ``qwen3_5.py::sanitize`` unconditionally strips "
+            "``mtp.*`` weights during the main load, so MTP weights "
+            "must be loaded from a separate sidecar safetensors blob "
+            "after ``mlx_lm.load(...)`` completes. Default: auto-pick "
+            "based on the base model alias (Qwen3.5-9B-4bit → "
+            "mlx-community/Qwen3.5-9B-MTP-4bit). Pass an explicit "
+            "value to override."
+        ),
+    )
+    parser.add_argument(
+        "--mtp-only",
+        action="store_true",
+        help=(
+            "Skip the baseline (--spec-decode none) condition and run "
+            "only the MTP condition. Useful when comparing against a "
+            "previously-captured baseline number."
+        ),
+    )
     return parser.parse_args()
+
+
+# Map from common base aliases / HF paths to their matching MTP sidecar.
+# The sidecar repo holds the MTP head only (no embed_tokens, no
+# backbone layers) — see ``mlx-community/Qwen3.5-9B-MTP-4bit`` README.
+_DEFAULT_MTP_SIDECAR: dict[str, str] = {
+    "qwen3.5-9b-4bit": "mlx-community/Qwen3.5-9B-MTP-4bit",
+    "mlx-community/Qwen3.5-9B-4bit": "mlx-community/Qwen3.5-9B-MTP-4bit",
+    "mlx-community/Qwen3.5-9B-MLX-4bit": "mlx-community/Qwen3.5-9B-MTP-4bit",
+}
+
+
+def _resolve_mtp_sidecar(model_alias: str, explicit: str | None) -> str | None:
+    """Pick the MTP sidecar for ``model_alias``.
+
+    Explicit ``--mtp-sidecar`` always wins. Otherwise look up the
+    alias in ``_DEFAULT_MTP_SIDECAR``. Return ``None`` if no default
+    is known — the inject will then fall back to a no-op load and
+    log a warning.
+    """
+    if explicit is not None:
+        return explicit
+    return _DEFAULT_MTP_SIDECAR.get(model_alias)
 
 
 def _planned_matrix(args: argparse.Namespace) -> dict[str, Any]:
@@ -208,6 +254,7 @@ def _run_once(
     prompt: str,
     max_tokens: int,
     temp: float,
+    mtp_sidecar: str | None = None,
 ) -> RunResult:
     """Run one generation under the requested condition.
 
@@ -235,13 +282,24 @@ def _run_once(
             validate_mtp_support,
         )
 
-        if not inject_mtp_support(model):
+        if not inject_mtp_support(model, mtp_sidecar=mtp_sidecar):
             raise RuntimeError(
                 f"MTP injection failed on model {model_alias!r} — "
-                "checkpoint likely lacks mtp.* weights. Re-convert from "
-                "HF with mlx-lm PR #990's sanitize() path."
+                f"sidecar {mtp_sidecar!r}. Confirm the sidecar repo or "
+                "local path exists, holds model.safetensors with the "
+                "expected MTP head schema, and the base model's "
+                "config carries mtp_num_hidden_layers >= 1."
             )
         assert validate_mtp_support(model)
+        # The patch lands on the inner TextModel (the VLM wrapper's
+        # ``language_model`` field). The generator drives the model
+        # directly, so re-bind ``model`` to the patched inner for the
+        # ``mtp_generate_step`` call. The mlx-lm 0.31.3 Qwen3.5
+        # arch ships only the VLM wrapper; the inner TextModel
+        # carries embed_tokens, lm_head, layers — everything the
+        # generator and ``mtp_forward`` reference.
+        if hasattr(model, "language_model"):
+            model = model.language_model
 
     prompt_ids = mx.array(tokenizer.encode(prompt), mx.uint32)
     counter = MTPAcceptCounter()
@@ -367,9 +425,13 @@ def main() -> int:
     n_prompts = min(args.prompts, len(_BENCH_PROMPTS))
     prompts = list(_BENCH_PROMPTS[:n_prompts])
 
+    mtp_sidecar = _resolve_mtp_sidecar(args.model, args.mtp_sidecar)
+    conditions: tuple[str, ...] = ("mtp",) if args.mtp_only else ("none", "mtp")
+
     print(
         f"[bench_spec_decode_mtp] model={args.model} runs={args.runs} "
-        f"prompts={n_prompts} max_tokens={args.max_tokens} temp={args.temp}",
+        f"prompts={n_prompts} max_tokens={args.max_tokens} temp={args.temp} "
+        f"mtp_sidecar={mtp_sidecar!r} conditions={conditions}",
         file=sys.stderr,
     )
 
@@ -378,7 +440,7 @@ def main() -> int:
     # #990 follows the same protocol).
     for run_idx in range(args.runs):
         for prompt_idx, prompt in enumerate(prompts):
-            for condition in ("none", "mtp"):
+            for condition in conditions:
                 try:
                     res = _run_once(
                         model_alias=args.model,
@@ -386,6 +448,7 @@ def main() -> int:
                         prompt=prompt,
                         max_tokens=args.max_tokens,
                         temp=args.temp,
+                        mtp_sidecar=mtp_sidecar,
                     )
                 except Exception as exc:  # pragma: no cover — bench
                     print(

--- a/tests/test_mtp_real_weights.py
+++ b/tests/test_mtp_real_weights.py
@@ -1,0 +1,204 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Real-weights integration test for the MTP injection pipeline.
+
+The unit tests in :mod:`tests.test_mtp_spec_decode` and
+:mod:`tests.test_mtp_lossless` use synthetic / mocked models so they
+run in 1s without GPU contention. That coverage is essential for the
+control-flow surfaces (eligibility, accept-counter math, install
+idempotency) but it does NOT exercise the **quantize → load-from-
+disk → real-forward** chain — exactly the chain whose absence shipped
+PR #918 with an inject pipeline that built a random-init MTP module
+and never loaded weights.
+
+This file fills the gap with one end-to-end probe:
+
+* Load ``mlx-community/Qwen3.5-9B-4bit`` via ``mlx_lm.load``.
+* Call :func:`inject_mtp_support` with the cached sidecar repo
+  ``mlx-community/Qwen3.5-9B-MTP-4bit``.
+* Verify the four contract surfaces land
+  (:func:`validate_mtp_support`).
+* Run a single 20-token MTP-spec-decode pass and a single 20-token
+  baseline pass, then compare them byte-equally — the lossless
+  contract at temp=0 says they MUST match.
+
+Heavy by default (5 GB base + 131 MB sidecar download on cold cache,
+~15 s wall on warm cache). Gated on ``RAPID_MLX_RUN_HEAVY_TESTS=1``
+so it does not fire in the ordinary CI sweep. Operators wanting to
+re-verify after touching the inject / generator / rollback code path
+run::
+
+    RAPID_MLX_RUN_HEAVY_TESTS=1 pytest tests/test_mtp_real_weights.py -xvs
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+mx = pytest.importorskip("mlx.core")
+
+# This whole file is gated on RAPID_MLX_RUN_HEAVY_TESTS=1. The unit
+# tests in ``test_mtp_spec_decode.py`` continue to cover the
+# control-flow surfaces in the normal CI sweep.
+_HEAVY = os.environ.get("RAPID_MLX_RUN_HEAVY_TESTS") == "1"
+
+pytestmark = pytest.mark.skipif(
+    not _HEAVY,
+    reason=(
+        "Heavy real-weights probe (5 GB base + 131 MB sidecar). "
+        "Set RAPID_MLX_RUN_HEAVY_TESTS=1 to run."
+    ),
+)
+
+
+_BASE_MODEL = "mlx-community/Qwen3.5-9B-4bit"
+_MTP_SIDECAR = "mlx-community/Qwen3.5-9B-MTP-4bit"
+
+
+@pytest.fixture(scope="module")
+def loaded_model():
+    """Load the base + inject MTP exactly once for all tests in the file."""
+    from mlx_lm import load
+
+    from vllm_mlx.spec_decode.mtp.qwen3_5_inject import (
+        inject_mtp_support,
+        validate_mtp_support,
+    )
+
+    model, tokenizer = load(_BASE_MODEL)
+    injected = inject_mtp_support(model, mtp_sidecar=_MTP_SIDECAR)
+    assert injected is True, (
+        "inject_mtp_support returned False on real Qwen3.5-9B-4bit + "
+        "sidecar. Likely causes: sidecar repo unreachable, base config "
+        "missing mtp_num_hidden_layers in text_config, or the inner "
+        "TextModel could not be resolved off model.language_model."
+    )
+    assert validate_mtp_support(model), (
+        "validate_mtp_support failed after a successful inject — "
+        "the four PR #990 surfaces (return_hidden, n_confirmed, "
+        "mtp_forward, make_mtp_cache) did not all land."
+    )
+    return model, tokenizer
+
+
+def test_inject_loads_real_sidecar_weights(loaded_model):
+    """The sidecar's 31 keys must round-trip into the quantized MTP head.
+
+    This is the test that would have caught the original PR #918
+    defect: it builds + quantizes + load_weights against a real
+    safetensors blob (not a stub) and asserts the resulting parameter
+    tree matches the upstream schema. If any of (quantization params
+    detect, MTP module layout, sidecar key map) drifts, the
+    ``mtp.load_weights(..., strict=False)`` call would still succeed
+    but parameters would silently retain their random init — caught
+    here by inspecting the loaded weight tensors against the sidecar
+    file directly.
+    """
+    import mlx.core as _mx
+
+    model, _ = loaded_model
+    inner = model.language_model
+    mtp = inner.mtp
+    assert mtp is not None, "inject_mtp_support did not attach inner.mtp"
+
+    # Sidecar weight count — every tensor in the safetensors must
+    # appear in the MTP module's parameter tree post-quantize.
+    from huggingface_hub import snapshot_download
+
+    sidecar_dir = snapshot_download(_MTP_SIDECAR)
+    weights_file = None
+    for candidate in ("model-mtp.safetensors", "model.safetensors"):
+        path = f"{sidecar_dir}/{candidate}"
+        try:
+            _mx.load(path)
+            weights_file = path
+            break
+        except Exception:
+            continue
+    assert weights_file is not None, (
+        f"No model.safetensors or model-mtp.safetensors found in {sidecar_dir}"
+    )
+
+    raw = _mx.load(weights_file)
+    # Spot-check a few weight tensors actually moved from sidecar into
+    # the MTP module — using values, not just shapes, so a random-init
+    # would fail.
+    fc_weight_from_disk = raw["fc.weight"]
+    fc_weight_in_module = mtp.fc.weight
+    assert (
+        fc_weight_from_disk.shape == fc_weight_in_module.shape
+    ), "fc.weight shape mismatch between sidecar and MTP module"
+    # Equality check requires evaluating. Compare uint32 quantized
+    # weights byte-equally — random init would not match.
+    diff = _mx.sum(fc_weight_from_disk != fc_weight_in_module).item()
+    assert diff == 0, (
+        f"fc.weight in MTP module differs from sidecar by {diff} entries — "
+        f"weights were NOT loaded from disk (likely random init still). "
+        f"This is the defect-class that PR #918 originally shipped."
+    )
+
+
+def test_mtp_lossless_byte_equal_against_baseline(loaded_model):
+    """At temp=0, MTP spec decode must be byte-equal to non-spec decode.
+
+    Tokenize a prompt, run 20 tokens through ``stream_generate``
+    (baseline) and 20 tokens through ``mtp_generate_step`` (MTP). The
+    decoded token sequences MUST match exactly. Any divergence
+    indicates either:
+
+    * The MTP head is producing wrong drafts AND the verify accepts
+      them anyway (probabilistic-accept arithmetic broken at temp=0).
+    * The cache rollback on draft rejection is failing to restore
+      linear-attention SSM state — output then drifts from the
+      baseline after the first rejected draft.
+
+    Both failure modes would invalidate the lossless contract; this
+    test is the canonical guard for it on a real checkpoint.
+    """
+    import mlx.core as _mx
+
+    from mlx_lm.generate import stream_generate
+
+    from vllm_mlx.spec_decode.mtp import MTPAcceptCounter
+    from vllm_mlx.spec_decode.mtp.generator import mtp_generate_step
+
+    model, tokenizer = loaded_model
+    inner = model.language_model
+
+    # Three prompts (chat / code / math) — matches the bench's
+    # coverage but with a 20-token budget so the test stays under
+    # ~3 s on warm GPU.
+    prompts = (
+        "Write a short Python Fibonacci function with type hints.",
+        "Explain how a Bloom filter works.",
+        "Two trains travel toward each other at 60 and 80 km/h, 350 km "
+        "apart. When do they meet?",
+    )
+    N = 20
+
+    for prompt in prompts:
+        # Baseline
+        base_tokens: list[int] = []
+        for resp in stream_generate(model, tokenizer, prompt, max_tokens=N):
+            base_tokens.append(int(resp.token))
+            if len(base_tokens) >= N:
+                break
+
+        # MTP
+        counter = MTPAcceptCounter()
+        prompt_ids = _mx.array(tokenizer.encode(prompt), _mx.uint32)
+        mtp_tokens: list[int] = []
+        for tok, _, _ in mtp_generate_step(
+            prompt_ids, inner, max_tokens=N, temp=0.0, accept_counter=counter
+        ):
+            mtp_tokens.append(int(tok))
+            if len(mtp_tokens) >= N:
+                break
+
+        # Lossless contract: byte-equal at temp=0.
+        assert mtp_tokens == base_tokens, (
+            f"MTP-vs-baseline divergence on prompt {prompt[:40]!r}: "
+            f"baseline {base_tokens} vs mtp {mtp_tokens}. "
+            f"Accept rate this run: {counter.snapshot()}."
+        )

--- a/tests/test_mtp_real_weights.py
+++ b/tests/test_mtp_real_weights.py
@@ -173,22 +173,77 @@ def test_inject_loads_real_sidecar_weights(loaded_model):
     )
 
     raw = _mx.load(weights_file)
-    # Spot-check a few weight tensors actually moved from sidecar into
-    # the MTP module — using values, not just shapes, so a random-init
-    # would fail.
-    fc_weight_from_disk = raw["fc.weight"]
-    fc_weight_in_module = mtp.fc.weight
-    assert fc_weight_from_disk.shape == fc_weight_in_module.shape, (
-        "fc.weight shape mismatch between sidecar and MTP module"
+
+    # ------------------------------------------------------------------
+    # Coverage-check: codex flagged on PR #954 that only checking
+    # ``fc.weight`` would let the test pass even if every other MTP
+    # tensor stayed random-init. Walk the MTP module's full parameter
+    # tree and assert every expected key is present in the sidecar AND
+    # byte-equal to the loaded module. This catches both partial-load
+    # (some key map drift on one layer) and key-name drift (e.g. norm
+    # vs norm_pre vs pre_norm).
+    # ------------------------------------------------------------------
+    from mlx.utils import tree_flatten
+
+    flat_module = dict(tree_flatten(mtp.parameters()))
+    expected_keys = set(flat_module.keys())
+    # ``mtp.``-prefix tolerance — same rewrite the inject does.
+    sidecar_norm = {
+        (k.removeprefix("mtp.") if k.startswith("mtp.") else k): v
+        for k, v in raw.items()
+    }
+    sidecar_norm_keys = set(sidecar_norm.keys())
+
+    missing_in_sidecar = expected_keys - sidecar_norm_keys
+    assert not missing_in_sidecar, (
+        f"Sidecar {weights_file} is missing {len(missing_in_sidecar)} required "
+        f"MTP parameter(s): {sorted(missing_in_sidecar)[:8]}. "
+        f"inject_mtp_support should have already refused this load."
     )
-    # Equality check requires evaluating. Compare uint32 quantized
-    # weights byte-equally — random init would not match.
-    diff = _mx.sum(fc_weight_from_disk != fc_weight_in_module).item()
-    assert diff == 0, (
-        f"fc.weight in MTP module differs from sidecar by {diff} entries — "
-        f"weights were NOT loaded from disk (likely random init still). "
-        f"This is the defect-class that PR #918 originally shipped."
+
+    # Byte-equal every shared key. uint32 packed quant weights compare
+    # exactly; bf16/fp16 norms compare exactly; bias tensors compare
+    # exactly. Random init on ANY tensor would surface here.
+    mismatched: list[tuple[str, int]] = []
+    for k in sorted(expected_keys):
+        on_disk = sidecar_norm[k]
+        in_module = flat_module[k]
+        assert on_disk.shape == in_module.shape, (
+            f"{k}: shape mismatch (disk {on_disk.shape} vs module {in_module.shape})"
+        )
+        diff = _mx.sum(on_disk != in_module).item()
+        if diff != 0:
+            mismatched.append((k, int(diff)))
+    assert not mismatched, (
+        f"{len(mismatched)} MTP tensor(s) differ between sidecar and module "
+        f"(first 5): {mismatched[:5]}. Weights were NOT loaded from disk — "
+        f"this is the defect-class PR #918 originally shipped. Sidecar key "
+        f"presence: {len(sidecar_norm_keys)} total in file, {len(expected_keys)} "
+        f"expected by module, {len(sidecar_norm_keys & expected_keys)} matched."
     )
+
+    # Explicit representative-key smoke check — codex suggested
+    # asserting coverage across ``fc.*``, ``layers.*``, ``norm`` (and
+    # the linear-attention pre-norms inside layer 0). Re-state the
+    # successful matches by category so a future regression that
+    # silently shrinks the parameter tree (e.g. a refactor that
+    # removes the pre-norms) shows up loud here, not just as a
+    # mysteriously-smaller expected_keys count.
+    categories = {
+        "fc.*": [k for k in expected_keys if k.startswith("fc.")],
+        "layers.0.*": [k for k in expected_keys if k.startswith("layers.0.")],
+        "norm": [k for k in expected_keys if k == "norm.weight" or k == "norm"],
+        "pre_norms (layers.0.*norm*)": [
+            k for k in expected_keys if k.startswith("layers.0.") and "norm" in k
+        ],
+    }
+    for label, keys in categories.items():
+        assert keys, (
+            f"Coverage gap: no parameters under category {label!r} in the "
+            f"MTP module's parameter tree. Either the upstream layout drifted "
+            f"or the inject failed to wire the sub-module. expected_keys "
+            f"sample: {sorted(expected_keys)[:8]}"
+        )
 
 
 def test_mtp_lossless_byte_equal_against_baseline(loaded_model, baseline_tokens):

--- a/tests/test_mtp_real_weights.py
+++ b/tests/test_mtp_real_weights.py
@@ -56,9 +56,61 @@ _BASE_MODEL = "mlx-community/Qwen3.5-9B-4bit"
 _MTP_SIDECAR = "mlx-community/Qwen3.5-9B-MTP-4bit"
 
 
+_BASELINE_PROMPTS = (
+    "Write a short Python Fibonacci function with type hints.",
+    "Explain how a Bloom filter works.",
+    "Two trains travel toward each other at 60 and 80 km/h, 350 km "
+    "apart. When do they meet?",
+)
+_BASELINE_N_TOKENS = 20
+
+
 @pytest.fixture(scope="module")
-def loaded_model():
-    """Load the base + inject MTP exactly once for all tests in the file."""
+def baseline_tokens():
+    """Capture baseline (no MTP) tokens BEFORE any inject runs.
+
+    Codex flagged on PR #954 that running ``stream_generate`` after
+    ``inject_mtp_support`` compares MTP against the *patched* model,
+    not the original Qwen3.5 forward — which silently weakens the
+    lossless guard. Fix: load a separate, un-injected model in this
+    fixture and tear it down before the MTP fixture loads. This
+    guarantees the baseline tokens were produced by the pristine
+    upstream code path.
+    """
+    import gc
+
+    from mlx_lm import load
+    from mlx_lm.generate import stream_generate
+
+    model, tokenizer = load(_BASE_MODEL)
+    baselines: dict[str, list[int]] = {}
+    for prompt in _BASELINE_PROMPTS:
+        toks: list[int] = []
+        for resp in stream_generate(
+            model, tokenizer, prompt, max_tokens=_BASELINE_N_TOKENS
+        ):
+            toks.append(int(resp.token))
+            if len(toks) >= _BASELINE_N_TOKENS:
+                break
+        baselines[prompt] = toks
+
+    # Release the un-injected model before the patched fixture loads
+    # the second copy. Two 9B-4bit copies briefly coexist; cleanup is
+    # explicit to keep peak GPU mem bounded.
+    del model
+    del tokenizer
+    gc.collect()
+    return baselines
+
+
+@pytest.fixture(scope="module")
+def loaded_model(baseline_tokens):
+    """Load the base + inject MTP exactly once for all tests in the file.
+
+    Depends on ``baseline_tokens`` so the un-injected baseline pass
+    completes (and releases its model) before this fixture mutates a
+    fresh copy via ``inject_mtp_support``.
+    """
     from mlx_lm import load
 
     from vllm_mlx.spec_decode.mtp.qwen3_5_inject import (
@@ -139,13 +191,17 @@ def test_inject_loads_real_sidecar_weights(loaded_model):
     )
 
 
-def test_mtp_lossless_byte_equal_against_baseline(loaded_model):
+def test_mtp_lossless_byte_equal_against_baseline(loaded_model, baseline_tokens):
     """At temp=0, MTP spec decode must be byte-equal to non-spec decode.
 
-    Tokenize a prompt, run 20 tokens through ``stream_generate``
-    (baseline) and 20 tokens through ``mtp_generate_step`` (MTP). The
-    decoded token sequences MUST match exactly. Any divergence
-    indicates either:
+    The ``baseline_tokens`` fixture captured ground-truth tokens
+    against a *fresh, un-injected* Qwen3.5-9B-4bit model BEFORE the
+    ``loaded_model`` fixture mutated a separate copy with
+    ``inject_mtp_support``. This test then runs the MTP generator on
+    the patched copy and asserts the decoded token sequences match
+    byte-equally.
+
+    Any divergence indicates either:
 
     * The MTP head is producing wrong drafts AND the verify accepts
       them anyway (probabilistic-accept arithmetic broken at temp=0).
@@ -157,7 +213,6 @@ def test_mtp_lossless_byte_equal_against_baseline(loaded_model):
     test is the canonical guard for it on a real checkpoint.
     """
     import mlx.core as _mx
-    from mlx_lm.generate import stream_generate
 
     from vllm_mlx.spec_decode.mtp import MTPAcceptCounter
     from vllm_mlx.spec_decode.mtp.generator import mtp_generate_step
@@ -165,34 +220,26 @@ def test_mtp_lossless_byte_equal_against_baseline(loaded_model):
     model, tokenizer = loaded_model
     inner = model.language_model
 
-    # Three prompts (chat / code / math) — matches the bench's
-    # coverage but with a 20-token budget so the test stays under
-    # ~3 s on warm GPU.
-    prompts = (
-        "Write a short Python Fibonacci function with type hints.",
-        "Explain how a Bloom filter works.",
-        "Two trains travel toward each other at 60 and 80 km/h, 350 km "
-        "apart. When do they meet?",
-    )
-    N = 20
+    for prompt in _BASELINE_PROMPTS:
+        base_tokens = baseline_tokens[prompt]
+        assert len(base_tokens) == _BASELINE_N_TOKENS, (
+            f"baseline_tokens fixture returned {len(base_tokens)} tokens for "
+            f"prompt {prompt[:40]!r}; expected {_BASELINE_N_TOKENS}."
+        )
 
-    for prompt in prompts:
-        # Baseline
-        base_tokens: list[int] = []
-        for resp in stream_generate(model, tokenizer, prompt, max_tokens=N):
-            base_tokens.append(int(resp.token))
-            if len(base_tokens) >= N:
-                break
-
-        # MTP
+        # MTP on the patched model.
         counter = MTPAcceptCounter()
         prompt_ids = _mx.array(tokenizer.encode(prompt), _mx.uint32)
         mtp_tokens: list[int] = []
         for tok, _, _ in mtp_generate_step(
-            prompt_ids, inner, max_tokens=N, temp=0.0, accept_counter=counter
+            prompt_ids,
+            inner,
+            max_tokens=_BASELINE_N_TOKENS,
+            temp=0.0,
+            accept_counter=counter,
         ):
             mtp_tokens.append(int(tok))
-            if len(mtp_tokens) >= N:
+            if len(mtp_tokens) >= _BASELINE_N_TOKENS:
                 break
 
         # Lossless contract: byte-equal at temp=0.

--- a/tests/test_mtp_real_weights.py
+++ b/tests/test_mtp_real_weights.py
@@ -126,9 +126,9 @@ def test_inject_loads_real_sidecar_weights(loaded_model):
     # would fail.
     fc_weight_from_disk = raw["fc.weight"]
     fc_weight_in_module = mtp.fc.weight
-    assert (
-        fc_weight_from_disk.shape == fc_weight_in_module.shape
-    ), "fc.weight shape mismatch between sidecar and MTP module"
+    assert fc_weight_from_disk.shape == fc_weight_in_module.shape, (
+        "fc.weight shape mismatch between sidecar and MTP module"
+    )
     # Equality check requires evaluating. Compare uint32 quantized
     # weights byte-equally — random init would not match.
     diff = _mx.sum(fc_weight_from_disk != fc_weight_in_module).item()
@@ -157,7 +157,6 @@ def test_mtp_lossless_byte_equal_against_baseline(loaded_model):
     test is the canonical guard for it on a real checkpoint.
     """
     import mlx.core as _mx
-
     from mlx_lm.generate import stream_generate
 
     from vllm_mlx.spec_decode.mtp import MTPAcceptCounter

--- a/tests/test_mtp_spec_decode.py
+++ b/tests/test_mtp_spec_decode.py
@@ -665,7 +665,9 @@ def test_inject_mtp_support_attaches_four_surfaces():
     except (TypeError, AttributeError) as exc:
         pytest.skip(f"Qwen3.5 TextModelArgs schema mismatch in this mlx-lm: {exc}")
 
-    injected = inject_mtp_support(model)
+    # allow_random_init=True: this is the test-only wiring probe
+    # (no sidecar download); production callers pass mtp_sidecar.
+    injected = inject_mtp_support(model, allow_random_init=True)
     assert injected is True
     assert validate_mtp_support(model) is True
 
@@ -707,6 +709,166 @@ def test_inject_mtp_support_rejects_stripped_checkpoint():
     # resolver picks up ``model.args`` and decides on
     # ``mtp_num_hidden_layers``.
     assert inject_mtp_support(_FakeInner()) is False
+
+
+def test_inject_mtp_support_refuses_no_sidecar_by_default():
+    """Default ``allow_random_init=False`` must refuse a sidecar-less inject.
+
+    Codex round-5 BLOCKING fix: silently shipping a random-init MTP
+    head (~0% accept rate) under the production-default code path
+    looked like spec-decode was enabled but yielded zero speedup.
+    With this fix, ``inject_mtp_support(model)`` (no sidecar, no
+    opt-in) must return False and leave the model unmodified.
+    """
+    from vllm_mlx.spec_decode.mtp.qwen3_5_inject import (
+        inject_mtp_support,
+        validate_mtp_support,
+    )
+
+    try:
+        model = _build_tiny_qwen3_5_text_model()
+    except (TypeError, AttributeError) as exc:
+        pytest.skip(f"Qwen3.5 TextModelArgs schema mismatch: {exc}")
+
+    # No sidecar, no allow_random_init → must fail closed.
+    assert inject_mtp_support(model) is False, (
+        "Default inject_mtp_support without sidecar should return False"
+    )
+    # And the model must NOT have been patched — validate_mtp_support
+    # checks the four surfaces, none should land on a failed inject.
+    assert validate_mtp_support(model) is False
+
+
+def test_inject_mtp_support_loads_synthetic_sidecar():
+    """Lightweight quantize → load → coverage-check probe (no 5 GB download).
+
+    Codex round-5 NIT: the heavy real-weights test is gated on
+    RAPID_MLX_RUN_HEAVY_TESTS=1 and doesn't run in normal CI, so the
+    quantize/load/key-coverage path it covers has no default
+    safety net. This test fills the gap with a synthetic sidecar:
+
+    1. Build a tiny Qwen3.5 TextModel (existing helper).
+    2. Build the MTP head module via build_mtp_module.
+    3. Persist its (random-init) parameters to a temp safetensors
+       file — this becomes the "sidecar" the inject will load.
+    4. Re-build a fresh model + inject with mtp_sidecar=<temp file>.
+       Inject must succeed AND the loaded MTP weights must match
+       what we persisted.
+
+    Failure modes this guards against:
+
+    * mtp.load_weights silently no-ops because key names drift
+      between build and load.
+    * The coverage check (expected_keys vs loaded_keys) misses
+      missing tensors.
+    * The custom-file-path branch of _resolve_sidecar_file
+      regresses.
+
+    Runs in <2 s on the CI machine — no network, no GPU required
+    beyond what every other unit test uses.
+    """
+    import tempfile
+    from pathlib import Path
+
+    import mlx.core as _mx
+    from mlx.utils import tree_flatten
+
+    from vllm_mlx.spec_decode.mtp.head import build_mtp_module
+    from vllm_mlx.spec_decode.mtp.qwen3_5_inject import (
+        inject_mtp_support,
+        validate_mtp_support,
+    )
+
+    try:
+        model_a = _build_tiny_qwen3_5_text_model()
+    except (TypeError, AttributeError) as exc:
+        pytest.skip(f"Qwen3.5 TextModelArgs schema mismatch: {exc}")
+
+    # Build the MTP head separately so we can capture its random-init
+    # weights, write them to disk, and verify the inject loads them
+    # byte-equally. (Note: this tiny model is FP, so no quantize step
+    # — the inject's _detect_base_quantization returns None and the
+    # MTP module stays FP, matching the sidecar layout.)
+    args = model_a.args
+    mtp_template = build_mtp_module(args, int(args.mtp_num_hidden_layers))
+    _mx.eval(mtp_template.parameters())
+    flat = dict(tree_flatten(mtp_template.parameters()))
+    assert flat, "build_mtp_module produced an empty parameter tree"
+
+    with tempfile.TemporaryDirectory() as tmp:
+        sidecar_path = Path(tmp) / "synthetic-mtp-head.safetensors"
+        _mx.save_safetensors(str(sidecar_path), flat)
+
+        # Build a fresh model (so MTP head random init differs from
+        # the persisted template), then inject with the synthetic
+        # sidecar file path. Tests the custom-filename branch of
+        # _resolve_sidecar_file.
+        model_b = _build_tiny_qwen3_5_text_model()
+        result = inject_mtp_support(model_b, mtp_sidecar=str(sidecar_path))
+        assert result is True, (
+            "inject_mtp_support failed on a synthetic sidecar that exactly "
+            "matches the MTP module's parameter tree — likely a coverage-check "
+            "false positive (expected_keys drift) or a _resolve_sidecar_file regression."
+        )
+        assert validate_mtp_support(model_b) is True
+
+        # The inject MUST have loaded the persisted weights byte-equally.
+        loaded = dict(tree_flatten(model_b.mtp.parameters()))
+        assert set(loaded.keys()) == set(flat.keys()), (
+            f"Parameter trees diverged. "
+            f"In template only: {set(flat) - set(loaded)}. "
+            f"In loaded only: {set(loaded) - set(flat)}."
+        )
+        for k in flat:
+            diff = _mx.sum(loaded[k] != flat[k]).item()
+            assert diff == 0, (
+                f"{k}: loaded MTP weight differs from sidecar by {diff} entries. "
+                f"This is the random-init defect class PR #918 shipped."
+            )
+
+
+def test_inject_mtp_support_refuses_synthetic_sidecar_missing_tensor():
+    """Coverage check: dropping one required tensor must fail the inject.
+
+    Codex round-3 BLOCKING fix added a pre-load coverage check that
+    walks mtp.parameters() and refuses inject when any required key
+    is missing from the sidecar. This test exercises that path with
+    a tiny synthetic sidecar — no network, no GPU contention.
+    """
+    import tempfile
+    from pathlib import Path
+
+    import mlx.core as _mx
+    from mlx.utils import tree_flatten
+
+    from vllm_mlx.spec_decode.mtp.head import build_mtp_module
+    from vllm_mlx.spec_decode.mtp.qwen3_5_inject import inject_mtp_support
+
+    try:
+        model = _build_tiny_qwen3_5_text_model()
+    except (TypeError, AttributeError) as exc:
+        pytest.skip(f"Qwen3.5 TextModelArgs schema mismatch: {exc}")
+
+    args = model.args
+    mtp_template = build_mtp_module(args, int(args.mtp_num_hidden_layers))
+    _mx.eval(mtp_template.parameters())
+    flat = dict(tree_flatten(mtp_template.parameters()))
+    # Drop the FC weight — the inject's coverage check must catch this.
+    fc_keys = [k for k in flat if k.startswith("fc.")]
+    assert fc_keys, "tiny MTP template missing fc.* keys — test premise broken"
+    drop_key = fc_keys[0]
+    crippled = {k: v for k, v in flat.items() if k != drop_key}
+
+    with tempfile.TemporaryDirectory() as tmp:
+        sidecar_path = Path(tmp) / "crippled-sidecar.safetensors"
+        _mx.save_safetensors(str(sidecar_path), crippled)
+
+        fresh_model = _build_tiny_qwen3_5_text_model()
+        result = inject_mtp_support(fresh_model, mtp_sidecar=str(sidecar_path))
+        assert result is False, (
+            f"inject_mtp_support should have refused a sidecar missing {drop_key!r}, "
+            f"but returned True — the coverage check has regressed."
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/vllm_mlx/spec_decode/mtp/cache_patch.py
+++ b/vllm_mlx/spec_decode/mtp/cache_patch.py
@@ -184,15 +184,33 @@ def patch_gated_delta_net_for_mtp() -> bool:
             n_conf = 0
             if cache is not None:
                 n_conf = int(getattr(cache, "n_confirmed_for_mtp", 0) or 0)
-                # Clear stale snapshot from a previous patched call
-                # BEFORE deciding which path runs. Codex flagged on
-                # PR #954 that without this reset a sequence of
+                # IMPORTANT: ``cache`` here is the PER-LAYER
+                # ArraysCache for THIS GatedDeltaNet instance only —
+                # mlx-lm's prompt-cache machinery makes one cache
+                # entry per layer in the linear-attention stack. Each
+                # ArraysCache has its OWN ``rollback_state`` slot
+                # (instance attribute that shadows the class default
+                # installed by patch_arrays_cache_rollback_state).
+                # The generator's ``_rollback_draft`` iterates ALL
+                # caches in ``model_cache`` and restores each
+                # instance's own snapshot:
+                #
+                #     for c in model_cache:
+                #         if isinstance(c, ArraysCache) and c.rollback_state is not None:
+                #             c[0], c[1] = c.rollback_state
+                #             c.rollback_state = None
+                #
+                # So clearing ``cache.rollback_state`` here ONLY
+                # touches the current layer's slot. The N-1 other
+                # linear layers' snapshots are untouched — they live
+                # on their own cache instances. Codex round-3
+                # flagged that without this reset a sequence of
                 # (chunk-split-accepted → single-token-call →
-                # chunk-split-rejected) could restore an obsolete
-                # boundary state. The contract is: rollback_state is
-                # ONLY valid for the most-recent patched call; any
-                # consumer that wants to use it must do so before the
-                # next call into this GatedDeltaNet layer.
+                # chunk-split-rejected) could restore an OBSOLETE
+                # boundary state on this layer (the next two patched
+                # calls hit the fast path and never wrote a new
+                # snapshot). This clear at entry fixes that path
+                # without affecting any sibling layer.
                 cache.rollback_state = None
 
             # Fast path — no MTP boundary signaled, or chunk has 1

--- a/vllm_mlx/spec_decode/mtp/cache_patch.py
+++ b/vllm_mlx/spec_decode/mtp/cache_patch.py
@@ -184,10 +184,22 @@ def patch_gated_delta_net_for_mtp() -> bool:
             n_conf = 0
             if cache is not None:
                 n_conf = int(getattr(cache, "n_confirmed_for_mtp", 0) or 0)
+                # Clear stale snapshot from a previous patched call
+                # BEFORE deciding which path runs. Codex flagged on
+                # PR #954 that without this reset a sequence of
+                # (chunk-split-accepted → single-token-call →
+                # chunk-split-rejected) could restore an obsolete
+                # boundary state. The contract is: rollback_state is
+                # ONLY valid for the most-recent patched call; any
+                # consumer that wants to use it must do so before the
+                # next call into this GatedDeltaNet layer.
+                cache.rollback_state = None
 
             # Fast path — no MTP boundary signaled, or chunk has 1
             # token, or boundary is outside the range. Defer to the
-            # original implementation (byte-equal behavior).
+            # original implementation (byte-equal behavior). The
+            # rollback_state cleared above stays None on this path —
+            # there is no boundary to snapshot.
             if n_conf <= 0 or n_conf >= S or S < 2:
                 return _orig_gated_delta_call(self, inputs, mask=mask, cache=cache)
 
@@ -195,7 +207,8 @@ def patch_gated_delta_net_for_mtp() -> bool:
             if self.sharding_group is not None:
                 # The verify cycle only runs single-device; bail back
                 # to the unsplit path under tensor parallel (which the
-                # MTP generator doesn't drive anyway).
+                # MTP generator doesn't drive anyway). rollback_state
+                # stays None here too — TP shards don't snapshot.
                 return _orig_gated_delta_call(self, inputs, mask=mask, cache=cache)
 
             # Steps 1-3: projections + conv prefix — identical to the

--- a/vllm_mlx/spec_decode/mtp/cache_patch.py
+++ b/vllm_mlx/spec_decode/mtp/cache_patch.py
@@ -327,6 +327,16 @@ def patch_gated_delta_net_for_mtp() -> bool:
 
             out = mx.concatenate([out1, out2], axis=1)
             cache[1] = state_final
+            # Advance the cache position by the FULL chunk length S —
+            # this exactly mirrors the upstream
+            # ``GatedDeltaNet.__call__`` (mlx_lm/models/qwen3_5.py
+            # line 196-198 in 0.31.3), which always calls
+            # ``cache.advance(S)`` when cache is non-None at end of
+            # forward. Our chunk-split path consumes the same S
+            # tokens, just in two sub-calls to gated_delta_update;
+            # the net advance is identical to the upstream single-
+            # call path. No double-advance: there is no other
+            # ``advance`` along this code path.
             cache.advance(S)
 
             out = self.norm(out, z)

--- a/vllm_mlx/spec_decode/mtp/cache_patch.py
+++ b/vllm_mlx/spec_decode/mtp/cache_patch.py
@@ -201,9 +201,7 @@ def patch_gated_delta_net_for_mtp() -> bool:
             # Steps 1-3: projections + conv prefix — identical to the
             # original call. Build all derived tensors once.
             qkv = self.in_proj_qkv(inputs)
-            z = self.in_proj_z(inputs).reshape(
-                B, S, self.num_v_heads, self.head_v_dim
-            )
+            z = self.in_proj_z(inputs).reshape(B, S, self.num_v_heads, self.head_v_dim)
             b = self.in_proj_b(inputs)
             a = self.in_proj_a(inputs)
 
@@ -222,9 +220,7 @@ def patch_gated_delta_net_for_mtp() -> bool:
             # Conv state AT BOUNDARY (after processing n_conf tokens):
             # the last n_keep entries of conv_input[:, : n_conf + n_keep].
             # Equivalently conv_input[:, n_conf : n_conf + n_keep].
-            conv_snap = mx.contiguous(
-                conv_input[:, n_conf : n_conf + n_keep, :]
-            )
+            conv_snap = mx.contiguous(conv_input[:, n_conf : n_conf + n_keep, :])
             # Conv state AT END (after processing all S tokens):
             # last n_keep entries of conv_input.
             conv_post = mx.contiguous(conv_input[:, -n_keep:, :])
@@ -254,8 +250,15 @@ def patch_gated_delta_net_for_mtp() -> bool:
             b1 = b[:, :n_conf]
             mask1 = mask[:, :n_conf] if mask is not None else None
             out1, state_at_boundary = gated_delta_update(
-                q1, k1, v1, a1, b1,
-                self.A_log, self.dt_bias, state, mask1,
+                q1,
+                k1,
+                v1,
+                a1,
+                b1,
+                self.A_log,
+                self.dt_bias,
+                state,
+                mask1,
                 use_kernel=not self.training,
             )
 
@@ -271,8 +274,15 @@ def patch_gated_delta_net_for_mtp() -> bool:
             b2 = b[:, n_conf:]
             mask2 = mask[:, n_conf:] if mask is not None else None
             out2, state_final = gated_delta_update(
-                q2, k2, v2, a2, b2,
-                self.A_log, self.dt_bias, state_at_boundary, mask2,
+                q2,
+                k2,
+                v2,
+                a2,
+                b2,
+                self.A_log,
+                self.dt_bias,
+                state_at_boundary,
+                mask2,
                 use_kernel=not self.training,
             )
 

--- a/vllm_mlx/spec_decode/mtp/cache_patch.py
+++ b/vllm_mlx/spec_decode/mtp/cache_patch.py
@@ -203,21 +203,13 @@ def patch_gated_delta_net_for_mtp() -> bool:
                 # So clearing ``cache.rollback_state`` here ONLY
                 # touches the current layer's slot. The N-1 other
                 # linear layers' snapshots are untouched — they live
-                # on their own cache instances. Codex round-3
-                # flagged that without this reset a sequence of
-                # (chunk-split-accepted → single-token-call →
-                # chunk-split-rejected) could restore an OBSOLETE
-                # boundary state on this layer (the next two patched
-                # calls hit the fast path and never wrote a new
-                # snapshot). This clear at entry fixes that path
-                # without affecting any sibling layer.
-                cache.rollback_state = None
+                # on their own cache instances.
 
             # Fast path — no MTP boundary signaled, or chunk has 1
             # token, or boundary is outside the range, or NO cache at
             # all. Defer to the original implementation (byte-equal
-            # behavior). The rollback_state cleared above stays None
-            # on this path — there is no boundary to snapshot.
+            # behavior). rollback_state is NOT touched on this path
+            # (see round-7 ordering fix below).
             #
             # Codex round-5 BLOCKING defensive fix: ``cache is None``
             # is explicitly in the guard. Today it's logically
@@ -234,8 +226,26 @@ def patch_gated_delta_net_for_mtp() -> bool:
                 # The verify cycle only runs single-device; bail back
                 # to the unsplit path under tensor parallel (which the
                 # MTP generator doesn't drive anyway). rollback_state
-                # stays None here too — TP shards don't snapshot.
+                # is NOT cleared on this path — see round-7 ordering
+                # fix: clearing only happens immediately before the
+                # chunk-split path writes a fresh snapshot.
                 return _orig_gated_delta_call(self, inputs, mask=mask, cache=cache)
+
+            # ROUND-7 ordering fix: codex flagged that an earlier
+            # unconditional clear at function entry would wipe a
+            # previous chunk-split's snapshot if the next call
+            # bailed to fast-path or TP fallback (no replacement
+            # written). The clean fix is to clear ONLY immediately
+            # before the chunk-split path writes a new snapshot —
+            # making the lifecycle a single atomic write per
+            # chunk-split call. Round-3's stale-snapshot concern is
+            # still addressed because: (a) chunk-split always
+            # overwrites with a fresh snapshot, and (b) fast/TP
+            # paths leaving rollback_state intact is benign — the
+            # consumer (``_rollback_draft``) is only called after a
+            # chunk-split verify that produced drafts to reject,
+            # never after a fast-path call.
+            cache.rollback_state = None
 
             # Steps 1-3: projections + conv prefix — identical to the
             # original call. Build all derived tensors once.

--- a/vllm_mlx/spec_decode/mtp/cache_patch.py
+++ b/vllm_mlx/spec_decode/mtp/cache_patch.py
@@ -54,6 +54,8 @@ logger = logging.getLogger(__name__)
 # atomic.
 _install_lock = threading.Lock()
 _patched = False
+_gated_delta_patched = False
+_orig_gated_delta_call = None
 
 
 def patch_arrays_cache_rollback_state() -> bool:
@@ -109,6 +111,188 @@ def patch_arrays_cache_rollback_state() -> bool:
         return True
 
 
+def patch_gated_delta_net_for_mtp() -> bool:
+    """Wrap ``GatedDeltaNet.__call__`` with a chunk-split version that
+    snapshots SSM/conv state at a confirmed boundary.
+
+    PR #990 adds an ``n_confirmed`` parameter to ``GatedDeltaNet`` so
+    that during the MTP verify forward (which processes
+    ``[main_tok, draft_tok]`` as a 2-token batch with
+    ``n_confirmed=1``) the layer splits its
+    :func:`mlx_lm.models.gated_delta.gated_delta_update` call into two
+    chunks and writes ``(conv_state_at_boundary, ssm_state_at_boundary)``
+    to ``cache.rollback_state``. On draft rejection the
+    :func:`vllm_mlx.spec_decode.mtp.generator._rollback_draft` path
+    restores those snapshots so the linear-attention state matches
+    "after main_tok, before draft_tok" — the position the next
+    generator iteration's input ``[verify_tok_id, new_draft]`` expects
+    to attend from.
+
+    Without this patch the verify forward advances the SSM by 2 steps
+    and there is no way to roll back to position 1 on rejection — the
+    LOSSLESS contract breaks on the linear-attention layers (only;
+    full-attention's ``KVCache.trim(1)`` already handles its rollback).
+    Output diverges from the non-spec-decode baseline within ~10
+    tokens at 90% accept rate.
+
+    The patch:
+
+    * Is idempotent — calling twice is a no-op.
+    * Is transparent — when ``cache.n_confirmed_for_mtp`` is 0 (the
+      class default), the wrapped call falls through to the original
+      ``__call__`` unchanged. Production non-MTP code paths are
+      unaffected.
+    * Reads the chunk boundary from ``cache.n_confirmed_for_mtp``,
+      which the MTP-wrapped ``TextModel.__call__`` sets before each
+      ``layer.linear_attn`` invocation. Threading via a cache attr
+      avoids changing the layer's call signature (and so avoids
+      touching ``DecoderLayer.__call__`` / ``Qwen3_5TextModel.__call__``
+      upstream).
+
+    Returns ``True`` when the patch was applied (or already in place),
+    ``False`` if mlx-lm cannot be imported.
+    """
+    global _gated_delta_patched, _orig_gated_delta_call
+
+    with _install_lock:
+        if _gated_delta_patched:
+            return True
+
+        try:
+            import mlx.core as mx
+            import mlx.nn as nn
+            from mlx_lm.models.cache import ArraysCache
+            from mlx_lm.models.gated_delta import gated_delta_update
+            from mlx_lm.models.qwen3_5 import GatedDeltaNet
+        except ImportError:  # pragma: no cover — mlx_lm always available
+            logger.warning(
+                "[mtp.cache_patch] Could not import GatedDeltaNet; "
+                "skipping rollback-state install."
+            )
+            return False
+
+        # Add a class-default ``n_confirmed_for_mtp`` slot to
+        # ArraysCache so the layer can read it without an
+        # ``AttributeError`` on caches the wrapper hasn't tagged.
+        if "n_confirmed_for_mtp" not in ArraysCache.__dict__:
+            ArraysCache.n_confirmed_for_mtp = 0  # type: ignore[attr-defined]
+
+        _orig_gated_delta_call = GatedDeltaNet.__call__
+
+        def _patched_call(self, inputs, mask=None, cache=None):
+            B, S, _ = inputs.shape
+            n_conf = 0
+            if cache is not None:
+                n_conf = int(getattr(cache, "n_confirmed_for_mtp", 0) or 0)
+
+            # Fast path — no MTP boundary signaled, or chunk has 1
+            # token, or boundary is outside the range. Defer to the
+            # original implementation (byte-equal behavior).
+            if n_conf <= 0 or n_conf >= S or S < 2:
+                return _orig_gated_delta_call(self, inputs, mask=mask, cache=cache)
+
+            # --- Chunk-split path (n_confirmed in (0, S)) ---
+            if self.sharding_group is not None:
+                # The verify cycle only runs single-device; bail back
+                # to the unsplit path under tensor parallel (which the
+                # MTP generator doesn't drive anyway).
+                return _orig_gated_delta_call(self, inputs, mask=mask, cache=cache)
+
+            # Steps 1-3: projections + conv prefix — identical to the
+            # original call. Build all derived tensors once.
+            qkv = self.in_proj_qkv(inputs)
+            z = self.in_proj_z(inputs).reshape(
+                B, S, self.num_v_heads, self.head_v_dim
+            )
+            b = self.in_proj_b(inputs)
+            a = self.in_proj_a(inputs)
+
+            if cache is not None and cache[0] is not None:
+                conv_state = cache[0]
+            else:
+                conv_state = mx.zeros(
+                    (B, self.conv_kernel_size - 1, self.conv_dim),
+                    dtype=inputs.dtype,
+                )
+
+            if mask is not None:
+                qkv = mx.where(mask[..., None], qkv, 0)
+            conv_input = mx.concatenate([conv_state, qkv], axis=1)
+            n_keep = self.conv_kernel_size - 1
+            # Conv state AT BOUNDARY (after processing n_conf tokens):
+            # the last n_keep entries of conv_input[:, : n_conf + n_keep].
+            # Equivalently conv_input[:, n_conf : n_conf + n_keep].
+            conv_snap = mx.contiguous(
+                conv_input[:, n_conf : n_conf + n_keep, :]
+            )
+            # Conv state AT END (after processing all S tokens):
+            # last n_keep entries of conv_input.
+            conv_post = mx.contiguous(conv_input[:, -n_keep:, :])
+            cache[0] = conv_post
+
+            conv_out = nn.silu(self.conv1d(conv_input))
+
+            q, k, v = [
+                t.reshape(B, S, h, d)
+                for t, h, d in zip(
+                    mx.split(conv_out, [self.key_dim, 2 * self.key_dim], -1),
+                    [self.num_k_heads, self.num_k_heads, self.num_v_heads],
+                    [self.head_k_dim, self.head_k_dim, self.head_v_dim],
+                )
+            ]
+
+            state = cache[1] if cache else None
+            inv_scale = k.shape[-1] ** -0.5
+            q = (inv_scale**2) * mx.fast.rms_norm(q, None, 1e-6)
+            k = inv_scale * mx.fast.rms_norm(k, None, 1e-6)
+
+            # Chunk 1: [0:n_conf]
+            q1 = q[:, :n_conf]
+            k1 = k[:, :n_conf]
+            v1 = v[:, :n_conf]
+            a1 = a[:, :n_conf]
+            b1 = b[:, :n_conf]
+            mask1 = mask[:, :n_conf] if mask is not None else None
+            out1, state_at_boundary = gated_delta_update(
+                q1, k1, v1, a1, b1,
+                self.A_log, self.dt_bias, state, mask1,
+                use_kernel=not self.training,
+            )
+
+            # Snapshot conv state at boundary + ssm state at boundary.
+            # _rollback_draft restores (cache[0], cache[1]) from this.
+            cache.rollback_state = (conv_snap, state_at_boundary)
+
+            # Chunk 2: [n_conf:S]
+            q2 = q[:, n_conf:]
+            k2 = k[:, n_conf:]
+            v2 = v[:, n_conf:]
+            a2 = a[:, n_conf:]
+            b2 = b[:, n_conf:]
+            mask2 = mask[:, n_conf:] if mask is not None else None
+            out2, state_final = gated_delta_update(
+                q2, k2, v2, a2, b2,
+                self.A_log, self.dt_bias, state_at_boundary, mask2,
+                use_kernel=not self.training,
+            )
+
+            out = mx.concatenate([out1, out2], axis=1)
+            cache[1] = state_final
+            cache.advance(S)
+
+            out = self.norm(out, z)
+            out = self.out_proj(out.reshape(B, S, -1))
+            return out
+
+        GatedDeltaNet.__call__ = _patched_call  # type: ignore[assignment]
+        _gated_delta_patched = True
+        logger.info(
+            "[mtp.cache_patch] Installed GatedDeltaNet chunk-split for MTP "
+            "rollback (snapshot at cache.n_confirmed_for_mtp boundary)."
+        )
+        return True
+
+
 def _is_patched_for_tests() -> bool:
     """Test-only — inspect the install flag."""
     return _patched
@@ -120,7 +304,7 @@ def _unpatch_for_tests() -> None:
     Allows tests to verify the install side-effect by toggling the
     install state. Never called from production.
     """
-    global _patched
+    global _patched, _gated_delta_patched, _orig_gated_delta_call
 
     with _install_lock:
         try:
@@ -128,6 +312,17 @@ def _unpatch_for_tests() -> None:
 
             if "rollback_state" in ArraysCache.__dict__:
                 delattr(ArraysCache, "rollback_state")
+            if "n_confirmed_for_mtp" in ArraysCache.__dict__:
+                delattr(ArraysCache, "n_confirmed_for_mtp")
         except ImportError:
             pass
+        if _gated_delta_patched and _orig_gated_delta_call is not None:
+            try:
+                from mlx_lm.models.qwen3_5 import GatedDeltaNet
+
+                GatedDeltaNet.__call__ = _orig_gated_delta_call  # type: ignore[assignment]
+            except ImportError:
+                pass
         _patched = False
+        _gated_delta_patched = False
+        _orig_gated_delta_call = None

--- a/vllm_mlx/spec_decode/mtp/cache_patch.py
+++ b/vllm_mlx/spec_decode/mtp/cache_patch.py
@@ -214,11 +214,19 @@ def patch_gated_delta_net_for_mtp() -> bool:
                 cache.rollback_state = None
 
             # Fast path — no MTP boundary signaled, or chunk has 1
-            # token, or boundary is outside the range. Defer to the
-            # original implementation (byte-equal behavior). The
-            # rollback_state cleared above stays None on this path —
-            # there is no boundary to snapshot.
-            if n_conf <= 0 or n_conf >= S or S < 2:
+            # token, or boundary is outside the range, or NO cache at
+            # all. Defer to the original implementation (byte-equal
+            # behavior). The rollback_state cleared above stays None
+            # on this path — there is no boundary to snapshot.
+            #
+            # Codex round-5 BLOCKING defensive fix: ``cache is None``
+            # is explicitly in the guard. Today it's logically
+            # unreachable (we only set n_conf > 0 when cache is not
+            # None) — but if a future refactor changes that
+            # invariant, the chunk-split below would crash on
+            # ``cache[0]``. Guarding here makes the contract
+            # self-documenting.
+            if cache is None or n_conf <= 0 or n_conf >= S or S < 2:
                 return _orig_gated_delta_call(self, inputs, mask=mask, cache=cache)
 
             # --- Chunk-split path (n_confirmed in (0, S)) ---

--- a/vllm_mlx/spec_decode/mtp/cache_patch.py
+++ b/vllm_mlx/spec_decode/mtp/cache_patch.py
@@ -184,26 +184,16 @@ def patch_gated_delta_net_for_mtp() -> bool:
             n_conf = 0
             if cache is not None:
                 n_conf = int(getattr(cache, "n_confirmed_for_mtp", 0) or 0)
-                # IMPORTANT: ``cache`` here is the PER-LAYER
-                # ArraysCache for THIS GatedDeltaNet instance only —
-                # mlx-lm's prompt-cache machinery makes one cache
-                # entry per layer in the linear-attention stack. Each
-                # ArraysCache has its OWN ``rollback_state`` slot
-                # (instance attribute that shadows the class default
-                # installed by patch_arrays_cache_rollback_state).
-                # The generator's ``_rollback_draft`` iterates ALL
-                # caches in ``model_cache`` and restores each
-                # instance's own snapshot:
-                #
-                #     for c in model_cache:
-                #         if isinstance(c, ArraysCache) and c.rollback_state is not None:
-                #             c[0], c[1] = c.rollback_state
-                #             c.rollback_state = None
-                #
-                # So clearing ``cache.rollback_state`` here ONLY
-                # touches the current layer's slot. The N-1 other
-                # linear layers' snapshots are untouched — they live
-                # on their own cache instances.
+                # NOTE on per-layer scope: ``cache`` here is the
+                # PER-LAYER ArraysCache for this single GatedDeltaNet
+                # instance only. mlx-lm's prompt-cache machinery
+                # builds one cache entry per backbone layer; each
+                # ArraysCache instance has its own ``rollback_state``
+                # slot. Any write below (clear or set) affects ONLY
+                # this layer's cache. The consumer side
+                # (generator.py::_rollback_draft) walks every cache
+                # and restores each instance's own snapshot
+                # independently.
 
             # Fast path — no MTP boundary signaled, or chunk has 1
             # token, or boundary is outside the range, or NO cache at

--- a/vllm_mlx/spec_decode/mtp/qwen3_5_inject.py
+++ b/vllm_mlx/spec_decode/mtp/qwen3_5_inject.py
@@ -94,13 +94,21 @@ def _detect_base_quantization(inner: Any) -> dict | None:
     """Detect the quantization params used by the base model.
 
     Walks the inner ``TextModel`` looking for a ``QuantizedLinear``
-    instance and reads its ``bits`` / ``group_size`` / ``mode``. The
-    MTP module must be quantized with the same params so its weight
-    shapes match the sidecar's safetensors layout (4-bit / group_size
-    64 / affine for ``mlx-community/Qwen3.5-9B-MTP-4bit``).
+    instance and reads its ``bits`` / ``group_size``. The MTP module
+    must be quantized with the same params so its weight shapes match
+    the sidecar's safetensors layout (4-bit / group_size 64 / affine
+    for ``mlx-community/Qwen3.5-9B-MTP-4bit``).
 
     Returns ``None`` for FP base models — the caller skips quantize
     in that case.
+
+    NOTE: only ``bits`` + ``group_size`` are returned. ``nn.quantize``
+    in the mlx-lm versions we target does not accept a ``mode`` arg —
+    it always applies the affine mode. The mlx-community sidecars
+    similarly assume affine. Returning ``mode`` would be dead data
+    that callers cannot pass through, so it's dropped. If/when
+    ``nn.quantize`` grows mode support, extend the dict here and
+    pipe it through at the inject call-site.
     """
     try:
         from mlx.nn import QuantizedEmbedding, QuantizedLinear
@@ -119,7 +127,6 @@ def _detect_base_quantization(inner: Any) -> dict | None:
                 return {
                     "bits": int(qp.bits),
                     "group_size": int(qp.group_size),
-                    "mode": getattr(qp, "mode", "affine"),
                 }
 
     # Fall back: embed_tokens (QuantizedEmbedding has bits/group_size too).
@@ -128,7 +135,6 @@ def _detect_base_quantization(inner: Any) -> dict | None:
         return {
             "bits": int(embed.bits),
             "group_size": int(embed.group_size),
-            "mode": getattr(embed, "mode", "affine"),
         }
 
     return None
@@ -239,19 +245,13 @@ def inject_mtp_support(model: Any, mtp_sidecar: str | Path | None = None) -> boo
     import mlx.core as mx
     import mlx.nn as nn
 
-    # Install the GatedDeltaNet chunk-split patch so the verify forward
-    # snapshots ``(conv_state, ssm_state)`` at ``n_confirmed`` and the
-    # generator's ``_rollback_draft`` can restore them on draft
-    # rejection. Without this the linear-attention layers' SSM state
-    # drifts on every reject and the LOSSLESS contract fails within
-    # ~10 tokens at temp=0. Idempotent — safe to call multiple times.
-    from .cache_patch import (
-        patch_arrays_cache_rollback_state,
-        patch_gated_delta_net_for_mtp,
-    )
-
-    patch_arrays_cache_rollback_state()
-    patch_gated_delta_net_for_mtp()
+    # NOTE: the global ``ArraysCache`` rollback_state class-default and
+    # the ``GatedDeltaNet.__call__`` chunk-split patches are deferred
+    # until AFTER every can-fail validation completes (see ``# --- Step
+    # 4`` below). Codex flagged on PR #954 that installing these
+    # monkey-patches up-front meant a failed sidecar load left
+    # process-global behavior mutated even though inject_mtp_support
+    # returned False. The patches are now strictly post-validation.
 
     inner = _resolve_inner_text_model(model)
     if inner is None:
@@ -386,7 +386,21 @@ def inject_mtp_support(model: Any, mtp_sidecar: str | Path | None = None) -> boo
             "equivalent) to load real weights."
         )
 
-    # --- Step 4: Attach + monkey-patch ``TextModel`` class ---
+    # --- Step 4: Install global ArraysCache + GatedDeltaNet patches ---
+    # Deferred from the top of this function so a failed validation /
+    # sidecar load (above) leaves the process global state untouched.
+    # Both patches are idempotent + transparent at n_confirmed=0, so
+    # a successful inject_mtp_support that runs after a failed one
+    # still lands cleanly.
+    from .cache_patch import (
+        patch_arrays_cache_rollback_state,
+        patch_gated_delta_net_for_mtp,
+    )
+
+    patch_arrays_cache_rollback_state()
+    patch_gated_delta_net_for_mtp()
+
+    # --- Step 5: Attach + monkey-patch ``TextModel`` class ---
     inner.mtp = mtp
     original_class = type(inner)
 

--- a/vllm_mlx/spec_decode/mtp/qwen3_5_inject.py
+++ b/vllm_mlx/spec_decode/mtp/qwen3_5_inject.py
@@ -16,29 +16,39 @@ runtime injection used by ``--enable-mtp``):
    delegated to :func:`vllm_mlx.spec_decode.mtp.head.build_mtp_module`.
 2. Quantize the MTP module to match the base model's quantization (so
    the weight tensors land in the right shape for ``load_weights``).
-3. Load the ``mtp.*`` weights from ``model.safetensors`` (or
-   ``model-mtp.safetensors`` when the converter split them out).
+3. Load the MTP weights from a separate ``mtp_sidecar`` checkpoint —
+   ``mlx-community/Qwen3.5-9B-MTP-4bit`` ships the head as a 131 MB
+   standalone safetensors file with top-level keys (``fc.*``,
+   ``layers.0.*``, ``norm.weight``, ``pre_fc_norm_{hidden,embedding}.weight``).
 4. Monkey-patch the ``TextModel`` instance's ``__class__`` to a
-   subclass that adds the four MTP surfaces.
+   subclass that adds the four MTP surfaces (``__call__`` with
+   ``return_hidden``/``n_confirmed``, ``mtp_forward``,
+   ``make_mtp_cache``).
 
 Coverage scope
 --------------
 
-In-scope: the dense ``TextModel`` (``mlx_lm.models.qwen3_5.TextModel``)
-and its MoE subclass (``mlx_lm.models.qwen3_5_moe.Model``). Both
-expose ``self.model`` (the underlying ``Qwen3_5TextModel``),
-``self.args``, ``self.lm_head`` (or tied embeddings), and ``self.layers``
-— enough for the patch to wire up identically.
+In-scope: the dense ``TextModel`` (``mlx_lm.models.qwen3_5.TextModel``),
+its MoE subclass (``mlx_lm.models.qwen3_5_moe.Model``), and the VLM
+wrapper (``mlx_lm.models.qwen3_5.Model``) where the text model is
+nested under ``model.language_model``. The patch always targets the
+inner ``TextModel`` — never the outer VLM wrapper (whose ``__call__``
+just delegates).
 
-Out-of-scope: VLM wrappers (no Qwen3.5/3.6 VLM has shipped MTP weights
-yet), pipeline-parallel splits (PR #990 supports them upstream but
-adapting the patch is a follow-up — the operator can boot single-
-device for MTP in the meantime).
+Out-of-scope: ``n_confirmed`` is accepted on ``__call__`` for ABI
+parity with PR #990 but is currently a no-op below the wrapper —
+proper rollback of ``GatedDeltaNet`` SSM/conv state at the confirmed
+boundary requires patching the layer's forward (tracked separately).
+Linear-attention cache state may drift on draft rejection; this is a
+known limitation that affects only the LOSSLESS contract on the
+hybrid (GatedDeltaNet) attention layers, not the full-attention
+layers or the throughput measurement.
 """
 
 from __future__ import annotations
 
 import logging
+from pathlib import Path
 from typing import Any
 
 logger = logging.getLogger(__name__)
@@ -47,75 +57,227 @@ logger = logging.getLogger(__name__)
 def _resolve_inner_text_model(model: Any) -> Any:
     """Return the ``TextModel`` instance the patch must monkey-patch.
 
-    The dense Qwen3.5 / 3.6 model is itself the ``TextModel``. The MoE
-    model subclasses ``Qwen3_5Model`` (which IS the dense TextModel)
-    so this is just ``model``. A VLM wrapper would expose
-    ``model.language_model`` — we don't support that path yet but the
-    shape check is here so the failure mode is a clear log line
-    rather than an AttributeError mid-forward.
+    For mlx-lm 0.31.3's Qwen3.5 architecture, ``mlx_lm.load(...)``
+    returns the VLM-style ``Model`` wrapper whose ``language_model``
+    field is the actual ``TextModel`` (carrying ``embed_tokens``,
+    ``lm_head``, the ``model.layers`` backbone, and ``args``). The
+    wrapper itself only has ``args = ModelArgs(model_type,
+    text_config)`` and a delegating ``__call__`` — patching it would
+    leave ``self.model.embed_tokens`` undefined for the injected
+    ``mtp_forward``.
+
+    Three shapes are accepted:
+
+    * The outer VLM-style ``Model`` with ``model.language_model`` (real
+      runtime path).
+    * The inner ``TextModel`` itself (the test path constructs this
+      directly to avoid the heavy VLM init).
+    * A custom shell that exposes ``args`` + ``model`` and where
+      ``args`` has either ``hidden_size`` (the inner-TextModel-like
+      shape) or ``mtp_num_hidden_layers`` (the explicit-test shape).
+      Used by ``test_inject_mtp_support_rejects_*`` paths.
     """
+    # Case 1: VLM wrapper — text model lives under ``language_model``.
+    lm = getattr(model, "language_model", None)
+    if lm is not None and hasattr(lm, "args") and hasattr(lm, "model"):
+        return lm
+
+    # Case 2: Already the inner TextModel (or a test shell). The inner
+    # TextModel exposes both ``model`` (the backbone) and ``args``.
     if hasattr(model, "model") and hasattr(model, "args"):
         return model
-
-    inner = getattr(model, "language_model", None)
-    if inner is not None and hasattr(inner, "args"):
-        logger.warning(
-            "[mtp.inject] Qwen3.5/3.6 + VLM wrapper not yet supported. "
-            "MTP is only wired for the text-only model class."
-        )
-        return None
 
     return None
 
 
-def inject_mtp_support(model: Any) -> bool:
+def _detect_base_quantization(inner: Any) -> dict | None:
+    """Detect the quantization params used by the base model.
+
+    Walks the inner ``TextModel`` looking for a ``QuantizedLinear``
+    instance and reads its ``bits`` / ``group_size`` / ``mode``. The
+    MTP module must be quantized with the same params so its weight
+    shapes match the sidecar's safetensors layout (4-bit / group_size
+    64 / affine for ``mlx-community/Qwen3.5-9B-MTP-4bit``).
+
+    Returns ``None`` for FP base models — the caller skips quantize
+    in that case.
+    """
+    try:
+        from mlx.nn import QuantizedEmbedding, QuantizedLinear
+    except ImportError:  # pragma: no cover — mlx.nn always available
+        return None
+
+    backbone = getattr(inner, "model", None)
+    if backbone is None:
+        return None
+
+    # Try a full-attention layer's q_proj first (always present + quantized).
+    for layer in getattr(backbone, "layers", []):
+        if hasattr(layer, "self_attn") and hasattr(layer.self_attn, "q_proj"):
+            qp = layer.self_attn.q_proj
+            if isinstance(qp, QuantizedLinear):
+                return {
+                    "bits": int(qp.bits),
+                    "group_size": int(qp.group_size),
+                    "mode": getattr(qp, "mode", "affine"),
+                }
+
+    # Fall back: embed_tokens (QuantizedEmbedding has bits/group_size too).
+    embed = getattr(backbone, "embed_tokens", None)
+    if isinstance(embed, QuantizedEmbedding):
+        return {
+            "bits": int(embed.bits),
+            "group_size": int(embed.group_size),
+            "mode": getattr(embed, "mode", "affine"),
+        }
+
+    return None
+
+
+def _resolve_sidecar_dir(mtp_sidecar: str | Path) -> Path | None:
+    """Resolve a sidecar reference to a local directory.
+
+    Accepts either:
+
+    * An absolute / relative path to a directory or safetensors file
+      (used by tests and operators with pre-downloaded weights).
+    * An HF Hub repo name like ``mlx-community/Qwen3.5-9B-MTP-4bit``
+      (downloaded via ``snapshot_download`` to the HF cache).
+
+    Returns ``None`` if the reference cannot be resolved — caller
+    treats this as a soft failure and logs.
+    """
+    if mtp_sidecar is None:
+        return None
+
+    path = Path(mtp_sidecar)
+    if path.exists():
+        return path if path.is_dir() else path.parent
+
+    # Treat as HF repo id.
+    try:
+        from huggingface_hub import snapshot_download
+
+        local = snapshot_download(repo_id=str(mtp_sidecar))
+        return Path(local)
+    except Exception as exc:  # pragma: no cover — network failure path
+        logger.warning(
+            "[mtp.inject] could not resolve sidecar %r: %s",
+            mtp_sidecar,
+            exc,
+        )
+        return None
+
+
+def _find_mtp_weights_file(sidecar_dir: Path) -> Path | None:
+    """Pick the safetensors file inside ``sidecar_dir`` that holds the MTP head.
+
+    The mlx-community ``Qwen3.5-9B-MTP-4bit`` repo ships
+    ``model.safetensors`` (single shard, 131 MB, 31 keys, no ``mtp.``
+    prefix). Other vendors may ship ``model-mtp.safetensors`` (the
+    Qwen3-Next convention used by ``add_mtp_weights.py``). Try both.
+    """
+    candidates = (
+        sidecar_dir / "model-mtp.safetensors",
+        sidecar_dir / "model.safetensors",
+    )
+    for c in candidates:
+        if c.exists():
+            return c
+    return None
+
+
+def inject_mtp_support(model: Any, mtp_sidecar: str | Path | None = None) -> bool:
     """Inject MTP support into a loaded Qwen3.5 / Qwen3.6 model.
 
     Args:
-        model: A model loaded via ``mlx_lm.load()``. Must be a
-            ``mlx_lm.models.qwen3_5.TextModel`` or its MoE subclass
-            from ``qwen3_5_moe.Model``. Other architectures raise
-            no-op early (returns ``False``).
+        model: A model loaded via ``mlx_lm.load()``. Either the VLM
+            wrapper ``Model`` (with ``model.language_model``) or the
+            inner ``TextModel`` directly (tests pass this shape).
+        mtp_sidecar: Optional reference to a separate checkpoint
+            holding the MTP head's safetensors. Accepts an HF Hub
+            repo id (``mlx-community/Qwen3.5-9B-MTP-4bit``) or a local
+            directory path. When ``None``, the MTP module is built
+            and quantized but RETAINS RANDOM INIT weights — the
+            patched ``mtp_forward`` will produce useless drafts
+            (accept rate ~0%). Used only by unit tests that pin
+            wiring + surfaces without paying the 131 MB download
+            cost. **Production callers (bench, server boot) MUST
+            pass a sidecar** to get real speedup.
 
     Returns:
         ``True`` when the patch landed and the model now exposes
         ``mtp_forward``, ``make_mtp_cache``, ``return_hidden``, and
         ``n_confirmed`` — the four contract surfaces
         :func:`vllm_mlx.spec_decode.mtp.generator.mtp_generate_step`
-        depends on. ``False`` when the model is not Qwen3.5 / 3.6 or
-        the MTP weights are not present in the checkpoint (operator
-        must re-convert from HF with PR #990's ``sanitize()`` path
-        that preserves ``mtp.*`` keys).
+        depends on. ``False`` when the model is not Qwen3.5 / 3.6,
+        the config lacks ``mtp_num_hidden_layers``, or the sidecar
+        cannot be resolved.
 
     Notes:
-        The function does NOT touch the ``ArraysCache.rollback_state``
-        slot — that patch is installed once at module import time by
-        :func:`vllm_mlx.spec_decode.mtp.cache_patch.patch_arrays_cache_rollback_state`,
-        and is independent of which model instance is patched here.
+        ``n_confirmed`` is accepted on the patched ``__call__`` for
+        ABI parity with PR #990 but does NOT thread through to the
+        ``GatedDeltaNet`` SSM rollback path (that requires patching
+        the layer's forward; tracked separately). This affects
+        lossless on draft rejection through linear-attention layers
+        only.
     """
     import mlx.core as mx
+    import mlx.nn as nn
+
+    # Install the GatedDeltaNet chunk-split patch so the verify forward
+    # snapshots ``(conv_state, ssm_state)`` at ``n_confirmed`` and the
+    # generator's ``_rollback_draft`` can restore them on draft
+    # rejection. Without this the linear-attention layers' SSM state
+    # drifts on every reject and the LOSSLESS contract fails within
+    # ~10 tokens at temp=0. Idempotent — safe to call multiple times.
+    from .cache_patch import (
+        patch_arrays_cache_rollback_state,
+        patch_gated_delta_net_for_mtp,
+    )
+
+    patch_arrays_cache_rollback_state()
+    patch_gated_delta_net_for_mtp()
 
     inner = _resolve_inner_text_model(model)
     if inner is None:
         logger.warning(
-            "[mtp.inject] model %s is not a Qwen3.5/3.6 TextModel; "
-            "skipping MTP injection.",
+            "[mtp.inject] model %s has neither model.language_model nor "
+            "(model + args); skipping MTP injection.",
             type(model).__name__,
         )
         return False
 
     args = inner.args
-    num_mtp_layers = getattr(args, "mtp_num_hidden_layers", 0) or 0
+
+    # 1. Resolve num_mtp_layers. Prefer the dataclass attr (which
+    # tests set via object.__setattr__); fall back to the outer
+    # wrapper's text_config dict (the real runtime path — mlx-lm
+    # 0.31.3's TextModelArgs lacks ``mtp_num_hidden_layers`` so the
+    # field gets dropped during ``BaseModelArgs.from_dict``).
+    num_mtp_layers = int(getattr(args, "mtp_num_hidden_layers", 0) or 0)
+    if num_mtp_layers < 1:
+        outer_args = getattr(model, "args", None)
+        text_config = getattr(outer_args, "text_config", None) or {}
+        if isinstance(text_config, dict):
+            num_mtp_layers = int(text_config.get("mtp_num_hidden_layers", 0) or 0)
+        if num_mtp_layers >= 1:
+            # Surface it on the dataclass so downstream code (incl.
+            # validate_mtp_support, accept_counter labels) can read it
+            # off ``args.mtp_num_hidden_layers`` uniformly.
+            try:
+                object.__setattr__(args, "mtp_num_hidden_layers", num_mtp_layers)
+            except (TypeError, AttributeError):  # pragma: no cover — frozen
+                pass
+
     if num_mtp_layers < 1:
         logger.info(
-            "[mtp.inject] config has mtp_num_hidden_layers=%d; "
-            "skipping MTP injection (re-convert from HF with PR #990 "
-            "sanitize() path to preserve mtp.* weights).",
-            num_mtp_layers,
+            "[mtp.inject] config has no mtp_num_hidden_layers; "
+            "skipping MTP injection."
         )
         return False
 
-    # --- Step 1: Build the MTP module from the head vendored module ---
+    # --- Step 1: Build the MTP module from the vendored head ---
     from .head import build_mtp_module
 
     mtp = build_mtp_module(args, num_mtp_layers)
@@ -125,18 +287,85 @@ def inject_mtp_support(model: Any) -> bool:
         getattr(args, "hidden_size", -1),
     )
 
-    # --- Step 2: Attach to the inner model so weight load can resolve
-    # ``mtp.*`` keys against ``model.model.mtp.*`` paths the converter
-    # writes out. ``model.load_weights`` then routes them naturally.
-    inner.mtp = mtp
+    # --- Step 2: Quantize MTP to match the base model's quantization ---
+    quant_info = _detect_base_quantization(inner)
+    if quant_info is not None:
+        nn.quantize(
+            mtp,
+            group_size=quant_info["group_size"],
+            bits=quant_info["bits"],
+        )
+        logger.info(
+            "[mtp.inject] Quantized MTP: %d-bit, group_size=%d",
+            quant_info["bits"],
+            quant_info["group_size"],
+        )
 
-    # --- Step 3: Monkey-patch the model class to add the four MTP
-    # surfaces. We subclass ``type(model)`` so the patch composes with
-    # any other runtime patches (e.g. quantization wrappers).
+    # --- Step 3: Load MTP weights from sidecar safetensors ---
+    if mtp_sidecar is not None:
+        sidecar_dir = _resolve_sidecar_dir(mtp_sidecar)
+        if sidecar_dir is None:
+            logger.warning(
+                "[mtp.inject] sidecar %r could not be resolved; "
+                "skipping MTP injection.",
+                mtp_sidecar,
+            )
+            return False
+        weights_file = _find_mtp_weights_file(sidecar_dir)
+        if weights_file is None:
+            logger.warning(
+                "[mtp.inject] no model.safetensors / model-mtp.safetensors "
+                "found in %s; skipping MTP injection.",
+                sidecar_dir,
+            )
+            return False
+        raw = mx.load(str(weights_file))
+        # Some sidecars (Qwen3-Next ``add_mtp_weights.py`` output) prefix
+        # every key with ``mtp.``; others (mlx-community/Qwen3.5-9B-MTP-4bit)
+        # store at top-level. Strip the prefix if present so both shapes
+        # land on the MTP module's parameter tree.
+        mtp_weights = {
+            (k.removeprefix("mtp.") if k.startswith("mtp.") else k): v
+            for k, v in raw.items()
+        }
+        # ``strict=False`` so the load tolerates unrelated keys (rare,
+        # but defensive — converters occasionally bundle metadata).
+        mtp.load_weights(list(mtp_weights.items()), strict=False)
+        mx.eval(mtp.parameters())
+        logger.info(
+            "[mtp.inject] Loaded %d MTP weight tensors from %s",
+            len(mtp_weights),
+            weights_file.name,
+        )
+    else:
+        # No sidecar: leave the MTP module at random init. This is the
+        # test-only path — production callers MUST pass a sidecar.
+        mx.eval(mtp.parameters())
+        logger.warning(
+            "[mtp.inject] inject_mtp_support called without mtp_sidecar — "
+            "MTP head retains RANDOM init weights (accept rate ~0%%). "
+            "Pass mtp_sidecar='mlx-community/Qwen3.5-9B-MTP-4bit' (or "
+            "equivalent) to load real weights."
+        )
+
+    # --- Step 4: Attach + monkey-patch ``TextModel`` class ---
+    inner.mtp = mtp
     original_class = type(inner)
 
     class _Qwen3_5WithMTP(original_class):  # type: ignore[valid-type, misc]
-        """``TextModel`` + MTP surfaces injected by R15 #302 (vendor PR #990)."""
+        """``TextModel`` + MTP surfaces injected by R15 #302 (vendor PR #990).
+
+        The forward is inlined from
+        ``mlx_lm.models.qwen3_5.Qwen3_5TextModel.__call__`` so that:
+
+        * ``return_hidden=True`` can return the pre-norm hidden state
+          the MTP head consumes (the upstream forward returns only the
+          post-norm output).
+        * ``n_confirmed`` is accepted on the signature for ABI parity
+          with PR #990 (the generator passes ``n_confirmed=1`` during
+          verify forwards). It is currently a no-op below this layer
+          — the GatedDeltaNet rollback patch is tracked separately.
+        """
 
         def __call__(  # type: ignore[override]
             self,
@@ -146,23 +375,57 @@ def inject_mtp_support(model: Any) -> bool:
             return_hidden: bool = False,
             n_confirmed: int = 0,
         ):
-            # Delegate to the inner ``Qwen3_5TextModel`` so the
-            # backbone runs unchanged, but route ``n_confirmed``
-            # through every layer (so GatedDeltaNet's
-            # ``_process_chunk`` split fires at the right boundary).
-            hidden = self.model(
-                inputs,
-                cache=cache,
-                input_embeddings=input_embeddings,
-                n_confirmed=n_confirmed,
-            )
-            normed = self.model.norm(hidden)
+            from mlx_lm.models.base import create_attention_mask, create_ssm_mask
+
+            inner_m = self.model
+            if input_embeddings is not None:
+                hidden_states = input_embeddings
+            else:
+                hidden_states = inner_m.embed_tokens(inputs)
+            if cache is None:
+                cache = [None] * len(inner_m.layers)
+
+            # Tag each ArraysCache (linear-attention) with the
+            # confirmed boundary so the patched GatedDeltaNet splits
+            # ``gated_delta_update`` into two chunks and writes
+            # ``(conv_snap, ssm_snap)`` to ``cache.rollback_state``.
+            # KVCache slots ignore the tag — their rollback is the
+            # existing ``c.trim(1)`` path. Tagged values are cleared
+            # in the ``finally`` block so a later non-MTP forward
+            # (mtp_forward, prefill, etc.) on the same cache list
+            # doesn't accidentally re-trigger a split.
+            if n_confirmed > 0:
+                for c in cache:
+                    if c is not None and hasattr(c, "rollback_state"):
+                        c.n_confirmed_for_mtp = n_confirmed
+
+            try:
+                fa_mask = create_attention_mask(
+                    hidden_states, cache[inner_m.fa_idx]
+                )
+                ssm_mask = create_ssm_mask(
+                    hidden_states, cache[inner_m.ssm_idx]
+                )
+                for layer, c in zip(inner_m.layers, cache):
+                    mask = ssm_mask if layer.is_linear else fa_mask
+                    hidden_states = layer(hidden_states, mask=mask, cache=c)
+            finally:
+                if n_confirmed > 0:
+                    for c in cache:
+                        if c is not None and hasattr(c, "n_confirmed_for_mtp"):
+                            c.n_confirmed_for_mtp = 0
+
+            # Return PRE-norm hidden so MTP can apply its own
+            # ``pre_fc_norm_hidden`` — matches PR #990's contract that
+            # ``mtp_forward(hidden, ...)`` consumes pre-norm hidden.
+            normed = inner_m.norm(hidden_states)
             if self.args.tie_word_embeddings:
-                out = self.model.embed_tokens.as_linear(normed)
+                out = inner_m.embed_tokens.as_linear(normed)
             else:
                 out = self.lm_head(normed)
+
             if return_hidden:
-                return out, hidden
+                return out, hidden_states
             return out
 
         def mtp_forward(
@@ -189,7 +452,6 @@ def inject_mtp_support(model: Any) -> bool:
             return [KVCache() for _ in self.mtp.layers]
 
     inner.__class__ = _Qwen3_5WithMTP
-    mx.eval(mtp.parameters())
     logger.info(
         "[mtp.inject] Patched %s with MTP surfaces "
         "(return_hidden, n_confirmed, mtp_forward, make_mtp_cache).",

--- a/vllm_mlx/spec_decode/mtp/qwen3_5_inject.py
+++ b/vllm_mlx/spec_decode/mtp/qwen3_5_inject.py
@@ -248,12 +248,21 @@ def inject_mtp_support(
         ``allow_random_init`` is ``False``.
 
     Notes:
-        ``n_confirmed`` is accepted on the patched ``__call__`` for
-        ABI parity with PR #990 but does NOT thread through to the
-        ``GatedDeltaNet`` SSM rollback path (that requires patching
-        the layer's forward; tracked separately). This affects
-        lossless on draft rejection through linear-attention layers
-        only.
+        This function is NEW in this PR (Qwen3.5 native MTP). It is
+        NOT the legacy ``vllm_mlx.patches.qwen3_next_mtp.inject_mtp_support``
+        used by the scheduler (different signature, different model
+        family, different load path). The only production caller of
+        this function is ``bench/bench_spec_decode_mtp.py`` (which
+        already passes ``mtp_sidecar``). There are no pre-existing
+        bare ``inject_mtp_support(model)`` call-sites to break with
+        the new ``allow_random_init=False`` default.
+
+        ``n_confirmed`` rollback is implemented as of this PR: it
+        threads through to each ``ArraysCache`` via
+        ``n_confirmed_for_mtp`` before forward, so the patched
+        ``GatedDeltaNet.__call__`` (installed by
+        ``patch_gated_delta_net_for_mtp``) can snapshot
+        ``(conv_state, ssm_state)`` AT the confirmed-token boundary.
     """
     import mlx.core as mx
     import mlx.nn as nn

--- a/vllm_mlx/spec_decode/mtp/qwen3_5_inject.py
+++ b/vllm_mlx/spec_decode/mtp/qwen3_5_inject.py
@@ -272,8 +272,7 @@ def inject_mtp_support(model: Any, mtp_sidecar: str | Path | None = None) -> boo
 
     if num_mtp_layers < 1:
         logger.info(
-            "[mtp.inject] config has no mtp_num_hidden_layers; "
-            "skipping MTP injection."
+            "[mtp.inject] config has no mtp_num_hidden_layers; skipping MTP injection."
         )
         return False
 
@@ -400,12 +399,8 @@ def inject_mtp_support(model: Any, mtp_sidecar: str | Path | None = None) -> boo
                         c.n_confirmed_for_mtp = n_confirmed
 
             try:
-                fa_mask = create_attention_mask(
-                    hidden_states, cache[inner_m.fa_idx]
-                )
-                ssm_mask = create_ssm_mask(
-                    hidden_states, cache[inner_m.ssm_idx]
-                )
+                fa_mask = create_attention_mask(hidden_states, cache[inner_m.fa_idx])
+                ssm_mask = create_ssm_mask(hidden_states, cache[inner_m.ssm_idx])
                 for layer, c in zip(inner_m.layers, cache):
                     mask = ssm_mask if layer.is_linear else fa_mask
                     hidden_states = layer(hidden_states, mask=mask, cache=c)

--- a/vllm_mlx/spec_decode/mtp/qwen3_5_inject.py
+++ b/vllm_mlx/spec_decode/mtp/qwen3_5_inject.py
@@ -134,15 +134,21 @@ def _detect_base_quantization(inner: Any) -> dict | None:
     return None
 
 
-def _resolve_sidecar_dir(mtp_sidecar: str | Path) -> Path | None:
-    """Resolve a sidecar reference to a local directory.
+def _resolve_sidecar_file(mtp_sidecar: str | Path) -> Path | None:
+    """Resolve a sidecar reference to a concrete safetensors file path.
 
-    Accepts either:
+    Accepts:
 
-    * An absolute / relative path to a directory or safetensors file
-      (used by tests and operators with pre-downloaded weights).
+    * An absolute / relative path to a directory containing a
+      ``model.safetensors`` or ``model-mtp.safetensors`` file
+      (operators with a pre-downloaded HF snapshot).
+    * An absolute / relative path to a ``*.safetensors`` file
+      directly (operators with a hand-assembled sidecar; the
+      filename does NOT have to be one of the two well-known
+      names).
     * An HF Hub repo name like ``mlx-community/Qwen3.5-9B-MTP-4bit``
-      (downloaded via ``snapshot_download`` to the HF cache).
+      (downloaded via ``snapshot_download`` to the HF cache, then
+      probed for ``model.safetensors`` / ``model-mtp.safetensors``).
 
     Returns ``None`` if the reference cannot be resolved — caller
     treats this as a soft failure and logs.
@@ -151,15 +157,23 @@ def _resolve_sidecar_dir(mtp_sidecar: str | Path) -> Path | None:
         return None
 
     path = Path(mtp_sidecar)
-    if path.exists():
-        return path if path.is_dir() else path.parent
+    if path.is_file():
+        # Explicit file path — use it verbatim. Supports operator
+        # workflows where the sidecar lives at a custom filename
+        # (``mtp-q4-g64.safetensors``, ``qwen3_5_mtp_head.safetensors``,
+        # …). Skipping the well-known-name probe avoids the silent
+        # "file is at a non-default name → fall back to None" trap
+        # codex flagged on PR #954 review.
+        return path
+    if path.is_dir():
+        return _find_mtp_weights_file(path)
 
     # Treat as HF repo id.
     try:
         from huggingface_hub import snapshot_download
 
         local = snapshot_download(repo_id=str(mtp_sidecar))
-        return Path(local)
+        return _find_mtp_weights_file(Path(local))
     except Exception as exc:  # pragma: no cover — network failure path
         logger.warning(
             "[mtp.inject] could not resolve sidecar %r: %s",
@@ -302,20 +316,15 @@ def inject_mtp_support(model: Any, mtp_sidecar: str | Path | None = None) -> boo
 
     # --- Step 3: Load MTP weights from sidecar safetensors ---
     if mtp_sidecar is not None:
-        sidecar_dir = _resolve_sidecar_dir(mtp_sidecar)
-        if sidecar_dir is None:
-            logger.warning(
-                "[mtp.inject] sidecar %r could not be resolved; "
-                "skipping MTP injection.",
-                mtp_sidecar,
-            )
-            return False
-        weights_file = _find_mtp_weights_file(sidecar_dir)
+        weights_file = _resolve_sidecar_file(mtp_sidecar)
         if weights_file is None:
             logger.warning(
-                "[mtp.inject] no model.safetensors / model-mtp.safetensors "
-                "found in %s; skipping MTP injection.",
-                sidecar_dir,
+                "[mtp.inject] sidecar %r could not be resolved to a "
+                "safetensors file; skipping MTP injection. "
+                "Pass either a repo id (mlx-community/Qwen3.5-9B-MTP-4bit), "
+                "a directory containing model.safetensors / "
+                "model-mtp.safetensors, or the file path directly.",
+                mtp_sidecar,
             )
             return False
         raw = mx.load(str(weights_file))

--- a/vllm_mlx/spec_decode/mtp/qwen3_5_inject.py
+++ b/vllm_mlx/spec_decode/mtp/qwen3_5_inject.py
@@ -207,7 +207,12 @@ def _find_mtp_weights_file(sidecar_dir: Path) -> Path | None:
     return None
 
 
-def inject_mtp_support(model: Any, mtp_sidecar: str | Path | None = None) -> bool:
+def inject_mtp_support(
+    model: Any,
+    mtp_sidecar: str | Path | None = None,
+    *,
+    allow_random_init: bool = False,
+) -> bool:
     """Inject MTP support into a loaded Qwen3.5 / Qwen3.6 model.
 
     Args:
@@ -216,14 +221,19 @@ def inject_mtp_support(model: Any, mtp_sidecar: str | Path | None = None) -> boo
             inner ``TextModel`` directly (tests pass this shape).
         mtp_sidecar: Optional reference to a separate checkpoint
             holding the MTP head's safetensors. Accepts an HF Hub
-            repo id (``mlx-community/Qwen3.5-9B-MTP-4bit``) or a local
-            directory path. When ``None``, the MTP module is built
-            and quantized but RETAINS RANDOM INIT weights — the
-            patched ``mtp_forward`` will produce useless drafts
-            (accept rate ~0%). Used only by unit tests that pin
-            wiring + surfaces without paying the 131 MB download
-            cost. **Production callers (bench, server boot) MUST
-            pass a sidecar** to get real speedup.
+            repo id (``mlx-community/Qwen3.5-9B-MTP-4bit``), a local
+            directory path, or a direct path to a ``.safetensors``
+            file.
+        allow_random_init: When ``True``, permit ``mtp_sidecar=None``
+            and ship the MTP head with its RANDOM INIT weights (the
+            patched ``mtp_forward`` produces useless drafts, accept
+            rate ~0%). Test-only. Codex flagged on PR #954 that
+            allowing this by default lets production callers silently
+            enable a useless/slow draft model, so the default is
+            ``False`` — a missing sidecar in production now returns
+            ``False`` from this function and the model is left
+            unmodified. The bench, server boot, and the rapid-mlx
+            spec_decode pipeline MUST pass a sidecar.
 
     Returns:
         ``True`` when the patch landed and the model now exposes
@@ -231,8 +241,9 @@ def inject_mtp_support(model: Any, mtp_sidecar: str | Path | None = None) -> boo
         ``n_confirmed`` — the four contract surfaces
         :func:`vllm_mlx.spec_decode.mtp.generator.mtp_generate_step`
         depends on. ``False`` when the model is not Qwen3.5 / 3.6,
-        the config lacks ``mtp_num_hidden_layers``, or the sidecar
-        cannot be resolved.
+        the config lacks ``mtp_num_hidden_layers``, the sidecar
+        cannot be resolved, or ``mtp_sidecar`` is ``None`` and
+        ``allow_random_init`` is ``False``.
 
     Notes:
         ``n_confirmed`` is accepted on the patched ``__call__`` for
@@ -376,14 +387,31 @@ def inject_mtp_support(model: Any, mtp_sidecar: str | Path | None = None) -> boo
             f" (+{len(extra)} extra sidecar key(s) ignored)" if extra else "",
         )
     else:
-        # No sidecar: leave the MTP module at random init. This is the
-        # test-only path — production callers MUST pass a sidecar.
+        # No sidecar.
+        if not allow_random_init:
+            # Codex round-5 BLOCKING fix: default is fail-closed. A
+            # missing sidecar in production silently enabled a draft
+            # model with random init weights (~0% accept rate) —
+            # invisible regression that LOOKS like spec-decode is
+            # running but emits zero speedup. Refuse the inject.
+            logger.warning(
+                "[mtp.inject] inject_mtp_support called without "
+                "mtp_sidecar and allow_random_init=False; refusing to "
+                "ship a random-init MTP head. Pass "
+                "mtp_sidecar='mlx-community/Qwen3.5-9B-MTP-4bit' (or "
+                "equivalent) for production use, or set "
+                "allow_random_init=True for unit-test wiring probes."
+            )
+            return False
+        # Test-only path — explicit opt-in to random-init weights for
+        # wiring tests that pin the surfaces without paying the
+        # 131 MB sidecar download cost.
         mx.eval(mtp.parameters())
         logger.warning(
-            "[mtp.inject] inject_mtp_support called without mtp_sidecar — "
-            "MTP head retains RANDOM init weights (accept rate ~0%%). "
-            "Pass mtp_sidecar='mlx-community/Qwen3.5-9B-MTP-4bit' (or "
-            "equivalent) to load real weights."
+            "[mtp.inject] inject_mtp_support called with "
+            "allow_random_init=True — MTP head retains RANDOM init "
+            "weights (accept rate ~0%%). This is the test-only path; "
+            "do not use in production."
         )
 
     # --- Step 4: Install global ArraysCache + GatedDeltaNet patches ---

--- a/vllm_mlx/spec_decode/mtp/qwen3_5_inject.py
+++ b/vllm_mlx/spec_decode/mtp/qwen3_5_inject.py
@@ -35,14 +35,16 @@ nested under ``model.language_model``. The patch always targets the
 inner ``TextModel`` — never the outer VLM wrapper (whose ``__call__``
 just delegates).
 
-Out-of-scope: ``n_confirmed`` is accepted on ``__call__`` for ABI
-parity with PR #990 but is currently a no-op below the wrapper —
-proper rollback of ``GatedDeltaNet`` SSM/conv state at the confirmed
-boundary requires patching the layer's forward (tracked separately).
-Linear-attention cache state may drift on draft rejection; this is a
-known limitation that affects only the LOSSLESS contract on the
-hybrid (GatedDeltaNet) attention layers, not the full-attention
-layers or the throughput measurement.
+``n_confirmed`` rollback: implemented as of this PR. ``__call__``
+accepts ``n_confirmed`` and threads it through to each
+``ArraysCache`` via ``n_confirmed_for_mtp`` before the forward, so
+the patched ``GatedDeltaNet.__call__`` (installed by
+``patch_gated_delta_net_for_mtp``) can snapshot ``(conv_state,
+ssm_state)`` AT the confirmed-token boundary. On draft rejection the
+generator's ``_rollback_draft`` restores the snapshot per cache
+instance. Lossless contract confirmed byte-equal × 3 profiles on
+mlx-community/Qwen3.5-9B-4bit + mlx-community/Qwen3.5-9B-MTP-4bit
+(see ``tests/test_mtp_real_weights.py``).
 """
 
 from __future__ import annotations
@@ -522,7 +524,21 @@ def inject_mtp_support(
             return self.lm_head(mtp_out)
 
         def make_mtp_cache(self):
-            """Return fresh ``KVCache`` entries — one per MTP layer."""
+            """Return fresh ``KVCache`` entries — one per MTP layer.
+
+            All MTP layers are full-attention by design (PR #990's
+            ``MTPDecoderLayer`` is hard-coded to ``self_attn =
+            Attention(...)`` — see ``vllm_mlx/spec_decode/mtp/head.py``
+            line 89-115). The MTP head deliberately does NOT include
+            ``GatedDeltaNet`` linear-attention layers (the backbone's
+            hybrid layout via ``args.full_attention_interval`` does not
+            apply here). So ``KVCache`` is correct for every MTP layer
+            — there are no ``ArraysCache`` slots to maintain on this
+            side of the rollback. The ``ArraysCache.rollback_state``
+            machinery installed by this PR exists to handle the
+            BACKBONE's linear-attention layers (where the GatedDeltaNet
+            patch lives), not the MTP head.
+            """
             from mlx_lm.models.cache import KVCache
 
             return [KVCache() for _ in self.mtp.layers]

--- a/vllm_mlx/spec_decode/mtp/qwen3_5_inject.py
+++ b/vllm_mlx/spec_decode/mtp/qwen3_5_inject.py
@@ -336,14 +336,44 @@ def inject_mtp_support(model: Any, mtp_sidecar: str | Path | None = None) -> boo
             (k.removeprefix("mtp.") if k.startswith("mtp.") else k): v
             for k, v in raw.items()
         }
-        # ``strict=False`` so the load tolerates unrelated keys (rare,
-        # but defensive — converters occasionally bundle metadata).
+        # Pre-load coverage check: codex flagged on PR #954 that
+        # ``strict=False`` lets the load silently succeed even when
+        # sidecar tensors are missing or misspelled — leaving part of
+        # the MTP head random-init while inject_mtp_support still
+        # returns True. Compute the expected parameter key set off
+        # ``mtp.parameters()`` (post-quantize, so ``weight`` /
+        # ``scales`` / ``biases`` for QuantizedLinear layers) and
+        # refuse the inject if any required tensor is missing.
+        from mlx.utils import tree_flatten
+
+        expected_keys = {k for k, _ in tree_flatten(mtp.parameters())}
+        loaded_keys = set(mtp_weights.keys())
+        missing = expected_keys - loaded_keys
+        if missing:
+            logger.warning(
+                "[mtp.inject] sidecar %s is missing %d required MTP "
+                "tensor(s); refusing to ship a partially-random-init head. "
+                "Missing keys (first 8): %s. "
+                "Either grab a correctly-converted sidecar (e.g. "
+                "mlx-community/Qwen3.5-9B-MTP-4bit) or regenerate via "
+                "the add_mtp_weights.py converter.",
+                weights_file.name,
+                len(missing),
+                sorted(missing)[:8],
+            )
+            return False
+        # ``strict=False`` still — we deliberately tolerate EXTRA
+        # keys (metadata blobs some converters bundle), but the
+        # coverage check above proves no required key is missing.
         mtp.load_weights(list(mtp_weights.items()), strict=False)
         mx.eval(mtp.parameters())
+        extra = loaded_keys - expected_keys
         logger.info(
-            "[mtp.inject] Loaded %d MTP weight tensors from %s",
-            len(mtp_weights),
+            "[mtp.inject] Loaded %d/%d expected MTP weight tensors from %s%s",
+            len(expected_keys),
+            len(expected_keys),
             weights_file.name,
+            f" (+{len(extra)} extra sidecar key(s) ignored)" if extra else "",
         )
     else:
         # No sidecar: leave the MTP module at random init. This is the


### PR DESCRIPTION
## Summary

The 0.9 MTP injection pipeline was structurally incomplete — it built a fresh MTP module from scratch but never quantized it or loaded the `mtp.*` weights. The working sibling `vllm_mlx/patches/qwen3_next_mtp.py:108-200` has both steps; this PR ports them into `vllm_mlx/spec_decode/mtp/qwen3_5_inject.py`.

Three compounding defects shipped together (each independently blocked the bench):

1. **VLM-wrapper resolution wrong** — mlx-lm 0.31.3 always loads Qwen3.5 as `Model(language_model=TextModel)`. The original `_resolve_inner_text_model` (qwen3_5_inject.py:47-68) short-circuited to "VLM not supported" and returned None before any MTP work fired.
2. **`mtp_num_hidden_layers` lookup wrong** — the field lives under `text_config` in config.json but `BaseModelArgs.from_dict` silently drops unknown fields, so `args.mtp_num_hidden_layers` was always 0 and inject bailed at the gate at line 109.
3. **No quantize, no sidecar load** — even if (1)+(2) passed, the MTP head was random-init; accept rate would be ~0%.

Compounding factor: mlx-lm 0.31.3 `qwen3_5.py:313` unconditionally strips `mtp.*` in `sanitize()` during the main `mlx_lm.load`. Loading from a separate sidecar blob (`mlx-community/Qwen3.5-9B-MTP-4bit`, 131 MB, 31 keys, no `mtp.` prefix) AFTER the main load completes is the correct workaround — no upstream patch required.

Plus a separately-needed runtime patch for lossless: `cache_patch.patch_gated_delta_net_for_mtp` wraps `GatedDeltaNet.__call__` with a chunk-split version that splits `gated_delta_update` at the `n_confirmed=1` boundary and writes `(conv_state, ssm_state)` snapshot to `cache.rollback_state`. The existing `_rollback_draft` path in `generator.py` consumes the snapshot. Without it, lossless byte-equal diverged within ~10 tokens at temp=0 (linear-attention SSM state drifted on the first reject).

## Defect file:line references

- Broken: `vllm_mlx/spec_decode/mtp/qwen3_5_inject.py:118-198` (pre-fix)
- Working sibling template: `vllm_mlx/patches/qwen3_next_mtp.py:108-200`
- Sanitize strip: `.venv/lib/python3.12/site-packages/mlx_lm/models/qwen3_5.py:313`
- Test gap: `tests/test_mtp_spec_decode.py:633-651` (uses synthetic `_build_tiny_qwen3_5_text_model`), `tests/test_mtp_lossless.py:180+` (uses `_LosslessTestModule` stub)

## What was ported / added

- `inject_mtp_support(model, mtp_sidecar=None)` — new signature takes an optional sidecar (HF repo id or local path).
- Quantization auto-detected by walking the base model for a `QuantizedLinear` and reading bits/group_size/mode.
- Sidecar weights load via `mx.load(model.safetensors)` -> `mtp.load_weights(strict=False)`.
- `_resolve_inner_text_model` now correctly returns `model.language_model` for the VLM wrapper case.
- `text_config["mtp_num_hidden_layers"]` fallback when the args dataclass strips it.
- `bench/bench_spec_decode_mtp.py` learns `--mtp-sidecar` flag with `_DEFAULT_MTP_SIDECAR` map.
- `cache_patch.patch_gated_delta_net_for_mtp` — chunk-split rollback patch (idempotent, transparent when `n_confirmed=0`).

## Bench evidence (M3 Ultra, mlx-community/Qwen3.5-9B-4bit + sidecar, temp=0, 200 toks)

3 runs each, medians:

| profile | baseline | mtp | speedup | accept |
|---|---|---|---|---|
| chat | 82.4 t/s | 94.5 | 1.15x | 77.7% |
| code | 89.6 | 89.4 | 1.00x | 79.3% |
| math | 86.8 | 91.5 | 1.05x | 90.5% |

**1.5x is unreachable on this hardware/model combo.** Per-cycle probe: baseline 10.05 ms/step, MTP cycle (verify + mtp_forward) 15.4 ms with chunk-split rollback. Theoretical ceiling at α=0.9 is `(1+α)*10/15.4 = 1.24x`. Qwen3.5-9B-4bit is too memory-bandwidth-bound for the 2-token verify forward to amortize against a fast single-token baseline. 27B-w4 (originally named in 0.9-TODO row 43) would amortize toward PR #990's reported 1.57x, but `mlx-community/Qwen3.5-27B-MTP-4bit` does not exist on HF and the only glue script (`scripts/add_mtp_weights.py`) supports Qwen3-Next, not Qwen3.5.

## Lossless verification

Real-weights test `tests/test_mtp_real_weights.py::test_mtp_lossless_byte_equal_against_baseline` — 20 tokens × 3 profiles (chat/code/math) MTP-vs-baseline byte-equal at temp=0. ALL PASS.

## Test plan

- [x] Existing 38 MTP unit tests still pass (`tests/test_mtp_spec_decode.py`, `tests/test_mtp_lossless.py`)
- [x] Existing 8 inject/install tests still pass (`tests/test_mtp_inject_and_install.py`)
- [x] New heavy test `tests/test_mtp_real_weights.py::test_inject_loads_real_sidecar_weights` PASSES — confirms `mtp.fc.weight` equals sidecar byte-for-byte (would catch the random-init defect that PR #918 shipped)
- [x] New heavy test `tests/test_mtp_real_weights.py::test_mtp_lossless_byte_equal_against_baseline` PASSES on chat/code/math at temp=0
- [x] Red->green proof: with this PR's changes stashed, the new tests ERROR with `TypeError: inject_mtp_support() got an unexpected keyword argument 'mtp_sidecar'`; with changes restored, both PASS
- [x] Bench `bench/bench_spec_decode_mtp.py --model mlx-community/Qwen3.5-9B-4bit --runs 1 --prompts 1 --max-tokens 30` returns real speedup (no longer "FAILED: MTP injection failed")
- [x] Per-cycle perf probe confirms 15.4 ms MTP cycle vs 10.05 ms baseline (hardware ceiling 1.24x at alpha=0.9, matches measured ~1.05x with generator Python overhead)

## Known limitations

- Speedup on Qwen3.5-9B-4bit at M3 Ultra is below the 0.9-TODO 1.5x gate (1.05-1.15x median). This is a hardware-level finding — the per-cycle MTP overhead (~5 ms) is too large relative to the 10 ms baseline single-token decode on this small/quantized model. Operators wanting 1.5x need a larger model (27B or 35B) where the verify-of-2 cost amortizes better.
- 27B-MTP-4bit sidecar publishing is a separate follow-up (needs a Qwen3.5-family extension to `scripts/add_mtp_weights.py`).
- `n_confirmed` parameter is accepted on the patched `TextModel.__call__` and threaded into `GatedDeltaNet` via `cache.n_confirmed_for_mtp` (no upstream `mlx-lm` changes needed). The chunk-split fires only for verify cycles where `S > n_confirmed > 0`; the original path is byte-equal in the fast (`n_confirmed=0`) path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)