### PR TITLE
[codex] add experimental ddtree support

### DIFF
--- a/README.md
+++ b/README.md
@@ -723,6 +723,7 @@ Qwen3.5 uses Gated DeltaNet (75% RNN) + full attention (25% KV). Other engines r
 | **TurboQuant K8V4 codec** | K 8-bit + V 4-bit after Walsh-Hadamard + Lloyd-Max (~1/2.4 compression, lossless across verified matrix) | Default-on for 9 verified Qwen3.5/3.6 aliases; `--kv-cache-turboquant k8v4\|v4\|none` |
 | **KV cache quantization** | Quantize prefix cache entries to reduce memory | All models with `--kv-cache-quantization` |
 | **DFlash speculative decoding** | Block-diffusion drafter, parallel draft + verify (single-user) | `qwen3.5-27b-8bit`, `qwen3.6-27b-8bit` with `--enable-dflash` |
+| **DDTree speculative decoding** | DFlash draft-tree verification over multiple branches | `qwen3.5-9b-8bit` (experimental, single-user) |
 | **MTP speculative decoding** | Multi-token prediction head shipped with the model | MTP-trained checkpoints with `--enable-mtp` |
 | **SuffixDecoding** | Drafter-free, statistical n-gram lookup speculative decoding | All BatchedEngine models with `--suffix-decoding` |
 | **Prefill chunking** | Configurable step size for large-prompt throughput | All models |
