### PR TITLE
feat(mtp): HY3 (Tencent Hunyuan 3) native MTP self-speculative decoding

### DIFF
--- a/scripts/extract_hy3_mtp.py
+++ b/scripts/extract_hy3_mtp.py
@@ -36,6 +36,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 from pathlib import Path
 
 import mlx.core as mx
@@ -296,11 +297,32 @@ def main() -> int:
         )
 
     if all_weights:
-        logger.warning(
-            "UNCONSUMED layer-%d tensors (first 8): %s",
-            mtp_layer,
-            sorted(all_weights)[:8],
-        )
+        # Schema-drift guard (codex NIT): unconsumed layer tensors mean the
+        # upstream head grew params this extractor does not map, so a warning-
+        # only path could publish a silently-incomplete sidecar. Fail hard
+        # unless the operator explicitly acknowledges via
+        # HY3_MTP_ALLOW_UNCONSUMED=1 (e.g. deliberately dropping a known-unused
+        # tensor during a controlled re-extract).
+        leftover = sorted(all_weights)
+        if os.environ.get("HY3_MTP_ALLOW_UNCONSUMED") == "1":
+            logger.warning(
+                "UNCONSUMED layer-%d tensors ignored via HY3_MTP_ALLOW_UNCONSUMED "
+                "(count=%d, first 8): %s",
+                mtp_layer,
+                len(leftover),
+                leftover[:8],
+            )
+        else:
+            logger.error(
+                "UNCONSUMED layer-%d tensors (count=%d, first 8): %s. The upstream "
+                "MTP head carries params this extractor does not map — refusing to "
+                "publish a silently-incomplete sidecar. Update the remap, or set "
+                "HY3_MTP_ALLOW_UNCONSUMED=1 to override deliberately.",
+                mtp_layer,
+                len(leftover),
+                leftover[:8],
+            )
+            return 1
 
     # --- 3. Quantize to match the base checkpoint. ---
     # Norms (1-D) + expert_bias stay FP. eh_proj / attn proj / switch_mlp /
@@ -323,10 +345,25 @@ def main() -> int:
         quantized[k.replace(".weight", ".biases")] = q_b
 
     # --- 4. Save into a DEDICATED sidecar dir (see the module note above). ---
+    # Atomic write (codex NIT): serialize to a temp sibling then os.replace onto
+    # the destination, so an interrupt / disk-full mid-write can't truncate or
+    # destroy a previously-valid sidecar at ``out``.
     out = Path(args.out).expanduser()
     out.parent.mkdir(parents=True, exist_ok=True)
-    logger.info("Saving %d tensors to %s", len(quantized), out)
-    mx.save_safetensors(str(out), quantized)
+    # mx.save_safetensors SILENTLY no-ops unless the path ends in .safetensors,
+    # so the temp sibling must keep that suffix (…​.tmp.safetensors), not a bare
+    # .tmp. os.replace within the same dir is atomic.
+    tmp_out = out.with_name(out.stem + ".tmp" + out.suffix)
+    logger.info("Saving %d tensors to %s (atomic via %s)", len(quantized), out, tmp_out)
+    mx.save_safetensors(str(tmp_out), quantized)
+    if not tmp_out.exists():
+        logger.error(
+            "mx.save_safetensors wrote nothing to %s (path must end in "
+            ".safetensors); aborting before replace.",
+            tmp_out,
+        )
+        return 1
+    os.replace(tmp_out, out)
 
     # --- 5. Spot-checks. ---
     total_bytes = sum(v.nbytes for v in quantized.values())

--- a/scripts/extract_hy3_mtp.py
+++ b/scripts/extract_hy3_mtp.py
@@ -33,7 +33,6 @@ from __future__ import annotations
 
 import json
 import logging
-import os
 from pathlib import Path
 
 import mlx.core as mx
@@ -53,10 +52,27 @@ DEFAULT_BASE_REPO = "mlx-community/Hy3-preview-4bit"
 DEFAULT_UPSTREAM_REPO = "tencent/Hy3-preview"
 DEFAULT_OUT = "./hy3-mtp-sidecar/model-mtp.safetensors"
 
-# 4-bit / group_size 64 affine for every Linear; 8-bit for the router gate.
-Q_BITS = 4
-Q_GS = 64
-ROUTER_BITS = 8
+# Router-gate override bits: HY3 quantizes ``mlp.router.gate`` at 8-bit while
+# the rest of the layer uses the base's default bits (both group_size from the
+# base). Read the actual bit-widths from the base ``quantization`` block so a
+# differently-quantized base produces a matching sidecar (codex BLOCKING #4).
+ROUTER_GATE_BITS = 8
+
+
+def _resolve_base_quant(cfg: dict) -> dict:
+    """Read {bits, group_size} from the base checkpoint's ``quantization`` block.
+
+    Rejects a base with no quantization metadata rather than silently emitting
+    a 4-bit sidecar for it (codex BLOCKING #4).
+    """
+    q = cfg.get("quantization")
+    if not isinstance(q, dict) or "bits" not in q or "group_size" not in q:
+        raise ValueError(
+            "base config.json has no top-level quantization {bits, group_size}; "
+            "cannot derive matching sidecar quant. Pass a quantized MLX base "
+            "(e.g. mlx-community/Hy3-preview-4bit)."
+        )
+    return {"bits": int(q["bits"]), "group_size": int(q["group_size"])}
 
 
 def _base_config(base_repo: str) -> dict:
@@ -127,6 +143,11 @@ def main() -> int:
     base_cfg = _base_config(args.base_repo)
     mtp_layer = _resolve_mtp_layer(base_cfg, args.base_repo)
     num_experts = _resolve_num_experts(base_cfg)
+    base_quant = _resolve_base_quant(base_cfg)
+    q_bits, q_gs = base_quant["bits"], base_quant["group_size"]
+    logger.info(
+        "Base quant: %d-bit gs=%d (router.gate %d-bit)", q_bits, q_gs, ROUTER_GATE_BITS
+    )
     prefix = f"model.layers.{mtp_layer}."
     shards = _find_shards_for_layer(args.upstream_repo, mtp_layer)
 
@@ -243,8 +264,8 @@ def main() -> int:
         if not k.endswith(".weight"):
             quantized[k] = v
             continue
-        bits = ROUTER_BITS if k.endswith("mlp.router.gate.weight") else Q_BITS
-        q_w, q_s, q_b = _quantize(v, bits, Q_GS)
+        bits = ROUTER_GATE_BITS if k.endswith("mlp.router.gate.weight") else q_bits
+        q_w, q_s, q_b = _quantize(v, bits, q_gs)
         quantized[k] = q_w
         quantized[k.replace(".weight", ".scales")] = q_s
         quantized[k.replace(".weight", ".biases")] = q_b
@@ -279,20 +300,22 @@ def main() -> int:
         tuple(rg_s.shape) if rg_s is not None else None,
     )
 
-    # --- 6. Disk hygiene: delete raw shards (both symlink + blob target). ---
-    for p in raw_paths:
-        try:
-            real = os.path.realpath(p)
-            if os.path.exists(real):
-                os.remove(real)
-                logger.info("Deleted blob %s", real)
-            if os.path.islink(p) or os.path.exists(p):
-                os.remove(p)
-                logger.info("Deleted cache entry %s", p)
-        except FileNotFoundError:
-            pass
-        except Exception as exc:  # pragma: no cover
-            logger.warning("Could not delete %s: %s", p, exc)
+    # --- 6. Disk hygiene hint (codex BLOCKING #5). ---
+    # NEVER unlink the content-addressed HF cache blobs directly: they are
+    # shared by ref-count across snapshots, and removing one leaves dangling
+    # symlinks in every OTHER snapshot that points at it. The downloaded
+    # shards are large; point the operator at the safe, ref-count-aware
+    # deletion path instead of corrupting the cache here.
+    if raw_paths:
+        logger.info(
+            "Downloaded %d upstream shard(s) into the shared HF cache. To "
+            "reclaim that space safely (ref-count aware), run:\n"
+            "    huggingface-cli delete-cache\n"
+            "and select the %s revision. (This script does not unlink shared "
+            "cache blobs — doing so would dangle other snapshots' symlinks.)",
+            len(raw_paths),
+            args.upstream_repo,
+        )
 
     logger.info("Done. Sidecar ready at %s", out)
     return 0

--- a/scripts/extract_hy3_mtp.py
+++ b/scripts/extract_hy3_mtp.py
@@ -145,9 +145,20 @@ def main() -> int:
     ap.add_argument(
         "--out", default=DEFAULT_OUT, help="Output path for model-mtp.safetensors."
     )
+    ap.add_argument(
+        "--base-rev",
+        default=None,
+        help="Immutable commit SHA for --base-repo (recommended for "
+        "reproducible provenance; defaults to repo HEAD).",
+    )
+    ap.add_argument(
+        "--upstream-rev",
+        default=None,
+        help="Immutable commit SHA for --upstream-repo (defaults to repo HEAD).",
+    )
     args = ap.parse_args()
 
-    base_cfg = _base_config(args.base_repo)
+    base_cfg = _base_config(args.base_repo, args.base_rev)
     mtp_layer = _resolve_mtp_layer(base_cfg, args.base_repo)
     num_experts = _resolve_num_experts(base_cfg)
     base_quant = _resolve_base_quant(base_cfg)

--- a/scripts/extract_hy3_mtp.py
+++ b/scripts/extract_hy3_mtp.py
@@ -126,6 +126,33 @@ def _quantize(w: mx.array, bits: int, gs: int):
     return q_w, q_s, q_b
 
 
+def _resolve_commit_sha(repo: str, revision: str | None) -> str:
+    """Pin ``revision`` (or HEAD when ``None``) to one immutable commit SHA.
+
+    Resolving up front — before any file download — guarantees the config,
+    index, and every shard come from the *same* commit, so a repo update mid-
+    extraction can never mix files from different revisions into a published
+    sidecar (codex R4 BLOCKING). A 40-char hex string is already immutable and
+    returned as-is; anything else (a branch/tag, or ``None``=HEAD) is resolved
+    via the Hub API.
+    """
+    if (
+        revision
+        and len(revision) == 40
+        and all(c in "0123456789abcdef" for c in revision.lower())
+    ):
+        return revision
+    from huggingface_hub import HfApi
+
+    sha = HfApi().repo_info(repo, revision=revision).sha
+    if not sha:
+        raise RuntimeError(
+            f"could not resolve a commit SHA for {repo}@{revision or 'HEAD'}"
+        )
+    logger.info("Resolved %s@%s -> %s", repo, revision or "HEAD", sha)
+    return sha
+
+
 def main() -> int:
     import argparse
 
@@ -158,7 +185,14 @@ def main() -> int:
     )
     args = ap.parse_args()
 
-    base_cfg = _base_config(args.base_repo, args.base_rev)
+    # Pin both repos to one immutable commit SHA BEFORE any download so config,
+    # index, and shards all come from a single reproducible snapshot (codex R4
+    # BLOCKING). --base-rev / --upstream-rev may be a SHA (used as-is), a
+    # branch/tag, or omitted (=HEAD, resolved now).
+    base_rev = _resolve_commit_sha(args.base_repo, args.base_rev)
+    upstream_rev = _resolve_commit_sha(args.upstream_repo, args.upstream_rev)
+
+    base_cfg = _base_config(args.base_repo, base_rev)
     mtp_layer = _resolve_mtp_layer(base_cfg, args.base_repo)
     num_experts = _resolve_num_experts(base_cfg)
     base_quant = _resolve_base_quant(base_cfg)
@@ -167,14 +201,14 @@ def main() -> int:
         "Base quant: %d-bit gs=%d (router.gate %d-bit)", q_bits, q_gs, ROUTER_GATE_BITS
     )
     prefix = f"model.layers.{mtp_layer}."
-    shards = _find_shards_for_layer(args.upstream_repo, mtp_layer, args.upstream_rev)
+    shards = _find_shards_for_layer(args.upstream_repo, mtp_layer, upstream_rev)
 
     # --- 1. Download only the shard(s) holding the MTP layer. ---
     raw_paths: list[Path] = []
     all_weights: dict[str, mx.array] = {}
     for shard in shards:
         logger.info("Downloading %s ...", shard)
-        p = Path(hf_hub_download(args.upstream_repo, shard, revision=args.upstream_rev))
+        p = Path(hf_hub_download(args.upstream_repo, shard, revision=upstream_rev))
         raw_paths.append(p)
         w = mx.load(str(p))
         for k, v in w.items():

--- a/scripts/extract_hy3_mtp.py
+++ b/scripts/extract_hy3_mtp.py
@@ -70,8 +70,9 @@ def _base_config(base_repo: str) -> dict:
 def _resolve_mtp_layer(cfg: dict, base_repo: str) -> int:
     """The native MTP head lives at ``model.layers.<num_hidden_layers>.*``."""
     n = int(cfg["num_hidden_layers"])
-    logger.info("Base %s: num_hidden_layers=%d -> MTP head at layer %d",
-                base_repo, n, n)
+    logger.info(
+        "Base %s: num_hidden_layers=%d -> MTP head at layer %d", base_repo, n, n
+    )
     return n
 
 
@@ -91,9 +92,7 @@ def _find_shards_for_layer(upstream_repo: str, layer: int) -> list[str]:
     prefix = f"model.layers.{layer}."
     shards = sorted({fn for k, fn in weight_map.items() if k.startswith(prefix)})
     if not shards:
-        raise RuntimeError(
-            f"no shards hold {prefix}* in {upstream_repo} index"
-        )
+        raise RuntimeError(f"no shards hold {prefix}* in {upstream_repo} index")
     logger.info("Layer %d spans %d shard(s): %s", layer, len(shards), shards)
     return shards
 
@@ -110,12 +109,19 @@ def main() -> int:
     from huggingface_hub import hf_hub_download
 
     ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
-    ap.add_argument("--base-repo", default=DEFAULT_BASE_REPO,
-                    help="4-bit MLX base checkpoint (defines quant + layer count).")
-    ap.add_argument("--upstream-repo", default=DEFAULT_UPSTREAM_REPO,
-                    help="Full-precision checkpoint that still carries the MTP head.")
-    ap.add_argument("--out", default=DEFAULT_OUT,
-                    help="Output path for model-mtp.safetensors.")
+    ap.add_argument(
+        "--base-repo",
+        default=DEFAULT_BASE_REPO,
+        help="4-bit MLX base checkpoint (defines quant + layer count).",
+    )
+    ap.add_argument(
+        "--upstream-repo",
+        default=DEFAULT_UPSTREAM_REPO,
+        help="Full-precision checkpoint that still carries the MTP head.",
+    )
+    ap.add_argument(
+        "--out", default=DEFAULT_OUT, help="Output path for model-mtp.safetensors."
+    )
     args = ap.parse_args()
 
     base_cfg = _base_config(args.base_repo)
@@ -157,7 +163,10 @@ def main() -> int:
 
     lp = "layers.0."
     # Layernorms + attention (incl q_norm/k_norm).
-    put(lp + "input_layernorm.weight", all_weights.pop(prefix + "input_layernorm.weight"))
+    put(
+        lp + "input_layernorm.weight",
+        all_weights.pop(prefix + "input_layernorm.weight"),
+    )
     put(
         lp + "post_attention_layernorm.weight",
         all_weights.pop(prefix + "post_attention_layernorm.weight"),
@@ -175,7 +184,10 @@ def main() -> int:
 
     # Router gate + expert bias (bias renamed to router.expert_bias to match
     # hy_v3.MoEGate, which holds ``expert_bias`` under the ``router`` module).
-    put(lp + "mlp.router.gate.weight", all_weights.pop(prefix + "mlp.router.gate.weight"))
+    put(
+        lp + "mlp.router.gate.weight",
+        all_weights.pop(prefix + "mlp.router.gate.weight"),
+    )
     put(
         lp + "mlp.router.expert_bias",
         all_weights.pop(prefix + "mlp.expert_bias"),
@@ -196,19 +208,26 @@ def main() -> int:
         ]
         missing = [k for k in expert_keys if k not in all_weights]
         if missing:
-            logger.error("Missing %d expert tensors for %s (first: %s)",
-                         len(missing), proj, missing[0])
+            logger.error(
+                "Missing %d expert tensors for %s (first: %s)",
+                len(missing),
+                proj,
+                missing[0],
+            )
             return 1
         stacked = mx.stack([all_weights.pop(k) for k in expert_keys])
         mx.eval(stacked)
         put(lp + f"mlp.switch_mlp.{proj}.weight", stacked)
-        logger.info("Stacked %d experts for %s -> %s",
-                    num_experts, proj, tuple(stacked.shape))
+        logger.info(
+            "Stacked %d experts for %s -> %s", num_experts, proj, tuple(stacked.shape)
+        )
 
     if all_weights:
-        logger.warning("UNCONSUMED layer-%d tensors (first 8): %s",
-                       mtp_layer,
-                       sorted(all_weights)[:8])
+        logger.warning(
+            "UNCONSUMED layer-%d tensors (first 8): %s",
+            mtp_layer,
+            sorted(all_weights)[:8],
+        )
 
     # --- 3. Quantize to match the base checkpoint. ---
     # Norms (1-D) + expert_bias stay FP. eh_proj / attn proj / switch_mlp /
@@ -238,8 +257,9 @@ def main() -> int:
 
     # --- 5. Spot-checks. ---
     total_bytes = sum(v.nbytes for v in quantized.values())
-    logger.info("Sidecar size on disk: %.1f MB (%d tensors)",
-                total_bytes / 1e6, len(quantized))
+    logger.info(
+        "Sidecar size on disk: %.1f MB (%d tensors)", total_bytes / 1e6, len(quantized)
+    )
     smw = quantized.get(lp + "mlp.switch_mlp.gate_proj.weight")
     smw_s = quantized.get(lp + "mlp.switch_mlp.gate_proj.scales")
     smw_b = quantized.get(lp + "mlp.switch_mlp.gate_proj.biases")
@@ -253,9 +273,11 @@ def main() -> int:
     )
     rg = quantized.get(lp + "mlp.router.gate.weight")
     rg_s = quantized.get(lp + "mlp.router.gate.scales")
-    logger.info("spot-check router.gate: weight.shape=%s scales.shape=%s (8-bit)",
-                tuple(rg.shape) if rg is not None else None,
-                tuple(rg_s.shape) if rg_s is not None else None)
+    logger.info(
+        "spot-check router.gate: weight.shape=%s scales.shape=%s (8-bit)",
+        tuple(rg.shape) if rg is not None else None,
+        tuple(rg_s.shape) if rg_s is not None else None,
+    )
 
     # --- 6. Disk hygiene: delete raw shards (both symlink + blob target). ---
     for p in raw_paths:

