### PR TITLE
fix(glm-5.2): surgical Indexer gate for REAP-pruned DeepseekV32 (D1)

### DIFF
--- a/tests/test_deepseek_v32_indexer_gate.py
+++ b/tests/test_deepseek_v32_indexer_gate.py
@@ -423,28 +423,26 @@ def test_decode_step_after_prefill_keeps_in_call_reuse(repro_dir):
 
 
 def test_empty_local_layer_slice_delegates_to_upstream(repro_dir):
-    """Pipeline-parallel layout with an empty (or out-of-range) local
-    layer slice safely delegates to upstream instead of crashing.
+    """Pipeline-parallel layout with an out-of-range ``start_idx``
+    safely delegates to ``_orig_model_call`` instead of crashing with
+    ``IndexError``.
 
     Codex finding #3 on PR #967 round 5: the patched ``Model.__call__``
-    used to dereference ``self.layers[self.start_idx]`` unconditionally,
-    which crashes when ``self.start_idx >= len(self.layers)`` (e.g. a
-    sharded slice that owns no layers). Fix: bounds-check before
-    inspecting the local layer's config; delegate to ``_orig_model_call``
-    when the slice is empty.
+    used to dereference ``self.layers[self.start_idx]`` unconditionally.
 
-    We exercise the delegation path by loading a non-REAP config (so
-    ``indexer_types`` is None and the patched call would delegate
-    anyway), then artificially setting ``start_idx`` out of range. The
-    test passes if no IndexError is raised; the assertion that delegation
-    actually fires lives in the unit logic — if the bounds-check were
-    removed, the forward would raise IndexError before reaching
-    ``_orig_model_call``.
+    Codex finding #1 on PR #967 round 6: a prior version of this test
+    only reimplemented the bounds-check inline and never invoked the
+    patched call, so removing the guard would not have caused it to
+    fail. This rewrite monkey-patches ``_orig_model_call`` to a
+    sentinel-recording stub and invokes the patched call on a model
+    whose ``start_idx`` is out of range, then asserts the sentinel was
+    reached. If the bounds-check guard were removed, the patched call
+    would raise ``IndexError`` BEFORE the sentinel is recorded.
     """
     from vllm_mlx.patches import deepseek_v32_indexer_gate as gate
 
     gate.install_deepseek_v32_indexer_gate()
-    # Non-REAP config — upstream Indexer-bearing path is fine.
+    # Non-REAP config — the orig path is the upstream Indexer-bearing one.
     repro = _forge_repro(repro_dir, indexer_types=None)
 
     from mlx_lm.utils import load_model
@@ -452,30 +450,122 @@ def test_empty_local_layer_slice_delegates_to_upstream(repro_dir):
     model, _cfg = load_model(repro)
     inner = model.model
 
-    # Force the bounds-check branch: start_idx >= len(layers) means no
-    # local layer to inspect. The patched call must NOT raise; it must
-    # delegate to upstream (which will run with whatever shape it has).
-    inner.start_idx = len(inner.layers)  # out of range
-    # We do NOT actually run the upstream forward here — it would still
-    # try to iterate ``self.num_layers`` layers and access cache slots;
-    # that's an upstream concern outside this patch's responsibility.
-    # The narrow guarantee this test pins is that the patched code's
-    # config-inspection branch handles the empty slice without an
-    # IndexError before delegation.
-    types = None
-    if (
-        inner.layers
-        and 0 <= inner.start_idx < len(inner.layers)
-        and inner.layers[inner.start_idx] is not None
-    ):
-        cfg = getattr(inner.layers[inner.start_idx].self_attn, "config", None)
-        if cfg is not None:
-            types = getattr(cfg, "indexer_types", None)
-    assert types is None, (
-        "bounds-checked config inspection should yield types=None for an "
-        "out-of-range start_idx; instead got a non-None value, indicating "
-        "the empty-slice guard did not engage."
+    # Out-of-range start_idx — no local layer to inspect.
+    inner.start_idx = len(inner.layers)
+
+    # Stub ``_orig_model_call`` so we can detect that delegation
+    # actually happened (rather than letting the upstream forward
+    # execute, which would still try to iterate a now-bogus slice).
+    sentinel = {"reached": False, "args": None}
+
+    def _stub_orig(self, x, cache=None):
+        sentinel["reached"] = True
+        sentinel["args"] = (x.shape, cache is None)
+        return mx.zeros((x.shape[0], x.shape[1], 64), dtype=mx.float32)
+
+    saved_orig = gate._orig_model_call
+    try:
+        gate._orig_model_call = _stub_orig
+        # Invoke the actual patched call. Bug behavior (no bounds check)
+        # would raise IndexError on ``self.layers[self.start_idx]`` before
+        # reaching the delegation. Fixed behavior delegates cleanly.
+        from mlx_lm.models import deepseek_v32 as ds
+
+        # The patched method is bound at install time and stored on the
+        # class. Call it directly so we're definitely exercising the
+        # patched ``__call__``.
+        x = mx.array([[1, 2, 3]], dtype=mx.int32)
+        _ = ds.DeepseekV32Model.__call__(inner, x, cache=None)
+    finally:
+        gate._orig_model_call = saved_orig
+
+    assert sentinel["reached"], (
+        "_patched_model_call should have delegated to _orig_model_call "
+        "when start_idx is out of range; sentinel was never recorded. "
+        "Either the bounds-check guard fired incorrectly or the patched "
+        "call short-circuited before reaching delegation."
     )
+
+
+def test_reuse_path_runs_for_run_of_consecutive_shared_layers(repro_dir):
+    """Layout with multiple consecutive shared layers after one full
+    anchor — the production-shaped pattern in GLM-5.2 REAP configs.
+
+    Codex finding #3 on PR #967 round 6: prior coverage only used the
+    alternating ``["full","shared","full","shared"]`` pattern, so a
+    regression that broke reuse for the second or third consecutive
+    shared layer would not be caught. The actual GLM-5.2 base config
+    has runs like ``["full","full","full","shared","shared","shared",
+    "full","shared",...]``.
+
+    Pin the in-call reuse semantic on a ``["full","shared","shared",
+    "shared"]`` layout: a SINGLE prefill forward must drive every one
+    of the three consecutive shared layers through the REAP reuse
+    path (not dense fallback), because each shared layer's
+    ``last_topk_indices`` carries forward across the layer loop
+    until the next full layer would refresh it.
+    """
+    from vllm_mlx.patches import deepseek_v32_indexer_gate as gate
+
+    gate.install_deepseek_v32_indexer_gate()
+    repro = _forge_repro(repro_dir, ["full", "shared", "shared", "shared"])
+
+    from mlx_lm.utils import load_model
+
+    model, _cfg = load_model(repro)
+    layers = model.model.layers
+    # Only layer 0 retains an Indexer; layers 1,2,3 are shared.
+    assert layers[0].self_attn.indexer is not None
+    for i in (1, 2, 3):
+        assert layers[i].self_attn.indexer is None, f"layer {i} should be shared"
+
+    # Forward — every shared layer must take the REAP reuse path.
+    gate._SHARED_LAYER_REUSE_COUNT = 0
+    gate._SHARED_LAYER_DENSE_FALLBACK_COUNT = 0
+    prompt = mx.array([[1, 2, 3, 4, 5]], dtype=mx.int32)
+    out = model(prompt)
+    mx.eval(out)
+    assert gate._SHARED_LAYER_REUSE_COUNT == 3, (
+        "all 3 consecutive shared layers must consume the layer-0 full "
+        f"anchor's topk — reuse={gate._SHARED_LAYER_REUSE_COUNT}, "
+        f"dense_fallback={gate._SHARED_LAYER_DENSE_FALLBACK_COUNT}. The "
+        "layer loop must carry last_topk_indices across consecutive "
+        "shared layers without resetting it (codex PR #967 round-6 "
+        "finding)."
+    )
+    assert gate._SHARED_LAYER_DENSE_FALLBACK_COUNT == 0
+
+
+def test_pp_shard_starting_on_shared_layer_raises_clear_error(repro_dir):
+    """Pipeline-parallel shard whose first locally-iterated layer is
+    ``"shared"`` raises a clear ``ValueError`` instead of silently
+    falling back to dense attention.
+
+    Codex finding #2 on PR #967 round 6: previously such a shard
+    would silently take the dense fallback on its leading shared
+    layers, changing inference semantics relative to the published
+    REAP contract. Fail fast with a clear error message instead;
+    cross-rank communication of the current full layer's topk is
+    the architecturally-correct remedy if ever needed, but that's
+    out of scope for the surgical D1 fix.
+    """
+    from vllm_mlx.patches import deepseek_v32_indexer_gate as gate
+
+    gate.install_deepseek_v32_indexer_gate()
+    repro = _forge_repro(repro_dir, ["full", "shared", "shared", "shared"])
+
+    from mlx_lm.utils import load_model
+
+    model, _cfg = load_model(repro)
+    inner = model.model
+
+    # Simulate a PP rank that starts mid-model on a shared layer.
+    inner.start_idx = 1
+    inner.num_layers = 3
+
+    prompt = mx.array([[1, 2, 3]], dtype=mx.int32)
+    with pytest.raises(ValueError, match="pipeline-parallel shard"):
+        model(prompt)
 
 
 def test_uninstall_restores_originals_across_module_reload(repro_dir):

--- a/tests/test_deepseek_v32_indexer_gate.py
+++ b/tests/test_deepseek_v32_indexer_gate.py
@@ -361,89 +361,121 @@ def test_gate_rejects_all_shared_indexer_types(repro_dir):
         load_model(repro)
 
 
-def test_decode_step_after_prefill_still_reuses_topk(repro_dir):
-    """Second forward call (decode) reuses topk from the prior forward
-    EVEN WHEN the first iterated layer in the decode pass is ``"shared"``.
+def test_decode_step_after_prefill_keeps_in_call_reuse(repro_dir):
+    """Across forward calls (prefill → decode), the per-call topk reuse
+    semantics is preserved: each full layer's forward refreshes
+    ``last_topk_indices`` for the immediately following shared layers
+    within the SAME call.
 
-    Codex finding #1 on PR #967 round 3: the model-level wrapper reset
-    ``last_topk_indices`` to ``None`` on every ``__call__``, so any
-    leading shared layer in a decode step could fall back to dense.
-    The current implementation seeds ``last_topk_indices`` from the
-    most-recent full layer's persisted ``_last_topk_indices`` by
-    scanning all of ``self.layers`` (not just this rank's slice).
+    Codex iteration history:
 
-    Codex finding (PR #967 round 4): a test that uses
-    ``["full","shared","full","shared"]`` would still pass with the
-    seed code deleted, because layer 0 (full) re-runs first and
-    refreshes ``last_topk_indices`` before any shared layer. To
-    actually exercise the seed code path, construct a scenario where
-    the first iterated layer in the decode pass is ``"shared"`` —
-    here we use a config with a single full anchor at layer 0 and
-    then simulate a pipeline-parallel rank that only iterates layers
-    [1, 2, 3] (all shared). Layer 0 stays in ``self.layers`` so the
-    seed loop can find its persisted state.
+    * PR #967 round 3 BLOCKING flagged a (hypothetical) regression
+      where a decode call's leading shared layer could see ``None``.
+      The round-3 fix added a "seed from prior forward" loop.
+    * PR #967 round 5 BLOCKING reversed: applying a prior call's
+      persisted ``_last_topk_indices`` at a fresh decode step would
+      be stale (computed at a different query/cache length). The
+      seed loop was reverted; the architecturally-correct remedy if
+      ever needed is inter-rank communication of the current full
+      layer's topk, which is out of scope for the surgical D1 fix.
+
+    Pin the now-stable behavior: with a valid REAP layout
+    ``["full","shared","full","shared"]`` (every shared layer
+    immediately preceded by a full layer in the iteration), both
+    prefill and the subsequent decode step keep every shared layer
+    on the REAP reuse path — no dense fallback.
     """
     from vllm_mlx.patches import deepseek_v32_indexer_gate as gate
 
     gate.install_deepseek_v32_indexer_gate()
-    # Single full anchor at index 0, three shared layers after.
-    repro = _forge_repro(repro_dir, ["full", "shared", "shared", "shared"])
+    repro = _forge_repro(repro_dir, ["full", "shared", "full", "shared"])
 
     from mlx_lm.models.cache import make_prompt_cache
     from mlx_lm.utils import load_model
 
     model, _cfg = load_model(repro)
-    inner = model.model  # DeepseekV32Model
 
-    # ---- Prefill on the full model: layer 0 (full) populates its
-    # indexer._last_topk_indices, all 3 shared layers reuse it.
+    # Prefill
     cache = make_prompt_cache(model)
     gate._SHARED_LAYER_REUSE_COUNT = 0
     gate._SHARED_LAYER_DENSE_FALLBACK_COUNT = 0
     prefill = mx.array([[1, 2, 3, 4, 5]], dtype=mx.int32)
     logits = model(prefill, cache=cache)
     mx.eval(logits)
-    assert gate._SHARED_LAYER_REUSE_COUNT == 3
+    assert gate._SHARED_LAYER_REUSE_COUNT == 2
     assert gate._SHARED_LAYER_DENSE_FALLBACK_COUNT == 0
-    # Sanity: layer 0's indexer DID persist a topk tensor.
-    assert (
-        getattr(inner.layers[0].self_attn.indexer, "_last_topk_indices", None)
-        is not None
-    )
 
-    # ---- Simulate a pipeline-parallel rank-1 that only iterates
-    # layers [1, 2, 3] (all shared). With this layout, the decode
-    # pass's FIRST iterated layer is shared — the only way for it to
-    # hit the REAP reuse path is if `last_topk_indices` is seeded
-    # from layer 0's persisted indexer state BEFORE the layer loop
-    # begins. Without the seed code, all three shared layers fall
-    # back to dense.
-    inner.start_idx = 1
-    inner.num_layers = 3
-    # The layer loop now consumes cache[0..2] for layers [1..3]; drop
-    # cache[0] which was for layer 0.
-    cache = cache[1:]
-
+    # Decode step (single new token). Each full layer in the iteration
+    # refreshes ``last_topk_indices`` BEFORE the following shared
+    # layer reads it, so in-call reuse semantics holds whether or not
+    # any prior forward's state is reachable.
     gate._SHARED_LAYER_REUSE_COUNT = 0
     gate._SHARED_LAYER_DENSE_FALLBACK_COUNT = 0
     next_tok = mx.array([[6]], dtype=mx.int32)
     logits = model(next_tok, cache=cache)
     mx.eval(logits)
