### PR TITLE
fix(scheduler): stop caching non-trimmable GatedDeltaNet recurrent state in reuse cache (fixes #1025, #1058 leak)

### DIFF
--- a/tests/test_hybrid_prefix_cache_growth.py
+++ b/tests/test_hybrid_prefix_cache_growth.py
@@ -217,6 +217,41 @@ def test_dict_form_all_kvcache_stored(cache):
     assert tuple(prompt) in cache._entries
 
 
+@pytest.mark.parametrize(
+    "kv_class", ["RotatingKVCache", "ChunkedKVCache", "ConcatenateKVCache", "QuantizedKVCache"]
+)
+def test_dict_form_trimmable_kv_variants_still_stored(cache, kv_class):
+    """Dict-form sliding-window / other trimmable KV classes must NOT be dropped.
+
+    Regression for codex #1075 finding: an allowlist of only KVCache would
+    wrongly classify RotatingKVCache & friends as non-trimmable and drop the
+    entry, regressing prefix reuse for dense / sliding-window models. The
+    denylist keeps them cacheable.
+    """
+    prompt = list(range(1000, 1100))
+    dict_cache = [
+        {"class_name": kv_class, "state": (1, 2), "meta_state": ("0",)},
+        {"class_name": kv_class, "state": (3, 4), "meta_state": ("0",)},
+    ]
+
+    assert cache.store(prompt, dict_cache) is True, (
+        f"{kv_class} is trimmable and must remain cacheable"
+    )
+    assert tuple(prompt) in cache._entries
+
+
+def test_dict_form_mamba_variant_dropped(cache):
+    """Vendor-suffixed recurrent class names are caught by substring match."""
+    prompt = list(range(1000, 1100))
+    dict_cache = [
+        {"class_name": "KVCache", "state": (1, 2), "meta_state": ("0",)},
+        {"class_name": "GatedDeltaNetArraysCache", "state": (3, 4), "meta_state": ("0",)},
+    ]
+
+    assert cache.store(prompt, dict_cache) is False
+    assert tuple(prompt) not in cache._entries
+
+
 # ---------------------------------------------------------------------------
 # Guards preserved from the #214 era: trim-required matches still MISS. These
 # now also never even reach fetch (store dropped them), but the fetch-side

--- a/tests/test_hybrid_prefix_cache_growth.py
+++ b/tests/test_hybrid_prefix_cache_growth.py
@@ -218,7 +218,8 @@ def test_dict_form_all_kvcache_stored(cache):
 
 
 @pytest.mark.parametrize(
-    "kv_class", ["RotatingKVCache", "ChunkedKVCache", "ConcatenateKVCache", "QuantizedKVCache"]
+    "kv_class",
+    ["RotatingKVCache", "ChunkedKVCache", "ConcatenateKVCache", "QuantizedKVCache"],
 )
 def test_dict_form_trimmable_kv_variants_still_stored(cache, kv_class):
     """Dict-form sliding-window / other trimmable KV classes must NOT be dropped.
@@ -245,7 +246,11 @@ def test_dict_form_mamba_variant_dropped(cache):
     prompt = list(range(1000, 1100))
     dict_cache = [
         {"class_name": "KVCache", "state": (1, 2), "meta_state": ("0",)},
-        {"class_name": "GatedDeltaNetArraysCache", "state": (3, 4), "meta_state": ("0",)},
+        {
+            "class_name": "GatedDeltaNetArraysCache",
+            "state": (3, 4),
+            "meta_state": ("0",),
+        },
     ]
 
     assert cache.store(prompt, dict_cache) is False

--- a/tests/test_hybrid_prefix_cache_growth.py
+++ b/tests/test_hybrid_prefix_cache_growth.py
@@ -1,16 +1,35 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Regression for issue #214 — prefix cache misses on every turn for hybrid
-attention models in growing multi-turn conversations.
+"""Hybrid (GatedDeltaNet / Mamba MoE) recurrent-state cache policy.
 
-Two external users (oldriverno1, michaelasper) confirmed: on hybrid models
-(GatedDeltaNet + Transformer, e.g. Qwen3.6-35B-A3B), each turn re-prefills
-the entire cumulative prompt, so TTFT grows linearly with conversation
-length. Dense models (Qwen3-Coder-30B-A3B) match ``mlx_lm.server`` within a
-few percent. The bug is hybrid-specific.
+History
+-------
+Issue #214 (oldriverno1, michaelasper) originally asked for hybrid multi-turn
+conversations to hit the prefix cache the way dense models do, so TTFT would
+not grow linearly with conversation length. We shipped that: stored
+``[P + R1]`` was reused as a strict prefix of turn-2's ``[P + R1 + M2]`` (no
+trim required — the RNN state at end-of-stored is exactly the state needed at
+start-of-M2-prefill).
 