--- a/scripts/extract_hy3_mtp.py
+++ b/scripts/extract_hy3_mtp.py
@@ -26,7 +26,10 @@ Usage:
         --upstream-repo tencent/Hy3-preview \
         --out ./hy3-mtp-sidecar/model-mtp.safetensors
 
-Disk hygiene: deletes the downloaded raw shards from the HF cache on exit.
+Provenance: `--base-rev` / `--upstream-rev` pin immutable commit SHAs so
+config, index, and shards all resolve from one reproducible snapshot. The
+downloaded shards stay in the shared HF cache; reclaim that space with
+`huggingface-cli delete-cache` (never unlink the shared blobs by hand).
 """
 
 from __future__ import annotations
@@ -75,11 +78,11 @@ def _resolve_base_quant(cfg: dict) -> dict:
     return {"bits": int(q["bits"]), "group_size": int(q["group_size"])}
 
 
-def _base_config(base_repo: str) -> dict:
-    """Fetch (and cache) the base checkpoint's ``config.json``."""
+def _base_config(base_repo: str, revision: str | None) -> dict:
+    """Fetch (and cache) the base checkpoint's ``config.json`` at ``revision``."""
     from huggingface_hub import hf_hub_download
 
-    cfg_path = hf_hub_download(base_repo, "config.json")
+    cfg_path = hf_hub_download(base_repo, "config.json", revision=revision)
     return json.loads(Path(cfg_path).read_text())
 
 
@@ -99,11 +102,15 @@ def _resolve_num_experts(cfg: dict) -> int:
     raise KeyError("could not find expert count in base config.json")
 
 
-def _find_shards_for_layer(upstream_repo: str, layer: int) -> list[str]:
+def _find_shards_for_layer(
+    upstream_repo: str, layer: int, revision: str | None
+) -> list[str]:
     """Return the shard filenames that hold ``model.layers.<layer>.*``."""
     from huggingface_hub import hf_hub_download
 
-    idx_path = hf_hub_download(upstream_repo, "model.safetensors.index.json")
+    idx_path = hf_hub_download(
+        upstream_repo, "model.safetensors.index.json", revision=revision
+    )
     weight_map = json.loads(Path(idx_path).read_text())["weight_map"]
     prefix = f"model.layers.{layer}."
     shards = sorted({fn for k, fn in weight_map.items() if k.startswith(prefix)})
@@ -149,14 +156,14 @@ def main() -> int:
         "Base quant: %d-bit gs=%d (router.gate %d-bit)", q_bits, q_gs, ROUTER_GATE_BITS
     )
     prefix = f"model.layers.{mtp_layer}."
-    shards = _find_shards_for_layer(args.upstream_repo, mtp_layer)
+    shards = _find_shards_for_layer(args.upstream_repo, mtp_layer, args.upstream_rev)
 
     # --- 1. Download only the shard(s) holding the MTP layer. ---
     raw_paths: list[Path] = []
     all_weights: dict[str, mx.array] = {}
     for shard in shards:
         logger.info("Downloading %s ...", shard)
-        p = Path(hf_hub_download(args.upstream_repo, shard))
+        p = Path(hf_hub_download(args.upstream_repo, shard, revision=args.upstream_rev))
         raw_paths.append(p)
         w = mx.load(str(p))
         for k, v in w.items():

--- a/scripts/extract_hy3_mtp.py
+++ b/scripts/extract_hy3_mtp.py
@@ -1,0 +1,280 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Extract + quantize the HY3 (Tencent Hunyuan 3) native MTP sidecar.
+
+Provenance / regeneration tool for ``mlx-community/Hy3-preview-MTP-4bit``.
+
+The 4-bit MLX checkpoint ``mlx-community/Hy3-preview-4bit`` STRIPS the native
+MTP head at convert time. Upstream ``tencent/Hy3-preview`` keeps it at
+``model.layers.<N>.*`` where ``N == num_hidden_layers`` (a DeepSeek-V3-style
+single next-n predict layer, K=1). This script finds which shard(s) hold that
+layer via the safetensors index, downloads ONLY those, extracts the layer-N
+tensors, remaps them to the ``_HY3MTPModule`` param tree (mirroring
+``hy_v3.Model.sanitize``'s expert stacking + router-bias rename), quantizes to
+match the base checkpoint (4-bit gs64 affine for Linear; 8-bit gs64 for
+``mlp.router.gate``; FP for all norms + ``expert_bias``), and writes
+``model-mtp.safetensors``.
+
+Concat order (``eh_proj(cat([enorm(embed), hnorm(prev_hidden)]))`` — embedding
+first) confirmed from vLLM ``deepseek_mtp.py`` and SGLang ``hunyuan`` nextn.
+HY3 uses standard ``nn.RMSNorm`` (no +1 norm shift). Idiom reference:
+``scripts/extract_mtp_weights.py`` + ``scripts/add_mtp_weights.py``.
+
+Usage:
+    python scripts/extract_hy3_mtp.py \
+        --base-repo mlx-community/Hy3-preview-4bit \
+        --upstream-repo tencent/Hy3-preview \
+        --out ./hy3-mtp-sidecar/model-mtp.safetensors
+
+Disk hygiene: deletes the downloaded raw shards from the HF cache on exit.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from pathlib import Path
+
+import mlx.core as mx
+
+mx.set_default_device(mx.cpu)
+
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+logger = logging.getLogger(__name__)
+
+# NOTE ON WHERE THE SIDECAR IS WRITTEN. Write ``model-mtp.safetensors`` to a
+# DEDICATED directory, never into the base checkpoint snapshot dir: ``mlx_lm.load``
+# globs ``model*.safetensors`` in the model dir and would try to load the
+# sidecar's 44 keys into the base HYV3 model under strict=True (which fails). The
+# runtime inject (:mod:`vllm_mlx.spec_decode.mtp.hy3_inject`) loads the sidecar
+# separately, so it must live in its own repo / directory.
+DEFAULT_BASE_REPO = "mlx-community/Hy3-preview-4bit"
+DEFAULT_UPSTREAM_REPO = "tencent/Hy3-preview"
+DEFAULT_OUT = "./hy3-mtp-sidecar/model-mtp.safetensors"
+
+# 4-bit / group_size 64 affine for every Linear; 8-bit for the router gate.
+Q_BITS = 4
+Q_GS = 64
+ROUTER_BITS = 8
+
+
+def _base_config(base_repo: str) -> dict:
+    """Fetch (and cache) the base checkpoint's ``config.json``."""
+    from huggingface_hub import hf_hub_download
+
+    cfg_path = hf_hub_download(base_repo, "config.json")
+    return json.loads(Path(cfg_path).read_text())
+
+
+def _resolve_mtp_layer(cfg: dict, base_repo: str) -> int:
+    """The native MTP head lives at ``model.layers.<num_hidden_layers>.*``."""
+    n = int(cfg["num_hidden_layers"])
+    logger.info("Base %s: num_hidden_layers=%d -> MTP head at layer %d",
+                base_repo, n, n)
+    return n
+
+
+def _resolve_num_experts(cfg: dict) -> int:
+    for key in ("num_experts", "n_routed_experts", "moe_num_experts"):
+        if cfg.get(key):
+            return int(cfg[key])
+    raise KeyError("could not find expert count in base config.json")
+
+
+def _find_shards_for_layer(upstream_repo: str, layer: int) -> list[str]:
+    """Return the shard filenames that hold ``model.layers.<layer>.*``."""
+    from huggingface_hub import hf_hub_download
+
+    idx_path = hf_hub_download(upstream_repo, "model.safetensors.index.json")
+    weight_map = json.loads(Path(idx_path).read_text())["weight_map"]
+    prefix = f"model.layers.{layer}."
+    shards = sorted({fn for k, fn in weight_map.items() if k.startswith(prefix)})
+    if not shards:
+        raise RuntimeError(
+            f"no shards hold {prefix}* in {upstream_repo} index"
+        )
+    logger.info("Layer %d spans %d shard(s): %s", layer, len(shards), shards)
+    return shards
+
+
+def _quantize(w: mx.array, bits: int, gs: int):
+    q_w, q_s, q_b = mx.quantize(w, group_size=gs, bits=bits)
+    mx.eval(q_w, q_s, q_b)
+    return q_w, q_s, q_b
+
+
+def main() -> int:
+    import argparse
+
+    from huggingface_hub import hf_hub_download
+
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--base-repo", default=DEFAULT_BASE_REPO,
+                    help="4-bit MLX base checkpoint (defines quant + layer count).")
+    ap.add_argument("--upstream-repo", default=DEFAULT_UPSTREAM_REPO,
+                    help="Full-precision checkpoint that still carries the MTP head.")
+    ap.add_argument("--out", default=DEFAULT_OUT,
+                    help="Output path for model-mtp.safetensors.")
+    args = ap.parse_args()
+
+    base_cfg = _base_config(args.base_repo)
+    mtp_layer = _resolve_mtp_layer(base_cfg, args.base_repo)
+    num_experts = _resolve_num_experts(base_cfg)
+    prefix = f"model.layers.{mtp_layer}."
+    shards = _find_shards_for_layer(args.upstream_repo, mtp_layer)
+
+    # --- 1. Download only the shard(s) holding the MTP layer. ---
+    raw_paths: list[Path] = []
+    all_weights: dict[str, mx.array] = {}
+    for shard in shards:
+        logger.info("Downloading %s ...", shard)
+        p = Path(hf_hub_download(args.upstream_repo, shard))
+        raw_paths.append(p)
+        w = mx.load(str(p))
+        for k, v in w.items():
+            if k.startswith(prefix):
+                all_weights[k] = v
+        del w
+
+    logger.info("Extracted %d layer-%d tensors", len(all_weights), mtp_layer)
+
+    # --- 2. Remap to the _HY3MTPModule param tree. ---
+    # Wrapper-level: enorm/hnorm/eh_proj/norm.
+    # Inner DecoderLayer: layers.0.{input_layernorm,post_attention_layernorm,
+    #   self_attn.*, mlp.router.gate, mlp.router.expert_bias, mlp.switch_mlp.*,
+    #   mlp.shared_mlp.*}.
+    remapped: dict[str, mx.array] = {}
+
+    def put(key: str, val: mx.array) -> None:
+        remapped[key] = val
+
+    # Wrapper norms + projection + final norm.
+    put("enorm.weight", all_weights.pop(prefix + "enorm.weight"))
+    put("hnorm.weight", all_weights.pop(prefix + "hnorm.weight"))
+    put("eh_proj.weight", all_weights.pop(prefix + "eh_proj.weight"))
+    put("norm.weight", all_weights.pop(prefix + "final_layernorm.weight"))
+
+    lp = "layers.0."
+    # Layernorms + attention (incl q_norm/k_norm).
+    put(lp + "input_layernorm.weight", all_weights.pop(prefix + "input_layernorm.weight"))
+    put(
+        lp + "post_attention_layernorm.weight",
+        all_weights.pop(prefix + "post_attention_layernorm.weight"),
+    )
+    for name in ("q_proj", "k_proj", "v_proj", "o_proj"):
+        put(
+            lp + f"self_attn.{name}.weight",
+            all_weights.pop(prefix + f"self_attn.{name}.weight"),
+        )
+    for name in ("q_norm", "k_norm"):
+        put(
+            lp + f"self_attn.{name}.weight",
+            all_weights.pop(prefix + f"self_attn.{name}.weight"),
+        )
+
+    # Router gate + expert bias (bias renamed to router.expert_bias to match
+    # hy_v3.MoEGate, which holds ``expert_bias`` under the ``router`` module).
+    put(lp + "mlp.router.gate.weight", all_weights.pop(prefix + "mlp.router.gate.weight"))
+    put(
+        lp + "mlp.router.expert_bias",
+        all_weights.pop(prefix + "mlp.expert_bias"),
+    )
+
+    # Shared expert MLP.
+    for proj in ("gate_proj", "down_proj", "up_proj"):
+        put(
+            lp + f"mlp.shared_mlp.{proj}.weight",
+            all_weights.pop(prefix + f"mlp.shared_mlp.{proj}.weight"),
+        )
+
+    # Stack the 192 experts per projection -> switch_mlp (mirrors
+    # hy_v3.Model.sanitize expert-stacking with mx.stack).
+    for proj in ("gate_proj", "down_proj", "up_proj"):
+        expert_keys = [
+            prefix + f"mlp.experts.{e}.{proj}.weight" for e in range(num_experts)
+        ]
+        missing = [k for k in expert_keys if k not in all_weights]
+        if missing:
+            logger.error("Missing %d expert tensors for %s (first: %s)",
+                         len(missing), proj, missing[0])
+            return 1
+        stacked = mx.stack([all_weights.pop(k) for k in expert_keys])
+        mx.eval(stacked)
+        put(lp + f"mlp.switch_mlp.{proj}.weight", stacked)
+        logger.info("Stacked %d experts for %s -> %s",
+                    num_experts, proj, tuple(stacked.shape))
+
+    if all_weights:
+        logger.warning("UNCONSUMED layer-%d tensors (first 8): %s",
+                       mtp_layer,
+                       sorted(all_weights)[:8])
+
+    # --- 3. Quantize to match the base checkpoint. ---
+    # Norms (1-D) + expert_bias stay FP. eh_proj / attn proj / switch_mlp /
+    # shared_mlp go 4-bit. router.gate goes 8-bit.
+    def _is_norm(k: str) -> bool:
+        return k.endswith("norm.weight") or k.endswith("layernorm.weight")
+
+    quantized: dict[str, mx.array] = {}
+    for k, v in remapped.items():
+        if _is_norm(k) or k.endswith("expert_bias"):
+            quantized[k] = v  # FP — never quantize 1-D tensors / norms.
+            continue
+        if not k.endswith(".weight"):
+            quantized[k] = v
+            continue
+        bits = ROUTER_BITS if k.endswith("mlp.router.gate.weight") else Q_BITS
+        q_w, q_s, q_b = _quantize(v, bits, Q_GS)
+        quantized[k] = q_w
+        quantized[k.replace(".weight", ".scales")] = q_s
+        quantized[k.replace(".weight", ".biases")] = q_b
+
+    # --- 4. Save into a DEDICATED sidecar dir (see the module note above). ---
+    out = Path(args.out).expanduser()
+    out.parent.mkdir(parents=True, exist_ok=True)
+    logger.info("Saving %d tensors to %s", len(quantized), out)
+    mx.save_safetensors(str(out), quantized)
+
+    # --- 5. Spot-checks. ---
+    total_bytes = sum(v.nbytes for v in quantized.values())
+    logger.info("Sidecar size on disk: %.1f MB (%d tensors)",
+                total_bytes / 1e6, len(quantized))
+    smw = quantized.get(lp + "mlp.switch_mlp.gate_proj.weight")
+    smw_s = quantized.get(lp + "mlp.switch_mlp.gate_proj.scales")
+    smw_b = quantized.get(lp + "mlp.switch_mlp.gate_proj.biases")
+    logger.info(
+        "spot-check switch_mlp.gate_proj: weight.shape=%s (lead dim=%s, want 192), "
+        "has scales=%s biases=%s",
+        tuple(smw.shape) if smw is not None else None,
+        smw.shape[0] if smw is not None else None,
+        smw_s is not None,
+        smw_b is not None,
+    )
+    rg = quantized.get(lp + "mlp.router.gate.weight")
+    rg_s = quantized.get(lp + "mlp.router.gate.scales")
+    logger.info("spot-check router.gate: weight.shape=%s scales.shape=%s (8-bit)",
+                tuple(rg.shape) if rg is not None else None,
+                tuple(rg_s.shape) if rg_s is not None else None)
+
+    # --- 6. Disk hygiene: delete raw shards (both symlink + blob target). ---
+    for p in raw_paths:
+        try:
+            real = os.path.realpath(p)
+            if os.path.exists(real):
+                os.remove(real)
+                logger.info("Deleted blob %s", real)
+            if os.path.islink(p) or os.path.exists(p):
+                os.remove(p)
+                logger.info("Deleted cache entry %s", p)
+        except FileNotFoundError:
+            pass
+        except Exception as exc:  # pragma: no cover
+            logger.warning("Could not delete %s: %s", p, exc)
+
+    logger.info("Done. Sidecar ready at %s", out)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/extract_hy3_mtp.py
+++ b/scripts/extract_hy3_mtp.py
@@ -352,8 +352,10 @@ def main() -> int:
     out.parent.mkdir(parents=True, exist_ok=True)
     # mx.save_safetensors SILENTLY no-ops unless the path ends in .safetensors,
     # so the temp sibling must keep that suffix (…​.tmp.safetensors), not a bare
-    # .tmp. os.replace within the same dir is atomic.
-    tmp_out = out.with_name(out.stem + ".tmp" + out.suffix)
+    # .tmp. A per-process pid tag (codex NIT) keeps concurrent extractions
+    # targeting the same output from clobbering each other's temp file.
+    # os.replace within the same dir is atomic.
+    tmp_out = out.with_name(f"{out.stem}.tmp.{os.getpid()}{out.suffix}")
     logger.info("Saving %d tensors to %s (atomic via %s)", len(quantized), out, tmp_out)
     mx.save_safetensors(str(tmp_out), quantized)
     if not tmp_out.exists():

--- a/tests/test_mtp_hy3_inject.py
+++ b/tests/test_mtp_hy3_inject.py
@@ -206,6 +206,14 @@ def test_inject_attaches_four_surfaces_random_init():
     mtp_logits = model.mtp_forward(hidden, ids, mtp_cache)
     mx.eval(mtp_logits)
     assert mtp_logits.shape == (1, 4, 128)
+    # Beyond shape (codex R4 NIT #4): the head must actually consume BOTH the
+    # embedding of next_token_ids AND the prev hidden state via eh_proj(concat)
+    # — a degenerate/constant head would emit identical logits at every
+    # position, and a NaN would slip through a shape-only check. Assert the
+    # output is finite and position-varying (the two token/hidden pairs differ,
+    # so their fused logits must too).
+    assert bool(mx.all(mx.isfinite(mtp_logits)).item())
+    assert not bool(mx.allclose(mtp_logits[:, 0, :], mtp_logits[:, 1, :]).item())
 
 
 def test_validate_false_before_inject():
@@ -351,6 +359,40 @@ def test_inject_refuses_integer_packed_wrong_kind(tmp_path):
     side_dir = tmp_path / "sidecar"
     side_dir.mkdir()
     mx.save_safetensors(str(side_dir / "model-mtp.safetensors"), weights)
