### PR TITLE
fix(deepseek): route DeepSeek-Coder-V2 tool calls to the deepseek_v3 parser

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.10.6"
+version = "0.10.7"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/tests/test_deepseek_v3_dedicated_parser.py
+++ b/tests/test_deepseek_v3_dedicated_parser.py
@@ -321,3 +321,39 @@ class TestStreaming:
 # round-trip test there avoids forcing this parser-regression file
 # to pull in the full route module — and lets parser-only CI shards
 # run without a Metal device (codex round-4 P2).
+
+
+class TestDeepSeekCoderV2CapturedWire:
+    """DeepSeek-Coder-V2-Lite emits the V3 fenced-JSON envelope. This is
+    the exact wire captured live from
+    ``mlx-community/DeepSeek-Coder-V2-Lite-Instruct-4bit-mlx``.
+
+    This test documents/locks the wire SHAPE the ``deepseek_v3`` parser
+    must handle for this model — it exercises the parser directly, so it
+    is not the regression guard for the routing bug itself (that lives in
+    ``tests/test_model_auto_config.py::TestDetectModelConfig``
+    ``.test_deepseek_coder_v2_routes_to_v3_parser``, which fails on the
+    old ``tool_call_parser=null`` alias). The production leak was caused
+    solely by no parser being attached; once ``deepseek_v3`` is routed
+    (via ``aliases.json`` + ``model_auto_config.py``), this envelope
+    parses into ``tool_calls`` instead of leaking into
+    ``message.content``."""
+
+    def test_coder_v2_web_search_envelope_parses(
+        self, v3_parser: DeepSeekV3ToolParser
+    ) -> None:
+        # Verbatim shape the Coder-V2-Lite weights produced at temperature
+        # (compact single-line args form).
+        payload = (
+            f"{TC_OPEN}{C_OPEN}function{SEP}web_search\n"
+            '```json\n{"query": "current weather in Tokyo"}\n```'
+            f"{C_CLOSE}{TC_CLOSE}"
+        )
+        result = v3_parser.extract_tool_calls(payload)
+        assert result.tools_called is True
+        assert len(result.tool_calls) == 1
+        tc = result.tool_calls[0]
+        assert tc["name"] == "web_search"
+        assert json.loads(tc["arguments"]) == {"query": "current weather in Tokyo"}
+        # Clean envelope with no prefix narration → no leaked content.
+        assert result.content is None

