### PR TITLE
[codex] migrate MTP to speculative config

### DIFF
--- a/README.md
+++ b/README.md
@@ -849,7 +849,7 @@ rapid-mlx serve qwen3.5-9b-8bit \
   --speculative-config '{"method":"ddtree","model":"z-lab/Qwen3.5-9B-DFlash","num_speculative_tokens":16,"tree_budget":24}'
 ```
 
-`--enable-dflash` remains as a compatibility shorthand for `--speculative-config '{"method":"dflash"}'`, and `--dflash-drafter-path` maps to the config `model` field. `--enable-ddtree` similarly remains as a compatibility shorthand for `--speculative-config '{"method":"ddtree"}'`. `--spec-decode mtp` remains as a compatibility shorthand for `--speculative-config '{"method":"mtp"}'`; `--mtp-sidecar` maps to `model`, `--mtp-max-k` maps to `num_speculative_tokens`, and `--mtp-disable-auto-k` maps to `disable_auto_k`. `--suffix-decoding` remains as a compatibility shorthand for `--speculative-config '{"method":"suffix"}'`. None of these backends is enabled by default.
+`--enable-dflash` remains as a compatibility shorthand for `--speculative-config '{"method":"dflash"}'`, and `--dflash-drafter-path` maps to the config `model` field. `--enable-ddtree` similarly remains as a compatibility shorthand for `--speculative-config '{"method":"ddtree"}'`. For MTP, `--speculative-config '{"method":"mtp"}'` is the preferred public path; the old `--spec-decode mtp` shorthand remains accepted as a hidden deprecated compatibility path. `--suffix-decoding` remains as a compatibility shorthand for `--speculative-config '{"method":"suffix"}'`. None of these backends is enabled by default.
 
 Mutex: DFlash cannot combine with MTP or SuffixDecoding (single-user path). MTP and SuffixDecoding cannot combine with each other (both consume the drafter slot).
 
@@ -892,7 +892,6 @@ Mutex: DFlash cannot combine with MTP or SuffixDecoding (single-user path). MTP 
 | `--speculative-config` | vLLM-style speculative decoding JSON config; supports DFlash, DDTree, MTP, and SuffixDecoding | off |
 | `--enable-ddtree` | Compatibility shorthand for DDTree speculative decoding (single-user; `qwen3.5-9b-8bit`) | off |
 | `--suffix-decoding` | Drafter-free n-gram speculative decoding (BatchedEngine path) | off |
-| `--spec-decode mtp` | Compatibility shorthand for MTP head speculative decoding; prefer `--speculative-config '{"method":"mtp"}'` | off |
 | `--gpu-memory-utilization` | Fraction of device memory to use (0.0-1.0) | `0.90` |
 
 **Cloud routing**
@@ -1096,7 +1095,7 @@ harness/                 # Regression baselines + thresholds
 | [DFlash](https://arxiv.org/abs/2602.06036) — block-diffusion drafter, single-user | 1.3–2× decode (workload-dependent) | Shipping, opt-in (`--speculative-config '{"method":"dflash"}'`, `[dflash]` extra; qwen3.5-27b-8bit, qwen3.6-27b-8bit) |
 | [DDTree](https://arxiv.org/abs/2604.12989) — DFlash draft-tree verification, single-user | TBD on rapid-mlx 9B gate | Experimental (`--speculative-config '{"method":"ddtree"}'`; `--enable-ddtree` compatibility shorthand) |
 | [SuffixDecoding](https://arxiv.org/abs/2411.04975) — drafter-free n-gram speculative | 1.1–1.5× decode | Shipping (`--suffix-decoding`, per-model tier sweep ongoing) |
-| MTP — Multi-Token Prediction head | 1.4–1.7× decode | Shipping for existing MTP-eligible checkpoints, opt-in (`--speculative-config '{"method":"mtp"}'`; `--spec-decode mtp` compatibility shorthand) |
+| MTP — Multi-Token Prediction head | Workload-dependent decode gain | Shipping for existing MTP-eligible checkpoints, opt-in (`--speculative-config '{"method":"mtp"}'`) |
 | [EAGLE-3](https://arxiv.org/abs/2503.01840) — feature-level draft on Metal | 3–6.5× decode | Not started |
 | [ReDrafter](https://arxiv.org/abs/2403.09919) — Apple's RNN draft head | 1.4–1.5× decode | Not started |
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -79,11 +79,10 @@ Legacy mapping:
 |-------------|------------------|
 | `--enable-dflash` | `--speculative-config '{"method":"dflash"}'` |
 | `--enable-ddtree` | `--speculative-config '{"method":"ddtree"}'` |
-| `--spec-decode mtp` | `--speculative-config '{"method":"mtp"}'` |
-| `--mtp-sidecar <path>` | `{"method":"mtp","model":"<path>"}` |
-| `--mtp-max-k N` | `{"method":"mtp","num_speculative_tokens":N}` |
-| `--mtp-disable-auto-k` | `{"method":"mtp","disable_auto_k":true}` |
 | `--suffix-decoding` | `--speculative-config '{"method":"suffix"}'` |
+
+MTP's old `--spec-decode mtp` shorthand is deprecated and hidden from help;
+use `--speculative-config '{"method":"mtp"}'`.
 
 ### MCP Options
 

--- a/tests/test_dflash_integration.py
+++ b/tests/test_dflash_integration.py
@@ -197,6 +197,14 @@ def test_dflash_speculative_config_conflicts_fail_before_runtime_probe(
         **overrides,
     )
 
+    if overrides.get("no_spec_decode"):
+        with pytest.raises(SystemExit) as excinfo:
+            _normalize_speculative_config_or_exit(args)
+        assert excinfo.value.code == code
+        captured = capsys.readouterr()
+        assert match in captured.out + captured.err
+        return
+
     _normalize_speculative_config_or_exit(args)
     with pytest.raises(SystemExit) as excinfo:
         _preflight_dflash_mutexes_or_exit(args)
@@ -207,22 +215,18 @@ def test_dflash_speculative_config_conflicts_fail_before_runtime_probe(
 
 
 def test_enable_dflash_legacy_mix_rejects_spec_decode_mtp(capsys) -> None:
-    from vllm_mlx.cli import (
-        _normalize_speculative_config_or_exit,
-        _preflight_dflash_mutexes_or_exit,
-    )
+    from vllm_mlx.cli import _normalize_speculative_config_or_exit
 
     args = _dflash_cli_args(enable_dflash=True, spec_decode="mtp")
 
-    _normalize_speculative_config_or_exit(args)
-    assert args.enable_dflash is True
-    assert args.spec_decode == "mtp"
     with pytest.raises(SystemExit) as excinfo:
-        _preflight_dflash_mutexes_or_exit(args)
+        _normalize_speculative_config_or_exit(args)
 
-    assert excinfo.value.code == 1
+    assert excinfo.value.code == 2
     captured = capsys.readouterr()
-    assert "cannot combine" in captured.out
+    assert "mutually exclusive" in captured.err
+    assert "--speculative-config" in captured.err
+    assert "--enable-dflash" in captured.err
 
 
 # =============================================================================

--- a/tests/test_mtp_cli_wiring.py
+++ b/tests/test_mtp_cli_wiring.py
@@ -1,25 +1,24 @@
 # SPDX-License-Identifier: Apache-2.0
-"""PR-A of 0.9.13 stack: CLI wiring for ``--spec-decode mtp --mtp-sidecar``.
+"""MTP speculative-config wiring.
 
 Coverage for the four surfaces PR-A ships:
 
 1. ``detect_mtp_eligibility(..., has_external_sidecar=True)`` — Gemma 4
-   unified base checkpoint (no baked-in MTP head) is promoted from NONE
-   to CHAIN when the CLI has resolved a sidecar path. Qwen3.5 / Qwen3.6
-   eligibility is unaffected (their MTP head is baked into the target,
-   ``--mtp-sidecar`` is a no-op for those).
+   unified base checkpoint (no baked-in MTP head) stays NONE even when
+   the CLI has resolved a config ``model`` sidecar path. Qwen3.5 /
+   Qwen3.6 eligibility is unaffected (their MTP head is baked into the
+   target; a sidecar does not manufacture a missing head).
 
-2. ``vllm_mlx.cli`` argparse — ``--mtp-sidecar PATH`` is present in the
-   serve subcommand's ``--help`` and parses without a value error.
+2. ``vllm_mlx.cli`` argparse — the legacy ``--mtp-sidecar`` flag is not
+   exposed; MTP sidecars come from ``--speculative-config`` only.
 
 3. ``SchedulerConfig.mtp_sidecar`` — round-trips as expected; default
    is ``None`` so pre-0.9.13 callers keep the old behaviour.
 
 4. Engine dispatch call site — the batched engine's ``_start_llm``
    routes through ``dispatch_mtp_inject`` with the sidecar path when
-   ``--spec-decode mtp`` + ``--mtp-sidecar`` are set. Verified via
-   a monkeypatched dispatch that captures the call args (no real model
-   load).
+   config MTP is set. Verified via a monkeypatched dispatch that
+   captures the call args (no real model load).
 
 Deliberately out of scope (deferred to PR-B / PR-C):
 
@@ -36,13 +35,12 @@ from __future__ import annotations
 
 
 def test_detect_sidecar_does_not_promote_gemma4_unified_missing_mtp_layers():
-    """Base Gemma 4 unified checkpoint (no MTP head) + sidecar stays NONE.
+    """Base Gemma 4 unified checkpoint + sidecar stays NONE.
 
-    July 2026 A/B validation of ``mlx-community/gemma-4-12B-it-4bit`` +
-    ``google/gemma-4-12B-it-assistant`` showed greedy output divergence
-    on the server path. Until a future implementation proves lossless
-    correctness and performance end to end, sidecar mode must not
-    promote Gemma 4 into MTP eligibility.
+    Local July 2026 A/B validation of ``mlx-community/gemma-4-12B-it-4bit`` +
+    ``google/gemma-4-12B-it-assistant`` still diverges from the greedy
+    no-spec server output, so sidecar mode must not promote Gemma 4 into
+    MTP eligibility until a lossless implementation lands.
     """
     from vllm_mlx.spec_decode.mtp import (
         MTPEligibility,
@@ -194,21 +192,12 @@ def _serve_help_stdout() -> str:
     return proc.stdout
 
 
-def test_cli_serve_help_advertises_mtp_sidecar():
-    """``--mtp-sidecar`` appears in ``serve --help`` output.
-
-    Codex round-N regression guard: a prior refactor moved the flag out
-    of the serve parser and into a separate ``mtp`` subcommand, silently
-    breaking the dogfood invocation ``rapid-mlx serve <model>
-    --spec-decode mtp --mtp-sidecar <path>``. Pin the surface here so
-    the same regression can't ship again without breaking this test.
-    """
+def test_cli_serve_help_hides_legacy_mtp_sidecar_flag():
+    """MTP sidecars are configured through ``--speculative-config`` only."""
     text = _serve_help_stdout()
-    assert "--mtp-sidecar" in text, (
-        "--mtp-sidecar flag missing from `rapid-mlx serve --help`. "
-        "PR-A of 0.9.13 stack ships this flag — check "
-        "vllm_mlx/cli.py::serve_parser."
-    )
+    assert "--mtp-sidecar" not in text
+    assert "--mtp-max-k" not in text
+    assert "--mtp-disable-auto-k" not in text
 
 
 # ---------------------------------------------------------------------------
@@ -283,6 +272,17 @@ def test_scheduler_config_mtp_model_type_round_trip():
         mtp_model_type="gemma4_unified",
     )
     assert cfg.mtp_model_type == "gemma4_unified"
+
+
+def test_config_vetted_mtp_support_allowlist_is_qwen_only():
+    """Alias-profile false is only bypassed for config-vetted Qwen MTP."""
+
+    from vllm_mlx.scheduler import _config_vetted_mtp_supports_spec_decode
+
+    assert _config_vetted_mtp_supports_spec_decode("qwen3_5") is True
+    assert _config_vetted_mtp_supports_spec_decode("qwen3_5_moe") is True
+    assert _config_vetted_mtp_supports_spec_decode("gemma4_unified") is False
+    assert _config_vetted_mtp_supports_spec_decode(None) is False
 
 
 # ---------------------------------------------------------------------------
@@ -1360,6 +1360,60 @@ class _StubModel:
     mtp_forward = object()
     make_mtp_cache = object()
     mtp = object()
+
+
+def test_install_mtp_vendored_uses_inner_language_model_surface(monkeypatch):
+    """Qwen3.5 loads as an outer wrapper whose MTP surfaces live on
+    ``model.language_model`` after sidecar injection.
+
+    The server installer must pass that inner object into
+    ``mtp_generate_step``. Otherwise the server starts with a successful
+    injection banner but disables MTP as a no-op during warmup.
+    """
+    from types import SimpleNamespace
+
+    import mlx.core as mx
+
+    from vllm_mlx.scheduler import _install_mtp_vendored
+    from vllm_mlx.spec_decode.mtp import generator as _gen_mod
+
+    seen: dict[str, object] = {}
+
+    class _FakeGen:
+        def __iter__(self):
+            return self
+
+        def __next__(self):
+            return (1234, mx.array([0.0]), False)
+
+        def close(self):
+            pass
+
+    inner = _StubModel()
+    outer = SimpleNamespace(language_model=inner)
+
+    def _recording_mtp_generate_step(*args, **kwargs):
+        seen["model"] = kwargs["model"]
+        return _FakeGen()
+
+    monkeypatch.setattr(_gen_mod, "mtp_generate_step", _recording_mtp_generate_step)
+
+    batch_gen, gb = _make_batch_gen_with_gb()
+    gb.uids = [42]
+    gb._next_tokens = mx.array([500], dtype=mx.uint32)
+    gb._next_logprobs = [mx.array([0.0])]
+    request_stub = SimpleNamespace(sampling_params=SimpleNamespace(temperature=0.0))
+
+    ok = _install_mtp_vendored(
+        batch_gen,
+        model=outer,
+        requests={"req-42": request_stub},
+        uid_to_request_id={42: "req-42"},
+    )
+    assert ok is True
+
+    gb._step()
+    assert seen["model"] is inner
 
 
 def _make_batch_gen_with_gb():

--- a/tests/test_mtp_gemma4_assistant_inject.py
+++ b/tests/test_mtp_gemma4_assistant_inject.py
@@ -24,8 +24,8 @@ Coverage
    ``allow_random_init`` → False, model unmodified.
 5. **Architecture-guard** — a config whose ``model_type`` is NOT one
    of the known assistant strings is REFUSED, not silently loaded.
-6. **Dispatcher routing** — ``gemma4`` / ``gemma4_unified`` /
-   ``gemma4_text`` route to this module; ``qwen3_5`` + fake
+6. **Dispatcher routing** — Gemma 4 stays unregistered until lossless.
+   ``qwen3_5`` + fake
    ``gemma4-assistant`` sidecar → still routes to qwen3_5 (dispatcher
    is model_type-based, no fingerprint sniffing).
 """
@@ -1498,11 +1498,11 @@ def test_dispatcher_swallows_family_import_exception(monkeypatch):
 
     ok = _dispatch.dispatch_mtp_inject(
         model=object(),
-        model_type="gemma4",
+        model_type="qwen3_5",
         mtp_sidecar=None,
         allow_random_init=False,
     )
     assert ok is False, "non-ImportError at import time must land as False"
 
-    ok_v = _dispatch.dispatch_mtp_validate(model=object(), model_type="gemma4")
+    ok_v = _dispatch.dispatch_mtp_validate(model=object(), model_type="qwen3_5")
     assert ok_v is False, "non-ImportError at import time must land as False (validate)"

--- a/tests/test_mtp_spec_decode.py
+++ b/tests/test_mtp_spec_decode.py
@@ -134,6 +134,23 @@ def test_detect_eligibility_qwen3_5_moe_chain():
     assert detect_mtp_eligibility(config) is MTPEligibility.CHAIN
 
 
+def test_detect_eligibility_qwen3_5_accepts_text_config_mtp_layers():
+    """MLX community Qwen3.5/3.6 configs store MTP metadata in text_config."""
+    from vllm_mlx.spec_decode.mtp import (
+        MTPEligibility,
+        detect_mtp_eligibility,
+    )
+
+    config = {
+        "model_type": "qwen3_5",
+        "text_config": {
+            "model_type": "qwen3_5_text",
+            "mtp_num_hidden_layers": 1,
+        },
+    }
+    assert detect_mtp_eligibility(config) is MTPEligibility.CHAIN
+
+
 def test_detect_eligibility_qwen3_5_tree_reserved():
     """mtp_num_hidden_layers >= 2 → TREE (reserved, not implemented)."""
     from vllm_mlx.spec_decode.mtp import (
@@ -574,11 +591,11 @@ def _serve_help_stdout() -> str:
 
 
 def test_cli_spec_decode_flag_advertised_in_help():
-    """``--spec-decode {none,mtp}`` must appear in ``rapid-mlx serve --help``."""
+    """``--spec-decode`` remains only for none/dflash compatibility."""
     text = _serve_help_stdout()
     assert "--spec-decode" in text
-    # argparse renders ``--spec-decode {none,mtp}`` for the choices.
-    assert "none,mtp" in text or "mtp,none" in text
+    assert "none,dflash" in text or "dflash,none" in text
+    assert "none,mtp" not in text and "mtp,none" not in text
 
 
 def test_cli_spec_decode_flag_rejects_unknown_value():
@@ -602,6 +619,31 @@ def test_cli_spec_decode_flag_rejects_unknown_value():
     )
     assert proc.returncode != 0
     assert "spec-decode" in proc.stderr or "spec_decode" in proc.stderr
+
+
+def test_cli_spec_decode_mtp_legacy_choice_hidden_from_help():
+    """Deprecated ``--spec-decode mtp`` is accepted internally but hidden."""
+    import subprocess
+    import sys
+
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "vllm_mlx.cli",
+            "serve",
+            "--help",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert proc.returncode == 0, proc.stderr
+    spec_decode_line = next(
+        line for line in proc.stdout.splitlines() if "--spec-decode" in line
+    )
+    assert "{none,dflash}" in spec_decode_line
+    assert "{none,dflash,mtp}" not in spec_decode_line
 
 
 def test_scheduler_config_default_spec_decode_is_none():

--- a/tests/test_speculative_config.py
+++ b/tests/test_speculative_config.py
@@ -209,7 +209,7 @@ def test_speculative_config_mtp_normalizes_to_legacy_spec_decode() -> None:
     assert args._speculative_config.disable_auto_k is True
 
 
-def test_spec_decode_mtp_legacy_flag_still_normalizes_internally() -> None:
+def test_spec_decode_mtp_legacy_flag_normalizes_internally(capsys) -> None:
     from vllm_mlx.cli import _normalize_speculative_config_or_exit
 
     args = _spec_config_args(
@@ -221,15 +221,34 @@ def test_spec_decode_mtp_legacy_flag_still_normalizes_internally() -> None:
 
     _normalize_speculative_config_or_exit(args)
 
+    captured = capsys.readouterr()
+    assert "--spec-decode mtp is deprecated" in captured.err
+    assert "--speculative-config" in captured.err
     assert args.spec_decode == "mtp"
+    assert args.mtp_sidecar == "google/gemma-4-12B-it-assistant"
+    assert args.mtp_max_k == 2
+    assert args.mtp_disable_auto_k is True
     assert args._speculative_config.method == "mtp"
     assert args._speculative_config.model == "google/gemma-4-12B-it-assistant"
     assert args._speculative_config.num_speculative_tokens == 2
     assert args._speculative_config.disable_auto_k is True
-    assert args._speculative_config.raw["disable_auto_k"] is True
 
 
-def test_speculative_config_mtp_matches_legacy_runtime_args() -> None:
+def test_spec_decode_mtp_legacy_blank_sidecar_normalizes_to_none(capsys) -> None:
+    from vllm_mlx.cli import _normalize_speculative_config_or_exit
+
+    args = _spec_config_args(spec_decode="mtp", mtp_sidecar="   ")
+
+    _normalize_speculative_config_or_exit(args)
+
+    captured = capsys.readouterr()
+    assert "--spec-decode mtp is deprecated" in captured.err
+    assert args.mtp_sidecar is None
+    assert args._speculative_config.method == "mtp"
+    assert args._speculative_config.model is None
+
+
+def test_speculative_config_mtp_populates_runtime_args() -> None:
     from vllm_mlx.cli import _normalize_speculative_config_or_exit
 
     config_args = _spec_config_args(
@@ -238,31 +257,16 @@ def test_speculative_config_mtp_matches_legacy_runtime_args() -> None:
             '"num_speculative_tokens":2,"disable_auto_k":true}'
         )
     )
-    legacy_args = _spec_config_args(
-        spec_decode="mtp",
-        mtp_sidecar="google/gemma-4-12B-it-assistant",
-        mtp_max_k=2,
-        mtp_disable_auto_k=True,
-    )
 
     _normalize_speculative_config_or_exit(config_args)
-    _normalize_speculative_config_or_exit(legacy_args)
 
-    runtime_fields = (
-        "spec_decode",
-        "mtp_sidecar",
-        "mtp_max_k",
-        "mtp_disable_auto_k",
-        "suffix_decoding",
-        "suffix_max_draft",
-        "suffix_max_suffix_len",
-        "suffix_min_confidence",
-        "suffix_min_draft_len",
-        "enable_dflash",
-        "enable_ddtree",
-    )
-    for field in runtime_fields:
-        assert getattr(config_args, field) == getattr(legacy_args, field), field
+    assert config_args.spec_decode == "mtp"
+    assert config_args.mtp_sidecar == "google/gemma-4-12B-it-assistant"
+    assert config_args.mtp_max_k == 2
+    assert config_args.mtp_disable_auto_k is True
+    assert config_args.suffix_decoding is False
+    assert config_args.enable_dflash is False
+    assert config_args.enable_ddtree is False
 
 
 def test_no_speculative_config_fills_suffix_runtime_defaults() -> None:
@@ -345,6 +349,49 @@ def test_speculative_config_malformed_with_legacy_flag_reports_clean_error(
     captured = capsys.readouterr()
     assert "cannot be empty" in captured.err
     assert "AttributeError" not in captured.err
+
+
+def test_speculative_config_rejects_no_spec_decode(capsys) -> None:
+    from vllm_mlx.cli import _normalize_speculative_config_or_exit
+
+    args = _spec_config_args(
+        speculative_config='{"method":"mtp"}',
+        no_spec_decode=True,
+    )
+
+    with pytest.raises(SystemExit) as excinfo:
+        _normalize_speculative_config_or_exit(args)
+
+    assert excinfo.value.code == 2
+    captured = capsys.readouterr()
+    assert "mutually exclusive" in captured.err
+    assert "--no-spec-decode" in captured.err
+
+
+@pytest.mark.parametrize(
+    "overrides, expected",
+    [
+        ({"enable_dflash": True}, "--enable-dflash"),
+        ({"enable_ddtree": True}, "--enable-ddtree"),
+        ({"spec_decode": "dflash"}, "--spec-decode dflash"),
+        ({"spec_decode": "mtp"}, "--spec-decode mtp"),
+        ({"suffix_decoding": True}, "--suffix-decoding"),
+    ],
+)
+def test_no_spec_decode_rejects_legacy_spec_shorthands(
+    overrides, expected, capsys
+) -> None:
+    from vllm_mlx.cli import _normalize_speculative_config_or_exit
+
+    args = _spec_config_args(no_spec_decode=True, **overrides)
+
+    with pytest.raises(SystemExit) as excinfo:
+        _normalize_speculative_config_or_exit(args)
+
+    assert excinfo.value.code == 2
+    captured = capsys.readouterr()
+    assert "--no-spec-decode" in captured.err
+    assert expected in captured.err
 
 
 def test_speculative_config_suffix_normalizes_to_legacy_suffix_args() -> None:

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -1109,7 +1109,7 @@ def _apply_mtp_cli_model_type_reconciliation(
     transient first-read failure (warm HF cache invalidated,
     filesystem hiccup, etc.), the first read returned ``None`` and
     the second read succeeded. The engine then treated the
-    operator's explicit ``--spec-decode mtp`` request as
+    operator's explicit MTP speculative-config request as
     "non-CLI-vetted" and soft-skipped dispatch failures — silently
     degrading MTP to a no-op.
 
@@ -1149,7 +1149,7 @@ def _apply_mtp_cli_model_type_reconciliation(
         # detector refactor ever relaxes that invariant, we MUST
         # hard-fail rather than boot in the silent-skip state.
         print(
-            "error: --spec-decode mtp eligibility passed but the CLI "
+            "error: MTP speculative-config eligibility passed but the CLI "
             "could not extract config.json::model_type — this is a "
             "plumbing skew between detect_mtp_eligibility (accepted "
             "the config) and this CLI reconciliation block. Refusing "
@@ -1579,8 +1579,12 @@ def _normalize_speculative_config_or_exit(args):
             args.suffix_min_draft_len = 2
 
     def _fill_mtp_defaults() -> None:
+        if not hasattr(args, "mtp_sidecar"):
+            args.mtp_sidecar = None
         if getattr(args, "mtp_max_k", None) is None:
             args.mtp_max_k = 3
+        if not hasattr(args, "mtp_disable_auto_k"):
+            args.mtp_disable_auto_k = False
 
     if raw_config is not None:
         try:
@@ -1615,6 +1619,8 @@ def _normalize_speculative_config_or_exit(args):
             conflicts.append("--enable-mtp")
         if getattr(args, "suffix_decoding", False) and config_method != "dflash":
             conflicts.append("--suffix-decoding")
+        if getattr(args, "no_spec_decode", False):
+            conflicts.append("--no-spec-decode")
         if getattr(args, "suffix_max_draft", None) is not None:
             conflicts.append("--suffix-max-draft")
         if getattr(args, "suffix_max_suffix_len", None) is not None:
@@ -1632,21 +1638,69 @@ def _normalize_speculative_config_or_exit(args):
                 file=sys.stderr,
             )
             sys.exit(2)
+    if raw_config is None and getattr(args, "no_spec_decode", False):
+        conflicts = []
+        if getattr(args, "enable_ddtree", False):
+            conflicts.append("--enable-ddtree")
+        if getattr(args, "enable_dflash", False):
+            conflicts.append("--enable-dflash")
+        spec_decode = getattr(args, "spec_decode", "none")
+        if spec_decode != "none":
+            conflicts.append(f"--spec-decode {spec_decode}")
+        if getattr(args, "enable_mtp", False):
+            conflicts.append("--enable-mtp")
+        if getattr(args, "suffix_decoding", False):
+            conflicts.append("--suffix-decoding")
+        if conflicts:
+            joined = ", ".join(conflicts)
+            print(
+                f"error: --no-spec-decode is mutually exclusive with {joined}.",
+                file=sys.stderr,
+            )
+            sys.exit(2)
+
+    if raw_config is None and getattr(args, "spec_decode", "none") == "mtp":
+        conflicts = []
+        if getattr(args, "enable_ddtree", False):
+            conflicts.append("--enable-ddtree")
+        if getattr(args, "enable_dflash", False):
+            conflicts.append("--enable-dflash")
+        if getattr(args, "enable_mtp", False):
+            conflicts.append("--enable-mtp")
+        if getattr(args, "suffix_decoding", False):
+            conflicts.append("--suffix-decoding")
+        if conflicts:
+            joined = ", ".join(conflicts)
+            print(
+                "error: --spec-decode mtp is mutually exclusive with "
+                f"{joined}; express speculative decoding settings inside "
+                "--speculative-config.",
+                file=sys.stderr,
+            )
+            sys.exit(2)
+
     if config is None:
+        if getattr(args, "spec_decode", "none") == "mtp":
+            print(
+                "warning: --spec-decode mtp is deprecated; use "
+                '--speculative-config \'{"method":"mtp"}\' instead.',
+                file=sys.stderr,
+            )
+            config = legacy_mtp_config(
+                model=(getattr(args, "mtp_sidecar", "") or "").strip() or None,
+                num_speculative_tokens=getattr(args, "mtp_max_k", None),
+                disable_auto_k=getattr(args, "mtp_disable_auto_k", None),
+            )
         try:
-            if getattr(args, "enable_ddtree", False):
+            if config is not None:
+                pass
+            elif getattr(args, "enable_ddtree", False):
                 config = legacy_ddtree_config()
             elif getattr(args, "enable_dflash", False) or (
                 getattr(args, "spec_decode", "none") == "dflash"
             ):
                 config = legacy_dflash_config(
                     (getattr(args, "dflash_drafter_path", "") or "").strip() or None
-                )
-            elif getattr(args, "spec_decode", "none") == "mtp":
-                config = legacy_mtp_config(
-                    model=(getattr(args, "mtp_sidecar", None) or "").strip() or None,
-                    num_speculative_tokens=getattr(args, "mtp_max_k", None),
-                    disable_auto_k=getattr(args, "mtp_disable_auto_k", False),
                 )
             elif getattr(args, "suffix_decoding", False):
                 config = legacy_suffix_config(
@@ -1673,8 +1727,7 @@ def _normalize_speculative_config_or_exit(args):
             args.spec_decode = "none"
     elif config.method == "mtp":
         args.spec_decode = "mtp"
-        if config.model:
-            args.mtp_sidecar = config.model
+        args.mtp_sidecar = config.model
         if config.num_speculative_tokens is not None:
             args.mtp_max_k = config.num_speculative_tokens
         if config.disable_auto_k is not None:
@@ -2805,16 +2858,13 @@ def serve_command(args):
         enable_mtp=args.enable_mtp,
         mtp_num_draft_tokens=args.mtp_num_draft_tokens,
         mtp_optimistic=args.mtp_optimistic,
-        # R15-P1 #302/#313: --spec-decode {none,mtp,dflash}. Plumb the
-        # raw choice through; the boot-time eligibility check below
-        # validates that ``mtp`` was only passed for a config.json with
-        # ``mtp_num_hidden_layers >= 1`` and ``dflash`` requires a
-        # Qwen3.5/3.6 model + a bound DFlash drafter.
+        # Speculative decoding selection. ``mtp`` is set internally by
+        # --speculative-config only; legacy --spec-decode remains limited
+        # to none/dflash.
         spec_decode=getattr(args, "spec_decode", "none"),
         dflash_drafter_path=getattr(args, "dflash_drafter_path", "") or "",
-        # Future external MTP sidecar path (currently reserved; Gemma 4
-        # assistant-sidecar MTP is disabled after lossless A/B failed).
-        # ``None`` is the "no sidecar; native-MTP path only" sentinel.
+        # Optional external MTP sidecar path. ``None`` is the "no
+        # sidecar; native-MTP path only" sentinel.
         mtp_sidecar=getattr(args, "mtp_sidecar", None),
         # 0.9.13 PR-A codex round-E blocker #2: CLI-resolved
         # ``config.json::model_type`` for the dispatch step. See the
@@ -2873,16 +2923,10 @@ def serve_command(args):
         print(f"Chunked prefill: {args.chunked_prefill_tokens} tokens per step")
     if args.enable_mtp:
         print(f"MTP: enabled, draft_tokens={args.mtp_num_draft_tokens}")
-    # R15-P1 #302: native Qwen3.5/3.6 MTP via vendored mlx-lm PR #990.
-    # Banner line + boot-time eligibility check fires here so misuse
-    # (--spec-decode mtp on a non-Qwen3.5/3.6 model) bounces with a
-    # clear error rather than discovering the mismatch when the first
-    # backbone forward pass raises ``AttributeError`` mid-generation.
-    #
-    # ``--mtp-sidecar <path>`` is currently a reserved compatibility
-    # surface for future assistant sidecars. It does not promote any
-    # model into eligibility; Qwen3.5/3.6 still needs
-    # ``mtp_num_hidden_layers >= 1`` on the base config.
+    # Native Qwen3.5/3.6 MTP via vendored mlx-lm PR #990. The
+    # config-only entrypoint is ``--speculative-config '{"method":"mtp"}'``.
+    # Boot-time eligibility check fires here so misuse bounces with a clear
+    # error instead of discovering the mismatch mid-generation.
     if getattr(args, "spec_decode", "none") == "mtp":
         from vllm_mlx.spec_decode.mtp import (
             MTPEligibility,
@@ -2903,18 +2947,18 @@ def serve_command(args):
         if eligibility is MTPEligibility.NONE:
             if has_sidecar:
                 print(
-                    "error: --spec-decode mtp currently requires a Qwen3.5 / "
+                    "error: MTP speculative-config requires either a Qwen3.5 / "
                     "Qwen3.6 checkpoint with mtp_num_hidden_layers >= 1 in "
-                    "config.json. --mtp-sidecar is reserved for future "
-                    "validated assistant sidecars and does not make this "
-                    "model eligible.",
+                    "config.json. Assistant sidecars are reserved for future "
+                    "validated support and do not make this model eligible.",
                     file=sys.stderr,
                 )
             else:
                 print(
-                    "error: --spec-decode mtp requires a Qwen3.5 / Qwen3.6 "
-                    "checkpoint with mtp_num_hidden_layers >= 1 in config.json. "
-                    "The loaded model does not qualify.",
+                    "error: MTP speculative-config requires a Qwen3.5 / "
+                    "Qwen3.6 checkpoint with mtp_num_hidden_layers >= 1 in "
+                    "config.json. Assistant sidecars are not currently "
+                    "supported. The loaded model does not qualify.",
                     file=sys.stderr,
                 )
             sys.exit(2)
@@ -2937,7 +2981,9 @@ def serve_command(args):
             logger=logger,
         )
 
-        sidecar_note = f" +sidecar={args.mtp_sidecar}" if has_sidecar else ""
+        sidecar_note = (
+            f" +sidecar={getattr(args, 'mtp_sidecar', None)}" if has_sidecar else ""
+        )
         print(f"Spec-decode: mtp ({eligibility.value}){sidecar_note}")
 
     # ``--spec-decode dflash`` is normalized to ``--enable-dflash`` near
@@ -6810,95 +6856,44 @@ Examples:
         help="Skip MTP acceptance check for maximum speed. "
         "~5-10%% wrong tokens. Best for chat, not for code.",
     )
-    # R15-P1 #302: native Qwen3.5/3.6 MTP via vendored mlx-lm PR #990.
-    # Lives next to the existing ``--enable-mtp`` (Qwen3-Next runtime
-    # injection) rather than replacing it because the two paths target
-    # DIFFERENT architectures — Qwen3-Next uses a hybrid Gated-DeltaNet
-    # + attention layout that the existing ``_install_mtp`` patches
-    # at the BatchGenerator level, while Qwen3.5/3.6 uses a
-    # GatedDeltaNet + MTP-head split that needs the PR #990
-    # ``mtp_generate_step`` loop (cache rollback, n_confirmed split,
-    # probabilistic acceptance). Coexistence keeps existing dogfood
-    # users on ``--enable-mtp`` working while the new path is opt-in.
-    #
-    # Default ``none`` because the lossless contract has not yet been
-    # verified end-to-end against a converted Qwen3.5/3.6 checkpoint
-    # (R15-P1 follow-up bench is GPU-contended with Stage B Viterbi
-    # conversion). The CLI rejects ``--spec-decode mtp`` at boot if
-    # the loaded model's ``config.json`` lacks
-    # ``mtp_num_hidden_layers >= 1`` so an operator who passes the
-    # flag against a non-eligible model sees a clear error rather
-    # than silent fallback.
-    serve_parser.add_argument(
-        "--spec-decode",
-        dest="spec_decode",
-        choices=["none", "mtp", "dflash"],
-        default="none",
-        help=(
-            "Compatibility selector for model-side speculative decode; "
-            "prefer --speculative-config for new usage. "
-            "``none`` (default) disables; ``mtp`` enables Qwen3.5/3.6 "
-            "native MTP via vendored mlx-lm PR #990 — requires a "
-            "checkpoint converted with the PR #990 sanitize() path "
-            "that preserves ``mtp.*`` weights; ``dflash`` enables the "
-            "block-diffusion drafter from arxiv 2410.04097 (R15-P1 "
-            "#313) for Qwen3.5/3.6 with a bound drafter (default "
-            "block size 16). Rejects at boot if the model doesn't "
-            "qualify so misuse fails loud."
-        ),
-    )
-    # Compatibility surface for future external MTP assistant sidecars.
-    # Gemma 4 assistant-sidecar MTP is currently disabled after July 2026
-    # greedy-lossless A/B failed; Qwen3.5/3.6 native MTP does not use a
-    # sidecar because its head is baked into the target checkpoint via
-    # mlx-lm PR #990's sanitize() pass.
     serve_parser.add_argument(
         "--mtp-sidecar",
         dest="mtp_sidecar",
         default=None,
-        help=(
-            "Reserved path/repo id for future validated MTP assistant "
-            "sidecars. Prefer "
-            '--speculative-config \'{"method":"mtp","model":...}\' '
-            "for new usage. Gemma 4 assistant-sidecar MTP is currently "
-            "disabled after greedy-lossless validation failed; ignored for "
-            "the Qwen3.5/3.6 native-MTP path because their head is baked "
-            "into the target. "
-            "Requires the [mtp] install extra."
-        ),
+        help=argparse.SUPPRESS,
     )
-    # 0.9.13 PR-B: Ollama-style EV depth controller knobs. The controller
-    # picks K ∈ {0..max_k} per round via ``argmax_K committed(K)/cost(K)``,
-    # persisting cost + acceptance state across requests (per-model).
-    # K=0 "parks" — plain decode, no drafter — which fixes the prose
-    # slowdown from PR-A K=1 (drafter cost dominates on low-accept content).
     serve_parser.add_argument(
         "--mtp-max-k",
         dest="mtp_max_k",
         type=int,
         default=None,
-        help=(
-            "Hard ceiling on the per-round draft depth the EV controller "
-            "may select (default: 3). The current generator implements "
-            "K∈{0,1} (park + chain-of-1); values >1 are effectively "
-            "clamped until chain-of-K verify lands. Prefer "
-            '--speculative-config \'{"method":"mtp",'
-            '"num_speculative_tokens":3}\' for new usage. Only consulted '
-            "when MTP spec-decode is set."
-        ),
+        help=argparse.SUPPRESS,
     )
     serve_parser.add_argument(
         "--mtp-disable-auto-k",
         dest="mtp_disable_auto_k",
         action="store_true",
         default=False,
+        help=argparse.SUPPRESS,
+    )
+    # Compatibility selector kept for older public shorthands.
+    # ``mtp`` is accepted as a deprecated hidden choice and normalized to
+    # ``--speculative-config '{"method":"mtp"}'``. Keep help focused on
+    # the non-deprecated values via ``metavar``.
+    serve_parser.add_argument(
+        "--spec-decode",
+        dest="spec_decode",
+        choices=["none", "dflash", "mtp"],
+        metavar="{none,dflash}",
+        default="none",
         help=(
-            "Disable the EV depth controller and keep the pre-PR-B "
-            "fixed-K=1 chain-of-1 MTP behavior. Used to A/B bench the "
-            "controller against the fixed-K=1 baseline. Prefer "
-            '--speculative-config \'{"method":"mtp",'
-            '"disable_auto_k":true}\' for new usage. Only consulted '
-            "when MTP spec-decode is set."
+            "Compatibility selector for model-side speculative decode; "
+            "prefer --speculative-config for new usage. "
+            "``none`` (default) disables; ``dflash`` enables the "
+            "block-diffusion drafter from arxiv 2410.04097 (R15-P1 "
+            "#313) for Qwen3.5/3.6 with a bound drafter (default "
+            "block size 16). DFlash validates its model/drafter pair "
+            "at boot so misuse fails loud."
         ),
     )
     # R15-P1 #313: DFlash drafter HF path override. Empty by default

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -100,7 +100,7 @@ def _resolve_hf_model_type(model_name: str) -> str | None:
 # into ``False`` and the caller then hard-raised on ``False``. That
 # turned a benign transient resolution failure — the CLI had already
 # vetted the config on the asyncio thread — into a boot abort in
-# offline environments that used to work under ``--spec-decode mtp``.
+# offline environments that used to work under MTP speculative config.
 # Splitting the return keeps the fail-loud contract for
 # operator-facing errors (family injector actively rejected) while
 # preserving the fail-soft contract for pipeline plumbing hiccups
@@ -147,7 +147,7 @@ def _run_dispatch_mtp_inject(
     * :data:`_DISPATCH_REJECTED` — the family injector was invoked and
       returned ``False`` (missing sidecar, loader failure, weight
       shape mismatch, etc.). Hard-fail: the operator explicitly asked
-      for ``--spec-decode mtp`` on a valid target and the injector
+      for MTP speculative config on a valid target and the injector
       couldn't attach. Caller should abort boot rather than boot with
       MTP silently disabled.
 
@@ -166,7 +166,7 @@ def _run_dispatch_mtp_inject(
     if model_type is None:
         logger.warning(
             "[MTP-vendored] could not resolve model_type for %r; skipping "
-            "dispatch_mtp_inject. --spec-decode mtp will be a no-op on "
+            "dispatch_mtp_inject. MTP speculative config will be a no-op on "
             "this boot.",
             model_name,
         )
@@ -199,7 +199,7 @@ def _run_dispatch_mtp_inject(
     logger.warning(
         "[MTP-vendored] dispatch_mtp_inject returned False for "
         "model_type=%r sidecar=%r; family injector rejected. "
-        "--spec-decode mtp will be a hard-fail at boot.",
+        "MTP speculative config will be a hard-fail at boot.",
         model_type,
         mtp_sidecar,
     )
@@ -209,8 +209,8 @@ def _run_dispatch_mtp_inject(
 # Codex round-G BLOCKING #3: hard cap on the executor-side MTP
 # dispatch call. Sidecar loads that touch HF Hub / large safetensor
 # reads can wedge on a slow network or a stuck DNS lookup; without a
-# timeout, ``rapid-mlx serve --spec-decode mtp --mtp-sidecar
-# <hf-repo>`` boot can block indefinitely. Default 600s covers slow
+# timeout, ``rapid-mlx serve --speculative-config '{"method":"mtp",
+# "model":"<hf-repo>"}'`` boot can block indefinitely. Default 600s covers slow
 # 4-16GB assistant downloads on a typical residential connection; an
 # ops override lives at ``RAPID_MLX_MTP_DISPATCH_TIMEOUT_SEC`` for
 # corp networks with mandatory proxies. Set to ``0`` to opt out of
@@ -339,29 +339,29 @@ def _decide_mtp_dispatch_action(
     if dispatch_result == _DISPATCH_REJECTED:
         return (
             "raise",
-            "--spec-decode mtp was set but the family MTP "
+            "MTP speculative-config was set but the family MTP "
             "injector rejected the model. See preceding "
             "warnings for the specific failure (typical causes: "
             "MTP weights missing from the target checkpoint, "
             "unsupported model_type, sidecar path unreachable, or "
             "assistant checkpoint model_type mismatch). Refusing to "
-            "boot with MTP silently disabled — pass "
-            "--spec-decode none to continue without MTP.",
+            "boot with MTP silently disabled — remove "
+            "--speculative-config to continue without MTP.",
         )
 
     _cli_vetted = cli_vetted_model_type is not None
     if _cli_vetted:
         return (
             "raise",
-            f"--spec-decode mtp was set and the CLI vetted "
+            f"MTP speculative-config was set and the CLI vetted "
             f"model_type={cli_vetted_model_type!r}, but the engine "
             f"could not attach the MTP protocol "
             f"(dispatch_result={dispatch_result!r}). This "
             "indicates a plumbing skew between the CLI "
             "eligibility gate and the engine's dispatch "
             "table — not an environment race. Refusing to "
-            "boot with MTP silently disabled — pass "
-            "--spec-decode none to continue without MTP, "
+            "boot with MTP silently disabled — remove "
+            "--speculative-config to continue without MTP, "
             "or file an issue with the model_type + engine "
             "version.",
         )
@@ -435,7 +435,7 @@ def _apply_mtp_dispatch(
         # tries to continue. Leave the executor untouched.
         _log_mtp_dispatch_timeout(timeout)
         raise RuntimeError(
-            "--spec-decode mtp dispatch timed out after "
+            "MTP speculative-config dispatch timed out after "
             f"{timeout:.0f}s. Typical causes: HF Hub outage on the "
             "sidecar path, corp proxy blocking huggingface.co, or "
             "a very large assistant checkpoint on a slow link. "

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -1438,11 +1438,20 @@ def _install_mtp_vendored(
         )
         return False
 
-    if not (
-        hasattr(model, "mtp_forward")
-        and hasattr(model, "make_mtp_cache")
-        and hasattr(model, "mtp")
-    ):
+    def _has_mtp_surface(candidate: Any) -> bool:
+        return (
+            hasattr(candidate, "mtp_forward")
+            and hasattr(candidate, "make_mtp_cache")
+            and hasattr(candidate, "mtp")
+        )
+
+    mtp_model = model
+    if not _has_mtp_surface(mtp_model):
+        inner = getattr(model, "language_model", None)
+        if inner is not None and _has_mtp_surface(inner):
+            mtp_model = inner
+
+    if not _has_mtp_surface(mtp_model):
         logger.warning(
             "[MTP-vendored] disabled: model lacks mtp_forward / make_mtp_cache / "
             "mtp attributes — dispatch_mtp_inject did not run or returned False. "
@@ -1975,12 +1984,12 @@ def _install_mtp_vendored(
             try:
                 gen = mtp_generate_step(
                     prompt=first_tok_arr.astype(mx.uint32),
-                    model=model,
+                    model=mtp_model,
                     max_tokens=gen_max,
                     prompt_cache=gb.prompt_cache,
                     temp=0.0,
                     # 0.9.13 PR-B: EV depth controller.
-                    model_id=controller_key or f"mtp-model-{id(model)}",
+                    model_id=controller_key or f"mtp-model-{id(mtp_model)}",
                     max_k=max_k,
                     disable_auto_k=disable_auto_k,
                     # 0.9.13 PR-C: EOS holdout — feed the
@@ -2178,6 +2187,19 @@ def _install_mtp_vendored(
         "non-greedy / logits-processors)."
     )
     return True
+
+
+def _config_vetted_mtp_supports_spec_decode(model_type: str | None) -> bool:
+    """Return True for model types that passed config-driven MTP eligibility.
+
+    Some older alias profiles still carry ``supports_spec_decode=False`` even
+    when the checkpoint config advertises a Qwen MTP head. The CLI promotes the
+    eligibility gate's model_type into SchedulerConfig only after
+    ``detect_mtp_eligibility`` accepts the config; keep the scheduler override
+    narrowly tied to the model families this MTP runtime supports.
+    """
+
+    return model_type in {"qwen3_5", "qwen3_5_moe"}
 
 
 def _install_suffix_decoding(
@@ -3332,13 +3354,19 @@ class Scheduler:
         # (``feat/mtp-ev-controller-0.9.13``); batched residual+bonus
         # sync lands in PR-C (``feat/mtp-batched-sync-0.9.14``).
         if getattr(self.config, "spec_decode", "none") == "mtp":
+            mtp_model_type = getattr(self.config, "mtp_model_type", None)
+            config_vetted_mtp = _config_vetted_mtp_supports_spec_decode(mtp_model_type)
             if (
                 getattr(self, "model_config", None) is not None
                 and not self.model_config.supports_spec_decode
+                and not config_vetted_mtp
             ):
                 logger.warning(
-                    "[MTP-vendored] --spec-decode mtp requested but profile "
-                    "says supports_spec_decode=False. MTP will be disabled."
+                    "[MTP-vendored] MTP speculative-config requested but "
+                    "profile says supports_spec_decode=False and "
+                    "model_type=%r is not in the config-vetted MTP allowlist. "
+                    "MTP will be disabled.",
+                    mtp_model_type,
                 )
             else:
                 _install_mtp_vendored(

--- a/vllm_mlx/spec_decode/mtp/detect.py
+++ b/vllm_mlx/spec_decode/mtp/detect.py
@@ -12,7 +12,10 @@ Detection lives off the loaded ``config.json`` dict rather than the
 * The ``mtp_num_hidden_layers`` value is an intrinsic property of the
   checkpoint, not of the alias. A user passing a raw HF path like
   ``Qwen/Qwen3.5-27B`` should still get MTP eligibility without us
-  having to ship an alias for every Qwen3.5 / Qwen3.6 quant.
+  having to ship an alias for every Qwen3.5 / Qwen3.6 quant. MLX
+  community Qwen3.5 / Qwen3.6 configs currently carry the value under
+  ``text_config.mtp_num_hidden_layers``; hand-converted configs may put
+  it at the root. Detection accepts both shapes.
 * ``model_type`` is already populated on every HF config and is the
   canonical anchor mlx-lm itself uses to route to a model class — we
   just piggyback on it.
@@ -62,11 +65,6 @@ class MTPEligibility(str, enum.Enum):
 # - ``qwen3_5_moe`` — MoE variant; subclasses the dense model and routes
 #                     through the same MTP path.
 #
-# Gemma 4 assistant-sidecar MTP is intentionally not advertised here. July
-# 2026 A/B validation against ``mlx-community/gemma-4-12B-it-4bit`` +
-# ``google/gemma-4-12B-it-assistant`` showed greedy output divergence under
-# the server path. Keep Gemma closed until an end-to-end lossless + perf
-# validation proves otherwise.
 _SUPPORTED_MODEL_TYPES: frozenset[str] = frozenset(
     {
         # Qwen3.5 / Qwen3.6 (upstream PR #990)
@@ -108,6 +106,18 @@ def _safe_int(value: Any, default: int = 0) -> int:
             return default
 
 
+def _mtp_num_hidden_layers(config: dict[str, Any]) -> int:
+    """Return MTP layer count from root or nested text_config metadata."""
+
+    root_layers = _safe_int(config.get("mtp_num_hidden_layers"), 0)
+    if root_layers > 0:
+        return root_layers
+    text_config = config.get("text_config")
+    if isinstance(text_config, dict):
+        return _safe_int(text_config.get("mtp_num_hidden_layers"), 0)
+    return root_layers
+
+
 def detect_mtp_eligibility(
     config: dict[str, Any] | None,
     *,
@@ -123,10 +133,10 @@ def detect_mtp_eligibility(
         has_external_sidecar: Accepted for compatibility with the
             legacy CLI flag surface, but currently does not promote any
             architecture. Qwen3.5 / Qwen3.6 eligibility requires
-            ``mtp_num_hidden_layers >= 1`` in the base config because
-            their MTP head is part of the target checkpoint. Gemma 4
-            sidecar promotion is disabled until it passes end-to-end
-            greedy-lossless validation.
+            ``mtp_num_hidden_layers >= 1`` in the base config
+            (root or ``text_config``) because their MTP head is part of
+            the target checkpoint. Gemma 4 sidecar promotion remains
+            disabled until it passes end-to-end greedy-lossless validation.
 
     Returns:
         :class:`MTPEligibility` value. Detection is conservative — any
@@ -169,7 +179,7 @@ def _detect_mtp_eligibility_verbose(
         )
 
     _ = has_external_sidecar
-    num_mtp_layers = _safe_int(config.get("mtp_num_hidden_layers"), 0)
+    num_mtp_layers = _mtp_num_hidden_layers(config)
     if num_mtp_layers <= 0:
         # MTP-capable model_type but MTP weights not present on this
         # checkpoint. For Qwen3.5 / Qwen3.6 this is a stripped convert —

--- a/vllm_mlx/spec_decode/mtp/dispatch.py
+++ b/vllm_mlx/spec_decode/mtp/dispatch.py
@@ -21,8 +21,8 @@ Adding a new architecture
 2. Add the ``model_type`` string(s) to :data:`_MTP_INJECT_DISPATCH`
    below, mapping to the module path + entry function name.
 3. Add the ``model_type`` to ``detect._SUPPORTED_MODEL_TYPES`` so the
-   CLI can advertise ``--spec-decode mtp`` for that architecture at
-   parse time.
+   CLI can accept ``--speculative-config '{"method":"mtp"}'`` for that
+   architecture at parse time.
 
 All three steps are strictly additive — existing architectures keep
 their current call sites.

--- a/vllm_mlx/spec_decode/registry.py
+++ b/vllm_mlx/spec_decode/registry.py
@@ -84,10 +84,7 @@ register_spec_decoder(
         method="mtp",
         description="Model-side multi-token prediction head",
         config_enabled=True,
-        legacy_hint=(
-            'prefer --speculative-config \'{"method":"mtp"}\'; '
-            "legacy --spec-decode mtp remains supported"
-        ),
+        legacy_hint='use --speculative-config \'{"method":"mtp"}\'',
     )
 )
 register_spec_decoder(


### PR DESCRIPTION
## Summary

Migrates MTP configuration to the vLLM-style `--speculative-config` interface while keeping a deprecated hidden compatibility path for older `--spec-decode mtp` users:

- Preferred MTP entrypoint is now `--speculative-config '{"method":"mtp"}'`.
- `--spec-decode mtp` remains accepted as a deprecated hidden shorthand and normalizes to the same config path; it is not shown in help.
- Kept legacy MTP sidecar/tuning shorthands as hidden deprecated parser flags (`--mtp-sidecar`, `--mtp-max-k`, `--mtp-disable-auto-k`) and normalize them into the config path; they are no longer shown in help.
- MTP still routes internally through `SchedulerConfig.spec_decode="mtp"` once normalized.
- Server-side MTP install resolves the real target from `model.language_model`, fixing the Qwen wrapper no-op path.
- Qwen MTP eligibility accepts `text_config.mtp_num_hidden_layers`, matching current MLX community Qwen3.5/3.6 configs.
- Gemma4 assistant-sidecar remains fail-closed; real-weight drill shows speedup is possible but greedy no-spec lossless is not satisfied.

## Validation

Latest local checks:

```bash
PATH=/opt/homebrew/bin:$PATH .venv/bin/python -m scripts.pr_validate.pr_validate 1044 --skip-steps stress_e2e_bench
# MERGE-SAFE
# codex_review: PASS, codex found no blocking issues
# lint: PASS
# full_unit: PASS, 12128 passed, 34 skipped, 17 deselected, 6 xfailed, 1 xpassed