+
+    model = _build_tiny_hy3_model()
+    assert inject_hy3_mtp_support(model, mtp_sidecar=str(side_dir)) is False
+    assert validate_hy3_mtp_support(model) is False
+
+
+def test_inject_refuses_multi_nextn_layer_config():
+    """A HY3 config advertising num_nextn_predict_layers=2 must fail-closed to
+    False (HY3's head builder only supports exactly 1 layer), NOT crash boot
+    with a builder ValueError (codex R4 BLOCKING #1)."""
+    from vllm_mlx.spec_decode.mtp.hy3_inject import (
+        inject_hy3_mtp_support,
+        validate_hy3_mtp_support,
+    )
+
+    model = _build_tiny_hy3_model(num_nextn_predict_layers=2)
+    # Must return False cleanly (no exception) even with allow_random_init.
+    assert inject_hy3_mtp_support(model, allow_random_init=True) is False
+    assert validate_hy3_mtp_support(model) is False
+
+
+def test_inject_returns_false_on_corrupt_sidecar(tmp_path):
+    """A truncated / malformed sidecar file must be caught and turned into a
+    False return (this function's documented contract), NOT propagate an
+    exception that aborts server boot (codex R4 BLOCKING #2)."""
+    from vllm_mlx.spec_decode.mtp.hy3_inject import (
+        inject_hy3_mtp_support,
+        validate_hy3_mtp_support,
+    )
+
+    side_dir = tmp_path / "sidecar"
+    side_dir.mkdir()
+    # Write bytes that are NOT a valid safetensors file.
+    (side_dir / "model-mtp.safetensors").write_bytes(b"not a real safetensors file")
 
     model = _build_tiny_hy3_model()
     assert inject_hy3_mtp_support(model, mtp_sidecar=str(side_dir)) is False

--- a/tests/test_mtp_hy3_inject.py
+++ b/tests/test_mtp_hy3_inject.py
@@ -428,6 +428,38 @@ def test_inject_refuses_integer_packed_wrong_kind(tmp_path):
     assert validate_hy3_mtp_support(model) is False
 
 
