### PR TITLE
feat(cache): opt-in bounded trim-free prefix reuse for hybrid models (fixes #1103)

### DIFF
--- a/tests/test_cli_bench_hybrid_cache_flag.py
+++ b/tests/test_cli_bench_hybrid_cache_flag.py
@@ -1,57 +1,98 @@
 # SPDX-License-Identifier: Apache-2.0
-"""#1103 codex BLOCKING-2: ``--hybrid-cache-entries`` must be honored by the
-benchmark path, not only ``serve``.
+"""#1103 codex BLOCKING-2 / BLOCKING-3: ``--hybrid-cache-entries`` must be
+honored by the benchmark path (not only ``serve``), and the test that proves
+it must run fully OFFLINE.
 
-The bench MemoryCacheConfig assembly reads ``args.hybrid_cache_entries`` (via
-``getattr(..., 0)``), but the flag was originally registered ONLY on
-``serve_parser``. So ``rapid-mlx bench --hybrid-cache-entries N`` was rejected
-by argparse (``unrecognized arguments``) and, had a caller reached the config
-assembly, it would have silently fallen back to 0 — meaning bench could never
-measure the hybrid-reuse effect the flag exists to expose.
+The bench ``SchedulerConfig`` assembly reads ``args.hybrid_cache_entries`` (via
+``getattr(..., 0)``) at ``cli.py`` and passes it as
+``hybrid_cache_entries=...``; the scheduler then forwards it to the memory
+cache as ``hybrid_reuse_max_entries``. The flag was originally registered ONLY
+on ``serve_parser``, so ``rapid-mlx bench --hybrid-cache-entries N`` was
+rejected by argparse and, had a caller reached the config assembly, it would
+have silently fallen back to 0.
 
-Verified via ``--help`` capture + a real parse attempt (subprocess) because
-the argparse parser is inlined into ``main()`` rather than exposed through a
-``build_parser`` helper — same approach as ``tests/test_kv_cache_dtype_cli.py``.
+These tests exercise the real ``main()`` parser AND the real ``bench_command``
+plumbing in-process, mocking only the model-loading / disk / network
+boundaries, so:
+
+* BLOCKING-2 — we assert the parsed value ACTUALLY arrives at
+  ``SchedulerConfig(hybrid_cache_entries=4)``. If the ``cli.py`` bench plumbing
+  line is deleted, this test fails (the argparse-only check could not).
+* BLOCKING-3 — NO network access happens: the disk/memory checks, the mirror
+  pre-fetch (``_ensure_model_downloaded``) and ``mlx_lm.load`` are all mocked,
+  and the download gate is skipped under a non-TTY stdin, so a bogus HF-style
+  model id never triggers external resolution / 60s retry timeouts.
 """
 
 from __future__ import annotations
 
-import subprocess
 import sys
+from unittest import mock
+
+import pytest
+
+import vllm_mlx.cli as cli
+
+# Pre-import ``engine_core`` so its module-level ``SchedulerConfig | None``
+# annotation evaluates against the REAL class BEFORE any test patches
+# ``vllm_mlx.scheduler.SchedulerConfig``. ``bench_command`` imports it lazily
+# (``from .engine_core import ...``); with the module already in ``sys.modules``
+# that is a pure name rebind — the class body never re-runs under the patch.
+import vllm_mlx.engine_core as _engine_core  # noqa: E402,F401
 
 
-def _bench_help() -> str:
-    proc = subprocess.run(
-        [sys.executable, "-m", "vllm_mlx.cli", "bench", "--help"],
-        capture_output=True,
-        text=True,
-        timeout=30,
-    )
-    assert proc.returncode == 0, proc.stderr
-    return proc.stdout
+class _StopBenchError(Exception):
+    """Sentinel raised right after SchedulerConfig is built to short-circuit
+    the benchmark before any engine boot."""
 
 
-def test_bench_help_advertises_hybrid_cache_entries_flag():
-    """The flag must appear in ``rapid-mlx bench --help`` — proof it is
-    registered on the benchmark parser, matching serve."""
-    text = _bench_help()
-    assert "--hybrid-cache-entries" in text
+def _run_bench_capturing_scheduler_config(argv: list[str]) -> dict:
+    """Drive ``cli.main()`` for a ``bench`` invocation with every model-loading
+    and network boundary mocked, capturing the kwargs passed to
+    ``SchedulerConfig``. Returns those kwargs.
 
-
-def test_bench_accepts_hybrid_cache_entries_flag():
-    """``rapid-mlx bench <model> --hybrid-cache-entries 4`` must PARSE — i.e.
-    argparse must not reject the flag with 'unrecognized arguments'.
-
-    We can't run a full benchmark in a unit test (it would download weights),
-    so we assert on the negative: whatever the run does downstream, it must
-    NOT die at the argparse layer complaining about the flag. Before the fix
-    the bench parser rejected it outright.
+    Raises ``AssertionError`` if ``SchedulerConfig`` was never constructed
+    (i.e. the flow died before the plumbing under test).
     """
-    proc = subprocess.run(
+    captured: dict = {}
+
+    def _fake_scheduler_config(*args, **kwargs):
+        assert not args, "bench builds SchedulerConfig keyword-only"
+        captured.update(kwargs)
+        # Stop before EngineConfig / engine boot — the value has arrived, which
+        # is all this test needs to prove.
+        raise _StopBenchError
+
+    with (
+        mock.patch.object(cli, "_check_disk_space", lambda *a, **k: None),
+        mock.patch.object(cli, "_check_memory_capacity", lambda *a, **k: None),
+        mock.patch.object(cli, "_ensure_model_downloaded", lambda *a, **k: None),
+        # ``bench_command`` does ``from mlx_lm import load`` — patch at source.
+        mock.patch("mlx_lm.load", return_value=(object(), object())),
+        # ``bench_command`` does ``from .scheduler import SchedulerConfig`` —
+        # patch on the scheduler module so the local import binds the mock.
+        mock.patch("vllm_mlx.scheduler.SchedulerConfig", _fake_scheduler_config),
+        mock.patch.object(sys, "argv", ["rapid-mlx", *argv]),
+        # Guarantee the non-interactive path so the download gate never
+        # touches the HF API even if a runner attaches a TTY.
+        mock.patch.object(sys.stdin, "isatty", return_value=False),
+        pytest.raises((_StopBenchError, SystemExit)),
+    ):
+        cli.main()
+
+    assert captured, (
+        "SchedulerConfig was never constructed — the bench flow died before "
+        "reaching the hybrid-cache plumbing under test"
+    )
+    return captured
+
+
+def test_bench_hybrid_cache_entries_reaches_scheduler_config():
+    """BLOCKING-2: the parsed ``--hybrid-cache-entries 4`` must actually arrive
+    at ``SchedulerConfig(hybrid_cache_entries=4)`` — guarding the bench plumbing
+    line, not merely that argparse accepted the flag."""
+    captured = _run_bench_capturing_scheduler_config(
         [
-            sys.executable,
-            "-m",
-            "vllm_mlx.cli",
             "bench",
             "does-not-exist/definitely-not-a-real-model",
             "--hybrid-cache-entries",
@@ -60,23 +101,42 @@ def test_bench_accepts_hybrid_cache_entries_flag():
             "1",
             "--max-tokens",
             "1",
-        ],
-        capture_output=True,
-        text=True,
-        timeout=60,
+        ]
     )
-    combined = proc.stdout + proc.stderr
-    # The flag itself must be accepted by argparse. Any downstream failure
-    # (bad model, no weights) is fine and expected — but NOT an argparse
-    # 'unrecognized arguments' rejection of our flag.
-    assert "unrecognized arguments" not in combined, combined
-    assert "--hybrid-cache-entries" not in _argparse_error_lines(combined), combined
+    assert captured.get("hybrid_cache_entries") == 4
 
 
-def _argparse_error_lines(text: str) -> str:
-    """Return only the lines argparse emits on a usage error, so a legitimate
-    mention of the flag elsewhere (e.g. a downstream log) doesn't mask a real
-    'unrecognized arguments' rejection."""
-    return "\n".join(
-        line for line in text.splitlines() if "error:" in line or "usage:" in line
+def test_bench_hybrid_cache_entries_defaults_to_zero():
+    """Without the flag the bench path must pass ``hybrid_cache_entries=0`` —
+    the #1075 drop-at-store default (opt-in stays off)."""
+    captured = _run_bench_capturing_scheduler_config(
+        [
+            "bench",
+            "does-not-exist/definitely-not-a-real-model",
+            "--num-prompts",
+            "1",
+            "--max-tokens",
+            "1",
+        ]
     )
+    assert captured.get("hybrid_cache_entries") == 0
+
+
+def test_bench_rejects_negative_hybrid_cache_entries():
+    """A negative value is nonsensical (the bound is ``>= 0``); argparse must
+    still PARSE it (the memory cache validates ``>= 0`` downstream), so this
+    only asserts the flag is registered on the bench parser and flows through
+    unchanged — i.e. plumbing is present."""
+    captured = _run_bench_capturing_scheduler_config(
+        [
+            "bench",
+            "does-not-exist/definitely-not-a-real-model",
+            "--hybrid-cache-entries",
+            "2",
+            "--num-prompts",
+            "1",
+            "--max-tokens",
+            "1",
+        ]
+    )
+    assert captured.get("hybrid_cache_entries") == 2

--- a/tests/test_cli_bench_hybrid_cache_flag.py
+++ b/tests/test_cli_bench_hybrid_cache_flag.py
@@ -123,20 +123,40 @@ def test_bench_hybrid_cache_entries_defaults_to_zero():
 
 
 def test_bench_rejects_negative_hybrid_cache_entries():
-    """A negative value is nonsensical (the bound is ``>= 0``); argparse must
-    still PARSE it (the memory cache validates ``>= 0`` downstream), so this
-    only asserts the flag is registered on the bench parser and flows through
-    unchanged — i.e. plumbing is present."""
+    """A negative value is nonsensical (the bound is ``>= 0``). argparse PARSES
+    it unchanged (``type=int`` does not clamp), so ``--hybrid-cache-entries -1``
+    flows through the bench plumbing into ``SchedulerConfig(hybrid_cache_entries
+    =-1)`` — and, at engine boot, the scheduler feeds that straight into
+    ``MemoryCacheConfig(hybrid_reuse_max_entries=...)`` (scheduler.py:1976),
+    whose ``__post_init__`` rejects ``< 0`` (memory_cache.py:844).
+
+    A positive-value assertion cannot prove the rejection — it would stay green
+    even if the ``>= 0`` guard were deleted. So here we (1) drive the real CLI /
+    ``SchedulerConfig`` assembly to confirm ``-1`` arrives UNCLAMPED, then
+    (2) reproduce the exact scheduler → cache mapping and assert the real
+    ``MemoryCacheConfig`` construction raises. Fully offline: no engine boot,
+    no network (the helper mocks every model-loading / disk / network
+    boundary)."""
+    from vllm_mlx.memory_cache import MemoryCacheConfig
+
     captured = _run_bench_capturing_scheduler_config(
         [
             "bench",
             "does-not-exist/definitely-not-a-real-model",
             "--hybrid-cache-entries",
-            "2",
+            "-1",
             "--num-prompts",
             "1",
             "--max-tokens",
             "1",
         ]
     )
-    assert captured.get("hybrid_cache_entries") == 2
+    # (1) The negative value reaches SchedulerConfig UNCLAMPED (nothing between
+    # argparse and the scheduler config sanitizes it away).
+    assert captured.get("hybrid_cache_entries") == -1
+
+    # (2) Feeding that scheduler value into MemoryCacheConfig exactly as
+    # scheduler.py:1976 does must raise — this is the guard the bench flow
+    # would trip at engine boot.
+    with pytest.raises(ValueError, match=r"hybrid_reuse_max_entries must be >= 0"):
+        MemoryCacheConfig(hybrid_reuse_max_entries=captured["hybrid_cache_entries"])

--- a/tests/test_cli_bench_hybrid_cache_flag.py
+++ b/tests/test_cli_bench_hybrid_cache_flag.py
@@ -1,0 +1,82 @@
+# SPDX-License-Identifier: Apache-2.0
+"""#1103 codex BLOCKING-2: ``--hybrid-cache-entries`` must be honored by the
+benchmark path, not only ``serve``.
+
+The bench MemoryCacheConfig assembly reads ``args.hybrid_cache_entries`` (via
+``getattr(..., 0)``), but the flag was originally registered ONLY on
+``serve_parser``. So ``rapid-mlx bench --hybrid-cache-entries N`` was rejected
+by argparse (``unrecognized arguments``) and, had a caller reached the config
+assembly, it would have silently fallen back to 0 — meaning bench could never
+measure the hybrid-reuse effect the flag exists to expose.
+
+Verified via ``--help`` capture + a real parse attempt (subprocess) because
+the argparse parser is inlined into ``main()`` rather than exposed through a
+``build_parser`` helper — same approach as ``tests/test_kv_cache_dtype_cli.py``.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+
+def _bench_help() -> str:
+    proc = subprocess.run(
+        [sys.executable, "-m", "vllm_mlx.cli", "bench", "--help"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert proc.returncode == 0, proc.stderr
+    return proc.stdout
+
+
+def test_bench_help_advertises_hybrid_cache_entries_flag():
+    """The flag must appear in ``rapid-mlx bench --help`` — proof it is
+    registered on the benchmark parser, matching serve."""
+    text = _bench_help()
+    assert "--hybrid-cache-entries" in text
+
+
+def test_bench_accepts_hybrid_cache_entries_flag():
+    """``rapid-mlx bench <model> --hybrid-cache-entries 4`` must PARSE — i.e.
+    argparse must not reject the flag with 'unrecognized arguments'.
+
+    We can't run a full benchmark in a unit test (it would download weights),
+    so we assert on the negative: whatever the run does downstream, it must
+    NOT die at the argparse layer complaining about the flag. Before the fix
+    the bench parser rejected it outright.
+    """
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "vllm_mlx.cli",
+            "bench",
+            "does-not-exist/definitely-not-a-real-model",
+            "--hybrid-cache-entries",
+            "4",
+            "--num-prompts",
+            "1",
+            "--max-tokens",
+            "1",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    combined = proc.stdout + proc.stderr
+    # The flag itself must be accepted by argparse. Any downstream failure
+    # (bad model, no weights) is fine and expected — but NOT an argparse
+    # 'unrecognized arguments' rejection of our flag.
+    assert "unrecognized arguments" not in combined, combined
+    assert "--hybrid-cache-entries" not in _argparse_error_lines(combined), combined
+
+
+def _argparse_error_lines(text: str) -> str:
+    """Return only the lines argparse emits on a usage error, so a legitimate
+    mention of the flag elsewhere (e.g. a downstream log) doesn't mask a real
+    'unrecognized arguments' rejection."""
+    return "\n".join(
+        line for line in text.splitlines() if "error:" in line or "usage:" in line
+    )

--- a/tests/test_hybrid_prefix_cache_growth.py
+++ b/tests/test_hybrid_prefix_cache_growth.py
@@ -433,6 +433,45 @@ def test_hybrid_bound_is_enforced(reuse_cache):
     assert stats["evictions"] >= 1
 
 
+def test_hybrid_bound_evicts_by_recency_not_insertion_order(reuse_cache):
+    """#1103 codex NIT-3: the bound is LRU, not FIFO — a cache HIT must
+    refresh an entry's recency so it survives a later eviction.
+
+    ``test_hybrid_bound_is_enforced`` only ever stores (never fetches), so
+    insertion order == recency order there and it can't distinguish LRU from
+    FIFO. Here we store chain_a then chain_b, then FETCH chain_a (an exact
+    trim-free hit that must bump it to most-recent), then store chain_c. Under
+    LRU the least-recently-used is now chain_b, so chain_b — NOT the
+    first-inserted chain_a — must be the one evicted.
+    """
+    chain_a = list(range(1000, 1100))
+    chain_b = list(range(2000, 2100))
+    chain_c = list(range(3000, 3100))
+
+    reuse_cache.store(chain_a, _hybrid_cache())
+    reuse_cache.store(chain_b, _hybrid_cache())
+
+    # Exact-match hit on chain_a — trim-free, so a retained hybrid entry
+    # serves it AND its recency is refreshed to most-recently-used.
+    result, remaining = reuse_cache.fetch(chain_a)
+    assert result is not None, "Exact match on chain_a must hit (trim-free)"
+    assert remaining == []
+
+    # Now the LRU order is [chain_b (oldest), chain_a (newest)]. Storing
+    # chain_c pushes the count to 3 > bound 2, so the OLDEST (chain_b) goes.
+    reuse_cache.store(chain_c, _hybrid_cache())
+
+    stats = reuse_cache.get_stats()
+    assert stats["non_trimmable_entries"] == 2, "Bound of 2 must hold"
+    assert tuple(chain_b) not in reuse_cache._entries, (
+        "chain_b was least-recently-used and must be evicted (LRU, not FIFO)"
+    )
+    assert tuple(chain_a) in reuse_cache._entries, (
+        "chain_a was refreshed by its fetch hit and must survive"
+    )
+    assert tuple(chain_c) in reuse_cache._entries
+
+
 def test_hybrid_bound_does_not_evict_dense_entries(reuse_cache):
     """The hybrid bound only ever evicts non-trimmable entries — dense
     KV-only entries are invisible to it."""
@@ -498,4 +537,134 @@ def test_hybrid_entry_memory_reaches_the_ledger(reuse_cache):
     assert entry.non_trimmable is True
     assert entry.memory_bytes >= 1000, (
         "ArraysCache state bytes must be included in the entry's ledger size"
+    )
+
+
+# ---------------------------------------------------------------------------
+# #1103 codex BLOCKING-1: the hybrid bound must be enforced on the
+# PERSISTENT-LOAD path too, not only at store time. A snapshot written while
+# the opt-in was enabled can be reloaded on restart under a DIFFERENT (or
+# absent) ``hybrid_reuse_max_entries``. Before the fix, loaded entries were
+# flagged non-trimmable but NEVER subjected to the bound — so a restart could
+# retain entries ABOVE N, or retain them at all when N == 0, breaking BOTH the
+# opt-in and the bounded guarantee (the "default is byte-for-byte unchanged"
+# property). These tests use REAL mlx-lm cache objects so the save/load round-
+# trip through safetensors is exercised end-to-end, not mocked.
+# ---------------------------------------------------------------------------
+
+
+def _real_hybrid_cache(seqlen: int = 8):
+    """A real (KVCache + ArraysCache) hybrid cache populated with mx arrays so
+    it survives ``save_prompt_cache`` / ``load_prompt_cache`` round-trips.
+
+    KVCache is trimmable (transformer attention); ArraysCache is the non-
+    trimmable recurrent state (GatedDeltaNet / Mamba) that the bound governs.
+    """
+    import mlx.core as mx
+    from mlx_lm.models.cache import ArraysCache, KVCache
+
+    kv = KVCache()
+    kv.update_and_fetch(
+        mx.random.normal((1, 2, seqlen, 4)),
+        mx.random.normal((1, 2, seqlen, 4)),
+    )
+    arr = ArraysCache(size=2)
+    arr[0] = mx.random.normal((1, 4, 4))
+    arr[1] = mx.random.normal((1, 4, 4))
+    mx.eval(kv.state, arr.state)
+    return [kv, arr]
+
+
+def _persist_three_hybrid_entries(tmp_path) -> str:
+    """Store 3 hybrid entries under a generous bound and save them to disk.
+    Returns the snapshot directory. All 3 are retained on the source side so
+    the RELOAD side is what exercises the bound."""
+    src_config = MemoryCacheConfig(
+        max_memory_mb=100, max_entries=64, hybrid_reuse_max_entries=9
+    )
+    src = MemoryAwarePrefixCache(MagicMock(), src_config)
+    for base in (1000, 2000, 3000):
+        assert src.store(list(range(base, base + 8)), _real_hybrid_cache()) is True
+    assert src.get_stats()["non_trimmable_entries"] == 3
+
+    cache_dir = str(tmp_path / "snap")
+    assert src.save_to_disk(cache_dir) is True
+    return cache_dir
+
+
+def test_persistent_load_respects_hybrid_bound(tmp_path):
+    """Reloading a snapshot of 3 hybrid entries with N=1 must retain only 1 —
+    the bound is applied at commit time, exactly like the store path."""
+    cache_dir = _persist_three_hybrid_entries(tmp_path)
+
+    dst_config = MemoryCacheConfig(
+        max_memory_mb=100, max_entries=64, hybrid_reuse_max_entries=1
+    )
+    dst = MemoryAwarePrefixCache(MagicMock(), dst_config)
+    loaded = dst.load_from_disk(cache_dir, replace=True)
+
+    stats = dst.get_stats()
+    assert stats["non_trimmable_entries"] == 1, (
+        "Persistent load must LRU-trim hybrid entries down to the bound"
+    )
+    assert len(dst._entries) == 1
+    # The reported loaded count must reflect only SURVIVING entries, not the
+    # 3 that were staged before the bound trimmed 2 away.
+    assert loaded == 1
+
+
+def test_persistent_load_drops_all_when_disabled(tmp_path):
+    """Reloading with N=0 (the default / disabled state) must drop ALL non-
+    trimmable entries — byte-for-byte the #1075 drop-at-store behavior applied
+    after a restart. This is the core "default is unchanged" guarantee."""
+    cache_dir = _persist_three_hybrid_entries(tmp_path)
+
+    dst_config = MemoryCacheConfig(
+        max_memory_mb=100, max_entries=64, hybrid_reuse_max_entries=0
+    )
+    dst = MemoryAwarePrefixCache(MagicMock(), dst_config)
+    loaded = dst.load_from_disk(cache_dir, replace=True)
+
+    stats = dst.get_stats()
+    assert stats["non_trimmable_entries"] == 0, (
+        "With reuse disabled, a restart must retain NO non-trimmable entries"
+    )
+    assert len(dst._entries) == 0
+    assert loaded == 0
+
+
+def test_persistent_load_keeps_trimmable_entries_when_disabled(tmp_path):
+    """The disabled-state drop is scoped to NON-trimmable entries only — a
+    persisted dense (all-KVCache) entry must still reload normally with N=0."""
+    import mlx.core as mx
+    from mlx_lm.models.cache import KVCache
+
+    src_config = MemoryCacheConfig(
+        max_memory_mb=100, max_entries=64, hybrid_reuse_max_entries=9
+    )
+    src = MemoryAwarePrefixCache(MagicMock(), src_config)
+
+    dense = KVCache()
+    dense.update_and_fetch(
+        mx.random.normal((1, 2, 8, 4)),
+        mx.random.normal((1, 2, 8, 4)),
+    )
+    mx.eval(dense.state)
+    dense_key = list(range(500, 508))
+    assert src.store(dense_key, [dense]) is True
+    # One hybrid entry too, so we can prove the drop is selective.
+    src.store(list(range(1000, 1008)), _real_hybrid_cache())
+
+    cache_dir = str(tmp_path / "snap")
+    assert src.save_to_disk(cache_dir) is True
+
+    dst_config = MemoryCacheConfig(
+        max_memory_mb=100, max_entries=64, hybrid_reuse_max_entries=0
+    )
+    dst = MemoryAwarePrefixCache(MagicMock(), dst_config)
+    dst.load_from_disk(cache_dir, replace=True)
+
+    assert dst.get_stats()["non_trimmable_entries"] == 0
+    assert tuple(dense_key) in dst._entries, (
+        "Dense (trimmable) entries must survive an N=0 reload"
     )

--- a/tests/test_hybrid_prefix_cache_growth.py
+++ b/tests/test_hybrid_prefix_cache_growth.py
@@ -668,3 +668,47 @@ def test_persistent_load_keeps_trimmable_entries_when_disabled(tmp_path):
     assert tuple(dense_key) in dst._entries, (
         "Dense (trimmable) entries must survive an N=0 reload"
     )
+
+
+def test_merge_load_into_full_hybrid_cache_counts_only_imported(tmp_path):
+    """#1103 codex BLOCKING-1: merge-loading (replace=False) ONE new hybrid
+    entry into a cache already AT the bound must report ``loaded == 1``.
+
+    The bound pass runs at commit and, being LRU, evicts the PRE-EXISTING
+    entry (older) to make room for the freshly imported one. That eviction
+    must NOT be subtracted from the import's ``loaded`` tally — the old code
+    subtracted every bound eviction and returned 0 (or corrupted the byte
+    total) for a load that actually installed a new entry.
+    """
+    # Snapshot on disk: a single NEW hybrid entry to import.
+    src_config = MemoryCacheConfig(
+        max_memory_mb=100, max_entries=64, hybrid_reuse_max_entries=9
+    )
+    src = MemoryAwarePrefixCache(MagicMock(), src_config)
+    assert src.store(list(range(7000, 7008)), _real_hybrid_cache()) is True
+    cache_dir = str(tmp_path / "snap")
+    assert src.save_to_disk(cache_dir) is True
+
+    # Destination already holds a pre-existing hybrid entry and the bound is
+    # N=1, so it is already FULL before the import.
+    dst_config = MemoryCacheConfig(
+        max_memory_mb=100, max_entries=64, hybrid_reuse_max_entries=1
+    )
+    dst = MemoryAwarePrefixCache(MagicMock(), dst_config)
+    assert dst.store(list(range(9000, 9008)), _real_hybrid_cache()) is True
+    assert dst.get_stats()["non_trimmable_entries"] == 1
+
+    loaded = dst.load_from_disk(cache_dir, replace=False)
+
+    # The imported entry survived the bound (it is the most-recent), the
+    # pre-existing one was LRU-evicted — but that eviction belongs to the
+    # destination, not this import, so the imported count stays 1.
+    assert loaded == 1, (
+        "Merge-load must count the surviving imported entry, not net it "
+        "against the pre-existing entry the bound evicted"
+    )
+    assert dst.get_stats()["non_trimmable_entries"] == 1
+    assert tuple(range(7000, 7008)) in dst._entries
+    assert tuple(range(9000, 9008)) not in dst._entries
+    # loaded_bytes ledger must stay coherent (non-negative, matches survivor).
+    assert dst._last_load_bytes > 0

--- a/tests/test_hybrid_prefix_cache_growth.py
+++ b/tests/test_hybrid_prefix_cache_growth.py
@@ -30,6 +30,19 @@ cross-conversation leak. The tests below encode the NEW policy; the previous
 
 Dense (all-``KVCache``) models are unaffected — their state is trimmable and
 still cached/reused normally.
+
+#1103 refinement (opt-in bounded trim-free reuse)
+-------------------------------------------------
+Issue #1103 showed a workload where the #214 reuse was real, not synthetic:
+a byte-stable system prompt + tools with append-only history produces clean
+prefix-extension matches, which fetch serves WITHOUT trimming (the leak's
+trim-side guards never applied to exact / prefix-extension matches). With
+``hybrid_reuse_max_entries = N > 0`` (CLI ``--hybrid-cache-entries N``),
+``store`` retains up to N non-trimmable entries — LRU-evicted among
+themselves so #1025's unbounded unique-superset accumulation cannot recur —
+and fetch keeps refusing the trim-requiring paths. The default (0) preserves
+the drop-at-store policy above byte-for-byte; the original policy tests are
+unchanged. The opt-in tests live in the "#1103" section at the bottom.
 """
 
 from unittest.mock import MagicMock
@@ -285,3 +298,204 @@ def test_hybrid_supersequence_still_skipped(cache):
         "Trim-required match on non-trimmable hybrid layers must still skip"
     )
     assert remaining == short_request
+
+
+# ---------------------------------------------------------------------------
+# #1103: opt-in bounded trim-free reuse (hybrid_reuse_max_entries > 0).
+#
+# The trim-free fetch paths (exact match, prefix-extension) never needed the
+# non-trimmable guard — resuming a stored prefix at its own token boundary
+# requires no trim. These tests cover the opt-in policy that stores hybrid
+# entries for exactly those paths, bounded so #1025 cannot recur.
+# ---------------------------------------------------------------------------
+
+
+class ArraysCacheLayer:
+    """Mirror mlx-lm ``ArraysCache``: ``state`` is a flat list of N arrays
+    (N is model-defined — NOT always 2), no ``keys``/``values`` attributes."""
+
+    def __init__(self, n_arrays: int = 3, nbytes_each: int = 100):
+        self._arrays = [_MockArray(nbytes_each) for _ in range(n_arrays)]
+
+    @property
+    def state(self):
+        return self._arrays
+
+    def is_trimmable(self) -> bool:
+        return False
+
+
+class CacheListLayer:
+    """Mirror mlx-lm ``CacheList``: ``state`` is a NESTED list of the wrapped
+    caches' states; trimmable only if every wrapped cache is."""
+
+    def __init__(self, *caches):
+        self._caches = caches
+
+    @property
+    def state(self):
+        return [c.state for c in self._caches]
+
+    def is_trimmable(self) -> bool:
+        return all(c.is_trimmable() for c in self._caches)
+
+
+@pytest.fixture
+def reuse_cache():
+    """Cache with the #1103 opt-in enabled (bound of 2 hybrid entries)."""
+    config = MemoryCacheConfig(
+        max_memory_mb=10, max_entries=64, hybrid_reuse_max_entries=2
+    )
+    return MemoryAwarePrefixCache(MagicMock(), config)
+
+
+def test_hybrid_store_retained_when_enabled(reuse_cache):
+    """With the opt-in, hybrid entries are stored (and not counted as skips)."""
+    prompt = list(range(1000, 1100))
+
+    assert reuse_cache.store(prompt, _hybrid_cache()) is True
+    assert tuple(prompt) in reuse_cache._entries
+    assert reuse_cache.get_stats()["non_trimmable_skips"] == 0
+    assert reuse_cache.get_stats()["non_trimmable_entries"] == 1
+
+
+def test_hybrid_exact_match_hit_when_enabled(reuse_cache):
+    """Exact match is trim-free — a retained hybrid entry must serve it."""
+    prompt = list(range(1000, 1100))
+    reuse_cache.store(prompt, _hybrid_cache())
+
+    result, remaining = reuse_cache.fetch(prompt)
+
+    assert result is not None, "Exact match needs no trim — hybrid entry must hit"
+    assert remaining == []
+
+
+def test_hybrid_prefix_extension_hit_when_enabled(reuse_cache):
+    """The #214 growing-conversation shape works again under the opt-in:
+    stored ``[P + R1]`` serves turn-2's ``[P + R1 + M2]`` as a prefix match
+    (no trim — the RNN state at end-of-stored is the state M2 prefill needs).
+    """
+    prompt = list(range(1000, 1100))
+    response_1 = [9001, 9002]
+    new_msg = list(range(2000, 2050))
+
+    reuse_cache.store(prompt + response_1, _hybrid_cache())
+
+    turn_2 = prompt + response_1 + new_msg
+    result, remaining = reuse_cache.fetch(turn_2)
+
+    assert result is not None, "Prefix-extension is trim-free — must hit"
+    assert remaining == new_msg
+
+
+def test_hybrid_trim_paths_still_refused_when_enabled(reuse_cache):
+    """The opt-in must NOT re-open the trim-requiring paths: a shorter request
+    against a longer stored hybrid entry (supersequence-with-excess, then LCP
+    fallback) still misses."""
+    long_stored = list(range(1000, 1200))
+    reuse_cache.store(long_stored, _hybrid_cache())
+
+    short_request = list(range(1000, 1100))
+    result, remaining = reuse_cache.fetch(short_request)
+
+    assert result is None, "Trim-required reuse of hybrid state must still be refused"
+    assert remaining == short_request
+
+
+def test_hybrid_divergent_lcp_still_refused_when_enabled(reuse_cache):
+    """Same-prefix-different-suffix (LCP shape) requires trimming the stored
+    entry — still refused for hybrid entries under the opt-in."""
+    prompt = list(range(1000, 1100))
+    reuse_cache.store(prompt + [9001, 9002], _hybrid_cache())
+
+    divergent = prompt + [9003, 9004]
+    result, _remaining = reuse_cache.fetch(divergent)
+
+    assert result is None, "LCP reuse trims the stored entry — must stay refused"
+
+
+def test_hybrid_bound_is_enforced(reuse_cache):
+    """Storing more hybrid entries than the bound LRU-evicts the oldest —
+    the #1025 unbounded unique-superset accumulation cannot recur."""
+    chain_a = list(range(1000, 1100))
+    chain_b = list(range(2000, 2100))
+    chain_c = list(range(3000, 3100))
+
+    reuse_cache.store(chain_a, _hybrid_cache())
+    reuse_cache.store(chain_b, _hybrid_cache())
+    reuse_cache.store(chain_c, _hybrid_cache())
+
+    stats = reuse_cache.get_stats()
+    assert stats["non_trimmable_entries"] == 2, "Bound of 2 must hold"
+    assert tuple(chain_a) not in reuse_cache._entries, "Oldest chain evicted"
+    assert tuple(chain_b) in reuse_cache._entries
+    assert tuple(chain_c) in reuse_cache._entries
+    assert stats["evictions"] >= 1
+
+
+def test_hybrid_bound_does_not_evict_dense_entries(reuse_cache):
+    """The hybrid bound only ever evicts non-trimmable entries — dense
+    KV-only entries are invisible to it."""
+    dense_key = list(range(500, 600))
+    reuse_cache.store(dense_key, _dense_cache())
+
+    for base in (1000, 2000, 3000, 4000):
+        reuse_cache.store(list(range(base, base + 100)), _hybrid_cache())
+
+    assert tuple(dense_key) in reuse_cache._entries, (
+        "Dense entry must survive hybrid-bound evictions"
+    )
+    assert reuse_cache.get_stats()["non_trimmable_entries"] == 2
+
+
+def test_default_config_keeps_drop_policy():
+    """No config change → byte-for-byte #1075 behavior (drop at store)."""
+    config = MemoryCacheConfig(max_memory_mb=10, max_entries=64)
+    c = MemoryAwarePrefixCache(MagicMock(), config)
+
+    assert c.store(list(range(1000, 1100)), _hybrid_cache()) is False
+    assert c.get_stats()["non_trimmable_skips"] == 1
+    assert c.get_stats()["non_trimmable_entries"] == 0
+
+
+# ---------------------------------------------------------------------------
+# #1103: recurrent-state byte accounting. ``ArraysCache.state`` is an N-array
+# list and ``CacheList.state`` is nested — both previously slipped through the
+# ``keys, values = state`` unpack and contributed 0 bytes to the eviction
+# ledger, so the very entries #1025 needed the budget to see were invisible
+# to it.
+# ---------------------------------------------------------------------------
+
+
+def test_arrayscache_state_bytes_are_counted():
+    from vllm_mlx.memory_cache import estimate_kv_cache_memory
+
+    # 3 state arrays (not the (keys, values) pair shape) × 100 bytes.
+    layer = ArraysCacheLayer(n_arrays=3, nbytes_each=100)
+    assert estimate_kv_cache_memory([layer]) == 300
+
+
+def test_cachelist_nested_state_bytes_are_counted():
+    from vllm_mlx.memory_cache import estimate_kv_cache_memory
+
+    # CacheList wrapping two ArraysCaches: nested state lists must be
+    # recursed into, not unpacked as (keys, values) and counted as 0.
+    layer = CacheListLayer(
+        ArraysCacheLayer(n_arrays=2, nbytes_each=100),
+        ArraysCacheLayer(n_arrays=2, nbytes_each=100),
+    )
+    assert estimate_kv_cache_memory([layer]) == 400
+
+
+def test_hybrid_entry_memory_reaches_the_ledger(reuse_cache):
+    """A stored hybrid entry's recurrent-state bytes must appear in
+    ``_current_memory`` so LRU / pressure eviction can actually act on it."""
+    prompt = list(range(1000, 1100))
+    cache_layers = [TrimmableLayer(), ArraysCacheLayer(n_arrays=2, nbytes_each=500)]
+
+    assert reuse_cache.store(prompt, cache_layers) is True
+    entry = reuse_cache._entries[tuple(prompt)]
+    assert entry.non_trimmable is True
+    assert entry.memory_bytes >= 1000, (
+        "ArraysCache state bytes must be included in the entry's ledger size"
+    )

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -2986,6 +2986,8 @@ def serve_command(args):
         use_memory_aware_cache=not args.no_memory_aware_cache,
         cache_memory_mb=args.cache_memory_mb,
         cache_memory_percent=args.cache_memory_percent,
+        # #1103: bounded trim-free hybrid (recurrent-state) prefix reuse.
+        hybrid_cache_entries=getattr(args, "hybrid_cache_entries", 0),
         # Paged cache options
         use_paged_cache=args.use_paged_cache,
         paged_cache_block_size=args.paged_cache_block_size,
@@ -4031,6 +4033,10 @@ def bench_command(args):
             use_memory_aware_cache=not args.no_memory_aware_cache,
             cache_memory_mb=args.cache_memory_mb,
             cache_memory_percent=args.cache_memory_percent,
+            # #1103: bounded trim-free hybrid (recurrent-state) prefix reuse.
+            # Bench path mirrors serve so hybrid-reuse effects show up in
+            # `rapid-mlx bench` numbers too.
+            hybrid_cache_entries=getattr(args, "hybrid_cache_entries", 0),
             # Paged cache options
             use_paged_cache=args.use_paged_cache,
             paged_cache_block_size=args.paged_cache_block_size,
@@ -6784,6 +6790,19 @@ Examples:
         type=float,
         default=0.20,
         help="Fraction of available RAM for cache if auto-detecting (default: 0.20)",
+    )
+    # #1103: bounded trim-free prefix reuse for hybrid (GatedDeltaNet /
+    # Mamba MoE) models. Opt-in: the default 0 keeps the #1075 policy of
+    # dropping recurrent-state entries at store time.
+    serve_parser.add_argument(
+        "--hybrid-cache-entries",
+        type=int,
+        default=0,
+        help=(
+            "Retain up to N hybrid (recurrent-state) prefix-cache entries for "
+            "exact/prefix-extension reuse; 0 disables (default: 0). Useful for "
+            "stable-system-prompt agent workloads on GatedDeltaNet/Mamba models."
+        ),
     )
     serve_parser.add_argument(
         "--no-memory-aware-cache",

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -7669,6 +7669,21 @@ Examples:
         default=256,
         help="Minimum tokens for quantization to apply (default: 256)",
     )
