### PR TITLE
[codex] migrate dflash to speculative config

### DIFF
--- a/README.md
+++ b/README.md
@@ -722,7 +722,7 @@ Qwen3.5 uses Gated DeltaNet (75% RNN) + full attention (25% KV). Other engines r
 | **Auto tool recovery** | Detect broken text-format tool calls, convert to structured | All 17 parser formats (incl. Gemma 4) |
 | **TurboQuant K8V4 codec** | K 8-bit + V 4-bit after Walsh-Hadamard + Lloyd-Max (~1/2.4 compression, lossless across verified matrix) | Default-on for 9 verified Qwen3.5/3.6 aliases; `--kv-cache-turboquant k8v4\|v4\|none` |
 | **KV cache quantization** | Quantize prefix cache entries to reduce memory | All models with `--kv-cache-quantization` |
-| **DFlash speculative decoding** | Block-diffusion drafter, parallel draft + verify (single-user) | `qwen3.5-27b-8bit`, `qwen3.6-27b-8bit` with `--enable-dflash` |
+| **DFlash speculative decoding** | Block-diffusion drafter, parallel draft + verify (single-user) | `qwen3.5-27b-8bit`, `qwen3.6-27b-8bit` with `--speculative-config '{"method":"dflash"}'` |
 | **DDTree speculative decoding** | DFlash draft-tree verification over multiple branches | `qwen3.5-9b-8bit` (experimental, single-user) |
 | **MTP speculative decoding** | Multi-token prediction head shipped with the model | MTP-trained checkpoints with `--enable-mtp` |
 | **SuffixDecoding** | Drafter-free, statistical n-gram lookup speculative decoding | All BatchedEngine models with `--suffix-decoding` |
