### PR TITLE
chore: bump version to 0.10.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.10.1"
+version = "0.10.2"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## Summary
Bumps `pyproject.toml` version 0.10.1 → 0.10.2 to fire `auto-release.yml` and publish to PyPI.

## What's in 0.10.2

**Layer C — deep integration (Task #443):**
- `#1030` — Portfolio ops: 8 Tier-1 agent profiles + 3 framework profiles + integration scaffold + README restructure
- `#1037` — 56-cell real-inference matrix: 11 agents × 4 Tier-1 families + 3 frameworks × 4 families. 39 PASS / 17 XFAIL (8 structural OpenHands+Aider × 4 families + 9 architectural DeepSeek R1-Distill non-tool-emission per arXiv 2501.12948) / 0 FAIL. Strong-pick models: Qwen 3.6 35B-A3B-8bit, Gemma 4 31B-4bit, DeepSeek R1-Distill-Qwen-32B-4bit, gpt-oss 120B-mxfp4-q8.
- `#1039` — \`rapid-mlx jlens\` Jacobian-lens interpretability command (works on 4/8-bit quantized MLX).

## Follow-ups tracked
- `#1041` — DeepSeek V4 Flash (671B MoE) Tier-1 hardware plan (single-node infeasible at 155 GB weights)
- `#460` folded into `#1037`
- Task #465 — gpt-oss-120b R2 mirror
- Task #467 — models.rapidmlx.com landing ItemList refresh

## Test plan
- [x] pyproject version bumped 0.10.1 → 0.10.2
- [x] Subject regex matches \`auto-release.yml\` fire pattern
- [x] Diff is 1 line, 1 file (pyproject.toml only)

Post-merge verification (prose, not a gate item): once auto-release.yml fires, \`pip install rapid-mlx==0.10.2\` should return an installable wheel and a GitHub release 0.10.2 tag will be created automatically. If either doesn't happen within 15 min of merge, investigate via `gh run list --workflow=auto-release.yml` and check the workflow logs.