### PR TITLE
fix(deps): promote mlx-vlm to core so Gemma 4 boots on fresh install

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ print(client.chat.completions.create(
 ).choices[0].message.content)
 ```
 
-> **Vision/multimodal models** (Gemma 4, Qwen-VL) need extras: `pip install 'rapid-mlx[vision]'`. Text-only install is ~460 MB; vision adds ~322 MB. See [Optional Extras](#optional-extras).
+> **Vision-input models** (Qwen-VL, image understanding) need extras: `pip install 'rapid-mlx[vision]'` (torch + torchvision + opencv). Gemma 4 (including DiffusionGemma) now works out of the box in 0.10.1+ — its runtime (mlx-vlm) is a core dep. Text-only install is ~570 MB; vision adds ~210 MB more. See [Optional Extras](#optional-extras).
 
 > **"No matching distribution" from pip?** Your Python is too old. Run `python3 --version` — if it says 3.9, run `brew install python@3.12` then `python3.12 -m pip install rapid-mlx`.
 
@@ -555,7 +555,7 @@ rapid-mlx serve qwen3-coder-4bit --prefill-step-size 8192 --port 8000
 # Vision — image understanding (needs [vision] extras)
 rapid-mlx serve qwen3-vl-4b-4bit --mllm --port 8000
 
-# Text-diffusion — DiffusionGemma 26B-A4B (block denoising, needs [vision] for mlx-vlm 0.6.3+)
+# Text-diffusion — DiffusionGemma 26B-A4B (block denoising; mlx-vlm is core in 0.10.1+)
 rapid-mlx serve diffusion-gemma-26b-4bit --port 8000
 ```
 
@@ -596,7 +596,7 @@ All 17 parsers include automatic recovery — if a quantized model outputs broke
 DiffusionGemma is a **non-autoregressive** language model — instead of emitting one token at a time, it denoises whole blocks of tokens in parallel via a diffusion process. Rapid-MLX wraps it behind the standard OpenAI Chat Completions API.
 
 ```bash
-pip install 'rapid-mlx[vision]'       # mlx-vlm 0.6.3+ provides the diffusion runtime
+# mlx-vlm (the diffusion runtime) is a core dep in 0.10.1+ — no extras needed.
 rapid-mlx serve diffusion-gemma-26b-4bit --port 8000
 ```
 
@@ -862,11 +862,11 @@ Mutex: DFlash cannot combine with MTP or SuffixDecoding (single-user path). MTP 
 
 ## Optional Extras
 
-The base `pip install rapid-mlx` is ~460 MB and covers all text-only models. Vision, audio, and other features ship as opt-in extras:
+The base `pip install rapid-mlx` is ~570 MB (0.10.1+ bundles the mlx-vlm runtime so Gemma 4 and DiffusionGemma work out of the box). Vision-input, audio, and other features ship as opt-in extras:
 
 | Extra | Install | Adds | What it unlocks |
 |---|---|---|---|
