### PR TITLE
refactor(profile): unify AliasProfile + ModelConfig into one frozen ModelProfile

### DIFF
--- a/tests/test_diffusion_engine.py
+++ b/tests/test_diffusion_engine.py
@@ -26,6 +26,29 @@ import pytest
 # 70 unrelated ImportError "failures" drown out real signal.
 pytest.importorskip("mlx")
 
+
+@pytest.fixture(autouse=True, scope="module")
+def _reset_config_after_module():
+    """Contain config-singleton leakage into downstream test files.
+
+    Several tests below deliberately mutate the process-wide config
+    singleton (e.g. ``cfg.tool_call_parser = "hermes"`` to exercise the
+    diffusion tool-call veto) via :func:`vllm_mlx.config.reset_config`
+    plus field assignment, but never restore it. Without this teardown
+    the last such mutation escapes the module and pollutes any later
+    test that reads a server-global parser without pinning it — e.g.
+    ``test_routes.py::TestModelsRoutes::test_retrieve_unknown_id_keeps_baseline_shape``
+    would observe a leaked ``tool_call_parser='hermes'`` and fail under
+    any collection order that runs this file first. Resetting at module
+    teardown keeps the leak contained without changing any in-file test
+    ordering or state (the leak only matters at the module boundary).
+    """
+    yield
+    from vllm_mlx.config import reset_config
+
+    reset_config()
+
+
 # ----------------------------------------------------------------------
 # Helpers — minimal mlx-vlm surface mock
 # ----------------------------------------------------------------------

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -729,6 +729,16 @@ class TestModelsRoutes:
             model_name="custom-operator-model-not-in-registry",
             model_alias=None,
             api_key=None,
+            # Pin the server-global parser explicitly: because
+            # ``model_name`` above makes this id the *served* model,
+            # ``effective_parsers_for`` (Tier 2) reads ``cfg.tool_call_parser``
+            # for it. Relying on the singleton default made this baseline
+            # assertion depend on leftover global state — any earlier test
+            # that set ``cfg.tool_call_parser`` without restoring it (e.g.
+            # the diffusion tool-call-veto tests) would leak a non-None
+            # value here. Pinning None keeps the "unknown-id baseline"
+            # contract hermetic regardless of collection order.
+            tool_call_parser=None,
         )
         try:
             client = TestClient(self._make_app())

--- a/tests/test_suffix_decoding_tier.py
+++ b/tests/test_suffix_decoding_tier.py
@@ -256,19 +256,24 @@ class TestModelConfigDefaults:
         assert ModelConfig().suffix_decoding_tier == "unknown"
 
     def test_default_speedup_dict_is_empty_not_none(self):
-        # ``None`` would crash hint/table code that does ``or {}``;
-        # default-empty-dict avoids the conditional and keeps semantics
-        # ("we have no data" reads cleanly as ``not cfg.suffix_bench_speedup``).
+        # Unified ModelProfile stores ``suffix_bench_speedup`` as a tuple
+        # (or None when not benched) so the frozen dataclass stays
+        # hashable/shareable; consumers read the dict via the
+        # ``speedup_dict`` property, which normalizes None → {} so the old
+        # ``or {}`` conditional in hint/table code is no longer needed.
         cfg = ModelConfig()
-        assert cfg.suffix_bench_speedup == {}
+        assert cfg.suffix_bench_speedup is None
+        assert cfg.speedup_dict == {}
 
     def test_each_modelconfig_gets_its_own_dict(self):
-        """``field(default_factory=dict)`` regression test — using a
-        bare ``dict()`` literal as the default would share the same
-        dict across all ModelConfig instances."""
+        """``speedup_dict`` must materialize a FRESH dict each call so a
+        caller that mutates the returned dict can't corrupt shared profile
+        state. The unified ModelProfile is frozen with an immutable tuple
+        backing field, so instances inherently cannot share mutable state
+        (the original ``default_factory=dict`` sharing concern is gone)."""
         a = ModelConfig()
-        b = ModelConfig()
-        a.suffix_bench_speedup["chat"] = 1.0
-        assert b.suffix_bench_speedup == {}, (
-            "ModelConfig instances must not share dict state"
+        d = a.speedup_dict
+        d["chat"] = 1.0  # mutating the returned dict must not persist
+        assert a.speedup_dict == {}, (
+            "speedup_dict must return a fresh dict, not shared state"
         )

--- a/vllm_mlx/engine_core.py
+++ b/vllm_mlx/engine_core.py
@@ -19,7 +19,7 @@ import sys
 import time
 import uuid
 from collections.abc import AsyncIterator
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Any
 
 import mlx.core as mx
@@ -262,8 +262,9 @@ class EngineCore:
         # auto-detection/enrichment but *before* the scheduler reads
         # capability gates. Mutex pairs (force_X / no_X) are validated
         # at the CLI layer and re-validated here as a second line of
-        # defense for programmatic callers. ModelConfig is non-frozen
-        # so direct mutation is fine; we only touch fields whose
+        # defense for programmatic callers. ModelConfig (now the frozen
+        # unified ``ModelProfile``) rebinds via ``dataclasses.replace``
+        # rather than in-place mutation; we only touch fields whose
         # override flag was explicitly set.
         if self.config.force_hybrid and self.config.no_hybrid:
             raise ValueError("force_hybrid and no_hybrid are mutually exclusive")
@@ -272,18 +273,18 @@ class EngineCore:
                 "force_spec_decode and no_spec_decode are mutually exclusive"
             )
         if self.config.no_hybrid:
-            self.model_config.is_hybrid = False
+            self.model_config = replace(self.model_config, is_hybrid=False)
             logger.info("Routing override: is_hybrid forced False via --no-hybrid")
         elif self.config.force_hybrid:
-            self.model_config.is_hybrid = True
+            self.model_config = replace(self.model_config, is_hybrid=True)
             logger.info("Routing override: is_hybrid forced True via --force-hybrid")
         if self.config.no_spec_decode:
