### PR TITLE
fix(gpt-oss): honor --no-thinking in Harmony chat prompts

### DIFF
--- a/tests/test_engine_router_non_stream.py
+++ b/tests/test_engine_router_non_stream.py
@@ -37,7 +37,11 @@ from __future__ import annotations
 
 import pytest
 
-from vllm_mlx.engine.batched import BatchedEngine
+from vllm_mlx.engine.base import GenerationOutput
+from vllm_mlx.engine.batched import (
+    _HARMONY_NO_THINKING_SUFFIX_TOKENS,
+    BatchedEngine,
+)
 
 
 class _FakeTokenizer:
@@ -50,6 +54,22 @@ class _FakeTokenizer:
 
     def get_vocab(self) -> dict[str, int]:
         return self._vocab
+
+    def convert_tokens_to_ids(self, token: str):
+        return self._vocab.get(token)
+
+    def encode(self, text: str, add_special_tokens=True):  # noqa: ARG002
+        """Greedy literal-token encoder for prompt-prefix tests."""
+        tokens = sorted(self._vocab, key=len, reverse=True)
+        ids: list[int] = []
+        cursor = 0
+        while cursor < len(text):
+            token = next((t for t in tokens if text.startswith(t, cursor)), None)
+            if token is None:
+                raise ValueError(f"no fake token at offset {cursor}: {text!r}")
+            ids.append(self._vocab[token])
+            cursor += len(token)
+        return ids
 
     def decode(self, ids):
         return "".join(self._id_to_text.get(i, f"<UNK:{i}>") for i in ids)
@@ -86,6 +106,181 @@ def engine() -> BatchedEngine:
     eng._is_mllm = False
     eng._tokenizer = _FakeTokenizer(_HARMONY_VOCAB)
     return eng
