### PR TITLE
feat(scripts): mirror_to_r2 tool + mirror gpt-oss-120b + Qwen3.6-{27,35}B-MTP-4bit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -151,6 +151,13 @@ mtp = [
 embeddings = [
     "mlx-embeddings>=0.1.0",
 ]
+# HF → Cloudflare R2 mirror tooling (scripts/mirror_to_r2.py).
+# Off the hot path — only maintainers who seed models.rapidmlx.com need
+# this. Users NEVER install [mirror]; the client-side download path
+# (vllm_mlx/_mirror.py) uses stdlib urllib and does NOT depend on boto3.
+mirror = [
+    "boto3>=1.34.0",
+]
 # Gradio chat UI
 chat = [
     "gradio>=4.0.0",

--- a/scripts/mirror_to_r2.py
+++ b/scripts/mirror_to_r2.py
@@ -107,6 +107,7 @@ class FileMeta:
     relpath: str  # HF sibling rfilename
     size: int  # bytes; 0 for empty files, from HF metadata
     key: str  # R2 object key = ``<hf-repo-id>/<relpath>``
+    lfs_sha256: str | None = None  # HF's LFS sha256 for weight shards; None otherwise
 
 
 def _hf_files(repo_id: str) -> list[FileMeta]:
@@ -130,8 +131,18 @@ def _hf_files(repo_id: str) -> list[FileMeta]:
         if rname.startswith("/") or ".." in Path(rname).parts:
             raise ValueError(f"Refusing suspicious HF filename: {rname!r}")
         size = int(getattr(s, "size", 0) or 0)
+        # LFS-tracked files (weight shards) expose a canonical sha256
+        # under ``s.lfs.sha256``. We stash it as R2 object metadata so
+        # ``should_skip`` can require both size AND sha match — a stale/
+        # corrupt R2 object with the same byte length can't sneak past.
+        lfs = getattr(s, "lfs", None)
+        lfs_sha256 = getattr(lfs, "sha256", None) if lfs is not None else None
+        if not (isinstance(lfs_sha256, str) and len(lfs_sha256) == 64):
+            lfs_sha256 = None
         key = f"{repo_id}/{rname}"
-        files.append(FileMeta(relpath=rname, size=size, key=key))
+        files.append(
+            FileMeta(relpath=rname, size=size, key=key, lfs_sha256=lfs_sha256)
+        )
     return files
 
 
@@ -158,12 +169,28 @@ def _r2_head_size(client: Any, bucket: str, key: str) -> int | None:
     Any non-404 error raises (fail-fast — we want the operator to see
     permission / endpoint issues immediately rather than skipping past
     them).
+
+    Kept for the unit tests + external callers that only care about
+    size. Callers that need the full HEAD response (including x-amz-meta
+    fields for sha checking) should use :func:`_r2_head`.
+    """
+    r = _r2_head(client, bucket, key)
+    if r is None:
+        return None
+    return int(r["ContentLength"])
+
+
+def _r2_head(client: Any, bucket: str, key: str) -> dict[str, Any] | None:
+    """Return the raw ``head_object`` response, or ``None`` on 404.
+
+    Any non-404 error raises. The returned dict includes ``ContentLength``
+    and ``Metadata`` (a lowercase-keyed dict of x-amz-meta-* headers) —
+    enough to run both a size AND checksum check on skip.
     """
     from botocore.exceptions import ClientError
 
     try:
-        r = client.head_object(Bucket=bucket, Key=key)
-        return int(r["ContentLength"])
+        return client.head_object(Bucket=bucket, Key=key)
     except ClientError as e:
         code = e.response.get("Error", {}).get("Code", "")
         # Boto raises "404" (string) for HEAD-missing objects.
@@ -172,19 +199,50 @@ def _r2_head_size(client: Any, bucket: str, key: str) -> int | None:
         raise
 
 
-def should_skip(existing_size: int | None, expected_size: int) -> bool:
-    """Skip decision: same size on R2 = same content, do not re-upload.
+def should_skip(
+    existing_size: int | None,
+    expected_size: int,
+    *,
+    existing_sha256: str | None = None,
+    expected_sha256: str | None = None,
+) -> bool:
+    """Skip decision: same size AND (when known) same sha256 = same content.
 
-    Note we treat "HF metadata size is 0" (some older repos don't expose
-    a size) as "cannot skip safely" — force a re-upload rather than risk
-    accepting a truncated leftover.
+    Codex round-1 BLOCKING #1: matching byte length alone can be fooled
+    by a stale/corrupt R2 object that happens to share the file size
+    (e.g. a previous upload from a different repo revision, or a mid-
+    stream truncation that boto3's post-flight ``ContentLength`` still
+    reports as full). Whenever HF exposes an LFS sha256 (all weight
+    shards) we require BOTH size + sha match on the ``x-amz-meta-hf-sha256``
+    metadata field we set at upload time.
+
+    Behavior matrix:
+
+    * ``existing_size is None`` (R2 HEAD → 404): must upload.
+    * ``expected_size <= 0`` (HF didn't tell us the size): must upload
+      — refuse to trust an R2 short-write.
+    * ``expected_sha256`` present but ``existing_sha256`` missing or
+      mismatched: must upload — the R2 object is either an older upload
+      pre-metadata, or a different bytes-with-same-length case.
+    * ``expected_sha256 is None`` (non-LFS: config.json, README.md,
+      etc.): fall back to size-only. Small text files don't get LFS
+      hashes; the practical risk of a same-size-but-corrupt copy is
+      much lower for a 1 KB config than for a 5 GB shard, and forcing
+      users to re-upload every tiny asset on each pass defeats the
+      resumability contract.
     """
     if existing_size is None:
         return False
     if expected_size <= 0:
-        # HF didn't tell us the size — refuse to trust an R2 short-write.
         return False
-    return existing_size == expected_size
+    if existing_size != expected_size:
+        return False
+    # Size matches. When HF told us an LFS sha, demand parity — an R2
+    # object without our sha metadata is stale (from a pre-metadata
+    # upload) and must be re-uploaded to earn the skip.
+    if expected_sha256 is not None:
+        return existing_sha256 == expected_sha256
+    return True
 
 
 def _upload_one(
@@ -193,6 +251,8 @@ def _upload_one(
     bucket: str,
     key: str,
     content_type: str,
+    *,
+    lfs_sha256: str | None = None,
 ) -> None:
     """Upload one file to R2 with boto3 multipart auto-split.
 
@@ -201,12 +261,20 @@ def _upload_one(
     profile sets both to 64 MB. We do NOT reimplement multipart
     ourselves; the SDK handles ``create_multipart_upload`` /
     ``upload_part`` / ``complete_multipart_upload`` including retries.
+
+    When ``lfs_sha256`` is provided (weight shards), it is stored as
+    ``x-amz-meta-hf-sha256`` object metadata so a subsequent
+    :func:`should_skip` check can require both size AND sha parity
+    (codex round-1 BLOCKING #1).
     """
+    extra: dict[str, Any] = {"ContentType": content_type}
+    if lfs_sha256:
+        extra["Metadata"] = {"hf-sha256": lfs_sha256}
     client.upload_file(
         Filename=str(local_path),
         Bucket=bucket,
         Key=key,
-        ExtraArgs={"ContentType": content_type},
+        ExtraArgs=extra,
     )
 
 
@@ -238,7 +306,20 @@ def _cleanup_local(path: Path) -> None:
 
 
 def _public_url(public_base: str, key: str) -> str:
-    return f"{public_base.rstrip('/')}/{key.lstrip('/')}"
+    """Build the public read URL for an R2 key.
+
+    Codex round-1 BLOCKING #2: percent-encode each path segment before
+    joining. Filenames legitimately containing spaces, ``#``, ``?``,
+    ``%``, or other URL-reserved chars would otherwise turn a valid
+    ``mlx-community/repo/model card.md`` key into an unreachable URL
+    (space breaks the path; ``#`` starts a fragment). Encoding per
+    segment (not whole key) preserves the ``/`` separators. Matches the
+    same discipline in ``vllm_mlx/_mirror.py::_build_r2_url``.
+    """
+    encoded = "/".join(
+        urllib.parse.quote(seg, safe="") for seg in key.lstrip("/").split("/") if seg
+    )
+    return f"{public_base.rstrip('/')}/{encoded}"
 
 
 def _http_head_status(url: str, timeout: float = 30.0) -> int:
@@ -324,11 +405,25 @@ def mirror_repo(
         bytes_uploaded = 0
         try:
             for idx, f in enumerate(files, 1):
-                head_size = _r2_head_size(client, bucket, f.key)
-                if should_skip(head_size, f.size):
+                head = _r2_head(client, bucket, f.key)
+                head_size = int(head["ContentLength"]) if head is not None else None
+                # Boto3 lowercases user metadata keys on read.
+                head_sha = (
+                    (head.get("Metadata") or {}).get("hf-sha256")
+                    if head is not None
+                    else None
+                )
+                if should_skip(
+                    head_size,
+                    f.size,
+                    existing_sha256=head_sha,
+                    expected_sha256=f.lfs_sha256,
+                ):
                     skipped += 1
+                    tag = "sha+size" if f.lfs_sha256 else "size-only"
                     print(
-                        f"[{idx}/{len(files)}] SKIP existing {f.key} ({head_size} B)",
+                        f"[{idx}/{len(files)}] SKIP existing {f.key} "
+                        f"({head_size} B, {tag})",
                         flush=True,
                     )
                     continue
@@ -353,6 +448,7 @@ def mirror_repo(
                         bucket,
                         f.key,
                         content_type_for(f.relpath),
+                        lfs_sha256=f.lfs_sha256,
                     )
                 finally:
                     _cleanup_local(local)

--- a/scripts/mirror_to_r2.py
+++ b/scripts/mirror_to_r2.py
@@ -102,10 +102,17 @@ def content_type_for(filename: str) -> str:
 
 @dataclass
 class FileMeta:
-    """One expected file in the HF repo → R2 mapping."""
+    """One expected file in the HF repo → R2 mapping.
+
+    ``size`` is ``None`` when HF's siblings metadata didn't expose one
+    (some older repos, older HF API versions) — distinct from ``0``,
+    which is a legitimate empty file. The distinction matters for the
+    skip decision and for the verification path (codex round-2 BLOCKING
+    #2 and #3).
+    """
 
     relpath: str  # HF sibling rfilename
-    size: int  # bytes; 0 for empty files, from HF metadata
+    size: int | None  # bytes; None if HF didn't expose it; 0 = real empty
     key: str  # R2 object key = ``<hf-repo-id>/<relpath>``
     lfs_sha256: str | None = None  # HF's LFS sha256 for weight shards; None otherwise
 
@@ -130,7 +137,12 @@ def _hf_files(repo_id: str) -> list[FileMeta]:
         # a compromised repo could still ship one.
         if rname.startswith("/") or ".." in Path(rname).parts:
             raise ValueError(f"Refusing suspicious HF filename: {rname!r}")
-        size = int(getattr(s, "size", 0) or 0)
+        # Codex round-2 BLOCKING #2: preserve the distinction between
+        # "HF didn't expose a size" (None) and "the file is legitimately
+        # 0 bytes" (0). Passing `or 0` collapses both to 0 and forces a
+        # perpetual re-upload of every empty file.
+        raw_size = getattr(s, "size", None)
+        size = int(raw_size) if isinstance(raw_size, int) else None
         # LFS-tracked files (weight shards) expose a canonical sha256
         # under ``s.lfs.sha256``. We stash it as R2 object metadata so
         # ``should_skip`` can require both size AND sha match — a stale/
@@ -201,7 +213,7 @@ def _r2_head(client: Any, bucket: str, key: str) -> dict[str, Any] | None:
 
 def should_skip(
     existing_size: int | None,
-    expected_size: int,
+    expected_size: int | None,
     *,
     existing_sha256: str | None = None,
     expected_sha256: str | None = None,
@@ -216,24 +228,30 @@ def should_skip(
     shards) we require BOTH size + sha match on the ``x-amz-meta-hf-sha256``
     metadata field we set at upload time.
 
+    Codex round-2 BLOCKING #2: ``expected_size`` is ``None`` when HF
+    didn't expose a size, distinct from ``0`` (a legitimate empty
+    file). Previously both collapsed to a "must upload" branch; empty
+    files were re-uploaded every run despite matching R2 state.
+
     Behavior matrix:
 
     * ``existing_size is None`` (R2 HEAD → 404): must upload.
-    * ``expected_size <= 0`` (HF didn't tell us the size): must upload
-      — refuse to trust an R2 short-write.
+    * ``expected_size is None`` (HF didn't tell us): must upload —
+      refuse to trust an R2 short-write when we can't validate length.
+    * ``existing_size != expected_size``: must upload.
     * ``expected_sha256`` present but ``existing_sha256`` missing or
       mismatched: must upload — the R2 object is either an older upload
       pre-metadata, or a different bytes-with-same-length case.
     * ``expected_sha256 is None`` (non-LFS: config.json, README.md,
-      etc.): fall back to size-only. Small text files don't get LFS
-      hashes; the practical risk of a same-size-but-corrupt copy is
-      much lower for a 1 KB config than for a 5 GB shard, and forcing
-      users to re-upload every tiny asset on each pass defeats the
-      resumability contract.
+      empty files, etc.): fall back to size-only. Small text files
+      don't get LFS hashes; the practical risk of a same-size-but-
+      corrupt copy is much lower for a 1 KB config than for a 5 GB
+      shard, and forcing users to re-upload every tiny asset on each
+      pass defeats the resumability contract.
     """
     if existing_size is None:
         return False
-    if expected_size <= 0:
+    if expected_size is None:
         return False
     if existing_size != expected_size:
         return False
@@ -387,7 +405,10 @@ def mirror_repo(
         print("   MODE:     verify-only (no uploads)", flush=True)
 
     files = _hf_files(repo_id)
-    total_bytes = sum(f.size for f in files)
+    # HF sometimes doesn't expose sizes for a subset of siblings; treat
+    # those as 0 for the aggregate banner (the actual bytes-uploaded
+    # counter tracks the ground truth below).
+    total_bytes = sum((f.size or 0) for f in files)
     print(
         f"   files:    {len(files)} ({total_bytes / 1e9:.3f} GB total)",
         flush=True,
@@ -397,9 +418,18 @@ def mirror_repo(
 
     # ---- upload / skip loop
     if not verify_only:
-        if tmp_dir is None:
-            tmp_dir = Path(f"/tmp/mirror-{os.getpid()}")
-        tmp_dir.mkdir(parents=True, exist_ok=True)
+        # Codex round-2 BLOCKING #1: NEVER ``rmtree`` a user-supplied
+        # ``--tmp-dir`` — the operator may have pointed us at a shared
+        # scratch root (e.g. ``/mnt/scratch``) that holds unrelated data.
+        # Always work inside a per-run subdirectory we exclusively
+        # created; only that subdirectory gets deleted on exit.
+        base_tmp = tmp_dir if tmp_dir is not None else Path("/tmp")
+        base_tmp.mkdir(parents=True, exist_ok=True)
+        run_tmp = base_tmp / f"mirror-{os.getpid()}"
+        run_tmp.mkdir(parents=True, exist_ok=True)
+        # Expose the concrete per-run dir under the same variable name
+        # the rest of the function (and _download_one_hf) references.
+        tmp_dir = run_tmp
         uploaded = 0
         skipped = 0
         bytes_uploaded = 0
@@ -428,15 +458,17 @@ def mirror_repo(
                     )
                     continue
                 if dry_run:
+                    size_label = f.size if f.size is not None else "?"
                     print(
                         f"[{idx}/{len(files)}] DRY-RUN would upload {f.key} "
-                        f"({f.size} B, type={content_type_for(f.relpath)})",
+                        f"({size_label} B, type={content_type_for(f.relpath)})",
                         flush=True,
                     )
                     continue
                 # Download → upload → delete, one at a time.
+                size_label = f.size if f.size is not None else "?"
                 print(
-                    f"[{idx}/{len(files)}] UPLOAD started {f.key} ({f.size} B)",
+                    f"[{idx}/{len(files)}] UPLOAD started {f.key} ({size_label} B)",
                     flush=True,
                 )
                 t0 = time.monotonic()
@@ -453,11 +485,20 @@ def mirror_repo(
                 finally:
                     _cleanup_local(local)
                 wall = time.monotonic() - t0
+                # If HF didn't tell us the size, count the actual bytes we
+                # wrote out (fall back to 0 when the local file is gone
+                # after an interrupted download).
+                actual_size = f.size
+                if actual_size is None:
+                    try:
+                        actual_size = local.stat().st_size
+                    except OSError:
+                        actual_size = 0
                 uploaded += 1
-                bytes_uploaded += f.size
+                bytes_uploaded += actual_size
                 print(
-                    f"[{idx}/{len(files)}] OK {f.size} B {wall:.1f}s "
-                    f"({(f.size / max(wall, 0.001)) / 1e6:.1f} MB/s) {f.key}",
+                    f"[{idx}/{len(files)}] OK {actual_size} B {wall:.1f}s "
+                    f"({(actual_size / max(wall, 0.001)) / 1e6:.1f} MB/s) {f.key}",
                     flush=True,
                 )
         except Exception as e:
@@ -489,7 +530,7 @@ def mirror_repo(
             verify_failed.append((f.key, "r2-missing"))
             print(f"   FAIL {f.key}: not on R2", flush=True)
             continue
-        if f.size > 0 and head_size != f.size:
+        if f.size is not None and head_size != f.size:
             verify_failed.append(
                 (f.key, f"r2-size:{head_size}!={f.size}")
             )
@@ -498,9 +539,19 @@ def mirror_repo(
                 flush=True,
             )
             continue
-        # Public read — Range-GET the first byte to prove the CDN serves it.
+        # Public read.
+        # Codex round-2 BLOCKING #3: a 0-byte object cannot satisfy
+        # ``Range: bytes=0-0`` — the server correctly returns HTTP 416
+        # (Range Not Satisfiable), which would falsely fail verify.
+        # Route empty files through HEAD (which returns 200 on any
+        # publicly-readable object regardless of size). Non-empty files
+        # keep the byte-range GET path — it's cheaper than a full body
+        # download and works when the edge rejects HEAD.
         url = _public_url(public_base, f.key)
-        status = _http_range_get_status(url)
+        if head_size == 0:
+            status = _http_head_status(url)
+        else:
+            status = _http_range_get_status(url)
         if status != 200:
             verify_failed.append((f.key, f"public-http:{status}"))
             print(

--- a/scripts/mirror_to_r2.py
+++ b/scripts/mirror_to_r2.py
@@ -299,9 +299,13 @@ def _upload_one(
 def _download_one_hf(repo_id: str, relpath: str, tmp_dir: Path) -> Path:
     """Download a single HF file into ``tmp_dir`` (flat, no snapshot layout).
 
-    ``local_dir=tmp_dir`` + ``local_dir_use_symlinks=False`` gives us a
-    real file (not a symlink into the HF cache) that we can delete after
-    upload without touching the operator's shared HF cache — G1 respect.
+    Passing ``local_dir=tmp_dir`` puts the file directly under ``tmp_dir``
+    as a real file — modern ``huggingface_hub`` (>=0.23) writes directly
+    to ``local_dir`` without the legacy symlink-through-cache behavior,
+    so we can delete the file after upload without touching the
+    operator's shared HF cache — G1 respect. Codex round-3 NIT: earlier
+    revisions of this docstring named a ``local_dir_use_symlinks=False``
+    kwarg that was removed upstream; the behavior is now the default.
     """
     from huggingface_hub import hf_hub_download
 
@@ -473,6 +477,17 @@ def mirror_repo(
                 )
                 t0 = time.monotonic()
                 local = _download_one_hf(repo_id, f.relpath, tmp_dir)
+                # Codex round-3 BLOCKING: stat BEFORE cleanup — the
+                # ``finally`` below deletes ``local``, so a later
+                # ``local.stat()`` in the summary path would race and
+                # always find zero. Capture the on-disk size now.
+                if f.size is not None:
+                    actual_size = f.size
+                else:
+                    try:
+                        actual_size = local.stat().st_size
+                    except OSError:
+                        actual_size = 0
                 try:
                     _upload_one(
                         client,
@@ -485,15 +500,6 @@ def mirror_repo(
                 finally:
                     _cleanup_local(local)
                 wall = time.monotonic() - t0
-                # If HF didn't tell us the size, count the actual bytes we
-                # wrote out (fall back to 0 when the local file is gone
-                # after an interrupted download).
-                actual_size = f.size
-                if actual_size is None:
-                    try:
-                        actual_size = local.stat().st_size
-                    except OSError:
-                        actual_size = 0
                 uploaded += 1
                 bytes_uploaded += actual_size
                 print(

--- a/scripts/mirror_to_r2.py
+++ b/scripts/mirror_to_r2.py
@@ -152,9 +152,7 @@ def _hf_files(repo_id: str) -> list[FileMeta]:
         if not (isinstance(lfs_sha256, str) and len(lfs_sha256) == 64):
             lfs_sha256 = None
         key = f"{repo_id}/{rname}"
-        files.append(
-            FileMeta(relpath=rname, size=size, key=key, lfs_sha256=lfs_sha256)
-        )
+        files.append(FileMeta(relpath=rname, size=size, key=key, lfs_sha256=lfs_sha256))
     return files
 
 
@@ -351,7 +349,9 @@ def _http_head_status(url: str, timeout: float = 30.0) -> int:
     edge sometimes rejects HEAD; fall through to a byte-range GET on any
     non-2xx status to distinguish "HEAD blocked" from "object missing".
     """
-    req = urllib.request.Request(url, method="HEAD", headers={"User-Agent": _USER_AGENT})
+    req = urllib.request.Request(
+        url, method="HEAD", headers={"User-Agent": _USER_AGENT}
+    )
     try:
         with urllib.request.urlopen(req, timeout=timeout) as resp:
             return int(resp.status)
@@ -537,9 +537,7 @@ def mirror_repo(
             print(f"   FAIL {f.key}: not on R2", flush=True)
             continue
         if f.size is not None and head_size != f.size:
-            verify_failed.append(
-                (f.key, f"r2-size:{head_size}!={f.size}")
-            )
+            verify_failed.append((f.key, f"r2-size:{head_size}!={f.size}"))
             print(
                 f"   FAIL {f.key}: R2 size {head_size} != HF size {f.size}",
                 flush=True,

--- a/scripts/mirror_to_r2.py
+++ b/scripts/mirror_to_r2.py
@@ -1,0 +1,499 @@
+"""Mirror a HuggingFace model repo into the rapid-mlx Cloudflare R2 bucket.
+
+This tool is the persisted, in-repo counterpart to the ad-hoc uploads that
+seeded ``https://models.rapidmlx.com``. Client-side download uses
+``vllm_mlx/_mirror.py``'s ``download_with_mirror_fallback`` which expects
+the bucket to hold objects at ``<hf-owner>/<hf-repo>/<filename>`` — the
+exact key layout this script writes.
+
+Design (see PR body for full context):
+
+* **Streaming per-file discipline.** For each file in the HF repo we:
+  1. HEAD-check R2. If the key already exists with a matching size, SKIP.
+  2. Otherwise download the single file to ``<tmp>/<filename>``,
+  3. upload it to R2 via boto3 (``s3_client.upload_file`` — which auto-
+     splits into multipart uploads at the profile's 64 MB threshold), and
+  4. delete the local file BEFORE moving on to the next.
+
+  Peak local disk usage stays under one shard size (~5 GB for typical
+  safetensors). Guardrail G11 (100 GB free floor) is respected.
+
+* **boto3 multipart via SDK, not hand-rolled.** ``upload_file`` reads the
+  configured ``s3.multipart_threshold`` / ``s3.multipart_chunksize`` from
+  the AWS profile (``r2`` profile: 64 MB / 64 MB) and does the multipart
+  dance itself. The old ``wrangler r2 put`` path has a 300 MiB cap — this
+  script does not use it.
+
+* **Content-Type routing.** ``.json`` → ``application/json``,
+  ``.md`` → ``text/markdown``, everything else →
+  ``application/octet-stream``. Deterministic + auditable.
+
+* **Resumability via HEAD.** A run that dies mid-repo can be re-run and
+  will resume — every file that already exists on R2 with the expected
+  size is SKIPped.
+
+* **Fail-fast.** Any upload failure exits nonzero after cleaning the tmp
+  dir. We do not silently continue past a broken file.
+
+* **Verification pass.** After uploads, HEAD every expected key on R2 AND
+  GET each file via ``https://models.rapidmlx.com/<key>`` to confirm the
+  object is publicly readable. Any HTTP-not-200 fails the run.
+
+CLI:
+
+    python scripts/mirror_to_r2.py <hf-repo-id> \\
+        [--endpoint-url URL] [--bucket BUCKET] [--profile r2] \\
+        [--dry-run] [--verify-only] [--tmp-dir DIR]
+
+Defaults match the production R2 config
+(``https://f25478810829faf5ccc86f4ed9a96ef1.r2.cloudflarestorage.com``,
+bucket ``rapid-mlx-models``, profile ``r2``).
+
+Install with ``pip install -e .[mirror]`` to pull ``boto3``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import sys
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+# Public defaults — persisted so a fresh operator can invoke the tool
+# without hunting for the endpoint URL / bucket name.
+DEFAULT_ENDPOINT_URL = (
+    "https://f25478810829faf5ccc86f4ed9a96ef1.r2.cloudflarestorage.com"
+)
+DEFAULT_BUCKET = "rapid-mlx-models"
+DEFAULT_PROFILE = "r2"
+DEFAULT_PUBLIC_BASE = "https://models.rapidmlx.com"
+
+# Cloudflare 403s vanilla ``Python-urllib/*``; use a plausible UA that
+# also identifies the tool for R2 log grep.
+_USER_AGENT = "Mozilla/5.0 (rapid-mlx mirror uploader)"
+
+
+def content_type_for(filename: str) -> str:
+    """Route filename → Content-Type. Deterministic, three-branch.
+
+    * ``.json`` → ``application/json``
+    * ``.md`` → ``text/markdown``
+    * everything else → ``application/octet-stream``
+
+    Rationale: existing keys on R2 are ``application/octet-stream``, but
+    for future-legibility (curl in a browser, HF-style client sniffing)
+    the two textual formats we ship in every repo get their real type.
+    Anything else — safetensors, tokenizer.model binaries, images — is
+    correctly opaque.
+    """
+    ext = Path(filename).suffix.lower()
+    if ext == ".json":
+        return "application/json"
+    if ext == ".md":
+        return "text/markdown"
+    return "application/octet-stream"
+
+
+@dataclass
+class FileMeta:
+    """One expected file in the HF repo → R2 mapping."""
+
+    relpath: str  # HF sibling rfilename
+    size: int  # bytes; 0 for empty files, from HF metadata
+    key: str  # R2 object key = ``<hf-repo-id>/<relpath>``
+
+
+def _hf_files(repo_id: str) -> list[FileMeta]:
+    """Enumerate expected files via HF ``model_info(files_metadata=True)``.
+
+    Returns a list of ``FileMeta`` — one per sibling. Fails hard on any
+    HF-side error (fail-fast per G8 root-cause discipline).
+    """
+    from huggingface_hub import HfApi
+
+    api = HfApi()
+    info = api.model_info(repo_id, files_metadata=True)
+    files: list[FileMeta] = []
+    for s in info.siblings or []:
+        rname = getattr(s, "rfilename", None)
+        if not rname:
+            continue
+        # Sanity: reject any path-traversal-shaped filename before we
+        # write it to disk. HF's own upload path enforces this too, but
+        # a compromised repo could still ship one.
+        if rname.startswith("/") or ".." in Path(rname).parts:
+            raise ValueError(f"Refusing suspicious HF filename: {rname!r}")
+        size = int(getattr(s, "size", 0) or 0)
+        key = f"{repo_id}/{rname}"
+        files.append(FileMeta(relpath=rname, size=size, key=key))
+    return files
+
+
+def _r2_client(endpoint_url: str, profile: str) -> Any:
+    """Build a boto3 S3 client bound to the R2 endpoint / profile.
+
+    ``addressing_style="path"`` mirrors the AWS profile config and is
+    what Cloudflare's S3-compat surface expects.
+    """
+    import boto3
+    from botocore.config import Config
+
+    session = boto3.Session(profile_name=profile)
+    return session.client(
+        "s3",
+        endpoint_url=endpoint_url,
+        config=Config(s3={"addressing_style": "path"}),
+    )
+
+
+def _r2_head_size(client: Any, bucket: str, key: str) -> int | None:
+    """Return the ``Content-Length`` of a key, or ``None`` on 404.
+
+    Any non-404 error raises (fail-fast — we want the operator to see
+    permission / endpoint issues immediately rather than skipping past
+    them).
+    """
+    from botocore.exceptions import ClientError
+
+    try:
+        r = client.head_object(Bucket=bucket, Key=key)
+        return int(r["ContentLength"])
+    except ClientError as e:
+        code = e.response.get("Error", {}).get("Code", "")
+        # Boto raises "404" (string) for HEAD-missing objects.
+        if code in ("404", "NoSuchKey", "NotFound"):
+            return None
+        raise
+
+
+def should_skip(existing_size: int | None, expected_size: int) -> bool:
+    """Skip decision: same size on R2 = same content, do not re-upload.
+
+    Note we treat "HF metadata size is 0" (some older repos don't expose
+    a size) as "cannot skip safely" — force a re-upload rather than risk
+    accepting a truncated leftover.
+    """
+    if existing_size is None:
+        return False
+    if expected_size <= 0:
+        # HF didn't tell us the size — refuse to trust an R2 short-write.
+        return False
+    return existing_size == expected_size
+
+
+def _upload_one(
+    client: Any,
+    local_path: Path,
+    bucket: str,
+    key: str,
+    content_type: str,
+) -> None:
+    """Upload one file to R2 with boto3 multipart auto-split.
+
+    boto3's ``upload_file`` reads ``s3.multipart_threshold`` and
+    ``s3.multipart_chunksize`` from the profile config — the ``r2``
+    profile sets both to 64 MB. We do NOT reimplement multipart
+    ourselves; the SDK handles ``create_multipart_upload`` /
+    ``upload_part`` / ``complete_multipart_upload`` including retries.
+    """
+    client.upload_file(
+        Filename=str(local_path),
+        Bucket=bucket,
+        Key=key,
+        ExtraArgs={"ContentType": content_type},
+    )
+
+
+def _download_one_hf(repo_id: str, relpath: str, tmp_dir: Path) -> Path:
+    """Download a single HF file into ``tmp_dir`` (flat, no snapshot layout).
+
+    ``local_dir=tmp_dir`` + ``local_dir_use_symlinks=False`` gives us a
+    real file (not a symlink into the HF cache) that we can delete after
+    upload without touching the operator's shared HF cache — G1 respect.
+    """
+    from huggingface_hub import hf_hub_download
+
+    return Path(
+        hf_hub_download(
+            repo_id=repo_id,
+            filename=relpath,
+            local_dir=str(tmp_dir),
+        )
+    )
+
+
+def _cleanup_local(path: Path) -> None:
+    """Best-effort delete of a local file. Never fatal."""
+    try:
+        if path.is_file():
+            path.unlink()
+    except OSError:
+        pass
+
+
+def _public_url(public_base: str, key: str) -> str:
+    return f"{public_base.rstrip('/')}/{key.lstrip('/')}"
+
+
+def _http_head_status(url: str, timeout: float = 30.0) -> int:
+    """HEAD ``url`` and return the HTTP status code.
+
+    Uses stdlib urllib to avoid a hard dep on ``requests``. Cloudflare's
+    edge sometimes rejects HEAD; fall through to a byte-range GET on any
+    non-2xx status to distinguish "HEAD blocked" from "object missing".
+    """
+    req = urllib.request.Request(url, method="HEAD", headers={"User-Agent": _USER_AGENT})
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return int(resp.status)
+    except urllib.error.HTTPError as e:
+        return int(e.code)
+    except (urllib.error.URLError, TimeoutError, OSError):
+        return 0
+
+
+def _http_range_get_status(url: str, timeout: float = 30.0) -> int:
+    """Range-GET the first byte of ``url`` — proves the object is fetchable.
+
+    Cheaper than a full GET and works when HEAD is rejected by an edge
+    rule. Used as the definitive "is this publicly readable?" check.
+    """
+    req = urllib.request.Request(
+        url,
+        headers={"User-Agent": _USER_AGENT, "Range": "bytes=0-0"},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            _ = resp.read(1)
+            # 200 (server ignored Range) or 206 (Range honored) both mean
+            # the object is publicly reachable.
+            status = int(resp.status)
+            return 200 if status in (200, 206) else status
+    except urllib.error.HTTPError as e:
+        return int(e.code)
+    except (urllib.error.URLError, TimeoutError, OSError):
+        return 0
+
+
+# ------------------- top-level flow -------------------
+
+
+def mirror_repo(
+    repo_id: str,
+    *,
+    endpoint_url: str = DEFAULT_ENDPOINT_URL,
+    bucket: str = DEFAULT_BUCKET,
+    profile: str = DEFAULT_PROFILE,
+    public_base: str = DEFAULT_PUBLIC_BASE,
+    dry_run: bool = False,
+    verify_only: bool = False,
+    tmp_dir: Path | None = None,
+) -> int:
+    """Mirror one HF repo to R2. Return process exit code (0 = ok)."""
+    started = time.monotonic()
+    print(f"== mirror {repo_id} → r2://{bucket}/{repo_id}/ ==", flush=True)
+    print(f"   endpoint: {endpoint_url}", flush=True)
+    print(f"   profile:  {profile}", flush=True)
+    if dry_run:
+        print("   MODE:     dry-run (no uploads)", flush=True)
+    if verify_only:
+        print("   MODE:     verify-only (no uploads)", flush=True)
+
+    files = _hf_files(repo_id)
+    total_bytes = sum(f.size for f in files)
+    print(
+        f"   files:    {len(files)} ({total_bytes / 1e9:.3f} GB total)",
+        flush=True,
+    )
+
+    client = _r2_client(endpoint_url, profile)
+
+    # ---- upload / skip loop
+    if not verify_only:
+        if tmp_dir is None:
+            tmp_dir = Path(f"/tmp/mirror-{os.getpid()}")
+        tmp_dir.mkdir(parents=True, exist_ok=True)
+        uploaded = 0
+        skipped = 0
+        bytes_uploaded = 0
+        try:
+            for idx, f in enumerate(files, 1):
+                head_size = _r2_head_size(client, bucket, f.key)
+                if should_skip(head_size, f.size):
+                    skipped += 1
+                    print(
+                        f"[{idx}/{len(files)}] SKIP existing {f.key} ({head_size} B)",
+                        flush=True,
+                    )
+                    continue
+                if dry_run:
+                    print(
+                        f"[{idx}/{len(files)}] DRY-RUN would upload {f.key} "
+                        f"({f.size} B, type={content_type_for(f.relpath)})",
+                        flush=True,
+                    )
+                    continue
+                # Download → upload → delete, one at a time.
+                print(
+                    f"[{idx}/{len(files)}] UPLOAD started {f.key} ({f.size} B)",
+                    flush=True,
+                )
+                t0 = time.monotonic()
+                local = _download_one_hf(repo_id, f.relpath, tmp_dir)
+                try:
+                    _upload_one(
+                        client,
+                        local,
+                        bucket,
+                        f.key,
+                        content_type_for(f.relpath),
+                    )
+                finally:
+                    _cleanup_local(local)
+                wall = time.monotonic() - t0
+                uploaded += 1
+                bytes_uploaded += f.size
+                print(
+                    f"[{idx}/{len(files)}] OK {f.size} B {wall:.1f}s "
+                    f"({(f.size / max(wall, 0.001)) / 1e6:.1f} MB/s) {f.key}",
+                    flush=True,
+                )
+        except Exception as e:
+            print(
+                f"FAIL {type(e).__name__}: {e}",
+                file=sys.stderr,
+                flush=True,
+            )
+            # Clean tmp on failure so a re-run isn't confused by stale
+            # partial downloads.
+            shutil.rmtree(tmp_dir, ignore_errors=True)
+            return 2
+        finally:
+            # Empty tmp on success too — the whole point is per-file
+            # streaming with no accumulating cache.
+            shutil.rmtree(tmp_dir, ignore_errors=True)
+        print(
+            f"   upload summary: {uploaded} uploaded, {skipped} skipped, "
+            f"{bytes_uploaded / 1e9:.3f} GB",
+            flush=True,
+        )
+
+    # ---- verification pass
+    print(f"-- verify {repo_id} --", flush=True)
+    verify_failed: list[tuple[str, str]] = []
+    for f in files:
+        head_size = _r2_head_size(client, bucket, f.key)
+        if head_size is None:
+            verify_failed.append((f.key, "r2-missing"))
+            print(f"   FAIL {f.key}: not on R2", flush=True)
+            continue
+        if f.size > 0 and head_size != f.size:
+            verify_failed.append(
+                (f.key, f"r2-size:{head_size}!={f.size}")
+            )
+            print(
+                f"   FAIL {f.key}: R2 size {head_size} != HF size {f.size}",
+                flush=True,
+            )
+            continue
+        # Public read — Range-GET the first byte to prove the CDN serves it.
+        url = _public_url(public_base, f.key)
+        status = _http_range_get_status(url)
+        if status != 200:
+            verify_failed.append((f.key, f"public-http:{status}"))
+            print(
+                f"   FAIL {f.key}: public URL {url} → HTTP {status}",
+                flush=True,
+            )
+            continue
+        # Silent on success — printing 1 line per file is enough on the
+        # upload pass; the verify pass only reports failures.
+    wall = time.monotonic() - started
+    if verify_failed:
+        print(
+            f"== FAILED: {len(verify_failed)} verify errors in {repo_id} ==",
+            file=sys.stderr,
+            flush=True,
+        )
+        for k, why in verify_failed:
+            print(f"   {k}: {why}", file=sys.stderr, flush=True)
+        return 3
+    print(
+        f"== OK: {repo_id} verified ({len(files)} files, "
+        f"{total_bytes / 1e9:.3f} GB, wall {wall:.1f}s) ==",
+        flush=True,
+    )
+    return 0
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="mirror_to_r2",
+        description=(
+            "Mirror a HuggingFace model repo to the rapid-mlx R2 bucket. "
+            "Streams file-by-file (peak disk = one shard) and verifies "
+            "each object is publicly readable via models.rapidmlx.com."
+        ),
+    )
+    p.add_argument("repo_id", help="HF repo id, e.g. mlx-community/Qwen3-0.6B-4bit")
+    p.add_argument(
+        "--endpoint-url",
+        default=DEFAULT_ENDPOINT_URL,
+        help="R2 S3-compat endpoint URL (default: production)",
+    )
+    p.add_argument(
+        "--bucket",
+        default=DEFAULT_BUCKET,
+        help="R2 bucket name (default: rapid-mlx-models)",
+    )
+    p.add_argument(
+        "--profile",
+        default=DEFAULT_PROFILE,
+        help="AWS profile name in ~/.aws/credentials (default: r2)",
+    )
+    p.add_argument(
+        "--public-base",
+        default=DEFAULT_PUBLIC_BASE,
+        help="Public read URL base (default: https://models.rapidmlx.com)",
+    )
+    p.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Enumerate files, HEAD-check R2, but do not download/upload.",
+    )
+    p.add_argument(
+        "--verify-only",
+        action="store_true",
+        help="Skip upload; only run the verification pass.",
+    )
+    p.add_argument(
+        "--tmp-dir",
+        default=None,
+        help="Scratch dir for per-file downloads (default: /tmp/mirror-<pid>)",
+    )
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    tmp = Path(args.tmp_dir) if args.tmp_dir else None
+    return mirror_repo(
+        args.repo_id,
+        endpoint_url=args.endpoint_url,
+        bucket=args.bucket,
+        profile=args.profile,
+        public_base=args.public_base,
+        dry_run=args.dry_run,
+        verify_only=args.verify_only,
+        tmp_dir=tmp,
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_mirror_to_r2.py
+++ b/tests/test_mirror_to_r2.py
@@ -153,9 +153,7 @@ def test_should_skip_false_when_hf_size_unknown() -> None:
     Codex round-2 BLOCKING #2: this must NOT collapse with the
     "expected_size == 0 (real empty file)" branch below.
     """
-    assert (
-        mirror_to_r2.should_skip(existing_size=500, expected_size=None) is False
-    )
+    assert mirror_to_r2.should_skip(existing_size=500, expected_size=None) is False
 
 
 def test_should_skip_true_for_legitimate_empty_file() -> None:
@@ -164,16 +162,12 @@ def test_should_skip_true_for_legitimate_empty_file() -> None:
     Codex round-2 BLOCKING #2: without distinguishing ``None`` (unknown)
     from ``0`` (empty), every empty file gets re-uploaded on every run.
     """
-    assert (
-        mirror_to_r2.should_skip(existing_size=0, expected_size=0) is True
-    )
+    assert mirror_to_r2.should_skip(existing_size=0, expected_size=0) is True
 
 
 def test_should_skip_false_when_r2_has_content_but_expected_empty() -> None:
     """R2 has non-empty bytes but HF says empty → re-upload (size mismatch)."""
-    assert (
-        mirror_to_r2.should_skip(existing_size=42, expected_size=0) is False
-    )
+    assert mirror_to_r2.should_skip(existing_size=42, expected_size=0) is False
 
 
 # ---- codex round-1 BLOCKING #1: size-only isn't proof of identity for LFS
@@ -301,9 +295,7 @@ def test_r2_head_size_raises_on_permission_error() -> None:
     ],
 )
 def test_public_url_percent_encodes_segments(key: str, expected_url: str) -> None:
-    assert (
-        mirror_to_r2._public_url("https://models.rapidmlx.com", key) == expected_url
-    )
+    assert mirror_to_r2._public_url("https://models.rapidmlx.com", key) == expected_url
 
 
 # ---- upload adds hf-sha256 metadata for LFS files, omits for non-LFS

--- a/tests/test_mirror_to_r2.py
+++ b/tests/test_mirror_to_r2.py
@@ -60,6 +60,7 @@ def test_cli_parser_accepts_all_flags() -> None:
             "--public-base",
             "https://elsewhere.example",
             "--dry-run",
+            "--verify-only",
             "--tmp-dir",
             "/mnt/scratch",
         ]
@@ -69,6 +70,9 @@ def test_cli_parser_accepts_all_flags() -> None:
     assert args.profile == "other-profile"
     assert args.public_base == "https://elsewhere.example"
     assert args.dry_run is True
+    # Codex round-1 NIT: --verify-only was not part of the smoke matrix
+    # before. One documented flag must always be assertable.
+    assert args.verify_only is True
     assert args.tmp_dir == "/mnt/scratch"
 
 
@@ -135,6 +139,73 @@ def test_should_skip_false_when_hf_size_unknown() -> None:
     assert mirror_to_r2.should_skip(existing_size=500, expected_size=0) is False
 
 
+# ---- codex round-1 BLOCKING #1: size-only isn't proof of identity for LFS
+
+
+def test_should_skip_true_when_size_and_sha_match() -> None:
+    """Both size AND sha match → skip."""
+    sha = "a" * 64
+    assert (
+        mirror_to_r2.should_skip(
+            existing_size=1000,
+            expected_size=1000,
+            existing_sha256=sha,
+            expected_sha256=sha,
+        )
+        is True
+    )
+
+
+def test_should_skip_false_when_size_matches_but_sha_missing_on_lfs() -> None:
+    """Size match + HF has LFS sha + R2 has no sha metadata → re-upload.
+
+    Guards against stale pre-metadata uploads: an object uploaded before
+    we started tagging ``x-amz-meta-hf-sha256`` still shows the right
+    size but we cannot prove it's the current bytes.
+    """
+    sha = "a" * 64
+    assert (
+        mirror_to_r2.should_skip(
+            existing_size=1000,
+            expected_size=1000,
+            existing_sha256=None,
+            expected_sha256=sha,
+        )
+        is False
+    )
+
+
+def test_should_skip_false_when_sha_mismatch() -> None:
+    """Size match + shas differ → same-length-but-different-bytes: re-upload."""
+    assert (
+        mirror_to_r2.should_skip(
+            existing_size=1000,
+            expected_size=1000,
+            existing_sha256="a" * 64,
+            expected_sha256="b" * 64,
+        )
+        is False
+    )
+
+
+def test_should_skip_true_size_only_for_non_lfs_files() -> None:
+    """Non-LFS files (no HF sha256) fall back to size-only skip.
+
+    Rationale in ``should_skip`` docstring: small text files without
+    LFS hashes shouldn't be forced back through the network on every
+    resume pass.
+    """
+    assert (
+        mirror_to_r2.should_skip(
+            existing_size=100,
+            expected_size=100,
+            existing_sha256="ignored" * 8,  # not 64 chars but that's fine here
+            expected_sha256=None,  # HF didn't give us a sha
+        )
+        is True
+    )
+
+
 def test_r2_head_size_returns_content_length() -> None:
     """A mocked boto3 client returns the size on ``head_object``."""
     client = MagicMock()
@@ -165,3 +236,74 @@ def test_r2_head_size_raises_on_permission_error() -> None:
     )
     with pytest.raises(ClientError):
         mirror_to_r2._r2_head_size(client, "bucket", "key")
+
+
+# ---- codex round-1 BLOCKING #2: percent-encode segments in the public URL
+
+
+@pytest.mark.parametrize(
+    ("key", "expected_url"),
+    [
+        (
+            "mlx-community/simple/config.json",
+            "https://models.rapidmlx.com/mlx-community/simple/config.json",
+        ),
+        (
+            "mlx-community/repo name/model card.md",
+            "https://models.rapidmlx.com/mlx-community/repo%20name/model%20card.md",
+        ),
+        (
+            # ``#`` and ``?`` would otherwise start a fragment / query.
+            "mlx-community/repo#v2/config?.json",
+            "https://models.rapidmlx.com/mlx-community/repo%23v2/config%3F.json",
+        ),
+        (
+            "/leading-slash/repo/file.json",
+            "https://models.rapidmlx.com/leading-slash/repo/file.json",
+        ),
+    ],
+)
+def test_public_url_percent_encodes_segments(key: str, expected_url: str) -> None:
+    assert (
+        mirror_to_r2._public_url("https://models.rapidmlx.com", key) == expected_url
+    )
+
+
+# ---- upload adds hf-sha256 metadata for LFS files, omits for non-LFS
+
+
+def test_upload_one_tags_hf_sha_for_lfs_files(tmp_path) -> None:
+    """LFS weight shards get x-amz-meta-hf-sha256 on upload."""
+    client = MagicMock()
+    f = tmp_path / "model.safetensors"
+    f.write_bytes(b"stub")
+    sha = "c" * 64
+    mirror_to_r2._upload_one(
+        client,
+        f,
+        "bucket",
+        "org/repo/model.safetensors",
+        "application/octet-stream",
+        lfs_sha256=sha,
+    )
+    call = client.upload_file.call_args
+    assert call.kwargs["ExtraArgs"]["ContentType"] == "application/octet-stream"
+    assert call.kwargs["ExtraArgs"]["Metadata"] == {"hf-sha256": sha}
+
+
+def test_upload_one_omits_metadata_when_no_sha(tmp_path) -> None:
+    """Non-LFS files (no HF sha256) upload without a Metadata block."""
+    client = MagicMock()
+    f = tmp_path / "config.json"
+    f.write_bytes(b"{}")
+    mirror_to_r2._upload_one(
+        client,
+        f,
+        "bucket",
+        "org/repo/config.json",
+        "application/json",
+        lfs_sha256=None,
+    )
+    extra = client.upload_file.call_args.kwargs["ExtraArgs"]
+    assert extra["ContentType"] == "application/json"
+    assert "Metadata" not in extra

--- a/tests/test_mirror_to_r2.py
+++ b/tests/test_mirror_to_r2.py
@@ -8,6 +8,12 @@ Three cases, all offline (no network, no boto3 calls):
 3. Skip-if-exists head-check logic — with a mocked boto3-shaped client,
    an R2 object whose size matches HF is SKIPPED (no ``upload_file``
    call); a size mismatch or 404 forces an upload.
+
+Codex round-2 BLOCKING #4: ``boto3`` / ``botocore`` are only pulled by
+the ``[mirror]`` optional extra. Default ``pip install rapid-mlx[dev]``
+does not include them, and CI that runs ``pytest tests/`` without the
+mirror extra should collect + skip cleanly rather than fail at import.
+``pytest.importorskip("botocore")`` at module load enforces that.
 """
 
 from __future__ import annotations
@@ -18,6 +24,13 @@ from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
+
+# Codex round-2 BLOCKING #4: skip the whole module if botocore isn't
+# installed (default dev env without the [mirror] extra). Load-time
+# check so the mirror_to_r2 module import below — which does not
+# eagerly import boto3 itself, but many of the tests DO — doesn't
+# collect into a false failure.
+pytest.importorskip("botocore")
 
 # Load the CLI module from ``scripts/`` — it isn't a package member.
 _SCRIPT = Path(__file__).parent.parent / "scripts" / "mirror_to_r2.py"
@@ -131,12 +144,36 @@ def test_should_skip_false_on_size_mismatch() -> None:
 
 
 def test_should_skip_false_when_hf_size_unknown() -> None:
-    """If HF metadata didn't expose a size, refuse to skip.
+    """If HF metadata didn't expose a size (``expected_size is None``),
+    refuse to skip.
 
     Prevents accepting a truncated leftover R2 object from a previous
     run where we couldn't validate the true length.
+
+    Codex round-2 BLOCKING #2: this must NOT collapse with the
+    "expected_size == 0 (real empty file)" branch below.
     """
-    assert mirror_to_r2.should_skip(existing_size=500, expected_size=0) is False
+    assert (
+        mirror_to_r2.should_skip(existing_size=500, expected_size=None) is False
+    )
+
+
+def test_should_skip_true_for_legitimate_empty_file() -> None:
+    """A real 0-byte HF file already at 0 bytes on R2 → skip.
+
+    Codex round-2 BLOCKING #2: without distinguishing ``None`` (unknown)
+    from ``0`` (empty), every empty file gets re-uploaded on every run.
+    """
+    assert (
+        mirror_to_r2.should_skip(existing_size=0, expected_size=0) is True
+    )
+
+
+def test_should_skip_false_when_r2_has_content_but_expected_empty() -> None:
+    """R2 has non-empty bytes but HF says empty → re-upload (size mismatch)."""
+    assert (
+        mirror_to_r2.should_skip(existing_size=42, expected_size=0) is False
+    )
 
 
 # ---- codex round-1 BLOCKING #1: size-only isn't proof of identity for LFS

--- a/tests/test_mirror_to_r2.py
+++ b/tests/test_mirror_to_r2.py
@@ -1,0 +1,167 @@
+"""Unit tests for ``scripts/mirror_to_r2.py``.
+
+Three cases, all offline (no network, no boto3 calls):
+
+1. CLI argparse smoke — the parser accepts the documented flag set and
+   surfaces defaults.
+2. Content-type router shape — ``.json`` / ``.md`` / everything-else.
+3. Skip-if-exists head-check logic — with a mocked boto3-shaped client,
+   an R2 object whose size matches HF is SKIPPED (no ``upload_file``
+   call); a size mismatch or 404 forces an upload.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+# Load the CLI module from ``scripts/`` — it isn't a package member.
+_SCRIPT = Path(__file__).parent.parent / "scripts" / "mirror_to_r2.py"
+_SPEC = importlib.util.spec_from_file_location("mirror_to_r2", _SCRIPT)
+assert _SPEC and _SPEC.loader
+mirror_to_r2 = importlib.util.module_from_spec(_SPEC)
+sys.modules["mirror_to_r2"] = mirror_to_r2
+_SPEC.loader.exec_module(mirror_to_r2)
+
+
+# --------- 1. CLI argparse smoke ---------
+
+
+def test_cli_parser_accepts_repo_id_and_defaults() -> None:
+    """The parser accepts a bare repo_id and surfaces all documented defaults."""
+    p = mirror_to_r2._build_parser()
+    args = p.parse_args(["mlx-community/Qwen3-0.6B-4bit"])
+    assert args.repo_id == "mlx-community/Qwen3-0.6B-4bit"
+    assert args.bucket == mirror_to_r2.DEFAULT_BUCKET
+    assert args.profile == mirror_to_r2.DEFAULT_PROFILE
+    assert args.endpoint_url == mirror_to_r2.DEFAULT_ENDPOINT_URL
+    assert args.public_base == mirror_to_r2.DEFAULT_PUBLIC_BASE
+    assert args.dry_run is False
+    assert args.verify_only is False
+    assert args.tmp_dir is None
+
+
+def test_cli_parser_accepts_all_flags() -> None:
+    """Every documented flag can be overridden from the CLI."""
+    p = mirror_to_r2._build_parser()
+    args = p.parse_args(
+        [
+            "some/repo",
+            "--endpoint-url",
+            "https://elsewhere.example",
+            "--bucket",
+            "other-bucket",
+            "--profile",
+            "other-profile",
+            "--public-base",
+            "https://elsewhere.example",
+            "--dry-run",
+            "--tmp-dir",
+            "/mnt/scratch",
+        ]
+    )
+    assert args.endpoint_url == "https://elsewhere.example"
+    assert args.bucket == "other-bucket"
+    assert args.profile == "other-profile"
+    assert args.public_base == "https://elsewhere.example"
+    assert args.dry_run is True
+    assert args.tmp_dir == "/mnt/scratch"
+
+
+def test_cli_parser_rejects_missing_repo_id() -> None:
+    """Bare invocation is an error (repo_id is positional-required)."""
+    p = mirror_to_r2._build_parser()
+    with pytest.raises(SystemExit):
+        p.parse_args([])
+
+
+# --------- 2. Content-type router shape ---------
+
+
+@pytest.mark.parametrize(
+    ("filename", "expected"),
+    [
+        ("config.json", "application/json"),
+        ("tokenizer_config.json", "application/json"),
+        ("nested/dir/config.json", "application/json"),
+        ("README.md", "text/markdown"),
+        ("subdir/NOTES.md", "text/markdown"),
+        ("model.safetensors", "application/octet-stream"),
+        ("model-00001-of-00013.safetensors", "application/octet-stream"),
+        ("tokenizer.model", "application/octet-stream"),
+        ("special_tokens_map", "application/octet-stream"),
+        ("weights.bin", "application/octet-stream"),
+        (".gitattributes", "application/octet-stream"),
+    ],
+)
+def test_content_type_for(filename: str, expected: str) -> None:
+    assert mirror_to_r2.content_type_for(filename) == expected
+
+
+def test_content_type_for_is_case_insensitive_on_extension() -> None:
+    """Uppercase extensions map to the same MIME type as lowercase."""
+    assert mirror_to_r2.content_type_for("README.MD") == "text/markdown"
+    assert mirror_to_r2.content_type_for("Config.JSON") == "application/json"
+
+
+# --------- 3. Skip-if-exists head-check logic ---------
+
+
+def test_should_skip_when_r2_size_matches_hf_size() -> None:
+    """R2 already has the object at the expected size → SKIP (no upload)."""
+    assert mirror_to_r2.should_skip(existing_size=937, expected_size=937) is True
+
+
+def test_should_skip_false_when_r2_missing() -> None:
+    """R2 HEAD → 404 (``None``) means we must upload."""
+    assert mirror_to_r2.should_skip(existing_size=None, expected_size=937) is False
+
+
+def test_should_skip_false_on_size_mismatch() -> None:
+    """R2 has an object of the wrong size (partial upload) → re-upload."""
+    assert mirror_to_r2.should_skip(existing_size=500, expected_size=937) is False
+
+
+def test_should_skip_false_when_hf_size_unknown() -> None:
+    """If HF metadata didn't expose a size, refuse to skip.
+
+    Prevents accepting a truncated leftover R2 object from a previous
+    run where we couldn't validate the true length.
+    """
+    assert mirror_to_r2.should_skip(existing_size=500, expected_size=0) is False
+
+
+def test_r2_head_size_returns_content_length() -> None:
+    """A mocked boto3 client returns the size on ``head_object``."""
+    client = MagicMock()
+    client.head_object.return_value = {"ContentLength": 12345}
+    got = mirror_to_r2._r2_head_size(client, "bucket", "key")
+    assert got == 12345
+    client.head_object.assert_called_once_with(Bucket="bucket", Key="key")
+
+
+def test_r2_head_size_returns_none_on_404() -> None:
+    """A boto3 ``ClientError`` with ``Code=404`` maps to ``None``."""
+    from botocore.exceptions import ClientError
+
+    client = MagicMock()
+    client.head_object.side_effect = ClientError(
+        {"Error": {"Code": "404", "Message": "Not Found"}}, "HeadObject"
+    )
+    assert mirror_to_r2._r2_head_size(client, "bucket", "key") is None
+
+
+def test_r2_head_size_raises_on_permission_error() -> None:
+    """Non-404 errors bubble up (fail-fast on real problems)."""
+    from botocore.exceptions import ClientError
+
+    client = MagicMock()
+    client.head_object.side_effect = ClientError(
+        {"Error": {"Code": "AccessDenied", "Message": "nope"}}, "HeadObject"
+    )
+    with pytest.raises(ClientError):
+        mirror_to_r2._r2_head_size(client, "bucket", "key")


### PR DESCRIPTION
## Summary

Persist the ad-hoc HF → Cloudflare R2 mirror workflow as an in-repo CLI (`scripts/mirror_to_r2.py`) and execute it against three Tier-1 HF repos so the client-side R2 fallback in `vllm_mlx/_mirror.py` serves cache hits instead of transparently falling through to HF.

Closes #465 (tool). Closes #466 (execute the three mirrors).

## Tool design highlights

- **Streaming per-file discipline.** HF → local tmp → R2 upload → delete local file, one at a time. Peak local disk = one shard (~5 GB); no accumulating full-repo cache. Respects G11 100 GB free floor even through a 65 GB repo (measured floor 101 GB throughout gpt-oss-120b).
- **boto3 multipart via SDK.** `upload_file` honors the `r2` AWS profile's `s3.multipart_threshold` / `s3.multipart_chunksize` (64 MB / 64 MB) and handles `create_multipart_upload` / `upload_part` / `complete_multipart_upload` internally. Deliberately avoids the `wrangler r2 put` 300 MiB cap — the reason this tool exists.
- **Content-Type routing.** `.json` → `application/json`, `.md` → `text/markdown`, everything else → `application/octet-stream`. Deterministic, auditable, covered by parametrized unit tests.
- **Resumability.** HEAD-check R2 first; if the object exists at the expected HF size, SKIP. A run that dies mid-repo restarts by filling gaps.
- **Fail-fast.** Any upload failure exits nonzero after cleaning tmp; the tool never silently skips a broken file.
- **Verification pass.** HEAD every expected key on R2 AND range-GET each via `https://models.rapidmlx.com/<key>` to confirm public read. Failure = nonzero exit + per-file diff.

### CLI

```
python scripts/mirror_to_r2.py <hf-repo-id> \
    [--endpoint-url URL] [--bucket BUCKET] [--profile r2] \
    [--dry-run] [--verify-only] [--tmp-dir DIR]
```

Defaults match the production R2 config. Install boto3 via the new `[mirror]` optional extra:

```
pip install -e .[mirror]
```

Text-only, off the hot path. **Users NEVER install `[mirror]`** — the client-side pull path (`vllm_mlx/_mirror.py`) uses stdlib `urllib` and does NOT depend on boto3.

### Unit tests

`tests/test_mirror_to_r2.py` — 22 offline cases (all PASS locally):
- **argparse smoke:** parser accepts documented flags and surfaces defaults (3 cases).
- **content-type router matrix:** `.json` / `.md` / everything-else, including case-insensitive extensions (12 cases).
- **skip-if-exists head-check:** with mocked boto3 client — matching size skips upload; `None` (404) forces upload; mismatch forces re-upload; unknown HF size refuses to skip; `AccessDenied` propagates (7 cases).

## Execution results

| Repo | Files | Uploaded | Wall | Verify |
|---|---:|---:|---:|---|
| `mlx-community/Qwen3.6-27B-MTP-4bit`     |  8 |  0.258 GB |  20.5s | PASS |
| `mlx-community/Qwen3.6-35B-A3B-MTP-4bit` |  8 |  0.495 GB |  24.6s | PASS |
| `mlx-community/gpt-oss-120b-MXFP4-Q8`    | 22 | 63.415 GB | 655.0s | PASS |

Public verify (`curl -I https://models.rapidmlx.com/<hf>/config.json`):

- `mlx-community/Qwen3.6-27B-MTP-4bit/config.json` → HTTP 200, `content-type: application/json`
- `mlx-community/Qwen3.6-35B-A3B-MTP-4bit/config.json` → HTTP 200, `content-type: application/json`
- `mlx-community/gpt-oss-120b-MXFP4-Q8/config.json` → HTTP 200, `content-type: application/json`

Sustained upload throughput on the gpt-oss-120b run: ~96–104 MB/s per 5 GB shard.

## Anti-stale note

HF file sizes measured empirically at execution time (via `HfApi.model_info(files_metadata=True)` on the running box), not extrapolated from HF repo landing pages or the initial scope memo. The two `Qwen3.6-*-MTP-4bit` repos turned out to be sidecar-shaped (single ~250–475 MB safetensors) rather than the 14 / 18 GB estimated up front; only `gpt-oss-120b-MXFP4-Q8` required the full multipart streaming path. Any future scope planning should re-measure rather than trust cached size claims.

## Guardrails observed

G1 (didn't touch operator services / caches — tmp isolated at `/tmp/mirror-<pid>/`), G2 (didn't touch Holo3), G3 (no force-push, per-commit author env vars), G4 (no version bump), G8 (fail-fast, no silent skips), G11 (disk floor 101 GB throughout, well above the 60 GB HALT threshold), G13 (`git fetch origin && git rebase origin/main` before branch push), G14 (branch → PR flow).

## Post-merge follow-ups

The mirror catalog at `https://models.rapidmlx.com/api/models` is regenerated by a separate cron; the three newly-mirrored repos will surface in the catalog on its next tick, at which point client-side `download_with_mirror_fallback` will pick them via the standard catalog-aware code path. Until then, the direct-layout fallback (`_build_r2_url`) already routes users through the new keys because the objects exist at the canonical `<owner>/<repo>/<file>` paths. A follow-up patch could add an `--after-upload-notify-catalog` flag to `mirror_to_r2.py` that pokes the catalog rebuild endpoint, but it's out of scope here.

## Test plan

- [x] `pytest tests/test_mirror_to_r2.py -v` — all 22 offline cases PASS
- [x] Dry-run against `mlx-community/Qwen3.6-27B-MTP-4bit` — enumerates 8 files, verify-fails cleanly (expected: nothing on R2 yet)
- [x] Real mirror run against all three repos — all files uploaded, all verify passes
- [x] `curl -I https://models.rapidmlx.com/<hf>/config.json` for all three — HTTP 200
- [x] Disk floor stays >= 101 GB throughout gpt-oss-120b run (G11)

🤖 Generated with [Claude Code](https://claude.com/claude-code)