### PR TITLE
feat(reasoning): translate OpenAI reasoning_effort at the route layer (#448)

### DIFF
--- a/tests/test_reasoning_effort_translation.py
+++ b/tests/test_reasoning_effort_translation.py
@@ -1,0 +1,387 @@
+# SPDX-License-Identifier: Apache-2.0
+"""#448 — route-layer translation of the OpenAI ``reasoning_effort`` knob.
+
+Before this fix the ``reasoning_effort`` field was declared + validated at
+the schema layer (garbage 400s at parse time) but ``accepted-but-not-yet-
+translated`` at the engine layer: a request with ``reasoning_effort="none"``
+still emitted reasoning tokens, blew ``max_tokens`` mid-``<think>``, and had
+``REASONING_CUTOFF_SENTINEL`` injected into ``content`` — corrupting the
+field an OpenAI-spec agent re-feeds verbatim into the next turn.
+
+``maybe_apply_reasoning_effort`` closes that gap:
+
+  * ``none`` → ``chat_template_kwargs.enable_thinking=False`` (suppress the
+    reasoning segment at the source, so the truncation scenario never
+    arises).
+  * ``minimal / low / medium / high`` → ``reasoning_max_tokens`` tier from
+    ``OPENAI_REASONING_EFFORT_TO_MAX_TOKENS``.
+
+The client's explicit, more-specific native knob (``enable_thinking`` /
+``reasoning_max_tokens``) always wins over the effort translation. Helper-
+level coverage runs on a ``SimpleNamespace`` shim so the gate is exercised
+in isolation from Pydantic; the typed-model tests confirm it works on real
+``ChatCompletionRequest`` / ``ResponsesRequest`` objects.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from vllm_mlx.api.models import (
+    OPENAI_REASONING_EFFORT_TO_MAX_TOKENS,
+    ChatCompletionRequest,
+)
+from vllm_mlx.api.responses_adapter import responses_to_openai
+from vllm_mlx.api.responses_models import ResponsesRequest
+from vllm_mlx.service.helpers import (
+    _client_signalled_reasoning_intent,
+    _extract_thinking_from_request,
+    _resolve_enable_thinking,
+    maybe_apply_reasoning_effort,
+    maybe_auto_disable_thinking_for_tools,
+)
+
+
+class TestReasoningIntentPredicate:
+    """The shared predicate both auto-disable gates consult."""
+
+    def test_none_of_the_signals(self):
+        assert _client_signalled_reasoning_intent(_shim()) is False
+
+    def test_reasoning_max_tokens_signal(self):
+        assert _client_signalled_reasoning_intent(_shim(reasoning_max_tokens=1)) is True
+
+    def test_reasoning_effort_signal(self):
+        assert _client_signalled_reasoning_intent(_shim(reasoning_effort="low")) is True
+
+    def test_native_responses_reasoning_effort_dict(self):
+        assert (
+            _client_signalled_reasoning_intent(
+                SimpleNamespace(reasoning={"effort": "low"})
+            )
+            is True
+        )
+
+    def test_native_responses_reasoning_null_effort_is_not_a_signal(self):
+        assert (
+            _client_signalled_reasoning_intent(
+                SimpleNamespace(reasoning={"effort": None, "summary": "auto"})
+            )
+            is False
+        )
+
+    def test_none_sources_are_skipped(self):
+        assert _client_signalled_reasoning_intent(None, _shim()) is False
+
+
+def _shim(**overrides):
+    """A request shim with the fields the helper reads, all defaulted to
+    the "client set nothing" state unless overridden."""
+    base = dict(
+        reasoning_effort=None,
+        reasoning_max_tokens=None,
+        chat_template_kwargs=None,
+        enable_thinking=None,
+        tools=None,
+    )
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+# ---------------------------------------------------------------------------
+# (0) The mapping table
+# ---------------------------------------------------------------------------
+
+
+class TestMappingTable:
+    def test_none_absent_from_cap_table(self):
+        """``none`` maps to enable_thinking=False, NOT a cap, so it must
+        not appear in the graded cap table."""
+        assert "none" not in OPENAI_REASONING_EFFORT_TO_MAX_TOKENS
+
+    def test_graded_tiers_are_monotonic(self):
+        m = OPENAI_REASONING_EFFORT_TO_MAX_TOKENS
+        assert m["minimal"] < m["low"] < m["medium"] < m["high"]
+
+    def test_graded_tiers_reuse_anthropic_magnitudes(self):
+        """low/medium/high reuse the Anthropic surface's tiers so the same
+        effort name yields the same budget across API dialects."""
+        from vllm_mlx.api.anthropic_models import (
+            ANTHROPIC_EFFORT_TO_REASONING_MAX_TOKENS,
+        )
+
+        for tier in ("low", "medium", "high"):
+            assert (
+                OPENAI_REASONING_EFFORT_TO_MAX_TOKENS[tier]
+                == ANTHROPIC_EFFORT_TO_REASONING_MAX_TOKENS[tier]
+            )
+
+
+# ---------------------------------------------------------------------------
+# (1) Helper: unset / no-op
+# ---------------------------------------------------------------------------
+
+
+class TestHelperNoOp:
+    def test_unset_effort_is_noop(self):
+        req = _shim()
+        assert maybe_apply_reasoning_effort(req) is False
+        assert req.chat_template_kwargs is None
+        assert req.reasoning_max_tokens is None
+
+    def test_empty_string_effort_is_noop(self):
+        # ``""`` is not a valid effort (schema would 400) but the helper
+        # must be defensive — a falsy value is treated as unset.
+        req = _shim(reasoning_effort="")
+        assert maybe_apply_reasoning_effort(req) is False
+        assert req.chat_template_kwargs is None
+
+
+# ---------------------------------------------------------------------------
+# (2) Helper: reasoning_effort="none" → enable_thinking=False
+# ---------------------------------------------------------------------------
+
+
+class TestHelperNoneSuppressesThinking:
+    def test_none_injects_enable_thinking_false(self):
+        req = _shim(reasoning_effort="none")
+        assert maybe_apply_reasoning_effort(req) is True
+        assert req.chat_template_kwargs == {"enable_thinking": False}
+        # Resolving thinking now returns False — the load-bearing #448 fix.
+        assert _resolve_enable_thinking(req) is False
+
+    def test_none_marks_auto_disabled_to_suppress_warning(self):
+        """The flag is server-injected (client set reasoning_effort, not
+        chat_template_kwargs.enable_thinking), so the L-05 warning header
+        must be suppressed via ``_auto_disabled_thinking``."""
+        req = _shim(reasoning_effort="none")
+        maybe_apply_reasoning_effort(req)
+        assert getattr(req, "_auto_disabled_thinking", False) is True
+
+    def test_none_merge_is_non_destructive(self):
+        req = _shim(
+            reasoning_effort="none",
+            chat_template_kwargs={"custom_forward_compat_key": 7},
+        )
+        assert maybe_apply_reasoning_effort(req) is True
+        assert req.chat_template_kwargs["custom_forward_compat_key"] == 7
+        assert req.chat_template_kwargs["enable_thinking"] is False
+
+    def test_none_yields_to_explicit_top_level_enable_thinking(self):
+        """Explicit ``enable_thinking=True`` alongside reasoning_effort=none
+        is contradictory; the more-specific native field wins."""
+        req = _shim(reasoning_effort="none", enable_thinking=True)
+        assert maybe_apply_reasoning_effort(req) is False
+        assert req.enable_thinking is True
+        assert req.chat_template_kwargs is None
+
+    def test_none_yields_to_explicit_kwarg_enable_thinking(self):
+        req = _shim(
+            reasoning_effort="none",
+            chat_template_kwargs={"enable_thinking": True},
+        )
+        assert maybe_apply_reasoning_effort(req) is False
+        assert req.chat_template_kwargs == {"enable_thinking": True}
+
+    def test_none_does_not_yield_to_reasoning_max_tokens_cap(self):
+        """``none`` controls the on/off dimension; a cap is orthogonal.
+        thinking-off makes the cap moot, so ``none`` still suppresses."""
+        req = _shim(reasoning_effort="none", reasoning_max_tokens=64)
+        assert maybe_apply_reasoning_effort(req) is True
+        assert req.chat_template_kwargs == {"enable_thinking": False}
+        assert req.reasoning_max_tokens == 64  # left as-is (moot)
+
+
+# ---------------------------------------------------------------------------
+# (3) Helper: graded effort → reasoning_max_tokens tier
+# ---------------------------------------------------------------------------
+
+
+class TestHelperGradedTiers:
+    @pytest.mark.parametrize("effort", ["minimal", "low", "medium", "high"])
+    def test_graded_sets_reasoning_max_tokens_only(self, effort):
+        """A graded effort caps reasoning via ``reasoning_max_tokens`` and
+        does NOT touch ``enable_thinking`` — it is itself a reasoning-intent
+        signal that the auto-disable gates step aside for (see
+        TestToolAutoDisableStepsAsideForReasoning)."""
+        req = _shim(reasoning_effort=effort)
+        assert maybe_apply_reasoning_effort(req) is True
+        assert req.reasoning_max_tokens == OPENAI_REASONING_EFFORT_TO_MAX_TOKENS[effort]
+        assert req.chat_template_kwargs is None
+        assert _extract_thinking_from_request(req) is None
+        assert getattr(req, "_auto_disabled_thinking", False) is False
+
+    @pytest.mark.parametrize("effort", ["minimal", "low", "medium", "high"])
+    def test_graded_yields_to_explicit_reasoning_max_tokens(self, effort):
+        """An explicit client cap wins over the tier."""
+        req = _shim(reasoning_effort=effort, reasoning_max_tokens=99)
+        assert maybe_apply_reasoning_effort(req) is False
+        assert req.reasoning_max_tokens == 99
+        assert req.chat_template_kwargs is None
+
+    @pytest.mark.parametrize("effort", ["minimal", "low", "medium", "high"])
+    def test_graded_with_explicit_thinking_false_still_caps(self, effort):
+        """``enable_thinking=False`` + a graded effort is not contradictory
+        the way ``none`` is — the client wants a bounded think budget IF the
+        model thinks. The cap still applies; enable_thinking is untouched."""
+        req = _shim(reasoning_effort=effort, enable_thinking=False)
+        assert maybe_apply_reasoning_effort(req) is True
+        assert req.reasoning_max_tokens == OPENAI_REASONING_EFFORT_TO_MAX_TOKENS[effort]
+        assert req.enable_thinking is False
+        assert req.chat_template_kwargs is None
+
+
+# ---------------------------------------------------------------------------
+# (4) Ordering contract vs the tool auto-disable
+# ---------------------------------------------------------------------------
+
+
+class TestOrderingWithToolAutoDisable:
+    def test_none_before_tool_autodisable_no_ops_the_latter(self):
+        """The route runs ``maybe_apply_reasoning_effort`` BEFORE the tool
+        auto-disable. After ``none`` registers enable_thinking=False, the
+        tool auto-disable sees a preference and no-ops — one resolved
+        source of truth."""
+        req = _shim(reasoning_effort="none", tools=[{"type": "function"}])
+        assert maybe_apply_reasoning_effort(req) is True
+        # Preference is now set, so the tool auto-disable is a no-op.
+        assert maybe_auto_disable_thinking_for_tools(req) is False
+        assert _resolve_enable_thinking(req) is False
+
+    def test_graded_high_with_tools_not_forced_off(self):
+        """codex #1009 r1 MAJOR: ``reasoning_effort="high"`` + tools must NOT
+        be silently turned off by the tool auto-disable. The graded path
+        sets the reasoning_max_tokens cap (a reasoning-intent signal), so
+        the tool auto-disable steps aside and enable_thinking is NOT forced
+        to False — the model keeps its template-default reasoning, bounded
+        by the cap."""
+        req = _shim(reasoning_effort="high", tools=[{"type": "function"}])
+        assert maybe_apply_reasoning_effort(req) is True
+        assert maybe_auto_disable_thinking_for_tools(req) is False
+        # not clobbered to False — stays template default (None here)
+        assert _extract_thinking_from_request(req) is None
+        assert req.reasoning_max_tokens == OPENAI_REASONING_EFFORT_TO_MAX_TOKENS["high"]
+
+
+class TestToolAutoDisableStepsAsideForReasoning:
+    """codex #1009 r1 MAJOR — the tool auto-disable must treat a raw
+    reasoning-intent signal as a preference and step aside, symmetric with
+    the casual-chat gate, even when ``maybe_apply_reasoning_effort`` has not
+    run yet (defensive: the signal alone is enough)."""
+
+    def test_tools_plus_raw_reasoning_effort_steps_aside(self):
+        req = _shim(reasoning_effort="high", tools=[{"type": "function"}])
+        assert maybe_auto_disable_thinking_for_tools(req) is False
+        assert _extract_thinking_from_request(req) is None
+
+    def test_tools_plus_raw_reasoning_max_tokens_steps_aside(self):
+        req = _shim(reasoning_max_tokens=64, tools=[{"type": "function"}])
+        assert maybe_auto_disable_thinking_for_tools(req) is False
+
+    def test_tools_without_reasoning_signal_still_auto_disables(self):
+        """No-regression: plain tools + no reasoning signal + no thinking
+        preference still auto-disables (the original R12-T1F contract)."""
+        req = _shim(tools=[{"type": "function"}])
+        assert maybe_auto_disable_thinking_for_tools(req) is True
+        assert req.chat_template_kwargs == {"enable_thinking": False}
+
+
+# ---------------------------------------------------------------------------
+# (5) Typed models — field declared + helper works on real objects
+# ---------------------------------------------------------------------------
+
+
+class TestTypedModels:
+    def test_chat_request_none_resolves_thinking_false(self):
+        req = ChatCompletionRequest(
+            model="m",
+            messages=[{"role": "user", "content": "hi"}],
+            reasoning_effort="none",
+        )
+        assert maybe_apply_reasoning_effort(req) is True
+        assert _resolve_enable_thinking(req) is False
+
+    def test_chat_request_high_sets_cap(self):
+        req = ChatCompletionRequest(
+            model="m",
+            messages=[{"role": "user", "content": "hi"}],
+            reasoning_effort="high",
+        )
+        assert maybe_apply_reasoning_effort(req) is True
+        assert req.reasoning_max_tokens == OPENAI_REASONING_EFFORT_TO_MAX_TOKENS["high"]
+
+    def test_chat_request_garbage_effort_400s_at_schema(self):
+        """The schema layer stays the hard surface — garbage never reaches
+        the translation helper."""
+        with pytest.raises(ValueError):
+            ChatCompletionRequest(
+                model="m",
+                messages=[{"role": "user", "content": "hi"}],
+                reasoning_effort="hgih",
+            )
+
+    def test_responses_request_none_resolves_thinking_false(self):
+        req = ResponsesRequest(
+            model="m",
+            input="hi",
+            reasoning_effort="none",
+        )
+        assert maybe_apply_reasoning_effort(req) is True
+        assert _resolve_enable_thinking(req) is False
+
+
+class TestResponsesAdapterForwardsEffort:
+    """codex #1009 r2 MAJOR — ``responses_to_openai`` dropped
+    ``reasoning_effort`` / native ``reasoning.effort`` so the route-layer
+    translation silently no-op'd on /v1/responses. The adapter now collapses
+    both surfaces onto the materialized ChatCompletionRequest's
+    ``reasoning_effort`` field so ``maybe_apply_reasoning_effort`` fires."""
+
+    def test_top_level_reasoning_effort_forwarded(self):
+        oai = responses_to_openai(
+            ResponsesRequest(model="m", input="hi", reasoning_effort="none")
+        )
+        assert oai.reasoning_effort == "none"
+        # and the translation now works end-to-end on the materialized req
+        assert maybe_apply_reasoning_effort(oai) is True
+        assert _resolve_enable_thinking(oai) is False
+
+    def test_native_reasoning_effort_dict_forwarded(self):
+        oai = responses_to_openai(
+            ResponsesRequest(model="m", input="hi", reasoning={"effort": "high"})
+        )
+        assert oai.reasoning_effort == "high"
+        assert maybe_apply_reasoning_effort(oai) is True
+        assert oai.reasoning_max_tokens == OPENAI_REASONING_EFFORT_TO_MAX_TOKENS["high"]
+
+    def test_top_level_wins_over_nested(self):
+        oai = responses_to_openai(
+            ResponsesRequest(
+                model="m",
+                input="hi",
+                reasoning_effort="low",
+                reasoning={"effort": "high"},
+            )
+        )
+        assert oai.reasoning_effort == "low"
+
+    def test_null_nested_effort_is_not_forwarded(self):
+        oai = responses_to_openai(
+            ResponsesRequest(
+                model="m", input="hi", reasoning={"effort": None, "summary": "auto"}
+            )
+        )
+        assert oai.reasoning_effort is None
+
+    def test_strict_json_branch_sees_reasoning_intent_after_forward(self):
+        """codex #1009 r3 MAJOR — the /v1/responses strict-json auto-disable
+        guards on ``_client_signalled_reasoning_intent(openai_request)``.
+        Because the adapter forwards effort onto the materialized request,
+        that predicate is True for a strict-json + graded-effort request, so
+        the branch steps aside instead of force-disabling thinking."""
+        oai = responses_to_openai(
+            ResponsesRequest(model="m", input="hi", reasoning={"effort": "high"})
+        )
+        assert _client_signalled_reasoning_intent(oai) is True

--- a/vllm_mlx/api/models.py
+++ b/vllm_mlx/api/models.py
@@ -489,6 +489,23 @@ _VALID_REASONING_EFFORTS: tuple[str, ...] = (
     "high",
 )
 
+#: Route-layer translation of the graded OpenAI ``reasoning_effort`` values
+#: into a concrete ``reasoning_max_tokens`` cap, applied by
+#: ``service.helpers.maybe_apply_reasoning_effort`` (issue #448). ``none`` is
+#: intentionally absent — it maps to ``enable_thinking=False`` (suppress the
+#: ``<think>`` segment entirely), NOT to a cap. The graded magnitudes reuse
+#: the Anthropic surface's ``ANTHROPIC_EFFORT_TO_REASONING_MAX_TOKENS`` tiers
+#: (low=512, medium=2048, high=8192) so the same effort name yields the same
+#: reasoning budget regardless of which API dialect it arrived on; ``minimal``
+#: (OpenAI-only, gpt-5 era) sits one tier below ``low``. Module-scoped so
+#: tests import + assert against the same table the helper uses.
+OPENAI_REASONING_EFFORT_TO_MAX_TOKENS: dict[str, int] = {
+    "minimal": 256,
+    "low": 512,
+    "medium": 2048,
+    "high": 8192,
+}
+
 
 def _validate_reasoning_effort(v):
     """Pin ``reasoning_effort`` to the OpenAI-spec closed set.
@@ -1576,11 +1593,15 @@ class ChatCompletionRequest(BaseModel):
     # Validated against ``_VALID_REASONING_EFFORTS`` via the
     # ``_validate_reasoning_effort_field`` validator below so int / list
     # / null / case-variant / garbage strings produce a clean 400.
-    # Today the value is accepted-but-not-yet-translated at the engine
-    # layer (a follow-up wires ``"none"`` through to ``enable_thinking
-    # =False`` and ``low/medium/high`` to ``reasoning_max_tokens``
-    # tiers); the schema-layer validation is the hard surface so SDK
-    # clients see the contract round-trip.
+    # The value is translated at the route layer by
+    # ``service.helpers.maybe_apply_reasoning_effort`` (issue #448):
+    # ``"none"`` → ``chat_template_kwargs.enable_thinking=False`` (suppress
+    # the ``<think>`` segment) and ``minimal/low/medium/high`` →
+    # ``reasoning_max_tokens`` via ``OPENAI_REASONING_EFFORT_TO_MAX_TOKENS``.
+    # An explicit ``enable_thinking`` / ``reasoning_max_tokens`` the client
+    # already set always wins over the effort translation. The schema-layer
+    # validation stays the hard surface so SDK clients see the contract
+    # round-trip even for surfaces that do not run the translation.
     reasoning_effort: str | None = None
     # Number of completions (only n=1 supported). F-155: the route used
     # to reject ``n > 1`` only, so ``n=0`` / ``n=-1`` slipped through

--- a/vllm_mlx/api/responses_adapter.py
+++ b/vllm_mlx/api/responses_adapter.py
@@ -301,6 +301,32 @@ def _submitted_tool_names(tools: list[dict] | None) -> set[str]:
     return names
 
 
+def _resolve_reasoning_effort(request: ResponsesRequest) -> str | None:
+    """Collapse the two Responses-spec effort surfaces into the single
+    chat-shape ``reasoning_effort`` string that
+    ``service.helpers.maybe_apply_reasoning_effort`` reads (#448).
+
+    Precedence (first wins):
+      1. top-level ``reasoning_effort`` (chat-completions shape some SDKs
+         reuse on this surface — closed-set validated at the schema layer).
+      2. native ``reasoning={"effort": ...}`` dict (the canonical Responses
+         shape). Only a non-null string counts; ``{"effort": null}`` /
+         ``{"summary": "auto"}`` carry no effort signal.
+      3. ``None`` — no effort signalled.
+
+    Both surfaces already passed the ResponsesRequest ``_validate_reasoning_
+    effort_*`` validators, so no re-validation is needed here.
+    """
+    if request.reasoning_effort is not None:
+        return request.reasoning_effort
+    reasoning = request.reasoning
+    if isinstance(reasoning, dict):
+        effort = reasoning.get("effort")
+        if isinstance(effort, str) and effort:
+            return effort
+    return None
+
+
 def responses_to_openai(request: ResponsesRequest) -> ChatCompletionRequest:
     """
     Convert a Responses-API request to an OpenAI Chat Completions request.
@@ -388,6 +414,15 @@ def responses_to_openai(request: ResponsesRequest) -> ChatCompletionRequest:
         # path used by /v1/chat/completions and /v1/messages applies on
         # /v1/responses (upstream vLLM PR #20859 backport).
         reasoning_max_tokens=request.reasoning_max_tokens,
+        # #448 — forward ``reasoning_effort`` so the route-layer
+        # ``maybe_apply_reasoning_effort`` translation fires on
+        # /v1/responses too. The Responses spec expresses effort two
+        # ways (top-level ``reasoning_effort`` OR nested
+        # ``reasoning={"effort": ...}``); ``_resolve_reasoning_effort``
+        # collapses them to the single chat-shape field the helper reads.
+        # Without this the materialized ChatCompletionRequest carried
+        # None and the translation silently no-op'd on this surface.
+        reasoning_effort=_resolve_reasoning_effort(request),
         # H-11: forward the per-request seed so the Responses surface
         # honours determinism the same way /v1/chat/completions does.
         # Without this, the seed declared on ResponsesRequest would

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -96,6 +96,7 @@ from ..service.helpers import (
     enable_thinking_warning_header,
     enforce_context_length_for_messages,
     get_engine,
+    maybe_apply_reasoning_effort,
     maybe_auto_disable_thinking_for_casual_chat,
     maybe_auto_disable_thinking_for_tools,
     repair_messages_fit_context,
@@ -1927,6 +1928,20 @@ async def _create_chat_completion_impl(
             )
         if json_instruction:
             messages = _inject_json_instruction(messages, json_instruction)
+
+    # #448 — translate the OpenAI ``reasoning_effort`` knob into rapid-mlx's
+    # native controls. MUST run BEFORE the tool auto-disable below so a
+    # ``reasoning_effort="none"`` request registers its enable_thinking
+    # preference first (the tool auto-disable then no-ops on it) and a
+    # graded value lands its ``reasoning_max_tokens`` cap from one source.
+    if maybe_apply_reasoning_effort(request):
+        logger.info(
+            "#448 reasoning_effort=%s translated on /v1/chat/completions "
+            "(none→enable_thinking=False; minimal/low/medium/high→"
+            "reasoning_max_tokens tier). Explicit client enable_thinking / "
+            "reasoning_max_tokens always wins.",
+            request.reasoning_effort,
+        )
 
     # R12-T1F (0.8.16 operator dogfood) — auto-disable thinking when
     # ``tools`` is non-empty and the client did NOT pin a thinking

--- a/vllm_mlx/routes/responses.py
+++ b/vllm_mlx/routes/responses.py
@@ -81,6 +81,7 @@ from ..service.helpers import (
     _apply_reasoning_cutoff_notice,
     _build_usage,
     _check_admission_or_503,
+    _client_signalled_reasoning_intent,
     _disconnect_guard,
     _effective_enable_thinking,
     _extract_thinking_from_request,
@@ -96,6 +97,7 @@ from ..service.helpers import (
     build_extended_sampling_kwargs,
     enforce_context_length_for_messages,
     get_engine,
+    maybe_apply_reasoning_effort,
     maybe_auto_disable_thinking_for_casual_chat,
     maybe_auto_disable_thinking_for_tools,
     repair_messages_fit_context,
@@ -534,7 +536,18 @@ async def create_response(request: Request):
             # below, ``engine.chat`` / ``generate_with_schema``,
             # ``_finalize_content_and_reasoning``) sees the same
             # resolved choice.
-            if _extract_thinking_from_request(openai_request) is None:
+            # #448 codex #1009 r3 MAJOR: also step aside when the client
+            # signalled explicit reasoning intent (reasoning_effort /
+            # reasoning_max_tokens / native reasoning.effort — all collapsed
+            # onto ``openai_request`` by the adapter). Symmetric with the
+            # tool + casual gates: a client asking for reasoning has opted
+            # into the budget risk, and the ``reasoning_max_tokens`` cap
+            # keeps it bounded. Without this, a strict-json request with
+            # ``reasoning_effort="high"`` got thinking force-disabled before
+            # ``maybe_apply_reasoning_effort`` set its (now-moot) cap.
+            if _extract_thinking_from_request(
+                openai_request
+            ) is None and not _client_signalled_reasoning_intent(openai_request):
                 existing_ctk = openai_request.chat_template_kwargs or {}
                 # Merge rather than replace so any non-thinking keys
                 # the client passed survive (forward-compat).
@@ -560,6 +573,21 @@ async def create_response(request: Request):
                     "inside <think>. Set chat_template_kwargs."
                     "enable_thinking=true to opt back in."
                 )
+
+        # #448 — translate the OpenAI ``reasoning_effort`` knob into
+        # rapid-mlx's native controls. MUST run BEFORE the tool auto-
+        # disable below so a ``reasoning_effort="none"`` request registers
+        # its enable_thinking preference first (the tool auto-disable then
+        # no-ops on it) and a graded value lands its reasoning_max_tokens
+        # cap from one source. Explicit client knobs always win.
+        if maybe_apply_reasoning_effort(openai_request):
+            logger.info(
+                "#448 reasoning_effort=%s translated on /v1/responses "
+                "(none→enable_thinking=False; minimal/low/medium/high→"
+                "reasoning_max_tokens tier). Explicit client enable_thinking "
+                "/ reasoning_max_tokens always wins.",
+                openai_request.reasoning_effort,
+            )
 
         # R12-T1F (0.8.16 operator dogfood) — auto-disable thinking
         # when ``tools`` is non-empty and the client did NOT pin a

--- a/vllm_mlx/service/helpers.py
+++ b/vllm_mlx/service/helpers.py
@@ -36,6 +36,7 @@ from ..api.constants import (  # noqa: F401
     RESCUE_TAIL_LENGTH,
 )
 from ..api.models import (
+    OPENAI_REASONING_EFFORT_TO_MAX_TOKENS,
     CompletionTokensDetails,
     FunctionCall,
     PromptTokensDetails,
@@ -1823,6 +1824,14 @@ def maybe_auto_disable_thinking_for_tools(request) -> bool:
         return False
     if _extract_thinking_from_request(request) is not None:
         return False
+    # Explicit reasoning intent (``reasoning_effort`` / ``reasoning_max_tokens``
+    # / native ``reasoning={"effort": ...}``) is a client "I want reasoning"
+    # signal — symmetric with the casual-chat gate. Forcing thinking off here
+    # would make ``reasoning_effort="high"`` a no-op on tool calls (codex
+    # #1009 r1 MAJOR); the request's own ``reasoning_max_tokens`` cap keeps
+    # the tool-call token budget bounded, so keep the model's reasoning.
+    if _client_signalled_reasoning_intent(request):
+        return False
     existing_ctk = getattr(request, "chat_template_kwargs", None) or {}
     # Merge rather than replace so any non-thinking keys the client
     # passed (forward-compat, e.g. future kwargs the chat template
@@ -1834,6 +1843,123 @@ def maybe_auto_disable_thinking_for_tools(request) -> bool:
     # ``enable_thinking_warning_header`` does NOT fire spuriously on
     # non-qwen3 parsers — the server injected the flag, not the client.
     _mark_thinking_auto_disabled(request)
+    return True
+
+
+def _client_signalled_reasoning_intent(*sources) -> bool:
+    """True iff any source carries an explicit reasoning-intent signal:
+    ``reasoning_max_tokens``, top-level ``reasoning_effort``, or the native
+    Responses ``reasoning={"effort": <non-null>}`` dict.
+
+    Single source of truth shared by the tool + casual-chat auto-disable
+    gates so "the client asked for reasoning" is detected identically across
+    surfaces. ``getattr`` with default ``None`` keeps it tolerant of shapes
+    that don't declare every field (SimpleNamespace shims, future surfaces).
+    ``None`` sources are skipped so callers can splat an optional
+    ``extra_signals`` without a guard.
+    """
+    for src in sources:
+        if src is None:
+            continue
+        if getattr(src, "reasoning_max_tokens", None) is not None:
+            return True
+        if getattr(src, "reasoning_effort", None) is not None:
+            return True
+        # ``reasoning`` is the native Responses-API shape. Gate on a
+        # NON-NULL ``effort`` only: ``reasoning={"effort": null}`` and
+        # ``reasoning={"summary": "auto"}`` are not reasoning-intent signals
+        # (codex r1 MEDIUM #3 on the casual gate). Defensive isinstance so a
+        # malformed payload that survived schema validation cannot crash.
+        reasoning = getattr(src, "reasoning", None)
+        if isinstance(reasoning, dict) and reasoning.get("effort") is not None:
+            return True
+    return False
+
+
+def maybe_apply_reasoning_effort(request) -> bool:
+    """Translate the OpenAI ``reasoning_effort`` knob into rapid-mlx's
+    native reasoning controls at the route layer (issue #448).
+
+    The schema layer (``_validate_reasoning_effort_field`` on
+    ``ChatCompletionRequest`` / ``ResponsesRequest``) only *validates*
+    ``reasoning_effort`` against the OpenAI-spec closed set
+    (``none / minimal / low / medium / high``) — it deliberately does NOT
+    translate, so garbage 400s at parse time without the schema depending
+    on engine internals. This helper is that translation, run once per
+    request from the chat / responses routes:
+
+      * ``reasoning_effort="none"`` → merge
+        ``chat_template_kwargs={"enable_thinking": False}`` so a hybrid-
+        thinking model (qwen3, glm4, deepseek_r1, …) stops emitting a
+        ``<think>`` segment. This is the load-bearing fix for #448: an
+        agent built against the OpenAI spec that passed
+        ``reasoning_effort="none"`` for concise answers previously got
+        reasoning anyway, blew ``max_tokens`` mid-think, and had
+        ``REASONING_CUTOFF_SENTINEL`` injected into ``content`` — corrupting
+        the field it re-feeds verbatim into the next turn. Suppressing the
+        reasoning at the source means the truncation scenario never arises.
+      * ``reasoning_effort in {minimal, low, medium, high}`` → set
+        ``request.reasoning_max_tokens`` to the matching tier from
+        ``OPENAI_REASONING_EFFORT_TO_MAX_TOKENS`` (a subtractive cap on how
+        long the model may think before answering).
+
+    Precedence — for each path the client's explicit, more-specific native
+    knob on the SAME dimension wins (mirrors
+    ``maybe_auto_disable_thinking_for_tools``):
+
+      * ``none`` controls the on/off dimension, so it yields to an explicit
+        ``enable_thinking`` preference (top-level field or
+        ``chat_template_kwargs``) — ``enable_thinking=true`` alongside
+        ``reasoning_effort="none"`` is contradictory and the native field
+        wins. A ``reasoning_max_tokens`` cap is orthogonal to ``none``:
+        thinking-off makes the cap moot, so ``none`` still applies (it does
+        NOT yield to a cap).
+      * the graded path controls the budget dimension, so it yields to an
+        explicit ``reasoning_max_tokens`` cap and does not touch
+        ``enable_thinking``.
+
+    MUST run BEFORE ``maybe_auto_disable_thinking_for_tools`` so a
+    ``reasoning_effort="none"`` request registers its ``enable_thinking``
+    preference first and the tool auto-disable then no-ops on it — one
+    resolved source of truth for the engine kwarg.
+
+    Returns ``True`` iff a translation was applied (for the route's
+    structured log line); ``False`` when ``reasoning_effort`` is unset or
+    the client's explicit knob took precedence.
+    """
+    effort = getattr(request, "reasoning_effort", None)
+    if not effort:
+        return False
+
+    if effort == "none":
+        # Only inject when the client did not pin thinking explicitly —
+        # the native ``enable_thinking`` field/kwarg wins a conflict.
+        if _extract_thinking_from_request(request) is not None:
+            return False
+        ctk = getattr(request, "chat_template_kwargs", None)
+        merged_ctk = dict(ctk) if isinstance(ctk, dict) else {}
+        merged_ctk["enable_thinking"] = False
+        request.chat_template_kwargs = merged_ctk
+        # The flag was server-injected (client set ``reasoning_effort``,
+        # not ``chat_template_kwargs.enable_thinking``), so suppress the
+        # L-05 warning header the same way the auto-disable family does.
+        _mark_thinking_auto_disabled(request)
+        return True
+
+    # Graded effort (minimal/low/medium/high) → ``reasoning_max_tokens``
+    # tier (a subtractive cap on how long the model may think), unless the
+    # client already set an explicit cap (which wins). Graded effort does
+    # NOT force ``enable_thinking`` on — it is itself a reasoning-intent
+    # signal that the tool / casual-chat auto-disable gates recognize (via
+    # ``_client_signalled_reasoning_intent``) and step aside for, so a
+    # thinking-capable model keeps its template-default reasoning instead
+    # of being silently turned off on tool calls (codex #1009 r1 MAJOR).
+    if getattr(request, "reasoning_max_tokens", None) is not None:
+        return False
+    cap = OPENAI_REASONING_EFFORT_TO_MAX_TOKENS.get(effort)
+    if cap is None:
+        return False
+    request.reasoning_max_tokens = cap
     return True
 
 
@@ -1980,31 +2106,17 @@ def maybe_auto_disable_thinking_for_casual_chat(request, *, extra_signals=None) 
     # ``reasoning={"effort":"low"}`` on the ResponsesRequest
     # short-circuits the gate even though the field never gets
     # forwarded onto the materialized ChatCompletionRequest.
-    sources = [request]
-    if extra_signals is not None and extra_signals is not request:
-        sources.append(extra_signals)
-    for src in sources:
-        if getattr(src, "reasoning_max_tokens", None) is not None:
-            return False
-        if getattr(src, "reasoning_effort", None) is not None:
-            return False
-        # ``reasoning`` is the native Responses-API shape
-        # (``{"effort": "low|medium|high", ...}``). Codex r1 MEDIUM #3:
-        # gate specifically on a NON-NULL ``effort`` rather than "any
-        # non-empty dict". The Responses spec allows
-        # ``reasoning={"effort": null}`` (the schema's
-        # ``_validate_reasoning_dict_effort`` explicitly lets ``None``
-        # through) and ``reasoning={"summary": "auto"}`` (summary is a
-        # SDK convenience flag, NOT a reasoning-intent signal). Pre-fix
-        # both shapes were treated as opt-in and skipped the auto-
-        # disable, leaving the default-thinking-ON budget-burn intact.
-        # Now only an explicit non-null ``effort`` counts as
-        # "client wants reasoning". Defensive ``isinstance(dict)`` so a
-        # malformed payload that survived schema validation does not
-        # silently lose the gate.
-        reasoning = getattr(src, "reasoning", None)
-        if isinstance(reasoning, dict) and reasoning.get("effort") is not None:
-            return False
+    # Explicit reasoning intent through any of the documented signals
+    # (``reasoning_max_tokens`` / top-level ``reasoning_effort`` / native
+    # ``reasoning={"effort": <non-null>}``). ``extra_signals`` (the optional
+    # secondary request shape) is consulted for the SAME field set so a
+    # /v1/responses caller that pinned ``reasoning={"effort":"low"}`` on the
+    # ResponsesRequest short-circuits the gate even though the field never
+    # gets forwarded onto the materialized ChatCompletionRequest. Detection
+    # is shared with the tool gate via ``_client_signalled_reasoning_intent``
+    # so both surfaces agree on what "client wants reasoning" means.
+    if _client_signalled_reasoning_intent(request, extra_signals):
+        return False
     existing_ctk = getattr(request, "chat_template_kwargs", None) or {}
     # Merge rather than replace so any non-thinking keys the client
     # passed (forward-compat, e.g. future kwargs the chat template


### PR DESCRIPTION
## Why

`reasoning_effort` was declared + validated at the schema layer (garbage 400s at parse time) but the code path was explicitly commented `accepted-but-not-yet-translated at the engine layer` — the documented follow-up was never wired. An agent built against the OpenAI spec that passed `reasoning_effort="none"` for concise answers still got reasoning tokens, blew `max_tokens` mid-`<think>`, and had `REASONING_CUTOFF_SENTINEL` injected into `delta.content` — corrupting the field it re-feeds verbatim into the next turn. This is issue #448 (v0.8.14 dogfood Persona 2 Alex).

## What

New `maybe_apply_reasoning_effort(request)` (`service/helpers.py`), called from `/v1/chat/completions` and `/v1/responses` **before** the tool auto-disable so there is one resolved source of truth for the engine kwargs:

- `reasoning_effort="none"` → merge `chat_template_kwargs.enable_thinking=False` so hybrid-thinking models stop emitting a `<think>` segment. Suppressing reasoning at the source means the mid-think truncation scenario never arises — the clean fix rather than papering over the sentinel.
- `minimal/low/medium/high` → `reasoning_max_tokens` tier from the new `OPENAI_REASONING_EFFORT_TO_MAX_TOKENS` table, reusing the Anthropic surface's low/medium/high magnitudes (512/2048/8192) for cross-dialect parity; `minimal` = 256.

**Precedence:** the client's explicit native knob (`enable_thinking` / `reasoning_max_tokens`) always wins over the effort translation, mirroring `maybe_auto_disable_thinking_for_tools`. The `none` path marks the request `_auto_disabled_thinking` so the L-05 warning header does not fire on a server-injected flag.

## Scope note — #448 part 1 (sentinel-in-content) intentionally NOT flipped

The truncation sentinel landing in `content` by default is a deliberate product decision: #858 reverted the opt-in default *because* every GUI client (rapid-desktop, vanilla OpenAI SDK, OpenWebUI) renders only `message.content` and ignores `finish_reason`, so default-off shows an empty bubble. Flipping it would regress that surface. The escape hatch for strict agent callers already exists (`RAPID_MLX_REASONING_CUTOFF_NOTICE=disabled` + the `is_rescue_payload()` classifier). Honoring `reasoning_effort="none"` is the non-regressive resolution: a spec-compliant agent asking for no reasoning no longer hits the truncation path at all.

## Tests

`tests/test_reasoning_effort_translation.py` (23 cases): mapping table parity with the Anthropic tiers, `none`→`enable_thinking=False`, graded→cap, explicit-knob precedence, non-destructive merge, ordering vs the tool auto-disable, and typed `ChatCompletionRequest` / `ResponsesRequest` integration. Adjacent suites (`test_tools_auto_disable_thinking`, `test_casual_chat_auto_disable_thinking`, `test_r10_scrub_validation_bundle`) green (132).

Addresses machinefi/rapid-desktop#448 (sidecar half). The desktop issue is closed when v0.8.21 bundles this engine — issue tracks the user surface, PR routes to where the code lives.