+
+
+def test_harmony_no_thinking_builds_token_level_final_channel_prompt(engine):
+    prompt = "<|start|>assistant"
+    prepared, seed = engine._prepare_harmony_no_thinking_prompt(
+        prompt,
+        enable_thinking=False,
+        has_tools=False,
+        as_token_ids=True,
+    )
+
+    expected_seed = tuple(
+        _HARMONY_VOCAB[token] for token in _HARMONY_NO_THINKING_SUFFIX_TOKENS
+    )
+    assert seed == expected_seed
+    assert prepared == [
+        _HARMONY_VOCAB["<|start|>"],
+        _HARMONY_VOCAB["assistant"],
+        *expected_seed,
+    ]
+
+
+@pytest.mark.parametrize(
+    ("enable_thinking", "has_tools"),
+    [(True, False), (None, False), (False, True)],
+)
+def test_harmony_no_thinking_preserves_ineligible_prompts(
+    engine, enable_thinking, has_tools
+):
+    prompt = "<|start|>assistant"
+    prepared, seed = engine._prepare_harmony_no_thinking_prompt(
+        prompt,
+        enable_thinking=enable_thinking,
+        has_tools=has_tools,
+        as_token_ids=True,
+    )
+    assert prepared == prompt
+    assert seed is None
+
+
+def test_harmony_no_thinking_preserves_noncanonical_template_boundary(engine):
+    prompt = "Plain"
+    prepared, seed = engine._prepare_harmony_no_thinking_prompt(
+        prompt,
+        enable_thinking=False,
+        has_tools=False,
+        as_token_ids=True,
+    )
+    assert prepared == prompt
+    assert seed is None
+
+
+def test_harmony_no_thinking_fails_closed_when_token_lookup_raises(engine, monkeypatch):
+    monkeypatch.setattr(
+        engine.tokenizer,
+        "convert_tokens_to_ids",
+        lambda _token: (_ for _ in ()).throw(ValueError("unsupported token")),
+    )
+    prompt = "<|start|>assistant"
+    prepared, seed = engine._prepare_harmony_no_thinking_prompt(
+        prompt,
+        enable_thinking=False,
+        has_tools=False,
+        as_token_ids=True,
+    )
+    assert prepared == prompt
+    assert seed is None
+
+
+def test_build_prompt_accounts_for_harmony_no_thinking_suffix(engine, monkeypatch):
+    monkeypatch.setattr(
+        engine,
+        "_apply_chat_template",
+        lambda *args, **kwargs: "<|start|>assistant",
+    )
+    prompt = engine.build_prompt(
+        [{"role": "user", "content": "hello"}],
+        enable_thinking=False,
+    )
+    assert prompt == "<|start|>assistant" + "".join(_HARMONY_NO_THINKING_SUFFIX_TOKENS)
+
+
+@pytest.mark.asyncio
+async def test_chat_forwards_token_prompt_and_router_seed(engine, monkeypatch):
+    monkeypatch.setattr(
+        engine,
+        "_apply_chat_template",
+        lambda *args, **kwargs: "<|start|>assistant",
+    )
+    captured = {}
+
+    async def _generate(**kwargs):
+        captured.update(kwargs)
+        return GenerationOutput(text="Plain", finish_reason="stop")
+
+    monkeypatch.setattr(engine, "generate", _generate)
+    await engine.chat(
+        [{"role": "user", "content": "hello"}],
+        enable_thinking=False,
+    )
+
+    expected_seed = tuple(
+        _HARMONY_VOCAB[token] for token in _HARMONY_NO_THINKING_SUFFIX_TOKENS
+    )
+    assert captured["prompt"][-len(expected_seed) :] == list(expected_seed)
+    assert captured["_output_router_seed_token_ids"] == expected_seed
+
+
+@pytest.mark.asyncio
+async def test_stream_chat_primes_router_for_prompt_opened_final_channel(
+    engine, monkeypatch
+):
+    monkeypatch.setattr(
+        engine,
+        "_apply_chat_template",
+        lambda *args, **kwargs: "<|start|>assistant",
+    )
+    captured = {}
+
+    async def _stream_generate(**kwargs):
+        captured.update(kwargs)
+        yield GenerationOutput(
+            text="Plain",
+            new_text="Plain",
+            tokens=[_HARMONY_VOCAB["Plain"]],
+            finished=True,
+            finish_reason="stop",
+        )
+
+    monkeypatch.setattr(engine, "stream_generate", _stream_generate)
+    outputs = [
+        output
+        async for output in engine.stream_chat(
+            [{"role": "user", "content": "hello"}],
+            enable_thinking=False,
+        )
+    ]
+
+    expected_seed = tuple(
+        _HARMONY_VOCAB[token] for token in _HARMONY_NO_THINKING_SUFFIX_TOKENS
+    )
+    assert captured["prompt"][-len(expected_seed) :] == list(expected_seed)
+    assert any(
+        output.channel == "content" and output.new_text == "Plain" for output in outputs
+    )
+
+
+def test_nonstream_router_is_primed_with_prompt_channel_state(engine, monkeypatch):
+    seed = (200005, 35644, 200008, 200007)
+
+    class _SeedRecordingRouter:
+        def __init__(self):
+            self.seen = []
+
+        def reset(self):
+            self.seen.clear()
+
+        def feed(self, token_id):
+            self.seen.append(token_id)
+            return None
+
+        def feed_sequence(self, token_ids):
+            assert self.seen == list(seed)
+            assert token_ids == [4]
+            return {"content": "Plain", "reasoning": None, "tool_calls": None}
+
+    monkeypatch.setattr(engine, "_create_output_router", _SeedRecordingRouter)
+    reasoning, content, tool_calls = engine._route_tokens_for_channels(
+        [4],
+        fallback_text="Plain",
+        seed_token_ids=seed,
+    )
+    assert reasoning == ""
+    assert content == "Plain"
+    assert tool_calls is None
 
 
 def test_truncated_analysis_drops_content_and_recovers_reasoning(engine):

