### PR TITLE
chore: revert accidental 0.10.1 bump in #1010

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.10.1"
+version = "0.10.0"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## Summary

- PR #1010 bumped \`pyproject.toml\` from 0.10.0 to 0.10.1 inside its feature commit; auto-release regex only fires on subjects matching \`chore: bump version to X.Y.Z (#N)\`, so the release never triggered. Main is at 0.10.1 while PyPI is stuck at 0.10.0.
- This PR reverts ONLY the pyproject.toml version line back to 0.10.0. #1010's ddtree runtime code stays intact on main.
- Follow-up PR will re-bump 0.10.0 → 0.10.1 with the correct chore subject so auto-release.yml fires. 0.10.1 will ship #1010 (ddtree) + #1017 (Gemma 4 vendor). Originally-planned 0.10.1 (Layer C agent integration) cascades to 0.10.2.

## Test plan

Single-line pyproject.toml revert; no runtime code touched. GH CI matrix + type-check + lint + validate all cover pyproject shape. After merge, verify \`git show main:pyproject.toml | grep '^version'\` prints \`version = "0.10.0"\`, then open the re-bump PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)