### PR TITLE
fix(scheduler): correct batch_gen -> batch_generator typo blocking disk-KV writes

### DIFF
--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -4647,7 +4647,7 @@ class Scheduler:
         # method directly on ``batch_gen.active_batch``. Walking both
         # surfaces keeps this hook portable across the mlx-lm versions
         # rapid-mlx supports.
-        batch = getattr(self, "batch_gen", None)
+        batch = getattr(self, "batch_generator", None)
         if batch is None:
             return
         gen_batch = getattr(batch, "_generation_batch", None) or getattr(


### PR DESCRIPTION
## Why

The disk-backed KV checkpoint hook (`Scheduler._maybe_disk_checkpoint`, added in PR #919) reads the BatchGenerator off the Scheduler with the wrong attribute name. The canonical attribute is `self.batch_generator` — assigned at `vllm_mlx/scheduler.py:1889` and read at `:2549, :2645, :2788, :4074, :4975, ...`. `self.batch_gen` is **never assigned anywhere in the codebase**:

```
$ grep -nE 'self\.batch_gen\s*=' vllm_mlx/scheduler.py
(no matches)
```

So `getattr(self, "batch_gen", None)` always returns `None`, the very next line `if batch is None: return` fires unconditionally, and the hook never reaches `maybe_write_checkpoint`. Result: `rapid_mlx_kv_checkpoint_writes_total` is stuck at 0 on `origin/main` even with `--kv-disk-checkpoint-interval 256`, which is what makes 体感 2 row 4 ("Disk-KV @ 32k reduces RAM >= 50%") measure 0.01% in the 0.9-TODO dashboard.

## What

One-line attribute-name correction:

```diff
-        batch = getattr(self, "batch_gen", None)
+        batch = getattr(self, "batch_generator", None)
```

at `vllm_mlx/scheduler.py:4650`. Same hook block; comments on `:4644-4648` already use the correct name `batch_gen.active_batch` for the *local* variable, so only the `self.<attr>` getattr was wrong.

## Verification

**Static.**
- `grep -nE 'self\.batch_gen\b' vllm_mlx/scheduler.py` -> 0 hits after fix.
- `git grep 'self\.batch_generator' vllm_mlx/scheduler.py | wc -l` -> 21 canonical reads.

**Unit.** `pytest tests/test_disk_kv_checkpoint.py -x -v` -> 27 passed, 0 failed (as expected — these test `write_checkpoint` directly, not the scheduler wiring; they pass on `main` today and still pass with the fix).

**Integration smoke.** Boot `rapid-mlx serve qwen3.5-9b-4bit --kv-disk-checkpoint-interval 256 --port 8773`, send a 400-token completion, scrape `/metrics`:

- **Before fix (`main`):** `rapid_mlx_kv_checkpoint_writes_total = 0`, `~/.cache/rapid-mlx/kv_checkpoints/` directory not created. The early `if batch is None: return` swallows the hook.
- **After fix (this PR):** `rapid_mlx_kv_checkpoint_writes_total = 0`, `~/.cache/rapid-mlx/kv_checkpoints/` directory still not created.

Wait — same number? See the next section. **This typo fix is necessary but not sufficient.**

## Honest disclosure: a second bug surfaces after this fix

Instrumented logging on the smoke (reverted before commit) shows the typo fix correctly progresses past `if batch is None`, but the very *first* line of `_maybe_disk_checkpoint` then raises an unrelated `AttributeError`:

```
WARNING:rapid_mlx.scheduler:[DBG-CKPT-PRE] calling _maybe_disk_checkpoint req=... num_tokens=406
WARNING:rapid_mlx.scheduler:[DBG-CKPT-EX] ...: 'Scheduler' object has no attribute 'scheduler_config'
```

The hook reads `self.scheduler_config.kv_disk_checkpoint_interval` at `:4610` and `self.scheduler_config.kv_cache_dtype` at `:4634`, but the canonical Scheduler attribute is `self.config` (assigned at `:1868` as `self.config = config or SchedulerConfig()` and read at `:1914-1938` and ~40 other sites). This is a **second** wrong-attribute typo from the same PR #919. The hook-wrapper at `:4406-4410` silently catches the `AttributeError`, which is why neither typo was loud.

Per the operator's instruction to ship only the one-line typo, **this PR does NOT fix the `scheduler_config` -> `config` typo**. That should be a follow-up PR: two `getattr(self.scheduler_config, ...)` calls at `:4610` and `:4634` to `getattr(self.config, ...)`. After both PRs land, the smoke counter goes positive.

## Test plan

- Unit: `pytest tests/test_disk_kv_checkpoint.py -x -v` passes (27/27).
- Static: `self.batch_gen` is gone from the file (grep proof above).
- pr_validate scorecard: see linked artifact / comment thread.
- Follow-up: open a separate PR for the `scheduler_config` -> `config` typo so the metric actually moves.

Refs: #919 (introducing PR), 0.9-TODO 体感 2 row 4.