### PR TITLE
[codex] wire suffix speculative config

### DIFF
--- a/tests/test_speculative_config.py
+++ b/tests/test_speculative_config.py
@@ -61,6 +61,20 @@ def test_parse_speculative_config_normalizes_registered_alias() -> None:
     assert cfg.method == "suffix"
 
 
+def test_parse_suffix_speculative_config_accepts_existing_knobs() -> None:
+    cfg = parse_speculative_config(
+        '{"method":"suffix","num_speculative_tokens":6,'
+        '"max_suffix_len":5,"min_confidence":0.4,"min_draft_len":3}'
+    )
+
+    assert cfg is not None
+    assert cfg.method == "suffix"
+    assert cfg.num_speculative_tokens == 6
+    assert cfg.max_suffix_len == 5
+    assert cfg.min_confidence == 0.4
+    assert cfg.min_draft_len == 3
+
+
 @pytest.mark.parametrize(
     ("raw", "match"),
     [
@@ -75,6 +89,15 @@ def test_parse_speculative_config_normalizes_registered_alias() -> None:
         ('{"method":"ddtree","tree_budget":0}', "positive integer"),
         ('{"method":"ddtree","tree_budget":true}', "positive integer"),
         ('{"method":"ddtree","unknown":1}', "unsupported speculative-config"),
+        ('{"method":"suffix","max_suffix_len":0}', "positive integer"),
+        ('{"method":"suffix","min_confidence":0}', "positive number"),
+        ('{"method":"suffix","min_confidence":true}', "positive number"),
+        ('{"method":"suffix","min_confidence":NaN}', "positive number"),
+        ('{"method":"suffix","min_confidence":Infinity}', "positive number"),
+        ('{"method":"suffix","min_confidence":1.5}', "between 0 and 1"),
+        ('{"method":"suffix","min_draft_len":0}', "positive integer"),
+        ('{"method":"suffix","model":"x"}', "unsupported speculative-config"),
+        ('{"method":"suffix","tree_budget":24}', "unsupported speculative-config"),
         (
             '{"method":"dflash","num_speculative_tokens":4}',
             "unsupported speculative-config",
@@ -109,6 +132,13 @@ def test_require_migrated_speculative_config_accepts_dflash() -> None:
     require_migrated_speculative_config(cfg)
 
 
+def test_require_migrated_speculative_config_accepts_suffix() -> None:
+    cfg = parse_speculative_config('{"method":"suffix"}')
+    assert cfg is not None
+
+    require_migrated_speculative_config(cfg)
+
+
 def test_spec_decoder_registry_lists_existing_backends() -> None:
     methods = {plugin.method for plugin in iter_spec_decoders()}
 
@@ -116,6 +146,7 @@ def test_spec_decoder_registry_lists_existing_backends() -> None:
     assert get_spec_decoder("ddtree").config_enabled is True
     assert get_spec_decoder("dflash").config_enabled is True
     assert get_spec_decoder("mtp").config_enabled is True
+    assert get_spec_decoder("suffix").config_enabled is True
     assert get_spec_decoder("ngram") == get_spec_decoder("suffix")
 
 
@@ -138,9 +169,15 @@ def _spec_config_args(**overrides):
         "enable_dflash": False,
         "spec_decode": "none",
         "dflash_drafter_path": "",
+        "enable_mtp": False,
         "mtp_sidecar": None,
         "mtp_num_draft_tokens": 1,
         "mtp_max_k": 3,
+        "suffix_decoding": False,
+        "suffix_max_draft": None,
+        "suffix_max_suffix_len": None,
+        "suffix_min_confidence": None,
+        "suffix_min_draft_len": None,
     }
     data.update(overrides)
     return SimpleNamespace(**data)
@@ -183,6 +220,20 @@ def test_spec_decode_mtp_legacy_flag_is_speculative_config_shorthand() -> None:
     assert args._speculative_config.num_speculative_tokens == 2
 
 
+def test_no_speculative_config_fills_suffix_runtime_defaults() -> None:
+    from vllm_mlx.cli import _normalize_speculative_config_or_exit
+
+    args = _spec_config_args()
+
+    _normalize_speculative_config_or_exit(args)
+
+    assert args._speculative_config is None
+    assert args.suffix_max_draft == 8
+    assert args.suffix_max_suffix_len == 4
+    assert args.suffix_min_confidence == 0.3
+    assert args.suffix_min_draft_len == 2
+
+
 def test_speculative_config_mtp_rejects_legacy_sidecar_flag(capsys) -> None:
     from vllm_mlx.cli import _normalize_speculative_config_or_exit
 
@@ -198,3 +249,125 @@ def test_speculative_config_mtp_rejects_legacy_sidecar_flag(capsys) -> None:
     captured = capsys.readouterr()
     assert "mutually exclusive" in captured.err
     assert "--mtp-sidecar" in captured.err
+
+
+def test_speculative_config_malformed_with_legacy_flag_reports_clean_error(
+    capsys,
+) -> None:
+    from vllm_mlx.cli import _normalize_speculative_config_or_exit
+
+    args = _spec_config_args(speculative_config="", enable_mtp=True)
+
+    with pytest.raises(SystemExit) as excinfo:
+        _normalize_speculative_config_or_exit(args)
+
+    assert excinfo.value.code == 2
+    captured = capsys.readouterr()
+    assert "cannot be empty" in captured.err
+    assert "AttributeError" not in captured.err
+
+
+def test_speculative_config_suffix_normalizes_to_legacy_suffix_args() -> None:
+    from vllm_mlx.cli import _normalize_speculative_config_or_exit
+
+    args = _spec_config_args(
+        speculative_config=(
+            '{"method":"suffix","num_speculative_tokens":6,'
+            '"max_suffix_len":5,"min_confidence":0.4,"min_draft_len":3}'
+        )
+    )
+
+    _normalize_speculative_config_or_exit(args)
+
+    assert args.suffix_decoding is True
+    assert args.suffix_max_draft == 6
+    assert args.suffix_max_suffix_len == 5
+    assert args.suffix_min_confidence == 0.4
+    assert args.suffix_min_draft_len == 3
+    assert args._speculative_config.method == "suffix"
+
+
+def test_suffix_decoding_legacy_flag_is_speculative_config_shorthand() -> None:
+    from vllm_mlx.cli import _normalize_speculative_config_or_exit
+
+    args = _spec_config_args(
+        suffix_decoding=True,
+        suffix_max_draft=6,
+        suffix_max_suffix_len=5,
+        suffix_min_confidence=0.4,
+        suffix_min_draft_len=3,
+    )
+
+    _normalize_speculative_config_or_exit(args)
+
+    assert args.suffix_decoding is True
+    assert args._speculative_config.method == "suffix"
+    assert args._speculative_config.num_speculative_tokens == 6
+    assert args._speculative_config.max_suffix_len == 5
+    assert args._speculative_config.min_confidence == 0.4
+    assert args._speculative_config.min_draft_len == 3
+
+
+def test_suffix_decoding_legacy_flag_without_knobs_fills_runtime_defaults() -> None:
+    from vllm_mlx.cli import _normalize_speculative_config_or_exit
+
+    args = _spec_config_args(suffix_decoding=True)
+
+    _normalize_speculative_config_or_exit(args)
+
+    assert args.suffix_max_draft == 8
+    assert args.suffix_max_suffix_len == 4
+    assert args.suffix_min_confidence == 0.3
+    assert args.suffix_min_draft_len == 2
+    assert args._speculative_config.method == "suffix"
+    assert args._speculative_config.num_speculative_tokens is None
+
+
+def test_suffix_decoding_legacy_invalid_flag_reports_clean_error(capsys) -> None:
+    from vllm_mlx.cli import _normalize_speculative_config_or_exit
+
+    args = _spec_config_args(
+        suffix_decoding=True,
+        suffix_max_draft=0,
+    )
+
+    with pytest.raises(SystemExit) as excinfo:
+        _normalize_speculative_config_or_exit(args)
+
+    assert excinfo.value.code == 2
+    captured = capsys.readouterr()
+    assert "num_speculative_tokens must be a positive integer" in captured.err
+
+
+def test_speculative_config_suffix_rejects_default_valued_legacy_knob(capsys) -> None:
+    from vllm_mlx.cli import _normalize_speculative_config_or_exit
+
+    args = _spec_config_args(
+        speculative_config='{"method":"suffix","num_speculative_tokens":6}',
+        suffix_max_draft=8,
+    )
+
+    with pytest.raises(SystemExit) as excinfo:
+        _normalize_speculative_config_or_exit(args)
+
+    assert excinfo.value.code == 2
+    captured = capsys.readouterr()
+    assert "mutually exclusive" in captured.err
+    assert "--suffix-max-draft" in captured.err
+
+
+def test_speculative_config_suffix_rejects_legacy_suffix_flag(capsys) -> None:
+    from vllm_mlx.cli import _normalize_speculative_config_or_exit
+
+    args = _spec_config_args(
+        speculative_config='{"method":"suffix"}',
+        suffix_decoding=True,
+    )
+
+    with pytest.raises(SystemExit) as excinfo:
+        _normalize_speculative_config_or_exit(args)
+
+    assert excinfo.value.code == 2
+    captured = capsys.readouterr()
+    assert "mutually exclusive" in captured.err
+    assert "--suffix-decoding" in captured.err

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -1560,12 +1560,33 @@ def _normalize_speculative_config_or_exit(args):
         legacy_ddtree_config,
         legacy_dflash_config,
         legacy_mtp_config,
+        legacy_suffix_config,
         parse_speculative_config,
         require_migrated_speculative_config,
     )
 
     raw_config = getattr(args, "speculative_config", None)
+    config = None
+
+    def _fill_suffix_defaults() -> None:
+        if getattr(args, "suffix_max_draft", None) is None:
+            args.suffix_max_draft = 8
+        if getattr(args, "suffix_max_suffix_len", None) is None:
+            args.suffix_max_suffix_len = 4
+        if getattr(args, "suffix_min_confidence", None) is None:
+            args.suffix_min_confidence = 0.3
+        if getattr(args, "suffix_min_draft_len", None) is None:
+            args.suffix_min_draft_len = 2
+
     if raw_config is not None:
+        try:
+            config = parse_speculative_config(raw_config)
+            if config is not None:
+                require_migrated_speculative_config(config)
+        except SpeculativeConfigError as exc:
+            print(f"error: {exc}", file=sys.stderr)
+            sys.exit(2)
+        config_method = config.method if config is not None else "none"
         conflicts = []
         if getattr(args, "enable_ddtree", False):
             conflicts.append("--enable-ddtree")
@@ -1578,6 +1599,22 @@ def _normalize_speculative_config_or_exit(args):
             conflicts.append("--dflash-drafter-path")
         if (getattr(args, "mtp_sidecar", None) or "").strip():
             conflicts.append("--mtp-sidecar")
+        # DFlash has a dedicated preflight that historically reports
+        # these runtime conflicts as "cannot combine" (exit 1) before
+        # probing mlx-vlm. Preserve that user-facing contract; other
+        # methods stay on the generic config/legacy mutual-exclusion path.
+        if getattr(args, "enable_mtp", False) and config_method != "dflash":
+            conflicts.append("--enable-mtp")
+        if getattr(args, "suffix_decoding", False) and config_method != "dflash":
+            conflicts.append("--suffix-decoding")
+        if getattr(args, "suffix_max_draft", None) is not None:
+            conflicts.append("--suffix-max-draft")
+        if getattr(args, "suffix_max_suffix_len", None) is not None:
+            conflicts.append("--suffix-max-suffix-len")
+        if getattr(args, "suffix_min_confidence", None) is not None:
+            conflicts.append("--suffix-min-confidence")
+        if getattr(args, "suffix_min_draft_len", None) is not None:
+            conflicts.append("--suffix-min-draft-len")
         if conflicts:
             joined = ", ".join(conflicts)
             print(
@@ -1587,29 +1624,34 @@ def _normalize_speculative_config_or_exit(args):
                 file=sys.stderr,
             )
             sys.exit(2)
-    try:
-        config = parse_speculative_config(raw_config)
-        if config is not None:
-            require_migrated_speculative_config(config)
-    except SpeculativeConfigError as exc:
-        print(f"error: {exc}", file=sys.stderr)
-        sys.exit(2)
     if config is None:
-        if getattr(args, "enable_ddtree", False):
-            config = legacy_ddtree_config()
-        elif getattr(args, "enable_dflash", False) or (
-            getattr(args, "spec_decode", "none") == "dflash"
-        ):
-            config = legacy_dflash_config(
-                (getattr(args, "dflash_drafter_path", "") or "").strip() or None
-            )
-        elif getattr(args, "spec_decode", "none") == "mtp":
-            config = legacy_mtp_config(
-                model=(getattr(args, "mtp_sidecar", None) or "").strip() or None,
-                num_speculative_tokens=getattr(args, "mtp_max_k", None),
-            )
+        try:
+            if getattr(args, "enable_ddtree", False):
+                config = legacy_ddtree_config()
+            elif getattr(args, "enable_dflash", False) or (
+                getattr(args, "spec_decode", "none") == "dflash"
+            ):
+                config = legacy_dflash_config(
+                    (getattr(args, "dflash_drafter_path", "") or "").strip() or None
+                )
+            elif getattr(args, "spec_decode", "none") == "mtp":
+                config = legacy_mtp_config(
+                    model=(getattr(args, "mtp_sidecar", None) or "").strip() or None,
+                    num_speculative_tokens=getattr(args, "mtp_max_k", None),
+                )
+            elif getattr(args, "suffix_decoding", False):
+                config = legacy_suffix_config(
+                    num_speculative_tokens=getattr(args, "suffix_max_draft", None),
+                    max_suffix_len=getattr(args, "suffix_max_suffix_len", None),
+                    min_confidence=getattr(args, "suffix_min_confidence", None),
+                    min_draft_len=getattr(args, "suffix_min_draft_len", None),
+                )
+        except SpeculativeConfigError as exc:
+            print(f"error: {exc}", file=sys.stderr)
+            sys.exit(2)
     args._speculative_config = config
     if config is None:
+        _fill_suffix_defaults()
         return
     if config.method == "ddtree":
         args.enable_ddtree = True
@@ -1625,6 +1667,18 @@ def _normalize_speculative_config_or_exit(args):
             args.mtp_sidecar = config.model
         if config.num_speculative_tokens is not None:
             args.mtp_max_k = config.num_speculative_tokens
+    elif config.method == "suffix":
+        args.suffix_decoding = True
+        if config.num_speculative_tokens is not None:
+            args.suffix_max_draft = config.num_speculative_tokens
+        if config.max_suffix_len is not None:
+            args.suffix_max_suffix_len = config.max_suffix_len
+        if config.min_confidence is not None:
+            args.suffix_min_confidence = config.min_confidence
+        if config.min_draft_len is not None:
+            args.suffix_min_draft_len = config.min_draft_len
+
+    _fill_suffix_defaults()
 
 
 def _resolve_dflash_drafter_repo(args, profile) -> str:
@@ -6638,8 +6692,8 @@ Examples:
             "parses method/model/num_speculative_tokens now. DFlash is "
             'available with \'{"method":"dflash"}\', DDTree with '
             '\'{"method":"ddtree"}\', and MTP with '
-            '\'{"method":"mtp"}\'. SuffixDecoding keeps its legacy flag '
-            "until it migrates to this surface."
+            '\'{"method":"mtp"}\'. SuffixDecoding is available with '
+            '\'{"method":"suffix","num_speculative_tokens":8}\'.'
         ),
     )
     serve_parser.add_argument(
@@ -6865,27 +6919,27 @@ Examples:
     serve_parser.add_argument(
         "--suffix-max-draft",
         type=int,
-        default=8,
+        default=None,
         help="Max draft tokens per verify step (default: 8). "
         "Verify forward cost grows linearly with this.",
     )
     serve_parser.add_argument(
         "--suffix-max-suffix-len",
         type=int,
-        default=4,
+        default=None,
         help="Max k-gram length indexed for suffix matching (default: 4).",
     )
     serve_parser.add_argument(
         "--suffix-min-confidence",
         type=float,
-        default=0.3,
+        default=None,
         help="Vote confidence floor for draft truncation (default: 0.3). "
         "Lower → more optimistic drafts; higher → fewer but more reliable.",
     )
     serve_parser.add_argument(
         "--suffix-min-draft-len",
         type=int,
-        default=2,
+        default=None,
         help="Skip the verify forward when drafter returns fewer than "
         "this many tokens (default: 2). Protects free-form chat from "
         "verify overhead on weak 1-token drafts. Set to 1 to verify "

--- a/vllm_mlx/spec_decode/config.py
+++ b/vllm_mlx/spec_decode/config.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import json
+import math
 from dataclasses import dataclass
 from typing import Any
 
@@ -26,19 +27,30 @@ class SpeculativeConfig:
     model: str | None = None
     num_speculative_tokens: int | None = None
     tree_budget: int | None = None
+    max_suffix_len: int | None = None
+    min_confidence: float | None = None
+    min_draft_len: int | None = None
     raw: dict[str, Any] | None = None
 
 
 _COMMON_KEYS = frozenset(
     {
         "method",
-        "model",
     }
 )
 
 _METHOD_KEYS = {
-    "ddtree": frozenset({"num_speculative_tokens", "tree_budget"}),
-    "mtp": frozenset({"num_speculative_tokens"}),
+    "ddtree": frozenset({"model", "num_speculative_tokens", "tree_budget"}),
+    "dflash": frozenset({"model"}),
+    "mtp": frozenset({"model", "num_speculative_tokens"}),
+    "suffix": frozenset(
+        {
+            "num_speculative_tokens",
+            "max_suffix_len",
+            "min_confidence",
+            "min_draft_len",
+        }
+    ),
 }
 
 
@@ -50,6 +62,26 @@ def _positive_int(value: Any, key: str) -> int | None:
     if value <= 0:
         raise SpeculativeConfigError(f"{key} must be a positive integer")
     return value
+
+
+def _positive_float(value: Any, key: str) -> float | None:
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise SpeculativeConfigError(f"{key} must be a positive number")
+    numeric = float(value)
+    if not math.isfinite(numeric) or numeric <= 0:
+        raise SpeculativeConfigError(f"{key} must be a positive number")
+    return numeric
+
+
+def _confidence(value: Any, key: str) -> float | None:
+    numeric = _positive_float(value, key)
+    if numeric is None:
+        return None
+    if numeric > 1:
+        raise SpeculativeConfigError(f"{key} must be between 0 and 1")
+    return numeric
 
 
 def _optional_string(value: Any, key: str) -> str | None:
@@ -106,6 +138,9 @@ def parse_speculative_config(value: str | None) -> SpeculativeConfig | None:
             payload.get("num_speculative_tokens"), "num_speculative_tokens"
         ),
         tree_budget=_positive_int(payload.get("tree_budget"), "tree_budget"),
+        max_suffix_len=_positive_int(payload.get("max_suffix_len"), "max_suffix_len"),
+        min_confidence=_confidence(payload.get("min_confidence"), "min_confidence"),
+        min_draft_len=_positive_int(payload.get("min_draft_len"), "min_draft_len"),
         raw=dict(payload),
     )
 
