### PR TITLE
feat(gemma4): verify-and-lock cross-layer KV-share (guard + 5-size test)

### DIFF
--- a/tests/test_gemma4_kv_share.py
+++ b/tests/test_gemma4_kv_share.py
@@ -194,6 +194,29 @@ def test_guard_non_int_shared_raises(bad):
         )
 
 
+def test_text_config_default_helper():
+    """_text_config_default_num_kv_shared reads the dataclass field DEFAULT.
+    An int default → that int; a None default (or non-dataclass) → 0 (fail-safe
+    inactive)."""
+    import dataclasses
+
+    from vllm_mlx.models.gemma4_text import _text_config_default_num_kv_shared
+
+    @dataclasses.dataclass
+    class _IntDefault:
+        num_kv_shared_layers: int = 7
+
+    @dataclasses.dataclass
+    class _NoneDefault:
+        num_kv_shared_layers: int | None = None
+
+    assert _text_config_default_num_kv_shared(_IntDefault()) == 7
+    assert _text_config_default_num_kv_shared(_NoneDefault()) == 0  # None → 0
+    assert _text_config_default_num_kv_shared(object()) == 0  # non-dataclass → 0
+    # And the real vendored TextConfig default is 20 (E2B shape).
+    assert _text_config_default_num_kv_shared(TextConfig()) == 20
+
+
 def test_guard_explicit_null_raises():
     """An EXPLICIT ``num_kv_shared_layers: null`` in the config dict is
     malformed → ValueError. We must not guess a size-specific value (forcing
@@ -207,10 +230,12 @@ def test_guard_explicit_null_raises():
 
 
 def test_guard_absent_key_with_none_field_uses_default(caplog):
-    """When the key is ABSENT from the config dict but the dataclass field is
-    ``None`` (e.g. a class whose default is None), fall back to the dataclass
-    DEFAULT — the legitimate "checkpoint didn't override the default" path. Not
-    the explicit-null case (that raises)."""
+    """When the key is ABSENT from the config dict but the field on the tc
+    instance is ``None``, fall back to the dataclass DEFAULT (20 for the
+    vendored TextConfig) — the legitimate "checkpoint didn't override the
+    default" path, distinct from the explicit-null case (which raises). The
+    helper's own None-default → 0 fallback is covered by
+    test_text_config_default_helper."""
     tc = _build_text_config(35, 20)
     tc.num_kv_shared_layers = None
     with caplog.at_level(logging.DEBUG, logger="vllm_mlx.models.gemma4_text"):

--- a/tests/test_gemma4_kv_share.py
+++ b/tests/test_gemma4_kv_share.py
@@ -1,0 +1,317 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Verify + lock Gemma 4 cross-layer KV-sharing.
+
+Cross-layer KV-sharing (Gemma-3n / Gemma-4) already ships in the vendored
+text stack (``vllm_mlx/models/gemma4_vendored/language.py``, since 0.10.1):
+the last ``num_kv_shared_layers`` decoder layers are "borrowers" that compute
+no K/V and reuse the last same-type producer layer's K/V. ``make_cache()``
+therefore returns a *producer-only* cache list (borrowers get no cache
+object), which is where the prefill/TTFT win comes from.
+
+Nothing in the tree asserted this held, so a future refactor that
+"normalizes" ``make_cache()`` back to one-cache-per-layer would silently
+break the borrow with zero coverage — and a checkpoint whose ``config.json``
+sets ``num_kv_shared_layers=0`` would silently pay full per-layer prefill.
+
+These tests lock both:
+
+* the load-time guard ``_check_kv_share_config`` (WARN on inactive, RAISE on
+  malformed, DEBUG on active), and
+* the producer→borrower map + ``make_cache()`` length for all 5 Gemma 4
+  size shapes (E2B / E4B / 12B / 26B-A4B / 31B), using their real
+  ``num_hidden_layers`` / ``num_kv_shared_layers`` values (no weights loaded).
+
+Real config values (from the mlx-community ``config.json`` ``text_config``
+blocks, confirmed 2026-07-13):
+
+    size       num_hidden_layers  num_kv_shared_layers
+    E2B        35                 20
+    E4B        42                 18
+    12B        48                  0   (dense — no sharing, by design)
+    26B-A4B    30                  0   (dense/MoE — no sharing, by design)
+    31B        60                  0   (dense — no sharing, by design)
+
+Only the Gemma-3n-lineage E-series (E2B / E4B) shares K/V; the dense large
+sizes ship ``num_kv_shared_layers=0`` and never borrow. The guard WARNs (not
+raises) on the ``0`` case precisely because it is legitimate for those sizes.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+
+import pytest
+
+from vllm_mlx.models.gemma4_text import _check_kv_share_config
+from vllm_mlx.models.gemma4_vendored.config import TextConfig
+from vllm_mlx.models.gemma4_vendored.language import LanguageModel
+
+# (size label, num_hidden_layers, num_kv_shared_layers)
+GEMMA4_SIZES = [
+    ("E2B", 35, 20),
+    ("E4B", 42, 18),
+    ("12B", 48, 0),
+    ("26B-A4B", 30, 0),
+    ("31B", 60, 0),
+]
+
+
+def _build_text_config(num_hidden_layers: int, num_kv_shared_layers: int) -> TextConfig:
+    """Construct a vendored ``TextConfig`` for a given size shape.
+
+    Only the fields that drive the producer/borrower split matter here; the
+    rest keep their E2B-shaped dataclass defaults. ``layer_types`` is derived
+    by ``__post_init__`` from ``sliding_window_pattern`` (4 sliding + 1 full),
+    matching how the real checkpoints interleave attention types.
+    """
+    return TextConfig.from_dict(
+        {
+            "num_hidden_layers": num_hidden_layers,
+            "num_kv_shared_layers": num_kv_shared_layers,
+        }
+    )
+
+
+def _expected_previous_kvs(tc: TextConfig) -> list[int]:
+    """Ground-truth borrower→producer map, computed independently of the
+    code under test.
+
+    Producers are layers ``[0, M)`` where ``M = num_hidden_layers -
+    num_kv_shared_layers``. Each borrower ``j >= M`` reuses the K/V of the
+    LAST producer of the SAME ``layer_type`` (full vs sliding). Producer
+    layers map to themselves (identity).
+    """
+    n = tc.num_hidden_layers
+    m = n - (tc.num_kv_shared_layers or 0)
+    prev = list(range(n))  # identity by default (producers)
+    if tc.num_kv_shared_layers:
+        last_of_type: dict[str, int] = {}
+        for i in range(m):
+            last_of_type[tc.layer_types[i]] = i
+        for j in range(m, n):
+            prev[j] = last_of_type[tc.layer_types[j]]
+    return prev
+
+
+# --------------------------------------------------------------------------
+# 1. Load-time guard ``_check_kv_share_config``
+# --------------------------------------------------------------------------
+
+
+def test_guard_active_logs_debug(caplog):
+    """0 < num_kv_shared_layers < num_hidden_layers → sharing active, DEBUG."""
+    tc = _build_text_config(35, 20)
+    with caplog.at_level(logging.DEBUG, logger="vllm_mlx.models.gemma4_text"):
+        _check_kv_share_config(
+            {"num_hidden_layers": 35, "num_kv_shared_layers": 20}, tc, "test/e2b"
+        )
+    text = caplog.text
+    assert "KV-sharing ACTIVE" in text
+    assert "15 producer" in text  # 35 - 20
+    assert "20 borrower" in text
+    # No WARNING, no raise.
+    assert not any(r.levelno >= logging.WARNING for r in caplog.records)
+
+
+def test_guard_explicit_zero_warns(caplog):
+    """num_kv_shared_layers=0 (real 12B/26B/31B case) → WARNING, no raise."""
+    tc = _build_text_config(48, 0)
+    with caplog.at_level(logging.WARNING, logger="vllm_mlx.models.gemma4_text"):
+        _check_kv_share_config(
+            {"num_hidden_layers": 48, "num_kv_shared_layers": 0}, tc, "test/12b"
+        )
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warnings) == 1
+    msg = warnings[0].getMessage()
+    assert "KV-sharing INACTIVE" in msg
+    assert "test/12b" in msg
+    assert "num_kv_shared_layers=0" in msg
+
+
+def test_guard_absent_key_defaults_to_active(caplog):
+    """An absent key is filled by the dataclass default (20) → the model IS
+    built with 20 borrowers, so the guard truthfully reports ACTIVE and notes
+    that the default was applied. (``from_dict`` masks absence — the guard
+    keys severity off the value the model is actually built from.)"""
+    tc = _build_text_config_absent(35)
+    assert tc.num_kv_shared_layers == 20  # dataclass default masks absence
+    with caplog.at_level(logging.DEBUG, logger="vllm_mlx.models.gemma4_text"):
+        _check_kv_share_config({"num_hidden_layers": 35}, tc, "test/absent")
+    text = caplog.text
+    assert "KV-sharing ACTIVE" in text
+    assert "checkpoint omitted the key" in text
+
+
+def _build_text_config_absent(num_hidden_layers: int) -> TextConfig:
+    """TextConfig from a dict that OMITS num_kv_shared_layers entirely."""
+    return TextConfig.from_dict({"num_hidden_layers": num_hidden_layers})
+
+
+@pytest.mark.parametrize("bad", [-1, 35, 100])
+def test_guard_invalid_raises(bad):
+    """num_kv_shared_layers < 0 or >= num_hidden_layers → ValueError."""
+    # Build the config bypassing __post_init__'s reliance on the value being
+    # sane; the guard reads tc.num_kv_shared_layers directly.
+    tc = _build_text_config(35, max(bad, 0))
+    tc.num_kv_shared_layers = bad
+    with pytest.raises(ValueError, match="KV-sharing config INVALID"):
+        _check_kv_share_config(
+            {"num_hidden_layers": 35, "num_kv_shared_layers": bad}, tc, "test/bad"
+        )
+
+
+def test_guard_skips_unknown_shape():
+    """Missing/zero num_hidden_layers → no-op (nothing to reason about)."""
+
+    class _Stub:
+        num_hidden_layers = 0
+        num_kv_shared_layers = 0
+
+    # Must not raise and must not log anything actionable.
+    _check_kv_share_config({}, _Stub(), "test/unknown")
+
+
+# --------------------------------------------------------------------------
+# 2. Producer map + make_cache() length across all 5 size shapes
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("label,n_hidden,n_shared", GEMMA4_SIZES)
+def test_make_cache_producer_only_length(label, n_hidden, n_shared):
+    """``make_cache()`` returns exactly ``num_hidden_layers -
+    num_kv_shared_layers`` cache objects — producer-only, borrowers get none.
+
+    For dense sizes (n_shared == 0) that means one cache per layer (no
+    borrowing) — which is correct: those checkpoints do not share.
+    """
+    tc = _build_text_config(n_hidden, n_shared)
+    lm = LanguageModel(tc)
+    caches = lm.make_cache()
+
+    expected_producers = n_hidden - n_shared
+    assert lm.model.first_kv_shared_layer_idx == expected_producers, label
+    assert len(caches) == expected_producers, (
+        f"{label}: make_cache() returned {len(caches)} cache objs, "
+        f"expected {expected_producers} (= {n_hidden} - {n_shared})"
+    )
+    if n_shared > 0:
+        # Sharing sizes: strictly fewer caches than layers.
+        assert len(caches) < len(lm.model.layers), label
+    else:
+        # Dense sizes: one cache per layer, no borrowing.
+        assert len(caches) == len(lm.model.layers), label
+
+
+@pytest.mark.parametrize("label,n_hidden,n_shared", GEMMA4_SIZES)
+def test_borrower_maps_to_last_same_type_producer(label, n_hidden, n_shared):
+    """Each borrower reuses the last same-type (full vs sliding) producer's
+    K/V; producers map to themselves. Compares the model's built
+    ``previous_kvs`` against an independently computed ground truth."""
+    tc = _build_text_config(n_hidden, n_shared)
+    lm = LanguageModel(tc)
+
+    expected = _expected_previous_kvs(tc)
+    assert lm.model.previous_kvs == expected, (
+        f"{label}: previous_kvs mismatch\n"
+        f"  got     ={lm.model.previous_kvs}\n"
+        f"  expected={expected}"
+    )
+
+    # Cross-check the semantic property directly for every borrower.
+    m = n_hidden - n_shared
+    for j in range(m, n_hidden):
+        producer = lm.model.previous_kvs[j]
+        assert producer < m, f"{label}: borrower {j} maps to non-producer {producer}"
+        assert lm.model.layers[producer].layer_type == lm.model.layers[j].layer_type, (
+            f"{label}: borrower {j} type mismatch with producer {producer}"
+        )
+        # It is the LAST same-type producer below the split.
+        later_same_type = [
+            i
+            for i in range(producer + 1, m)
+            if lm.model.layers[i].layer_type == lm.model.layers[j].layer_type
+        ]
+        assert not later_same_type, (
+            f"{label}: borrower {j} should map to the LAST same-type producer, "
+            f"but producers {later_same_type} come after {producer}"
+        )
+
+
+def test_e2b_borrow_is_active_smoke():
+    """E2B default shape: borrow is structurally active (the shipped
+    behaviour). Guards the mlx-lm ``make_cache`` deferral contract — if a
+    future edit made make_cache() return one-cache-per-layer, this fails."""
+    tc = TextConfig()  # default == E2B (35 layers, 20 shared)
+    lm = LanguageModel(tc)
+    caches = lm.make_cache()
+    assert len(caches) == 15 < len(lm.model.layers) == 35
+    # Both a full-attention and a sliding-attention producer feed the top block.
+    borrower_producers = {lm.model.previous_kvs[j] for j in range(15, 35)}
+    producer_types = {lm.model.layers[p].layer_type for p in borrower_producers}
+    assert producer_types == {"full_attention", "sliding_attention"}
+
+
+# --------------------------------------------------------------------------
+# 3. Guard fires on the real load path
+# --------------------------------------------------------------------------
+
+
+def _write_gemma4_config(tmp_path, num_kv_shared_layers, num_hidden_layers=2):
+    layer_types = (["sliding_attention"] * (num_hidden_layers - 1)) + ["full_attention"]
+    cfg = {
+        "model_type": "gemma4",
+        "text_config": {
+            "hidden_size": 16,
+            "num_hidden_layers": num_hidden_layers,
+            "intermediate_size": 32,
+            "num_attention_heads": 2,
+            "num_key_value_heads": 1,
+            "head_dim": 8,
+            "global_head_dim": 8,
+            "vocab_size": 32,
+            "vocab_size_per_layer_input": 32,
+            "hidden_size_per_layer_input": 0,
+            "num_kv_shared_layers": num_kv_shared_layers,
+            "sliding_window_pattern": 2,
+            "layer_types": layer_types,
+            "use_double_wide_mlp": False,
+        },
+    }
+    (tmp_path / "config.json").write_text(json.dumps(cfg))
+    return tmp_path
+
+
+def test_loader_warns_on_inactive_sharing(tmp_path, caplog):
+    """Through the real ``load_gemma4_text`` path, a config with
+    ``num_kv_shared_layers=0`` emits the INACTIVE warning before the loader
+    reaches the (absent) weight files."""
+    from vllm_mlx.models.gemma4_text import load_gemma4_text
+
+    model_dir = _write_gemma4_config(tmp_path, num_kv_shared_layers=0)
+    # No safetensors present → loader raises FileNotFoundError AFTER the guard
+    # has already run and logged.
+    with (
+        caplog.at_level(logging.WARNING, logger="vllm_mlx.models.gemma4_text"),
+        pytest.raises(FileNotFoundError),
+    ):
+        load_gemma4_text(model_dir, None)
+    assert any(
+        "KV-sharing INACTIVE" in r.getMessage()
+        for r in caplog.records
+        if r.levelno == logging.WARNING
+    ), "loader did not emit the INACTIVE warning for num_kv_shared_layers=0"
+
+
+def test_loader_raises_on_malformed_split(tmp_path):
+    """Through the real load path, a config with num_kv_shared_layers >=
+    num_hidden_layers raises the malformed-config ValueError (before the
+    weight-file check)."""
+    from vllm_mlx.models.gemma4_text import load_gemma4_text
+
+    # 2 layers, 2 shared → invalid (no producers).
+    model_dir = _write_gemma4_config(
+        tmp_path, num_kv_shared_layers=2, num_hidden_layers=2
+    )
+    with pytest.raises(ValueError, match="KV-sharing config INVALID"):
+        load_gemma4_text(model_dir, None)

--- a/tests/test_gemma4_kv_share.py
+++ b/tests/test_gemma4_kv_share.py
@@ -192,6 +192,38 @@ def test_guard_none_shared_is_inactive(caplog):
     assert not any(r.levelno >= logging.WARNING for r in caplog.records)
 
 
+def test_guard_none_writeback_lets_model_build():
+    """None num_kv_shared_layers is normalized to 0 IN PLACE on tc, so the
+    subsequent LanguageModel(tc) build sees a plain int and does not raise a
+    TypeError in its ``num_hidden - num_kv_shared_layers`` producer split."""
+    tc = _build_text_config(35, 20)
+    tc.num_kv_shared_layers = None
+    _check_kv_share_config(
+        {"num_hidden_layers": 35, "num_kv_shared_layers": None}, tc, "test/none"
+    )
+    assert tc.num_kv_shared_layers == 0  # written back
+    # The model must now build without a TypeError.
+    lm = LanguageModel(tc)
+    assert lm.model.first_kv_shared_layer_idx == 35  # no borrowers
+
+
+def test_guard_active_requires_usable_layer_types():
+    """Sharing on but layer_types missing/wrong-length → ValueError (cannot
+    establish the producer→borrower map), NOT a bare ACTIVE log."""
+    tc = _build_text_config(35, 20)
+    tc.layer_types = None
+    with pytest.raises(ValueError, match="layer_types is missing or"):
+        _check_kv_share_config(
+            {"num_hidden_layers": 35, "num_kv_shared_layers": 20}, tc, "test/nolt"
+        )
+    tc2 = _build_text_config(35, 20)
+    tc2.layer_types = ["full_attention"] * 10  # wrong length
+    with pytest.raises(ValueError, match="wrong length"):
+        _check_kv_share_config(
+            {"num_hidden_layers": 35, "num_kv_shared_layers": 20}, tc2, "test/shortlt"
+        )
+
+
 def test_guard_orphan_borrower_type_raises():
     """A borrower attention type with no producer of that type below the split
     is a malformed layer_types layout → ValueError (borrower has nothing to
@@ -300,6 +332,38 @@ def test_e2b_borrow_is_active_smoke():
     borrower_producers = {lm.model.previous_kvs[j] for j in range(15, 35)}
     producer_types = {lm.model.layers[p].layer_type for p in borrower_producers}
     assert producer_types == {"full_attention", "sliding_attention"}
+
+
+def _assert_e2b_active_sharing(cfg_cls, model_cls):
+    """Build an E2B-shape (35/20) model with the given class pair and assert
+    make_cache() is producer-only (borrow active). Works for both the upstream
+    mlx-vlm and the vendored class implementations."""
+    tc = cfg_cls.from_dict({"num_hidden_layers": 35, "num_kv_shared_layers": 20})
+    lm = model_cls(tc)
+    caches = lm.make_cache()
+    assert len(caches) == 15, (
+        f"{model_cls.__module__}: make_cache() returned {len(caches)} caches, "
+        "expected 15 (producer-only) — borrow is NOT active"
+    )
+    assert lm.model.first_kv_shared_layer_idx == 15
+    assert len(caches) < len(lm.model.layers) == 35
+
+
+def test_resolved_load_path_borrow_active():
+    """Exercise the SAME class resolution production uses
+    (``_resolve_gemma4_text_classes`` — upstream mlx-vlm when installed, else
+    vendored). If the class production actually loads ever stops sharing, this
+    fails — the vendored-only tests above would not catch that."""
+    from vllm_mlx.models.gemma4_text import _resolve_gemma4_text_classes
+
+    cfg_cls, model_cls = _resolve_gemma4_text_classes()
+    _assert_e2b_active_sharing(cfg_cls, model_cls)
+
+
+def test_vendored_fallback_borrow_active():
+    """The fresh-install path (no mlx-vlm ``[vision]`` extra) must also keep
+    borrow active. Force the vendored branch regardless of what is installed."""
+    _assert_e2b_active_sharing(TextConfig, LanguageModel)
 
 
 # --------------------------------------------------------------------------

--- a/tests/test_gemma4_kv_share.py
+++ b/tests/test_gemma4_kv_share.py
@@ -348,10 +348,12 @@ def test_borrower_maps_to_last_same_type_producer(label, n_hidden, n_shared):
 
 
 def test_e2b_borrow_is_active_smoke():
-    """E2B default shape: borrow is structurally active (the shipped
-    behaviour). Guards the mlx-lm ``make_cache`` deferral contract — if a
-    future edit made make_cache() return one-cache-per-layer, this fails."""
-    tc = TextConfig()  # default == E2B (35 layers, 20 shared)
+    """E2B shape (35 layers / 20 shared): borrow is structurally active (the
+    shipped behaviour). Guards the mlx-lm ``make_cache`` deferral contract — if
+    a future edit made make_cache() return one-cache-per-layer, this fails.
+    Uses the tiny-dim builder so it doesn't allocate the full 262144x1536
+    embedding."""
+    tc = _build_text_config(35, 20)  # E2B topology, tiny dims
     lm = LanguageModel(tc)
     caches = lm.make_cache()
     assert len(caches) == 15 < len(lm.model.layers) == 35

--- a/tests/test_gemma4_kv_share.py
+++ b/tests/test_gemma4_kv_share.py
@@ -194,31 +194,36 @@ def test_guard_non_int_shared_raises(bad):
         )
 
 
