### PR TITLE
fix: enforce DFlash server security policy

### DIFF
--- a/tests/test_dflash_integration.py
+++ b/tests/test_dflash_integration.py
@@ -2073,6 +2073,161 @@ def test_dflash_admission_reserved_before_body_parse(monkeypatch) -> None:
     assert response.json()["error"]["code"] == "at_capacity"
 
 
+def test_dflash_unauthenticated_request_does_not_reserve_slot() -> None:
+    """codex round-3 #3: auth is enforced BEFORE the admission slot is
+    reserved. A missing / wrong API key must return 401 and must NOT occupy
+    a DFlash slot — otherwise an unauthenticated client could exhaust every
+    slot (e.g. via slow body uploads) and deny service to authorized callers.
+    """
+    from fastapi.testclient import TestClient
+
+    from vllm_mlx.speculative.dflash.runtime import DFlashRuntime
+    from vllm_mlx.speculative.dflash.server import _build_app
+
+    model = MagicMock()
+    model.config = MagicMock()
+    app = _build_app(
+        model=model,
+        processor=MagicMock(),
+        runtime=DFlashRuntime(
+            drafter=MagicMock(),
+            kind="dflash",
+            drafter_repo="z-lab/Qwen3.5-27B-DFlash",
+        ),
+        served_model_name="qwen3.5-27b-8bit",
+        default_max_tokens=64,
+        cors_origins=[],
+        api_key="secret",
+        max_concurrent_requests=1,
+    )
+    client = TestClient(app)
+    admission = app.state.dflash_admission
+
+    body = {
+        "model": "qwen3.5-27b-8bit",
+        "messages": [{"role": "user", "content": "hi"}],
+    }
+
+    # No key → 401 and no slot consumed.
+    r = client.post("/v1/chat/completions", json=body)
+    assert r.status_code == 401, r.text
+    assert admission._reservations == 0, "codex #3 regression: 401 reserved a slot"
+
+    # Wrong key → 401 and no slot consumed.
+    r = client.post(
+        "/v1/chat/completions", headers={"Authorization": "Bearer nope"}, json=body
+    )
+    assert r.status_code == 401, r.text
+    assert admission._reservations == 0, (
+        "codex #3 regression: wrong key reserved a slot"
+    )
+
+    # A slot held externally must NOT block the pre-admission 401 — the auth
+    # rejection happens before the admission gate is even consulted.
+    held = admission.reserve()
+    try:
+        r = client.post("/v1/chat/completions", json=body)
+        assert r.status_code == 401, r.text
+    finally:
+        held.release()
+
+
+def test_dflash_rate_limited_request_does_not_reserve_slot() -> None:
+    """codex round-3 #3: rate-limit rejection also happens BEFORE reserving,
+    and the limiter is consulted exactly once per request (no double-count
+    from a leftover route dependency)."""
+    from fastapi.testclient import TestClient
+
+    from vllm_mlx.speculative.dflash.runtime import DFlashRuntime
+    from vllm_mlx.speculative.dflash.server import _build_app
+
+    model = MagicMock()
+    model.config = MagicMock()
+    app = _build_app(
+        model=model,
+        processor=MagicMock(),
+        runtime=DFlashRuntime(
+            drafter=MagicMock(),
+            kind="dflash",
+            drafter_repo="z-lab/Qwen3.5-27B-DFlash",
+        ),
+        served_model_name="qwen3.5-27b-8bit",
+        default_max_tokens=64,
+        cors_origins=[],
+        rate_limit=1,
+        max_concurrent_requests=4,
+    )
+    client = TestClient(app)
+    admission = app.state.dflash_admission
+
+    # Empty messages → 400, but the request still counts as the single
+    # allowed request (limiter consulted ONCE, not twice).
+    empty = {"model": "qwen3.5-27b-8bit", "messages": []}
+    r1 = client.post("/v1/chat/completions", json=empty)
+    assert r1.status_code == 400, r1.text
+    # Second request is over the per-minute budget → 429 from the middleware,
+    # before any slot is reserved.
+    r2 = client.post("/v1/chat/completions", json=empty)
+    assert r2.status_code == 429, r2.text
+    assert r2.json()["error"]["code"] == "rate_limit_exceeded"
+    assert admission._reservations == 0, "codex #3 regression: 429 reserved a slot"
+
+
+def test_dflash_stream_terminal_frame_delivered_on_timeout(monkeypatch) -> None:
+    """codex round-3 #2: the deadline-bounded backpressure on content frames
+    must NOT suppress the TERMINAL timeout/error + [DONE] frames. Even when
+    the request deadline is already blown, the client must still receive the
+    "timed out" notice and the stream terminator — otherwise it sees a
+    truncated stream with no explanation.
+    """
+    import asyncio
+    import sys
+    import time
+    import types
+
+    from vllm_mlx.api.models import ChatCompletionRequest, Message
+    from vllm_mlx.speculative.dflash import server as srv
+
+    class _SlowGenerator:
+        def __next__(self):
+            time.sleep(0.05)
+            raise StopIteration
+
+        def close(self):
+            pass
+
+    fake_mlx_vlm = types.ModuleType("mlx_vlm")
+    fake_mlx_vlm.stream_generate = lambda *_a, **_kw: _SlowGenerator()
+    monkeypatch.setitem(sys.modules, "mlx_vlm", fake_mlx_vlm)
+
+    request = ChatCompletionRequest(
+        model="qwen3.5-27b-8bit",
+        messages=[Message(role="user", content="hi")],
+        stream=True,
+    )
+
+    async def exercise() -> None:
+        stream = srv._stream_completion(
+            prompt="p",
+            request=request,
+            served_model_name="qwen3.5-27b-8bit",
+            gen_kwargs={"max_tokens": 8},
+            model=MagicMock(),
+            processor=MagicMock(),
+            timeout=0.01,  # already blown by the time the terminal frames emit
+        )
+        body = b"".join([chunk async for chunk in stream]).decode()
+        # Terminal frames survive the deadline bound.
+        assert "DFlash stream timed out after 0.0 seconds." in body
+        assert "data: [DONE]" in body
+
+    srv._dflash_lock = asyncio.Lock()
+    try:
+        asyncio.run(exercise())
+    finally:
+        srv._dflash_lock = asyncio.Lock()
+
+
 # =============================================================================
 # End-to-end — heavy. Requires:
 #   - ``RAPID_MLX_DFLASH_E2E=1`` env var (opt-in; CI doesn't set it)

--- a/tests/test_dflash_integration.py
+++ b/tests/test_dflash_integration.py
@@ -39,19 +39,44 @@ _skip_without_mlx_vlm = pytest.mark.skipif(
 
 @pytest.fixture(autouse=True)
 def _reset_dflash_shared_globals():
-    """Isolate the process-global rate limiter across DFlash tests.
+    """Isolate the process-global server state that DFlash tests mutate.
 
-    ``_build_app`` / ``run_dflash_server`` call ``configure_rate_limiter``,
-    which mutates a module-level singleton shared with the main server. A
-    DFlash test that enables the limiter (``rate_limit>0``) would otherwise
-    leak that enabled state into unrelated later tests (e.g.
-    ``tests/test_embeddings_timeout_admission.py``), turning their requests
-    into surprise 429s. Reset the limiter to disabled after every test here.
+    ``_build_app`` / ``run_dflash_server`` mutate two shared singletons that
+    outlive a single test:
+
+    * the process-global rate limiter (via ``configure_rate_limiter``) — a
+      DFlash test that enables it (``rate_limit>0``) would otherwise leak that
+      enabled state into unrelated later tests (e.g.
+      ``tests/test_embeddings_timeout_admission.py``), turning their requests
+      into surprise 429s; and
+
+    * the shared ``get_config()`` singleton — ``_build_app`` writes ``api_key``,
+      ``max_request_bytes``, ``body_receive_timeout_seconds`` and
+      ``default_timeout`` into it. codex round-7 #4: snapshot and restore ALL
+      of these so tests are not order-dependent under randomized execution
+      (e.g. a test setting ``api_key`` must not silently authenticate — or
+      reject — a later test that assumes no key).
     """
-    yield
-    from vllm_mlx.middleware.auth import configure_rate_limiter
+    from vllm_mlx.config import get_config
 
-    configure_rate_limiter(0, enabled=False)
+    cfg = get_config()
+    _snapshot = {
+        field: getattr(cfg, field)
+        for field in (
+            "api_key",
+            "max_request_bytes",
+            "body_receive_timeout_seconds",
+            "default_timeout",
+        )
+    }
+    try:
+        yield
+    finally:
+        from vllm_mlx.middleware.auth import configure_rate_limiter
+
+        configure_rate_limiter(0, enabled=False)
+        for field, value in _snapshot.items():
+            setattr(cfg, field, value)
 
 
 # =============================================================================
@@ -628,6 +653,8 @@ def test_dflash_format_timeout_seconds_adaptive_precision() -> None:
     assert _format_timeout_seconds(0.01) == "0.010 seconds"
     assert _format_timeout_seconds(0.005) == "0.005 seconds"
     assert _format_timeout_seconds(0.0) == "0 seconds"
+    # codex round-7 #3: sub-millisecond timeouts floor instead of "0.000".
+    assert _format_timeout_seconds(0.0001) == "<0.001 seconds"
 
 
 def test_dflash_stream_timeout_stops_after_the_inflight_worker_step(
@@ -2506,6 +2533,11 @@ def test_dflash_slow_prompt_render_is_charged_against_deadline(monkeypatch) -> N
     the deadline now spans rendering. (It also could not have surfaced a 504
     at all if rendering still ran unbounded on the event loop.)
     """
+    # A render that overruns the 0.05s request budget. Runs on the separate
+    # render pool (offloaded), so the event loop stays free to enforce the
+    # deadline via ``asyncio.wait_for``. Uses an event so the test controls
+    # exactly when the (uncancellable, already-running) render finishes.
+    import threading
     import time
 
     from fastapi.testclient import TestClient
@@ -2514,11 +2546,10 @@ def test_dflash_slow_prompt_render_is_charged_against_deadline(monkeypatch) -> N
     from vllm_mlx.speculative.dflash.runtime import DFlashRuntime
     from vllm_mlx.speculative.dflash.server import _build_app
 
-    # A render that vastly overruns the 0.05s request budget. Runs on the
-    # DFlash worker thread (offloaded), so the event loop stays free to
-    # enforce the deadline via ``asyncio.wait_for``.
+    render_may_finish = threading.Event()
+
     def _slow_render(*_args, **_kwargs) -> str:
-        time.sleep(0.4)
+        render_may_finish.wait(timeout=5)
         return "rendered"
 
     monkeypatch.setattr(srv, "_render_prompt", _slow_render)
@@ -2539,18 +2570,33 @@ def test_dflash_slow_prompt_render_is_charged_against_deadline(monkeypatch) -> N
     client = TestClient(app)
     admission = app.state.dflash_admission
 
-    r = client.post(
-        "/v1/chat/completions",
-        json={
-            "model": "qwen3.5-27b-8bit",
-            "messages": [{"role": "user", "content": "hi"}],
-            "timeout": 0.05,
-        },
-    )
-    assert r.status_code == 504, r.text
-    # The slot must not leak when rendering times out.
+    try:
+        r = client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "qwen3.5-27b-8bit",
+                "messages": [{"role": "user", "content": "hi"}],
+                "timeout": 0.05,
+            },
+        )
+        assert r.status_code == 504, r.text
+        # codex round-7 #2: the render is STILL running (uncancellable), so the
+        # admission slot is HELD — not freed — until it drains. This is what
+        # stops a burst of cancelled/timed-out requests from piling up renders
+        # on the single-worker pool while capacity is handed back out.
+        assert admission._reservations == 1, (
+            "codex #7 regression: slot freed while the render was still running"
+        )
+    finally:
+        # Let the render finish; the deferred callback then releases the slot.
+        render_may_finish.set()
+
+    for _ in range(300):
+        if admission._reservations == 0:
+            break
+        time.sleep(0.01)
     assert admission._reservations == 0, (
-        "codex #4 regression: render-timeout leaked an admission slot"
+        "codex #4/#7 regression: slot not released after the render drained"
     )
 
 

--- a/tests/test_dflash_integration.py
+++ b/tests/test_dflash_integration.py
@@ -617,6 +617,19 @@ def test_dflash_timeout_message_reports_original_not_post_render_budget(
         srv._dflash_lock = asyncio.Lock()
 
 
+def test_dflash_format_timeout_seconds_adaptive_precision() -> None:
+    """codex round-6 #5: small positive timeouts keep meaningful digits."""
+    from vllm_mlx.speculative.dflash.server import _format_timeout_seconds
+
+    assert _format_timeout_seconds(60.0) == "60.0 seconds"
+    assert _format_timeout_seconds(1.5) == "1.5 seconds"
+    # Sub-second and sub-100ms: NOT collapsed to "0.0 seconds".
+    assert _format_timeout_seconds(0.25) == "0.25 seconds"
+    assert _format_timeout_seconds(0.01) == "0.010 seconds"
+    assert _format_timeout_seconds(0.005) == "0.005 seconds"
+    assert _format_timeout_seconds(0.0) == "0 seconds"
+
+
 def test_dflash_stream_timeout_stops_after_the_inflight_worker_step(
     monkeypatch,
 ) -> None:
@@ -689,7 +702,9 @@ def test_dflash_stream_timeout_stops_after_the_inflight_worker_step(
         elapsed = asyncio.get_running_loop().time() - started
 
         # The timeout SSE + DONE are emitted without blocking on the worker.
-        assert "DFlash stream timed out after 0.0 seconds." in body
+        # codex round-6 #5: adaptive precision renders the 0.01s deadline as
+        # "0.010 seconds", not a misleading "0.0 seconds".
+        assert "DFlash stream timed out after 0.010 seconds." in body
         assert "data: [DONE]" in body
         # The worker step must NOT gate the response — the fixed path surfaces
         # the timeout well before the worker's (much longer) sleep elapses.
@@ -2334,6 +2349,107 @@ def test_dflash_stream_backpressure_delivers_terminal_notice(monkeypatch) -> Non
         srv._dflash_lock = asyncio.Lock()
 
 
+def test_dflash_hung_generator_close_does_not_block_terminal_sse(monkeypatch) -> None:
+    """codex round-6 #2: a hung ``generator.close()`` must NOT block the
+    terminal SSE (final frame + [DONE]).
+
+    ``__aexit__`` closes the generator on the serial worker. If that close
+    hangs (a runaway mlx-vlm GPU-teardown finally block), awaiting it inline
+    would stall the producer's terminal frames indefinitely. The lease now
+    bounds the close wait and DETACHES a slow close, retaining the lock/slot
+    until it finishes while letting the response terminate promptly. Here the
+    generator errors mid-stream (so we hit the terminal path) and its
+    ``close()`` blocks; the client must still get [DONE] quickly.
+    """
+    import asyncio
+    import sys
+    import threading
+    import types
+
+    from vllm_mlx.api.models import ChatCompletionRequest, Message
+    from vllm_mlx.speculative.dflash import server as srv
+
+    # Tiny close grace so the test doesn't wait the real 5s to detach.
+    monkeypatch.setattr(srv, "_STREAM_GENERATOR_CLOSE_GRACE_SECONDS", 0.05)
+
+    close_called = threading.Event()
+    release_close = threading.Event()
+
+    class _HangOnCloseGenerator:
+        def __init__(self):
+            self._n = 0
+
+        def __iter__(self):
+            return self
+
+        def __next__(self):
+            self._n += 1
+            if self._n == 1:
+                return SimpleNamespace(
+                    text="tok1", generation_tokens=1, prompt_tokens=3, token=101
+                )
+            # Error mid-stream → terminal error path → __aexit__ closes gen.
+            raise RuntimeError("boom")
+
+        def close(self):
+            close_called.set()
+            # Block until the test explicitly releases — simulates a hung close.
+            release_close.wait(timeout=5)
+
+    fake_mlx_vlm = types.ModuleType("mlx_vlm")
+    fake_mlx_vlm.stream_generate = lambda *a, **kw: _HangOnCloseGenerator()
+    monkeypatch.setitem(sys.modules, "mlx_vlm", fake_mlx_vlm)
+
+    request = ChatCompletionRequest(
+        model="qwen3.5-27b-8bit",
+        messages=[Message(role="user", content="hi")],
+        stream=True,
+    )
+
+    async def exercise() -> None:
+        admission = srv._DFlashAdmission(max_concurrent_requests=1)
+        reservation = admission.reserve()
+        stream = srv._stream_completion(
+            prompt="p",
+            request=request,
+            served_model_name="qwen3.5-27b-8bit",
+            gen_kwargs={"max_tokens": 8},
+            model=MagicMock(),
+            processor=MagicMock(),
+            timeout=0,
+            admission_reservation=reservation,
+        )
+        started = asyncio.get_running_loop().time()
+        body = b"".join([chunk async for chunk in stream]).decode()
+        elapsed = asyncio.get_running_loop().time() - started
+
+        # The terminal [DONE] arrived even though close() is still blocked.
+        assert "data: [DONE]" in body
+        assert await asyncio.to_thread(close_called.wait, 1)
+        # The stream terminated on the ~0.05s detach grace, NOT the 5s close.
+        assert elapsed < 1.0, (
+            f"codex #6 regression: terminal SSE blocked on hung close ({elapsed:.2f}s)"
+        )
+        # Lock/slot stay HELD until the detached close finishes.
+        assert srv._dflash_lock.locked()
+        assert admission._reservations == 1
+        # Now let the close complete; lock + slot release from its callback.
+        release_close.set()
+        for _ in range(300):
+            if not srv._dflash_lock.locked() and admission._reservations == 0:
+                break
+            await asyncio.sleep(0.01)
+        assert not srv._dflash_lock.locked()
+        assert admission._reservations == 0
+
+    srv._dflash_lock = asyncio.Lock()
+    try:
+        asyncio.run(exercise())
+    finally:
+        release_close.set()
+        srv._dflash_lock = asyncio.Lock()
+
+
 def test_dflash_admission_reserved_before_body_parse(monkeypatch) -> None:
     """F1: the ASGI admission middleware rejects with 503 BEFORE FastAPI
     parses the request body.
@@ -2504,6 +2620,17 @@ def test_dflash_unauthenticated_request_does_not_reserve_slot() -> None:
         "challenge required for bearer-protected resources"
     )
 
+    # codex round-6 #1: the /v1/models route (which uses a route dependency,
+    # not the chat ASGI middleware) must ALSO emit the challenge on 401.
+    r = client.get("/v1/models")
+    assert r.status_code == 401, r.text
+    assert r.headers.get("WWW-Authenticate") == "Bearer", (
+        "codex #6 regression: /v1/models 401 dropped WWW-Authenticate: Bearer"
+    )
+    # And a correct key still passes.
+    r = client.get("/v1/models", headers={"Authorization": "Bearer secret"})
+    assert r.status_code == 200, r.text
+
 
 def test_dflash_rate_limited_request_does_not_reserve_slot() -> None:
     """codex round-3 #3: rate-limit rejection also happens BEFORE reserving,
@@ -2620,7 +2747,8 @@ def test_dflash_stream_terminal_frame_delivered_on_timeout(monkeypatch) -> None:
         )
         body = b"".join([chunk async for chunk in stream]).decode()
         # Terminal frames survive the deadline bound.
-        assert "DFlash stream timed out after 0.0 seconds." in body
+        # codex round-6 #5: 0.01s renders as "0.010 seconds" (adaptive).
+        assert "DFlash stream timed out after 0.010 seconds." in body
         assert "data: [DONE]" in body
 
     srv._dflash_lock = asyncio.Lock()

--- a/tests/test_dflash_integration.py
+++ b/tests/test_dflash_integration.py
@@ -568,10 +568,15 @@ def test_dflash_stream_timeout_stops_after_the_inflight_worker_step(
     deadline expiry — the response must NOT block on the non-preemptible
     in-flight worker step. The lock stays held (deferred cleanup) until the
     detached worker actually exits, then is released. Here the worker sleeps
-    0.05s while the deadline is 0.01s, so a fix that awaited the worker
-    before emitting the timeout would keep the client waiting the full 0.05s;
-    the fixed path emits the timeout SSE right away and releases the lock
-    only after the worker done-callback runs.
+    a long ``_WORKER_SLEEP`` while the deadline is ``_DEADLINE``, so a fix
+    that awaited the worker before emitting the timeout would keep the client
+    waiting the full worker sleep; the fixed path emits the timeout SSE right
+    away and releases the lock only after the worker done-callback runs.
+
+    codex round-4 #6: the elapsed-time assertion uses a threshold with ample
+    separation from BOTH the deadline and the worker completion (rather than
+    comparing against the worker's exact sleep), so it is not
+    scheduler-sensitive on loaded CI hosts.
     """
     import asyncio
     import sys
@@ -582,11 +587,19 @@ def test_dflash_stream_timeout_stops_after_the_inflight_worker_step(
     from vllm_mlx.api.models import ChatCompletionRequest, Message
     from vllm_mlx.speculative.dflash import server as srv
 
+    # Wide separation (codex round-4 #6): deadline 10 ms, worker 500 ms,
+    # assertion threshold 200 ms. The fixed path returns the timeout in
+    # ~10 ms; a regressed (worker-awaiting) path would take ~500 ms. 200 ms
+    # sits well clear of both, so ordinary scheduler jitter cannot flip it.
+    _DEADLINE = 0.01
+    _WORKER_SLEEP = 0.5
+    _ELAPSED_THRESHOLD = 0.2
+
     worker_finished = threading.Event()
 
     class _SlowGenerator:
         def __next__(self):
-            time.sleep(0.05)
+            time.sleep(_WORKER_SLEEP)
             worker_finished.set()
             raise StopIteration
 
@@ -611,7 +624,7 @@ def test_dflash_stream_timeout_stops_after_the_inflight_worker_step(
             gen_kwargs={"max_tokens": 8},
             model=MagicMock(),
             processor=MagicMock(),
-            timeout=0.01,
+            timeout=_DEADLINE,
         )
         started = asyncio.get_running_loop().time()
         body = b"".join([chunk async for chunk in stream]).decode()
@@ -620,9 +633,9 @@ def test_dflash_stream_timeout_stops_after_the_inflight_worker_step(
         # The timeout SSE + DONE are emitted without blocking on the worker.
         assert "DFlash stream timed out after 0.0 seconds." in body
         assert "data: [DONE]" in body
-        # The 0.05s worker step must NOT gate the response — the fixed path
-        # surfaces the timeout well before the worker's sleep elapses.
-        assert elapsed < 0.05, (
+        # The worker step must NOT gate the response — the fixed path surfaces
+        # the timeout well before the worker's (much longer) sleep elapses.
+        assert elapsed < _ELAPSED_THRESHOLD, (
             f"timeout SSE blocked on the in-flight worker ({elapsed:.3f}s); "
             "codex round-2 #2 regression"
         )
@@ -758,6 +771,66 @@ def test_dflash_stream_cancellation_releases_admission_slot() -> None:
         assert admission._reservations == 0
 
     asyncio.run(cancel_stream())
+
+
+def test_dflash_stream_claims_slot_only_when_iteration_begins() -> None:
+    """codex round-4 #1: ownership of the admission slot must transfer to the
+    stream (``claim``) only once ``_stream_with_admission`` is actually
+    iterated — NOT when the endpoint returns the ``StreamingResponse``.
+
+    If the endpoint claimed the slot eagerly and Starlette then failed to send
+    the response headers (client vanished during startup), the stream body
+    would never run, its ``finally`` release would never fire, and the
+    middleware safety net — seeing a *claimed* slot — would decline to release
+    it, permanently shrinking capacity. Guarding on ``claimed`` here proves an
+    unstarted stream stays unclaimed (middleware reclaims it) and a started
+    one claims + releases itself.
+    """
+    import asyncio
+
+    from vllm_mlx.speculative.dflash import server as srv
+
+    async def exercise() -> None:
+        admission = srv._DFlashAdmission(max_concurrent_requests=1)
+
+        # 1. Response-startup failure: the wrapped generator is created but
+        #    never iterated (Starlette never got past sending headers). The
+        #    slot must remain UNCLAIMED so the middleware's safety net owns
+        #    the release.
+        never_started = False
+
+        async def unused_source():
+            nonlocal never_started
+            never_started = True
+            yield b"data: x\n\n"
+
+        reservation = admission.reserve()
+        stream = srv._stream_with_admission(unused_source(), reservation)
+        assert reservation.claimed is False, (
+            "codex #1 regression: slot claimed before the stream was iterated"
+        )
+        assert never_started is False
+        # The middleware safety net force-releases an unclaimed slot.
+        await stream.aclose()
+        if not reservation.claimed:
+            reservation.release(force=True)
+        assert admission._reservations == 0
+
+        # 2. Normal start: iterating the wrapper transfers ownership (claim),
+        #    and closing it releases the slot exactly once.
+        async def source():
+            yield b"data: first\n\n"
+
+        reservation2 = admission.reserve()
+        stream2 = srv._stream_with_admission(source(), reservation2)
+        assert await anext(stream2) == b"data: first\n\n"
+        assert reservation2.claimed is True, (
+            "codex #1 regression: iterating the stream did not claim the slot"
+        )
+        await stream2.aclose()
+        assert admission._reservations == 0
+
+    asyncio.run(exercise())
 
 
 def test_dflash_stream_cancellation_waits_for_worker_cleanup(monkeypatch) -> None:
@@ -2047,6 +2120,107 @@ def test_dflash_stream_backpressure_does_not_hold_lock(monkeypatch) -> None:
         srv._dflash_lock = asyncio.Lock()
 
 
+def test_dflash_stream_backpressure_delivers_terminal_notice(monkeypatch) -> None:
+    """codex round-4 #3: hitting the server-side backpressure cap must NOT
+    truncate the stream silently — the client gets an explicit terminal error
+    frame + ``[DONE]``.
+
+    Previously a full queue past ``_STREAM_BACKPRESSURE_TIMEOUT_SECONDS`` raised
+    ``_DFlashClientGoneError``, which ``_drive_producer`` swallowed with no
+    terminator. A client that was merely SLOW (not gone) then saw an
+    unexplained truncation. Now the producer converts that abort into a
+    ``finish_reason="length"`` error notice + ``[DONE]`` so a resuming client
+    always learns why generation stopped — even with ``timeout=0`` (no request
+    deadline), where only this backpressure cap applies.
+    """
+    import asyncio
+    import sys
+    import types
+
+    from vllm_mlx.api.models import ChatCompletionRequest, Message
+    from vllm_mlx.speculative.dflash import server as srv
+
+    # Tiny queue + tiny backpressure window so the test triggers the cap fast.
+    monkeypatch.setattr(srv, "_STREAM_QUEUE_MAXSIZE", 2)
+    monkeypatch.setattr(srv, "_STREAM_BACKPRESSURE_TIMEOUT_SECONDS", 0.05)
+
+    class _ManyChunks:
+        def __init__(self):
+            self._n = 0
+
+        def __iter__(self):
+            return self
+
+        def __next__(self):
+            self._n += 1
+            if self._n > 50:
+                raise StopIteration
+            return SimpleNamespace(
+                text=f"tok{self._n}",
+                generation_tokens=self._n,
+                prompt_tokens=3,
+                token=100 + self._n,
+            )
+
+        def close(self):
+            pass
+
+    fake_mlx_vlm = types.ModuleType("mlx_vlm")
+    fake_mlx_vlm.stream_generate = lambda *a, **kw: _ManyChunks()
+    monkeypatch.setitem(sys.modules, "mlx_vlm", fake_mlx_vlm)
+
+    request = ChatCompletionRequest(
+        model="qwen3.5-27b-8bit",
+        messages=[Message(role="user", content="hi")],
+        stream=True,
+    )
+
+    async def exercise() -> None:
+        admission = srv._DFlashAdmission(max_concurrent_requests=1)
+        reservation = admission.reserve()
+        stream = srv._stream_completion(
+            prompt="p",
+            request=request,
+            served_model_name="qwen3.5-27b-8bit",
+            gen_kwargs={"max_tokens": 100},
+            model=MagicMock(),
+            processor=MagicMock(),
+            timeout=0,  # NO request deadline — only the backpressure cap.
+            admission_reservation=reservation,
+        )
+        # A SLOW-but-connected client: read the role marker, pause long enough
+        # to trip the content-frame backpressure cap (0.05s) on the full
+        # 2-slot queue, then keep draining. The producer aborts generation on
+        # backpressure but must still deliver a terminal notice + [DONE]; the
+        # continued draining gives those terminal frames queue room to land.
+        assert b'"role": "assistant"' in await anext(stream)
+        await asyncio.sleep(0.15)  # > backpressure window → content put aborts
+        rest_frames: list[bytes] = []
+        async for chunk in stream:
+            rest_frames.append(chunk)
+            await asyncio.sleep(0.005)  # keep draining, slowly
+        rest = b"".join(rest_frames).decode()
+        assert "server-side backpressure" in rest, (
+            "codex #3 regression: backpressure abort truncated the stream "
+            "without a terminal error notice"
+        )
+        assert '"finish_reason": "length"' in rest
+        assert "data: [DONE]" in rest
+        # Lock + slot released after the abort.
+        for _ in range(300):
+            if not srv._dflash_lock.locked() and admission._reservations == 0:
+                break
+            await asyncio.sleep(0.01)
+        assert not srv._dflash_lock.locked()
+        assert admission._reservations == 0
+
+    srv._dflash_lock = asyncio.Lock()
+    try:
+        asyncio.run(exercise())
+    finally:
+        srv._dflash_lock = asyncio.Lock()
+
+
 def test_dflash_admission_reserved_before_body_parse(monkeypatch) -> None:
     """F1: the ASGI admission middleware rejects with 503 BEFORE FastAPI
     parses the request body.
@@ -2089,6 +2263,66 @@ def test_dflash_admission_reserved_before_body_parse(monkeypatch) -> None:
     assert response.status_code == 503, response.text
     assert response.headers.get("Retry-After") == "1"
     assert response.json()["error"]["code"] == "at_capacity"
+
+
+def test_dflash_slow_prompt_render_is_charged_against_deadline(monkeypatch) -> None:
+    """codex round-4 #4: prompt rendering time is charged against the request
+    ``timeout``, and rendering is offloaded off the event loop.
+
+    The pre-fix endpoint rendered the prompt SYNCHRONOUSLY before either
+    completion helper established its deadline, so an expensive chat template
+    could block the event loop and blow past the configured ``timeout`` with
+    no enforcement. Here we make ``_render_prompt`` take far longer than the
+    request ``timeout`` and assert the request is rejected with 504 — proving
+    the deadline now spans rendering. (It also could not have surfaced a 504
+    at all if rendering still ran unbounded on the event loop.)
+    """
+    import time
+
+    from fastapi.testclient import TestClient
+
+    from vllm_mlx.speculative.dflash import server as srv
+    from vllm_mlx.speculative.dflash.runtime import DFlashRuntime
+    from vllm_mlx.speculative.dflash.server import _build_app
+
+    # A render that vastly overruns the 0.05s request budget. Runs on the
+    # DFlash worker thread (offloaded), so the event loop stays free to
+    # enforce the deadline via ``asyncio.wait_for``.
+    def _slow_render(*_args, **_kwargs) -> str:
+        time.sleep(0.4)
+        return "rendered"
+
+    monkeypatch.setattr(srv, "_render_prompt", _slow_render)
+
+    app = _build_app(
+        model=MagicMock(),
+        processor=MagicMock(),
+        runtime=DFlashRuntime(
+            drafter=MagicMock(),
+            kind="dflash",
+            drafter_repo="z-lab/Qwen3.5-27B-DFlash",
+        ),
+        served_model_name="qwen3.5-27b-8bit",
+        default_max_tokens=64,
+        cors_origins=[],
+        max_concurrent_requests=1,
+    )
+    client = TestClient(app)
+    admission = app.state.dflash_admission
+
+    r = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "qwen3.5-27b-8bit",
+            "messages": [{"role": "user", "content": "hi"}],
+            "timeout": 0.05,
+        },
+    )
+    assert r.status_code == 504, r.text
+    # The slot must not leak when rendering times out.
+    assert admission._reservations == 0, (
+        "codex #4 regression: render-timeout leaked an admission slot"
+    )
 
 
 def test_dflash_unauthenticated_request_does_not_reserve_slot() -> None:
@@ -2174,7 +2408,7 @@ def test_dflash_rate_limited_request_does_not_reserve_slot() -> None:
         default_max_tokens=64,
         cors_origins=[],
         rate_limit=1,
-        max_concurrent_requests=4,
+        max_concurrent_requests=1,
     )
     try:
         client = TestClient(app)
