### PR TITLE
chore: bump version to 0.10.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.10.8"
+version = "0.10.9"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## Why

`main` has one merged fix (#1096) sitting unreleased since the 0.10.8 bump. This is the 0.10.9 fix-slot cut (odd cadence = fix) that fires `auto-release.yml` to publish it to PyPI + Homebrew + GitHub Release. Bumping the version is the only mechanism that ships accumulated fixes to naive `pip install rapid-mlx` users, so we cut it now rather than let the fix rot on main.

Refs #1096.

## Ships
- **#1096** `fix(share): systematic serve-flag passthrough via \`--\` + MTP K=3 default`
  - `rapid-mlx share <model> -- <serve flags>` — everything after a literal `--` is forwarded verbatim to the spawned `rapid-mlx serve` (git/cargo/kubectl end-of-options idiom), so every serve flag works over the tunnel without share re-declaring it.
  - Prefix-aware denylist: `--host` / `--api-key` / `--port` / `--listen-fd` / `--log-level` are owned by share and rejected if forwarded (prevents LAN re-exposure / key leak).
  - Spec-decode stays **off by default**, opt-in per share: `rapid-mlx share hy3-preview-4bit -- --force-spec-decode --speculative-config '{"method":"mtp"}'`.
  - Under `--force-spec-decode`, MTP defaults to **K=3** unless the user specifies `num_speculative_tokens`; `--mtp-max-k` and `--speculative-config` are mutually exclusive.

## HY3 default = MTP off (confirmed)
Clean same-machine A/B (temp=0, 3 prompts) shows HY3 native MTP is a ~6% regression (31.2 vs 33.1 tok/s) because accept rate 52–74% at K=3 can't overcome draft+verify overhead. HY3's alias ships MTP **off**; MTP is opt-in only. No code change needed here (already correct).

## Scope
- `pyproject.toml` version `0.10.8` → `0.10.9` only. Zero dep/install-size delta (G12).

## Dogfood (fresh venv, python3.12, pre-bump HEAD)
- `share --help` epilog documents the `-- <serve flags>` passthrough + denylist ✓
- `--help --` → exit 0, single usage print (no double help) ✓
- denylist: `--host` rejected with LAN warning; `-- --api-key leaked` → exit 2 ✓
- serve boot 1s, `/v1/models` correct, chat completion returns `pong` (finish=stop) ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)