--- a/tests/test_model_auto_config.py
+++ b/tests/test_model_auto_config.py
@@ -6,6 +6,7 @@ import pytest
 
 from vllm_mlx.model_auto_config import (
     ModelConfig,
+    _deepseek_template_family,
     _reset_resolution_log_cache,
     detect_model_config,
     enrich_model_config,
@@ -192,6 +193,158 @@ class TestDetectModelConfig:
             assert config.reasoning_parser == "deepseek_r1"
         assert config.is_hybrid is False
         assert config.supports_spec_decode is True
+
+    # DeepSeek-Coder-V2 / V2-Lite — despite the ``V2`` version tag these
+    # checkpoints ship the DeepSeek-V3 chat template and emit the V3
+    # fenced-JSON tool-call body, so they must route to the dedicated
+    # block-wise ``deepseek_v3`` parser (its hardened owner). Before this
+    # fix the alias pinned ``tool_call_parser=null`` so NO parser was
+    # attached and the raw envelope leaked into ``content`` with
+    # ``tool_calls=null``. Live-verified against
+    # ``mlx-community/DeepSeek-Coder-V2-Lite-Instruct-4bit-mlx``.
+    @pytest.mark.parametrize(
+        "model_path",
+        [
+            # Bare HF paths that hit the regex fallback (not aliased).
+            "deepseek-ai/DeepSeek-Coder-V2-Instruct",
+            "deepseek-ai/DeepSeek-Coder-V2-Lite-Instruct",
+            "mlx-community/DeepSeek-Coder-V2-Lite-Base-4bit",
+            # Alias name + alias HF path (both resolve via aliases.json).
+            "deepseek-coder-v2-lite-16b-4bit",
+            "mlx-community/DeepSeek-Coder-V2-Lite-Instruct-4bit-mlx",
+        ],
+    )
+    def test_deepseek_coder_v2_routes_to_v3_parser(self, model_path):
+        config = detect_model_config(model_path)
+        assert config is not None
+        assert config.tool_call_parser == "deepseek_v3", (
+            f"{model_path}: Coder-V2 emits the V3 fenced-JSON envelope and "
+            f"must route to the deepseek_v3 parser, got "
+            f"{config.tool_call_parser!r}."
+        )
+        assert config.reasoning_parser is None
+
+    def test_deepseek_coder_v2_does_not_shadow_generic_deepseek(self):
+        # The new Coder-V2 rule must NOT steal matches from the generic
+        # ``deepseek`` fallback: a non-Coder-V2 / non-V3 DeepSeek path
+        # (V2.5, plain Coder without a V2 tag) still resolves to the
+        # legacy ``deepseek`` parser. The boundary anchor also rejects
+        # ``V20``/``V2.5``/``V2Beta`` (unrelated hypothetical version tags)
+        # so they too fall through to the generic parser.
+        for path in (
+            "deepseek-ai/DeepSeek-V2.5",
+            "deepseek-ai/DeepSeek-Coder-6.7B-Instruct",
+            "deepseek-ai/deepseek-coder-33b-instruct",
+            "deepseek-ai/DeepSeek-Coder-V20-Instruct",
+            "deepseek-ai/DeepSeek-Coder-V2.5-Instruct",
+            "deepseek-ai/DeepSeek-Coder-V2Beta",
+        ):
+            cfg = detect_model_config(path)
+            assert cfg is not None
+            assert cfg.tool_call_parser == "deepseek", (
+                f"{path}: must stay on the generic deepseek parser, got "
+                f"{cfg.tool_call_parser!r}."
+            )
+
+    def test_deepseek_coder_v2_distill_does_not_route_to_v3(self):
+        # A Coder-V2 distill (Qwen2/Llama-arch SFT, NOT a V3-template
+        # checkpoint) must NOT auto-route to deepseek_v3. Detection is
+        # scoped to the extracted MODEL-NAME segment (shared with the
+        # classifier), and a ``distill`` in that segment — suffix OR prefix
+        # — deterministically resolves to the legacy ``deepseek`` parser
+        # here, matching the classifier's ``distill`` reject, so the two
+        # layers agree in every case.
+        for path in (
+            "deepseek-ai/DeepSeek-Coder-V2-Distill-Qwen-7B",
+            "org/Distill-DeepSeek-Coder-V2-Lite-Instruct",
+            "deepseek-ai/DeepSeek-Coder-V2-lite-distill",
+        ):
+            cfg = detect_model_config(path)
+            assert cfg is not None
+            assert cfg.tool_call_parser == "deepseek", (
+                f"{path}: a distill in the name must fall through to the "
+                f"generic deepseek parser, got {cfg.tool_call_parser!r}."
+            )
+            # Classifier agrees: not a V3-template checkpoint.
+            assert _deepseek_template_family(path) is None
+
+    def test_deepseek_coder_v2_parent_dir_distill_still_routes_to_v3(self):
+        # A ``distill`` token in a PARENT directory (not the model-name
+        # segment) must NOT suppress the match — routing and the classifier
+        # both scope ``distill`` to the model-name segment, so these local /
+        # HF-cache paths still resolve to deepseek_v3. This locks the
+        # routing/classifier alignment for the parent-dir case.
+        for path in (
+            "/tmp/distilled/DeepSeek-Coder-V2-Lite-Instruct",
+            "/home/user/distill-cache/DeepSeek-Coder-V2",
+            "models--mlx-community--DeepSeek-Coder-V2-Lite-Instruct-4bit-mlx/"
+            "snapshots/abc1234",
+        ):
+            cfg = detect_model_config(path)
+            assert cfg is not None
+            assert cfg.tool_call_parser == "deepseek_v3", (
+                f"{path}: a distill token in a parent dir must not suppress "
+                f"the Coder-V2 match, got {cfg.tool_call_parser!r}."
+            )
+            assert _deepseek_template_family(path) == "v3"
+
+    def test_non_coder_v2_model_under_coder_v2_parent_dir_not_misrouted(self):
+        # A NON-Coder-V2 checkpoint stored beneath a ``…/DeepSeek-Coder-V2/``
+        # parent directory must NOT inherit the deepseek_v3 parser — the
+        # model-name SEGMENT (``qwen-model``) is what identifies the family.
+        # Routing scopes to the extracted segment (shared helper), so it
+        # agrees with the classifier (which returns None). Without segment
+        # scoping a full-path regex would misroute this Qwen checkpoint.
+        path = "/models/DeepSeek-Coder-V2/qwen-model"
+        cfg = detect_model_config(path)
+        assert cfg is not None
+        assert cfg.tool_call_parser != "deepseek_v3", (
+            f"{path}: model segment is 'qwen-model', must NOT route to "
+            f"deepseek_v3, got {cfg.tool_call_parser!r}."
+        )
+        assert _deepseek_template_family(path) is None
+
+    def test_coder_v2_distill_under_v3_parent_dir_stays_generic(self):
+        # A Coder-V2 *distill* whose parent directory carries a V3-family
+        # marker must still resolve deterministically from its own
+        # model-name segment (distill → generic ``deepseek``), NOT be
+        # hijacked to a V3-family parser by the parent dir. This keeps
+        # routing aligned with the classifier (which returns None for a
+        # distill) for these adversarial nested paths.
+        for path in (
+            "/models/DeepSeek-V3/DeepSeek-Coder-V2-Distill-Qwen-7B",
+            "/cache/DeepSeek-V3.1/DeepSeek-Coder-V2-lite-distill",
+            "/x/DeepSeek-R1-0528/Distill-DeepSeek-Coder-V2-Lite",
+        ):
+            cfg = detect_model_config(path)
+            assert cfg is not None
+            assert cfg.tool_call_parser == "deepseek", (
+                f"{path}: Coder-V2 distill must stay on the generic deepseek "
+                f"parser regardless of parent dir, got "
+                f"{cfg.tool_call_parser!r}."
+            )
+            assert _deepseek_template_family(path) is None
+
+    def test_deepseek_coder_v2_template_family_and_no_misbind_warning(self):
+        # The chat-template classifier recognises Coder-V2 as V3-lineage,
+        # so an explicit ``--tool-call-parser deepseek_v3`` is in-spec and
+        # produces NO misbind warning.
+        assert (
+            _deepseek_template_family("deepseek-ai/DeepSeek-Coder-V2-Instruct") == "v3"
+        )
+        assert (
+            _deepseek_template_family(
+                "mlx-community/DeepSeek-Coder-V2-Lite-Instruct-4bit-mlx"
+            )
+            == "v3"
+        )
+        assert (
+            warn_misbound_deepseek_v3_parser(
+                "mlx-community/DeepSeek-Coder-V2-Lite-Instruct-4bit-mlx",
+                "deepseek_v3",
+            )
+            is None
+        )
 
     # ---- 2026 model families ----
 

--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -463,7 +463,7 @@
   },
   "deepseek-coder-v2-lite-16b-4bit": {
     "hf_path": "mlx-community/DeepSeek-Coder-V2-Lite-Instruct-4bit-mlx",
-    "tool_call_parser": null,
+    "tool_call_parser": "deepseek_v3",
     "reasoning_parser": null,
     "is_hybrid": false,
     "is_moe": true,

--- a/vllm_mlx/model_auto_config.py
+++ b/vllm_mlx/model_auto_config.py
@@ -197,6 +197,21 @@ _MODEL_PATTERNS: list[tuple[re.Pattern, ModelConfig]] = [
             reasoning_parser=None,
         ),
     ),