@@ -2185,12 +2419,34 @@ def test_dflash_rate_limited_request_does_not_reserve_slot() -> None:
         empty = {"model": "qwen3.5-27b-8bit", "messages": []}
         r1 = client.post("/v1/chat/completions", json=empty)
         assert r1.status_code == 400, r1.text
-        # Second request is over the per-minute budget → 429 from the
-        # middleware, before any slot is reserved.
-        r2 = client.post("/v1/chat/completions", json=empty)
-        assert r2.status_code == 429, r2.text
-        assert r2.json()["error"]["code"] == "rate_limit_exceeded"
-        assert admission._reservations == 0, "codex #3 regression: 429 reserved a slot"
+
+        # codex round-4 #5: prove rate-limiting runs BEFORE admission by
+        # occupying the *only* admission slot before the over-limit request.
+        # A correct impl rejects with 429 (rate-limit checked first, no slot
+        # touched). A regressed impl that reserves-first would instead find
+        # the gate full and return 503 — or, worse, reserve + then release,
+        # masking a pre-admission DoS. Asserting 429 (NOT 503) with the slot
+        # held closes that hole; the old "reservations == 0 afterwards"
+        # assertion alone could not tell reserve-then-release from
+        # never-reserve.
+        held = admission.reserve()
+        try:
+            assert admission._reservations == 1
+            r2 = client.post("/v1/chat/completions", json=empty)
+            assert r2.status_code == 429, (
+                f"codex #5 regression: over-limit request returned "
+                f"{r2.status_code} (expected 429 from pre-admission "
+                f"rate-limit, not 503 from the full gate)"
+            )
+            assert r2.json()["error"]["code"] == "rate_limit_exceeded"
+            # The externally held slot is the ONLY reservation; the rejected
+            # request must not have minted (or transiently minted) another.
+            assert admission._reservations == 1, (
+                "codex #5 regression: 429 request touched the admission gate"
+            )
+        finally:
+            held.release()
+        assert admission._reservations == 0
     finally:
         # The rate limiter is a process-global singleton; leaving it enabled
         # would pollute every later test that exercises admission/rate paths

--- a/tests/test_dflash_integration.py
+++ b/tests/test_dflash_integration.py
@@ -333,6 +333,566 @@ def test_healthz_and_models_routes() -> None:
     assert body["data"][0]["id"] == "qwen3.5-27b-8bit"
 
 
+def test_run_dflash_server_wires_security_configuration(monkeypatch) -> None:
+    """DFlash must enforce the same auth, rate, and body guards as serve.
+
+    The production entry point is exercised with mocked model loading so this
+    test covers the actual ``run_dflash_server`` -> ``_build_app`` wiring
+    without downloading the DFlash model pair or binding a TCP port.
+    """
+    import sys
+    import types
+
+    from fastapi.testclient import TestClient
+
+    from vllm_mlx.config import get_config
+    from vllm_mlx.speculative.dflash import server as srv
+    from vllm_mlx.speculative.dflash.runtime import DFlashRuntime
+
+    runtime = DFlashRuntime(
+        drafter=MagicMock(),
+        kind="dflash",
+        drafter_repo="z-lab/Qwen3.5-27B-DFlash",
+    )
+    monkeypatch.setattr(srv, "have_runtime", lambda: True)
+    monkeypatch.setattr(srv, "load_runtime", lambda _repo: runtime)
+
+    fake_mlx_vlm = types.ModuleType("mlx_vlm")
+    fake_mlx_vlm.load = lambda _repo: (MagicMock(), MagicMock())
+    monkeypatch.setitem(sys.modules, "mlx_vlm", fake_mlx_vlm)
+
+    captured: dict = {}
+    import uvicorn
+
+    monkeypatch.setattr(
+        uvicorn,
+        "run",
+        lambda app, **_kwargs: captured.setdefault("app", app),
+    )
+
+    srv.run_dflash_server(
+        main_model_repo="mlx-community/Qwen3.5-27B-8bit",
+        drafter_repo="z-lab/Qwen3.5-27B-DFlash",
+        host="127.0.0.1",
+        port=58997,
+        served_model_name="qwen3.5-27b-8bit",
+        default_max_tokens=64,
+        cors_origins=[],
+        uvicorn_log_level="info",
+        api_key="dflash-secret",
+        rate_limit=1,
+        max_request_bytes=512,
+        body_receive_timeout_seconds=7.5,
+        default_timeout=12.5,
+        max_concurrent_requests=3,
+    )
+
+    app = captured["app"]
+    client = TestClient(app)
+    auth = {"Authorization": "Bearer dflash-secret"}
+
+    # Probe routes remain available to load balancers, but every /v1 route
+    # requires the configured bearer key.
+    assert client.get("/healthz").status_code == 200
+    assert client.get("/v1/models").status_code == 401
+    assert client.get("/v1/models", headers=auth).status_code == 200
+
+    # The first request reaches DFlash's normal validation path (empty
+    # messages -> 400) and therefore consumes the one-request rate budget;
+    # the second must be rejected before it can reach generation.
+    invalid_chat = {"model": "qwen3.5-27b-8bit", "messages": []}
+    assert (
+        client.post("/v1/chat/completions", headers=auth, json=invalid_chat).status_code
+        == 400
+    )
+    assert (
+        client.post("/v1/chat/completions", headers=auth, json=invalid_chat).status_code
+        == 429
+    )
+
+    # The generic ASGI guard runs before FastAPI parses the JSON body.
+    oversized = client.post(
+        "/v1/chat/completions",
+        headers={**auth, "Content-Type": "application/json"},
+        content=b"x" * 513,
+    )
+    assert oversized.status_code == 413
+    assert get_config().max_request_bytes == 512
+    assert get_config().body_receive_timeout_seconds == 7.5
+    assert get_config().default_timeout == 12.5
+    assert app.state.dflash_admission._max_concurrent_requests == 3
+
+
+def test_dflash_cli_forwards_security_and_resource_limits() -> None:
+    """The dedicated server must receive every relevant ``serve`` policy.
+
+    Keep this as a structural CLI contract: invoking ``serve_command`` would
+    otherwise require a model alias, preflight checks, and an actual listener
+    before the DFlash fork is reached.
+    """
+    import ast
+    import inspect
+
+    from vllm_mlx import cli
+
+    tree = ast.parse(inspect.getsource(cli.serve_command))
+    call = next(
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "run_dflash_server"
+    )
+    keywords = {keyword.arg: keyword.value for keyword in call.keywords}
+
+    expected = {
+        "api_key": "server._api_key",
+        "rate_limit": "args.rate_limit",
+        "max_request_bytes": "server._max_request_bytes",
+        "body_receive_timeout_seconds": "server._body_receive_timeout_seconds",
+        "default_timeout": "server._default_timeout",
+        "max_concurrent_requests": "args.max_concurrent_requests",
+        "cors_policy": "server.get_resolved_cors_policy()",
+    }
+    assert {name: ast.unparse(keywords[name]) for name in expected} == expected
+
+
+def test_dflash_admission_cap_rejects_before_prompt_rendering() -> None:
+    """DFlash must bound its serial queue before prompt work or generation."""
+    from fastapi.testclient import TestClient
+
+    from vllm_mlx.speculative.dflash.runtime import DFlashRuntime
+    from vllm_mlx.speculative.dflash.server import _build_app
+
+    app = _build_app(
+        model=MagicMock(),
+        processor=MagicMock(),
+        runtime=DFlashRuntime(
+            drafter=MagicMock(),
+            kind="dflash",
+            drafter_repo="z-lab/Qwen3.5-27B-DFlash",
+        ),
+        served_model_name="qwen3.5-27b-8bit",
+        default_max_tokens=64,
+        cors_origins=[],
+        max_concurrent_requests=1,
+    )
+    reservation = app.state.dflash_admission.reserve()
+    try:
+        response = TestClient(app).post(
+            "/v1/chat/completions",
+            json={
+                "model": "qwen3.5-27b-8bit",
+                "messages": [{"role": "user", "content": "hi"}],
+            },
+        )
+    finally:
+        reservation.release()
+
+    assert response.status_code == 503
+    assert response.headers["Retry-After"] == "1"
+
+
+def test_dflash_nonstream_timeout_keeps_gpu_slot_until_worker_finishes(
+    monkeypatch,
+) -> None:
+    """A 504 must not let another call overlap the still-running worker."""
+    import asyncio
+    import sys
+    import time
+    import types
+
+    from fastapi import HTTPException
+
+    from vllm_mlx.speculative.dflash import server as srv
+
+    fake_mlx_vlm = types.ModuleType("mlx_vlm")
+
+    def slow_generate(*_args, **_kwargs):
+        time.sleep(0.05)
+        return SimpleNamespace(text="done", prompt_tokens=1, generation_tokens=1)
+
+    fake_mlx_vlm.generate = slow_generate
+    monkeypatch.setitem(sys.modules, "mlx_vlm", fake_mlx_vlm)
+
+    async def exercise_timeout() -> None:
+        admission = srv._DFlashAdmission(max_concurrent_requests=1)
+        reservation = admission.reserve()
+        with pytest.raises(HTTPException) as excinfo:
+            await srv._non_stream_completion(
+                prompt="prompt",
+                request=MagicMock(),
+                served_model_name="qwen3.5-27b-8bit",
+                gen_kwargs={},
+                model=MagicMock(),
+                processor=MagicMock(),
+                timeout=0.01,
+                admission_reservation=reservation,
+            )
+        assert excinfo.value.status_code == 504
+        assert admission._reservations == 1
+        assert srv._dflash_lock.locked()
+
+        # The detached worker owns the lock until ``slow_generate`` returns.
+        await asyncio.sleep(0.1)
+        assert admission._reservations == 0
+        assert not srv._dflash_lock.locked()
+
+    asyncio.run(exercise_timeout())
+
+
+def test_dflash_stream_timeout_stops_after_the_inflight_worker_step(
+    monkeypatch,
+) -> None:
+    """DFlash honors stream deadlines without overlapping GPU work."""
+    import asyncio
+    import sys
+    import time
+    import types
+
+    from vllm_mlx.api.models import ChatCompletionRequest, Message
+    from vllm_mlx.speculative.dflash import server as srv
+
+    class _SlowGenerator:
+        def __next__(self):
+            time.sleep(0.05)
+            raise StopIteration
+
+        def close(self):
+            pass
+
+    fake_mlx_vlm = types.ModuleType("mlx_vlm")
+    fake_mlx_vlm.stream_generate = lambda *_args, **_kwargs: _SlowGenerator()
+    monkeypatch.setitem(sys.modules, "mlx_vlm", fake_mlx_vlm)
+
+    request = ChatCompletionRequest(
+        model="qwen3.5-27b-8bit",
+        messages=[Message(role="user", content="hi")],
+        stream=True,
+    )
+    stream = srv._stream_completion(
+        prompt="prompt",
+        request=request,
+        served_model_name="qwen3.5-27b-8bit",
+        gen_kwargs={"max_tokens": 8},
+        model=MagicMock(),
+        processor=MagicMock(),
+        timeout=0.01,
+    )
+
+    async def drain() -> list[bytes]:
+        return [chunk async for chunk in stream]
+
+    body = b"".join(asyncio.run(drain())).decode()
+    assert "DFlash stream timed out after 0.0 seconds." in body
+    assert "data: [DONE]" in body
+    assert not srv._dflash_lock.locked()
+
+
+def test_dflash_stream_timeout_bounds_lock_queue_wait(monkeypatch) -> None:
+    """A stream deadline expires while waiting for DFlash's serial lock."""
+    import asyncio
+    import sys
+    import threading
+    import types
+
+    from vllm_mlx.api.models import ChatCompletionRequest, Message
+    from vllm_mlx.speculative.dflash import server as srv
+
+    started = threading.Event()
+    release_first = threading.Event()
+    generated = 0
+
+    class _BlockingGenerator:
+        def __next__(self):
+            started.set()
+            assert release_first.wait(timeout=5)
+            raise StopIteration
+
+        def close(self):
+            pass
+
+    class _EmptyGenerator:
+        def __next__(self):
+            raise StopIteration
+
+        def close(self):
+            pass
+
+    def stream_generate(*_args, **_kwargs):
+        nonlocal generated
+        generated += 1
+        return _BlockingGenerator() if generated == 1 else _EmptyGenerator()
+
+    fake_mlx_vlm = types.ModuleType("mlx_vlm")
+    fake_mlx_vlm.stream_generate = stream_generate
+    monkeypatch.setitem(sys.modules, "mlx_vlm", fake_mlx_vlm)
+
+    request = ChatCompletionRequest(
+        model="qwen3.5-27b-8bit",
+        messages=[Message(role="user", content="hi")],
+        stream=True,
+    )
+
+    async def exercise_queue_timeout() -> None:
+        first = srv._stream_completion(
+            prompt="first",
+            request=request,
+            served_model_name="qwen3.5-27b-8bit",
+            gen_kwargs={},
+            model=MagicMock(),
+            processor=MagicMock(),
+        )
+        await anext(first)
+        first_next = asyncio.create_task(anext(first))
+        assert await asyncio.to_thread(started.wait, 1)
+
+        second = srv._stream_completion(
+            prompt="second",
+            request=request,
+            served_model_name="qwen3.5-27b-8bit",
+            gen_kwargs={},
+            model=MagicMock(),
+            processor=MagicMock(),
+            timeout=0.01,
+        )
+        await anext(second)
+        try:
+            timeout_event = await anext(second)
+            assert b"DFlash stream timed out" in timeout_event
+            assert generated == 1
+        finally:
+            release_first.set()
+            await first_next
+
+    # asyncio.Lock binds to the first loop that has waiters. Production has
+    # one long-lived uvicorn loop; tests intentionally create short-lived
+    # loops, so leave the module global fresh for the next isolated case.
+    srv._dflash_lock = asyncio.Lock()
+    try:
+        asyncio.run(exercise_queue_timeout())
+    finally:
+        srv._dflash_lock = asyncio.Lock()
+
+
+def test_dflash_stream_cancellation_releases_admission_slot() -> None:
+    """Client disconnects must not leave DFlash permanently at capacity."""
+    import asyncio
+
+    from vllm_mlx.speculative.dflash import server as srv
+
+    closed = False
+
+    async def source():
+        nonlocal closed
+        try:
+            yield b"data: first\n\n"
+            await asyncio.Event().wait()
+        finally:
+            closed = True
+
+    async def cancel_stream() -> None:
+        admission = srv._DFlashAdmission(max_concurrent_requests=1)
+        reservation = admission.reserve()
+        stream = srv._stream_with_admission(source(), reservation)
+        assert await anext(stream) == b"data: first\n\n"
+        await stream.aclose()
+        assert closed
+        assert admission._reservations == 0
+
+    asyncio.run(cancel_stream())
+
+
+def test_dflash_stream_cancellation_waits_for_worker_cleanup(monkeypatch) -> None:
+    """A cancelled stream cannot let a new generator overtake its close."""
+    import asyncio
+    import sys
+    import threading
+    import types
+
+    from vllm_mlx.api.models import ChatCompletionRequest, Message
+    from vllm_mlx.speculative.dflash import server as srv
+
+    first_step_started = threading.Event()
+    allow_first_step_to_finish = threading.Event()
+    first_closed = threading.Event()
+    events: list[str] = []
+    generated = 0
+
+    class _FirstGenerator:
+        def __next__(self):
+            first_step_started.set()
+            assert allow_first_step_to_finish.wait(timeout=5)
+            raise StopIteration
+
+        def close(self):
+            events.append("first-close")
+            first_closed.set()
+
+    class _SecondGenerator:
+        def __next__(self):
+            raise StopIteration
+
+        def close(self):
+            pass
+
+    def stream_generate(*_args, **_kwargs):
+        nonlocal generated
+        generated += 1
+        if generated == 1:
+            events.append("first-generate")
+            return _FirstGenerator()
+        events.append("second-generate")
+        return _SecondGenerator()
+
+    fake_mlx_vlm = types.ModuleType("mlx_vlm")
+    fake_mlx_vlm.stream_generate = stream_generate
+    monkeypatch.setitem(sys.modules, "mlx_vlm", fake_mlx_vlm)
+
+    request = ChatCompletionRequest(
+        model="qwen3.5-27b-8bit",
+        messages=[Message(role="user", content="hi")],
+        stream=True,
+    )
+
+    async def exercise_cancellation() -> None:
+        admission = srv._DFlashAdmission(max_concurrent_requests=2)
+        first = srv._stream_completion(
+            prompt="first",
+            request=request,
+            served_model_name="qwen3.5-27b-8bit",
+            gen_kwargs={},
+            model=MagicMock(),
+            processor=MagicMock(),
+            admission_reservation=admission.reserve(),
+        )
+        # The role marker is emitted before the GPU worker starts.
+        await anext(first)
+        first_next = asyncio.create_task(anext(first))
+        assert await asyncio.to_thread(first_step_started.wait, 1)
+
+        first_next.cancel()
+        # Do not await the cancelled consumer yet: its worker is still in a
+        # blocking token step. A new stream must remain outside the serial
+        # worker until that step's generator has been closed.
+        await asyncio.sleep(0)
+
+        second = srv._stream_completion(
+            prompt="second",
+            request=request,
+            served_model_name="qwen3.5-27b-8bit",
+            gen_kwargs={},
+            model=MagicMock(),
+            processor=MagicMock(),
+            admission_reservation=admission.reserve(),
+        )
+        await anext(second)
+        second_next = asyncio.create_task(anext(second))
+        await asyncio.sleep(0.01)
+        assert "second-generate" not in events
+
+        allow_first_step_to_finish.set()
+        assert await asyncio.to_thread(first_closed.wait, 1)
+        with pytest.raises(asyncio.CancelledError):
+            await first_next
+        await second_next
+        assert events.index("first-close") < events.index("second-generate")
+        await second.aclose()
+        assert admission._reservations == 0
+
+    srv._dflash_lock = asyncio.Lock()
+    try:
+        asyncio.run(exercise_cancellation())
+    finally:
+        srv._dflash_lock = asyncio.Lock()
+
+
+def test_dflash_inherits_explicit_cors_policy(monkeypatch) -> None:
+    """DFlash must not broaden the operator's resolved CORS settings."""
+    from fastapi.testclient import TestClient
+
+    from vllm_mlx import server
+    from vllm_mlx.speculative.dflash.runtime import DFlashRuntime
+    from vllm_mlx.speculative.dflash.server import _build_app
+
+    monkeypatch.setenv("RAPID_MLX_CORS_ALLOW_METHODS", "POST")
+    monkeypatch.setenv("RAPID_MLX_CORS_ALLOW_HEADERS", "Content-Type")
+    monkeypatch.setenv("RAPID_MLX_CORS_MAX_AGE", "17")
+    monkeypatch.setenv("RAPID_MLX_CORS_ALLOW_CREDENTIALS", "false")
+    server.configure_cors_from_env(["https://console.example"])
+    policy = server.get_resolved_cors_policy()
+    assert policy is not None
+
+    app = _build_app(
+        model=MagicMock(),
+        processor=MagicMock(),
+        runtime=DFlashRuntime(
+            drafter=MagicMock(),
+            kind="dflash",
+            drafter_repo="z-lab/Qwen3.5-27B-DFlash",
+        ),
+        served_model_name="qwen3.5-27b-8bit",
+        default_max_tokens=64,
+        cors_origins=list(policy.origins),
+        cors_policy=policy,
+    )
+    client = TestClient(app)
+    allowed = {
+        "Origin": "https://console.example",
+        "Access-Control-Request-Method": "POST",
+        "Access-Control-Request-Headers": "Content-Type",
+    }
+    response = client.options("/v1/chat/completions", headers=allowed)
+    assert response.status_code == 200
+    assert response.headers["Access-Control-Allow-Methods"] == "POST"
+    assert response.headers["Access-Control-Max-Age"] == "17"
+    assert "Access-Control-Allow-Credentials" not in response.headers
+
+    denied = client.options(
+        "/v1/chat/completions",
+        headers={**allowed, "Access-Control-Request-Headers": "Authorization"},
+    )
+    assert denied.status_code == 400
+
+
+def test_dflash_cors_wildcard_forces_credentials_off(monkeypatch) -> None:
+    """A CORS policy snapshot must retain Fetch's wildcard invariant."""
+    from fastapi.testclient import TestClient
+
+    from vllm_mlx import server
+    from vllm_mlx.speculative.dflash.runtime import DFlashRuntime
+    from vllm_mlx.speculative.dflash.server import _build_app
+
+    monkeypatch.setenv("RAPID_MLX_CORS_ALLOW_CREDENTIALS", "true")
+    server.configure_cors_from_env(["*"])
+    policy = server.get_resolved_cors_policy()
+    assert policy is not None
+    assert policy.allow_credentials is False
+
+    app = _build_app(
+        model=MagicMock(),
+        processor=MagicMock(),
+        runtime=DFlashRuntime(
+            drafter=MagicMock(),
+            kind="dflash",
+            drafter_repo="z-lab/Qwen3.5-27B-DFlash",
+        ),
+        served_model_name="qwen3.5-27b-8bit",
+        default_max_tokens=64,
+        cors_origins=list(policy.origins),
+        cors_policy=policy,
+    )
+    response = TestClient(app).options(
+        "/v1/chat/completions",
+        headers={
+            "Origin": "https://evil.example",
+            "Access-Control-Request-Method": "POST",
+        },
+    )
+    assert response.headers["Access-Control-Allow-Origin"] == "*"
+    assert "Access-Control-Allow-Credentials" not in response.headers
+
+
 def test_chat_completions_rejects_tools() -> None:
     """DFlash v1 doesn't run a tool-call parser. The route must reject
     tool requests with a clear 400 — silent passthrough would surprise

--- a/tests/test_dflash_integration.py
+++ b/tests/test_dflash_integration.py
@@ -36,6 +36,24 @@ _skip_without_mlx_vlm = pytest.mark.skipif(
     reason="mlx_vlm not installed (DFlash test path needs [dflash] extras)",
 )
 
+
+@pytest.fixture(autouse=True)
+def _reset_dflash_shared_globals():
+    """Isolate the process-global rate limiter across DFlash tests.
+
+    ``_build_app`` / ``run_dflash_server`` call ``configure_rate_limiter``,
+    which mutates a module-level singleton shared with the main server. A
+    DFlash test that enables the limiter (``rate_limit>0``) would otherwise
+    leak that enabled state into unrelated later tests (e.g.
+    ``tests/test_embeddings_timeout_admission.py``), turning their requests
+    into surprise 429s. Reset the limiter to disabled after every test here.
+    """
+    yield
+    from vllm_mlx.middleware.auth import configure_rate_limiter
+
+    configure_rate_limiter(0, enabled=False)
+
+
 # =============================================================================
 # CLI flag plumbing — argparse exposes --speculative-config and the eligibility check
 # fires before the model load when an ineligible alias is passed.
@@ -2138,6 +2156,7 @@ def test_dflash_rate_limited_request_does_not_reserve_slot() -> None:
     from a leftover route dependency)."""
     from fastapi.testclient import TestClient
 
+    from vllm_mlx.middleware.auth import configure_rate_limiter
     from vllm_mlx.speculative.dflash.runtime import DFlashRuntime
     from vllm_mlx.speculative.dflash.server import _build_app
 
@@ -2157,20 +2176,26 @@ def test_dflash_rate_limited_request_does_not_reserve_slot() -> None:
         rate_limit=1,
         max_concurrent_requests=4,
     )
-    client = TestClient(app)
-    admission = app.state.dflash_admission
+    try:
+        client = TestClient(app)
+        admission = app.state.dflash_admission
 
-    # Empty messages → 400, but the request still counts as the single
-    # allowed request (limiter consulted ONCE, not twice).
-    empty = {"model": "qwen3.5-27b-8bit", "messages": []}
-    r1 = client.post("/v1/chat/completions", json=empty)
-    assert r1.status_code == 400, r1.text
-    # Second request is over the per-minute budget → 429 from the middleware,
-    # before any slot is reserved.
-    r2 = client.post("/v1/chat/completions", json=empty)
-    assert r2.status_code == 429, r2.text
-    assert r2.json()["error"]["code"] == "rate_limit_exceeded"
-    assert admission._reservations == 0, "codex #3 regression: 429 reserved a slot"
+        # Empty messages → 400, but the request still counts as the single
+        # allowed request (limiter consulted ONCE, not twice).
+        empty = {"model": "qwen3.5-27b-8bit", "messages": []}
+        r1 = client.post("/v1/chat/completions", json=empty)
+        assert r1.status_code == 400, r1.text
+        # Second request is over the per-minute budget → 429 from the
+        # middleware, before any slot is reserved.
+        r2 = client.post("/v1/chat/completions", json=empty)
+        assert r2.status_code == 429, r2.text
+        assert r2.json()["error"]["code"] == "rate_limit_exceeded"
+        assert admission._reservations == 0, "codex #3 regression: 429 reserved a slot"
+    finally:
+        # The rate limiter is a process-global singleton; leaving it enabled
+        # would pollute every later test that exercises admission/rate paths
+        # (e.g. tests/test_embeddings_timeout_admission.py). Reset it.
+        configure_rate_limiter(0, enabled=False)
 
 
 def test_dflash_stream_terminal_frame_delivered_on_timeout(monkeypatch) -> None:

--- a/tests/test_dflash_integration.py
+++ b/tests/test_dflash_integration.py
@@ -559,6 +559,64 @@ def test_dflash_nonstream_timeout_keeps_gpu_slot_until_worker_finishes(
     asyncio.run(exercise_timeout())
 
 
+def test_dflash_timeout_message_reports_original_not_post_render_budget(
+    monkeypatch,
+) -> None:
+    """codex round-5 #6: the 504 message reports the ORIGINAL configured
+    timeout, not the render-reduced remaining budget.
+
+    The endpoint charges prompt-render time against one absolute deadline and
+    hands the REMAINING budget to the completion helper as ``timeout``. But a
+    user who set a 60s timeout and spent 20s rendering should read "timed out
+    after 60.0 seconds", not "40.0" — otherwise they chase a phantom shorter
+    limit. ``timeout_label`` carries the original for diagnostics.
+    """
+    import asyncio
+    import sys
+    import time
+    import types
+
+    from fastapi import HTTPException
+
+    from vllm_mlx.speculative.dflash import server as srv
+
+    fake_mlx_vlm = types.ModuleType("mlx_vlm")
+    fake_mlx_vlm.generate = lambda *a, **kw: (
+        time.sleep(0.05)
+        or SimpleNamespace(text="x", prompt_tokens=1, generation_tokens=1)
+    )
+    monkeypatch.setitem(sys.modules, "mlx_vlm", fake_mlx_vlm)
+
+    async def exercise() -> None:
+        admission = srv._DFlashAdmission(max_concurrent_requests=1)
+        reservation = admission.reserve()
+        with pytest.raises(HTTPException) as excinfo:
+            await srv._non_stream_completion(
+                prompt="prompt",
+                request=MagicMock(),
+                served_model_name="qwen3.5-27b-8bit",
+                gen_kwargs={},
+                model=MagicMock(),
+                processor=MagicMock(),
+                timeout=0.01,  # enforced remaining budget (tiny → 504)
+                timeout_label=60.0,  # ORIGINAL configured timeout
+                admission_reservation=reservation,
+            )
+        assert excinfo.value.status_code == 504
+        # Message reports the ORIGINAL 60.0s, NOT the 0.01s remaining budget
+        # (which would round to "0.0 seconds").
+        assert "60.0 seconds" in excinfo.value.detail, excinfo.value.detail
+        assert "after 0.0 seconds" not in excinfo.value.detail
+        # Let the detached worker finish so the lock/slot release.
+        await asyncio.sleep(0.1)
+
+    srv._dflash_lock = asyncio.Lock()
+    try:
+        asyncio.run(exercise())
+    finally:
+        srv._dflash_lock = asyncio.Lock()
+
+
 def test_dflash_stream_timeout_stops_after_the_inflight_worker_step(
     monkeypatch,
 ) -> None:
@@ -829,6 +887,50 @@ def test_dflash_stream_claims_slot_only_when_iteration_begins() -> None:
         )
         await stream2.aclose()
         assert admission._reservations == 0
