### PR TITLE
community-bench: qwen3.6-35b-4bit, qwen3.6-35b-4bit and gpt-oss-20b-mxfp4-q8 on Apple M2 Max

### DIFF
--- a/community-benchmarks/submissions/20260709-apple-m2-max-gpt-oss-20b-mxfp4-q8-92592822946c.json
+++ b/community-benchmarks/submissions/20260709-apple-m2-max-gpt-oss-20b-mxfp4-q8-92592822946c.json
@@ -1,0 +1,134 @@
+{
+  "schema_version": 2,
+  "submission_id": "92592822946c",
+  "submitted_at": "2026-07-09T07:38:02+00:00",
+  "hardware": {
+    "chip": "Apple M2 Max",
+    "ram_gb": 32,
+    "cpu_cores": 12,
+    "gpu_cores": 38
+  },
+  "software": {
+    "macos": "26.5.2",
+    "rapid_mlx": "0.10.5",
+    "mlx": "0.32.0",
+    "python": "3.13.13"
+  },
+  "model": {
+    "alias": "gpt-oss-20b-mxfp4-q8",
+    "hf_path": "mlx-community/gpt-oss-20b-MXFP4-Q8"
+  },
+  "config": {
+    "rounds": 5,
+    "warmup_rounds": 1,
+    "sampling": "greedy",
+    "buckets_spec": {
+      "short": {
+        "prompt_tokens": 512,
+        "max_tokens": 128
+      },
+      "long": {
+        "prompt_tokens": 2048,
+        "max_tokens": 512
+      }
+    },
+    "prompt_hash": "3414e7611df5cfbc"
+  },
+  "buckets": {
+    "short": {
+      "decode_tps": {
+        "median": 86.02819429237304,
+        "min": 85.93344015278367,
+        "max": 86.17436134337915,
+        "stddev": 0.07761622780715476
+      },
+      "prefill_tps": {
+        "median": 599.1820259647302,
+        "min": 596.2582538257468,
+        "max": 600.2146504061365,
+        "stddev": 1.3595395247553577
+      },
+      "ttft_ms": {
+        "median": 881.2013330170885,
+        "min": 879.6852919913363,
+        "max": 885.5223330028821,
+        "stddev": 2.0069330063517525
+      },
+      "rounds_raw": [
+        {
+          "decode_tps": 86.17436134337915,
+          "prefill_tps": 596.2582538257468,
+          "ttft_ms": 885.5223330028821
+        },
+        {
+          "decode_tps": 86.01892721271321,
+          "prefill_tps": 599.1820259647302,
+          "ttft_ms": 881.2013330170885
+        },
+        {
+          "decode_tps": 86.05178971964932,
+          "prefill_tps": 599.0521531452908,
+          "ttft_ms": 881.3923749839887
+        },
+        {
+          "decode_tps": 85.93344015278367,
+          "prefill_tps": 600.2146504061365,
+          "ttft_ms": 879.6852919913363
+        },
+        {
+          "decode_tps": 86.02819429237304,
+          "prefill_tps": 599.5650598315918,
+          "ttft_ms": 880.6383750052191
+        }
+      ]
+    },
+    "long": {
+      "decode_tps": {
+        "median": 80.08705666811433,
+        "min": 79.9972400169234,
+        "max": 80.42793220343249,
+        "stddev": 0.16415744143833264
+      },
+      "prefill_tps": {
+        "median": 655.8510033648988,
+        "min": 648.8761694426519,
+        "max": 656.6248209063216,
+        "stddev": 3.1168223520062908
+      },
+      "ttft_ms": {
+        "median": 3237.015708000399,
+        "min": 3233.2009579986334,
+        "max": 3271.8107090040576,
+        "stddev": 15.523477819433595
+      },
+      "rounds_raw": [
+        {
+          "decode_tps": 80.08705666811433,
+          "prefill_tps": 648.8761694426519,
+          "ttft_ms": 3271.8107090040576
+        },
+        {
+          "decode_tps": 80.26342004576937,
+          "prefill_tps": 656.2560760196228,
+          "ttft_ms": 3235.0176670006476
+        },
+        {
+          "decode_tps": 79.9972400169234,
+          "prefill_tps": 651.3279397052343,
+          "ttft_ms": 3259.494750003796
+        },
+        {
+          "decode_tps": 80.42793220343249,
+          "prefill_tps": 655.8510033648988,
+          "ttft_ms": 3237.015708000399
+        },
+        {
+          "decode_tps": 80.01698155159244,
+          "prefill_tps": 656.6248209063216,
+          "ttft_ms": 3233.2009579986334
+        }
+      ]
+    }
+  },
+  "peak_ram_mb": 12354
+}

