### PR TITLE
fix(tokenizer): skip repair_byte_level_decoder on Gemma 4 hybrid tokenizers (#950)

### DIFF
--- a/tests/test_tokenizer_gemma4_hybrid.py
+++ b/tests/test_tokenizer_gemma4_hybrid.py
@@ -1,0 +1,415 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for issue #950 — Gemma 4 hybrid tokenizer space corruption.
+
+PR #793 (``repair_byte_level_decoder``) misfires on hybrid SentencePiece-
+metaspace + GPT-2-byte-level tokenizers like Gemma 4
+(``mlx-community/gemma-4-26b-a4b-it-4bit``). Mechanism:
+
+  1. Gemma 4's vocab contains legitimate GPT-2 byte tokens (id 240630 =
+     ``ĉ`` for tab) alongside the dominant SentencePiece ``▁``-prefixed
+     space tokens.
+  2. PR #793's probe finds the legit ``ĉ`` byte token, sees the SP
+     decoder fails to invert it (``ByteFallback`` doesn't know about
+     GPT-2 pretty-byte encoding), and declares the tokenizer "broken".
+  3. PR #793 swaps the whole decoder for a bare ``ByteLevel()``,
+     dropping the load-bearing ``Replace("▁", " ")`` step.
+  4. Post-swap verify only re-decodes the probe byte token (now clean)
+     — never notices spaces are now ``▁``-corrupted.
+
+  Result: every space in ``content``, ``reasoning_content``, streaming
+  deltas, and ``/v1/completions[0].text`` becomes ``▁`` (U+2581).
+
+The fix (two gates inside ``repair_byte_level_decoder``):
+
+  * **Gate 2** — bail before mutating if the existing decoder already
+    contains a ``Replace("▁", " ")`` step AND a ``encode("a b c")``
+    sample produces tokens containing ``▁`` (the load-bearing
+    metaspace indicator). The latter check is the disambiguator: a
+    pure GPT-2 byte-level vocab with a *mis-applied* SP decoder (the
+    PR #793 target, DeepSeek-R1 distills) ALSO has the ``Replace``
+    step in its decoder, but its vocab uses ``Ġ`` (not ``▁``) for
+    spaces — so the encode-sample check correctly distinguishes the
+    two cases.
+
+  * **Gate 3** — even if a future hybrid we haven't seen slips past
+    gate 2, after the swap decode ``encode("a b c")`` and assert no
+    ``▁`` leaks. If it does, revert to the original decoder.
+
+This test file pins both gates with a synthetic reproducer (no
+download required, runs in CI) AND a real-Gemma-4 reproducer
+(``AutoTokenizer.from_pretrained`` only — no model load).
+"""
+
+from __future__ import annotations
+
+import pytest
+from tokenizers import Tokenizer, decoders, models, pre_tokenizers
+from transformers import AutoTokenizer, PreTrainedTokenizerFast
+
+from vllm_mlx.utils.tokenizer import (
+    _decoder_has_metaspace_replace,
+    _METASPACE_MARKER,
+    repair_byte_level_decoder,
+)
+
+# Real Gemma 4 alias the bug reporter used. The model weights are NOT
+# downloaded — ``AutoTokenizer.from_pretrained`` only fetches the
+# tokenizer files (tokenizer.json + tokenizer_config.json + sidecars),
+# which total a few MB and are cached on first run.
+_GEMMA4_ALIAS = "mlx-community/gemma-4-26b-a4b-it-4bit"
+
+
+def _build_synthetic_gemma4_hybrid() -> PreTrainedTokenizerFast:
+    """Synthetic reproducer of Gemma 4's hybrid tokenizer shape.
+
+    Vocab combines:
+      * SentencePiece ``▁``-prefixed space tokens (dominant)
+      * A legit GPT-2-pretty byte token (``ĉ`` = tab) — the probe trap
+        that fooled PR #793 into mis-classifying Gemma 4 as broken.
+
+    Decoder is the real Gemma 4 chain:
+      ``Sequence([Replace("▁", " "), ByteFallback(), Fuse()])``
+
+    On THIS tokenizer:
+      * ``decode([▁quick id])`` correctly returns ``" quick"`` (via the
+        ``Replace`` step).
+      * ``decode([ĉ id])`` returns ``"ĉ"`` verbatim because
+        ``ByteFallback`` doesn't know GPT-2 pretty-byte encoding.
+
+    The pre-fix ``repair_byte_level_decoder`` "fixes" the latter at the
+    cost of the former. The fix gate 2 must bail before mutating so the
+    spaces survive.
+    """
+    vocab = {
+        "<pad>": 0,
+        "<eos>": 1,
+        "<unk>": 2,
+        "▁the": 3,
+        "the": 4,
+        "▁quick": 5,
+        "▁brown": 6,
+        "▁fox": 7,
+        # The trap: legit GPT-2-pretty byte token that PR #793's probe
+        # would have flagged as "broken decoder".
+        "ĉ": 8,
+        # Single-char SP tokens so ``encode("a b c")`` produces the
+        # ``▁`` metaspace marker tokens that gate 2's disambiguator
+        # depends on.
+        "▁a": 9,
+        "▁b": 10,
+        "▁c": 11,
+    }
+    wl = models.WordLevel(vocab=vocab, unk_token="<unk>")
+    rust = Tokenizer(wl)
+    # Match Gemma 4's tokenizer pipeline (Metaspace converts ASCII
+    # spaces into the ``▁`` metaspace marker at the pre-tokenizer
+    # stage). Without this, ``encode("a b c")`` cannot produce
+    # ``▁``-containing tokens and gate 2's disambiguator can't tell
+    # the synthetic hybrid apart from a pure-byte-level vocab.
+    rust.pre_tokenizer = pre_tokenizers.Metaspace()
+    rust.decoder = decoders.Sequence(
+        [
+            decoders.Replace("▁", " "),
+            decoders.ByteFallback(),
+            decoders.Fuse(),
+        ]
+    )
+    return PreTrainedTokenizerFast(
+        tokenizer_object=rust,
+        eos_token="<eos>",
+        pad_token="<pad>",
+        unk_token="<unk>",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Gate 2 helper: _decoder_has_metaspace_replace
+# ---------------------------------------------------------------------------
+
+
+class TestDecoderHasMetaspaceReplace:
+    """Pin the helper that drives gate 2 — must detect ``Replace('▁',' ')``
+    whether top-level or nested inside a ``Sequence``."""
+
+    def test_detects_top_level_replace(self) -> None:
+        d = decoders.Replace("▁", " ")
+        assert _decoder_has_metaspace_replace(d) is True
+
+    def test_detects_replace_nested_in_sequence(self) -> None:
+        d = decoders.Sequence(
+            [
+                decoders.Replace("▁", " "),
+                decoders.ByteFallback(),
+                decoders.Fuse(),
+            ]
+        )
+        assert _decoder_has_metaspace_replace(d) is True
+
+    def test_returns_false_for_bare_byte_level(self) -> None:
+        d = decoders.ByteLevel()
+        assert _decoder_has_metaspace_replace(d) is False
+
+    def test_returns_false_for_replace_with_different_pattern(self) -> None:
+        # Different character — not the metaspace marker.
+        d = decoders.Replace("X", " ")
+        assert _decoder_has_metaspace_replace(d) is False
+
+    def test_returns_false_for_replace_with_different_content(self) -> None:
+        # Correct pattern but different replacement — not a space.
+        d = decoders.Replace("▁", "_")
+        assert _decoder_has_metaspace_replace(d) is False
+
+
+# ---------------------------------------------------------------------------
+# Gate 2: synthetic reproducer — hybrid tokenizer must NOT have its
+# decoder swapped, and spaces must round-trip cleanly.
+# ---------------------------------------------------------------------------
+
+
+class TestGate2SyntheticHybrid:
+    """The pre-fix bug: PR #793 would swap the decoder out, dropping
+    ``Replace("▁", " ")``, and the next ``decode`` round-trip would
+    leak ``▁`` into model output. Gate 2 must bail BEFORE the swap."""
+
+    def test_synthetic_hybrid_decode_clean_before_repair(self) -> None:
+        """Sanity: the synthetic hybrid tokenizer round-trips spaces
+        correctly with its native decoder. This is the contract we
+        must not break."""
+        tok = _build_synthetic_gemma4_hybrid()
+        ids = [4, 5, 6, 7]  # "the ▁quick ▁brown ▁fox"
+        assert tok.decode(ids) == "the quick brown fox"
+
+    def test_repair_returns_false_on_synthetic_hybrid(self) -> None:
+        """Gate 2: with a metaspace ``Replace`` step in the decoder AND
+        ``▁`` in the spaced-encoding sample, repair must short-circuit
+        without mutation."""
+        tok = _build_synthetic_gemma4_hybrid()
+        assert repair_byte_level_decoder(tok) is False
+
+    def test_repair_does_not_corrupt_spaces_on_synthetic_hybrid(self) -> None:
+        """The actual user-visible bug: every space becomes ``▁`` after
+        repair. This test FAILS pre-fix and PASSES post-fix."""
+        tok = _build_synthetic_gemma4_hybrid()
+        ids = [4, 5, 6, 7]
+        repair_byte_level_decoder(tok)
+        # No metaspace marker leakage post-repair.
+        decoded = tok.decode(ids)
+        assert _METASPACE_MARKER not in decoded, (
+            f"space corruption regression: decoded={decoded!r}"
+        )
+        assert decoded == "the quick brown fox"
+
+    def test_repair_leaves_decoder_unchanged_on_synthetic_hybrid(self) -> None:
+        """Gate 2 is a no-op contract: not just decode parity, but the
+        live decoder object must remain identical. Catches a future
+        regression where someone refactors gate 2 to "swap then revert"
+        instead of "bail outright"."""
+        tok = _build_synthetic_gemma4_hybrid()
+        decoder_before = tok.backend_tokenizer.decoder
+        before_state = decoder_before.__getstate__()
+        repair_byte_level_decoder(tok)
+        after_state = tok.backend_tokenizer.decoder.__getstate__()
+        assert before_state == after_state, (
+            f"decoder mutated by gate-2 path:\n"
+            f"  before: {before_state!r}\n  after:  {after_state!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Gate 2: real Gemma 4 reproducer (tokenizer-only, no model weights).
+# This is the exact reproducer from the bug report.
+# ---------------------------------------------------------------------------
+
+
+class TestGate2RealGemma4:
+    """Pin the issue-#950 reproducer end-to-end on the real Gemma 4
+    tokenizer. Tokenizer files only — no model weights, no MLX load."""
+
+    @pytest.fixture(scope="class")
+    def gemma4_tokenizer(self):
+        return AutoTokenizer.from_pretrained(_GEMMA4_ALIAS)
+
+    def test_issue_950_reproducer_fixed(self, gemma4_tokenizer) -> None:
+        """The exact reproducer from issue #950: ``decode(encode("the
+        quick brown fox"))`` must round-trip cleanly even AFTER calling
+        ``repair_byte_level_decoder``. Pre-fix the spaces became ``▁``;
+        post-fix the round-trip is identity."""
+        tok = gemma4_tokenizer
+        text = "the quick brown fox"
+        ids = tok.encode(text, add_special_tokens=False)
+        # Sanity: native round-trip works.
+        assert tok.decode(ids) == text, "Gemma 4 native decode is broken"
+        repair_byte_level_decoder(tok)
+        # The fix: round-trip still works after calling repair.
+        assert tok.decode(ids) == text, (
+            f"issue #950 regression: decode after repair = {tok.decode(ids)!r}, "
+            f"expected {text!r}"
+        )
+
+    def test_gemma4_repair_returns_false(self, gemma4_tokenizer) -> None:
+        """Gate 2 short-circuits: repair returns False (no mutation) on
+        Gemma 4 — not True (swap applied)."""
+        tok = gemma4_tokenizer
+        assert repair_byte_level_decoder(tok) is False
+
+    def test_gemma4_multiple_spaced_phrases(self, gemma4_tokenizer) -> None:
+        """Broad coverage: a variety of spaced inputs all round-trip
+        cleanly after repair, locking that the fix covers more than
+        just the single phrase the bug report used."""
+        tok = gemma4_tokenizer
+        repair_byte_level_decoder(tok)
+        for text in [
+            "hello world",
+            "a b c d e f",
+            "The answer is 42.",
+            "Lorem ipsum dolor sit amet",
+            "  leading and trailing spaces  ",
+        ]:
+            ids = tok.encode(text, add_special_tokens=False)
+            decoded = tok.decode(ids)
+            assert _METASPACE_MARKER not in decoded, (
+                f"metaspace leaked for {text!r}: decoded={decoded!r}"
+            )
+
+    def test_gemma4_decoder_not_mutated(self, gemma4_tokenizer) -> None:
+        """Gate 2: the real Gemma 4 decoder object must remain
+        identical (same JSON state) after a repair call."""
+        tok = gemma4_tokenizer
+        before = tok.backend_tokenizer.decoder.__getstate__()
+        repair_byte_level_decoder(tok)
+        after = tok.backend_tokenizer.decoder.__getstate__()
+        assert before == after, "Gemma 4 decoder unexpectedly mutated"
+
+
+# ---------------------------------------------------------------------------
+# PR #793 still works: DeepSeek/Qwen-style mis-paired SP decoder over
+# pure GPT-2-byte-level vocab. Gate 2's disambiguator (encode("a b c")
+# must produce ``▁``-containing tokens) MUST distinguish this case from
+# the Gemma 4 hybrid and let the swap proceed.
+# ---------------------------------------------------------------------------
+
+
+class TestPR793PathStillRepairs:
+    """The PR #793 win — DeepSeek-R1 distills with a mis-paired Llama SP
+    decoder over a pure GPT-2-byte-level vocab — must STILL get its
+    decoder swapped. Locks that gate 2's disambiguator works."""
+
+    def test_simulated_deepseek_r1_distill_still_repairs(self) -> None:
+        """Take a real GPT-2-byte-level tokenizer (Qwen3 — same shape as
+        DeepSeek-R1 distills) and force-replace its decoder with the
+        broken Llama SP chain. This reproduces the exact malformation
+        PR #793 was meant to fix. Gate 2 must NOT fire here (vocab
+        encodes spaces as ``Ġ``, not ``▁``), so the swap proceeds and
+        ``decode`` is repaired."""
+        tok = AutoTokenizer.from_pretrained("mlx-community/Qwen3-0.6B-4bit")
+        # Force the bug: swap in the Llama SP decoder chain. The vocab
+        # itself is unchanged (still pure GPT-2 byte-level).
+        tok.backend_tokenizer.decoder = decoders.Sequence(
+            [
+                decoders.Replace("▁", " "),
+                decoders.ByteFallback(),
+                decoders.Fuse(),
+                decoders.Strip(" ", 1, 0),
+            ]
+        )
+        ids = tok.encode("hello world", add_special_tokens=False)
+        # Pre-repair: the ``Ġ`` mojibake leaks because the SP decoder
+        # doesn't know how to invert GPT-2 pretty-byte tokens.
+        broken = tok.decode(ids)
+        assert "Ġ" in broken, (
+            f"reproducer didn't break Qwen3 decoder as expected: {broken!r}"
+        )
+        # Post-repair: swap fires, mojibake is gone.
+        assert repair_byte_level_decoder(tok) is True
+        repaired = tok.decode(ids)
+        assert repaired == "hello world", (
+            f"PR #793 repair path broken: {repaired!r}"
+        )
+
+    def test_pure_byte_level_vocab_with_sp_decoder_falls_to_gate_2_safely(
+        self,
+    ) -> None:
+        """A synthetic vocab with NO ``▁`` tokens but a SP-style decoder
+        — exactly the shape PR #793's existing
+        ``test_streaming_detokenizer_bpe.py::_build_broken_tokenizer``
+        fixture targets. Gate 2's encode-sample check finds no ``▁`` in
+        the vocab so the swap must proceed."""
+        vocab = {
+            "<pad>": 0,
+            "<s>": 1,
+            "</s>": 2,
+            "Hello": 3,
+            "ĠHello": 4,
+            "Ġworld": 5,
+            "Ċ": 6,
+        }
+        bpe = models.BPE(vocab=vocab, merges=[])
+        rust = Tokenizer(bpe)
+        rust.pre_tokenizer = pre_tokenizers.ByteLevel(add_prefix_space=False)
+        rust.decoder = decoders.Sequence(
+            [
+                decoders.Replace("▁", " "),
+                decoders.ByteFallback(),
+                decoders.Fuse(),
+                decoders.Strip(" ", 1, 0),
+            ]
+        )
+        tok = PreTrainedTokenizerFast(
+            tokenizer_object=rust,
+            eos_token="</s>",
+            bos_token="<s>",
+            pad_token="<pad>",
+        )
+        # Pre-repair: ``Ġ`` leaks.
+        assert "Ġ" in tok.decode([4, 5], skip_special_tokens=False)
+        # Gate 2 sees the SP ``Replace`` in the decoder, but
+        # ``encode("a b c")`` on this synthetic vocab returns no
+        # tokens containing ``▁`` (the BPE has no ``▁`` entries) — so
+        # gate 2's disambiguator clears it and the swap proceeds.
+        assert repair_byte_level_decoder(tok) is True
+        assert "Ġ" not in tok.decode([4, 5], skip_special_tokens=False)
+
+
+# ---------------------------------------------------------------------------
+# Gate 3: belt-and-braces — even a hybrid that slips past gate 2 (e.g.
+# a future model with a metaspace ``Replace`` we don't recognise via
+# ``__getstate__``) must have its swap reverted when the post-swap
+# spaced-sample decode leaks ``▁``.
+# ---------------------------------------------------------------------------
+
+
+class TestGate3SpacedSampleVerification:
+    """Lock the gate-3 fail-closed contract."""
+
+    def test_gate_3_reverts_when_metaspace_leaks_post_swap(
+        self, monkeypatch
+    ) -> None:
+        """Simulate a "future hybrid we haven't seen": force gate 2 to
+        clear (by neutering ``_decoder_has_metaspace_replace``), so the
+        swap runs. The swap is now a regression because the vocab uses
+        ``▁``. Gate 3's spaced-sample decode must catch it and revert.
+        """
+        tok = _build_synthetic_gemma4_hybrid()
+        # Neuter gate 2 — pretend the decoder has no metaspace step,
+        # so the swap path will run.
+        from vllm_mlx.utils import tokenizer as _toktools
+
+        monkeypatch.setattr(
+            _toktools, "_decoder_has_metaspace_replace", lambda d: False
+        )
+
+        # Capture the original decoder state for revert verification.
+        original_state = tok.backend_tokenizer.decoder.__getstate__()
+
+        # Repair must run, hit the swap, and gate 3 must catch the
+        # metaspace leak in the post-swap spaced sample.
+        result = repair_byte_level_decoder(tok)
+        assert result is False, "gate 3 should have caught metaspace leak"
+
+        # Decoder reverted to original state — not left as ByteLevel.
+        assert tok.backend_tokenizer.decoder.__getstate__() == original_state, (
+            "gate 3 must revert decoder when spaced-sample verify fails"
+        )
+
+        # And of course the spaces still round-trip cleanly.
+        assert tok.decode([4, 5, 6, 7]) == "the quick brown fox"

--- a/tests/test_tokenizer_gemma4_hybrid.py
+++ b/tests/test_tokenizer_gemma4_hybrid.py
@@ -47,8 +47,8 @@ from tokenizers import Tokenizer, decoders, models, pre_tokenizers
 from transformers import AutoTokenizer, PreTrainedTokenizerFast
 
 from vllm_mlx.utils.tokenizer import (
-    _decoder_has_metaspace_replace,
     _METASPACE_MARKER,
+    _decoder_has_metaspace_replace,
     repair_byte_level_decoder,
 )
 
@@ -322,9 +322,7 @@ class TestPR793PathStillRepairs:
         # Post-repair: swap fires, mojibake is gone.
         assert repair_byte_level_decoder(tok) is True
         repaired = tok.decode(ids)
-        assert repaired == "hello world", (
-            f"PR #793 repair path broken: {repaired!r}"
-        )
+        assert repaired == "hello world", f"PR #793 repair path broken: {repaired!r}"
 
     def test_pure_byte_level_vocab_with_sp_decoder_falls_to_gate_2_safely(
         self,
@@ -381,9 +379,7 @@ class TestPR793PathStillRepairs:
 class TestGate3SpacedSampleVerification:
     """Lock the gate-3 fail-closed contract."""
 
-    def test_gate_3_reverts_when_metaspace_leaks_post_swap(
-        self, monkeypatch
-    ) -> None:
+    def test_gate_3_reverts_when_metaspace_leaks_post_swap(self, monkeypatch) -> None:
         """Simulate a "future hybrid we haven't seen": force gate 2 to
         clear (by neutering ``_decoder_has_metaspace_replace``), so the
         swap runs. The swap is now a regression because the vocab uses

--- a/vllm_mlx/utils/tokenizer.py
+++ b/vllm_mlx/utils/tokenizer.py
@@ -52,6 +52,73 @@ _BYTE_LEVEL_MOJIBAKE_MARKERS: tuple[str, ...] = (
     "ĉ",  # 'ĉ' — GPT-2 byte-level encoding of tab
 )
 
+# SentencePiece metaspace marker — ``▁`` (U+2581). Hybrid SP/byte-level
+# tokenizers (Gemma 4, future GG-style models) encode word boundaries
+# with this character and rely on a ``Replace("▁", " ")`` decoder step
+# to surface them as ASCII spaces. Issue #950 (Gemma 4): swapping the
+# whole decoder for a bare GPT-2 ``ByteLevel`` drops that ``Replace``
+# step and corrupts EVERY space in model output. Gate 2 in
+# ``repair_byte_level_decoder`` detects this configuration and bails
+# before any mutation; gate 3 catches future hybrids that slip past
+# gate 2 by post-swap-decoding a spaced sample and reverting if any
+# ``▁`` leaks. Both gates use this marker.
+_METASPACE_MARKER = "▁"  # ▁
+
+
+def _decoder_has_metaspace_replace(decoder) -> bool:
+    """Return True if ``decoder`` contains a ``Replace("▁", " ")`` step.
+
+    SentencePiece-metaspace tokenizers (Gemma family, Llama base, ...)
+    encode word boundaries as ``▁`` (U+2581) in the vocab and rely on a
+    ``Replace("▁", " ")`` decoder step to surface them as ASCII spaces.
+    A ``Replace`` step may be the top-level decoder OR nested inside a
+    ``Sequence`` (e.g. Gemma 4 ships
+    ``Sequence([Replace("▁"," "), ByteFallback(), Fuse()])``).
+
+    Gate 2 of issue #950 (Gemma 4): when this returns True, the caller
+    must NOT swap the decoder out for a bare ``ByteLevel`` — that would
+    drop the ``Replace`` step and corrupt every space in model output.
+    Such tokenizers are HYBRIDS (SP metaspace + legit GPT-2-pretty byte
+    tokens) and the rare cosmetic byte-token issue PR #793 was solving
+    is not worth universal space corruption.
+
+    Inspects the Rust decoder via ``__getstate__`` which returns a JSON
+    bytes blob describing the decoder tree. We walk it for any
+    ``{"type": "Replace", "pattern": {"String": "▁"}, "content": " "}``
+    node (or ``Regex`` variant of the pattern). Returns False on any
+    introspection failure — a fail-open default that does not block
+    legitimate repairs on tokenizers whose state can't be parsed.
+    """
+    try:
+        state_raw = decoder.__getstate__()
+    except Exception:
+        return False
+    try:
+        state = json.loads(state_raw)
+    except Exception:
+        return False
+
+    def _walk(node) -> bool:
+        if not isinstance(node, dict):
+            return False
+        ntype = node.get("type")
+        if ntype == "Replace":
+            pattern = node.get("pattern") or {}
+            content = node.get("content", "")
+            # The ``pattern`` slot is a discriminated union — either
+            # ``{"String": "<lit>"}`` or ``{"Regex": "<re>"}``. We
+            # accept either if it matches the metaspace marker.
+            pattern_str = pattern.get("String") or pattern.get("Regex") or ""
+            if pattern_str == _METASPACE_MARKER and content == " ":
+                return True
+        if ntype == "Sequence":
+            for child in node.get("decoders", []) or []:
+                if _walk(child):
+                    return True
+        return False
+
+    return _walk(state)
+
 
 def repair_byte_level_decoder(tokenizer) -> bool:
     """Repair a mis-configured byte-level BPE decoder in place.
@@ -83,6 +150,24 @@ def repair_byte_level_decoder(tokenizer) -> bool:
     ``decode([id])`` still contains the marker, swap the live
     ``backend_tokenizer.decoder`` for a plain GPT-2 ``ByteLevel`` decoder.
     The vocab itself is correct — only the decoder side needs swapping.
+
+    **Two safety gates for HYBRID tokenizers (issue #950, Gemma 4):**
+
+    * **Gate 2** — short-circuit when the existing decoder already
+      contains a ``Replace("▁", " ")`` step. Such tokenizers are
+      SentencePiece-metaspace hybrids: vocab has both ``▁``-prefixed
+      space tokens (the dominant case) AND a few legit GPT-2-pretty
+      byte tokens (e.g. Gemma 4's id-240630 ``ĉ`` for tab). The byte
+      probe trips on those rare tokens, but swapping the decoder out
+      drops the ``Replace`` step and corrupts every space — a
+      universal cosmetic regression in exchange for a rare cosmetic
+      fix. Bail before any mutation.
+
+    * **Gate 3** — even after the swap clears the probe, decode a
+      spaced sample (``encode("a b c")`` → ``decode(...)``) and assert
+      no ``▁`` (U+2581) leaks. If it does, restore the original
+      decoder and return False. This catches any future hybrid that
+      slips past gate 2.
 
     Idempotent: a second call on a healthy tokenizer is a no-op.
 
@@ -122,6 +207,46 @@ def repair_byte_level_decoder(tokenizer) -> bool:
         # is healthy by construction.
         return False
     backend = inner.backend_tokenizer
+
+    # Gate 2 (issue #950): HYBRID tokenizers (SentencePiece metaspace +
+    # legit GPT-2-pretty byte tokens) — e.g. Gemma 4 — keep their
+    # existing decoder. Their vocab has both ``▁``-prefixed tokens AND
+    # a few legit byte tokens like ``ĉ`` (tab); the byte probe trips
+    # on the legit byte tokens, but swapping the decoder out drops the
+    # ``Replace("▁", " ")`` step and corrupts every space.
+    #
+    # PR #793's target — DeepSeek/Qwen with a mis-paired Llama SP
+    # decoder over a pure-GPT-2-byte-level vocab — ALSO carries a
+    # ``Replace("▁", " ")`` step in its (broken) decoder, so the decoder-
+    # shape check alone would over-fire. The disambiguator: pure-GPT-2-
+    # byte-level vocabs (DeepSeek distills, Qwen3) ENCODE spaces as
+    # ``Ġ`` and have NO ``▁`` in their vocab — so the (mis-applied)
+    # ``Replace`` step is a no-op and the swap is safe. Hybrid Gemma-4-
+    # style vocabs ENCODE spaces as ``▁`` — encoding "a b c" yields
+    # tokens containing ``▁``. We tell the two apart by encoding a
+    # known-spaced sample: if the resulting tokens contain ``▁``, the
+    # ``Replace`` step is LOAD-BEARING and we must not swap.
+    if _decoder_has_metaspace_replace(backend.decoder):
+        try:
+            spaced_ids = inner.encode("a b c", add_special_tokens=False)
+            spaced_tokens = inner.convert_ids_to_tokens(spaced_ids)
+        except Exception:
+            spaced_tokens = []
+        if any(
+            isinstance(t, str) and _METASPACE_MARKER in t for t in spaced_tokens
+        ):
+            # Hybrid tokenizer: vocab uses ``▁`` for spaces AND the
+            # decoder has the matching ``Replace`` step. Bail without
+            # mutation — the cosmetic byte-token quirk PR #793 was
+            # chasing is not worth corrupting every space.
+            logger.debug(
+                "repair_byte_level_decoder: skipping %s — decoder has "
+                "load-bearing Replace('%s', ' ') step (hybrid "
+                "SentencePiece-metaspace tokenizer)",
+                type(inner).__name__,
+                _METASPACE_MARKER,
+            )
+            return False
 
     # Find a probe id whose pretty token starts with a byte-level marker.
     # We scan the *entire* vocab (codex r2 NIT) — a 4 KB id prefix cap
@@ -207,6 +332,37 @@ def repair_byte_level_decoder(tokenizer) -> bool:
             probe_id,
             probe_pretty,
             verify,
+        )
+        return False
+
+    # Gate 3 (issue #950): even after the probe clears, decode a spaced
+    # sample and ensure no ``▁`` (U+2581) leaks. A hybrid tokenizer
+    # whose decoder didn't trip gate 2 — for instance one whose
+    # ``Replace`` step has a different shape we don't recognise, or one
+    # where the metaspace marker appears via a different decoder
+    # primitive — would here surface ``▁`` in the round-trip and we
+    # must revert so we never ship corrupted spaces to users.
+    try:
+        spaced_ids = inner.encode("a b c", add_special_tokens=False)
+        spaced_decoded = inner.decode(spaced_ids, skip_special_tokens=False)
+    except Exception:
+        spaced_decoded = ""
+    if _METASPACE_MARKER in spaced_decoded:
+        try:
+            backend.decoder = original_decoder
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "repair_byte_level_decoder: could not restore original "
+                "decoder on %s after spaced-sample verification failed: %s",
+                type(inner).__name__,
+                exc,
+            )
+        logger.warning(
+            "repair_byte_level_decoder: post-swap spaced-sample decode "
+            "leaked metaspace marker on %s (encode('a b c') -> %r); "
+            "restored original decoder",
+            type(inner).__name__,
+            spaced_decoded,
         )
         return False
 

--- a/vllm_mlx/utils/tokenizer.py
+++ b/vllm_mlx/utils/tokenizer.py
@@ -232,9 +232,7 @@ def repair_byte_level_decoder(tokenizer) -> bool:
             spaced_tokens = inner.convert_ids_to_tokens(spaced_ids)
         except Exception:
             spaced_tokens = []
-        if any(
-            isinstance(t, str) and _METASPACE_MARKER in t for t in spaced_tokens
-        ):
+        if any(isinstance(t, str) and _METASPACE_MARKER in t for t in spaced_tokens):
             # Hybrid tokenizer: vocab uses ``▁`` for spaces AND the
             # decoder has the matching ``Replace`` step. Bail without
             # mutation — the cosmetic byte-token quirk PR #793 was


### PR DESCRIPTION
## Summary

Fixes #950 (reported by @jakeledwards). PR #793's `repair_byte_level_decoder` misfires on **Gemma 4** and corrupts every space in model output (`content`, `reasoning_content`, streaming deltas, `/v1/completions[0].text`).

## Reproducer (from the issue, runs in this PR's regression test)

```python
from transformers import AutoTokenizer
from vllm_mlx.utils.tokenizer import repair_byte_level_decoder

tok = AutoTokenizer.from_pretrained("mlx-community/gemma-4-26b-a4b-it-4bit")
ids = tok.encode("the quick brown fox", add_special_tokens=False)
print("before:", repr(tok.decode(ids)))   # 'the quick brown fox'
repair_byte_level_decoder(tok)
print("after: ", repr(tok.decode(ids)))   # 'the▁quick▁brown▁fox'  -- BUG pre-fix
                                          # 'the quick brown fox'                  -- post-fix
```

## Root cause (per reporter)

Gemma 4's tokenizer is a **hybrid**: SentencePiece metaspace decoder (`Replace("▁", " ")`) PLUS GPT-2-byte-level byte tokens (e.g. id 240630, pretty `ĉ` = tab).

1. PR #793's probe scans for the first `Ġ`/`Ċ`/`ĉ` token, finds Gemma's **legitimate** `ĉ` byte token.
2. Under the native SP decoder it decodes to `'ĉ'` (SP `ByteFallback` doesn't handle GPT-2-pretty byte tokens) so the heuristic mis-classifies the decoder as "broken".
3. Swaps in a bare `ByteLevel()` decoder, dropping the `Replace("▁", " ")` step.
4. The post-swap verify only re-decodes the probe byte-token (now clean) and never notices that **every space** is now corrupted.

Net: a rare byte-token cosmetic issue gets "repaired" at the cost of universal space corruption.

## Fix — combines reporter's options 2 + 3

**Gate 2** (short-circuit BEFORE the swap): if the existing decoder contains a `Replace("▁", " ")` step AND `encode("a b c")` produces tokens containing `▁`, bail without mutation. The encode-sample check is the disambiguator: pure-GPT-2-byte-level vocabs (DeepSeek-R1 distills, Qwen3 — PR #793's actual targets) also carry a `Replace` step in their mis-applied SP decoder, but they encode spaces as `Ġ` (not `▁`), so they correctly fall through and get repaired as before.

**Gate 3** (fail-closed verify AFTER the swap): even if a future hybrid we haven't seen slips past gate 2, decode `encode("a b c")` after the swap and restore the original decoder if any `▁` leaks. This locks the "never ship corrupted spaces" contract for unknown vocab shapes.

Both gates together: a Gemma-4-style hybrid never gets its decoder swapped at all (gate 2), and any future hybrid that's structurally different but still load-bearing on metaspace `▁` is caught by gate 3 and reverted.

## Files changed

- `vllm_mlx/utils/tokenizer.py` — new `_decoder_has_metaspace_replace` helper + gate 2 + gate 3 in `repair_byte_level_decoder`.
- `tests/test_tokenizer_gemma4_hybrid.py` — NEW, 16 regression tests covering:
  - Issue #950 reproducer end-to-end on the real `mlx-community/gemma-4-26b-a4b-it-4bit` tokenizer (no model weights — `AutoTokenizer.from_pretrained` only).
  - Synthetic Gemma-4-shaped hybrid (no download) for fast CI coverage.
  - Helper-level unit tests for `_decoder_has_metaspace_replace`.
  - **PR #793 regression guard**: simulated DeepSeek-R1-Distill malformation on a real Qwen3 tokenizer + the existing `_build_broken_tokenizer` shape, both verified to still trigger the repair.
  - Gate 3 fail-closed contract via monkey-patched gate-2 bypass.

The existing `tests/test_streaming_detokenizer_bpe.py` suite (16 tests pinning PR #793's win) continues to pass unchanged.

## Test plan

- `pytest tests/test_tokenizer_gemma4_hybrid.py -v` — 16 new tests, all pass post-fix
- `pytest tests/test_streaming_detokenizer_bpe.py -v` — 16 existing PR #793 tests, all pass (no regression)
- `pytest tests/test_streaming_detokenizer.py -v` — broader streaming detokenizer suite, all pass
- Real-Gemma-4 reproducer from issue #950: `decode(encode("the quick brown fox"))` round-trips identically after `repair_byte_level_decoder`

## Scope guardrails respected

- No `aliases.json`, `0.9-TODO.md`, `vllm_mlx/spec_decode/`, `vllm_mlx/turboquant.py`, or MTP tests touched.
- No backwards-compat shims; no release-notes copy.

fixes #950

🤖 Generated with [Claude Code](https://claude.com/claude-code)