+
+    asyncio.run(exercise())
+
+
+def test_dflash_stream_admission_released_when_aclose_is_cancelled() -> None:
+    """codex round-5 #4: ``_stream_with_admission`` must release the slot even
+    if ``aclose()`` raises ``asyncio.CancelledError``.
+
+    ``CancelledError`` subclasses ``BaseException``, not ``Exception``, so the
+    pre-fix ``except Exception`` around ``await aclose()`` let it skip the
+    mandatory ``reservation.release()`` — permanently leaking a slot whenever a
+    client cancellation propagated through generator teardown. The release now
+    lives in its own unconditional ``finally``.
+    """
+    import asyncio
+
+    from vllm_mlx.speculative.dflash import server as srv
+
+    class _CancelOnClose:
+        """An async-iterator whose ``aclose`` raises CancelledError."""
+
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            raise StopAsyncIteration
+
+        async def aclose(self):
+            raise asyncio.CancelledError
+
+    async def exercise() -> None:
+        admission = srv._DFlashAdmission(max_concurrent_requests=1)
+        reservation = admission.reserve()
+        wrapped = srv._stream_with_admission(_CancelOnClose(), reservation)
+        # Drive the wrapper to completion; its ``finally`` closes the inner
+        # stream (which raises CancelledError) and must STILL release the slot.
+        with pytest.raises(asyncio.CancelledError):
+            async for _ in wrapped:
+                pass
+        assert admission._reservations == 0, (
+            "codex #4 regression: CancelledError in aclose() skipped the "
+            "admission release"
+        )
+        assert reservation.claimed is True
 
     asyncio.run(exercise())
 
@@ -2206,6 +2308,17 @@ def test_dflash_stream_backpressure_delivers_terminal_notice(monkeypatch) -> Non
         )
         assert '"finish_reason": "length"' in rest
         assert "data: [DONE]" in rest
+        # codex round-5 #3: the [DONE] terminator MUST be last — after the
+        # final finish_reason/error frame — even when both spill to the
+        # direct-emit path. A regressed ordering would deliver [DONE] first.
+        assert rest.index('"finish_reason": "length"') < rest.index("data: [DONE]"), (
+            "codex #3 ordering regression: [DONE] delivered before final frame"
+        )
+        # [DONE] is the very last non-empty frame.
+        nonempty = [f for f in rest.split("\n\n") if f.strip()]
+        assert nonempty[-1].strip() == "data: [DONE]", (
+            f"codex #3 ordering regression: last frame was {nonempty[-1]!r}"
+        )
         # Lock + slot released after the abort.
         for _ in range(300):
             if not srv._dflash_lock.locked() and admission._reservations == 0:
@@ -2382,6 +2495,14 @@ def test_dflash_unauthenticated_request_does_not_reserve_slot() -> None:
         assert r.status_code == 401, r.text
     finally:
         held.release()
+
+    # codex round-5 #5: the 401 must carry the RFC 6750 bearer challenge.
+    r = client.post("/v1/chat/completions", json=body)
+    assert r.status_code == 401, r.text
+    assert r.headers.get("WWW-Authenticate") == "Bearer", (
+        "codex #5 regression: 401 dropped the WWW-Authenticate: Bearer "
+        "challenge required for bearer-protected resources"
+    )
 
 
 def test_dflash_rate_limited_request_does_not_reserve_slot() -> None:

--- a/tests/test_dflash_integration.py
+++ b/tests/test_dflash_integration.py
@@ -1651,6 +1651,376 @@ def test_run_dflash_server_loads_models_on_executor_thread(monkeypatch) -> None:
 
 
 # =============================================================================
+# Adversarial concurrency / liveness regressions (PR #1109 codex review).
+# These pin the five BLOCKING findings so a future refactor cannot silently
+# reintroduce a lock leak, an unstarted-but-charged GPU job, a path-dependent
+# zero-timeout, or an admission gate that runs after body parse.
+# =============================================================================
+
+
+@_skip_without_mlx_vlm
+def test_dflash_stream_cancel_during_construction_releases_lock(monkeypatch) -> None:
+    """F3: cancelling while the generator is still being CONSTRUCTED must
+    not leak ``_dflash_lock``.
+
+    Reproduces the codex finding: with no deadline, the worker future is
+    awaited bare; a client cancellation that lands in the tiny window while
+    ``_make_gen`` is in flight used to unwind through ``__aexit__`` →
+    ``_capture_generator`` → ``future.result()``, which raised
+    ``CancelledError`` (a ``BaseException``, not caught by ``except
+    Exception``) and skipped the lock release entirely. After the fix the
+    lease's ``__aexit__`` always drives cleanup to completion.
+    """
+    import asyncio
+    import sys
+    import threading
+    import types
+
+    from vllm_mlx.api.models import ChatCompletionRequest, Message
+    from vllm_mlx.speculative.dflash import server as srv
+
+    in_construction = threading.Event()
+    allow_construction_to_finish = threading.Event()
+
+    class _EmptyGenerator:
+        def __next__(self):
+            raise StopIteration
+
+        def close(self):
+            pass
+
+    def blocking_stream_generate(*_args, **_kwargs):
+        # Block INSIDE generator construction so the cancellation can land
+        # while the ``_make_gen`` worker future is still in flight.
+        in_construction.set()
+        assert allow_construction_to_finish.wait(timeout=5)
+        return _EmptyGenerator()
+
+    fake_mlx_vlm = types.ModuleType("mlx_vlm")
+    fake_mlx_vlm.stream_generate = blocking_stream_generate
+    monkeypatch.setitem(sys.modules, "mlx_vlm", fake_mlx_vlm)
+
+    request = ChatCompletionRequest(
+        model="qwen3.5-27b-8bit",
+        messages=[Message(role="user", content="hi")],
+        stream=True,
+    )
+
+    async def exercise() -> None:
+        admission = srv._DFlashAdmission(max_concurrent_requests=1)
+        reservation = admission.reserve()
+        stream = srv._stream_completion(
+            prompt="prompt",
+            request=request,
+            served_model_name="qwen3.5-27b-8bit",
+            gen_kwargs={},
+            model=MagicMock(),
+            processor=MagicMock(),
+            timeout=0,  # no deadline -> bare-await construction path
+            admission_reservation=reservation,
+        )
+        # Role marker first; the producer then starts constructing the gen.
+        await anext(stream)
+        assert await asyncio.to_thread(in_construction.wait, 1)
+
+        # Cancel mid-construction, then let construction finish so the
+        # deferred cleanup can run the generator close + lock release.
+        await stream.aclose()
+        allow_construction_to_finish.set()
+
+        # The lock and the admission slot must both be freed once the
+        # detached worker unwinds — poll briefly for the deferred cleanup.
+        for _ in range(200):
+            if not srv._dflash_lock.locked() and admission._reservations == 0:
+                break
+            await asyncio.sleep(0.01)
+        assert not srv._dflash_lock.locked(), "F3 regression: lock leaked"
+        assert admission._reservations == 0, "F3 regression: admission slot leaked"
+
+    srv._dflash_lock = asyncio.Lock()
+    try:
+        asyncio.run(exercise())
+    finally:
+        srv._dflash_lock = asyncio.Lock()
+
+
+@_skip_without_mlx_vlm
+def test_dflash_nonstream_expired_deadline_skips_gpu_work(monkeypatch) -> None:
+    """F5: a non-stream request whose deadline expired while acquiring the
+    serial lock must NOT submit GPU work.
+
+    Hold the lock with a foreign owner so the request's ``wait_for`` on the
+    lock burns its whole (tiny) budget; release just after so acquisition
+    succeeds but the deadline is already gone. ``generate`` must never be
+    called, and the 504 must come back immediately without a detached
+    worker holding the lock.
+    """
+    import asyncio
+    import sys
+    import types
+
+    from fastapi import HTTPException
+
+    from vllm_mlx.speculative.dflash import server as srv
+
+    generate_calls = [0]
+
+    def spy_generate(*_args, **_kwargs):
+        generate_calls[0] += 1
+        return SimpleNamespace(text="x", prompt_tokens=1, generation_tokens=1)
+
+    fake_mlx_vlm = types.ModuleType("mlx_vlm")
+    fake_mlx_vlm.generate = spy_generate
+    monkeypatch.setitem(sys.modules, "mlx_vlm", fake_mlx_vlm)
+
+    async def exercise() -> None:
+        admission = srv._DFlashAdmission(max_concurrent_requests=1)
+        reservation = admission.reserve()
+
+        # Foreign owner holds the lock; release it just after the request's
+        # deadline expires so the request acquires it already-expired.
+        await srv._dflash_lock.acquire()
+
+        async def _release_soon() -> None:
+            await asyncio.sleep(0.03)
+            srv._dflash_lock.release()
+
+        releaser = asyncio.create_task(_release_soon())
+        with pytest.raises(HTTPException) as excinfo:
+            await srv._non_stream_completion(
+                prompt="prompt",
+                request=MagicMock(),
+                served_model_name="qwen3.5-27b-8bit",
+                gen_kwargs={},
+                model=MagicMock(),
+                processor=MagicMock(),
+                timeout=0.01,
+                admission_reservation=reservation,
+            )
+        await releaser
+        assert excinfo.value.status_code == 504
+        # The core F5 assertion: no GPU work started for an expired request.
+        assert generate_calls[0] == 0, "F5 regression: GPU work started after deadline"
+        # And no detached worker is holding the lock (nothing was submitted).
+        assert not srv._dflash_lock.locked()
+        reservation.release()
+        assert admission._reservations == 0
+
+    srv._dflash_lock = asyncio.Lock()
+    try:
+        asyncio.run(exercise())
+    finally:
+        srv._dflash_lock = asyncio.Lock()
+
+
+@_skip_without_mlx_vlm
+def test_dflash_zero_timeout_is_no_deadline_on_both_paths(monkeypatch) -> None:
+    """F4: ``timeout <= 0`` means "no deadline" consistently on the stream
+    AND non-stream paths — not "unlimited" on one and "immediate 504" on
+    the other.
+    """
+    import asyncio
+    import sys
+    import types
+
+    from vllm_mlx.api.models import ChatCompletionRequest, Message
+    from vllm_mlx.speculative.dflash import server as srv
+
+    class _OneChunk:
+        text = "hi"
+        generation_tokens = 1
+        prompt_tokens = 2
+        token = 7
+
+    def _gen():
+        yield _OneChunk()
+
+    fake_mlx_vlm = types.ModuleType("mlx_vlm")
+    fake_mlx_vlm.stream_generate = lambda *a, **kw: _gen()
+    fake_mlx_vlm.generate = lambda *a, **kw: SimpleNamespace(
+        text="hi", prompt_tokens=2, generation_tokens=1
+    )
+    monkeypatch.setitem(sys.modules, "mlx_vlm", fake_mlx_vlm)
+
+    request = ChatCompletionRequest(
+        model="qwen3.5-27b-8bit",
+        messages=[Message(role="user", content="hi")],
+        stream=True,
+    )
+
+    async def exercise() -> None:
+        # Stream path with timeout=0 must generate normally (no immediate
+        # timeout SSE) and finish cleanly.
+        stream = srv._stream_completion(
+            prompt="p",
+            request=request,
+            served_model_name="qwen3.5-27b-8bit",
+            gen_kwargs={"max_tokens": 8},
+            model=MagicMock(),
+            processor=MagicMock(),
+            timeout=0,
+        )
+        body = b"".join([chunk async for chunk in stream]).decode()
+        assert "DFlash stream timed out" not in body
+        assert '"content": "hi"' in body
+        assert "data: [DONE]" in body
+        assert not srv._dflash_lock.locked()
+
+        # Non-stream path with timeout=0 must NOT return an immediate 504 —
+        # it must run to completion (the pre-fix bug returned 504 here).
+        resp = await srv._non_stream_completion(
+            prompt="p",
+            request=MagicMock(),
+            served_model_name="qwen3.5-27b-8bit",
+            gen_kwargs={"max_tokens": 8},
+            model=MagicMock(),
+            processor=MagicMock(),
+            timeout=0,
+        )
+        assert resp.choices[0].message.content == "hi"
+        assert not srv._dflash_lock.locked()
+
+    srv._dflash_lock = asyncio.Lock()
+    try:
+        asyncio.run(exercise())
+    finally:
+        srv._dflash_lock = asyncio.Lock()
+
+
+@_skip_without_mlx_vlm
+def test_dflash_stream_backpressure_does_not_hold_lock(monkeypatch) -> None:
+    """F2: a slow/stalled consumer must not pin ``_dflash_lock``.
+
+    Generation runs in a producer task that owns the lease; the consumer
+    only shuttles bytes to the socket. So once the (short) generation
+    finishes, the lock is released even if the consumer never reads another
+    chunk. We prove it by draining exactly the role marker, then — without
+    reading any generated chunk — waiting for the lock to free while the
+    producer completes independently.
+    """
+    import asyncio
+    import sys
+    import types
+
+    from vllm_mlx.api.models import ChatCompletionRequest, Message
+    from vllm_mlx.speculative.dflash import server as srv
+
+    class _TwoChunks:
+        def __init__(self):
+            self._n = 0
+
+        def __iter__(self):
+            return self
+
+        def __next__(self):
+            self._n += 1
+            if self._n > 2:
+                raise StopIteration
+            return SimpleNamespace(
+                text=f"tok{self._n}",
+                generation_tokens=self._n,
+                prompt_tokens=3,
+                token=100 + self._n,
+            )
+
+        def close(self):
+            pass
+
+    fake_mlx_vlm = types.ModuleType("mlx_vlm")
+    fake_mlx_vlm.stream_generate = lambda *a, **kw: _TwoChunks()
+    monkeypatch.setitem(sys.modules, "mlx_vlm", fake_mlx_vlm)
+
+    request = ChatCompletionRequest(
+        model="qwen3.5-27b-8bit",
+        messages=[Message(role="user", content="hi")],
+        stream=True,
+    )
+
+    async def exercise() -> None:
+        admission = srv._DFlashAdmission(max_concurrent_requests=1)
+        reservation = admission.reserve()
+        stream = srv._stream_completion(
+            prompt="p",
+            request=request,
+            served_model_name="qwen3.5-27b-8bit",
+            gen_kwargs={"max_tokens": 8},
+            model=MagicMock(),
+            processor=MagicMock(),
+            timeout=30,
+            admission_reservation=reservation,
+        )
+        # Read ONLY the role marker, then stop reading (simulate a stalled
+        # socket). The producer keeps running to completion in the
+        # background and must release the lock + slot without us reading
+        # any more chunks.
+        assert b'"role": "assistant"' in await anext(stream)
+        for _ in range(300):
+            if not srv._dflash_lock.locked() and admission._reservations == 0:
+                break
+            await asyncio.sleep(0.01)
+        assert not srv._dflash_lock.locked(), (
+            "F2 regression: lock held while consumer is not reading"
+        )
+        assert admission._reservations == 0, (
+            "F2 regression: slot held under backpressure"
+        )
+        # Drain the rest so the generator closes cleanly.
+        async for _ in stream:
+            pass
+
+    srv._dflash_lock = asyncio.Lock()
+    try:
+        asyncio.run(exercise())
+    finally:
+        srv._dflash_lock = asyncio.Lock()
+
+
+@_skip_without_mlx_vlm
+def test_dflash_admission_reserved_before_body_parse(monkeypatch) -> None:
+    """F1: the ASGI admission middleware rejects with 503 BEFORE FastAPI
+    parses the request body.
+
+    We fill the single admission slot, then post a body that is intentionally
+    invalid JSON. If admission ran only inside the endpoint (post-parse),
+    FastAPI would 400 on the bad JSON first; with the ASGI gate the 503 wins
+    because it fires before the body is read.
+    """
+    from fastapi.testclient import TestClient
+
+    from vllm_mlx.speculative.dflash.runtime import DFlashRuntime
+    from vllm_mlx.speculative.dflash.server import _build_app
+
+    app = _build_app(
+        model=MagicMock(),
+        processor=MagicMock(),
+        runtime=DFlashRuntime(
+            drafter=MagicMock(),
+            kind="dflash",
+            drafter_repo="z-lab/Qwen3.5-27B-DFlash",
+        ),
+        served_model_name="qwen3.5-27b-8bit",
+        default_max_tokens=64,
+        cors_origins=[],
+        max_concurrent_requests=1,
+    )
+    # Occupy the only slot so the incoming request must be rejected.
+    reservation = app.state.dflash_admission.reserve()
+    try:
+        response = TestClient(app).post(
+            "/v1/chat/completions",
+            headers={"Content-Type": "application/json"},
+            content=b'{"model": "x", "messages": [ THIS IS NOT VALID JSON',
+        )
+    finally:
+        reservation.release()
+
+    # 503 (admission) — NOT 400 (body parse) — proves the gate ran first.
+    assert response.status_code == 503, response.text
+    assert response.headers.get("Retry-After") == "1"
+    assert response.json()["error"]["code"] == "at_capacity"
+
+
+# =============================================================================
 # End-to-end — heavy. Requires:
 #   - ``RAPID_MLX_DFLASH_E2E=1`` env var (opt-in; CI doesn't set it)
 #   - mlx-vlm 0.5.0+ installed (skipif gates this)

--- a/tests/test_dflash_integration.py
+++ b/tests/test_dflash_integration.py
@@ -57,6 +57,7 @@ def _reset_dflash_shared_globals():
       (e.g. a test setting ``api_key`` must not silently authenticate — or
       reject — a later test that assumes no key).
     """
+    from vllm_mlx import server as _main_server
     from vllm_mlx.config import get_config
 
     cfg = get_config()
@@ -69,6 +70,11 @@ def _reset_dflash_shared_globals():
             "default_timeout",
         )
     }
+    # codex round-8 #3: the CORS tests here call ``configure_cors_from_env``,
+    # which writes the process-global ``_last_resolved_cors_policy`` in
+    # ``vllm_mlx.server``. Snapshot + restore it too so a resolved policy from
+    # one test can't leak into a later one under randomized ordering.
+    _cors_snapshot = _main_server._last_resolved_cors_policy
     try:
         yield
     finally:
@@ -77,6 +83,7 @@ def _reset_dflash_shared_globals():
         configure_rate_limiter(0, enabled=False)
         for field, value in _snapshot.items():
             setattr(cfg, field, value)
+        _main_server._last_resolved_cors_policy = _cors_snapshot
 
 
 # =============================================================================
@@ -634,6 +641,80 @@ def test_dflash_timeout_message_reports_original_not_post_render_budget(
         assert "after 0.0 seconds" not in excinfo.value.detail
         # Let the detached worker finish so the lock/slot release.
         await asyncio.sleep(0.1)
+
+    srv._dflash_lock = asyncio.Lock()
+    try:
+        asyncio.run(exercise())
+    finally:
+        srv._dflash_lock = asyncio.Lock()
+
+
+def test_dflash_stream_uses_absolute_deadline_over_relative_timeout(
+    monkeypatch,
+) -> None:
+    """codex round-8 #2: an absolute ``deadline`` takes precedence over a
+    relative ``timeout``, so the wall-clock spent before the first stream step
+    is NOT refunded to the request budget.
+
+    We pass a ``deadline`` that is ALREADY in the past alongside a large
+    ``timeout``. If the helper re-based the clock from ``timeout`` (the bug),
+    the stream would run to completion; honoring the absolute past deadline, it
+    must time out immediately.
+    """
+    import asyncio
+    import sys
+    import types
+
+    from vllm_mlx.api.models import ChatCompletionRequest, Message
+    from vllm_mlx.speculative.dflash import server as srv
+
+    class _Gen:
+        def __iter__(self):
+            return self
+
+        def __next__(self):
+            return SimpleNamespace(
+                text="tok", generation_tokens=1, prompt_tokens=1, token=1
+            )
+
+        def close(self):
+            pass
+
+    fake_mlx_vlm = types.ModuleType("mlx_vlm")
+    fake_mlx_vlm.stream_generate = lambda *a, **kw: _Gen()
+    monkeypatch.setitem(sys.modules, "mlx_vlm", fake_mlx_vlm)
+
+    request = ChatCompletionRequest(
+        model="qwen3.5-27b-8bit",
+        messages=[Message(role="user", content="hi")],
+        stream=True,
+    )
+
+    async def exercise() -> None:
+        admission = srv._DFlashAdmission(max_concurrent_requests=1)
+        reservation = admission.reserve()
+        loop = asyncio.get_running_loop()
+        stream = srv._stream_completion(
+            prompt="p",
+            request=request,
+            served_model_name="qwen3.5-27b-8bit",
+            gen_kwargs={"max_tokens": 8},
+            model=MagicMock(),
+            processor=MagicMock(),
+            # A large relative timeout that MUST be ignored in favor of...
+            timeout=999.0,
+            timeout_label=999.0,
+            # ...this already-expired absolute deadline.
+            deadline=loop.time() - 1.0,
+            admission_reservation=reservation,
+        )
+        body = b"".join([chunk async for chunk in stream]).decode()
+        # Immediate timeout — the past deadline wins over the 999s timeout.
+        assert "timed out" in body, (
+            "codex #8 regression: relative timeout re-based the clock, "
+            "ignoring the absolute (already-expired) deadline"
+        )
+        assert "data: [DONE]" in body
 
     srv._dflash_lock = asyncio.Lock()
     try:

--- a/tests/test_dflash_integration.py
+++ b/tests/test_dflash_integration.py
@@ -544,18 +544,32 @@ def test_dflash_nonstream_timeout_keeps_gpu_slot_until_worker_finishes(
 def test_dflash_stream_timeout_stops_after_the_inflight_worker_step(
     monkeypatch,
 ) -> None:
-    """DFlash honors stream deadlines without overlapping GPU work."""
+    """DFlash honors stream deadlines without overlapping GPU work.
+
+    codex round-2 #2: the timeout SSE must be emitted IMMEDIATELY on
+    deadline expiry — the response must NOT block on the non-preemptible
+    in-flight worker step. The lock stays held (deferred cleanup) until the
+    detached worker actually exits, then is released. Here the worker sleeps
+    0.05s while the deadline is 0.01s, so a fix that awaited the worker
+    before emitting the timeout would keep the client waiting the full 0.05s;
+    the fixed path emits the timeout SSE right away and releases the lock
+    only after the worker done-callback runs.
+    """
     import asyncio
     import sys
+    import threading
     import time
     import types
 
     from vllm_mlx.api.models import ChatCompletionRequest, Message
     from vllm_mlx.speculative.dflash import server as srv
 
+    worker_finished = threading.Event()
+
     class _SlowGenerator:
         def __next__(self):
             time.sleep(0.05)
+            worker_finished.set()
             raise StopIteration
 
         def close(self):
@@ -570,23 +584,48 @@ def test_dflash_stream_timeout_stops_after_the_inflight_worker_step(
         messages=[Message(role="user", content="hi")],
         stream=True,
     )
-    stream = srv._stream_completion(
-        prompt="prompt",
-        request=request,
-        served_model_name="qwen3.5-27b-8bit",
-        gen_kwargs={"max_tokens": 8},
-        model=MagicMock(),
-        processor=MagicMock(),
-        timeout=0.01,
-    )
 
-    async def drain() -> list[bytes]:
-        return [chunk async for chunk in stream]
+    async def exercise() -> None:
+        stream = srv._stream_completion(
+            prompt="prompt",
+            request=request,
+            served_model_name="qwen3.5-27b-8bit",
+            gen_kwargs={"max_tokens": 8},
+            model=MagicMock(),
+            processor=MagicMock(),
+            timeout=0.01,
+        )
+        started = asyncio.get_running_loop().time()
+        body = b"".join([chunk async for chunk in stream]).decode()
+        elapsed = asyncio.get_running_loop().time() - started
 
-    body = b"".join(asyncio.run(drain())).decode()
-    assert "DFlash stream timed out after 0.0 seconds." in body
-    assert "data: [DONE]" in body
-    assert not srv._dflash_lock.locked()
+        # The timeout SSE + DONE are emitted without blocking on the worker.
+        assert "DFlash stream timed out after 0.0 seconds." in body
+        assert "data: [DONE]" in body
+        # The 0.05s worker step must NOT gate the response — the fixed path
+        # surfaces the timeout well before the worker's sleep elapses.
+        assert elapsed < 0.05, (
+            f"timeout SSE blocked on the in-flight worker ({elapsed:.3f}s); "
+            "codex round-2 #2 regression"
+        )
+
+        # The lock stays held by deferred cleanup until the detached worker
+        # exits; then the done-callback releases it. Poll (keeping the loop
+        # alive) until that happens.
+        assert await asyncio.to_thread(worker_finished.wait, 1)
+        for _ in range(200):
+            if not srv._dflash_lock.locked():
+                break
+            await asyncio.sleep(0.01)
+        assert not srv._dflash_lock.locked(), (
+            "lock not released after the deferred worker finished"
+        )
+
+    srv._dflash_lock = asyncio.Lock()
+    try:
+        asyncio.run(exercise())
+    finally:
+        srv._dflash_lock = asyncio.Lock()
 
 
 def test_dflash_stream_timeout_bounds_lock_queue_wait(monkeypatch) -> None:
@@ -1658,7 +1697,6 @@ def test_run_dflash_server_loads_models_on_executor_thread(monkeypatch) -> None:
 # =============================================================================
 
 
-@_skip_without_mlx_vlm
 def test_dflash_stream_cancel_during_construction_releases_lock(monkeypatch) -> None:
     """F3: cancelling while the generator is still being CONSTRUCTED must
     not leak ``_dflash_lock``.
@@ -1744,16 +1782,19 @@ def test_dflash_stream_cancel_during_construction_releases_lock(monkeypatch) -> 
         srv._dflash_lock = asyncio.Lock()
 
 
-@_skip_without_mlx_vlm
 def test_dflash_nonstream_expired_deadline_skips_gpu_work(monkeypatch) -> None:
     """F5: a non-stream request whose deadline expired while acquiring the
     serial lock must NOT submit GPU work.
 
-    Hold the lock with a foreign owner so the request's ``wait_for`` on the
-    lock burns its whole (tiny) budget; release just after so acquisition
-    succeeds but the deadline is already gone. ``generate`` must never be
-    called, and the 504 must come back immediately without a detached
-    worker holding the lock.
+    Deterministic construction (codex round-2 #4): the lock is FREE, so
+    acquisition succeeds immediately — this test does NOT rely on the
+    lock-acquire ``wait_for`` timing out (which would leave the F5
+    post-acquisition recheck untested and pass even if it were deleted).
+    Instead a fake monotonic clock jumps PAST the deadline between the
+    deadline computation and the post-acquire recheck, so acquisition
+    succeeds but the recheck sees an already-expired deadline and must
+    raise 504 BEFORE submitting the executor job. ``generate`` must never
+    be called.
     """
     import asyncio
     import sys
@@ -1777,15 +1818,29 @@ def test_dflash_nonstream_expired_deadline_skips_gpu_work(monkeypatch) -> None:
         admission = srv._DFlashAdmission(max_concurrent_requests=1)
         reservation = admission.reserve()
 
-        # Foreign owner holds the lock; release it just after the request's
-        # deadline expires so the request acquires it already-expired.
-        await srv._dflash_lock.acquire()
+        loop = asyncio.get_running_loop()
+        real_time = loop.time
+        # Deterministic clock: ``loop.time`` returns ``real_now + advance``.
+        # The lock is FREE, so acquisition succeeds instantly (this does NOT
+        # rely on the acquire ``wait_for`` timing out — the flaw codex #4
+        # flagged). We advance the clock PAST the deadline the instant the
+        # lock is acquired, via an ``acquire`` wrapper, so that:
+        #   * the deadline anchor + pre-acquire remaining-time check both see
+        #     ``advance == 0`` (plenty of budget), and
+        #   * the POST-acquire remaining-time recheck (the actual F5 guard)
+        #     sees ``advance == +10s`` → deadline blown → 504 before submit.
+        advance = {"v": 0.0}
+        monkeypatch.setattr(loop, "time", lambda: real_time() + advance["v"])
 
-        async def _release_soon() -> None:
-            await asyncio.sleep(0.03)
-            srv._dflash_lock.release()
+        real_acquire = srv._dflash_lock.acquire
 
