### PR TITLE
fix(packaging): ship TurboQuant Metal source

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -347,6 +347,7 @@ vllm_mlx = [
     "aliases.json",
     "audio/aliases.json",
     "agents/profiles/*.yaml",
+    "kernels/*.metal",
     # Integration tests bundled inside the package so `rapid-mlx agents
     # <name> --test` works on pip/brew installs (the source layout keeps
     # them at tests/integrations/, mirrored here via symlinks). Without

--- a/tests/test_packaging_data_files.py
+++ b/tests/test_packaging_data_files.py
@@ -46,6 +46,9 @@ REQUIRED_DATA_FILES: list[tuple[str, str, str]] = [
     # r10-A: audio alias registry. Codex r10-B caught this missing from
     # package-data; this entry locks the fix in place.
     ("vllm_mlx", "audio/aliases.json", "audio/aliases.json"),
+    # TurboQuant compiles this source at runtime; the fused path silently
+    # falls back when an installed wheel does not contain it.
+    ("vllm_mlx", "kernels/turboquant_fused.metal", "kernels/*.metal"),
 ]
 
 


### PR DESCRIPTION
## What does this PR do?

Ships `vllm_mlx/kernels/turboquant_fused.metal` in wheel and sdist artifacts and adds it to the existing runtime package-data regression roster.

## Why is this needed?

The fused TurboQuant implementation loads this Metal source at runtime. The current 0.10.5 wheel and sdist omit the file, so every installed release catches `FileNotFoundError` during kernel compilation and silently falls back to the unfused implementation.

The source checkout masks the problem because the file exists beside the Python binding. Declaring `kernels/*.metal` in package data restores the fused path for installed artifacts.

## AI assistance disclosure

Assisted review and patch generation touched `pyproject.toml` and `tests/test_packaging_data_files.py`. I reproduced the missing artifact, reviewed the four-line diff, ran the focused tests and lint checks, and inspected freshly built wheel and sdist contents.

> By submitting this PR I confirm I can explain the intent, risk, and behavior of every non-generated change in this PR. For any generated / boilerplate / scaffolded sections, I've identified them above and can describe how I verified them.

## Test plan

- `python -m pytest tests/test_packaging_data_files.py -q` — 6 passed
- `ruff check tests/test_packaging_data_files.py`
- `ruff format --check tests/test_packaging_data_files.py`
- `python -m build --wheel --sdist` — both artifacts contain `vllm_mlx/kernels/turboquant_fused.metal`
- Confirmed the published 0.10.5 wheel contains zero `.metal` files
- `python -m scripts.pr_validate.pr_validate 1086` — targeted tests pass; the strict aggregate remains blocked by the expected external-author supply-chain review for `pyproject.toml` and by Apple-Silicon-only full-suite collection on Windows

## Checklist

- [x] Focused packaging tests pass locally (`6 passed`)
- [x] Changed-file lint and format checks pass
- [x] Self-validation executed for PR #1086; platform/policy blockers documented above
- [x] If new tests touch a critical code path, the regression fails when the package-data declaration is absent
- [x] Updated README/docs if applicable — not applicable; packaging-only fix
- [x] No breaking changes to existing API