@@ -148,6 +183,38 @@ def legacy_mtp_config(
     )
 
 
+def legacy_suffix_config(
+    *,
+    num_speculative_tokens: int | None = None,
+    max_suffix_len: int | None = None,
+    min_confidence: float | None = None,
+    min_draft_len: int | None = None,
+) -> SpeculativeConfig:
+    """Return the compatibility config represented by ``--suffix-decoding``."""
+
+    raw: dict[str, Any] = {"method": "suffix"}
+    tokens = _positive_int(num_speculative_tokens, "num_speculative_tokens")
+    if tokens is not None:
+        raw["num_speculative_tokens"] = tokens
+    suffix_len = _positive_int(max_suffix_len, "max_suffix_len")
+    if suffix_len is not None:
+        raw["max_suffix_len"] = suffix_len
+    confidence = _confidence(min_confidence, "min_confidence")
+    if confidence is not None:
+        raw["min_confidence"] = confidence
+    draft_len = _positive_int(min_draft_len, "min_draft_len")
+    if draft_len is not None:
+        raw["min_draft_len"] = draft_len
+    return SpeculativeConfig(
+        method="suffix",
+        num_speculative_tokens=tokens,
+        max_suffix_len=suffix_len,
+        min_confidence=confidence,
+        min_draft_len=draft_len,
+        raw=raw,
+    )
+
+
 def require_migrated_speculative_config(config: SpeculativeConfig) -> None:
     """Fail until ``config.method`` is wired to a backend runner."""
 
