### PR TITLE
chore: bump version to 0.9.14

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.9.12"
+version = "0.9.14"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## Release 0.9.14

Two-step bump **0.9.12 → 0.9.14** — 0.9.13 is already claimed by the published tag + PyPI wheel, so the next free version is 0.9.14.

### Why 0.9.14 and not 0.9.13-again
`#1008` reverted the experimental ddtree support and, as a side effect, reset `pyproject.toml` to `0.9.12` on `main` — even though `v0.9.13` was already tagged and published to PyPI. `main` was therefore *behind its own published release*. This bump reconciles that: `main` moves to 0.9.14, strictly ahead of the published 0.9.13.

### Ships to PyPI
- **#448** — OpenAI `reasoning_effort` route-layer translation (PR #1009): `none` suppresses thinking; graded values cap `reasoning_max_tokens`; symmetric step-aside on `/v1/chat/completions` and `/v1/responses` when a client signals reasoning intent.
- **gemma-4 external-MTP speculative decode** — already merged in the v0.9.13 tree (`--spec-decode mtp --mtp-sidecar`), now reaching PyPI on a clean version.

### Gates
- CI: PF-1 subject regex · G1 clean-room smoke · G11 escape-hatch · pr_validate
- M3-local: `make release-check-m3` (G4-G9) run before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)