### PR TITLE
chore: bump version to 0.10.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.9.15"
+version = "0.10.0"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## Summary

0.10.0 release trigger — dedicated version-bump commit per repo policy.
Auto-release.yml will fire on this PR's squash-merge (regex requires the exact `chore: bump version to X.Y.Z (#N)` subject).

## What ships in 0.10.0

**Layer A — model coverage (top-tier 3 families):**
- Qwen 3.6 (+8 aliases): bare 27b/35b, MTP-4bit, OptiQ-4bit, unsloth UD-3bit/6bit
- Gemma 4 (+13 aliases): E2B/E4B 6bit/8bit, 26B-8bit, OptiQ-4bit variants, 5 Google MTP `-assistant` sidecars, QAT assistant 4bit
- gpt-oss (+9 aliases): bare 20b/120b, MXFP4-Q4 variants, OptiQ-4bit, 8bit, 120b 4bit, safeguard-20b
- Bumps `POPULAR_ALIASES` to include `gpt-oss-20b`
- All 30 hf_paths HF-verified before registering (PR #1014)

**Layer B — API:**
- Codex namespace tool-groups on `/v1/responses` (external contribution, hardened through 4 codex adversarial-review rounds — PR #993)
- gpt-oss `reasoning_effort` passthrough per harmony spec (already-live in 0.9.14, PR #1009)

**Interface freeze:**
- `--speculative-config` JSON + plugin registry (PR #1012) is now the canonical entry point for every future spec-decoding method. Legacy per-method flags stay behind hints; 0.10.x spec-decode work migrates onto the runner.

**Downstream:**
- rapidmlx.com models manifest synced (138 → 168 entries); landing page counts and gpt-oss callouts updated (rapidmlx.com PR #54, merged).

## Pre-merge dogfood (VERIFIED)

- Bare alias `gpt-oss-20b` boots on M3 Ultra (256 GB), resolves to `mlx-community/gpt-oss-20b-MXFP4-Q8`, responds to `/v1/chat/completions` with `reasoning_effort: "low"` — returns clean "pong" (39 reasoning tokens, 1 content token, harmony parser routing correctly).
- All 30 new aliases resolve through `vllm_mlx.model_aliases.resolve_model` + `resolve_profile` cleanly (30/30 PASS).

## Post-merge follow-through

All release verification runs after auto-release fires — no pre-merge checkboxes because these items are post-merge by construction (per prior test_plan_check policy on bump PRs). Operator will confirm on release-tag arrival: the auto-release workflow fires on squash-merge (subject regex match already green), `pip install rapid-mlx==0.10.0` becomes installable within ~5 min of the workflow completing, GitHub release notes are populated by the workflow, and `rapid-mlx version` prints `0.10.0` post-upgrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)