@@ -169,6 +236,7 @@ __all__ = [
     "legacy_ddtree_config",
     "legacy_dflash_config",
     "legacy_mtp_config",
+    "legacy_suffix_config",
     "parse_speculative_config",
     "require_migrated_speculative_config",
 ]

--- a/vllm_mlx/spec_decode/registry.py
+++ b/vllm_mlx/spec_decode/registry.py
@@ -91,6 +91,7 @@ register_spec_decoder(
     SpecDecoderPlugin(
         method="suffix",
         description="Drafter-free suffix / n-gram speculative decoding",
+        config_enabled=True,
         legacy_hint="use --suffix-decoding",
         aliases=("ngram",),
     )


### PR DESCRIPTION
## Summary

- enables `--speculative-config` for the existing SuffixDecoding backend
- maps `{"method":"suffix","num_speculative_tokens":N}` onto the current `--suffix-decoding` / `--suffix-max-draft` runtime path
- supports the existing suffix knobs in JSON form: `max_suffix_len`, `min_confidence`, and `min_draft_len`
- treats legacy `--suffix-decoding` as a shorthand that produces the same `SpeculativeConfig`
- rejects ambiguous mixes of `--speculative-config` with legacy suffix flags

## Notes

This PR does not change the SuffixDecoding algorithm or scheduler install path. It only wires the already-supported runtime behind the unified vLLM-style speculative config frontend, matching the DFlash/DDTree/MTP direction.

No version bump.

## Validation

- `uv run --extra test --python 3.11 python -m pytest tests/test_speculative_config.py tests/test_suffix_decoding.py tests/test_suffix_decoding_tier.py -q` -> 86 passed
- `uv run --extra test --python 3.11 python -m pytest tests/test_mtp_cli_wiring.py tests/test_dflash_eligibility.py tests/test_ddtree_eligibility.py -q` -> 91 passed
- `uv run --extra test --python 3.11 python -m pytest tests/test_no_out_of_band_routing.py -q` -> 14 passed
- `uv run --python 3.11 ruff check vllm_mlx/spec_decode/config.py vllm_mlx/spec_decode/registry.py vllm_mlx/cli.py tests/test_speculative_config.py` -> passed