### PR TITLE
chore: bump version to 0.9.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.9.8"
+version = "0.9.9"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## Why
Cut rapid-mlx 0.9.9 to ship two user-facing fixes — the **gemma-4-on-18GB false-reject** (#968) and the **K8V4 tool-calling 500** (#972, regression guard for #970) — to users, including via the bundled rapid-desktop sidecar. This is the standard version bump that triggers the auto-release pipeline; the substantive code already landed + was reviewed on `main`.

## Release 0.9.9

Version bump only (one line in `pyproject.toml`). All shipped changes already landed + reviewed on `main` since 0.9.8:

| PR | Change |
| --- | --- |
| #972 | **fix(turboquant): deepcopy-safe K8V4 cache layer** — `cannot pickle 'mlx.core.Dtype'` 500 on prefix-cache hit (regression guard for #970, see below) |
| #970 | release(0.9): K8V4 default-on for 9 Qwen3.5/3.6 aliases (mxfp4 excluded), release-notes claim cleanup, coverage truthing |
| #967 | fix(glm-5.2): surgical Indexer gate for REAP-pruned DeepseekV32 |
| #968 | fix(scheduler): read modern `dtype` config key in KV-cache dtype inference (**gemma-4-on-18GB false reject**) |
| #966 | feat(runtime): surgical macOS UBC eviction helper |
| #962 | feat(turboquant): `--kv-cache-turboquant none` off-switch |
| #965 | fix(scheduler): systematic disk-KV hook fix — typos + silent-swallow guard |

### Headline user-facing fixes
- **gemma-4 on 18 GB Macs** no longer false-rejects at load (#968) — shipped to rapid-desktop users via the bundled sidecar.
- **K8V4 tool-calling 500s** (#972): #970 turned K8V4 default-on for the desktop default-tier qwen3.5-9b/27b; without #972 every prefix-cache-hit tool call (2nd+ call reusing a system/tool prefix) 500'd. Caught by the M3 gauntlet on the post-#970 code and fixed before release.

### Release validation (M3-local gauntlet on K8V4-default qwen3.5-9b-4bit)
- G5 stress 8/8 · G7 Anthropic SDK 5/5 · G7 pydantic_ai 5/6 · G6 parallel-cap PASS · G9 10-seq latency PASS (no 500s) · G8 microbench OK · `/v1/responses` 200
- Sole gauntlet red is `pydantic_ai 3_structured` — a **pre-existing**, turboquant-independent Qwen chat-template `|items` bug (filed #973), present on 0.9.8.
- CI preflight gates (G1/G3/G4/G8a/G10/G11/PF-1) on this PR. Refs #968, #970, #972; follow-ups #973, #974.