### PR TITLE
fix(context): honor local checkpoint context limits

### DIFF
--- a/tests/test_context_length_exceeded.py
+++ b/tests/test_context_length_exceeded.py
@@ -171,6 +171,21 @@ def test_max_context_ignores_malformed_local_tokenizer_config(tmp_path):
     assert get_model_max_context(_StubEngine(tokenizer=tok)) == 4096
 
 
+@pytest.mark.parametrize("invalid_value", ["true", "1e10000"])
+def test_max_context_rejects_invalid_local_config_values(tmp_path, invalid_value):
+    """Boolean and non-finite numeric JSON values must fail soft."""
+    from vllm_mlx.service.helpers import get_model_max_context
+
+    checkpoint = tmp_path / f"invalid-context-{invalid_value}"
+    checkpoint.mkdir()
+    (checkpoint / "config.json").write_text(
+        f'{{"max_position_embeddings": {invalid_value}}}'
+    )
+    tok = _StubTokenizer(model_max_length=4096, name_or_path=str(checkpoint))
+
+    assert get_model_max_context(_StubEngine(tokenizer=tok)) == 4096
+
+
 def test_max_context_from_tokenizer_when_model_silent():
     """Engines whose loader doesn't propagate the config still
     surface a useful cap via ``tokenizer.model_max_length``."""

--- a/tests/test_context_length_exceeded.py
+++ b/tests/test_context_length_exceeded.py
@@ -17,6 +17,8 @@ chat route is covered by ``test_chat_route_*`` smoke runs.
 
 from __future__ import annotations
 
+import json
+
 import pytest
 
 # Helpers under test depend on the engine contract (``_model.args.*``,
