### PR TITLE
feat(aliases): add bonsai-1.7b-2bit ternary alias, drop FP16 unpacked bonsai

### DIFF
--- a/scripts/rename_map.json
+++ b/scripts/rename_map.json
@@ -1,7 +1,5 @@
 {
-  "bonsai-1.7b": "bonsai-1.7b-unpacked",
-  "bonsai-4b": "bonsai-4b-unpacked",
-  "bonsai-8b": "bonsai-8b-unpacked",
+  "bonsai-1.7b": "bonsai-1.7b-2bit",
   "deepseek-r1-32b": "deepseek-r1-32b-4bit",
   "deepseek-r1-8b": "deepseek-r1-8b-4bit",
   "deepseek-v4-flash": "deepseek-v4-flash-8bit",

--- a/tests/test_aliases_contract.py
+++ b/tests/test_aliases_contract.py
@@ -615,45 +615,86 @@ def test_audit_batch_reasoning_parser_wirings() -> None:
         )
 
 
-def test_bonsai_family_wires_glm4_reasoning_parser() -> None:
-    """The Bonsai chat template (verified at
-    https://huggingface.co/prism-ml/Bonsai-1.7B-unpacked/resolve/main/chat_template.jinja)
-    injects an empty ``<think>\\n\\n</think>`` block when
-    ``add_generation_prompt=True`` — the model's actual output stream
-    then contains only content, no tags. The base class' "no tags
-    yet, treat as reasoning" default would misclassify every Bonsai
-    token; the ``glm4`` parser overrides exactly that branch.
+def test_bonsai_ternary_alias_wiring() -> None:
+    """The Bonsai first-run candidate is the **ternary** (1.58-bit,
+    MLX-2bit-packed) checkpoint ``prism-ml/Ternary-Bonsai-1.7B-mlx-2bit``
+    — a ``Qwen3ForCausalLM`` at ~0.5 GB. Dogfooded 2026-07-10 through the
+    OpenAI server: multi-turn recall PASS and tool-call 6/6 clean with the
+    ``hermes`` parser (the model emits ``<tool_call>...</tool_call>``
+    blocks).
 
