### PR TITLE
fix(qwen3_coder_xml): anchor streaming on <function=…>, not <tool_call> wrapper

### DIFF
--- a/tests/test_qwen3coder_bare_wrapper_streaming.py
+++ b/tests/test_qwen3coder_bare_wrapper_streaming.py
@@ -244,6 +244,92 @@ def test_wrapped_streaming_still_works():
         )
 
 
+def test_function_prefix_in_parameter_value_not_counted_as_tool_boundary():
+    """Unit test on ``_function_start_positions``: a ``<function=``
+    substring inside a ``<parameter=…>…</parameter>`` value MUST NOT
+    count as a top-level tool boundary.
+
+    Codex adversarial review on this PR flagged the naive ``str.find``
+    variant as a corruption vector: with it, streaming would advance
+    ``current_tool_index`` mid-argument and either miss trailing
+    content or emit a phantom second tool call. The fix scans
+    top-level occurrences by skipping past parameter-value spans.
+    """
+    parser = Qwen3CoderToolParser(tokenizer=None)
+
+    text = (
+        "<function=echo>"
+        "<parameter=text>call <function=inner> in a code snippet</parameter>"
+        "</function>"
+    )
+    starts = parser._function_start_positions(text)
+    assert starts == [0], (
+        f"top-level ``<function=`` scanner miscounted: expected [0], got {starts!r}"
+    )
+
+
+def test_function_end_in_parameter_value_not_counted_as_tool_close():
+    """Unit test on ``_top_level_function_close_count``: a
+    ``</function>`` substring inside a parameter value MUST NOT count
+    as a structural tool close.
+
+    Same codex concern as above, applied to the ``</function>`` counter
+    that drives ``current_tool_index`` advancement.
+    """
+    parser = Qwen3CoderToolParser(tokenizer=None)
+
+    text = "<function=echo><parameter=code>foo</function>bar</parameter></function>"
+    starts = parser._function_start_positions(text)
+    close_count = parser._top_level_function_close_count(text, starts)
+    assert close_count == 1, (
+        f"top-level ``</function>`` scanner miscounted: expected 1, "
+        f"got {close_count}. starts={starts!r}"
+    )
+
+
+def test_streaming_state_not_corrupted_by_function_prefix_in_value():
+    """End-to-end: even when a parameter value carries a full inner
+    ``<function=inner></function>`` block, the state machine MUST emit
+    exactly ONE tool call — not a phantom second call anchored on the
+    inner literal, and not a stalled advance that swallows trailing
+    content.
+
+    This is the exact regression codex round-1 caught: with the naive
+    ``count(<function=)`` and ``count(</function>)`` the advance block
+    would try to promote the inner literal to a real tool_call.
+    """
+    parser = Qwen3CoderToolParser(tokenizer=None)
+    request = _request_with_tool("echo", {"note": {"type": "string"}})
+
+    chunks = [
+        "<function=echo>",
+        "<parameter=note>",
+        # Full inner XML — the naive scanner would see 2 openers and 2
+        # closers here and try to advance mid-argument.
+        "see also <function=inner></function> below",
+        "</parameter>",
+        "</function>",
+        # Trailing content after the real tool closes — the naive
+        # scanner would still think ``is_tool_call_started`` is True
+        # and try to slice a phantom second block instead of emitting
+        # this as a content event.
+        " done.",
+    ]
+
+    deltas = _feed(parser, chunks, request)
+    names = _names_by_index(deltas)
+    assert set(names.keys()) == {0}, (
+        f"phantom tool index emitted; names={names!r}, deltas={deltas!r}"
+    )
+    assert names[0] == "echo"
+    # Trailing content after the real tool close must reach the
+    # content stream, not vanish into a phantom advance.
+    contents = _content_events(deltas)
+    assert any("done" in c for c in contents), (
+        f"trailing content swallowed by phantom advance; contents={contents!r}"
+    )
+
+
 def test_content_before_bare_function_is_emitted_as_content():
     """Prose before a bare ``<function=`` opener must surface as a ``content``
     delta — not be swallowed and not be miscategorized as tool_call payload.

--- a/tests/test_qwen3coder_bare_wrapper_streaming.py
+++ b/tests/test_qwen3coder_bare_wrapper_streaming.py
@@ -1,0 +1,279 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Streaming parity for ``Qwen3CoderToolParser`` when the model output does
+NOT carry the ``<tool_call>`` wrapper token.
+
+Closes issue #978. Repro: ``Shiftedx/qwopus3.6-35b-a3b-coder-mxfp4-mlx``
+tokenizer lacks ``<|tool_call|>`` / ``<tool_call>`` as a special token, so
+the model reliably emits well-formed ``<function=NAME>...</function>``
+XML *without* the wrapper. The non-streaming ``extract_tool_calls`` path
+already handles both shapes (it triggers on the ``<function=`` prefix);
+the streaming path used to anchor on ``<tool_call>`` and therefore never
+fired for wrapper-less output — Claude Code (which always streams) then
+saw the entire tool call as raw assistant content.
+
+The four tests below pin the invariant:
+
+* ``test_bare_function_block_streams_as_tool_call`` — the failing case
+  from the issue: no ``<tool_call>`` wrapper, chunked incrementally,
+  must emit a ``tool_calls`` delta with the correct name + arguments
+  BEFORE the stream ends.
+* ``test_bare_multi_function_blocks_stream_both_calls`` — two bare
+  ``<function=...>...</function>`` blocks back-to-back must emit both
+  as separate ``tool_calls`` deltas with distinct indices.
+* ``test_wrapped_streaming_still_works`` — regression guard: the native
+  ``<tool_call><function=...>...</function></tool_call>`` shape MUST
+  continue to stream correctly (this is what would break if the fix
+  went ad-hoc and swapped one anchor for the other).
+* ``test_content_before_bare_function_is_emitted_as_content`` — prose
+  before a bare ``<function=`` opener must surface as a ``content``
+  delta, not be swallowed or misclassified as tool_call payload.
+"""
+
+from __future__ import annotations
+
+import json
+
+from vllm_mlx.tool_parsers.qwen3coder_tool_parser import Qwen3CoderToolParser
+
+
+def _request_with_tool(name: str, properties: dict) -> dict:
+    return {
+        "tools": [
+            {
+                "type": "function",
+                "function": {
+                    "name": name,
+                    "parameters": {"type": "object", "properties": properties},
+                },
+            }
+        ]
+    }
+
+
+def _feed(parser: Qwen3CoderToolParser, chunks: list[str], request: dict | None):
+    parser.reset()
+    deltas: list[dict] = []
+    previous = ""
+    for chunk in chunks:
+        if not chunk:
+            continue
+        current = previous + chunk
+        delta = parser.extract_tool_calls_streaming(
+            previous_text=previous,
+            current_text=current,
+            delta_text=chunk,
+            request=request,
+        )
+        if delta is not None:
+            deltas.append(delta)
+        previous = current
+    return deltas
+
+
+def _argument_fragments_for_index(deltas: list[dict], index: int) -> list[str]:
+    """Flatten ``function.arguments`` strings for a specific tool call index."""
+    out: list[str] = []
+    for d in deltas:
+        for tc in d.get("tool_calls") or []:
+            if tc.get("index") != index:
+                continue
+            fn = tc.get("function") or {}
+            args = fn.get("arguments")
+            if args:
+                out.append(args)
+    return out
+
+
+def _names_by_index(deltas: list[dict]) -> dict[int, str]:
+    """Collect tool call name assigned per index (header emit)."""
+    seen: dict[int, str] = {}
+    for d in deltas:
+        for tc in d.get("tool_calls") or []:
+            fn = tc.get("function") or {}
+            name = fn.get("name")
+            if name and tc.get("index") not in seen:
+                seen[tc.get("index")] = name
+    return seen
+
+
+def _content_events(deltas: list[dict]) -> list[str]:
+    return [d["content"] for d in deltas if "content" in d]
+
+
+def test_bare_function_block_streams_as_tool_call():
+    """The exact failing case from #978: bare ``<function=...>...</function>``
+    with NO ``<tool_call>`` wrapper streamed incrementally must emit a
+    ``tool_calls`` delta with the correct name and JSON-valid arguments.
+    """
+    parser = Qwen3CoderToolParser(tokenizer=None)
+    request = _request_with_tool("read_file", {"path": {"type": "string"}})
+
+    chunks = [
+        "<function=read_file>\n",
+        "<parameter=path>\n",
+        "/src/main.py",
+        "\n</parameter>\n",
+        "</function>",
+    ]
+
+    deltas = _feed(parser, chunks, request)
+
+    names = _names_by_index(deltas)
+    assert names.get(0) == "read_file", (
+        f"bare <function=…> stream never emitted a tool_calls header; "
+        f"names={names!r}, deltas={deltas!r}"
+    )
+
+    fragments = _argument_fragments_for_index(deltas, 0)
+    # Exclude the header emit (empty arguments) so we count only body deltas.
+    body_fragments = [f for f in fragments if f != ""]
+    combined = "".join(body_fragments)
+    decoded = json.loads(combined)
+    assert decoded == {"path": "/src/main.py"}, (
+        f"bare-wrapper arguments did not stream correctly. "
+        f"combined={combined!r}, decoded={decoded!r}"
+    )
+
+    # No content event should have leaked the raw tool-call markup.
+    for text in _content_events(deltas):
+        assert "<function=" not in text, (
+            f"bare tool-call markup leaked as content: {text!r}"
+        )
+        assert "</function>" not in text, (
+            f"bare tool-call markup leaked as content: {text!r}"
+        )
+        assert "<parameter=" not in text, (
+            f"bare tool-call markup leaked as content: {text!r}"
+        )
+
+
+def test_bare_multi_function_blocks_stream_both_calls():
+    """Two bare ``<function=A>...</function><function=B>...</function>`` blocks
+    back-to-back must emit BOTH as tool_calls with distinct indices."""
+    parser = Qwen3CoderToolParser(tokenizer=None)
+    request = {
+        "tools": [
+            {
+                "type": "function",
+                "function": {
+                    "name": "read_file",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"path": {"type": "string"}},
+                    },
+                },
+            },
+            {
+                "type": "function",
+                "function": {
+                    "name": "write_file",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "path": {"type": "string"},
+                            "content": {"type": "string"},
+                        },
+                    },
+                },
+            },
+        ]
+    }
+
+    chunks = [
+        "<function=read_file>",
+        "<parameter=path>/a.py</parameter>",
+        "</function>",
+        "\n",
+        "<function=write_file>",
+        "<parameter=path>/b.py</parameter>",
+        "<parameter=content>hello</parameter>",
+        "</function>",
+    ]
+
+    deltas = _feed(parser, chunks, request)
+
+    names = _names_by_index(deltas)
+    assert names.get(0) == "read_file", f"tool index 0 must be read_file, got {names!r}"
+    assert names.get(1) == "write_file", (
+        f"tool index 1 must be write_file, got {names!r}"
+    )
+
+    args_0 = json.loads("".join(_argument_fragments_for_index(deltas, 0)))
+    args_1 = json.loads("".join(_argument_fragments_for_index(deltas, 1)))
+    assert args_0 == {"path": "/a.py"}, args_0
+    assert args_1 == {"path": "/b.py", "content": "hello"}, args_1
+
+
+def test_wrapped_streaming_still_works():
+    """Regression guard: the native ``<tool_call><function=…>…</function>
+    </tool_call>`` shape MUST continue to stream correctly. This is what
+    breaks if the bare-wrapper fix goes ad-hoc and merely swaps anchors
+    instead of unifying detection.
+    """
+    parser = Qwen3CoderToolParser(tokenizer=None)
+    request = _request_with_tool("read_file", {"path": {"type": "string"}})
+
+    chunks = [
+        "<tool_call>\n",
+        "<function=read_file>\n",
+        "<parameter=path>\n",
+        "/src/main.py",
+        "\n</parameter>\n",
+        "</function>\n",
+        "</tool_call>",
+    ]
+
+    deltas = _feed(parser, chunks, request)
+
+    names = _names_by_index(deltas)
+    assert names.get(0) == "read_file", names
+
+    fragments = _argument_fragments_for_index(deltas, 0)
+    combined = "".join(f for f in fragments if f != "")
+    decoded = json.loads(combined)
+    assert decoded == {"path": "/src/main.py"}, (
+        f"wrapped-mode regression: expected {{'path': '/src/main.py'}}, got {decoded!r}"
+    )
+
+    for text in _content_events(deltas):
+        assert "<tool_call>" not in text, (
+            f"wrapped tool-call markup leaked as content: {text!r}"
+        )
+        assert "<function=" not in text, (
+            f"wrapped tool-call markup leaked as content: {text!r}"
+        )
+
+
+def test_content_before_bare_function_is_emitted_as_content():
+    """Prose before a bare ``<function=`` opener must surface as a ``content``
+    delta — not be swallowed and not be miscategorized as tool_call payload.
+    Mirrors the wrapped-mode behavior that already extracts prose before
+    ``<tool_call>``.
+    """
+    parser = Qwen3CoderToolParser(tokenizer=None)
+    request = _request_with_tool("read_file", {"path": {"type": "string"}})
+
+    # Fine-grained chunking so the streaming state machine has enough
+    # deltas to reach the params-loop after (a) emitting content-before,
+    # (b) parsing the header, and (c) emitting the JSON opener ``{``.
+    # This mirrors the per-token deltas real streams deliver.
+    chunks = [
+        "Let me read that file. ",
+        "<function=read_file>",
+        "<parameter=path>",
+        "/src/main.py",
+        "</parameter>",
+        "</function>",
+    ]
+
+    deltas = _feed(parser, chunks, request)
+
+    contents = _content_events(deltas)
+    assert any("Let me read that file. " in c for c in contents), (
+        f"prose before <function=…> was dropped. contents={contents!r}"
+    )
+    # And the tool call still fired.
+    names = _names_by_index(deltas)
+    assert names.get(0) == "read_file", names
+    combined = "".join(f for f in _argument_fragments_for_index(deltas, 0) if f != "")
+    assert json.loads(combined) == {"path": "/src/main.py"}

