### PR TITLE
[codex] add speculative config frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -763,7 +763,7 @@ Run your own: `bash evals/run_all_models.sh` runs the full quality suite (tool c
 | **TurboQuant K8V4 KV codec** | K is 8-bit + V is 4-bit after Walsh-Hadamard rotation + Lloyd-Max quantization — compresses KV to ~1/2.4 (~58% savings), lossless across the verified matrix. **Default-on for 9 verified Qwen3.5/3.6 aliases** (see below); `--kv-cache-turboquant none` to force off. |
 | **Smart cloud routing** | Large-context requests auto-route to a cloud LLM (`--cloud-model openai/gpt-5 --cloud-threshold 20000`) when local prefill would be slow. |
 | **Multimodal** | Vision, audio (STT/TTS with bundled Silero VAD silence pre-trim), video understanding, text embeddings — all through the standard OpenAI endpoints. |
-| **Speculative decoding** | DFlash (block-diffusion drafter, `--enable-dflash`), MTP (multi-token prediction head, `--enable-mtp`), SuffixDecoding (drafter-free n-gram, `--suffix-decoding`). Opt-in per alias — see below. |
+| **Speculative decoding** | DFlash (block-diffusion drafter, `--enable-dflash`), MTP (multi-token prediction head, `--enable-mtp`), SuffixDecoding (drafter-free n-gram, `--suffix-decoding`). `--speculative-config` is the vLLM-style frontend reserved for backend migration. Opt-in per alias — see below. |
 | **Structured output, logprobs, continuous batching, KV quantization** | Standard, no flags or with one flag each. |
 | **3300+ tests** | Across reasoning, tool parsing, streaming, agent harnesses, and engine integration. |
 
@@ -831,6 +831,7 @@ Mutex: DFlash cannot combine with MTP or SuffixDecoding (single-user path). MTP 
 | `--prefix-cache-index` | Prefix-cache lookup index: `radix` (default) or `hash` | `radix` |
 | `--pflash` | PFlash sparse prefill: `auto` / `always` / `off` | `auto` (on for verified aliases) |
 | `--enable-dflash` | DFlash speculative decoding (single-user; `qwen3.5-27b-8bit` / `qwen3.6-27b-8bit`) | off |
+| `--speculative-config` | vLLM-style speculative decoding JSON frontend; existing backends keep legacy flags until migrated | off |
 | `--suffix-decoding` | Drafter-free n-gram speculative decoding (BatchedEngine path) | off |
 | `--enable-mtp` | MTP head speculative decoding (requires MTP-trained model) | off |
 | `--gpu-memory-utilization` | Fraction of device memory to use (0.0-1.0) | `0.90` |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.9.14"
+version = "0.9.15"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/tests/test_speculative_config.py
+++ b/tests/test_speculative_config.py
@@ -1,0 +1,102 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the vLLM-style speculative config frontend."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+import pytest
+
+from vllm_mlx.spec_decode.config import (
+    SpeculativeConfigError,
+    parse_speculative_config,
+    require_migrated_speculative_config,
+)
+from vllm_mlx.spec_decode.registry import get_spec_decoder, iter_spec_decoders
+
+
+def test_parse_speculative_config_accepts_vllm_common_keys() -> None:
+    cfg = parse_speculative_config(
+        '{"method":"mtp","model":"local/draft","num_speculative_tokens":4}'
+    )
+
+    assert cfg is not None
+    assert cfg.method == "mtp"
+    assert cfg.model == "local/draft"
+    assert cfg.num_speculative_tokens == 4
+
+
+def test_parse_speculative_config_normalizes_registered_alias() -> None:
+    cfg = parse_speculative_config('{"method":"ngram"}')
+
+    assert cfg is not None
+    assert cfg.method == "suffix"
+
+
+@pytest.mark.parametrize(
+    ("raw", "match"),
+    [
+        ("", "cannot be empty"),
+        ("[]", "JSON object"),
+        ("{bad", "valid JSON"),
+        ('{"model":"x"}', "requires string key 'method'"),
+        ('{"method":"mtp","num_speculative_tokens":0}', "positive integer"),
+        ('{"method":"mtp","num_speculative_tokens":true}', "positive integer"),
+        ('{"method":"mtp","model":""}', "non-empty string"),
+        ('{"method":"mtp","tree_budget":24}', "unsupported speculative-config"),
+        ('{"method":"unknown"}', "unsupported speculative decoding method"),
+    ],
+)
+def test_parse_speculative_config_rejects_bad_payloads(raw: str, match: str) -> None:
+    with pytest.raises(SpeculativeConfigError, match=match):
+        parse_speculative_config(raw)
+
+
+def test_require_migrated_speculative_config_rejects_unwired_method() -> None:
+    cfg = parse_speculative_config('{"method":"mtp"}')
+    assert cfg is not None
+
+    with pytest.raises(SpeculativeConfigError, match="not wired yet"):
+        require_migrated_speculative_config(cfg)
+
+
+def test_spec_decoder_registry_lists_existing_backends() -> None:
+    methods = {plugin.method for plugin in iter_spec_decoders()}
+
+    assert {"dflash", "mtp", "suffix"}.issubset(methods)
+    assert get_spec_decoder("ngram") == get_spec_decoder("suffix")
+
+
+def test_serve_help_exposes_speculative_config() -> None:
+    proc = subprocess.run(
+        [sys.executable, "-m", "vllm_mlx.cli", "serve", "--help"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+    assert proc.returncode == 0, proc.stderr
+    assert "--speculative-config" in proc.stdout
+
+
+def test_serve_rejects_unwired_speculative_config_before_model_load() -> None:
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "vllm_mlx.cli",
+            "serve",
+            "qwen3.5-9b-8bit",
+            "--speculative-config",
+            '{"method":"mtp"}',
+        ],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+    assert proc.returncode == 2
+    assert "not wired yet" in proc.stderr
+    assert "use --spec-decode mtp" in proc.stderr
+    assert "Fetching" not in proc.stderr

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -1551,6 +1551,26 @@ def _build_benchmark_context(target_tokens: int) -> str:
     return (block * repeats).strip()
 
 
+def _normalize_speculative_config_or_exit(args):
+    """Parse ``--speculative-config`` and reject methods not yet migrated."""
+    import sys
+
+    from .spec_decode.config import (
+        SpeculativeConfigError,
+        parse_speculative_config,
+        require_migrated_speculative_config,
+    )
+
+    try:
+        config = parse_speculative_config(getattr(args, "speculative_config", None))
+        if config is not None:
+            require_migrated_speculative_config(config)
+    except SpeculativeConfigError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        sys.exit(2)
+    args._speculative_config = config
+
+
 def serve_command(args):
     """Start the OpenAI-compatible server."""
     import logging
@@ -1637,6 +1657,8 @@ def serve_command(args):
 
     if is_audio_model_alias(getattr(args, "model", None)):
         require_audio_or_exit(args.model)
+
+    _normalize_speculative_config_or_exit(args)
 
     # 0.9.2 dogfood (parallels the [embeddings]/[vision]/[audio] guards
     # immediately above): ``--enable-dflash`` and the equivalent
@@ -6249,6 +6271,17 @@ Examples:
         "(see ``rapid-mlx info <alias>``). Loads the drafter from the "
         "alias's ``dflash_draft_model`` field. Install with "
         "``pip install 'rapid-mlx[dflash]'``.",
+    )
+    serve_parser.add_argument(
+        "--speculative-config",
+        dest="speculative_config",
+        default=None,
+        help=(
+            "vLLM-style speculative decoding JSON config. This frontend "
+            "parses method/model/num_speculative_tokens now; existing "
+            "DFlash, MTP, and SuffixDecoding backends keep their legacy "
+            "flags until they migrate to this surface."
+        ),
     )
     serve_parser.add_argument(
         "--num-draft-tokens",

--- a/vllm_mlx/spec_decode/__init__.py
+++ b/vllm_mlx/spec_decode/__init__.py
@@ -28,6 +28,10 @@ Currently bundled:
   :func:`vllm_mlx.positioned_kv_cache.positioned_update_and_fetch`
   HELPER (NOT the subclass — the subclass breaks
   ``mlx_lm.save_prompt_cache``).
+* :mod:`vllm_mlx.spec_decode.config` and
+  :mod:`vllm_mlx.spec_decode.registry` — vLLM-style
+  ``--speculative-config`` parsing plus the small method registry used
+  to migrate DFlash / MTP / SuffixDecoding behind one frontend surface.
 
 Each backend exposes a thin public API the CLI / scheduler can call to
 choose between ``--spec-decode none|mtp|dflash`` at boot — the model-side
@@ -37,4 +41,4 @@ sub-package.
 
 from __future__ import annotations
 
-__all__ = ["dflash", "mtp"]
+__all__ = ["config", "dflash", "mtp", "registry"]

--- a/vllm_mlx/spec_decode/config.py
+++ b/vllm_mlx/spec_decode/config.py
@@ -1,0 +1,126 @@
+# SPDX-License-Identifier: Apache-2.0
+"""vLLM-style speculative decoding config parsing."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any
+
+from .registry import get_spec_decoder, iter_spec_decoders
+
+
+class SpeculativeConfigError(ValueError):
+    """Raised when ``--speculative-config`` is malformed or unsupported."""
+
+
+@dataclass(frozen=True)
+class SpeculativeConfig:
+    """Parsed ``--speculative-config`` payload.
+
+    Field names intentionally match vLLM where they overlap. Backend-specific
+    keys remain in ``raw`` until a method is migrated to this surface.
+    """
+
+    method: str
+    model: str | None = None
+    num_speculative_tokens: int | None = None
+    raw: dict[str, Any] | None = None
+
+
+_COMMON_KEYS = frozenset(
+    {
+        "method",
+        "model",
+        "num_speculative_tokens",
+    }
+)
+
+
+def _positive_int(value: Any, key: str) -> int | None:
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise SpeculativeConfigError(f"{key} must be a positive integer")
+    if value <= 0:
+        raise SpeculativeConfigError(f"{key} must be a positive integer")
+    return value
+
+
+def _optional_string(value: Any, key: str) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str) or not value.strip():
+        raise SpeculativeConfigError(f"{key} must be a non-empty string")
+    return value.strip()
+
+
+def parse_speculative_config(value: str | None) -> SpeculativeConfig | None:
+    """Parse the JSON value passed to ``--speculative-config``."""
+
+    if value is None:
+        return None
+    if not value.strip():
+        raise SpeculativeConfigError("--speculative-config cannot be empty")
+    try:
+        payload = json.loads(value)
+    except json.JSONDecodeError as exc:
+        raise SpeculativeConfigError(
+            f"--speculative-config must be valid JSON: {exc.msg}"
+        ) from exc
+    if not isinstance(payload, dict):
+        raise SpeculativeConfigError("--speculative-config must be a JSON object")
+
+    raw_method = payload.get("method")
+    if not isinstance(raw_method, str) or not raw_method.strip():
+        raise SpeculativeConfigError(
+            "--speculative-config requires string key 'method'"
+        )
+    method = raw_method.strip().lower()
+    plugin = get_spec_decoder(method)
+    known = ", ".join(plugin.method for plugin in iter_spec_decoders())
+    if plugin is None:
+        raise SpeculativeConfigError(
+            f"unsupported speculative decoding method {method!r}; "
+            f"known methods: {known}"
+        )
+    method = plugin.method
+
+    unknown = sorted(set(payload) - _COMMON_KEYS)
+    if unknown:
+        joined = ", ".join(unknown)
+        raise SpeculativeConfigError(
+            f"unsupported speculative-config key(s) for {method!r}: {joined}"
+        )
+
+    return SpeculativeConfig(
+        method=method,
+        model=_optional_string(payload.get("model"), "model"),
+        num_speculative_tokens=_positive_int(
+            payload.get("num_speculative_tokens"), "num_speculative_tokens"
+        ),
+        raw=dict(payload),
+    )
+
+
+def require_migrated_speculative_config(config: SpeculativeConfig) -> None:
+    """Fail until ``config.method`` is wired to a backend runner."""
+
+    plugin = get_spec_decoder(config.method)
+    if plugin is None:
+        raise SpeculativeConfigError(
+            f"unsupported speculative decoding method {config.method!r}"
+        )
+    if not plugin.config_enabled:
+        hint = f"; {plugin.legacy_hint}" if plugin.legacy_hint else ""
+        raise SpeculativeConfigError(
+            f"--speculative-config method {plugin.method!r} is not wired yet{hint}."
+        )
+
+
+__all__ = [
+    "SpeculativeConfig",
+    "SpeculativeConfigError",
+    "parse_speculative_config",
+    "require_migrated_speculative_config",
+]

--- a/vllm_mlx/spec_decode/registry.py
+++ b/vllm_mlx/spec_decode/registry.py
@@ -1,0 +1,96 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Registry metadata for speculative decoder frontends.
+
+The user-facing shape follows vLLM's ``--speculative-config`` JSON. The
+runtime contracts are still MLX-specific, so this registry starts as the
+stable place to name/configure methods before each backend is migrated
+behind a common runner interface.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class SpecDecoderPlugin:
+    """Metadata for a speculative decoding method exposed to the CLI."""
+
+    method: str
+    description: str
+    config_enabled: bool = False
+    legacy_hint: str | None = None
+    aliases: tuple[str, ...] = ()
+
+
+_PLUGINS: dict[str, SpecDecoderPlugin] = {}
+
+
+def register_spec_decoder(plugin: SpecDecoderPlugin) -> None:
+    """Register ``plugin`` under its method and aliases."""
+
+    method = plugin.method.strip().lower()
+    if not method:
+        raise ValueError("spec decoder method cannot be empty")
+    normalized = SpecDecoderPlugin(
+        method=method,
+        description=plugin.description,
+        config_enabled=plugin.config_enabled,
+        legacy_hint=plugin.legacy_hint,
+        aliases=tuple(alias.strip().lower() for alias in plugin.aliases if alias),
+    )
+    for name in (normalized.method, *normalized.aliases):
+        if name in _PLUGINS and _PLUGINS[name] != normalized:
+            raise ValueError(f"spec decoder method {name!r} is already registered")
+        _PLUGINS[name] = normalized
+
+
+def get_spec_decoder(method: str) -> SpecDecoderPlugin | None:
+    """Return the plugin registered for ``method``, if any."""
+
+    return _PLUGINS.get(method.strip().lower())
+
+
+def iter_spec_decoders() -> tuple[SpecDecoderPlugin, ...]:
+    """Return each registered plugin once, excluding alias duplicates."""
+
+    seen: set[str] = set()
+    out: list[SpecDecoderPlugin] = []
+    for plugin in _PLUGINS.values():
+        if plugin.method in seen:
+            continue
+        seen.add(plugin.method)
+        out.append(plugin)
+    return tuple(out)
+
+
+register_spec_decoder(
+    SpecDecoderPlugin(
+        method="dflash",
+        description="Block-diffusion drafter via the existing single-user bridge",
+        legacy_hint="use --enable-dflash or --spec-decode dflash",
+    )
+)
+register_spec_decoder(
+    SpecDecoderPlugin(
+        method="mtp",
+        description="Model-side multi-token prediction head",
+        legacy_hint="use --spec-decode mtp",
+    )
+)
+register_spec_decoder(
+    SpecDecoderPlugin(
+        method="suffix",
+        description="Drafter-free suffix / n-gram speculative decoding",
+        legacy_hint="use --suffix-decoding",
+        aliases=("ngram",),
+    )
+)
+
+
+__all__ = [
+    "SpecDecoderPlugin",
+    "get_spec_decoder",
+    "iter_spec_decoders",
+    "register_spec_decoder",
+]


### PR DESCRIPTION
## Summary

Adds a vLLM-style `--speculative-config` frontend for speculative decoding without wiring any backend to it yet.

This PR is intentionally scoped to the interface layer only:
- adds `vllm_mlx.spec_decode.config` for JSON parsing and validation
- adds `vllm_mlx.spec_decode.registry` for method metadata (`dflash`, `mtp`, `suffix` / `ngram`)
- exposes `--speculative-config` on `rapid-mlx serve`
- rejects registered-but-unmigrated methods early with a clear legacy-flag hint
- documents the frontend as reserved until backend migration

No DDTree runtime, alias, eligibility, or server wiring is included in this PR.

## Validation

- `uv run --with ruff ruff check vllm_mlx/spec_decode/config.py vllm_mlx/spec_decode/registry.py vllm_mlx/spec_decode/__init__.py vllm_mlx/cli.py tests/test_speculative_config.py README.md`
- `uv run --with ruff ruff format --check vllm_mlx/spec_decode/config.py vllm_mlx/spec_decode/registry.py vllm_mlx/spec_decode/__init__.py vllm_mlx/cli.py tests/test_speculative_config.py`
- `uv run --with pytest pytest -q tests/test_speculative_config.py tests/test_mtp_spec_decode.py::test_cli_spec_decode_flag_advertised_in_help tests/test_mtp_spec_decode.py::test_cli_spec_decode_flag_rejects_unknown_value tests/test_dflash_spec_decode.py::test_cli_spec_decode_flag_advertises_dflash_choice tests/test_dflash_spec_decode.py::test_cli_dflash_drafter_path_flag_present tests/test_dflash_spec_decode.py::test_cli_spec_decode_rejects_unknown_value`
- `python3 -m compileall -q vllm_mlx/spec_decode/config.py vllm_mlx/spec_decode/registry.py vllm_mlx/cli.py tests/test_speculative_config.py`

Mutation spot-check:
- mutation: changed `if not plugin.config_enabled:` to `if False and not plugin.config_enabled:` in `require_migrated_speculative_config`
- failing tests: `tests/test_speculative_config.py::test_require_migrated_speculative_config_rejects_unwired_method` and `tests/test_speculative_config.py::test_serve_rejects_unwired_speculative_config_before_model_load`
- observed failure: first test did not raise `SpeculativeConfigError`; second test continued past the early gate instead of returning rc=2
- mutation was reverted and the targeted suite passed again