### PR TITLE
fix(jlens): route model weights through R2 mirror before falling back to HF

### DIFF
--- a/tests/test_cli_jlens.py
+++ b/tests/test_cli_jlens.py
@@ -249,3 +249,151 @@ def test_jlens_command_rejects_nonpositive_step_before_loading() -> None:
     assert exc.value.code == 2
     assert "--step must be a positive integer" in buf.getvalue()
     loader.assert_not_called()  # must fail before loading weights
+
+
+# --- R2 mirror routing (bug fix: jlens was bypassing the mirror) ------------
+def test_prefetch_via_mirror_skips_local_paths(tmp_path) -> None:
+    """Existing local dirs / arbitrary strings must not hit the mirror."""
+    from unittest.mock import MagicMock
+
+    fake = MagicMock(return_value=True)
+    with patch("vllm_mlx._mirror.download_with_mirror_fallback", fake):
+        # Existing local directory — bypass mirror entirely.
+        assert jlens._prefetch_via_mirror(str(tmp_path)) is False
+        # No slash → not an HF-style ``owner/name`` id.
+        assert jlens._prefetch_via_mirror("not-a-repo-id") is False
+        # Empty path — degenerate.
+        assert jlens._prefetch_via_mirror("") is False
+    fake.assert_not_called()
+
+
+def test_prefetch_via_mirror_prefers_mirror_for_hf_repos() -> None:
+    """A ``mlx-community/Foo`` id must be handed to the mirror before HF."""
+    from unittest.mock import MagicMock
+
+    fake = MagicMock(return_value=True)
+    with patch("vllm_mlx._mirror.download_with_mirror_fallback", fake):
+        assert jlens._prefetch_via_mirror("mlx-community/Qwen3-1.7B-4bit") is True
+    fake.assert_called_once_with("mlx-community/Qwen3-1.7B-4bit")
+
+
+def test_prefetch_via_mirror_falls_back_when_mirror_misses() -> None:
+    """A mirror miss (return False) must not fail the call — mlx_lm.load
+    will complete the pull via HF. Mirrors observed returning False in
+    production: catalog says ``not yet mirrored``, per-file 404, or
+    catalog outage on a custom mirror."""
+    from unittest.mock import MagicMock
+
+    fake = MagicMock(return_value=False)
+    with patch("vllm_mlx._mirror.download_with_mirror_fallback", fake):
+        assert jlens._prefetch_via_mirror("mlx-community/UnmirroredModel") is False
+    fake.assert_called_once_with("mlx-community/UnmirroredModel")
+
+
+def test_prefetch_via_mirror_swallows_unexpected_exceptions() -> None:
+    """A raised mirror error must NOT bubble up — the mirror is a UX
+    optimization, not a correctness dependency. jlens still runs; the
+    ensuing ``mlx_lm.load`` handles the pull via HF."""
+    from unittest.mock import MagicMock
+
+    fake = MagicMock(side_effect=RuntimeError("boom"))
+    with patch("vllm_mlx._mirror.download_with_mirror_fallback", fake):
+        # Must return False and not raise.
+        assert jlens._prefetch_via_mirror("mlx-community/Qwen3-1.7B-4bit") is False
+
+
+def _install_fake_mlx_lm(fake_load) -> object:
+    """Patch ``sys.modules`` so ``from mlx_lm import load`` binds our fake.
+
+    Returns a ModuleType we've registered as ``mlx_lm`` with a single
+    ``load`` attribute pointing at ``fake_load``. Tests use this to
+    intercept ``jlens._load_model``'s deferred import without touching
+    the real mlx_lm — the real one loads native MLX runtime state that
+    doesn't survive being clobbered by mid-test module replacement.
+    """
+    import types
+
+    fake_mod = types.ModuleType("mlx_lm")
+    fake_mod.load = fake_load
+    return fake_mod
+
+
+def test_load_model_prefetches_via_mirror_before_hf() -> None:
+    """The concrete fix: ``_load_model`` must give the mirror first crack
+    at the download before ``mlx_lm.load`` runs its own
+    ``snapshot_download``. Otherwise a fresh install jlens invocation
+    fetches directly from HF (the regression reported on 0.10.2)."""
+    from unittest.mock import MagicMock, call
+
+    order: list[str] = []
+
+    def _mirror_side_effect(name):
+        order.append(f"mirror:{name}")
+        return True  # simulate the mirror hydrating the HF cache
+
+    def _load_side_effect(name):
+        order.append(f"mlx_lm.load:{name}")
+        return (object(), object())
+
+    fake_mirror = MagicMock(side_effect=_mirror_side_effect)
+    fake_load = MagicMock(side_effect=_load_side_effect)
+    fake_compat = MagicMock()
+
+    with (
+        patch("vllm_mlx._mirror.download_with_mirror_fallback", fake_mirror),
+        patch("vllm_mlx._mlx_compat.install", fake_compat),
+        patch.dict(sys.modules, {"mlx_lm": _install_fake_mlx_lm(fake_load)}),
+    ):
+        jlens._load_model("mlx-community/Qwen3-1.7B-4bit")
+
+    # 1) Mirror was consulted, 2) before mlx_lm.load ran, 3) with the
+    # SAME model id — no accidental alias re-resolution or mangling.
+    assert order == [
+        "mirror:mlx-community/Qwen3-1.7B-4bit",
+        "mlx_lm.load:mlx-community/Qwen3-1.7B-4bit",
+    ]
+    fake_mirror.assert_has_calls([call("mlx-community/Qwen3-1.7B-4bit")])
+    fake_load.assert_called_once_with("mlx-community/Qwen3-1.7B-4bit")
+
+
+def test_load_model_still_runs_when_mirror_returns_404() -> None:
+    """When the mirror can't serve the model (catalog says ``not mirrored``
+    or per-file 404), ``_load_model`` must proceed to ``mlx_lm.load``,
+    which will complete the pull via HuggingFace. This is the graceful-
+    degradation contract."""
+    from unittest.mock import MagicMock
+
+    fake_mirror = MagicMock(return_value=False)  # simulate mirror miss
+    fake_load = MagicMock(return_value=(object(), object()))
+    fake_compat = MagicMock()
+
+    with (
+        patch("vllm_mlx._mirror.download_with_mirror_fallback", fake_mirror),
+        patch("vllm_mlx._mlx_compat.install", fake_compat),
+        patch.dict(sys.modules, {"mlx_lm": _install_fake_mlx_lm(fake_load)}),
+    ):
+        jlens._load_model("mlx-community/UnmirroredModel")
+
+    fake_mirror.assert_called_once_with("mlx-community/UnmirroredModel")
+    # mlx_lm.load STILL runs — it will drive its own snapshot_download.
+    fake_load.assert_called_once_with("mlx-community/UnmirroredModel")
+
+
+def test_load_model_skips_mirror_for_local_paths(tmp_path) -> None:
+    """A user pointing jlens at a local directory (``rapid-mlx jlens -m
+    ~/models/foo ...``) must not incur a mirror round-trip."""
+    from unittest.mock import MagicMock
+
+    fake_mirror = MagicMock(return_value=True)
+    fake_load = MagicMock(return_value=(object(), object()))
+    fake_compat = MagicMock()
+
+    with (
+        patch("vllm_mlx._mirror.download_with_mirror_fallback", fake_mirror),
+        patch("vllm_mlx._mlx_compat.install", fake_compat),
+        patch.dict(sys.modules, {"mlx_lm": _install_fake_mlx_lm(fake_load)}),
+    ):
+        jlens._load_model(str(tmp_path))
+
+    fake_mirror.assert_not_called()
+    fake_load.assert_called_once_with(str(tmp_path))