-        releaser = asyncio.create_task(_release_soon())
+        async def acquire_then_blow_deadline() -> bool:
+            got = await real_acquire()
+            advance["v"] = 10.0  # deadline (anchor + 5s) is now in the past
+            return got
+
+        monkeypatch.setattr(srv._dflash_lock, "acquire", acquire_then_blow_deadline)
+
         with pytest.raises(HTTPException) as excinfo:
             await srv._non_stream_completion(
                 prompt="prompt",
@@ -1794,14 +1849,15 @@ def test_dflash_nonstream_expired_deadline_skips_gpu_work(monkeypatch) -> None:
                 gen_kwargs={},
                 model=MagicMock(),
                 processor=MagicMock(),
-                timeout=0.01,
+                timeout=5.0,  # positive deadline; blown right after acquire
                 admission_reservation=reservation,
             )
-        await releaser
+        monkeypatch.setattr(loop, "time", real_time)
+
         assert excinfo.value.status_code == 504
         # The core F5 assertion: no GPU work started for an expired request.
         assert generate_calls[0] == 0, "F5 regression: GPU work started after deadline"
-        # And no detached worker is holding the lock (nothing was submitted).
+        # Nothing was submitted, so no detached worker holds the lock.
         assert not srv._dflash_lock.locked()
         reservation.release()
         assert admission._reservations == 0
@@ -1813,7 +1869,6 @@ def test_dflash_nonstream_expired_deadline_skips_gpu_work(monkeypatch) -> None:
         srv._dflash_lock = asyncio.Lock()
 
 
-@_skip_without_mlx_vlm
 def test_dflash_zero_timeout_is_no_deadline_on_both_paths(monkeypatch) -> None:
     """F4: ``timeout <= 0`` means "no deadline" consistently on the stream
     AND non-stream paths — not "unlimited" on one and "immediate 504" on
@@ -1887,7 +1942,6 @@ def test_dflash_zero_timeout_is_no_deadline_on_both_paths(monkeypatch) -> None:
         srv._dflash_lock = asyncio.Lock()
 
 
-@_skip_without_mlx_vlm
 def test_dflash_stream_backpressure_does_not_hold_lock(monkeypatch) -> None:
     """F2: a slow/stalled consumer must not pin ``_dflash_lock``.
 
@@ -1975,7 +2029,6 @@ def test_dflash_stream_backpressure_does_not_hold_lock(monkeypatch) -> None:
         srv._dflash_lock = asyncio.Lock()
 
 
-@_skip_without_mlx_vlm
 def test_dflash_admission_reserved_before_body_parse(monkeypatch) -> None:
     """F1: the ASGI admission middleware rejects with 503 BEFORE FastAPI
     parses the request body.

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -3242,6 +3242,13 @@ def serve_command(args):
             cors_origins=cors_origins,
             uvicorn_log_level=uvicorn_log_level,
             no_thinking=args.no_thinking,
+            api_key=server._api_key,
+            rate_limit=args.rate_limit,
+            max_request_bytes=server._max_request_bytes,
+            body_receive_timeout_seconds=server._body_receive_timeout_seconds,
+            default_timeout=server._default_timeout,
+            max_concurrent_requests=args.max_concurrent_requests,
+            cors_policy=server.get_resolved_cors_policy(),
         )
         return
 

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -39,6 +39,7 @@ import asyncio
 import gc
 import logging
 import os
+from dataclasses import dataclass
 
 import uvicorn
 from fastapi import FastAPI
@@ -681,6 +682,25 @@ _DEFAULT_CORS_HEADERS: tuple[str, ...] = (
 _DEFAULT_CORS_MAX_AGE: int = 3600
 
 
+@dataclass(frozen=True)
+class ResolvedCORSPolicy:
+    """The fully resolved CORS policy shared by all HTTP server modes."""
+
+    origins: tuple[str, ...]
+    methods: tuple[str, ...]
+    headers: tuple[str, ...]
+    max_age: int
+    allow_credentials: bool
+
+
+_last_resolved_cors_policy: ResolvedCORSPolicy | None = None
+
+
+def get_resolved_cors_policy() -> ResolvedCORSPolicy | None:
+    """Return the policy configured during this process's CLI startup."""
+    return _last_resolved_cors_policy
+
+
 class _SpecAlignedCORSMiddleware(CORSMiddleware):
     """``CORSMiddleware`` whose preflight rejection is spec-aligned (L-02).
 
@@ -860,6 +880,8 @@ def configure_cors_from_env(
 
     Returns the resolved origin list (empty list when CORS is disabled).
     """
+    global _last_resolved_cors_policy
+
     # ``came_from_cli`` discriminates the two compat tiers (codex round-3
     # BLOCKING). The legacy ``--cors-origins`` CLI path used to imply
     # ``allow_headers=["*"]`` / ``allow_methods=["*"]``; existing browser
@@ -1025,6 +1047,18 @@ def configure_cors_from_env(
                 creds_env,
             )
 
+    # Keep the policy snapshot byte-for-byte equivalent to the middleware
+    # actually installed below. In particular, a credentialed wildcard is
+    # invalid under Fetch and must never reappear on DFlash via its separate
+    # FastAPI application.
+    if "*" in origins and allow_credentials:
+        logger.warning(
+            "%s requested with a wildcard origin is invalid per the "
+            "Fetch spec; forcing allow_credentials=False",
+            "RAPID_MLX_CORS_ALLOW_CREDENTIALS",
+        )
+        allow_credentials = False
+
     # Fail-closed path: ``RAPID_MLX_CORS_ALLOW_ORIGINS`` was set but
     # parsed to an empty list (operator-controlled typo). Don't register
     # CORSMiddleware — that's the visible signal the WARNING above
