### PR TITLE
fix(nemotron): fail-open tool-call parsing for degraded wire variants

### DIFF
--- a/tests/test_nemotron_tool_parser_fail_open.py
+++ b/tests/test_nemotron_tool_parser_fail_open.py
@@ -1,0 +1,250 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Fail-open regression tests for :class:`NemotronToolParser`.
+
+Nemotron's *nominal* tool-call wire shape is fully wrapped::
+
+    <tool_call><function=NAME>...</function></tool_call>
+
+In practice the model (especially at low quantization / after several tool
+rounds) degrades into several near-miss variants. The historical parser
+keyed on the whole ``<tool_call>...</tool_call>`` wrapper, so every one of
+these leaked the call through as plain assistant ``content`` instead of a
+structured tool call:
+
+    (a) a missing / truncated ``</tool_call>``
+    (b) a bare ``<function=..>..</function>`` with no wrapper at all
+    (d) stray text between ``</function>`` and ``</tool_call>``
+    (e) prose between ``<tool_call>`` and ``<function=``
+
+The load-bearing signature of a call is ``<function=NAME>...</function>``, so
+the parser now keys on that and treats the wrapper as optional. Prose that
+does not contain ``<function=..>..</function>`` still never matches, so this
+cannot manufacture a tool call out of plain text.
+
+This module imports only the parser class (no MLX / model runtime), so it is
+runnable in isolation.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from vllm_mlx.tool_parsers.nemotron_tool_parser import NemotronToolParser
+
+
+@pytest.fixture
+def parser() -> NemotronToolParser:
+    return NemotronToolParser()
+
+
+def _only_call(result):
+    assert result.tools_called
+    assert len(result.tool_calls) == 1
+    return result.tool_calls[0]
+
+
+# ---------------------------------------------------------------------------
+# Canonical regression — the fully-wrapped shape must keep working.
+# ---------------------------------------------------------------------------
+
+
+def test_canonical_parameter_wrapper(parser):
+    text = (
+        "<tool_call><function=get_weather>"
+        "<parameter=city>Paris</parameter>"
+        "</function></tool_call>"
+    )
+    tc = _only_call(parser.extract_tool_calls(text))
+    assert tc["name"] == "get_weather"
+    assert json.loads(tc["arguments"]) == {"city": "Paris"}
+
+
+def test_canonical_json_body_wrapper(parser):
+    text = '<tool_call><function=calculate>{"expression": "2*3"}</function></tool_call>'
+    tc = _only_call(parser.extract_tool_calls(text))
+    assert tc["name"] == "calculate"
+    assert json.loads(tc["arguments"]) == {"expression": "2*3"}
+
+
+# ---------------------------------------------------------------------------
+# Degraded variants that previously leaked as text.
+# ---------------------------------------------------------------------------
+
+
+def test_variant_a_missing_closing_tool_call(parser):
+    """(a) ``</tool_call>`` truncated away — the call must still parse."""
+    text = (
+        "<tool_call><function=get_weather>"
+        "<parameter=city>Paris</parameter></function>"
+    )
+    tc = _only_call(parser.extract_tool_calls(text))
+    assert tc["name"] == "get_weather"
+    assert json.loads(tc["arguments"]) == {"city": "Paris"}
+
+
+def test_variant_b_bare_function_no_wrapper(parser):
+    """(b) No ``<tool_call>`` wrapper at all."""
+    text = "<function=get_weather><parameter=city>Paris</parameter></function>"
+    tc = _only_call(parser.extract_tool_calls(text))
+    assert tc["name"] == "get_weather"
+    assert json.loads(tc["arguments"]) == {"city": "Paris"}
+
+
+def test_variant_d_stray_text_before_close(parser):
+    """(d) Stray text between ``</function>`` and ``</tool_call>``."""
+    text = (
+        "<tool_call><function=get_weather>"
+        "<parameter=city>Paris</parameter></function>"
+        " some junk </tool_call>"
+    )
+    result = parser.extract_tool_calls(text)
+    tc = _only_call(result)
+    assert tc["name"] == "get_weather"
+    assert json.loads(tc["arguments"]) == {"city": "Paris"}
+    # The stray text survives as content; residual wrapper tags do not leak.
+    assert result.content == "some junk"
+    assert "tool_call" not in (result.content or "")
+
+
+def test_variant_e_prose_before_function(parser):
+    """(e) Prose between ``<tool_call>`` and ``<function=``."""
+    text = (
+        "<tool_call>Let me check the weather."
+        "<function=get_weather><parameter=city>Paris</parameter></function></tool_call>"
+    )
+    result = parser.extract_tool_calls(text)
+    tc = _only_call(result)
+    assert tc["name"] == "get_weather"
+    assert result.content == "Let me check the weather."
+    assert "tool_call" not in (result.content or "")
+
+
+def test_surrounding_prose_bare_call_no_leak(parser):
+    """A bare call embedded in prose parses; no XML leaks into content."""
+    text = (
+        "Sure, I'll do that.\n"
+        "<function=get_weather><parameter=city>Paris</parameter></function>\n"
+        "Done."
+    )
+    result = parser.extract_tool_calls(text)
+    tc = _only_call(result)
+    assert tc["name"] == "get_weather"
+    assert "<function=" not in (result.content or "")
+    assert "</function>" not in (result.content or "")
+
+
+# ---------------------------------------------------------------------------
+# Zero false positives — prose without a function signature never matches.
+# ---------------------------------------------------------------------------
+
+
+def test_zero_false_positive_plain_prose(parser):
+    text = "Here is the information you requested. No tools needed."
+    result = parser.extract_tool_calls(text)
+    assert not result.tools_called
+    assert result.content == text
+
+
+def test_zero_false_positive_mentions_function_word(parser):
+    text = "You can call the function get_weather to retrieve the data."
+    result = parser.extract_tool_calls(text)
+    assert not result.tools_called
+    assert result.content == text
+
+
+def test_marker_present_but_unparseable_logs_and_fails_open(parser, caplog):
+    """A ``<tool_call>`` marker with no parseable function must fail open
+    (return the raw text unchanged) and emit a diagnostic warning so the
+    unhandled shape can be captured."""
+    text = "<tool_call>garbled, no function here</tool_call>"
+    with caplog.at_level(
+        "WARNING", logger="vllm_mlx.tool_parsers.nemotron_tool_parser"
+    ):
+        result = parser.extract_tool_calls(text)
+    assert not result.tools_called
+    assert result.content == text
+    assert any("no tool call extracted" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# Streaming.
+# ---------------------------------------------------------------------------
+
+
+def _stream(parser, chunks):
+    """Feed ``chunks`` incrementally; return the list of per-delta results."""
+    previous = ""
+    results = []
+    for chunk in chunks:
+        current = previous + chunk
+        results.append(
+            parser.extract_tool_calls_streaming(previous, current, chunk)
+        )
+        previous = current
+    return results
+
+
+def test_streaming_passthrough_without_marker(parser):
+    assert parser.extract_tool_calls_streaming("", "Hello", "Hello") == {
+        "content": "Hello"
+    }
+
+
+def test_streaming_closes_on_function_when_tool_call_truncated(parser):
+    """A truncated variant only ever emits ``</function>`` (no
+    ``</tool_call>``); the streaming path must still emit the call."""
+    chunks = [
+        "<tool_call>",
+        "<function=get_weather>",
+        "<parameter=city>Paris</parameter>",
+        "</function>",
+    ]
+    deltas = _stream(parser, chunks)
+    emitted = [d for d in deltas if d and "tool_calls" in d]
+    assert len(emitted) == 1
+    tc = emitted[0]["tool_calls"][0]
+    assert tc["index"] == 0
+    assert tc["function"]["name"] == "get_weather"
+    assert json.loads(tc["function"]["arguments"]) == {"city": "Paris"}
+
+
+def test_streaming_closes_on_function_bare_no_wrapper(parser):
+    chunks = [
+        "<function=get_weather>",
+        "<parameter=city>Paris</parameter>",
+        "</function>",
+    ]
+    deltas = _stream(parser, chunks)
+    emitted = [d for d in deltas if d and "tool_calls" in d]
+    assert len(emitted) == 1
+    assert emitted[0]["tool_calls"][0]["function"]["name"] == "get_weather"
+
+
+def test_streaming_dedup_across_separate_close_deltas(parser):
+    """When ``</function>`` and ``</tool_call>`` arrive in *separate* deltas,
+    the call must be emitted exactly once, not twice."""
+    chunks = [
+        "<tool_call>",
+        "<function=get_weather><parameter=city>Paris</parameter></function>",
+        "</tool_call>",
+    ]
+    deltas = _stream(parser, chunks)
+    emitted = [d for d in deltas if d and "tool_calls" in d]
+    assert len(emitted) == 1
+    assert emitted[0]["tool_calls"][0]["function"]["name"] == "get_weather"
+
+
+def test_streaming_two_sequential_calls_increment_index(parser):
+    chunks = [
+        "<tool_call><function=f1><parameter=a>1</parameter></function></tool_call>",
+        "<tool_call><function=f2><parameter=b>2</parameter></function></tool_call>",
+    ]
+    deltas = _stream(parser, chunks)
+    emitted = [d for d in deltas if d and "tool_calls" in d]
+    assert len(emitted) == 2
+    assert emitted[0]["tool_calls"][0]["index"] == 0
+    assert emitted[0]["tool_calls"][0]["function"]["name"] == "f1"
+    assert emitted[1]["tool_calls"][0]["index"] == 1
+    assert emitted[1]["tool_calls"][0]["function"]["name"] == "f2"

--- a/vllm_mlx/tool_parsers/nemotron_tool_parser.py
+++ b/vllm_mlx/tool_parsers/nemotron_tool_parser.py
@@ -9,6 +9,7 @@ Supports Nemotron-3-Nano-30B-A3B and similar models.
 """
 
 import json
+import logging
 import re
 import uuid
 from collections.abc import Sequence
@@ -19,6 +20,8 @@ from .abstract_tool_parser import (
     ToolParser,
     ToolParserManager,
 )
+
+logger = logging.getLogger(__name__)
 
 
 def generate_tool_id() -> str:
@@ -42,11 +45,25 @@ class NemotronToolParser(ToolParser):
 
     EXPECTED_WIRE_FORMATS = ("tool_call_xml_body",)
 
-    # Pattern for Nemotron-style with parameters
+    # Pattern for Nemotron-style with parameters.
+    #
+    # The load-bearing signature of a call is ``<function=NAME>...</function>``;
+    # the ``<tool_call>``/``</tool_call>`` wrapper is treated as optional /
+    # decorative so that observed degradations still parse:
+    #   (a) a missing/truncated ``</tool_call>``,
+    #   (b) a bare ``<function=..>..</function>`` with no wrapper at all,
+    #   (d) stray text between ``</function>`` and ``</tool_call>``,
+    #   (e) prose between ``<tool_call>`` and ``<function=``.
+    # Prose without ``<function=..>..</function>`` still never matches, so
+    # this cannot manufacture a tool call out of plain text.
     TOOL_CALL_PATTERN = re.compile(
-        r"<tool_call>\s*<function=([^>]+)>(.*?)</function>\s*</tool_call>",
+        r"<function=([^>]+)>(.*?)</function>",
         re.DOTALL,
     )
+
+    # Residual bare wrapper tags left behind after the function bodies have
+    # been stripped from ``content``; removed so they don't leak as text.
+    RESIDUAL_WRAPPER_PATTERN = re.compile(r"</?tool_call>")
 
     # Pattern to extract parameters
     PARAM_PATTERN = re.compile(
@@ -60,7 +77,7 @@ class NemotronToolParser(ToolParser):
         """
         Extract tool calls from Nemotron model output.
         """
-        if "<tool_call>" not in model_output:
+        if "<tool_call>" not in model_output and "<function=" not in model_output:
             return ExtractedToolCallInformation(
                 tools_called=False, tool_calls=[], content=model_output
             )
@@ -116,9 +133,11 @@ class NemotronToolParser(ToolParser):
                     }
                 )
 
-        # Clean the text
+        # Clean the text: drop the function bodies and any residual bare
+        # <tool_call>/</tool_call> wrapper tags so they don't leak as content.
         if matches:
-            cleaned_text = self.TOOL_CALL_PATTERN.sub("", cleaned_text).strip()
+            cleaned_text = self.TOOL_CALL_PATTERN.sub("", cleaned_text)
+            cleaned_text = self.RESIDUAL_WRAPPER_PATTERN.sub("", cleaned_text).strip()
 
         if tool_calls:
             return ExtractedToolCallInformation(
@@ -127,6 +146,15 @@ class NemotronToolParser(ToolParser):
                 content=cleaned_text if cleaned_text else None,
             )
         else:
+            # Diagnostic: a tool-call marker was present but nothing parsed
+            # out — i.e. an as-yet-unhandled wire variant. Log the raw output
+            # (truncated) so the real shape can be captured next time it hits.
+            logger.warning(
+                "nemotron tool parser: tool-call marker present but no tool "
+                "call extracted (possible unhandled variant); raw model_output"
+                "[:500]=%r",
+                model_output[:500],
+            )
             return ExtractedToolCallInformation(
                 tools_called=False, tool_calls=[], content=model_output
             )
@@ -144,25 +172,36 @@ class NemotronToolParser(ToolParser):
         """
         Extract tool calls from streaming Nemotron model output.
         """
-        if "<tool_call>" not in current_text:
+        if "<tool_call>" not in current_text and "<function=" not in current_text:
             return {"content": delta_text}
 
-        if "</tool_call>" in delta_text:
+        # Fire on either close tag: a truncated variant may only ever emit
+        # </function> (no </tool_call>). extract_tool_calls re-parses the full
+        # current_text and returns ALL calls, so we de-dupe against the number
+        # already streamed (tracked in current_tool_id, which reset() zeroes
+        # per request) to avoid re-emitting when </function> and </tool_call>
+        # arrive in separate deltas.
+        if "</tool_call>" in delta_text or "</function>" in delta_text:
             result = self.extract_tool_calls(current_text)
             if result.tools_called:
-                return {
-                    "tool_calls": [
-                        {
-                            "index": i,
-                            "id": tc["id"],
-                            "type": "function",
-                            "function": {
-                                "name": tc["name"],
-                                "arguments": tc["arguments"],
-                            },
-                        }
-                        for i, tc in enumerate(result.tool_calls)
-                    ]
-                }
+                already_emitted = self.current_tool_id + 1
+                total = len(result.tool_calls)
+                if total > already_emitted:
+                    new_calls = result.tool_calls[already_emitted:]
+                    self.current_tool_id = total - 1
+                    return {
+                        "tool_calls": [
+                            {
+                                "index": already_emitted + i,
+                                "id": tc["id"],
+                                "type": "function",
+                                "function": {
+                                    "name": tc["name"],
+                                    "arguments": tc["arguments"],
+                                },
+                            }
+                            for i, tc in enumerate(new_calls)
+                        ]
+                    }
 
         return None


### PR DESCRIPTION
## Problem

`NemotronToolParser` (`vllm_mlx/tool_parsers/nemotron_tool_parser.py`, registered as `nemotron` / `nemotron3`) keys tool-call extraction on the **full** `<tool_call>...</tool_call>` wrapper:

```python
TOOL_CALL_PATTERN = re.compile(
    r"<tool_call>\s*<function=([^>]+)>(.*?)</function>\s*</tool_call>",
    re.DOTALL,
)
```

Nemotron models — especially at low quantization or after several tool rounds — frequently emit near-miss variants of that shape. Because the wrapper (and its closing tag) are mandatory in the regex, every one of these variants fails to match and the call **leaks through as plain assistant `content`** instead of a structured tool call:

| | Variant | Example |
|---|---|---|
| **(a)** | missing / truncated `</tool_call>` | `<tool_call><function=f><parameter=x>1</parameter></function>` |
| **(b)** | bare `<function=..>..</function>`, no wrapper at all | `<function=f><parameter=x>1</parameter></function>` |
| **(d)** | stray text between `</function>` and `</tool_call>` | `<tool_call><function=f>..</function> ok </tool_call>` |
| **(e)** | prose between `<tool_call>` and `<function=` | `<tool_call>Let me check.<function=f>..</function></tool_call>` |

The streaming path has the matching gap: its sentinel requires `<tool_call>` and it only fires on `</tool_call>`, so a truncated variant that ends at `</function>` never emits a streamed tool call.

## Fix

The load-bearing signature of a call is `<function=NAME>...</function>`; the `<tool_call>` / `</tool_call>` wrapper is decorative. So key on the function signature and treat the wrapper as optional:

- `TOOL_CALL_PATTERN` → `r"<function=([^>]+)>(.*?)</function>"`.
- New `RESIDUAL_WRAPPER_PATTERN = re.compile(r"</?tool_call>")` strips leftover bare `<tool_call>` / `</tool_call>` tags from `content` so they don't leak as text.
- The early-out now returns *not-called* only when **neither** `<tool_call>` **nor** `<function=` is present. Prose that lacks a `<function=..>..</function>` signature still never matches, so this **cannot manufacture a tool call out of plain text** — verified by the zero-false-positive tests below.
- **Streaming** (`extract_tool_calls_streaming`): the guard accepts `<tool_call>` **or** `<function=`, and fires on `</tool_call>` **or** `</function>`. Since `extract_tool_calls` re-parses the full `current_text` and returns *all* calls, the new calls are de-duped against `current_tool_id` (which `reset()` zeroes per request), so a call is emitted exactly once even when `</function>` and `</tool_call>` arrive in separate deltas.
- A diagnostic `WARNING` (with truncated raw `model_output`) is logged on the miss path — a `<tool_call>`/`<function=` marker was present but nothing parsed — so any still-unhandled wire variant can be captured from logs.

The `<parameter=..>` handling and the JSON-body path are **unchanged**.

## Tests

Adds `tests/test_nemotron_tool_parser_fail_open.py` — 15 cases:

- canonical regression (parameter and JSON-body wrappers still parse),
- variants **(a) / (b) / (d) / (e)**,
- surrounding-prose bare call with **no XML leak** into `content`,
- **zero false positives**: plain prose, and prose that mentions the word "function" but has no tag,
- diagnostic-log miss path (marker present, nothing parseable → fails open + warns),
- streaming: passthrough without a marker, **close on `</function>`** for a truncated variant, close on `</function>` for a bare (unwrapped) call, **de-dup** across separate `</function>` / `</tool_call>` deltas, and index increment across two sequential calls.

The test imports only the parser class, so it runs without the MLX model runtime. `tests/test_tool_parsers.py` (156 tests, including the existing `TestNemotronToolParser`) still passes unchanged.

## Note on affected versions

The parser is **byte-identical in 0.9.8 and 0.10.1** (the current `main`), so both releases are affected.

---

Co-authored with Claude Opus 4.8 (the commit carries a `Co-Authored-By` trailer). Happy to adjust naming, log level, or test layout to match project conventions.