--- a/community-benchmarks/submissions/20260709-apple-m2-max-qwen3-5-9b-4bit-426cc891c0a3.json
+++ b/community-benchmarks/submissions/20260709-apple-m2-max-qwen3-5-9b-4bit-426cc891c0a3.json
@@ -1,0 +1,134 @@
+{
+  "schema_version": 2,
+  "submission_id": "426cc891c0a3",
+  "submitted_at": "2026-07-09T07:28:47+00:00",
+  "hardware": {
+    "chip": "Apple M2 Max",
+    "ram_gb": 32,
+    "cpu_cores": 12,
+    "gpu_cores": 38
+  },
+  "software": {
+    "macos": "26.5.2",
+    "rapid_mlx": "0.10.5",
+    "mlx": "0.32.0",
+    "python": "3.13.13"
+  },
+  "model": {
+    "alias": "qwen3.5-9b-4bit",
+    "hf_path": "mlx-community/Qwen3.5-9B-4bit"
+  },
+  "config": {
+    "rounds": 5,
+    "warmup_rounds": 1,
+    "sampling": "greedy",
+    "buckets_spec": {
+      "short": {
+        "prompt_tokens": 512,
+        "max_tokens": 128
+      },
+      "long": {
+        "prompt_tokens": 2048,
+        "max_tokens": 512
+      }
+    },
+    "prompt_hash": "3414e7611df5cfbc"
+  },
+  "buckets": {
+    "short": {
+      "decode_tps": {
+        "median": 63.50301639314472,
+        "min": 63.435426699733775,
+        "max": 63.60537289048206,
+        "stddev": 0.06354678851449551
+      },
+      "prefill_tps": {
+        "median": 378.32026861616833,
+        "min": 375.7020274212081,
+        "max": 387.3037605316457,
+        "stddev": 4.752701000506205
+      },
+      "ttft_ms": {
+        "median": 1414.1457499936223,
+        "min": 1381.344708002871,
+        "max": 1424.0008329798002,
+        "stddev": 17.46155404068318
+      },
+      "rounds_raw": [
+        {
+          "decode_tps": 63.50301639314472,
+          "prefill_tps": 375.7020274212081,
+          "ttft_ms": 1424.0008329798002
+        },
+        {
+          "decode_tps": 63.60537289048206,
+          "prefill_tps": 387.3037605316457,
+          "ttft_ms": 1381.344708002871
+        },
+        {
+          "decode_tps": 63.497649284709624,
+          "prefill_tps": 385.6911582219667,
+          "ttft_ms": 1387.1202089940198
+        },
+        {
+          "decode_tps": 63.435426699733775,
+          "prefill_tps": 376.98160867346843,
+          "ttft_ms": 1419.1673749883194
+        },
+        {
+          "decode_tps": 63.59201366939935,
+          "prefill_tps": 378.32026861616833,
+          "ttft_ms": 1414.1457499936223
+        }
+      ]
+    },
+    "long": {
+      "decode_tps": {
+        "median": 62.00298958665433,
+        "min": 60.76819922827788,
+        "max": 62.16350530382774,
+        "stddev": 0.516104106339587
+      },
+      "prefill_tps": {
+        "median": 396.9084117721946,
+        "min": 392.07807645674825,
+        "max": 404.40277548501064,
+        "stddev": 4.77055435206615
+      },
+      "ttft_ms": {
+        "median": 5421.905749972211,
+        "min": 5321.427375019994,
+        "max": 5488.70270801126,
+        "stddev": 64.67792170516218
+      },
+      "rounds_raw": [
+        {
+          "decode_tps": 60.76819922827788,
+          "prefill_tps": 396.9084117721946,
+          "ttft_ms": 5421.905749972211
+        },
+        {
+          "decode_tps": 62.00298958665433,
+          "prefill_tps": 404.40277548501064,
+          "ttft_ms": 5321.427375019994
+        },
+        {
+          "decode_tps": 61.77947060592055,
+          "prefill_tps": 402.8027264519527,
+          "ttft_ms": 5342.565625003772
+        },
+        {
+          "decode_tps": 62.115077340669664,
+          "prefill_tps": 392.07807645674825,
+          "ttft_ms": 5488.70270801126
+        },
+        {
+          "decode_tps": 62.16350530382774,
+          "prefill_tps": 394.3228413373247,
+          "ttft_ms": 5457.457124983193
+        }
+      ]
+    }
+  },
+  "peak_ram_mb": 6453
+}

