### PR TITLE
feat(pflash): surface silent endpoints-only compression collapse

### DIFF
--- a/tests/test_pflash_endpoints_only.py
+++ b/tests/test_pflash_endpoints_only.py
@@ -1,0 +1,73 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for PFlash endpoints-only detection.
+
+When ``sink_tokens + tail_tokens`` meet or exceed the keep budget, PFlash keeps
+only the leading sink and trailing tail and drops the entire middle span. With
+the default ``always``-mode settings (sink 256 + tail 2048, min_keep 2048,
+keep_ratio 0.20) this happens for every prompt shorter than ~11.5k tokens, yet
+``compressed`` stays True and ``reason`` stays ``"compressed"``. These tests pin
+the observability added for that regime — ``PFlashResult.endpoints_only`` /
+``middle_tokens_kept`` and the matching ``compress_request_tokens`` metadata —
+and assert the normal compression path stays unflagged.
+"""
+
+from vllm_mlx.pflash import (
+    PFlashConfig,
+    compress_request_tokens,
+    compress_tokens,
+)
+
+
+class TestPFlashEndpointsOnly:
+    def test_default_always_config_collapses_short_prompt(self):
+        # 3k tokens under the default always-mode config: keep_budget == 2048 but
+        # sink(256)+tail(2048) == 2304 > budget, so the whole middle is dropped
+        # and kept_tokens (2304) even exceeds the nominal budget.
+        result = compress_tokens(list(range(3000)), PFlashConfig(mode="always"))
+        assert result.compressed is True
+        assert result.reason == "compressed"
+        assert result.middle_tokens_kept == 0
+        assert result.endpoints_only is True
+        assert result.kept_tokens == 2304
+
+    def test_generous_budget_keeps_middle_and_is_not_flagged(self):
+        # 20k tokens: 0.2 * 20k == 4000 budget leaves room for middle blocks.
+        result = compress_tokens(
+            list(range(20000)), PFlashConfig(mode="always", keep_ratio=0.2)
+        )
+        assert result.compressed is True
+        assert result.middle_tokens_kept > 0
+        assert result.endpoints_only is False
+
+    def test_metadata_surfaces_endpoints_only(self):
+        _, metadata = compress_request_tokens(
+            list(range(3000)), PFlashConfig(mode="always")
+        )
+        assert metadata["endpoints_only"] is True
+        assert metadata["middle_tokens_kept"] == 0
+
+    def test_metadata_middle_tokens_kept_positive_on_normal_compression(self):
+        _, metadata = compress_request_tokens(
+            list(range(20000)), PFlashConfig(mode="always", keep_ratio=0.2)
+        )
+        assert metadata["endpoints_only"] is False
+        assert metadata["middle_tokens_kept"] > 0
+
+    def test_uncompressed_result_is_not_endpoints_only(self):
+        result = compress_tokens(list(range(20000)), PFlashConfig(mode="off"))
+        assert result.compressed is False
+        assert result.endpoints_only is False
+
+    def test_small_sink_tail_leaves_middle_on_short_prompt(self):
+        cfg = PFlashConfig(
+            mode="always",
+            keep_ratio=0.5,
+            min_keep_tokens=64,
+            sink_tokens=8,
+            tail_tokens=8,
+            block_size=8,
+        )
+        result = compress_tokens(list(range(2000)), cfg)
+        assert result.compressed is True
+        assert result.middle_tokens_kept > 0
+        assert result.endpoints_only is False

--- a/tests/test_pflash_endpoints_only.py
+++ b/tests/test_pflash_endpoints_only.py
@@ -11,6 +11,9 @@ the observability added for that regime — ``PFlashResult.endpoints_only`` /
 and assert the normal compression path stays unflagged.
 """
 