+    # #1103 codex BLOCKING-2: the bench path reads args.hybrid_cache_entries
+    # (see the MemoryCacheConfig assembly above) but the flag was only
+    # registered on serve_parser, so `rapid-mlx bench --hybrid-cache-entries N`
+    # was rejected and the getattr fell back to 0. Register it here too, with
+    # the same semantics/default as serve, so bench honors the knob.
+    bench_parser.add_argument(
+        "--hybrid-cache-entries",
+        type=int,
+        default=0,
+        help=(
+            "Retain up to N hybrid (recurrent-state) prefix-cache entries for "
+            "exact/prefix-extension reuse; 0 disables (default: 0). Useful for "
+            "stable-system-prompt agent workloads on GatedDeltaNet/Mamba models."
+        ),
+    )
     # Paged cache options (experimental)
     bench_parser.add_argument(
         "--use-paged-cache",

--- a/vllm_mlx/memory_cache.py
+++ b/vllm_mlx/memory_cache.py
@@ -1874,20 +1874,10 @@ class MemoryAwarePrefixCache:
                     )
 
             # #1103: dedicated LRU bound over non-trimmable (hybrid
-            # recurrent-state) entries. Their keys are unique supersets
-            # across conversations (#1025), so unlike KV-only entries they
-            # can pile up without ever being reclaimed by prefix-subset
-            # eviction — this bound is what keeps the recovered reuse from
-            # re-opening that leak. Scans in LRU order (``_entries`` is an
-            # ``OrderedDict``); O(entries) only on the hybrid store path.
+            # recurrent-state) entries — the recovered reuse can otherwise
+            # re-open the #1025 leak. Only the hybrid store path pays the scan.
             if entry.non_trimmable:
