### PR TITLE
fix(pr_validate): repin codex_review to gpt-5.6-sol + PR_VALIDATE_CODEX_MODEL override

### DIFF
--- a/scripts/pr_validate/README.md
+++ b/scripts/pr_validate/README.md
@@ -245,8 +245,10 @@ malicious diff shouldn't be able to bypass review by inducing a
 crash). See "Failure-mode classification" below for the full table.
 
 Authentication: codex uses its own ChatGPT login at
-`~/.codex/auth.json`. No env var is read here; the repo is public and
-we explicitly do not want a fallback key in source.
+`~/.codex/auth.json`. No auth/API-key env var is read here; the repo is
+public and we explicitly do not want a fallback key in source. (The
+`PR_VALIDATE_CODEX_MODEL` env var documented below only selects the
+model — it carries no credentials.)
 
 Model is pinned to `gpt-5.6-sol` via the `--model` flag so a change to
 the caller's `~/.codex/config.toml` default cannot silently swap the

--- a/scripts/pr_validate/README.md
+++ b/scripts/pr_validate/README.md
@@ -232,7 +232,7 @@ must keep the runner image read-only.
 
 ### `codex_review` (step 6, runs early)
 
-Sends the diff to `codex exec` (OpenAI gpt-5.5) with the prompt
+Sends the diff to `codex exec` (OpenAI gpt-5.6-sol) with the prompt
 embedded as the `PROMPT_TEMPLATE` string constant in
 `steps/codex_review.py`. The prompt requires `[BLOCKING]`/`[NIT]`
 tiering on every finding (see "Code Review Philosophy" above). Only
@@ -248,9 +248,12 @@ Authentication: codex uses its own ChatGPT login at
 `~/.codex/auth.json`. No env var is read here; the repo is public and
 we explicitly do not want a fallback key in source.
 
-Model is pinned to `gpt-5.5` via the `--model` flag so a change to
+Model is pinned to `gpt-5.6-sol` via the `--model` flag so a change to
 the caller's `~/.codex/config.toml` default cannot silently swap the
-reviewer underneath the gate.
+reviewer underneath the gate. The `-sol` suffix is required: the bare
+`gpt-5.6` id is 400-rejected ("model not supported") under ChatGPT
+auth. Override the pin with the `PR_VALIDATE_CODEX_MODEL` env var when
+a newer generation ships or for local experimentation.
 
 `PR_VALIDATE_NO_DEEPSEEK=1` is still honored (with a one-line stderr
 deprecation notice) so CI/local workflows that pre-date the codex