--- a/tests/test_cli_jlens.py
+++ b/tests/test_cli_jlens.py
@@ -267,6 +267,27 @@ def test_prefetch_via_mirror_skips_local_paths(tmp_path) -> None:
     fake.assert_not_called()
 
 
+def test_looks_like_hf_repo_id_rejects_non_hf_shapes() -> None:
+    """The tightened heuristic — HF ids are exactly ``owner/name``. Codex
+    nit on PR #1045: without this, ``./missing/model``, ``/tmp/model``,
+    ``foo/bar/baz`` and URLs would each incur a wasted
+    ``download_with_mirror_fallback`` → ``model_info`` HF round-trip
+    before ``mlx_lm.load`` had a chance to reject them locally."""
+    # Positive cases — canonical HF ids.
+    assert jlens._looks_like_hf_repo_id("mlx-community/Qwen3-1.7B-4bit")
+    assert jlens._looks_like_hf_repo_id("meta-llama/Llama-3.1-8B")
+    # Negative cases — everything else.
+    assert not jlens._looks_like_hf_repo_id("")
+    assert not jlens._looks_like_hf_repo_id("qwen3-1.7b")  # no slash
+    assert not jlens._looks_like_hf_repo_id("foo/bar/baz")  # too many parts
+    assert not jlens._looks_like_hf_repo_id("/tmp/model")  # absolute path
+    assert not jlens._looks_like_hf_repo_id("./missing/model")  # relative path
+    assert not jlens._looks_like_hf_repo_id("~/models/foo")  # home-relative
+    assert not jlens._looks_like_hf_repo_id("https://hf.co/mlx-community/X")
+    assert not jlens._looks_like_hf_repo_id("/only-name")  # empty owner
+    assert not jlens._looks_like_hf_repo_id("only-owner/")  # empty name
+
+
 def test_prefetch_via_mirror_prefers_mirror_for_hf_repos() -> None:
     """A ``mlx-community/Foo`` id must be handed to the mirror before HF."""
     from unittest.mock import MagicMock

