### PR TITLE
fix(scheduler): read modern `dtype` config key in KV-cache dtype inference (gemma4-on-18GB false reject)

### DIFF
--- a/tests/test_metal_cap_enforcement.py
+++ b/tests/test_metal_cap_enforcement.py
@@ -26,6 +26,7 @@ alike) and doesn't depend on the actual GPU pressure at test time.
 from __future__ import annotations
 
 import logging
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -614,6 +615,170 @@ class TestDtypeInference:
         sched = self._build_sched_with_dtype("some-future-quant-format")
         per_tok = sched._resolve_kv_bytes_per_token()
         assert per_tok == 2 * 4 * 2 * 64 * 4
+
+
+class TestModernDtypeKeyInference:
+    """gemma4-on-18GB false-rejection regression.
+
+    Transformers renamed the config dtype key ``torch_dtype`` →
+    ``dtype``. Newer configs (e.g. Gemma 4, bf16) carry ONLY ``dtype``,
+    so ``_infer_kv_dtype_bytes`` reading only ``torch_dtype`` fell
+    through to the fp32 (4-byte) fallback — DOUBLING the projected KV vs
+    the real bf16 (2-byte) cache and rejecting at admission a request
+    whose real usage fit under the cap (gemma-4-12b on an 18 GB MBP:
+    real 10.7 GB < 11.6 GB cap, but projected 14.4 GB).
+
+    Uses ``SimpleNamespace`` rather than ``MagicMock`` so an UNSET
+    attribute resolves to ``None`` (a MagicMock auto-creates every
+    attribute, which would mask whether the modern key is actually
+    read)."""
+
+    def _sched(self, config_obj):
+        config = SchedulerConfig(
+            max_num_seqs=8,
+            max_concurrent_requests=64,
+            enable_prefix_cache=False,
+            use_memory_aware_cache=False,
+            use_paged_cache=False,
+            gpu_memory_utilization=0.5,
+            metal_cap_kv_bytes_per_token=0,  # exercise auto-derivation
+        )
+        model = MagicMock()
+        model.config = config_obj
+        return Scheduler(model=model, tokenizer=MagicMock(), config=config)
+
+    def test_modern_dtype_key_bf16_uses_2_bytes(self):
+        # Gemma 4 shape: only the modern ``dtype`` key (bf16), no
+        # legacy ``torch_dtype``.
+        cfg = SimpleNamespace(
+            num_hidden_layers=4,
+            num_key_value_heads=2,
+            head_dim=64,
+            dtype="bfloat16",
+        )
+        sched = self._sched(cfg)
+        assert sched._infer_kv_dtype_bytes(cfg) == 2
+        # 2 (K+V) × 4 layers × 2 kv_heads × 64 head_dim × 2 bytes —
+        # NOT the fp32 (×4) over-estimate that caused the false reject.
+        assert sched._resolve_kv_bytes_per_token() == 2 * 4 * 2 * 64 * 2
+
+    def test_modern_dtype_key_torchdtype_str_form(self):
+        # ``str(torch.bfloat16)`` form on the modern key.
+        cfg = SimpleNamespace(
+            num_hidden_layers=4,
+            num_key_value_heads=2,
+            head_dim=64,
+            dtype="torch.bfloat16",
+        )
+        sched = self._sched(cfg)
+        assert sched._infer_kv_dtype_bytes(cfg) == 2
+
+    def test_modern_dtype_key_preferred_when_both_present(self):
+        # Both keys present with CONFLICTING byte sizes → modern
+        # ``dtype`` (bf16, 2 B) must win over legacy ``torch_dtype``
+        # (fp32, 4 B), matching transformers' own precedence. Using a
+        # conflicting pair is what actually pins the ordering — a
+        # bf16/fp16 pair would pass regardless since both map to 2.
+        cfg = SimpleNamespace(
+            num_hidden_layers=4,
+            num_key_value_heads=2,
+            head_dim=64,
+            dtype="bfloat16",
+            torch_dtype="float32",
+        )
+        sched = self._sched(cfg)
+        assert sched._infer_kv_dtype_bytes(cfg) == 2
+
+    def test_legacy_torch_dtype_still_read(self):
+        # Back-compat: a config carrying ONLY the legacy key still works.
+        cfg = SimpleNamespace(
+            num_hidden_layers=4,
+            num_key_value_heads=2,
+            head_dim=64,
+            torch_dtype="float32",
+        )
+        sched = self._sched(cfg)
+        assert sched._infer_kv_dtype_bytes(cfg) == 4
+
+    def test_nested_text_config_dtype(self):
+        # Multimodal config: the LM dtype lives on the nested
+        # ``text_config`` while the top level has none.
+        cfg = SimpleNamespace(
+            num_hidden_layers=4,
+            num_key_value_heads=2,
+            head_dim=64,
+            text_config=SimpleNamespace(dtype="bfloat16"),
+        )
+        sched = self._sched(cfg)
+        assert sched._infer_kv_dtype_bytes(cfg) == 2
+
+    def test_no_dtype_anywhere_falls_back_to_4(self):
+        # Neither key, no text_config → genuine-unknown fp32 fallback.
+        cfg = SimpleNamespace(
+            num_hidden_layers=4,
+            num_key_value_heads=2,
+            head_dim=64,
+        )
+        sched = self._sched(cfg)
+        assert sched._infer_kv_dtype_bytes(cfg) == 4
+
+    def test_gemma4_12b_on_18gb_admitted_after_fix(self):
+        """End-to-end regression for the reported gemma4用不了 bug.
+
+        gemma-4-12b real config: 48 layers, 8 KV heads, head_dim 256,
+        bf16 KV exposed via the MODERN ``dtype`` key. On an 18 GB MBP
+        the sidecar default ``--gpu-memory-utilization 0.90`` yields an
+        ~11.6 GB cap; the 4-bit weights sit at ~6.7 GB Metal-active.
+
+        Per-token KV with the fix (bf16, 2 bytes):
+            2 (K+V) × 48 × 8 × 256 × 2 = 393_216 B  (384 KB)
+        A ~10 K-token budget projects ≈ 3.94 GB, so
+            6.7 GB active + 3.94 GB projected ≈ 10.6 GB < 11.6 GB cap
+        → ADMIT. Pre-fix the modern ``dtype`` key was ignored, the
+        fp32 fallback doubled per-token KV to 786_432 B → ≈ 7.87 GB
+        projected → 14.6 GB > cap → the first chat was rejected with
+        BackpressureError ("Internal error during streaming") even
+        though the model genuinely fit."""
+        config = SchedulerConfig(
+            max_num_seqs=8,
+            max_concurrent_requests=64,
+            enable_prefix_cache=False,
+            use_memory_aware_cache=False,
+            use_paged_cache=False,
+            gpu_memory_utilization=0.90,
+            metal_cap_kv_bytes_per_token=0,  # auto-derive from config
+        )
+        cfg = SimpleNamespace(
+            num_hidden_layers=48,
+            num_key_value_heads=8,
+            head_dim=256,
+            dtype="bfloat16",  # modern key only (Gemma 4 shape)
+        )
+        model = MagicMock()
+        model.config = cfg
+        sched = Scheduler(model=model, tokenizer=MagicMock(), config=config)
+
+        # Per-token KV is the bf16 value, not the fp32 over-estimate.
+        assert sched._resolve_kv_bytes_per_token() == 2 * 48 * 8 * 256 * 2
+
+        req = _make_request(tokens=12)
+        req.sampling_params = SamplingParams(max_tokens=10_000)
+        with (
+            patch.object(
+                sched, "_resolve_metal_cap_bytes", return_value=11_600_000_000
+            ),
+            patch.object(
+                sched, "_current_metal_active_bytes", return_value=6_700_000_000
+            ),
+        ):
+            # Must NOT raise — the request genuinely fits under the cap.
+            sched._enforce_metal_cap_at_admission(req)
+        assert sched.num_metal_cap_violations == 0
+
+        # And the fp32 mis-read WOULD have exceeded the cap — proving the
+        # fix is what flips this from reject to admit.
+        fp32_projected = (2 * 48 * 8 * 256 * 4) * (12 + 10_000)
+        assert 6_700_000_000 + fp32_projected > 11_600_000_000
 
 
 class TestMetricsRoute:

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -3100,50 +3100,84 @@ class Scheduler:
         """Best-effort KV-cache dtype-bytes inference.
 
         Codex round 5 BLOCKING #2: returns the size in bytes of the
-        KV-cache element dtype. Falls back to ``4`` (fp32) when the
-        dtype cannot be determined, which is the largest plausible
-        dtype for typical MLX deployments — over-estimating is the
-        safe direction (admission rejects a borderline request
-        rather than letting it slip past the cap).
+        KV-cache element dtype. Falls back to ``4`` (fp32) ONLY when the
+        dtype genuinely cannot be determined — over-estimating is the
+        safe direction for a TRULY unknown dtype (admission rejects a
+        borderline request rather than letting it slip past the cap).
 
-        Reads ``torch_dtype`` (the HuggingFace config convention).
+        Reads the element dtype from, in priority order:
+          1. ``dtype`` — the MODERN HuggingFace/transformers key.
+             ``torch_dtype`` was renamed to ``dtype`` upstream, so newer
+             configs (e.g. Gemma 4) carry ONLY ``dtype``.
+          2. ``torch_dtype`` — the legacy key, still emitted by older
+             configs.
+          3. The same two keys on a nested ``text_config`` — multimodal
+             configs (Gemma 4, Qwen-VL) nest the language-model config
+             there and may leave the top level without a usable dtype.
+
+        Why this matters (gemma4-on-18GB false-rejection bug): reading
+        ONLY ``torch_dtype`` meant a config that uses the modern
+        ``dtype`` key fell through to the fp32 fallback, DOUBLING the
+        projected KV (bf16 2 B/elem mis-read as fp32 4 B/elem) and
+        rejecting at admission a request whose real usage fits under the
+        cap. An MLX fp16/bf16 model's KV cache is 2 bytes/elem; fp32 KV
+        is not a real MLX deployment, so the fallback should be the rare
+        last resort, not the default for every modern config.
+
         Quantized KV-cache deployments are not auto-detected — the
         operator-tuned ``metal_cap_kv_bytes_per_token`` knob is the
         right escape hatch for those.
         """
