### PR TITLE
fix(gemma4): explicit gemma4_unified routing, no more substring match

### DIFF
--- a/tests/test_gemma4_unified_routing.py
+++ b/tests/test_gemma4_unified_routing.py
@@ -2,25 +2,31 @@
 """Regression tests for explicit ``gemma4`` vs ``gemma4_unified`` routing.
 
 Issue #509: ``is_gemma4_model`` used a ``"gemma4" in model_type`` substring
-test that matched BOTH the non-unified ``gemma4`` arch (26B/31B/e2b/e4b)
-AND ``gemma4_unified`` (the 12B aliases) — plus any sibling like
-``gemma4_assistant`` (which already exists on the Hub) or a hypothetical
-``gemma4_videogen``. Both loaded through the non-unified mlx-vlm
-subpackage. It worked empirically (dataclass-identical ``TextConfig`` +
-shared ``LanguageModel``) but was misleading and fragile.
+test that matched the non-unified ``gemma4`` arch (26B/31B/e2b/e4b), the
+unified ``gemma4_unified`` arch (the 12B aliases), the ``gemma4_assistant``
+aliases, AND would catch any hypothetical future sibling like
+``gemma4_videogen`` or the inner sub-config's own ``gemma4_text`` label.
+Everything loaded through the non-unified mlx-vlm subpackage. It worked
+empirically (dataclass-identical ``TextConfig`` + shared ``LanguageModel``)
+but was misleading and fragile.
 
-These tests pin the corrected behavior:
-- ``is_gemma4_model`` matches ONLY exact ``model_type == "gemma4"``.
+These tests pin the corrected behavior — an exact-match allow-list, not a
+substring test:
+- ``is_gemma4_model`` matches the NON-unified arches
+  (``gemma4`` + ``gemma4_assistant``), the ones served by
+  ``load_gemma4_text``. NOT ``gemma4_unified``.
 - ``is_gemma4_unified_model`` matches ONLY exact ``"gemma4_unified"``.
-- ``is_gemma4_family_model`` is the OR of the two, and REJECTS
-  ``gemma4_assistant`` / ``gemma4_videogen`` (the substring-match trap).
+- ``is_gemma4_family_model`` is the OR of all three accepted outer types;
+  ``gemma4_assistant`` is ACCEPTED (kept on the non-unified path for
+  backward compat), while genuinely-unknown siblings (``gemma4_videogen``,
+  the inner ``gemma4_text``, etc.) are REJECTED — the substring-match trap.
+- ``gemma4_family_kind`` classifies with a single config read.
 - Each loader resolves to the matching mlx-vlm subpackage when installed,
   and falls back to the vendored copy when mlx-vlm is absent (the
   0.10.0 fresh-install regression that must never come back).
 
 The old substring implementation FAILS the ``gemma4_unified`` /
-``gemma4_assistant`` discrimination assertions; the fixed implementation
-PASSES.
+unknown-sibling discrimination assertions; the fixed implementation PASSES.
 """
 
 from __future__ import annotations