+    # NOTE: DeepSeek-Coder-V2 / V2-Lite is NOT matched here. Despite the
+    # ``V2`` version tag those checkpoints ship the DeepSeek-V3 chat
+    # template and emit the V3 fenced-JSON tool-call body, so they must
+    # route to ``deepseek_v3`` — but the decision has to be scoped to the
+    # extracted MODEL-NAME segment (like ``_classify_deepseek_template_name``),
+    # not the full path, or a plain-``deepseek`` regex here would also fire
+    # on a non-Coder-V2 checkpoint stored beneath a ``…/DeepSeek-Coder-V2/``
+    # parent directory. A full-path regex in this table cannot express
+    # "canonical model-name segment only" without diverging from the
+    # classifier's segment scope (codex rounds 4-5). Coder-V2 detection is
+    # therefore handled in ``detect_model_config`` via the shared
+    # ``_is_deepseek_coder_v2_name`` helper, BEFORE this generic
+    # ``deepseek`` fallback runs. The classifier reuses the same helper, so
+    # routing and misbind-validation stay in lock-step.
+    #
     # DeepSeek (V2.5 and older) — no reasoning parser
     (
         re.compile(r"deepseek", re.IGNORECASE),
@@ -761,6 +776,53 @@ def detect_model_config(model_path: str) -> ModelConfig | None:
             supports_dflash=profile.supports_dflash,
         )
 
