### PR TITLE
fix(bench): route model weights through R2 mirror in bench + bench --submit

### DIFF
--- a/tests/test_cli_bench.py
+++ b/tests/test_cli_bench.py
@@ -1,0 +1,296 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for ``rapid-mlx bench`` R2-mirror routing (regression: #650 shape).
+
+Before this fix, ``bench_command`` (freeform path) and ``_run_submit_flow``
+(``--submit`` community-bench path) both delegated the initial weight pull
+to ``mlx_lm.load`` → ``huggingface_hub.snapshot_download`` DIRECTLY,
+bypassing the R2 mirror at ``models.rapidmlx.com`` that every other
+weight-materializing command (``serve``, ``chat``, ``pull``, ``jlens``)
+prefetches through. Result: users burned bandwidth on HF and tripped rate
+limits even though a warm mirror shard was 50 ms away.
+
+These tests lock the fix: both bench paths call ``_ensure_model_downloaded``
+(the same helper ``serve`` uses, which handles the R2-first + HF-fallback
+contract) BEFORE ``mlx_lm.load`` runs. They also confirm the graceful
+degradation contract: when the mirror is unreachable, prefetch returns
+without raising and bench proceeds to ``mlx_lm.load`` (which then pulls
+from HF directly, matching pre-fix behavior for the fallback case).
+
+Pattern lifted from ``tests/test_cli_jlens.py`` (PR #1045).
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+
+import pytest
+
+
+# ---------- shared helpers ---------------------------------------------------
+def _patch_mlx_lm_load(monkeypatch, fake_load) -> None:
+    """Patch ONLY the ``load`` attribute on the real ``mlx_lm`` module.
+
+    ``bench_command`` and ``_run_submit_flow`` use ``from mlx_lm import
+    load`` at call time — that's ``getattr(sys.modules['mlx_lm'], 'load')``
+    resolved fresh each call. Replacing the whole module object would
+    break other imports (``mlx_lm.generate``, ``mlx_lm.utils``…) that
+    the engine's own imports trigger during ``bench_command`` setup.
+    Attribute patching leaves those intact.
+    """
+    import mlx_lm  # already loaded by the test-time environment
+
+    monkeypatch.setattr(mlx_lm, "load", fake_load, raising=True)
+
+
+def _make_freeform_bench_args(model: str) -> argparse.Namespace:
+    """Minimal Namespace to reach ``load(args.model)`` in the freeform path.
+
+    Every attribute below is one that ``bench_command`` (or the shared
+    pflash / prefix-cache setup it drives) reads before the load call.
+    Setting ``pflash="off"`` short-circuits the alias-lookup branch in
+    ``resolve_pflash_mode_default`` and lets ``config_from_args`` build a
+    real ``PFlashConfig`` without any HF metadata calls.
+    """
+    return argparse.Namespace(
+        model=model,
+        tier=None,
+        submit=False,
+        force_disk_check=False,
+        # PFlash knobs — all required by ``config_from_args``. Values
+        # match the CLI defaults (see ``vllm_mlx/args.py``).
+        pflash="off",
+        pflash_threshold=1024,
+        pflash_keep_ratio=0.20,
+        pflash_min_keep_tokens=256,
+        pflash_sink_tokens=64,
+        pflash_tail_tokens=64,
+        pflash_block_size=16,
+        pflash_query_window=128,
+        pflash_stride_blocks=0,
+        pflash_include_tools=False,
+        mllm=False,
+        # Prefix cache toggle read BEFORE the async runner.
+        enable_prefix_cache=True,
+        disable_prefix_cache=False,
+    )
+
+
+# ---------- freeform bench path (bench_command) -----------------------------
+def test_bench_command_prefetches_via_mirror_before_hf_load(monkeypatch) -> None:
+    """Freeform ``rapid-mlx bench <alias>`` must call
+    ``_ensure_model_downloaded(args.model)`` BEFORE ``mlx_lm.load(args.model)``.
+
+    Regression contract: without the prefetch, ``load`` triggers
+    ``huggingface_hub.snapshot_download`` directly and skips the R2
+    mirror at ``models.rapidmlx.com`` — the exact bypass that also
+    hit ``jlens`` before PR #1045 and ``serve`` before #651.
+    """
+    cli = importlib.import_module("vllm_mlx.cli")
+
+    order: list[str] = []
+
+    def _fake_prefetch(name: str) -> None:
+        order.append(f"prefetch:{name}")
+
+    def _fake_load(name: str):
+        order.append(f"load:{name}")
+        # Abort inside the async runner: ``ValueError`` hits the
+        # bench's own 404-friendly except branch which calls
+        # ``sys.exit(1)`` — we swallow that below with ``pytest.raises``.
+        raise ValueError("test-abort — bench should reach load AFTER prefetch")
+
+    # Silence the network-heavy pre-checks. ``_ensure_model_downloaded``
+    # is the piece under test; ``_check_disk_space`` /
+    # ``_check_memory_capacity`` are covered by their own tests.
+    monkeypatch.setattr(cli, "_check_disk_space", lambda *a, **kw: None)
+    monkeypatch.setattr(cli, "_check_memory_capacity", lambda *a, **kw: None)
+    monkeypatch.setattr(cli, "_ensure_model_downloaded", _fake_prefetch)
+
+    # Bypass the pflash alias-tier lookup (would touch aliases.json /
+    # detect_model_config). The order test doesn't depend on it.
+    monkeypatch.setattr(
+        "vllm_mlx.pflash.resolve_pflash_mode_default",
+        lambda args, *, model_name: "off",
+    )
+    # Route the ``from mlx_lm import load`` inside bench_command to
+    # our mock. Patching ``mlx_lm.load`` on the module object makes
+    # the deferred ``from`` import bind to our recorder.
+    _patch_mlx_lm_load(monkeypatch, _fake_load)
+
+    args = _make_freeform_bench_args("mlx-community/Qwen3-1.7B-4bit")
+
+    with pytest.raises(SystemExit) as exc:
+        cli.bench_command(args)
+    # bench_command's own 404-branch translates ValueError → sys.exit(1).
+    assert exc.value.code == 1
+
+    # 1) prefetch was consulted, 2) BEFORE mlx_lm.load, 3) with the
+    # SAME model id the user typed — no accidental re-resolution.
+    assert order == [
+        "prefetch:mlx-community/Qwen3-1.7B-4bit",
+        "load:mlx-community/Qwen3-1.7B-4bit",
+    ], f"order violation: {order}"
+
+
+def test_bench_command_proceeds_when_mirror_prefetch_is_silent_noop(
+    monkeypatch,
+) -> None:
+    """Graceful degradation contract: when ``_ensure_model_downloaded``
+    returns None (the normal contract for cached / local / mirror-miss
+    paths — the helper swallows mirror errors internally), the freeform
+    bench proceeds to ``mlx_lm.load`` which falls through to HF. Bench
+    MUST NOT raise from the prefetch call site.
+    """
+    cli = importlib.import_module("vllm_mlx.cli")
+
+    load_called: list[str] = []
+
+    def _silent_prefetch(name: str) -> None:
+        # Simulates the real helper's happy path (cached repo / warm
+        # mirror / silent mirror miss). Return None, no raise.
+        return None
+
+    def _fake_load(name: str):
+        load_called.append(name)
+        raise ValueError("test-abort")
+
+    monkeypatch.setattr(cli, "_check_disk_space", lambda *a, **kw: None)
+    monkeypatch.setattr(cli, "_check_memory_capacity", lambda *a, **kw: None)
+    monkeypatch.setattr(cli, "_ensure_model_downloaded", _silent_prefetch)
+    monkeypatch.setattr(
+        "vllm_mlx.pflash.resolve_pflash_mode_default",
+        lambda args, *, model_name: "off",
+    )
+    _patch_mlx_lm_load(monkeypatch, _fake_load)
+
+    args = _make_freeform_bench_args("mlx-community/Qwen3-1.7B-4bit")
+
+    with pytest.raises(SystemExit):
+        cli.bench_command(args)
+
+    # Bench proceeded to load — the graceful-fallback contract holds.
+    assert load_called == ["mlx-community/Qwen3-1.7B-4bit"]
+
+
+# ---------- --submit community-bench path (_run_submit_flow) ----------------
+def _install_submit_flow_stubs(monkeypatch, cli, *, alias: str, hf_path: str):
+    """Common patches for the ``--submit`` path: bypass the Apple-Silicon
+    gate, the whitelist lookup, and the disk / memory pre-checks so the
+    test can reach the executor without touching real hardware or HF."""
+
+    # Community bench is Apple-Silicon only; CI runs on Linux workers,
+    # so the ``is_apple_silicon`` gate would exit 2 before our mocks
+    # get to observe anything.
+    monkeypatch.setattr(
+        "vllm_mlx.community_bench.hardware.is_apple_silicon", lambda: True
+    )
+
+    # Whitelist lookup: return a stub profile with our controlled hf_path
+    # so the alias-key guard passes without touching aliases.json.
+    class _Profile:
+        def __init__(self, hf_path):
+            self.hf_path = hf_path
+
+    monkeypatch.setattr(
+        "vllm_mlx.model_aliases.resolve_profile",
+        lambda name: _Profile(hf_path),
+    )
+
+    monkeypatch.setattr(cli, "_check_disk_space", lambda *a, **kw: None)
+    monkeypatch.setattr(cli, "_check_memory_capacity", lambda *a, **kw: None)
+
+
+def test_run_submit_flow_prefetches_via_mirror_before_hf_load(
+    monkeypatch,
+) -> None:
+    """``--submit`` community-bench path MUST call
+    ``_ensure_model_downloaded(hf_path)`` BEFORE the thread executor spins
+    up ``mlx_lm.load(hf_path)``.
+
+    Running in the main thread means the mirror's per-file progress lines
+    print on the contributor's terminal; deferring to the executor would
+    hide them behind the ``Loading model …`` line above.
+    """
+    cli = importlib.import_module("vllm_mlx.cli")
+
+    order: list[str] = []
+
+    def _fake_prefetch(name: str) -> None:
+        order.append(f"prefetch:{name}")
+
+    def _fake_load(name: str):
+        order.append(f"load:{name}")
+        # Return 2 branch: ``ValueError`` inside the executor is caught
+        # at cli.py:3554 which returns 2 from ``_run`` (NOT ``sys.exit``).
+        raise ValueError("test-abort — submit should reach load AFTER prefetch")
+
+    _install_submit_flow_stubs(
+        monkeypatch,
+        cli,
+        alias="qwen3.5-9b-4bit",
+        hf_path="mlx-community/Qwen3.5-9B-4bit",
+    )
+    monkeypatch.setattr(cli, "_ensure_model_downloaded", _fake_prefetch)
+    _patch_mlx_lm_load(monkeypatch, _fake_load)
+
+    args = argparse.Namespace(
+        model="qwen3.5-9b-4bit",
+        submit=True,
+        sampled=False,
+        notes=None,
+        force_disk_check=False,
+        # ``_original_alias`` is unset on the direct-alias path — the
+        # flow falls back to ``args.model`` (matches production).
+    )
+
+    rc = cli._run_submit_flow(args)
+    # Load raised ValueError → caught at cli.py:3554 → return 2.
+    assert rc == 2
+
+    assert order == [
+        "prefetch:mlx-community/Qwen3.5-9B-4bit",
+        "load:mlx-community/Qwen3.5-9B-4bit",
+    ], f"order violation: {order}"
+
+
+def test_run_submit_flow_proceeds_when_mirror_prefetch_is_silent_noop(
+    monkeypatch,
+) -> None:
+    """Mirror-fallback contract for ``--submit``: when
+    ``_ensure_model_downloaded`` returns None (cached / mirror miss /
+    disabled mirror), ``_run_submit_flow`` MUST proceed to
+    ``mlx_lm.load``, which then completes the pull via HF."""
+    cli = importlib.import_module("vllm_mlx.cli")
+
+    load_called: list[str] = []
+
+    def _silent_prefetch(name: str) -> None:
+        return None
+
+    def _fake_load(name: str):
+        load_called.append(name)
+        raise ValueError("test-abort")
+
+    _install_submit_flow_stubs(
+        monkeypatch,
+        cli,
+        alias="qwen3.5-9b-4bit",
+        hf_path="mlx-community/Qwen3.5-9B-4bit",
+    )
+    monkeypatch.setattr(cli, "_ensure_model_downloaded", _silent_prefetch)
+    _patch_mlx_lm_load(monkeypatch, _fake_load)
+
+    args = argparse.Namespace(
+        model="qwen3.5-9b-4bit",
+        submit=True,
+        sampled=False,
+        notes=None,
+        force_disk_check=False,
+    )
+
+    rc = cli._run_submit_flow(args)
+    assert rc == 2  # ValueError → load-branch → return 2
+
+    # Submit proceeded to load — the graceful-fallback contract holds.
+    assert load_called == ["mlx-community/Qwen3.5-9B-4bit"]

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -3516,6 +3516,21 @@ def _run_submit_flow(
     _check_disk_space(hf_path, force=getattr(args, "force_disk_check", False))
     _check_memory_capacity(hf_path)
 
+    # Pre-fetch the model via the R2 mirror (with HF fallback) BEFORE the
+    # thread executor spins up. Without this, ``mlx_lm.load`` runs inside
+    # the executor and delegates to ``huggingface_hub.snapshot_download``
+    # directly, skipping the mirror entirely (bug: --submit diverged from
+    # ``serve``/``chat``/``pull``/``jlens`` which all prefetch via the
+    # mirror first). Running this in the main thread — before the executor
+    # is created — surfaces the mirror's per-file progress lines to the
+    # contributor's terminal; if we deferred to the executor, the tqdm
+    # bars from a warm cache-miss would race the ``Loading model …`` print
+    # below. ``_ensure_model_downloaded`` is a no-op on local paths and on
+    # fully-cached repos, and swallows mirror errors gracefully so
+    # ``mlx_lm.load`` still falls through to HF when the mirror is
+    # unreachable.
+    _ensure_model_downloaded(hf_path)
+
     # ``--sampled`` runs a SECOND submission (with sampling="sampled")
     # in addition to the always-on greedy run. The README contract is
     # "two rows when --sampled is set, one row otherwise" — a previous
@@ -3756,6 +3771,18 @@ def bench_command(args):
 
     _check_disk_space(args.model, force=getattr(args, "force_disk_check", False))
     _check_memory_capacity(args.model)
+
+    # Pre-fetch the model via the R2 mirror (with HF fallback) BEFORE the
+    # heavy bench boot. Without this, ``bench`` falls into ``mlx_lm.load``
+    # → ``huggingface_hub.snapshot_download`` directly and skips the
+    # mirror entirely, wasting the user's bandwidth and hitting HF rate
+    # limits (bug: bench diverged from ``serve``/``chat``/``pull``/``jlens``
+    # which all prefetch via the mirror first).
+    # ``_ensure_model_downloaded`` is a no-op on local paths and on
+    # fully-cached repos and swallows mirror errors gracefully (mlx_lm.load
+    # falls through to HF), so this is safe on the warm path and when
+    # the mirror is unreachable.
+    _ensure_model_downloaded(args.model)
 
     # Handle prefix cache flags
     enable_prefix_cache = args.enable_prefix_cache and not args.disable_prefix_cache


### PR DESCRIPTION
## Summary

`rapid-mlx bench` (freeform) and `rapid-mlx bench --submit` (community bench) both shipped calling `mlx_lm.load(...)` directly, which delegates to `huggingface_hub.snapshot_download` and pulls every shard straight from HuggingFace. Every other rapid-mlx command that materializes weights (`serve`, `chat`, `pull`, `jlens`) routes the initial download through `_ensure_model_downloaded` so users get the R2 mirror at `models.rapidmlx.com` (edge-cached, resumable, no HF rate limits) with a per-file HF fallback. Bench was the outlier.

Same shape as PR #1045 (jlens) — closes the last remaining mirror bypass in the CLI.

## Root cause

Both bench call sites in `vllm_mlx/cli.py` skipped the `_ensure_model_downloaded(...)` step that `serve_command` runs before its own loader dispatch (`cli.py:2004`, added in #651):

- `bench_command` (freeform path) called `load(args.model)` at `cli.py:3786` with no prefetch.
- `_run_submit_flow` called `model_load_executor.submit(load, hf_path).result()` at `cli.py:3553` with no prefetch. The executor'd `load` also fires under a worker thread, so any HF progress bars are hidden behind the `Loading model …` banner above.

## Fix

Two insertion points, both invoking the existing `_ensure_model_downloaded` helper (private-scoped in the same file, no new imports).

- Freeform path: after the disk / memory pre-checks at `cli.py:3757-3758`, before the pflash / prefix-cache setup runs. This surfaces the mirror's per-file progress on the operator's terminal before the pflash import chain.
- Submit path: after `_check_disk_space` / `_check_memory_capacity` at `cli.py:3516-3517`, before the thread executor is created. Running the prefetch in the main thread keeps the mirror's progress lines visible; deferring to the executor would race the `Loading model …` line inside `_run`.

Graceful degradation is inherited from `_ensure_model_downloaded`: local paths are no-ops; a fully-cached repo returns via `is_repo_cached`; a mirror miss / catalog outage / mirror-module absence falls through to HuggingFace via the helper's own `snapshot_download` block. Bench still boots when the mirror is unreachable — same fallback contract `serve` and `jlens` rely on.

## Test plan

- [x] `pytest tests/test_cli_bench.py` — 4 new cases, all pass
  - Freeform bench prefetches via mirror BEFORE `mlx_lm.load` runs (order + same model id)
  - Freeform bench proceeds to `mlx_lm.load` when prefetch is a silent no-op (graceful degradation)
  - `--submit` bench prefetches via mirror BEFORE executor's `mlx_lm.load` runs (order + same `hf_path`)
  - `--submit` bench proceeds to `mlx_lm.load` on silent no-op
- [x] `pytest tests/test_cli_jlens.py tests/test_bench_tier_submit_combo.py tests/test_bench_tier_smoke.py tests/test_disk_space_check.py` — 52 tests, no regressions
- [x] `ruff check` + `ruff format --check` clean on both files
- [x] Rebased on `origin/main` at `0157e469` (post-jlens fix)

Post-merge follow-ups: apply `skip-version-bump` label so this batches into the next patch release rather than triggering an immediate bump — matches the current 0.10.x fix-batching cadence.