-def test_guard_none_shared_is_inactive(caplog):
-    """num_kv_shared_layers=None normalizes to 0 (inactive) → INFO, no raise."""
+def test_guard_none_falls_back_to_dataclass_default(caplog):
+    """num_kv_shared_layers=None (explicit null / absent) → the config dataclass
+    DEFAULT (20 for the vendored TextConfig), NOT a forced 0. Forcing 0 would
+    turn a shared-KV checkpoint's borrowers into producers and change its
+    architecture; the least-surprising fallback is the same default an absent
+    key already gets. So None → ACTIVE (20 borrowers here)."""
     tc = _build_text_config(35, 20)
     tc.num_kv_shared_layers = None
-    with caplog.at_level(logging.INFO, logger="vllm_mlx.models.gemma4_text"):
+    with caplog.at_level(logging.DEBUG, logger="vllm_mlx.models.gemma4_text"):
         _check_kv_share_config(
             {"num_hidden_layers": 35, "num_kv_shared_layers": None}, tc, "test/none"
         )
-    assert "KV-sharing INACTIVE" in caplog.text
+    assert "KV-sharing ACTIVE" in caplog.text
+    assert "checkpoint omitted the key" in caplog.text  # not explicitly specified
     assert not any(r.levelno >= logging.WARNING for r in caplog.records)
 
 
 def test_guard_none_writeback_lets_model_build():