@@ -1033,8 +1067,16 @@ def configure_cors_from_env(
     # lambda — we never call ``configure_cors(...)`` on the fail-closed
     # path, so the stub's signature doesn't matter.
     if not origins:
+        _last_resolved_cors_policy = None
         return []
 
+    _last_resolved_cors_policy = ResolvedCORSPolicy(
+        origins=tuple(origins),
+        methods=tuple(methods),
+        headers=tuple(headers),
+        max_age=max_age,
+        allow_credentials=allow_credentials,
+    )
     configure_cors(
         origins,
         methods=methods,

--- a/vllm_mlx/speculative/dflash/server.py
+++ b/vllm_mlx/speculative/dflash/server.py
@@ -143,6 +143,11 @@ def _format_timeout_seconds(seconds: float) -> str:
     """
     if seconds <= 0:
         return "0 seconds"
+    if seconds < 0.001:
+        # codex round-7 #3: below the 3-decimal resolution ``:.3f`` would print
+        # "0.000 seconds" — the very misleading zero this formatter exists to
+        # avoid. Report a floor instead so the message stays truthful.
+        return "<0.001 seconds"
     if seconds < 0.1:
         # e.g. 0.01 → "0.010", 0.005 → "0.005"
         return f"{seconds:.3f} seconds"
@@ -552,8 +557,21 @@ class _DFlashStreamLease:
                 # The client task can be cancelled a second time while it is
                 # already unwinding. The queued close still owns the GPU
                 # ordering, so release only from its completion callback.
+                #
+                # codex round-7 #1: DEFER the admission release too — otherwise
+                # the reservation could be force-released here while
+                # ``generator.close()`` (and thus the serial GPU lock) is still
+                # in flight, freeing capacity for a new request to overlap
+                # teardown. And RE-RAISE the ``CancelledError`` rather than
+                # swallowing it: this coroutine runs inside the cancelled client
+                # task's unwind, so returning normally would resurrect a
+                # cancelled task and let producer work continue past
+                # cancellation. The completion callback still owns the eventual
+                # lock + slot release.
+                if self._reservation is not None:
+                    self._reservation.defer_release()
                 close_future.add_done_callback(lambda _done: self._release())
-                return
+                raise
         self._release()
 
     def _release(self) -> None:
@@ -815,6 +833,11 @@ def _build_app(
         reservation = getattr(http_request.state, "dflash_reservation", None)
         if reservation is None:
             reservation = admission.reserve()
+        # Tracks the offloaded render's ``concurrent.futures.Future`` (the real
+        # worker-thread state) so the failure/cancellation cleanup can decide
+        # whether the slot may be freed now or must be held until an in-flight
+        # render actually finishes (codex round-7 #2).
+        render_future: concurrent.futures.Future[str] | None = None
         try:
             # F4 (codex round-2 #3): resolve the effective timeout with an
             # ``is None`` check, NOT ``request.timeout or default_timeout``.
@@ -890,13 +913,24 @@ def _build_app(
                     processor, model, request, enable_thinking=enable_thinking
                 )
 
-            render_future = loop.run_in_executor(_dflash_render_executor, _render)
+            # codex round-7 #2: submit via the executor DIRECTLY so we hold the
+            # ``concurrent.futures.Future`` — which tracks the ACTUAL worker
+            # thread. (``loop.run_in_executor`` returns an asyncio future whose
+            # ``.cancel()`` marks itself done while the thread keeps running, so
+            # its ``.done()`` cannot tell "still executing" from "finished" — the
+            # exact ambiguity that let the slot be freed under a live render.)
+            # ``asyncio.wrap_future`` gives an awaitable view; cancelling that
+            # view never touches the underlying thread future, so
+            # ``render_cf.done()`` in the cleanup below reflects true completion.
+            render_cf = _dflash_render_executor.submit(_render)
+            render_future = render_cf  # tracked for the cleanup handler
+            render_awaitable = asyncio.wrap_future(render_cf)
             if request_deadline is None:
-                prompt = await render_future
+                prompt = await render_awaitable
             else:
                 render_budget = request_deadline - loop.time()
                 if render_budget <= 0:
-                    render_future.cancel()
+                    render_cf.cancel()
                     raise HTTPException(
                         status_code=504,
                         detail=(
@@ -906,17 +940,13 @@ def _build_app(
                     )
                 try:
                     prompt = await asyncio.wait_for(
-                        asyncio.shield(render_future), timeout=render_budget
+                        asyncio.shield(render_awaitable), timeout=render_budget
                     )
                 except asyncio.TimeoutError as exc:
-                    # ``shield`` kept the render alive across our ``wait_for``
-                    # cancellation; cancel it now (a no-op if its sync body
-                    # already started, but it prevents a queued render from
-                    # firing). Abandoning it is safe — it runs on the separate
-                    # render pool, holds no GPU lock, and its result is simply
-                    # discarded — so the ``except BaseException`` below releases
-                    # the admission slot immediately with nothing left to defer.
-                    render_future.cancel()
+                    # ``cancel()`` stops the render only if it is still QUEUED;
+                    # a render already running on the pool keeps going (the
+                    # cleanup handler below holds the slot until it drains).
+                    render_cf.cancel()
                     raise HTTPException(
                         status_code=504,
                         detail=(
@@ -966,7 +996,31 @@ def _build_app(
                     )
                 effective_timeout = remaining_budget
         except BaseException:
-            reservation.release()
+            # codex round-7 #2: if we are unwinding while the offloaded render
+            # is STILL in flight (timeout/cancel/disconnect), releasing the slot
+            # now would let repeated cancelled requests each leave a render
+            # running/queued on the single-worker render pool while freeing
+            # capacity — an unbounded pileup that bypasses
+            # ``max_concurrent_requests``. Try to cancel it; if it was still
+            # queued the cancel succeeds and we release immediately, but if it
+            # is already running (cancel returns False) DEFER the slot release
+            # to the render's completion so the admission gate keeps counting it
+            # until the work actually drains. A finished render releases at once.
+            if render_future is not None and not render_future.done():
+                render_future.cancel()
+            if render_future is not None and not render_future.done():
+                # Still running (uncancellable) — hold the slot until it drains.
+                # CLAIM ownership so the ASGI middleware safety net does not
+                # force-release the (as-yet unclaimed) slot out from under the
+                # still-running render; the completion callback then owns the
+                # single deferred release.
+                reservation.claim()
+                reservation.defer_release()
+                render_future.add_done_callback(
+                    lambda _f: reservation.release(force=True)
+                )
+            else:
+                reservation.release()
             raise
 
         if request.stream:

--- a/vllm_mlx/speculative/dflash/server.py
+++ b/vllm_mlx/speculative/dflash/server.py
@@ -91,10 +91,16 @@ _dflash_executor = concurrent.futures.ThreadPoolExecutor(
 # steal its deadline and touch its model/processor mid-generation). This pool
 # is single-worker too, so renders serialize among themselves — cheap, and it
 # sidesteps any tokenizer thread-safety question — while remaining fully
-# independent of ``_dflash_lock`` and GPU generation. Because an in-flight
-# render here holds no GPU/serial resource, an uncancellable render that
-# overruns its deadline can be abandoned and its admission slot released
-# immediately (nothing serial is left running).
+# independent of ``_dflash_lock`` and GPU generation.
+#
+# codex round-8 #5: an uncancellable render that overruns its deadline does NOT
+# free its admission slot immediately. The endpoint retains the slot (claim +
+# defer) until the render's ``concurrent.futures.Future`` actually completes
+# and releases from its callback (codex round-7 #2). Holding the slot is what
+# keeps ``max_concurrent_requests`` honest: a burst of cancelled/timed-out
+# requests each keeps its render counted until it drains, so they cannot pile
+# up unbounded on this pool's queue. (The slot is held only for accounting —
+# the render still touches no GPU/serial resource, so nothing blocks the GPU.)
 _dflash_render_executor = concurrent.futures.ThreadPoolExecutor(
     max_workers=1, thread_name_prefix="dflash-render"
 )
@@ -913,6 +919,20 @@ def _build_app(
                     processor, model, request, enable_thinking=enable_thinking
                 )
 
+            # codex round-8 #1: validate the remaining budget BEFORE submitting
+            # any work. Submitting first — then checking ``render_budget <= 0``
+            # — could still start an uncancellable tokenizer render on an
+            # already-expired deadline before returning the 504. Check first;
+            # only submit when there is time to render.
+            if request_deadline is not None and request_deadline - loop.time() <= 0:
+                raise HTTPException(
+                    status_code=504,
+                    detail=(
+                        "DFlash request deadline elapsed before prompt "
+                        "rendering could start."
+                    ),
+                )
+
             # codex round-7 #2: submit via the executor DIRECTLY so we hold the
             # ``concurrent.futures.Future`` — which tracks the ACTUAL worker
             # thread. (``loop.run_in_executor`` returns an asyncio future whose
@@ -929,15 +949,6 @@ def _build_app(
                 prompt = await render_awaitable
             else:
                 render_budget = request_deadline - loop.time()
-                if render_budget <= 0:
-                    render_cf.cancel()
-                    raise HTTPException(
-                        status_code=504,
-                        detail=(
-                            "DFlash request deadline elapsed before prompt "
-                            "rendering could start."
-                        ),
-                    )
                 try:
                     prompt = await asyncio.wait_for(
                         asyncio.shield(render_awaitable), timeout=render_budget
@@ -1035,6 +1046,7 @@ def _build_app(
                         processor=processor,
                         timeout=effective_timeout,
                         timeout_label=request_timeout_for_diagnostics,
+                        deadline=request_deadline,
                         admission_reservation=reservation,
                     ),
                     reservation,
@@ -1060,6 +1072,7 @@ def _build_app(
                 processor=processor,
                 timeout=effective_timeout,
                 timeout_label=request_timeout_for_diagnostics,
+                deadline=request_deadline,
                 admission_reservation=reservation,
             )
         finally:
@@ -1189,10 +1202,19 @@ async def _stream_completion(
     processor: Any,
     timeout: float | None = None,
     timeout_label: float | None = None,
+    deadline: float | None = None,
     admission_reservation: _DFlashAdmissionReservation | None = None,
 ) -> AsyncIterator[bytes]:
     """Stream OpenAI-format chunks. Generation happens under the serial
     lock; chunks are forwarded as ``data: ...\\n\\n`` SSE events.
+
+    ``deadline`` is an ABSOLUTE ``loop.time()`` instant (codex round-8 #2). The
+    endpoint establishes one deadline spanning render + generation and passes
+    it here directly; reconstructing a fresh deadline from a relative
+    ``timeout`` at this point would silently hand back the wall-clock time spent
+    between the endpoint and the first stream step (returning ``StreamingResponse``
+    + header send). When ``deadline`` is omitted (direct callers/tests) it is
+    derived from ``timeout`` as before.
 
     ``timeout`` is the ENFORCED remaining budget (post prompt-render);
     ``timeout_label`` is the ORIGINAL configured request timeout used only in
@@ -1239,7 +1261,13 @@ async def _stream_completion(
         _eos_ids.update(int(t) for t in _eos if isinstance(t, int))
 
     loop = asyncio.get_running_loop()
-    deadline = loop.time() + timeout if timeout and timeout > 0 else None
+    # codex round-8 #2: prefer the absolute ``deadline`` the endpoint passed
+    # (which already spans render + generation on this loop's clock). Only
+    # derive one from the relative ``timeout`` when a direct caller/test omits
+    # it — otherwise the clock would be re-based here, refunding the time spent
+    # returning the response and sending headers.
+    if deadline is None and timeout and timeout > 0:
+        deadline = loop.time() + timeout
     timed_out = object()
     lease = _DFlashStreamLease(loop, admission_reservation, deadline)
 
@@ -1708,6 +1736,7 @@ async def _non_stream_completion(
     processor: Any,
     timeout: float = 1800.0,
     timeout_label: float | None = None,
+    deadline: float | None = None,
     admission_reservation: _DFlashAdmissionReservation | None = None,
 ) -> ChatCompletionResponse:
     """Run generation under the serial lock and enforce a safe deadline.
@@ -1717,9 +1746,12 @@ async def _non_stream_completion(
     lock and admission slot until the worker exits; otherwise a second call
     could overlap the first GPU operation on the same thread.
 
-    ``timeout`` is the ENFORCED remaining budget (post prompt-render);
-    ``timeout_label`` is the ORIGINAL configured request timeout reported in
-    the 504 message (codex round-5 #6). Omitted → mirrors ``timeout``.
+    ``deadline`` is an ABSOLUTE ``loop.time()`` instant (codex round-8 #2)
+    spanning render + generation; when omitted (direct callers/tests) it is
+    derived from the relative ``timeout``. ``timeout`` is the ENFORCED remaining
+    budget (post prompt-render); ``timeout_label`` is the ORIGINAL configured
+    request timeout reported in the 504 message (codex round-5 #6). Omitted →
+    mirrors ``timeout``.
     """
     from mlx_vlm import generate
 
@@ -1743,7 +1775,11 @@ async def _non_stream_completion(
     # already-expired deadline and returned an immediate 504, while the
     # same value disabled the streaming deadline — identical requests
     # behaving oppositely by path.
-    deadline = loop.time() + timeout if timeout and timeout > 0 else None
+    #
+    # codex round-8 #2: prefer the absolute ``deadline`` the endpoint passed;
+    # only derive from the relative ``timeout`` when a direct caller omitted it.
+    if deadline is None and timeout and timeout > 0:
+        deadline = loop.time() + timeout
     lock_acquired = False
     worker_future: asyncio.Future[Any] | None = None
 

--- a/vllm_mlx/speculative/dflash/server.py
+++ b/vllm_mlx/speculative/dflash/server.py
@@ -82,6 +82,23 @@ _dflash_executor = concurrent.futures.ThreadPoolExecutor(
     max_workers=1, thread_name_prefix="dflash-worker"
 )
 
+# Separate executor for prompt rendering (codex round-4 #4 → round-5 #1/#2).
+# ``_render_prompt`` applies the chat template + tokenizes into a *string* —
+# pure CPU tokenizer work that never creates mlx GPU arrays, so it does NOT
+# need the thread-local GPU affinity ``_dflash_executor`` enforces. Keeping it
+# OFF the single GPU worker is what makes it safe to offload: a render must
+# never run between the token steps of a lock-owning generation (that would
+# steal its deadline and touch its model/processor mid-generation). This pool
+# is single-worker too, so renders serialize among themselves — cheap, and it
+# sidesteps any tokenizer thread-safety question — while remaining fully
+# independent of ``_dflash_lock`` and GPU generation. Because an in-flight
+# render here holds no GPU/serial resource, an uncancellable render that
+# overruns its deadline can be abandoned and its admission slot released
+# immediately (nothing serial is left running).
+_dflash_render_executor = concurrent.futures.ThreadPoolExecutor(
+    max_workers=1, thread_name_prefix="dflash-render"
+)
+
 
 # F2 (codex round-2 #1): bound the producer→consumer SSE handoff queue so a
 # stalled client cannot make the producer buffer an entire completion in
@@ -261,12 +278,22 @@ class _DFlashAdmissionMiddleware:
                 _extract_bearer_token(request.headers.get("Authorization"))
             )
         except HTTPException as exc:
+            # codex round-5 #5: a 401 must carry the ``WWW-Authenticate:
+            # Bearer`` challenge (RFC 6750). Forward any headers the
+            # ``HTTPException`` attached, and — because the shared
+            # ``_verify_api_key_values`` raises a bare 401 without the
+            # challenge — inject it here for a 401 so the DFlash auth rejection
+            # is spec-compliant rather than an unchallenged 401.
+            challenge_headers = dict(exc.headers or {})
+            if exc.status_code == 401:
+                challenge_headers.setdefault("WWW-Authenticate", "Bearer")
             await _send_json_error(
                 send,
                 status_code=exc.status_code,
                 message=str(exc.detail),
                 error_type="invalid_request_error",
                 code="invalid_api_key",
+                extra_headers=challenge_headers,
             )
             return
 
@@ -318,6 +345,7 @@ async def _send_json_error(
     error_type: str,
     code: str,
     retry_after: str | None = None,
+    extra_headers: dict[str, str] | None = None,
 ) -> None:
     """Emit an OpenAI-shaped error JSON response from inside ASGI middleware.
 
@@ -325,6 +353,11 @@ async def _send_json_error(
     before FastAPI's exception machinery is reachable — the request body has
     not been read. Used for the middleware's pre-admission 401 / 429 / 503
     (F1 + codex round-3 #3).
+
+    ``extra_headers`` carries response headers the caught ``HTTPException``
+    attached (codex round-5 #5) — notably ``WWW-Authenticate: Bearer`` on a
+    401, the RFC 6750 challenge that FastAPI's own auth path emits and that a
+    hand-rolled middleware rejection would otherwise drop.
     """
     body = json.dumps(
         {
@@ -342,6 +375,13 @@ async def _send_json_error(
     ]
     if retry_after:
         headers.append((b"retry-after", str(retry_after).encode("ascii")))
+    if extra_headers:
+        for name, value in extra_headers.items():
+            # ``retry-after`` is handled above; skip a duplicate if both paths
+            # supply it. Header names are ASCII-lowercased per ASGI convention.
+            if name.lower() == "retry-after" and retry_after:
+                continue
+            headers.append((name.lower().encode("ascii"), str(value).encode("ascii")))
     try:
         await send(
             {"type": "http.response.start", "status": status_code, "headers": headers}
@@ -484,11 +524,12 @@ class _DFlashStreamLease:
 
 @atexit.register
 def _shutdown_dflash_executor() -> None:
-    """Drain the DFlash worker on interpreter exit. Python registers an
+    """Drain the DFlash workers on interpreter exit. Python registers an
     implicit atexit for ThreadPoolExecutor, but registering ours
     explicitly makes shutdown order deterministic and silences
     "unfinished thread" warnings during graceful uvicorn termination."""
     _dflash_executor.shutdown(wait=False, cancel_futures=True)
+    _dflash_render_executor.shutdown(wait=False, cancel_futures=True)
 
 
 def _build_app(
@@ -714,6 +755,13 @@ def _build_app(
             effective_timeout = (
                 request.timeout if request.timeout is not None else default_timeout
             )
+            # codex round-5 #6: keep the ORIGINAL configured timeout for
+            # human-facing diagnostics. ``effective_timeout`` is rewritten below
+            # to the post-render REMAINING budget (so the absolute deadline
+            # spans render + generation), but a 504 message should still say
+            # "timed out after 60s" for a 60s request that spent 20s rendering
+            # — not "after 40s" — or users chase a phantom shorter limit.
+            request_timeout_for_diagnostics = effective_timeout
             loop = asyncio.get_running_loop()
             request_deadline = (
                 loop.time() + effective_timeout
@@ -740,18 +788,30 @@ def _build_app(
             else:
                 enable_thinking = _extract_thinking_from_request(request)
 
-            # codex round-4 #4: OFFLOAD rendering to the DFlash worker thread so
-            # a heavy chat template cannot block the event loop (starving other
+            # codex round-4 #4 → round-5 #1/#2: OFFLOAD rendering so a heavy
+            # chat template cannot block the event loop (starving other
             # connections, health checks, and — critically — the very deadline
-            # enforcement we rely on elsewhere). Bound it by the request
-            # deadline so an expensive render on an already-tight budget fails
-            # fast with a 504 rather than running unbounded.
+            # enforcement we rely on elsewhere), and bound it by the request
+            # deadline so an expensive render on a tight budget fails fast with
+            # a 504 rather than running unbounded.
+            #
+            # It runs on ``_dflash_render_executor`` — a pool SEPARATE from the
+            # single GPU worker — NOT ``_dflash_executor``. Using the GPU worker
+            # (the round-4 mistake) let a later request's render run between the
+            # token steps of the lock-owning generation, consuming its deadline
+            # and touching its model/processor mid-generation. Rendering
+            # produces only a string (pure CPU tokenizer work, no mlx GPU
+            # arrays), so it needs neither the GPU thread affinity nor
+            # ``_dflash_lock``. Because this render holds NO serial/GPU resource,
+            # an uncancellable overrun can be abandoned and its admission slot
+            # released immediately (round-5 #2) — nothing serial is left running
+            # behind it, unlike a timed-out generation worker.
             def _render() -> str:
                 return _render_prompt(
                     processor, model, request, enable_thinking=enable_thinking
                 )
 
-            render_future = loop.run_in_executor(_dflash_executor, _render)
+            render_future = loop.run_in_executor(_dflash_render_executor, _render)
             if request_deadline is None:
                 prompt = await render_future
             else:
@@ -770,18 +830,20 @@ def _build_app(
                         asyncio.shield(render_future), timeout=render_budget
                     )
                 except asyncio.TimeoutError as exc:
-                    # The render is running on the single serial worker; letting
-                    # it keep running would block the next request's generation.
-                    # ``shield`` kept the future alive across our ``wait_for``
-                    # cancellation; cancel it explicitly now (a no-op if the
-                    # sync body already started, but it prevents a queued render
-                    # from firing) and surface the timeout.
+                    # ``shield`` kept the render alive across our ``wait_for``
+                    # cancellation; cancel it now (a no-op if its sync body
+                    # already started, but it prevents a queued render from
+                    # firing). Abandoning it is safe — it runs on the separate
+                    # render pool, holds no GPU lock, and its result is simply
+                    # discarded — so the ``except BaseException`` below releases
+                    # the admission slot immediately with nothing left to defer.
                     render_future.cancel()
                     raise HTTPException(
                         status_code=504,
                         detail=(
                             "DFlash prompt rendering exceeded the request "
-                            f"timeout of {effective_timeout:.1f} seconds."
+                            f"timeout of {request_timeout_for_diagnostics:.1f} "
+                            "seconds."
                         ),
                     ) from exc
 
@@ -838,6 +900,7 @@ def _build_app(
                         model=model,
                         processor=processor,
                         timeout=effective_timeout,
+                        timeout_label=request_timeout_for_diagnostics,
                         admission_reservation=reservation,
                     ),
                     reservation,
@@ -862,6 +925,7 @@ def _build_app(
                 model=model,
                 processor=processor,
                 timeout=effective_timeout,
+                timeout_label=request_timeout_for_diagnostics,
                 admission_reservation=reservation,
             )
         finally:
@@ -961,15 +1025,24 @@ async def _stream_with_admission(
         # return. Closing the inner generator here covers client disconnects
         # and send failures too, so its GPU cleanup runs before the slot is
         # made available again.
+        #
+        # codex round-5 #4: ``reservation.release()`` MUST run even if
+        # ``aclose()`` raises ``asyncio.CancelledError`` — which subclasses
+        # ``BaseException``, NOT ``Exception``, so an ``except Exception`` would
+        # let it skip the release and permanently leak the slot on a client
+        # cancellation. Put the release in its own unconditional ``finally`` so
+        # it fires regardless of how ``aclose()`` unwinds, then let cancellation
+        # propagate.
         aclose = getattr(stream, "aclose", None)
-        if aclose is not None:
-            try:
+        try:
+            if aclose is not None:
                 await aclose()
-            except Exception:  # noqa: BLE001 -- release remains mandatory
-                logger.debug(
-                    "DFlash stream close raised; releasing admission", exc_info=True
-                )
-        reservation.release()
+        except Exception:  # noqa: BLE001 -- release remains mandatory
+            logger.debug(
+                "DFlash stream close raised; releasing admission", exc_info=True
+            )
+        finally:
+            reservation.release()
 
 
 async def _stream_completion(
@@ -981,11 +1054,21 @@ async def _stream_completion(
     model: Any,
     processor: Any,
     timeout: float | None = None,
+    timeout_label: float | None = None,
     admission_reservation: _DFlashAdmissionReservation | None = None,
 ) -> AsyncIterator[bytes]:
     """Stream OpenAI-format chunks. Generation happens under the serial
-    lock; chunks are forwarded as ``data: ...\\n\\n`` SSE events."""
+    lock; chunks are forwarded as ``data: ...\\n\\n`` SSE events.
+
+    ``timeout`` is the ENFORCED remaining budget (post prompt-render);
+    ``timeout_label`` is the ORIGINAL configured request timeout used only in
+    human-facing timeout messages (codex round-5 #6), so a client sees the
+    limit it actually asked for rather than the render-reduced remainder. When
+    omitted (direct callers/tests) it mirrors ``timeout``."""
     from mlx_vlm import stream_generate
+
+    if timeout_label is None:
+        timeout_label = timeout
 
     completion_id = f"chatcmpl-{uuid.uuid4().hex[:24]}"
     created = int(time.time())
@@ -1208,7 +1291,9 @@ async def _stream_completion(
             # generator to drive; the lease's deferred cleanup owns closing
             # the (possibly in-flight) worker.
             if gen_or_err is timed_out:
-                error_message = f"DFlash stream timed out after {timeout:.1f} seconds."
+                error_message = (
+                    f"DFlash stream timed out after {timeout_label:.1f} seconds."
+                )
                 finish_reason = "length"
                 gen = None
             elif isinstance(gen_or_err, Exception):
@@ -1251,7 +1336,7 @@ async def _stream_completion(
                     # tracked by the lease and cleaned up (lock + slot held
                     # until it stops) via ``__aexit__``'s deferred path.
                     error_message = (
-                        f"DFlash stream timed out after {timeout:.1f} seconds."
+                        f"DFlash stream timed out after {timeout_label:.1f} seconds."
                     )
                     finish_reason = "length"
                     break
@@ -1315,7 +1400,7 @@ async def _stream_completion(
                     await _emit(f"data: {json.dumps(piece)}\n\n".encode())
                 except _DFlashStreamDeadlineError:
                     error_message = (
-                        f"DFlash stream timed out after {timeout:.1f} seconds."
+                        f"DFlash stream timed out after {timeout_label:.1f} seconds."
                     )
                     finish_reason = "length"
                     break
@@ -1378,10 +1463,22 @@ async def _stream_completion(
         # it drains, rather than dropping them. A truly-departed client's
         # consumer is already cancelled, so the direct emit is a harmless
         # no-op; a slow-but-present client gets its terminator.
+        #
+        # codex round-5 #3: ORDER is a contract — the [DONE] terminator must
+        # arrive LAST, after the final finish_reason/error frame. Once ANY
+        # terminal frame spills to ``pending_terminal`` (queue full), every
+        # subsequent frame MUST go there too, even if the queue drains in
+        # between; otherwise a later ``[DONE]`` could be enqueued and delivered
+        # ahead of the still-pending final frame. ``spilled`` latches that.
+        spilled = False
         for frame in (final_frame, done_frame):
+            if spilled:
+                pending_terminal.append(frame)
+                continue
             try:
                 await _emit(frame, terminal=True)
             except _DFlashClientGoneError:
+                spilled = True
                 pending_terminal.append(frame)
 
     async def _drive_producer() -> None:
@@ -1482,6 +1579,7 @@ async def _non_stream_completion(
     model: Any,
     processor: Any,
     timeout: float = 1800.0,
+    timeout_label: float | None = None,
     admission_reservation: _DFlashAdmissionReservation | None = None,
 ) -> ChatCompletionResponse:
     """Run generation under the serial lock and enforce a safe deadline.
@@ -1490,8 +1588,15 @@ async def _non_stream_completion(
     dedicated worker. On timeout we return a 504, but keep both the serial
     lock and admission slot until the worker exits; otherwise a second call
     could overlap the first GPU operation on the same thread.
+
+    ``timeout`` is the ENFORCED remaining budget (post prompt-render);
+    ``timeout_label`` is the ORIGINAL configured request timeout reported in
+    the 504 message (codex round-5 #6). Omitted → mirrors ``timeout``.
     """
     from mlx_vlm import generate
+
+    if timeout_label is None:
+        timeout_label = timeout
 
     completion_id = f"chatcmpl-{uuid.uuid4().hex[:24]}"
     created = int(time.time())
@@ -1578,7 +1683,7 @@ async def _non_stream_completion(
             _defer_worker_cleanup()
         raise HTTPException(
             status_code=504,
-            detail=f"DFlash request timed out after {timeout:.1f} seconds.",
+            detail=f"DFlash request timed out after {timeout_label:.1f} seconds.",
         ) from exc
     except asyncio.CancelledError:
         if lock_acquired and worker_future is not None:

--- a/vllm_mlx/speculative/dflash/server.py
+++ b/vllm_mlx/speculative/dflash/server.py
@@ -91,17 +91,42 @@ _dflash_executor = concurrent.futures.ThreadPoolExecutor(
 # lease are cleaned up. The bound is chunk-count, not bytes — each queued
 # item is one small SSE frame, so a modest count keeps buffered memory tiny
 # without throttling a healthy fast reader.
+#
+# codex round-4 #3: ``_STREAM_BACKPRESSURE_TIMEOUT_SECONDS`` is an EXPLICIT,
+# documented server-side backpressure cap, INDEPENDENT of the per-request
+# ``timeout``. It applies even when ``timeout=0`` ("no request deadline"),
+# because a client that has stopped reading must not be able to pin an
+# unbounded in-memory completion (or the sole GPU lock) indefinitely — that
+# is itself a denial-of-service vector, deadline or not. Crucially, hitting
+# this cap no longer truncates the stream silently: the producer converts the
+# backpressure abort into a terminal ``finish_reason="length"`` error frame +
+# ``[DONE]`` (see ``_stream_completion``'s content-emit handler), so a client
+# that is merely slow still receives an explicit explanation of why the
+# stream ended. Only a client that has genuinely departed misses it — and
+# that terminal ``_emit`` is itself swallowed rather than hanging.
 _STREAM_QUEUE_MAXSIZE = 64
 _STREAM_BACKPRESSURE_TIMEOUT_SECONDS = 30.0
 
 
 class _DFlashClientGoneError(Exception):
-    """Raised inside the stream producer when the SSE handoff queue stays
-    full past ``_STREAM_BACKPRESSURE_TIMEOUT_SECONDS`` — i.e. the client
-    has stopped reading. Signals the producer to abort generation and let
-    the lease close the generator + release the GPU lock / admission slot,
-    rather than buffering an unbounded completion for a client that is
-    almost certainly gone."""
+    """Raised inside the stream producer when a CONTENT-frame ``put`` blocks
+    on a full SSE handoff queue past ``_STREAM_BACKPRESSURE_TIMEOUT_SECONDS``
+    — i.e. the client has stopped reading. Signals the producer to abort
+    generation and let the lease close the generator + release the GPU lock /
+    admission slot, rather than buffering an unbounded completion for a client
+    that is almost certainly gone. (Terminal frames use a longer/independent
+    bound and never raise this — see ``_emit``.)"""
+
+
+class _DFlashStreamDeadlineError(Exception):
+    """Raised inside the stream producer when the REQUEST DEADLINE expires
+    while a content frame is waiting for queue capacity (codex round-3 #2).
+
+    Distinct from :class:`_DFlashClientGoneError`: the client may be perfectly
+    healthy — the configured request ``timeout`` simply elapsed. This routes
+    to the normal stream-timeout path (emit the ``finish_reason="length"``
+    timeout notice + ``[DONE]``) instead of silently aborting, so the client
+    always learns why the stream ended."""
 
 
 class _DFlashAdmissionReservation:
@@ -651,16 +676,51 @@ def _build_app(
             )
         # F1: the slot was reserved at the ASGI layer
         # (``_DFlashAdmissionMiddleware``) BEFORE this body was parsed, so
-        # admission bounds parsed-body memory too. Reuse that slot and take
-        # ownership of its release (``claim``); the middleware's safety-net
-        # release becomes a no-op once claimed. A direct-ASGI/test caller
-        # that bypasses the middleware won't have seeded scope state, so
-        # fall back to reserving here (unclaimed → still gated).
+        # admission bounds parsed-body memory too. Reuse that slot. A
+        # direct-ASGI/test caller that bypasses the middleware won't have
+        # seeded scope state, so fall back to reserving here (still gated).
+        #
+        # Ownership handoff (``claim``) is deliberately NOT taken here
+        # (codex round-4 #1). If we claimed now, a client that disconnects
+        # while Starlette is sending the ``StreamingResponse`` headers would
+        # leave the stream iterator unstarted — its ``finally`` release never
+        # runs — while the middleware's safety net refuses to release a
+        # *claimed* slot, permanently leaking capacity. Instead each path
+        # claims only at the point its release is guaranteed to fire:
+        #   * non-stream: inside the ``finally`` below, which always runs;
+        #   * stream: inside ``_stream_with_admission`` when the iterator
+        #     actually begins. Until then the slot stays *unclaimed*, so the
+        #     middleware's safety-net ``finally`` owns the release if response
+        #     startup fails.
         reservation = getattr(http_request.state, "dflash_reservation", None)
         if reservation is None:
             reservation = admission.reserve()
-        reservation.claim()
         try:
+            # F4 (codex round-2 #3): resolve the effective timeout with an
+            # ``is None`` check, NOT ``request.timeout or default_timeout``.
+            # ``or`` treats an explicit ``timeout=0`` as falsy and swaps in
+            # ``default_timeout``, silently contradicting the ``timeout <= 0``
+            # "no deadline" semantics both completion paths now honor. Only
+            # an omitted (``None``) timeout should fall back to the default.
+            #
+            # codex round-4 #4: resolve this BEFORE rendering the prompt and
+            # establish ONE absolute deadline here — prompt rendering (chat
+            # template application + tokenization) can be non-trivial, and the
+            # pre-fix code charged its cost to nobody: each completion helper
+            # started its own ``deadline = now + timeout`` only AFTER rendering
+            # returned, so a slow template could blow well past the client's
+            # configured ``timeout`` unenforced. ``timeout=0`` still means "no
+            # deadline" (``request_deadline is None``).
+            effective_timeout = (
+                request.timeout if request.timeout is not None else default_timeout
+            )
+            loop = asyncio.get_running_loop()
+            request_deadline = (
+                loop.time() + effective_timeout
+                if effective_timeout and effective_timeout > 0
+                else None
+            )
+
             # Render chat messages into a single prompt string via mlx-vlm's
             # processor. We pass through the model's chat template so the
             # tokenizer-side reasoning/tool markers match what the model was
@@ -679,9 +739,51 @@ def _build_app(
                 enable_thinking: bool | None = False
             else:
                 enable_thinking = _extract_thinking_from_request(request)
-            prompt = _render_prompt(
-                processor, model, request, enable_thinking=enable_thinking
-            )
+
+            # codex round-4 #4: OFFLOAD rendering to the DFlash worker thread so
+            # a heavy chat template cannot block the event loop (starving other
+            # connections, health checks, and — critically — the very deadline
+            # enforcement we rely on elsewhere). Bound it by the request
+            # deadline so an expensive render on an already-tight budget fails
+            # fast with a 504 rather than running unbounded.
+            def _render() -> str:
+                return _render_prompt(
+                    processor, model, request, enable_thinking=enable_thinking
+                )
+
+            render_future = loop.run_in_executor(_dflash_executor, _render)
+            if request_deadline is None:
+                prompt = await render_future
+            else:
+                render_budget = request_deadline - loop.time()
+                if render_budget <= 0:
+                    render_future.cancel()
+                    raise HTTPException(
+                        status_code=504,
+                        detail=(
+                            "DFlash request deadline elapsed before prompt "
+                            "rendering could start."
+                        ),
+                    )
+                try:
+                    prompt = await asyncio.wait_for(
+                        asyncio.shield(render_future), timeout=render_budget
+                    )
+                except asyncio.TimeoutError as exc:
+                    # The render is running on the single serial worker; letting
+                    # it keep running would block the next request's generation.
+                    # ``shield`` kept the future alive across our ``wait_for``
+                    # cancellation; cancel it explicitly now (a no-op if the
+                    # sync body already started, but it prevents a queued render
+                    # from firing) and surface the timeout.
+                    render_future.cancel()
+                    raise HTTPException(
+                        status_code=504,
+                        detail=(
+                            "DFlash prompt rendering exceeded the request "
+                            f"timeout of {effective_timeout:.1f} seconds."
+                        ),
+                    ) from exc
 
             max_tokens = (
                 request.max_tokens
@@ -700,15 +802,27 @@ def _build_app(
                 draft_model=runtime.drafter,
                 draft_kind=runtime.kind,
             )
-            # F4 (codex round-2 #3): resolve the effective timeout with an
-            # ``is None`` check, NOT ``request.timeout or default_timeout``.
-            # ``or`` treats an explicit ``timeout=0`` as falsy and swaps in
-            # ``default_timeout``, silently contradicting the ``timeout <= 0``
-            # "no deadline" semantics both completion paths now honor. Only
-            # an omitted (``None``) timeout should fall back to the default.
-            effective_timeout = (
-                request.timeout if request.timeout is not None else default_timeout
-            )
+
+            # Pass the REMAINING budget (post-render) to the completion helper,
+            # not the original timeout, so the single absolute deadline
+            # established above spans render + generation. ``0`` keeps its "no
+            # deadline" meaning ONLY when the request had no deadline to begin
+            # with; a request that DID set a deadline which rendering fully
+            # consumed must NOT collapse into the no-deadline sentinel (that
+            # would let generation run unbounded) — surface a 504 instead.
+            if request_deadline is None:
+                effective_timeout = 0.0
+            else:
+                remaining_budget = request_deadline - loop.time()
+                if remaining_budget <= 0:
+                    raise HTTPException(
+                        status_code=504,
+                        detail=(
+                            "DFlash request deadline elapsed during prompt "
+                            f"rendering (timeout {effective_timeout:.1f}s)."
+                        ),
+                    )
+                effective_timeout = remaining_budget
         except BaseException:
             reservation.release()
             raise
@@ -731,6 +845,14 @@ def _build_app(
                 media_type="text/event-stream",
             )
 
+        # Non-stream path: take ownership now. Unlike the streaming path,
+        # this coroutine is awaited directly, so the ``finally`` below is
+        # guaranteed to run (no header-send-then-abort gap). Claiming here is
+        # required because ``_non_stream_completion`` may ``defer_release`` the
+        # slot until a timed-out worker actually exits; if the slot were still
+        # unclaimed the middleware safety net would force-release it out from
+        # under the still-running worker.
+        reservation.claim()
         try:
             return await _non_stream_completion(
                 prompt=prompt,
@@ -818,7 +940,19 @@ def _render_prompt(
 async def _stream_with_admission(
     stream: AsyncIterator[bytes], reservation: _DFlashAdmissionReservation
 ) -> AsyncIterator[bytes]:
-    """Release an admission slot even when Starlette cancels an SSE stream."""
+    """Release an admission slot even when Starlette cancels an SSE stream.
+
+    Ownership handoff happens here, at the first body of this generator —
+    i.e. only once Starlette has begun consuming the ``StreamingResponse``
+    (codex round-4 #1). Claiming any earlier (e.g. in the endpoint before
+    returning the response) risks a leak: if sending the response headers
+    fails, this generator is never iterated, its ``finally`` release never
+    runs, and the middleware safety net would refuse to release a *claimed*
+    slot. By claiming here, an unstarted stream stays unclaimed and the
+    middleware ``finally`` reclaims the slot. Once claimed, the ``finally``
+    below owns the release for the whole stream lifecycle.
+    """
+    reservation.claim()
     try:
         async for chunk in stream:
             yield chunk
@@ -909,6 +1043,15 @@ async def _stream_completion(
     # the generator + lease cleaned up.
     queue: asyncio.Queue[bytes | None] = asyncio.Queue(maxsize=_STREAM_QUEUE_MAXSIZE)
 
+    # codex round-4 #3: terminal frames (the ``finish_reason`` notice + [DONE])
+    # that could NOT be pushed through the bounded queue — because it stayed
+    # full past the backpressure cap — are stashed here for the CONSUMER to
+    # emit DIRECTLY to the socket after it finishes draining. This guarantees a
+    # connected-but-slow client always receives an explicit stream terminator
+    # even when the queue-based handoff itself hit backpressure; the consumer
+    # owns the socket and will deliver these to any client still reading.
+    pending_terminal: list[bytes] = []
+
     async def _produce() -> None:
         """Own the lease, generate, and push SSE chunks onto the queue.
 
@@ -931,34 +1074,47 @@ async def _stream_completion(
         async def _emit(item: bytes, *, terminal: bool = False) -> None:
             """Put one SSE frame on the bounded queue.
 
-            For streamed content frames the wait is bounded by BOTH the
-            backpressure timeout and the request deadline:
-            * codex round-2 #1: a full bounded queue means the consumer
-              stopped reading; waiting forever would buffer an unbounded
-              completion.
-            * codex round-3 #2: waiting the full backpressure timeout while
-              ignoring a shorter request deadline would let a stalled client
-              retain the sole GPU lock + admission slot well past the
-              configured timeout.
-            So the content wait is ``min(backpressure_timeout, deadline-now)``;
-            when either elapses we raise ``_DFlashClientGoneError`` to abort
-            generation and unwind the lease.
+            CONTENT frames (``terminal=False``) are emitted while the lease
+            holds the GPU lock, so a full queue means the lock is pinned. The
+            wait is bounded by BOTH:
+            * the request deadline (codex round-2 #2): a full queue must not
+              let a stalled client retain the sole GPU lock past the configured
+              ``timeout``; and
+            * the backpressure timeout (codex round-2 #1): even with no
+              deadline, an indefinitely-stalled client must not make the
+              producer buffer an unbounded completion.
+            On timeout we tell the two apart (codex round-3 #2):
+            * the request DEADLINE elapsed → raise ``_DFlashStreamDeadlineError``
+              so the loop emits the normal timeout notice + ``[DONE]`` (the
+              client is told why the stream ended); vs
+            * pure BACKPRESSURE (no deadline, or backpressure shorter than the
+              remaining deadline) → raise ``_DFlashClientGoneError`` to abort
+              silently (the client is gone; nothing to tell it).
 
-            ``terminal=True`` frames (the final finish_reason/usage chunk and
-            ``[DONE]``, incl. the timeout/error notice) are delivered under the
-            plain backpressure timeout only — NOT the deadline bound. They are
-            emitted AFTER the lease is released, so they cannot hold the GPU
-            lock, and their whole purpose is to tell the client how the stream
-            ended (e.g. "timed out"); dropping them because the deadline is
-            already gone would leave the client with a truncated, unexplained
-            stream. The bounded queue still caps the wait so a truly-gone
-            client can't wedge the terminator."""
-            wait = _STREAM_BACKPRESSURE_TIMEOUT_SECONDS
-            if not terminal and deadline is not None:
-                wait = min(wait, max(0.0, deadline - loop.time()))
+            TERMINAL frames (final finish_reason/usage chunk, timeout/error
+            notice, ``[DONE]``) are emitted AFTER the lease is released, so they
+            cannot pin the GPU lock. They wait only on the backpressure timeout
+            — NEVER the deadline — so an already-blown deadline can't suppress
+            the explanation of how the stream ended. A truly-gone client can
+            still not wedge them thanks to the backpressure cap."""
+            backpressure = _STREAM_BACKPRESSURE_TIMEOUT_SECONDS
+            deadline_left = (
+                None
+                if (terminal or deadline is None)
+                else max(0.0, deadline - loop.time())
+            )
+            wait = (
+                backpressure
+                if deadline_left is None
+                else min(backpressure, deadline_left)
+            )
             try:
                 await asyncio.wait_for(queue.put(item), timeout=wait)
             except asyncio.TimeoutError as exc:
+                # Deadline expiry is signalled ONLY when the deadline is what
+                # actually bounded the wait (it is <= the backpressure cap).
+                if deadline_left is not None and deadline_left <= backpressure:
+                    raise _DFlashStreamDeadlineError from exc
                 raise _DFlashClientGoneError from exc
 
         async def _await_worker(func: Any, *, makes_generator: bool = False) -> Any:
@@ -1138,12 +1294,40 @@ async def _stream_completion(
                 }
                 # F2: push to the bounded queue instead of yielding to the
                 # socket directly, so the lease (and its lock) is never held
-                # across a suspended socket write. ``_emit`` raises
-                # ``_DFlashClientGoneError`` if the queue stays full past the
-                # backpressure timeout — that unwinds through
-                # ``async with lease`` (closing the generator + releasing the
-                # lock) and is swallowed in ``_drive_producer``.
-                await _emit(f"data: {json.dumps(piece)}\n\n".encode())
+                # across a suspended socket write. ``_emit`` on a content frame
+                # can raise on two timeouts, and BOTH now route through the
+                # terminal notice path (codex round-3 #2 + round-4 #3) so the
+                # stream ALWAYS ends with an explicit error + ``[DONE]`` rather
+                # than a silent truncation:
+                #   * ``_DFlashStreamDeadlineError`` — the request ``timeout``
+                #     elapsed while a content frame waited for queue capacity.
+                #   * ``_DFlashClientGoneError`` — the queue stayed full past
+                #     the ``_STREAM_BACKPRESSURE_TIMEOUT_SECONDS`` server-side
+                #     backpressure cap. This bound applies even when
+                #     ``timeout=0`` ("no request deadline"), because an
+                #     unbounded in-memory completion for a client that has
+                #     stopped reading is itself a DoS. A client that is merely
+                #     slow (not gone) still gets a terminal explanation; a truly
+                #     departed client's terminal ``_emit`` will itself hit the
+                #     cap and be swallowed in ``_drive_producer`` — no hang
+                #     either way.
+                try:
+                    await _emit(f"data: {json.dumps(piece)}\n\n".encode())
+                except _DFlashStreamDeadlineError:
+                    error_message = (
+                        f"DFlash stream timed out after {timeout:.1f} seconds."
+                    )
+                    finish_reason = "length"
+                    break
+                except _DFlashClientGoneError:
+                    error_message = (
+                        "DFlash stream aborted: the client did not read "
+                        "buffered output within "
+                        f"{_STREAM_BACKPRESSURE_TIMEOUT_SECONDS:.0f}s of "
+                        "server-side backpressure."
+                    )
+                    finish_reason = "length"
+                    break
 
         # Length-truncation detection — mlx-vlm's GenerationResult has no
         # ``finish_reason`` field, so we infer "length" by comparing the
@@ -1185,8 +1369,20 @@ async def _stream_completion(
                 "type": "dflash_runtime_error",
                 "message": error_message,
             }
-        await _emit(f"data: {json.dumps(final)}\n\n".encode(), terminal=True)
-        await _emit(b"data: [DONE]\n\n", terminal=True)
+        final_frame = f"data: {json.dumps(final)}\n\n".encode()
+        done_frame = b"data: [DONE]\n\n"
+        # codex round-4 #3: terminal frames must reach a connected client even
+        # if the queue is still full from a backpressure abort. Try the queue
+        # first (normal fast path); on backpressure, hand the remaining
+        # terminal frames to the consumer to emit DIRECTLY to the socket after
+        # it drains, rather than dropping them. A truly-departed client's
+        # consumer is already cancelled, so the direct emit is a harmless
+        # no-op; a slow-but-present client gets its terminator.
+        for frame in (final_frame, done_frame):
+            try:
+                await _emit(frame, terminal=True)
+            except _DFlashClientGoneError:
+                pending_terminal.append(frame)
 
     async def _drive_producer() -> None:
         """Run ``_produce``; swallow the client-gone abort.
@@ -1251,6 +1447,13 @@ async def _stream_completion(
                 # performs the actual termination decision.
                 continue
             yield item
+        # codex round-4 #3: emit any terminal frames the producer could not
+        # push through a backpressure-full queue. We own the socket and the
+        # producer has finished, so these go straight to the client — the
+        # bounded queue never blocks them. A departed client's generator is
+        # already closed, so this yields into a no-op teardown.
+        for frame in pending_terminal:
+            yield frame
         # Surface a producer crash (not one of the sentinel-wrapped
         # generation errors, which are already emitted as error SSE) so it
         # is logged rather than silently swallowed.

--- a/vllm_mlx/speculative/dflash/server.py
+++ b/vllm_mlx/speculative/dflash/server.py
@@ -211,12 +211,61 @@ class _DFlashAdmissionMiddleware:
         ):
             return await self.app(scope, receive, send)
 
+        # codex round-3 #3: reject unauthenticated / over-rate-limit clients
+        # BEFORE reserving a slot. Otherwise a client that will ultimately be
+        # 401'd or 429'd (e.g. one dribbling a slow body upload) still holds a
+        # scarce DFlash slot for the whole request, denying service to
+        # authorized callers. These checks are header-only — no body is read —
+        # and they run OUTSIDE the admission gate. Because the chat route's
+        # ``verify_api_key`` / ``check_rate_limit`` dependencies are dropped
+        # for this path (this middleware is now the single source of truth on
+        # ``/v1/chat/completions``), the rate limiter is consulted exactly
+        # once per request, so counting stays correct.
+        from starlette.requests import Request as _StarletteRequest
+
+        from ...middleware.auth import (
+            _extract_bearer_token,
+            _rate_limit_client_id,
+            _verify_api_key_values,
+            rate_limiter,
+        )
+
+        request = _StarletteRequest(scope, receive)
+        try:
+            _verify_api_key_values(
+                _extract_bearer_token(request.headers.get("Authorization"))
+            )
+        except HTTPException as exc:
+            await _send_json_error(
+                send,
+                status_code=exc.status_code,
+                message=str(exc.detail),
+                error_type="invalid_request_error",
+                code="invalid_api_key",
+            )
+            return
+
+        allowed, retry_after = rate_limiter.is_allowed(_rate_limit_client_id(request))
+        if not allowed:
+            await _send_json_error(
+                send,
+                status_code=429,
+                message=f"Rate limit exceeded. Retry after {retry_after} seconds.",
+                error_type="rate_limit_error",
+                code="rate_limit_exceeded",
+                retry_after=str(retry_after),
+            )
+            return
+
         try:
             reservation = self._admission.reserve()
         except HTTPException as exc:
-            await _send_503(
+            await _send_json_error(
                 send,
-                detail=str(exc.detail),
+                status_code=503,
+                message=str(exc.detail),
+                error_type="service_unavailable",
+                code="at_capacity",
                 retry_after=(exc.headers or {}).get("Retry-After"),
             )
             return
@@ -236,18 +285,28 @@ class _DFlashAdmissionMiddleware:
                 reservation.release(force=True)
 
 
-async def _send_503(send, *, detail: str, retry_after: str | None) -> None:
-    """Emit an OpenAI-shaped 503 from inside ASGI middleware (F1).
+async def _send_json_error(
+    send,
+    *,
+    status_code: int,
+    message: str,
+    error_type: str,
+    code: str,
+    retry_after: str | None = None,
+) -> None:
+    """Emit an OpenAI-shaped error JSON response from inside ASGI middleware.
 
-    Hand-rolled (not ``HTTPException``) because we reject before FastAPI's
-    exception machinery is reachable — the request body has not been read.
+    Hand-rolled (not ``HTTPException``) because these rejections happen
+    before FastAPI's exception machinery is reachable — the request body has
+    not been read. Used for the middleware's pre-admission 401 / 429 / 503
+    (F1 + codex round-3 #3).
     """
     body = json.dumps(
         {
             "error": {
-                "message": detail,
-                "type": "service_unavailable",
-                "code": "at_capacity",
+                "message": message,
+                "type": error_type,
+                "code": code,
                 "param": None,
             }
         }
@@ -259,10 +318,12 @@ async def _send_503(send, *, detail: str, retry_after: str | None) -> None:
     if retry_after:
         headers.append((b"retry-after", str(retry_after).encode("ascii")))
     try:
-        await send({"type": "http.response.start", "status": 503, "headers": headers})
+        await send(
+            {"type": "http.response.start", "status": status_code, "headers": headers}
+        )
         await send({"type": "http.response.body", "body": body, "more_body": False})
     except Exception:  # noqa: BLE001 -- client already gone; nothing to emit
-        logger.debug("DFlash 503 send failed (client already disconnected)")
+        logger.debug("DFlash %d send failed (client already disconnected)", status_code)
 
 
 class _DFlashStreamLease:
@@ -450,7 +511,6 @@ def _build_app(
     cfg.default_timeout = max(0.0, float(default_timeout))
 
     from ...middleware.auth import (
-        check_rate_limit,
         configure_rate_limiter,
         verify_api_key,
     )
@@ -477,13 +537,26 @@ def _build_app(
     # middleware also enforces the configured body-receive idle timeout, so a
     # DFlash request cannot bypass the slow-client protection by taking this
     # dedicated app path.
+    # Middleware nesting (``add_middleware`` wraps last-added OUTERMOST).
+    # Target order, outer → inner:
+    #   body-size (413/408)  →  admission (auth/rate/reserve)  →  body-depth
+    #   →  route (Pydantic body bind)
+    # Rationale:
+    #   * body-size stays OUTERMOST so an oversized body is rejected with 413
+    #     (and a slow upload with 408) as cheaply as possible — before any
+    #     auth/rate/admission work (codex round-3 didn't ask to move these
+    #     generic DoS gates, and 413-cheapest-first is the established
+    #     contract the security test pins).
+    #   * admission sits INSIDE body-size but OUTSIDE body-depth + the route,
+    #     so its header-only auth + rate rejection (codex round-3 #3) runs
+    #     before a slot is reserved, and the reservation is taken before
+    #     body-depth reads the body and before FastAPI binds the Pydantic
+    #     model (F1 — bounds parsed-body memory).
+    # Add order to realize that nesting: body-depth (innermost), then
+    # admission, then body-size (outermost) last.
     install_request_body_depth_middleware(app)
-    install_request_body_limit_middleware(app)
-    # F1: admission runs OUTERMOST so a slot is reserved before the body-
-    # size / body-depth wrappers even read bytes and before FastAPI binds
-    # the Pydantic body. ``add_middleware`` wraps last-added first, so this
-    # call must come after the two above to sit on the outside.
     app.add_middleware(_DFlashAdmissionMiddleware, admission=admission)
+    install_request_body_limit_middleware(app)
     # F-090/F-091: register CORS only when an explicit origin allowlist is
     # configured. ``cors_origins=[]`` (the new default — see
     # ``vllm_mlx/server.py::configure_cors_from_env``) skips the middleware
@@ -536,10 +609,12 @@ def _build_app(
             ]
         )
 
-    @app.post(
-        "/v1/chat/completions",
-        dependencies=[Depends(verify_api_key), Depends(check_rate_limit)],
-    )
+    # codex round-3 #3: auth + rate-limit for this route are enforced in
+    # ``_DFlashAdmissionMiddleware`` BEFORE the admission slot is reserved and
+    # before the body is read — NOT as route dependencies here. Keeping them
+    # here too would consult the rate limiter twice per request (halving the
+    # effective limit) and would run only AFTER a slot was already reserved.
+    @app.post("/v1/chat/completions")
     async def create_chat_completion(
         request: ChatCompletionRequest, http_request: Request
     ):
@@ -853,17 +928,36 @@ async def _stream_completion(
         last_token_id: int | None = None
         error_message: str | None = None
 
-        async def _emit(item: bytes) -> None:
-            """Put one SSE frame on the bounded queue with a backpressure
-            deadline (codex round-2 #1). If the queue stays full past the
-            backpressure timeout the consumer has stopped reading, so raise
-            ``_DFlashClientGoneError`` to abort generation instead of buffering
-            an unbounded completion for a client that is gone."""
+        async def _emit(item: bytes, *, terminal: bool = False) -> None:
+            """Put one SSE frame on the bounded queue.
+
+            For streamed content frames the wait is bounded by BOTH the
+            backpressure timeout and the request deadline:
+            * codex round-2 #1: a full bounded queue means the consumer
+              stopped reading; waiting forever would buffer an unbounded
+              completion.
+            * codex round-3 #2: waiting the full backpressure timeout while
+              ignoring a shorter request deadline would let a stalled client
+              retain the sole GPU lock + admission slot well past the
+              configured timeout.
+            So the content wait is ``min(backpressure_timeout, deadline-now)``;
+            when either elapses we raise ``_DFlashClientGoneError`` to abort
+            generation and unwind the lease.
+
+            ``terminal=True`` frames (the final finish_reason/usage chunk and
+            ``[DONE]``, incl. the timeout/error notice) are delivered under the
+            plain backpressure timeout only — NOT the deadline bound. They are
+            emitted AFTER the lease is released, so they cannot hold the GPU
+            lock, and their whole purpose is to tell the client how the stream
+            ended (e.g. "timed out"); dropping them because the deadline is
+            already gone would leave the client with a truncated, unexplained
+            stream. The bounded queue still caps the wait so a truly-gone
+            client can't wedge the terminator."""
+            wait = _STREAM_BACKPRESSURE_TIMEOUT_SECONDS
+            if not terminal and deadline is not None:
+                wait = min(wait, max(0.0, deadline - loop.time()))
             try:
-                await asyncio.wait_for(
-                    queue.put(item),
-                    timeout=_STREAM_BACKPRESSURE_TIMEOUT_SECONDS,
-                )
+                await asyncio.wait_for(queue.put(item), timeout=wait)
             except asyncio.TimeoutError as exc:
                 raise _DFlashClientGoneError from exc
 
@@ -1091,38 +1185,39 @@ async def _stream_completion(
                 "type": "dflash_runtime_error",
                 "message": error_message,
             }
-        await _emit(f"data: {json.dumps(final)}\n\n".encode())
-        await _emit(b"data: [DONE]\n\n")
+        await _emit(f"data: {json.dumps(final)}\n\n".encode(), terminal=True)
+        await _emit(b"data: [DONE]\n\n", terminal=True)
 
     async def _drive_producer() -> None:
-        """Run ``_produce`` and always terminate the queue with a sentinel.
+        """Run ``_produce``; swallow the client-gone abort.
 
-        The ``finally`` guarantees the consumer's drain loop wakes and
-        exits even if ``_produce`` is cancelled (client disconnect) or
-        raises — otherwise ``queue.get()`` would block forever.
+        codex round-3 #1: this NO LONGER relies on pushing a queue sentinel
+        to terminate the consumer (a full bounded queue could drop it, hanging
+        a slow-but-resuming client). The consumer instead terminates from this
+        task's completion state — see the drain loop below. We still push a
+        best-effort sentinel to wake a consumer that is blocked in
+        ``queue.get()`` right now, but correctness no longer depends on it.
         """
         try:
             await _produce()
         except _DFlashClientGoneError:
-            # codex round-2 #1: the client stopped reading and the bounded
-            # queue stayed full past the backpressure timeout. ``_produce``
+            # codex round-2 #1/#3: the client stopped reading (bounded queue
+            # stayed full past the backpressure / deadline bound). ``_produce``
             # already unwound ``async with lease`` (generator closed, lock +
-            # slot released or deferred). Nothing more to emit — fall through
-            # to the sentinel so the drain loop (if still alive) exits.
+            # slot released or deferred). Nothing more to emit.
             logger.debug(
-                "DFlash stream aborted: client stopped reading past the "
-                "%.0fs backpressure timeout",
-                _STREAM_BACKPRESSURE_TIMEOUT_SECONDS,
+                "DFlash stream aborted: client stopped reading within the "
+                "backpressure/deadline bound"
             )
         finally:
-            # Sentinel wakes the consumer's drain loop. Use ``put_nowait``
-            # inside a guard: if the bounded queue is full (the very
-            # backpressure that aborted us), drop the sentinel — the consumer
-            # is gone and its ``finally`` cancels this task anyway.
+            # Best-effort wake for a consumer currently blocked on
+            # ``queue.get()``. If the queue is full the sentinel is dropped,
+            # but the consumer's producer-completion check still terminates
+            # it, so no hang. ``put_nowait`` never blocks.
             try:
                 queue.put_nowait(None)
             except asyncio.QueueFull:
-                logger.debug("DFlash stream queue full at teardown; sentinel dropped")
+                pass
 
     # F2: start generation in its own task BEFORE the first client read.
     # ``ensure_future`` schedules the producer eagerly so its deadline
@@ -1139,10 +1234,22 @@ async def _stream_completion(
         # the prior contract. The producer may already be mid-generation by
         # now; its output waits in the queue behind this marker.
         yield f"data: {json.dumps(first)}\n\n".encode()
+        # codex round-3 #1: drive termination from producer-completion state,
+        # not solely a queue sentinel. The top-of-loop check
+        # ``producer.done() and queue.empty()`` guarantees termination even if
+        # the sentinel was dropped: the sentinel is only ever dropped when the
+        # queue is FULL (``put_nowait`` raises only on a full queue), and a
+        # full queue means ``await queue.get()`` returns immediately — it can
+        # never block forever. Once the producer is done and every buffered
+        # item has been yielded, ``queue.empty()`` is True and the loop exits.
         while True:
+            if producer.done() and queue.empty():
+                break
             item = await queue.get()
             if item is None:
-                break
+                # Best-effort sentinel — just re-loop; the top-of-loop check
+                # performs the actual termination decision.
+                continue
             yield item
         # Surface a producer crash (not one of the sentinel-wrapped
         # generation errors, which are already emitted as error SSE) so it

--- a/vllm_mlx/speculative/dflash/server.py
+++ b/vllm_mlx/speculative/dflash/server.py
@@ -37,12 +37,13 @@ import atexit
 import concurrent.futures
 import json
 import logging
+import threading
 import time
 import uuid
 from collections.abc import AsyncIterator
 from typing import Any
 
-from fastapi import FastAPI, HTTPException
+from fastapi import Depends, FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import StreamingResponse
 
@@ -55,6 +56,7 @@ from vllm_mlx.api.models import (
     ModelsResponse,
     Usage,
 )
+from vllm_mlx.config import get_config
 
 from .eligibility import have_runtime
 from .runtime import DFlashRuntime, load_runtime
@@ -81,6 +83,176 @@ _dflash_executor = concurrent.futures.ThreadPoolExecutor(
 )
 
 
+class _DFlashAdmissionReservation:
+    """One request slot from a :class:`_DFlashAdmission` gate."""
+
+    def __init__(self, admission: _DFlashAdmission) -> None:
+        self._admission = admission
+        self._deferred = False
+        self._released = False
+
+    def defer_release(self) -> None:
+        """Keep the slot until a timed-out worker has actually stopped."""
+        self._deferred = True
+
+    def release(self, *, force: bool = False) -> None:
+        if self._deferred and not force:
+            return
+        with self._admission._lock:
+            if self._released:
+                return
+            self._released = True
+            self._admission._reservations = max(0, self._admission._reservations - 1)
+
+
+class _DFlashAdmission:
+    """Bound DFlash's serial-lock queue before it consumes worker memory."""
+
+    def __init__(self, max_concurrent_requests: int) -> None:
+        self._max_concurrent_requests = max(0, int(max_concurrent_requests))
+        self._reservations = 0
+        self._lock = threading.Lock()
+
+    def reserve(self) -> _DFlashAdmissionReservation:
+        with self._lock:
+            if (
+                self._max_concurrent_requests > 0
+                and self._reservations >= self._max_concurrent_requests
+            ):
+                raise HTTPException(
+                    status_code=503,
+                    detail=(
+                        "DFlash is at its max_concurrent_requests admission "
+                        "limit; retry shortly."
+                    ),
+                    headers={"Retry-After": "1"},
+                )
+            self._reservations += 1
+        return _DFlashAdmissionReservation(self)
+
+
+class _DFlashStreamLease:
+    """Keep DFlash resources owned until a cancelled worker is cleaned up."""
+
+    def __init__(
+        self,
+        loop: asyncio.AbstractEventLoop,
+        reservation: _DFlashAdmissionReservation | None,
+        deadline: float | None,
+    ) -> None:
+        self._loop = loop
+        self._reservation = reservation
+        self._deadline = deadline
+        self.timed_out = False
+        self._lock_acquired = False
+        self._released = False
+        self._cleanup_deferred = False
+        self._active_future: asyncio.Future[Any] | None = None
+        self._active_future_makes_generator = False
+        self._generator: Any | None = None
+
+    async def __aenter__(self) -> _DFlashStreamLease:
+        if self._deadline is None:
+            await _dflash_lock.acquire()
+        else:
+            remaining = self._deadline - self._loop.time()
+            if remaining <= 0:
+                self.timed_out = True
+                return self
+            try:
+                await asyncio.wait_for(_dflash_lock.acquire(), timeout=remaining)
+            except asyncio.TimeoutError:
+                self.timed_out = True
+                return self
+        self._lock_acquired = True
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> bool:  # noqa: ANN001
+        future = self._active_future
+        if future is not None and not future.done():
+            self._defer_cleanup(future)
+            return False
+        if future is not None:
+            # Cancellation can land after the executor future resolves but
+            # before its caller stores a constructed generator.
+            self._capture_generator(future)
+            self.clear_future(future)
+        await self._close_generator_and_release()
+        return False
+
+    def track_future(
+        self, future: asyncio.Future[Any], *, makes_generator: bool = False
+    ) -> None:
+        self._active_future = future
+        self._active_future_makes_generator = makes_generator
+
+    def clear_future(self, future: asyncio.Future[Any]) -> None:
+        if self._active_future is future:
+            self._active_future = None
+            self._active_future_makes_generator = False
+
+    def set_generator(self, generator: Any) -> None:
+        self._generator = generator
+
+    def _capture_generator(self, future: asyncio.Future[Any]) -> None:
+        if not self._active_future_makes_generator or self._generator is not None:
+            return
+        try:
+            candidate = future.result()
+        except Exception:  # noqa: BLE001 -- worker error has no generator to close
+            return
+        if not isinstance(candidate, Exception) and hasattr(candidate, "close"):
+            self._generator = candidate
+
+    def _defer_cleanup(self, future: asyncio.Future[Any]) -> None:
+        if self._cleanup_deferred:
+            return
+        self._cleanup_deferred = True
+        if self._reservation is not None:
+            self._reservation.defer_release()
+
+        def _on_worker_done(done: asyncio.Future[Any]) -> None:
+            self._capture_generator(done)
+            self._active_future = None
+            self._active_future_makes_generator = False
+            self._loop.create_task(self._close_generator_and_release())
+
+        future.add_done_callback(_on_worker_done)
+
+    async def _close_generator_and_release(self) -> None:
+        generator = self._generator
+        if generator is not None:
+
+            def _close_gen() -> None:
+                try:
+                    generator.close()
+                except Exception:  # noqa: BLE001 -- cleanup is best-effort
+                    logger.debug(
+                        "DFlash generator close raised; ignoring", exc_info=True
+                    )
+
+            close_future = self._loop.run_in_executor(_dflash_executor, _close_gen)
+            try:
+                await asyncio.shield(close_future)
+            except asyncio.CancelledError:
+                # The client task can be cancelled a second time while it is
+                # already unwinding. The queued close still owns the GPU
+                # ordering, so release only from its completion callback.
+                close_future.add_done_callback(lambda _done: self._release())
+                return
+        self._release()
+
+    def _release(self) -> None:
+        if self._released:
+            return
+        self._released = True
+        if self._lock_acquired:
+            _dflash_lock.release()
+            self._lock_acquired = False
+        if self._reservation is not None:
+            self._reservation.release(force=True)
+
+
 @atexit.register
 def _shutdown_dflash_executor() -> None:
     """Drain the DFlash worker on interpreter exit. Python registers an
@@ -99,13 +271,21 @@ def _build_app(
     default_max_tokens: int,
     cors_origins: list[str],
     no_thinking: bool = False,
+    api_key: str | None = None,
+    rate_limit: int = 0,
+    max_request_bytes: int = 8 * 1024 * 1024,
+    body_receive_timeout_seconds: float = 15.0,
+    default_timeout: float = 1800.0,
+    max_concurrent_requests: int = 256,
+    cors_policy: Any | None = None,
 ) -> FastAPI:
     """Create the FastAPI application for DFlash mode.
 
-    Per-app state (``model``, ``processor``, ``runtime``,
-    ``served_model_name``) is captured by closure so a single Python
-    process could in principle host multiple ``_build_app`` instances
-    against different models without per-request state collision.
+    Per-app model state (``model``, ``processor``, ``runtime``,
+    ``served_model_name``) is captured by closure. The security policy
+    deliberately uses the shared server config and rate limiter, matching
+    the unified server; DFlash therefore supports one active app per
+    process.
 
     Note: ``_dflash_lock`` and ``_dflash_executor`` are *module-level*
     by design — every DFlash invocation must serialise through the
@@ -114,7 +294,34 @@ def _build_app(
     multi-model deployment would still share that worker; one model
     can't run while another's generator is mid-step.
     """
+    # DFlash owns a separate FastAPI application, so it cannot inherit the
+    # unified server's dependencies or middleware implicitly. Copy the
+    # already-resolved security settings into the shared config singleton
+    # before wiring those common protections onto this app. In particular,
+    # ``verify_api_key`` and ``RequestBodyLimitMiddleware`` read this
+    # singleton at request time.
+    cfg = get_config()
+    cfg.api_key = api_key
+    cfg.max_request_bytes = max(0, int(max_request_bytes))
+    cfg.body_receive_timeout_seconds = max(0.0, float(body_receive_timeout_seconds))
+    cfg.default_timeout = max(0.0, float(default_timeout))
+
+    from ...middleware.auth import (
+        check_rate_limit,
+        configure_rate_limiter,
+        verify_api_key,
+    )
+    from ...middleware.body_depth import install_request_body_depth_middleware
+    from ...middleware.body_size import install_request_body_limit_middleware
+
+    configure_rate_limiter(rate_limit, enabled=rate_limit > 0)
+
     app = FastAPI(title="Rapid-MLX (DFlash)")
+    # DFlash has one GPU worker and serializes generation with
+    # ``_dflash_lock``. Bound its waiting room as well so a burst cannot
+    # accumulate an unbounded number of requests and their parsed bodies.
+    admission = _DFlashAdmission(max_concurrent_requests)
+    app.state.dflash_admission = admission
     # D-ANTHRO-VALIDATION F11: install the shared exception handlers so
     # Pydantic validation errors return the canonical
     # ``{"error":{"type":"invalid_request_error","code":"invalid_request",
@@ -123,12 +330,27 @@ def _build_app(
     from ...middleware.exception_handlers import install_exception_handlers
 
     install_exception_handlers(app)
+    # Match the main server's generic JSON request defenses. The body-size
+    # middleware also enforces the configured body-receive idle timeout, so a
+    # DFlash request cannot bypass the slow-client protection by taking this
+    # dedicated app path.
+    install_request_body_depth_middleware(app)
+    install_request_body_limit_middleware(app)
     # F-090/F-091: register CORS only when an explicit origin allowlist is
     # configured. ``cors_origins=[]`` (the new default — see
     # ``vllm_mlx/server.py::configure_cors_from_env``) skips the middleware
     # entirely so preflight returns 405 and no ``Access-Control-*`` header
     # leaks. The dflash path mirrors the main server's stance.
-    if cors_origins:
+    if cors_policy is not None:
+        app.add_middleware(
+            CORSMiddleware,
+            allow_origins=cors_policy.origins,
+            allow_credentials=cors_policy.allow_credentials,
+            allow_methods=cors_policy.methods,
+            allow_headers=cors_policy.headers,
+            max_age=cors_policy.max_age,
+        )
+    elif cors_origins:
         wildcard = "*" in cors_origins
         app.add_middleware(
             CORSMiddleware,
@@ -154,7 +376,7 @@ def _build_app(
             "drafter": runtime.drafter_repo,
         }
 
-    @app.get("/v1/models")
+    @app.get("/v1/models", dependencies=[Depends(verify_api_key)])
     async def list_models() -> ModelsResponse:
         return ModelsResponse(
             data=[
@@ -166,7 +388,10 @@ def _build_app(
             ]
         )
 
-    @app.post("/v1/chat/completions")
+    @app.post(
+        "/v1/chat/completions",
+        dependencies=[Depends(verify_api_key), Depends(check_rate_limit)],
+    )
     async def create_chat_completion(request: ChatCompletionRequest):
         if not request.messages:
             raise HTTPException(status_code=400, detail="messages must not be empty")
@@ -199,64 +424,82 @@ def _build_app(
                     "in DFlash mode. Restart without DFlash."
                 ),
             )
+        reservation = admission.reserve()
+        try:
+            # Render chat messages into a single prompt string via mlx-vlm's
+            # processor. We pass through the model's chat template so the
+            # tokenizer-side reasoning/tool markers match what the model was
+            # trained on; no rapid-mlx-side prompt mutation happens here.
+            #
+            # Resolve enable_thinking (#387). The dflash app captures its own
+            # ``no_thinking`` by closure rather than going through the
+            # ServerConfig singleton, so we apply that override first then
+            # delegate the request-side precedence (chat_template_kwargs >
+            # request.enable_thinking > None) to the shared extractor — same
+            # source of truth as the OpenAI/anthropic helper, but without the
+            # ``cfg.no_thinking`` consult that doesn't apply to dflash.
+            from ...service.helpers import _extract_thinking_from_request
 
-        # Render chat messages into a single prompt string via mlx-vlm's
-        # processor. We pass through the model's chat template so the
-        # tokenizer-side reasoning/tool markers match what the model was
-        # trained on; no rapid-mlx-side prompt mutation happens here.
-        #
-        # Resolve enable_thinking (#387). The dflash app captures its own
-        # ``no_thinking`` by closure rather than going through the
-        # ServerConfig singleton, so we apply that override first then
-        # delegate the request-side precedence (chat_template_kwargs >
-        # request.enable_thinking > None) to the shared extractor — same
-        # source of truth as the OpenAI/anthropic helper, but without the
-        # ``cfg.no_thinking`` consult that doesn't apply to dflash.
-        from ...service.helpers import _extract_thinking_from_request
+            if no_thinking:
+                enable_thinking: bool | None = False
+            else:
+                enable_thinking = _extract_thinking_from_request(request)
+            prompt = _render_prompt(
+                processor, model, request, enable_thinking=enable_thinking
+            )
 
-        if no_thinking:
-            enable_thinking: bool | None = False
-        else:
-            enable_thinking = _extract_thinking_from_request(request)
-        prompt = _render_prompt(
-            processor, model, request, enable_thinking=enable_thinking
-        )
+            max_tokens = (
+                request.max_tokens
+                if request.max_tokens is not None
+                else default_max_tokens
+            )
+            temperature = (
+                request.temperature if request.temperature is not None else 0.0
+            )
+            top_p = request.top_p if request.top_p is not None else 1.0
 
-        max_tokens = (
-            request.max_tokens if request.max_tokens is not None else default_max_tokens
-        )
-        temperature = request.temperature if request.temperature is not None else 0.0
-        top_p = request.top_p if request.top_p is not None else 1.0
-
-        gen_kwargs = dict(
-            max_tokens=max_tokens,
-            temperature=temperature,
-            top_p=top_p,
-            draft_model=runtime.drafter,
-            draft_kind=runtime.kind,
-        )
+            gen_kwargs = dict(
+                max_tokens=max_tokens,
+                temperature=temperature,
+                top_p=top_p,
+                draft_model=runtime.drafter,
+                draft_kind=runtime.kind,
+            )
+        except BaseException:
+            reservation.release()
+            raise
 
         if request.stream:
             return StreamingResponse(
-                _stream_completion(
-                    prompt=prompt,
-                    request=request,
-                    served_model_name=served_model_name,
-                    gen_kwargs=gen_kwargs,
-                    model=model,
-                    processor=processor,
+                _stream_with_admission(
+                    _stream_completion(
+                        prompt=prompt,
+                        request=request,
+                        served_model_name=served_model_name,
+                        gen_kwargs=gen_kwargs,
+                        model=model,
+                        processor=processor,
+                        timeout=request.timeout or default_timeout,
+                        admission_reservation=reservation,
+                    ),
+                    reservation,
                 ),
                 media_type="text/event-stream",
             )
 
-        return await _non_stream_completion(
-            prompt=prompt,
-            request=request,
-            served_model_name=served_model_name,
-            gen_kwargs=gen_kwargs,
-            model=model,
-            processor=processor,
-        )
+        try:
+            return await _non_stream_completion(
+                prompt=prompt,
+                request=request,
+                served_model_name=served_model_name,
+                gen_kwargs=gen_kwargs,
+                model=model,
+                processor=processor,
+                timeout=request.timeout or default_timeout,
+                admission_reservation=reservation,
+            )
+        finally:
+            reservation.release()
 
     return app
 
@@ -328,6 +571,29 @@ def _render_prompt(
     )
 
 
+async def _stream_with_admission(
+    stream: AsyncIterator[bytes], reservation: _DFlashAdmissionReservation
+) -> AsyncIterator[bytes]:
+    """Release an admission slot even when Starlette cancels an SSE stream."""
+    try:
+        async for chunk in stream:
+            yield chunk
+    finally:
+        # ``StreamingResponse`` runs its background task only on a normal
+        # return. Closing the inner generator here covers client disconnects
+        # and send failures too, so its GPU cleanup runs before the slot is
+        # made available again.
+        aclose = getattr(stream, "aclose", None)
+        if aclose is not None:
+            try:
+                await aclose()
+            except Exception:  # noqa: BLE001 -- release remains mandatory
+                logger.debug(
+                    "DFlash stream close raised; releasing admission", exc_info=True
+                )
+        reservation.release()
+
+
 async def _stream_completion(
     *,
     prompt: str,
@@ -336,6 +602,8 @@ async def _stream_completion(
     gen_kwargs: dict[str, Any],
     model: Any,
     processor: Any,
+    timeout: float | None = None,
+    admission_reservation: _DFlashAdmissionReservation | None = None,
 ) -> AsyncIterator[bytes]:
     """Stream OpenAI-format chunks. Generation happens under the serial
     lock; chunks are forwarded as ``data: ...\\n\\n`` SSE events."""
@@ -384,8 +652,42 @@ async def _stream_completion(
         _eos_ids.update(int(t) for t in _eos if isinstance(t, int))
 
     error_message: str | None = None
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout if timeout and timeout > 0 else None
+    timed_out = object()
+    lease = _DFlashStreamLease(loop, admission_reservation, deadline)
 
-    async with _dflash_lock:
+    async def _await_worker(func: Any, *, makes_generator: bool = False) -> Any:
+        """Wait without cancelling an mlx operation on deadline expiry."""
+        if lease.timed_out:
+            return timed_out
+        future = loop.run_in_executor(_dflash_executor, func)
+        lease.track_future(future, makes_generator=makes_generator)
+        if deadline is None:
+            result = await future
+            lease.clear_future(future)
+            return result
+        remaining = deadline - loop.time()
+        if remaining <= 0:
+            # The future was submitted by the caller already. It may be a
+            # GPU step, so wait for it before releasing the serial lock.
+            result = await asyncio.shield(future)
+            lease.clear_future(future)
+            return result, timed_out
+        done, _pending = await asyncio.wait({future}, timeout=remaining)
+        if done:
+            result = future.result()
+            lease.clear_future(future)
+            return result
+
+        # mlx work is not preemptible. Let the in-flight token step finish
+        # while the serial lock remains held, then close its generator rather
+        # than letting another request overlap it on the GPU worker.
+        result = await asyncio.shield(future)
+        lease.clear_future(future)
+        return result, timed_out
+
+    async with lease:
         # mlx-vlm's stream_generate is a sync generator — run it in a
         # thread pool so we don't block the FastAPI event loop. Iterate
         # by polling with ``run_in_executor`` per chunk. We're already
@@ -395,8 +697,6 @@ async def _stream_completion(
         # consecutive ``next(gen)`` calls land on the same worker —
         # mlx's GPU Stream is thread-local and a hand-off across worker
         # threads would crash mid-generation.
-        loop = asyncio.get_running_loop()
-
         # Create the generator on the same worker that will drive it,
         # not on the event-loop thread — otherwise the first ``next``
         # crosses a thread boundary just like the rest.
@@ -413,8 +713,24 @@ async def _stream_completion(
             except Exception as e:  # noqa: BLE001 — surface upstream; outer code converts to error SSE
                 return e
 
-        gen_or_err = await loop.run_in_executor(_dflash_executor, _make_gen)
-        if isinstance(gen_or_err, Exception):
+        gen_or_err = await _await_worker(_make_gen, makes_generator=True)
+        timed_out_after_generation = False
+        if gen_or_err is timed_out:
+            timed_out_after_generation = True
+        elif isinstance(gen_or_err, tuple):
+            gen_or_err, _timeout_marker = gen_or_err
+            timed_out_after_generation = _timeout_marker is timed_out
+        if timed_out_after_generation:
+            error_message = f"DFlash stream timed out after {timeout:.1f} seconds."
+            finish_reason = "length"
+            gen = (
+                None
+                if gen_or_err is timed_out or isinstance(gen_or_err, Exception)
+                else gen_or_err
+            )
+            if gen is not None:
+                lease.set_generator(gen)
+        elif isinstance(gen_or_err, Exception):
             logger.exception(
                 "DFlash stream_generate raised at construction: %s",
                 gen_or_err,
@@ -428,6 +744,7 @@ async def _stream_completion(
             gen = None
         else:
             gen = gen_or_err
+            lease.set_generator(gen)
 
         # Sentinels distinguish "generator exhausted" (None) from
         # "generator raised mid-stream" (an Exception instance). Catching
@@ -443,76 +760,54 @@ async def _stream_completion(
             except Exception as e:  # noqa: BLE001 — surface upstream; loop converts to error SSE
                 return e
 
-        try:
-            while gen is not None:
-                chunk = await loop.run_in_executor(_dflash_executor, _next_chunk)
-                if chunk is None:
-                    break
-                if isinstance(chunk, Exception):
-                    logger.exception(
-                        "DFlash stream_generate raised mid-stream: %s",
-                        chunk,
-                        exc_info=chunk,
-                    )
-                    error_message = f"{type(chunk).__name__}: {chunk}"
-                    # See above for OpenAI spec literal-set rationale.
-                    finish_reason = "length"
-                    break
-                # Always sync token counts from the chunk — even when text
-                # is empty (mlx-vlm occasionally emits trailing flush
-                # chunks carrying the final token counters but no
-                # incremental text). Skipping the update would leave the
-                # final usage block with stale numbers.
-                total_completion_tokens = chunk.generation_tokens
-                prompt_tokens = chunk.prompt_tokens
-                _ct = getattr(chunk, "token", None)
-                if isinstance(_ct, int):
-                    last_token_id = _ct
-                if not chunk.text:
-                    continue
-                piece = {
-                    "id": completion_id,
-                    "object": "chat.completion.chunk",
-                    "created": created,
-                    "model": served_model_name,
-                    "choices": [
-                        {
-                            "index": 0,
-                            "delta": {"content": chunk.text},
-                            "finish_reason": None,
-                        }
-                    ],
-                }
-                yield f"data: {json.dumps(piece)}\n\n".encode()
-        finally:
-            # On client disconnect (CancelledError) or any other exit
-            # from the loop, drain the generator so its GPU state is
-            # released *before* the lock unblocks the next request.
-            # Without this the abandoned generator's KV cache lingers
-            # until GC runs, transiently doubling memory and risking a
-            # mid-step crash if the next request triggers reallocation.
-            # Routed through ``_dflash_executor`` for thread affinity.
-            if gen is not None:
-                _gen_to_close = gen
-
-                def _close_gen():
-                    try:
-                        _gen_to_close.close()
-                    except Exception:  # noqa: BLE001 — cleanup is best-effort
-                        logger.debug(
-                            "DFlash generator close raised; ignoring",
-                            exc_info=True,
-                        )
-
-                # ``run_in_executor`` may itself observe cancellation;
-                # shield so the cleanup completes before propagating
-                # the cancellation up.
-                try:
-                    await asyncio.shield(
-                        loop.run_in_executor(_dflash_executor, _close_gen)
-                    )
-                except (asyncio.CancelledError, Exception):  # noqa: BLE001
-                    pass
+        while gen is not None:
+            chunk = await _await_worker(_next_chunk)
+            timed_out_after_generation = False
+            if isinstance(chunk, tuple):
+                chunk, _timeout_marker = chunk
+                timed_out_after_generation = _timeout_marker is timed_out
+            if timed_out_after_generation:
+                error_message = f"DFlash stream timed out after {timeout:.1f} seconds."
+                finish_reason = "length"
+                break
+            if chunk is None:
+                break
+            if isinstance(chunk, Exception):
+                logger.exception(
+                    "DFlash stream_generate raised mid-stream: %s",
+                    chunk,
+                    exc_info=chunk,
+                )
+                error_message = f"{type(chunk).__name__}: {chunk}"
+                # See above for OpenAI spec literal-set rationale.
+                finish_reason = "length"
+                break
+            # Always sync token counts from the chunk — even when text
+            # is empty (mlx-vlm occasionally emits trailing flush
+            # chunks carrying the final token counters but no
+            # incremental text). Skipping the update would leave the
+            # final usage block with stale numbers.
+            total_completion_tokens = chunk.generation_tokens
+            prompt_tokens = chunk.prompt_tokens
+            _ct = getattr(chunk, "token", None)
+            if isinstance(_ct, int):
+                last_token_id = _ct
+            if not chunk.text:
+                continue
+            piece = {
+                "id": completion_id,
+                "object": "chat.completion.chunk",
+                "created": created,
+                "model": served_model_name,
+                "choices": [
+                    {
+                        "index": 0,
+                        "delta": {"content": chunk.text},
+                        "finish_reason": None,
+                    }
+                ],
+            }
+            yield f"data: {json.dumps(piece)}\n\n".encode()
 
     # Length-truncation detection — mlx-vlm's GenerationResult has no
     # ``finish_reason`` field, so we infer "length" by comparing the
@@ -563,16 +858,52 @@ async def _non_stream_completion(
     gen_kwargs: dict[str, Any],
     model: Any,
     processor: Any,
+    timeout: float = 1800.0,
+    admission_reservation: _DFlashAdmissionReservation | None = None,
 ) -> ChatCompletionResponse:
-    """Run generation under the serial lock, return one
-    ``ChatCompletionResponse`` containing the full text."""
+    """Run generation under the serial lock and enforce a safe deadline.
+
+    ``mlx_vlm.generate`` cannot be preempted once it is running on the
+    dedicated worker. On timeout we return a 504, but keep both the serial
+    lock and admission slot until the worker exits; otherwise a second call
+    could overlap the first GPU operation on the same thread.
+    """
     from mlx_vlm import generate
 
     completion_id = f"chatcmpl-{uuid.uuid4().hex[:24]}"
     created = int(time.time())
 
-    async with _dflash_lock:
-        loop = asyncio.get_running_loop()
+    # Keep the helper usable by direct programmatic callers and existing
+    # focused tests. The request route always supplies its real admission
+    # reservation; this private fallback only matters outside the ASGI path.
+    if admission_reservation is None:
+        admission_reservation = _DFlashAdmission(0).reserve()
+
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout
+    lock_acquired = False
+    worker_future: asyncio.Future[Any] | None = None
+
+    def _release_after_worker(_future: asyncio.Future[Any]) -> None:
+        """Run in the event loop after a timed-out worker exits."""
+        _dflash_lock.release()
+        admission_reservation.release(force=True)
+
+    def _defer_worker_cleanup() -> None:
+        nonlocal lock_acquired
+        assert worker_future is not None
+        admission_reservation.defer_release()
+        worker_future.add_done_callback(_release_after_worker)
+        # The callback above is now responsible for the serial lock. Do not
+        # release it in this coroutine's finally block.
+        lock_acquired = False
+
+    try:
+        remaining = deadline - loop.time()
+        if remaining <= 0:
+            raise asyncio.TimeoutError
+        await asyncio.wait_for(_dflash_lock.acquire(), timeout=remaining)
+        lock_acquired = True
 
         # mlx-vlm's ``generate`` blocks; offload to the dedicated
         # single-thread DFlash executor so every mlx-vlm call lands on
@@ -589,7 +920,27 @@ async def _non_stream_completion(
             except Exception as e:  # noqa: BLE001 — surface as HTTPException below
                 return e
 
-        result = await loop.run_in_executor(_dflash_executor, _generate_safely)
+        worker_future = loop.run_in_executor(_dflash_executor, _generate_safely)
+        remaining = deadline - loop.time()
+        if remaining <= 0:
+            raise asyncio.TimeoutError
+        result = await asyncio.wait_for(
+            asyncio.shield(worker_future), timeout=remaining
+        )
+    except asyncio.TimeoutError as exc:
+        if lock_acquired and worker_future is not None:
+            _defer_worker_cleanup()
+        raise HTTPException(
+            status_code=504,
+            detail=f"DFlash request timed out after {timeout:.1f} seconds.",
+        ) from exc
+    except asyncio.CancelledError:
+        if lock_acquired and worker_future is not None:
+            _defer_worker_cleanup()
+        raise
+    finally:
+        if lock_acquired:
+            _dflash_lock.release()
 
     if isinstance(result, Exception):
         logger.exception(
@@ -651,6 +1002,13 @@ def run_dflash_server(
     cors_origins: list[str],
     uvicorn_log_level: str,
     no_thinking: bool = False,
+    api_key: str | None = None,
+    rate_limit: int = 0,
+    max_request_bytes: int = 8 * 1024 * 1024,
+    body_receive_timeout_seconds: float = 15.0,
+    default_timeout: float = 1800.0,
+    max_concurrent_requests: int = 256,
+    cors_policy: Any | None = None,
 ) -> None:
     """Load the model + DFlash drafter via mlx-vlm and start uvicorn.
 
@@ -727,6 +1085,13 @@ def run_dflash_server(
         default_max_tokens=default_max_tokens,
         cors_origins=cors_origins,
         no_thinking=no_thinking,
+        api_key=api_key,
+        rate_limit=rate_limit,
+        max_request_bytes=max_request_bytes,
+        body_receive_timeout_seconds=body_receive_timeout_seconds,
+        default_timeout=default_timeout,
+        max_concurrent_requests=max_concurrent_requests,
+        cors_policy=cors_policy,
     )
 
     print()

--- a/vllm_mlx/speculative/dflash/server.py
+++ b/vllm_mlx/speculative/dflash/server.py
@@ -83,6 +83,27 @@ _dflash_executor = concurrent.futures.ThreadPoolExecutor(
 )
 
 
+# F2 (codex round-2 #1): bound the producer→consumer SSE handoff queue so a
+# stalled client cannot make the producer buffer an entire completion in
+# memory. Once the queue is full, the producer waits at most
+# ``_STREAM_BACKPRESSURE_TIMEOUT_SECONDS`` for the consumer to drain a slot;
+# if the client is truly gone, generation is aborted and the generator +
+# lease are cleaned up. The bound is chunk-count, not bytes — each queued
+# item is one small SSE frame, so a modest count keeps buffered memory tiny
+# without throttling a healthy fast reader.
+_STREAM_QUEUE_MAXSIZE = 64
+_STREAM_BACKPRESSURE_TIMEOUT_SECONDS = 30.0
+
+
+class _DFlashClientGoneError(Exception):
+    """Raised inside the stream producer when the SSE handoff queue stays
+    full past ``_STREAM_BACKPRESSURE_TIMEOUT_SECONDS`` — i.e. the client
+    has stopped reading. Signals the producer to abort generation and let
+    the lease close the generator + release the GPU lock / admission slot,
+    rather than buffering an unbounded completion for a client that is
+    almost certainly gone."""
+
+
 class _DFlashAdmissionReservation:
     """One request slot from a :class:`_DFlashAdmission` gate.
 
@@ -604,6 +625,15 @@ def _build_app(
                 draft_model=runtime.drafter,
                 draft_kind=runtime.kind,
             )
+            # F4 (codex round-2 #3): resolve the effective timeout with an
+            # ``is None`` check, NOT ``request.timeout or default_timeout``.
+            # ``or`` treats an explicit ``timeout=0`` as falsy and swaps in
+            # ``default_timeout``, silently contradicting the ``timeout <= 0``
+            # "no deadline" semantics both completion paths now honor. Only
+            # an omitted (``None``) timeout should fall back to the default.
+            effective_timeout = (
+                request.timeout if request.timeout is not None else default_timeout
+            )
         except BaseException:
             reservation.release()
             raise
@@ -618,7 +648,7 @@ def _build_app(
                         gen_kwargs=gen_kwargs,
                         model=model,
                         processor=processor,
-                        timeout=request.timeout or default_timeout,
+                        timeout=effective_timeout,
                         admission_reservation=reservation,
                     ),
                     reservation,
@@ -634,7 +664,7 @@ def _build_app(
                 gen_kwargs=gen_kwargs,
                 model=model,
                 processor=processor,
-                timeout=request.timeout or default_timeout,
+                timeout=effective_timeout,
                 admission_reservation=reservation,
             )
         finally:
@@ -795,10 +825,14 @@ async def _stream_completion(
     # the outer ``yield`` suspends — but the producer keeps running and
     # its deadline checks keep firing, so a stalled reader can no longer
     # pin ``_dflash_lock`` past ``timeout``. Lease acquisition/release is
-    # therefore independent of downstream socket writes. The queue is
-    # unbounded but generation is ``max_tokens``-bounded, so buffered
-    # memory is bounded by the completion length.
-    queue: asyncio.Queue[bytes | None] = asyncio.Queue()
+    # therefore independent of downstream socket writes.
+    #
+    # codex round-2 #1: the queue is BOUNDED so a stalled client cannot make
+    # the producer buffer the whole completion. When the queue fills, the
+    # producer's ``put`` blocks; if it stays blocked past the backpressure
+    # timeout, the client is treated as gone and generation is aborted with
+    # the generator + lease cleaned up.
+    queue: asyncio.Queue[bytes | None] = asyncio.Queue(maxsize=_STREAM_QUEUE_MAXSIZE)
 
     async def _produce() -> None:
         """Own the lease, generate, and push SSE chunks onto the queue.
@@ -818,6 +852,20 @@ async def _stream_completion(
         # budget. None means "no token observed yet".
         last_token_id: int | None = None
         error_message: str | None = None
+
+        async def _emit(item: bytes) -> None:
+            """Put one SSE frame on the bounded queue with a backpressure
+            deadline (codex round-2 #1). If the queue stays full past the
+            backpressure timeout the consumer has stopped reading, so raise
+            ``_DFlashClientGoneError`` to abort generation instead of buffering
+            an unbounded completion for a client that is gone."""
+            try:
+                await asyncio.wait_for(
+                    queue.put(item),
+                    timeout=_STREAM_BACKPRESSURE_TIMEOUT_SECONDS,
+                )
+            except asyncio.TimeoutError as exc:
+                raise _DFlashClientGoneError from exc
 
         async def _await_worker(func: Any, *, makes_generator: bool = False) -> Any:
             """Wait without cancelling an mlx operation on deadline expiry."""
@@ -850,24 +898,31 @@ async def _stream_completion(
                 return result
             remaining = deadline - loop.time()
             if remaining <= 0:
-                # The future was submitted just above. It may be a GPU
-                # step, so wait for it before releasing the serial lock.
-                result = await asyncio.shield(future)
-                lease.clear_future(future)
-                return result, timed_out
+                # F2 (codex round-2 #2): the deadline is already gone. Do
+                # NOT block on the non-preemptible worker — a hung token
+                # step would make the timeout ineffective indefinitely.
+                # Return the timeout marker IMMEDIATELY, leaving
+                # ``_active_future`` tracked so the lease's ``__aexit__``
+                # routes the still-running worker through deferred cleanup
+                # (retaining the lock + admission slot until the worker
+                # actually stops, then closing its generator). Mark the
+                # lease timed-out so any further ``_await_worker`` call
+                # short-circuits.
+                lease.timed_out = True
+                return timed_out
             done, _pending = await asyncio.wait({future}, timeout=remaining)
             if done:
                 result = future.result()
                 lease.clear_future(future)
                 return result
 
-            # mlx work is not preemptible. Let the in-flight token step
-            # finish while the serial lock remains held, then close its
-            # generator rather than letting another request overlap it on
-            # the GPU worker.
-            result = await asyncio.shield(future)
-            lease.clear_future(future)
-            return result, timed_out
+            # F2 (codex round-2 #2): the wait elapsed before the worker
+            # finished. Same policy as above — surface the timeout
+            # immediately and defer the in-flight worker's cleanup to the
+            # lease instead of blocking the response on a non-preemptible
+            # step. ``_active_future`` stays tracked for ``__aexit__``.
+            lease.timed_out = True
+            return timed_out
 
         finish_reason = "stop"
         async with lease:
@@ -897,22 +952,15 @@ async def _stream_completion(
                     return e
 
             gen_or_err = await _await_worker(_make_gen, makes_generator=True)
-            timed_out_after_generation = False
+            # ``_await_worker`` now returns the ``timed_out`` sentinel
+            # immediately on deadline expiry (codex round-2 #2) — never a
+            # tuple. When it times out during construction we have no
+            # generator to drive; the lease's deferred cleanup owns closing
+            # the (possibly in-flight) worker.
             if gen_or_err is timed_out:
-                timed_out_after_generation = True
-            elif isinstance(gen_or_err, tuple):
-                gen_or_err, _timeout_marker = gen_or_err
-                timed_out_after_generation = _timeout_marker is timed_out
-            if timed_out_after_generation:
                 error_message = f"DFlash stream timed out after {timeout:.1f} seconds."
                 finish_reason = "length"
-                gen = (
-                    None
-                    if gen_or_err is timed_out or isinstance(gen_or_err, Exception)
-                    else gen_or_err
-                )
-                if gen is not None:
-                    lease.set_generator(gen)
+                gen = None
             elif isinstance(gen_or_err, Exception):
                 logger.exception(
                     "DFlash stream_generate raised at construction: %s",
@@ -947,11 +995,11 @@ async def _stream_completion(
 
             while gen is not None:
                 chunk = await _await_worker(_next_chunk)
-                timed_out_after_generation = False
-                if isinstance(chunk, tuple):
-                    chunk, _timeout_marker = chunk
-                    timed_out_after_generation = _timeout_marker is timed_out
-                if timed_out_after_generation:
+                if chunk is timed_out:
+                    # codex round-2 #2: deadline hit mid-stream. Surface the
+                    # timeout immediately; the still-running token step is
+                    # tracked by the lease and cleaned up (lock + slot held
+                    # until it stops) via ``__aexit__``'s deferred path.
                     error_message = (
                         f"DFlash stream timed out after {timeout:.1f} seconds."
                     )
@@ -994,10 +1042,14 @@ async def _stream_completion(
                         }
                     ],
                 }
-                # F2: push to the queue instead of yielding to the socket
-                # directly, so the lease (and its lock) is never held across
-                # a suspended socket write.
-                await queue.put(f"data: {json.dumps(piece)}\n\n".encode())
+                # F2: push to the bounded queue instead of yielding to the
+                # socket directly, so the lease (and its lock) is never held
+                # across a suspended socket write. ``_emit`` raises
+                # ``_DFlashClientGoneError`` if the queue stays full past the
+                # backpressure timeout — that unwinds through
+                # ``async with lease`` (closing the generator + releasing the
+                # lock) and is swallowed in ``_drive_producer``.
+                await _emit(f"data: {json.dumps(piece)}\n\n".encode())
 
         # Length-truncation detection — mlx-vlm's GenerationResult has no
         # ``finish_reason`` field, so we infer "length" by comparing the
@@ -1039,8 +1091,8 @@ async def _stream_completion(
                 "type": "dflash_runtime_error",
                 "message": error_message,
             }
-        await queue.put(f"data: {json.dumps(final)}\n\n".encode())
-        await queue.put(b"data: [DONE]\n\n")
+        await _emit(f"data: {json.dumps(final)}\n\n".encode())
+        await _emit(b"data: [DONE]\n\n")
 
     async def _drive_producer() -> None:
         """Run ``_produce`` and always terminate the queue with a sentinel.
@@ -1051,8 +1103,26 @@ async def _stream_completion(
         """
         try:
             await _produce()
+        except _DFlashClientGoneError:
+            # codex round-2 #1: the client stopped reading and the bounded
+            # queue stayed full past the backpressure timeout. ``_produce``
+            # already unwound ``async with lease`` (generator closed, lock +
+            # slot released or deferred). Nothing more to emit — fall through
+            # to the sentinel so the drain loop (if still alive) exits.
+            logger.debug(
+                "DFlash stream aborted: client stopped reading past the "
+                "%.0fs backpressure timeout",
+                _STREAM_BACKPRESSURE_TIMEOUT_SECONDS,
+            )
         finally:
-            queue.put_nowait(None)
+            # Sentinel wakes the consumer's drain loop. Use ``put_nowait``
+            # inside a guard: if the bounded queue is full (the very
+            # backpressure that aborted us), drop the sentinel — the consumer
+            # is gone and its ``finally`` cancels this task anyway.
+            try:
+                queue.put_nowait(None)
+            except asyncio.QueueFull:
+                logger.debug("DFlash stream queue full at teardown; sentinel dropped")
 
     # F2: start generation in its own task BEFORE the first client read.
     # ``ensure_future`` schedules the producer eagerly so its deadline

--- a/vllm_mlx/speculative/dflash/server.py
+++ b/vllm_mlx/speculative/dflash/server.py
@@ -43,7 +43,7 @@ import uuid
 from collections.abc import AsyncIterator
 from typing import Any
 
-from fastapi import Depends, FastAPI, HTTPException
+from fastapi import Depends, FastAPI, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import StreamingResponse
 
@@ -84,12 +84,32 @@ _dflash_executor = concurrent.futures.ThreadPoolExecutor(
 
 
 class _DFlashAdmissionReservation:
-    """One request slot from a :class:`_DFlashAdmission` gate."""
+    """One request slot from a :class:`_DFlashAdmission` gate.
+
+    Ownership handoff (F1): the reservation is minted at the ASGI layer
+    *before* the request body is parsed, so ``max_concurrent_requests``
+    bounds the number of concurrently parsed bodies rather than only the
+    number of requests already inside the endpoint. The middleware keeps
+    a safety-net ``finally`` that force-releases the slot, but once the
+    endpoint (stream lease / non-stream path) takes ownership via
+    :meth:`claim` it is responsible for the release — including the
+    deferred-until-worker-exits case — and the middleware net becomes a
+    no-op. This prevents a double decrement of ``_reservations``.
+    """
 
     def __init__(self, admission: _DFlashAdmission) -> None:
         self._admission = admission
         self._deferred = False
         self._released = False
+        self._claimed = False
+
+    def claim(self) -> None:
+        """Mark the endpoint as the owner of this slot's release."""
+        self._claimed = True
+
+    @property
+    def claimed(self) -> bool:
+        return self._claimed
 
     def defer_release(self) -> None:
         """Keep the slot until a timed-out worker has actually stopped."""
@@ -129,6 +149,99 @@ class _DFlashAdmission:
                 )
             self._reservations += 1
         return _DFlashAdmissionReservation(self)
+
+
+class _DFlashAdmissionMiddleware:
+    """ASGI gate that reserves a DFlash slot BEFORE the body is parsed (F1).
+
+    ``_DFlashAdmission`` was previously consulted inside the endpoint —
+    i.e. after FastAPI had already streamed, JSON-decoded, and
+    Pydantic-validated the full ``ChatCompletionRequest``. That bounded
+    the number of requests *in generation* but not the number of
+    concurrently parsed bodies: an authenticated burst could inflate
+    unbounded parsed-body memory and only trip the 503 once each body was
+    already resident. Reserving here — before ``self.app`` (and therefore
+    before FastAPI's route body-binding) runs — makes
+    ``max_concurrent_requests`` bound parsed-body memory too.
+
+    The reservation is stashed in ``scope["state"]`` so the endpoint reuses
+    the same slot (it calls :meth:`_DFlashAdmissionReservation.claim`
+    and owns the release, including the deferred-worker-cleanup case). The
+    middleware keeps a ``finally`` safety-net that force-releases the slot
+    only when the endpoint never claimed it — e.g. the request was bounced
+    by auth / rate-limit / body-size / validation before generation began,
+    or never matched the chat route at all. This retains the reservation
+    across the full streaming-response lifecycle without ever double
+    decrementing the counter.
+    """
+
+    _GUARDED_METHOD = "POST"
+    _GUARDED_PATH = "/v1/chat/completions"
+
+    def __init__(self, app: Any, admission: _DFlashAdmission) -> None:
+        self.app = app
+        self._admission = admission
+
+    async def __call__(self, scope, receive, send):
+        if (
+            scope.get("type") != "http"
+            or scope.get("method") != self._GUARDED_METHOD
+            or scope.get("path") != self._GUARDED_PATH
+        ):
+            return await self.app(scope, receive, send)
+
+        try:
+            reservation = self._admission.reserve()
+        except HTTPException as exc:
+            await _send_503(
+                send,
+                detail=str(exc.detail),
+                retry_after=(exc.headers or {}).get("Retry-After"),
+            )
+            return
+
+        # Hand the slot to the endpoint via ASGI scope state. Starlette
+        # seeds ``scope["state"]`` per-request; create it defensively for
+        # bare-ASGI callers/tests that omit it.
+        state = scope.setdefault("state", {})
+        state["dflash_reservation"] = reservation
+        try:
+            await self.app(scope, receive, send)
+        finally:
+            # Safety net only. Once the endpoint claims the slot it owns
+            # the release (possibly deferred until a timed-out worker
+            # exits), so force-releasing here would double-decrement.
+            if not reservation.claimed:
+                reservation.release(force=True)
+
+
+async def _send_503(send, *, detail: str, retry_after: str | None) -> None:
+    """Emit an OpenAI-shaped 503 from inside ASGI middleware (F1).
+
+    Hand-rolled (not ``HTTPException``) because we reject before FastAPI's
+    exception machinery is reachable — the request body has not been read.
+    """
+    body = json.dumps(
+        {
+            "error": {
+                "message": detail,
+                "type": "service_unavailable",
+                "code": "at_capacity",
+                "param": None,
+            }
+        }
+    ).encode("utf-8")
+    headers = [
+        (b"content-type", b"application/json"),
+        (b"content-length", str(len(body)).encode("ascii")),
+    ]
+    if retry_after:
+        headers.append((b"retry-after", str(retry_after).encode("ascii")))
+    try:
+        await send({"type": "http.response.start", "status": 503, "headers": headers})
+        await send({"type": "http.response.body", "body": body, "more_body": False})
+    except Exception:  # noqa: BLE001 -- client already gone; nothing to emit
+        logger.debug("DFlash 503 send failed (client already disconnected)")
 
 
 class _DFlashStreamLease:
@@ -197,9 +310,18 @@ class _DFlashStreamLease:
     def _capture_generator(self, future: asyncio.Future[Any]) -> None:
         if not self._active_future_makes_generator or self._generator is not None:
             return
+        # F3: catch ``BaseException`` — a cancelled ``run_in_executor``
+        # future raises ``CancelledError`` from ``.result()``, and
+        # ``CancelledError`` subclasses ``BaseException`` (not
+        # ``Exception``). The pre-fix ``except Exception`` let that escape
+        # out of ``__aexit__`` before ``_close_generator_and_release`` /
+        # ``_release`` ran, permanently leaking ``_dflash_lock`` when the
+        # client cancelled during generator construction (the tiny window
+        # after ``run_in_executor`` submits but before the single worker
+        # thread picks the task up, so ``future.cancel()`` succeeds).
         try:
             candidate = future.result()
-        except Exception:  # noqa: BLE001 -- worker error has no generator to close
+        except BaseException:  # noqa: BLE001 -- worker error/cancel has no generator to close
             return
         if not isinstance(candidate, Exception) and hasattr(candidate, "close"):
             self._generator = candidate
@@ -336,6 +458,11 @@ def _build_app(
     # dedicated app path.
     install_request_body_depth_middleware(app)
     install_request_body_limit_middleware(app)
+    # F1: admission runs OUTERMOST so a slot is reserved before the body-
+    # size / body-depth wrappers even read bytes and before FastAPI binds
+    # the Pydantic body. ``add_middleware`` wraps last-added first, so this
+    # call must come after the two above to sit on the outside.
+    app.add_middleware(_DFlashAdmissionMiddleware, admission=admission)
     # F-090/F-091: register CORS only when an explicit origin allowlist is
     # configured. ``cors_origins=[]`` (the new default — see
     # ``vllm_mlx/server.py::configure_cors_from_env``) skips the middleware
@@ -392,7 +519,9 @@ def _build_app(
         "/v1/chat/completions",
         dependencies=[Depends(verify_api_key), Depends(check_rate_limit)],
     )
-    async def create_chat_completion(request: ChatCompletionRequest):
+    async def create_chat_completion(
+        request: ChatCompletionRequest, http_request: Request
+    ):
         if not request.messages:
             raise HTTPException(status_code=400, detail="messages must not be empty")
         if request.n is not None and request.n > 1:
@@ -424,7 +553,17 @@ def _build_app(
                     "in DFlash mode. Restart without DFlash."
                 ),
             )
-        reservation = admission.reserve()
+        # F1: the slot was reserved at the ASGI layer
+        # (``_DFlashAdmissionMiddleware``) BEFORE this body was parsed, so
+        # admission bounds parsed-body memory too. Reuse that slot and take
+        # ownership of its release (``claim``); the middleware's safety-net
+        # release becomes a no-op once claimed. A direct-ASGI/test caller
+        # that bypasses the middleware won't have seeded scope state, so
+        # fall back to reserving here (unclaimed → still gated).
+        reservation = getattr(http_request.state, "dflash_reservation", None)
+        if reservation is None:
+            reservation = admission.reserve()
+        reservation.claim()
         try:
             # Render chat messages into a single prompt string via mlx-vlm's
             # processor. We pass through the model's chat template so the
@@ -612,7 +751,9 @@ async def _stream_completion(
     completion_id = f"chatcmpl-{uuid.uuid4().hex[:24]}"
     created = int(time.time())
 
-    # First chunk — role marker
+    # First chunk — role marker. Emitted by the consumer loop below,
+    # before the producer task is started, so the client sees the role
+    # delta before any GPU lock is touched (matches the prior contract).
     first = {
         "id": completion_id,
         "object": "chat.completion.chunk",
@@ -622,16 +763,6 @@ async def _stream_completion(
             {"index": 0, "delta": {"role": "assistant"}, "finish_reason": None}
         ],
     }
-    yield f"data: {json.dumps(first)}\n\n".encode()
-
-    finish_reason = "stop"
-    total_completion_tokens = 0
-    prompt_tokens = 0
-    # Track the last token id to disambiguate "hit max_tokens but the
-    # final token was actually EOS" — without this we'd falsely flag a
-    # natural-stop response as truncated when it lands on exactly the
-    # budget. None means "no token observed yet".
-    last_token_id: int | None = None
 
     # Track max_tokens so we can report ``finish_reason="length"`` when
     # generation was truncated (OpenAI clients distinguish "stop"
@@ -651,203 +782,315 @@ async def _stream_completion(
     elif isinstance(_eos, (list, tuple, set)):
         _eos_ids.update(int(t) for t in _eos if isinstance(t, int))
 
-    error_message: str | None = None
     loop = asyncio.get_running_loop()
     deadline = loop.time() + timeout if timeout and timeout > 0 else None
     timed_out = object()
     lease = _DFlashStreamLease(loop, admission_reservation, deadline)
 
-    async def _await_worker(func: Any, *, makes_generator: bool = False) -> Any:
-        """Wait without cancelling an mlx operation on deadline expiry."""
-        if lease.timed_out:
-            return timed_out
-        future = loop.run_in_executor(_dflash_executor, func)
-        lease.track_future(future, makes_generator=makes_generator)
-        if deadline is None:
-            result = await future
-            lease.clear_future(future)
-            return result
-        remaining = deadline - loop.time()
-        if remaining <= 0:
-            # The future was submitted by the caller already. It may be a
-            # GPU step, so wait for it before releasing the serial lock.
+    # F2: decouple generation from socket writes. Generation runs in a
+    # dedicated producer task that OWNS the lease (serial GPU lock +
+    # admission slot) and pushes ready-to-send SSE byte chunks onto this
+    # queue. This outer coroutine only drains the queue and yields to the
+    # client socket. If the client applies backpressure (stops reading),
+    # the outer ``yield`` suspends — but the producer keeps running and
+    # its deadline checks keep firing, so a stalled reader can no longer
+    # pin ``_dflash_lock`` past ``timeout``. Lease acquisition/release is
+    # therefore independent of downstream socket writes. The queue is
+    # unbounded but generation is ``max_tokens``-bounded, so buffered
+    # memory is bounded by the completion length.
+    queue: asyncio.Queue[bytes | None] = asyncio.Queue()
+
+    async def _produce() -> None:
+        """Own the lease, generate, and push SSE chunks onto the queue.
+
+        Always terminates the queue with a ``None`` sentinel so the
+        consumer's drain loop can exit even on error/cancel. Runs under
+        ``async with lease`` so the serial lock + admission slot are
+        released (or deferred until a timed-out/cancelled worker exits)
+        the moment generation finishes, regardless of consumer speed.
+        """
+        finish_reason = "stop"
+        total_completion_tokens = 0
+        prompt_tokens = 0
+        # Track the last token id to disambiguate "hit max_tokens but the
+        # final token was actually EOS" — without this we'd falsely flag a
+        # natural-stop response as truncated when it lands on exactly the
+        # budget. None means "no token observed yet".
+        last_token_id: int | None = None
+        error_message: str | None = None
+
+        async def _await_worker(func: Any, *, makes_generator: bool = False) -> Any:
+            """Wait without cancelling an mlx operation on deadline expiry."""
+            if lease.timed_out:
+                return timed_out
+            # F5: recheck the remaining deadline BEFORE submitting the
+            # executor job. Acquiring the serial lock (and prior token
+            # steps) can consume the whole budget; submitting first — as
+            # the pre-fix code did — would start expensive, non-preemptible
+            # GPU work for an already-expired request and keep the lock
+            # held until it finished. Check first; only submit if time
+            # remains.
+            if deadline is not None and deadline - loop.time() <= 0:
+                return timed_out
+            future = loop.run_in_executor(_dflash_executor, func)
+            lease.track_future(future, makes_generator=makes_generator)
+            if deadline is None:
+                # F3: shield so a client cancellation during this bare
+                # await cannot tear a non-preemptible GPU step mid-flight
+                # while leaving the lock leaked. The shield keeps the
+                # underlying worker running; the raised ``CancelledError``
+                # unwinds into ``lease.__aexit__``, which defers cleanup
+                # until the worker completes and then releases the lock.
+                # ``clear_future`` runs only on the normal (uncancelled)
+                # path — on cancel we leave ``_active_future`` set so
+                # ``__aexit__`` sees the in-flight future and routes it
+                # through deferred cleanup.
+                result = await asyncio.shield(future)
+                lease.clear_future(future)
+                return result
+            remaining = deadline - loop.time()
+            if remaining <= 0:
+                # The future was submitted just above. It may be a GPU
+                # step, so wait for it before releasing the serial lock.
+                result = await asyncio.shield(future)
+                lease.clear_future(future)
+                return result, timed_out
+            done, _pending = await asyncio.wait({future}, timeout=remaining)
+            if done:
+                result = future.result()
+                lease.clear_future(future)
+                return result
+
+            # mlx work is not preemptible. Let the in-flight token step
+            # finish while the serial lock remains held, then close its
+            # generator rather than letting another request overlap it on
+            # the GPU worker.
             result = await asyncio.shield(future)
             lease.clear_future(future)
             return result, timed_out
-        done, _pending = await asyncio.wait({future}, timeout=remaining)
-        if done:
-            result = future.result()
-            lease.clear_future(future)
-            return result
 
-        # mlx work is not preemptible. Let the in-flight token step finish
-        # while the serial lock remains held, then close its generator rather
-        # than letting another request overlap it on the GPU worker.
-        result = await asyncio.shield(future)
-        lease.clear_future(future)
-        return result, timed_out
+        finish_reason = "stop"
+        async with lease:
+            # mlx-vlm's stream_generate is a sync generator — run it in a
+            # thread pool so we don't block the FastAPI event loop. Iterate
+            # by polling with ``run_in_executor`` per chunk. We're already
+            # inside a coroutine, so use ``get_running_loop`` (the 3.10+
+            # idiom; ``get_event_loop`` is deprecated for in-coroutine use).
+            # The executor MUST be ``_dflash_executor`` (single-thread) so
+            # consecutive ``next(gen)`` calls land on the same worker —
+            # mlx's GPU Stream is thread-local and a hand-off across worker
+            # threads would crash mid-generation.
+            # Create the generator on the same worker that will drive it,
+            # not on the event-loop thread — otherwise the first ``next``
+            # crosses a thread boundary just like the rest.
+            #
+            # Wrap construction in a sentinel pattern too: if
+            # ``stream_generate`` raises at setup time (OOM, missing kernel,
+            # bad arg) the exception would otherwise propagate out of the
+            # async generator and leave the SSE client hanging without a
+            # ``[DONE]``. Surfacing it as an error SSE keeps the contract
+            # the same as the mid-stream error path below.
+            def _make_gen():
+                try:
+                    return stream_generate(model, processor, prompt, **gen_kwargs)
+                except Exception as e:  # noqa: BLE001 — surface upstream; outer code converts to error SSE
+                    return e
 
-    async with lease:
-        # mlx-vlm's stream_generate is a sync generator — run it in a
-        # thread pool so we don't block the FastAPI event loop. Iterate
-        # by polling with ``run_in_executor`` per chunk. We're already
-        # inside a coroutine, so use ``get_running_loop`` (the 3.10+
-        # idiom; ``get_event_loop`` is deprecated for in-coroutine use).
-        # The executor MUST be ``_dflash_executor`` (single-thread) so
-        # consecutive ``next(gen)`` calls land on the same worker —
-        # mlx's GPU Stream is thread-local and a hand-off across worker
-        # threads would crash mid-generation.
-        # Create the generator on the same worker that will drive it,
-        # not on the event-loop thread — otherwise the first ``next``
-        # crosses a thread boundary just like the rest.
-        #
-        # Wrap construction in a sentinel pattern too: if
-        # ``stream_generate`` raises at setup time (OOM, missing kernel,
-        # bad arg) the exception would otherwise propagate out of the
-        # async generator and leave the SSE client hanging without a
-        # ``[DONE]``. Surfacing it as an error SSE keeps the contract
-        # the same as the mid-stream error path below.
-        def _make_gen():
-            try:
-                return stream_generate(model, processor, prompt, **gen_kwargs)
-            except Exception as e:  # noqa: BLE001 — surface upstream; outer code converts to error SSE
-                return e
-
-        gen_or_err = await _await_worker(_make_gen, makes_generator=True)
-        timed_out_after_generation = False
-        if gen_or_err is timed_out:
-            timed_out_after_generation = True
-        elif isinstance(gen_or_err, tuple):
-            gen_or_err, _timeout_marker = gen_or_err
-            timed_out_after_generation = _timeout_marker is timed_out
-        if timed_out_after_generation:
-            error_message = f"DFlash stream timed out after {timeout:.1f} seconds."
-            finish_reason = "length"
-            gen = (
-                None
-                if gen_or_err is timed_out or isinstance(gen_or_err, Exception)
-                else gen_or_err
-            )
-            if gen is not None:
-                lease.set_generator(gen)
-        elif isinstance(gen_or_err, Exception):
-            logger.exception(
-                "DFlash stream_generate raised at construction: %s",
-                gen_or_err,
-                exc_info=gen_or_err,
-            )
-            error_message = f"{type(gen_or_err).__name__}: {gen_or_err}"
-            # OpenAI ChatCompletion only accepts {stop, length, tool_calls,
-            # content_filter, function_call}. The error block on the final
-            # SSE chunk carries the abort details for clients.
-            finish_reason = "length"
-            gen = None
-        else:
-            gen = gen_or_err
-            lease.set_generator(gen)
-
-        # Sentinels distinguish "generator exhausted" (None) from
-        # "generator raised mid-stream" (an Exception instance). Catching
-        # only StopIteration would let any other mlx-vlm error propagate
-        # through run_in_executor, abort the response coroutine, and
-        # leave the SSE client hanging without a final ``[DONE]`` — the
-        # client then either times out or holds the connection forever.
-        def _next_chunk():
-            try:
-                return next(gen)
-            except StopIteration:
-                return None
-            except Exception as e:  # noqa: BLE001 — surface upstream; loop converts to error SSE
-                return e
-
-        while gen is not None:
-            chunk = await _await_worker(_next_chunk)
+            gen_or_err = await _await_worker(_make_gen, makes_generator=True)
             timed_out_after_generation = False
-            if isinstance(chunk, tuple):
-                chunk, _timeout_marker = chunk
+            if gen_or_err is timed_out:
+                timed_out_after_generation = True
+            elif isinstance(gen_or_err, tuple):
+                gen_or_err, _timeout_marker = gen_or_err
                 timed_out_after_generation = _timeout_marker is timed_out
             if timed_out_after_generation:
                 error_message = f"DFlash stream timed out after {timeout:.1f} seconds."
                 finish_reason = "length"
-                break
-            if chunk is None:
-                break
-            if isinstance(chunk, Exception):
-                logger.exception(
-                    "DFlash stream_generate raised mid-stream: %s",
-                    chunk,
-                    exc_info=chunk,
+                gen = (
+                    None
+                    if gen_or_err is timed_out or isinstance(gen_or_err, Exception)
+                    else gen_or_err
                 )
-                error_message = f"{type(chunk).__name__}: {chunk}"
-                # See above for OpenAI spec literal-set rationale.
+                if gen is not None:
+                    lease.set_generator(gen)
+            elif isinstance(gen_or_err, Exception):
+                logger.exception(
+                    "DFlash stream_generate raised at construction: %s",
+                    gen_or_err,
+                    exc_info=gen_or_err,
+                )
+                error_message = f"{type(gen_or_err).__name__}: {gen_or_err}"
+                # OpenAI ChatCompletion only accepts {stop, length,
+                # tool_calls, content_filter, function_call}. The error
+                # block on the final SSE chunk carries the abort details
+                # for clients.
                 finish_reason = "length"
-                break
-            # Always sync token counts from the chunk — even when text
-            # is empty (mlx-vlm occasionally emits trailing flush
-            # chunks carrying the final token counters but no
-            # incremental text). Skipping the update would leave the
-            # final usage block with stale numbers.
-            total_completion_tokens = chunk.generation_tokens
-            prompt_tokens = chunk.prompt_tokens
-            _ct = getattr(chunk, "token", None)
-            if isinstance(_ct, int):
-                last_token_id = _ct
-            if not chunk.text:
-                continue
-            piece = {
-                "id": completion_id,
-                "object": "chat.completion.chunk",
-                "created": created,
-                "model": served_model_name,
-                "choices": [
-                    {
-                        "index": 0,
-                        "delta": {"content": chunk.text},
-                        "finish_reason": None,
-                    }
-                ],
+                gen = None
+            else:
+                gen = gen_or_err
+                lease.set_generator(gen)
+
+            # Sentinels distinguish "generator exhausted" (None) from
+            # "generator raised mid-stream" (an Exception instance).
+            # Catching only StopIteration would let any other mlx-vlm error
+            # propagate through run_in_executor, abort the response
+            # coroutine, and leave the SSE client hanging without a final
+            # ``[DONE]`` — the client then either times out or holds the
+            # connection forever.
+            def _next_chunk():
+                try:
+                    return next(gen)
+                except StopIteration:
+                    return None
+                except Exception as e:  # noqa: BLE001 — surface upstream; loop converts to error SSE
+                    return e
+
+            while gen is not None:
+                chunk = await _await_worker(_next_chunk)
+                timed_out_after_generation = False
+                if isinstance(chunk, tuple):
+                    chunk, _timeout_marker = chunk
+                    timed_out_after_generation = _timeout_marker is timed_out
+                if timed_out_after_generation:
+                    error_message = (
+                        f"DFlash stream timed out after {timeout:.1f} seconds."
+                    )
+                    finish_reason = "length"
+                    break
+                if chunk is None:
+                    break
+                if isinstance(chunk, Exception):
+                    logger.exception(
+                        "DFlash stream_generate raised mid-stream: %s",
+                        chunk,
+                        exc_info=chunk,
+                    )
+                    error_message = f"{type(chunk).__name__}: {chunk}"
+                    # See above for OpenAI spec literal-set rationale.
+                    finish_reason = "length"
+                    break
+                # Always sync token counts from the chunk — even when text
+                # is empty (mlx-vlm occasionally emits trailing flush
+                # chunks carrying the final token counters but no
+                # incremental text). Skipping the update would leave the
+                # final usage block with stale numbers.
+                total_completion_tokens = chunk.generation_tokens
+                prompt_tokens = chunk.prompt_tokens
+                _ct = getattr(chunk, "token", None)
+                if isinstance(_ct, int):
+                    last_token_id = _ct
+                if not chunk.text:
+                    continue
+                piece = {
+                    "id": completion_id,
+                    "object": "chat.completion.chunk",
+                    "created": created,
+                    "model": served_model_name,
+                    "choices": [
+                        {
+                            "index": 0,
+                            "delta": {"content": chunk.text},
+                            "finish_reason": None,
+                        }
+                    ],
+                }
+                # F2: push to the queue instead of yielding to the socket
+                # directly, so the lease (and its lock) is never held across
+                # a suspended socket write.
+                await queue.put(f"data: {json.dumps(piece)}\n\n".encode())
+
+        # Length-truncation detection — mlx-vlm's GenerationResult has no
+        # ``finish_reason`` field, so we infer "length" by comparing the
+        # completion token count to the budget. Only set when we exited the
+        # loop normally (StopIteration), not when the generator errored or
+        # produced fewer tokens (natural stop).
+        #
+        # Subtle case: if the model emitted EOS exactly at ``max_tokens``,
+        # the stop was natural and reporting "length" would mislead clients
+        # into auto-continuing (only to get an immediate EOS again). Check
+        # the last token id against the resolved EOS set to keep the
+        # classification honest in this edge case.
+        if (
+            finish_reason == "stop"
+            and _max_tokens is not None
+            and total_completion_tokens >= _max_tokens
+            and last_token_id not in _eos_ids
+        ):
+            finish_reason = "length"
+
+        # Final chunk — finish_reason + usage. If we broke out of the loop
+        # because the underlying generator raised, attach an OpenAI-style
+        # error block so the client gets a readable failure instead of
+        # silent truncation.
+        final = {
+            "id": completion_id,
+            "object": "chat.completion.chunk",
+            "created": created,
+            "model": served_model_name,
+            "choices": [{"index": 0, "delta": {}, "finish_reason": finish_reason}],
+            "usage": {
+                "prompt_tokens": prompt_tokens,
+                "completion_tokens": total_completion_tokens,
+                "total_tokens": prompt_tokens + total_completion_tokens,
+            },
+        }
+        if error_message is not None:
+            final["error"] = {
+                "type": "dflash_runtime_error",
+                "message": error_message,
             }
-            yield f"data: {json.dumps(piece)}\n\n".encode()
+        await queue.put(f"data: {json.dumps(final)}\n\n".encode())
+        await queue.put(b"data: [DONE]\n\n")
 
-    # Length-truncation detection — mlx-vlm's GenerationResult has no
-    # ``finish_reason`` field, so we infer "length" by comparing the
-    # completion token count to the budget. Only set when we exited the
-    # loop normally (StopIteration), not when the generator errored or
-    # produced fewer tokens (natural stop).
-    #
-    # Subtle case: if the model emitted EOS exactly at ``max_tokens``,
-    # the stop was natural and reporting "length" would mislead clients
-    # into auto-continuing (only to get an immediate EOS again). Check
-    # the last token id against the resolved EOS set to keep the
-    # classification honest in this edge case.
-    if (
-        finish_reason == "stop"
-        and _max_tokens is not None
-        and total_completion_tokens >= _max_tokens
-        and last_token_id not in _eos_ids
-    ):
-        finish_reason = "length"
+    async def _drive_producer() -> None:
+        """Run ``_produce`` and always terminate the queue with a sentinel.
 
-    # Final chunk — finish_reason + usage. If we broke out of the loop
-    # because the underlying generator raised, attach an OpenAI-style
-    # error block so the client gets a readable failure instead of
-    # silent truncation.
-    final = {
-        "id": completion_id,
-        "object": "chat.completion.chunk",
-        "created": created,
-        "model": served_model_name,
-        "choices": [{"index": 0, "delta": {}, "finish_reason": finish_reason}],
-        "usage": {
-            "prompt_tokens": prompt_tokens,
-            "completion_tokens": total_completion_tokens,
-            "total_tokens": prompt_tokens + total_completion_tokens,
-        },
-    }
-    if error_message is not None:
-        final["error"] = {"type": "dflash_runtime_error", "message": error_message}
-    yield f"data: {json.dumps(final)}\n\n".encode()
-    yield b"data: [DONE]\n\n"
+        The ``finally`` guarantees the consumer's drain loop wakes and
+        exits even if ``_produce`` is cancelled (client disconnect) or
+        raises — otherwise ``queue.get()`` would block forever.
+        """
+        try:
+            await _produce()
+        finally:
+            queue.put_nowait(None)
+
+    # F2: start generation in its own task BEFORE the first client read.
+    # ``ensure_future`` schedules the producer eagerly so its deadline
+    # checks and lease lifecycle run independently of when (or whether) the
+    # consumer pulls the next chunk. This coroutine only shuttles
+    # already-formatted SSE bytes from the queue to the socket, so client
+    # backpressure suspends THIS coroutine — never the lease-holding
+    # producer. Creating it before the role-marker yield (rather than after)
+    # also guarantees ``producer`` is defined for the ``finally`` cleanup
+    # even if the client reads exactly the role marker and then disconnects.
+    producer = asyncio.ensure_future(_drive_producer())
+    try:
+        # Role marker first — emitted before any generated chunk, matching
+        # the prior contract. The producer may already be mid-generation by
+        # now; its output waits in the queue behind this marker.
+        yield f"data: {json.dumps(first)}\n\n".encode()
+        while True:
+            item = await queue.get()
+            if item is None:
+                break
+            yield item
+        # Surface a producer crash (not one of the sentinel-wrapped
+        # generation errors, which are already emitted as error SSE) so it
+        # is logged rather than silently swallowed.
+        await producer
+    finally:
+        # Client disconnect / ``aclose`` cancels this generator. Cancel the
+        # producer so its ``async with lease`` unwinds and releases (or
+        # defers) the serial lock + admission slot; then await it so the
+        # lease cleanup actually completes before we return.
+        if not producer.done():
+            producer.cancel()
+        try:
+            await producer
+        except asyncio.CancelledError:
+            pass
+        except Exception:  # noqa: BLE001 -- lease cleanup is what matters here
+            logger.debug("DFlash stream producer raised on teardown", exc_info=True)
 
 
 async def _non_stream_completion(
@@ -880,7 +1123,14 @@ async def _non_stream_completion(
         admission_reservation = _DFlashAdmission(0).reserve()
 
     loop = asyncio.get_running_loop()
-    deadline = loop.time() + timeout
+    # F4: unify zero-timeout policy with the streaming path. ``timeout <= 0``
+    # means "no deadline" on BOTH completion paths (matches the main
+    # server's ``default_timeout`` semantics and ``_stream_completion``'s
+    # ``timeout and timeout > 0`` gate). Previously a 0 here built an
+    # already-expired deadline and returned an immediate 504, while the
+    # same value disabled the streaming deadline — identical requests
+    # behaving oppositely by path.
+    deadline = loop.time() + timeout if timeout and timeout > 0 else None
     lock_acquired = False
     worker_future: asyncio.Future[Any] | None = None
 
@@ -898,11 +1148,18 @@ async def _non_stream_completion(
         # release it in this coroutine's finally block.
         lock_acquired = False
 
+    def _remaining() -> float | None:
+        """Seconds left before the deadline, or ``None`` for no deadline."""
+        return None if deadline is None else deadline - loop.time()
+
     try:
-        remaining = deadline - loop.time()
-        if remaining <= 0:
+        remaining = _remaining()
+        if remaining is not None and remaining <= 0:
             raise asyncio.TimeoutError
-        await asyncio.wait_for(_dflash_lock.acquire(), timeout=remaining)
+        if remaining is None:
+            await _dflash_lock.acquire()
+        else:
+            await asyncio.wait_for(_dflash_lock.acquire(), timeout=remaining)
         lock_acquired = True
 
         # mlx-vlm's ``generate`` blocks; offload to the dedicated
@@ -920,13 +1177,22 @@ async def _non_stream_completion(
             except Exception as e:  # noqa: BLE001 — surface as HTTPException below
                 return e
 
-        worker_future = loop.run_in_executor(_dflash_executor, _generate_safely)
-        remaining = deadline - loop.time()
-        if remaining <= 0:
+        # F5: recompute and validate the remaining deadline BEFORE
+        # submitting to the executor. Acquiring the serial lock can itself
+        # consume the whole budget; submitting first (as the pre-fix code
+        # did) would start expensive GPU work for an already-expired
+        # request and hold the lock until it finished. Check first, submit
+        # only if time remains.
+        remaining = _remaining()
+        if remaining is not None and remaining <= 0:
             raise asyncio.TimeoutError
-        result = await asyncio.wait_for(
-            asyncio.shield(worker_future), timeout=remaining
-        )
+        worker_future = loop.run_in_executor(_dflash_executor, _generate_safely)
+        if remaining is None:
+            result = await asyncio.shield(worker_future)
+        else:
+            result = await asyncio.wait_for(
+                asyncio.shield(worker_future), timeout=remaining
+            )
     except asyncio.TimeoutError as exc:
         if lock_acquired and worker_future is not None:
             _defer_worker_cleanup()

--- a/vllm_mlx/speculative/dflash/server.py
+++ b/vllm_mlx/speculative/dflash/server.py
@@ -124,6 +124,32 @@ _dflash_render_executor = concurrent.futures.ThreadPoolExecutor(
 _STREAM_QUEUE_MAXSIZE = 64
 _STREAM_BACKPRESSURE_TIMEOUT_SECONDS = 30.0
 
+# codex round-6 #2: grace window for a synchronous ``generator.close()`` before
+# the lease stops awaiting it and detaches the close (retaining the lock/slot
+# until the close future finishes). A normal close returns in microseconds, so
+# this only ever triggers for a genuinely hung teardown — and even a tiny value
+# would keep the fast path synchronous; 5s just avoids detaching on a briefly
+# slow (but not hung) GPU cleanup under load.
+_STREAM_GENERATOR_CLOSE_GRACE_SECONDS = 5.0
+
+
+def _format_timeout_seconds(seconds: float) -> str:
+    """Human-facing rendering of a timeout in seconds (codex round-6 #5).
+
+    A fixed ``:.1f`` renders a valid sub-100 ms limit like ``0.01`` as
+    "0.0 seconds", a misleading operational message. Use adaptive precision so
+    small positive timeouts keep enough significant digits to be meaningful,
+    while typical multi-second values stay clean.
+    """
+    if seconds <= 0:
+        return "0 seconds"
+    if seconds < 0.1:
+        # e.g. 0.01 → "0.010", 0.005 → "0.005"
+        return f"{seconds:.3f} seconds"
+    if seconds < 1:
+        return f"{seconds:.2f} seconds"
+    return f"{seconds:.1f} seconds"
+
 
 class _DFlashClientGoneError(Exception):
     """Raised inside the stream producer when a CONTENT-frame ``put`` blocks
@@ -502,7 +528,26 @@ class _DFlashStreamLease:
 
             close_future = self._loop.run_in_executor(_dflash_executor, _close_gen)
             try:
-                await asyncio.shield(close_future)
+                # codex round-6 #2: bound the close wait. ``generator.close()``
+                # runs the generator's finally blocks (mlx-vlm GPU teardown),
+                # which normally return in microseconds — so on the common path
+                # this await completes immediately and the lock/slot release
+                # synchronously, preserving the fast-path contract. But a hung
+                # close would otherwise block ``__aexit__`` — and therefore the
+                # producer's terminal SSE (timeout notice + [DONE]) —
+                # indefinitely. If the close overruns the grace window, DETACH
+                # it (like an in-flight worker): keep the serial lock + slot
+                # held until the close future actually completes (release fires
+                # from its done-callback) while letting the response proceed.
+                await asyncio.wait_for(
+                    asyncio.shield(close_future),
+                    timeout=_STREAM_GENERATOR_CLOSE_GRACE_SECONDS,
+                )
+            except asyncio.TimeoutError:
+                if self._reservation is not None:
+                    self._reservation.defer_release()
+                close_future.add_done_callback(lambda _done: self._release())
+                return
             except asyncio.CancelledError:
                 # The client task can be cancelled a second time while it is
                 # already unwinding. The queued close still owns the GPU
@@ -578,12 +623,43 @@ def _build_app(
 
     from ...middleware.auth import (
         configure_rate_limiter,
-        verify_api_key,
     )
     from ...middleware.body_depth import install_request_body_depth_middleware
     from ...middleware.body_size import install_request_body_limit_middleware
 
     configure_rate_limiter(rate_limit, enabled=rate_limit > 0)
+
+    from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+
+    from ...middleware.auth import _verify_api_key_values
+
+    _bearer_scheme = HTTPBearer(auto_error=False)
+
+    async def _verify_api_key_with_bearer_challenge(
+        credentials: HTTPAuthorizationCredentials | None = Depends(_bearer_scheme),
+    ) -> bool:
+        """``verify_api_key`` that attaches the RFC 6750 bearer challenge.
+
+        codex round-5 #5 / round-6 #1: the shared ``verify_api_key`` raises a
+        bare 401 (no ``WWW-Authenticate`` header). Any DFlash bearer-protected
+        route that used it directly returned an unchallenged 401. This wrapper
+        runs the same verification but re-raises the 401 WITH the challenge so
+        ``/v1/models`` is RFC-compliant, mirroring the chat route's ASGI
+        middleware — without editing the shared verifier (a different lane).
+        """
+        bearer_key = credentials.credentials if credentials is not None else None
+        try:
+            return _verify_api_key_values(bearer_key)
+        except HTTPException as exc:
+            if exc.status_code == 401:
+                headers = dict(exc.headers or {})
+                headers.setdefault("WWW-Authenticate", "Bearer")
+                raise HTTPException(
+                    status_code=exc.status_code,
+                    detail=exc.detail,
+                    headers=headers,
+                ) from exc
+            raise
 
     app = FastAPI(title="Rapid-MLX (DFlash)")
     # DFlash has one GPU worker and serializes generation with
@@ -663,7 +739,10 @@ def _build_app(
             "drafter": runtime.drafter_repo,
         }
 
-    @app.get("/v1/models", dependencies=[Depends(verify_api_key)])
+    @app.get(
+        "/v1/models",
+        dependencies=[Depends(_verify_api_key_with_bearer_challenge)],
+    )
     async def list_models() -> ModelsResponse:
         return ModelsResponse(
             data=[
@@ -842,8 +921,8 @@ def _build_app(
                         status_code=504,
                         detail=(
                             "DFlash prompt rendering exceeded the request "
-                            f"timeout of {request_timeout_for_diagnostics:.1f} "
-                            "seconds."
+                            "timeout of "
+                            f"{_format_timeout_seconds(request_timeout_for_diagnostics)}."
                         ),
                     ) from exc
 
@@ -881,7 +960,8 @@ def _build_app(
                         status_code=504,
                         detail=(
                             "DFlash request deadline elapsed during prompt "
-                            f"rendering (timeout {effective_timeout:.1f}s)."
+                            "rendering (timeout "
+                            f"{_format_timeout_seconds(request_timeout_for_diagnostics)})."
                         ),
                     )
                 effective_timeout = remaining_budget
@@ -1291,9 +1371,7 @@ async def _stream_completion(
             # generator to drive; the lease's deferred cleanup owns closing
             # the (possibly in-flight) worker.
             if gen_or_err is timed_out:
-                error_message = (
-                    f"DFlash stream timed out after {timeout_label:.1f} seconds."
-                )
+                error_message = f"DFlash stream timed out after {_format_timeout_seconds(timeout_label)}."
                 finish_reason = "length"
                 gen = None
             elif isinstance(gen_or_err, Exception):
@@ -1335,9 +1413,7 @@ async def _stream_completion(
                     # timeout immediately; the still-running token step is
                     # tracked by the lease and cleaned up (lock + slot held
                     # until it stops) via ``__aexit__``'s deferred path.
-                    error_message = (
-                        f"DFlash stream timed out after {timeout_label:.1f} seconds."
-                    )
+                    error_message = f"DFlash stream timed out after {_format_timeout_seconds(timeout_label)}."
                     finish_reason = "length"
                     break
                 if chunk is None:
@@ -1399,9 +1475,7 @@ async def _stream_completion(
                 try:
                     await _emit(f"data: {json.dumps(piece)}\n\n".encode())
                 except _DFlashStreamDeadlineError:
-                    error_message = (
-                        f"DFlash stream timed out after {timeout_label:.1f} seconds."
-                    )
+                    error_message = f"DFlash stream timed out after {_format_timeout_seconds(timeout_label)}."
                     finish_reason = "length"
                     break
                 except _DFlashClientGoneError:
@@ -1683,7 +1757,7 @@ async def _non_stream_completion(
             _defer_worker_cleanup()
         raise HTTPException(
             status_code=504,
-            detail=f"DFlash request timed out after {timeout_label:.1f} seconds.",
+            detail=f"DFlash request timed out after {_format_timeout_seconds(timeout_label)}.",
         ) from exc
     except asyncio.CancelledError:
         if lock_acquired and worker_future is not None:


### PR DESCRIPTION
# Summary

Brings the dedicated DFlash FastAPI application under the same resolved security and resource-governance policy as `rapid-mlx serve`.

## Root cause

DFlash bypasses the unified server application. Although the CLI parsed API-key, rate-limit, request-body, timeout, concurrency, and CORS policy, it did not pass or install those controls on DFlash's independent app.

## Changes

- Wire API-key auth, rate limiting, body depth/size limits, body receive timeout, request timeout, and `max_concurrent_requests` into DFlash.
- Add safe stream and non-stream timeout handling that retains the single GPU worker lock and admission slot until in-flight work and generator cleanup finish.
- Preserve full resolved CORS policy (origins, methods, headers, max-age, credentials) and normalize wildcard credentials before DFlash sees it.
- Add regression coverage for CLI plumbing, auth/rate/body enforcement, CORS, admission, timeouts, client cancellation, and worker cleanup ordering.

## Impact

`rapid-mlx serve ... --speculative-config '{"method":"dflash"}'` now enforces the operator's explicit safeguards instead of silently bypassing them. Health probes remain unauthenticated.

## Validation

- `pytest tests/ -q --ignore=tests/integrations --deselect tests/test_event_loop.py --deselect tests/test_batching_deterministic.py --deselect tests/test_reasoning_parsers.py`
  - 12,460 passed, 17 skipped, 212 deselected, 6 xfailed
- Security regression suite: 128 passed, 1 skipped
- `ruff check vllm_mlx/ tests/`
- `ruff format --check vllm_mlx/ tests/`
- `python3 scripts/audit_cli_config_fidelity.py`
- Two independent Codex review rounds, converged with no remaining blockers.
