### PR TITLE
chore: bump version to 0.10.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.10.7"
+version = "0.10.8"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## Why

Ship the accumulated `v0.10.7..main` backlog as **0.10.8**. Two headline user-facing features are ready and gated, plus five fixes; a dedicated pyproject bump is the only thing that fires auto-release (`auto-release.yml` matches the `chore: bump version to X.Y.Z` subject), because version bumps buried inside feature PRs silently skip the release. Batching per the no-PR-per-release SOP.

## Headline
- **HY3 native MTP self-speculative decoding** (#1094) — `hy3-preview-4bit --speculative-config '{"method":"mtp"}'` → ~1.62× decode, 64.5% draft accept, sidecar `mlx-community/Hy3-preview-MTP-4bit` auto-resolved. HY3 becomes a spec-decode-capable Tier-1 family.
- **bonsai-1.7b-2bit ternary alias** (#1092) — 0.5 GB desktop-flagship small model, mirrored to R2 (catalog LIVE), dogfood PASS (coherence/code/math/中文/tool-call all green).

## Also in this release
- fix(gpt-oss): honor `--no-thinking` in Harmony chat prompts (#1093)
- fix(pr_validate): repin codex_review to gpt-5.6-sol + `PR_VALIDATE_CODEX_MODEL` override (#1091)
- fix(readme): restore `[vision]` extra install hint (#1090)
- fix(context): honor local checkpoint context limits (#1089)
- ci: version-check gate — forbid stray version bumps outside dedicated bump PRs (#1088)

pyproject-only bump (0.10.7 → 0.10.8), no code change.