-| `vision` | `pip install 'rapid-mlx[vision]'` | ~322 MB | Gemma 4, Qwen-VL, DiffusionGemma, video understanding (mlx-vlm + opencv + torch) |
+| `vision` | `pip install 'rapid-mlx[vision]'` | ~210 MB | Qwen-VL, video understanding, non-mlx-vlm vision preprocessing (torch + torchvision). Gemma 4 & DiffusionGemma no longer need this — mlx-vlm is core. |
 | `audio` | `pip install 'rapid-mlx[audio]'` | ~600 MB | 26 TTS/STT aliases (Kokoro, Chatterbox, VibeVoice, VoxCPM, Dia, Whisper, Parakeet) via `/v1/audio/speech` and `/v1/audio/transcriptions`; bundles Silero VAD for silence pre-trim (guards Whisper against silence hallucination) |
 | `embeddings` | `pip install 'rapid-mlx[embeddings]'` | ~50 MB | `/v1/embeddings` endpoint (mlx-embeddings) |
 | `chat` | `pip install 'rapid-mlx[chat]'` | ~150 MB | Built-in Gradio chat UI |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,18 @@ dependencies = [
     # default — the only path that round-trips cleanly across threads.
     "mlx>=0.31.2",
     "mlx-lm>=0.31.3",  # 0.31.1+ required for presence_penalty/frequency_penalty kwargs on make_logits_processors (#512); 0.31.3 added thread-local generation_stream but cross-thread eval is still broken (see shim sites).
-    # mlx-vlm is opt-in via [vision] extras (saves ~322 MB for text-only users)
+    # mlx-vlm is now a CORE dep (was `[vision]` extra pre-0.10.1). Reason:
+    # 0.10.0 shipped +13 Gemma 4 aliases as a headline feature, but a first-time
+    # `pip install rapid-mlx==0.10.0 && rapid-mlx serve gemma-4-12b-4bit` failed
+    # at import with `ImportError: mlx-vlm dependency missing` — a naive-user
+    # regression the M3 Ultra pre-merge dogfood missed because the local venv
+    # already had mlx-vlm from a prior session. See project_0100_shipped.md.
+    # Transitive cost: ~+110 MB (opencv + datasets + miniaudio + llguidance +
+    # mlx-audio + Pillow); NOT the +322 MB the old `[vision]` comment quoted
+    # (that included torch + torchvision, which are still `[vision]`-only for
+    # the non-mlx-vlm vision preprocessing paths). L-07 contract updated in
+    # `tests/test_vision_extra_install.py` to lock this in.
+    "mlx-vlm>=0.6.3",
     #
     # Upper cap <5.13 (release-blocker): mlx-lm and mlx-vlm both float
     # transformers with no upper bound, but transformers 5.13.0 tightened
@@ -100,16 +111,23 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-# Vision/multimodal models (Gemma 4, Qwen-VL, etc.) — adds ~322 MB
-# Required for any model with vision input. Text-only models work without this.
-# 0.5.0+ also unlocks DFlash speculative decoding (see [dflash] extras).
+# Vision-INPUT preprocessing (Qwen-VL image understanding, video, etc.) —
+# adds ~210 MB (torch + torchvision).
+#
+# 0.10.1 note: mlx-vlm was previously listed here; it is now a CORE dep so
+# Gemma 4 and DiffusionGemma work with a plain `pip install rapid-mlx`.
+# mlx-vlm is still listed below (redundant but harmless — pip resolves it as
+# already-satisfied) to keep the L-07 lock-in tests + `[all]` synthesis
+# straightforward. Its transitive pillow/opencv-python satisfy the direct
+# imports below.
 vision = [
-    "mlx-vlm>=0.6.3",  # 0.6.3: DiffusionGemma (Gemma 4 DLM PR #1347 + long-context prefill PR #1348). 0.6.1 floor: gemma4_unified architecture. 0.5.0 baseline: gemma4 multi-image + tool-parser fixes, TurboQuant race-condition fix, continuous-batching guard. Also unlocks DFlash spec-decode hooks (see [dflash] extras).
-    "opencv-python>=4.8.0",
-    "torch>=2.3.0",
+    "mlx-vlm>=0.6.3",  # core dep in 0.10.1+; kept here for backward-compat with the L-07 lock-in test surface (`test_vision_extra_lists_mlx_vlm`).
+    "opencv-python>=4.8.0",  # also in mlx-vlm's transitive; kept explicit for the non-mlx-vlm code paths (mllm.py, benchmark.py image mode).
+    "torch>=2.3.0",  # the actual reason `[vision]` still exists — torch is NOT a mlx-vlm transitive.
     "torchvision>=0.18.0",
     # vllm_mlx imports PIL directly on vision paths (mllm.py, benchmark.py
-    # image mode); mlx-vlm requires it too — listed for explicitness.
+    # image mode); mlx-vlm's transitive would satisfy it, listed explicit
+    # so a future mlx-vlm dep-drop doesn't silently break vision code.
     "pillow>=10.0.0",
 ]
 # DFlash speculative decoding for Qwen3.5/3.6 dense 8-bit models

--- a/tests/test_vision_extra_install.py
+++ b/tests/test_vision_extra_install.py
@@ -147,23 +147,39 @@ def test_vision_mlx_vlm_floor_is_recognizable() -> None:
 
 
 # ──────────────────────────────────────────────────────────────────────
-# Defense in depth: mlx-vlm must NOT be in core deps (would defeat the
-# whole point of the extra — the ~322 MB save for text-only users).
+# 0.10.1 CONTRACT FLIP — mlx-vlm MUST now be in core deps.
+#
+# History: 0.8.0-0.10.0 kept mlx-vlm as an opt-in `[vision]` extra to save
+# text-only users the ~322 MB torch+torchvision+opencv+mlx-vlm bundle.
+# 0.10.0 then shipped +13 Gemma 4 aliases as a headline feature — but Gemma
+# 4's model class lives inside mlx-vlm, so a first-time `pip install
+# rapid-mlx==0.10.0 && rapid-mlx serve gemma-4-12b-4bit` failed with an
+# ImportError at boot. Pre-merge dogfood on M3 Ultra missed it because the
+# local venv already carried mlx-vlm from a prior session; only a fresh-venv
+# naive-user simulation caught it.
+#
+# 0.10.1 promotes `mlx-vlm>=0.6.3` to core. Transitive cost: ~+110 MB
+# (opencv + datasets + miniaudio + llguidance + mlx-audio + Pillow). torch
+# + torchvision remain `[vision]`-only for non-mlx-vlm vision preprocessing
+# (Qwen-VL etc.). The L-07 contract is reversed: this test now enforces
+# `mlx-vlm IS in core`.
 # ──────────────────────────────────────────────────────────────────────
 
 
-def test_mlx_vlm_not_in_core_dependencies() -> None:
-    """If ``mlx-vlm`` slips into ``[project].dependencies`` the
-    text-only ``pip install rapid-mlx`` jumps from ~460 MB to ~782 MB.
-    The point of the ``[vision]`` extra is to keep that surface
-    opt-in. This is the second half of L-07's contract."""
+def test_mlx_vlm_is_in_core_dependencies() -> None:
+    """0.10.1 contract flip — mlx-vlm MUST be a core dep so a fresh
+    ``pip install rapid-mlx && rapid-mlx serve gemma-4-*`` works out of
+    the box. If this assertion fails, the fresh-install Gemma 4 regression
+    surfaced 2026-07-04 in project_0100_shipped.md returns."""
     py = _load_pyproject()
     core = py.get("project", {}).get("dependencies", [])
     core_names = {_split_spec(s)[0].lower() for s in core}
-    assert "mlx-vlm" not in core_names, (
-        f"mlx-vlm leaked into core deps={core!r}. Move it back under "
-        f"`[project.optional-dependencies].vision` so the text-only "
-        f"`pip install rapid-mlx` stays slim (L-07)."
+    assert "mlx-vlm" in core_names, (
+        f"mlx-vlm missing from core deps={core!r}. Fresh `pip install "
+        f"rapid-mlx && rapid-mlx serve gemma-4-12b-4bit` now fails with "
+        f"`ImportError: mlx-vlm dependency missing`. Add "
+        f"`\"mlx-vlm>=0.6.3\"` to `[project].dependencies` — that's the "
+        f"post-0.10.1 L-07 contract."
     )
 
 

--- a/tests/test_vision_extra_install.py
+++ b/tests/test_vision_extra_install.py
@@ -178,7 +178,7 @@ def test_mlx_vlm_is_in_core_dependencies() -> None:
         f"mlx-vlm missing from core deps={core!r}. Fresh `pip install "
         f"rapid-mlx && rapid-mlx serve gemma-4-12b-4bit` now fails with "
         f"`ImportError: mlx-vlm dependency missing`. Add "
-        f"`\"mlx-vlm>=0.6.3\"` to `[project].dependencies` — that's the "
+        f'`"mlx-vlm>=0.6.3"` to `[project].dependencies` — that\'s the '
         f"post-0.10.1 L-07 contract."
     )
 


### PR DESCRIPTION
## Summary

**Regression fix for 0.10.0.** A first-time user who ran `pip install rapid-mlx==0.10.0 && rapid-mlx serve gemma-4-12b-4bit` hit `ImportError: Gemma 4 models require the optional 'mlx-vlm' dependency` — but the release notes advertised 13 new Gemma 4 aliases as a headline feature. Pre-merge dogfood on M3 Ultra missed this because the local venv already carried mlx-vlm from a prior session; only fresh-venv naive-user simulation caught it (post-release dogfood matrix in `project_0100_shipped.md`).

## Change

- `pyproject.toml`: add `mlx-vlm>=0.6.3` to core `[project].dependencies`. Transitive install cost: **~+110 MB** (opencv-python + datasets + miniaudio + llguidance + mlx-audio + Pillow). NOT the +322 MB the old `[vision]` comment quoted — that number included torch + torchvision, which stay `[vision]`-only for non-mlx-vlm vision preprocessing (Qwen-VL image understanding, video, etc.).
- `tests/test_vision_extra_install.py`: reverse the L-07 contract's second half. Prior `test_mlx_vlm_not_in_core_dependencies` renamed to `test_mlx_vlm_is_in_core_dependencies` with a doc-string explaining the flip and pointing at the 0.10.0 regression. The other 7 L-07 assertions still pass (`[vision]` extra still exists, still lists mlx-vlm, still has a real floor, still mentioned in README, `[all]` still includes it) — mlx-vlm being in **both** core and `[vision]` is redundant but harmless.
- `README.md`: update the "vision extras" callout in Install + the extras table so first-timers understand Gemma 4 / DiffusionGemma work with a plain `pip install rapid-mlx` in 0.10.1+. `[vision]` is now scoped to Qwen-VL image preprocessing (torch + torchvision).

## Fresh-venv dogfood proof

```bash
python3.12 -m venv /tmp/rmx-df-mlxvlm-fix
/tmp/rmx-df-mlxvlm-fix/bin/pip install .
/tmp/rmx-df-mlxvlm-fix/bin/rapid-mlx serve gemma-4-12b-4bit --port 8906
# → ~12s to boot; Uvicorn on http://127.0.0.1:8906
curl -sS http://127.0.0.1:8906/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{"model":"gemma-4-12b-4bit","messages":[{"role":"user","content":"Reply with exactly the single word: papaya"}],"max_tokens":16,"temperature":0}'
# → {"content":"papaya","finish_reason":"stop"}
```

L-07 lock-in suite: **8/8** passing on the new pyproject shape.

## Notes for review

- **Extras redundancy on purpose**: keeping `mlx-vlm>=0.6.3` in both core AND `[vision]` avoids churning the L-07 test surface. Pip treats it as already-satisfied on `pip install 'rapid-mlx[vision]'`; only tradeoff is one extra line of pyproject noise. A follow-up PR could clean this if reviewers prefer.
- **`[mtp]` extra** still ships pillow explicitly. mlx-vlm's transitive Pillow now satisfies it too, so the `[mtp]` extra is technically redundant on fresh installs — but I'm not touching it in this PR (respects the codex round-I NIT documented at pyproject.toml:135-146).
- **Auto-release**: this is a fix PR, NOT a bump. Version stays 0.10.0. The 0.10.1 bump PR follows separately per repo release SOP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)