-We isolate the cache-lookup layer (no model load) and assert the multi-turn
-growing pattern hits the prefix path on hybrid layouts the same way it does
-on dense.
+Issues #1025 / #1058 then showed the OTHER edge of the same behavior: those
+per-request recurrent-state (``ArraysCache``) entries are stored by reference
+and are NEVER a prefix of the *next* request across DIFFERENT conversations
+(each request's output differs → every key is a unique superset), so
+prefix-subset eviction never reclaims them. They only drop under the cache's
+own byte budget (independent of ``--gpu-memory-utilization``), so Metal
+``active`` ratchets up holding leaked recurrent state → D-METAL-CAP wedges /
+OOM.
+
+Resolution (direction 1, raullen 2026-07-09)
+--------------------------------------------
+Stop caching non-trimmable recurrent-state entries entirely. ``store`` now
+DROPS any cache that carries an ``ArraysCache`` / ``CacheList``-wrapping-one
+layer (``is_trimmable() == False``). This trades away the #214 within-
+conversation multi-turn speedup (hybrid turns re-prefill) to stop the
+cross-conversation leak. The tests below encode the NEW policy; the previous
+#214 "must hit" assertions are intentionally inverted.
+
+Dense (all-``KVCache``) models are unaffected — their state is trimmable and
+still cached/reused normally.
 """
 
 from unittest.mock import MagicMock
@@ -44,6 +63,9 @@ class TrimmableLayer:
     def is_trimmable(self) -> bool:
         return True
 
+    def trim(self, n: int) -> int:  # KVCache-like: defines trim
+        return n
+
 
 class NonTrimmableLayer:
     """Stands in for ArraysCache (DeltaNet/Mamba RNN state)."""
@@ -54,6 +76,10 @@ class NonTrimmableLayer:
 
     def is_trimmable(self) -> bool:
         return False
+
+
+def _dense_cache(n: int = 10):
+    return [TrimmableLayer() for _ in range(n)]
 
 
 def _hybrid_cache(n_trimmable: int = 10, n_non_trimmable: int = 30):
@@ -70,21 +96,19 @@ def cache():
 
 
 # ---------------------------------------------------------------------------
-# Baseline: dense (all-trimmable) growing conversation already hits.
+# Dense (all-trimmable) is unaffected — still stored and reused.
 # ---------------------------------------------------------------------------
 
 
 def test_dense_growing_conversation_hits_prefix(cache):
-    """Sanity: dense models hit the prefix path on growing conversations."""
-    prompt = list(range(1000, 1100))  # turn 1 prompt
-    response_1 = [9001, 9002]  # model output
-    new_msg = list(range(2000, 2050))  # turn 2 user message
+    """Dense models still hit the prefix path on growing conversations."""
+    prompt = list(range(1000, 1100))
+    response_1 = [9001, 9002]
+    new_msg = list(range(2000, 2050))
 
-    # Turn 1: prompt-snapshot store, then full prompt+output store
-    cache.store(prompt, _hybrid_cache(n_trimmable=10, n_non_trimmable=0))
-    cache.store(prompt + response_1, _hybrid_cache(n_trimmable=10, n_non_trimmable=0))
+    assert cache.store(prompt, _dense_cache()) is True
+    assert cache.store(prompt + response_1, _dense_cache()) is True
 
-    # Turn 2 request = strict superset of [P + R1]
     turn_2 = prompt + response_1 + new_msg
     result, remaining = cache.fetch(turn_2)
 
@@ -93,18 +117,50 @@ def test_dense_growing_conversation_hits_prefix(cache):
 
 
 # ---------------------------------------------------------------------------
-# The bug: hybrid (mixed trimmable + non-trimmable) growing conversation.
+# #1025 / #1058: hybrid recurrent-state entries are DROPPED at store time.
 # ---------------------------------------------------------------------------
 
 
-def test_hybrid_growing_conversation_hits_prefix(cache):
-    """Issue #214: hybrid model multi-turn conversation must hit prefix path.
+def test_hybrid_store_is_dropped(cache):
+    """A cache with any non-trimmable layer must NOT be stored (leak fix)."""
+    prompt = list(range(1000, 1100))
 
-    Stored ``[P + R1]`` is a strict prefix of turn 2's ``[P + R1 + M2]``.
-    No trimming required — the RNN state at end-of-stored is exactly the
-    state needed at start-of-M2-prefill. The non-trimmability of DeltaNet
-    layers is irrelevant on this path.
+    stored = cache.store(prompt, _hybrid_cache())
+
+    assert stored is False, "Hybrid recurrent-state entry must be dropped, not stored"
+    assert tuple(prompt) not in cache._entries, (
+        "Non-trimmable entry leaked into _entries — this is the #1025/#1058 leak"
+    )
+    assert cache.get_stats()["non_trimmable_skips"] == 1
+
+
+def test_hybrid_multiturn_does_not_leak(cache):
+    """A multi-turn hybrid conversation leaves NO entries in the cache.
+
+    Every turn stores a longer ``[P + ... ]`` superset; before the fix each
+    one lingered forever (never a prefix of a *different* conversation's next
+    key). After the fix none are retained → ``_entries`` stays empty and
+    ``_current_memory`` returns to 0.
     """
+    prompt = list(range(1000, 1100))
+    r1, r2 = [9001, 9002], [9003, 9004]
+    m2, m3 = list(range(2000, 2050)), list(range(3000, 3030))
+
+    cache.store(prompt, _hybrid_cache())
+    cache.store(prompt + r1, _hybrid_cache())
+    cache.store(prompt + r1 + m2 + r2, _hybrid_cache())
+    cache.store(prompt + r1 + m2 + r2 + m3, _hybrid_cache())
+
+    assert len(cache._entries) == 0, (
+        f"Hybrid conversation left {len(cache._entries)} lingering entries — "
+        "this is the recurrent-state leak (#1025/#1058)"
+    )
+    assert cache._current_memory == 0
+    assert cache.get_stats()["non_trimmable_skips"] == 4
+
+
+def test_hybrid_fetch_always_misses(cache):
+    """With hybrid stores dropped, every hybrid fetch is a clean miss."""
     prompt = list(range(1000, 1100))
     response_1 = [9001, 9002]
     new_msg = list(range(2000, 2050))
@@ -115,71 +171,72 @@ def test_hybrid_growing_conversation_hits_prefix(cache):
     turn_2 = prompt + response_1 + new_msg
     result, remaining = cache.fetch(turn_2)
 
-    assert result is not None, (
-        "Hybrid growing conversation MISSED prefix cache — this is issue #214. "
-        "Stored [P + R1] is a strict prefix of request [P + R1 + M2]; no "
-        "trim is required, so non-trimmable RNN layers should not block."
-    )
-    # Should pick the longer of the two stored prefixes.
-    assert remaining == new_msg, (
-        f"Expected remaining = M2 ({len(new_msg)} tokens, picking [P+R1]); "
-        f"got {len(remaining)} tokens"
-    )
-
-
-def test_hybrid_only_prompt_stored_still_hits(cache):
-    """Even when only ``[P]`` is stored (no full prompt+output entry yet)."""
-    prompt = list(range(1000, 1100))
-    response_1 = [9001, 9002]
-    new_msg = list(range(2000, 2050))
-
-    cache.store(prompt, _hybrid_cache())
-
-    turn_2 = prompt + response_1 + new_msg
-    result, remaining = cache.fetch(turn_2)
-
-    assert result is not None, "Stored [P] must hit as prefix of [P + R1 + M2]"
-    assert remaining == response_1 + new_msg
-
-
-def test_hybrid_three_turn_growth(cache):
-    """Three-turn conversation: each turn picks the longest stored prefix."""
-    prompt = list(range(1000, 1100))
-    r1, r2 = [9001, 9002], [9003, 9004]
-    m2, m3 = list(range(2000, 2050)), list(range(3000, 3030))
-
-    # Turn 1: store [P] and [P + R1]
-    cache.store(prompt, _hybrid_cache())
-    cache.store(prompt + r1, _hybrid_cache())
-
-    # Turn 2 fetch
-    turn_2 = prompt + r1 + m2
-    res, rem = cache.fetch(turn_2)
-    assert res is not None
-    assert rem == m2, "Turn 2 should pick [P + R1] (longest prefix)"
-
-    # Turn 2 finishes: store [P + R1 + M2 + R2]
-    cache.store(prompt + r1 + m2 + r2, _hybrid_cache())
-
-    # Turn 3 fetch
-    turn_3 = prompt + r1 + m2 + r2 + m3
-    res, rem = cache.fetch(turn_3)
-    assert res is not None
-    assert rem == m3, "Turn 3 should pick [P + R1 + M2 + R2] (longest prefix)"
+    assert result is None, "Hybrid entries are never stored → fetch must miss"
+    assert remaining == turn_2
 
 
 # ---------------------------------------------------------------------------
-# Guards: the fix must not loosen non-trim safety in cases that DO need trim.
+# Granularity: partial hybrid (even ONE non-trimmable layer) drops the entry.
+# ---------------------------------------------------------------------------
+
+
+def test_single_non_trimmable_layer_drops_entry(cache):
+    """One non-trimmable layer among many trimmable ones drops the whole entry.
+
+    A half-populated entry (trimmable layers only) can't reconstruct a hybrid
+    model, so we skip the whole entry rather than store a useless subset.
+    """
+    prompt = list(range(1000, 1100))
+    mostly_dense = _dense_cache(n=39) + [NonTrimmableLayer()]
+
+    assert cache.store(prompt, mostly_dense) is False
+    assert tuple(prompt) not in cache._entries
+
+
+def test_dict_form_arrayscache_dropped(cache):
+    """Block-aware (dict-form) extracted states are gated on class_name too."""
+    prompt = list(range(1000, 1100))
+    dict_cache = [
+        {"class_name": "KVCache", "state": (1, 2), "meta_state": ("0",)},
+        {"class_name": "ArraysCache", "state": (3, 4), "meta_state": ("0",)},
+    ]
+
+    assert cache.store(prompt, dict_cache) is False
+    assert tuple(prompt) not in cache._entries
+
+
+def test_dict_form_all_kvcache_stored(cache):
+    """A dict-form entry with only KVCache layers is still stored."""
+    prompt = list(range(1000, 1100))
+    dict_cache = [
+        {"class_name": "KVCache", "state": (1, 2), "meta_state": ("0",)},
+        {"class_name": "KVCache", "state": (3, 4), "meta_state": ("0",)},
+    ]
+
+    assert cache.store(prompt, dict_cache) is True
+    assert tuple(prompt) in cache._entries
+
+
+# ---------------------------------------------------------------------------
+# Guards preserved from the #214 era: trim-required matches still MISS. These
+# now also never even reach fetch (store dropped them), but the fetch-side
+# non-trimmable guard stays as defense-in-depth for any legacy on-disk entry.
 # ---------------------------------------------------------------------------
 
 
 def test_hybrid_supersequence_still_skipped(cache):
-    """Stored ``[P + extra]`` longer than request ``[P]`` still cannot hit on
-    hybrid. Trimming would be required to roll the RNN state back to ``[P]``,
-    which is not safe — must MISS.
+    """Even if a hybrid entry existed, a trim-required supersequence match must
+    skip. We inject directly into ``_entries`` to bypass the store gate and
+    exercise the fetch-side guard (legacy on-disk entry defense-in-depth).
     """
+    from vllm_mlx.memory_cache import _CacheEntry
+
     long_stored = list(range(1000, 1200))
-    cache.store(long_stored, _hybrid_cache())
+    entry = _CacheEntry.create(long_stored, _hybrid_cache())
+    cache._entries[tuple(long_stored)] = entry
+    import bisect
+
+    bisect.insort(cache._sorted_keys, tuple(long_stored))
 
     short_request = list(range(1000, 1100))
     result, remaining = cache.fetch(short_request)
@@ -188,18 +245,3 @@ def test_hybrid_supersequence_still_skipped(cache):
         "Trim-required match on non-trimmable hybrid layers must still skip"
     )
     assert remaining == short_request
-
-
-def test_hybrid_lcp_with_divergence_still_skipped(cache):
-    """Stored and request share a prefix then diverge mid-sequence. LCP would
-    require trimming the stored state back to the divergence point — not
-    safe on non-trimmable layers, must MISS.
-    """
-    stored = list(range(1000, 1100)) + [5000, 5001, 5002]
-    cache.store(stored, _hybrid_cache())
-
-    request = list(range(1000, 1100)) + [6000, 6001, 6002]
-    result, remaining = cache.fetch(request)
-
-    assert result is None
-    assert remaining == request

--- a/tests/test_prefix_cache_eviction.py
+++ b/tests/test_prefix_cache_eviction.py
@@ -157,7 +157,11 @@ class _FakeCacheLayer:
         self.offset = n
 
     def is_trimmable(self) -> bool:
-        return False
+        # KV-shaped fixture: represents a trimmable KVCache being evicted by
+        # memory pressure (the path these tests exercise). Real KVCache
+        # reports is_trimmable() == True; a False here would make the
+        # #1025/#1058 store gate drop the entry before eviction can run.
+        return True
 
 
 def _make_cache_entry(byte_size: int):

--- a/vllm_mlx/memory_cache.py
+++ b/vllm_mlx/memory_cache.py
@@ -1052,10 +1052,28 @@ def _needs_kv_trim(layer: Any) -> bool:
 # hybrid entry that fetch will never reuse but store retains forever is pure
 # leak: so we DROP it at store time (whole entry — see below).
 #
-# Class-name allowlist mirrors ``prefix_cache._SEQ_AXIS_KV_CLASSES`` for the
-# dict-form extracted cache (block-aware path, where layers are
-# ``{"class_name": ...}`` dicts, not live objects).
-_TRIMMABLE_CACHE_CLASSES = frozenset({"KVCache", "QuantizedKVCache"})
+# For the dict-form extracted cache (block-aware path, where layers are
+# ``{"class_name": ...}`` dicts, not live objects) we cannot call
+# ``is_trimmable()``, so we match ``class_name`` against a DENYLIST of the
+# known recurrent-state cache classes. A denylist (not an allowlist of KV
+# classes) is deliberate: it keeps the dict path consistent with the
+# conservative object-path default — an UNKNOWN or new trimmable KV class
+# (``RotatingKVCache`` / ``ChunkedKVCache`` / ``ConcatenateKVCache`` / a future
+# addition) stays cacheable (status quo) instead of being wrongly dropped and
+# regressing prefix reuse for dense / sliding-window models. Only classes that
+# are affirmatively recurrent-state (``ArraysCache`` and Mamba-style aliases)
+# are dropped. Names are matched leniently (substring) so vendor-suffixed
+# variants (``MambaCache`` etc.) are also caught.
+_RECURRENT_STATE_CACHE_CLASSES = frozenset({"ArraysCache", "MambaCache"})
+
+
+def _class_name_is_recurrent(class_name: str) -> bool:
+    """True if ``class_name`` names a known recurrent-state (non-trimmable) cache."""
+    if class_name in _RECURRENT_STATE_CACHE_CLASSES:
+        return True
+    # Lenient substring match for vendor/variant names (e.g. "MambaCache2",
+    # "GatedDeltaNetArraysCache"). "KVCache" etc. never contain these tokens.
+    return any(marker in class_name for marker in _RECURRENT_STATE_CACHE_CLASSES)
 
 
 def _layer_is_non_trimmable(layer: Any) -> bool:
@@ -1076,17 +1094,17 @@ def _layer_is_non_trimmable(layer: Any) -> bool:
         non-trimmable here — modern mlx-lm (0.29+) gives every cache class the
         method, so its absence means a test double / unknown shape, which we
         leave cacheable rather than guess from the absence of ``trim``.
-      * dict-form extracted states (block-aware path) — keyed on ``class_name``
-        against the trimmable allowlist (mirrors
-        ``prefix_cache._SEQ_AXIS_KV_CLASSES``).
+      * dict-form extracted states (block-aware path) — matched on
+        ``class_name`` against the recurrent-state DENYLIST (unknown/new KV
+        classes stay cacheable).
     """
     if layer is None:
         return False
     if isinstance(layer, dict):
         class_name = layer.get("class_name")
-        if class_name is None:
+        if not class_name:
             return False
-        return class_name not in _TRIMMABLE_CACHE_CLASSES
+        return _class_name_is_recurrent(class_name)
     is_trimmable = getattr(layer, "is_trimmable", None)
     if callable(is_trimmable):
         try:

--- a/vllm_mlx/memory_cache.py
+++ b/vllm_mlx/memory_cache.py
@@ -880,6 +880,14 @@ class CacheStats:
     # ``cache.clear()`` / ``reset_stats``, same contract as
     # ``load_skipped``.
     save_drift_drops: int = 0
+    # #1025 / #1058: cumulative count of ``store`` calls dropped because the
+    # cache carried a non-trimmable recurrent-state layer (hybrid GatedDeltaNet
+    # / Mamba MoE). These entries are unreusable by the fetch path anyway;
+    # dropping them at store time is what stops the Metal ``active`` leak.
+    # Surfaced so operators can see hybrid traffic is being (correctly) skipped
+    # rather than silently leaking. Cumulative, same carry-over contract as
+    # ``load_skipped``.
+    non_trimmable_skips: int = 0
 
     @property
     def hit_rate(self) -> float:
@@ -924,6 +932,12 @@ class CacheStats:
             # ``rapid_mlx_prefix_cache_save_drift_drops_total``
             # Prometheus counter. Cumulative same as ``load_skipped``.
             "save_drift_drops": int(self.save_drift_drops),
+            # #1025 / #1058: cumulative count of hybrid recurrent-state
+            # entries skipped at store time — drives the
+            # ``rapid_mlx_prefix_cache_non_trimmable_skips_total`` counter and
+            # is the observable signal that the GatedDeltaNet leak fix is
+            # active for a given model.
+            "non_trimmable_skips": int(self.non_trimmable_skips),
         }
 
 
