### PR TITLE
[codex] fix ddtree draft config compatibility

### DIFF
--- a/tests/test_ddtree_eligibility.py
+++ b/tests/test_ddtree_eligibility.py
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 from vllm_mlx.model_aliases import AliasProfile
@@ -92,3 +94,37 @@ def test_qwen3_5_9b_4bit_alias_fails_with_4bit_reason() -> None:
     with pytest.raises(DDTreeUnavailable) as excinfo:
         check(profile, alias="qwen3.5-9b-4bit")
     assert "4-bit" in str(excinfo.value)
+
+
+def test_runtime_patches_rope_parameters_without_copying_weights(
+    tmp_path, monkeypatch
+) -> None:
+    from vllm_mlx.speculative.ddtree import runtime
+
+    source = tmp_path / "source"
+    source.mkdir()
+    (source / "config.json").write_text(
+        """
+        {
+          "model_type": "qwen3",
+          "rope_parameters": {
+            "rope_theta": 10000000,
+            "rope_type": "default"
+          }
+        }
+        """
+    )
+    (source / "model.safetensors").write_bytes(b"fake")
+    cache = tmp_path / "patched"
+    monkeypatch.setenv("RAPID_MLX_DDTREE_PATCH_CACHE", str(cache))
+
+    patched = runtime._prepare_draft_model_for_dtree(str(source))
+    patched_path = Path(patched)
+
+    assert patched_path != source
+    patched_cfg = patched_path / "config.json"
+    assert patched_cfg.exists()
+    assert '"rope_theta": 10000000' in patched_cfg.read_text()
+    weight = patched_path / "model.safetensors"
+    assert weight.is_symlink()
+    assert weight.resolve() == (source / "model.safetensors").resolve()

--- a/vllm_mlx/speculative/ddtree/runtime.py
+++ b/vllm_mlx/speculative/ddtree/runtime.py
@@ -9,8 +9,11 @@ reimplement the tree verifier.
 
 from __future__ import annotations
 
+import json
 import logging
+import os
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any
 
 from .eligibility import have_runtime
