### PR TITLE
revert: gate MTP speculative-config exposure

### DIFF
--- a/README.md
+++ b/README.md
@@ -757,7 +757,7 @@ Qwen3.5 uses Gated DeltaNet (75% RNN) + full attention (25% KV). Other engines r
 | **KV cache quantization** | Quantize prefix cache entries to reduce memory | All models with `--kv-cache-quantization` |
 | **DFlash speculative decoding** | Block-diffusion drafter, parallel draft + verify (single-user) | `qwen3.5-27b-8bit`, `qwen3.6-27b-8bit` with `--speculative-config '{"method":"dflash"}'` |
 | **DDTree speculative decoding** | DFlash draft-tree verification over multiple branches | `qwen3.5-9b-8bit` (experimental, single-user) |
-| **MTP speculative decoding** | Multi-token prediction head shipped with the model | MTP-trained checkpoints with `--speculative-config '{"method":"mtp"}'` |
+| **MTP speculative decoding** | Multi-token prediction head shipped with the model | MTP-trained checkpoints with legacy `--spec-decode mtp` |
 | **SuffixDecoding** | Drafter-free, statistical n-gram lookup speculative decoding | All BatchedEngine models with `--suffix-decoding` |
 | **Prefill chunking** | Configurable step size for large-prompt throughput | All models |
 | **Cloud routing** | Offload high-token requests to cloud LLM when local is slow | All models with `--cloud-model` |
