### PR TITLE
feat: add LiquidAI LFM2.x parser support

### DIFF
--- a/scripts/audit_tool_parser_coverage.py
+++ b/scripts/audit_tool_parser_coverage.py
@@ -109,6 +109,19 @@ MATRIX_EXEMPT: dict[str, str] = {
     "ui_tars": "TODO: add UI-TARS-1.5-7B-4bit to golden_models once the VLM matrix supports mlx-vlm-backed Computer-Use models",
     "ui-tars": "alias of ui_tars (kebab-case spelling)",
     "uitars": "alias of ui_tars (no-separator spelling)",
+    "lfm": (
+        "TODO: add a Liquid LFM2.5 model (e.g. mlx-community/"
+        "LFM2.5-1.2B-Instruct-4bit) to golden_models once a CI slot is "
+        "free (#85). Wire format is verified end-to-end another way in the "
+        "meantime: the LFM2.5-1.2B model loads + generates on the engine "
+        'and emits the pythonic-bracket call — [get_weather(location="Paris")] '
+        "— that LfmToolParser handles (special-token wrappers "
+        "<|tool_call_start|>/<|tool_call_end|> are stripped upstream). "
+        "Class + streaming-parity coverage lives in "
+        "tests/test_lfm_tool_parser.py and "
+        "tests/test_tool_call_streaming_parity.py."
+    ),
+    "liquid": "alias of lfm",
 }
 
 

