### PR TITLE
[codex] fix PR validation debt

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -209,6 +209,13 @@ test = [
     # would module-skip the entire lock-in suite and let a future
     # refactor silently drop the ``[vision]`` extra).
     'tomli>=2.0.1; python_version < "3.11"',
+    # Full-unit imports / runs optional-surface tests too. Keep these in
+    # [test] so pr_validate can rebuild a venv that actually runs
+    # ``pytest tests/`` without hand-installed local extras.
+    "aiohttp>=3.9.0",
+    "pillow>=10.0.0",
+    "mlx-vlm>=0.6.3",
+    "mlx-audio>=0.2.9,<0.4.4",
 ]
 dev = [
     # Test runtime (must mirror the `test` extras above; a unit test in
@@ -220,6 +227,10 @@ dev = [
     "pytest-asyncio>=0.21.0",
     "prometheus_client>=0.16.0",
     'tomli>=2.0.1; python_version < "3.11"',
+    "aiohttp>=3.9.0",
+    "pillow>=10.0.0",
+    "mlx-vlm>=0.6.3",
+    "mlx-audio>=0.2.9,<0.4.4",
     # Linters / typer — NOT in the `test` extras because pr_validate
     # only needs to *run* the tests; lint is its own pipeline step
     # (ruff) and runs from the host environment.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -214,8 +214,8 @@ test = [
     # ``pytest tests/`` without hand-installed local extras.
     "aiohttp>=3.9.0",
     "pillow>=10.0.0",
-    "mlx-vlm>=0.6.3",
-    "mlx-audio>=0.2.9,<0.4.4",
+    "mlx-vlm>=0.6.3; platform_system == 'Darwin'",
+    "mlx-audio>=0.2.9,<0.4.4; platform_system == 'Darwin'",
 ]
 dev = [
     # Test runtime (must mirror the `test` extras above; a unit test in
@@ -229,8 +229,8 @@ dev = [
     'tomli>=2.0.1; python_version < "3.11"',
     "aiohttp>=3.9.0",
     "pillow>=10.0.0",
-    "mlx-vlm>=0.6.3",
-    "mlx-audio>=0.2.9,<0.4.4",
+    "mlx-vlm>=0.6.3; platform_system == 'Darwin'",
+    "mlx-audio>=0.2.9,<0.4.4; platform_system == 'Darwin'",
     # Linters / typer — NOT in the `test` extras because pr_validate
     # only needs to *run* the tests; lint is its own pipeline step
     # (ruff) and runs from the host environment.

--- a/scripts/pr_validate/_test_env.py
+++ b/scripts/pr_validate/_test_env.py
@@ -72,6 +72,26 @@ REQUIRED_TEST_PACKAGES: tuple[tuple[str, str, str], ...] = (
         "pytest.ini sets asyncio_mode=auto; without this every "
         "`async def test_*` fails at collection",
     ),
+    (
+        "aiohttp",
+        "aiohttp>=3.9.0",
+        "prompt-lookup bench tests import aiohttp at module load",
+    ),
+    (
+        "PIL",
+        "pillow>=10.0.0",
+        "image/aspect-ratio and Gemma MTP tests import PIL at collection/run time",
+    ),
+    (
+        "mlx_vlm",
+        "mlx-vlm>=0.6.3",
+        "Gemma 4 / DFlash / vision lock-in tests expect mlx_vlm importability",
+    ),
+    (
+        "mlx_audio",
+        "mlx-audio>=0.2.9,<0.4.4",
+        "audio route tests expect mlx-audio importability",
+    ),
 )
 
 # Canonical extras name from pyproject.toml. If you rename the extras,
@@ -147,6 +167,10 @@ def is_dep_declaration_file(path: str) -> bool:
 TRUSTED_TEST_PINS: tuple[str, ...] = (
     "pytest>=7.0.0,<9",
     "pytest-asyncio>=0.21.0,<1",
+    "aiohttp>=3.9.0,<4",
+    "pillow>=10.0.0,<13",
+    "mlx-vlm>=0.6.3,<0.7",
+    "mlx-audio>=0.2.9,<0.4.4",
 )
 
 

--- a/scripts/pr_validate/_test_env.py
+++ b/scripts/pr_validate/_test_env.py
@@ -84,15 +84,20 @@ REQUIRED_TEST_PACKAGES: tuple[tuple[str, str, str], ...] = (
     ),
     (
         "mlx_vlm",
-        "mlx-vlm>=0.6.3",
+        "mlx-vlm>=0.6.3; platform_system == 'Darwin'",
         "Gemma 4 / DFlash / vision lock-in tests expect mlx_vlm importability",
     ),
     (
         "mlx_audio",
-        "mlx-audio>=0.2.9,<0.4.4",
+        "mlx-audio>=0.2.9,<0.4.4; platform_system == 'Darwin'",
         "audio route tests expect mlx-audio importability",
     ),
 )
+
+# MLX runtime surfaces are Apple-only. Local Apple-Silicon validation
+# should require them, but Linux CI must not treat these imports as a
+# readiness signal.
+DARWIN_ONLY_TEST_IMPORTS = frozenset({"mlx_vlm", "mlx_audio"})
 
 # Canonical extras name from pyproject.toml. If you rename the extras,
 # update this constant too (and the unit test that pins it).
@@ -169,9 +174,21 @@ TRUSTED_TEST_PINS: tuple[str, ...] = (
     "pytest-asyncio>=0.21.0,<1",
     "aiohttp>=3.9.0,<4",
     "pillow>=10.0.0,<13",
-    "mlx-vlm>=0.6.3,<0.7",
-    "mlx-audio>=0.2.9,<0.4.4",
+    "mlx-vlm>=0.6.3,<0.7; platform_system == 'Darwin'",
+    "mlx-audio>=0.2.9,<0.4.4; platform_system == 'Darwin'",
 )
+
+
+def required_test_packages_for_platform(
+    platform: str | None = None,
+) -> tuple[tuple[str, str, str], ...]:
+    """Return the test-env import probes required on ``platform``."""
+    platform_name = platform or sys.platform
+    if platform_name == "darwin":
+        return REQUIRED_TEST_PACKAGES
+    return tuple(
+        pkg for pkg in REQUIRED_TEST_PACKAGES if pkg[0] not in DARWIN_ONLY_TEST_IMPORTS
+    )
 
 
 @dataclass(frozen=True)
@@ -217,7 +234,7 @@ def check_test_env(python: str | None = None) -> TestEnvStatus:
     pytest_asyncio twice could trip a "plugin already registered" warning).
     """
     interp = python or sys.executable
-    import_names = [pkg for pkg, _, _ in REQUIRED_TEST_PACKAGES]
+    import_names = [pkg for pkg, _, _ in required_test_packages_for_platform()]
     probe = "; ".join(f"import {name}" for name in import_names)
 
     proc = subprocess.run(  # noqa: S603

--- a/tests/test_deep_nest_dos.py
+++ b/tests/test_deep_nest_dos.py
@@ -363,11 +363,18 @@ def test_d_deep_json_disabled_cap_passes_through(monkeypatch):
 # ============================================================
 
 
-def test_d_tool_recur_tools_depth_1000_returns_400_canonical_envelope(monkeypatch):
-    """A 1000-deep ``tools[0].function.parameters`` body MUST be
-    rejected with the canonical 400 envelope. Pre-fix this crashed
-    with HTTP 500 mentioning ``_sanitize_tools_for_template._walk``
-    — that's an unauthenticated DoS surface."""
+def test_d_tool_recur_tools_depth_above_cap_returns_400_canonical_envelope(
+    monkeypatch,
+):
+    """A ``tools[0].function.parameters`` body above the tool-schema cap
+    MUST be rejected with the canonical 400 envelope. Pre-fix this crashed
+    with HTTP 500 mentioning ``_sanitize_tools_for_template._walk`` — an
+    unauthenticated DoS surface.
+
+    Keep this payload above the default 64-level tool cap but below
+    Starlette/Python's JSON parser recursion ceiling so the per-tool
+    validator, not the generic body parser, is the gate under test.
+    """
     # Disable the whole-body depth gate so the per-tool validator is
     # the only thing standing between the payload and the chat-template
     # sanitiser. We want both gates to work independently — a defense-