@@ -797,7 +797,7 @@ Run your own: `bash evals/run_all_models.sh` runs the full quality suite (tool c
 | **TurboQuant K8V4 KV codec** | K is 8-bit + V is 4-bit after Walsh-Hadamard rotation + Lloyd-Max quantization — compresses KV to ~1/2.4 (~58% savings), lossless across the verified matrix. **Default-on for 9 verified Qwen3.5/3.6 aliases** (see below); `--kv-cache-turboquant none` to force off. |
 | **Smart cloud routing** | Large-context requests auto-route to a cloud LLM (`--cloud-model openai/gpt-5 --cloud-threshold 20000`) when local prefill would be slow. |
 | **Multimodal** | Vision, audio (STT/TTS with bundled Silero VAD silence pre-trim), video understanding, text embeddings — all through the standard OpenAI endpoints. |
-| **Speculative decoding** | DFlash (block-diffusion drafter, vLLM-style `--speculative-config '{"method":"dflash"}'`), DDTree (DFlash draft tree, `--speculative-config '{"method":"ddtree"}'`), MTP (multi-token prediction head, `--speculative-config '{"method":"mtp"}'`), SuffixDecoding (drafter-free n-gram, `--suffix-decoding`). Opt-in per alias — see below. |
+| **Speculative decoding** | DFlash (block-diffusion drafter, vLLM-style `--speculative-config '{"method":"dflash"}'`), DDTree (DFlash draft tree, `--speculative-config '{"method":"ddtree"}'`), MTP (multi-token prediction head, legacy `--spec-decode mtp`), SuffixDecoding (drafter-free n-gram, `--suffix-decoding`). Opt-in per alias — see below. |
 | **Structured output, logprobs, continuous batching, KV quantization** | Standard, no flags or with one flag each. |
 | **3300+ tests** | Across reasoning, tool parsing, streaming, agent harnesses, and engine integration. |
 
@@ -823,16 +823,9 @@ rapid-mlx serve qwen3.5-27b-8bit --speculative-config '{"method":"dflash"}'
 
 Workload sensitivity: coding / math / summarization typically see **1.5–2.7×**; high-entropy creative writing and long-form chat can dip to **0.6–0.9×** because the drafter's training distribution diverges from open-ended generation — a known spec-decode literature pattern ([AdaEDL](https://arxiv.org/abs/2410.18351)), not a bug. DFlash mode runs a dedicated single-user server (no batched kernel yet); tool calling, MCP, and embeddings aren't available in that mode — restart without DFlash for those.
 
-**MTP** (Multi-Token Prediction) — draft head baked into the model. Opt in with `--speculative-config '{"method":"mtp"}'` on MTP-trained checkpoints. `num_speculative_tokens` maps to the existing MTP max-K controller ceiling; `disable_auto_k` pins the fixed-K=1 bench path. Gemma 4 assistant-sidecar MTP is not advertised because July 2026 A/B validation found greedy output divergence; it remains disabled until a lossless implementation lands.
+**MTP** (Multi-Token Prediction) — draft head baked into the model. It remains on the legacy `--spec-decode mtp` surface until real-model A/B parity is revalidated for the shared `--speculative-config` interface. Gemma 4 assistant-sidecar MTP is not advertised because July 2026 A/B validation found greedy output divergence; it remains disabled until a lossless implementation lands.
 
-For fixed-K parity benches:
-
-```bash
-rapid-mlx serve qwen3.6-27b-mtp-4bit \
-  --speculative-config '{"method":"mtp","num_speculative_tokens":1,"disable_auto_k":true}'
-```
-
-**SuffixDecoding** — drafter-free, statistical n-gram lookup over the running suffix. Opt in explicitly with `--speculative-config '{"method":"suffix","num_speculative_tokens":8}'` only for high-overlap workloads; `--suffix-decoding` remains as a compatibility shorthand.
+**SuffixDecoding** — drafter-free, statistical n-gram lookup over the running suffix. Opt in with `--suffix-decoding`; works on any BatchedEngine alias.
 
 **DDTree** (experimental) — builds a tree from one DFlash draft pass, then verifies multiple likely continuations. The first rapid-mlx integration is intentionally opt-in and single-user, using the external `dtree-mlx` runtime:
 
@@ -849,7 +842,7 @@ rapid-mlx serve qwen3.5-9b-8bit \
   --speculative-config '{"method":"ddtree","model":"z-lab/Qwen3.5-9B-DFlash","num_speculative_tokens":16,"tree_budget":24}'
 ```
 
-`--enable-dflash` remains as a compatibility shorthand for `--speculative-config '{"method":"dflash"}'`, and `--dflash-drafter-path` maps to the config `model` field. `--enable-ddtree` similarly remains as a compatibility shorthand for `--speculative-config '{"method":"ddtree"}'`. `--spec-decode mtp` remains as a compatibility shorthand for `--speculative-config '{"method":"mtp"}'`; `--mtp-sidecar` maps to `model`, `--mtp-max-k` maps to `num_speculative_tokens`, and `--mtp-disable-auto-k` maps to `disable_auto_k`. `--suffix-decoding` remains as a compatibility shorthand for `--speculative-config '{"method":"suffix"}'`. None of these backends is enabled by default.
+`--enable-dflash` remains as a compatibility shorthand for `--speculative-config '{"method":"dflash"}'`, and `--dflash-drafter-path` maps to the config `model` field. `--enable-ddtree` similarly remains as a compatibility shorthand for `--speculative-config '{"method":"ddtree"}'`. MTP remains on the legacy `--spec-decode mtp` surface until the shared interface is revalidated end to end. None of these backends is enabled by default. SuffixDecoding keeps its existing flag until it migrates behind the same config interface.
 
 Mutex: DFlash cannot combine with MTP or SuffixDecoding (single-user path). MTP and SuffixDecoding cannot combine with each other (both consume the drafter slot).
 
@@ -889,10 +882,10 @@ Mutex: DFlash cannot combine with MTP or SuffixDecoding (single-user path). MTP 
 | `--prefix-cache-index` | Prefix-cache lookup index: `radix` (default) or `hash` | `radix` |
 | `--pflash` | PFlash sparse prefill: `auto` / `always` / `off` | `auto` (on for verified aliases) |
 | `--enable-dflash` | Compatibility shorthand for DFlash speculative decoding (single-user; prefer `--speculative-config '{"method":"dflash"}'`) | off |
-| `--speculative-config` | vLLM-style speculative decoding JSON config; supports DFlash, DDTree, MTP, and SuffixDecoding | off |
+| `--speculative-config` | vLLM-style speculative decoding JSON config; supports DFlash `{"method":"dflash"}` and DDTree `{"method":"ddtree"}` | off |
 | `--enable-ddtree` | Compatibility shorthand for DDTree speculative decoding (single-user; `qwen3.5-9b-8bit`) | off |
 | `--suffix-decoding` | Drafter-free n-gram speculative decoding (BatchedEngine path) | off |
-| `--spec-decode mtp` | Compatibility shorthand for MTP head speculative decoding; prefer `--speculative-config '{"method":"mtp"}'` | off |
+| `--spec-decode mtp` | Legacy opt-in for MTP head speculative decoding | off |
 | `--gpu-memory-utilization` | Fraction of device memory to use (0.0-1.0) | `0.90` |
 
 **Cloud routing**
@@ -1096,7 +1089,7 @@ harness/                 # Regression baselines + thresholds
 | [DFlash](https://arxiv.org/abs/2602.06036) — block-diffusion drafter, single-user | 1.3–2× decode (workload-dependent) | Shipping, opt-in (`--speculative-config '{"method":"dflash"}'`, `[dflash]` extra; qwen3.5-27b-8bit, qwen3.6-27b-8bit) |
 | [DDTree](https://arxiv.org/abs/2604.12989) — DFlash draft-tree verification, single-user | TBD on rapid-mlx 9B gate | Experimental (`--speculative-config '{"method":"ddtree"}'`; `--enable-ddtree` compatibility shorthand) |
 | [SuffixDecoding](https://arxiv.org/abs/2411.04975) — drafter-free n-gram speculative | 1.1–1.5× decode | Shipping (`--suffix-decoding`, per-model tier sweep ongoing) |
-| MTP — Multi-Token Prediction head | 1.4–1.7× decode | Shipping, opt-in (`--speculative-config '{"method":"mtp"}'`; `--spec-decode mtp` compatibility shorthand) |
+| MTP — Multi-Token Prediction head | 1.4–1.7× decode | Legacy opt-in (`--spec-decode mtp`); shared config interface pending revalidation |
 | [EAGLE-3](https://arxiv.org/abs/2503.01840) — feature-level draft on Metal | 3–6.5× decode | Not started |
 | [ReDrafter](https://arxiv.org/abs/2403.09919) — Apple's RNN draft head | 1.4–1.5× decode | Not started |
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -92,10 +92,6 @@ rapid-mlx serve qwen3.5-27b-8bit --speculative-config '{"method":"dflash"}' --po
 # DDTree speculative decoding (experimental, single-user)
 rapid-mlx serve qwen3.5-9b-8bit --speculative-config '{"method":"ddtree"}' --port 8000
 
-# MTP fixed-K parity bench mode
-rapid-mlx serve qwen3.6-27b-mtp-4bit \
-  --speculative-config '{"method":"mtp","num_speculative_tokens":1,"disable_auto_k":true}'
-
 # SuffixDecoding for explicit high-overlap workloads
 rapid-mlx serve gemma-4-12b-4bit \
   --speculative-config '{"method":"suffix","num_speculative_tokens":8}'

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -60,17 +60,14 @@
 
 ### Speculative Decoding Options
 
-Prefer `--speculative-config` for new speculative decoding usage. Legacy
-flags remain compatibility shorthands.
+Prefer `--speculative-config` for DFlash, DDTree, and SuffixDecoding usage.
+MTP remains on the legacy `--spec-decode mtp` surface until real-model A/B
+parity is revalidated for the shared interface.
 
 | Config | Description |
 |--------|-------------|
 | `{"method":"dflash"}` | Enable the DFlash single-user bridge on validated aliases. |
 | `{"method":"ddtree"}` | Enable experimental DDTree verification on validated aliases. |
-| `{"method":"mtp"}` | Enable MTP speculative decoding for MTP-trained checkpoints. |
-| `{"method":"mtp","model":"<sidecar>"}` | Reserved for future validated assistant sidecars. Gemma 4 sidecar MTP is currently disabled after greedy-lossless A/B failed. |
-| `{"method":"mtp","num_speculative_tokens":3}` | Set the MTP max-K controller ceiling. |
-| `{"method":"mtp","disable_auto_k":true}` | Disable the MTP EV depth controller for fixed-K parity benches. |
 | `{"method":"suffix","num_speculative_tokens":8}` | Enable explicit SuffixDecoding for high-overlap workloads. |
 
 Legacy mapping:
@@ -79,10 +76,6 @@ Legacy mapping:
 |-------------|------------------|
 | `--enable-dflash` | `--speculative-config '{"method":"dflash"}'` |
 | `--enable-ddtree` | `--speculative-config '{"method":"ddtree"}'` |
-| `--spec-decode mtp` | `--speculative-config '{"method":"mtp"}'` |
-| `--mtp-sidecar <path>` | `{"method":"mtp","model":"<path>"}` |
-| `--mtp-max-k N` | `{"method":"mtp","num_speculative_tokens":N}` |
-| `--mtp-disable-auto-k` | `{"method":"mtp","disable_auto_k":true}` |
 | `--suffix-decoding` | `--speculative-config '{"method":"suffix"}'` |
 
 ### MCP Options

--- a/tests/test_speculative_config.py
+++ b/tests/test_speculative_config.py
@@ -19,15 +19,13 @@ from vllm_mlx.spec_decode.registry import get_spec_decoder, iter_spec_decoders
 
 def test_parse_speculative_config_accepts_vllm_common_keys() -> None:
     cfg = parse_speculative_config(
-        '{"method":"mtp","model":"local/draft","num_speculative_tokens":4,'
-        '"disable_auto_k":true}'
+        '{"method":"mtp","model":"local/draft","num_speculative_tokens":4}'
     )
 
     assert cfg is not None
     assert cfg.method == "mtp"
     assert cfg.model == "local/draft"
     assert cfg.num_speculative_tokens == 4
-    assert cfg.disable_auto_k is True
     assert cfg.tree_budget is None
 
 
@@ -88,7 +86,7 @@ def test_parse_suffix_speculative_config_accepts_existing_knobs() -> None:
         ('{"method":"mtp","num_speculative_tokens":true}', "positive integer"),
         ('{"method":"mtp","model":""}', "non-empty string"),
         ('{"method":"mtp","tree_budget":24}', "unsupported speculative-config"),
-        ('{"method":"mtp","disable_auto_k":1}', "boolean"),
+        ('{"method":"mtp","disable_auto_k":true}', "unsupported speculative-config"),
         ('{"method":"ddtree","tree_budget":0}', "positive integer"),
         ('{"method":"ddtree","tree_budget":true}', "positive integer"),
         ('{"method":"ddtree","unknown":1}', "unsupported speculative-config"),
@@ -114,11 +112,12 @@ def test_parse_speculative_config_rejects_bad_payloads(raw: str, match: str) -> 
         parse_speculative_config(raw)
 
 
-def test_require_migrated_speculative_config_accepts_mtp() -> None:
+def test_require_migrated_speculative_config_rejects_mtp_until_revalidated() -> None:
     cfg = parse_speculative_config('{"method":"mtp"}')
     assert cfg is not None
 
-    require_migrated_speculative_config(cfg)
+    with pytest.raises(SpeculativeConfigError, match="not wired yet"):
+        require_migrated_speculative_config(cfg)
 
 
 def test_require_migrated_speculative_config_accepts_ddtree() -> None:
@@ -148,7 +147,7 @@ def test_spec_decoder_registry_lists_existing_backends() -> None:
     assert {"ddtree", "dflash", "mtp", "suffix"}.issubset(methods)
     assert get_spec_decoder("ddtree").config_enabled is True
     assert get_spec_decoder("dflash").config_enabled is True
-    assert get_spec_decoder("mtp").config_enabled is True
+    assert get_spec_decoder("mtp").config_enabled is False
     assert get_spec_decoder("suffix").config_enabled is True
     assert get_spec_decoder("ngram") == get_spec_decoder("suffix")
 
@@ -187,29 +186,26 @@ def _spec_config_args(**overrides):
     return SimpleNamespace(**data)
 
 
-def test_speculative_config_mtp_normalizes_to_legacy_spec_decode() -> None:
+def test_speculative_config_mtp_is_not_exposed_until_revalidated(capsys) -> None:
     from vllm_mlx.cli import _normalize_speculative_config_or_exit
 
     args = _spec_config_args(
         speculative_config=(
             '{"method":"mtp","model":"google/gemma-4-12B-it-assistant",'
-            '"num_speculative_tokens":2,"disable_auto_k":true}'
+            '"num_speculative_tokens":2}'
         )
     )
 
-    _normalize_speculative_config_or_exit(args)
+    with pytest.raises(SystemExit) as excinfo:
+        _normalize_speculative_config_or_exit(args)
 
-    assert args.spec_decode == "mtp"
-    assert args.mtp_sidecar == "google/gemma-4-12B-it-assistant"
-    assert args.mtp_max_k == 2
-    assert args.mtp_disable_auto_k is True
-    assert args._speculative_config.method == "mtp"
-    assert args._speculative_config.model == "google/gemma-4-12B-it-assistant"
-    assert args._speculative_config.num_speculative_tokens == 2
-    assert args._speculative_config.disable_auto_k is True
+    assert excinfo.value.code == 2
+    captured = capsys.readouterr()
+    assert "not wired yet" in captured.err
+    assert "--spec-decode mtp" in captured.err
 
 
-def test_spec_decode_mtp_legacy_flag_is_speculative_config_shorthand() -> None:
+def test_spec_decode_mtp_legacy_flag_still_normalizes_internally() -> None:
     from vllm_mlx.cli import _normalize_speculative_config_or_exit
 
     args = _spec_config_args(
@@ -226,6 +222,7 @@ def test_spec_decode_mtp_legacy_flag_is_speculative_config_shorthand() -> None:
     assert args._speculative_config.model == "google/gemma-4-12B-it-assistant"
     assert args._speculative_config.num_speculative_tokens == 2
     assert args._speculative_config.disable_auto_k is True
+    assert args._speculative_config.raw["disable_auto_k"] is True
 
 
 def test_no_speculative_config_fills_suffix_runtime_defaults() -> None:
@@ -242,7 +239,9 @@ def test_no_speculative_config_fills_suffix_runtime_defaults() -> None:
     assert args.suffix_min_draft_len == 2
 
 
-def test_speculative_config_mtp_rejects_legacy_sidecar_flag(capsys) -> None:
+def test_speculative_config_mtp_rejects_before_legacy_sidecar_conflict(
+    capsys,
+) -> None:
     from vllm_mlx.cli import _normalize_speculative_config_or_exit
 
     args = _spec_config_args(
@@ -255,25 +254,8 @@ def test_speculative_config_mtp_rejects_legacy_sidecar_flag(capsys) -> None:
 
     assert excinfo.value.code == 2
     captured = capsys.readouterr()
-    assert "mutually exclusive" in captured.err
-    assert "--mtp-sidecar" in captured.err
-
-
-def test_speculative_config_mtp_rejects_legacy_disable_auto_k_flag(capsys) -> None:
-    from vllm_mlx.cli import _normalize_speculative_config_or_exit
-
-    args = _spec_config_args(
-        speculative_config='{"method":"mtp","disable_auto_k":false}',
-        mtp_disable_auto_k=True,
-    )
-
-    with pytest.raises(SystemExit) as excinfo:
-        _normalize_speculative_config_or_exit(args)
-
-    assert excinfo.value.code == 2
-    captured = capsys.readouterr()
-    assert "mutually exclusive" in captured.err
-    assert "--mtp-disable-auto-k" in captured.err
+    assert "not wired yet" in captured.err
+    assert "--spec-decode mtp" in captured.err
 
 
 def test_speculative_config_malformed_with_legacy_flag_reports_clean_error(

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -1599,8 +1599,6 @@ def _normalize_speculative_config_or_exit(args):
             conflicts.append("--dflash-drafter-path")
         if (getattr(args, "mtp_sidecar", None) or "").strip():
             conflicts.append("--mtp-sidecar")
-        if getattr(args, "mtp_disable_auto_k", False):
-            conflicts.append("--mtp-disable-auto-k")
         # DFlash has a dedicated preflight that historically reports
         # these runtime conflicts as "cannot combine" (exit 1) before
         # probing mlx-vlm. Preserve that user-facing contract; other
@@ -6690,10 +6688,9 @@ Examples:
             "vLLM-style speculative decoding JSON config. This frontend "
             "parses method/model/num_speculative_tokens now. DFlash is "
             'available with \'{"method":"dflash"}\', DDTree with '
-            '\'{"method":"ddtree"}\', and MTP with '
-            '\'{"method":"mtp","model":"<optional-sidecar>",'
-            '"num_speculative_tokens":3,"disable_auto_k":false}\'. '
-            "SuffixDecoding is an explicit, "
+            '\'{"method":"ddtree"}\'. MTP remains on the legacy '
+            "--spec-decode mtp surface until real-model A/B parity is "
+            "revalidated. SuffixDecoding is an explicit, "
             "workload-specific flag for high prompt/output-overlap traffic "
             "and is available with "
             '\'{"method":"suffix","num_speculative_tokens":8}\'.'
@@ -6828,8 +6825,7 @@ Examples:
         choices=["none", "mtp", "dflash"],
         default="none",
         help=(
-            "Compatibility selector for model-side speculative decode; "
-            "prefer --speculative-config for new usage. "
+            "R15-P1 model-side speculative decode. "
             "``none`` (default) disables; ``mtp`` enables Qwen3.5/3.6 "
             "native MTP via vendored mlx-lm PR #990 — requires a "
             "checkpoint converted with the PR #990 sanitize() path "
@@ -6851,9 +6847,7 @@ Examples:
         default=None,
         help=(
             "Reserved path/repo id for future validated MTP assistant "
-            "sidecars. Prefer "
-            '--speculative-config \'{"method":"mtp","model":...}\' '
-            "for new usage. Gemma 4 assistant-sidecar MTP is currently "
+            "sidecars. Gemma 4 assistant-sidecar MTP is currently "
             "disabled after greedy-lossless validation failed; ignored for "
             "the Qwen3.5/3.6 native-MTP path because their head is baked "
             "into the target. "
@@ -6874,10 +6868,8 @@ Examples:
             "Hard ceiling on the per-round draft depth the EV controller "
             "may select (default: 3). The current generator implements "
             "K∈{0,1} (park + chain-of-1); values >1 are effectively "
-            "clamped until chain-of-K verify lands. Prefer "
-            '--speculative-config \'{"method":"mtp",'
-            '"num_speculative_tokens":3}\' for new usage. Only consulted '
-            "when MTP spec-decode is set."
+            "clamped until chain-of-K verify lands. Only consulted when "
+            "--spec-decode mtp is set."
         ),
     )
     serve_parser.add_argument(
@@ -6888,10 +6880,8 @@ Examples:
         help=(
             "Disable the EV depth controller and keep the pre-PR-B "
             "fixed-K=1 chain-of-1 MTP behavior. Used to A/B bench the "
-            "controller against the fixed-K=1 baseline. Prefer "
-            '--speculative-config \'{"method":"mtp",'
-            '"disable_auto_k":true}\' for new usage. Only consulted '
-            "when MTP spec-decode is set."
+            "controller against the fixed-K=1 baseline. Only consulted "
+            "when --spec-decode mtp is set."
         ),
     )
     # R15-P1 #313: DFlash drafter HF path override. Empty by default

--- a/vllm_mlx/spec_decode/config.py
+++ b/vllm_mlx/spec_decode/config.py
@@ -43,7 +43,7 @@ _COMMON_KEYS = frozenset(
 _METHOD_KEYS = {
     "ddtree": frozenset({"model", "num_speculative_tokens", "tree_budget"}),
     "dflash": frozenset({"model"}),
-    "mtp": frozenset({"model", "num_speculative_tokens", "disable_auto_k"}),
+    "mtp": frozenset({"model", "num_speculative_tokens"}),
     "suffix": frozenset(
         {
             "num_speculative_tokens",
@@ -147,7 +147,6 @@ def parse_speculative_config(value: str | None) -> SpeculativeConfig | None:
             payload.get("num_speculative_tokens"), "num_speculative_tokens"
         ),
         tree_budget=_positive_int(payload.get("tree_budget"), "tree_budget"),
-        disable_auto_k=_optional_bool(payload.get("disable_auto_k"), "disable_auto_k"),
         max_suffix_len=_positive_int(payload.get("max_suffix_len"), "max_suffix_len"),
         min_confidence=_confidence(payload.get("min_confidence"), "min_confidence"),
         min_draft_len=_positive_int(payload.get("min_draft_len"), "min_draft_len"),

--- a/vllm_mlx/spec_decode/registry.py
+++ b/vllm_mlx/spec_decode/registry.py
@@ -83,8 +83,11 @@ register_spec_decoder(
     SpecDecoderPlugin(
         method="mtp",
         description="Model-side multi-token prediction head",
-        config_enabled=True,
-        legacy_hint="use --spec-decode mtp",
+        config_enabled=False,
+        legacy_hint=(
+            "MTP is available only through the legacy --spec-decode mtp "
+            "surface until real-model A/B parity is revalidated"
+        ),
     )
 )
 register_spec_decoder(


### PR DESCRIPTION
## Summary
- gate MTP out of the shared `--speculative-config` interface until real-model A/B parity is revalidated
- keep legacy `--spec-decode mtp` parsing and runtime behavior intact, including legacy `--mtp-disable-auto-k` internal config recording
- remove MTP JSON examples/preferred-config docs so users are not guided toward an unvalidated surface
- keep the #1038 Gemma4 sidecar fail-closed runtime behavior; this PR does not touch `vllm_mlx/spec_decode/mtp/*` or `vllm_mlx/engine/batched.py`

## Why
MTP interface wiring was merged before we had enough end-to-end evidence that the new `--speculative-config` surface preserved legacy MTP behavior, performance, and stability. Speculative decoding enablement must fail closed unless real-model A/B validation proves correctness and performance.

## Validation
- `pytest tests/test_speculative_config.py tests/test_mtp_cli_wiring.py tests/test_mtp_spec_decode.py -q` -> 154 passed
- `ruff check vllm_mlx/cli.py vllm_mlx/spec_decode/config.py vllm_mlx/spec_decode/registry.py tests/test_speculative_config.py` -> pass
- `ruff format --check vllm_mlx/cli.py vllm_mlx/spec_decode/config.py vllm_mlx/spec_decode/registry.py tests/test_speculative_config.py` -> pass
- `python -m compileall -q vllm_mlx tests/test_speculative_config.py` -> pass
- `git diff --check origin/main..HEAD` -> pass
- CLI smoke: `--speculative-config {"method":"mtp"}` exits 2; legacy `--spec-decode mtp` still parses as `mtp`
- Diff audit: no changes under `vllm_mlx/spec_decode/mtp/*`; no changes to `vllm_mlx/engine/batched.py`
- `scripts.pr_validate 1040 -v`: codex_review PASS, lint PASS, targeted_tests PASS (`827 passed`); full_unit intentionally not run for this rollback after operator guidance

skip-version-bump