-    """None num_kv_shared_layers is normalized to 0 IN PLACE on tc, so the
-    subsequent LanguageModel(tc) build sees a plain int and does not raise a
-    TypeError in its ``num_hidden - num_kv_shared_layers`` producer split."""
+    """None num_kv_shared_layers is normalized IN PLACE on tc to the dataclass
+    default (an int), so the subsequent LanguageModel(tc) build sees a plain
+    int and does not raise a TypeError in its producer-split computation."""
     tc = _build_text_config(35, 20)
     tc.num_kv_shared_layers = None
     _check_kv_share_config(
         {"num_hidden_layers": 35, "num_kv_shared_layers": None}, tc, "test/none"
     )
-    assert tc.num_kv_shared_layers == 0  # written back
+    assert tc.num_kv_shared_layers == 20  # written back to the dataclass default
     # The model must now build without a TypeError.
     lm = LanguageModel(tc)
-    assert lm.model.first_kv_shared_layer_idx == 35  # no borrowers
+    assert lm.model.first_kv_shared_layer_idx == 15  # 35 - 20
 
 
 def test_guard_active_requires_usable_layer_types():
@@ -392,6 +397,17 @@ def _assert_e2b_active_sharing(cfg_cls, model_cls):
     )
     assert lm.model.first_kv_shared_layer_idx == 15
     assert len(caches) < len(lm.model.layers) == 35
+
+    # Also validate the borrower→producer mapping on THIS class (not just the
+    # cache count): every borrower must reuse the last same-type producer below
+    # the split. A resolved upstream impl with a wrong previous_kvs mapping
+    # would pass the count check but produce wrong attention — this catches it.
+    expected = _expected_previous_kvs(tc)
+    assert list(lm.model.previous_kvs) == expected, (
+        f"{model_cls.__module__}: previous_kvs mismatch\n"
+        f"  got     ={list(lm.model.previous_kvs)}\n"
+        f"  expected={expected}"
+    )
     return tc
 
 

--- a/tests/test_gemma4_kv_share.py
+++ b/tests/test_gemma4_kv_share.py
@@ -6,16 +6,18 @@ text stack (``vllm_mlx/models/gemma4_vendored/language.py``, since 0.10.1):
 the last ``num_kv_shared_layers`` decoder layers are "borrowers" that compute
 no K/V and reuse the last same-type producer layer's K/V. ``make_cache()``
 therefore returns a *producer-only* cache list (borrowers get no cache
-object), which is where the prefill/TTFT win comes from.
+object) — which reduces the resident KV cache (measured ~2.3x smaller
+footprint on gemma-4-e2b-4bit; the prefill/TTFT wall-time delta was ~1.0x on
+that size, so the demonstrated benefit is memory, not decode speed).
 
 Nothing in the tree asserted this held, so a future refactor that
 "normalizes" ``make_cache()`` back to one-cache-per-layer would silently
 break the borrow with zero coverage — and a checkpoint whose ``config.json``
-sets ``num_kv_shared_layers=0`` would silently pay full per-layer prefill.
+sets ``num_kv_shared_layers=0`` would silently lose the KV-memory reduction.
 
 These tests lock both:
 
-* the load-time guard ``_check_kv_share_config`` (WARN on inactive, RAISE on
+* the load-time guard ``_check_kv_share_config`` (INFO on inactive, RAISE on
   malformed, DEBUG on active), and
 * the producer→borrower map + ``make_cache()`` length for all 5 Gemma 4
   size shapes (E2B / E4B / 12B / 26B-A4B / 31B), using their real
@@ -32,8 +34,9 @@ blocks, confirmed 2026-07-13):
     31B        60                  0   (dense — no sharing, by design)
 
 Only the Gemma-3n-lineage E-series (E2B / E4B) shares K/V; the dense large