-                limit = self._config.hybrid_reuse_max_entries
-                non_trimmable_keys = [
-                    key for key, e in self._entries.items() if e.non_trimmable
-                ]
-                while len(non_trimmable_keys) > limit:
-                    oldest = non_trimmable_keys.pop(0)
-                    self._evict_entry_locked(oldest, reason="hybrid_bound")
+                self._enforce_hybrid_bound_locked()
 
         logger.debug(
             f"Stored cache: {len(tokens)} tokens, "
@@ -1940,6 +1930,47 @@ class MemoryAwarePrefixCache:
             f"[{reason}] removed {len(tokens_key)} tokens, "
             f"freed {entry.memory_bytes / _BYTES_PER_MB:.2f}MB"
         )
+
+    def _enforce_hybrid_bound_locked(self) -> tuple[int, int]:
+        """Enforce the ``hybrid_reuse_max_entries`` bound over non-trimmable
+        (hybrid recurrent-state) entries.
+
+        Caller must hold ``self._lock``. Returns ``(evicted_count,
+        evicted_bytes)`` so the persistent-load path can reconcile its
+        loaded-entry / loaded-byte tallies with what actually survived.
+
+        #1103: non-trimmable entries carry unique-superset keys across
+        conversations (#1025), so unlike KV-only entries they are never
+        reclaimed by prefix-subset eviction and can pile up unbounded. This
+        bound is the single source of truth for how many are retained and is
+        shared by BOTH the store path (after inserting a fresh non-trimmable
+        entry) and the persistent-load commit path (after installing a staged
+        set, which may carry legacy hybrid entries from a pre-#1075 snapshot).
+
+        Semantics MATCH the store-time gate exactly:
+
+        * ``hybrid_reuse_max_entries <= 0`` (disabled, the default) → drop ALL
+          non-trimmable entries, so a server restart that reloads a snapshot is
+          byte-for-byte the #1075 drop-at-store behavior — including retaining
+          NONE when N == 0.
+        * ``> 0`` → LRU-evict the oldest non-trimmable entries until at most N
+          remain. ``_entries`` is an ``OrderedDict`` in LRU order, so the head
+          of the filtered list is the least-recently-used.
+        """
+        limit = self._config.hybrid_reuse_max_entries
+        non_trimmable_keys = [
+            key for key, e in self._entries.items() if e.non_trimmable
+        ]
+        evicted_count = 0
+        evicted_bytes = 0
+        # limit <= 0 disables reuse: the ``> max(limit, 0)`` guard drops every
+        # non-trimmable entry (matches the store-path ``<= 0`` drop-at-store).
+        while len(non_trimmable_keys) > max(limit, 0):
+            oldest = non_trimmable_keys.pop(0)
+            evicted_bytes += self._entries[oldest].memory_bytes
+            self._evict_entry_locked(oldest, reason="hybrid_bound")
+            evicted_count += 1
+        return evicted_count, evicted_bytes
 
     def remove(self, tokens: list[int]) -> bool:
         """
@@ -3395,6 +3426,21 @@ class MemoryAwarePrefixCache:
                         continue
 
                 loaded_bytes += entry.memory_bytes
+
+            # #1103 codex BLOCKING-1: loaded snapshots can carry non-trimmable
+            # hybrid entries (flagged at staging above). Unlike the store path,
+            # nothing gated them on the way in, so a restart could retain them
+            # ABOVE ``hybrid_reuse_max_entries`` — or retain them at all when
+            # N == 0 — breaking both the opt-in AND the bounded guarantee.
+            # Enforce the SAME bound the store path applies: with N <= 0 this
+            # drops every non-trimmable entry (byte-for-byte #1075 after a
+            # restart); with N > 0 it LRU-trims down to N. Runs inside the
+            # commit critical section so a scraper never sees an over-bound
+            # cache. Reconcile the reported tallies so the import route counts
+            # only entries that SURVIVED the bound.
+            bound_evicted, bound_bytes = self._enforce_hybrid_bound_locked()
+            loaded -= bound_evicted
+            loaded_bytes -= bound_bytes
 
             self._stats.entry_count = len(self._entries)
             self._stats.current_memory_bytes = self._current_memory

--- a/vllm_mlx/memory_cache.py
+++ b/vllm_mlx/memory_cache.py
@@ -701,6 +701,29 @@ def _array_memory(arr) -> int:
     return 0
 
 
+def _state_memory(state: Any) -> int:
+    """Recursively sum array bytes in a cache layer's ``state``.
+
+    ``state`` shapes seen in the wild (mlx-lm 0.29+):
+      * ``KVCache.state``          → ``(keys, values)`` — two arrays.
+      * ``ArraysCache.state``      → ``list[array]`` of ANY length (e.g.
+        ``[conv_state, recurrent_state]`` for GatedDeltaNet, but the size
+        is model-defined — issue #1103 found sizes != 2 silently counted
+        as 0 bytes under the old ``keys, values = state`` unpack).
+      * ``CacheList.state``        → ``[c.state for c in caches]`` — a
+        NESTED list of the above. The old unpack "succeeded" on a
+        two-cache ``CacheList`` and then counted 0 bytes for both halves
+        (lists have no shape/dtype/nbytes), so recurrent-state entries
+        escaped the byte ledger entirely — the eviction budget never saw
+        the very entries #1025 needed it to reclaim.
+    """
+    if state is None:
+        return 0
+    if isinstance(state, (list, tuple)):
+        return sum(_state_memory(s) for s in state)
+    return _array_memory(state)
+
+
 def estimate_kv_cache_memory(cache: list[Any]) -> int:
     """
     Estimate memory usage of a KV cache in bytes.
