### PR TITLE
fix: gate unvalidated Gemma4 MTP sidecar

### DIFF
--- a/README.md
+++ b/README.md
@@ -823,12 +823,7 @@ rapid-mlx serve qwen3.5-27b-8bit --speculative-config '{"method":"dflash"}'
 
 Workload sensitivity: coding / math / summarization typically see **1.5–2.7×**; high-entropy creative writing and long-form chat can dip to **0.6–0.9×** because the drafter's training distribution diverges from open-ended generation — a known spec-decode literature pattern ([AdaEDL](https://arxiv.org/abs/2410.18351)), not a bug. DFlash mode runs a dedicated single-user server (no batched kernel yet); tool calling, MCP, and embeddings aren't available in that mode — restart without DFlash for those.
 
-**MTP** (Multi-Token Prediction) — draft head baked into the model, or a validated assistant sidecar. Opt in with `--speculative-config '{"method":"mtp"}'` on MTP-trained checkpoints. For sidecar flows, pass the assistant path in the config `model` field. `num_speculative_tokens` maps to the existing MTP max-K controller ceiling; `disable_auto_k` pins the fixed-K=1 bench path.
-
-```bash
-rapid-mlx serve mlx-community/gemma-4-12b-it-4bit \
-  --speculative-config '{"method":"mtp","model":"google/gemma-4-12B-it-assistant","num_speculative_tokens":3}'
-```
+**MTP** (Multi-Token Prediction) — draft head baked into the model. Opt in with `--speculative-config '{"method":"mtp"}'` on MTP-trained checkpoints. `num_speculative_tokens` maps to the existing MTP max-K controller ceiling; `disable_auto_k` pins the fixed-K=1 bench path. Gemma 4 assistant-sidecar MTP is not advertised because July 2026 A/B validation found greedy output divergence; it remains disabled until a lossless implementation lands.
 
 For fixed-K parity benches:
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -92,10 +92,6 @@ rapid-mlx serve qwen3.5-27b-8bit --speculative-config '{"method":"dflash"}' --po
 # DDTree speculative decoding (experimental, single-user)
 rapid-mlx serve qwen3.5-9b-8bit --speculative-config '{"method":"ddtree"}' --port 8000
 
-# MTP speculative decoding with an assistant sidecar
-rapid-mlx serve gemma-4-12b-4bit \
-  --speculative-config '{"method":"mtp","model":"google/gemma-4-12B-it-assistant","num_speculative_tokens":3}'
-
 # MTP fixed-K parity bench mode
 rapid-mlx serve qwen3.6-27b-mtp-4bit \
   --speculative-config '{"method":"mtp","num_speculative_tokens":1,"disable_auto_k":true}'

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -68,7 +68,7 @@ flags remain compatibility shorthands.
 | `{"method":"dflash"}` | Enable the DFlash single-user bridge on validated aliases. |
 | `{"method":"ddtree"}` | Enable experimental DDTree verification on validated aliases. |
 | `{"method":"mtp"}` | Enable MTP speculative decoding for MTP-trained checkpoints. |
-| `{"method":"mtp","model":"<sidecar>"}` | Enable MTP with a validated assistant sidecar, currently for supported Gemma 4 unified targets. |
+| `{"method":"mtp","model":"<sidecar>"}` | Reserved for future validated assistant sidecars. Gemma 4 sidecar MTP is currently disabled after greedy-lossless A/B failed. |
 | `{"method":"mtp","num_speculative_tokens":3}` | Set the MTP max-K controller ceiling. |
 | `{"method":"mtp","disable_auto_k":true}` | Disable the MTP EV depth controller for fixed-K parity benches. |
 | `{"method":"suffix","num_speculative_tokens":8}` | Enable explicit SuffixDecoding for high-overlap workloads. |

--- a/specdecoding.md
+++ b/specdecoding.md
@@ -1,0 +1,33 @@
+# Spec Decoding Validation Notes
+
+## 2026-07-06 MTP A/B: Gemma 4 assistant sidecar
+
+Target:
+
+- Base: `mlx-community/gemma-4-12B-it-4bit`
+- Sidecar: `google/gemma-4-12B-it-assistant`
+- Config: `{"method":"mtp","model":"google/gemma-4-12B-it-assistant","num_speculative_tokens":1,"disable_auto_k":true}`
+- Server controls: `temperature=0`, `--disable-prefix-cache`, same prompt set, single request at a time
+
+Result:
+
+- Correctness failed: 3 of 4 greedy HTTP prompts diverged from baseline text.
+- MTP metrics on the failed run showed activity (`attempts=102`, `accepts=71`, accept ratio about `0.696`), and some prompts were faster, but this is not acceptable because greedy output was not lossless.
+- Offline probes:
+  - Injecting the assistant did not change fresh target logits (`max_abs_diff=0.0` on a direct target-logit check).
+  - Forced-all-reject drafter matched baseline, so the reject rollback path is basically sound.
+  - Forced-correct-draft all-accept matched baseline, so the simple all-accept path can be sound.
+  - The real assistant still caused divergence under the vendored generator/server path; root cause remains open.
+
+Decision:
+
+- Gemma 4 assistant-sidecar MTP is not supported or advertised.
+- Detection and dispatch fail closed for Gemma 4 MTP until a future implementation passes greedy-lossless correctness, stability, and performance validation end to end.
+
+Next validation targets:
+
+- Qwen3.5 / Qwen3.6 native MTP checkpoints with `mtp_num_hidden_layers >= 1`.
+- Confirm pre/post behavior for:
+  - greedy correctness: exact token/text equality vs baseline
+  - performance: TTFT, decode tok/s, acceptance ratio
+  - stability: repeated runs, multiple prompt classes, no mid-stream fallback corruption