@@ -42,16 +45,18 @@ def load_runtime(
 
     from dtree_mlx.api import DFlashGenerator
 
+    resolved_drafter_repo = _prepare_draft_model_for_dtree(drafter_repo)
+
     logger.info(
         "Loading DDTree runtime: target=%s drafter=%s spec=%d tree_budget=%d",
         main_model_repo,
-        drafter_repo,
+        resolved_drafter_repo,
         speculative_tokens,
         tree_budget,
     )
     generator = DFlashGenerator(
         target_model=main_model_repo,
-        draft_model=drafter_repo,
+        draft_model=resolved_drafter_repo,
         draft_attention_mask="auto",
     )
     return DDTreeRuntime(
@@ -61,3 +66,78 @@ def load_runtime(
         speculative_tokens=speculative_tokens,
         tree_budget=tree_budget,
     )
+
+
+def _prepare_draft_model_for_dtree(draft_model: str) -> str:
+    """Return a dtree-mlx-compatible draft path.
+
+    The public Qwen3.5 DFlash draft repos use the newer transformers 5
+    ``rope_parameters.rope_theta`` config shape. Current ``dtree-mlx``
+    expects the older top-level ``rope_theta`` field, so the raw HF repo
+    fails at load time before generation starts. Materialize a small local
+    mirror with a patched config and symlinked weights, then pass that path
+    to ``dtree-mlx``.
+    """
+    path = _resolve_model_path(draft_model)
+    cfg_path = path / "config.json"
+    if not cfg_path.exists():
+        return draft_model
+    try:
+        cfg = json.loads(cfg_path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return draft_model
+
+    rope_parameters = cfg.get("rope_parameters")
+    if cfg.get("rope_theta") is not None or not isinstance(rope_parameters, dict):
+        return draft_model
+    rope_theta = rope_parameters.get("rope_theta")
+    if rope_theta is None:
+        return draft_model
+
+    patched_cfg = dict(cfg)
+    patched_cfg["rope_theta"] = rope_theta
+    if "rope_scaling" not in patched_cfg and "rope_scaling" in rope_parameters:
+        patched_cfg["rope_scaling"] = rope_parameters["rope_scaling"]
+
+    patched = _patched_draft_dir(path)
+    patched.mkdir(parents=True, exist_ok=True)
+    for child in path.iterdir():
+        dst = patched / child.name
+        if child.name == "config.json":
+            continue
+        target = child.resolve()
+        if dst.exists() or dst.is_symlink():
+            if dst.is_symlink() and Path(os.readlink(dst)) == target:
+                continue
+            if dst.is_dir() and not dst.is_symlink():
+                continue
+            dst.unlink()
+        dst.symlink_to(target, target_is_directory=target.is_dir())
+    (patched / "config.json").write_text(json.dumps(patched_cfg, indent=2) + "\n")
+    logger.info(
+        "DDTree: patched draft config for dtree-mlx compatibility: %s -> %s",
+        draft_model,
+        patched,
+    )
+    return str(patched)
+
+
+def _resolve_model_path(path_or_repo: str) -> Path:
+    path = Path(path_or_repo).expanduser()
+    if path.exists():
+        return path
+    from huggingface_hub import snapshot_download
+
+    return Path(snapshot_download(path_or_repo))
+
+
+def _patched_draft_dir(source: Path) -> Path:
+    import hashlib
+
+    root = Path(
+        os.environ.get(
+            "RAPID_MLX_DDTREE_PATCH_CACHE", "~/.cache/rapid-mlx/ddtree-drafts"
+        )
+    ).expanduser()
+    digest = hashlib.sha1(str(source.resolve()).encode("utf-8")).hexdigest()[:16]
+    return root / f"{source.name}-{digest}"


### PR DESCRIPTION
## Summary

Follow-up to #1005 after real 9B DDTree validation.

The public `z-lab/Qwen3.5-9B-DFlash` and `modal-labs/Qwen3.5-9B-DFlash` configs use the transformers 5 shape `rope_parameters.rope_theta`, while current `dtree-mlx` expects a top-level `rope_theta`. The merged DDTree alias therefore passed CLI/runtime availability gates but failed at actual load time.

This PR adds a narrow compatibility shim in the DDTree runtime boundary:

- resolves the draft HF snapshot before constructing `DFlashGenerator`
- when `config.json` lacks top-level `rope_theta` but has `rope_parameters.rope_theta`, creates a local patched draft mirror under `~/.cache/rapid-mlx/ddtree-drafts`
- symlinks the large draft weights instead of copying them
- passes the patched local path to `dtree-mlx`
- adds a regression test that verifies the config patch and symlink behavior

## Real Validation

Downloaded and cached:

- `mlx-community/Qwen3.5-9B-8bit` target: about 9.7 GiB
- `z-lab/Qwen3.5-9B-DFlash` draft: about 2.4 GiB

Runtime correctness:

- Direct `load_runtime(... drafter_repo='z-lab/Qwen3.5-9B-DFlash')` now auto-patches the draft config and generates `Four<|im_end|>` for `2+2`.
- Full HTTP E2E: `rapid-mlx serve qwen3.5-9b-8bit --enable-ddtree --host 127.0.0.1 --port 59999 --max-tokens 16`
  - `GET /healthz` returns `engine=ddtree`
  - `POST /v1/chat/completions` for `What is 2+2?` returns content `4`

Performance smoke, Apple Silicon local run, 3 prompts, max 96 tokens, same chat template as DDTree:

| prompt | AR tok/s | DFlash tok/s | DDTree tok/s | DFlash vs AR | DDTree vs AR | DDTree vs DFlash | DDTree accept | peak GB |
|---|---:|---:|---:|---:|---:|---:|---:|---:|
| colors | 50.7 | 62.0 | 47.1 | 1.22x | 0.93x | 0.76x | 8.40 | 12.29 |
| python | 40.7 | 148.1 | 49.5 | 3.64x | 1.22x | 0.33x | 12.83 | 12.30 |
| summary | 50.0 | 13.5 | 43.9 | 0.27x | 0.88x | 3.24x | 3.43 | 12.29 |

Conclusion: DDTree is correct enough for experimental opt-in, but this sample does **not** prove DDTree is a consistent perf win over plain AR. It is workload-sensitive and should remain non-default.

## Local Validation

- `uv run --with ruff --with 'transformers<5.13' ruff format --check vllm_mlx/speculative/ddtree tests/test_ddtree_eligibility.py tests/test_ddtree_integration.py`
- `uv run --with ruff --with 'transformers<5.13' ruff check vllm_mlx/speculative/ddtree tests/test_ddtree_eligibility.py tests/test_ddtree_integration.py`
- `uv run --with pytest --with 'transformers<5.13' python -m pytest -q tests/test_ddtree_eligibility.py tests/test_ddtree_integration.py` (14 passed)

Note: local runtime validation required `transformers<5.13`; `transformers 5.13.0` still trips the known `mlx_lm` `AutoTokenizer.register("NewlineTokenizer", ...)` crash.