@@ -746,11 +769,13 @@ def estimate_kv_cache_memory(cache: list[Any]) -> int:
                 total_bytes += _array_memory(arr)
             continue
         elif hasattr(layer_cache, "state") and not isinstance(layer_cache, dict):
-            # Cache with state property returning (keys, values)
+            # Cache with a ``state`` property: ``(keys, values)`` for KV
+            # classes, an N-array list for ``ArraysCache``, or a nested
+            # list for ``CacheList``. Summed recursively so recurrent-state
+            # arrays are counted instead of silently contributing 0 bytes
+            # (#1103 — they previously escaped the eviction byte ledger).
             try:
-                keys, values = layer_cache.state
-                total_bytes += _array_memory(keys)
-                total_bytes += _array_memory(values)
+                total_bytes += _state_memory(layer_cache.state)
             except (TypeError, ValueError):
                 pass
         elif hasattr(layer_cache, "keys") and hasattr(layer_cache, "values"):
@@ -795,6 +820,19 @@ class MemoryCacheConfig:
     kv_turboquant_bits: int | None = None  # None = auto-select by head_dim
     kv_turboquant_group_size: int = 32
     kv_turboquant_mode: str = "v4"
+    # #1103 (follow-up to #1025/#1058/#1075): bounded trim-free reuse for
+    # hybrid (GatedDeltaNet / Mamba MoE) recurrent-state entries.
+    #
+    #   0 (default)  — #1075 behavior: any entry carrying a non-trimmable
+    #                  recurrent-state layer is DROPPED at store time.
+    #   N > 0        — at most N such entries are retained, evicted LRU-first
+    #                  among themselves. Fetch serves them ONLY on the two
+    #                  trim-free match paths (exact and prefix-extension);
+    #                  the trim-requiring paths (supersequence-with-excess,
+    #                  LCP) still refuse them, so the #214-era within-
+    #                  conversation reuse comes back without re-opening the
+    #                  #1025 unbounded-retention leak.
+    hybrid_reuse_max_entries: int = 0
 
     def __post_init__(self) -> None:
         if not 0.0 < self.max_memory_percent <= 1.0:
@@ -803,6 +841,11 @@ class MemoryCacheConfig:
             )
         if self.max_entries < 1:
             raise ValueError(f"max_entries must be >= 1, got {self.max_entries}")
+        if self.hybrid_reuse_max_entries < 0:
+            raise ValueError(
+                "hybrid_reuse_max_entries must be >= 0, "
+                f"got {self.hybrid_reuse_max_entries}"
+            )
         if self.kv_min_quantize_tokens < 0:
             raise ValueError(
                 f"kv_min_quantize_tokens must be >= 0, got {self.kv_min_quantize_tokens}"
@@ -959,6 +1002,10 @@ class _CacheEntry:
     tokens: tuple[int, ...]
     cache: list[Any]
     memory_bytes: int
+    # #1103: True when any layer is a non-trimmable recurrent-state cache
+    # (hybrid GatedDeltaNet / Mamba MoE). Computed once at creation so the
+    # hybrid-bound eviction scan doesn't re-inspect layers per store.
+    non_trimmable: bool = False
 
     @classmethod
     def create(cls, tokens: list[int], cache: list[Any]) -> _CacheEntry:
@@ -968,6 +1015,7 @@ class _CacheEntry:
             tokens=tuple(tokens),
             cache=cache,
             memory_bytes=memory,
+            non_trimmable=_cache_has_non_trimmable(cache),
         )
 
 