--- a/vllm_mlx/jlens.py
+++ b/vllm_mlx/jlens.py
@@ -47,12 +47,62 @@ class UnsupportedArchitectureError(Exception):
     """Raised when a model's architecture is not (yet) J-lens compatible."""
 
 
+def _prefetch_via_mirror(model_path: str) -> bool:
+    """R2-first prefetch for HF-style repos; no-op otherwise.
+
+    Every other rapid-mlx command that materializes weights (``serve``,
+    ``chat``, ``pull``, ``bench``) routes the initial download through
+    :func:`vllm_mlx._mirror.download_with_mirror_fallback` so users get
+    the R2 mirror (edge-cached, resumable, no HF rate limits) with a
+    per-file HF fallback. ``jlens`` bypassed that pipeline in PR #1039
+    and went straight to ``mlx_lm.load`` → ``snapshot_download``, so a
+    first-time ``rapid-mlx jlens qwen3-1.7b "..."`` pulled every shard
+    from HuggingFace directly. This helper closes that gap while
+    preserving mlx_lm.load's own fallback:
+
+    * If ``model_path`` is a local directory / non-repo path / disabled
+      mirror, we no-op and mlx_lm.load handles it.
+    * If the mirror hydrates the HF cache (returns True), ``mlx_lm.load``
+      sees a warm cache and never hits HuggingFace.
+    * If the mirror returns False / raises (catalog outage, per-file
+      miss, mirror module unavailable), mlx_lm.load's own
+      ``snapshot_download`` completes the pull from HF. This is the
+      same graceful-degradation contract ``_ensure_model_downloaded``
+      relies on in cli.py.
+
+    Best-effort: any exception here is swallowed — the mirror is a UX
+    optimization, not a correctness dependency for ``jlens``.
+    """
+    if not model_path or "/" not in model_path or os.path.exists(model_path):
+        return False
+    try:
+        from ._mirror import download_with_mirror_fallback
+    except ImportError:
+        # Minimal-deps install without the mirror module — fall through
+        # to plain HF via mlx_lm.load.
+        return False
+    try:
+        return bool(download_with_mirror_fallback(model_path))
+    except Exception:
+        # Any unexpected mirror failure is treated as "let mlx_lm.load
+        # handle it via HF". Don't fail the whole jlens invocation over
+        # a mirror hiccup.
+        return False
+
+
 def _load_model(model_path: str):
     """Load an mlx_lm model, installing the MLX hardware-compat shim first."""
     # The shim must run before ``from mlx_lm import load`` (see cli.py / #404).
     from . import _mlx_compat
 
     _mlx_compat.install()
+
+    # Route HF-style repos through the R2 mirror before mlx_lm.load runs
+    # its own ``snapshot_download``. Warm caches (either from a prior
+    # ``pull`` or from a successful mirror pass here) are picked up by
+    # ``mlx_lm.load`` transparently.
+    _prefetch_via_mirror(model_path)
+
     from mlx_lm import load
 
     return load(model_path)