--- a/tests/test_lfm_tool_parser.py
+++ b/tests/test_lfm_tool_parser.py
@@ -1,0 +1,408 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for Liquid/LFM tool call parser."""
+
+import json
+from unittest.mock import MagicMock
+
+from vllm_mlx.service.postprocessor import StreamingPostProcessor
+from vllm_mlx.tool_parsers import AutoToolParser, LfmToolParser, ToolParserManager
+from vllm_mlx.tool_parsers.lfm_tool_parser import parse_lfm_tool_calls
+
+
+class TestLfmRegistration:
+    """Test that the LFM parser is registered correctly."""
+
+    def test_registered_as_lfm(self):
+        parser_cls = ToolParserManager.get_tool_parser("lfm")
+        assert parser_cls is LfmToolParser
+
+    def test_registered_as_liquid(self):
+        parser_cls = ToolParserManager.get_tool_parser("liquid")
+        assert parser_cls is LfmToolParser
+
+
+class TestLfmExtractToolCalls:
+    """Test non-streaming LFM tool call extraction."""
+
+    def test_single_pythonic_tool_call(self):
+        parser = LfmToolParser()
+        result = parser.extract_tool_calls(
+            'Let me check. [get_current_weather(location="Paris")]'
+        )
+
+        assert result.tools_called
+        assert len(result.tool_calls) == 1
+        assert result.tool_calls[0]["name"] == "get_current_weather"
+        assert json.loads(result.tool_calls[0]["arguments"]) == {"location": "Paris"}
+        assert result.content == "Let me check."
+
+    def test_multiple_pythonic_tool_calls(self):
+        parser = LfmToolParser()
+        result = parser.extract_tool_calls(
+            '[get_current_weather(location="Paris", unit="celsius"), '
+            'get_time(timezone="Europe/Paris")]'
+        )
+
+        assert result.tools_called
+        assert [tc["name"] for tc in result.tool_calls] == [
+            "get_current_weather",
+            "get_time",
+        ]
+        assert json.loads(result.tool_calls[0]["arguments"]) == {
+            "location": "Paris",
+            "unit": "celsius",
+        }
+        assert json.loads(result.tool_calls[1]["arguments"]) == {
+            "timezone": "Europe/Paris"
+        }
+
+    def test_auto_parser_malformed_bracketed_text_does_not_crash(self):
+        """Auto parser should ignore prose brackets that are not LFM calls."""
+        parser = AutoToolParser()
+        text = "This is prose [not a function call] and should stay content."
+
+        result = parser.extract_tool_calls(text)
+
+        assert not result.tools_called
+        assert result.content == text
+
+
+class TestLfmStreaming:
+    """Test streaming LFM tool call extraction."""
+
+    def test_streaming_pythonic_tool_call_emits_when_closing_bracket_arrives(self):
+        parser = LfmToolParser()
+        previous_text = 'Checking [get_current_weather(location="Paris"'
+        current_text = previous_text + ")]"
+
+        result = parser.extract_tool_calls_streaming(
+            previous_text=previous_text,
+            current_text=current_text,
+            delta_text=")]",
+        )
+
+        assert result is not None
+        assert "tool_calls" in result
+        assert len(result["tool_calls"]) == 1
+        tool_call = result["tool_calls"][0]
+        assert tool_call["function"]["name"] == "get_current_weather"
+        assert json.loads(tool_call["function"]["arguments"]) == {"location": "Paris"}
+
+    def test_streaming_bracketed_prose_passes_through(self):
+        """Non-tool brackets must not be suppressed as pending tool markup."""
+        parser = LfmToolParser()
+        previous_text = "Here are "
+        delta_text = "[two] options."
+        current_text = previous_text + delta_text
+
+        result = parser.extract_tool_calls_streaming(
+            previous_text=previous_text,
+            current_text=current_text,
+            delta_text=delta_text,
+        )
+
+        assert result == {"content": delta_text}
+
+    def test_streaming_content_after_completed_call_is_emitted(self):
+        """Trailing prose after an emitted call must not be held forever.
+
+        Regression: the partial-start tail-hold matched an already-closed
+        ``[f(x=1)]`` block (the ``\\(.*`` swallowed everything), so every
+        delta after a completed call returned None — and since a tool call
+        had fired, finalize() never flushed it either. Content lost.
+        """
+        parser = LfmToolParser()
+        # Stream up to the completed call; the closing delta emits tools.
+        result = parser.extract_tool_calls_streaming(
+            previous_text="Hi [f(x=1",
+            current_text="Hi [f(x=1)]",
+            delta_text=")]",
+        )
+        assert result is not None and "tool_calls" in result
+
+        # The next content delta must come through as content.
+        result = parser.extract_tool_calls_streaming(
+            previous_text="Hi [f(x=1)]",
+            current_text="Hi [f(x=1)] all done now",
+            delta_text=" all done now",
+        )
+        assert result == {"content": " all done now"}
+
+    def test_streaming_later_bracket_does_not_duplicate_tool_calls(self):
+        """A ``]`` in trailing prose must not re-emit the same tool call.
+
+        Regression: every delta containing ``]`` re-ran extract_tool_calls
+        over the full text and re-emitted the call with a fresh id at
+        index 0 — OpenAI-delta clients concatenate per-index arguments,
+        corrupting the JSON.
+        """
+        parser = LfmToolParser()
+        result = parser.extract_tool_calls_streaming(
+            previous_text="Hi [f(x=1",
+            current_text="Hi [f(x=1)]",
+            delta_text=")]",
+        )
+        assert result is not None and "tool_calls" in result
+
+        result = parser.extract_tool_calls_streaming(
+            previous_text="Hi [f(x=1)] see [notes",
+            current_text="Hi [f(x=1)] see [notes] ok",
+            delta_text="] ok",
+        )
+        assert result is None or "tool_calls" not in result
+
+    def test_streaming_second_separate_block_emits_with_next_index(self):
+        """A second bracket block completing later must still be emitted.
+
+        Regression: a one-shot ``_streaming_tools_emitted`` latch dropped
+        every tool call after the first block. LFM's non-streaming path
+        parses N separate blocks, so streaming must reach parity — the
+        second call is emitted with a continuing index (1), not lost.
+        """
+        parser = LfmToolParser()
+        first = parser.extract_tool_calls_streaming(
+            previous_text="[f(x=1",
+            current_text="[f(x=1)]",
+            delta_text=")]",
+        )
+        assert first is not None and "tool_calls" in first
+        assert first["tool_calls"][0]["index"] == 0
+        assert first["tool_calls"][0]["function"]["name"] == "f"
+
+        second = parser.extract_tool_calls_streaming(
+            previous_text="[f(x=1)] then [g(y=2",
+            current_text="[f(x=1)] then [g(y=2)]",
+            delta_text=")]",
+        )
+        assert second is not None and "tool_calls" in second
+        # Exactly one NEW call, indexed after the first (not restarting at 0).
+        assert len(second["tool_calls"]) == 1
+        assert second["tool_calls"][0]["index"] == 1
+        assert second["tool_calls"][0]["function"]["name"] == "g"
+
+    def test_streaming_preface_and_call_in_same_delta_keeps_content(self):
+        """Leading prose + the first call in ONE delta must not drop prose.
+
+        Regression: when a batched chunk / finalize / single-shot stream
+        delivers ``Let me check. [get_weather(...)]`` at once, the tool
+        branch returned only ``tool_calls`` and never emitted the preface —
+        and once a call fires, the EOF flush path is skipped, so
+        ``Let me check.`` was lost (non-streaming keeps it). The parser must
+        emit BOTH channels in one return (the llama-parser precedent).
+        """
+        parser = LfmToolParser()
+        result = parser.extract_tool_calls_streaming(
+            previous_text="",
+            current_text='Let me check. [get_weather(location="Paris")]',
+            delta_text='Let me check. [get_weather(location="Paris")]',
+        )
+        assert result is not None
+        assert "tool_calls" in result
+        assert result["tool_calls"][0]["function"]["name"] == "get_weather"
+        assert result.get("content") == "Let me check. "
+
+    def test_streaming_preface_not_double_emitted_token_by_token(self):
+        """Token-by-token, the preface streams once and is NOT re-emitted
+        in the tool-call delta."""
+        parser = LfmToolParser()
+        full = 'Hello there [get_time(zone="CET")]'
+        prev = ""
+        content = []
+        tool_content = None
+        for i in range(1, len(full) + 1):
+            cur = full[:i]
+            r = parser.extract_tool_calls_streaming(prev, cur, full[i - 1 : i])
+            if r:
+                if r.get("content"):
+                    content.append(r["content"])
+                if "tool_calls" in r:
+                    tool_content = r.get("content")
+            prev = cur
+        assert "".join(content) == "Hello there "
+        # The tool-call delta carried no duplicate preface.
+        assert tool_content is None
+
+    def test_streaming_positional_call_passes_through_as_content(self):
+        """A closed pythonic-looking block with positional args is content."""
+        parser = LfmToolParser()
+        previous_text = "see "
+        delta_text = "[index(0)] for details"
+        current_text = previous_text + delta_text
+
+        result = parser.extract_tool_calls_streaming(
+            previous_text=previous_text,
+            current_text=current_text,
+            delta_text=delta_text,
+        )
+
+        assert result == {"content": delta_text}
+
+    def test_flush_held_content_releases_partial_call_prefix(self):
+        """A stream ending mid-``[func(`` must release the held bytes."""
+        parser = LfmToolParser()
+        assert parser.flush_held_content("see [get_we") == "[get_we"
+        # Nothing held when the text contains no partial markup.
+        assert parser.flush_held_content("plain text") == ""
+
+
+class TestLfmArgumentHandling:
+    """Regression tests for argument evaluation edge cases."""
+
+    def test_positional_args_reject_the_call(self):
+        """Positional args can't map to named parameters — the call must
+        NOT be emitted with silently-empty arguments."""
+        parser = LfmToolParser()
+        result = parser.extract_tool_calls('[get_weather("Paris")]')
+
+        assert not result.tools_called
+        assert result.content == '[get_weather("Paris")]'
+
+    def test_positional_args_anywhere_reject_the_whole_block(self):
+        tool_calls, cleaned = parse_lfm_tool_calls('[f("x"), g(y=1)]')
+        assert tool_calls == []
+        assert cleaned == '[f("x"), g(y=1)]'
+
+    def test_non_call_element_rejects_the_whole_block(self):
+        tool_calls, cleaned = parse_lfm_tool_calls("[f(x=1), note]")
+        assert tool_calls == []
+        assert cleaned == "[f(x=1), note]"
+
+    def test_keyword_unpack_rejects_the_whole_block(self):
+        tool_calls, cleaned = parse_lfm_tool_calls('[f(**{"x": 1})]')
+        assert tool_calls == []
+        assert cleaned == '[f(**{"x": 1})]'
+
+    def test_list_dict_and_numeric_args(self):
+        """Non-scalar kwarg values must parse.
+
+        Regression: ``eval_node`` touched ``ast.Num``/``ast.Str``/
+        ``ast.NameConstant``, which were removed in Python 3.14 — any
+        list/dict/bare-name argument raised AttributeError and the whole
+        tool call was silently dropped.
+        """
+        parser = LfmToolParser()
+        result = parser.extract_tool_calls(
+            '[search(tags=["a", "b"], limit=5, opts={"k": 1}, exact=True)]'
+        )
+
+        assert result.tools_called
+        assert json.loads(result.tool_calls[0]["arguments"]) == {
+            "tags": ["a", "b"],
+            "limit": 5,
+            "opts": {"k": 1},
+            "exact": True,
+        }
+
+    def test_bare_name_arg_becomes_string(self):
+        parser = LfmToolParser()
+        result = parser.extract_tool_calls("[get_weather(unit=celsius)]")
+
+        assert result.tools_called
+        assert json.loads(result.tool_calls[0]["arguments"]) == {"unit": "celsius"}
+
+    def test_multiple_separate_blocks_all_parsed(self):
+        parser = LfmToolParser()
+        result = parser.extract_tool_calls("[f(x=1)] and then [g(y=2)]")
+
+        assert result.tools_called
+        assert [tc["name"] for tc in result.tool_calls] == ["f", "g"]
+        assert result.content == "and then"
+
+
+class TestAutoParserLfmStreaming:
+    """Regression tests for the LFM hooks in AutoToolParser streaming."""
+
+    def test_prose_starting_with_bracket_streams_through(self):
+        """Responses starting with ``[`` (markdown links, ``[1]`` citations)
+        must stream as content.
+
+        Regression: a bare ``current_text.startswith("[")`` gate held every
+        delta of such responses, and with no flush override the entire
+        response was silently dropped.
+        """
+        parser = AutoToolParser()
+        text = ""
+        for chunk in ["[link](https://x.com)", " is the ref.", " Done."]:
+            previous = text
+            text += chunk
+            result = parser.extract_tool_calls_streaming(
+                previous_text=previous, current_text=text, delta_text=chunk
+            )
+            assert result == {"content": chunk}
+
+    def test_flush_releases_held_content_when_call_never_completes(self):
+        parser = AutoToolParser()
+        result = parser.extract_tool_calls_streaming(
+            previous_text="", current_text="calc", delta_text="calc"
+        )
+        assert result == {"content": "calc"}
+
+        # Pythonic-looking marker appears: content is held...
+        result = parser.extract_tool_calls_streaming(
+            previous_text="calc", current_text="calc [index(0", delta_text=" [index(0"
+        )
+        assert result is None
+
+        # ...and released at stream end since no tool call ever completed.
+        assert parser.flush_held_content("calc [index(0") == " [index(0"
+
+    def test_close_bracket_split_across_deltas_still_emits(self):
+        """``)`` and ``]`` arriving in separate deltas must still emit."""
+        parser = AutoToolParser()
+        text = ""
+        results = []
+        for chunk in ['[f(x="hi"', ")", "]"]:
+            previous = text
+            text += chunk
+            results.append(
+                parser.extract_tool_calls_streaming(
+                    previous_text=previous, current_text=text, delta_text=chunk
+                )
+            )
+
+        assert results[-1] is not None and "tool_calls" in results[-1]
+        assert results[-1]["tool_calls"][0]["function"]["name"] == "f"
+
+    def test_no_duplicate_emission_after_tool_call(self):
+        parser = AutoToolParser()
+        result = parser.extract_tool_calls_streaming(
+            previous_text="[f(x=1",
+            current_text="[f(x=1)]",
+            delta_text=")]",
+        )
+        assert result is not None and "tool_calls" in result
+
+        result = parser.extract_tool_calls_streaming(
+            previous_text="[f(x=1)] see [notes",
+            current_text="[f(x=1)] see [notes] ok",
+            delta_text="] ok",
+        )
+        assert result is None or "tool_calls" not in result
+
+
+class TestPostprocessorLfmFinalize:
+    """End-of-stream recovery must recognize pythonic markup."""
+
+    @staticmethod
+    def _make_cfg(parser):
+        cfg = MagicMock()
+        cfg.engine = None
+        cfg.reasoning_parser = None
+        cfg.reasoning_parser_name = None
+        cfg.enable_auto_tool_choice = True
+        cfg.tool_call_parser = None
+        cfg.tool_parser_instance = parser
+        return cfg
+
+    def test_finalize_recovers_pythonic_call_missed_by_streaming(self):
+        """Regression: the plausible-markup pre-check only looked for
+        ``<``, ``{``, or ``[Calling`` — ``[f(x="y")]`` contains none of
+        them, so the finalize() fallback never ran for LFM output."""
+        pp = StreamingPostProcessor(self._make_cfg(LfmToolParser()))
+        pp.reset()
+        pp.tool_accumulated_text = '[get_current_weather(location="Paris")]'
+
+        events = pp.finalize()
+
+        tool_events = [e for e in events if e.type == "tool_call"]
+        assert len(tool_events) == 1

--- a/tests/test_native_tool_format.py
+++ b/tests/test_native_tool_format.py
@@ -20,6 +20,7 @@ from vllm_mlx.tool_parsers import (
     HarmonyToolParser,
     HermesToolParser,
     KimiToolParser,
+    LfmToolParser,
     LlamaToolParser,
     MistralToolParser,
     NemotronToolParser,
@@ -60,6 +61,7 @@ class TestNativeToolFormatCapability:
             NemotronToolParser,
             xLAMToolParser,
             AutoToolParser,
+            LfmToolParser,
         ]
         for parser_cls in non_native_parsers:
             assert parser_cls.SUPPORTS_NATIVE_TOOL_FORMAT is False, (
@@ -90,7 +92,7 @@ class TestNativeToolFormatCapability:
             )
 
         # No native support
-        for name in ["qwen", "nemotron", "xlam", "auto"]:
+        for name in ["qwen", "nemotron", "xlam", "auto", "lfm", "liquid"]:
             parser_cls = ToolParserManager.get_tool_parser(name)
             assert parser_cls.supports_native_format() is False, (
                 f"Parser '{name}' should not support native format"

--- a/tests/test_tool_call_streaming_parity.py
+++ b/tests/test_tool_call_streaming_parity.py
@@ -215,6 +215,17 @@ PARITY_FIXTURES: list = [
         "Thought: Click search.\nAction: click(point='<point>200 300</point>')",
         [("computer", {"action": "click", "point": [200, 300]})],
     ),
+    # lfm — pythonic bracket calls (Liquid LFM2.x). Parity here depends on
+    # finalize()'s plausible-markup pre-check recognizing ``[name(`` —
+    # ``[f(x="y")]`` contains none of the ``<`` / ``{`` / ``[Calling``
+    # markers the pre-check originally looked for, so the streaming path
+    # silently skipped extraction while non-stream succeeded.
+    (
+        "lfm",
+        "pythonic_bracket",
+        'Checking. [get_current_weather(location="Paris", unit="celsius")]',
+        [("get_current_weather", {"location": "Paris", "unit": "celsius"})],
+    ),
 ]
 
 
@@ -268,6 +279,7 @@ _PARITY_COVERAGE_EXEMPT: dict[str, str] = {
     "hy3": "alias of hy_v3",
     "ui-tars": "alias of ui_tars (kebab-case spelling)",
     "uitars": "alias of ui_tars (no-separator spelling)",
+    "liquid": "alias of lfm",
     "auto": "router, not a wire-format parser",
     "generic": "router, not a wire-format parser",
 }

--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -1657,5 +1657,28 @@
     "is_moe": true,
     "supports_spec_decode": false,
     "supports_dflash": false
+  },
+  "lfm2-24b-a2b-4bit": {
+    "hf_path": "lmstudio-community/LFM2-24B-A2B-MLX-4bit",
+    "tool_call_parser": "lfm",
+    "reasoning_parser": null,
+    "is_hybrid": false,
+    "supports_spec_decode": false,
+    "is_moe": true
+  },
+  "lfm2.5-8b-a1b-4bit": {
+    "hf_path": "mlx-community/LFM2.5-8B-A1B-MLX-4bit",
+    "tool_call_parser": "lfm",
+    "reasoning_parser": null,
+    "is_hybrid": false,
+    "supports_spec_decode": false,
+    "is_moe": true
+  },
+  "lfm2.5-1b-4bit": {
+    "hf_path": "mlx-community/LFM2.5-1.2B-Instruct-4bit",
+    "tool_call_parser": "lfm",
+    "reasoning_parser": null,
+    "is_hybrid": false,
+    "supports_spec_decode": false
   }
 }

--- a/vllm_mlx/model_auto_config.py
+++ b/vllm_mlx/model_auto_config.py
@@ -130,6 +130,10 @@ class ModelConfig:
 # Model family patterns → optimal config.
 # Order matters: first match wins. More specific patterns go first.
 _MODEL_PATTERNS: list[tuple[re.Pattern, ModelConfig]] = [
+    # NOTE: Liquid LFM routing intentionally lives ONLY in aliases.json
+    # (the lfm2*/lfm2.5* entries carry ``tool_call_parser="lfm"``), per
+    # the "do NOT add new regex entries here" migration rule above. New
+    # LFM variants should be added to aliases.json, not this table.
     # DeepSeek V4 / V4-Flash — sparse MoE with sliding-window attention
     # (RotatingKVCache). Pure-attention so spec decode is safe; tool
     # parser inherits the standard DeepSeek format. Upstream chat

--- a/vllm_mlx/service/postprocessor.py
+++ b/vllm_mlx/service/postprocessor.py
@@ -3482,18 +3482,22 @@ class StreamingPostProcessor:
         # Cheap pre-check: every known tool-call format carries at least
         # one structural marker — ``<`` (XML wrappers: ``<tool_call>``,
         # ``<function=>``, ``<|tool_call>``), ``{`` (bare JSON, parameter
-        # blocks), or ``[Calling`` (text-format degradation). Skipping the
+        # blocks), ``[Calling`` (text-format degradation), or ``[name(``
+        # (LFM pythonic bracket calls). Skipping the
         # full regex scan when none of these markers is present keeps
         # end-of-stream cost flat on plain-text responses that happened to
         # have ``tools=...`` in the request (DeepSeek pr_validate finding
         # on PR #424 — high-throughput servers with tool-enabled
         # endpoints would otherwise pay the parser cost on every reply
         # that didn't actually call a tool).
+        from ..tool_parsers.lfm_tool_parser import LFM_CALL_START
+
         _fallback_text = self.tool_accumulated_text or self.accumulated_text
         _has_plausible_markup = bool(_fallback_text) and (
             "<" in _fallback_text
             or "{" in _fallback_text
             or "[Calling" in _fallback_text
+            or LFM_CALL_START.search(_fallback_text) is not None
         )
         if (
             self.tool_parser

--- a/vllm_mlx/tool_parsers/__init__.py
+++ b/vllm_mlx/tool_parsers/__init__.py
@@ -63,6 +63,7 @@ from .harmony_tool_parser import HarmonyToolParser
 from .hermes_tool_parser import HermesToolParser
 from .hy_v3_tool_parser import HyV3ToolParser
 from .kimi_tool_parser import KimiToolParser
+from .lfm_tool_parser import LfmToolParser
 from .llama_tool_parser import LlamaToolParser
 from .minimax_tool_parser import MiniMaxToolParser
 from .mistral_tool_parser import MistralToolParser
@@ -86,6 +87,7 @@ __all__ = [
     "HermesToolParser",
     "DeepSeekToolParser",
     "KimiToolParser",
+    "LfmToolParser",
     "GraniteToolParser",
     "NemotronToolParser",
     "xLAMToolParser",

--- a/vllm_mlx/tool_parsers/abstract_tool_parser.py
+++ b/vllm_mlx/tool_parsers/abstract_tool_parser.py
@@ -69,6 +69,7 @@ class ExtractedToolCallInformation:
 #                           xLAM, Llama JSON variant)
 #   calling_tool_text     — [Calling tool="name" k="v"]  text fallback for
 #                           low-quant degradation
+#   pythonic_bracket      — [func_name(arg="value"), ...]  (Liquid LFM)
 #   gemma4_native         — <|tool_call>call:name{k:v}<tool_call|>  (Gemma 4)
 #   harmony_commentary    — <|channel|>commentary to=functions.X<|message|>
 #                           {...}<|call|>  (GPT-OSS / Harmony)
@@ -105,6 +106,7 @@ WIRE_FORMAT_LABELS: frozenset[str] = frozenset(
         "function_xml_named",
         "raw_json",
         "calling_tool_text",
+        "pythonic_bracket",
         "gemma4_native",
         "harmony_commentary",
         "mistral_tool_calls",

--- a/vllm_mlx/tool_parsers/auto_tool_parser.py
+++ b/vllm_mlx/tool_parsers/auto_tool_parser.py
@@ -16,6 +16,7 @@ from .abstract_tool_parser import (
     ToolParser,
     ToolParserManager,
 )
+from .lfm_tool_parser import LFM_CALL_START, parse_lfm_tool_calls
 
 
 def generate_tool_id() -> str:
@@ -34,7 +35,8 @@ class AutoToolParser(ToolParser):
     3. Qwen/Hermes XML: <tool_call>{"name": "...", "arguments": {...}}</tool_call>
     4. Llama: <function=name>{"arg": "value"}</function>
     5. Nemotron: <tool_call><function=name>...</function></tool_call>
-    6. Raw JSON: {"name": "...", "arguments": {...}}
+    6. LFM pythonic: [func_name(arg="value")]
+    7. Raw JSON: {"name": "...", "arguments": {...}}
 
     This is the default parser when no specific parser is selected.
     """
@@ -53,6 +55,29 @@ class AutoToolParser(ToolParser):
     NEMOTRON_PARAM_PATTERN = re.compile(
         r"<parameter=([^>]+)>\s*(.*?)\s*</parameter>", re.DOTALL
     )
+
+    def __init__(self, tokenizer=None):
+        super().__init__(tokenizer)
+        # Count of tool calls already streamed this turn. Re-running
+        # ``extract_tool_calls`` on each end marker and slicing
+        # ``result.tool_calls[_emitted_tool_count:]`` means (a) a later
+        # ``]`` in trailing prose yields no NEW calls, so nothing is
+        # re-emitted with a fresh id (which OpenAI-delta clients would
+        # concatenate into corrupt arguments), and (b) a genuinely new
+        # tool-call block completing later in the stream is still emitted
+        # with a continuing index — the Gemma4/Qwen dedup pattern.
+        self._emitted_tool_count = 0
+        # Length of ``current_text`` already emitted as content. When a
+        # marker appears, content is held (None) for the rest of the
+        # stream; if no tool call ever completes, ``flush_held_content``
+        # releases everything past this boundary so prose that merely
+        # looked like markup isn't silently dropped.
+        self._content_emitted_len = 0
+
+    def reset(self) -> None:
+        super().reset()
+        self._emitted_tool_count = 0
+        self._content_emitted_len = 0
 
     def extract_tool_calls(
         self, model_output: str, request: dict[str, Any] | None = None
@@ -210,7 +235,14 @@ class AutoToolParser(ToolParser):
         if llama_matches:
             cleaned_text = self.LLAMA_PATTERN.sub("", cleaned_text).strip()
 
-        # 6. Fallback: Try raw JSON
+        # 6. Try LFM bracket pythonic calls format
+        if not tool_calls and LFM_CALL_START.search(cleaned_text):
+            lfm_tool_calls, lfm_cleaned = parse_lfm_tool_calls(cleaned_text)
+            if lfm_tool_calls:
+                tool_calls.extend(lfm_tool_calls)
+                cleaned_text = lfm_cleaned
+
+        # 7. Fallback: Try raw JSON
         if not tool_calls:
             raw_calls = self._parse_raw_json_tool_calls(cleaned_text)
             if raw_calls:
@@ -333,20 +365,32 @@ class AutoToolParser(ToolParser):
             "<function=",
         ]
 
-        has_marker = any(m in current_text for m in markers)
+        has_marker = any(m in current_text for m in markers) or bool(
+            LFM_CALL_START.search(current_text)
+        )
 
         if not has_marker:
+            self._content_emitted_len = len(current_text)
             return {"content": delta_text}
 
-        # Check for completion markers
-        end_markers = ["</tool_call>", "</function>", ")]"]
+        # Check for completion markers. A bare ``]`` (rather than ``)]``)
+        # covers LFM pythonic calls whose closing ``)`` and ``]`` arrive
+        # in separate deltas; extraction below only fires if a complete
+        # call actually parses, so the looser trigger is safe.
+        end_markers = ["</tool_call>", "</function>", "]"]
         if any(m in delta_text for m in end_markers):
             result = self.extract_tool_calls(current_text)
-            if result.tools_called:
+            if (
+                result.tools_called
+                and len(result.tool_calls) > self._emitted_tool_count
+            ):
+                base = self._emitted_tool_count
+                new_calls = result.tool_calls[base:]
+                self._emitted_tool_count = len(result.tool_calls)
                 return {
                     "tool_calls": [
                         {
-                            "index": i,
+                            "index": base + i,
                             "id": tc["id"],
                             "type": "function",
                             "function": {
@@ -354,8 +398,16 @@ class AutoToolParser(ToolParser):
                                 "arguments": tc["arguments"],
                             },
                         }
-                        for i, tc in enumerate(result.tool_calls)
+                        for i, tc in enumerate(new_calls)
                     ]
                 }
 
         return None
+
+    def flush_held_content(self, full_text: str) -> str:
+        """Release content held behind a marker that never became a tool call.
+
+        The postprocessor only calls this when no tool calls fired, so
+        everything past the last emitted boundary is ordinary content.
+        """
+        return full_text[self._content_emitted_len :]

--- a/vllm_mlx/tool_parsers/lfm_tool_parser.py
+++ b/vllm_mlx/tool_parsers/lfm_tool_parser.py
@@ -1,0 +1,356 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+LFM / Liquid tool call parser for vllm-mlx.
+
+Handles Liquid AI's LFM model tool calling format:
+- Bracketed pythonic format: [func_name(arg1=val1, arg2=val2)]
+"""
+
+import ast
+import json
+import logging
+import re
+import uuid
+from collections.abc import Sequence
+from typing import Any
+
+from .abstract_tool_parser import (
+    ExtractedToolCallInformation,
+    ToolParser,
+    ToolParserManager,
+)
+
+logger = logging.getLogger(__name__)
+
+# ``[name(`` — the structural marker of a pythonic LFM call. Shared with
+# AutoToolParser and the streaming postprocessor's plausible-markup
+# pre-check so all three agree on what counts as LFM markup.
+LFM_CALL_START = re.compile(r"\[\s*([A-Za-z_]\w*)\s*\(", re.DOTALL)
+_LFM_PARTIAL_START = re.compile(r"\[\s*(?:[A-Za-z_]\w*\s*(?:\(.*)?)?$", re.DOTALL)
+
+
+def generate_tool_id() -> str:
+    """Generate a unique tool call ID."""
+    return f"call_{uuid.uuid4().hex[:8]}"
+
+
+def eval_node(node: ast.AST) -> Any:
+    """Safely evaluate AST nodes to Python values.
+
+    Only ``ast.Constant`` and friends — never ``eval``. The deprecated
+    ``ast.Num`` / ``ast.Str`` / ``ast.NameConstant`` aliases are NOT
+    referenced here: they were removed in Python 3.14 and touching them
+    raises ``AttributeError`` (constants have parsed as ``ast.Constant``
+    since 3.8, so the aliases were dead code anyway).
+    """
+    if isinstance(node, ast.Constant):
+        return node.value
+    if isinstance(node, ast.Name):
+        # Bare names (``unit=celsius``) are treated as strings.
+        return node.id
+    if isinstance(node, ast.List):
+        return [eval_node(elt) for elt in node.elts]
+    if isinstance(node, ast.Tuple):
+        return tuple(eval_node(elt) for elt in node.elts)
+    if isinstance(node, ast.Dict):
+        return {eval_node(k): eval_node(v) for k, v in zip(node.keys, node.values)}
+
+    try:
+        return ast.literal_eval(node)
+    except Exception:
+        try:
+            return ast.unparse(node)
+        except Exception:
+            return str(node)
+
+
+def _find_lfm_call_start(text: str, start: int = 0) -> int:
+    """Return the next ``[name(`` style LFM call start, or ``-1``."""
+    match = LFM_CALL_START.search(text, start)
+    return -1 if match is None else match.start()
+
+
+def _extract_balanced_bracket_block(
+    text: str, start_idx: int
+) -> tuple[str | None, str]:
+    """
+    Return the balanced bracket block at ``start_idx`` and remaining text.
+
+    Nested brackets and quoted strings are accounted for so values like
+    ``items=[1, 2]`` or ``query="]"`` do not prematurely close the block.
+    """
+    depth = 0
+    in_string = False
+    string_char = None
+    escaped = False
+
+    for i in range(start_idx, len(text)):
+        char = text[i]
+
+        if escaped:
+            escaped = False
+            continue
+
+        if char == "\\":
+            escaped = True
+            continue
+
+        if in_string:
+            if char == string_char:
+                in_string = False
+            continue
+
+        if char in ('"', "'"):
+            in_string = True
+            string_char = char
+            continue
+
+        if char == "[":
+            depth += 1
+        elif char == "]":
+            depth -= 1
+            if depth == 0:
+                bracket_block = text[start_idx : i + 1]
+                remaining = text[:start_idx] + text[i + 1 :]
+                return bracket_block, remaining
+
+    return None, text
+
+
+def _parse_call_block(block: str) -> list[dict[str, Any]]:
+    """Parse one balanced ``[...]`` block into tool-call dicts.
+
+    Returns an empty list when the block is not a clean LFM call list.
+    A call carrying positional arguments rejects the WHOLE block:
+    positional values cannot be mapped to named tool parameters, and
+    emitting the call with empty/partial arguments would silently invoke
+    the tool wrong. Rejected blocks stay in the content instead.
+    """
+    try:
+        tree = ast.parse(block.strip())
+    except SyntaxError:
+        return []
+
+    if not tree.body or not isinstance(tree.body[0], ast.Expr):
+        return []
+    node = tree.body[0].value
+    if not isinstance(node, ast.List):
+        return []
+
+    calls: list[dict[str, Any]] = []
+    for elt in node.elts:
+        if not (isinstance(elt, ast.Call) and isinstance(elt.func, ast.Name)):
+            return []
+        if elt.args:
+            return []
+        arguments = {}
+        for kw in elt.keywords:
+            if kw.arg is None:
+                return []
+            arguments[kw.arg] = eval_node(kw.value)
+        calls.append(
+            {
+                "id": generate_tool_id(),
+                "name": elt.func.id,
+                "arguments": json.dumps(arguments, ensure_ascii=False),
+            }
+        )
+    return calls
+
+
+def parse_lfm_tool_calls(model_output: str) -> tuple[list[dict[str, Any]], str]:
+    """Parse LFM pythonic tool calls and return ``(tool_calls, cleaned_text)``.
+
+    Every ``[name(...)]`` block in the output is considered — LFM may emit
+    several separate blocks, not just one list. Blocks that don't parse as
+    clean call lists (prose, positional args) are left in the content.
+    """
+    tool_calls: list[dict[str, Any]] = []
+    text = model_output
+    search_from = 0
+
+    while True:
+        start = _find_lfm_call_start(text, search_from)
+        if start == -1:
+            break
+        block, remaining = _extract_balanced_bracket_block(text, start)
+        if block is None:
+            break
+
+        try:
+            block_calls = _parse_call_block(block)
+        except Exception as exc:
+            logger.debug("Failed to parse LFM pythonic tool call: %s", exc)
+            block_calls = []
+
+        if block_calls:
+            tool_calls.extend(block_calls)
+            text = remaining
+            search_from = start
+        else:
+            search_from = start + 1
+
+    if not tool_calls:
+        return [], model_output
+    return tool_calls, text
+
+
+@ToolParserManager.register_module(["lfm", "liquid"])
+class LfmToolParser(ToolParser):
+    """
+    Tool call parser for Liquid's LFM models.
+
+    Supports LFM bracket pythonic format:
+    - [get_current_weather(location="Paris")]
+    - [get_current_weather(location="New York", unit="celsius"), other_tool(arg=123)]
+    """
+
+    SUPPORTS_NATIVE_TOOL_FORMAT = False
+    EXPECTED_WIRE_FORMATS = ("pythonic_bracket",)
+
+    def __init__(self, tokenizer=None):
+        super().__init__(tokenizer)
+        # Count of tool calls already streamed to the client this turn.
+        # LFM may emit several bracket blocks over the course of a stream
+        # (``[f(x=1)] ... [g(y=2)]``); each ``]`` re-runs full-text
+        # extraction, so we slice ``result.tool_calls[_emitted_tool_count:]``
+        # to send only the newly-completed calls with continuing indices —
+        # the same dedup pattern as Gemma4/Qwen. Re-running extraction on a
+        # later ``]`` in trailing prose yields no NEW calls (slice is
+        # empty), so the same call is never re-emitted with a fresh id
+        # (which would corrupt OpenAI per-index ``arguments`` concat).
+        # Parser instances are per-request (see StreamingPostProcessor), so
+        # this counter never leaks across streams.
+        self._emitted_tool_count = 0
+
+    def reset(self) -> None:
+        super().reset()
+        self._emitted_tool_count = 0
+
+    def has_pending_tool_call(self, text: str) -> bool:
+        return _find_unclosed_lfm_call_start(text) != -1
+
+    def extract_tool_calls(
+        self, model_output: str, request: dict[str, Any] | None = None
+    ) -> ExtractedToolCallInformation:
+        """Extract tool calls from a complete LFM model response."""
+        tool_calls, cleaned_text = parse_lfm_tool_calls(model_output)
+
+        if tool_calls:
+            content = cleaned_text.strip()
+            return ExtractedToolCallInformation(
+                tools_called=True,
+                tool_calls=tool_calls,
+                content=content if content else None,
+            )
+
+        return ExtractedToolCallInformation(
+            tools_called=False, tool_calls=[], content=model_output
+        )
+
+    @classmethod
+    def _safe_content_prefix(cls, text: str) -> str:
+        """Return text safe to emit without leaking partial LFM markup."""
+        start = _find_unclosed_lfm_call_start(text)
+        if start != -1:
+            return text[:start]
+
+        # Hold a tail that could still become ``[func(`` once more tokens
+        # arrive — but only while the bracket block is still unbalanced. A
+        # closed block is either an already-extracted tool call or plain
+        # content; holding it would suppress everything after a completed
+        # call for the rest of the stream.
+        last_bracket = text.rfind("[")
+        if last_bracket != -1 and _LFM_PARTIAL_START.fullmatch(text[last_bracket:]):
+            block, _ = _extract_balanced_bracket_block(text, last_bracket)
+            if block is None:
+                return text[:last_bracket]
+
+        return text
+
+    @classmethod
+    def _emit_safe_content(
+        cls, previous_text: str, current_text: str
+    ) -> dict[str, Any] | None:
+        safe_current = cls._safe_content_prefix(current_text)
+        safe_previous = cls._safe_content_prefix(previous_text)
+        if len(safe_current) <= len(safe_previous):
+            return None
+        return {"content": safe_current[len(safe_previous) :]}
+
+    def flush_held_content(self, full_text: str) -> str:
+        """Release any held non-tool bracket prefix at stream end."""
+        return full_text[len(self._safe_content_prefix(full_text)) :]
+
+    def extract_tool_calls_streaming(
+        self,
+        previous_text: str,
+        current_text: str,
+        delta_text: str,
+        previous_token_ids: Sequence[int] | None = None,
+        current_token_ids: Sequence[int] | None = None,
+        delta_token_ids: Sequence[int] | None = None,
+        request: dict[str, Any] | None = None,
+    ) -> dict[str, Any] | None:
+        """Extract tool calls from streaming LFM model output."""
+        if "[" not in current_text:
+            return {"content": delta_text}
+
+        if LFM_CALL_START.search(current_text) is not None and "]" in delta_text:
+            result = self.extract_tool_calls(current_text)
+            if (
+                result.tools_called
+                and len(result.tool_calls) > self._emitted_tool_count
+            ):
+                base = self._emitted_tool_count
+                new_calls = result.tool_calls[base:]
+                self._emitted_tool_count = len(result.tool_calls)
+                out: dict[str, Any] = {
+                    "tool_calls": [
+                        {
+                            "index": base + i,
+                            "id": tc["id"],
+                            "type": "function",
+                            "function": {
+                                "name": tc["name"],
+                                "arguments": tc["arguments"],
+                            },
+                        }
+                        for i, tc in enumerate(new_calls)
+                    ]
+                }
+                # If a prose preface and the first completed call land in
+                # the SAME delta (batched chunk / finalize / single-shot
+                # stream), the leading prose was never emitted — and once a
+                # tool fires, the EOF ``flush_held_content`` path is skipped,
+                # so it would be lost. Emit the un-emitted leading content in
+                # the same return; the postprocessor renders the content
+                # event before the tool-call event (the llama-parser
+                # precedent, StreamingPostProcessor._detect_tool_calls). Only
+                # the FIRST emission needs this — content between/after later
+                # blocks streams through ``_emit_safe_content`` normally.
+                if base == 0:
+                    first_block = _find_lfm_call_start(current_text)
+                    already = len(self._safe_content_prefix(previous_text))
+                    if 0 <= already < first_block:
+                        lead = current_text[already:first_block]
+                        if lead.strip():
+                            out["content"] = lead
+                return out
+
+        return self._emit_safe_content(previous_text, current_text)
+
+
+def _find_unclosed_lfm_call_start(text: str) -> int:
+    """Return the first plausible LFM call start without a matching ``]``."""
+    search_from = 0
+    while True:
+        start = _find_lfm_call_start(text, search_from)
+        if start == -1:
+            return -1
+
+        bracket_block, _ = _extract_balanced_bracket_block(text, start)
+        if bracket_block is None:
+            return start
+
+        search_from = start + len(bracket_block)


### PR DESCRIPTION
## Summary

Adds tool-call parser support for **Liquid AI's LFM2 / LFM2.5** model family, implementing owner issue #85. Lands the work from external PR #552 by @necaris (rebased onto latest `main`, reviewed, and hardened).

LFM2 emits tool calls in a **pythonic-bracket** format wrapped in special tokens:

```
<|tool_call_start|>[get_weather(location="Paris")]<|tool_call_end|>
```

The special-token wrappers are stripped upstream by the detokenizer/sanitizer, so the parser operates on the inner `[func_name(arg="value"), ...]` list.

## What's included

- New `vllm_mlx/tool_parsers/lfm_tool_parser.py` (`LfmToolParser`, registered as `["lfm", "liquid"]`) — AST-based, safe (no `eval`), balanced-bracket aware, rejects positional-arg calls.
- `AutoToolParser` gains LFM pythonic detection (gated behind all other wire formats + AST validation).
- 3 LFM aliases in `aliases.json` (`lfm2-24b-a2b-4bit`, `lfm2.5-8b-a1b-4bit`, `lfm2.5-1b-4bit`) routing to the `lfm` parser.
- `pythonic_bracket` wire-format label; coverage-audit + streaming-parity registrations.
- 24 unit tests + streaming-parity fixture.

## Verification

- **Real model, real wire format.** `mlx-community/LFM2.5-1.2B-Instruct-4bit` loads and generates on the engine (Mac Studio, rapid-mlx 0.10.2). With `tools=[...]` it emits `[get_weather(location="Paris")]…` — exactly the format the parser handles. Fed that real output through the parser: correct extraction, no markup leak, prose preserved (non-streaming **and** char-by-char streaming).
- Full tool-parser test battery green.

## Changes made while landing (beyond #552)

- **Multi-block streaming fix.** Replaced a one-shot emission latch with the codebase-standard incremental `_emitted_tool_count` (Gemma4/Qwen pattern) in both `LfmToolParser` and `AutoToolParser`, so a second tool-call block completing later in a stream is emitted (with a continuing index) instead of dropped — while still never re-emitting a call on a trailing `]`. Regression test added.
- **Removed the `_MODEL_PATTERNS` regex entry** for LFM: that table is a documented-deprecated dispatch surface ("do NOT add new regex entries here — extend `aliases.json`"). LFM routing lives solely in `aliases.json`.
- Resolved the leftover coverage-audit TODO into a properly-documented exemption referencing #85.

Reviewed with codex (gpt-5.5) to convergence.

Credit: original implementation by @necaris in #552. Closes #85.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