@@ -45,9 +47,17 @@ class _StubTokenizer:
     (1 token per 4 characters) so the test can hit specific
     boundaries without depending on a real BPE."""
 
-    def __init__(self, model_max_length=None, bos_token=None, chars_per_token=4):
+    def __init__(
+        self,
+        model_max_length=None,
+        bos_token=None,
+        chars_per_token=4,
+        name_or_path=None,
+    ):
         if model_max_length is not None:
             self.model_max_length = model_max_length
+        if name_or_path is not None:
+            self.name_or_path = name_or_path
         self.bos_token = bos_token
         self._cpt = chars_per_token
 
@@ -104,6 +114,61 @@ def test_max_context_from_model_config_attribute():
     cfg = _StubArgs(max_position_embeddings=8192)
     eng = _StubEngine(model=_StubModel(config=cfg))
     assert get_model_max_context(eng) == 8192
+
+
+def test_max_context_from_local_tokenizer_config_for_gpt_oss(tmp_path):
+    """mlx-lm's GPT-OSS ModelArgs drops ``max_position_embeddings``.
+
+    The tokenizer then exposes Hugging Face's unknown-length sentinel,
+    but its local checkpoint still has the authoritative 128K limit in
+    ``config.json``. Resolve that local metadata before falling back to
+    the permissive DoS sentinel so over-context requests are rejected
+    before their expensive prefill (issue #1084).
+    """
+    from fastapi import HTTPException
+
+    from vllm_mlx.service.helpers import (
+        enforce_context_length,
+        get_model_max_context,
+    )
+
+    checkpoint = tmp_path / "gpt-oss-120b"
+    checkpoint.mkdir()
+    (checkpoint / "config.json").write_text(
+        json.dumps(
+            {
+                "model_type": "gpt_oss",
+                "max_position_embeddings": 131_072,
+            }
+        )
+    )
+    tok = _StubTokenizer(
+        model_max_length=int(1e30),
+        name_or_path=str(checkpoint),
+    )
+    eng = _StubEngine(model=_StubModel(args=_StubArgs()), tokenizer=tok)
+
+    assert get_model_max_context(eng) == 131_072
+    with pytest.raises(HTTPException) as excinfo:
+        enforce_context_length(
+            eng,
+            prompt_tokens=116_650,
+            max_tokens=32_768,
+        )
+    assert excinfo.value.status_code == 400
+    assert excinfo.value.detail["error"]["code"] == "context_length_exceeded"
+
+
+def test_max_context_ignores_malformed_local_tokenizer_config(tmp_path):
+    """A damaged sidecar must fall through, not turn admission into a 500."""
+    from vllm_mlx.service.helpers import get_model_max_context
+
+    checkpoint = tmp_path / "broken-checkpoint"
+    checkpoint.mkdir()
+    (checkpoint / "config.json").write_text("{not-json")
+    tok = _StubTokenizer(model_max_length=4096, name_or_path=str(checkpoint))
+
+    assert get_model_max_context(_StubEngine(tokenizer=tok)) == 4096
 
 
 def test_max_context_from_tokenizer_when_model_silent():

--- a/vllm_mlx/service/helpers.py
+++ b/vllm_mlx/service/helpers.py
@@ -17,6 +17,8 @@ import os
 import threading
 import uuid
 from collections.abc import AsyncIterator
+from functools import lru_cache
+from pathlib import Path
 
 from fastapi import HTTPException
 from starlette.requests import Request
@@ -3890,6 +3892,41 @@ async def _wait_with_disconnect(
 _FALLBACK_MAX_CONTEXT_TOKENS = 4_194_304
 
 
+@lru_cache(maxsize=32)
+def _read_local_config_max_context(config_path: str) -> int | None:
+    """Read a positive context limit from one local ``config.json``.
+
+    ``get_model_max_context`` runs on request admission, so cache the
+    immutable checkpoint metadata instead of reopening the file for every
+    request. The caller only passes paths that already exist locally; this
+    helper never resolves a Hub ID or performs network I/O.
+    """
+    try:
+        payload = json.loads(Path(config_path).read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError):
+        logger.debug(
+            "get_model_max_context: could not read local %s",
+            config_path,
+            exc_info=True,
+        )
+        return None
+    if not isinstance(payload, dict):
+        return None
+
+    candidates = [payload.get("max_position_embeddings")]
+    text_config = payload.get("text_config")
+    if isinstance(text_config, dict):
+        candidates.append(text_config.get("max_position_embeddings"))
+    for value in candidates:
+        try:
+            parsed = int(value)
+        except (TypeError, ValueError):
+            continue
+        if parsed > 0:
+            return parsed
+    return None
+
+
 def get_model_max_context(engine) -> int:
     """Return the model's max prompt-token context window for ``engine``.
 
@@ -3900,10 +3937,12 @@ def get_model_max_context(engine) -> int:
          multimodal Qwen3.5 / Gemma 4 nest the text-config inside.
       3. ``engine._model.config.max_position_embeddings`` — older
          attribute style.
-      4. ``engine.tokenizer.model_max_length`` if not the HuggingFace
+      4. Local ``config.json`` beside ``tokenizer.name_or_path`` — some
+         mlx-lm dataclasses (notably GPT-OSS) drop the HF context field.
+      5. ``engine.tokenizer.model_max_length`` if not the HuggingFace
          "VERY_LARGE_INTEGER" sentinel (``1e30``). Some tokenizers
          report a useful cap here even when the model object doesn't.
-      5. ``_FALLBACK_MAX_CONTEXT_TOKENS`` — see module-level comment.
+      6. ``_FALLBACK_MAX_CONTEXT_TOKENS`` — see module-level comment.
 
     The function is intentionally permissive about missing fields: we'd
     rather pass through a request the model can handle than refuse a
@@ -3948,6 +3987,35 @@ def get_model_max_context(engine) -> int:
         engine, "_tokenizer", None
     )
     if tokenizer is not None:
+        # mlx-lm's GPT-OSS ModelArgs does not retain the checkpoint's
+        # ``max_position_embeddings`` field. Its tokenizer also reports
+        # Hugging Face's unknown-length sentinel, but ``name_or_path`` still
+        # points at the already-downloaded checkpoint. Read that local config
+        # before consulting the tokenizer sentinel. Wrapper tokenizers may
+        # keep the HF tokenizer under ``_tokenizer`` or ``tokenizer``.
+        seen_config_paths: set[str] = set()
+        tokenizer_candidates = (
+            tokenizer,
+            getattr(tokenizer, "_tokenizer", None),
+            getattr(tokenizer, "tokenizer", None),
+        )
+        for candidate in tokenizer_candidates:
+            if candidate is None:
+                continue
+            name_or_path = getattr(candidate, "name_or_path", None)
+            try:
+                checkpoint_path = Path(os.fspath(name_or_path)).expanduser()
+            except TypeError:
+                continue
+            config_path = checkpoint_path / "config.json"
+            config_key = os.fspath(config_path)
+            if config_key in seen_config_paths or not config_path.is_file():
+                continue
+            seen_config_paths.add(config_key)
+            local_max = _read_local_config_max_context(config_key)
+            if local_max is not None:
+                return local_max
+
         tok_max = getattr(tokenizer, "model_max_length", None)
         if tok_max is not None:
             # HuggingFace tokenizers report 1e30 ("no cap known") which

