### PR TITLE
fix(mcp): sync initialized manager into ServerConfig and add /v1/mcp/status alias

### DIFF
--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1187,6 +1187,65 @@ class TestMCPRoutes:
             assert r.status_code == 200
             assert r.json()["servers"] == []
 
+    def _make_server_status(self):
+        server_status = MagicMock()
+        server_status.name = "test_server"
+        server_status.state.value = "connected"
+        server_status.transport.value = "stdio"
+        server_status.tools_count = 3
+        server_status.error = None
+        return server_status
+
+    def test_status_alias_parity_no_mcp(self):
+        """/v1/mcp/status returns the same JSON as /v1/mcp/servers."""
+        with (
+            patch.object(get_config(), "mcp_manager", None),
+            patch.object(get_config(), "api_key", None),
+        ):
+            app = self._make_app()
+            client = TestClient(app)
+            servers_resp = client.get("/v1/mcp/servers")
+            status_resp = client.get("/v1/mcp/status")
+            assert servers_resp.status_code == status_resp.status_code == 200
+            assert servers_resp.json() == status_resp.json()
+
+    def test_status_alias_parity_with_mcp(self):
+        """/v1/mcp/status mirrors /v1/mcp/servers when MCP is configured."""
+        mcp = MagicMock()
+        mcp.get_server_status.return_value = [self._make_server_status()]
+
+        with (
+            patch.object(get_config(), "mcp_manager", mcp),
+            patch.object(get_config(), "api_key", None),
+        ):
+            app = self._make_app()
+            client = TestClient(app)
+            servers_resp = client.get("/v1/mcp/servers")
+            status_resp = client.get("/v1/mcp/status")
+            assert servers_resp.status_code == status_resp.status_code == 200
+            assert servers_resp.json() == status_resp.json()
+            data = status_resp.json()
+            assert data["servers"][0]["name"] == "test_server"
+            assert data["servers"][0]["tools_count"] == 3
+
+    def test_status_alias_auth_parity(self):
+        """/v1/mcp/status and /v1/mcp/servers share the same auth dependency."""
+        with (
+            patch.object(get_config(), "mcp_manager", None),
+            patch.object(get_config(), "api_key", "secret-key"),
+        ):
+            app = self._make_app()
+            client = TestClient(app)
+            servers_resp = client.get("/v1/mcp/servers")
+            status_resp = client.get("/v1/mcp/status")
+            assert servers_resp.status_code == status_resp.status_code == 401
+
+            headers = {"Authorization": "Bearer secret-key"}
+            servers_resp = client.get("/v1/mcp/servers", headers=headers)
+            status_resp = client.get("/v1/mcp/status", headers=headers)
+            assert servers_resp.status_code == status_resp.status_code == 200
+            assert servers_resp.json() == status_resp.json()
+
     def test_execute_no_mcp(self):
         """Execute tool returns 503 when MCP not configured."""
         with (

--- a/tests/test_server_load_model_order.py
+++ b/tests/test_server_load_model_order.py
@@ -198,3 +198,65 @@ def test_sync_config_is_idempotent(monkeypatch):
 
     for k, v in snapshot.items():
         assert getattr(cfg2, k) == v, f"_sync_config() not idempotent on cfg.{k}"
+
+
+def test_sync_config_propagates_mcp_manager(monkeypatch):
+    """After init_mcp() sets the global _mcp_manager, _sync_config() must
+    copy it into cfg so MCP routes read a live manager instead of None.
+
+    Regression for #986: load_model() stamped cfg.mcp_manager = None before
+    lifespan init_mcp() ran, and no later _sync_config() updated it.
+    """
+    from unittest.mock import MagicMock
+
+    from vllm_mlx import server
+    from vllm_mlx.config import get_config
+
+    monkeypatch.setattr(server, "_mcp_manager", None, raising=False)
+    monkeypatch.setattr(server, "_mcp_executor", None, raising=False)
+
+    server._sync_config()
+    assert get_config().mcp_manager is None
+
+    mock_manager = MagicMock()
+    mock_executor = MagicMock()
+    monkeypatch.setattr(server, "_mcp_manager", mock_manager, raising=False)
+    monkeypatch.setattr(server, "_mcp_executor", mock_executor, raising=False)
+
+    server._sync_config()
+    cfg = get_config()
+    assert cfg.mcp_manager is mock_manager
+    assert cfg.mcp_executor is mock_executor
+
+
+def test_sync_config_preserves_unrelated_config_on_mcp_update(monkeypatch):
+    """Updating MCP globals and re-syncing must not clobber unrelated cfg.
+
+    Regression for the fix to #986: the post-init_mcp _sync_config() runs
+    late in startup; if it overwrote fields that were intentionally set
+    earlier, it would introduce ordering bugs.
+    """
+    from unittest.mock import MagicMock
+
+    from vllm_mlx import server
+    from vllm_mlx.config import get_config
+
+    monkeypatch.setattr(server, "_model_name", "model-a", raising=False)
+    monkeypatch.setattr(server, "_tool_call_parser", "hermes", raising=False)
+    monkeypatch.setattr(server, "_mcp_manager", None, raising=False)
+    monkeypatch.setattr(server, "_mcp_executor", None, raising=False)
+
+    server._sync_config()
+    cfg_before = get_config()
+    assert cfg_before.model_name == "model-a"
+    assert cfg_before.tool_call_parser == "hermes"
+    assert cfg_before.mcp_manager is None
+
+    mock_manager = MagicMock()
+    monkeypatch.setattr(server, "_mcp_manager", mock_manager, raising=False)
+
+    server._sync_config()
+    cfg_after = get_config()
+    assert cfg_after.mcp_manager is mock_manager
+    assert cfg_after.model_name == "model-a"
+    assert cfg_after.tool_call_parser == "hermes"

--- a/tests/test_server_load_model_order.py
+++ b/tests/test_server_load_model_order.py
@@ -260,3 +260,38 @@ def test_sync_config_preserves_unrelated_config_on_mcp_update(monkeypatch):
     assert cfg_after.mcp_manager is mock_manager
     assert cfg_after.model_name == "model-a"
     assert cfg_after.tool_call_parser == "hermes"
+
+
+async def test_init_mcp_syncs_config_into_cfg(monkeypatch):
+    """init_mcp() must publish the initialized manager/executor to cfg.
+
+    Regression for #986: this guards against deleting the `_sync_config()`
+    call inside init_mcp() and re-introducing the stale cfg bug.
+    """
+    from unittest.mock import AsyncMock, MagicMock
+
+    import vllm_mlx.mcp as mcp_module
+    from vllm_mlx import server
+    from vllm_mlx.config import get_config
+
+    mock_manager = MagicMock()
+    mock_manager.start = AsyncMock()
+    mock_manager.get_all_tools.return_value = []
+    mock_executor = MagicMock()
+
+    mock_config = MagicMock()
+    mock_config.allowed_high_risk_tools = []
+
+    monkeypatch.setattr(mcp_module, "load_mcp_config", lambda _path: mock_config)
+    monkeypatch.setattr(mcp_module, "MCPClientManager", lambda _cfg: mock_manager)
+    monkeypatch.setattr(mcp_module, "ToolExecutor", lambda _mgr: mock_executor)
+    monkeypatch.setattr(mcp_module, "set_sandbox", MagicMock())
+
+    monkeypatch.setattr(server, "_mcp_manager", None, raising=False)
+    monkeypatch.setattr(server, "_mcp_executor", None, raising=False)
+
+    await server.init_mcp("/tmp/fake-mcp.json")
+
+    cfg = get_config()
+    assert cfg.mcp_manager is mock_manager
+    assert cfg.mcp_executor is mock_executor

--- a/tests/test_server_load_model_order.py
+++ b/tests/test_server_load_model_order.py
@@ -212,6 +212,10 @@ def test_sync_config_propagates_mcp_manager(monkeypatch):
     from vllm_mlx import server
     from vllm_mlx.config import get_config
 
+    cfg = get_config()
+    monkeypatch.setattr(cfg, "mcp_manager", None, raising=False)
+    monkeypatch.setattr(cfg, "mcp_executor", None, raising=False)
+
     monkeypatch.setattr(server, "_mcp_manager", None, raising=False)
     monkeypatch.setattr(server, "_mcp_executor", None, raising=False)
 
@@ -240,6 +244,10 @@ def test_sync_config_preserves_unrelated_config_on_mcp_update(monkeypatch):
 
     from vllm_mlx import server
     from vllm_mlx.config import get_config
+
+    cfg = get_config()
+    monkeypatch.setattr(cfg, "mcp_manager", None, raising=False)
+    monkeypatch.setattr(cfg, "mcp_executor", None, raising=False)
 
     monkeypatch.setattr(server, "_model_name", "model-a", raising=False)
     monkeypatch.setattr(server, "_tool_call_parser", "hermes", raising=False)
@@ -273,6 +281,10 @@ async def test_init_mcp_syncs_config_into_cfg(monkeypatch):
     import vllm_mlx.mcp as mcp_module
     from vllm_mlx import server
     from vllm_mlx.config import get_config
+
+    cfg = get_config()
+    monkeypatch.setattr(cfg, "mcp_manager", None, raising=False)
+    monkeypatch.setattr(cfg, "mcp_executor", None, raising=False)
 
     mock_manager = MagicMock()
     mock_manager.start = AsyncMock()

--- a/vllm_mlx/routes/mcp_routes.py
+++ b/vllm_mlx/routes/mcp_routes.py
@@ -62,6 +62,16 @@ async def list_mcp_servers() -> MCPServersResponse:
     return MCPServersResponse(servers=servers)
 
 
+@router.get("/v1/mcp/status", dependencies=[Depends(verify_api_key)])
+async def get_mcp_status() -> MCPServersResponse:
+    """Backward-compatible alias for ``/v1/mcp/servers``.
+
+    The MCP tools guide documents ``/v1/mcp/status`` as the status endpoint,
+    so this route prevents 404s for users following the docs.
+    """
+    return await list_mcp_servers()
+
+
 @router.post("/v1/mcp/execute", dependencies=[Depends(verify_api_key)])
 async def execute_mcp_tool(request: MCPExecuteRequest) -> MCPExecuteResponse:
     """Execute an MCP tool."""

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -1555,6 +1555,11 @@ async def init_mcp(config_path: str):
 
         logger.info(f"MCP initialized with {len(_mcp_manager.get_all_tools())} tools")
 
+        # Sync the newly-created manager/executor into the ServerConfig
+        # singleton so MCP routes see them. Keeping this inside init_mcp()
+        # means every code path that initializes MCP also publishes it to cfg.
+        _sync_config()
+
     except ImportError:
         logger.error("MCP SDK not installed. Install with: pip install mcp")
         raise


### PR DESCRIPTION
## Summary
Fixes #986.

- Sync `_mcp_manager` / `_mcp_executor` into `ServerConfig` inside `init_mcp()` so MCP routes see the live manager after lifespan startup.
- Add `/v1/mcp/status` as a backward-compatible alias for `/v1/mcp/servers`.
- Add regression tests covering config propagation, preservation of unrelated config fields, and parity between the two status endpoints.

## Test plan
- `pytest tests/test_routes.py::TestMCPRoutes tests/test_server_load_model_order.py -q` (14 passed)
- Manually verified with `rapid-mlx serve --mcp-config examples/mcp.example.json`: `/v1/mcp/tools`, `/v1/mcp/servers`, and `/v1/mcp/status` all return the expected data.