### PR TITLE
chore: bump version to 0.10.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.10.3"
+version = "0.10.5"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## Why

Cut a patch release **because** the past 5 PRs (`#1050`, `#1053`, `#1054`, `#1055`, `#1056`) accumulated hero refactor + user-facing installer fix + integration-test corrections since `v0.10.3` (2026-07-05). W5 pre-release dogfood is GREEN — get these to end-users. Odd-Y patch slot (fix cadence); Gemma 4 perf feature (0.10.4 slot) cascaded because work not ready.

Closes the 0.10.3→0.10.5 release train.

## 0.10.5 · Fix batch

Cut after `#1050` spec-decode unified interface migration landed. Odd-Y patch slot (fix cadence).

### 🔧 Fixes
- `#1053` install.sh: pivot `RECOMMENDED_MODEL` map to 0.10 Tier-1 families + canonical URL
- `#1055` tests/integrations: correct gpt-oss+OpenHands XFAIL reason (format mismatch, not stop-scoping) + digest handling

### 🧱 Internal / Refactor
- `#1050` refactor: remove legacy `_install_mtp` (475 LOC) + `mtp_optimistic` hard-reject on 3 surfaces (scheduler / server / cli) + `spec_decode='suffix'` canonical
- `#1056` scripts/mirror_to_r2.py — HF→R2 mirroring tool (dev/maintenance)

### 📚 Docs
- `#1054` README trim (1142 → ~280 LOC) with per-section → docs links

### Skipped
- 0.10.4 (Gemma 4 perf feature slot) — cascaded, work not ready. See `0.10-TODO.md`.

### W5 pre-release dogfood
GREEN. Wheel size Δ **−4 KB** (dead-code delete reflected). Fresh-venv install-path + spec-decode hard-reject smoke both PASS. Homebrew tap 0.9.13 known-lagging (publish.yml → tap dispatch channel broken; will diagnose during this release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)