--- a/vllm_mlx/service/helpers.py
+++ b/vllm_mlx/service/helpers.py
@@ -3918,9 +3918,21 @@ def _read_local_config_max_context(config_path: str) -> int | None:
     if isinstance(text_config, dict):
         candidates.append(text_config.get("max_position_embeddings"))
     for value in candidates:
-        try:
-            parsed = int(value)
-        except (TypeError, ValueError):
+        # JSON booleans are ``int`` subclasses in Python, and non-integral
+        # JSON numbers may decode to floats (including ``inf`` for a huge
+        # exponent). A context window is an integer schema field: accept an
+        # actual integer or decimal integer string and fail soft on every
+        # other shape.
+        if isinstance(value, bool):
+            continue
+        if isinstance(value, int):
+            parsed = value
+        elif isinstance(value, str):
+            try:
+                parsed = int(value)
+            except ValueError:
+                continue
+        else:
             continue
         if parsed > 0:
             return parsed


### PR DESCRIPTION
## What does this PR do?

Makes `get_model_max_context()` recover `max_position_embeddings` from the already-local checkpoint `config.json` when mlx-lm's model dataclass drops the field.

The local metadata lookup runs before `tokenizer.model_max_length`, caches immutable checkpoint metadata, handles both top-level and nested `text_config` values, accepts only positive integer schema values, and fails soft on missing, malformed, boolean, float, or non-finite values. It never resolves a Hub ID or performs network I/O.

## Why is this needed?

Closes #1084.

mlx-lm's GPT-OSS `ModelArgs` drops `max_position_embeddings`, while the tokenizer reports Hugging Face's unknown-length sentinel. Rapid-MLX consequently falls back to 4,194,304 tokens and admits requests beyond the model's physical 131,072-token window.

The reported 116,650-token prompt plus a 32,768-token completion budget was therefore admitted and spent roughly ten minutes in invalid prefill. With this change it is rejected before prefill with the existing OpenAI-compatible `context_length_exceeded` response.

## AI assistance disclosure

Codex implemented and reviewed both `vllm_mlx/service/helpers.py` and `tests/test_context_length_exceeded.py`. Codex review round 1 found that JSON booleans and non-finite numbers were not rejected; I fixed that blocking finding, added negative regression cases, and reran review to convergence with no blocking issues. I also reviewed the complete diff, ran the focused context and route suites, Ruff, and the repository PR-validation pipeline.

> By submitting this PR I confirm I can explain the intent, risk, and behavior of every non-generated change in this PR. For any generated / boilerplate / scaffolded sections, I've identified them above and can describe how I verified them.

## Test plan

- [x] `python3.12 -m pytest tests/test_context_length_exceeded.py tests/test_context_overflow_400.py tests/test_routes.py tests/test_enable_thinking_prompt_accounting.py -q` — 112 passed
- [x] `ruff check vllm_mlx/service/helpers.py tests/test_context_length_exceeded.py`
- [x] `ruff format --check vllm_mlx/service/helpers.py tests/test_context_length_exceeded.py`
- [x] Confirmed the GPT-OSS regression test fails before the production change
- [x] Full-unit validation — 12,594 passed; only failure is the pre-existing `main` baseline tracked by #1080
- [x] `python3.12 -m scripts.pr_validate 1089 -v --skip-steps full_unit` — MERGE-SAFE after the full-unit A/B classification
- [x] Codex review converged with no blocking issues

## Checklist

- [x] Focused tests pass locally
- [x] Changed-file lint and format checks pass
- [x] Self-validated with `python3.12 -m scripts.pr_validate 1089`
- [x] Regression tests fail when the local-config lookup or strict value validation is absent
- [x] README/docs not applicable; behavior restores the advertised context limit
- [x] No breaking API changes
