### PR TITLE
fix(share): systematic serve-flag passthrough + MTP K=3 default under --force-spec-decode

### DIFF
--- a/tests/test_share_cli.py
+++ b/tests/test_share_cli.py
@@ -349,6 +349,26 @@ def test_share_forwards_passthrough_flags_after_double_dash():
     assert "--no-thinking" in extra
 
 
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["share", "--", "hy3-preview-4bit"],  # -- before the model
+        ["--", "share", "hy3-preview-4bit"],  # -- before the subcommand
+    ],
+)
+def test_share_native_double_dash_before_model_is_not_passthrough(argv):
+    """A ``--`` that precedes the model (or the subcommand) is argparse's
+    native end-of-options marker, NOT the passthrough separator: the model
+    still parses and there is no passthrough. Regression guard for the codex
+    finding that splitting at the first ``--`` unconditionally broke these
+    previously-valid forms by stripping the required positional."""
+    parser = _real_top_parser()
+    args = top_cli._parse_args_with_share_passthrough(parser, argv)
+    assert args.command == "share"
+    assert args.model == "hy3-preview-4bit"
+    assert args._passthrough == []
+
+
 def test_share_unknown_flag_without_double_dash_is_a_hard_error():
     """Passthrough REQUIRES the ``--`` separator. A serve flag written
     without it is a normal argparse error (not silently forwarded, not

--- a/tests/test_share_cli.py
+++ b/tests/test_share_cli.py
@@ -288,6 +288,69 @@ def test_spawn_serve_passes_loopback_host():
     assert argv[argv.index("--host") + 1] == "127.0.0.1"
 
 
+def test_share_forwards_passthrough_flags_to_serve():
+    """Unrecognized flags (collected by ``cli.main`` parse_known_args into
+    ``args._passthrough``) are forwarded verbatim to the spawned serve, so
+    e.g. ``--force-spec-decode`` / ``--speculative-config`` work over a
+    share tunnel even though share doesn't declare them itself."""
+    serve_proc = MagicMock()
+    serve_proc.poll.return_value = None
+    tunnel = _fake_tunnel()
+    passthrough = [
+        "--force-spec-decode",
+        "--speculative-config",
+        '{"method":"mtp"}',
+    ]
+    with (
+        patch.object(share_cli, "_spawn_serve", return_value=serve_proc) as spawn,
+        patch.object(share_cli, "_wait_for_healthz", return_value=True),
+        patch.object(share_cli, "_verify_auth_gate", return_value=True),
+        patch.object(share_cli.ws_tunnel, "TunnelClient", return_value=tunnel),
+        patch.object(share_cli.ws_tunnel, "wait_for_public_url", return_value=True),
+        patch.object(share_cli, "_pick_port", return_value=18765),
+        patch.object(
+            share_cli, "_resolve_served_model_name", return_value="qwen3.5-4b-4bit"
+        ),
+        patch("time.sleep", side_effect=_ctrl_c_in_monitor_loop()),
+    ):
+        share_cli.share_command(_make_args(_passthrough=passthrough))
+
+    extra = spawn.call_args.kwargs["extra_args"]
+    # Forwarded verbatim.
+    assert "--force-spec-decode" in extra
+    assert "--speculative-config" in extra
+    assert '{"method":"mtp"}' in extra
+    # Share's own forwarded flags are still present alongside the passthrough.
+    assert "--no-thinking" in extra
+
+
+@pytest.mark.parametrize(
+    "denied",
+    [
+        ["--host", "0.0.0.0"],
+        ["--host=0.0.0.0"],
+        ["--api-key", "leaked-secret"],
+        ["--port", "9999"],
+        ["--listen-fd", "7"],
+        ["--log-level", "DEBUG"],
+    ],
+)
+def test_share_rejects_denied_passthrough_flags(denied):
+    """Flags share MUST own for its security / lifecycle model are rejected
+    (exit 2) rather than forwarded. The load-bearing case is ``--host``: a
+    forwarded ``--host 0.0.0.0`` would re-expose the bearer-gated serve
+    port on the LAN, defeating the tunnel-only design. Rejection happens
+    before serve is ever spawned."""
+    with (
+        patch.object(share_cli, "_maybe_confirm_download"),
+        patch.object(share_cli, "_spawn_serve") as spawn,
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        share_cli.share_command(_make_args(_passthrough=denied))
+    assert exc_info.value.code == 2
+    spawn.assert_not_called()
+
+
 def test_spawn_serve_passes_api_key_via_env_not_argv():
     """The bearer key must travel via env (RAPID_MLX_API_KEY) and never
     appear in argv where ``ps`` / shell history would leak it."""

--- a/tests/test_share_cli.py
+++ b/tests/test_share_cli.py
@@ -436,6 +436,43 @@ def test_double_dash_probe_does_not_double_print_help(action_flag, capsys):
     assert out.count("usage:") == 1, f"help printed {out.count('usage:')}×, want 1"
 
 
+def test_non_share_double_dash_skips_probe_no_double_convert():
+    """A ``--`` in a non-``share`` invocation must NOT trigger the passthrough
+    probe: ``share`` isn't the command token, so ``--`` keeps its native
+    meaning and the head is parsed exactly ONCE. Guards the codex nit that the
+    unconditional probe re-parsed the full head for every ``--``-bearing
+    command, running argparse type converters / custom actions a second time.
+
+    Proven the faithful way — a sibling subcommand whose option uses a spy
+    type converter: with the guard, the converter fires once; without it, the
+    probe would parse the head and run it twice."""
+    parser = _real_top_parser()  # registers the real ``share`` subcommand
+    subparsers = next(
+        a for a in parser._actions if isinstance(a, argparse._SubParsersAction)
+    )
+    calls = {"n": 0}
+
+    def _spy_int(raw):
+        calls["n"] += 1
+        return int(raw)
+
+    diag = subparsers.add_parser("diag")
+    diag.add_argument("--n", type=_spy_int)
+    diag.add_argument("rest", nargs="*")  # absorbs tokens after native ``--``
+
+    # ``share`` is absent from the head (``["diag", "--n", "5"]``) → probe is
+    # skipped; native parse runs the converter on "5" exactly once and ``--``
+    # keeps its native meaning (end-of-options; "x" lands in ``rest``).
+    args = top_cli._parse_args_with_share_passthrough(
+        parser, ["diag", "--n", "5", "--", "x"]
+    )
+    assert args.command == "diag"
+    assert args.n == 5
+    assert args.rest == ["x"]
+    assert args._passthrough == []
+    assert calls["n"] == 1, f"converter ran {calls['n']}×, want 1 (probe skipped)"
+
+
 def test_spawn_serve_passes_api_key_via_env_not_argv():
     """The bearer key must travel via env (RAPID_MLX_API_KEY) and never
     appear in argv where ``ps`` / shell history would leak it."""

--- a/tests/test_share_cli.py
+++ b/tests/test_share_cli.py
@@ -455,6 +455,65 @@ def test_double_dash_probe_does_not_double_print_help(argv, capsys):
     assert out.count("usage:") == 1, f"help printed {out.count('usage:')}×, want 1"
 
 
+def test_main_routes_share_passthrough_to_spawned_serve(monkeypatch):
+    """End-to-end through ``cli.main`` (not the helper in isolation): a real
+    ``rapid-mlx share MODEL -- <serve flags>`` argv, parsed by ``main``'s own
+    ``sys.argv`` handling, must reach the spawned serve with the passthrough
+    forwarded verbatim. Guards the codex finding that the unit tests call
+    ``_parse_args_with_share_passthrough`` directly and so would stay green if
+    ``main`` ever stopped routing CLI args through it."""
+    monkeypatch.setenv("RAPID_MLX_TELEMETRY", "0")
+    monkeypatch.setattr(
+        top_cli.sys,
+        "argv",
+        [
+            "rapid-mlx",
+            "share",
+            "hy3-preview-4bit",
+            "--",
+            "--force-spec-decode",
+            "--speculative-config",
+            '{"method":"mtp"}',
+        ],
+    )
+
+    serve_proc = MagicMock()
+    serve_proc.poll.return_value = None
+    tunnel = _fake_tunnel()
+    captured: list[str] = []
+
+    def fake_spawn(*, alias, port, api_key, log_path, extra_args):  # noqa: ARG001
+        captured.extend(extra_args)
+        return serve_proc
+
+    patches = [
+        patch.object(share_cli, "_spawn_serve", side_effect=fake_spawn),
+        patch.object(share_cli, "_wait_for_healthz", return_value=True),
+        patch.object(share_cli, "_verify_auth_gate", return_value=True),
+        patch.object(share_cli.ws_tunnel, "TunnelClient", return_value=tunnel),
+        patch.object(share_cli.ws_tunnel, "wait_for_public_url", return_value=True),
+        patch.object(share_cli, "_pick_port", return_value=18765),
+        patch.object(share_cli, "_maybe_confirm_download"),
+        patch.object(
+            share_cli, "_resolve_served_model_name", return_value="hy3-preview-4bit"
+        ),
+        patch("time.sleep", side_effect=_ctrl_c_in_monitor_loop()),
+    ]
+    with contextlib.ExitStack() as stack:
+        for p in patches:
+            stack.enter_context(p)
+        # ``main`` may exit 0 via share's Ctrl-C-keeps-zero path; tolerate it.
+        with contextlib.suppress(SystemExit):
+            top_cli.main()
+
+    # The serve child receives the verbatim passthrough (option+value pairing
+    # intact) alongside share's own forwarded flags — proving main → helper →
+    # share_command → _spawn_serve is wired end to end.
+    assert "--force-spec-decode" in captured
+    sc = captured.index("--speculative-config")
+    assert captured[sc + 1] == '{"method":"mtp"}'
+
+
 def test_non_share_positional_value_share_skips_probe_no_double_convert():
     """A non-``share`` invocation must NOT trigger the passthrough probe even
     when a POSITIONAL VALUE happens to equal ``"share"`` — the probe is gated on

--- a/tests/test_share_cli.py
+++ b/tests/test_share_cli.py
@@ -415,6 +415,27 @@ def test_share_rejects_denied_passthrough_flags_incl_abbreviations(denied_tokens
     spawn.assert_not_called()
 
 
+@pytest.mark.parametrize("action_flag", ["--help", "-h"])
+def test_double_dash_probe_does_not_double_print_help(action_flag, capsys):
+    """``rapid-mlx --help --`` must print help EXACTLY once and exit 0.
+
+    Regression guard for the codex finding that the ``--`` passthrough probe
+    swallowed the ``SystemExit(0)`` raised by argparse's terminal help/version
+    *action*: the probe ran ``parse_args(head)`` (printing help to stdout),
+    caught the exit, then fell through to the native parse which printed the
+    SAME help a second time. The probe now re-raises a zero exit so the action
+    fires once. stderr-only muting in the probe is why this bug was invisible —
+    help goes to stdout."""
+    parser = _real_top_parser()
+    with pytest.raises(SystemExit) as exc_info:
+        top_cli._parse_args_with_share_passthrough(parser, [action_flag, "--"])
+    # Zero exit propagates (help/version are a successful terminal action).
+    assert exc_info.value.code in (None, 0)
+    out = capsys.readouterr().out
+    # ``usage:`` is argparse's help banner header — exactly one, not two.
+    assert out.count("usage:") == 1, f"help printed {out.count('usage:')}×, want 1"
+
+
 def test_spawn_serve_passes_api_key_via_env_not_argv():
     """The bearer key must travel via env (RAPID_MLX_API_KEY) and never
     appear in argv where ``ps`` / shell history would leak it."""

--- a/tests/test_share_cli.py
+++ b/tests/test_share_cli.py
@@ -415,9 +415,24 @@ def test_share_rejects_denied_passthrough_flags_incl_abbreviations(denied_tokens
     spawn.assert_not_called()
 
 
-@pytest.mark.parametrize("action_flag", ["--help", "-h"])
-def test_double_dash_probe_does_not_double_print_help(action_flag, capsys):
-    """``rapid-mlx --help --`` must print help EXACTLY once and exit 0.
+@pytest.mark.parametrize(
+    "argv",
+    [
+        # Share head → the probe RUNS (``cmd_token == "share"``) and the share
+        # subparser's ``--help`` raises ``SystemExit(0)`` mid-probe. This is the
+        # case that actually exercises the zero-exit re-raise: without it the
+        # fall-through native parse would print share's help a SECOND time.
+        ["share", "hy3-preview-4bit", "--help", "--"],
+        ["share", "hy3-preview-4bit", "-h", "--"],
+        # Top-level head with no command token → probe is skipped; the native
+        # parse prints top-level help once. Kept so both the probe path and the
+        # skip path are covered.
+        ["--help", "--"],
+        ["-h", "--"],
+    ],
+)
+def test_double_dash_probe_does_not_double_print_help(argv, capsys):
+    """``… --help --`` must print help EXACTLY once and exit 0.
 
     Regression guard for the codex finding that the ``--`` passthrough probe
     swallowed the ``SystemExit(0)`` raised by argparse's terminal help/version
@@ -425,10 +440,14 @@ def test_double_dash_probe_does_not_double_print_help(action_flag, capsys):
     caught the exit, then fell through to the native parse which printed the
     SAME help a second time. The probe now re-raises a zero exit so the action
     fires once. stderr-only muting in the probe is why this bug was invisible —
-    help goes to stdout."""
+    help goes to stdout.
+
+    The share-head cases are load-bearing: a top-level ``--help`` skips the
+    probe entirely (no command token), so only a complete share head drives the
+    probe into the re-raise branch under test."""
     parser = _real_top_parser()
     with pytest.raises(SystemExit) as exc_info:
-        top_cli._parse_args_with_share_passthrough(parser, [action_flag, "--"])
+        top_cli._parse_args_with_share_passthrough(parser, argv)
     # Zero exit propagates (help/version are a successful terminal action).
     assert exc_info.value.code in (None, 0)
     out = capsys.readouterr().out
@@ -436,16 +455,17 @@ def test_double_dash_probe_does_not_double_print_help(action_flag, capsys):
     assert out.count("usage:") == 1, f"help printed {out.count('usage:')}×, want 1"
 
 
-def test_non_share_double_dash_skips_probe_no_double_convert():
-    """A ``--`` in a non-``share`` invocation must NOT trigger the passthrough
-    probe: ``share`` isn't the command token, so ``--`` keeps its native
-    meaning and the head is parsed exactly ONCE. Guards the codex nit that the
-    unconditional probe re-parsed the full head for every ``--``-bearing
-    command, running argparse type converters / custom actions a second time.
+def test_non_share_positional_value_share_skips_probe_no_double_convert():
+    """A non-``share`` invocation must NOT trigger the passthrough probe even
+    when a POSITIONAL VALUE happens to equal ``"share"`` — the probe is gated on
+    the structurally-selected command token (first non-option token), not on
+    ``"share"`` merely appearing somewhere in the head. Guards the codex finding
+    that a substring/``in`` check re-parsed such invocations twice, rerunning
+    argparse type converters / custom actions.
 
-    Proven the faithful way — a sibling subcommand whose option uses a spy
-    type converter: with the guard, the converter fires once; without it, the
-    probe would parse the head and run it twice."""
+    Proven the faithful way — a sibling subcommand with a spy type converter and
+    a model positional set to ``"share"``: the converter must fire exactly once
+    (probe skipped); a double parse would run it twice."""
     parser = _real_top_parser()  # registers the real ``share`` subcommand
     subparsers = next(
         a for a in parser._actions if isinstance(a, argparse._SubParsersAction)
@@ -457,16 +477,17 @@ def test_non_share_double_dash_skips_probe_no_double_convert():
         return int(raw)
 
     diag = subparsers.add_parser("diag")
+    diag.add_argument("model")  # positional value is literally "share" below
     diag.add_argument("--n", type=_spy_int)
     diag.add_argument("rest", nargs="*")  # absorbs tokens after native ``--``
 
-    # ``share`` is absent from the head (``["diag", "--n", "5"]``) → probe is
-    # skipped; native parse runs the converter on "5" exactly once and ``--``
-    # keeps its native meaning (end-of-options; "x" lands in ``rest``).
+    # Command token is ``diag`` (first non-option token); the ``"share"`` here is
+    # only diag's model value → probe skipped, converter runs on "5" once.
     args = top_cli._parse_args_with_share_passthrough(
-        parser, ["diag", "--n", "5", "--", "x"]
+        parser, ["diag", "share", "--n", "5", "--", "x"]
     )
     assert args.command == "diag"
+    assert args.model == "share"
     assert args.n == 5
     assert args.rest == ["x"]
     assert args._passthrough == []

--- a/tests/test_share_cli.py
+++ b/tests/test_share_cli.py
@@ -21,6 +21,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from vllm_mlx import cli as top_cli
 from vllm_mlx.share import cli as share_cli
 
 
@@ -288,65 +289,108 @@ def test_spawn_serve_passes_loopback_host():
     assert argv[argv.index("--host") + 1] == "127.0.0.1"
 
 
-def test_share_forwards_passthrough_flags_to_serve():
-    """Unrecognized flags (collected by ``cli.main`` parse_known_args into
-    ``args._passthrough``) are forwarded verbatim to the spawned serve, so
-    e.g. ``--force-spec-decode`` / ``--speculative-config`` work over a
-    share tunnel even though share doesn't declare them itself."""
-    serve_proc = MagicMock()
-    serve_proc.poll.return_value = None
-    tunnel = _fake_tunnel()
-    passthrough = [
+def _real_top_parser() -> argparse.ArgumentParser:
+    """Build a top-level parser whose ``share`` subcommand is registered
+    through the SAME ``share_cli.register`` path ``cli.main`` uses, so these
+    tests exercise the real subparser (required ``model`` positional
+    included) and the real ``--`` passthrough split — not a hand-rolled
+    stand-in that could paper over the parser-layer bugs."""
+    parser = argparse.ArgumentParser(prog="rapid-mlx")
+    subparsers = parser.add_subparsers(dest="command")
+    share_cli.register(subparsers)
+    return parser
+
+
+def _drive_share_from_argv(argv, *, extra_patches=()):
+    """Parse ``argv`` through the real top-level parser + the real
+    ``cli._parse_args_with_share_passthrough`` split, then run
+    ``share_command`` with its lifecycle mocked and return
+    ``(args, spawned_serve_extra_args)``.
+
+    Driving from raw argv — rather than injecting a pre-built
+    ``_passthrough`` — is the whole point: it's the only way these tests can
+    catch a parser-layer regression that corrupts ``model`` or the
+    option/value grouping of the passthrough (codex review finding: a test
+    that hand-injects ``_passthrough`` stays green even when the parser
+    swallows the JSON value into share's ``model`` positional)."""
+    args = top_cli._parse_args_with_share_passthrough(_real_top_parser(), list(argv))
+    captured = _drive_share_capture(args, extra_patches=extra_patches)
+    return args, captured
+
+
+def test_share_forwards_passthrough_flags_after_double_dash():
+    """End-to-end: ``rapid-mlx share MODEL -- <serve flags>`` forwards every
+    token after ``--`` verbatim to the spawned serve, with option/value
+    grouping intact, so ``--force-spec-decode`` / ``--speculative-config``
+    work over a share tunnel even though share doesn't declare them."""
+    argv = [
+        "share",
+        "hy3-preview-4bit",
+        "--",
         "--force-spec-decode",
         "--speculative-config",
         '{"method":"mtp"}',
     ]
-    with (
-        patch.object(share_cli, "_spawn_serve", return_value=serve_proc) as spawn,
-        patch.object(share_cli, "_wait_for_healthz", return_value=True),
-        patch.object(share_cli, "_verify_auth_gate", return_value=True),
-        patch.object(share_cli.ws_tunnel, "TunnelClient", return_value=tunnel),
-        patch.object(share_cli.ws_tunnel, "wait_for_public_url", return_value=True),
-        patch.object(share_cli, "_pick_port", return_value=18765),
-        patch.object(
-            share_cli, "_resolve_served_model_name", return_value="qwen3.5-4b-4bit"
-        ),
-        patch("time.sleep", side_effect=_ctrl_c_in_monitor_loop()),
-    ):
-        share_cli.share_command(_make_args(_passthrough=passthrough))
+    args, extra = _drive_share_from_argv(argv)
 
-    extra = spawn.call_args.kwargs["extra_args"]
-    # Forwarded verbatim.
+    # The ``model`` positional must NOT swallow the JSON value of the
+    # passthrough flag — the exact corruption a bare parse_known_args had.
+    assert args.model == "hy3-preview-4bit"
+    assert args._passthrough == [
+        "--force-spec-decode",
+        "--speculative-config",
+        '{"method":"mtp"}',
+    ]
+    # Forwarded verbatim into the serve argv, option+value pairing preserved.
     assert "--force-spec-decode" in extra
-    assert "--speculative-config" in extra
-    assert '{"method":"mtp"}' in extra
-    # Share's own forwarded flags are still present alongside the passthrough.
+    sc = extra.index("--speculative-config")
+    assert extra[sc + 1] == '{"method":"mtp"}'
+    # Share's own forwarded flags still present alongside the passthrough.
     assert "--no-thinking" in extra
 
 
+def test_share_unknown_flag_without_double_dash_is_a_hard_error():
+    """Passthrough REQUIRES the ``--`` separator. A serve flag written
+    without it is a normal argparse error (not silently forwarded, not
+    swallowed) — this is what removes the model-positional value-steal
+    ambiguity for good and makes the passthrough grammar unambiguous."""
+    argv = ["share", "hy3-preview-4bit", "--force-spec-decode"]
+    with pytest.raises(SystemExit):
+        top_cli._parse_args_with_share_passthrough(_real_top_parser(), argv)
+
+
 @pytest.mark.parametrize(
-    "denied",
+    "denied_tokens",
     [
         ["--host", "0.0.0.0"],
         ["--host=0.0.0.0"],
+        # argparse keeps allow_abbrev=True on the serve child, so an
+        # abbreviation of a denied flag would resolve to the full flag and
+        # bypass a name-only denylist — the LAN-reexposure the review flagged.
+        ["--hos=0.0.0.0"],
+        ["--ho", "0.0.0.0"],
         ["--api-key", "leaked-secret"],
+        ["--api", "leaked-secret"],
         ["--port", "9999"],
         ["--listen-fd", "7"],
         ["--log-level", "DEBUG"],
     ],
 )
-def test_share_rejects_denied_passthrough_flags(denied):
+def test_share_rejects_denied_passthrough_flags_incl_abbreviations(denied_tokens):
     """Flags share MUST own for its security / lifecycle model are rejected
-    (exit 2) rather than forwarded. The load-bearing case is ``--host``: a
-    forwarded ``--host 0.0.0.0`` would re-expose the bearer-gated serve
-    port on the LAN, defeating the tunnel-only design. Rejection happens
-    before serve is ever spawned."""
+    (exit 2) rather than forwarded — including every unambiguous abbreviation
+    of them. The load-bearing case is ``--host`` (and ``--hos`` / ``--ho``):
+    a forwarded ``--host 0.0.0.0`` re-exposes the bearer-gated serve port on
+    the LAN, defeating the tunnel-only design. Rejection is driven from real
+    argv and happens before serve is ever spawned."""
+    argv = ["share", "hy3-preview-4bit", "--", *denied_tokens]
+    args = top_cli._parse_args_with_share_passthrough(_real_top_parser(), argv)
     with (
         patch.object(share_cli, "_maybe_confirm_download"),
         patch.object(share_cli, "_spawn_serve") as spawn,
         pytest.raises(SystemExit) as exc_info,
     ):
-        share_cli.share_command(_make_args(_passthrough=denied))
+        share_cli.share_command(args)
     assert exc_info.value.code == 2
     spawn.assert_not_called()
 

--- a/tests/test_speculative_config.py
+++ b/tests/test_speculative_config.py
@@ -316,6 +316,29 @@ def test_speculative_config_mtp_explicit_tokens_win_over_force_default() -> None
     assert args.mtp_max_k == 2
 
 
+def test_speculative_config_rejects_explicit_max_k_flag_combo(capsys) -> None:
+    """The ``--force-spec-decode`` K=3 default can never overwrite a
+    user-pinned ``--mtp-max-k`` because ``--mtp-max-k`` and
+    ``--speculative-config`` are mutually exclusive: the legacy-alias guard
+    (`_legacy_speculative_fields` lists ``mtp_max_k``) exits with code 2
+    before the mtp branch runs. This documents that the codex-flagged
+    "explicit depth silently overridden by 3" scenario is unreachable."""
+    import pytest
+
+    from vllm_mlx.cli import _normalize_speculative_config_or_exit
+
+    args = _spec_config_args(
+        speculative_config='{"method":"mtp"}',
+        force_spec_decode=True,
+        mtp_max_k=5,  # explicit --mtp-max-k alongside --speculative-config
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        _normalize_speculative_config_or_exit(args)
+    assert exc_info.value.code == 2
+    assert "mutually exclusive" in capsys.readouterr().err
+
+
 def test_speculative_config_parse_none_cleanly_disables(monkeypatch) -> None:
     from vllm_mlx.cli import _normalize_speculative_config_or_exit
     from vllm_mlx.spec_decode import config as config_mod

--- a/tests/test_speculative_config.py
+++ b/tests/test_speculative_config.py
@@ -282,6 +282,40 @@ def test_speculative_config_mtp_without_token_count_keeps_legacy_one_token() -> 
     assert args.mtp_disable_auto_k is False
 
 
+def test_speculative_config_mtp_force_spec_decode_defaults_k_three() -> None:
+    """When the user opts into spec-decode via ``--force-spec-decode`` but
+    doesn't pin ``num_speculative_tokens``, MTP defaults to K=3 (auto-K
+    controller's intended default) instead of the K=1 chain-of-1 that
+    carries draft overhead with no net speedup."""
+    from vllm_mlx.cli import _normalize_speculative_config_or_exit
+
+    args = _spec_config_args(
+        speculative_config='{"method":"mtp"}', force_spec_decode=True
+    )
+
+    _normalize_speculative_config_or_exit(args)
+
+    assert args.spec_decode == "mtp"
+    assert args.mtp_max_k == 3
+    assert args.mtp_disable_auto_k is False
+
+
+def test_speculative_config_mtp_explicit_tokens_win_over_force_default() -> None:
+    """An explicit ``num_speculative_tokens`` always wins, even under
+    ``--force-spec-decode`` — the K=3 default only fills the unset case."""
+    from vllm_mlx.cli import _normalize_speculative_config_or_exit
+
+    args = _spec_config_args(
+        speculative_config='{"method":"mtp","num_speculative_tokens":2}',
+        force_spec_decode=True,
+    )
+
+    _normalize_speculative_config_or_exit(args)
+
+    assert args.spec_decode == "mtp"
+    assert args.mtp_max_k == 2
+
+
 def test_speculative_config_parse_none_cleanly_disables(monkeypatch) -> None:
     from vllm_mlx.cli import _normalize_speculative_config_or_exit
     from vllm_mlx.spec_decode import config as config_mod

--- a/tests/test_speculative_config.py
+++ b/tests/test_speculative_config.py
@@ -316,27 +316,37 @@ def test_speculative_config_mtp_explicit_tokens_win_over_force_default() -> None
     assert args.mtp_max_k == 2
 
 
-def test_speculative_config_rejects_explicit_max_k_flag_combo(capsys) -> None:
+@pytest.mark.parametrize("explicit_k", [5, 1, 0])
+def test_speculative_config_rejects_explicit_max_k_flag_combo(
+    explicit_k, capsys
+) -> None:
     """The ``--force-spec-decode`` K=3 default can never overwrite a
     user-pinned ``--mtp-max-k`` because ``--mtp-max-k`` and
     ``--speculative-config`` are mutually exclusive: the legacy-alias guard
     (`_legacy_speculative_fields` lists ``mtp_max_k``) exits with code 2
     before the mtp branch runs. This documents that the codex-flagged
-    "explicit depth silently overridden by 3" scenario is unreachable."""
-    import pytest
+    "explicit depth silently overridden by 3" scenario is unreachable.
 
+    Parametrized over ``explicit_k`` INCLUDING ``1`` — the value that equals the
+    runtime default — and ``0``: the guard keys on ``mtp_max_k is not None`` (an
+    unset sentinel), NOT on ``!= 1``, so ``--mtp-max-k 1`` is a *set* value and
+    is rejected exactly like ``5``. This nails the codex claim that a
+    default-valued flag slips past the guard and gets silently rewritten to 3;
+    it does not — it exits 2, and ``mtp_max_k`` is never mutated to 3."""
     from vllm_mlx.cli import _normalize_speculative_config_or_exit
 
     args = _spec_config_args(
         speculative_config='{"method":"mtp"}',
         force_spec_decode=True,
-        mtp_max_k=5,  # explicit --mtp-max-k alongside --speculative-config
+        mtp_max_k=explicit_k,  # explicit --mtp-max-k alongside --speculative-config
     )
 
     with pytest.raises(SystemExit) as exc_info:
         _normalize_speculative_config_or_exit(args)
     assert exc_info.value.code == 2
     assert "mutually exclusive" in capsys.readouterr().err
+    # The user's explicit depth is preserved, never silently overwritten to 3.
+    assert args.mtp_max_k == explicit_k
 
 
 def test_speculative_config_parse_none_cleanly_disables(monkeypatch) -> None:

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -6571,28 +6571,55 @@ def _parse_args_with_share_passthrough(
     representative argv orderings (see tests/test_share_cli.py) — the crux
     being that ``share`` must not corrupt ``model`` or the passthrough list.
     """
-    # Detect the subcommand with a side-effect-free lightweight probe rather
-    # than a full ``parser.parse_known_args`` — the latter would run every
-    # recognized type converter and custom argparse action a second time on
-    # normal invocations. The probe knows ONLY the subcommand positional, so
-    # no serve/bench converters fire. It is safe because the top-level parser
-    # has no value-taking global options ahead of the subcommand (only the
-    # valueless ``--version``/``-V``/``-h``), so the first positional token is
-    # unambiguously the command.
-    _probe = argparse.ArgumentParser(add_help=False)
-    _probe.add_argument("command", nargs="?", default=None)
-    probed, _ = _probe.parse_known_args(raw_argv)
-    if probed.command == "share" and "--" in raw_argv:
+    # A ``--`` is only the passthrough separator when it comes AFTER a
+    # COMPLETE ``share <model>`` head. A ``--`` positioned BEFORE the model
+    # (``share -- MODEL``) or before the subcommand (``-- share MODEL``) is
+    # argparse's native end-of-options marker and must keep its native
+    # meaning — splitting there would strip the required positional and break
+    # those valid forms. So we only split when the tokens to the left of the
+    # first ``--`` STRICTLY parse as ``share`` WITH a model.
+    #
+    # ``normal`` invocations (no ``--`` at all — the overwhelming majority)
+    # skip this block entirely and hit the single ``parse_args`` below, so no
+    # converter/action runs twice on the common path.
+    if "--" in raw_argv:
+        import contextlib
+        import io
+
         sep = raw_argv.index("--")
         head_argv, passthrough_argv = raw_argv[:sep], raw_argv[sep + 1 :]
-        # Strict parse of the head so typos in share's OWN flags still
-        # error; the denylist in share.cli then vets the passthrough. This is
-        # the single authoritative parse of share's own arguments.
-        args = parser.parse_args(head_argv)
-        args._passthrough = passthrough_argv
-    else:
-        args = parser.parse_args(raw_argv)
-        args._passthrough = []
+        # Strict probe: does the head fully resolve to a ``share`` command
+        # with a model? A STRICT ``parse_args`` (not ``parse_known_args``)
+        # means an incomplete head (``share`` alone, i.e. ``share -- MODEL``)
+        # or a typo'd share flag makes the probe exit — in which case this
+        # ``--`` is NOT a passthrough separator and we fall through to native
+        # parsing. stderr is muted so the probe's would-be usage error never
+        # reaches the user (the fall-through re-parses and either succeeds or
+        # emits the real error itself).
+        probed = None
+        with contextlib.redirect_stderr(io.StringIO()):
+            try:
+                probed = parser.parse_args(head_argv)
+            except SystemExit:
+                probed = None
+        if (
+            probed is not None
+            and getattr(probed, "command", None) == "share"
+            and getattr(probed, "model", None) is not None
+        ):
+            # Head is a complete share command; the tokens after ``--`` are
+            # verbatim serve-flag passthrough. ``probed`` already holds share's
+            # authoritative parsed args (model + share flags); the denylist in
+            # share.cli then vets the passthrough.
+            probed._passthrough = passthrough_argv
+            return probed
+
+    # Everything else — non-share commands, ``share`` with no passthrough
+    # ``--``, and the ``share -- MODEL`` / ``-- share MODEL`` native forms —
+    # keeps argparse's native behavior, including native ``--`` handling and
+    # hard errors on unrecognized flags.
+    args = parser.parse_args(raw_argv)
+    args._passthrough = []
     return args
 
 

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -6591,17 +6591,26 @@ def _parse_args_with_share_passthrough(
         # Strict probe: does the head fully resolve to a ``share`` command
         # with a model? A STRICT ``parse_args`` (not ``parse_known_args``)
         # means an incomplete head (``share`` alone, i.e. ``share -- MODEL``)
-        # or a typo'd share flag makes the probe exit — in which case this
-        # ``--`` is NOT a passthrough separator and we fall through to native
-        # parsing. stderr is muted so the probe's would-be usage error never
-        # reaches the user (the fall-through re-parses and either succeeds or
-        # emits the real error itself).
+        # or a typo'd share flag makes the probe exit with a NON-ZERO code — in
+        # which case this ``--`` is NOT a passthrough separator and we fall
+        # through to native parsing. stderr is muted so the probe's would-be
+        # usage error never reaches the user (the fall-through re-parses and
+        # either succeeds or emits the real error itself).
+        #
+        # A ZERO exit is different: the probe already ran a terminal argparse
+        # *action* — ``--help`` / ``--version`` printed to stdout and called
+        # ``parser.exit(0)``. Swallowing that would make the fall-through parse
+        # print the SAME message a second time, so re-raise instead: the text
+        # prints exactly once and the process exits cleanly.
         probed = None
         with contextlib.redirect_stderr(io.StringIO()):
             try:
                 probed = parser.parse_args(head_argv)
-            except SystemExit:
-                probed = None
+            except SystemExit as exc:
+                if exc.code not in (None, 0):
+                    probed = None
+                else:
+                    raise
         if (
             probed is not None
             and getattr(probed, "command", None) == "share"

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -1923,6 +1923,14 @@ def _normalize_speculative_config_or_exit(args):
         args.mtp_sidecar = config.model
         if config.num_speculative_tokens is not None:
             args.mtp_max_k = config.num_speculative_tokens
+        elif getattr(args, "force_spec_decode", False):
+            # User explicitly opted into spec-decode via --force-spec-decode
+            # but didn't pin a draft depth. K=1 chain-of-1 carries draft
+            # overhead with no net speedup; default to K=3 (the EV auto-K
+            # controller's intended default) so MTP actually accelerates.
+            # An explicit ``num_speculative_tokens`` always wins (branch
+            # above), so passing e.g. num_speculative_tokens=2 still holds.
+            args.mtp_max_k = 3
         if config.disable_auto_k is not None:
             args.mtp_disable_auto_k = config.disable_auto_k
     elif config.method == "suffix":
@@ -8032,7 +8040,20 @@ Examples:
     else:
         argcomplete.autocomplete(parser)
 
-    args = parser.parse_args()
+    # ``parse_known_args`` instead of ``parse_args`` so the ``share``
+    # subcommand can forward unrecognized flags verbatim to the
+    # ``rapid-mlx serve`` it spawns (systematic serve-flag passthrough:
+    # every serve flag — spec-decode, KV-cache tuning, sampling defaults —
+    # works over a share tunnel without share re-declaring each one). For
+    # EVERY other subcommand we preserve the original strict behavior:
+    # unknown args are a hard error, exactly as ``parse_args`` raised.
+    args, _unknown_args = parser.parse_known_args()
+    if getattr(args, "command", None) == "share":
+        args._passthrough = _unknown_args
+    else:
+        if _unknown_args:
+            parser.error(f"unrecognized arguments: {' '.join(_unknown_args)}")
+        args._passthrough = []
 
     # First-run consent prompt — fires at most once per machine, only on
     # interactive subcommands when stdin is a tty. Safe no-op otherwise.

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -6544,6 +6544,44 @@ def telemetry_command(args) -> None:
     sys.exit(1)
 
 
+def _parse_args_with_share_passthrough(
+    parser: argparse.ArgumentParser, raw_argv: list[str]
+) -> argparse.Namespace:
+    """Parse ``raw_argv`` with the fully-registered top-level ``parser``,
+    applying ``share``'s ``--`` end-of-options passthrough split.
+
+    ``rapid-mlx share <model> -- <serve flags…>`` forwards everything after
+    the literal ``--`` verbatim to the ``rapid-mlx serve`` that ``share``
+    spawns (stored on ``args._passthrough``). Splitting on ``--`` up front is
+    what keeps a value-taking serve flag such as
+    ``--speculative-config '{"method":"mtp"}'`` from having its JSON value
+    swallowed by share's required ``model`` positional — the passthrough
+    tokens never reach share's parser, so option/value grouping is preserved
+    exactly as typed. Every other subcommand (and ``share`` with no ``--``)
+    keeps argparse's native behavior, including hard errors on unrecognized
+    flags and native ``--`` end-of-options handling.
+
+    Factored out of ``main`` so tests can drive the real parser + split with
+    representative argv orderings (see tests/test_share_cli.py) — the crux
+    being that ``share`` must not corrupt ``model`` or the passthrough list.
+    """
+    # The peek parse only reads ``command`` — the subparser action sets it
+    # regardless of any downstream positional/optional ambiguity, so a
+    # tolerant ``parse_known_args`` is safe purely to route here.
+    peeked, _ = parser.parse_known_args(raw_argv)
+    if getattr(peeked, "command", None) == "share" and "--" in raw_argv:
+        sep = raw_argv.index("--")
+        head_argv, passthrough_argv = raw_argv[:sep], raw_argv[sep + 1 :]
+        # Strict parse of the head so typos in share's OWN flags still
+        # error; the denylist in share.cli then vets the passthrough.
+        args = parser.parse_args(head_argv)
+        args._passthrough = passthrough_argv
+    else:
+        args = parser.parse_args(raw_argv)
+        args._passthrough = []
+    return args
+
+
 def main():
     from importlib.metadata import version as pkg_version
 
@@ -8040,20 +8078,9 @@ Examples:
     else:
         argcomplete.autocomplete(parser)
 
-    # ``parse_known_args`` instead of ``parse_args`` so the ``share``
-    # subcommand can forward unrecognized flags verbatim to the
-    # ``rapid-mlx serve`` it spawns (systematic serve-flag passthrough:
-    # every serve flag — spec-decode, KV-cache tuning, sampling defaults —
-    # works over a share tunnel without share re-declaring each one). For
-    # EVERY other subcommand we preserve the original strict behavior:
-    # unknown args are a hard error, exactly as ``parse_args`` raised.
-    args, _unknown_args = parser.parse_known_args()
-    if getattr(args, "command", None) == "share":
-        args._passthrough = _unknown_args
-    else:
-        if _unknown_args:
-            parser.error(f"unrecognized arguments: {' '.join(_unknown_args)}")
-        args._passthrough = []
+    # Systematic serve-flag passthrough for ``share`` via the standard ``--``
+    # end-of-options separator — see ``_parse_args_with_share_passthrough``.
+    args = _parse_args_with_share_passthrough(parser, sys.argv[1:])
 
     # First-run consent prompt — fires at most once per machine, only on
     # interactive subcommands when stdin is a tty. Safe no-op otherwise.

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -1928,8 +1928,14 @@ def _normalize_speculative_config_or_exit(args):
             # but didn't pin a draft depth. K=1 chain-of-1 carries draft
             # overhead with no net speedup; default to K=3 (the EV auto-K
             # controller's intended default) so MTP actually accelerates.
-            # An explicit ``num_speculative_tokens`` always wins (branch
-            # above), so passing e.g. num_speculative_tokens=2 still holds.
+            #
+            # Only two draft-depth sources exist for the mtp method and
+            # neither is set here: (a) ``num_speculative_tokens`` in the JSON
+            # is handled by the branch above; (b) the legacy ``--mtp-max-k``
+            # flag CANNOT co-occur with ``--speculative-config`` — the
+            # mutual-exclusion guard (`_legacy_speculative_fields` lists
+            # ``mtp_max_k``) exits with code 2 before we reach this branch.
+            # So K=3 here never overwrites a user-pinned depth.
             args.mtp_max_k = 3
         if config.disable_auto_k is not None:
             args.mtp_disable_auto_k = config.disable_auto_k
@@ -6565,15 +6571,23 @@ def _parse_args_with_share_passthrough(
     representative argv orderings (see tests/test_share_cli.py) — the crux
     being that ``share`` must not corrupt ``model`` or the passthrough list.
     """
-    # The peek parse only reads ``command`` — the subparser action sets it
-    # regardless of any downstream positional/optional ambiguity, so a
-    # tolerant ``parse_known_args`` is safe purely to route here.
-    peeked, _ = parser.parse_known_args(raw_argv)
-    if getattr(peeked, "command", None) == "share" and "--" in raw_argv:
+    # Detect the subcommand with a side-effect-free lightweight probe rather
+    # than a full ``parser.parse_known_args`` — the latter would run every
+    # recognized type converter and custom argparse action a second time on
+    # normal invocations. The probe knows ONLY the subcommand positional, so
+    # no serve/bench converters fire. It is safe because the top-level parser
+    # has no value-taking global options ahead of the subcommand (only the
+    # valueless ``--version``/``-V``/``-h``), so the first positional token is
+    # unambiguously the command.
+    _probe = argparse.ArgumentParser(add_help=False)
+    _probe.add_argument("command", nargs="?", default=None)
+    probed, _ = _probe.parse_known_args(raw_argv)
+    if probed.command == "share" and "--" in raw_argv:
         sep = raw_argv.index("--")
         head_argv, passthrough_argv = raw_argv[:sep], raw_argv[sep + 1 :]
         # Strict parse of the head so typos in share's OWN flags still
-        # error; the denylist in share.cli then vets the passthrough.
+        # error; the denylist in share.cli then vets the passthrough. This is
+        # the single authoritative parse of share's own arguments.
         args = parser.parse_args(head_argv)
         args._passthrough = passthrough_argv
     else:

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -6588,40 +6588,49 @@ def _parse_args_with_share_passthrough(
 
         sep = raw_argv.index("--")
         head_argv, passthrough_argv = raw_argv[:sep], raw_argv[sep + 1 :]
-        # Strict probe: does the head fully resolve to a ``share`` command
-        # with a model? A STRICT ``parse_args`` (not ``parse_known_args``)
-        # means an incomplete head (``share`` alone, i.e. ``share -- MODEL``)
-        # or a typo'd share flag makes the probe exit with a NON-ZERO code — in
-        # which case this ``--`` is NOT a passthrough separator and we fall
-        # through to native parsing. stderr is muted so the probe's would-be
-        # usage error never reaches the user (the fall-through re-parses and
-        # either succeeds or emits the real error itself).
-        #
-        # A ZERO exit is different: the probe already ran a terminal argparse
-        # *action* — ``--help`` / ``--version`` printed to stdout and called
-        # ``parser.exit(0)``. Swallowing that would make the fall-through parse
-        # print the SAME message a second time, so re-raise instead: the text
-        # prints exactly once and the process exits cleanly.
-        probed = None
-        with contextlib.redirect_stderr(io.StringIO()):
-            try:
-                probed = parser.parse_args(head_argv)
-            except SystemExit as exc:
-                if exc.code not in (None, 0):
-                    probed = None
-                else:
-                    raise
-        if (
-            probed is not None
-            and getattr(probed, "command", None) == "share"
-            and getattr(probed, "model", None) is not None
-        ):
-            # Head is a complete share command; the tokens after ``--`` are
-            # verbatim serve-flag passthrough. ``probed`` already holds share's
-            # authoritative parsed args (model + share flags); the denylist in
-            # share.cli then vets the passthrough.
-            probed._passthrough = passthrough_argv
-            return probed
+        # Cheap gate before the probe: the passthrough split only ever applies
+        # to ``share``, and ``share`` must appear as a literal token in the head
+        # to be the command. If it doesn't (any other subcommand, or ``-- share
+        # MODEL`` where the head is empty), this ``--`` is argparse's native
+        # end-of-options marker — skip the probe so non-share invocations aren't
+        # parsed twice (which would run argparse type converters / custom
+        # actions a second time), and fall straight through to the single
+        # native parse below.
+        if "share" in head_argv:
+            # Strict probe: does the head fully resolve to a ``share`` command
+            # with a model? A STRICT ``parse_args`` (not ``parse_known_args``)
+            # means an incomplete head (``share`` alone, i.e. ``share -- MODEL``)
+            # or a typo'd share flag makes the probe exit with a NON-ZERO code —
+            # in which case this ``--`` is NOT a passthrough separator and we
+            # fall through to native parsing. stderr is muted so the probe's
+            # would-be usage error never reaches the user (the fall-through
+            # re-parses and either succeeds or emits the real error itself).
+            #
+            # A ZERO exit is different: the probe already ran a terminal argparse
+            # *action* — ``--help`` / ``--version`` printed to stdout and called
+            # ``parser.exit(0)``. Swallowing that would make the fall-through
+            # parse print the SAME message a second time, so re-raise instead:
+            # the text prints exactly once and the process exits cleanly.
+            probed = None
+            with contextlib.redirect_stderr(io.StringIO()):
+                try:
+                    probed = parser.parse_args(head_argv)
+                except SystemExit as exc:
+                    if exc.code not in (None, 0):
+                        probed = None
+                    else:
+                        raise
+            if (
+                probed is not None
+                and getattr(probed, "command", None) == "share"
+                and getattr(probed, "model", None) is not None
+            ):
+                # Head is a complete share command; the tokens after ``--`` are
+                # verbatim serve-flag passthrough. ``probed`` already holds
+                # share's authoritative parsed args (model + share flags); the
+                # denylist in share.cli then vets the passthrough.
+                probed._passthrough = passthrough_argv
+                return probed
 
     # Everything else — non-share commands, ``share`` with no passthrough
     # ``--``, and the ``share -- MODEL`` / ``-- share MODEL`` native forms —

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -6589,14 +6589,20 @@ def _parse_args_with_share_passthrough(
         sep = raw_argv.index("--")
         head_argv, passthrough_argv = raw_argv[:sep], raw_argv[sep + 1 :]
         # Cheap gate before the probe: the passthrough split only ever applies
-        # to ``share``, and ``share`` must appear as a literal token in the head
-        # to be the command. If it doesn't (any other subcommand, or ``-- share
-        # MODEL`` where the head is empty), this ``--`` is argparse's native
-        # end-of-options marker — skip the probe so non-share invocations aren't
-        # parsed twice (which would run argparse type converters / custom
-        # actions a second time), and fall straight through to the single
-        # native parse below.
-        if "share" in head_argv:
+        # to ``share``, so only probe when ``share`` is the SELECTED subcommand.
+        # The selected subcommand is the first non-option token in the head —
+        # the top-level parser's only pre-subcommand options (``--version`` /
+        # ``-V`` / ``-h`` / ``--no-telemetry``) are all valueless, so no earlier
+        # token can be an option *value* masquerading as the command. Checking
+        # the command token structurally (rather than ``"share" in head_argv``)
+        # excludes a positional value that merely equals "share" — e.g. a model
+        # named "share" after another subcommand (``serve share …``) — so NO
+        # non-share invocation is ever parsed twice (which would rerun argparse
+        # type converters / custom actions). A ``--`` before the command
+        # (``-- share MODEL``, empty head → ``cmd_token is None``) also skips the
+        # probe and keeps argparse's native end-of-options meaning.
+        cmd_token = next((t for t in head_argv if not t.startswith("-")), None)
+        if cmd_token == "share":
             # Strict probe: does the head fully resolve to a ``share`` command
             # with a model? A STRICT ``parse_args`` (not ``parse_known_args``)
             # means an incomplete head (``share`` alone, i.e. ``share -- MODEL``)

--- a/vllm_mlx/share/cli.py
+++ b/vllm_mlx/share/cli.py
@@ -530,6 +530,46 @@ def share_command(args: argparse.Namespace) -> None:
         extra_serve_args.append("--rate-limit")
         extra_serve_args.append(str(args.rate_limit))
 
+    # Systematic serve-flag passthrough. ``cli.main`` collects any flag
+    # ``share`` does not define itself (via ``parse_known_args``) into
+    # ``args._passthrough`` and we forward it verbatim to the spawned
+    # ``rapid-mlx serve``. This means every serve flag — ``--force-spec-decode``
+    # / ``--speculative-config`` (spec-decode is off by default; the user
+    # opts in by passing them), KV-cache tuning, sampling defaults, etc. —
+    # works over a share tunnel without share re-declaring each one.
+    #
+    # A denylist blocks flags share MUST own for its security / lifecycle
+    # model. ``--host`` is the load-bearing one: share pins 127.0.0.1 so the
+    # bearer-gated port is reachable only through the frp tunnel; a
+    # forwarded ``--host 0.0.0.0`` would re-expose it to the whole LAN. The
+    # rest (``--api-key`` bearer minting, ``--port`` / ``--listen-fd`` /
+    # ``--log-level`` process + binding control) are set by share itself;
+    # forwarding a duplicate would either leak the key or fight share's own
+    # value. Reject with a clear message instead of silently dropping.
+    passthrough = list(getattr(args, "_passthrough", None) or [])
+    if passthrough:
+        denied = {
+            "--host": (
+                "share always binds 127.0.0.1 so the bearer-gated port is "
+                "reachable only through the tunnel; --host would re-expose "
+                "it on your LAN"
+            ),
+            "--api-key": "share mints its own single-use bearer key",
+            "--port": "use `rapid-mlx share --port` instead",
+            "--listen-fd": "share owns the serve process lifecycle",
+            "--log-level": "share sets the serve log level",
+        }
+        for token in passthrough:
+            flag = token.split("=", 1)[0]
+            if flag in denied:
+                print(
+                    f"share: {flag} cannot be forwarded to serve — "
+                    f"{denied[flag]}.",
+                    file=sys.stderr,
+                )
+                sys.exit(2)
+        extra_serve_args.extend(passthrough)
+
     api_key = secrets.token_hex(24)
     # Port parsing is lazy on purpose: validating RAPID_MLX_SHARE_PORT at
     # parser-build time crashes ``rapid-mlx models`` (and every other

--- a/vllm_mlx/share/cli.py
+++ b/vllm_mlx/share/cli.py
@@ -579,8 +579,7 @@ def share_command(args: argparse.Namespace) -> None:
             )
             if hit is not None:
                 print(
-                    f"share: {flag} cannot be forwarded to serve — "
-                    f"{denied[hit]}.",
+                    f"share: {flag} cannot be forwarded to serve — {denied[hit]}.",
                     file=sys.stderr,
                 )
                 sys.exit(2)
@@ -843,7 +842,7 @@ def register(subparsers: argparse._SubParsersAction) -> None:
             "  off by default; opt in per share like this:\n"
             "\n"
             "    rapid-mlx share hy3-preview-4bit -- \\\n"
-            "        --force-spec-decode --speculative-config '{\"method\":\"mtp\"}'\n"
+            '        --force-spec-decode --speculative-config \'{"method":"mtp"}\'\n'
             "\n"
             "  (`--host` / `--api-key` / `--port` / `--listen-fd` /\n"
             "  `--log-level` are owned by share and rejected if forwarded.)"

--- a/vllm_mlx/share/cli.py
+++ b/vllm_mlx/share/cli.py
@@ -530,13 +530,16 @@ def share_command(args: argparse.Namespace) -> None:
         extra_serve_args.append("--rate-limit")
         extra_serve_args.append(str(args.rate_limit))
 
-    # Systematic serve-flag passthrough. ``cli.main`` collects any flag
-    # ``share`` does not define itself (via ``parse_known_args``) into
-    # ``args._passthrough`` and we forward it verbatim to the spawned
+    # Systematic serve-flag passthrough. ``cli.main`` splits the CLI on the
+    # standard ``--`` end-of-options separator and hands everything after it
+    # to us verbatim in ``args._passthrough``; we forward it to the spawned
     # ``rapid-mlx serve``. This means every serve flag — ``--force-spec-decode``
     # / ``--speculative-config`` (spec-decode is off by default; the user
     # opts in by passing them), KV-cache tuning, sampling defaults, etc. —
-    # works over a share tunnel without share re-declaring each one.
+    # works over a share tunnel without share re-declaring each one, and
+    # value-taking flags keep their arguments (``--`` is why the JSON of
+    # ``--speculative-config '{...}'`` is no longer swallowed by share's
+    # ``model`` positional).
     #
     # A denylist blocks flags share MUST own for its security / lifecycle
     # model. ``--host`` is the load-bearing one: share pins 127.0.0.1 so the
@@ -561,10 +564,23 @@ def share_command(args: argparse.Namespace) -> None:
         }
         for token in passthrough:
             flag = token.split("=", 1)[0]
-            if flag in denied:
+            # Match the canonical spelling AND any prefix of it. serve's
+            # parser keeps argparse's default ``allow_abbrev=True``, so an
+            # abbreviation like ``--hos`` / ``--hos=0.0.0.0`` resolves to
+            # ``--host`` on the child and would re-expose the port. Reject
+            # every unambiguous abbreviation of a denied flag, not just its
+            # full spelling, or the denylist is trivially bypassed. (Bare
+            # ``--`` — len 2 — is a literal separator, never an option.)
+            if not (flag.startswith("--") and len(flag) > 2):
+                continue
+            hit = next(
+                (d for d in denied if d == flag or d.startswith(flag)),
+                None,
+            )
+            if hit is not None:
                 print(
                     f"share: {flag} cannot be forwarded to serve — "
-                    f"{denied[flag]}.",
+                    f"{denied[hit]}.",
                     file=sys.stderr,
                 )
                 sys.exit(2)
@@ -817,6 +833,20 @@ def register(subparsers: argparse._SubParsersAction) -> None:
             "Start rapid-mlx serve and open a public Cloudflare-fronted "
             "URL on rapidmlx.com so you can use the model from a different "
             "device — or share it with a friend. Press Ctrl-C to stop."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=(
+            "serve-flag passthrough:\n"
+            "  Anything after a literal `--` is forwarded verbatim to the\n"
+            "  `rapid-mlx serve` that share spawns, so every serve flag works\n"
+            "  over the tunnel without share re-declaring it. Spec-decode is\n"
+            "  off by default; opt in per share like this:\n"
+            "\n"
+            "    rapid-mlx share hy3-preview-4bit -- \\\n"
+            "        --force-spec-decode --speculative-config '{\"method\":\"mtp\"}'\n"
+            "\n"
+            "  (`--host` / `--api-key` / `--port` / `--listen-fd` /\n"
+            "  `--log-level` are owned by share and rejected if forwarded.)"
         ),
     )
     p.add_argument(


### PR DESCRIPTION
## Why

`rapid-mlx share` only forwarded 3 of serve's 80+ flags (`--no-thinking`, `--cors-origins`, `--rate-limit`). A user sharing e.g. **HY3** could not turn on spec-decode over the tunnel — `--force-spec-decode` / `--speculative-config` were silently unavailable (share's argparse rejected them outright). And even when reachable, MTP defaulted to **K=1 chain-of-1**, which carries draft overhead with no net speedup.

## What

1. **Systematic passthrough via the `--` separator** — everything after a literal `--` on a `share` command line is forwarded verbatim to the spawned `serve` (the git / cargo / kubectl idiom):

   ```
   rapid-mlx share hy3-preview-4bit -- --force-spec-decode --speculative-config '{"method":"mtp"}'
   ```

   So every serve flag (spec-decode, KV-cache tuning, sampling defaults) works over a tunnel, current *and future*. The `--` is **required** — it removes all ambiguity between share's own flags and forwarded serve flags, and avoids the positional value-steal a bare `parse_known_args` would cause (e.g. a JSON config value being swallowed into share's `model`). Every **other** subcommand, and `share` without `--`, keeps argparse's strict rejection of unknown args, unchanged. The `share --help` epilog documents the form.

2. **Security denylist (prefix-aware)** — `--host` / `--api-key` / `--port` / `--listen-fd` / `--log-level` are rejected (exit 2) rather than forwarded, **including every unambiguous abbreviation** (`--hos`, `--ho`, `--api`, `--host=…`). share owns these; a forwarded `--host 0.0.0.0` would re-expose the bearer-gated port on the LAN, defeating the tunnel-only design. Spec-decode stays **OFF by default**; the user opts in by passing the flags after `--`.

3. **MTP K=3 default** — when the user opts into spec-decode via `--force-spec-decode` with `method=mtp` but doesn't pin `num_speculative_tokens`, default **K=3** instead of the no-speedup K=1. An explicit `num_speculative_tokens` always wins. `--mtp-max-k` and `--speculative-config` remain mutually exclusive (exit 2) — the K=3 default can never silently overwrite a user-pinned depth.

## Honest perf note

This PR is the **opt-in plumbing + safe defaults**, not a claim that MTP is a win everywhere. A clean same-machine A/B on `hy3-preview-4bit` (M3 Ultra, same weights / prompts / temp=0) measured **MTP-ON K=3 ≈ 31.2 tok/s vs MTP-OFF ≈ 33.1 tok/s — a ~6% regression** (HY3's ~52-74% draft accept can't overcome K=3 draft+verify overhead; same wall as the Gemma A3 K>1 investigation). That is exactly why spec-decode is **OFF by default** here — users opt in per share, and get a sane K=3 (not a strictly-worse K=1) when they do.

## Verification

- **185 targeted unit tests pass** across the share + speculative-config suites — passthrough forwards verbatim after `--`; native `-- MODEL` / `-- share MODEL` forms preserved; denylist rejects all abbreviations; `--help` / `--version` print exactly once through the probe; non-share `--` commands parse once (no double type-conversion); a `main()` integration test asserts the spawned serve argv carries the passthrough; K=3-under-force; explicit-K wins; `--mtp-max-k {0,1,5}` + `--speculative-config` all exit 2.
- **End-to-end pilot on real HY3** (155 GB, M3 Ultra): `rapid-mlx share hy3-preview-4bit -- --force-spec-decode --speculative-config '{"method":"mtp"}'` → serve engages MTP K=3 over the public tunnel; denylist rejects `-- --host 0.0.0.0` (exit 2, no model load); `rapid-mlx models --bogus-flag` still errors as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
