### PR TITLE
fix(cli): resolve audio aliases for `pull`/`rm` (#991)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.9.10"
+version = "0.9.11"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/tests/test_pull_audio_alias_resolution.py
+++ b/tests/test_pull_audio_alias_resolution.py
@@ -1,0 +1,137 @@
+# SPDX-License-Identifier: Apache-2.0
+"""#991 — ``rapid-mlx pull <audio-alias>`` must resolve to the concrete HF id.
+
+Regression: the CLI dispatch resolves *text* aliases (``resolve_model`` over
+``aliases.json``) before handing ``args.model`` to ``pull_command`` /
+``rm_command``. Audio aliases live in the separate audio registry and were
+never resolved on that path, so ``rapid-mlx pull whisper`` reached
+``pull_command`` as the literal string ``"whisper"``, missed the R2 mirror
+catalog (keyed by ``hf_path``), and 404'd at HuggingFace — even though
+``serve whisper`` and ``pull mlx-community/whisper-large-v3-mlx`` both work.
+
+``serve`` deliberately keeps the short alias (it resolves audio at request
+time); only ``pull``/``rm`` — which consume ``args.model`` verbatim — need the
+concrete HF id stamped up front. These tests pin both halves of that contract.
+"""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+from vllm_mlx import cli
+from vllm_mlx.cli import _resolve_audio_download_alias
+
+# --- pure helper -----------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "alias,expected",
+    [
+        ("whisper-tiny", "mlx-community/whisper-tiny-mlx"),
+        ("whisper", "mlx-community/whisper-large-v3-mlx"),
+        ("kokoro", "mlx-community/Kokoro-82M-bf16"),
+        ("parakeet", "mlx-community/parakeet-tdt-0.6b-v2"),
+    ],
+)
+def test_helper_resolves_audio_alias_for_pull(alias: str, expected: str) -> None:
+    """``pull`` maps a short audio alias to its registry HF id."""
+    assert _resolve_audio_download_alias("pull", alias) == expected
+
+
+def test_helper_resolves_audio_alias_for_rm() -> None:
+    """``rm`` gets the same resolution (cache is scanned by HF id)."""
+    assert (
+        _resolve_audio_download_alias("rm", "whisper")
+        == "mlx-community/whisper-large-v3-mlx"
+    )
+
+
+@pytest.mark.parametrize("command", ["serve", "chat", "run", "bench", "info", None])
+def test_helper_leaves_short_alias_for_non_download_commands(command) -> None:
+    """Only ``pull``/``rm`` rewrite. ``serve`` (and friends) keep the short
+    alias so their request-time audio resolution still fires."""
+    assert _resolve_audio_download_alias(command, "whisper") is None
+
+
+@pytest.mark.parametrize("model", ["qwen3.6-27b-4bit", "not-a-real-alias-xyz", ""])
+def test_helper_returns_none_for_non_audio(model: str) -> None:
+    """Non-audio names get no rewrite even under ``pull`` — the text/HF path
+    handles them (or fails with its own unknown-model help)."""
+    assert _resolve_audio_download_alias("pull", model) is None
+
+
+# --- end-to-end dispatch (main) --------------------------------------------
+
+
+def _run_main(monkeypatch, argv: list[str]) -> None:
+    """Invoke ``cli.main()`` with a fixed argv and telemetry disabled."""
+    monkeypatch.setenv("RAPID_MLX_TELEMETRY", "0")
+    # Bypass the interactive download-size gate so the dispatch never touches
+    # the network regardless of the runner's TTY state.
+    monkeypatch.setenv("RAPID_MLX_AUTO_PULL", "1")
+    monkeypatch.setattr(sys, "argv", ["rapid-mlx", "--no-telemetry", *argv])
+    cli.main()
+
+
+def test_main_pull_rewrites_audio_alias_to_hf_id(monkeypatch) -> None:
+    """End-to-end: ``rapid-mlx pull whisper-tiny`` reaches ``pull_command``
+    with ``args.model`` rewritten to the HF id and the original alias
+    preserved for the banner / summary."""
+    captured: dict[str, object] = {}
+
+    def _fake_pull(args) -> None:
+        captured["model"] = args.model
+        captured["original"] = getattr(args, "_original_alias", None)
+
+    monkeypatch.setattr(cli, "pull_command", _fake_pull)
+    _run_main(monkeypatch, ["pull", "whisper-tiny"])
+
+    assert captured["model"] == "mlx-community/whisper-tiny-mlx"
+    assert captured["original"] == "whisper-tiny"
+
+
+def test_main_rm_rewrites_audio_alias_to_hf_id(monkeypatch) -> None:
+    """``rapid-mlx rm whisper`` reaches ``rm_command`` with the HF id so the
+    cache scan (``models--<owner>--<repo>``) can actually match."""
+    captured: dict[str, object] = {}
+
+    def _fake_rm(args) -> None:
+        captured["model"] = args.model
+
+    monkeypatch.setattr(cli, "rm_command", _fake_rm)
+    _run_main(monkeypatch, ["rm", "whisper"])
+
+    assert captured["model"] == "mlx-community/whisper-large-v3-mlx"
+
+
+def test_main_serve_keeps_short_audio_alias(monkeypatch) -> None:
+    """``rapid-mlx serve whisper`` must NOT be rewritten at dispatch — serve
+    resolves audio at request time and relies on the short alias."""
+    captured: dict[str, object] = {}
+
+    def _fake_serve(args) -> None:
+        captured["model"] = args.model
+        captured["original"] = getattr(args, "_original_alias", None)
+
+    monkeypatch.setattr(cli, "serve_command", _fake_serve)
+    _run_main(monkeypatch, ["serve", "whisper"])
+
+    assert captured["model"] == "whisper"
+    # No alias banner was stamped, so the download-path original is unset.
+    assert captured["original"] is None
+
+
+def test_main_pull_full_hf_path_unchanged(monkeypatch) -> None:
+    """A full HF path for an audio repo passes straight through — the mirror
+    catalog is keyed by ``hf_path``, so no rewrite is needed or wanted."""
+    captured: dict[str, object] = {}
+
+    def _fake_pull(args) -> None:
+        captured["model"] = args.model
+
+    monkeypatch.setattr(cli, "pull_command", _fake_pull)
+    _run_main(monkeypatch, ["pull", "mlx-community/whisper-tiny-mlx"])
+
+    assert captured["model"] == "mlx-community/whisper-tiny-mlx"

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -618,6 +618,36 @@ def _resolve_audio_model_for_serve(model_name: str):
     return resolve_audio_alias(model_name)
 
 