+        mapping = {
+            "float64": 8,
+            "fp64": 8,
+            "double": 8,
+            "float32": 4,
+            "fp32": 4,
+            "float16": 2,
+            "fp16": 2,
+            "half": 2,
+            "bfloat16": 2,
+            "bf16": 2,
+            "int8": 1,
+            "uint8": 1,
+            "float8": 1,
+            "fp8": 1,
+        }
+
+        def _bytes_from(obj: Any) -> int:
+            # ``dtype`` (modern) and ``torch_dtype`` (legacy) may each be
+            # a string (``"bfloat16"``) or a ``torch.dtype`` whose
+            # ``str()`` is e.g. ``"torch.bfloat16"``. Note ``"float16"``
+            # is a substring of ``"bfloat16"`` — harmless here since both
+            # map to 2.
+            for attr in ("dtype", "torch_dtype"):
+                raw = getattr(obj, attr, None)
+                if raw is None:
+                    continue
+                dtype_str = str(raw).lower()
+                for needle, n in mapping.items():
+                    if needle in dtype_str:
+                        return n
+            return 0
+
         try:
-            dtype_str = ""
-            torch_dtype = getattr(model_config, "torch_dtype", None)
-            if torch_dtype is not None:
-                # ``torch_dtype`` is sometimes a string
-                # (``"float16"``, ``"bfloat16"``) and sometimes a
-                # ``torch.dtype`` whose ``str()`` is e.g.
-                # ``"torch.float16"``.
-                dtype_str = str(torch_dtype).lower()
-            mapping = {
-                "float64": 8,
-                "fp64": 8,
-                "double": 8,
-                "float32": 4,
-                "fp32": 4,
-                "float16": 2,
-                "fp16": 2,
-                "half": 2,
-                "bfloat16": 2,
-                "bf16": 2,
-                "int8": 1,
-                "uint8": 1,
-                "float8": 1,
-                "fp8": 1,
-            }
-            for needle, n in mapping.items():
-                if needle in dtype_str:
+            n = _bytes_from(model_config)
+            if n > 0:
+                return n
+            # Multimodal configs nest the LM dtype under ``text_config``.
+            text_config = getattr(model_config, "text_config", None)
+            if text_config is not None:
+                n = _bytes_from(text_config)
+                if n > 0:
                     return n
         except Exception:
             pass
         # Default: assume the LARGEST plausible dtype (fp32 = 4) so we
         # over-estimate KV usage and err toward rejection rather than
