### PR TITLE
chore: bump version to 0.10.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.10.2"
+version = "0.10.3"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## Summary

Bumps `pyproject.toml` version 0.10.2 → 0.10.3 to fire `auto-release.yml` and publish to PyPI + Homebrew + GitHub Release.

## What's in 0.10.3

### R2 mirror correctness (Task #470)
- **#1045** — `rapid-mlx jlens`: route model weights through `models.rapidmlx.com` R2 mirror before falling back to HuggingFace.
- **#1046** — `rapid-mlx bench` + `rapid-mlx bench --submit`: same routing fix. `serve` / `chat` / `pull` were already mirror-aware; these three closed the coverage gap.

### Real E2E harnesses — un-xfailed Tier-1 cells
- **#1047** — Aider real bash-CLI harness driving `aider --openai-api-base` against `rapid-mlx serve`. Un-xfailed 4 family cells (Qwen 3.6 / Gemma 4 / DeepSeek R1-Distill / gpt-oss) — all empirically PASS. Confirms DeepSeek R1-Distill drives Aider despite the OpenAI tool-call gap because Aider parses plain-text SEARCH/REPLACE, not `tool_calls`.
- **#1048** — OpenHands real Docker E2E harness (image pinned) driving CodeActAgent against `rapid-mlx serve`. Un-xfailed 3 family cells (Qwen 3.6 / Gemma 4 / DeepSeek R1-Distill) — all PASS. gpt-oss remained XFAIL with root-cause documented → issue #1049 → fixed in #1051 below.

### Correctness fix (unblocks gpt-oss on CodeAct-style agents)
- **#1051** — Harmony parser: apply user-supplied `stop=[...]` only to the emitted `final` channel, not the raw token stream that interleaves the `analysis` channel. Before: gpt-oss requests with CodeAct stops returned `content=""` because the CoT reasoning mentioned `</execute_ipython>` verbatim, tripping the raw-stream stop-check. After: `content` contains the real action; wire-level LiteLLM smoke returns 482 chars vs `""`. Fixes issue #1049. Byte-for-byte no-op on non-harmony models (21-cell regression PIN).

## Follow-ups tracked

- **#472** — `benchmark.py` / `rapid-mlx-bench` console script R2 mirror bypass (last remaining bypass; ties into 0.11 UX consolidation with `rapid-mlx bench --mllm/--video`).
- **#471** — jlens architecture adapters for Gemma 4 (rms_norm tuple signature) + Qwen 3.6 DeltaNet (dict output) — surfaced by 0.10.2 shipped jlens dogfood.
- **#476** — install.sh stale content (Qwen 3.5 recommend map, upgrade URL, banner claim) — must land before README redesign.
- **#477** — README trim 1142 → ~280 lines with content migration to docs.rapidmlx.com.
- OpenHands 0.9.0 upstream `runtime_build.py` parser bug documented in #1048 body — separate follow-up, not our issue.

## Test plan

- [x] `pyproject.toml` version bumped 0.10.2 → 0.10.3
- [x] Commit subject `chore: bump version to 0.10.3` matches `auto-release.yml` regex `^chore: bump version to [0-9]+\.[0-9]+\.[0-9]+( \(#[0-9]+\))?$`
- [x] Diff is 1 line, 1 file (`pyproject.toml` only)

Post-merge verification (prose, not a gate item): once `auto-release.yml` fires, `pip install rapid-mlx==0.10.3` should return an installable wheel, `rapid-mlx --version` should report `0.10.3`, and a GitHub release `v0.10.3` tag will be created automatically. If either doesn't happen within 15 minutes of merge, investigate via `gh run list --workflow=auto-release.yml` and check the workflow logs.