@@ -1057,11 +1105,15 @@ def _needs_kv_trim(layer: Any) -> bool:
 # ratchets up holding leaked recurrent state while ``reserved KV`` stays ~0,
 # wedging the D-METAL-CAP admission gate / eventually OOM-crashing.
 #
-# The fetch path already refuses to reuse these entries (supersequence match
-# is skipped when any layer ``not is_trimmable()`` — see ``fetch`` above) AND
-# the paged path gates them out via ``prefix_cache._SEQ_AXIS_KV_CLASSES``. A
-# hybrid entry that fetch will never reuse but store retains forever is pure
-# leak: so we DROP it at store time (whole entry — see below).
+# The fetch path refuses to reuse these entries on the TRIM-REQUIRING match
+# paths (supersequence-with-excess and LCP are skipped when any layer ``not
+# is_trimmable()`` — see ``fetch`` above) AND the paged path gates them out
+# via ``prefix_cache._SEQ_AXIS_KV_CLASSES``. The two TRIM-FREE paths (exact
+# match and prefix-extension) can serve them safely — resuming a stored
+# prefix at its own token boundary needs no trim (#214, #1103). By default we
+# still DROP the whole entry at store time (leak-safe #1075 policy); setting
+# ``hybrid_reuse_max_entries > 0`` opts in to a BOUNDED number of retained
+# hybrid entries for trim-free reuse (see ``store``).
 #
 # For the dict-form extracted cache (block-aware path, where layers are
 # ``{"class_name": ...}`` dicts, not live objects) we cannot call
@@ -1669,19 +1721,29 @@ class MemoryAwarePrefixCache:
         # Reuse-cache gate for hybrid recurrent-state models (#1025 / #1058).
         #
         # If ANY layer is a non-trimmable recurrent-state cache (ArraysCache /
-        # CacheList-wrapping-one, from GatedDeltaNet / Mamba MoE models), DROP
-        # the whole entry rather than store it. Granularity = whole entry, not
-        # per-layer, because:
-        #   * reconstruction needs ALL layers (a half-populated entry with only
-        #     the KVCache layers cannot resume a hybrid model — mlx-lm rebuilds
-        #     the full cache list or nothing), and
-        #   * the fetch path already refuses to reuse an entry once any layer
-        #     is non-trimmable (supersequence match is skipped), so storing the
-        #     trimmable subset would only cost memory for zero reuse.
-        # Result: the per-request recurrent state has NO lingering reference in
-        # ``_entries`` and is reclaimed by ``mx.clear_cache()`` / GC once the
-        # request object drops its own reference in ``_cleanup_finished``.
-        if _cache_has_non_trimmable(cache):
+        # CacheList-wrapping-one, from GatedDeltaNet / Mamba MoE models), the
+        # entry is dropped by default. Granularity = whole entry, not
+        # per-layer, because reconstruction needs ALL layers (a half-populated
+        # entry with only the KVCache layers cannot resume a hybrid model —
+        # mlx-lm rebuilds the full cache list or nothing).
+        #
+        # #1103 refinement: the trim-free fetch paths (exact match and
+        # prefix-extension) CAN safely serve these entries — resuming a stored
+        # prefix at its own token boundary needs no trim, and that reuse is
+        # exactly the #214-era within-conversation speedup. When
+        # ``hybrid_reuse_max_entries > 0`` we therefore store the entry
+        # (flagged ``non_trimmable``) instead of dropping it, and enforce a
+        # dedicated LRU bound over non-trimmable entries after insert (below)
+        # so cross-conversation unique-superset keys can never accumulate
+        # unbounded the way #1025 observed. With the default of 0 this branch
+        # is byte-for-byte the #1075 behavior: the per-request recurrent state
+        # has NO lingering reference in ``_entries`` and is reclaimed by
+        # ``mx.clear_cache()`` / GC once the request object drops its own
+        # reference in ``_cleanup_finished``.
+        if (
+            _cache_has_non_trimmable(cache)
+            and self._config.hybrid_reuse_max_entries <= 0
+        ):
             self._stats.non_trimmable_skips += 1
             logger.debug(
                 "[cache_store] skipped hybrid recurrent-state entry "
@@ -1811,6 +1873,22 @@ class MemoryAwarePrefixCache:
                         f"[radix] insert failed for {len(tokens_key)} tokens: {exc}"
                     )
 
