### PR TITLE
fix(tokenizer): don't swap SentencePiece decoder to ByteLevel (gemma-3 ▁ space leak)

### DIFF
--- a/tests/test_streaming_detokenizer_bpe.py
+++ b/tests/test_streaming_detokenizer_bpe.py
@@ -258,6 +258,84 @@ class TestRepairByteLevelDecoder:
         )
 
 
+def _build_sentencepiece_with_literal_marker_token() -> PreTrainedTokenizerFast:
+    """A genuine SentencePiece (metaspace) tokenizer that ALSO carries an
+    isolated literal ``ĉ`` (U+0109) character token — the exact gemma-3
+    shape that false-tripped ``repair_byte_level_decoder``.
+
+    Spaces are encoded as the metaspace marker ``▁`` and the decoder is the
+    correct SentencePiece ``Replace("▁"," ")`` chain. The lone ``ĉ`` token
+    is a real character in the vocab, NOT byte-level mojibake — the repair
+    must leave this tokenizer untouched.
+    """
+    vocab = {
+        "<pad>": 0,
+        "<s>": 1,
+        "</s>": 2,
+        "▁the": 3,  # ' the'
+        "▁search": 4,  # ' search'
+        "▁results": 5,  # ' results'
+        "ĉ": 6,  # genuine U+0109 literal char token — the trap
+        "the": 7,  # 'the'
+    }
+    model = models.BPE(vocab=vocab, merges=[])
+    tok = Tokenizer(model)
+    tok.pre_tokenizer = pre_tokenizers.Metaspace()
+    tok.decoder = decoders.Sequence(
+        [
+            decoders.Replace("▁", " "),
+            decoders.ByteFallback(),
+            decoders.Fuse(),
+        ]
+    )
+    return PreTrainedTokenizerFast(
+        tokenizer_object=tok,
+        eos_token="</s>",
+        bos_token="<s>",
+        pad_token="<pad>",
+    )
+
+
+class TestRepairSkipsGenuineSentencePiece:
+    """Regression: ``repair_byte_level_decoder`` must NOT swap the decoder
+    on a genuine SentencePiece vocab that happens to contain an isolated
+    literal ``Ġ``/``Ċ``/``ĉ`` *character* token (gemma-3 reported the
+    ``The▁search▁results`` leak — every space rendered as ``▁``)."""
+
+    def test_marker_probe_would_have_tripped(self) -> None:
+        """Sanity: the old marker heuristic DID find a trap token here, so
+        this fixture genuinely exercises the false-positive guard rather
+        than just lacking a marker."""
+        tok = _build_sentencepiece_with_literal_marker_token()
+        vocab = tok.get_vocab()
+        trap = [p for p in vocab if any(p.startswith(m) for m in _BYTE_LEVEL_MOJIBAKE_MARKERS)]
+        assert trap == ["ĉ"], f"expected lone 'ĉ' trap token, got {trap!r}"
+
+    def test_repair_is_noop_on_sentencepiece(self) -> None:
+        tok = _build_sentencepiece_with_literal_marker_token()
+        assert repair_byte_level_decoder(tok) is False
+        # Decoder left as the original SentencePiece Sequence, NOT ByteLevel.
+        assert tok.backend_tokenizer.decoder.__class__.__name__ == "Sequence"
+
+    def test_spaces_survive_after_repair_call(self) -> None:
+        """The actual user-visible contract: ``▁`` decodes back to a space,
+        not leaked verbatim, after the repair pass runs at load time."""
+        tok = _build_sentencepiece_with_literal_marker_token()
+        repair_byte_level_decoder(tok)
+        ids = [3, 4, 5]  # '▁the' '▁search' '▁results'
+        decoded = tok.decode(ids, skip_special_tokens=False)
+        assert "▁" not in decoded, f"metaspace leaked: {decoded!r}"
+        assert decoded == " the search results"
+
+    def test_incremental_stream_keeps_spaces(self) -> None:
+        tok = _build_sentencepiece_with_literal_marker_token()
+        repair_byte_level_decoder(tok)
+        decoder = IncrementalDecoder(tok)
+        emitted = "".join(decoder.add_token(t) for t in (3, 4, 5))
+        assert "▁" not in emitted, f"metaspace leaked in stream: {emitted!r}"
+        assert emitted == " the search results"
+
+
 # ---------------------------------------------------------------------------
 # 2. Streaming surface: IncrementalDecoder (delta.* path)
 # ---------------------------------------------------------------------------

--- a/vllm_mlx/utils/tokenizer.py
+++ b/vllm_mlx/utils/tokenizer.py
@@ -123,6 +123,44 @@ def repair_byte_level_decoder(tokenizer) -> bool:
         return False
     backend = inner.backend_tokenizer
 