-sizes ship ``num_kv_shared_layers=0`` and never borrow. The guard WARNs (not
-raises) on the ``0`` case precisely because it is legitimate for those sizes.
+sizes ship ``num_kv_shared_layers=0`` and never borrow. The guard logs the
+``0`` case at INFO (not WARNING, not raise) precisely because it is
+legitimate — and the common case — for those dense sizes.
 """
 
 from __future__ import annotations
@@ -114,19 +117,23 @@ def test_guard_active_logs_debug(caplog):
     assert not any(r.levelno >= logging.WARNING for r in caplog.records)
 
 
-def test_guard_explicit_zero_warns(caplog):
-    """num_kv_shared_layers=0 (real 12B/26B/31B case) → WARNING, no raise."""
+def test_guard_explicit_zero_logs_info_not_warning(caplog):
+    """num_kv_shared_layers=0 (real 12B/26B/31B case) → INFO, not WARNING, no
+    raise. The dense sizes legitimately ship 0 and are the common case, so a
+    WARNING on every such load would be a false-positive alert."""
     tc = _build_text_config(48, 0)
-    with caplog.at_level(logging.WARNING, logger="vllm_mlx.models.gemma4_text"):
+    with caplog.at_level(logging.INFO, logger="vllm_mlx.models.gemma4_text"):
         _check_kv_share_config(
             {"num_hidden_layers": 48, "num_kv_shared_layers": 0}, tc, "test/12b"
         )
-    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
-    assert len(warnings) == 1
-    msg = warnings[0].getMessage()
+    infos = [r for r in caplog.records if r.levelno == logging.INFO]
+    assert len(infos) == 1
+    msg = infos[0].getMessage()
     assert "KV-sharing INACTIVE" in msg
     assert "test/12b" in msg
     assert "num_kv_shared_layers=0" in msg
+    # Explicitly NOT a warning — no false-positive production alert.
+    assert not any(r.levelno >= logging.WARNING for r in caplog.records)
 
 
 def test_guard_absent_key_defaults_to_active(caplog):
@@ -158,6 +165,49 @@ def test_guard_invalid_raises(bad):
     with pytest.raises(ValueError, match="KV-sharing config INVALID"):
         _check_kv_share_config(
             {"num_hidden_layers": 35, "num_kv_shared_layers": bad}, tc, "test/bad"
+        )
+
+
+@pytest.mark.parametrize("bad", ["20", 3.5, [], True])
+def test_guard_non_int_shared_raises(bad):
+    """A non-int (or bool) num_kv_shared_layers is a malformed config → clear
+    ValueError, not an incidental TypeError from the range comparison."""
+    tc = _build_text_config(35, 20)
+    tc.num_kv_shared_layers = bad
+    with pytest.raises(ValueError, match="KV-sharing config INVALID"):
+        _check_kv_share_config(
+            {"num_hidden_layers": 35, "num_kv_shared_layers": bad}, tc, "test/badtype"
+        )
+
+
+def test_guard_none_shared_is_inactive(caplog):
+    """num_kv_shared_layers=None normalizes to 0 (inactive) → INFO, no raise."""
+    tc = _build_text_config(35, 20)
+    tc.num_kv_shared_layers = None
+    with caplog.at_level(logging.INFO, logger="vllm_mlx.models.gemma4_text"):
+        _check_kv_share_config(
+            {"num_hidden_layers": 35, "num_kv_shared_layers": None}, tc, "test/none"
+        )
+    assert "KV-sharing INACTIVE" in caplog.text
+    assert not any(r.levelno >= logging.WARNING for r in caplog.records)
+
+
+def test_guard_orphan_borrower_type_raises():
+    """A borrower attention type with no producer of that type below the split
+    is a malformed layer_types layout → ValueError (borrower has nothing to
+    borrow)."""
+    tc = _build_text_config(4, 2)
+    # 2 producers, 2 borrowers. Make the only full_attention layer a borrower
+    # so the full-attention borrower has no full-attention producer.
+    tc.layer_types = [
+        "sliding_attention",  # producer 0
+        "sliding_attention",  # producer 1
+        "full_attention",  # borrower 2 — no full producer below split!
+        "sliding_attention",  # borrower 3
+    ]
+    with pytest.raises(ValueError, match="have no producer layer of that type"):
+        _check_kv_share_config(
+            {"num_hidden_layers": 4, "num_kv_shared_layers": 2}, tc, "test/orphan"
         )
 
 
@@ -282,9 +332,9 @@ def _write_gemma4_config(tmp_path, num_kv_shared_layers, num_hidden_layers=2):
     return tmp_path
 
 
-def test_loader_warns_on_inactive_sharing(tmp_path, caplog):
+def test_loader_logs_inactive_sharing(tmp_path, caplog):
     """Through the real ``load_gemma4_text`` path, a config with
-    ``num_kv_shared_layers=0`` emits the INACTIVE warning before the loader
+    ``num_kv_shared_layers=0`` emits the INACTIVE INFO line before the loader
     reaches the (absent) weight files."""
     from vllm_mlx.models.gemma4_text import load_gemma4_text
 
@@ -292,15 +342,15 @@ def test_loader_warns_on_inactive_sharing(tmp_path, caplog):
     # No safetensors present → loader raises FileNotFoundError AFTER the guard
     # has already run and logged.
     with (
-        caplog.at_level(logging.WARNING, logger="vllm_mlx.models.gemma4_text"),
+        caplog.at_level(logging.INFO, logger="vllm_mlx.models.gemma4_text"),
         pytest.raises(FileNotFoundError),
     ):
         load_gemma4_text(model_dir, None)
     assert any(
         "KV-sharing INACTIVE" in r.getMessage()
         for r in caplog.records
-        if r.levelno == logging.WARNING
-    ), "loader did not emit the INACTIVE warning for num_kv_shared_layers=0"
+        if r.levelno == logging.INFO
+    ), "loader did not emit the INACTIVE info line for num_kv_shared_layers=0"
 
 
 def test_loader_raises_on_malformed_split(tmp_path):

--- a/tests/test_gemma4_kv_share.py
+++ b/tests/test_gemma4_kv_share.py
@@ -63,15 +63,29 @@ GEMMA4_SIZES = [
 def _build_text_config(num_hidden_layers: int, num_kv_shared_layers: int) -> TextConfig:
     """Construct a vendored ``TextConfig`` for a given size shape.
 
-    Only the fields that drive the producer/borrower split matter here; the
-    rest keep their E2B-shaped dataclass defaults. ``layer_types`` is derived
-    by ``__post_init__`` from ``sliding_window_pattern`` (4 sliding + 1 full),
+    Only the layer count + share count + ``layer_types`` topology drive the
+    producer/borrower split under test, so we shrink hidden/intermediate/vocab/
+    head dims to tiny consistent values. This keeps ``LanguageModel(tc)`` builds
+    (constructed by the make_cache / producer-map tests up to 60 layers) cheap
+    — the default E2B dims (hidden 1536, vocab 262144) would allocate a
+    262144x1536 embedding per build. ``layer_types`` is still derived by
+    ``__post_init__`` from ``sliding_window_pattern`` (4 sliding + 1 full),
     matching how the real checkpoints interleave attention types.
     """
     return TextConfig.from_dict(
         {
             "num_hidden_layers": num_hidden_layers,
             "num_kv_shared_layers": num_kv_shared_layers,
+            "hidden_size": 16,
+            "intermediate_size": 32,
+            "num_attention_heads": 2,
+            "num_key_value_heads": 1,
+            "head_dim": 8,
+            "global_head_dim": 8,
+            "vocab_size": 32,
+            "vocab_size_per_layer_input": 32,
+            "hidden_size_per_layer_input": 0,
+            "use_double_wide_mlp": False,
         }
     )
 
@@ -222,6 +236,19 @@ def test_guard_active_requires_usable_layer_types():
         _check_kv_share_config(
             {"num_hidden_layers": 35, "num_kv_shared_layers": 20}, tc2, "test/shortlt"
         )
+    # Non-string / unhashable entry → clear ValueError, not an incidental
+    # TypeError from the set() construction.
+    tc3 = _build_text_config(4, 2)
+    tc3.layer_types = [
+        "sliding_attention",
+        "full_attention",
+        ["oops"],
+        "sliding_attention",
+    ]
+    with pytest.raises(ValueError, match="must be a list of attention-type strings"):
+        _check_kv_share_config(
+            {"num_hidden_layers": 4, "num_kv_shared_layers": 2}, tc3, "test/badlt"
+        )
 
 
 def test_guard_orphan_borrower_type_raises():
@@ -337,8 +364,24 @@ def test_e2b_borrow_is_active_smoke():
 def _assert_e2b_active_sharing(cfg_cls, model_cls):
     """Build an E2B-shape (35/20) model with the given class pair and assert
     make_cache() is producer-only (borrow active). Works for both the upstream
-    mlx-vlm and the vendored class implementations."""
-    tc = cfg_cls.from_dict({"num_hidden_layers": 35, "num_kv_shared_layers": 20})
+    mlx-vlm and the vendored class implementations. Uses tiny hidden/vocab/head
+    dims (only the 35/20 topology matters) to keep the build cheap."""
+    tc = cfg_cls.from_dict(
+        {
+            "num_hidden_layers": 35,
+            "num_kv_shared_layers": 20,
+            "hidden_size": 16,
+            "intermediate_size": 32,
+            "num_attention_heads": 2,
+            "num_key_value_heads": 1,
+            "head_dim": 8,
+            "global_head_dim": 8,
+            "vocab_size": 32,
+            "vocab_size_per_layer_input": 32,
+            "hidden_size_per_layer_input": 0,
+            "use_double_wide_mlp": False,
+        }
+    )
     lm = model_cls(tc)
     caches = lm.make_cache()
     assert len(caches) == 15, (
@@ -347,17 +390,26 @@ def _assert_e2b_active_sharing(cfg_cls, model_cls):
     )
     assert lm.model.first_kv_shared_layer_idx == 15
     assert len(caches) < len(lm.model.layers) == 35
