### PR TITLE
fix(mtp): address codex round-16 blocking findings (post-merge follow-up on PR #990)

### DIFF
--- a/tests/test_mtp_gemma4_assistant_inject.py
+++ b/tests/test_mtp_gemma4_assistant_inject.py
@@ -1079,6 +1079,52 @@ def test_inject_refuses_when_target_tail_layer_types_mismatch(tmp_path):
     assert ok is False, "layer_types-tail mismatch must fail closed"
 
 
+def test_inject_refuses_when_target_layer_types_shorter_than_assistant(tmp_path):
+    """Codex round-16 blocking-fix locked in.
+
+    When the target publishes ``layer_types`` but the list is shorter
+    than the assistant's, the previous revision fell through the guard
+    and ``_shared_kv_target_indices`` was later built from an invalid
+    tail mapping (or the positional fallback with negative indices via
+    Python's wrap-around). That crashes inside ``mtp_forward`` at
+    ``target_cache[idx]`` or feeds the drafter K/V from a wrong-type
+    target layer. Inject must refuse closed before wiring the drafter.
+    """
+    from mlx.utils import tree_flatten
+
+    from vllm_mlx.spec_decode.mtp.gemma4_inject import (
+        _build_assistant_model,
+        _build_assistant_model_args,
+        inject_mtp_support,
+    )
+
+    cfg = _google_shaped_assistant_config(hidden=64, backbone=128, n_layers=4)
+    args = _build_assistant_model_args(cfg, target_backbone_hidden=128)
+    model_template = _build_assistant_model(args, backbone_hidden_size=128)
+    mx.eval(model_template.parameters())
+    flat = dict(tree_flatten(model_template.parameters()))
+
+    sidecar_dir = tmp_path / "short-target-types-assistant"
+    sidecar_dir.mkdir(parents=True, exist_ok=True)
+    (sidecar_dir / "config.json").write_text(json.dumps(cfg))
+    mx.save_safetensors(str(sidecar_dir / "model.safetensors"), flat)
+
+    try:
+        target = _build_tiny_gemma4_target_model()
+    except (TypeError, AttributeError) as exc:
+        pytest.skip(f"Gemma 4 ModelArgs schema mismatch: {exc}")
+
+    # Publish only 2 layer_types on the target — shorter than the
+    # assistant's 4. Guard must fire before building the shared_kv
+    # mapping.
+    target.args.layer_types = ["sliding_attention", "full_attention"]
+
+    ok = inject_mtp_support(target, mtp_sidecar=str(sidecar_dir))
+    assert ok is False, (
+        "target layer_types shorter than assistant layer count must fail closed"
+    )
+
+
 def test_find_safetensors_refuses_multi_file_even_with_model_safetensors(tmp_path):
     """Codex round-10 nit-fix locked in.
 

--- a/vllm_mlx/spec_decode/mtp/gemma4_inject.py
+++ b/vllm_mlx/spec_decode/mtp/gemma4_inject.py
@@ -604,11 +604,25 @@ def inject_mtp_support(
         assistant_layer_types = list(getattr(args, "layer_types", []) or [])
         target_layer_types = list(getattr(inner.args, "layer_types", []) or [])
         n_assistant = len(assistant_layer_types)
-        if (
-            assistant_layer_types
-            and target_layer_types
-            and len(target_layer_types) >= n_assistant
-        ):
+        if assistant_layer_types and target_layer_types:
+            # Codex round-16 blocking fix: when the target publishes
+            # ``layer_types`` but the list is shorter than the
+            # assistant's, the earlier revision fell through and
+            # ``_shared_kv_target_indices`` ended up sourced from an
+            # invalid tail mapping (or the positional fallback with
+            # negative indices via Python's wrap-around). That crashes
+            # inside ``mtp_forward`` at ``target_cache[idx]`` or feeds
+            # the drafter K/V from a wrong-type target layer. Refuse
+            # closed here before we ever wire up the drafter.
+            if len(target_layer_types) < n_assistant:
+                logger.warning(
+                    "[mtp.inject.gemma4] target published only %d layer_types "
+                    "but the assistant has %d drafter layers; the tail mapping "
+                    "cannot be resolved. Refusing to inject.",
+                    len(target_layer_types),
+                    n_assistant,
+                )
+                return False
             target_tail = target_layer_types[-n_assistant:]
             if target_tail != assistant_layer_types:
                 logger.warning(
@@ -986,12 +1000,23 @@ def inject_mtp_support(
                 )
 
             n_positions = int(hidden_states.shape[1])
-            base_offset = int(shared_kv_slots[-1].offset)
 
-            # Cache the per-layer shared K/V once (they don't vary
-            # per position — the target's cache is shared across all
-            # drafter queries in this call).
+            # Cache the per-layer shared K/V AND the per-layer target
+            # cache offset once (neither varies per position — the
+            # target's cache is shared across all drafter queries in
+            # this call). Codex round-16 blocking fix: keep a
+            # per-layer offset instead of collapsing to
+            # ``shared_kv_slots[-1].offset``. Under rotating / sliding
+            # cache behavior the sliding target cache slots can carry
+            # a DIFFERENT offset (position within the rotated buffer)
+            # than the full-attention slot at the tail — using the
+            # tail's offset for a sliding layer's RoPE rotates the
+            # drafter's Q with an offset that doesn't match the
+            # sliding K/V it reads. Preserve per-slot offsets so each
+            # drafter layer's Q rotation matches the target-layer
+            # cache it consumes.
             layer_states: list[tuple] = []
+            layer_offsets: list[int] = []
             for tgt_cache in shared_kv_slots:
                 try:
                     state = tgt_cache.state
@@ -1010,6 +1035,7 @@ def inject_mtp_support(
                     keys = state
                     values = state
                 layer_states.append((keys, values))
+                layer_offsets.append(int(tgt_cache.offset))
 
             # Embed via TARGET's tokenizer table — matches
             # pre_projection's backbone_hidden input dim. Root-cause
@@ -1040,14 +1066,21 @@ def inject_mtp_support(
                 )  # (B, 1, 2 * backbone_hidden)
                 h_pos_proj = self.mtp.pre_projection(fused_pos)  # (B, 1, hidden_size)
 
-                # Per-position RoPE offset: base - (N - 1) + pos.
-                row_offset_int = base_offset - n_positions + 1 + pos
-                if row_offset_int < 0:
-                    row_offset_int = 0
-                row_offset = _mx.array(row_offset_int)
-
+                # Per-position, per-layer RoPE offset: for row ``pos`` in
+                # a call with N positions, layer i's Q is rotated with
+                # ``layer_offsets[i] - (N - 1) + pos``. Codex round-16
+                # blocking fix: derive from each shared cache slot's
+                # OWN offset rather than the last slot's, so sliding
+                # layers don't inherit the full-attention layer's
+                # position under rotating cache behavior.
                 h_layer = h_pos_proj
-                for layer, (keys, values) in zip(self.mtp.model.layers, layer_states):
+                for layer, (keys, values), tgt_offset in zip(
+                    self.mtp.model.layers, layer_states, layer_offsets
+                ):
+                    row_offset_int = tgt_offset - n_positions + 1 + pos
+                    if row_offset_int < 0:
+                        row_offset_int = 0
+                    row_offset = _mx.array(row_offset_int)
                     h_layer, _shared, _off = layer(
                         h_layer,
                         mask=None,


### PR DESCRIPTION
## Summary

Follow-up to #990 (merged as ``aa1762e4`` in 0.9.11). Two BLOCKING findings from codex adversarial review landed AFTER the merge and need to ship in 0.9.12.

## Root cause 1 — short target ``layer_types`` slips past guard

``inject_mtp_support`` verified target's tail ``layer_types`` against the assistant's only when ``len(target_layer_types) >= n_assistant``. If a target published a shorter list, the guard fell through and ``_shared_kv_target_indices`` was later built from an invalid tail mapping (or the positional fallback with negative indices via Python wrap-around). Crashes inside ``mtp_forward`` at ``target_cache[idx]`` or feeds the drafter K/V from a wrong-type target layer.

**Fix:** explicitly refuse when ``len(target_layer_types) < n_assistant`` before wiring the drafter.

## Root cause 2 — sliding drafter layers inherit full-attention offset

``mtp_forward`` snapped ``base_offset = int(shared_kv_slots[-1].offset)`` — the last shared slot's offset — and used it for every drafter layer's RoPE. Under rotating / sliding cache behavior sliding target-cache slots carry a different offset than the full-attention tail slot, so sliding drafter layers rotate their Q with an offset that doesn't match the K/V they read.

**Fix:** snapshot ``layer_offsets: list[int]`` alongside the shared K/V, then use each layer's own ``layer_offsets[i] - (N - 1) + pos`` inside the per-position drafter loop.

## Verification

- ``tests/test_mtp_gemma4_assistant_inject.py::test_inject_refuses_when_target_layer_types_shorter_than_assistant`` locks the new guard.
- All 33 unit tests in the assistant-inject file pass locally.
- Ruff clean.

Per-slot offset behavior is covered by the existing shape/forward tests + the 12B smoke bench downstream. No test added for the offset fix here because the existing suite already exercises the layer-offset code path structurally; the fix is a correctness change under sliding-cache behavior that a unit-level target fake cannot reliably reproduce without also porting the sliding-cache rotation logic.

## Impact assessment

Both bugs are behind additional gates in 0.9.11's real-world hot path — real Gemma 4 12B has 42 target layers vs the assistant's 4, so ``len(target_layer_types) >= n_assistant`` always holds under a well-formed config. The sliding-offset issue only surfaces once the sliding cache rotates (long context, > sliding_window tokens). 0.9.11 users on short-context 12B are unaffected in practice.

## Test plan

- [x] 33/33 assistant-inject tests pass locally in 0.92 s
- [x] Ruff format + check clean
- [x] Cherry-picked from PR #990 branch; no other file touched