+    # DeepSeek-Coder-V2 / V2-Lite routing — handled here (not in the
+    # ``_MODEL_PATTERNS`` regex table) because the decision MUST be scoped
+    # to the extracted model-name SEGMENT, exactly like the misbind
+    # classifier ``_classify_deepseek_template_name``. A full-path regex in
+    # the table would also fire on a non-Coder-V2 checkpoint stored beneath
+    # a ``…/DeepSeek-Coder-V2/`` parent directory (codex round-5 finding),
+    # diverging from the classifier. Reusing ``_extract_model_name_segment``
+    # + the shared ``_is_deepseek_coder_v2_name`` helper (and the same
+    # ``distill`` reject the classifier applies) guarantees the two layers
+    # agree for every path shape — HF repo names, local dirs, and HF-cache
+    # ``models--…`` layouts. Despite the ``V2`` version tag these ship the
+    # DeepSeek-V3 chat template and emit the V3 fenced-JSON tool-call body,
+    # so they route to the dedicated hardened ``deepseek_v3`` parser (the
+    # pre-fix alias pinned ``tool_call_parser=null``, so the raw envelope
+    # leaked into ``content`` with ``tool_calls=null``). This check runs
+    # BEFORE the loop so it wins over the generic ``deepseek`` fallback.
+    #
+    # Residual model-capability limitation (out of scope for parser
+    # routing): at temperature the model sometimes invents a wrong tool
+    # name/schema — a model quality issue, not parser-fixable.
+    name_segment = _extract_model_name_segment(model_path.lower())
+    if _is_deepseek_coder_v2_name(name_segment):
+        # The Coder-V2 marker is in the canonical model-name segment, so
+        # this IS a Coder-V2 checkpoint regardless of what parent
+        # directories the path carries. Resolve the parser deterministically
+        # FROM THE SEGMENT here (rather than letting a ``distill`` variant
+        # fall through to the ``_MODEL_PATTERNS`` loop, where a
+        # ``…/DeepSeek-V3/…`` PARENT dir could hijack it to a V3-family
+        # parser and diverge from the classifier). A Coder-V2 *distill* is a
+        # Qwen2/Llama-arch SFT — NOT a V3-template checkpoint — so it takes
+        # the legacy ``deepseek`` parser, matching the classifier's
+        # ``distill`` reject. A non-distill Coder-V2 takes the hardened
+        # ``deepseek_v3`` parser.
+        if "distill" in name_segment:
+            cfg = ModelConfig(tool_call_parser="deepseek", reasoning_parser=None)
+            note = "distill SFT — legacy deepseek parser"
+        else:
+            cfg = ModelConfig(tool_call_parser="deepseek_v3", reasoning_parser=None)
+            note = "V3 chat-template lineage — deepseek_v3 parser"
+        _log_resolution_once(
+            model_path,
+            f"Auto-detected DeepSeek-Coder-V2 family for '{model_path}' → "
+            f"tool_call_parser={cfg.tool_call_parser}, "
+            f"reasoning_parser={cfg.reasoning_parser} ({note})",
+        )
+        return cfg
+
     for pattern, config in _MODEL_PATTERNS:
         if not pattern.search(model_path):
             continue
@@ -803,7 +865,10 @@ def detect_model_config(model_path: str) -> ModelConfig | None:
 #       body = ``function<｜tool▁sep｜>NAME\n``\`json\n{…}\n``\```
 #       emitted by V3-line checkpoints whose ``chat_template.jinja`` is
 #       the V3 template — vanilla V3-0324, R1-0528 (R1 retrained on V3),
-#       and the forward-cover V4 / V5 family per the upstream V4 card.
+#       and Coder-V2 / V2-Lite (which inherit the V3 template despite the
+#       ``V2`` tag). NOT V4 / V5: an earlier "forward-cover" for those was
+#       removed (#893) — their wire shape is the legacy V2.x envelope
+#       today (see the note in ``_classify_deepseek_template_name``).
 #
 #   * ``deepseek_v31`` (DeepSeekV31ToolParser):
 #       body = ``NAME<｜tool▁sep｜>{…json…}``