--- a/tests/test_engine_router_non_stream.py
+++ b/tests/test_engine_router_non_stream.py
@@ -215,6 +215,42 @@ async def test_chat_forwards_token_prompt_and_router_seed(engine, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_generate_recovers_router_seed_from_build_prompt(engine, monkeypatch):
+    expected_seed = tuple(
+        _HARMONY_VOCAB[token] for token in _HARMONY_NO_THINKING_SUFFIX_TOKENS
+    )
+
+    class _CoreOutput:
+        output_text = "Plain"
+        output_token_ids = [_HARMONY_VOCAB["Plain"]]
+        prompt_tokens = 1
+        completion_tokens = 1
+        cached_tokens = 0
+        finish_reason = "stop"
+
+    class _Core:
+        async def generate(self, **_kwargs):
+            return _CoreOutput()
+
+    captured = {}
+
+    def _route(token_ids, *, fallback_text, seed_token_ids=None):
+        captured["token_ids"] = token_ids
+        captured["fallback_text"] = fallback_text
+        captured["seed_token_ids"] = seed_token_ids
+        return "", fallback_text, None
+
+    engine._engine = _Core()
+    monkeypatch.setattr(engine, "_route_tokens_for_channels", _route)
+    prepared_prompt = "<|start|>assistant" + "".join(_HARMONY_NO_THINKING_SUFFIX_TOKENS)
+
+    output = await engine.generate(prepared_prompt)
+
+    assert output.text == "Plain"
+    assert captured["seed_token_ids"] == expected_seed
+
+
+@pytest.mark.asyncio
 async def test_stream_chat_primes_router_for_prompt_opened_final_channel(
     engine, monkeypatch
 ):

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -27,6 +27,25 @@ from .base import BaseEngine, GenerationOutput
 
 logger = logging.getLogger(__name__)
 
+# Harmony's chat template ends its generation prompt immediately after
+# ``<|start|>assistant`` and expects the model to choose a channel. When
+# thinking is disabled, seed an empty analysis message followed by an open
+# final message. These are resolved to token IDs from the loaded tokenizer;
+# they never pass through user-controlled message content or the template
+# sanitizer.
+_HARMONY_ASSISTANT_PREFIX_TOKENS = ("<|start|>", "assistant")
+_HARMONY_NO_THINKING_SUFFIX_TOKENS = (
+    "<|channel|>",
+    "analysis",
+    "<|message|>",
+    "<|end|>",
+    "<|start|>",
+    "assistant",
+    "<|channel|>",
+    "final",
+    "<|message|>",
+)
+
 
 def _resolve_hf_model_type(model_name: str) -> str | None:
     """Best-effort read of ``config.json::model_type`` for ``model_name``.
@@ -1273,6 +1292,92 @@ class BatchedEngine(BaseEngine):
         self._engine_started = False
         logger.info("BatchedEngine stopped")
 
+    def _prepare_harmony_no_thinking_prompt(
+        self,
+        prompt: str,
+        *,
+        enable_thinking: bool | None,
+        has_tools: bool,
+        as_token_ids: bool,
+    ) -> tuple[str | list[int], tuple[int, ...] | None]:
+        """Open Harmony's final channel when thinking is disabled.
+
+        GPT-OSS ignores the generic ``enable_thinking`` template kwarg. Its
+        protocol instead requires an empty analysis message followed by an
+        open final message. Build that continuation from tokenizer-owned IDs
+        after template rendering so Harmony control markers are structural
+        tokens, never user text.
+
+        Tool requests are excluded: Harmony tool calls are emitted through
+        the commentary channel and forcing final would make them impossible.
+        Non-Harmony or non-canonical templates fail closed to the unchanged
+        string prompt.
+
+        Returns the generation/accounting prompt and the suffix IDs used to
+        prime the output router into the same open-final state.
+        """
+        if enable_thinking is not False or has_tools or self._is_mllm:
+            return prompt, None
+
+        tokenizer = self.tokenizer
+        convert = getattr(tokenizer, "convert_tokens_to_ids", None)
+        encode = getattr(tokenizer, "encode", None)
+        if not callable(convert) or not callable(encode):
+            return prompt, None
+
+        unk_id = getattr(tokenizer, "unk_token_id", None)
+
+        def _ids_for(tokens: tuple[str, ...]) -> tuple[int, ...] | None:
+            ids: list[int] = []
+            for token in tokens:
+                try:
+                    token_id = convert(token)
+                except Exception:
+                    logger.debug(
+                        "Harmony no-thinking token lookup failed for %r",
+                        token,
+                        exc_info=True,
+                    )
+                    return None
+                if (
+                    not isinstance(token_id, int)
+                    or isinstance(token_id, bool)
+                    or token_id < 0
+                    or token_id == unk_id
+                ):
+                    return None
+                ids.append(token_id)
+            return tuple(ids)
+
+        assistant_prefix_ids = _ids_for(_HARMONY_ASSISTANT_PREFIX_TOKENS)
+        suffix_ids = _ids_for(_HARMONY_NO_THINKING_SUFFIX_TOKENS)
+        if assistant_prefix_ids is None or suffix_ids is None:
+            return prompt, None
+
+        bos = getattr(tokenizer, "bos_token", None)
+        add_special_tokens = bos is None or not prompt.startswith(bos)
+        try:
+            prompt_ids = list(encode(prompt, add_special_tokens=add_special_tokens))
+        except Exception:
+            logger.debug(
+                "Harmony no-thinking prompt tokenization failed",
+                exc_info=True,
+            )
+            return prompt, None
+
+        # Canonical GPT-OSS templates end at ``<|start|>assistant``. Refuse
+        # to inject into a custom template with a different boundary.
+        if tuple(prompt_ids[-len(assistant_prefix_ids) :]) != assistant_prefix_ids:
+            logger.debug(
+                "Harmony no-thinking skipped: generation prompt does not end "
+                "with <|start|>assistant"
+            )
+            return prompt, None
+
+        if as_token_ids:
+            return [*prompt_ids, *suffix_ids], suffix_ids
+        return prompt + "".join(_HARMONY_NO_THINKING_SUFFIX_TOKENS), suffix_ids
+
     def build_prompt(
         self,
         messages: list[dict[str, Any]],
@@ -1301,11 +1406,18 @@ class BatchedEngine(BaseEngine):
         if self._is_mllm:
             raise RuntimeError("build_prompt is not supported for MLLM models")
         template_tools = convert_tools_for_template(tools) if tools else None
-        return self._apply_chat_template(
+        prompt = self._apply_chat_template(
             messages,
             tools=template_tools,
             enable_thinking=enable_thinking,
         )
+        prepared, _ = self._prepare_harmony_no_thinking_prompt(
+            prompt,
+            enable_thinking=enable_thinking,
+            has_tools=bool(template_tools),
+            as_token_ids=False,
+        )
+        return prepared
 
     def estimate_new_tokens(self, prompt: str) -> tuple[int, int]:
         """Return ``(total_tokens, new_tokens)`` for ``prompt``.
@@ -1438,7 +1550,7 @@ class BatchedEngine(BaseEngine):
 
     async def generate(
         self,
-        prompt: str,
+        prompt: str | list[int],
         max_tokens: int = 256,
         temperature: float = 0.7,
         top_p: float = 0.9,
@@ -1569,6 +1681,7 @@ class BatchedEngine(BaseEngine):
         # the continuation, so we prepend the prefix to the response text
         # below before the tool parser scans it.
         assistant_text_prefix = kwargs.pop("_assistant_text_prefix", "") or ""
+        output_router_seed = kwargs.pop("_output_router_seed_token_ids", None)
         output = await self._engine.generate(
             prompt=prompt,
             sampling_params=sampling_params,
@@ -1598,7 +1711,9 @@ class BatchedEngine(BaseEngine):
         # terminators so it also recovers reasoning from truncated
         # output (``finish_reason=length`` mid-thinking).
         reasoning_text, text, structured_tool_calls = self._route_tokens_for_channels(
-            output.output_token_ids, fallback_text=text
+            output.output_token_ids,
+            fallback_text=text,
+            seed_token_ids=output_router_seed,
         )
 
         return GenerationOutput(
@@ -1621,7 +1736,7 @@ class BatchedEngine(BaseEngine):
 
     async def stream_generate(
         self,
-        prompt: str,
+        prompt: str | list[int],
         max_tokens: int = 256,
         temperature: float = 0.7,
         top_p: float = 0.9,
@@ -1920,6 +2035,14 @@ class BatchedEngine(BaseEngine):
             num_images=len(all_images),
             enable_thinking=enable_thinking,
         )
+        prompt, output_router_seed = self._prepare_harmony_no_thinking_prompt(
+            prompt,
+            enable_thinking=enable_thinking,
+            has_tools=bool(template_tools),
+            as_token_ids=True,
+        )
+        if output_router_seed is not None:
+            kwargs["_output_router_seed_token_ids"] = output_router_seed
 
         # ``forced_assistant_prefix`` — OpenAI-spec ``tool_choice`` forced
         # mode (#673). The route layer builds a parser-shaped prefix
@@ -2058,7 +2181,11 @@ class BatchedEngine(BaseEngine):
             return 0
 
     def _route_tokens_for_channels(
-        self, token_ids: list[int] | None, *, fallback_text: str
+        self,
+        token_ids: list[int] | None,
+        *,
+        fallback_text: str,
+        seed_token_ids: tuple[int, ...] | None = None,
     ) -> tuple[str, str, list[dict] | None]:
         """Run ``OutputRouter.feed_sequence`` on a completed token list.
 
@@ -2098,6 +2225,8 @@ class BatchedEngine(BaseEngine):
             return "", fallback_text, None
         try:
             router.reset()
+            for token_id in seed_token_ids or ():
+                router.feed(token_id)
             routed = router.feed_sequence(token_ids)
         except Exception as e:
             logger.debug("OutputRouter sequence routing failed: %s", e)
@@ -2426,6 +2555,12 @@ class BatchedEngine(BaseEngine):
             num_images=len(all_images),
             enable_thinking=enable_thinking,
         )
+        prompt, output_router_seed = self._prepare_harmony_no_thinking_prompt(
+            prompt,
+            enable_thinking=enable_thinking,
+            has_tools=bool(template_tools),
+            as_token_ids=True,
+        )
 
         # ``forced_assistant_prefix`` — see ``chat()`` for the rationale.
         # On the streaming path the prefix is also injected into the
@@ -2453,6 +2588,18 @@ class BatchedEngine(BaseEngine):
             kwargs["requires_prompt_integrity"] = True
 
         router = self._create_output_router()
+        if router is not None and output_router_seed is not None:
+            try:
+                router.reset()
+                for token_id in output_router_seed:
+                    router.feed(token_id)
+            except Exception as e:
+                logger.warning(
+                    "Harmony no-thinking output-router seed failed; "
+                    "falling back to unrouted output: %s",
+                    e,
+                )
+                router = None
         stream = self.stream_generate(
             prompt=prompt,
             max_tokens=max_tokens,

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -1682,6 +1682,23 @@ class BatchedEngine(BaseEngine):
         # below before the tool parser scans it.
         assistant_text_prefix = kwargs.pop("_assistant_text_prefix", "") or ""
         output_router_seed = kwargs.pop("_output_router_seed_token_ids", None)
+        if output_router_seed is None and isinstance(prompt, str):
+            # ``build_prompt(enable_thinking=False)`` is part of the public
+            # engine contract and returns the prepared Harmony string. A
+            # caller may feed that string back into ``generate()`` without
+            # going through ``chat()``, which is normally responsible for
+            # carrying the private router seed. Recover the seed from the
+            # exact prepared suffix so routing starts in the prompt-opened
+            # final channel on that composition path too.
+            suffix = "".join(_HARMONY_NO_THINKING_SUFFIX_TOKENS)
+            if prompt.endswith(suffix):
+                base_prompt = prompt[: -len(suffix)]
+                _, output_router_seed = self._prepare_harmony_no_thinking_prompt(
+                    base_prompt,
+                    enable_thinking=False,
+                    has_tools=False,
+                    as_token_ids=False,
+                )
         output = await self._engine.generate(
             prompt=prompt,
             sampling_params=sampling_params,


### PR DESCRIPTION
## Summary

- honor `enable_thinking=False` for GPT-OSS/Harmony chat prompts
- append the empty-analysis/open-final sequence as tokenizer-owned token IDs after chat-template rendering
- prime streaming and non-streaming output routers with the prompt-opened final-channel state
- recover that router state when callers compose `build_prompt()` with `generate()` directly
- leave tool requests and non-Harmony/custom prompt boundaries unchanged

## Root cause

GPT-OSS uses the Harmony channel protocol and its chat template ignores the generic `enable_thinking` keyword. Injecting Harmony markers into message content escapes them as user text, while the raw completions workaround only works because it supplies structural token IDs directly.

## User impact

`--no-thinking`, `reasoning_effort="none"`, and other request paths that resolve to `enable_thinking=False` can now skip GPT-OSS analysis while continuing to use `/v1/chat/completions`. Tool-enabled requests retain the normal commentary-channel path so tool calls remain available.

## Validation

- final `pr_validate` profile: **MERGE-SAFE**; Codex review converged with 0 blocking findings
- latest head full-unit suite: `12,580 passed, 21 skipped, 17 deselected, 6 xfailed, 1 xpassed`
- focused Harmony/router/thinking suites: `393 passed`
- GitHub CI: lint, type-check, Python 3.10–3.12, Apple Silicon, aggregate tests, and CI `pr_validate` all passed
- real `mlx-community/gpt-oss-20b-MXFP4-Q8` OpenAI SDK E2E with server `--no-thinking`:
  - non-stream: `content="NO_THINKING_OK"`, `reasoning_content=None`, `finish_reason="stop"`
  - stream: `content="NO_THINKING_OK"`, `reasoning_content=None`, `finish_reason="stop"`
- full automatic four-family stress was not run because it would download more than 65 GiB of uncached, unrelated Qwen models on a disk with about 50 GiB free; the affected Harmony target was validated directly instead

Fixes #1067