-        # admitting a request that exceeds the cap.
+        # admitting a request that exceeds the cap. Reached only when
+        # NEITHER ``dtype`` nor ``torch_dtype`` is present on the config
+        # or its ``text_config`` — rare on real HF/MLX configs.
         return 4
 
     def _resolve_kv_bytes_per_token(self) -> int:


### PR DESCRIPTION
## Why

Refs machinefi/rapid-desktop#471.

`gemma-4-12b-4bit` on an **18 GB MacBook** fails its **first chat** with `BackpressureError`, surfaced in the desktop app as an opaque *"Transport error talking to rapid-mlx: Internal error during streaming"* — even though the model genuinely fits. gemma-4-12b is the Quality recommendation for the 17–24 GB bucket, so this fails on the exact Mac it's recommended for. We fix it **because** the admission gate's KV estimate was wrong, not because the model was too big.

Log:
```
Backpressure(error): Metal active 6.7GB + reserved KV 0.0GB + projected KV 7.7GB
would exceed gpu_memory_utilization cap 11.6GB (0-METAL-CAP)
```

## Root cause

`Scheduler._infer_kv_dtype_bytes` read **only** the legacy `torch_dtype` config key. transformers renamed `torch_dtype` → `dtype`, and newer model configs (e.g. Gemma 4) carry **only** `dtype="bfloat16"`. The missing key fell through to the **fp32 (4-byte) fallback**, doubling the projected per-token KV vs the real **bf16 (2-byte)** cache. The D-METAL-CAP admission gate then rejected a request whose real usage fit under the cap.