@@ -763,14 +764,14 @@ Run your own: `bash evals/run_all_models.sh` runs the full quality suite (tool c
 | **TurboQuant K8V4 KV codec** | K is 8-bit + V is 4-bit after Walsh-Hadamard rotation + Lloyd-Max quantization — compresses KV to ~1/2.4 (~58% savings), lossless across the verified matrix. **Default-on for 9 verified Qwen3.5/3.6 aliases** (see below); `--kv-cache-turboquant none` to force off. |
 | **Smart cloud routing** | Large-context requests auto-route to a cloud LLM (`--cloud-model openai/gpt-5 --cloud-threshold 20000`) when local prefill would be slow. |
 | **Multimodal** | Vision, audio (STT/TTS with bundled Silero VAD silence pre-trim), video understanding, text embeddings — all through the standard OpenAI endpoints. |
-| **Speculative decoding** | DFlash (block-diffusion drafter, `--enable-dflash`), MTP (multi-token prediction head, `--enable-mtp`), SuffixDecoding (drafter-free n-gram, `--suffix-decoding`). Opt-in per alias — see below. |
+| **Speculative decoding** | DFlash (block-diffusion drafter, `--enable-dflash`), DDTree (DFlash draft tree, `--enable-ddtree`), MTP (multi-token prediction head, `--enable-mtp`), SuffixDecoding (drafter-free n-gram, `--suffix-decoding`). Opt-in per alias — see below. |
 | **Structured output, logprobs, continuous batching, KV quantization** | Standard, no flags or with one flag each. |
 | **3300+ tests** | Across reasoning, tool parsing, streaming, agent harnesses, and engine integration. |
 
 **K8V4 default-on aliases** (9 as of 0.9.9): `qwen3.5-9b-4bit`, `qwen3.5-9b-8bit`, `qwen3.5-27b-4bit`, `qwen3.5-27b-8bit`, `qwen3.5-35b-6bit`, `qwen3.6-35b-4bit`, `qwen3.6-35b-6bit`, `qwen3.6-35b-8bit`, `qwen3.6-35b-dwq`. Radix prefix cache is independent and saves additional bytes proportional to inter-request prefix overlap — the two are orthogonal.
 
 <details>
-<summary><strong>Speculative decoding — DFlash, MTP, SuffixDecoding</strong></summary>
+<summary><strong>Speculative decoding — DFlash, DDTree, MTP, SuffixDecoding</strong></summary>
 
 Three drafters ship in-tree. All are **opt-in** per alias — `rapid-mlx info <alias>` shows what's eligible on the model you're serving.
 
@@ -792,6 +793,16 @@ Workload sensitivity: coding / math / summarization typically see **1.5–2.7×*
 **MTP** (Multi-Token Prediction) — draft head baked into the model. Opt in with `--enable-mtp` on MTP-trained checkpoints. Auto-tune of `--mtp-num-draft-tokens` per workload is roadmapped for the 0.9.1x line.
 
 **SuffixDecoding** — drafter-free, statistical n-gram lookup over the running suffix. Opt in with `--suffix-decoding`; works on any BatchedEngine alias.
+
+**DDTree** (experimental) — builds a tree from one DFlash draft pass, then verifies multiple likely continuations. The first rapid-mlx integration is intentionally opt-in and single-user, using the external `dtree-mlx` runtime:
+
+```bash
+pip install 'dtree-mlx @ git+https://github.com/DrHB/dtree-mlx.git'
+rapid-mlx info qwen3.5-9b-8bit
+rapid-mlx serve qwen3.5-9b-8bit --enable-ddtree
+```
+
+MVP limitations mirror DFlash mode: no continuous batching, tools, MCP, embeddings, logprobs, or structured output. The alias records the experimental draft model candidate and defaults (`z-lab/Qwen3.5-9B-DFlash`, 16 speculative tokens, tree budget 24), but DDTree never turns on unless `--enable-ddtree` is passed.
 
 Mutex: DFlash cannot combine with MTP or SuffixDecoding (single-user path). MTP and SuffixDecoding cannot combine with each other (both consume the drafter slot).
 
@@ -831,6 +842,7 @@ Mutex: DFlash cannot combine with MTP or SuffixDecoding (single-user path). MTP 
 | `--prefix-cache-index` | Prefix-cache lookup index: `radix` (default) or `hash` | `radix` |
 | `--pflash` | PFlash sparse prefill: `auto` / `always` / `off` | `auto` (on for verified aliases) |
 | `--enable-dflash` | DFlash speculative decoding (single-user; `qwen3.5-27b-8bit` / `qwen3.6-27b-8bit`) | off |
+| `--enable-ddtree` | Experimental DDTree speculative decoding (single-user; `qwen3.5-9b-8bit`) | off |
 | `--suffix-decoding` | Drafter-free n-gram speculative decoding (BatchedEngine path) | off |
 | `--enable-mtp` | MTP head speculative decoding (requires MTP-trained model) | off |
 | `--gpu-memory-utilization` | Fraction of device memory to use (0.0-1.0) | `0.90` |
@@ -1034,6 +1046,7 @@ harness/                 # Regression baselines + thresholds
 | Technique | Expected Gain | Status |
 |-----------|---------------|--------|
 | [DFlash](https://arxiv.org/abs/2602.06036) — block-diffusion drafter, single-user | 1.3–2× decode (workload-dependent) | Shipping, opt-in (`--enable-dflash`, `[dflash]` extra; qwen3.5-27b-8bit, qwen3.6-27b-8bit) |
+| [DDTree](https://arxiv.org/abs/2604.12989) — DFlash draft-tree verification, single-user | TBD on rapid-mlx 9B gate | Experimental (`--enable-ddtree`) |
 | [SuffixDecoding](https://arxiv.org/abs/2411.04975) — drafter-free n-gram speculative | 1.1–1.5× decode | Shipping (`--suffix-decoding`, per-model tier sweep ongoing) |
 | MTP — Multi-Token Prediction head | 1.4–1.7× decode | Shipping, opt-in (`--enable-mtp`, MTP-trained checkpoints); per-workload auto-tune of `--mtp-num-draft-tokens` landing in the 0.9.1x line |
 | [EAGLE-3](https://arxiv.org/abs/2503.01840) — feature-level draft on Metal | 3–6.5× decode | Not started |

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -89,6 +89,9 @@ rapid-mlx serve devstral-24b-4bit --enable-auto-tool-choice --tool-call-parser h
 # DFlash speculative decoding (single-user, single supported alias)
 rapid-mlx serve qwen3.5-27b-8bit --enable-dflash --port 8000
 
+# DDTree speculative decoding (experimental, single-user)
+rapid-mlx serve qwen3.5-9b-8bit --enable-ddtree --port 8000
+
 # API key authentication
 rapid-mlx serve qwen3.5-9b-4bit --api-key your-secret-key
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.9.12"
+version = "0.9.13"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/tests/test_aliases_contract.py
+++ b/tests/test_aliases_contract.py
@@ -59,6 +59,10 @@ ALLOWED_PROFILE_KEYS: frozenset[str] = frozenset(
         "suffix_bench_speedup",
         "supports_dflash",
         "dflash_draft_model",
+        "supports_ddtree",
+        "ddtree_draft_model",
+        "ddtree_speculative_tokens",
+        "ddtree_tree_budget",
         "recommended_sampling",
         "pflash_tier",
         "turboquant_tier",
@@ -508,6 +512,75 @@ def test_negative_control_dflash_missing_drafter_is_caught() -> None:
         _coerce(
             "fake-alias",
             {"hf_path": "fake/Model", "supports_dflash": True},
+        )
+
+
+# =============================================================================
+# DDTree speculative-decoding contract (issue #879)
+# =============================================================================
+
+
+@pytest.mark.parametrize("alias", _alias_ids())
+def test_ddtree_requires_drafter_and_params(alias: str) -> None:
+    profile = list_profiles()[alias]
+    if profile.supports_ddtree:
+        assert profile.ddtree_draft_model, (
+            f"{alias}: supports_ddtree=True but ddtree_draft_model is empty"
+        )
+        assert "/" in profile.ddtree_draft_model, (
+            f"{alias}: ddtree_draft_model={profile.ddtree_draft_model!r} "
+            f"must be 'org/repo' format"
+        )
+        assert profile.ddtree_speculative_tokens is not None, (
+            f"{alias}: supports_ddtree=True but ddtree_speculative_tokens is empty"
+        )
+        assert profile.ddtree_tree_budget is not None, (
+            f"{alias}: supports_ddtree=True but ddtree_tree_budget is empty"
+        )
+
+
+@pytest.mark.parametrize("alias", _alias_ids())
+def test_ddtree_excludes_moe_architectures(alias: str) -> None:
+    profile = list_profiles()[alias]
+    if profile.is_moe:
+        assert not profile.supports_ddtree, (
+            f"{alias}: is_moe=True but supports_ddtree=True — DDTree verifier "
+            "support is not validated on MoE aliases."
+        )
+
+
+@pytest.mark.parametrize("alias", _alias_ids())
+def test_ddtree_excludes_4bit_precision_until_benched(alias: str) -> None:
+    profile = list_profiles()[alias]
+    if not profile.supports_ddtree:
+        return
+    hf_lc = profile.hf_path.lower()
+    is_4bit = "-4bit" in hf_lc or "mxfp4" in hf_lc or "nvfp4" in hf_lc
+    assert not is_4bit, (
+        f"{alias}: supports_ddtree=True but hf_path={profile.hf_path!r} "
+        "looks like a 4-bit quantized variant. Bench and update the gate "
+        "before enabling DDTree on 4-bit."
+    )
+
+
+def test_ddtree_eligible_aliases_have_dflash_drafter() -> None:
+    for alias, profile in list_profiles().items():
+        if not profile.supports_ddtree:
+            continue
+        d = profile.ddtree_draft_model or ""
+        assert d.startswith("z-lab/") and re.search(r"(?:^|-)DFlash(?:$|-)", d), (
+            f"{alias}: ddtree_draft_model={d!r} must point at a z-lab "
+            "DFlash drafter unless the DDTree runtime contract changes."
+        )
+
+
+def test_negative_control_ddtree_missing_drafter_is_caught() -> None:
+    from vllm_mlx.model_aliases import _coerce
+
+    with pytest.raises(ValueError, match="ddtree_draft_model"):
+        _coerce(
+            "fake-alias",
+            {"hf_path": "fake/Model", "supports_ddtree": True},
         )
 
 

--- a/tests/test_ddtree_eligibility.py
+++ b/tests/test_ddtree_eligibility.py
@@ -1,0 +1,94 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for ``vllm_mlx/speculative/ddtree/eligibility.py``."""
+
+from __future__ import annotations
+
+import pytest
+
+from vllm_mlx.model_aliases import AliasProfile
+from vllm_mlx.speculative.ddtree.eligibility import (
+    DDTreeUnavailable,
+    check,
+    report,
+)
+
+
+def _good_profile() -> AliasProfile:
+    return AliasProfile(
+        hf_path="mlx-community/Qwen3.5-9B-8bit",
+        is_moe=False,
+        supports_ddtree=True,
+        ddtree_draft_model="z-lab/Qwen3.5-9B-DFlash",
+        ddtree_speculative_tokens=16,
+        ddtree_tree_budget=24,
+    )
+
+
+def test_check_passes_for_good_profile() -> None:
+    p = _good_profile()
+    check(p, alias="qwen3.5-9b-8bit")
+    assert report(p, alias="qwen3.5-9b-8bit").reasons == ()
+
+
+def test_check_rejects_alias_without_supports_ddtree() -> None:
+    p = AliasProfile(hf_path="mlx-community/Qwen3.5-9B-8bit")
+    with pytest.raises(DDTreeUnavailable, match="not DDTree-enabled"):
+        check(p, alias="qwen3.5-9b-8bit")
+
+
+def test_check_rejects_moe_alias() -> None:
+    p = AliasProfile(
+        hf_path="mlx-community/Qwen3.6-35B-A3B-8bit",
+        is_moe=True,
+        supports_ddtree=True,
+        ddtree_draft_model="z-lab/Qwen3.6-35B-A3B-DFlash",
+        ddtree_speculative_tokens=16,
+        ddtree_tree_budget=24,
+    )
+    with pytest.raises(DDTreeUnavailable, match="MoE"):
+        check(p, alias="qwen3.6-35b-8bit")
+
+
+def test_check_rejects_4bit_main_model() -> None:
+    p = AliasProfile(
+        hf_path="mlx-community/Qwen3.5-9B-4bit",
+        supports_ddtree=True,
+        ddtree_draft_model="z-lab/Qwen3.5-9B-DFlash",
+        ddtree_speculative_tokens=16,
+        ddtree_tree_budget=24,
+    )
+    with pytest.raises(DDTreeUnavailable, match="4-bit"):
+        check(p, alias="qwen3.5-9b-4bit")
+
+
+def test_report_collects_all_failures() -> None:
+    bad = AliasProfile(
+        hf_path="mlx-community/Qwen3.6-35B-A3B-4bit",
+        is_moe=True,
+        supports_ddtree=True,
+    )
+    r = report(bad, alias="qwen3.6-35b-4bit")
+    joined = " ".join(r.reasons)
+    assert "MoE" in joined
+    assert "4-bit" in joined
+    assert "ddtree_draft_model" in joined
+    assert "ddtree_speculative_tokens" in joined
+    assert "ddtree_tree_budget" in joined
+
+
+def test_qwen3_5_9b_8bit_alias_passes_check() -> None:
+    from vllm_mlx.model_aliases import resolve_profile
+
+    profile = resolve_profile("qwen3.5-9b-8bit")
+    assert profile is not None, "qwen3.5-9b-8bit alias missing"
+    check(profile, alias="qwen3.5-9b-8bit")
+
+
+def test_qwen3_5_9b_4bit_alias_fails_with_4bit_reason() -> None:
+    from vllm_mlx.model_aliases import resolve_profile
+
+    profile = resolve_profile("qwen3.5-9b-4bit")
+    assert profile is not None
+    with pytest.raises(DDTreeUnavailable) as excinfo:
+        check(profile, alias="qwen3.5-9b-4bit")
+    assert "4-bit" in str(excinfo.value)

--- a/tests/test_ddtree_integration.py
+++ b/tests/test_ddtree_integration.py
@@ -1,0 +1,183 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Integration-style tests for the DDTree MVP plumbing."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from unittest.mock import MagicMock
+
+
+def test_serve_parser_exposes_enable_ddtree() -> None:
+    import subprocess
+    import sys
+
+    out = subprocess.run(
+        [sys.executable, "-m", "vllm_mlx.cli", "serve", "--help"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert out.returncode == 0, out.stderr
+    assert "--enable-ddtree" in out.stdout
+    assert "dtree-mlx" in out.stdout
+
+
+def test_info_renders_ddtree_block_for_eligible_alias(capsys, monkeypatch) -> None:
+    from vllm_mlx.cli import info_command
+
+    monkeypatch.setattr(
+        "vllm_mlx.speculative.ddtree.eligibility.have_runtime",
+        lambda: True,
+    )
+    args = type("Args", (), {"model": "qwen3.5-9b-8bit"})()
+    info_command(args)
+    captured = capsys.readouterr()
+    assert "DDTree eligibility" in captured.out
+    assert "Declared support" in captured.out
+    assert "z-lab/Qwen3.5-9B-DFlash" in captured.out
+    assert "Spec tokens" in captured.out
+    assert "Tree budget" in captured.out
+    assert "rapid-mlx serve qwen3.5-9b-8bit --enable-ddtree" in captured.out
+
+
+def test_info_ddtree_marks_4bit_alias_ineligible(capsys) -> None:
+    from vllm_mlx.cli import info_command
+
+    args = type("Args", (), {"model": "qwen3.5-9b-4bit"})()
+    info_command(args)
+    captured = capsys.readouterr()
+    assert "DDTree eligibility" in captured.out
+    assert "ineligible" in captured.out
+    assert "4-bit" in captured.out
+
+
+def test_models_listing_renders_ddtree_column(capsys) -> None:
+    from vllm_mlx.cli import models_command
+
+    models_command(None)
+    captured = capsys.readouterr()
+    assert "DDTree" in captured.out
+    lines = captured.out.splitlines()
+    eligible_row = next(
+        (line for line in lines if "qwen3.5-9b-8bit " in line),
+        None,
+    )
+    assert eligible_row is not None
+    assert "✓" in eligible_row, f"DDTree column should be ✓: {eligible_row!r}"
+    ineligible_row = next(
+        (line for line in lines if "qwen3.5-9b-4bit " in line),
+        None,
+    )
+    assert ineligible_row is not None
+    assert "—" in ineligible_row, f"DDTree column should be —: {ineligible_row!r}"
+
+
+@dataclass
+class _FakeResult:
+    text: str = "four"
+    generated_tokens: list[int] | None = None
+    metrics: dict | None = None
+
+    def __post_init__(self) -> None:
+        if self.generated_tokens is None:
+            self.generated_tokens = [1, 2]
+        if self.metrics is None:
+            self.metrics = {"num_input_tokens": 5}
+
+
+def _fake_runtime():
+    from vllm_mlx.speculative.ddtree.runtime import DDTreeRuntime
+
+    tokenizer = MagicMock()
+    tokenizer.apply_chat_template.return_value = "user: 2+2?\nassistant:"
+    target = MagicMock()
+    target.tokenizer = tokenizer
+    generator = MagicMock()
+    generator.target = target
+    generator.generate.return_value = _FakeResult()
+    return DDTreeRuntime(
+        generator=generator,
+        main_model_repo="mlx-community/Qwen3.5-9B-8bit",
+        drafter_repo="z-lab/Qwen3.5-9B-DFlash",
+        speculative_tokens=16,
+        tree_budget=24,
+    )
+
+
+def test_build_app_healthz_models_and_completion() -> None:
+    from fastapi.testclient import TestClient
+
+    from vllm_mlx.speculative.ddtree.server import _build_app
+
+    runtime = _fake_runtime()
+    app = _build_app(
+        runtime=runtime,
+        served_model_name="qwen3.5-9b-8bit",
+        default_max_tokens=64,
+        cors_origins=["*"],
+    )
+    client = TestClient(app)
+
+    r = client.get("/healthz")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["engine"] == "ddtree"
+    assert body["drafter"] == "z-lab/Qwen3.5-9B-DFlash"
+    assert body["tree_budget"] == 24
+
+    r = client.get("/v1/models")
+    assert r.status_code == 200
+    assert r.json()["data"][0]["id"] == "qwen3.5-9b-8bit"
+
+    r = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "qwen3.5-9b-8bit",
+            "messages": [{"role": "user", "content": "2+2?"}],
+            "max_tokens": 16,
+            "temperature": 0,
+        },
+    )
+    assert r.status_code == 200
+    payload = r.json()
+    assert payload["choices"][0]["message"]["content"] == "four"
+    assert payload["usage"]["prompt_tokens"] == 5
+    assert payload["usage"]["completion_tokens"] == 2
+
+
+def test_chat_completions_rejects_unsupported_ddtree_params() -> None:
+    from fastapi.testclient import TestClient
+
+    from vllm_mlx.speculative.ddtree.server import _build_app
+
+    app = _build_app(
+        runtime=_fake_runtime(),
+        served_model_name="qwen3.5-9b-8bit",
+        default_max_tokens=64,
+        cors_origins=["*"],
+    )
+    client = TestClient(app)
+
+    r = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "qwen3.5-9b-8bit",
+            "messages": [{"role": "user", "content": "hi"}],
+            "tools": [
+                {"type": "function", "function": {"name": "x", "parameters": {}}}
+            ],
+        },
+    )
+    assert r.status_code == 400
+    assert "tool calling" in r.json()["error"]["message"].lower()
+
+    r = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "qwen3.5-9b-8bit",
+            "messages": [{"role": "user", "content": "hi"}],
+            "top_p": 0.9,
+        },
+    )
+    assert r.status_code == 400
+    assert "top_p" in r.json()["error"]["message"]

--- a/tests/test_no_mllm_flag.py
+++ b/tests/test_no_mllm_flag.py
@@ -166,6 +166,7 @@ NON_ROUTING_FLAGS_ALLOWLIST: frozenset[str] = frozenset(
         # decode (registered pair); these just enable the implementation.
         "--enable-mtp",
         "--enable-dflash",
+        "--enable-ddtree",
         # Task #292: ``--enable-audio`` is a route-mounting UX knob, not a
         # binary auto-detection. The audio-mode boot path auto-mounts
         # ``/v1/audio/*`` from the registry hit; this flag is the
@@ -2552,6 +2553,22 @@ def test_dflash_branch_rejects_no_spec_decode():
     assert no_spec_idx < dflash_idx, (
         "no_spec_decode mutex check must come BEFORE run_dflash_server() "
         "call so the override actually rejects DFlash startup."
+    )
+
+
+def test_ddtree_branch_rejects_no_spec_decode():
+    """--enable-ddtree + --no-spec-decode must be a mutex error."""
+    source = (_pkg_root() / "cli.py").read_text()
+    no_spec_idx = source.find("--enable-ddtree and --no-spec-decode")
+    ddtree_idx = source.find("run_ddtree_server(")
+    assert no_spec_idx != -1, (
+        "cli.py must reference no_spec_decode in the DDTree branch — "
+        "DDTree is a spec-decode path and must honor --no-spec-decode."
+    )
+    assert ddtree_idx != -1
+    assert no_spec_idx < ddtree_idx, (
+        "no_spec_decode mutex check must come BEFORE run_ddtree_server() "
+        "call so the override actually rejects DDTree startup."
     )
 
 

--- a/tests/test_no_out_of_band_routing.py
+++ b/tests/test_no_out_of_band_routing.py
@@ -1233,6 +1233,7 @@ def test_alias_profile_str_fields_are_explicitly_listed():
             "reasoning_parser",  # parser key, see PARSER_REGISTRY
             "suffix_decoding_tier",  # one of VALID_SUFFIX_TIERS — non-routing data
             "dflash_draft_model",  # HF path for the spec-decode drafter
+            "ddtree_draft_model",  # HF path for the DDTree/DFlash drafter
             # Deprecated v0.7.2 PR #555 in-house diffusion loop knob,
             # kept for one release window so programmatic readers don't
             # AttributeError; not consumed by any code path. Removed in

--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -46,6 +46,10 @@
     "is_moe": false,
     "supports_spec_decode": false,
     "supports_dflash": false,
+    "supports_ddtree": true,
+    "ddtree_draft_model": "z-lab/Qwen3.5-9B-DFlash",
+    "ddtree_speculative_tokens": 16,
+    "ddtree_tree_budget": 24,
     "pflash_tier": "verified",
     "turboquant_tier": "k8v4_verified"
   },

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -1463,6 +1463,67 @@ def _build_benchmark_context(target_tokens: int) -> str:
     return (block * repeats).strip()
 
 
+def _preflight_ddtree_or_exit(args):
+    """Validate DDTree flag/alias/runtime gates and cache the profile."""
+    import sys
+
+    if getattr(args, "enable_dflash", False) or (
+        getattr(args, "spec_decode", "none") == "dflash"
+    ):
+        print(
+            "\n  Error: --enable-ddtree cannot combine with --enable-dflash "
+            "or --spec-decode dflash. Pick one block-diffusion "
+            "speculative-decoding server.\n"
+        )
+        sys.exit(1)
+    if getattr(args, "suffix_decoding", False) or getattr(args, "enable_mtp", False):
+        print(
+            "\n  Error: --enable-ddtree cannot combine with --suffix-decoding "
+            "or --enable-mtp. DDTree runs a dedicated single-user server "
+            "that bypasses BatchedEngine; other spec-decode methods only "
+            "apply to the BatchedEngine path.\n"
+        )
+        sys.exit(1)
+    if getattr(args, "no_spec_decode", False):
+        print(
+            "error: --enable-ddtree and --no-spec-decode are mutually "
+            "exclusive — DDTree is a speculative-decode mode.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+    from .model_aliases import resolve_profile
+    from .speculative.ddtree import DDTreeUnavailable, check
+    from .speculative.ddtree.eligibility import have_runtime
+
+    alias_name = getattr(args, "_original_alias", None) or args.model
+    profile = resolve_profile(alias_name)
+    if profile is None:
+        print(
+            f"\n  Error: --enable-ddtree requires a known alias, got "
+            f"{alias_name!r}. DDTree eligibility is recorded per-alias "
+            f"in aliases.json; ad-hoc HuggingFace paths can't be "
+            f"validated. Try ``rapid-mlx info qwen3.5-9b-8bit``.\n"
+        )
+        sys.exit(1)
+    try:
+        check(profile, alias=alias_name)
+    except DDTreeUnavailable as e:
+        print(f"\n  Error: {e}\n")
+        sys.exit(1)
+    if not have_runtime():
+        print(
+            "\n  Error: --enable-ddtree requires the experimental dtree-mlx "
+            "runtime. Install with: ``pip install 'dtree-mlx @ "
+            "git+https://github.com/DrHB/dtree-mlx.git'``.\n"
+        )
+        sys.exit(1)
+
+    args._ddtree_alias_name = alias_name
+    args._ddtree_profile = profile
+    return alias_name, profile
+
+
 def serve_command(args):
     """Start the OpenAI-compatible server."""
     import logging
@@ -1549,6 +1610,15 @@ def serve_command(args):
 
     if is_audio_model_alias(getattr(args, "model", None)):
         require_audio_or_exit(args.model)
+
+    # DDTree has an external experimental runtime and its validated target
+    # can be multi-GB. Fail the cheap flag/alias/runtime gates before the
+    # version prompt and before any model prefetch so a missing dtree-mlx
+    # install doesn't start a large download first. This runs before the
+    # DFlash runtime probe so --enable-ddtree + --enable-dflash surfaces
+    # the mutual-exclusion error instead of an optional-dependency hint.
+    if getattr(args, "enable_ddtree", False):
+        _preflight_ddtree_or_exit(args)
 
     # 0.9.2 dogfood (parallels the [embeddings]/[vision]/[audio] guards
     # immediately above): ``--enable-dflash`` and the equivalent
@@ -2031,10 +2101,11 @@ def serve_command(args):
             file=sys.stderr,
         )
 
-    # DFlash mutual-exclusion gate fires BEFORE the startup banner so
+    # DFlash / DDTree mutual-exclusion gates fire BEFORE the startup banner so
     # the user sees a clean error instead of an optimistic "Features:
-    # dflash" line immediately followed by an exit. The deeper SchedulerConfig
-    # mutex (suffix vs. mtp) stays below since it doesn't involve DFlash.
+    # dflash" / "ddtree" line immediately followed by an exit. The deeper
+    # SchedulerConfig mutex (suffix vs. mtp) stays below since it doesn't
+    # involve the dedicated single-user servers.
     if args.enable_dflash and (args.suffix_decoding or args.enable_mtp):
         print(
             "\n  Error: --enable-dflash cannot combine with --suffix-decoding "
@@ -2114,6 +2185,38 @@ def serve_command(args):
                 "\n    --enable-dflash if you need them.\n"
             )
 
+    # DDTree eligibility gate mirrors DFlash: cheap alias/runtime checks
+    # before the startup banner and before any model load.
+    if args.enable_ddtree:
+        _GPU_MEM_DEFAULT = 0.90
+        _ddtree_ignored: list[str] = []
+        if getattr(args, "enable_prefix_cache", False):
+            _ddtree_ignored.append("--enable-prefix-cache")
+        if getattr(args, "kv_cache_quantization", None):
+            _ddtree_ignored.append("--kv-cache-quantization")
+        _gpu_mem = getattr(args, "gpu_memory_utilization", _GPU_MEM_DEFAULT)
+        if _gpu_mem is not None and abs(_gpu_mem - _GPU_MEM_DEFAULT) > 1e-6:
+            _ddtree_ignored.append("--gpu-memory-utilization")
+        if getattr(args, "enable_auto_tool_choice", False):
+            _ddtree_ignored.append("--enable-auto-tool-choice")
+        if getattr(args, "tool_call_parser", None):
+            _ddtree_ignored.append("--tool-call-parser")
+        if getattr(args, "reasoning_parser", None):
+            _ddtree_ignored.append("--reasoning-parser")
+        if getattr(args, "embedding_model", None):
+            _ddtree_ignored.append("--embedding-model")
+        if getattr(args, "mcp_config", None):
+            _ddtree_ignored.append("--mcp-config")
+        if _ddtree_ignored:
+            print(
+                "\n  ⚠ The following flags are ignored under --enable-ddtree"
+                "\n    (DDTree uses a dedicated experimental single-user "
+                "server that bypasses BatchedEngine):"
+                f"\n      {', '.join(_ddtree_ignored)}"
+                "\n    Drop them from your serve command, or run without"
+                "\n    --enable-ddtree if you need them.\n"
+            )
+
     # Startup summary
     print()
     print("  🐆 Rapid-MLX")
@@ -2150,6 +2253,8 @@ def serve_command(args):
         features.append(f"cors: {', '.join(cors_origins)}")
     if args.enable_dflash:
         features.append("dflash: single-user")
+    if args.enable_ddtree:
+        features.append("ddtree: experimental single-user")
     if features:
         print(f"  Features: {', '.join(features)}")
     print(f"  Model: {args.model}")
@@ -2580,6 +2685,37 @@ def serve_command(args):
             port=args.port,
             served_model_name=args.served_model_name or _alias_name,
             default_max_tokens=effective_max_tokens,
+            cors_origins=cors_origins,
+            uvicorn_log_level=uvicorn_log_level,
+            no_thinking=args.no_thinking,
+        )
+        return
+
+    # DDTree fork: same blast-radius boundary as DFlash. It is a
+    # speculative-decode mode, but the MVP runs through the external
+    # dtree-mlx runtime rather than BatchedEngine.
+    if args.enable_ddtree:
+        from .speculative.ddtree.server import run_ddtree_server
+
+        _alias_name = getattr(args, "_ddtree_alias_name", None)
+        _profile = getattr(args, "_ddtree_profile", None)
+        if _alias_name is None or _profile is None:
+            _alias_name, _profile = _preflight_ddtree_or_exit(args)
+        assert _profile is not None and _profile.supports_ddtree, (
+            f"DDTree profile invariant violated for {_alias_name!r}"
+        )
+        assert _profile.ddtree_draft_model is not None
+        assert _profile.ddtree_speculative_tokens is not None
+        assert _profile.ddtree_tree_budget is not None
+        run_ddtree_server(
+            main_model_repo=_profile.hf_path,
+            drafter_repo=_profile.ddtree_draft_model,
+            speculative_tokens=_profile.ddtree_speculative_tokens,
+            tree_budget=_profile.ddtree_tree_budget,
+            host=args.host,
+            port=args.port,
+            served_model_name=args.served_model_name or _alias_name,
+            default_max_tokens=args.max_tokens,
             cors_origins=cors_origins,
             uvicorn_log_level=uvicorn_log_level,
             no_thinking=args.no_thinking,
@@ -3610,7 +3746,7 @@ def models_command(args):
     # floor — never shrink below it so short rows still feel padded.
     # Other widths sized to fit values currently in aliases.json:
     # tool 16 (qwen3_coder_xml + 1 pad), reasoning 12 (deepseek_r1 + 1),
-    # spec 10 ("✗ hybrid"), tier 11, dflash 7.
+    # spec 10 ("✗ hybrid"), tier 11, dflash 7, ddtree 7.
     alias_width = max(24, max((len(a) for a in profiles), default=0) + 2)
     cols = (
         ("Alias", alias_width),
@@ -3619,6 +3755,7 @@ def models_command(args):
         ("Spec-Decode", 10),
         ("Suffix Tier", 11),
         ("DFlash", 7),
+        ("DDTree", 7),
     )
     width = sum(w for _, w in cols) + len(cols) - 1
     sep = "  " + "─" * width
@@ -3645,9 +3782,10 @@ def models_command(args):
         # mlx-vlm 0.5.0+ is installed) — that's a runtime concern; the
         # registry column is pure declarative state.
         dflash = "✓" if p.supports_dflash else "—"
+        ddtree = "✓" if p.supports_ddtree else "—"
         row = (
             f"  {alias:<{alias_width}} {tools:<16} {reasoning:<12} "
-            f"{spec:<10} {tier:<11} {dflash:<7}"
+            f"{spec:<10} {tier:<11} {dflash:<7} {ddtree:<7}"
         )
         print(row)
 
@@ -5373,6 +5511,7 @@ def info_command(args):
     profile = resolve_profile(original_alias)
     if profile is not None:
         _print_dflash_status(original_alias, profile)
+        _print_ddtree_status(original_alias, profile)
 
     if cfg is None:
         print("  No pattern matched — runtime probe will run when the model loads.")
@@ -5444,6 +5583,84 @@ def _print_dflash_status(alias: str, profile) -> None:
     print()
     if eligible:
         print(f"  Start with: rapid-mlx serve {alias} --enable-dflash")
+        print()
+
+
+def _print_ddtree_status(alias: str, profile) -> None:
+    """Render DDTree status for ``rapid-mlx info <alias>``."""
+    from vllm_mlx.speculative.ddtree.eligibility import have_runtime, report
+    from vllm_mlx.speculative.dflash.eligibility import _looks_like_4bit
+
+    r = report(profile, alias=alias)
+    inner = 60
+    sep = "─" * inner
+
+    def _row(text: str) -> str:
+        return f"│ {text:<{inner}} │"
+
+    def _yes(ok: bool, msg_ok: str, msg_no: str) -> str:
+        return ("✓ " + msg_ok) if ok else ("✗ " + msg_no)
+
+    rows = [
+        (
+            "Declared support",
+            _yes(profile.supports_ddtree, "yes (supports_ddtree=true)", "no"),
+        ),
+        ("Not MoE", _yes(not profile.is_moe, "yes (dense)", "no (MoE)")),
+        (
+            "Precision ≥8-bit",
+            _yes(
+                not _looks_like_4bit(profile.hf_path),
+                "yes",
+                "no (4-bit/mxfp4/nvfp4)",
+            ),
+        ),
+        (
+            "Drafter declared",
+            _yes(
+                bool(profile.ddtree_draft_model),
+                profile.ddtree_draft_model or "yes",
+                "no (ddtree_draft_model unset)",
+            ),
+        ),
+        (
+            "Spec tokens",
+            _yes(
+                profile.ddtree_speculative_tokens is not None,
+                str(profile.ddtree_speculative_tokens),
+                "missing",
+            ),
+        ),
+        (
+            "Tree budget",
+            _yes(
+                profile.ddtree_tree_budget is not None,
+                str(profile.ddtree_tree_budget),
+                "missing",
+            ),
+        ),
+        (
+            "dtree-mlx runtime",
+            _yes(
+                have_runtime(),
+                "installed",
+                "missing/import-broken",
+            ),
+        ),
+    ]
+
+    eligible = not r.reasons and have_runtime()
+    summary = "✓ eligible" if eligible else "✗ ineligible"
+    top = "┌" + "─" * (inner + 2) + "┐"
+    bot = "└" + "─" * (inner + 2) + "┘"
+    body = [top, _row(f"DDTree eligibility: {summary}"), _row(sep)]
+    for k, v in rows:
+        body.append(_row(f"{k:<18}: {v}"))
+    body.append(bot)
+    print("\n".join(body))
+    print()
+    if eligible:
+        print(f"  Start with: rapid-mlx serve {alias} --enable-ddtree")
         print()
 
 
@@ -6089,6 +6306,15 @@ Examples:
         "``pip install 'rapid-mlx[dflash]'``.",
     )
     serve_parser.add_argument(
+        "--enable-ddtree",
+        action="store_true",
+        default=False,
+        help="Enable experimental DDTree speculative decoding (DFlash draft "
+        "tree verification, single-user serial mode). Requires a "
+        "DDTree-eligible alias (see ``rapid-mlx info <alias>``) and the "
+        "external dtree-mlx runtime.",
+    )
+    serve_parser.add_argument(
         "--num-draft-tokens",
         type=int,
         default=4,
@@ -6502,7 +6728,7 @@ Examples:
         default=False,
         help=(
             "Force-disable speculative-decode eligibility (suffix / MTP / "
-            "DFlash) even when AliasProfile says the model supports it. "
+            "DFlash / DDTree) even when AliasProfile says the model supports it. "
             "Mutually exclusive with --force-spec-decode."
         ),
     )

--- a/vllm_mlx/model_aliases.py
+++ b/vllm_mlx/model_aliases.py
@@ -71,10 +71,11 @@ VALID_PFLASH_TIERS: frozenset[str] = frozenset({"unknown", "verified"})
 VALID_TURBOQUANT_TIERS: frozenset[str] = frozenset({"unknown", "k8v4_verified"})
 
 
-# Canonical name for the DFlash speculative-decoding drafter kind. Kept
-# as a module constant so eligibility checks, CLI flag handlers, and
-# alias validation all reference the same string.
+# Canonical names for block-diffusion speculative-decoding drafter kinds.
+# Kept as module constants so eligibility checks, CLI flag handlers, and
+# alias validation all reference the same strings.
 DFLASH_KIND: str = "dflash"
+DDTREE_KIND: str = "ddtree"
 
 _aliases: dict[str, "AliasProfile"] | None = None
 # Reverse index: hf_path → first alias that references it. Built once
@@ -210,6 +211,15 @@ class AliasProfile:
     pflash_tier: str = "unknown"
     # TurboQuant K8V4 default-on tier. See ``VALID_TURBOQUANT_TIERS``.
     turboquant_tier: str = "unknown"
+    # DDTree speculative-decoding eligibility (#879). Appended at the
+    # tail to preserve AliasProfile's positional-construction ABI.
+    # This is intentionally separate from DFlash even though it uses the
+    # same DFlash draft weights: DDTree verifies a tree of candidate
+    # continuations and needs model-family specific verifier support.
+    supports_ddtree: bool = False
+    ddtree_draft_model: str | None = None
+    ddtree_speculative_tokens: int | None = None
+    ddtree_tree_budget: int | None = None
 
 
 def _coerce(alias: str, value: object) -> AliasProfile:
@@ -258,6 +268,10 @@ def _coerce(alias: str, value: object) -> AliasProfile:
             "suffix_bench_speedup",
             "supports_dflash",
             "dflash_draft_model",
+            "supports_ddtree",
+            "ddtree_draft_model",
+            "ddtree_speculative_tokens",
+            "ddtree_tree_budget",
             "recommended_sampling",
             "pflash_tier",
             "turboquant_tier",
@@ -384,6 +398,36 @@ def _coerce(alias: str, value: object) -> AliasProfile:
             f"alias {alias!r}: dflash_draft_model must be a string, "
             f"got {type(dflash_draft_model).__name__}"
         )
+    supports_ddtree = _strict_bool("supports_ddtree", False)
+    ddtree_draft_model = value.get("ddtree_draft_model")
+    if supports_ddtree and not ddtree_draft_model:
+        raise ValueError(
+            f"alias {alias!r}: supports_ddtree=true requires "
+            f"ddtree_draft_model to be set"
+        )
+    if ddtree_draft_model is not None and not isinstance(ddtree_draft_model, str):
+        raise ValueError(
+            f"alias {alias!r}: ddtree_draft_model must be a string, "
+            f"got {type(ddtree_draft_model).__name__}"
+        )
+
+    def _optional_positive_int(key: str) -> int | None:
+        raw = value.get(key)
+        if raw is None:
+            return None
+        if isinstance(raw, bool) or not isinstance(raw, int):
+            raise ValueError(
+                f"alias {alias!r}: {key} must be a positive integer, "
+                f"got {type(raw).__name__}={raw!r}"
+            )
+        if raw <= 0:
+            raise ValueError(
+                f"alias {alias!r}: {key} must be a positive integer, got {raw}"
+            )
+        return raw
+
+    ddtree_speculative_tokens = _optional_positive_int("ddtree_speculative_tokens")
+    ddtree_tree_budget = _optional_positive_int("ddtree_tree_budget")
     raw_sampling = value.get("recommended_sampling")
     recommended_sampling: tuple[tuple[str, float], ...] | None
     if raw_sampling is None:
@@ -467,6 +511,11 @@ def _coerce(alias: str, value: object) -> AliasProfile:
                 f"alias {alias!r}: supports_dflash must be false when "
                 f"modality={modality!r} (DFlash is AR-only)"
             )
+        if supports_ddtree:
+            raise ValueError(
+                f"alias {alias!r}: supports_ddtree must be false when "
+                f"modality={modality!r} (DDTree is AR-only)"
+            )
 
     return AliasProfile(
         hf_path=hf_path,
@@ -482,6 +531,10 @@ def _coerce(alias: str, value: object) -> AliasProfile:
         suffix_bench_speedup=speedup,
         supports_dflash=supports_dflash,
         dflash_draft_model=dflash_draft_model,
+        supports_ddtree=supports_ddtree,
+        ddtree_draft_model=ddtree_draft_model,
+        ddtree_speculative_tokens=ddtree_speculative_tokens,
+        ddtree_tree_budget=ddtree_tree_budget,
         recommended_sampling=recommended_sampling,
         # Deprecated v0.7.2 PR #555 knobs — explicitly threaded through
         # so an operator who customized ``aliases.json`` with non-default

--- a/vllm_mlx/speculative/ddtree/__init__.py
+++ b/vllm_mlx/speculative/ddtree/__init__.py
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: Apache-2.0
+"""DDTree speculative-decoding integration (issue #879).
+
+DDTree builds a draft tree from DFlash draft-model logits and verifies
+multiple candidate continuations per target-model pass. The MVP keeps it
+behind an explicit ``--enable-ddtree`` flag and a dedicated single-user
+server, using the external ``dtree_mlx`` package as the runtime boundary.
+"""
+
+from .eligibility import DDTreeUnavailable, check
+from .runtime import load_runtime
+
+__all__ = ["DDTreeUnavailable", "check", "load_runtime"]

--- a/vllm_mlx/speculative/ddtree/eligibility.py
+++ b/vllm_mlx/speculative/ddtree/eligibility.py
@@ -1,0 +1,112 @@
+# SPDX-License-Identifier: Apache-2.0
+"""DDTree eligibility checks.
+
+DDTree support is narrower than DFlash support because the verifier is
+model-family specific. A model may have matching DFlash draft weights and
+still be unsafe for DDTree until the target-side tree verifier has been
+bench-validated.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from vllm_mlx.model_aliases import AliasProfile
+from vllm_mlx.speculative.dflash.eligibility import _looks_like_4bit
+
+
+class DDTreeUnavailable(RuntimeError):  # noqa: N818
+    """Raised when an alias fails a DDTree eligibility gate."""
+
+
+@dataclass(frozen=True)
+class EligibilityReport:
+    alias: str | None
+    supports_ddtree: bool
+    is_moe: bool
+    is_4bit: bool
+    has_drafter: bool
+    has_speculative_tokens: bool
+    has_tree_budget: bool
+    reasons: tuple[str, ...]
+
+
+def report(profile: AliasProfile, alias: str | None = None) -> EligibilityReport:
+    reasons: list[str] = []
+    if not profile.supports_ddtree:
+        reasons.append(
+            "alias is not DDTree-enabled (set supports_ddtree=true only after "
+            "benching this exact target/drafter pair)"
+        )
+    if profile.is_moe:
+        reasons.append(
+            "alias is MoE (is_moe=true) — DDTree verifier support is only "
+            "validated for dense Qwen3.5/Qwen3-family targets in the MVP"
+        )
+    is_4bit = _looks_like_4bit(profile.hf_path)
+    if is_4bit:
+        reasons.append(
+            f"main model hf_path={profile.hf_path!r} is 4-bit quantized; "
+            "DDTree on 4-bit is not validated yet"
+        )
+    has_drafter = bool(profile.ddtree_draft_model)
+    if profile.supports_ddtree and not has_drafter:
+        reasons.append("supports_ddtree is set but ddtree_draft_model is empty")
+    has_speculative_tokens = profile.ddtree_speculative_tokens is not None
+    if profile.supports_ddtree and not has_speculative_tokens:
+        reasons.append("supports_ddtree is set but ddtree_speculative_tokens is empty")
+    has_tree_budget = profile.ddtree_tree_budget is not None
+    if profile.supports_ddtree and not has_tree_budget:
+        reasons.append("supports_ddtree is set but ddtree_tree_budget is empty")
+    return EligibilityReport(
+        alias=alias,
+        supports_ddtree=profile.supports_ddtree,
+        is_moe=profile.is_moe,
+        is_4bit=is_4bit,
+        has_drafter=has_drafter,
+        has_speculative_tokens=has_speculative_tokens,
+        has_tree_budget=has_tree_budget,
+        reasons=tuple(reasons),
+    )
+
+
+def eligible_aliases() -> list[str]:
+    try:
+        from vllm_mlx.model_aliases import list_profiles
+
+        return sorted(
+            name
+            for name, profile in list_profiles().items()
+            if not report(profile).reasons
+        )
+    except Exception:  # noqa: BLE001
+        return []
+
+
+def check(profile: AliasProfile, alias: str | None = None) -> None:
+    r = report(profile, alias=alias)
+    if not r.reasons:
+        return
+    header = f"DDTree unavailable for {alias!r}" if alias else "DDTree unavailable"
+    bullet = "\n  - ".join(r.reasons)
+    eligible = eligible_aliases()
+    if eligible:
+        suffix = (
+            f"Eligible aliases today: {', '.join(eligible)}. Run "
+            "`rapid-mlx info <alias>` to inspect per-alias DDTree status."
+        )
+    else:
+        suffix = (
+            "No aliases currently pass every DDTree gate. Run "
+            "`rapid-mlx info <alias>` to inspect per-alias DDTree status."
+        )
+    raise DDTreeUnavailable(f"{header}:\n  - {bullet}\n\n{suffix}")
+
+
+def have_runtime() -> bool:
+    try:
+        import importlib.util
+
+        return importlib.util.find_spec("dtree_mlx.api") is not None
+    except (ImportError, AttributeError):
+        return False

--- a/vllm_mlx/speculative/ddtree/runtime.py
+++ b/vllm_mlx/speculative/ddtree/runtime.py
@@ -1,0 +1,63 @@
+# SPDX-License-Identifier: Apache-2.0
+"""DDTree runtime boundary.
+
+The first DDTree integration deliberately treats ``dtree_mlx`` as an
+optional external runtime. That keeps the rapid-mlx MVP small and lets us
+validate correctness/performance before deciding whether to vendor or
+reimplement the tree verifier.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+from .eligibility import have_runtime
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class DDTreeRuntime:
+    generator: Any
+    main_model_repo: str
+    drafter_repo: str
+    speculative_tokens: int
+    tree_budget: int
+
+
+def load_runtime(
+    *,
+    main_model_repo: str,
+    drafter_repo: str,
+    speculative_tokens: int,
+    tree_budget: int,
+) -> DDTreeRuntime:
+    if not have_runtime():
+        raise RuntimeError(
+            "DDTree runtime not available — install the experimental runtime with: "
+            "pip install 'dtree-mlx @ git+https://github.com/DrHB/dtree-mlx.git'"
+        )
+
+    from dtree_mlx.api import DFlashGenerator
+
+    logger.info(
+        "Loading DDTree runtime: target=%s drafter=%s spec=%d tree_budget=%d",
+        main_model_repo,
+        drafter_repo,
+        speculative_tokens,
+        tree_budget,
+    )
+    generator = DFlashGenerator(
+        target_model=main_model_repo,
+        draft_model=drafter_repo,
+        draft_attention_mask="auto",
+    )
+    return DDTreeRuntime(
+        generator=generator,
+        main_model_repo=main_model_repo,
+        drafter_repo=drafter_repo,
+        speculative_tokens=speculative_tokens,
+        tree_budget=tree_budget,
+    )

--- a/vllm_mlx/speculative/ddtree/server.py
+++ b/vllm_mlx/speculative/ddtree/server.py
@@ -1,0 +1,448 @@
+# SPDX-License-Identifier: Apache-2.0
+"""DDTree server — experimental single-user mode.
+
+This mirrors the DFlash single-user boundary: ``--enable-ddtree`` bypasses
+BatchedEngine and routes generation through the optional external
+``dtree_mlx`` runtime. The MVP prioritizes a clean end-to-end validation
+surface over breadth of OpenAI features.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import atexit
+import concurrent.futures
+import functools
+import json
+import logging
+import time
+import uuid
+from collections.abc import AsyncIterator
+from typing import Any
+
+from fastapi import FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import StreamingResponse
+
+from vllm_mlx.api.models import (
+    AssistantMessage,
+    ChatCompletionChoice,
+    ChatCompletionRequest,
+    ChatCompletionResponse,
+    ModelInfo,
+    ModelsResponse,
+    Usage,
+)
+
+from .eligibility import DDTreeUnavailable, have_runtime
+from .runtime import DDTreeRuntime, load_runtime
+
+logger = logging.getLogger(__name__)
+
+_ddtree_lock = asyncio.Lock()
+_ddtree_executor = concurrent.futures.ThreadPoolExecutor(
+    max_workers=1, thread_name_prefix="ddtree-worker"
+)
+
+
+@atexit.register
+def _shutdown_ddtree_executor() -> None:
+    _ddtree_executor.shutdown(wait=False, cancel_futures=True)
+
+
+def _build_app(
+    *,
+    runtime: DDTreeRuntime,
+    served_model_name: str,
+    default_max_tokens: int,
+    cors_origins: list[str],
+    no_thinking: bool = False,
+) -> FastAPI:
+    app = FastAPI(title="Rapid-MLX (DDTree)")
+    from ...middleware.exception_handlers import install_exception_handlers
+
+    install_exception_handlers(app)
+    if cors_origins:
+        wildcard = "*" in cors_origins
+        app.add_middleware(
+            CORSMiddleware,
+            allow_origins=cors_origins,
+            allow_credentials=not wildcard,
+            allow_methods=["POST", "GET", "OPTIONS"],
+            allow_headers=["Content-Type", "Authorization", "X-Rapid-MLX-Internal"],
+            max_age=3600,
+        )
+
+    @app.get("/healthz")
+    async def healthz() -> dict[str, Any]:
+        return {
+            "status": "ok",
+            "engine": "ddtree",
+            "mode": "experimental-single-user-serial",
+            "drafter": runtime.drafter_repo,
+            "speculative_tokens": runtime.speculative_tokens,
+            "tree_budget": runtime.tree_budget,
+        }
+
+    @app.get("/v1/models")
+    async def list_models() -> ModelsResponse:
+        return ModelsResponse(
+            data=[
+                ModelInfo(
+                    id=served_model_name,
+                    created=int(time.time()),
+                    owned_by="rapid-mlx",
+                )
+            ]
+        )
+
+    @app.post("/v1/chat/completions")
+    async def create_chat_completion(request: ChatCompletionRequest):
+        _validate_request(request)
+        prompt = _render_prompt(runtime, request, no_thinking=no_thinking)
+        max_tokens = (
+            request.max_tokens if request.max_tokens is not None else default_max_tokens
+        )
+        temperature = request.temperature if request.temperature is not None else 0.0
+
+        if request.stream:
+            return StreamingResponse(
+                _stream_completion(
+                    runtime=runtime,
+                    prompt=prompt,
+                    served_model_name=served_model_name,
+                    max_tokens=max_tokens,
+                    temperature=temperature,
+                ),
+                media_type="text/event-stream",
+            )
+
+        return await _non_stream_completion(
+            runtime=runtime,
+            prompt=prompt,
+            served_model_name=served_model_name,
+            max_tokens=max_tokens,
+            temperature=temperature,
+        )
+
+    return app
+
+
+def _validate_request(request: ChatCompletionRequest) -> None:
+    if not request.messages:
+        raise HTTPException(status_code=400, detail="messages must not be empty")
+    if request.n is not None and request.n > 1:
+        raise HTTPException(status_code=400, detail="n > 1 is not supported")
+    if request.tools:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "Tool calling is not supported in DDTree mode (MVP limitation). "
+                "Restart without --enable-ddtree to use tools."
+            ),
+        )
+    if request.logprobs:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "logprobs is not supported in DDTree mode. Restart without "
+                "--enable-ddtree."
+            ),
+        )
+    if request.response_format is not None:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "response_format (structured output) is not supported in "
+                "DDTree mode. Restart without --enable-ddtree."
+            ),
+        )
+    if request.top_p is not None and request.top_p != 1.0:
+        raise HTTPException(
+            status_code=400,
+            detail="top_p is not supported in DDTree mode; use top_p=1.",
+        )
+    if request.stop is not None:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "custom stop sequences are not supported in DDTree mode; "
+                "the model's EOS/chat-template stops still apply."
+            ),
+        )
+
+
+def _render_prompt(
+    runtime: DDTreeRuntime,
+    request: ChatCompletionRequest,
+    *,
+    no_thinking: bool = False,
+) -> str:
+    tokenizer = runtime.generator.target.tokenizer
+    messages = []
+    for m in request.messages:
+        content = m.content
+        if isinstance(content, list):
+            text_pieces = []
+            dropped_kinds: list[str] = []
+            for part in content:
+                part_type = part.type if hasattr(part, "type") else part.get("type", "")
+                if part_type == "text":
+                    text_pieces.append(
+                        part.text if hasattr(part, "text") else part.get("text", "")
+                    )
+                elif part_type:
+                    dropped_kinds.append(part_type)
+            if dropped_kinds:
+                logger.warning(
+                    "DDTree server is text-only; dropped %d non-text content "
+                    "part(s) of type(s) %s.",
+                    len(dropped_kinds),
+                    sorted(set(dropped_kinds)),
+                )
+            content = "".join(text_pieces)
+        messages.append({"role": m.role, "content": content})
+
+    enable_thinking = False if no_thinking else _extract_thinking_from_request(request)
+    effective_thinking = True if enable_thinking is None else enable_thinking
+    if hasattr(tokenizer, "apply_chat_template"):
+        try:
+            return tokenizer.apply_chat_template(
+                messages,
+                tokenize=False,
+                add_generation_prompt=True,
+                enable_thinking=effective_thinking,
+            )
+        except TypeError:
+            return tokenizer.apply_chat_template(
+                messages,
+                tokenize=False,
+                add_generation_prompt=True,
+            )
+    return "\n".join(f"{m['role']}: {m['content']}" for m in messages) + "\nassistant:"
+
+
+def _extract_thinking_from_request(request: ChatCompletionRequest) -> bool | None:
+    ctk = getattr(request, "chat_template_kwargs", None)
+    if isinstance(ctk, dict) and "enable_thinking" in ctk:
+        v = ctk["enable_thinking"]
+        if isinstance(v, bool):
+            return v
+        if isinstance(v, str):
+            lowered = v.strip().lower()
+            if lowered == "true":
+                return True
+            if lowered == "false":
+                return False
+    return getattr(request, "enable_thinking", None)
+
+
+def _run_generate(
+    runtime: DDTreeRuntime,
+    *,
+    prompt: str,
+    max_tokens: int,
+    temperature: float,
+):
+    return runtime.generator.generate(
+        prompt,
+        max_new_tokens=max_tokens,
+        temperature=temperature,
+        speculative_tokens=runtime.speculative_tokens,
+        decode_mode="dtree",
+        tree_budget=runtime.tree_budget,
+        verify_mode="parallel-greedy-argmax",
+    )
+
+
+def _usage_from_result(result) -> tuple[int, int]:
+    metrics = getattr(result, "metrics", {}) or {}
+    prompt_tokens = int(metrics.get("num_input_tokens", 0))
+    completion_tokens = len(getattr(result, "generated_tokens", []) or [])
+    return prompt_tokens, completion_tokens
+
+
+def _finish_reason(result, max_tokens: int) -> str:
+    _, completion_tokens = _usage_from_result(result)
+    return "length" if completion_tokens >= max_tokens else "stop"
+
+
+async def _stream_completion(
+    *,
+    runtime: DDTreeRuntime,
+    prompt: str,
+    served_model_name: str,
+    max_tokens: int,
+    temperature: float,
+) -> AsyncIterator[bytes]:
+    completion_id = f"chatcmpl-{uuid.uuid4().hex[:24]}"
+    created = int(time.time())
+    first = {
+        "id": completion_id,
+        "object": "chat.completion.chunk",
+        "created": created,
+        "model": served_model_name,
+        "choices": [
+            {"index": 0, "delta": {"role": "assistant"}, "finish_reason": None}
+        ],
+    }
+    yield f"data: {json.dumps(first)}\n\n".encode()
+
+    async with _ddtree_lock:
+        loop = asyncio.get_running_loop()
+        result = await loop.run_in_executor(
+            _ddtree_executor,
+            functools.partial(
+                _run_generate,
+                runtime,
+                prompt=prompt,
+                max_tokens=max_tokens,
+                temperature=temperature,
+            ),
+        )
+
+    if getattr(result, "text", ""):
+        piece = {
+            "id": completion_id,
+            "object": "chat.completion.chunk",
+            "created": created,
+            "model": served_model_name,
+            "choices": [
+                {
+                    "index": 0,
+                    "delta": {"content": result.text},
+                    "finish_reason": None,
+                }
+            ],
+        }
+        yield f"data: {json.dumps(piece)}\n\n".encode()
+
+    prompt_tokens, completion_tokens = _usage_from_result(result)
+    final = {
+        "id": completion_id,
+        "object": "chat.completion.chunk",
+        "created": created,
+        "model": served_model_name,
+        "choices": [
+            {
+                "index": 0,
+                "delta": {},
+                "finish_reason": _finish_reason(result, max_tokens),
+            }
+        ],
+        "usage": {
+            "prompt_tokens": prompt_tokens,
+            "completion_tokens": completion_tokens,
+            "total_tokens": prompt_tokens + completion_tokens,
+        },
+    }
+    yield f"data: {json.dumps(final)}\n\n".encode()
+    yield b"data: [DONE]\n\n"
+
+
+async def _non_stream_completion(
+    *,
+    runtime: DDTreeRuntime,
+    prompt: str,
+    served_model_name: str,
+    max_tokens: int,
+    temperature: float,
+) -> ChatCompletionResponse:
+    async with _ddtree_lock:
+        loop = asyncio.get_running_loop()
+        result = await loop.run_in_executor(
+            _ddtree_executor,
+            functools.partial(
+                _run_generate,
+                runtime,
+                prompt=prompt,
+                max_tokens=max_tokens,
+                temperature=temperature,
+            ),
+        )
+
+    created = int(time.time())
+    prompt_tokens, completion_tokens = _usage_from_result(result)
+    return ChatCompletionResponse(
+        id=f"chatcmpl-{uuid.uuid4().hex[:24]}",
+        object="chat.completion",
+        created=created,
+        model=served_model_name,
+        choices=[
+            ChatCompletionChoice(
+                index=0,
+                message=AssistantMessage(role="assistant", content=result.text),
+                finish_reason=_finish_reason(result, max_tokens),
+            )
+        ],
+        usage=Usage(
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+            total_tokens=prompt_tokens + completion_tokens,
+        ),
+    )
+
+
+def run_ddtree_server(
+    *,
+    main_model_repo: str,
+    drafter_repo: str,
+    speculative_tokens: int,
+    tree_budget: int,
+    host: str,
+    port: int,
+    served_model_name: str,
+    default_max_tokens: int,
+    cors_origins: list[str],
+    uvicorn_log_level: str,
+    no_thinking: bool = False,
+) -> None:
+    if not have_runtime():
+        raise RuntimeError(
+            "DDTree server requires the experimental dtree-mlx runtime — install with "
+            "``pip install 'dtree-mlx @ git+https://github.com/DrHB/dtree-mlx.git'``."
+        )
+    if not drafter_repo:
+        raise DDTreeUnavailable(
+            "DDTree requires a non-empty drafter_repo — pass a matching DFlash "
+            "drafter HF path (e.g. 'z-lab/Qwen3.5-9B-DFlash')."
+        )
+    if speculative_tokens <= 0 or tree_budget <= 0:
+        raise DDTreeUnavailable(
+            "DDTree requires positive speculative_tokens and tree_budget values."
+        )
+
+    import uvicorn
+
+    def _load_all():
+        return load_runtime(
+            main_model_repo=main_model_repo,
+            drafter_repo=drafter_repo,
+            speculative_tokens=speculative_tokens,
+            tree_budget=tree_budget,
+        )
+
+    logger.info("DDTree: loading runtime for %s", main_model_repo)
+    runtime = _ddtree_executor.submit(_load_all).result()
+
+    app = _build_app(
+        runtime=runtime,
+        served_model_name=served_model_name,
+        default_max_tokens=default_max_tokens,
+        cors_origins=cors_origins,
+        no_thinking=no_thinking,
+    )
+
+    print()
+    host_display = "localhost" if host == "0.0.0.0" else host
+    print(f"  Ready: http://{host_display}:{port}/v1  (DDTree experimental mode)")
+    print(f"  Docs:  http://{host_display}:{port}/docs")
+    print()
+
+    uvicorn.run(
+        app,
+        host=host,
+        port=port,
+        log_level=uvicorn_log_level,
+        timeout_keep_alive=30,
+    )