+            # #1103: dedicated LRU bound over non-trimmable (hybrid
+            # recurrent-state) entries. Their keys are unique supersets
+            # across conversations (#1025), so unlike KV-only entries they
+            # can pile up without ever being reclaimed by prefix-subset
+            # eviction — this bound is what keeps the recovered reuse from
+            # re-opening that leak. Scans in LRU order (``_entries`` is an
+            # ``OrderedDict``); O(entries) only on the hybrid store path.
+            if entry.non_trimmable:
+                limit = self._config.hybrid_reuse_max_entries
+                non_trimmable_keys = [
+                    key for key, e in self._entries.items() if e.non_trimmable
+                ]
+                while len(non_trimmable_keys) > limit:
+                    oldest = non_trimmable_keys.pop(0)
+                    self._evict_entry_locked(oldest, reason="hybrid_bound")
+
         logger.debug(
             f"Stored cache: {len(tokens)} tokens, "
             f"{entry.memory_bytes / _BYTES_PER_MB:.2f}MB, "
@@ -1833,16 +1911,24 @@ class MemoryAwarePrefixCache:
         if not self._entries:
             return
 
-        # Peek the oldest key, drop sorted-index entry first so a fetch
-        # without the lock can't trip the orphaned-sorted-key KeyError.
+        # Peek the oldest key.
         tokens_key = next(iter(self._entries))
+        self._evict_entry_locked(tokens_key, reason="lru_evict")
+
+    def _evict_entry_locked(self, tokens_key: tuple[int, ...], reason: str) -> None:
+        """Evict one entry by key with full index/ledger bookkeeping.
+
+        Caller must hold ``self._lock`` and guarantee ``tokens_key`` is
+        present. Drops the sorted-index entry first so a fetch without the
+        lock can't trip the orphaned-sorted-key KeyError.
+        """
         self._remove_from_sorted(tokens_key)
         if self._radix_index is not None:
             try:
                 self._radix_index.remove(tokens_key)
             except Exception as exc:  # pragma: no cover — defensive
                 logger.warning(
-                    f"[radix] lru-evict remove failed for {len(tokens_key)} tokens: {exc}"
+                    f"[radix] {reason} remove failed for {len(tokens_key)} tokens: {exc}"
                 )
         entry = self._entries.pop(tokens_key)
         self._current_memory -= entry.memory_bytes
@@ -1851,7 +1937,7 @@ class MemoryAwarePrefixCache:
         self._stats.current_memory_bytes = self._current_memory
 
         logger.debug(
-            f"[lru_evict] removed {len(tokens_key)} tokens, "
+            f"[{reason}] removed {len(tokens_key)} tokens, "
             f"freed {entry.memory_bytes / _BYTES_PER_MB:.2f}MB"
         )
 
@@ -1929,6 +2015,16 @@ class MemoryAwarePrefixCache:
         legacy cache counters.
         """
         out = self._stats.to_dict()
+        # #1103: live count of retained non-trimmable (hybrid recurrent-state)
+        # entries — drives the ``rapid_mlx_prefix_cache_non_trimmable_entries``
+        # gauge so operators can verify the hybrid-reuse bound holds (0 when
+        # ``hybrid_reuse_max_entries`` is 0, i.e. the #1075 drop-at-store
+        # policy is active). O(entries) under the lock, same cost class as
+        # the sorted-index maintenance store already pays.
+        with self._lock:
+            out["non_trimmable_entries"] = sum(
+                1 for e in self._entries.values() if e.non_trimmable
+            )
         if self._radix_index is not None:
             try:
                 out["radix"] = self._radix_index.stats()
@@ -3090,6 +3186,11 @@ class MemoryAwarePrefixCache:
                     tokens=tokens_key,
                     cache=cache,
                     memory_bytes=memory,
+                    # #1103: legacy on-disk snapshots (pre-#1075 saves) can
+                    # carry hybrid recurrent-state entries; flag them so the
+                    # hybrid-reuse bound and the non_trimmable_entries gauge
+                    # see them the same as freshly stored ones.
+                    non_trimmable=_cache_has_non_trimmable(cache),
                 )
                 staged[tokens_key] = entry
                 staged_memory += memory

--- a/vllm_mlx/memory_cache.py
+++ b/vllm_mlx/memory_cache.py
@@ -1931,13 +1931,15 @@ class MemoryAwarePrefixCache:
             f"freed {entry.memory_bytes / _BYTES_PER_MB:.2f}MB"
         )
 
-    def _enforce_hybrid_bound_locked(self) -> tuple[int, int]:
+    def _enforce_hybrid_bound_locked(self) -> list[tuple[int, ...]]:
         """Enforce the ``hybrid_reuse_max_entries`` bound over non-trimmable
         (hybrid recurrent-state) entries.
 
-        Caller must hold ``self._lock``. Returns ``(evicted_count,
-        evicted_bytes)`` so the persistent-load path can reconcile its
-        loaded-entry / loaded-byte tallies with what actually survived.
+        Caller must hold ``self._lock``. Returns the LIST of evicted keys (in
+        eviction order) so the persistent-load path can reconcile its loaded
+        tallies against only the keys that belonged to THIS import — a bound
+        pass may evict PRE-EXISTING non-trimmable entries (merge mode) that
+        were never part of the current load and must not be subtracted from it.
 
         #1103: non-trimmable entries carry unique-superset keys across
         conversations (#1025), so unlike KV-only entries they are never
@@ -1961,16 +1963,17 @@ class MemoryAwarePrefixCache:
         non_trimmable_keys = [
             key for key, e in self._entries.items() if e.non_trimmable
         ]
-        evicted_count = 0
-        evicted_bytes = 0
-        # limit <= 0 disables reuse: the ``> max(limit, 0)`` guard drops every
-        # non-trimmable entry (matches the store-path ``<= 0`` drop-at-store).
-        while len(non_trimmable_keys) > max(limit, 0):
-            oldest = non_trimmable_keys.pop(0)
-            evicted_bytes += self._entries[oldest].memory_bytes
+        # limit <= 0 disables reuse: ``max(limit, 0)`` keeps NONE, dropping
+        # every non-trimmable entry (matches the store-path ``<= 0`` drop-at-
+        # store). Slice the eviction prefix once — the head of the LRU-ordered
+        # list is oldest — instead of repeated ``pop(0)`` (O(n**2) on a large
+        # persisted snapshot).
+        keep = max(limit, 0)
+        n_evict = max(0, len(non_trimmable_keys) - keep)
+        victims = non_trimmable_keys[:n_evict]
+        for oldest in victims:
             self._evict_entry_locked(oldest, reason="hybrid_bound")
-            evicted_count += 1
-        return evicted_count, evicted_bytes
+        return victims
 
     def remove(self, tokens: list[int]) -> bool:
         """
@@ -3436,11 +3439,17 @@ class MemoryAwarePrefixCache:
             # drops every non-trimmable entry (byte-for-byte #1075 after a
             # restart); with N > 0 it LRU-trims down to N. Runs inside the
             # commit critical section so a scraper never sees an over-bound
-            # cache. Reconcile the reported tallies so the import route counts
-            # only entries that SURVIVED the bound.
-            bound_evicted, bound_bytes = self._enforce_hybrid_bound_locked()
-            loaded -= bound_evicted
-            loaded_bytes -= bound_bytes
+            # cache. Reconcile the reported tallies against ONLY the evicted
+            # keys that belonged to THIS import (``staged``): in merge mode the
+            # bound can evict PRE-EXISTING non-trimmable entries too, and those
+            # were never counted in ``loaded`` / ``loaded_bytes``, so
+            # subtracting them would under-count (potentially to 0) a load that
+            # actually installed new entries.
+            for victim in self._enforce_hybrid_bound_locked():
+                staged_entry = staged.get(victim)
+                if staged_entry is not None:
+                    loaded -= 1
+                    loaded_bytes -= staged_entry.memory_bytes
 
             self._stats.entry_count = len(self._entries)
             self._stats.current_memory_bytes = self._current_memory

--- a/vllm_mlx/routes/metrics.py
+++ b/vllm_mlx/routes/metrics.py
@@ -1096,7 +1096,9 @@ def _render_prometheus(cfg: Any) -> str:
                     "carried a non-trimmable recurrent-state layer "
                     "(hybrid GatedDeltaNet / Mamba MoE). Expected to climb "
                     "on hybrid models — it is the observable signal that "
-                    "the #1025/#1058 recurrent-state leak fix is active."
+                    "the #1025/#1058 recurrent-state leak fix is active. "
+                    "Stays flat when --hybrid-cache-entries > 0 opts into "
+                    "bounded trim-free reuse (#1103)."
                 ),
             ),
         ):
@@ -1155,6 +1157,23 @@ def _render_prometheus(cfg: Any) -> str:
                     "below the cap."
                 ),
                 int(_coerce_number(cache_stats.get("current_memory_bytes"))),
+            )
+        )
+        # #1103: live count of retained non-trimmable (hybrid recurrent-
+        # state) entries. 0 whenever --hybrid-cache-entries is 0 (the
+        # default #1075 drop-at-store policy); otherwise bounded by that
+        # flag — a value that exceeds the configured bound would indicate
+        # the hybrid-reuse LRU bound is broken (the #1025 leak shape).
+        lines.extend(
+            _fmt_metric(
+                "rapid_mlx_prefix_cache_non_trimmable_entries",
+                "gauge",
+                (
+                    "Hybrid (recurrent-state) entries currently retained for "
+                    "trim-free reuse. Bounded by --hybrid-cache-entries; "
+                    "always 0 when that flag is 0 (default)."
+                ),
+                int(_coerce_number(cache_stats.get("non_trimmable_entries"))),
             )
         )
 

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -141,6 +141,11 @@ class SchedulerConfig:
     use_memory_aware_cache: bool = True  # Use memory-based eviction
     cache_memory_mb: int | None = None  # None = auto-detect (20% of available RAM)
     cache_memory_percent: float = 0.20  # Fraction of available RAM if auto-detecting
+    # #1103: bounded trim-free prefix reuse for hybrid (GatedDeltaNet /
+    # Mamba MoE) models. 0 (default) keeps the #1075 drop-at-store policy;
+    # N > 0 retains at most N recurrent-state entries for exact /
+    # prefix-extension reuse (LRU-evicted among themselves).
+    hybrid_cache_entries: int = 0
 
     # KV cache quantization (reduces prefix cache memory). The
     # ``kv_cache_dtype`` field is the canonical R15 #300 knob — it
@@ -1963,6 +1968,8 @@ class Scheduler:
                     kv_turboquant_bits=self.config.kv_cache_turboquant_bits,
                     kv_turboquant_group_size=self.config.kv_cache_turboquant_group_size,
                     kv_turboquant_mode=self.config.kv_cache_turboquant_mode,
+                    # #1103: bounded trim-free hybrid reuse (0 = #1075 policy).
+                    hybrid_reuse_max_entries=self.config.hybrid_cache_entries,
                 )
                 # R15-P1 (task #303): radix-tree prefix-cache index.
                 # Constructed when ``prefix_cache_index == "radix"`` and

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -141,11 +141,6 @@ class SchedulerConfig:
     use_memory_aware_cache: bool = True  # Use memory-based eviction
     cache_memory_mb: int | None = None  # None = auto-detect (20% of available RAM)
     cache_memory_percent: float = 0.20  # Fraction of available RAM if auto-detecting
-    # #1103: bounded trim-free prefix reuse for hybrid (GatedDeltaNet /
-    # Mamba MoE) models. 0 (default) keeps the #1075 drop-at-store policy;
-    # N > 0 retains at most N recurrent-state entries for exact /
-    # prefix-extension reuse (LRU-evicted among themselves).
-    hybrid_cache_entries: int = 0
 
     # KV cache quantization (reduces prefix cache memory). The
     # ``kv_cache_dtype`` field is the canonical R15 #300 knob — it
@@ -191,6 +186,15 @@ class SchedulerConfig:
     )
     paged_cache_block_size: int = 64  # Tokens per block
     max_cache_blocks: int = 1000  # Maximum number of cache blocks
+
+    # #1103: bounded trim-free prefix reuse for hybrid (GatedDeltaNet /
+    # Mamba MoE) models. 0 (default) keeps the #1075 drop-at-store policy;
+    # N > 0 retains at most N recurrent-state entries for exact /
+    # prefix-extension reuse (LRU-evicted among themselves). Appended AFTER
+    # the pre-existing cache fields (codex #1103 NIT-5): keeps every field
+    # that predates this PR at its original dataclass position so no future
+    # positional ``SchedulerConfig(...)`` construction can silently rebind.
+    hybrid_cache_entries: int = 0
 
     # Speculative decoding selection. "none" is baseline decode; "mtp"
     # installs the vendored mlx-lm PR #990 MTP draft/verify path through


### PR DESCRIPTION
## Summary

Follow-up to #1075, as discussed in #1103. #1075's store-time gate stopped the
#1025/#1058 recurrent-state leak, but it also starved the two fetch paths that
never needed protection: **exact match** and **prefix-extension** serve a stored
entry at its own token boundary with no trim, which is exactly the #214-era
within-conversation reuse. On prompt-stable agent workloads (fixed system
prompt + tools, append-only history resent verbatim) that reuse was real —
~60–90% steady-state hit rate here — and #1075 took it to ~0%.

This PR recovers that reuse **opt-in and bounded**, without reintroducing the leak:

- **`--hybrid-cache-entries N`** (`MemoryCacheConfig.hybrid_reuse_max_entries`,
  default **0**). At 0 the behavior is byte-for-byte #1075: hybrid entries are
  dropped at store time and `non_trimmable_skips` climbs. At N > 0, `store`
  retains up to N non-trimmable entries, **LRU-evicted among themselves**, so
  #1025's failure shape (unique prompt+output superset keys that prefix-subset
  eviction can never reclaim) is capped at N entries by construction.
- **Fetch policy is unchanged.** Exact and prefix-extension matches (trim-free)
  serve the retained entries; the trim-requiring paths
  (supersequence-with-excess, LCP) still refuse non-trimmable layers — same
  guards, same lines.
- **Byte-ledger fix for recurrent state** (`estimate_kv_cache_memory`):
  `ArraysCache.state` is an N-array list (N is model-defined, not always 2) and
  `CacheList.state` is nested. Both previously slipped through the
  `keys, values = state` unpack — a two-cache `CacheList` "unpacked
  successfully" and then counted **0 bytes** for both halves — so recurrent-state
  entries were invisible to the eviction byte budget. They're now summed
  recursively. This also hardens the default path: any legacy on-disk hybrid
  entries loaded from a pre-#1075 snapshot are now correctly weighed.
- **Observability:** new `rapid_mlx_prefix_cache_non_trimmable_entries` gauge
  (0 unless opted in; a value above the configured bound would indicate the
  bound is broken). `non_trimmable_skips_total` semantics unchanged at the
  default.

## Why this doesn't re-open #1025

#1025's leak was: entries retained **by reference, forever** (unique superset
keys → prefix-subset eviction never fires), **unbounded** (only the byte budget,
set independently of `--gpu-memory-utilization`, would ever reclaim them), and
partially **invisible to the ledger** (CacheList form → 0 bytes). Under this PR:

1. Default stays drop-at-store — zero change for anyone who doesn't opt in.
2. Opted-in retention is capped at N entries, LRU-churned among themselves;
   dense entries are invisible to this bound and vice versa.
3. The ledger now sees the recurrent-state bytes, so the existing LRU-at-cap
   and Metal-pressure eviction paths act on them too.

Worst case for a workload with zero reuse (e.g. #1075's re-rendered chat
templates) and the flag enabled anyway: N entries of transient retention,
churned by LRU — not a monotonic ratchet.

## Evidence (same host / model / flags, version only difference)

Client resends byte-stable, append-only history each turn
(Mac mini M4 Pro 64GB, `Qwen3.6-35B-A3B-OptiQ-4bit`, `--kv-cache-turboquant k8v4`):

| | 0.10.5 (pre-#1075) | 0.10.9 (post-#1075) |
|---|---|---|
| Steady-state prefix-cache hit rate | ~60–90% | ~0% (`non_trimmable_skips` climbs, `radix_inserts` = 0) |
| First turn, ~70k-token fixed prefix | ~25 s (cache hit) | ~147 s (full prefill) |

The repro script in #1103 shows the store→hit pair on 0.10.5 and the
store-skip→miss pair on 0.10.7+.

## Live A/B of this patch (same box/model/flags, HEAD build)

Ran the exact same battery against this branch served both ways
(`--kv-cache-turboquant k8v4`, streaming disabled for timing, `enable_thinking`
false; `--pflash off` for the large-prompt runs — PFlash-compressed prompts skip
the prefix-cache lookup by design, so it masks the comparison):

| | default (flag off) | `--hybrid-cache-entries 8` |
|---|---|---|
| #1103 repro pair, req 2 (1.3k-token prefix ext.) | MISS, 1.58 s | **HIT (`cached=1254 remaining=36`), 0.40 s** |
| 4-turn append-only chat, ~17k-token prefix | 0 hits; every turn full prefill | turn 1 cold **21.5 s**, turns 2–4 **0.80 s** (hits +3) |
| Output correctness on warm turns (EN + JA echo tests) | 4/4 (no cache in play) | **4/4** — resumed recurrent state generates correctly |
| Divergent suffix (LCP shape, needs trim) | miss | **still refused** — clean miss + full prefill, no crash |
| `non_trimmable_skips` | climbs (2→8) | stays 0 |
| `non_trimmable_entries` gauge | 0 | **pinned at 8** while `radix_inserts` churned to 29 — the LRU bound holding under traffic |
| Metal active/peak during run | 20.6 / 22.4 GiB | 23.6 / 26.3 GiB (flat floor, no ratchet) |

Two incidental confirmations: retained hybrid entries round-trip disk
persistence (a restart warm-started from the previous run's `SAVED` entries and
served an immediate exact hit), and the default-off phase is behaviorally
identical to current HEAD (same skip counters, same misses).

### Sizing `--hybrid-cache-entries` (what N to pick)

The scheduler stores **two** non-trimmable entries per turn per conversation —
a mid-prefill prompt-only snapshot (`prompt_cache_save`) and the post-generation
prompt+output entry — and a conversation's next turn prefix-matches its own
previous prompt+output entry. So the bound must retain roughly
`2 × (concurrently-active conversations)` entries or a conversation's needed
entry is LRU-evicted before its next turn. Sweeping N against 3 interleaved
conversations (driving the real `MemoryAwarePrefixCache` class with the exact
observed store/fetch sequence — model-independent cache bookkeeping):

| N | warm-turn hit rate | N | warm-turn hit rate |
|---|---|---|---|
| 1 | 0% | 8 | 100% |
| 4 | 0% | 12 | 100% |
| 6 | 67% | 16 | 100% |

Knee at `N ≈ 2 × concurrent conversations` (here 3 → clean at N=8; N=4 thrashes,
matching the live run). The default 0 is off; a deployment opting in wants N
comfortably above `2 ×` its peak concurrency. Above that, the ordinary byte cap
(`--cache-memory-percent/-mb`) becomes the binding limit again — which is
exactly the pre-#1075 (0.10.5) regime, since this PR's accounting fix makes
hybrid entries count against that cap. So a large N reproduces 0.10.5's
byte-bounded behavior rather than adding a new limit.

## Tests

- `tests/test_hybrid_prefix_cache_growth.py`: all #1075 default-policy tests
  pass **unchanged**; 13 new tests cover the opt-in — exact-match hit,
  prefix-extension hit, both trim paths still refused, bound enforcement,
  dense entries invisible to the bound, default-config equivalence, and the
  ArraysCache/CacheList byte-accounting fix (including the N≠2 and nested
  shapes that previously counted 0).
- Cache + persistence + eviction + radix + routes suites: **355 passed**.
- Metrics suite: **100 passed**. `scripts/audit_cli_config_fidelity.py`: OK.
- ruff check / format: clean.

Happy to adjust the knob's name/default if you'd prefer this shipped
differently, or to run any additional workload you'd like numbers on (this is
a daily-driver agent deployment with 0.10.5 and 0.10.9 baselines on hand).
