### PR TITLE
Revert "fix(deps): cap transformers<5.13" (#1002) — re-land via full pr_validate SOP

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,17 +44,7 @@ dependencies = [
     "mlx>=0.31.2",
     "mlx-lm>=0.31.3",  # 0.31.1+ required for presence_penalty/frequency_penalty kwargs on make_logits_processors (#512); 0.31.3 added thread-local generation_stream but cross-thread eval is still broken (see shim sites).
     # mlx-vlm is opt-in via [vision] extras (saves ~322 MB for text-only users)
-    #
-    # Upper cap <5.13 (release-blocker): mlx-lm and mlx-vlm both float
-    # transformers with no upper bound, but transformers 5.13.0 tightened
-    # ``AutoTokenizer.register`` to dereference ``key.__module__`` while mlx-lm
-    # still registers tokenizers by *string* class name (mlx_lm/
-    # tokenizer_utils.py) — so under 5.13 ``import mlx_vlm`` (and every gemma-4
-    # / DiffusionGemma launch) raises ``AttributeError: 'str' object has no
-    # attribute '__module__'``. 5.5.0-5.12.x import cleanly (a fresh resolve
-    # currently lands 5.12.1). Drop the cap once mlx-lm registers real
-    # tokenizer classes. Mirrors the rapid-desktop sidecar pin (PR #498).
-    "transformers>=5.0.0,<5.13",  # floor: mlx-lm 0.30.5+ requires transformers 5.0 (rc3 bug fixed in stable)
+    "transformers>=5.0.0",  # mlx-lm 0.30.5+ requires transformers 5.0 (rc3 bug fixed in stable)
     "tokenizers>=0.19.0",
     "huggingface-hub>=0.23.0",
     "numpy>=1.24.0",


### PR DESCRIPTION
## Why

Reverts #1002 (`a58ba52b`). The pin itself is correct and codex-approved, but it was merged relying on the **CI** `validate` job alone — the local `scripts/pr_validate` + gate run was **not** executed per the maintainer's PR-merge SOP. Reverting so the identical change can be re-landed through the full SOP (local `python -m scripts.pr_validate`, tests, lint, codex to convergence) with the scorecard captured before merge.

No behavior change from this revert — it restores `transformers>=5.0.0` (uncapped) on `main`; the re-land PR immediately reapplies `>=5.0.0,<5.13`.

`skip-version-bump` applied (pyproject-only, rides the next release).