+def _resolve_audio_download_alias(command: str | None, model: str) -> str | None:
+    """Resolve a short audio alias to its concrete HF id for ``pull``/``rm``.
+
+    #991: the CLI's alias resolver (``resolve_model``) only knows *text*
+    aliases (``aliases.json``); audio aliases live in the separate audio
+    registry and resolve via :func:`resolve_audio_alias`. ``serve`` keeps
+    the short alias and resolves it at request time (see
+    :func:`_resolve_audio_model_for_serve` and the route-level
+    ``TTS_MODEL_ALIASES`` / ``STT_MODEL_ALIASES`` lookup), but ``pull`` and
+    ``rm`` consume ``args.model`` verbatim with no request-time path:
+
+      * ``pull`` — the R2 mirror catalog is keyed by ``hf_path``, so a bare
+        alias misses the mirror and then 404s at HF
+        (``snapshot_download("whisper")``).
+      * ``rm`` — the HF cache is scanned by ``models--<owner>--<repo>``,
+        which a bare alias can never match.
+
+    Returns the resolved HF id when ``command`` is ``pull``/``rm`` AND
+    ``model`` is a known audio alias; otherwise ``None`` — no rewrite, so
+    ``serve``/``chat``/``bench`` keep the short alias and non-audio names
+    fall through to the text path unchanged.
+    """
+    if command not in {"pull", "rm"}:
+        return None
+    from .audio.registry import resolve_audio_alias
+
+    entry = resolve_audio_alias(model)
+    return entry.hf_id if entry is not None else None
+
+
 def _serve_audio_mode(args, entry) -> None:
     """Bind the audio-only serve path for a resolved registry entry.
 
@@ -7379,6 +7409,20 @@ Examples:
                     args.model, full_path_example="mlx-community/Qwen3.5-9B-4bit"
                 )
                 sys.exit(1)
+            else:
+                # #991: it IS an audio alias. ``serve`` keeps the short
+                # alias for request-time resolution, but ``pull``/``rm``
+                # consume ``args.model`` directly and would miss the R2
+                # mirror (catalog keyed by ``hf_path``) then 404 at HF.
+                # Stamp the concrete HF id up front for those two commands
+                # only, mirroring the text-alias banner above.
+                _audio_hf_id = _resolve_audio_download_alias(
+                    getattr(args, "command", None), args.model
+                )
+                if _audio_hf_id is not None:
+                    print(f"  Alias: {args.model} → {_audio_hf_id}")
+                    args._original_alias = args.model
+                    args.model = _audio_hf_id
         # Round 16 codex catch: record the resolved (or already-canonical)
         # model so ``session_end`` can report what this invocation loaded.
         # ``normalize_model_path`` inside the emit helper redacts local


### PR DESCRIPTION
## Summary

Fixes #991. `rapid-mlx pull <audio-alias>` (`whisper`, `kokoro`, `parakeet`, …) failed with "not found on HuggingFace", even though `serve <audio-alias>` and `pull mlx-community/whisper-large-v3-mlx` both work.

**Root cause.** The CLI dispatch resolves only *text* aliases (`resolve_model` over `aliases.json`) before handing `args.model` to `pull_command`/`rm_command`. Audio aliases live in the separate audio registry (`resolve_audio_alias`) and were never resolved on that path — the `is_audio_model_alias` branch only *skipped the fail-fast* (so `serve` could resolve at request time), leaving `args.model` as the bare string. `pull_command` then missed the R2 mirror catalog (keyed by `hf_path`) and fell through to `snapshot_download("whisper")`, which 404s.

## Fix

- New pure helper `_resolve_audio_download_alias(command, model)`: for `pull`/`rm` **only**, map a known audio alias to its registry HF id via `resolve_audio_alias`; return `None` otherwise.
- Wired into the dispatch audio branch — stamps `args._original_alias` + prints the `Alias: X → Y` banner, mirroring text-alias resolution.
- `serve`/`chat`/`bench` keep the short alias (serve resolves audio at request time — unchanged). Non-audio names and full HF paths fall through untouched.

Why `rm` too: it scans the HF cache by `models--<owner>--<repo>`, which a bare alias can never match.

## Verification

End-to-end against the live R2 mirror (working-tree code):

```
$ rapid-mlx pull whisper-tiny
  Alias: whisper-tiny → mlx-community/whisper-tiny-mlx
  Pulling mlx-community/whisper-tiny-mlx (R2 mirror, fallback: HF)
  [4/4] weights.npz R2 (74 MB)
  Pulled 4 files, 74 MB (R2: 3, HF: 1) in 1s (70 MB/s)
```

## Tests

`tests/test_pull_audio_alias_resolution.py` (18 cases):
- Helper: `pull`/`rm` audio alias → HF id; `serve`/`chat`/`run`/`bench`/`info`/None → no rewrite; non-audio → no rewrite.
- End-to-end `main()` dispatch: `pull whisper-tiny` + `rm whisper` reach the command with `args.model` rewritten to the HF id (`_original_alias` preserved); `serve whisper` keeps the short alias; full HF path passes through unchanged.

`18 passed`; related suites (`test_audio_boot_check`, `test_mirror_pull`, `test_pull_summary`, `test_audio_alias_registry`) `199 passed`, no regressions. ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)