### PR TITLE
fix(install.sh): pivot RECOMMENDED_MODEL to 0.10 Tier-1 + rapidmlx.com canonical URL

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Rapid-MLX installer — AI inference for Apple Silicon
-# Usage: curl -fsSL https://raullenchai.github.io/Rapid-MLX/install.sh | bash
+# Usage: curl -fsSL https://rapidmlx.com/install.sh | bash
 #        curl ... | bash -s 0.4.3          # specific version
 #        curl ... | bash -s latest         # latest from GitHub (pre-release)
 set -euo pipefail
@@ -85,10 +85,10 @@ fi
 # ── 2. Detect RAM → recommend model ──────────────────────────────────────────
 
 RAM_GB=$(sysctl -n hw.memsize 2>/dev/null | awk '{printf "%d", $1/1073741824}')
-if   [ "$RAM_GB" -ge 96 ]; then RECOMMENDED_MODEL="qwen3.5-122b-mxfp4"; RAM_TIER="96+ GB"
-elif [ "$RAM_GB" -ge 48 ]; then RECOMMENDED_MODEL="qwen3.5-35b-8bit";  RAM_TIER="48-95 GB"
-elif [ "$RAM_GB" -ge 24 ]; then RECOMMENDED_MODEL="qwen3.5-9b-4bit";   RAM_TIER="24-47 GB"
-else                            RECOMMENDED_MODEL="qwen3.5-4b-4bit";   RAM_TIER="8-23 GB"
+if   [ "$RAM_GB" -ge 96 ]; then RECOMMENDED_MODEL="gpt-oss-120b-mxfp4-q8"; RAM_TIER="96+ GB"
+elif [ "$RAM_GB" -ge 48 ]; then RECOMMENDED_MODEL="qwen3.6-35b-8bit";      RAM_TIER="48-95 GB"
+elif [ "$RAM_GB" -ge 24 ]; then RECOMMENDED_MODEL="gpt-oss-20b-mxfp4-q8";  RAM_TIER="24-47 GB"
+else                            RECOMMENDED_MODEL="qwen3.5-4b-4bit";       RAM_TIER="8-23 GB"
 fi
 
 dim "macOS $(sw_vers -productVersion) · Apple Silicon · ${RAM_GB} GB RAM"
@@ -245,8 +245,8 @@ echo "    rapid-mlx-chat                                    # built-in chat"
 echo "    OPENAI_BASE_URL=http://localhost:8000/v1 claude    # Claude Code"
 echo "    OPENAI_BASE_URL=http://localhost:8000/v1 aider     # Aider"
 echo ""
-dim "Upgrade:    curl -fsSL https://raullenchai.github.io/Rapid-MLX/install.sh | bash"
-dim "Uninstall:  rm -rf ~/.rapid-mlx ~/.local/bin/rapid-mlx* ~/.local/bin/vllm-mlx*"
+dim "Upgrade:    curl -fsSL https://rapidmlx.com/install.sh | bash"
+dim "Uninstall:  rm -rf ~/.rapid-mlx ~/.rapid-mlx-python ~/.local/bin/rapid-mlx* ~/.local/bin/vllm-mlx*"
 echo ""
 
 if [ "$NEED_PATH_HINT" = true ]; then


### PR DESCRIPTION
## Summary

`install.sh` (single-source-of-truth for `rapidmlx.com/install.sh` via Cloudflare Worker proxy → GH Pages, 300s TTL) had 4 pieces of stale content from the pre-0.10 era. This PR fixes them, tested end-to-end against `rapid-mlx==0.10.3`.

The `RECOMMENDED_MODEL` tier map now reflects the 0.10 Tier-1 family pivot (Qwen 3.6 · Gemma 4 · gpt-oss · DeepSeek). Each pick was empirically verified to boot to `/v1/models` Ready on the current install.

## Changes (4)

| # | What | Before | After |
|---|------|--------|-------|
| 1 | 96+ GB tier | `qwen3.5-122b-mxfp4` | `gpt-oss-120b-mxfp4-q8` |
| 1 | 48-95 GB tier | `qwen3.5-35b-8bit` | `qwen3.6-35b-8bit` |
| 1 | 24-47 GB tier | `qwen3.5-9b-4bit` | `gpt-oss-20b-mxfp4-q8` |
| 1 | 8-23 GB tier | `qwen3.5-4b-4bit` | `qwen3.5-4b-4bit` (unchanged — no Qwen 3.6 4B exists yet) |
| 2 | Upgrade banner URL | `raullenchai.github.io/Rapid-MLX/install.sh` | `rapidmlx.com/install.sh` |
| 3 | Header Usage comment | `raullenchai.github.io/Rapid-MLX/install.sh` | `rapidmlx.com/install.sh` |
| 4 | Uninstall hint | missing `~/.rapid-mlx-python` | added `~/.rapid-mlx-python` (standalone-Python cleanup) |

The `2-4x faster than Ollama` banner line is deliberately unchanged (marketing claim, out of scope).

## Empirical tier boots (rapid-mlx 0.10.3, cached models, port 8804-8807)

| RAM tier | Alias | HF repo | Boot to Ready | Peak RSS | Notes |
|----------|-------|---------|---------------|----------|-------|
| 96+ GB | `gpt-oss-120b-mxfp4-q8` | `mlx-community/gpt-oss-120b-MXFP4-Q8` | 15s | 60.9 GB | cache: 59 GB |
| 48-95 GB | `qwen3.6-35b-8bit` | `mlx-community/Qwen3.6-35B-A3B-8bit` | 11s | 35.6 GB | cache: 35 GB, native MTP |
| 24-47 GB | `gpt-oss-20b-mxfp4-q8` | `mlx-community/gpt-oss-20b-MXFP4-Q8` | 6s | 12.1 GB | cache: 11 GB, harmony native |
| 8-23 GB | `qwen3.5-4b-4bit` | `mlx-community/Qwen3.5-4B-MLX-4bit` | 8s | 2.8 GB | cache: 2.9 GB, no Qwen 3.6 4B yet |

All 4 booted to `/v1/models` responding 200. No new downloads triggered (all candidates already cached).

## Sandbox re-verify (post-edit)

```
SANDBOX=/tmp/rmx-install-sandbox-verify
HOME="$SANDBOX" bash install.sh > "$SANDBOX/install.log" 2>&1
```

- exit code: `0`
- version reported: `rapid-mlx 0.10.3`
- `raullenchai.github.io` references in output: `0`
- Quick-start line rendered: `rapid-mlx serve gpt-oss-120b-mxfp4-q8` (this host is 256 GB → 96+ tier ✓)
- Uninstall hint rendered: `rm -rf ~/.rapid-mlx ~/.rapid-mlx-python ~/.local/bin/rapid-mlx* ~/.local/bin/vllm-mlx*`
- Upgrade hint rendered: `curl -fsSL https://rapidmlx.com/install.sh | bash`
- Sandbox HOME cleaned up: OK

## Not touched

Platform check block, Python detection loop, `.vllm-mlx` migration, venv/pip/uv installer paths, symlink block, PATH hint block, banner box art/colors, the `2-4x faster than Ollama` line.

## Post-merge follow-ups

Cloudflare Worker cache TTL is 300s so the change propagates to `rapidmlx.com/install.sh` within 5 minutes of merge. This unblocks the README slim-down that will make `install.sh` the canonical first-touch UX.

Apply `skip-version-bump` label — this is a docs/UX fix, no engine change.