### PR TITLE
feat(models): onboard Qwen3-Coder-Next 80B aliases

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.10.9"
+version = "0.10.10"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.10.10"
+version = "0.10.9"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/tests/test_model_auto_config.py
+++ b/tests/test_model_auto_config.py
@@ -119,7 +119,8 @@ class TestDetectModelConfig:
         assert config.tool_call_parser == "mistral"
         assert config.reasoning_parser is None
 
-    # Qwen3-Coder (no reasoning parser)
+    # Qwen3-Coder-Next emits the XML ``<function=...>`` tool envelope and
+    # has no thinking channel (see its upstream chat template/model card).
     @pytest.mark.parametrize(
         "model_path",
         [
@@ -127,10 +128,10 @@ class TestDetectModelConfig:
             "lmstudio-community/Qwen3-Coder-Next-MLX-6bit",
         ],
     )
-    def test_qwen_coder(self, model_path):
+    def test_qwen_coder_next(self, model_path):
         config = detect_model_config(model_path)
         assert config is not None
-        assert config.tool_call_parser == "hermes"
+        assert config.tool_call_parser == "qwen3_coder_xml"
         assert config.reasoning_parser is None
 
     # DeepSeek V3.1 thinking-channel → deepseek_v31 parser. R12-5

--- a/tests/test_qwen3_coder_next_aliases.py
+++ b/tests/test_qwen3_coder_next_aliases.py
@@ -15,7 +15,7 @@ _CANONICAL_ALIASES = (
     ),
     (
         "qwen3-coder-next-80b-8bit",
-        "lmstudio-community/Qwen3-Next-80B-A3B-Instruct-MLX-8bit",
+        "lmstudio-community/Qwen3-Coder-Next-MLX-8bit",
     ),
 )
 
@@ -87,3 +87,4 @@ def test_qwen3_coder_next_direct_paths_use_xml_tools_without_reasoning(
     assert config.reasoning_parser is None
     assert config.is_hybrid is True
     assert config.supports_spec_decode is False
+    assert config.supports_dflash is False

--- a/tests/test_qwen3_coder_next_aliases.py
+++ b/tests/test_qwen3_coder_next_aliases.py
@@ -1,0 +1,89 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Qwen3-Coder-Next alias and fallback-routing contracts for #925."""
+
+from __future__ import annotations
+
+import pytest
+
+from vllm_mlx.model_aliases import list_profiles
+from vllm_mlx.model_auto_config import detect_model_config
+
+_CANONICAL_ALIASES = (
+    (
+        "qwen3-coder-next-80b-4bit",
+        "mlx-community/Qwen3-Coder-Next-4bit",
+    ),
+    (
+        "qwen3-coder-next-80b-8bit",
+        "lmstudio-community/Qwen3-Next-80B-A3B-Instruct-MLX-8bit",
+    ),
+)
+
+
+@pytest.mark.parametrize(("alias", "hf_path"), _CANONICAL_ALIASES)
+def test_qwen3_coder_next_aliases_declare_the_safe_runtime_profile(
+    alias: str, hf_path: str
+) -> None:
+    """Both shipped precisions are hybrid MoE, XML-tool, non-thinking models.
+
+    The upstream Qwen template requests ``<tool_call><function=...>`` XML,
+    while the model card states that Coder-Next never emits ``<think>``.
+    Keeping this contract in the alias profile prevents the generic Hermes
+    parser from leaking XML tool calls and prevents the qwen3 reasoning parser
+    from duplicating ordinary content as reasoning.
+    """
+    profile = list_profiles()[alias]
+
+    assert profile.hf_path == hf_path
+    assert profile.tool_call_parser == "qwen3_coder_xml"
+    assert profile.reasoning_parser is None
+    assert profile.is_hybrid is True
+    assert profile.is_moe is True
+    assert profile.supports_spec_decode is False
+    assert profile.supports_dflash is False
+    assert dict(profile.recommended_sampling or ()) == {
+        "temperature": 1.0,
+        "top_k": 40.0,
+        "top_p": 0.95,
+    }
+
+
+def test_legacy_qwen3_coder_alias_keeps_coder_next_safe_profile() -> None:
+    """The existing short alias is a Coder-Next repack, not older Coder-30B.
+
+    Preserve its public name for compatibility while giving it the same parser
+    and architecture gates as the explicit 80B aliases.
+    """
+    profile = list_profiles()["qwen3-coder-4bit"]
+
+    assert profile.tool_call_parser == "qwen3_coder_xml"
+    assert profile.reasoning_parser is None
+    assert profile.is_hybrid is True
+    assert profile.is_moe is True
+    assert profile.supports_spec_decode is False
+    assert profile.supports_dflash is False
+
+
+@pytest.mark.parametrize(
+    "model_path",
+    [
+        "Qwen/Qwen3-Coder-Next",
+        *(hf_path for _, hf_path in _CANONICAL_ALIASES),
+    ],
+)
+def test_qwen3_coder_next_direct_paths_use_xml_tools_without_reasoning(
+    model_path: str,
+) -> None:
+    """Unaliased official/repacked paths stay on the same safe fallback.
+
+    This is the boundary case: a user can serve the official HF ID directly
+    instead of a Rapid-MLX alias and must still receive XML tool parsing with
+    hybrid speculative-decode gating.
+    """
+    config = detect_model_config(model_path)
+
+    assert config is not None
+    assert config.tool_call_parser == "qwen3_coder_xml"
+    assert config.reasoning_parser is None
+    assert config.is_hybrid is True
+    assert config.supports_spec_decode is False

--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -498,7 +498,7 @@
     }
   },
   "qwen3-coder-next-80b-8bit": {
-    "hf_path": "lmstudio-community/Qwen3-Next-80B-A3B-Instruct-MLX-8bit",
+    "hf_path": "lmstudio-community/Qwen3-Coder-Next-MLX-8bit",
     "tool_call_parser": "qwen3_coder_xml",
     "reasoning_parser": null,
     "is_hybrid": true,

--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -471,10 +471,45 @@
   },
   "qwen3-coder-4bit": {
     "hf_path": "lmstudio-community/Qwen3-Coder-Next-MLX-4bit",
-    "tool_call_parser": "hermes",
+    "tool_call_parser": "qwen3_coder_xml",
     "reasoning_parser": null,
     "is_hybrid": true,
-    "supports_spec_decode": false
+    "is_moe": true,
+    "supports_spec_decode": false,
+    "supports_dflash": false,
+    "recommended_sampling": {
+      "temperature": 1.0,
+      "top_p": 0.95,
+      "top_k": 40
+    }
+  },
+  "qwen3-coder-next-80b-4bit": {
+    "hf_path": "mlx-community/Qwen3-Coder-Next-4bit",
+    "tool_call_parser": "qwen3_coder_xml",
+    "reasoning_parser": null,
+    "is_hybrid": true,
+    "is_moe": true,
+    "supports_spec_decode": false,
+    "supports_dflash": false,
+    "recommended_sampling": {
+      "temperature": 1.0,
+      "top_p": 0.95,
+      "top_k": 40
+    }
+  },
+  "qwen3-coder-next-80b-8bit": {
+    "hf_path": "lmstudio-community/Qwen3-Next-80B-A3B-Instruct-MLX-8bit",
+    "tool_call_parser": "qwen3_coder_xml",
+    "reasoning_parser": null,
+    "is_hybrid": true,
+    "is_moe": true,
+    "supports_spec_decode": false,
+    "supports_dflash": false,
+    "recommended_sampling": {
+      "temperature": 1.0,
+      "top_p": 0.95,
+      "top_k": 40
+    }
   },
   "qwen3-vl-4b-4bit": {
     "hf_path": "mlx-community/Qwen3-VL-4B-Instruct-4bit",

--- a/vllm_mlx/model_auto_config.py
+++ b/vllm_mlx/model_auto_config.py
@@ -291,6 +291,13 @@ _MODEL_PATTERNS: list[tuple[re.Pattern, ModelConfig]] = [
             reasoning_parser=None,
             is_hybrid=True,
             supports_spec_decode=False,
+            # Coder-Next is hybrid Gated-DeltaNet + MoE: DFlash draft-model
+            # decoding is unsupported. This mirrors the alias profiles so a
+            # user serving the raw HF path (no alias) gets the same safe
+            # gate. ``is_moe`` is not a ModelConfig field (it lives only on
+            # AliasProfile), so the MoE fact is carried by the aliases; the
+            # direct-path only needs the hybrid + capability gates.
+            supports_dflash=False,
         ),
     ),
     # Qwen3.6 MoE (A3B / A10B / generic MoE markers) — hybrid