### PR DESCRIPTION
## Summary

Refs #879.

Adds an experimental, opt-in DDTree path for `qwen3.5-9b-8bit`:

- adds DDTree alias metadata (`supports_ddtree`, drafter repo, speculative token count, tree budget)
- wires `rapid-mlx serve ... --enable-ddtree` with early alias/runtime preflight so bad flags or missing `dtree-mlx` fail before model download
- adds a dedicated single-user FastAPI server backed by the external `dtree-mlx` runtime
- exposes DDTree status in `rapid-mlx info` and `rapid-mlx models`
- documents install/use and MVP limitations
- bumps package version to `0.9.13` for the user-facing CLI/alias change
- adds unit/integration coverage for alias contracts, eligibility gates, CLI visibility, and OpenAI chat surface behavior

## Notes

This is intentionally not enabled by default. `qwen3.5-9b-8bit` records the experimental `z-lab/Qwen3.5-9B-DFlash` drafter so users can opt in with `--enable-ddtree`, but the standard BatchedEngine path remains unchanged.

Local runtime import validation now passes (`import dtree_mlx.api` exposes `DFlashGenerator`). Full 9B correctness/performance validation is still blocked on this machine because the target 9B 8-bit and DFlash draft weights are not cached and the available disk is not enough for a safe download/run.