@@ -1012,6 +1026,81 @@ def _needs_kv_trim(layer: Any) -> bool:
     if shape is None or len(shape) < 3:
         return False
     return 0 < offset < shape[2]
+
+
+# ---------------------------------------------------------------------------
+# Non-trimmable (recurrent-state) layer gate — issues #1025 / #1058
+# ---------------------------------------------------------------------------
+# Hybrid GatedDeltaNet / Mamba MoE models (Qwen3.6, Qwen3-Coder-Next, ...)
+# emit per-request RECURRENT state layers — ``ArraysCache`` (conv_state /
+# recurrent_state), NOT keys/values. Unlike ``KVCache`` these layers:
+#   * cannot be trimmed back to a prefix (``_trim_to_offset`` /
+#     ``_quantize_cache`` pass them through UNCHANGED, so ``store`` keeps the
+#     full array by reference), and
+#   * are never a prefix of the next request's key (each request's output
+#     differs → every key is a unique superset), so prefix-subset eviction
+#     NEVER reclaims them.
+# The net effect: the recurrent state accumulates in ``_entries`` and only
+# drops under the cache's own byte budget (``max_memory_percent × RAM``),
+# which is set INDEPENDENTLY of ``--gpu-memory-utilization``. Metal ``active``
+# ratchets up holding leaked recurrent state while ``reserved KV`` stays ~0,
+# wedging the D-METAL-CAP admission gate / eventually OOM-crashing.
+#
+# The fetch path already refuses to reuse these entries (supersequence match
+# is skipped when any layer ``not is_trimmable()`` — see ``fetch`` above) AND
+# the paged path gates them out via ``prefix_cache._SEQ_AXIS_KV_CLASSES``. A
+# hybrid entry that fetch will never reuse but store retains forever is pure
+# leak: so we DROP it at store time (whole entry — see below).
+#
+# Class-name allowlist mirrors ``prefix_cache._SEQ_AXIS_KV_CLASSES`` for the
+# dict-form extracted cache (block-aware path, where layers are
+# ``{"class_name": ...}`` dicts, not live objects).
+_TRIMMABLE_CACHE_CLASSES = frozenset({"KVCache", "QuantizedKVCache"})
+
+
+def _layer_is_non_trimmable(layer: Any) -> bool:
+    """Return True ONLY for layers that AFFIRMATIVELY declare non-trimmability.
+
+    This is deliberately conservative: a layer is treated as a recurrent-state
+    leak source (and dropped from the reuse cache) only when we can positively
+    identify it as such. When in doubt we keep the status-quo behaviour (store
+    it) rather than risk newly dropping a legitimate KVCache entry.
+
+    Two cache-layer forms reach ``store``:
+      * live mlx-lm cache objects (standard ``memory_aware_cache`` path) —
+        classified via the ``is_trimmable()`` idiom already used on the fetch
+        side. ``ArraysCache.is_trimmable()`` returns ``False``; a ``CacheList``
+        wrapping one also returns ``False``; every KV-class
+        (``KVCache`` / ``RotatingKVCache`` / ``QuantizedKVCache`` / ...) returns
+        ``True``. A layer with NO ``is_trimmable`` method is NOT classified as
+        non-trimmable here — modern mlx-lm (0.29+) gives every cache class the
+        method, so its absence means a test double / unknown shape, which we
+        leave cacheable rather than guess from the absence of ``trim``.
+      * dict-form extracted states (block-aware path) — keyed on ``class_name``
+        against the trimmable allowlist (mirrors
+        ``prefix_cache._SEQ_AXIS_KV_CLASSES``).
+    """
+    if layer is None:
+        return False
+    if isinstance(layer, dict):
+        class_name = layer.get("class_name")
+        if class_name is None:
+            return False
+        return class_name not in _TRIMMABLE_CACHE_CLASSES
+    is_trimmable = getattr(layer, "is_trimmable", None)
+    if callable(is_trimmable):
+        try:
+            return not bool(is_trimmable())
+        except Exception:  # pragma: no cover — defensive
+            return False
+    # No ``is_trimmable`` method → cannot positively classify. Default to
+    # cacheable (status quo) so we never newly drop a legitimate KV entry.
+    return False
+
+
+def _cache_has_non_trimmable(cache: list[Any]) -> bool:
+    """True if ANY layer is a non-trimmable recurrent-state layer."""
+    return any(_layer_is_non_trimmable(layer) for layer in cache)
 
 
 def _trim_to_offset(cache: list[Any]) -> list[Any]:
@@ -1534,6 +1623,31 @@ class MemoryAwarePrefixCache:
         if not tokens or not cache:
             return False
 
+        # Reuse-cache gate for hybrid recurrent-state models (#1025 / #1058).
+        #
+        # If ANY layer is a non-trimmable recurrent-state cache (ArraysCache /
+        # CacheList-wrapping-one, from GatedDeltaNet / Mamba MoE models), DROP
+        # the whole entry rather than store it. Granularity = whole entry, not
+        # per-layer, because:
+        #   * reconstruction needs ALL layers (a half-populated entry with only
+        #     the KVCache layers cannot resume a hybrid model — mlx-lm rebuilds
+        #     the full cache list or nothing), and
+        #   * the fetch path already refuses to reuse an entry once any layer
+        #     is non-trimmable (supersequence match is skipped), so storing the
+        #     trimmable subset would only cost memory for zero reuse.
+        # Result: the per-request recurrent state has NO lingering reference in
+        # ``_entries`` and is reclaimed by ``mx.clear_cache()`` / GC once the
+        # request object drops its own reference in ``_cleanup_finished``.
+        if _cache_has_non_trimmable(cache):
+            self._stats.non_trimmable_skips += 1
+            logger.debug(
+                "[cache_store] skipped hybrid recurrent-state entry "
+                "(%d tokens): non-trimmable layer present, not reusable — "
+                "dropping to avoid leak (#1025/#1058)",
+                len(tokens),
+            )
+            return False
+
         tokens_key = tuple(tokens)
 
         # Fast path: already cached — bump LRU and skip expensive trim/quantize.