--- a/vllm_mlx/model_auto_config.py
+++ b/vllm_mlx/model_auto_config.py
@@ -287,7 +287,7 @@ _MODEL_PATTERNS: list[tuple[re.Pattern, ModelConfig]] = [
     (
         re.compile(r"qwen3[-_]?(coder[-_]?next|next)", re.IGNORECASE),
         ModelConfig(
-            tool_call_parser="hermes",
+            tool_call_parser="qwen3_coder_xml",
             reasoning_parser=None,
             is_hybrid=True,
             supports_spec_decode=False,


### PR DESCRIPTION
## Summary
- add explicit 4-bit and 8-bit Qwen3-Coder-Next 80B aliases
- correct the existing `qwen3-coder-4bit` Coder-Next repack profile
- route direct Coder-Next paths through `qwen3_coder_xml`, with non-thinking and hybrid/MoE safety gates
- add alias and fallback-routing regression coverage
- bump the package version to 0.10.10

## Root cause
Coder-Next emits the native XML `<tool_call><function=...>` format, but the existing profile and fallback selected the generic Hermes parser. The upstream model card also says Coder-Next is non-thinking, so it must not use the `qwen3` reasoning parser.

## Validation
- `python3.12 -m pytest -q tests/test_qwen3_coder_next_aliases.py tests/test_model_auto_config.py tests/test_aliases_contract.py tests/test_alias_hybrid_classification.py tests/test_tool_parser_coverage.py tests/test_alias_recommended_sampling.py` (2666 passed)
- `python3.12 -m ruff check ...`
- `python3.12 -m ruff format --check ...`
- verified both MLX repository `config.json` endpoints return HTTP 200
- **Live 4-bit inference:** loaded `mlx-community/Qwen3-Coder-Next-4bit` via `rapid-mlx serve qwen3-coder-next-80b-4bit`; forced non-streaming and streaming function calls both returned structured `tool_calls` without XML leaking into `content`.

## AI assistance
Implemented and tested with Codex; configuration choices were cross-checked against the official Qwen model card and chat template.