### PR TITLE
fix(dflash/bench): rebuild driver around mlx-vlm 0.6.3, bench now runs (#343)

### DIFF
--- a/bench/bench_spec_decode_dflash.py
+++ b/bench/bench_spec_decode_dflash.py
@@ -222,6 +222,23 @@ def _parse_args() -> argparse.Namespace:
 def _resolve_prompt_indices(args: argparse.Namespace) -> list[int]:
     if args.prompt_indices.strip():
         ix = [int(x) for x in args.prompt_indices.split(",") if x.strip()]
+        # Reject duplicates — pooling the same prompt twice silently
+        # weights it 2x in the summary and reports misleading
+        # speedup. The operator likely meant to type two different
+        # indices; surface the typo loudly instead.
+        seen: set[int] = set()
+        dupes: list[int] = []
+        for i in ix:
+            if i in seen:
+                dupes.append(i)
+            else:
+                seen.add(i)
+        if dupes:
+            raise ValueError(
+                f"--prompt-indices contains duplicate entries "
+                f"{sorted(set(dupes))}; each prompt should appear at most "
+                "once or the pooled speedup over-weights the repeated prompt."
+            )
         for i in ix:
             if i < 0 or i >= len(_BENCH_PROMPTS):
                 raise ValueError(

--- a/bench/bench_spec_decode_dflash.py
+++ b/bench/bench_spec_decode_dflash.py
@@ -259,9 +259,18 @@ def _resolve_prompt_indices(args: argparse.Namespace) -> list[int]:
     return list(range(n))
 
 
-def _planned_matrix(args: argparse.Namespace) -> dict[str, Any]:
-    """Return the bench plan as a JSON-serializable dict (dry-run mode)."""
-    indices = _resolve_prompt_indices(args)
+def _planned_matrix(
+    args: argparse.Namespace, indices: list[int] | None = None
+) -> dict[str, Any]:
+    """Return the bench plan as a JSON-serializable dict (dry-run mode).
+
+    ``indices`` is optional so callers that already validated the
+    prompt-indices CLI can pass them through (avoids double validation
+    and ensures the dry-run plan reflects the same resolved set the
+    real run would).
+    """
+    if indices is None:
+        indices = _resolve_prompt_indices(args)
     prompts = [_BENCH_PROMPTS[i] for i in indices]
     return {
         "model": args.model,
@@ -431,8 +440,19 @@ def _summarize(
 def main() -> int:
     args = _parse_args()
 
+    # Resolve indices up front so both --dry-run and the real run
+    # share the same operator-facing error path. ValueError raised by
+    # _resolve_prompt_indices (bad int, out-of-range, duplicate) is
+    # caught here and surfaced as "error: ..." + exit 2, the same
+    # convention argparse uses.
+    try:
+        indices = _resolve_prompt_indices(args)
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
     if args.dry_run:
-        plan = _planned_matrix(args)
+        plan = _planned_matrix(args, indices=indices)
         if args.format == "markdown":
             print("# DFlash bench plan (dry-run)\n")
             for k, v in plan.items():
@@ -446,7 +466,6 @@ def main() -> int:
             print(json.dumps(plan, indent=2))
         return 0
 
-    indices = _resolve_prompt_indices(args)
     prompts = [_BENCH_PROMPTS[i] for i in indices]
 
     drafter_path = _resolve_drafter_path(args, args.model)

--- a/bench/bench_spec_decode_dflash.py
+++ b/bench/bench_spec_decode_dflash.py
@@ -221,7 +221,16 @@ def _parse_args() -> argparse.Namespace:
 
 def _resolve_prompt_indices(args: argparse.Namespace) -> list[int]:
     if args.prompt_indices.strip():
-        ix = [int(x) for x in args.prompt_indices.split(",") if x.strip()]
+        try:
+            ix = [int(x) for x in args.prompt_indices.split(",") if x.strip()]
+        except ValueError as exc:
+            # Surface a clean argparse-style error rather than a raw
+            # traceback for "--prompt-indices 0,foo,1" — the operator
+            # likely typo'd.
+            raise ValueError(
+                f"--prompt-indices entries must be integers; "
+                f"got {args.prompt_indices!r} ({exc})"
+            ) from None
         # Reject duplicates — pooling the same prompt twice silently
         # weights it 2x in the summary and reports misleading
         # speedup. The operator likely meant to type two different
@@ -481,12 +490,17 @@ def main() -> int:
     )
     # Share the already-loaded target rather than letting the driver
     # re-load it: ``MlxVlmDFlashDriver.load()`` re-calls
-    # ``mlx_vlm.load`` and we'd pay double the weight-load latency.
+    # ``mlx_vlm.load`` and we'd pay double the weight-load latency
+    # (the 27B-8bit target is 28+ GB). Adopt the already-loaded
+    # objects via the public injection API; the bench then exercises
+    # the same generate() code path production does.
     from vllm_mlx.speculative.dflash import load_runtime
 
-    driver._target = target  # noqa: SLF001 — bench-time shared-load shortcut
-    driver._processor = processor  # noqa: SLF001
-    driver._runtime = load_runtime(drafter_path)  # noqa: SLF001
+    driver.adopt(
+        target=target,
+        processor=processor,
+        runtime=load_runtime(drafter_path),
+    )
     print(
         f"[bench_spec_decode_dflash] all loaded in {time.perf_counter() - t_load:.1f}s",
         file=sys.stderr,

--- a/bench/bench_spec_decode_dflash.py
+++ b/bench/bench_spec_decode_dflash.py
@@ -221,8 +221,18 @@ def _parse_args() -> argparse.Namespace:
 
 def _resolve_prompt_indices(args: argparse.Namespace) -> list[int]:
     if args.prompt_indices.strip():
+        # Reject malformed lists like "0,,1" or "0, ,1" — an empty
+        # segment is a typo, not a "skip this index" idiom. Silently
+        # dropping it would hide the operator's slip.
+        raw_segments = args.prompt_indices.split(",")
+        empties = [seg for seg in raw_segments if not seg.strip()]
+        if empties:
+            raise ValueError(
+                f"--prompt-indices contains empty segment(s) in "
+                f"{args.prompt_indices!r}; remove the stray comma(s)."
+            )
         try:
-            ix = [int(x) for x in args.prompt_indices.split(",") if x.strip()]
+            ix = [int(x) for x in raw_segments]
         except ValueError as exc:
             # Surface a clean argparse-style error rather than a raw
             # traceback for "--prompt-indices 0,foo,1" — the operator

--- a/bench/bench_spec_decode_dflash.py
+++ b/bench/bench_spec_decode_dflash.py
@@ -462,6 +462,29 @@ def main() -> int:
             file=sys.stderr,
         )
         return 2
+    if args.prompts < 1 and not args.prompt_indices.strip():
+        # ``--prompts 0`` would resolve to an empty index list and the
+        # bench would emit a zero-run summary that looks identical to
+        # success. Reject so the operator notices the typo. (Skipped
+        # when --prompt-indices is set — that path supplies its own
+        # validation via _resolve_prompt_indices.)
+        print(
+            f"error: --prompts must be >= 1; got {args.prompts}.",
+            file=sys.stderr,
+        )
+        return 2
+    if args.runs < 1:
+        print(
+            f"error: --runs must be >= 1; got {args.runs}.",
+            file=sys.stderr,
+        )
+        return 2
+    if args.max_tokens < 1:
+        print(
+            f"error: --max-tokens must be >= 1; got {args.max_tokens}.",
+            file=sys.stderr,
+        )
+        return 2
     try:
         indices = _resolve_prompt_indices(args)
     except ValueError as exc:

--- a/bench/bench_spec_decode_dflash.py
+++ b/bench/bench_spec_decode_dflash.py
@@ -231,6 +231,16 @@ def _resolve_prompt_indices(args: argparse.Namespace) -> list[int]:
                 f"--prompt-indices entries must be integers; "
                 f"got {args.prompt_indices!r} ({exc})"
             ) from None
+        if not ix:
+            # ``--prompt-indices ","`` or ``--prompt-indices " "`` parses
+            # to empty after strip-filtering. Without this guard the
+            # bench would run zero generations and emit an empty
+            # summary, which looks identical to a success and silently
+            # invalidates any pooled-speedup interpretation.
+            raise ValueError(
+                f"--prompt-indices is empty after parsing {args.prompt_indices!r}; "
+                "pass at least one valid index."
+            )
         # Reject duplicates — pooling the same prompt twice silently
         # weights it 2x in the summary and reports misleading
         # speedup. The operator likely meant to type two different
@@ -440,11 +450,18 @@ def _summarize(
 def main() -> int:
     args = _parse_args()
 
-    # Resolve indices up front so both --dry-run and the real run
-    # share the same operator-facing error path. ValueError raised by
-    # _resolve_prompt_indices (bad int, out-of-range, duplicate) is
-    # caught here and surfaced as "error: ..." + exit 2, the same
-    # convention argparse uses.
+    # Validate CLI inputs up front so both --dry-run and the real run
+    # share the same operator-facing error path. Any ValueError raised
+    # by _resolve_prompt_indices (bad int, out-of-range, duplicate,
+    # empty) is caught here and surfaced as "error: ..." + exit 2,
+    # the same convention argparse uses.
+    if args.block_size < 0:
+        print(
+            f"error: --block-size must be >= 0; got {args.block_size}. "
+            "Use 0 (the default) to defer to the drafter's trained value.",
+            file=sys.stderr,
+        )
+        return 2
     try:
         indices = _resolve_prompt_indices(args)
     except ValueError as exc:

--- a/bench/bench_spec_decode_dflash.py
+++ b/bench/bench_spec_decode_dflash.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0
-"""DFlash speculative-decode decode-tok/s bench (R15-P1 #313).
+"""DFlash speculative-decode decode-tok/s bench (R15-P1 #313, #343 fix).
 
 Compares ``--spec-decode dflash`` against ``--spec-decode none`` on a
 Qwen3.5 / Qwen3.6 checkpoint with the matching block-diffusion drafter
@@ -9,23 +9,33 @@ bound in :mod:`vllm_mlx.spec_decode.dflash.drafter_registry` (or via
 8-prompt × 3-run protocol so the two backends are directly comparable
 on the same workload.
 
-DEFERRED: at landing time the GPU is contended with the Stage B
-PonyExl3 Viterbi conversion (PID 56486). The script is committed but
-NOT executed in the same agent run that opens the PR. Operators run::
+Architecture note (#343 fix)
+----------------------------
+
+The bench drives the WORKING DFlash path: both target and drafter load
+through ``mlx_vlm`` (0.6.3) and generation flows through
+``mlx_vlm.stream_generate`` with the drafter bound. Previously this
+script tried to call rapid-mlx's own
+:func:`vllm_mlx.spec_decode.dflash.generator.dflash_generate_step`
+loop, which in turn called a ``draft_block(prefix_tokens,
+current_position)`` adapter signature that mlx-vlm 0.6.3's
+``DFlashDraftModel`` does NOT implement (the actual signature is
+``draft_block(last_bonus, hidden, cache, block_size, sampler,
+token_dtype)``). As a result the bench could not run end-to-end — the
+2.34× math / 2.22× adaptive numbers in the 0.9 release dashboard came
+from a different harness, not this script. With #343 this script now
+runs cleanly and re-benches are trustworthy.
+
+Usage::
 
     python bench/bench_spec_decode_dflash.py \\
         --model qwen3.5-9b-4bit \\
         --runs 3 \\
         --max-tokens 256
 
-Outputs JSON (default) or a markdown table for the follow-up PR
-comment::
+Outputs JSON (default) or a markdown table::
 
     python bench/bench_spec_decode_dflash.py --format markdown
-
-Expected numbers (paper 2410.04097, M5 Max projection): baseline
-30.95 tok/s, DFlash temp=0 135.34 tok/s (4.37×, accept ratio depends
-on workload). The bench script reports the same triplet.
 
 Dry-run mode
 ------------
@@ -81,9 +91,14 @@ _BENCH_PROMPTS: tuple[str, ...] = (
 class RunResult:
     """One ``(condition, run_idx, prompt_idx)`` measurement.
 
-    The extra ``tokens_saved`` field (vs the MTP RunResult) captures
-    DFlash's block-bonus: a fully accepted block of size B saves up to
-    ``B - 1`` extra tokens per attempt, not just 1.
+    Per-run accept stats reflect DFlash's block-bonus contract: each
+    attempt drafts ``draft_block_size - 1`` candidate positions and
+    accepts some prefix [0..draft_block_size-1] of them, plus the
+    always-emitted verify bonus. We track both ``accept_count``
+    (positions accepted by the verifier) and ``drafted_tokens``
+    (positions drafted total) so the summary can report a true
+    per-position ``accept_ratio = accept_count / drafted_tokens`` and
+    a per-attempt mean ``accept_count / attempts``.
     """
 
     condition: str
@@ -93,7 +108,7 @@ class RunResult:
     n_tokens: int
     accept_attempts: int
     accept_count: int
-    tokens_saved: int
+    drafted_tokens: int
     elapsed_seconds: float
 
 
@@ -119,10 +134,11 @@ def _parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--model",
-        default="qwen3.5-9b-4bit",
+        default="mlx-community/Qwen3.5-9B-4bit",
         help=(
-            "Model alias or HF path (default: qwen3.5-9b-4bit). The "
-            "matching DFlash drafter must be bound in the side-registry "
+            "Target model HF path (default: mlx-community/Qwen3.5-9B-4bit). "
+            "Both the baseline and DFlash conditions load this via mlx-vlm. "
+            "The matching DFlash drafter must be bound in the side-registry "
             "or passed via --dflash-drafter-path."
         ),
     )
@@ -137,8 +153,13 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--block-size",
         type=int,
-        default=16,
-        help="DFlash block size (default: 16, paper bench value).",
+        default=0,
+        help=(
+            "DFlash block size override (default: 0 = use drafter's "
+            "trained value, typically 16). When set, mlx-vlm treats this "
+            "as the ceiling; the adaptive scaler still backs off on poor "
+            "acceptance."
+        ),
     )
     parser.add_argument(
         "--runs",
@@ -157,9 +178,9 @@ def _parse_args() -> argparse.Namespace:
         type=float,
         default=0.0,
         help=(
-            "Sampling temperature (default: 0.0 = greedy = lossless "
-            "contract enforced). DFlash temp>0 is not yet supported; "
-            "the script raises if a non-zero value is passed."
+            "Sampling temperature (default: 0.0 = greedy). DFlash temp>0 "
+            "is supported by mlx-vlm 0.6.3 but the lossless contract is "
+            "only validated at temp=0."
         ),
     )
     parser.add_argument(
@@ -183,27 +204,52 @@ def _parse_args() -> argparse.Namespace:
         default=len(_BENCH_PROMPTS),
         help=(
             f"Number of prompts to run (default: {len(_BENCH_PROMPTS)} "
-            "= full PR #990 mix)."
+            "= full PR #990 mix). Pass a small N for a fast smoke run."
+        ),
+    )
+    parser.add_argument(
+        "--prompt-indices",
+        default="",
+        help=(
+            "Comma-separated list of prompt indices into the canonical "
+            "8-prompt set (e.g. '0,4,6' for code/dialogue/math). When "
+            "set, overrides --prompts and runs only the selected prompts."
         ),
     )
     return parser.parse_args()
 
 
+def _resolve_prompt_indices(args: argparse.Namespace) -> list[int]:
+    if args.prompt_indices.strip():
+        ix = [int(x) for x in args.prompt_indices.split(",") if x.strip()]
+        for i in ix:
+            if i < 0 or i >= len(_BENCH_PROMPTS):
+                raise ValueError(
+                    f"--prompt-indices entry {i} out of range "
+                    f"[0, {len(_BENCH_PROMPTS) - 1}]"
+                )
+        return ix
+    n = min(args.prompts, len(_BENCH_PROMPTS))
+    return list(range(n))
+
+
 def _planned_matrix(args: argparse.Namespace) -> dict[str, Any]:
     """Return the bench plan as a JSON-serializable dict (dry-run mode)."""
-    n_prompts = min(args.prompts, len(_BENCH_PROMPTS))
+    indices = _resolve_prompt_indices(args)
+    prompts = [_BENCH_PROMPTS[i] for i in indices]
     return {
         "model": args.model,
         "drafter_override": args.dflash_drafter_path or None,
-        "block_size": args.block_size,
+        "block_size_override": args.block_size or None,
         "runs_per_condition": args.runs,
         "max_tokens": args.max_tokens,
         "temp": args.temp,
         "conditions": ["none", "dflash"],
-        "prompts": list(_BENCH_PROMPTS[:n_prompts]),
-        "total_generations": 2 * args.runs * n_prompts,
+        "prompt_indices": indices,
+        "prompts": prompts,
+        "total_generations": 2 * args.runs * len(prompts),
         "estimated_wall_time_seconds_at_30_tok_per_sec": (
-            2 * args.runs * n_prompts * args.max_tokens / 30.0
+            2 * args.runs * len(prompts) * args.max_tokens / 30.0
         ),
         "expected_speedup_paper": 4.37,
         "expected_baseline_tok_per_sec_m5_max": 30.95,
@@ -211,104 +257,97 @@ def _planned_matrix(args: argparse.Namespace) -> dict[str, Any]:
     }
 
 
-def _run_once(
-    *,
+def _load_baseline_target(model_alias: str) -> tuple[Any, Any]:
+    """Load the target + processor via mlx-vlm (for the baseline run).
+
+    Imported here so ``--dry-run`` doesn't pay the mlx-vlm import +
+    weight-load cost.
+    """
+    from mlx_vlm import load as _mlx_vlm_load
+
+    return _mlx_vlm_load(model_alias)
+
+
+def _resolve_drafter_path(
+    args: argparse.Namespace,
     model_alias: str,
-    drafter_override: str,
-    condition: str,
+) -> str:
+    """Resolve the drafter HF path from the explicit flag or the registry."""
+    if args.dflash_drafter_path:
+        return args.dflash_drafter_path
+    from vllm_mlx.spec_decode.dflash import get_dflash_drafter_path
+
+    return get_dflash_drafter_path(model_alias) or ""
+
+
+def _run_baseline_once(
+    *,
+    target: Any,
+    processor: Any,
     prompt: str,
-    block_size: int,
     max_tokens: int,
     temp: float,
 ) -> RunResult:
-    """Run one generation under the requested condition.
-
-    Imports ``mlx_lm`` and the rapid-mlx DFlash modules lazily so
-    ``--dry-run`` doesn't pay the import cost.
-    """
-    import mlx.core as mx
-    from mlx_lm import load
-
-    from vllm_mlx.spec_decode.dflash import (
-        DFlashAcceptCounter,
-        get_dflash_drafter_path,
-        get_global_counter,
-    )
-
-    model, tokenizer = load(model_alias)
-
-    if condition == "dflash":
-        from vllm_mlx.spec_decode.dflash.drafter import (
-            MlxVlmBlockDiffusionDrafter,
-        )
-        from vllm_mlx.spec_decode.dflash.generator import dflash_generate_step
-
-        drafter_path = drafter_override or get_dflash_drafter_path(model_alias)
-        if not drafter_path:
-            raise RuntimeError(
-                f"No DFlash drafter bound for {model_alias!r}. Pass "
-                "--dflash-drafter-path or register via "
-                "vllm_mlx.spec_decode.dflash.register_dflash_drafter()."
-            )
-        drafter = MlxVlmBlockDiffusionDrafter(drafter_path, block_size=block_size)
-
-    prompt_ids = mx.array(tokenizer.encode(prompt), mx.uint32)
-    counter = DFlashAcceptCounter()
-    prior_attempts = get_global_counter().snapshot().attempts
-    prior_accepts = get_global_counter().snapshot().accepts
+    """Run one baseline (no spec-decode) generation via mlx-vlm."""
+    from mlx_vlm import stream_generate
 
     t0 = time.perf_counter()
     n = 0
-    if condition == "dflash":
-        gen = dflash_generate_step(
-            prompt_ids,
-            model,
-            drafter,
-            block_size=block_size,
-            max_tokens=max_tokens,
-            temperature=temp,
-            accept_counter=counter,
-        )
-        for _ in gen:
-            n += 1
-    else:
-        from mlx_lm.generate import stream_generate
-
-        for _resp in stream_generate(
-            model,
-            tokenizer,
-            prompt,
-            max_tokens=max_tokens,
-        ):
-            n += 1
-            if n >= max_tokens:
-                break
-
+    for chunk in stream_generate(
+        target,
+        processor,
+        prompt,
+        max_tokens=max_tokens,
+        temperature=temp,
+    ):
+        n = chunk.generation_tokens
+        if n >= max_tokens:
+            break
     elapsed = time.perf_counter() - t0
-
-    if condition == "dflash":
-        snap = counter.snapshot()
-        snap_attempts, snap_accepts, tokens_saved = (
-            snap.attempts,
-            snap.accepts,
-            snap.tokens_saved,
-        )
-    else:
-        snap_attempts, snap_accepts, tokens_saved = 0, 0, 0
-    # Sanity-check: global counter shouldn't have moved.
-    assert get_global_counter().snapshot().attempts == prior_attempts
-    assert get_global_counter().snapshot().accepts == prior_accepts
-
     tok_per_sec = n / elapsed if elapsed > 0 else 0.0
     return RunResult(
-        condition=condition,
+        condition="none",
         run_idx=-1,
         prompt_idx=-1,
         decode_tok_per_sec=tok_per_sec,
         n_tokens=n,
-        accept_attempts=snap_attempts,
-        accept_count=snap_accepts,
-        tokens_saved=tokens_saved,
+        accept_attempts=0,
+        accept_count=0,
+        drafted_tokens=0,
+        elapsed_seconds=elapsed,
+    )
+
+
+def _run_dflash_once(
+    *,
+    driver: Any,
+    prompt: str,
+    max_tokens: int,
+    temp: float,
+) -> RunResult:
+    """Run one DFlash generation via the rapid-mlx driver wrapper."""
+    t0 = time.perf_counter()
+    n = 0
+    for chunk in driver.generate(
+        prompt,
+        max_tokens=max_tokens,
+        temperature=temp,
+    ):
+        n = chunk.generation_tokens
+        if n >= max_tokens:
+            break
+    elapsed = time.perf_counter() - t0
+    stats = driver.accept_stats()
+    tok_per_sec = n / elapsed if elapsed > 0 else 0.0
+    return RunResult(
+        condition="dflash",
+        run_idx=-1,
+        prompt_idx=-1,
+        decode_tok_per_sec=tok_per_sec,
+        n_tokens=n,
+        accept_attempts=int(stats["attempts"]),
+        accept_count=int(stats["accepted_tokens"]),
+        drafted_tokens=int(stats["drafted_tokens"]),
         elapsed_seconds=elapsed,
     )
 
@@ -339,9 +378,12 @@ def _summarize(
     p90 = per_run[int(0.9 * (len(per_run) - 1))] if per_run else 0.0
     attempts = sum(r.accept_attempts for r in results)
     accepts = sum(r.accept_count for r in results)
-    tokens_saved = sum(r.tokens_saved for r in results)
-    accept_ratio = accepts / attempts if attempts > 0 else 0.0
-    mean_tps = tokens_saved / attempts if attempts > 0 else 0.0
+    drafted = sum(r.drafted_tokens for r in results)
+    # accept_ratio = fraction of DRAFTED positions accepted by the
+    # verifier (paper's standard metric). mean_tps = accepted positions
+    # per attempt, which can be > 1 (per the block-bonus contract).
+    accept_ratio = accepts / drafted if drafted > 0 else 0.0
+    mean_tps = accepts / attempts if attempts > 0 else 0.0
     speedup = (
         pooled / baseline_tok_per_sec
         if baseline_tok_per_sec and baseline_tok_per_sec > 0
@@ -363,15 +405,6 @@ def _summarize(
 def main() -> int:
     args = _parse_args()
 
-    if args.temp != 0.0 and not args.dry_run:
-        print(
-            "error: DFlash bench currently only supports temp=0.0 "
-            "(greedy / lossless). See verifier docstring for the "
-            "speculative-sampling extension plan.",
-            file=sys.stderr,
-        )
-        return 2
-
     if args.dry_run:
         plan = _planned_matrix(args)
         if args.format == "markdown":
@@ -387,32 +420,83 @@ def main() -> int:
             print(json.dumps(plan, indent=2))
         return 0
 
-    n_prompts = min(args.prompts, len(_BENCH_PROMPTS))
-    prompts = list(_BENCH_PROMPTS[:n_prompts])
+    indices = _resolve_prompt_indices(args)
+    prompts = [_BENCH_PROMPTS[i] for i in indices]
+
+    drafter_path = _resolve_drafter_path(args, args.model)
+    if not drafter_path:
+        print(
+            f"error: no DFlash drafter bound for model={args.model!r}. "
+            f"Pass --dflash-drafter-path or register via "
+            f"vllm_mlx.spec_decode.dflash.register_dflash_drafter().",
+            file=sys.stderr,
+        )
+        return 2
 
     print(
         f"[bench_spec_decode_dflash] model={args.model} "
-        f"drafter={args.dflash_drafter_path or '<registry>'} "
-        f"block_size={args.block_size} runs={args.runs} "
-        f"prompts={n_prompts} max_tokens={args.max_tokens} temp={args.temp}",
+        f"drafter={drafter_path} "
+        f"block_size={args.block_size or '<drafter-default>'} "
+        f"runs={args.runs} prompts={len(prompts)} "
+        f"prompt_indices={indices} "
+        f"max_tokens={args.max_tokens} temp={args.temp}",
+        file=sys.stderr,
+    )
+
+    # Load target + drafter ONCE, reuse across runs. mlx-vlm 0.6.3's
+    # ``stream_generate`` is safe to call repeatedly against the same
+    # model + drafter pair.
+    from vllm_mlx.spec_decode.dflash.drafter import MlxVlmDFlashDriver
+
+    t_load = time.perf_counter()
+    print("[bench_spec_decode_dflash] loading target via mlx-vlm…", file=sys.stderr)
+    target, processor = _load_baseline_target(args.model)
+    print(
+        f"[bench_spec_decode_dflash] target loaded in {time.perf_counter() - t_load:.1f}s; "
+        "loading drafter…",
+        file=sys.stderr,
+    )
+    block_size_arg: int | None = args.block_size or None
+    driver = MlxVlmDFlashDriver(
+        target_repo=args.model,
+        drafter_repo=drafter_path,
+        block_size=block_size_arg,
+    )
+    # Share the already-loaded target rather than letting the driver
+    # re-load it: ``MlxVlmDFlashDriver.load()`` re-calls
+    # ``mlx_vlm.load`` and we'd pay double the weight-load latency.
+    from vllm_mlx.speculative.dflash import load_runtime
+
+    driver._target = target  # noqa: SLF001 — bench-time shared-load shortcut
+    driver._processor = processor  # noqa: SLF001
+    driver._runtime = load_runtime(drafter_path)  # noqa: SLF001
+    print(
+        f"[bench_spec_decode_dflash] all loaded in {time.perf_counter() - t_load:.1f}s",
         file=sys.stderr,
     )
 
     all_results: dict[str, list[RunResult]] = {"none": [], "dflash": []}
     # Interleave conditions per run to avoid thermal drift.
     for run_idx in range(args.runs):
-        for prompt_idx, prompt in enumerate(prompts):
+        for prompt_local_idx, prompt in enumerate(prompts):
+            prompt_idx = indices[prompt_local_idx]
             for condition in ("none", "dflash"):
                 try:
-                    res = _run_once(
-                        model_alias=args.model,
-                        drafter_override=args.dflash_drafter_path,
-                        condition=condition,
-                        prompt=prompt,
-                        block_size=args.block_size,
-                        max_tokens=args.max_tokens,
-                        temp=args.temp,
-                    )
+                    if condition == "none":
+                        res = _run_baseline_once(
+                            target=target,
+                            processor=processor,
+                            prompt=prompt,
+                            max_tokens=args.max_tokens,
+                            temp=args.temp,
+                        )
+                    else:
+                        res = _run_dflash_once(
+                            driver=driver,
+                            prompt=prompt,
+                            max_tokens=args.max_tokens,
+                            temp=args.temp,
+                        )
                 except Exception as exc:  # pragma: no cover — bench
                     print(
                         f"[bench_spec_decode_dflash] {condition} "
@@ -428,15 +512,34 @@ def main() -> int:
                     n_tokens=res.n_tokens,
                     accept_attempts=res.accept_attempts,
                     accept_count=res.accept_count,
-                    tokens_saved=res.tokens_saved,
+                    drafted_tokens=res.drafted_tokens,
                     elapsed_seconds=res.elapsed_seconds,
                 )
                 all_results[condition].append(res)
+                if condition == "dflash":
+                    rate = (
+                        100.0 * res.accept_count / res.drafted_tokens
+                        if res.drafted_tokens > 0
+                        else 0.0
+                    )
+                    mean_per_attempt = (
+                        res.accept_count / res.accept_attempts
+                        if res.accept_attempts > 0
+                        else 0.0
+                    )
+                    accept_suffix = (
+                        f" accept={res.accept_count}/{res.drafted_tokens} "
+                        f"({rate:.1f}% per slot, {mean_per_attempt:.2f}/attempt, "
+                        f"{res.accept_attempts} attempts)"
+                    )
+                else:
+                    accept_suffix = ""
                 print(
                     f"[bench_spec_decode_dflash] {condition} "
                     f"run={run_idx} prompt={prompt_idx} "
                     f"{res.decode_tok_per_sec:.1f} tok/s "
-                    f"({res.n_tokens} tokens in {res.elapsed_seconds:.1f}s)",
+                    f"({res.n_tokens} tokens in {res.elapsed_seconds:.1f}s)"
+                    + accept_suffix,
                     file=sys.stderr,
                 )
 
@@ -447,17 +550,18 @@ def main() -> int:
 
     out = {
         "model": args.model,
-        "drafter_override": args.dflash_drafter_path or None,
-        "block_size": args.block_size,
+        "drafter": drafter_path,
+        "block_size_override": args.block_size or None,
         "max_tokens": args.max_tokens,
         "temp": args.temp,
+        "prompt_indices": indices,
         "summaries": [asdict(baseline_summary), asdict(dflash_summary)],
         "raw_runs": [asdict(r) for c in all_results.values() for r in c],
     }
     if args.format == "markdown":
         print("# DFlash spec-decode bench\n")
         print(
-            f"Model: `{args.model}`  block_size: {args.block_size}  "
+            f"Model: `{args.model}`  drafter: `{drafter_path}`  "
             f"max_tokens: {args.max_tokens}  temp: {args.temp}\n"
         )
         print(

--- a/tests/test_dflash_adapter_signature.py
+++ b/tests/test_dflash_adapter_signature.py
@@ -143,7 +143,14 @@ class _FakeRuntime:
 
 @pytest.fixture
 def stub_mlx_vlm(monkeypatch: pytest.MonkeyPatch):
-    """Install a fake mlx-vlm + load_runtime so we can exercise the driver.
+    """Stub ``mlx_vlm.load`` + ``stream_generate`` + ``load_runtime``.
+
+    NOTE: this fixture uses ``importorskip("mlx_vlm")`` to skip the
+    driver wiring tests cleanly when ``rapid-mlx`` is installed
+    WITHOUT the ``[dflash]`` extra (mlx-vlm is an optional dep). The
+    ``test_mlx_vlm_draft_block_signature_matches_0_6_3`` test above
+    already gates on ``importorskip`` for the same reason; mirroring
+    here keeps the surface consistent.
 
     Patches:
       * ``mlx_vlm.load`` — returns (model, processor) tuples
@@ -154,6 +161,8 @@ def stub_mlx_vlm(monkeypatch: pytest.MonkeyPatch):
     invocation) and ``runtime`` (the fake DFlashRuntime instance), so
     individual tests can swap in different drafter state.
     """
+    mlx_vlm = pytest.importorskip("mlx_vlm")
+
     calls: list[dict[str, Any]] = []
     drafter = _FakeDrafter()
     runtime = _FakeRuntime(drafter)
@@ -175,10 +184,6 @@ def stub_mlx_vlm(monkeypatch: pytest.MonkeyPatch):
         yield _FakeChunk("hello", token=1, generation_tokens=1)
         yield _FakeChunk(" world", token=2, generation_tokens=2)
         yield _FakeChunk("", token=3, generation_tokens=3)
-
-    # Install a fake mlx_vlm module — preserves existing attributes
-    # so other imports (speculative.drafters.* etc) still resolve.
-    import mlx_vlm
 
     monkeypatch.setattr(mlx_vlm, "load", fake_load, raising=True)
     monkeypatch.setattr(mlx_vlm, "stream_generate", fake_stream_generate, raising=True)

--- a/tests/test_dflash_adapter_signature.py
+++ b/tests/test_dflash_adapter_signature.py
@@ -43,8 +43,12 @@ import sys
 import types
 from typing import Any
 
-import mlx.core as mx
 import pytest
+
+# ``mlx.core`` is an optional dep (in ``[dflash]`` extras). The
+# signature test below imports it lazily after ``importorskip`` so a
+# collect on a bare-Python env doesn't crash with ImportError before
+# pytest can skip.
 
 # ---------------------------------------------------------------------------
 # Upstream-contract pins — fail loudly when mlx-vlm drifts the signature.
@@ -62,6 +66,7 @@ def test_mlx_vlm_draft_block_signature_matches_0_6_3() -> None:
     update the rapid-mlx wrapper") instead of a flaky GPU crash.
     """
     pytest.importorskip("mlx_vlm")
+    mx = pytest.importorskip("mlx.core")
     from mlx_vlm.speculative.drafters.qwen3_dflash.dflash import DFlashDraftModel
 
     sig = inspect.signature(DFlashDraftModel.draft_block)

--- a/tests/test_dflash_adapter_signature.py
+++ b/tests/test_dflash_adapter_signature.py
@@ -1,0 +1,393 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression coverage for the DFlash driver vs mlx-vlm 0.6.3 (#343).
+
+The previous adapter in ``vllm_mlx/spec_decode/dflash/drafter.py`` called
+``DFlashDraftModel.draft_block(prefix_tokens, current_position)`` — a
+signature that mlx-vlm 0.6.3 does NOT expose. The real signature is
+``draft_block(last_bonus, hidden, cache, block_size, sampler,
+token_dtype)`` (the drafter is hidden-state-conditioned). That mismatch
+made the bench script non-functional and would have failed at the first
+real call into the drafter.
+
+These tests pin the assumptions the new :class:`MlxVlmDFlashDriver`
+makes about mlx-vlm so a future bump that drifts the signature (or
+renames a callback) trips a clear assertion here instead of producing
+silently-wrong bench numbers.
+
+Coverage:
+
+* :func:`test_mlx_vlm_draft_block_signature_matches_0_6_3` —
+  ``inspect.signature(DFlashDraftModel.draft_block)`` exposes the
+  expected parameter names AND the ``token_dtype`` default. If
+  mlx-vlm renames any of these, this test pins the failure to the
+  upstream contract change.
+* :func:`test_dflash_runtime_kind_attribute` — the rapid-mlx wrapper
+  reads ``runtime.kind`` to populate the ``draft_kind`` kwarg into
+  ``stream_generate``. Pin that attribute name.
+* :func:`test_driver_generate_invokes_stream_generate_with_drafter` —
+  with the heavy dependencies stubbed, exercise
+  :meth:`MlxVlmDFlashDriver.generate` and assert the kwargs forwarded
+  to ``mlx_vlm.stream_generate`` include both ``draft_model`` (the
+  drafter object) and ``draft_kind`` (the runtime kind).
+* :func:`test_driver_accept_stats_reads_drafter_lists` — the wrapper
+  uses ``drafter.accept_lens`` and ``drafter.draft_lens`` to compute
+  accept rate. Pin those attribute names and the summary math.
+* :func:`test_driver_load_is_idempotent` — :meth:`load` must be safe
+  to call repeatedly without re-loading.
+"""
+
+from __future__ import annotations
+
+import inspect
+import sys
+import types
+from typing import Any
+
+import mlx.core as mx
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Upstream-contract pins — fail loudly when mlx-vlm drifts the signature.
+# ---------------------------------------------------------------------------
+
+
+def test_mlx_vlm_draft_block_signature_matches_0_6_3() -> None:
+    """Pin the mlx-vlm 0.6.3 ``draft_block`` parameter contract.
+
+    The rapid-mlx DFlash driver assumes mlx-vlm's drafter is called
+    with these positional args by mlx-vlm's own ``_dflash_rounds``
+    loop. We don't call it directly anymore — but if the upstream
+    drifts the signature, ``_dflash_rounds`` itself stops working,
+    and we want a CLEAR diagnostic ("mlx-vlm signature changed,
+    update the rapid-mlx wrapper") instead of a flaky GPU crash.
+    """
+    pytest.importorskip("mlx_vlm")
+    from mlx_vlm.speculative.drafters.qwen3_dflash.dflash import DFlashDraftModel
+
+    sig = inspect.signature(DFlashDraftModel.draft_block)
+    params = list(sig.parameters)
+    assert params == [
+        "self",
+        "last_bonus",
+        "hidden",
+        "cache",
+        "block_size",
+        "sampler",
+        "token_dtype",
+    ], (
+        "mlx-vlm 0.6.3 DFlashDraftModel.draft_block parameter list "
+        f"changed: got {params}. Update MlxVlmDFlashDriver in "
+        "vllm_mlx/spec_decode/dflash/drafter.py to match — see #343."
+    )
+    # token_dtype has a default; the other slots are positional-required.
+    assert sig.parameters["token_dtype"].default is mx.int32
+
+
+def test_dflash_runtime_kind_attribute_exists() -> None:
+    """Pin ``DFlashRuntime.kind`` — the wrapper reads it for stream_generate."""
+    from vllm_mlx.speculative.dflash.runtime import DFlashRuntime
+
+    # Construct a stub runtime (load_runtime hits mlx-vlm, but the
+    # dataclass itself is plain).
+    rt = DFlashRuntime(drafter=object(), kind="dflash", drafter_repo="z-lab/test")
+    assert rt.kind == "dflash"
+    assert rt.drafter_repo == "z-lab/test"
+
+
+# ---------------------------------------------------------------------------
+# Driver-level tests — mock the mlx-vlm surface to isolate wiring.
+# ---------------------------------------------------------------------------
+
+
+class _FakeChunk:
+    """Minimal stand-in for mlx-vlm's ``GenerationResult`` chunk."""
+
+    def __init__(self, text: str, token: int, generation_tokens: int) -> None:
+        self.text = text
+        self.token = token
+        self.generation_tokens = generation_tokens
+        self.prompt_tokens = 7  # arbitrary; bench doesn't read this for tok/s
+
+
+class _FakeDrafter:
+    """Stand-in for mlx-vlm's ``DFlashDraftModel`` for wiring tests.
+
+    Owns the ``accept_lens`` / ``draft_lens`` lists the driver reads
+    after generation. We don't simulate the per-block diffusion math —
+    the driver delegates that to the stubbed ``stream_generate``.
+    """
+
+    def __init__(self) -> None:
+        self.accept_lens: list[int] = []
+        self.draft_lens: list[int] = []
+
+    def populate(self, accept_lens: list[int], draft_lens: list[int]) -> None:
+        self.accept_lens = list(accept_lens)
+        self.draft_lens = list(draft_lens)
+
+
+class _FakeRuntime:
+    """Minimal stand-in for :class:`DFlashRuntime`."""
+
+    def __init__(self, drafter: _FakeDrafter, kind: str = "dflash") -> None:
+        self.drafter = drafter
+        self.kind = kind
+        self.drafter_repo = "z-lab/fake-drafter"
+        self.reset_calls = 0
+
+    def reset_accept_lens(self) -> None:
+        self.reset_calls += 1
+        if isinstance(self.drafter.accept_lens, list):
+            self.drafter.accept_lens.clear()
+
+
+@pytest.fixture
+def stub_mlx_vlm(monkeypatch: pytest.MonkeyPatch):
+    """Install a fake mlx-vlm + load_runtime so we can exercise the driver.
+
+    Patches:
+      * ``mlx_vlm.load`` — returns (model, processor) tuples
+      * ``mlx_vlm.stream_generate`` — records call args, yields fake chunks
+      * ``vllm_mlx.speculative.dflash.load_runtime`` — returns a fake runtime
+
+    Returns a dict with ``calls`` (list of dict, one per stream_generate
+    invocation) and ``runtime`` (the fake DFlashRuntime instance), so
+    individual tests can swap in different drafter state.
+    """
+    calls: list[dict[str, Any]] = []
+    drafter = _FakeDrafter()
+    runtime = _FakeRuntime(drafter)
+
+    def fake_load(repo: str):
+        return (f"<target-{repo}>", f"<processor-{repo}>")
+
+    def fake_stream_generate(model, processor, prompt, **kwargs):
+        calls.append(
+            {
+                "model": model,
+                "processor": processor,
+                "prompt": prompt,
+                "kwargs": dict(kwargs),
+            }
+        )
+        # Emit 3 fake chunks; the bench reads .generation_tokens
+        # so we yield a strictly-increasing counter.
+        yield _FakeChunk("hello", token=1, generation_tokens=1)
+        yield _FakeChunk(" world", token=2, generation_tokens=2)
+        yield _FakeChunk("", token=3, generation_tokens=3)
+
+    # Install a fake mlx_vlm module — preserves existing attributes
+    # so other imports (speculative.drafters.* etc) still resolve.
+    import mlx_vlm
+
+    monkeypatch.setattr(mlx_vlm, "load", fake_load, raising=True)
+    monkeypatch.setattr(mlx_vlm, "stream_generate", fake_stream_generate, raising=True)
+
+    # Patch load_runtime in the speculative bridge module.
+    import vllm_mlx.speculative.dflash as bridge
+
+    monkeypatch.setattr(bridge, "load_runtime", lambda repo: runtime, raising=True)
+    # Also patch the symbol re-export so ``from ... import load_runtime``
+    # inside the driver picks up the fake one.
+    monkeypatch.setattr(
+        sys.modules["vllm_mlx.speculative.dflash"],
+        "load_runtime",
+        lambda repo: runtime,
+        raising=True,
+    )
+
+    return {"calls": calls, "runtime": runtime, "drafter": drafter}
+
+
+def test_driver_generate_invokes_stream_generate_with_drafter(stub_mlx_vlm) -> None:
+    """The driver must forward ``draft_model`` and ``draft_kind`` to mlx-vlm.
+
+    Pinning this catches a regression where the wrapper forgets to set
+    the drafter (resulting in a silent fall-back to plain AR decode —
+    the exact failure mode that masked the broken 0.9 bench).
+    """
+    from vllm_mlx.spec_decode.dflash.drafter import MlxVlmDFlashDriver
+
+    driver = MlxVlmDFlashDriver(
+        target_repo="mlx-community/Qwen3.5-9B-4bit",
+        drafter_repo="z-lab/Qwen3.5-9B-DFlash",
+    )
+    driver.load()
+    chunks = list(driver.generate("Hello, world.", max_tokens=8, temperature=0.0))
+
+    assert len(chunks) == 3
+    assert len(stub_mlx_vlm["calls"]) == 1
+    call = stub_mlx_vlm["calls"][0]
+    assert call["prompt"] == "Hello, world."
+    kwargs = call["kwargs"]
+    # Critical contract: drafter + kind both threaded through.
+    assert kwargs["draft_model"] is stub_mlx_vlm["runtime"].drafter
+    assert kwargs["draft_kind"] == "dflash"
+    assert kwargs["max_tokens"] == 8
+    assert kwargs["temperature"] == 0.0
+    # block_size left to mlx-vlm default when not set.
+    assert "draft_block_size" not in kwargs
+
+
+def test_driver_forwards_block_size_override(stub_mlx_vlm) -> None:
+    """When ``block_size`` is set on the driver, forward it to mlx-vlm."""
+    from vllm_mlx.spec_decode.dflash.drafter import MlxVlmDFlashDriver
+
+    driver = MlxVlmDFlashDriver(
+        target_repo="mlx-community/Qwen3.5-9B-4bit",
+        drafter_repo="z-lab/Qwen3.5-9B-DFlash",
+        block_size=8,
+    )
+    driver.load()
+    list(driver.generate("Hello.", max_tokens=4, temperature=0.0))
+    assert stub_mlx_vlm["calls"][0]["kwargs"]["draft_block_size"] == 8
+
+
+def test_driver_accept_stats_reads_drafter_lists(stub_mlx_vlm) -> None:
+    """Pin the ``accept_lens`` / ``draft_lens`` attribute names + the math."""
+    from vllm_mlx.spec_decode.dflash.drafter import MlxVlmDFlashDriver
+
+    driver = MlxVlmDFlashDriver(
+        target_repo="mlx-community/Qwen3.5-9B-4bit",
+        drafter_repo="z-lab/Qwen3.5-9B-DFlash",
+    )
+    driver.load()
+
+    # Pre-populate so the bench sees a real number — generate() will
+    # call reset_accept_lens() which clears accept_lens; we re-populate
+    # AFTER iteration to simulate what _dflash_rounds does.
+    list(driver.generate("Hi.", max_tokens=4, temperature=0.0))
+    stub_mlx_vlm["drafter"].populate(
+        accept_lens=[3, 2, 4, 0],
+        draft_lens=[7, 7, 7, 7],
+    )
+
+    stats = driver.accept_stats()
+    assert stats["attempts"] == 4
+    assert stats["accepted_tokens"] == 9
+    assert stats["drafted_tokens"] == 28
+    assert stats["accept_rate"] == pytest.approx(9 / 28)
+    assert stats["mean_accepted_per_attempt"] == pytest.approx(9 / 4)
+    assert stats["accept_lens"] == [3, 2, 4, 0]
+    assert stats["draft_lens"] == [7, 7, 7, 7]
+
+
+def test_driver_accept_stats_handles_empty_runs(stub_mlx_vlm) -> None:
+    """Zero-attempt runs must not divide by zero."""
+    from vllm_mlx.spec_decode.dflash.drafter import MlxVlmDFlashDriver
+
+    driver = MlxVlmDFlashDriver(
+        target_repo="mlx-community/Qwen3.5-9B-4bit",
+        drafter_repo="z-lab/Qwen3.5-9B-DFlash",
+    )
+    driver.load()
+    stats = driver.accept_stats()
+    assert stats["attempts"] == 0
+    assert stats["accepted_tokens"] == 0
+    assert stats["accept_rate"] == 0.0
+    assert stats["mean_accepted_per_attempt"] == 0.0
+
+
+def test_driver_load_is_idempotent(stub_mlx_vlm) -> None:
+    """A second ``load()`` must not re-invoke the loaders."""
+    from vllm_mlx.spec_decode.dflash.drafter import MlxVlmDFlashDriver
+
+    # Patch load to count invocations.
+    load_calls = {"n": 0}
+    import mlx_vlm
+
+    original = mlx_vlm.load
+
+    def counting_load(repo):
+        load_calls["n"] += 1
+        return original(repo)
+
+    mlx_vlm.load = counting_load
+    try:
+        driver = MlxVlmDFlashDriver(
+            target_repo="mlx-community/Qwen3.5-9B-4bit",
+            drafter_repo="z-lab/Qwen3.5-9B-DFlash",
+        )
+        driver.load()
+        assert load_calls["n"] == 1
+        driver.load()  # idempotent
+        assert load_calls["n"] == 1
+    finally:
+        mlx_vlm.load = original
+
+
+def test_driver_generate_without_load_raises() -> None:
+    """``generate`` before ``load`` should error clearly, not crash inside mlx-vlm."""
+    from vllm_mlx.spec_decode.dflash.drafter import MlxVlmDFlashDriver
+
+    driver = MlxVlmDFlashDriver(
+        target_repo="mlx-community/Qwen3.5-9B-4bit",
+        drafter_repo="z-lab/Qwen3.5-9B-DFlash",
+    )
+    with pytest.raises(RuntimeError, match="load"):
+        next(driver.generate("Hi.", max_tokens=4))
+
+
+def test_driver_rejects_empty_repos() -> None:
+    """Empty target / drafter args should fail at construction, not load."""
+    from vllm_mlx.spec_decode.dflash.drafter import MlxVlmDFlashDriver
+
+    with pytest.raises(ValueError, match="target_repo"):
+        MlxVlmDFlashDriver(target_repo="", drafter_repo="z-lab/Qwen3.5-9B-DFlash")
+    with pytest.raises(ValueError, match="drafter_repo"):
+        MlxVlmDFlashDriver(target_repo="mlx-community/Qwen3.5-9B-4bit", drafter_repo="")
+
+
+def test_driver_rejects_nonpositive_block_size() -> None:
+    """``block_size <= 0`` is a programming error; surface it early."""
+    from vllm_mlx.spec_decode.dflash.drafter import MlxVlmDFlashDriver
+
+    with pytest.raises(ValueError, match="block_size"):
+        MlxVlmDFlashDriver(
+            target_repo="mlx-community/Qwen3.5-9B-4bit",
+            drafter_repo="z-lab/Qwen3.5-9B-DFlash",
+            block_size=0,
+        )
+    with pytest.raises(ValueError, match="block_size"):
+        MlxVlmDFlashDriver(
+            target_repo="mlx-community/Qwen3.5-9B-4bit",
+            drafter_repo="z-lab/Qwen3.5-9B-DFlash",
+            block_size=-1,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Symbol-export pin — make sure nothing renames the public surface.
+# ---------------------------------------------------------------------------
+
+
+def test_drafter_module_exports() -> None:
+    """``vllm_mlx.spec_decode.dflash.drafter.__all__`` is the stable surface."""
+    import vllm_mlx.spec_decode.dflash.drafter as mod
+
+    assert set(mod.__all__) == {
+        "BlockDiffusionDrafter",
+        "StubBlockDiffusionDrafter",
+        "MlxVlmDFlashDriver",
+    }
+
+
+def test_old_class_name_removed() -> None:
+    """``MlxVlmBlockDiffusionDrafter`` was the broken pre-#343 wrapper.
+
+    Removed in #343 — keep this test green to catch accidental
+    resurrection of the dead per-block adapter API.
+    """
+    import vllm_mlx.spec_decode.dflash.drafter as mod
+
+    assert not hasattr(mod, "MlxVlmBlockDiffusionDrafter"), (
+        "MlxVlmBlockDiffusionDrafter was the broken pre-#343 per-block "
+        "adapter (signature mismatch with mlx-vlm 0.6.3). Use "
+        "MlxVlmDFlashDriver instead."
+    )
+
+
+# Silence the unused-import linter — ``types`` is reserved for the
+# fixture's monkeypatching infrastructure.
+_ = types

--- a/tests/test_dflash_adapter_signature.py
+++ b/tests/test_dflash_adapter_signature.py
@@ -338,6 +338,67 @@ def test_driver_rejects_empty_repos() -> None:
         MlxVlmDFlashDriver(target_repo="mlx-community/Qwen3.5-9B-4bit", drafter_repo="")
 
 
+def test_driver_adopt_accepts_preloaded_objects(stub_mlx_vlm) -> None:
+    """``adopt()`` lets a caller inject already-loaded objects.
+
+    Bench scripts pay one mlx-vlm.load() for both baseline and DFlash
+    conditions and re-use the resulting model. Without ``adopt()`` they
+    would either have to load twice (28+ GB for Qwen3.5-27B-8bit) or
+    poke at the driver's private attrs.
+    """
+    from vllm_mlx.spec_decode.dflash.drafter import MlxVlmDFlashDriver
+
+    runtime = stub_mlx_vlm["runtime"]
+    driver = MlxVlmDFlashDriver(
+        target_repo="mlx-community/Qwen3.5-9B-4bit",
+        drafter_repo="z-lab/Qwen3.5-9B-DFlash",
+    )
+    assert not driver.loaded
+    driver.adopt(
+        target="<pre-loaded-target>", processor="<pre-loaded-proc>", runtime=runtime
+    )
+    assert driver.loaded
+    assert driver.target == "<pre-loaded-target>"
+    assert driver.processor == "<pre-loaded-proc>"
+    assert driver.runtime is runtime
+
+    # generate() works as it does after load().
+    list(driver.generate("Hi.", max_tokens=4, temperature=0.0))
+    assert stub_mlx_vlm["calls"][0]["model"] == "<pre-loaded-target>"
+    assert stub_mlx_vlm["calls"][0]["processor"] == "<pre-loaded-proc>"
+
+
+def test_driver_adopt_rejects_double_call(stub_mlx_vlm) -> None:
+    """Calling ``adopt()`` after ``load()`` (or twice) raises."""
+    from vllm_mlx.spec_decode.dflash.drafter import MlxVlmDFlashDriver
+
+    runtime = stub_mlx_vlm["runtime"]
+    driver = MlxVlmDFlashDriver(
+        target_repo="mlx-community/Qwen3.5-9B-4bit",
+        drafter_repo="z-lab/Qwen3.5-9B-DFlash",
+    )
+    driver.load()
+    with pytest.raises(ValueError, match="already loaded"):
+        driver.adopt(target="x", processor="y", runtime=runtime)
+
+
+def test_driver_adopt_rejects_none(stub_mlx_vlm) -> None:
+    """``adopt(target=None)`` etc. fail fast — easier than debugging a NoneType error mid-decode."""
+    from vllm_mlx.spec_decode.dflash.drafter import MlxVlmDFlashDriver
+
+    driver = MlxVlmDFlashDriver(
+        target_repo="mlx-community/Qwen3.5-9B-4bit",
+        drafter_repo="z-lab/Qwen3.5-9B-DFlash",
+    )
+    runtime = stub_mlx_vlm["runtime"]
+    with pytest.raises(ValueError, match="non-None"):
+        driver.adopt(target=None, processor="p", runtime=runtime)
+    with pytest.raises(ValueError, match="non-None"):
+        driver.adopt(target="t", processor=None, runtime=runtime)
+    with pytest.raises(ValueError, match="non-None"):
+        driver.adopt(target="t", processor="p", runtime=None)
+
+
 def test_driver_rejects_nonpositive_block_size() -> None:
     """``block_size <= 0`` is a programming error; surface it early."""
     from vllm_mlx.spec_decode.dflash.drafter import MlxVlmDFlashDriver

--- a/tests/test_dflash_adapter_signature.py
+++ b/tests/test_dflash_adapter_signature.py
@@ -46,7 +46,6 @@ from typing import Any
 import mlx.core as mx
 import pytest
 
-
 # ---------------------------------------------------------------------------
 # Upstream-contract pins — fail loudly when mlx-vlm drifts the signature.
 # ---------------------------------------------------------------------------

--- a/tests/test_dflash_adapter_signature.py
+++ b/tests/test_dflash_adapter_signature.py
@@ -253,8 +253,17 @@ def test_driver_forwards_block_size_override(stub_mlx_vlm) -> None:
     assert stub_mlx_vlm["calls"][0]["kwargs"]["draft_block_size"] == 8
 
 
-def test_driver_accept_stats_reads_drafter_lists(stub_mlx_vlm) -> None:
-    """Pin the ``accept_lens`` / ``draft_lens`` attribute names + the math."""
+def test_driver_accept_stats_reads_drafter_lists(monkeypatch, stub_mlx_vlm) -> None:
+    """Pin the ``accept_lens`` / ``draft_lens`` attribute names + the math.
+
+    Simulates ``_dflash_rounds``'s real behavior: the round loop
+    appends to the drafter's lists DURING iteration. Reading
+    ``accept_stats()`` after the generator drains then reflects what
+    a production bench would see — and proves the driver doesn't
+    accidentally clear the lists post-iteration.
+    """
+    import mlx_vlm
+
     from vllm_mlx.spec_decode.dflash.drafter import MlxVlmDFlashDriver
 
     driver = MlxVlmDFlashDriver(
@@ -263,14 +272,31 @@ def test_driver_accept_stats_reads_drafter_lists(stub_mlx_vlm) -> None:
     )
     driver.load()
 
-    # Pre-populate so the bench sees a real number — generate() will
-    # call reset_accept_lens() which clears accept_lens; we re-populate
-    # AFTER iteration to simulate what _dflash_rounds does.
-    list(driver.generate("Hi.", max_tokens=4, temperature=0.0))
-    stub_mlx_vlm["drafter"].populate(
-        accept_lens=[3, 2, 4, 0],
-        draft_lens=[7, 7, 7, 7],
+    # Patch stream_generate to mutate the drafter's accept_lens /
+    # draft_lens between chunks — exactly the way mlx-vlm's
+    # _dflash_rounds populates them as it walks the prompt.
+    drafter = stub_mlx_vlm["drafter"]
+
+    def populating_stream_generate(model, processor, prompt, **kwargs):
+        from tests.test_dflash_adapter_signature import _FakeChunk
+
+        drafter.accept_lens.append(3)
+        drafter.draft_lens.append(7)
+        yield _FakeChunk("a", token=1, generation_tokens=1)
+        drafter.accept_lens.append(2)
+        drafter.draft_lens.append(7)
+        yield _FakeChunk("b", token=2, generation_tokens=2)
+        drafter.accept_lens.append(4)
+        drafter.draft_lens.append(7)
+        drafter.accept_lens.append(0)
+        drafter.draft_lens.append(7)
+        yield _FakeChunk("c", token=3, generation_tokens=3)
+
+    monkeypatch.setattr(
+        mlx_vlm, "stream_generate", populating_stream_generate, raising=True
     )
+
+    list(driver.generate("Hi.", max_tokens=4, temperature=0.0))
 
     stats = driver.accept_stats()
     assert stats["attempts"] == 4

--- a/tests/test_dflash_spec_decode.py
+++ b/tests/test_dflash_spec_decode.py
@@ -1181,3 +1181,30 @@ def test_bench_script_dry_run_executes_cleanly():
     assert '"conditions"' in proc.stdout
     assert '"dflash"' in proc.stdout
     assert '"block_size_override"' in proc.stdout
+
+
+def test_bench_script_rejects_duplicate_prompt_indices():
+    """``--prompt-indices 0,0,1`` must fail loudly.
+
+    Pooling the same prompt twice silently over-weights it in the
+    summary speedup. The operator likely meant to type two different
+    indices; surface the typo as a clean argparse-style error rather
+    than producing misleading benchmark numbers.
+    """
+    import subprocess
+    import sys
+
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "bench/bench_spec_decode_dflash.py",
+            "--dry-run",
+            "--prompt-indices",
+            "0,0,1",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert proc.returncode != 0
+    assert "duplicate" in proc.stderr.lower() or "duplicate" in proc.stdout.lower()

--- a/tests/test_dflash_spec_decode.py
+++ b/tests/test_dflash_spec_decode.py
@@ -1173,7 +1173,11 @@ def test_bench_script_dry_run_executes_cleanly():
         timeout=60,
     )
     assert proc.returncode == 0, proc.stderr
-    # The plan JSON must declare the two conditions and a block size.
+    # The plan JSON must declare the two conditions and a block size
+    # field. The key is ``block_size_override`` since #343 — the bench
+    # now delegates the per-run block-size policy to mlx-vlm's adaptive
+    # scaler (it's a CEILING, not a fixed value) and only sends the CLI
+    # override through when set.
     assert '"conditions"' in proc.stdout
     assert '"dflash"' in proc.stdout
-    assert '"block_size"' in proc.stdout
+    assert '"block_size_override"' in proc.stdout

--- a/vllm_mlx/spec_decode/dflash/drafter.py
+++ b/vllm_mlx/spec_decode/dflash/drafter.py
@@ -346,9 +346,7 @@ class MlxVlmDFlashDriver:
 
         from vllm_mlx.speculative.dflash import load_runtime
 
-        logger.info(
-            "[dflash.driver] Loading target via mlx-vlm: %s", self.target_repo
-        )
+        logger.info("[dflash.driver] Loading target via mlx-vlm: %s", self.target_repo)
         self._target, self._processor = _mlx_vlm_load(self.target_repo)
         logger.info(
             "[dflash.driver] Loading DFlash drafter: %s (block_size=%r)",
@@ -417,7 +415,22 @@ class MlxVlmDFlashDriver:
         )
         if self.block_size is not None:
             gen_kwargs["draft_block_size"] = self.block_size
-        yield from stream_generate(self.target, self.processor, prompt, **gen_kwargs)
+        # NOTE: deliberately not ``yield from`` here — a bare ``yield
+        # from`` would leak the upstream generator on early caller
+        # break (e.g. the bench's ``if n >= max_tokens: break``). The
+        # try/finally ensures ``stream_generate``'s GeneratorExit
+        # cleanup runs and the drafter's KV cache is released before
+        # the next prompt starts. mlx-vlm transiently doubles GPU
+        # memory if a generator's KV state isn't released — without
+        # this close() the next prompt would race a half-freed cache.
+        upstream = stream_generate(self.target, self.processor, prompt, **gen_kwargs)
+        try:
+            for chunk in upstream:
+                yield chunk
+        finally:
+            close = getattr(upstream, "close", None)
+            if callable(close):
+                close()
 
     def accept_stats(self) -> dict[str, Any]:
         """Return per-request DFlash accept stats from the underlying drafter.

--- a/vllm_mlx/spec_decode/dflash/drafter.py
+++ b/vllm_mlx/spec_decode/dflash/drafter.py
@@ -6,27 +6,56 @@ from a "block diffusion drafter": a small auxiliary model that emits
 ``block_size`` candidate tokens per forward pass given a prefix and
 the current position.
 
-Two concrete implementations live in this module:
+Three concrete pieces live in this module:
 
-1. :class:`MlxVlmBlockDiffusionDrafter` — a thin adapter around the
-   mlx-vlm 0.5.0+ DFlash drafter loader (the same backend
-   :mod:`vllm_mlx.speculative.dflash` uses). When the operator passes
-   ``--spec-decode dflash`` against a real Qwen3.5/3.6 deployment and
-   the matching drafter checkpoint is bound in the side-registry, this
-   adapter is what loads and runs the forward.
-2. :class:`StubBlockDiffusionDrafter` — a deterministic, MLX-allocation-
-   free stub used by the generator unit tests and by the bench script
-   dry-run. The stub takes a Python list of "scripted blocks" and
-   emits them one at a time on each :meth:`draft_block` call. This is
-   not the real drafter (no diffusion math, no weights) — it exists so
-   the verifier / generator wiring can be exercised without holding
-   the GPU.
+1. :class:`BlockDiffusionDrafter` — the per-block ``Protocol`` consumed
+   by :mod:`vllm_mlx.spec_decode.dflash.generator` and ...verifier.
+   This per-block contract is the **0.10 interface** — the standardized
+   ``--spec-decode dflash`` integration that pairs with rapid-mlx's own
+   generator/verifier. It is NOT what mlx-vlm 0.6.3's DFlash drafter
+   actually exposes (see #3 below); the rapid-mlx generator/verifier
+   pair around this Protocol remains scaffolding until the BatchedEngine
+   integration lands.
+2. :class:`StubBlockDiffusionDrafter` — deterministic, MLX-allocation-
+   free stub that satisfies the Protocol. Used by the generator /
+   verifier unit tests and by ``--dry-run`` smoke runs. Not a model —
+   no diffusion math, no weights, no GPU.
+3. :class:`MlxVlmDFlashDriver` — production driver. Wraps mlx-vlm
+   0.6.3's full DFlash round loop (target prefill → hidden capture →
+   :func:`mlx_vlm.speculative.dflash._dflash_rounds`) behind a single
+   :meth:`generate` method. Unlike #1 it is **not** a per-block adapter:
+   mlx-vlm 0.6.3's ``DFlashDraftModel.draft_block`` requires the target
+   model's captured hidden states as input (it is a hidden-state
+   conditioned diffusion model), so a per-block adapter cannot satisfy
+   it without owning the verify forward too. Rather than re-implement
+   the full DFlash control flow in rapid-mlx (the previous adapter at
+   this site tried and silently broke on any real call — the bench
+   could never produce a number), this class delegates the whole loop
+   to mlx-vlm's reference implementation and surfaces accept-rate /
+   tok-saved stats through the underlying drafter's ``accept_lens`` /
+   ``draft_lens`` lists.
 
-The interface is intentionally narrow: one ``draft_block(prefix_tokens,
-current_position)`` method returning a length-``block_size`` ``mx.array``
-of candidate token IDs. The verifier owns the position math, the cache
-write, and the longest-accepted-prefix decision — see
-:mod:`vllm_mlx.spec_decode.dflash.verifier`.
+Why the architecture split
+--------------------------
+
+The :class:`BlockDiffusionDrafter` Protocol describes "what an ideal
+per-block drafter looks like" from rapid-mlx's BatchedEngine point of
+view — one ``draft_block`` call returns the next block's candidate
+tokens, the verifier owns the rest. Today that contract is satisfied
+ONLY by the stub: the production mlx-vlm drafter cannot fit it because
+it needs target hidden states as input. When the BatchedEngine
+integration lands (0.10), we'll either:
+
+* extend the Protocol to thread hidden states through ``draft_block``
+  AND teach the verifier to capture + pass them, OR
+* re-architect around a "drive the whole loop" driver model that
+  matches mlx-vlm's contract more directly (which is what
+  :class:`MlxVlmDFlashDriver` already does).
+
+Until then, the bench script and the dflash-server-mode use
+:class:`MlxVlmDFlashDriver`; unit tests of the
+:mod:`...spec_decode.dflash.generator` / .verifier code path use
+:class:`StubBlockDiffusionDrafter`.
 
 Why not a duck-typed callable
 -----------------------------
@@ -47,6 +76,7 @@ The interface is a Protocol rather than a free function so:
 from __future__ import annotations
 
 import logging
+from collections.abc import Generator
 from typing import Any, Protocol
 
 import mlx.core as mx
@@ -188,116 +218,257 @@ class StubBlockDiffusionDrafter:
 
 
 # ---------------------------------------------------------------------------
-# MlxVlmBlockDiffusionDrafter — production adapter
+# MlxVlmDFlashDriver — production driver around mlx-vlm 0.6.3
 # ---------------------------------------------------------------------------
 
 
-class MlxVlmBlockDiffusionDrafter:
-    """Production adapter wrapping mlx-vlm 0.5.0+'s DFlash drafter.
+class MlxVlmDFlashDriver:
+    """Production DFlash driver — wraps mlx-vlm 0.6.3's ``stream_generate``.
 
-    The adapter loads the drafter through the SAME
-    :mod:`vllm_mlx.speculative.dflash.runtime` module the existing
-    mlx-vlm bridge uses, so a deployment that has the drafter cached
-    for the mlx-vlm bridge doesn't re-download for spec_decode.
+    Background — why this is NOT a per-block adapter
+    ------------------------------------------------
 
-    Construction is deferred until first :meth:`draft_block` so the
-    CLI boot path doesn't pay the drafter-load cost if the operator
-    asks for ``--spec-decode none``. The first call pays the load;
-    subsequent calls hit the warm drafter.
+    mlx-vlm 0.6.3 ships ``DFlashDraftModel.draft_block`` with the
+    signature::
+
+        draft_block(self, last_bonus, hidden, cache, block_size,
+                    sampler, token_dtype=mx.int32) -> mx.array
+
+    The ``hidden`` arg is the TARGET model's captured hidden states for
+    the previously-emitted positions — DFlash is a hidden-state-
+    conditioned diffusion drafter, not a token-only one. A per-block
+    adapter that knows only ``(prefix_tokens, current_position)`` (the
+    previous adapter contract here, and the
+    :class:`BlockDiffusionDrafter` Protocol above) cannot synthesize
+    those hidden states; the verifier forward owns them, and the
+    drafter's first call needs the prefill hidden state. Wiring this
+    into rapid-mlx's own verifier/generator pair would require
+    re-implementing mlx-vlm's :func:`_dflash_rounds` control flow —
+    explicitly out of scope for 0.9.
+
+    Instead, this driver wraps the WHOLE round loop. It loads target
+    + drafter via mlx-vlm's loaders, then exposes
+    :meth:`generate` which delegates to ``mlx_vlm.stream_generate``
+    with ``draft_model`` and ``draft_kind`` set. The same code path the
+    DFlash server mode uses (see :mod:`vllm_mlx.speculative.dflash.server`).
+    The bench script consumes the wrapper's generator and reads accept-
+    rate / draft-len telemetry from the underlying drafter's
+    ``accept_lens`` and ``draft_lens`` lists, which mlx-vlm populates as
+    a side effect of the loop.
+
+    Concurrency
+    -----------
+
+    mlx-vlm's DFlash path is single-stream (mlx-vlm 0.6.3 has no batched
+    DFlash kernel). Callers that need concurrency should serialize
+    through an external lock — see
+    :mod:`vllm_mlx.speculative.dflash.server` for the pattern.
 
     Args:
-        drafter_hf_path: HF path / local path passed to mlx-vlm's
-            :func:`load_drafter`. Examples: ``"z-lab/Qwen3.5-9B-DFlash"``
-            (HF), ``"/path/to/drafter"`` (local).
-        block_size: Number of tokens the drafter is configured to emit
-            per forward. Defaults to 16 (the paper bench value).
+        target_repo: HF path / local path of the target model. Loaded
+            via :func:`mlx_vlm.utils.load`.
+        drafter_repo: HF path / local path of the DFlash drafter.
+            Loaded via :func:`vllm_mlx.speculative.dflash.load_runtime`.
+        block_size: Default block size override passed to mlx-vlm's
+            ``draft_block_size`` kwarg. Defaults to ``None`` so mlx-vlm
+            uses the drafter checkpoint's trained value (typically 16).
+            When set, mlx-vlm uses it as the CEILING; the adaptive
+            ``_dflash_next_block_size`` heuristic still scales down on
+            poor acceptance unless the drafter sets
+            ``prefer_requested_block_size=True``.
     """
 
     def __init__(
         self,
-        drafter_hf_path: str,
-        block_size: int = 16,
+        target_repo: str,
+        drafter_repo: str,
+        *,
+        block_size: int | None = None,
     ) -> None:
-        if not drafter_hf_path:
-            raise ValueError("drafter_hf_path must be a non-empty string")
-        if block_size <= 0:
-            raise ValueError(f"block_size must be >= 1; got {block_size}")
-        self.drafter_hf_path = drafter_hf_path
+        if not target_repo:
+            raise ValueError("target_repo must be a non-empty string")
+        if not drafter_repo:
+            raise ValueError("drafter_repo must be a non-empty string")
+        if block_size is not None and block_size <= 0:
+            raise ValueError(f"block_size must be >= 1 or None; got {block_size}")
+        self.target_repo = target_repo
+        self.drafter_repo = drafter_repo
         self.block_size = block_size
+        self._target: Any | None = None
+        self._processor: Any | None = None
         self._runtime: Any | None = None
 
-    def _ensure_loaded(self) -> Any:
-        """Lazy-load the underlying mlx-vlm drafter runtime.
+    @property
+    def loaded(self) -> bool:
+        """True once :meth:`load` has materialized target + drafter."""
+        return self._target is not None and self._runtime is not None
 
-        Defers the import + load until the first ``draft_block`` so
-        a CLI that doesn't actually use DFlash never touches mlx-vlm.
-        """
+    @property
+    def target(self) -> Any:
+        """The loaded mlx-vlm target model. Raises if :meth:`load` hasn't run."""
+        if self._target is None:
+            raise RuntimeError("MlxVlmDFlashDriver.load() must be called first")
+        return self._target
+
+    @property
+    def processor(self) -> Any:
+        """The loaded mlx-vlm processor / tokenizer. Raises if not loaded."""
+        if self._processor is None:
+            raise RuntimeError("MlxVlmDFlashDriver.load() must be called first")
+        return self._processor
+
+    @property
+    def runtime(self) -> Any:
+        """The :class:`vllm_mlx.speculative.dflash.DFlashRuntime` handle."""
         if self._runtime is None:
-            # Reuse the existing speculative bridge so a deployment
-            # that has the drafter cached for mlx-vlm doesn't re-download.
-            from vllm_mlx.speculative.dflash import load_runtime
-
-            logger.info(
-                "[dflash.drafter] Loading mlx-vlm DFlash drafter: %s (block_size=%d)",
-                self.drafter_hf_path,
-                self.block_size,
-            )
-            self._runtime = load_runtime(self.drafter_hf_path)
+            raise RuntimeError("MlxVlmDFlashDriver.load() must be called first")
         return self._runtime
 
-    def draft_block(
-        self,
-        prefix_tokens: mx.array,
-        current_position: int,
-    ) -> mx.array:
-        """Run one drafter forward pass and return the block.
+    def load(self) -> None:
+        """Materialize the target + drafter via mlx-vlm loaders.
 
-        Delegates to the mlx-vlm drafter's ``_dflash_rounds`` call
-        adapter (the same surface the bridge uses). The mlx-vlm
-        drafter returns a ``(block_size,)`` array of token IDs at
-        every successful round; we forward that unchanged.
+        Idempotent — a second call is a no-op. Defers all heavy I/O
+        until first use so test harnesses can construct the driver
+        without paying the GB-scale weight load just to verify wiring.
 
-        On a drafter failure (mlx-vlm not installed, drafter
-        download blocked, GPU OOM) we propagate the exception — the
-        generator's outer loop catches it and falls back to the
-        no-spec-decode path for that step. We don't catch + suppress
-        here because the upper-layer fallback is the right place to
-        decide between "skip this attempt and continue" vs "disable
-        spec-decode for the rest of the session".
+        Caller is responsible for thread affinity: mlx-lm 0.31.3+ keeps
+        GPU streams in thread-local storage. Loading on thread A and
+        generating on thread B will crash. The DFlash server pins both
+        to a single-worker executor (see
+        :mod:`vllm_mlx.speculative.dflash.server` for the pattern).
         """
-        runtime = self._ensure_loaded()
-        drafter = runtime.drafter
-        # The mlx-vlm drafter exposes ``draft_block(prefix, position)``
-        # in v0.5.0+ per the bridge's surface contract. Older versions
-        # use a different name; an AttributeError here would surface as
-        # a clear "drafter doesn't implement DFlash block interface"
-        # message to the operator.
-        block = drafter.draft_block(prefix_tokens, current_position)
-        # Defensive shape check: the verifier downstream relies on the
-        # block having the right size; a drafter that silently returns
-        # a shorter block would corrupt the position-id contract.
-        if block.shape[0] != self.block_size:
+        if self.loaded:
+            return
+        # Lazy imports — leave mlx-vlm optional at module import time so
+        # an installation without ``[dflash]`` extras keeps unit tests
+        # of the Stub working.
+        from mlx_vlm import load as _mlx_vlm_load
+
+        from vllm_mlx.speculative.dflash import load_runtime
+
+        logger.info(
+            "[dflash.driver] Loading target via mlx-vlm: %s", self.target_repo
+        )
+        self._target, self._processor = _mlx_vlm_load(self.target_repo)
+        logger.info(
+            "[dflash.driver] Loading DFlash drafter: %s (block_size=%r)",
+            self.drafter_repo,
+            self.block_size,
+        )
+        self._runtime = load_runtime(self.drafter_repo)
+
+    def generate(
+        self,
+        prompt: str,
+        *,
+        max_tokens: int,
+        temperature: float = 0.0,
+        top_p: float = 1.0,
+    ) -> Generator[Any, None, None]:
+        """Drive the full DFlash round loop and yield mlx-vlm chunks.
+
+        Args:
+            prompt: The full prompt string. mlx-vlm's
+                ``stream_generate`` handles tokenization via the
+                processor.
+            max_tokens: Generation budget. Forwarded to
+                ``stream_generate``.
+            temperature: Sampling temperature. ``0.0`` selects greedy.
+            top_p: Nucleus sampling threshold. ``1.0`` disables it.
+
+        Yields:
+            ``mlx_vlm`` ``GenerationResult`` chunks, one per emitted
+            token. Each carries ``.text`` (incremental decode),
+            ``.token`` (the int id), ``.generation_tokens`` (cumulative
+            counter), and ``.prompt_tokens``. The bench script reads
+            ``.generation_tokens`` for tok/s; the accept-rate is
+            sourced from :meth:`accept_stats` after the generator is
+            exhausted.
+
+        Raises:
+            RuntimeError: If :meth:`load` hasn't been called.
+
+        Notes:
+            Resets the drafter's per-request ``accept_lens`` and
+            ``draft_lens`` so accept-rate isn't pooled across calls.
+        """
+        if not self.loaded:
             raise RuntimeError(
-                f"mlx-vlm drafter returned block of size "
-                f"{int(block.shape[0])}, expected {self.block_size}. "
-                "Check drafter checkpoint's block_size config matches "
-                "the rapid-mlx spec_decode/dflash default."
+                "MlxVlmDFlashDriver.generate() requires load() to be called first"
             )
-        return block.astype(mx.uint32)
+        # Clear per-request state so the accept-rate snapshot below
+        # only reflects this prompt's rounds. (mlx-vlm's
+        # ``DFlashDraftModel.reset`` is called by ``_dflash_rounds`` at
+        # the start of every loop, but a small belt-and-suspenders.)
+        self.runtime.reset_accept_lens()
+        drafter = self.runtime.drafter
+        if hasattr(drafter, "draft_lens") and isinstance(drafter.draft_lens, list):
+            drafter.draft_lens.clear()
 
-    def reset(self) -> None:
-        """Reset per-request drafter state.
+        # Lazy import — same rationale as in load().
+        from mlx_vlm import stream_generate
 
-        Delegates to the mlx-vlm bridge's ``reset_accept_lens`` so the
-        accept-len list doesn't pool across requests; it also clears
-        the drafter's internal KV cache via the mlx-vlm
-        ``DFlashRuntime`` adapter when the cache attribute is present.
+        gen_kwargs: dict[str, Any] = dict(
+            max_tokens=max_tokens,
+            temperature=temperature,
+            top_p=top_p,
+            draft_model=drafter,
+            draft_kind=self.runtime.kind,
+        )
+        if self.block_size is not None:
+            gen_kwargs["draft_block_size"] = self.block_size
+        yield from stream_generate(self.target, self.processor, prompt, **gen_kwargs)
+
+    def accept_stats(self) -> dict[str, Any]:
+        """Return per-request DFlash accept stats from the underlying drafter.
+
+        ``mlx_vlm`` stores per-round acceptance as two lists on the
+        drafter: ``accept_lens[i]`` = positions accepted in round ``i``,
+        ``draft_lens[i]`` = positions drafted in that round (always
+        equal to ``block_size - 1`` since the first slot is the
+        always-accepted bonus). Both are reset by :meth:`generate`.
+
+        Returns:
+            Dict with:
+              - ``attempts`` — number of verify rounds (``len(accept_lens)``).
+              - ``accepted_tokens`` — sum over accepted positions.
+              - ``drafted_tokens`` — sum of drafted positions.
+              - ``accept_rate`` — ``accepted / drafted`` (0.0 when no rounds).
+              - ``mean_accepted_per_attempt`` — ``accepted / attempts``.
+              - ``accept_lens`` — a copy of the per-round list.
+              - ``draft_lens`` — a copy of the per-round list.
         """
         if self._runtime is None:
-            return
-        self._runtime.reset_accept_lens()
-        # Clear the drafter's KV cache if the mlx-vlm drafter exposes
-        # one. Tolerant of versions that don't.
+            return {
+                "attempts": 0,
+                "accepted_tokens": 0,
+                "drafted_tokens": 0,
+                "accept_rate": 0.0,
+                "mean_accepted_per_attempt": 0.0,
+                "accept_lens": [],
+                "draft_lens": [],
+            }
         drafter = self._runtime.drafter
-        if hasattr(drafter, "reset_cache"):
-            drafter.reset_cache()
+        accept_lens = list(getattr(drafter, "accept_lens", []) or [])
+        draft_lens = list(getattr(drafter, "draft_lens", []) or [])
+        attempts = len(accept_lens)
+        accepted = int(sum(accept_lens))
+        drafted = int(sum(draft_lens))
+        accept_rate = accepted / drafted if drafted > 0 else 0.0
+        mean_accept = accepted / attempts if attempts > 0 else 0.0
+        return {
+            "attempts": attempts,
+            "accepted_tokens": accepted,
+            "drafted_tokens": drafted,
+            "accept_rate": accept_rate,
+            "mean_accepted_per_attempt": mean_accept,
+            "accept_lens": accept_lens,
+            "draft_lens": draft_lens,
+        }
+
+
+__all__ = [
+    "BlockDiffusionDrafter",
+    "StubBlockDiffusionDrafter",
+    "MlxVlmDFlashDriver",
+]

--- a/vllm_mlx/spec_decode/dflash/drafter.py
+++ b/vllm_mlx/spec_decode/dflash/drafter.py
@@ -222,6 +222,36 @@ class StubBlockDiffusionDrafter:
 # ---------------------------------------------------------------------------
 
 
+# Methods + attributes the driver invokes on the runtime handle. Pin
+# them in one place so a fresh contributor can read the contract
+# without digging through the loop body.
+_RUNTIME_REQUIRED_ATTRS: tuple[str, ...] = (
+    "drafter",  # the mlx-vlm DFlashDraftModel (read by generate())
+    "kind",  # draft_kind for stream_generate (read by generate())
+    "reset_accept_lens",  # called per-request to clear accept_lens
+)
+
+
+def _validate_runtime_contract(runtime: Any) -> None:
+    """Verify ``runtime`` exposes the surface the driver needs.
+
+    Pulled out as a helper so :meth:`MlxVlmDFlashDriver.adopt` and
+    :meth:`MlxVlmDFlashDriver.load` both validate against the same
+    list. A malformed runtime (typo, drift, mock missing a method)
+    surfaces a ``TypeError`` with the missing attribute name AT
+    ADOPTION TIME rather than as an ``AttributeError`` deep inside
+    a generator several hundred tokens in.
+    """
+    missing = [attr for attr in _RUNTIME_REQUIRED_ATTRS if not hasattr(runtime, attr)]
+    if missing:
+        raise TypeError(
+            f"runtime is missing required attribute(s) {missing}. "
+            "Expected a vllm_mlx.speculative.dflash.DFlashRuntime instance "
+            "or a compatible shim. See "
+            "vllm_mlx/speculative/dflash/runtime.py for the contract."
+        )
+
+
 class MlxVlmDFlashDriver:
     """Production DFlash driver — wraps mlx-vlm 0.6.3's ``stream_generate``.
 
@@ -353,7 +383,9 @@ class MlxVlmDFlashDriver:
             self.drafter_repo,
             self.block_size,
         )
-        self._runtime = load_runtime(self.drafter_repo)
+        runtime = load_runtime(self.drafter_repo)
+        _validate_runtime_contract(runtime)
+        self._runtime = runtime
 
     def adopt(
         self,
@@ -392,6 +424,7 @@ class MlxVlmDFlashDriver:
             )
         if target is None or processor is None or runtime is None:
             raise ValueError("adopt() requires non-None target, processor, runtime")
+        _validate_runtime_contract(runtime)
         self._target = target
         self._processor = processor
         self._runtime = runtime

--- a/vllm_mlx/spec_decode/dflash/drafter.py
+++ b/vllm_mlx/spec_decode/dflash/drafter.py
@@ -459,6 +459,10 @@ class MlxVlmDFlashDriver:
 
         Raises:
             RuntimeError: If :meth:`load` hasn't been called.
+            ValueError: If ``max_tokens < 1`` or ``top_p`` is outside
+                ``(0, 1]`` — surfaces the typo at the driver boundary
+                rather than delegating an invalid budget into
+                ``mlx_vlm.stream_generate``.
 
         Notes:
             Resets the drafter's per-request ``accept_lens`` and
@@ -468,6 +472,12 @@ class MlxVlmDFlashDriver:
             raise RuntimeError(
                 "MlxVlmDFlashDriver.generate() requires load() to be called first"
             )
+        if max_tokens < 1:
+            raise ValueError(f"max_tokens must be >= 1; got {max_tokens}")
+        if not (0.0 < top_p <= 1.0):
+            raise ValueError(f"top_p must be in (0.0, 1.0]; got {top_p}")
+        if temperature < 0.0:
+            raise ValueError(f"temperature must be >= 0.0; got {temperature}")
         # Clear per-request state so the accept-rate snapshot below
         # only reflects this prompt's rounds. (mlx-vlm's
         # ``DFlashDraftModel.reset`` is called by ``_dflash_rounds`` at

--- a/vllm_mlx/spec_decode/dflash/drafter.py
+++ b/vllm_mlx/spec_decode/dflash/drafter.py
@@ -355,6 +355,47 @@ class MlxVlmDFlashDriver:
         )
         self._runtime = load_runtime(self.drafter_repo)
 
+    def adopt(
+        self,
+        *,
+        target: Any,
+        processor: Any,
+        runtime: Any,
+    ) -> None:
+        """Inject already-loaded target + processor + runtime objects.
+
+        For callers that have already paid the mlx-vlm load cost
+        elsewhere (e.g. a bench script that wants ONE shared target
+        instance across baseline and DFlash conditions, instead of
+        loading 28+ GB of weights twice). After :meth:`adopt`,
+        :meth:`generate` and :meth:`accept_stats` work the same way
+        they would after :meth:`load`.
+
+        Args:
+            target: An ``mlx_vlm.load``-style model object — must
+                expose ``language_model`` and the DFlash hooks
+                (``capture_layer_ids``, ``rollback_speculative_cache``).
+                The bench script gets one of these via ``mlx_vlm.load``.
+            processor: The matching mlx-vlm processor / tokenizer.
+            runtime: A
+                :class:`vllm_mlx.speculative.dflash.DFlashRuntime` — the
+                loaded drafter + kind. Get one from
+                :func:`vllm_mlx.speculative.dflash.load_runtime`.
+
+        Raises:
+            ValueError: If the driver was already loaded or adopted.
+        """
+        if self.loaded:
+            raise ValueError(
+                "MlxVlmDFlashDriver is already loaded; adopt() is for "
+                "fresh instances. Construct a new driver."
+            )
+        if target is None or processor is None or runtime is None:
+            raise ValueError("adopt() requires non-None target, processor, runtime")
+        self._target = target
+        self._processor = processor
+        self._runtime = runtime
+
     def generate(
         self,
         prompt: str,


### PR DESCRIPTION
## Summary

Fixes #343. The DFlash bench script (`bench/bench_spec_decode_dflash.py`)
was non-functional because the `MlxVlmBlockDiffusionDrafter` adapter at
`vllm_mlx/spec_decode/dflash/drafter.py:275` called mlx-vlm with the
wrong signature:

```python
# rapid-mlx call:
drafter.draft_block(prefix_tokens, current_position)

# mlx-vlm 0.6.3 actual signature:
draft_block(last_bonus, hidden, cache, block_size, sampler, token_dtype)
```

The drafter is hidden-state-conditioned (mlx-vlm's `DFlashDraftModel._hidden`
mixes the target's captured hidden states into the drafter's forward); a
per-block adapter cannot synthesize those hidden states without owning the
verify forward too. Rather than re-implement mlx-vlm's `_dflash_rounds`
control flow in rapid-mlx, this PR replaces the broken adapter with
`MlxVlmDFlashDriver`, a wrapper around `mlx_vlm.stream_generate` — the
same upstream path the working DFlash server mode uses. The bench now
runs end-to-end.

The `BlockDiffusionDrafter` Protocol, `StubBlockDiffusionDrafter`, and the
deferred-to-0.10 `generator`/`verifier` pair are unchanged — those are
the 0.10 BatchedEngine-integration scaffolding, still using the per-block
contract.

## What changed

- **`vllm_mlx/spec_decode/dflash/drafter.py`** — replaced `MlxVlmBlockDiffusionDrafter` with `MlxVlmDFlashDriver`. New API: `load()` / `adopt()` (preloaded objects), `generate(prompt, max_tokens, temperature)`, `accept_stats()`. Sources accept-rate from the underlying drafter's `accept_lens` / `draft_lens` lists. Adds `_validate_runtime_contract()` to surface missing methods at adoption time rather than mid-generation.
- **`bench/bench_spec_decode_dflash.py`** — both conditions load target via `mlx_vlm.load`; baseline goes through `mlx_vlm.stream_generate` (no drafter), DFlash goes through `driver.generate(...)` via `driver.adopt(...)` (avoids loading the 28+ GB target twice). Added `--prompt-indices` for selecting a subset of the canonical 8-prompt set. Clean CLI errors for `--block-size < 0`, `--prompts < 1`, `--runs < 1`, `--max-tokens < 1`, malformed/duplicate/empty `--prompt-indices`. Schema change: per-run `tokens_saved` renamed to `drafted_tokens` so the summary can report a true accept rate (`accepted / drafted`) separately from `accepted / attempts`.
- **`tests/test_dflash_adapter_signature.py` (new)** — 15 regression tests pinning the mlx-vlm contract via `inspect.signature` plus driver-level wiring tests against a fake `stream_generate`. A future mlx-vlm bump that drifts the signature trips a clear assertion here instead of producing silently-wrong bench numbers.
- **`tests/test_dflash_spec_decode.py`** — one assertion updated to reflect the `block_size_override` JSON key rename; added a regression test for the duplicate-indices error path.

## Honest bench numbers (M3 Ultra)

`mlx-community/Qwen3.5-27B-8bit` + `z-lab/Qwen3.5-27B-DFlash`, temp=0, max_tokens=256, 1 run × 3 profile prompts:

| Profile | Baseline tok/s | DFlash tok/s | Speedup | Accept (per slot) | Mean accepted / attempt |
|---|---|---|---|---|---|
| code (Fibonacci memoization) | 13.9 | 22.8 | **1.64×** | 68.1% | 4.22 |
| chat (Moby-Dick summary)      | 16.6 | 18.8 | **1.13×** | 44.4% | 1.68 |
| math (trains problem)         | 18.5 | 27.4 | **1.48×** | 65.8% | 4.57 |
| **pooled**                    | 16.1 | 22.5 | **1.40×** | 58.7% | 3.04 |

## Honesty notes

The 0.9-TODO 体感 3 row 2 claim was 2.34× math / 2.22× adaptive on the
same model + drafter pair. **Those numbers do NOT reproduce** on this
bench — math prompt 1.48×, pooled 1.40×. The prior numbers must have
come from a different harness — this bench was broken (it would have
raised on the first real call into mlx-vlm).

Possible reasons for the gap:
1. Different hardware (this is M3 Ultra; the historical claim doesn't record device)
2. Different prompt mix (the 体感 set may have been more code-heavy; code shows 1.64× here, the highest of the three)
3. HF revision drift on the `z-lab/Qwen3.5-27B-DFlash` checkpoint

**Gate status**: 3.5× lossless is UNREACHABLE on this configuration at
temp=0 with this bench. Per memory `[[root-cause-before-release-notes-downgrade]]`,
flagging here for operator decision rather than proposing a downgrade.

## Notes on `pr_validate` scorecard

- **`codex_review` PASS** (2 NITs surfaced, no blocking). One NIT recommends keeping a deprecated `MlxVlmBlockDiffusionDrafter` shim. The task spec for this fix is explicit: "Don't add backwards-compat shims; rename in callers." The old class never produced a working bench (it would have raised at the first real mlx-vlm call — that's the bug this PR fixes), so the loss of import compatibility is intentional. The other NIT about validating `--prompts >= 1` is fixed.
- **`full_unit` FAIL — 8 failures, all pre-existing on `origin/main`**. Verified by running the same `pytest tests/` invocation on a fresh `origin/main` worktree (see `/tmp/mtp-baseline-fail.log`): same 8 tests fail. 7 of them are MTP / dflash-lossless cross-thread MLX GPU stream errors (`RuntimeError: There is no Stream(gpu, 11) in current thread`), and 1 is `test_alias_profile_str_fields_are_explicitly_listed` complaining about the (also pre-existing) `turboquant_tier` field. None of the failing tests touch DFlash code modified in this PR; all 111 DFlash-related tests in `tests/test_dflash_*.py` pass.

## Test plan

- 111 dflash-related tests pass (eligibility + integration + spec_decode + new adapter_signature) ✓
- bench `--dry-run --format json` produces expected schema ✓
- bench end-to-end with 3 prompts × 1 run × 256 tokens completes cleanly with non-zero accept rates ✓
- CLI validates `--block-size`, `--prompts`, `--runs`, `--max-tokens`, `--prompt-indices` (bad int / out-of-range / duplicate / empty) → exit 2 + clear "error: ..." ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)