### PR TITLE
chore: bump version to 0.9.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.9.11"
+version = "0.9.12"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## Summary
Bumps version to 0.9.12. Triggers auto-release + PyPI + Homebrew publish.

## Contents (already merged to main)
- **#997** — revert of prematurely-merged #990 (pre-codex Gemma 4 MTP consumer with 2 blocking correctness findings)
- **#998** — feat(mtp): Gemma 4 assistant drafter inject — polished re-apply with round-16 fixes baked in, codex CLEAN via CLI pr_validate 2 rounds

## Correctness delta since 0.9.11
- inject_mtp_support: reject populated mtp_cache (offset != 0); reject negative row_offset (caller must prefill target first)
- mtp_forward: use per-slot layer_offsets[] (fixes Gemma 4 MTP rotating-cache long-context > 1024 tokens sliding-window)
- Defensive guard: reject when len(target_layer_types) < n_assistant

## v0.9.11 status
v0.9.11 shipped to PyPI + Homebrew with the pre-revert code containing the above bugs. 0.9.12 supersedes. Recommend post-release consideration of yanking 0.9.11 from PyPI.

## Test plan
- pr_validate PASS (codex CLEAN via CLI — PATH=/opt/homebrew/bin:\$PATH exported to reach codex CLI)
- auto-release.yml dispatches on merge → v0.9.12 tag + PyPI + Homebrew tap dispatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)