### PR TITLE
feat(mtp): universal draft-k auto-tune controller (0.9.11 PR-1)

### DIFF
--- a/tests/test_mtp_draft_k_controller.py
+++ b/tests/test_mtp_draft_k_controller.py
@@ -49,10 +49,47 @@ def _clear_controller_singleton():
 
     Tests that flip on the global for integration coverage must not
     leak into subsequent cases.
+
+    Also resets ``mlx_lm.generate.generation_stream`` and the
+    ``vllm_mlx.spec_decode.mtp`` module singletons — mirrors the
+    :func:`tests.test_mtp_spec_decode._reset_mtp_module_state`
+    fixture so this file is robust to full-sweep ordering. Without
+    it, the integration test at the bottom of this file can leave
+    the ArraysCache patch mutated (or the ``generation_stream``
+    stamped by a prior sweep test's worker executor) and cascade
+    failures into ``tests/test_mtp_lossless.py`` +
+    ``tests/test_mtp_spec_decode.py`` when the whole suite runs
+    together. See the full rationale in the corresponding fixture
+    docstring at ``tests/test_mtp_spec_decode.py:_reset_mtp_module_state``.
     """
+    import sys
+
+    try:
+        import mlx.core as mx
+        import mlx_lm.generate  # noqa: F401
+    except ImportError:
+        mx = None
+
+    from vllm_mlx.spec_decode.mtp.accept_counter import (
+        reset_global_counter_for_tests,
+    )
+    from vllm_mlx.spec_decode.mtp.cache_patch import _unpatch_for_tests
+
     clear_global_controller()
+    _unpatch_for_tests()
+    reset_global_counter_for_tests()
+    if mx is not None:
+        sys.modules["mlx_lm.generate"].generation_stream = mx.default_stream(
+            mx.default_device()
+        )
     yield
     clear_global_controller()
+    _unpatch_for_tests()
+    reset_global_counter_for_tests()
+    if mx is not None:
+        sys.modules["mlx_lm.generate"].generation_stream = mx.default_stream(
+            mx.default_device()
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -399,43 +436,41 @@ def test_generator_static_k_path_unchanged_without_controller():
     from vllm_mlx.spec_decode.mtp.cache_patch import _unpatch_for_tests
     from vllm_mlx.spec_decode.mtp.generator import mtp_generate_step
 
-    # Ensure the ArraysCache patch is a clean install for this
-    # case (matches the test_mtp_lossless fixture behaviour).
-    _unpatch_for_tests()
-
-    # Re-bind mlx_lm.generate.generation_stream to this thread's
-    # default stream (see test_mtp_spec_decode fixture docstring).
-    import sys
-
-    import mlx_lm.generate  # noqa: F401
-
-    sys.modules["mlx_lm.generate"].generation_stream = mx.default_stream(
-        mx.default_device()
-    )
-
-    # Global controller must be uninstalled (autouse fixture guarantees
-    # this) — sanity-check the invariant.
+    # The autouse ``_clear_controller_singleton`` fixture already
+    # unpatches ArraysCache + resets the accept counter + re-binds
+    # ``mlx_lm.generate.generation_stream`` before/after this test.
+    # Sanity-check the module-global controller is uninstalled
+    # (the fixture invariant).
     assert get_global_controller() is None
 
-    # Same all-accept script as test_mtp_lossless: primary=7, three
-    # accept pairs.
-    backbone_script = [7, 11, 13, 15, 17, 19, 21]
-    mtp_script = [11, 0, 15, 0, 19]
-    model = _MockedQwen35Model(backbone_script, mtp_script)
-    counter = MTPAcceptCounter()
+    try:
+        # Same all-accept script as test_mtp_lossless: primary=7,
+        # three accept pairs.
+        backbone_script = [7, 11, 13, 15, 17, 19, 21]
+        mtp_script = [11, 0, 15, 0, 19]
+        model = _MockedQwen35Model(backbone_script, mtp_script)
+        counter = MTPAcceptCounter()
 
-    tokens = [
-        tok
-        for tok, _lp, _fd in mtp_generate_step(
-            mx.array([1], mx.uint32),
-            model,
-            max_tokens=7,
-            accept_counter=counter,
-        )
-    ]
+        tokens = [
+            tok
+            for tok, _lp, _fd in mtp_generate_step(
+                mx.array([1], mx.uint32),
+                model,
+                max_tokens=7,
+                accept_counter=counter,
+            )
+        ]
 
-    # The regression guard: static-k output matches the reference
-    # sequence. Any change to generator.py that broke the
-    # controller-off path would flip this.
-    assert tokens == [7, 11, 13, 15, 17, 19, 21]
-    _unpatch_for_tests()
+        # The regression guard: static-k output matches the
+        # reference sequence. Any change to generator.py that broke
+        # the controller-off path would flip this.
+        assert tokens == [7, 11, 13, 15, 17, 19, 21]
+    finally:
+        # Codex NIT: guarantee the cache patch is torn down even
+        # when the assert (or an unexpected exception in
+        # mtp_generate_step) fires, so a mid-test failure doesn't
+        # leave the ArraysCache patch installed for later cases.
+        # The autouse fixture teardown also unpatches, but a
+        # belt-and-braces call here keeps the state clean if the
+        # fixture teardown ever changes.
+        _unpatch_for_tests()

--- a/tests/test_mtp_draft_k_controller.py
+++ b/tests/test_mtp_draft_k_controller.py
@@ -1,0 +1,441 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the universal MTP draft-``k`` auto-tune controller (0.9.11 PR-1).
+
+The controller lives in
+:mod:`vllm_mlx.spec_decode.mtp.draft_k_controller` and is intentionally
+pure Python (no MLX imports). These tests exercise its state machine
+without spawning a server or importing MLX — they can run under any
+Python 3.10+ interpreter.
+
+Coverage:
+
+* Ramp-up: feeding all-accepts must ramp ``k`` up to ``k_max``, and
+  each adjustment must respect the ``cooldown`` gate.
+* Ramp-down: feeding all-rejects must ramp ``k`` down to ``k_min``.
+* Hold: an accept rate strictly between the two thresholds must
+  produce zero adjustments no matter how many attempts are recorded.
+* Constructor validation: NaN, ``+inf``, ``-inf`` on either
+  threshold must raise; inverted thresholds must raise; degenerate
+  ``k_min == k_max == 1`` must construct without error and never
+  change ``k``.
+* Regression guard for the generator: with auto-tune off (the
+  default), the vendored ``mtp_generate_step`` must emit exactly the
+  same tokens it did before PR-1 landed. We exercise this via the
+  same all-accept / all-reject scripts the lossless test uses.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from vllm_mlx.spec_decode.mtp.draft_k_controller import (
+    DraftKController,
+    clear_global_controller,
+    get_global_controller,
+    install_global_controller,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixture — isolate the module-level singleton between cases.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _clear_controller_singleton():
+    """Ensure ``get_global_controller()`` returns ``None`` at case start.
+
+    Tests that flip on the global for integration coverage must not
+    leak into subsequent cases.
+    """
+    clear_global_controller()
+    yield
+    clear_global_controller()
+
+
+# ---------------------------------------------------------------------------
+# 1. Ramp-up: all-accepts should bump k to k_max, respecting cooldown.
+# ---------------------------------------------------------------------------
+
+
+def test_all_accepts_ramps_up_to_k_max_respecting_cooldown():
+    """All-accept feed with cooldown=W (fully populated window) should
+    produce exactly ``k_max - k_start`` adjustments spaced ``cooldown``
+    attempts apart.
+
+    With W=cooldown=8, k_start=1, k_max=4, and every attempt an
+    accept:
+
+    * attempts 1..7: window fills, no adjustment (window not full yet).
+    * attempt 8: window fills (rate=1.0), first evaluation fires,
+      k=2. Steps_since_eval resets to 0.
+    * attempts 9..15: cooldown counting up, no re-eval.
+    * attempt 16: cooldown elapsed, rate=1.0 → k=3.
+    * attempt 24: rate=1.0 → k=4 (=k_max, capped).
+    * attempt 32: rate=1.0, k is at k_max already, no change.
+
+    So the adjustment schedule is deterministic: (attempt 8: 1→2),
+    (attempt 16: 2→3), (attempt 24: 3→4), then no further changes.
+    """
+    ctrl = DraftKController(
+        k_min=1,
+        k_max=4,
+        k_start=1,
+        window=8,
+        upshift_threshold=0.80,
+        downshift_threshold=0.40,
+        cooldown=8,
+    )
+
+    # Attempts 1..7: window is filling; no eval fires.
+    for _ in range(7):
+        ctrl.record_attempt(accepted=True)
+    assert ctrl.current_k() == 1
+    assert ctrl.snapshot()["adjust_count"] == 0
+
+    # Attempt 8: first eval, k should bump 1 → 2.
+    ctrl.record_attempt(accepted=True)
+    assert ctrl.current_k() == 2
+    assert ctrl.snapshot()["adjust_count"] == 1
+
+    # Attempts 9..15: cooldown counter re-populating.
+    for _ in range(7):
+        ctrl.record_attempt(accepted=True)
+    assert ctrl.current_k() == 2
+
+    # Attempt 16: second eval, k should bump 2 → 3.
+    ctrl.record_attempt(accepted=True)
+    assert ctrl.current_k() == 3
+
+    # Attempt 24: third eval, k should bump 3 → 4.
+    for _ in range(8):
+        ctrl.record_attempt(accepted=True)
+    assert ctrl.current_k() == 4
+    assert ctrl.snapshot()["adjust_count"] == 3
+
+    # Attempt 32+: k is at k_max, no further changes even with 100
+    # more all-accept attempts.
+    for _ in range(100):
+        ctrl.record_attempt(accepted=True)
+    assert ctrl.current_k() == 4
+    assert ctrl.snapshot()["adjust_count"] == 3
+
+
+# ---------------------------------------------------------------------------
+# 2. Ramp-down: all-rejects should bump k to k_min.
+# ---------------------------------------------------------------------------
+
+
+def test_all_rejects_ramps_down_to_k_min():
+    """All-reject feed with k_start at k_max should ratchet down to
+    k_min. Same deterministic cadence as the all-accept case.
+    """
+    ctrl = DraftKController(
+        k_min=1,
+        k_max=4,
+        k_start=4,
+        window=8,
+        upshift_threshold=0.80,
+        downshift_threshold=0.40,
+        cooldown=8,
+    )
+
+    for _ in range(8):
+        ctrl.record_attempt(accepted=False)
+    assert ctrl.current_k() == 3
+
+    for _ in range(8):
+        ctrl.record_attempt(accepted=False)
+    assert ctrl.current_k() == 2
+
+    for _ in range(8):
+        ctrl.record_attempt(accepted=False)
+    assert ctrl.current_k() == 1
+
+    # Floor reached: further rejects must NOT go below k_min.
+    for _ in range(100):
+        ctrl.record_attempt(accepted=False)
+    assert ctrl.current_k() == 1
+
+
+# ---------------------------------------------------------------------------
+# 3. In-band rate should hold (no oscillation).
+# ---------------------------------------------------------------------------
+
+
+def test_in_band_accept_rate_holds():
+    """Alternating accept/reject → rate=0.50 which is in the (0.40,
+    0.80) hold band. No adjustments should fire, no matter how many
+    attempts we record.
+    """
+    ctrl = DraftKController(
+        k_min=1,
+        k_max=4,
+        k_start=2,
+        window=8,
+        upshift_threshold=0.80,
+        downshift_threshold=0.40,
+        cooldown=8,
+    )
+
+    for i in range(1000):
+        ctrl.record_attempt(accepted=(i % 2 == 0))
+    assert ctrl.current_k() == 2
+    assert ctrl.snapshot()["adjust_count"] == 0
+
+
+def test_no_oscillation_within_same_window():
+    """A single window flip from mostly-accepts to mostly-rejects
+    must NOT produce an up-then-down oscillation within the SAME
+    cooldown period.
+
+    The cooldown gate is the invariant that guarantees this — the
+    controller cannot re-evaluate until at least ``cooldown`` new
+    attempts have been recorded. As long as ``cooldown`` is set
+    (>= 1), the invariant holds by construction.
+    """
+    ctrl = DraftKController(
+        k_min=1,
+        k_max=4,
+        k_start=2,
+        window=8,
+        upshift_threshold=0.80,
+        downshift_threshold=0.40,
+        cooldown=8,
+    )
+
+    # Fill the window with 100% accepts. This should adjust ONCE
+    # (k 2 → 3) at the 8th attempt.
+    for _ in range(8):
+        ctrl.record_attempt(accepted=True)
+    assert ctrl.current_k() == 3
+
+    # Immediately flip to rejects. Cooldown says we can't re-eval
+    # until 8 more attempts. Rejects during the cooldown should not
+    # trigger a downshift even though the accept-rate over the
+    # window is dropping.
+    for _ in range(7):
+        ctrl.record_attempt(accepted=False)
+    assert ctrl.current_k() == 3, (
+        "Downshift must not fire within the cooldown window "
+        "even when the rate has dropped."
+    )
+
+
+# ---------------------------------------------------------------------------
+# 4. Constructor validation.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("bad", [float("nan"), float("inf"), float("-inf")])
+def test_ctor_rejects_nan_and_infinity_on_upshift(bad):
+    """NaN and infinities on upshift_threshold must raise. Pydantic
+    ``Field(ge=, le=)`` accepts NaN silently (see the memory gotcha
+    ``pydantic-field-does-not-reject-nan``), so we validate here.
+    """
+    with pytest.raises(ValueError, match="upshift_threshold"):
+        DraftKController(upshift_threshold=bad, downshift_threshold=0.40)
+
+
+@pytest.mark.parametrize("bad", [float("nan"), float("inf"), float("-inf")])
+def test_ctor_rejects_nan_and_infinity_on_downshift(bad):
+    """Same gate for downshift_threshold."""
+    with pytest.raises(ValueError, match="downshift_threshold"):
+        DraftKController(upshift_threshold=0.80, downshift_threshold=bad)
+
+
+def test_ctor_rejects_upshift_lteq_downshift():
+    """Inverted thresholds (upshift <= downshift) must raise. A
+    controller with them inverted would ratchet ``k`` down on high
+    accept rates — a silent inversion that would be very hard to
+    diagnose in production.
+    """
+    with pytest.raises(ValueError, match="strictly greater"):
+        DraftKController(upshift_threshold=0.40, downshift_threshold=0.80)
+    with pytest.raises(ValueError, match="strictly greater"):
+        DraftKController(upshift_threshold=0.50, downshift_threshold=0.50)
+
+
+def test_ctor_rejects_thresholds_out_of_range():
+    """Thresholds must be in (0, 1] and [0, 1) respectively."""
+    with pytest.raises(ValueError, match="upshift_threshold"):
+        DraftKController(upshift_threshold=0.0, downshift_threshold=0.0)
+    with pytest.raises(ValueError, match="upshift_threshold"):
+        DraftKController(upshift_threshold=1.5, downshift_threshold=0.40)
+    with pytest.raises(ValueError, match="downshift_threshold"):
+        DraftKController(upshift_threshold=0.80, downshift_threshold=-0.1)
+    with pytest.raises(ValueError, match="downshift_threshold"):
+        DraftKController(upshift_threshold=0.80, downshift_threshold=1.0)
+
+
+def test_ctor_rejects_bad_integer_bounds():
+    """k_min, k_max, window, cooldown must be positive ints."""
+    with pytest.raises(ValueError, match="k_min"):
+        DraftKController(k_min=0, k_max=4)
+    with pytest.raises(ValueError, match="k_max"):
+        DraftKController(k_min=3, k_max=2)
+    with pytest.raises(ValueError, match="window"):
+        DraftKController(window=0)
+    with pytest.raises(ValueError, match="cooldown"):
+        DraftKController(cooldown=0)
+
+
+def test_ctor_rejects_bool_where_int_expected():
+    """``bool`` is a subclass of ``int`` in Python, but a ``True``/
+    ``False`` mistake in a caller should fail loud rather than
+    silently mis-configuring the controller.
+    """
+    with pytest.raises(TypeError, match="k_min"):
+        DraftKController(k_min=True, k_max=4)
+
+
+def test_ctor_rejects_start_out_of_bounds():
+    """k_start must satisfy k_min <= start <= k_max."""
+    with pytest.raises(ValueError, match="k_start"):
+        DraftKController(k_min=2, k_max=4, k_start=1)
+    with pytest.raises(ValueError, match="k_start"):
+        DraftKController(k_min=2, k_max=4, k_start=5)
+
+
+# ---------------------------------------------------------------------------
+# 5. Degenerate k_min == k_max == 1 must not crash and must never change k.
+# ---------------------------------------------------------------------------
+
+
+def test_degenerate_bounds_never_change_k():
+    """k_min == k_max == 1 → controller is a no-op ``k``-wise but
+    still records attempts and updates its window (so /metrics keeps
+    getting fresh accept-rate numbers).
+    """
+    ctrl = DraftKController(
+        k_min=1,
+        k_max=1,
+        window=8,
+        upshift_threshold=0.80,
+        downshift_threshold=0.40,
+        cooldown=8,
+    )
+
+    for i in range(1000):
+        ctrl.record_attempt(accepted=(i % 3 != 0))  # ~66% accepts
+    assert ctrl.current_k() == 1
+    # Adjustments would be attempted at cooldown boundaries but
+    # capped by the bounds — the adjust counter must stay at 0.
+    assert ctrl.snapshot()["adjust_count"] == 0
+
+
+# ---------------------------------------------------------------------------
+# 6. Snapshot shape + module-global installer contract.
+# ---------------------------------------------------------------------------
+
+
+def test_snapshot_returns_expected_keys():
+    ctrl = DraftKController(k_min=1, k_max=4, window=4, cooldown=4)
+    snap = ctrl.snapshot()
+    expected_keys = {
+        "current_k",
+        "k_min",
+        "k_max",
+        "window_size",
+        "window_fill",
+        "window_accept_rate",
+        "cooldown_steps",
+        "steps_since_eval",
+        "adjust_count",
+        "upshift_threshold",
+        "downshift_threshold",
+    }
+    assert set(snap) == expected_keys
+    assert snap["current_k"] == 1
+    assert snap["window_fill"] == 0
+    assert snap["window_accept_rate"] == 0.0
+    assert math.isfinite(snap["upshift_threshold"])
+    assert math.isfinite(snap["downshift_threshold"])
+
+
+def test_global_controller_starts_uninstalled():
+    """The module-global controller must default to ``None`` so the
+    static-``k`` fast path in generator.py stays engaged when the
+    operator hasn't opted in.
+    """
+    assert get_global_controller() is None
+
+
+def test_install_and_clear_global_controller_roundtrip():
+    ctrl = DraftKController(k_min=1, k_max=2, window=2, cooldown=2)
+    install_global_controller(ctrl)
+    assert get_global_controller() is ctrl
+    clear_global_controller()
+    assert get_global_controller() is None
+
+
+def test_install_rejects_non_controller():
+    with pytest.raises(TypeError, match="DraftKController"):
+        install_global_controller("not a controller")  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# 7. Regression guard for generator.py — auto-tune off must be a no-op.
+# ---------------------------------------------------------------------------
+
+
+def test_generator_static_k_path_unchanged_without_controller():
+    """When ``draft_k_controller`` is not installed globally AND not
+    passed explicitly, the vendored ``mtp_generate_step`` must emit
+    the same tokens it did before PR-1 landed.
+
+    We exercise this by reusing the mocked-model plumbing from
+    :mod:`tests.test_mtp_spec_decode` and asserting the emitted
+    token sequence in the all-accept scenario byte-matches the
+    reference. If the ``if draft_k_controller is not None`` guard
+    in generator.py ever regressed to a call on a None controller,
+    an AttributeError would surface here.
+    """
+    mx = pytest.importorskip("mlx.core")
+    from tests.test_mtp_spec_decode import _MockedQwen35Model  # noqa: E402
+    from vllm_mlx.spec_decode.mtp.accept_counter import MTPAcceptCounter
+    from vllm_mlx.spec_decode.mtp.cache_patch import _unpatch_for_tests
+    from vllm_mlx.spec_decode.mtp.generator import mtp_generate_step
+
+    # Ensure the ArraysCache patch is a clean install for this
+    # case (matches the test_mtp_lossless fixture behaviour).
+    _unpatch_for_tests()
+
+    # Re-bind mlx_lm.generate.generation_stream to this thread's
+    # default stream (see test_mtp_spec_decode fixture docstring).
+    import sys
+
+    import mlx_lm.generate  # noqa: F401
+
+    sys.modules["mlx_lm.generate"].generation_stream = mx.default_stream(
+        mx.default_device()
+    )
+
+    # Global controller must be uninstalled (autouse fixture guarantees
+    # this) — sanity-check the invariant.
+    assert get_global_controller() is None
+
+    # Same all-accept script as test_mtp_lossless: primary=7, three
+    # accept pairs.
+    backbone_script = [7, 11, 13, 15, 17, 19, 21]
+    mtp_script = [11, 0, 15, 0, 19]
+    model = _MockedQwen35Model(backbone_script, mtp_script)
+    counter = MTPAcceptCounter()
+
+    tokens = [
+        tok
+        for tok, _lp, _fd in mtp_generate_step(
+            mx.array([1], mx.uint32),
+            model,
+            max_tokens=7,
+            accept_counter=counter,
+        )
+    ]
+
+    # The regression guard: static-k output matches the reference
+    # sequence. Any change to generator.py that broke the
+    # controller-off path would flip this.
+    assert tokens == [7, 11, 13, 15, 17, 19, 21]
+    _unpatch_for_tests()

--- a/tests/test_mtp_draft_k_controller.py
+++ b/tests/test_mtp_draft_k_controller.py
@@ -37,7 +37,6 @@ from vllm_mlx.spec_decode.mtp.draft_k_controller import (
     install_global_controller,
 )
 
-
 # ---------------------------------------------------------------------------
 # Fixture — isolate the module-level singleton between cases.
 # ---------------------------------------------------------------------------

--- a/tests/test_mtp_spec_decode.py
+++ b/tests/test_mtp_spec_decode.py
@@ -608,7 +608,7 @@ def test_metrics_current_draft_k_gauge_reports_controller_state():
 
         body = "\n".join(_render_spec_decode_mtp_counters(_Cfg()))
         assert (
-            'rapid_mlx_spec_decode_mtp_current_draft_k{'
+            "rapid_mlx_spec_decode_mtp_current_draft_k{"
             'family="qwen3.5-9b-4bit",method="mtp"} 3'
         ) in body
     finally:

--- a/tests/test_mtp_spec_decode.py
+++ b/tests/test_mtp_spec_decode.py
@@ -428,6 +428,24 @@ def test_cli_spec_decode_flag_advertised_in_help():
     assert "none,mtp" in text or "mtp,none" in text
 
 
+def test_cli_mtp_draft_k_auto_tune_flags_advertised_in_help():
+    """0.9.11 PR-1: all six ``--mtp-draft-k-*`` flags must appear in
+    ``rapid-mlx serve --help``. Guards against a future refactor
+    silently dropping any of the surface — the flag names ARE the
+    public contract.
+    """
+    text = _serve_help_stdout()
+    for flag in (
+        "--mtp-draft-k-auto-tune",
+        "--mtp-draft-k-max",
+        "--mtp-draft-k-window",
+        "--mtp-draft-k-upshift-threshold",
+        "--mtp-draft-k-downshift-threshold",
+        "--mtp-draft-k-cooldown",
+    ):
+        assert flag in text, f"{flag} missing from serve --help"
+
+
 def test_cli_spec_decode_flag_rejects_unknown_value():
     """``--spec-decode eagle`` is rejected by argparse choices."""
     import subprocess
@@ -531,6 +549,70 @@ def test_metrics_renders_post_acceptance_counters():
     # accept_ratio = 0.75 → must appear rounded to 4 decimals.
     assert "0.75" in body
     reset_global_counter_for_tests()
+
+
+def test_metrics_current_draft_k_gauge_absent_without_controller():
+    """0.9.11 PR-1: the current-draft-k gauge is only emitted when
+    the auto-tune controller has been installed at boot. Without
+    the controller, ``0`` in the gauge would falsely imply the
+    controller ratcheted k to zero — instead we skip the line.
+    """
+    from vllm_mlx.routes.metrics import _render_spec_decode_mtp_counters
+    from vllm_mlx.spec_decode.mtp.accept_counter import (
+        reset_global_counter_for_tests,
+    )
+    from vllm_mlx.spec_decode.mtp.draft_k_controller import (
+        clear_global_controller,
+    )
+
+    reset_global_counter_for_tests()
+    clear_global_controller()
+
+    class _Cfg:
+        model_alias = "qwen3.5-9b-4bit"
+
+    body = "\n".join(_render_spec_decode_mtp_counters(_Cfg()))
+    assert "rapid_mlx_spec_decode_mtp_current_draft_k" not in body
+
+
+def test_metrics_current_draft_k_gauge_reports_controller_state():
+    """0.9.11 PR-1: with a controller installed, the gauge should
+    surface its current ``k`` value. The label set is joined with
+    the other MTP counters via the shared ``family``/``method``
+    keys.
+    """
+    from vllm_mlx.routes.metrics import _render_spec_decode_mtp_counters
+    from vllm_mlx.spec_decode.mtp.accept_counter import (
+        reset_global_counter_for_tests,
+    )
+    from vllm_mlx.spec_decode.mtp.draft_k_controller import (
+        DraftKController,
+        clear_global_controller,
+        install_global_controller,
+    )
+
+    reset_global_counter_for_tests()
+    clear_global_controller()
+    controller = DraftKController(
+        k_min=1,
+        k_max=4,
+        k_start=3,
+        window=4,
+        cooldown=4,
+    )
+    install_global_controller(controller)
+    try:
+
+        class _Cfg:
+            model_alias = "qwen3.5-9b-4bit"
+
+        body = "\n".join(_render_spec_decode_mtp_counters(_Cfg()))
+        assert (
+            'rapid_mlx_spec_decode_mtp_current_draft_k{'
+            'family="qwen3.5-9b-4bit",method="mtp"} 3'
+        ) in body
+    finally:
+        clear_global_controller()
 
 
 def test_metrics_renders_zero_ratio_when_no_attempts():

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -2436,25 +2436,31 @@ def serve_command(args):
         print(f"Spec-decode: mtp ({eligibility.value})")
 
     # 0.9.11 PR-1: universal MTP draft-``k`` auto-tune controller.
-    # Gate: EITHER --enable-mtp (Qwen3-Next legacy path) OR
-    # --spec-decode mtp (Qwen3.5/3.6 native path from PR #990) must
-    # already be on. Requiring one of them is a defensive check —
-    # without an MTP path installed the controller would sit
-    # installed but never receive ``record_attempt()`` calls, which
-    # is a silent no-op that's hard to diagnose from the operator
-    # side. Fail loud at boot instead. (Task PR description said
-    # "requires --enable-mtp"; the wider gate covers the vendored
-    # spec-decode path since the controller wires into
-    # ``generator.py`` which only runs under --spec-decode mtp.)
+    #
+    # Gate: --spec-decode mtp MUST be set. The only ``record_attempt()``
+    # feedback wiring in PR-1 lives inside
+    # ``vllm_mlx/spec_decode/mtp/generator.py::mtp_generate_step`` —
+    # which only runs when ``--spec-decode mtp`` is active. The legacy
+    # ``--enable-mtp`` (Qwen3-Next) path uses a different scheduler-
+    # side monkey-patch (``_install_mtp`` in scheduler.py) that does
+    # NOT touch the controller, so allowing ``--enable-mtp`` alone
+    # would install a controller that never receives feedback — a
+    # silent no-op that would confuse operators looking at the
+    # ``rapid_mlx_spec_decode_mtp_current_draft_k`` gauge sitting on
+    # its cold-start value forever. Fail loud instead. The stricter
+    # gate is intentional; a future PR that wires the controller into
+    # ``_install_mtp`` can loosen this to ``args.enable_mtp or
+    # spec_decode == "mtp"``.
     if getattr(args, "mtp_draft_k_auto_tune", False):
-        if not (
-            args.enable_mtp or getattr(args, "spec_decode", "none") == "mtp"
-        ):
+        if getattr(args, "spec_decode", "none") != "mtp":
             print(
-                "error: --mtp-draft-k-auto-tune requires either "
-                "--enable-mtp or --spec-decode mtp to be set. The "
-                "controller only receives accept/reject feedback from "
-                "an active MTP path.",
+                "error: --mtp-draft-k-auto-tune requires --spec-decode "
+                "mtp to be set. The controller's accept/reject "
+                "feedback wiring lives inside the vendored "
+                "mtp_generate_step (from mlx-lm PR #990), which only "
+                "runs under --spec-decode mtp. The legacy --enable-mtp "
+                "(Qwen3-Next) path does not feed the controller and "
+                "would leave the current-k gauge frozen at cold-start.",
                 file=sys.stderr,
             )
             sys.exit(2)
@@ -6269,10 +6275,12 @@ Examples:
         default=False,
         help=(
             "Enable the runtime MTP draft-k auto-tune controller "
-            "(0.9.11 PR-1). Requires --enable-mtp or --spec-decode mtp; "
-            "boot fails otherwise. Adjusts draft-k between 1 and "
-            "--mtp-draft-k-max based on the rolling accept rate. "
-            "Default off — the pre-0.9.11 static-k path is preserved."
+            "(0.9.11 PR-1). Requires --spec-decode mtp (the vendored "
+            "PR #990 path — the only path that feeds the controller "
+            "in PR-1); boot fails otherwise. Adjusts draft-k between "
+            "1 and --mtp-draft-k-max based on the rolling accept "
+            "rate. Default off — the pre-0.9.11 static-k path is "
+            "preserved."
         ),
     )
     serve_parser.add_argument(

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -2435,6 +2435,84 @@ def serve_command(args):
             sys.exit(2)
         print(f"Spec-decode: mtp ({eligibility.value})")
 
+    # 0.9.11 PR-1: universal MTP draft-``k`` auto-tune controller.
+    # Gate: EITHER --enable-mtp (Qwen3-Next legacy path) OR
+    # --spec-decode mtp (Qwen3.5/3.6 native path from PR #990) must
+    # already be on. Requiring one of them is a defensive check —
+    # without an MTP path installed the controller would sit
+    # installed but never receive ``record_attempt()`` calls, which
+    # is a silent no-op that's hard to diagnose from the operator
+    # side. Fail loud at boot instead. (Task PR description said
+    # "requires --enable-mtp"; the wider gate covers the vendored
+    # spec-decode path since the controller wires into
+    # ``generator.py`` which only runs under --spec-decode mtp.)
+    if getattr(args, "mtp_draft_k_auto_tune", False):
+        if not (
+            args.enable_mtp or getattr(args, "spec_decode", "none") == "mtp"
+        ):
+            print(
+                "error: --mtp-draft-k-auto-tune requires either "
+                "--enable-mtp or --spec-decode mtp to be set. The "
+                "controller only receives accept/reject feedback from "
+                "an active MTP path.",
+                file=sys.stderr,
+            )
+            sys.exit(2)
+        k_max = args.mtp_draft_k_max
+        if k_max < 1 or k_max > 8:
+            print(
+                f"error: --mtp-draft-k-max must be in [1, 8]; got {k_max}.",
+                file=sys.stderr,
+            )
+            sys.exit(2)
+        # ``--mtp-num-draft-tokens`` is the starting-k seed when
+        # auto-tune is on. Must satisfy k_min=1 <= start <= k_max
+        # else the controller constructor would raise deep inside
+        # the boot path — trap here so the operator gets a clean
+        # error line instead of an ImportError-shaped traceback.
+        k_start = args.mtp_num_draft_tokens
+        if not (1 <= k_start <= k_max):
+            print(
+                f"error: --mtp-num-draft-tokens ({k_start}) must satisfy "
+                f"1 <= start <= --mtp-draft-k-max ({k_max}) when "
+                "--mtp-draft-k-auto-tune is set.",
+                file=sys.stderr,
+            )
+            sys.exit(2)
+        # Construct + install. Constructor raises on NaN / +Inf /
+        # -Inf thresholds, inverted thresholds, non-positive window
+        # / cooldown, etc. — surface those with a clean error line.
+        try:
+            from vllm_mlx.spec_decode.mtp import (
+                DraftKController,
+                install_global_controller,
+            )
+
+            controller = DraftKController(
+                k_min=1,
+                k_max=k_max,
+                k_start=k_start,
+                window=args.mtp_draft_k_window,
+                upshift_threshold=args.mtp_draft_k_upshift_threshold,
+                downshift_threshold=args.mtp_draft_k_downshift_threshold,
+                cooldown=args.mtp_draft_k_cooldown,
+            )
+        except (TypeError, ValueError) as exc:
+            print(
+                f"error: --mtp-draft-k-auto-tune controller config invalid: {exc}",
+                file=sys.stderr,
+            )
+            sys.exit(2)
+        install_global_controller(controller)
+        print(
+            "MTP draft-k auto-tune: enabled "
+            f"(k_start={k_start}, k_max={k_max}, "
+            f"window={args.mtp_draft_k_window}, "
+            f"upshift={args.mtp_draft_k_upshift_threshold}, "
+            f"downshift={args.mtp_draft_k_downshift_threshold}, "
+            f"cooldown={args.mtp_draft_k_cooldown})"
+        )
+
     # ``--spec-decode dflash`` is normalized to ``--enable-dflash`` near
     # the top of serve_command (#318 redirect); by the time we reach
     # here, args.spec_decode is "none" for dflash callers. The
@@ -6161,6 +6239,97 @@ Examples:
         default=False,
         help="Skip MTP acceptance check for maximum speed. "
         "~5-10%% wrong tokens. Best for chat, not for code.",
+    )
+    # ------------------------------------------------------------------
+    # 0.9.11 PR-1: universal MTP draft-``k`` auto-tune controller.
+    #
+    # The controller lives in ``vllm_mlx.spec_decode.mtp.draft_k_controller``
+    # and adjusts ``k`` (draft tokens per verify pass) between
+    # ``--mtp-draft-k-min=1`` and ``--mtp-draft-k-max`` based on the
+    # rolling accept rate. Design rationale: hysteresis (two
+    # thresholds) + cooldown prevents the ``k = 3 ↔ k = 4`` oscillation
+    # a single-threshold controller would show when the accept rate
+    # hovers right at the boundary between "one more draft is a win"
+    # and "one more draft is a loss".
+    #
+    # The controller is opt-in (default off) so the pre-0.9.11
+    # static-``k`` behaviour is preserved byte-for-byte for operators
+    # who don't pass the flag. The generator (`generator.py`) checks
+    # the module-global controller once per verify pass via an
+    # ``is None`` guard, so the fast-path cost when off is a single
+    # attribute load per step.
+    #
+    # PR-1 lands the controller + feedback loop. PR-2/3 (Gemma-4
+    # sidecar) will consume ``controller.current_k()`` in the
+    # generator hot loop to actually draft ``k`` tokens per verify
+    # pass — that requires the upstream MTP sidecar (parked).
+    serve_parser.add_argument(
+        "--mtp-draft-k-auto-tune",
+        action="store_true",
+        default=False,
+        help=(
+            "Enable the runtime MTP draft-k auto-tune controller "
+            "(0.9.11 PR-1). Requires --enable-mtp or --spec-decode mtp; "
+            "boot fails otherwise. Adjusts draft-k between 1 and "
+            "--mtp-draft-k-max based on the rolling accept rate. "
+            "Default off — the pre-0.9.11 static-k path is preserved."
+        ),
+    )
+    serve_parser.add_argument(
+        "--mtp-draft-k-max",
+        type=int,
+        default=4,
+        help=(
+            "Upper bound on MTP draft-k when auto-tune is enabled "
+            "(default: 4; range: 1-8). Ignored when "
+            "--mtp-draft-k-auto-tune is off."
+        ),
+    )
+    serve_parser.add_argument(
+        "--mtp-draft-k-window",
+        type=int,
+        default=64,
+        help=(
+            "Rolling window size (in attempts) used to compute the "
+            "accept rate that drives auto-tune adjustments "
+            "(default: 64). Ignored when auto-tune is off."
+        ),
+    )
+    serve_parser.add_argument(
+        "--mtp-draft-k-upshift-threshold",
+        type=float,
+        default=0.80,
+        help=(
+            "Accept-rate at or above which draft-k is bumped up "
+            "(default: 0.80). Must be strictly greater than "
+            "--mtp-draft-k-downshift-threshold. NaN / +Inf / -Inf "
+            "and values outside (0, 1] are rejected at boot. Ignored "
+            "when auto-tune is off."
+        ),
+    )
+    serve_parser.add_argument(
+        "--mtp-draft-k-downshift-threshold",
+        type=float,
+        default=0.40,
+        help=(
+            "Accept-rate at or below which draft-k is cut down "
+            "(default: 0.40). Must be strictly less than "
+            "--mtp-draft-k-upshift-threshold. NaN / +Inf / -Inf and "
+            "values outside [0, 1) are rejected at boot. Ignored "
+            "when auto-tune is off."
+        ),
+    )
+    serve_parser.add_argument(
+        "--mtp-draft-k-cooldown",
+        type=int,
+        default=128,
+        help=(
+            "Minimum number of recorded verify attempts between "
+            "auto-tune adjustment decisions (default: 128). Prevents "
+            "a lucky streak of accepts right after cold-start from "
+            "ratcheting k up before steady-state behaviour kicks in. "
+            "Ignored when auto-tune is off."
+        ),
     )
     # R15-P1 #302: native Qwen3.5/3.6 MTP via vendored mlx-lm PR #990.
     # Lives next to the existing ``--enable-mtp`` (Qwen3-Next runtime

--- a/vllm_mlx/routes/metrics.py
+++ b/vllm_mlx/routes/metrics.py
@@ -501,6 +501,40 @@ def _render_spec_decode_mtp_counters(cfg: Any) -> list[str]:
             labels=common_labels,
         )
     )
+
+    # 0.9.11 PR-1: MTP draft-``k`` auto-tune current-k gauge.
+    #
+    # Emitted ONLY when a controller has been installed at boot via
+    # ``--mtp-draft-k-auto-tune``. When auto-tune is off the gauge
+    # is skipped entirely — emitting a placeholder ``0`` would
+    # falsely imply the controller ratcheted ``k`` to zero, which
+    # is not a state the controller can reach (``k_min >= 1``).
+    #
+    # Labelled with the same ``family`` (model alias) as the accept
+    # counters so a dashboard can join the two on a single panel
+    # without cardinality gymnastics.
+    try:
+        from ..spec_decode.mtp import get_global_controller
+
+        controller = get_global_controller()
+    except ImportError:  # pragma: no cover — defensive, matches counter path
+        controller = None
+    if controller is not None:
+        controller_snapshot = controller.snapshot()
+        out.extend(
+            _fmt_metric(
+                "rapid_mlx_spec_decode_mtp_current_draft_k",
+                "gauge",
+                (
+                    "Currently in-use MTP draft-k as chosen by the "
+                    "0.9.11 auto-tune controller. Bounded by "
+                    "--mtp-draft-k-min and --mtp-draft-k-max at boot. "
+                    "Only emitted when --mtp-draft-k-auto-tune is set."
+                ),
+                int(controller_snapshot["current_k"]),
+                labels=common_labels,
+            )
+        )
     return out
 
 

--- a/vllm_mlx/routes/metrics.py
+++ b/vllm_mlx/routes/metrics.py
@@ -527,9 +527,9 @@ def _render_spec_decode_mtp_counters(cfg: Any) -> list[str]:
                 "gauge",
                 (
                     "Currently in-use MTP draft-k as chosen by the "
-                    "0.9.11 auto-tune controller. Bounded by "
-                    "--mtp-draft-k-min and --mtp-draft-k-max at boot. "
-                    "Only emitted when --mtp-draft-k-auto-tune is set."
+                    "0.9.11 auto-tune controller. Bounded between 1 "
+                    "and --mtp-draft-k-max (default 4). Only emitted "
+                    "when --mtp-draft-k-auto-tune is set."
                 ),
                 int(controller_snapshot["current_k"]),
                 labels=common_labels,

--- a/vllm_mlx/spec_decode/mtp/__init__.py
+++ b/vllm_mlx/spec_decode/mtp/__init__.py
@@ -65,12 +65,22 @@ from __future__ import annotations
 from .accept_counter import MTPAcceptCounter, get_global_counter
 from .cache_patch import patch_arrays_cache_rollback_state
 from .detect import MTPEligibility, detect_mtp_eligibility
+from .draft_k_controller import (
+    DraftKController,
+    clear_global_controller,
+    get_global_controller,
+    install_global_controller,
+)
 
 __all__ = [
+    "DraftKController",
     "MTPAcceptCounter",
     "MTPEligibility",
+    "clear_global_controller",
     "detect_mtp_eligibility",
+    "get_global_controller",
     "get_global_counter",
+    "install_global_controller",
     "patch_arrays_cache_rollback_state",
 ]
 

--- a/vllm_mlx/spec_decode/mtp/draft_k_controller.py
+++ b/vllm_mlx/spec_decode/mtp/draft_k_controller.py
@@ -353,7 +353,8 @@ def get_global_controller() -> DraftKController | None:
     ``k`` fast path — only an ``is None`` check separates the two
     modes in the hot loop.
     """
-    return _global_controller
+    with _global_controller_lock:
+        return _global_controller
 
 
 def install_global_controller(controller: DraftKController) -> None:

--- a/vllm_mlx/spec_decode/mtp/draft_k_controller.py
+++ b/vllm_mlx/spec_decode/mtp/draft_k_controller.py
@@ -1,0 +1,392 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Universal MTP draft-``k`` auto-tune controller (0.9.11, PR-1 of Gemma 4 MTP).
+
+Background
+----------
+
+The chain-MTP generator in :mod:`vllm_mlx.spec_decode.mtp.generator`
+proposes a single draft token per verify backbone pass. A future
+Gemma-4 sidecar (PR-2/3) will let callers propose ``k`` draft tokens
+per pass, but choosing the right ``k`` is workload-dependent:
+
+* On highly-predictable content (JSON, tool calls, code
+  boilerplate) the accept-rate stays close to 1.0 and larger ``k``
+  amortizes the verify cost across more accepted tokens.
+* On free-form chat / creative prose the accept-rate drops and a
+  larger ``k`` inflates the verify forward cost without a matching
+  accept rate — a net regression.
+* The optimum drifts within a single session — a code-heavy request
+  followed by a chat request wants a different ``k``.
+
+This module implements the *runtime feedback loop* that adjusts
+``k`` based on the rolling accept rate. It is intentionally pure
+Python (no MLX imports) so it can be unit-tested without spawning
+a server, and it uses hysteresis + a cooldown so a noisy window
+around the thresholds doesn't oscillate ``k`` up-and-down every
+attempt.
+
+Design contract
+---------------
+
+* **Rolling window.** The controller maintains a bounded deque of
+  the last ``window`` attempt outcomes (``True`` / ``False``). The
+  accept-rate is ``sum(True) / len(window)``.
+* **Hysteresis thresholds.** If the rate is ``>= upshift_threshold``
+  and ``current_k < k_max``, ``k`` is bumped by 1. If the rate is
+  ``<= downshift_threshold`` and ``current_k > k_min``, ``k`` is
+  cut by 1. In between → hold. The gap between the two thresholds
+  is the hysteresis band that prevents the ``k = 3 ↔ k = 4``
+  oscillation the naïve single-threshold controller would exhibit
+  when the rate hovers right at the boundary.
+* **Cooldown.** Adjustments are only considered every ``cooldown``
+  recorded attempts. Without cooldown, a lucky streak of accepts
+  right after startup would bump ``k`` up before the window even
+  has ``k_max - k_min`` samples of steady-state behavior.
+* **Bounds.** ``k`` is clamped to ``[k_min, k_max]`` at all times.
+  ``k_min == k_max`` is the degenerate case (auto-tune disabled by
+  the operator via a tight bound) and MUST NOT crash — the
+  controller still records attempts but never adjusts.
+* **Validation at construction time.** NaN, ``+inf``, ``-inf``, and
+  values outside ``(0, 1)`` on either threshold raise
+  :class:`ValueError`. This is deliberate — the memory gotcha
+  ``pydantic-field-does-not-reject-nan`` notes that Pydantic
+  ``Field(ge=, le=)`` accepts NaN silently, so any float that
+  reaches a math kernel needs an explicit ``math.isfinite`` gate.
+  The controller is upstream of any math kernel, so we gate here.
+* **``upshift_threshold`` must be strictly greater than
+  ``downshift_threshold``.** An operator passing them the other
+  way around would produce a controller that ratchets ``k`` down
+  on high accept rates — a silent inversion that would be very
+  hard to notice at scale. Fail loud at construction time.
+
+Thread-safety
+-------------
+
+The MTP generator runs from the scheduler thread; the metrics
+endpoint reads :meth:`snapshot` from the FastAPI worker pool. All
+state changes and reads acquire ``self._lock`` — the lock is held
+for O(1) work (a deque push, a small sum over the deque, one or two
+int assignments) so contention is negligible in practice.
+
+Public surface
+--------------
+
+* :class:`DraftKController` — the controller class.
+* :func:`get_global_controller` — module-level singleton getter.
+  Returns ``None`` when auto-tune is disabled (the default). The
+  generator uses ``get_global_controller() or None`` to preserve
+  the static-``k`` fast path when auto-tune is off — no extra
+  branches in the hot loop except the ``is None`` check.
+* :func:`install_global_controller` — CLI-boot-time installer.
+  Called from ``vllm_mlx/cli.py::serve_command`` when the operator
+  passes ``--mtp-draft-k-auto-tune``. Idempotent — a subsequent
+  install replaces the singleton (used by the test suite).
+* :func:`clear_global_controller` — teardown hook, primarily used
+  by the test fixture to isolate cases.
+"""
+
+from __future__ import annotations
+
+import math
+import threading
+from collections import deque
+from typing import Any
+
+
+class DraftKController:
+    """Runtime feedback loop that adjusts MTP draft-``k`` from accept rate.
+
+    See the module docstring for the design contract. Instances are
+    thread-safe.
+
+    Args:
+        k_min: Lower bound on ``k`` (inclusive). Must be ``>= 1``.
+        k_max: Upper bound on ``k`` (inclusive). Must be ``>= k_min``.
+        k_start: Starting value for ``k``. Defaults to ``k_min``.
+            Must satisfy ``k_min <= k_start <= k_max``.
+        window: Rolling window size (in attempts) used to compute
+            the accept rate. Defaults to 64.
+        upshift_threshold: Accept-rate at or above which ``k`` is
+            bumped by 1 (when ``current_k < k_max``). Defaults to
+            ``0.80``. Must be a finite float in ``(0, 1]``.
+        downshift_threshold: Accept-rate at or below which ``k`` is
+            cut by 1 (when ``current_k > k_min``). Defaults to
+            ``0.40``. Must be a finite float in ``[0, 1)`` and
+            strictly less than ``upshift_threshold``.
+        cooldown: Minimum number of recorded attempts between
+            adjustment decisions. Defaults to 128. Must be ``>= 1``.
+    """
+
+    def __init__(
+        self,
+        *,
+        k_min: int = 1,
+        k_max: int = 4,
+        k_start: int | None = None,
+        window: int = 64,
+        upshift_threshold: float = 0.80,
+        downshift_threshold: float = 0.40,
+        cooldown: int = 128,
+    ) -> None:
+        # --- integer bounds ------------------------------------------------
+        # ``bool`` is a subclass of ``int`` in Python; reject it explicitly
+        # so a ``True``/``False`` mistake in a caller (e.g. from a
+        # ``argparse`` boolean flag routed to the wrong kwarg) fails loud
+        # rather than silently ratcheting ``k`` to 0.
+        for name, val in (
+            ("k_min", k_min),
+            ("k_max", k_max),
+            ("window", window),
+            ("cooldown", cooldown),
+        ):
+            if isinstance(val, bool) or not isinstance(val, int):
+                raise TypeError(f"{name} must be int, got {type(val).__name__}")
+        if k_min < 1:
+            raise ValueError(f"k_min must be >= 1, got {k_min}")
+        if k_max < k_min:
+            raise ValueError(f"k_max ({k_max}) must be >= k_min ({k_min})")
+        if window < 1:
+            raise ValueError(f"window must be >= 1, got {window}")
+        if cooldown < 1:
+            raise ValueError(f"cooldown must be >= 1, got {cooldown}")
+
+        # --- threshold validation -----------------------------------------
+        # Pydantic ``Field(ge=, le=)`` does not reject NaN (per the
+        # ``pydantic-field-does-not-reject-nan`` gotcha) — even though
+        # we're not going through Pydantic here, any operator-supplied
+        # float needs an explicit ``math.isfinite`` guard because
+        # comparisons against NaN silently return False.
+        for name, val in (
+            ("upshift_threshold", upshift_threshold),
+            ("downshift_threshold", downshift_threshold),
+        ):
+            if isinstance(val, bool) or not isinstance(val, (int, float)):
+                raise TypeError(f"{name} must be float, got {type(val).__name__}")
+            if not math.isfinite(float(val)):
+                raise ValueError(f"{name} must be finite, got {val!r}")
+
+        upshift_threshold = float(upshift_threshold)
+        downshift_threshold = float(downshift_threshold)
+
+        if not (0.0 < upshift_threshold <= 1.0):
+            raise ValueError(
+                f"upshift_threshold must be in (0.0, 1.0], got {upshift_threshold}"
+            )
+        if not (0.0 <= downshift_threshold < 1.0):
+            raise ValueError(
+                f"downshift_threshold must be in [0.0, 1.0), got {downshift_threshold}"
+            )
+        if upshift_threshold <= downshift_threshold:
+            raise ValueError(
+                "upshift_threshold must be strictly greater than "
+                f"downshift_threshold; got upshift={upshift_threshold}, "
+                f"downshift={downshift_threshold}. A controller with the "
+                "thresholds inverted would ratchet k DOWN on high accept "
+                "rates — almost certainly a config error."
+            )
+
+        # --- starting-k validation ----------------------------------------
+        if k_start is None:
+            k_start = k_min
+        if isinstance(k_start, bool) or not isinstance(k_start, int):
+            raise TypeError(f"k_start must be int, got {type(k_start).__name__}")
+        if not (k_min <= k_start <= k_max):
+            raise ValueError(
+                f"k_start ({k_start}) must satisfy k_min ({k_min}) "
+                f"<= k_start <= k_max ({k_max})"
+            )
+
+        self._k_min = k_min
+        self._k_max = k_max
+        self._current_k = k_start
+        self._window_size = window
+        self._upshift = upshift_threshold
+        self._downshift = downshift_threshold
+        self._cooldown = cooldown
+
+        # ``deque(maxlen=window)`` is O(1) push + auto-eviction, which
+        # is the cheapest ring buffer Python ships.
+        self._buf: deque[bool] = deque(maxlen=window)
+        # Attempts recorded since the last adjustment/hold decision.
+        # Resets to zero on every re-evaluation (whether we changed
+        # ``k`` or held). This is what enforces the ``cooldown`` gate.
+        self._steps_since_eval = 0
+        self._adjust_count = 0
+        self._lock = threading.Lock()
+
+    # ------------------------------------------------------------------
+    # recording side
+    # ------------------------------------------------------------------
+
+    def record_attempt(self, accepted: bool) -> None:
+        """Record one MTP verify outcome and maybe adjust ``k``.
+
+        Called once per verify backbone pass in
+        :func:`vllm_mlx.spec_decode.mtp.generator.mtp_generate_step`
+        AFTER the accept/reject decision has been made. When the
+        rolling window has enough samples and the cooldown has
+        elapsed, the accept rate is compared against the thresholds
+        and ``k`` is bumped, cut, or held.
+
+        Args:
+            accepted: ``True`` when the verify pass accepted the
+                draft token(s); ``False`` when it rejected. Anything
+                truthy is coerced to ``True`` for defensive symmetry
+                with ``bool()`` in call sites.
+        """
+        accepted_bool = bool(accepted)
+        with self._lock:
+            self._buf.append(accepted_bool)
+            self._steps_since_eval += 1
+
+            # Fast path: not enough attempts since the last decision
+            # OR the window isn't fully populated yet. Waiting for a
+            # full window prevents an "all-accept first 5 samples"
+            # cold start from ratcheting ``k`` all the way up before
+            # steady state kicks in.
+            if self._steps_since_eval < self._cooldown:
+                return
+            if len(self._buf) < self._window_size:
+                return
+
+            rate = sum(1 for a in self._buf if a) / len(self._buf)
+
+            # Every re-evaluation resets the cooldown counter,
+            # whether we adjusted or held — the invariant is
+            # "one decision per cooldown window", not "one
+            # adjustment per cooldown window". Otherwise a
+            # persistently-in-band accept rate would recompute
+            # ``rate`` every single attempt after the first
+            # cooldown, which is wasted work and also a subtle
+            # source of oscillation (the deque contents shift by
+            # one every attempt, and edge cases at the
+            # thresholds could produce alternating decisions).
+            self._steps_since_eval = 0
+
+            if rate >= self._upshift and self._current_k < self._k_max:
+                self._current_k += 1
+                self._adjust_count += 1
+            elif rate <= self._downshift and self._current_k > self._k_min:
+                self._current_k -= 1
+                self._adjust_count += 1
+            # else: hold. No state change beyond the cooldown reset.
+
+    # ------------------------------------------------------------------
+    # read side
+    # ------------------------------------------------------------------
+
+    def current_k(self) -> int:
+        """Return the currently-in-use ``k``.
+
+        Callers reading this from the MTP generator hot loop hold
+        onto the returned value for the next verify pass; the next
+        :meth:`record_attempt` may adjust it, but the reader-side
+        value is used for the in-flight step, not the just-completed
+        one. This is intentional — swapping ``k`` mid-verify would
+        require additional cache bookkeeping that PR-1 does not
+        implement.
+        """
+        with self._lock:
+            return self._current_k
+
+    def snapshot(self) -> dict[str, Any]:
+        """Return a snapshot of controller state for observability.
+
+        Consumed by :mod:`vllm_mlx.routes.metrics` to render the
+        ``rapid_mlx_spec_decode_mtp_current_draft_k`` gauge and by
+        the ``/logs`` debugging surface. The snapshot is causally
+        consistent — all fields are read under a single lock so a
+        concurrent ``record_attempt`` either lands fully before or
+        fully after the snapshot, never mid-tuple.
+
+        Returns:
+            A dict with the following stable keys:
+
+            * ``current_k`` — current draft-``k``.
+            * ``k_min``, ``k_max`` — configured bounds.
+            * ``window_size`` — configured window size.
+            * ``window_fill`` — number of samples currently in the
+              rolling window (``<= window_size``; ramps up during
+              cold start).
+            * ``window_accept_rate`` — accept rate over the current
+              window contents. Returns ``0.0`` when the window is
+              empty (Prometheus convention: no data → 0, not NaN).
+            * ``cooldown_steps`` — configured cooldown.
+            * ``steps_since_eval`` — attempts since the last
+              adjustment/hold decision.
+            * ``adjust_count`` — cumulative number of adjustments
+              (up + down) since the controller was constructed.
+            * ``upshift_threshold``, ``downshift_threshold`` —
+              configured hysteresis band.
+        """
+        with self._lock:
+            n = len(self._buf)
+            accepts = sum(1 for a in self._buf if a)
+            return {
+                "current_k": self._current_k,
+                "k_min": self._k_min,
+                "k_max": self._k_max,
+                "window_size": self._window_size,
+                "window_fill": n,
+                "window_accept_rate": (accepts / n) if n else 0.0,
+                "cooldown_steps": self._cooldown,
+                "steps_since_eval": self._steps_since_eval,
+                "adjust_count": self._adjust_count,
+                "upshift_threshold": self._upshift,
+                "downshift_threshold": self._downshift,
+            }
+
+
+# ---------------------------------------------------------------------------
+# Module-level singleton — installed by CLI when --mtp-draft-k-auto-tune=True.
+# ---------------------------------------------------------------------------
+
+_global_controller: DraftKController | None = None
+_global_controller_lock = threading.Lock()
+
+
+def get_global_controller() -> DraftKController | None:
+    """Return the process-global :class:`DraftKController`, if installed.
+
+    Returns ``None`` when auto-tune has not been enabled (the
+    default). The MTP generator uses this to preserve the static-
+    ``k`` fast path — only an ``is None`` check separates the two
+    modes in the hot loop.
+    """
+    return _global_controller
+
+
+def install_global_controller(controller: DraftKController) -> None:
+    """Install (or replace) the process-global controller.
+
+    Called from ``vllm_mlx/cli.py::serve_command`` at boot when the
+    operator passes ``--mtp-draft-k-auto-tune``. Idempotent: a
+    subsequent install replaces the singleton. The test suite uses
+    the replacement behavior to isolate cases without relying on
+    module-reload tricks.
+
+    Args:
+        controller: A pre-constructed :class:`DraftKController`.
+            Passing the constructed instance rather than raw kwargs
+            keeps the CLI-side validation and error-formatting in
+            one place.
+    """
+    global _global_controller
+    if not isinstance(controller, DraftKController):
+        raise TypeError(
+            f"controller must be a DraftKController, got {type(controller).__name__}"
+        )
+    with _global_controller_lock:
+        _global_controller = controller
+
+
+def clear_global_controller() -> None:
+    """Reset the process-global controller to ``None``.
+
+    Primarily a test hook — production code never uninstalls the
+    controller once boot has completed. Fixtures call this in
+    teardown to isolate cases.
+    """
+    global _global_controller
+    with _global_controller_lock:
+        _global_controller = None

--- a/vllm_mlx/spec_decode/mtp/generator.py
+++ b/vllm_mlx/spec_decode/mtp/generator.py
@@ -53,6 +53,8 @@ from .accept_counter import get_global_counter
 from .cache_patch import patch_arrays_cache_rollback_state
 from .draft_k_controller import (
     DraftKController,
+)
+from .draft_k_controller import (
     get_global_controller as _get_global_draft_k_controller,
 )
 

--- a/vllm_mlx/spec_decode/mtp/generator.py
+++ b/vllm_mlx/spec_decode/mtp/generator.py
@@ -51,6 +51,10 @@ import mlx.core as mx
 # missing-class-attr to a class-default-None.
 from .accept_counter import get_global_counter
 from .cache_patch import patch_arrays_cache_rollback_state
+from .draft_k_controller import (
+    DraftKController,
+    get_global_controller as _get_global_draft_k_controller,
+)
 
 patch_arrays_cache_rollback_state()
 
@@ -184,6 +188,7 @@ def mtp_generate_step(
     xtc_threshold: float = 0.0,
     xtc_special_tokens: list[int] | None = None,
     accept_counter=None,
+    draft_k_controller: DraftKController | None = None,
 ) -> Generator[tuple[int, mx.array, bool], None, None]:
     """Generator that uses the model's native MTP head for spec decode.
 
@@ -222,6 +227,22 @@ def mtp_generate_step(
             :class:`MTPAcceptCounter`. Tests pass a fresh counter to
             isolate measurements; production callers pass ``None``
             and the module-global counter is used.
+        draft_k_controller: Optional runtime auto-tune controller for
+            the number of draft tokens per verify pass (PR-1 of the
+            0.9.11 Gemma-4 MTP roadmap). When ``None`` (the default),
+            the module-global controller is consulted via
+            :func:`~vllm_mlx.spec_decode.mtp.draft_k_controller.get_global_controller`;
+            when that is also ``None`` the generator is in
+            static-``k`` mode and behaves byte-identically to the
+            pre-PR-1 code path. When set, every verify-pass outcome
+            (accept or reject) is recorded on the controller AFTER
+            the accept/reject decision has been made. The controller
+            does NOT change the arithmetic of this generator — the
+            lossless verify/accept contract from PR #990 is
+            preserved verbatim. Reading ``current_k()`` and looping
+            over ``k`` draft tokens per verify pass is a follow-up
+            PR (Gemma-4 sidecar); PR-1 only lands the feedback
+            input.
     """
     from mlx_lm.generate import generation_stream, maybe_quantize_kv_cache
     from mlx_lm.models import cache as _cache_module
@@ -230,6 +251,13 @@ def mtp_generate_step(
     xtc_special_tokens = xtc_special_tokens or []
     if accept_counter is None:
         accept_counter = get_global_counter()
+    # Fall back to the module-global controller when the caller
+    # doesn't pass one. ``get_global_controller()`` returns ``None``
+    # when auto-tune has not been installed at boot — that keeps the
+    # hot loop cost to one ``is None`` check per verify pass, so the
+    # static-``k`` fast path is byte-identical to the pre-PR-1 code.
+    if draft_k_controller is None:
+        draft_k_controller = _get_global_draft_k_controller()
 
     y = prompt.astype(mx.uint32)
     prev_tokens: mx.array | None = None
@@ -468,6 +496,12 @@ def mtp_generate_step(
             if accept:
                 _clear_rollback()
                 accept_counter.record_accept(tokens_saved=1)
+                # PR-1 auto-tune feedback: record the accepted verify
+                # outcome. When the controller is not installed this
+                # branch is skipped entirely, preserving the pre-PR-1
+                # code path byte-for-byte.
+                if draft_k_controller is not None:
+                    draft_k_controller.record_attempt(accepted=True)
                 ntoks += 1
                 yield draft_tok_id, draft_lp, True
                 if ntoks >= max_tokens:
@@ -490,6 +524,12 @@ def mtp_generate_step(
             else:
                 _rollback_draft()
                 accept_counter.record_reject()
+                # PR-1 auto-tune feedback: record the rejected verify
+                # outcome. Same reasoning as the accept branch — the
+                # ``is None`` check keeps the static-``k`` path
+                # unchanged when the controller is not installed.
+                if draft_k_controller is not None:
+                    draft_k_controller.record_attempt(accepted=False)
                 if logits_processors and prev_tokens is not None:
                     prev_tokens = prev_tokens[:-1]  # discard rejected
                 verify_tok_id = verify_pred.item()


### PR DESCRIPTION
## Summary

PR-1 of the 0.9.11 Gemma-4 MTP roadmap. Lands the **universal MTP draft-``k`` auto-tune controller** — a runtime feedback loop that adjusts the number of draft tokens per verify pass based on the rolling accept rate. Uses hysteresis thresholds + a cooldown so a noisy accept rate around the boundary doesn't oscillate ``k`` every attempt. Design is future-proof: PR-2/3 (Gemma-4 sidecar, blocked upstream) will consume ``controller.current_k()`` inside the generator hot loop to actually vary the drafting count; PR-1 only lands the controller + feedback wiring.

**Zero behavioral change when off** — the controller is opt-in via ``--mtp-draft-k-auto-tune`` (default False). When off, the vendored ``mtp_generate_step`` runs byte-identically to the pre-PR-1 code (guarded by an ``is None`` check in the hot loop). Regression test locks this in.

## Design

- **Hysteresis (two thresholds).** ``upshift_threshold`` (default 0.80) is the "one more draft is a win" gate; ``downshift_threshold`` (default 0.40) is the "one fewer draft" gate. Between them → hold. A single-threshold controller would ping-pong ``k = 3 ↔ k = 4`` when the rate hovers right at the boundary.
- **Cooldown (default 128 attempts).** Prevents a lucky streak of accepts right after cold start from ratcheting ``k`` up before steady-state kicks in. Every re-evaluation resets the cooldown counter, whether we adjusted or held.
- **Rolling window (default 64).** Bounded ``deque(maxlen=W)``. Adjustment decisions require a fully-populated window — same cold-start guard as above.
- **Bounds clamped.** ``k`` is clamped to ``[1, k_max]``. Degenerate ``k_min == k_max == 1`` still records attempts (for /metrics) but never adjusts.
- **NaN / inf gate at construction time.** Per gotcha ``pydantic-field-does-not-reject-nan``, ``math.isfinite`` is the explicit guard. Inverted thresholds (``upshift <= downshift``) raise loudly — they would silently ratchet ``k`` down on high accept rates.
- **Pure Python, no MLX imports.** Testable without spawning a server. Thread-safe via one lock (held for O(1) work per call).

## Flag surface

| Flag | Type | Default | Notes |
| ---- | ---- | ------- | ----- |
| ``--mtp-draft-k-auto-tune`` | bool | False | Requires ``--spec-decode mtp`` at boot; boot fails otherwise |
| ``--mtp-draft-k-max`` | int | 4 | Range ``[1, 8]``; ignored when auto-tune is off |
| ``--mtp-draft-k-window`` | int | 64 | Rolling window size (attempts) |
| ``--mtp-draft-k-upshift-threshold`` | float | 0.80 | Must be in ``(0, 1]``; NaN/inf rejected |
| ``--mtp-draft-k-downshift-threshold`` | float | 0.40 | Must be in ``[0, 1)`` and strictly less than upshift |
| ``--mtp-draft-k-cooldown`` | int | 128 | Min attempts between adjustment decisions |

When both ``--mtp-num-draft-tokens`` and ``--mtp-draft-k-auto-tune`` are set, the num-draft-tokens value is used as the STARTING ``k`` (must satisfy ``1 <= start <= k_max``).

## Boot-gate scope (post-review tightening)

The auto-tune gate requires ``--spec-decode mtp`` — NOT ``--enable-mtp``. Rationale: the only ``record_attempt()`` feedback wiring in PR-1 lives inside the vendored ``mtp_generate_step`` (mlx-lm PR #990 path), which only runs under ``--spec-decode mtp``. The legacy ``--enable-mtp`` (Qwen3-Next) path uses ``_install_mtp`` in ``scheduler.py`` which does NOT touch the controller — allowing ``--enable-mtp`` alone would install a controller that never receives feedback (silent no-op). A future PR that wires the controller into ``_install_mtp`` can loosen this.

## Prometheus surface

New gauge ``rapid_mlx_spec_decode_mtp_current_draft_k`` (label set ``{family, method="mtp"}``, joined with existing ``rapid_mlx_spec_decode_*`` counters via ``family``). Emitted **only** when a controller has been installed at boot — a placeholder ``0`` would falsely imply the controller ratcheted ``k`` to zero (which the ``k_min >= 1`` bound makes impossible).

## Test plan

- [x] Ramp-up: all-accepts feed ramps ``k`` up to ``k_max`` at cooldown-spaced boundaries, then holds
- [x] Ramp-down: all-rejects feed ramps ``k`` down to ``k_min``, then holds
- [x] In-band accept rate (0.40 < rate < 0.80) → zero adjustments over 1000 attempts
- [x] No oscillation within the same cooldown window (flip mid-window → no downshift until next eval)
- [x] Constructor rejects NaN / +Inf / -Inf on either threshold
- [x] Constructor rejects inverted thresholds (upshift <= downshift)
- [x] Constructor rejects out-of-range thresholds (upshift ∉ (0, 1], downshift ∉ [0, 1))
- [x] Constructor rejects bad integer bounds (k_min < 1, k_max < k_min, window < 1, cooldown < 1)
- [x] Constructor rejects ``bool`` where ``int`` expected (bool is subclass of int in Python)
- [x] Constructor rejects k_start outside [k_min, k_max]
- [x] Degenerate ``k_min == k_max == 1`` never adjusts, never crashes
- [x] Snapshot returns 11 documented keys
- [x] Module-global controller defaults to ``None`` (static-k fast path)
- [x] ``install_global_controller`` + ``clear_global_controller`` round-trip
- [x] Generator regression: static-k path emits byte-identical tokens with no controller installed
- [x] Metrics gauge absent when controller not installed
- [x] Metrics gauge emits current ``k`` when controller installed
- [x] All six new CLI flags advertised in ``rapid-mlx serve --help``
- [x] All 41 pre-existing MTP tests still pass (no regression)

Test suite: ``pytest tests/test_mtp_draft_k_controller.py tests/test_mtp_spec_decode.py tests/test_mtp_lossless.py`` → 65 passed, 0 failed.

## Bench sanity

**SKIPPED** — deliberate. The bench script ``bench/bench_spec_decode_mtp.py`` compares ``--spec-decode mtp`` against ``--spec-decode none`` and doesn't yet accept a ``--mtp-draft-k-auto-tune`` flag. More fundamentally, **PR-1's controller does not vary the drafting count** — the generator's verify pass still drafts exactly one token per step (the vendored PR #990 chain-MTP behavior). The controller only records feedback; consuming ``current_k()`` in the hot loop is PR-2/3. So a bench comparing auto-tune-on vs auto-tune-off would show numbers indistinguishable from noise. Numbers will land with PR-2 when ``current_k()`` actually changes the drafting count.

## Notes for review

- Version file (``pyproject.toml``) untouched — the 0.9.11 bump is a separate follow-up commit, not part of this PR.
- Vendored ``mtp_generate_step`` verify/accept arithmetic is preserved verbatim; only two ``if draft_k_controller is not None: controller.record_attempt(...)`` calls added inside the existing accept/reject branches.
- ``_SUPPORTED_MODEL_TYPES`` in ``detect.py`` untouched — Gemma 4 MTP is PR-2/3 (upstream sidecar parked).
- Test fixture in the new ``test_mtp_draft_k_controller.py`` mirrors the ``_reset_mtp_module_state`` autouse fixture from ``test_mtp_spec_decode.py`` (resets ``mlx_lm.generate.generation_stream``, unpatches ArraysCache, resets the accept counter) so full-sweep runs don't leak state into the other MTP test files.