### PR TITLE
[codex] complete MTP speculative-config wiring

### DIFF
--- a/README.md
+++ b/README.md
@@ -823,14 +823,21 @@ rapid-mlx serve qwen3.5-27b-8bit --speculative-config '{"method":"dflash"}'
 
 Workload sensitivity: coding / math / summarization typically see **1.5–2.7×**; high-entropy creative writing and long-form chat can dip to **0.6–0.9×** because the drafter's training distribution diverges from open-ended generation — a known spec-decode literature pattern ([AdaEDL](https://arxiv.org/abs/2410.18351)), not a bug. DFlash mode runs a dedicated single-user server (no batched kernel yet); tool calling, MCP, and embeddings aren't available in that mode — restart without DFlash for those.
 
-**MTP** (Multi-Token Prediction) — draft head baked into the model. Opt in with `--speculative-config '{"method":"mtp"}'` on MTP-trained checkpoints. When using an already-supported MTP sidecar flow, pass the sidecar path in the config `model` field; it maps to the existing `--mtp-sidecar` plumbing.
+**MTP** (Multi-Token Prediction) — draft head baked into the model, or a validated assistant sidecar. Opt in with `--speculative-config '{"method":"mtp"}'` on MTP-trained checkpoints. For sidecar flows, pass the assistant path in the config `model` field. `num_speculative_tokens` maps to the existing MTP max-K controller ceiling; `disable_auto_k` pins the fixed-K=1 bench path.
 
 ```bash
 rapid-mlx serve mlx-community/gemma-4-12b-it-4bit \
-  --speculative-config '{"method":"mtp","model":"google/gemma-4-12B-it-assistant"}'
+  --speculative-config '{"method":"mtp","model":"google/gemma-4-12B-it-assistant","num_speculative_tokens":3}'
 ```
 
-**SuffixDecoding** — drafter-free, statistical n-gram lookup over the running suffix. Opt in with `--suffix-decoding`; works on any BatchedEngine alias.
+For fixed-K parity benches:
+
+```bash
+rapid-mlx serve qwen3.6-27b-mtp-4bit \
+  --speculative-config '{"method":"mtp","num_speculative_tokens":1,"disable_auto_k":true}'
+```
+
+**SuffixDecoding** — drafter-free, statistical n-gram lookup over the running suffix. Opt in explicitly with `--speculative-config '{"method":"suffix","num_speculative_tokens":8}'` only for high-overlap workloads; `--suffix-decoding` remains as a compatibility shorthand.
 
 **DDTree** (experimental) — builds a tree from one DFlash draft pass, then verifies multiple likely continuations. The first rapid-mlx integration is intentionally opt-in and single-user, using the external `dtree-mlx` runtime:
 
