### PR TITLE
fix(scheduler): trim prompt cache by 1 on exact-hit to prevent duplicate KV entry

### DIFF
--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -4201,8 +4201,47 @@ class Scheduler:
                 request.remaining_tokens is not None
                 and len(request.remaining_tokens) == 0
             ):
-                # Exact cache match - pass only last token for generation kickoff
+                # Exact cache match — pass only the last token for
+                # generation kickoff. The saved cache captured state at
+                # offset=N (all N prompt tokens processed).
+                # ``PromptProcessingBatch.generate([last_token])`` then
+                # calls ``GenerationBatch.__init__(inputs=last_token)``
+                # which invokes ``_step()``. That step forwards the last
+                # token through the model with ``cache=prompt_cache``,
+                # writing K/V at position N and advancing offset to N+1.
+                # The result: the last prompt token appears at TWO cache
+                # positions (N-1 from the saved cache, N from the re-fed
+                # step), the sampling query is emitted at position N+1
+                # (with a shifted RoPE), and the softmax denominator
+                # includes an extra spurious K/V. That drifts the first
+                # output token vs. the fresh-prefill baseline (which
+                # samples at position N with cache offset=N-1 → N).
+                #
+                # Fix: trim the cache offset by 1 before the batch
+                # generator picks it up. The last prompt token's K/V is
+                # discarded from cache; ``_step()``'s forward then
+                # overwrites position N-1 in-place, ending at offset=N.
+                # Position and softmax denominator now match the fresh
+                # path exactly, restoring byte-equal output between a
+                # cold prompt and a warm-cache repeat.
                 tokens_to_process = request.prompt_token_ids[-1:]
+                if request.prompt_cache is not None:
+                    try:
+                        from mlx_lm.models.cache import (
+                            can_trim_prompt_cache,
+                            trim_prompt_cache,
+                        )
+
+                        if can_trim_prompt_cache(request.prompt_cache):
+                            trim_prompt_cache(request.prompt_cache, 1)
+                    except Exception as _trim_exc:  # noqa: BLE001
+                        logger.debug(
+                            "[cache_fetch] exact-hit trim(1) failed for "
+                            "request=%s: %s (continuing without trim; "
+                            "output may drift from fresh baseline)",
+                            request.request_id[:12],
+                            _trim_exc,
+                        )
             elif request.remaining_tokens:
                 tokens_to_process = request.remaining_tokens
             else:


### PR DESCRIPTION
## Summary
Fixes a cross-cutting non-determinism bug in the scheduler's prefix-cache exact-hit path. Same prompt at `temperature=0` currently produces different output on first (cache MISS) vs subsequent (cache HIT) requests. This affects both MTP and plain decode paths — any user of rapid-mlx with prefix cache enabled (the default) is impacted.

## Root cause
`_prompt_cache_save` at `vllm_mlx/scheduler.py:2793` snapshots the KV cache at `end_of_prompt=True` (offset = N tokens). On exact reload, `scheduler.py:4519` passes `prompt_token_ids[-1:]` to `PromptProcessingBatch.generate`, which runs `_step()` on that last token against the loaded cache. That `_step()` writes K/V for the last prompt token AGAIN at position N, produces offset N+1 with wrong RoPE and a spurious duplicate K/V slot in the softmax denominator, and drifts the first sampled token.

## Fix
Trim the loaded cache by 1 before the batch generator consumes it, so `_step()` overwrites position N-1 in place instead of appending a duplicate at position N. Guarded on `can_trim_prompt_cache(cache)` for cache types that don't support trim.

## Reproduction (before fix)
Same prompt at temp=0, plain decode + prefix cache:
- run 1 (MISS): sha `90f98c87`
- run 2 (HIT):  sha `6102d39b`  ← should equal run 1
- run 3 (HIT):  sha `6102d39b`

After fix, all 3 runs produce sha `90f98c87` (the cold-baseline output).

## Discovery
Row 14 non-determinism during Gemma 4 MTP investigation. MTP made the bug visible; plain decode also reproduces it. Investigation notes preserved in memory under `knowledge/gotchas.md`.

## Test plan
- pr_validate full unit suite: PASS
- Manual: same prompt × 5 at temp=0 with prefix cache enabled → all 5 SHA identical
- Manual: same prompt × 5 with `--disable-prefix-cache` → all 5 identical (regression check on the non-cache path)

Post-merge follow-ups (not gating): consider adding a scheduler-level regression test that asserts determinism across cache MISS/HIT for a canned prompt; investigate whether `_prompt_cache_save` should snapshot at offset N-1 in the first place to avoid the trim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)