### PR TITLE
test(hy3): Hy3 Tier-1 5th family in integration matrix + Ultra-only docs (PR 3 of 3)

### DIFF
--- a/docs/reference/models.md
+++ b/docs/reference/models.md
@@ -31,9 +31,12 @@ Browse thousands of pre-optimized models at: **https://huggingface.co/mlx-commun
 
 ### Ultra-only: Hunyuan 3 (Hy3)
 
-> ⚠️ **Requires an M3 Ultra with 256 GB unified memory.** Do not attempt
-> on a smaller Mac — it will OOM the Metal allocator (or, on macOS < 15.2,
-> kernel-panic) before the first token generates.
+> ⚠️ **Validated only on an M3 Ultra with 256 GB unified memory.** The
+> runtime enforces a **192 GB** unified-memory floor (`min_memory_gb`) and
+> prints a loud warning below it — it does *not* check the chip
+> generation, so a 192 GB non-Ultra Mac is not blocked but is untested.
+> Do not attempt on a smaller Mac — it will OOM the Metal allocator (or,
+> on macOS < 15.2, kernel-panic) before the first token generates.
 
 Tencent's **Hunyuan 3** is a 295B-parameter Mixture-of-Experts model
 (21B active per token). Only a 4-bit quant is shipped:

--- a/docs/reference/models.md
+++ b/docs/reference/models.md
@@ -18,6 +18,7 @@ Browse thousands of pre-optimized models at: **https://huggingface.co/mlx-commun
 | Phi-3 | 3.8B, 14B | 4-bit |
 | Granite 3.x, 4.x | Various | 4-bit |
 | Nemotron | 3 Nano 30B | 6-bit |
+| Hunyuan 3 (Hy3) | 295B MoE (21B active) — **Ultra-only** | 4-bit |
 
 ### Recommended Models
 
@@ -27,6 +28,44 @@ Browse thousands of pre-optimized models at: **https://huggingface.co/mlx-commun
 | Balanced | `mlx-community/Llama-3.2-3B-Instruct-4bit` | ~1.8 GB |
 | Quality | `mlx-community/Llama-3.1-8B-Instruct-4bit` | ~4.5 GB |
 | Large | `mlx-community/Qwen3-30B-A3B-4bit` | ~16 GB |
+
+### Ultra-only: Hunyuan 3 (Hy3)
+
+> ⚠️ **Requires an M3 Ultra with 256 GB unified memory.** Do not attempt
+> on a smaller Mac — it will OOM the Metal allocator (or, on macOS < 15.2,
+> kernel-panic) before the first token generates.
+
+Tencent's **Hunyuan 3** is a 295B-parameter Mixture-of-Experts model
+(21B active per token). Only a 4-bit quant is shipped:
+
+| Alias | HF path | Weights | Peak RAM | Hardware |
+|-------|---------|---------|----------|----------|
+| `hy3-preview-4bit` | `mlx-community/Hy3-preview-4bit` | ~166 GB | ~156 GB | M3 Ultra 256 GB |
+
+```bash
+rapid-mlx serve hy3-preview-4bit
+```
+
+The alias carries a `min_memory_gb: 192` floor. Before the 166 GB
+download begins, rapid-mlx checks your machine's total unified memory and
+prints a loud warning if it is below the floor:
+
+```
+⚠  Ultra-only alias 'hy3-preview-4bit' declares a 192 GB unified-memory
+   floor, but this Mac reports 128.0 GB.
+   The model weights are large enough to OOM the Metal allocator (or
+   kernel-panic on macOS < 15.2, issue #324) before the first token
+   generates.
+   Recommended: pick a Tier-1 alias sized for this machine
+   (`rapid-mlx models` for the full list). Proceeding anyway…
+```
+
+The warning never aborts (an operator with an unusual allocator setup can
+still opt in), but on any non-Ultra Mac you should pick a smaller alias
+instead — `rapid-mlx models` lists every alias with its size. Hy3's tool
+calling and reasoning are exercised in CI without booting the model via
+an offline parser-level integration test; real-inference coverage runs in
+the weekly Golden Path job on M3 Ultra hardware.
 
 ## Multimodal Models (via mlx-vlm)
 

--- a/tests/integrations/README.md
+++ b/tests/integrations/README.md
@@ -171,10 +171,13 @@ Family choice per matrix run:
 | gpt-oss | `gpt-oss-20b-mxfp4-q8` | Smallest gpt-oss; ~11 GB |
 | Hy3 (Hunyuan 3) | `hy3-preview-4bit` | **Ultra-only** — 295B/21B-active MoE, 166 GB weights / ~156 GB peak (`min_memory_gb: 192`). No cheap alias exists; single-node-infeasible under G11 like DeepSeek V4-Flash. All 14 Hy3 cells `xfail(strict=True)`; real inference is weekly-Golden-Path-only; always-on CI coverage is the offline `test_hy3_offline.py` (parser wire, no model boot) |
 
-## Current cell status (2026-07-06 · 0.10.2)
+## Current cell status (matrix through 0.11.0; PASS/XFAIL data from the 2026-07-06 · 0.10.2 pilot)
 
-Populated as tests land. Empty (🔲) cells will be filled by the 0.10.6 Phase
-4 plumbing per `0.10-TODO.md`.
+The PASS / XFAIL results below are from the 2026-07-06 serial pilot run on
+the 0.10.2 four-family matrix. The 0.11.0 Hy3 column is `xfail(strict=True)`
+across the board (Ultra-only — see the Hy3 note above); its always-on
+coverage is `test_hy3_offline.py`, not these live cells. Empty (🔲) cells
+will be filled by the 0.10.6 Phase 4 plumbing per `0.10-TODO.md`.
 
 ### Agent × Family matrix (11 × 5 = 55)
 

--- a/tests/integrations/README.md
+++ b/tests/integrations/README.md
@@ -7,20 +7,40 @@ Rapid-MLX server on `http://localhost:8000` and a loaded model — the fixtures
 `skip` cells when no server is reachable, so a naïve `pytest tests/` still
 comes out green.
 
-## Two matrices — 11 agents + 3 frameworks × 4 families
+## Two matrices — 11 agents + 3 frameworks × 5 families
 
 0.10.2 PR-2 pilot expanded the matrices to the 0.10.2 **Tier-1 four
 families** (added DeepSeek V4) and the finalized **top-10** commercial /
 open-source agents (three commercial-CLI cells added via docs-confirmed
-BYOK routes). Both matrices share the harness in `conftest.py`:
+BYOK routes). 0.11.0 adds **Hy3 (Tencent Hunyuan 3)** as the Tier-1 5th
+family. Both matrices share the harness in `conftest.py`:
 
-- `test_agents_matrix.py` — **11 Tier-1 agents × 4 families** (Qwen 3.6,
-  Gemma 4, DeepSeek V4, gpt-oss) = 44 cells. Each cell is a lightweight
-  smoke; deep flows live in the dedicated files below.
-- `test_frameworks_matrix.py` — **3 Tier-1 frameworks × 4 families** =
-  12 cells.
+- `test_agents_matrix.py` — **11 Tier-1 agents × 5 families** (Qwen 3.6,
+  Gemma 4, DeepSeek V4, gpt-oss, Hy3) = 55 cells. Each cell is a
+  lightweight smoke; deep flows live in the dedicated files below.
+- `test_frameworks_matrix.py` — **3 Tier-1 frameworks × 5 families** =
+  15 cells.
 
