### PR TITLE
chore: bump version to 0.10.1 (#1021)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.10.0"
+version = "0.10.1"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## Summary

0.10.1 release trigger — dedicated version-bump commit per repo policy. Auto-release.yml fires on this PR's squash-merge (regex requires the exact `chore: bump version to X.Y.Z (#N)` subject).

0.10.1 ships:
- **#1010** — codex re-land validated experimental ddtree support
- **#1017** — Gemma 4 fresh-install regression fix (vendor mlx-vlm text classes into `vllm_mlx/models/gemma4_vendored/`, no [vision] extra required for text-only Gemma 4 chat/tools/reasoning)
- **#1020** — chore revert of #1010's accidental inline 0.10.1 bump (this PR re-bumps 0.10.0 → 0.10.1)

The originally-planned 0.10.1 scope (Layer C agent integration — Tier 1 codex/claude-code/opencode/qwen-code/openhands) cascades to 0.10.2; downstream perf work (Gemma 4/Qwen 3.6/gpt-oss) shifts by one version accordingly.

## Test plan

Single-line pyproject.toml bump; no runtime code touched. GH CI matrix + type-check + lint + validate cover pyproject shape. After merge, verify: (a) auto-release.yml fires within a minute, (b) fresh `pip install rapid-mlx==0.10.1` on Python 3.12 venv succeeds, (c) that same venv runs `rapid-mlx serve gemma-4-12b-4bit` and responds via `/v1/chat/completions` (regression fix validated end-to-end), (d) `brew upgrade rapid-mlx` picks up 0.10.1 within the Homebrew mirror lag window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)