+    return tc
 
 
 def test_resolved_load_path_borrow_active():
     """Exercise the SAME class resolution production uses
     (``_resolve_gemma4_text_classes`` — upstream mlx-vlm when installed, else
     vendored). If the class production actually loads ever stops sharing, this
-    fails — the vendored-only tests above would not catch that."""
+    fails — the vendored-only tests above would not catch that. Also runs the
+    load-time guard on the resolved active config so the guard cannot silently
+    reject the upstream TextConfig shape production resolves."""
     from vllm_mlx.models.gemma4_text import _resolve_gemma4_text_classes
 
     cfg_cls, model_cls = _resolve_gemma4_text_classes()
-    _assert_e2b_active_sharing(cfg_cls, model_cls)
+    tc = _assert_e2b_active_sharing(cfg_cls, model_cls)
+    # Guard must ACCEPT the resolved active config (no raise) and log ACTIVE.
+    _check_kv_share_config(
+        {"num_hidden_layers": 35, "num_kv_shared_layers": 20},
+        tc,
+        "test/resolved-e2b",
+    )
 
 
 def test_vendored_fallback_borrow_active():

--- a/tests/test_gemma4_kv_share.py
+++ b/tests/test_gemma4_kv_share.py
@@ -194,34 +194,32 @@ def test_guard_non_int_shared_raises(bad):
         )
 
 
-def test_guard_none_falls_back_to_dataclass_default(caplog):
-    """num_kv_shared_layers=None (explicit null / absent) → the config dataclass
-    DEFAULT (20 for the vendored TextConfig), NOT a forced 0. Forcing 0 would
-    turn a shared-KV checkpoint's borrowers into producers and change its
-    architecture; the least-surprising fallback is the same default an absent
-    key already gets. So None → ACTIVE (20 borrowers here)."""
+def test_guard_explicit_null_raises():
+    """An EXPLICIT ``num_kv_shared_layers: null`` in the config dict is
+    malformed → ValueError. We must not guess a size-specific value (forcing
+    the default would give e.g. E4B 20 borrowers instead of 18)."""
+    tc = _build_text_config(35, 20)
+    tc.num_kv_shared_layers = None
+    with pytest.raises(ValueError, match="explicitly null"):
+        _check_kv_share_config(
+            {"num_hidden_layers": 35, "num_kv_shared_layers": None}, tc, "test/null"
+        )
+
+
+def test_guard_absent_key_with_none_field_uses_default(caplog):
+    """When the key is ABSENT from the config dict but the dataclass field is
+    ``None`` (e.g. a class whose default is None), fall back to the dataclass
+    DEFAULT — the legitimate "checkpoint didn't override the default" path. Not
+    the explicit-null case (that raises)."""
     tc = _build_text_config(35, 20)
     tc.num_kv_shared_layers = None
     with caplog.at_level(logging.DEBUG, logger="vllm_mlx.models.gemma4_text"):
-        _check_kv_share_config(
-            {"num_hidden_layers": 35, "num_kv_shared_layers": None}, tc, "test/none"
-        )
-    assert "KV-sharing ACTIVE" in caplog.text
-    assert "checkpoint omitted the key" in caplog.text  # not explicitly specified
-    assert not any(r.levelno >= logging.WARNING for r in caplog.records)
-
-
-def test_guard_none_writeback_lets_model_build():
-    """None num_kv_shared_layers is normalized IN PLACE on tc to the dataclass
-    default (an int), so the subsequent LanguageModel(tc) build sees a plain
-    int and does not raise a TypeError in its producer-split computation."""
-    tc = _build_text_config(35, 20)
-    tc.num_kv_shared_layers = None
-    _check_kv_share_config(
-        {"num_hidden_layers": 35, "num_kv_shared_layers": None}, tc, "test/none"
-    )
+        # dict OMITS the key → absent, not explicit null.
+        _check_kv_share_config({"num_hidden_layers": 35}, tc, "test/absentnone")
     assert tc.num_kv_shared_layers == 20  # written back to the dataclass default
-    # The model must now build without a TypeError.
+    assert "KV-sharing ACTIVE" in caplog.text
+    assert "checkpoint omitted the key" in caplog.text
+    # Model must build without a TypeError on the (now int) value.
     lm = LanguageModel(tc)
     assert lm.model.first_kv_shared_layer_idx == 15  # 35 - 20
 
@@ -275,15 +273,18 @@ def test_guard_orphan_borrower_type_raises():
         )
 
 
-def test_guard_skips_unknown_shape():
-    """Missing/zero num_hidden_layers → no-op (nothing to reason about)."""
+@pytest.mark.parametrize("bad_hidden", [0, -1, None, "35", True])
+def test_guard_invalid_num_hidden_raises(bad_hidden):
+    """A malformed num_hidden_layers (0, negative, None, string, bool) is a
+    broken config → clear ValueError, not a silent skip that lets the model
+    build fail cryptically or produce an empty stack."""
 
     class _Stub:
-        num_hidden_layers = 0
+        num_hidden_layers = bad_hidden
         num_kv_shared_layers = 0
 
-    # Must not raise and must not log anything actionable.
-    _check_kv_share_config({}, _Stub(), "test/unknown")
+    with pytest.raises(ValueError, match="num_hidden_layers"):
+        _check_kv_share_config({}, _Stub(), "test/badhidden")
 
 
 # --------------------------------------------------------------------------

--- a/vllm_mlx/models/gemma4_text.py
+++ b/vllm_mlx/models/gemma4_text.py
@@ -552,6 +552,16 @@ def _check_kv_share_config(text_config: dict, tc, model_id: str) -> None:
     else:
         num_shared = raw_shared
 
+    # Write the normalized value back onto ``tc`` so the subsequent
+    # ``LanguageModel(tc)`` build sees a plain int (its producer-split math
+    # ``num_hidden - num_kv_shared_layers`` would otherwise raise a cryptic
+    # ``TypeError`` on a ``None`` that reached it via an explicit config null).
+    if raw_shared is not num_shared:
+        try:
+            tc.num_kv_shared_layers = num_shared
+        except Exception:
+            pass
+
     if num_shared < 0 or num_shared >= num_hidden:
         raise ValueError(
             f"Gemma 4 KV-sharing config INVALID for {model_id}: "
@@ -571,22 +581,35 @@ def _check_kv_share_config(text_config: dict, tc, model_id: str) -> None:
         )
         return
 
-    # 0 < num_shared < num_hidden → sharing candidate. Verify every borrower
-    # attention type actually has a producer of that type below the split;
-    # otherwise a borrower would have nothing to borrow (malformed layer_types).
+    # 0 < num_shared < num_hidden → sharing candidate. Active sharing REQUIRES
+    # a usable ``layer_types`` (one entry per layer): the producer→borrower map
+    # is built by matching each borrower's attention type to the last same-type
+    # producer. Without it we cannot establish that map, so declaring sharing
+    # ACTIVE would be unfounded — raise instead of logging a claim we did not
+    # validate. (The dataclass ``__post_init__`` always derives ``layer_types``;
+    # a missing/short one is a genuinely malformed config.)
     layer_types = getattr(tc, "layer_types", None)
     num_producers = num_hidden - num_shared
-    if isinstance(layer_types, (list, tuple)) and len(layer_types) == num_hidden:
-        producer_types = set(layer_types[:num_producers])
-        borrower_types = set(layer_types[num_producers:])
-        orphan_types = borrower_types - producer_types
-        if orphan_types:
-            raise ValueError(
-                f"Gemma 4 KV-sharing config INVALID for {model_id}: borrower "
-                f"attention type(s) {sorted(orphan_types)} have no producer "
-                f"layer of that type in the first {num_producers} layer(s). "
-                "This layer_types layout cannot share K/V correctly."
-            )
+    if not isinstance(layer_types, (list, tuple)) or len(layer_types) != num_hidden:
+        raise ValueError(
+            f"Gemma 4 KV-sharing config INVALID for {model_id}: sharing is on "
+            f"(num_kv_shared_layers={num_shared}) but layer_types is missing or "
+            f"the wrong length (need {num_hidden} entries, got "
+            f"{len(layer_types) if isinstance(layer_types, (list, tuple)) else layer_types!r}). "
+            "Cannot establish the producer→borrower map."
+        )
+    # Every borrower attention type must have a producer of that type below the
+    # split; otherwise a borrower would have nothing to borrow.
+    producer_types = set(layer_types[:num_producers])
+    borrower_types = set(layer_types[num_producers:])
+    orphan_types = borrower_types - producer_types
+    if orphan_types:
+        raise ValueError(
+            f"Gemma 4 KV-sharing config INVALID for {model_id}: borrower "
+            f"attention type(s) {sorted(orphan_types)} have no producer "
+            f"layer of that type in the first {num_producers} layer(s). "
+            "This layer_types layout cannot share K/V correctly."
+        )
 
     default_note = (
         ""

--- a/vllm_mlx/models/gemma4_text.py
+++ b/vllm_mlx/models/gemma4_text.py
@@ -478,6 +478,29 @@ def load_gemma4_text(model_path: str | Path, tokenizer_config: dict = None):
     )
 
 
+def _text_config_default_num_kv_shared(tc) -> int:
+    """The ``num_kv_shared_layers`` dataclass DEFAULT for ``tc``'s class.
+
+    Used when the checkpoint left the field unspecified (absent or explicit
+    ``null``): we fall back to the same default an absent key already receives
+    via ``from_dict`` rather than forcing 0, which would silently change a
+    shared-KV checkpoint's architecture. Robust across the upstream mlx-vlm and
+    vendored ``TextConfig`` dataclasses; returns 0 if the default cannot be
+    introspected (fail-safe: inactive rather than a wrong active split).
+    """
+    import dataclasses
+
+    try:
+        for f in dataclasses.fields(tc):
+            if f.name == "num_kv_shared_layers":
+                default = f.default
+                if isinstance(default, int) and not isinstance(default, bool):
+                    return default
+    except (TypeError, ValueError):
+        pass
+    return 0
+
+
 def _check_kv_share_config(text_config: dict, tc, model_id: str) -> None:
     """Guard Gemma 4 cross-layer KV-sharing at load time.
 
