### PR TITLE
fix(stt): guard Whisper silence hallucination via Silero VAD pre-trim (#961)

### DIFF
--- a/docs/guides/audio.md
+++ b/docs/guides/audio.md
@@ -261,6 +261,35 @@ curl http://localhost:8000/v1/audio/transcriptions \
   -F model=whisper-large-v3
 ```
 
+#### Silence-hallucination guard (Whisper only)
+
+Whisper is known to invent tokens like `"Thank you."` or
+`"Thanks for watching!"` when handed pure-silence input, and to append
+similar tails to legitimate clips that end in dead-air (issue #961).
+Every Whisper request is therefore pre-filtered by Silero VAD
+(bundled with the `[audio]` extra):
+
+- **Pure-silence clips** — VAD detects no speech; the endpoint returns
+  `{"text": "", "segments": [], "language": null}` and skips Whisper
+  entirely (latency win: ~200 ms VAD vs multi-second decode).
+- **Clips with leading / trailing silence** — VAD reports the speech
+  span; Whisper only sees the trimmed waveform, and returned segment
+  timestamps are shifted back to the original file's absolute time.
+- **Sanity check** — if VAD reports no speech but the waveform still
+  has non-trivial energy (RMS > ~-50 dBFS), the guard trusts the
+  audio and falls back to Whisper. Real quiet / whispered speech is
+  never silenced.
+
+Operator controls:
+
+| Knob | Type | Default | Effect |
+| --- | --- | --- | --- |
+| `RAPID_MLX_STT_VAD_PRETRIM` | env var | on | Set to `0`, `false`, `no`, or `off` to disable the guard run-wide and restore the pre-fix pass-through behaviour. |
+| `STTEngine(..., enable_vad_pretrim=True)` | Python API | `True` | Same effect at the engine level; use when embedding `STTEngine` directly. |
+
+The guard applies only to Whisper backends. Parakeet, Canary, and
+other non-Whisper STT engines are never pre-filtered.
+
 ### POST /v1/audio/speech
 
 Generate speech from text (OpenAI TTS API compatible).

--- a/tests/test_no_out_of_band_routing.py
+++ b/tests/test_no_out_of_band_routing.py
@@ -338,6 +338,16 @@ ALLOWED_RAPID_MLX_ENV_VARS: frozenset[str] = frozenset(
         # blow up the FS. Pure wire-level capacity gate — never
         # selects a model, parser, or routing tier.
         "RAPID_MLX_KV_CHECKPOINT_MAX_BYTES",
+        # F-K-WHISPER-961 anti-hallucination VAD pre-trim opt-out
+        # (accepts ``0`` / ``false`` / ``no`` / ``off``). Consumed by
+        # ``vllm_mlx.audio.stt._vad_pretrim_disabled_by_env`` only to
+        # decide whether ``STTEngine.transcribe`` runs Silero VAD
+        # before Whisper for silence-hallucination suppression on
+        # pure-silence and trailing-silence clips (issue #961). Pure
+        # behaviour-policy knob on a single existing STT engine —
+        # never selects a model, parser, or routing tier; identical
+        # semantic shape to ``RAPID_MLX_REASONING_RESCUE`` above.
+        "RAPID_MLX_STT_VAD_PRETRIM",
     }
 )
 

--- a/tests/test_stt_vad_pretrim.py
+++ b/tests/test_stt_vad_pretrim.py
@@ -1,0 +1,529 @@
+# SPDX-License-Identifier: Apache-2.0
+"""F-K-WHISPER-961 — Whisper silence hallucination guard.
+
+kootenayalex reported (issue #961) that ``STTEngine.transcribe`` on
+12 s of digital silence returns ``"Thank you."`` — a canonical Whisper
+silence hallucination. The documented anti-hallucination guards
+(``no_speech_threshold`` / ``logprob_threshold`` /
+``hallucination_silence_threshold``) inside
+``mlx_audio.stt.models.whisper.Model.generate`` are inert in practice:
+on pure silence the model returns ``no_speech_prob ≈ 1e-11`` and
+``avg_logprob ≈ -0.26``, and the AND-gate skip condition never fires.
+
+The fix at ``vllm_mlx/audio/stt.py`` runs the bundled Silero VAD
+(via ``mlx_audio.vad``) before Whisper:
+
+* No speech → return an empty ``TranscriptionResult`` without invoking
+  Whisper.
+* Speech present → trim to the speech span, invoke Whisper on the
+  trimmed waveform, then shift each returned segment (and per-word)
+  timestamp back by the trim offset so callers see absolute times.
+
+These tests stub the VAD + Whisper models to exercise the guard's
+control flow deterministically without downloading multi-hundred-MB
+weights on the CI runner.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Fake VAD + Whisper doubles. Both mimic the shape the production code
+# consumes: ``vad.get_speech_timestamps(...)`` returns a list of
+# ``{start,end}`` dicts (seconds), and ``whisper.generate(audio, ...)``
+# returns an ``STTOutput``-shaped object with ``text``, ``segments``,
+# ``language``.
+# ---------------------------------------------------------------------------
+
+
+class _FakeVAD:
+    """VAD stub that returns a pre-configured speech-timestamp list.
+
+    ``timestamps`` is a list of {"start": s, "end": s} dicts (seconds).
+    The test controls the list to simulate every VAD outcome shape:
+    empty (pure silence), single span (leading/trailing silence trim),
+    multiple spans (mid-silence gap).
+    """
+
+    def __init__(self, timestamps: list[dict]):
+        self._timestamps = timestamps
+        self.call_count = 0
+        self.last_kwargs: dict = {}
+
+    def get_speech_timestamps(self, audio, **kwargs):
+        self.call_count += 1
+        self.last_kwargs = kwargs
+        # We copy so callers can't mutate our fixture in place.
+        return [dict(ts) for ts in self._timestamps]
+
+
+class _FakeWhisperResult:
+    """Mimics ``mlx_audio.stt.models.whisper.STTOutput`` — a dataclass
+    with ``text``, ``segments`` (list of dicts), ``language``."""
+
+    def __init__(self, text: str, segments: list[dict], language: str = "en"):
+        self.text = text
+        self.segments = segments
+        self.language = language
+
+
+class _FakeWhisperModel:
+    """Records every ``generate(...)`` call so the tests can assert both
+    that Whisper was NOT called on pure silence AND that the correct
+    audio input (trimmed waveform vs. original path) was passed."""
+
+    def __init__(self, result: _FakeWhisperResult | None = None):
+        # Default: a single 0.0-2.0s "hello world" segment.
+        self._result = result or _FakeWhisperResult(
+            text="hello world",
+            segments=[
+                {"start": 0.0, "end": 2.0, "text": "hello world"},
+            ],
+            language="en",
+        )
+        self.calls: list[tuple[object, dict]] = []
+        # Ensure the ``_ensure_whisper_processor`` gate is a no-op.
+        self._processor = object()
+
+    def generate(self, audio, **kwargs):
+        # Copy so mutation on our side doesn't upset test assertions.
+        self.calls.append((audio, dict(kwargs)))
+        return self._result
+
+
+class _FakeMxArray:
+    """Lightweight stand-in for ``mx.array`` that supports the two
+    operations the VAD helper touches: ``.shape`` and slice indexing.
+
+    We deliberately avoid importing ``mlx.core`` in this test to keep
+    the unit test isolated from Metal / MLX runtime state — the guard
+    itself only uses ``waveform.shape[-1]`` and ``waveform[start:end]``.
+    """
+
+    def __init__(self, length_samples: int):
+        self._length = length_samples
+
+    @property
+    def shape(self):  # noqa: ANN201
+        return (self._length,)
+
+    def __getitem__(self, key):
+        if isinstance(key, slice):
+            start = key.start or 0
+            stop = key.stop if key.stop is not None else self._length
+            return _FakeMxArray(max(0, stop - start))
+        raise TypeError(f"unsupported index: {key!r}")
+
+
+# ---------------------------------------------------------------------------
+# Fixture: build a fully-stubbed STTEngine that never touches the network
+# or the mlx runtime, and expose the fake VAD + fake Whisper for
+# per-test assertions.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def stub_engine(monkeypatch, tmp_path):
+    """Yields ``(engine, fake_vad, fake_whisper, fake_audio_path)``.
+
+    * ``fake_vad.get_speech_timestamps`` returns whatever
+      ``fake_vad._timestamps`` holds — mutate that list before calling
+      ``engine.transcribe`` to steer the guard's branch.
+    * ``fake_whisper.calls`` is the recorded generate() history.
+    """
+    from vllm_mlx.audio import stt as stt_mod
+
+    # Reset the module-level VAD cache between tests so each fixture
+    # gets a fresh singleton pinned to its own _FakeVAD.
+    monkeypatch.setattr(stt_mod, "_VAD_MODEL_CACHE", None, raising=True)
+    monkeypatch.setattr(stt_mod, "_VAD_LOAD_ATTEMPTED", False, raising=True)
+    # Ensure env override does not leak in from the host.
+    monkeypatch.delenv("RAPID_MLX_STT_VAD_PRETRIM", raising=False)
+
+    fake_vad = _FakeVAD(timestamps=[])
+    fake_whisper = _FakeWhisperModel()
+
+    def _fake_get_vad_model():
+        return fake_vad
+
+    def _fake_load_audio(_path):
+        # 12 s of audio at 16 kHz for the pure-silence + short-tail
+        # tests; individual tests can override by monkeypatching this
+        # again with a different length.
+        return _FakeMxArray(length_samples=16_000 * 12)
+
+    # Patch the VAD lookup + audio decode inside stt.py.
+    monkeypatch.setattr(stt_mod, "_get_vad_model", _fake_get_vad_model)
+
+    # Route ``from mlx_audio.stt.utils import load_audio`` inside the
+    # ``_maybe_vad_trim`` helper to our fake. We do this by patching
+    # the module cache — the helper imports lazily on every call.
+    import sys as _sys
+    import types as _types
+
+    fake_stt_utils = _types.ModuleType("mlx_audio.stt.utils")
+    fake_stt_utils.load_audio = _fake_load_audio
+    fake_stt_utils.load_model = lambda *_a, **_kw: fake_whisper
+    monkeypatch.setitem(_sys.modules, "mlx_audio.stt.utils", fake_stt_utils)
+
+    # Build the engine.
+    eng = stt_mod.STTEngine("mlx-community/whisper-large-v3-turbo")
+    eng.model = fake_whisper
+    eng._loaded = True
+
+    # A dummy file path — the fake load_audio ignores it, so it need
+    # not exist on disk (but we materialise a stub to keep any
+    # downstream ``str(Path)`` conversions predictable).
+    audio_path = tmp_path / "audio.wav"
+    audio_path.write_bytes(b"RIFFsize")
+
+    yield eng, fake_vad, fake_whisper, str(audio_path), _fake_load_audio, monkeypatch
+
+
+# ---------------------------------------------------------------------------
+# Test coverage — one class per behaviour, per the task's spec.
+# ---------------------------------------------------------------------------
+
+
+class TestSilenceReturnsEmpty:
+    """Pure-silence input must NOT be handed to Whisper — the whole
+    point of the guard. Whisper.generate must not be called; the
+    returned result must be an empty ``TranscriptionResult``."""
+
+    def test_pure_silence_returns_empty_string(self, stub_engine):
+        eng, fake_vad, fake_whisper, path, *_ = stub_engine
+        # VAD reports no speech at all.
+        fake_vad._timestamps = []
+
+        result = eng.transcribe(path)
+
+        assert result.text == ""
+        assert result.segments == []
+        assert result.language is None
+        assert result.duration == 0.0
+        # Critical: Whisper was NOT invoked. This is the whole
+        # anti-hallucination invariant.
+        assert fake_whisper.calls == []
+
+
+class TestRealSpeechStillTranscribes:
+    """Speech-containing input must reach Whisper and produce the same
+    text as pre-fix — the guard must never eat legitimate content."""
+
+    def test_real_speech_still_transcribes(self, stub_engine):
+        eng, fake_vad, fake_whisper, path, *_ = stub_engine
+        # VAD reports a single 0-2 s speech span (matches the fake
+        # Whisper result's segment span, so no trim/offset artefacts).
+        fake_vad._timestamps = [{"start": 0.0, "end": 2.0}]
+
+        result = eng.transcribe(path)
+
+        assert result.text == "hello world"
+        assert result.language == "en"
+        assert result.segments and len(result.segments) == 1
+        # Whisper WAS called — with the trimmed waveform (mx.array-
+        # shaped), not the path string.
+        assert len(fake_whisper.calls) == 1
+        audio_in, _kwargs = fake_whisper.calls[0]
+        assert not isinstance(audio_in, str)
+        assert hasattr(audio_in, "shape")
+
+
+class TestTrailingSilenceTrimmed:
+    """Speech in [0, 2] + 10 s trailing silence must be trimmed so
+    Whisper never sees the tail — the pre-fix bug was that Whisper
+    would emit "Thank you." over the tail dead-air."""
+
+    def test_speech_with_trailing_silence_stops_at_speech_end(self, stub_engine):
+        eng, fake_vad, fake_whisper, path, *_ = stub_engine
+        # Real speech 0-2 s inside a 12 s clip → VAD reports the span.
+        fake_vad._timestamps = [{"start": 0.0, "end": 2.0}]
+
+        result = eng.transcribe(path)
+
+        # Whisper received the trimmed waveform, not the original 12 s.
+        audio_in, _ = fake_whisper.calls[0]
+        assert audio_in.shape[0] <= int(16_000 * (2.0 + 0.4 + 0.01)), (
+            "Trimmed waveform must not exceed [speech_end + 2 * pad]; "
+            f"got {audio_in.shape[0]} samples"
+        )
+        # And the last segment.end stays close to the real speech end
+        # — no hallucinated tail extending past 2.5 s.
+        last_end = result.segments[-1]["end"]
+        assert last_end < 2.0 + 0.5, f"tail hallucination: end={last_end}"
+
+
+class TestVADDisabledViaEnv:
+    """Env override ``RAPID_MLX_STT_VAD_PRETRIM=0`` must fully bypass
+    the guard: VAD is never asked, Whisper receives the original path."""
+
+    def test_vad_disabled_via_env_pass_through(self, stub_engine, monkeypatch):
+        eng, fake_vad, fake_whisper, path, *_ = stub_engine
+        monkeypatch.setenv("RAPID_MLX_STT_VAD_PRETRIM", "0")
+
+        result = eng.transcribe(path)
+
+        # VAD was never called.
+        assert fake_vad.call_count == 0
+        # Whisper was called with the ORIGINAL path (pre-fix path).
+        assert len(fake_whisper.calls) == 1
+        audio_in, _kwargs = fake_whisper.calls[0]
+        assert audio_in == path
+        # And the transcription flowed through unchanged.
+        assert result.text == "hello world"
+
+    @pytest.mark.parametrize("value", ["false", "no", "off", "FALSE", "Off"])
+    def test_env_disable_accepts_common_falsy_strings(
+        self, stub_engine, monkeypatch, value
+    ):
+        eng, fake_vad, fake_whisper, path, *_ = stub_engine
+        monkeypatch.setenv("RAPID_MLX_STT_VAD_PRETRIM", value)
+
+        eng.transcribe(path)
+
+        assert fake_vad.call_count == 0, f"env value {value!r} should disable VAD"
+
+
+class TestAbsoluteTimestampsPreserved:
+    """When VAD trims leading silence, returned segment timestamps must
+    be shifted back to absolute (file-relative) time. Otherwise a caller
+    stitching multiple transcripts together would see spurious 0.0-s
+    starts for every clip that had a silent lead-in."""
+
+    def test_absolute_timestamps_preserved_when_vad_trims_leading_silence(
+        self, stub_engine
+    ):
+        eng, fake_vad, fake_whisper, path, *_ = stub_engine
+        # VAD says speech starts 3.0 s in and ends 5.0 s in.
+        fake_vad._timestamps = [{"start": 3.0, "end": 5.0}]
+        # Whisper (on the trimmed span) reports segments starting at
+        # 0.0 relative to its input.
+        fake_whisper._result = _FakeWhisperResult(
+            text="hello world",
+            segments=[
+                {"start": 0.0, "end": 2.0, "text": "hello world"},
+            ],
+            language="en",
+        )
+
+        result = eng.transcribe(path)
+
+        # Trim offset was ``max(0, 3.0 - 0.2) = 2.8``. Segment start
+        # relative to the ORIGINAL file must be 0.0 + 2.8 = 2.8 s.
+        seg = result.segments[0]
+        assert seg["start"] >= 2.7 and seg["start"] <= 2.9, (
+            f"segment.start must be shifted back to ~2.8 s; got {seg['start']}"
+        )
+        assert seg["end"] >= 4.7 and seg["end"] <= 4.9
+
+    def test_word_level_timestamps_also_shifted(self, stub_engine):
+        eng, fake_vad, fake_whisper, path, *_ = stub_engine
+        fake_vad._timestamps = [{"start": 3.0, "end": 5.0}]
+        fake_whisper._result = _FakeWhisperResult(
+            text="hello world",
+            segments=[
+                {
+                    "start": 0.0,
+                    "end": 2.0,
+                    "text": "hello world",
+                    "words": [
+                        {"start": 0.0, "end": 0.5, "word": "hello"},
+                        {"start": 0.5, "end": 2.0, "word": "world"},
+                    ],
+                },
+            ],
+        )
+
+        result = eng.transcribe(path)
+
+        words = result.segments[0]["words"]
+        assert words[0]["start"] >= 2.7
+        assert words[1]["end"] >= 4.7
+
+
+class TestKwargOverrideDisables:
+    """The ``enable_vad_pretrim=False`` kwarg on ``STTEngine`` must fully
+    bypass the guard even without an env override."""
+
+    def test_enable_vad_pretrim_false_kwarg_disables(self, stub_engine, monkeypatch):
+        _eng, fake_vad, fake_whisper, path, _load_audio, mp = stub_engine
+        from vllm_mlx.audio import stt as stt_mod
+
+        eng2 = stt_mod.STTEngine(
+            "mlx-community/whisper-large-v3-turbo",
+            enable_vad_pretrim=False,
+        )
+        eng2.model = fake_whisper
+        eng2._loaded = True
+
+        eng2.transcribe(path)
+
+        assert fake_vad.call_count == 0
+        # Whisper was called with the ORIGINAL path (pre-fix behaviour).
+        audio_in, _ = fake_whisper.calls[0]
+        assert audio_in == path
+
+
+class TestVADImportFailureFallsBack:
+    """If ``mlx_audio.vad`` is not importable (e.g. user installed
+    rapid-mlx without the ``[audio]`` extra but supplied their own
+    Whisper build), the guard must gracefully skip and pass through
+    to the original path — never raise."""
+
+    def test_vad_import_failure_falls_back(self, monkeypatch, tmp_path):
+        # Rebuild a clean engine that goes through the REAL
+        # ``_get_vad_model`` path, then break the ``mlx_audio.vad``
+        # import so the helper hits the ``except ImportError`` branch.
+        from vllm_mlx.audio import stt as stt_mod
+
+        importlib.reload(stt_mod)
+        monkeypatch.setattr(stt_mod, "_VAD_MODEL_CACHE", None)
+        monkeypatch.setattr(stt_mod, "_VAD_LOAD_ATTEMPTED", False)
+        monkeypatch.delenv("RAPID_MLX_STT_VAD_PRETRIM", raising=False)
+
+        import sys as _sys
+
+        # Kill any cached mlx_audio.vad and mask further imports.
+        for name in list(_sys.modules):
+            if name.startswith("mlx_audio.vad"):
+                monkeypatch.delitem(_sys.modules, name, raising=False)
+
+        import builtins
+
+        real_import = builtins.__import__
+
+        def _blocked_import(name, *args, **kwargs):
+            if name == "mlx_audio.vad" or name.startswith("mlx_audio.vad."):
+                raise ImportError("simulated: mlx_audio.vad not installed")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", _blocked_import)
+
+        fake_whisper = _FakeWhisperModel()
+        eng = stt_mod.STTEngine("mlx-community/whisper-large-v3-turbo")
+        eng.model = fake_whisper
+        eng._loaded = True
+
+        path = str(tmp_path / "audio.wav")
+        (tmp_path / "audio.wav").write_bytes(b"RIFFsize")
+
+        # Must not raise. Whisper receives the original path (fallback).
+        result = eng.transcribe(path)
+
+        assert result.text == "hello world"
+        assert len(fake_whisper.calls) == 1
+        audio_in, _ = fake_whisper.calls[0]
+        assert audio_in == path
+
+
+class TestParakeetEngineSkipsVAD:
+    """Parakeet has its own silence behaviour and is out of scope for
+    #961 — the guard must be gated so it never fires on non-Whisper
+    engines regardless of the ``enable_vad_pretrim`` default."""
+
+    def test_parakeet_engine_skips_vad(self, stub_engine):
+        _eng, fake_vad, fake_whisper, path, _la, _mp = stub_engine
+        from vllm_mlx.audio import stt as stt_mod
+
+        eng_p = stt_mod.STTEngine("mlx-community/parakeet-tdt-0.6b-v2")
+        eng_p.model = fake_whisper
+        eng_p._loaded = True
+        assert eng_p._is_parakeet is True
+
+        eng_p.transcribe(path)
+
+        # VAD helper was NOT consulted for Parakeet.
+        assert fake_vad.call_count == 0
+        audio_in, kwargs = fake_whisper.calls[0]
+        assert audio_in == path
+        # Parakeet strips language / task kwargs per pre-fix behaviour.
+        assert "language" not in kwargs
+        assert "task" not in kwargs
+
+
+# ---------------------------------------------------------------------------
+# Sanity check on ``_vad_pretrim_disabled_by_env`` directly — the
+# helper is small enough to unit-test in isolation.
+# ---------------------------------------------------------------------------
+
+
+class TestEnvHelper:
+    @pytest.mark.parametrize(
+        "val,expected",
+        [
+            (None, False),
+            ("", False),
+            ("1", False),
+            ("true", False),
+            ("yes", False),
+            ("on", False),
+            ("0", True),
+            ("false", True),
+            ("FALSE", True),
+            ("no", True),
+            ("off", True),
+            (" 0 ", True),  # whitespace tolerated
+        ],
+    )
+    def test_env_helper(self, monkeypatch, val, expected):
+        from vllm_mlx.audio import stt as stt_mod
+
+        if val is None:
+            monkeypatch.delenv("RAPID_MLX_STT_VAD_PRETRIM", raising=False)
+        else:
+            monkeypatch.setenv("RAPID_MLX_STT_VAD_PRETRIM", val)
+        assert stt_mod._vad_pretrim_disabled_by_env() is expected
+
+
+# ---------------------------------------------------------------------------
+# Sanity check on ``_shift_segment_time`` — pure function, easy to
+# assert directly to catch off-by-one bugs before the integration path.
+# ---------------------------------------------------------------------------
+
+
+class TestShiftHelper:
+    def test_shift_dict_segment(self):
+        from vllm_mlx.audio.stt import _shift_segment_time
+
+        seg = {"start": 1.0, "end": 2.0, "text": "hi"}
+        _shift_segment_time(seg, 3.0)
+        assert seg == {"start": 4.0, "end": 5.0, "text": "hi"}
+
+    def test_shift_dict_segment_with_words(self):
+        from vllm_mlx.audio.stt import _shift_segment_time
+
+        seg = {
+            "start": 1.0,
+            "end": 2.0,
+            "words": [
+                {"start": 1.0, "end": 1.5, "word": "hi"},
+                {"start": 1.5, "end": 2.0, "word": "there"},
+            ],
+        }
+        _shift_segment_time(seg, 0.5)
+        assert seg["start"] == 1.5
+        assert seg["end"] == 2.5
+        assert seg["words"][0]["start"] == 1.5
+        assert seg["words"][1]["end"] == 2.5
+
+    def test_shift_missing_keys_is_noop(self):
+        from vllm_mlx.audio.stt import _shift_segment_time
+
+        seg = {"text": "hi"}  # no start/end
+        _shift_segment_time(seg, 5.0)
+        assert seg == {"text": "hi"}
+
+    def test_shift_object_segment(self):
+        from vllm_mlx.audio.stt import _shift_segment_time
+
+        class _Seg:
+            start = 1.0
+            end = 2.0
+
+        s = _Seg()
+        _shift_segment_time(s, 3.0)
+        assert s.start == 4.0
+        assert s.end == 5.0

--- a/tests/test_stt_vad_pretrim.py
+++ b/tests/test_stt_vad_pretrim.py
@@ -759,16 +759,30 @@ class TestUpstreamWhisperInputContract:
                 f"has a non-str arm: {annotation}"
             )
 
-    def test_whisper_log_mel_spectrogram_accepts_np_and_mx(self):
-        """Codex r2 NIT #2: prove at RUNTIME that the array-conversion
-        + mel-spectrogram path inside ``_prepare_audio`` actually
-        accepts both numpy and mx.array shapes. This is stricter than
-        the annotation check — a runtime narrowing (e.g. an
-        ``assert isinstance(audio, mx.array)`` added upstream) would
-        make the annotation check pass but break the trim path.
+    def test_numpy_to_mx_conversion_still_works(self):
+        """Codex r3 BLOCKING: pin the ``elif not isinstance(audio,
+        mx.array): audio = mx.array(audio)`` branch inside
+        ``Model._prepare_audio``. If ``mx.array(np.ndarray)`` ever
+        stopped accepting a numpy float32 waveform, the trim path
+        (which hands Whisper an mx.array converted from numpy or
+        loaded via ``load_audio``) would break in production.
+        """
+        try:
+            import mlx.core as mx  # noqa: PLC0415
+            import numpy as np  # noqa: PLC0415
+        except ImportError:
+            pytest.skip("mlx.core / numpy not installed; contract check n/a")
 
-        Runs on a 1-second synthetic waveform so it's weight-free and
-        deterministic.
+        sample_rate = 16_000
+        one_second = np.zeros(sample_rate, dtype=np.float32)
+        converted = mx.array(one_second)
+        assert converted.shape == (sample_rate,)
+
+    def test_whisper_log_mel_spectrogram_accepts_mx_array(self):
+        """Codex r2 NIT #2 / r3 BLOCKING: prove at RUNTIME that the
+        mel-spectrogram path — the very next step ``_prepare_audio``
+        takes after the array conversion above — still accepts the
+        ``mx.array`` shape our trim path hands Whisper. Weight-free.
         """
         try:
             from mlx_audio.stt.models.whisper.audio import (  # noqa: PLC0415
@@ -782,17 +796,20 @@ class TestUpstreamWhisperInputContract:
 
         sample_rate = 16_000
         one_second = np.zeros(sample_rate, dtype=np.float32)
-
-        # numpy → mx.array (mirrors the ``elif not isinstance(audio,
-        # mx.array): audio = mx.array(audio)`` branch inside
-        # _prepare_audio).
         as_mx = mx.array(one_second)
-        mel_np = log_mel_spectrogram(as_mx, n_mels=80, padding=0)
-        assert mel_np.shape[-1] == 80 or mel_np.shape[-2] == 80
 
-        # Pure mx.array input — should also succeed.
-        mel_mx = log_mel_spectrogram(as_mx, n_mels=80, padding=0)
-        assert mel_mx.shape == mel_np.shape
+        # This is the shape the trim path passes to model.generate()
+        # → _prepare_audio() → log_mel_spectrogram(). A runtime
+        # narrowing to str-only would raise here.
+        mel = log_mel_spectrogram(as_mx, n_mels=80, padding=0)
+        # log_mel_spectrogram returns a rank-2 (time, n_mels) or
+        # (n_mels, time) tensor — assert one axis matches n_mels
+        # rather than pin the exact layout (upstream has flipped it
+        # historically).
+        assert 80 in mel.shape, (
+            f"log_mel_spectrogram output shape {mel.shape} lacks the "
+            "requested n_mels=80 axis — upstream contract change."
+        )
 
 
 class TestParakeetEngineSkipsVAD:

--- a/tests/test_stt_vad_pretrim.py
+++ b/tests/test_stt_vad_pretrim.py
@@ -139,7 +139,8 @@ def stub_engine(monkeypatch, tmp_path):
     # Reset the module-level VAD cache between tests so each fixture
     # gets a fresh singleton pinned to its own _FakeVAD.
     monkeypatch.setattr(stt_mod, "_VAD_MODEL_CACHE", None, raising=True)
-    monkeypatch.setattr(stt_mod, "_VAD_LOAD_ATTEMPTED", False, raising=True)
+    monkeypatch.setattr(stt_mod, "_VAD_IMPORT_UNAVAILABLE", False, raising=True)
+    monkeypatch.setattr(stt_mod, "_VAD_LOAD_FAILURE_LOGGED", False, raising=True)
     # Ensure env override does not leak in from the host.
     monkeypatch.delenv("RAPID_MLX_STT_VAD_PRETRIM", raising=False)
 
@@ -339,9 +340,14 @@ class TestAbsoluteTimestampsPreserved:
 
         result = eng.transcribe(path)
 
+        # Codex r1 NIT: assert exact shifted values, not just lower
+        # bounds — a double-shift bug would still pass a >= check.
+        # Trim offset = max(0, 3.0 - 0.2) = 2.8.
         words = result.segments[0]["words"]
-        assert words[0]["start"] >= 2.7
-        assert words[1]["end"] >= 4.7
+        assert words[0]["start"] == pytest.approx(2.8, abs=1e-6)
+        assert words[0]["end"] == pytest.approx(3.3, abs=1e-6)
+        assert words[1]["start"] == pytest.approx(3.3, abs=1e-6)
+        assert words[1]["end"] == pytest.approx(4.8, abs=1e-6)
 
 
 class TestKwargOverrideDisables:
@@ -381,7 +387,8 @@ class TestVADImportFailureFallsBack:
 
         importlib.reload(stt_mod)
         monkeypatch.setattr(stt_mod, "_VAD_MODEL_CACHE", None)
-        monkeypatch.setattr(stt_mod, "_VAD_LOAD_ATTEMPTED", False)
+        monkeypatch.setattr(stt_mod, "_VAD_IMPORT_UNAVAILABLE", False)
+        monkeypatch.setattr(stt_mod, "_VAD_LOAD_FAILURE_LOGGED", False)
         monkeypatch.delenv("RAPID_MLX_STT_VAD_PRETRIM", raising=False)
 
         import sys as _sys
@@ -417,6 +424,173 @@ class TestVADImportFailureFallsBack:
         assert len(fake_whisper.calls) == 1
         audio_in, _ = fake_whisper.calls[0]
         assert audio_in == path
+
+
+class TestMalformedVADOutputFallsBack:
+    """Codex r1 BLOCKING #2 defense: if the VAD helper returns
+    malformed timestamps (missing ``start`` / ``end`` keys, wrong types,
+    empty dicts), the guard must fall back to unmodified transcription
+    instead of raising ``KeyError`` out of ``transcribe()``."""
+
+    def test_missing_start_key_falls_back(self, stub_engine):
+        eng, fake_vad, fake_whisper, path, *_ = stub_engine
+        fake_vad._timestamps = [{"end": 2.0}]  # missing 'start'
+
+        # Must not raise. Whisper is invoked with the original path
+        # as the fallback (the reporter's pre-fix behaviour is
+        # preferable to a 500).
+        result = eng.transcribe(path)
+
+        assert result.text == "hello world"
+        audio_in, _ = fake_whisper.calls[0]
+        assert audio_in == path
+
+    def test_missing_end_key_falls_back(self, stub_engine):
+        eng, fake_vad, fake_whisper, path, *_ = stub_engine
+        fake_vad._timestamps = [{"start": 1.0}]  # missing 'end'
+
+        result = eng.transcribe(path)
+
+        assert result.text == "hello world"
+        audio_in, _ = fake_whisper.calls[0]
+        assert audio_in == path
+
+    def test_none_valued_timestamp_falls_back(self, stub_engine):
+        eng, fake_vad, fake_whisper, path, *_ = stub_engine
+        fake_vad._timestamps = [{"start": None, "end": 2.0}]  # TypeError
+
+        result = eng.transcribe(path)
+
+        assert result.text == "hello world"
+        audio_in, _ = fake_whisper.calls[0]
+        assert audio_in == path
+
+
+class TestTransientLoadFailureRetries:
+    """Codex r1 BLOCKING #1 defense: a transient ``vad_load(...)``
+    failure must NOT permanently disable the guard for the process
+    lifetime. Import failures are permanent (weights aren't installed)
+    and DO stay cached, but transient load errors retry on every
+    subsequent call.
+    """
+
+    def test_transient_load_failure_retries_on_next_call(self, monkeypatch):
+        from vllm_mlx.audio import stt as stt_mod
+
+        # Fresh module state.
+        monkeypatch.setattr(stt_mod, "_VAD_MODEL_CACHE", None)
+        monkeypatch.setattr(stt_mod, "_VAD_IMPORT_UNAVAILABLE", False)
+        monkeypatch.setattr(stt_mod, "_VAD_LOAD_FAILURE_LOGGED", False)
+
+        # Fake ``mlx_audio.vad.load`` that fails the first call, then
+        # succeeds the second — mimics a network hiccup that recovers.
+        import sys as _sys
+        import types as _types
+
+        state = {"calls": 0}
+
+        def _flaky_load(_repo):
+            state["calls"] += 1
+            if state["calls"] == 1:
+                raise RuntimeError("simulated: HF 502")
+            return _FakeVAD(timestamps=[])
+
+        fake_vad_pkg = _types.ModuleType("mlx_audio.vad")
+        fake_vad_pkg.load = _flaky_load
+        monkeypatch.setitem(_sys.modules, "mlx_audio.vad", fake_vad_pkg)
+
+        # First call — transient failure.
+        assert stt_mod._get_vad_model() is None
+        assert state["calls"] == 1
+        # Permanent-unavailable flag must NOT be latched.
+        assert stt_mod._VAD_IMPORT_UNAVAILABLE is False
+
+        # Second call — retries, succeeds.
+        vad = stt_mod._get_vad_model()
+        assert vad is not None
+        assert state["calls"] == 2
+
+    def test_permanent_import_failure_is_cached(self, monkeypatch):
+        """ImportError → cached, no retries (module isn't installed
+        and can't become installed without a process restart)."""
+        from vllm_mlx.audio import stt as stt_mod
+
+        monkeypatch.setattr(stt_mod, "_VAD_MODEL_CACHE", None)
+        monkeypatch.setattr(stt_mod, "_VAD_IMPORT_UNAVAILABLE", False)
+        monkeypatch.setattr(stt_mod, "_VAD_LOAD_FAILURE_LOGGED", False)
+
+        import sys as _sys
+
+        # Ensure any cached mlx_audio.vad module is gone so the import
+        # actually runs. Then block re-imports of it.
+        for name in list(_sys.modules):
+            if name.startswith("mlx_audio.vad"):
+                monkeypatch.delitem(_sys.modules, name, raising=False)
+
+        import builtins
+
+        real_import = builtins.__import__
+
+        def _blocked(name, *args, **kwargs):
+            if name == "mlx_audio.vad" or name.startswith("mlx_audio.vad."):
+                raise ImportError("simulated: not installed")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", _blocked)
+
+        assert stt_mod._get_vad_model() is None
+        assert stt_mod._VAD_IMPORT_UNAVAILABLE is True
+
+        # Now un-block the import and call again — must NOT retry,
+        # because permanent failures stay cached.
+        monkeypatch.setattr(builtins, "__import__", real_import)
+        assert stt_mod._get_vad_model() is None
+
+
+class TestUpstreamWhisperInputContract:
+    """Codex r1 NIT #3 defense: pin the upstream Whisper
+    ``generate()`` input-shape contract so if
+    ``mlx_audio.stt.models.whisper.Model._prepare_audio`` ever narrows
+    its accepted input types we fail loudly here instead of in
+    production. This tests the real installed ``mlx_audio`` (not our
+    fake) but does NOT download weights.
+    """
+
+    def test_whisper_prepare_audio_accepts_np_and_mx(self):
+        try:
+            from mlx_audio.stt.models.whisper.whisper import Model
+        except ImportError:
+            pytest.skip("mlx_audio not installed; contract check n/a")
+
+        import inspect
+        import typing as _typing
+
+        sig = inspect.signature(Model._prepare_audio)
+        audio_param = sig.parameters.get("audio")
+        assert audio_param is not None, (
+            "Upstream ``Model._prepare_audio`` renamed the ``audio`` "
+            "parameter — VAD trim path passes a positional array here."
+        )
+        annotation = audio_param.annotation
+        # Accept both the raw ``Union[str, np.ndarray, mx.array]`` typing
+        # and any subclass that still allows a bare ndarray/mx.array
+        # positional. If the signature narrows to ``str`` only, this
+        # would need to catch it — flag by asserting the annotation
+        # isn't the bare string type.
+        assert annotation is not str, (
+            "Upstream ``Model._prepare_audio`` narrowed to str-only. "
+            "The VAD trim path can no longer pass a trimmed waveform."
+        )
+        # Fallback: if the annotation is a Union, at least one of the
+        # arms must be a non-``str`` type (numpy or mx.array).
+        origin = _typing.get_origin(annotation)
+        if origin is not None:
+            args = _typing.get_args(annotation)
+            non_str = [a for a in args if a is not str]
+            assert non_str, (
+                "Upstream ``Model._prepare_audio`` audio Union no longer "
+                f"has a non-str arm: {annotation}"
+            )
 
 
 class TestParakeetEngineSkipsVAD:

--- a/tests/test_stt_vad_pretrim.py
+++ b/tests/test_stt_vad_pretrim.py
@@ -158,6 +158,14 @@ def stub_engine(monkeypatch, tmp_path):
 
     # Patch the VAD lookup + audio decode inside stt.py.
     monkeypatch.setattr(stt_mod, "_get_vad_model", _fake_get_vad_model)
+    # Codex r2 BLOCKING #1 fix side-effect: ``_rms_above_floor`` runs
+    # after every empty ``speech_ts``. In these unit tests the fake
+    # waveform has no real RMS so the helper defaults to True (i.e.
+    # "trust it's audio, don't suppress"). That would break the
+    # pure-silence assertion. Default the RMS check to False here
+    # (simulating true silence); tests that exercise the false-
+    # negative path re-override this per-test.
+    monkeypatch.setattr(stt_mod, "_rms_above_floor", lambda _w, _f: False)
 
     # Route ``from mlx_audio.stt.utils import load_audio`` inside the
     # ``_maybe_vad_trim`` helper to our fake. We do this by patching
@@ -547,16 +555,182 @@ class TestTransientLoadFailureRetries:
         assert stt_mod._get_vad_model() is None
 
 
+class TestVADFalseNegativeGuard:
+    """Codex r2 BLOCKING #1: Silero can false-negative on quiet /
+    whispered / breathy speech. The RMS-floor sanity check must
+    override VAD's "no speech" verdict when the waveform has
+    non-trivial energy, so real audio never gets silenced."""
+
+    def test_high_rms_no_speech_falls_back_to_whisper(self, stub_engine):
+        eng, fake_vad, fake_whisper, path, _load_audio, mp = stub_engine
+        from vllm_mlx.audio import stt as stt_mod
+
+        # VAD reports no speech (empty timestamps).
+        fake_vad._timestamps = []
+
+        # But the "audio" has high RMS — simulate by returning a
+        # noisy waveform from load_audio.
+        class _NoisyArr(_FakeMxArray):
+            pass
+
+        def _noisy_load_audio(_p):
+            arr = _NoisyArr(length_samples=16_000 * 12)
+            return arr
+
+        import sys as _sys
+
+        mp.setitem(
+            _sys.modules,
+            "mlx_audio.stt.utils",
+            type(_sys.modules["mlx_audio.stt.utils"])("mlx_audio.stt.utils"),
+        )
+        _sys.modules["mlx_audio.stt.utils"].load_audio = _noisy_load_audio
+
+        # Patch the RMS helper to report above-floor energy.
+        mp.setattr(stt_mod, "_rms_above_floor", lambda _w, _f: True)
+
+        result = eng.transcribe(path)
+
+        # Because RMS was above floor, guard falls back to Whisper
+        # (the original path) rather than returning empty text.
+        assert result.text == "hello world"
+        assert len(fake_whisper.calls) == 1
+        audio_in, _ = fake_whisper.calls[0]
+        assert audio_in == path
+
+    def test_pure_silence_below_rms_floor_still_returns_empty(self, stub_engine):
+        eng, fake_vad, fake_whisper, path, _load_audio, mp = stub_engine
+        from vllm_mlx.audio import stt as stt_mod
+
+        fake_vad._timestamps = []
+        # Force RMS below floor — the #961 pure-silence path.
+        mp.setattr(stt_mod, "_rms_above_floor", lambda _w, _f: False)
+
+        result = eng.transcribe(path)
+
+        # Guard fires: empty text, Whisper NOT invoked.
+        assert result.text == ""
+        assert result.segments == []
+        assert fake_whisper.calls == []
+
+
+class TestVADThresholdKwargPropagates:
+    """The lower Silero threshold (0.3, biased toward false positives)
+    must actually reach the underlying get_speech_timestamps call —
+    otherwise the false-negative bias reverts to Silero's default 0.5."""
+
+    def test_speech_threshold_kwarg_reaches_silero(self, stub_engine):
+        eng, fake_vad, fake_whisper, path, *_ = stub_engine
+        fake_vad._timestamps = [{"start": 0.0, "end": 2.0}]
+
+        eng.transcribe(path)
+
+        assert fake_vad.call_count == 1
+        assert fake_vad.last_kwargs.get("threshold") == 0.3
+
+
+class TestRMSHelper:
+    """Unit tests for ``_rms_above_floor`` — the sanity check that
+    protects real audio from a Silero false negative."""
+
+    def test_pure_silence_below_floor(self):
+        import numpy as np
+
+        from vllm_mlx.audio.stt import _rms_above_floor
+
+        silence = np.zeros(16_000, dtype=np.float32)
+        assert _rms_above_floor(silence, 1e-4) is False
+
+    def test_noisy_signal_above_floor(self):
+        import numpy as np
+
+        from vllm_mlx.audio.stt import _rms_above_floor
+
+        # Sine wave at 0.5 amplitude → RMS ~0.35, well above any
+        # reasonable silence floor.
+        t = np.linspace(0, 1, 16_000, dtype=np.float32)
+        sine = (0.5 * np.sin(2 * np.pi * 440 * t)).astype(np.float32)
+        assert _rms_above_floor(sine, 3.16e-3) is True
+
+    def test_helper_swallows_bad_input_conservatively(self):
+        """If the RMS computation fails we assume "trust it's audio"
+        so we never accidentally suppress real speech."""
+        from vllm_mlx.audio.stt import _rms_above_floor
+
+        # Non-array, non-numpy input — both math backends should
+        # fail. Contract: return True.
+        assert _rms_above_floor("not-an-array", 1e-3) is True
+
+
+class TestVADLoadLock:
+    """Codex r2 NIT #3: the load path must be serialized so N
+    concurrent transcriptions don't kick off N duplicate downloads."""
+
+    def test_load_lock_serializes_first_load(self, monkeypatch):
+        import sys as _sys
+        import threading
+        import types as _types
+
+        from vllm_mlx.audio import stt as stt_mod
+
+        monkeypatch.setattr(stt_mod, "_VAD_MODEL_CACHE", None)
+        monkeypatch.setattr(stt_mod, "_VAD_IMPORT_UNAVAILABLE", False)
+        monkeypatch.setattr(stt_mod, "_VAD_LOAD_FAILURE_LOGGED", False)
+        # Fresh lock so old test state doesn't leak.
+        monkeypatch.setattr(stt_mod, "_VAD_LOAD_LOCK", threading.Lock())
+
+        call_count = [0]
+        released = threading.Event()
+
+        def _slow_load(_repo):
+            call_count[0] += 1
+            # Block long enough for a second thread to enter the
+            # ``_get_vad_model`` fast path.
+            released.wait(timeout=2.0)
+            return _FakeVAD(timestamps=[])
+
+        fake_vad_pkg = _types.ModuleType("mlx_audio.vad")
+        fake_vad_pkg.load = _slow_load
+        monkeypatch.setitem(_sys.modules, "mlx_audio.vad", fake_vad_pkg)
+
+        results: list[object] = []
+
+        def _worker():
+            results.append(stt_mod._get_vad_model())
+
+        t1 = threading.Thread(target=_worker)
+        t2 = threading.Thread(target=_worker)
+        t1.start()
+        # Give the first thread time to acquire the lock and start
+        # the slow load.
+        import time as _t
+
+        _t.sleep(0.05)
+        t2.start()
+        # Now unblock the first load — the second thread should get
+        # the cached result under the lock re-check.
+        released.set()
+        t1.join(timeout=3.0)
+        t2.join(timeout=3.0)
+
+        assert call_count[0] == 1, (
+            f"expected exactly 1 vad_load call under lock; got {call_count[0]}"
+        )
+        assert results[0] is results[1]
+        assert stt_mod._VAD_MODEL_CACHE is not None
+
+
 class TestUpstreamWhisperInputContract:
-    """Codex r1 NIT #3 defense: pin the upstream Whisper
+    """Codex r1 NIT #3 / r2 NIT #2 defense: pin the upstream Whisper
     ``generate()`` input-shape contract so if
     ``mlx_audio.stt.models.whisper.Model._prepare_audio`` ever narrows
     its accepted input types we fail loudly here instead of in
-    production. This tests the real installed ``mlx_audio`` (not our
-    fake) but does NOT download weights.
+    production. Combines two forms of evidence — the signature
+    annotation AND direct runtime execution of the very function
+    ``_prepare_audio`` delegates array-conversion to.
     """
 
-    def test_whisper_prepare_audio_accepts_np_and_mx(self):
+    def test_whisper_prepare_audio_signature_still_accepts_arrays(self):
         try:
             from mlx_audio.stt.models.whisper.whisper import Model
         except ImportError:
@@ -572,17 +746,10 @@ class TestUpstreamWhisperInputContract:
             "parameter — VAD trim path passes a positional array here."
         )
         annotation = audio_param.annotation
-        # Accept both the raw ``Union[str, np.ndarray, mx.array]`` typing
-        # and any subclass that still allows a bare ndarray/mx.array
-        # positional. If the signature narrows to ``str`` only, this
-        # would need to catch it — flag by asserting the annotation
-        # isn't the bare string type.
         assert annotation is not str, (
             "Upstream ``Model._prepare_audio`` narrowed to str-only. "
             "The VAD trim path can no longer pass a trimmed waveform."
         )
-        # Fallback: if the annotation is a Union, at least one of the
-        # arms must be a non-``str`` type (numpy or mx.array).
         origin = _typing.get_origin(annotation)
         if origin is not None:
             args = _typing.get_args(annotation)
@@ -591,6 +758,41 @@ class TestUpstreamWhisperInputContract:
                 "Upstream ``Model._prepare_audio`` audio Union no longer "
                 f"has a non-str arm: {annotation}"
             )
+
+    def test_whisper_log_mel_spectrogram_accepts_np_and_mx(self):
+        """Codex r2 NIT #2: prove at RUNTIME that the array-conversion
+        + mel-spectrogram path inside ``_prepare_audio`` actually
+        accepts both numpy and mx.array shapes. This is stricter than
+        the annotation check — a runtime narrowing (e.g. an
+        ``assert isinstance(audio, mx.array)`` added upstream) would
+        make the annotation check pass but break the trim path.
+
+        Runs on a 1-second synthetic waveform so it's weight-free and
+        deterministic.
+        """
+        try:
+            from mlx_audio.stt.models.whisper.audio import (  # noqa: PLC0415
+                log_mel_spectrogram,
+            )
+        except ImportError:
+            pytest.skip("mlx_audio not installed; contract check n/a")
+
+        import mlx.core as mx  # noqa: PLC0415
+        import numpy as np  # noqa: PLC0415
+
+        sample_rate = 16_000
+        one_second = np.zeros(sample_rate, dtype=np.float32)
+
+        # numpy → mx.array (mirrors the ``elif not isinstance(audio,
+        # mx.array): audio = mx.array(audio)`` branch inside
+        # _prepare_audio).
+        as_mx = mx.array(one_second)
+        mel_np = log_mel_spectrogram(as_mx, n_mels=80, padding=0)
+        assert mel_np.shape[-1] == 80 or mel_np.shape[-2] == 80
+
+        # Pure mx.array input — should also succeed.
+        mel_mx = log_mel_spectrogram(as_mx, n_mels=80, padding=0)
+        assert mel_mx.shape == mel_np.shape
 
 
 class TestParakeetEngineSkipsVAD:

--- a/vllm_mlx/audio/stt.py
+++ b/vllm_mlx/audio/stt.py
@@ -8,14 +8,67 @@ Supports:
 """
 
 import logging
+import os
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
 # Default models
 DEFAULT_WHISPER_MODEL = "mlx-community/whisper-large-v3-mlx"
 DEFAULT_PARAKEET_MODEL = "mlx-community/parakeet-tdt-0.6b-v2"
+
+# ---------------------------------------------------------------------------
+# F-K-WHISPER-961: VAD pre-trim guard (see #961)
+# ---------------------------------------------------------------------------
+# kootenayalex reproduced ``STTEngine.transcribe`` on 12 s of digital
+# silence returning ``"Thank you."`` — a canonical Whisper silence
+# hallucination. The documented anti-hallucination guards inside
+# ``mlx_audio.stt.models.whisper.Model.generate`` (``no_speech_threshold``,
+# ``logprob_threshold``, ``hallucination_silence_threshold``) are inert
+# in practice because on pure silence the model returns
+# ``no_speech_prob ≈ 1e-11`` (or NaN on some chunked paths) AND
+# ``avg_logprob ≈ -0.26`` — the AND-gate skip condition
+# ``no_speech_prob > 0.6 AND avg_logprob < -1.0`` never fires. The
+# upstream fix would require modifying ``mlx_audio`` (third-party, not
+# vendored here); monkey-patching it is fragile across upstream bumps.
+#
+# The systematic remedy applied here — "if the audio has no speech,
+# don't invoke Whisper on it" — is a strictly-stronger invariant than
+# post-hoc hallucination detection. We use the bundled
+# ``mlx_audio.vad.silero_vad`` model (already installable via the
+# ``[audio]`` extra, no new dependency) as a cheap pre-filter:
+#
+#   * VAD reports no speech → return an empty ``TranscriptionResult``
+#     without invoking Whisper. Cost: ~200 ms VAD vs. multi-second
+#     Whisper decode → strict latency win on silent clips too.
+#   * VAD reports speech → trim the input to
+#     ``[first_speech.start - pad, last_speech.end + pad]`` and pass
+#     the trimmed waveform to Whisper. Segment timestamps are then
+#     offset by the trim start so callers still see absolute times.
+#
+# Gating (both must be true for the guard to run):
+#   * The engine kwarg ``enable_vad_pretrim`` (default ``True``).
+#   * The env override ``RAPID_MLX_STT_VAD_PRETRIM`` is not one of
+#     ``{"0", "false", "no", "off"}`` (case-insensitive).
+#
+# If the VAD model fails to load (missing extras, network error, etc.),
+# the guard logs a warning once and every subsequent call transparently
+# falls back to the unmodified transcription path — no regression to
+# pre-fix behaviour.
+_VAD_MODEL_REPO = "mlx-community/silero-vad"
+# Silero already applies ``speech_pad_ms=30`` internally; the extra
+# 200 ms we add on each side gives Whisper a small ambient-context
+# tail so an onset isn't clipped mid-phoneme.
+_VAD_TRIM_PAD_SECONDS = 0.2
+_VAD_SAMPLE_RATE = 16_000
+
+# Load-once cache. Kept module-level (not instance-level) so multiple
+# STTEngine instances share one VAD model — the Silero weights are
+# ~1.7 MB but the mx.array upload isn't free either.
+_VAD_MODEL_CACHE: Any | None = None
+_VAD_LOAD_ATTEMPTED = False
 
 
 # F-K-WHISPER-500: every mlx-community Whisper repo ships ONLY
@@ -61,6 +114,194 @@ class TranscriptionResult:
     segments: list | None = None
 
 
+@dataclass
+class _VADTrimResult:
+    """Outcome of a single VAD pre-trim call — see #961.
+
+    Three shapes:
+
+    * ``skipped=True`` — VAD is unavailable, disabled by env, or the
+      audio decode failed. Caller must fall back to the unmodified
+      transcription path (Whisper reads the original ``audio_path``).
+    * ``skipped=False, has_speech=False`` — VAD ran and reported no
+      speech at all. Caller must return an empty
+      ``TranscriptionResult`` without invoking Whisper.
+    * ``skipped=False, has_speech=True, waveform=..., offset_seconds=...``
+      — VAD found speech. Caller must invoke Whisper on ``waveform``
+      (mono 16 kHz) and add ``offset_seconds`` to every returned
+      segment (and per-word) timestamp so callers still see absolute
+      times relative to the original file.
+    """
+
+    skipped: bool = False
+    has_speech: bool = False
+    waveform: Any = None  # mx.array | np.ndarray, mono @ 16 kHz
+    offset_seconds: float = 0.0
+    sample_rate: int = _VAD_SAMPLE_RATE
+
+
+def _vad_pretrim_disabled_by_env() -> bool:
+    """Return ``True`` if ``RAPID_MLX_STT_VAD_PRETRIM`` opts out.
+
+    Truthy defaults ("", "1", "true", "yes", "on") leave the guard on;
+    only the explicit disable strings turn it off. This matches the
+    ``env_truthy`` convention used elsewhere in the repo (see
+    ``scripts/pr_validate/context.py``) — inverted here because the
+    default is on.
+    """
+    val = os.environ.get("RAPID_MLX_STT_VAD_PRETRIM", "").strip().lower()
+    return val in {"0", "false", "no", "off"}
+
+
+def _get_vad_model() -> Any | None:
+    """Return the shared Silero VAD model, loading it on first call.
+
+    Returns ``None`` on any failure (import error, network hiccup,
+    weight-file mismatch) so callers fall back to the unmodified
+    transcription path without ever raising into ``transcribe()``.
+    The failure is logged at WARNING once — subsequent calls short-
+    circuit off ``_VAD_LOAD_ATTEMPTED`` and produce no more log spam.
+    """
+    global _VAD_MODEL_CACHE, _VAD_LOAD_ATTEMPTED
+    if _VAD_MODEL_CACHE is not None:
+        return _VAD_MODEL_CACHE
+    if _VAD_LOAD_ATTEMPTED:
+        return None
+    _VAD_LOAD_ATTEMPTED = True
+    try:
+        from mlx_audio.vad import load as vad_load  # noqa: PLC0415
+    except ImportError as e:
+        logger.warning(
+            "VAD pre-trim disabled: mlx_audio.vad not importable (%s). "
+            "Install rapid-mlx[audio] to enable the anti-hallucination "
+            "guard for pure-silence clips (#961).",
+            e,
+        )
+        return None
+    try:
+        _VAD_MODEL_CACHE = vad_load(_VAD_MODEL_REPO)
+    except Exception as e:  # noqa: BLE001
+        # Network failure, weight mismatch, HF gate — log once + bail.
+        logger.warning(
+            "VAD pre-trim disabled: could not load %r: %s",
+            _VAD_MODEL_REPO,
+            e,
+        )
+        return None
+    return _VAD_MODEL_CACHE
+
+
+def _maybe_vad_trim(audio_path: str) -> _VADTrimResult:
+    """Run Silero VAD, trim to the speech span, return a ``_VADTrimResult``.
+
+    Never raises: any failure short-circuits to ``skipped=True`` so the
+    caller falls back to unmodified transcription. The rationale is that
+    the guard is best-effort — a hallucinated ``"Thank you."`` is a bug
+    but a *harder* bug for the reporter than a raise-through crash.
+    """
+    if _vad_pretrim_disabled_by_env():
+        return _VADTrimResult(skipped=True)
+
+    vad = _get_vad_model()
+    if vad is None:
+        return _VADTrimResult(skipped=True)
+
+    try:
+        from mlx_audio.stt.utils import load_audio  # noqa: PLC0415
+    except ImportError:
+        return _VADTrimResult(skipped=True)
+
+    try:
+        waveform = load_audio(audio_path)  # mono float32 mx.array @ 16 kHz
+    except Exception as e:  # noqa: BLE001
+        # Decode failure — do NOT swallow. Return skipped so Whisper's
+        # own file open surfaces the same error via the route's decode
+        # classifier (see tests/test_stt_corrupted_file.py).
+        logger.debug(
+            "VAD pre-trim: audio load failed for %r, deferring to Whisper: %s",
+            audio_path,
+            e,
+        )
+        return _VADTrimResult(skipped=True)
+
+    if getattr(waveform, "shape", (0,))[-1] == 0:
+        # Empty audio → no speech by definition.
+        return _VADTrimResult(skipped=False, has_speech=False)
+
+    try:
+        speech_ts = vad.get_speech_timestamps(
+            waveform,
+            sample_rate=_VAD_SAMPLE_RATE,
+            return_seconds=True,
+        )
+    except Exception as e:  # noqa: BLE001
+        logger.warning(
+            "VAD pre-trim: get_speech_timestamps failed on %r: %s — "
+            "falling back to unmodified transcription.",
+            audio_path,
+            e,
+        )
+        return _VADTrimResult(skipped=True)
+
+    if not speech_ts:
+        return _VADTrimResult(skipped=False, has_speech=False)
+
+    total_seconds = waveform.shape[-1] / _VAD_SAMPLE_RATE
+    start_s = max(0.0, float(speech_ts[0]["start"]) - _VAD_TRIM_PAD_SECONDS)
+    end_s = min(
+        total_seconds,
+        float(speech_ts[-1]["end"]) + _VAD_TRIM_PAD_SECONDS,
+    )
+    if end_s <= start_s:
+        # Degenerate span (shouldn't happen with valid VAD output, but
+        # be defensive). Treat as no speech to avoid pushing a zero-
+        # length array into Whisper.
+        return _VADTrimResult(skipped=False, has_speech=False)
+
+    start_sample = int(round(start_s * _VAD_SAMPLE_RATE))
+    end_sample = int(round(end_s * _VAD_SAMPLE_RATE))
+    trimmed = waveform[start_sample:end_sample]
+
+    return _VADTrimResult(
+        skipped=False,
+        has_speech=True,
+        waveform=trimmed,
+        offset_seconds=start_s,
+        sample_rate=_VAD_SAMPLE_RATE,
+    )
+
+
+def _shift_segment_time(seg: Any, offset: float) -> None:
+    """Add ``offset`` seconds to a segment's ``start``/``end`` (and
+    per-word times when word-level timestamps are present).
+
+    Mutates in place. Handles both dict-shaped segments (Whisper) and
+    object-shaped segments (Parakeet / future engines). No-op when a
+    key/attribute is missing or None.
+    """
+    if isinstance(seg, dict):
+        for key in ("start", "end"):
+            v = seg.get(key)
+            if v is not None:
+                seg[key] = float(v) + offset
+        words = seg.get("words")
+        if isinstance(words, list):
+            for w in words:
+                if not isinstance(w, dict):
+                    continue
+                for k in ("start", "end"):
+                    v = w.get(k)
+                    if v is not None:
+                        w[k] = float(v) + offset
+        return
+
+    for k in ("start", "end"):
+        if hasattr(seg, k):
+            v = getattr(seg, k)
+            if v is not None:
+                setattr(seg, k, float(v) + offset)
+
+
 class STTEngine:
     """
     Speech-to-Text engine supporting Whisper and Parakeet models.
@@ -75,6 +316,7 @@ class STTEngine:
     def __init__(
         self,
         model_name: str = DEFAULT_WHISPER_MODEL,
+        enable_vad_pretrim: bool = True,
     ):
         """
         Initialize STT engine.
@@ -87,6 +329,15 @@ class STTEngine:
                 - mlx-community/whisper-small-mlx
                 - mlx-community/parakeet-tdt-0.6b-v2 (English, fastest)
                 - mlx-community/parakeet-tdt-0.6b-v3
+            enable_vad_pretrim: If ``True`` (default) and the engine
+                is Whisper-shaped, run Silero VAD before Whisper. Pure-
+                silence clips return ``text=""`` (guards #961), and
+                clips with trailing/leading silence get trimmed to the
+                speech span (Whisper hallucinates less on shorter
+                inputs). Set to ``False`` to preserve pre-fix behaviour
+                — or set the env ``RAPID_MLX_STT_VAD_PRETRIM=0`` for a
+                run-wide override. Non-Whisper engines (Parakeet, etc.)
+                are unaffected regardless of this flag.
         """
         self.model_name = model_name
         self.model = None
@@ -100,6 +351,11 @@ class STTEngine:
         # only fires for actual Whisper backends — non-Whisper engines
         # surface their own load-time errors unmodified.
         self._is_whisper = "whisper" in model_name.lower()
+        # F-K-WHISPER-961: VAD pre-trim guard. See top-of-file block
+        # for the full rationale. Only applied to Whisper engines —
+        # Parakeet/Canary/etc. have their own silence semantics and
+        # are not covered by the reported issue.
+        self._enable_vad_pretrim = enable_vad_pretrim
 
     def load(self) -> None:
         """Load the STT model."""
@@ -236,6 +492,27 @@ class STTEngine:
 
         audio_path = str(audio_path)
 
+        # F-K-WHISPER-961: VAD pre-trim guard. Runs only for Whisper
+        # engines with the guard enabled — see class docstring + the
+        # module-level rationale block. On any failure the helper
+        # returns ``skipped=True`` and we fall back to the original
+        # unmodified path, so we never regress on pre-fix inputs.
+        trim: _VADTrimResult | None = None
+        if self._is_whisper and self._enable_vad_pretrim:
+            trim = _maybe_vad_trim(audio_path)
+            if not trim.skipped and not trim.has_speech:
+                logger.debug(
+                    "VAD pre-trim: no speech detected in %r; returning "
+                    "empty TranscriptionResult without invoking Whisper.",
+                    audio_path,
+                )
+                return TranscriptionResult(
+                    text="",
+                    language=None,
+                    duration=0.0,
+                    segments=[],
+                )
+
         try:
             # Use the model's generate method directly
             kwargs = {"verbose": False}
@@ -244,12 +521,35 @@ class STTEngine:
             if task and not self._is_parakeet:
                 kwargs["task"] = task
 
-            result = self.model.generate(audio_path, **kwargs)
+            # Choose the input Whisper actually sees: either the
+            # VAD-trimmed waveform (mono 16 kHz) or the original file
+            # path (fallback / VAD skipped / non-Whisper).
+            if trim is not None and not trim.skipped and trim.has_speech:
+                audio_input: Any = trim.waveform
+            else:
+                audio_input = audio_path
+
+            result = self.model.generate(audio_input, **kwargs)
 
             # Extract text and metadata from result
             text = getattr(result, "text", str(result)) if result else ""
             segments = getattr(result, "segments", None)
             detected_lang = getattr(result, "language", None)
+
+            # Absolute-time contract: if we handed Whisper a trimmed
+            # span starting at ``offset_seconds`` into the original
+            # audio, every segment.start / segment.end (and per-word
+            # timestamp, when present) must be shifted back by that
+            # offset so downstream consumers see file-relative times.
+            if (
+                segments
+                and trim is not None
+                and not trim.skipped
+                and trim.has_speech
+                and trim.offset_seconds > 0.0
+            ):
+                for seg in segments:
+                    _shift_segment_time(seg, trim.offset_seconds)
 
             # Calculate duration from segments if available
             duration = None

--- a/vllm_mlx/audio/stt.py
+++ b/vllm_mlx/audio/stt.py
@@ -9,6 +9,7 @@ Supports:
 
 import logging
 import os
+import threading
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -64,6 +65,25 @@ _VAD_MODEL_REPO = "mlx-community/silero-vad"
 _VAD_TRIM_PAD_SECONDS = 0.2
 _VAD_SAMPLE_RATE = 16_000
 
+# Codex r2 BLOCKING: bias Silero toward false positives (skip
+# Whisper less often than default) so quiet / whispered / breathy
+# speech doesn't get silenced. Silero's default threshold is 0.5;
+# 0.3 keeps the "confident no speech" bar the same at ~-50 dBFS
+# noise floors but starts calling ambiguous chunks "speech" earlier.
+# On pure digital silence the probability is essentially 0.0 (well
+# below either threshold) so this doesn't weaken the #961 guard.
+_VAD_SPEECH_THRESHOLD = 0.3
+
+# Codex r2 BLOCKING: additional defense — if VAD reports "no speech"
+# BUT the waveform's RMS is above this floor, distrust VAD and fall
+# back to Whisper. A signal at -50 dBFS is on the loud side for pure
+# background noise; anything louder is more likely to be quiet
+# speech (or intentional audio the caller wants transcribed) than
+# actual silence. The 12 s digital-silence repro in #961 has
+# RMS ≈ 0 so it stays firmly below this bar.
+# 10**(-50/20) ≈ 3.16e-3
+_VAD_NO_SPEECH_RMS_FLOOR = 3.16e-3
+
 # Load-once cache. Kept module-level (not instance-level) so multiple
 # STTEngine instances share one VAD model — the Silero weights are
 # ~1.7 MB but the mx.array upload isn't free either.
@@ -85,6 +105,13 @@ _VAD_SAMPLE_RATE = 16_000
 _VAD_MODEL_CACHE: Any | None = None
 _VAD_IMPORT_UNAVAILABLE = False
 _VAD_LOAD_FAILURE_LOGGED = False
+# Codex r2 NIT #3: serialize the first-load path so concurrent
+# transcriptions on server startup don't kick off N duplicate
+# downloads / weight-load rounds for the same singleton. The lock is
+# only held during the load itself; the fast-path (cache hit or
+# import-permanently-unavailable) skips the lock via the double-
+# checked read at the top of ``_get_vad_model``.
+_VAD_LOAD_LOCK = threading.Lock()
 
 
 # F-K-WHISPER-500: every mlx-community Whisper repo ships ONLY
@@ -190,41 +217,55 @@ def _get_vad_model() -> Any | None:
     block for the wider design.
     """
     global _VAD_MODEL_CACHE, _VAD_IMPORT_UNAVAILABLE, _VAD_LOAD_FAILURE_LOGGED
+    # Fast path (unlocked double-checked read): if the cache is warm
+    # or the module is permanently unavailable, don't take the load
+    # lock at all — every concurrent request would otherwise contend
+    # on a lock they never need.
     if _VAD_MODEL_CACHE is not None:
         return _VAD_MODEL_CACHE
     if _VAD_IMPORT_UNAVAILABLE:
         return None
-    try:
-        from mlx_audio.vad import load as vad_load  # noqa: PLC0415
-    except ImportError as e:
-        # Permanent for this process (module isn't importable).
-        _VAD_IMPORT_UNAVAILABLE = True
-        logger.warning(
-            "VAD pre-trim disabled: mlx_audio.vad not importable (%s). "
-            "Install rapid-mlx[audio] to enable the anti-hallucination "
-            "guard for pure-silence clips (#961).",
-            e,
-        )
-        return None
-    try:
-        _VAD_MODEL_CACHE = vad_load(_VAD_MODEL_REPO)
-    except Exception as e:  # noqa: BLE001
-        # Transient: log ONCE, then retry on every subsequent call so
-        # a recovered network / freed disk still gets the guard back.
-        if not _VAD_LOAD_FAILURE_LOGGED:
+    # Codex r2 NIT #3: serialize the actual load so N concurrent
+    # first-requests don't kick off N duplicate downloads / weight
+    # loads. Re-check under the lock in case a prior caller already
+    # succeeded.
+    with _VAD_LOAD_LOCK:
+        if _VAD_MODEL_CACHE is not None:
+            return _VAD_MODEL_CACHE
+        if _VAD_IMPORT_UNAVAILABLE:
+            return None
+        try:
+            from mlx_audio.vad import load as vad_load  # noqa: PLC0415
+        except ImportError as e:
+            # Permanent for this process (module isn't importable).
+            _VAD_IMPORT_UNAVAILABLE = True
             logger.warning(
-                "VAD pre-trim: could not load %r (%s). Retrying on "
-                "next request. Guard falls back to unmodified "
-                "transcription until load succeeds.",
-                _VAD_MODEL_REPO,
+                "VAD pre-trim disabled: mlx_audio.vad not importable (%s). "
+                "Install rapid-mlx[audio] to enable the anti-hallucination "
+                "guard for pure-silence clips (#961).",
                 e,
             )
-            _VAD_LOAD_FAILURE_LOGGED = True
-        return None
-    # Reset the log-once flag on eventual success so a subsequent
-    # process-level unload/re-init still surfaces a fresh warning.
-    _VAD_LOAD_FAILURE_LOGGED = False
-    return _VAD_MODEL_CACHE
+            return None
+        try:
+            _VAD_MODEL_CACHE = vad_load(_VAD_MODEL_REPO)
+        except Exception as e:  # noqa: BLE001
+            # Transient: log ONCE, then retry on every subsequent call
+            # so a recovered network / freed disk still gets the guard
+            # back.
+            if not _VAD_LOAD_FAILURE_LOGGED:
+                logger.warning(
+                    "VAD pre-trim: could not load %r (%s). Retrying on "
+                    "next request. Guard falls back to unmodified "
+                    "transcription until load succeeds.",
+                    _VAD_MODEL_REPO,
+                    e,
+                )
+                _VAD_LOAD_FAILURE_LOGGED = True
+            return None
+        # Reset the log-once flag on eventual success so a subsequent
+        # process-level unload/re-init still surfaces a fresh warning.
+        _VAD_LOAD_FAILURE_LOGGED = False
+        return _VAD_MODEL_CACHE
 
 
 def _maybe_vad_trim(audio_path: str) -> _VADTrimResult:
@@ -268,6 +309,7 @@ def _maybe_vad_trim(audio_path: str) -> _VADTrimResult:
         speech_ts = vad.get_speech_timestamps(
             waveform,
             sample_rate=_VAD_SAMPLE_RATE,
+            threshold=_VAD_SPEECH_THRESHOLD,
             return_seconds=True,
         )
     except Exception as e:  # noqa: BLE001
@@ -280,6 +322,22 @@ def _maybe_vad_trim(audio_path: str) -> _VADTrimResult:
         return _VADTrimResult(skipped=True)
 
     if not speech_ts:
+        # Codex r2 BLOCKING #1: VAD false-negative defence. Silero at
+        # threshold 0.3 is already biased toward false positives, but
+        # quiet / whispered / breathy speech in a noisy room can still
+        # slip past. Sanity-check the "no speech" verdict with an
+        # audio-energy floor: if the clip has non-trivial RMS
+        # (> ~-50 dBFS), trust the audio over the classifier and fall
+        # back to Whisper. Pure digital silence (RMS ≈ 0, the #961
+        # repro) stays well below the floor so the guard still fires.
+        if _rms_above_floor(waveform, _VAD_NO_SPEECH_RMS_FLOOR):
+            logger.info(
+                "VAD reported no speech but audio RMS exceeds silence "
+                "floor (%.4g) — falling back to Whisper to guard "
+                "against a Silero false negative on quiet speech.",
+                _VAD_NO_SPEECH_RMS_FLOOR,
+            )
+            return _VADTrimResult(skipped=True)
         return _VADTrimResult(skipped=False, has_speech=False)
 
     # Codex r1 BLOCKING: extract the span defensively. Upstream Silero
@@ -322,6 +380,42 @@ def _maybe_vad_trim(audio_path: str) -> _VADTrimResult:
         offset_seconds=start_s,
         sample_rate=_VAD_SAMPLE_RATE,
     )
+
+
+def _rms_above_floor(waveform: Any, floor: float) -> bool:
+    """Return ``True`` if the waveform's RMS energy exceeds ``floor``.
+
+    Used to sanity-check a "no speech" verdict from Silero — see
+    ``_maybe_vad_trim``. Accepts any array supporting ``float()``-able
+    ``mx.mean(x ** 2)`` (``mx.array``, ``np.ndarray``, list-of-floats
+    via numpy fallback). On any computation error returns ``True``
+    conservatively — the operative philosophy is "when in doubt,
+    transcribe" so we err toward calling Whisper.
+    """
+    try:
+        # Prefer mx.core if available for float32 fidelity; fall back
+        # to numpy which every audio-backed engine already ships.
+        import mlx.core as _mx  # noqa: PLC0415
+
+        arr = (
+            waveform
+            if isinstance(waveform, _mx.array)
+            else _mx.array(waveform, dtype=_mx.float32)
+        )
+        arr = arr.astype(_mx.float32)
+        rms = float(_mx.sqrt(_mx.mean(arr * arr)))
+    except Exception:  # noqa: BLE001
+        try:
+            import numpy as _np  # noqa: PLC0415
+
+            arr = _np.asarray(waveform, dtype=_np.float32)
+            rms = float(_np.sqrt(_np.mean(arr * arr)))
+        except Exception:  # noqa: BLE001
+            # If we can't measure energy, err toward "trust it's
+            # speech" — that's the conservative choice for #961's
+            # invariant (never eat real audio).
+            return True
+    return rms > floor
 
 
 def _shift_segment_time(seg: Any, offset: float) -> None:

--- a/vllm_mlx/audio/stt.py
+++ b/vllm_mlx/audio/stt.py
@@ -67,8 +67,24 @@ _VAD_SAMPLE_RATE = 16_000
 # Load-once cache. Kept module-level (not instance-level) so multiple
 # STTEngine instances share one VAD model — the Silero weights are
 # ~1.7 MB but the mx.array upload isn't free either.
+#
+# Codex r1 BLOCKING: distinguish permanent import failure from
+# transient load failure. Previously a single ``_VAD_LOAD_ATTEMPTED``
+# flag latched TRUE on ANY failure, so a one-off network hiccup at
+# process start would silently disable the guard for the entire
+# lifetime of the server — reintroducing the silence hallucination
+# for every later request. New scheme:
+#
+#   * ``_VAD_IMPORT_UNAVAILABLE`` — set only when ``import mlx_audio.vad``
+#     itself fails. That state cannot change without a process restart
+#     (the extras aren't installed), so caching TRUE is safe.
+#   * ``_VAD_LOAD_FAILURE_LOGGED`` — log-once suppression for transient
+#     ``vad_load(...)`` failures (HF 500, disk-full, weight mismatch).
+#     The failure is NOT cached — every subsequent call retries, so a
+#     later request whose network has recovered will succeed.
 _VAD_MODEL_CACHE: Any | None = None
-_VAD_LOAD_ATTEMPTED = False
+_VAD_IMPORT_UNAVAILABLE = False
+_VAD_LOAD_FAILURE_LOGGED = False
 
 
 # F-K-WHISPER-500: every mlx-community Whisper repo ships ONLY
@@ -156,21 +172,33 @@ def _vad_pretrim_disabled_by_env() -> bool:
 def _get_vad_model() -> Any | None:
     """Return the shared Silero VAD model, loading it on first call.
 
-    Returns ``None`` on any failure (import error, network hiccup,
-    weight-file mismatch) so callers fall back to the unmodified
-    transcription path without ever raising into ``transcribe()``.
-    The failure is logged at WARNING once — subsequent calls short-
-    circuit off ``_VAD_LOAD_ATTEMPTED`` and produce no more log spam.
+    Returns ``None`` on any failure so callers fall back to the
+    unmodified transcription path without ever raising into
+    ``transcribe()``. Failure caching is split by kind:
+
+    * ``ImportError`` — ``mlx_audio.vad`` isn't installed. Cached
+      permanently via ``_VAD_IMPORT_UNAVAILABLE``: the outcome cannot
+      change without a process restart.
+    * Any other load exception (HF fetch failed, weight mismatch,
+      disk full, transient network hiccup) — NOT cached. Subsequent
+      calls retry so a later request whose network has recovered can
+      still load the VAD. To avoid log spam we suppress repeat
+      warnings via ``_VAD_LOAD_FAILURE_LOGGED``.
+
+    Codex r1 BLOCKING: this split closes the "process-wide silent
+    disable on transient hiccup" hole. See the module-level comment
+    block for the wider design.
     """
-    global _VAD_MODEL_CACHE, _VAD_LOAD_ATTEMPTED
+    global _VAD_MODEL_CACHE, _VAD_IMPORT_UNAVAILABLE, _VAD_LOAD_FAILURE_LOGGED
     if _VAD_MODEL_CACHE is not None:
         return _VAD_MODEL_CACHE
-    if _VAD_LOAD_ATTEMPTED:
+    if _VAD_IMPORT_UNAVAILABLE:
         return None
-    _VAD_LOAD_ATTEMPTED = True
     try:
         from mlx_audio.vad import load as vad_load  # noqa: PLC0415
     except ImportError as e:
+        # Permanent for this process (module isn't importable).
+        _VAD_IMPORT_UNAVAILABLE = True
         logger.warning(
             "VAD pre-trim disabled: mlx_audio.vad not importable (%s). "
             "Install rapid-mlx[audio] to enable the anti-hallucination "
@@ -181,13 +209,21 @@ def _get_vad_model() -> Any | None:
     try:
         _VAD_MODEL_CACHE = vad_load(_VAD_MODEL_REPO)
     except Exception as e:  # noqa: BLE001
-        # Network failure, weight mismatch, HF gate — log once + bail.
-        logger.warning(
-            "VAD pre-trim disabled: could not load %r: %s",
-            _VAD_MODEL_REPO,
-            e,
-        )
+        # Transient: log ONCE, then retry on every subsequent call so
+        # a recovered network / freed disk still gets the guard back.
+        if not _VAD_LOAD_FAILURE_LOGGED:
+            logger.warning(
+                "VAD pre-trim: could not load %r (%s). Retrying on "
+                "next request. Guard falls back to unmodified "
+                "transcription until load succeeds.",
+                _VAD_MODEL_REPO,
+                e,
+            )
+            _VAD_LOAD_FAILURE_LOGGED = True
         return None
+    # Reset the log-once flag on eventual success so a subsequent
+    # process-level unload/re-init still surfaces a fresh warning.
+    _VAD_LOAD_FAILURE_LOGGED = False
     return _VAD_MODEL_CACHE
 
 
@@ -246,12 +282,29 @@ def _maybe_vad_trim(audio_path: str) -> _VADTrimResult:
     if not speech_ts:
         return _VADTrimResult(skipped=False, has_speech=False)
 
+    # Codex r1 BLOCKING: extract the span defensively. Upstream Silero
+    # today always emits ``{"start": float, "end": float}`` dicts (see
+    # ``mlx_audio.vad.models.silero_vad.silero_vad.Model._probs_to_
+    # timestamps``), but the contract is not typed and a future refactor
+    # / a mocked-in-test implementation could pass ``None`` or omit a
+    # key. A ``KeyError`` / ``TypeError`` here would escape the helper's
+    # "never raises" contract and 500 the request before Whisper's own
+    # fallback runs. Wrap + fall back to ``skipped=True``.
     total_seconds = waveform.shape[-1] / _VAD_SAMPLE_RATE
-    start_s = max(0.0, float(speech_ts[0]["start"]) - _VAD_TRIM_PAD_SECONDS)
-    end_s = min(
-        total_seconds,
-        float(speech_ts[-1]["end"]) + _VAD_TRIM_PAD_SECONDS,
-    )
+    try:
+        first_start = float(speech_ts[0]["start"])
+        last_end = float(speech_ts[-1]["end"])
+    except (KeyError, TypeError, ValueError, IndexError) as e:
+        logger.warning(
+            "VAD pre-trim: malformed timestamp entry %r: %s — falling "
+            "back to unmodified transcription.",
+            speech_ts,
+            e,
+        )
+        return _VADTrimResult(skipped=True)
+
+    start_s = max(0.0, first_start - _VAD_TRIM_PAD_SECONDS)
+    end_s = min(total_seconds, last_end + _VAD_TRIM_PAD_SECONDS)
     if end_s <= start_s:
         # Degenerate span (shouldn't happen with valid VAD output, but
         # be defensive). Treat as no speech to avoid pushing a zero-


### PR DESCRIPTION
## Summary

Fix for [#961](https://github.com/raullenchai/Rapid-MLX/issues/961) — Whisper STT hallucinates over silence: 12 s of digital silence transcribes as ``"Thank you."``, and real clips with trailing dead-air get transcribed correctly + an invented tail.

## Reporter's exact repro

Generate silence + run the reporter's Python snippet:

```bash
ffmpeg -y -f lavfi -i anullsrc=r=16000:cl=mono -t 12 silence.wav
```

```python
from vllm_mlx.audio.stt import STTEngine
eng = STTEngine("mlx-community/whisper-large-v3-turbo"); eng.load()
print(repr(eng.transcribe("silence.wav").text))
```

| behaviour | text |
|---|---|
| pre-fix (main) | `'Thank you.'` |
| post-fix (this PR) | `''` |

Also verified against the trailing-silence pattern (3 s silence + 2.5 s "the quick brown fox..." + 3 s silence): pre-fix produced a hallucinated tail, post-fix returns a single clean segment with the speech text and an absolute start time of `2.78 s` (leading silence correctly reflected).

## Root cause

`STTEngine.transcribe()` at `vllm_mlx/audio/stt.py` calls `self.model.generate(audio_path, **kwargs)` with no anti-hallucination handling. The documented guards inside `mlx_audio.stt.models.whisper.Model.generate` — `no_speech_threshold=0.6`, `logprob_threshold=-1.0`, `hallucination_silence_threshold` — are inert in practice because on pure silence Whisper returns:

* `no_speech_prob ≈ 9.6e-11` (upstream field: `mlx_audio/stt/models/whisper/whisper.py:1010`)
* `avg_logprob ≈ -0.26` (upstream field: `whisper.py:1008`)

The AND-gate skip condition at `whisper.py:964-970` (`no_speech_prob > no_speech_threshold AND avg_logprob < logprob_threshold`) therefore never fires and the model emits its silence-priors ("Thank you.", "Thanks for watching!", etc.). The reporter observed `NaN` on some chunked paths; either way the guard's precondition never holds on true silence.

Fixing this upstream would require modifying `mlx_audio` itself (not vendored here); monkey-patching it is fragile across upstream bumps.

## Design decision — VAD pre-trim vs upstream fix

| option | assessment |
|---|---|
| PR upstream to populate `no_speech_prob` | slow (gated on maintainer response); not our release |
| monkey-patch upstream `Model.generate` in rapid-mlx | fragile — breaks on next `mlx_audio` bump |
| re-compute `no_speech_prob` from decoder logits in `STTEngine` | reproduces internal decode loop; heavy for a bug fix |
| **VAD pre-trim in `transcribe()`** | **self-contained, systematic, model-agnostic** |

The chosen invariant — *"if the audio has no speech, don't invoke Whisper on it"* — is strictly stronger than post-hoc detection. It also uses a bundled dependency (`mlx_audio.vad.silero_vad`) so the `[audio]` extra needs no changes.

## Implementation

`vllm_mlx/audio/stt.py`:

* `_get_vad_model()` — lazy, once-per-process cached `mlx-community/silero-vad` load. Returns `None` on failure (missing extras, network, weight mismatch) → guard transparently falls back.
* `_maybe_vad_trim(audio_path) -> _VADTrimResult` — 3-shape outcome: `skipped=True` (fallback), `has_speech=False` (return empty), or `has_speech=True` (trim + offset). Never raises.
* `_shift_segment_time(seg, offset)` — mutates segment/word timestamps back to file-relative absolute time.
* `STTEngine.__init__(..., enable_vad_pretrim: bool = True)` — new kwarg.
* `STTEngine.transcribe()` — runs the guard before `self.model.generate(...)`; picks trimmed waveform vs. original path; shifts returned segments.

Gating contract (both must be true for the guard to run):
* engine kwarg `enable_vad_pretrim = True` (default)
* env `RAPID_MLX_STT_VAD_PRETRIM` ∉ `{"0","false","no","off"}` (case-insensitive)

Guard applies only to Whisper engines (`self._is_whisper`). Parakeet/Canary/future STT engines are unaffected.

## Timestamp-preservation contract

When VAD trims leading silence, every returned `segment.start` / `segment.end` (and per-word `word.start` / `word.end` when `word_timestamps=True`) is shifted back by the trim offset so downstream consumers see file-relative absolute times. Verified end-to-end: `3 s silence + speech` → `segment.start == 2.78 s`, not `0.0`.

## Test coverage

`tests/test_stt_vad_pretrim.py` — 30 tests, all passing:

- `TestSilenceReturnsEmpty::test_pure_silence_returns_empty_string` — VAD reports no speech → text=="", segments==[], Whisper NOT invoked.
- `TestRealSpeechStillTranscribes::test_real_speech_still_transcribes` — passes trimmed waveform to Whisper, text unchanged.
- `TestTrailingSilenceTrimmed::test_speech_with_trailing_silence_stops_at_speech_end` — no tail hallucination; last segment end within `speech_end + 0.5 s`.
- `TestVADDisabledViaEnv::test_vad_disabled_via_env_pass_through` — `RAPID_MLX_STT_VAD_PRETRIM=0` fully bypasses guard.
- `TestVADDisabledViaEnv::test_env_disable_accepts_common_falsy_strings` — parametrized over `false / no / off / FALSE / Off`.
- `TestAbsoluteTimestampsPreserved::test_absolute_timestamps_preserved_when_vad_trims_leading_silence` — 3 s silence + speech → segment.start ≥ 2.7 s.
- `TestAbsoluteTimestampsPreserved::test_word_level_timestamps_also_shifted` — per-word timestamps shifted too.
- `TestKwargOverrideDisables::test_enable_vad_pretrim_false_kwarg_disables` — kwarg False disables.
- `TestVADImportFailureFallsBack::test_vad_import_failure_falls_back` — simulated `mlx_audio.vad` `ImportError` → falls back to unmodified path.
- `TestParakeetEngineSkipsVAD::test_parakeet_engine_skips_vad` — Parakeet engine never consults VAD.
- `TestEnvHelper` (12 parametrized) — env-parser sanity.
- `TestShiftHelper` (4) — segment/word/object timestamp shifting.

No regressions in existing STT/audio suites:
- `tests/test_stt_response_format.py` — 18 passed
- `tests/test_stt_corrupted_file.py` — 14 passed
- `tests/test_audio*.py` — 204 passed

## Operator-visible behaviour changes

* **New env**: `RAPID_MLX_STT_VAD_PRETRIM` — set to `0` / `false` / `no` / `off` to disable the guard run-wide.
* **New engine kwarg**: `STTEngine(..., enable_vad_pretrim: bool = True)`.
* **First-request latency** on Whisper engines: adds a one-shot ~2 s VAD model download + load (cached in `~/.cache/huggingface/hub/models--mlx-community--silero-vad`), then ~200 ms VAD inference per call. Net latency is negative for silent clips (skips multi-second Whisper decode).
* **Timestamps in transcription responses**: now file-relative absolute times even when the guard trims leading silence (previously would have been `0.0`-relative to the trimmed span had the trim path existed — it did not).
* **Silence semantics**: pure-silence uploads return `text=""`, `segments=[]`, `duration=0.0`, `language=None` (was: hallucinated tokens like `"Thank you."`).

## Test plan

- [x] Reporter's `ffmpeg silence.wav` + Python snippet returns `''` on this branch.
- [x] Real 2.5 s speech still transcribes correctly.
- [x] `3 s silence + speech + 3 s silence` returns clean segment with absolute `start ≈ 2.78 s` and no tail hallucination.
- [x] `RAPID_MLX_STT_VAD_PRETRIM=0` restores pre-fix behaviour.
- [x] `tests/test_stt_vad_pretrim.py` — 30/30 pass.
- [x] `tests/test_stt_*` + `tests/test_audio*` — no regressions.
- [x] `ruff check` + `ruff format --check` — clean.

Closes #961

🤖 Generated with [Claude Code](https://claude.com/claude-code)