+    try:
+        vocab = inner.get_vocab()
+    except Exception:
+        return False
+
+    # Guard against a false positive on genuine SentencePiece vocabs
+    # (gemma-3 / gemma-4, etc.). The bug this function repairs is specific
+    # to byte-level (GPT-2) vocabs that encode a leading space as ``Ġ`` but
+    # were handed a SentencePiece ``Replace("▁"," ")`` decoder. A real
+    # SentencePiece tokenizer encodes a leading space as the metaspace
+    # marker ``▁`` (U+2581) and its decoder is *correct* — swapping it to
+    # ByteLevel would leak ``▁`` into every space (the gemma-3
+    # ``The▁search▁results`` regression).
+    #
+    # Distinguish the two by the vocab's space-encoding convention, NOT by
+    # "some token's pretty form starts with a marker char": a genuine
+    # SentencePiece vocab can still contain an isolated literal
+    # ``Ġ``/``Ċ``/``ĉ`` *character* token (e.g. gemma-3's ``ĉ`` = U+0109,
+    # id 240630 — plus a single stray ``Ġ``), which tripped the marker
+    # heuristic below and broke detokenisation for the whole model. A
+    # metaspace vocab has ``▁`` on tens of thousands of tokens; a byte-
+    # level vocab has ``Ġ`` on tens of thousands and ``▁`` on ~none. So
+    # compare counts, not presence: if metaspace dominates, the decoder is
+    # already correct and must be left alone.
+    try:
+        metaspace_count = sum(
+            1 for p in vocab if isinstance(p, str) and p.startswith("▁")
+        )
+        byte_level_count = sum(
+            1 for p in vocab if isinstance(p, str) and p.startswith("Ġ")
+        )
+        if metaspace_count > byte_level_count:
+            return False
+    except Exception:
+        # Count failed (unusual vocab surface) — fall through to the marker
+        # heuristic so the byte-level repair still runs.
+        pass
+
     # Find a probe id whose pretty token starts with a byte-level marker.
     # We scan the *entire* vocab (codex r2 NIT) — a 4 KB id prefix cap
     # silently skips valid byte-level vocabs whose byte tokens all live
@@ -133,10 +171,6 @@ def repair_byte_level_decoder(tokenizer) -> bool:
     # round-trip, so even a 200k-entry vocab probes in <5 ms.
     probe_id: int | None = None
     probe_pretty: str | None = None
-    try:
-        vocab = inner.get_vocab()
-    except Exception:
-        return False
     # ``get_vocab`` returns ``{pretty: id}``. Sort by id so the probe
     # is deterministic across HF tokenizer versions (some return dicts
     # in insertion order, others in hash order).


### PR DESCRIPTION
## Bug

On `gemma3-1b-qat-4bit` (and all gemma-3 sizes — same vocab), every space in generated text leaked as the SentencePiece metaspace marker `▁` — chat content, streaming `delta.*`, and `/v1/completions[0].text` all rendered `The▁search▁results▁mention…` (the user saw it as `The__search__results…`). Reported via the desktop app.

## Root cause

`repair_byte_level_decoder()` (which fixes DeepSeek-R1-distill tokenizers whose **byte-level** vocab was handed a SentencePiece decoder) **false-positived on a genuine SentencePiece vocab**:

1. It scanned the vocab for any token whose pretty form starts with a GPT-2 byte-level marker (`Ġ`/`Ċ`/`ĉ`).
2. It found gemma-3's lone **literal `ĉ` character token** (U+0109, id 240630) — a real character, not byte-level mojibake.
3. `decode([id])` correctly returned `'ĉ'`, but the check "decoded still contains a marker" was satisfied, so it concluded the decoder was a broken byte-level chain.
4. It swapped the decoder to `ByteLevel()`, **destroying the SentencePiece `Replace("▁"," ")` step for the entire tokenizer** → `▁` leaked into every space.

Plain `mlx_lm.load` (no repair) decodes gemma-3 correctly; only our load path broke it.

## Fix

Gate the repair on the vocab's **space-encoding convention**, not "some token's pretty form starts with a marker char":

- A genuine SentencePiece vocab encodes spaces as `▁` on tens of thousands of tokens (gemma-3: **137,541** `▁` vs **1** `Ġ`).
- A byte-level (GPT-2) vocab encodes them as `Ġ`.
- Compare **counts, not presence** (either family can carry an isolated literal `Ġ`/`Ċ`/`ĉ` char token). If metaspace dominates, the decoder is already correct → leave it alone.

This preserves the DeepSeek-R1-distill byte-level repair (those vocabs are `Ġ`-dominant, `▁`≈0).

## Verification

- **End-to-end**: `gemma-3-1b` streaming generation of "why is the sky blue?" now returns proper spaces, **no `▁`/`__`** ("The sky appears blue due to a phenomenon called Rayleigh scattering. …").
- Decoder stays `Sequence` (SPM), `repair_byte_level_decoder()` correctly returns `False`.
- New `TestRepairSkipsGenuineSentencePiece` (4 cases) in the synthetic-fixture suite, incl. a sanity test proving the old marker heuristic *would* have tripped on the fixture. Full byte-level suite **20/20**; related tokenizer/detok suites green.
- Codex review: 0 BLOCKING / 0 MAJOR.

Note: this affects the bundled sidecar — reaches desktop users via a rapid-mlx release + submodule bump.