### PR TITLE
feat(turboquant): add --kv-cache-turboquant none to disable on k8v4_verified aliases (#351)

### DIFF
--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -5938,6 +5938,10 @@ Examples:
     #   --kv-cache-turboquant              → V-only legacy (v4)
     #   --kv-cache-turboquant v4           → V-only explicit
     #   --kv-cache-turboquant k8v4         → K-8bit + V-4bit mix (R15 Phase 4)
+    #   --kv-cache-turboquant none         → explicit off-switch (overrides
+    #                                        alias ``turboquant_tier=k8v4_verified``
+    #                                        auto-resolution; see
+    #                                        ``resolve_turboquant_mode_default``)
     #
     # The bare-flag form preserves PR #157 backward compatibility. Mode
     # is mutually exclusive with --kv-cache-quantization.
@@ -5946,12 +5950,15 @@ Examples:
         nargs="?",
         const="v4",
         default=None,
-        choices=["v4", "k8v4"],
+        choices=["v4", "k8v4", "none"],
         help="Enable TurboQuant KV-cache compression. ``v4`` (default when "
         "the flag is bare) is V-only 3-4 bit Lloyd-Max with K in FP16; "
         "``k8v4`` is the R15 Phase 4 mix — K at 8-bit Walsh-Hadamard + V at "
-        "4-bit Lloyd-Max (~4.6x KV compression on dense models). "
-        "Experimental — mutually exclusive with --kv-cache-quantization.",
+        "4-bit Lloyd-Max (~4.6x KV compression on dense models); ``none`` "
+        "is the explicit off-switch — overrides the alias-driven "
+        "``turboquant_tier=k8v4_verified`` default so the operator can A/B "
+        "the bare FP16 KV path. Experimental — mutually exclusive with "
+        "--kv-cache-quantization.",
     )
     serve_parser.add_argument(
         "--kv-cache-turboquant-bits",

--- a/vllm_mlx/turboquant.py
+++ b/vllm_mlx/turboquant.py
@@ -64,9 +64,23 @@ def resolve_turboquant_mode_default(args: Any, *, model_name: str) -> str | None
     when the legacy ``--kv-cache-quantization`` is pinned (mutually
     exclusive); else ``"k8v4"`` when the alias profile carries
     ``turboquant_tier == "k8v4_verified"``; else ``None``.
+
+    The sentinel value ``"none"`` (passed by the operator as
+    ``--kv-cache-turboquant none``) is the explicit off-switch — it
+    bypasses the ``k8v4_verified`` auto-resolution and returns
+    ``None`` so the engine boots with the bare FP16 KV path. This
+    is the A/B knob for the ``k8v4_verified`` decode-ratio gate.
     """
-    if getattr(args, "kv_cache_turboquant", None) is not None:
-        return args.kv_cache_turboquant
+    raw = getattr(args, "kv_cache_turboquant", None)
+    if raw == "none":
+        logger.info(
+            "TurboQuant off-switch: --kv-cache-turboquant=none — disabling "
+            "TurboQuant even though alias %r may carry turboquant_tier.",
+            model_name,
+        )
+        return None
+    if raw is not None:
+        return raw
     if getattr(args, "kv_cache_quantization", False):
         return None
     try:


### PR DESCRIPTION
## Summary

Adds the `"none"` sentinel to `--kv-cache-turboquant` choices so the operator can disable TurboQuant on aliases that carry `turboquant_tier=k8v4_verified` (the 10 hero MoE aliases flipped in PR #952). Without this knob, the alias-driven `k8v4` auto-resolution in `resolve_turboquant_mode_default` is unconditional — the broader-bench cycle on `qwen3.6-35b-{mxfp4,nvfp4}` needs an A/B switch to attribute decode/quality deltas to the codec vs the FP16 baseline.

This is the off-switch the operator referenced in `0.9-TODO.md` row 34 as `0.9-attic/k8v4-off-switch-2026-06-28.diff` — see the **2026-06-28 broader-bench** note for the `qwen3.6-35b-mxfp4` lossiness finding that motivated landing this knob.

## What changes

- **`vllm_mlx/cli.py`** (≈5949) — extend `--kv-cache-turboquant` `choices` from `["v4", "k8v4"]` to `["v4", "k8v4", "none"]`; expand help text to document the alias-override semantics. Bare-flag form still resolves to `v4` (PR #157 backward compat preserved).
- **`vllm_mlx/turboquant.py`** (`resolve_turboquant_mode_default`, ≈60-85) — short-circuit on the `"none"` sentinel: return `None` and emit a one-shot `INFO` log, even when the alias carries `turboquant_tier=k8v4_verified`. All other branches unchanged.

Net diff: +25 / -5, 2 files, no public-API surface change beyond the new enum value.

## Resolver behavior matrix (verified)

| alias `turboquant_tier` | `--kv-cache-turboquant` flag | resolved mode |
|---|---|---|
| `None` | `None` | `None` |
| `k8v4_verified` | `None` | `"k8v4"` (alias default — unchanged) |
| `k8v4_verified` | `"k8v4"` | `"k8v4"` |
| `k8v4_verified` | `"v4"` | `"v4"` |
| `k8v4_verified` | `"none"` | `None` (new — off-switch fires) |

## Smoke test results

1. **CLI**: `python -m vllm_mlx.cli serve --help | grep kv-cache-turboquant` shows `{v4,k8v4,none}` in choices and the help text reflects the off-switch wording.
2. **Resolver table**: inline 5-case smoke against `vllm_mlx.turboquant.resolve_turboquant_mode_default` with a mocked `detect_model_config` — all 5 rows match expectations; the off-switch INFO log fires exactly once on the `"none"` case.
3. **Prototype `/metrics` (operator's last round, `0.9-TODO.md` row 34)**: `rapid_mlx_turboquant_mode{mode="k8v4"} 1` on ON and `{mode="disabled"} 1` on OFF — confirms the runtime gauge tracks the resolver decision.

## Why now

`0.9-TODO.md` row 34 ("TurboQuant K8V4 default-on; decode ≥ 0.95× FP16 baseline") needs broader bench coverage to flip from 🟡 to ✅. The 2026-06-28 bench surfaced `qwen3.6-35b-mxfp4` lossiness (decode 1.010× but text-diff 4/10) — operator A/B-decision on whether to keep `mxfp4` in `k8v4_verified` or drop to a 9-alias set is blocked on having an off-switch available in shipped CLI, not just a worktree diff.

## Out of scope

- No `aliases.json` change — the `mxfp4` keep-vs-drop decision is a separate follow-up PR.
- No release-notes copy change.
- No new metric / counter.
- No test file added (per the operator's spec for this PR — the inline 5-case smoke + the live `/metrics` round-trip from the prototype are the validation surface).

## Test plan

- Smoke CLI shows `{v4,k8v4,none}` choices and updated help text — PASS
- Inline resolver smoke 5-case table — PASS (all 5 match)
- Logger emits the off-switch INFO line exactly once on `"none"` — PASS
- `pr_validate` end-to-end — see scorecard below (will update after the gate finishes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)