-            self.model_config.supports_spec_decode = False
+            self.model_config = replace(self.model_config, supports_spec_decode=False)
             logger.info(
                 "Routing override: supports_spec_decode forced False via --no-spec-decode"
             )
         elif self.config.force_spec_decode:
-            self.model_config.supports_spec_decode = True
+            self.model_config = replace(self.model_config, supports_spec_decode=True)
             logger.info(
                 "Routing override: supports_spec_decode forced True via --force-spec-decode"
             )

--- a/vllm_mlx/model_aliases.py
+++ b/vllm_mlx/model_aliases.py
@@ -14,20 +14,15 @@ that entry just gets default capability flags.
 import difflib
 import json
 import os
-from dataclasses import dataclass
-from typing import Literal
 
-# Canonical modality enum. Default is ``"text"`` so every legacy alias
-# (and every external JSON snippet that pre-dates this field) keeps the
-# auto-regressive LLM lane untouched. New modalities branch the runtime
-# at startup — see ``runtime/diffusion_lane.py`` for the discrete
-# text-diffusion path used by DiffusionGemma. ``"vision"`` and
-# ``"image-gen"`` are reserved for forthcoming Bonsai/VLM integrations
-# (see project memory: bonsai_image_4b_integration). Adding a new value
-# requires editing this Literal AND the dispatch table in cli.py /
-# routes/models.py so the surface-level UX (info, ls, chat) doesn't
-# silently expose LLM-only columns on a non-LLM alias.
-Modality = Literal["text", "text-diffusion", "vision", "image-gen"]
+from .model_profile import Modality, ModelProfile
+
+# ``Modality`` and the unified ``ModelProfile`` dataclass live in the
+# import-light ``model_profile`` module — the single source of truth for
+# per-model profile shape. Re-exported here so existing
+# ``from vllm_mlx.model_aliases import Modality`` / ``AliasProfile`` call
+# sites keep resolving. See ``model_profile`` for why the class lives
+# there (import-light + avoids the model_auto_config↔model_aliases cycle).
 # Implemented lanes — what ``load_model`` can actually dispatch to today.
 # ``vision`` and ``image-gen`` are RESERVED in the type alias so that
 # routing code can pattern-match on them once their dispatch paths land,
@@ -88,127 +83,13 @@ _aliases: dict[str, "AliasProfile"] | None = None
 _hf_to_alias: dict[str, str] | None = None
 
 
