### PR TITLE
fix(parser): route Mistral family to the mistral tool-call parser (#1071)

### DIFF
--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -149,7 +149,7 @@ If you need to pin the parser manually:
 
 ```bash
 rapid-mlx serve devstral-24b-4bit \
-  --enable-auto-tool-choice --tool-call-parser hermes
+  --enable-auto-tool-choice --tool-call-parser mistral
 ```
 
 ## Next Steps

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -83,8 +83,8 @@ rapid-mlx serve qwen3.5-9b-4bit --reasoning-parser qwen3
 # DeepSeek reasoning model
 rapid-mlx serve deepseek-r1-8b-4bit --reasoning-parser deepseek_r1
 
-# Tool calling with Mistral/Devstral
-rapid-mlx serve devstral-24b-4bit --enable-auto-tool-choice --tool-call-parser hermes
+# Tool calling with Mistral/Devstral (parser auto-detected; pin shown for clarity)
+rapid-mlx serve devstral-24b-4bit --enable-auto-tool-choice --tool-call-parser mistral
 
 # DFlash speculative decoding (single-user, single supported alias)
 rapid-mlx serve qwen3.5-27b-8bit --speculative-config '{"method":"dflash"}' --port 8000

--- a/evals/EVAL_CONFIGS.md
+++ b/evals/EVAL_CONFIGS.md
@@ -198,10 +198,11 @@ Detailed configuration record for every model evaluation. **Update this file whe
 | **Architecture** | Mistral3 24B (dense, code-specialized). Based on Mistral Small 3. |
 | **Quantization** | 4bit affine |
 | **Engine** | SimpleEngine |
-| **Parser** | `hermes` |
-| **Server command** | `vllm-mlx serve <path> --port 8000 --enable-auto-tool-choice --tool-call-parser hermes` |
-| **Load notes** | Loads directly (model_type=`mistral3`). Chat template uses `[SYSTEM_PROMPT]...[/SYSTEM_PROMPT]` and `[INST]...[/INST]` format — NO tool calling support in template. Tool calling 17% (only irrelevance/missing-params pass). Coding 90% — one of the best coding models. |
-| **Last tested** | 2026-03-04 |
+| **Parser (as tested)** | `hermes` |
+| **Recommended parser** | `mistral` (#1071) — the historical run used `hermes` and scored only 17% tool calling. See load notes. |
+| **Server command** | `vllm-mlx serve <path> --port 8000 --enable-auto-tool-choice --tool-call-parser mistral` |
+| **Load notes** | Loads directly (model_type=`mistral3`). Emits Mistral-native `[TOOL_CALLS]name[ARGS]{json}` tool calls, so it MUST use the `mistral` parser (#1071). The 2026-03-04 run used `hermes` (see result file) and scored 17% tool calling because `hermes` only understands `<tool_call>` XML and left the raw envelope in content. Coding 90% — one of the best coding models. |
+| **Last tested** | 2026-03-04 (with `hermes`; pre-#1071) |
 | **Result file** | `devstral-small-2-4bit.json` |
 
 ### Qwen3.5-27B-4bit
@@ -240,10 +241,11 @@ Detailed configuration record for every model evaluation. **Update this file whe
 | **Architecture** | Mistral Small 3.2 24B (dense). VLM-packaged (has `language_model.` prefix weights). |
 | **Quantization** | 4bit affine |
 | **Engine** | SimpleEngine |
-| **Parser** | `hermes` |
-| **Server command** | `vllm-mlx serve <path> --port 8000 --enable-auto-tool-choice --tool-call-parser hermes` |
-| **Load notes** | Loads via `strict=False` fallback (VLM packaging). Chat template has NO tool calling support — only user/system/assistant roles. Using `hermes` parser but model never generates `<tool_call>` tags. Tool calling 17% (only irrelevance detection passes). **Should use `mistral` parser with a model that has native tool support.** Tokenizer regex warning: `fix_mistral_regex=True` recommended. |
-| **Last tested** | 2026-03-04 |
+| **Parser (as tested)** | `hermes` |
+| **Recommended parser** | `mistral` (#1071) — the historical run used `hermes` and scored only 17% tool calling. See load notes. |
+| **Server command** | `vllm-mlx serve <path> --port 8000 --enable-auto-tool-choice --tool-call-parser mistral` |
+| **Load notes** | Loads via `strict=False` fallback (VLM packaging). The model emits Mistral-native `[TOOL_CALLS]name[ARGS]{json}` tool calls, so it MUST use the `mistral` parser (#1071). The 2026-03-04 run used `hermes` (see result file) and scored 17% tool calling because `hermes` only understands `<tool_call>` XML and left the raw envelope in content. Tokenizer regex warning: `fix_mistral_regex=True` recommended. |
+| **Last tested** | 2026-03-04 (with `hermes`; pre-#1071) |
 | **Result file** | `mistral-small-3.2-4bit.json` |
 
 ---

--- a/evals/run_all_models.sh
+++ b/evals/run_all_models.sh
@@ -35,10 +35,10 @@ declare -a MODELS=(
   "Qwen3.5-122B-A10B-8bit|/Users/raullenstudio/.lmstudio/models/mlx-community/Qwen3.5-122B-A10B-8bit|hermes|8bit"
   "Qwen3.5-4B-4bit|/Users/raullenstudio/.lmstudio/models/mlx-community/Qwen3.5-4B-MLX-4bit|hermes|4bit"
   "Qwen3.5-9B-4bit|/Users/raullenstudio/.lmstudio/models/mlx-community/Qwen3.5-9B-4bit|hermes|4bit"
-  "Mistral-Small-3.2-4bit|/Users/raullenstudio/.lmstudio/models/lmstudio-community/Mistral-Small-3.2-24B-Instruct-2506-MLX-4bit|hermes|4bit"
+  "Mistral-Small-3.2-4bit|/Users/raullenstudio/.lmstudio/models/lmstudio-community/Mistral-Small-3.2-24B-Instruct-2506-MLX-4bit|mistral|4bit"
   "Qwen3.5-27B-4bit|/Users/raullenstudio/.lmstudio/models/mlx-community/Qwen3.5-27B-4bit|hermes|4bit"
   "GLM-4.5-Air-4bit|/Users/raullenstudio/.lmstudio/models/lmstudio-community/GLM-4.5-Air-MLX-4bit|glm47|4bit"
-  "Devstral-Small-2-4bit|/Users/raullenstudio/.lmstudio/models/mlx-community/Devstral-Small-2-24B-Instruct-2512-4bit|hermes|4bit"
+  "Devstral-Small-2-4bit|/Users/raullenstudio/.lmstudio/models/mlx-community/Devstral-Small-2-24B-Instruct-2512-4bit|mistral|4bit"
   # Not yet downloaded:
   # "Nemotron-Nano-30B-4bit|<path>|hermes|4bit"
 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.10.5"
+version = "0.10.6"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/scripts/bench_all_models.sh
+++ b/scripts/bench_all_models.sh
@@ -15,7 +15,7 @@ mkdir -p "$RESULTS_DIR"
 # Model configs: "short_name|model_path|tool_parser|reasoning_parser"
 MODELS=(
   "phi4-mini-14b|/Users/raullenstudio/.lmstudio/models/lmstudio-community/Phi-4-mini-reasoning-MLX-4bit|hermes|"
-  "mistral-small-24b|/Users/raullenstudio/.lmstudio/models/lmstudio-community/Mistral-Small-3.2-24B-Instruct-2506-MLX-4bit|hermes|"
+  "mistral-small-24b|/Users/raullenstudio/.lmstudio/models/lmstudio-community/Mistral-Small-3.2-24B-Instruct-2506-MLX-4bit|mistral|"
   "gemma3-12b-4bit|/Users/raullenstudio/.lmstudio/models/mlx-community/gemma-3-12b-it-qat-4bit|hermes|"
   "gpt-oss-20b-mxfp4-q8|/Users/raullenstudio/.lmstudio/models/mlx-community/gpt-oss-20b-MXFP4-Q8|seed_oss|"
   "glm47-9b|/Users/raullenstudio/.lmstudio/models/mlx-community/GLM-4.7-4bit|glm47|"

--- a/tests/test_aliases_contract.py
+++ b/tests/test_aliases_contract.py
@@ -1450,9 +1450,11 @@ def test_mistral_small_4_119b_family_follows_mistral_24b_precedent() -> None:
     ]
     for alias in family:
         profile = list_profiles()[alias]
-        assert profile.tool_call_parser == twentyfour.tool_call_parser == "hermes", (
+        # #1071: the whole Mistral family uses the ``mistral`` parser
+        # (Mistral-native ``[TOOL_CALLS]`` envelope), not ``hermes`` XML.
+        assert profile.tool_call_parser == twentyfour.tool_call_parser == "mistral", (
             f"{alias}: tool_call_parser must match mistral-24b-4bit "
-            f"('hermes'). Got {profile.tool_call_parser!r}."
+            f"('mistral'). Got {profile.tool_call_parser!r}."
         )
         assert profile.reasoning_parser is None, (
             f"{alias}: Mistral-Small-4 is a non-thinking variant; no "

--- a/tests/test_model_auto_config.py
+++ b/tests/test_model_auto_config.py
@@ -101,7 +101,10 @@ class TestDetectModelConfig:
         assert config.tool_call_parser == "harmony"
         assert config.reasoning_parser == "harmony"
 
-    # Mistral / Devstral
+    # Mistral / Devstral — emit ``[TOOL_CALLS]name[ARGS]{json}`` (Mistral
+    # tekken/v7 native format), which only the ``mistral`` parser handles.
+    # Routing them to ``hermes`` leaked the raw envelope into chat content
+    # (#1071); the regex fallback must resolve to ``mistral``.
     @pytest.mark.parametrize(
         "model_path",
         [
@@ -112,7 +115,7 @@ class TestDetectModelConfig:
     def test_mistral_devstral(self, model_path):
         config = detect_model_config(model_path)
         assert config is not None
-        assert config.tool_call_parser == "hermes"
+        assert config.tool_call_parser == "mistral"
         assert config.reasoning_parser is None
 
     # Qwen3-Coder (no reasoning parser)
@@ -296,7 +299,11 @@ class TestDetectModelConfig:
         cfg = detect_model_config(model_path)
         assert cfg is not None
         # Magistral routes through its own entry, NOT generic Mistral.
-        # Critical: reasoning_parser must be set.
+        # Critical: reasoning_parser must be set. Tool calls use the
+        # Mistral-native ``[TOOL_CALLS]`` envelope, so the tool parser is
+        # ``mistral`` (NOT hermes) while the reasoning wrapper stays
+        # ``qwen3`` (#1071) — the two are orthogonal.
+        assert cfg.tool_call_parser == "mistral"
         assert cfg.reasoning_parser == "qwen3"
         assert cfg.is_hybrid is False
 
@@ -1560,3 +1567,295 @@ class TestHy3AutoDetectBoundary:
         if cfg is not None:
             assert cfg.tool_call_parser != "hy_v3"
             assert cfg.reasoning_parser != "hy_v3"
+
+
+class TestMistralFamilyToolParser:
+    """Regression guard for #1071 — the Mistral family must resolve to the
+    ``mistral`` tool-call parser, NOT ``hermes``.
+
+    Mistral / Devstral / Magistral / Mistral-Small-4 emit tool calls as the
+    Mistral-native ``[TOOL_CALLS]name[ARGS]{json}`` envelope (shared
+    tekken/v7 tokenizer). The ``hermes`` parser only understands
+    ``<tool_call>`` XML, so it parsed nothing and leaked the raw envelope
+    into ``message.content`` 6/6 of the time. The registered ``mistral``
+    parser owns that wire shape.
+
+    These assertions FAIL on the pre-#1071 code (every entry resolved to
+    ``hermes``) and pass on the fix.
+    """
+
+    # Every in-tree Mistral-family alias. Resolution goes through the
+    # alias profile (single source of truth) in ``aliases.json``. Note
+    # ``ministral-3b-4bit`` is included even though the ``mistral|devstral``
+    # regex does NOT match "Ministral" — its alias profile is the authority
+    # (#1071 codex round 1). This list is kept exhaustive; the
+    # ``test_every_mistral_family_alias_is_covered`` guard below fails if a
+    # new Mistral-family alias is added without a ``mistral`` parser.
+    _MISTRAL_ALIASES = (
+        "mistral-24b-4bit",
+        "devstral-24b-4bit",
+        "devstral-v2-24b-4bit",
+        "ministral-3b-4bit",
+        "mistral-small-4-119b",
+        "mistral-small-4-119b-4bit",
+        "mistral-small-4-119b-8bit",
+    )
+
+    @pytest.mark.parametrize("alias", _MISTRAL_ALIASES)
+    def test_alias_resolves_to_mistral_parser(self, alias):
+        cfg = detect_model_config(alias)
+        assert cfg is not None, f"{alias}: no alias profile found"
+        assert cfg.tool_call_parser == "mistral", (
+            f"{alias}: tool_call_parser must be 'mistral' (Mistral-native "
+            f"[TOOL_CALLS] envelope), got {cfg.tool_call_parser!r}. "
+            f"Routing to 'hermes' leaks the raw envelope into content."
+        )
+
+    @pytest.mark.parametrize("alias", _MISTRAL_ALIASES)
+    def test_alias_tool_parser_is_the_registered_mistral_parser(self, alias):
+        # Belt-and-suspenders: the resolved name must map to a real,
+        # registered parser class so serve time doesn't fall back silently.
+        from vllm_mlx.tool_parsers import ToolParserManager
+
+        cfg = detect_model_config(alias)
+        assert cfg is not None
+        # ``get_tool_parser`` raises KeyError on an unregistered name, so a
+        # clean return already proves the parser exists.
+        parser_cls = ToolParserManager.get_tool_parser(cfg.tool_call_parser)
+        assert parser_cls.__name__ == "MistralToolParser"
+
+    # Auto-detection path — raw HF paths / model names with no alias entry.
+    # All Mistral-family members (Mistral / Devstral / Ministral) are
+    # resolved by the segment-scoped ``_detect_mistral_family_config``
+    # pre-check (bare "mistral" does not substring-match "Ministral", and a
+    # full-path regex would steal a family-named parent dir / org — #1071).
+    @pytest.mark.parametrize(
+        "model_path",
+        [
+            "mistralai/Mistral-Small-3.2-24B-Instruct-2506",
+            "mlx-community/Devstral-Small-2-24B-Instruct-2512-4bit",
+            "some-org/Mistral-Nemo-Instruct-2407",
+            "org/Devstral-Future-99B",
+            # Raw (non-aliased) Ministral path — the "ministral" token is
+            # matched on the segment, not the full path.
+            "some-org/Ministral-3-3B-Instruct-2512-8bit",
+            "mistralai/Ministral-8B-Instruct-2410",
+        ],
+    )
+    def test_auto_detect_resolves_to_mistral_parser(self, model_path):
+        cfg = detect_model_config(model_path)
+        assert cfg is not None
+        assert cfg.tool_call_parser == "mistral"
+        assert cfg.reasoning_parser is None
+
+    # Magistral (Mistral reasoning variant) — same native tool envelope, so
+    # ``mistral`` tool parser, but it KEEPS its ``qwen3`` reasoning parser.
+    @pytest.mark.parametrize(
+        "model_path",
+        [
+            "mistralai/Magistral-Small-2509",
+            "mlx-community/Magistral-Small-2509-4bit",
+            "org/Magistral-Medium-2507",
+        ],
+    )
+    def test_magistral_mistral_tool_parser_keeps_qwen3_reasoning(self, model_path):
+        cfg = detect_model_config(model_path)
+        assert cfg is not None
+        assert cfg.tool_call_parser == "mistral"
+        assert cfg.reasoning_parser == "qwen3"
+
+    # Guard against over-broadening: the fix must NOT touch other families.
+    # Every non-Mistral model keeps its own parser.
+    @pytest.mark.parametrize(
+        "model_path,expected_parser",
+        [
+            ("mlx-community/Qwen3.5-9B-4bit", "hermes"),
+            ("Qwen/Qwen3-8B", "hermes"),
+            ("some-org/Qwen3.6-30B-A3B-Instruct", "qwen3_coder_xml"),
+            ("meta-llama/Llama-3.3-70B-Instruct", "llama"),
+            ("openai/gpt-oss-20b", "harmony"),
+            ("zai-org/GLM-4.6", "glm47"),
+            ("deepseek-ai/DeepSeek-R1", "deepseek"),
+        ],
+    )
+    def test_non_mistral_families_unchanged(self, model_path, expected_parser):
+        cfg = detect_model_config(model_path)
+        assert cfg is not None
+        assert cfg.tool_call_parser == expected_parser, (
+            f"{model_path}: the #1071 Mistral fix must not touch other "
+            f"families. Expected {expected_parser!r}, got "
+            f"{cfg.tool_call_parser!r}."
+        )
+        assert cfg.tool_call_parser != "mistral"
+
+    # Cross-family PRECEDENCE (#1071 pr_validate): a compound name that
+    # carries a Mistral token but belongs to a higher-priority family
+    # (DeepSeek / Qwen, which match earlier in ``_MODEL_PATTERNS``) must
+    # resolve to that family, NOT mistral. The Mistral-family entry keeps
+    # its original list position so these are unaffected.
+    @pytest.mark.parametrize(
+        "model_path,expected_tool",
+        [
+            ("org/DeepSeek-R1-Distill-Mistral-7B", "deepseek"),
+            ("org/DeepSeek-V3-Mistral-Merge", "deepseek_v3"),
+            ("some/Qwen3-Mistral-Merge-8B", "hermes"),
+        ],
+    )
+    def test_compound_name_keeps_higher_priority_family(
+        self, model_path, expected_tool
+    ):
+        cfg = detect_model_config(model_path)
+        assert cfg is not None
+        assert cfg.tool_call_parser == expected_tool, (
+            f"{model_path}: a compound name belonging to a higher-priority "
+            f"family must resolve to {expected_tool!r}, not mistral. "
+            f"Got {cfg.tool_call_parser!r}."
+        )
+        assert cfg.tool_call_parser != "mistral"
+
+    # Token-boundary guard (#1071 pr_validate MINOR): an incidental
+    # substring must NOT classify as Mistral family — family tokens are
+    # matched on separator/word boundaries within the model-name segment.
+    @pytest.mark.parametrize(
+        "model_path",
+        [
+            "org/NotMistral-7B",
+            "org/Llama-Mistralized-70B",
+            "org/Administral-Model",
+        ],
+    )
+    def test_incidental_substring_is_not_mistral_family(self, model_path):
+        cfg = detect_model_config(model_path)
+        # Either no family match (None) or a DIFFERENT family — never mistral.
+        if cfg is not None:
+            assert cfg.tool_call_parser != "mistral", (
+                f"{model_path}: 'mistral'/'ministral' appears only as an "
+                f"incidental substring (no token boundary) and must NOT be "
+                f"classified as Mistral family. Got {cfg.tool_call_parser!r}."
+            )
+
+    # Over-broadening guard (#1071 codex round 1): repo names carry
+    # "mistral" but are Hermes SFTs emitting ``<tool_call>`` XML — they MUST
+    # stay on the ``hermes`` parser. The segment-scoped Hermes-on-Mistral
+    # check wins over the generic Mistral classification.
+    @pytest.mark.parametrize(
+        "model_path",
+        [
+            "NousResearch/Hermes-2-Pro-Mistral-7B",
+            "teknium/OpenHermes-2.5-Mistral-7B",
+            "mlx-community/OpenHermes-2.5-Mistral-7B-4bit",
+            # Order-independent: "Mistral" before "Hermes" in the NAME must
+            # also be treated as a Hermes-on-Mistral SFT (#1071 codex r3).
+            "org/Mistral-Hermes-7B",
+            # HF-cache-flattened layout resolves to the model-name segment.
+            "models--NousResearch--Hermes-2-Pro-Mistral-7B/snapshots/abc1234",
+        ],
+    )
+    def test_hermes_on_mistral_stays_hermes(self, model_path):
+        cfg = detect_model_config(model_path)
+        assert cfg is not None
+        assert cfg.tool_call_parser == "hermes", (
+            f"{model_path}: Hermes-on-Mistral fine-tunes emit <tool_call> "
+            f"XML and must stay on 'hermes', NOT be stolen by the generic "
+            f"mistral rule. Got {cfg.tool_call_parser!r}."
+        )
+
+    # Inverse of the above: a REAL Mistral/Magistral model that merely lives
+    # under a ``hermes`` parent directory or org namespace must NOT be
+    # exempted by the Hermes-on-Mistral rule — the rule is scoped to the
+    # model-name segment (#1071 codex round 2, parent-dir collision).
+    @pytest.mark.parametrize(
+        "model_path,expected_tool,expected_reasoning",
+        [
+            ("/Users/hermes/models/Mistral-Small-3.2", "mistral", None),
+            ("hermes-labs/Mistral-Small-24B", "mistral", None),
+            ("/Volumes/hermes-cache/Magistral-Small-2509", "mistral", "qwen3"),
+            # Both "hermes" AND "mistral" appear, but in a PARENT dir — the
+            # actual model name (final segment) is a plain Mistral model, so
+            # the Hermes-on-Mistral exception must NOT fire (#1071 codex r3).
+            ("/cache/Hermes-Mistral/archive/Mistral-Small-3.2", "mistral", None),
+        ],
+    )
+    def test_hermes_parent_or_org_does_not_steal_real_mistral(
+        self, model_path, expected_tool, expected_reasoning
+    ):
+        cfg = detect_model_config(model_path)
+        assert cfg is not None
+        assert cfg.tool_call_parser == expected_tool, (
+            f"{model_path}: 'hermes' appears only in a parent dir / org, not "
+            f"the model-name segment — this is a real Mistral model and must "
+            f"resolve to {expected_tool!r}. Got {cfg.tool_call_parser!r}."
+        )
+        assert cfg.reasoning_parser == expected_reasoning
+
+    # A family-named PARENT dir / org (mistral / devstral / ministral) must
+    # NOT steal an unrelated model — the whole Mistral-family detection is
+    # segment-scoped (#1071 codex / pr_validate). A naive
+    # ``pattern.search(full_path)`` would have wrongly resolved all of these
+    # to ``mistral``; the segment classifier keeps them correct.
+    @pytest.mark.parametrize(
+        "model_path,expected_tool",
+        [
+            ("/cache/ministral/models/Llama-3.3-70B", "llama"),
+            ("ministral-labs/Llama-3.3-70B-Instruct", "llama"),
+            ("/cache/mistral/models/Llama-3.3-70B", "llama"),
+            ("mistral-labs/Llama-3.3-70B-Instruct", "llama"),
+            ("/cache/devstral/models/Llama-3.3-70B", "llama"),
+        ],
+    )
+    def test_family_named_parent_or_org_does_not_steal_unrelated_model(
+        self, model_path, expected_tool
+    ):
+        cfg = detect_model_config(model_path)
+        assert cfg is not None
+        assert cfg.tool_call_parser == expected_tool, (
+            f"{model_path}: a Mistral-family token appears only in a parent "
+            f"dir / org — the model is {expected_tool!r}, not Mistral. "
+            f"Got {cfg.tool_call_parser!r}."
+        )
+        assert cfg.tool_call_parser != "mistral"
+
+    def test_every_mistral_family_alias_is_covered(self):
+        """Exhaustive guard: any alias whose HF path's MODEL-NAME SEGMENT is
+        a native Mistral-family model (Mistral / Ministral / Devstral /
+        Magistral, excluding Hermes-on-Mistral SFTs) MUST use the ``mistral``
+        parser. Adding a new such alias with ``hermes`` re-introduces #1071
+        and fails here.
+
+        Uses ``list_profiles()`` (the loaded registry) so string-form and
+        object-form alias entries are both covered, and classifies on the
+        final path segment so a ``hermes-labs/Mistral-*`` org namespace is
+        NOT wrongly exempted. Also cross-checks the discovered set against
+        the static ``_MISTRAL_ALIASES`` list so the two never drift apart.
+        """
+        from vllm_mlx.model_aliases import list_profiles
+
+        discovered = set()
+        offenders = []
+        for name, profile in list_profiles().items():
+            hf = getattr(profile, "hf_path", None) or ""
+            # Classify on the model-name segment only (last path component),
+            # so a ``hermes`` org/parent does not exempt a real Mistral model.
+            segment = hf.rstrip("/").split("/")[-1].lower()
+            is_mistral_family = any(
+                tok in segment
+                for tok in ("mistral", "ministral", "devstral", "magistral")
+            )
+            # Exclude Hermes-on-Mistral SFTs (they emit <tool_call> XML) —
+            # only when ``hermes`` is in the SAME model-name segment.
+            if is_mistral_family and "hermes" not in segment:
+                discovered.add(name)
+                if profile.tool_call_parser != "mistral":
+                    offenders.append((name, profile.tool_call_parser))
+        assert not offenders, (
+            "Mistral-family aliases must use the 'mistral' parser (#1071). "
+            f"Offenders (alias, parser): {offenders}"
+        )
+        # The static list drives the per-alias parametrized tests above; keep
+        # it in lockstep with what the registry scan actually finds.
+        assert discovered == set(self._MISTRAL_ALIASES), (
+            "Mistral-family alias inventory drifted. "
+            f"Registry scan found {sorted(discovered)}, "
+            f"static _MISTRAL_ALIASES is {sorted(self._MISTRAL_ALIASES)}. "
+            "Update both together."
+        )

--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -910,14 +910,14 @@
   },
   "mistral-24b-4bit": {
     "hf_path": "mlx-community/Mistral-Small-3.1-24B-Instruct-2503-4bit",
-    "tool_call_parser": "hermes",
+    "tool_call_parser": "mistral",
     "reasoning_parser": null,
     "is_hybrid": false,
     "supports_spec_decode": true
   },
   "devstral-24b-4bit": {
     "hf_path": "mlx-community/Devstral-Small-2507-4bit",
-    "tool_call_parser": "hermes",
+    "tool_call_parser": "mistral",
     "reasoning_parser": null,
     "is_hybrid": false,
     "supports_spec_decode": true,
@@ -1113,7 +1113,7 @@
   },
   "ministral-3b-4bit": {
     "hf_path": "mlx-community/Ministral-3-3B-Instruct-2512-4bit",
-    "tool_call_parser": "hermes",
+    "tool_call_parser": "mistral",
     "reasoning_parser": null,
     "is_hybrid": false,
     "supports_spec_decode": true,
@@ -1175,7 +1175,7 @@
   },
   "devstral-v2-24b-4bit": {
     "hf_path": "mlx-community/Devstral-Small-2-24B-Instruct-2512-4bit",
-    "tool_call_parser": "hermes",
+    "tool_call_parser": "mistral",
     "reasoning_parser": null,
     "is_hybrid": false,
     "supports_spec_decode": true,
@@ -1627,7 +1627,7 @@
   },
   "mistral-small-4-119b": {
     "hf_path": "mlx-community/Mistral-Small-4-119B-2603-4bit",
-    "tool_call_parser": "hermes",
+    "tool_call_parser": "mistral",
     "reasoning_parser": null,
     "is_hybrid": false,
     "is_moe": false,
@@ -1635,7 +1635,7 @@
   },
   "mistral-small-4-119b-4bit": {
     "hf_path": "mlx-community/Mistral-Small-4-119B-2603-4bit",
-    "tool_call_parser": "hermes",
+    "tool_call_parser": "mistral",
     "reasoning_parser": null,
     "is_hybrid": false,
     "is_moe": false,
@@ -1643,7 +1643,7 @@
   },
   "mistral-small-4-119b-8bit": {
     "hf_path": "mlx-community/Mistral-Small-4-119B-2603-8bit",
-    "tool_call_parser": "hermes",
+    "tool_call_parser": "mistral",
     "reasoning_parser": null,
     "is_hybrid": false,
     "is_moe": false,

--- a/vllm_mlx/model_auto_config.py
+++ b/vllm_mlx/model_auto_config.py
@@ -127,6 +127,16 @@ class ModelConfig:
 # the migration completes (tracked separately so PRs stay tight on a
 # single issue).
 #
+# Sentinel config: when a pattern maps to this exact object, the loop
+# delegates the final decision to the segment-scoped
+# ``_detect_mistral_family_config`` resolver (#1071). Used for the Mistral
+# family so its ORIGINAL precedence position in this list is preserved
+# (higher-priority families like DeepSeek / Qwen still win first, e.g.
+# ``DeepSeek-R1-Distill-Mistral-7B`` → deepseek), while classification
+# still happens on the model-name SEGMENT rather than the full path (so a
+# family-named parent dir / org does not steal an unrelated model).
+_MISTRAL_FAMILY_SENTINEL = ModelConfig()
+
 # Model family patterns → optimal config.
 # Order matters: first match wins. More specific patterns go first.
 _MODEL_PATTERNS: list[tuple[re.Pattern, ModelConfig]] = [
@@ -393,23 +403,20 @@ _MODEL_PATTERNS: list[tuple[re.Pattern, ModelConfig]] = [
             reasoning_parser=None,
         ),
     ),
-    # Magistral (Mistral reasoning variant) — must precede generic
-    # mistral so the reasoning_parser is set. Magistral emits standard
-    # ``<think>...</think>`` so the qwen3 reasoning parser handles it.
+    # Mistral family — Hermes-on-Mistral SFTs, Magistral, Ministral,
+    # Mistral, Devstral (#1071). This entry keeps the family at its
+    # ORIGINAL precedence (after DeepSeek/Qwen/GLM/Kimi, before Gemma/
+    # Hermes/Llama), so a compound name like ``DeepSeek-R1-Distill-Mistral``
+    # still resolves to its higher-priority family. The regex is only a
+    # cheap full-path pre-filter; the ``_MISTRAL_FAMILY_SENTINEL`` marker
+    # makes ``detect_model_config`` delegate the real decision to the
+    # model-name-SEGMENT-scoped ``_detect_mistral_family_config`` resolver.
+    # If that resolver returns ``None`` (the family token is only in a
+    # parent dir / org, not the model name), the loop simply continues —
+    # so a family-named parent directory cannot steal an unrelated model.
     (
-        re.compile(r"magistral", re.IGNORECASE),
-        ModelConfig(
-            tool_call_parser="hermes",
-            reasoning_parser="qwen3",
-        ),
-    ),
-    # Mistral / Devstral / Mistral-Small-3.x (model_type=mistral3)
-    (
-        re.compile(r"mistral|devstral", re.IGNORECASE),
-        ModelConfig(
-            tool_call_parser="hermes",
-            reasoning_parser=None,
-        ),
+        re.compile(r"ministral|mistral|devstral|magistral", re.IGNORECASE),
+        _MISTRAL_FAMILY_SENTINEL,
     ),
     # Gemma 4 (native tool format)
     (
@@ -620,6 +627,78 @@ def _log_resolution_once(model_path: str, message: str) -> None:
     logger.info(message)
 
 
+def _detect_mistral_family_config(model_path: str) -> ModelConfig | None:
+    """Segment-scoped resolver for the whole Mistral family (#1071).
+
+    Classifies on the MODEL-NAME SEGMENT (via ``_extract_model_name_segment``
+    so HF cache layouts like ``models--<org>--<name>/snapshots/<sha>``
+    resolve to the canonical name), NOT the full path. This is deliberate:
+    the generic ``_MODEL_PATTERNS`` loop uses ``pattern.search(full_path)``,
+    which would mis-route a model that merely lives under a family-named
+    PARENT directory / org (``/cache/mistral/models/Llama-…``,
+    ``ministral-labs/Llama-…``). Doing the Mistral-family classification on
+    the segment avoids that collision class entirely.
+
+    Priority order (first match wins):
+
+    1. **Hermes-on-Mistral SFTs** (``Hermes-2-Pro-Mistral-7B``,
+       ``OpenHermes-2.5-Mistral-7B``) — carry ``mistral`` in the name but
+       emit ``<tool_call>`` XML, so → ``hermes``. Order-independent (both
+       ``Hermes-…-Mistral`` and ``Mistral-…-Hermes`` count).
+    2. **Magistral** (Mistral reasoning variant) — emits ``<think>…</think>``
+       so keeps ``reasoning_parser="qwen3"``; tool calls are the native
+       ``[TOOL_CALLS]`` envelope → ``mistral``.
+    3. **Ministral** — Mistral AI's small family; bare ``mistral`` does not
+       substring-match "Ministral", hence the explicit token → ``mistral``.
+    4. **Mistral / Devstral** (model_type=mistral3) — native
+       ``[TOOL_CALLS]name[ARGS]{json}`` envelope → ``mistral``.
+
+    Returns ``None`` when the segment is not a Mistral-family model, so the
+    caller falls through to the ``_MODEL_PATTERNS`` loop.
+
+    Family tokens are matched on separator/word boundaries within the
+    segment (not bare substrings) so incidental substrings like
+    ``NotMistral-7B``, ``Llama-Mistralized-70B``, or ``Administral`` do NOT
+    classify as Mistral family.
+    """
+    segment = _extract_model_name_segment(model_path).lower()
+
+    def _has_token(token: str) -> bool:
+        # Family token on BOTH-side boundaries: preceded by start-of-segment
+        # or a name separator (``-`` ``_`` ``.`` ``/`` whitespace), and
+        # followed by end-of-segment, a separator, or a digit
+        # (``mistral7b``). Prevents both leading overmatch (``notmistral``)
+        # and trailing overrun (``mistralized`` / ``administral``).
+        return (
+            re.search(rf"(?:^|[/_.\-\s]){token}(?:$|[/_.\-\s\d])", segment) is not None
+        )
+
+    # ``hermes`` is a distinctive brand that legitimately appears as a word
+    # SUFFIX (``OpenHermes``), so only its TRAILING boundary is enforced —
+    # a leading letter run is allowed. Incidental-substring risk is
+    # negligible for this token.
+    has_hermes = re.search(r"hermes(?:$|[/_.\-\s\d])", segment) is not None
+
+    has_mistral = _has_token("mistral")
+    has_ministral = _has_token("ministral")
+    has_devstral = _has_token("devstral")
+    has_magistral = _has_token("magistral")
+
+    # (1) Hermes-on-Mistral SFTs — emit <tool_call> XML, stay on hermes.
+    if has_hermes and (has_mistral or has_ministral):
+        return ModelConfig(tool_call_parser="hermes", reasoning_parser=None)
+
+    # (2) Magistral — mistral tool envelope + qwen3 reasoning wrapper.
+    if has_magistral:
+        return ModelConfig(tool_call_parser="mistral", reasoning_parser="qwen3")
+
+    # (3) Ministral, and (4) Mistral / Devstral — all native [TOOL_CALLS].
+    if has_ministral or has_mistral or has_devstral:
+        return ModelConfig(tool_call_parser="mistral", reasoning_parser=None)
+
+    return None
+
+
 def detect_model_config(model_path: str) -> ModelConfig | None:
     """Detect optimal parser config from model name/path.
 
@@ -679,16 +758,36 @@ def detect_model_config(model_path: str) -> ModelConfig | None:
         )
 
     for pattern, config in _MODEL_PATTERNS:
-        if pattern.search(model_path):
+        if not pattern.search(model_path):
+            continue
+        # #1071: the Mistral-family entry is a full-path pre-filter that
+        # delegates to a MODEL-NAME-SEGMENT-scoped resolver. This keeps the
+        # family at its original precedence (so a compound name like
+        # ``DeepSeek-R1-Distill-Mistral`` still resolves to its
+        # higher-priority family, which matched earlier in this loop) while
+        # avoiding the parent-dir / org collision a full-path match has. If
+        # the segment isn't actually a Mistral-family model NAME, the
+        # resolver returns None and we keep scanning later patterns.
+        if config is _MISTRAL_FAMILY_SENTINEL:
+            mistral_cfg = _detect_mistral_family_config(model_path)
+            if mistral_cfg is None:
+                continue
             _log_resolution_once(
                 model_path,
-                f"Auto-detected model family '{pattern.pattern}' → "
-                f"tool_call_parser={config.tool_call_parser}, "
-                f"reasoning_parser={config.reasoning_parser}, "
-                f"is_hybrid={config.is_hybrid}, "
-                f"supports_spec_decode={config.supports_spec_decode}",
+                f"Auto-detected Mistral-family model '{model_path}' → "
+                f"tool_call_parser={mistral_cfg.tool_call_parser}, "
+                f"reasoning_parser={mistral_cfg.reasoning_parser}",
             )
-            return config
+            return mistral_cfg
+        _log_resolution_once(
+            model_path,
+            f"Auto-detected model family '{pattern.pattern}' → "
+            f"tool_call_parser={config.tool_call_parser}, "
+            f"reasoning_parser={config.reasoning_parser}, "
+            f"is_hybrid={config.is_hybrid}, "
+            f"supports_spec_decode={config.supports_spec_decode}",
+        )
+        return config
     return None
 
 


### PR DESCRIPTION
## Summary

Fixes #1071. Mistral-family models (Mistral-Small, Devstral, Magistral, Ministral) emit tool calls in the Mistral-native envelope `[TOOL_CALLS]name[ARGS]{json}` with the correct tool name and JSON args, but were routed to the `hermes` parser, which only understands `<tool_call>` XML. The parser extracted nothing and the raw `[TOOL_CALLS]...[ARGS]{...}` text leaked into `message.content` **6/6 of the time**.

## Root cause (two SSOT locations)

1. `vllm_mlx/model_auto_config.py` — the `mistral|devstral` and `magistral` family regex rules set `tool_call_parser="hermes"`.
2. `vllm_mlx/aliases.json` — 7 aliases explicitly pinned `hermes`, overriding auto-config at serve time: `mistral-24b-4bit`, `devstral-24b-4bit`, `devstral-v2-24b-4bit`, `ministral-3b-4bit`, `mistral-small-4-119b{,-4bit,-8bit}`.

## Fix (single source of truth)

- `mistral|devstral` rule → registered `mistral` parser.
- `magistral` rule → `mistral` parser, keeping `reasoning_parser="qwen3"` (the reasoning wrapper is orthogonal to the tool-call wire format).
- All 7 Mistral-family aliases pinned to `mistral`.
- Segment-scoped, order-independent `_is_hermes_on_mistral` pre-check so Hermes-on-Mistral fine-tunes (`Hermes-2-Pro-Mistral-7B`, `OpenHermes-2.5-Mistral-7B`) — which emit `<tool_call>` XML — stay on `hermes`. Scoping to the model-name segment avoids stealing a real Mistral model that merely lives under a `hermes` parent dir / org.
- Segment-scoped `_is_ministral` pre-check for raw Ministral paths (bare `mistral` does not substring-match "Ministral"; adding it to the full-path regex would steal a `ministral` parent dir / org).
- Docs and eval scripts that hardcoded `--tool-call-parser hermes` for these models (and thus reproduced the bug) updated. `EVAL_CONFIGS.md` preserves the historical "as tested: hermes" provenance and adds a separate "recommended: mistral".

## Reproduction (live `devstral-v2-24b-4bit`)

| | tool_calls | content leak | result |
|---|---|---|---|
| Before (`hermes`) | `null` 6/6 | `[TOOL_CALLS]web_search[ARGS]{...}` 6/6 | 6/6 leaked |
| After (`mistral`) | `web_search` + valid JSON args 6/6 | none | **6/6 clean** |

Startup log confirms the resolved parser flips `hermes` → `mistral`.

## Tests

New `TestMistralFamilyToolParser` (42 cases): alias resolution, auto-detect incl. raw Ministral, magistral, order-independent Hermes-on-Mistral, HF-cache layout, parent-dir/org non-stealing (hermes and ministral), and an exhaustive alias-inventory guard (`list_profiles()` + segment classify + static-list cross-check). Verified to **fail on the pre-fix code and pass after**. Non-Mistral families (Qwen3.5, Llama, gpt-oss, GLM, DeepSeek) asserted unchanged. Pre-existing `test_mistral_devstral` / `test_magistral` / alias-contract expectations updated.

## Validation

- Codex review iterated to convergence (0 BLOCKING, 0 MAJOR); 3 rounds of MAJOR findings addressed (Hermes-on-Mistral over-broadening, missing Ministral alias, doc prescriptions, then segment-scoping + Ministral parent-collision).
- `ruff check` + `ruff format` clean.
- 2786 parser/alias/routes tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)