### PR TITLE
fix(release_check_m3): thread $PORT into RAPID_MLX_BASE_URL for G7 SDK tests (#974)

### DIFF
--- a/scripts/release_check_m3.sh
+++ b/scripts/release_check_m3.sh
@@ -28,6 +28,30 @@ PORT="${PORT:-8000}"
 LOG=/tmp/release-check-m3.log
 PIDFILE=/tmp/release-check-m3.pid
 
+# Base URL the gauntlet expects every child gate to hit. Threaded from
+# $PORT so `PORT=8011 bash scripts/release_check_m3.sh` correctly aims
+# every gate at 127.0.0.1:8011 — including gates that read the URL from
+# env instead of accepting --base-url / --port.
+#
+# Issue #974: previously, only G5/G6/G7b/G9/G12 threaded $PORT (via
+# --port / --base-url / hardcoded "http://127.0.0.1:$PORT" URLs). The
+# G7 SDK integration tests (Anthropic / pydantic_ai / smolagents /
+# langchain / hermes) read the URL from ``RAPID_MLX_BASE_URL`` with a
+# hardcoded default of ``http://localhost:8000/v1``. With
+# ``PORT=8011``, the SDK tests silently hit whatever was on 8000 —
+# typically the operator's production server — reporting either false
+# failures (wrong model served) or, worse, false PASSes (prod happens
+# to answer). Export the URL here so every downstream block inherits
+# it regardless of how the child gate resolves its endpoint.
+#
+# We also export the OpenAI-SDK conventional sibling env vars
+# (OPENAI_BASE_URL / OPENAI_API_BASE) as a defensive belt-and-braces
+# for any future integration test that follows the OpenAI SDK
+# convention instead of RAPID_MLX_BASE_URL.
+export RAPID_MLX_BASE_URL="http://127.0.0.1:${PORT}/v1"
+export OPENAI_BASE_URL="http://127.0.0.1:${PORT}/v1"
+export OPENAI_API_BASE="http://127.0.0.1:${PORT}/v1"
+
 line() { printf '%s\n' "============================================================"; }
 
 line
@@ -35,6 +59,7 @@ echo "  M3 release gauntlet"
 echo "  model:    $MODEL"
 echo "  python:   $PY"
 echo "  port:     $PORT"
+echo "  base_url: $RAPID_MLX_BASE_URL"
 echo "  log:      $LOG"
 line
 
@@ -85,6 +110,18 @@ line
 "$PY" scripts/dev_test.py stress --port "$PORT"
 
 #-------------------- G7 SDK integration --------------------------
+# Fail-loud assertion: G7 SDK tests read the target endpoint from
+# ``RAPID_MLX_BASE_URL`` (see issue #974). If the top-of-script export
+# is ever regressed / clobbered downstream / disabled, bail out here
+# rather than silently pointing G7 at whatever server the default URL
+# lands on (typically the operator's production 8000).
+_expected_base="http://127.0.0.1:${PORT}/v1"
+if [ "${RAPID_MLX_BASE_URL:-}" != "$_expected_base" ]; then
+  echo "ERROR: G7 env mismatch — RAPID_MLX_BASE_URL='${RAPID_MLX_BASE_URL:-}' expected '$_expected_base'." >&2
+  echo "  This means G7 SDK tests would hit a different server than the gauntlet booted." >&2
+  exit 1
+fi
+
 line
 echo "  G7 — Anthropic SDK"
 line

--- a/tests/test_release_check_m3_port_thread.py
+++ b/tests/test_release_check_m3_port_thread.py
@@ -126,37 +126,52 @@ def test_script_asserts_g7_env_matches_port() -> None:
     invocation_idx = text.find("tests/integrations/test_anthropic_sdk.py", idx)
     assert invocation_idx != -1, "G7 no longer runs test_anthropic_sdk.py"
     g7_block = text[idx:invocation_idx]
-    assert 'RAPID_MLX_BASE_URL' in g7_block, (
+    assert "RAPID_MLX_BASE_URL" in g7_block, (
         "G7 block should reference RAPID_MLX_BASE_URL in an assertion"
     )
-    assert 'G7 env mismatch' in g7_block, (
+    assert "G7 env mismatch" in g7_block, (
         "G7 assertion should print a distinctive 'G7 env mismatch' error"
     )
 
 
 def test_every_integration_base_url_env_is_covered() -> None:
-    """Systematic guard: every ``os.environ.get("<FOO>_BASE_URL", ...)``
-    (or ``_API_BASE`` / ``_ENDPOINT``) any integration test reads MUST
-    be exported by the shell script. Adding a new harness that reads a
-    novel env var should trip this test."""
+    """Systematic guard: every env var an integration test reads with an
+    HTTP-URL default MUST be exported by the shell script. Adding a new
+    harness that reads a novel HTTP endpoint env should trip this test.
+
+    We identify endpoint envs by the *shape of the default* (starts with
+    ``http://`` or ``https://``) rather than by the env-var name. A
+    name-based regex would false-positive on unrelated envs like
+    ``DATABASE_URL`` (which happens to end in ``BASE_URL`` but points at
+    a DB DSN, not an HTTP API) — codex_review NIT on PR #982.
+    """
+    # Capture the env-var name AND its default. Both single- and
+    # double-quoted forms; whitespace tolerant. We require the default
+    # to be a string literal (not a Python expression) so we can
+    # inspect the URL scheme directly.
     pattern = re.compile(
-        r'os\.environ\.get\(\s*["\']([A-Z_]*(?:BASE(?:_URL)?|API_BASE|ENDPOINT))["\']'
+        r"""os\.environ\.get\(
+            \s*["']([A-Z_][A-Z0-9_]*)["']
+            \s*,\s*
+            (?:f?["']([^"']*)["'])
+            \s*\)""",
+        re.VERBOSE,
     )
-    found: set[str] = set()
+    endpoint_envs: set[str] = set()
     for path in INTEGRATIONS.glob("*.py"):
         text = path.read_text()
-        found.update(pattern.findall(text))
-    # Only interesting envs — filter out obvious misses.
-    interesting = {name for name in found if "BASE" in name or "ENDPOINT" in name}
-    uncovered = interesting - KNOWN_BASE_URL_ENVS
+        for name, default in pattern.findall(text):
+            if default.startswith(("http://", "https://")):
+                endpoint_envs.add(name)
+    uncovered = endpoint_envs - KNOWN_BASE_URL_ENVS
     assert not uncovered, (
-        f"Integration tests read env vars {uncovered!r} that the release "
-        f"script does not export. Either export them in "
+        f"Integration tests read HTTP-endpoint env vars {uncovered!r} "
+        f"that the release script does not export. Either export them in "
         f"scripts/release_check_m3.sh or add to KNOWN_BASE_URL_ENVS with "
         f"a justification."
     )
-    # And every covered env MUST actually appear as an ``export`` in
-    # the script prelude — no drift the other direction either.
+    # And every declared env MUST actually appear as an ``export`` in
+    # the script — no drift the other direction either.
     script_text = SCRIPT.read_text()
     for env in KNOWN_BASE_URL_ENVS:
         assert re.search(rf"^\s*export\s+{env}=", script_text, flags=re.MULTILINE), (

--- a/tests/test_release_check_m3_port_thread.py
+++ b/tests/test_release_check_m3_port_thread.py
@@ -1,0 +1,166 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for issue #974 — ``scripts/release_check_m3.sh``
+must thread ``$PORT`` into ``RAPID_MLX_BASE_URL`` (and OpenAI-SDK
+conventional siblings) so G7 SDK integration tests hit the gauntlet
+server, not whatever default port their env-var defaults resolve to.
+
+The bug: G7 SDK tests (Anthropic / pydantic_ai / smolagents / langchain
+/ hermes) read the endpoint from ``os.environ.get("RAPID_MLX_BASE_URL",
+"http://localhost:8000/v1")``. If the gauntlet is booted with a PORT
+override (e.g. ``PORT=8011`` to avoid a running production server on
+8000) but the script does NOT export ``RAPID_MLX_BASE_URL``, the SDK
+tests silently target ``http://localhost:8000`` — usually the
+operator's production box — producing either false failures (wrong
+model) or false PASSes (prod happens to answer).
+
+We assert two invariants on the shell script:
+
+1. **Every G-block env var is present and derived from $PORT.** Sourcing
+   the top of the script under ``PORT=<random>`` yields
+   ``RAPID_MLX_BASE_URL == http://127.0.0.1:<PORT>/v1``.
+
+2. **Every base-url env var read by any test under
+   ``tests/integrations/*.py`` is covered by the export block.** This
+   is a systematic guard: adding a new integration test that reads
+   ``FOOBAR_BASE`` should trip this test so the script export list is
+   updated in lockstep.
+
+The script is Bash, not Python, so we shell out via ``subprocess`` —
+never actually booting rapid-mlx serve or touching a real port.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "release_check_m3.sh"
+INTEGRATIONS = REPO_ROOT / "tests" / "integrations"
+
+# Env vars any integration test under tests/integrations/*.py reads to
+# resolve the rapid-mlx server endpoint. The shell script MUST export
+# each of these before running G7. Grow this set if we ever add a new
+# integration harness with a different env-var convention.
+KNOWN_BASE_URL_ENVS = {
+    "RAPID_MLX_BASE_URL",
+    "OPENAI_BASE_URL",
+    "OPENAI_API_BASE",
+}
+
+
+def _extract_prelude(script_path: Path) -> str:
+    """Return everything from the top of the script up through the
+    ``echo "  log:"`` banner line — i.e. the part that resolves ``PORT``
+    and exports base-url env vars. Everything after (server boot, G-block
+    orchestration) is skipped so sourcing the prelude in a test doesn't
+    try to actually launch ``rapid-mlx serve``."""
+    text = script_path.read_text()
+    marker = 'echo "  log:'
+    idx = text.find(marker)
+    assert idx != -1, "banner marker 'echo \"  log:' vanished from script"
+    # Cut at the end of the marker's line so ``line`` (echo separator)
+    # doesn't get sourced without its function definition. The prelude
+    # is enough for env-var setup verification.
+    end_of_line = text.find("\n", idx)
+    return text[: end_of_line + 1]
+
+
+def test_prelude_exports_base_url_from_port(tmp_path: Path) -> None:
+    """PORT override MUST propagate to RAPID_MLX_BASE_URL — the exact
+    invariant the fix for issue #974 enforces."""
+    prelude = _extract_prelude(SCRIPT)
+    # Source under a non-default PORT and print the resolved env vars.
+    port = "8011"
+    probe = tmp_path / "probe.sh"
+    probe.write_text(
+        prelude
+        + '\necho "RAPID_MLX_BASE_URL=$RAPID_MLX_BASE_URL"\n'
+        + 'echo "OPENAI_BASE_URL=$OPENAI_BASE_URL"\n'
+        + 'echo "OPENAI_API_BASE=$OPENAI_API_BASE"\n'
+    )
+    result = subprocess.run(
+        ["bash", str(probe)],
+        capture_output=True,
+        text=True,
+        env={"PORT": port, "PATH": "/usr/bin:/bin"},
+        check=True,
+    )
+    expected = f"http://127.0.0.1:{port}/v1"
+    assert f"RAPID_MLX_BASE_URL={expected}" in result.stdout, result.stdout
+    assert f"OPENAI_BASE_URL={expected}" in result.stdout, result.stdout
+    assert f"OPENAI_API_BASE={expected}" in result.stdout, result.stdout
+
+
+def test_prelude_default_port_matches_hardcoded_probes() -> None:
+    """Default PORT (unset) MUST resolve to 8000 — matching the hardcoded
+    "http://127.0.0.1:$PORT" URLs elsewhere in the script AND the
+    ``localhost:8000`` default the SDK tests fall back to when no env
+    override is present."""
+    prelude = _extract_prelude(SCRIPT)
+    result = subprocess.run(
+        ["bash", "-c", prelude + '\necho "URL=$RAPID_MLX_BASE_URL"'],
+        capture_output=True,
+        text=True,
+        env={"PATH": "/usr/bin:/bin"},  # no PORT export
+        check=True,
+    )
+    assert "URL=http://127.0.0.1:8000/v1" in result.stdout, result.stdout
+
+
+def test_script_asserts_g7_env_matches_port() -> None:
+    """The G7 block MUST include a fail-loud assertion that
+    ``RAPID_MLX_BASE_URL`` still points at the gauntlet PORT. Without
+    this, a downstream ``unset RAPID_MLX_BASE_URL`` or an unrelated
+    clobber would silently reopen the issue #974 hole."""
+    text = SCRIPT.read_text()
+    # Locate the G7 SDK integration section header (the ``#---…``
+    # banner, not a mere comment reference elsewhere in the script).
+    marker = "#-------------------- G7 SDK integration"
+    idx = text.find(marker)
+    assert idx != -1, "'G7 SDK integration' section banner vanished"
+    # The assertion should live between the section header and the first
+    # test invocation (`test_anthropic_sdk.py`). Look for the fail-loud
+    # shape in that slice.
+    invocation_idx = text.find("tests/integrations/test_anthropic_sdk.py", idx)
+    assert invocation_idx != -1, "G7 no longer runs test_anthropic_sdk.py"
+    g7_block = text[idx:invocation_idx]
+    assert 'RAPID_MLX_BASE_URL' in g7_block, (
+        "G7 block should reference RAPID_MLX_BASE_URL in an assertion"
+    )
+    assert 'G7 env mismatch' in g7_block, (
+        "G7 assertion should print a distinctive 'G7 env mismatch' error"
+    )
+
+
+def test_every_integration_base_url_env_is_covered() -> None:
+    """Systematic guard: every ``os.environ.get("<FOO>_BASE_URL", ...)``
+    (or ``_API_BASE`` / ``_ENDPOINT``) any integration test reads MUST
+    be exported by the shell script. Adding a new harness that reads a
+    novel env var should trip this test."""
+    pattern = re.compile(
+        r'os\.environ\.get\(\s*["\']([A-Z_]*(?:BASE(?:_URL)?|API_BASE|ENDPOINT))["\']'
+    )
+    found: set[str] = set()
+    for path in INTEGRATIONS.glob("*.py"):
+        text = path.read_text()
+        found.update(pattern.findall(text))
+    # Only interesting envs — filter out obvious misses.
+    interesting = {name for name in found if "BASE" in name or "ENDPOINT" in name}
+    uncovered = interesting - KNOWN_BASE_URL_ENVS
+    assert not uncovered, (
+        f"Integration tests read env vars {uncovered!r} that the release "
+        f"script does not export. Either export them in "
+        f"scripts/release_check_m3.sh or add to KNOWN_BASE_URL_ENVS with "
+        f"a justification."
+    )
+    # And every covered env MUST actually appear as an ``export`` in
+    # the script prelude — no drift the other direction either.
+    script_text = SCRIPT.read_text()
+    for env in KNOWN_BASE_URL_ENVS:
+        assert re.search(rf"^\s*export\s+{env}=", script_text, flags=re.MULTILINE), (
+            f"KNOWN_BASE_URL_ENVS declares {env} but the shell script does "
+            f"not export it — either drop it from the constant or add the "
+            f"export in scripts/release_check_m3.sh."
+        )


### PR DESCRIPTION
Closes #974.

## Problem

`scripts/release_check_m3.sh` boots the gauntlet server on `$PORT` (default 8000, overridable) and threads the port through G5 / G6 / G7b / G9 / G12 (via `--port` / `--base-url` / hardcoded `http://127.0.0.1:$PORT` URLs). But the G7 SDK integration tests read the endpoint from an env var whose default hardcodes port 8000:

```python
# tests/integrations/test_anthropic_sdk.py, test_pydantic_ai_full.py, test_smolagents_full.py
_BASE = os.environ.get("RAPID_MLX_BASE_URL", "http://localhost:8000/v1")
```

The script does NOT set `RAPID_MLX_BASE_URL`, so running with `PORT=8011` (a common override to dodge a production server on 8000) silently pointed G7 at whatever answered on port 8000 — typically the operator's production box.

**Observed impact:** G7 Anthropic 0/5 `404 not_found` because prod served a different model. **Worse:** if prod healthily answered, G7 could falsely PASS against prod while the actual release build was never exercised.

## G-block-by-G-block audit

| Gate | Endpoint resolution | Threads `$PORT`? |
| --- | --- | --- |
| G5 stress | `scripts/dev_test.py stress --port "$PORT"` | yes |
| **G7 Anthropic / pydantic_ai / smolagents** | env `RAPID_MLX_BASE_URL`, default `http://localhost:8000/v1` | **no — bug** |
| G7b Part A (`bench --tier harness`) | `--base-url "http://127.0.0.1:$PORT"` (and `AgentTestRunner` re-exports `RAPID_MLX_BASE_URL` for `_run_specific_tests`) | yes |
| G7b Part B (`/v1/responses` curl) | hardcoded `http://127.0.0.1:$PORT` | yes |
| G6 (`/v1/chat/completions` curl) | hardcoded `http://127.0.0.1:$PORT` | yes |
| G9 latency (heredoc urllib) | hardcoded `http://127.0.0.1:$PORT` | yes |
| G8 parser microbench | no server touch | n/a |
| G12 random-coverage | `release_check_m3_random.py --port "$PORT"` (harness sub-runner passes `--base-url` further) | yes |

Only G7 was broken. Env-var grep of `tests/integrations/*.py` confirms `RAPID_MLX_BASE_URL` is the sole endpoint env any G7 SDK test reads — no `OPENAI_API_BASE`, `ANTHROPIC_API_BASE`, or `MODEL_ENDPOINT` variants. `MODEL_ID` is resolved by calling `/v1/models` on the server the URL points at, so once the URL is correct, the model name auto-follows.

## Fix

1. **Top of `release_check_m3.sh`, right after `PORT` resolves:** `export RAPID_MLX_BASE_URL="http://127.0.0.1:${PORT}/v1"`. Every downstream block inherits the correct endpoint regardless of how the child gate resolves it. Also export the OpenAI-SDK conventional siblings `OPENAI_BASE_URL` and `OPENAI_API_BASE` as defensive belt-and-braces for any future harness following the OpenAI SDK env convention.
2. **G7 start:** fail-loud assertion — if `RAPID_MLX_BASE_URL` was clobbered by a downstream block or intentionally unset, abort with `G7 env mismatch` rather than silently re-opening the hole.
3. **Banner:** print the resolved `base_url` alongside `port` so a `PORT=8011` invocation immediately shows the threaded URL.

Prefer editing the shell script over the integration tests — the tests are correct-by-contract (read env with sensible default); the gap was in the orchestrator that boots the server.

## Test coverage

New `tests/test_release_check_m3_port_thread.py` — four regressions:

- **`test_prelude_exports_base_url_from_port`**: subprocess-sources the script prelude under `PORT=8011`, asserts `RAPID_MLX_BASE_URL == http://127.0.0.1:8011/v1` (plus sibling envs). This is the exact repro of the issue #974 bug.
- **`test_prelude_default_port_matches_hardcoded_probes`**: default PORT (unset) resolves to `127.0.0.1:8000/v1`.
- **`test_script_asserts_g7_env_matches_port`**: the G7 block contains the fail-loud `G7 env mismatch` assertion between the section banner and the first test invocation.
- **`test_every_integration_base_url_env_is_covered`**: systematic guard — every `os.environ.get("<FOO>_BASE_URL", …)` any integration test reads MUST be exported by the script. Adding a new harness with a novel env var (say `LITELLM_API_ENDPOINT`) now trips this test.

Bug-reproduction check performed: stashing the fix and re-running the tests fails 2/4 (the two positive assertions), confirming the tests actually exercise the bug. Re-applying the fix makes all 4 pass.

## Verification

- `bash -n scripts/release_check_m3.sh` — syntax clean.
- `shellcheck scripts/release_check_m3.sh` — no warnings.
- `.venv/bin/ruff check tests/test_release_check_m3_port_thread.py` — clean.
- `.venv/bin/python -m pytest tests/test_release_check_m3_port_thread.py -v` — 4/4 pass.

## Operator-visible behavior change

`PORT=8011 bash scripts/release_check_m3.sh` now correctly aims G7 at 127.0.0.1:8011 (previously silently aimed at 127.0.0.1:8000, hitting prod). Any regression that unsets `RAPID_MLX_BASE_URL` before G7 becomes a loud script exit with `G7 env mismatch`, not a silent misroute.

## Test plan

- [x] `bash -n scripts/release_check_m3.sh` clean
- [x] `shellcheck scripts/release_check_m3.sh` clean
- [x] `.venv/bin/python -m pytest tests/test_release_check_m3_port_thread.py -v` 4/4 pass
- [x] Bug reproduction: stash fix -> test fails; reapply fix -> test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)