-@dataclass(frozen=True)
-class AliasProfile:
-    """Per-alias profile — resolved from ``aliases.json``.
-
-    Mirrors a subset of ``ModelConfig``'s fields. Kept separate so this
-    module stays import-light (``model_auto_config`` pulls in regex,
-    typing, etc. that aren't needed when callers only want the alias →
-    hf_path map).
-    """
-
-    hf_path: str
-    tool_call_parser: str | None = None
-    reasoning_parser: str | None = None
-    is_hybrid: bool = False
-    # r6-A R6-C1: when an aliases.json entry explicitly declares
-    # ``is_hybrid``, the runtime ArraysCache probe in
-    # ``model_auto_config.enrich_model_config`` MUST NOT override the
-    # declared value. Without this flag, the probe one-way-promotes
-    # ``is_hybrid`` to ``True`` for any model whose ``make_cache()``
-    # returns linear-attention layers — which is exactly what dense
-    # Qwen3.5 / Qwen3.6 weights do (model_type=qwen3_5 uses
-    # GatedDeltaNet), forcing the alias-level routing decision (hybrid
-    # throttle + prefix-boundary snapshot) back on even after the JSON
-    # marked the model as non-hybrid. That re-promotion is what
-    # wedges ``rapid-mlx serve qwen3.5-4b-4bit`` on metal::malloc with a
-    # 499000 byte limit; ``--no-hybrid`` was the only workaround.
-    #
-    # Default ``False`` keeps the existing safety-net behaviour for
-    # legacy aliases that haven't opted into the explicit contract —
-    # those still pick up the probe's hybrid promotion as before.
-    is_hybrid_explicit: bool = False
-    # MoE / sparse-expert architecture (A3B, A10B, A17B Qwen3.5/3.6 variants,
-    # plus future Mixtral/Granite-MoE families). Tracked separately from
-    # ``is_hybrid`` because the two attributes gate different downstream
-    # paths — hybrid affects ArraysCache/GDN rollback, MoE affects DFlash
-    # acceptance rate (the drafter's hidden-state fusion misfires on
-    # expert-routing churn; PoC measured 0.76-0.82× regression regardless
-    # of precision on Qwen3.6-35B-A3B).
-    is_moe: bool = False
-    supports_spec_decode: bool = True
-    default_max_tokens: int | None = None
-    # SuffixDecoding eligibility — populated from cross-model bench (issue #269).
-    # ``None`` for ``suffix_bench_speedup`` means "not benched yet"; the tier
-    # then defaults to ``"unknown"`` and the startup hint stays silent.
-    # When populated, ``suffix_bench_speedup`` is a tuple of ``(workload, speedup)``
-    # pairs (tuple, not dict, so frozen dataclass instances stay safely shareable).
-    suffix_decoding_tier: str = "unknown"
-    suffix_bench_speedup: tuple[tuple[str, float], ...] | None = None
-    # DFlash speculative-decoding eligibility (issue #264). Explicit opt-in
-    # per alias rather than auto-derived because the PoC showed
-    # precision-dependent regressions: 4-bit kills acceptance even on dense
-    # models. Aliases keep ``supports_dflash=False`` until benched to win
-    # by ≥1.3× on the canonical Fibonacci/Quicksort/HashTable prompts.
-    # ``dflash_draft_model`` is the matching drafter HF path (e.g.
-    # ``z-lab/Qwen3.5-27B-DFlash``); required if ``supports_dflash=True``.
-    supports_dflash: bool = False
-    dflash_draft_model: str | None = None
-    # Recommended sampling defaults — curated per-family overrides that
-    # sit above HF ``generation_config.json`` in the resolve chain (see
-    # ``service/helpers.py``). Tuple-of-pairs (not dict) because the
-    # dataclass is frozen and dict defaults are mutable. Keys are
-    # restricted to the sampling subset: ``temperature``, ``top_p``,
-    # ``top_k``, ``min_p``, ``repetition_penalty``, ``presence_penalty``,
-    # ``frequency_penalty``. ``None`` means "no curated value" → fall
-    # through to ``generation_config.json``.
-    recommended_sampling: tuple[tuple[str, float], ...] | None = None
-    # Inference modality. Default ``"text"`` covers every legacy LLM
-    # alias and keeps the auto-regressive scheduler/runtime path
-    # unchanged. Non-text modalities branch into dedicated lanes:
-    # ``"text-diffusion"`` → ``runtime/diffusion_lane.py`` (block
-    # denoising, no spec-decode, no DFlash); ``"vision"`` /
-    # ``"image-gen"`` reserved for upcoming integrations.
-    #
-    # NOTE on positional ABI: this field is intentionally appended at
-    # the END of the dataclass instead of after ``hf_path`` so that
-    # existing callers using positional construction
-    # (``AliasProfile(hf_path, tool_call_parser, ...)``) continue to
-    # bind their positional args to the same fields they always did.
-    # pr_validate codex round 11 [BLOCKING #1]: inserting ``modality``
-    # at position 1 silently routed the parser positional into the
-    # modality slot and broke construction without raising. Keep new
-    # fields at the tail.
-    modality: Modality = "text"
-    # PFlash long-prompt compression eligibility (#287). Default
-    # ``"unknown"`` keeps the engine's PFlash mode at ``"off"`` so a
-    # brand-new alias never silently enables compression on an
-    # unbenched architecture. ``"verified"`` flips the engine's default
-    # to ``"always"`` — used only for aliases where we've measured both
-    # the TTFT speedup AND the needle-recall floor (Qwen3.5 / Qwen3.6
-    # families per #287). Explicit CLI ``--pflash {off,auto,always}``
-    # still wins; this only changes the no-flag default.
-    #
-    # NOTE on positional ABI: kept at the tail of the dataclass to
-    # preserve the positional-construction contract spelled out on
-    # ``modality`` — inserting a field higher silently routes existing
-    # positional kwargs into the wrong slot.
-    pflash_tier: str = "unknown"
-    # TurboQuant K8V4 default-on tier. See ``VALID_TURBOQUANT_TIERS``.
-    turboquant_tier: str = "unknown"
-    # DDTree speculative-decoding eligibility (#879). Appended at the
-    # tail to preserve AliasProfile's positional-construction ABI.
-    # This is intentionally separate from DFlash even though it uses the
-    # same DFlash draft weights: DDTree verifies a tree of candidate
-    # continuations and needs model-family specific verifier support.
-    supports_ddtree: bool = False
-    ddtree_draft_model: str | None = None
-    ddtree_speculative_tokens: int | None = None
-    ddtree_tree_budget: int | None = None
-    # codex round 3 [NIT #3]: minimum unified-memory floor (in GB) for
-    # aliases that are unfit for smaller machines. ``None`` means "no
-    # hardware gate" — the default for every text/vision model we ship
-    # under 100 GB weights. Populated for the flagship-tier Ultra-only
-    # entries (currently ``hy3-preview-4bit`` at 166 GB weights + ~156
-    # GB peak RSS per the pre-vendor memory profile — needs 192 GB+ M3
-    # Ultra). Enforced as a boot-time WARNING (not a hard block) in
-    # ``vllm_mlx/cli.py`` so a user who bought a 128 GB Max still sees
-    # the actionable pointer before the download starts instead of an
-    # opaque OOM 90 minutes later. Appended at the tail to preserve
-    # AliasProfile's positional-construction ABI (see the ``modality``
-    # comment block above for the rationale).
-    min_memory_gb: float | None = None
+# ``AliasProfile`` is a DEPRECATED alias of the unified ``ModelProfile``
+# (defined in the import-light ``model_profile`` module). Retained so the
+# ~20 call sites that import ``AliasProfile`` by name keep resolving; a
+# follow-up rename PR migrates them to ``ModelProfile`` and drops this
+# shim. It is the SAME class object, not a subclass — construction and
+# ``isinstance`` behave identically to ``ModelProfile``.
+AliasProfile = ModelProfile
 
 
 def _coerce(alias: str, value: object) -> AliasProfile:

--- a/vllm_mlx/model_auto_config.py
+++ b/vllm_mlx/model_auto_config.py
@@ -24,90 +24,25 @@ specific first.
 
 import logging
 import re
-from dataclasses import dataclass, field, replace
+from dataclasses import replace
 from typing import Any
 
 from .model_aliases import resolve_profile
+from .model_profile import ModelProfile
 
 logger = logging.getLogger(__name__)
 
 
