### PR TITLE
fix(deps): cap transformers<5.13 (mlx-lm string-registration → gemma-4 crash)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,17 @@ dependencies = [
     "mlx>=0.31.2",
     "mlx-lm>=0.31.3",  # 0.31.1+ required for presence_penalty/frequency_penalty kwargs on make_logits_processors (#512); 0.31.3 added thread-local generation_stream but cross-thread eval is still broken (see shim sites).
     # mlx-vlm is opt-in via [vision] extras (saves ~322 MB for text-only users)
-    "transformers>=5.0.0",  # mlx-lm 0.30.5+ requires transformers 5.0 (rc3 bug fixed in stable)
+    #
+    # Upper cap <5.13 (release-blocker): mlx-lm and mlx-vlm both float
+    # transformers with no upper bound, but transformers 5.13.0 tightened
+    # ``AutoTokenizer.register`` to dereference ``key.__module__`` while mlx-lm
+    # still registers tokenizers by *string* class name (mlx_lm/
+    # tokenizer_utils.py) — so under 5.13 ``import mlx_vlm`` (and every gemma-4
+    # / DiffusionGemma launch) raises ``AttributeError: 'str' object has no
+    # attribute '__module__'``. 5.5.0-5.12.x import cleanly (a fresh resolve
+    # currently lands 5.12.1). Drop the cap once mlx-lm registers real
+    # tokenizer classes. Mirrors the rapid-desktop sidecar pin (PR #498).
+    "transformers>=5.0.0,<5.13",  # floor: mlx-lm 0.30.5+ requires transformers 5.0 (rc3 bug fixed in stable)
     "tokenizers>=0.19.0",
     "huggingface-hub>=0.23.0",
     "numpy>=1.24.0",


### PR DESCRIPTION
## Why

A fresh `pip install rapid-mlx==0.9.12` currently crashes every gemma-4 / DiffusionGemma launch, **because** `mlx-lm` and `mlx-vlm` declare `transformers` with **no upper bound** and the resolver pulls **5.13.0**. transformers 5.13.0 tightened `AutoTokenizer.register` to dereference `key.__module__`, but `mlx-lm` still registers tokenizers by **string** class name (`mlx_lm/tokenizer_utils.py`), so `import mlx_vlm` raises:

```
AttributeError: 'str' object has no attribute '__module__'
```

Bisected empirically (rapid-desktop PR #498): **5.5.0–5.12.x import cleanly; only 5.13.0+ breaks.** Capping at the engine root is the smallest change that closes the hole for all fresh installs — the alternative (waiting for an mlx-lm fix) leaves every PyPI user's gemma-4 broken in the meantime.

## Fix

Cap the base `transformers` dependency: `>=5.0.0` → `>=5.0.0,<5.13`.

- Floor unchanged (`>=5.0.0`) — `mlx-lm` 0.30.5+ needs 5.0; the `[vision]` extra's `mlx-vlm` 0.6.3 still enforces its own `>=5.5.0`, so the effective vision floor stays 5.5.0.
- Base dep is always installed, so `<5.13` intersects every extra — protects text-only **and** `[vision]` installs with a single ceiling.
- A fresh resolve now lands **5.12.1** (unchanged from the currently-working env).
- Temporary: drop the cap once `mlx-lm` registers real tokenizer classes.

Mirrors the already-shipped rapid-desktop sidecar pin (`build-sidecar.sh`, PR #498) at the engine root, so fresh PyPI installs get the same protection.

## Not a version bump

`skip-version-bump` label applied — the pin rides the next release (a 0.9.13 cut takes it to PyPI users).

## Validation

- `pyproject.toml` parses; specifier accepts 5.4.0/5.5.0/5.12.1, rejects 5.13.0/5.14.0.
- Only one `transformers` declaration in the project (base deps); no other uncapped occurrence in `pyproject.toml`.
- Correctness of the 5.5.0–5.12.x-clean / 5.13-broken range is the empirical result from PR #498's scratch-venv bisect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)