### PR TITLE
[codex] clarify suffix decoding explicit flag

### DIFF
--- a/docs/inference-efficiency-papers-2025.md
+++ b/docs/inference-efficiency-papers-2025.md
@@ -37,7 +37,7 @@ Ranked by: (1) Apple Silicon relevance = High, (2) expected impact on rapid-mlx,
 |------|-------|------------|-----------|---------------|--------|--------|
 | 1 | **DuoAttention** | ICLR | Retrieval vs streaming head classification; full KV for retrieval, sliding window for streaming | 2.55x memory, 2.18x decode | Medium | [On roadmap (#3)](README.md) -- not started |
 | 2 | **R-KV** | NeurIPS | Importance + non-redundancy ranking for reasoning KV caches | 100% quality at 10% cache | Medium | New |
-| 3 | **SuffixDecoding** | NeurIPS (Spotlight) | Model-free speculative decoding via suffix trees from past outputs | 5.3x speedup, zero extra memory | Medium | New |
+| 3 | **SuffixDecoding** | NeurIPS (Spotlight) | Model-free speculative decoding via suffix trees from past outputs | Workload-gated; local Gemma 4 copy/code/tool-XML gains, GPT-OSS/Qwen regressions | Medium | Explicit flag only |
 | 4 | **SWIFT** | ICLR | Self-speculative decoding by skipping intermediate layers | 1.3-1.6x, no draft model | Low | New |
 | 5 | **KVzip** | NeurIPS (Oral) / ICML | Query-agnostic KV compression via context reconstruction | 3-4x cache reduction | Medium | New |
 | 6 | **RocketKV** | ICML | Two-stage: coarse eviction + fine-grain top-k sparse attention | 400x compression, 3.7x speedup | Medium | New |
@@ -75,6 +75,10 @@ Z. Zhong et al. (CMU) | [arXiv](https://arxiv.org/abs/2411.04975) | [Project](ht
 > Model-free speculative decoding using suffix trees built from past outputs; exploits repetitive patterns in agentic workloads.
 > Expected improvement: Up to 5.3x; 2.8x faster than EAGLE-2/3 on agentic benchmarks
 > Apple Silicon relevance: High -- no draft model memory needed
+> Rapid-MLX status: exposed only as an explicit flag. Local deep benches
+> showed gains on Gemma 4 high-overlap copy/code/tool-XML traffic, but
+> regressions on GPT-OSS and Qwen3.6, so it is not a general-purpose
+> accelerator.
 
 **SWIFT: On-the-Fly Self-Speculative Decoding for LLM Inference Acceleration** -- ICLR 2025
 Heming Xia et al. | [GitHub](https://github.com/hemingkx/SWIFT)

--- a/docs/suffix_decoding_eligibility.md
+++ b/docs/suffix_decoding_eligibility.md
@@ -1,17 +1,62 @@
-# SuffixDecoding eligibility — per-model classification
+# SuffixDecoding eligibility — explicit workload flag
 
-> **Default**: `--suffix-decoding` is **OFF**. The flag is opt-in because
-> the win is workload-dependent and some models regress on plain chat.
+> **Default**: `--suffix-decoding` is **OFF** and must stay opt-in.
+> SuffixDecoding is a workload-specific optimization, not a general model
+> accelerator. It helps only when the request generates long, repetitive
+> continuations with high prompt/output n-gram overlap.
 >
-> This page tells you whether flipping it on for *your* model is a good
-> idea.
+> Prefer the unified form for new usage:
+>
+> ```bash
+> rapid-mlx serve gemma-4-12b-4bit \
+>   --speculative-config '{"method":"suffix","num_speculative_tokens":8}'
+> ```
+>
+> The legacy `--suffix-decoding` flag is still accepted for compatibility.
+
+## When To Use It
+
+Use SuffixDecoding only when the user explicitly knows their traffic is
+high-overlap, for example:
+
+- code editing that re-emits most of the input file/function;
+- prompt-copy or template-fill tasks;
+- tool-call XML loops with repeated structure;
+- agent loops that emit repeated scaffolding across many turns.
+
+Leave it off for ordinary chat, diverse prose, low-overlap JSONL, and
+unknown traffic mixes. Rapid-MLX does not infer the user's workload yet;
+future adaptive gating may sample early acceptance rates per request, but
+that is not implemented today.
+
+## Current Local Validation
+
+Deep local benches on 2026-07-06 showed the expected split: Suffix helps
+some high-overlap Gemma 4 workloads, but regresses GPT-OSS and Qwen.
+
+| Model | Workload | Median speedup | Recommendation |
+|---|---|---:|---|
+| `gemma-4-12b-4bit` | copy code | 1.54x | Candidate |
+| `gemma-4-12b-4bit` | long code edit | 1.56x | Candidate |
+| `gemma-4-12b-4bit` | repeated tool XML | 1.49x | Candidate |
+| `gemma-4-12b-4bit` | JSONL repeat | 0.77x | Avoid |
+| `gemma-4-31b-4bit` | copy code | 1.54x | Candidate |
+| `gemma-4-31b-4bit` | long code edit | 1.44x | Candidate |
+| `gemma-4-31b-4bit` | repeated tool XML | 1.52x | Candidate |
+| `gemma-4-31b-4bit` | JSONL repeat | 0.76x | Avoid |
+| `gpt-oss-20b` | deep high-overlap sweep | ~0.86x | Avoid |
+| `qwen3.6-27b-8bit` | forced deep high-overlap sweep | 0.88-0.95x | Avoid |
+
+This is why SuffixDecoding is exposed as an explicit flag only. It is
+reasonable to try on Gemma 4 code-edit / copy / repeated tool-XML traffic;
+it is not recommended for GPT-OSS, Qwen3.6, or general chat.
 
 ## Tier definitions
 
 | Tier | Trigger | Startup hint | What you should do |
 |---|---|---|---|
-| **AGENT** | `tool_loop ≥ 1.8x` AND `min(其余) ≥ 0.95x` | `💡 SuffixDecoding recommended for this model (tool ~Nx) — try --suffix-decoding` | Enable `--suffix-decoding` for agentic / tool-heavy traffic. |
-| **STRUCTURED** | `max ≥ 1.5x` AND `min ≥ 0.90x` | `💡 SuffixDecoding may help on structured output (~Nx peak) — try --suffix-decoding` | Worth trying if you do JSON / code generation; benchmark your own traffic. |
+| **AGENT** | `tool_loop ≥ 1.8x` AND `min(others) ≥ 0.95x` | Explicit flag hint | Try only for agent/tool-heavy traffic matching the bench. |
+| **STRUCTURED** | `max ≥ 1.5x` AND `min ≥ 0.90x` | Explicit flag hint | Try only for the winning structured workload. |
 | **NEUTRAL** | `min ≥ 0.95x` AND `max ≥ 1.0x` | (silent) | Leave OFF; it neither helps nor hurts. |
 | **AVOID** | any workload `< 0.85x` | `⚠️ SuffixDecoding is known to regress this model — avoid --suffix-decoding` | Leave OFF. It will measurably slow chat/tool/etc. |
 | **UNKNOWN** | not benched | (silent) | Leave OFF, or run the bench (below) and update the profile. |
@@ -21,27 +66,26 @@ workload mix at *your* startup is unknown, so the user owns the flag.
 
 ## Why this matters
 
-`--suffix-decoding` exploits repetition in the *output* token stream. It
-wins big when output is structured (JSON), agentic (tool-call loops), or
-code-edit-like (lots of token reuse from the prompt). It loses on
-free-form chat where repetition is incidental — every wasted draft is a
-small but real overhead.
+`--suffix-decoding` exploits repetition in the prompt and generated token
+stream. It wins only when many drafted tokens are accepted. When the
+prompt/output overlap is weak, the verify forwards become pure overhead
+and the request slows down.
 
-The same model size can land in opposite tiers depending on training
-mix:
+The same model can be positive on one workload and negative on another:
 
 | Model | Tier | tool_loop speedup | Why |
 |---|---|---|---|
-| Qwen3-0.6B-8bit | **AGENT** | 4.6x | RLHF tuned for tool calling — output token vocabulary tightly clusters around the tool-format tokens, so the suffix tree hits often. |
-| Llama-3.2-1B-Instruct-4bit | **NEUTRAL/STRUCTURED** | 1.27x | Same size, but no tool-RLHF. Outputs more diverse, fewer suffix hits. |
+| Gemma 4 12B | **mixed** | 1.49x on repeated tool XML | Repeated XML scaffolding creates high n-gram reuse. |
+| Gemma 4 12B | **avoid** | 0.77x on JSONL repeat | The generated token path did not match drafts well enough to pay for verify. |
 
-In other words: **size doesn't predict tier**. Bench the model you ship.
+In other words: **model family alone is not enough**. Bench the workload
+you ship, and leave the flag off unless the traffic is known.
 
 ## How to bench a new model
 
 ```bash
 python3.12 scripts/bench_suffix_decoding_integrated.py \
-    --model mlx-community/Qwen3-0.6B-8bit \
+    --model gemma-4-12b-4bit \
     --runs 3 \
     --max-tokens 256
 ```
@@ -56,11 +100,11 @@ speedup ratios, and the resulting tier:
 
 ```json
 {
-  "model": "mlx-community/Qwen3-0.6B-8bit",
-  "vanilla_tps": {"chat": 280.0, "json_array": 290.0, "tool_loop": 305.0, "code_edit": 240.0},
-  "suffix_tps":  {"chat": 295.0, "json_array": 410.0, "tool_loop": 1402.0, "code_edit": 380.0},
-  "speedup":     {"chat": 1.05,  "json_array": 1.41,  "tool_loop": 4.60,    "code_edit": 1.58},
-  "tier": "agent"
+  "model": "gemma-4-12b-4bit",
+  "vanilla_tps": {"chat": 58.0, "json_array": 61.0, "tool_loop": 64.0, "code_edit": 57.0},
+  "suffix_tps":  {"chat": 53.0, "json_array": 47.0, "tool_loop": 95.0, "code_edit": 88.0},
+  "speedup":     {"chat": 0.91, "json_array": 0.77, "tool_loop": 1.48, "code_edit": 1.54},
+  "tier": "avoid"
 }
 ```
 
@@ -83,21 +127,19 @@ The first sweep (issue #269 acceptance criteria) covers:
 - mlx-community/Llama-3.1-8B-Instruct-4bit
 - mlx-community/SmolLM3-3B-4bit
 
-Hybrid arches (Qwen3.5/3.6, Granite4, Qwopus) are gated upstream by
-`supports_spec_decode=False` and stay `n/a (hybrid arch)`.
+Hybrid arches (Qwen3.5/3.6 A3B/A10B, Granite4, Qwopus) are gated
+upstream by `supports_spec_decode=False` and stay `n/a (hybrid arch)`.
 
 ## FAQ
 
-**Why not auto-enable AGENT-tier models?**
-Because the *traffic mix* at your startup is unknown. A model classified
-AGENT may still see chat-only requests in your deployment, where the
-tier-defining `tool_loop` win never applies. Default-OFF is conservative
-and predictable.
+**Why not auto-enable positive models?**
+Because the *traffic mix* at startup is unknown. Even Gemma 4 can be
+positive on repeated tool XML and negative on JSONL. Default-OFF is
+conservative and predictable.
 
 **Why does model size not determine the tier?**
-See the Qwen3-0.6B vs Llama-3.2-1B example above. Tier is determined by
-output-token *predictability*, which is a function of training data and
-RLHF — not parameter count.
+Tier is determined by prompt/output token reuse and acceptance rate, not
+parameter count.
 
 **When do tiers re-bench?**
 On meaningful upstream version bumps (`mlx`, `mlx-lm`, the model

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -6692,7 +6692,9 @@ Examples:
             "parses method/model/num_speculative_tokens now. DFlash is "
             'available with \'{"method":"dflash"}\', DDTree with '
             '\'{"method":"ddtree"}\', and MTP with '
-            '\'{"method":"mtp"}\'. SuffixDecoding is available with '
+            '\'{"method":"mtp"}\'. SuffixDecoding is an explicit, '
+            "workload-specific flag for high prompt/output-overlap traffic "
+            "and is available with "
             '\'{"method":"suffix","num_speculative_tokens":8}\'.'
         ),
     )
@@ -6905,16 +6907,20 @@ Examples:
         ),
     )
     # SuffixDecoding — drafter-free spec-decode using a suffix tree over
-    # generated tokens. Big wins on agent/tool/JSON workloads (3-5x);
-    # ~zero overhead on free-form chat. Pure-attention only.
+    # prompt/generated tokens. This is an explicit workload flag, not a
+    # general accelerator: it can help long high-overlap copy/code-edit/
+    # repeated tool-XML traffic, and can regress ordinary chat / JSONL /
+    # unsupported model families. Pure-attention only.
     serve_parser.add_argument(
         "--suffix-decoding",
         action="store_true",
         default=False,
         help="Enable SuffixDecoding spec-decode (drafter-free, statistical). "
-        "Speedup is workload-dependent: 3-5x on tool-call/JSON/code-edit, "
-        "~1x on free-form chat. Auto-disabled on hybrid models "
-        "(Qwen3.5/3.6, Granite4, Mamba/Jamba/RWKV).",
+        "Explicit opt-in only: useful for long high-overlap workloads such "
+        "as prompt-copy, code editing, and repeated tool XML on validated "
+        "models. Do not use as a general chat accelerator; GPT-OSS/Qwen "
+        "families have shown regressions in local benches. Auto-disabled "
+        "on hybrid models (Qwen3.5/3.6 A3B/A10B, Granite4, Mamba/Jamba/RWKV).",
     )
     serve_parser.add_argument(
         "--suffix-max-draft",

--- a/vllm_mlx/model_auto_config.py
+++ b/vllm_mlx/model_auto_config.py
@@ -1110,7 +1110,8 @@ def enrich_model_config(cfg: ModelConfig | None, model: Any) -> ModelConfig:
 # a user looking at the same table by eye:
 #
 #   - AGENT     — tool calling specifically wins big AND nothing regresses
-#                 (we'd tell the user "turn it on").
+#                 (we'd tell the user "try the explicit flag if your traffic
+#                 matches").
 #   - STRUCTURED — some workload wins meaningfully AND nothing meaningfully
 #                  regresses (we'd say "try it for that workload").
 #   - NEUTRAL   — within noise across the board (silent — no point
@@ -1125,7 +1126,7 @@ def classify_suffix_decoding_tier(speedup: dict[str, float]) -> str:
     Empty dict → "unknown". Single-workload dicts use the special-case
     rule that an empty ``min(others)`` is treated as +∞ (the AGENT gate
     is satisfied vacuously). See ``tests/test_suffix_decoding_tier.py``
-    for boundary cases including the real Qwen3-0.6B / Qwen3-14B numbers.
+    for boundary cases.
     """
     if not speedup:
         return "unknown"
@@ -1184,14 +1185,15 @@ def suffix_decoding_hint(cfg: "ModelConfig | None") -> str | None:
         peak = speedup.get("tool_loop") or (max(speedup.values()) if speedup else 0)
         return (
             f"SuffixDecoding: recommended for tool/agent traffic "
-            f"(tool_loop {peak:.1f}x). Pass --suffix-decoding to enable."
+            f"(tool_loop {peak:.1f}x). Explicitly pass --suffix-decoding "
+            "only if your traffic matches."
         )
     if tier == "structured":
         peak_key = max(speedup, key=speedup.get) if speedup else "structured"
         peak_val = speedup.get(peak_key, 0)
         return (
             f"SuffixDecoding: may help on {peak_key} ({peak_val:.2f}x). "
-            "Pass --suffix-decoding if your traffic matches."
+            "Explicitly pass --suffix-decoding only if your traffic matches."
         )
     if tier == "avoid":
         worst_key = min(speedup, key=speedup.get) if speedup else "some workloads"

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -2194,9 +2194,10 @@ def _install_suffix_decoding(
     """Monkey-patch BatchGenerator's GenerationBatch to add SuffixDecoding.
 
     Drafter-free spec-decode: a suffix-tree index over prompt + emitted
-    tokens predicts repeated patterns (tool calls, JSON, code edits,
-    ReAct loops) at zero drafter cost. Big wins on agent workloads
-    (3-5×); ~1× on free-form chat (regression-floor).
+    tokens predicts repeated patterns. This is workload-specific, not a
+    general accelerator: it can help long high-overlap copy/code-edit/
+    repeated tool-XML traffic, and can regress ordinary chat or model
+    families whose generated token path does not match the suffix drafts.
 
     The hot path lives in ``GenerationBatch._step`` (mlx-lm 0.31+):
 

--- a/vllm_mlx/spec_decode/registry.py
+++ b/vllm_mlx/spec_decode/registry.py
@@ -90,7 +90,7 @@ register_spec_decoder(
 register_spec_decoder(
     SpecDecoderPlugin(
         method="suffix",
-        description="Drafter-free suffix / n-gram speculative decoding",
+        description=("Explicit suffix / n-gram speculation for high-overlap workloads"),
         config_enabled=True,
         legacy_hint="use --suffix-decoding",
         aliases=("ngram",),


### PR DESCRIPTION
## Summary

Clarifies that SuffixDecoding is an explicit, workload-specific opt-in flag rather than a general decoding accelerator.

Changes:
- rewrites the SuffixDecoding eligibility doc around high-overlap workload gating
- documents local validation results showing Gemma 4 copy/code/tool-XML gains but GPT-OSS/Qwen regressions
- updates CLI help, scheduler docstring, registry description, and auto-config hints to avoid over-claiming generic speedups
- keeps both `--speculative-config '{"method":"suffix"}'` and legacy `--suffix-decoding` paths documented

## Why

The deeper suffix experiments showed the right contract is explicit user choice: it can help specific long repetitive workloads, but should not be recommended or auto-enabled for unknown traffic.

## Validation

- `PATH=/opt/homebrew/bin:$PATH uv run --extra test --python 3.11 python -m pytest tests/test_suffix_decoding_tier.py tests/test_speculative_config.py tests/test_cli_models.py -q` -> 88 passed
- `PATH=/opt/homebrew/bin:$PATH uv run --python 3.11 ruff check vllm_mlx/cli.py vllm_mlx/model_auto_config.py vllm_mlx/scheduler.py vllm_mlx/spec_decode/registry.py` -> pass
- `git diff --check` -> pass
- `PATH=/opt/homebrew/bin:$PATH .venv/bin/python -m scripts.pr_validate.pr_validate 1034 --skip-steps stress_e2e_bench` -> MERGE-SAFE
  - codex_review PASS
  - lint PASS
  - targeted_tests PASS: 682 passed
  - full_unit PASS: 12113 passed, 34 skipped, 17 deselected, 6 xfailed, 1 xpassed

`stress_e2e_bench` was intentionally skipped for this docs/help-text PR. A first full run entered stress and selected multiple 20B/35B-scale models; no code path that affects runtime decoding behavior changed in this PR, and the Suffix performance evidence is recorded from the prior deep local benches.

No version bump: this is docs/help-text wording only, and the PR carries `skip-version-bump`.