-Total: **56 cells** (up from 33 in #1030).
+Total: **70 cells** (up from 56; +14 Hy3 cells, all strict-xfail — see
+the Hy3 note below).
+
+> **Hy3 is Ultra-only and strict-xfail in always-on CI.** Hy3
+> (`hy3-preview-4bit`) is a 295B/21B-active MoE whose only SKU is 166 GB
+> (~156 GB peak, `min_memory_gb: 192`) — single-node-infeasible on the
+> M3 Ultra under the G11 100 GB free-disk floor, exactly like DeepSeek
+> V4-Flash. Rather than downgrade its 14 cells to plain `skip` (G8:
+> root-cause failures, do not hide behind skips), every Hy3 matrix cell
+> is `xfail(strict=True)` (applied in
+> `conftest.py::pytest_collection_modifyitems`,
+> reason `conftest.py::_HY3_XFAIL_REASON`). Real Hy3 inference runs only
+> in the **weekly Golden Path job on real Ultra hardware**, never in
+> per-PR CI. The always-on CI value-add for Hy3 is the offline
+> parser-level integration test **`test_hy3_offline.py`** — it drives
+> captured Hy3 wire strings through the `hy_v3` tool + reasoning parsers
+> (the parsers `hy3-preview-4bit` wires) and asserts the OpenAI-API-shape
+> contract (tool_calls array well-formed, `<think>` reasoning routed to
+> its own channel, no leak) **without booting the 166 GB model**. That
+> file runs in the normal `pytest tests/` sweep (8 tests, sub-second).
 
 > **Pilot scope note.** This pilot runs the Qwen 3.6 35B-A3B-8bit
 > family end-to-end and leaves Gemma 4 / DeepSeek V4 Flash / gpt-oss
@@ -129,7 +149,7 @@ python3 tests/integrations/test_librechat_docker.py
 | Variable | Default | Purpose |
 |---|---|---|
 | `RAPID_MLX_BASE_URL` | `http://localhost:8000/v1` | Where matrix clients point |
-| `RAPID_MLX_AGENT_MATRIX_FAMILY` | (all) | Restrict to `qwen36` / `gemma4` / `deepseek` / `gptoss` |
+| `RAPID_MLX_AGENT_MATRIX_FAMILY` | (all) | Restrict to `qwen36` / `gemma4` / `deepseek` / `gptoss` / `hy3` (`hy3` is Ultra-only, weekly Golden Path only) |
 | `RAPID_MLX_MATRIX_STRICT` | `0` | If `1`, missing-server → fail (default: skip) |
 
 ## Cheap-alias policy
@@ -149,13 +169,14 @@ Family choice per matrix run:
 | Gemma 4 | `gemma-4-12b-4bit` | Smallest text-only alias; ~7 GB at 4-bit |
 | DeepSeek | `deepseek-r1-32b-4bit` | 0.10.2 PR-2 pilot swapped from `deepseek-v4-flash-8bit` (~155 GB weights, single-node-infeasible on 256 GB M3 Ultra + G11 100 GB floor). R1-Distill-Qwen-32B-4bit at ~16 GB stays above the "no cheap-alias" bar and exercises the same `deepseek` tool-call + `deepseek_r1` reasoning parsers V4-Flash would have. **Full DeepSeek V4 Flash Tier-1 slot tracked in follow-up issue #1041** (hardware plan needed) |
 | gpt-oss | `gpt-oss-20b-mxfp4-q8` | Smallest gpt-oss; ~11 GB |
+| Hy3 (Hunyuan 3) | `hy3-preview-4bit` | **Ultra-only** — 295B/21B-active MoE, 166 GB weights / ~156 GB peak (`min_memory_gb: 192`). No cheap alias exists; single-node-infeasible under G11 like DeepSeek V4-Flash. All 14 Hy3 cells `xfail(strict=True)`; real inference is weekly-Golden-Path-only; always-on CI coverage is the offline `test_hy3_offline.py` (parser wire, no model boot) |
 
 ## Current cell status (2026-07-06 · 0.10.2)
 
 Populated as tests land. Empty (🔲) cells will be filled by the 0.10.6 Phase
 4 plumbing per `0.10-TODO.md`.
 
-### Agent × Family matrix (11 × 4 = 44)
+### Agent × Family matrix (11 × 5 = 55)
 
 Pilot execution 2026-07-06 — **serial 3-family run** against real
 inference under `RAPID_MLX_MATRIX_STRICT=1`. All PASS cells exercised
@@ -264,27 +285,27 @@ Full V4 Flash coverage tracked in follow-up issue **#1041**
 > Empirical rerun of the other three families under the harness digest
 > fix (this PR) deferred to CI.
 
-| Agent | Qwen 3.6 | Gemma 4 | DeepSeek | gpt-oss |
-|---|---|---|---|---|
-| codex-cli | ✅ | ✅ | ✅ | ✅ |
-| claude-code | ✅ | ✅ | ✅ | ✅ |
-| opencode | ✅ | ✅ | XFAIL (arch) | ✅ |
-| qwen-code | ✅ | ✅ | XFAIL (arch) | ✅ |
-| openhands | ✅ | ✅ | ✅ | XFAIL (format) |
-| hermes-agent | ✅ | ✅ | XFAIL (arch) | ✅ |
-| aider | ✅ | ✅ | ✅ | ✅ |
-| kilo-code | ✅ | ✅ | XFAIL (arch) | ✅ |
-| copilot | ✅ | ✅ | XFAIL (arch) | ✅ |
-| droid | ✅ | ✅ | XFAIL (arch) | ✅ |
-| kimi-code | ✅ | ✅ | XFAIL (arch) | ✅ |
+| Agent | Qwen 3.6 | Gemma 4 | DeepSeek | gpt-oss | Hy3 |
+|---|---|---|---|---|---|
+| codex-cli | ✅ | ✅ | ✅ | ✅ | XFAIL (Ultra) |
+| claude-code | ✅ | ✅ | ✅ | ✅ | XFAIL (Ultra) |
+| opencode | ✅ | ✅ | XFAIL (arch) | ✅ | XFAIL (Ultra) |
+| qwen-code | ✅ | ✅ | XFAIL (arch) | ✅ | XFAIL (Ultra) |
+| openhands | ✅ | ✅ | ✅ | XFAIL (format) | XFAIL (Ultra) |
+| hermes-agent | ✅ | ✅ | XFAIL (arch) | ✅ | XFAIL (Ultra) |
+| aider | ✅ | ✅ | ✅ | ✅ | XFAIL (Ultra) |
+| kilo-code | ✅ | ✅ | XFAIL (arch) | ✅ | XFAIL (Ultra) |
+| copilot | ✅ | ✅ | XFAIL (arch) | ✅ | XFAIL (Ultra) |
+| droid | ✅ | ✅ | XFAIL (arch) | ✅ | XFAIL (Ultra) |
+| kimi-code | ✅ | ✅ | XFAIL (arch) | ✅ | XFAIL (Ultra) |
 
-### Framework × Family matrix (3 × 4 = 12)
+### Framework × Family matrix (3 × 5 = 15)
 
-| Framework | Qwen 3.6 | Gemma 4 | DeepSeek | gpt-oss |
-|---|---|---|---|---|
-| LangChain (+ LangGraph) | ✅ | ✅ | XFAIL (arch) | ✅ |
-| PydanticAI | ✅ | ✅ | XFAIL (arch) | ✅ |
-| smolagents | ✅ | ✅ | ✅ | ✅ |
+| Framework | Qwen 3.6 | Gemma 4 | DeepSeek | gpt-oss | Hy3 |
+|---|---|---|---|---|---|
+| LangChain (+ LangGraph) | ✅ | ✅ | XFAIL (arch) | ✅ | XFAIL (Ultra) |
+| PydanticAI | ✅ | ✅ | XFAIL (arch) | ✅ | XFAIL (Ultra) |
+| smolagents | ✅ | ✅ | ✅ | ✅ | XFAIL (Ultra) |
 
 Legend: ✅ passing (real inference · real tool call · semantic assertion;
 or for aider / openhands: real bash-CLI drive · real file rewrite)
@@ -297,13 +318,23 @@ OpenHands parser gap tracked at
 [All-Hands-AI/OpenHands#15167](https://github.com/All-Hands-AI/OpenHands/issues/15167).
 The rapid-mlx wire-level harmony bug that used to underlie this cell is
 fixed in PR #1051 (see `conftest.py::_GPTOSS_OPENHANDS_XFAIL_REASON`).
+· **XFAIL (Ultra)** = Hy3 (`hy3-preview-4bit`) is 166 GB / ~156 GB peak,
+single-node-infeasible in per-PR CI under G11 (like DeepSeek V4-Flash);
+real inference runs weekly on M3 Ultra. Always-on parser coverage is the
+offline `test_hy3_offline.py`. See `conftest.py::_HY3_XFAIL_REASON`.
 
-**Totals across all 4 families**: 56 cells run → **46 PASS · 10 XFAIL · 0 FAIL**
-(9 XFAIL are the R1-Distill architectural tool-emission cells listed in
+**Totals across the 4 always-on families**: 56 cells run → **46 PASS ·
+10 XFAIL · 0 FAIL** (9 XFAIL are the R1-Distill architectural
+tool-emission cells listed in
 `conftest.py::_DEEPSEEK_R1_TOOLCALL_XFAIL_NODEIDS`; 1 XFAIL is the
 gpt-oss+OpenHands cell — gpt-oss harmony format vs CodeActAgent
 text-action parser mismatch, tracked upstream at
 [All-Hands-AI/OpenHands#15167](https://github.com/All-Hands-AI/OpenHands/issues/15167)).
+
+**Hy3 (5th family, 0.11.0)**: +14 cells, all `xfail(strict=True)` in
+always-on CI (Ultra-only, weekly Golden Path). The CI-runnable coverage
+is the 8-test offline `test_hy3_offline.py` (parser wire, no model boot)
+— **8 PASS** in the normal `pytest tests/` sweep.
 
 **DeepSeek family — architectural tool-emission gap.** The 9 DeepSeek
 tool-call cells (7 agents + LangChain + PydanticAI) are marked

--- a/tests/integrations/conftest.py
+++ b/tests/integrations/conftest.py
@@ -424,11 +424,19 @@ _GPTOSS_OPENHANDS_XFAIL_REASON = (
 #
 # Hy3 / Hunyuan 3 is a 295B/21B-active MoE and the 0.11.0 Tier-1 5th
 # family. It has NO cheap alias: the only shipped SKU is the 4-bit
-# ``hy3-preview-4bit`` (166 GB weights, ~156 GB peak resident, gated by
-# ``min_memory_gb: 192`` in ``vllm_mlx/aliases.json``). This mirrors the
-# DeepSeek V4-Flash situation EXACTLY — 166 GB weights + the G11 100 GB
-# free-disk floor = 266 GB required against a 256 GB M3 Ultra, so the
-# model is single-node-infeasible in always-on per-PR CI.
+# ``hy3-preview-4bit`` (166 GB weights on disk, ~156 GB peak unified-memory
+# resident, gated by ``min_memory_gb: 192`` in ``vllm_mlx/aliases.json``).
+# This mirrors the DeepSeek V4-Flash situation EXACTLY. Two independent
+# constraints each make it single-node-infeasible in always-on per-PR CI —
+# they are NOT summed, they are evaluated separately:
+#   * RAM: ~156 GB peak resident leaves almost no headroom under a 256 GB
+#     M3 Ultra's unified memory once the OS + server + Metal scratch are
+#     accounted for, and the alias floor is 192 GB.
+#   * Disk: the 166 GB weight download plus the G11 100 GB free-disk floor
+#     means a CI runner needs ~266 GB free before the pull even starts.
+# A supported M3 Ultra (256 GB RAM, ample disk) CAN boot it — that is what
+# the weekly Golden Path job does; it is the always-on per-PR CI runners
+# that cannot.
 #
 # Following the same G8 discipline as the V4-Flash precedent
 # (root-caused note in ``_FAMILY_ALIASES['deepseek'].reason`` +

--- a/tests/integrations/conftest.py
+++ b/tests/integrations/conftest.py
@@ -433,8 +433,9 @@ _GPTOSS_OPENHANDS_XFAIL_REASON = (
 # Following the same G8 discipline as the V4-Flash precedent
 # (root-caused note in ``_FAMILY_ALIASES['deepseek'].reason`` +
 # README §"DeepSeek family — architectural tool-emission gap"): rather
-# than downgrade the 11 Hy3 cells to plain ``skip`` (G8: "root-cause
-# failures, do not hide behind skips"), every Hy3 cell is marked
+# than downgrade the 14 Hy3 cells (11 agents + 3 frameworks) to plain
+# ``skip`` (G8: "root-cause failures, do not hide behind skips"), every
+# Hy3 cell is marked
 # ``xfail(strict=True)``. These are structural placeholders + a weekly
 # Golden-Path anchor + a regression guard: if a future change made the
 # always-on CI able to boot Hy3 (a smaller quant re-upload, a REAP-pruned
@@ -501,7 +502,11 @@ def pytest_collection_modifyitems(
                     strict=True,
                 )
             )
-        # Hy3 — every cell (all 11 agents + frameworks), 166 GB Ultra-only.
+        # Hy3 — every cell (all 14: 11 agents + 3 frameworks), 166 GB
+        # Ultra-only. The matrix parametrizes by a single ``family``
+        # argument, so every Hy3 nodeid ends in exactly ``[hy3]`` (never a
+        # combined id like ``[agent-hy3]``); the bare-token match below is
+        # the same pattern the merged DeepSeek/gpt-oss blocks use.
         if f"[{_HY3_XFAIL_FAMILY}]" in item.nodeid:
             item.add_marker(
                 pytest.mark.xfail(

--- a/tests/integrations/conftest.py
+++ b/tests/integrations/conftest.py
@@ -3,15 +3,24 @@
 
 Two matrices share this harness:
 
-* ``test_agents_matrix.py`` — 11 Tier-1 agents × 4 families (Qwen 3.6,
-  Gemma 4, DeepSeek V4, gpt-oss) = 44 cells. The three commercial-CLI
+* ``test_agents_matrix.py`` — 11 Tier-1 agents × 5 families (Qwen 3.6,
+  Gemma 4, DeepSeek V4, gpt-oss, Hy3) = 55 cells. The three commercial-CLI
   cells added in the 0.10.2 pilot (copilot / droid / kimi-code) run as
   **wire-smoke via the shared OpenAI SDK helper** — driving the actual
   CLI binaries as subprocesses in <60 s is blocked by vendor OAuth /
   first-run onboarding flows (documented in the pre-flight verdict at
   the top of ``README.md``).
-* ``test_frameworks_matrix.py`` — 3 Tier-1 frameworks × 4 families =
-  12 cells.
+* ``test_frameworks_matrix.py`` — 3 Tier-1 frameworks × 5 families =
+  15 cells.
+
+The 5th family (Hy3 / Hunyuan 3, added 0.11.0) is a 295B/21B-active MoE
+whose only SKU (``hy3-preview-4bit``, 166 GB / ~156 GB peak) is Ultra-only
+and single-node-infeasible under G11 — every Hy3 cell is strict-xfail'd
+(see ``pytest_collection_modifyitems``) and the real-inference coverage
+lives in the weekly Golden Path job, NOT always-on CI. The CI-runnable
+value-add for Hy3 is the offline parser-level integration test in
+``test_hy3_offline.py``, which drives captured Hy3 wire strings through
+the ``hy_v3`` tool + reasoning parsers without booting the 166 GB model.
 
 Both matrices reuse the same server fixture, cheap-alias-per-family fixture,
 and assertion helpers. The fixtures never boot the server themselves — the
@@ -25,9 +34,11 @@ Environment overrides
 
 * ``RAPID_MLX_BASE_URL`` — where to point clients (default: localhost:8000/v1).
 * ``RAPID_MLX_AGENT_MATRIX_FAMILY`` — restrict matrix to one family
-  (``qwen36`` / ``gemma4`` / ``deepseek`` / ``gptoss``). Handy for CI
-  shards, and mandatory in Golden-Path runs so the CI job knows which
-  server alias to boot.
+  (``qwen36`` / ``gemma4`` / ``deepseek`` / ``gptoss`` / ``hy3``). Handy
+  for CI shards, and mandatory in Golden-Path runs so the CI job knows
+  which server alias to boot. ``hy3`` is Ultra-only (166 GB) and its
+  cells are strict-xfail regardless, so this shard is only meaningful in
+  the weekly Golden Path job on real hardware.
 * ``RAPID_MLX_MATRIX_STRICT`` — if ``1``, missing-server / model-mismatch
   raise instead of skipping. Off by default so a naive ``pytest`` run stays
   green.
@@ -116,6 +127,28 @@ _FAMILY_ALIASES: dict[str, FamilyAlias] = {
         family="gptoss",
         alias="gpt-oss-20b-mxfp4-q8",
         reason="smallest gpt-oss (20B MXFP4-Q8 ~11 GB); no <20B in the family",
+    ),
+    "hy3": FamilyAlias(
+        family="hy3",
+        # 0.11.0 Tier-1 5th family — Tencent Hunyuan 3, a 295B/21B-active
+        # MoE. There is NO cheap alias: the only shipped SKU is the
+        # 4-bit ``hy3-preview-4bit`` (166 GB weights, ~156 GB peak
+        # resident). Like DeepSeek V4-Flash it is single-node-infeasible
+        # on the M3 Ultra under the G11 100 GB free floor
+        # (166 GB weights + 100 GB floor > 256 GB), so every HY3 matrix
+        # cell is strict-xfail'd (see the block below) and the family is
+        # exercised only in the weekly Golden Path job on real Ultra
+        # hardware — never in always-on per-PR CI. The offline
+        # parser-level integration test (``test_hy3_offline.py``) covers
+        # the CI-runnable wire-shape layer without booting the 166 GB
+        # model.
+        alias="hy3-preview-4bit",
+        reason=(
+            "Hy3 (Hunyuan 3) 295B/21B-active MoE — 4bit-only "
+            "hy3-preview-4bit is 166 GB (~156 GB peak), Ultra-only "
+            "(min_memory_gb=192). Single-node-infeasible under G11 100 GB "
+            "floor; exercised in the weekly Golden Path job, not always-on CI"
+        ),
     ),
 }
 
@@ -245,6 +278,11 @@ def family_alias_for_active_server(
         return _FAMILY_ALIASES["gemma4"]
     if mid.startswith("gpt-oss") or "gpt-oss" in mid:
         return _FAMILY_ALIASES["gptoss"]
+    # Hy3 / Hunyuan 3 — 0.11.0 Tier-1 5th family. Only bootable in the
+    # weekly Golden Path job on real Ultra hardware (166 GB weights).
+    # Served id resolves to ``mlx-community/Hy3-preview-4bit``.
+    if mid.startswith("hy3") or "hy3" in mid or "hunyuan-3" in mid or "hunyuan3" in mid:
+        return _FAMILY_ALIASES["hy3"]
     # DeepSeek family — 0.10.2 Tier-1. Match both:
     #  * the R1-Distill-Qwen 32B 4-bit variant used as Tier-1 rep in
     #    the PR-2 pilot (served id = "mlx-community/DeepSeek-R1-Distill-Qwen-32B-4bit");
@@ -380,18 +418,64 @@ _GPTOSS_OPENHANDS_XFAIL_REASON = (
 )
 
 
+# --------------------------------------------------------------------------- #
+# Family-wide strict-xfail: Hy3 (Hunyuan 3) — 166 GB single-node-infeasible
+# --------------------------------------------------------------------------- #
+#
+# Hy3 / Hunyuan 3 is a 295B/21B-active MoE and the 0.11.0 Tier-1 5th
+# family. It has NO cheap alias: the only shipped SKU is the 4-bit
+# ``hy3-preview-4bit`` (166 GB weights, ~156 GB peak resident, gated by
+# ``min_memory_gb: 192`` in ``vllm_mlx/aliases.json``). This mirrors the
+# DeepSeek V4-Flash situation EXACTLY — 166 GB weights + the G11 100 GB
+# free-disk floor = 266 GB required against a 256 GB M3 Ultra, so the
+# model is single-node-infeasible in always-on per-PR CI.
+#
+# Following the same G8 discipline as the V4-Flash precedent
+# (root-caused note in ``_FAMILY_ALIASES['deepseek'].reason`` +
+# README §"DeepSeek family — architectural tool-emission gap"): rather
+# than downgrade the 11 Hy3 cells to plain ``skip`` (G8: "root-cause
+# failures, do not hide behind skips"), every Hy3 cell is marked
+# ``xfail(strict=True)``. These are structural placeholders + a weekly
+# Golden-Path anchor + a regression guard: if a future change made the
+# always-on CI able to boot Hy3 (a smaller quant re-upload, a REAP-pruned
+# SKU, or a ≥ 320 GB Mac), the strict marker would XPASS and force a
+# revisit of the always-on-vs-weekly decision.
+#
+# The CI-runnable value-add for Hy3 is NOT here — it is the offline
+# parser-level integration test in ``test_hy3_offline.py``, which feeds
+# captured Hy3 wire strings through the ``hy_v3`` tool + reasoning parsers
+# without booting the 166 GB model. That is where the real always-on
+# coverage for the family lives.
+
+_HY3_XFAIL_FAMILY = "hy3"  # matches the parametrize id
+_HY3_XFAIL_REASON = (
+    "hy3-preview-4bit 166 GB single-node — Ultra-only "
+    "(min_memory_gb=192, ~156 GB peak), 295B/21B-active MoE. Like DeepSeek "
+    "V4-Flash it is single-node-infeasible on the M3 Ultra under the G11 "
+    "100 GB free-disk floor (166 GB + 100 GB > 256 GB). Exercised in the "
+    "weekly Golden Path job on real Ultra hardware, not always-on CI. "
+    "CI-runnable parser coverage lives in "
+    "tests/integrations/test_hy3_offline.py (offline wire → hy_v3 parsers, "
+    "no model boot)."
+)
+
+
 def pytest_collection_modifyitems(
     config: pytest.Config, items: list[pytest.Item]
 ) -> None:
     """Apply strict-xfail markers to family-specific cells.
 
-    Two independent xfail sets are applied here:
+    Three independent xfail sets are applied here:
 
     * The 9 DeepSeek R1-Distill tool-call cells (block above), driven by
       the R1 architectural tool-emission gap.
     * The single gpt-oss × OpenHands cell (block just above), driven by
       the harmony ↔ CodeActAgent text-action format mismatch documented
       upstream.
+    * ALL Hy3 cells (block just above), driven by the 166 GB
+      single-node-infeasible Ultra-only constraint — real inference is
+      weekly-Golden-Path-only; the always-on parser coverage lives in
+      ``test_hy3_offline.py``.
     """
     del config  # unused — items already carry the config context.
     for item in items:
@@ -414,6 +498,14 @@ def pytest_collection_modifyitems(
             item.add_marker(
                 pytest.mark.xfail(
                     reason=_GPTOSS_OPENHANDS_XFAIL_REASON,
+                    strict=True,
+                )
+            )
+        # Hy3 — every cell (all 11 agents + frameworks), 166 GB Ultra-only.
+        if f"[{_HY3_XFAIL_FAMILY}]" in item.nodeid:
+            item.add_marker(
+                pytest.mark.xfail(
+                    reason=_HY3_XFAIL_REASON,
                     strict=True,
                 )
             )
@@ -453,7 +545,7 @@ def _guard_family_matches_server(request: pytest.FixtureRequest) -> None:
         strict_skip_or_fail(
             f"cell {cell_family.family}: running model "
             f"{server_info['model_id']!r} doesn't map to any known family "
-            f"(qwen36 / gemma4 / deepseek / gptoss)."
+            f"(qwen36 / gemma4 / deepseek / gptoss / hy3)."
         )
         return
     if active.family != cell_family.family:

--- a/tests/integrations/test_hy3_offline.py
+++ b/tests/integrations/test_hy3_offline.py
@@ -1,0 +1,304 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Offline Hy3 (Hunyuan 3) parser-level integration test — CI-runnable.
+
+The always-on-CI value-add for the Hy3 Tier-1 family. Every *live* Hy3
+matrix cell in ``test_agents_matrix.py`` / ``test_frameworks_matrix.py``
+is strict-xfail'd because the only shipped SKU (``hy3-preview-4bit``) is
+166 GB / ~156 GB peak and single-node-infeasible in per-PR CI — real
+inference for Hy3 lives in the weekly Golden Path job (see
+``conftest.py`` ``_HY3_XFAIL_REASON``).
+
+This file fills the CI gap. It exercises the Hy3 parsing path
+END-TO-END at the OpenAI-API-shape level **without booting the 166 GB
+model**: captured Hy3 wire strings (the exact
+``<tool_call:opensource>…<end_of_tool_call:opensource>`` and
+``<think:opensource>…</think:opensource>`` shapes the 4-bit checkpoint
+emits, harvested in the 2026-07-09 ``pipenetwork/Hy3-REAP50/75-MLX-4bit``
+spike that seeded the PR-2 parser unit tests) are fed through the two
+parsers the ``hy3-preview-4bit`` alias wires
+(``tool_call_parser="hy_v3"`` + ``reasoning_parser="hy_v3"``) and the
+resulting API-shape objects are asserted:
+
+* tool_calls array is well-formed (OpenAI ``tool_call`` dict shape,
+  JSON-parseable ``arguments``) — reuses the shared
+  ``assert_tool_call_shape`` helper the live matrix cells use;
+* ``<think>`` reasoning content is routed to the reasoning channel, NOT
+  leaked into visible content — reuses ``assert_no_think_tag_leak``;
+* no analysis/think-tag markers leak into either channel.
+
+Unlike the PR-2 *unit* tests (``tests/test_hy_v3_tool_parser.py`` /
+``tests/test_hy3_reasoning_parser.py``), which assert parser internals in
+isolation, THIS file asserts the composed *API-shape contract* a real
+agent/framework client would observe on the wire — the same contract the
+live matrix cells assert against a booted server, minus the boot. If PR-2
+changes parser behavior, the captured fixtures here may need adjustment
+at rebase time; that is expected and called out in the PR body.
+
+Runs in the normal ``pytest tests/`` sweep — no server, no model, no
+Docker. Pure-Python, sub-second.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from tests.integrations.conftest import (
+    assert_no_analysis_channel_leak,
+    assert_no_think_tag_leak,
+    assert_tool_call_shape,
+)
+
+# --------------------------------------------------------------------------- #
+# Captured Hy3 wire fixtures
+# --------------------------------------------------------------------------- #
+#
+# These are the canonical shapes emitted by the 4-bit ``hy3-preview-4bit``
+# checkpoint, harvested from the ``pipenetwork/Hy3-REAP50-MLX-4bit`` +
+# ``Hy3-REAP75-MLX-4bit`` BFCL spike (2026-07-09). They match the fixtures
+# that seed the PR-2 unit suites, so if PR-2 changes the parser contract
+# these strings are the single place to re-sync at rebase time.
+
+# Canonical single tool call — the chat-template default emission.
+_WIRE_SINGLE_TOOL_CALL = (
+    "<tool_call:opensource>get_weather"
+    '<tool_sep:opensource>{"city": "Tokyo"}'
+    "<end_of_tool_call:opensource>"
+)
+
+# Two tool calls in one assistant turn (parallel tool-calling wire).
+_WIRE_MULTI_TOOL_CALL = (
+    "<tool_call:opensource>get_weather"
+    '<tool_sep:opensource>{"city": "Tokyo"}'
+    "<end_of_tool_call:opensource>"
+    "<tool_call:opensource>get_time"
+    '<tool_sep:opensource>{"tz": "Asia/Tokyo"}'
+    "<end_of_tool_call:opensource>"
+)
+
+# 4-bit numerical-noise malformed close — the model skips the JSON body and
+# jumps straight to ``</arg_value>``. The non-streaming path must still
+# surface the tool name with empty args rather than dropping the call.
+_WIRE_MALFORMED_CLOSE = "<tool_call:opensource>get_weather</arg_value:opensource>"
+
+# Reasoning span then answer — the canonical Hy3 think emission.
+_WIRE_REASONING_THEN_ANSWER = (
+    "<think:opensource>The user wants the weather in Tokyo. "
+    "I should call the get_weather tool.</think:opensource>"
+    "The weather in Tokyo is sunny."
+)
+
+# Reasoning span with no visible answer after it (all reasoning).
+_WIRE_REASONING_ONLY = (
+    "<think:opensource>Let me work through this step by step.</think:opensource>"
+)
+
+# Plain content, no tool call, no reasoning — must pass straight through.
+_WIRE_PLAIN_CONTENT = "The answer is 42."
+
+
+def _tool_parser():
+    """Construct the Hy3 tool parser the ``hy3-preview-4bit`` alias wires.
+
+    Skips (never errors) if the parser can't be imported — keeps the
+    naive ``pytest tests/`` sweep green on a checkout that predates the
+    PR-2 parser landing.
+    """
+    try:
+        from vllm_mlx.tool_parsers import HyV3ToolParser, ToolParserManager
+    except Exception as exc:  # noqa: BLE001
+        pytest.skip(f"hy_v3 tool parser not importable ({exc}) — cell deferred")
+    # Resolve through the registry too, mirroring how the server wires it
+    # from the alias's ``tool_call_parser="hy_v3"`` field.
+    assert ToolParserManager.get_tool_parser("hy_v3") is HyV3ToolParser
+    return HyV3ToolParser()
+
+
+def _reasoning_parser():
+    """Construct the Hy3 reasoning parser the alias wires (``reasoning_parser=hy_v3``)."""
+    try:
+        from vllm_mlx.reasoning import get_parser
+        from vllm_mlx.reasoning.hy3_parser import Hy3ReasoningParser
+    except Exception as exc:  # noqa: BLE001
+        pytest.skip(f"hy_v3 reasoning parser not importable ({exc}) — cell deferred")
+    assert get_parser("hy_v3") is Hy3ReasoningParser
+    return Hy3ReasoningParser()
+
+
+def _tool_calls_to_openai_shape(extracted) -> list[dict]:
+    """Project the parser's ``ExtractedToolCallInformation`` into the
+    OpenAI ``tool_call`` dict list a chat-completions client observes."""
+    out: list[dict] = []
+    for idx, tc in enumerate(extracted.tool_calls):
+        # The parser emits ``{"name": ..., "arguments": <json str>}`` dicts.
+        out.append(
+            {
+                "id": tc.get("id") or f"call_hy3_{idx}",
+                "type": "function",
+                "function": {
+                    "name": tc["name"],
+                    "arguments": tc["arguments"],
+                },
+            }
+        )
+    return out
+
+
+# --------------------------------------------------------------------------- #
+# Tool-call path — API-shape contract
+# --------------------------------------------------------------------------- #
+
+
+class TestHy3ToolCallWireOffline:
+    """Feed captured Hy3 tool-call wire through the parser; assert the
+    OpenAI-shape ``tool_calls`` array a real agent client would see."""
+
+    def test_single_tool_call_wellformed(self) -> None:
+        parser = _tool_parser()
+        res = parser.extract_tool_calls(_WIRE_SINGLE_TOOL_CALL)
+        assert res.tools_called is True, res
+        assert res.content is None, (
+            f"content leaked alongside tool call: {res.content!r}"
+        )
+
+        tool_calls = _tool_calls_to_openai_shape(res)
+        assert len(tool_calls) == 1, tool_calls
+        tc = tool_calls[0]
+        # Reuse the exact shared helper the live matrix cells use.
+        assert_tool_call_shape(tc)
+        assert tc["function"]["name"] == "get_weather", tc
+        args = json.loads(tc["function"]["arguments"])
+        assert args == {"city": "Tokyo"}, args
+
+    def test_multiple_tool_calls_each_wellformed(self) -> None:
+        parser = _tool_parser()
+        res = parser.extract_tool_calls(_WIRE_MULTI_TOOL_CALL)
+        assert res.tools_called is True, res
+
+        tool_calls = _tool_calls_to_openai_shape(res)
+        assert len(tool_calls) == 2, tool_calls
+        for tc in tool_calls:
+            assert_tool_call_shape(tc)
+        assert [tc["function"]["name"] for tc in tool_calls] == [
+            "get_weather",
+            "get_time",
+        ]
+        assert json.loads(tool_calls[0]["function"]["arguments"]) == {"city": "Tokyo"}
+        assert json.loads(tool_calls[1]["function"]["arguments"]) == {
+            "tz": "Asia/Tokyo"
+        }
+
+    def test_malformed_close_still_surfaces_call(self) -> None:
+        """4-bit numerical-noise close — the tool name must still surface as
+        a well-formed OpenAI tool_call with empty args, so a client sees a
+        real call instead of an empty array and thinks the model refused."""
+        parser = _tool_parser()
+        res = parser.extract_tool_calls(_WIRE_MALFORMED_CLOSE)
+        assert res.tools_called is True, res
+
+        tool_calls = _tool_calls_to_openai_shape(res)
+        assert len(tool_calls) == 1, tool_calls
+        tc = tool_calls[0]
+        assert_tool_call_shape(tc)  # arguments="{}" is still JSON-parseable
+        assert tc["function"]["name"] == "get_weather", tc
+        assert json.loads(tc["function"]["arguments"]) == {}
+
+    def test_plain_content_is_not_a_tool_call(self) -> None:
+        """A plain reply with no ``<tool_call>`` opener routes to content,
+        not a phantom tool call — and the content is channel-clean."""
+        parser = _tool_parser()
+        res = parser.extract_tool_calls(_WIRE_PLAIN_CONTENT)
+        assert res.tools_called is False, res
+        assert res.tool_calls == [], res.tool_calls
+        assert res.content == _WIRE_PLAIN_CONTENT
+        assert_no_think_tag_leak(res.content)
+        assert_no_analysis_channel_leak(res.content)
+
+
+# --------------------------------------------------------------------------- #
+# Reasoning path — think content routed, not leaked
+# --------------------------------------------------------------------------- #
+
+
+class TestHy3ReasoningWireOffline:
+    """Feed captured Hy3 ``<think:opensource>`` wire through the reasoning
+    parser; assert reasoning is routed to its own channel and never leaks
+    into the visible content a chat client renders."""
+
+    def test_reasoning_routed_content_clean(self) -> None:
+        parser = _reasoning_parser()
+        reasoning, content = parser.extract_reasoning(_WIRE_REASONING_THEN_ANSWER)
+        assert reasoning is not None and reasoning.strip(), reasoning
+        assert "get_weather tool" in reasoning, reasoning
+        assert content == "The weather in Tokyo is sunny.", content
+        # The visible content the client renders must be think-tag-clean.
+        assert_no_think_tag_leak(content)
+        assert_no_analysis_channel_leak(content)
+        # And the raw ``:opensource`` suffix must never survive into content.
+        assert ":opensource" not in content, content
+
+    def test_reasoning_only_no_content_leak(self) -> None:
+        parser = _reasoning_parser()
+        reasoning, content = parser.extract_reasoning(_WIRE_REASONING_ONLY)
+        assert reasoning is not None and reasoning.strip(), reasoning
+        # Pure reasoning span — content is empty / None, never the raw tags.
+        assert not (content or "").strip(), content
+        assert_no_think_tag_leak(content or "")
+
+    def test_plain_content_no_reasoning(self) -> None:
+        """A reply with no ``<think>`` span → reasoning is None, content
+        passes through verbatim."""
+        parser = _reasoning_parser()
+        reasoning, content = parser.extract_reasoning(_WIRE_PLAIN_CONTENT)
+        assert reasoning is None, reasoning
+        assert content == _WIRE_PLAIN_CONTENT, content
+
+
+# --------------------------------------------------------------------------- #
+# Composed contract — reasoning + tool call in one turn
+# --------------------------------------------------------------------------- #
+
+
+class TestHy3ComposedWireOffline:
+    """The realistic Hy3 turn: a ``<think>`` span THEN a tool call. The
+    server pipeline routes the reasoning to its channel first, then the
+    tool parser extracts the call from the residual content. Assert the
+    composed API-shape contract end-to-end, offline."""
+
+    _WIRE_REASON_THEN_TOOL = (
+        "<think:opensource>The user asked for the weather in Tokyo; "
+        "I'll call get_weather.</think:opensource>"
+        "<tool_call:opensource>get_weather"
+        '<tool_sep:opensource>{"city": "Tokyo"}'
+        "<end_of_tool_call:opensource>"
+    )
+
+    def test_reasoning_then_tool_call_both_wellformed(self) -> None:
+        reasoning_parser = _reasoning_parser()
+        tool_parser = _tool_parser()
+
+        # Stage 1: reasoning parser splits off the think span; the residual
+        # is what the tool parser sees (mirrors the server pipeline order).
+        reasoning, residual = reasoning_parser.extract_reasoning(
+            self._WIRE_REASON_THEN_TOOL
+        )
+        assert reasoning is not None and "get_weather" in reasoning, reasoning
+        assert_no_think_tag_leak(residual or "")
+        assert (
+            ":opensource"
+            not in (
+                # only the reasoning-tag suffix should be gone; the tool-call
+                # tokens legitimately remain in the residual for stage 2.
+                (residual or "").split("<tool_call")[0]
+            )
+        ), residual
+
+        # Stage 2: tool parser extracts the OpenAI-shape call from residual.
+        res = tool_parser.extract_tool_calls(residual or "")
+        assert res.tools_called is True, res
+        tool_calls = _tool_calls_to_openai_shape(res)
+        assert len(tool_calls) == 1, tool_calls
+        assert_tool_call_shape(tool_calls[0])
+        assert tool_calls[0]["function"]["name"] == "get_weather"
+        assert json.loads(tool_calls[0]["function"]["arguments"]) == {"city": "Tokyo"}

--- a/tests/integrations/test_hy3_offline.py
+++ b/tests/integrations/test_hy3_offline.py
@@ -99,36 +99,68 @@ _WIRE_REASONING_ONLY = (
 _WIRE_PLAIN_CONTENT = "The answer is 42."
 
 
+_HY3_ALIAS = "hy3-preview-4bit"
+
+
+def _hy3_alias_profile():
+    """Resolve the production ``hy3-preview-4bit`` alias profile.
+
+    Resolving through the real alias loader (not a hard-coded parser
+    name) means this test also guards the **alias → parser wiring**: if
+    the alias ever stops declaring ``tool_call_parser`` /
+    ``reasoning_parser``, or points them at a different parser, the
+    assertions below fail instead of silently passing on a stale literal.
+    """
+    from vllm_mlx.model_aliases import resolve_profile
+
+    profile = resolve_profile(_HY3_ALIAS)
+    assert profile is not None, f"{_HY3_ALIAS!r} alias not found in aliases.json"
+    return profile
+
+
 def _tool_parser():
     """Construct the Hy3 tool parser the ``hy3-preview-4bit`` alias wires.
 
-    The ``hy_v3`` tool parser is merged (PR-2, #1070) and is now a
-    permanent part of the tree, so the import is HARD: an import-time
-    regression or an accidental deletion of the production parser must
-    FAIL this test, not silently skip it. Skipping would let the
-    always-on coverage this file promises go green on broken code — the
-    exact failure mode the offline test exists to catch.
+    The parser name is read FROM the alias config (``tool_call_parser``),
+    not hard-coded, so a change that unwires the alias from ``hy_v3`` is
+    caught here. The import + registry lookup are HARD (no ``pytest.skip``):
+    the ``hy_v3`` parser is merged (PR-2, #1070) and permanent, so an
+    import-time regression or accidental deletion must FAIL this always-on
+    test rather than skip it green — the exact failure mode this file
+    exists to catch.
     """
     from vllm_mlx.tool_parsers import HyV3ToolParser, ToolParserManager
 
-    # Resolve through the registry too, mirroring how the server wires it
-    # from the alias's ``tool_call_parser="hy_v3"`` field.
-    assert ToolParserManager.get_tool_parser("hy_v3") is HyV3ToolParser
-    return HyV3ToolParser()
+    parser_name = _hy3_alias_profile().tool_call_parser
+    assert parser_name == "hy_v3", (
+        f"{_HY3_ALIAS} tool_call_parser changed to {parser_name!r}; "
+        "update this offline test to match the alias wiring"
+    )
+    # Resolve through the registry the way the server wires it from the
+    # alias's ``tool_call_parser`` field.
+    resolved = ToolParserManager.get_tool_parser(parser_name)
+    assert resolved is HyV3ToolParser
+    return resolved()
 
 
 def _reasoning_parser():
-    """Construct the Hy3 reasoning parser the alias wires (``reasoning_parser=hy_v3``).
+    """Construct the Hy3 reasoning parser the alias wires (``reasoning_parser``).
 
-    Hard import for the same reason as ``_tool_parser`` — the ``hy_v3``
-    reasoning parser is merged (PR-2, #1070); a missing/broken import
-    must fail, not skip.
+    Same discipline as ``_tool_parser``: the parser name is read from the
+    alias config and the import is HARD — a missing/broken import or an
+    unwired alias must fail, not skip.
     """
     from vllm_mlx.reasoning import get_parser
     from vllm_mlx.reasoning.hy3_parser import Hy3ReasoningParser
 
-    assert get_parser("hy_v3") is Hy3ReasoningParser
-    return Hy3ReasoningParser()
+    parser_name = _hy3_alias_profile().reasoning_parser
+    assert parser_name == "hy_v3", (
+        f"{_HY3_ALIAS} reasoning_parser changed to {parser_name!r}; "
+        "update this offline test to match the alias wiring"
+    )
+    resolved = get_parser(parser_name)
+    assert resolved is Hy3ReasoningParser
+    return resolved()
 
 
 def _tool_calls_to_openai_shape(extracted) -> list[dict]:
@@ -235,7 +267,16 @@ class TestHy3ReasoningWireOffline:
         parser = _reasoning_parser()
         reasoning, content = parser.extract_reasoning(_WIRE_REASONING_THEN_ANSWER)
         assert reasoning is not None and reasoning.strip(), reasoning
-        assert "get_weather tool" in reasoning, reasoning
+        # The reasoning channel carries the extracted think TEXT verbatim,
+        # with the wrapping ``<think:opensource>…</think:opensource>`` tags
+        # (and the ``:opensource`` suffix) stripped — assert the exact
+        # payload, not just a substring, so a parser that left the raw tags
+        # in ``reasoning`` would fail here (not only in ``content``).
+        assert reasoning == (
+            "The user wants the weather in Tokyo. I should call the get_weather tool."
+        ), reasoning
+        assert_no_think_tag_leak(reasoning)
+        assert ":opensource" not in reasoning, reasoning
         assert content == "The weather in Tokyo is sunny.", content
         # The visible content the client renders must be think-tag-clean.
         assert_no_think_tag_leak(content)
@@ -247,6 +288,10 @@ class TestHy3ReasoningWireOffline:
         parser = _reasoning_parser()
         reasoning, content = parser.extract_reasoning(_WIRE_REASONING_ONLY)
         assert reasoning is not None and reasoning.strip(), reasoning
+        # Reasoning channel holds the stripped think text — no raw tags/suffix.
+        assert reasoning == "Let me work through this step by step.", reasoning
+        assert_no_think_tag_leak(reasoning)
+        assert ":opensource" not in reasoning, reasoning
         # Pure reasoning span — content is empty / None, never the raw tags.
         assert not (content or "").strip(), content
         assert_no_think_tag_leak(content or "")

--- a/tests/integrations/test_hy3_offline.py
+++ b/tests/integrations/test_hy3_offline.py
@@ -30,9 +30,12 @@ Unlike the PR-2 *unit* tests (``tests/test_hy_v3_tool_parser.py`` /
 ``tests/test_hy3_reasoning_parser.py``), which assert parser internals in
 isolation, THIS file asserts the composed *API-shape contract* a real
 agent/framework client would observe on the wire — the same contract the
-live matrix cells assert against a booted server, minus the boot. If PR-2
-changes parser behavior, the captured fixtures here may need adjustment
-at rebase time; that is expected and called out in the PR body.
+live matrix cells assert against a booted server, minus the boot. PR-2
+(#1070) is now merged; these fixtures were re-verified green against the
+merged parser at rebase time (5 codex rounds of literal-close / reasoning
+partial-close / brace-depth fixes landed after this file was first
+written, and the captured wire still round-trips byte-exact — no
+assertion change was needed).
 
 Runs in the normal ``pytest tests/`` sweep — no server, no model, no
 Docker. Pure-Python, sub-second.
@@ -41,8 +44,6 @@ Docker. Pure-Python, sub-second.
 from __future__ import annotations
 
 import json
-
-import pytest
 
 from tests.integrations.conftest import (
     assert_no_analysis_channel_leak,
@@ -101,14 +102,15 @@ _WIRE_PLAIN_CONTENT = "The answer is 42."
 def _tool_parser():
     """Construct the Hy3 tool parser the ``hy3-preview-4bit`` alias wires.
 
-    Skips (never errors) if the parser can't be imported — keeps the
-    naive ``pytest tests/`` sweep green on a checkout that predates the
-    PR-2 parser landing.
+    The ``hy_v3`` tool parser is merged (PR-2, #1070) and is now a
+    permanent part of the tree, so the import is HARD: an import-time
+    regression or an accidental deletion of the production parser must
+    FAIL this test, not silently skip it. Skipping would let the
+    always-on coverage this file promises go green on broken code — the
+    exact failure mode the offline test exists to catch.
     """
-    try:
-        from vllm_mlx.tool_parsers import HyV3ToolParser, ToolParserManager
-    except Exception as exc:  # noqa: BLE001
-        pytest.skip(f"hy_v3 tool parser not importable ({exc}) — cell deferred")
+    from vllm_mlx.tool_parsers import HyV3ToolParser, ToolParserManager
+
     # Resolve through the registry too, mirroring how the server wires it
     # from the alias's ``tool_call_parser="hy_v3"`` field.
     assert ToolParserManager.get_tool_parser("hy_v3") is HyV3ToolParser
@@ -116,12 +118,15 @@ def _tool_parser():
 
 
 def _reasoning_parser():
-    """Construct the Hy3 reasoning parser the alias wires (``reasoning_parser=hy_v3``)."""
-    try:
-        from vllm_mlx.reasoning import get_parser
-        from vllm_mlx.reasoning.hy3_parser import Hy3ReasoningParser
-    except Exception as exc:  # noqa: BLE001
-        pytest.skip(f"hy_v3 reasoning parser not importable ({exc}) — cell deferred")
+    """Construct the Hy3 reasoning parser the alias wires (``reasoning_parser=hy_v3``).
+
+    Hard import for the same reason as ``_tool_parser`` — the ``hy_v3``
+    reasoning parser is merged (PR-2, #1070); a missing/broken import
+    must fail, not skip.
+    """
+    from vllm_mlx.reasoning import get_parser
+    from vllm_mlx.reasoning.hy3_parser import Hy3ReasoningParser
+
     assert get_parser("hy_v3") is Hy3ReasoningParser
     return Hy3ReasoningParser()
 


### PR DESCRIPTION
**Rebased onto main — PR-2 (#1070, parsers) + the P0 leak fix (#1075) are both merged.** This branch was originally cut from `feat/011.0-hy3-parsers`; it has now been rebased `--onto origin/main` so only the PR-3 test/docs commits replay. Diff-vs-main is exactly the 4 PR-3 files (`docs/reference/models.md` + `tests/integrations/{README.md,conftest.py,test_hy3_offline.py}`) — **no parser or engine code** (PR-2's parser files are already in main and correctly dropped out of this diff). Ready for review.

## Why

Hy3 (Tencent Hunyuan 3) landed as the Tier-1 **5th family** in #1069 (vendor) + #1070 (parsers), but the always-on integration matrices still only knew four families. Without this PR the family has **zero CI coverage**: the live matrix cells would either be missing entirely or, worse, try to boot the 166 GB `hy3-preview-4bit` on non-Ultra CI and OOM. This PR closes that gap the same way the DeepSeek V4-Flash Ultra-only precedent did — register Hy3 as a strict-xfail column (so an XPASS is a deliberate tripwire if the model ever becomes always-on-bootable) **and** add a real, sub-second, model-free offline parser test that gives the family genuine per-PR coverage. Refs #1069, #1070. Completes the 3-PR Hy3 series.

PR-3 of the Hy3 (Tencent Hunyuan 3) series. PR-1 (#1069, merged) vendored the 295B/21B-active MoE + `hy3-preview-4bit` alias; PR-2 (#1070, open) adds the tool + reasoning parsers. PR-3 adds Hy3 as the Tier-1 **5th family** across the agent + framework integration matrices, plus the Ultra-only launch docs. Strictly test/docs layer — **no parser or engine code touched** (verified: only `tests/integrations/**` + `docs/reference/models.md`).

## What changed

### A/B — matrix family registration + strict-xfail cells (`conftest.py`)
- `hy3-preview-4bit` registered as the 5th `_FAMILY_ALIASES` entry (Ultra-only / 166 GB / weekly-Golden-Path reason).
- All **14 Hy3 cells** (11 agents + 3 frameworks) marked `xfail(strict=True)` via `pytest_collection_modifyitems`, mirroring the DeepSeek V4-Flash single-node-infeasible precedent: 166 GB weights + the G11 100 GB free-disk floor > 256 GB M3 Ultra. Per G8 this is strict-xfail, **not** plain skip — an XPASS forces a revisit if a smaller quant or bigger Mac ever makes always-on CI feasible.
- Family map recognises `hy3` / `hunyuan-3` served ids.

### C — offline parser-level integration test (`test_hy3_offline.py`) — the CI-runnable value-add
Drives **captured Hy3 wire strings** (from the same 2026-07-09 REAP50/75 spike that seeded PR-2's unit tests) through the `hy_v3` tool + reasoning parsers **without booting the 166 GB model**, asserting the OpenAI-API-shape contract: `tool_calls` array well-formed, `<think>` reasoning routed to its own channel, no content leak, and a composed reasoning-then-tool-call turn. **8 tests, sub-second, runs in the normal `pytest tests/` sweep.**

### D — Ultra-only docs
- `docs/reference/models.md`: new **"Ultra-only: Hunyuan 3 (Hy3)"** section with the `min_memory_gb: 192` pre-download warning example + LM-family table row.
- `tests/integrations/README.md`: Hy3 column in both status matrices, family-alias row, cell counts (56 → 70), offline-test note.
- Verified the `min_memory_gb: 192` warning (PR-1 wiring, `cli.py::_check_alias_min_memory`) **actually fires** for `hy3-preview-4bit` on a sub-192 GB Mac — no gap, purely documented.

## Local verification (post-rebase, against the merged PR-2 parser)
- `pytest tests/integrations/test_hy3_offline.py` → **8 passed** — re-run against the now-merged `hy_v3` parser (5 codex rounds of literal-close / reasoning-leak / brace-depth fixes); captured fixtures still match the merged contract, **no assertion change needed**.
- All **14 Hy3 matrix cells** confirmed carrying `strict=True` xfail markers (verified via collection introspection); cells skip cleanly with no matching server — no false red.
- `ruff check vllm_mlx/ tests/` + `ruff format --check vllm_mlx/ tests/` clean under **ruff 0.15.21** (CI-pinned version).

## Notes for reviewer
- `skip-version-bump` label applied — no `pyproject.toml` change.
- If PR-2 changes parser wire behavior mid-flight, the captured fixtures in `test_hy3_offline.py` may need a re-sync at rebase time (single fixture block at top of file) — expected, not synced live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