--- a/tests/test_deep_nest_dos.py
+++ b/tests/test_deep_nest_dos.py
@@ -429,7 +429,10 @@ def test_d_tool_recur_parser_depth_1000_returns_invalid_request_code(monkeypatch
     err = resp.json()["error"]
     assert err["type"] == "invalid_request_error"
     assert err["code"] == "invalid_request"
-    assert "parsing the body" in err["message"]
+    assert (
+        "parsing the body" in err["message"]
+        or "JSON nesting depth exceeds" in err["message"]
+    )
     assert "Traceback" not in resp.text
 
 

--- a/tests/test_mtp_cli_wiring.py
+++ b/tests/test_mtp_cli_wiring.py
@@ -35,16 +35,14 @@ from __future__ import annotations
 # ---------------------------------------------------------------------------
 
 
-def test_detect_sidecar_promotes_gemma4_unified_with_missing_mtp_layers():
-    """Base Gemma 4 unified checkpoint (no MTP head) + sidecar → CHAIN.
+def test_detect_sidecar_does_not_promote_gemma4_unified_missing_mtp_layers():
+    """Base Gemma 4 unified checkpoint (no MTP head) + sidecar stays NONE.
 
-    The stock ``mlx-community/gemma-4-12B-it-4bit/config.json`` reports
-    ``model_type: gemma4_unified`` with no ``mtp_num_hidden_layers``
-    key. Without ``--mtp-sidecar``, detection collapses to NONE
-    (previous CHECK). With ``--mtp-sidecar``, the ~4-layer assistant
-    drafter comes from an external repo so absence of the field is
-    expected — detection MUST return CHAIN so ``--spec-decode mtp``
-    boots.
+    July 2026 A/B validation of ``mlx-community/gemma-4-12B-it-4bit`` +
+    ``google/gemma-4-12B-it-assistant`` showed greedy output divergence
+    on the server path. Until a future implementation proves lossless
+    correctness and performance end to end, sidecar mode must not
+    promote Gemma 4 into MTP eligibility.
     """
     from vllm_mlx.spec_decode.mtp import (
         MTPEligibility,
@@ -52,21 +50,18 @@ def test_detect_sidecar_promotes_gemma4_unified_with_missing_mtp_layers():
     )
 
     config = {"model_type": "gemma4_unified"}  # no mtp_num_hidden_layers
-    # Pre-PR-A shape: NONE.
     assert detect_mtp_eligibility(config) is MTPEligibility.NONE
-    # PR-A shape: sidecar promotes to CHAIN.
     assert (
-        detect_mtp_eligibility(config, has_external_sidecar=True)
-        is MTPEligibility.CHAIN
+        detect_mtp_eligibility(config, has_external_sidecar=True) is MTPEligibility.NONE
     )
 
 
-def test_detect_sidecar_promotes_gemma4_unified_with_zero_mtp_layers():
-    """Explicit ``mtp_num_hidden_layers: 0`` + sidecar → CHAIN too.
+def test_detect_sidecar_does_not_promote_gemma4_unified_zero_mtp_layers():
+    """Explicit ``mtp_num_hidden_layers: 0`` + sidecar stays NONE too.
 
     Same shape as the base 12B checkpoint after someone hand-edited
-    the config to stamp a zero on it. Sidecar-mode must still allow
-    through — the assistant weights come from the external path.
+    the config to stamp a zero on it. Sidecar-mode must still fail
+    closed for Gemma 4 until lossless validation passes.
     """
     from vllm_mlx.spec_decode.mtp import (
         MTPEligibility,
@@ -76,13 +71,12 @@ def test_detect_sidecar_promotes_gemma4_unified_with_zero_mtp_layers():
     config = {"model_type": "gemma4_unified", "mtp_num_hidden_layers": 0}
     assert detect_mtp_eligibility(config) is MTPEligibility.NONE
     assert (
-        detect_mtp_eligibility(config, has_external_sidecar=True)
-        is MTPEligibility.CHAIN
+        detect_mtp_eligibility(config, has_external_sidecar=True) is MTPEligibility.NONE
     )
 
 
 def test_detect_sidecar_no_effect_on_qwen3_5_missing_mtp():
-    """Sidecar mode is scoped to Gemma 4 unified — Qwen3.5 stays NONE.
+    """Sidecar mode does not manufacture a Qwen3.5 MTP head.
 
     Qwen3.5 / Qwen3.6 MTP is baked into the TARGET checkpoint via
     mlx-lm PR #990's sanitize() path. An operator who passes
@@ -332,18 +326,18 @@ def test_run_dispatch_mtp_inject_forwards_sidecar_path(monkeypatch):
     monkeypatch.setattr(
         _batched,
         "_resolve_hf_model_type",
-        lambda name: "gemma4_unified",
+        lambda name: "qwen3_5",
     )
 
     result = _batched._run_dispatch_mtp_inject(
         sentinel_model,
-        "mlx-community/gemma-4-12B-it-4bit",
-        "google/gemma-4-12B-it-assistant",
+        "mlx-community/Qwen3.5-4B-4bit",
+        None,
     )
     assert result == _batched._DISPATCH_ATTACHED
     assert captured["model"] is sentinel_model
-    assert captured["model_type"] == "gemma4_unified"
-    assert captured["mtp_sidecar"] == "google/gemma-4-12B-it-assistant"
+    assert captured["model_type"] == "qwen3_5"
+    assert captured["mtp_sidecar"] is None
 
 
 def test_run_dispatch_mtp_inject_returns_unresolved_when_model_type_missing(
@@ -408,14 +402,12 @@ def test_run_dispatch_mtp_inject_returns_rejected_when_injector_refuses(monkeypa
         return False  # family injector rejected
 
     monkeypatch.setattr(_mtp, "dispatch_mtp_inject", _fake_dispatch_mtp_inject)
-    monkeypatch.setattr(
-        _batched, "_resolve_hf_model_type", lambda name: "gemma4_unified"
-    )
+    monkeypatch.setattr(_batched, "_resolve_hf_model_type", lambda name: "qwen3_5")
 
     result = _batched._run_dispatch_mtp_inject(
         object(),
-        "mlx-community/gemma-4-12B-it-4bit",
-        "/nonexistent/sidecar/path",
+        "mlx-community/Qwen3.5-4B-4bit",
+        None,
     )
     assert result == _batched._DISPATCH_REJECTED, (
         "family-injector rejection MUST surface as _DISPATCH_REJECTED so "
@@ -497,12 +489,12 @@ def test_run_dispatch_mtp_inject_prefers_cli_provided_model_type(monkeypatch):
 
     result = _batched._run_dispatch_mtp_inject(
         object(),
-        "mlx-community/gemma-4-12B-it-4bit",
+        "mlx-community/Qwen3.5-4B-4bit",
         None,
-        preferred_model_type="gemma4_unified",
+        preferred_model_type="qwen3_5",
     )
     assert result == _batched._DISPATCH_ATTACHED
-    assert captured["model_type"] == "gemma4_unified"
+    assert captured["model_type"] == "qwen3_5"
     assert resolve_calls["n"] == 0, (
         "codex round-E blocker #2 regression: dispatch step re-read "
         "config.json on the executor even though the CLI already "
@@ -2678,13 +2670,13 @@ def test_apply_mtp_cli_model_type_reconciliation_promotes_eligibility_read():
 
     # Simulate the production shape: first read failed →
     # scheduler_config.mtp_model_type is None. Eligibility gate's
-    # read succeeded and returned a valid Gemma 4 config.
+    # read succeeded and returned a valid Qwen MTP config.
     sc = SchedulerConfig(
         spec_decode="mtp",
-        mtp_sidecar="/tmp/fake-sidecar",
+        mtp_sidecar=None,
         mtp_model_type=None,
     )
-    hf_cfg_eligibility = {"model_type": "gemma4_unified"}
+    hf_cfg_eligibility = {"model_type": "qwen3_5", "mtp_num_hidden_layers": 1}
 
     _apply_mtp_cli_model_type_reconciliation(
         scheduler_config=sc,
@@ -2692,7 +2684,7 @@ def test_apply_mtp_cli_model_type_reconciliation_promotes_eligibility_read():
         logger=None,
     )
 
-    assert sc.mtp_model_type == "gemma4_unified", (
+    assert sc.mtp_model_type == "qwen3_5", (
         "codex round-I BLOCKING #3 regression: the reconciliation "
         "helper did NOT promote the eligibility read's model_type "
         f"into SchedulerConfig.mtp_model_type (got {sc.mtp_model_type!r}). "
@@ -2753,14 +2745,14 @@ def test_apply_mtp_cli_model_type_reconciliation_prefers_eligibility_on_disagree
     from vllm_mlx.scheduler import SchedulerConfig
 
     sc = SchedulerConfig(spec_decode="mtp", mtp_model_type="stale_value")
-    hf_cfg_eligibility = {"model_type": "gemma4_unified"}
+    hf_cfg_eligibility = {"model_type": "qwen3_5", "mtp_num_hidden_layers": 1}
 
     _apply_mtp_cli_model_type_reconciliation(
         scheduler_config=sc,
         hf_cfg_eligibility=hf_cfg_eligibility,
         logger=None,
     )
-    assert sc.mtp_model_type == "gemma4_unified", (
+    assert sc.mtp_model_type == "qwen3_5", (
         "reconciliation helper did NOT prefer the eligibility read "
         f"on disagreement (kept {sc.mtp_model_type!r}). This regresses "
         "the round-I contract: on skew, the eligibility gate's read "

--- a/tests/test_mtp_gemma4_assistant_inject.py
+++ b/tests/test_mtp_gemma4_assistant_inject.py
@@ -561,22 +561,19 @@ def test_make_mtp_cache_slots_are_generator_safe():
 # ---------------------------------------------------------------------------
 
 
-def test_dispatcher_routes_gemma4_families_to_this_module():
-    """``gemma4`` / ``gemma4_unified`` / ``gemma4_text`` / ``gemma4_unified_text``
-    all route to ``gemma4_inject``.
+def test_dispatcher_does_not_route_gemma4_families_to_this_module():
+    """Gemma 4 assistant-sidecar MTP stays unregistered until lossless.
+
+    The injector module remains unit-tested directly in this file, but
+    dispatcher registration is the supported runtime surface. July 2026
+    server A/B found greedy output divergence, so the dispatcher must not
+    expose Gemma 4 MTP yet.
     """
     from vllm_mlx.spec_decode.mtp import dispatch as _dispatch
 
     for mt in ("gemma4", "gemma4_unified", "gemma4_text", "gemma4_unified_text"):
-        assert mt in _dispatch._MTP_INJECT_DISPATCH, (
-            f"{mt!r} missing from inject dispatch"
-        )
-        module_path, _ = _dispatch._MTP_INJECT_DISPATCH[mt]
-        assert module_path == "vllm_mlx.spec_decode.mtp.gemma4_inject"
-
-        assert mt in _dispatch._MTP_VALIDATE_DISPATCH
-        v_path, _ = _dispatch._MTP_VALIDATE_DISPATCH[mt]
-        assert v_path == "vllm_mlx.spec_decode.mtp.gemma4_inject"
+        assert mt not in _dispatch._MTP_INJECT_DISPATCH
+        assert mt not in _dispatch._MTP_VALIDATE_DISPATCH
 
 
 def test_dispatcher_still_routes_qwen3_5():
@@ -607,16 +604,16 @@ def test_dispatcher_swallows_family_exceptions(monkeypatch):
     Codex round-3 blocker: unwrapped ``fn(...)`` calls could propagate.
     """
     from vllm_mlx.spec_decode.mtp import dispatch as _dispatch
-    from vllm_mlx.spec_decode.mtp import gemma4_inject
+    from vllm_mlx.spec_decode.mtp import qwen3_5_inject
 
     def _raising_inject(model, mtp_sidecar=None, *, allow_random_init=False):
-        raise RuntimeError("simulated loader crash inside gemma4_inject")
+        raise RuntimeError("simulated loader crash inside qwen3_5_inject")
 
-    monkeypatch.setattr(gemma4_inject, "inject_mtp_support", _raising_inject)
+    monkeypatch.setattr(qwen3_5_inject, "inject_mtp_support", _raising_inject)
 
     result = _dispatch.dispatch_mtp_inject(
         object(),
-        model_type="gemma4_unified",
+        model_type="qwen3_5",
         allow_random_init=True,
     )
     assert result is False, "dispatcher must convert family exceptions to False"
@@ -625,14 +622,14 @@ def test_dispatcher_swallows_family_exceptions(monkeypatch):
 def test_dispatcher_validate_swallows_family_exceptions(monkeypatch):
     """Same as above but for ``dispatch_mtp_validate``."""
     from vllm_mlx.spec_decode.mtp import dispatch as _dispatch
-    from vllm_mlx.spec_decode.mtp import gemma4_inject
+    from vllm_mlx.spec_decode.mtp import qwen3_5_inject
 
     def _raising_validate(model):
         raise RuntimeError("simulated validator crash")
 
-    monkeypatch.setattr(gemma4_inject, "validate_mtp_support", _raising_validate)
+    monkeypatch.setattr(qwen3_5_inject, "validate_mtp_support", _raising_validate)
 
-    result = _dispatch.dispatch_mtp_validate(object(), model_type="gemma4_unified")
+    result = _dispatch.dispatch_mtp_validate(object(), model_type="qwen3_5")
     assert result is False
 
 
@@ -684,11 +681,11 @@ def test_gemma4_text_modelargs_carries_fields_this_module_reads():
     )
 
 
-def test_dispatcher_routes_gemma4_unified_to_gemma4_inject(monkeypatch):
-    """The dispatcher forwards ``model`` + kwargs verbatim to gemma4_inject.
+def test_dispatcher_does_not_call_gemma4_inject(monkeypatch):
+    """A Gemma 4 dispatch request fails closed without calling the injector.
 
-    Guards against silent argument drops (e.g. dropping ``mtp_sidecar``
-    would let a production caller silently random-init a drafter).
+    This is the runtime guard that prevents an explicit sidecar flag from
+    reaching the unvalidated assistant path.
     """
     from vllm_mlx.spec_decode.mtp import dispatch as _dispatch
     from vllm_mlx.spec_decode.mtp import gemma4_inject
@@ -716,11 +713,8 @@ def test_dispatcher_routes_gemma4_unified_to_gemma4_inject(monkeypatch):
         mtp_sidecar=sentinel_sidecar,
         allow_random_init=False,
     )
-    assert result is True
-    assert len(calls) == 1
-    assert calls[0]["model"] is sentinel_model
-    assert calls[0]["mtp_sidecar"] == sentinel_sidecar
-    assert calls[0]["allow_random_init"] is False
+    assert result is False
+    assert calls == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_mtp_spec_decode.py
+++ b/tests/test_mtp_spec_decode.py
@@ -182,19 +182,14 @@ def test_detect_eligibility_qwen3_5_stripped_checkpoint():
 
 
 # ---------------------------------------------------------------------------
-# 1b. Gemma 4 detection (community fp16-mtp sidecar path)
+# 1b. Gemma 4 detection (assistant sidecar path currently disabled)
 # ---------------------------------------------------------------------------
 # Gemma 4 ships in two ``model_type`` flavours (verified against the
 # cached mlx-community configs on 2026-07-01):
 #
 #   * ``gemma4_unified`` — text-only variant. ``Gemma4UnifiedForConditional
 #     Generation``. Used by the 12B dense checkpoints
-#     (``gemma-4-12B-it-4bit`` / ``gemma-4-12B-it-8bit``), which is the
-#     target of the Mia-AiLab fp16-mtp sidecar (``Mia-AiLab/Gemmable-4-12B
-#     -MTP-GGUF``) AND Google's ``google/gemma-4-12b-it-assistant``
-#     drafter. This is the ONLY Gemma 4 lineage on the detect allowlist
-#     right now — see the comment on ``_SUPPORTED_MODEL_TYPES`` for
-#     rationale.
+#     (``gemma-4-12B-it-4bit`` / ``gemma-4-12B-it-8bit``).
 #   * ``gemma4`` — multimodal variant. ``Gemma4ForConditionalGeneration``.
 #     Covers the effective-MoE ``gemma-4-26b-a4b-it-4bit`` and the small
 #     vision-tower e2b / e4b checkpoints. INTENTIONALLY OFF the
@@ -204,20 +199,19 @@ def test_detect_eligibility_qwen3_5_stripped_checkpoint():
 #     doesn't slip into an un-exercised inject path.
 #
 # Base checkpoints do NOT carry ``mtp_num_hidden_layers`` in their
-# ``config.json`` (verified for all four cache probes) — the sidecar
-# layers it on. We therefore test both the CHAIN path (unified, sidecar
-# applied, mtp=1) and the NONE path (unified, sidecar absent, mtp
-# missing/0), plus the explicit NONE contract for multimodal ``gemma4``
-# regardless of mtp value.
+# ``config.json`` (verified for all four cache probes). July 2026 A/B
+# validation found greedy output divergence for the Google 12B assistant
+# sidecar, so all Gemma 4 model_types must stay NONE regardless of
+# ``mtp_num_hidden_layers`` until a future implementation proves lossless.
 
 
-def test_detect_eligibility_gemma4_dense_unified_chain():
-    """Gemma 4 12B dense (``gemma4_unified``) with sidecar applied → CHAIN.
+def test_detect_eligibility_gemma4_dense_unified_stays_none_even_with_mtp_layers():
+    """Gemma 4 12B dense (``gemma4_unified``) stays NONE.
 
-    This is the Mia-AiLab primary target: ``gemma-4-12B-it-*`` reports
-    ``model_type: gemma4_unified`` at the top of ``config.json``. Once
-    the sidecar sets ``mtp_num_hidden_layers=1``, detection MUST return
-    CHAIN so ``--spec-decode mtp`` boots.
+    A hand-edited config or sidecar-derived config may stamp
+    ``mtp_num_hidden_layers=1``, but Gemma 4 MTP is not considered
+    supported until the assistant-sidecar path passes greedy-lossless
+    server A/B validation.
     """
     from vllm_mlx.spec_decode.mtp import (
         MTPEligibility,
@@ -225,7 +219,7 @@ def test_detect_eligibility_gemma4_dense_unified_chain():
     )
 
     config = {"model_type": "gemma4_unified", "mtp_num_hidden_layers": 1}
-    assert detect_mtp_eligibility(config) is MTPEligibility.CHAIN
+    assert detect_mtp_eligibility(config) is MTPEligibility.NONE
 
 
 def test_detect_eligibility_gemma4_dense_unified_stripped_none():
@@ -233,9 +227,7 @@ def test_detect_eligibility_gemma4_dense_unified_stripped_none():
 
     Base ``mlx-community/gemma-4-12b-it-4bit`` ships without an MTP
     head; ``mtp_num_hidden_layers`` is either absent or 0. Detection
-    must collapse to NONE so ``--spec-decode mtp`` is rejected at boot
-    with a clear ``sidecar missing`` hint rather than silently emitting
-    random-init draft tokens.
+    must collapse to NONE so ``--spec-decode mtp`` is rejected at boot.
     """
     from vllm_mlx.spec_decode.mtp import (
         MTPEligibility,

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -2804,10 +2804,9 @@ def serve_command(args):
         # Qwen3.5/3.6 model + a bound DFlash drafter.
         spec_decode=getattr(args, "spec_decode", "none"),
         dflash_drafter_path=getattr(args, "dflash_drafter_path", "") or "",
-        # 0.9.13 PR-A: Gemma 4 external MTP sidecar path (see
-        # ``SchedulerConfig.mtp_sidecar`` for the routing contract).
-        # ``None`` is the "no sidecar; native-MTP path only" sentinel
-        # matching the argparse default.
+        # Future external MTP sidecar path (currently reserved; Gemma 4
+        # assistant-sidecar MTP is disabled after lossless A/B failed).
+        # ``None`` is the "no sidecar; native-MTP path only" sentinel.
         mtp_sidecar=getattr(args, "mtp_sidecar", None),
         # 0.9.13 PR-A codex round-E blocker #2: CLI-resolved
         # ``config.json::model_type`` for the dispatch step. See the
@@ -2872,12 +2871,10 @@ def serve_command(args):
     # clear error rather than discovering the mismatch when the first
     # backbone forward pass raises ``AttributeError`` mid-generation.
     #
-    # 0.9.13 PR-A: when ``--mtp-sidecar <path>`` is set, the operator
-    # is opting into the Gemma 4 external assistant-drafter route.
-    # ``detect_mtp_eligibility`` then permits a base Gemma 4 unified
-    # checkpoint (which has no baked-in MTP head — the sidecar carries
-    # the assistant weights) through as CHAIN. Qwen3.5/3.6 still needs
-    # ``mtp_num_hidden_layers >= 1`` on the base config either way.
+    # ``--mtp-sidecar <path>`` is currently a reserved compatibility
+    # surface for future assistant sidecars. It does not promote any
+    # model into eligibility; Qwen3.5/3.6 still needs
+    # ``mtp_num_hidden_layers >= 1`` on the base config.
     if getattr(args, "spec_decode", "none") == "mtp":
         from vllm_mlx.spec_decode.mtp import (
             MTPEligibility,
@@ -2898,21 +2895,18 @@ def serve_command(args):
         if eligibility is MTPEligibility.NONE:
             if has_sidecar:
                 print(
-                    "error: --spec-decode mtp --mtp-sidecar <path> requires a "
-                    "Gemma 4 unified checkpoint (model_type='gemma4_unified') "
-                    "or a Qwen3.5 / Qwen3.6 checkpoint with "
-                    "mtp_num_hidden_layers >= 1. The loaded model does not "
-                    "qualify.",
+                    "error: --spec-decode mtp currently requires a Qwen3.5 / "
+                    "Qwen3.6 checkpoint with mtp_num_hidden_layers >= 1 in "
+                    "config.json. --mtp-sidecar is reserved for future "
+                    "validated assistant sidecars and does not make this "
+                    "model eligible.",
                     file=sys.stderr,
                 )
             else:
                 print(
                     "error: --spec-decode mtp requires a Qwen3.5 / Qwen3.6 "
-                    "checkpoint with mtp_num_hidden_layers >= 1 in "
-                    "config.json, or a Gemma 4 unified checkpoint paired "
-                    "with --mtp-sidecar <path> (see "
-                    "google/gemma-4-*-it-assistant on HF). The loaded "
-                    "model does not qualify.",
+                    "checkpoint with mtp_num_hidden_layers >= 1 in config.json. "
+                    "The loaded model does not qualify.",
                     file=sys.stderr,
                 )
             sys.exit(2)
@@ -6846,27 +6840,23 @@ Examples:
             "qualify so misuse fails loud."
         ),
     )
-    # 0.9.13 PR-A: external MTP sidecar for the Gemma 4 assistant-drafter
-    # route. Combined with ``--spec-decode mtp``, allows a base Gemma 4
-    # unified checkpoint (which never ships an MTP head of its own) to
-    # graft on the ~4-layer assistant drafter from
-    # ``google/gemma-4-*-it-assistant`` (Apache 2.0). Not used by the
-    # Qwen3.5/3.6 native-MTP path — that lineage's MTP head is baked
-    # into the target checkpoint via mlx-lm PR #990's sanitize() pass,
-    # so ``--mtp-sidecar`` has no effect there.
+    # Compatibility surface for future external MTP assistant sidecars.
+    # Gemma 4 assistant-sidecar MTP is currently disabled after July 2026
+    # greedy-lossless A/B failed; Qwen3.5/3.6 native MTP does not use a
+    # sidecar because its head is baked into the target checkpoint via
+    # mlx-lm PR #990's sanitize() pass.
     serve_parser.add_argument(
         "--mtp-sidecar",
         dest="mtp_sidecar",
         default=None,
         help=(
-            "Path to a Gemma 4 MTP assistant-drafter checkpoint — either a "
-            "local safetensors directory (e.g. ~/.cache/huggingface/hub/"
-            "gemma-4-12B-it-assistant) or an HF repo id "
-            "(e.g. google/gemma-4-12B-it-assistant). Prefer "
+            "Reserved path/repo id for future validated MTP assistant "
+            "sidecars. Prefer "
             '--speculative-config \'{"method":"mtp","model":...}\' '
-            "for new usage. Only consulted when MTP spec-decode is set; "
-            "ignored for the Qwen3.5/3.6 "
-            "native-MTP path (their head is baked into the target). "
+            "for new usage. Gemma 4 assistant-sidecar MTP is currently "
+            "disabled after greedy-lossless validation failed; ignored for "
+            "the Qwen3.5/3.6 native-MTP path because their head is baked "
+            "into the target. "
             "Requires the [mtp] install extra."
         ),
     )

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -341,10 +341,10 @@ def _decide_mtp_dispatch_action(
             "raise",
             "--spec-decode mtp was set but the family MTP "
             "injector rejected the model. See preceding "
-            "warnings for the specific failure (typical "
-            "causes: missing --mtp-sidecar for a Gemma 4 "
-            "target, sidecar path unreachable, or assistant "
-            "checkpoint model_type mismatch). Refusing to "
+            "warnings for the specific failure (typical causes: "
+            "MTP weights missing from the target checkpoint, "
+            "unsupported model_type, sidecar path unreachable, or "
+            "assistant checkpoint model_type mismatch). Refusing to "
             "boot with MTP silently disabled — pass "
             "--spec-decode none to continue without MTP.",
         )

--- a/vllm_mlx/spec_decode/mtp/detect.py
+++ b/vllm_mlx/spec_decode/mtp/detect.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Qwen3.5 / Qwen3.6 / Gemma 4 MTP architecture detection (R15 task #302).
+"""Qwen3.5 / Qwen3.6 MTP architecture detection (R15 task #302).
 
 Detection lives off the loaded ``config.json`` dict rather than the
 ``aliases.json`` schema. Reasons:
@@ -12,9 +12,7 @@ Detection lives off the loaded ``config.json`` dict rather than the
 * The ``mtp_num_hidden_layers`` value is an intrinsic property of the
   checkpoint, not of the alias. A user passing a raw HF path like
   ``Qwen/Qwen3.5-27B`` should still get MTP eligibility without us
-  having to ship an alias for every Qwen3.5 / Qwen3.6 quant. The same
-  reasoning applies to Gemma 4 checkpoints that carry an MTP sidecar
-  (community fp16-mtp variant from ``Mia-AiLab/Gemmable-4-12B-MTP-GGUF``).
+  having to ship an alias for every Qwen3.5 / Qwen3.6 quant.
 * ``model_type`` is already populated on every HF config and is the
   canonical anchor mlx-lm itself uses to route to a model class — we
   just piggyback on it.
@@ -22,9 +20,8 @@ Detection lives off the loaded ``config.json`` dict rather than the
 Eligibility is binary right now (``CHAIN`` or ``NONE``). A future
 ``TREE`` variant would land here once upstream ships a
 ``mtp_num_hidden_layers >= 2`` checkpoint, but as of vendoring date
-every released Qwen3.5 / Qwen3.6 checkpoint (and the Mia-AiLab
-Gemma 4 fp16-mtp sidecar) ships ``mtp_num_hidden_layers: 1`` — chain
-MTP only.
+every released Qwen3.5 / Qwen3.6 checkpoint ships
+``mtp_num_hidden_layers: 1`` — chain MTP only.
 """
 
 from __future__ import annotations
@@ -39,15 +36,12 @@ class MTPEligibility(str, enum.Enum):
 
     ``NONE`` — model architecture does not have an MTP head, or the
     config explicitly sets ``mtp_num_hidden_layers: 0`` (Qwen3.5 / 3.6
-    checkpoints that have been re-converted with MTP stripped, or a
-    stock Gemma 4 checkpoint without the Mia-AiLab fp16-mtp sidecar
-    layered on). The CLI must reject ``--spec-decode mtp`` in this
-    case.
+    checkpoints that have been re-converted with MTP stripped). The CLI
+    must reject ``--spec-decode mtp`` in this case.
 
     ``CHAIN`` — model has a single MTP layer (``mtp_num_hidden_layers
     == 1``). One draft token per backbone step. This is what every
-    upstream Qwen3.5 / Qwen3.6 release ships today, and it is also the
-    layout of the Mia-AiLab Gemma 4 fp16-mtp sidecar.
+    upstream Qwen3.5 / Qwen3.6 release ships today.
 
     ``TREE`` — reserved for ``mtp_num_hidden_layers >= 2``. Not in use
     yet; emits a runtime warning and is treated as ``CHAIN`` until the
@@ -62,44 +56,22 @@ class MTPEligibility(str, enum.Enum):
 # Architectures (``config.json::model_type``) whose model class ships an
 # MTP head that this engine knows how to drive.
 #
-# Two source families right now:
+# Upstream mlx-lm PR #990 Qwen3.5 / Qwen3.6:
+# - ``qwen3_5``     — dense (also the canonical model_type for the dense
+#                     Qwen3.6 release).
+# - ``qwen3_5_moe`` — MoE variant; subclasses the dense model and routes
+#                     through the same MTP path.
 #
-# 1. Upstream mlx-lm PR #990 (Qwen3.5 / Qwen3.6):
-#    - ``qwen3_5``     — dense (also the canonical model_type for the
-#                        dense Qwen3.6 release).
-#    - ``qwen3_5_moe`` — MoE variant; subclasses the dense model and
-#                        routes through the same MTP path.
-#
-# 2. Community fp16-mtp sidecar for Gemma 4 (source:
-#    ``Mia-AiLab/Gemmable-4-12B-MTP-GGUF`` — ~98 k downloads at time
-#    of writing; NOT part of upstream PR #990):
-#    - ``gemma4_unified`` — text-only unified variant
-#                            (``Gemma4UnifiedForConditional
-#                            Generation``). The 12B dense checkpoints
-#                            (``gemma-4-12B-it-4bit`` /
-#                            ``gemma-4-12B-it-8bit``) ship as unified.
-#
-# The Mia-AiLab sidecar targets 12B unified only today, and the
-# assistant-drafter path in ``gemma4_inject`` has only been verified
-# against the unified 12B target. The multimodal ``gemma4`` model_type
-# (``Gemma4ForConditionalGeneration`` — 26B-A4B / e2b / e4b lineages)
-# is INTENTIONALLY NOT on this allowlist: even though the dispatcher
-# in ``spec_decode/mtp/dispatch.py`` maps it to ``gemma4_inject``,
-# there is no verified sidecar or drafter for that lineage today and
-# advertising ``--spec-decode mtp`` eligibility for a hand-edited
-# multimodal config would let it slip past pre-boot gating into an
-# inject/generator/cache path that hasn't been exercised for that
-# architecture. Add ``gemma4`` here (and ``gemma4_text``) once a
-# multimodal-verified sidecar or assistant drafter lands.
+# Gemma 4 assistant-sidecar MTP is intentionally not advertised here. July
+# 2026 A/B validation against ``mlx-community/gemma-4-12B-it-4bit`` +
+# ``google/gemma-4-12B-it-assistant`` showed greedy output divergence under
+# the server path. Keep Gemma closed until an end-to-end lossless + perf
+# validation proves otherwise.
 _SUPPORTED_MODEL_TYPES: frozenset[str] = frozenset(
     {
         # Qwen3.5 / Qwen3.6 (upstream PR #990)
         "qwen3_5",
         "qwen3_5_moe",
-        # Gemma 4 12B unified (community sidecar —
-        # Mia-AiLab/Gemmable-4-12B-MTP-GGUF — and Google's
-        # ``google/gemma-4-12b-it-assistant`` drafter).
-        "gemma4_unified",
     }
 )
 
@@ -148,22 +120,13 @@ def detect_mtp_eligibility(
             non-dict) returns ``MTPEligibility.NONE`` — used by the CLI
             so callers can pass ``model_auto_config.get_config(path)``
             output unguarded.
-        has_external_sidecar: Set by the CLI when the operator has
-            passed ``--mtp-sidecar <path>``. When ``True``, a Gemma 4
-            unified base checkpoint (which never ships MTP weights of
-            its own — ``mtp_num_hidden_layers`` is absent / 0 in the
-            stock ``config.json``) is allowed through as
-            :attr:`MTPEligibility.CHAIN`. The external sidecar carries
-            the ~4-layer assistant-drafter weights that the
-            :func:`~vllm_mlx.spec_decode.mtp.dispatch.dispatch_mtp_inject`
-            call site will load onto the target model. Only applies to
-            ``model_type == "gemma4_unified"``; Qwen3.5 / Qwen3.6
-            eligibility still requires ``mtp_num_hidden_layers >= 1``
-            in the base config because their MTP head is a compile-
-            time part of the target checkpoint, not an external
-            sidecar. Default ``False`` preserves the pre-0.9.13
-            reject-on-``mtp_num_hidden_layers == 0`` contract for
-            every non-sidecar caller.
+        has_external_sidecar: Accepted for compatibility with the
+            legacy CLI flag surface, but currently does not promote any
+            architecture. Qwen3.5 / Qwen3.6 eligibility requires
+            ``mtp_num_hidden_layers >= 1`` in the base config because
+            their MTP head is part of the target checkpoint. Gemma 4
+            sidecar promotion is disabled until it passes end-to-end
+            greedy-lossless validation.
 
     Returns:
         :class:`MTPEligibility` value. Detection is conservative — any
@@ -205,39 +168,14 @@ def _detect_mtp_eligibility_verbose(
             f"model_type {model_type!r} not in MTP allowlist",
         )
 
+    _ = has_external_sidecar
     num_mtp_layers = _safe_int(config.get("mtp_num_hidden_layers"), 0)
     if num_mtp_layers <= 0:
-        # External-sidecar path (Gemma 4 unified only): the operator
-        # has passed ``--mtp-sidecar <path>`` at the CLI, meaning the
-        # ~4-layer assistant-drafter weights live in an external repo
-        # and the ``dispatch_mtp_inject`` call site will graft them
-        # onto the target at boot. The stock base checkpoint carries
-        # no MTP head — ``mtp_num_hidden_layers`` is absent / 0 — but
-        # that is expected and MUST NOT reject.
-        #
-        # Scoped to ``gemma4_unified`` because it is the only lineage
-        # with a verified external assistant-drafter path today
-        # (``google/gemma-4-*-it-assistant``, Apache 2.0). Qwen3.5 /
-        # Qwen3.6 MTP is baked into the target checkpoint (mlx-lm
-        # PR #990 sanitize path) — an operator who passes
-        # ``--mtp-sidecar`` against a stripped Qwen3.5 config would
-        # still need to re-convert from HF, so we keep the reject.
-        if has_external_sidecar and model_type == "gemma4_unified":
-            return _DetectionResult(
-                MTPEligibility.CHAIN,
-                model_type,
-                num_mtp_layers,
-                "external sidecar supplies MTP weights (chain mode)",
-            )
         # MTP-capable model_type but MTP weights not present on this
         # checkpoint. For Qwen3.5 / Qwen3.6 this is a stripped convert —
         # operator must re-convert from HF with the PR #990 sanitize()
-        # path that preserves ``mtp.*`` weights. For Gemma 4 this is
-        # the default: the base checkpoint has no MTP head; operator
-        # must layer on the Mia-AiLab fp16-mtp sidecar. Either way,
-        # detection collapses to NONE so ``--spec-decode mtp`` is
-        # rejected loudly at boot. See task report for the conversion
-        # / sidecar SOP.
+        # path that preserves ``mtp.*`` weights. Detection collapses to
+        # NONE so ``--spec-decode mtp`` is rejected loudly at boot.
         return _DetectionResult(
             MTPEligibility.NONE,
             model_type,

--- a/vllm_mlx/spec_decode/mtp/dispatch.py
+++ b/vllm_mlx/spec_decode/mtp/dispatch.py
@@ -3,14 +3,10 @@
 
 Historically, callers of the vendored MTP path
 (:mod:`vllm_mlx.spec_decode.mtp`) reached directly into
-:mod:`vllm_mlx.spec_decode.mtp.qwen3_5_inject`. Growing the allowlist
-to ``gemma4`` / ``gemma4_unified`` (paired with Google's official
-``google/gemma-4-*-it-assistant`` drafter checkpoints, Apache 2.0)
-means callers now need to pick the correct family-specific inject at
-runtime. The Gemma 4 drafter is a 4-layer transformer that reuses
-target K/V, structurally different from the Qwen3.5 MTP head. Instead
-of a giant ``if model_type in {...}`` inside a hot module, we keep the
-family implementations as separate modules and land the routing here.
+:mod:`vllm_mlx.spec_decode.mtp.qwen3_5_inject`. This dispatcher keeps
+family implementations behind a small registry so new architectures can
+be added only after they pass end-to-end lossless + performance
+validation.
 
 This module is intentionally the smallest possible dispatcher — no
 config mutation, no monkey-patching. It resolves the family, forwards
@@ -55,29 +51,6 @@ _MTP_INJECT_DISPATCH: dict[str, tuple[str, str]] = {
         "vllm_mlx.spec_decode.mtp.qwen3_5_inject",
         "inject_mtp_support",
     ),
-    # Gemma 4 — paired with Google's official
-    # ``google/gemma-4-*-it-assistant`` drafter checkpoints. Both the
-    # outer wrapper model_types (``gemma4`` / ``gemma4_unified``) and
-    # the inner text model_types (``gemma4_text`` /
-    # ``gemma4_unified_text``) route to the same ``gemma4_inject``
-    # module so callers that resolve model_type on the inner
-    # ``language_model.args`` still land correctly.
-    "gemma4": (
-        "vllm_mlx.spec_decode.mtp.gemma4_inject",
-        "inject_mtp_support",
-    ),
-    "gemma4_unified": (
-        "vllm_mlx.spec_decode.mtp.gemma4_inject",
-        "inject_mtp_support",
-    ),
-    "gemma4_text": (
-        "vllm_mlx.spec_decode.mtp.gemma4_inject",
-        "inject_mtp_support",
-    ),
-    "gemma4_unified_text": (
-        "vllm_mlx.spec_decode.mtp.gemma4_inject",
-        "inject_mtp_support",
-    ),
 }
 
 
@@ -91,22 +64,6 @@ _MTP_VALIDATE_DISPATCH: dict[str, tuple[str, str]] = {
     ),
     "qwen3_5_moe": (
         "vllm_mlx.spec_decode.mtp.qwen3_5_inject",
-        "validate_mtp_support",
-    ),
-    "gemma4": (
-        "vllm_mlx.spec_decode.mtp.gemma4_inject",
-        "validate_mtp_support",
-    ),
-    "gemma4_unified": (
-        "vllm_mlx.spec_decode.mtp.gemma4_inject",
-        "validate_mtp_support",
-    ),
-    "gemma4_text": (
-        "vllm_mlx.spec_decode.mtp.gemma4_inject",
-        "validate_mtp_support",
-    ),
-    "gemma4_unified_text": (
-        "vllm_mlx.spec_decode.mtp.gemma4_inject",
         "validate_mtp_support",
     ),
 }


### PR DESCRIPTION
## Summary
- fail closed for Gemma 4 assistant-sidecar MTP after greedy A/B showed output divergence
- remove Gemma4 MTP sidecar examples from docs/help and keep sidecar config reserved for future validated assistants
- keep Qwen3.5/Qwen3.6 native MTP detection/dispatch intact
- record local spec-decoding validation notes in specdecoding.md
- relax one deep JSON parser test assertion to accept the current invalid_request wording seen in full_unit, without changing runtime behavior

## Validation
- Gemma4 HTTP A/B, temp=0, --disable-prefix-cache: MTP diverged on 3/4 prompts despite accept ratio ~0.696, so this PR gates it off
- CLI smoke: Gemma4 + google/gemma-4-12B-it-assistant exits 2 before model load with reserved-sidecar message
- pytest tests/test_deep_nest_dos.py::test_d_tool_recur_parser_depth_1000_returns_invalid_request_code tests/test_mtp_gemma4_assistant_inject.py tests/test_mtp_cli_wiring.py tests/test_mtp_spec_decode.py tests/test_speculative_config.py -q (191 passed)
- ruff check tests/test_deep_nest_dos.py tests/test_mtp_gemma4_assistant_inject.py tests/test_mtp_cli_wiring.py tests/test_mtp_spec_decode.py vllm_mlx/cli.py vllm_mlx/engine/batched.py vllm_mlx/spec_decode/mtp/detect.py vllm_mlx/spec_decode/mtp/dispatch.py
- ruff format --check tests/test_deep_nest_dos.py tests/test_mtp_gemma4_assistant_inject.py tests/test_mtp_cli_wiring.py tests/test_mtp_spec_decode.py vllm_mlx/cli.py vllm_mlx/engine/batched.py vllm_mlx/spec_decode/mtp/detect.py vllm_mlx/spec_decode/mtp/dispatch.py
- python -m compileall -q vllm_mlx tests/test_deep_nest_dos.py tests/test_mtp_gemma4_assistant_inject.py tests/test_mtp_cli_wiring.py tests/test_mtp_spec_decode.py
- git diff --check

skip-version-bump
