### PR TITLE
fix(readme): restore [vision] extra install hint (fixes test_readme_quickstart_mentions_vision_extra red since #1054)

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,8 @@ python3.12 -m pip install rapid-mlx
 
 If `pip install rapid-mlx` says "no matching distribution", your Python is too old. `brew install python@3.12` first. Upgrade with `pip install -U rapid-mlx`.
 
+For image-input / VLM models (Qwen-VL, true multimodal), install the vision extra: `pip install 'rapid-mlx[vision]'` — see [Optional extras](https://rapidmlx.com/docs/extras.html).
+
 </details>
 
 ---


### PR DESCRIPTION
## What

Restore ONE concise line in `README.md` documenting the `[vision]` opt-in extra, inside the existing **pip** `<details>` block under "Alternative install methods".

```
For image-input / VLM models (Qwen-VL, true multimodal), install the vision extra: `pip install 'rapid-mlx[vision]'` — see [Optional extras](https://rapidmlx.com/docs/extras.html).
```

## Why

The #1054 README slim (README trimmed to ~240 lines) removed the `pip install 'rapid-mlx[vision]'` mention, turning the docs-code drift guard `tests/test_vision_extra_install.py::test_readme_quickstart_mentions_vision_extra` **RED**.

That guard protects **L-07**: a fresh-venv user hitting a VL route otherwise gets a bare 500 with no install hint. The test asserts any single README line carries both `rapid-mlx` and `[vision]`.

## Link verification (feedback_readme_link_to_docs)

The line links to a **specific verified docs page**, not a bare mention:

| URL | Status |
|---|---|
| `https://rapidmlx.com/docs/multimodal.html` | 404 |
| `https://rapidmlx.com/docs/guides/multimodal.html` | 404 |
| `https://rapidmlx.com/docs/extras.html` | **200** ✅ (used) |

`extras.html` is the canonical "vision/audio/embeddings opt-in extras" page and is already linked from README line 82 for the same topic, so it's the consistent, verified home.

## Scope

- README.md only: **+2 lines** (239 → 241).
- No `pyproject.toml` change → #1088 version-check guard does not trigger. No version bump, no `skip-version-bump` label.

## Test

```
$ python3.12 -m pytest tests/test_vision_extra_install.py -x -q
11 passed in 3.15s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)