### PR TITLE
[codex] wire MTP into speculative config

### DIFF
--- a/README.md
+++ b/README.md
@@ -724,7 +724,7 @@ Qwen3.5 uses Gated DeltaNet (75% RNN) + full attention (25% KV). Other engines r
 | **KV cache quantization** | Quantize prefix cache entries to reduce memory | All models with `--kv-cache-quantization` |
 | **DFlash speculative decoding** | Block-diffusion drafter, parallel draft + verify (single-user) | `qwen3.5-27b-8bit`, `qwen3.6-27b-8bit` with `--speculative-config '{"method":"dflash"}'` |
 | **DDTree speculative decoding** | DFlash draft-tree verification over multiple branches | `qwen3.5-9b-8bit` (experimental, single-user) |
-| **MTP speculative decoding** | Multi-token prediction head shipped with the model | MTP-trained checkpoints with `--enable-mtp` |
+| **MTP speculative decoding** | Multi-token prediction head shipped with the model | MTP-trained checkpoints with `--speculative-config '{"method":"mtp"}'` |
 | **SuffixDecoding** | Drafter-free, statistical n-gram lookup speculative decoding | All BatchedEngine models with `--suffix-decoding` |
 | **Prefill chunking** | Configurable step size for large-prompt throughput | All models |
 | **Cloud routing** | Offload high-token requests to cloud LLM when local is slow | All models with `--cloud-model` |