-    If a downstream user enables thinking via ``reasoning_content``
-    on a prior assistant turn, the model may emit real
-    ``<think>...</think>`` blocks; the same glm4 parser splits those
-    correctly. Net effect: glm4 is strictly safer than null with
-    zero behavioural downside for non-thinking turns.
+    ``reasoning_parser`` is ``None`` on purpose. This checkpoint is a
+    NON-THINKING Qwen3 variant — its packed chat template never emits
+    ``<think>...</think>`` blocks (there is no working ``enable_thinking``
+    toggle). Wiring the ``qwen3`` reasoning parser on such a model
+    DUPLICATES the whole answer into BOTH ``content`` and
+    ``reasoning_content`` when a client passes ``enable_thinking=True``
+    (same class as ``test_qwen3_non_thinking_variants`` / PR #715 fuzz
+    finding A) — verified live on this checkpoint. ``None`` keeps every
+    turn's output in ``content`` with no duplication.
+
+    The earlier ``bonsai-*-unpacked`` aliases pointed at the FP16
+    DECOMPRESSED repos (``prism-ml/Bonsai-*-unpacked``), which the vendor
+    documents as "loses all compression benefits" — they discarded the
+    entire point of Bonsai and are removed. The loop below guards that no
+    alias resurrects an ``-unpacked`` repo.
     """
-    profiles = list_profiles()
-    for alias in ("bonsai-1.7b-unpacked", "bonsai-4b-unpacked", "bonsai-8b-unpacked"):
-        assert alias in profiles, f"{alias} missing from aliases.json"
-        assert profiles[alias].reasoning_parser == "glm4", (
-            f"{alias}: reasoning_parser must be 'glm4' per audit. "
-            f"Got {profiles[alias].reasoning_parser!r}."
+    raw = _raw_aliases()
+    alias = "bonsai-1.7b-2bit"
+    assert alias in raw, f"{alias} missing from aliases.json"
+    p = list_profiles()[alias]
+    assert p.hf_path == "prism-ml/Ternary-Bonsai-1.7B-mlx-2bit", (
+        f"{alias}: must point at the ternary MLX-2bit repo, got {p.hf_path!r}."
+    )
+    assert p.tool_call_parser == "hermes", (
+        f"{alias}: tool_call_parser must be 'hermes' (model emits "
+        f"<tool_call> blocks). Got {p.tool_call_parser!r}."
+    )
+    assert p.reasoning_parser is None, (
+        f"{alias}: reasoning_parser must be None — a non-thinking Qwen3 "
+        f"variant; qwen3 here duplicates content into reasoning_content. "
+        f"Got {p.reasoning_parser!r}."
+    )
+    assert p.is_hybrid is False
+    # Explicit non-hybrid pin suppresses the runtime ArraysCache
+    # auto-promotion; spec-decode is off (no verified drafter).
+    assert raw[alias].get("is_hybrid_explicit") is True, (
+        f"{alias}: is_hybrid_explicit must be true to pin non-hybrid."
+    )
+    assert p.supports_spec_decode is False
+
+    # The three FP16 ``bonsai-*-unpacked`` aliases are gone, and no alias
+    # may resurrect an ``-unpacked`` repo (they lose all compression).
+    assert not any(k.startswith("bonsai-") and k.endswith("-unpacked") for k in raw), (
+        "an FP16 bonsai-*-unpacked alias was reintroduced"
+    )
+    for name, entry in raw.items():
+        hf = entry.get("hf_path") if isinstance(entry, dict) else entry
+        assert not (isinstance(hf, str) and hf.endswith("-unpacked")), (
+            f"{name}: resolves to an FP16 unpacked repo {hf!r} — use the "
+            f"Ternary-*-mlx-2bit checkpoint instead."
         )
 
 
-def test_audit_batch_bonsai_tool_call_parser_wired() -> None:
-    """Pin the Model Onboarding SOP audit fix for the Bonsai family.
-    The chat template emits ``<tool_call>...</tool_call>`` blocks
-    (hermes pattern); leaving ``tool_call_parser=null`` made every
-    tool call land in ``message.content`` as plain text. Verified the
-    template format directly against
-    https://huggingface.co/prism-ml/Bonsai-1.7B-unpacked.
-    """
+def test_rename_map_targets_are_live_aliases() -> None:
+    """``scripts/rename_map.json`` canonicalizes legacy bare alias names to
+    the current explicit aliases and is consumed by ``sweep_alias_refs.py``
+    to rewrite references repo-wide. Every target MUST be a live alias — a
+    dangling target (e.g. left behind when an alias is deleted) makes the
+    sweep rewrite references to a NON-EXISTENT model. Regression guard for
+    the ``bonsai-*-unpacked`` removal (the three legacy ``bonsai-*`` names
+    used to point at the now-deleted unpacked aliases)."""
+    rename_map = json.loads(
+        (
+            Path(__file__).resolve().parents[1] / "scripts" / "rename_map.json"
+        ).read_text()
+    )
     profiles = list_profiles()
-    for alias in ("bonsai-1.7b-unpacked", "bonsai-4b-unpacked", "bonsai-8b-unpacked"):
-        assert alias in profiles, f"{alias} missing from aliases.json"
-        assert profiles[alias].tool_call_parser == "hermes", (
-            f"{alias}: tool_call_parser must be 'hermes' per audit. "
-            f"Got {profiles[alias].tool_call_parser!r}."
-        )
+    dangling = {old: new for old, new in rename_map.items() if new not in profiles}
+    assert not dangling, (
+        f"rename_map.json targets missing from aliases.json: {dangling}. "
+        f"Point each at a live alias or remove the entry."
+    )
 
 
 def test_deepseek_v4_flash_family_wires_deepseek_r1_reasoning_parser() -> None:

--- a/tests/test_model_profiles_ssot.py
+++ b/tests/test_model_profiles_ssot.py
@@ -80,12 +80,14 @@ def test_no_orphan_aliases() -> None:
 
 
 def test_orphan_aliases_now_covered() -> None:
-    """Pin the 6 specific aliases that were orphans before this PR to
-    catch a regression where someone deletes their profile."""
+    """Pin the specific aliases that were orphans before the SSOT PR to
+    catch a regression where someone deletes their profile.
+
+    The three ``bonsai-*-unpacked`` entries (FP16 decompressed repos) were
+    removed in favour of the ternary ``bonsai-1.7b-2bit`` checkpoint, which
+    must itself resolve — so it takes their slot in this guard."""
     for orphan in (
-        "bonsai-1.7b-unpacked",
-        "bonsai-4b-unpacked",
-        "bonsai-8b-unpacked",
+        "bonsai-1.7b-2bit",
         "ministral-3b-4bit",
         "nemotron-30b-4bit",
     ):

--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -1266,45 +1266,13 @@
     "supports_spec_decode": false,
     "is_moe": true
   },
-  "bonsai-1.7b-unpacked": {
-    "hf_path": "prism-ml/Bonsai-1.7B-unpacked",
+  "bonsai-1.7b-2bit": {
+    "hf_path": "prism-ml/Ternary-Bonsai-1.7B-mlx-2bit",
     "tool_call_parser": "hermes",
-    "reasoning_parser": "glm4",
+    "reasoning_parser": null,
     "is_hybrid": false,
-    "supports_spec_decode": true,
-    "suffix_decoding_tier": "avoid",
-    "suffix_bench_speedup": {
-      "chat": 0.713,
-      "json_array": 1.304,
-      "tool_loop": 0.884,
-      "code_edit": 1.051
-    }
-  },
-  "bonsai-4b-unpacked": {
-    "hf_path": "prism-ml/Bonsai-4B-unpacked",
-    "tool_call_parser": "hermes",
-    "reasoning_parser": "glm4",
-    "is_hybrid": false,
-    "supports_spec_decode": true,
-    "suffix_decoding_tier": "avoid",
-    "suffix_bench_speedup": {
-      "chat": 0.732,
-      "json_array": 0.799,
-      "code_edit": 1.012
-    }
-  },
-  "bonsai-8b-unpacked": {
-    "hf_path": "prism-ml/Bonsai-8B-unpacked",
-    "tool_call_parser": "hermes",
-    "reasoning_parser": "glm4",
-    "is_hybrid": false,
-    "supports_spec_decode": true,
-    "suffix_decoding_tier": "avoid",
-    "suffix_bench_speedup": {
-      "chat": 0.78,
-      "json_array": 1.268,
-      "code_edit": 1.181
-    }
+    "is_hybrid_explicit": true,
+    "supports_spec_decode": false
   },
   "smollm3-3b-4bit": {
     "hf_path": "mlx-community/SmolLM3-3B-4bit",


### PR DESCRIPTION
## Why

Bonsai's **ternary** line (`prism-ml/Ternary-Bonsai-*-mlx-2bit`) is a genuinely-good extreme-low-bit model that runs on **stock mlx-lm** (a `Qwen3ForCausalLM` packed as MLX 2-bit). At **~0.5 GB** the 1.7B is a compelling small first-run / bootstrap model for the desktop app.

We already shipped `bonsai-*-unpacked` aliases, but those point at the FP16 **decompressed** repos (`prism-ml/Bonsai-*-unpacked`), which the vendor documents as *"loses all compression benefits"* — they throw away the entire point of Bonsai. This replaces them with the real compressed checkpoint.

## Dogfood evidence (this machine, OpenAI server, BatchedEngine, stock mlx-lm 0.31.3)

`Ternary-Bonsai-1.7B-mlx-2bit` (0.50 GB download, ~0.80 GB process RSS):

| probe | result |
|---|---|
| multi-turn recall (4 turns + distractor) | ✅ PASS |
| tool-call, N=6 (standard tool preamble) | ✅ **6/6 clean** `web_search` + valid JSON args, zero leaks |
| GSM8K / instruction-format / anti-hallucination / palindrome | ✅ all correct |
| throughput | 92–267 tok/s |

## Changes

- **`aliases.json`**: add `bonsai-1.7b-2bit` → `prism-ml/Ternary-Bonsai-1.7B-mlx-2bit` (`tool_call_parser: hermes`, `reasoning_parser: null`, `is_hybrid: false`, `is_hybrid_explicit: true`, `supports_spec_decode: false`); remove the three `bonsai-*-unpacked` aliases.
- **`scripts/rename_map.json`**: repoint the legacy `bonsai-1.7b` target at the new alias; drop the orphaned `bonsai-4b`/`bonsai-8b` entries (their targets are deleted).
- **Tests**: replace the two unpacked-family contract tests with one that pins the new alias wiring + a no-`-unpacked` guard; add a guard that every `rename_map.json` target resolves to a live alias; update the SSOT orphan-coverage list.

No version bump — per the Version bump guard (G4), feature PRs must not touch the version line; the release is cut separately.

### `reasoning_parser` is `null` on purpose

This is a **non-thinking** Qwen3 variant — its packed chat template never emits `<think>` blocks (no working `enable_thinking` toggle). Wiring the `qwen3` reasoning parser **duplicates** the whole answer into both `content` and `reasoning_content` when a client sends `enable_thinking=True` (same class as `test_qwen3_non_thinking_variants` / PR #715 fuzz finding A) — **verified live on this checkpoint** (content == reasoning_content before the fix; `reasoning_content=null` after). `null` keeps output in `content` only.

## Verified locally

- Alias resolves end-to-end: `/v1/models` reports `tool_call_parser=hermes, reasoning_parser=None`, `capabilities=[text, tools]`; `enable_thinking=True` no longer duplicates content.
- `test_aliases_contract.py` + `test_model_profiles_ssot.py` + `test_model_auto_config.py`: 2590 passed. `ruff check` / `ruff format` clean.

## Addressed in review (codex → converged 0 BLOCKING / 0 MAJOR)

- **MAJOR** reasoning duplication under `enable_thinking=True` → `reasoning_parser` set to `null` (verified live).
- **MAJOR** stale `rename_map.json` targets → repointed/removed + new live-target guard test.
- **MINOR** weak contract assertions → now assert `is_hybrid_explicit`, `supports_spec_decode`, exact `-unpacked` removal.

## Follow-ups (not in this PR)

- R2-mirror the chosen repo for the desktop first-run download path.
- Optionally validate + add 4B (1.14 GB) as the "one tier up" upgrade target, and 8B (2.32 GB, already dogfooded 6/6) as the quality tier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)