@@ -42,7 +48,7 @@ def _write_config(tmp_path: Path, model_type: str) -> Path:
     weight download or forward pass.
     """
     d = tmp_path / model_type
-    d.mkdir()
+    d.mkdir(exist_ok=True)
     (d / "config.json").write_text(json.dumps({"model_type": model_type}))
     return d
 
@@ -71,6 +77,21 @@ def test_gemma4_nonunified_detected_only_by_base_detector(tmp_path):
     assert gemma4_text.is_gemma4_unified_model(d) is False
     assert gemma4_text.is_gemma4_family_model(d) is True
     assert gemma4_text.gemma4_family_kind(d) == "nonunified"
+
+
+def test_is_gemma4_model_is_alias_of_nonunified(tmp_path):
+    """``is_gemma4_model`` is a back-compat alias for
+    ``is_gemma4_nonunified_model`` — same verdict for every model_type,
+    and (per #509) it no longer claims ``gemma4_unified``."""
+    for mt in ("gemma4", "gemma4_assistant", "gemma4_unified", "qwen3_moe"):
+        d = _write_config(tmp_path, mt)
+        assert gemma4_text.is_gemma4_model(d) is gemma4_text.is_gemma4_nonunified_model(
+            d
+        )
+    # Spot-check the narrowed semantics explicitly: no longer unified.
+    assert (
+        gemma4_text.is_gemma4_model(_write_config(tmp_path, "gemma4_unified")) is False
+    )
 
 
 def test_gemma4_assistant_routes_to_nonunified(tmp_path):

--- a/tests/test_gemma4_unified_routing.py
+++ b/tests/test_gemma4_unified_routing.py
@@ -60,6 +60,7 @@ def test_gemma4_unified_detected_only_by_unified_detector(tmp_path):
     assert gemma4_text.is_gemma4_unified_model(d) is True
     assert gemma4_text.is_gemma4_model(d) is False
     assert gemma4_text.is_gemma4_family_model(d) is True
+    assert gemma4_text.gemma4_family_kind(d) == "unified"
 
 
 def test_gemma4_nonunified_detected_only_by_base_detector(tmp_path):
@@ -69,20 +70,36 @@ def test_gemma4_nonunified_detected_only_by_base_detector(tmp_path):
     assert gemma4_text.is_gemma4_model(d) is True
     assert gemma4_text.is_gemma4_unified_model(d) is False
     assert gemma4_text.is_gemma4_family_model(d) is True
+    assert gemma4_text.gemma4_family_kind(d) == "nonunified"
 
 
-@pytest.mark.parametrize("mt", ["gemma4_assistant", "gemma4_videogen", "gemma4_text"])
-def test_gemma4_siblings_not_misrouted(tmp_path, mt):
-    """Sibling model_types that the old ``"gemma4" in model_type`` substring
-    match would have swallowed must NOT be claimed by any Gemma 4 text
-    detector. ``gemma4_assistant`` already exists on the Hub
-    (mlx-community/gemma-4-31B-it-assistant); routing it (or a future
-    ``gemma4_videogen``) through the text loader would be a silent
-    misroute. This assertion fails against the old substring impl."""
+def test_gemma4_assistant_routes_to_nonunified(tmp_path):
+    """``gemma4_assistant`` (the ``gemma-4-*-assistant`` aliases) is a
+    first-class NON-unified member: the old substring match sent it down
+    the ``gemma4`` text fallback and its nested ``text_config`` is a
+    ``gemma4_text`` shape, so we keep it on that path to avoid regressing
+    those aliases. It must be claimed by ``is_gemma4_model`` +
+    ``is_gemma4_family_model`` but NOT by the unified detector."""
+    d = _write_config(tmp_path, "gemma4_assistant")
+    assert gemma4_text.is_gemma4_model(d) is True
+    assert gemma4_text.is_gemma4_unified_model(d) is False
+    assert gemma4_text.is_gemma4_family_model(d) is True
+    assert gemma4_text.gemma4_family_kind(d) == "nonunified"
+
+
+@pytest.mark.parametrize("mt", ["gemma4_videogen", "gemma4_text", "gemma4_foo"])
+def test_gemma4_unknown_siblings_not_misrouted(tmp_path, mt):
+    """Unknown sibling model_types that the old ``"gemma4" in model_type``
+    substring match would have swallowed must NOT be claimed by any Gemma
+    4 text detector. A hypothetical future ``gemma4_videogen`` (or the
+    inner sub-config's own ``gemma4_text`` label) routed through the text
+    loader would be a silent misroute. These assertions fail against the
+    old substring impl."""
     d = _write_config(tmp_path, mt)
     assert gemma4_text.is_gemma4_model(d) is False
     assert gemma4_text.is_gemma4_unified_model(d) is False
     assert gemma4_text.is_gemma4_family_model(d) is False
+    assert gemma4_text.gemma4_family_kind(d) is None
 
 
 def test_non_gemma_model_rejected(tmp_path):
@@ -233,6 +250,7 @@ def test_unified_loader_reaches_weight_check_without_mlx_vlm(tmp_path, monkeypat
     [
         ("gemma4_unified", "load_gemma4_unified_text", "load_gemma4_text"),
         ("gemma4", "load_gemma4_text", "load_gemma4_unified_text"),
+        ("gemma4_assistant", "load_gemma4_text", "load_gemma4_unified_text"),
     ],
 )
 def test_dispatch_routes_to_matching_loader(
@@ -240,7 +258,7 @@ def test_dispatch_routes_to_matching_loader(
 ):
     """``_load_model_with_fallback_impl`` (the tokenizer dispatch) must send
     ``gemma4_unified`` to ``load_gemma4_unified_text`` and non-unified
-    ``gemma4`` to ``load_gemma4_text``.
+    ``gemma4`` / ``gemma4_assistant`` to ``load_gemma4_text``.
 
     We force the "native mlx-lm load failed" branch (so the explicit
     loaders run) by making ``mlx_lm.load`` raise, and stub both loaders to
@@ -280,3 +298,40 @@ def test_dispatch_routes_to_matching_loader(
     assert called.get("loader") == expected_loader, (
         f"{model_type} should route to {expected_loader}, got {called.get('loader')}"
     )
+
+
+# --------------------------------------------------------------------------
+# Wrapper reports the routed arch, not the generic inner "gemma4_text"
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "routed,inner,expected",
+    [
+        # Shared text stack reports the generic inner label → normalize to
+        # the routed arch (the real bug codex flagged: default never used).
+        ("gemma4_unified", "gemma4_text", "gemma4_unified"),
+        ("gemma4", "gemma4_text", "gemma4"),
+        ("gemma4_assistant", "gemma4_text", "gemma4_assistant"),
+        # A more-specific inner label (if a future model reports one) wins.
+        ("gemma4", "gemma4_special", "gemma4_special"),
+        # Missing inner attribute → routed arch.
+        ("gemma4_unified", None, "gemma4_unified"),
+    ],
+)
+def test_wrapper_reports_routed_model_type(routed, inner, expected):
+    """``Gemma4TextWrapper.model_type`` must reflect the arch the caller
+    routed for. Before the fix, ``getattr(lm, "model_type", default)``
+    always returned the wrapped stack's generic ``"gemma4_text"`` and the
+    routed default was dead code, so a unified wrapper reported the wrong
+    arch."""
+
+    class _FakeLM:
+        def __init__(self):
+            self.config = object()
+            self.model = object()
+            if inner is not None:
+                self.model_type = inner
+
+    wrapper = gemma4_text.Gemma4TextWrapper(_FakeLM(), routed_model_type=routed)
+    assert wrapper.model_type == expected

--- a/tests/test_gemma4_unified_routing.py
+++ b/tests/test_gemma4_unified_routing.py
@@ -12,7 +12,7 @@ but was misleading and fragile.
 
 These tests pin the corrected behavior — an exact-match allow-list, not a
 substring test:
-- ``is_gemma4_model`` matches the NON-unified arches
+- ``is_gemma4_nonunified_model`` matches the NON-unified arches
   (``gemma4`` + ``gemma4_assistant``), the ones served by
   ``load_gemma4_text``. NOT ``gemma4_unified``.
 - ``is_gemma4_unified_model`` matches ONLY exact ``"gemma4_unified"``.
@@ -20,6 +20,10 @@ substring test:
   ``gemma4_assistant`` is ACCEPTED (kept on the non-unified path for
   backward compat), while genuinely-unknown siblings (``gemma4_videogen``,
   the inner ``gemma4_text``, etc.) are REJECTED — the substring-match trap.
+- ``is_gemma4_model`` is the family-wide back-compat alias — it delegates
+  to ``is_gemma4_family_model``, preserving the broad meaning the name
+  carried pre-#509 (True for all three) while no longer swallowing a
+  non-family arch that merely contains the text ``"gemma4"``.
 - ``gemma4_family_kind`` classifies with a single config read.
 - Each loader resolves to the matching mlx-vlm subpackage when installed,
   and falls back to the vendored copy when mlx-vlm is absent (the

--- a/tests/test_gemma4_unified_routing.py
+++ b/tests/test_gemma4_unified_routing.py
@@ -261,18 +261,30 @@ def test_dispatch_routes_to_matching_loader(
     ``gemma4`` / ``gemma4_assistant`` to ``load_gemma4_text``.
 
     We force the "native mlx-lm load failed" branch (so the explicit
-    loaders run) by making ``mlx_lm.load`` raise, and stub both loaders to
-    record which one fired. This exercises the real routing decision in
-    ``vllm_mlx/utils/tokenizer.py`` without any weight download.
+    loaders run) by making the ``load`` symbol the dispatch calls raise,
+    and stub both loaders to record which one fired. This exercises the
+    real routing decision in ``vllm_mlx/utils/tokenizer.py`` without any
+    weight download.
+
+    ``_load_model_with_fallback_impl`` rebinds ``load`` locally via
+    ``from mlx_lm import load`` on every call, so patching ``mlx_lm.load``
+    is what the dispatch actually resolves — but we assert the forced
+    exception fired (``native_load_raised``) so the test can never pass by
+    coincidence via a native load that happened to succeed or a different
+    rejection path.
     """
     from vllm_mlx.utils import tokenizer as tok
 
     d = _write_config(tmp_path, model_type)
 
-    # Force the native-load path to fail so the fallback branch runs.
-    def _boom(*a, **k):
+    native_load_calls: list[str] = []
+
+    def _boom(model_name, *a, **k):
+        native_load_calls.append(model_name)
         raise RuntimeError("native load unavailable (forced for test)")
 
+    # The dispatch does ``from mlx_lm import load`` at call time, so the
+    # authoritative binding to patch is ``mlx_lm.load``.
     monkeypatch.setattr("mlx_lm.load", _boom)
     # Neutralize side-effects the dispatch may attempt before the gemma gate.
     monkeypatch.setattr(tok, "_needs_tokenizer_fallback", lambda *_: False)
@@ -294,6 +306,13 @@ def test_dispatch_routes_to_matching_loader(
 
     result = tok._load_model_with_fallback_impl(str(d), {})
 
+    # The forced native-load failure must actually have fired — otherwise
+    # the routing assertion below could pass via a native path we didn't
+    # intend to test.
+    assert native_load_calls, (
+        "native mlx_lm.load was never called — the dispatch didn't reach "
+        "the gemma4 fallback branch, so this test isn't exercising routing"
+    )
     assert result == ("MODEL", "TOKENIZER")
     assert called.get("loader") == expected_loader, (
         f"{model_type} should route to {expected_loader}, got {called.get('loader')}"

--- a/tests/test_gemma4_unified_routing.py
+++ b/tests/test_gemma4_unified_routing.py
@@ -60,37 +60,40 @@ def _write_config(tmp_path: Path, model_type: str) -> Path:
 
 def test_gemma4_unified_detected_only_by_unified_detector(tmp_path):
     """A ``gemma4_unified`` model (the gemma-4-12b aliases) is detected by
-    ``is_gemma4_unified_model`` and NOT by the corrected
-    ``is_gemma4_model``."""
+    ``is_gemma4_unified_model`` and NOT by the NARROWED
+    ``is_gemma4_nonunified_model``. The family-wide back-compat
+    ``is_gemma4_model`` still claims it."""
     d = _write_config(tmp_path, "gemma4_unified")
     assert gemma4_text.is_gemma4_unified_model(d) is True
-    assert gemma4_text.is_gemma4_model(d) is False
+    assert gemma4_text.is_gemma4_nonunified_model(d) is False
     assert gemma4_text.is_gemma4_family_model(d) is True
+    assert gemma4_text.is_gemma4_model(d) is True  # family-wide alias
     assert gemma4_text.gemma4_family_kind(d) == "unified"
 
 
 def test_gemma4_nonunified_detected_only_by_base_detector(tmp_path):
     """A non-unified ``gemma4`` model (gemma-4-31b etc.) is detected by
-    ``is_gemma4_model`` and NOT by ``is_gemma4_unified_model``."""
+    ``is_gemma4_nonunified_model`` and NOT by ``is_gemma4_unified_model``."""
     d = _write_config(tmp_path, "gemma4")
-    assert gemma4_text.is_gemma4_model(d) is True
+    assert gemma4_text.is_gemma4_nonunified_model(d) is True
     assert gemma4_text.is_gemma4_unified_model(d) is False
     assert gemma4_text.is_gemma4_family_model(d) is True
+    assert gemma4_text.is_gemma4_model(d) is True
     assert gemma4_text.gemma4_family_kind(d) == "nonunified"
 
 
-def test_is_gemma4_model_is_alias_of_nonunified(tmp_path):
-    """``is_gemma4_model`` is a back-compat alias for
-    ``is_gemma4_nonunified_model`` — same verdict for every model_type,
-    and (per #509) it no longer claims ``gemma4_unified``."""
+def test_is_gemma4_model_is_family_wide_alias(tmp_path):
+    """``is_gemma4_model`` is the back-compat family-wide predicate: it
+    tracks ``is_gemma4_family_model`` for every model_type (True for
+    gemma4 / gemma4_unified / gemma4_assistant, False otherwise) and,
+    unlike the old substring test, does NOT claim a non-family arch that
+    merely contains the text ``"gemma4"``."""
     for mt in ("gemma4", "gemma4_assistant", "gemma4_unified", "qwen3_moe"):
         d = _write_config(tmp_path, mt)
-        assert gemma4_text.is_gemma4_model(d) is gemma4_text.is_gemma4_nonunified_model(
-            d
-        )
-    # Spot-check the narrowed semantics explicitly: no longer unified.
-    assert (
-        gemma4_text.is_gemma4_model(_write_config(tmp_path, "gemma4_unified")) is False
+        assert gemma4_text.is_gemma4_model(d) is gemma4_text.is_gemma4_family_model(d)
+    # The #509 fix: a hypothetical sibling is no longer swallowed.
+    assert gemma4_text.is_gemma4_model(_write_config(tmp_path, "gemma4_videogen")) is (
+        False
     )
 
 

--- a/tests/test_gemma4_unified_routing.py
+++ b/tests/test_gemma4_unified_routing.py
@@ -1,0 +1,282 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for explicit ``gemma4`` vs ``gemma4_unified`` routing.
+
+Issue #509: ``is_gemma4_model`` used a ``"gemma4" in model_type`` substring
+test that matched BOTH the non-unified ``gemma4`` arch (26B/31B/e2b/e4b)
+AND ``gemma4_unified`` (the 12B aliases) — plus any sibling like
+``gemma4_assistant`` (which already exists on the Hub) or a hypothetical
+``gemma4_videogen``. Both loaded through the non-unified mlx-vlm
+subpackage. It worked empirically (dataclass-identical ``TextConfig`` +
+shared ``LanguageModel``) but was misleading and fragile.
+
+These tests pin the corrected behavior:
+- ``is_gemma4_model`` matches ONLY exact ``model_type == "gemma4"``.
+- ``is_gemma4_unified_model`` matches ONLY exact ``"gemma4_unified"``.
+- ``is_gemma4_family_model`` is the OR of the two, and REJECTS
+  ``gemma4_assistant`` / ``gemma4_videogen`` (the substring-match trap).
+- Each loader resolves to the matching mlx-vlm subpackage when installed,
+  and falls back to the vendored copy when mlx-vlm is absent (the
+  0.10.0 fresh-install regression that must never come back).
+
+The old substring implementation FAILS the ``gemma4_unified`` /
+``gemma4_assistant`` discrimination assertions; the fixed implementation
+PASSES.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+from vllm_mlx.models import gemma4_text
+
+
+def _write_config(tmp_path: Path, model_type: str) -> Path:
+    """Write a minimal local model dir carrying only ``model_type``.
+
+    The detectors read the TOP-LEVEL ``model_type`` from config.json, so a
+    one-key config is enough to exercise the routing decision without any
+    weight download or forward pass.
+    """
+    d = tmp_path / model_type
+    d.mkdir()
+    (d / "config.json").write_text(json.dumps({"model_type": model_type}))
+    return d
+
+
+# --------------------------------------------------------------------------
+# Detection: exact-match, no substring bleed
+# --------------------------------------------------------------------------
+
+
+def test_gemma4_unified_detected_only_by_unified_detector(tmp_path):
+    """A ``gemma4_unified`` model (the gemma-4-12b aliases) is detected by
+    ``is_gemma4_unified_model`` and NOT by the corrected
+    ``is_gemma4_model``."""
+    d = _write_config(tmp_path, "gemma4_unified")
+    assert gemma4_text.is_gemma4_unified_model(d) is True
+    assert gemma4_text.is_gemma4_model(d) is False
+    assert gemma4_text.is_gemma4_family_model(d) is True
+
+
+def test_gemma4_nonunified_detected_only_by_base_detector(tmp_path):
+    """A non-unified ``gemma4`` model (gemma-4-31b etc.) is detected by
+    ``is_gemma4_model`` and NOT by ``is_gemma4_unified_model``."""
+    d = _write_config(tmp_path, "gemma4")
+    assert gemma4_text.is_gemma4_model(d) is True
+    assert gemma4_text.is_gemma4_unified_model(d) is False
+    assert gemma4_text.is_gemma4_family_model(d) is True
+
+
+@pytest.mark.parametrize("mt", ["gemma4_assistant", "gemma4_videogen", "gemma4_text"])
+def test_gemma4_siblings_not_misrouted(tmp_path, mt):
+    """Sibling model_types that the old ``"gemma4" in model_type`` substring
+    match would have swallowed must NOT be claimed by any Gemma 4 text
+    detector. ``gemma4_assistant`` already exists on the Hub
+    (mlx-community/gemma-4-31B-it-assistant); routing it (or a future
+    ``gemma4_videogen``) through the text loader would be a silent
+    misroute. This assertion fails against the old substring impl."""
+    d = _write_config(tmp_path, mt)
+    assert gemma4_text.is_gemma4_model(d) is False
+    assert gemma4_text.is_gemma4_unified_model(d) is False
+    assert gemma4_text.is_gemma4_family_model(d) is False
+
+
+def test_non_gemma_model_rejected(tmp_path):
+    """A completely unrelated arch is rejected by all detectors."""
+    d = _write_config(tmp_path, "qwen3_moe")
+    assert gemma4_text.is_gemma4_model(d) is False
+    assert gemma4_text.is_gemma4_unified_model(d) is False
+    assert gemma4_text.is_gemma4_family_model(d) is False
+
+
+def test_unreadable_config_is_not_gemma(tmp_path):
+    """A directory with no config.json (and not a resolvable repo id)
+    yields ``None`` model_type → not Gemma 4."""
+    d = tmp_path / "empty"
+    d.mkdir()
+    assert gemma4_text.is_gemma4_model(d) is False
+    assert gemma4_text.is_gemma4_unified_model(d) is False
+    assert gemma4_text.is_gemma4_family_model(d) is False
+
+
+# --------------------------------------------------------------------------
+# Loader class resolution: pin to the matching subpackage
+# --------------------------------------------------------------------------
+
+
+def test_nonunified_resolves_to_gemma4_subpackage():
+    """``load_gemma4_text`` resolves TextConfig + LanguageModel from the
+    non-unified ``mlx_vlm.models.gemma4`` subpackage when mlx-vlm is
+    installed."""
+    pytest.importorskip("mlx_vlm.models.gemma4")
+    tc, lm = gemma4_text._resolve_gemma4_text_classes()
+    assert tc.__module__ == "mlx_vlm.models.gemma4.config"
+    assert lm.__module__ == "mlx_vlm.models.gemma4.language"
+
+
+def test_unified_resolves_to_gemma4_unified_subpackage():
+    """``load_gemma4_unified_text`` resolves TextConfig from the
+    ``mlx_vlm.models.gemma4_unified`` subpackage (the matching one) when
+    mlx-vlm is installed.
+
+    Note: upstream deliberately re-exports the SAME ``LanguageModel`` from
+    ``gemma4.language`` inside ``gemma4_unified`` (the unified arch only
+    wraps vision/audio embedders around the identical text stack), so we
+    only assert the CONFIG module pin here — that's the drift-surfacing
+    signal. The LanguageModel object identity is asserted separately."""
+    pytest.importorskip("mlx_vlm.models.gemma4_unified")
+    tc, lm = gemma4_text._resolve_gemma4_unified_text_classes()
+    assert tc.__module__ == "mlx_vlm.models.gemma4_unified.config"
+
+
+def test_unified_and_base_share_language_model_class():
+    """Sanity: upstream's ``gemma4_unified`` LanguageModel IS the
+    ``gemma4`` one (re-export). This is WHY serving gemma-4-12b through
+    the non-unified classes worked empirically before this fix — and why
+    the vendored fallback (which has no unified variant) is correct."""
+    pytest.importorskip("mlx_vlm.models.gemma4_unified")
+    _, lm_base = gemma4_text._resolve_gemma4_text_classes()
+    _, lm_unified = gemma4_text._resolve_gemma4_unified_text_classes()
+    assert lm_base is lm_unified
+
+
+# --------------------------------------------------------------------------
+# Fresh-install (no mlx-vlm) anti-regression: vendored fallback
+# --------------------------------------------------------------------------
+
+
+def _block_mlx_vlm(monkeypatch):
+    """Make every ``import mlx_vlm*`` raise ImportError, simulating a fresh
+    ``pip install rapid-mlx`` without the ``[vision]`` extra."""
+    for mod_name in list(sys.modules):
+        if mod_name == "mlx_vlm" or mod_name.startswith("mlx_vlm."):
+            monkeypatch.delitem(sys.modules, mod_name, raising=False)
+
+    real_import = (
+        __builtins__["__import__"]
+        if isinstance(__builtins__, dict)
+        else __builtins__.__import__
+    )
+
+    def blocking_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "mlx_vlm" or name.startswith("mlx_vlm."):
+            raise ImportError(f"No module named {name!r}")
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr("builtins.__import__", blocking_import)
+
+
+def test_unified_resolver_falls_back_to_vendored_without_mlx_vlm(monkeypatch):
+    """The #1 anti-regression: the unified loader must resolve to the
+    VENDORED text classes when mlx-vlm is absent, NOT raise ImportError.
+    Breaking this reintroduces the 0.10.0 fresh-install regression where
+    ``rapid-mlx serve gemma-4-12b`` died on a missing mlx-vlm."""
+    _block_mlx_vlm(monkeypatch)
+    tc, lm = gemma4_text._resolve_gemma4_unified_text_classes()
+    assert tc.__module__ == "vllm_mlx.models.gemma4_vendored.config"
+    assert lm.__module__ == "vllm_mlx.models.gemma4_vendored.language"
+
+
+def test_base_resolver_falls_back_to_vendored_without_mlx_vlm(monkeypatch):
+    """Non-unified loader also falls back to vendored classes without
+    mlx-vlm (existing 0.10.1 contract, re-pinned)."""
+    _block_mlx_vlm(monkeypatch)
+    tc, lm = gemma4_text._resolve_gemma4_text_classes()
+    assert tc.__module__ == "vllm_mlx.models.gemma4_vendored.config"
+    assert lm.__module__ == "vllm_mlx.models.gemma4_vendored.language"
+
+
+def test_unified_loader_reaches_weight_check_without_mlx_vlm(tmp_path, monkeypatch):
+    """End-to-end-ish: with mlx-vlm blocked, ``load_gemma4_unified_text``
+    gets past class construction (via the vendored fallback) and reaches
+    the ``No .safetensors files`` check — proving the vendored path is
+    actually exercised, mirroring ``test_gemma4_text_import_guard`` for
+    the unified loader."""
+    cfg = {
+        "model_type": "gemma4_unified",
+        "text_config": {
+            "hidden_size": 16,
+            "num_hidden_layers": 2,
+            "intermediate_size": 32,
+            "num_attention_heads": 2,
+            "num_key_value_heads": 1,
+            "head_dim": 8,
+            "global_head_dim": 8,
+            "vocab_size": 32,
+            "vocab_size_per_layer_input": 32,
+            "hidden_size_per_layer_input": 0,
+            "num_kv_shared_layers": 0,
+            "sliding_window_pattern": 2,
+            "layer_types": ["sliding_attention", "full_attention"],
+            "use_double_wide_mlp": False,
+        },
+    }
+    (tmp_path / "config.json").write_text(json.dumps(cfg))
+
+    _block_mlx_vlm(monkeypatch)
+
+    with pytest.raises(FileNotFoundError, match="No .safetensors files"):
+        gemma4_text.load_gemma4_unified_text(tmp_path, None)
+
+
+# --------------------------------------------------------------------------
+# Dispatch wiring: tokenizer.py routes each arch to the matching loader
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "model_type,expected_loader,other_loader",
+    [
+        ("gemma4_unified", "load_gemma4_unified_text", "load_gemma4_text"),
+        ("gemma4", "load_gemma4_text", "load_gemma4_unified_text"),
+    ],
+)
+def test_dispatch_routes_to_matching_loader(
+    tmp_path, monkeypatch, model_type, expected_loader, other_loader
+):
+    """``_load_model_with_fallback_impl`` (the tokenizer dispatch) must send
+    ``gemma4_unified`` to ``load_gemma4_unified_text`` and non-unified
+    ``gemma4`` to ``load_gemma4_text``.
+
+    We force the "native mlx-lm load failed" branch (so the explicit
+    loaders run) by making ``mlx_lm.load`` raise, and stub both loaders to
+    record which one fired. This exercises the real routing decision in
+    ``vllm_mlx/utils/tokenizer.py`` without any weight download.
+    """
+    from vllm_mlx.utils import tokenizer as tok
+
+    d = _write_config(tmp_path, model_type)
+
+    # Force the native-load path to fail so the fallback branch runs.
+    def _boom(*a, **k):
+        raise RuntimeError("native load unavailable (forced for test)")
+
+    monkeypatch.setattr("mlx_lm.load", _boom)
+    # Neutralize side-effects the dispatch may attempt before the gemma gate.
+    monkeypatch.setattr(tok, "_needs_tokenizer_fallback", lambda *_: False)
+    monkeypatch.setattr(tok, "_is_vendored_arch_model", lambda *_: False)
+    monkeypatch.setattr(tok, "_register_vendored_archs", lambda *_: None)
+
+    called: dict[str, object] = {}
+
+    def make_stub(name):
+        def _stub(model_name, tokenizer_config=None):
+            called["loader"] = name
+            called["model_name"] = model_name
+            return ("MODEL", "TOKENIZER")
+
+        return _stub
+
+    monkeypatch.setattr(gemma4_text, expected_loader, make_stub(expected_loader))
+    monkeypatch.setattr(gemma4_text, other_loader, make_stub(other_loader))
+
+    result = tok._load_model_with_fallback_impl(str(d), {})
+
+    assert result == ("MODEL", "TOKENIZER")
+    assert called.get("loader") == expected_loader, (
+        f"{model_type} should route to {expected_loader}, got {called.get('loader')}"
+    )

--- a/vllm_mlx/models/gemma4_text.py
+++ b/vllm_mlx/models/gemma4_text.py
@@ -210,10 +210,12 @@ def is_gemma4_nonunified_model(model_path: str | Path) -> bool:
 
     Matches ``gemma4`` and ``gemma4_assistant`` — the arches served by
     :func:`load_gemma4_text`. This is the explicitly-named narrowed
-    predicate; :func:`is_gemma4_model` is a back-compat alias for it.
-    Callers that want "any Gemma 4 text-servable arch" should use
-    :func:`is_gemma4_family_model`; callers that specifically want the
-    unified arch should use :func:`is_gemma4_unified_model`.
+    predicate (the complement of :func:`is_gemma4_unified_model` within
+    the family). Callers that want "any Gemma 4 text-servable arch"
+    should use :func:`is_gemma4_family_model` (which the family-wide
+    back-compat alias :func:`is_gemma4_model` delegates to); callers that
+    specifically want the unified arch should use
+    :func:`is_gemma4_unified_model`.
     """
     return _read_model_type(model_path) in _GEMMA4_NONUNIFIED_MODEL_TYPES
 

--- a/vllm_mlx/models/gemma4_text.py
+++ b/vllm_mlx/models/gemma4_text.py
@@ -17,8 +17,10 @@ the old ``"gemma4" in model_type`` substring test would silently
 misroute a hypothetical ``gemma4_videogen`` or the inner sub-config's
 own ``gemma4_text`` label):
 
-- ``gemma4``           → :func:`is_gemma4_model` / :func:`load_gemma4_text`
-- ``gemma4_assistant`` → :func:`is_gemma4_model` / :func:`load_gemma4_text`
+- ``gemma4``           → :func:`is_gemma4_nonunified_model` /
+                         :func:`load_gemma4_text`
+- ``gemma4_assistant`` → :func:`is_gemma4_nonunified_model` /
+                         :func:`load_gemma4_text`
                          (the ``gemma-4-*-assistant`` aliases; its nested
                          ``text_config`` is a ``gemma4_text`` shape, so it
                          rides the same non-unified loader the old
@@ -29,10 +31,13 @@ own ``gemma4_text`` label):
 
 :func:`is_gemma4_family_model` is the OR of all three for call sites that
 just need "is this a Gemma 4 text-servable arch?"; :func:`gemma4_family_kind`
-classifies with a single config read for dispatch sites. Both loaders
-prefer the matching upstream ``mlx_vlm`` subpackage when installed and
-fall back to the vendored copy under ``vllm_mlx/models/gemma4_vendored/``
-so a fresh ``pip install rapid-mlx`` (no ``[vision]`` extra) still boots.
+classifies with a single config read for dispatch sites.
+:func:`is_gemma4_model` is a family-wide back-compat alias for
+:func:`is_gemma4_family_model` (NOT the narrow non-unified router — new
+code should use the precise predicates above). Both loaders prefer the
+matching upstream ``mlx_vlm`` subpackage when installed and fall back to
+the vendored copy under ``vllm_mlx/models/gemma4_vendored/`` so a fresh
+``pip install rapid-mlx`` (no ``[vision]`` extra) still boots.
 
 The wrapper is thin: it just ensures model(input_ids, cache=cache) returns
 a raw logits tensor instead of LanguageModelOutput.

--- a/vllm_mlx/models/gemma4_text.py
+++ b/vllm_mlx/models/gemma4_text.py
@@ -219,25 +219,23 @@ def is_gemma4_nonunified_model(model_path: str | Path) -> bool:
 
 
 def is_gemma4_model(model_path: str | Path) -> bool:
-    """Back-compat alias for :func:`is_gemma4_nonunified_model`.
+    """Back-compat alias: is this ANY Gemma 4 text-servable arch?
 
-    Pre-#509 this did ``"gemma4" in model_type``, so it returned True for
-    the base ``gemma4`` arch AND (by substring) ``gemma4_unified`` /
-    ``gemma4_assistant`` / a hypothetical ``gemma4_videogen``. That worked
-    only because ``gemma4`` and ``gemma4_unified`` ship dataclass-identical
-    ``TextConfig`` shapes and reuse the same ``LanguageModel`` class — but
-    conflating them was misleading and fragile.
+    Pre-#509 this did ``"gemma4" in model_type``, returning True for the
+    base ``gemma4`` arch AND (by substring) ``gemma4_unified`` /
+    ``gemma4_assistant``. To keep that documented family-wide meaning for
+    any existing caller of this name, it now delegates to
+    :func:`is_gemma4_family_model` (the exact-match allow-list) rather
+    than the old substring test. The only behavioral difference vs the
+    substring version is that a NON-family arch that merely contains the
+    text ``"gemma4"`` (a hypothetical ``gemma4_videogen``) is no longer
+    falsely claimed — which is the whole point of #509.
 
-    The name is kept (the only in-tree callers are this module's own tests
-    — it is not exported and had a single production caller, now migrated
-    to :func:`gemma4_family_kind`), but its meaning is now the exact
-    NON-unified set. ``gemma4_unified`` split out to its own
-    detector/loader; ``gemma4_assistant`` stays on the non-unified path
-    (its nested ``text_config`` is a ``gemma4_text`` shape). Prefer
-    :func:`is_gemma4_nonunified_model` (explicit) or
-    :func:`is_gemma4_family_model` (family-wide) in new code. See #509.
+    New code should call the precise predicate for its intent:
+    :func:`is_gemma4_unified_model`, :func:`is_gemma4_nonunified_model`,
+    or :func:`gemma4_family_kind` (single-read classification).
     """
-    return is_gemma4_nonunified_model(model_path)
+    return is_gemma4_family_model(model_path)
 
 
 def is_gemma4_unified_model(model_path: str | Path) -> bool:

--- a/vllm_mlx/models/gemma4_text.py
+++ b/vllm_mlx/models/gemma4_text.py
@@ -154,50 +154,67 @@ def _read_model_type(model_path: str | Path) -> str | None:
         return None
 
 
+# Model_types the Gemma 4 text loader path claims. This is a deliberate
+# exact-match allow-list, NOT a ``"gemma4" in model_type`` substring test
+# (see #509). The substring check also matched a hypothetical future
+# ``gemma4_videogen`` (or ``gemma4_text`` — the inner text sub-config's
+# own model_type) and would silently misroute it. Each member here maps
+# to a concrete loader in :func:`_gemma4_loader_for`; adding a new
+# supported arch is a one-line edit plus a loader branch, which is the
+# point — routing is explicit and unknown arches surface loudly instead
+# of silently riding the text path.
+#
+# - ``gemma4``           : non-unified text arch (26B/31B/e2b/e4b,
+#                          ``Gemma4ForConditionalGeneration``).
+# - ``gemma4_unified``   : unified arch (the four ``gemma-4-12b-*``
+#                          aliases, ``Gemma4UnifiedForConditionalGeneration``).
+# - ``gemma4_assistant`` : the ``gemma-4-*-assistant`` aliases
+#                          (``Gemma4AssistantForCausalLM``). Its nested
+#                          ``text_config`` is a ``gemma4_text`` shape, so
+#                          it loads through the SAME non-unified path the
+#                          old substring match sent it down. Kept in the
+#                          allow-list to preserve that pre-#509 behavior
+#                          (dropping it would regress those aliases to the
+#                          unsupported native-load path).
+_GEMMA4_NONUNIFIED_MODEL_TYPES = ("gemma4", "gemma4_assistant")
+_GEMMA4_UNIFIED_MODEL_TYPES = ("gemma4_unified",)
+_GEMMA4_FAMILY_MODEL_TYPES = (
+    _GEMMA4_NONUNIFIED_MODEL_TYPES + _GEMMA4_UNIFIED_MODEL_TYPES
+)
+
+
 def is_gemma4_family_model(model_path: str | Path) -> bool:
     """Check if the model belongs to the Gemma 4 *family* (text loader path).
 
-    Covers the two model_types the Gemma 4 text loader knows how to
-    serve today:
-
-    - ``gemma4`` — the non-unified text arch (26B / 31B / e2b / e4b
-      aliases, ``Gemma4ForConditionalGeneration``).
-    - ``gemma4_unified`` — the unified arch shipped by the
-      ``gemma-4-12b-*`` aliases (``Gemma4UnifiedForConditionalGeneration``).
-
-    This is a deliberate exact-match allow-list, NOT a ``"gemma4" in
-    model_type`` substring test. The old substring check also matched
-    unrelated future or sibling arches by accident — e.g.
-    ``gemma4_assistant`` (which already exists on the Hub as
-    ``mlx-community/gemma-4-31B-it-assistant``) or a hypothetical
-    ``gemma4_videogen`` — and silently routed them through the text
-    loader even though we've never validated them. Adding a new
-    supported member is a one-line edit here plus a real loader branch,
-    which is the point: routing becomes explicit and drift surfaces as a
-    clear "unsupported model_type" instead of a silent misroute.
+    True for any model_type the Gemma 4 text loaders serve — see
+    :data:`_GEMMA4_FAMILY_MODEL_TYPES`. Use this as the routing gate;
+    then split with :func:`is_gemma4_unified_model` to pick the loader.
     """
     # Read the model_type once (may hit hf_hub_download for a remote repo,
-    # cached ~5 KB) rather than paying two lookups via the two exact
+    # cached ~5 KB) rather than paying multiple lookups via the exact
     # detectors.
-    return _read_model_type(model_path) in ("gemma4", "gemma4_unified")
+    return _read_model_type(model_path) in _GEMMA4_FAMILY_MODEL_TYPES
 
 
 def is_gemma4_model(model_path: str | Path) -> bool:
-    """Check if the model is the NON-unified Gemma 4 text arch.
+    """Check if the model is a NON-unified Gemma 4 text arch.
 
-    Exact match on ``model_type == "gemma4"`` (26B / 31B / e2b / e4b).
-    Callers that want "any Gemma 4 text-servable arch" should use
-    :func:`is_gemma4_family_model`; callers that specifically want the
-    unified arch should use :func:`is_gemma4_unified_model`.
+    Matches ``gemma4`` and ``gemma4_assistant`` — the arches served by
+    :func:`load_gemma4_text`. Callers that want "any Gemma 4
+    text-servable arch" should use :func:`is_gemma4_family_model`;
+    callers that specifically want the unified arch should use
+    :func:`is_gemma4_unified_model`.
 
-    Historically this did ``"gemma4" in model_type``, which also caught
-    ``gemma4_unified`` (and ``gemma4_assistant``, ``gemma4_text``, …) by
-    substring. That happened to work because ``gemma4`` and
-    ``gemma4_unified`` ship dataclass-identical ``TextConfig`` shapes and
-    reuse the same ``LanguageModel`` class — but the routing was
-    misleading and fragile. See #509.
+    Historically this did ``"gemma4" in model_type``, which ALSO caught
+    ``gemma4_unified`` by substring. That happened to work because
+    ``gemma4`` and ``gemma4_unified`` ship dataclass-identical
+    ``TextConfig`` shapes and reuse the same ``LanguageModel`` class —
+    but conflating them was misleading and fragile. We now split unified
+    out to its own detector/loader while keeping the assistant arch on
+    this non-unified path (its nested ``text_config`` is ``gemma4_text``,
+    same as the base arch). See #509.
     """
-    return _read_model_type(model_path) == "gemma4"
+    return _read_model_type(model_path) in _GEMMA4_NONUNIFIED_MODEL_TYPES
 
 
 def is_gemma4_unified_model(model_path: str | Path) -> bool:
@@ -210,7 +227,26 @@ def is_gemma4_unified_model(model_path: str | Path) -> bool:
     ``mlx_vlm.models.gemma4_unified`` subpackage when mlx-vlm is
     installed and falls back to the vendored copy otherwise. See #509.
     """
-    return _read_model_type(model_path) == "gemma4_unified"
+    return _read_model_type(model_path) in _GEMMA4_UNIFIED_MODEL_TYPES
+
+
+def gemma4_family_kind(model_path: str | Path) -> str | None:
+    """Classify a Gemma 4 family model with a SINGLE config read.
+
+    Returns ``"unified"`` for ``gemma4_unified``, ``"nonunified"`` for
+    ``gemma4`` / ``gemma4_assistant``, or ``None`` if the model isn't in
+    the Gemma 4 text-loader family. Prefer this over calling
+    :func:`is_gemma4_family_model` then :func:`is_gemma4_unified_model` at
+    a dispatch site — it reads ``config.json`` once (one Hub lookup for a
+    remote repo) and the retained classification can't be flipped by a
+    transient second lookup failure.
+    """
+    mt = _read_model_type(model_path)
+    if mt in _GEMMA4_UNIFIED_MODEL_TYPES:
+        return "unified"
+    if mt in _GEMMA4_NONUNIFIED_MODEL_TYPES:
+        return "nonunified"
+    return None
 
 
 class Gemma4TextWrapper(nn.Module):
@@ -221,16 +257,22 @@ class Gemma4TextWrapper(nn.Module):
     This wrapper extracts .logits so the interface matches.
     """
 
-    def __init__(self, language_model, default_model_type: str = "gemma4"):
+    def __init__(self, language_model, routed_model_type: str = "gemma4"):
         super().__init__()
         self.language_model = language_model
         # Expose config for mlx-lm compatibility
         self.config = language_model.config
         self.model = language_model.model
-        # The unified arch reuses the same text ``LanguageModel`` (which
-        # reports model_type "gemma4_text"), so fall back to the arch the
-        # caller actually routed for (``gemma4`` vs ``gemma4_unified``).
-        self.model_type = getattr(language_model, "model_type", default_model_type)
+        # Report the arch the caller ACTUALLY routed for (``gemma4`` /
+        # ``gemma4_unified`` / ``gemma4_assistant``). The wrapped
+        # ``LanguageModel`` is the shared text stack and always reports the
+        # generic inner label ``"gemma4_text"`` regardless of the outer
+        # arch, so we normalize that to the routed model_type. If the
+        # wrapped model ever reports a more specific type, honor it.
+        inner = getattr(language_model, "model_type", None)
+        self.model_type = (
+            inner if inner and inner != "gemma4_text" else routed_model_type
+        )
 
     def __call__(self, input_ids, cache=None, **kwargs):
         out = self.language_model(input_ids, cache=cache, **kwargs)
@@ -434,13 +476,19 @@ def _load_gemma4_text_impl(
     config = json.loads((p / "config.json").read_text())
     text_config = config.get("text_config", config)
 
+    # The outer arch the checkpoint actually declares (``gemma4`` /
+    # ``gemma4_unified`` / ``gemma4_assistant``). Prefer it over the
+    # ``default_model_type`` hint so the wrapper reports the real arch
+    # (e.g. ``gemma4_assistant``) instead of a coarser default.
+    routed_model_type = config.get("model_type") or default_model_type
+
     TextConfig, LanguageModel = resolve_classes()
 
     tc = TextConfig.from_dict(text_config)
     language_model = LanguageModel(tc)
 
     # Wrap for mlx-lm compatibility
-    model = Gemma4TextWrapper(language_model, default_model_type=default_model_type)
+    model = Gemma4TextWrapper(language_model, routed_model_type=routed_model_type)
 
     # Load weights once up front (mmap-backed, cheap) — we'll feed these
     # back into ``model.load_weights`` after quantization. Sanitize per
@@ -563,7 +611,7 @@ def _load_gemma4_text_impl(
 
     logger.info(
         "[gemma4] Loaded %s text-only model via LLM path (%d layers)",
-        default_model_type,
+        routed_model_type,
         len(model.layers),
     )
     return model, tokenizer

--- a/vllm_mlx/models/gemma4_text.py
+++ b/vllm_mlx/models/gemma4_text.py
@@ -1,15 +1,30 @@
 # SPDX-License-Identifier: Apache-2.0
 """
-Gemma 4 text-only model loader for the LLM path.
+Gemma 4 text-only model loaders for the LLM path.
 
 mlx-lm 0.31+ added native ``gemma4`` (used by the 26B / 31B aliases), but
 ``gemma4_unified`` (the model_type the four ``gemma-4-12b-*`` aliases ship
 under) is still not in mlx-lm. This module loads the language model
-portion from mlx-vlm and wraps it to be compatible with mlx-lm's
-generate_step() interface, enabling:
+portion from mlx-vlm (or the vendored copy) and wraps it to be compatible
+with mlx-lm's generate_step() interface, enabling:
 - Prompt cache (KV reuse across requests)
 - DeltaNet state snapshots (if applicable)
 - All LLM-path optimizations
+
+Two model_types are served, each with an EXPLICIT detector + loader so
+routing is unambiguous (see #509 — the old ``"gemma4" in model_type``
+substring test also caught siblings like ``gemma4_assistant`` and would
+silently misroute a hypothetical ``gemma4_videogen``):
+
+- ``gemma4``          → :func:`is_gemma4_model` / :func:`load_gemma4_text`
+- ``gemma4_unified``  → :func:`is_gemma4_unified_model` /
+                        :func:`load_gemma4_unified_text`
+
+:func:`is_gemma4_family_model` is the OR of the two for call sites that
+just need "is this a Gemma 4 text-servable arch?". Both loaders prefer
+the matching upstream ``mlx_vlm`` subpackage when installed and fall back
+to the vendored copy under ``vllm_mlx/models/gemma4_vendored/`` so a
+fresh ``pip install rapid-mlx`` (no ``[vision]`` extra) still boots.
 
 The wrapper is thin: it just ensures model(input_ids, cache=cache) returns
 a raw logits tensor instead of LanguageModelOutput.
@@ -102,18 +117,22 @@ def _path_matches_any_suffix(path: str, suffixes: set[str]) -> bool:
     return False
 
 
-def is_gemma4_model(model_path: str | Path) -> bool:
-    """Check if the model at the given path is a Gemma 4 model.
+def _read_model_type(model_path: str | Path) -> str | None:
+    """Read the top-level ``model_type`` from a model's ``config.json``.
 
-    The previous implementation called ``snapshot_download(repo_id)`` to
-    populate a local cache before reading ``config.json``. That works,
-    but ``snapshot_download`` validates/fetches the ENTIRE model tree
-    (all safetensors shards, tokenizer files, generation config), which
-    for an 8-bit 35B model is ~35 GB of Xet-protocol revalidation on
-    every cold ``rapid-mlx serve`` start. Switch to ``hf_hub_download``
-    targeting ``config.json`` directly: a ~5 KB file, validated against
-    the existing HF cache. This was the root cause of stress_e2e_bench
-    server-boot timeouts on large models in PR #600 validation.
+    Returns ``None`` when the config is unreachable or unparseable so
+    callers can treat "can't tell" as "not this family".
+
+    The previous ``is_gemma4_model`` implementation called
+    ``snapshot_download(repo_id)`` to populate a local cache before
+    reading ``config.json``. That works, but ``snapshot_download``
+    validates/fetches the ENTIRE model tree (all safetensors shards,
+    tokenizer files, generation config), which for an 8-bit 35B model is
+    ~35 GB of Xet-protocol revalidation on every cold ``rapid-mlx serve``
+    start. We fetch ``config.json`` directly via ``hf_hub_download``: a
+    ~5 KB file, validated against the existing HF cache. This was the
+    root cause of stress_e2e_bench server-boot timeouts on large models
+    in PR #600 validation.
     """
     p = Path(model_path)
     config_path = p / "config.json" if p.is_dir() else None
@@ -125,15 +144,73 @@ def is_gemma4_model(model_path: str | Path) -> bool:
                 hf_hub_download(repo_id=str(model_path), filename="config.json")
             )
         except Exception:
-            return False
+            return None
     if not config_path.exists():
-        return False
+        return None
     try:
         config = json.loads(config_path.read_text())
-        model_type = config.get("model_type", "")
-        return "gemma4" in model_type
+        return config.get("model_type", "")
     except Exception:
-        return False
+        return None
+
+
+def is_gemma4_family_model(model_path: str | Path) -> bool:
+    """Check if the model belongs to the Gemma 4 *family* (text loader path).
+
+    Covers the two model_types the Gemma 4 text loader knows how to
+    serve today:
+
+    - ``gemma4`` — the non-unified text arch (26B / 31B / e2b / e4b
+      aliases, ``Gemma4ForConditionalGeneration``).
+    - ``gemma4_unified`` — the unified arch shipped by the
+      ``gemma-4-12b-*`` aliases (``Gemma4UnifiedForConditionalGeneration``).
+
+    This is a deliberate exact-match allow-list, NOT a ``"gemma4" in
+    model_type`` substring test. The old substring check also matched
+    unrelated future or sibling arches by accident — e.g.
+    ``gemma4_assistant`` (which already exists on the Hub as
+    ``mlx-community/gemma-4-31B-it-assistant``) or a hypothetical
+    ``gemma4_videogen`` — and silently routed them through the text
+    loader even though we've never validated them. Adding a new
+    supported member is a one-line edit here plus a real loader branch,
+    which is the point: routing becomes explicit and drift surfaces as a
+    clear "unsupported model_type" instead of a silent misroute.
+    """
+    # Read the model_type once (may hit hf_hub_download for a remote repo,
+    # cached ~5 KB) rather than paying two lookups via the two exact
+    # detectors.
+    return _read_model_type(model_path) in ("gemma4", "gemma4_unified")
+
+
+def is_gemma4_model(model_path: str | Path) -> bool:
+    """Check if the model is the NON-unified Gemma 4 text arch.
+
+    Exact match on ``model_type == "gemma4"`` (26B / 31B / e2b / e4b).
+    Callers that want "any Gemma 4 text-servable arch" should use
+    :func:`is_gemma4_family_model`; callers that specifically want the
+    unified arch should use :func:`is_gemma4_unified_model`.
+
+    Historically this did ``"gemma4" in model_type``, which also caught
+    ``gemma4_unified`` (and ``gemma4_assistant``, ``gemma4_text``, …) by
+    substring. That happened to work because ``gemma4`` and
+    ``gemma4_unified`` ship dataclass-identical ``TextConfig`` shapes and
+    reuse the same ``LanguageModel`` class — but the routing was
+    misleading and fragile. See #509.
+    """
+    return _read_model_type(model_path) == "gemma4"
+
+
+def is_gemma4_unified_model(model_path: str | Path) -> bool:
+    """Check if the model is the unified Gemma 4 arch (``gemma4_unified``).
+
+    Exact match on ``model_type == "gemma4_unified"`` — the arch the four
+    ``gemma-4-12b-*`` aliases ship under
+    (``Gemma4UnifiedForConditionalGeneration``). Routed to
+    :func:`load_gemma4_unified_text`, which pins to the matching
+    ``mlx_vlm.models.gemma4_unified`` subpackage when mlx-vlm is
+    installed and falls back to the vendored copy otherwise. See #509.
+    """
+    return _read_model_type(model_path) == "gemma4_unified"
 
 
 class Gemma4TextWrapper(nn.Module):
@@ -144,13 +221,16 @@ class Gemma4TextWrapper(nn.Module):
     This wrapper extracts .logits so the interface matches.
     """
 
-    def __init__(self, language_model):
+    def __init__(self, language_model, default_model_type: str = "gemma4"):
         super().__init__()
         self.language_model = language_model
         # Expose config for mlx-lm compatibility
         self.config = language_model.config
         self.model = language_model.model
-        self.model_type = getattr(language_model, "model_type", "gemma4")
+        # The unified arch reuses the same text ``LanguageModel`` (which
+        # reports model_type "gemma4_text"), so fall back to the arch the
+        # caller actually routed for (``gemma4`` vs ``gemma4_unified``).
+        self.model_type = getattr(language_model, "model_type", default_model_type)
 
     def __call__(self, input_ids, cache=None, **kwargs):
         out = self.language_model(input_ids, cache=cache, **kwargs)
@@ -205,10 +285,143 @@ class Gemma4TextWrapper(nn.Module):
         return self.language_model.n_kv_heads
 
 
-def load_gemma4_text(model_path: str | Path, tokenizer_config: dict = None):
-    """Load Gemma 4 as a text-only model via the LLM path.
+# Shared preamble for both loaders. As of 0.10.1 we vendor the Gemma 4
+# text classes (~50 KB, ~1200 lines) directly under
+# `vllm_mlx/models/gemma4_vendored/` so a fresh `pip install rapid-mlx`
+# boots Gemma 4 out of the box — no `[vision]` extra required.
+# Previously we imported from `mlx_vlm.models.gemma4.*`, but that
+# required either promoting mlx-vlm to a core dep (~+483 MB transitive
+# bloat: opencv-python, pyarrow, pandas, scipy, mlx-audio — none of
+# which text-only Gemma 4 inference touches) or making users know to
+# `pip install --no-deps 'mlx-vlm>=0.6.1'` themselves. See
+# `vllm_mlx/models/gemma4_vendored/__init__.py` for the sync policy.
+#
+# We still prefer upstream mlx-vlm when it's already importable
+# (e.g. `[vision]` users): mlx-vlm may ship a bug fix or Gemma 4.1
+# update before we sync the vendored copy. The vendored fallback keeps
+# the fresh-install path working with zero extras.
 
-    Returns (model, tokenizer) compatible with mlx-lm's generate_step().
+
+def _resolve_gemma4_text_classes():
+    """Return ``(TextConfig, LanguageModel)`` for the NON-unified ``gemma4``
+    arch — upstream ``mlx_vlm.models.gemma4`` when importable, else the
+    vendored copy (dataclass-identical, no ``[vision]`` extra needed)."""
+    try:
+        from mlx_vlm.models.gemma4.config import TextConfig
+        from mlx_vlm.models.gemma4.language import LanguageModel
+
+        return TextConfig, LanguageModel
+    except ImportError:
+        from vllm_mlx.models.gemma4_vendored import (
+            config as _v_cfg,
+        )
+        from vllm_mlx.models.gemma4_vendored import (
+            language as _v_lang,
+        )
+
+        return _v_cfg.TextConfig, _v_lang.LanguageModel
+
+
+def _resolve_gemma4_unified_text_classes():
+    """Return ``(TextConfig, LanguageModel)`` for the ``gemma4_unified`` arch.
+
+    Prefer upstream ``mlx_vlm.models.gemma4_unified`` when mlx-vlm is
+    installed, so we pin to the subpackage that actually matches the
+    ``Gemma4UnifiedForConditionalGeneration`` checkpoints and surface any
+    future upstream drift instead of silently reusing the non-unified
+    classes. Notes on the upstream layout (mlx-vlm 0.6.3):
+
+    - ``gemma4_unified.config.TextConfig`` subclasses
+      ``gemma4.config.TextConfig`` with unified-specific defaults; the
+      concrete field values still come from the checkpoint's
+      ``text_config`` via ``from_dict``, so it stays dataclass-compatible
+      with the vendored copy.
+    - ``gemma4_unified.LanguageModel`` is literally re-exported from
+      ``gemma4.language`` (``from ..gemma4.language import LanguageModel``
+      in ``gemma4_unified.py``) — the unified arch only adds vision/audio
+      embedders around the SAME text stack. So the text forward path is
+      identical to the non-unified loader by construction, which is why
+      serving ``gemma-4-12b`` through the ``gemma4`` classes worked
+      empirically (see #509). Routing here just makes the intent explicit.
+
+    Falls back to the vendored ``gemma4`` copy when mlx-vlm is absent
+    (fresh install). The vendored copy has no separate ``unified``
+    variant, but since upstream's ``LanguageModel`` IS the ``gemma4`` one
+    and the ``TextConfig`` is dataclass-identical for text purposes, the
+    vendored classes serve ``gemma4_unified`` correctly — same behavior
+    as today, just reached through an explicit branch. A real
+    ``ImportError`` is only possible if BOTH upstream-unified AND the
+    vendored copy are unavailable, which cannot happen because the
+    vendored copy ships inside the wheel.
+    """
+    try:
+        from mlx_vlm.models.gemma4_unified import LanguageModel
+        from mlx_vlm.models.gemma4_unified.config import TextConfig
+
+        return TextConfig, LanguageModel
+    except ImportError:
+        # No upstream unified subpackage (fresh install, or an older
+        # mlx-vlm without gemma4_unified). Fall back to the vendored
+        # text classes — same as the non-unified path.
+        from vllm_mlx.models.gemma4_vendored import (
+            config as _v_cfg,
+        )
+        from vllm_mlx.models.gemma4_vendored import (
+            language as _v_lang,
+        )
+
+        return _v_cfg.TextConfig, _v_lang.LanguageModel
+
+
+def load_gemma4_unified_text(model_path: str | Path, tokenizer_config: dict = None):
+    """Load a ``gemma4_unified`` Gemma 4 checkpoint as a text-only model.
+
+    Explicit loader for the ``gemma-4-12b-*`` aliases
+    (``Gemma4UnifiedForConditionalGeneration``). Pins to the matching
+    ``mlx_vlm.models.gemma4_unified`` subpackage when mlx-vlm is
+    installed, else falls back to the vendored copy. See #509 and
+    :func:`_resolve_gemma4_unified_text_classes` for the fallback
+    rationale. Returns ``(model, tokenizer)`` compatible with mlx-lm's
+    ``generate_step()``.
+    """
+    return _load_gemma4_text_impl(
+        model_path,
+        tokenizer_config,
+        resolve_classes=_resolve_gemma4_unified_text_classes,
+        default_model_type="gemma4_unified",
+    )
+
+
+def load_gemma4_text(model_path: str | Path, tokenizer_config: dict = None):
+    """Load a NON-unified ``gemma4`` checkpoint as a text-only model.
+
+    For the 26B / 31B / e2b / e4b aliases
+    (``Gemma4ForConditionalGeneration``). Returns ``(model, tokenizer)``
+    compatible with mlx-lm's ``generate_step()``. For ``gemma4_unified``
+    (12B) use :func:`load_gemma4_unified_text` instead.
+    """
+    return _load_gemma4_text_impl(
+        model_path,
+        tokenizer_config,
+        resolve_classes=_resolve_gemma4_text_classes,
+        default_model_type="gemma4",
+    )
+
+
+def _load_gemma4_text_impl(
+    model_path: str | Path,
+    tokenizer_config: dict = None,
+    *,
+    resolve_classes,
+    default_model_type: str,
+):
+    """Shared build for both Gemma 4 text loaders.
+
+    ``resolve_classes`` returns ``(TextConfig, LanguageModel)`` for the
+    target arch (unified vs non-unified); everything downstream —
+    weight sanitize, checkpoint-driven quantization, tokenizer load — is
+    identical between the two because the unified arch reuses the same
+    text ``LanguageModel``.
     """
     from mlx_lm.utils import load_tokenizer
 
@@ -221,40 +434,13 @@ def load_gemma4_text(model_path: str | Path, tokenizer_config: dict = None):
     config = json.loads((p / "config.json").read_text())
     text_config = config.get("text_config", config)
 
-    # Build the language model. As of 0.10.1 we vendor the Gemma 4 text
-    # classes (~50 KB, ~1200 lines) directly under
-    # `vllm_mlx/models/gemma4_vendored/` so a fresh `pip install rapid-mlx`
-    # boots Gemma 4 out of the box — no `[vision]` extra required.
-    # Previously we imported from `mlx_vlm.models.gemma4.*`, but that
-    # required either promoting mlx-vlm to a core dep (~+483 MB transitive
-    # bloat: opencv-python, pyarrow, pandas, scipy, mlx-audio — none of
-    # which text-only Gemma 4 inference touches) or making users know to
-    # `pip install --no-deps 'mlx-vlm>=0.6.1'` themselves. See
-    # `vllm_mlx/models/gemma4_vendored/__init__.py` for the sync policy.
-    #
-    # We still prefer upstream mlx-vlm when it's already importable
-    # (e.g. `[vision]` users): mlx-vlm may ship a bug fix or Gemma 4.1
-    # update before we sync the vendored copy. The vendored fallback
-    # keeps the fresh-install path working with zero extras.
-    try:
-        from mlx_vlm.models.gemma4.config import TextConfig
-        from mlx_vlm.models.gemma4.language import LanguageModel
-    except ImportError:
-        from vllm_mlx.models.gemma4_vendored import (
-            config as _v_cfg,
-        )
-        from vllm_mlx.models.gemma4_vendored import (
-            language as _v_lang,
-        )
-
-        TextConfig = _v_cfg.TextConfig
-        LanguageModel = _v_lang.LanguageModel
+    TextConfig, LanguageModel = resolve_classes()
 
     tc = TextConfig.from_dict(text_config)
     language_model = LanguageModel(tc)
 
     # Wrap for mlx-lm compatibility
-    model = Gemma4TextWrapper(language_model)
+    model = Gemma4TextWrapper(language_model, default_model_type=default_model_type)
 
     # Load weights once up front (mmap-backed, cheap) — we'll feed these
     # back into ``model.load_weights`` after quantization. Sanitize per
@@ -376,6 +562,8 @@ def load_gemma4_text(model_path: str | Path, tokenizer_config: dict = None):
     tokenizer = load_tokenizer(p, tokenizer_config, eos_token_ids=eos_token_ids)
 
     logger.info(
-        "[gemma4] Loaded text-only model via LLM path (%d layers)", len(model.layers)
+        "[gemma4] Loaded %s text-only model via LLM path (%d layers)",
+        default_model_type,
+        len(model.layers),
     )
     return model, tokenizer

--- a/vllm_mlx/models/gemma4_text.py
+++ b/vllm_mlx/models/gemma4_text.py
@@ -205,25 +205,39 @@ def is_gemma4_family_model(model_path: str | Path) -> bool:
     return _read_model_type(model_path) in _GEMMA4_FAMILY_MODEL_TYPES
 
 
-def is_gemma4_model(model_path: str | Path) -> bool:
+def is_gemma4_nonunified_model(model_path: str | Path) -> bool:
     """Check if the model is a NON-unified Gemma 4 text arch.
 
     Matches ``gemma4`` and ``gemma4_assistant`` — the arches served by
-    :func:`load_gemma4_text`. Callers that want "any Gemma 4
-    text-servable arch" should use :func:`is_gemma4_family_model`;
-    callers that specifically want the unified arch should use
-    :func:`is_gemma4_unified_model`.
-
-    Historically this did ``"gemma4" in model_type``, which ALSO caught
-    ``gemma4_unified`` by substring. That happened to work because
-    ``gemma4`` and ``gemma4_unified`` ship dataclass-identical
-    ``TextConfig`` shapes and reuse the same ``LanguageModel`` class —
-    but conflating them was misleading and fragile. We now split unified
-    out to its own detector/loader while keeping the assistant arch on
-    this non-unified path (its nested ``text_config`` is ``gemma4_text``,
-    same as the base arch). See #509.
+    :func:`load_gemma4_text`. This is the explicitly-named narrowed
+    predicate; :func:`is_gemma4_model` is a back-compat alias for it.
+    Callers that want "any Gemma 4 text-servable arch" should use
+    :func:`is_gemma4_family_model`; callers that specifically want the
+    unified arch should use :func:`is_gemma4_unified_model`.
     """
     return _read_model_type(model_path) in _GEMMA4_NONUNIFIED_MODEL_TYPES
+
+
+def is_gemma4_model(model_path: str | Path) -> bool:
+    """Back-compat alias for :func:`is_gemma4_nonunified_model`.
+
+    Pre-#509 this did ``"gemma4" in model_type``, so it returned True for
+    the base ``gemma4`` arch AND (by substring) ``gemma4_unified`` /
+    ``gemma4_assistant`` / a hypothetical ``gemma4_videogen``. That worked
+    only because ``gemma4`` and ``gemma4_unified`` ship dataclass-identical
+    ``TextConfig`` shapes and reuse the same ``LanguageModel`` class — but
+    conflating them was misleading and fragile.
+
+    The name is kept (the only in-tree callers are this module's own tests
+    — it is not exported and had a single production caller, now migrated
+    to :func:`gemma4_family_kind`), but its meaning is now the exact
+    NON-unified set. ``gemma4_unified`` split out to its own
+    detector/loader; ``gemma4_assistant`` stays on the non-unified path
+    (its nested ``text_config`` is a ``gemma4_text`` shape). Prefer
+    :func:`is_gemma4_nonunified_model` (explicit) or
+    :func:`is_gemma4_family_model` (family-wide) in new code. See #509.
+    """
+    return is_gemma4_nonunified_model(model_path)
 
 
 def is_gemma4_unified_model(model_path: str | Path) -> bool:

--- a/vllm_mlx/models/gemma4_text.py
+++ b/vllm_mlx/models/gemma4_text.py
@@ -11,20 +11,28 @@ with mlx-lm's generate_step() interface, enabling:
 - DeltaNet state snapshots (if applicable)
 - All LLM-path optimizations
 
-Two model_types are served, each with an EXPLICIT detector + loader so
-routing is unambiguous (see #509 — the old ``"gemma4" in model_type``
-substring test also caught siblings like ``gemma4_assistant`` and would
-silently misroute a hypothetical ``gemma4_videogen``):
+Three outer model_types are served, routed to two loaders via an
+EXPLICIT exact-match allow-list so routing is unambiguous (see #509 —
+the old ``"gemma4" in model_type`` substring test would silently
+misroute a hypothetical ``gemma4_videogen`` or the inner sub-config's
+own ``gemma4_text`` label):
 
-- ``gemma4``          → :func:`is_gemma4_model` / :func:`load_gemma4_text`
-- ``gemma4_unified``  → :func:`is_gemma4_unified_model` /
-                        :func:`load_gemma4_unified_text`
+- ``gemma4``           → :func:`is_gemma4_model` / :func:`load_gemma4_text`
+- ``gemma4_assistant`` → :func:`is_gemma4_model` / :func:`load_gemma4_text`
+                         (the ``gemma-4-*-assistant`` aliases; its nested
+                         ``text_config`` is a ``gemma4_text`` shape, so it
+                         rides the same non-unified loader the old
+                         substring match sent it down — kept for
+                         backward compat)
+- ``gemma4_unified``   → :func:`is_gemma4_unified_model` /
+                         :func:`load_gemma4_unified_text`
 
-:func:`is_gemma4_family_model` is the OR of the two for call sites that
-just need "is this a Gemma 4 text-servable arch?". Both loaders prefer
-the matching upstream ``mlx_vlm`` subpackage when installed and fall back
-to the vendored copy under ``vllm_mlx/models/gemma4_vendored/`` so a
-fresh ``pip install rapid-mlx`` (no ``[vision]`` extra) still boots.
+:func:`is_gemma4_family_model` is the OR of all three for call sites that
+just need "is this a Gemma 4 text-servable arch?"; :func:`gemma4_family_kind`
+classifies with a single config read for dispatch sites. Both loaders
+prefer the matching upstream ``mlx_vlm`` subpackage when installed and
+fall back to the vendored copy under ``vllm_mlx/models/gemma4_vendored/``
+so a fresh ``pip install rapid-mlx`` (no ``[vision]`` extra) still boots.
 
 The wrapper is thin: it just ensures model(input_ids, cache=cache) returns
 a raw logits tensor instead of LanguageModelOutput.
@@ -158,11 +166,12 @@ def _read_model_type(model_path: str | Path) -> str | None:
 # exact-match allow-list, NOT a ``"gemma4" in model_type`` substring test
 # (see #509). The substring check also matched a hypothetical future
 # ``gemma4_videogen`` (or ``gemma4_text`` — the inner text sub-config's
-# own model_type) and would silently misroute it. Each member here maps
-# to a concrete loader in :func:`_gemma4_loader_for`; adding a new
-# supported arch is a one-line edit plus a loader branch, which is the
-# point — routing is explicit and unknown arches surface loudly instead
-# of silently riding the text path.
+# own model_type) and would silently misroute it. Each member is
+# classified by :func:`gemma4_family_kind` and routed to the matching
+# ``load_gemma4_*`` loader; adding a new supported arch is a one-line
+# edit here plus a loader branch, which is the point — routing is
+# explicit and unknown arches surface loudly instead of silently riding
+# the text path.
 #
 # - ``gemma4``           : non-unified text arch (26B/31B/e2b/e4b,
 #                          ``Gemma4ForConditionalGeneration``).

--- a/vllm_mlx/utils/tokenizer.py
+++ b/vllm_mlx/utils/tokenizer.py
@@ -792,17 +792,19 @@ def _load_model_with_fallback_impl(model_name: str, tokenizer_config: dict = Non
         return _load_with_tokenizer_fallback(model_name)
 
     # Gemma 4: mlx-lm 0.31+ supports it natively. Only use our wrapper
-    # for older mlx-lm versions that lack gemma4 model support. Two
+    # for older mlx-lm versions that lack gemma4 model support. Several
     # model_types ride this path — the non-unified ``gemma4`` (26B/31B/
-    # e2b/e4b) and ``gemma4_unified`` (12B). Detect the whole family
-    # here, but dispatch the fallback to the loader that pins to the
-    # matching mlx-vlm subpackage (see #509).
+    # e2b/e4b) and ``gemma4_assistant`` (assistant aliases), plus
+    # ``gemma4_unified`` (12B). Read the arch ONCE and retain the
+    # classification through the native-load fallback so a remote repo's
+    # config isn't fetched twice and a transient second lookup can't
+    # flip the loader choice (see #509).
     from ..models.gemma4_text import (
-        is_gemma4_family_model,
-        is_gemma4_unified_model,
+        gemma4_family_kind,
     )
 
-    if is_gemma4_family_model(model_name):
+    gemma4_kind = gemma4_family_kind(model_name)  # "unified" | "nonunified" | None
+    if gemma4_kind is not None:
         try:
             # Try native mlx-lm load first (0.31+)
             model, tokenizer = load(model_name, tokenizer_config=tokenizer_config)
@@ -820,7 +822,7 @@ def _load_model_with_fallback_impl(model_name: str, tokenizer_config: dict = Non
             # ``gemma4_unified`` to the explicit unified loader so it
             # pins to ``mlx_vlm.models.gemma4_unified`` (with vendored
             # fallback); everything else uses the non-unified loader.
-            if is_gemma4_unified_model(model_name):
+            if gemma4_kind == "unified":
                 from ..models.gemma4_text import load_gemma4_unified_text
 
                 logger.info(

--- a/vllm_mlx/utils/tokenizer.py
+++ b/vllm_mlx/utils/tokenizer.py
@@ -792,10 +792,17 @@ def _load_model_with_fallback_impl(model_name: str, tokenizer_config: dict = Non
         return _load_with_tokenizer_fallback(model_name)
 
     # Gemma 4: mlx-lm 0.31+ supports it natively. Only use our wrapper
-    # for older mlx-lm versions that lack gemma4 model support.
-    from ..models.gemma4_text import is_gemma4_model
+    # for older mlx-lm versions that lack gemma4 model support. Two
+    # model_types ride this path — the non-unified ``gemma4`` (26B/31B/
+    # e2b/e4b) and ``gemma4_unified`` (12B). Detect the whole family
+    # here, but dispatch the fallback to the loader that pins to the
+    # matching mlx-vlm subpackage (see #509).
+    from ..models.gemma4_text import (
+        is_gemma4_family_model,
+        is_gemma4_unified_model,
+    )
 
-    if is_gemma4_model(model_name):
+    if is_gemma4_family_model(model_name):
         try:
             # Try native mlx-lm load first (0.31+)
             model, tokenizer = load(model_name, tokenizer_config=tokenizer_config)
@@ -809,7 +816,19 @@ def _load_model_with_fallback_impl(model_name: str, tokenizer_config: dict = Non
             return model, tokenizer
         except Exception as e:
             # Fall back to our wrapper for older mlx-lm versions
-            # that lack native gemma4 architecture support
+            # that lack native gemma4 architecture support. Route
+            # ``gemma4_unified`` to the explicit unified loader so it
+            # pins to ``mlx_vlm.models.gemma4_unified`` (with vendored
+            # fallback); everything else uses the non-unified loader.
+            if is_gemma4_unified_model(model_name):
+                from ..models.gemma4_text import load_gemma4_unified_text
+
+                logger.info(
+                    f"Gemma 4 unified native load failed ({e}), "
+                    "falling back to unified text-only wrapper (legacy mlx-lm)"
+                )
+                return load_gemma4_unified_text(model_name, tokenizer_config)
+
             from ..models.gemma4_text import load_gemma4_text
 
             logger.info(


### PR DESCRIPTION
## Why

`vllm_mlx/models/gemma4_text.py::is_gemma4_model` used a fragile
`"gemma4" in model_type` **substring** match. That match claimed FOUR
model_types at once: the non-unified `gemma4` (26B/31B/e2b/e4b), the
`gemma4_unified` arch the four `gemma-4-12b-*` aliases actually ship
under (`Gemma4UnifiedForConditionalGeneration`), the language sub-config's
`gemma4_text`, **and** `gemma4_assistant` — which already exists on the
Hub as `mlx-community/gemma-4-31B-it-assistant`. Every one of them loaded
through the **non-unified** `mlx_vlm.models.gemma4` subpackage.

It worked empirically only by luck: `gemma4.TextConfig` and
`gemma4_unified.TextConfig` are dataclass-compatible, and upstream
literally re-exports the SAME `LanguageModel` from `gemma4.language`
inside `gemma4_unified` (the unified arch just wraps vision/audio
embedders around the identical text stack). But the routing was
misleading and one new Google arch (`gemma4_videogen`, …) away from a
silent misroute. This is the cleanup Codex flagged on PR #507.

Closes #509.

## What changed

- **`gemma4_text.py`** — split detection into exact-match
  `is_gemma4_model` (`== "gemma4"`), new `is_gemma4_unified_model`
  (`== "gemma4_unified"`), and `is_gemma4_family_model` (OR of the two),
  all backed by a shared `_read_model_type` helper (keeps the
  `hf_hub_download('config.json')`-not-`snapshot_download` fix from #600).
  Add `load_gemma4_unified_text` that **pins to
  `mlx_vlm.models.gemma4_unified`** when mlx-vlm is installed and **falls
  back to the vendored copy** otherwise. Both loaders now share
  `_load_gemma4_text_impl`.
- **`utils/tokenizer.py`** — gate on `is_gemma4_family_model`, then
  dispatch the fallback to `load_gemma4_unified_text` for unified
  checkpoints and `load_gemma4_text` for the rest.

## Fresh-install nuance (the #1 thing to get right)

The issue's suggested `import mlx_vlm.models.gemma4_unified` is
incomplete: it only works for `[vision]` users. `load_gemma4_unified_text`
mirrors the existing prefer-upstream-else-vendored pattern, so a fresh
`pip install rapid-mlx` (no mlx-vlm) still boots `gemma-4-12b` via the
vendored text classes — no reintroduction of the 0.10.0 regression. Also
note: upstream's unified `LanguageModel` submodule is at
`gemma4_unified.gemma4_unified`, not `.language`, and it re-exports the
`gemma4` one — so the loader imports `TextConfig` from
`gemma4_unified.config` and `LanguageModel` from the `gemma4_unified`
package root.

## Tests

New `tests/test_gemma4_unified_routing.py` (15 cases): each arch is
claimed only by its matching detector; siblings `gemma4_assistant` /
`gemma4_videogen` / `gemma4_text` are rejected (fails against the old
substring impl); loaders resolve to the matching subpackage; the
vendored fallback is exercised when mlx-vlm is monkeypatched absent; and
the `tokenizer.py` dispatch routes each arch to the right loader.

## Fresh-venv proof (G9 — both paths, mlx-vlm absent in venv)

Fresh `python3.12 -m venv` + `pip install .`, no `[vision]` extra:

- **Non-unified** `gemma-4-31b-4bit` (`gemma4`, cached canonical): boots,
  `/v1/models` ok, `/v1/chat/completions` → "The capital of France is
  Paris." (finish=stop). Native mlx-lm path.
- **Unified** `gemma-4-12b-4bit` (`gemma4_unified`, pulled + deleted
  after): boots via the NEW unified fallback branch — log shows
  `Gemma 4 unified native load failed (Model type gemma4_unified not
  supported.), falling back to unified text-only wrapper` and
  `[gemma4] Loaded gemma4_unified text-only model via LLM path (48
  layers)` — `/v1/models` ok, `/v1/chat/completions` → "Red, blue,
  yellow" (finish=stop). Vendored fallback exercised live (no mlx-vlm in
  venv).

## Scope

Does not touch `spec_decode/**` or `speculative/**`. `cli.py`'s
`gemma4_unified` reference is an error-message heuristic, not a routing
site — left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