@@ -1754,10 +1868,12 @@ class MemoryAwarePrefixCache:
             self._current_memory = 0
             carried_load_skipped = self._stats.load_skipped
             carried_save_drift_drops = self._stats.save_drift_drops
+            carried_non_trimmable_skips = self._stats.non_trimmable_skips
             self._stats = CacheStats(
                 max_memory_bytes=self._max_memory,
                 load_skipped=carried_load_skipped,
                 save_drift_drops=carried_save_drift_drops,
+                non_trimmable_skips=carried_non_trimmable_skips,
             )
         logger.debug("Cache cleared")
 
@@ -1786,6 +1902,9 @@ class MemoryAwarePrefixCache:
 
         R12-T1: ``save_drift_drops`` likewise must carry across so its
         backing Prometheus counter never regresses.
+
+        #1025/#1058: ``non_trimmable_skips`` carries across for the same
+        monotonic-counter reason.
         """
         self._stats = CacheStats(
             max_memory_bytes=self._max_memory,
@@ -1793,6 +1912,7 @@ class MemoryAwarePrefixCache:
             entry_count=len(self._entries),
             load_skipped=self._stats.load_skipped,
             save_drift_drops=self._stats.save_drift_drops,
+            non_trimmable_skips=self._stats.non_trimmable_skips,
         )
 
     @property

--- a/vllm_mlx/routes/metrics.py
+++ b/vllm_mlx/routes/metrics.py
@@ -1216,6 +1216,25 @@ def _render_prometheus(cfg: Any) -> str:
                     "reaches cache_dir."
                 ),
             ),
+            (
+                # #1025 / #1058: hybrid GatedDeltaNet / Mamba MoE
+                # recurrent-state entries dropped at store time. These
+                # carry a non-trimmable ArraysCache layer that the fetch
+                # path can never reuse (it refuses supersequence trims on
+                # non-trimmable layers) but that store would otherwise
+                # retain forever — the source of the Metal ``active``
+                # leak. A steadily-climbing rate on a hybrid model is the
+                # EXPECTED, healthy signal that the leak fix is engaged.
+                "non_trimmable_skips",
+                "rapid_mlx_prefix_cache_non_trimmable_skips_total",
+                (
+                    "Prefix-cache store calls dropped because the cache "
+                    "carried a non-trimmable recurrent-state layer "
+                    "(hybrid GatedDeltaNet / Mamba MoE). Expected to climb "
+                    "on hybrid models — it is the observable signal that "
+                    "the #1025/#1058 recurrent-state leak fix is active."
+                ),
+            ),
         ):
             raw = int(_coerce_number(cache_stats.get(raw_key)))
             monotonic = _cache_counter_accumulator.advance(metric_name, raw)


### PR DESCRIPTION
## Summary

Root-cause fix for the P0 Metal memory leak on hybrid GatedDeltaNet models (fixes #1025, #1058).

Qwen 3.6 (and Qwen3-Coder-Next) are hybrid GatedDeltaNet / linear-attention MoE. Each request produces a per-request **recurrent state** — mlx-lm `ArraysCache` (conv_state / recurrent_state), **not** keys/values. `MemoryAwarePrefixCache.store` retained this layer by reference:

- `_trim_to_offset` / `_quantize_cache` pass non-`KVCache` layers through **unchanged**, so the full recurrent array is kept; and
- every stored key is `prompt + output` — a unique **superset** that is never a prefix of the next request, so prefix-subset eviction never reclaims it.

The state therefore only drops under the cache's own byte budget (`--cache-memory-percent × RAM`), which is set **independently** of `--gpu-memory-utilization`. Metal `active` ratchets up holding leaked recurrent state while reserved KV stays ~0 → the D-METAL-CAP admission gate wedges / eventually OOM-crashes. Pure-attention models (gemma-4) don't hit this because their KV lives in the trimmable pool.

## The fix (direction 1)

A store-time gate that **drops the whole entry** when any layer is a non-trimmable recurrent-state layer (`ArraysCache`, or a `CacheList` wrapping one). It mirrors the allowlist idiom the paged path already uses (`prefix_cache._SEQ_AXIS_KV_CLASSES`) and the fetch-side `is_trimmable()` check.

**Granularity = whole entry**, not per-layer, because (a) reconstruction needs *all* layers — a half-populated KVCache-only entry can't resume a hybrid model, and (b) the fetch path already refuses to reuse an entry once any layer is non-trimmable, so storing the trimmable subset would cost memory for zero reuse. The per-request recurrent state now has no lingering reference in `_entries` and is reclaimed by `mx.clear_cache()` / GC at `_cleanup_finished`.

The detection is deliberately **conservative**: a layer is dropped only when it *affirmatively* reports `is_trimmable() == False`. A layer with no `is_trimmable` method is left cacheable (status quo) — modern mlx-lm gives every cache class the method, so absence means a test double, not a real recurrent cache.

Adds a `non_trimmable_skips` stat + `rapid_mlx_prefix_cache_non_trimmable_skips_total` Prometheus counter so operators can observe hybrid stores being (correctly) dropped.

## Real-hardware proof (Qwen3.6-27B-4bit, M3 Ultra)

Config: `--enable-prefix-cache --cache-memory-percent 0.40 --gpu-memory-utilization 0.80 --pin-system-prompt`; 18 distinct medium-context requests + 8s idle settle.

| metric | **before** | **after** |
|---|---|---|
| baseline Metal active | 16.2 GB | 15.13 GB |
| peak active (after 18 req) | 22.97 GB | **15.13 GB** |
| **idle active − baseline** | **+6.77 GB** (ratchets, holds at idle) | **0.0 GB** (flat floor) |
| cache byte-ledger (final) | 6414 MB | 0 MB |
| cache entries (final) | 42 (+2/req, never evicted) | 0 |

Before-fix: active climbs ~+0.38 GB/request in lockstep with the byte ledger and never drops at idle. After-fix: active is a perfectly flat 15.13 GB floor across all 18 requests.

## Perf cost

Multi-turn TTFT bench (growing 5-turn chat-templated conversation):

| turn | before TTFT | after TTFT |
|---|---|---|
| 1 | 0.743s | 0.732s |
| 3 | 1.625s | 1.655s (1.02x) |
| 5 | 2.553s | 2.498s |

**~0x regression.** `cache_hits = 0` on every turn *before* the fix too — the hybrid prefix entries were stored (leaking) but never actually hit on the real chat-templated path, because the re-rendered template does not make the stored `[P+R1]` token sequence a clean prefix of the next turn's full render. The #214 "hybrid multi-turn reuse" only worked in the synthetic unit test that hand-builds perfect token prefixes. So this fix removes pure-leak storage with no realized reuse benefit.

## Behavior change

Reverses the #214 hybrid-multi-turn prefix-reuse *store* behavior; the affected tests are updated to encode the new leak-free policy. **Dense / pure-`KVCache` models are unaffected** — their state is trimmable and still cached/reused normally.

## Tests

- Rewrote `test_hybrid_prefix_cache_growth.py` to assert hybrid recurrent-state entries are dropped (not stored/leaked), incl. dict-form (block-aware) gating and single-non-trimmable-layer -> whole-entry drop.
- Corrected the `_FakeCacheLayer` fixture in `test_prefix_cache_eviction.py` (a KV-shaped fixture that mislabeled itself `is_trimmable() == False`).
- 291 cache/metrics tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