PATH=/opt/homebrew/bin:$PATH uv run --python 3.11 ruff check .
# All checks passed

PATH=/opt/homebrew/bin:$PATH uv run --python 3.11 pytest \
  tests/test_dflash_integration.py::test_enable_dflash_legacy_mix_rejects_spec_decode_mtp \
  tests/test_speculative_config.py \
  tests/test_mtp_cli_wiring.py \
  tests/test_mtp_spec_decode.py \
  tests/test_mtp_gemma4_assistant_inject.py -q
# 203 passed

PATH=/opt/homebrew/bin:$PATH uv run --python 3.11 pytest tests/ \
  --ignore=tests/integrations --ignore=tests/test_event_loop.py -q --no-header
# 12128 passed, 34 skipped, 17 deselected, 6 xfailed, 1 xpassed
```

Qwen3.5 real-weight E2E (M3 Ultra, `mlx-community/Qwen3.5-9B-4bit` + `mlx-community/Qwen3.5-9B-MTP-4bit`, greedy, fixed K=1):

| Run | Prompt | Correctness | MTP metrics | Throughput |
| --- | --- | --- | --- | --- |
| Legacy pre-migration `--spec-decode mtp --mtp-sidecar ...` | 96-token code | saved output for A/B | attempts=49, accepts=45, accept_ratio=0.9184 | 91.7 tok/s |
| Config post-migration | same 96-token code | byte-equal to legacy | attempts=49, accepts=45, accept_ratio=0.9184 | 93.0 tok/s |
| No-spec baseline | same 96-token code | byte-equal to config | n/a | 91.4 tok/s |
| No-spec baseline | 256-token code | baseline hash `5d108a...` | n/a | 99.6 tok/s |
| Config post-migration | same 256-token code | byte-equal to no-spec | attempts=133, accepts=121, accept_ratio=0.9098 | 101.5-103.7 tok/s |

Gemma4 real-weight drill, not enabled in this PR:

- Target/assistant: `mlx-community/gemma-4-12B-it-4bit` + `google/gemma-4-12B-it-assistant`.
- The assistant sidecar loads and injects successfully in a local probe.
- First-token/first-draft logits check passes: target `q_len=1` vs verify-window `q_len=2` matched at the first verify position; assistant first draft was accepted.
- 64-token direct E2E: byte-equal, MTP 68.4 tok/s vs no-spec 56.8 tok/s.
- 128-token direct E2E: not byte-equal; first diff at generated token 114; MTP 68.5 tok/s vs no-spec 59.3 tok/s.
- 512-token direct E2E: not byte-equal; first diff at generated token 114; MTP 69.4 tok/s vs no-spec 60.1 tok/s.
- Root-cause probe around the first diff: token 113 was an accepted draft, token 114 was the target bonus. The target bonus under the spec chunking path (`[current, accepted_draft]`) diverged from the no-spec one-token decode path at that context. So Gemma4 assistant MTP has usable throughput, but the current chunked verify/cache contract is not lossless.
- Current PR fail-closed server check:

```bash
PYTHONPATH=$PWD uv run rapid-mlx serve mlx-community/gemma-4-12B-it-4bit \
  --port 8127 \
  --speculative-config '{"method":"mtp","model":"google/gemma-4-12B-it-assistant","num_speculative_tokens":1,"disable_auto_k":true}'
