### PR TITLE
fix(chat-template): normalize assistant tool_call.arguments to dict at boundary (GH-973)

### DIFF
--- a/tests/test_chat_template_tool_call_arguments.py
+++ b/tests/test_chat_template_tool_call_arguments.py
@@ -237,11 +237,13 @@ class TestNormalizeAssistantToolCallArguments:
         # Original untouched.
         assert messages[0]["tool_calls"][0]["arguments"] == '{"city": "Paris"}'
 
-    def test_top_level_arguments_only_normalized_when_no_function_envelope(self):
-        """When ``function`` is present, ``function.arguments`` is
-        authoritative and any stray top-level ``arguments`` MUST NOT be
-        normalised — normalising both would double-mutate and could
-        introduce inconsistent state.
+    def test_mixed_shape_normalizes_both_nested_and_top_level(self):
+        """Codex r3 BLOCKING on PR #981 — a mixed-shape replay that
+        carries BOTH ``function.arguments`` and top-level ``arguments``
+        (some SDKs mirror the field for template compatibility) must
+        normalise both, otherwise a template that iterates
+        ``tc.arguments|items`` still crashes even when
+        ``tc.function.arguments`` was normalised.
         """
         messages = [
             {
@@ -249,16 +251,16 @@ class TestNormalizeAssistantToolCallArguments:
                 "tool_calls": [
                     {
                         "function": {"name": "x", "arguments": '{"a": 1}'},
-                        # Deliberately stray top-level payload — kept as-is.
-                        "arguments": "some other string",
+                        "arguments": '{"a": 1}',
                     }
                 ],
             }
         ]
         out = _normalize_assistant_tool_call_arguments(messages)
+        # Both shapes end up dict-form; templates that read either
+        # location render without crashing.
         assert out[0]["tool_calls"][0]["function"]["arguments"] == {"a": 1}
-        # Top-level left alone.
-        assert out[0]["tool_calls"][0]["arguments"] == "some other string"
+        assert out[0]["tool_calls"][0]["arguments"] == {"a": 1}
 
     def test_top_level_arguments_malformed_wrapped(self):
         messages = [

--- a/tests/test_chat_template_tool_call_arguments.py
+++ b/tests/test_chat_template_tool_call_arguments.py
@@ -185,6 +185,91 @@ class TestNormalizeAssistantToolCallArguments:
         m2 = [{"role": "assistant", "tool_calls": [{"function": "oops"}]}]
         assert _normalize_assistant_tool_call_arguments(m2) is m2
 
+    def test_absent_arguments_key_is_not_invented(self):
+        """Missing ``arguments`` key MUST NOT be materialised as
+        ``{"value": None}`` — that would silently invent a payload the
+        client never sent (codex r1 NIT on PR #981).
+        """
+        # Missing on nested function
+        m1 = [
+            {
+                "role": "assistant",
+                "tool_calls": [{"function": {"name": "x"}}],
+            }
+        ]
+        assert _normalize_assistant_tool_call_arguments(m1) is m1
+        # Missing on top-level (no ``function`` envelope)
+        m2 = [{"role": "assistant", "tool_calls": [{"name": "x"}]}]
+        assert _normalize_assistant_tool_call_arguments(m2) is m2
+        # Present but None on nested — treat as present (get_arguments
+        # explicitly wrapped) — this IS the SDK-bug case the wrapper
+        # exists for; verify we wrap None as {"value": None} only when
+        # the key is actually present.
+        m3 = [
+            {
+                "role": "assistant",
+                "tool_calls": [{"function": {"name": "x", "arguments": None}}],
+            }
+        ]
+        out3 = _normalize_assistant_tool_call_arguments(m3)
+        assert out3[0]["tool_calls"][0]["function"]["arguments"] == {"value": None}
+
+    def test_top_level_arguments_string_becomes_dict(self):
+        """Codex r1 BLOCKING: some templates access ``tool_call.arguments``
+        directly (no ``tool_call.function`` unwrap). The nested-only
+        normaliser leaked the JSON-string form to those templates.
+        """
+        messages = [
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "name": "get_weather",
+                        "arguments": '{"city": "Paris"}',
+                    }
+                ],
+            }
+        ]
+        out = _normalize_assistant_tool_call_arguments(messages)
+        assert out[0]["tool_calls"][0]["arguments"] == {"city": "Paris"}
+        # Original untouched.
+        assert messages[0]["tool_calls"][0]["arguments"] == '{"city": "Paris"}'
+
+    def test_top_level_arguments_only_normalized_when_no_function_envelope(self):
+        """When ``function`` is present, ``function.arguments`` is
+        authoritative and any stray top-level ``arguments`` MUST NOT be
+        normalised — normalising both would double-mutate and could
+        introduce inconsistent state.
+        """
+        messages = [
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {
+                        "function": {"name": "x", "arguments": '{"a": 1}'},
+                        # Deliberately stray top-level payload — kept as-is.
+                        "arguments": "some other string",
+                    }
+                ],
+            }
+        ]
+        out = _normalize_assistant_tool_call_arguments(messages)
+        assert out[0]["tool_calls"][0]["function"]["arguments"] == {"a": 1}
+        # Top-level left alone.
+        assert out[0]["tool_calls"][0]["arguments"] == "some other string"
+
+    def test_top_level_arguments_malformed_wrapped(self):
+        messages = [
+            {
+                "role": "assistant",
+                "tool_calls": [{"name": "x", "arguments": "not json"}],
+            }
+        ]
+        out = _normalize_assistant_tool_call_arguments(messages)
+        assert out[0]["tool_calls"][0]["arguments"] == {"value": "not json"}
+
 
 # ---------------------------------------------------------------------------
 # Cross-parser end-to-end coverage — apply_chat_template with fake
@@ -335,6 +420,25 @@ QWEN3_CODER_XML_LIKE_TEMPLATE = """\
 {% endfor -%}
 """
 
+# Top-level (flat) shape — some templates access ``tc.arguments`` directly
+# without an ``if tool_call.function is defined`` unwrap. Codex r1
+# BLOCKING on PR #981: the nested-only fix left this shape crashing.
+FLAT_TOP_LEVEL_TEMPLATE = """\
+{% for m in messages -%}
+{% if m.role == 'assistant' and m.tool_calls -%}
+{% for tc in m.tool_calls -%}
+<tool_call name={{ tc.name }}>
+{% for k, v in tc.arguments|items -%}
+{{ k }}={{ v }}
+{% endfor -%}
+</tool_call>
+{% endfor -%}
+{% else -%}
+{{ m.role }}: {{ m.content }}
+{% endif -%}
+{% endfor -%}
+"""
+
 # Table of (parser_family_id, template_str, expected_substrings_dict_form).
 # Each parser family gets exercised for both the dict-form input (baseline)
 # and the JSON-string input (the GH-973 crash form). Post-fix, both
@@ -456,6 +560,62 @@ def test_cross_parser_dict_and_string_render_identically(
         f"dict-form:\n{dict_form}\n"
         f"str-form:\n{string_form}"
     )
+
+
+def _messages_with_flat_top_level_tool_call(arguments):
+    """Legacy / flat wire shape: ``tool_call`` carries ``name`` + ``arguments``
+    directly, no ``function`` envelope. Some templates access it via
+    ``tc.arguments`` without an unwrap step; this is the codex r1
+    BLOCKING case on PR #981.
+    """
+    return [
+        {"role": "user", "content": "What's the weather in Paris?"},
+        {
+            "role": "assistant",
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "name": "get_weather",
+                    "arguments": arguments,
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "call_1",
+            "content": "sunny, 22C in Paris",
+        },
+        {"role": "user", "content": "and tomorrow?"},
+    ]
+
+
+def test_flat_top_level_template_json_string_arguments_renders():
+    """Codex r1 BLOCKING on PR #981 — templates that iterate
+    ``tc.arguments|items`` on the FLAT wire shape (no ``function``
+    unwrap) MUST also be normalised at the boundary.
+    """
+    tokenizer = _fake_tokenizer_with_template(FLAT_TOP_LEVEL_TEMPLATE)
+    messages = _messages_with_flat_top_level_tool_call('{"city": "Paris", "unit": "C"}')
+    prompt = apply_chat_template(tokenizer, messages)
+    assert "city=Paris" in prompt
+    assert "unit=C" in prompt
+
+
+def test_flat_top_level_template_dict_arguments_identical():
+    """The dict-form input and JSON-string input render identically on
+    the flat wire shape too."""
+    tokenizer_a = _fake_tokenizer_with_template(FLAT_TOP_LEVEL_TEMPLATE)
+    tokenizer_b = _fake_tokenizer_with_template(FLAT_TOP_LEVEL_TEMPLATE)
+    dict_form = apply_chat_template(
+        tokenizer_a,
+        _messages_with_flat_top_level_tool_call({"city": "Paris", "unit": "C"}),
+    )
+    string_form = apply_chat_template(
+        tokenizer_b,
+        _messages_with_flat_top_level_tool_call('{"city": "Paris", "unit": "C"}'),
+    )
+    assert dict_form == string_form
 
 
 def test_pydantic_ai_style_retry_message_list_does_not_crash():

--- a/tests/test_chat_template_tool_call_arguments.py
+++ b/tests/test_chat_template_tool_call_arguments.py
@@ -1,0 +1,496 @@
+# SPDX-License-Identifier: Apache-2.0
+"""GH-973 regression tests — assistant tool_call.arguments dict invariant.
+
+Every mainstream HF chat template renders prior assistant tool_calls by
+iterating ``tool_call.arguments|items`` (Qwen3 / Hermes / Llama3 / GLM4 /
+Nemotron / minimax). The OpenAI wire contract encodes
+``tool_calls[i].function.arguments`` as a JSON *string*, so any client
+that replays an assistant tool_call in the history verbatim (notably
+``pydantic_ai``'s structured-output retry path — GH-973) crashes the
+Jinja render with:
+
+    TypeError: Can only get item pairs from a mapping.
+
+The fix normalises assistant ``tool_call.function.arguments`` to a dict
+at the shared ``apply_chat_template`` boundary, which is the single choke
+point every model / route / engine funnels through. This test module
+pins:
+
+1. The helper's behaviour (dict / str-json / str-non-json / already-dict
+   / mixed).
+2. Cross-parser end-to-end coverage — hermes / qwen3 / qwen3-coder /
+   glm4.7 / harmony / minimax / deepseek-v3. Each parser gets a
+   template shape that would have crashed pre-fix (``|items``,
+   ``|tojson``, dict-attribute access) and we assert:
+     * no exception is raised
+     * the rendered prompt contains the expected argument values
+     * the dict-form input yields the same output as the JSON-string
+       input (backward-compat)
+
+The parser suite uses *minimal fake tokenizers* that carry the shape of
+each real Jinja template — we do NOT depend on the HF hub or on any
+mlx-lm model weights, so this suite runs in unit CI.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from vllm_mlx.utils.chat_template import (
+    _normalize_assistant_tool_call_arguments,
+    apply_chat_template,
+)
+
+# ---------------------------------------------------------------------------
+# Helper-level tests
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeAssistantToolCallArguments:
+    def test_json_string_dict_becomes_dict(self):
+        messages = [
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {
+                            "name": "get_weather",
+                            "arguments": '{"city": "Paris", "unit": "C"}',
+                        },
+                    }
+                ],
+            }
+        ]
+        out = _normalize_assistant_tool_call_arguments(messages)
+        assert out[0]["tool_calls"][0]["function"]["arguments"] == {
+            "city": "Paris",
+            "unit": "C",
+        }
+        # Original untouched — the API surface keeps the wire shape.
+        assert messages[0]["tool_calls"][0]["function"]["arguments"] == (
+            '{"city": "Paris", "unit": "C"}'
+        )
+
+    def test_already_dict_is_identity(self):
+        original_args = {"city": "Tokyo"}
+        messages = [
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {"function": {"name": "get_weather", "arguments": original_args}}
+                ],
+            }
+        ]
+        out = _normalize_assistant_tool_call_arguments(messages)
+        # Short-circuit: nothing to normalise, so the list is returned
+        # by reference (idempotent — layering on top of upstream
+        # normalisers costs nothing).
+        assert out is messages
+        assert out[0]["tool_calls"][0]["function"]["arguments"] is original_args
+
+    def test_json_string_non_dict_is_wrapped(self):
+        messages = [
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {"function": {"name": "echo", "arguments": '["a", "b"]'}}
+                ],
+            }
+        ]
+        out = _normalize_assistant_tool_call_arguments(messages)
+        assert out[0]["tool_calls"][0]["function"]["arguments"] == {"value": ["a", "b"]}
+
+    def test_malformed_json_is_wrapped(self):
+        messages = [
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {"function": {"name": "bad", "arguments": "{not valid json"}}
+                ],
+            }
+        ]
+        out = _normalize_assistant_tool_call_arguments(messages)
+        assert out[0]["tool_calls"][0]["function"]["arguments"] == {
+            "value": "{not valid json"
+        }
+
+    def test_non_assistant_messages_untouched(self):
+        messages = [
+            {"role": "user", "content": "hi"},
+            {"role": "tool", "tool_call_id": "x", "content": "result"},
+            {"role": "system", "content": "you are a helper"},
+        ]
+        out = _normalize_assistant_tool_call_arguments(messages)
+        assert out is messages  # no-op short-circuit
+
+    def test_assistant_without_tool_calls_untouched(self):
+        messages = [{"role": "assistant", "content": "hello"}]
+        out = _normalize_assistant_tool_call_arguments(messages)
+        assert out is messages
+
+    def test_multi_tool_call_batch(self):
+        messages = [
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {"function": {"name": "a", "arguments": '{"x": 1}'}},
+                    {"function": {"name": "b", "arguments": {"y": 2}}},
+                    {"function": {"name": "c", "arguments": '{"z": 3}'}},
+                ],
+            }
+        ]
+        out = _normalize_assistant_tool_call_arguments(messages)
+        args = [tc["function"]["arguments"] for tc in out[0]["tool_calls"]]
+        assert args == [{"x": 1}, {"y": 2}, {"z": 3}]
+
+    def test_partial_mutation_preserves_untouched_messages(self):
+        # Only the last message needs mutation. The middle assistant
+        # message is dict-form and MUST pass through by reference.
+        user_msg = {"role": "user", "content": "q"}
+        dict_form_msg = {
+            "role": "assistant",
+            "tool_calls": [{"function": {"name": "x", "arguments": {"a": 1}}}],
+        }
+        tool_msg = {"role": "tool", "content": "r"}
+        str_form_msg = {
+            "role": "assistant",
+            "tool_calls": [{"function": {"name": "y", "arguments": '{"b": 2}'}}],
+        }
+        messages = [user_msg, dict_form_msg, tool_msg, str_form_msg]
+        out = _normalize_assistant_tool_call_arguments(messages)
+        assert out[0] is user_msg
+        assert out[1] is dict_form_msg
+        assert out[2] is tool_msg
+        # Touched message got copied so the caller's message list is
+        # left with the OpenAI-wire string form.
+        assert out[3] is not str_form_msg
+        assert out[3]["tool_calls"][0]["function"]["arguments"] == {"b": 2}
+        assert str_form_msg["tool_calls"][0]["function"]["arguments"] == '{"b": 2}'
+
+    def test_empty_and_degenerate_shapes(self):
+        # Empty list
+        assert _normalize_assistant_tool_call_arguments([]) == []
+        # Non-list
+        assert _normalize_assistant_tool_call_arguments("not a list") == "not a list"  # type: ignore[arg-type]
+        # Non-dict message
+        assert _normalize_assistant_tool_call_arguments([42]) == [42]  # type: ignore[list-item]
+        # Assistant with tool_calls not a list
+        m = [{"role": "assistant", "tool_calls": "oops"}]
+        assert _normalize_assistant_tool_call_arguments(m) is m
+        # Assistant with tool_call whose function is not a dict
+        m2 = [{"role": "assistant", "tool_calls": [{"function": "oops"}]}]
+        assert _normalize_assistant_tool_call_arguments(m2) is m2
+
+
+# ---------------------------------------------------------------------------
+# Cross-parser end-to-end coverage — apply_chat_template with fake
+# tokenizers that mimic each real family's Jinja arguments-access shape.
+# ---------------------------------------------------------------------------
+
+
+def _fake_tokenizer_with_template(chat_template_str: str) -> MagicMock:
+    """Return a tokenizer stub that renders ``chat_template_str`` via a real
+    Jinja environment.
+
+    The stub exposes the same surface the sanitiser wants (all-special-tokens
+    lists), so the sanitisation layer and the tool-call normalisation layer
+    both run end-to-end.
+    """
+    import jinja2
+
+    env = jinja2.Environment(  # noqa: S701 - test scaffolding
+        keep_trailing_newline=True,
+        trim_blocks=True,
+        lstrip_blocks=True,
+    )
+    template = env.from_string(chat_template_str)
+
+    tok = MagicMock()
+    tok.all_special_tokens = []
+    tok.additional_special_tokens = []
+    tok.special_tokens_map = {}
+    # Prevent recursive processor-unwrap in _collect_role_markers.
+    del tok.tokenizer
+
+    def _apply(messages, tokenize=False, add_generation_prompt=True, **kwargs):
+        return template.render(
+            messages=messages,
+            add_generation_prompt=add_generation_prompt,
+            **kwargs,
+        )
+
+    tok.apply_chat_template.side_effect = _apply
+    return tok
+
+
+# --- The template shapes (one per parser family). ------------------------
+#
+# These are minimal — only the bits that touch ``tool_call.arguments``.
+# Each shape is representative of the family's real chat_template.jinja
+# on HuggingFace (Qwen3 / Hermes / Llama3 / GLM4.7 / harmony / minimax /
+# DeepSeek-V3 as of 2026-Q2). The goal is not to fully render the
+# family's prompt — just to trigger the ``|items`` / ``|tojson`` /
+# dict-access path that GH-973's traceback shows.
+
+# Qwen3 / Nemotron shape — ``arguments|items`` (the actual crashing form).
+QWEN3_LIKE_TEMPLATE = """\
+{% for m in messages -%}
+{% if m.role == 'assistant' and m.tool_calls -%}
+{%- for tc in m.tool_calls -%}
+<tool_call>
+name={{ tc.function.name }}
+{% for k, v in tc.function.arguments|items -%}
+{{ k }}={{ v }}
+{% endfor -%}
+</tool_call>
+{% endfor -%}
+{% else -%}
+{{ m.role }}: {{ m.content }}
+{% endif -%}
+{% endfor -%}
+"""
+
+# Hermes shape — dict-attribute access via `|tojson` (used by NousResearch
+# Hermes 2/3 tool-use templates).
+HERMES_LIKE_TEMPLATE = """\
+{% for m in messages -%}
+{% if m.role == 'assistant' and m.tool_calls -%}
+{% for tc in m.tool_calls -%}
+<tool_call>{"name": "{{ tc.function.name }}", "arguments": {{ tc.function.arguments | tojson }}}</tool_call>
+{% endfor -%}
+{% else -%}
+{{ m.role }}: {{ m.content }}
+{% endif -%}
+{% endfor -%}
+"""
+
+# GLM 4.7 shape — same ``|items`` pattern (GLM-4.6 / 4.7 templates).
+GLM47_LIKE_TEMPLATE = QWEN3_LIKE_TEMPLATE
+
+# Harmony (gpt-oss) shape — dict access + ``|tojson``.
+HARMONY_LIKE_TEMPLATE = """\
+{% for m in messages -%}
+{% if m.role == 'assistant' and m.tool_calls -%}
+{% for tc in m.tool_calls -%}
+<|start|>assistant to=functions.{{ tc.function.name }}<|channel|>commentary<|message|>{{ tc.function.arguments | tojson }}<|end|>
+{% endfor -%}
+{% else -%}
+{{ m.role }}: {{ m.content }}
+{% endif -%}
+{% endfor -%}
+"""
+
+# MiniMax shape — mixed access (dict-key + iteration).
+MINIMAX_LIKE_TEMPLATE = """\
+{% for m in messages -%}
+{% if m.role == 'assistant' and m.tool_calls -%}
+{% for tc in m.tool_calls -%}
+[function_call]{{ tc.function.name }}
+{% for k, v in tc.function.arguments|items -%}
+{{ k }} = {{ v }}
+{% endfor -%}
+[/function_call]
+{% endfor -%}
+{% else -%}
+{{ m.role }}: {{ m.content }}
+{% endif -%}
+{% endfor -%}
+"""
+
+# DeepSeek V3 shape — dict-attribute access with fenced JSON body.
+DEEPSEEK_V3_LIKE_TEMPLATE = """\
+{% for m in messages -%}
+{% if m.role == 'assistant' and m.tool_calls -%}
+{% for tc in m.tool_calls -%}
+```json
+{"name": "{{ tc.function.name }}", "arguments": {{ tc.function.arguments | tojson }}}
+```
+{% endfor -%}
+{% else -%}
+{{ m.role }}: {{ m.content }}
+{% endif -%}
+{% endfor -%}
+"""
+
+# Qwen3-coder XML shape — attribute access + string-safe cast (matches the
+# in-tree Nemotron template's `<parameter=NAME>VALUE</parameter>` output,
+# which is the closest thing to the qwen3-coder-xml family in the repo).
+QWEN3_CODER_XML_LIKE_TEMPLATE = """\
+{% for m in messages -%}
+{% if m.role == 'assistant' and m.tool_calls -%}
+{% for tc in m.tool_calls -%}
+<function={{ tc.function.name }}>
+{% for k, v in tc.function.arguments|items -%}
+<parameter={{ k }}>{{ v | string }}</parameter>
+{% endfor -%}
+</function>
+{% endfor -%}
+{% else -%}
+{{ m.role }}: {{ m.content }}
+{% endif -%}
+{% endfor -%}
+"""
+
+# Table of (parser_family_id, template_str, expected_substrings_dict_form).
+# Each parser family gets exercised for both the dict-form input (baseline)
+# and the JSON-string input (the GH-973 crash form). Post-fix, both
+# inputs render the same output.
+PARSER_TEMPLATE_MATRIX = [
+    ("hermes", HERMES_LIKE_TEMPLATE, ['"city":', '"Paris"']),
+    ("qwen3_xml", QWEN3_LIKE_TEMPLATE, ["city=Paris", "unit=C"]),
+    ("qwen3_coder_xml", QWEN3_CODER_XML_LIKE_TEMPLATE, ["<parameter=city>Paris"]),
+    ("glm4_7", GLM47_LIKE_TEMPLATE, ["city=Paris", "unit=C"]),
+    ("harmony", HARMONY_LIKE_TEMPLATE, ['"city":', '"Paris"']),
+    ("minimax", MINIMAX_LIKE_TEMPLATE, ["city = Paris", "unit = C"]),
+    ("deepseek_v3", DEEPSEEK_V3_LIKE_TEMPLATE, ['"city":', '"Paris"']),
+]
+
+
+def _messages_with_assistant_tool_call(arguments):
+    return [
+        {"role": "user", "content": "What's the weather in Paris?"},
+        {
+            "role": "assistant",
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "get_weather", "arguments": arguments},
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "call_1",
+            "content": "sunny, 22C in Paris",
+        },
+        {"role": "user", "content": "and tomorrow?"},
+    ]
+
+
+@pytest.mark.parametrize(
+    ("parser_id", "template_str", "expected_substrings"),
+    PARSER_TEMPLATE_MATRIX,
+    ids=[row[0] for row in PARSER_TEMPLATE_MATRIX],
+)
+def test_cross_parser_json_string_arguments_renders_without_crash(
+    parser_id, template_str, expected_substrings
+):
+    """The GH-973 crash form: ``arguments`` = OpenAI-wire JSON string.
+
+    Every mainstream template family iterates or dict-accesses
+    ``tool_call.function.arguments``, so any of these would raise a
+    ``TypeError`` on the JSON-string form pre-fix. Post-fix, the shared
+    ``apply_chat_template`` normalises to dict before the Jinja render.
+    """
+    tokenizer = _fake_tokenizer_with_template(template_str)
+    messages = _messages_with_assistant_tool_call('{"city": "Paris", "unit": "C"}')
+
+    prompt = apply_chat_template(tokenizer, messages)
+
+    for expected in expected_substrings:
+        assert expected in prompt, (
+            f"[{parser_id}] expected substring {expected!r} not found in "
+            f"prompt:\n{prompt}"
+        )
+
+
+@pytest.mark.parametrize(
+    ("parser_id", "template_str", "expected_substrings"),
+    PARSER_TEMPLATE_MATRIX,
+    ids=[row[0] for row in PARSER_TEMPLATE_MATRIX],
+)
+def test_cross_parser_dict_arguments_backward_compat(
+    parser_id, template_str, expected_substrings
+):
+    """Backward-compat: dict-form input renders exactly like it did pre-fix.
+
+    Callers that already pass dict-form (the ``routes/chat.py`` non-MLLM
+    path, the ``engine/batched.py`` upstream normaliser) MUST NOT
+    regress. The normaliser short-circuits when nothing needs mutation
+    (returns the caller's list by reference), so this is also the
+    perf-critical common case.
+    """
+    tokenizer = _fake_tokenizer_with_template(template_str)
+    messages = _messages_with_assistant_tool_call({"city": "Paris", "unit": "C"})
+
+    prompt = apply_chat_template(tokenizer, messages)
+
+    for expected in expected_substrings:
+        assert expected in prompt, (
+            f"[{parser_id}] expected substring {expected!r} not found in "
+            f"prompt:\n{prompt}"
+        )
+
+
+@pytest.mark.parametrize(
+    ("parser_id", "template_str", "expected_substrings"),
+    PARSER_TEMPLATE_MATRIX,
+    ids=[row[0] for row in PARSER_TEMPLATE_MATRIX],
+)
+def test_cross_parser_dict_and_string_render_identically(
+    parser_id, template_str, expected_substrings
+):
+    """The GH-973 invariant: str-form and dict-form MUST render to the
+    same prompt post-normalisation. This is the property that makes
+    ``pydantic_ai``'s structured-output retry path work — the retry
+    replay uses the JSON-string wire shape, the initial call uses dict.
+    """
+    tokenizer_a = _fake_tokenizer_with_template(template_str)
+    tokenizer_b = _fake_tokenizer_with_template(template_str)
+
+    dict_form = apply_chat_template(
+        tokenizer_a,
+        _messages_with_assistant_tool_call({"city": "Paris", "unit": "C"}),
+    )
+    string_form = apply_chat_template(
+        tokenizer_b,
+        _messages_with_assistant_tool_call('{"city": "Paris", "unit": "C"}'),
+    )
+    assert dict_form == string_form, (
+        f"[{parser_id}] dict-form and str-form renders diverged:\n"
+        f"dict-form:\n{dict_form}\n"
+        f"str-form:\n{string_form}"
+    )
+
+
+def test_pydantic_ai_style_retry_message_list_does_not_crash():
+    """End-to-end shape of the GH-973 repro: replayed assistant tool_call
+    whose ``arguments`` is a JSON string (the pydantic_ai retry path
+    against Qwen3.5 / 3.6). Pre-fix this raised ``TypeError`` mid-render
+    and the route returned 500. Post-fix the render succeeds and the
+    prompt contains the tool call's parsed arguments.
+    """
+    tokenizer = _fake_tokenizer_with_template(QWEN3_LIKE_TEMPLATE)
+    messages = [
+        {"role": "system", "content": "You are a helper."},
+        {"role": "user", "content": "Extract: 'Alice is 30 years old'"},
+        {
+            # pydantic_ai's retry replay — arguments as JSON string per
+            # the OpenAI wire contract.
+            "role": "assistant",
+            "tool_calls": [
+                {
+                    "id": "call_final_result_1",
+                    "type": "function",
+                    "function": {
+                        "name": "final_result",
+                        "arguments": '{"name": "Alice", "age": 30}',
+                    },
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "call_final_result_1",
+            "content": "validation_error: age must be int",
+        },
+        {"role": "user", "content": "Please retry."},
+    ]
+    prompt = apply_chat_template(tokenizer, messages)
+    assert "name=Alice" in prompt
+    assert "age=30" in prompt

--- a/vllm_mlx/utils/chat_template.py
+++ b/vllm_mlx/utils/chat_template.py
@@ -421,12 +421,13 @@ def _tool_call_arguments_need_mutation(tool_call: dict) -> tuple[bool, bool]:
 
     * ``nested_needs`` — ``function.arguments`` is present AND non-dict.
     * ``top_needs`` — ``tool_call.arguments`` (top-level) is present AND
-      non-dict AND there is no nested ``function`` dict (top-level
-      arguments is the fallback shape for legacy clients that flatten
-      the OpenAI envelope; when ``function`` is present the OpenAI
-      convention is that ``function.arguments`` is authoritative and
-      the top-level ``arguments`` doesn't exist — a defensive extra
-      normalisation there could double-mutate).
+      non-dict. Both shapes are normalised INDEPENDENTLY: a mixed-shape
+      replay that carries BOTH nested and top-level ``arguments`` (some
+      SDKs mirror the field for template compatibility) must have both
+      forms dict-safe, otherwise a template that iterates
+      ``tc.arguments|items`` still crashes even when
+      ``tc.function.arguments`` was normalised (codex r3 BLOCKING on
+      PR #981).
 
     Absent ``arguments`` keys yield ``False`` — we don't invent a
     payload for something the caller never sent (codex r1 NIT).
@@ -437,10 +438,8 @@ def _tool_call_arguments_need_mutation(tool_call: dict) -> tuple[bool, bool]:
         and "arguments" in function
         and not isinstance(function.get("arguments"), dict)
     )
-    top_needs = (
-        not isinstance(function, dict)
-        and "arguments" in tool_call
-        and not isinstance(tool_call.get("arguments"), dict)
+    top_needs = "arguments" in tool_call and not isinstance(
+        tool_call.get("arguments"), dict
     )
     return nested_needs, top_needs
 
@@ -461,7 +460,7 @@ def _normalize_assistant_tool_call_arguments(messages: list) -> list:
     * ABSENT ``arguments`` key is untouched — we do not invent a
       payload the client never sent (codex r1 NIT).
 
-    Both OpenAI-wire shapes are covered:
+    Both OpenAI-wire shapes are covered INDEPENDENTLY:
 
     * Nested — ``tool_call.function.arguments`` (OpenAI ChatCompletion
       canonical shape; pydantic_ai / OpenAI SDK).
@@ -471,6 +470,13 @@ def _normalize_assistant_tool_call_arguments(messages: list) -> list:
       ``if tool_call.function is defined`` unwrap step, so the
       nested-only fix leaked the JSON-string form to those templates
       and the same ``TypeError`` fired.
+
+    A mixed-shape replay (both nested AND top-level ``arguments``
+    populated — some SDKs mirror the field for template compatibility)
+    normalises BOTH. Codex r3 BLOCKING on PR #981 — a defensive
+    "top-level only when nested absent" gate still leaked the
+    JSON-string form to ``tc.arguments|items`` templates on the mixed
+    replay shape.
 
     Idempotent: repeated calls after the first are no-ops for
     dict-form arguments, so this can safely layer on top of upstream

--- a/vllm_mlx/utils/chat_template.py
+++ b/vllm_mlx/utils/chat_template.py
@@ -384,9 +384,70 @@ def _normalize_text_only_content_arrays(messages: list[dict]) -> list[dict]:
 #     wrapper so log-style renderers keep the original text.
 
 
+def _coerce_arguments_to_dict(arguments):
+    """Convert an ``arguments`` value to a dict per the GH-973 rules.
+
+    * ``dict`` → returned unchanged (idempotent).
+    * ``str`` → ``json.loads``; if the parsed value is a dict, use it;
+      otherwise wrap the parsed value as ``{"value": <parsed>}``.
+    * ``str`` that fails to JSON-parse → wrap as ``{"value": <raw>}``.
+    * Anything else (``list``, scalar, ...) → wrap as ``{"value": <raw>}``.
+
+    Callers MUST have already checked that an ``arguments`` key is
+    present on the source dict — this helper is only invoked after
+    presence-and-non-dict is confirmed by the two-pass walk in
+    :func:`_normalize_assistant_tool_call_arguments`, so an absent key
+    never reaches here (codex r1 NIT: pre-fix we synthesised
+    ``{"value": None}`` for absent ``arguments``, silently inventing an
+    argument payload; the presence guard closes that).
+    """
+    if isinstance(arguments, dict):
+        return arguments
+    if isinstance(arguments, str):
+        try:
+            parsed = json.loads(arguments)
+        except (json.JSONDecodeError, ValueError, TypeError):
+            return {"value": arguments}
+        if isinstance(parsed, dict):
+            return parsed
+        return {"value": parsed}
+    # Non-string, non-dict — rarely seen (an SDK bug or a test injecting
+    # a bare list/int). Wrap so ``|items`` still works.
+    return {"value": arguments}
+
+
+def _tool_call_arguments_need_mutation(tool_call: dict) -> tuple[bool, bool]:
+    """Return ``(nested_needs, top_needs)`` for ``tool_call``.
+
+    * ``nested_needs`` — ``function.arguments`` is present AND non-dict.
+    * ``top_needs`` — ``tool_call.arguments`` (top-level) is present AND
+      non-dict AND there is no nested ``function`` dict (top-level
+      arguments is the fallback shape for legacy clients that flatten
+      the OpenAI envelope; when ``function`` is present the OpenAI
+      convention is that ``function.arguments`` is authoritative and
+      the top-level ``arguments`` doesn't exist — a defensive extra
+      normalisation there could double-mutate).
+
+    Absent ``arguments`` keys yield ``False`` — we don't invent a
+    payload for something the caller never sent (codex r1 NIT).
+    """
+    function = tool_call.get("function")
+    nested_needs = (
+        isinstance(function, dict)
+        and "arguments" in function
+        and not isinstance(function.get("arguments"), dict)
+    )
+    top_needs = (
+        not isinstance(function, dict)
+        and "arguments" in tool_call
+        and not isinstance(tool_call.get("arguments"), dict)
+    )
+    return nested_needs, top_needs
+
+
 def _normalize_assistant_tool_call_arguments(messages: list) -> list:
     """Return ``messages`` with every ``assistant``-role tool_call's
-    ``function.arguments`` normalized to a dict.
+    ``arguments`` normalised to a dict.
 
     Rules (mirror ``engine/batched.py::_normalize_tool_call_arguments_
     for_template`` so the two normalisers are semantically identical
@@ -397,6 +458,19 @@ def _normalize_assistant_tool_call_arguments(messages: list) -> list:
       otherwise wrap as ``{"value": <parsed>}``.
     * ``str`` that fails to JSON-parse → wrap as ``{"value": <raw>}``.
     * Every non-assistant role is untouched.
+    * ABSENT ``arguments`` key is untouched — we do not invent a
+      payload the client never sent (codex r1 NIT).
+
+    Both OpenAI-wire shapes are covered:
+
+    * Nested — ``tool_call.function.arguments`` (OpenAI ChatCompletion
+      canonical shape; pydantic_ai / OpenAI SDK).
+    * Top-level — ``tool_call.arguments`` (legacy / MCP / a few chat
+      templates that flatten the envelope). Codex r1 BLOCKING: some
+      templates access ``tool_call.arguments`` directly without an
+      ``if tool_call.function is defined`` unwrap step, so the
+      nested-only fix leaked the JSON-string form to those templates
+      and the same ``TypeError`` fired.
 
     Idempotent: repeated calls after the first are no-ops for
     dict-form arguments, so this can safely layer on top of upstream
@@ -405,16 +479,17 @@ def _normalize_assistant_tool_call_arguments(messages: list) -> list:
 
     The scan is O(N) over messages. When nothing needs mutation we
     return the caller's list unchanged (no copy). When at least one
-    ``function.arguments`` needs conversion we materialise a shallow
-    copy of the touched messages (and their ``tool_calls``) so the
-    caller's message list — which the route layer treats as the API
-    surface where ``arguments`` MUST stay a string — is left intact.
+    ``arguments`` needs conversion we materialise a shallow copy of
+    the touched messages (and their ``tool_calls``) so the caller's
+    message list — which the route layer treats as the API surface
+    where ``arguments`` MUST stay a string — is left intact.
     """
     if not isinstance(messages, list) or not messages:
         return messages
 
-    # First pass: detect whether any assistant tool_call.function.arguments
-    # is a non-dict. If none, short-circuit without touching the list.
+    # First pass: detect whether any assistant tool_call has a
+    # non-dict ``arguments`` payload (either nested under ``function``
+    # or top-level). If none, short-circuit without touching the list.
     needs_mutation = False
     for msg in messages:
         if not isinstance(msg, dict) or msg.get("role") != "assistant":
@@ -425,10 +500,8 @@ def _normalize_assistant_tool_call_arguments(messages: list) -> list:
         for tc in tool_calls:
             if not isinstance(tc, dict):
                 continue
-            function = tc.get("function")
-            if not isinstance(function, dict):
-                continue
-            if not isinstance(function.get("arguments"), dict):
+            nested_needs, top_needs = _tool_call_arguments_need_mutation(tc)
+            if nested_needs or top_needs:
                 needs_mutation = True
                 break
         if needs_mutation:
@@ -453,37 +526,20 @@ def _normalize_assistant_tool_call_arguments(messages: list) -> list:
             if not isinstance(tc, dict):
                 new_tool_calls.append(tc)
                 continue
-            function = tc.get("function")
-            if not isinstance(function, dict):
+            nested_needs, top_needs = _tool_call_arguments_need_mutation(tc)
+            if not nested_needs and not top_needs:
                 new_tool_calls.append(tc)
                 continue
-            arguments = function.get("arguments")
-            if isinstance(arguments, dict):
-                new_tool_calls.append(tc)
-                continue
-            # arguments is a string (or something else we treat as the
-            # OpenAI wire shape). Try to parse; fall through to the
-            # ``{"value": ...}`` wrapper on failure or non-dict result.
-            new_arguments: dict
-            if isinstance(arguments, str):
-                try:
-                    parsed = json.loads(arguments)
-                except (json.JSONDecodeError, ValueError, TypeError):
-                    new_arguments = {"value": arguments}
-                else:
-                    if isinstance(parsed, dict):
-                        new_arguments = parsed
-                    else:
-                        new_arguments = {"value": parsed}
-            else:
-                # Non-string, non-dict — rarely seen (an SDK bug or a
-                # test injecting a bare list/int). Wrap so the template's
-                # ``|items`` still works.
-                new_arguments = {"value": arguments}
-            new_function = dict(function)
-            new_function["arguments"] = new_arguments
             new_tc = dict(tc)
-            new_tc["function"] = new_function
+            if nested_needs:
+                function = tc["function"]
+                new_function = dict(function)
+                new_function["arguments"] = _coerce_arguments_to_dict(
+                    function["arguments"]
+                )
+                new_tc["function"] = new_function
+            if top_needs:
+                new_tc["arguments"] = _coerce_arguments_to_dict(tc["arguments"])
             new_tool_calls.append(new_tc)
             touched_any = True
         if touched_any:

--- a/vllm_mlx/utils/chat_template.py
+++ b/vllm_mlx/utils/chat_template.py
@@ -344,6 +344,157 @@ def _normalize_text_only_content_arrays(messages: list[dict]) -> list[dict]:
     return out
 
 
+# =============================================================================
+# GH-973: assistant tool_call.arguments dict-form invariant
+# =============================================================================
+#
+# The OpenAI wire contract encodes ``message.tool_calls[i].function.arguments``
+# as a JSON string (see: https://platform.openai.com/docs/api-reference/chat/
+# create → ``tool_calls.function.arguments``). Every mainstream HF chat
+# template (Qwen3 / Hermes / Llama3 / GLM4 / Nemotron / minimax) iterates
+# that field as a mapping — ``tool_call.arguments|items`` — so a JSON-string
+# render blows up with:
+#
+#     TypeError: Can only get item pairs from a mapping.
+#
+# The bug surfaces on the ``pydantic_ai`` structured-output retry path
+# (GH-973): pydantic_ai replays the prior assistant tool_call verbatim in
+# the OpenAI wire shape (``arguments`` = JSON string), and the retry pass
+# through ``apply_chat_template`` crashes with 500. The direct fix upstream
+# in ``routes/chat.py::extract_multimodal_content`` and
+# ``engine/batched.py::_normalize_tool_call_arguments_for_template`` covers
+# the standard ``/v1/chat/completions`` non-MLLM path, but every other
+# caller of the shared ``apply_chat_template`` (guided-generation
+# ``BatchedEngine.stream_guided_completion``, native-video path, direct
+# engine callers, tests) bypassed those. Moving the invariant to the
+# shared ``apply_chat_template`` boundary makes it a single choke point.
+#
+# Behaviour matches ``engine/batched.py::_normalize_tool_call_arguments_
+# for_template`` (str → parsed dict when JSON dict; parsed non-dict
+# wrapped as ``{"value": <parsed>}``; malformed JSON wrapped as
+# ``{"value": <raw>}``). Dict-form arguments pass through unchanged
+# (idempotent), so callers that already normalised upstream pay no cost.
+#
+# NON-GOALS:
+#   * Parser output shape is untouched — tool_parsers/*.py write dict
+#     for round-trip correctness; this fix is about REPLAYED messages
+#     from the client.
+#   * User / tool / system messages are untouched — only assistant.
+#   * Malformed JSON is preserved verbatim inside the ``{"value": ...}``
+#     wrapper so log-style renderers keep the original text.
+
+
+def _normalize_assistant_tool_call_arguments(messages: list) -> list:
+    """Return ``messages`` with every ``assistant``-role tool_call's
+    ``function.arguments`` normalized to a dict.
+
+    Rules (mirror ``engine/batched.py::_normalize_tool_call_arguments_
+    for_template`` so the two normalisers are semantically identical
+    and safe to layer):
+
+    * ``dict`` → unchanged.
+    * ``str`` → ``json.loads``; if the parsed value is a dict, use it;
+      otherwise wrap as ``{"value": <parsed>}``.
+    * ``str`` that fails to JSON-parse → wrap as ``{"value": <raw>}``.
+    * Every non-assistant role is untouched.
+
+    Idempotent: repeated calls after the first are no-ops for
+    dict-form arguments, so this can safely layer on top of upstream
+    normalisers in ``routes/chat.py`` and ``engine/batched.py`` without
+    double-work.
+
+    The scan is O(N) over messages. When nothing needs mutation we
+    return the caller's list unchanged (no copy). When at least one
+    ``function.arguments`` needs conversion we materialise a shallow
+    copy of the touched messages (and their ``tool_calls``) so the
+    caller's message list — which the route layer treats as the API
+    surface where ``arguments`` MUST stay a string — is left intact.
+    """
+    if not isinstance(messages, list) or not messages:
+        return messages
+
+    # First pass: detect whether any assistant tool_call.function.arguments
+    # is a non-dict. If none, short-circuit without touching the list.
+    needs_mutation = False
+    for msg in messages:
+        if not isinstance(msg, dict) or msg.get("role") != "assistant":
+            continue
+        tool_calls = msg.get("tool_calls")
+        if not isinstance(tool_calls, list):
+            continue
+        for tc in tool_calls:
+            if not isinstance(tc, dict):
+                continue
+            function = tc.get("function")
+            if not isinstance(function, dict):
+                continue
+            if not isinstance(function.get("arguments"), dict):
+                needs_mutation = True
+                break
+        if needs_mutation:
+            break
+    if not needs_mutation:
+        return messages
+
+    # Second pass: shallow-copy touched messages + tool_calls + function
+    # dicts. Untouched messages are shared by reference (cheap).
+    normalized: list = []
+    for msg in messages:
+        if not isinstance(msg, dict) or msg.get("role") != "assistant":
+            normalized.append(msg)
+            continue
+        tool_calls = msg.get("tool_calls")
+        if not isinstance(tool_calls, list):
+            normalized.append(msg)
+            continue
+        new_tool_calls: list = []
+        touched_any = False
+        for tc in tool_calls:
+            if not isinstance(tc, dict):
+                new_tool_calls.append(tc)
+                continue
+            function = tc.get("function")
+            if not isinstance(function, dict):
+                new_tool_calls.append(tc)
+                continue
+            arguments = function.get("arguments")
+            if isinstance(arguments, dict):
+                new_tool_calls.append(tc)
+                continue
+            # arguments is a string (or something else we treat as the
+            # OpenAI wire shape). Try to parse; fall through to the
+            # ``{"value": ...}`` wrapper on failure or non-dict result.
+            new_arguments: dict
+            if isinstance(arguments, str):
+                try:
+                    parsed = json.loads(arguments)
+                except (json.JSONDecodeError, ValueError, TypeError):
+                    new_arguments = {"value": arguments}
+                else:
+                    if isinstance(parsed, dict):
+                        new_arguments = parsed
+                    else:
+                        new_arguments = {"value": parsed}
+            else:
+                # Non-string, non-dict — rarely seen (an SDK bug or a
+                # test injecting a bare list/int). Wrap so the template's
+                # ``|items`` still works.
+                new_arguments = {"value": arguments}
+            new_function = dict(function)
+            new_function["arguments"] = new_arguments
+            new_tc = dict(tc)
+            new_tc["function"] = new_function
+            new_tool_calls.append(new_tc)
+            touched_any = True
+        if touched_any:
+            new_msg = dict(msg)
+            new_msg["tool_calls"] = new_tool_calls
+            normalized.append(new_msg)
+        else:
+            normalized.append(msg)
+    return normalized
+
+
 def _baseline_sanitize_messages(messages):
     """Fail-closed fallback for ``_sanitize_messages_for_template``.
 
@@ -656,6 +807,23 @@ def apply_chat_template(
     # the same "tool content missing" footgun (Qwen3 rendered an empty
     # ``<tool_response>``, Hermes3 ``TypeError``-d).
     messages = _normalize_text_only_content_arrays(messages)
+
+    # GH-973: enforce the assistant tool_call.arguments = dict invariant
+    # BEFORE any Jinja rendering. Every mainstream HF chat template
+    # (Qwen3 / Hermes / Llama3 / GLM4 / Nemotron / minimax) iterates
+    # ``tool_call.arguments|items`` and blows up with
+    # ``TypeError: Can only get item pairs from a mapping`` when the
+    # OpenAI-wire JSON-string form leaks through. Upstream normalisers
+    # in ``routes/chat.py::extract_multimodal_content`` and
+    # ``engine/batched.py::_normalize_tool_call_arguments_for_template``
+    # cover the standard ``/v1/chat/completions`` non-MLLM path, but
+    # every other caller (guided-generation
+    # ``BatchedEngine.stream_guided_completion``, native-video path,
+    # direct engine callers, tests) bypasses them. Applying the
+    # invariant here — the single ``apply_chat_template`` choke point —
+    # closes the gap uniformly. Idempotent: dict-form arguments pass
+    # through unchanged, so callers that already normalised pay no cost.
+    messages = _normalize_assistant_tool_call_arguments(messages)
 
     # Neutralize chat-template role markers in untrusted (user/tool)
     # content BEFORE the tokenizer parses them. Runs unconditionally for


### PR DESCRIPTION
## Summary
Fixes GH-973: `pydantic_ai` structured output (`Agent(model, output_type=SomeBaseModel).run_sync(...)`) against Qwen3.5/3.6 returns HTTP 500 because the Qwen chat template iterates prior assistant `tool_call.arguments|items` — expecting a mapping — but pydantic_ai's retry path replays the assistant message with `arguments` as the OpenAI-wire JSON string.

## Root cause
Server-side traceback (reporter):
```
vllm_mlx/utils/chat_template.py: apply_chat_template
  → transformers render_jinja_template
  → <template> line 120:  {%- for args_name, args_value in tool_call.arguments|items %}
TypeError: Can only get item pairs from a mapping.
```

Existing normalisers in `routes/chat.py::extract_multimodal_content` and `engine/batched.py::_normalize_tool_call_arguments_for_template` cover the standard `/v1/chat/completions` non-MLLM path, but every other caller of the shared `apply_chat_template` bypasses them:

- `BatchedEngine.stream_guided_completion` — used when `response_format=json_schema` triggers guided (constrained) decoding.
- `models/mllm.py::_apply_native_video_template` — bespoke video path.
- Direct engine callers, tests, and future callers.

## Design
Enforce the dict-form invariant at the single `apply_chat_template` choke point every template render funnels through. Behaviour mirrors the existing `engine/batched.py` normaliser so the two are semantically identical and safe to layer:

- `dict` → unchanged (identity — the caller's message list is returned by reference when no assistant tool_call needs mutation, so upstream normalisers pay zero cost).
- `str` → `json.loads`; if parsed value is a dict, use it; otherwise wrap as `{"value": <parsed>}`.
- Malformed JSON → wrap as `{"value": <raw>}`.

## Cross-parser regression matrix
`tests/test_chat_template_tool_call_arguments.py` covers seven parser families via minimal Jinja templates carrying each family's real arguments-access shape:

| Parser family     | Template access pattern                          | Verified |
|-------------------|--------------------------------------------------|----------|
| `hermes`          | `tc.function.arguments \| tojson`                | PASS     |
| `qwen3_xml`       | `for k, v in tc.function.arguments\|items`       | PASS     |
| `qwen3_coder_xml` | `for k, v in tc.function.arguments\|items` + XML | PASS     |
| `glm4_7`          | `for k, v in tc.function.arguments\|items`       | PASS     |
| `harmony`         | `tc.function.arguments \| tojson`                | PASS     |
| `minimax`         | mixed dict-key + iteration                       | PASS     |
| `deepseek_v3`     | fenced JSON body + `\| tojson`                   | PASS     |

Each parser is exercised with **both** the dict-form input (baseline) and the OpenAI-wire JSON-string form (the GH-973 crash form). Post-fix, both renders produce byte-identical output.

Plus the pydantic_ai retry-shape end-to-end test that mirrors the exact repro.

## Non-goals
- Do NOT change parser output shape — `vllm_mlx/tool_parsers/*.py` already produce dict for round-trip correctness; this fix is about REPLAYED messages from the client, not fresh parser output.
- Do NOT touch dict-form arguments (the helper short-circuits and returns the caller's list by reference when nothing needs mutation).
- Do NOT touch user / tool / system messages — only assistant role.

## Operator-visible behaviour change
Assistant `tool_call.arguments` is now always dict-form after `apply_chat_template` runs. Callers that stored the OpenAI-wire JSON-string form now see it normalised. The route-level surface (where `arguments` MUST stay a string per the OpenAI contract) is untouched — normalisation happens on a shallow copy of touched messages.

## Test plan
- [x] `tests/test_chat_template_tool_call_arguments.py` — 31 new tests, all pass
- [x] `tests/test_chat_template_marker_sanitize.py` + `tests/test_chat_template_kwargs.py` + `tests/test_chat_template_sidecar.py` — 45 existing chat_template tests still pass
- [x] `tests/test_batched_engine_tool_call_normalization.py` — 6 existing batched-engine normalization tests still pass
- [x] `tests/test_batched_engine_chat_template.py` + `tests/test_tool_result_content_array.py` + `tests/test_native_tool_format.py` — 40 related tests still pass
- [x] `tests/test_api_utils.py` + `tests/test_tool_calling.py` + `tests/test_tool_parsers.py` + `tests/test_tool_injection.py` + all `*_tool_parser.py` suites — 500+ tool-parser tests still pass
- [x] `tests/test_anthropic_adapter.py` + `tests/test_responses_adapter.py` — adapter round-trip tests still pass
- [x] `ruff check` + `ruff format --check` clean on touched files

Closes #973