### PR TITLE
[codex] re-land validated experimental ddtree support

### DIFF
--- a/README.md
+++ b/README.md
@@ -773,7 +773,7 @@ Run your own: `bash evals/run_all_models.sh` runs the full quality suite (tool c
 <details>
 <summary><strong>Speculative decoding — DFlash, DDTree, MTP, SuffixDecoding</strong></summary>
 
-Three drafters ship in-tree. All are **opt-in** per alias — `rapid-mlx info <alias>` shows what's eligible on the model you're serving.
+Rapid-MLX ships in-tree speculative modes plus an experimental external DDTree integration. All are **opt-in** per alias — `rapid-mlx info <alias>` shows what's eligible on the model you're serving.
 
 **DFlash** — block-diffusion drafter (via mlx-vlm), single-user path. Opt in with `--enable-dflash`; requires `pip install 'rapid-mlx[dflash]'`.
 

--- a/README.md
+++ b/README.md
@@ -723,6 +723,7 @@ Qwen3.5 uses Gated DeltaNet (75% RNN) + full attention (25% KV). Other engines r
 | **TurboQuant K8V4 codec** | K 8-bit + V 4-bit after Walsh-Hadamard + Lloyd-Max (~1/2.4 compression, lossless across verified matrix) | Default-on for 9 verified Qwen3.5/3.6 aliases; `--kv-cache-turboquant k8v4\|v4\|none` |
 | **KV cache quantization** | Quantize prefix cache entries to reduce memory | All models with `--kv-cache-quantization` |
 | **DFlash speculative decoding** | Block-diffusion drafter, parallel draft + verify (single-user) | `qwen3.5-27b-8bit`, `qwen3.6-27b-8bit` with `--enable-dflash` |
+| **DDTree speculative decoding** | DFlash draft-tree verification over multiple branches | `qwen3.5-9b-8bit` (experimental, single-user) |
 | **MTP speculative decoding** | Multi-token prediction head shipped with the model | MTP-trained checkpoints with `--enable-mtp` |
 | **SuffixDecoding** | Drafter-free, statistical n-gram lookup speculative decoding | All BatchedEngine models with `--suffix-decoding` |
 | **Prefill chunking** | Configurable step size for large-prompt throughput | All models |
@@ -763,14 +764,14 @@ Run your own: `bash evals/run_all_models.sh` runs the full quality suite (tool c
 | **TurboQuant K8V4 KV codec** | K is 8-bit + V is 4-bit after Walsh-Hadamard rotation + Lloyd-Max quantization — compresses KV to ~1/2.4 (~58% savings), lossless across the verified matrix. **Default-on for 9 verified Qwen3.5/3.6 aliases** (see below); `--kv-cache-turboquant none` to force off. |
 | **Smart cloud routing** | Large-context requests auto-route to a cloud LLM (`--cloud-model openai/gpt-5 --cloud-threshold 20000`) when local prefill would be slow. |
 | **Multimodal** | Vision, audio (STT/TTS with bundled Silero VAD silence pre-trim), video understanding, text embeddings — all through the standard OpenAI endpoints. |
-| **Speculative decoding** | DFlash (block-diffusion drafter, `--enable-dflash`), MTP (multi-token prediction head, `--enable-mtp`), SuffixDecoding (drafter-free n-gram, `--suffix-decoding`). `--speculative-config` is the vLLM-style frontend reserved for backend migration. Opt-in per alias — see below. |
+| **Speculative decoding** | DFlash (block-diffusion drafter, `--enable-dflash`), DDTree (DFlash draft tree, vLLM-style `--speculative-config '{"method":"ddtree"}'`), MTP (multi-token prediction head, `--enable-mtp`), SuffixDecoding (drafter-free n-gram, `--suffix-decoding`). Opt-in per alias — see below. |
 | **Structured output, logprobs, continuous batching, KV quantization** | Standard, no flags or with one flag each. |
 | **3300+ tests** | Across reasoning, tool parsing, streaming, agent harnesses, and engine integration. |
 
 **K8V4 default-on aliases** (9 as of 0.9.9): `qwen3.5-9b-4bit`, `qwen3.5-9b-8bit`, `qwen3.5-27b-4bit`, `qwen3.5-27b-8bit`, `qwen3.5-35b-6bit`, `qwen3.6-35b-4bit`, `qwen3.6-35b-6bit`, `qwen3.6-35b-8bit`, `qwen3.6-35b-dwq`. Radix prefix cache is independent and saves additional bytes proportional to inter-request prefix overlap — the two are orthogonal.
 
 <details>
-<summary><strong>Speculative decoding — DFlash, MTP, SuffixDecoding</strong></summary>
+<summary><strong>Speculative decoding — DFlash, DDTree, MTP, SuffixDecoding</strong></summary>
 
 Three drafters ship in-tree. All are **opt-in** per alias — `rapid-mlx info <alias>` shows what's eligible on the model you're serving.
 
@@ -792,6 +793,23 @@ Workload sensitivity: coding / math / summarization typically see **1.5–2.7×*
 **MTP** (Multi-Token Prediction) — draft head baked into the model. Opt in with `--enable-mtp` on MTP-trained checkpoints. Auto-tune of `--mtp-num-draft-tokens` per workload is roadmapped for the 0.9.1x line.
 
 **SuffixDecoding** — drafter-free, statistical n-gram lookup over the running suffix. Opt in with `--suffix-decoding`; works on any BatchedEngine alias.
+
+**DDTree** (experimental) — builds a tree from one DFlash draft pass, then verifies multiple likely continuations. The first rapid-mlx integration is intentionally opt-in and single-user, using the external `dtree-mlx` runtime:
+
+```bash
+pip install 'dtree-mlx @ git+https://github.com/DrHB/dtree-mlx.git'
+rapid-mlx info qwen3.5-9b-8bit
+rapid-mlx serve qwen3.5-9b-8bit --speculative-config '{"method":"ddtree"}'
+```
+
+MVP limitations mirror DFlash mode: no continuous batching, tools, MCP, embeddings, logprobs, or structured output. The alias records the experimental draft model candidate and defaults (`z-lab/Qwen3.5-9B-DFlash`, 16 speculative tokens, tree budget 24), but DDTree never turns on unless explicitly requested. Advanced users can override the drafter and DDTree knobs with the vLLM-style surface:
+
+```bash
+rapid-mlx serve qwen3.5-9b-8bit \
+  --speculative-config '{"method":"ddtree","model":"z-lab/Qwen3.5-9B-DFlash","num_speculative_tokens":16,"tree_budget":24}'
+```
+
+`--enable-ddtree` remains as a compatibility shorthand for `--speculative-config '{"method":"ddtree"}'`; it is not enabled by default. MTP, DFlash, and SuffixDecoding keep their existing flags until they migrate behind the same config interface.
 
 Mutex: DFlash cannot combine with MTP or SuffixDecoding (single-user path). MTP and SuffixDecoding cannot combine with each other (both consume the drafter slot).
 
@@ -831,7 +849,8 @@ Mutex: DFlash cannot combine with MTP or SuffixDecoding (single-user path). MTP 
 | `--prefix-cache-index` | Prefix-cache lookup index: `radix` (default) or `hash` | `radix` |
 | `--pflash` | PFlash sparse prefill: `auto` / `always` / `off` | `auto` (on for verified aliases) |
 | `--enable-dflash` | DFlash speculative decoding (single-user; `qwen3.5-27b-8bit` / `qwen3.6-27b-8bit`) | off |
-| `--speculative-config` | vLLM-style speculative decoding JSON frontend; existing backends keep legacy flags until migrated | off |
+| `--speculative-config` | vLLM-style speculative decoding JSON config; DDTree MVP supports `{"method":"ddtree"}` | off |
+| `--enable-ddtree` | Compatibility shorthand for DDTree speculative decoding (single-user; `qwen3.5-9b-8bit`) | off |
 | `--suffix-decoding` | Drafter-free n-gram speculative decoding (BatchedEngine path) | off |
 | `--enable-mtp` | MTP head speculative decoding (requires MTP-trained model) | off |
 | `--gpu-memory-utilization` | Fraction of device memory to use (0.0-1.0) | `0.90` |
@@ -1035,6 +1054,7 @@ harness/                 # Regression baselines + thresholds
 | Technique | Expected Gain | Status |
 |-----------|---------------|--------|
 | [DFlash](https://arxiv.org/abs/2602.06036) — block-diffusion drafter, single-user | 1.3–2× decode (workload-dependent) | Shipping, opt-in (`--enable-dflash`, `[dflash]` extra; qwen3.5-27b-8bit, qwen3.6-27b-8bit) |
+| [DDTree](https://arxiv.org/abs/2604.12989) — DFlash draft-tree verification, single-user | TBD on rapid-mlx 9B gate | Experimental (`--enable-ddtree`) |
 | [SuffixDecoding](https://arxiv.org/abs/2411.04975) — drafter-free n-gram speculative | 1.1–1.5× decode | Shipping (`--suffix-decoding`, per-model tier sweep ongoing) |
 | MTP — Multi-Token Prediction head | 1.4–1.7× decode | Shipping, opt-in (`--enable-mtp`, MTP-trained checkpoints); per-workload auto-tune of `--mtp-num-draft-tokens` landing in the 0.9.1x line |
 | [EAGLE-3](https://arxiv.org/abs/2503.01840) — feature-level draft on Metal | 3–6.5× decode | Not started |

--- a/README.md
+++ b/README.md
@@ -1054,7 +1054,7 @@ harness/                 # Regression baselines + thresholds
 | Technique | Expected Gain | Status |
 |-----------|---------------|--------|
 | [DFlash](https://arxiv.org/abs/2602.06036) — block-diffusion drafter, single-user | 1.3–2× decode (workload-dependent) | Shipping, opt-in (`--enable-dflash`, `[dflash]` extra; qwen3.5-27b-8bit, qwen3.6-27b-8bit) |
-| [DDTree](https://arxiv.org/abs/2604.12989) — DFlash draft-tree verification, single-user | TBD on rapid-mlx 9B gate | Experimental (`--enable-ddtree`) |
+| [DDTree](https://arxiv.org/abs/2604.12989) — DFlash draft-tree verification, single-user | TBD on rapid-mlx 9B gate | Experimental (`--speculative-config '{"method":"ddtree"}'`; `--enable-ddtree` compatibility shorthand) |
 | [SuffixDecoding](https://arxiv.org/abs/2411.04975) — drafter-free n-gram speculative | 1.1–1.5× decode | Shipping (`--suffix-decoding`, per-model tier sweep ongoing) |
 | MTP — Multi-Token Prediction head | 1.4–1.7× decode | Shipping, opt-in (`--enable-mtp`, MTP-trained checkpoints); per-workload auto-tune of `--mtp-num-draft-tokens` landing in the 0.9.1x line |
 | [EAGLE-3](https://arxiv.org/abs/2503.01840) — feature-level draft on Metal | 3–6.5× decode | Not started |

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -89,6 +89,9 @@ rapid-mlx serve devstral-24b-4bit --enable-auto-tool-choice --tool-call-parser h
 # DFlash speculative decoding (single-user, single supported alias)
 rapid-mlx serve qwen3.5-27b-8bit --enable-dflash --port 8000
 
+# DDTree speculative decoding (experimental, single-user)
+rapid-mlx serve qwen3.5-9b-8bit --enable-ddtree --port 8000
+
 # API key authentication
 rapid-mlx serve qwen3.5-9b-4bit --api-key your-secret-key
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -90,7 +90,7 @@ rapid-mlx serve devstral-24b-4bit --enable-auto-tool-choice --tool-call-parser h
 rapid-mlx serve qwen3.5-27b-8bit --enable-dflash --port 8000
 
 # DDTree speculative decoding (experimental, single-user)
-rapid-mlx serve qwen3.5-9b-8bit --enable-ddtree --port 8000
+rapid-mlx serve qwen3.5-9b-8bit --speculative-config '{"method":"ddtree"}' --port 8000
 
 # API key authentication
 rapid-mlx serve qwen3.5-9b-4bit --api-key your-secret-key

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.10.0"
+version = "0.10.1"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/tests/test_aliases_contract.py
+++ b/tests/test_aliases_contract.py
@@ -59,6 +59,10 @@ ALLOWED_PROFILE_KEYS: frozenset[str] = frozenset(
         "suffix_bench_speedup",
         "supports_dflash",
         "dflash_draft_model",
+        "supports_ddtree",
+        "ddtree_draft_model",
+        "ddtree_speculative_tokens",
+        "ddtree_tree_budget",
         "recommended_sampling",
         "pflash_tier",
         "turboquant_tier",
@@ -508,6 +512,75 @@ def test_negative_control_dflash_missing_drafter_is_caught() -> None:
         _coerce(
             "fake-alias",
             {"hf_path": "fake/Model", "supports_dflash": True},
+        )
+
+
+# =============================================================================
+# DDTree speculative-decoding contract (issue #879)
+# =============================================================================
+
+
+@pytest.mark.parametrize("alias", _alias_ids())
+def test_ddtree_requires_drafter_and_params(alias: str) -> None:
+    profile = list_profiles()[alias]
+    if profile.supports_ddtree:
+        assert profile.ddtree_draft_model, (
+            f"{alias}: supports_ddtree=True but ddtree_draft_model is empty"
+        )
+        assert "/" in profile.ddtree_draft_model, (
+            f"{alias}: ddtree_draft_model={profile.ddtree_draft_model!r} "
+            f"must be 'org/repo' format"
+        )
+        assert profile.ddtree_speculative_tokens is not None, (
+            f"{alias}: supports_ddtree=True but ddtree_speculative_tokens is empty"
+        )
+        assert profile.ddtree_tree_budget is not None, (
+            f"{alias}: supports_ddtree=True but ddtree_tree_budget is empty"
+        )
+
+
+@pytest.mark.parametrize("alias", _alias_ids())
+def test_ddtree_excludes_moe_architectures(alias: str) -> None:
+    profile = list_profiles()[alias]
+    if profile.is_moe:
+        assert not profile.supports_ddtree, (
+            f"{alias}: is_moe=True but supports_ddtree=True — DDTree verifier "
+            "support is not validated on MoE aliases."
+        )
+
+
+@pytest.mark.parametrize("alias", _alias_ids())
+def test_ddtree_excludes_4bit_precision_until_benched(alias: str) -> None:
+    profile = list_profiles()[alias]
+    if not profile.supports_ddtree:
+        return
+    hf_lc = profile.hf_path.lower()
+    is_4bit = "-4bit" in hf_lc or "mxfp4" in hf_lc or "nvfp4" in hf_lc
+    assert not is_4bit, (
+        f"{alias}: supports_ddtree=True but hf_path={profile.hf_path!r} "
+        "looks like a 4-bit quantized variant. Bench and update the gate "
+        "before enabling DDTree on 4-bit."
+    )
+
+
+def test_ddtree_eligible_aliases_have_dflash_drafter() -> None:
+    for alias, profile in list_profiles().items():
+        if not profile.supports_ddtree:
+            continue
+        d = profile.ddtree_draft_model or ""
+        assert d.startswith("z-lab/") and re.search(r"(?:^|-)DFlash(?:$|-)", d), (
+            f"{alias}: ddtree_draft_model={d!r} must point at a z-lab "
+            "DFlash drafter unless the DDTree runtime contract changes."
+        )
+
+
+def test_negative_control_ddtree_missing_drafter_is_caught() -> None:
+    from vllm_mlx.model_aliases import _coerce
+
+    with pytest.raises(ValueError, match="ddtree_draft_model"):
+        _coerce(
+            "fake-alias",
+            {"hf_path": "fake/Model", "supports_ddtree": True},
         )
 
 

--- a/tests/test_ddtree_eligibility.py
+++ b/tests/test_ddtree_eligibility.py
@@ -1,0 +1,94 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for ``vllm_mlx/speculative/ddtree/eligibility.py``."""
+
+from __future__ import annotations
+
+import pytest
+
+from vllm_mlx.model_aliases import AliasProfile
+from vllm_mlx.speculative.ddtree.eligibility import (
+    DDTreeUnavailable,
+    check,
+    report,
+)
+
+
+def _good_profile() -> AliasProfile:
+    return AliasProfile(
+        hf_path="mlx-community/Qwen3.5-9B-8bit",
+        is_moe=False,
+        supports_ddtree=True,
+        ddtree_draft_model="z-lab/Qwen3.5-9B-DFlash",
+        ddtree_speculative_tokens=16,
+        ddtree_tree_budget=24,
+    )
+
+
+def test_check_passes_for_good_profile() -> None:
+    p = _good_profile()
+    check(p, alias="qwen3.5-9b-8bit")
+    assert report(p, alias="qwen3.5-9b-8bit").reasons == ()
+
+
+def test_check_rejects_alias_without_supports_ddtree() -> None:
+    p = AliasProfile(hf_path="mlx-community/Qwen3.5-9B-8bit")
+    with pytest.raises(DDTreeUnavailable, match="not DDTree-enabled"):
+        check(p, alias="qwen3.5-9b-8bit")
+
+
+def test_check_rejects_moe_alias() -> None:
+    p = AliasProfile(
+        hf_path="mlx-community/Qwen3.6-35B-A3B-8bit",
+        is_moe=True,
+        supports_ddtree=True,
+        ddtree_draft_model="z-lab/Qwen3.6-35B-A3B-DFlash",
+        ddtree_speculative_tokens=16,
+        ddtree_tree_budget=24,
+    )
+    with pytest.raises(DDTreeUnavailable, match="MoE"):
+        check(p, alias="qwen3.6-35b-8bit")
+
+
+def test_check_rejects_4bit_main_model() -> None:
+    p = AliasProfile(
+        hf_path="mlx-community/Qwen3.5-9B-4bit",
+        supports_ddtree=True,
+        ddtree_draft_model="z-lab/Qwen3.5-9B-DFlash",
+        ddtree_speculative_tokens=16,
+        ddtree_tree_budget=24,
+    )
+    with pytest.raises(DDTreeUnavailable, match="4-bit"):
+        check(p, alias="qwen3.5-9b-4bit")
+
+
+def test_report_collects_all_failures() -> None:
+    bad = AliasProfile(
+        hf_path="mlx-community/Qwen3.6-35B-A3B-4bit",
+        is_moe=True,
+        supports_ddtree=True,
+    )
+    r = report(bad, alias="qwen3.6-35b-4bit")
+    joined = " ".join(r.reasons)
+    assert "MoE" in joined
+    assert "4-bit" in joined
+    assert "ddtree_draft_model" in joined
+    assert "ddtree_speculative_tokens" in joined
+    assert "ddtree_tree_budget" in joined
+
+
+def test_qwen3_5_9b_8bit_alias_passes_check() -> None:
+    from vllm_mlx.model_aliases import resolve_profile
+
+    profile = resolve_profile("qwen3.5-9b-8bit")
+    assert profile is not None, "qwen3.5-9b-8bit alias missing"
+    check(profile, alias="qwen3.5-9b-8bit")
+
+
+def test_qwen3_5_9b_4bit_alias_fails_with_4bit_reason() -> None:
+    from vllm_mlx.model_aliases import resolve_profile
+
+    profile = resolve_profile("qwen3.5-9b-4bit")
+    assert profile is not None
+    with pytest.raises(DDTreeUnavailable) as excinfo:
+        check(profile, alias="qwen3.5-9b-4bit")
+    assert "4-bit" in str(excinfo.value)

--- a/tests/test_ddtree_eligibility.py
+++ b/tests/test_ddtree_eligibility.py
@@ -128,3 +128,66 @@ def test_runtime_patches_rope_parameters_without_copying_weights(
     weight = patched_path / "model.safetensors"
     assert weight.is_symlink()
     assert weight.resolve() == (source / "model.safetensors").resolve()
+
+
+def test_runtime_patches_qwen35_split_prefill() -> None:
+    import mlx.core as mx
+
+    from vllm_mlx.speculative.ddtree import runtime
+
+    class Cache:
+        offset = 0
+        keys = None
+        values = None
+
+        def __init__(self):
+            self.items = [None, None]
+
+        def __getitem__(self, idx):
+            return self.items[idx]
+
+    class Target:
+        adapter = type("Adapter", (), {"family": "qwen3_5"})()
+
+        def __init__(self):
+            self.calls = []
+
+        def forward_with_hidden_states(
+            self, inputs, cache, layer_ids, return_rollback_records=False
+        ):
+            del cache, layer_ids
+            self.calls.append((inputs.tolist(), return_rollback_records))
+            seq_len = int(inputs.shape[1])
+            logits = mx.zeros((1, seq_len, 3))
+            hidden = mx.ones((1, seq_len, 2)) * seq_len
+            return logits, hidden
+
+    target = Target()
+    generator = type("Generator", (), {"target": target})()
+    cache = [Cache()]
+
+    runtime._install_qwen35_split_prefill_patch(generator)
+    logits, hidden = target.forward_with_hidden_states(
+        mx.array([[1, 2, 3]], dtype=mx.uint32),
+        cache,
+        [0],
+    )
+
+    assert target._rapid_mlx_split_prefill_patch is True
+    assert target.calls == [([[1, 2]], False), ([[3]], False)]
+    assert logits.shape == (1, 1, 3)
+    assert hidden.tolist() == [[[2, 2], [2, 2], [1, 1]]]
+
+    target.calls.clear()
+    cache[0].offset = 1
+    target.forward_with_hidden_states(mx.array([[4, 5]], dtype=mx.uint32), cache, [0])
+    assert target.calls == [([[4, 5]], False)]
+
+    target.calls.clear()
+    target.forward_with_hidden_states(
+        mx.array([[6, 7]], dtype=mx.uint32),
+        [Cache()],
+        [0],
+        return_rollback_records=True,
+    )
+    assert target.calls == [([[6, 7]], True)]

--- a/tests/test_ddtree_eligibility.py
+++ b/tests/test_ddtree_eligibility.py
@@ -130,6 +130,39 @@ def test_runtime_patches_rope_parameters_without_copying_weights(
     assert weight.resolve() == (source / "model.safetensors").resolve()
 
 
+def test_runtime_replaces_stale_ddtree_patch_dir(tmp_path, monkeypatch) -> None:
+    from vllm_mlx.speculative.ddtree import runtime
+
+    source = tmp_path / "source"
+    source.mkdir()
+    (source / "config.json").write_text(
+        """
+        {
+          "model_type": "qwen3",
+          "rope_parameters": {
+            "rope_theta": 10000000,
+            "rope_type": "default"
+          }
+        }
+        """
+    )
+    (source / "model.safetensors").write_bytes(b"fake")
+    cache = tmp_path / "patched"
+    monkeypatch.setenv("RAPID_MLX_DDTREE_PATCH_CACHE", str(cache))
+    stale = runtime._patched_draft_dir(source)
+    stale.mkdir(parents=True)
+    (stale / "model.safetensors").mkdir()
+
+    patched = runtime._prepare_draft_model_for_dtree(str(source))
+    patched_path = Path(patched)
+
+    assert patched_path == stale
+    assert (patched_path / "model.safetensors").is_symlink()
+    assert (patched_path / "model.safetensors").resolve() == (
+        source / "model.safetensors"
+    ).resolve()
+
+
 def test_runtime_patches_qwen35_split_prefill() -> None:
     import mlx.core as mx
 

--- a/tests/test_ddtree_eligibility.py
+++ b/tests/test_ddtree_eligibility.py
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 from vllm_mlx.model_aliases import AliasProfile
@@ -92,3 +94,37 @@ def test_qwen3_5_9b_4bit_alias_fails_with_4bit_reason() -> None:
     with pytest.raises(DDTreeUnavailable) as excinfo:
         check(profile, alias="qwen3.5-9b-4bit")
     assert "4-bit" in str(excinfo.value)
+
+
+def test_runtime_patches_rope_parameters_without_copying_weights(
+    tmp_path, monkeypatch
+) -> None:
+    from vllm_mlx.speculative.ddtree import runtime
+
+    source = tmp_path / "source"
+    source.mkdir()
+    (source / "config.json").write_text(
+        """
+        {
+          "model_type": "qwen3",
+          "rope_parameters": {
+            "rope_theta": 10000000,
+            "rope_type": "default"
+          }
+        }
+        """
+    )
+    (source / "model.safetensors").write_bytes(b"fake")
+    cache = tmp_path / "patched"
+    monkeypatch.setenv("RAPID_MLX_DDTREE_PATCH_CACHE", str(cache))
+
+    patched = runtime._prepare_draft_model_for_dtree(str(source))
+    patched_path = Path(patched)
+
+    assert patched_path != source
+    patched_cfg = patched_path / "config.json"
+    assert patched_cfg.exists()
+    assert '"rope_theta": 10000000' in patched_cfg.read_text()
+    weight = patched_path / "model.safetensors"
+    assert weight.is_symlink()
+    assert weight.resolve() == (source / "model.safetensors").resolve()

--- a/tests/test_ddtree_eligibility.py
+++ b/tests/test_ddtree_eligibility.py
@@ -163,6 +163,20 @@ def test_runtime_replaces_stale_ddtree_patch_dir(tmp_path, monkeypatch) -> None:
     ).resolve()
 
 
+def test_eligible_aliases_surfaces_alias_registry_errors(monkeypatch) -> None:
+    import pytest
+
+    from vllm_mlx.speculative.ddtree import eligibility
+
+    def boom():
+        raise RuntimeError("alias registry broken")
+
+    monkeypatch.setattr("vllm_mlx.model_aliases.list_profiles", boom)
+
+    with pytest.raises(RuntimeError, match="alias registry broken"):
+        eligibility.eligible_aliases()
+
+
 def test_runtime_patches_qwen35_split_prefill() -> None:
     import mlx.core as mx
 

--- a/tests/test_ddtree_eligibility.py
+++ b/tests/test_ddtree_eligibility.py
@@ -163,6 +163,43 @@ def test_runtime_replaces_stale_ddtree_patch_dir(tmp_path, monkeypatch) -> None:
     ).resolve()
 
 
+def test_runtime_cleans_temp_patch_dir_on_write_failure(tmp_path, monkeypatch) -> None:
+    import pytest
+
+    from vllm_mlx.speculative.ddtree import runtime
+
+    source = tmp_path / "source"
+    source.mkdir()
+    (source / "config.json").write_text(
+        """
+        {
+          "model_type": "qwen3",
+          "rope_parameters": {
+            "rope_theta": 10000000,
+            "rope_type": "default"
+          }
+        }
+        """
+    )
+    (source / "model.safetensors").write_bytes(b"fake")
+    cache = tmp_path / "patched"
+    monkeypatch.setenv("RAPID_MLX_DDTREE_PATCH_CACHE", str(cache))
+
+    original_write_text = Path.write_text
+
+    def fail_config_write(path, *args, **kwargs):
+        if path.name == "config.json" and path.parent.name.startswith("."):
+            raise OSError("disk full")
+        return original_write_text(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "write_text", fail_config_write)
+
+    with pytest.raises(OSError, match="disk full"):
+        runtime._prepare_draft_model_for_dtree(str(source))
+
+    assert not list(cache.glob(".*.tmp-*"))
+
+
 def test_eligible_aliases_surfaces_alias_registry_errors(monkeypatch) -> None:
     import pytest
 

--- a/tests/test_ddtree_eligibility.py
+++ b/tests/test_ddtree_eligibility.py
@@ -156,11 +156,12 @@ def test_runtime_replaces_stale_ddtree_patch_dir(tmp_path, monkeypatch) -> None:
     patched = runtime._prepare_draft_model_for_dtree(str(source))
     patched_path = Path(patched)
 
-    assert patched_path == stale
+    assert patched_path != stale
     assert (patched_path / "model.safetensors").is_symlink()
     assert (patched_path / "model.safetensors").resolve() == (
         source / "model.safetensors"
     ).resolve()
+    assert (stale / "model.safetensors").is_dir()
 
 
 def test_runtime_cleans_temp_patch_dir_on_write_failure(tmp_path, monkeypatch) -> None:

--- a/tests/test_ddtree_integration.py
+++ b/tests/test_ddtree_integration.py
@@ -1,0 +1,301 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Integration-style tests for the DDTree MVP plumbing."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+
+def test_serve_parser_exposes_enable_ddtree() -> None:
+    import subprocess
+    import sys
+
+    out = subprocess.run(
+        [sys.executable, "-m", "vllm_mlx.cli", "serve", "--help"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert out.returncode == 0, out.stderr
+    assert "--enable-ddtree" in out.stdout
+    assert "--speculative-config" in out.stdout
+    assert "dtree-mlx" in out.stdout
+
+
+def _ddtree_cli_args(**overrides):
+    data = {
+        "model": "qwen3.5-9b-8bit",
+        "_original_alias": None,
+        "speculative_config": None,
+        "enable_ddtree": False,
+        "enable_dflash": False,
+        "spec_decode": "none",
+        "suffix_decoding": False,
+        "enable_mtp": False,
+        "no_spec_decode": False,
+    }
+    data.update(overrides)
+    return SimpleNamespace(**data)
+
+
+def test_speculative_config_ddtree_preflight_uses_config_overrides(
+    monkeypatch,
+) -> None:
+    from vllm_mlx.cli import (
+        _normalize_speculative_config_or_exit,
+        _preflight_ddtree_or_exit,
+    )
+
+    monkeypatch.setattr(
+        "vllm_mlx.speculative.ddtree.eligibility.have_runtime",
+        lambda: True,
+    )
+    args = _ddtree_cli_args(
+        speculative_config=(
+            '{"method":"ddtree","model":"local/draft",'
+            '"num_speculative_tokens":8,"tree_budget":12}'
+        )
+    )
+
+    _normalize_speculative_config_or_exit(args)
+    assert args.enable_ddtree is True
+    alias, profile = _preflight_ddtree_or_exit(args)
+
+    assert alias == "qwen3.5-9b-8bit"
+    assert profile.supports_ddtree is True
+    assert args._ddtree_drafter_repo == "local/draft"
+    assert args._ddtree_speculative_tokens == 8
+    assert args._ddtree_tree_budget == 12
+
+
+def test_speculative_config_ddtree_preflight_falls_back_to_alias_defaults(
+    monkeypatch,
+) -> None:
+    from vllm_mlx.cli import (
+        _normalize_speculative_config_or_exit,
+        _preflight_ddtree_or_exit,
+    )
+
+    monkeypatch.setattr(
+        "vllm_mlx.speculative.ddtree.eligibility.have_runtime",
+        lambda: True,
+    )
+    args = _ddtree_cli_args(speculative_config='{"method":"ddtree"}')
+
+    _normalize_speculative_config_or_exit(args)
+    _preflight_ddtree_or_exit(args)
+
+    assert args._ddtree_drafter_repo == "z-lab/Qwen3.5-9B-DFlash"
+    assert args._ddtree_speculative_tokens == 16
+    assert args._ddtree_tree_budget == 24
+
+
+def test_enable_ddtree_legacy_flag_is_speculative_config_shorthand(
+    monkeypatch,
+) -> None:
+    from vllm_mlx.cli import (
+        _normalize_speculative_config_or_exit,
+        _preflight_ddtree_or_exit,
+    )
+
+    monkeypatch.setattr(
+        "vllm_mlx.speculative.ddtree.eligibility.have_runtime",
+        lambda: True,
+    )
+    args = _ddtree_cli_args(enable_ddtree=True)
+
+    _normalize_speculative_config_or_exit(args)
+    _preflight_ddtree_or_exit(args)
+
+    assert args._speculative_config.method == "ddtree"
+    assert args._ddtree_drafter_repo == "z-lab/Qwen3.5-9B-DFlash"
+
+
+def test_enable_ddtree_conflicts_with_explicit_speculative_config(capsys) -> None:
+    import pytest
+
+    from vllm_mlx.cli import _normalize_speculative_config_or_exit
+
+    args = _ddtree_cli_args(
+        enable_ddtree=True,
+        speculative_config='{"method":"ddtree"}',
+    )
+
+    with pytest.raises(SystemExit) as excinfo:
+        _normalize_speculative_config_or_exit(args)
+
+    assert excinfo.value.code == 2
+    captured = capsys.readouterr()
+    assert "mutually exclusive" in captured.err
+
+
+def test_info_renders_ddtree_block_for_eligible_alias(capsys, monkeypatch) -> None:
+    from vllm_mlx.cli import info_command
+
+    monkeypatch.setattr(
+        "vllm_mlx.speculative.ddtree.eligibility.have_runtime",
+        lambda: True,
+    )
+    args = type("Args", (), {"model": "qwen3.5-9b-8bit"})()
+    info_command(args)
+    captured = capsys.readouterr()
+    assert "DDTree eligibility" in captured.out
+    assert "Declared support" in captured.out
+    assert "z-lab/Qwen3.5-9B-DFlash" in captured.out
+    assert "Spec tokens" in captured.out
+    assert "Tree budget" in captured.out
+    assert (
+        'rapid-mlx serve qwen3.5-9b-8bit --speculative-config \'{"method":"ddtree"}\''
+        in captured.out
+    )
+
+
+def test_info_ddtree_marks_4bit_alias_ineligible(capsys) -> None:
+    from vllm_mlx.cli import info_command
+
+    args = type("Args", (), {"model": "qwen3.5-9b-4bit"})()
+    info_command(args)
+    captured = capsys.readouterr()
+    assert "DDTree eligibility" in captured.out
+    assert "ineligible" in captured.out
+    assert "4-bit" in captured.out
+
+
+def test_models_listing_renders_ddtree_column(capsys) -> None:
+    from vllm_mlx.cli import models_command
+
+    models_command(None)
+    captured = capsys.readouterr()
+    assert "DDTree" in captured.out
+    lines = captured.out.splitlines()
+    eligible_row = next(
+        (line for line in lines if "qwen3.5-9b-8bit " in line),
+        None,
+    )
+    assert eligible_row is not None
+    assert "✓" in eligible_row, f"DDTree column should be ✓: {eligible_row!r}"
+    ineligible_row = next(
+        (line for line in lines if "qwen3.5-9b-4bit " in line),
+        None,
+    )
+    assert ineligible_row is not None
+    assert "—" in ineligible_row, f"DDTree column should be —: {ineligible_row!r}"
+
+
+@dataclass
+class _FakeResult:
+    text: str = "four"
+    generated_tokens: list[int] | None = None
+    metrics: dict | None = None
+
+    def __post_init__(self) -> None:
+        if self.generated_tokens is None:
+            self.generated_tokens = [1, 2]
+        if self.metrics is None:
+            self.metrics = {"num_input_tokens": 5}
+
+
+def _fake_runtime():
+    from vllm_mlx.speculative.ddtree.runtime import DDTreeRuntime
+
+    tokenizer = MagicMock()
+    tokenizer.apply_chat_template.return_value = "user: 2+2?\nassistant:"
+    tokenizer.encode.return_value = [10, 11, 12]
+    target = MagicMock()
+    target.tokenizer = tokenizer
+    generator = MagicMock()
+    generator.target = target
+    generator.generate_from_tokens.return_value = _FakeResult()
+    return DDTreeRuntime(
+        generator=generator,
+        main_model_repo="mlx-community/Qwen3.5-9B-8bit",
+        drafter_repo="z-lab/Qwen3.5-9B-DFlash",
+        speculative_tokens=16,
+        tree_budget=24,
+    )
+
+
+def test_build_app_healthz_models_and_completion() -> None:
+    from fastapi.testclient import TestClient
+
+    from vllm_mlx.speculative.ddtree.server import _build_app
+
+    runtime = _fake_runtime()
+    app = _build_app(
+        runtime=runtime,
+        served_model_name="qwen3.5-9b-8bit",
+        default_max_tokens=64,
+        cors_origins=["*"],
+    )
+    client = TestClient(app)
+
+    r = client.get("/healthz")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["engine"] == "ddtree"
+    assert body["drafter"] == "z-lab/Qwen3.5-9B-DFlash"
+    assert body["tree_budget"] == 24
+
+    r = client.get("/v1/models")
+    assert r.status_code == 200
+    assert r.json()["data"][0]["id"] == "qwen3.5-9b-8bit"
+
+    r = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "qwen3.5-9b-8bit",
+            "messages": [{"role": "user", "content": "2+2?"}],
+            "max_tokens": 16,
+            "temperature": 0,
+        },
+    )
+    assert r.status_code == 200
+    payload = r.json()
+    assert payload["choices"][0]["message"]["content"] == "four"
+    assert payload["usage"]["prompt_tokens"] == 5
+    assert payload["usage"]["completion_tokens"] == 2
+    runtime.generator.generate.assert_not_called()
+    runtime.generator.generate_from_tokens.assert_called_once()
+    call = runtime.generator.generate_from_tokens.call_args
+    assert call.kwargs["prompt_tokens"].tolist() == [10, 11, 12]
+    assert call.kwargs["skip_special_tokens"] is True
+
+
+def test_chat_completions_rejects_unsupported_ddtree_params() -> None:
+    from fastapi.testclient import TestClient
+
+    from vllm_mlx.speculative.ddtree.server import _build_app
+
+    app = _build_app(
+        runtime=_fake_runtime(),
+        served_model_name="qwen3.5-9b-8bit",
+        default_max_tokens=64,
+        cors_origins=["*"],
+    )
+    client = TestClient(app)
+
+    r = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "qwen3.5-9b-8bit",
+            "messages": [{"role": "user", "content": "hi"}],
+            "tools": [
+                {"type": "function", "function": {"name": "x", "parameters": {}}}
+            ],
+        },
+    )
+    assert r.status_code == 400
+    assert "tool calling" in r.json()["error"]["message"].lower()
+
+    r = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "qwen3.5-9b-8bit",
+            "messages": [{"role": "user", "content": "hi"}],
+            "top_p": 0.9,
+        },
+    )
+    assert r.status_code == 400
+    assert "top_p" in r.json()["error"]["message"]

--- a/tests/test_ddtree_integration.py
+++ b/tests/test_ddtree_integration.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import concurrent.futures
 from dataclasses import dataclass
 from types import SimpleNamespace
 from unittest.mock import MagicMock
@@ -263,6 +264,46 @@ def test_build_app_healthz_models_and_completion() -> None:
     assert call.kwargs["skip_special_tokens"] is True
 
 
+def test_build_app_healthz_works_while_runtime_loads() -> None:
+    from fastapi.testclient import TestClient
+
+    from vllm_mlx.speculative.ddtree.server import _build_app
+
+    future: concurrent.futures.Future = concurrent.futures.Future()
+    app = _build_app(
+        runtime_future=future,
+        served_model_name="qwen3.5-9b-8bit",
+        default_max_tokens=64,
+        cors_origins=["*"],
+        drafter_repo="z-lab/Qwen3.5-9B-DFlash",
+        speculative_tokens=16,
+        tree_budget=24,
+    )
+    client = TestClient(app)
+
+    r = client.get("/healthz")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["status"] == "loading"
+    assert body["ready"] is False
+    assert body["drafter"] == "z-lab/Qwen3.5-9B-DFlash"
+
+    r = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "qwen3.5-9b-8bit",
+            "messages": [{"role": "user", "content": "2+2?"}],
+        },
+    )
+    assert r.status_code == 503
+    assert "still loading" in r.json()["error"]["message"]
+
+    future.set_result(_fake_runtime())
+    r = client.get("/healthz")
+    assert r.status_code == 200
+    assert r.json()["ready"] is True
+
+
 def test_chat_completions_rejects_unsupported_ddtree_params() -> None:
     from fastapi.testclient import TestClient
 
@@ -299,3 +340,24 @@ def test_chat_completions_rejects_unsupported_ddtree_params() -> None:
     )
     assert r.status_code == 400
     assert "top_p" in r.json()["error"]["message"]
+
+    r = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "qwen3.5-9b-8bit",
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "describe this"},
+                        {
+                            "type": "image_url",
+                            "image_url": {"url": "data:image/png;base64,abc"},
+                        },
+                    ],
+                }
+            ],
+        },
+    )
+    assert r.status_code == 400
+    assert "non-text" in r.json()["error"]["message"].lower()

--- a/tests/test_ddtree_integration.py
+++ b/tests/test_ddtree_integration.py
@@ -315,7 +315,7 @@ def test_build_app_healthz_works_while_runtime_loads() -> None:
 def test_build_app_honors_api_key_and_model_name() -> None:
     from fastapi.testclient import TestClient
 
-    from vllm_mlx.config import reset_config
+    from vllm_mlx.config import get_config, reset_config
     from vllm_mlx.speculative.ddtree.server import _build_app
 
     reset_config()
@@ -357,6 +357,24 @@ def test_build_app_honors_api_key_and_model_name() -> None:
                 "messages": [{"role": "user", "content": "2+2?"}],
             },
         )
+        assert r.status_code == 200
+    finally:
+        reset_config()
+
+    reset_config()
+    try:
+        get_config().api_key = "env-secret"
+        app = _build_app(
+            runtime=_fake_runtime(),
+            served_model_name="qwen3.5-9b-8bit",
+            default_max_tokens=64,
+            cors_origins=["*"],
+        )
+        client = TestClient(app)
+
+        r = client.get("/healthz")
+        assert r.status_code == 401
+        r = client.get("/healthz", headers={"Authorization": "Bearer env-secret"})
         assert r.status_code == 200
     finally:
         reset_config()

--- a/tests/test_ddtree_integration.py
+++ b/tests/test_ddtree_integration.py
@@ -440,6 +440,7 @@ def test_chat_completions_rejects_unsupported_ddtree_params() -> None:
     unsupported_cases = [
         ({"stream": True}, "stream=true"),
         ({"stream_options": {"include_usage": True}}, "stream_options"),
+        ({"temperature": 0.7}, "temperature"),
         ({"top_p": 0.9}, "top_p"),
         ({"top_k": 8}, "top_k"),
         ({"min_p": 0.1}, "min_p"),

--- a/tests/test_ddtree_integration.py
+++ b/tests/test_ddtree_integration.py
@@ -304,6 +304,87 @@ def test_build_app_healthz_works_while_runtime_loads() -> None:
     assert r.json()["ready"] is True
 
 
+def test_build_app_honors_api_key_and_model_name() -> None:
+    from fastapi.testclient import TestClient
+
+    from vllm_mlx.config import reset_config
+    from vllm_mlx.speculative.ddtree.server import _build_app
+
+    reset_config()
+    try:
+        app = _build_app(
+            runtime=_fake_runtime(),
+            served_model_name="qwen3.5-9b-8bit",
+            default_max_tokens=64,
+            cors_origins=["*"],
+            api_key="secret",
+        )
+        client = TestClient(app)
+
+        r = client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "qwen3.5-9b-8bit",
+                "messages": [{"role": "user", "content": "2+2?"}],
+            },
+        )
+        assert r.status_code == 401
+
+        r = client.post(
+            "/v1/chat/completions",
+            headers={"Authorization": "Bearer secret"},
+            json={
+                "model": "other-model",
+                "messages": [{"role": "user", "content": "2+2?"}],
+            },
+        )
+        assert r.status_code == 404
+        assert "other-model" in r.json()["error"]["message"]
+
+        r = client.post(
+            "/v1/chat/completions",
+            headers={"Authorization": "Bearer secret"},
+            json={
+                "model": "qwen3.5-9b-8bit",
+                "messages": [{"role": "user", "content": "2+2?"}],
+            },
+        )
+        assert r.status_code == 200
+    finally:
+        reset_config()
+
+
+def test_build_app_runtime_load_failure_is_sanitized() -> None:
+    from fastapi.testclient import TestClient
+
+    from vllm_mlx.speculative.ddtree.server import _build_app
+
+    future: concurrent.futures.Future = concurrent.futures.Future()
+    future.set_exception(RuntimeError("secret local path /tmp/model-cache"))
+    app = _build_app(
+        runtime_future=future,
+        served_model_name="qwen3.5-9b-8bit",
+        default_max_tokens=64,
+        cors_origins=["*"],
+    )
+    client = TestClient(app)
+
+    r = client.get("/healthz")
+    assert r.status_code == 200
+    assert r.json()["status"] == "error"
+    assert "secret local path" not in r.text
+
+    r = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "qwen3.5-9b-8bit",
+            "messages": [{"role": "user", "content": "2+2?"}],
+        },
+    )
+    assert r.status_code == 500
+    assert "secret local path" not in r.text
+
+
 def test_chat_completions_rejects_unsupported_ddtree_params() -> None:
     from fastapi.testclient import TestClient
 

--- a/tests/test_ddtree_integration.py
+++ b/tests/test_ddtree_integration.py
@@ -330,16 +330,31 @@ def test_chat_completions_rejects_unsupported_ddtree_params() -> None:
     assert r.status_code == 400
     assert "tool calling" in r.json()["error"]["message"].lower()
 
-    r = client.post(
-        "/v1/chat/completions",
-        json={
+    unsupported_cases = [
+        ({"stream": True}, "stream=true"),
+        ({"stream_options": {"include_usage": True}}, "stream_options"),
+        ({"top_p": 0.9}, "top_p"),
+        ({"top_k": 8}, "top_k"),
+        ({"min_p": 0.1}, "min_p"),
+        ({"frequency_penalty": 0.5}, "frequency_penalty"),
+        ({"presence_penalty": 0.5}, "presence_penalty"),
+        ({"repetition_penalty": 1.1}, "repetition_penalty"),
+        ({"seed": 42}, "seed"),
+        ({"logit_bias": {"1": 1.0}}, "logit_bias"),
+        ({"top_logprobs": 1}, "top_logprobs"),
+        ({"reasoning_max_tokens": 8}, "reasoning_max_tokens"),
+        ({"reasoning_effort": "low"}, "reasoning_effort"),
+        ({"video_fps": 1.0}, "video parameters"),
+    ]
+    for extra, expected in unsupported_cases:
+        payload = {
             "model": "qwen3.5-9b-8bit",
             "messages": [{"role": "user", "content": "hi"}],
-            "top_p": 0.9,
-        },
-    )
-    assert r.status_code == 400
-    assert "top_p" in r.json()["error"]["message"]
+        }
+        payload.update(extra)
+        r = client.post("/v1/chat/completions", json=payload)
+        assert r.status_code == 400, extra
+        assert expected in r.json()["error"]["message"]
 
     r = client.post(
         "/v1/chat/completions",
@@ -361,3 +376,41 @@ def test_chat_completions_rejects_unsupported_ddtree_params() -> None:
     )
     assert r.status_code == 400
     assert "non-text" in r.json()["error"]["message"].lower()
+
+
+def test_run_ddtree_server_loads_runtime_on_separate_executor(monkeypatch) -> None:
+    from vllm_mlx.speculative.ddtree import server
+
+    class RecordingExecutor:
+        def __init__(self) -> None:
+            self.submitted = []
+            self.future: concurrent.futures.Future = concurrent.futures.Future()
+
+        def submit(self, fn, *args, **kwargs):
+            self.submitted.append((fn, args, kwargs))
+            return self.future
+
+    loader = RecordingExecutor()
+    generator = RecordingExecutor()
+    uvicorn_run = MagicMock()
+    monkeypatch.setattr(server, "have_runtime", lambda: True)
+    monkeypatch.setattr(server, "_ddtree_loader_executor", loader)
+    monkeypatch.setattr(server, "_ddtree_executor", generator)
+    monkeypatch.setattr("uvicorn.run", uvicorn_run)
+
+    server.run_ddtree_server(
+        main_model_repo="mlx-community/Qwen3.5-9B-8bit",
+        drafter_repo="z-lab/Qwen3.5-9B-DFlash",
+        speculative_tokens=16,
+        tree_budget=24,
+        host="127.0.0.1",
+        port=59999,
+        served_model_name="qwen3.5-9b-8bit",
+        default_max_tokens=64,
+        cors_origins=[],
+        uvicorn_log_level="warning",
+    )
+
+    assert len(loader.submitted) == 1
+    assert generator.submitted == []
+    uvicorn_run.assert_called_once()

--- a/tests/test_ddtree_integration.py
+++ b/tests/test_ddtree_integration.py
@@ -171,18 +171,26 @@ def test_models_listing_renders_ddtree_column(capsys) -> None:
     captured = capsys.readouterr()
     assert "DDTree" in captured.out
     lines = captured.out.splitlines()
+
+    def ddtree_cell(row: str) -> str:
+        return row.split()[-1]
+
     eligible_row = next(
-        (line for line in lines if "qwen3.5-9b-8bit " in line),
+        (line for line in lines if line.strip().startswith("qwen3.5-9b-8bit ")),
         None,
     )
     assert eligible_row is not None
-    assert "✓" in eligible_row, f"DDTree column should be ✓: {eligible_row!r}"
+    assert ddtree_cell(eligible_row) == "✓", (
+        f"DDTree column should be ✓: {eligible_row!r}"
+    )
     ineligible_row = next(
-        (line for line in lines if "qwen3.5-9b-4bit " in line),
+        (line for line in lines if line.strip().startswith("qwen3.5-9b-4bit ")),
         None,
     )
     assert ineligible_row is not None
-    assert "—" in ineligible_row, f"DDTree column should be —: {ineligible_row!r}"
+    assert ddtree_cell(ineligible_row) == "—", (
+        f"DDTree column should be —: {ineligible_row!r}"
+    )
 
 
 @dataclass
@@ -423,6 +431,9 @@ def test_chat_completions_rejects_unsupported_ddtree_params() -> None:
         ({"seed": 42}, "seed"),
         ({"logit_bias": {"1": 1.0}}, "logit_bias"),
         ({"top_logprobs": 1}, "top_logprobs"),
+        ({"tool_choice": "required"}, "tool_choice"),
+        ({"function_call": "auto"}, "tool_choice"),
+        ({"functions": [{"name": "x"}]}, "Tool calling"),
         ({"reasoning_max_tokens": 8}, "reasoning_max_tokens"),
         ({"reasoning_effort": "low"}, "reasoning_effort"),
         ({"video_fps": 1.0}, "video parameters"),

--- a/tests/test_no_mllm_flag.py
+++ b/tests/test_no_mllm_flag.py
@@ -166,6 +166,7 @@ NON_ROUTING_FLAGS_ALLOWLIST: frozenset[str] = frozenset(
         # decode (registered pair); these just enable the implementation.
         "--enable-mtp",
         "--enable-dflash",
+        "--enable-ddtree",
         # Task #292: ``--enable-audio`` is a route-mounting UX knob, not a
         # binary auto-detection. The audio-mode boot path auto-mounts
         # ``/v1/audio/*`` from the registry hit; this flag is the
@@ -2552,6 +2553,22 @@ def test_dflash_branch_rejects_no_spec_decode():
     assert no_spec_idx < dflash_idx, (
         "no_spec_decode mutex check must come BEFORE run_dflash_server() "
         "call so the override actually rejects DFlash startup."
+    )
+
+
+def test_ddtree_branch_rejects_no_spec_decode():
+    """--enable-ddtree + --no-spec-decode must be a mutex error."""
+    source = (_pkg_root() / "cli.py").read_text()
+    no_spec_idx = source.find("--enable-ddtree and --no-spec-decode")
+    ddtree_idx = source.find("run_ddtree_server(")
+    assert no_spec_idx != -1, (
+        "cli.py must reference no_spec_decode in the DDTree branch — "
+        "DDTree is a spec-decode path and must honor --no-spec-decode."
+    )
+    assert ddtree_idx != -1
+    assert no_spec_idx < ddtree_idx, (
+        "no_spec_decode mutex check must come BEFORE run_ddtree_server() "
+        "call so the override actually rejects DDTree startup."
     )
 
 

--- a/tests/test_no_mllm_flag.py
+++ b/tests/test_no_mllm_flag.py
@@ -2558,18 +2558,25 @@ def test_dflash_branch_rejects_no_spec_decode():
 
 def test_ddtree_branch_rejects_no_spec_decode():
     """--enable-ddtree + --no-spec-decode must be a mutex error."""
-    source = (_pkg_root() / "cli.py").read_text()
-    no_spec_idx = source.find("--enable-ddtree and --no-spec-decode")
-    ddtree_idx = source.find("run_ddtree_server(")
-    assert no_spec_idx != -1, (
-        "cli.py must reference no_spec_decode in the DDTree branch — "
-        "DDTree is a spec-decode path and must honor --no-spec-decode."
+    from types import SimpleNamespace
+
+    from vllm_mlx.cli import _preflight_ddtree_or_exit
+
+    args = SimpleNamespace(
+        model="qwen3.5-9b-8bit",
+        _original_alias=None,
+        _speculative_config=None,
+        enable_ddtree=True,
+        enable_dflash=False,
+        spec_decode="none",
+        suffix_decoding=False,
+        enable_mtp=False,
+        no_spec_decode=True,
     )
-    assert ddtree_idx != -1
-    assert no_spec_idx < ddtree_idx, (
-        "no_spec_decode mutex check must come BEFORE run_ddtree_server() "
-        "call so the override actually rejects DDTree startup."
-    )
+
+    with pytest.raises(SystemExit) as excinfo:
+        _preflight_ddtree_or_exit(args)
+    assert excinfo.value.code == 2
 
 
 def test_friendly_error_does_not_swallow_unrelated_valueerror(monkeypatch):

--- a/tests/test_no_out_of_band_routing.py
+++ b/tests/test_no_out_of_band_routing.py
@@ -1245,6 +1245,7 @@ def test_alias_profile_str_fields_are_explicitly_listed():
             "reasoning_parser",  # parser key, see PARSER_REGISTRY
             "suffix_decoding_tier",  # one of VALID_SUFFIX_TIERS — non-routing data
             "dflash_draft_model",  # HF path for the spec-decode drafter
+            "ddtree_draft_model",  # HF path for the DDTree/DFlash drafter
             # Deprecated v0.7.2 PR #555 in-house diffusion loop knob,
             # kept for one release window so programmatic readers don't
             # AttributeError; not consumed by any code path. Removed in

--- a/tests/test_no_out_of_band_routing.py
+++ b/tests/test_no_out_of_band_routing.py
@@ -137,6 +137,10 @@ ALLOWED_RAPID_MLX_ENV_VARS: frozenset[str] = frozenset(
         # Override the per-user config dir used to remember "seen-tips"
         # banner state (chat REPL first-launch tip gating).
         "RAPID_MLX_CONFIG_HOME",
+        # Override where DDTree writes its patched draft-config mirror.
+        # This is a cache placement/testing knob; model routing and DDTree
+        # enablement still come from explicit CLI flags and alias metadata.
+        "RAPID_MLX_DDTREE_PATCH_CACHE",
         # Set by ``rapid-mlx chat`` on the spawned ``serve`` subprocess
         # so the child's B2 download gate no-ops (parent already gated).
         # Pure UX flag — never read by the engine or scheduler.

--- a/tests/test_speculative_config.py
+++ b/tests/test_speculative_config.py
@@ -25,6 +25,20 @@ def test_parse_speculative_config_accepts_vllm_common_keys() -> None:
     assert cfg.method == "mtp"
     assert cfg.model == "local/draft"
     assert cfg.num_speculative_tokens == 4
+    assert cfg.tree_budget is None
+
+
+def test_parse_ddtree_speculative_config_accepts_method_keys() -> None:
+    cfg = parse_speculative_config(
+        '{"method":"ddtree","model":"local/draft",'
+        '"num_speculative_tokens":8,"tree_budget":24}'
+    )
+
+    assert cfg is not None
+    assert cfg.method == "ddtree"
+    assert cfg.model == "local/draft"
+    assert cfg.num_speculative_tokens == 8
+    assert cfg.tree_budget == 24
 
 
 def test_parse_speculative_config_normalizes_registered_alias() -> None:
@@ -45,6 +59,9 @@ def test_parse_speculative_config_normalizes_registered_alias() -> None:
         ('{"method":"mtp","num_speculative_tokens":true}', "positive integer"),
         ('{"method":"mtp","model":""}', "non-empty string"),
         ('{"method":"mtp","tree_budget":24}', "unsupported speculative-config"),
+        ('{"method":"ddtree","tree_budget":0}', "positive integer"),
+        ('{"method":"ddtree","tree_budget":true}', "positive integer"),
+        ('{"method":"ddtree","unknown":1}', "unsupported speculative-config"),
         ('{"method":"unknown"}', "unsupported speculative decoding method"),
     ],
 )
@@ -61,10 +78,18 @@ def test_require_migrated_speculative_config_rejects_unwired_method() -> None:
         require_migrated_speculative_config(cfg)
 
 
+def test_require_migrated_speculative_config_accepts_ddtree() -> None:
+    cfg = parse_speculative_config('{"method":"ddtree"}')
+    assert cfg is not None
+
+    require_migrated_speculative_config(cfg)
+
+
 def test_spec_decoder_registry_lists_existing_backends() -> None:
     methods = {plugin.method for plugin in iter_spec_decoders()}
 
-    assert {"dflash", "mtp", "suffix"}.issubset(methods)
+    assert {"ddtree", "dflash", "mtp", "suffix"}.issubset(methods)
+    assert get_spec_decoder("ddtree").config_enabled is True
     assert get_spec_decoder("ngram") == get_spec_decoder("suffix")
 
 

--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -46,6 +46,10 @@
     "is_moe": false,
     "supports_spec_decode": false,
     "supports_dflash": false,
+    "supports_ddtree": true,
+    "ddtree_draft_model": "z-lab/Qwen3.5-9B-DFlash",
+    "ddtree_speculative_tokens": 16,
+    "ddtree_tree_budget": 24,
     "pflash_tier": "verified",
     "turboquant_tier": "k8v4_verified"
   },

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -6536,7 +6536,7 @@ Examples:
         help=(
             "vLLM-style speculative decoding JSON config. This frontend "
             "parses method/model/num_speculative_tokens now. DDTree is "
-            "available with '{\"method\":\"ddtree\"}'; existing DFlash, "
+            'available with \'{"method":"ddtree"}\'; existing DFlash, '
             "MTP, and SuffixDecoding backends keep their legacy flags "
             "until they migrate to this surface."
         ),

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -1622,7 +1622,7 @@ def _preflight_ddtree_or_exit(args):
 
     from .model_aliases import resolve_profile
     from .speculative.ddtree import DDTreeUnavailable, check
-    from .speculative.ddtree.eligibility import have_runtime
+    from .speculative.ddtree.eligibility import have_runtime, runtime_probe_error
 
     alias_name = getattr(args, "_original_alias", None) or args.model
     profile = resolve_profile(alias_name)
@@ -1640,10 +1640,12 @@ def _preflight_ddtree_or_exit(args):
         print(f"\n  Error: {e}\n")
         sys.exit(1)
     if not have_runtime():
+        probe_error = runtime_probe_error()
+        detail = f" Probe failure: {probe_error}." if probe_error else ""
         print(
             "\n  Error: --enable-ddtree requires the experimental dtree-mlx "
             "runtime. Install with: ``pip install 'dtree-mlx @ "
-            "git+https://github.com/DrHB/dtree-mlx.git'``.\n"
+            f"git+https://github.com/DrHB/dtree-mlx.git'``.{detail}\n"
         )
         sys.exit(1)
 

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -1552,23 +1552,109 @@ def _build_benchmark_context(target_tokens: int) -> str:
 
 
 def _normalize_speculative_config_or_exit(args):
-    """Parse ``--speculative-config`` and reject methods not yet migrated."""
+    """Parse ``--speculative-config`` and map method shorthands to flags."""
     import sys
 
     from .spec_decode.config import (
         SpeculativeConfigError,
+        legacy_ddtree_config,
         parse_speculative_config,
         require_migrated_speculative_config,
     )
 
+    raw_config = getattr(args, "speculative_config", None)
+    if raw_config is not None and getattr(args, "enable_ddtree", False):
+        print(
+            "error: --speculative-config and --enable-ddtree are mutually "
+            "exclusive; use method='ddtree' in --speculative-config.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
     try:
-        config = parse_speculative_config(getattr(args, "speculative_config", None))
+        config = parse_speculative_config(raw_config)
         if config is not None:
             require_migrated_speculative_config(config)
     except SpeculativeConfigError as exc:
         print(f"error: {exc}", file=sys.stderr)
         sys.exit(2)
+    if config is None and getattr(args, "enable_ddtree", False):
+        config = legacy_ddtree_config()
     args._speculative_config = config
+    if config is not None and config.method == "ddtree":
+        args.enable_ddtree = True
+
+
+def _preflight_ddtree_or_exit(args):
+    """Validate DDTree flag/alias/runtime gates and cache the profile."""
+    import sys
+
+    from .spec_decode.config import legacy_ddtree_config
+
+    spec_config = getattr(args, "_speculative_config", None)
+    if spec_config is None and getattr(args, "enable_ddtree", False):
+        spec_config = legacy_ddtree_config()
+        args._speculative_config = spec_config
+
+    if getattr(args, "enable_dflash", False) or (
+        getattr(args, "spec_decode", "none") == "dflash"
+    ):
+        print(
+            "\n  Error: --enable-ddtree cannot combine with --enable-dflash "
+            "or --spec-decode dflash. Pick one block-diffusion "
+            "speculative-decoding server.\n"
+        )
+        sys.exit(1)
+    if getattr(args, "suffix_decoding", False) or getattr(args, "enable_mtp", False):
+        print(
+            "\n  Error: --enable-ddtree cannot combine with --suffix-decoding "
+            "or --enable-mtp. DDTree runs a dedicated single-user server "
+            "that bypasses BatchedEngine; other spec-decode methods only "
+            "apply to the BatchedEngine path.\n"
+        )
+        sys.exit(1)
+    if getattr(args, "no_spec_decode", False):
+        print(
+            "error: --enable-ddtree and --no-spec-decode are mutually "
+            "exclusive — DDTree is a speculative-decode mode.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+    from .model_aliases import resolve_profile
+    from .speculative.ddtree import DDTreeUnavailable, check
+    from .speculative.ddtree.eligibility import have_runtime
+
+    alias_name = getattr(args, "_original_alias", None) or args.model
+    profile = resolve_profile(alias_name)
+    if profile is None:
+        print(
+            f"\n  Error: --enable-ddtree requires a known alias, got "
+            f"{alias_name!r}. DDTree eligibility is recorded per-alias "
+            f"in aliases.json; ad-hoc HuggingFace paths can't be "
+            f"validated. Try ``rapid-mlx info qwen3.5-9b-8bit``.\n"
+        )
+        sys.exit(1)
+    try:
+        check(profile, alias=alias_name)
+    except DDTreeUnavailable as e:
+        print(f"\n  Error: {e}\n")
+        sys.exit(1)
+    if not have_runtime():
+        print(
+            "\n  Error: --enable-ddtree requires the experimental dtree-mlx "
+            "runtime. Install with: ``pip install 'dtree-mlx @ "
+            "git+https://github.com/DrHB/dtree-mlx.git'``.\n"
+        )
+        sys.exit(1)
+
+    args._ddtree_alias_name = alias_name
+    args._ddtree_profile = profile
+    args._ddtree_drafter_repo = spec_config.model or profile.ddtree_draft_model
+    args._ddtree_speculative_tokens = (
+        spec_config.num_speculative_tokens or profile.ddtree_speculative_tokens
+    )
+    args._ddtree_tree_budget = spec_config.tree_budget or profile.ddtree_tree_budget
+    return alias_name, profile
 
 
 def serve_command(args):
@@ -1659,6 +1745,15 @@ def serve_command(args):
         require_audio_or_exit(args.model)
 
     _normalize_speculative_config_or_exit(args)
+
+    # DDTree has an external experimental runtime and its validated target
+    # can be multi-GB. Fail the cheap flag/alias/runtime gates before the
+    # version prompt and before any model prefetch so a missing dtree-mlx
+    # install doesn't start a large download first. This runs before the
+    # DFlash runtime probe so --enable-ddtree + --enable-dflash surfaces
+    # the mutual-exclusion error instead of an optional-dependency hint.
+    if getattr(args, "enable_ddtree", False):
+        _preflight_ddtree_or_exit(args)
 
     # 0.9.2 dogfood (parallels the [embeddings]/[vision]/[audio] guards
     # immediately above): ``--enable-dflash`` and the equivalent
@@ -2141,10 +2236,11 @@ def serve_command(args):
             file=sys.stderr,
         )
 
-    # DFlash mutual-exclusion gate fires BEFORE the startup banner so
+    # DFlash / DDTree mutual-exclusion gates fire BEFORE the startup banner so
     # the user sees a clean error instead of an optimistic "Features:
-    # dflash" line immediately followed by an exit. The deeper SchedulerConfig
-    # mutex (suffix vs. mtp) stays below since it doesn't involve DFlash.
+    # dflash" / "ddtree" line immediately followed by an exit. The deeper
+    # SchedulerConfig mutex (suffix vs. mtp) stays below since it doesn't
+    # involve the dedicated single-user servers.
     if args.enable_dflash and (args.suffix_decoding or args.enable_mtp):
         print(
             "\n  Error: --enable-dflash cannot combine with --suffix-decoding "
@@ -2224,6 +2320,38 @@ def serve_command(args):
                 "\n    --enable-dflash if you need them.\n"
             )
 
+    # DDTree eligibility gate mirrors DFlash: cheap alias/runtime checks
+    # before the startup banner and before any model load.
+    if args.enable_ddtree:
+        _GPU_MEM_DEFAULT = 0.90
+        _ddtree_ignored: list[str] = []
+        if getattr(args, "enable_prefix_cache", False):
+            _ddtree_ignored.append("--enable-prefix-cache")
+        if getattr(args, "kv_cache_quantization", None):
+            _ddtree_ignored.append("--kv-cache-quantization")
+        _gpu_mem = getattr(args, "gpu_memory_utilization", _GPU_MEM_DEFAULT)
+        if _gpu_mem is not None and abs(_gpu_mem - _GPU_MEM_DEFAULT) > 1e-6:
+            _ddtree_ignored.append("--gpu-memory-utilization")
+        if getattr(args, "enable_auto_tool_choice", False):
+            _ddtree_ignored.append("--enable-auto-tool-choice")
+        if getattr(args, "tool_call_parser", None):
+            _ddtree_ignored.append("--tool-call-parser")
+        if getattr(args, "reasoning_parser", None):
+            _ddtree_ignored.append("--reasoning-parser")
+        if getattr(args, "embedding_model", None):
+            _ddtree_ignored.append("--embedding-model")
+        if getattr(args, "mcp_config", None):
+            _ddtree_ignored.append("--mcp-config")
+        if _ddtree_ignored:
+            print(
+                "\n  ⚠ The following flags are ignored under --enable-ddtree"
+                "\n    (DDTree uses a dedicated experimental single-user "
+                "server that bypasses BatchedEngine):"
+                f"\n      {', '.join(_ddtree_ignored)}"
+                "\n    Drop them from your serve command, or run without"
+                "\n    --enable-ddtree if you need them.\n"
+            )
+
     # Startup summary
     print()
     print("  🐆 Rapid-MLX")
@@ -2260,6 +2388,8 @@ def serve_command(args):
         features.append(f"cors: {', '.join(cors_origins)}")
     if args.enable_dflash:
         features.append("dflash: single-user")
+    if args.enable_ddtree:
+        features.append("ddtree: experimental single-user")
     if features:
         print(f"  Features: {', '.join(features)}")
     print(f"  Model: {args.model}")
@@ -2764,6 +2894,40 @@ def serve_command(args):
             port=args.port,
             served_model_name=args.served_model_name or _alias_name,
             default_max_tokens=effective_max_tokens,
+            cors_origins=cors_origins,
+            uvicorn_log_level=uvicorn_log_level,
+            no_thinking=args.no_thinking,
+        )
+        return
+
+    # DDTree fork: same blast-radius boundary as DFlash. It is a
+    # speculative-decode mode, but the MVP runs through the external
+    # dtree-mlx runtime rather than BatchedEngine.
+    if args.enable_ddtree:
+        from .speculative.ddtree.server import run_ddtree_server
+
+        _alias_name = getattr(args, "_ddtree_alias_name", None)
+        _profile = getattr(args, "_ddtree_profile", None)
+        if _alias_name is None or _profile is None:
+            _alias_name, _profile = _preflight_ddtree_or_exit(args)
+        assert _profile is not None and _profile.supports_ddtree, (
+            f"DDTree profile invariant violated for {_alias_name!r}"
+        )
+        assert _profile.ddtree_draft_model is not None
+        assert _profile.ddtree_speculative_tokens is not None
+        assert _profile.ddtree_tree_budget is not None
+        run_ddtree_server(
+            main_model_repo=_profile.hf_path,
+            drafter_repo=getattr(args, "_ddtree_drafter_repo", None)
+            or _profile.ddtree_draft_model,
+            speculative_tokens=getattr(args, "_ddtree_speculative_tokens", None)
+            or _profile.ddtree_speculative_tokens,
+            tree_budget=getattr(args, "_ddtree_tree_budget", None)
+            or _profile.ddtree_tree_budget,
+            host=args.host,
+            port=args.port,
+            served_model_name=args.served_model_name or _alias_name,
+            default_max_tokens=args.max_tokens,
             cors_origins=cors_origins,
             uvicorn_log_level=uvicorn_log_level,
             no_thinking=args.no_thinking,
@@ -3794,7 +3958,7 @@ def models_command(args):
     # floor — never shrink below it so short rows still feel padded.
     # Other widths sized to fit values currently in aliases.json:
     # tool 16 (qwen3_coder_xml + 1 pad), reasoning 12 (deepseek_r1 + 1),
-    # spec 10 ("✗ hybrid"), tier 11, dflash 7.
+    # spec 10 ("✗ hybrid"), tier 11, dflash 7, ddtree 7.
     alias_width = max(24, max((len(a) for a in profiles), default=0) + 2)
     cols = (
         ("Alias", alias_width),
@@ -3803,6 +3967,7 @@ def models_command(args):
         ("Spec-Decode", 10),
         ("Suffix Tier", 11),
         ("DFlash", 7),
+        ("DDTree", 7),
     )
     width = sum(w for _, w in cols) + len(cols) - 1
     sep = "  " + "─" * width
@@ -3829,9 +3994,10 @@ def models_command(args):
         # mlx-vlm 0.5.0+ is installed) — that's a runtime concern; the
         # registry column is pure declarative state.
         dflash = "✓" if p.supports_dflash else "—"
+        ddtree = "✓" if p.supports_ddtree else "—"
         row = (
             f"  {alias:<{alias_width}} {tools:<16} {reasoning:<12} "
-            f"{spec:<10} {tier:<11} {dflash:<7}"
+            f"{spec:<10} {tier:<11} {dflash:<7} {ddtree:<7}"
         )
         print(row)
 
@@ -5557,6 +5723,7 @@ def info_command(args):
     profile = resolve_profile(original_alias)
     if profile is not None:
         _print_dflash_status(original_alias, profile)
+        _print_ddtree_status(original_alias, profile)
 
     if cfg is None:
         print("  No pattern matched — runtime probe will run when the model loads.")
@@ -5628,6 +5795,87 @@ def _print_dflash_status(alias: str, profile) -> None:
     print()
     if eligible:
         print(f"  Start with: rapid-mlx serve {alias} --enable-dflash")
+        print()
+
+
+def _print_ddtree_status(alias: str, profile) -> None:
+    """Render DDTree status for ``rapid-mlx info <alias>``."""
+    from vllm_mlx.speculative.ddtree.eligibility import have_runtime, report
+    from vllm_mlx.speculative.dflash.eligibility import _looks_like_4bit
+
+    r = report(profile, alias=alias)
+    inner = 60
+    sep = "─" * inner
+
+    def _row(text: str) -> str:
+        return f"│ {text:<{inner}} │"
+
+    def _yes(ok: bool, msg_ok: str, msg_no: str) -> str:
+        return ("✓ " + msg_ok) if ok else ("✗ " + msg_no)
+
+    rows = [
+        (
+            "Declared support",
+            _yes(profile.supports_ddtree, "yes (supports_ddtree=true)", "no"),
+        ),
+        ("Not MoE", _yes(not profile.is_moe, "yes (dense)", "no (MoE)")),
+        (
+            "Precision ≥8-bit",
+            _yes(
+                not _looks_like_4bit(profile.hf_path),
+                "yes",
+                "no (4-bit/mxfp4/nvfp4)",
+            ),
+        ),
+        (
+            "Drafter declared",
+            _yes(
+                bool(profile.ddtree_draft_model),
+                profile.ddtree_draft_model or "yes",
+                "no (ddtree_draft_model unset)",
+            ),
+        ),
+        (
+            "Spec tokens",
+            _yes(
+                profile.ddtree_speculative_tokens is not None,
+                str(profile.ddtree_speculative_tokens),
+                "missing",
+            ),
+        ),
+        (
+            "Tree budget",
+            _yes(
+                profile.ddtree_tree_budget is not None,
+                str(profile.ddtree_tree_budget),
+                "missing",
+            ),
+        ),
+        (
+            "dtree-mlx runtime",
+            _yes(
+                have_runtime(),
+                "installed",
+                "missing/import-broken",
+            ),
+        ),
+    ]
+
+    eligible = not r.reasons and have_runtime()
+    summary = "✓ eligible" if eligible else "✗ ineligible"
+    top = "┌" + "─" * (inner + 2) + "┐"
+    bot = "└" + "─" * (inner + 2) + "┘"
+    body = [top, _row(f"DDTree eligibility: {summary}"), _row(sep)]
+    for k, v in rows:
+        body.append(_row(f"{k:<18}: {v}"))
+    body.append(bot)
+    print("\n".join(body))
+    print()
+    if eligible:
+        print(
+            f"  Start with: rapid-mlx serve {alias} "
+            """--speculative-config '{"method":"ddtree"}'"""
+        )
         print()
 
 
@@ -6273,14 +6521,24 @@ Examples:
         "``pip install 'rapid-mlx[dflash]'``.",
     )
     serve_parser.add_argument(
+        "--enable-ddtree",
+        action="store_true",
+        default=False,
+        help="Enable experimental DDTree speculative decoding (DFlash draft "
+        "tree verification, single-user serial mode). Requires a "
+        "DDTree-eligible alias (see ``rapid-mlx info <alias>``) and the "
+        "external dtree-mlx runtime.",
+    )
+    serve_parser.add_argument(
         "--speculative-config",
         dest="speculative_config",
         default=None,
         help=(
             "vLLM-style speculative decoding JSON config. This frontend "
-            "parses method/model/num_speculative_tokens now; existing "
-            "DFlash, MTP, and SuffixDecoding backends keep their legacy "
-            "flags until they migrate to this surface."
+            "parses method/model/num_speculative_tokens now. DDTree is "
+            "available with '{\"method\":\"ddtree\"}'; existing DFlash, "
+            "MTP, and SuffixDecoding backends keep their legacy flags "
+            "until they migrate to this surface."
         ),
     )
     serve_parser.add_argument(
@@ -6749,7 +7007,7 @@ Examples:
         default=False,
         help=(
             "Force-disable speculative-decode eligibility (suffix / MTP / "
-            "DFlash) even when AliasProfile says the model supports it. "
+            "DFlash / DDTree) even when AliasProfile says the model supports it. "
             "Mutually exclusive with --force-spec-decode."
         ),
     )

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -2931,6 +2931,7 @@ def serve_command(args):
             cors_origins=cors_origins,
             uvicorn_log_level=uvicorn_log_level,
             no_thinking=args.no_thinking,
+            api_key=server._api_key,
         )
         return
 

--- a/vllm_mlx/model_aliases.py
+++ b/vllm_mlx/model_aliases.py
@@ -71,10 +71,11 @@ VALID_PFLASH_TIERS: frozenset[str] = frozenset({"unknown", "verified"})
 VALID_TURBOQUANT_TIERS: frozenset[str] = frozenset({"unknown", "k8v4_verified"})
 
 
-# Canonical name for the DFlash speculative-decoding drafter kind. Kept
-# as a module constant so eligibility checks, CLI flag handlers, and
-# alias validation all reference the same string.
+# Canonical names for block-diffusion speculative-decoding drafter kinds.
+# Kept as module constants so eligibility checks, CLI flag handlers, and
+# alias validation all reference the same strings.
 DFLASH_KIND: str = "dflash"
+DDTREE_KIND: str = "ddtree"
 
 _aliases: dict[str, "AliasProfile"] | None = None
 # Reverse index: hf_path → first alias that references it. Built once
@@ -210,6 +211,15 @@ class AliasProfile:
     pflash_tier: str = "unknown"
     # TurboQuant K8V4 default-on tier. See ``VALID_TURBOQUANT_TIERS``.
     turboquant_tier: str = "unknown"
+    # DDTree speculative-decoding eligibility (#879). Appended at the
+    # tail to preserve AliasProfile's positional-construction ABI.
+    # This is intentionally separate from DFlash even though it uses the
+    # same DFlash draft weights: DDTree verifies a tree of candidate
+    # continuations and needs model-family specific verifier support.
+    supports_ddtree: bool = False
+    ddtree_draft_model: str | None = None
+    ddtree_speculative_tokens: int | None = None
+    ddtree_tree_budget: int | None = None
 
 
 def _coerce(alias: str, value: object) -> AliasProfile:
@@ -258,6 +268,10 @@ def _coerce(alias: str, value: object) -> AliasProfile:
             "suffix_bench_speedup",
             "supports_dflash",
             "dflash_draft_model",
+            "supports_ddtree",
+            "ddtree_draft_model",
+            "ddtree_speculative_tokens",
+            "ddtree_tree_budget",
             "recommended_sampling",
             "pflash_tier",
             "turboquant_tier",
@@ -384,6 +398,36 @@ def _coerce(alias: str, value: object) -> AliasProfile:
             f"alias {alias!r}: dflash_draft_model must be a string, "
             f"got {type(dflash_draft_model).__name__}"
         )
+    supports_ddtree = _strict_bool("supports_ddtree", False)
+    ddtree_draft_model = value.get("ddtree_draft_model")
+    if supports_ddtree and not ddtree_draft_model:
+        raise ValueError(
+            f"alias {alias!r}: supports_ddtree=true requires "
+            f"ddtree_draft_model to be set"
+        )
+    if ddtree_draft_model is not None and not isinstance(ddtree_draft_model, str):
+        raise ValueError(
+            f"alias {alias!r}: ddtree_draft_model must be a string, "
+            f"got {type(ddtree_draft_model).__name__}"
+        )
+
+    def _optional_positive_int(key: str) -> int | None:
+        raw = value.get(key)
+        if raw is None:
+            return None
+        if isinstance(raw, bool) or not isinstance(raw, int):
+            raise ValueError(
+                f"alias {alias!r}: {key} must be a positive integer, "
+                f"got {type(raw).__name__}={raw!r}"
+            )
+        if raw <= 0:
+            raise ValueError(
+                f"alias {alias!r}: {key} must be a positive integer, got {raw}"
+            )
+        return raw
+
+    ddtree_speculative_tokens = _optional_positive_int("ddtree_speculative_tokens")
+    ddtree_tree_budget = _optional_positive_int("ddtree_tree_budget")
     raw_sampling = value.get("recommended_sampling")
     recommended_sampling: tuple[tuple[str, float], ...] | None
     if raw_sampling is None:
@@ -467,6 +511,11 @@ def _coerce(alias: str, value: object) -> AliasProfile:
                 f"alias {alias!r}: supports_dflash must be false when "
                 f"modality={modality!r} (DFlash is AR-only)"
             )
+        if supports_ddtree:
+            raise ValueError(
+                f"alias {alias!r}: supports_ddtree must be false when "
+                f"modality={modality!r} (DDTree is AR-only)"
+            )
 
     return AliasProfile(
         hf_path=hf_path,
@@ -482,6 +531,10 @@ def _coerce(alias: str, value: object) -> AliasProfile:
         suffix_bench_speedup=speedup,
         supports_dflash=supports_dflash,
         dflash_draft_model=dflash_draft_model,
+        supports_ddtree=supports_ddtree,
+        ddtree_draft_model=ddtree_draft_model,
+        ddtree_speculative_tokens=ddtree_speculative_tokens,
+        ddtree_tree_budget=ddtree_tree_budget,
         recommended_sampling=recommended_sampling,
         # Deprecated v0.7.2 PR #555 knobs — explicitly threaded through
         # so an operator who customized ``aliases.json`` with non-default

--- a/vllm_mlx/spec_decode/config.py
+++ b/vllm_mlx/spec_decode/config.py
@@ -25,6 +25,7 @@ class SpeculativeConfig:
     method: str
     model: str | None = None
     num_speculative_tokens: int | None = None
+    tree_budget: int | None = None
     raw: dict[str, Any] | None = None
 
 
@@ -35,6 +36,10 @@ _COMMON_KEYS = frozenset(
         "num_speculative_tokens",
     }
 )
+
+_METHOD_KEYS = {
+    "ddtree": frozenset({"tree_budget"}),
+}
 
 
 def _positive_int(value: Any, key: str) -> int | None:
@@ -86,7 +91,8 @@ def parse_speculative_config(value: str | None) -> SpeculativeConfig | None:
         )
     method = plugin.method
 
-    unknown = sorted(set(payload) - _COMMON_KEYS)
+    allowed_keys = _COMMON_KEYS | _METHOD_KEYS.get(method, frozenset())
+    unknown = sorted(set(payload) - allowed_keys)
     if unknown:
         joined = ", ".join(unknown)
         raise SpeculativeConfigError(
@@ -99,8 +105,15 @@ def parse_speculative_config(value: str | None) -> SpeculativeConfig | None:
         num_speculative_tokens=_positive_int(
             payload.get("num_speculative_tokens"), "num_speculative_tokens"
         ),
+        tree_budget=_positive_int(payload.get("tree_budget"), "tree_budget"),
         raw=dict(payload),
     )
+
+
+def legacy_ddtree_config() -> SpeculativeConfig:
+    """Return the compatibility config represented by ``--enable-ddtree``."""
+
+    return SpeculativeConfig(method="ddtree", raw={"method": "ddtree"})
 
 
 def require_migrated_speculative_config(config: SpeculativeConfig) -> None:
@@ -121,6 +134,7 @@ def require_migrated_speculative_config(config: SpeculativeConfig) -> None:
 __all__ = [
     "SpeculativeConfig",
     "SpeculativeConfigError",
+    "legacy_ddtree_config",
     "parse_speculative_config",
     "require_migrated_speculative_config",
 ]

--- a/vllm_mlx/spec_decode/registry.py
+++ b/vllm_mlx/spec_decode/registry.py
@@ -66,6 +66,13 @@ def iter_spec_decoders() -> tuple[SpecDecoderPlugin, ...]:
 
 register_spec_decoder(
     SpecDecoderPlugin(
+        method="ddtree",
+        description="DDTree / DFlash draft-tree verifier",
+        config_enabled=True,
+    )
+)
+register_spec_decoder(
+    SpecDecoderPlugin(
         method="dflash",
         description="Block-diffusion drafter via the existing single-user bridge",
         legacy_hint="use --enable-dflash or --spec-decode dflash",

--- a/vllm_mlx/speculative/ddtree/__init__.py
+++ b/vllm_mlx/speculative/ddtree/__init__.py
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: Apache-2.0
+"""DDTree speculative-decoding integration (issue #879).
+
+DDTree builds a draft tree from DFlash draft-model logits and verifies
+multiple candidate continuations per target-model pass. The MVP keeps it
+behind an explicit ``--enable-ddtree`` flag and a dedicated single-user
+server, using the external ``dtree_mlx`` package as the runtime boundary.
+"""
+
+from .eligibility import DDTreeUnavailable, check
+from .runtime import load_runtime
+
+__all__ = ["DDTreeUnavailable", "check", "load_runtime"]

--- a/vllm_mlx/speculative/ddtree/__init__.py
+++ b/vllm_mlx/speculative/ddtree/__init__.py
@@ -3,8 +3,9 @@
 
 DDTree builds a draft tree from DFlash draft-model logits and verifies
 multiple candidate continuations per target-model pass. The MVP keeps it
-behind an explicit ``--enable-ddtree`` flag and a dedicated single-user
-server, using the external ``dtree_mlx`` package as the runtime boundary.
+behind explicit ``--speculative-config {"method":"ddtree"}`` opt-in and a
+dedicated single-user server, using the external ``dtree_mlx`` package as the
+runtime boundary.
 """
 
 from .eligibility import DDTreeUnavailable, check

--- a/vllm_mlx/speculative/ddtree/eligibility.py
+++ b/vllm_mlx/speculative/ddtree/eligibility.py
@@ -1,0 +1,112 @@
+# SPDX-License-Identifier: Apache-2.0
+"""DDTree eligibility checks.
+
+DDTree support is narrower than DFlash support because the verifier is
+model-family specific. A model may have matching DFlash draft weights and
+still be unsafe for DDTree until the target-side tree verifier has been
+bench-validated.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from vllm_mlx.model_aliases import AliasProfile
+from vllm_mlx.speculative.dflash.eligibility import _looks_like_4bit
+
+
+class DDTreeUnavailable(RuntimeError):  # noqa: N818
+    """Raised when an alias fails a DDTree eligibility gate."""
+
+
+@dataclass(frozen=True)
+class EligibilityReport:
+    alias: str | None
+    supports_ddtree: bool
+    is_moe: bool
+    is_4bit: bool
+    has_drafter: bool
+    has_speculative_tokens: bool
+    has_tree_budget: bool
+    reasons: tuple[str, ...]
+
+
+def report(profile: AliasProfile, alias: str | None = None) -> EligibilityReport:
+    reasons: list[str] = []
+    if not profile.supports_ddtree:
+        reasons.append(
+            "alias is not DDTree-enabled (set supports_ddtree=true only after "
+            "benching this exact target/drafter pair)"
+        )
+    if profile.is_moe:
+        reasons.append(
+            "alias is MoE (is_moe=true) — DDTree verifier support is only "
+            "validated for dense Qwen3.5/Qwen3-family targets in the MVP"
+        )
+    is_4bit = _looks_like_4bit(profile.hf_path)
+    if is_4bit:
+        reasons.append(
+            f"main model hf_path={profile.hf_path!r} is 4-bit quantized; "
+            "DDTree on 4-bit is not validated yet"
+        )
+    has_drafter = bool(profile.ddtree_draft_model)
+    if profile.supports_ddtree and not has_drafter:
+        reasons.append("supports_ddtree is set but ddtree_draft_model is empty")
+    has_speculative_tokens = profile.ddtree_speculative_tokens is not None
+    if profile.supports_ddtree and not has_speculative_tokens:
+        reasons.append("supports_ddtree is set but ddtree_speculative_tokens is empty")
+    has_tree_budget = profile.ddtree_tree_budget is not None
+    if profile.supports_ddtree and not has_tree_budget:
+        reasons.append("supports_ddtree is set but ddtree_tree_budget is empty")
+    return EligibilityReport(
+        alias=alias,
+        supports_ddtree=profile.supports_ddtree,
+        is_moe=profile.is_moe,
+        is_4bit=is_4bit,
+        has_drafter=has_drafter,
+        has_speculative_tokens=has_speculative_tokens,
+        has_tree_budget=has_tree_budget,
+        reasons=tuple(reasons),
+    )
+
+
+def eligible_aliases() -> list[str]:
+    try:
+        from vllm_mlx.model_aliases import list_profiles
+
+        return sorted(
+            name
+            for name, profile in list_profiles().items()
+            if not report(profile).reasons
+        )
+    except Exception:  # noqa: BLE001
+        return []
+
+
+def check(profile: AliasProfile, alias: str | None = None) -> None:
+    r = report(profile, alias=alias)
+    if not r.reasons:
+        return
+    header = f"DDTree unavailable for {alias!r}" if alias else "DDTree unavailable"
+    bullet = "\n  - ".join(r.reasons)
+    eligible = eligible_aliases()
+    if eligible:
+        suffix = (
+            f"Eligible aliases today: {', '.join(eligible)}. Run "
+            "`rapid-mlx info <alias>` to inspect per-alias DDTree status."
+        )
+    else:
+        suffix = (
+            "No aliases currently pass every DDTree gate. Run "
+            "`rapid-mlx info <alias>` to inspect per-alias DDTree status."
+        )
+    raise DDTreeUnavailable(f"{header}:\n  - {bullet}\n\n{suffix}")
+
+
+def have_runtime() -> bool:
+    try:
+        import importlib.util
+
+        return importlib.util.find_spec("dtree_mlx.api") is not None
+    except (ImportError, AttributeError):
+        return False

--- a/vllm_mlx/speculative/ddtree/eligibility.py
+++ b/vllm_mlx/speculative/ddtree/eligibility.py
@@ -16,6 +16,7 @@ from vllm_mlx.model_aliases import AliasProfile
 from vllm_mlx.speculative.dflash.eligibility import _looks_like_4bit
 
 logger = logging.getLogger(__name__)
+_runtime_probe_error: str | None = None
 
 
 class DDTreeUnavailable(RuntimeError):  # noqa: N818
@@ -102,10 +103,17 @@ def check(profile: AliasProfile, alias: str | None = None) -> None:
 
 
 def have_runtime() -> bool:
+    global _runtime_probe_error
     try:
         from dtree_mlx.api import DFlashGenerator  # noqa: F401
 
+        _runtime_probe_error = None
         return True
     except Exception as exc:  # noqa: BLE001
-        logger.debug("DDTree runtime probe failed: %s", exc)
+        _runtime_probe_error = f"{type(exc).__name__}: {exc}"[:240]
+        logger.debug("DDTree runtime probe failed: %s", _runtime_probe_error)
         return False
+
+
+def runtime_probe_error() -> str | None:
+    return _runtime_probe_error

--- a/vllm_mlx/speculative/ddtree/eligibility.py
+++ b/vllm_mlx/speculative/ddtree/eligibility.py
@@ -9,10 +9,13 @@ bench-validated.
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 
 from vllm_mlx.model_aliases import AliasProfile
 from vllm_mlx.speculative.dflash.eligibility import _looks_like_4bit
+
+logger = logging.getLogger(__name__)
 
 
 class DDTreeUnavailable(RuntimeError):  # noqa: N818
@@ -100,8 +103,9 @@ def check(profile: AliasProfile, alias: str | None = None) -> None:
 
 def have_runtime() -> bool:
     try:
-        import importlib.util
+        from dtree_mlx.api import DFlashGenerator  # noqa: F401
 
-        return importlib.util.find_spec("dtree_mlx.api") is not None
-    except (ImportError, AttributeError):
+        return True
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("DDTree runtime probe failed: %s", exc)
         return False

--- a/vllm_mlx/speculative/ddtree/eligibility.py
+++ b/vllm_mlx/speculative/ddtree/eligibility.py
@@ -71,16 +71,11 @@ def report(profile: AliasProfile, alias: str | None = None) -> EligibilityReport
 
 
 def eligible_aliases() -> list[str]:
-    try:
-        from vllm_mlx.model_aliases import list_profiles
+    from vllm_mlx.model_aliases import list_profiles
 
-        return sorted(
-            name
-            for name, profile in list_profiles().items()
-            if not report(profile).reasons
-        )
-    except Exception:  # noqa: BLE001
-        return []
+    return sorted(
+        name for name, profile in list_profiles().items() if not report(profile).reasons
+    )
 
 
 def check(profile: AliasProfile, alias: str | None = None) -> None:

--- a/vllm_mlx/speculative/ddtree/runtime.py
+++ b/vllm_mlx/speculative/ddtree/runtime.py
@@ -1,0 +1,142 @@
+# SPDX-License-Identifier: Apache-2.0
+"""DDTree runtime boundary.
+
+The first DDTree integration deliberately treats ``dtree_mlx`` as an
+optional external runtime. That keeps the rapid-mlx MVP small and lets us
+validate correctness/performance before deciding whether to vendor or
+reimplement the tree verifier.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from .eligibility import have_runtime
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class DDTreeRuntime:
+    generator: Any
+    main_model_repo: str
+    drafter_repo: str
+    speculative_tokens: int
+    tree_budget: int
+
+
+def load_runtime(
+    *,
+    main_model_repo: str,
+    drafter_repo: str,
+    speculative_tokens: int,
+    tree_budget: int,
+) -> DDTreeRuntime:
+    if not have_runtime():
+        raise RuntimeError(
+            "DDTree runtime not available — install the experimental runtime with: "
+            "pip install 'dtree-mlx @ git+https://github.com/DrHB/dtree-mlx.git'"
+        )
+
+    from dtree_mlx.api import DFlashGenerator
+
+    resolved_drafter_repo = _prepare_draft_model_for_dtree(drafter_repo)
+
+    logger.info(
+        "Loading DDTree runtime: target=%s drafter=%s spec=%d tree_budget=%d",
+        main_model_repo,
+        resolved_drafter_repo,
+        speculative_tokens,
+        tree_budget,
+    )
+    generator = DFlashGenerator(
+        target_model=main_model_repo,
+        draft_model=resolved_drafter_repo,
+        draft_attention_mask="auto",
+    )
+    return DDTreeRuntime(
+        generator=generator,
+        main_model_repo=main_model_repo,
+        drafter_repo=drafter_repo,
+        speculative_tokens=speculative_tokens,
+        tree_budget=tree_budget,
+    )
+
+
+def _prepare_draft_model_for_dtree(draft_model: str) -> str:
+    """Return a dtree-mlx-compatible draft path.
+
+    Public Qwen3.5 DFlash draft repos use the newer transformers 5
+    ``rope_parameters.rope_theta`` config shape. Current ``dtree-mlx`` expects
+    the older top-level ``rope_theta`` field, so materialize a small local
+    mirror with a patched config and symlinked weights when needed.
+    """
+
+    path = _resolve_model_path(draft_model)
+    cfg_path = path / "config.json"
+    if not cfg_path.exists():
+        return draft_model
+    try:
+        cfg = json.loads(cfg_path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return draft_model
+
+    rope_parameters = cfg.get("rope_parameters")
+    if cfg.get("rope_theta") is not None or not isinstance(rope_parameters, dict):
+        return draft_model
+    rope_theta = rope_parameters.get("rope_theta")
+    if rope_theta is None:
+        return draft_model
+
+    patched_cfg = dict(cfg)
+    patched_cfg["rope_theta"] = rope_theta
+    if "rope_scaling" not in patched_cfg and "rope_scaling" in rope_parameters:
+        patched_cfg["rope_scaling"] = rope_parameters["rope_scaling"]
+
+    patched = _patched_draft_dir(path)
+    patched.mkdir(parents=True, exist_ok=True)
+    for child in path.iterdir():
+        dst = patched / child.name
+        if child.name == "config.json":
+            continue
+        target = child.resolve()
+        if dst.exists() or dst.is_symlink():
+            if dst.is_symlink() and Path(os.readlink(dst)) == target:
+                continue
+            if dst.is_dir() and not dst.is_symlink():
+                continue
+            dst.unlink()
+        dst.symlink_to(target, target_is_directory=target.is_dir())
+    (patched / "config.json").write_text(json.dumps(patched_cfg, indent=2) + "\n")
+    logger.info(
+        "DDTree: patched draft config for dtree-mlx compatibility: %s -> %s",
+        draft_model,
+        patched,
+    )
+    return str(patched)
+
+
+def _resolve_model_path(path_or_repo: str) -> Path:
+    path = Path(path_or_repo).expanduser()
+    if path.exists():
+        return path
+    from huggingface_hub import snapshot_download
+
+    return Path(snapshot_download(path_or_repo))
+
+
+def _patched_draft_dir(source: Path) -> Path:
+    import hashlib
+
+    root = Path(
+        os.environ.get(
+            "RAPID_MLX_DDTREE_PATCH_CACHE", "~/.cache/rapid-mlx/ddtree-drafts"
+        )
+    ).expanduser()
+    digest = hashlib.sha1(str(source.resolve()).encode("utf-8")).hexdigest()[:16]
+    return root / f"{source.name}-{digest}"

--- a/vllm_mlx/speculative/ddtree/runtime.py
+++ b/vllm_mlx/speculative/ddtree/runtime.py
@@ -13,6 +13,7 @@ import json
 import logging
 import os
 import shutil
+import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -174,9 +175,7 @@ def _prepare_draft_model_for_dtree(draft_model: str) -> str:
 
     patched = _patched_draft_dir(path)
     patched.parent.mkdir(parents=True, exist_ok=True)
-    tmp = patched.with_name(f".{patched.name}.tmp-{os.getpid()}")
-    _remove_path(tmp)
-    tmp.mkdir(parents=True, exist_ok=False)
+    tmp = Path(tempfile.mkdtemp(prefix=f".{patched.name}.tmp-", dir=patched.parent))
     completed = False
     for child in path.iterdir():
         dst = tmp / child.name

--- a/vllm_mlx/speculative/ddtree/runtime.py
+++ b/vllm_mlx/speculative/ddtree/runtime.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import shutil
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -172,26 +173,38 @@ def _prepare_draft_model_for_dtree(draft_model: str) -> str:
         patched_cfg["rope_scaling"] = rope_parameters["rope_scaling"]
 
     patched = _patched_draft_dir(path)
-    patched.mkdir(parents=True, exist_ok=True)
+    patched.parent.mkdir(parents=True, exist_ok=True)
+    tmp = patched.with_name(f".{patched.name}.tmp-{os.getpid()}")
+    _remove_path(tmp)
+    tmp.mkdir(parents=True, exist_ok=False)
+    completed = False
     for child in path.iterdir():
-        dst = patched / child.name
+        dst = tmp / child.name
         if child.name == "config.json":
             continue
         target = child.resolve()
-        if dst.exists() or dst.is_symlink():
-            if dst.is_symlink() and Path(os.readlink(dst)) == target:
-                continue
-            if dst.is_dir() and not dst.is_symlink():
-                continue
-            dst.unlink()
         dst.symlink_to(target, target_is_directory=target.is_dir())
-    (patched / "config.json").write_text(json.dumps(patched_cfg, indent=2) + "\n")
+    (tmp / "config.json").write_text(json.dumps(patched_cfg, indent=2) + "\n")
+    try:
+        _remove_path(patched)
+        tmp.replace(patched)
+        completed = True
+    finally:
+        if not completed:
+            _remove_path(tmp)
     logger.info(
         "DDTree: patched draft config for dtree-mlx compatibility: %s -> %s",
         draft_model,
         patched,
     )
     return str(patched)
+
+
+def _remove_path(path: Path) -> None:
+    if path.is_symlink() or path.is_file():
+        path.unlink()
+    elif path.exists():
+        shutil.rmtree(path)
 
 
 def _resolve_model_path(path_or_repo: str) -> Path:

--- a/vllm_mlx/speculative/ddtree/runtime.py
+++ b/vllm_mlx/speculative/ddtree/runtime.py
@@ -59,6 +59,7 @@ def load_runtime(
         draft_model=resolved_drafter_repo,
         draft_attention_mask="auto",
     )
+    _install_qwen35_split_prefill_patch(generator)
     return DDTreeRuntime(
         generator=generator,
         main_model_repo=main_model_repo,
@@ -66,6 +67,77 @@ def load_runtime(
         speculative_tokens=speculative_tokens,
         tree_budget=tree_budget,
     )
+
+
+def _install_qwen35_split_prefill_patch(generator: Any) -> None:
+    """Match MLX-LM prompt prefill semantics for dtree-mlx Qwen3.5 targets.
+
+    ``mlx_lm.generate_step`` processes all prompt tokens except the final one
+    into cache first, then samples the first generated token from a separate
+    one-token call. Current ``dtree-mlx`` Qwen3.5 DFlash/DDTree paths prefill
+    the whole prompt in one call, which is not numerically equivalent for the
+    hybrid GatedDeltaNet target and can change greedy outputs. Keep the patch
+    local to the optional runtime boundary until upstream exposes the behavior.
+    """
+
+    target = getattr(generator, "target", None)
+    adapter = getattr(target, "adapter", None)
+    if getattr(adapter, "family", None) != "qwen3_5":
+        return
+    if getattr(target, "_rapid_mlx_split_prefill_patch", False):
+        return
+    original = getattr(target, "forward_with_hidden_states", None)
+    if original is None:
+        return
+
+    import mlx.core as mx
+
+    def cache_is_empty(cache: Any) -> bool:
+        if not isinstance(cache, (list, tuple)):
+            return False
+        for layer_cache in cache:
+            if int(getattr(layer_cache, "offset", 0) or 0) > 0:
+                return False
+            if getattr(layer_cache, "keys", None) is not None:
+                return False
+            if getattr(layer_cache, "values", None) is not None:
+                return False
+            try:
+                if layer_cache[0] is not None or layer_cache[1] is not None:
+                    return False
+            except (TypeError, IndexError, KeyError, AttributeError):
+                pass
+        return True
+
+    def forward_with_split_prefill(
+        inputs,
+        cache,
+        layer_ids,
+        return_rollback_records: bool = False,
+    ):
+        if (
+            not return_rollback_records
+            and getattr(inputs, "ndim", None) == 2
+            and int(inputs.shape[0]) == 1
+            and int(inputs.shape[1]) > 1
+            and cache_is_empty(cache)
+        ):
+            prefix_inputs = inputs[:, :-1]
+            last_input = inputs[:, -1:]
+            _prefix_logits, prefix_hidden = original(
+                prefix_inputs,
+                cache,
+                layer_ids,
+                False,
+            )
+            last_logits, last_hidden = original(last_input, cache, layer_ids, False)
+            mx.eval(last_logits, prefix_hidden, last_hidden)
+            return last_logits, mx.concatenate([prefix_hidden, last_hidden], axis=1)
+
+        return original(inputs, cache, layer_ids, return_rollback_records)
+
+    target.forward_with_hidden_states = forward_with_split_prefill
+    target._rapid_mlx_split_prefill_patch = True
 
 
 def _prepare_draft_model_for_dtree(draft_model: str) -> str:

--- a/vllm_mlx/speculative/ddtree/runtime.py
+++ b/vllm_mlx/speculative/ddtree/runtime.py
@@ -14,6 +14,7 @@ import logging
 import os
 import shutil
 import tempfile
+import uuid
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -175,6 +176,8 @@ def _prepare_draft_model_for_dtree(draft_model: str) -> str:
         patched_cfg["rope_scaling"] = rope_parameters["rope_scaling"]
 
     patched = _patched_draft_dir(path)
+    if _patched_dir_is_usable(patched, path, patched_cfg):
+        return str(patched)
     patched.parent.mkdir(parents=True, exist_ok=True)
     tmp = Path(tempfile.mkdtemp(prefix=f".{patched.name}.tmp-", dir=patched.parent))
     completed = False
@@ -186,8 +189,15 @@ def _prepare_draft_model_for_dtree(draft_model: str) -> str:
             target = child.resolve()
             dst.symlink_to(target, target_is_directory=target.is_dir())
         (tmp / "config.json").write_text(json.dumps(patched_cfg, indent=2) + "\n")
-        _remove_path(patched)
-        tmp.replace(patched)
+        try:
+            tmp.replace(patched)
+        except OSError:
+            if _patched_dir_is_usable(patched, path, patched_cfg):
+                completed = True
+                _remove_path(tmp)
+                return str(patched)
+            patched = patched.with_name(f"{patched.name}-{uuid.uuid4().hex[:8]}")
+            tmp.replace(patched)
         completed = True
     finally:
         if not completed:
@@ -198,6 +208,24 @@ def _prepare_draft_model_for_dtree(draft_model: str) -> str:
         patched,
     )
     return str(patched)
+
+
+def _patched_dir_is_usable(patched: Path, source: Path, patched_cfg: dict) -> bool:
+    cfg_path = patched / "config.json"
+    if not cfg_path.is_file():
+        return False
+    try:
+        if json.loads(cfg_path.read_text()) != patched_cfg:
+            return False
+    except (OSError, json.JSONDecodeError):
+        return False
+    for child in source.iterdir():
+        if child.name == "config.json":
+            continue
+        dst = patched / child.name
+        if not dst.is_symlink() or dst.resolve() != child.resolve():
+            return False
+    return True
 
 
 def _remove_path(path: Path) -> None:

--- a/vllm_mlx/speculative/ddtree/runtime.py
+++ b/vllm_mlx/speculative/ddtree/runtime.py
@@ -126,14 +126,15 @@ def _install_qwen35_split_prefill_patch(generator: Any) -> None:
         ):
             prefix_inputs = inputs[:, :-1]
             last_input = inputs[:, -1:]
-            _prefix_logits, prefix_hidden = original(
+            prefix_logits, prefix_hidden = original(
                 prefix_inputs,
                 cache,
                 layer_ids,
                 False,
             )
+            mx.eval(prefix_logits, prefix_hidden)
             last_logits, last_hidden = original(last_input, cache, layer_ids, False)
-            mx.eval(last_logits, prefix_hidden, last_hidden)
+            mx.eval(last_logits, last_hidden)
             return last_logits, mx.concatenate([prefix_hidden, last_hidden], axis=1)
 
         return original(inputs, cache, layer_ids, return_rollback_records)
@@ -177,14 +178,14 @@ def _prepare_draft_model_for_dtree(draft_model: str) -> str:
     patched.parent.mkdir(parents=True, exist_ok=True)
     tmp = Path(tempfile.mkdtemp(prefix=f".{patched.name}.tmp-", dir=patched.parent))
     completed = False
-    for child in path.iterdir():
-        dst = tmp / child.name
-        if child.name == "config.json":
-            continue
-        target = child.resolve()
-        dst.symlink_to(target, target_is_directory=target.is_dir())
-    (tmp / "config.json").write_text(json.dumps(patched_cfg, indent=2) + "\n")
     try:
+        for child in path.iterdir():
+            dst = tmp / child.name
+            if child.name == "config.json":
+                continue
+            target = child.resolve()
+            dst.symlink_to(target, target_is_directory=target.is_dir())
+        (tmp / "config.json").write_text(json.dumps(patched_cfg, indent=2) + "\n")
         _remove_path(patched)
         tmp.replace(patched)
         completed = True

--- a/vllm_mlx/speculative/ddtree/runtime.py
+++ b/vllm_mlx/speculative/ddtree/runtime.py
@@ -71,12 +71,13 @@ def load_runtime(
 def _prepare_draft_model_for_dtree(draft_model: str) -> str:
     """Return a dtree-mlx-compatible draft path.
 
-    Public Qwen3.5 DFlash draft repos use the newer transformers 5
-    ``rope_parameters.rope_theta`` config shape. Current ``dtree-mlx`` expects
-    the older top-level ``rope_theta`` field, so materialize a small local
-    mirror with a patched config and symlinked weights when needed.
+    The public Qwen3.5 DFlash draft repos use the newer transformers 5
+    ``rope_parameters.rope_theta`` config shape. Current ``dtree-mlx``
+    expects the older top-level ``rope_theta`` field, so the raw HF repo
+    fails at load time before generation starts. Materialize a small local
+    mirror with a patched config and symlinked weights, then pass that path
+    to ``dtree-mlx``.
     """
-
     path = _resolve_model_path(draft_model)
     cfg_path = path / "config.json"
     if not cfg_path.exists():

--- a/vllm_mlx/speculative/ddtree/server.py
+++ b/vllm_mlx/speculative/ddtree/server.py
@@ -1,0 +1,456 @@
+# SPDX-License-Identifier: Apache-2.0
+"""DDTree server — experimental single-user mode.
+
+This mirrors the DFlash single-user boundary: ``--enable-ddtree`` bypasses
+BatchedEngine and routes generation through the optional external
+``dtree_mlx`` runtime. The MVP prioritizes a clean end-to-end validation
+surface over breadth of OpenAI features.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import atexit
+import concurrent.futures
+import functools
+import json
+import logging
+import time
+import uuid
+from collections.abc import AsyncIterator
+from typing import Any
+
+from fastapi import FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import StreamingResponse
+
+from vllm_mlx.api.models import (
+    AssistantMessage,
+    ChatCompletionChoice,
+    ChatCompletionRequest,
+    ChatCompletionResponse,
+    ModelInfo,
+    ModelsResponse,
+    Usage,
+)
+
+from .eligibility import DDTreeUnavailable, have_runtime
+from .runtime import DDTreeRuntime, load_runtime
+
+logger = logging.getLogger(__name__)
+
+_ddtree_lock = asyncio.Lock()
+_ddtree_executor = concurrent.futures.ThreadPoolExecutor(
+    max_workers=1, thread_name_prefix="ddtree-worker"
+)
+
+
+@atexit.register
+def _shutdown_ddtree_executor() -> None:
+    _ddtree_executor.shutdown(wait=False, cancel_futures=True)
+
+
+def _build_app(
+    *,
+    runtime: DDTreeRuntime,
+    served_model_name: str,
+    default_max_tokens: int,
+    cors_origins: list[str],
+    no_thinking: bool = False,
+) -> FastAPI:
+    app = FastAPI(title="Rapid-MLX (DDTree)")
+    from ...middleware.exception_handlers import install_exception_handlers
+
+    install_exception_handlers(app)
+    if cors_origins:
+        wildcard = "*" in cors_origins
+        app.add_middleware(
+            CORSMiddleware,
+            allow_origins=cors_origins,
+            allow_credentials=not wildcard,
+            allow_methods=["POST", "GET", "OPTIONS"],
+            allow_headers=["Content-Type", "Authorization", "X-Rapid-MLX-Internal"],
+            max_age=3600,
+        )
+
+    @app.get("/healthz")
+    async def healthz() -> dict[str, Any]:
+        return {
+            "status": "ok",
+            "engine": "ddtree",
+            "mode": "experimental-single-user-serial",
+            "drafter": runtime.drafter_repo,
+            "speculative_tokens": runtime.speculative_tokens,
+            "tree_budget": runtime.tree_budget,
+        }
+
+    @app.get("/v1/models")
+    async def list_models() -> ModelsResponse:
+        return ModelsResponse(
+            data=[
+                ModelInfo(
+                    id=served_model_name,
+                    created=int(time.time()),
+                    owned_by="rapid-mlx",
+                )
+            ]
+        )
+
+    @app.post("/v1/chat/completions")
+    async def create_chat_completion(request: ChatCompletionRequest):
+        _validate_request(request)
+        prompt = _render_prompt(runtime, request, no_thinking=no_thinking)
+        max_tokens = (
+            request.max_tokens if request.max_tokens is not None else default_max_tokens
+        )
+        temperature = request.temperature if request.temperature is not None else 0.0
+
+        if request.stream:
+            return StreamingResponse(
+                _stream_completion(
+                    runtime=runtime,
+                    prompt=prompt,
+                    served_model_name=served_model_name,
+                    max_tokens=max_tokens,
+                    temperature=temperature,
+                ),
+                media_type="text/event-stream",
+            )
+
+        return await _non_stream_completion(
+            runtime=runtime,
+            prompt=prompt,
+            served_model_name=served_model_name,
+            max_tokens=max_tokens,
+            temperature=temperature,
+        )
+
+    return app
+
+
+def _validate_request(request: ChatCompletionRequest) -> None:
+    if not request.messages:
+        raise HTTPException(status_code=400, detail="messages must not be empty")
+    if request.n is not None and request.n > 1:
+        raise HTTPException(status_code=400, detail="n > 1 is not supported")
+    if request.tools:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "Tool calling is not supported in DDTree mode (MVP limitation). "
+                "Restart without --enable-ddtree to use tools."
+            ),
+        )
+    if request.logprobs:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "logprobs is not supported in DDTree mode. Restart without "
+                "--enable-ddtree."
+            ),
+        )
+    if request.response_format is not None:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "response_format (structured output) is not supported in "
+                "DDTree mode. Restart without --enable-ddtree."
+            ),
+        )
+    if request.top_p is not None and request.top_p != 1.0:
+        raise HTTPException(
+            status_code=400,
+            detail="top_p is not supported in DDTree mode; use top_p=1.",
+        )
+    if request.stop is not None:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "custom stop sequences are not supported in DDTree mode; "
+                "the model's EOS/chat-template stops still apply."
+            ),
+        )
+
+
+def _render_prompt(
+    runtime: DDTreeRuntime,
+    request: ChatCompletionRequest,
+    *,
+    no_thinking: bool = False,
+) -> str:
+    tokenizer = runtime.generator.target.tokenizer
+    messages = []
+    for m in request.messages:
+        content = m.content
+        if isinstance(content, list):
+            text_pieces = []
+            dropped_kinds: list[str] = []
+            for part in content:
+                part_type = part.type if hasattr(part, "type") else part.get("type", "")
+                if part_type == "text":
+                    text_pieces.append(
+                        part.text if hasattr(part, "text") else part.get("text", "")
+                    )
+                elif part_type:
+                    dropped_kinds.append(part_type)
+            if dropped_kinds:
+                logger.warning(
+                    "DDTree server is text-only; dropped %d non-text content "
+                    "part(s) of type(s) %s.",
+                    len(dropped_kinds),
+                    sorted(set(dropped_kinds)),
+                )
+            content = "".join(text_pieces)
+        messages.append({"role": m.role, "content": content})
+
+    enable_thinking = False if no_thinking else _extract_thinking_from_request(request)
+    effective_thinking = True if enable_thinking is None else enable_thinking
+    if hasattr(tokenizer, "apply_chat_template"):
+        try:
+            return tokenizer.apply_chat_template(
+                messages,
+                tokenize=False,
+                add_generation_prompt=True,
+                enable_thinking=effective_thinking,
+            )
+        except TypeError:
+            return tokenizer.apply_chat_template(
+                messages,
+                tokenize=False,
+                add_generation_prompt=True,
+            )
+    return "\n".join(f"{m['role']}: {m['content']}" for m in messages) + "\nassistant:"
+
+
+def _extract_thinking_from_request(request: ChatCompletionRequest) -> bool | None:
+    ctk = getattr(request, "chat_template_kwargs", None)
+    if isinstance(ctk, dict) and "enable_thinking" in ctk:
+        v = ctk["enable_thinking"]
+        if isinstance(v, bool):
+            return v
+        if isinstance(v, str):
+            lowered = v.strip().lower()
+            if lowered == "true":
+                return True
+            if lowered == "false":
+                return False
+    return getattr(request, "enable_thinking", None)
+
+
+def _run_generate(
+    runtime: DDTreeRuntime,
+    *,
+    prompt: str,
+    max_tokens: int,
+    temperature: float,
+):
+    import mlx.core as mx
+
+    tokenizer = runtime.generator.target.tokenizer
+    prompt_tokens = mx.array(
+        tokenizer.encode(prompt, add_special_tokens=False),
+        dtype=mx.uint32,
+    )
+    return runtime.generator.generate_from_tokens(
+        prompt_tokens=prompt_tokens,
+        max_new_tokens=max_tokens,
+        temperature=temperature,
+        speculative_tokens=runtime.speculative_tokens,
+        decode_mode="dtree",
+        tree_budget=runtime.tree_budget,
+        verify_mode="parallel-greedy-argmax",
+        skip_special_tokens=True,
+    )
+
+
+def _usage_from_result(result) -> tuple[int, int]:
+    metrics = getattr(result, "metrics", {}) or {}
+    prompt_tokens = int(metrics.get("num_input_tokens", 0))
+    completion_tokens = len(getattr(result, "generated_tokens", []) or [])
+    return prompt_tokens, completion_tokens
+
+
+def _finish_reason(result, max_tokens: int) -> str:
+    _, completion_tokens = _usage_from_result(result)
+    return "length" if completion_tokens >= max_tokens else "stop"
+
+
+async def _stream_completion(
+    *,
+    runtime: DDTreeRuntime,
+    prompt: str,
+    served_model_name: str,
+    max_tokens: int,
+    temperature: float,
+) -> AsyncIterator[bytes]:
+    completion_id = f"chatcmpl-{uuid.uuid4().hex[:24]}"
+    created = int(time.time())
+    first = {
+        "id": completion_id,
+        "object": "chat.completion.chunk",
+        "created": created,
+        "model": served_model_name,
+        "choices": [
+            {"index": 0, "delta": {"role": "assistant"}, "finish_reason": None}
+        ],
+    }
+    yield f"data: {json.dumps(first)}\n\n".encode()
+
+    async with _ddtree_lock:
+        loop = asyncio.get_running_loop()
+        result = await loop.run_in_executor(
+            _ddtree_executor,
+            functools.partial(
+                _run_generate,
+                runtime,
+                prompt=prompt,
+                max_tokens=max_tokens,
+                temperature=temperature,
+            ),
+        )
+
+    if getattr(result, "text", ""):
+        piece = {
+            "id": completion_id,
+            "object": "chat.completion.chunk",
+            "created": created,
+            "model": served_model_name,
+            "choices": [
+                {
+                    "index": 0,
+                    "delta": {"content": result.text},
+                    "finish_reason": None,
+                }
+            ],
+        }
+        yield f"data: {json.dumps(piece)}\n\n".encode()
+
+    prompt_tokens, completion_tokens = _usage_from_result(result)
+    final = {
+        "id": completion_id,
+        "object": "chat.completion.chunk",
+        "created": created,
+        "model": served_model_name,
+        "choices": [
+            {
+                "index": 0,
+                "delta": {},
+                "finish_reason": _finish_reason(result, max_tokens),
+            }
+        ],
+        "usage": {
+            "prompt_tokens": prompt_tokens,
+            "completion_tokens": completion_tokens,
+            "total_tokens": prompt_tokens + completion_tokens,
+        },
+    }
+    yield f"data: {json.dumps(final)}\n\n".encode()
+    yield b"data: [DONE]\n\n"
+
+
+async def _non_stream_completion(
+    *,
+    runtime: DDTreeRuntime,
+    prompt: str,
+    served_model_name: str,
+    max_tokens: int,
+    temperature: float,
+) -> ChatCompletionResponse:
+    async with _ddtree_lock:
+        loop = asyncio.get_running_loop()
+        result = await loop.run_in_executor(
+            _ddtree_executor,
+            functools.partial(
+                _run_generate,
+                runtime,
+                prompt=prompt,
+                max_tokens=max_tokens,
+                temperature=temperature,
+            ),
+        )
+
+    created = int(time.time())
+    prompt_tokens, completion_tokens = _usage_from_result(result)
+    return ChatCompletionResponse(
+        id=f"chatcmpl-{uuid.uuid4().hex[:24]}",
+        object="chat.completion",
+        created=created,
+        model=served_model_name,
+        choices=[
+            ChatCompletionChoice(
+                index=0,
+                message=AssistantMessage(role="assistant", content=result.text),
+                finish_reason=_finish_reason(result, max_tokens),
+            )
+        ],
+        usage=Usage(
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+            total_tokens=prompt_tokens + completion_tokens,
+        ),
+    )
+
+
+def run_ddtree_server(
+    *,
+    main_model_repo: str,
+    drafter_repo: str,
+    speculative_tokens: int,
+    tree_budget: int,
+    host: str,
+    port: int,
+    served_model_name: str,
+    default_max_tokens: int,
+    cors_origins: list[str],
+    uvicorn_log_level: str,
+    no_thinking: bool = False,
+) -> None:
+    if not have_runtime():
+        raise RuntimeError(
+            "DDTree server requires the experimental dtree-mlx runtime — install with "
+            "``pip install 'dtree-mlx @ git+https://github.com/DrHB/dtree-mlx.git'``."
+        )
+    if not drafter_repo:
+        raise DDTreeUnavailable(
+            "DDTree requires a non-empty drafter_repo — pass a matching DFlash "
+            "drafter HF path (e.g. 'z-lab/Qwen3.5-9B-DFlash')."
+        )
+    if speculative_tokens <= 0 or tree_budget <= 0:
+        raise DDTreeUnavailable(
+            "DDTree requires positive speculative_tokens and tree_budget values."
+        )
+
+    import uvicorn
+
+    def _load_all():
+        return load_runtime(
+            main_model_repo=main_model_repo,
+            drafter_repo=drafter_repo,
+            speculative_tokens=speculative_tokens,
+            tree_budget=tree_budget,
+        )
+
+    logger.info("DDTree: loading runtime for %s", main_model_repo)
+    runtime = _ddtree_executor.submit(_load_all).result()
+
+    app = _build_app(
+        runtime=runtime,
+        served_model_name=served_model_name,
+        default_max_tokens=default_max_tokens,
+        cors_origins=cors_origins,
+        no_thinking=no_thinking,
+    )
+
+    print()
+    host_display = "localhost" if host == "0.0.0.0" else host
+    print(f"  Ready: http://{host_display}:{port}/v1  (DDTree experimental mode)")
+    print(f"  Docs:  http://{host_display}:{port}/docs")
+    print()
+
+    uvicorn.run(
+        app,
+        host=host,
+        port=port,
+        log_level=uvicorn_log_level,
+        timeout_keep_alive=30,
+    )

--- a/vllm_mlx/speculative/ddtree/server.py
+++ b/vllm_mlx/speculative/ddtree/server.py
@@ -18,7 +18,7 @@ import time
 import uuid
 from typing import Any
 
-from fastapi import FastAPI, HTTPException
+from fastapi import Depends, FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 
 from vllm_mlx.api.models import (
@@ -30,11 +30,13 @@ from vllm_mlx.api.models import (
     ModelsResponse,
     Usage,
 )
+from vllm_mlx.config import get_config
 
 from .eligibility import DDTreeUnavailable, have_runtime
 from .runtime import DDTreeRuntime, load_runtime
 
 logger = logging.getLogger(__name__)
+_LOAD_FAILURE_DETAIL = "DDTree runtime failed to load; check server logs."
 
 _ddtree_lock = asyncio.Lock()
 _ddtree_executor = concurrent.futures.ThreadPoolExecutor(
@@ -59,6 +61,7 @@ def _build_app(
     default_max_tokens: int,
     cors_origins: list[str],
     no_thinking: bool = False,
+    api_key: str | None = None,
     drafter_repo: str | None = None,
     speculative_tokens: int | None = None,
     tree_budget: int | None = None,
@@ -66,8 +69,14 @@ def _build_app(
     if runtime is None and runtime_future is None:
         raise ValueError("DDTree app requires runtime or runtime_future")
 
-    app = FastAPI(title="Rapid-MLX (DDTree)")
+    get_config().api_key = api_key
+    from ...middleware.auth import verify_api_key
     from ...middleware.exception_handlers import install_exception_handlers
+
+    app = FastAPI(
+        title="Rapid-MLX (DDTree)",
+        dependencies=[Depends(verify_api_key)],
+    )
 
     install_exception_handlers(app)
     if cors_origins:
@@ -92,9 +101,13 @@ def _build_app(
             )
         exc = runtime_future.exception()
         if exc is not None:
+            logger.error(
+                "DDTree runtime failed to load.",
+                exc_info=(type(exc), exc, exc.__traceback__),
+            )
             raise HTTPException(
                 status_code=500,
-                detail=f"DDTree runtime failed to load: {exc}",
+                detail=_LOAD_FAILURE_DETAIL,
             )
         return runtime_future.result()
 
@@ -111,7 +124,7 @@ def _build_app(
                     ready_runtime = runtime_future.result()
                 else:
                     status = "error"
-                    error = str(exc)
+                    error = _LOAD_FAILURE_DETAIL
             else:
                 status = "loading"
         return {
@@ -150,6 +163,7 @@ def _build_app(
     @app.post("/v1/chat/completions")
     async def create_chat_completion(request: ChatCompletionRequest):
         _validate_request(request)
+        _validate_model_name(request.model, served_model_name=served_model_name)
         ready_runtime = get_ready_runtime()
         prompt = _render_prompt(ready_runtime, request, no_thinking=no_thinking)
         max_tokens = (
@@ -305,6 +319,21 @@ def _validate_request(request: ChatCompletionRequest) -> None:
             detail=(
                 "custom stop sequences are not supported in DDTree mode; "
                 "the model's EOS/chat-template stops still apply."
+            ),
+        )
+
+
+def _validate_model_name(request_model: str | None, *, served_model_name: str) -> None:
+    if request_model is None:
+        return
+    if request_model == "":
+        raise HTTPException(status_code=400, detail="model must not be empty")
+    if request_model != served_model_name:
+        raise HTTPException(
+            status_code=404,
+            detail=(
+                f"The model `{request_model}` does not exist. "
+                f"Available: {served_model_name}"
             ),
         )
 
@@ -468,6 +497,7 @@ def run_ddtree_server(
     cors_origins: list[str],
     uvicorn_log_level: str,
     no_thinking: bool = False,
+    api_key: str | None = None,
 ) -> None:
     if not have_runtime():
         raise RuntimeError(
@@ -503,6 +533,7 @@ def run_ddtree_server(
         default_max_tokens=default_max_tokens,
         cors_origins=cors_origins,
         no_thinking=no_thinking,
+        api_key=api_key,
         drafter_repo=drafter_repo,
         speculative_tokens=speculative_tokens,
         tree_budget=tree_budget,

--- a/vllm_mlx/speculative/ddtree/server.py
+++ b/vllm_mlx/speculative/ddtree/server.py
@@ -223,6 +223,21 @@ def _validate_request(request: ChatCompletionRequest) -> None:
                 "Restart without --enable-ddtree to use tools."
             ),
         )
+    if request.tool_choice not in (None, "none"):
+        raise HTTPException(
+            status_code=400,
+            detail="tool_choice is not supported in DDTree mode; use tool_choice=none.",
+        )
+    if request.functions:
+        raise HTTPException(
+            status_code=400,
+            detail="functions is not supported in DDTree mode.",
+        )
+    if request.function_call not in (None, "none"):
+        raise HTTPException(
+            status_code=400,
+            detail="function_call is not supported in DDTree mode; use function_call=none.",
+        )
     if request.logprobs:
         raise HTTPException(
             status_code=400,

--- a/vllm_mlx/speculative/ddtree/server.py
+++ b/vllm_mlx/speculative/ddtree/server.py
@@ -199,6 +199,11 @@ def _validate_request(request: ChatCompletionRequest) -> None:
             status_code=400,
             detail="stream_options is not supported in DDTree mode.",
         )
+    if request.temperature is not None and request.temperature != 0.0:
+        raise HTTPException(
+            status_code=400,
+            detail="temperature is not supported in DDTree mode; use temperature=0.",
+        )
     for message in request.messages:
         content = message.content
         if not isinstance(content, list):

--- a/vllm_mlx/speculative/ddtree/server.py
+++ b/vllm_mlx/speculative/ddtree/server.py
@@ -69,7 +69,8 @@ def _build_app(
     if runtime is None and runtime_future is None:
         raise ValueError("DDTree app requires runtime or runtime_future")
 
-    get_config().api_key = api_key
+    if api_key is not None:
+        get_config().api_key = api_key
     from ...middleware.auth import verify_api_key
     from ...middleware.exception_handlers import install_exception_handlers
 

--- a/vllm_mlx/speculative/ddtree/server.py
+++ b/vllm_mlx/speculative/ddtree/server.py
@@ -13,16 +13,13 @@ import asyncio
 import atexit
 import concurrent.futures
 import functools
-import json
 import logging
 import time
 import uuid
-from collections.abc import AsyncIterator
 from typing import Any
 
 from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import StreamingResponse
 
 from vllm_mlx.api.models import (
     AssistantMessage,
@@ -43,11 +40,15 @@ _ddtree_lock = asyncio.Lock()
 _ddtree_executor = concurrent.futures.ThreadPoolExecutor(
     max_workers=1, thread_name_prefix="ddtree-worker"
 )
+_ddtree_loader_executor = concurrent.futures.ThreadPoolExecutor(
+    max_workers=1, thread_name_prefix="ddtree-loader"
+)
 
 
 @atexit.register
 def _shutdown_ddtree_executor() -> None:
     _ddtree_executor.shutdown(wait=False, cancel_futures=True)
+    _ddtree_loader_executor.shutdown(wait=False, cancel_futures=True)
 
 
 def _build_app(
@@ -156,18 +157,6 @@ def _build_app(
         )
         temperature = request.temperature if request.temperature is not None else 0.0
 
-        if request.stream:
-            return StreamingResponse(
-                _stream_completion(
-                    runtime=ready_runtime,
-                    prompt=prompt,
-                    served_model_name=served_model_name,
-                    max_tokens=max_tokens,
-                    temperature=temperature,
-                ),
-                media_type="text/event-stream",
-            )
-
         return await _non_stream_completion(
             runtime=ready_runtime,
             prompt=prompt,
@@ -182,6 +171,19 @@ def _build_app(
 def _validate_request(request: ChatCompletionRequest) -> None:
     if not request.messages:
         raise HTTPException(status_code=400, detail="messages must not be empty")
+    if request.stream:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "stream=true is not supported in DDTree mode yet; use "
+                "non-streaming requests or restart without --enable-ddtree."
+            ),
+        )
+    if request.stream_options is not None:
+        raise HTTPException(
+            status_code=400,
+            detail="stream_options is not supported in DDTree mode.",
+        )
     for message in request.messages:
         content = message.content
         if not isinstance(content, list):
@@ -215,6 +217,16 @@ def _validate_request(request: ChatCompletionRequest) -> None:
                 "--enable-ddtree."
             ),
         )
+    if request.top_logprobs is not None:
+        raise HTTPException(
+            status_code=400,
+            detail="top_logprobs is not supported in DDTree mode.",
+        )
+    if request.logit_bias:
+        raise HTTPException(
+            status_code=400,
+            detail="logit_bias is not supported in DDTree mode.",
+        )
     if request.response_format is not None:
         raise HTTPException(
             status_code=400,
@@ -227,6 +239,65 @@ def _validate_request(request: ChatCompletionRequest) -> None:
         raise HTTPException(
             status_code=400,
             detail="top_p is not supported in DDTree mode; use top_p=1.",
+        )
+    if request.top_k is not None:
+        raise HTTPException(
+            status_code=400,
+            detail="top_k is not supported in DDTree mode.",
+        )
+    if request.min_p is not None and request.min_p != 0.0:
+        raise HTTPException(
+            status_code=400,
+            detail="min_p is not supported in DDTree mode; use min_p=0.",
+        )
+    if request.repetition_penalty is not None and request.repetition_penalty != 1.0:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "repetition_penalty is not supported in DDTree mode; "
+                "use repetition_penalty=1."
+            ),
+        )
+    if request.presence_penalty is not None and request.presence_penalty != 0.0:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "presence_penalty is not supported in DDTree mode; "
+                "use presence_penalty=0."
+            ),
+        )
+    if request.frequency_penalty is not None and request.frequency_penalty != 0.0:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "frequency_penalty is not supported in DDTree mode; "
+                "use frequency_penalty=0."
+            ),
+        )
+    if request.seed is not None:
+        raise HTTPException(
+            status_code=400,
+            detail="seed is not supported in DDTree mode.",
+        )
+    if request.parallel_tool_calls is not None:
+        raise HTTPException(
+            status_code=400,
+            detail="parallel_tool_calls is not supported in DDTree mode.",
+        )
+    if request.reasoning_max_tokens is not None:
+        raise HTTPException(
+            status_code=400,
+            detail="reasoning_max_tokens is not supported in DDTree mode.",
+        )
+    if request.reasoning_effort is not None:
+        raise HTTPException(
+            status_code=400,
+            detail="reasoning_effort is not supported in DDTree mode.",
+        )
+    if request.video_fps is not None or request.video_max_frames is not None:
+        raise HTTPException(
+            status_code=400,
+            detail="video parameters are not supported in DDTree mode.",
         )
     if request.stop is not None:
         raise HTTPException(
@@ -341,79 +412,6 @@ def _finish_reason(result, max_tokens: int) -> str:
     return "length" if completion_tokens >= max_tokens else "stop"
 
 
-async def _stream_completion(
-    *,
-    runtime: DDTreeRuntime,
-    prompt: str,
-    served_model_name: str,
-    max_tokens: int,
-    temperature: float,
-) -> AsyncIterator[bytes]:
-    completion_id = f"chatcmpl-{uuid.uuid4().hex[:24]}"
-    created = int(time.time())
-    first = {
-        "id": completion_id,
-        "object": "chat.completion.chunk",
-        "created": created,
-        "model": served_model_name,
-        "choices": [
-            {"index": 0, "delta": {"role": "assistant"}, "finish_reason": None}
-        ],
-    }
-    yield f"data: {json.dumps(first)}\n\n".encode()
-
-    async with _ddtree_lock:
-        loop = asyncio.get_running_loop()
-        result = await loop.run_in_executor(
-            _ddtree_executor,
-            functools.partial(
-                _run_generate,
-                runtime,
-                prompt=prompt,
-                max_tokens=max_tokens,
-                temperature=temperature,
-            ),
-        )
-
-    if getattr(result, "text", ""):
-        piece = {
-            "id": completion_id,
-            "object": "chat.completion.chunk",
-            "created": created,
-            "model": served_model_name,
-            "choices": [
-                {
-                    "index": 0,
-                    "delta": {"content": result.text},
-                    "finish_reason": None,
-                }
-            ],
-        }
-        yield f"data: {json.dumps(piece)}\n\n".encode()
-
-    prompt_tokens, completion_tokens = _usage_from_result(result)
-    final = {
-        "id": completion_id,
-        "object": "chat.completion.chunk",
-        "created": created,
-        "model": served_model_name,
-        "choices": [
-            {
-                "index": 0,
-                "delta": {},
-                "finish_reason": _finish_reason(result, max_tokens),
-            }
-        ],
-        "usage": {
-            "prompt_tokens": prompt_tokens,
-            "completion_tokens": completion_tokens,
-            "total_tokens": prompt_tokens + completion_tokens,
-        },
-    }
-    yield f"data: {json.dumps(final)}\n\n".encode()
-    yield b"data: [DONE]\n\n"
-
-
 async def _non_stream_completion(
     *,
     runtime: DDTreeRuntime,
@@ -497,7 +495,7 @@ def run_ddtree_server(
         )
 
     logger.info("DDTree: loading runtime for %s", main_model_repo)
-    runtime_future = _ddtree_executor.submit(_load_all)
+    runtime_future = _ddtree_loader_executor.submit(_load_all)
 
     app = _build_app(
         runtime_future=runtime_future,

--- a/vllm_mlx/speculative/ddtree/server.py
+++ b/vllm_mlx/speculative/ddtree/server.py
@@ -52,12 +52,19 @@ def _shutdown_ddtree_executor() -> None:
 
 def _build_app(
     *,
-    runtime: DDTreeRuntime,
+    runtime: DDTreeRuntime | None = None,
+    runtime_future: concurrent.futures.Future[DDTreeRuntime] | None = None,
     served_model_name: str,
     default_max_tokens: int,
     cors_origins: list[str],
     no_thinking: bool = False,
+    drafter_repo: str | None = None,
+    speculative_tokens: int | None = None,
+    tree_budget: int | None = None,
 ) -> FastAPI:
+    if runtime is None and runtime_future is None:
+        raise ValueError("DDTree app requires runtime or runtime_future")
+
     app = FastAPI(title="Rapid-MLX (DDTree)")
     from ...middleware.exception_handlers import install_exception_handlers
 
@@ -73,15 +80,58 @@ def _build_app(
             max_age=3600,
         )
 
+    def get_ready_runtime() -> DDTreeRuntime:
+        if runtime is not None:
+            return runtime
+        assert runtime_future is not None
+        if not runtime_future.done():
+            raise HTTPException(
+                status_code=503,
+                detail="DDTree runtime is still loading; retry shortly.",
+            )
+        exc = runtime_future.exception()
+        if exc is not None:
+            raise HTTPException(
+                status_code=500,
+                detail=f"DDTree runtime failed to load: {exc}",
+            )
+        return runtime_future.result()
+
     @app.get("/healthz")
     async def healthz() -> dict[str, Any]:
+        status = "ok"
+        ready_runtime: DDTreeRuntime | None = runtime
+        error: str | None = None
+        if ready_runtime is None:
+            assert runtime_future is not None
+            if runtime_future.done():
+                exc = runtime_future.exception()
+                if exc is None:
+                    ready_runtime = runtime_future.result()
+                else:
+                    status = "error"
+                    error = str(exc)
+            else:
+                status = "loading"
         return {
-            "status": "ok",
+            "status": status,
             "engine": "ddtree",
             "mode": "experimental-single-user-serial",
-            "drafter": runtime.drafter_repo,
-            "speculative_tokens": runtime.speculative_tokens,
-            "tree_budget": runtime.tree_budget,
+            "drafter": (
+                ready_runtime.drafter_repo
+                if ready_runtime is not None
+                else drafter_repo
+            ),
+            "speculative_tokens": (
+                ready_runtime.speculative_tokens
+                if ready_runtime is not None
+                else speculative_tokens
+            ),
+            "tree_budget": (
+                ready_runtime.tree_budget if ready_runtime is not None else tree_budget
+            ),
+            "ready": ready_runtime is not None,
+            **({"error": error} if error is not None else {}),
         }
 
     @app.get("/v1/models")
@@ -99,7 +149,8 @@ def _build_app(
     @app.post("/v1/chat/completions")
     async def create_chat_completion(request: ChatCompletionRequest):
         _validate_request(request)
-        prompt = _render_prompt(runtime, request, no_thinking=no_thinking)
+        ready_runtime = get_ready_runtime()
+        prompt = _render_prompt(ready_runtime, request, no_thinking=no_thinking)
         max_tokens = (
             request.max_tokens if request.max_tokens is not None else default_max_tokens
         )
@@ -108,7 +159,7 @@ def _build_app(
         if request.stream:
             return StreamingResponse(
                 _stream_completion(
-                    runtime=runtime,
+                    runtime=ready_runtime,
                     prompt=prompt,
                     served_model_name=served_model_name,
                     max_tokens=max_tokens,
@@ -118,7 +169,7 @@ def _build_app(
             )
 
         return await _non_stream_completion(
-            runtime=runtime,
+            runtime=ready_runtime,
             prompt=prompt,
             served_model_name=served_model_name,
             max_tokens=max_tokens,
@@ -131,6 +182,21 @@ def _build_app(
 def _validate_request(request: ChatCompletionRequest) -> None:
     if not request.messages:
         raise HTTPException(status_code=400, detail="messages must not be empty")
+    for message in request.messages:
+        content = message.content
+        if not isinstance(content, list):
+            continue
+        for part in content:
+            part_type = part.type if hasattr(part, "type") else part.get("type", "")
+            if part_type != "text":
+                raise HTTPException(
+                    status_code=400,
+                    detail=(
+                        "Non-text chat content is not supported in DDTree mode "
+                        "(MVP limitation). Restart without --enable-ddtree to "
+                        "use multimodal inputs."
+                    ),
+                )
     if request.n is not None and request.n > 1:
         raise HTTPException(status_code=400, detail="n > 1 is not supported")
     if request.tools:
@@ -431,19 +497,23 @@ def run_ddtree_server(
         )
 
     logger.info("DDTree: loading runtime for %s", main_model_repo)
-    runtime = _ddtree_executor.submit(_load_all).result()
+    runtime_future = _ddtree_executor.submit(_load_all)
 
     app = _build_app(
-        runtime=runtime,
+        runtime_future=runtime_future,
         served_model_name=served_model_name,
         default_max_tokens=default_max_tokens,
         cors_origins=cors_origins,
         no_thinking=no_thinking,
+        drafter_repo=drafter_repo,
+        speculative_tokens=speculative_tokens,
+        tree_budget=tree_budget,
     )
 
     print()
     host_display = "localhost" if host == "0.0.0.0" else host
-    print(f"  Ready: http://{host_display}:{port}/v1  (DDTree experimental mode)")
+    print(f"  Starting: http://{host_display}:{port}/v1  (DDTree experimental mode)")
+    print(f"  Health: http://{host_display}:{port}/healthz")
     print(f"  Docs:  http://{host_display}:{port}/docs")
     print()
 


### PR DESCRIPTION
## What changed

Re-lands experimental DDTree support behind the vLLM-style speculative config frontend from #1012:

```bash
rapid-mlx serve qwen3.5-9b-8bit --speculative-config '{"method":"ddtree"}'
```

`--enable-ddtree` remains a compatibility shorthand, but DDTree is never enabled by alias/default.

## Why

Issue #879 asked whether DDTree is worth supporting. The MVP keeps the blast radius small: only explicitly DDTree-enabled aliases can use the external `dtree-mlx` runtime, and the server runs as a single-user experimental path like DFlash.

## Fixes after validation

The first re-land attempt exposed two runtime correctness issues before merge:

- public Qwen3.5 DFlash draft configs use `rope_parameters.rope_theta`, while current `dtree-mlx` expects top-level `rope_theta`; the runtime now materializes a tiny symlinked patched draft config cache.
- `dtree-mlx` Qwen3.5 DDTree prefilled the whole prompt in one target call, while MLX-LM/Rapid-MLX generate by caching `prompt[:-1]` and sampling from `prompt[-1:]`; the runtime now wraps the Qwen3.5 target to use split-prefill only for the initial empty-cache prefill.

## Validation

Local:

- `uv run --with ruff ruff check ...` passed for DDTree/spec-config files.
- `uv run --with ruff ruff format --check ...` passed.
- `uv run --with pytest pytest -q tests/test_speculative_config.py tests/test_ddtree_eligibility.py tests/test_ddtree_integration.py`: 39 passed.
- `uv run --with pytest pytest -q tests/test_aliases_contract.py tests/test_no_mllm_flag.py tests/test_no_out_of_band_routing.py`: 1888 passed, 2 skipped.
- HTTP E2E with `qwen3.5-9b-8bit --speculative-config '{"method":"ddtree"}'`: `/healthz` OK and chat completion OK.
- Real 9B A/B after split-prefill fix: 6/6 exact match vs Rapid-MLX/MLX-LM greedy baseline, 10/10 stability repeat, mean speedup 1.14x, median speedup 1.03x, min 0.82x, max 1.65x. Performance remains workload-dependent.

Full `pr_validate` is run separately with `stress_e2e_bench` skipped because this local machine currently has low free disk and the DDTree 9B real-model E2E/bench above covers the changed runtime path.