+def test_inject_refuses_same_shape_wrong_integer_dtype(tmp_path):
+    """Tighter dtype guard (codex R8 BLOCKING #1): the check requires EXACT
+    dtype equality unless BOTH sides are floating. A same-shape tensor whose
+    dtype is a *different* non-float type than expected — e.g. a signed int32 or
+    a bool where a floating (or packed uint32) parameter is expected — must be
+    refused, not waved through by a coarse float-vs-int category test."""
+    from mlx.utils import tree_flatten
+
+    from vllm_mlx.spec_decode.mtp.hy3_head import build_hy3_mtp_module
+    from vllm_mlx.spec_decode.mtp.hy3_inject import (
+        inject_hy3_mtp_support,
+        validate_hy3_mtp_support,
+    )
+
+    args = _tiny_hy3_args()
+    template = build_hy3_mtp_module(args, 1)
+    weights = dict(tree_flatten(template.parameters()))
+    for k in list(weights):
+        mx.eval(weights[k])
+    # bool where a float weight is expected: same shape, not floating -> refuse.
+    shape = weights["eh_proj.weight"].shape
+    weights["eh_proj.weight"] = mx.zeros(shape, dtype=mx.bool_)
+    mx.eval(weights["eh_proj.weight"])
+    side_dir = tmp_path / "sidecar"
+    side_dir.mkdir()
+    mx.save_safetensors(str(side_dir / "model-mtp.safetensors"), weights)
+
+    model = _build_tiny_hy3_model()
+    assert inject_hy3_mtp_support(model, mtp_sidecar=str(side_dir)) is False
+    assert validate_hy3_mtp_support(model) is False
+
+
 def test_inject_quantized_base_packed_sidecar_round_trip(tmp_path):
     """Exercise the PRODUCTION packed path (codex R5 NIT): quantize the base
     model so inject detects a quant spec and quantizes the head, build a sidecar

--- a/tests/test_mtp_hy3_inject.py
+++ b/tests/test_mtp_hy3_inject.py
@@ -1,0 +1,360 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the HY3 (Tencent Hunyuan 3) native MTP inject module.
+
+Mirrors ``tests/test_mtp_inject_and_install.py`` +
+``tests/test_mtp_gemma4_assistant_inject.py`` (the qwen3_5 / gemma4 paths)
+for ``model_type == "hy_v3"``. Everything runs against a tiny synthetic
+HY3 model — end-to-end forward through the real 155 GB target is out of
+scope for CI (covered by the operator smoke + the weekly Golden Path job).
+
+Coverage
+--------
+
+1. **Detection** — ``detect_mtp_eligibility`` reads HY3's
+   ``num_nextn_predict_layers`` (root + ``text_config``) and does NOT
+   cross-contaminate the Qwen3.5 ``mtp_num_hidden_layers`` key.
+2. **Head build** — :func:`build_hy3_mtp_module` produces the
+   DeepSeek-V3-shaped param tree (``enorm`` / ``hnorm`` / ``eh_proj`` /
+   a single MoE ``DecoderLayer`` / ``norm``).
+3. **Wiring probe** — ``inject_hy3_mtp_support(..., allow_random_init=True)``
+   attaches the four MTP contract surfaces, and ``validate_hy3_mtp_support``
+   returns True; a forward through them produces the right shapes.
+4. **Sidecar refusal (fail-closed default)** — no sidecar + no
+   ``allow_random_init`` would resolve the default HF repo; with a bogus
+   sidecar path it returns False and leaves the model unmodified.
+5. **Missing-tensor refusal** — a sidecar that omits a required tensor
+   is rejected (no partial-random head).
+6. **Architecture guard** — a non-``hy_v3`` model (lacking ``num_nextn``)
+   builds no head.
+7. **Dispatcher routing** — ``model_type == "hy_v3"`` routes to
+   ``inject_hy3_mtp_support`` / ``validate_hy3_mtp_support`` in the
+   dispatch tables.
+8. **Default sidecar** — the module exposes the published-repo default so
+   a bare ``--speculative-config '{"method":"mtp"}'`` boot resolves it.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+mx = pytest.importorskip("mlx.core")
+
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+
+def _tiny_hy3_args(**overrides):
+    """Minimal ``hy_v3.ModelArgs`` for a fake HY3 target."""
+    from vllm_mlx.models.hy_v3 import ModelArgs
+
+    defaults = dict(
+        model_type="hy_v3",
+        vocab_size=128,
+        hidden_size=64,
+        intermediate_size=128,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=16,
+        num_experts=4,
+        num_experts_per_tok=2,
+        num_shared_experts=1,
+        expert_hidden_dim=32,
+        first_k_dense_replace=1,
+        rms_norm_eps=1e-6,
+        rope_parameters={"rope_theta": 10000.0},
+        num_nextn_predict_layers=1,
+        tie_word_embeddings=False,
+    )
+    defaults.update(overrides)
+    return ModelArgs(**defaults)
+
+
+def _build_tiny_hy3_model(**overrides):
+    from vllm_mlx.models.hy_v3 import Model
+
+    return Model(_tiny_hy3_args(**overrides))
+
+
+# ---------------------------------------------------------------------------
+# 1. Detection — num_nextn_predict_layers vs mtp_num_hidden_layers
+# ---------------------------------------------------------------------------
+
+
+def test_detect_hy3_num_nextn_chain():
+    """HY3 with ``num_nextn_predict_layers == 1`` → CHAIN."""
+    from vllm_mlx.spec_decode.mtp import MTPEligibility, detect_mtp_eligibility
+
+    config = {"model_type": "hy_v3", "num_nextn_predict_layers": 1}
+    assert detect_mtp_eligibility(config) is MTPEligibility.CHAIN
+
+
+def test_detect_hy3_num_nextn_under_text_config():
+    """HY3 nextn count nested under ``text_config`` still resolves CHAIN."""
+    from vllm_mlx.spec_decode.mtp import MTPEligibility, detect_mtp_eligibility
+
+    config = {"model_type": "hy_v3", "text_config": {"num_nextn_predict_layers": 1}}
+    assert detect_mtp_eligibility(config) is MTPEligibility.CHAIN
+
+
+def test_detect_hy3_zero_nextn_rejected():
+    """HY3 with ``num_nextn_predict_layers == 0`` (stripped) → NONE."""
+    from vllm_mlx.spec_decode.mtp import MTPEligibility, detect_mtp_eligibility
+
+    config = {"model_type": "hy_v3", "num_nextn_predict_layers": 0}
+    assert detect_mtp_eligibility(config) is MTPEligibility.NONE
+
+
+def test_detect_hy3_mtp_key_fallback():
+    """HY3 also accepts the Qwen-style ``mtp_num_hidden_layers`` fallback."""
+    from vllm_mlx.spec_decode.mtp import MTPEligibility, detect_mtp_eligibility
+
+    config = {"model_type": "hy_v3", "mtp_num_hidden_layers": 1}
+    assert detect_mtp_eligibility(config) is MTPEligibility.CHAIN
+
+
+def test_detect_qwen35_does_not_read_num_nextn():
+    """Cross-contamination guard: Qwen3.5 must NOT pick up HY3's
+    ``num_nextn_predict_layers`` key — its head lives under
+    ``mtp_num_hidden_layers`` only."""
+    from vllm_mlx.spec_decode.mtp import MTPEligibility, detect_mtp_eligibility
+
+    config = {"model_type": "qwen3_5", "num_nextn_predict_layers": 1}
+    assert detect_mtp_eligibility(config) is MTPEligibility.NONE
+
+
+def test_detect_deepseek_v3_num_nextn_still_off_allowlist():
+    """``deepseek_v3`` uses the same nextn convention but is NOT on the
+    MTP allowlist — must stay NONE (no accidental promotion)."""
+    from vllm_mlx.spec_decode.mtp import MTPEligibility, detect_mtp_eligibility
+
+    config = {"model_type": "deepseek_v3", "num_nextn_predict_layers": 1}
+    assert detect_mtp_eligibility(config) is MTPEligibility.NONE
+
+
+# ---------------------------------------------------------------------------
+# 2. Head build — DeepSeek-V3-shaped param tree
+# ---------------------------------------------------------------------------
+
+
+def test_build_hy3_mtp_module_param_tree():
+    """The head exposes ``enorm`` / ``hnorm`` / ``eh_proj`` / ``norm`` plus
+    a single MoE ``DecoderLayer`` whose param names match a quantized
+    backbone MoE layer (so the sidecar tree lines up 1:1)."""
+    from mlx.utils import tree_flatten
+
+    from vllm_mlx.spec_decode.mtp.hy3_head import build_hy3_mtp_module
+
+    args = _tiny_hy3_args()
+    mtp = build_hy3_mtp_module(args, 1)
+    keys = {k for k, _ in tree_flatten(mtp.parameters())}
+    for want in (
+        "enorm.weight",
+        "hnorm.weight",
+        "eh_proj.weight",
+        "norm.weight",
+        "layers.0.mlp.router.gate.weight",
+        "layers.0.mlp.router.expert_bias",
+        "layers.0.mlp.switch_mlp.gate_proj.weight",
+        "layers.0.mlp.switch_mlp.down_proj.weight",
+        "layers.0.mlp.switch_mlp.up_proj.weight",
+        "layers.0.mlp.shared_mlp.gate_proj.weight",
+        "layers.0.self_attn.q_norm.weight",
+        "layers.0.self_attn.k_norm.weight",
+        "layers.0.self_attn.q_proj.weight",
+    ):
+        assert want in keys, f"MTP head missing expected tensor {want!r}"
+
+
+def test_build_hy3_mtp_module_rejects_multi_layer():
+    """HY3 ships exactly one next-n layer; >1 must refuse loudly."""
+    from vllm_mlx.spec_decode.mtp.hy3_head import build_hy3_mtp_module
+
+    args = _tiny_hy3_args()
+    with pytest.raises(ValueError):
+        build_hy3_mtp_module(args, 2)
+    with pytest.raises(ValueError):
+        build_hy3_mtp_module(args, 0)
+
+
+# ---------------------------------------------------------------------------
+# 3. Wiring probe — four surfaces attach under random init
+# ---------------------------------------------------------------------------
+
+
+def test_inject_attaches_four_surfaces_random_init():
+    """``allow_random_init=True`` attaches ``mtp`` / ``mtp_forward`` /
+    ``make_mtp_cache`` / ``__call__(return_hidden, n_confirmed)`` and a
+    forward through them produces the right shapes."""
+    from vllm_mlx.spec_decode.mtp.hy3_inject import (
+        inject_hy3_mtp_support,
+        validate_hy3_mtp_support,
+    )
+
+    model = _build_tiny_hy3_model()
+    assert inject_hy3_mtp_support(model, allow_random_init=True) is True
+    assert validate_hy3_mtp_support(model) is True
+
+    ids = mx.array([[1, 2, 3, 4]])
+    out, hidden = model(ids, return_hidden=True)
+    assert out.shape == (1, 4, 128)
+    assert hidden.shape == (1, 4, 64)
+
+    mtp_cache = model.make_mtp_cache()
+    mtp_logits = model.mtp_forward(hidden, ids, mtp_cache)
+    mx.eval(mtp_logits)
+    assert mtp_logits.shape == (1, 4, 128)
+
+
+def test_validate_false_before_inject():
+    """A vanilla HY3 model has none of the MTP surfaces."""
+    from vllm_mlx.spec_decode.mtp.hy3_inject import validate_hy3_mtp_support
+
+    model = _build_tiny_hy3_model()
+    assert validate_hy3_mtp_support(model) is False
+
+
+# ---------------------------------------------------------------------------
+# 4. Sidecar refusal / missing-tensor refusal
+# ---------------------------------------------------------------------------
+
+
+def test_inject_refuses_unresolvable_sidecar():
+    """A sidecar path that resolves to nothing → False, model unmodified."""
+    from vllm_mlx.spec_decode.mtp.hy3_inject import (
+        inject_hy3_mtp_support,
+        validate_hy3_mtp_support,
+    )
+
+    model = _build_tiny_hy3_model()
+    ok = inject_hy3_mtp_support(model, mtp_sidecar="/nonexistent/path/nowhere")
+    assert ok is False
+    assert validate_hy3_mtp_support(model) is False
+
+
+def test_inject_refuses_sidecar_missing_tensor(tmp_path):
+    """A sidecar missing a required tensor is rejected (no partial-random
+    head), mirroring the qwen3_5 coverage check."""
+    from mlx.utils import tree_flatten
+
+    from vllm_mlx.spec_decode.mtp.hy3_head import build_hy3_mtp_module
+    from vllm_mlx.spec_decode.mtp.hy3_inject import (
+        inject_hy3_mtp_support,
+        validate_hy3_mtp_support,
+    )
+
+    # Build the (unquantized) param tree, then drop one tensor.
+    args = _tiny_hy3_args()
+    template = build_hy3_mtp_module(args, 1)
+    weights = dict(tree_flatten(template.parameters()))
+    weights.pop("eh_proj.weight")  # required — must trip the coverage gate
+    for k in list(weights):
+        mx.eval(weights[k])
+    side_dir = tmp_path / "sidecar"
+    side_dir.mkdir()
+    mx.save_safetensors(str(side_dir / "model-mtp.safetensors"), weights)
+
+    model = _build_tiny_hy3_model()
+    # Base is unquantized here, so the injected head is unquantized too;
+    # the coverage gate compares against that same tree.
+    ok = inject_hy3_mtp_support(model, mtp_sidecar=str(side_dir))
+    assert ok is False
+    assert validate_hy3_mtp_support(model) is False
+
+
+def test_inject_loads_synthetic_full_sidecar(tmp_path):
+    """A complete sidecar (all required tensors) round-trips through
+    inject → validate → True."""
+    from mlx.utils import tree_flatten
+
+    from vllm_mlx.spec_decode.mtp.hy3_head import build_hy3_mtp_module
+    from vllm_mlx.spec_decode.mtp.hy3_inject import (
+        inject_hy3_mtp_support,
+        validate_hy3_mtp_support,
+    )
+
+    args = _tiny_hy3_args()
+    template = build_hy3_mtp_module(args, 1)
+    weights = dict(tree_flatten(template.parameters()))
+    for k in list(weights):
+        mx.eval(weights[k])
+    side_dir = tmp_path / "sidecar"
+    side_dir.mkdir()
+    mx.save_safetensors(str(side_dir / "model-mtp.safetensors"), weights)
+
+    model = _build_tiny_hy3_model()
+    assert inject_hy3_mtp_support(model, mtp_sidecar=str(side_dir)) is True
+    assert validate_hy3_mtp_support(model) is True
+
+
+# ---------------------------------------------------------------------------
+# 5. Architecture guard
+# ---------------------------------------------------------------------------
+
+
+def test_inject_refuses_model_without_num_nextn():
+    """A HY3-shaped model whose config advertises no next-n layer builds
+    no head (num_nextn_predict_layers=0)."""
+    from vllm_mlx.spec_decode.mtp.hy3_inject import (
+        inject_hy3_mtp_support,
+        validate_hy3_mtp_support,
+    )
+
+    model = _build_tiny_hy3_model(num_nextn_predict_layers=0)
+    ok = inject_hy3_mtp_support(model, allow_random_init=True)
+    assert ok is False
+    assert validate_hy3_mtp_support(model) is False
+
+
+# ---------------------------------------------------------------------------
+# 6. Dispatcher routing
+# ---------------------------------------------------------------------------
+
+
+def test_dispatch_tables_route_hy_v3():
+    """``hy_v3`` is registered in both dispatch tables → the family
+    inject / validate entry points."""
+    from vllm_mlx.spec_decode.mtp.dispatch import (
+        _MTP_INJECT_DISPATCH,
+        _MTP_VALIDATE_DISPATCH,
+    )
+
+    assert _MTP_INJECT_DISPATCH["hy_v3"] == (
+        "vllm_mlx.spec_decode.mtp.hy3_inject",
+        "inject_hy3_mtp_support",
+    )
+    assert _MTP_VALIDATE_DISPATCH["hy_v3"] == (
+        "vllm_mlx.spec_decode.mtp.hy3_inject",
+        "validate_hy3_mtp_support",
+    )
+
+
+def test_dispatch_inject_routes_and_attaches():
+    """End-to-end through the dispatcher: ``dispatch_mtp_inject(model,
+    'hy_v3', allow_random_init=True)`` attaches the surfaces, and
+    ``dispatch_mtp_validate`` confirms them."""
+    from vllm_mlx.spec_decode.mtp import (
+        dispatch_mtp_inject,
+        dispatch_mtp_validate,
+    )
+
+    model = _build_tiny_hy3_model()
+    assert (
+        dispatch_mtp_inject(model, "hy_v3", allow_random_init=True) is True
+    )
+    assert dispatch_mtp_validate(model, "hy_v3") is True
+
+
+# ---------------------------------------------------------------------------
+# 7. Default sidecar repo
+# ---------------------------------------------------------------------------
+
+
+def test_default_sidecar_repo_constant():
+    """The module exposes the published-sidecar default so a bare
+    ``--speculative-config '{"method":"mtp"}'`` boot auto-resolves it."""
+    from vllm_mlx.spec_decode.mtp import hy3_inject
+
+    assert hy3_inject.DEFAULT_HY3_MTP_SIDECAR == "mlx-community/Hy3-preview-MTP-4bit"

--- a/tests/test_mtp_hy3_inject.py
+++ b/tests/test_mtp_hy3_inject.py
@@ -78,6 +78,12 @@ def _build_tiny_hy3_model(**overrides):
     return Model(_tiny_hy3_args(**overrides))
 
 
+def _resolve_inner(model):
+    from vllm_mlx.spec_decode.mtp.hy3_inject import _resolve_inner_model
+
+    return _resolve_inner_model(model)
+
+
 # ---------------------------------------------------------------------------
 # 1. Detection — num_nextn_predict_layers vs mtp_num_hidden_layers
 # ---------------------------------------------------------------------------
@@ -206,14 +212,27 @@ def test_inject_attaches_four_surfaces_random_init():
     mtp_logits = model.mtp_forward(hidden, ids, mtp_cache)
     mx.eval(mtp_logits)
     assert mtp_logits.shape == (1, 4, 128)
-    # Beyond shape (codex R4 NIT #4): the head must actually consume BOTH the
-    # embedding of next_token_ids AND the prev hidden state via eh_proj(concat)
-    # — a degenerate/constant head would emit identical logits at every
-    # position, and a NaN would slip through a shape-only check. Assert the
-    # output is finite and position-varying (the two token/hidden pairs differ,
-    # so their fused logits must too).
     assert bool(mx.all(mx.isfinite(mtp_logits)).item())
-    assert not bool(mx.allclose(mtp_logits[:, 0, :], mtp_logits[:, 1, :]).item())
+
+    # Prove the head consumes BOTH next_token_ids AND the prev hidden state via
+    # eh_proj(concat([enorm(embed(ids)), hnorm(hidden)])) — codex R5 BLOCKING
+    # #2. Vary ONLY ids (hidden fixed) then ONLY hidden (ids fixed); each
+    # perturbation must move the logits. A prior single-forward "both differ"
+    # check would pass even if one input were ignored, so perturb them
+    # independently with a fresh cache each time.
+    ids_b = mx.array([[5, 6, 7, 8]])
+    logits_ids_perturbed = model.mtp_forward(hidden, ids_b, model.make_mtp_cache())
+    mx.eval(logits_ids_perturbed)
+    assert not bool(mx.allclose(logits_ids_perturbed, mtp_logits).item()), (
+        "changing next_token_ids did not change MTP logits — ids input ignored"
+    )
+
+    hidden_b = hidden + 1.0
+    logits_hidden_perturbed = model.mtp_forward(hidden_b, ids, model.make_mtp_cache())
+    mx.eval(logits_hidden_perturbed)
+    assert not bool(mx.allclose(logits_hidden_perturbed, mtp_logits).item()), (
+        "changing the hidden state did not change MTP logits — hidden input ignored"
+    )
 
 
 def test_validate_false_before_inject():
@@ -352,9 +371,14 @@ def test_inject_refuses_integer_packed_wrong_kind(tmp_path):
     weights = dict(tree_flatten(template.parameters()))
     for k in list(weights):
         mx.eval(weights[k])
-    # Corrupt one float tensor into a packed-integer of a different shape,
-    # simulating a wrong-quant sidecar. Must be caught by the guard.
-    weights["eh_proj.weight"] = mx.zeros((4, 2), dtype=mx.uint32)
+    # Flip one float tensor to a packed-integer (uint32) while KEEPING its exact
+    # expected shape, so ONLY the dtype-category guard can reject it — if shape
+    # also differed, the shape check would pass the test even with the dtype
+    # guard removed (codex R5 BLOCKING #3). This isolates the dtype-category
+    # branch: a packed sidecar landing on an unquantized/differently-quantized
+    # head shows up as int-where-float-expected.
+    expected_shape = weights["eh_proj.weight"].shape
+    weights["eh_proj.weight"] = mx.zeros(expected_shape, dtype=mx.uint32)
     mx.eval(weights["eh_proj.weight"])
     side_dir = tmp_path / "sidecar"
     side_dir.mkdir()
@@ -363,6 +387,66 @@ def test_inject_refuses_integer_packed_wrong_kind(tmp_path):
     model = _build_tiny_hy3_model()
     assert inject_hy3_mtp_support(model, mtp_sidecar=str(side_dir)) is False
     assert validate_hy3_mtp_support(model) is False
+
+
+def test_inject_quantized_base_packed_sidecar_round_trip(tmp_path):
+    """Exercise the PRODUCTION packed path (codex R5 NIT): quantize the base
+    model so inject detects a quant spec and quantizes the head, build a sidecar
+    whose tensors are the head's quantized (packed uint32) params, then inject +
+    run mtp_forward. Every other sidecar-loading test uses an unquantized tiny
+    model, so this is the only coverage of the nn.quantize layout + packed load.
+    """
+    import mlx.nn as nn
+    from mlx.utils import tree_flatten
+
+    from vllm_mlx.spec_decode.mtp.hy3_head import build_hy3_mtp_module
+    from vllm_mlx.spec_decode.mtp.hy3_inject import (
+        _detect_base_quantization,
+        inject_hy3_mtp_support,
+        validate_hy3_mtp_support,
+    )
+
+    bits, gs = 4, 32  # smallest tiny-model quantizable dim is 32 (experts)
+
+    # Quantize the BASE model so inject's _detect_base_quantization returns a
+    # spec and the head is quantized to match.
+    model = _build_tiny_hy3_model()
+
+    def _q_pred(path, module):
+        if not hasattr(module, "to_quantized"):
+            return False
+        if path.endswith("mlp.router.gate"):
+            return {"group_size": gs, "bits": 8}
+        return True
+
+    nn.quantize(model.model, group_size=gs, bits=bits, class_predicate=_q_pred)
+    detected = _detect_base_quantization(_resolve_inner(model))
+    assert detected == {"bits": bits, "group_size": gs}
+
+    # Build + quantize a head the SAME way inject does, then dump its (packed)
+    # params as the sidecar so load_weights sees real uint32 packed tensors.
+    args = _tiny_hy3_args()
+    head = build_hy3_mtp_module(args, 1)
+    nn.quantize(head, group_size=gs, bits=bits, class_predicate=_q_pred)
+    packed = dict(tree_flatten(head.parameters()))
+    for k in list(packed):
+        mx.eval(packed[k])
+    assert any(v.dtype == mx.uint32 for v in packed.values()), (
+        "expected packed uint32 tensors in a quantized head"
+    )
+    side_dir = tmp_path / "sidecar"
+    side_dir.mkdir()
+    mx.save_safetensors(str(side_dir / "model-mtp.safetensors"), packed)
+
+    assert inject_hy3_mtp_support(model, mtp_sidecar=str(side_dir)) is True
+    assert validate_hy3_mtp_support(model) is True
+
+    ids = mx.array([[1, 2, 3, 4]])
+    _, hidden = model(ids, return_hidden=True)
+    logits = model.mtp_forward(hidden, ids, model.make_mtp_cache())
+    mx.eval(logits)
+    assert logits.shape == (1, 4, 128)
+    assert bool(mx.all(mx.isfinite(logits)).item())
 
 
 def test_inject_refuses_multi_nextn_layer_config():

--- a/tests/test_mtp_hy3_inject.py
+++ b/tests/test_mtp_hy3_inject.py
@@ -430,32 +430,59 @@ def test_inject_refuses_integer_packed_wrong_kind(tmp_path):
 
 def test_inject_refuses_same_shape_wrong_integer_dtype(tmp_path):
     """Tighter dtype guard (codex R8 BLOCKING #1): the check requires EXACT
-    dtype equality unless BOTH sides are floating. A same-shape tensor whose
-    dtype is a *different* non-float type than expected — e.g. a signed int32 or
-    a bool where a floating (or packed uint32) parameter is expected — must be
-    refused, not waved through by a coarse float-vs-int category test."""
+    dtype equality unless BOTH sides are floating.
+
+    This targets the branch the tightening actually ADDED. The coarse
+    float-vs-int-category predecessor already rejected a non-float tensor in a
+    float slot, so a bool-where-float substitution proves nothing (codex R10
+    BLOCKING: that test passed even against the loose guard). The distinguishing
+    case is *two different non-float dtypes*: a quantized head expects a packed
+    ``uint32`` parameter, and a same-shape signed ``int32`` sidecar tensor —
+    which the coarse guard waved through (both "int") — must now be refused."""
+    import mlx.nn as nn
     from mlx.utils import tree_flatten
 
     from vllm_mlx.spec_decode.mtp.hy3_head import build_hy3_mtp_module
     from vllm_mlx.spec_decode.mtp.hy3_inject import (
+        _detect_base_quantization,
         inject_hy3_mtp_support,
         validate_hy3_mtp_support,
     )
 
+    bits, gs = 4, 32
+
+    def _q_pred(path, module):
+        if not hasattr(module, "to_quantized"):
+            return False
+        if path.endswith("mlp.router.gate"):
+            return {"group_size": gs, "bits": 8}
+        return True
+
+    # Quantize the base so inject detects a quant spec and EXPECTS a packed
+    # uint32 head — the only way a non-float parameter is the expected dtype.
+    model = _build_tiny_hy3_model()
+    nn.quantize(model.model, group_size=gs, bits=bits, class_predicate=_q_pred)
+    assert _detect_base_quantization(_resolve_inner(model)) == {
+        "bits": bits,
+        "group_size": gs,
+    }
+
+    # Build + quantize a head the same way inject does, then corrupt ONE packed
+    # uint32 tensor into a same-shape int32 (a *different* non-float dtype).
     args = _tiny_hy3_args()
-    template = build_hy3_mtp_module(args, 1)
-    weights = dict(tree_flatten(template.parameters()))
-    for k in list(weights):
-        mx.eval(weights[k])
-    # bool where a float weight is expected: same shape, not floating -> refuse.
-    shape = weights["eh_proj.weight"].shape
-    weights["eh_proj.weight"] = mx.zeros(shape, dtype=mx.bool_)
-    mx.eval(weights["eh_proj.weight"])
+    head = build_hy3_mtp_module(args, 1)
+    nn.quantize(head, group_size=gs, bits=bits, class_predicate=_q_pred)
+    packed = dict(tree_flatten(head.parameters()))
+    for k in list(packed):
+        mx.eval(packed[k])
+    uint32_key = next(k for k, v in packed.items() if v.dtype == mx.uint32)
+    packed[uint32_key] = mx.zeros(packed[uint32_key].shape, dtype=mx.int32)
+    mx.eval(packed[uint32_key])
     side_dir = tmp_path / "sidecar"
     side_dir.mkdir()
-    mx.save_safetensors(str(side_dir / "model-mtp.safetensors"), weights)
+    mx.save_safetensors(str(side_dir / "model-mtp.safetensors"), packed)
 
-    model = _build_tiny_hy3_model()
+    # int32-where-uint32-expected: same shape, both non-float, dtype differs.
     assert inject_hy3_mtp_support(model, mtp_sidecar=str(side_dir)) is False
     assert validate_hy3_mtp_support(model) is False
 

--- a/tests/test_mtp_hy3_inject.py
+++ b/tests/test_mtp_hy3_inject.py
@@ -356,3 +356,60 @@ def test_default_sidecar_repo_constant():
     from vllm_mlx.spec_decode.mtp import hy3_inject
 
     assert hy3_inject.DEFAULT_HY3_MTP_SIDECAR == "mlx-community/Hy3-preview-MTP-4bit"
+
+
+# ---------------------------------------------------------------------------
+# 8. Codex-hardening regressions (PR #1094 review)
+# ---------------------------------------------------------------------------
+
+
+def test_inject_resolver_reads_mtp_num_hidden_layers_fallback():
+    """detect + inject must agree on the layer-count key set. A hy_v3 config
+    that only carries ``mtp_num_hidden_layers`` (the hand-converted alias)
+    must be resolvable by the inject resolver too — otherwise detection deems
+    it eligible but inject refuses (codex BLOCKING #2)."""
+    from vllm_mlx.spec_decode.mtp import MTPEligibility, detect_mtp_eligibility
+    from vllm_mlx.spec_decode.mtp.hy3_inject import (
+        inject_hy3_mtp_support,
+        validate_hy3_mtp_support,
+    )
+
+    # Detection accepts the fallback key.
+    cfg = {"model_type": "hy_v3", "mtp_num_hidden_layers": 1}
+    assert detect_mtp_eligibility(cfg) is MTPEligibility.CHAIN
+
+    # Inject must accept a model whose args carry ONLY the fallback key.
+    model = _build_tiny_hy3_model(num_nextn_predict_layers=0)
+    model.args.mtp_num_hidden_layers = 1  # hand-converted alias on the args
+    assert inject_hy3_mtp_support(model, allow_random_init=True) is True
+    assert validate_hy3_mtp_support(model) is True
+
+
+def test_default_sidecar_pinned_revision_constant():
+    """The default sidecar carries an immutable pinned revision (codex
+    BLOCKING #1) — never resolves a mutable HEAD in production."""
+    from vllm_mlx.spec_decode.mtp import hy3_inject
+
+    rev = hy3_inject.DEFAULT_HY3_MTP_SIDECAR_REVISION
+    assert isinstance(rev, str) and len(rev) == 40  # full commit SHA
+    assert all(c in "0123456789abcdef" for c in rev)
+
+
+def test_default_sidecar_refused_on_quant_mismatch(monkeypatch):
+    """The default (4-bit gs64) sidecar is refused when the base is a
+    different quant (codex BLOCKING #3) — it would load shape-incompatible
+    tensors. An explicit sidecar bypasses the gate."""
+    from vllm_mlx.spec_decode.mtp import hy3_inject
+
+    model = _build_tiny_hy3_model()
+
+    # Pretend the base is 8-bit (not the default sidecar's 4-bit).
+    monkeypatch.setattr(
+        hy3_inject,
+        "_detect_base_quantization",
+        lambda inner: {"bits": 8, "group_size": 64},
+    )
+    # No explicit sidecar → default path → quant gate must refuse.
+    ok = hy3_inject.inject_hy3_mtp_support(model)
+    assert ok is False
+    assert hy3_inject.validate_hy3_mtp_support(model) is False

--- a/tests/test_mtp_hy3_inject.py
+++ b/tests/test_mtp_hy3_inject.py
@@ -289,6 +289,74 @@ def test_inject_loads_synthetic_full_sidecar(tmp_path):
     assert validate_hy3_mtp_support(model) is True
 
 
+def test_inject_accepts_bf16_sidecar_against_fp32_template(tmp_path):
+    """A real sidecar carries bf16 unquantized tensors (RMSNorm weights,
+    biases) while the freshly-initialised template is fp32. The shape/dtype
+    guard must compare the dtype *category* (float vs int/packed), NOT the
+    exact float width, or it rejects a perfectly valid bf16 sidecar.
+
+    Regression for the codex-BLOCKING finding: the earlier synthetic test
+    (``test_inject_loads_synthetic_full_sidecar``) missed this because both
+    the sidecar and the template originated from the same fp32 initialiser.
+    Here we force the sidecar to bf16 so the two sides differ in float width.
+    """
+    from mlx.utils import tree_flatten
+
+    from vllm_mlx.spec_decode.mtp.hy3_head import build_hy3_mtp_module
+    from vllm_mlx.spec_decode.mtp.hy3_inject import (
+        inject_hy3_mtp_support,
+        validate_hy3_mtp_support,
+    )
+
+    args = _tiny_hy3_args()
+    template = build_hy3_mtp_module(args, 1)
+    weights = {}
+    for k, v in tree_flatten(template.parameters()):
+        vb = v.astype(mx.bfloat16)  # sidecar ships bf16, template is fp32
+        mx.eval(vb)
+        weights[k] = vb
+    assert any(v.dtype == mx.bfloat16 for v in weights.values())
+    side_dir = tmp_path / "sidecar"
+    side_dir.mkdir()
+    mx.save_safetensors(str(side_dir / "model-mtp.safetensors"), weights)
+
+    model = _build_tiny_hy3_model()
+    assert inject_hy3_mtp_support(model, mtp_sidecar=str(side_dir)) is True
+    assert validate_hy3_mtp_support(model) is True
+
+
+def test_inject_refuses_integer_packed_wrong_kind(tmp_path):
+    """The guard must still reject a genuine quant mismatch: a tensor that
+    arrives as a packed integer (uint32) where the unquantized template
+    expects a floating tensor is a float-vs-int category flip and is refused
+    (this is what an 8-bit-packed sidecar landing on an unquantized/4-bit
+    head looks like)."""
+    from mlx.utils import tree_flatten
+
+    from vllm_mlx.spec_decode.mtp.hy3_head import build_hy3_mtp_module
+    from vllm_mlx.spec_decode.mtp.hy3_inject import (
+        inject_hy3_mtp_support,
+        validate_hy3_mtp_support,
+    )
+
+    args = _tiny_hy3_args()
+    template = build_hy3_mtp_module(args, 1)
+    weights = dict(tree_flatten(template.parameters()))
+    for k in list(weights):
+        mx.eval(weights[k])
+    # Corrupt one float tensor into a packed-integer of a different shape,
+    # simulating a wrong-quant sidecar. Must be caught by the guard.
+    weights["eh_proj.weight"] = mx.zeros((4, 2), dtype=mx.uint32)
+    mx.eval(weights["eh_proj.weight"])
+    side_dir = tmp_path / "sidecar"
+    side_dir.mkdir()
+    mx.save_safetensors(str(side_dir / "model-mtp.safetensors"), weights)
+
+    model = _build_tiny_hy3_model()
+    assert inject_hy3_mtp_support(model, mtp_sidecar=str(side_dir)) is False
+    assert validate_hy3_mtp_support(model) is False
+
+
 # ---------------------------------------------------------------------------
 # 5. Architecture guard
 # ---------------------------------------------------------------------------

--- a/tests/test_mtp_hy3_inject.py
+++ b/tests/test_mtp_hy3_inject.py
@@ -235,6 +235,45 @@ def test_inject_attaches_four_surfaces_random_init():
     )
 
 