@@ -384,7 +391,7 @@ def test_d_tool_recur_tools_depth_1000_returns_400_canonical_envelope(monkeypatc
     # server.
     resp = client.post(
         "/v1/chat/completions",
-        content=_chat_request_with_deep_tool_bytes(1000),
+        content=_chat_request_with_deep_tool_bytes(80),
         headers=_JSON_HEADERS,
     )
     assert resp.status_code == 400, resp.text[:400]
@@ -401,6 +408,29 @@ def test_d_tool_recur_tools_depth_1000_returns_400_canonical_envelope(monkeypatc
     assert "RAPID_MLX_MAX_TOOL_SCHEMA_DEPTH" in err["message"]
     assert "Traceback" not in resp.text
     assert "_walk" not in resp.text
+
+
+def test_d_tool_recur_parser_depth_1000_returns_invalid_request_code(monkeypatch):
+    """At extreme depths the JSON parser can reject the body before the
+    per-tool validator sees it. That is still a client 400, and the
+    OpenAI-shaped envelope should carry the canonical invalid_request code
+    instead of a null code.
+    """
+    monkeypatch.setenv("RAPID_MLX_MAX_BODY_DEPTH", "0")
+    app = _build_minimal_app(with_pydantic_chat=True)
+    client = TestClient(app, raise_server_exceptions=False)
+
+    resp = client.post(
+        "/v1/chat/completions",
+        content=_chat_request_with_deep_tool_bytes(1000),
+        headers=_JSON_HEADERS,
+    )
+    assert resp.status_code == 400, resp.text[:400]
+    err = resp.json()["error"]
+    assert err["type"] == "invalid_request_error"
+    assert err["code"] == "invalid_request"
+    assert "parsing the body" in err["message"]
+    assert "Traceback" not in resp.text
 
 
 def test_walk_tools_iter_preserves_nested_tuples():

--- a/tests/test_gemma4_text_import_guard.py
+++ b/tests/test_gemma4_text_import_guard.py
@@ -1,19 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Regression test for the Gemma 4 loader import guard.
-
-User report: ``rapid-mlx chat gemma-4-12b-qat-8bit`` on a default brew
-install (no ``[vision]`` extra) crashed with a raw
-``ModuleNotFoundError: No module named 'mlx_vlm'`` because
-``load_gemma4_text`` did ``from mlx_vlm.models.gemma4...`` without
-guarding. The fix wraps the import in ``try/except ImportError`` and
-re-raises with an actionable message pointing at the cheapest install
-path (``pip install --no-deps mlx-vlm``, +16 MB).
-
-The brew tap formula now installs mlx-vlm with ``--no-deps``
-automatically, so brew users no longer hit this path. PyPI users on the
-bare install still do — this test pins the actionable error so the
-guard isn't accidentally removed by a future refactor.
-"""
+"""Regression tests for the Gemma 4 text loader fallback."""
 
 from __future__ import annotations
 
@@ -27,27 +13,40 @@ from vllm_mlx.models.gemma4_text import load_gemma4_text
 
 
 def _write_minimal_gemma4_config(tmp_path: Path) -> Path:
-    """Write a config.json the loader will accept up to the mlx-vlm import."""
+    """Write a tiny config the vendored loader can instantiate cheaply."""
     cfg = {
         "model_type": "gemma4",
         "text_config": {
-            "hidden_size": 256,
-            "num_hidden_layers": 1,
-            "intermediate_size": 512,
+            "hidden_size": 16,
+            "num_hidden_layers": 2,
+            "intermediate_size": 32,
             "num_attention_heads": 2,
             "num_key_value_heads": 1,
+            "head_dim": 8,
+            "global_head_dim": 8,
             "vocab_size": 32,
+            "vocab_size_per_layer_input": 32,
+            "hidden_size_per_layer_input": 0,
+            "num_kv_shared_layers": 0,
+            "sliding_window_pattern": 2,
+            "layer_types": ["sliding_attention", "full_attention"],
+            "use_double_wide_mlp": False,
         },
     }
     (tmp_path / "config.json").write_text(json.dumps(cfg))
     return tmp_path
 
 
-def test_missing_mlx_vlm_raises_actionable_error(tmp_path, monkeypatch):
-    """Importing ``mlx_vlm`` is the only mlx-vlm contact point during
-    load. If the package is absent, the user must see a message that
-    names the fix command — NOT a raw ``ModuleNotFoundError`` traceback
-    from deep inside the loader."""
+def test_missing_mlx_vlm_uses_vendored_text_loader(tmp_path, monkeypatch):
+    """A bare install without ``mlx_vlm`` must still use vendored Gemma 4
+    text classes.
+
+    The current fresh-install contract is stronger than the original
+    actionable ImportError: Gemma 4 text-only inference should boot without
+    the ``[vision]`` extra. This test forces the upstream import branch to
+    fail and asserts the loader gets past class construction to the expected
+    local-weight check.
+    """
     model_dir = _write_minimal_gemma4_config(tmp_path)
 
     # Force ``import mlx_vlm`` (and any submodule) to fail even if the
@@ -69,20 +68,8 @@ def test_missing_mlx_vlm_raises_actionable_error(tmp_path, monkeypatch):
 
     monkeypatch.setattr("builtins.__import__", blocking_import)
 
-    with pytest.raises(ImportError) as excinfo:
+    with pytest.raises(FileNotFoundError, match="No .safetensors files"):
         load_gemma4_text(model_dir, None)
-
-    msg = str(excinfo.value)
-    # Must name BOTH install options so users on a slim brew install
-    # can pick the cheap one (--no-deps) and PyPI users can pick the
-    # extras one.
-    assert "mlx-vlm" in msg
-    assert "--no-deps" in msg
-    assert "rapid-mlx[vision]" in msg
-    # Original ModuleNotFoundError must be chained via ``from e`` so the
-    # underlying cause stays visible in the traceback.
-    assert excinfo.value.__cause__ is not None
-    assert isinstance(excinfo.value.__cause__, ImportError)
 
 
 def test_is_gemma4_model_uses_hf_hub_download_not_snapshot(monkeypatch) -> None:

--- a/tests/test_pr_validate_test_env.py
+++ b/tests/test_pr_validate_test_env.py
@@ -38,6 +38,7 @@ from scripts.pr_validate._test_env import (
     TestEnvStatus,
     auto_install_disabled,
     check_test_env,
+    required_test_packages_for_platform,
 )
 from scripts.pr_validate.context import Context
 from scripts.pr_validate.steps.test_env_check import TestEnvCheckStep
@@ -479,6 +480,22 @@ class TestRequiredPackages:
         names = {pkg for pkg, _, _ in REQUIRED_TEST_PACKAGES}
         assert "pytest" in names
         assert "pytest_asyncio" in names
+
+    def test_mlx_optional_surface_required_only_on_darwin(self):
+        """GitHub pr_validate runs on Linux, where Apple-only MLX
+        imports are not a valid test-env readiness signal. Local
+        Apple-Silicon validation still requires them."""
+        linux_names = {
+            pkg for pkg, _, _ in required_test_packages_for_platform("linux")
+        }
+        darwin_names = {
+            pkg for pkg, _, _ in required_test_packages_for_platform("darwin")
+        }
+
+        assert "mlx_vlm" not in linux_names
+        assert "mlx_audio" not in linux_names
+        assert "mlx_vlm" in darwin_names
+        assert "mlx_audio" in darwin_names
 
     def test_every_entry_has_a_pip_name_with_version(self):
         """Defensive: each entry must carry a version constraint so

--- a/vllm_mlx/middleware/exception_handlers.py
+++ b/vllm_mlx/middleware/exception_handlers.py
@@ -893,13 +893,20 @@ def _http_error_response(exc: StarletteHTTPException) -> JSONResponse:
             content=detail,
             headers=getattr(exc, "headers", None),
         )
+    code = None
+    if (
+        exc.status_code == 400
+        and isinstance(exc.detail, str)
+        and exc.detail == "There was an error parsing the body"
+    ):
+        code = "invalid_request"
     return JSONResponse(
         status_code=exc.status_code,
         content={
             "error": {
                 "message": str(exc.detail),
                 "type": _HTTP_ERROR_TYPE_MAP.get(exc.status_code, "api_error"),
-                "code": None,
+                "code": code,
                 "param": None,
             }
         },

--- a/vllm_mlx/models/gemma4_vendored/language.py
+++ b/vllm_mlx/models/gemma4_vendored/language.py
@@ -4,12 +4,22 @@ from typing import Any, List, Optional
 import mlx.core as mx
 import mlx.nn as nn
 from mlx.nn import RMSNorm
+
+# MUST install the MLX hardware-compat shim BEFORE any `from mlx_lm.*` import.
+# `mlx_lm/__init__.py` re-exports from `mlx_lm.generate`, which captures
+# `mx.new_thread_local_stream(mx.default_device())` at module-import time; on
+# M5 single-stream GPUs that stream is unusable (#404). The shim is
+# idempotent and a no-op on hardware where the original API works.
+from ... import _mlx_compat as _mlx_compat
+
+_mlx_compat.install()
+
 from mlx_lm.models.base import (
     create_attention_mask,
     create_causal_mask,
     scaled_dot_product_attention,
-)
-from mlx_lm.models.cache import KVCache, RotatingKVCache
+)  # noqa: E402
+from mlx_lm.models.cache import KVCache, RotatingKVCache  # noqa: E402
 
 from . import LanguageModelOutput
 from .config import TextConfig


### PR DESCRIPTION
## Summary

- installs the MLX hardware-compat shim before vendored Gemma 4 `mlx_lm` imports
- restores canonical `invalid_request` error codes for Starlette JSON parser 400s while preserving route-raised HTTPException behavior
- updates stale Gemma 4 text fallback coverage now that text-only loading uses the vendored fallback without `mlx_vlm`
- makes pr_validate/full-unit test env rebuilds install the optional surfaces that tests import (`aiohttp`, `pillow`, `mlx-vlm`, `mlx-audio`)

## Notes

- No version bump: this changes test/dev extras and validation tooling only; runtime/core dependencies are unchanged.
- This PR is validation debt cleanup before continuing the speculative-decoding migration work.

## Validation

- `uv run --extra test --python 3.11 ruff check pyproject.toml scripts/pr_validate/_test_env.py tests/test_pr_validate_test_env.py vllm_mlx/models/gemma4_vendored/language.py vllm_mlx/middleware/exception_handlers.py tests/test_gemma4_text_import_guard.py tests/test_deep_nest_dos.py` -> passed
- `uv run --extra test --python 3.11 python -m pytest tests/test_deep_nest_dos.py::test_d_tool_recur_tools_depth_above_cap_returns_400_canonical_envelope tests/test_deep_nest_dos.py::test_d_tool_recur_parser_depth_1000_returns_invalid_request_code tests/test_gemma4_text_import_guard.py::test_missing_mlx_vlm_uses_vendored_text_loader tests/test_mlx_compat.py::test_every_mlx_lm_consumer_installs_shim -q` -> 4 passed
- `uv run --extra test --python 3.11 python -m pytest tests/test_config_and_middleware.py::TestHTTPExceptionHandlerOnProductionApp tests/test_sampling_param_finite_range.py -q` -> 142 passed
- `uv run --extra test --python 3.11 python -m pytest tests/test_vision_extra_install.py::test_gemma4_vendored_module_exists tests/test_vision_extra_install.py::test_gemma4_vendored_modules_importable_without_mlx_vlm tests/test_vision_extra_install.py::test_gemma4_text_prefers_vendored_fallback tests/test_gemma4_text_import_guard.py -q` -> 5 passed
- `uv run --extra test --python 3.11 python -m pytest tests/test_audio_alias_registry.py tests/test_audio_path_shaped_model.py tests/test_audio_probe_consistency.py tests/test_audio_r11_b_bundle.py tests/test_audio_r8_a_bundle.py tests/test_audio_routes_bundle.py tests/test_audio_upload_size_limit.py tests/test_exception_handlers.py::test_audio_route_accepts_model_via_query_for_back_compat tests/test_exception_handlers.py::test_audio_route_form_field_overrides_query tests/test_image_aspect_ratio.py -q` -> 276 passed, 7 skipped
- `uv run --extra test --python 3.11 python -m pytest tests/test_pr_validate_test_env.py -q` -> 37 passed
- `uv run --extra test --python 3.11 python -m pytest tests/test_deep_nest_dos.py tests/test_gemma4_text_import_guard.py tests/test_mlx_compat.py tests/test_vision_extra_install.py tests/test_audio_alias_registry.py tests/test_audio_routes_bundle.py tests/test_image_aspect_ratio.py -q` -> 217 passed
- `uv run --extra test --python 3.11 python -m pytest tests/ --ignore=tests/integrations --ignore=tests/test_event_loop.py -q --no-header` -> 12093 passed, 34 skipped, 17 deselected, 6 xfailed, 1 xpassed