+import logging
+
+import vllm_mlx.pflash as pflash
 from vllm_mlx.pflash import (
     PFlashConfig,
     compress_request_tokens,
@@ -71,3 +74,26 @@ class TestPFlashEndpointsOnly:
         assert result.compressed is True
         assert result.middle_tokens_kept > 0
         assert result.endpoints_only is False
+
+    def test_endpoints_only_warns_at_most_once_per_process(self, caplog):
+        # Reset the module-global warn-once flag so the assertion is independent
+        # of test ordering / prior process state.
+        pflash._ENDPOINTS_ONLY_WARNED = False
+        try:
+            with caplog.at_level(logging.WARNING, logger="vllm_mlx.pflash"):
+                # First endpoints-only collapse: must emit exactly one warning.
+                first = compress_tokens(list(range(3000)), PFlashConfig(mode="always"))
+                assert first.endpoints_only is True
+                # A second, separate collapse must NOT log again.
+                second = compress_tokens(list(range(4000)), PFlashConfig(mode="always"))
+                assert second.endpoints_only is True
+
+            endpoints_warnings = [
+                rec
+                for rec in caplog.records
+                if rec.levelno == logging.WARNING
+                and "PFlash endpoints-only" in rec.getMessage()
+            ]
+            assert len(endpoints_warnings) == 1
+        finally:
+            pflash._ENDPOINTS_ONLY_WARNED = False

--- a/vllm_mlx/pflash.py
+++ b/vllm_mlx/pflash.py
@@ -24,10 +24,20 @@ This adaptation differs from the fork in three places:
 
 from __future__ import annotations
 
+import logging
 from collections import Counter
 from dataclasses import dataclass
 from math import ceil
 from typing import Any, Literal
+
+logger = logging.getLogger(__name__)
+
+# Warn at most once per process when compression degrades to "endpoints-only"
+# (leading sink + trailing tail consume the entire keep budget, so the whole
+# middle span is dropped). It is a config-level footgun rather than a per-request
+# event, so one warning is the right dosage; per-request occurrences are still
+# exposed via the ``endpoints_only`` / ``middle_tokens_kept`` metadata for metrics.
+_ENDPOINTS_ONLY_WARNED = False
 
 PFlashMode = Literal["off", "auto", "always"]
 
@@ -86,12 +96,32 @@ class PFlashResult:
     reason: str
     original_tokens: int
     kept_tokens: int
+    # Number of *middle* tokens (between the leading sink and trailing tail) that
+    # survived compression. 0 on a compressed result means the sink+tail budget
+    # left no room for body content — see ``endpoints_only``. Defaults to 0 so
+    # existing keyword construction (e.g. ``_unchanged``) is unaffected.
+    middle_tokens_kept: int = 0
 
     @property
     def compression_ratio(self) -> float:
         if self.original_tokens == 0:
             return 1.0
         return self.kept_tokens / self.original_tokens
+
+    @property
+    def endpoints_only(self) -> bool:
+        """True when a *compressed* result kept zero middle tokens.
+
+        In this regime ``sink_tokens + tail_tokens`` met or exceeded the keep
+        budget, so PFlash retained only the leading sink and trailing tail and
+        dropped the entire middle span. Mid-document recall collapses to ~0 here
+        (a paraphrased or body-resident answer is simply not in the kept set),
+        even though ``compressed`` is True and ``reason`` is ``"compressed"``.
+        A compressed result always has a non-empty middle span — an all-endpoints
+        prompt short-circuits to ``reason="budget"`` unchanged — so this flag is
+        an unambiguous signal of the degenerate budget, not of a short prompt.
+        """
+        return self.compressed and self.middle_tokens_kept == 0
 
 
 def config_from_args(args: Any) -> PFlashConfig:
@@ -248,7 +278,15 @@ def compress_tokens(
     keep_positions = set(range(sink_end))
     keep_positions.update(range(tail_start, n_tokens))
 
+    # Tokens available in the middle span (everything the sink/tail don't cover)
+    # and the budget left for them after the endpoints are reserved. When
+    # ``remaining_budget <= 0`` the sink+tail already meet or exceed the keep
+    # budget, so not a single middle block can be selected — the whole body is
+    # dropped. Track how many middle tokens actually survive so the result can
+    # flag the degenerate "endpoints-only" regime.
+    middle_span = tail_start - sink_end
     remaining_budget = keep_budget - len(keep_positions)
+    middle_selected = 0
     if remaining_budget > 0:
         scored_blocks = _score_middle_blocks(
             tokens=tokens,
@@ -259,22 +297,41 @@ def compress_tokens(
             stride_blocks=max(0, config.stride_blocks),
         )
 
-        selected_tokens = 0
         for block in scored_blocks:
             block_len = block.end - block.start
-            slots = remaining_budget - selected_tokens
+            slots = remaining_budget - middle_selected
             if slots <= 0:
                 break
             take = min(block_len, slots)
             keep_positions.update(range(block.start, block.start + take))
-            selected_tokens += take
-            if selected_tokens >= remaining_budget:
+            middle_selected += take
+            if middle_selected >= remaining_budget:
                 break
+
+    if middle_span > 0 and middle_selected == 0:
+        # Endpoints-only: sink+tail consumed the whole budget, so the entire
+        # middle span is dropped and mid-document recall falls to ~0. Warn once
+        # (it is a config-level footgun) with the numbers an operator needs.
+        global _ENDPOINTS_ONLY_WARNED
+        if not _ENDPOINTS_ONLY_WARNED:
+            _ENDPOINTS_ONLY_WARNED = True
+            logger.warning(
+                "PFlash endpoints-only: sink(%d)+tail(%d) meet or exceed the keep "
+                "budget (%d) for a %d-token prompt, so all %d middle tokens are "
+                "dropped and mid-document recall falls to ~0. Raise "
+                "--pflash-keep-ratio / --pflash-min-keep-tokens or lower "
+                "--pflash-sink-tokens / --pflash-tail-tokens to retain body context.",
+                sink_end,
+                n_tokens - tail_start,
+                keep_budget,
+                n_tokens,
+                middle_span,
+            )
 
     kept = [tokens[i] for i in sorted(keep_positions)]
     if len(kept) >= n_tokens:
         return _unchanged(tokens, "budget")
-    return _changed(tokens, kept, "compressed")
+    return _changed(tokens, kept, "compressed", middle_tokens_kept=middle_selected)
 
 
 def compress_request_tokens(
@@ -298,6 +355,8 @@ def compress_request_tokens(
         "kept_tokens": result.kept_tokens,
         "dropped_tokens": result.original_tokens - result.kept_tokens,
         "compression_ratio": result.compression_ratio,
+        "middle_tokens_kept": result.middle_tokens_kept,
+        "endpoints_only": result.endpoints_only,
     }
 
 
@@ -363,11 +422,18 @@ def _unchanged(tokens: list[int], reason: str) -> PFlashResult:
     )
 
 
-def _changed(tokens: list[int], kept: list[int], reason: str) -> PFlashResult:
+def _changed(
+    tokens: list[int],
+    kept: list[int],
+    reason: str,
+    *,
+    middle_tokens_kept: int = 0,
+) -> PFlashResult:
     return PFlashResult(
         tokens=kept,
         compressed=True,
         reason=reason,
         original_tokens=len(tokens),
         kept_tokens=len(kept),
+        middle_tokens_kept=middle_tokens_kept,
     )

--- a/vllm_mlx/pflash.py
+++ b/vllm_mlx/pflash.py
@@ -25,6 +25,7 @@ This adaptation differs from the fork in three places:
 from __future__ import annotations
 
 import logging
+import threading
 from collections import Counter
 from dataclasses import dataclass
 from math import ceil
@@ -37,7 +38,10 @@ logger = logging.getLogger(__name__)
 # middle span is dropped). It is a config-level footgun rather than a per-request
 # event, so one warning is the right dosage; per-request occurrences are still
 # exposed via the ``endpoints_only`` / ``middle_tokens_kept`` metadata for metrics.
+# The lock makes the check-then-set atomic so concurrent requests can't both
+# observe ``False`` and each emit the "once" warning.
 _ENDPOINTS_ONLY_WARNED = False
+_ENDPOINTS_ONLY_WARN_LOCK = threading.Lock()
 
 PFlashMode = Literal["off", "auto", "always"]
 
@@ -313,8 +317,16 @@ def compress_tokens(
         # middle span is dropped and mid-document recall falls to ~0. Warn once
         # (it is a config-level footgun) with the numbers an operator needs.
         global _ENDPOINTS_ONLY_WARNED
+        should_warn = False
         if not _ENDPOINTS_ONLY_WARNED:
-            _ENDPOINTS_ONLY_WARNED = True
+            # Double-checked locking: cheap unlocked read on the hot path, then
+            # take the lock only to atomically re-check and flip the flag so a
+            # single winner emits the once-per-process warning below.
+            with _ENDPOINTS_ONLY_WARN_LOCK:
+                if not _ENDPOINTS_ONLY_WARNED:
+                    _ENDPOINTS_ONLY_WARNED = True
+                    should_warn = True
+        if should_warn:
             logger.warning(
                 "PFlash endpoints-only: sink(%d)+tail(%d) meet or exceed the keep "
                 "budget (%d) for a %d-token prompt, so all %d middle tokens are "


### PR DESCRIPTION
## What

Adds observability for a silent failure mode in `compress_tokens`: when the
leading **sink + trailing tail** already consume the whole keep budget, PFlash
selects **zero** middle blocks and keeps only the endpoints — dropping the
entire document body — while still returning `compressed=True`,
`reason="compressed"`, and (in this regime) `kept_tokens` *greater than*
`keep_budget`. Nothing today distinguishes that from a healthy compression.

This PR surfaces it, with **no change to the scoring algorithm, the defaults, or
any existing `reason` string**:

- `PFlashResult.middle_tokens_kept` — middle tokens that actually survived.
- `PFlashResult.endpoints_only` — `True` when a *compressed* result kept zero
  middle tokens.
- a **warn-once** log naming the exact budget/sink/tail numbers and the knobs to
  fix it.
- `middle_tokens_kept` / `endpoints_only` added to `compress_request_tokens`
  metadata (purely additive keys).

## Why — this is not an edge case under the shipped defaults

The relevant lines in `compress_tokens`:

```python
keep_positions = set(range(sink_end))
keep_positions.update(range(tail_start, n_tokens))
remaining_budget = keep_budget - len(keep_positions)   # can be <= 0
if remaining_budget > 0:
    ... select middle blocks ...
# else: no middle block is ever considered
```

With the default `always`-mode config — `sink_tokens=256`, `tail_tokens=2048`,
`min_keep_tokens=2048`, `keep_ratio=0.20` — the endpoints reserve
`256 + 2048 = 2304` tokens, while `keep_budget = max(2048, ceil(0.20 · N))`.
So `remaining_budget > 0` requires:

```
max(2048, 0.20·N) > 2304   ⟹   0.20·N > 2304   ⟹   N > ~11,520 tokens
```

**For every prompt shorter than ~11.5k tokens, the middle is dropped in full.**
Concretely, a 3,000-token prompt keeps exactly the 2,304 endpoint tokens (all
696 middle tokens gone) and `kept_tokens` (2304) exceeds `keep_budget` (2048) —
yet the result is reported as an ordinary `"compressed"` success. `auto` mode
hides this (it only engages past `threshold=32768`), but the verified-tier
default is `always`, so any short-to-moderate prompt on those aliases is
silently compressed to endpoints-only.

This is by-design and *fine* when the answer lives in the sink or tail (often the
case — the user's query is usually near the end). It is silently harmful when the
answer is mid-document, which is exactly the case a needle/RAG workload cares
about.

## Evidence

We hit this while independently evaluating PFlash on Apple-Silicon MLX models
(Qwen3-8B / Qwen3-32B / Phi-3.5-mini, needle-in-haystack). Summary at matched
`keep_ratio=0.20`:

- **Lexically-anchored needle in homogeneous filler** (a rare code whose token
  also appears in the question): recall ≈ 100% — the rarity+overlap scorer is
  practically built for this, so PFlash looks free.
- **Paraphrased question + heterogeneous filler** (the needle is *not* the only
  rare thing and shares no distinctive tokens with the query): recall collapses
  to ~20% at 16k, and at 4k (fully endpoints-only) only tail-adjacent needles
  survive.

The TTFT win itself replicates well (≈2–5× on our runs), so this is not a
"PFlash is bad" report — it's a "PFlash silently drops the body in a common
config regime, and users have no signal" report.

**Caveats (in fairness):** the recall numbers are from an independent NIAH
harness against a faithful reimplementation of the core `compress_tokens`
scorer, not your full serving path (alias-tier defaults, prefix-cache
interactions, etc.); single-fact needle; MLX-quantized models. The
*endpoints-only mechanism*, however, is a direct reading of the current code and
does not depend on any of that — hence this PR is scoped to observability, not to
second-guessing the algorithm.

## What this PR deliberately does **not** do

- No change to scoring, block selection, budget math, or defaults.
- No change to existing `reason` values (`"compressed"` still `"compressed"`).
- No new dependency.

A mitigation knob (e.g. a `min_middle_tokens` floor that trades some tail for
body, or auto-widening the budget) is a reasonable follow-up, but it's a design
choice that's yours to make — this PR just makes the regime visible first.

## Testing

- New `tests/test_pflash_endpoints_only.py` (6 tests): collapse is flagged,
  normal compression is not, metadata surfaces both keys, uncompressed results
  are never flagged.
- Full existing `tests/test_pflash.py` still passes unchanged (30 passed total).

## Attribution

Thanks for shipping PFlash (and for the `bench/pflash_replication.py` harness —
it's what let us reproduce cleanly). Filed in the same open-source spirit the
feature was built in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