With the sidecar default `--gpu-memory-utilization 0.90` the cap on an 18 GB Mac is ~11.6 GB; the 4-bit weights sit at ~6.7 GB Metal-active. gemma-4-12b = 48 layers, 8 KV heads, head_dim 256:

| dtype used | per-token KV | KV @ ~10k tok | weights + KV | vs 11.6 GB cap |
|---|---|---|---|---|
| **bf16 (correct)** | 384 KB | ~3.9 GB | 6.7 + 3.9 = **10.6 GB** | ✅ admit |
| **fp32 (the bug)** | 768 KB | ~7.9 GB | 6.7 + 7.9 = **14.6 GB** | ❌ reject |

## Fix

`_infer_kv_dtype_bytes` now reads the **modern `dtype` key** (priority over the legacy `torch_dtype`, matching transformers' own precedence where `torch_dtype` is an alias of `dtype`), and also checks a nested **`text_config`** for multimodal configs (Gemma 4, Qwen-VL) that nest the LM config. The fp32 fallback is retained **only** for genuinely-unknown dtypes (neither key present anywhere) — the rare, truly-safe last resort. An MLX fp16/bf16 model's KV cache is 2 bytes/elem; fp32 KV is not a real MLX deployment, so the over-estimate should not be the default for every modern config.

No weakening of the cap guarantee: when a dtype IS resolvable the projection is now *accurate*, so the gate admits exactly what fits and still rejects what genuinely won't (which should surface as a clear out-of-memory message in the client — tracked in machinefi/rapid-desktop#471).

## Tests

`TestModernDtypeKeyInference` (new):
- modern `dtype` bf16 → 2 bytes (+ `_resolve_kv_bytes_per_token` halves)
- `torch.bfloat16` string form
- modern-wins-over-legacy precedence with a **conflicting** byte pair (bf16 vs fp32)
- legacy-`torch_dtype`-only back-compat
- nested `text_config.dtype`
- no-dtype-anywhere → fp32 fallback
- **end-to-end**: gemma-4-12b-on-18GB admission scenario — rejected pre-fix, admits post-fix

`python3.12 -m pytest tests/test_metal_cap_enforcement.py` → **34/34**. `ruff` clean. codex review: 0 BLOCKING / 0 MAJOR — converged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)