--- a/community-benchmarks/submissions/20260709-apple-m2-max-qwen3-6-35b-4bit-96c1152b8cfe.json
+++ b/community-benchmarks/submissions/20260709-apple-m2-max-qwen3-6-35b-4bit-96c1152b8cfe.json
@@ -1,0 +1,134 @@
+{
+  "schema_version": 2,
+  "submission_id": "96c1152b8cfe",
+  "submitted_at": "2026-07-09T07:40:51+00:00",
+  "hardware": {
+    "chip": "Apple M2 Max",
+    "ram_gb": 32,
+    "cpu_cores": 12,
+    "gpu_cores": 38
+  },
+  "software": {
+    "macos": "26.5.2",
+    "rapid_mlx": "0.10.5",
+    "mlx": "0.32.0",
+    "python": "3.13.13"
+  },
+  "model": {
+    "alias": "qwen3.6-35b-4bit",
+    "hf_path": "mlx-community/Qwen3.6-35B-A3B-4bit"
+  },
+  "config": {
+    "rounds": 5,
+    "warmup_rounds": 1,
+    "sampling": "greedy",
+    "buckets_spec": {
+      "short": {
+        "prompt_tokens": 512,
+        "max_tokens": 128
+      },
+      "long": {
+        "prompt_tokens": 2048,
+        "max_tokens": 512
+      }
+    },
+    "prompt_hash": "3414e7611df5cfbc"
+  },
+  "buckets": {
+    "short": {
+      "decode_tps": {
+        "median": 84.1651336497196,
+        "min": 82.82186257433663,
+        "max": 84.59999014418081,
+        "stddev": 0.6007484922476635
+      },
+      "prefill_tps": {
+        "median": 619.0095817699445,
+        "min": 595.4647289241452,
+        "max": 635.1781865440539,
+        "stddev": 13.476635431977057
+      },
+      "ttft_ms": {
+        "median": 864.2838750092778,
+        "min": 842.2833329823334,
+        "max": 898.4579170064535,
+        "stddev": 19.08400055732796
+      },
+      "rounds_raw": [
+        {
+          "decode_tps": 84.18502075916697,
+          "prefill_tps": 635.1781865440539,
+          "ttft_ms": 842.2833329823334
+        },
+        {
+          "decode_tps": 84.59999014418081,
+          "prefill_tps": 619.0095817699445,
+          "ttft_ms": 864.2838750092778
+        },
+        {
+          "decode_tps": 84.04294658988647,
+          "prefill_tps": 621.4923978272308,
+          "ttft_ms": 860.8311249990948
+        },
+        {
+          "decode_tps": 84.1651336497196,
+          "prefill_tps": 607.0544554704161,
+          "ttft_ms": 881.3047909934539
+        },
+        {
+          "decode_tps": 82.82186257433663,
+          "prefill_tps": 595.4647289241452,
+          "ttft_ms": 898.4579170064535
+        }
+      ]
+    },
+    "long": {
+      "decode_tps": {
+        "median": 80.16361743830764,
+        "min": 77.55089713941071,
+        "max": 80.68135057620391,
+        "stddev": 1.1850632014014082
+      },
+      "prefill_tps": {
+        "median": 753.2159775928258,
+        "min": 733.0536485448935,
+        "max": 753.2527559349404,
+        "stddev": 8.644407054583395
+      },
+      "ttft_ms": {
+        "median": 2857.0822500041686,
+        "min": 2856.9427500187885,
+        "max": 2935.6650830013677,
+        "stddev": 33.61523193338208
+      },
+      "rounds_raw": [
+        {
+          "decode_tps": 80.68135057620391,
+          "prefill_tps": 753.2159775928258,
+          "ttft_ms": 2857.0822500041686
+        },
+        {
+          "decode_tps": 77.55089713941071,
+          "prefill_tps": 738.9578152578391,
+          "ttft_ms": 2912.2095410129987
+        },
+        {
+          "decode_tps": 78.90215196170942,
+          "prefill_tps": 733.0536485448935,
+          "ttft_ms": 2935.6650830013677
+        },
+        {
+          "decode_tps": 80.16361743830764,
+          "prefill_tps": 753.2349157557312,
+          "ttft_ms": 2857.010415988043
+        },
+        {
+          "decode_tps": 80.52485184456168,
+          "prefill_tps": 753.2527559349404,
+          "ttft_ms": 2856.9427500187885
+        }
+      ]
+    }
+  },
+  "peak_ram_mb": 20455
+}


### PR DESCRIPTION
Community benchmark submission.

    chip: Apple M2 Max (32 GB)
    models: qwen3.6-35b-4bit, qwen3.6-35b-4bit, gpt-oss-20b-mxfp4-q8
    rapid-mlx: 0.10.5 