--- a/scripts/pr_validate/runner.py
+++ b/scripts/pr_validate/runner.py
@@ -63,7 +63,7 @@ STEPS: list[Step] = [
     # when the diff touches dep-declaration files — see ``_test_env.py``
     # for the gate.
     TestEnvCheckStep(),
-    CodexReviewStep(),  # 6 — adversarial review (codex exec, gpt-5.5)
+    CodexReviewStep(),  # 6 — adversarial review (codex exec, gpt-5.6-sol)
     LintStep(),  # 2 — ruff check + format
     TargetedTestsStep(),  # 3 — diff-aware test selection + neg control
     FullUnitStep(),  # 4 — full pytest, gated on blast radius

--- a/scripts/pr_validate/steps/codex_review.py
+++ b/scripts/pr_validate/steps/codex_review.py
@@ -68,9 +68,17 @@ DEFAULT_CODEX_PATH = "/opt/homebrew/bin/codex"
 # Pinned model. ``codex exec`` without ``--model`` falls back to the
 # caller's ``~/.codex/config.toml`` default — which silently changes
 # the gate whenever the user (or a fresh CI machine) configures
-# something else. The README + step description promise gpt-5.5; pin
-# explicitly so the promise is mechanically enforced.
-CODEX_MODEL = "gpt-5.5"
+# something else. The README + step description promise gpt-5.6-sol;
+# pin explicitly so the promise is mechanically enforced.
+#
+# The id MUST be ``gpt-5.6-sol`` (the codex config default), NOT the
+# bare ``gpt-5.6``: under ChatGPT auth (``~/.codex/auth.json``) the
+# bare id is 400-rejected with "model not supported", so the ``-sol``
+# suffix is REQUIRED for the gpt-5.6 generation to resolve.
+#
+# Override via the ``PR_VALIDATE_CODEX_MODEL`` env var when a newer
+# generation ships or for local experimentation.
+CODEX_MODEL = os.environ.get("PR_VALIDATE_CODEX_MODEL", "gpt-5.6-sol")
 
 # Diff byte budget for the codex review prompt. Truncation always
 # happens at a file boundary; partially-cut files would produce
@@ -82,14 +90,14 @@ CODEX_MODEL = "gpt-5.5"
 # specific files getting omitted, leaving codex with only the
 # adjacent test/config/alias files. That produced "alias is live
 # but engine wiring cannot be reviewed" meta-BLOCKING findings on
-# every round, none of which were code defects. gpt-5/gpt-5.5 ship
+# every round, none of which were code defects. gpt-5/gpt-5.6 ship
 # with 200K+ token input windows; 200 KB of UTF-8 diff fits
 # comfortably even with the reviewer prompt header. If a future PR
 # is large enough to need more, prefer splitting it over bumping
 # this further — past ~200KB the model's signal-to-noise drops.
 MAX_DIFF_BYTES = 200_000
 
-# Wall-clock cap on the codex subprocess. gpt-5.5 reviews a typical
+# Wall-clock cap on the codex subprocess. gpt-5.6-sol reviews a typical
 # diff in 20–90s; complex multi-commit diffs (e.g. PR #504's 73 KB
 # diff) take 2–4 min. 10 min is generous and matches the DeepSeek
 # previous cap.
@@ -253,7 +261,7 @@ If you find no issues, say "No blocking issues found." and stop.
 
 class CodexReviewStep(Step):
     name = "codex_review"
-    description = "Codex (gpt-5.5) adversarial review of diff"
+    description = "Codex (gpt-5.6-sol) adversarial review of diff"
 
     def should_run(self, ctx: Context) -> bool:
         # Allow opt-out (offline dev, CI without codex auth, etc.).
@@ -383,14 +391,14 @@ class CodexReviewStep(Step):
                         # Pin the model explicitly so a change to the
                         # user's ``~/.codex/config.toml`` default can't
                         # silently swap reviewers underneath us. The
-                        # README + step description promise gpt-5.5.
+                        # README + step description promise gpt-5.6-sol.
                         "--model",
                         CODEX_MODEL,
                         # Force the OpenAI cloud provider for the review
                         # call. The user's config.toml may set
                         # ``model_provider = "rapid-mlx"`` for normal
                         # codex use (so codex routes to local server),
-                        # but pr_validate wants the gpt-5.5 cloud model
+                        # but pr_validate wants the gpt-5.6-sol cloud model
                         # talking through OpenAI, not the local mlx
                         # server. Without this override, codex tries to
                         # refresh /models against the rapid-mlx server

--- a/scripts/pr_validate/steps/codex_review.py
+++ b/scripts/pr_validate/steps/codex_review.py
@@ -261,7 +261,12 @@ If you find no issues, say "No blocking issues found." and stop.
 
 class CodexReviewStep(Step):
     name = "codex_review"
-    description = "Codex (gpt-5.6-sol) adversarial review of diff"
+
+    @property
+    def description(self) -> str:  # type: ignore[override]
+        # Report the effective model (respects PR_VALIDATE_CODEX_MODEL)
+        # so verbose logs / scorecards name the reviewer actually used.
+        return f"Codex ({CODEX_MODEL}) adversarial review of diff"
 
     def should_run(self, ctx: Context) -> bool:
         # Allow opt-out (offline dev, CI without codex auth, etc.).

--- a/scripts/pr_validate/steps/codex_review.py
+++ b/scripts/pr_validate/steps/codex_review.py
@@ -81,7 +81,9 @@ DEFAULT_CODEX_PATH = "/opt/homebrew/bin/codex"
 # whitespace-only override falls back to the default rather than
 # passing ``--model ""`` (which codex rejects with an opaque error).
 _DEFAULT_CODEX_MODEL = "gpt-5.6-sol"
-CODEX_MODEL = os.environ.get("PR_VALIDATE_CODEX_MODEL", "").strip() or _DEFAULT_CODEX_MODEL
+CODEX_MODEL = (
+    os.environ.get("PR_VALIDATE_CODEX_MODEL", "").strip() or _DEFAULT_CODEX_MODEL
+)
 
 # Diff byte budget for the codex review prompt. Truncation always
 # happens at a file boundary; partially-cut files would produce

--- a/scripts/pr_validate/steps/codex_review.py
+++ b/scripts/pr_validate/steps/codex_review.py
@@ -77,8 +77,11 @@ DEFAULT_CODEX_PATH = "/opt/homebrew/bin/codex"
 # suffix is REQUIRED for the gpt-5.6 generation to resolve.
 #
 # Override via the ``PR_VALIDATE_CODEX_MODEL`` env var when a newer
-# generation ships or for local experimentation.
-CODEX_MODEL = os.environ.get("PR_VALIDATE_CODEX_MODEL", "gpt-5.6-sol")
+# generation ships or for local experimentation. An empty or
+# whitespace-only override falls back to the default rather than
+# passing ``--model ""`` (which codex rejects with an opaque error).
+_DEFAULT_CODEX_MODEL = "gpt-5.6-sol"
+CODEX_MODEL = os.environ.get("PR_VALIDATE_CODEX_MODEL", "").strip() or _DEFAULT_CODEX_MODEL
 
 # Diff byte budget for the codex review prompt. Truncation always
 # happens at a file boundary; partially-cut files would produce

--- a/tests/test_pr_validate_codex.py
+++ b/tests/test_pr_validate_codex.py
@@ -321,6 +321,23 @@ class TestModelPinning:
     the ``-sol`` suffix is required.
     """
 
+    @pytest.fixture(autouse=True)
+    def _restore_module_state(self):
+        """Reload ``codex_review`` under the ambient (real) env after each
+        test so a test that mutates ``PR_VALIDATE_CODEX_MODEL`` + reloads
+        can't leak a stale module-level ``CODEX_MODEL`` into later tests.
+        Reloading (rather than restoring a captured value) also rebinds
+        the ``@property`` and every other module global consistently.
+        """
+        import importlib
+
+        import scripts.pr_validate.steps.codex_review as _cr
+
+        try:
+            yield
+        finally:
+            importlib.reload(_cr)
+
     def test_codex_model_constant_matches_documented(self, monkeypatch):
         # Default (no override) must be the pinned gpt-5.6-sol id.
         monkeypatch.delenv("PR_VALIDATE_CODEX_MODEL", raising=False)
@@ -330,9 +347,6 @@ class TestModelPinning:
 
         importlib.reload(_cr)
         assert _cr.CODEX_MODEL == "gpt-5.6-sol"
-        # Reload once more so module state reflects the ambient env for
-        # any later tests importing the same module object.
-        importlib.reload(_cr)
 
     def test_codex_model_env_override(self, monkeypatch):
         monkeypatch.setenv("PR_VALIDATE_CODEX_MODEL", "gpt-6.0-sol")
@@ -341,11 +355,7 @@ class TestModelPinning:
         import scripts.pr_validate.steps.codex_review as _cr
 
         importlib.reload(_cr)
-        try:
-            assert _cr.CODEX_MODEL == "gpt-6.0-sol"
-        finally:
-            monkeypatch.delenv("PR_VALIDATE_CODEX_MODEL", raising=False)
-            importlib.reload(_cr)
+        assert _cr.CODEX_MODEL == "gpt-6.0-sol"
 
     def test_codex_command_includes_explicit_model_flag(self, monkeypatch, tmp_path):
         """Drive the step with a fake ``codex`` binary that records the

--- a/tests/test_pr_validate_codex.py
+++ b/tests/test_pr_validate_codex.py
@@ -231,7 +231,7 @@ class TestParseCodexJsonl:
         assert usage == {"input_tokens": 100, "output_tokens": 20}
 
     def test_concatenates_multiple_agent_messages_in_order(self):
-        """gpt-5.5 streams in chunks; the parser must keep order."""
+        """gpt-5.6-sol streams in chunks; the parser must keep order."""
         stdout = self._stream(
             {
                 "type": "item.completed",
@@ -311,14 +311,41 @@ class TestParseCodexJsonl:
 
 
 class TestModelPinning:
-    """The README + step description promise ``gpt-5.5``; the
+    """The README + step description promise ``gpt-5.6-sol``; the
     invocation must pass ``--model`` explicitly so a change to the
     caller's ``~/.codex/config.toml`` default can't silently swap the
     reviewer underneath the gate (codex round-1 BLOCKER on PR #505).
+
+    ``gpt-5.6-sol`` is the default; ``PR_VALIDATE_CODEX_MODEL`` overrides
+    it. The bare ``gpt-5.6`` id is 400-rejected under ChatGPT auth, so
+    the ``-sol`` suffix is required.
     """
 
-    def test_codex_model_constant_matches_documented(self):
-        assert CODEX_MODEL == "gpt-5.5"
+    def test_codex_model_constant_matches_documented(self, monkeypatch):
+        # Default (no override) must be the pinned gpt-5.6-sol id.
+        monkeypatch.delenv("PR_VALIDATE_CODEX_MODEL", raising=False)
+        import importlib
+
+        import scripts.pr_validate.steps.codex_review as _cr
+
+        importlib.reload(_cr)
+        assert _cr.CODEX_MODEL == "gpt-5.6-sol"
+        # Reload once more so module state reflects the ambient env for
+        # any later tests importing the same module object.
+        importlib.reload(_cr)
+
+    def test_codex_model_env_override(self, monkeypatch):
+        monkeypatch.setenv("PR_VALIDATE_CODEX_MODEL", "gpt-6.0-sol")
+        import importlib
+
+        import scripts.pr_validate.steps.codex_review as _cr
+
+        importlib.reload(_cr)
+        try:
+            assert _cr.CODEX_MODEL == "gpt-6.0-sol"
+        finally:
+            monkeypatch.delenv("PR_VALIDATE_CODEX_MODEL", raising=False)
+            importlib.reload(_cr)
 
     def test_codex_command_includes_explicit_model_flag(self, monkeypatch, tmp_path):
         """Drive the step with a fake ``codex`` binary that records the

--- a/tests/test_pr_validate_codex.py
+++ b/tests/test_pr_validate_codex.py
@@ -356,6 +356,21 @@ class TestModelPinning:
 
         importlib.reload(_cr)
         assert _cr.CODEX_MODEL == "gpt-6.0-sol"
+        # The step description must report the *effective* model, not a
+        # stale default, so scorecards/logs name the real reviewer.
+        assert "gpt-6.0-sol" in _cr.CodexReviewStep().description
+
+    def test_codex_model_blank_override_falls_back_to_default(self, monkeypatch):
+        # An empty / whitespace-only override must not become ``--model
+        # ""``; it falls back to the pinned default.
+        import importlib
+
+        import scripts.pr_validate.steps.codex_review as _cr
+
+        for blank in ("", "   ", "\t"):
+            monkeypatch.setenv("PR_VALIDATE_CODEX_MODEL", blank)
+            importlib.reload(_cr)
+            assert _cr.CODEX_MODEL == "gpt-5.6-sol"
 
     def test_codex_command_includes_explicit_model_flag(self, monkeypatch, tmp_path):
         """Drive the step with a fake ``codex`` binary that records the


### PR DESCRIPTION
## Why

The codex_review step hard-pinned the adversarial reviewer to `CODEX_MODEL = "gpt-5.5"`. Per raullen's 2026-07-09 directive, the codex reviewer must use the **gpt-5.6 generation**. This PR repins it because leaving it on gpt-5.5 keeps every future PR reviewed by the wrong (older) model, and there was no runtime escape hatch to point it at a newer generation without editing source.

**Critical id fact:** the bare id `gpt-5.6` is 400-rejected ("model not supported") under ChatGPT auth (`~/.codex/auth.json`). The valid gpt-5.6-generation id is **`gpt-5.6-sol`** (the codex config default), so the `-sol` suffix is **required**.

## What

- **`codex_review.py`** — `CODEX_MODEL` is now env-overridable: `os.environ.get("PR_VALIDATE_CODEX_MODEL", "gpt-5.6-sol")`. Updated the pin comment block (documents the `-sol` requirement + the override env var), the wall-clock comment, the input-window comment, and the provider-override comment. The `Step.description` is now a property so verbose logs/scorecards report the *effective* model (respects the override).
- **`runner.py`** — step comment `gpt-5.5` → `gpt-5.6-sol`.
- **`README.md`** — model-pin paragraph now documents the `gpt-5.6-sol` default, the `-sol` requirement, and the `PR_VALIDATE_CODEX_MODEL` override; auth paragraph clarified so it no longer contradicts the new model-select env var.

`import os` was already present at the top of the file — no new import.

## Self-validation

When pr_validate runs on this PR, its `codex_review` step imports the **modified** `codex_review.py` from this branch, so codex runs on `gpt-5.6-sol` — self-proving the new pin. (First run: codex_review PASS in 29.1s, no auth error, which confirms gpt-5.6-sol resolves and works.)

## Scope / guardrails

- No `pyproject.toml` change, because the version-check gate (#1088) only watches that file → it won't fire. No version bump, no `skip-version-bump` label.
- Dev-infra only; does not touch `vllm_mlx/spec_decode/**` or `vllm_mlx/speculative/**`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)