### PR TITLE
fix(tests): register turboquant_tier in ALLOWED_STR_FIELDS gate (#355)

### DIFF
--- a/tests/test_no_out_of_band_routing.py
+++ b/tests/test_no_out_of_band_routing.py
@@ -1237,6 +1237,18 @@ def test_alias_profile_str_fields_are_explicitly_listed():
             # validated by VALID_PFLASH_TIERS at JSON load — so a typo'd
             # value fails loud rather than misrouting.
             "pflash_tier",
+            # TurboQuant K8V4 default-on tier (issue #355, PR #952). One
+            # of VALID_TURBOQUANT_TIERS ({"unknown", "k8v4_verified"}).
+            # Same routing-vs-data tradeoff as ``pflash_tier``: the
+            # value flips the engine's no-flag ``--kv-cache-turboquant``
+            # default, but the value space is a closed enum, the
+            # explicit CLI flag still wins, and ``_coerce`` validates
+            # against ``VALID_TURBOQUANT_TIERS`` at JSON load so a
+            # typo'd value fails loud at startup rather than silently
+            # misrouting. New tier fields with this shape MUST be
+            # registered here AND in their VALID_*_TIERS enum — adding
+            # the dataclass field alone is what broke the gate in #952.
+            "turboquant_tier",
         }
     )
 


### PR DESCRIPTION
## Summary

PR #952 ([commit `d6b59fb4`](https://github.com/raullenchai/Rapid-MLX/commit/d6b59fb4), 2026-06-27 15:09Z) added the `turboquant_tier` string field to `AliasProfile` and flipped 10 hero MoE aliases in `vllm_mlx/aliases.json` to `turboquant_tier: "k8v4_verified"`. The author forgot to register `turboquant_tier` in the `ALLOWED_STR_FIELDS` allowlist in `tests/test_no_out_of_band_routing.py::test_alias_profile_str_fields_are_explicitly_listed` — the gate that surfaces every `str`-typed `AliasProfile` field at PR review time so closed-enum routing fields don't slip in unannotated.

Consequence: that test has been **failing on `main` and every PR branch since #952 merged**.

## Fix

One change, one file. Add `turboquant_tier` to the `ALLOWED_STR_FIELDS` frozenset with a comment that mirrors the existing `pflash_tier` entry — same routing-vs-data tradeoff (enum value flips a no-flag CLI default, explicit `--kv-cache-turboquant` flag still wins, value space is closed and validated at JSON load by `VALID_TURBOQUANT_TIERS`).

The comment also explicitly calls out the omission pattern from #952 so the next contributor adding a tier-shaped field has the registration pattern visible.

## Scope (deliberately tight)

- `vllm_mlx/aliases.json` — **NOT touched** (the data is correct; the registry was stale)
- `vllm_mlx/turboquant.py` — **NOT touched** (PR #955 owns it)
- `vllm_mlx/model_aliases.py` — **NOT touched** (`_ALLOWED_PROFILE_KEYS` and `VALID_TURBOQUANT_TIERS` were already updated correctly by #952)

Only the test-side gate registry was missed.

## Test plan

- [x] Reproduce the failure on `main`: `pytest tests/test_no_out_of_band_routing.py::test_alias_profile_str_fields_are_explicitly_listed` fails with `AliasProfile has unlisted string field(s): ['turboquant_tier']`
- [x] After fix: target test PASS
- [x] Sibling gate files end-to-end pass: `tests/test_no_out_of_band_routing.py`, `tests/test_no_mllm_flag.py`, `tests/test_aliases_contract.py`, `tests/test_model_aliases.py` — 1527 passed
- [x] `pr_validate` run locally — see PR comments for scorecard. `targeted_tests`, `lint`, `codex_review`, `supply_chain`, `test_env_check`, `cl_description_quality` all PASS. `full_unit` MTP failures (`test_mtp_*`) are pre-existing on `main` (cross-thread `RuntimeError: There is no Stream(gpu, 11)` from MTP generator) and out of scope for this PR (parallel agent owns MTP test files; see issue #354).

Closes #355.