-@dataclass
-class ModelConfig:
-    """Auto-detected configuration for a model family.
-
-    Includes both parser defaults (tool/reasoning) and capability gates
-    (which optimizations are safe to enable). Defaults err on the side
-    of "supported" — known-incompatible families set the flag explicitly.
-    """
-
-    # --- Parser defaults ---
-    tool_call_parser: str | None = None
-    reasoning_parser: str | None = None
-    default_max_tokens: int | None = (
-        None  # Per-model default when user omits max_tokens
-    )
-
-    # --- Architecture / capability gates ---
-    # ``is_hybrid`` = the model uses linear-attention or recurrent layers
-    # (GatedDeltaNet, Mamba, Jamba, ...). Hybrid models need request
-    # throttling and disable optimizations that rely on chunked-batched
-    # forward — verified on Qwen3.5-4B where spec decode produces
-    # corrupted output (see evals/results/SUFFIX_POC_REPORT.md).
-    is_hybrid: bool = False
-
-    # r6-A R6-C1: when the alias profile (or an explicit caller) pins
-    # ``is_hybrid``, ``enrich_model_config``'s runtime ArraysCache probe
-    # MUST NOT one-way-flip the value to True. Without this gate, dense
-    # Qwen3.5 / Qwen3.6 aliases whose JSON declares ``is_hybrid=false``
-    # still got promoted to hybrid at boot because ``make_cache()``
-    # returns linear-attention layers — re-enabling the throttle +
-    # prefix-boundary snapshot path that wedges ``rapid-mlx serve
-    # qwen3.5-4b-4bit`` with ``metal::malloc`` Resource-limit (499000)
-    # errors. Default ``False`` preserves the legacy safety-net behaviour
-    # for aliases / serve targets that haven't opted into the explicit
-    # contract; the probe still promotes ``is_hybrid`` to True when the
-    # cache type indicates linear attention.
-    is_hybrid_explicit: bool = False
-
-    # ``supports_spec_decode`` controls SuffixDecoding / draft-model
-    # speculative decoding. Disabled for hybrid models because the
-    # batched-verify path through GatedDeltaNet derails generation.
-    # Pure-attention models (llama, qwen3, mistral, gemma3, gpt-oss,
-    # phi, ...) are safe.
-    supports_spec_decode: bool = True
-
-    # SuffixDecoding eligibility tier (#269). One of:
-    #   "unknown"    — not benched (silent default)
-    #   "agent"      — tool_loop ≥ 1.8x, no regression — recommend the flag
-    #   "structured" — peak workload ≥ 1.5x, no regression — may help
-    #   "neutral"    — no workload wins, no regression — silent
-    #   "avoid"      — at least one workload regresses — warn
-    suffix_decoding_tier: str = "unknown"
-    # Per-workload speedup measured by ``scripts/bench_suffix_decoding_integrated.py``.
-    # ``field(default_factory=dict)`` so each ``ModelConfig`` instance gets
-    # its own fresh dict (a literal ``{}`` would silently share state).
-    suffix_bench_speedup: dict[str, float] = field(default_factory=dict)
-
-    # PFlash long-prompt compression eligibility (#287). Mirrors
-    # ``AliasProfile.pflash_tier`` — the single source of truth lives in
-    # ``aliases.json`` and is copied here by ``detect_model_config`` so
-    # ``serve``/``bench`` can pick up the default without re-resolving
-    # the profile. Values: ``"unknown"`` (engine defaults PFlash off) or
-    # ``"verified"`` (engine defaults PFlash to ``always``). Explicit
-    # CLI ``--pflash`` still wins. See VALID_PFLASH_TIERS for the enum.
-    pflash_tier: str = "unknown"
-
-    # Mirrors ``AliasProfile.turboquant_tier``; see VALID_TURBOQUANT_TIERS.
-    turboquant_tier: str = "unknown"
-
-    # DFlash block-diffusion speculative decoding eligibility (#264).
-    # Mirrors ``AliasProfile.supports_dflash`` so ``rapid-mlx info`` can
-    # call out the DFlash opt-in path in the ``Spec decode`` row instead
-    # of mis-leading the user with ``(no MTP/drafter trained)`` when an
-    # alias has the DFlash drafter registered. 0.9.1 dogfood found the
-    # 27B-8bit alias hitting exactly that mismatch.
-    supports_dflash: bool = False
+# ``ModelConfig`` is a DEPRECATED alias of the unified ``ModelProfile``
+# (defined in the import-light ``model_profile`` module). The regex table
+# below constructs ``ModelConfig(...)`` by keyword; since it is the SAME
+# class as ``ModelProfile`` (frozen; ``hf_path`` defaults to "" so a
+# regex-detected profile needs no owning alias), those constructions are
+# unchanged. ``detect_model_config`` now returns the resolved
+# ``ModelProfile`` directly for aliases — no field-by-field copy that
+# could silently drop a field. A follow-up rename PR migrates the ~20
+# call sites to ``ModelProfile`` and drops this shim.
+ModelConfig = ModelProfile
 
 
 # The name-regex map below is the ONLY fall-back when a serve target lacks
@@ -756,30 +691,15 @@ def detect_model_config(model_path: str) -> ModelConfig | None:
             f"pflash_tier={profile.pflash_tier}, "
             f"turboquant_tier={profile.turboquant_tier}",
         )
-        # AliasProfile stores the bench dict as a sorted tuple (frozen
-        # dataclasses must avoid mutable shared state). Materialize a
-        # fresh dict here so each ModelConfig instance owns its copy.
-        speedup = (
-            dict(profile.suffix_bench_speedup) if profile.suffix_bench_speedup else {}
-        )
-        return ModelConfig(
-            tool_call_parser=profile.tool_call_parser,
-            reasoning_parser=profile.reasoning_parser,
-            default_max_tokens=profile.default_max_tokens,
-            is_hybrid=profile.is_hybrid,
-            # r6-A R6-C1: thread the explicit-pin flag so
-            # ``enrich_model_config`` can honour aliases that have
-            # deliberately marked their model as non-hybrid even when
-            # the upstream ``make_cache()`` returns linear-attention
-            # layers (qwen3_5 dense weights).
-            is_hybrid_explicit=profile.is_hybrid_explicit,
-            supports_spec_decode=profile.supports_spec_decode,
-            suffix_decoding_tier=profile.suffix_decoding_tier,
-            suffix_bench_speedup=speedup,
-            pflash_tier=profile.pflash_tier,
-            turboquant_tier=profile.turboquant_tier,
-            supports_dflash=profile.supports_dflash,
-        )
+        # The resolved profile IS a ModelProfile with every field already
+        # populated — return it directly. The former field-by-field copy
+        # into a fresh ModelConfig is exactly the drift surface this
+        # unification removes: any AliasProfile field omitted from that
+        # copy (is_moe, dflash_draft_model, recommended_sampling, modality,
+        # ddtree_*, min_memory_gb) silently never reached callers of
+        # detect_model_config. ``suffix_bench_speedup`` stays a tuple here;
+        # consumers that index by workload key use ``.speedup_dict``.
+        return profile
 
     # DeepSeek-Coder-V2 / V2-Lite routing — handled here (not in the
     # ``_MODEL_PATTERNS`` regex table) because the decision MUST be scoped
