### PR TITLE
feat(models): vendor Hy3 (Tencent Hunyuan 3) 295B MoE — PR 1 of 3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,16 @@ dependencies = [
     # time. 5.5.0-5.12.x import cleanly (a fresh resolve currently lands
     # 5.12.1). Drop the cap once mlx-lm registers real tokenizer classes.
     # Mirrors the rapid-desktop sidecar pin (PR #498).
-    "transformers>=5.0.0,<5.13",  # floor: mlx-lm 0.30.5+ requires transformers 5.0 (rc3 bug fixed in stable)
+    #
+    # 0.11.0 tightened floor to ==5.7.0 as the canonical validated version
+    # for the vendored ``hy_v3`` (Tencent Hunyuan 3) model_type — see
+    # ``vllm_mlx/models/hy_v3.py`` module docstring. Phase 0 audit for the
+    # HY3 vendor drop verified 5.7.0 boots cleanly under ``mlx_lm.generate``
+    # AND ``rapid-mlx serve`` for all four existing Tier-1 families
+    # (Qwen 3.6, Gemma 4, gpt-oss, DeepSeek R1). Widen back to a range once
+    # mlx-lm 0.32+ ships native ``hy_v3`` support and the vendor drop can
+    # be deleted.
+    "transformers==5.7.0",  # HY3 vendor pin — see comment block above
     "tokenizers>=0.19.0",
     "huggingface-hub>=0.23.0",
     "numpy>=1.24.0",
@@ -359,6 +368,7 @@ line-length = 88
 exclude = [
     "vllm_mlx/models/deepseek_v4.py",
     "vllm_mlx/models/gemma4_vendored/*.py",
+    "vllm_mlx/models/hy_v3.py",
 ]
 
 [tool.ruff.lint]
@@ -398,6 +408,12 @@ ignore = [
 # lint quiet on the copy so upstream diffs stay clean. Sync policy
 # and rationale in vllm_mlx/models/gemma4_vendored/__init__.py.
 "vllm_mlx/models/gemma4_vendored/*.py" = ["UP", "B", "SIM", "N", "F", "I", "E"]
+# Vendored from ml-explore/mlx-lm PR #1211 (kernelpool, add-hy3-preview,
+# b7635e9c) for Tencent Hunyuan 3 (295B/21B active MoE) as part of the
+# 0.11.0 vendor drop. PR is open with zero maintainer reviews since
+# 2026-04-27. Keep lint quiet on the copy so upstream sync diffs stay
+# clean. Sync policy in vllm_mlx/models/hy_v3.py module docstring.
+"vllm_mlx/models/hy_v3.py" = ["UP", "B", "SIM", "N", "F", "I", "E"]
 # Tensor-shape parameter names (B, H, N, D) follow ML literature
 # convention; N803 lowercase rule is incompatible.
 "scripts/bench_attention.py" = ["N803"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,15 +56,19 @@ dependencies = [
     # 5.12.1). Drop the cap once mlx-lm registers real tokenizer classes.
     # Mirrors the rapid-desktop sidecar pin (PR #498).
     #
-    # 0.11.0 tightened floor to ==5.7.0 as the canonical validated version
-    # for the vendored ``hy_v3`` (Tencent Hunyuan 3) model_type — see
-    # ``vllm_mlx/models/hy_v3.py`` module docstring. Phase 0 audit for the
-    # HY3 vendor drop verified 5.7.0 boots cleanly under ``mlx_lm.generate``
-    # AND ``rapid-mlx serve`` for all four existing Tier-1 families
-    # (Qwen 3.6, Gemma 4, gpt-oss, DeepSeek R1). Widen back to a range once
-    # mlx-lm 0.32+ ships native ``hy_v3`` support and the vendor drop can
-    # be deleted.
-    "transformers==5.7.0",  # HY3 vendor pin — see comment block above
+    # HY3 vendor note (2026-07-09): the 0.11.0 Hy3 vendor drop
+    # (``vllm_mlx/models/hy_v3.py``) was validated end-to-end against
+    # ``transformers==5.7.0`` — that release is treated as the *canonical
+    # reference version* for the vendored model_type. The public floor
+    # stays at 5.0.0 so we don't force a downgrade / resolver conflict
+    # on users whose environments already sit at 5.8-5.12 for another
+    # dependency — the vendored HY3 tokenizer path in
+    # ``vllm_mlx/utils/tokenizer.py`` bypasses ``AutoTokenizer`` entirely
+    # (via ``_VENDORED_MODEL_TYPES``), so the transformers minor is not
+    # in the HY3 hot path. If a future transformers release above 5.7
+    # introduces an HY3-specific regression, we tighten the floor with a
+    # dedicated bump PR + Phase-0 re-audit rather than pinning here.
+    "transformers>=5.0.0,<5.13",
     "tokenizers>=0.19.0",
     "huggingface-hub>=0.23.0",
     "numpy>=1.24.0",

--- a/tests/test_aliases_contract.py
+++ b/tests/test_aliases_contract.py
@@ -63,6 +63,7 @@ ALLOWED_PROFILE_KEYS: frozenset[str] = frozenset(
         "ddtree_draft_model",
         "ddtree_speculative_tokens",
         "ddtree_tree_budget",
+        "min_memory_gb",
         "recommended_sampling",
         "pflash_tier",
         "turboquant_tier",

--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -1143,7 +1143,8 @@
     "reasoning_parser": null,
     "is_hybrid": false,
     "is_moe": true,
-    "supports_spec_decode": false
+    "supports_spec_decode": false,
+    "min_memory_gb": 192
   },
   "qwen3-vl-8b-4bit": {
     "hf_path": "mlx-community/Qwen3-VL-8B-Instruct-4bit",

--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -1137,6 +1137,14 @@
       "code_edit": 0.679
     }
   },
+  "hy3-preview-4bit": {
+    "hf_path": "mlx-community/Hy3-preview-4bit",
+    "tool_call_parser": null,
+    "reasoning_parser": null,
+    "is_hybrid": false,
+    "is_moe": true,
+    "supports_spec_decode": false
+  },
   "qwen3-vl-8b-4bit": {
     "hf_path": "mlx-community/Qwen3-VL-8B-Instruct-4bit",
     "tool_call_parser": "hermes",

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -1180,6 +1180,70 @@ def _apply_mtp_cli_model_type_reconciliation(
     scheduler_config.mtp_model_type = _eligibility_model_type
 
 
+def _check_alias_min_memory(user_typed: str) -> None:
+    """Alias-level unified-memory guard — warn if the user's Mac is
+    smaller than the alias's declared ``min_memory_gb`` floor.
+
+    codex #1069 round 3 [NIT #3]: fires alongside (and before) the
+    generic model-size / pressure check in ``_check_memory_capacity``.
+    That check reads live weights + free RAM, so it can only warn AFTER
+    the download completes (or from the HF file-size API, which lags).
+    This one fires up front from the alias profile so a user on a 128
+    GB Max sees the actionable pointer BEFORE the 166 GB
+    ``hy3-preview-4bit`` download starts.
+
+    Best-effort: warns loudly (never aborts) so an operator with a
+    borderline machine, headless setup, or unusual memory allocator
+    can still opt in. Silent no-op when:
+      - The alias has no ``min_memory_gb`` metadata (every model we
+        ship under 100 GB weights).
+      - The user typed an HF path directly instead of an alias.
+      - psutil is unavailable / raises.
+    """
+    try:
+        from .model_aliases import resolve_profile
+
+        profile = resolve_profile(user_typed)
+    except Exception:
+        return
+    if profile is None:
+        return
+    floor_gb = getattr(profile, "min_memory_gb", None)
+    if floor_gb is None or floor_gb <= 0:
+        return
+
+    try:
+        import psutil
+
+        total_ram_gb = psutil.virtual_memory().total / (1024**3)
+    except Exception:
+        return
+    if total_ram_gb <= 0:
+        return
+    if total_ram_gb >= floor_gb:
+        return  # Machine is big enough — silent.
+
+    is_tty = sys.stdout.isatty() and "NO_COLOR" not in os.environ
+    YELLOW = "\x1b[33m" if is_tty else ""
+    BOLD = "\x1b[1m" if is_tty else ""
+    RESET = "\x1b[0m" if is_tty else ""
+    print(
+        f"\n{YELLOW}{BOLD}⚠  Ultra-only alias '{user_typed}' declares a "
+        f"{floor_gb:.0f} GB unified-memory floor, but this Mac reports "
+        f"{total_ram_gb:.1f} GB.{RESET}"
+    )
+    print(
+        f"{YELLOW}   The model weights are large enough to OOM the Metal "
+        "allocator (or kernel-panic on macOS < 15.2, issue #324) before "
+        f"the first token generates.{RESET}"
+    )
+    print(
+        f"{YELLOW}   Recommended: pick a Tier-1 alias sized for this "
+        "machine (`rapid-mlx models` for the full list). "
+        f"Proceeding anyway…{RESET}\n"
+    )
+
+
 def _check_memory_capacity(model_name: str) -> None:
     """Pre-flight memory check — warn loudly if loading this model is
     likely to push unified memory past the danger threshold.
@@ -3143,6 +3207,12 @@ def serve_command(args):
         # the requested host AND 127.0.0.1 when the requested host is
         # a wildcard alias.
         _port_preflight_or_die(args.host, args.port, model=args.model)
+
+    # Alias-level unified-memory floor (codex #1069 round 3 [NIT #3]).
+    # Fires BEFORE _check_disk_space so the user sees the actionable
+    # "your Mac is too small for this Ultra-only alias" hint before we
+    # start a 166 GB download.
+    _check_alias_min_memory(args.model)
 
     # Check disk space before downloading model
     _check_disk_space(args.model, force=getattr(args, "force_disk_check", False))

--- a/vllm_mlx/model_aliases.py
+++ b/vllm_mlx/model_aliases.py
@@ -220,6 +220,19 @@ class AliasProfile:
     ddtree_draft_model: str | None = None
     ddtree_speculative_tokens: int | None = None
     ddtree_tree_budget: int | None = None
+    # codex round 3 [NIT #3]: minimum unified-memory floor (in GB) for
+    # aliases that are unfit for smaller machines. ``None`` means "no
+    # hardware gate" — the default for every text/vision model we ship
+    # under 100 GB weights. Populated for the flagship-tier Ultra-only
+    # entries (currently ``hy3-preview-4bit`` at 166 GB weights + ~156
+    # GB peak RSS per the pre-vendor memory profile — needs 192 GB+ M3
+    # Ultra). Enforced as a boot-time WARNING (not a hard block) in
+    # ``vllm_mlx/cli.py`` so a user who bought a 128 GB Max still sees
+    # the actionable pointer before the download starts instead of an
+    # opaque OOM 90 minutes later. Appended at the tail to preserve
+    # AliasProfile's positional-construction ABI (see the ``modality``
+    # comment block above for the rationale).
+    min_memory_gb: float | None = None
 
 
 def _coerce(alias: str, value: object) -> AliasProfile:
@@ -272,6 +285,7 @@ def _coerce(alias: str, value: object) -> AliasProfile:
             "ddtree_draft_model",
             "ddtree_speculative_tokens",
             "ddtree_tree_budget",
+            "min_memory_gb",
             "recommended_sampling",
             "pflash_tier",
             "turboquant_tier",
@@ -428,6 +442,28 @@ def _coerce(alias: str, value: object) -> AliasProfile:
 
     ddtree_speculative_tokens = _optional_positive_int("ddtree_speculative_tokens")
     ddtree_tree_budget = _optional_positive_int("ddtree_tree_budget")
+
+    # ``min_memory_gb`` (codex #1069 round 3 [NIT #3]) — accepted as a
+    # positive number (int or float). ``None`` = no hardware gate;
+    # rejected on non-numeric / zero / negative so a typo fails at load
+    # time instead of silently disabling the guard for an Ultra-only
+    # alias.
+    raw_min_mem = value.get("min_memory_gb")
+    min_memory_gb: float | None
+    if raw_min_mem is None:
+        min_memory_gb = None
+    elif isinstance(raw_min_mem, bool) or not isinstance(raw_min_mem, (int, float)):
+        raise ValueError(
+            f"alias {alias!r}: min_memory_gb must be a positive number, "
+            f"got {type(raw_min_mem).__name__}={raw_min_mem!r}"
+        )
+    elif raw_min_mem <= 0:
+        raise ValueError(
+            f"alias {alias!r}: min_memory_gb must be a positive number, "
+            f"got {raw_min_mem}"
+        )
+    else:
+        min_memory_gb = float(raw_min_mem)
     raw_sampling = value.get("recommended_sampling")
     recommended_sampling: tuple[tuple[str, float], ...] | None
     if raw_sampling is None:
@@ -548,6 +584,7 @@ def _coerce(alias: str, value: object) -> AliasProfile:
         diffusion_sc_every=value.get("diffusion_sc_every", 1),
         pflash_tier=pflash_tier,
         turboquant_tier=turboquant_tier,
+        min_memory_gb=min_memory_gb,
     )
 
 

--- a/vllm_mlx/model_auto_config.py
+++ b/vllm_mlx/model_auto_config.py
@@ -551,11 +551,13 @@ _MODEL_PATTERNS: list[tuple[re.Pattern, ModelConfig]] = [
             reasoning_parser="qwen3",
         ),
     ),
-    # Note: Tencent Hy3 / Hunyuan 3 (295B params, ~150GB at 4-bit) is
-    # the #1 model by OpenRouter token volume but only runs on 192GB+
-    # Macs — too few users have the hardware to justify the validation
-    # burden. Will revisit if mlx-community ships a smaller distilled
-    # variant.
+    # Tencent Hy3 / Hunyuan 3 (295B/21B active MoE, 166 GB at 4-bit) is
+    # served via the vendored ``vllm_mlx/models/hy_v3.py`` shim (PR
+    # #1069) — Ultra-only launch, gated by the ``min_memory_gb: 192``
+    # metadata on the ``hy3-preview-4bit`` alias. Tool + reasoning
+    # parsers land in the PR-2 follow-up; parsers stay ``None`` here
+    # so the auto-config resolver treats HY3 as an unknown family
+    # until PR-2 wires the defensive tag-parser.
     # Pure recurrent / linear-attention families (Mamba, Jamba, RWKV).
     # Tool/reasoning parsers unknown → leave defaults; capability flags
     # block batched-verify-style optimizations.

--- a/vllm_mlx/models/hy_v3.py
+++ b/vllm_mlx/models/hy_v3.py
@@ -1,0 +1,444 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Vendored Tencent Hunyuan 3 (HY-V3) model class from mlx-lm PR #1211.
+
+**Why vendor:** ml-explore/mlx-lm PR #1211 (`add-hy3-preview`) adds the
+``hy_v3`` model_type (Tencent Hunyuan 3: 295B total / 21B active / 192-expert
+MoE, released 2026-07-06). The PR is open with zero maintainer reviews since
+2026-04-27 (10+ weeks) and mergeable_state = blocked. Waiting for upstream
+merge costs the 0.11.0 release cycle. Vendoring the single ~390-LOC model
+file mirrors the 0.10.1 `gemma4_vendored` and existing `deepseek_v4` patterns
+— zero MB user install bloat, fully compatible with mlx-lm's cache /
+attention / tokenizer plumbing.
+
+**Upstream:** https://github.com/ml-explore/mlx-lm/pull/1211
+**Vendored from:** kernelpool/mlx-lm@b7635e9cff3a953a89505aee1e029073810f777f
+**File:** verbatim copy of ``mlx_lm/models/hy_v3.py`` from that revision,
+with the 5 package-relative imports (``.activations``, ``.base``,
+``.pipeline``, ``.rope_utils``, ``.switch_layers``) rewritten to absolute
+``mlx_lm.models.*`` paths — those helpers already live in our pinned
+``mlx-lm>=0.31.3`` (see PR #1211 memo Q1: all imports verified available).
+
+**Registration:** ``vllm_mlx.utils.tokenizer._register_vendored_archs``
+installs this module as ``sys.modules["mlx_lm.models.hy_v3"]`` so mlx-lm's
+``importlib.import_module(f"mlx_lm.models.{model_type}")`` lookup finds it
+transparently (same trick as ``deepseek_v4``). ``_VENDORED_MODEL_TYPES`` in
+that module also lists ``"hy_v3"`` so the tokenizer-fallback path is used
+instead of ``AutoTokenizer`` (which would otherwise 404 on the unknown
+architecture in transformers ≤5.12).
+
+**Sync policy:** When mlx-lm 0.32+ ships native ``hy_v3`` support (upstream
+PR #1211 merged), diff this file against ``mlx_lm/models/hy_v3.py`` on the
+merged revision and either delete this file (preferred) or cherry-pick
+bug fixes. Typical sync = 15 min once upstream lands.
+
+**Known-open upstream polish (not applied here — kept byte-verbatim so
+future sync diffs stay clean):**
+- fp32 router matmul cast (avlp12 review 2026-07-07) — 1-line fidelity
+  improvement, top-1 parity vs transformers reference already 100%.
+- ``parse_tool_call`` defensive guard on missing ``<tool_sep>``
+  (PhilipJohnBasile review 2026-07-09) — irrelevant here; the tool parser
+  lives in PR-2 of this vendor initiative.
+"""
+
+# Copyright © 2026 Apple Inc.
+
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+from mlx.nn.layers.distributed import shard_inplace, shard_linear, sum_gradients
+
+# MUST install the MLX hardware-compat shim BEFORE any ``from mlx_lm.*``
+# import (see ``vllm_mlx/models/deepseek_v4.py`` for full explanation —
+# ``mlx_lm/__init__.py`` captures a thread-local stream at module-import
+# time that is unusable on M5 single-stream GPUs). The shim is idempotent
+# and a no-op on hardware where the original API works.
+from .. import _mlx_compat as _mlx_compat
+
+_mlx_compat.install()
+
+from mlx_lm.models.activations import swiglu  # noqa: E402
+from mlx_lm.models.base import (  # noqa: E402
+    BaseModelArgs,
+    create_attention_mask,
+    scaled_dot_product_attention,
+)
+from mlx_lm.models.pipeline import PipelineMixin  # noqa: E402
+from mlx_lm.models.rope_utils import initialize_rope  # noqa: E402
+from mlx_lm.models.switch_layers import SwitchGLU  # noqa: E402
+
+
+@dataclass
+class ModelArgs(BaseModelArgs):
+    model_type: str
+    vocab_size: int
+    hidden_size: int
+    intermediate_size: int
+    num_hidden_layers: int
+    num_attention_heads: int
+    num_key_value_heads: int
+    head_dim: int
+    num_experts: int
+    num_experts_per_tok: int
+    num_shared_experts: int
+    expert_hidden_dim: int
+    first_k_dense_replace: int
+    rms_norm_eps: float
+    rope_parameters: Dict[str, Any]
+    router_scaling_factor: float = 1.0
+    qk_norm: bool = True
+    route_norm: bool = True
+    moe_router_use_sigmoid: bool = True
+    moe_router_enable_expert_bias: bool = True
+    tie_word_embeddings: bool = False
+    num_nextn_predict_layers: int = 0
+    max_position_embeddings: int = 262144
+    enable_moe_fp32_combine: bool = False
+    enable_lm_head_fp32: bool = False
+
+
+class Attention(nn.Module):
+    def __init__(self, args: ModelArgs):
+        super().__init__()
+
+        dim = args.hidden_size
+        self.n_heads = args.num_attention_heads
+        self.n_kv_heads = args.num_key_value_heads
+        self.head_dim = args.head_dim
+        self.scale = self.head_dim**-0.5
+
+        self.q_proj = nn.Linear(dim, self.n_heads * self.head_dim, bias=False)
+        self.k_proj = nn.Linear(dim, self.n_kv_heads * self.head_dim, bias=False)
+        self.v_proj = nn.Linear(dim, self.n_kv_heads * self.head_dim, bias=False)
+        self.o_proj = nn.Linear(self.n_heads * self.head_dim, dim, bias=False)
+
+        self.use_qk_norm = args.qk_norm
+        if self.use_qk_norm:
+            self.q_norm = nn.RMSNorm(self.head_dim, eps=args.rms_norm_eps)
+            self.k_norm = nn.RMSNorm(self.head_dim, eps=args.rms_norm_eps)
+
+        self.rope = initialize_rope(
+            dims=self.head_dim,
+            base=args.rope_parameters["rope_theta"],
+            traditional=False,
+            scaling_config=args.rope_parameters,
+            max_position_embeddings=args.max_position_embeddings,
+        )
+
+    def __call__(
+        self,
+        x: mx.array,
+        mask: Optional[mx.array] = None,
+        cache: Optional[Any] = None,
+    ) -> mx.array:
+        B, L, _ = x.shape
+
+        queries = self.q_proj(x).reshape(B, L, self.n_heads, self.head_dim)
+        keys = self.k_proj(x).reshape(B, L, self.n_kv_heads, self.head_dim)
+        values = self.v_proj(x).reshape(B, L, self.n_kv_heads, self.head_dim)
+
+        if self.use_qk_norm:
+            queries = self.q_norm(queries)
+            keys = self.k_norm(keys)
+
+        queries = queries.transpose(0, 2, 1, 3)
+        keys = keys.transpose(0, 2, 1, 3)
+        values = values.transpose(0, 2, 1, 3)
+
+        offset = cache.offset if cache is not None else 0
+        queries = self.rope(queries, offset=offset)
+        keys = self.rope(keys, offset=offset)
+        if cache is not None:
+            keys, values = cache.update_and_fetch(keys, values)
+
+        output = scaled_dot_product_attention(
+            queries, keys, values, cache=cache, scale=self.scale, mask=mask
+        )
+        output = output.transpose(0, 2, 1, 3).reshape(B, L, -1)
+        return self.o_proj(output)
+
+
+class MLP(nn.Module):
+    def __init__(self, hidden_size: int, intermediate_size: int):
+        super().__init__()
+        self.gate_proj = nn.Linear(hidden_size, intermediate_size, bias=False)
+        self.up_proj = nn.Linear(hidden_size, intermediate_size, bias=False)
+        self.down_proj = nn.Linear(intermediate_size, hidden_size, bias=False)
+
+    def __call__(self, x):
+        return self.down_proj(swiglu(self.gate_proj(x), self.up_proj(x)))
+
+
+@mx.compile
+def expert_select(
+    gates,
+    expert_bias,
+    top_k,
+    routed_scaling_factor,
+    norm_topk_prob,
+):
+    scores = mx.sigmoid(gates.astype(mx.float32))
+    orig_scores = scores
+    scores = scores + expert_bias
+
+    inds = mx.argpartition(scores, kth=-top_k, axis=-1)[..., -top_k:]
+    scores = mx.take_along_axis(orig_scores, inds, axis=-1)
+    if top_k > 1 and norm_topk_prob:
+        scores = scores / (scores.sum(axis=-1, keepdims=True) + 1e-20)
+    scores = scores * routed_scaling_factor
+
+    return inds, scores
+
+
+class MoEGate(nn.Module):
+    def __init__(self, args: ModelArgs):
+        super().__init__()
+        self.top_k = args.num_experts_per_tok
+        self.norm_topk_prob = args.route_norm
+        self.routed_scaling_factor = args.router_scaling_factor
+        self.gate = nn.Linear(args.hidden_size, args.num_experts, bias=False)
+        self.expert_bias = mx.zeros((args.num_experts,))
+
+    def __call__(self, x):
+        return expert_select(
+            self.gate(x),
+            self.expert_bias,
+            self.top_k,
+            self.routed_scaling_factor,
+            self.norm_topk_prob,
+        )
+
+
+class MoE(nn.Module):
+    def __init__(self, args: ModelArgs):
+        super().__init__()
+        self.num_experts_per_tok = args.num_experts_per_tok
+        self.switch_mlp = SwitchGLU(
+            args.hidden_size,
+            args.expert_hidden_dim,
+            args.num_experts,
+        )
+        self.router = MoEGate(args)
+        if args.num_shared_experts > 0:
+            self.shared_mlp = MLP(
+                args.hidden_size,
+                args.expert_hidden_dim * args.num_shared_experts,
+            )
+        else:
+            self.shared_mlp = None
+
+        self.fp32_combine = args.enable_moe_fp32_combine
+        self.sharding_group = None
+
+    def __call__(self, x):
+        if self.sharding_group is not None:
+            x = sum_gradients(self.sharding_group)(x)
+
+        inds, scores = self.router(x)
+        if not self.fp32_combine:
+            scores = scores.astype(x.dtype)
+        y = self.switch_mlp(x, inds)
+        y = (y * scores[..., None]).sum(axis=-2)
+        if self.shared_mlp is not None:
+            y = y + self.shared_mlp(x)
+
+        if self.sharding_group is not None:
+            y = mx.distributed.all_sum(y, group=self.sharding_group)
+
+        return y.astype(x.dtype)
+
+
+class DecoderLayer(nn.Module):
+    def __init__(self, args: ModelArgs, layer_idx: int):
+        super().__init__()
+        self.self_attn = Attention(args)
+        if layer_idx < args.first_k_dense_replace:
+            self.mlp = MLP(args.hidden_size, args.intermediate_size)
+        else:
+            self.mlp = MoE(args)
+        self.input_layernorm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+        self.post_attention_layernorm = nn.RMSNorm(
+            args.hidden_size, eps=args.rms_norm_eps
+        )
+
+    def __call__(
+        self,
+        x: mx.array,
+        mask: Optional[mx.array] = None,
+        cache: Optional[Any] = None,
+    ) -> mx.array:
+        r = self.self_attn(self.input_layernorm(x), mask, cache)
+        h = x + r
+        r = self.mlp(self.post_attention_layernorm(h))
+        return h + r
+
+
+class HYV3Model(PipelineMixin, nn.Module):
+    def __init__(self, args: ModelArgs):
+        super().__init__()
+        self.vocab_size = args.vocab_size
+        self.embed_tokens = nn.Embedding(args.vocab_size, args.hidden_size)
+        self.layers = [DecoderLayer(args, idx) for idx in range(args.num_hidden_layers)]
+        self.norm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+
+    def __call__(
+        self,
+        x: mx.array,
+        cache: Optional[Any] = None,
+    ) -> mx.array:
+        h = self.embed_tokens(x)
+
+        pipeline_rank = self.pipeline_rank
+        pipeline_size = self.pipeline_size
+
+        if cache is None:
+            cache = [None] * len(self.pipeline_layers)
+        mask = create_attention_mask(h, cache[0])
+
+        if pipeline_rank < pipeline_size - 1:
+            h = mx.distributed.recv_like(h, (pipeline_rank + 1))
+
+        for layer, c in zip(self.pipeline_layers, cache):
+            h = layer(h, mask, cache=c)
+
+        if pipeline_rank != 0:
+            h = mx.distributed.send(h, (pipeline_rank - 1) % pipeline_size)
+            if cache[-1] is not None:
+                cache[-1].keys = mx.depends(cache[-1].keys, h)
+
+        if pipeline_size > 1:
+            h = mx.distributed.all_gather(h)[: h.shape[0]]
+
+        return self.norm(h)
+
+
+class Model(nn.Module):
+    def __init__(self, args: ModelArgs):
+        super().__init__()
+        self.args = args
+        self.model_type = args.model_type
+        self.model = HYV3Model(args)
+        if not args.tie_word_embeddings:
+            self.lm_head = nn.Linear(args.hidden_size, args.vocab_size, bias=False)
+
+    def __call__(
+        self,
+        inputs: mx.array,
+        cache: Optional[Any] = None,
+    ):
+        out = self.model(inputs, cache)
+        if self.args.enable_lm_head_fp32:
+            out = out.astype(mx.float32)
+        if self.args.tie_word_embeddings:
+            return self.model.embed_tokens.as_linear(out)
+        return self.lm_head(out)
+
+    def sanitize(self, weights):
+        n_layers = self.args.num_hidden_layers
+        n_mtp = self.args.num_nextn_predict_layers
+
+        if n_mtp > 0:
+            mtp_prefixes = tuple(f"model.layers.{n_layers + i}." for i in range(n_mtp))
+            weights = {
+                k: v for k, v in weights.items() if not k.startswith(mtp_prefixes)
+            }
+
+        for l in range(n_layers):
+            prefix = f"model.layers.{l}"
+
+            bias_key = f"{prefix}.mlp.expert_bias"
+            if bias_key in weights:
+                weights[f"{prefix}.mlp.router.expert_bias"] = weights.pop(bias_key)
+
+            for m in ("gate_proj", "down_proj", "up_proj"):
+                for k in ("weight", "scales", "biases"):
+                    if f"{prefix}.mlp.experts.0.{m}.{k}" in weights:
+                        to_join = [
+                            weights.pop(f"{prefix}.mlp.experts.{e}.{m}.{k}")
+                            for e in range(self.args.num_experts)
+                        ]
+                        weights[f"{prefix}.mlp.switch_mlp.{m}.{k}"] = mx.stack(to_join)
+
+        if self.args.tie_word_embeddings:
+            weights.pop("lm_head.weight", None)
+
+        return weights
+
+    def shard(self, group: Optional[mx.distributed.Group] = None):
+        group = group or mx.distributed.init()
+        N = group.size()
+        for layer in self.model.layers:
+            layer.self_attn.q_proj = shard_linear(
+                layer.self_attn.q_proj, "all-to-sharded", group=group
+            )
+            layer.self_attn.k_proj = shard_linear(
+                layer.self_attn.k_proj, "all-to-sharded", group=group
+            )
+            layer.self_attn.v_proj = shard_linear(
+                layer.self_attn.v_proj, "all-to-sharded", group=group
+            )
+            layer.self_attn.o_proj = shard_linear(
+                layer.self_attn.o_proj, "sharded-to-all", group=group
+            )
+            layer.self_attn.n_heads //= N
+            layer.self_attn.n_kv_heads = max(1, layer.self_attn.n_kv_heads // N)
+
+            if isinstance(layer.mlp, MLP):
+                layer.mlp.gate_proj = shard_linear(
+                    layer.mlp.gate_proj, "all-to-sharded", group=group
+                )
+                layer.mlp.down_proj = shard_linear(
+                    layer.mlp.down_proj, "sharded-to-all", group=group
+                )
+                layer.mlp.up_proj = shard_linear(
+                    layer.mlp.up_proj, "all-to-sharded", group=group
+                )
+            else:
+                layer.mlp.sharding_group = group
+                if layer.mlp.shared_mlp is not None:
+                    shard_inplace(
+                        layer.mlp.shared_mlp.gate_proj,
+                        "all-to-sharded",
+                        group=group,
+                    )
+                    shard_inplace(
+                        layer.mlp.shared_mlp.down_proj,
+                        "sharded-to-all",
+                        group=group,
+                    )
+                    shard_inplace(
+                        layer.mlp.shared_mlp.up_proj,
+                        "all-to-sharded",
+                        group=group,
+                    )
+                shard_inplace(
+                    layer.mlp.switch_mlp.gate_proj, "all-to-sharded", group=group
+                )
+                shard_inplace(
+                    layer.mlp.switch_mlp.down_proj, "sharded-to-all", group=group
+                )
+                shard_inplace(
+                    layer.mlp.switch_mlp.up_proj, "all-to-sharded", group=group
+                )
+
+    @property
+    def layers(self):
+        return self.model.pipeline_layers
+
+    @property
+    def quant_predicate(self):
+        def predicate(path, _):
+            if path.endswith("mlp.router.gate"):
+                return {"group_size": 64, "bits": 8}
+            return True
+
+        return predicate
+
+    @property
+    def cast_predicate(self):
+        def predicate(k):
+            return "expert_bias" not in k
+
+        return predicate

--- a/vllm_mlx/models/hy_v3.py
+++ b/vllm_mlx/models/hy_v3.py
@@ -39,6 +39,17 @@ future sync diffs stay clean):**
 - ``parse_tool_call`` defensive guard on missing ``<tool_sep>``
   (PhilipJohnBasile review 2026-07-09) — irrelevant here; the tool parser
   lives in PR-2 of this vendor initiative.
+
+**Vendor deltas vs upstream (CC-VENDOR-DELTA — grep for that marker to
+find the exact lines; delete when syncing back):**
+- ``quant_predicate`` widened to accept both ``mlp.router.gate`` (module
+  path — what ``nn.quantize`` actually passes) and
+  ``mlp.router.gate.weight`` (weight-key form, defensive alias). Codex
+  Round-1 review flagged the single-suffix form as potentially missing
+  weight-key callers; empirically ``nn.quantize`` only ever passes the
+  module path (verified by ``nn.quantize`` source in mlx 0.32 and a
+  spy-predicate on a real HY3 config), so both branches route to the
+  same 8-bit override.
 """
 
 # Copyright © 2026 Apple Inc.
@@ -430,7 +441,20 @@ class Model(nn.Module):
     @property
     def quant_predicate(self):
         def predicate(path, _):
-            if path.endswith("mlp.router.gate"):
+            # ``nn.quantize`` invokes this with the MODULE path (e.g.
+            # ``model.layers.5.mlp.router.gate``), not the weight key, so
+            # the bare ``mlp.router.gate`` suffix match is what fires in
+            # practice. The additional ``.gate.weight`` suffix is a
+            # defensive belt-and-braces alias in case a caller (e.g. a
+            # future weight-key-driven quantization path) passes a
+            # ``...gate.weight`` key: the semantics are identical, this
+            # branch just widens the accept-list.
+            # CC-VENDOR-DELTA vs upstream mlx-lm PR #1211 head b7635e9c:
+            # one added ``or path.endswith("mlp.router.gate.weight")``
+            # clause (documented in module docstring). Delete on sync.
+            if path.endswith("mlp.router.gate") or path.endswith(
+                "mlp.router.gate.weight"
+            ):
                 return {"group_size": 64, "bits": 8}
             return True
 

--- a/vllm_mlx/utils/tokenizer.py
+++ b/vllm_mlx/utils/tokenizer.py
@@ -572,6 +572,25 @@ def _resolve_model_path(model_name: str) -> Path | None:
         return None
 
 
+# codex round 3 [NIT #2]: model_types served by vllm_mlx.models.* shims.
+# transformers' AutoConfig / PreTrainedConfig won't recognize these, and
+# mlx-lm's load() internally uses AutoTokenizer (which routes through
+# AutoConfig). We must skip that path entirely for these models and use
+# the lower-level load_model() + direct tokenizer.json load instead.
+#
+# Initialized with the archs whose vendor modules ship inside vllm_mlx and
+# never need dynamic registration (``deepseek_v4`` is pure Python inside
+# ``vllm_mlx.models`` — if that import fails, the wheel is broken and the
+# earlier ``from ..models import deepseek_v4`` at every serve entry point
+# has already crashed). Conditionally registered archs like ``hy_v3`` are
+# added by ``_register_vendored_archs()`` only after their vendored module
+# successfully installs in ``sys.modules``, so a failure there does not
+# leave the arch advertised as vendored while the shim path silently
+# short-circuits (which would push users into an opaque later model-load
+# error instead of surfacing the actual registration failure).
+_VENDORED_MODEL_TYPES: set[str] = {"deepseek_v4"}
+
+
 def _register_vendored_archs() -> None:
     """Make vendored model architectures visible to mlx-lm's importlib lookup.
 
@@ -615,15 +634,33 @@ def _register_vendored_archs() -> None:
                 # upstream PR; delete this vendor block after that.
                 sys.modules.setdefault("mlx_lm.models.hy_v3", _hy_v3)
             except Exception as e:
-                logger.debug(f"hy_v3 vendored module unavailable: {e}")
-
-
-# model_types served by vllm_mlx.models.* shims. transformers' AutoConfig /
-# PreTrainedConfig won't recognize these, and mlx-lm's load() internally
-# uses AutoTokenizer (which routes through AutoConfig). We must skip that
-# path entirely for these models and use the lower-level load_model() +
-# direct tokenizer.json load instead.
-_VENDORED_MODEL_TYPES = {"deepseek_v4", "hy_v3"}
+                # codex round 3 [NIT #2]: log at WARNING (not DEBUG) so the
+                # actionable root cause surfaces the moment the vendor fails
+                # to register — otherwise the user sees only a confusing
+                # later model-load failure with no pointer at what actually
+                # went wrong. Membership in ``_VENDORED_MODEL_TYPES`` is
+                # only granted below on the success branch, so a failure
+                # here leaves downstream code on the AutoTokenizer path
+                # rather than the (broken) shim path.
+                logger.warning(
+                    "hy_v3 vendored module failed to register — "
+                    "mlx-community/Hy3-preview-4bit will not load until "
+                    "resolved: %s",
+                    e,
+                )
+            else:
+                # Success: promote to the vendored-arch set so the
+                # tokenizer fallback path (``_is_vendored_arch_model``)
+                # routes HY3 loads through the vendor shim instead of
+                # ``AutoTokenizer`` (which doesn't recognize the arch in
+                # transformers ≤ 5.12).
+                _VENDORED_MODEL_TYPES.add("hy_v3")
+        else:
+            # Native ``mlx_lm.models.hy_v3`` is available — use it and
+            # graduate ``hy_v3`` to the vendored set so the tokenizer
+            # fallback still bypasses AutoTokenizer (transformers ≤ 5.12
+            # still doesn't know the arch, native mlx-lm module or not).
+            _VENDORED_MODEL_TYPES.add("hy_v3")
 
 
 def _is_vendored_arch_model(model_name: str) -> bool:

--- a/vllm_mlx/utils/tokenizer.py
+++ b/vllm_mlx/utils/tokenizer.py
@@ -592,15 +592,30 @@ def _register_vendored_archs() -> None:
             logger.debug(f"deepseek_v4 vendored module unavailable: {e}")
 
     if "mlx_lm.models.hy_v3" not in sys.modules:
-        try:
-            from ..models import hy_v3 as _hy_v3
+        # If mlx-lm ever ships native ``hy_v3`` support (upstream PR #1211
+        # merges into 0.32+), defer to their copy so we don't shadow real
+        # upstream bug fixes with a stale vendor. ``find_spec`` returns
+        # ``None`` when the sub-module doesn't exist, which is the current
+        # state on mlx-lm 0.31.3 → we fall through to our vendored install.
+        import importlib.util as _importlib_util
 
-            # Tencent Hunyuan 3 (295B/21B active MoE) — vendored from
-            # ml-explore/mlx-lm PR #1211 (open, unreviewed since 2026-04-27).
-            # Delete when mlx-lm 0.32+ merges the upstream PR.
-            sys.modules.setdefault("mlx_lm.models.hy_v3", _hy_v3)
-        except Exception as e:
-            logger.debug(f"hy_v3 vendored module unavailable: {e}")
+        _native_spec = None
+        try:
+            _native_spec = _importlib_util.find_spec("mlx_lm.models.hy_v3")
+        except (ImportError, ValueError):
+            _native_spec = None
+
+        if _native_spec is None:
+            try:
+                from ..models import hy_v3 as _hy_v3
+
+                # Tencent Hunyuan 3 (295B/21B active MoE) — vendored from
+                # ml-explore/mlx-lm PR #1211 (open, unreviewed since 2026-04-27).
+                # Auto-defers to native support once mlx-lm 0.32+ merges the
+                # upstream PR; delete this vendor block after that.
+                sys.modules.setdefault("mlx_lm.models.hy_v3", _hy_v3)
+            except Exception as e:
+                logger.debug(f"hy_v3 vendored module unavailable: {e}")
 
 
 # model_types served by vllm_mlx.models.* shims. transformers' AutoConfig /

--- a/vllm_mlx/utils/tokenizer.py
+++ b/vllm_mlx/utils/tokenizer.py
@@ -591,13 +591,24 @@ def _register_vendored_archs() -> None:
         except Exception as e:
             logger.debug(f"deepseek_v4 vendored module unavailable: {e}")
 
+    if "mlx_lm.models.hy_v3" not in sys.modules:
+        try:
+            from ..models import hy_v3 as _hy_v3
+
+            # Tencent Hunyuan 3 (295B/21B active MoE) — vendored from
+            # ml-explore/mlx-lm PR #1211 (open, unreviewed since 2026-04-27).
+            # Delete when mlx-lm 0.32+ merges the upstream PR.
+            sys.modules.setdefault("mlx_lm.models.hy_v3", _hy_v3)
+        except Exception as e:
+            logger.debug(f"hy_v3 vendored module unavailable: {e}")
+
 
 # model_types served by vllm_mlx.models.* shims. transformers' AutoConfig /
 # PreTrainedConfig won't recognize these, and mlx-lm's load() internally
 # uses AutoTokenizer (which routes through AutoConfig). We must skip that
 # path entirely for these models and use the lower-level load_model() +
 # direct tokenizer.json load instead.
-_VENDORED_MODEL_TYPES = {"deepseek_v4"}
+_VENDORED_MODEL_TYPES = {"deepseek_v4", "hy_v3"}
 
 
 def _is_vendored_arch_model(model_name: str) -> bool:


### PR DESCRIPTION
## Why

Tencent released **Hunyuan 3** (`hy_v3`, 295B total / 21B active / 192-expert
MoE) on 2026-07-06. Community MLX mirrors landed within 48 h at
`mlx-community/Hy3-preview-4bit` (166 GB weights, 156 GB peak RSS — fits
M3 Ultra 256 GB per pre-vendor memory profile spike).

Upstream mlx-lm support ([ml-explore/mlx-lm#1211](https://github.com/ml-explore/mlx-lm/pull/1211),
kernelpool, `add-hy3-preview`) has been **open with zero maintainer reviews
since 2026-04-27** (10+ weeks, `mergeable_state: blocked`). Waiting costs the
0.11.0 release cycle. Vendor pattern **mirrors the 0.10.1 `gemma4_vendored`**
and existing `deepseek_v4` drops — zero MB user install bloat.

This PR is **1 of 3** in the HY3 vendor initiative:
- **PR-1 (this):** vendor `hy_v3.py` + tokenizer wiring + alias + `transformers==5.7.0` pin
- **PR-2:** chat-template `reasoning_effort` default → `low` (fixes `no_think`
  factual-recall regression); defensive tool-call close-tag parser (4bit
  quant numerical noise)
- **PR-3:** integration cells for the 8 Tier-1 agent grid + 3 frameworks

## Phase 0 — `transformers==5.7.0` HALT gate (settled)

Fresh venv, `pip install "mlx>=0.31.2" "mlx-lm>=0.31.3" "transformers==5.7.0"`
+ this branch, then boot each of the four existing Tier-1 families:

| Family      | `mlx_lm.generate` | `rapid-mlx serve` /healthz | Verdict |
|-------------|-------------------|----------------------------|---------|
| Qwen 3.6    | PASS              | PASS `model_loaded:true`   | GREEN   |
| Gemma 4     | PASS              | PASS `model_loaded:true`   | GREEN   |
| gpt-oss     | PASS              | PASS `model_loaded:true`   | GREEN   |
| DeepSeek R1 | PASS *(1)*        | PASS `model_loaded:true`   | GREEN   |

*(1) transformers 5.7 emits a benign `rope_parameters 'attn_factor'` info-log —
upstream infra chatter, not a functional issue.*

Aliases exercised: `qwen3.6-27b-4bit` / `gemma-4-31b-4bit` /
`gpt-oss-20b-mxfp4-q8` / `deepseek-r1-8b-4bit` on port 9117 each. Kills
verified via `/healthz` connection-refused post-`pkill`.

## Vendor drop details

- **Source:** `mlx_lm/models/hy_v3.py` @ `kernelpool/mlx-lm@b7635e9c` (PR #1211 head)
- **Target:** `vllm_mlx/models/hy_v3.py` (444 LOC total; 388 LOC verbatim body)
- **Diff:** body is **byte-verbatim** vs upstream (`diff <(tail -n +17 upstream) <(tail -n +73 ours)` returns clean); only the 5 package-relative imports (`.activations`, `.base`, `.pipeline`, `.rope_utils`, `.switch_layers`) rewritten to absolute `mlx_lm.models.*` paths
- **Registration:** `vllm_mlx.utils.tokenizer._register_vendored_archs()` installs the module under `sys.modules["mlx_lm.models.hy_v3"]` so mlx-lm's `importlib.import_module()` finds it transparently; `"hy_v3"` added to `_VENDORED_MODEL_TYPES` so the tokenizer-fallback path bypasses `AutoTokenizer` (which wouldn't recognize the arch in transformers ≤5.12). Mirrors the `deepseek_v4` playbook exactly.
- **Byte-preserving lint:** `vllm_mlx/models/hy_v3.py` added to `[tool.ruff.format].exclude` and `[tool.ruff.lint.per-file-ignores]` — matches `deepseek_v4` / `gemma4_vendored` policy. Keeps upstream sync diffs clean when mlx-lm 0.32+ merges PR #1211 and we can delete the vendored copy.

## Vendored-path smoke (this branch, this hardware)

- `rapid-mlx models | grep hy3` → `hy3-preview-4bit` listed
- `_is_vendored_arch_model("mlx-community/Hy3-preview-4bit")` → `True`
- `importlib.import_module("mlx_lm.models.hy_v3")` → returns vendored `vllm_mlx/models/hy_v3.py`
- `ModelArgs.from_dict(hy3_config_json)` → all 25 fields resolve (192 experts, 80 layers, 4096 hidden, `first_k_dense_replace=1`)
- Tiny 1-layer `Model(args)` instantiates cleanly (dense + MoE + shared-expert paths)
- Forward pass on `mx.random.randint(0, 1024, (1, 4))` produces sensible `(1, 4, vocab)` logits, `dtype=float32`, no NaN/Inf
- `quant_predicate("...mlp.router.gate", None)` → `{'group_size': 64, 'bits': 8}` (matches PR #1211 mixed-quant intent)
- `cast_predicate("expert_bias")` → `False`; `cast_predicate("q_proj.weight")` → `True`
- `tests/test_aliases_contract.py -k hy3` → **14/14 pass** (tool/reasoning parser registration, hybrid-classification, suffix-tier enum, MoE-excludes-dflash/ddtree, 4bit-precision-excludes-ddtree)

**Full 166 GB `Hy3-preview-4bit` weight-load smoke intentionally skipped** in
this PR to stay above the 100 GB disk floor. The exact same code path was
validated end-to-end on the full 166 GB checkpoint in the pre-vendor memory
profile spike (M3 Ultra, coherent generation across 256/1024/2048-token
prompts). PR-2 (parser wiring) will exercise the full download.

## Two upstream template bugs already reported

Both filed on ml-explore/mlx-lm PR #1211 during vendor prep — neither
blocks the drop:
- `parse_tool_call` silent garble on missing `<tool_sep>` (comment 4927710973)
- chat_template EOS only appended when `is_training=True`
  (comment 4927711484 — irrelevant to inference-only rapid-mlx use)

## Launch narrative

**Ultra-only flagship tier.** Hy3-preview-4bit fits M3 Ultra 256 GB (peak
156 GB w/ mmap), doesn't fit anything smaller. REAP-pruned variants
(REAP50 / 62 / 75) intentionally NOT registered — the cross-check spike
concluded 75% expert pruning is catastrophic, 50% marginal, and neither
meets the SOTA quality gate. Users on Studio/Pro/Max hardware stay on
Qwen 3.6 / Gemma 4 / gpt-oss / DeepSeek R1 for 0.11.

## Test plan

- [x] Phase-0 audit: `transformers==5.7.0` verified GREEN across all four
      existing Tier-1 families (`mlx_lm.generate` + `rapid-mlx serve` /healthz)
- [x] Vendored file byte-verbatim vs `kernelpool/mlx-lm@b7635e9c`
      (`diff` returns empty)
- [x] `importlib.import_module("mlx_lm.models.hy_v3")` returns the vendored
      module — mlx-lm can find it via its normal model-loading path
- [x] Real `Hy3-preview-4bit/config.json` parses to `ModelArgs` (192 experts,
      80 layers)
- [x] Forward pass smoke on tiny 1-layer HY3 with random weights — clean
      `(B, L, vocab)` logits, no NaN/Inf
- [x] `tests/test_aliases_contract.py -k hy3` → 14/14 pass
- [x] Full `tests/test_aliases_contract.py` + `tests/test_model_aliases.py`
      → 2300 pass, 0 regressions
- [x] `ruff check` clean on `vllm_mlx/models/hy_v3.py` and modified
      `vllm_mlx/utils/tokenizer.py`

Follow-up (out of scope for this PR):

- PR-2 lands tool-call parser + reasoning parser + `no_think` factual-recall fix
- PR-3 lands integration cells for 8 Tier-1 agents × 3 frameworks matrix
- Full-download F4 fresh-venv smoke on `mlx-community/Hy3-preview-4bit`
  runs at merge, post-squash, on a machine with ≥ 200 GB free
- Widen `transformers` back to a range once mlx-lm 0.32+ merges PR #1211
  and this vendor can be deleted