### PR TITLE
chore: bump version to 0.9.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.9.9"
+version = "0.9.10"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## Summary

Cuts the 0.9.10 release. Batches 7 dogfood fixes merged since 0.9.9 (2026-06-30):

| PR | Change | Impact |
|---|---|---|
| #976 | api/anthropic_adapter: merge non-leading system messages before chat template | Fixes tool-loop crash on Anthropic → chat-template lane |
| #979 | fix(qwen3_coder_xml): anchor streaming on `<function=…>`, not `<tool_call>` wrapper | Restores Qwen3-Coder XML streaming for pydantic_ai / Cursor |
| #980 | fix(stt): guard Whisper silence hallucination via Silero VAD pre-trim (closes #961) | Silero VAD auto-bundled with `[audio]` extra; kills phantom transcription on silent leading audio |
| #981 | fix(chat-template): normalize assistant `tool_call.arguments` to dict at boundary (closes #973) | Fixes Qwen `arguments\|items` crash surfaced by pydantic_ai |
| #982 | fix(release_check_m3): thread `$PORT` into `RAPID_MLX_BASE_URL` for G7 SDK tests (closes #974) | Release-check no longer accidentally hits prod when `$PORT` is overridden |
| #983 | fix(server): thread TurboQuant flags into `SchedulerConfig` on `python -m vllm_mlx.server` (closes #969) | `--kv-cache-turboquant` was silently dropped on the standalone entrypoint; adds `none` off-switch, shares flag-plumbing helper between entrypoints |
| #601 | docs(readme): audit + rewrite for clarity and value-prop (0.8/0.9 polish) | New README with 0.9.x feature surface + value-prop-first ordering |

## Test plan

- [x] pyproject.toml version → 0.9.10
- [x] Commit subject matches `chore: bump version to X.Y.Z` (auto-release.yml trigger)
- [x] All 7 batched PRs individually pr_validate PASS before merge
- [x] `origin/main` HEAD stable (9bb6d37a)

Post-merge: `auto-release.yml` will publish rapid-mlx 0.9.10 to PyPI + cut GitHub Release.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>