### PR TITLE
fix(tests): scope HY3 strict-xfail hook to integration matrix cells only

### DIFF
--- a/tests/integrations/conftest.py
+++ b/tests/integrations/conftest.py
@@ -457,6 +457,24 @@ _GPTOSS_OPENHANDS_XFAIL_REASON = (
 # coverage for the family lives.
 
 _HY3_XFAIL_FAMILY = "hy3"  # matches the parametrize id
+
+# The integration-matrix modules whose ``family_alias``-parametrized cells
+# (ids ``[qwen36]`` / ``[gemma4]`` / ``[deepseek]`` / ``[gptoss]`` / ``[hy3]``)
+# are the ONLY items this hook is meant to mark. Any other collected test may
+# legitimately carry a ``[<family>]`` param id for an unrelated reason — e.g.
+# ``test_model_auto_config.py::TestHy3AutoDetectBoundary::
+# test_hy3_basename_is_detected[hy3]`` is an offline unit test whose raw
+# string param value happens to be ``"hy3"``. Gating on the matrix module
+# prevents the bare-substring match from bleeding onto those cells (which
+# would turn a legitimate PASS into an XPASS(strict) red under full-tree
+# ``pytest tests/``). The DeepSeek and gpt-oss blocks below already scope
+# themselves to these modules via their ``test_*_matrix.py::`` nodeid
+# prefixes; this makes the HY3 block follow the same convention.
+_INTEGRATION_MATRIX_MODULES = (
+    "test_agents_matrix.py",
+    "test_frameworks_matrix.py",
+)
+
 _HY3_XFAIL_REASON = (
     "hy3-preview-4bit 166 GB single-node — Ultra-only "
     "(min_memory_gb=192, ~156 GB peak), 295B/21B-active MoE. Like DeepSeek "
@@ -510,12 +528,18 @@ def pytest_collection_modifyitems(
                     strict=True,
                 )
             )
-        # Hy3 — every cell (all 14: 11 agents + 3 frameworks), 166 GB
-        # Ultra-only. The matrix parametrizes by a single ``family``
-        # argument, so every Hy3 nodeid ends in exactly ``[hy3]`` (never a
-        # combined id like ``[agent-hy3]``); the bare-token match below is
-        # the same pattern the merged DeepSeek/gpt-oss blocks use.
-        if f"[{_HY3_XFAIL_FAMILY}]" in item.nodeid:
+        # Hy3 — every matrix cell (all 14: 11 agents + 3 frameworks), 166 GB
+        # Ultra-only. The matrix parametrizes by a single ``family`` argument,
+        # so every Hy3 matrix nodeid ends in exactly ``[hy3]`` (never a
+        # combined id like ``[agent-hy3]``). The bare ``[hy3]`` token is NOT
+        # unique to the matrix, though: an unrelated offline unit test
+        # (``TestHy3AutoDetectBoundary::test_hy3_basename_is_detected[hy3]``)
+        # legitimately shares the id. Scope to the matrix modules — mirroring
+        # the ``test_*_matrix.py::`` prefixes the DeepSeek/gpt-oss blocks use
+        # — so the bare-token match cannot bleed onto those passing cells.
+        if f"[{_HY3_XFAIL_FAMILY}]" in item.nodeid and any(
+            module in item.nodeid for module in _INTEGRATION_MATRIX_MODULES
+        ):
             item.add_marker(
                 pytest.mark.xfail(
                     reason=_HY3_XFAIL_REASON,


### PR DESCRIPTION
## Why this change

**Why:** dogfood for the 0.10.7 release caught a CI-facing red that gates the
release. This PR fixes it. The change is needed **because** the HY3
strict-xfail hook over-reaches and turns a legitimately-passing offline unit
test into an `XPASS(strict)` failure under full-tree `pytest tests/`.

## Problem

The `pytest_collection_modifyitems` hook in `tests/integrations/conftest.py`
marked **strict-xfail** on ANY collected item whose nodeid contained the
bare substring `[hy3]`.

That over-reaches. The offline unit test
`tests/test_model_auto_config.py::TestHy3AutoDetectBoundary::test_hy3_basename_is_detected[hy3]`
(added in #1070) is parametrized with a raw string value `"hy3"`, so it
legitimately carries the `[hy3]` param id — and it **passes**. Strict-xfail
turned that pass into `XPASS(strict)` → RED under full-tree `pytest tests/`.
The regression was introduced when the family-wide HY3 hook landed in #1072;
both product code paths (the parser auto-detect and the matrix) are 100%
correct — this is a pure test-infra marker-scope bug, so no product code is
touched here.

**Isolation proof:** running `TestHy3AutoDetectBoundary` alone → 11/11 pass;
the red only appears when both #1070's unit test and #1072's hook are in the
same collection (`pytest tests/`).

## Fix

Gate the HY3 block on the item's nodeid referencing one of the two
integration-matrix modules (`test_agents_matrix.py` /
`test_frameworks_matrix.py`), because that mirrors the `test_*_matrix.py::`
nodeid prefixes that the **DeepSeek** and **gpt-oss** blocks in the same hook
already use. This is not a novel scheme — it makes HY3 follow the existing
convention. Only the 14 intended HY3 matrix cells (11 agents + 3 frameworks)
get the strict-xfail marker; the offline unit test no longer does.

30 insertions / 6 deletions, one file. No product code touched.

## Verification

Marker-introspection probe over `TestHy3AutoDetectBoundary` + both matrices:

| Metric | Pre-fix | Post-fix |
| --- | --- | --- |
| `test_hy3_basename_is_detected[hy3]` strict-xfail | **1 (bug)** | **0** |
| HY3 matrix cells strict-xfail | 14 | **14** (unchanged) |
| DeepSeek matrix strict-xfail | 9 | 9 (unchanged) |
| gpt-oss matrix strict-xfail | 1 | 1 (unchanged) |
| qwen36 / gemma4 matrix strict-xfail | 0 | 0 (unchanged) |

- `TestHy3AutoDetectBoundary` → **11/11 pass** in full-tree collection.
- Subset run (`unit class + both matrices`): 11 passed, 70 skipped, **0 XPASS**.
  (Matrix cells SKIP on a no-server run via the pre-existing
  `_guard_family_matches_server` autouse guard; the strict-xfail marker is
  still attached — proven by the probe above.)
- ruff 0.15.21 (CI pin) `format --check` + `check` → clean.

## Guardrails

- No `pyproject.toml` version change (G4) — `skip-version-bump` labeled.
- No `spec_decode/**` / `speculative/**` touched.
- G8: fixed the hook, did NOT delete/skip the unit test or downgrade its
  assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)