@@ -537,12 +560,20 @@ def _check_kv_share_config(text_config: dict, tc, model_id: str) -> None:
     key_present = "num_kv_shared_layers" in text_config
     raw_shared = getattr(tc, "num_kv_shared_layers", 0)
 
-    # Normalize: None / absent → 0 (sharing off). A non-int, non-None value
-    # (e.g. a string from malformed JSON) is itself a broken config — raise a
-    # clear error rather than letting the range comparison throw TypeError or
-    # silently coercing.
+    # Normalize the value the model will be built from.
+    #   * A plain non-negative int → used as-is.
+    #   * ``None`` (explicit JSON ``null`` OR an absent key that left the field
+    #     ``None``) → treated as "not specified": fall back to the config
+    #     dataclass DEFAULT for the field, NOT a hard 0. Forcing 0 would turn a
+    #     shared-KV checkpoint's borrower layers into producers and make the
+    #     model expect K/V projections the checkpoint doesn't ship. We cannot
+    #     know the size-specific correct value from config alone (that is the
+    #     checkpoint's job), so the least-surprising fallback is the same
+    #     default an absent key already gets via ``from_dict``.
+    #   * Anything else (string, list, float, bool) → malformed config → raise.
     if raw_shared is None:
-        num_shared = 0
+        num_shared = _text_config_default_num_kv_shared(tc)
+        key_present = False  # surface "not explicitly specified" in the log
     elif isinstance(raw_shared, bool) or not isinstance(raw_shared, int):
         raise ValueError(
             f"Gemma 4 KV-sharing config INVALID for {model_id}: "

--- a/vllm_mlx/models/gemma4_text.py
+++ b/vllm_mlx/models/gemma4_text.py
@@ -478,6 +478,92 @@ def load_gemma4_text(model_path: str | Path, tokenizer_config: dict = None):
     )
 
 