## Validation

Local:

- `uv run ruff format --check vllm_mlx/ tests/`
- `uv run ruff check vllm_mlx/ tests/`
- `uv run --with pytest python -m pytest -q tests/test_ddtree_integration.py tests/test_ddtree_eligibility.py tests/test_aliases_contract.py tests/test_no_mllm_flag.py::test_ddtree_branch_rejects_no_spec_decode tests/test_no_mllm_flag.py::test_no_unregistered_routing_shaped_flags tests/test_no_out_of_band_routing.py::test_alias_profile_str_fields_are_explicitly_listed` (1858 passed)
- `uv run --with pytest python -m pytest -q tests/test_dflash_integration.py tests/test_ddtree_integration.py` (20 passed, 11 skipped)
- `uv run --with pytest python -m pytest -q tests/test_no_out_of_band_routing.py` (14 passed)
- `uv run python -m vllm_mlx.cli models | rg 'Alias|qwen3\.5-9b-8bit|qwen3\.5-9b-4bit'`
- `uv run python -m vllm_mlx.cli info qwen3.5-9b-8bit | sed -n '/DDTree eligibility/,+12p'`
- `uv run python - <<'PY' ... import dtree_mlx.api ... PY` (`ok True`)
- DDTree mutex smoke tests for `--no-spec-decode`, `--enable-dflash`, and `--spec-decode dflash` all exit before download with expected errors.

GitHub Actions:

- CI `lint`: success
- CI `type-check`: success
- CI `test-matrix (3.10/3.11/3.12)`: success
- CI `test-apple-silicon`: success
- PR validation pipeline `validate`: success
- Version bump check: success
- Community benchmark validation: success