### PR TITLE
release(0.9): K8V4 default-on for 9 aliases; release-notes claim cleanup; coverage truthing

### DIFF
--- a/README.md
+++ b/README.md
@@ -561,14 +561,14 @@ Decoded examples:
 
 ### Full model lineup
 
-103 explicit aliases across 15 families ship today. Run `rapid-mlx models` for the live list with parser, hybrid / MoE flags, and DFlash eligibility.
+103 explicit aliases across 15 families ship today. Run `rapid-mlx models` for the live list with parser, hybrid / MoE flags, and per-alias capabilities.
 
 <details>
 <summary><strong>Show all 103 aliases by family</strong></summary>
 
 | Family | Aliases | Notable |
 |---|---|---|
-| **Qwen3.5** | `qwen3.5-4b-4bit`, `-4b-8bit`, `-9b-4bit`, `-9b-8bit`, `-27b-4bit`, `-27b-8bit` ✨, `-35b-4bit`, `-35b-8bit`, `-122b-mxfp4`, `-122b-8bit` | DeltaNet hybrid; **27b-8bit DFlash-eligible** |
+| **Qwen3.5** | `qwen3.5-4b-4bit`, `-4b-8bit`, `-9b-4bit`, `-9b-8bit`, `-27b-4bit`, `-27b-8bit`, `-35b-4bit`, `-35b-8bit`, `-122b-mxfp4`, `-122b-8bit` | DeltaNet hybrid |
 | **Qwen3.6** | `qwen3.6-27b-4bit`, `-27b-8bit`, `-27b-ud`, `-35b-4bit`, `-35b-6bit`, `-35b-8bit`, `-35b-dwq`, `-35b-ud` | 262K ctx, 256 MoE experts |
 | **Qwen3** | `qwen3-0.6b-4bit`, `-0.6b-8bit`, `-4b-8bit`, `-8b-4bit`, `-8b-8bit`, `qwen3-coder-4bit`, `qwen3-coder-30b-4bit`, `qwen3-vl-4b-4bit`, `-8b-4bit`, `-30b-4bit` | Coding + vision |
 | **Qwen2.5** | `qwen2.5-14b-4bit` | Legacy 14B base for back-compat agents |
@@ -584,7 +584,7 @@ Decoded examples:
 | 🆕 **Text-Diffusion** | `diffusion-gemma-26b-4bit`, `diffusion-gemma-26b-8bit` | Non-autoregressive (block denoising); same `/v1/chat/completions` API |
 | 🆕 **UI-TARS** | `ui-tars-1.5-7b-4bit`, `-6bit`, `-8bit`, `ui-tars-7b-dpo-4bit`, `-6bit`, `-8bit`, `ui-tars-7b-sft-4bit`, `-8bit`, `ui-tars-72b-dpo-4bit` | ByteDance GUI agent (Qwen2-VL); Computer-Use actions parsed as OpenAI `tool_calls` + Anthropic `tool_use` (`name="computer"`) |
 
-✨ = DFlash speculative decoding supported (opt in with `--enable-dflash`). `rapid-mlx info <alias>` shows per-alias capabilities.
+`rapid-mlx info <alias>` shows per-alias capabilities (parser, hybrid / MoE flags, TurboQuant K8V4 eligibility).
 
 </details>
 
@@ -834,9 +834,8 @@ Qwen3.5 uses Gated DeltaNet (75% RNN) + full attention (25% KV). Other engines r
 | **Hybrid cache sync** | Keep trimmable KV + non-trimmable RNN layers in sync | Qwen3.5 (Gated DeltaNet + attention) |
 | **Tool logits bias** | Jump-forward decoding — bias logits toward structured tokens | All models with `--enable-tool-logits-bias` |
 | **Auto tool recovery** | Detect broken text-format tool calls, convert to structured | All 17 parser formats (incl. Gemma 4) |