--- a/vllm_mlx/jlens.py
+++ b/vllm_mlx/jlens.py
@@ -73,7 +73,9 @@ def _prefetch_via_mirror(model_path: str) -> bool:
     Best-effort: any exception here is swallowed — the mirror is a UX
     optimization, not a correctness dependency for ``jlens``.
     """
-    if not model_path or "/" not in model_path or os.path.exists(model_path):
+    if not _looks_like_hf_repo_id(model_path):
+        return False
+    if os.path.exists(model_path):
         return False
     try:
         from ._mirror import download_with_mirror_fallback
@@ -88,6 +90,32 @@ def _prefetch_via_mirror(model_path: str) -> bool:
         # handle it via HF". Don't fail the whole jlens invocation over
         # a mirror hiccup.
         return False
+
+
+def _looks_like_hf_repo_id(model_path: str) -> bool:
+    """Return True if ``model_path`` is shaped like a HuggingFace ``owner/name``.
+
+    Codex nit on PR #1045: a bare ``"/" in model_path`` check treats
+    ``./missing/model``, ``/tmp/model``, ``foo/bar/baz``, and URLs like
+    ``https://hf.co/mlx-community/X`` as mirror-eligible. Each of those
+    would hit ``download_with_mirror_fallback`` → ``model_info`` (a real
+    HF API round-trip) before mlx_lm.load ever gets a chance to reject
+    them locally. Match HuggingFace's own repo-id shape here so garbage
+    inputs short-circuit.
+    """
+    if not model_path:
+        return False
+    if "://" in model_path:  # a URL
+        return False
+    if model_path.startswith(("/", ".", "~")):  # absolute / relative / home
+        return False
+    parts = model_path.split("/")
+    if len(parts) != 2:  # exactly one slash separating owner and name
+        return False
+    owner, name = parts
+    if not owner or not name:
+        return False
+    return True
 
 
 def _load_model(model_path: str):


### PR DESCRIPTION
## Summary

``rapid-mlx jlens`` (shipped in 0.10.2 via #1039) bypassed the R2
mirror when fetching model weights and went directly to HuggingFace,
producing the ``Fetching 9 files:`` HF-native progress bar instead of
the rapid-mlx ``[N/M] file R2 (X MB)`` mirror lines. Every other
weight-loading command (``serve``, ``chat``, ``pull``, ``bench``)
routes through ``vllm_mlx._mirror.download_with_mirror_fallback`` and
this closes that gap.

## Root cause

``jlens._load_model`` called ``mlx_lm.load(model_path)`` directly.
``mlx_lm.load`` delegates the download to
``huggingface_hub.snapshot_download`` — that's where the mirror-bypass
happens. The rest of the CLI runs ``_try_mirror_prefetch(model_name)``
first (see ``vllm_mlx.cli._ensure_model_downloaded`` for serve/chat
and ``pull_command`` for the CLI ``pull`` path), which invokes
``download_with_mirror_fallback`` and populates the HF cache from R2
so ``mlx_lm.load`` / ``snapshot_download`` sees a warm cache and never
touches HuggingFace. jlens shipped without that pre-fetch step.

## Fix

Introduce ``_prefetch_via_mirror`` inside ``jlens.py`` and call it
before the ``from mlx_lm import load`` line executes:

- Local dirs / non-HF-shaped ids / disabled mirror → early return,
  falls through to ``mlx_lm.load`` untouched.
- ``download_with_mirror_fallback`` hydrates the HF cache → warm cache
  when ``mlx_lm.load`` runs, zero HF traffic.
- Mirror returns ``False`` (catalog outage, per-file miss, ``not yet
  mirrored`` status) or raises → best-effort swallow;
  ``mlx_lm.load``'s own ``snapshot_download`` completes the pull from
  HF. Same graceful-degradation contract as
  ``_ensure_model_downloaded``.

Env var / config: honors the same ``RAPID_MLX_MODEL_MIRROR`` knob
(default ``https://models.rapidmlx.com``, empty string disables) that
the rest of the codebase reads — no new hard-coded URL introduced.

## Test plan

- [x] Extend ``tests/test_cli_jlens.py`` with 7 new tests exercising:
  - Local paths bypass the mirror (no round-trip).
  - HF-shaped repo ids are routed through
    ``download_with_mirror_fallback``.
  - Mirror ``False`` return falls back to ``mlx_lm.load`` cleanly.
  - Unexpected mirror exceptions are swallowed (jlens does not fail
    because of a mirror hiccup).
  - ``_load_model`` calls mirror BEFORE ``mlx_lm.load``, both with
    the same pre-resolved model id.
- [x] All 20 tests in ``tests/test_cli_jlens.py`` pass.
- [x] All 63 tests in ``tests/test_mirror_pull.py`` pass — mirror
  semantics unchanged.
- [x] Manual repro pre-fix: ``jlens._load_model`` invokes only
  ``mlx_lm.load``, mirror never consulted.
- [x] Manual verify post-fix: ``jlens._load_model`` invokes
  ``download_with_mirror_fallback`` first, then ``mlx_lm.load``, both
  with the same model id.

Post-merge: this is a bug fix. Apply ``skip-version-bump`` so it
batches into the next dedicated bump PR rather than firing an
independent release (per the standing feedback to batch dogfood fixes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)