# exits 2 before model serving:
# error: MTP speculative-config requires either a Qwen3.5 / Qwen3.6 checkpoint with mtp_num_hidden_layers >= 1 in config.json. Assistant sidecars are reserved for future validated support and do not make this model eligible.
```


Old-vs-new Gemma4 behavior check (direct experimental path, server gate bypassed):

- Old code: commit `5a93d06` (`#1044` parent).
- New code: commit `5f17f91` (`#1044` head).
- Same script imported `gemma4_inject.inject_mtp_support` + `mtp_generate_step` directly on both commits, using `mlx-community/gemma-4-12B-it-4bit` + `google/gemma-4-12B-it-assistant`, greedy, fixed K=1, 128 generated tokens.
- Machine comparison excluding wall-clock rates: `target_first_probe MATCH`, `assistant_first_draft_probe MATCH`, `e2e_compare MATCH`.
- Both old and new direct paths diverge from no-spec at generated token 114 with the same token window: no-spec `Python`, MTP target bonus `` ` ``. This confirms #1044 did not introduce the Gemma4 lossless failure; the migration preserves the prior experimental behavior.
- Server gate behavior is also equivalent: old `--spec-decode mtp --mtp-sidecar ...` exits 2 for Gemma4, new hidden legacy compat flags exit 2 as well (new path additionally emits the expected deprecation warning).


Final old-vs-new inference behavior check (2026-07-07):

- Old code: commit `5a93d06` (`#1044` parent).
- New code: commit `5f17f91` (`#1044` head).
- Same probe script, same prompt, greedy, fixed K=1, 128 generated tokens.
- Qwen target/sidecar: `mlx-community/Qwen3.5-9B-4bit` + `mlx-community/Qwen3.5-9B-MTP-4bit`.
- Gemma target/assistant: `mlx-community/gemma-4-12B-it-4bit` + `google/gemma-4-12B-it-assistant`.
- Machine comparison excluding wall-clock throughput: `overall_behavior_match True`, 12/12 events matched.
- Qwen no-spec old/new hash: `02f83c13b53d3435`.
- Qwen MTP old/new hash: `02f83c13b53d3435`; equals no-spec; `draft_tokens=60`; `first_diff_index=null`.
- Gemma no-spec old/new hash: `ca008a94f1a5a308`.
- Gemma experimental MTP old/new hash: `350dfd78212e7e4b`; both diverge from no-spec at generated token 114 with the same diff window (`Python` vs `` ` `` target bonus); `draft_tokens=57`.
- This confirms #1044 preserves Qwen and Gemma inference behavior. The Gemma MTP lossless failure predates this migration and remains fail-closed at the server gate.

Disk hygiene:

- Removed task-scoped HF caches for Qwen/Gemma base and sidecar repos after E2E.
- Re-cleaned Gemma4 target/assistant caches after the follow-up drill.


