### PR TITLE
fix(service): resolve GPT-OSS context from local checkpoint config

### DIFF
--- a/tests/test_context_length_exceeded.py
+++ b/tests/test_context_length_exceeded.py
@@ -17,12 +17,19 @@ chat route is covered by ``test_chat_route_*`` smoke runs.
 
 from __future__ import annotations
 
+import importlib.util
+
 import pytest
 
 # Helpers under test depend on the engine contract (``_model.args.*``,
 # ``tokenizer.encode``) — both surfaces exist regardless of mlx-lm
 # availability, so this file runs everywhere. The chat route import
 # itself transitively pulls in mlx, so we don't import it here.
+
+_requires_mlx = pytest.mark.skipif(
+    importlib.util.find_spec("mlx") is None,
+    reason="service.helpers transitively requires Apple MLX",
+)
 
 
 class _StubArgs:
@@ -114,6 +121,122 @@ def test_max_context_from_tokenizer_when_model_silent():
     tok = _StubTokenizer(model_max_length=4096)
     eng = _StubEngine(tokenizer=tok)
     assert get_model_max_context(eng) == 4096
+
+
+@_requires_mlx
+def test_max_context_from_local_config_when_mlx_lm_args_drop_field(tmp_path):
+    """mlx-lm GPT-OSS drops ``max_position_embeddings`` from ModelArgs and
+    its tokenizer reports the HF 1e30 sentinel. The local checkpoint config
+    must still enforce the real 128k window instead of the permissive 4M
+    fallback."""
+    import json
+
+    from vllm_mlx.service.helpers import get_model_max_context
+
+    (tmp_path / "config.json").write_text(
+        json.dumps(
+            {
+                "model_type": "gpt_oss",
+                "max_position_embeddings": 131072,
+            }
+        )
+    )
+    tok = _StubTokenizer(model_max_length=int(1e30))
+    tok.name_or_path = str(tmp_path)
+    eng = _StubEngine(model=_StubModel(args=_StubArgs()), tokenizer=tok)
+
+    assert get_model_max_context(eng) == 131072
+
+
+@_requires_mlx
+def test_local_config_context_rejects_observed_gpt_oss_codex_budget(tmp_path):
+    """Dogfood regression: 116650 prompt + implicit 32768 completion must
+    fail before the ten-minute prefill on a 131072-token GPT-OSS model."""
+    import json
+
+    from fastapi import HTTPException
+
+    from vllm_mlx.service.helpers import enforce_context_length
+
+    (tmp_path / "config.json").write_text(
+        json.dumps({"max_position_embeddings": 131072})
+    )
+    tok = _StubTokenizer(model_max_length=int(1e30))
+    tok.name_or_path = str(tmp_path)
+    eng = _StubEngine(model=_StubModel(args=_StubArgs()), tokenizer=tok)
+
+    with pytest.raises(HTTPException) as excinfo:
+        enforce_context_length(eng, prompt_tokens=116650, max_tokens=32768)
+
+    error = excinfo.value.detail["error"]
+    assert error["code"] == "context_length_exceeded"
+    assert "149418" in error["message"]
+    assert "131072" in error["message"]
+
+
+@_requires_mlx
+def test_malformed_local_config_falls_through_to_tokenizer(tmp_path):
+    """A corrupt sidecar must not turn an otherwise valid request into 500."""
+    from vllm_mlx.service.helpers import get_model_max_context
+
+    (tmp_path / "config.json").write_bytes(b"\xff\xfe")
+    tok = _StubTokenizer(model_max_length=4096)
+    tok.name_or_path = str(tmp_path)
+    eng = _StubEngine(tokenizer=tok)
+
+    assert get_model_max_context(eng) == 4096
+
+
+@_requires_mlx
+def test_oversized_local_config_falls_through_to_tokenizer(tmp_path):
+    """An unbounded sidecar must not be parsed in the request path."""
+    import json
+
+    from vllm_mlx.service.helpers import get_model_max_context
+
+    (tmp_path / "config.json").write_text(
+        json.dumps(
+            {
+                "padding": "x" * (1024 * 1024),
+                "max_position_embeddings": 131072,
+            }
+        )
+    )
+    tok = _StubTokenizer(model_max_length=4096)
+    tok.name_or_path = str(tmp_path)
+    eng = _StubEngine(tokenizer=tok)
+
+    assert get_model_max_context(eng) == 4096
+
+
+@_requires_mlx
+def test_local_config_is_read_once_per_model_path(tmp_path, monkeypatch):
+    """Context resolution is hot-path code, so sidecar I/O must be cached."""
+    import json
+
+    import vllm_mlx.service.helpers as helpers
+
+    (tmp_path / "config.json").write_text(
+        json.dumps({"max_position_embeddings": 131072})
+    )
+    tok = _StubTokenizer(model_max_length=int(1e30))
+    tok.name_or_path = str(tmp_path)
+    eng = _StubEngine(tokenizer=tok)
+
+    real_reader = helpers._try_read_config_json
+    reads = 0
+
+    def counting_reader(model_path):
+        nonlocal reads
+        reads += 1
+        return real_reader(model_path)
+
+    helpers._read_local_context_config.cache_clear()
+    monkeypatch.setattr(helpers, "_try_read_config_json", counting_reader)
+
+    assert helpers.get_model_max_context(eng) == 131072
+    assert helpers.get_model_max_context(eng) == 131072
+    assert reads == 1
 
 
 def test_max_context_ignores_hf_sentinel_value():

