### PR TITLE
fix(server): thread TurboQuant flags into SchedulerConfig on `python -m vllm_mlx.server`

### DIFF
--- a/scripts/audit_cli_config_fidelity.py
+++ b/scripts/audit_cli_config_fidelity.py
@@ -35,6 +35,41 @@ CLI_ENTRY_PATHS = [
     REPO_ROOT / "vllm_mlx" / "server.py",
 ]
 
+# Helpers that RETURN a dict of ``SchedulerConfig`` kwargs and are
+# star-unpacked at construction sites via ``**helper(args)``. The audit
+# expands the starred unpacking into the field set the helper injects
+# so the drift check doesn't false-positive on the shared entrypoint
+# mirror pattern (#969 — ``cli.py`` and ``server.py`` both call
+# ``turboquant_scheduler_kwargs`` to guarantee lock-step behaviour).
+#
+# Key: helper function name (matches ``Call.func.id``); may include
+# local aliases used by ``from ... import ... as _local``.
+# Value: the set of ``SchedulerConfig`` field names the helper returns.
+# Keep the field set in sync with the helper body — a mismatch here
+# either (a) hides a real drift (values in helper, missing here) or
+# (b) creates a false-clean audit (values here, not in helper).
+KWARG_INJECTOR_HELPERS: dict[str, set[str]] = {
+    "turboquant_scheduler_kwargs": {
+        "kv_cache_turboquant",
+        "kv_cache_turboquant_bits",
+        "kv_cache_turboquant_group_size",
+        "kv_cache_turboquant_mode",
+    },
+    # Import-time aliases used inside the two entrypoints.
+    "_turboquant_scheduler_kwargs": {
+        "kv_cache_turboquant",
+        "kv_cache_turboquant_bits",
+        "kv_cache_turboquant_group_size",
+        "kv_cache_turboquant_mode",
+    },
+    "_server_turboquant_scheduler_kwargs": {
+        "kv_cache_turboquant",
+        "kv_cache_turboquant_bits",
+        "kv_cache_turboquant_group_size",
+        "kv_cache_turboquant_mode",
+    },
+}
+
 
 def _dataclass_field_names(source_path: Path, class_name: str) -> set[str]:
     """Extract field names of a @dataclass via AST — no runtime import.
@@ -104,7 +139,19 @@ def audit(cli_path: Path, config_source: Path, config_cls_name: str) -> list[str
             ):
                 continue
 
-            kwargs = {kw.arg for kw in call.keywords if kw.arg}
+            kwargs: set[str] = set()
+            for kw in call.keywords:
+                if kw.arg is not None:
+                    kwargs.add(kw.arg)
+                elif (
+                    isinstance(kw.value, ast.Call)
+                    and isinstance(kw.value.func, ast.Name)
+                    and kw.value.func.id in KWARG_INJECTOR_HELPERS
+                ):
+                    # ``**helper(args)`` star-unpacking — pick up the
+                    # injected fields so the shared entrypoint helper
+                    # pattern (#969) doesn't false-positive as drift.
+                    kwargs |= KWARG_INJECTOR_HELPERS[kw.value.func.id]
             # Fields that this function CAN supply (args.X is referenced) but
             # this construction site does NOT pass.
             dropped = (field_names & arg_refs) - kwargs

--- a/tests/test_turboquant_k8v4.py
+++ b/tests/test_turboquant_k8v4.py
@@ -543,6 +543,193 @@ class TestCLIFlag:
         assert "mutually exclusive" in source.lower()
 
 
+# ---------------------------------------------------------------------------
+# 8b. #969 — ``python -m vllm_mlx.server`` entrypoint parity
+# ---------------------------------------------------------------------------
+#
+# Pre-fix, the standalone ``python -m vllm_mlx.server`` argparse:
+#   * rejected the ``"none"`` off-switch added in #962 (``choices`` set
+#     to ``["v4", "k8v4"]`` only), and
+#   * silently dropped every TurboQuant value at the ``SchedulerConfig``
+#     construction site — the parser accepted ``--kv-cache-turboquant
+#     k8v4`` but the engine still booted with FP16 KV.
+#
+# Both are user-visible silent-flag-drop bugs of the same class as #400.
+# The fix mirrors ``cli.py``'s behaviour: add ``"none"`` to choices,
+# resolve the mode via ``resolve_turboquant_mode_default``, and thread
+# the values into ``SchedulerConfig`` via the shared
+# ``turboquant_scheduler_kwargs`` helper. The two entries share the
+# helper so future TurboQuant fields can't drift.
+
+
+def _extract_server_argparse_choices(flag_name: str) -> list[str] | None:
+    """AST-scrape ``server.main``'s argparse for the given flag's ``choices``.
+
+    Avoids invoking the parser at test time (which would drag the full
+    mlx-core / uvicorn stack via ``server.main``'s imports).
+    """
+    import ast
+
+    source = (
+        __import__("pathlib").Path(__file__).parent.parent / "vllm_mlx" / "server.py"
+    ).read_text()
+    tree = ast.parse(source)
+    for node in ast.walk(tree):
+        if not (isinstance(node, ast.Call)):
+            continue
+        # add_argument("--flag", ...)
+        if not (
+            isinstance(node.func, ast.Attribute) and node.func.attr == "add_argument"
+        ):
+            continue
+        if not node.args or not isinstance(node.args[0], ast.Constant):
+            continue
+        if node.args[0].value != flag_name:
+            continue
+        for kw in node.keywords:
+            if kw.arg == "choices" and isinstance(kw.value, ast.List):
+                return [e.value for e in kw.value.elts if isinstance(e, ast.Constant)]
+    return None
+
+
+class TestServerEntrypointParity:
+    """#969 — the standalone ``python -m vllm_mlx.server`` entrypoint
+    must honor ``--kv-cache-turboquant`` at parity with ``cli.py``.
+    """
+
+    def test_server_argparse_accepts_none_off_switch(self):
+        """#969 pre-fix: ``choices=["v4", "k8v4"]`` REJECTED the
+        ``--kv-cache-turboquant none`` off-switch added in #962. Post-fix
+        the standalone entry must accept it just like ``rapid-mlx serve``.
+        """
+        choices = _extract_server_argparse_choices("--kv-cache-turboquant")
+        assert choices is not None, (
+            "--kv-cache-turboquant argparse entry missing from server.main"
+        )
+        assert "none" in choices, (
+            f"--kv-cache-turboquant on `python -m vllm_mlx.server` must "
+            f"accept the ``none`` off-switch added in #962 (got choices="
+            f"{choices!r}). Pre-fix, argparse rejected the off-switch "
+            f"outright."
+        )
+        assert "v4" in choices and "k8v4" in choices, (
+            f"choice set drifted from cli.py: got {choices!r}"
+        )
+
+    def test_server_main_threads_turboquant_into_scheduler_config(self):
+        """#969 silent-drop regression — ``server.main`` must plumb the
+        parsed TurboQuant values into ``SchedulerConfig`` (like the #400
+        fix for ``--prefill-step-size``). The shared
+        ``turboquant_scheduler_kwargs`` helper is the canonical mirror,
+        so the test asserts either the direct kwargs OR the helper
+        star-unpacking is present at the construction site.
+        """
+        import ast
+        from pathlib import Path
+
+        source = (Path(__file__).parent.parent / "vllm_mlx" / "server.py").read_text()
+        tree = ast.parse(source)
+        # Find the ``main`` function and its ``SchedulerConfig(...)`` call.
+        main_func = next(
+            (
+                n
+                for n in ast.walk(tree)
+                if isinstance(n, ast.FunctionDef) and n.name == "main"
+            ),
+            None,
+        )
+        assert main_func is not None, "server.main not found"
+        sc_call = None
+        for node in ast.walk(main_func):
+            if (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Name)
+                and node.func.id == "SchedulerConfig"
+            ):
+                sc_call = node
+                break
+        assert sc_call is not None, "SchedulerConfig(...) call missing in server.main"
+
+        required = {
+            "kv_cache_turboquant",
+            "kv_cache_turboquant_bits",
+            "kv_cache_turboquant_group_size",
+            "kv_cache_turboquant_mode",
+        }
+        direct_kwargs = {kw.arg for kw in sc_call.keywords if kw.arg is not None}
+
+        # Star-unpacked ``**helper(args)`` counts as passing the fields
+        # the helper injects, matching the audit script's
+        # ``KWARG_INJECTOR_HELPERS`` map.
+        star_kwargs: set[str] = set()
+        helper_names = {
+            "turboquant_scheduler_kwargs",
+            "_turboquant_scheduler_kwargs",
+            "_server_turboquant_scheduler_kwargs",
+        }
+        for kw in sc_call.keywords:
+            if (
+                kw.arg is None
+                and isinstance(kw.value, ast.Call)
+                and isinstance(kw.value.func, ast.Name)
+                and kw.value.func.id in helper_names
+            ):
+                star_kwargs |= required
+
+        passed = direct_kwargs | star_kwargs
+        missing = required - passed
+        assert not missing, (
+            f"regression #969: server.main SchedulerConfig(...) drops "
+            f"TurboQuant fields {sorted(missing)}. Either pass them "
+            f"directly or unpack ``**turboquant_scheduler_kwargs(args)``. "
+            f"Pre-fix, this entrypoint accepted ``--kv-cache-turboquant`` "
+            f"but never threaded the value to the engine (silent flag "
+            f"drop, same bug class as #400)."
+        )
+
+    def test_shared_turboquant_scheduler_kwargs_returns_all_fields(self):
+        """Helper must return every ``SchedulerConfig`` TurboQuant field
+        so both entrypoints stay in lock-step. If a new TurboQuant field
+        lands on ``SchedulerConfig`` but the helper doesn't emit it,
+        server.py's SchedulerConfig would silently regress even though
+        cli.py's banner code keeps the arg refs live.
+        """
+        from types import SimpleNamespace
+
+        from vllm_mlx.turboquant import turboquant_scheduler_kwargs
+
+        # All-off shape.
+        off = turboquant_scheduler_kwargs(
+            SimpleNamespace(
+                kv_cache_turboquant=None,
+                kv_cache_turboquant_bits=None,
+                kv_cache_turboquant_group_size=32,
+            )
+        )
+        assert off == {
+            "kv_cache_turboquant": False,
+            "kv_cache_turboquant_bits": None,
+            "kv_cache_turboquant_group_size": 32,
+            # Off: mode collapses to the dataclass default ``"v4"``.
+            "kv_cache_turboquant_mode": "v4",
+        }
+
+        # K8V4 explicit — bool True, mode carries the string.
+        on = turboquant_scheduler_kwargs(
+            SimpleNamespace(
+                kv_cache_turboquant="k8v4",
+                kv_cache_turboquant_bits=4,
+                kv_cache_turboquant_group_size=64,
+            )
+        )
+        assert on == {
+            "kv_cache_turboquant": True,
+            "kv_cache_turboquant_bits": 4,
+            "kv_cache_turboquant_group_size": 64,
+            "kv_cache_turboquant_mode": "k8v4",
+        }
+
+
 # subprocess / sys are kept available for future regression scenarios.
 _ = (subprocess, sys)
 

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -2166,8 +2166,16 @@ def serve_command(args):
         print("\n  ⚠ --specprefill is deprecated and has no effect.\n")
 
     # Resolve per-alias TurboQuant default before the mutual-exclusion
-    # check below — operator-explicit values still win.
-    from .turboquant import resolve_turboquant_mode_default
+    # check below — operator-explicit values still win. The
+    # ``turboquant_scheduler_kwargs`` helper is the shared invariant
+    # (#969) — ``python -m vllm_mlx.server`` calls the same helper so
+    # the two entrypoints can't drift.
+    from .turboquant import (
+        resolve_turboquant_mode_default,
+    )
+    from .turboquant import (
+        turboquant_scheduler_kwargs as _turboquant_scheduler_kwargs,
+    )
 
     args.kv_cache_turboquant = resolve_turboquant_mode_default(
         args, model_name=args.model
@@ -2363,21 +2371,20 @@ def serve_command(args):
         kv_cache_quantization_bits=args.kv_cache_quantization_bits,
         kv_cache_quantization_group_size=args.kv_cache_quantization_group_size,
         kv_cache_min_quantize_tokens=args.kv_cache_min_quantize_tokens,
-        # TurboQuant compression (R15 Phase 4: mode-aware)
-        # ``--kv-cache-turboquant`` now carries a mode value: ``None``
-        # when off, ``"v4"`` for the legacy V-only path, ``"k8v4"`` for
-        # the K-8bit + V-4bit mix. SchedulerConfig keeps the boolean
-        # ``kv_cache_turboquant`` for downstream callers; the mode
-        # string rides on the dedicated field below.
-        kv_cache_turboquant=bool(args.kv_cache_turboquant),
-        kv_cache_turboquant_bits=args.kv_cache_turboquant_bits,
-        kv_cache_turboquant_group_size=args.kv_cache_turboquant_group_size,
+        # TurboQuant compression (R15 Phase 4: mode-aware). Shared
+        # helper (#969) — ``python -m vllm_mlx.server`` calls the same
+        # ``turboquant_scheduler_kwargs`` so both entrypoints stay in
+        # lock-step. ``--kv-cache-turboquant`` carries a mode value:
+        # ``None`` when off, ``"v4"`` for the legacy V-only path,
+        # ``"k8v4"`` for the K-8bit + V-4bit mix. SchedulerConfig keeps
+        # the boolean ``kv_cache_turboquant`` for downstream callers;
+        # the mode string rides on the dedicated ``_mode`` field.
+        **_turboquant_scheduler_kwargs(args),
         # R15-P1 (task #296): disk-backed KV checkpointing at 256-tok
         # boundaries. ``0`` disables; the runtime module guards every
         # hot-path call with ``should_checkpoint`` so the cost when off
         # is one int comparison.
         kv_disk_checkpoint_interval=getattr(args, "kv_disk_checkpoint_interval", 256),
-        kv_cache_turboquant_mode=(args.kv_cache_turboquant or "v4"),
         # PFlash long-prompt compression (#287)
         pflash_config=pflash_config,
         # D-METAL-CAP: thread the user's --gpu-memory-utilization into

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -1786,13 +1786,19 @@ Examples:
     parser.add_argument("--kv-group-size", type=int, default=64, help=_ap.SUPPRESS)
     parser.add_argument("--draft-model", type=str, default=None, help=_ap.SUPPRESS)
     parser.add_argument("--num-draft-tokens", type=int, default=4, help=_ap.SUPPRESS)
-    # TurboQuant flags — accepted but only functional via rapid-mlx serve (cli.py)
+    # TurboQuant flags — MUST match ``rapid-mlx serve`` (cli.py) choice
+    # set + defaults so this standalone entry is functionally at parity.
+    # Pre-#969, this parser was missing the ``"none"`` off-switch added
+    # in #962 (argparse rejected the flag outright) AND the parsed values
+    # were never threaded into ``SchedulerConfig`` below (silent drop —
+    # same bug class as #400). Both entries now share the
+    # ``turboquant_scheduler_kwargs`` helper.
     parser.add_argument(
         "--kv-cache-turboquant",
         nargs="?",
         const="v4",
         default=None,
-        choices=["v4", "k8v4"],
+        choices=["v4", "k8v4", "none"],
         help=_ap.SUPPRESS,
     )
     parser.add_argument(
@@ -2141,9 +2147,28 @@ Examples:
     except ValueError as e:
         parser.error(str(e))
 
+    # TurboQuant resolution (#969): mirror ``rapid-mlx serve`` so the
+    # standalone entry actually honors ``--kv-cache-turboquant``. The
+    # helper collapses the ``"none"`` off-switch sentinel to ``None`` and
+    # applies the per-alias ``k8v4_verified`` default. There is no
+    # ``--kv-cache-quantization`` flag on this parser, so the mutual-
+    # exclusion check in ``cli.py`` is a no-op here (``getattr`` guard on
+    # the shared helper covers programmatic callers that inject one).
+    from .turboquant import (
+        resolve_turboquant_mode_default as _server_turboquant_resolve_default,
+    )
+    from .turboquant import (
+        turboquant_scheduler_kwargs as _server_turboquant_scheduler_kwargs,
+    )
+
+    args.kv_cache_turboquant = _server_turboquant_resolve_default(
+        args, model_name=args.model
+    )
+
     scheduler_config = SchedulerConfig(
         prefill_step_size=args.prefill_step_size,
         pflash_config=server_pflash_config,
+        **_server_turboquant_scheduler_kwargs(args),
     )
 
     # Load model before starting server

--- a/vllm_mlx/turboquant.py
+++ b/vllm_mlx/turboquant.py
@@ -99,6 +99,35 @@ def resolve_turboquant_mode_default(args: Any, *, model_name: str) -> str | None
     return None
 
 
+def turboquant_scheduler_kwargs(args: Any) -> dict[str, Any]:
+    """Build ``SchedulerConfig`` kwargs from the resolved ``args.kv_cache_turboquant*``.
+
+    Systematic invariant (#969): every user-facing entrypoint that owns
+    a ``--kv-cache-turboquant*`` argparse surface MUST route the parsed
+    values through this helper so the primary ``rapid-mlx serve`` path
+    and the standalone ``python -m vllm_mlx.server`` path stay in
+    lock-step. Prior to the fix, ``server.py`` accepted the flags but
+    silently dropped them at the ``SchedulerConfig(...)`` construction
+    site — same silent-flag-drop bug class as #400.
+
+    Callers must first normalise ``args.kv_cache_turboquant`` via
+    :func:`resolve_turboquant_mode_default` so the ``"none"`` off-switch
+    sentinel has been collapsed to ``None``. Mutual exclusion with
+    ``--kv-cache-quantization`` is a caller responsibility because the
+    error-reporting convention differs per entry (``sys.exit`` vs
+    ``parser.error`` vs library ``ValueError``).
+    """
+    return {
+        "kv_cache_turboquant": bool(args.kv_cache_turboquant),
+        "kv_cache_turboquant_bits": args.kv_cache_turboquant_bits,
+        "kv_cache_turboquant_group_size": args.kv_cache_turboquant_group_size,
+        # SchedulerConfig requires a string mode even when the boolean
+        # toggle is off; ``"v4"`` matches the dataclass default and the
+        # historical behaviour prior to R15 Phase 4.
+        "kv_cache_turboquant_mode": (args.kv_cache_turboquant or "v4"),
+    }
+
+
 # ---------------------------------------------------------------------------
 # Configuration
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes #969.

The standalone `python -m vllm_mlx.server` entrypoint at
`vllm_mlx/server.py:1789` accepted `--kv-cache-turboquant` in argparse
but silently dropped the value at the `SchedulerConfig(...)`
construction site (line 2144). Additionally, `choices=["v4", "k8v4"]`
rejected the `--kv-cache-turboquant none` off-switch added in #962.

Two user-visible silent-flag-drop bugs of the same class as #400 —
argparse advertises the flag, engine never sees it.

## Docs check + option choice

`python -m vllm_mlx.server` is a **supported** public surface:

- Included in the `release-smoke` gate (docs/development/releasing.md).
- Covered by `scripts/audit_cli_config_fidelity.py` and
  `tests/test_cli_config_fidelity.py::test_prefill_step_size_is_plumbed_in_server_main`.
- Referenced across `tests/` as "the second supported entrypoint"
  (`test_serve_host_loopback_default.py`, `test_embeddings_extra_guard.py`,
  `test_audio_route_registration_gate.py`).
- Used in `examples/mllm_benchmark.py`.

Systematic invariant: since the entrypoint is supported, its flag
behaviour MUST match `rapid-mlx serve` (cli.py). **Option 1 (functional
parity)** is the systematic answer; Option 2 (fail-loud drop) would
break the supported-surface contract.

## Fix — extraction pattern

- **New helper**: `vllm_mlx/turboquant.py::turboquant_scheduler_kwargs(args)` returns
  the four SchedulerConfig kwargs (`kv_cache_turboquant`,
  `kv_cache_turboquant_bits`, `kv_cache_turboquant_group_size`,
  `kv_cache_turboquant_mode`) derived from the resolved argparse
  values.
- **Both entries call it**: `cli.py::serve_command` and
  `server.py::main` unpack `**turboquant_scheduler_kwargs(args)` into
  their `SchedulerConfig(...)`. Future TurboQuant fields land in both
  entries automatically — drift prevention by design.
- **Server-side**: `"none"` added to argparse `choices` (mirrors
  cli.py:5953); `resolve_turboquant_mode_default` called on the
  args prior to SchedulerConfig construction (mirrors cli.py:2172).
- **Audit-side**: `scripts/audit_cli_config_fidelity.py` learned to
  expand `**helper(args)` star-unpacking via an explicit
  `KWARG_INJECTOR_HELPERS` map, so the shared-helper pattern doesn't
  false-positive as drift.

`cli.py` behaviour is unchanged on the wire — the mutex check and the
banner code that greps `args.kv_cache_turboquant` remain in place;
only the four SchedulerConfig kwargs at the construction site are
delegated to the helper.

## Test coverage — `tests/test_turboquant_k8v4.py::TestServerEntrypointParity`

Three new regression tests. All three fail on `main` prior to the fix
(verified by `git stash` on the implementation) and pass after:

- `test_server_argparse_accepts_none_off_switch` — AST-scrapes
  `--kv-cache-turboquant` from `server.main` and asserts `"none"` is
  in `choices`. Would have caught the #962 off-switch rejection.
- `test_server_main_threads_turboquant_into_scheduler_config` — walks
  the `SchedulerConfig(...)` call in `server.main` and asserts every
  TurboQuant field is either passed directly or unpacked from a known
  helper. Would have caught the silent flag drop that shipped for
  every 0.9.x release.
- `test_shared_turboquant_scheduler_kwargs_returns_all_fields` — pins
  the helper's return shape so a future TurboQuant field addition to
  `SchedulerConfig` can't silently degrade `python -m vllm_mlx.server`
  while `cli.py` keeps working (the banner code in cli.py references
  the raw args).

Existing turboquant / cli-config-fidelity / help-fuzzy / no-mllm-flag
tests all pass (`143 + 49 = 192` selected). `ruff check` and
`ruff format --check` are clean on all touched files.

## Operator-visible change

`python -m vllm_mlx.server --kv-cache-turboquant none` no longer
argparse-errors and now correctly boots with FP16 KV.
`python -m vllm_mlx.server --kv-cache-turboquant k8v4` now actually
engages TurboQuant K8V4 (previously silently dropped). Aliases marked
`turboquant_tier=k8v4_verified` now auto-default to k8v4 on this
entrypoint (previously only on `rapid-mlx serve`).

## Test plan

- [x] `pytest tests/test_turboquant.py tests/test_turboquant_k8v4.py tests/test_turboquant_kvcache_state.py tests/test_cli_config_fidelity.py tests/test_pflash_scheduler.py tests/test_no_mllm_flag.py tests/test_help_fuzzy.py` — 192 passed.
- [x] `scripts/audit_cli_config_fidelity.py` — clean.
- [x] `ruff check && ruff format --check` on touched files — clean.
- [x] Manual smoke: `--kv-cache-turboquant none` accepted by argparse;
      `turboquant_scheduler_kwargs` returns the expected dict shape
      for both off (`v4` mode default) and `k8v4` cases.
- [x] Pre-fix reproducer: all three new tests fail on `main`; all pass
      after fix.

Closes #969

🤖 Generated with [Claude Code](https://claude.com/claude-code)