-    # Three shared layers, all must reuse — dense fallback would mean
-    # the seed code path didn't fire. The previous-round test (using
-    # ["full","shared","full","shared"] with start_idx=0) would still
-    # have passed without the seed code because layer 0 re-runs first
-    # in the iteration; this test fails if the seed code is deleted.
-    assert gate._SHARED_LAYER_REUSE_COUNT == 3, (
-        "decode step with leading shared layer in this rank lost the seed-"
-        "from-prior-forward topk reuse — "
+    assert gate._SHARED_LAYER_REUSE_COUNT == 2, (
+        "decode step lost in-call topk reuse — "
         f"reuse={gate._SHARED_LAYER_REUSE_COUNT}, "
-        f"dense_fallback={gate._SHARED_LAYER_DENSE_FALLBACK_COUNT}. The "
-        "seed loop at the top of `_patched_model_call` must find layer 0's "
-        "persisted indexer._last_topk_indices and thread it into the first "
-        "iterated shared layer (codex PR #967 round-4 finding)."
+        f"dense_fallback={gate._SHARED_LAYER_DENSE_FALLBACK_COUNT}"
     )
     assert gate._SHARED_LAYER_DENSE_FALLBACK_COUNT == 0
+
+
+def test_empty_local_layer_slice_delegates_to_upstream(repro_dir):
+    """Pipeline-parallel layout with an empty (or out-of-range) local
+    layer slice safely delegates to upstream instead of crashing.
+
+    Codex finding #3 on PR #967 round 5: the patched ``Model.__call__``
+    used to dereference ``self.layers[self.start_idx]`` unconditionally,
+    which crashes when ``self.start_idx >= len(self.layers)`` (e.g. a
+    sharded slice that owns no layers). Fix: bounds-check before
+    inspecting the local layer's config; delegate to ``_orig_model_call``
+    when the slice is empty.
+
+    We exercise the delegation path by loading a non-REAP config (so
+    ``indexer_types`` is None and the patched call would delegate
+    anyway), then artificially setting ``start_idx`` out of range. The
+    test passes if no IndexError is raised; the assertion that delegation
+    actually fires lives in the unit logic — if the bounds-check were
+    removed, the forward would raise IndexError before reaching
+    ``_orig_model_call``.
+    """
+    from vllm_mlx.patches import deepseek_v32_indexer_gate as gate
+
+    gate.install_deepseek_v32_indexer_gate()
+    # Non-REAP config — upstream Indexer-bearing path is fine.
+    repro = _forge_repro(repro_dir, indexer_types=None)
+
+    from mlx_lm.utils import load_model
+
+    model, _cfg = load_model(repro)
+    inner = model.model
+
+    # Force the bounds-check branch: start_idx >= len(layers) means no
+    # local layer to inspect. The patched call must NOT raise; it must
+    # delegate to upstream (which will run with whatever shape it has).
+    inner.start_idx = len(inner.layers)  # out of range
+    # We do NOT actually run the upstream forward here — it would still
+    # try to iterate ``self.num_layers`` layers and access cache slots;
+    # that's an upstream concern outside this patch's responsibility.
+    # The narrow guarantee this test pins is that the patched code's
+    # config-inspection branch handles the empty slice without an
+    # IndexError before delegation.
+    types = None
+    if (
+        inner.layers
+        and 0 <= inner.start_idx < len(inner.layers)
+        and inner.layers[inner.start_idx] is not None
+    ):
+        cfg = getattr(inner.layers[inner.start_idx].self_attn, "config", None)
+        if cfg is not None:
+            types = getattr(cfg, "indexer_types", None)
+    assert types is None, (
+        "bounds-checked config inspection should yield types=None for an "
+        "out-of-range start_idx; instead got a non-None value, indicating "
+        "the empty-slice guard did not engage."
+    )
 
 
 def test_uninstall_restores_originals_across_module_reload(repro_dir):

--- a/tests/test_deepseek_v32_indexer_gate.py
+++ b/tests/test_deepseek_v32_indexer_gate.py
@@ -26,20 +26,18 @@ configs (e.g. ``mlx-community/pipenetwork-GLM-5.2-REAP50-MLX-4bit``):
 from __future__ import annotations
 
 import json
-import shutil
+from collections.abc import Iterable
 from pathlib import Path
-from typing import Iterable, List, Optional
 
 import mlx.core as mx
 import pytest
-
 
 # ----------------------------------------------------------------------
 # Synthetic glm_moe_dsa config + weight forge (no GLM-5.2 download)
 # ----------------------------------------------------------------------
 
 
-def _config(num_layers: int, indexer_types: Optional[Iterable[str]]) -> dict:
+def _config(num_layers: int, indexer_types: Iterable[str] | None) -> dict:
     cfg = {
         "model_type": "glm_moe_dsa",
         "vocab_size": 256,
@@ -120,8 +118,8 @@ def _layer_keys(layer_idx: int, mode: str, cfg: dict) -> dict:
 
 def _forge_repro(
     tmp_path: Path,
-    indexer_types: Optional[List[str]],
-    layer_modes_for_safetensors: Optional[List[str]] = None,
+    indexer_types: list[str] | None,
+    layer_modes_for_safetensors: list[str] | None = None,
 ) -> Path:
     """Write a tiny config + safetensors stub for the test.
 
@@ -165,9 +163,7 @@ def repro_dir(tmp_path: Path) -> Path:
 # ----------------------------------------------------------------------
 
 
-def test_upstream_without_gate_fails_with_missing_indexer_keys(
-    monkeypatch, repro_dir
-):
+def test_upstream_without_gate_fails_with_missing_indexer_keys(monkeypatch, repro_dir):
     """Pin the bug we are patching around.
 
     Uninstall the gate, then call ``mlx_lm.utils.load_model`` on a 4-layer

--- a/tests/test_deepseek_v32_indexer_gate.py
+++ b/tests/test_deepseek_v32_indexer_gate.py
@@ -536,6 +536,38 @@ def test_reuse_path_runs_for_run_of_consecutive_shared_layers(repro_dir):
     assert gate._SHARED_LAYER_DENSE_FALLBACK_COUNT == 0
 
 
+def test_pp_shard_with_oversized_num_layers_raises_clear_error(repro_dir):
+    """Pipeline-parallel shard whose ``num_layers`` extends past the
+    local ``self.layers`` list raises a clear ``ValueError`` before
+    entering the layer loop, instead of a deep opaque ``IndexError``.
+
+    Codex finding #1 on PR #967 round 7: the patched model loop
+    indexes ``self.layers[self.start_idx + i]`` for ``i in
+    range(self.num_layers)`` unconditionally. A malformed shard
+    where ``start_idx + num_layers > len(self.layers)`` would crash
+    deep inside the loop with no actionable error message. Add a
+    pre-loop bounds check.
+    """
+    from vllm_mlx.patches import deepseek_v32_indexer_gate as gate
+
+    gate.install_deepseek_v32_indexer_gate()
+    repro = _forge_repro(repro_dir, ["full", "shared", "full", "shared"])
+
+    from mlx_lm.utils import load_model
+
+    model, _cfg = load_model(repro)
+    inner = model.model
+
+    # Simulate a malformed PP shard: start_idx legitimate, but
+    # num_layers exceeds local layer list length.
+    inner.start_idx = 2
+    inner.num_layers = 5  # 2 + 5 = 7 > len(layers)=4
+
+    prompt = mx.array([[1, 2, 3]], dtype=mx.int32)
+    with pytest.raises(ValueError, match="extends past local layer list"):
+        model(prompt)
+
+
 def test_pp_shard_starting_on_shared_layer_raises_clear_error(repro_dir):
     """Pipeline-parallel shard whose first locally-iterated layer is
     ``"shared"`` raises a clear ``ValueError`` instead of silently

--- a/tests/test_deepseek_v32_indexer_gate.py
+++ b/tests/test_deepseek_v32_indexer_gate.py
@@ -211,14 +211,21 @@ def test_upstream_without_gate_fails_with_missing_indexer_keys(monkeypatch, repr
 def test_gate_loads_mixed_full_shared_config(repro_dir):
     """4-layer ``["full","shared","full","shared"]`` config loads cleanly.
 
-    Only "full" layers retain an Indexer; "shared" layers have
-    ``self_attn.indexer is None``.
-    """
-    from vllm_mlx.patches.deepseek_v32_indexer_gate import (
-        install_deepseek_v32_indexer_gate,
-    )
+    Pins three properties beyond "no crash on load":
 
-    install_deepseek_v32_indexer_gate()
+    1. Only "full" layers retain an Indexer; "shared" layers have
+       ``self_attn.indexer is None`` (load-time gate fired correctly).
+    2. The shared-layer attention codepath is actually invoked during
+       forward (the counter ``_SHARED_LAYER_FORWARD_COUNT`` increments
+       by exactly the number of shared layers traversed). Catches
+       regressions where a refactor accidentally routes shared layers
+       back through the upstream Indexer-bearing ``__call__``.
+    3. Forward output is finite (no NaN/Inf) — the dense-attention
+       fallback on shared layers produces numerically valid logits.
+    """
+    from vllm_mlx.patches import deepseek_v32_indexer_gate as gate
+
+    gate.install_deepseek_v32_indexer_gate()
     repro = _forge_repro(repro_dir, ["full", "shared", "full", "shared"])
 
     from mlx_lm.utils import load_model
@@ -226,17 +233,35 @@ def test_gate_loads_mixed_full_shared_config(repro_dir):
     model, _cfg = load_model(repro)
     layers = model.model.layers
     assert len(layers) == 4
+    # (1) load-time gate
     assert layers[0].self_attn.indexer is not None
     assert layers[1].self_attn.indexer is None
     assert layers[2].self_attn.indexer is not None
     assert layers[3].self_attn.indexer is None
 
-    # And a forward pass through the model executes without crash on
-    # both the full and shared layers.
+    # (2) shared-layer code path is exercised exactly once per shared layer
+    # per forward call. Reset the counter, run forward, assert delta.
+    gate._SHARED_LAYER_FORWARD_COUNT = 0
     prompt = mx.array([[1, 2, 3, 4, 5]], dtype=mx.int32)
     out = model(prompt)
     mx.eval(out)
     assert out.shape == (1, 5, 256)
+    # 2 "shared" layers in this config; forward visits each once.
+    assert gate._SHARED_LAYER_FORWARD_COUNT == 2, (
+        "shared-layer attention path was not invoked exactly twice — "
+        f"got {gate._SHARED_LAYER_FORWARD_COUNT}. A regression may have "
+        "routed shared layers back through the upstream Indexer path."
+    )
+
+    # (3) logits are finite (synthetic zero weights make absolute values
+    # tiny but the dense-attention fallback should not produce NaN/Inf).
+    import math
+
+    out_max = float(mx.max(mx.abs(out)).item())
+    assert math.isfinite(out_max), (
+        f"forward output contains NaN/Inf (max |.|={out_max}); the dense "
+        "shared-layer attention path produced numerically invalid logits"
+    )
 
 
 # ----------------------------------------------------------------------
@@ -283,6 +308,11 @@ def test_gate_rejects_all_shared_indexer_types(repro_dir):
     the shared layers reuse a prior full layer's indexer output. An all-
     shared config has no Indexer at all and could never be inferenced.
     Fail fast at model build instead of crashing later in forward.
+
+    The (a) index-0 check fires first (``shared`` at the first layer has
+    no anchor to reuse), so the ``ValueError`` message specifically calls
+    out the first-layer violation; the all-shared check is the (b)
+    defensive backstop covered by ``test_gate_rejects_shared_at_index_zero``.
     """
     from vllm_mlx.patches.deepseek_v32_indexer_gate import (
         install_deepseek_v32_indexer_gate,
@@ -299,5 +329,35 @@ def test_gate_rejects_all_shared_indexer_types(repro_dir):
 
     from mlx_lm.utils import load_model
 
-    with pytest.raises(ValueError, match="no 'full' anchor"):
+    with pytest.raises(
+        ValueError, match="(?:no 'full' anchor|first layer must be 'full')"
+    ):
+        load_model(repro)
+
+
+def test_gate_rejects_shared_at_index_zero(repro_dir):
+    """``["shared", "full", "full", "full"]`` is invalid — index-0 has no
+    anchor to reuse.
+
+    Codex finding (PR #967, round 1): the original ``_validate_anchor``
+    only rejected all-``"shared"`` configs and accepted ``["shared",
+    "full", ...]`` as valid. The first-layer guard added in response
+    rejects any ``indexer_types[0] != "full"``; pin it here.
+    """
+    from vllm_mlx.patches.deepseek_v32_indexer_gate import (
+        install_deepseek_v32_indexer_gate,
+    )
+
+    install_deepseek_v32_indexer_gate()
+    repro = _forge_repro(
+        repro_dir,
+        ["shared", "full", "full", "full"],
+        # Lie about safetensors so the validator fires before
+        # missing-keys does (layer 0's safetensors emits "full" keys).
+        layer_modes_for_safetensors=["full"] * 4,
+    )
+
+    from mlx_lm.utils import load_model
+
+    with pytest.raises(ValueError, match="first layer must be 'full'"):
         load_model(repro)

--- a/tests/test_deepseek_v32_indexer_gate.py
+++ b/tests/test_deepseek_v32_indexer_gate.py
@@ -362,51 +362,86 @@ def test_gate_rejects_all_shared_indexer_types(repro_dir):
 
 
 def test_decode_step_after_prefill_still_reuses_topk(repro_dir):
-    """Second forward call (decode) reuses topk from the prior forward.
+    """Second forward call (decode) reuses topk from the prior forward
+    EVEN WHEN the first iterated layer in the decode pass is ``"shared"``.
 
     Codex finding #1 on PR #967 round 3: the model-level wrapper reset
-    ``last_topk_indices`` to ``None`` on every ``__call__``, so the
-    leading shared layer in a decode step could briefly see ``None``
-    before the first full layer refreshed it. The current implementation
-    seeds ``last_topk_indices`` from the most-recent full layer's
-    persisted ``_last_topk_indices`` at the top of the loop. Pin it
-    here: after a prefill forward, a decode forward continues to hit
-    the REAP reuse path on every shared layer (no dense fallback).
+    ``last_topk_indices`` to ``None`` on every ``__call__``, so any
+    leading shared layer in a decode step could fall back to dense.
+    The current implementation seeds ``last_topk_indices`` from the
+    most-recent full layer's persisted ``_last_topk_indices`` by
+    scanning all of ``self.layers`` (not just this rank's slice).
+
+    Codex finding (PR #967 round 4): a test that uses
+    ``["full","shared","full","shared"]`` would still pass with the
+    seed code deleted, because layer 0 (full) re-runs first and
+    refreshes ``last_topk_indices`` before any shared layer. To
+    actually exercise the seed code path, construct a scenario where
+    the first iterated layer in the decode pass is ``"shared"`` —
+    here we use a config with a single full anchor at layer 0 and
+    then simulate a pipeline-parallel rank that only iterates layers
+    [1, 2, 3] (all shared). Layer 0 stays in ``self.layers`` so the
+    seed loop can find its persisted state.
     """
     from vllm_mlx.patches import deepseek_v32_indexer_gate as gate
 
     gate.install_deepseek_v32_indexer_gate()
-    repro = _forge_repro(repro_dir, ["full", "shared", "full", "shared"])
+    # Single full anchor at index 0, three shared layers after.
+    repro = _forge_repro(repro_dir, ["full", "shared", "shared", "shared"])
 
     from mlx_lm.models.cache import make_prompt_cache
     from mlx_lm.utils import load_model
 
     model, _cfg = load_model(repro)
+    inner = model.model  # DeepseekV32Model
 
-    # Prefill
+    # ---- Prefill on the full model: layer 0 (full) populates its
+    # indexer._last_topk_indices, all 3 shared layers reuse it.
     cache = make_prompt_cache(model)
     gate._SHARED_LAYER_REUSE_COUNT = 0
     gate._SHARED_LAYER_DENSE_FALLBACK_COUNT = 0
     prefill = mx.array([[1, 2, 3, 4, 5]], dtype=mx.int32)
     logits = model(prefill, cache=cache)
     mx.eval(logits)
-    assert gate._SHARED_LAYER_REUSE_COUNT == 2
+    assert gate._SHARED_LAYER_REUSE_COUNT == 3
     assert gate._SHARED_LAYER_DENSE_FALLBACK_COUNT == 0
+    # Sanity: layer 0's indexer DID persist a topk tensor.
+    assert (
+        getattr(inner.layers[0].self_attn.indexer, "_last_topk_indices", None)
+        is not None
+    )
 
-    # Decode step (single new token). The full layers refresh
-    # _last_topk_indices on each step; the seeded loop initial value
-    # also picks up the prior call's last full layer in case ``start_idx
-    # > 0`` (pipeline-parallel) or a future model layout puts a leading
-    # shared layer ahead of all full layers in this rank.
+    # ---- Simulate a pipeline-parallel rank-1 that only iterates
+    # layers [1, 2, 3] (all shared). With this layout, the decode
+    # pass's FIRST iterated layer is shared — the only way for it to
+    # hit the REAP reuse path is if `last_topk_indices` is seeded
+    # from layer 0's persisted indexer state BEFORE the layer loop
+    # begins. Without the seed code, all three shared layers fall
+    # back to dense.
+    inner.start_idx = 1
+    inner.num_layers = 3
+    # The layer loop now consumes cache[0..2] for layers [1..3]; drop
+    # cache[0] which was for layer 0.
+    cache = cache[1:]
+
     gate._SHARED_LAYER_REUSE_COUNT = 0
     gate._SHARED_LAYER_DENSE_FALLBACK_COUNT = 0
     next_tok = mx.array([[6]], dtype=mx.int32)
     logits = model(next_tok, cache=cache)
     mx.eval(logits)
-    assert gate._SHARED_LAYER_REUSE_COUNT == 2, (
-        "decode step lost topk reuse — "
+    # Three shared layers, all must reuse — dense fallback would mean
+    # the seed code path didn't fire. The previous-round test (using
+    # ["full","shared","full","shared"] with start_idx=0) would still
+    # have passed without the seed code because layer 0 re-runs first
+    # in the iteration; this test fails if the seed code is deleted.
+    assert gate._SHARED_LAYER_REUSE_COUNT == 3, (
+        "decode step with leading shared layer in this rank lost the seed-"
+        "from-prior-forward topk reuse — "
         f"reuse={gate._SHARED_LAYER_REUSE_COUNT}, "
-        f"dense_fallback={gate._SHARED_LAYER_DENSE_FALLBACK_COUNT}"
+        f"dense_fallback={gate._SHARED_LAYER_DENSE_FALLBACK_COUNT}. The "
+        "seed loop at the top of `_patched_model_call` must find layer 0's "
+        "persisted indexer._last_topk_indices and thread it into the first "
+        "iterated shared layer (codex PR #967 round-4 finding)."
     )
     assert gate._SHARED_LAYER_DENSE_FALLBACK_COUNT == 0
 

--- a/tests/test_deepseek_v32_indexer_gate.py
+++ b/tests/test_deepseek_v32_indexer_gate.py
@@ -706,3 +706,86 @@ def test_gate_rejects_shared_at_index_zero(repro_dir):
 
     with pytest.raises(ValueError, match="first layer must be 'full'"):
         load_model(repro)
+
+
+def test_install_fires_on_real_serve_import_path():
+    """Regression for PR #967 wiring bug — the gate must install when a
+    SERVE-path module is imported, not only when the patch module itself
+    is imported directly.
+
+    The original PR #967 wired ``install_deepseek_v32_indexer_gate()`` at
+    ``vllm_mlx/model_runner.py:34``. The real ``rapid-mlx serve`` boot
+    path is::
+
+        cli -> server -> engine.batched._start_llm
+        -> utils.tokenizer.load_model_with_fallback -> mlx_lm.load
+        -> mlx_lm.utils.load_model
+
+    None of those import ``model_runner``, so the gate was NEVER installed
+    in production and ``mlx_lm.load`` aborted with ``Missing 285 parameters
+    ...indexer...`` on real GLM-5.2 REAP-pruned weights. The 11 synthetic
+    regression tests passed only because pytest imports the patch module
+    directly via ``from vllm_mlx.patches.deepseek_v32_indexer_gate import
+    ...`` — which triggered the install as an import side-effect of the
+    test module itself, masking the production gap.
+
+    This test guards against a recurrence by:
+
+    1. Uninstalling the gate via the currently-loaded patch module.
+    2. Purging cached ``vllm_mlx`` modules from ``sys.modules`` so the
+       next import re-runs module-level code.
+    3. Importing a SERVE-path module (``vllm_mlx.utils.tokenizer``),
+       NOT the patch module directly.
+    4. Asserting the gate is installed afterwards.
+
+    A future refactor that moves the install hook back to a module not on
+    the serve import path would fail at step 4 with the same 285-missing-
+    keys symptom that broke real GLM-5.2 boot.
+    """
+    import sys
+
+    # (1) Cleanly uninstall via the currently-loaded patch module so the
+    # subsequent re-install in step 3 truly fires through the new code
+    # path rather than early-returning on a stale _INSTALLED=True flag.
+    from vllm_mlx.patches.deepseek_v32_indexer_gate import (
+        uninstall_deepseek_v32_indexer_gate,
+    )
+
+    uninstall_deepseek_v32_indexer_gate()
+
+    # (2) Purge cached vllm_mlx imports so importing utils.tokenizer
+    # re-executes its module-level code (which is where the install
+    # hook now lives — PR #967 wiring fix).
+    for mod_name in list(sys.modules):
+        if mod_name.startswith("vllm_mlx"):
+            del sys.modules[mod_name]
+
+    # (3) Import a SERVE-path module. This MUST trigger the install
+    # hook — that is the whole point of the wiring fix. We deliberately
+    # do NOT touch ``vllm_mlx.patches.deepseek_v32_indexer_gate`` here;
+    # importing it directly would mask the bug.
+    import vllm_mlx.utils.tokenizer  # noqa: F401
+
+    # (4) Assert the gate is now installed. Re-import the patch module
+    # to read its post-install state — the freshly-loaded instance has
+    # ``_INSTALLED = True`` set by the install call that fired during
+    # the ``utils.tokenizer`` import.
+    from vllm_mlx.patches.deepseek_v32_indexer_gate import is_installed
+
+    assert is_installed(), (
+        "install hook did NOT fire when serve-path module "
+        "vllm_mlx.utils.tokenizer was imported — PR #967 wiring "
+        "regression. On real GLM-5.2 REAP weights this symptom is "
+        "'Missing 285 parameters ...indexer...' on boot."
+    )
+
+    # Also verify the patch is live on the upstream class (defense-in-
+    # depth — guards against a regression where _INSTALLED gets flipped
+    # to True without the actual monkey-patches being applied).
+    from mlx_lm.models import deepseek_v32 as ds
+
+    assert getattr(ds, "_RAPID_MLX_INDEXER_GATE_INSTALLED", False), (
+        "patch module flag says installed, but the upstream marker on "
+        "mlx_lm.models.deepseek_v32 is missing — the monkey-patch was "
+        "not actually applied"
+    )

--- a/tests/test_deepseek_v32_indexer_gate.py
+++ b/tests/test_deepseek_v32_indexer_gate.py
@@ -361,6 +361,136 @@ def test_gate_rejects_all_shared_indexer_types(repro_dir):
         load_model(repro)
 
 
+def test_decode_step_after_prefill_still_reuses_topk(repro_dir):
+    """Second forward call (decode) reuses topk from the prior forward.
+
+    Codex finding #1 on PR #967 round 3: the model-level wrapper reset
+    ``last_topk_indices`` to ``None`` on every ``__call__``, so the
+    leading shared layer in a decode step could briefly see ``None``
+    before the first full layer refreshed it. The current implementation
+    seeds ``last_topk_indices`` from the most-recent full layer's
+    persisted ``_last_topk_indices`` at the top of the loop. Pin it
+    here: after a prefill forward, a decode forward continues to hit
+    the REAP reuse path on every shared layer (no dense fallback).
+    """
+    from vllm_mlx.patches import deepseek_v32_indexer_gate as gate
+
+    gate.install_deepseek_v32_indexer_gate()
+    repro = _forge_repro(repro_dir, ["full", "shared", "full", "shared"])
+
+    from mlx_lm.models.cache import make_prompt_cache
+    from mlx_lm.utils import load_model
+
+    model, _cfg = load_model(repro)
+
+    # Prefill
+    cache = make_prompt_cache(model)
+    gate._SHARED_LAYER_REUSE_COUNT = 0
+    gate._SHARED_LAYER_DENSE_FALLBACK_COUNT = 0
+    prefill = mx.array([[1, 2, 3, 4, 5]], dtype=mx.int32)
+    logits = model(prefill, cache=cache)
+    mx.eval(logits)
+    assert gate._SHARED_LAYER_REUSE_COUNT == 2
+    assert gate._SHARED_LAYER_DENSE_FALLBACK_COUNT == 0
+
+    # Decode step (single new token). The full layers refresh
+    # _last_topk_indices on each step; the seeded loop initial value
+    # also picks up the prior call's last full layer in case ``start_idx
+    # > 0`` (pipeline-parallel) or a future model layout puts a leading
+    # shared layer ahead of all full layers in this rank.
+    gate._SHARED_LAYER_REUSE_COUNT = 0
+    gate._SHARED_LAYER_DENSE_FALLBACK_COUNT = 0
+    next_tok = mx.array([[6]], dtype=mx.int32)
+    logits = model(next_tok, cache=cache)
+    mx.eval(logits)
+    assert gate._SHARED_LAYER_REUSE_COUNT == 2, (
+        "decode step lost topk reuse — "
+        f"reuse={gate._SHARED_LAYER_REUSE_COUNT}, "
+        f"dense_fallback={gate._SHARED_LAYER_DENSE_FALLBACK_COUNT}"
+    )
+    assert gate._SHARED_LAYER_DENSE_FALLBACK_COUNT == 0
+
+
+def test_uninstall_restores_originals_across_module_reload(repro_dir):
+    """``uninstall`` restores upstream callables even after a module-
+    reload-style re-install (codex finding #2, PR #967 round 3).
+
+    Sequence:
+    1. install + uninstall on a fresh module — captures originals,
+       restores them. Sanity.
+    2. install (no uninstall yet) — sets the upstream marker.
+    3. Simulate a module reload: clear THIS module's ``_orig_*``
+       globals + ``_INSTALLED`` flag, then call ``install`` again.
+       Bug behavior would leave ``_orig_*`` = None (because the
+       early-return path skips capture); fixed behavior copies the
+       originals from the upstream-stashed slot.
+    4. uninstall — must restore the un-patched callables.
+    5. Without the gate, loading a REAP config fails (proves the
+       un-patched callables really are back in place).
+    """
+    from vllm_mlx.patches import deepseek_v32_indexer_gate as gate
+
+    # (1) install + uninstall round-trip — fresh state.
+    gate.uninstall_deepseek_v32_indexer_gate()  # be defensive
+    gate._INSTALLED = False
+    gate._orig_attn_call = None
+    gate._orig_decoder_init = None
+    gate._orig_indexer_call = None
+    gate._orig_model_call = None
+    gate._orig_from_dict = None
+    gate.install_deepseek_v32_indexer_gate()
+    assert gate._INSTALLED is True
+    assert gate._orig_attn_call is not None
+    gate.uninstall_deepseek_v32_indexer_gate()
+    assert gate._INSTALLED is False
+    assert gate._orig_attn_call is None
+
+    # (2) install (now the upstream module has the marker).
+    gate.install_deepseek_v32_indexer_gate()
+    from mlx_lm.models import deepseek_v32 as ds
+
+    assert getattr(ds, "_RAPID_MLX_INDEXER_GATE_INSTALLED", False)
+
+    # (3) simulate module-reload: clear the module-side globals and
+    # call install again. The reload path must populate ``_orig_*``
+    # from the upstream stash, not capture the currently-patched
+    # callables.
+    gate._INSTALLED = False
+    gate._orig_attn_call = None
+    gate._orig_decoder_init = None
+    gate._orig_indexer_call = None
+    gate._orig_model_call = None
+    gate._orig_from_dict = None
+    gate.install_deepseek_v32_indexer_gate()
+    assert gate._INSTALLED is True
+    assert gate._orig_attn_call is not None, (
+        "install after module reload did not populate _orig_attn_call; "
+        "uninstall would silently leave the patches in place. Codex "
+        "PR #967 round-3 finding #2."
+    )
+
+    # (4) uninstall — should restore the true upstream callables.
+    gate.uninstall_deepseek_v32_indexer_gate()
+    assert gate._INSTALLED is False
+    assert not getattr(ds, "_RAPID_MLX_INDEXER_GATE_INSTALLED", False)
+
+    # (5) Without the gate, loading a REAP config crashes with missing
+    # indexer keys — proves the upstream un-patched callables really
+    # are back in place.
+    repro = _forge_repro(repro_dir, ["full", "shared", "full", "shared"])
+
+    from mlx_lm.utils import load_model
+
+    with pytest.raises(ValueError) as exc_info:
+        load_model(repro)
+    msg = str(exc_info.value)
+    assert "Missing 10 parameters" in msg, msg
+    assert "indexer" in msg, msg
+
+    # Re-arm the gate for downstream tests.
+    gate.install_deepseek_v32_indexer_gate()
+
+
 def test_gate_rejects_shared_at_index_zero(repro_dir):
     """``["shared", "full", "full", "full"]`` is invalid — index-0 has no
     anchor to reuse.

--- a/tests/test_deepseek_v32_indexer_gate.py
+++ b/tests/test_deepseek_v32_indexer_gate.py
@@ -1,0 +1,307 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for the Defect 1 indexer gate.
+
+Pins the surgical fix shipped in
+``vllm_mlx.patches.deepseek_v32_indexer_gate`` for REAP-pruned DeepseekV32
+configs (e.g. ``mlx-community/pipenetwork-GLM-5.2-REAP50-MLX-4bit``):
+
+1. Without the gate installed, ``mlx_lm.utils.load_model`` on a config
+   carrying ``indexer_types`` aborts with ``Missing N parameters:
+   ...indexer...`` for each ``"shared"`` layer. This is the bug we are
+   patching around — pin it so we notice if mlx_lm upstream changes
+   behavior.
+
+2. With the gate installed, the same config loads cleanly; ``"shared"``
+   layers have ``self_attn.indexer is None`` while ``"full"`` layers
+   still carry an ``Indexer`` instance.
+
+3. Backward-compat: a config WITHOUT ``indexer_types`` keeps upstream
+   behavior (every layer has an Indexer; gate is a no-op).
+
+4. Edge case: an all-``"shared"`` ``indexer_types`` raises ``ValueError``
+   on model construction — there is no valid REAP config without at
+   least one ``"full"`` anchor.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+from typing import Iterable, List, Optional
+
+import mlx.core as mx
+import pytest
+
+
+# ----------------------------------------------------------------------
+# Synthetic glm_moe_dsa config + weight forge (no GLM-5.2 download)
+# ----------------------------------------------------------------------
+
+
+def _config(num_layers: int, indexer_types: Optional[Iterable[str]]) -> dict:
+    cfg = {
+        "model_type": "glm_moe_dsa",
+        "vocab_size": 256,
+        "hidden_size": 64,
+        "index_head_dim": 16,
+        "index_n_heads": 4,
+        "index_topk": 4,
+        "intermediate_size": 128,
+        "moe_intermediate_size": 64,
+        "num_hidden_layers": num_layers,
+        "num_attention_heads": 4,
+        "num_key_value_heads": 4,
+        "n_shared_experts": None,
+        "n_routed_experts": None,
+        "routed_scaling_factor": 1.0,
+        "kv_lora_rank": 16,
+        "q_lora_rank": 32,
+        "qk_rope_head_dim": 16,
+        "v_head_dim": 32,
+        "qk_nope_head_dim": 32,
+        "topk_method": "noaux_tc",
+        "scoring_func": "sigmoid",
+        "norm_topk_prob": True,
+        "n_group": 1,
+        "topk_group": 1,
+        "num_experts_per_tok": 1,
+        "moe_layer_freq": 1,
+        "first_k_dense_replace": 0,
+        "max_position_embeddings": 64,
+        "rms_norm_eps": 1e-6,
+        "rope_parameters": {"rope_theta": 10000.0},
+        "attention_bias": False,
+    }
+    if indexer_types is not None:
+        cfg["indexer_types"] = list(indexer_types)
+    return cfg
+
+
+def _layer_keys(layer_idx: int, mode: str, cfg: dict) -> dict:
+    H = cfg["hidden_size"]
+    Q = cfg["q_lora_rank"]
+    KV = cfg["kv_lora_rank"]
+    QKR = cfg["qk_rope_head_dim"]
+    QK_NOPE = cfg["qk_nope_head_dim"]
+    VH = cfg["v_head_dim"]
+    NH = cfg["num_attention_heads"]
+    INT = cfg["intermediate_size"]
+    IH = cfg["index_head_dim"]
+    IN = cfg["index_n_heads"]
+    prefix = f"model.layers.{layer_idx}"
+    keys = {
+        f"{prefix}.input_layernorm.weight": (H,),
+        f"{prefix}.post_attention_layernorm.weight": (H,),
+        f"{prefix}.self_attn.q_a_proj.weight": (Q, H),
+        f"{prefix}.self_attn.q_a_layernorm.weight": (Q,),
+        f"{prefix}.self_attn.q_b_proj.weight": (NH * (QK_NOPE + QKR), Q),
+        f"{prefix}.self_attn.kv_a_proj_with_mqa.weight": (KV + QKR, H),
+        f"{prefix}.self_attn.kv_a_layernorm.weight": (KV,),
+        f"{prefix}.self_attn.embed_q.weight": (NH, KV, QK_NOPE),
+        f"{prefix}.self_attn.unembed_out.weight": (NH, VH, KV),
+        f"{prefix}.self_attn.o_proj.weight": (H, NH * VH),
+        f"{prefix}.mlp.gate_proj.weight": (INT, H),
+        f"{prefix}.mlp.up_proj.weight": (INT, H),
+        f"{prefix}.mlp.down_proj.weight": (H, INT),
+    }
+    if mode == "full":
+        keys.update(
+            {
+                f"{prefix}.self_attn.indexer.wq_b.weight": (IN * IH, Q),
+                f"{prefix}.self_attn.indexer.wk.weight": (IH, H),
+                f"{prefix}.self_attn.indexer.k_norm.weight": (IH,),
+                f"{prefix}.self_attn.indexer.k_norm.bias": (IH,),
+                f"{prefix}.self_attn.indexer.weights_proj.weight": (IN, H),
+            }
+        )
+    return keys
+
+
+def _forge_repro(
+    tmp_path: Path,
+    indexer_types: Optional[List[str]],
+    layer_modes_for_safetensors: Optional[List[str]] = None,
+) -> Path:
+    """Write a tiny config + safetensors stub for the test.
+
+    ``layer_modes_for_safetensors`` defaults to ``indexer_types`` (one
+    indexer per "full" layer, none per "shared" layer). Tests that want
+    to lie about what's on disk (e.g. emit indexer weights for every
+    layer when ``indexer_types`` is None) can override.
+    """
+    cfg = _config(num_layers=4, indexer_types=indexer_types)
+    repro = tmp_path / "model"
+    repro.mkdir(parents=True, exist_ok=True)
+    with open(repro / "config.json", "w") as f:
+        json.dump(cfg, f)
+
+    layer_modes = layer_modes_for_safetensors or (
+        indexer_types if indexer_types is not None else ["full"] * 4
+    )
+    weights = {
+        "model.embed_tokens.weight": mx.zeros(
+            (cfg["vocab_size"], cfg["hidden_size"]), dtype=mx.float32
+        ),
+        "model.norm.weight": mx.zeros((cfg["hidden_size"],), dtype=mx.float32),
+        "lm_head.weight": mx.zeros(
+            (cfg["vocab_size"], cfg["hidden_size"]), dtype=mx.float32
+        ),
+    }
+    for i, mode in enumerate(layer_modes):
+        for k, shape in _layer_keys(i, mode, cfg).items():
+            weights[k] = mx.zeros(shape, dtype=mx.float32)
+    mx.save_safetensors(str(repro / "model.safetensors"), weights)
+    return repro
+
+
+@pytest.fixture
+def repro_dir(tmp_path: Path) -> Path:
+    return tmp_path
+
+
+# ----------------------------------------------------------------------
+# 1. WITHOUT-patch baseline — pins the upstream-bug surface.
+# ----------------------------------------------------------------------
+
+
+def test_upstream_without_gate_fails_with_missing_indexer_keys(
+    monkeypatch, repro_dir
+):
+    """Pin the bug we are patching around.
+
+    Uninstall the gate, then call ``mlx_lm.utils.load_model`` on a 4-layer
+    glm_moe_dsa config with ``indexer_types=["full","shared","full","shared"]``.
+    Upstream should abort with ``Missing 10 parameters: ...indexer...``.
+    """
+    from vllm_mlx.patches.deepseek_v32_indexer_gate import (
+        install_deepseek_v32_indexer_gate,
+        uninstall_deepseek_v32_indexer_gate,
+    )
+
+    # Ensure baseline: gate uninstalled for the duration of this test.
+    install_deepseek_v32_indexer_gate()  # capture originals
+    uninstall_deepseek_v32_indexer_gate()
+    monkeypatch.setattr(
+        "vllm_mlx.patches.deepseek_v32_indexer_gate._INSTALLED",
+        False,
+        raising=False,
+    )
+
+    repro = _forge_repro(repro_dir, ["full", "shared", "full", "shared"])
+
+    from mlx_lm.utils import load_model
+
+    with pytest.raises(ValueError) as exc_info:
+        load_model(repro)
+
+    msg = str(exc_info.value)
+    assert "Missing" in msg
+    assert "indexer" in msg
+    # Each "shared" layer is missing exactly the 5 Indexer keys; 2 shared
+    # layers * 5 keys = 10 total. Pin the count so a future upstream
+    # refactor of Indexer.__init__ is caught here.
+    assert "Missing 10 parameters" in msg
+
+    # Re-arm the gate for downstream tests in this session.
+    install_deepseek_v32_indexer_gate()
+
+
+# ----------------------------------------------------------------------
+# 2. WITH-patch — the actual fix.
+# ----------------------------------------------------------------------
+
+
+def test_gate_loads_mixed_full_shared_config(repro_dir):
+    """4-layer ``["full","shared","full","shared"]`` config loads cleanly.
+
+    Only "full" layers retain an Indexer; "shared" layers have
+    ``self_attn.indexer is None``.
+    """
+    from vllm_mlx.patches.deepseek_v32_indexer_gate import (
+        install_deepseek_v32_indexer_gate,
+    )
+
+    install_deepseek_v32_indexer_gate()
+    repro = _forge_repro(repro_dir, ["full", "shared", "full", "shared"])
+
+    from mlx_lm.utils import load_model
+
+    model, _cfg = load_model(repro)
+    layers = model.model.layers
+    assert len(layers) == 4
+    assert layers[0].self_attn.indexer is not None
+    assert layers[1].self_attn.indexer is None
+    assert layers[2].self_attn.indexer is not None
+    assert layers[3].self_attn.indexer is None
+
+    # And a forward pass through the model executes without crash on
+    # both the full and shared layers.
+    prompt = mx.array([[1, 2, 3, 4, 5]], dtype=mx.int32)
+    out = model(prompt)
+    mx.eval(out)
+    assert out.shape == (1, 5, 256)
+
+
+# ----------------------------------------------------------------------
+# 3. Backward-compat — config without ``indexer_types`` is unchanged.
+# ----------------------------------------------------------------------
+
+
+def test_gate_is_noop_when_indexer_types_absent(repro_dir):
+    """Non-REAP config loads with every layer having an Indexer.
+
+    This pins backward-compat: the gate must NOT change behavior on
+    configs lacking ``indexer_types`` (legitimate non-REAP DSv32 /
+    GLM-4.6 models). All 4 layers get full Indexer construction and
+    every safetensors key matches.
+    """
+    from vllm_mlx.patches.deepseek_v32_indexer_gate import (
+        install_deepseek_v32_indexer_gate,
+    )
+
+    install_deepseek_v32_indexer_gate()
+    # All layers emit indexer weights — what upstream non-REAP models do.
+    repro = _forge_repro(repro_dir, indexer_types=None)
+
+    from mlx_lm.utils import load_model
+
+    model, _cfg = load_model(repro)
+    layers = model.model.layers
+    assert len(layers) == 4
+    for i, layer in enumerate(layers):
+        assert layer.self_attn.indexer is not None, (
+            f"layer {i} should retain Indexer when indexer_types is absent"
+        )
+
+
+# ----------------------------------------------------------------------
+# 4. Edge case — all-"shared" is rejected with a clear error.
+# ----------------------------------------------------------------------
+
+
+def test_gate_rejects_all_shared_indexer_types(repro_dir):
+    """``indexer_types=["shared"]*4`` is invalid; raise clearly.
+
+    A real REAP-pruned model always has at least one ``"full"`` anchor —
+    the shared layers reuse a prior full layer's indexer output. An all-
+    shared config has no Indexer at all and could never be inferenced.
+    Fail fast at model build instead of crashing later in forward.
+    """
+    from vllm_mlx.patches.deepseek_v32_indexer_gate import (
+        install_deepseek_v32_indexer_gate,
+    )
+
+    install_deepseek_v32_indexer_gate()
+    # Use "full" safetensors-mode so the failure is the validator's
+    # error, not "missing indexer keys" downstream.
+    repro = _forge_repro(
+        repro_dir,
+        ["shared"] * 4,
+        layer_modes_for_safetensors=["full"] * 4,
+    )
+
+    from mlx_lm.utils import load_model
+
+    with pytest.raises(ValueError, match="no 'full' anchor"):
+        load_model(repro)

--- a/tests/test_deepseek_v32_indexer_gate.py
+++ b/tests/test_deepseek_v32_indexer_gate.py
@@ -209,9 +209,11 @@ def test_upstream_without_gate_fails_with_missing_indexer_keys(monkeypatch, repr
 
 
 def test_gate_loads_mixed_full_shared_config(repro_dir):
-    """4-layer ``["full","shared","full","shared"]`` config loads cleanly.
+    """4-layer ``["full","shared","full","shared"]`` config loads cleanly,
+    and shared layers REUSE the prior full layer's indexer topk (the REAP
+    contract — not a dense fallback).
 
-    Pins three properties beyond "no crash on load":
+    Pins four properties beyond "no crash on load":
 
     1. Only "full" layers retain an Indexer; "shared" layers have
        ``self_attn.indexer is None`` (load-time gate fired correctly).
@@ -220,8 +222,18 @@ def test_gate_loads_mixed_full_shared_config(repro_dir):
        by exactly the number of shared layers traversed). Catches
        regressions where a refactor accidentally routes shared layers
        back through the upstream Indexer-bearing ``__call__``.
-    3. Forward output is finite (no NaN/Inf) — the dense-attention
-       fallback on shared layers produces numerically valid logits.
+    3. The REAP reuse path fires: every shared layer consumes a
+       non-None ``topk_indices`` threaded from the prior full layer
+       (``_SHARED_LAYER_REUSE_COUNT == 2``,
+       ``_SHARED_LAYER_DENSE_FALLBACK_COUNT == 0``). The synthetic
+       config has ``index_topk=4`` and the prompt has 5 tokens, so
+       the indexer's internal early-exit (``k.shape[2] <= index_topk
+       → return None``) does NOT fire and the threaded topk is real.
+       Codex finding #1 on PR #967 round 2: the shared layer must NOT
+       silently take the dense fallback when the model author's intent
+       is sparse top-K reuse.
+    4. Forward output is finite (no NaN/Inf) on both the reuse and
+       dense paths.
     """
     from vllm_mlx.patches import deepseek_v32_indexer_gate as gate
 
@@ -240,8 +252,10 @@ def test_gate_loads_mixed_full_shared_config(repro_dir):
     assert layers[3].self_attn.indexer is None
 
     # (2) shared-layer code path is exercised exactly once per shared layer
-    # per forward call. Reset the counter, run forward, assert delta.
+    # per forward call. Reset counters, run forward, assert deltas.
     gate._SHARED_LAYER_FORWARD_COUNT = 0
+    gate._SHARED_LAYER_REUSE_COUNT = 0
+    gate._SHARED_LAYER_DENSE_FALLBACK_COUNT = 0
     prompt = mx.array([[1, 2, 3, 4, 5]], dtype=mx.int32)
     out = model(prompt)
     mx.eval(out)
@@ -253,13 +267,25 @@ def test_gate_loads_mixed_full_shared_config(repro_dir):
         "routed shared layers back through the upstream Indexer path."
     )
 
-    # (3) logits are finite (synthetic zero weights make absolute values
-    # tiny but the dense-attention fallback should not produce NaN/Inf).
+    # (3) REAP reuse path is the one that fired (prompt=5 tok > index_topk=4
+    # so the prior full layer's indexer DID produce a topk tensor).
+    assert gate._SHARED_LAYER_REUSE_COUNT == 2, (
+        "shared-layer REAP reuse path did not fire on both shared layers — "
+        f"got reuse={gate._SHARED_LAYER_REUSE_COUNT}, "
+        f"dense_fallback={gate._SHARED_LAYER_DENSE_FALLBACK_COUNT}. The "
+        "prior full layer's topk_indices were not threaded through the "
+        "model loop, so shared layers silently ran dense attention instead "
+        "of reusing the top-K KV selection (codex PR #967 round-2 finding)."
+    )
+    assert gate._SHARED_LAYER_DENSE_FALLBACK_COUNT == 0
+
+    # (4) logits are finite (synthetic zero weights make absolute values
+    # tiny but the shared-layer attention path should not produce NaN/Inf).
     import math
 
     out_max = float(mx.max(mx.abs(out)).item())
     assert math.isfinite(out_max), (
-        f"forward output contains NaN/Inf (max |.|={out_max}); the dense "
+        f"forward output contains NaN/Inf (max |.|={out_max}); the "
         "shared-layer attention path produced numerically invalid logits"
     )
 

--- a/tests/test_deepseek_v32_indexer_gate.py
+++ b/tests/test_deepseek_v32_indexer_gate.py
@@ -729,63 +729,71 @@ def test_install_fires_on_real_serve_import_path():
     ...`` — which triggered the install as an import side-effect of the
     test module itself, masking the production gap.
 
-    This test guards against a recurrence by:
-
-    1. Uninstalling the gate via the currently-loaded patch module.
-    2. Purging cached ``vllm_mlx`` modules from ``sys.modules`` so the
-       next import re-runs module-level code.
-    3. Importing a SERVE-path module (``vllm_mlx.utils.tokenizer``),
-       NOT the patch module directly.
-    4. Asserting the gate is installed afterwards.
+    Implementation: we run the import + assertion in a SUBPROCESS rather
+    than the pytest worker process. In-process module purging
+    (``del sys.modules["vllm_mlx..."]``) pollutes the test session because
+    later test modules hold bound references to the OLD class objects,
+    while a re-import installs NEW class objects — every subsequent
+    ``isinstance(obj, OldClass)`` check fails. The subprocess gets a
+    pristine interpreter, executes the import, prints OK/FAIL, and exits.
+    No state leaks back into the parent test session.
 
     A future refactor that moves the install hook back to a module not on
-    the serve import path would fail at step 4 with the same 285-missing-
-    keys symptom that broke real GLM-5.2 boot.
+    the serve import path would make the subprocess assertion fail with
+    the same 285-missing-keys symptom that broke real GLM-5.2 boot.
     """
+    import subprocess
     import sys
+    import textwrap
 
-    # (1) Cleanly uninstall via the currently-loaded patch module so the
-    # subsequent re-install in step 3 truly fires through the new code
-    # path rather than early-returning on a stale _INSTALLED=True flag.
-    from vllm_mlx.patches.deepseek_v32_indexer_gate import (
-        uninstall_deepseek_v32_indexer_gate,
+    # The subprocess does the canonical sequence: import a SERVE-path
+    # module (NOT the patch module directly), then check that the gate's
+    # ``_INSTALLED`` flag and the upstream-class marker are both set.
+    # Anything but "OK" on stdout (or a non-zero exit) is a failure.
+    script = textwrap.dedent(
+        """
+        import sys
+
+        # Import a SERVE-path module. Importing the patch module directly
+        # would mask the bug PR #967 was meant to prevent — the production
+        # boot path goes through utils.tokenizer, not the patch module.
+        import vllm_mlx.utils.tokenizer  # noqa: F401
+
+        # Read the post-install state via the patch module's public API
+        # plus the upstream-class marker (belt + suspenders).
+        from vllm_mlx.patches.deepseek_v32_indexer_gate import is_installed
+
+        if not is_installed():
+            print("FAIL: is_installed() returned False after serve-path import")
+            sys.exit(1)
+
+        from mlx_lm.models import deepseek_v32 as ds
+
+        if not getattr(ds, "_RAPID_MLX_INDEXER_GATE_INSTALLED", False):
+            print(
+                "FAIL: upstream marker mlx_lm.models.deepseek_v32."
+                "_RAPID_MLX_INDEXER_GATE_INSTALLED is missing"
+            )
+            sys.exit(1)
+
+        print("OK")
+        """
+    ).strip()
+
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        timeout=60,
     )
 
-    uninstall_deepseek_v32_indexer_gate()
-
-    # (2) Purge cached vllm_mlx imports so importing utils.tokenizer
-    # re-executes its module-level code (which is where the install
-    # hook now lives — PR #967 wiring fix).
-    for mod_name in list(sys.modules):
-        if mod_name.startswith("vllm_mlx"):
-            del sys.modules[mod_name]
-
-    # (3) Import a SERVE-path module. This MUST trigger the install
-    # hook — that is the whole point of the wiring fix. We deliberately
-    # do NOT touch ``vllm_mlx.patches.deepseek_v32_indexer_gate`` here;
-    # importing it directly would mask the bug.
-    import vllm_mlx.utils.tokenizer  # noqa: F401
-
-    # (4) Assert the gate is now installed. Re-import the patch module
-    # to read its post-install state — the freshly-loaded instance has
-    # ``_INSTALLED = True`` set by the install call that fired during
-    # the ``utils.tokenizer`` import.
-    from vllm_mlx.patches.deepseek_v32_indexer_gate import is_installed
-
-    assert is_installed(), (
-        "install hook did NOT fire when serve-path module "
-        "vllm_mlx.utils.tokenizer was imported — PR #967 wiring "
-        "regression. On real GLM-5.2 REAP weights this symptom is "
-        "'Missing 285 parameters ...indexer...' on boot."
+    assert result.returncode == 0, (
+        f"subprocess install-on-serve-path check failed (exit={result.returncode}).\n"
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}\n"
+        "PR #967 wiring regression — on real GLM-5.2 REAP weights this "
+        "symptom is 'Missing 285 parameters ...indexer...' on boot."
     )
-
-    # Also verify the patch is live on the upstream class (defense-in-
-    # depth — guards against a regression where _INSTALLED gets flipped
-    # to True without the actual monkey-patches being applied).
-    from mlx_lm.models import deepseek_v32 as ds
-
-    assert getattr(ds, "_RAPID_MLX_INDEXER_GATE_INSTALLED", False), (
-        "patch module flag says installed, but the upstream marker on "
-        "mlx_lm.models.deepseek_v32 is missing — the monkey-patch was "
-        "not actually applied"
+    assert "OK" in result.stdout, (
+        f"subprocess did not print OK marker. stdout:\n{result.stdout}\n"
+        f"stderr:\n{result.stderr}"
     )

--- a/vllm_mlx/model_runner.py
+++ b/vllm_mlx/model_runner.py
@@ -18,11 +18,20 @@ from typing import TYPE_CHECKING, Any
 
 import mlx.core as mx
 
+from vllm_mlx.patches.deepseek_v32_indexer_gate import (
+    install_deepseek_v32_indexer_gate as _install_dsv32_indexer_gate,
+)
+
 if TYPE_CHECKING:
     from vllm.config import VllmConfig
     from vllm.v1.core.sched.output import SchedulerOutput
 
 logger = logging.getLogger(__name__)
+
+# Install the per-layer Indexer gate so REAP-pruned DeepseekV32 configs
+# (e.g. mlx-community/pipenetwork-GLM-5.2-REAP50-MLX-4bit) load via mlx_lm.
+# Idempotent + no-op on configs that don't publish ``indexer_types``.
+_install_dsv32_indexer_gate()
 
 
 @dataclass

--- a/vllm_mlx/patches/deepseek_v32_indexer_gate.py
+++ b/vllm_mlx/patches/deepseek_v32_indexer_gate.py
@@ -54,7 +54,7 @@ from __future__ import annotations
 import inspect
 import logging
 import threading
-from typing import Any, Optional
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -65,9 +65,9 @@ _ALLOWED_MODES = ("full", "shared")
 # Saved references to the upstream callables; used to undo the patch in tests
 # and (rarely) at runtime via ``uninstall_deepseek_v32_indexer_gate``. ``None``
 # until the gate is installed.
-_orig_attn_call: Optional[Any] = None
-_orig_decoder_init: Optional[Any] = None
-_orig_from_dict: Optional[Any] = None
+_orig_attn_call: Any | None = None
+_orig_decoder_init: Any | None = None
+_orig_from_dict: Any | None = None
 
 
 def _resolve_mode(types, layer_idx: int) -> str:
@@ -83,8 +83,7 @@ def _resolve_mode(types, layer_idx: int) -> str:
     mode = types[layer_idx]
     if mode not in _ALLOWED_MODES:
         raise ValueError(
-            f"indexer_types[{layer_idx}]={mode!r}; "
-            f"expected one of {_ALLOWED_MODES}"
+            f"indexer_types[{layer_idx}]={mode!r}; expected one of {_ALLOWED_MODES}"
         )
     return mode
 
@@ -108,7 +107,9 @@ def _validate_anchor(types) -> None:
         )
 
 
-def _shared_layer_attn_call(self, x, mask, cache):  # pragma: no cover - exercised by smoke test
+def _shared_layer_attn_call(
+    self, x, mask, cache
+):  # pragma: no cover - exercised by smoke test
     """Replica of upstream ``DeepseekV32Attention.__call__`` minus the indexer.
 
     The shared path simply runs dense MLA attention over the full KV window

--- a/vllm_mlx/patches/deepseek_v32_indexer_gate.py
+++ b/vllm_mlx/patches/deepseek_v32_indexer_gate.py
@@ -1,0 +1,272 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Surgical indexer gate for REAP-pruned DeepseekV32 models.
+
+Background
+----------
+Upstream ``mlx_lm.models.deepseek_v32.DeepseekV32Attention.__init__`` builds
+``self.indexer = Indexer(config)`` on **every** layer unconditionally. REAP-
+pruned variants (e.g. ``mlx-community/pipenetwork-GLM-5.2-REAP50-MLX-4bit``)
+publish a per-layer ``indexer_types: List[str]`` field where each entry is
+either ``"full"`` (this layer owns Indexer weights in the safetensors) or
+``"shared"`` (this layer has **no** Indexer weights and reuses the previous
+full layer's indexer output at inference time). On such configs every
+``"shared"`` layer's Indexer parameters are missing from the safetensors and
+``mlx_lm.load`` aborts with ``Missing N parameters: ...indexer...``.
+
+What this module patches
+------------------------
+1. ``DeepseekV32DecoderLayer.__init__`` — after the upstream init runs, if
+   ``config.indexer_types`` is present and the current layer is ``"shared"``,
+   drop ``self_attn.indexer`` (``= None``) so it is removed from the model's
+   parameter tree (see :class:`mlx.nn.Module.__setattr__`: assigning a
+   non-array/dict/list/tuple deregisters the child from the parameter dict).
+   The ``layer_idx`` is also threaded onto ``self_attn`` for diagnostics.
+
+2. ``DeepseekV32Attention.__call__`` — wrap so layers where ``self.indexer is
+   None`` take a shared-layer code path that (a) skips the Indexer call and
+   the sparse-mask block, and (b) skips the trailing
+   ``cache[0].keys = mx.depends(cache[0].keys, (cache[1].keys, cache[1].values))``
+   line. On a shared layer ``cache[1]`` is never populated so ``cache[1].keys``
+   is ``None`` and the ``mx.depends`` call would crash. The shared path falls
+   through to dense MLA attention over the full KV window.
+
+3. ``glm_moe_dsa.ModelArgs.from_dict`` — extend ``BaseModelArgs.from_dict``
+   filtering so ``indexer_types`` is preserved on the dataclass instance.
+   Upstream's filter (``inspect.signature(cls).parameters``) drops keys not
+   declared on the dataclass; without this patch ``indexer_types`` is
+   silently dropped and the gate above never fires.
+
+What it does NOT change
+-----------------------
+* Configs **without** ``indexer_types`` (legitimate non-REAP DSv32 / GLM-4.6)
+  take the upstream path verbatim. The patched ``__init__`` returns early,
+  the patched ``__call__`` immediately delegates to the original, and
+  ``from_dict`` matches upstream's behavior when ``indexer_types`` is absent.
+* No vendored copy of ``deepseek_v32.py``. Total surface area: this module
+  plus one import + one call in ``vllm_mlx.model_runner``.
+
+When upstream mlx_lm lands ``indexer_types`` support, delete this module and
+the import in ``vllm_mlx.model_runner`` — nothing else needs to change.
+"""
+
+from __future__ import annotations
+
+import inspect
+import logging
+import threading
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+_LOCK = threading.Lock()
+_INSTALLED = False
+_ALLOWED_MODES = ("full", "shared")
+
+# Saved references to the upstream callables; used to undo the patch in tests
+# and (rarely) at runtime via ``uninstall_deepseek_v32_indexer_gate``. ``None``
+# until the gate is installed.
+_orig_attn_call: Optional[Any] = None
+_orig_decoder_init: Optional[Any] = None
+_orig_from_dict: Optional[Any] = None
+
+
+def _resolve_mode(types, layer_idx: int) -> str:
+    """Return ``"full"`` or ``"shared"`` for ``layer_idx``.
+
+    Backward-compatible: when ``types`` is missing/empty/over-the-end we fall
+    back to ``"full"`` (= upstream behavior).
+    """
+    if types is None or not isinstance(types, (list, tuple)):
+        return "full"
+    if layer_idx is None or layer_idx < 0 or layer_idx >= len(types):
+        return "full"
+    mode = types[layer_idx]
+    if mode not in _ALLOWED_MODES:
+        raise ValueError(
+            f"indexer_types[{layer_idx}]={mode!r}; "
+            f"expected one of {_ALLOWED_MODES}"
+        )
+    return mode
+
+
+def _validate_anchor(types) -> None:
+    """Fail fast on configs with no ``"full"`` anchor.
+
+    A real REAP-pruned model always has at least one ``"full"`` layer at the
+    front; an all-``"shared"`` config would have no Indexer weights at all
+    and could never be inferenced.
+    """
+    if types is None:
+        return
+    if not isinstance(types, (list, tuple)) or len(types) == 0:
+        return
+    if all(m == "shared" for m in types):
+        raise ValueError(
+            "indexer_types has no 'full' anchor — at least one layer must be "
+            "'full' (a REAP-pruned config without any full layer is invalid; "
+            "shared layers reuse the previous full layer's indexer output)."
+        )
+
+
+def _shared_layer_attn_call(self, x, mask, cache):  # pragma: no cover - exercised by smoke test
+    """Replica of upstream ``DeepseekV32Attention.__call__`` minus the indexer.
+
+    The shared path simply runs dense MLA attention over the full KV window
+    — the same fallback the upstream code naturally takes when
+    ``topk_indices is None`` (e.g. on the very first decode step), but here
+    we also skip the ``mx.depends`` on ``cache[1]`` since the indexer cache
+    is never populated on shared layers and ``cache[1].keys`` is ``None``.
+
+    Kept inline (instead of monkey-patching the indexer with a stub) so the
+    failure traceback says ``_shared_layer_attn_call`` if anything goes
+    wrong — easier to grep than a stack ending in upstream code.
+    """
+    import mlx.core as mx
+    from mlx_lm.models.base import scaled_dot_product_attention
+
+    B, L, _ = x.shape
+    qr = self.q_a_layernorm(self.q_a_proj(x))
+    q = self.q_b_proj(qr)
+    q = q.reshape(B, L, self.num_heads, self.q_head_dim).transpose(0, 2, 1, 3)
+    q_nope, q_pe = mx.split(q, [self.qk_nope_head_dim], axis=-1)
+    compressed_kv = self.kv_a_proj_with_mqa(x)
+    compressed_kv, k_pe = mx.split(compressed_kv, [self.kv_lora_rank], axis=-1)
+    k_pe = k_pe.reshape(B, L, 1, self.qk_rope_head_dim).transpose(0, 2, 1, 3)
+    kv_latent = self.kv_a_layernorm(compressed_kv)
+
+    offset = cache[0].offset if cache is not None else 0
+    q_pe = self.rope(q_pe, offset)
+    k_pe = self.rope(k_pe, offset)
+
+    kv_latent = mx.expand_dims(kv_latent, axis=1)
+    if cache is not None:
+        kv_latent, k_pe = cache[0].update_and_fetch(kv_latent, k_pe)
+    else:
+        cache = [None] * 2
+
+    # No indexer => no sparse mask, no ``cache[0].keys = mx.depends(...)`` on
+    # the (unpopulated) ``cache[1]``. Dense MLA attention over the full KV
+    # window is the natural fallback the upstream code already takes when
+    # ``topk_indices is None``.
+    pe_scores = (q_pe * self.scale) @ k_pe.swapaxes(-1, -2)
+    if mask is not None:
+        pe_scores = mx.where(
+            mask,
+            pe_scores,
+            mx.array(mx.finfo(pe_scores.dtype).min, pe_scores.dtype),
+        )
+
+    if L == 1:
+        q_nope = self.embed_q(q_nope)
+        k = v = kv_latent
+    else:
+        k = self.embed_q(kv_latent, transpose=False)
+        v = self.unembed_out(kv_latent)
+
+    output = scaled_dot_product_attention(
+        q_nope, k, v, cache=cache, scale=self.scale, mask=pe_scores
+    )
+    if L == 1:
+        output = self.unembed_out(output)
+
+    output = output.transpose(0, 2, 1, 3).reshape(B, L, -1)
+    return self.o_proj(output)
+
+
+def install_deepseek_v32_indexer_gate() -> None:
+    """Install the indexer gate. Idempotent and thread-safe."""
+    global _INSTALLED, _orig_attn_call, _orig_decoder_init, _orig_from_dict
+
+    with _LOCK:
+        if _INSTALLED:
+            return
+
+        # Import lazily so this module is cheap to import even when mlx_lm
+        # is unavailable (e.g. tests that patch import paths).
+        try:
+            from mlx_lm.models import deepseek_v32 as ds
+            from mlx_lm.models import glm_moe_dsa as glm
+        except ImportError:  # pragma: no cover - mlx_lm always present in our env
+            logger.debug(
+                "[deepseek_v32_indexer_gate] mlx_lm not importable; skipping install"
+            )
+            return
+
+        # Detect double-install across module reloads (e.g. pytest restart).
+        if getattr(ds, "_RAPID_MLX_INDEXER_GATE_INSTALLED", False):
+            _INSTALLED = True
+            return
+
+        _orig_attn_call = ds.DeepseekV32Attention.__call__
+        _orig_decoder_init = ds.DeepseekV32DecoderLayer.__init__
+        _orig_from_dict = glm.ModelArgs.from_dict
+
+        def _patched_decoder_init(self, config, layer_idx):
+            _orig_decoder_init(self, config, layer_idx)
+            types = getattr(config, "indexer_types", None)
+            if types is None:
+                return
+            # Fail fast on the all-shared edge case (no valid REAP config has
+            # this shape; bail before load_weights spits a confusing error).
+            if layer_idx == 0:
+                _validate_anchor(types)
+            self.self_attn.layer_idx = layer_idx
+            mode = _resolve_mode(types, layer_idx)
+            if mode == "shared":
+                # Assigning ``None`` to an nn.Module child removes it from
+                # the parameter dict (see ``Module.__setattr__``), which is
+                # exactly what we want so ``load_weights(strict=True)`` no
+                # longer demands the absent ``indexer.*`` keys.
+                self.self_attn.indexer = None
+
+        def _patched_attn_call(self, x, mask=None, cache=None):
+            if getattr(self, "indexer", None) is not None:
+                return _orig_attn_call(self, x, mask, cache)
+            return _shared_layer_attn_call(self, x, mask, cache)
+
+        @classmethod
+        def _patched_from_dict(cls, params):
+            sig = set(inspect.signature(cls).parameters)
+            instance = cls(**{k: v for k, v in params.items() if k in sig})
+            # Preserve the REAP extension field. Plain attribute assignment
+            # is fine on a non-frozen dataclass; downstream code reads via
+            # ``getattr(config, "indexer_types", None)``.
+            if "indexer_types" in params:
+                instance.indexer_types = params["indexer_types"]
+            return instance
+
+        ds.DeepseekV32Attention.__call__ = _patched_attn_call
+        ds.DeepseekV32DecoderLayer.__init__ = _patched_decoder_init
+        glm.ModelArgs.from_dict = _patched_from_dict
+        ds._RAPID_MLX_INDEXER_GATE_INSTALLED = True
+        _INSTALLED = True
+        logger.debug("[deepseek_v32_indexer_gate] installed")
+
+
+def uninstall_deepseek_v32_indexer_gate() -> None:
+    """Undo the gate. Test-only; production code does not call this."""
+    global _INSTALLED, _orig_attn_call, _orig_decoder_init, _orig_from_dict
+
+    with _LOCK:
+        if not _INSTALLED:
+            return
+        try:
+            from mlx_lm.models import deepseek_v32 as ds
+            from mlx_lm.models import glm_moe_dsa as glm
+        except ImportError:  # pragma: no cover
+            return
+        if _orig_attn_call is not None:
+            ds.DeepseekV32Attention.__call__ = _orig_attn_call
+        if _orig_decoder_init is not None:
+            ds.DeepseekV32DecoderLayer.__init__ = _orig_decoder_init
+        if _orig_from_dict is not None:
+            glm.ModelArgs.from_dict = _orig_from_dict
+        ds._RAPID_MLX_INDEXER_GATE_INSTALLED = False
+        _INSTALLED = False
+        _orig_attn_call = None
+        _orig_decoder_init = None
+        _orig_from_dict = None
+
+
+def is_installed() -> bool:
+    return _INSTALLED

--- a/vllm_mlx/patches/deepseek_v32_indexer_gate.py
+++ b/vllm_mlx/patches/deepseek_v32_indexer_gate.py
@@ -30,6 +30,26 @@ What this module patches
    is ``None`` and the ``mx.depends`` call would crash. The shared path falls
    through to dense MLA attention over the full KV window.
 
+   .. warning::
+      Inference-quality caveat: the REAP convention is that a ``"shared"``
+      layer reuses the previous ``"full"`` layer's indexer top-K KV
+      selection. This patch does NOT implement that reuse — it runs dense
+      MLA attention over the full KV window, which is the same fallback
+      the upstream Indexer takes when ``k.shape[2] <= self.index_topk``
+      (see ``Indexer.__call__`` returning ``None``). Dense attention is a
+      strict correctness-preserving SUPERSET of any sparse top-K
+      selection (it attends to ALL keys, not just the top-K), so model
+      outputs are bounded above any sparse approximation, never wrong in
+      the NaN/Inf sense — but the per-token logit distribution will
+      differ from a true REAP-reuse implementation on long sequences.
+
+      A spec-compliant reuse path would require threading the previous
+      full layer's ``topk_indices`` tensor through
+      ``DeepseekV32Model.__call__`` so each shared layer can pick it up,
+      which is a larger architectural change. Tracked as a follow-up. We
+      log a warning on the FIRST shared-layer forward so the operator
+      knows the dense path is in play.
+
 3. ``glm_moe_dsa.ModelArgs.from_dict`` — extend ``BaseModelArgs.from_dict``
    filtering so ``indexer_types`` is preserved on the dataclass instance.
    Upstream's filter (``inspect.signature(cls).parameters``) drops keys not
@@ -62,6 +82,12 @@ _LOCK = threading.Lock()
 _INSTALLED = False
 _ALLOWED_MODES = ("full", "shared")
 
+# Counter (test-observable) of how many times the shared-layer dense
+# fallback has run. Tests assert against this to prove the gated code
+# path was exercised; production code ignores it.
+_SHARED_LAYER_FORWARD_COUNT = 0
+_WARNED_DENSE_FALLBACK = False
+
 # Saved references to the upstream callables; used to undo the patch in tests
 # and (rarely) at runtime via ``uninstall_deepseek_v32_indexer_gate``. ``None``
 # until the gate is installed.
@@ -89,16 +115,30 @@ def _resolve_mode(types, layer_idx: int) -> str:
 
 
 def _validate_anchor(types) -> None:
-    """Fail fast on configs with no ``"full"`` anchor.
+    """Fail fast on configs that have no valid ``"full"`` anchor before a
+    ``"shared"`` layer.
 
-    A real REAP-pruned model always has at least one ``"full"`` layer at the
-    front; an all-``"shared"`` config would have no Indexer weights at all
-    and could never be inferenced.
+    REAP-pruned configs always (a) start with a ``"full"`` layer and
+    (b) have at least one ``"full"`` somewhere — every ``"shared"`` layer
+    by definition reuses a previous full layer's indexer output, so
+    a ``"shared"`` at index 0 has nothing to reuse and the config is
+    structurally invalid.
     """
     if types is None:
         return
     if not isinstance(types, (list, tuple)) or len(types) == 0:
         return
+    # (a) the very first entry must be "full" — there is no prior layer
+    # for an index-0 "shared" to reuse from.
+    if types[0] != "full":
+        raise ValueError(
+            f"indexer_types[0]={types[0]!r}; the first layer must be "
+            "'full' (a 'shared' layer at index 0 has no previous full "
+            "layer to reuse the indexer output from)."
+        )
+    # (b) at least one "full" anchor must exist. Redundant given (a),
+    # but kept defensively so refactors of (a) don't silently weaken
+    # the validator.
     if all(m == "shared" for m in types):
         raise ValueError(
             "indexer_types has no 'full' anchor — at least one layer must be "
@@ -107,9 +147,7 @@ def _validate_anchor(types) -> None:
         )
 
 
-def _shared_layer_attn_call(
-    self, x, mask, cache
-):  # pragma: no cover - exercised by smoke test
+def _shared_layer_attn_call(self, x, mask, cache):
     """Replica of upstream ``DeepseekV32Attention.__call__`` minus the indexer.
 
     The shared path simply runs dense MLA attention over the full KV window
@@ -121,7 +159,26 @@ def _shared_layer_attn_call(
     Kept inline (instead of monkey-patching the indexer with a stub) so the
     failure traceback says ``_shared_layer_attn_call`` if anything goes
     wrong — easier to grep than a stack ending in upstream code.
+
+    Bumps ``_SHARED_LAYER_FORWARD_COUNT`` so tests can prove the gated
+    path was actually exercised on a "shared" layer (catches regressions
+    where a refactor accidentally routes shared layers back through the
+    upstream Indexer-bearing ``__call__``).
     """
+    global _SHARED_LAYER_FORWARD_COUNT, _WARNED_DENSE_FALLBACK
+    _SHARED_LAYER_FORWARD_COUNT += 1
+    if not _WARNED_DENSE_FALLBACK:
+        _WARNED_DENSE_FALLBACK = True
+        logger.warning(
+            "[deepseek_v32_indexer_gate] running dense MLA attention on "
+            "a 'shared' layer (layer_idx=%s); this differs from the REAP "
+            "reuse-prior-indexer convention. Outputs are bounded by dense "
+            "attention (a strict superset of any top-K sparse selection), "
+            "but per-token logits may differ from a true REAP-reuse "
+            "implementation on long sequences. See the module docstring.",
+            getattr(self, "layer_idx", "?"),
+        )
+
     import mlx.core as mx
     from mlx_lm.models.base import scaled_dot_product_attention
 

--- a/vllm_mlx/patches/deepseek_v32_indexer_gate.py
+++ b/vllm_mlx/patches/deepseek_v32_indexer_gate.py
@@ -438,24 +438,54 @@ def install_deepseek_v32_indexer_gate() -> None:
             # ``config`` as an attribute. Pick the config off the first
             # decoder layer's attention — every layer's
             # ``self_attn.config`` is set by upstream
-            # ``DeepseekV32Attention.__init__``. Bounds-check
-            # ``start_idx`` so a pipeline/sharded layout with an empty
-            # local slice (or out-of-range ``start_idx``) safely
-            # delegates to upstream (codex finding #3 on PR #967 round 5).
-            types = None
-            if (
-                self.layers
+            # ``DeepseekV32Attention.__init__``.
+            #
+            # The slice is considered "inspectable" when the local
+            # ``self.layers`` list is non-empty and the local
+            # ``start_idx`` points to a real layer in it. An out-of-
+            # range ``start_idx`` is a pre-condition violation
+            # specifically for REAP shards (single-rank, non-REAP
+            # models always have ``start_idx == 0`` and a populated
+            # layer list, so they cannot hit this branch).
+            in_range = (
+                bool(self.layers)
                 and 0 <= self.start_idx < len(self.layers)
                 and self.layers[self.start_idx] is not None
-            ):
+            )
+            types = None
+            if in_range:
                 cfg = getattr(self.layers[self.start_idx].self_attn, "config", None)
                 if cfg is not None:
                     types = getattr(cfg, "indexer_types", None)
 
             if types is None:
-                # Non-REAP path (or out-of-range slice) — delegate to
-                # upstream verbatim.
+                # Non-REAP path: delegate to upstream verbatim. If
+                # ``in_range`` is False but this is genuinely a non-REAP
+                # model, upstream's own forward will handle the bogus
+                # slice the same way it always has — we are not making
+                # things any worse. We do NOT reach into the REAP path
+                # in this branch.
+                if not in_range:
+                    # Sanity: a non-REAP model with an out-of-range
+                    # slice is operator error. Delegating to upstream
+                    # here matches the prior behavior; we intentionally
+                    # do not raise so legitimate non-REAP edge cases
+                    # are not regressed.
+                    pass
                 return _orig_model_call(self, x, cache)
+
+            # From here on we know we're in a REAP path. Reject any
+            # out-of-range slice for REAP shards explicitly — silently
+            # delegating to upstream would leave the REAP semantic
+            # ambiguous (codex finding #2 on PR #967 round 8).
+            if not in_range:
+                raise ValueError(
+                    "deepseek_v32_indexer_gate: REAP shard start_idx="
+                    f"{self.start_idx} is out of range for local layers "
+                    f"list of length {len(self.layers)}. Each rank's "
+                    "start_idx must point to a real layer in its local "
+                    "self.layers."
+                )
 
             # Validate the local layer slice before entering the REAP
             # path: a malformed pipeline shard whose ``num_layers``
@@ -541,6 +571,17 @@ def install_deepseek_v32_indexer_gate() -> None:
             # here.
             last_topk_indices = None
 
+            # Cache contract (mirrors upstream DeepseekV3Model.__call__
+            # exactly): ``cache`` is the LOCAL per-rank cache, length
+            # ``self.num_layers`` (not the full model's
+            # ``num_hidden_layers``). ``cache[i]`` corresponds to
+            # ``self.layers[self.start_idx + i]`` — the i-th layer in
+            # THIS rank's slice. Upstream's ``DeepseekV3Model.make_cache``
+            # builds the per-rank slice list and the wrapper's forward
+            # iterates ``enumerate(self.layers[start:end])`` indexing
+            # ``cache[e]`` the same way. Do not change ``cache[i]`` to
+            # ``cache[layer_idx]`` — it would mis-index the per-rank
+            # cache list and corrupt KV state across layers.
             for i in range(self.num_layers):
                 layer = self.layers[self.start_idx + i]
                 layer_idx = self.start_idx + i

--- a/vllm_mlx/patches/deepseek_v32_indexer_gate.py
+++ b/vllm_mlx/patches/deepseek_v32_indexer_gate.py
@@ -457,6 +457,23 @@ def install_deepseek_v32_indexer_gate() -> None:
                 # upstream verbatim.
                 return _orig_model_call(self, x, cache)
 
+            # Validate the local layer slice before entering the REAP
+            # path: a malformed pipeline shard whose ``num_layers``
+            # extends past ``len(self.layers)`` would crash on
+            # ``self.layers[self.start_idx + i]`` deep inside the loop
+            # with an opaque ``IndexError``. Fail with a clear
+            # actionable error before any forward work happens (codex
+            # finding #1 on PR #967 round 7).
+            if self.start_idx + self.num_layers > len(self.layers):
+                raise ValueError(
+                    "deepseek_v32_indexer_gate: pipeline shard "
+                    f"start_idx={self.start_idx}, num_layers="
+                    f"{self.num_layers} extends past local layer list "
+                    f"length {len(self.layers)}. Each rank's "
+                    "[start_idx, start_idx + num_layers) range must fit "
+                    "entirely within self.layers."
+                )
+
             # Reject pipeline-parallel shards whose first locally-iterated
             # layer is ``"shared"``: the REAP reuse contract requires the
             # most-recent ``"full"`` layer's topk indices, which on such a
@@ -510,15 +527,18 @@ def install_deepseek_v32_indexer_gate() -> None:
             # positions computed at a different query/cache length and
             # applying them to a fresh decode step would be a stale
             # selection (codex finding #1 on PR #967 round 5; supersedes
-            # the round-3 seed attempt). When this rank's iteration
-            # window starts with a ``"shared"`` layer (e.g. a pipeline-
-            # parallel slice without a local full-layer anchor), those
-            # leading shared layers correctly hit the dense fallback —
-            # the same path the upstream Indexer takes when
-            # ``k.shape[2] <= index_topk``. Cross-rank communication of
-            # the current full layer's topk would be the
-            # architecturally-correct remedy if needed in the future;
-            # that is out of scope for the surgical D1 fix here.
+            # the round-3 seed attempt). The case where this rank's
+            # iteration window would start with a ``"shared"`` layer
+            # (e.g. a pipeline-parallel slice without a local full-layer
+            # anchor) is rejected by the explicit ``ValueError`` raised
+            # before this point — so when we reach this line, the loop
+            # is guaranteed to encounter a ``"full"`` layer before any
+            # ``"shared"`` layer, and the initial ``None`` value is
+            # never consumed by a shared layer. Cross-rank communication
+            # of the current full layer's topk would be the
+            # architecturally-correct remedy for the rejected case if
+            # ever needed; that is out of scope for the surgical D1 fix
+            # here.
             last_topk_indices = None
 
             for i in range(self.num_layers):

--- a/vllm_mlx/patches/deepseek_v32_indexer_gate.py
+++ b/vllm_mlx/patches/deepseek_v32_indexer_gate.py
@@ -145,11 +145,32 @@ def _validate_anchor(types, num_hidden_layers: int | None = None) -> None:
     silently treat the over-the-end layers as ``"full"`` and then crash
     later with "missing weights" instead of a clear validation error
     (codex finding #2 on PR #967 round 2).
+
+    Malformed non-``None`` values (wrong type, empty, invalid mode) are
+    rejected up-front rather than silently treated as all-``"full"``
+    (codex NIT on PR #967 round 4).
     """
     if types is None:
         return
-    if not isinstance(types, (list, tuple)) or len(types) == 0:
-        return
+    # Reject malformed non-None values up-front — previously this branch
+    # silently returned and downstream code would treat the config as all-
+    # "full", masking the misconfiguration until safetensors loading
+    # eventually crashed with a less clear "missing weights" error.
+    if not isinstance(types, (list, tuple)):
+        raise ValueError(
+            f"indexer_types must be a list or tuple when present, got "
+            f"{type(types).__name__}"
+        )
+    if len(types) == 0:
+        raise ValueError(
+            "indexer_types is present but empty; omit the field entirely "
+            "for non-REAP configs"
+        )
+    for i, m in enumerate(types):
+        if m not in _ALLOWED_MODES:
+            raise ValueError(
+                f"indexer_types[{i}]={m!r}; expected one of {_ALLOWED_MODES}"
+            )
     # (a) the very first entry must be "full" — there is no prior layer
     # for an index-0 "shared" to reuse from.
     if types[0] != "full":
@@ -443,26 +464,34 @@ def install_deepseek_v32_indexer_gate() -> None:
             if pipeline_rank < pipeline_size - 1:
                 h = mx.distributed.recv_like(h, (pipeline_rank + 1))
 
-            # Initialize from the most-recent full layer in this rank's
-            # range that has run on a prior forward call (its indexer's
-            # ``_last_topk_indices`` slot persists). Critical for two
-            # cases (codex finding #1 on PR #967 round 3):
-            #   (a) pipeline-parallel rank with ``start_idx > 0`` whose
-            #       first owned layer is "shared" — there is no preceding
-            #       full layer in this rank's range to refresh from.
-            #   (b) a fresh decode call after prefill where the layer
-            #       loop's first iteration is the same full layer that
-            #       just ran the last time — without this seeding, that
-            #       full layer's own forward is the FIRST thing to refresh
-            #       ``last_topk_indices``, so any shared layer in
-            #       between would briefly see None.
+            # Initialize from the most-recent full layer anywhere in
+            # ``self.layers`` that has run on a prior forward call (its
+            # indexer's ``_last_topk_indices`` slot persists). Critical
+            # for the case (codex finding #1 on PR #967 round 3) where
+            # this rank's first iterated layer is ``"shared"`` — e.g.
+            # a pipeline-parallel slice whose head is shared, or a
+            # future model layout that places shared layers ahead of
+            # any full layer in this rank. Without this seed the
+            # leading shared layers would dense-fall-back on every
+            # decode step.
+            #
+            # We iterate ALL ``self.layers`` (not just
+            # ``[start_idx, start_idx+num_layers)``) so a full layer
+            # outside this rank's iteration window — but still owned by
+            # this Python-side model instance — can be the source.
+            # Pipeline-parallel ranks that own NO full layer at all
+            # cannot seed from another rank's indexer state via this
+            # path; that's a separate (out-of-scope here)
+            # inter-rank-communication concern and the dense fallback
+            # remains correct for it.
+            #
             # ``_last_topk_indices`` is only present after at least one
             # full-layer forward; on the very first call it is None and
-            # leading shared layers correctly hit the dense fallback (the
-            # same path upstream Indexer takes when k.shape[2] <= index_topk).
+            # leading shared layers correctly hit the dense fallback
+            # (the same path upstream Indexer takes when
+            # ``k.shape[2] <= index_topk``).
             last_topk_indices = None
-            for i in range(self.num_layers - 1, -1, -1):
-                layer = self.layers[self.start_idx + i]
+            for layer in reversed(self.layers):
                 if layer is None:
                     continue
                 indexer = getattr(layer.self_attn, "indexer", None)
@@ -506,6 +535,15 @@ def install_deepseek_v32_indexer_gate() -> None:
             # is fine on a non-frozen dataclass; downstream code reads via
             # ``getattr(config, "indexer_types", None)``.
             if "indexer_types" in params:
+                # Validate at config-parse time so a malformed REAP config
+                # fails clearly here rather than later in weight loading
+                # (codex NIT, PR #967 round 4). ``_validate_anchor`` enforces
+                # type, allowed values, length, anchor-at-0 and at-least-one-
+                # anchor — see its docstring.
+                _validate_anchor(
+                    params["indexer_types"],
+                    num_hidden_layers=params.get("num_hidden_layers"),
+                )
                 instance.indexer_types = params["indexer_types"]
             return instance
 

--- a/vllm_mlx/patches/deepseek_v32_indexer_gate.py
+++ b/vllm_mlx/patches/deepseek_v32_indexer_gate.py
@@ -457,6 +457,36 @@ def install_deepseek_v32_indexer_gate() -> None:
                 # upstream verbatim.
                 return _orig_model_call(self, x, cache)
 
+            # Reject pipeline-parallel shards whose first locally-iterated
+            # layer is ``"shared"``: the REAP reuse contract requires the
+            # most-recent ``"full"`` layer's topk indices, which on such a
+            # shard would have to be communicated from a prior pipeline
+            # rank. The surgical D1 fix here does not implement cross-rank
+            # communication of indexer state, so silently dense-fallback
+            # on the leading shared layers would change inference
+            # semantics relative to the published REAP contract. Fail
+            # clearly instead (codex finding #2 on PR #967 round 6).
+            # Single-rank usage is unaffected because ``_validate_anchor``
+            # already requires ``indexer_types[0] == "full"`` at model
+            # construction, so layer 0 (= start_idx 0) is never shared.
+            if (
+                0 <= self.start_idx < len(self.layers)
+                and self.layers[self.start_idx] is not None
+                and _resolve_mode(types, self.start_idx) == "shared"
+            ):
+                raise ValueError(
+                    "deepseek_v32_indexer_gate: pipeline-parallel shard "
+                    f"starting at layer {self.start_idx} is 'shared' "
+                    "(no local full-layer anchor for the REAP reuse "
+                    "contract). This surgical D1 fix does not implement "
+                    "cross-rank communication of the indexer's "
+                    "topk_indices; running this shard would silently "
+                    "fall back to dense MLA attention and change "
+                    "inference semantics. Re-shard so each rank starts "
+                    "on a 'full' layer, or extend the indexer gate with "
+                    "inter-rank topk communication."
+                )
+
             # Replica of upstream ``DeepseekV32Model.__call__`` with topk
             # threading inserted into the layer loop.
             h = self.embed_tokens(x)

--- a/vllm_mlx/patches/deepseek_v32_indexer_gate.py
+++ b/vllm_mlx/patches/deepseek_v32_indexer_gate.py
@@ -4,14 +4,21 @@
 Background
 ----------
 Upstream ``mlx_lm.models.deepseek_v32.DeepseekV32Attention.__init__`` builds
-``self.indexer = Indexer(config)`` on **every** layer unconditionally. REAP-
-pruned variants (e.g. ``mlx-community/pipenetwork-GLM-5.2-REAP50-MLX-4bit``)
-publish a per-layer ``indexer_types: List[str]`` field where each entry is
-either ``"full"`` (this layer owns Indexer weights in the safetensors) or
-``"shared"`` (this layer has **no** Indexer weights and reuses the previous
-full layer's indexer output at inference time). On such configs every
-``"shared"`` layer's Indexer parameters are missing from the safetensors and
-``mlx_lm.load`` aborts with ``Missing N parameters: ...indexer...``.
+``self.indexer = Indexer(config)`` on **every** layer unconditionally. The base
+GLM-5.2 architecture (and its REAP-pruned variant
+``mlx-community/pipenetwork-GLM-5.2-REAP50-MLX-4bit``) publishes a per-layer
+``indexer_types: List[str]`` field where each entry is either ``"full"`` (this
+layer owns Indexer weights in the safetensors) or ``"shared"`` (this layer has
+**no** Indexer weights and is expected at inference time to reuse the
+``topk_indices`` produced by the **most recent preceding "full" layer**'s
+indexer). The GLM-5.2 base config pattern is e.g.
+``["full", "full", "full", "shared", "shared", "shared", "full", "shared", ...]``
+— full anchors at positions 0,1,2,6,10,14,...; shared layers in between.
+
+On such configs every ``"shared"`` layer's Indexer parameters are missing from
+the safetensors and ``mlx_lm.load`` aborts with
+``Missing N parameters: ...indexer...`` (on the full 78-layer model: 11 keys ×
+57 shared layers = 627 missing tensors).
 
 What this module patches
 ------------------------
@@ -20,53 +27,62 @@ What this module patches
    drop ``self_attn.indexer`` (``= None``) so it is removed from the model's
    parameter tree (see :class:`mlx.nn.Module.__setattr__`: assigning a
    non-array/dict/list/tuple deregisters the child from the parameter dict).
-   The ``layer_idx`` is also threaded onto ``self_attn`` for diagnostics.
+   ``layer_idx`` is threaded onto ``self_attn``.
 
-2. ``DeepseekV32Attention.__call__`` — wrap so layers where ``self.indexer is
-   None`` take a shared-layer code path that (a) skips the Indexer call and
-   the sparse-mask block, and (b) skips the trailing
-   ``cache[0].keys = mx.depends(cache[0].keys, (cache[1].keys, cache[1].values))``
-   line. On a shared layer ``cache[1]`` is never populated so ``cache[1].keys``
-   is ``None`` and the ``mx.depends`` call would crash. The shared path falls
-   through to dense MLA attention over the full KV window.
+2. ``Indexer.__call__`` — wrap to stash the return tensor on
+   ``self._last_topk_indices`` so the next shared layer in the same forward
+   pass can pick it up.
 
-   .. warning::
-      Inference-quality caveat: the REAP convention is that a ``"shared"``
-      layer reuses the previous ``"full"`` layer's indexer top-K KV
-      selection. This patch does NOT implement that reuse — it runs dense
-      MLA attention over the full KV window, which is the same fallback
-      the upstream Indexer takes when ``k.shape[2] <= self.index_topk``
-      (see ``Indexer.__call__`` returning ``None``). Dense attention is a
-      strict correctness-preserving SUPERSET of any sparse top-K
-      selection (it attends to ALL keys, not just the top-K), so model
-      outputs are bounded above any sparse approximation, never wrong in
-      the NaN/Inf sense — but the per-token logit distribution will
-      differ from a true REAP-reuse implementation on long sequences.
+3. ``DeepseekV32Model.__call__`` — wrap so it threads the most-recent
+   ``"full"`` layer's ``topk_indices`` into each subsequent ``"shared"``
+   layer's attention via an instance attribute
+   ``self_attn._shared_topk_indices`` (cleared after each shared layer
+   reads it). On non-REAP configs (``indexer_types is None``) the wrapped
+   call delegates immediately to the upstream implementation.
 
-      A spec-compliant reuse path would require threading the previous
-      full layer's ``topk_indices`` tensor through
-      ``DeepseekV32Model.__call__`` so each shared layer can pick it up,
-      which is a larger architectural change. Tracked as a follow-up. We
-      log a warning on the FIRST shared-layer forward so the operator
-      knows the dense path is in play.
+4. ``DeepseekV32Attention.__call__`` — wrap so layers where ``self.indexer is
+   None`` take a shared-layer code path that:
 
-3. ``glm_moe_dsa.ModelArgs.from_dict`` — extend ``BaseModelArgs.from_dict``
+   * Reads ``self._shared_topk_indices`` (set by the model-level wrapper).
+     If non-None, applies the same sparse-mask block as the upstream full
+     layer (so the layer attends to the same top-K KV slots the most-recent
+     full layer selected — the REAP reuse contract).
+   * Falls back to dense MLA attention only when the threaded topk is
+     ``None`` (e.g. when the indexer would itself have returned ``None``
+     because ``k.shape[2] <= self.index_topk``). This matches the natural
+     upstream fallback for short sequences.
+   * Skips the trailing
+     ``cache[0].keys = mx.depends(cache[0].keys, (cache[1].keys, cache[1].values))``
+     line because ``cache[1]`` is never populated on a shared layer
+     (``cache[1].keys`` is ``None`` and the ``mx.depends`` call would crash).
+
+5. ``glm_moe_dsa.ModelArgs.from_dict`` — extend ``BaseModelArgs.from_dict``
    filtering so ``indexer_types`` is preserved on the dataclass instance.
    Upstream's filter (``inspect.signature(cls).parameters``) drops keys not
    declared on the dataclass; without this patch ``indexer_types`` is
-   silently dropped and the gate above never fires.
+   silently dropped and the gates above never fire.
 
 What it does NOT change
 -----------------------
 * Configs **without** ``indexer_types`` (legitimate non-REAP DSv32 / GLM-4.6)
-  take the upstream path verbatim. The patched ``__init__`` returns early,
-  the patched ``__call__`` immediately delegates to the original, and
-  ``from_dict`` matches upstream's behavior when ``indexer_types`` is absent.
+  take the upstream path verbatim. Every patched function delegates straight
+  to the original on the no-types branch.
 * No vendored copy of ``deepseek_v32.py``. Total surface area: this module
   plus one import + one call in ``vllm_mlx.model_runner``.
 
-When upstream mlx_lm lands ``indexer_types`` support, delete this module and
-the import in ``vllm_mlx.model_runner`` — nothing else needs to change.
+Concurrency note
+----------------
+The shared-topk thread runs through per-attention-instance attributes
+(``self_attn._shared_topk_indices``). Concurrent forward passes on the same
+model instance would race on these attributes. rapid-mlx's engine serializes
+forward passes per model (one event loop, one model_runner per process), so
+this is fine in production. The model.__call__ wrapper clears each shared
+layer's attribute IMMEDIATELY before the layer runs so stale values from a
+prior forward cannot leak into a fresh one.
+
+When upstream mlx_lm lands first-class ``indexer_types`` support, delete this
+module and the import in ``vllm_mlx.model_runner`` — nothing else needs to
+change.
 """
 
 from __future__ import annotations
@@ -82,10 +98,11 @@ _LOCK = threading.Lock()
 _INSTALLED = False
 _ALLOWED_MODES = ("full", "shared")
 
-# Counter (test-observable) of how many times the shared-layer dense
-# fallback has run. Tests assert against this to prove the gated code
-# path was exercised; production code ignores it.
+# Counters (test-observable) used by the regression suite to prove the
+# gated code paths actually fire. Production code ignores them.
 _SHARED_LAYER_FORWARD_COUNT = 0
+_SHARED_LAYER_REUSE_COUNT = 0  # shared layers that consumed a non-None prior topk
+_SHARED_LAYER_DENSE_FALLBACK_COUNT = 0  # shared layers that hit the dense fallback
 _WARNED_DENSE_FALLBACK = False
 
 # Saved references to the upstream callables; used to undo the patch in tests
@@ -93,6 +110,8 @@ _WARNED_DENSE_FALLBACK = False
 # until the gate is installed.
 _orig_attn_call: Any | None = None
 _orig_decoder_init: Any | None = None
+_orig_indexer_call: Any | None = None
+_orig_model_call: Any | None = None
 _orig_from_dict: Any | None = None
 
 
@@ -114,15 +133,18 @@ def _resolve_mode(types, layer_idx: int) -> str:
     return mode
 
 
-def _validate_anchor(types) -> None:
-    """Fail fast on configs that have no valid ``"full"`` anchor before a
-    ``"shared"`` layer.
+def _validate_anchor(types, num_hidden_layers: int | None = None) -> None:
+    """Fail fast on structurally invalid ``indexer_types`` configs.
 
     REAP-pruned configs always (a) start with a ``"full"`` layer and
     (b) have at least one ``"full"`` somewhere — every ``"shared"`` layer
     by definition reuses a previous full layer's indexer output, so
     a ``"shared"`` at index 0 has nothing to reuse and the config is
-    structurally invalid.
+    structurally invalid. Also (c) the ``indexer_types`` length must match
+    ``num_hidden_layers`` when both are known — a mismatched config would
+    silently treat the over-the-end layers as ``"full"`` and then crash
+    later with "missing weights" instead of a clear validation error
+    (codex finding #2 on PR #967 round 2).
     """
     if types is None:
         return
@@ -145,39 +167,70 @@ def _validate_anchor(types) -> None:
             "'full' (a REAP-pruned config without any full layer is invalid; "
             "shared layers reuse the previous full layer's indexer output)."
         )
+    # (c) length must equal num_hidden_layers when both are known.
+    if num_hidden_layers is not None and len(types) != num_hidden_layers:
+        raise ValueError(
+            f"indexer_types has length {len(types)} but num_hidden_layers="
+            f"{num_hidden_layers}; the lists must be the same length so each "
+            "layer has an explicit 'full'/'shared' designation."
+        )
 
 
 def _shared_layer_attn_call(self, x, mask, cache):
-    """Replica of upstream ``DeepseekV32Attention.__call__`` minus the indexer.
+    """Replica of upstream ``DeepseekV32Attention.__call__`` for layers
+    where ``self.indexer is None``.
 
-    The shared path simply runs dense MLA attention over the full KV window
-    — the same fallback the upstream code naturally takes when
-    ``topk_indices is None`` (e.g. on the very first decode step), but here
-    we also skip the ``mx.depends`` on ``cache[1]`` since the indexer cache
-    is never populated on shared layers and ``cache[1].keys`` is ``None``.
+    Per the REAP reuse contract: if the model-level wrapper threaded a
+    non-None ``topk_indices`` from the prior ``"full"`` layer onto
+    ``self._shared_topk_indices``, apply the same sparse-mask block as
+    the upstream full layer (so this shared layer attends to the same
+    top-K KV slots). Otherwise (no prior topk — typically because the
+    KV cache is shorter than ``self.index_topk`` so the prior indexer
+    itself returned ``None``), fall through to dense MLA attention over
+    the full KV window — the same natural fallback upstream takes.
 
-    Kept inline (instead of monkey-patching the indexer with a stub) so the
-    failure traceback says ``_shared_layer_attn_call`` if anything goes
-    wrong — easier to grep than a stack ending in upstream code.
+    Always skips the ``cache[0].keys = mx.depends(cache[0].keys,
+    (cache[1].keys, cache[1].values))`` line because ``cache[1]`` is
+    never populated on a shared layer.
 
-    Bumps ``_SHARED_LAYER_FORWARD_COUNT`` so tests can prove the gated
-    path was actually exercised on a "shared" layer (catches regressions
-    where a refactor accidentally routes shared layers back through the
-    upstream Indexer-bearing ``__call__``).
+    Kept inline (instead of monkey-patching the indexer with a stub) so
+    the failure traceback says ``_shared_layer_attn_call`` if anything
+    goes wrong — easier to grep than a stack ending in upstream code.
+
+    Bumps test-observable counters:
+
+    * ``_SHARED_LAYER_FORWARD_COUNT`` — total shared-layer forwards.
+    * ``_SHARED_LAYER_REUSE_COUNT`` — shared forwards that successfully
+      consumed a non-None prior topk (proves the REAP reuse path fired).
+    * ``_SHARED_LAYER_DENSE_FALLBACK_COUNT`` — shared forwards that hit
+      the dense fallback (no prior topk available).
     """
-    global _SHARED_LAYER_FORWARD_COUNT, _WARNED_DENSE_FALLBACK
+    global \
+        _SHARED_LAYER_FORWARD_COUNT, \
+        _SHARED_LAYER_REUSE_COUNT, \
+        _SHARED_LAYER_DENSE_FALLBACK_COUNT, \
+        _WARNED_DENSE_FALLBACK
+
     _SHARED_LAYER_FORWARD_COUNT += 1
-    if not _WARNED_DENSE_FALLBACK:
-        _WARNED_DENSE_FALLBACK = True
-        logger.warning(
-            "[deepseek_v32_indexer_gate] running dense MLA attention on "
-            "a 'shared' layer (layer_idx=%s); this differs from the REAP "
-            "reuse-prior-indexer convention. Outputs are bounded by dense "
-            "attention (a strict superset of any top-K sparse selection), "
-            "but per-token logits may differ from a true REAP-reuse "
-            "implementation on long sequences. See the module docstring.",
-            getattr(self, "layer_idx", "?"),
-        )
+    # Consume + clear the threaded topk so a stale value from a prior
+    # forward cannot leak into a fresh one.
+    topk_indices = getattr(self, "_shared_topk_indices", None)
+    self._shared_topk_indices = None
+
+    if topk_indices is None:
+        _SHARED_LAYER_DENSE_FALLBACK_COUNT += 1
+        if not _WARNED_DENSE_FALLBACK:
+            _WARNED_DENSE_FALLBACK = True
+            logger.warning(
+                "[deepseek_v32_indexer_gate] no prior-full-layer topk "
+                "available on shared layer (layer_idx=%s); falling back to "
+                "dense MLA attention. This is the same behavior the "
+                "upstream Indexer takes when k.shape[2] <= index_topk (short "
+                "KV cache), so it is typically benign.",
+                getattr(self, "layer_idx", "?"),
+            )
+    else:
+        _SHARED_LAYER_REUSE_COUNT += 1
 
     import mlx.core as mx
     from mlx_lm.models.base import scaled_dot_product_attention
@@ -202,10 +255,42 @@ def _shared_layer_attn_call(self, x, mask, cache):
     else:
         cache = [None] * 2
 
-    # No indexer => no sparse mask, no ``cache[0].keys = mx.depends(...)`` on
-    # the (unpopulated) ``cache[1]``. Dense MLA attention over the full KV
-    # window is the natural fallback the upstream code already takes when
-    # ``topk_indices is None``.
+    # REAP reuse: apply the prior full layer's top-K KV selection to this
+    # shared layer, exactly as the upstream full path does after running
+    # its own indexer. The sparse-mask block is a verbatim copy of
+    # ``DeepseekV32Attention.__call__`` in mlx_lm 0.31.3.
+    if topk_indices is not None:
+        if L == 1:
+            idx = topk_indices[:, :, 0, :, None]
+            kv_latent = mx.take_along_axis(
+                kv_latent,
+                mx.broadcast_to(idx, idx.shape[:-1] + (kv_latent.shape[-1],)),
+                axis=2,
+            )
+            k_pe = mx.take_along_axis(
+                k_pe,
+                mx.broadcast_to(idx, idx.shape[:-1] + (k_pe.shape[-1],)),
+                axis=2,
+            )
+            if mask is not None:
+                mask = mx.take_along_axis(mask, topk_indices, axis=-1)
+        else:
+            shape = list(topk_indices.shape)
+            shape[-1] = kv_latent.shape[2]
+            sparse_mask = mx.zeros(shape, dtype=mx.bool_)
+            sparse_mask = mx.put_along_axis(
+                sparse_mask, topk_indices, mx.array(True), axis=-1
+            )
+            if mask is not None:
+                sparse_mask = sparse_mask & mask
+            mask = sparse_mask
+
+    # NB: NO ``cache[0].keys = mx.depends(cache[0].keys, (cache[1].keys,
+    # cache[1].values))`` — cache[1] is never populated on a shared layer
+    # so ``cache[1].keys`` is ``None`` and ``mx.depends`` would crash.
+    # Skipping is safe: that line is an upstream graph-pruning hint, not a
+    # correctness requirement.
+
     pe_scores = (q_pe * self.scale) @ k_pe.swapaxes(-1, -2)
     if mask is not None:
         pe_scores = mx.where(
@@ -233,7 +318,13 @@ def _shared_layer_attn_call(self, x, mask, cache):
 
 def install_deepseek_v32_indexer_gate() -> None:
     """Install the indexer gate. Idempotent and thread-safe."""
-    global _INSTALLED, _orig_attn_call, _orig_decoder_init, _orig_from_dict
+    global \
+        _INSTALLED, \
+        _orig_attn_call, \
+        _orig_decoder_init, \
+        _orig_indexer_call, \
+        _orig_model_call, \
+        _orig_from_dict
 
     with _LOCK:
         if _INSTALLED:
@@ -257,6 +348,8 @@ def install_deepseek_v32_indexer_gate() -> None:
 
         _orig_attn_call = ds.DeepseekV32Attention.__call__
         _orig_decoder_init = ds.DeepseekV32DecoderLayer.__init__
+        _orig_indexer_call = ds.Indexer.__call__
+        _orig_model_call = ds.DeepseekV32Model.__call__
         _orig_from_dict = glm.ModelArgs.from_dict
 
         def _patched_decoder_init(self, config, layer_idx):
@@ -264,11 +357,15 @@ def install_deepseek_v32_indexer_gate() -> None:
             types = getattr(config, "indexer_types", None)
             if types is None:
                 return
-            # Fail fast on the all-shared edge case (no valid REAP config has
-            # this shape; bail before load_weights spits a confusing error).
+            # Fail fast on structurally-invalid configs (no anchor, shared at
+            # index 0, length mismatch).
             if layer_idx == 0:
-                _validate_anchor(types)
+                _validate_anchor(types, num_hidden_layers=config.num_hidden_layers)
             self.self_attn.layer_idx = layer_idx
+            # Initialize the topk reuse slot; the model-level wrapper writes
+            # the prior full layer's topk here before invoking the shared
+            # layer's ``__call__``.
+            self.self_attn._shared_topk_indices = None
             mode = _resolve_mode(types, layer_idx)
             if mode == "shared":
                 # Assigning ``None`` to an nn.Module child removes it from
@@ -277,10 +374,80 @@ def install_deepseek_v32_indexer_gate() -> None:
                 # longer demands the absent ``indexer.*`` keys.
                 self.self_attn.indexer = None
 
+        def _patched_indexer_call(self, x, qr, mask, cache=None):
+            # Cache the return tensor on the instance so the model-level
+            # wrapper can pick it up after the full-layer forward and thread
+            # it into the subsequent shared layers.
+            result = _orig_indexer_call(self, x, qr, mask, cache)
+            self._last_topk_indices = result
+            return result
+
         def _patched_attn_call(self, x, mask=None, cache=None):
             if getattr(self, "indexer", None) is not None:
                 return _orig_attn_call(self, x, mask, cache)
             return _shared_layer_attn_call(self, x, mask, cache)
+
+        def _patched_model_call(self, x, cache=None):
+            # Lazy import so the patch module doesn't pull mlx at import.
+            import mlx.core as mx
+            from mlx_lm.models.base import create_attention_mask
+
+            # ``DeepseekV32Model`` (the inner module) doesn't store
+            # ``config`` as an attribute. Pick the config off the first
+            # decoder layer's attention — every layer's
+            # ``self_attn.config`` is set by upstream
+            # ``DeepseekV32Attention.__init__``.
+            types = None
+            if self.layers and self.layers[self.start_idx] is not None:
+                cfg = getattr(self.layers[self.start_idx].self_attn, "config", None)
+                if cfg is not None:
+                    types = getattr(cfg, "indexer_types", None)
+
+            if types is None:
+                # Non-REAP path: delegate to upstream verbatim.
+                return _orig_model_call(self, x, cache)
+
+            # Replica of upstream ``DeepseekV32Model.__call__`` with topk
+            # threading inserted into the layer loop.
+            h = self.embed_tokens(x)
+            pipeline_rank = self.pipeline_rank
+            pipeline_size = self.pipeline_size
+
+            if cache is None:
+                cache = [None] * self.num_layers
+            mask = create_attention_mask(
+                h, cache[0][0] if cache[0] else None, return_array=True
+            )
+
+            if pipeline_rank < pipeline_size - 1:
+                h = mx.distributed.recv_like(h, (pipeline_rank + 1))
+
+            last_topk_indices = None
+            for i in range(self.num_layers):
+                layer = self.layers[self.start_idx + i]
+                layer_idx = self.start_idx + i
+                mode = _resolve_mode(types, layer_idx)
+                if mode == "shared":
+                    # Thread the most-recent full layer's topk into this
+                    # shared layer's attention BEFORE it runs.
+                    layer.self_attn._shared_topk_indices = last_topk_indices
+                h = layer(h, mask, cache[i])
+                if mode == "full":
+                    # Pick up the topk this layer's indexer just produced
+                    # (may be None if k.shape[2] <= index_topk).
+                    indexer = getattr(layer.self_attn, "indexer", None)
+                    if indexer is not None:
+                        last_topk_indices = getattr(indexer, "_last_topk_indices", None)
+
+            if pipeline_rank != 0:
+                h = mx.distributed.send(h, (pipeline_rank - 1) % pipeline_size)
+                if cache[-1] is not None:
+                    cache[-1][0].keys = mx.depends(cache[-1][0].keys, h)
+
+            if pipeline_size > 1:
+                h = mx.distributed.all_gather(h)[: h.shape[0]]
+
+            return self.norm(h)
 
         @classmethod
         def _patched_from_dict(cls, params):
@@ -295,6 +462,8 @@ def install_deepseek_v32_indexer_gate() -> None:
 
         ds.DeepseekV32Attention.__call__ = _patched_attn_call
         ds.DeepseekV32DecoderLayer.__init__ = _patched_decoder_init
+        ds.Indexer.__call__ = _patched_indexer_call
+        ds.DeepseekV32Model.__call__ = _patched_model_call
         glm.ModelArgs.from_dict = _patched_from_dict
         ds._RAPID_MLX_INDEXER_GATE_INSTALLED = True
         _INSTALLED = True
@@ -303,7 +472,13 @@ def install_deepseek_v32_indexer_gate() -> None:
 
 def uninstall_deepseek_v32_indexer_gate() -> None:
     """Undo the gate. Test-only; production code does not call this."""
-    global _INSTALLED, _orig_attn_call, _orig_decoder_init, _orig_from_dict
+    global \
+        _INSTALLED, \
+        _orig_attn_call, \
+        _orig_decoder_init, \
+        _orig_indexer_call, \
+        _orig_model_call, \
+        _orig_from_dict
 
     with _LOCK:
         if not _INSTALLED:
@@ -317,12 +492,18 @@ def uninstall_deepseek_v32_indexer_gate() -> None:
             ds.DeepseekV32Attention.__call__ = _orig_attn_call
         if _orig_decoder_init is not None:
             ds.DeepseekV32DecoderLayer.__init__ = _orig_decoder_init
+        if _orig_indexer_call is not None:
+            ds.Indexer.__call__ = _orig_indexer_call
+        if _orig_model_call is not None:
+            ds.DeepseekV32Model.__call__ = _orig_model_call
         if _orig_from_dict is not None:
             glm.ModelArgs.from_dict = _orig_from_dict
         ds._RAPID_MLX_INDEXER_GATE_INSTALLED = False
         _INSTALLED = False
         _orig_attn_call = None
         _orig_decoder_init = None
+        _orig_indexer_call = None
+        _orig_model_call = None
         _orig_from_dict = None
 
 

--- a/vllm_mlx/patches/deepseek_v32_indexer_gate.py
+++ b/vllm_mlx/patches/deepseek_v32_indexer_gate.py
@@ -341,16 +341,37 @@ def install_deepseek_v32_indexer_gate() -> None:
             )
             return
 
-        # Detect double-install across module reloads (e.g. pytest restart).
+        # Stash the upstream originals on the ds module itself the FIRST
+        # time we install. On a later install after a module reload, we
+        # retrieve them from there instead of re-capturing the currently-
+        # patched callables (which would self-reference and either
+        # infinite-loop in the wrappers or leak originals through a
+        # subsequent uninstall — codex finding #2 on PR #967 round 3).
+        if not getattr(ds, "_RAPID_MLX_INDEXER_GATE_INSTALLED", False):
+            ds._RAPID_MLX_ORIG_ATTN_CALL = ds.DeepseekV32Attention.__call__
+            ds._RAPID_MLX_ORIG_DECODER_INIT = ds.DeepseekV32DecoderLayer.__init__
+            ds._RAPID_MLX_ORIG_INDEXER_CALL = ds.Indexer.__call__
+            ds._RAPID_MLX_ORIG_MODEL_CALL = ds.DeepseekV32Model.__call__
+            ds._RAPID_MLX_ORIG_FROM_DICT = glm.ModelArgs.from_dict
+
+        # Always copy from the stash into this module's globals so a later
+        # ``uninstall_deepseek_v32_indexer_gate()`` from a freshly-loaded
+        # module instance still restores the true upstream callables.
+        _orig_attn_call = ds._RAPID_MLX_ORIG_ATTN_CALL
+        _orig_decoder_init = ds._RAPID_MLX_ORIG_DECODER_INIT
+        _orig_indexer_call = ds._RAPID_MLX_ORIG_INDEXER_CALL
+        _orig_model_call = ds._RAPID_MLX_ORIG_MODEL_CALL
+        _orig_from_dict = ds._RAPID_MLX_ORIG_FROM_DICT
+
+        # Re-entry guard: if a previous module instance already installed
+        # the gate on the upstream classes, mark this instance as
+        # installed and return WITHOUT re-wrapping (otherwise the new
+        # wrappers would call the old wrappers as "originals" → infinite
+        # delegation). The captured originals above are the un-patched
+        # callables, so uninstall still works.
         if getattr(ds, "_RAPID_MLX_INDEXER_GATE_INSTALLED", False):
             _INSTALLED = True
             return
-
-        _orig_attn_call = ds.DeepseekV32Attention.__call__
-        _orig_decoder_init = ds.DeepseekV32DecoderLayer.__init__
-        _orig_indexer_call = ds.Indexer.__call__
-        _orig_model_call = ds.DeepseekV32Model.__call__
-        _orig_from_dict = glm.ModelArgs.from_dict
 
         def _patched_decoder_init(self, config, layer_idx):
             _orig_decoder_init(self, config, layer_idx)
@@ -422,7 +443,35 @@ def install_deepseek_v32_indexer_gate() -> None:
             if pipeline_rank < pipeline_size - 1:
                 h = mx.distributed.recv_like(h, (pipeline_rank + 1))
 
+            # Initialize from the most-recent full layer in this rank's
+            # range that has run on a prior forward call (its indexer's
+            # ``_last_topk_indices`` slot persists). Critical for two
+            # cases (codex finding #1 on PR #967 round 3):
+            #   (a) pipeline-parallel rank with ``start_idx > 0`` whose
+            #       first owned layer is "shared" — there is no preceding
+            #       full layer in this rank's range to refresh from.
+            #   (b) a fresh decode call after prefill where the layer
+            #       loop's first iteration is the same full layer that
+            #       just ran the last time — without this seeding, that
+            #       full layer's own forward is the FIRST thing to refresh
+            #       ``last_topk_indices``, so any shared layer in
+            #       between would briefly see None.
+            # ``_last_topk_indices`` is only present after at least one
+            # full-layer forward; on the very first call it is None and
+            # leading shared layers correctly hit the dense fallback (the
+            # same path upstream Indexer takes when k.shape[2] <= index_topk).
             last_topk_indices = None
+            for i in range(self.num_layers - 1, -1, -1):
+                layer = self.layers[self.start_idx + i]
+                if layer is None:
+                    continue
+                indexer = getattr(layer.self_attn, "indexer", None)
+                if indexer is None:
+                    continue
+                last_topk_indices = getattr(indexer, "_last_topk_indices", None)
+                if last_topk_indices is not None:
+                    break
+
             for i in range(self.num_layers):
                 layer = self.layers[self.start_idx + i]
                 layer_idx = self.start_idx + i

--- a/vllm_mlx/patches/deepseek_v32_indexer_gate.py
+++ b/vllm_mlx/patches/deepseek_v32_indexer_gate.py
@@ -438,15 +438,23 @@ def install_deepseek_v32_indexer_gate() -> None:
             # ``config`` as an attribute. Pick the config off the first
             # decoder layer's attention — every layer's
             # ``self_attn.config`` is set by upstream
-            # ``DeepseekV32Attention.__init__``.
+            # ``DeepseekV32Attention.__init__``. Bounds-check
+            # ``start_idx`` so a pipeline/sharded layout with an empty
+            # local slice (or out-of-range ``start_idx``) safely
+            # delegates to upstream (codex finding #3 on PR #967 round 5).
             types = None
-            if self.layers and self.layers[self.start_idx] is not None:
+            if (
+                self.layers
+                and 0 <= self.start_idx < len(self.layers)
+                and self.layers[self.start_idx] is not None
+            ):
                 cfg = getattr(self.layers[self.start_idx].self_attn, "config", None)
                 if cfg is not None:
                     types = getattr(cfg, "indexer_types", None)
 
             if types is None:
-                # Non-REAP path: delegate to upstream verbatim.
+                # Non-REAP path (or out-of-range slice) — delegate to
+                # upstream verbatim.
                 return _orig_model_call(self, x, cache)
 
             # Replica of upstream ``DeepseekV32Model.__call__`` with topk
@@ -464,42 +472,24 @@ def install_deepseek_v32_indexer_gate() -> None:
             if pipeline_rank < pipeline_size - 1:
                 h = mx.distributed.recv_like(h, (pipeline_rank + 1))
 
-            # Initialize from the most-recent full layer anywhere in
-            # ``self.layers`` that has run on a prior forward call (its
-            # indexer's ``_last_topk_indices`` slot persists). Critical
-            # for the case (codex finding #1 on PR #967 round 3) where
-            # this rank's first iterated layer is ``"shared"`` — e.g.
-            # a pipeline-parallel slice whose head is shared, or a
-            # future model layout that places shared layers ahead of
-            # any full layer in this rank. Without this seed the
-            # leading shared layers would dense-fall-back on every
-            # decode step.
-            #
-            # We iterate ALL ``self.layers`` (not just
-            # ``[start_idx, start_idx+num_layers)``) so a full layer
-            # outside this rank's iteration window — but still owned by
-            # this Python-side model instance — can be the source.
-            # Pipeline-parallel ranks that own NO full layer at all
-            # cannot seed from another rank's indexer state via this
-            # path; that's a separate (out-of-scope here)
-            # inter-rank-communication concern and the dense fallback
-            # remains correct for it.
-            #
-            # ``_last_topk_indices`` is only present after at least one
-            # full-layer forward; on the very first call it is None and
-            # leading shared layers correctly hit the dense fallback
-            # (the same path upstream Indexer takes when
-            # ``k.shape[2] <= index_topk``).
+            # ``last_topk_indices`` is set fresh by each ``"full"``
+            # layer's forward in THIS call and consumed by the
+            # immediately-following ``"shared"`` layers. We deliberately
+            # do NOT seed it from a prior forward's persisted
+            # ``_last_topk_indices`` — those indices reference KV-slot
+            # positions computed at a different query/cache length and
+            # applying them to a fresh decode step would be a stale
+            # selection (codex finding #1 on PR #967 round 5; supersedes
+            # the round-3 seed attempt). When this rank's iteration
+            # window starts with a ``"shared"`` layer (e.g. a pipeline-
+            # parallel slice without a local full-layer anchor), those
+            # leading shared layers correctly hit the dense fallback —
+            # the same path the upstream Indexer takes when
+            # ``k.shape[2] <= index_topk``. Cross-rank communication of
+            # the current full layer's topk would be the
+            # architecturally-correct remedy if needed in the future;
+            # that is out of scope for the surgical D1 fix here.
             last_topk_indices = None
-            for layer in reversed(self.layers):
-                if layer is None:
-                    continue
-                indexer = getattr(layer.self_attn, "indexer", None)
-                if indexer is None:
-                    continue
-                last_topk_indices = getattr(indexer, "_last_topk_indices", None)
-                if last_topk_indices is not None:
-                    break
 
             for i in range(self.num_layers):
                 layer = self.layers[self.start_idx + i]
@@ -534,7 +524,17 @@ def install_deepseek_v32_indexer_gate() -> None:
             # Preserve the REAP extension field. Plain attribute assignment
             # is fine on a non-frozen dataclass; downstream code reads via
             # ``getattr(config, "indexer_types", None)``.
-            if "indexer_types" in params:
+            #
+            # Scope the validation strictly to the GLM-MoE-DSA model
+            # type. Although ``glm.ModelArgs.from_dict`` is itself class-
+            # specific (inherited subclasses of ``BaseModelArgs`` are not
+            # affected by this assignment), gating on ``model_type``
+            # provides a defense-in-depth signal that the validation
+            # only applies to REAP-pruned DeepseekV32/GLM-MoE-DSA
+            # configs and not to any future extension that happens to
+            # reuse this dataclass for a different architecture (codex
+            # finding #2 on PR #967 round 5).
+            if "indexer_types" in params and params.get("model_type") == "glm_moe_dsa":
                 # Validate at config-parse time so a malformed REAP config
                 # fails clearly here rather than later in weight loading
                 # (codex NIT, PR #967 round 4). ``_validate_anchor`` enforces
@@ -544,6 +544,7 @@ def install_deepseek_v32_indexer_gate() -> None:
                     params["indexer_types"],
                     num_hidden_layers=params.get("num_hidden_layers"),
                 )
+            if "indexer_types" in params:
                 instance.indexer_types = params["indexer_types"]
             return instance
 

--- a/vllm_mlx/utils/tokenizer.py
+++ b/vllm_mlx/utils/tokenizer.py
@@ -15,6 +15,22 @@ from .chat_templates import DEFAULT_CHATML_TEMPLATE, NEMOTRON_CHAT_TEMPLATE
 
 logger = logging.getLogger(__name__)
 
+# Install the per-layer Indexer gate for REAP-pruned DeepseekV32 configs
+# (e.g. mlx-community/pipenetwork-GLM-5.2-REAP50-MLX-4bit). The hook is
+# placed HERE (and not only in vllm_mlx.model_runner) because the real
+# `rapid-mlx serve` boot path is:
+#   cli -> server -> engine.batched._start_llm -> utils.tokenizer.load_model_with_fallback
+#   -> mlx_lm.load -> mlx_lm.utils.load_model
+# None of those import model_runner, so installing the gate there alone
+# missed the production load path (PR #967 wiring bug). Install is
+# idempotent (_LOCK + _INSTALLED early-return) and a no-op on configs
+# that don't publish ``indexer_types``.
+from ..patches.deepseek_v32_indexer_gate import (
+    install_deepseek_v32_indexer_gate as _install_dsv32_indexer_gate,
+)
+
+_install_dsv32_indexer_gate()
+
 # Models that require tokenizer fallback
 FALLBACK_MODELS = [
     "nemotron",


### PR DESCRIPTION
## Summary

Surgical fix for Defect 1 of the GLM-5.2 boot chain. REAP-pruned
DeepseekV32 configs (e.g. `mlx-community/pipenetwork-GLM-5.2-REAP50-MLX-4bit`)
publish a per-layer `indexer_types: List[str]` where each entry is `"full"`
(layer owns Indexer weights in the safetensors) or `"shared"` (no Indexer
weights — reuses the previous full layer's indexer output at inference).

Upstream `mlx_lm.models.deepseek_v32.DeepseekV32Attention.__init__` builds
`self.indexer = Indexer(config)` unconditionally on every layer, so
`mlx_lm.load` aborts with `Missing N parameters: ...indexer...` for each
shared layer — 627 missing on the full 78-layer GLM-5.2-REAP50 (11 indexer
tensors per layer * 57 shared layers).

## Approach (Option A — monkey-patch, ~190 LOC vs ~800 LOC vendor)

Single new module `vllm_mlx/patches/deepseek_v32_indexer_gate.py`
monkey-patches THREE upstream symbols at import time:

1. `DeepseekV32DecoderLayer.__init__` — after upstream init, drop
   `self.self_attn.indexer` (set `= None`) on `"shared"` layers so it's
   removed from the parameter tree (`Module.__setattr__` deregisters
   non-array assignments).
2. `DeepseekV32Attention.__call__` — when `self.indexer is None`, route
   through a shared-layer code path that skips the Indexer invocation
   AND the trailing `mx.depends(cache[0].keys, (cache[1].keys,
   cache[1].values))` (cache[1] never populated on a shared layer).
3. `glm_moe_dsa.ModelArgs.from_dict` — preserve `indexer_types`, which
   `BaseModelArgs.from_dict`'s signature filter otherwise silently drops.

ONE-line install in `vllm_mlx/model_runner.py`. Idempotent + thread-safe.

**Backward-compat:** configs WITHOUT `indexer_types` take the upstream
path verbatim — every patched function is a no-op on that branch.

## Why not vendor the whole `deepseek_v32.py`?

The prototype in worktree `agent-ab1e6ca1e03faf639` vendored 721 LOC of
`deepseek_v32.py` + 73 LOC `glm_moe_dsa.py`. Operator's instruction:
**surgical, minimum vendor**. The actual fix is ~10 lines of behavior
spread over 3 functions; copying 794 LOC to express it is overkill and
creates ongoing drift cost vs upstream. When upstream lands
`indexer_types` support (likely soon — REAP is a known pattern), we
delete this one module + one import line, no large diff to revert.

## Test plan

Regression tests in `tests/test_deepseek_v32_indexer_gate.py` (4 tests):

- Pin the without-gate failure (`Missing 10 parameters: ...indexer...`)
  on a synthetic 4-layer config so an upstream Indexer refactor lights
  this up.
- Mixed `["full","shared","full","shared"]` loads cleanly + forward
  pass executes through both full and shared layers.
- Backward-compat: `indexer_types=None` keeps every layer's Indexer
  (no behavior change for non-REAP configs).
- All-`"shared"` raises a clear `ValueError("no 'full' anchor")` — no
  valid REAP config has this shape.

All 4 pass. No GLM-5.2 download was performed (synthetic 4-layer config,
~100 KB safetensors).

Smoke proof at `/tmp/d1_smoke_proof.log`:
- Build 4-layer glm_moe_dsa, load via `mlx_lm.utils.load_model`, run
  5-token generation. No crash.

Baseline reproduction at `/tmp/repro_d1_baseline_FAIL.log`:
- Same 4-layer config WITHOUT the gate aborts with
  `Missing 10 parameters: ... indexer ...`.

## Defect chain status

Closes the load-time failure (D1) only. GLM-5.2 still needs D3+D4+D5
to actually boot end-to-end — tracked on 0.9-TODO row 21. This PR does
NOT flip the row status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)