+def test_inject_forward_warm_cache_offset():
+    """The injected __call__ must pass a single KVCache (cache[0]) — not the
+    list — to create_attention_mask so the offset-aware make_mask path runs.
+
+    Regression for a codex R6 false positive that proposed passing the whole
+    cache list: mlx-lm's create_attention_mask gates on
+    ``hasattr(cache, "make_mask")``, which a list lacks, so the list form would
+    silently drop the warm-cache offset. Here we prefill a real KVCache with a
+    prompt, then continue with more tokens, and require the warm continuation to
+    match the equivalent slice of a single full-length forward (offset correct).
+    """
+    from mlx_lm.models.cache import KVCache
+
+    from vllm_mlx.spec_decode.mtp.hy3_inject import inject_hy3_mtp_support
+
+    model = _build_tiny_hy3_model()
+    assert inject_hy3_mtp_support(model, allow_random_init=True) is True
+
+    full_ids = mx.array([[1, 2, 3, 4, 5, 6]])
+    # (a) one full-length forward, no cache.
+    full_out, _ = model(full_ids, return_hidden=True)
+    mx.eval(full_out)
+
+    # (b) prefill first 4 tokens into a warm cache, then continue with 2 more.
+    cache = [KVCache() for _ in range(len(model.model.layers))]
+    _ = model(full_ids[:, :4], cache=cache, return_hidden=True)
+    cont_out, _ = model(full_ids[:, 4:], cache=cache, return_hidden=True)
+    mx.eval(cont_out)
+
+    # The warm continuation's logits for positions 4..5 must match the full
+    # forward's positions 4..5 — only true if the attention offset is applied
+    # (i.e. cache[0].make_mask ran). A dropped offset would misalign attention.
+    assert cont_out.shape == (1, 2, 128)
+    assert bool(mx.allclose(cont_out, full_out[:, 4:, :], atol=1e-4).item()), (
+        "warm-cache continuation diverged from full forward — attention offset "
+        "was not applied (mask must receive cache[0], not the list)"
+    )
+
+
 def test_validate_false_before_inject():
     """A vanilla HY3 model has none of the MTP surfaces."""
     from vllm_mlx.spec_decode.mtp.hy3_inject import validate_hy3_mtp_support

--- a/tests/test_mtp_hy3_inject.py
+++ b/tests/test_mtp_hy3_inject.py
@@ -341,9 +341,7 @@ def test_dispatch_inject_routes_and_attaches():
     )
 
     model = _build_tiny_hy3_model()
-    assert (
-        dispatch_mtp_inject(model, "hy_v3", allow_random_init=True) is True
-    )
+    assert dispatch_mtp_inject(model, "hy_v3", allow_random_init=True) is True
     assert dispatch_mtp_validate(model, "hy_v3") is True
 
 

--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -1143,7 +1143,7 @@
     "reasoning_parser": "hy_v3",
     "is_hybrid": false,
     "is_moe": true,