+def _check_kv_share_config(text_config: dict, tc, model_id: str) -> None:
+    """Guard Gemma 4 cross-layer KV-sharing at load time.
+
+    Gemma 3n / Gemma 4's last ``num_kv_shared_layers`` decoder layers are
+    "borrowers": they compute no K/V and reuse the last same-type producer
+    layer's K/V (split at ``num_hidden_layers - num_kv_shared_layers``). This
+    is the mechanism behind the prefill/TTFT win — see
+    ``models/gemma4_vendored/language.py`` (``make_cache`` returns a
+    producer-only cache list; borrowers get no cache object).
+
+    Severity is decided on ``tc.num_kv_shared_layers`` — the value the model
+    is actually built from (``LanguageModel(tc)`` uses it to split producers
+    from borrowers). The raw ``text_config`` dict is consulted only to enrich
+    the message (distinguish "checkpoint omitted the key, dataclass default
+    applied" from "checkpoint explicitly set 0"), because ``from_dict`` fills
+    an absent key with the dataclass default and thereby masks its absence.
+
+    Failure modes this guards against:
+
+    * ``tc.num_kv_shared_layers == 0`` → ``first_kv_shared`` equals
+      ``num_hidden_layers`` → NO layer borrows → every layer allocates its
+      own KV → the user silently pays a full per-layer prefill with no
+      cross-layer reuse. We WARN (do not hard-fail: the dense large Gemma 4
+      sizes — 12B / 26B-A4B / 31B — legitimately ship ``num_kv_shared_layers=0``
+      and never share; only the Gemma-3n-lineage E2B / E4B do). The WARNING
+      makes the "no cross-layer reuse" fact observable so a user can never
+      silently believe sharing is on when it is not.
+    * ``tc.num_kv_shared_layers`` invalid (``< 0`` or ``>= num_hidden_layers``)
+      → malformed config that would ask for at least as many borrowers as
+      there are layers (no producers, or an out-of-range split). We RAISE —
+      this is a broken checkpoint, not a silent degrade.
+    * ``0 < tc.num_kv_shared_layers < num_hidden_layers`` → sharing active;
+      log the producer/borrower split at debug.
+
+    Placed on the shared build path (``_load_gemma4_text_impl``) so it fires
+    for every Gemma 4 size and both loaders (``gemma4`` / ``gemma4_unified``),
+    regardless of whether ``resolve_classes`` returns the upstream mlx-vlm or
+    the vendored text classes (both expose ``num_hidden_layers`` /
+    ``num_kv_shared_layers`` on the dataclass ``TextConfig``).
+    """
+    num_hidden = getattr(tc, "num_hidden_layers", None)
+    if not isinstance(num_hidden, int) or num_hidden <= 0:
+        # Not a shape we can reason about; nothing to guard.
+        return
+
+    key_present = "num_kv_shared_layers" in text_config
+    num_shared = getattr(tc, "num_kv_shared_layers", 0) or 0
+
+    if num_shared < 0 or num_shared >= num_hidden:
+        raise ValueError(
+            f"Gemma 4 KV-sharing config INVALID for {model_id}: "
+            f"num_kv_shared_layers={num_shared} must satisfy "
+            f"0 <= num_kv_shared_layers < num_hidden_layers={num_hidden}. "
+            "This is a malformed checkpoint config (borrowers would exceed "
+            "producers, or the split would be out of range)."
+        )
+
+    if num_shared == 0:
+        logger.warning(
+            "Gemma 4 KV-sharing INACTIVE for %s: config sets "
+            "num_kv_shared_layers=0; prefill will not benefit from "
+            "cross-layer KV reuse (every layer allocates its own KV). This "
+            "is expected for the dense sizes (12B / 26B-A4B / 31B) and a "
+            "regression for the E-series (E2B / E4B).",
+            model_id,
+        )
+        return
+
+    # 0 < num_shared < num_hidden → sharing active.
+    num_producers = num_hidden - num_shared
+    default_note = (
+        ""
+        if key_present
+        else " (checkpoint omitted the key; dataclass default applied)"
+    )
+    logger.debug(
+        "[gemma4] KV-sharing ACTIVE for %s: %d producer layer(s) + "
+        "%d borrower layer(s) (first_kv_shared_layer_idx=%d)%s",
+        model_id,
+        num_producers,
+        num_shared,
+        num_producers,
+        default_note,
+    )
+
+
 def _load_gemma4_text_impl(
     model_path: str | Path,
     tokenizer_config: dict = None,
@@ -513,6 +599,12 @@ def _load_gemma4_text_impl(
     TextConfig, LanguageModel = resolve_classes()
 
     tc = TextConfig.from_dict(text_config)
+
+    # Guard cross-layer KV-sharing before building the model: warn if the
+    # checkpoint won't benefit (no/zero num_kv_shared_layers → silent
+    # double-prefill), raise on a malformed split. See _check_kv_share_config.
+    _check_kv_share_config(text_config, tc, str(model_path))
+
     language_model = LanguageModel(tc)
 
     # Wrap for mlx-lm compatibility

--- a/vllm_mlx/models/gemma4_text.py
+++ b/vllm_mlx/models/gemma4_text.py
@@ -548,28 +548,47 @@ def _check_kv_share_config(text_config: dict, tc, model_id: str) -> None:
     the vendored text classes (both expose ``num_hidden_layers`` /
     ``num_kv_shared_layers`` on the dataclass ``TextConfig``).
     """
+    # ``num_hidden_layers`` must be a positive, non-boolean int for any of the
+    # split math to make sense. A malformed value (0, negative, bool, string,
+    # None) is a broken config — raise the clear diagnostic here rather than
+    # letting the model build fail cryptically or silently produce an empty
+    # stack. (``bool`` is an ``int`` subclass in Python, so exclude it first.)
     num_hidden = getattr(tc, "num_hidden_layers", None)
-    if not isinstance(num_hidden, bool) and isinstance(num_hidden, int):
-        pass
-    else:
-        # Not a shape we can reason about; nothing to guard.
-        return
-    if num_hidden <= 0:
-        return
+    if (
+        isinstance(num_hidden, bool)
+        or not isinstance(num_hidden, int)
+        or num_hidden <= 0
+    ):
+        raise ValueError(
+            f"Gemma 4 config INVALID for {model_id}: num_hidden_layers="
+            f"{num_hidden!r} must be a positive integer."
+        )
 
     key_present = "num_kv_shared_layers" in text_config
+    raw_dict_val = text_config.get("num_kv_shared_layers", "__absent__")
     raw_shared = getattr(tc, "num_kv_shared_layers", 0)
+
+    # Reject an EXPLICIT JSON null: a config that writes ``num_kv_shared_layers:
+    # null`` is malformed (it can't declare a share count and leave it unset).
+    # We must not guess a size-specific value — forcing the class default would
+    # give E4B 20 borrowers instead of 18, or a dense model 20 instead of 0,
+    # silently changing its architecture. An ABSENT key is different: it keeps
+    # whatever the dataclass default already filled in via ``from_dict`` (the
+    # legitimate "checkpoint didn't override the default" case).
+    if key_present and raw_dict_val is None:
+        raise ValueError(
+            f"Gemma 4 KV-sharing config INVALID for {model_id}: "
+            "num_kv_shared_layers is explicitly null. A checkpoint must declare "
+            "a concrete share count (an int) or omit the key entirely; a null "
+            "value is malformed and cannot be resolved to a size-specific split."
+        )
 
     # Normalize the value the model will be built from.
     #   * A plain non-negative int → used as-is.
-    #   * ``None`` (explicit JSON ``null`` OR an absent key that left the field
-    #     ``None``) → treated as "not specified": fall back to the config
-    #     dataclass DEFAULT for the field, NOT a hard 0. Forcing 0 would turn a
-    #     shared-KV checkpoint's borrower layers into producers and make the
-    #     model expect K/V projections the checkpoint doesn't ship. We cannot
-    #     know the size-specific correct value from config alone (that is the
-    #     checkpoint's job), so the least-surprising fallback is the same
-    #     default an absent key already gets via ``from_dict``.
+    #   * ``None`` reaching here means the key was ABSENT (not explicit null,
+    #     handled above) and the dataclass field itself is ``None`` — fall back
+    #     to the config dataclass DEFAULT for the field, the same value an
+    #     absent key already gets via ``from_dict``.
     #   * Anything else (string, list, float, bool) → malformed config → raise.
     if raw_shared is None:
         num_shared = _text_config_default_num_kv_shared(tc)

--- a/vllm_mlx/models/gemma4_text.py
+++ b/vllm_mlx/models/gemma4_text.py
@@ -556,11 +556,18 @@ def _check_kv_share_config(text_config: dict, tc, model_id: str) -> None:
     # ``LanguageModel(tc)`` build sees a plain int (its producer-split math
     # ``num_hidden - num_kv_shared_layers`` would otherwise raise a cryptic
     # ``TypeError`` on a ``None`` that reached it via an explicit config null).
+    # If the writeback can't take (e.g. a frozen config), fail loudly here
+    # rather than let the model crash later on the unchanged value.
     if raw_shared is not num_shared:
         try:
             tc.num_kv_shared_layers = num_shared
-        except Exception:
-            pass
+        except Exception as exc:
+            raise ValueError(
+                f"Gemma 4 KV-sharing config for {model_id}: could not normalize "
+                f"num_kv_shared_layers={raw_shared!r} → {num_shared} on the "
+                f"config object ({exc}); the model would then fail its "
+                "producer-split computation."
+            ) from exc
 
     if num_shared < 0 or num_shared >= num_hidden:
         raise ValueError(
@@ -597,6 +604,14 @@ def _check_kv_share_config(text_config: dict, tc, model_id: str) -> None:
             f"the wrong length (need {num_hidden} entries, got "
             f"{len(layer_types) if isinstance(layer_types, (list, tuple)) else layer_types!r}). "
             "Cannot establish the producer→borrower map."
+        )
+    # Entries must be strings (attention-type labels) — guard against
+    # unhashable / non-string entries producing an incidental TypeError from
+    # the set() below instead of this clear malformed-config diagnostic.
+    if not all(isinstance(t, str) for t in layer_types):
+        raise ValueError(
+            f"Gemma 4 KV-sharing config INVALID for {model_id}: layer_types "
+            "must be a list of attention-type strings; found a non-string entry."
         )
     # Every borrower attention type must have a producer of that type below the
     # split; otherwise a borrower would have nothing to borrow.

--- a/vllm_mlx/models/gemma4_text.py
+++ b/vllm_mlx/models/gemma4_text.py
@@ -481,12 +481,15 @@ def load_gemma4_text(model_path: str | Path, tokenizer_config: dict = None):
 def _text_config_default_num_kv_shared(tc) -> int:
     """The ``num_kv_shared_layers`` dataclass DEFAULT for ``tc``'s class.
 
-    Used when the checkpoint left the field unspecified (absent or explicit
-    ``null``): we fall back to the same default an absent key already receives
-    via ``from_dict`` rather than forcing 0, which would silently change a
-    shared-KV checkpoint's architecture. Robust across the upstream mlx-vlm and
-    vendored ``TextConfig`` dataclasses; returns 0 if the default cannot be
-    introspected (fail-safe: inactive rather than a wrong active split).
+    Used only when the config key was ABSENT and the dataclass field itself
+    resolved to ``None`` (an explicit ``null`` is rejected upstream in
+    :func:`_check_kv_share_config`, so it never reaches here). We fall back to
+    the same default an absent key already receives via ``from_dict`` rather
+    than forcing 0, which would silently change a shared-KV checkpoint's
+    architecture. Robust across the upstream mlx-vlm and vendored
+    ``TextConfig`` dataclasses; returns 0 if the default cannot be introspected
+    or is itself ``None`` (fail-safe: inactive rather than a wrong active
+    split).
     """
     import dataclasses
 

--- a/vllm_mlx/models/gemma4_text.py
+++ b/vllm_mlx/models/gemma4_text.py
@@ -484,7 +484,10 @@ def _check_kv_share_config(text_config: dict, tc, model_id: str) -> None:
     Gemma 3n / Gemma 4's last ``num_kv_shared_layers`` decoder layers are
     "borrowers": they compute no K/V and reuse the last same-type producer
     layer's K/V (split at ``num_hidden_layers - num_kv_shared_layers``). This
-    is the mechanism behind the prefill/TTFT win — see
+    is the mechanism behind the smaller resident KV cache (measured ~2.3x
+    footprint reduction on gemma-4-e2b-4bit; the prefill/TTFT wall-time win is
+    negligible on the small quantized sizes because the eliminated
+    K/V-projection compute is <3% of prefill) — see
     ``models/gemma4_vendored/language.py`` (``make_cache`` returns a
     producer-only cache list; borrowers get no cache object).
 
@@ -499,18 +502,22 @@ def _check_kv_share_config(text_config: dict, tc, model_id: str) -> None:
 
     * ``tc.num_kv_shared_layers == 0`` → ``first_kv_shared`` equals
       ``num_hidden_layers`` → NO layer borrows → every layer allocates its
-      own KV → the user silently pays a full per-layer prefill with no
-      cross-layer reuse. We WARN (do not hard-fail: the dense large Gemma 4
-      sizes — 12B / 26B-A4B / 31B — legitimately ship ``num_kv_shared_layers=0``
-      and never share; only the Gemma-3n-lineage E2B / E4B do). The WARNING
-      makes the "no cross-layer reuse" fact observable so a user can never
-      silently believe sharing is on when it is not.
-    * ``tc.num_kv_shared_layers`` invalid (``< 0`` or ``>= num_hidden_layers``)
-      → malformed config that would ask for at least as many borrowers as
-      there are layers (no producers, or an out-of-range split). We RAISE —
-      this is a broken checkpoint, not a silent degrade.
-    * ``0 < tc.num_kv_shared_layers < num_hidden_layers`` → sharing active;
-      log the producer/borrower split at debug.
+      own KV, so the resident cache is not reduced by cross-layer reuse. We
+      log at INFO (not WARNING, and never hard-fail): the dense large Gemma 4
+      sizes — 12B / 26B-A4B / 31B — legitimately ship
+      ``num_kv_shared_layers=0`` and never share, so warning on every such
+      load would be a false-positive alert. INFO still makes the "no
+      cross-layer reuse" fact observable so a user can never silently believe
+      sharing is on when it is not.
+    * ``tc.num_kv_shared_layers`` invalid — not a non-negative integer, or
+      ``>= num_hidden_layers``, or a borrower attention type with no
+      producer of that type below the split — → malformed config that cannot
+      share correctly (no producers, out-of-range split, or a borrower with
+      nothing to borrow). We RAISE — a broken checkpoint, not a silent
+      degrade.
+    * ``0 < tc.num_kv_shared_layers < num_hidden_layers`` (and every borrower
+      type has a producer) → sharing active; log the producer/borrower split
+      at debug.
 
     Placed on the shared build path (``_load_gemma4_text_impl``) so it fires
     for every Gemma 4 size and both loaders (``gemma4`` / ``gemma4_unified``),
@@ -519,12 +526,31 @@ def _check_kv_share_config(text_config: dict, tc, model_id: str) -> None:
     ``num_kv_shared_layers`` on the dataclass ``TextConfig``).
     """
     num_hidden = getattr(tc, "num_hidden_layers", None)
-    if not isinstance(num_hidden, int) or num_hidden <= 0:
+    if not isinstance(num_hidden, bool) and isinstance(num_hidden, int):
+        pass
+    else:
         # Not a shape we can reason about; nothing to guard.
+        return
+    if num_hidden <= 0:
         return
 
     key_present = "num_kv_shared_layers" in text_config
-    num_shared = getattr(tc, "num_kv_shared_layers", 0) or 0
+    raw_shared = getattr(tc, "num_kv_shared_layers", 0)
+
+    # Normalize: None / absent → 0 (sharing off). A non-int, non-None value
+    # (e.g. a string from malformed JSON) is itself a broken config — raise a
+    # clear error rather than letting the range comparison throw TypeError or
+    # silently coercing.
+    if raw_shared is None:
+        num_shared = 0
+    elif isinstance(raw_shared, bool) or not isinstance(raw_shared, int):
+        raise ValueError(
+            f"Gemma 4 KV-sharing config INVALID for {model_id}: "
+            f"num_kv_shared_layers={raw_shared!r} is not a non-negative "
+            "integer. This is a malformed checkpoint config."
+        )
+    else:
+        num_shared = raw_shared
 
     if num_shared < 0 or num_shared >= num_hidden:
         raise ValueError(
@@ -536,18 +562,32 @@ def _check_kv_share_config(text_config: dict, tc, model_id: str) -> None:
         )
 
     if num_shared == 0:
-        logger.warning(
-            "Gemma 4 KV-sharing INACTIVE for %s: config sets "
-            "num_kv_shared_layers=0; prefill will not benefit from "
-            "cross-layer KV reuse (every layer allocates its own KV). This "
-            "is expected for the dense sizes (12B / 26B-A4B / 31B) and a "
-            "regression for the E-series (E2B / E4B).",
+        logger.info(
+            "[gemma4] KV-sharing INACTIVE for %s: num_kv_shared_layers=0; "
+            "no cross-layer KV reuse (every layer allocates its own KV). "
+            "Expected for the dense sizes (12B / 26B-A4B / 31B); only the "
+            "E-series (E2B / E4B) shares.",
             model_id,
         )
         return
 
-    # 0 < num_shared < num_hidden → sharing active.
+    # 0 < num_shared < num_hidden → sharing candidate. Verify every borrower
+    # attention type actually has a producer of that type below the split;
+    # otherwise a borrower would have nothing to borrow (malformed layer_types).
+    layer_types = getattr(tc, "layer_types", None)
     num_producers = num_hidden - num_shared
+    if isinstance(layer_types, (list, tuple)) and len(layer_types) == num_hidden:
+        producer_types = set(layer_types[:num_producers])
+        borrower_types = set(layer_types[num_producers:])
+        orphan_types = borrower_types - producer_types
+        if orphan_types:
+            raise ValueError(
+                f"Gemma 4 KV-sharing config INVALID for {model_id}: borrower "
+                f"attention type(s) {sorted(orphan_types)} have no producer "
+                f"layer of that type in the first {num_producers} layer(s). "
+                "This layer_types layout cannot share K/V correctly."
+            )
+
     default_note = (
         ""
         if key_present
@@ -600,9 +640,9 @@ def _load_gemma4_text_impl(
 
     tc = TextConfig.from_dict(text_config)
 
-    # Guard cross-layer KV-sharing before building the model: warn if the
-    # checkpoint won't benefit (no/zero num_kv_shared_layers → silent
-    # double-prefill), raise on a malformed split. See _check_kv_share_config.
+    # Guard cross-layer KV-sharing before building the model: log (INFO) if the
+    # checkpoint won't share (num_kv_shared_layers=0 — normal for the dense
+    # sizes), raise on a malformed split. See _check_kv_share_config.
     _check_kv_share_config(text_config, tc, str(model_path))
 
     language_model = LanguageModel(tc)


### PR DESCRIPTION
## Why

Gemma 4's **cross-layer KV-sharing** already ships (since 0.10.1) but nothing asserts it holds — so a checkpoint with `num_kv_shared_layers=0`, or a future refactor of `make_cache()`, could silently disable it with zero test coverage. This PR adds a load-time guard + a cross-5-size test that lock the shipped behavior, because a silent loss of KV-share (or a silently-wrong producer→borrower map on an untested size) is exactly the failure the verify-and-lock task exists to prevent. Closes the "KV-share divergence on an untested Gemma 4 size" risk cheaply. No engine plumbing changes.

## Background

Gemma 4 (Gemma-3n lineage): the last `num_kv_shared_layers` decoder layers are "borrowers" that compute no K/V and reuse the last *same-type* (full vs sliding) producer layer's K/V. `make_cache()` returns a **producer-only** cache list (borrowers get no cache object); the forward feeds producer K/V into borrower attention as `shared_kv`. **The plumbing is not new — this PR only guards + tests it.**

## Changes

**1. Load-time guard** — `vllm_mlx/models/gemma4_text.py::_check_kv_share_config`, called from the shared `_load_gemma4_text_impl` build path (fires for every size, both loaders, and whether `resolve_classes` returns upstream mlx-vlm *or* the vendored classes):

| condition | severity |
|---|---|
| `0 < num_kv_shared_layers < num_hidden_layers` (and every borrower type has a producer) | DEBUG — sharing active, logs producer/borrower split |
| `num_kv_shared_layers == 0` (or `None`) | **INFO** — "KV-sharing INACTIVE … no cross-layer KV reuse". Not WARNING: the dense sizes (12B / 26B-A4B / 31B) legitimately ship `0` and are the common load, so warning-per-load would be a false-positive alert. Still observable so KV-share can't be silently lost. |
| `num_kv_shared_layers` not a non-negative int, or `>= num_hidden_layers`, or a borrower type with no producer | **ValueError** — malformed config, not a silent degrade |

**2. Cross-5-size test** — `tests/test_gemma4_kv_share.py` (26 tests). Guard branches (active / zero / none / non-int / invalid-range / orphan-type / unknown-shape) + across all 5 real Gemma 4 size shapes (real config values, **no weights loaded**):

| size | num_hidden_layers | num_kv_shared_layers |
|---|---|---|
| E2B | 35 | 20 |
| E4B | 42 | 18 |
| 12B | 48 | 0 (dense — no sharing, by design) |
| 26B-A4B | 30 | 0 (dense/MoE — no sharing, by design) |
| 31B | 60 | 0 (dense — no sharing, by design) |

Asserts (a) `make_cache()` returns the producer-only length, (b) each borrower maps to the correct last-same-type producer (vs an independently computed ground truth), (c) the mlx-lm `make_cache`-deferral contract — a future refactor to one-cache-per-layer breaks the borrow → the test fails.

## Honest e2b measurement (`gemma-4-e2b-4bit` → `mlx-community/gemma-4-e2b-it-4bit`)

Borrow is **ACTIVE**: 15 producer caches / 35 layers, 20 borrowers correctly mapped. Measured borrow-ON (shipped producer-only cache) vs a faithful borrow-OFF (every layer gets its own cache; borrowers store + attend their borrowed K/V):

| prompt tok | prefill ON | prefill OFF | **time ratio** | KV MB ON | KV MB OFF | **KV ratio** |
|---:|---:|---:|:---:|---:|---:|:---:|
| 1024 | 334 ms | 334 ms | **1.00×** | 18.9 | 44.0 | **2.33×** |
| 4096 | 1553 ms | 1553 ms | **1.00×** | 75.5 | 176.2 | **2.33×** |
| 8192 | 3865 ms | 3866 ms | **1.00×** | 151.0 | 352.3 | **2.33×** |

**KV memory: 2.33× smaller with sharing — the real, substantial win** (constant across prompt lengths; benefits long-context and concurrency — the Gemma-3n design goal). **Prefill/TTFT wall-time: ~1.00× (no measurable speedup).** Decomposition: the K/V-projection compute KV-share eliminates is **<3% of prefill** on e2b — `n_kv_heads=1` makes `k_proj`/`v_proj` tiny, and borrowers still run full `q_proj`/`o_proj` + double-wide MLP + attention.

This is **not** the "borrow inactive" failure mode — the memory saving is real and measured. The **prefill-time** win does not materialize on this small quantized size. Google's ~2× headline is **Gemma-4 vs Gemma-3-4B** (an architecture-to-architecture comparison), *not* same-checkpoint borrow-on-vs-off; the honest same-checkpoint number here is 1.0× on time / 2.33× on KV memory. (Measurement code was throwaway and is **not** in this PR; the e2b weights were deleted after measuring.)

## Guardrails
- No `pyproject.toml` version bump (G4).
- No touch to `spec_decode/**` or `speculative/**` (operator lane) — target-model KV-share only.
- e2b weights pulled for measurement, deleted after (disk hygiene, G11).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