@@ -847,7 +854,7 @@ rapid-mlx serve qwen3.5-9b-8bit \
   --speculative-config '{"method":"ddtree","model":"z-lab/Qwen3.5-9B-DFlash","num_speculative_tokens":16,"tree_budget":24}'
 ```
 
-`--enable-dflash` remains as a compatibility shorthand for `--speculative-config '{"method":"dflash"}'`, and `--dflash-drafter-path` maps to the config `model` field. `--enable-ddtree` similarly remains as a compatibility shorthand for `--speculative-config '{"method":"ddtree"}'`. `--spec-decode mtp` remains as a compatibility shorthand for `--speculative-config '{"method":"mtp"}'`, and `--mtp-sidecar` maps to the config `model` field. None of these backends is enabled by default. SuffixDecoding keeps its existing flag until it migrates behind the same config interface.
+`--enable-dflash` remains as a compatibility shorthand for `--speculative-config '{"method":"dflash"}'`, and `--dflash-drafter-path` maps to the config `model` field. `--enable-ddtree` similarly remains as a compatibility shorthand for `--speculative-config '{"method":"ddtree"}'`. `--spec-decode mtp` remains as a compatibility shorthand for `--speculative-config '{"method":"mtp"}'`; `--mtp-sidecar` maps to `model`, `--mtp-max-k` maps to `num_speculative_tokens`, and `--mtp-disable-auto-k` maps to `disable_auto_k`. `--suffix-decoding` remains as a compatibility shorthand for `--speculative-config '{"method":"suffix"}'`. None of these backends is enabled by default.
 
 Mutex: DFlash cannot combine with MTP or SuffixDecoding (single-user path). MTP and SuffixDecoding cannot combine with each other (both consume the drafter slot).
 
@@ -887,7 +894,7 @@ Mutex: DFlash cannot combine with MTP or SuffixDecoding (single-user path). MTP 
 | `--prefix-cache-index` | Prefix-cache lookup index: `radix` (default) or `hash` | `radix` |
 | `--pflash` | PFlash sparse prefill: `auto` / `always` / `off` | `auto` (on for verified aliases) |
 | `--enable-dflash` | Compatibility shorthand for DFlash speculative decoding (single-user; prefer `--speculative-config '{"method":"dflash"}'`) | off |
-| `--speculative-config` | vLLM-style speculative decoding JSON config; supports DFlash `{"method":"dflash"}`, DDTree `{"method":"ddtree"}`, and MTP `{"method":"mtp"}` | off |
+| `--speculative-config` | vLLM-style speculative decoding JSON config; supports DFlash, DDTree, MTP, and SuffixDecoding | off |
 | `--enable-ddtree` | Compatibility shorthand for DDTree speculative decoding (single-user; `qwen3.5-9b-8bit`) | off |
 | `--suffix-decoding` | Drafter-free n-gram speculative decoding (BatchedEngine path) | off |
 | `--spec-decode mtp` | Compatibility shorthand for MTP head speculative decoding; prefer `--speculative-config '{"method":"mtp"}'` | off |

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -92,6 +92,18 @@ rapid-mlx serve qwen3.5-27b-8bit --speculative-config '{"method":"dflash"}' --po
 # DDTree speculative decoding (experimental, single-user)
 rapid-mlx serve qwen3.5-9b-8bit --speculative-config '{"method":"ddtree"}' --port 8000
 
+# MTP speculative decoding with an assistant sidecar
+rapid-mlx serve gemma-4-12b-4bit \
+  --speculative-config '{"method":"mtp","model":"google/gemma-4-12B-it-assistant","num_speculative_tokens":3}'
+
+# MTP fixed-K parity bench mode
+rapid-mlx serve qwen3.6-27b-mtp-4bit \
+  --speculative-config '{"method":"mtp","num_speculative_tokens":1,"disable_auto_k":true}'
+
+# SuffixDecoding for explicit high-overlap workloads
+rapid-mlx serve gemma-4-12b-4bit \
+  --speculative-config '{"method":"suffix","num_speculative_tokens":8}'
+
 # API key authentication
 rapid-mlx serve qwen3.5-9b-4bit --api-key your-secret-key
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -58,6 +58,33 @@
 |--------|-------------|---------|
 | `--embedding-model` | Pre-load an embedding model at startup (requires `pip install 'rapid-mlx[embeddings]'`) | None |
 
+### Speculative Decoding Options
+
+Prefer `--speculative-config` for new speculative decoding usage. Legacy
+flags remain compatibility shorthands.
+
+| Config | Description |
+|--------|-------------|
+| `{"method":"dflash"}` | Enable the DFlash single-user bridge on validated aliases. |
+| `{"method":"ddtree"}` | Enable experimental DDTree verification on validated aliases. |
+| `{"method":"mtp"}` | Enable MTP speculative decoding for MTP-trained checkpoints. |
+| `{"method":"mtp","model":"<sidecar>"}` | Enable MTP with a validated assistant sidecar, currently for supported Gemma 4 unified targets. |
+| `{"method":"mtp","num_speculative_tokens":3}` | Set the MTP max-K controller ceiling. |
+| `{"method":"mtp","disable_auto_k":true}` | Disable the MTP EV depth controller for fixed-K parity benches. |
+| `{"method":"suffix","num_speculative_tokens":8}` | Enable explicit SuffixDecoding for high-overlap workloads. |
+
+Legacy mapping:
+
+| Legacy flag | Preferred config |
+|-------------|------------------|
+| `--enable-dflash` | `--speculative-config '{"method":"dflash"}'` |
+| `--enable-ddtree` | `--speculative-config '{"method":"ddtree"}'` |
+| `--spec-decode mtp` | `--speculative-config '{"method":"mtp"}'` |
+| `--mtp-sidecar <path>` | `{"method":"mtp","model":"<path>"}` |
+| `--mtp-max-k N` | `{"method":"mtp","num_speculative_tokens":N}` |
+| `--mtp-disable-auto-k` | `{"method":"mtp","disable_auto_k":true}` |
+| `--suffix-decoding` | `--speculative-config '{"method":"suffix"}'` |
+
 ### MCP Options
 
 | Option | Description | Default |

--- a/tests/test_speculative_config.py
+++ b/tests/test_speculative_config.py
@@ -19,13 +19,15 @@ from vllm_mlx.spec_decode.registry import get_spec_decoder, iter_spec_decoders
 
 def test_parse_speculative_config_accepts_vllm_common_keys() -> None:
     cfg = parse_speculative_config(
-        '{"method":"mtp","model":"local/draft","num_speculative_tokens":4}'
+        '{"method":"mtp","model":"local/draft","num_speculative_tokens":4,'
+        '"disable_auto_k":true}'
     )
 
     assert cfg is not None
     assert cfg.method == "mtp"
     assert cfg.model == "local/draft"
     assert cfg.num_speculative_tokens == 4
+    assert cfg.disable_auto_k is True
     assert cfg.tree_budget is None
 
 
@@ -86,6 +88,7 @@ def test_parse_suffix_speculative_config_accepts_existing_knobs() -> None:
         ('{"method":"mtp","num_speculative_tokens":true}', "positive integer"),
         ('{"method":"mtp","model":""}', "non-empty string"),
         ('{"method":"mtp","tree_budget":24}', "unsupported speculative-config"),
+        ('{"method":"mtp","disable_auto_k":1}', "boolean"),
         ('{"method":"ddtree","tree_budget":0}', "positive integer"),
         ('{"method":"ddtree","tree_budget":true}', "positive integer"),
         ('{"method":"ddtree","unknown":1}', "unsupported speculative-config"),
@@ -173,6 +176,7 @@ def _spec_config_args(**overrides):
         "mtp_sidecar": None,
         "mtp_num_draft_tokens": 1,
         "mtp_max_k": 3,
+        "mtp_disable_auto_k": False,
         "suffix_decoding": False,
         "suffix_max_draft": None,
         "suffix_max_suffix_len": None,
@@ -189,7 +193,7 @@ def test_speculative_config_mtp_normalizes_to_legacy_spec_decode() -> None:
     args = _spec_config_args(
         speculative_config=(
             '{"method":"mtp","model":"google/gemma-4-12B-it-assistant",'
-            '"num_speculative_tokens":2}'
+            '"num_speculative_tokens":2,"disable_auto_k":true}'
         )
     )
 
@@ -198,9 +202,11 @@ def test_speculative_config_mtp_normalizes_to_legacy_spec_decode() -> None:
     assert args.spec_decode == "mtp"
     assert args.mtp_sidecar == "google/gemma-4-12B-it-assistant"
     assert args.mtp_max_k == 2
+    assert args.mtp_disable_auto_k is True
     assert args._speculative_config.method == "mtp"
     assert args._speculative_config.model == "google/gemma-4-12B-it-assistant"
     assert args._speculative_config.num_speculative_tokens == 2
+    assert args._speculative_config.disable_auto_k is True
 
 
 def test_spec_decode_mtp_legacy_flag_is_speculative_config_shorthand() -> None:
@@ -210,6 +216,7 @@ def test_spec_decode_mtp_legacy_flag_is_speculative_config_shorthand() -> None:
         spec_decode="mtp",
         mtp_sidecar="google/gemma-4-12B-it-assistant",
         mtp_max_k=2,
+        mtp_disable_auto_k=True,
     )
 
     _normalize_speculative_config_or_exit(args)
@@ -218,6 +225,7 @@ def test_spec_decode_mtp_legacy_flag_is_speculative_config_shorthand() -> None:
     assert args._speculative_config.method == "mtp"
     assert args._speculative_config.model == "google/gemma-4-12B-it-assistant"
     assert args._speculative_config.num_speculative_tokens == 2
+    assert args._speculative_config.disable_auto_k is True
 
 
 def test_no_speculative_config_fills_suffix_runtime_defaults() -> None:
@@ -249,6 +257,23 @@ def test_speculative_config_mtp_rejects_legacy_sidecar_flag(capsys) -> None:
     captured = capsys.readouterr()
     assert "mutually exclusive" in captured.err
     assert "--mtp-sidecar" in captured.err
+
+
+def test_speculative_config_mtp_rejects_legacy_disable_auto_k_flag(capsys) -> None:
+    from vllm_mlx.cli import _normalize_speculative_config_or_exit
+
+    args = _spec_config_args(
+        speculative_config='{"method":"mtp","disable_auto_k":false}',
+        mtp_disable_auto_k=True,
+    )
+
+    with pytest.raises(SystemExit) as excinfo:
+        _normalize_speculative_config_or_exit(args)
+
+    assert excinfo.value.code == 2
+    captured = capsys.readouterr()
+    assert "mutually exclusive" in captured.err
+    assert "--mtp-disable-auto-k" in captured.err
 
 
 def test_speculative_config_malformed_with_legacy_flag_reports_clean_error(

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -1599,6 +1599,8 @@ def _normalize_speculative_config_or_exit(args):
             conflicts.append("--dflash-drafter-path")
         if (getattr(args, "mtp_sidecar", None) or "").strip():
             conflicts.append("--mtp-sidecar")
+        if getattr(args, "mtp_disable_auto_k", False):
+            conflicts.append("--mtp-disable-auto-k")
         # DFlash has a dedicated preflight that historically reports
         # these runtime conflicts as "cannot combine" (exit 1) before
         # probing mlx-vlm. Preserve that user-facing contract; other
@@ -1638,6 +1640,7 @@ def _normalize_speculative_config_or_exit(args):
                 config = legacy_mtp_config(
                     model=(getattr(args, "mtp_sidecar", None) or "").strip() or None,
                     num_speculative_tokens=getattr(args, "mtp_max_k", None),
+                    disable_auto_k=getattr(args, "mtp_disable_auto_k", False),
                 )
             elif getattr(args, "suffix_decoding", False):
                 config = legacy_suffix_config(
@@ -1667,6 +1670,8 @@ def _normalize_speculative_config_or_exit(args):
             args.mtp_sidecar = config.model
         if config.num_speculative_tokens is not None:
             args.mtp_max_k = config.num_speculative_tokens
+        if config.disable_auto_k is not None:
+            args.mtp_disable_auto_k = config.disable_auto_k
     elif config.method == "suffix":
         args.suffix_decoding = True
         if config.num_speculative_tokens is not None:
@@ -6692,7 +6697,9 @@ Examples:
             "parses method/model/num_speculative_tokens now. DFlash is "
             'available with \'{"method":"dflash"}\', DDTree with '
             '\'{"method":"ddtree"}\', and MTP with '
-            '\'{"method":"mtp"}\'. SuffixDecoding is an explicit, '
+            '\'{"method":"mtp","model":"<optional-sidecar>",'
+            '"num_speculative_tokens":3,"disable_auto_k":false}\'. '
+            "SuffixDecoding is an explicit, "
             "workload-specific flag for high prompt/output-overlap traffic "
             "and is available with "
             '\'{"method":"suffix","num_speculative_tokens":8}\'.'
@@ -6827,7 +6834,8 @@ Examples:
         choices=["none", "mtp", "dflash"],
         default="none",
         help=(
-            "R15-P1 model-side speculative decode. "
+            "Compatibility selector for model-side speculative decode; "
+            "prefer --speculative-config for new usage. "
             "``none`` (default) disables; ``mtp`` enables Qwen3.5/3.6 "
             "native MTP via vendored mlx-lm PR #990 — requires a "
             "checkpoint converted with the PR #990 sanitize() path "
@@ -6854,8 +6862,10 @@ Examples:
             "Path to a Gemma 4 MTP assistant-drafter checkpoint — either a "
             "local safetensors directory (e.g. ~/.cache/huggingface/hub/"
             "gemma-4-12B-it-assistant) or an HF repo id "
-            "(e.g. google/gemma-4-12B-it-assistant). Only consulted when "
-            "--spec-decode mtp is set; ignored for the Qwen3.5/3.6 "
+            "(e.g. google/gemma-4-12B-it-assistant). Prefer "
+            '--speculative-config \'{"method":"mtp","model":...}\' '
+            "for new usage. Only consulted when MTP spec-decode is set; "
+            "ignored for the Qwen3.5/3.6 "
             "native-MTP path (their head is baked into the target). "
             "Requires the [mtp] install extra."
         ),
@@ -6874,8 +6884,10 @@ Examples:
             "Hard ceiling on the per-round draft depth the EV controller "
             "may select (default: 3). The current generator implements "
             "K∈{0,1} (park + chain-of-1); values >1 are effectively "
-            "clamped until chain-of-K verify lands. Only consulted when "
-            "--spec-decode mtp is set."
+            "clamped until chain-of-K verify lands. Prefer "
+            '--speculative-config \'{"method":"mtp",'
+            '"num_speculative_tokens":3}\' for new usage. Only consulted '
+            "when MTP spec-decode is set."
         ),
     )
     serve_parser.add_argument(
@@ -6886,8 +6898,10 @@ Examples:
         help=(
             "Disable the EV depth controller and keep the pre-PR-B "
             "fixed-K=1 chain-of-1 MTP behavior. Used to A/B bench the "
-            "controller against the fixed-K=1 baseline. Only consulted "
-            "when --spec-decode mtp is set."
+            "controller against the fixed-K=1 baseline. Prefer "
+            '--speculative-config \'{"method":"mtp",'
+            '"disable_auto_k":true}\' for new usage. Only consulted '
+            "when MTP spec-decode is set."
         ),
     )
     # R15-P1 #313: DFlash drafter HF path override. Empty by default

--- a/vllm_mlx/spec_decode/config.py
+++ b/vllm_mlx/spec_decode/config.py
@@ -27,6 +27,7 @@ class SpeculativeConfig:
     model: str | None = None
     num_speculative_tokens: int | None = None
     tree_budget: int | None = None
+    disable_auto_k: bool | None = None
     max_suffix_len: int | None = None
     min_confidence: float | None = None
     min_draft_len: int | None = None
@@ -42,7 +43,7 @@ _COMMON_KEYS = frozenset(
 _METHOD_KEYS = {
     "ddtree": frozenset({"model", "num_speculative_tokens", "tree_budget"}),
     "dflash": frozenset({"model"}),
-    "mtp": frozenset({"model", "num_speculative_tokens"}),
+    "mtp": frozenset({"model", "num_speculative_tokens", "disable_auto_k"}),
     "suffix": frozenset(
         {
             "num_speculative_tokens",
@@ -92,6 +93,14 @@ def _optional_string(value: Any, key: str) -> str | None:
     return value.strip()
 
 
+def _optional_bool(value: Any, key: str) -> bool | None:
+    if value is None:
+        return None
+    if not isinstance(value, bool):
+        raise SpeculativeConfigError(f"{key} must be a boolean")
+    return value
+
+
 def parse_speculative_config(value: str | None) -> SpeculativeConfig | None:
     """Parse the JSON value passed to ``--speculative-config``."""
 
@@ -138,6 +147,7 @@ def parse_speculative_config(value: str | None) -> SpeculativeConfig | None:
             payload.get("num_speculative_tokens"), "num_speculative_tokens"
         ),
         tree_budget=_positive_int(payload.get("tree_budget"), "tree_budget"),
+        disable_auto_k=_optional_bool(payload.get("disable_auto_k"), "disable_auto_k"),
         max_suffix_len=_positive_int(payload.get("max_suffix_len"), "max_suffix_len"),
         min_confidence=_confidence(payload.get("min_confidence"), "min_confidence"),
         min_draft_len=_positive_int(payload.get("min_draft_len"), "min_draft_len"),
@@ -165,6 +175,7 @@ def legacy_mtp_config(
     *,
     model: str | None = None,
     num_speculative_tokens: int | None = None,
+    disable_auto_k: bool | None = None,
 ) -> SpeculativeConfig:
     """Return the compatibility config represented by MTP legacy flags."""
 
@@ -175,10 +186,14 @@ def legacy_mtp_config(
     tokens = _positive_int(num_speculative_tokens, "num_speculative_tokens")
     if tokens is not None:
         raw["num_speculative_tokens"] = tokens
+    disable_auto = _optional_bool(disable_auto_k, "disable_auto_k")
+    if disable_auto is not None:
+        raw["disable_auto_k"] = disable_auto
     return SpeculativeConfig(
         method="mtp",
         model=sidecar,
         num_speculative_tokens=tokens,
+        disable_auto_k=disable_auto,
         raw=raw,
     )
 


### PR DESCRIPTION
## Summary

Completes the MTP side of the unified `--speculative-config` interface.

Changes:
- adds `disable_auto_k` to `{"method":"mtp"}` config parsing
- maps legacy `--mtp-disable-auto-k` into the normalized speculative config
- maps JSON `disable_auto_k` back onto the existing scheduler input
- rejects mixed `--speculative-config` + legacy `--mtp-disable-auto-k` usage
- updates CLI help, README, and reference docs so new usage prefers the JSON interface

## Why

MTP was already partially normalized through `--speculative-config`, but fixed-K parity/bench mode still required the legacy `--mtp-disable-auto-k` flag. This made MTP the odd backend in the spec-decoding plugin interface. The new field lets users and benches describe MTP entirely in one config object while preserving legacy flags as shorthands.

## Validation

- `PATH=/opt/homebrew/bin:$PATH uv run --extra test --python 3.11 python -m pytest tests/test_speculative_config.py tests/test_mtp_cli_wiring.py tests/test_mtp_lossless.py tests/test_mtp_stream_contract.py -q` -> 117 passed
- `PATH=/opt/homebrew/bin:$PATH uv run --extra test --python 3.11 python -m pytest tests/test_mtp_spec_decode.py tests/test_cli_models.py tests/test_no_out_of_band_routing.py -q` -> 79 passed
- `PATH=/opt/homebrew/bin:$PATH uv run --python 3.11 ruff check README.md docs/reference/cli.md docs/reference/configuration.md vllm_mlx/spec_decode/config.py vllm_mlx/cli.py tests/test_speculative_config.py` -> pass
- `git diff --check` -> pass
- `PATH=/opt/homebrew/bin:$PATH .venv/bin/python -m scripts.pr_validate.pr_validate 1036 --skip-steps stress_e2e_bench` -> MERGE-SAFE
  - codex_review PASS
  - lint PASS
  - targeted_tests PASS: 691 passed
  - full_unit PASS: 12115 passed, 34 skipped, 17 deselected, 6 xfailed, 1 xpassed

`stress_e2e_bench` was intentionally skipped for the final pr_validate run. A first run entered stress and selected multiple 20B/27B/35B-scale models; this PR changes CLI/config mapping and docs, not the MTP generator or scheduler hot path. The correctness-sensitive MTP unit/lossless/stream/CLI suites and full unit suite passed.

No version bump: CLI/docs/interface polish only; PR carries `skip-version-bump`.