@@ -1422,7 +1342,7 @@ def suffix_decoding_hint(cfg: "ModelConfig | None") -> str | None:
     if not cfg.supports_spec_decode:
         return None
     tier = cfg.suffix_decoding_tier
-    speedup = cfg.suffix_bench_speedup or {}
+    speedup = cfg.speedup_dict
     if tier == "agent":
         peak = speedup.get("tool_loop") or (max(speedup.values()) if speedup else 0)
         return (
@@ -1489,7 +1409,7 @@ def _suffix_tier_cell(cfg: "ModelConfig", max_width: int | None = None) -> str:
             text = "n/a (no MTP/drafter — spec decode off)"
     else:
         tier = cfg.suffix_decoding_tier
-        speedup = cfg.suffix_bench_speedup or {}
+        speedup = cfg.speedup_dict
         if tier == "unknown":
             text = "unknown — run scripts/bench_suffix_decoding_integrated"
         elif tier == "agent" and speedup:

--- a/vllm_mlx/model_profile.py
+++ b/vllm_mlx/model_profile.py
@@ -53,27 +53,46 @@ from typing import Literal
 Modality = Literal["text", "text-diffusion", "vision", "image-gen"]
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class ModelProfile:
     """Per-model profile — parser defaults + capability gates.
 
     The single dataclass behind both ``AliasProfile`` (alias-keyed) and
     ``ModelConfig`` (regex-detected). Frozen so a resolved profile can be
-    shared safely across threads and cached without a defensive copy;
-    ``enrich_model_config`` produces mutated variants via
-    ``dataclasses.replace``. Defaults err on the side of "supported" —
-    known-incompatible families set the flag explicitly.
+    shared safely across threads and cached without a defensive copy.
 
     ``hf_path`` defaults to ``""`` so a regex-detected profile (no owning
     alias) can be constructed without one; alias construction always
     passes a validated non-empty path via ``model_aliases._coerce``.
 
-    Field ORDER is load-bearing: ``hf_path`` stays first and new fields
-    are appended at the tail so existing positional construction
-    (``ModelProfile(hf_path, tool_call_parser, ...)`` — historically
-    ``AliasProfile(...)``) keeps binding to the same slots. pr_validate
-    codex round 11 [BLOCKING #1] once caught a mid-dataclass insert
-    silently routing the parser positional into the wrong field.
+    Construction is KEYWORD-ONLY (``kw_only=True``). This is deliberate
+    and load-bearing for the unification: the pre-unification ``ModelConfig``
+    began with ``tool_call_parser`` and carried no ``hf_path`` field at
+    all, whereas the unified profile begins with ``hf_path``. Under
+    positional construction a legacy call like ``ModelConfig("hermes")``
+    would silently bind ``hf_path="hermes"`` instead of the intended
+    ``tool_call_parser`` (pr_validate codex flagged exactly this on PR
+    #1108). ``kw_only=True`` makes any positional construction a loud
+    ``TypeError`` instead of a silent field-misbind, so the field-order
+    difference between the two former dataclasses can never surface as a
+    routing bug. Every construction site in-tree already passes keywords
+    (``model_aliases._coerce``, the ``model_auto_config`` regex table,
+    and all tests), so this is a no-op for existing callers.
+
+    Migration paths for the two shape changes the unification introduced
+    (both flagged by codex as needing an explicit deprecation path):
+      * ``ModelConfig`` was mutable; a resolved profile is now frozen.
+        Produce a modified copy with ``dataclasses.replace(profile,
+        field=value)`` instead of ``profile.field = value``
+        (``model_auto_config.enrich_model_config`` and
+        ``engine_core`` already do this).
+      * ``suffix_bench_speedup`` was a ``dict``; it is now a tuple of
+        ``(workload, speedup)`` pairs (frozen dataclasses need immutable,
+        hashable fields). Read it as a mapping via the ``speedup_dict``
+        property, never ``profile.suffix_bench_speedup.get(...)``.
+
+    Defaults err on the side of "supported" — known-incompatible families
+    set the flag explicitly.
     """
 
     hf_path: str = ""
@@ -154,10 +173,6 @@ class ModelProfile:
     # ``"text-diffusion"`` → ``runtime/diffusion_lane.py`` (block
     # denoising, no spec-decode, no DFlash); ``"vision"`` /
     # ``"image-gen"`` reserved for upcoming integrations.
-    #
-    # NOTE on positional ABI: appended at the tail (not after ``hf_path``)
-    # so existing positional construction keeps binding to the same
-    # fields. Keep new fields at the tail.
     modality: Modality = "text"
     # PFlash long-prompt compression eligibility (#287). Default
     # ``"unknown"`` keeps the engine's PFlash mode at ``"off"`` so a

--- a/vllm_mlx/model_profile.py
+++ b/vllm_mlx/model_profile.py
@@ -1,0 +1,199 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Single source of truth for per-model profile data.
+
+Unifies the former ``AliasProfile`` (alias-keyed, resolved from
+``aliases.json``) and ``ModelConfig`` (regex-detected, from
+``model_auto_config``) into ONE frozen dataclass. Before this module the
+two dataclasses mirrored a shared field set by hand, and
+``detect_model_config`` copied a *subset* of ``AliasProfile``'s fields
+into a fresh ``ModelConfig`` — so any field that existed on the alias
+profile but was forgotten in that copy (``is_moe``, ``dflash_draft_model``,
+``recommended_sampling``, ``modality``, ``ddtree_*``, ``min_memory_gb``)
+silently never reached ``rapid-mlx info`` / serve defaults. Adding a field
+meant editing two dataclasses AND the copy site; missing any one dropped
+the field. Now there is exactly one class + one field set: add a field
+here and every consumer sees it, with no copy step to drift out of sync.
+
+``AliasProfile`` (in ``model_aliases``) and ``ModelConfig`` (in
+``model_auto_config``) remain as module-level aliases of this class for
+backward compatibility with the ~20 call sites that import them by name —
+they are the *same* class, not two shapes.
+
+Import-light on purpose: only stdlib + typing, so lightweight callers
+(the CLI alias map, dflash / ddtree eligibility checks) can import the
+profile shape without pulling in ``model_auto_config``'s regex detection
+tables. Locating the class here (rather than in ``model_auto_config``)
+also avoids an import cycle: ``model_auto_config`` already imports
+``model_aliases.resolve_profile``, so the profile dataclass cannot live in
+``model_auto_config`` without ``model_aliases`` importing it back.
+"""
+
+from dataclasses import dataclass
+from typing import Literal
+
+# NOTE: deliberately NO ``from __future__ import annotations`` here. The
+# out-of-band-routing guard (tests/test_no_out_of_band_routing.py) inspects
+# ``dataclasses.fields(...).type`` to flag any ``str`` field as a possible
+# covert routing switch. Under stringized annotations that check sees the
+# raw source text, so tuple fields whose element type mentions ``str``
+# (``recommended_sampling``, ``suffix_bench_speedup``) get misread as str
+# fields. Keeping real type objects matches the pre-unification AliasProfile
+# behaviour. All annotations below are valid at runtime on Python 3.10+
+# (PEP 604 ``X | None`` + PEP 585 ``tuple[...]``).
+
+# Canonical modality enum. Default is ``"text"`` so every legacy alias
+# (and every external JSON snippet that pre-dates this field) keeps the
+# auto-regressive LLM lane untouched. New modalities branch the runtime
+# at startup — see ``runtime/diffusion_lane.py`` for the discrete
+# text-diffusion path used by DiffusionGemma. ``"vision"`` and
+# ``"image-gen"`` are reserved for forthcoming Bonsai/VLM integrations.
+# Adding a new value requires editing this Literal AND the dispatch table
+# in cli.py / routes/models.py so the surface-level UX (info, ls, chat)
+# doesn't silently expose LLM-only columns on a non-LLM alias.
+Modality = Literal["text", "text-diffusion", "vision", "image-gen"]
+
+
+@dataclass(frozen=True)
+class ModelProfile:
+    """Per-model profile — parser defaults + capability gates.
+
+    The single dataclass behind both ``AliasProfile`` (alias-keyed) and
+    ``ModelConfig`` (regex-detected). Frozen so a resolved profile can be
+    shared safely across threads and cached without a defensive copy;
+    ``enrich_model_config`` produces mutated variants via
+    ``dataclasses.replace``. Defaults err on the side of "supported" —
+    known-incompatible families set the flag explicitly.
+
+    ``hf_path`` defaults to ``""`` so a regex-detected profile (no owning
+    alias) can be constructed without one; alias construction always
+    passes a validated non-empty path via ``model_aliases._coerce``.
+
+    Field ORDER is load-bearing: ``hf_path`` stays first and new fields
+    are appended at the tail so existing positional construction
+    (``ModelProfile(hf_path, tool_call_parser, ...)`` — historically
+    ``AliasProfile(...)``) keeps binding to the same slots. pr_validate
+    codex round 11 [BLOCKING #1] once caught a mid-dataclass insert
+    silently routing the parser positional into the wrong field.
+    """
+
+    hf_path: str = ""
+
+    # --- Parser defaults ---
+    tool_call_parser: str | None = None
+    reasoning_parser: str | None = None
+
+    # --- Architecture / capability gates ---
+    # ``is_hybrid`` = the model uses linear-attention or recurrent layers
+    # (GatedDeltaNet, Mamba, Jamba, ...). Hybrid models need request
+    # throttling and disable optimizations that rely on chunked-batched
+    # forward — verified on Qwen3.5-4B where spec decode produces
+    # corrupted output (see evals/results/SUFFIX_POC_REPORT.md).
+    is_hybrid: bool = False
+    # r6-A R6-C1: when an aliases.json entry explicitly declares
+    # ``is_hybrid``, the runtime ArraysCache probe in
+    # ``model_auto_config.enrich_model_config`` MUST NOT override the
+    # declared value. Without this flag, the probe one-way-promotes
+    # ``is_hybrid`` to ``True`` for any model whose ``make_cache()``
+    # returns linear-attention layers — which is exactly what dense
+    # Qwen3.5 / Qwen3.6 weights do (model_type=qwen3_5 uses
+    # GatedDeltaNet), forcing the alias-level routing decision (hybrid
+    # throttle + prefix-boundary snapshot) back on even after the JSON
+    # marked the model as non-hybrid. That re-promotion is what
+    # wedges ``rapid-mlx serve qwen3.5-4b-4bit`` on metal::malloc with a
+    # 499000 byte limit; ``--no-hybrid`` was the only workaround.
+    #
+    # Default ``False`` keeps the existing safety-net behaviour for
+    # legacy aliases that haven't opted into the explicit contract —
+    # those still pick up the probe's hybrid promotion as before.
+    is_hybrid_explicit: bool = False
+    # MoE / sparse-expert architecture (A3B, A10B, A17B Qwen3.5/3.6 variants,
+    # plus future Mixtral/Granite-MoE families). Tracked separately from
+    # ``is_hybrid`` because the two attributes gate different downstream
+    # paths — hybrid affects ArraysCache/GDN rollback, MoE affects DFlash
+    # acceptance rate (the drafter's hidden-state fusion misfires on
+    # expert-routing churn; PoC measured 0.76-0.82× regression regardless
+    # of precision on Qwen3.6-35B-A3B).
+    is_moe: bool = False
+    # ``supports_spec_decode`` controls SuffixDecoding / draft-model
+    # speculative decoding. Disabled for hybrid models because the
+    # batched-verify path through GatedDeltaNet derails generation.
+    # Pure-attention models (llama, qwen3, mistral, gemma3, gpt-oss,
+    # phi, ...) are safe.
+    supports_spec_decode: bool = True
+    default_max_tokens: int | None = None  # Per-model default when user omits
+
+    # SuffixDecoding eligibility — populated from cross-model bench (issue #269).
+    # ``None`` for ``suffix_bench_speedup`` means "not benched yet"; the tier
+    # then defaults to ``"unknown"`` and the startup hint stays silent.
+    # When populated, ``suffix_bench_speedup`` is a tuple of ``(workload, speedup)``
+    # pairs (tuple, not dict, so frozen dataclass instances stay safely shareable).
+    # Consumers that index by workload key use the ``speedup_dict`` property.
+    suffix_decoding_tier: str = "unknown"
+    suffix_bench_speedup: tuple[tuple[str, float], ...] | None = None
+    # DFlash speculative-decoding eligibility (issue #264). Explicit opt-in
+    # per alias rather than auto-derived because the PoC showed
+    # precision-dependent regressions: 4-bit kills acceptance even on dense
+    # models. Aliases keep ``supports_dflash=False`` until benched to win
+    # by ≥1.3× on the canonical Fibonacci/Quicksort/HashTable prompts.
+    # ``dflash_draft_model`` is the matching drafter HF path (e.g.
+    # ``z-lab/Qwen3.5-27B-DFlash``); required if ``supports_dflash=True``.
+    supports_dflash: bool = False
+    dflash_draft_model: str | None = None
+    # Recommended sampling defaults — curated per-family overrides that
+    # sit above HF ``generation_config.json`` in the resolve chain (see
+    # ``service/helpers.py``). Tuple-of-pairs (not dict) because the
+    # dataclass is frozen and dict defaults are mutable. Keys are
+    # restricted to the sampling subset: ``temperature``, ``top_p``,
+    # ``top_k``, ``min_p``, ``repetition_penalty``, ``presence_penalty``,
+    # ``frequency_penalty``. ``None`` means "no curated value" → fall
+    # through to ``generation_config.json``.
+    recommended_sampling: tuple[tuple[str, float], ...] | None = None
+    # Inference modality. Default ``"text"`` covers every legacy LLM
+    # alias and keeps the auto-regressive scheduler/runtime path
+    # unchanged. Non-text modalities branch into dedicated lanes:
+    # ``"text-diffusion"`` → ``runtime/diffusion_lane.py`` (block
+    # denoising, no spec-decode, no DFlash); ``"vision"`` /
+    # ``"image-gen"`` reserved for upcoming integrations.
+    #
+    # NOTE on positional ABI: appended at the tail (not after ``hf_path``)
+    # so existing positional construction keeps binding to the same
+    # fields. Keep new fields at the tail.
+    modality: Modality = "text"
+    # PFlash long-prompt compression eligibility (#287). Default
+    # ``"unknown"`` keeps the engine's PFlash mode at ``"off"`` so a
+    # brand-new alias never silently enables compression on an
+    # unbenched architecture. ``"verified"`` flips the engine's default
+    # to ``"always"`` — used only for aliases where we've measured both
+    # the TTFT speedup AND the needle-recall floor (Qwen3.5 / Qwen3.6
+    # families per #287). Explicit CLI ``--pflash {off,auto,always}``
+    # still wins; this only changes the no-flag default.
+    pflash_tier: str = "unknown"
+    # TurboQuant K8V4 default-on tier. See ``VALID_TURBOQUANT_TIERS``.
+    turboquant_tier: str = "unknown"
+    # DDTree speculative-decoding eligibility (#879). Intentionally
+    # separate from DFlash even though it uses the same DFlash draft
+    # weights: DDTree verifies a tree of candidate continuations and
+    # needs model-family specific verifier support.
+    supports_ddtree: bool = False
+    ddtree_draft_model: str | None = None
+    ddtree_speculative_tokens: int | None = None
+    ddtree_tree_budget: int | None = None
+    # codex round 3 [NIT #3]: minimum unified-memory floor (in GB) for
+    # aliases that are unfit for smaller machines. ``None`` means "no
+    # hardware gate" — the default for every text/vision model we ship
+    # under 100 GB weights. Populated for the flagship-tier Ultra-only
+    # entries (currently ``hy3-preview-4bit`` at 166 GB weights + ~156
+    # GB peak RSS — needs 192 GB+ M3 Ultra). Enforced as a boot-time
+    # WARNING (not a hard block) in ``vllm_mlx/cli.py``.
+    min_memory_gb: float | None = None
+
+    @property
+    def speedup_dict(self) -> dict[str, float]:
+        """``suffix_bench_speedup`` materialized as a fresh dict.
+
+        The field is stored as a tuple-of-pairs so the frozen dataclass
+        stays hashable and safely shareable; consumers that index by
+        workload key (``_suffix_tier_cell``) call this to get a plain
+        dict. ``None`` (not benched) yields an empty dict.
+        """
+        return dict(self.suffix_bench_speedup or ())


### PR DESCRIPTION
## Why

`rapid-mlx info` (and serve defaults) silently dropped half a model's profile **because** two dataclasses described the same thing and `detect_model_config` hand-copied only 11 of 20+ fields between them. Any field on the alias profile that wasn't in that copy (`is_moe`, `dflash_draft_model`, `recommended_sampling`, `modality`, `ddtree_*`, `min_memory_gb`) never reached the reader. The root cause is having two shapes at all; this PR collapses them to one so the drift surface is gone by construction.

## What

Unify the two per-model profile dataclasses into a single frozen source of truth.

Before this PR two dataclasses described the same concept:

- `AliasProfile` (`model_aliases.py`) — 21-field superset, alias-keyed, resolved from `aliases.json`.
- `ModelConfig` (`model_auto_config.py`) — 11-field lossy subset, regex-detected.

`detect_model_config` resolved a full `AliasProfile` and then **hand-copied only 11 of its 20+ fields** into a fresh `ModelConfig`. Any field present on the alias profile but forgotten in that copy — `is_moe`, `dflash_draft_model`, `recommended_sampling`, `modality`, `ddtree_*`, `min_memory_gb` — silently never reached downstream readers (`rapid-mlx info`, serve defaults). Adding a field meant editing two dataclasses **and** the copy site; missing any one dropped the field on the floor.

## How

- New import-light module `vllm_mlx/model_profile.py` holds one `@dataclass(frozen=True) ModelProfile` with the full field set + a `speedup_dict` property.
- `AliasProfile` (in `model_aliases`) and `ModelConfig` (in `model_auto_config`) are now **deprecated module-level aliases** of `ModelProfile` — same class, not two shapes. All ~20 existing import sites keep working unchanged.
- `detect_model_config` returns the resolved profile directly — **no copy step** to drift out of sync. A field added to `ModelProfile` now reaches every consumer automatically.
- Locating the class in its own module (not `model_auto_config`) avoids an import cycle: `model_auto_config` already imports `model_aliases.resolve_profile`, so the dataclass can't live in `model_auto_config` without `model_aliases` importing it back.

### Reconciled differences between the two originals

- **frozen** — `ModelConfig` was mutable; unified to frozen (shareable across threads, cacheable without defensive copy). `engine_core.py`'s 4 direct field mutations migrated to `dataclasses.replace()`. `enrich_model_config` already used `replace()`.
- **`suffix_bench_speedup`** — `ModelConfig` stored a `dict` (mutable, unhashable → incompatible with frozen); `AliasProfile` stored a `tuple` of pairs. Unified to the tuple form + a `speedup_dict` property that normalizes `None`/tuple → fresh `dict`. Consumers migrated from `cfg.suffix_bench_speedup or {}` to `cfg.speedup_dict`.
- **`hf_path`** — was required on `AliasProfile`; given default `""` so a regex-detected profile (no owning alias) constructs without one. Field ORDER preserved (`hf_path` first) for positional-construction ABI.

### Note on `from __future__ import annotations`

Deliberately **omitted** from `model_profile.py`. The out-of-band-routing guard (`tests/test_no_out_of_band_routing.py`) inspects `dataclasses.fields(...).type` to flag any `str` field as a possible covert routing switch. Under stringized annotations that check sees raw source text, so tuple fields whose element type text mentions `str` (`recommended_sampling`, `suffix_bench_speedup`) get misread as `str` fields. Keeping real type objects matches the pre-unification `AliasProfile` behaviour; all annotations are valid at runtime on Python 3.10+ (PEP 604 `X | None` + PEP 585 `tuple[...]`).

## Test plan

- `ModelProfile is AliasProfile is ModelConfig` → True (single class).
- `detect_model_config('gpt-oss-20b').is_moe` → True and `.hf_path` set (previously dropped by the lossy copy).
- Regex-fallback path still builds a full profile (`Qwen3-42B` → `tool_call_parser='hermes'`, `hf_path=''`).
- Frozen enforcement: field assignment raises `FrozenInstanceError`; overrides go through `replace()`.
- `ModelConfig().speedup_dict == {}` / `.suffix_bench_speedup is None`; `speedup_dict` returns a fresh dict each call.
- Full unit suite green; `ruff check` + `ruff format --check` clean.

## Drive-by: fix a pre-existing test-isolation flake

While validating this PR I hit a latent cross-file flake (unrelated to the profile change — reproduces identically on `main`):

- `test_diffusion_engine.py` mutates the process-wide config singleton (`cfg.tool_call_parser = "hermes"`, to exercise the diffusion tool-call veto) and never restores it.
- `test_routes.py::test_retrieve_unknown_id_keeps_baseline_shape` asserts the "unknown-id baseline" but didn't pin `tool_call_parser` — for a *served* id the route legitimately reads `cfg.tool_call_parser` (Tier-2 of `effective_parsers_for`), so it inherited the leaked `'hermes'` under any collection order that runs the diffusion file first.

The full unit suite is deterministically ordered (no `pytest-randomly`), so `main` happens to be green — but the interaction is real and order-fragile. Fixed at both ends:

- **Root cause** — module-scoped autouse teardown in `test_diffusion_engine.py` that `reset_config()`s at module exit, so the file can never leak config state downstream (zero change to in-file ordering/state).
- **Hermeticity** — the baseline test now pins `tool_call_parser=None`, so it controls every input to its own assertion.

## Addressing codex round 1

codex flagged three contract changes on the deprecated `ModelConfig` alias. All three are real *shape* changes but break **zero** in-tree callers (verified: 12633-test full suite green, plus targeted greps — every construction site is keyword, every former mutation goes through `replace()`, every former dict access goes through `speedup_dict`). `ModelConfig` is an internal, non-exported dataclass slated for removal in the follow-up rename PR. Addressed concretely:

- **Positional-constructor misbind** (the one genuine latent footgun — old `ModelConfig` began with `tool_call_parser` and had no `hf_path`; unified profile begins with `hf_path`): the dataclass is now `kw_only=True`. Positional construction is a loud `TypeError`, so the field-order difference can never surface as a silent field-misbind. No-op for existing callers (all keyword).
- **frozen** (was mutable) and **`suffix_bench_speedup` dict → tuple**: intentional and required for a thread-shareable, hashable single source of truth. The migration paths (`dataclasses.replace()` and the `speedup_dict` property) are now documented explicitly in the `ModelProfile` docstring.

## Follow-up

Separate mechanical PR: rename every `AliasProfile`/`ModelConfig` reference to `ModelProfile` and drop the deprecated aliases.