-| **TurboQuant V-cache** | Rotate + Lloyd-Max compress V cache (86% savings on dense models) | All models with `--kv-cache-turboquant` |
+| **TurboQuant K8V4 codec** | Rotate + Lloyd-Max compress K (8-bit) + V (4-bit) cache — codec compresses KV to ~1/2.4 (~58% savings); lossless across the default-on alias matrix (mxfp4 excluded). Radix prefix cache is independent and saves additional bytes proportional to inter-request prefix overlap — the two are orthogonal and do not multiply. | All models with `--kv-cache-turboquant`; default-on for 9 verified Qwen3.5/3.6 aliases |
 | **KV cache quantization** | Quantize prefix cache entries to reduce memory | All models with `--kv-cache-quantization` |
-| **DFlash speculative decoding** | Block-diffusion drafter, parallel draft + verify | `qwen3.5-27b-8bit` (single-user, opt-in) |
 | **SuffixDecoding** | Drafter-free, statistical n-gram lookup speculative decoding | All BatchedEngine models with `--suffix-decoding` |
 | **Prefill chunking** | Configurable step size for large-prompt throughput | All models |
 | **Cloud routing** | Offload high-token requests to cloud LLM when local is slow | All models with `--cloud-model` |
@@ -895,31 +894,9 @@ rapid-mlx serve qwen3.5-9b-4bit          # PFlash auto-on for verified aliases
 rapid-mlx serve <model> --pflash always  # force it on for any model
 ```
 
-PFlash speeds up the prompt going *in*; **DFlash** speeds up the tokens coming *out*.
+PFlash speeds up the prompt going *in*. The 0.9 line ships a fused single-kernel sampler (faster than mlx-vlm's, identical sampling math), logprobs API, structured JSON output (`response_format`), continuous batching, the TurboQuant K8V4 KV codec (default-on for 9 verified Qwen3.5/3.6 aliases), and [3300+ tests](tests/).
 
-### DFlash Speculative Decoding (single-user)
-
-z-lab's block-diffusion drafter (via mlx-vlm) accelerates single-stream generation on the one validated Qwen3.5 alias for 0.9.0. Opt in with `--enable-dflash`:
-
-| Alias | Drafter | Code median | Chat (non-code) | Best / Worst code |
-|---|---|---|---|---|
-| `qwen3.5-27b-8bit` | `z-lab/Qwen3.5-27B-DFlash` | **1.85×** | 0.74× ↓ | 3.17× sortedlist / 1.40× hashtable |
-
-Measured: `scripts/bench_dflash.py --model qwen3.5-27b-8bit --runs 3 --max-tokens 256`, Apple Silicon M-series, 4 code workloads + 1 chat workload.
-
-```bash
-pip install 'rapid-mlx[dflash]'
-rapid-mlx info qwen3.5-27b-8bit       # check per-gate eligibility
-rapid-mlx serve qwen3.5-27b-8bit --enable-dflash
-```
-
-**Best on code generation** (fibonacci, quicksort, hashtable, sortedlist: 1.40–3.17× decode tok/s). **Regresses on open-ended chat** (0.74× decode tok/s) — the drafter's accept rate collapses outside the code distribution it was distilled for. Use the flag for code workloads only.
-
-**Why only 27B-8bit?** z-lab's drafters were distilled against `bfloat16` targets on NVIDIA B200 + SGLang (paper headlines 5–6×); on Apple Silicon + MLX 8bit target + int4 KV cache (TurboQuant K8V4 default), only `qwen3.5-27b-8bit` clears our SOP §6 ship gate. The same bench on `qwen3.5-9b-8bit` (chat 0.57×) and `qwen3.6-27b-8bit` (chat 0.41×) failed the non-code-floor rule. We'll re-check on 0.9.x with bf16 targets where disk + RAM allow.
-
-**v1 limitations**: DFlash mode runs a dedicated single-user server (mlx-vlm doesn't expose a batched DFlash kernel yet). Tool calling, MCP, and embeddings aren't available in DFlash mode — restart without `--enable-dflash` for those.
-
-Also: a fused single-kernel sampler (faster than mlx-vlm's, identical sampling math), logprobs API, structured JSON output (`response_format`), continuous batching, KV cache quantization (`--kv-cache-quantization`), and [3300+ tests](tests/).
+> *DFlash (block-diffusion speculative drafter) remains in the tree as experimental, flag-gated code (`pip install 'rapid-mlx[dflash]'`, `--enable-dflash`). The drafter's accept rate is workload-sensitive and is being re-validated; not included in the 0.9 release-claim set.*
 
 ---
 
@@ -950,10 +927,10 @@ Also: a fused single-kernel sampler (faster than mlx-vlm's, identical sampling m
 | Flag | Description | Default |
 |------|-------------|---------|
 | `--prefill-step-size` | Tokens per prefill chunk | `2048` |
-| `--kv-cache-turboquant` | TurboQuant V-cache compression (3-4 bit, 86% savings on dense models) | off |
+| `--kv-cache-turboquant` | TurboQuant KV-cache codec (`k8v4` = K8 + V4, ~1/2.4 codec compression; `v4` = V-only legacy; `none` = off). Default-on for 9 verified Qwen3.5/3.6 aliases; workload-dependent in absolute bytes. | auto (on for verified aliases) |
 | `--kv-cache-quantization` | Quantize prefix cache entries for memory savings | off |
 | `--enable-prefix-cache` / `--disable-prefix-cache` | Cache common prefixes across requests | on |
-| `--enable-dflash` | DFlash speculative decoding (single-user; `qwen3.5-27b-8bit` only) | off |
+| `--enable-dflash` | DFlash speculative decoding (experimental, single-user, opt-in; install with `pip install 'rapid-mlx[dflash]'`) | off |
 | `--suffix-decoding` | Drafter-free n-gram speculative decoding (BatchedEngine path) | off |
 | `--enable-mtp` | MTP head speculative decoding (requires MTP-trained model) | off |
 | `--gpu-memory-utilization` | Fraction of device memory to use (0.0-1.0) | `0.90` |
@@ -1184,7 +1161,7 @@ harness/                 # Regression baselines + thresholds
 
 | Technique | Expected Gain | Status |
 |-----------|---------------|--------|
-| [DFlash](https://arxiv.org/abs/2602.06036) — block-diffusion drafter, single-user | 1.3-2× decode | **Shipping** (qwen3.5-27b-8bit, qwen3.6-27b-8bit) |
+| [DFlash](https://arxiv.org/abs/2602.06036) — block-diffusion drafter, single-user | 1.3-2× decode (workload-dependent) | Experimental (`--enable-dflash`, `[dflash]` extra; re-validation in 0.9.x) |
 | [SuffixDecoding](https://arxiv.org/abs/2411.04975) — drafter-free n-gram speculative | 1.1-1.5× decode | Shipping (`--suffix-decoding`, per-model tier sweep ongoing) |
 | MTP — Multi-Token Prediction head | 1.4-1.7× decode | Experimental (requires MTP-trained checkpoint) |
 | [EAGLE-3](https://arxiv.org/abs/2503.01840) — feature-level draft on Metal | 3-6.5× decode | Not started |

--- a/docs/benchmarks/llm.md
+++ b/docs/benchmarks/llm.md
@@ -95,7 +95,7 @@ Notes:
 - Throughput peaks at **1024–2048** tokens, then dips at 4096 — consistent with KV-cache pressure as the rolling window fills.
 - Memory delta (baseline → DFlash) tracks the draft model + verification overhead; see the source benchmark for the exact figure.
 
-`Qwen3.6-35B-A3B-8bit` ships with DFlash enabled by default (`✨` in the alias table); these numbers reflect the out-of-the-box experience.
+`Qwen3.6-35B-A3B-8bit` supports DFlash as an experimental opt-in (install `[dflash]` extra, pass `--enable-dflash`); numbers above are from a community benchmark and reflect that single run.
 
 ## Prefix Cache Results
 

--- a/tests/test_turboquant_k8v4.py
+++ b/tests/test_turboquant_k8v4.py
@@ -693,9 +693,7 @@ def test_k8v4_default_on_whitelist_matches_aliases_json():
     import json
     from pathlib import Path
 
-    aliases_path = (
-        Path(__file__).resolve().parent.parent / "vllm_mlx" / "aliases.json"
-    )
+    aliases_path = Path(__file__).resolve().parent.parent / "vllm_mlx" / "aliases.json"
     aliases = json.loads(aliases_path.read_text())
 
     on = {

--- a/tests/test_turboquant_k8v4.py
+++ b/tests/test_turboquant_k8v4.py
@@ -647,3 +647,76 @@ def test_codec_preserves_input_dtype():
     out = TurboQuantKVCache.from_kv_cache(src, cfg).to_kv_cache()
     assert out.keys.dtype == mx.bfloat16
     assert out.values.dtype == mx.bfloat16
+
+
+# K8V4 default-on alias whitelist (0.9 release, option B). The
+# 9-entry roster below is the operator-approved set after the 体感
+# sweep: 4 Qwen3.5 dense aliases (9b/27b × 4/8bit) plus the 5
+# Qwen3.5/3.6-35B-A3B MoE variants that cleared coverage. mxfp4 is
+# explicitly excluded because the codec interacts badly with the
+# sub-fp4 weight quantization (4/10 prompts text-diff in coverage).
+#
+# Tightening this list is a release-notes-claim change ("lossless
+# across the default-on alias matrix") — touch the whitelist and the
+# release-notes phrasing together.
+K8V4_DEFAULT_ON_ALIASES_0_9: frozenset[str] = frozenset(
+    {
+        "qwen3.5-9b-4bit",
+        "qwen3.5-9b-8bit",
+        "qwen3.5-27b-4bit",
+        "qwen3.5-27b-8bit",
+        "qwen3.5-35b-6bit",
+        "qwen3.6-35b-4bit",
+        "qwen3.6-35b-6bit",
+        "qwen3.6-35b-8bit",
+        "qwen3.6-35b-dwq",
+    }
+)
+
+
+def test_k8v4_default_on_whitelist_matches_aliases_json():
+    """The aliases.json K8V4 default-on roster must equal the 0.9 whitelist.
+
+    Catches accidental drift in either direction:
+
+    * adding ``turboquant_tier=k8v4_verified`` to a new alias without
+      a corresponding coverage signoff (false positive — the alias
+      flips on silently and the release-notes lossless claim no
+      longer holds);
+    * dropping ``turboquant_tier=k8v4_verified`` from a verified
+      alias (false negative — operators that relied on the codec
+      default-on regress to FP16 KV with no warning).
+
+    mxfp4 specifically must NOT be in the on-list (coverage 4/10
+    prompts text-diff against FP16 KV reference).
+    """
+    import json
+    from pathlib import Path
+
+    aliases_path = (
+        Path(__file__).resolve().parent.parent / "vllm_mlx" / "aliases.json"
+    )
+    aliases = json.loads(aliases_path.read_text())
+
+    on = {
+        name
+        for name, profile in aliases.items()
+        if profile.get("turboquant_tier") == "k8v4_verified"
+    }
+
+    assert on == K8V4_DEFAULT_ON_ALIASES_0_9, (
+        "K8V4 default-on roster drifted from the 0.9 whitelist.\n"
+        f"  extra (in aliases.json but not whitelist): {sorted(on - K8V4_DEFAULT_ON_ALIASES_0_9)}\n"
+        f"  missing (in whitelist but not aliases.json): {sorted(K8V4_DEFAULT_ON_ALIASES_0_9 - on)}\n"
+        "Update vllm_mlx/aliases.json AND the K8V4_DEFAULT_ON_ALIASES_0_9 "
+        "frozenset above in lockstep, and re-frame the release notes claim "
+        "if the matrix changes."
+    )
+
+    # Defensive: mxfp4 must stay off even if a future hand-edit
+    # broadens the on-list. Coverage 2026-06-29 showed 4/10 text-diff
+    # against the FP16 KV reference.
+    assert "qwen3.6-35b-mxfp4" not in on, (
+        "qwen3.6-35b-mxfp4 must not be K8V4 default-on; codec interacts "
+        "with sub-fp4 weight quant (option B / 2026-06-29 coverage)."
+    )

--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -34,7 +34,8 @@
     "is_hybrid": false,
     "is_hybrid_explicit": true,
     "supports_spec_decode": false,
-    "pflash_tier": "verified"
+    "pflash_tier": "verified",
+    "turboquant_tier": "k8v4_verified"
   },
   "qwen3.5-9b-8bit": {
     "hf_path": "mlx-community/Qwen3.5-9B-8bit",
@@ -45,7 +46,8 @@
     "is_moe": false,
     "supports_spec_decode": false,
     "supports_dflash": false,
-    "pflash_tier": "verified"
+    "pflash_tier": "verified",
+    "turboquant_tier": "k8v4_verified"
   },
   "qwen3.5-9b-6bit": {
     "hf_path": "mlx-community/Qwen3.5-9B-6bit",
@@ -63,7 +65,8 @@
     "is_hybrid": false,
     "is_hybrid_explicit": true,
     "supports_spec_decode": false,
-    "pflash_tier": "verified"
+    "pflash_tier": "verified",
+    "turboquant_tier": "k8v4_verified"
   },
   "qwen3.5-35b-8bit": {
     "hf_path": "mlx-community/Qwen3.5-35B-A3B-8bit",
@@ -72,8 +75,7 @@
     "is_hybrid": true,
     "supports_spec_decode": false,
     "is_moe": true,
-    "pflash_tier": "verified",
-    "turboquant_tier": "k8v4_verified"
+    "pflash_tier": "verified"
   },
   "qwen3.5-35b-4bit": {
     "hf_path": "mlx-community/Qwen3.5-35B-A3B-4bit",
@@ -82,8 +84,7 @@
     "is_hybrid": true,
     "supports_spec_decode": false,
     "is_moe": true,
-    "pflash_tier": "verified",
-    "turboquant_tier": "k8v4_verified"
+    "pflash_tier": "verified"
   },
   "qwen3.5-35b-6bit": {
     "hf_path": "mlx-community/Qwen3.5-35B-A3B-6bit",
@@ -193,7 +194,8 @@
     "supports_spec_decode": false,
     "supports_dflash": true,
     "dflash_draft_model": "z-lab/Qwen3.5-27B-DFlash",
-    "pflash_tier": "verified"
+    "pflash_tier": "verified",
+    "turboquant_tier": "k8v4_verified"
   },
   "qwen3.5-27b-6bit": {
     "hf_path": "mlx-community/Qwen3.5-27B-6bit",
@@ -278,8 +280,7 @@
     "is_hybrid": true,
     "supports_spec_decode": false,
     "is_moe": true,
-    "pflash_tier": "verified",
-    "turboquant_tier": "k8v4_verified"
+    "pflash_tier": "verified"
   },
   "qwen3.6-35b-dwq": {
     "hf_path": "mlx-community/Qwen3.6-35B-A3B-4bit-DWQ",
@@ -297,8 +298,7 @@
     "reasoning_parser": "qwen3",
     "is_hybrid": true,
     "supports_spec_decode": false,
-    "is_moe": true,
-    "turboquant_tier": "k8v4_verified"
+    "is_moe": true
   },
   "qwen3.6-35b-nvfp4": {
     "hf_path": "mlx-community/Qwen3.6-35B-A3B-nvfp4",
@@ -306,8 +306,7 @@
     "reasoning_parser": "qwen3",
     "is_hybrid": true,
     "supports_spec_decode": false,
-    "is_moe": true,
-    "turboquant_tier": "k8v4_verified"
+    "is_moe": true
   },
   "deepseek-v4-flash-2bit": {
     "hf_path": "mlx-community/DeepSeek-V4-Flash-2bit-DQ",


### PR DESCRIPTION
## Summary

Batches the operator-decisions from the 2026-06-30 体感 sweep round into a single
0.9 truth-up PR. Two distinct change-types, kept in their own commits:

1. **K8V4 codec default-on flip — option B**: 9 verified Qwen3.5/3.6 aliases
   flip to ``turboquant_tier: k8v4_verified``; ``qwen3.6-35b-mxfp4`` explicitly
   excluded due to coverage failure (4/10 prompts text-diff against FP16 KV).
2. **Release-notes claim cleanup**: drop unverified or
   workload-dependent-without-caveat claims (TurboQuant V-cache "86% savings",
   DFlash marquee framing) and reframe TurboQuant as a codec with the radix
   prefix cache as an orthogonal layer (no multiplication of savings).

No version bump in this PR per repo SOP — bump-only commit is its own PR after
this merges.

## What Changed

### `vllm_mlx/aliases.json`
**K8V4 default-on (9 aliases) — operator whitelist, option B:**
- `qwen3.5-9b-{4,8}bit`         **NEW** — added `turboquant_tier: k8v4_verified`
- `qwen3.5-27b-{4,8}bit`        **NEW**
- `qwen3.5-35b-6bit`            kept
- `qwen3.6-35b-{4,6,8}bit`      kept
- `qwen3.6-35b-dwq`             kept

**K8V4 removed from default-on (5 aliases):**
- `qwen3.5-35b-{4,8}bit`        removed — not in operator whitelist
- `qwen3.6-35b-ud`              removed
- `qwen3.6-35b-mxfp4`           removed — coverage gate failure (4/10 text-diff)
- `qwen3.6-35b-nvfp4`           removed — not in whitelist

Aliases themselves stay in `aliases.json`; only the default-on tier moves.
Closed-key schema preserved — no new fields introduced.

### `tests/test_turboquant_k8v4.py`
New `test_k8v4_default_on_whitelist_matches_aliases_json` pins the exact 9-alias
default-on whitelist. Catches both directions of drift (silent additions or
silent regressions) and explicitly guards `qwen3.6-35b-mxfp4` against
re-addition. The frozenset and the JSON must move in lockstep with a
release-notes reframe — the test message states this in prose.

### `README.md` (release-notes substrate)
- TurboQuant V-cache "86% savings on dense models" → reframed as
  "K8V4 codec compresses KV to ~1/2.4 (~58% savings); lossless across the
  default-on alias matrix (mxfp4 excluded). Radix prefix cache is independent
  and saves additional bytes proportional to inter-request prefix overlap —
  the two are orthogonal and do not multiply." Touches both the features
  table and the `--kv-cache-turboquant` CLI flag-table row.
- DFlash marquee framing removed — alias-table ✨ markers, features-table
  DFlash row, "DFlash Speculative Decoding (single-user)" section, and the
  roadmap "Shipping" badge are demoted to "Experimental (`--enable-dflash`,
  `[dflash]` extra; re-validation in 0.9.x)". Code stays in tree; CLI flag
  and usage example in `docs/reference/cli.md` remain documented.

### `docs/benchmarks/llm.md`
Corrects the now-stale "ships with DFlash enabled by default (`✨` in the
alias table)" claim on the community 35B-A3B-8bit bench. The ✨ marker no
longer exists; DFlash is opt-in via the `[dflash]` extra and `--enable-dflash`.

## Test Plan

Full local pytest sweep ran green before push (10936 passed, 32 skipped,
17 deselected, 7 xfailed in 140.78s under `~/.rapid-mlx` venv after
`pip install --no-deps --force-reinstall .`). The new whitelist test is
covered by `tests/test_turboquant_k8v4.py::test_k8v4_default_on_whitelist_matches_aliases_json`
which loads `vllm_mlx/aliases.json`, collects the set of aliases with
`turboquant_tier == "k8v4_verified"`, and asserts equality against the
9-entry frozenset — failure messages name the extra and missing aliases
explicitly. The existing `TestResolveTurboquantModeDefault` suite still
exercises the resolver semantics (verified alias flips, explicit flag wins,
legacy-quantization suppresses, unknown tier preserves today behaviour).
For the release-notes / docs changes, the substrate is the README and a
benchmarks doc — no executable contract beyond markdown render correctness,
which `pr_validate` will surface if anything regresses.

## Risk Notes

- **5 aliases lose K8V4 default-on**: `qwen3.5-35b-{4,8}bit`,
  `qwen3.6-35b-{ud,nvfp4}`, and `qwen3.6-35b-mxfp4`. Operators who relied on
  the codec being auto-on for these aliases will see FP16 KV behaviour by
  default; they can opt back in via `--kv-cache-turboquant k8v4`. mxfp4
  specifically is removed because of measured lossiness (4/10 text-diff in
  the 2026-06-29 coverage round); the others fall outside the operator's
  9-alias whitelist for option B.
- **DFlash visibility cut**: existing users with `--enable-dflash` scripts
  are unaffected (flag still works, `[dflash]` extra still installs), but
  the README no longer foregrounds DFlash as a 0.9 marquee feature.
- **No code logic touched** in the codec, resolver, or CLI — this is a
  data-file + docs PR with one new test.