### PR TITLE
fix(turboquant): deepcopy-safe K8V4 cache layer (mx.Dtype) — 500 on prefix-cache hit

### DIFF
--- a/tests/test_turboquant_k8v4.py
+++ b/tests/test_turboquant_k8v4.py
@@ -19,6 +19,7 @@ skipped + fused gauges.
 from __future__ import annotations
 
 import argparse
+import copy
 import subprocess
 import sys
 from unittest.mock import patch
@@ -247,6 +248,61 @@ class TestK8V4Cache:
         assert k8v4.memory_bytes < v4.memory_bytes
         # And strictly positive.
         assert k8v4.memory_bytes > 0
+
+
+# ---------------------------------------------------------------------------
+# 4b. K8V4 prefix-cache deepcopy (release 0.9.9 regression guard)
+# ---------------------------------------------------------------------------
+
+
+class TestK8V4DeepcopyPrefixCache:
+    """``memory_cache`` deep-copies stored prefix-cache layers on every
+    fetch / trim so a request mutates its own copy, never the shared
+    entry. A raw ``copy.deepcopy`` of a K8V4 ``TurboQuantKVCache`` used to
+    raise ``TypeError: cannot pickle 'mlx.core.Dtype' object`` on the
+    immutable ``original_dtype`` attribute — surfaced to the user as a
+    500 on every K8V4-cached request that hit the prefix cache (the 2nd+
+    tool call reusing a system / tool-schema prefix). #970 turned K8V4
+    default-on for 9 Qwen3.5/3.6 aliases, widening the blast radius to the
+    desktop default-tier models. These pin the ``__deepcopy__`` fix.
+    """
+
+    def test_deepcopy_k8v4_layer_does_not_raise(self):
+        kv = _make_kv(head_dim=128)
+        tq = TurboQuantKVCache.from_kv_cache(kv, TurboQuantConfig(bits=4, mode="k8v4"))
+        # The attribute that used to break deepcopy.
+        assert isinstance(tq.original_dtype, mx.Dtype)
+        clone = copy.deepcopy(tq)  # must not raise
+        # Immutable dtype singleton is shared by reference (correct).
+        assert clone.original_dtype is tq.original_dtype
+
+    def test_deepcopy_clone_roundtrips_identically(self):
+        kv = _make_kv(head_dim=128)
+        tq = TurboQuantKVCache.from_kv_cache(kv, TurboQuantConfig(bits=4, mode="k8v4"))
+        clone = copy.deepcopy(tq)
+        assert clone is not tq
+        # Arrays survived the copy intact: the clone decompresses to the
+        # exact same KV as the original.
+        orig_restored = tq.to_kv_cache()
+        clone_restored = clone.to_kv_cache()
+        np.testing.assert_array_equal(
+            np.array(clone_restored.keys), np.array(orig_restored.keys)
+        )
+        np.testing.assert_array_equal(
+            np.array(clone_restored.values), np.array(orig_restored.values)
+        )
+
+    def test_deepcopy_layer_list_matches_memory_cache_fetch(self):
+        # memory_cache fetches via ``copy.deepcopy(entry.cache)`` where
+        # ``entry.cache`` is the per-layer list — exercise that exact shape.
+        kv = _make_kv(head_dim=128)
+        layers = [
+            TurboQuantKVCache.from_kv_cache(kv, TurboQuantConfig(bits=4, mode="k8v4"))
+            for _ in range(3)
+        ]
+        cloned = copy.deepcopy(layers)  # must not raise
+        assert len(cloned) == 3
+        assert all(isinstance(c.original_dtype, mx.Dtype) for c in cloned)
 
 
 # ---------------------------------------------------------------------------

--- a/vllm_mlx/turboquant.py
+++ b/vllm_mlx/turboquant.py
@@ -39,6 +39,7 @@ Usage::
 
 from __future__ import annotations
 
+import copy
 import logging
 import math
 import re