--- a/vllm_mlx/service/helpers.py
+++ b/vllm_mlx/service/helpers.py
@@ -17,6 +17,7 @@ import os
 import threading
 import uuid
 from collections.abc import AsyncIterator
+from functools import lru_cache
 
 from fastapi import HTTPException
 from starlette.requests import Request
@@ -46,7 +47,11 @@ from ..api.models import (
     Usage,
 )
 from ..api.tool_calling import parse_tool_calls
-from ..api.utils import sanitize_output, strip_reasoning_channel_markup
+from ..api.utils import (
+    _try_read_config_json,
+    sanitize_output,
+    strip_reasoning_channel_markup,
+)
 from ..config import get_config
 from ..engine import BaseEngine, GenerationOutput
 from ..tool_parsers import ToolParserManager
@@ -3890,6 +3895,19 @@ async def _wait_with_disconnect(
 _FALLBACK_MAX_CONTEXT_TOKENS = 4_194_304
 
 
+@lru_cache(maxsize=128)
+def _read_local_context_config(model_path: str) -> dict | None:
+    """Return a bounded, cached local checkpoint config.
+
+    Model metadata is immutable for the lifetime of a loaded engine, while
+    context-length resolution runs on every request. Reuse the defensive
+    local-only reader from :mod:`vllm_mlx.api.utils` so malformed UTF-8,
+    invalid JSON, and oversized sidecars fall through without blocking or
+    failing admission checks.
+    """
+    return _try_read_config_json(model_path)
+
+
 def get_model_max_context(engine) -> int:
     """Return the model's max prompt-token context window for ``engine``.
 
@@ -3900,10 +3918,14 @@ def get_model_max_context(engine) -> int:
          multimodal Qwen3.5 / Gemma 4 nest the text-config inside.
       3. ``engine._model.config.max_position_embeddings`` — older
          attribute style.
-      4. ``engine.tokenizer.model_max_length`` if not the HuggingFace
+      4. Local ``config.json`` beside the loaded tokenizer. This is
+         load-bearing for mlx-lm GPT-OSS: its ``ModelArgs`` dataclass does
+         not declare ``max_position_embeddings``, so mlx-lm silently drops
+         the field even though the checkpoint's config contains it.
+      5. ``engine.tokenizer.model_max_length`` if not the HuggingFace
          "VERY_LARGE_INTEGER" sentinel (``1e30``). Some tokenizers
          report a useful cap here even when the model object doesn't.
-      5. ``_FALLBACK_MAX_CONTEXT_TOKENS`` — see module-level comment.
+      6. ``_FALLBACK_MAX_CONTEXT_TOKENS`` — see module-level comment.
 
     The function is intentionally permissive about missing fields: we'd
     rather pass through a request the model can handle than refuse a
@@ -3948,6 +3970,34 @@ def get_model_max_context(engine) -> int:
         engine, "_tokenizer", None
     )
     if tokenizer is not None:
+        # mlx-lm's GPT-OSS ModelArgs intentionally contains only fields used
+        # by the implementation and therefore drops HF's
+        # ``max_position_embeddings`` during dataclass construction. Its
+        # tokenizer also exposes the HF unknown-length sentinel (1e30), which
+        # previously made a real 131072-token model look like our 4M fallback.
+        # Read the already-local checkpoint sidecar before consulting that
+        # sentinel. No network resolution occurs here: ``name_or_path`` is the
+        # concrete directory used to load the tokenizer.
+        tokenizer_paths = [
+            getattr(tokenizer, "name_or_path", None),
+            getattr(getattr(tokenizer, "_tokenizer", None), "name_or_path", None),
+            getattr(engine, "_model_name", None),
+        ]
+        for model_path in tokenizer_paths:
+            if not isinstance(model_path, str):
+                continue
+            raw_config = _read_local_context_config(model_path)
+            if raw_config is None:
+                continue
+            sidecar_direct = _maybe_int(raw_config.get("max_position_embeddings"))
+            if sidecar_direct is not None:
+                return sidecar_direct
+            sidecar_text = raw_config.get("text_config")
+            if isinstance(sidecar_text, dict):
+                sidecar_nested = _maybe_int(sidecar_text.get("max_position_embeddings"))
+                if sidecar_nested is not None:
+                    return sidecar_nested
+
         tok_max = getattr(tokenizer, "model_max_length", None)
         if tok_max is not None:
             # HuggingFace tokenizers report 1e30 ("no cap known") which


### PR DESCRIPTION
## What does this PR do?

- Resolves `max_position_embeddings` from a checkpoint's already-local `config.json` before consulting `tokenizer.model_max_length`.
- Supports both top-level and nested `text_config.max_position_embeddings` metadata.
- Reuses the bounded local config reader and caches results by model path, so request admission does not repeatedly perform synchronous sidecar I/O.
- Falls through safely for malformed UTF-8, invalid JSON, missing files, and oversized sidecars.
- Adds regression coverage for GPT-OSS context resolution, the observed Codex request budget, malformed and oversized configs, and cached reads.

## Why is this needed?

Fixes #1084.

`mlx-lm`'s GPT-OSS `ModelArgs` drops `max_position_embeddings`, while the tokenizer reports Hugging Face's unknown-length sentinel (`~1e30`). Rapid-MLX therefore fell through to its permissive 4,194,304-token fallback instead of enforcing the checkpoint's 131,072-token context window.

As a result, a real Codex request with 116,650 prompt tokens and a 32,768-token completion budget was admitted even though its 149,418-token total exceeded the model's physical context. This PR rejects that request before the expensive prefill with an OpenAI-compatible `context_length_exceeded` response.

## AI assistance disclosure

Codex authored and reviewed the changes in `vllm_mlx/service/helpers.py` and `tests/test_context_length_exceeded.py` under contributor direction. The output was verified with Ruff, targeted and broad unit suites, a real local GPT-OSS checkpoint reproduction, and a mutation spot-check against the behavior contract. No generated dependency or lockfile changes are included.

> By submitting this PR I confirm I can explain the intent, risk, and behavior of every non-generated change in this PR. For any generated / boilerplate / scaffolded sections, I've identified them above and can describe how I verified them.

## Test plan

- [x] `ruff check .`
- [x] `ruff format --check .`
- [x] `python -m pytest tests/test_context_length_exceeded.py tests/test_context_overflow_400.py tests/test_routes.py -k 'context_length or context_window' -q` — 38 passed
- [x] Canonical SOP unit suite excluding integrations and model-dependent MLLM/video files — 12,269 passed, 35 skipped, 6 xfailed; 3 unrelated failures reproduced identically on clean `main`
- [x] Real local GPT-OSS reproduction — resolved context is 131,072 and `116650 + 32768` returns HTTP 400 with `context_length_exceeded`
- [x] Mutation spot-check: changed the direct-sidecar branch from `return sidecar_direct` to `continue`; `test_max_context_from_local_config_when_mlx_lm_args_drop_field` failed with `4194304 != 131072`, and `test_local_config_context_rejects_observed_gpt_oss_codex_budget` failed because no `HTTPException` was raised
- [x] `PR_VALIDATE_NO_CODEX=1 PR_VALIDATE_NO_STRESS=1 python -m scripts.pr_validate.pr_validate 1085 --verbose` — fetch, description, supply-chain, environment, and 73 targeted tests passed; the full-unit step reported only the same 3 failures reproduced on clean `main`

The three full-suite failures are pre-existing on clean `main`:

- `TestResponsesStreamR10C3::test_stream_event_payloads_validate_against_sdk_event_models`
- `TestResponsesStreamR10C3::test_stream_consumable_by_openai_python_sdk`
- `test_readme_quickstart_mentions_vision_extra`

`make check` was skipped per the merge SOP because this change does not modify engine, scheduler, parser, routing, or generation behavior. Live-server integrations were not run.

## Checklist

- [x] Relevant tests pass locally; the full SOP unit suite's unrelated failures were proven pre-existing on clean `main`
- [x] Lint passes (`ruff check && ruff format --check`)
- [x] Self-validated with `python3 -m scripts.pr_validate.pr_validate 1085`; pre-existing full-unit failures are documented above
- [x] Critical-path tests were mutation spot-checked; exact mutation and assertions are documented above
- [x] README/docs update is not applicable; wire behavior remains OpenAI-compatible and the fix is covered by tests
- [x] No breaking changes to existing API