@@ -885,6 +950,28 @@ def _extract_model_name_segment(path: str) -> str:
     return candidate
 
 
+# DeepSeek-Coder-V2 / V2-Lite name test — operates on an already-extracted
+# MODEL-NAME segment (see ``_extract_model_name_segment``), so both the
+# parser router (``detect_model_config``) and the misbind classifier
+# (``_classify_deepseek_template_name``) can share ONE source of truth and
+# never diverge. ``[-_]*`` matches the ``DeepSeek-Coder-V2`` /
+# ``DeepSeek_Coder_V2`` / ``DeepSeekCoderV2`` separator variants. The
+# trailing ``(?![a-z0-9.])`` boundary rejects the unrelated
+# ``V20``/``V2.5``/``V2Beta`` version tags (bare ``V2`` at end-of-segment
+# still matches). Callers apply the ``distill`` reject separately so the
+# same rule that excludes R1-Distill from the V3 sub-families also keeps a
+# hypothetical Coder-V2 distill (Qwen2/Llama-arch SFT) off ``deepseek_v3``.
+_CODER_V2_NAME_RE = re.compile(r"deepseek[-_]*coder[-_]*v2(?![a-z0-9.])")
+
+
+def _is_deepseek_coder_v2_name(name_segment: str) -> bool:
+    """True if ``name_segment`` (a lowercased model-name segment) is a
+    DeepSeek-Coder-V2 / V2-Lite checkpoint that inherits the V3 chat
+    template. ``distill`` variants are excluded by the caller (they are
+    Qwen2/Llama-arch SFTs, not V3-template checkpoints)."""
+    return _CODER_V2_NAME_RE.search(name_segment) is not None
+
+
 def _classify_deepseek_template_name(s: str) -> str | None:
     """Inner name-pattern classifier — see ``_deepseek_template_family``
     for the public contract. Pulled out so the public helper can run the
@@ -931,6 +1018,18 @@ def _classify_deepseek_template_name(s: str) -> str | None:
     # R1-0528 — the R1 retrain on the V3 chat template.
     if re.search(r"deepseek.*r1[-_]?0528", name):
         return "v3"
+    # DeepSeek-Coder-V2 / V2-Lite — the ``V2`` tag is misleading: these
+    # checkpoints inherit the DeepSeek-V3 chat template and emit the V3
+    # fenced-JSON body shape (live-verified). Classify as ``"v3"`` so an
+    # explicit ``--tool-call-parser deepseek_v3`` on this model is treated
+    # as in-spec (no false misbind warning). Uses the SAME
+    # ``_is_deepseek_coder_v2_name`` helper the parser router calls, so the
+    # two layers can never diverge. The ``distill`` early-return above
+    # already excludes any hypothetical Coder-V2 distill (Qwen2/Llama-arch
+    # SFT). The helper's boundary anchor keeps ``V2.5``/``V20``/``V2Beta``
+    # on the unrelated chat lineages that use the legacy ``deepseek`` parser.
+    if _is_deepseek_coder_v2_name(name):
+        return "v3"
     # NOTE on V4 / V5: an earlier revision of this classifier returned
     # ``"v3"`` for ``DeepSeek-V[45]*`` as a "forward-cover" — the V4
     # upstream model card mentioned the V3 chat template lineage, and
@@ -971,8 +1070,14 @@ def _deepseek_template_family(model_path: str) -> str | None:
     belongs to, by name pattern.
 
     Returns one of:
-      * ``"v3"``     — V3 chat template (vanilla V3, R1-0528, V4, V5)
-                       → emits the V3 fenced-JSON body shape
+      * ``"v3"``     — V3 chat template (vanilla V3, R1-0528, and
+                       Coder-V2 / V2-Lite, which inherit the V3 template
+                       despite the ``V2`` tag)
+                       → emits the V3 fenced-JSON body shape.
+                       NOTE: V4 / V5 are deliberately NOT classified here
+                       (see the inline note in
+                       ``_classify_deepseek_template_name``) — their wire
+                       shape is the legacy V2.x envelope today.
       * ``"v31"``    — V3.1 chat template (DeepSeek-V3.1-*)
                        → emits the V3.1 plain-JSON body shape
       * ``None``     — not a V3-template checkpoint (R1-Distill family,


### PR DESCRIPTION
## Why

Because `deepseek-coder-v2-lite-16b-4bit` shipped with `tool_call_parser=null`, tool calls from this model never got parsed — the raw DeepSeek-V3 envelope leaked into `message.content` with `tool_calls: null`, making the model unusable for tool/agent workflows. This routes it to the correct parser so well-formed envelopes are parsed instead of leaked.

## Problem

The alias `deepseek-coder-v2-lite-16b-4bit` (`mlx-community/DeepSeek-Coder-V2-Lite-Instruct-4bit-mlx`) shipped with `tool_call_parser=null`, so **no tool-call parser was ever attached**. When given tools, the model emits a well-formed DeepSeek-V3-style envelope:

```
<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>web_search
```json
{"query": "current weather in Tokyo"}
```<｜tool▁call▁end｜><｜tool▁calls▁end｜>
```

but with no parser attached the raw envelope dumped straight into `message.content` with `tool_calls: null`.

## Root cause

Despite the `V2` version tag, DeepSeek-Coder-V2 / V2-Lite **inherit the DeepSeek-V3 chat template** and emit the V3 fenced-JSON body shape. `model_auto_config.py` had rules for `deepseek` / `deepseek_v3` / `deepseek_v31` / `r1-0528` / `v4`, but **none matched Coder-V2**, and the alias pinned `null` — which, resolving via the alias SSOT before any regex, short-circuited parser selection entirely.

## Fix (single source of truth)

- **`aliases.json`**: set `tool_call_parser="deepseek_v3"` for the alias. This governs both the alias-name serve and the exact-HF-path serve (via the reverse `hf_path` index).
- **`model_auto_config.py`**: detect DeepSeek-Coder-V2(-Lite) in `detect_model_config` for non-aliased HF-path serves, **scoped to the extracted MODEL-NAME segment** (shared `_is_deepseek_coder_v2_name` helper + the same `distill` reject the misbind classifier uses) so the parser router and `_classify_deepseek_template_name` **can never diverge** — including for local dirs, HF-cache `models--…` layouts, and adversarial parent-dir paths. A Coder-V2 *distill* (Qwen2/Llama-arch SFT, not a V3-template checkpoint) → legacy `deepseek` parser; a non-distill Coder-V2 → hardened `deepseek_v3` parser.
- `_classify_deepseek_template_name` classifies Coder-V2 as `v3` so an explicit `--tool-call-parser deepseek_v3` is in-spec (no false misbind warning).

The `deepseek_v3` parser is the dedicated registered owner of the V3 fenced-JSON body shape and carries the block-wise scanner + forced-tool hardening.

## Before / after (live, `mlx-community/DeepSeek-Coder-V2-Lite-Instruct-4bit-mlx`)

| | envelope leaked into `content` | parsed into `tool_calls` |
|---|---|---|
| **before** | 8/8 (`tool_call_parser=null`) | 0/8 |
| **after**  | 0/8 | 8/8 |

Startup log after: `Auto-configured --tool-call-parser deepseek_v3` / `Native tool format enabled for parser: deepseek_v3`.

## Residual model-capability limitation (out of scope, documented)

At temperature the model sometimes **invents a tool name/schema not in the advertised list** (e.g. `get_next_spacex_launch_date` instead of `web_search`). That is a model-quality limitation, **not parser-fixable** — well-formed envelopes still parse correctly into `tool_calls` regardless of the (possibly wrong) name. This PR's scope is narrow and correct: well-formed envelopes are parsed, not leaked.

## Tests

- Coder-V2 alias + bare-HF-path resolve to `deepseek_v3` (**fails on old code, passes on new**).
- Boundary (`V20`/`V2.5`/`V2Beta`) + in-name `distill` (prefix/suffix) + parent-dir `distill` + non-Coder-V2-under-`Coder-V2`-parent cases lock **routing == classifier** alignment.
- A captured-wire `deepseek_v3` parser test documents the exact envelope.
- All existing deepseek/qwen/gpt-oss rules unchanged.

Codex review iterated to convergence (**0 BLOCKING / 0 MAJOR / 0 MINOR**).

## Note on pr_validate `full_unit`

The single `full_unit` failure (`test_vision_extra_install.py::test_readme_quickstart_mentions_vision_extra`) is **pre-existing on `main`** (base README already has zero `[vision]` install mentions) and unrelated to this diff — this PR touches neither `README.md` nor that test. Should be a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)