### PR TITLE
fix(deps): cap transformers<5.13 (re-land of #1002 via full pr_validate SOP)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,18 @@ dependencies = [
     "mlx>=0.31.2",
     "mlx-lm>=0.31.3",  # 0.31.1+ required for presence_penalty/frequency_penalty kwargs on make_logits_processors (#512); 0.31.3 added thread-local generation_stream but cross-thread eval is still broken (see shim sites).
     # mlx-vlm is opt-in via [vision] extras (saves ~322 MB for text-only users)
-    "transformers>=5.0.0",  # mlx-lm 0.30.5+ requires transformers 5.0 (rc3 bug fixed in stable)
+    #
+    # Upper cap <5.13 (release-blocker): mlx-lm and mlx-vlm both float
+    # transformers with no upper bound, but transformers 5.13.0 tightened
+    # ``AutoTokenizer.register`` to dereference ``key.__module__`` while mlx-lm
+    # still registers tokenizers by *string* class name (mlx_lm/
+    # tokenizer_utils.py:505) — so under 5.13 even a bare ``import mlx_lm``
+    # (and therefore every serve / gemma-4 / DiffusionGemma launch) raises
+    # ``AttributeError: 'str' object has no attribute '__module__'`` at import
+    # time. 5.5.0-5.12.x import cleanly (a fresh resolve currently lands
+    # 5.12.1). Drop the cap once mlx-lm registers real tokenizer classes.
+    # Mirrors the rapid-desktop sidecar pin (PR #498).
+    "transformers>=5.0.0,<5.13",  # floor: mlx-lm 0.30.5+ requires transformers 5.0 (rc3 bug fixed in stable)
     "tokenizers>=0.19.0",
     "huggingface-hub>=0.23.0",
     "numpy>=1.24.0",


### PR DESCRIPTION
## Why

A fresh `pip install rapid-mlx` crashes on **`import mlx_lm`** itself, **because** mlx-lm / mlx-vlm leave `transformers` uncapped and the resolver pulls **5.13.0**, which tightened `AutoTokenizer.register` to deref `key.__module__` while mlx-lm registers tokenizers by **string** class name (`mlx_lm/tokenizer_utils.py:505`):

```
AttributeError: 'str' object has no attribute '__module__'
```

This breaks every `serve` / gemma-4 / DiffusionGemma launch on a fresh install.

**Empirical proof (this cycle):** reverting the cap in #1003 turned `test-apple-silicon` **red** with exactly this error at pytest collection (5 files) once the runner freshly resolved transformers 5.13. So the cap is provably necessary — CI is green **with** it, red **without**.

## Fix

Cap the base `transformers` dependency: `>=5.0.0` → `>=5.0.0,<5.13` (floor unchanged; `[vision]`'s mlx-vlm still enforces its own `>=5.5.0`; single base cap intersects every extra). Fresh resolve lands **5.12.1**. Temporary — drop once mlx-lm registers real tokenizer classes. Mirrors the shipped rapid-desktop sidecar pin (`build-sidecar.sh`, PR #498).

## Process

This is a re-land of #1002. That PR passed the CI `validate` (pr_validate) job but was not run through **local** pr_validate per the maintainer SOP, so it was reverted (#1003) and re-landed here after `python -m scripts.pr_validate` was run locally (scorecard in the PR thread). `skip-version-bump` applied — rides the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)