@@ -764,7 +764,7 @@ Run your own: `bash evals/run_all_models.sh` runs the full quality suite (tool c
 | **TurboQuant K8V4 KV codec** | K is 8-bit + V is 4-bit after Walsh-Hadamard rotation + Lloyd-Max quantization — compresses KV to ~1/2.4 (~58% savings), lossless across the verified matrix. **Default-on for 9 verified Qwen3.5/3.6 aliases** (see below); `--kv-cache-turboquant none` to force off. |
 | **Smart cloud routing** | Large-context requests auto-route to a cloud LLM (`--cloud-model openai/gpt-5 --cloud-threshold 20000`) when local prefill would be slow. |
 | **Multimodal** | Vision, audio (STT/TTS with bundled Silero VAD silence pre-trim), video understanding, text embeddings — all through the standard OpenAI endpoints. |
-| **Speculative decoding** | DFlash (block-diffusion drafter, vLLM-style `--speculative-config '{"method":"dflash"}'`), DDTree (DFlash draft tree, `--speculative-config '{"method":"ddtree"}'`), MTP (multi-token prediction head, `--enable-mtp`), SuffixDecoding (drafter-free n-gram, `--suffix-decoding`). Opt-in per alias — see below. |
+| **Speculative decoding** | DFlash (block-diffusion drafter, vLLM-style `--speculative-config '{"method":"dflash"}'`), DDTree (DFlash draft tree, `--speculative-config '{"method":"ddtree"}'`), MTP (multi-token prediction head, `--speculative-config '{"method":"mtp"}'`), SuffixDecoding (drafter-free n-gram, `--suffix-decoding`). Opt-in per alias — see below. |
 | **Structured output, logprobs, continuous batching, KV quantization** | Standard, no flags or with one flag each. |
 | **3300+ tests** | Across reasoning, tool parsing, streaming, agent harnesses, and engine integration. |
 
@@ -790,7 +790,12 @@ rapid-mlx serve qwen3.5-27b-8bit --speculative-config '{"method":"dflash"}'
 
 Workload sensitivity: coding / math / summarization typically see **1.5–2.7×**; high-entropy creative writing and long-form chat can dip to **0.6–0.9×** because the drafter's training distribution diverges from open-ended generation — a known spec-decode literature pattern ([AdaEDL](https://arxiv.org/abs/2410.18351)), not a bug. DFlash mode runs a dedicated single-user server (no batched kernel yet); tool calling, MCP, and embeddings aren't available in that mode — restart without DFlash for those.
 
-**MTP** (Multi-Token Prediction) — draft head baked into the model. Opt in with `--enable-mtp` on MTP-trained checkpoints. Auto-tune of `--mtp-num-draft-tokens` per workload is roadmapped for the 0.9.1x line.
+**MTP** (Multi-Token Prediction) — draft head baked into the model. Opt in with `--speculative-config '{"method":"mtp"}'` on MTP-trained checkpoints. When using an already-supported MTP sidecar flow, pass the sidecar path in the config `model` field; it maps to the existing `--mtp-sidecar` plumbing.
+
+```bash
+rapid-mlx serve mlx-community/gemma-4-12b-it-4bit \
+  --speculative-config '{"method":"mtp","model":"google/gemma-4-12B-it-assistant"}'
+```
 
 **SuffixDecoding** — drafter-free, statistical n-gram lookup over the running suffix. Opt in with `--suffix-decoding`; works on any BatchedEngine alias.
 
@@ -809,7 +814,7 @@ rapid-mlx serve qwen3.5-9b-8bit \
   --speculative-config '{"method":"ddtree","model":"z-lab/Qwen3.5-9B-DFlash","num_speculative_tokens":16,"tree_budget":24}'
 ```
 
-`--enable-dflash` remains as a compatibility shorthand for `--speculative-config '{"method":"dflash"}'`, and `--dflash-drafter-path` maps to the config `model` field. `--enable-ddtree` similarly remains as a compatibility shorthand for `--speculative-config '{"method":"ddtree"}'`. Neither backend is enabled by default. MTP and SuffixDecoding keep their existing flags until they migrate behind the same config interface.
+`--enable-dflash` remains as a compatibility shorthand for `--speculative-config '{"method":"dflash"}'`, and `--dflash-drafter-path` maps to the config `model` field. `--enable-ddtree` similarly remains as a compatibility shorthand for `--speculative-config '{"method":"ddtree"}'`. `--spec-decode mtp` remains as a compatibility shorthand for `--speculative-config '{"method":"mtp"}'`, and `--mtp-sidecar` maps to the config `model` field. None of these backends is enabled by default. SuffixDecoding keeps its existing flag until it migrates behind the same config interface.
 
 Mutex: DFlash cannot combine with MTP or SuffixDecoding (single-user path). MTP and SuffixDecoding cannot combine with each other (both consume the drafter slot).
 
@@ -849,10 +854,10 @@ Mutex: DFlash cannot combine with MTP or SuffixDecoding (single-user path). MTP 
 | `--prefix-cache-index` | Prefix-cache lookup index: `radix` (default) or `hash` | `radix` |
 | `--pflash` | PFlash sparse prefill: `auto` / `always` / `off` | `auto` (on for verified aliases) |
 | `--enable-dflash` | Compatibility shorthand for DFlash speculative decoding (single-user; prefer `--speculative-config '{"method":"dflash"}'`) | off |
-| `--speculative-config` | vLLM-style speculative decoding JSON config; DFlash supports `{"method":"dflash"}` and DDTree supports `{"method":"ddtree"}` | off |
+| `--speculative-config` | vLLM-style speculative decoding JSON config; supports DFlash `{"method":"dflash"}`, DDTree `{"method":"ddtree"}`, and MTP `{"method":"mtp"}` | off |
 | `--enable-ddtree` | Compatibility shorthand for DDTree speculative decoding (single-user; `qwen3.5-9b-8bit`) | off |
 | `--suffix-decoding` | Drafter-free n-gram speculative decoding (BatchedEngine path) | off |
-| `--enable-mtp` | MTP head speculative decoding (requires MTP-trained model) | off |
+| `--spec-decode mtp` | Compatibility shorthand for MTP head speculative decoding; prefer `--speculative-config '{"method":"mtp"}'` | off |
 | `--gpu-memory-utilization` | Fraction of device memory to use (0.0-1.0) | `0.90` |
 
 **Cloud routing**
@@ -1056,7 +1061,7 @@ harness/                 # Regression baselines + thresholds
 | [DFlash](https://arxiv.org/abs/2602.06036) — block-diffusion drafter, single-user | 1.3–2× decode (workload-dependent) | Shipping, opt-in (`--speculative-config '{"method":"dflash"}'`, `[dflash]` extra; qwen3.5-27b-8bit, qwen3.6-27b-8bit) |
 | [DDTree](https://arxiv.org/abs/2604.12989) — DFlash draft-tree verification, single-user | TBD on rapid-mlx 9B gate | Experimental (`--speculative-config '{"method":"ddtree"}'`; `--enable-ddtree` compatibility shorthand) |
 | [SuffixDecoding](https://arxiv.org/abs/2411.04975) — drafter-free n-gram speculative | 1.1–1.5× decode | Shipping (`--suffix-decoding`, per-model tier sweep ongoing) |
-| MTP — Multi-Token Prediction head | 1.4–1.7× decode | Shipping, opt-in (`--enable-mtp`, MTP-trained checkpoints); per-workload auto-tune of `--mtp-num-draft-tokens` landing in the 0.9.1x line |
+| MTP — Multi-Token Prediction head | 1.4–1.7× decode | Shipping, opt-in (`--speculative-config '{"method":"mtp"}'`; `--spec-decode mtp` compatibility shorthand) |
 | [EAGLE-3](https://arxiv.org/abs/2503.01840) — feature-level draft on Metal | 3–6.5× decode | Not started |
 | [ReDrafter](https://arxiv.org/abs/2403.09919) — Apple's RNN draft head | 1.4–1.5× decode | Not started |
 

--- a/tests/test_mtp_lossless.py
+++ b/tests/test_mtp_lossless.py
@@ -101,9 +101,11 @@ def _reset_mtp_module_state():
         reset_global_counter_for_tests,
     )
     from vllm_mlx.spec_decode.mtp.cache_patch import _unpatch_for_tests
+    from vllm_mlx.spec_decode.mtp.draft_k_controller_v2 import reset_controllers
 
     _unpatch_for_tests()
     reset_global_counter_for_tests()
+    reset_controllers()
     # See the matching fixture in ``test_mtp_spec_decode.py`` for the
     # cross-thread stream reasoning. ``mlx_lm.generate.generation_stream``
     # may have been re-bound by a preceding sweep test's worker-thread
@@ -119,6 +121,7 @@ def _reset_mtp_module_state():
     yield
     _unpatch_for_tests()
     reset_global_counter_for_tests()
+    reset_controllers()
     sys.modules["mlx_lm.generate"].generation_stream = mx.default_stream(
         mx.default_device()
     )
@@ -428,6 +431,8 @@ def test_lossless_default_path_is_deterministic():
     emit sequence twice in a row. If controller state leakage or non-
     deterministic K picks slipped in, this smoke test would catch it.
     """
+    from vllm_mlx.spec_decode.mtp.draft_k_controller_v2 import reset_controllers
+
     backbone_mtp = [7, 11, 13, 15, 17, 19, 21]
     mtp_drafts = [11, 0, 15, 0, 19]
     run1 = _spec_decode_mtp_path_auto_k(
@@ -436,6 +441,7 @@ def test_lossless_default_path_is_deterministic():
         prompt=mx.array([1], mx.uint32),
         max_tokens=7,
     )
+    reset_controllers()
     run2 = _spec_decode_mtp_path_auto_k(
         backbone_mtp[:],
         mtp_drafts[:],

--- a/tests/test_speculative_config.py
+++ b/tests/test_speculative_config.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import subprocess
 import sys
+from types import SimpleNamespace
 
 import pytest
 
@@ -87,12 +88,11 @@ def test_parse_speculative_config_rejects_bad_payloads(raw: str, match: str) -> 
         parse_speculative_config(raw)
 
 
-def test_require_migrated_speculative_config_rejects_unwired_method() -> None:
+def test_require_migrated_speculative_config_accepts_mtp() -> None:
     cfg = parse_speculative_config('{"method":"mtp"}')
     assert cfg is not None
 
-    with pytest.raises(SpeculativeConfigError, match="not wired yet"):
-        require_migrated_speculative_config(cfg)
+    require_migrated_speculative_config(cfg)
 
 
 def test_require_migrated_speculative_config_accepts_ddtree() -> None:
@@ -115,6 +115,7 @@ def test_spec_decoder_registry_lists_existing_backends() -> None:
     assert {"ddtree", "dflash", "mtp", "suffix"}.issubset(methods)
     assert get_spec_decoder("ddtree").config_enabled is True
     assert get_spec_decoder("dflash").config_enabled is True
+    assert get_spec_decoder("mtp").config_enabled is True
     assert get_spec_decoder("ngram") == get_spec_decoder("suffix")
 
 
@@ -130,23 +131,70 @@ def test_serve_help_exposes_speculative_config() -> None:
     assert "--speculative-config" in proc.stdout
 
 
-def test_serve_rejects_unwired_speculative_config_before_model_load() -> None:
-    proc = subprocess.run(
-        [
-            sys.executable,
-            "-m",
-            "vllm_mlx.cli",
-            "serve",
-            "qwen3.5-9b-8bit",
-            "--speculative-config",
-            '{"method":"mtp"}',
-        ],
-        capture_output=True,
-        text=True,
-        timeout=30,
+def _spec_config_args(**overrides):
+    data = {
+        "speculative_config": None,
+        "enable_ddtree": False,
+        "enable_dflash": False,
+        "spec_decode": "none",
+        "dflash_drafter_path": "",
+        "mtp_sidecar": None,
+        "mtp_num_draft_tokens": 1,
+        "mtp_max_k": 3,
+    }
+    data.update(overrides)
+    return SimpleNamespace(**data)
+
+
+def test_speculative_config_mtp_normalizes_to_legacy_spec_decode() -> None:
+    from vllm_mlx.cli import _normalize_speculative_config_or_exit
+
+    args = _spec_config_args(
+        speculative_config=(
+            '{"method":"mtp","model":"google/gemma-4-12B-it-assistant",'
+            '"num_speculative_tokens":2}'
+        )
     )
 
-    assert proc.returncode == 2
-    assert "not wired yet" in proc.stderr
-    assert "use --spec-decode mtp" in proc.stderr
-    assert "Fetching" not in proc.stderr
+    _normalize_speculative_config_or_exit(args)
+
+    assert args.spec_decode == "mtp"
+    assert args.mtp_sidecar == "google/gemma-4-12B-it-assistant"
+    assert args.mtp_max_k == 2
+    assert args._speculative_config.method == "mtp"
+    assert args._speculative_config.model == "google/gemma-4-12B-it-assistant"
+    assert args._speculative_config.num_speculative_tokens == 2
+
+
+def test_spec_decode_mtp_legacy_flag_is_speculative_config_shorthand() -> None:
+    from vllm_mlx.cli import _normalize_speculative_config_or_exit
+
+    args = _spec_config_args(
+        spec_decode="mtp",
+        mtp_sidecar="google/gemma-4-12B-it-assistant",
+        mtp_max_k=2,
+    )
+
+    _normalize_speculative_config_or_exit(args)
+
+    assert args.spec_decode == "mtp"
+    assert args._speculative_config.method == "mtp"
+    assert args._speculative_config.model == "google/gemma-4-12B-it-assistant"
+    assert args._speculative_config.num_speculative_tokens == 2
+
+
+def test_speculative_config_mtp_rejects_legacy_sidecar_flag(capsys) -> None:
+    from vllm_mlx.cli import _normalize_speculative_config_or_exit
+
+    args = _spec_config_args(
+        speculative_config='{"method":"mtp"}',
+        mtp_sidecar="google/gemma-4-12B-it-assistant",
+    )
+
+    with pytest.raises(SystemExit) as excinfo:
+        _normalize_speculative_config_or_exit(args)
+
+    assert excinfo.value.code == 2
+    captured = capsys.readouterr()
+    assert "mutually exclusive" in captured.err
+    assert "--mtp-sidecar" in captured.err

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -1559,6 +1559,7 @@ def _normalize_speculative_config_or_exit(args):
         SpeculativeConfigError,
         legacy_ddtree_config,
         legacy_dflash_config,
+        legacy_mtp_config,
         parse_speculative_config,
         require_migrated_speculative_config,
     )
@@ -1575,6 +1576,8 @@ def _normalize_speculative_config_or_exit(args):
             conflicts.append(f"--spec-decode {spec_decode}")
         if (getattr(args, "dflash_drafter_path", "") or "").strip():
             conflicts.append("--dflash-drafter-path")
+        if (getattr(args, "mtp_sidecar", None) or "").strip():
+            conflicts.append("--mtp-sidecar")
         if conflicts:
             joined = ", ".join(conflicts)
             print(
@@ -1600,6 +1603,11 @@ def _normalize_speculative_config_or_exit(args):
             config = legacy_dflash_config(
                 (getattr(args, "dflash_drafter_path", "") or "").strip() or None
             )
+        elif getattr(args, "spec_decode", "none") == "mtp":
+            config = legacy_mtp_config(
+                model=(getattr(args, "mtp_sidecar", None) or "").strip() or None,
+                num_speculative_tokens=getattr(args, "mtp_max_k", None),
+            )
     args._speculative_config = config
     if config is None:
         return
@@ -1611,6 +1619,12 @@ def _normalize_speculative_config_or_exit(args):
         if legacy_spec_decode_dflash:
             args._legacy_spec_decode_dflash = True
             args.spec_decode = "none"
+    elif config.method == "mtp":
+        args.spec_decode = "mtp"
+        if config.model:
+            args.mtp_sidecar = config.model
+        if config.num_speculative_tokens is not None:
+            args.mtp_max_k = config.num_speculative_tokens
 
 
 def _resolve_dflash_drafter_repo(args, profile) -> str:
@@ -2514,7 +2528,9 @@ def serve_command(args):
             "\n    For DFlash speculative decoding, use "
             """--speculative-config '{"method":"dflash"}' """
             "(requires a DFlash-eligible alias). "
-            "For MTP, use --enable-mtp (requires a model with MTP head).\n"
+            "For MTP, use "
+            """--speculative-config '{"method":"mtp"}' """
+            "(requires a model with MTP head).\n"
         )
     if getattr(args, "specprefill", False):
         print("\n  ⚠ --specprefill is deprecated and has no effect.\n")
@@ -6620,9 +6636,10 @@ Examples:
         help=(
             "vLLM-style speculative decoding JSON config. This frontend "
             "parses method/model/num_speculative_tokens now. DFlash is "
-            'available with \'{"method":"dflash"}\' and DDTree with '
-            '\'{"method":"ddtree"}\'; MTP and SuffixDecoding keep their '
-            "legacy flags until they migrate to this surface."
+            'available with \'{"method":"dflash"}\', DDTree with '
+            '\'{"method":"ddtree"}\', and MTP with '
+            '\'{"method":"mtp"}\'. SuffixDecoding keeps its legacy flag '
+            "until it migrates to this surface."
         ),
     )
     serve_parser.add_argument(

--- a/vllm_mlx/spec_decode/config.py
+++ b/vllm_mlx/spec_decode/config.py
@@ -126,6 +126,28 @@ def legacy_dflash_config(model: str | None = None) -> SpeculativeConfig:
     return SpeculativeConfig(method="dflash", model=drafter, raw=raw)
 
 
+def legacy_mtp_config(
+    *,
+    model: str | None = None,
+    num_speculative_tokens: int | None = None,
+) -> SpeculativeConfig:
+    """Return the compatibility config represented by MTP legacy flags."""
+
+    raw: dict[str, Any] = {"method": "mtp"}
+    sidecar = _optional_string(model, "model")
+    if sidecar is not None:
+        raw["model"] = sidecar
+    tokens = _positive_int(num_speculative_tokens, "num_speculative_tokens")
+    if tokens is not None:
+        raw["num_speculative_tokens"] = tokens
+    return SpeculativeConfig(
+        method="mtp",
+        model=sidecar,
+        num_speculative_tokens=tokens,
+        raw=raw,
+    )
+
+
 def require_migrated_speculative_config(config: SpeculativeConfig) -> None:
     """Fail until ``config.method`` is wired to a backend runner."""
 
@@ -146,6 +168,7 @@ __all__ = [
     "SpeculativeConfigError",
     "legacy_ddtree_config",
     "legacy_dflash_config",
+    "legacy_mtp_config",
     "parse_speculative_config",
     "require_migrated_speculative_config",
 ]

--- a/vllm_mlx/spec_decode/registry.py
+++ b/vllm_mlx/spec_decode/registry.py
@@ -83,6 +83,7 @@ register_spec_decoder(
     SpecDecoderPlugin(
         method="mtp",
         description="Model-side multi-token prediction head",
+        config_enabled=True,
         legacy_hint="use --spec-decode mtp",
     )
 )


### PR DESCRIPTION
## Summary

- Enable MTP in the `--speculative-config` registry surface.
- Map `--speculative-config '{"method":"mtp"}'` onto the existing `--spec-decode mtp` runtime path, including existing sidecar plumbing through the config `model` field.
- Keep legacy `--spec-decode mtp` as a compatibility shorthand and add focused tests for both directions.
- Reset MTP draft-k controller state in lossless tests to remove test-only cross-run leakage.

## Validation

- `uv run --python 3.11 ruff check vllm_mlx/spec_decode/config.py vllm_mlx/spec_decode/registry.py vllm_mlx/cli.py tests/test_speculative_config.py tests/test_mtp_lossless.py`
- `uv run --extra test --python 3.11 python -m pytest tests/test_speculative_config.py tests/test_mtp_cli_wiring.py tests/test_mtp_spec_decode.py tests/test_mtp_lossless.py tests/test_mtp_gemma4_assistant_inject.py tests/test_mtp_inject_and_install.py -q` (`182 passed`)
- `RAPID_MLX_RUN_HEAVY_TESTS=1 uv run --extra test --python 3.11 python -m pytest tests/test_mtp_real_weights.py -q` (`2 passed`)
- Local `pr_validate #1023 --skip-steps stress_e2e_bench` on head `451e1de`:
  - `codex_review`: PASS, no blocking issues.
  - `targeted_tests`: PASS, `812 passed`.
  - `full_unit`: ran with audio/mlx-vlm validation deps installed; only 3 failures remained.
  - The same 3 failures reproduce on `origin/main` with the same interpreter: `tests/test_deep_nest_dos.py::test_d_tool_recur_tools_depth_1000_returns_400_canonical_envelope`, `tests/test_gemma4_text_import_guard.py::test_missing_mlx_vlm_raises_actionable_error`, and `tests/test_mlx_compat.py::test_every_mlx_lm_consumer_installs_shim`.
  - `stress_e2e_bench` was skipped locally because the machine had only ~27 GiB free, below the workflow G11 100 GiB floor, and the stress matrix selected 27B/35B models. This PR's runtime risk is covered by the focused real MTP E2E smoke below.
- GH checks on head `451e1de`: PASS (`check`, `validate`, `lint`, `type-check`, `test-matrix 3.10/3.11/3.12`, `test-apple-silicon`, `tests`). `skip-version-bump` label is intentional per operator instruction not to bump version in this PR.

## Real MTP E2E equivalence smoke

Compared the new config surface against the legacy flags on the existing supported Gemma 4 sidecar path:

- config: `rapid-mlx serve mlx-community/gemma-4-12b-it-4bit --speculative-config '{"method":"mtp","model":"google/gemma-4-12B-it-assistant"}'`
- legacy: `rapid-mlx serve mlx-community/gemma-4-12b-it-4bit --spec-decode mtp --mtp-sidecar google/gemma-4-12B-it-assistant`
- same prompt, `temperature=0`, `max_tokens=16`; exact same output and finish reason.
- logs showed the same `Spec-decode: mtp (chain) +sidecar=...`, same `dispatch_mtp_inject succeeded for model_type='gemma4_unified'`, and same scheduler patch path.
- config: `0.446s`, logged `38.4 tok/s`; legacy: `0.485s`, logged `38.3 tok/s`.

## Notes

This PR intentionally does not add new Qwen sidecar support. It only migrates the existing MTP runtime surface behind the shared speculative config interface.