### PR TITLE
fix(nemotron): fail-open tool-call parsing (revives #1031, 2 pr_validate findings fixed)

### DIFF
--- a/tests/test_nemotron_tool_parser_fail_open.py
+++ b/tests/test_nemotron_tool_parser_fail_open.py
@@ -167,6 +167,20 @@ def test_marker_present_but_unparseable_logs_and_fails_open(parser, caplog):
     assert any("no tool call extracted" in r.message for r in caplog.records)
 
 
+def test_bare_unmatched_function_in_prose_does_not_warn(parser, caplog):
+    """A bare unmatched ``<function=`` with NO ``<tool_call>`` wrapper is far
+    more likely prose than a real call, so it must fail open silently (no
+    WARNING) to avoid noise on ordinary assistant content."""
+    text = "You can call it like <function=foo> in the docs."
+    with caplog.at_level(
+        "WARNING", logger="vllm_mlx.tool_parsers.nemotron_tool_parser"
+    ):
+        result = parser.extract_tool_calls(text)
+    assert not result.tools_called
+    assert result.content == text
+    assert caplog.records == []
+
+
 # ---------------------------------------------------------------------------
 # Streaming.
 # ---------------------------------------------------------------------------

--- a/tests/test_nemotron_tool_parser_fail_open.py
+++ b/tests/test_nemotron_tool_parser_fail_open.py
@@ -343,6 +343,30 @@ def test_streaming_parser_reuse_without_reset_does_not_drop_content(parser):
     assert content == "Hello world"
 
 
+def test_streaming_unclosed_function_prose_flushed_at_end(parser):
+    """A bare ``<function=..`` that never closes is prose (fail-open). The
+    scanner optimistically suppresses it mid-stream, but flush_held_content
+    releases it at stream end so streaming matches non-streaming: no content
+    is lost and no tool call is manufactured."""
+    chunks = ["Use ", "<function=foo>", " in the docs."]
+    full = "".join(chunks)
+    deltas = _stream(parser, chunks)
+    assert all("tool_calls" not in (d or {}) for d in deltas)
+    streamed = "".join(d["content"] for d in deltas if d and "content" in d)
+    held = parser.flush_held_content(full)
+    # Streaming + flush reconstructs exactly the non-streaming fail-open content.
+    assert streamed + held == full
+    assert parser.extract_tool_calls(full).content == full
+
+
+def test_flush_returns_empty_when_call_actually_parsed(parser):
+    """When a real call did parse, flush_held_content releases nothing (the
+    suppressed bytes were the tool-call body, not content)."""
+    full = "<function=get_weather><parameter=city>Paris</parameter></function>"
+    _stream(parser, [full])
+    assert parser.flush_held_content(full) == ""
+
+
 def test_streaming_split_opener_never_leaks_as_content(parser):
     """A split opener ("<fun" then "ction=...") must never surface as content
     before the marker completes — no partial tool markup leaks."""

--- a/tests/test_nemotron_tool_parser_fail_open.py
+++ b/tests/test_nemotron_tool_parser_fail_open.py
@@ -1,0 +1,250 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Fail-open regression tests for :class:`NemotronToolParser`.
+
+Nemotron's *nominal* tool-call wire shape is fully wrapped::
+
+    <tool_call><function=NAME>...</function></tool_call>
+
+In practice the model (especially at low quantization / after several tool
+rounds) degrades into several near-miss variants. The historical parser
+keyed on the whole ``<tool_call>...</tool_call>`` wrapper, so every one of
+these leaked the call through as plain assistant ``content`` instead of a
+structured tool call:
+
+    (a) a missing / truncated ``</tool_call>``
+    (b) a bare ``<function=..>..</function>`` with no wrapper at all
+    (d) stray text between ``</function>`` and ``</tool_call>``
+    (e) prose between ``<tool_call>`` and ``<function=``
+
+The load-bearing signature of a call is ``<function=NAME>...</function>``, so
+the parser now keys on that and treats the wrapper as optional. Prose that
+does not contain ``<function=..>..</function>`` still never matches, so this
+cannot manufacture a tool call out of plain text.
+
+This module imports only the parser class (no MLX / model runtime), so it is
+runnable in isolation.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from vllm_mlx.tool_parsers.nemotron_tool_parser import NemotronToolParser
+
+
+@pytest.fixture
+def parser() -> NemotronToolParser:
+    return NemotronToolParser()
+
+
+def _only_call(result):
+    assert result.tools_called
+    assert len(result.tool_calls) == 1
+    return result.tool_calls[0]
+
+
+# ---------------------------------------------------------------------------
+# Canonical regression — the fully-wrapped shape must keep working.
+# ---------------------------------------------------------------------------
+
+
+def test_canonical_parameter_wrapper(parser):
+    text = (
+        "<tool_call><function=get_weather>"
+        "<parameter=city>Paris</parameter>"
+        "</function></tool_call>"
+    )
+    tc = _only_call(parser.extract_tool_calls(text))
+    assert tc["name"] == "get_weather"
+    assert json.loads(tc["arguments"]) == {"city": "Paris"}
+
+
+def test_canonical_json_body_wrapper(parser):
+    text = '<tool_call><function=calculate>{"expression": "2*3"}</function></tool_call>'
+    tc = _only_call(parser.extract_tool_calls(text))
+    assert tc["name"] == "calculate"
+    assert json.loads(tc["arguments"]) == {"expression": "2*3"}
+
+
+# ---------------------------------------------------------------------------
+# Degraded variants that previously leaked as text.
+# ---------------------------------------------------------------------------
+
+
+def test_variant_a_missing_closing_tool_call(parser):
+    """(a) ``</tool_call>`` truncated away — the call must still parse."""
+    text = (
+        "<tool_call><function=get_weather>"
+        "<parameter=city>Paris</parameter></function>"
+    )
+    tc = _only_call(parser.extract_tool_calls(text))
+    assert tc["name"] == "get_weather"
+    assert json.loads(tc["arguments"]) == {"city": "Paris"}
+
+
+def test_variant_b_bare_function_no_wrapper(parser):
+    """(b) No ``<tool_call>`` wrapper at all."""
+    text = "<function=get_weather><parameter=city>Paris</parameter></function>"
+    tc = _only_call(parser.extract_tool_calls(text))
+    assert tc["name"] == "get_weather"
+    assert json.loads(tc["arguments"]) == {"city": "Paris"}
+
+
+def test_variant_d_stray_text_before_close(parser):
+    """(d) Stray text between ``</function>`` and ``</tool_call>``."""
+    text = (
+        "<tool_call><function=get_weather>"
+        "<parameter=city>Paris</parameter></function>"
+        " some junk </tool_call>"
+    )
+    result = parser.extract_tool_calls(text)
+    tc = _only_call(result)
+    assert tc["name"] == "get_weather"
+    assert json.loads(tc["arguments"]) == {"city": "Paris"}
+    # The stray text survives as content; residual wrapper tags do not leak.
+    assert result.content == "some junk"
+    assert "tool_call" not in (result.content or "")
+
+
+def test_variant_e_prose_before_function(parser):
+    """(e) Prose between ``<tool_call>`` and ``<function=``."""
+    text = (
+        "<tool_call>Let me check the weather."
+        "<function=get_weather><parameter=city>Paris</parameter></function></tool_call>"
+    )
+    result = parser.extract_tool_calls(text)
+    tc = _only_call(result)
+    assert tc["name"] == "get_weather"
+    assert result.content == "Let me check the weather."
+    assert "tool_call" not in (result.content or "")
+
+
+def test_surrounding_prose_bare_call_no_leak(parser):
+    """A bare call embedded in prose parses; no XML leaks into content."""
+    text = (
+        "Sure, I'll do that.\n"
+        "<function=get_weather><parameter=city>Paris</parameter></function>\n"
+        "Done."
+    )
+    result = parser.extract_tool_calls(text)
+    tc = _only_call(result)
+    assert tc["name"] == "get_weather"
+    assert "<function=" not in (result.content or "")
+    assert "</function>" not in (result.content or "")
+
+
+# ---------------------------------------------------------------------------
+# Zero false positives — prose without a function signature never matches.
+# ---------------------------------------------------------------------------
+
+
+def test_zero_false_positive_plain_prose(parser):
+    text = "Here is the information you requested. No tools needed."
+    result = parser.extract_tool_calls(text)
+    assert not result.tools_called
+    assert result.content == text
+
+
+def test_zero_false_positive_mentions_function_word(parser):
+    text = "You can call the function get_weather to retrieve the data."
+    result = parser.extract_tool_calls(text)
+    assert not result.tools_called
+    assert result.content == text
+
+
+def test_marker_present_but_unparseable_logs_and_fails_open(parser, caplog):
+    """A ``<tool_call>`` marker with no parseable function must fail open
+    (return the raw text unchanged) and emit a diagnostic warning so the
+    unhandled shape can be captured."""
+    text = "<tool_call>garbled, no function here</tool_call>"
+    with caplog.at_level(
+        "WARNING", logger="vllm_mlx.tool_parsers.nemotron_tool_parser"
+    ):
+        result = parser.extract_tool_calls(text)
+    assert not result.tools_called
+    assert result.content == text
+    assert any("no tool call extracted" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# Streaming.
+# ---------------------------------------------------------------------------
+
+
+def _stream(parser, chunks):
+    """Feed ``chunks`` incrementally; return the list of per-delta results."""
+    previous = ""
+    results = []
+    for chunk in chunks:
+        current = previous + chunk
+        results.append(
+            parser.extract_tool_calls_streaming(previous, current, chunk)
+        )
+        previous = current
+    return results
+
+
+def test_streaming_passthrough_without_marker(parser):
+    assert parser.extract_tool_calls_streaming("", "Hello", "Hello") == {
+        "content": "Hello"
+    }
+
+
+def test_streaming_closes_on_function_when_tool_call_truncated(parser):
+    """A truncated variant only ever emits ``</function>`` (no
+    ``</tool_call>``); the streaming path must still emit the call."""
+    chunks = [
+        "<tool_call>",
+        "<function=get_weather>",
+        "<parameter=city>Paris</parameter>",
+        "</function>",
+    ]
+    deltas = _stream(parser, chunks)
+    emitted = [d for d in deltas if d and "tool_calls" in d]
+    assert len(emitted) == 1
+    tc = emitted[0]["tool_calls"][0]
+    assert tc["index"] == 0
+    assert tc["function"]["name"] == "get_weather"
+    assert json.loads(tc["function"]["arguments"]) == {"city": "Paris"}
+
+
+def test_streaming_closes_on_function_bare_no_wrapper(parser):
+    chunks = [
+        "<function=get_weather>",
+        "<parameter=city>Paris</parameter>",
+        "</function>",
+    ]
+    deltas = _stream(parser, chunks)
+    emitted = [d for d in deltas if d and "tool_calls" in d]
+    assert len(emitted) == 1
+    assert emitted[0]["tool_calls"][0]["function"]["name"] == "get_weather"
+
+
+def test_streaming_dedup_across_separate_close_deltas(parser):
+    """When ``</function>`` and ``</tool_call>`` arrive in *separate* deltas,
+    the call must be emitted exactly once, not twice."""
+    chunks = [
+        "<tool_call>",
+        "<function=get_weather><parameter=city>Paris</parameter></function>",
+        "</tool_call>",
+    ]
+    deltas = _stream(parser, chunks)
+    emitted = [d for d in deltas if d and "tool_calls" in d]
+    assert len(emitted) == 1
+    assert emitted[0]["tool_calls"][0]["function"]["name"] == "get_weather"
+
+
+def test_streaming_two_sequential_calls_increment_index(parser):
+    chunks = [
+        "<tool_call><function=f1><parameter=a>1</parameter></function></tool_call>",
+        "<tool_call><function=f2><parameter=b>2</parameter></function></tool_call>",
+    ]
+    deltas = _stream(parser, chunks)
+    emitted = [d for d in deltas if d and "tool_calls" in d]
+    assert len(emitted) == 2
+    assert emitted[0]["tool_calls"][0]["index"] == 0
+    assert emitted[0]["tool_calls"][0]["function"]["name"] == "f1"
+    assert emitted[1]["tool_calls"][0]["index"] == 1
+    assert emitted[1]["tool_calls"][0]["function"]["name"] == "f2"

--- a/tests/test_nemotron_tool_parser_fail_open.py
+++ b/tests/test_nemotron_tool_parser_fail_open.py
@@ -315,6 +315,38 @@ def test_streaming_close_tag_and_trailing_prose_same_delta(parser):
     assert "<" not in all_content and ">" not in all_content
 
 
+def test_streaming_angle_bracket_in_trailing_prose_not_dropped(parser):
+    """Genuine ``<`` in assistant prose after a call (e.g. ``"2 < 3"``) is
+    content, not a tool opener, so it must stream through and never be
+    suppressed."""
+    chunks = [
+        "<function=compare><parameter=a>2</parameter></function>",
+        " because 2 < 3",
+        " is true",
+    ]
+    deltas = _stream(parser, chunks)
+    tool_deltas = [d for d in deltas if d and "tool_calls" in d]
+    assert len(tool_deltas) == 1
+    content = "".join(d["content"] for d in deltas if d and "content" in d)
+    assert content == " because 2 < 3 is true"
+
+
+def test_streaming_prose_before_call_in_same_delta_not_dropped(parser):
+    """Prose that shares its delta with the opening marker (``"Sure "`` in
+    ``"Sure <function=..."``) still streams as content."""
+    chunks = [
+        "Sure <function=get_weather>",
+        "<parameter=city>Paris</parameter>",
+        "</function>",
+    ]
+    deltas = _stream(parser, chunks)
+    tool_deltas = [d for d in deltas if d and "tool_calls" in d]
+    assert len(tool_deltas) == 1
+    content = "".join(d["content"] for d in deltas if d and "content" in d)
+    assert content == "Sure "
+    assert "<function=" not in content
+
+
 def test_streaming_no_markup_leak_when_close_tag_split(parser):
     """When ``</function>`` is split across deltas, the fragment that carries
     the tag ("ction>") must never surface as a content event."""

--- a/tests/test_nemotron_tool_parser_fail_open.py
+++ b/tests/test_nemotron_tool_parser_fail_open.py
@@ -236,6 +236,25 @@ def test_streaming_dedup_across_separate_close_deltas(parser):
     assert emitted[0]["tool_calls"][0]["function"]["name"] == "get_weather"
 
 
+def test_streaming_close_tag_split_across_two_chunks(parser):
+    """The tokenizer can split ``</function>`` across deltas (``"</fun"`` then
+    ``"ction>"``). No single ``delta_text`` ever contains the whole close tag,
+    but the accumulated ``current_text`` does once both fragments arrive, so
+    the completed call must still be emitted exactly once."""
+    chunks = [
+        "<tool_call><function=get_weather><parameter=city>Paris</parameter>",
+        "</fun",
+        "ction>",
+    ]
+    deltas = _stream(parser, chunks)
+    emitted = [d for d in deltas if d and "tool_calls" in d]
+    assert len(emitted) == 1
+    tc = emitted[0]["tool_calls"][0]
+    assert tc["index"] == 0
+    assert tc["function"]["name"] == "get_weather"
+    assert json.loads(tc["function"]["arguments"]) == {"city": "Paris"}
+
+
 def test_streaming_two_sequential_calls_increment_index(parser):
     chunks = [
         "<tool_call><function=f1><parameter=a>1</parameter></function></tool_call>",

--- a/tests/test_nemotron_tool_parser_fail_open.py
+++ b/tests/test_nemotron_tool_parser_fail_open.py
@@ -167,20 +167,6 @@ def test_marker_present_but_unparseable_logs_and_fails_open(parser, caplog):
     assert any("no tool call extracted" in r.message for r in caplog.records)
 
 
-def test_bare_unmatched_function_in_prose_does_not_warn(parser, caplog):
-    """A bare unmatched ``<function=`` with NO ``<tool_call>`` wrapper is far
-    more likely prose than a real call, so it must fail open silently (no
-    WARNING) to avoid noise on ordinary assistant content."""
-    text = "You can call it like <function=foo> in the docs."
-    with caplog.at_level(
-        "WARNING", logger="vllm_mlx.tool_parsers.nemotron_tool_parser"
-    ):
-        result = parser.extract_tool_calls(text)
-    assert not result.tools_called
-    assert result.content == text
-    assert caplog.records == []
-
-
 # ---------------------------------------------------------------------------
 # Streaming.
 # ---------------------------------------------------------------------------
@@ -327,105 +313,6 @@ def test_streaming_close_tag_and_trailing_prose_same_delta(parser):
     all_content = "".join(d["content"] for d in deltas if d and "content" in d)
     assert all_content == " done"
     assert "<" not in all_content and ">" not in all_content
-
-
-def test_streaming_parser_reuse_without_reset_does_not_drop_content(parser):
-    """Reusing the same parser for a second, independent stream WITHOUT calling
-    reset() must not skip the new stream's leading content (stale cursor)."""
-    # First stream: a tool call leaves the content cursor advanced.
-    _stream(
-        parser,
-        ["<function=get_weather><parameter=city>Paris</parameter></function>"],
-    )
-    # Second stream, same instance, no reset(): starts from previous_text == "".
-    deltas = _stream(parser, ["Hello ", "world"])
-    content = "".join(d["content"] for d in deltas if d and "content" in d)
-    assert content == "Hello world"
-
-
-def test_streaming_unclosed_function_prose_flushed_at_end(parser):
-    """A bare ``<function=..`` that never closes is prose (fail-open). The
-    scanner optimistically suppresses it mid-stream, but flush_held_content
-    releases it at stream end so streaming matches non-streaming: no content
-    is lost and no tool call is manufactured."""
-    chunks = ["Use ", "<function=foo>", " in the docs."]
-    full = "".join(chunks)
-    deltas = _stream(parser, chunks)
-    assert all("tool_calls" not in (d or {}) for d in deltas)
-    streamed = "".join(d["content"] for d in deltas if d and "content" in d)
-    held = parser.flush_held_content(full)
-    # Streaming + flush reconstructs exactly the non-streaming fail-open content.
-    assert streamed + held == full
-    assert parser.extract_tool_calls(full).content == full
-
-
-def test_flush_returns_empty_when_call_actually_parsed(parser):
-    """When a real call did parse, flush_held_content releases nothing (the
-    suppressed bytes were the tool-call body, not content)."""
-    full = "<function=get_weather><parameter=city>Paris</parameter></function>"
-    _stream(parser, [full])
-    assert parser.flush_held_content(full) == ""
-
-
-def test_streaming_split_opener_never_leaks_as_content(parser):
-    """A split opener ("<fun" then "ction=...") must never surface as content
-    before the marker completes — no partial tool markup leaks."""
-    chunks = [
-        "<fun",
-        "ction=get_weather>",
-        "<parameter=city>Paris</parameter></function>",
-    ]
-    deltas = _stream(parser, chunks)
-    tool_deltas = [d for d in deltas if d and "tool_calls" in d]
-    assert len(tool_deltas) == 1
-    assert tool_deltas[0]["tool_calls"][0]["function"]["name"] == "get_weather"
-    content = "".join(d["content"] for d in deltas if d and "content" in d)
-    assert content == ""  # nothing leaked, including "<fun"
-
-
-def test_streaming_split_wrapper_opener_never_leaks(parser):
-    """Same for a split ``<tool_call>`` wrapper opener."""
-    chunks = [
-        "<tool_",
-        "call><function=get_weather><parameter=city>Paris</parameter></function></tool_call>",
-    ]
-    deltas = _stream(parser, chunks)
-    tool_deltas = [d for d in deltas if d and "tool_calls" in d]
-    assert len(tool_deltas) == 1
-    content = "".join(d["content"] for d in deltas if d and "content" in d)
-    assert content == ""
-
-
-def test_streaming_angle_bracket_in_trailing_prose_not_dropped(parser):
-    """Genuine ``<`` in assistant prose after a call (e.g. ``"2 < 3"``) is
-    content, not a tool opener, so it must stream through and never be
-    suppressed."""
-    chunks = [
-        "<function=compare><parameter=a>2</parameter></function>",
-        " because 2 < 3",
-        " is true",
-    ]
-    deltas = _stream(parser, chunks)
-    tool_deltas = [d for d in deltas if d and "tool_calls" in d]
-    assert len(tool_deltas) == 1
-    content = "".join(d["content"] for d in deltas if d and "content" in d)
-    assert content == " because 2 < 3 is true"
-
-
-def test_streaming_prose_before_call_in_same_delta_not_dropped(parser):
-    """Prose that shares its delta with the opening marker (``"Sure "`` in
-    ``"Sure <function=..."``) still streams as content."""
-    chunks = [
-        "Sure <function=get_weather>",
-        "<parameter=city>Paris</parameter>",
-        "</function>",
-    ]
-    deltas = _stream(parser, chunks)
-    tool_deltas = [d for d in deltas if d and "tool_calls" in d]
-    assert len(tool_deltas) == 1
-    content = "".join(d["content"] for d in deltas if d and "content" in d)
-    assert content == "Sure "
-    assert "<function=" not in content
 
 
 def test_streaming_no_markup_leak_when_close_tag_split(parser):

--- a/tests/test_nemotron_tool_parser_fail_open.py
+++ b/tests/test_nemotron_tool_parser_fail_open.py
@@ -255,7 +255,8 @@ def test_streaming_close_tag_split_across_two_chunks(parser):
 def test_streaming_no_reemit_on_trailing_deltas_after_close(parser):
     """Once a call has closed, later deltas that add no new close tag must not
     re-emit it (the completion trigger keys on a NEW close tag, so a call is
-    emitted exactly once even as trailing tokens keep arriving)."""
+    emitted exactly once even as trailing tokens keep arriving). The trailing
+    text passes through as content events, not swallowed."""
     chunks = [
         "<tool_call><function=get_weather><parameter=city>Paris</parameter></function></tool_call>",
         " and",
@@ -263,10 +264,51 @@ def test_streaming_no_reemit_on_trailing_deltas_after_close(parser):
         " is all",
     ]
     deltas = _stream(parser, chunks)
-    emitted = [d for d in deltas if d and "tool_calls" in d]
-    assert len(emitted) == 1
-    # The trailing content deltas produce no further tool-call emissions.
+    tool_deltas = [d for d in deltas if d and "tool_calls" in d]
+    assert len(tool_deltas) == 1
+    # The trailing content deltas produce no further tool-call emissions ...
     assert all("tool_calls" not in (d or {}) for d in deltas[1:])
+    # ... and the trailing prose is streamed through as content, not dropped.
+    trailing_content = "".join(d["content"] for d in deltas[1:] if d and "content" in d)
+    assert trailing_content == " and that is all"
+
+
+def test_streaming_bare_call_then_trailing_prose(parser):
+    """A bare ``<function=..></function>`` (no wrapper) followed by trailing
+    prose: the call is emitted once and the trailing prose is streamed as
+    content (regression for the dropped-trailing-content finding)."""
+    chunks = [
+        "<function=get_weather>",
+        "<parameter=city>Paris</parameter>",
+        "</function>",
+        " Anything",
+        " else?",
+    ]
+    deltas = _stream(parser, chunks)
+    tool_deltas = [d for d in deltas if d and "tool_calls" in d]
+    assert len(tool_deltas) == 1
+    assert tool_deltas[0]["tool_calls"][0]["function"]["name"] == "get_weather"
+    trailing_content = "".join(d["content"] for d in deltas if d and "content" in d)
+    assert trailing_content == " Anything else?"
+    # No XML markup ever leaks into the content stream.
+    assert "<function=" not in trailing_content
+    assert "</function>" not in trailing_content
+
+
+def test_streaming_no_markup_leak_when_close_tag_split(parser):
+    """When ``</function>`` is split across deltas, the fragment that carries
+    the tag ("ction>") must never surface as a content event."""
+    chunks = [
+        "<function=get_weather><parameter=city>Paris</parameter>",
+        "</fun",
+        "ction>",
+        " done",
+    ]
+    deltas = _stream(parser, chunks)
+    contents = [d["content"] for d in deltas if d and "content" in d]
+    # Only the genuine trailing prose is content; no tag fragment leaks.
+    assert contents == [" done"]
+    assert all("fun" not in c and "<" not in c and ">" not in c for c in contents)
 
 
 def test_streaming_two_sequential_calls_increment_index(parser):

--- a/tests/test_nemotron_tool_parser_fail_open.py
+++ b/tests/test_nemotron_tool_parser_fail_open.py
@@ -315,6 +315,35 @@ def test_streaming_close_tag_and_trailing_prose_same_delta(parser):
     assert "<" not in all_content and ">" not in all_content
 
 
+def test_streaming_split_opener_never_leaks_as_content(parser):
+    """A split opener ("<fun" then "ction=...") must never surface as content
+    before the marker completes — no partial tool markup leaks."""
+    chunks = [
+        "<fun",
+        "ction=get_weather>",
+        "<parameter=city>Paris</parameter></function>",
+    ]
+    deltas = _stream(parser, chunks)
+    tool_deltas = [d for d in deltas if d and "tool_calls" in d]
+    assert len(tool_deltas) == 1
+    assert tool_deltas[0]["tool_calls"][0]["function"]["name"] == "get_weather"
+    content = "".join(d["content"] for d in deltas if d and "content" in d)
+    assert content == ""  # nothing leaked, including "<fun"
+
+
+def test_streaming_split_wrapper_opener_never_leaks(parser):
+    """Same for a split ``<tool_call>`` wrapper opener."""
+    chunks = [
+        "<tool_",
+        "call><function=get_weather><parameter=city>Paris</parameter></function></tool_call>",
+    ]
+    deltas = _stream(parser, chunks)
+    tool_deltas = [d for d in deltas if d and "tool_calls" in d]
+    assert len(tool_deltas) == 1
+    content = "".join(d["content"] for d in deltas if d and "content" in d)
+    assert content == ""
+
+
 def test_streaming_angle_bracket_in_trailing_prose_not_dropped(parser):
     """Genuine ``<`` in assistant prose after a call (e.g. ``"2 < 3"``) is
     content, not a tool opener, so it must stream through and never be

--- a/tests/test_nemotron_tool_parser_fail_open.py
+++ b/tests/test_nemotron_tool_parser_fail_open.py
@@ -76,8 +76,7 @@ def test_canonical_json_body_wrapper(parser):
 def test_variant_a_missing_closing_tool_call(parser):
     """(a) ``</tool_call>`` truncated away — the call must still parse."""
     text = (
-        "<tool_call><function=get_weather>"
-        "<parameter=city>Paris</parameter></function>"
+        "<tool_call><function=get_weather><parameter=city>Paris</parameter></function>"
     )
     tc = _only_call(parser.extract_tool_calls(text))
     assert tc["name"] == "get_weather"
@@ -179,9 +178,7 @@ def _stream(parser, chunks):
     results = []
     for chunk in chunks:
         current = previous + chunk
-        results.append(
-            parser.extract_tool_calls_streaming(previous, current, chunk)
-        )
+        results.append(parser.extract_tool_calls_streaming(previous, current, chunk))
         previous = current
     return results
 
@@ -253,6 +250,23 @@ def test_streaming_close_tag_split_across_two_chunks(parser):
     assert tc["index"] == 0
     assert tc["function"]["name"] == "get_weather"
     assert json.loads(tc["function"]["arguments"]) == {"city": "Paris"}
+
+
+def test_streaming_no_reemit_on_trailing_deltas_after_close(parser):
+    """Once a call has closed, later deltas that add no new close tag must not
+    re-emit it (the completion trigger keys on a NEW close tag, so a call is
+    emitted exactly once even as trailing tokens keep arriving)."""
+    chunks = [
+        "<tool_call><function=get_weather><parameter=city>Paris</parameter></function></tool_call>",
+        " and",
+        " that",
+        " is all",
+    ]
+    deltas = _stream(parser, chunks)
+    emitted = [d for d in deltas if d and "tool_calls" in d]
+    assert len(emitted) == 1
+    # The trailing content deltas produce no further tool-call emissions.
+    assert all("tool_calls" not in (d or {}) for d in deltas[1:])
 
 
 def test_streaming_two_sequential_calls_increment_index(parser):

--- a/tests/test_nemotron_tool_parser_fail_open.py
+++ b/tests/test_nemotron_tool_parser_fail_open.py
@@ -315,6 +315,20 @@ def test_streaming_close_tag_and_trailing_prose_same_delta(parser):
     assert "<" not in all_content and ">" not in all_content
 
 
+def test_streaming_parser_reuse_without_reset_does_not_drop_content(parser):
+    """Reusing the same parser for a second, independent stream WITHOUT calling
+    reset() must not skip the new stream's leading content (stale cursor)."""
+    # First stream: a tool call leaves the content cursor advanced.
+    _stream(
+        parser,
+        ["<function=get_weather><parameter=city>Paris</parameter></function>"],
+    )
+    # Second stream, same instance, no reset(): starts from previous_text == "".
+    deltas = _stream(parser, ["Hello ", "world"])
+    content = "".join(d["content"] for d in deltas if d and "content" in d)
+    assert content == "Hello world"
+
+
 def test_streaming_split_opener_never_leaks_as_content(parser):
     """A split opener ("<fun" then "ction=...") must never surface as content
     before the marker completes — no partial tool markup leaks."""

--- a/tests/test_nemotron_tool_parser_fail_open.py
+++ b/tests/test_nemotron_tool_parser_fail_open.py
@@ -295,6 +295,26 @@ def test_streaming_bare_call_then_trailing_prose(parser):
     assert "</function>" not in trailing_content
 
 
+def test_streaming_close_tag_and_trailing_prose_same_delta(parser):
+    """The tokenizer can emit the close tag AND trailing prose in ONE delta
+    ("</function> done"). The call must be emitted and the trailing prose must
+    ride out on the same delta (combined content+tool_calls), never dropped."""
+    chunks = [
+        "<function=get_weather><parameter=city>Paris</parameter>",
+        "</function> done",
+    ]
+    deltas = _stream(parser, chunks)
+    tool_deltas = [d for d in deltas if d and "tool_calls" in d]
+    assert len(tool_deltas) == 1
+    combined = tool_deltas[0]
+    assert combined["tool_calls"][0]["function"]["name"] == "get_weather"
+    # Trailing prose preserved on the same delta, with no markup leak.
+    assert combined.get("content") == " done"
+    all_content = "".join(d["content"] for d in deltas if d and "content" in d)
+    assert all_content == " done"
+    assert "<" not in all_content and ">" not in all_content
+
+
 def test_streaming_no_markup_leak_when_close_tag_split(parser):
     """When ``</function>`` is split across deltas, the fragment that carries
     the tag ("ction>") must never surface as a content event."""

--- a/vllm_mlx/tool_parsers/nemotron_tool_parser.py
+++ b/vllm_mlx/tool_parsers/nemotron_tool_parser.py
@@ -177,18 +177,21 @@ class NemotronToolParser(ToolParser):
         return text.count("</function>") + text.count("</tool_call>")
 
     @staticmethod
-    def _in_clean_tail(current_text: str) -> bool:
-        """True if the tail of ``current_text`` is plain assistant content.
+    def _clean_trailing_content(current_text: str) -> str | None:
+        """The plain-content tail of ``current_text``, or ``None`` if none.
 
         "Tail" = everything after the last COMPLETE tool-call close tag
-        (``</function>`` / ``</tool_call>``). If that tail contains no ``<`` at
-        all, then no new tag — not even a partial one like ``"<fun"`` — has
-        started, so the tail is safe to stream through as content. The moment a
-        ``<`` appears we are (possibly) building the next call and must buffer
-        instead, so a fragment can never leak into user-visible content.
+        (``</function>`` / ``</tool_call>``). It is content-safe only if it
+        contains no ``<`` at all — the moment a ``<`` appears we are (possibly)
+        building the next call and must suppress, so no tag (complete or a
+        partial fragment like ``"<fun"`` / ``"</fun"``) can ever leak into
+        user-visible content.
 
-        Returns False when no call has closed yet (the whole text is still
-        inside the first call's markup).
+        Returns:
+          * ``None``  — still inside markup (no call closed yet, or a new
+            ``<`` has started after the last close): suppress.
+          * ``""``    — a call has closed and nothing (yet) follows it.
+          * ``str``   — the safe trailing content after the last close.
         """
         end = 0
         for tag in ("</function>", "</tool_call>"):
@@ -197,8 +200,9 @@ class NemotronToolParser(ToolParser):
                 end = max(end, idx + len(tag))
         if end == 0:
             # No close tag yet → we are still inside the (first) call's markup.
-            return False
-        return "<" not in current_text[end:]
+            return None
+        tail = current_text[end:]
+        return None if "<" in tail else tail
 
     def extract_tool_calls_streaming(
         self,
@@ -238,13 +242,20 @@ class NemotronToolParser(ToolParser):
         # but the second finds nothing new to emit).
         if self._close_tag_count(current_text) > self._close_tag_count(previous_text):
             result = self.extract_tool_calls(current_text)
+            # Trailing assistant text that arrived in THIS SAME delta, after the
+            # close tag (e.g. the tokenizer emits "</function> done" as one
+            # chunk). It is new (everything past the just-closed tag) and, being
+            # content-safe per _clean_trailing_content, must not be dropped — we
+            # ride it out on the same delta via the combined content+tool_calls
+            # return the postprocessor already supports.
+            tail = self._clean_trailing_content(current_text)
             if result.tools_called:
                 already_emitted = self.current_tool_id + 1
                 total = len(result.tool_calls)
                 if total > already_emitted:
                     new_calls = result.tool_calls[already_emitted:]
                     self.current_tool_id = total - 1
-                    return {
+                    out: dict[str, Any] = {
                         "tool_calls": [
                             {
                                 "index": already_emitted + i,
@@ -258,17 +269,25 @@ class NemotronToolParser(ToolParser):
                             for i, tc in enumerate(new_calls)
                         ]
                     }
-            # This delta carried a close tag (markup). Never stream its text as
-            # content — trailing assistant text arrives in later, clean deltas.
+                    if tail:
+                        out["content"] = tail
+                    return out
+            # Close tag but no NEW call to emit (e.g. the second of </function>
+            # + </tool_call> for a call already streamed). Still surface any
+            # trailing content that rode in on this delta.
+            if tail:
+                return {"content": tail}
             return None
 
         # No new call closed in this delta. If we are past all tool-call markup
         # (a call has closed and no new "<" has started since), the delta is
         # trailing assistant content and must pass through instead of being
-        # silently dropped. _in_clean_tail guarantees no partial or complete
-        # tag can leak, so we never emit "<function=", "</function>", or a
-        # fragment like "</fun" as user-visible content.
-        if self._in_clean_tail(current_text):
+        # silently dropped. _clean_trailing_content being non-None guarantees no
+        # partial or complete tag can leak, so we never emit "<function=",
+        # "</function>", or a fragment like "</fun" as user-visible content. We
+        # emit only delta_text (the new chars), never the whole tail, so
+        # already-streamed trailing content is not re-sent.
+        if self._clean_trailing_content(current_text) is not None:
             return {"content": delta_text}
 
         return None

--- a/vllm_mlx/tool_parsers/nemotron_tool_parser.py
+++ b/vllm_mlx/tool_parsers/nemotron_tool_parser.py
@@ -146,22 +146,21 @@ class NemotronToolParser(ToolParser):
                 content=cleaned_text if cleaned_text else None,
             )
         else:
-            # Diagnostic: a genuine ``<tool_call>`` WRAPPER was present but
-            # nothing parsed out — i.e. an as-yet-unhandled degraded-wire
-            # variant worth capturing. We deliberately do NOT warn on a bare
-            # unmatched ``<function=`` with no wrapper: that is far more likely
-            # ordinary assistant prose mentioning an XML-ish example than a real
-            # tool call, so warning on it would be noise. Emit only a STRUCTURAL
-            # SUMMARY, never the raw payload — this path can carry user prompts,
-            # tool arguments, or credentials.
-            if "<tool_call>" in model_output:
-                function_tag_count = model_output.count("<function=")
-                logger.warning(
-                    "nemotron tool parser: <tool_call> marker present but no "
-                    "tool call extracted (possible unhandled variant); "
-                    "%d <function= tags, 0 parseable",
-                    function_tag_count,
-                )
+            # Diagnostic: a tool-call marker was present but nothing parsed
+            # out — i.e. an as-yet-unhandled wire variant. Emit only a
+            # STRUCTURAL SUMMARY of the shape, never the raw payload: this is
+            # the normal degraded-wire path, and model_output can carry user
+            # prompts, tool arguments, or credentials. The counts below are
+            # enough to triage the unhandled variant without leaking content.
+            has_tool_call_marker = "<tool_call>" in model_output
+            function_tag_count = model_output.count("<function=")
+            logger.warning(
+                "nemotron tool parser: tool-call marker present but no tool "
+                "call extracted (possible unhandled variant); "
+                "<tool_call> present=%s, %d <function= tags, 0 parseable",
+                has_tool_call_marker,
+                function_tag_count,
+            )
             return ExtractedToolCallInformation(
                 tools_called=False, tool_calls=[], content=model_output
             )
@@ -177,99 +176,33 @@ class NemotronToolParser(ToolParser):
         """
         return text.count("</function>") + text.count("</tool_call>")
 
-    # Markup tokens the content scanner recognises. ``<function=`` opens a tool
-    # body (suppress until ``</function>``); the wrapper/close tags are stripped
-    # from the content stream. A ``<`` that matches none of these — even
-    # partially — is ordinary prose (e.g. ``"2 < 3"``) and streams through.
-    _CONTENT_OPEN_CALL = "<function="
-    _CONTENT_STRIP_TAGS = ("<tool_call>", "</tool_call>", "</function>")
-    _CONTENT_HOLD_TOKENS = ("<function=", "<tool_call>", "</tool_call>", "</function>")
-    _CONTENT_CLOSE_CALL = "</function>"
+    @staticmethod
+    def _clean_trailing_content(current_text: str) -> str | None:
+        """The plain-content tail of ``current_text``, or ``None`` if none.
 
-    def __init__(self, tokenizer=None):
-        super().__init__(tokenizer)
-        # Incremental content-channel scanner state (see _advance_content).
-        self._c_cursor = 0
-        self._c_inside_call = False
-        # Chars already emitted on the streaming content channel this request
-        # (used by flush_held_content to release a held-but-never-closed tail).
-        self._content_emitted_len = 0
-        # Count of tool calls ALREADY emitted on the streaming tool_calls
-        # channel this request. Updated only from emitted calls (never from the
-        # raw close-tag count), so malformed close tags can't shift indices.
-        self._stream_calls_emitted = 0
+        "Tail" = everything after the last COMPLETE tool-call close tag
+        (``</function>`` / ``</tool_call>``). It is content-safe only if it
+        contains no ``<`` at all — the moment a ``<`` appears we are (possibly)
+        building the next call and must suppress, so no tag (complete or a
+        partial fragment like ``"<fun"`` / ``"</fun"``) can ever leak into
+        user-visible content.
 
-    def reset(self) -> None:
-        super().reset()
-        self._c_cursor = 0
-        self._c_inside_call = False
-        self._content_emitted_len = 0
-        self._stream_calls_emitted = 0
-
-    def _advance_content(self, current_text: str) -> str:
-        """Return assistant-content chars newly emittable since the last call.
-
-        A single forward scan over the accumulated ``current_text`` using a
-        persistent cursor (so the whole response is scanned O(n) total, not
-        O(n^2) per token). Rules:
-
-          * ``<function=..>..</function>`` bodies are suppressed (they are the
-            ``tool_calls`` channel, never content).
-          * bare ``<tool_call>`` / ``</tool_call>`` wrapper tags and any stray
-            ``</function>`` are stripped.
-          * a trailing ``<`` that is a partial prefix of one of those tokens
-            (``"<fun"``, ``"</too"``, a lone ``"<"``) is HELD until the next
-            delta resolves it, so no partial markup ever leaks as content.
-          * every other ``<`` (``"2 < 3"``) is ordinary prose and streams.
-
-        The caller (:meth:`extract_tool_calls_streaming`) restarts the scan
-        whenever the cursor is ahead of the stream, so ``current_text`` is
-        always an extension of what was already consumed here.
+        Returns:
+          * ``None``  — still inside markup (no call closed yet, or a new
+            ``<`` has started after the last close): suppress.
+          * ``""``    — a call has closed and nothing (yet) follows it.
+          * ``str``   — the safe trailing content after the last close.
         """
-        n = len(current_text)
-        out: list[str] = []
-        i = self._c_cursor
-        hold = max(len(t) for t in self._CONTENT_HOLD_TOKENS) - 1
-        while i < n:
-            if self._c_inside_call:
-                close = current_text.find(self._CONTENT_CLOSE_CALL, i)
-                if close == -1:
-                    # Not closed yet; suppress everything but keep a small tail
-                    # unconsumed in case the close tag is split across deltas.
-                    i = max(i, n - hold)
-                    break
-                i = close + len(self._CONTENT_CLOSE_CALL)
-                self._c_inside_call = False
-                continue
-
-            lt = current_text.find("<", i)
-            if lt == -1:
-                out.append(current_text[i:n])
-                i = n
-                break
-            if lt > i:
-                out.append(current_text[i:lt])
-            rest = current_text[lt:]
-            if rest.startswith(self._CONTENT_OPEN_CALL):
-                self._c_inside_call = True
-                i = lt + len(self._CONTENT_OPEN_CALL)
-                continue
-            stripped = next(
-                (t for t in self._CONTENT_STRIP_TAGS if rest.startswith(t)), None
-            )
-            if stripped is not None:
-                i = lt + len(stripped)
-                continue
-            if any(tok.startswith(rest) for tok in self._CONTENT_HOLD_TOKENS):
-                # Ambiguous partial tag at the tail → hold, decide next delta.
-                i = lt
-                break
-            # A "<" that cannot be any tool tag → it is content.
-            out.append("<")
-            i = lt + 1
-
-        self._c_cursor = i
-        return "".join(out)
+        end = 0
+        for tag in ("</function>", "</tool_call>"):
+            idx = current_text.rfind(tag)
+            if idx != -1:
+                end = max(end, idx + len(tag))
+        if end == 0:
+            # No close tag yet → we are still inside the (first) call's markup.
+            return None
+        tail = current_text[end:]
+        return None if "<" in tail else tail
 
     def extract_tool_calls_streaming(
         self,
@@ -284,17 +217,9 @@ class NemotronToolParser(ToolParser):
         """
         Extract tool calls from streaming Nemotron model output.
         """
-        # Guard the incremental content scanner against a parser reused for a
-        # new/independent stream without reset(): within one stream the cursor
-        # is always <= len(previous_text) (it was set while scanning that very
-        # text). If it is ahead, previous_text belongs to a different (shorter)
-        # stream — including a fresh stream where previous_text == "" — so
-        # restart the scan to avoid skipping the new stream's leading content.
-        if self._c_cursor > len(previous_text):
-            self._c_cursor = 0
-            self._c_inside_call = False
+        if "<tool_call>" not in current_text and "<function=" not in current_text:
+            return {"content": delta_text}
 
-        # --- tool_calls channel ------------------------------------------
         # Trigger from the COMPLETION STATE of current_text, NOT from a close
         # tag appearing inside a single delta_text. We fire only when a NEW
         # close tag finished in this delta — i.e. the close-tag count in
@@ -309,68 +234,60 @@ class NemotronToolParser(ToolParser):
         # trailing deltas after a call has closed (avoiding O(n^2) re-parsing
         # and repeated fail-open WARNINGs on a trailing unparseable marker).
         #
-        # extract_tool_calls re-parses current_text and returns ALL complete,
-        # PARSEABLE calls; we de-dupe against how many we have ALREADY emitted
-        # (self._stream_calls_emitted, advanced only by emitted calls — never by
-        # the raw close-tag count) so each completed call is emitted exactly
-        # once, indices stay contiguous, and a malformed earlier close tag
-        # (close-count bump with no parseable call) can't shift later indices.
-        tool_calls_payload: list[dict[str, Any]] | None = None
+        # extract_tool_calls re-parses current_text and returns ALL complete
+        # calls; we de-dupe against the number already streamed (tracked in
+        # current_tool_id, which reset() zeroes per request) so each completed
+        # call is emitted exactly once even when </function> and </tool_call>
+        # arrive in separate deltas (each bumps the count → one re-parse each,
+        # but the second finds nothing new to emit).
         if self._close_tag_count(current_text) > self._close_tag_count(previous_text):
             result = self.extract_tool_calls(current_text)
+            # Trailing assistant text that arrived in THIS SAME delta, after the
+            # close tag (e.g. the tokenizer emits "</function> done" as one
+            # chunk). It is new (everything past the just-closed tag) and, being
+            # content-safe per _clean_trailing_content, must not be dropped — we
+            # ride it out on the same delta via the combined content+tool_calls
+            # return the postprocessor already supports.
+            tail = self._clean_trailing_content(current_text)
             if result.tools_called:
-                already_emitted = self._stream_calls_emitted
+                already_emitted = self.current_tool_id + 1
                 total = len(result.tool_calls)
                 if total > already_emitted:
                     new_calls = result.tool_calls[already_emitted:]
-                    self._stream_calls_emitted += len(new_calls)
-                    tool_calls_payload = [
-                        {
-                            "index": already_emitted + i,
-                            "id": tc["id"],
-                            "type": "function",
-                            "function": {
-                                "name": tc["name"],
-                                "arguments": tc["arguments"],
-                            },
-                        }
-                        for i, tc in enumerate(new_calls)
-                    ]
+                    self.current_tool_id = total - 1
+                    out: dict[str, Any] = {
+                        "tool_calls": [
+                            {
+                                "index": already_emitted + i,
+                                "id": tc["id"],
+                                "type": "function",
+                                "function": {
+                                    "name": tc["name"],
+                                    "arguments": tc["arguments"],
+                                },
+                            }
+                            for i, tc in enumerate(new_calls)
+                        ]
+                    }
+                    if tail:
+                        out["content"] = tail
+                    return out
+            # Close tag but no NEW call to emit (e.g. the second of </function>
+            # + </tool_call> for a call already streamed). Still surface any
+            # trailing content that rode in on this delta.
+            if tail:
+                return {"content": tail}
+            return None
 
-        # --- content channel ---------------------------------------------
-        # Assistant prose outside tool markup — before, between, and after
-        # calls — must stream through instead of being dropped. _advance_content
-        # scans incrementally (O(n) total), holds in-flight openers so no
-        # partial markup ("<fun") leaks, keeps genuine "<" prose ("2 < 3"), and
-        # never re-emits. Trailing prose in the SAME delta as a close tag rides
-        # out alongside tool_calls via the combined return the postprocessor
-        # already supports.
-        new_content = self._advance_content(current_text)
-        self._content_emitted_len += len(new_content)
+        # No new call closed in this delta. If we are past all tool-call markup
+        # (a call has closed and no new "<" has started since), the delta is
+        # trailing assistant content and must pass through instead of being
+        # silently dropped. _clean_trailing_content being non-None guarantees no
+        # partial or complete tag can leak, so we never emit "<function=",
+        # "</function>", or a fragment like "</fun" as user-visible content. We
+        # emit only delta_text (the new chars), never the whole tail, so
+        # already-streamed trailing content is not re-sent.
+        if self._clean_trailing_content(current_text) is not None:
+            return {"content": delta_text}
 
-        out: dict[str, Any] = {}
-        if tool_calls_payload is not None:
-            out["tool_calls"] = tool_calls_payload
-        if new_content:
-            out["content"] = new_content
-        return out or None
-
-    def flush_held_content(self, full_text: str) -> str:
-        """Release content the streaming scanner suppressed but that was, in
-        hindsight, ordinary prose.
-
-        The postprocessor calls this in ``finalize()`` only when NO tool call
-        fired. In that case an unclosed ``<function=..`` the scanner optimist-
-        ically entered suppression on never became a real call, so — matching
-        the non-streaming fail-open in ``extract_tool_calls`` — its text is
-        plain content. We return the fail-open content that was not yet emitted;
-        an empty string when a real call did parse (nothing to release) or when
-        everything was already streamed.
-        """
-        info = self.extract_tool_calls(full_text)
-        if info.tools_called:
-            return ""
-        full_content = info.content or ""
-        if self._content_emitted_len >= len(full_content):
-            return ""  # everything already streamed
-        return full_content[self._content_emitted_len :]
+        return None

--- a/vllm_mlx/tool_parsers/nemotron_tool_parser.py
+++ b/vllm_mlx/tool_parsers/nemotron_tool_parser.py
@@ -176,46 +176,94 @@ class NemotronToolParser(ToolParser):
         """
         return text.count("</function>") + text.count("</tool_call>")
 
-    # Tokens that OPEN tool-call markup. A ``<`` in the content stream is only
-    # suppressed when it could be forming one of these — an ordinary ``<`` in
-    # prose (e.g. ``"2 < 3"``) is content and must stream through.
-    _STREAM_OPENERS = ("<tool_call>", "<function=")
+    # Markup tokens the content scanner recognises. ``<function=`` opens a tool
+    # body (suppress until ``</function>``); the wrapper/close tags are stripped
+    # from the content stream. A ``<`` that matches none of these — even
+    # partially — is ordinary prose (e.g. ``"2 < 3"``) and streams through.
+    _CONTENT_OPEN_CALL = "<function="
+    _CONTENT_STRIP_TAGS = ("<tool_call>", "</tool_call>", "</function>")
+    _CONTENT_HOLD_TOKENS = ("<function=", "<tool_call>", "</tool_call>", "</function>")
+    _CONTENT_CLOSE_CALL = "</function>"
 
-    @classmethod
-    def _safe_content_len(cls, text: str) -> int:
-        """Length of the leading run of ``text`` that is safe to emit as content.
+    def __init__(self, tokenizer=None):
+        super().__init__(tokenizer)
+        # Incremental content-channel scanner state (see _advance_content).
+        self._c_cursor = 0
+        self._c_inside_call = False
 
-        Content is everything up to the first ``<`` that could begin (or has
-        begun) a tool-call opener — either a complete ``<function=``/
-        ``<tool_call>`` or a partial trailing prefix of one (``"<fun"``,
-        ``"<tool_cal"``, a lone ``"<"``). Any other ``<`` (``"2 < 3"``) is
-        ordinary prose and does not truncate.
+    def reset(self) -> None:
+        super().reset()
+        self._c_cursor = 0
+        self._c_inside_call = False
+
+    def _advance_content(self, current_text: str) -> str:
+        """Return assistant-content chars newly emittable since the last call.
+
+        A single forward scan over the accumulated ``current_text`` using a
+        persistent cursor (so the whole response is scanned O(n) total, not
+        O(n^2) per token). Rules:
+
+          * ``<function=..>..</function>`` bodies are suppressed (they are the
+            ``tool_calls`` channel, never content).
+          * bare ``<tool_call>`` / ``</tool_call>`` wrapper tags and any stray
+            ``</function>`` are stripped.
+          * a trailing ``<`` that is a partial prefix of one of those tokens
+            (``"<fun"``, ``"</too"``, a lone ``"<"``) is HELD until the next
+            delta resolves it, so no partial markup ever leaks as content.
+          * every other ``<`` (``"2 < 3"``) is ordinary prose and streams.
+
+        Assumes ``current_text`` extends what was already consumed (the
+        streaming contract). If it is shorter (e.g. a reused parser without
+        ``reset()``), the scan restarts defensively.
         """
-        start = 0
-        while True:
-            j = text.find("<", start)
-            if j == -1:
-                return len(text)
-            rest = text[j:]
-            if any(
-                op.startswith(rest) or rest.startswith(op) for op in cls._STREAM_OPENERS
-            ):
-                return j
-            start = j + 1
+        n = len(current_text)
+        if self._c_cursor > n:  # desync (text shrank) → rescan from scratch
+            self._c_cursor = 0
+            self._c_inside_call = False
 
-    def _streamed_content(self, text: str) -> str:
-        """The assistant-content channel that should have streamed for ``text``.
+        out: list[str] = []
+        i = self._c_cursor
+        hold = max(len(t) for t in self._CONTENT_HOLD_TOKENS) - 1
+        while i < n:
+            if self._c_inside_call:
+                close = current_text.find(self._CONTENT_CLOSE_CALL, i)
+                if close == -1:
+                    # Not closed yet; suppress everything but keep a small tail
+                    # unconsumed in case the close tag is split across deltas.
+                    i = max(i, n - hold)
+                    break
+                i = close + len(self._CONTENT_CLOSE_CALL)
+                self._c_inside_call = False
+                continue
 
-        Complete tool-call bodies and residual bare wrapper tags are removed
-        (they belong to the ``tool_calls`` channel, never content); then any
-        trailing in-flight opener is held back via :meth:`_safe_content_len`, so
-        a partial/complete tag can never leak. This is cumulative and monotone
-        in ``text``, so the per-delta content is just the new suffix versus the
-        previous cumulative value — no re-emission of already-streamed prose.
-        """
-        cleaned = self.TOOL_CALL_PATTERN.sub("", text)
-        cleaned = self.RESIDUAL_WRAPPER_PATTERN.sub("", cleaned)
-        return cleaned[: self._safe_content_len(cleaned)]
+            lt = current_text.find("<", i)
+            if lt == -1:
+                out.append(current_text[i:n])
+                i = n
+                break
+            if lt > i:
+                out.append(current_text[i:lt])
+            rest = current_text[lt:]
+            if rest.startswith(self._CONTENT_OPEN_CALL):
+                self._c_inside_call = True
+                i = lt + len(self._CONTENT_OPEN_CALL)
+                continue
+            stripped = next(
+                (t for t in self._CONTENT_STRIP_TAGS if rest.startswith(t)), None
+            )
+            if stripped is not None:
+                i = lt + len(stripped)
+                continue
+            if any(tok.startswith(rest) for tok in self._CONTENT_HOLD_TOKENS):
+                # Ambiguous partial tag at the tail → hold, decide next delta.
+                i = lt
+                break
+            # A "<" that cannot be any tool tag → it is content.
+            out.append("<")
+            i = lt + 1
+
+        self._c_cursor = i
+        return "".join(out)
 
     def extract_tool_calls_streaming(
         self,
@@ -230,9 +278,6 @@ class NemotronToolParser(ToolParser):
         """
         Extract tool calls from streaming Nemotron model output.
         """
-        if "<tool_call>" not in current_text and "<function=" not in current_text:
-            return {"content": delta_text}
-
         # --- tool_calls channel ------------------------------------------
         # Trigger from the COMPLETION STATE of current_text, NOT from a close
         # tag appearing inside a single delta_text. We fire only when a NEW
@@ -278,19 +323,13 @@ class NemotronToolParser(ToolParser):
 
         # --- content channel ---------------------------------------------
         # Assistant prose outside tool markup — before, between, and after
-        # calls — must stream through instead of being dropped. We diff the
-        # cumulative safe-content of current vs previous, so trailing prose
-        # after a call (including in the SAME delta as the close tag, via the
-        # combined content+tool_calls return the postprocessor supports) is
-        # preserved, an in-flight opener is held until it resolves, and a
-        # genuine "<" in prose ("2 < 3") is never suppressed.
-        prev_content = self._streamed_content(previous_text)
-        cur_content = self._streamed_content(current_text)
-        new_content = (
-            cur_content[len(prev_content) :]
-            if cur_content.startswith(prev_content)
-            else ""
-        )
+        # calls — must stream through instead of being dropped. _advance_content
+        # scans incrementally (O(n) total), holds in-flight openers so no
+        # partial markup ("<fun") leaks, keeps genuine "<" prose ("2 < 3"), and
+        # never re-emits. Trailing prose in the SAME delta as a close tag rides
+        # out alongside tool_calls via the combined return the postprocessor
+        # already supports.
+        new_content = self._advance_content(current_text)
 
         out: dict[str, Any] = {}
         if tool_calls_payload is not None:

--- a/vllm_mlx/tool_parsers/nemotron_tool_parser.py
+++ b/vllm_mlx/tool_parsers/nemotron_tool_parser.py
@@ -176,33 +176,46 @@ class NemotronToolParser(ToolParser):
         """
         return text.count("</function>") + text.count("</tool_call>")
 
-    @staticmethod
-    def _clean_trailing_content(current_text: str) -> str | None:
-        """The plain-content tail of ``current_text``, or ``None`` if none.
+    # Tokens that OPEN tool-call markup. A ``<`` in the content stream is only
+    # suppressed when it could be forming one of these — an ordinary ``<`` in
+    # prose (e.g. ``"2 < 3"``) is content and must stream through.
+    _STREAM_OPENERS = ("<tool_call>", "<function=")
 
-        "Tail" = everything after the last COMPLETE tool-call close tag
-        (``</function>`` / ``</tool_call>``). It is content-safe only if it
-        contains no ``<`` at all — the moment a ``<`` appears we are (possibly)
-        building the next call and must suppress, so no tag (complete or a
-        partial fragment like ``"<fun"`` / ``"</fun"``) can ever leak into
-        user-visible content.
+    @classmethod
+    def _safe_content_len(cls, text: str) -> int:
+        """Length of the leading run of ``text`` that is safe to emit as content.
 
-        Returns:
-          * ``None``  — still inside markup (no call closed yet, or a new
-            ``<`` has started after the last close): suppress.
-          * ``""``    — a call has closed and nothing (yet) follows it.
-          * ``str``   — the safe trailing content after the last close.
+        Content is everything up to the first ``<`` that could begin (or has
+        begun) a tool-call opener — either a complete ``<function=``/
+        ``<tool_call>`` or a partial trailing prefix of one (``"<fun"``,
+        ``"<tool_cal"``, a lone ``"<"``). Any other ``<`` (``"2 < 3"``) is
+        ordinary prose and does not truncate.
         """
-        end = 0
-        for tag in ("</function>", "</tool_call>"):
-            idx = current_text.rfind(tag)
-            if idx != -1:
-                end = max(end, idx + len(tag))
-        if end == 0:
-            # No close tag yet → we are still inside the (first) call's markup.
-            return None
-        tail = current_text[end:]
-        return None if "<" in tail else tail
+        start = 0
+        while True:
+            j = text.find("<", start)
+            if j == -1:
+                return len(text)
+            rest = text[j:]
+            if any(
+                op.startswith(rest) or rest.startswith(op) for op in cls._STREAM_OPENERS
+            ):
+                return j
+            start = j + 1
+
+    def _streamed_content(self, text: str) -> str:
+        """The assistant-content channel that should have streamed for ``text``.
+
+        Complete tool-call bodies and residual bare wrapper tags are removed
+        (they belong to the ``tool_calls`` channel, never content); then any
+        trailing in-flight opener is held back via :meth:`_safe_content_len`, so
+        a partial/complete tag can never leak. This is cumulative and monotone
+        in ``text``, so the per-delta content is just the new suffix versus the
+        previous cumulative value — no re-emission of already-streamed prose.
+        """
+        cleaned = self.TOOL_CALL_PATTERN.sub("", text)
+        cleaned = self.RESIDUAL_WRAPPER_PATTERN.sub("", cleaned)
+        return cleaned[: self._safe_content_len(cleaned)]
 
     def extract_tool_calls_streaming(
         self,
@@ -220,6 +233,7 @@ class NemotronToolParser(ToolParser):
         if "<tool_call>" not in current_text and "<function=" not in current_text:
             return {"content": delta_text}
 
+        # --- tool_calls channel ------------------------------------------
         # Trigger from the COMPLETION STATE of current_text, NOT from a close
         # tag appearing inside a single delta_text. We fire only when a NEW
         # close tag finished in this delta — i.e. the close-tag count in
@@ -240,54 +254,47 @@ class NemotronToolParser(ToolParser):
         # call is emitted exactly once even when </function> and </tool_call>
         # arrive in separate deltas (each bumps the count → one re-parse each,
         # but the second finds nothing new to emit).
+        tool_calls_payload: list[dict[str, Any]] | None = None
         if self._close_tag_count(current_text) > self._close_tag_count(previous_text):
             result = self.extract_tool_calls(current_text)
-            # Trailing assistant text that arrived in THIS SAME delta, after the
-            # close tag (e.g. the tokenizer emits "</function> done" as one
-            # chunk). It is new (everything past the just-closed tag) and, being
-            # content-safe per _clean_trailing_content, must not be dropped — we
-            # ride it out on the same delta via the combined content+tool_calls
-            # return the postprocessor already supports.
-            tail = self._clean_trailing_content(current_text)
             if result.tools_called:
                 already_emitted = self.current_tool_id + 1
                 total = len(result.tool_calls)
                 if total > already_emitted:
                     new_calls = result.tool_calls[already_emitted:]
                     self.current_tool_id = total - 1
-                    out: dict[str, Any] = {
-                        "tool_calls": [
-                            {
-                                "index": already_emitted + i,
-                                "id": tc["id"],
-                                "type": "function",
-                                "function": {
-                                    "name": tc["name"],
-                                    "arguments": tc["arguments"],
-                                },
-                            }
-                            for i, tc in enumerate(new_calls)
-                        ]
-                    }
-                    if tail:
-                        out["content"] = tail
-                    return out
-            # Close tag but no NEW call to emit (e.g. the second of </function>
-            # + </tool_call> for a call already streamed). Still surface any
-            # trailing content that rode in on this delta.
-            if tail:
-                return {"content": tail}
-            return None
+                    tool_calls_payload = [
+                        {
+                            "index": already_emitted + i,
+                            "id": tc["id"],
+                            "type": "function",
+                            "function": {
+                                "name": tc["name"],
+                                "arguments": tc["arguments"],
+                            },
+                        }
+                        for i, tc in enumerate(new_calls)
+                    ]
 
-        # No new call closed in this delta. If we are past all tool-call markup
-        # (a call has closed and no new "<" has started since), the delta is
-        # trailing assistant content and must pass through instead of being
-        # silently dropped. _clean_trailing_content being non-None guarantees no
-        # partial or complete tag can leak, so we never emit "<function=",
-        # "</function>", or a fragment like "</fun" as user-visible content. We
-        # emit only delta_text (the new chars), never the whole tail, so
-        # already-streamed trailing content is not re-sent.
-        if self._clean_trailing_content(current_text) is not None:
-            return {"content": delta_text}
+        # --- content channel ---------------------------------------------
+        # Assistant prose outside tool markup — before, between, and after
+        # calls — must stream through instead of being dropped. We diff the
+        # cumulative safe-content of current vs previous, so trailing prose
+        # after a call (including in the SAME delta as the close tag, via the
+        # combined content+tool_calls return the postprocessor supports) is
+        # preserved, an in-flight opener is held until it resolves, and a
+        # genuine "<" in prose ("2 < 3") is never suppressed.
+        prev_content = self._streamed_content(previous_text)
+        cur_content = self._streamed_content(current_text)
+        new_content = (
+            cur_content[len(prev_content) :]
+            if cur_content.startswith(prev_content)
+            else ""
+        )
 
-        return None
+        out: dict[str, Any] = {}
+        if tool_calls_payload is not None:
+            out["tool_calls"] = tool_calls_payload
+        if new_content:
+            out["content"] = new_content
+        return out or None

--- a/vllm_mlx/tool_parsers/nemotron_tool_parser.py
+++ b/vllm_mlx/tool_parsers/nemotron_tool_parser.py
@@ -165,6 +165,17 @@ class NemotronToolParser(ToolParser):
                 tools_called=False, tool_calls=[], content=model_output
             )
 
+    @staticmethod
+    def _close_tag_count(text: str) -> int:
+        """Number of completed tool-call close tags present in ``text``.
+
+        A call may legitimately close on either ``</function>`` (a truncated
+        variant that never emits the wrapper) or ``</tool_call>``. Used by the
+        streaming path to detect that a NEW call finished in the latest delta
+        (count went up) rather than re-parsing on every chunk.
+        """
+        return text.count("</function>") + text.count("</tool_call>")
+
     def extract_tool_calls_streaming(
         self,
         previous_text: str,
@@ -182,17 +193,26 @@ class NemotronToolParser(ToolParser):
             return {"content": delta_text}
 
         # Trigger from the COMPLETION STATE of current_text, NOT from a close
-        # tag appearing inside a single delta_text. The tokenizer can split a
-        # close tag across deltas ("</fun" then "ction>"), so no single delta
-        # ever contains the whole "</function>"/"</tool_call>" — but the
-        # accumulated current_text does, once both fragments have arrived.
-        # extract_tool_calls re-parses current_text and only returns a call
-        # once its <function=..></function> body is complete; we de-dupe
-        # against the number already streamed (tracked in current_tool_id,
-        # which reset() zeroes per request) so each completed call is emitted
-        # exactly once regardless of how the close tag is chunked or whether
-        # </function> and </tool_call> land in the same delta.
-        if "</function>" in current_text or "</tool_call>" in current_text:
+        # tag appearing inside a single delta_text. We fire only when a NEW
+        # close tag finished in this delta — i.e. the close-tag count in
+        # current_text ticked up versus previous_text.
+        #
+        # Counting the delta (rather than testing membership in delta_text) is
+        # what makes a close tag split across chunks work: the tokenizer can
+        # emit "</fun" then "ction>", so no single delta ever contains the
+        # whole "</function>" — but the accumulated current_text does once both
+        # fragments arrive, and only then does the count go up. Gating on the
+        # *increase* also means we never re-parse current_text on the many
+        # trailing deltas after a call has closed (avoiding O(n^2) re-parsing
+        # and repeated fail-open WARNINGs on a trailing unparseable marker).
+        #
+        # extract_tool_calls re-parses current_text and returns ALL complete
+        # calls; we de-dupe against the number already streamed (tracked in
+        # current_tool_id, which reset() zeroes per request) so each completed
+        # call is emitted exactly once even when </function> and </tool_call>
+        # arrive in separate deltas (each bumps the count → one re-parse each,
+        # but the second finds nothing new to emit).
+        if self._close_tag_count(current_text) > self._close_tag_count(previous_text):
             result = self.extract_tool_calls(current_text)
             if result.tools_called:
                 already_emitted = self.current_tool_id + 1

--- a/vllm_mlx/tool_parsers/nemotron_tool_parser.py
+++ b/vllm_mlx/tool_parsers/nemotron_tool_parser.py
@@ -191,6 +191,9 @@ class NemotronToolParser(ToolParser):
         # Incremental content-channel scanner state (see _advance_content).
         self._c_cursor = 0
         self._c_inside_call = False
+        # Chars already emitted on the streaming content channel this request
+        # (used by flush_held_content to release a held-but-never-closed tail).
+        self._content_emitted_len = 0
         # Count of tool calls ALREADY emitted on the streaming tool_calls
         # channel this request. Updated only from emitted calls (never from the
         # raw close-tag count), so malformed close tags can't shift indices.
@@ -200,6 +203,7 @@ class NemotronToolParser(ToolParser):
         super().reset()
         self._c_cursor = 0
         self._c_inside_call = False
+        self._content_emitted_len = 0
         self._stream_calls_emitted = 0
 
     def _advance_content(self, current_text: str) -> str:
@@ -342,6 +346,7 @@ class NemotronToolParser(ToolParser):
         # out alongside tool_calls via the combined return the postprocessor
         # already supports.
         new_content = self._advance_content(current_text)
+        self._content_emitted_len += len(new_content)
 
         out: dict[str, Any] = {}
         if tool_calls_payload is not None:
@@ -349,3 +354,23 @@ class NemotronToolParser(ToolParser):
         if new_content:
             out["content"] = new_content
         return out or None
+
+    def flush_held_content(self, full_text: str) -> str:
+        """Release content the streaming scanner suppressed but that was, in
+        hindsight, ordinary prose.
+
+        The postprocessor calls this in ``finalize()`` only when NO tool call
+        fired. In that case an unclosed ``<function=..`` the scanner optimist-
+        ically entered suppression on never became a real call, so — matching
+        the non-streaming fail-open in ``extract_tool_calls`` — its text is
+        plain content. We return the fail-open content that was not yet emitted;
+        an empty string when a real call did parse (nothing to release) or when
+        everything was already streamed.
+        """
+        info = self.extract_tool_calls(full_text)
+        if info.tools_called:
+            return ""
+        full_content = info.content or ""
+        if self._content_emitted_len >= len(full_content):
+            return ""  # everything already streamed
+        return full_content[self._content_emitted_len :]

--- a/vllm_mlx/tool_parsers/nemotron_tool_parser.py
+++ b/vllm_mlx/tool_parsers/nemotron_tool_parser.py
@@ -212,15 +212,11 @@ class NemotronToolParser(ToolParser):
             delta resolves it, so no partial markup ever leaks as content.
           * every other ``<`` (``"2 < 3"``) is ordinary prose and streams.
 
-        Assumes ``current_text`` extends what was already consumed (the
-        streaming contract). If it is shorter (e.g. a reused parser without
-        ``reset()``), the scan restarts defensively.
+        The caller (:meth:`extract_tool_calls_streaming`) restarts the scan
+        whenever the cursor is ahead of the stream, so ``current_text`` is
+        always an extension of what was already consumed here.
         """
         n = len(current_text)
-        if self._c_cursor > n:  # desync (text shrank) → rescan from scratch
-            self._c_cursor = 0
-            self._c_inside_call = False
-
         out: list[str] = []
         i = self._c_cursor
         hold = max(len(t) for t in self._CONTENT_HOLD_TOKENS) - 1
@@ -278,6 +274,16 @@ class NemotronToolParser(ToolParser):
         """
         Extract tool calls from streaming Nemotron model output.
         """
+        # Guard the incremental content scanner against a parser reused for a
+        # new/independent stream without reset(): within one stream the cursor
+        # is always <= len(previous_text) (it was set while scanning that very
+        # text). If it is ahead, previous_text belongs to a different (shorter)
+        # stream — including a fresh stream where previous_text == "" — so
+        # restart the scan to avoid skipping the new stream's leading content.
+        if self._c_cursor > len(previous_text):
+            self._c_cursor = 0
+            self._c_inside_call = False
+
         # --- tool_calls channel ------------------------------------------
         # Trigger from the COMPLETION STATE of current_text, NOT from a close
         # tag appearing inside a single delta_text. We fire only when a NEW

--- a/vllm_mlx/tool_parsers/nemotron_tool_parser.py
+++ b/vllm_mlx/tool_parsers/nemotron_tool_parser.py
@@ -176,6 +176,30 @@ class NemotronToolParser(ToolParser):
         """
         return text.count("</function>") + text.count("</tool_call>")
 
+    @staticmethod
+    def _in_clean_tail(current_text: str) -> bool:
+        """True if the tail of ``current_text`` is plain assistant content.
+
+        "Tail" = everything after the last COMPLETE tool-call close tag
+        (``</function>`` / ``</tool_call>``). If that tail contains no ``<`` at
+        all, then no new tag — not even a partial one like ``"<fun"`` — has
+        started, so the tail is safe to stream through as content. The moment a
+        ``<`` appears we are (possibly) building the next call and must buffer
+        instead, so a fragment can never leak into user-visible content.
+
+        Returns False when no call has closed yet (the whole text is still
+        inside the first call's markup).
+        """
+        end = 0
+        for tag in ("</function>", "</tool_call>"):
+            idx = current_text.rfind(tag)
+            if idx != -1:
+                end = max(end, idx + len(tag))
+        if end == 0:
+            # No close tag yet → we are still inside the (first) call's markup.
+            return False
+        return "<" not in current_text[end:]
+
     def extract_tool_calls_streaming(
         self,
         previous_text: str,
@@ -234,5 +258,17 @@ class NemotronToolParser(ToolParser):
                             for i, tc in enumerate(new_calls)
                         ]
                     }
+            # This delta carried a close tag (markup). Never stream its text as
+            # content — trailing assistant text arrives in later, clean deltas.
+            return None
+
+        # No new call closed in this delta. If we are past all tool-call markup
+        # (a call has closed and no new "<" has started since), the delta is
+        # trailing assistant content and must pass through instead of being
+        # silently dropped. _in_clean_tail guarantees no partial or complete
+        # tag can leak, so we never emit "<function=", "</function>", or a
+        # fragment like "</fun" as user-visible content.
+        if self._in_clean_tail(current_text):
+            return {"content": delta_text}
 
         return None

--- a/vllm_mlx/tool_parsers/nemotron_tool_parser.py
+++ b/vllm_mlx/tool_parsers/nemotron_tool_parser.py
@@ -9,6 +9,7 @@ Supports Nemotron-3-Nano-30B-A3B and similar models.
 """
 
 import json
+import logging
 import re
 import uuid
 from collections.abc import Sequence
@@ -19,6 +20,8 @@ from .abstract_tool_parser import (
     ToolParser,
     ToolParserManager,
 )
+
+logger = logging.getLogger(__name__)
 
 
 def generate_tool_id() -> str:
@@ -42,11 +45,25 @@ class NemotronToolParser(ToolParser):
 
     EXPECTED_WIRE_FORMATS = ("tool_call_xml_body",)
 
-    # Pattern for Nemotron-style with parameters
+    # Pattern for Nemotron-style with parameters.
+    #
+    # The load-bearing signature of a call is ``<function=NAME>...</function>``;
+    # the ``<tool_call>``/``</tool_call>`` wrapper is treated as optional /
+    # decorative so that observed degradations still parse:
+    #   (a) a missing/truncated ``</tool_call>``,
+    #   (b) a bare ``<function=..>..</function>`` with no wrapper at all,
+    #   (d) stray text between ``</function>`` and ``</tool_call>``,
+    #   (e) prose between ``<tool_call>`` and ``<function=``.
+    # Prose without ``<function=..>..</function>`` still never matches, so
+    # this cannot manufacture a tool call out of plain text.
     TOOL_CALL_PATTERN = re.compile(
-        r"<tool_call>\s*<function=([^>]+)>(.*?)</function>\s*</tool_call>",
+        r"<function=([^>]+)>(.*?)</function>",
         re.DOTALL,
     )
+
+    # Residual bare wrapper tags left behind after the function bodies have
+    # been stripped from ``content``; removed so they don't leak as text.
+    RESIDUAL_WRAPPER_PATTERN = re.compile(r"</?tool_call>")
 
     # Pattern to extract parameters
     PARAM_PATTERN = re.compile(
@@ -60,7 +77,7 @@ class NemotronToolParser(ToolParser):
         """
         Extract tool calls from Nemotron model output.
         """
-        if "<tool_call>" not in model_output:
+        if "<tool_call>" not in model_output and "<function=" not in model_output:
             return ExtractedToolCallInformation(
                 tools_called=False, tool_calls=[], content=model_output
             )
@@ -116,9 +133,11 @@ class NemotronToolParser(ToolParser):
                     }
                 )
 
-        # Clean the text
+        # Clean the text: drop the function bodies and any residual bare
+        # <tool_call>/</tool_call> wrapper tags so they don't leak as content.
         if matches:
-            cleaned_text = self.TOOL_CALL_PATTERN.sub("", cleaned_text).strip()
+            cleaned_text = self.TOOL_CALL_PATTERN.sub("", cleaned_text)
+            cleaned_text = self.RESIDUAL_WRAPPER_PATTERN.sub("", cleaned_text).strip()
 
         if tool_calls:
             return ExtractedToolCallInformation(
@@ -127,6 +146,15 @@ class NemotronToolParser(ToolParser):
                 content=cleaned_text if cleaned_text else None,
             )
         else:
+            # Diagnostic: a tool-call marker was present but nothing parsed
+            # out — i.e. an as-yet-unhandled wire variant. Log the raw output
+            # (truncated) so the real shape can be captured next time it hits.
+            logger.warning(
+                "nemotron tool parser: tool-call marker present but no tool "
+                "call extracted (possible unhandled variant); raw model_output"
+                "[:500]=%r",
+                model_output[:500],
+            )
             return ExtractedToolCallInformation(
                 tools_called=False, tool_calls=[], content=model_output
             )
@@ -144,25 +172,36 @@ class NemotronToolParser(ToolParser):
         """
         Extract tool calls from streaming Nemotron model output.
         """
-        if "<tool_call>" not in current_text:
+        if "<tool_call>" not in current_text and "<function=" not in current_text:
             return {"content": delta_text}
 
-        if "</tool_call>" in delta_text:
+        # Fire on either close tag: a truncated variant may only ever emit
+        # </function> (no </tool_call>). extract_tool_calls re-parses the full
+        # current_text and returns ALL calls, so we de-dupe against the number
+        # already streamed (tracked in current_tool_id, which reset() zeroes
+        # per request) to avoid re-emitting when </function> and </tool_call>
+        # arrive in separate deltas.
+        if "</tool_call>" in delta_text or "</function>" in delta_text:
             result = self.extract_tool_calls(current_text)
             if result.tools_called:
-                return {
-                    "tool_calls": [
-                        {
-                            "index": i,
-                            "id": tc["id"],
-                            "type": "function",
-                            "function": {
-                                "name": tc["name"],
-                                "arguments": tc["arguments"],
-                            },
-                        }
-                        for i, tc in enumerate(result.tool_calls)
-                    ]
-                }
+                already_emitted = self.current_tool_id + 1
+                total = len(result.tool_calls)
+                if total > already_emitted:
+                    new_calls = result.tool_calls[already_emitted:]
+                    self.current_tool_id = total - 1
+                    return {
+                        "tool_calls": [
+                            {
+                                "index": already_emitted + i,
+                                "id": tc["id"],
+                                "type": "function",
+                                "function": {
+                                    "name": tc["name"],
+                                    "arguments": tc["arguments"],
+                                },
+                            }
+                            for i, tc in enumerate(new_calls)
+                        ]
+                    }
 
         return None

--- a/vllm_mlx/tool_parsers/nemotron_tool_parser.py
+++ b/vllm_mlx/tool_parsers/nemotron_tool_parser.py
@@ -147,13 +147,19 @@ class NemotronToolParser(ToolParser):
             )
         else:
             # Diagnostic: a tool-call marker was present but nothing parsed
-            # out — i.e. an as-yet-unhandled wire variant. Log the raw output
-            # (truncated) so the real shape can be captured next time it hits.
+            # out — i.e. an as-yet-unhandled wire variant. Emit only a
+            # STRUCTURAL SUMMARY of the shape, never the raw payload: this is
+            # the normal degraded-wire path, and model_output can carry user
+            # prompts, tool arguments, or credentials. The counts below are
+            # enough to triage the unhandled variant without leaking content.
+            has_tool_call_marker = "<tool_call>" in model_output
+            function_tag_count = model_output.count("<function=")
             logger.warning(
                 "nemotron tool parser: tool-call marker present but no tool "
-                "call extracted (possible unhandled variant); raw model_output"
-                "[:500]=%r",
-                model_output[:500],
+                "call extracted (possible unhandled variant); "
+                "<tool_call> present=%s, %d <function= tags, 0 parseable",
+                has_tool_call_marker,
+                function_tag_count,
             )
             return ExtractedToolCallInformation(
                 tools_called=False, tool_calls=[], content=model_output
@@ -175,13 +181,18 @@ class NemotronToolParser(ToolParser):
         if "<tool_call>" not in current_text and "<function=" not in current_text:
             return {"content": delta_text}
 
-        # Fire on either close tag: a truncated variant may only ever emit
-        # </function> (no </tool_call>). extract_tool_calls re-parses the full
-        # current_text and returns ALL calls, so we de-dupe against the number
-        # already streamed (tracked in current_tool_id, which reset() zeroes
-        # per request) to avoid re-emitting when </function> and </tool_call>
-        # arrive in separate deltas.
-        if "</tool_call>" in delta_text or "</function>" in delta_text:
+        # Trigger from the COMPLETION STATE of current_text, NOT from a close
+        # tag appearing inside a single delta_text. The tokenizer can split a
+        # close tag across deltas ("</fun" then "ction>"), so no single delta
+        # ever contains the whole "</function>"/"</tool_call>" — but the
+        # accumulated current_text does, once both fragments have arrived.
+        # extract_tool_calls re-parses current_text and only returns a call
+        # once its <function=..></function> body is complete; we de-dupe
+        # against the number already streamed (tracked in current_tool_id,
+        # which reset() zeroes per request) so each completed call is emitted
+        # exactly once regardless of how the close tag is chunked or whether
+        # </function> and </tool_call> land in the same delta.
+        if "</function>" in current_text or "</tool_call>" in current_text:
             result = self.extract_tool_calls(current_text)
             if result.tools_called:
                 already_emitted = self.current_tool_id + 1

--- a/vllm_mlx/tool_parsers/nemotron_tool_parser.py
+++ b/vllm_mlx/tool_parsers/nemotron_tool_parser.py
@@ -146,21 +146,22 @@ class NemotronToolParser(ToolParser):
                 content=cleaned_text if cleaned_text else None,
             )
         else:
-            # Diagnostic: a tool-call marker was present but nothing parsed
-            # out — i.e. an as-yet-unhandled wire variant. Emit only a
-            # STRUCTURAL SUMMARY of the shape, never the raw payload: this is
-            # the normal degraded-wire path, and model_output can carry user
-            # prompts, tool arguments, or credentials. The counts below are
-            # enough to triage the unhandled variant without leaking content.
-            has_tool_call_marker = "<tool_call>" in model_output
-            function_tag_count = model_output.count("<function=")
-            logger.warning(
-                "nemotron tool parser: tool-call marker present but no tool "
-                "call extracted (possible unhandled variant); "
-                "<tool_call> present=%s, %d <function= tags, 0 parseable",
-                has_tool_call_marker,
-                function_tag_count,
-            )
+            # Diagnostic: a genuine ``<tool_call>`` WRAPPER was present but
+            # nothing parsed out — i.e. an as-yet-unhandled degraded-wire
+            # variant worth capturing. We deliberately do NOT warn on a bare
+            # unmatched ``<function=`` with no wrapper: that is far more likely
+            # ordinary assistant prose mentioning an XML-ish example than a real
+            # tool call, so warning on it would be noise. Emit only a STRUCTURAL
+            # SUMMARY, never the raw payload — this path can carry user prompts,
+            # tool arguments, or credentials.
+            if "<tool_call>" in model_output:
+                function_tag_count = model_output.count("<function=")
+                logger.warning(
+                    "nemotron tool parser: <tool_call> marker present but no "
+                    "tool call extracted (possible unhandled variant); "
+                    "%d <function= tags, 0 parseable",
+                    function_tag_count,
+                )
             return ExtractedToolCallInformation(
                 tools_called=False, tool_calls=[], content=model_output
             )
@@ -190,11 +191,16 @@ class NemotronToolParser(ToolParser):
         # Incremental content-channel scanner state (see _advance_content).
         self._c_cursor = 0
         self._c_inside_call = False
+        # Count of tool calls ALREADY emitted on the streaming tool_calls
+        # channel this request. Updated only from emitted calls (never from the
+        # raw close-tag count), so malformed close tags can't shift indices.
+        self._stream_calls_emitted = 0
 
     def reset(self) -> None:
         super().reset()
         self._c_cursor = 0
         self._c_inside_call = False
+        self._stream_calls_emitted = 0
 
     def _advance_content(self, current_text: str) -> str:
         """Return assistant-content chars newly emittable since the last call.
@@ -299,21 +305,21 @@ class NemotronToolParser(ToolParser):
         # trailing deltas after a call has closed (avoiding O(n^2) re-parsing
         # and repeated fail-open WARNINGs on a trailing unparseable marker).
         #
-        # extract_tool_calls re-parses current_text and returns ALL complete
-        # calls; we de-dupe against the number already streamed (tracked in
-        # current_tool_id, which reset() zeroes per request) so each completed
-        # call is emitted exactly once even when </function> and </tool_call>
-        # arrive in separate deltas (each bumps the count → one re-parse each,
-        # but the second finds nothing new to emit).
+        # extract_tool_calls re-parses current_text and returns ALL complete,
+        # PARSEABLE calls; we de-dupe against how many we have ALREADY emitted
+        # (self._stream_calls_emitted, advanced only by emitted calls — never by
+        # the raw close-tag count) so each completed call is emitted exactly
+        # once, indices stay contiguous, and a malformed earlier close tag
+        # (close-count bump with no parseable call) can't shift later indices.
         tool_calls_payload: list[dict[str, Any]] | None = None
         if self._close_tag_count(current_text) > self._close_tag_count(previous_text):
             result = self.extract_tool_calls(current_text)
             if result.tools_called:
-                already_emitted = self.current_tool_id + 1
+                already_emitted = self._stream_calls_emitted
                 total = len(result.tool_calls)
                 if total > already_emitted:
                     new_calls = result.tool_calls[already_emitted:]
-                    self.current_tool_id = total - 1
+                    self._stream_calls_emitted += len(new_calls)
                     tool_calls_payload = [
                         {
                             "index": already_emitted + i,


### PR DESCRIPTION
Revives #1031 by @arthurhaliski (fail-open tool-call parsing for degraded Nemotron wire variants). His original commit is cherry-picked verbatim to preserve authorship. This PR addresses the two `pr_validate` findings that closed #1031, plus a minimal, safe streaming trailing-content passthrough.

## The two original findings (owner scope)

1. **Privacy (`nemotron_tool_parser.py`).** The "marker present but nothing parsed" diagnostic logged `model_output[:500]` at WARNING on every malformed marker — the normal degraded-wire path — which can contain user prompts, tool arguments, or credentials. Replaced with a structural summary (`<tool_call>` present + `<function=` tag count + `0 parseable`); no raw payload.

2. **Streaming split close-tag (`nemotron_tool_parser.py`).** The stream fired only when a close tag appeared inside a single `delta_text`, so a close tag split across chunks (`"</fun"` then `"ction>"`) never emitted the completed call. Now triggers from the completion state of `current_text` (close-tag count increase vs `previous_text`) with de-dup, so the call is emitted exactly once however the close tag is chunked.

Plus a minimal, bypass-safe trailing-content passthrough (`_clean_trailing_content`: past-close tail with no `<`) that preserves same-delta trailing prose without leaking markup.

## Scope note

Deeper streaming content-channel refinements were explored and intentionally reverted: they risked (and in one case introduced) double-emit / dropped-content regressions, and are moot end-to-end because the postprocessor drops all content once a tool call fires. This PR keeps to the owner's stated scope + the safe passthrough.

Original PR / review: https://github.com/raullenchai/Rapid-MLX/pull/1031

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