@@ -756,6 +757,32 @@ class TurboQuantKVCache:
         # bf16 models pay a ~46% decode-throughput tax if the cache is
         # handed back as fp16. ``None`` preserves the legacy fp16 contract.
         self.original_dtype = original_dtype
+
+    def __deepcopy__(self, memo):
+        """Deep-copy that tolerates the immutable ``mx.Dtype`` attribute.
+
+        ``memory_cache`` deep-copies stored prefix-cache layers on every
+        fetch / trim so a request mutates its own copy, never the shared
+        entry. ``copy.deepcopy`` cannot pickle ``mlx.core.Dtype`` (an
+        immutable C value type), so a raw deepcopy of a K8V4
+        ``TurboQuantKVCache`` — whose ``original_dtype`` holds one —
+        raised ``TypeError: cannot pickle 'mlx.core.Dtype' object``. That
+        surfaced to the user as a 500 on every K8V4-cached request that
+        hit the prefix cache (e.g. the 2nd+ tool call reusing a system /
+        tool-schema prefix). ``mx.Dtype`` is a singleton value, so
+        sharing the reference across copies is correct; every other
+        attribute (the packed arrays, config, offsets) is deep-copied as
+        before so the returned layer stays independent of the cached one.
+        """
+        cls = self.__class__
+        new = cls.__new__(cls)
+        memo[id(self)] = new
+        for key, value in self.__dict__.items():
+            if isinstance(value, mx.Dtype):
+                new.__dict__[key] = value
+            else:
+                new.__dict__[key] = copy.deepcopy(value, memo)
+        return new
 
     @property
     def mode(self) -> str:


### PR DESCRIPTION
## Symptom
Every K8V4-cached request that hits the **prefix cache** (e.g. the 2nd+ tool call reusing a system / tool-schema prefix) returns **500 Internal Server Error**:

```
TypeError: cannot pickle 'mlx.core.Dtype' object
  ...
  vllm_mlx/memory_cache.py, in _fetch_locked: copy.deepcopy(best_match.cache)
  vllm_mlx/turboquant.py: TurboQuantKVCache.original_dtype  (an mx.Dtype)
```

`memory_cache` deep-copies stored prefix-cache layers on every fetch / trim so a request mutates its own copy, never the shared entry. `mlx.core.Dtype` is an immutable C value type `copy.deepcopy` cannot pickle, so a raw deepcopy of a K8V4 `TurboQuantKVCache` (whose `original_dtype` holds one) blows up. Regular `KVCache` layers carry no `mx.Dtype`, so non-turboquant models were unaffected.

## Why now
**#970** turned K8V4 default-on for 9 Qwen3.5/3.6 aliases — including the desktop default-tier **qwen3.5-9b / 27b** — widening the blast radius from the already-K8V4 35B family to the most common chat models. The release gauntlet model (`qwen3.5-9b-4bit`) was previously non-K8V4, so it never exercised this path.

## Repro / isolation (pydantic_ai integration suite)
| | K8V4 default | `--kv-cache-turboquant none` |
|---|---|---|
| `4_tool_single` | **500 → PASS (after fix)** | PASS |
| `6_multi_tool`  | **500 → PASS (after fix)** | PASS |

Identical no-turboquant runs already passed → isolates K8V4 as the cause.

## Fix
`TurboQuantKVCache.__deepcopy__` shares the immutable `mx.Dtype` singleton by reference (correct — it's a value type) and deep-copies every other attribute as before, so the returned layer stays independent of the cached one. Keyed on `isinstance(value, mx.Dtype)` so a future rename / second dtype field stays covered.

## Tests
`TestK8V4DeepcopyPrefixCache` pins: (1) deepcopy of a K8V4 layer no longer raises + shares the dtype singleton, (2) the clone decompresses bit-identically to the original (arrays survived), (3) deepcopy of the per-layer list — the exact shape `memory_cache` copies — is clean.

> Note: `3_structured` in the same suite still 500s — a **separate, pre-existing** jinja chat-template `.items()` bug (turboquant-independent, present on 0.9.8; `chat_template.py` untouched by 0.9.9). Filed separately.