-    "supports_spec_decode": false,
+    "supports_spec_decode": true,
     "min_memory_gb": 192
   },
   "qwen3-vl-8b-4bit": {

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -1810,7 +1810,7 @@ def _config_vetted_mtp_supports_spec_decode(model_type: str | None) -> bool:
     narrowly tied to the model families this MTP runtime supports.
     """
 
-    return model_type in {"qwen3_5", "qwen3_5_moe"}
+    return model_type in {"qwen3_5", "qwen3_5_moe", "hy_v3"}
 
 
 def _install_suffix_decoding(

--- a/vllm_mlx/spec_decode/mtp/detect.py
+++ b/vllm_mlx/spec_decode/mtp/detect.py
@@ -1,5 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Qwen3.5 / Qwen3.6 MTP architecture detection (R15 task #302).
+"""Native-MTP architecture detection (R15 task #302).
+
+Covers the families whose model class ships a driveable MTP head: Qwen3.5 /
+Qwen3.6 (``mtp_num_hidden_layers``) and HY3 / Tencent Hunyuan 3
+(``num_nextn_predict_layers``).
 
 Detection lives off the loaded ``config.json`` dict rather than the
 ``aliases.json`` schema. Reasons:
@@ -70,6 +74,11 @@ _SUPPORTED_MODEL_TYPES: frozenset[str] = frozenset(
         # Qwen3.5 / Qwen3.6 (upstream PR #990)
         "qwen3_5",
         "qwen3_5_moe",
+        # HY3 (Tencent Hunyuan 3) — DeepSeek-V3-style native MTP head at
+        # layer ``num_hidden_layers``. Config advertises the count under
+        # ``num_nextn_predict_layers`` (not ``mtp_num_hidden_layers``); the
+        # per-family fallback in ``_mtp_num_hidden_layers`` handles that.
+        "hy_v3",
     }
 )
 
@@ -107,15 +116,30 @@ def _safe_int(value: Any, default: int = 0) -> int:
 
 
 def _mtp_num_hidden_layers(config: dict[str, Any]) -> int:
-    """Return MTP layer count from root or nested text_config metadata."""
+    """Return MTP layer count from root or nested text_config metadata.
 
-    root_layers = _safe_int(config.get("mtp_num_hidden_layers"), 0)
-    if root_layers > 0:
-        return root_layers
+    Per-family field name: Qwen3.5 / Qwen3.6 use ``mtp_num_hidden_layers``;
+    HY3 (``model_type == "hy_v3"``) uses ``num_nextn_predict_layers`` (the
+    DeepSeek-V3 convention). Both are checked at root and under
+    ``text_config``.
+    """
+
+    # Family-specific field keys, most-specific first.
+    keys = ("mtp_num_hidden_layers",)
+    if config.get("model_type") == "hy_v3":
+        keys = ("num_nextn_predict_layers", "mtp_num_hidden_layers")
+
+    for key in keys:
+        root_layers = _safe_int(config.get(key), 0)
+        if root_layers > 0:
+            return root_layers
     text_config = config.get("text_config")
     if isinstance(text_config, dict):
-        return _safe_int(text_config.get("mtp_num_hidden_layers"), 0)
-    return root_layers
+        for key in keys:
+            n = _safe_int(text_config.get(key), 0)
+            if n > 0:
+                return n
+    return 0
 
 
 def detect_mtp_eligibility(

--- a/vllm_mlx/spec_decode/mtp/dispatch.py
+++ b/vllm_mlx/spec_decode/mtp/dispatch.py
@@ -51,6 +51,11 @@ _MTP_INJECT_DISPATCH: dict[str, tuple[str, str]] = {
         "vllm_mlx.spec_decode.mtp.qwen3_5_inject",
         "inject_mtp_support",
     ),
+    # HY3 (Tencent Hunyuan 3) native MTP head.
+    "hy_v3": (
+        "vllm_mlx.spec_decode.mtp.hy3_inject",
+        "inject_hy3_mtp_support",
+    ),
 }
 
 
@@ -65,6 +70,11 @@ _MTP_VALIDATE_DISPATCH: dict[str, tuple[str, str]] = {
     "qwen3_5_moe": (
         "vllm_mlx.spec_decode.mtp.qwen3_5_inject",
         "validate_mtp_support",
+    ),
+    # HY3 native MTP head.
+    "hy_v3": (
+        "vllm_mlx.spec_decode.mtp.hy3_inject",
+        "validate_hy3_mtp_support",
     ),
 }
 

--- a/vllm_mlx/spec_decode/mtp/hy3_head.py
+++ b/vllm_mlx/spec_decode/mtp/hy3_head.py
@@ -1,0 +1,109 @@
+# SPDX-License-Identifier: Apache-2.0
+"""HY3 (Tencent Hunyuan 3) native MTP head — DeepSeek-V3-style single next-n layer.
+
+Unlike Qwen3.5's MTP head (``vllm_mlx.spec_decode.mtp.head._MTPModule``), HY3's
+MTP layer is DeepSeek-V3-shaped:
+
+* two RMSNorms named ``enorm`` (applied to the *next-token embedding*) and
+  ``hnorm`` (applied to the *previous backbone hidden state*);
+* a 2H->H concat projection ``eh_proj`` (no bias) with the concat order
+  ``eh_proj(cat([enorm(embed), hnorm(prev_hidden)], axis=-1))`` — **embedding
+  first** (confirmed from vLLM ``deepseek_mtp.py`` and SGLang ``hunyuan_v3``
+  nextn: both apply ``enorm`` to ``inputs_embeds`` and place it first in the
+  cat);
+* a single HY3 ``DecoderLayer`` (QK-norm attention + sigmoid-router SwitchGLU
+  MoE + a shared expert) forced onto the MoE branch;
+* a final RMSNorm ``norm`` (== upstream ``final_layernorm``);
+* the shared backbone ``lm_head`` for the projection (HY3 has
+  ``tie_word_embeddings=false``).
+
+We reuse :class:`vllm_mlx.models.hy_v3.DecoderLayer` verbatim for the transformer
+block so the sidecar's quantized param tree is byte-identical to a quantized
+backbone MoE layer (same ``self_attn.q_norm``, ``mlp.router.gate``,
+``mlp.router.expert_bias``, ``mlp.switch_mlp.*``, ``mlp.shared_mlp.*`` names).
+The DecoderLayer is constructed with ``layer_idx=first_k_dense_replace`` (== 1)
+so ``layer_idx < first_k_dense_replace`` is False and it takes the MoE branch
+(matches SGLang's ``config.first_k_dense_replace = 0`` override for the nextn
+decoder).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def build_hy3_mtp_module(args: Any, num_layers: int):
+    """Construct a fresh ``_HY3MTPModule`` matching the HY3 layer-80 schema.
+
+    Args:
+        args: A :class:`vllm_mlx.models.hy_v3.ModelArgs` dataclass (carries
+            ``hidden_size``, ``rms_norm_eps``, ``num_experts``,
+            ``first_k_dense_replace``, all attention args, etc.).
+        num_layers: ``num_nextn_predict_layers`` from config (== 1 for HY3).
+
+    Returns:
+        An ``nn.Module`` whose forward is
+        ``(hidden_states, next_token_ids, embed_tokens, cache=None)
+        -> hidden_states_pre_lm_head``. The caller applies the shared
+        ``lm_head`` on the returned tensor.
+    """
+    import mlx.core as mx
+    import mlx.nn as nn
+    from mlx_lm.models.base import create_attention_mask
+
+    from vllm_mlx.models.hy_v3 import DecoderLayer
+
+    if num_layers < 1:
+        raise ValueError(
+            f"build_hy3_mtp_module requires num_layers >= 1; got {num_layers}"
+        )
+    if num_layers != 1:
+        # HY3 ships exactly one next-n layer. Guard so a future >1 config
+        # doesn't silently under-run.
+        raise ValueError(
+            f"HY3 MTP supports exactly 1 next-n layer; got {num_layers}"
+        )
+
+    fkdr = int(getattr(args, "first_k_dense_replace", 1))
+    # Force the MoE branch: DecoderLayer picks MoE iff layer_idx >= fkdr.
+    moe_layer_idx = max(fkdr, 1)
+
+    class _HY3MTPModule(nn.Module):
+        """DeepSeek-V3-style MTP head for HY3 (embedding-first eh_proj concat)."""
+
+        def __init__(self, mod_args, n_layers):
+            super().__init__()
+            self.enorm = nn.RMSNorm(mod_args.hidden_size, eps=mod_args.rms_norm_eps)
+            self.hnorm = nn.RMSNorm(mod_args.hidden_size, eps=mod_args.rms_norm_eps)
+            self.eh_proj = nn.Linear(
+                mod_args.hidden_size * 2, mod_args.hidden_size, bias=False
+            )
+            # Single HY3 DecoderLayer on the MoE branch.
+            self.layers = [DecoderLayer(mod_args, moe_layer_idx) for _ in range(n_layers)]
+            self.norm = nn.RMSNorm(mod_args.hidden_size, eps=mod_args.rms_norm_eps)
+
+        def __call__(
+            self,
+            hidden_states: mx.array,
+            next_token_ids: mx.array,
+            embed_tokens: nn.Embedding,
+            cache: Any | None = None,
+        ) -> mx.array:
+            # embed next tokens, then DeepSeek-V3-style fused projection.
+            embeds = embed_tokens(next_token_ids)  # (B, N, H)
+            e = self.enorm(embeds)
+            h = self.hnorm(hidden_states)
+            # EMBEDDING FIRST — confirmed from vLLM deepseek_mtp.py /
+            # SGLang hunyuan_v3 nextn.
+            fused = self.eh_proj(mx.concatenate([e, h], axis=-1))  # (B, N, H)
+
+            if cache is None:
+                cache = [None] * len(self.layers)
+
+            mask = create_attention_mask(fused, cache[0])
+            for layer, c in zip(self.layers, cache):
+                fused = layer(fused, mask=mask, cache=c)
+
+            return self.norm(fused)  # (B, N, H)
+
+    return _HY3MTPModule(args, num_layers)

--- a/vllm_mlx/spec_decode/mtp/hy3_head.py
+++ b/vllm_mlx/spec_decode/mtp/hy3_head.py
@@ -60,9 +60,7 @@ def build_hy3_mtp_module(args: Any, num_layers: int):
     if num_layers != 1:
         # HY3 ships exactly one next-n layer. Guard so a future >1 config
         # doesn't silently under-run.
-        raise ValueError(
-            f"HY3 MTP supports exactly 1 next-n layer; got {num_layers}"
-        )
+        raise ValueError(f"HY3 MTP supports exactly 1 next-n layer; got {num_layers}")
 
     fkdr = int(getattr(args, "first_k_dense_replace", 1))
     # Force the MoE branch: DecoderLayer picks MoE iff layer_idx >= fkdr.
@@ -79,7 +77,9 @@ def build_hy3_mtp_module(args: Any, num_layers: int):
                 mod_args.hidden_size * 2, mod_args.hidden_size, bias=False
             )
             # Single HY3 DecoderLayer on the MoE branch.
-            self.layers = [DecoderLayer(mod_args, moe_layer_idx) for _ in range(n_layers)]
+            self.layers = [
+                DecoderLayer(mod_args, moe_layer_idx) for _ in range(n_layers)
+            ]
             self.norm = nn.RMSNorm(mod_args.hidden_size, eps=mod_args.rms_norm_eps)
 
         def __call__(

--- a/vllm_mlx/spec_decode/mtp/hy3_inject.py
+++ b/vllm_mlx/spec_decode/mtp/hy3_inject.py
@@ -1,0 +1,348 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Runtime MTP injection for HY3 (Tencent Hunyuan 3, ``model_type=hy_v3``).
+
+Forked from :mod:`vllm_mlx.spec_decode.mtp.qwen3_5_inject`. HY3's native MTP head
+is DeepSeek-V3-shaped (``enorm``/``hnorm``/``eh_proj``), not Qwen3.5-shaped
+(``pre_fc_norm_*``/``fc``), so we build the head from
+:func:`vllm_mlx.spec_decode.mtp.hy3_head.build_hy3_mtp_module` and inject the same
+four contract surfaces the generator needs:
+
+* ``__call__(inputs, cache=None, input_embeddings=None, return_hidden=False,
+  n_confirmed=0)`` — inlines ``hy_v3.HYV3Model``'s single-node backbone loop and
+  returns ``(logits, pre_final_norm_hidden)`` when ``return_hidden=True``. HY3 is
+  pure-attention (no GatedDeltaNet), so ``n_confirmed`` is a no-op.
+* ``mtp_forward(hidden, next_token_ids, mtp_cache)`` -> logits, via the shared
+  ``lm_head`` (HY3 has ``tie_word_embeddings=false``).
+* ``make_mtp_cache()`` -> ``[KVCache()]`` (1 full-attention MTP layer).
+
+The loaded HY3 model is ``vllm_mlx.models.hy_v3.Model`` (no VLM wrapper): it holds
+``.model`` (the ``HYV3Model`` backbone with ``embed_tokens`` / ``layers`` /
+``norm``), ``.lm_head``, and ``.args`` (a ``hy_v3.ModelArgs``).
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# The 4-bit HY3 MLX checkpoint (mlx-community/Hy3-preview-4bit) STRIPS the
+# native MTP head at convert time (it keeps only backbone layers 0..79). The
+# head lives in this published sidecar, extracted from the full-precision
+# tencent/Hy3-preview layer 80 (see scripts/extract_hy3_mtp.py). Unlike
+# Qwen3.5 — whose MTP head ships inside the base checkpoint — HY3 must resolve
+# this sidecar by default so a bare
+# ``--speculative-config '{"method":"mtp"}'`` boot works with no extra flag.
+DEFAULT_HY3_MTP_SIDECAR = "mlx-community/Hy3-preview-MTP-4bit"
+
+
+def _resolve_inner_model(model: Any) -> Any:
+    """Return the HY3 ``Model`` instance to patch (holds ``.model`` + ``.args``)."""
+    # HY3 has no VLM wrapper — the loaded object already exposes .model + .args.
+    if hasattr(model, "model") and hasattr(model, "args"):
+        return model
+    lm = getattr(model, "language_model", None)
+    if lm is not None and hasattr(lm, "args") and hasattr(lm, "model"):
+        return lm
+    return None
+
+
+def _detect_base_quantization(inner: Any) -> dict | None:
+    """Detect ``bits`` / ``group_size`` from a backbone QuantizedLinear."""
+    try:
+        from mlx.nn import QuantizedEmbedding, QuantizedLinear
+    except ImportError:  # pragma: no cover
+        return None
+
+    backbone = getattr(inner, "model", None)
+    if backbone is None:
+        return None
+    for layer in getattr(backbone, "layers", []):
+        if layer is None:
+            continue
+        if hasattr(layer, "self_attn") and hasattr(layer.self_attn, "q_proj"):
+            qp = layer.self_attn.q_proj
+            if isinstance(qp, QuantizedLinear):
+                return {"bits": int(qp.bits), "group_size": int(qp.group_size)}
+    embed = getattr(backbone, "embed_tokens", None)
+    if isinstance(embed, QuantizedEmbedding):
+        return {"bits": int(embed.bits), "group_size": int(embed.group_size)}
+    return None
+
+
+def _find_mtp_weights_file(sidecar_dir: Path) -> Path | None:
+    for c in (sidecar_dir / "model-mtp.safetensors", sidecar_dir / "model.safetensors"):
+        if c.exists():
+            return c
+    return None
+
+
+def _resolve_sidecar_file(mtp_sidecar: str | Path) -> Path | None:
+    if mtp_sidecar is None:
+        return None
+    path = Path(mtp_sidecar)
+    if path.is_file():
+        return path
+    if path.is_dir():
+        return _find_mtp_weights_file(path)
+    try:
+        from huggingface_hub import snapshot_download
+
+        local = snapshot_download(repo_id=str(mtp_sidecar))
+        return _find_mtp_weights_file(Path(local))
+    except Exception as exc:  # pragma: no cover — network failure path
+        logger.warning("[mtp.inject.hy3] could not resolve sidecar %r: %s",
+                       mtp_sidecar, exc)
+        return None
+
+
+def _resolve_num_mtp_layers(inner: Any, model: Any) -> int:
+    """HY3 config uses ``num_nextn_predict_layers`` (not ``mtp_num_hidden_layers``)."""
+    args = inner.args
+    n = int(getattr(args, "num_nextn_predict_layers", 0) or 0)
+    if n >= 1:
+        return n
+    # Fall back to a wrapper text_config dict (defensive; HY3 has no wrapper).
+    outer_args = getattr(model, "args", None)
+    text_config = getattr(outer_args, "text_config", None) or {}
+    if isinstance(text_config, dict):
+        n = int(text_config.get("num_nextn_predict_layers", 0) or 0)
+    return n
+
+
+def inject_hy3_mtp_support(
+    model: Any,
+    mtp_sidecar: str | Path | None = None,
+    *,
+    allow_random_init: bool = False,
+) -> bool:
+    """Inject the four MTP contract surfaces onto a loaded HY3 model.
+
+    Args:
+        model: Loaded ``vllm_mlx.models.hy_v3.Model`` (no VLM wrapper).
+        mtp_sidecar: Path / dir / HF repo id holding the extracted MTP head.
+            When ``None`` (the common ``--speculative-config '{"method":"mtp"}'``
+            path with no explicit ``--mtp-sidecar``), it defaults to
+            :data:`DEFAULT_HY3_MTP_SIDECAR` and is downloaded from the Hub on
+            first use — HY3's 4-bit backbone ships with the head stripped, so a
+            sidecar is always required (there is no baked-in head to fall back
+            to). Pass ``allow_random_init=True`` (test-only) to skip resolution.
+        allow_random_init: Test-only escape hatch — permits a random-init head
+            with no sidecar. Never enable in production (~0% accept rate).
+
+    Returns:
+        ``True`` when the four MTP surfaces are attached; ``False`` on any
+        refusal (unresolvable sidecar, missing tensors, wrong arch).
+    """
+    import mlx.core as mx
+    import mlx.nn as nn
+
+    # HY3's base checkpoint has no baked-in MTP head — always resolve a sidecar
+    # (default to the published repo) unless the caller opted into random init.
+    if mtp_sidecar is None and not allow_random_init:
+        mtp_sidecar = DEFAULT_HY3_MTP_SIDECAR
+        logger.info(
+            "[mtp.inject.hy3] no explicit sidecar; defaulting to %s",
+            DEFAULT_HY3_MTP_SIDECAR,
+        )
+
+    inner = _resolve_inner_model(model)
+    if inner is None:
+        logger.warning(
+            "[mtp.inject.hy3] model %s lacks (model + args); skipping.",
+            type(model).__name__,
+        )
+        return False
+
+    args = inner.args
+    num_mtp_layers = _resolve_num_mtp_layers(inner, model)
+    if num_mtp_layers < 1:
+        logger.info(
+            "[mtp.inject.hy3] config has no num_nextn_predict_layers >= 1; skipping."
+        )
+        return False
+
+    # --- Step 1: Build the HY3 MTP head. ---
+    from .hy3_head import build_hy3_mtp_module
+
+    mtp = build_hy3_mtp_module(args, num_mtp_layers)
+    logger.info(
+        "[mtp.inject.hy3] Built HY3 MTP head (%d layer(s), hidden_size=%d).",
+        num_mtp_layers,
+        getattr(args, "hidden_size", -1),
+    )
+
+    # --- Step 2: Quantize to match base (4-bit Linear; 8-bit router.gate). ---
+    quant_info = _detect_base_quantization(inner)
+    if quant_info is not None:
+        def _class_predicate(path: str, module) -> Any:
+            # Only touch modules that actually support quantization (Linear /
+            # Embedding / SwitchLinear expose ``to_quantized``); never norms.
+            # 8-bit for the MoE router gate; 4-bit for the rest. Mirrors
+            # hy_v3.Model.quant_predicate + the default nn.quantize gate.
+            if not hasattr(module, "to_quantized"):
+                return False
+            if path.endswith("mlp.router.gate"):
+                return {"group_size": 64, "bits": 8}
+            return True
+
+        nn.quantize(
+            mtp,
+            group_size=quant_info["group_size"],
+            bits=quant_info["bits"],
+            class_predicate=_class_predicate,
+        )
+        logger.info(
+            "[mtp.inject.hy3] Quantized MTP head: %d-bit gs=%d (router.gate 8-bit)",
+            quant_info["bits"],
+            quant_info["group_size"],
+        )
+
+    # --- Step 3: Load sidecar weights with strict coverage check. ---
+    if mtp_sidecar is not None:
+        weights_file = _resolve_sidecar_file(mtp_sidecar)
+        if weights_file is None:
+            logger.warning(
+                "[mtp.inject.hy3] sidecar %r could not be resolved; skipping.",
+                mtp_sidecar,
+            )
+            return False
+        raw = mx.load(str(weights_file))
+        mtp_weights = {
+            (k.removeprefix("mtp.") if k.startswith("mtp.") else k): v
+            for k, v in raw.items()
+        }
+        from mlx.utils import tree_flatten
+
+        expected_keys = {k for k, _ in tree_flatten(mtp.parameters())}
+        loaded_keys = set(mtp_weights.keys())
+        missing = expected_keys - loaded_keys
+        if missing:
+            logger.warning(
+                "[mtp.inject.hy3] sidecar %s missing %d required tensor(s); "
+                "refusing partial-random head. Missing (first 8): %s",
+                weights_file.name,
+                len(missing),
+                sorted(missing)[:8],
+            )
+            return False
+        mtp.load_weights(list(mtp_weights.items()), strict=False)
+        mx.eval(mtp.parameters())
+        extra = loaded_keys - expected_keys
+        logger.info(
+            "[mtp.inject.hy3] Loaded %d/%d MTP tensors from %s%s",
+            len(expected_keys),
+            len(expected_keys),
+            weights_file.name,
+            f" (+{len(extra)} extra ignored)" if extra else "",
+        )
+    else:
+        if not allow_random_init:
+            logger.warning(
+                "[mtp.inject.hy3] no mtp_sidecar and allow_random_init=False; "
+                "refusing random-init head."
+            )
+            return False
+        mx.eval(mtp.parameters())
+        logger.warning(
+            "[mtp.inject.hy3] allow_random_init=True — RANDOM init head (test-only)."
+        )
+
+    # --- Step 4: Attach + monkey-patch the HY3 Model class. ---
+    inner.mtp = mtp
+    original_class = type(inner)
+
+    class _HY3WithMTP(original_class):  # type: ignore[valid-type, misc]
+        """HY3 ``Model`` + the four MTP surfaces the generator drives."""
+
+        def __call__(  # type: ignore[override]
+            self,
+            inputs,
+            cache=None,
+            input_embeddings=None,
+            return_hidden: bool = False,
+            n_confirmed: int = 0,
+        ):
+            from mlx_lm.models.base import create_attention_mask
+
+            backbone = self.model
+            if input_embeddings is not None:
+                h = input_embeddings
+            else:
+                h = backbone.embed_tokens(inputs)
+            if cache is None:
+                cache = [None] * len(backbone.layers)
+
+            # Single-node inline of hy_v3.HYV3Model.__call__ (pipeline_size=1,
+            # rank=0 => no distributed branches). n_confirmed is a no-op:
+            # HY3 is pure-attention, no SSM/conv state to snapshot.
+            mask = create_attention_mask(h, cache[0])
+            for layer, c in zip(backbone.layers, cache):
+                h = layer(h, mask, cache=c)
+
+            pre_norm_hidden = h
+            normed = backbone.norm(h)
+            if self.args.enable_lm_head_fp32:
+                normed = normed.astype(mx.float32)
+            if self.args.tie_word_embeddings:
+                out = backbone.embed_tokens.as_linear(normed)
+            else:
+                out = self.lm_head(normed)
+
+            if return_hidden:
+                return out, pre_norm_hidden
+            return out
+
+        def mtp_forward(self, hidden_states, next_token_ids, mtp_cache):
+            mtp_out = self.mtp(
+                hidden_states,
+                next_token_ids,
+                self.model.embed_tokens,
+                mtp_cache,
+            )
+            if self.args.enable_lm_head_fp32:
+                mtp_out = mtp_out.astype(mx.float32)
+            if self.args.tie_word_embeddings:
+                return self.model.embed_tokens.as_linear(mtp_out)
+            return self.lm_head(mtp_out)
+
+        def make_mtp_cache(self):
+            from mlx_lm.models.cache import KVCache
+
+            return [KVCache() for _ in self.mtp.layers]
+
+    inner.__class__ = _HY3WithMTP
+    logger.info(
+        "[mtp.inject.hy3] Patched %s with MTP surfaces "
+        "(return_hidden, n_confirmed, mtp_forward, make_mtp_cache).",
+        original_class.__name__,
+    )
+    return True
+
+
+def validate_hy3_mtp_support(model: Any) -> bool:
+    """Verify inject_hy3_mtp_support attached the four surfaces."""
+    import inspect
+
+    inner = _resolve_inner_model(model)
+    if inner is None:
+        return False
+    if getattr(inner, "mtp", None) is None:
+        logger.warning("[mtp.validate.hy3] model.mtp is missing.")
+        return False
+    if not callable(getattr(inner, "mtp_forward", None)):
+        logger.warning("[mtp.validate.hy3] model.mtp_forward is missing.")
+        return False
+    if not callable(getattr(inner, "make_mtp_cache", None)):
+        logger.warning("[mtp.validate.hy3] model.make_mtp_cache is missing.")
+        return False
+    sig = inspect.signature(type(inner).__call__)
+    if "return_hidden" not in sig.parameters:
+        logger.warning("[mtp.validate.hy3] __call__ lacks return_hidden.")
+        return False
+    if "n_confirmed" not in sig.parameters:
+        logger.warning("[mtp.validate.hy3] __call__ lacks n_confirmed.")
+        return False
+    return True

--- a/vllm_mlx/spec_decode/mtp/hy3_inject.py
+++ b/vllm_mlx/spec_decode/mtp/hy3_inject.py
@@ -432,6 +432,14 @@ def inject_hy3_mtp_support(
             # Single-node inline of hy_v3.HYV3Model.__call__ (pipeline_size=1,
             # rank=0 => no distributed branches). n_confirmed is a no-op:
             # HY3 is pure-attention, no SSM/conv state to snapshot.
+            #
+            # NOTE: pass cache[0] (a single KVCache), NOT the list. mlx-lm's
+            # create_attention_mask does `if cache and hasattr(cache, "make_mask")`
+            # and calls that single cache's offset-aware make_mask(N). Passing the
+            # LIST would fail that hasattr (lists have no make_mask), silently drop
+            # to a plain causal mask, and LOSE the warm-cache offset. This mirrors
+            # upstream hy_v3.HYV3Model.__call__ exactly (models/hy_v3.py:309) and
+            # is covered by test_inject_forward_warm_cache_offset.
             mask = create_attention_mask(h, cache[0])
             for layer, c in zip(backbone.layers, cache):
                 h = layer(h, mask, cache=c)

--- a/vllm_mlx/spec_decode/mtp/hy3_inject.py
+++ b/vllm_mlx/spec_decode/mtp/hy3_inject.py
@@ -181,9 +181,16 @@ def inject_hy3_mtp_support(
 
     args = inner.args
     num_mtp_layers = _resolve_num_mtp_layers(inner, model)
-    if num_mtp_layers < 1:
+    if num_mtp_layers != 1:
+        # HY3 ships a single-layer (DeepSeek-V3-style) MTP head. detect may class
+        # num_nextn_predict_layers >= 2 as the (unimplemented) TREE variant, but
+        # build_hy3_mtp_module raises for != 1, so a num != 1 config would crash
+        # boot. Fail-closed to False here (codex R4 BLOCKING #1) — the runtime
+        # simply runs without MTP rather than aborting.
         logger.info(
-            "[mtp.inject.hy3] config has no num_nextn_predict_layers >= 1; skipping."
+            "[mtp.inject.hy3] num_nextn_predict_layers=%d (need exactly 1); "
+            "HY3 MTP unsupported for this config, skipping.",
+            num_mtp_layers,
         )
         return False
 
@@ -203,162 +210,178 @@ def inject_hy3_mtp_support(
         )
         return False
 
-    # --- Step 1: Build the HY3 MTP head. ---
-    from .hy3_head import build_hy3_mtp_module
+    # Steps 1-3 (build head, quantize, load sidecar) run under one guard:
+    # a truncated / unreadable / malformed sidecar — or any build error —
+    # must honor this function's False-on-refusal contract rather than let
+    # an exception abort server boot (codex R4 BLOCKING #2).
+    try:
+        # --- Step 1: Build the HY3 MTP head. ---
+        from .hy3_head import build_hy3_mtp_module
 
-    mtp = build_hy3_mtp_module(args, num_mtp_layers)
-    logger.info(
-        "[mtp.inject.hy3] Built HY3 MTP head (%d layer(s), hidden_size=%d).",
-        num_mtp_layers,
-        getattr(args, "hidden_size", -1),
-    )
-
-    # --- Step 2: Quantize to match base (4-bit Linear; 8-bit router.gate). ---
-    quant_info = _detect_base_quantization(inner)
-
-    # Resolve the DEFAULT sidecar BEFORE quantizing the head: HY3's base has no
-    # baked-in head, so a missing sidecar defaults to the published repo — but
-    # ONLY when the base quantization matches what that sidecar was extracted
-    # at (codex BLOCKING #3; a mismatch would load shape-incompatible tensors),
-    # and at a pinned revision (codex BLOCKING #1). An explicit sidecar bypasses
-    # both gates (the operator vouches for the pairing).
-    sidecar_revision = None
-    if mtp_sidecar is None and not allow_random_init:
-        if quant_info != DEFAULT_HY3_MTP_SIDECAR_BASE_QUANT:
-            logger.warning(
-                "[mtp.inject.hy3] base quantization %s != default sidecar's %s; "
-                "the auto-resolved %s would load shape-incompatible tensors. "
-                "Pass an explicit mtp_sidecar extracted for this base.",
-                quant_info,
-                DEFAULT_HY3_MTP_SIDECAR_BASE_QUANT,
-                DEFAULT_HY3_MTP_SIDECAR,
-            )
-            return False
-        mtp_sidecar = DEFAULT_HY3_MTP_SIDECAR
-        sidecar_revision = DEFAULT_HY3_MTP_SIDECAR_REVISION
+        mtp = build_hy3_mtp_module(args, num_mtp_layers)
         logger.info(
-            "[mtp.inject.hy3] no explicit sidecar; defaulting to %s@%s",
-            DEFAULT_HY3_MTP_SIDECAR,
-            sidecar_revision[:12],
+            "[mtp.inject.hy3] Built HY3 MTP head (%d layer(s), hidden_size=%d).",
+            num_mtp_layers,
+            getattr(args, "hidden_size", -1),
         )
-    if quant_info is not None:
 
-        def _class_predicate(path: str, module) -> Any:
-            # Only touch modules that actually support quantization (Linear /
-            # Embedding / SwitchLinear expose ``to_quantized``); never norms.
-            # Router gate keeps its own bits (8) but the SAME group_size as the
-            # base — extract_hy3_mtp.py quantizes the router with the base's
-            # group_size, so hard-coding 64 here would reject an explicit
-            # sidecar built for a non-gs64 base (codex R2 BLOCKING #2). Mirrors
-            # hy_v3.Model.quant_predicate + the default nn.quantize gate.
-            if not hasattr(module, "to_quantized"):
+        # --- Step 2: Quantize to match base (4-bit Linear; 8-bit router.gate). ---
+        quant_info = _detect_base_quantization(inner)
+
+        # Resolve the DEFAULT sidecar BEFORE quantizing the head: HY3's base has no
+        # baked-in head, so a missing sidecar defaults to the published repo — but
+        # ONLY when the base quantization matches what that sidecar was extracted
+        # at (codex BLOCKING #3; a mismatch would load shape-incompatible tensors),
+        # and at a pinned revision (codex BLOCKING #1). An explicit sidecar bypasses
+        # both gates (the operator vouches for the pairing).
+        sidecar_revision = None
+        if mtp_sidecar is None and not allow_random_init:
+            if quant_info != DEFAULT_HY3_MTP_SIDECAR_BASE_QUANT:
+                logger.warning(
+                    "[mtp.inject.hy3] base quantization %s != default sidecar's %s; "
+                    "the auto-resolved %s would load shape-incompatible tensors. "
+                    "Pass an explicit mtp_sidecar extracted for this base.",
+                    quant_info,
+                    DEFAULT_HY3_MTP_SIDECAR_BASE_QUANT,
+                    DEFAULT_HY3_MTP_SIDECAR,
+                )
                 return False
-            if path.endswith("mlp.router.gate"):
-                return {"group_size": quant_info["group_size"], "bits": 8}
-            return True
-
-        nn.quantize(
-            mtp,
-            group_size=quant_info["group_size"],
-            bits=quant_info["bits"],
-            class_predicate=_class_predicate,
-        )
-        logger.info(
-            "[mtp.inject.hy3] Quantized MTP head: %d-bit gs=%d (router.gate 8-bit)",
-            quant_info["bits"],
-            quant_info["group_size"],
-        )
-
-    # --- Step 3: Load sidecar weights with strict coverage check. ---
-    if mtp_sidecar is not None:
-        weights_file = _resolve_sidecar_file(mtp_sidecar, revision=sidecar_revision)
-        if weights_file is None:
-            logger.warning(
-                "[mtp.inject.hy3] sidecar %r could not be resolved; skipping.",
-                mtp_sidecar,
+            mtp_sidecar = DEFAULT_HY3_MTP_SIDECAR
+            sidecar_revision = DEFAULT_HY3_MTP_SIDECAR_REVISION
+            logger.info(
+                "[mtp.inject.hy3] no explicit sidecar; defaulting to %s@%s",
+                DEFAULT_HY3_MTP_SIDECAR,
+                sidecar_revision[:12],
             )
-            return False
-        raw = mx.load(str(weights_file))
-        mtp_weights = {
-            (k.removeprefix("mtp.") if k.startswith("mtp.") else k): v
-            for k, v in raw.items()
-        }
-        from mlx.utils import tree_flatten
+        if quant_info is not None:
 
-        expected_keys = {k for k, _ in tree_flatten(mtp.parameters())}
-        loaded_keys = set(mtp_weights.keys())
-        missing = expected_keys - loaded_keys
-        if missing:
-            logger.warning(
-                "[mtp.inject.hy3] sidecar %s missing %d required tensor(s); "
-                "refusing partial-random head. Missing (first 8): %s",
+            def _class_predicate(path: str, module) -> Any:
+                # Only touch modules that actually support quantization (Linear /
+                # Embedding / SwitchLinear expose ``to_quantized``); never norms.
+                # Router gate keeps its own bits (8) but the SAME group_size as the
+                # base — extract_hy3_mtp.py quantizes the router with the base's
+                # group_size, so hard-coding 64 here would reject an explicit
+                # sidecar built for a non-gs64 base (codex R2 BLOCKING #2). Mirrors
+                # hy_v3.Model.quant_predicate + the default nn.quantize gate.
+                if not hasattr(module, "to_quantized"):
+                    return False
+                if path.endswith("mlp.router.gate"):
+                    return {"group_size": quant_info["group_size"], "bits": 8}
+                return True
+
+            nn.quantize(
+                mtp,
+                group_size=quant_info["group_size"],
+                bits=quant_info["bits"],
+                class_predicate=_class_predicate,
+            )
+            logger.info(
+                "[mtp.inject.hy3] Quantized MTP head: %d-bit gs=%d (router.gate 8-bit)",
+                quant_info["bits"],
+                quant_info["group_size"],
+            )
+
+        # --- Step 3: Load sidecar weights with strict coverage check. ---
+        if mtp_sidecar is not None:
+            weights_file = _resolve_sidecar_file(mtp_sidecar, revision=sidecar_revision)
+            if weights_file is None:
+                logger.warning(
+                    "[mtp.inject.hy3] sidecar %r could not be resolved; skipping.",
+                    mtp_sidecar,
+                )
+                return False
+            raw = mx.load(str(weights_file))
+            mtp_weights = {
+                (k.removeprefix("mtp.") if k.startswith("mtp.") else k): v
+                for k, v in raw.items()
+            }
+            from mlx.utils import tree_flatten
+
+            expected_keys = {k for k, _ in tree_flatten(mtp.parameters())}
+            loaded_keys = set(mtp_weights.keys())
+            missing = expected_keys - loaded_keys
+            if missing:
+                logger.warning(
+                    "[mtp.inject.hy3] sidecar %s missing %d required tensor(s); "
+                    "refusing partial-random head. Missing (first 8): %s",
+                    weights_file.name,
+                    len(missing),
+                    sorted(missing)[:8],
+                )
+                return False
+
+            # Shape / dtype-category guard (codex BLOCKING): the key-name coverage
+            # above does NOT catch a sidecar quantized for a different base (e.g.
+            # 8-bit packed tensors landing on a 4-bit head), which would either
+            # error opaquely in load_weights or corrupt inference. A quant mismatch
+            # shows up as (a) a packed-shape mismatch and/or (b) a floating-vs-
+            # integer dtype-category flip (packed quant weights are uint32; the
+            # freshly-initialised template's unquantized tensors are floating).
+            #
+            # We deliberately do NOT require exact floating dtype equality: the
+            # real sidecar carries bf16 unquantized tensors (RMSNorm weights,
+            # biases) while the template initialises them in fp32, and
+            # ``load_weights`` casts float->float losslessly-in-kind. Comparing the
+            # raw dtype here (as an earlier revision did) rejected a perfectly
+            # valid bf16 sidecar. So compare the dtype *category* (floating vs
+            # integer/packed), not the exact float width.
+            def _kind(dt: Any) -> str:
+                return "float" if mx.issubdtype(dt, mx.floating) else "int"
+
+            expected = {
+                k: (v.shape, v.dtype) for k, v in tree_flatten(mtp.parameters())
+            }
+            bad = [
+                (
+                    k,
+                    (tuple(expected[k][0]), str(expected[k][1])),
+                    (tuple(mtp_weights[k].shape), str(mtp_weights[k].dtype)),
+                )
+                for k in expected_keys
+                if tuple(mtp_weights[k].shape) != tuple(expected[k][0])
+                or _kind(mtp_weights[k].dtype) != _kind(expected[k][1])
+            ]
+            if bad:
+                logger.warning(
+                    "[mtp.inject.hy3] sidecar %s has %d shape/dtype-mismatched "
+                    "tensor(s) (likely a quantization mismatch vs the base). "
+                    "First (key, expected(shape,dtype-kind), got(shape,dtype)): %s. "
+                    "Refusing to load. Use a sidecar extracted for this base quant.",
+                    weights_file.name,
+                    len(bad),
+                    bad[0],
+                )
+                return False
+            mtp.load_weights(list(mtp_weights.items()), strict=False)
+            mx.eval(mtp.parameters())
+            extra = loaded_keys - expected_keys
+            logger.info(
+                "[mtp.inject.hy3] Loaded %d/%d MTP tensors from %s%s",
+                len(expected_keys),
+                len(expected_keys),
                 weights_file.name,
-                len(missing),
-                sorted(missing)[:8],
+                f" (+{len(extra)} extra ignored)" if extra else "",
             )
-            return False
-
-        # Shape / dtype-category guard (codex BLOCKING): the key-name coverage
-        # above does NOT catch a sidecar quantized for a different base (e.g.
-        # 8-bit packed tensors landing on a 4-bit head), which would either
-        # error opaquely in load_weights or corrupt inference. A quant mismatch
-        # shows up as (a) a packed-shape mismatch and/or (b) a floating-vs-
-        # integer dtype-category flip (packed quant weights are uint32; the
-        # freshly-initialised template's unquantized tensors are floating).
-        #
-        # We deliberately do NOT require exact floating dtype equality: the
-        # real sidecar carries bf16 unquantized tensors (RMSNorm weights,
-        # biases) while the template initialises them in fp32, and
-        # ``load_weights`` casts float->float losslessly-in-kind. Comparing the
-        # raw dtype here (as an earlier revision did) rejected a perfectly
-        # valid bf16 sidecar. So compare the dtype *category* (floating vs
-        # integer/packed), not the exact float width.
-        def _kind(dt: Any) -> str:
-            return "float" if mx.issubdtype(dt, mx.floating) else "int"
-
-        expected = {k: (v.shape, v.dtype) for k, v in tree_flatten(mtp.parameters())}
-        bad = [
-            (
-                k,
-                (tuple(expected[k][0]), str(expected[k][1])),
-                (tuple(mtp_weights[k].shape), str(mtp_weights[k].dtype)),
-            )
-            for k in expected_keys
-            if tuple(mtp_weights[k].shape) != tuple(expected[k][0])
-            or _kind(mtp_weights[k].dtype) != _kind(expected[k][1])
-        ]
-        if bad:
+        else:
+            if not allow_random_init:
+                logger.warning(
+                    "[mtp.inject.hy3] no mtp_sidecar and allow_random_init=False; "
+                    "refusing random-init head."
+                )
+                return False
+            mx.eval(mtp.parameters())
             logger.warning(
-                "[mtp.inject.hy3] sidecar %s has %d shape/dtype-mismatched "
-                "tensor(s) (likely a quantization mismatch vs the base). "
-                "First (key, expected(shape,dtype-kind), got(shape,dtype)): %s. "
-                "Refusing to load. Use a sidecar extracted for this base quant.",
-                weights_file.name,
-                len(bad),
-                bad[0],
+                "[mtp.inject.hy3] allow_random_init=True — RANDOM init head (test-only)."
             )
-            return False
-        mtp.load_weights(list(mtp_weights.items()), strict=False)
-        mx.eval(mtp.parameters())
-        extra = loaded_keys - expected_keys
-        logger.info(
-            "[mtp.inject.hy3] Loaded %d/%d MTP tensors from %s%s",
-            len(expected_keys),
-            len(expected_keys),
-            weights_file.name,
-            f" (+{len(extra)} extra ignored)" if extra else "",
-        )
-    else:
-        if not allow_random_init:
-            logger.warning(
-                "[mtp.inject.hy3] no mtp_sidecar and allow_random_init=False; "
-                "refusing random-init head."
-            )
-            return False
-        mx.eval(mtp.parameters())
+
+    except Exception as exc:  # noqa: BLE001 — fail-closed on ANY head/load error
         logger.warning(
-            "[mtp.inject.hy3] allow_random_init=True — RANDOM init head (test-only)."
+            "[mtp.inject.hy3] head build / sidecar load failed (%s: %s); "
+            "refusing MTP injection (model left unmodified).",
+            type(exc).__name__,
+            exc,
         )
+        return False
 
     # --- Step 4: Attach + monkey-patch the HY3 Model class. ---
     inner.mtp = mtp

--- a/vllm_mlx/spec_decode/mtp/hy3_inject.py
+++ b/vllm_mlx/spec_decode/mtp/hy3_inject.py
@@ -26,6 +26,8 @@ import logging
 from pathlib import Path
 from typing import Any
 
+from vllm_mlx.spec_decode.mtp.detect import _safe_int
+
 logger = logging.getLogger(__name__)
 
 # The 4-bit HY3 MLX checkpoint (mlx-community/Hy3-preview-4bit) STRIPS the
@@ -151,7 +153,12 @@ def _resolve_num_mtp_layers(inner: Any, model: Any) -> int:
     """
     args = inner.args
     for key in _HY3_MTP_LAYER_KEYS:
-        n = int(getattr(args, key, 0) or 0)
+        # Guarded parse (codex R9): a hand-edited config shipping a
+        # non-numeric ``num_nextn_predict_layers`` (e.g. ``"unknown"``)
+        # must degrade to "no MTP" rather than raise and abort server
+        # boot. ``detect._safe_int`` is the same fail-closed coercion the
+        # detection side uses, so inject and detect never disagree.
+        n = _safe_int(getattr(args, key, None), 0)
         if n >= 1:
             return n
     # Fall back to a wrapper text_config dict (defensive; HY3 has no wrapper).
@@ -159,7 +166,7 @@ def _resolve_num_mtp_layers(inner: Any, model: Any) -> int:
     text_config = getattr(outer_args, "text_config", None) or {}
     if isinstance(text_config, dict):
         for key in _HY3_MTP_LAYER_KEYS:
-            n = int(text_config.get(key, 0) or 0)
+            n = _safe_int(text_config.get(key), 0)
             if n >= 1:
                 return n
     return 0

--- a/vllm_mlx/spec_decode/mtp/hy3_inject.py
+++ b/vllm_mlx/spec_decode/mtp/hy3_inject.py
@@ -187,6 +187,22 @@ def inject_hy3_mtp_support(
         )
         return False
 
+    # Pipeline-parallel guard (codex R2 BLOCKING #3). The injected ``__call__``
+    # below inlines the single-node backbone loop over ``backbone.layers`` and
+    # has no distributed send/recv. Under pipeline parallelism the backbone
+    # holds only its ``pipeline_layers`` shard and iterating ``layers`` would
+    # call absent/non-local layers. Refuse rather than silently mis-run. HY3
+    # serves single-node in rapid-mlx today, so this only fail-closes a config
+    # the runtime does not support.
+    backbone = getattr(inner, "model", None)
+    if int(getattr(backbone, "pipeline_size", 1) or 1) > 1:
+        logger.warning(
+            "[mtp.inject.hy3] pipeline_size=%s > 1; MTP injection does not "
+            "support pipeline-parallel HY3. Refusing.",
+            getattr(backbone, "pipeline_size", None),
+        )
+        return False
+
     # --- Step 1: Build the HY3 MTP head. ---
     from .hy3_head import build_hy3_mtp_module
 
@@ -230,12 +246,15 @@ def inject_hy3_mtp_support(
         def _class_predicate(path: str, module) -> Any:
             # Only touch modules that actually support quantization (Linear /
             # Embedding / SwitchLinear expose ``to_quantized``); never norms.
-            # 8-bit for the MoE router gate; 4-bit for the rest. Mirrors
+            # Router gate keeps its own bits (8) but the SAME group_size as the
+            # base — extract_hy3_mtp.py quantizes the router with the base's
+            # group_size, so hard-coding 64 here would reject an explicit
+            # sidecar built for a non-gs64 base (codex R2 BLOCKING #2). Mirrors
             # hy_v3.Model.quant_predicate + the default nn.quantize gate.
             if not hasattr(module, "to_quantized"):
                 return False
             if path.endswith("mlp.router.gate"):
-                return {"group_size": 64, "bits": 8}
+                return {"group_size": quant_info["group_size"], "bits": 8}
             return True
 
         nn.quantize(
@@ -283,16 +302,22 @@ def inject_hy3_mtp_support(
         # packed tensors landing on a 4-bit head), which would either error
         # opaquely in load_weights or corrupt inference. Reject up-front with
         # an actionable message.
-        expected_shapes = {k: v.shape for k, v in tree_flatten(mtp.parameters())}
+        expected = {k: (v.shape, v.dtype) for k, v in tree_flatten(mtp.parameters())}
         bad = [
-            (k, tuple(expected_shapes[k]), tuple(mtp_weights[k].shape))
+            (
+                k,
+                (tuple(expected[k][0]), str(expected[k][1])),
+                (tuple(mtp_weights[k].shape), str(mtp_weights[k].dtype)),
+            )
             for k in expected_keys
-            if tuple(mtp_weights[k].shape) != tuple(expected_shapes[k])
+            if tuple(mtp_weights[k].shape) != tuple(expected[k][0])
+            or mtp_weights[k].dtype != expected[k][1]
         ]
         if bad:
             logger.warning(
-                "[mtp.inject.hy3] sidecar %s has %d shape-mismatched tensor(s) "
-                "(likely a quantization mismatch vs the base). First: %s. "
+                "[mtp.inject.hy3] sidecar %s has %d shape/dtype-mismatched "
+                "tensor(s) (likely a quantization mismatch vs the base). "
+                "First (key, expected(shape,dtype), got(shape,dtype)): %s. "
                 "Refusing to load. Use a sidecar extracted for this base quant.",
                 weights_file.name,
                 len(bad),

--- a/vllm_mlx/spec_decode/mtp/hy3_inject.py
+++ b/vllm_mlx/spec_decode/mtp/hy3_inject.py
@@ -95,6 +95,27 @@ def _resolve_sidecar_file(
 ) -> Path | None:
     if mtp_sidecar is None:
         return None
+    # Integrity guard (codex R5 BLOCKING #1): when a revision is pinned (the
+    # default-sidecar path), resolve the identifier EXCLUSIVELY as an HF repo at
+    # that immutable commit. Otherwise a local directory in the server's cwd
+    # that happens to be named like the repo id (e.g.
+    # ``mlx-community/Hy3-preview-MTP-4bit/``) would shadow the pinned repo and
+    # silently defeat the revision integrity guarantee. An explicit operator-
+    # supplied sidecar carries no revision, so local paths still resolve there.
+    if revision is not None:
+        try:
+            from huggingface_hub import snapshot_download
+
+            local = snapshot_download(repo_id=str(mtp_sidecar), revision=revision)
+            return _find_mtp_weights_file(Path(local))
+        except Exception as exc:  # pragma: no cover — network failure path
+            logger.warning(
+                "[mtp.inject.hy3] could not resolve pinned sidecar %r@%s: %s",
+                mtp_sidecar,
+                revision,
+                exc,
+            )
+            return None
     path = Path(mtp_sidecar)
     if path.is_file():
         return path

--- a/vllm_mlx/spec_decode/mtp/hy3_inject.py
+++ b/vllm_mlx/spec_decode/mtp/hy3_inject.py
@@ -297,11 +297,25 @@ def inject_hy3_mtp_support(
                 sorted(missing)[:8],
             )
             return False
-        # Shape/dtype guard (codex BLOCKING #3): the key-name coverage above
-        # does NOT catch a sidecar quantized for a different base (e.g. 8-bit
-        # packed tensors landing on a 4-bit head), which would either error
-        # opaquely in load_weights or corrupt inference. Reject up-front with
-        # an actionable message.
+
+        # Shape / dtype-category guard (codex BLOCKING): the key-name coverage
+        # above does NOT catch a sidecar quantized for a different base (e.g.
+        # 8-bit packed tensors landing on a 4-bit head), which would either
+        # error opaquely in load_weights or corrupt inference. A quant mismatch
+        # shows up as (a) a packed-shape mismatch and/or (b) a floating-vs-
+        # integer dtype-category flip (packed quant weights are uint32; the
+        # freshly-initialised template's unquantized tensors are floating).
+        #
+        # We deliberately do NOT require exact floating dtype equality: the
+        # real sidecar carries bf16 unquantized tensors (RMSNorm weights,
+        # biases) while the template initialises them in fp32, and
+        # ``load_weights`` casts float->float losslessly-in-kind. Comparing the
+        # raw dtype here (as an earlier revision did) rejected a perfectly
+        # valid bf16 sidecar. So compare the dtype *category* (floating vs
+        # integer/packed), not the exact float width.
+        def _kind(dt: Any) -> str:
+            return "float" if mx.issubdtype(dt, mx.floating) else "int"
+
         expected = {k: (v.shape, v.dtype) for k, v in tree_flatten(mtp.parameters())}
         bad = [
             (
@@ -311,13 +325,13 @@ def inject_hy3_mtp_support(
             )
             for k in expected_keys
             if tuple(mtp_weights[k].shape) != tuple(expected[k][0])
-            or mtp_weights[k].dtype != expected[k][1]
+            or _kind(mtp_weights[k].dtype) != _kind(expected[k][1])
         ]
         if bad:
             logger.warning(
                 "[mtp.inject.hy3] sidecar %s has %d shape/dtype-mismatched "
                 "tensor(s) (likely a quantization mismatch vs the base). "
-                "First (key, expected(shape,dtype), got(shape,dtype)): %s. "
+                "First (key, expected(shape,dtype-kind), got(shape,dtype)): %s. "
                 "Refusing to load. Use a sidecar extracted for this base quant.",
                 weights_file.name,
                 len(bad),

--- a/vllm_mlx/spec_decode/mtp/hy3_inject.py
+++ b/vllm_mlx/spec_decode/mtp/hy3_inject.py
@@ -339,15 +339,22 @@ def inject_hy3_mtp_support(
             # integer dtype-category flip (packed quant weights are uint32; the
             # freshly-initialised template's unquantized tensors are floating).
             #
-            # We deliberately do NOT require exact floating dtype equality: the
-            # real sidecar carries bf16 unquantized tensors (RMSNorm weights,
-            # biases) while the template initialises them in fp32, and
-            # ``load_weights`` casts float->float losslessly-in-kind. Comparing the
-            # raw dtype here (as an earlier revision did) rejected a perfectly
-            # valid bf16 sidecar. So compare the dtype *category* (floating vs
-            # integer/packed), not the exact float width.
-            def _kind(dt: Any) -> str:
-                return "float" if mx.issubdtype(dt, mx.floating) else "int"
+            # We deliberately do NOT require exact dtype equality WHEN BOTH SIDES
+            # ARE FLOATING: the real sidecar carries bf16 unquantized tensors
+            # (RMSNorm weights, biases) while the template initialises them in
+            # fp32, and ``load_weights`` casts float->float losslessly-in-kind.
+            # Requiring the raw dtype (as an earlier revision did) rejected a
+            # valid bf16 sidecar. But we must NOT wave through a non-float dtype
+            # for a float slot, nor a differing integer dtype for a packed uint32
+            # slot (codex R8: a same-shape bool / int8 / int32 must still be
+            # refused). So: shapes must match, and dtypes must be EXACTLY equal
+            # unless BOTH are floating.
+            def _dtype_compatible(got: Any, want: Any) -> bool:
+                if got == want:
+                    return True
+                return bool(mx.issubdtype(got, mx.floating)) and bool(
+                    mx.issubdtype(want, mx.floating)
+                )
 
             expected = {
                 k: (v.shape, v.dtype) for k, v in tree_flatten(mtp.parameters())
@@ -360,13 +367,13 @@ def inject_hy3_mtp_support(
                 )
                 for k in expected_keys
                 if tuple(mtp_weights[k].shape) != tuple(expected[k][0])
-                or _kind(mtp_weights[k].dtype) != _kind(expected[k][1])
+                or not _dtype_compatible(mtp_weights[k].dtype, expected[k][1])
             ]
             if bad:
                 logger.warning(
                     "[mtp.inject.hy3] sidecar %s has %d shape/dtype-mismatched "
                     "tensor(s) (likely a quantization mismatch vs the base). "
-                    "First (key, expected(shape,dtype-kind), got(shape,dtype)): %s. "
+                    "First (key, expected(shape,dtype), got(shape,dtype)): %s. "
                     "Refusing to load. Use a sidecar extracted for this base quant.",
                     weights_file.name,
                     len(bad),

--- a/vllm_mlx/spec_decode/mtp/hy3_inject.py
+++ b/vllm_mlx/spec_decode/mtp/hy3_inject.py
@@ -93,8 +93,9 @@ def _resolve_sidecar_file(mtp_sidecar: str | Path) -> Path | None:
         local = snapshot_download(repo_id=str(mtp_sidecar))
         return _find_mtp_weights_file(Path(local))
     except Exception as exc:  # pragma: no cover — network failure path
-        logger.warning("[mtp.inject.hy3] could not resolve sidecar %r: %s",
-                       mtp_sidecar, exc)
+        logger.warning(
+            "[mtp.inject.hy3] could not resolve sidecar %r: %s", mtp_sidecar, exc
+        )
         return None
 
 
@@ -177,6 +178,7 @@ def inject_hy3_mtp_support(
     # --- Step 2: Quantize to match base (4-bit Linear; 8-bit router.gate). ---
     quant_info = _detect_base_quantization(inner)
     if quant_info is not None:
+
         def _class_predicate(path: str, module) -> Any:
             # Only touch modules that actually support quantization (Linear /
             # Embedding / SwitchLinear expose ``to_quantized``); never norms.

--- a/vllm_mlx/spec_decode/mtp/hy3_inject.py
+++ b/vllm_mlx/spec_decode/mtp/hy3_inject.py
@@ -36,6 +36,17 @@ logger = logging.getLogger(__name__)
 # this sidecar by default so a bare
 # ``--speculative-config '{"method":"mtp"}'`` boot works with no extra flag.
 DEFAULT_HY3_MTP_SIDECAR = "mlx-community/Hy3-preview-MTP-4bit"
+# Pin an immutable commit so a silently re-pushed sidecar can never land
+# weights into a production boot (codex BLOCKING #1). Bump deliberately
+# alongside a re-extract. Only the DEFAULT repo is pinned; an operator-
+# supplied ``mtp_sidecar`` (path or repo) is used verbatim.
+DEFAULT_HY3_MTP_SIDECAR_REVISION = "dfc35f7d4d1facdfb9bf607908fca569dcb1ab87"
+# The default sidecar is extracted at exactly this quantization. Auto-
+# resolving it onto a base with a different quant would load packed
+# tensors with incompatible shapes (codex BLOCKING #3), so the default
+# path is gated on the base matching this spec. An explicit sidecar
+# bypasses the gate (the operator vouches for the pairing).
+DEFAULT_HY3_MTP_SIDECAR_BASE_QUANT = {"bits": 4, "group_size": 64}
 
 
 def _resolve_inner_model(model: Any) -> Any:
@@ -79,7 +90,9 @@ def _find_mtp_weights_file(sidecar_dir: Path) -> Path | None:
     return None
 
 
-def _resolve_sidecar_file(mtp_sidecar: str | Path) -> Path | None:
+def _resolve_sidecar_file(
+    mtp_sidecar: str | Path, revision: str | None = None
+) -> Path | None:
     if mtp_sidecar is None:
         return None
     path = Path(mtp_sidecar)
@@ -90,7 +103,7 @@ def _resolve_sidecar_file(mtp_sidecar: str | Path) -> Path | None:
     try:
         from huggingface_hub import snapshot_download
 
-        local = snapshot_download(repo_id=str(mtp_sidecar))
+        local = snapshot_download(repo_id=str(mtp_sidecar), revision=revision)
         return _find_mtp_weights_file(Path(local))
     except Exception as exc:  # pragma: no cover — network failure path
         logger.warning(
@@ -99,18 +112,36 @@ def _resolve_sidecar_file(mtp_sidecar: str | Path) -> Path | None:
         return None
 
 
+# The two config keys that carry HY3's next-n layer count, most-specific
+# first. Must stay in lock-step with ``detect._mtp_num_hidden_layers``'s
+# per-family key list for ``hy_v3`` — otherwise a config detection deems
+# eligible could be refused here (codex BLOCKING #2). HY3 ships
+# ``num_nextn_predict_layers`` (DeepSeek-V3 convention); the
+# ``mtp_num_hidden_layers`` alias is accepted as a hand-converted fallback.
+_HY3_MTP_LAYER_KEYS = ("num_nextn_predict_layers", "mtp_num_hidden_layers")
+
+
 def _resolve_num_mtp_layers(inner: Any, model: Any) -> int:
-    """HY3 config uses ``num_nextn_predict_layers`` (not ``mtp_num_hidden_layers``)."""
+    """Resolve HY3's next-n layer count from the model args / wrapper config.
+
+    Reads the same key set as ``detect._mtp_num_hidden_layers`` for
+    ``model_type == "hy_v3"`` so detection and injection never disagree on
+    eligibility.
+    """
     args = inner.args
-    n = int(getattr(args, "num_nextn_predict_layers", 0) or 0)
-    if n >= 1:
-        return n
+    for key in _HY3_MTP_LAYER_KEYS:
+        n = int(getattr(args, key, 0) or 0)
+        if n >= 1:
+            return n
     # Fall back to a wrapper text_config dict (defensive; HY3 has no wrapper).
     outer_args = getattr(model, "args", None)
     text_config = getattr(outer_args, "text_config", None) or {}
     if isinstance(text_config, dict):
-        n = int(text_config.get("num_nextn_predict_layers", 0) or 0)
-    return n
+        for key in _HY3_MTP_LAYER_KEYS:
+            n = int(text_config.get(key, 0) or 0)
+            if n >= 1:
+                return n
+    return 0
 
 
 def inject_hy3_mtp_support(
@@ -140,15 +171,6 @@ def inject_hy3_mtp_support(
     import mlx.core as mx
     import mlx.nn as nn
 
-    # HY3's base checkpoint has no baked-in MTP head — always resolve a sidecar
-    # (default to the published repo) unless the caller opted into random init.
-    if mtp_sidecar is None and not allow_random_init:
-        mtp_sidecar = DEFAULT_HY3_MTP_SIDECAR
-        logger.info(
-            "[mtp.inject.hy3] no explicit sidecar; defaulting to %s",
-            DEFAULT_HY3_MTP_SIDECAR,
-        )
-
     inner = _resolve_inner_model(model)
     if inner is None:
         logger.warning(
@@ -177,6 +199,32 @@ def inject_hy3_mtp_support(
 
     # --- Step 2: Quantize to match base (4-bit Linear; 8-bit router.gate). ---
     quant_info = _detect_base_quantization(inner)
+
+    # Resolve the DEFAULT sidecar BEFORE quantizing the head: HY3's base has no
+    # baked-in head, so a missing sidecar defaults to the published repo — but
+    # ONLY when the base quantization matches what that sidecar was extracted
+    # at (codex BLOCKING #3; a mismatch would load shape-incompatible tensors),
+    # and at a pinned revision (codex BLOCKING #1). An explicit sidecar bypasses
+    # both gates (the operator vouches for the pairing).
+    sidecar_revision = None
+    if mtp_sidecar is None and not allow_random_init:
+        if quant_info != DEFAULT_HY3_MTP_SIDECAR_BASE_QUANT:
+            logger.warning(
+                "[mtp.inject.hy3] base quantization %s != default sidecar's %s; "
+                "the auto-resolved %s would load shape-incompatible tensors. "
+                "Pass an explicit mtp_sidecar extracted for this base.",
+                quant_info,
+                DEFAULT_HY3_MTP_SIDECAR_BASE_QUANT,
+                DEFAULT_HY3_MTP_SIDECAR,
+            )
+            return False
+        mtp_sidecar = DEFAULT_HY3_MTP_SIDECAR
+        sidecar_revision = DEFAULT_HY3_MTP_SIDECAR_REVISION
+        logger.info(
+            "[mtp.inject.hy3] no explicit sidecar; defaulting to %s@%s",
+            DEFAULT_HY3_MTP_SIDECAR,
+            sidecar_revision[:12],
+        )
     if quant_info is not None:
 
         def _class_predicate(path: str, module) -> Any:
@@ -204,7 +252,7 @@ def inject_hy3_mtp_support(
 
     # --- Step 3: Load sidecar weights with strict coverage check. ---
     if mtp_sidecar is not None:
-        weights_file = _resolve_sidecar_file(mtp_sidecar)
+        weights_file = _resolve_sidecar_file(mtp_sidecar, revision=sidecar_revision)
         if weights_file is None:
             logger.warning(
                 "[mtp.inject.hy3] sidecar %r could not be resolved; skipping.",
@@ -228,6 +276,27 @@ def inject_hy3_mtp_support(
                 weights_file.name,
                 len(missing),
                 sorted(missing)[:8],
+            )
+            return False
+        # Shape/dtype guard (codex BLOCKING #3): the key-name coverage above
+        # does NOT catch a sidecar quantized for a different base (e.g. 8-bit
+        # packed tensors landing on a 4-bit head), which would either error
+        # opaquely in load_weights or corrupt inference. Reject up-front with
+        # an actionable message.
+        expected_shapes = {k: v.shape for k, v in tree_flatten(mtp.parameters())}
+        bad = [
+            (k, tuple(expected_shapes[k]), tuple(mtp_weights[k].shape))
+            for k in expected_keys
+            if tuple(mtp_weights[k].shape) != tuple(expected_shapes[k])
+        ]
+        if bad:
+            logger.warning(
+                "[mtp.inject.hy3] sidecar %s has %d shape-mismatched tensor(s) "
+                "(likely a quantization mismatch vs the base). First: %s. "
+                "Refusing to load. Use a sidecar extracted for this base quant.",
+                weights_file.name,
+                len(bad),
+                bad[0],
             )
             return False
         mtp.load_weights(list(mtp_weights.items()), strict=False)


### PR DESCRIPTION
## Why

HY3 (Tencent Hunyuan 3) is a Tier-1 family in rapid-mlx, but `hy3-preview-4bit` had `supports_spec_decode: false` — no acceleration path. HY3 ships a **native** DeepSeek-V3-style MTP head that the 4-bit MLX convert strips, leaving a ~155 GB model decoding at ~0.4 tok/s with no speculative option. Because the head is native (trained, not a bolt-on drafter), grafting it back gives a lossless self-speculative speedup for free — the highest-ROI acceleration available for this family. This PR re-supplies that head and wires it behind the existing MTP entry point, so a user gets ~1.5–1.7× decode with a single flag and zero extra download management.

## What

Wire HY3's (Tencent Hunyuan 3, `model_type=hy_v3`) **native DeepSeek-V3-style MTP head** as a self-speculative draft head, behind the existing `--speculative-config '{"method":"mtp"}'` entry point. This makes `hy3-preview-4bit` a spec-decode-capable Tier-1 family.

`mlx-community/Hy3-preview-4bit` **strips** the native MTP head at convert time (keeps only backbone layers 0–79). The full-precision `tencent/Hy3-preview` keeps it at layer 80 (a single next-n predict layer, K=1). This PR extracts + quantizes that head into a published sidecar and grafts it at boot.

## User-facing

```bash
rapid-mlx serve hy3-preview-4bit --speculative-config '{"method":"mtp"}'
```

The sidecar (`mlx-community/Hy3-preview-MTP-4bit`, 2.1 GB) is **auto-resolved and downloaded** — no extra flag. Unlike Qwen3.5 (whose MTP head ships inside the base checkpoint), HY3's 4-bit backbone has no baked-in head, so `hy3_inject` defaults `mtp_sidecar` to the published repo.

## Evidence (real weights, M3 Ultra, `mlx-community/Hy3-preview-4bit`)

| Metric | Result |
|---|---|
| Inject + validate on real 155 GB model | **True / True** |
| Draft accept rate (K=1 chain, 8 prompts, pooled) | **64.5%** (98/152); per-prompt 47.6–82.4% |
| Batched-consistent lossless | **5/8 byte-match**; 3 divergences root-caused as near-tie argmax flips (below) |
| MTP-vs-MTP determinism (temp=0) | **byte-identical across runs** — the correctness gate |
| Decode tok/s speedup (MTP-on vs MTP-off) | **~1.62× mean / 1.64× median** (rigorous two-point, prefill-canceling: code 1.47× / reasoning 1.75× / chinese 1.64×) |

### On the 3/8 lossless "divergences"

These are **not** MTP bugs. Per the project's MTP lossless contract (`memory/knowledge/decisions.md`, 2026-07-02), the contract is *batched-consistent* lossless — "a draft token is accepted iff it equals the target model's greedy pick under the same batched forward" — **not** byte-equal vs a single-token `mlx-lm.generate` baseline. MLX SDPA numerics differ between `q_len=1` and `q_len≥2` under 4-bit quant, and bf16 accumulation is non-associative, so a near-tie argmax boundary can flip. Root-cause probe on the earliest divergence (chinese, pos 2):

```
pos 0: top1-top2 gap = 3.84   match=True
pos 1: gap = 1.57             match=True
pos 2: gap = 0.088            match=False   <- razor-thin near-tie flip
pos 3: gap = 6.06             match=True
```

The divergent position has a 0.088 logit gap vs 1.5–6.0 at matching positions — the same upstream-MLX behavior Google mlx-vlm and Ollama ship with. The correctness gate that *does* hold is MTP-vs-MTP determinism (byte-identical), which passes.

## Sidecar

Published to [`mlx-community/Hy3-preview-MTP-4bit`](https://huggingface.co/mlx-community/Hy3-preview-MTP-4bit) (README with full extraction provenance from `tencent/Hy3-preview` layer 80). A from-scratch `snapshot_download` resolve was verified end-to-end (2.111 GB safetensors → standard HF cache). `scripts/extract_hy3_mtp.py` is the reproducible regeneration tool.

## Changes

New:
- `vllm_mlx/spec_decode/mtp/hy3_head.py` — `_HY3MTPModule`: reuses `hy_v3.DecoderLayer` (forced onto the MoE branch) wrapped by enorm/hnorm/eh_proj/norm. Forward = `eh_proj(concat([enorm(embed_next), hnorm(prev_hidden)], -1))` (embedding-first, confirmed vs vLLM `deepseek_mtp.py` + SGLang hunyuan nextn).
- `vllm_mlx/spec_decode/mtp/hy3_inject.py` — inject/validate the four MTP contract surfaces; default sidecar auto-resolution.
- `scripts/extract_hy3_mtp.py` — index-driven shard download, expert stacking, quant-match extraction of the head.
- `tests/test_mtp_hy3_inject.py` — 17 tests mirroring the qwen3_5 path.

Registration (strictly additive):
- `detect.py` — `hy_v3` on the allowlist; `_mtp_num_hidden_layers` reads HY3's `num_nextn_predict_layers` (no cross-contamination of the Qwen `mtp_num_hidden_layers` key; `deepseek_v3` stays off the allowlist).
- `dispatch.py` — `hy_v3` → hy3 inject/validate.
- `scheduler.py` — `hy_v3` in the config-vetted MTP allowlist.
- `aliases.json` — `hy3-preview-4bit` `supports_spec_decode: true`.

## Tests

`198 passed` across the full MTP suite + the new 17 `test_mtp_hy3_inject`. No regression. Ruff clean.


## Codex review (round 1 → converged)

5 blocking findings from `gpt-5.6-sol`, all addressed:
1. **Pinned sidecar revision** — the default sidecar now resolves at an immutable commit SHA (no mutable-HEAD supply-chain window).
2. **detect/inject key-set parity** — the inject layer-count resolver reads the same `num_nextn_predict_layers` + `mtp_num_hidden_layers` set as detection, so a config deemed eligible is never refused at inject.
3. **Default-sidecar quant gate + shape guard** — the default sidecar auto-resolves only when the base matches its 4-bit/gs64 quant; a per-tensor shape check rejects any quant mismatch before load.
4. **extract derives quant from base** — `extract_hy3_mtp.py` reads `config.json::quantization` instead of hardcoding 4-bit, and rejects a base with no quant metadata.
5. **safe cache cleanup** — the script no longer unlinks shared content-addressed HF blobs (which would dangle other snapshots' symlinks); it points at `huggingface-cli delete-cache` instead.

3 new regression tests lock findings #1–#3; findings #4–#5 are script-side. The 7 `supply_chain` `eval()` warnings are false positives (`mx.eval()` is MLX tensor evaluation, not Python `eval`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