--- a/vllm_mlx/tool_parsers/qwen3coder_tool_parser.py
+++ b/vllm_mlx/tool_parsers/qwen3coder_tool_parser.py
@@ -359,22 +359,98 @@ class Qwen3CoderToolParser(ToolParser):
             or self.tool_call_prefix in delta_text
         )
 
-    def _function_start_positions(self, text: str) -> list[int]:
-        """All top-level ``<function=`` positions in ``text``, in order.
+    def _top_level_function_close(self, text: str, start: int) -> int:
+        """Return the position of the top-level ``</function>`` that closes
+        the tool opened at ``start`` — i.e. the first ``</function>`` after
+        ``start`` that is NOT inside a ``<parameter=…>…</parameter>`` value.
 
-        Each position marks the start of a tool-call block; the state
-        machine uses this list to slice the current block and to decide
-        when to advance the tool index. Independent of whether the model
-        wrapped the block in ``<tool_call>...</tool_call>``.
+        Returns ``-1`` when the tool hasn't closed yet in the buffer. A
+        ``</function>`` embedded in a user's ``code`` parameter (XML
+        code samples are the canonical example) MUST NOT be treated as
+        the tool boundary; otherwise streaming truncates mid-argument
+        (codex review on #978).
+        """
+        prefix_len = len(self.tool_call_prefix)
+        param_open_len = len(self.parameter_prefix)
+        param_close_len = len(self.parameter_end_token)
+        j = start + prefix_len
+        n = len(text)
+        while j < n:
+            next_param = text.find(self.parameter_prefix, j)
+            next_close = text.find(self.function_end_token, j)
+            if next_close == -1:
+                return -1
+            if next_param != -1 and next_param < next_close:
+                header_end = text.find(">", next_param + param_open_len)
+                if header_end == -1:
+                    return -1
+                pclose = text.find(self.parameter_end_token, header_end + 1)
+                if pclose == -1:
+                    return -1
+                j = pclose + param_close_len
+                continue
+            return next_close
+        return -1
+
+    def _top_level_function_close_count(
+        self, text: str, top_level_starts: list[int]
+    ) -> int:
+        """Count ``</function>`` tokens that structurally close a top-level
+        ``<function=…>`` opener from ``top_level_starts``.
+
+        Uses ``_top_level_function_close`` per start so a ``</function>``
+        inside a ``<parameter=…>…</parameter>`` value (e.g. a user's
+        ``code`` argument containing XML) never counts as a tool close.
+        """
+        return sum(
+            1
+            for start in top_level_starts
+            if self._top_level_function_close(text, start) != -1
+        )
+
+    def _function_start_positions(self, text: str) -> list[int]:
+        """Positions of TOP-LEVEL ``<function=`` openers in ``text``.
+
+        Skips ``<function=`` substrings that appear inside a
+        ``<parameter=…>…</parameter>`` value — those are user data (e.g.
+        a ``code`` parameter containing XML), not structural tool-call
+        boundaries. Function tags don't nest in Qwen3-Coder XML, so a
+        top-level scan alternates between (a) looking for the next
+        function opener while skipping parameter-value spans and (b)
+        recording found openers. Both the tool-index slicing AND the
+        "any more tools?" counter rely on this — using a naive
+        ``str.count(...)`` for either would let a bogus in-value
+        ``<function=…>`` corrupt streaming state (codex review on #978).
+
+        Incomplete parameter tails (opener without matching
+        ``</parameter>``) terminate the scan: everything after an
+        unclosed value is potentially user data, so we conservatively
+        refuse to promote further ``<function=`` occurrences until the
+        value closes.
         """
         positions: list[int] = []
-        idx = 0
-        while True:
-            idx = text.find(self.tool_call_prefix, idx)
-            if idx == -1:
+        i = 0
+        n = len(text)
+        prefix_len = len(self.tool_call_prefix)
+        param_open_len = len(self.parameter_prefix)
+        param_close_len = len(self.parameter_end_token)
+        while i < n:
+            next_func = text.find(self.tool_call_prefix, i)
+            next_param = text.find(self.parameter_prefix, i)
+            if next_func == -1:
                 return positions
-            positions.append(idx)
-            idx += len(self.tool_call_prefix)
+            if next_param != -1 and next_param < next_func:
+                header_end = text.find(">", next_param + param_open_len)
+                if header_end == -1:
+                    return positions
+                close_pos = text.find(self.parameter_end_token, header_end + 1)
+                if close_pos == -1:
+                    return positions
+                i = close_pos + param_close_len
+                continue
+            positions.append(next_func)
+            i = next_func + prefix_len
+        return positions
 
     def extract_tool_calls_streaming(
         self,
@@ -400,9 +476,18 @@ class Qwen3CoderToolParser(ToolParser):
 
         # Check if we need to advance to next tool. The tool boundary is
         # ``</function>`` — that is the invariant close, whether or not
-        # a wrapping ``</tool_call>`` follows.
+        # a wrapping ``</tool_call>`` follows. Both the close-count and
+        # the "any more tools?" check must ignore ``<function=`` /
+        # ``</function>`` substrings inside parameter values — a
+        # ``code`` parameter carrying XML code would otherwise trip the
+        # advance loop into targeting a bogus next block (codex review
+        # on #978).
         if self.json_closed and not self.in_function:
-            tool_ends = current_text.count(self.function_end_token)
+            top_level_starts = self._function_start_positions(current_text)
+            tool_count = len(top_level_starts)
+            tool_ends = self._top_level_function_close_count(
+                current_text, top_level_starts
+            )
             if tool_ends > self.current_tool_index:
                 self.current_tool_index += 1
                 self.header_sent = False
@@ -410,7 +495,7 @@ class Qwen3CoderToolParser(ToolParser):
                 self.json_started = False
                 self.json_closed = False
                 self.accumulated_params = {}
-                if self.current_tool_index >= current_text.count(self.tool_call_prefix):
+                if self.current_tool_index >= tool_count:
                     self.is_tool_call_started = False
                 return None
 
@@ -443,14 +528,17 @@ class Qwen3CoderToolParser(ToolParser):
                 return {"content": delta_text}
 
         # Find current tool call portion. Slice from the current
-        # ``<function=`` opener to the matching ``</function>`` close —
-        # this is the wrapper-agnostic tool-call block.
+        # ``<function=`` opener to the matching top-level ``</function>``
+        # close — this is the wrapper-agnostic tool-call block. Both
+        # ends use the parameter-aware scanners so a user-visible
+        # ``<function=…>`` OR ``</function>`` embedded in a parameter
+        # value can't corrupt the slice.
         function_starts = self._function_start_positions(current_text)
         if self.current_tool_index >= len(function_starts):
             return None
 
         tool_start_idx = function_starts[self.current_tool_index]
-        func_close_idx = current_text.find(self.function_end_token, tool_start_idx)
+        func_close_idx = self._top_level_function_close(current_text, tool_start_idx)
         if func_close_idx == -1:
             tool_text = current_text[tool_start_idx:]
         else:

--- a/vllm_mlx/tool_parsers/qwen3coder_tool_parser.py
+++ b/vllm_mlx/tool_parsers/qwen3coder_tool_parser.py
@@ -5,11 +5,20 @@ Qwen3-Coder XML tool call parser for rapid-mlx.
 Ported from vLLM upstream (vllm/tool_parsers/qwen3coder_tool_parser.py).
 
 Format:
-  <tool_call>
-  <function=NAME>
+  <tool_call>                           <- optional wrapper (framing only)
+  <function=NAME>                       <- REQUIRED, defines the tool call
   <parameter=KEY>VALUE</parameter>
-  </function>
-  </tool_call>
+  </function>                           <- REQUIRED
+  </tool_call>                          <- optional wrapper (framing only)
+
+The ``<tool_call>...</tool_call>`` wrapper is OPTIONAL framing. What
+structurally defines a tool call is the ``<function=NAME>...</function>``
+XML block — so the streaming state machine anchors on ``<function=``
+throughout and treats the wrapper as a prefix to strip from content
+(issue #978). Anchoring on the wrapper would leak whole tool calls as
+raw content when a fine-tune's tokenizer omits the wrapper as a special
+token but the model still emits well-formed ``<function=...>`` bodies
+(observed with ``Shiftedx/qwopus3.6-35b-a3b-coder-mxfp4-mlx``).
 
 Similar to Seed-OSS but without the seed: namespace prefix.
 """
@@ -304,6 +313,69 @@ class Qwen3CoderToolParser(ToolParser):
                 tools_called=False, tool_calls=[], content=model_output
             )
 
+    # --- streaming helpers -----------------------------------------------
+    #
+    # The streaming state machine is anchored on the ``<function=`` /
+    # ``</function>`` pair, NOT on the optional ``<tool_call>`` wrapper.
+    # These helpers make that decoupling explicit so the wrapper token
+    # only appears in the content-before strip logic (where it must, to
+    # avoid emitting wrapper framing as user-visible content).
+
+    def _first_opener_pos(self, text: str) -> int:
+        """Position of the earliest tool-call framing character in ``text``.
+
+        A tool call may be introduced by either the ``<tool_call>`` wrapper
+        or the bare ``<function=`` prefix; both must be stripped from any
+        content emitted before the call. Returns ``len(text)`` when no
+        opener is present so callers can use it as an unconditional slice
+        endpoint.
+        """
+        tc = text.find(self.tool_call_start_token)
+        fn = text.find(self.tool_call_prefix)
+        if tc == -1 and fn == -1:
+            return len(text)
+        if tc == -1:
+            return fn
+        if fn == -1:
+            return tc
+        return min(tc, fn)
+
+    def _has_new_opener(self, delta_text: str, delta_token_ids: Sequence[int]) -> bool:
+        """True when this delta introduces the first-ever tool-call opener.
+
+        Accepts the wrapper token via string OR token-id (tokenizers that
+        expose ``<tool_call>`` as a special token), and the bare
+        ``<function=`` prefix via string. The two openers are equivalent
+        as far as the state machine is concerned — either triggers the
+        transition out of content-only mode.
+        """
+        if (
+            self.tool_call_start_token_id is not None
+            and self.tool_call_start_token_id in delta_token_ids
+        ):
+            return True
+        return (
+            self.tool_call_start_token in delta_text
+            or self.tool_call_prefix in delta_text
+        )
+
+    def _function_start_positions(self, text: str) -> list[int]:
+        """All top-level ``<function=`` positions in ``text``, in order.
+
+        Each position marks the start of a tool-call block; the state
+        machine uses this list to slice the current block and to decide
+        when to advance the tool index. Independent of whether the model
+        wrapped the block in ``<tool_call>...</tool_call>``.
+        """
+        positions: list[int] = []
+        idx = 0
+        while True:
+            idx = text.find(self.tool_call_prefix, idx)
+            if idx == -1:
+                return positions
+            positions.append(idx)
+            idx += len(self.tool_call_prefix)
+
     def extract_tool_calls_streaming(
         self,
         previous_text: str,
@@ -326,9 +398,11 @@ class Qwen3CoderToolParser(ToolParser):
         delta_token_ids = delta_token_ids or []
         self.accumulated_text = current_text
 
-        # Check if we need to advance to next tool
+        # Check if we need to advance to next tool. The tool boundary is
+        # ``</function>`` — that is the invariant close, whether or not
+        # a wrapping ``</tool_call>`` follows.
         if self.json_closed and not self.in_function:
-            tool_ends = current_text.count(self.tool_call_end_token)
+            tool_ends = current_text.count(self.function_end_token)
             if tool_ends > self.current_tool_index:
                 self.current_tool_index += 1
                 self.header_sent = False
@@ -336,59 +410,52 @@ class Qwen3CoderToolParser(ToolParser):
                 self.json_started = False
                 self.json_closed = False
                 self.accumulated_params = {}
-                if self.current_tool_index >= current_text.count(
-                    self.tool_call_start_token
-                ):
+                if self.current_tool_index >= current_text.count(self.tool_call_prefix):
                     self.is_tool_call_started = False
                 return None
 
-        # Handle content before tool calls
+        # Handle content before tool calls. Either opener (wrapper or bare
+        # ``<function=``) transitions us out of content-only mode; the
+        # content-before-strip position is whichever opener appears first
+        # in ``delta_text`` so wrapper framing never leaks to the client.
         if not self.is_tool_call_started:
-            if (
-                self.tool_call_start_token_id is not None
-                and self.tool_call_start_token_id in delta_token_ids
-            ) or self.tool_call_start_token in delta_text:
+            if self._has_new_opener(delta_text, delta_token_ids):
                 self.is_tool_call_started = True
-                if self.tool_call_start_token in delta_text:
-                    content_before = delta_text[
-                        : delta_text.index(self.tool_call_start_token)
-                    ]
-                    if content_before:
-                        return {"content": content_before}
+                opener_pos = self._first_opener_pos(delta_text)
+                content_before = (
+                    delta_text[:opener_pos] if opener_pos < len(delta_text) else ""
+                )
+                if content_before:
+                    return {"content": content_before}
                 # Fall through to header parsing below instead of returning
                 # None — the function header may already be in current_text.
             else:
-                if (
-                    current_text.rstrip().endswith(self.tool_call_end_token)
-                    and delta_text.strip() == ""
+                # Suppress the trailing-wrapper-close whitespace event so
+                # a stream that ends with just ``</tool_call>\n`` doesn't
+                # emit an empty tail. ``</function>`` is the actual tool
+                # close; ``</tool_call>`` may follow as optional framing.
+                trailing = current_text.rstrip()
+                if delta_text.strip() == "" and (
+                    trailing.endswith(self.tool_call_end_token)
+                    or trailing.endswith(self.function_end_token)
                 ):
                     return None
                 return {"content": delta_text}
 
-        # Find current tool call portion
-        tool_starts_count = current_text.count(self.tool_call_start_token)
-        if self.current_tool_index >= tool_starts_count:
+        # Find current tool call portion. Slice from the current
+        # ``<function=`` opener to the matching ``</function>`` close —
+        # this is the wrapper-agnostic tool-call block.
+        function_starts = self._function_start_positions(current_text)
+        if self.current_tool_index >= len(function_starts):
             return None
 
-        tool_start_positions: list[int] = []
-        idx = 0
-        while True:
-            idx = current_text.find(self.tool_call_start_token, idx)
-            if idx == -1:
-                break
-            tool_start_positions.append(idx)
-            idx += len(self.tool_call_start_token)
-
-        if self.current_tool_index >= len(tool_start_positions):
-            return None
-
-        tool_start_idx = tool_start_positions[self.current_tool_index]
-        tool_end_idx = current_text.find(self.tool_call_end_token, tool_start_idx)
-        if tool_end_idx == -1:
+        tool_start_idx = function_starts[self.current_tool_index]
+        func_close_idx = current_text.find(self.function_end_token, tool_start_idx)
+        if func_close_idx == -1:
             tool_text = current_text[tool_start_idx:]
         else:
             tool_text = current_text[
-                tool_start_idx : tool_end_idx + len(self.tool_call_end_token)
+                tool_start_idx : func_close_idx + len(self.function_end_token)
             ]
 
         # Parse function header


### PR DESCRIPTION
Closes #978.

## Reproduction (from issue)

Model: `Shiftedx/qwopus3.6-35b-a3b-coder-mxfp4-mlx`. Tokenizer lacks
`<|tool_call|>` / `<tool_call>` as a special token. In streaming mode,
correctly-formed tool calls leaked into assistant content as raw
`<function=…</function>` text instead of being emitted as `tool_call`
events. Non-streaming worked (lenient `extract_tool_calls` scans for
`<function=`); streaming didn't (anchored on `<tool_call>`). Claude
Code always streams, so users hit this every request.

New test file `tests/test_qwen3coder_bare_wrapper_streaming.py` pins
the failing case:

```
$ pytest tests/test_qwen3coder_bare_wrapper_streaming.py -v
tests/test_qwen3coder_bare_wrapper_streaming.py::test_bare_function_block_streams_as_tool_call PASSED
tests/test_qwen3coder_bare_wrapper_streaming.py::test_bare_multi_function_blocks_stream_both_calls PASSED
tests/test_qwen3coder_bare_wrapper_streaming.py::test_wrapped_streaming_still_works PASSED
tests/test_qwen3coder_bare_wrapper_streaming.py::test_content_before_bare_function_is_emitted_as_content PASSED
```

## Root cause

`Qwen3CoderToolParser.extract_tool_calls_streaming` was gated on
`self.tool_call_start_token = "<tool_call>"` in two places:

1. Opener detection (`is_tool_call_started` transition) — bare
   `<function=…>` never flipped the flag.
2. Tool-block slicing (`tool_start_positions` used `<tool_call>`
   positions, `tool_end_idx` used `</tool_call>`) — even after
   detection, the parser couldn't locate the block boundaries in
   wrapper-less output.

## Design decision (systematic vs. ad-hoc)

The reporter's proposed fix "trigger on `<function=` when `<|tool_call|>`
is absent" branches on tokenizer capabilities. That's an ad-hoc
symptomatic patch and would leave the same class of bug open for any
future fine-tune that omits the wrapper for other reasons.

The invariant is structural: **what defines a tool call is the
`<function=NAME>…</function>` XML block. The `<tool_call>…</tool_call>`
wrapper is OPTIONAL framing.** The non-streaming path already treats
it that way (it looks for `<function=`). This PR aligns the streaming
path with the same invariant:

- `_function_start_positions` returns every top-level `<function=`
  position — this is now the source-of-truth for both "current tool
  index" and per-block slicing (`tool_text`).
- Advancement counts `</function>` (the invariant close), not
  `</tool_call>` (optional close).
- `_has_new_opener` accepts either opener; the special-token-id fast
  path is preserved so tokenizers that DO expose `<tool_call>` benefit.
- `_first_opener_pos` picks whichever opener appears first in a delta
  so wrapper framing is stripped from content-before, in both wrapped
  and bare modes.

No tokenizer-capability branch. No regex tweak. One state machine,
one invariant, both shapes fall out.

## Test coverage

New file `tests/test_qwen3coder_bare_wrapper_streaming.py` (4 tests):

- `test_bare_function_block_streams_as_tool_call` — the failing case
  from #978.
- `test_bare_multi_function_blocks_stream_both_calls` — two
  back-to-back bare blocks emit distinct indices.
- `test_wrapped_streaming_still_works` — regression guard for the
  native wrapped shape (this is what breaks if the fix goes ad-hoc
  and merely swaps anchors).
- `test_content_before_bare_function_is_emitted_as_content` — prose
  before a bare `<function=` opener surfaces as `content`, not
  tool-call payload.

Existing coverage held:

- `tests/test_qwen3coder_tool_parser_streaming.py` — 9/9 pass
  (incremental long-string, close-tag tail-buffer, mixed-param
  parity, same-chunk close+trailing, truncation).
- `tests/test_tool_parsers.py` — 156/156 pass.
- `tests/test_tool_parser_wire_formats.py`,
  `tests/test_tool_call_streaming_parity.py`,
  `tests/test_chat_route_forced_tool_prefix.py`,
  `tests/test_chat_route_tool_choice_enforcement.py`,
  `tests/test_upstream_regression.py` — all pass.
- `ruff check` / `ruff format --check` — clean.

## Non-goals

- The prefix-hold problem for `<f`, `<fu`, … partial-sentinel deltas
  when the model emits per-character (analogous to what Hermes does
  via `_STREAMING_SENTINELS`) is not addressed here — the current
  wrapped code doesn't prefix-hold either, so this PR keeps parity
  and doesn't regress. If a separate report comes in for that class
  of leak, a follow-up can add it symmetrically for both openers.