@@ -764,7 +764,7 @@ Run your own: `bash evals/run_all_models.sh` runs the full quality suite (tool c
 | **TurboQuant K8V4 KV codec** | K is 8-bit + V is 4-bit after Walsh-Hadamard rotation + Lloyd-Max quantization — compresses KV to ~1/2.4 (~58% savings), lossless across the verified matrix. **Default-on for 9 verified Qwen3.5/3.6 aliases** (see below); `--kv-cache-turboquant none` to force off. |
 | **Smart cloud routing** | Large-context requests auto-route to a cloud LLM (`--cloud-model openai/gpt-5 --cloud-threshold 20000`) when local prefill would be slow. |
 | **Multimodal** | Vision, audio (STT/TTS with bundled Silero VAD silence pre-trim), video understanding, text embeddings — all through the standard OpenAI endpoints. |
-| **Speculative decoding** | DFlash (block-diffusion drafter, `--enable-dflash`), DDTree (DFlash draft tree, vLLM-style `--speculative-config '{"method":"ddtree"}'`), MTP (multi-token prediction head, `--enable-mtp`), SuffixDecoding (drafter-free n-gram, `--suffix-decoding`). Opt-in per alias — see below. |
+| **Speculative decoding** | DFlash (block-diffusion drafter, vLLM-style `--speculative-config '{"method":"dflash"}'`), DDTree (DFlash draft tree, `--speculative-config '{"method":"ddtree"}'`), MTP (multi-token prediction head, `--enable-mtp`), SuffixDecoding (drafter-free n-gram, `--suffix-decoding`). Opt-in per alias — see below. |
 | **Structured output, logprobs, continuous batching, KV quantization** | Standard, no flags or with one flag each. |
 | **3300+ tests** | Across reasoning, tool parsing, streaming, agent harnesses, and engine integration. |
 
@@ -775,7 +775,7 @@ Run your own: `bash evals/run_all_models.sh` runs the full quality suite (tool c
 
 Rapid-MLX ships in-tree speculative modes plus an experimental external DDTree integration. All are **opt-in** per alias — `rapid-mlx info <alias>` shows what's eligible on the model you're serving.
 
-**DFlash** — block-diffusion drafter (via mlx-vlm), single-user path. Opt in with `--enable-dflash`; requires `pip install 'rapid-mlx[dflash]'`.
+**DFlash** — block-diffusion drafter (via mlx-vlm), single-user path. Opt in with `--speculative-config '{"method":"dflash"}'`; requires `pip install 'rapid-mlx[dflash]'`.
 
 | Alias | Drafter | Avg speedup | Min / Max |
 |---|---|---|---|
@@ -785,10 +785,10 @@ Rapid-MLX ships in-tree speculative modes plus an experimental external DDTree i
 ```bash
 pip install 'rapid-mlx[dflash]'
 rapid-mlx info qwen3.5-27b-8bit       # check per-gate eligibility
-rapid-mlx serve qwen3.5-27b-8bit --enable-dflash
+rapid-mlx serve qwen3.5-27b-8bit --speculative-config '{"method":"dflash"}'
 ```
 
-Workload sensitivity: coding / math / summarization typically see **1.5–2.7×**; high-entropy creative writing and long-form chat can dip to **0.6–0.9×** because the drafter's training distribution diverges from open-ended generation — a known spec-decode literature pattern ([AdaEDL](https://arxiv.org/abs/2410.18351)), not a bug. DFlash mode runs a dedicated single-user server (no batched kernel yet); tool calling, MCP, and embeddings aren't available in that mode — restart without `--enable-dflash` for those.
+Workload sensitivity: coding / math / summarization typically see **1.5–2.7×**; high-entropy creative writing and long-form chat can dip to **0.6–0.9×** because the drafter's training distribution diverges from open-ended generation — a known spec-decode literature pattern ([AdaEDL](https://arxiv.org/abs/2410.18351)), not a bug. DFlash mode runs a dedicated single-user server (no batched kernel yet); tool calling, MCP, and embeddings aren't available in that mode — restart without DFlash for those.
 
 **MTP** (Multi-Token Prediction) — draft head baked into the model. Opt in with `--enable-mtp` on MTP-trained checkpoints. Auto-tune of `--mtp-num-draft-tokens` per workload is roadmapped for the 0.9.1x line.
 
@@ -809,7 +809,7 @@ rapid-mlx serve qwen3.5-9b-8bit \
   --speculative-config '{"method":"ddtree","model":"z-lab/Qwen3.5-9B-DFlash","num_speculative_tokens":16,"tree_budget":24}'
 ```
 
-`--enable-ddtree` remains as a compatibility shorthand for `--speculative-config '{"method":"ddtree"}'`; it is not enabled by default. MTP, DFlash, and SuffixDecoding keep their existing flags until they migrate behind the same config interface.
+`--enable-dflash` remains as a compatibility shorthand for `--speculative-config '{"method":"dflash"}'`, and `--dflash-drafter-path` maps to the config `model` field. `--enable-ddtree` similarly remains as a compatibility shorthand for `--speculative-config '{"method":"ddtree"}'`. Neither backend is enabled by default. MTP and SuffixDecoding keep their existing flags until they migrate behind the same config interface.
 
 Mutex: DFlash cannot combine with MTP or SuffixDecoding (single-user path). MTP and SuffixDecoding cannot combine with each other (both consume the drafter slot).
 
@@ -848,8 +848,8 @@ Mutex: DFlash cannot combine with MTP or SuffixDecoding (single-user path). MTP 
 | `--enable-prefix-cache` / `--disable-prefix-cache` | Cache common prefixes across requests | on |
 | `--prefix-cache-index` | Prefix-cache lookup index: `radix` (default) or `hash` | `radix` |
 | `--pflash` | PFlash sparse prefill: `auto` / `always` / `off` | `auto` (on for verified aliases) |
-| `--enable-dflash` | DFlash speculative decoding (single-user; `qwen3.5-27b-8bit` / `qwen3.6-27b-8bit`) | off |
-| `--speculative-config` | vLLM-style speculative decoding JSON config; DDTree MVP supports `{"method":"ddtree"}` | off |
+| `--enable-dflash` | Compatibility shorthand for DFlash speculative decoding (single-user; prefer `--speculative-config '{"method":"dflash"}'`) | off |
+| `--speculative-config` | vLLM-style speculative decoding JSON config; DFlash supports `{"method":"dflash"}` and DDTree supports `{"method":"ddtree"}` | off |
 | `--enable-ddtree` | Compatibility shorthand for DDTree speculative decoding (single-user; `qwen3.5-9b-8bit`) | off |
 | `--suffix-decoding` | Drafter-free n-gram speculative decoding (BatchedEngine path) | off |
 | `--enable-mtp` | MTP head speculative decoding (requires MTP-trained model) | off |
@@ -1053,7 +1053,7 @@ harness/                 # Regression baselines + thresholds
 
 | Technique | Expected Gain | Status |
 |-----------|---------------|--------|
-| [DFlash](https://arxiv.org/abs/2602.06036) — block-diffusion drafter, single-user | 1.3–2× decode (workload-dependent) | Shipping, opt-in (`--enable-dflash`, `[dflash]` extra; qwen3.5-27b-8bit, qwen3.6-27b-8bit) |
+| [DFlash](https://arxiv.org/abs/2602.06036) — block-diffusion drafter, single-user | 1.3–2× decode (workload-dependent) | Shipping, opt-in (`--speculative-config '{"method":"dflash"}'`, `[dflash]` extra; qwen3.5-27b-8bit, qwen3.6-27b-8bit) |
 | [DDTree](https://arxiv.org/abs/2604.12989) — DFlash draft-tree verification, single-user | TBD on rapid-mlx 9B gate | Experimental (`--speculative-config '{"method":"ddtree"}'`; `--enable-ddtree` compatibility shorthand) |
 | [SuffixDecoding](https://arxiv.org/abs/2411.04975) — drafter-free n-gram speculative | 1.1–1.5× decode | Shipping (`--suffix-decoding`, per-model tier sweep ongoing) |
 | MTP — Multi-Token Prediction head | 1.4–1.7× decode | Shipping, opt-in (`--enable-mtp`, MTP-trained checkpoints); per-workload auto-tune of `--mtp-num-draft-tokens` landing in the 0.9.1x line |

--- a/docs/benchmarks/llm.md
+++ b/docs/benchmarks/llm.md
@@ -95,7 +95,7 @@ Notes:
 - Throughput peaks at **1024–2048** tokens, then dips at 4096 — consistent with KV-cache pressure as the rolling window fills.
 - Memory delta (baseline → DFlash) tracks the draft model + verification overhead; see the source benchmark for the exact figure.
 
-`Qwen3.6-35B-A3B-8bit` supports DFlash as an experimental opt-in (install `[dflash]` extra, pass `--enable-dflash`); numbers above are from a community benchmark and reflect that single run.
+`Qwen3.6-35B-A3B-8bit` supports DFlash as an experimental opt-in (install `[dflash]` extra, pass `--speculative-config '{"method":"dflash"}'`); numbers above are from a community benchmark and reflect that single run.
 
 ## Prefix Cache Results
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -87,7 +87,7 @@ rapid-mlx serve deepseek-r1-8b-4bit --reasoning-parser deepseek_r1
 rapid-mlx serve devstral-24b-4bit --enable-auto-tool-choice --tool-call-parser hermes
 
 # DFlash speculative decoding (single-user, single supported alias)
-rapid-mlx serve qwen3.5-27b-8bit --enable-dflash --port 8000
+rapid-mlx serve qwen3.5-27b-8bit --speculative-config '{"method":"dflash"}' --port 8000
 
 # DDTree speculative decoding (experimental, single-user)
 rapid-mlx serve qwen3.5-9b-8bit --speculative-config '{"method":"ddtree"}' --port 8000

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.10.1"
+version = "0.10.2"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.10.2"
+version = "0.10.1"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/tests/test_dflash_integration.py
+++ b/tests/test_dflash_integration.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import importlib.util
 import os
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
@@ -61,6 +62,167 @@ def test_serve_parser_exposes_enable_dflash() -> None:
     assert "[dflash]" in out.stdout, (
         "help text should reference the rapid-mlx[dflash] extras"
     )
+
+
+def _dflash_cli_args(**overrides):
+    data = {
+        "model": "qwen3.5-27b-8bit",
+        "_original_alias": None,
+        "speculative_config": None,
+        "enable_ddtree": False,
+        "enable_dflash": False,
+        "spec_decode": "none",
+        "suffix_decoding": False,
+        "enable_mtp": False,
+        "no_spec_decode": False,
+        "dflash_drafter_path": "",
+    }
+    data.update(overrides)
+    return SimpleNamespace(**data)
+
+
+def test_speculative_config_dflash_normalizes_to_legacy_server_flag() -> None:
+    from vllm_mlx.cli import (
+        _normalize_speculative_config_or_exit,
+        _resolve_dflash_drafter_repo,
+    )
+
+    args = _dflash_cli_args(
+        speculative_config=('{"method":"dflash","model":"z-lab/Qwen3.5-27B-DFlash"}')
+    )
+
+    _normalize_speculative_config_or_exit(args)
+
+    assert args.enable_dflash is True
+    assert args.spec_decode == "none"
+    assert args._speculative_config.method == "dflash"
+    assert args._speculative_config.model == "z-lab/Qwen3.5-27B-DFlash"
+    profile = SimpleNamespace(dflash_draft_model="z-lab/default")
+    assert _resolve_dflash_drafter_repo(args, profile) == "z-lab/Qwen3.5-27B-DFlash"
+
+
+def test_enable_dflash_legacy_flag_is_speculative_config_shorthand() -> None:
+    from vllm_mlx.cli import (
+        _normalize_speculative_config_or_exit,
+        _resolve_dflash_drafter_repo,
+    )
+
+    args = _dflash_cli_args(
+        enable_dflash=True,
+        dflash_drafter_path="local/dflash-drafter",
+    )
+
+    _normalize_speculative_config_or_exit(args)
+
+    assert args.enable_dflash is True
+    assert args.spec_decode == "none"
+    assert args._speculative_config.method == "dflash"
+    assert args._speculative_config.model == "local/dflash-drafter"
+    profile = SimpleNamespace(dflash_draft_model="z-lab/default")
+    assert _resolve_dflash_drafter_repo(args, profile) == "local/dflash-drafter"
+
+
+def test_spec_decode_dflash_legacy_flag_is_speculative_config_shorthand() -> None:
+    from vllm_mlx.cli import _normalize_speculative_config_or_exit
+
+    args = _dflash_cli_args(spec_decode="dflash")
+
+    _normalize_speculative_config_or_exit(args)
+
+    assert args.enable_dflash is True
+    assert args.spec_decode == "none"
+    assert args._legacy_spec_decode_dflash is True
+    assert args._speculative_config.method == "dflash"
+    assert args._speculative_config.model is None
+
+
+def test_spec_decode_dflash_legacy_redirect_notice_is_preserved(capsys) -> None:
+    from vllm_mlx.cli import (
+        _maybe_print_legacy_dflash_redirect,
+        _normalize_speculative_config_or_exit,
+    )
+
+    args = _dflash_cli_args(spec_decode="dflash")
+
+    _normalize_speculative_config_or_exit(args)
+    _maybe_print_legacy_dflash_redirect(args)
+
+    captured = capsys.readouterr()
+    assert "--spec-decode dflash routed to --enable-dflash" in captured.err
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"enable_dflash": True},
+        {"spec_decode": "dflash"},
+        {"spec_decode": "mtp"},
+        {"dflash_drafter_path": "local/drafter"},
+    ],
+)
+def test_speculative_config_rejects_legacy_spec_decode_flags(overrides, capsys) -> None:
+    from vllm_mlx.cli import _normalize_speculative_config_or_exit
+
+    args = _dflash_cli_args(
+        speculative_config='{"method":"dflash"}',
+        **overrides,
+    )
+
+    with pytest.raises(SystemExit) as excinfo:
+        _normalize_speculative_config_or_exit(args)
+
+    assert excinfo.value.code == 2
+    captured = capsys.readouterr()
+    assert "mutually exclusive" in captured.err
+
+
+@pytest.mark.parametrize(
+    ("overrides", "code", "match"),
+    [
+        ({"enable_mtp": True}, 1, "cannot combine"),
+        ({"suffix_decoding": True}, 1, "cannot combine"),
+        ({"no_spec_decode": True}, 2, "mutually exclusive"),
+    ],
+)
+def test_dflash_speculative_config_conflicts_fail_before_runtime_probe(
+    overrides, code, match, capsys
+) -> None:
+    from vllm_mlx.cli import (
+        _normalize_speculative_config_or_exit,
+        _preflight_dflash_mutexes_or_exit,
+    )
+
+    args = _dflash_cli_args(
+        speculative_config='{"method":"dflash"}',
+        **overrides,
+    )
+
+    _normalize_speculative_config_or_exit(args)
+    with pytest.raises(SystemExit) as excinfo:
+        _preflight_dflash_mutexes_or_exit(args)
+
+    assert excinfo.value.code == code
+    captured = capsys.readouterr()
+    assert match in captured.out + captured.err
+
+
+def test_enable_dflash_legacy_mix_rejects_spec_decode_mtp(capsys) -> None:
+    from vllm_mlx.cli import (
+        _normalize_speculative_config_or_exit,
+        _preflight_dflash_mutexes_or_exit,
+    )
+
+    args = _dflash_cli_args(enable_dflash=True, spec_decode="mtp")
+
+    _normalize_speculative_config_or_exit(args)
+    assert args.enable_dflash is True
+    assert args.spec_decode == "mtp"
+    with pytest.raises(SystemExit) as excinfo:
+        _preflight_dflash_mutexes_or_exit(args)
+
+    assert excinfo.value.code == 1
+    captured = capsys.readouterr()
+    assert "cannot combine" in captured.out
 
 
 # =============================================================================
@@ -141,7 +303,10 @@ def test_info_dflash_start_with_uses_alias_not_hf_path(capsys, monkeypatch) -> N
     )()
     info_command(args)
     captured = capsys.readouterr()
-    assert "rapid-mlx serve qwen3.5-27b-8bit --enable-dflash" in captured.out
+    assert (
+        """rapid-mlx serve qwen3.5-27b-8bit --speculative-config '{"method":"dflash"}'"""
+        in captured.out
+    )
     # The HF path must not show up in the start-with hint.
     assert "rapid-mlx serve mlx-community/" not in captured.out
 

--- a/tests/test_speculative_config.py
+++ b/tests/test_speculative_config.py
@@ -41,6 +41,18 @@ def test_parse_ddtree_speculative_config_accepts_method_keys() -> None:
     assert cfg.tree_budget == 24
 
 
+def test_parse_dflash_speculative_config_accepts_drafter_model() -> None:
+    cfg = parse_speculative_config(
+        '{"method":"dflash","model":"z-lab/Qwen3.5-27B-DFlash"}'
+    )
+
+    assert cfg is not None
+    assert cfg.method == "dflash"
+    assert cfg.model == "z-lab/Qwen3.5-27B-DFlash"
+    assert cfg.num_speculative_tokens is None
+    assert cfg.tree_budget is None
+
+
 def test_parse_speculative_config_normalizes_registered_alias() -> None:
     cfg = parse_speculative_config('{"method":"ngram"}')
 
@@ -62,6 +74,11 @@ def test_parse_speculative_config_normalizes_registered_alias() -> None:
         ('{"method":"ddtree","tree_budget":0}', "positive integer"),
         ('{"method":"ddtree","tree_budget":true}', "positive integer"),
         ('{"method":"ddtree","unknown":1}', "unsupported speculative-config"),
+        (
+            '{"method":"dflash","num_speculative_tokens":4}',
+            "unsupported speculative-config",
+        ),
+        ('{"method":"dflash","tree_budget":24}', "unsupported speculative-config"),
         ('{"method":"unknown"}', "unsupported speculative decoding method"),
     ],
 )
@@ -85,11 +102,19 @@ def test_require_migrated_speculative_config_accepts_ddtree() -> None:
     require_migrated_speculative_config(cfg)
 
 
+def test_require_migrated_speculative_config_accepts_dflash() -> None:
+    cfg = parse_speculative_config('{"method":"dflash"}')
+    assert cfg is not None
+
+    require_migrated_speculative_config(cfg)
+
+
 def test_spec_decoder_registry_lists_existing_backends() -> None:
     methods = {plugin.method for plugin in iter_spec_decoders()}
 
     assert {"ddtree", "dflash", "mtp", "suffix"}.issubset(methods)
     assert get_spec_decoder("ddtree").config_enabled is True
+    assert get_spec_decoder("dflash").config_enabled is True
     assert get_spec_decoder("ngram") == get_spec_decoder("suffix")
 
 

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -1558,18 +1558,32 @@ def _normalize_speculative_config_or_exit(args):
     from .spec_decode.config import (
         SpeculativeConfigError,
         legacy_ddtree_config,
+        legacy_dflash_config,
         parse_speculative_config,
         require_migrated_speculative_config,
     )
 
     raw_config = getattr(args, "speculative_config", None)
-    if raw_config is not None and getattr(args, "enable_ddtree", False):
-        print(
-            "error: --speculative-config and --enable-ddtree are mutually "
-            "exclusive; use method='ddtree' in --speculative-config.",
-            file=sys.stderr,
-        )
-        sys.exit(2)
+    if raw_config is not None:
+        conflicts = []
+        if getattr(args, "enable_ddtree", False):
+            conflicts.append("--enable-ddtree")
+        if getattr(args, "enable_dflash", False):
+            conflicts.append("--enable-dflash")
+        spec_decode = getattr(args, "spec_decode", "none")
+        if spec_decode != "none":
+            conflicts.append(f"--spec-decode {spec_decode}")
+        if (getattr(args, "dflash_drafter_path", "") or "").strip():
+            conflicts.append("--dflash-drafter-path")
+        if conflicts:
+            joined = ", ".join(conflicts)
+            print(
+                "error: --speculative-config is mutually exclusive with "
+                f"{joined}; express speculative decoding settings inside "
+                "--speculative-config.",
+                file=sys.stderr,
+            )
+            sys.exit(2)
     try:
         config = parse_speculative_config(raw_config)
         if config is not None:
@@ -1577,11 +1591,81 @@ def _normalize_speculative_config_or_exit(args):
     except SpeculativeConfigError as exc:
         print(f"error: {exc}", file=sys.stderr)
         sys.exit(2)
-    if config is None and getattr(args, "enable_ddtree", False):
-        config = legacy_ddtree_config()
+    if config is None:
+        if getattr(args, "enable_ddtree", False):
+            config = legacy_ddtree_config()
+        elif getattr(args, "enable_dflash", False) or (
+            getattr(args, "spec_decode", "none") == "dflash"
+        ):
+            config = legacy_dflash_config(
+                (getattr(args, "dflash_drafter_path", "") or "").strip() or None
+            )
     args._speculative_config = config
-    if config is not None and config.method == "ddtree":
+    if config is None:
+        return
+    if config.method == "ddtree":
         args.enable_ddtree = True
+    elif config.method == "dflash":
+        legacy_spec_decode_dflash = getattr(args, "spec_decode", "none") == "dflash"
+        args.enable_dflash = True
+        if legacy_spec_decode_dflash:
+            args._legacy_spec_decode_dflash = True
+            args.spec_decode = "none"
+
+
+def _resolve_dflash_drafter_repo(args, profile) -> str:
+    """Return the effective DFlash drafter repo for normalized CLI args."""
+
+    spec_config = getattr(args, "_speculative_config", None)
+    if spec_config is not None and spec_config.method == "dflash" and spec_config.model:
+        return spec_config.model
+    legacy_override = (getattr(args, "dflash_drafter_path", "") or "").strip()
+    return legacy_override or profile.dflash_draft_model
+
+
+def _preflight_dflash_mutexes_or_exit(args) -> None:
+    """Reject DFlash flag combinations before optional-runtime probes."""
+
+    if not getattr(args, "enable_dflash", False):
+        return
+
+    import sys
+
+    spec_decode = getattr(args, "spec_decode", "none")
+    if (
+        getattr(args, "suffix_decoding", False)
+        or getattr(args, "enable_mtp", False)
+        or spec_decode != "none"
+    ):
+        print(
+            "\n  Error: DFlash cannot combine with --suffix-decoding "
+            "or other spec-decode methods. DFlash runs a dedicated "
+            "single-user server that bypasses BatchedEngine; other "
+            "spec-decode methods only apply to the BatchedEngine path.\n"
+        )
+        sys.exit(1)
+    if getattr(args, "no_spec_decode", False):
+        print(
+            "error: DFlash and --no-spec-decode are mutually exclusive "
+            "— DFlash is a speculative-decode mode.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+
+def _maybe_print_legacy_dflash_redirect(args) -> None:
+    """Preserve the legacy ``--spec-decode dflash`` redirect notice."""
+
+    if not getattr(args, "_legacy_spec_decode_dflash", False):
+        return
+
+    import sys
+
+    print(
+        "Spec-decode: --spec-decode dflash routed to --enable-dflash "
+        "(mlx-vlm bridge; BatchedEngine integration deferred to 0.10).",
+        file=sys.stderr,
+    )
 
 
 def _preflight_ddtree_or_exit(args):
@@ -1757,6 +1841,8 @@ def serve_command(args):
     if getattr(args, "enable_ddtree", False):
         _preflight_ddtree_or_exit(args)
 
+    _preflight_dflash_mutexes_or_exit(args)
+
     # 0.9.2 dogfood (parallels the [embeddings]/[vision]/[audio] guards
     # immediately above): ``--enable-dflash`` and the equivalent
     # ``--spec-decode dflash`` both depend on the optional ``mlx-vlm``
@@ -1780,9 +1866,11 @@ def serve_command(args):
 
         if not have_runtime():
             print(
-                "\n  Error: --enable-dflash (and --spec-decode dflash) "
-                "requires mlx-vlm 0.5.0+ for the DFlash drafter hooks. "
-                "Install with: ``pip install 'rapid-mlx[dflash]'``.\n"
+                "\n  Error: DFlash speculative decoding "
+                '(``--speculative-config \'{"method":"dflash"}\'``, '
+                "--enable-dflash, or --spec-decode dflash) requires "
+                "mlx-vlm 0.5.0+ for the DFlash drafter hooks. Install with: "
+                "``pip install 'rapid-mlx[dflash]'``.\n"
             )
             sys.exit(1)
 
@@ -2229,14 +2317,7 @@ def serve_command(args):
     # ``spec_decode/dflash/{generator,drafter,verifier}.py`` modules
     # remain importable but inert; the ``accept_counter`` /
     # ``drafter_registry`` siblings stay active for metric scaffolding.
-    if getattr(args, "spec_decode", "none") == "dflash":
-        args.enable_dflash = True
-        args.spec_decode = "none"
-        print(
-            "Spec-decode: --spec-decode dflash routed to --enable-dflash "
-            "(mlx-vlm bridge; BatchedEngine integration deferred to 0.10).",
-            file=sys.stderr,
-        )
+    _maybe_print_legacy_dflash_redirect(args)
 
     # DFlash / DDTree mutual-exclusion gates fire BEFORE the startup banner so
     # the user sees a clean error instead of an optimistic "Features:
@@ -2245,7 +2326,7 @@ def serve_command(args):
     # involve the dedicated single-user servers.
     if args.enable_dflash and (args.suffix_decoding or args.enable_mtp):
         print(
-            "\n  Error: --enable-dflash cannot combine with --suffix-decoding "
+            "\n  Error: DFlash cannot combine with --suffix-decoding "
             "or --enable-mtp. DFlash runs a dedicated single-user server "
             "that bypasses BatchedEngine; other spec-decode methods only "
             "apply to the BatchedEngine path.\n"
@@ -2266,7 +2347,7 @@ def serve_command(args):
         _profile = resolve_profile(_alias_name)
         if _profile is None:
             print(
-                f"\n  Error: --enable-dflash requires a known alias, got "
+                f"\n  Error: DFlash requires a known alias, got "
                 f"{_alias_name!r}. DFlash eligibility is recorded per-alias "
                 f"in aliases.json; ad-hoc HuggingFace paths can't be "
                 f"validated. Try ``rapid-mlx info qwen3.5-27b-8bit``.\n"
@@ -2314,12 +2395,12 @@ def serve_command(args):
             _dflash_ignored.append("--mcp-config")
         if _dflash_ignored:
             print(
-                "\n  ⚠ The following flags are ignored under --enable-dflash"
+                "\n  ⚠ The following flags are ignored under DFlash"
                 "\n    (DFlash uses a dedicated single-user server that bypasses"
                 "\n    BatchedEngine):"
                 f"\n      {', '.join(_dflash_ignored)}"
-                "\n    Drop them from your serve command, or run without"
-                "\n    --enable-dflash if you need them.\n"
+                "\n    Drop them from your serve command, or run without DFlash"
+                "\n    if you need them.\n"
             )
 
     # DDTree eligibility gate mirrors DFlash: cheap alias/runtime checks
@@ -2430,7 +2511,8 @@ def serve_command(args):
     if getattr(args, "draft_model", None):
         print(
             "\n  ⚠ --draft-model is deprecated and has no effect."
-            "\n    For DFlash speculative decoding, use --enable-dflash "
+            "\n    For DFlash speculative decoding, use "
+            """--speculative-config '{"method":"dflash"}' """
             "(requires a DFlash-eligible alias). "
             "For MTP, use --enable-mtp (requires a model with MTP head).\n"
         )
@@ -2866,7 +2948,7 @@ def serve_command(args):
         # its dedicated server, never touching EngineCore / ModelConfig.
         if getattr(args, "no_spec_decode", False):
             print(
-                "error: --enable-dflash and --no-spec-decode are mutually "
+                "error: DFlash and --no-spec-decode are mutually "
                 "exclusive — DFlash is a speculative-decode mode.",
                 file=sys.stderr,
             )
@@ -2881,17 +2963,13 @@ def serve_command(args):
         assert _profile is not None and _profile.supports_dflash, (
             f"DFlash profile invariant violated for {_alias_name!r}"
         )
-        # ``--dflash-drafter-path`` override stays valid through both
-        # ``--enable-dflash`` and the ``--spec-decode dflash`` redirect
-        # path (#318): an operator-supplied path wins over the profile
-        # default. Empty string / missing attr falls back to the alias
-        # registry entry (validated non-None by _coerce_alias_dflash).
-        _dflash_drafter_override = (
-            getattr(args, "dflash_drafter_path", "") or ""
-        ).strip()
+        # The vLLM-style surface uses ``model`` for the drafter override.
+        # Legacy ``--dflash-drafter-path`` is normalized into
+        # ``_speculative_config.model`` above, with a direct fallback here
+        # for defensive compatibility.
         run_dflash_server(
             main_model_repo=_profile.hf_path,
-            drafter_repo=_dflash_drafter_override or _profile.dflash_draft_model,
+            drafter_repo=_resolve_dflash_drafter_repo(args, _profile),
             host=args.host,
             port=args.port,
             served_model_name=args.served_model_name or _alias_name,
@@ -5797,7 +5875,10 @@ def _print_dflash_status(alias: str, profile) -> None:
     print("\n".join(body))
     print()
     if eligible:
-        print(f"  Start with: rapid-mlx serve {alias} --enable-dflash")
+        print(
+            f"  Start with: rapid-mlx serve {alias} "
+            """--speculative-config '{"method":"dflash"}'"""
+        )
         print()
 
 
@@ -6538,10 +6619,10 @@ Examples:
         default=None,
         help=(
             "vLLM-style speculative decoding JSON config. This frontend "
-            "parses method/model/num_speculative_tokens now. DDTree is "
-            'available with \'{"method":"ddtree"}\'; existing DFlash, '
-            "MTP, and SuffixDecoding backends keep their legacy flags "
-            "until they migrate to this surface."
+            "parses method/model/num_speculative_tokens now. DFlash is "
+            'available with \'{"method":"dflash"}\' and DDTree with '
+            '\'{"method":"ddtree"}\'; MTP and SuffixDecoding keep their '
+            "legacy flags until they migrate to this surface."
         ),
     )
     serve_parser.add_argument(
@@ -6745,11 +6826,11 @@ Examples:
         dest="dflash_drafter_path",
         default="",
         help=(
-            "Override the per-alias DFlash drafter HF path. "
+            "Compatibility override for the per-alias DFlash drafter HF path; "
+            'prefer --speculative-config \'{"method":"dflash","model":...}\'. '
             "Defaults to the empty string, in which case "
             "vllm_mlx.spec_decode.dflash.drafter_registry resolves "
-            "the drafter for the loaded alias. Only consulted when "
-            "--spec-decode dflash is set; ignored otherwise."
+            "the drafter for the loaded alias."
         ),
     )
     # SuffixDecoding — drafter-free spec-decode using a suffix tree over

--- a/vllm_mlx/spec_decode/config.py
+++ b/vllm_mlx/spec_decode/config.py
@@ -33,12 +33,12 @@ _COMMON_KEYS = frozenset(
     {
         "method",
         "model",
-        "num_speculative_tokens",
     }
 )
 
 _METHOD_KEYS = {
-    "ddtree": frozenset({"tree_budget"}),
+    "ddtree": frozenset({"num_speculative_tokens", "tree_budget"}),
+    "mtp": frozenset({"num_speculative_tokens"}),
 }
 
 
@@ -116,6 +116,16 @@ def legacy_ddtree_config() -> SpeculativeConfig:
     return SpeculativeConfig(method="ddtree", raw={"method": "ddtree"})
 
 
+def legacy_dflash_config(model: str | None = None) -> SpeculativeConfig:
+    """Return the compatibility config represented by DFlash legacy flags."""
+
+    raw = {"method": "dflash"}
+    drafter = _optional_string(model, "model")
+    if drafter is not None:
+        raw["model"] = drafter
+    return SpeculativeConfig(method="dflash", model=drafter, raw=raw)
+
+
 def require_migrated_speculative_config(config: SpeculativeConfig) -> None:
     """Fail until ``config.method`` is wired to a backend runner."""
 
@@ -135,6 +145,7 @@ __all__ = [
     "SpeculativeConfig",
     "SpeculativeConfigError",
     "legacy_ddtree_config",
+    "legacy_dflash_config",
     "parse_speculative_config",
     "require_migrated_speculative_config",
 ]

--- a/vllm_mlx/spec_decode/registry.py
+++ b/vllm_mlx/spec_decode/registry.py
@@ -75,6 +75,7 @@ register_spec_decoder(
     SpecDecoderPlugin(
         method="dflash",
         description="Block-diffusion drafter via the existing single-user bridge",
+        config_enabled=True,
         legacy_hint="use --enable-dflash or --spec-decode dflash",
     )
 )

--- a/vllm_mlx/speculative/dflash/server.py
+++ b/vllm_mlx/speculative/dflash/server.py
@@ -1,8 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 """DFlash server — dedicated single-user mode that bypasses BatchedEngine.
 
-When ``--enable-dflash`` is set, the CLI launches this server instead of
-the standard ``vllm_mlx.server.app``. It hosts a minimal OpenAI-compatible
+When DFlash is enabled, the CLI launches this server instead of the
+standard ``vllm_mlx.server.app``. It hosts a minimal OpenAI-compatible
 surface (``/healthz``, ``/v1/models``, ``/v1/chat/completions``) and routes
 generation through mlx-vlm's ``stream_generate`` with the loaded DFlash
 drafter.
@@ -25,8 +25,9 @@ v1 limitations (documented in README + ``rapid-mlx info``):
   - No prefix cache (per-request KV cache built fresh each call).
 
 These limitations are deliberate for v1 — the target user is someone
-running ``rapid-mlx serve qwen3.5-27b-8bit --enable-dflash`` to get a
-~2× speedup on code/long-form completions on a single Apple Silicon box.
+running ``rapid-mlx serve qwen3.5-27b-8bit --speculative-config
+'{"method":"dflash"}'`` to get a ~2× speedup on code/long-form
+completions on a single Apple Silicon box.
 """
 
 from __future__ import annotations
@@ -179,8 +180,7 @@ def _build_app(
                 status_code=400,
                 detail=(
                     "Tool calling is not supported in DFlash mode (v1 "
-                    "limitation). Restart without --enable-dflash to use "
-                    "tools."
+                    "limitation). Restart without DFlash to use tools."
                 ),
             )
         # Surface unsupported params explicitly rather than silently
@@ -189,17 +189,14 @@ def _build_app(
         if request.logprobs:
             raise HTTPException(
                 status_code=400,
-                detail=(
-                    "logprobs is not supported in DFlash mode. Restart "
-                    "without --enable-dflash."
-                ),
+                detail="logprobs is not supported in DFlash mode. Restart without DFlash.",
             )
         if request.response_format is not None:
             raise HTTPException(
                 status_code=400,
                 detail=(
                     "response_format (structured output) is not supported "
-                    "in DFlash mode. Restart without --enable-dflash."
+                    "in DFlash mode. Restart without DFlash."
                 ),
             )
 
@@ -310,8 +307,7 @@ def _render_prompt(
                     "DFlash server is text-only; dropped %d non-text "
                     "content part(s) of type(s) %s. The request will be "
                     "served using text parts only — switch to the standard "
-                    "server (no --enable-dflash) for full multimodal "
-                    "support.",
+                    "server without DFlash for full multimodal support.",
                     len(dropped_kinds),
                     sorted(set(dropped_kinds)),
                 )


### PR DESCRIPTION
## Summary

Migrates DFlash onto the shared vLLM-style `--speculative-config` frontend while preserving the existing legacy flags as shorthands.

- Enables `method="dflash"` in the speculative decoder registry.
- Adds DFlash parsing/legacy config normalization so `--speculative-config '{"method":"dflash"}'`, `--enable-dflash`, and `--spec-decode dflash` land on the same dedicated DFlash server path.
- Maps DFlash drafter overrides to the config `model` field while keeping `--dflash-drafter-path` as compatibility shorthand.
- Tightens method-specific config keys so DFlash rejects unsupported knobs instead of silently ignoring them.
- Moves DFlash mutex checks ahead of optional runtime probing, preserving correct first-error behavior.
- Updates docs/help/status text to prefer `--speculative-config '{"method":"dflash"}'`.

## Workflow Compliance

- Feature PR: no `pyproject.toml` version bump per workflow G4.
- Applied `skip-version-bump` label for the CI version-bump gate.

## Validation

Correctness / reliability:

- `uv run ruff check vllm_mlx/spec_decode/config.py vllm_mlx/spec_decode/registry.py vllm_mlx/cli.py vllm_mlx/speculative/dflash/server.py tests/test_speculative_config.py tests/test_dflash_integration.py`
- `uv run --extra test --python 3.11 python -m pytest tests/test_speculative_config.py tests/test_dflash_integration.py tests/test_ddtree_integration.py tests/test_dflash_spec_decode.py tests/test_no_mllm_flag.py::test_dflash_branch_rejects_no_spec_decode -q`
  - `126 passed, 1 skipped`

End-to-end DFlash parity / perf smoke on `qwen3.5-27b-8bit`:

- New config: `--speculative-config '{"method":"dflash"}'`
  - ready: 9.081s, TTFT: 1.225s, total: 3.020s, output chars: 184
- Legacy flag: `--enable-dflash`
  - ready: 4.050s, TTFT: 1.650s, total: 7.171s, output chars: 184
- Output parity: identical greedy output

Drafter override parity:

- Legacy override: `--enable-dflash --dflash-drafter-path z-lab/Qwen3.5-27B-DFlash`
  - ready: 4.043s, TTFT: 0.831s, total: 0.838s, output: `DFLASH_INTERFACE_OK`
- Config override: `--speculative-config '{"method":"dflash","model":"z-lab/Qwen3.5-27B-DFlash"}'`
  - ready: 4.038s, TTFT: 0.828s, total: 0.841s, output: `DFLASH_INTERFACE_OK`
- Output parity: identical greedy output

`pr_validate` on PR #1022:

- `codex_review`: PASS, no blocking issues
- `lint`: PASS
- `stress_e2e_bench`: PASS, matrix 4x3
- `full_unit`: FAIL, but failures are baseline failures reproduced unchanged on `origin/main` (`b6aa4f3`), not introduced by this PR:
  - `tests/test_deep_nest_dos.py::test_d_tool_recur_tools_depth_1000_returns_400_canonical_envelope`
  - `tests/test_gemma4_text_import_guard.py::test_missing_mlx_vlm_raises_actionable_error`
  - `tests/test_mlx_compat.py::test_every_mlx_lm_consumer_installs_shim`
- Baseline repro command run in a detached `origin/main` worktree:
  - `uv run --extra test --python 3.11 python -m pytest tests/test_deep_nest_dos.py::test_d_tool_recur_tools_depth_1000_returns_400_canonical_envelope tests/test_gemma4_text_import_guard.py::test_missing_mlx_vlm_raises_actionable_error tests/test_mlx_compat.py::test_every_mlx_lm_consumer_installs_shim -q`
  - Result: same 3 failures on `origin/main`.

Review:

- Codex review round 1 found stale legacy notice/docs and an early mutex ordering issue.
- Follow-up fixes added early DFlash mutex preflight and preserved the legacy `--spec-decode dflash` redirect notice.
- Codex review round 2 found one blocker for legacy `--enable-dflash --spec-decode mtp`; fixed by rejecting remaining `spec_decode != "none"` in DFlash preflight and adding a regression test.
- Final Codex review: no remaining blockers.

Cleanup:

- Downloaded `z-lab/Qwen3.5-27B-DFlash` only for E2E parity, then removed the Hugging Face cache directory after validation.
