### PR TITLE
fix(cli): add MTP/KV-share truth row to `info` + remove dead A5 mx.compile code

### DIFF
--- a/tests/test_model_auto_config.py
+++ b/tests/test_model_auto_config.py
@@ -1099,6 +1099,39 @@ class TestVisibility:
         assert _kv_share_label(stub.hf_path, stub) == "yes (default)"
         assert _mtp_path_label(stub.hf_path, stub) == "sidecar"
 
+    def test_native_stamp_wins_over_gemma_name_marker(self):
+        # codex #1112 [BLOCKING] round 2: an authoritative ``hy_v3`` parser
+        # stamp must win over a stray ``gemma-4`` name marker. A
+        # hypothetical HY3 distilled from Gemma 4 must render native / no,
+        # NOT sidecar / yes.
+        from vllm_mlx.model_auto_config import _kv_share_label, _mtp_path_label
+        from vllm_mlx.model_profile import ModelProfile
+
+        stub = ModelProfile(
+            hf_path="some-org/Hy3-distilled-from-Gemma-4-8bit",
+            tool_call_parser="hy_v3",
+            reasoning_parser="hy_v3",
+        )
+        assert _mtp_path_label(stub.hf_path, stub) == "native"
+        assert _kv_share_label(stub.hf_path, stub) == "no"
+
+    def test_family_token_boundaries_reject_substrings(self):
+        # codex #1112 [NIT] round 2: unrelated basenames that merely
+        # CONTAIN a family token as a substring must not match (no token
+        # boundaries → false labels). ``Llama-3-hy3per-8B`` contains
+        # ``hy3`` but is not HY3; ``megemma4x`` contains ``gemma4`` but is
+        # not Gemma 4.
+        from vllm_mlx.model_auto_config import _kv_share_label, _mtp_path_label
+        from vllm_mlx.model_profile import ModelProfile
+
+        not_hy3 = ModelProfile(hf_path="some-org/Llama-3-hy3per-8B")
+        assert _mtp_path_label(not_hy3.hf_path, not_hy3) == "disabled"
+        assert _kv_share_label(not_hy3.hf_path, not_hy3) == "no"
+
+        not_gemma4 = ModelProfile(hf_path="some-org/megemma4x-13B")
+        assert _kv_share_label(not_gemma4.hf_path, not_gemma4) == "no"
+        assert _mtp_path_label(not_gemma4.hf_path, not_gemma4) == "disabled"
+
 
 class TestGetProfile:
     """``get_profile()`` is the public one-shot API."""

--- a/tests/test_model_auto_config.py
+++ b/tests/test_model_auto_config.py
@@ -1041,16 +1041,18 @@ class TestVisibility:
         assert "MTP path         : disabled" in table
         assert "KV-share         : no" in table
 
-    def test_unknown_model_mtp_disabled_kv_share_no(self):
-        # ``cfg is None`` path — an unmatched family has no known MTP head
-        # or KV-share config. codex #1112 [NIT] round 4: the value must be
-        # exactly ``disabled`` (within the documented native | sidecar |
-        # disabled contract), not a fourth value like
-        # ``disabled (unknown family)``.
+    def test_unknown_model_reports_unknown_not_definite(self):
+        # ``cfg is None`` path — no regex/alias matched, so the
+        # architecture is genuinely UNKNOWN (an opaquely named Qwen3.5 /
+        # Gemma 4 checkpoint lands here too). codex #1112 [BLOCKING]
+        # round 7: reporting a definite ``disabled`` / ``no`` would falsely
+        # claim the model lacks MTP / KV-sharing — report ``unknown``.
         table = format_profile_table("some-brand-new-model-xyz", None)
-        assert "MTP path         : disabled" in table
-        assert "disabled (unknown family)" not in table
-        assert "KV-share         : no" in table
+        assert "MTP path         : unknown (unmatched profile)" in table
+        assert "KV-share         : unknown (unmatched profile)" in table
+        # Must NOT falsely assert a definite off-state for an unknown arch.
+        assert "MTP path         : disabled" not in table
+        assert "KV-share         : no" not in table
 
     def test_mtp_path_value_stays_within_contract(self):
         # codex #1112 [NIT] round 4: the MTP-path value must always be one

--- a/tests/test_model_auto_config.py
+++ b/tests/test_model_auto_config.py
@@ -992,6 +992,78 @@ class TestVisibility:
         for line in table.splitlines():
             assert len(line) <= 80, f"line too wide: {line!r}"
 
+    # --- MTP path / KV-share truth-in-labeling rows ---
+
+    def test_table_has_mtp_and_kv_share_rows(self):
+        # Both rows must be present on every rendered table so users see
+        # the spec-decode/KV-share truth without loading weights.
+        cfg = detect_model_config("mlx-community/gemma-4-12B-it-4bit")
+        table = format_profile_table("mlx-community/gemma-4-12B-it-4bit", cfg)
+        assert "MTP path" in table
+        assert "KV-share" in table
+
+    def test_gemma4_mtp_is_sidecar_and_kv_share_yes(self):
+        # Gemma 4 uses an assistant/sidecar drafter (no native head) and
+        # ships cross-layer KV-sharing (num_kv_shared_layers > 0).
+        cfg = detect_model_config("mlx-community/gemma-4-12B-it-4bit")
+        assert cfg is not None and cfg.supports_spec_decode is True
+        table = format_profile_table("mlx-community/gemma-4-12B-it-4bit", cfg)
+        assert "MTP path         : sidecar" in table
+        assert "KV-share         : yes" in table
+
+    def test_hy3_mtp_is_native_and_kv_share_no(self):
+        # HY3 ships a native DeepSeek-V3-style MTP head; not a Gemma 4, so
+        # no cross-layer KV-share.
+        cfg = detect_model_config("mlx-community/Hy3-preview-4bit")
+        assert cfg is not None and cfg.supports_spec_decode is True
+        table = format_profile_table("mlx-community/Hy3-preview-4bit", cfg)
+        assert "MTP path         : native" in table
+        assert "KV-share         : no" in table
+
+    def test_qwen35_spec_off_mtp_disabled(self):
+        # Native-MTP family (Qwen3.5), but this alias has spec decode off
+        # (no MTP head registered) → the honest MTP path is ``disabled``.
+        cfg = detect_model_config("mlx-community/Qwen3.5-4B-MLX-4bit")
+        assert cfg is not None and cfg.supports_spec_decode is False
+        table = format_profile_table("mlx-community/Qwen3.5-4B-MLX-4bit", cfg)
+        assert "MTP path         : disabled" in table
+        assert "KV-share         : no" in table
+
+    def test_non_mtp_spec_on_family_mtp_disabled(self):
+        # Qwen3 dense enables spec decode via SuffixDecoding, NOT MTP.
+        # The MTP-path row must stay ``disabled`` — SuffixDecoding is a
+        # different lane, surfaced by the Spec-decode / Suffix-tier rows.
+        cfg = detect_model_config("mlx-community/Qwen3-0.6B-8bit")
+        assert cfg is not None and cfg.supports_spec_decode is True
+        table = format_profile_table("mlx-community/Qwen3-0.6B-8bit", cfg)
+        assert "MTP path         : disabled" in table
+        assert "KV-share         : no" in table
+
+    def test_unknown_model_mtp_disabled_kv_share_no(self):
+        # ``cfg is None`` path — an unmatched family has no known MTP head
+        # or KV-share config.
+        table = format_profile_table("some-brand-new-model-xyz", None)
+        assert "MTP path" in table and "disabled" in table
+        assert "KV-share         : no" in table
+
+    def test_mtp_kv_share_rows_fit_box(self):
+        # New rows must not break the fixed-width box on any family.
+        for name in (
+            "mlx-community/gemma-4-12B-it-4bit",
+            "mlx-community/Hy3-preview-4bit",
+            "mlx-community/Qwen3.5-4B-MLX-4bit",
+        ):
+            table = format_profile_table(name, detect_model_config(name))
+            widths = {
+                len(line)
+                for line in table.splitlines()
+                if line.startswith(("│", "┌", "└"))
+            }
+            assert len(widths) == 1, (
+                f"MTP/KV-share rows broke box alignment for {name}: "
+                f"widths={widths}\n{table}"
+            )
+
 
 class TestGetProfile:
     """``get_profile()`` is the public one-shot API."""

--- a/tests/test_model_auto_config.py
+++ b/tests/test_model_auto_config.py
@@ -1132,6 +1132,32 @@ class TestVisibility:
         assert _kv_share_label(not_gemma4.hf_path, not_gemma4) == "no"
         assert _mtp_path_label(not_gemma4.hf_path, not_gemma4) == "disabled"
 
+    def test_ambiguous_both_markers_no_stamp_is_conservative(self):
+        # codex #1112 [BLOCKING] round 3: a name carrying BOTH a Gemma 4
+        # and a native-MTP marker with no parser stamp to disambiguate is
+        # ambiguous — degrade to the conservative disabled / no rather
+        # than guessing a family.
+        from vllm_mlx.model_auto_config import _kv_share_label, _mtp_path_label
+        from vllm_mlx.model_profile import ModelProfile
+
+        ambiguous = ModelProfile(hf_path="some-org/Qwen3.5-gemma-4-merge-8bit")
+        assert _mtp_path_label(ambiguous.hf_path, ambiguous) == "disabled"
+        assert _kv_share_label(ambiguous.hf_path, ambiguous) == "no"
+
+    def test_ambiguous_name_with_stamp_uses_stamp(self):
+        # But an authoritative parser stamp still wins over an ambiguous
+        # name — the stamp is the SSOT.
+        from vllm_mlx.model_auto_config import _kv_share_label, _mtp_path_label
+        from vllm_mlx.model_profile import ModelProfile
+
+        stamped = ModelProfile(
+            hf_path="some-org/Qwen3.5-gemma-4-merge-8bit",
+            tool_call_parser="gemma4",
+            reasoning_parser="gemma4",
+        )
+        assert _mtp_path_label(stamped.hf_path, stamped) == "sidecar"
+        assert _kv_share_label(stamped.hf_path, stamped) == "yes (default)"
+
 
 class TestGetProfile:
     """``get_profile()`` is the public one-shot API."""

--- a/tests/test_model_auto_config.py
+++ b/tests/test_model_auto_config.py
@@ -1159,21 +1159,38 @@ class TestVisibility:
         assert _kv_share_label(stub.hf_path, stub) == "yes (default)"
         assert _mtp_path_label(stub.hf_path, stub) == "sidecar"
 
-    def test_native_stamp_wins_over_gemma_name_marker(self):
-        # codex #1112 [BLOCKING] round 2: an authoritative ``hy_v3`` parser
-        # stamp must win over a stray ``gemma-4`` name marker. A
-        # hypothetical HY3 distilled from Gemma 4 must render native / no,
-        # NOT sidecar / yes.
+    def test_leading_family_token_beats_provenance_suffix(self):
+        # codex #1112 round 5 + round 9: the family is decided by the
+        # LEADING architecture-position token, not a later provenance
+        # token. ``Hy3-distilled-from-Gemma-4`` leads with ``Hy3`` → native
+        # (the trailing ``gemma-4`` is provenance and is ignored). The
+        # resolver is name-based, so parser stamps here are irrelevant —
+        # this documents leading-token precedence, not stamp precedence.
         from vllm_mlx.model_auto_config import _kv_share_label, _mtp_path_label
         from vllm_mlx.model_profile import ModelProfile
 
-        stub = ModelProfile(
-            hf_path="some-org/Hy3-distilled-from-Gemma-4-8bit",
-            tool_call_parser="hy_v3",
-            reasoning_parser="hy_v3",
-        )
+        stub = ModelProfile(hf_path="some-org/Hy3-distilled-from-Gemma-4-8bit")
         assert _mtp_path_label(stub.hf_path, stub) == "native"
         assert _kv_share_label(stub.hf_path, stub) == "no"
+
+    def test_quant_prefix_before_family_token_still_resolves(self):
+        # codex #1112 [BLOCKING] round 9: a repackaged/renamed checkpoint
+        # may prepend a quantization/format prefix before the architecture
+        # token. Those must still resolve to the family, while a mid-name
+        # provenance token (not a known prefix) stays rejected.
+        from vllm_mlx.model_auto_config import _kv_share_label, _mtp_path_label
+        from vllm_mlx.model_profile import ModelProfile
+
+        for name, mtp, kv in (
+            ("some-org/quantized-gemma-4-12b", "sidecar", "yes (default)"),
+            ("some-org/mlx-gemma-4-9b-it", "sidecar", "yes (default)"),
+            ("some-org/4bit-gemma-4-12b", "sidecar", "yes (default)"),
+            ("some-org/quant-Qwen3.6-35B", "native", "no"),
+            ("some-org/mlx-Hy3-preview", "native", "no"),
+        ):
+            stub = ModelProfile(hf_path=name)  # spec decode defaults True
+            assert _mtp_path_label(name, stub) == mtp, name
+            assert _kv_share_label(name, stub) == kv, name
 
     def test_family_token_substrings_and_provenance_rejected(self):
         # codex #1112 [NIT] round 2 + [BLOCKING] round 5: a family token

--- a/tests/test_model_auto_config.py
+++ b/tests/test_model_auto_config.py
@@ -1004,12 +1004,14 @@ class TestVisibility:
 
     def test_gemma4_mtp_is_sidecar_and_kv_share_yes(self):
         # Gemma 4 uses an assistant/sidecar drafter (no native head) and
-        # ships cross-layer KV-sharing (num_kv_shared_layers > 0).
+        # ships cross-layer KV-sharing (num_kv_shared_layers > 0). The
+        # ``(default)`` qualifier signals the value is the family default,
+        # not a per-checkpoint config.json read (info stays weight-free).
         cfg = detect_model_config("mlx-community/gemma-4-12B-it-4bit")
         assert cfg is not None and cfg.supports_spec_decode is True
         table = format_profile_table("mlx-community/gemma-4-12B-it-4bit", cfg)
         assert "MTP path         : sidecar" in table
-        assert "KV-share         : yes" in table
+        assert "KV-share         : yes (default)" in table
 
     def test_hy3_mtp_is_native_and_kv_share_no(self):
         # HY3 ships a native DeepSeek-V3-style MTP head; not a Gemma 4, so
@@ -1063,6 +1065,39 @@ class TestVisibility:
                 f"MTP/KV-share rows broke box alignment for {name}: "
                 f"widths={widths}\n{table}"
             )
+
+    def test_family_marker_in_org_dir_does_not_mislabel(self):
+        # codex #1112 [BLOCKING]: a family marker in an ORG / parent
+        # directory must not spoof the MTP/KV-share family — the match is
+        # scoped to the extracted model-NAME segment. Here the name
+        # segment is a plain Llama checkpoint; the ``gemma4`` / ``qwen3.5``
+        # markers live only in the (fictional) org prefix and must be
+        # ignored. The resolved profile carries no gemma4/hy_v3 parser
+        # stamp for these, so the label falls through to disabled/no.
+        from vllm_mlx.model_auto_config import _kv_share_label, _mtp_path_label
+
+        cfg = detect_model_config("some-random-model")  # None → build a stub
+        from vllm_mlx.model_profile import ModelProfile
+
+        stub = ModelProfile(hf_path="gemma4-labs/Llama-3-8B-Instruct-4bit")
+        assert _kv_share_label(stub.hf_path, stub) == "no"
+        assert _mtp_path_label(stub.hf_path, stub) == "disabled"
+
+        stub2 = ModelProfile(hf_path="qwen3.5-community/Mistral-7B-4bit")
+        assert _mtp_path_label(stub2.hf_path, stub2) == "disabled"
+
+    def test_gemma4_name_in_segment_still_labels_sidecar(self):
+        # Positive control for the anchoring fix: when the Gemma 4 marker
+        # IS in the model-name segment (direct HF path, no parser stamp
+        # because it's an unaliased path routed through the regex), it
+        # must still label sidecar / KV-share yes.
+        from vllm_mlx.model_auto_config import _kv_share_label, _mtp_path_label
+        from vllm_mlx.model_profile import ModelProfile
+
+        # No parser stamp, spec on — the name segment carries ``gemma-4``.
+        stub = ModelProfile(hf_path="some-org/gemma-4-9b-custom-4bit")
+        assert _kv_share_label(stub.hf_path, stub) == "yes (default)"
+        assert _mtp_path_label(stub.hf_path, stub) == "sidecar"
 
 
 class TestGetProfile:

--- a/tests/test_model_auto_config.py
+++ b/tests/test_model_auto_config.py
@@ -1160,38 +1160,48 @@ class TestVisibility:
         assert _mtp_path_label(stub.hf_path, stub) == "native"
         assert _kv_share_label(stub.hf_path, stub) == "no"
 
-    def test_family_token_boundaries_reject_substrings(self):
-        # codex #1112 [NIT] round 2: unrelated basenames that merely
-        # CONTAIN a family token as a substring must not match (no token
-        # boundaries → false labels). ``Llama-3-hy3per-8B`` contains
-        # ``hy3`` but is not HY3; ``megemma4x`` contains ``gemma4`` but is
-        # not Gemma 4.
+    def test_family_token_substrings_and_provenance_rejected(self):
+        # codex #1112 [NIT] round 2 + [BLOCKING] round 5: a family token
+        # must be at the START of the name segment (the architecture-
+        # position slot). Reject (a) substrings — ``Llama-3-hy3per-8B``
+        # contains ``hy3``, ``megemma4x`` contains ``gemma4`` — and (b)
+        # LATER provenance tokens — ``Llama-3-Distilled-from-Gemma-4`` is a
+        # Llama, ``Mistral-merge-of-Qwen3.5`` is a Mistral.
         from vllm_mlx.model_auto_config import _kv_share_label, _mtp_path_label
         from vllm_mlx.model_profile import ModelProfile
 
-        not_hy3 = ModelProfile(hf_path="some-org/Llama-3-hy3per-8B")
-        assert _mtp_path_label(not_hy3.hf_path, not_hy3) == "disabled"
-        assert _kv_share_label(not_hy3.hf_path, not_hy3) == "no"
+        for name in (
+            "some-org/Llama-3-hy3per-8B",
+            "some-org/megemma4x-13B",
+            "some-org/Llama-3-Distilled-from-Gemma-4-8bit",
+            "some-org/Mistral-merge-of-Qwen3.5-7b",
+            "some-org/Yi-based-on-Hy3-9b",
+        ):
+            stub = ModelProfile(hf_path=name)  # spec decode defaults True
+            assert _mtp_path_label(name, stub) == "disabled", name
+            assert _kv_share_label(name, stub) == "no", name
 
-        not_gemma4 = ModelProfile(hf_path="some-org/megemma4x-13B")
-        assert _kv_share_label(not_gemma4.hf_path, not_gemma4) == "no"
-        assert _mtp_path_label(not_gemma4.hf_path, not_gemma4) == "disabled"
-
-    def test_ambiguous_both_markers_no_stamp_is_conservative(self):
-        # codex #1112 [BLOCKING] round 3: a name carrying BOTH a Gemma 4
-        # and a native-MTP marker with no parser stamp to disambiguate is
-        # ambiguous — degrade to the conservative disabled / no rather
-        # than guessing a family.
+    def test_architecture_position_token_wins_in_merge_name(self):
+        # codex #1112 round 5: in a merge name the LEADING family token is
+        # the architecture; the later token is provenance. ``Qwen3.5-gemma-
+        # 4-merge`` is a Qwen3.5-architecture merge → native; ``gemma-4-
+        # qwen3.5-merge`` leads with Gemma 4 → sidecar / KV-share yes.
         from vllm_mlx.model_auto_config import _kv_share_label, _mtp_path_label
         from vllm_mlx.model_profile import ModelProfile
 
-        ambiguous = ModelProfile(hf_path="some-org/Qwen3.5-gemma-4-merge-8bit")
-        assert _mtp_path_label(ambiguous.hf_path, ambiguous) == "disabled"
-        assert _kv_share_label(ambiguous.hf_path, ambiguous) == "no"
+        qwen_lead = ModelProfile(hf_path="some-org/Qwen3.5-gemma-4-merge-8bit")
+        assert _mtp_path_label(qwen_lead.hf_path, qwen_lead) == "native"
+        assert _kv_share_label(qwen_lead.hf_path, qwen_lead) == "no"
 
-    def test_ambiguous_name_with_stamp_uses_stamp(self):
-        # But an authoritative parser stamp still wins over an ambiguous
-        # name — the stamp is the SSOT.
+        gemma_lead = ModelProfile(hf_path="some-org/gemma-4-qwen3.5-merge-8bit")
+        assert _mtp_path_label(gemma_lead.hf_path, gemma_lead) == "sidecar"
+        assert _kv_share_label(gemma_lead.hf_path, gemma_lead) == "yes (default)"
+
+    def test_stamp_does_not_override_architecture_position(self):
+        # A ``gemma4`` parser stamp (which can come from an org-dir regex
+        # match on the full path) does NOT override the architecture-
+        # position name marker: ``Qwen3.5-…`` leads with Qwen3.5, so it
+        # stays native even with a stray gemma4 stamp.
         from vllm_mlx.model_auto_config import _kv_share_label, _mtp_path_label
         from vllm_mlx.model_profile import ModelProfile
 
@@ -1200,8 +1210,8 @@ class TestVisibility:
             tool_call_parser="gemma4",
             reasoning_parser="gemma4",
         )
-        assert _mtp_path_label(stamped.hf_path, stamped) == "sidecar"
-        assert _kv_share_label(stamped.hf_path, stamped) == "yes (default)"
+        assert _mtp_path_label(stamped.hf_path, stamped) == "native"
+        assert _kv_share_label(stamped.hf_path, stamped) == "no"
 
 
 class TestGetProfile:

--- a/tests/test_model_auto_config.py
+++ b/tests/test_model_auto_config.py
@@ -1055,12 +1055,16 @@ class TestVisibility:
         assert "KV-share         : no" not in table
 
     def test_mtp_path_value_stays_within_contract(self):
-        # codex #1112 [NIT] round 4: the MTP-path value must always be one
-        # of the three documented tokens — never a fourth free-form value.
-        from vllm_mlx.model_auto_config import _mtp_path_label
-        from vllm_mlx.model_profile import ModelProfile
+        # codex #1112 [NIT] round 4 + [BLOCKING] round 8: the RENDERED MTP-
+        # path value must always be one of the documented tokens. This
+        # parses ``format_profile_table`` output (the real public surface),
+        # NOT ``_mtp_path_label`` in isolation — so the ``cfg is None``
+        # branch's ``unknown`` value is covered too. Contract vocabulary:
+        # a MATCHED profile → native | sidecar | disabled; the UNMATCHED
+        # (``cfg is None``) branch → "unknown (unmatched profile)".
+        import re
 
-        allowed = {"native", "sidecar", "disabled"}
+        matched_allowed = {"native", "sidecar", "disabled"}
         probes = [
             "mlx-community/gemma-4-12B-it-4bit",
             "mlx-community/Hy3-preview-4bit",
@@ -1071,12 +1075,21 @@ class TestVisibility:
             "some-org/Qwen3.5-gemma-4-merge-8bit",
             "totally-unknown-model",
         ]
+        row_re = re.compile(r"MTP path\s+:\s+(.*?)\s+│")
         for name in probes:
             cfg = detect_model_config(name)
-            profile = cfg if cfg is not None else ModelProfile(hf_path=name)
-            assert _mtp_path_label(name, profile) in allowed, (
-                f"MTP path for {name!r} escaped the contract"
-            )
+            table = format_profile_table(name, cfg)
+            m = row_re.search(table)
+            assert m is not None, f"no MTP path row rendered for {name!r}"
+            value = m.group(1)
+            if cfg is None:
+                assert value == "unknown (unmatched profile)", (
+                    f"unmatched profile {name!r} must report unknown, got {value!r}"
+                )
+            else:
+                assert value in matched_allowed, (
+                    f"matched profile {name!r} escaped the contract: {value!r}"
+                )
 
     def test_mtp_kv_share_rows_fit_box(self):
         # New rows must not break the fixed-width box on any family.

--- a/tests/test_model_auto_config.py
+++ b/tests/test_model_auto_config.py
@@ -1043,10 +1043,38 @@ class TestVisibility:
 
     def test_unknown_model_mtp_disabled_kv_share_no(self):
         # ``cfg is None`` path — an unmatched family has no known MTP head
-        # or KV-share config.
+        # or KV-share config. codex #1112 [NIT] round 4: the value must be
+        # exactly ``disabled`` (within the documented native | sidecar |
+        # disabled contract), not a fourth value like
+        # ``disabled (unknown family)``.
         table = format_profile_table("some-brand-new-model-xyz", None)
-        assert "MTP path" in table and "disabled" in table
+        assert "MTP path         : disabled" in table
+        assert "disabled (unknown family)" not in table
         assert "KV-share         : no" in table
+
+    def test_mtp_path_value_stays_within_contract(self):
+        # codex #1112 [NIT] round 4: the MTP-path value must always be one
+        # of the three documented tokens — never a fourth free-form value.
+        from vllm_mlx.model_auto_config import _mtp_path_label
+        from vllm_mlx.model_profile import ModelProfile
+
+        allowed = {"native", "sidecar", "disabled"}
+        probes = [
+            "mlx-community/gemma-4-12B-it-4bit",
+            "mlx-community/Hy3-preview-4bit",
+            "mlx-community/Qwen3.5-4B-MLX-4bit",
+            "mlx-community/Qwen3-0.6B-8bit",
+            "mlx-community/Qwen3.6-35B-A3B-4bit",
+            "gemma4-labs/Llama-3-8B-Instruct-4bit",
+            "some-org/Qwen3.5-gemma-4-merge-8bit",
+            "totally-unknown-model",
+        ]
+        for name in probes:
+            cfg = detect_model_config(name)
+            profile = cfg if cfg is not None else ModelProfile(hf_path=name)
+            assert _mtp_path_label(name, profile) in allowed, (
+                f"MTP path for {name!r} escaped the contract"
+            )
 
     def test_mtp_kv_share_rows_fit_box(self):
         # New rows must not break the fixed-width box on any family.
@@ -1068,23 +1096,40 @@ class TestVisibility:
 
     def test_family_marker_in_org_dir_does_not_mislabel(self):
         # codex #1112 [BLOCKING]: a family marker in an ORG / parent
-        # directory must not spoof the MTP/KV-share family — the match is
-        # scoped to the extracted model-NAME segment. Here the name
-        # segment is a plain Llama checkpoint; the ``gemma4`` / ``qwen3.5``
-        # markers live only in the (fictional) org prefix and must be
-        # ignored. The resolved profile carries no gemma4/hy_v3 parser
-        # stamp for these, so the label falls through to disabled/no.
-        from vllm_mlx.model_auto_config import _kv_share_label, _mtp_path_label
+        # directory must not spoof the MTP/KV-share family. This exercises
+        # the REAL public path (``detect_model_config`` →
+        # ``format_profile_table``), NOT a hand-built stub — because
+        # ``detect_model_config``'s regex table matches the FULL path, an
+        # org prefix like ``gemma4-labs/…`` yields a ``gemma4`` parser
+        # stamp on a non-Gemma model; the info-row family resolver must
+        # require the family marker in the NAME segment, so the stamp
+        # alone cannot spoof the label. The name segment here is a plain
+        # Llama / Mistral checkpoint — no family marker → disabled / no.
+        for spoof in (
+            "gemma4-labs/Llama-3-8B-Instruct-4bit",
+            "qwen3.5-community/Mistral-7B-Instruct-4bit",
+            "hy3-org/Llama-3-8B-Instruct-4bit",
+        ):
+            table = format_profile_table(spoof, detect_model_config(spoof))
+            assert "MTP path         : disabled" in table, (
+                f"org-dir marker spoofed MTP path for {spoof}:\n{table}"
+            )
+            assert "KV-share         : no" in table, (
+                f"org-dir marker spoofed KV-share for {spoof}:\n{table}"
+            )
 
-        cfg = detect_model_config("some-random-model")  # None → build a stub
+    def test_qwen35_spec_on_stub_labels_native(self):
+        # codex #1112 [NIT] round 4: a positive assertion that a spec-decode-
+        # enabled Qwen3.5/3.6 name renders ``MTP path: native`` via the
+        # name regex — so deleting Qwen handling from ``_NATIVE_MTP_NAME_RE``
+        # would break this test (the shipped Qwen3.5 aliases all have spec
+        # decode OFF, which alone can't catch a native-regex regression).
+        from vllm_mlx.model_auto_config import _mtp_path_label
         from vllm_mlx.model_profile import ModelProfile
 
-        stub = ModelProfile(hf_path="gemma4-labs/Llama-3-8B-Instruct-4bit")
-        assert _kv_share_label(stub.hf_path, stub) == "no"
-        assert _mtp_path_label(stub.hf_path, stub) == "disabled"
-
-        stub2 = ModelProfile(hf_path="qwen3.5-community/Mistral-7B-4bit")
-        assert _mtp_path_label(stub2.hf_path, stub2) == "disabled"
+        for name in ("some-org/Qwen3.5-9B-custom-4bit", "some-org/Qwen3.6-9B-4bit"):
+            stub = ModelProfile(hf_path=name)  # spec decode defaults True
+            assert _mtp_path_label(stub.hf_path, stub) == "native"
 
     def test_gemma4_name_in_segment_still_labels_sidecar(self):
         # Positive control for the anchoring fix: when the Gemma 4 marker

--- a/vllm_mlx/model_auto_config.py
+++ b/vllm_mlx/model_auto_config.py
@@ -1477,22 +1477,66 @@ def _truncate_tier_note(text: str, max_width: int | None) -> str:
 # separate drafter model. This mirrors the authoritative
 # ``vllm_mlx.spec_decode.mtp.detect._SUPPORTED_MODEL_TYPES`` allowlist
 # (``qwen3_5`` / ``qwen3_5_moe`` / ``hy_v3``) but is derived from the
-# name-regex-resolved profile rather than a loaded ``config.json`` so the
+# already-resolved profile rather than a loaded ``config.json`` so the
 # ``rapid-mlx info`` fast path stays weight-free. Kept as a small local
 # regex (not an import from the operator-owned ``spec_decode`` package)
 # so this display helper has no coupling into that lane. Qwen3.5 and the
 # dense/MoE Qwen3.6 release share the ``qwen3_5`` model_type upstream, so
 # one ``qwen3\.[56]`` regex covers both; HY3 (Tencent Hunyuan 3) carries
 # a DeepSeek-V3-style native MTP head.
-_NATIVE_MTP_NAME_RE = re.compile(r"qwen3[._]?[56]|hy[-_]?v?3|hunyuan[-_]?3", re.IGNORECASE)
+#
+# codex #1112 [BLOCKING]: these regexes are matched ONLY against the
+# extracted model-NAME segment (``_extract_model_name_segment`` — the
+# canonical basename, org/parent dirs and HF-cache intermediates
+# stripped), never the full unanchored path. Matching the raw path let an
+# org or parent directory named e.g. ``qwen3.5-org/…`` mislabel an
+# unrelated checkpoint, and (when both a Qwen and a Gemma marker appeared
+# in the path) the native branch stole Gemma's sidecar branch.
+_NATIVE_MTP_NAME_RE = re.compile(
+    r"qwen3[._]?[56]|hy[-_]?v?3|hunyuan[-_]?3", re.IGNORECASE
+)
 
 # Gemma 4 uses an assistant/sidecar drafter (``gemma4_assistant`` /
 # ``gemma4_unified_assistant`` — see
 # ``vllm_mlx.spec_decode.mtp.gemma4_inject``), NOT a native head baked
 # into the checkpoint. Identify the family from the Gemma-4-specific
 # parser stamp the profile already carries (``tool_call_parser`` /
-# ``reasoning_parser`` == ``gemma4``), falling back to the name.
+# ``reasoning_parser`` == ``gemma4``), falling back to a name match
+# against the extracted name segment only.
 _GEMMA4_NAME_RE = re.compile(r"gemma[-_]?4", re.IGNORECASE)
+
+
+def _is_gemma4_family(model_path: str, cfg: "ModelConfig") -> bool:
+    """True iff the resolved profile is a Gemma 4 checkpoint.
+
+    Family is decided from the Gemma-4-specific parser stamp the profile
+    already carries (the single source of truth set by the
+    precedence-ordered detection in ``detect_model_config`` — Gemma 3n
+    matches the earlier ``gemma-3n`` regex to ``tool_call_parser=None``
+    and is therefore excluded). The name match is a fallback for
+    direct-HF-path serves whose parser stamp is a generic default, and is
+    scoped to the extracted model-NAME segment so an org/parent dir
+    cannot spoof the family.
+    """
+    if cfg.tool_call_parser == "gemma4" or cfg.reasoning_parser == "gemma4":
+        return True
+    name_seg = _extract_model_name_segment((cfg.hf_path or model_path).lower())
+    return bool(_GEMMA4_NAME_RE.search(name_seg))
+
+
+def _is_native_mtp_family(model_path: str, cfg: "ModelConfig") -> bool:
+    """True iff the resolved profile is a native-MTP-head family.
+
+    HY3 carries a unique ``hy_v3`` parser stamp (SSOT). Qwen3.5 / Qwen3.6
+    share the generic ``hermes`` / ``qwen3_coder_xml`` parsers with
+    non-MTP Qwen variants, so those need a name match — scoped to the
+    extracted model-NAME segment (not the full path) so an org/parent dir
+    cannot spoof the family.
+    """
+    if cfg.tool_call_parser == "hy_v3" or cfg.reasoning_parser == "hy_v3":
+        return True
+    name_seg = _extract_model_name_segment((cfg.hf_path or model_path).lower())
+    return bool(_NATIVE_MTP_NAME_RE.search(name_seg))
 
 
 def _mtp_path_label(model_path: str, cfg: "ModelConfig") -> str:
@@ -1514,31 +1558,21 @@ def _mtp_path_label(model_path: str, cfg: "ModelConfig") -> str:
       are surfaced by the ``Spec decode`` / ``Suffix tier`` rows, not
       here — this row is specifically about MTP).
 
-    Derivation is from the name-regex profile only (no ``config.json``
+    Derivation is from the resolved profile only (no ``config.json``
     read), keeping the ``rapid-mlx info`` path weight-free.
     """
-    is_gemma4 = (
-        cfg.tool_call_parser == "gemma4"
-        or cfg.reasoning_parser == "gemma4"
-        or bool(_GEMMA4_NAME_RE.search(cfg.hf_path or ""))
-        or bool(_GEMMA4_NAME_RE.search(model_path))
-    )
-    is_native_mtp_family = bool(
-        _NATIVE_MTP_NAME_RE.search(cfg.hf_path or "")
-        or _NATIVE_MTP_NAME_RE.search(model_path)
-        or cfg.tool_call_parser == "hy_v3"
-        or cfg.reasoning_parser == "hy_v3"
-    )
-
     if not cfg.supports_spec_decode:
         # Honest: the profile has spec decode gated off (hybrid arch, or
         # no MTP head/drafter registered for this alias). Even for a
         # native-MTP family the head isn't wired for this checkpoint.
         return "disabled"
-    if is_native_mtp_family:
-        return "native"
-    if is_gemma4:
+    # Gemma 4 (sidecar) is checked before the native-MTP family so a path
+    # that somehow carries both markers resolves to the correct
+    # parser-stamped family rather than letting the native branch win.
+    if _is_gemma4_family(model_path, cfg):
         return "sidecar"
+    if _is_native_mtp_family(model_path, cfg):
+        return "native"
     # Spec decode is on but via a non-MTP mechanism (SuffixDecoding).
     return "disabled"
 
@@ -1546,28 +1580,26 @@ def _mtp_path_label(model_path: str, cfg: "ModelConfig") -> str:
 def _kv_share_label(model_path: str, cfg: "ModelConfig") -> str:
     """Truth-in-labeling for Gemma 4 cross-layer KV-sharing.
 
-    Returns ``yes`` for Gemma 4 (every shipped Gemma 4 checkpoint declares
-    ``num_kv_shared_layers > 0`` — the last N decoder layers borrow an
-    earlier layer's K/V; default 20 on the vendored ``TextConfig``,
-    verify-locked in #1104), ``no`` for every other family. Gemma 3n
-    shares the mechanism but is matched by the more specific ``gemma-3n``
-    regex to ``tool_call_parser=None`` and is intentionally out of scope
-    here (its aliases don't route through the Gemma 4 KV-share path).
+    Returns ``yes (default)`` for Gemma 4, ``no`` for every other family.
 
-    Family is read from the Gemma-4 parser stamp the profile already
-    carries, falling back to the name — no ``config.json`` read, so the
-    ``info`` fast path stays weight-free. On the rare unshared Gemma 4
-    checkpoint (``num_kv_shared_layers=0``) this over-reports, but that
-    configuration is non-canonical and the load-time guard
+    The ``(default)`` qualifier is deliberate and load-bearing for
+    honesty (codex #1112 [BLOCKING]): the ``rapid-mlx info`` fast path
+    does NOT read ``config.json``, so the true per-checkpoint
+    ``num_kv_shared_layers`` is not inspected here. Every shipped Gemma 4
+    checkpoint ships cross-layer KV-sharing on (``num_kv_shared_layers >
+    0`` — the last N decoder layers borrow an earlier layer's K/V;
+    default 20 on the vendored ``TextConfig``, verify-locked in #1104),
+    so ``yes (default)`` reports the family default rather than claiming a
+    verified read. On the rare non-canonical unshared checkpoint
+    (``num_kv_shared_layers=0``) the load-time guard
     (``gemma4_text._check_kv_share_config``) logs the real state at serve.
+
+    Gemma 3n shares the mechanism but is matched by the more specific
+    ``gemma-3n`` regex to ``tool_call_parser=None`` and is intentionally
+    out of scope here (its aliases don't route through the Gemma 4
+    KV-share path).
     """
-    is_gemma4 = (
-        cfg.tool_call_parser == "gemma4"
-        or cfg.reasoning_parser == "gemma4"
-        or bool(_GEMMA4_NAME_RE.search(cfg.hf_path or ""))
-        or bool(_GEMMA4_NAME_RE.search(model_path))
-    )
-    return "yes" if is_gemma4 else "no"
+    return "yes (default)" if _is_gemma4_family(model_path, cfg) else "no"
 
 
 def format_profile_summary(model_path: str, cfg: "ModelConfig | None") -> str:

--- a/vllm_mlx/model_auto_config.py
+++ b/vllm_mlx/model_auto_config.py
@@ -1683,15 +1683,18 @@ def format_profile_table(model_path: str, cfg: "ModelConfig | None") -> str:
             ("Reasoning parser", "(none)"),
             ("Architecture", "unknown"),
             ("Spec decode", "✓ default-on"),
-            # Truth-in-labeling: an unmatched family has no known native
-            # MTP head / KV-share config, so both default to the
-            # conservative "off" state until the model loads and the
-            # runtime probe / load-time guard reports the real config.
-            # ``MTP path`` stays within the documented native | sidecar |
-            # disabled contract (codex #1112 [NIT] round 4 — no fourth
-            # value).
-            ("MTP path", "disabled"),
-            ("KV-share", "no"),
+            # Truth-in-labeling: no regex/alias matched, so the
+            # architecture is genuinely UNKNOWN here — an opaquely named
+            # Qwen3.5 or Gemma 4 checkpoint would land in this branch too.
+            # Reporting a definite ``disabled`` / ``no`` would falsely
+            # claim the model lacks MTP / KV-sharing (codex #1112
+            # [BLOCKING] round 7). Report ``unknown`` until the model loads
+            # and the runtime probe / load-time guard reports the real
+            # config. ``unknown`` is the ONLY branch that emits this value;
+            # a matched profile always resolves to a definite token via
+            # ``_mtp_path_label`` / ``_kv_share_label``.
+            ("MTP path", "unknown (unmatched profile)"),
+            ("KV-share", "unknown (unmatched profile)"),
             ("Throttle", "✗ default-off"),
             (
                 "Suffix tier",
@@ -1727,10 +1730,12 @@ def format_profile_table(model_path: str, cfg: "ModelConfig | None") -> str:
             ("Spec decode", spec),
             # Truth-in-labeling for the MTP spec-decode path and Gemma 4
             # cross-layer KV-share, derived from the resolved profile (no
-            # weight load). ``MTP path`` = native | sidecar | disabled;
-            # ``KV-share`` = "yes (default)" | no (the ``(default)``
-            # qualifier is honest — the fast path reports the Gemma 4
-            # family default, not a per-checkpoint config.json read).
+            # weight load). For a MATCHED profile: ``MTP path`` = native |
+            # sidecar | disabled; ``KV-share`` = "yes (default)" | no (the
+            # ``(default)`` qualifier is honest — the fast path reports the
+            # Gemma 4 family default, not a per-checkpoint config.json
+            # read). The unmatched-profile (``cfg is None``) branch above
+            # reports ``unknown`` for both instead of a definite value.
             ("MTP path", _mtp_path_label(model_path, cfg)),
             ("KV-share", _kv_share_label(model_path, cfg)),
             ("Throttle", throttle),

--- a/vllm_mlx/model_auto_config.py
+++ b/vllm_mlx/model_auto_config.py
@@ -1493,15 +1493,24 @@ def _truncate_tier_note(text: str, max_width: int | None) -> str:
 # unrelated checkpoint, and (when both a Qwen and a Gemma marker appeared
 # in the path) the native branch stole Gemma's sidecar branch.
 #
-# codex #1112 [NIT]: the family tokens are boundary-anchored so an
-# unrelated substring (``Llama-3-hy3per-8B`` → ``hy3``, ``megemma4x`` →
-# ``gemma4``) does NOT match. ``(?:^|[^0-9a-z])`` / ``(?=$|[^0-9a-z])``
-# require the token to start/end at a name-segment boundary (a separator
-# ``-`` / ``_`` / ``.`` / ``/`` or the string edge), since HF names use
-# those separators between tokens. The family core allows an internal
-# separator (``qwen3.5`` / ``qwen3-5``, ``hy-v3`` / ``hyv3``).
+# codex #1112 [BLOCKING] round 5: the family token must be at the START
+# of the model-NAME segment — the architecture-position slot. HF model
+# names lead with the architecture family (``gemma-4-12b-it``,
+# ``Qwen3.5-4B``, ``Hy3-preview``); a family token appearing LATER in the
+# name is provenance, not the architecture (``Llama-3-Distilled-from-
+# Gemma-4`` is a Llama, ``Mistral-merge-of-Qwen3.5`` is a Mistral). The
+# leading ``^`` anchors to the segment start; the trailing
+# ``(?=$|[^0-9a-z])`` boundary still rejects substrings that merely begin
+# with the token (``gemma-40b``, ``qwen3.55``). This is verified against
+# the whole alias registry: every real Gemma 4 / HY3 / Qwen3.5 / Qwen3.6
+# checkpoint leads with its family token; only ``diffusiongemma`` (a
+# text-diffusion variant, correctly NOT a Gemma 4 KV-share checkpoint)
+# does not lead with ``gemma-4`` and is excluded.
+#
+# [NIT round 4] the family core still allows an internal separator
+# (``qwen3.5`` / ``qwen3-5``, ``hy-v3`` / ``hyv3``).
 _NATIVE_MTP_NAME_RE = re.compile(
-    r"(?:^|[^0-9a-z])(?:qwen3[._-]?[56]|hy[-_]?v?3|hunyuan[-_]?3)(?=$|[^0-9a-z])",
+    r"^(?:qwen3[._-]?[56]|hy[-_]?v?3|hunyuan[-_]?3)(?=$|[^0-9a-z])",
     re.IGNORECASE,
 )
 
@@ -1509,12 +1518,10 @@ _NATIVE_MTP_NAME_RE = re.compile(
 # ``gemma4_unified_assistant`` — see
 # ``vllm_mlx.spec_decode.mtp.gemma4_inject``), NOT a native head baked
 # into the checkpoint. Identify the family from the Gemma-4-specific
-# parser stamp the profile already carries (``tool_call_parser`` /
-# ``reasoning_parser`` == ``gemma4``), falling back to a boundary-anchored
-# name match against the extracted name segment only.
-_GEMMA4_NAME_RE = re.compile(
-    r"(?:^|[^0-9a-z])gemma[-_]?4(?=$|[^0-9a-z])", re.IGNORECASE
-)
+# parser stamp the profile carries; the name fallback (below) is
+# start-anchored to the architecture-position slot for the same reason as
+# the native-MTP regex above.
+_GEMMA4_NAME_RE = re.compile(r"^gemma[-_]?4(?=$|[^0-9a-z])", re.IGNORECASE)
 
 
 def _resolve_family(model_path: str, cfg: "ModelConfig") -> str:
@@ -1531,15 +1538,17 @@ def _resolve_family(model_path: str, cfg: "ModelConfig") -> str:
     Both callers (``_mtp_path_label`` / ``_kv_share_label``) consume this
     single function so their family view can never disagree.
 
-    The load-bearing signal is the **name marker on the extracted
-    model-NAME segment** — the canonical basename
+    The load-bearing signal is the **architecture-position family marker
+    on the extracted model-NAME segment** — the canonical basename
     (``_extract_model_name_segment``: org/parent dirs and HF-cache
-    intermediates stripped; boundary-anchored so substrings like
-    ``Llama-3-hy3per-8B`` / ``megemma4x`` don't match). The name segment
-    is REQUIRED (codex #1112 [BLOCKING] round 4): the parser stamp alone
-    is not trusted because ``detect_model_config``'s regex table matches
-    the FULL path, so an org/parent dir like ``gemma4-labs/Llama-3-8B``
-    yields a ``gemma4`` stamp on a non-Gemma model. Every real Gemma 4 /
+    intermediates stripped). The marker must lead the name segment
+    (``^``-anchored), so a substring (``Llama-3-hy3per-8B``) and a later
+    provenance token (``Llama-3-Distilled-from-Gemma-4`` is a Llama, not a
+    Gemma) are both rejected. The name segment is REQUIRED (codex #1112
+    [BLOCKING] round 4): the parser stamp alone is not trusted because
+    ``detect_model_config``'s regex table matches the FULL path, so an
+    org/parent dir like ``gemma4-labs/Llama-3-8B`` yields a ``gemma4``
+    stamp on a non-Gemma model. Every real Gemma 4 /
     HY3 / Qwen3.5 / Qwen3.6 checkpoint carries its family marker in the
     name segment, so requiring it costs nothing and closes the spoof.
     (It also correctly excludes ``diffusiongemma`` — a text-diffusion

--- a/vllm_mlx/model_auto_config.py
+++ b/vllm_mlx/model_auto_config.py
@@ -1493,24 +1493,35 @@ def _truncate_tier_note(text: str, max_width: int | None) -> str:
 # unrelated checkpoint, and (when both a Qwen and a Gemma marker appeared
 # in the path) the native branch stole Gemma's sidecar branch.
 #
-# codex #1112 [BLOCKING] round 5: the family token must be at the START
-# of the model-NAME segment — the architecture-position slot. HF model
-# names lead with the architecture family (``gemma-4-12b-it``,
-# ``Qwen3.5-4B``, ``Hy3-preview``); a family token appearing LATER in the
-# name is provenance, not the architecture (``Llama-3-Distilled-from-
-# Gemma-4`` is a Llama, ``Mistral-merge-of-Qwen3.5`` is a Mistral). The
-# leading ``^`` anchors to the segment start; the trailing
-# ``(?=$|[^0-9a-z])`` boundary still rejects substrings that merely begin
-# with the token (``gemma-40b``, ``qwen3.55``). This is verified against
-# the whole alias registry: every real Gemma 4 / HY3 / Qwen3.5 / Qwen3.6
-# checkpoint leads with its family token; only ``diffusiongemma`` (a
-# text-diffusion variant, correctly NOT a Gemma 4 KV-share checkpoint)
-# does not lead with ``gemma-4`` and is excluded.
+# codex #1112 [BLOCKING] round 5: the family token must be at the
+# architecture-position slot of the model-NAME segment. HF names lead
+# with the architecture family (``gemma-4-12b-it``, ``Qwen3.5-4B``,
+# ``Hy3-preview``); a family token appearing LATER is provenance, not the
+# architecture (``Llama-3-Distilled-from-Gemma-4`` is a Llama,
+# ``Mistral-merge-of-Qwen3.5`` is a Mistral). The trailing
+# ``(?=$|[^0-9a-z])`` boundary rejects substrings that merely begin with
+# the token (``gemma-40b``, ``qwen3.55``, ``megemma4x``, ``diffusiongemma``).
+#
+# codex #1112 [BLOCKING] round 9: a renamed/repackaged checkpoint may
+# prepend a quantization/format prefix before the architecture token
+# (``quantized-gemma-4-12b``, ``mlx-hy3-preview``, ``4bit-gemma-4-12b``).
+# ``_NAME_PREFIX`` allows a run of known repackaging prefixes before the
+# family token, so those resolve correctly — while a MID-name provenance
+# token (which is NOT one of these prefixes, e.g. ``distilled-from-`` /
+# ``merge-of-`` / ``based-on-``) is still rejected. Verified against the
+# whole alias registry: zero real Gemma 4 / HY3 / Qwen3.5 / Qwen3.6 alias
+# regresses.
 #
 # [NIT round 4] the family core still allows an internal separator
 # (``qwen3.5`` / ``qwen3-5``, ``hy-v3`` / ``hyv3``).
+_NAME_PREFIX = (
+    r"(?:(?:quantized|quant|mlx|gguf|awq|gptq|int4|int8|fp16|bf16|4bit|8bit|"
+    r"6bit|3bit|2bit|mxfp4|nvfp4|dwq|ud|optiq|turbo|q4|q8)[-_.])*"
+)
 _NATIVE_MTP_NAME_RE = re.compile(
-    r"^(?:qwen3[._-]?[56]|hy[-_]?v?3|hunyuan[-_]?3)(?=$|[^0-9a-z])",
+    r"^"
+    + _NAME_PREFIX
+    + r"(?:qwen3[._-]?[56]|hy[-_]?v?3|hunyuan[-_]?3)(?=$|[^0-9a-z])",
     re.IGNORECASE,
 )
 
@@ -1518,10 +1529,12 @@ _NATIVE_MTP_NAME_RE = re.compile(
 # ``gemma4_unified_assistant`` — see
 # ``vllm_mlx.spec_decode.mtp.gemma4_inject``), NOT a native head baked
 # into the checkpoint. Identify the family from the Gemma-4-specific
-# parser stamp the profile carries; the name fallback (below) is
-# start-anchored to the architecture-position slot for the same reason as
-# the native-MTP regex above.
-_GEMMA4_NAME_RE = re.compile(r"^gemma[-_]?4(?=$|[^0-9a-z])", re.IGNORECASE)
+# parser stamp the profile carries; the name fallback (below) is anchored
+# to the architecture-position slot (optional ``_NAME_PREFIX`` allowed)
+# for the same reason as the native-MTP regex above.
+_GEMMA4_NAME_RE = re.compile(
+    r"^" + _NAME_PREFIX + r"gemma[-_]?4(?=$|[^0-9a-z])", re.IGNORECASE
+)
 
 
 def _resolve_family(model_path: str, cfg: "ModelConfig") -> str:
@@ -1555,13 +1568,15 @@ def _resolve_family(model_path: str, cfg: "ModelConfig") -> str:
     variant that carries the ``gemma4`` parser stamp but is not a
     canonical Gemma 4 KV-share checkpoint.)
 
-    Because both name regexes are anchored to the segment START and their
-    leading tokens are disjoint (``gemma-4`` begins with ``g``; the
-    native tokens begin with ``q`` / ``h``), at most ONE can match — the
-    leading (architecture-position) token alone decides the family, so no
-    tie-break is needed. A merge name resolves to whichever family it
-    leads with (``Qwen3.5-gemma-4-merge`` → native; ``gemma-4-qwen3.5-
-    merge`` → gemma4). A name that leads with neither is ``other``.
+    Because both name regexes are anchored to the architecture-position
+    slot (segment start, after an optional ``_NAME_PREFIX`` run of
+    quant/format prefixes) and their family tokens are disjoint, at most
+    ONE can match — the leading architecture token alone decides the
+    family, so no tie-break is needed. A merge name resolves to whichever
+    family it leads with (``Qwen3.5-gemma-4-merge`` → native;
+    ``gemma-4-qwen3.5-merge`` → gemma4); a repackaged name resolves
+    through its quant prefix (``quantized-gemma-4-12b`` → gemma4). A name
+    that leads with neither is ``other``.
     """
     name_seg = _extract_model_name_segment((cfg.hf_path or model_path).lower())
     if _GEMMA4_NAME_RE.search(name_seg):

--- a/vllm_mlx/model_auto_config.py
+++ b/vllm_mlx/model_auto_config.py
@@ -1472,6 +1472,104 @@ def _truncate_tier_note(text: str, max_width: int | None) -> str:
     return text
 
 
+# Families whose checkpoints ship a NATIVE multi-token-prediction (MTP)
+# head baked into the model class — the engine drives it directly, no
+# separate drafter model. This mirrors the authoritative
+# ``vllm_mlx.spec_decode.mtp.detect._SUPPORTED_MODEL_TYPES`` allowlist
+# (``qwen3_5`` / ``qwen3_5_moe`` / ``hy_v3``) but is derived from the
+# name-regex-resolved profile rather than a loaded ``config.json`` so the
+# ``rapid-mlx info`` fast path stays weight-free. Kept as a small local
+# regex (not an import from the operator-owned ``spec_decode`` package)
+# so this display helper has no coupling into that lane. Qwen3.5 and the
+# dense/MoE Qwen3.6 release share the ``qwen3_5`` model_type upstream, so
+# one ``qwen3\.[56]`` regex covers both; HY3 (Tencent Hunyuan 3) carries
+# a DeepSeek-V3-style native MTP head.
+_NATIVE_MTP_NAME_RE = re.compile(r"qwen3[._]?[56]|hy[-_]?v?3|hunyuan[-_]?3", re.IGNORECASE)
+
+# Gemma 4 uses an assistant/sidecar drafter (``gemma4_assistant`` /
+# ``gemma4_unified_assistant`` — see
+# ``vllm_mlx.spec_decode.mtp.gemma4_inject``), NOT a native head baked
+# into the checkpoint. Identify the family from the Gemma-4-specific
+# parser stamp the profile already carries (``tool_call_parser`` /
+# ``reasoning_parser`` == ``gemma4``), falling back to the name.
+_GEMMA4_NAME_RE = re.compile(r"gemma[-_]?4", re.IGNORECASE)
+
+
+def _mtp_path_label(model_path: str, cfg: "ModelConfig") -> str:
+    """Truth-in-labeling for the MTP spec-decode path of a model.
+
+    Returns one of ``native`` / ``sidecar`` / ``disabled``:
+
+    * ``native``   — the family ships a native MTP head in the checkpoint
+      (Qwen3.5 / Qwen3.6 / HY3) AND the resolved profile enables spec
+      decode (``supports_spec_decode=True``). This is the path
+      ``vllm_mlx.spec_decode.mtp`` drives directly.
+    * ``sidecar``  — Gemma 4: MTP is provided by an assistant drafter
+      loaded alongside the base weights (no head baked in), and the
+      profile enables spec decode.
+    * ``disabled`` — spec decode is off for this profile
+      (``supports_spec_decode=False`` — hybrid arch, or no MTP head /
+      drafter registered for this alias), OR the family has no MTP
+      mechanism at all (SuffixDecoding / DFlash are separate lanes and
+      are surfaced by the ``Spec decode`` / ``Suffix tier`` rows, not
+      here — this row is specifically about MTP).
+
+    Derivation is from the name-regex profile only (no ``config.json``
+    read), keeping the ``rapid-mlx info`` path weight-free.
+    """
+    is_gemma4 = (
+        cfg.tool_call_parser == "gemma4"
+        or cfg.reasoning_parser == "gemma4"
+        or bool(_GEMMA4_NAME_RE.search(cfg.hf_path or ""))
+        or bool(_GEMMA4_NAME_RE.search(model_path))
+    )
+    is_native_mtp_family = bool(
+        _NATIVE_MTP_NAME_RE.search(cfg.hf_path or "")
+        or _NATIVE_MTP_NAME_RE.search(model_path)
+        or cfg.tool_call_parser == "hy_v3"
+        or cfg.reasoning_parser == "hy_v3"
+    )
+
+    if not cfg.supports_spec_decode:
+        # Honest: the profile has spec decode gated off (hybrid arch, or
+        # no MTP head/drafter registered for this alias). Even for a
+        # native-MTP family the head isn't wired for this checkpoint.
+        return "disabled"
+    if is_native_mtp_family:
+        return "native"
+    if is_gemma4:
+        return "sidecar"
+    # Spec decode is on but via a non-MTP mechanism (SuffixDecoding).
+    return "disabled"
+
+
+def _kv_share_label(model_path: str, cfg: "ModelConfig") -> str:
+    """Truth-in-labeling for Gemma 4 cross-layer KV-sharing.
+
+    Returns ``yes`` for Gemma 4 (every shipped Gemma 4 checkpoint declares
+    ``num_kv_shared_layers > 0`` — the last N decoder layers borrow an
+    earlier layer's K/V; default 20 on the vendored ``TextConfig``,
+    verify-locked in #1104), ``no`` for every other family. Gemma 3n
+    shares the mechanism but is matched by the more specific ``gemma-3n``
+    regex to ``tool_call_parser=None`` and is intentionally out of scope
+    here (its aliases don't route through the Gemma 4 KV-share path).
+
+    Family is read from the Gemma-4 parser stamp the profile already
+    carries, falling back to the name — no ``config.json`` read, so the
+    ``info`` fast path stays weight-free. On the rare unshared Gemma 4
+    checkpoint (``num_kv_shared_layers=0``) this over-reports, but that
+    configuration is non-canonical and the load-time guard
+    (``gemma4_text._check_kv_share_config``) logs the real state at serve.
+    """
+    is_gemma4 = (
+        cfg.tool_call_parser == "gemma4"
+        or cfg.reasoning_parser == "gemma4"
+        or bool(_GEMMA4_NAME_RE.search(cfg.hf_path or ""))
+        or bool(_GEMMA4_NAME_RE.search(model_path))
+    )
+    return "yes" if is_gemma4 else "no"
+
+
 def format_profile_summary(model_path: str, cfg: "ModelConfig | None") -> str:
     """Single-line profile summary for startup logs (Level 1).
 
@@ -1519,6 +1617,12 @@ def format_profile_table(model_path: str, cfg: "ModelConfig | None") -> str:
             ("Reasoning parser", "(none)"),
             ("Architecture", "unknown"),
             ("Spec decode", "✓ default-on"),
+            # Truth-in-labeling: an unmatched family has no known native
+            # MTP head / KV-share config, so both default to the
+            # conservative "off" state until the model loads and the
+            # runtime probe / load-time guard reports the real config.
+            ("MTP path", "disabled (unknown family)"),
+            ("KV-share", "no"),
             ("Throttle", "✗ default-off"),
             (
                 "Suffix tier",
@@ -1552,6 +1656,12 @@ def format_profile_table(model_path: str, cfg: "ModelConfig | None") -> str:
             ("Reasoning parser", cfg.reasoning_parser or "(none)"),
             ("Architecture", _arch_label(cfg)),
             ("Spec decode", spec),
+            # Truth-in-labeling for the MTP spec-decode path and Gemma 4
+            # cross-layer KV-share, derived from the resolved profile (no
+            # weight load). ``MTP path`` = native | sidecar | disabled;
+            # ``KV-share`` = yes | no.
+            ("MTP path", _mtp_path_label(model_path, cfg)),
+            ("KV-share", _kv_share_label(model_path, cfg)),
             ("Throttle", throttle),
             ("Suffix tier", _suffix_tier_cell(cfg, max_width=value_width)),
         ]

--- a/vllm_mlx/model_auto_config.py
+++ b/vllm_mlx/model_auto_config.py
@@ -1555,33 +1555,18 @@ def _resolve_family(model_path: str, cfg: "ModelConfig") -> str:
     variant that carries the ``gemma4`` parser stamp but is not a
     canonical Gemma 4 KV-share checkpoint.)
 
-    The parser stamp is used only as a TIE-BREAKER when the segment
-    carries BOTH a Gemma 4 and a native-MTP marker (a merge/distill name):
-    an authoritative ``gemma4`` / ``hy_v3`` stamp picks the family;
-    without one the name is genuinely ambiguous and we return ``"other"``
-    so the row degrades to the conservative ``disabled`` / ``no`` rather
-    than guessing.
+    Because both name regexes are anchored to the segment START and their
+    leading tokens are disjoint (``gemma-4`` begins with ``g``; the
+    native tokens begin with ``q`` / ``h``), at most ONE can match — the
+    leading (architecture-position) token alone decides the family, so no
+    tie-break is needed. A merge name resolves to whichever family it
+    leads with (``Qwen3.5-gemma-4-merge`` → native; ``gemma-4-qwen3.5-
+    merge`` → gemma4). A name that leads with neither is ``other``.
     """
     name_seg = _extract_model_name_segment((cfg.hf_path or model_path).lower())
-    is_gemma4 = bool(_GEMMA4_NAME_RE.search(name_seg))
-    is_native = bool(_NATIVE_MTP_NAME_RE.search(name_seg))
-
-    if is_gemma4 and is_native:
-        # Ambiguous segment — let an authoritative parser stamp break the
-        # tie; otherwise do not guess.
-        tcp, rp = cfg.tool_call_parser, cfg.reasoning_parser
-        if (tcp == "gemma4" or rp == "gemma4") and not (
-            tcp == "hy_v3" or rp == "hy_v3"
-        ):
-            return "gemma4"
-        if (tcp == "hy_v3" or rp == "hy_v3") and not (
-            tcp == "gemma4" or rp == "gemma4"
-        ):
-            return "native_mtp"
-        return "other"
-    if is_gemma4:
+    if _GEMMA4_NAME_RE.search(name_seg):
         return "gemma4"
-    if is_native:
+    if _NATIVE_MTP_NAME_RE.search(name_seg):
         return "native_mtp"
     return "other"
 
@@ -1743,7 +1728,9 @@ def format_profile_table(model_path: str, cfg: "ModelConfig | None") -> str:
             # Truth-in-labeling for the MTP spec-decode path and Gemma 4
             # cross-layer KV-share, derived from the resolved profile (no
             # weight load). ``MTP path`` = native | sidecar | disabled;
-            # ``KV-share`` = yes | no.
+            # ``KV-share`` = "yes (default)" | no (the ``(default)``
+            # qualifier is honest — the fast path reports the Gemma 4
+            # family default, not a per-checkpoint config.json read).
             ("MTP path", _mtp_path_label(model_path, cfg)),
             ("KV-share", _kv_share_label(model_path, cfg)),
             ("Throttle", throttle),

--- a/vllm_mlx/model_auto_config.py
+++ b/vllm_mlx/model_auto_config.py
@@ -1517,54 +1517,53 @@ _GEMMA4_NAME_RE = re.compile(
 )
 
 
-def _is_gemma4_family(model_path: str, cfg: "ModelConfig") -> bool:
-    """True iff the resolved profile is a Gemma 4 checkpoint.
+def _resolve_family(model_path: str, cfg: "ModelConfig") -> str:
+    """Single authoritative family discriminator for the info rows.
 
-    Family is decided from the Gemma-4-specific parser stamp the profile
-    already carries (the single source of truth set by the
-    precedence-ordered detection in ``detect_model_config`` — Gemma 3n
-    matches the earlier ``gemma-3n`` regex to ``tool_call_parser=None``
-    and is therefore excluded). The name match is a fallback for
-    direct-HF-path serves whose parser stamp is a generic default, and is
-    scoped to the extracted model-NAME segment so an org/parent dir
-    cannot spoof the family.
+    Returns exactly one of:
 
-    codex #1112 [BLOCKING] round 2: the authoritative ``hy_v3`` native
-    stamp WINS over a stray ``gemma4`` name marker. Without this a
-    hypothetical ``Hy3-distilled-from-Gemma-4`` (native ``hy_v3`` parser
-    stamp + ``gemma-4`` in the name) would be mislabeled ``sidecar`` /
-    ``KV-share: yes`` instead of ``native`` / ``no``. Explicit family
-    stamps are resolved before any name fallback.
+    * ``"gemma4"``     — Gemma 4 (sidecar MTP drafter + cross-layer
+      KV-share).
+    * ``"native_mtp"`` — a native-MTP-head family (Qwen3.5 / Qwen3.6 /
+      HY3).
+    * ``"other"``      — anything else, INCLUDING an ambiguous name that
+      carries BOTH a Gemma 4 and a native-MTP marker with no parser stamp
+      to disambiguate (conservative — codex #1112 [BLOCKING] round 3).
+
+    Resolution order (first authoritative signal wins), so both callers
+    (``_mtp_path_label`` / ``_kv_share_label``) always agree and there is
+    no per-caller check-ordering that could disagree:
+
+    1. Parser stamp — the single source of truth set by
+       ``detect_model_config``'s precedence-ordered detection. ``gemma4``
+       ⇒ Gemma 4; ``hy_v3`` ⇒ native. A stamp is authoritative and a
+       stray opposite-family NAME marker cannot override it (a
+       ``Hy3-distilled-from-Gemma-4`` with a ``hy_v3`` stamp is native).
+    2. Name markers on the extracted model-NAME segment (basename only;
+       org/parent dirs stripped; boundary-anchored so substrings like
+       ``Llama-3-hy3per-8B`` / ``megemma4x`` don't match). If EXACTLY one
+       family's marker is present, that family wins. If BOTH are present
+       (a genuinely ambiguous name with no stamp), return ``"other"`` so
+       the row degrades to the conservative ``disabled`` / ``no`` rather
+       than guessing.
     """
-    # A native-MTP parser stamp is authoritative and excludes Gemma 4.
-    if cfg.tool_call_parser == "hy_v3" or cfg.reasoning_parser == "hy_v3":
-        return False
-    if cfg.tool_call_parser == "gemma4" or cfg.reasoning_parser == "gemma4":
-        return True
+    tcp, rp = cfg.tool_call_parser, cfg.reasoning_parser
+    if tcp == "gemma4" or rp == "gemma4":
+        return "gemma4"
+    if tcp == "hy_v3" or rp == "hy_v3":
+        return "native_mtp"
+
     name_seg = _extract_model_name_segment((cfg.hf_path or model_path).lower())
-    return bool(_GEMMA4_NAME_RE.search(name_seg))
-
-
-def _is_native_mtp_family(model_path: str, cfg: "ModelConfig") -> bool:
-    """True iff the resolved profile is a native-MTP-head family.
-
-    HY3 carries a unique ``hy_v3`` parser stamp (SSOT). Qwen3.5 / Qwen3.6
-    share the generic ``hermes`` / ``qwen3_coder_xml`` parsers with
-    non-MTP Qwen variants, so those need a name match — scoped to the
-    extracted model-NAME segment (not the full path) so an org/parent dir
-    cannot spoof the family, and boundary-anchored so an unrelated
-    substring (``Llama-3-hy3per-8B``) does not match.
-
-    A ``gemma4`` parser stamp is authoritative and excludes the native
-    family (Gemma 4 uses the sidecar drafter), mirroring the reciprocal
-    exclusion in ``_is_gemma4_family``.
-    """
-    if cfg.tool_call_parser == "gemma4" or cfg.reasoning_parser == "gemma4":
-        return False
-    if cfg.tool_call_parser == "hy_v3" or cfg.reasoning_parser == "hy_v3":
-        return True
-    name_seg = _extract_model_name_segment((cfg.hf_path or model_path).lower())
-    return bool(_NATIVE_MTP_NAME_RE.search(name_seg))
+    is_gemma4 = bool(_GEMMA4_NAME_RE.search(name_seg))
+    is_native = bool(_NATIVE_MTP_NAME_RE.search(name_seg))
+    if is_gemma4 and is_native:
+        # Ambiguous, no stamp — do not guess.
+        return "other"
+    if is_gemma4:
+        return "gemma4"
+    if is_native:
+        return "native_mtp"
+    return "other"
 
 
 def _mtp_path_label(model_path: str, cfg: "ModelConfig") -> str:
@@ -1581,10 +1580,10 @@ def _mtp_path_label(model_path: str, cfg: "ModelConfig") -> str:
       profile enables spec decode.
     * ``disabled`` — spec decode is off for this profile
       (``supports_spec_decode=False`` — hybrid arch, or no MTP head /
-      drafter registered for this alias), OR the family has no MTP
-      mechanism at all (SuffixDecoding / DFlash are separate lanes and
-      are surfaced by the ``Spec decode`` / ``Suffix tier`` rows, not
-      here — this row is specifically about MTP).
+      drafter registered for this alias), the family has no MTP mechanism
+      at all (SuffixDecoding / DFlash are separate lanes surfaced by the
+      ``Spec decode`` / ``Suffix tier`` rows), or the family is ambiguous
+      (see ``_resolve_family``).
 
     Derivation is from the resolved profile only (no ``config.json``
     read), keeping the ``rapid-mlx info`` path weight-free.
@@ -1594,40 +1593,42 @@ def _mtp_path_label(model_path: str, cfg: "ModelConfig") -> str:
         # no MTP head/drafter registered for this alias). Even for a
         # native-MTP family the head isn't wired for this checkpoint.
         return "disabled"
-    # Gemma 4 (sidecar) is checked before the native-MTP family so a path
-    # that somehow carries both markers resolves to the correct
-    # parser-stamped family rather than letting the native branch win.
-    if _is_gemma4_family(model_path, cfg):
+    family = _resolve_family(model_path, cfg)
+    if family == "gemma4":
         return "sidecar"
-    if _is_native_mtp_family(model_path, cfg):
+    if family == "native_mtp":
         return "native"
-    # Spec decode is on but via a non-MTP mechanism (SuffixDecoding).
+    # Spec decode is on but via a non-MTP mechanism (SuffixDecoding), or
+    # the family could not be disambiguated.
     return "disabled"
 
 
 def _kv_share_label(model_path: str, cfg: "ModelConfig") -> str:
-    """Truth-in-labeling for Gemma 4 cross-layer KV-sharing.
+    """Truth-in-labeling for cross-layer KV-sharing.
 
     Returns ``yes (default)`` for Gemma 4, ``no`` for every other family.
 
-    The ``(default)`` qualifier is deliberate and load-bearing for
-    honesty (codex #1112 [BLOCKING]): the ``rapid-mlx info`` fast path
-    does NOT read ``config.json``, so the true per-checkpoint
-    ``num_kv_shared_layers`` is not inspected here. Every shipped Gemma 4
-    checkpoint ships cross-layer KV-sharing on (``num_kv_shared_layers >
-    0`` — the last N decoder layers borrow an earlier layer's K/V;
-    default 20 on the vendored ``TextConfig``, verify-locked in #1104),
-    so ``yes (default)`` reports the family default rather than claiming a
+    Scope is deliberately Gemma 4 only: it is the sole family with a
+    cross-layer KV-share code path in this engine (the vendored
+    ``gemma4_vendored`` decoder, guard + 5-size test verify-locked in
+    #1104). Gemma 3n has no model implementation here (its aliases carry
+    ``tool_call_parser=None`` and route through the generic lane), so this
+    row makes no claim about it — reporting ``no`` for a family the engine
+    does not drive with KV-sharing is the honest answer, not a false
+    negative (codex #1112 [BLOCKING] round 3).
+
+    The ``(default)`` qualifier is load-bearing for honesty: the
+    ``rapid-mlx info`` fast path does NOT read ``config.json``, so the
+    true per-checkpoint ``num_kv_shared_layers`` is not inspected here.
+    Every shipped Gemma 4 checkpoint ships cross-layer KV-sharing on
+    (``num_kv_shared_layers > 0`` — the last N decoder layers borrow an
+    earlier layer's K/V; default 20 on the vendored ``TextConfig``), so
+    ``yes (default)`` reports the family default rather than claiming a
     verified read. On the rare non-canonical unshared checkpoint
     (``num_kv_shared_layers=0``) the load-time guard
     (``gemma4_text._check_kv_share_config``) logs the real state at serve.
-
-    Gemma 3n shares the mechanism but is matched by the more specific
-    ``gemma-3n`` regex to ``tool_call_parser=None`` and is intentionally
-    out of scope here (its aliases don't route through the Gemma 4
-    KV-share path).
     """
-    return "yes (default)" if _is_gemma4_family(model_path, cfg) else "no"
+    return "yes (default)" if _resolve_family(model_path, cfg) == "gemma4" else "no"
 
 
 def format_profile_summary(model_path: str, cfg: "ModelConfig | None") -> str:

--- a/vllm_mlx/model_auto_config.py
+++ b/vllm_mlx/model_auto_config.py
@@ -1492,8 +1492,17 @@ def _truncate_tier_note(text: str, max_width: int | None) -> str:
 # org or parent directory named e.g. ``qwen3.5-org/…`` mislabel an
 # unrelated checkpoint, and (when both a Qwen and a Gemma marker appeared
 # in the path) the native branch stole Gemma's sidecar branch.
+#
+# codex #1112 [NIT]: the family tokens are boundary-anchored so an
+# unrelated substring (``Llama-3-hy3per-8B`` → ``hy3``, ``megemma4x`` →
+# ``gemma4``) does NOT match. ``(?:^|[^0-9a-z])`` / ``(?=$|[^0-9a-z])``
+# require the token to start/end at a name-segment boundary (a separator
+# ``-`` / ``_`` / ``.`` / ``/`` or the string edge), since HF names use
+# those separators between tokens. The family core allows an internal
+# separator (``qwen3.5`` / ``qwen3-5``, ``hy-v3`` / ``hyv3``).
 _NATIVE_MTP_NAME_RE = re.compile(
-    r"qwen3[._]?[56]|hy[-_]?v?3|hunyuan[-_]?3", re.IGNORECASE
+    r"(?:^|[^0-9a-z])(?:qwen3[._-]?[56]|hy[-_]?v?3|hunyuan[-_]?3)(?=$|[^0-9a-z])",
+    re.IGNORECASE,
 )
 
 # Gemma 4 uses an assistant/sidecar drafter (``gemma4_assistant`` /
@@ -1501,9 +1510,11 @@ _NATIVE_MTP_NAME_RE = re.compile(
 # ``vllm_mlx.spec_decode.mtp.gemma4_inject``), NOT a native head baked
 # into the checkpoint. Identify the family from the Gemma-4-specific
 # parser stamp the profile already carries (``tool_call_parser`` /
-# ``reasoning_parser`` == ``gemma4``), falling back to a name match
-# against the extracted name segment only.
-_GEMMA4_NAME_RE = re.compile(r"gemma[-_]?4", re.IGNORECASE)
+# ``reasoning_parser`` == ``gemma4``), falling back to a boundary-anchored
+# name match against the extracted name segment only.
+_GEMMA4_NAME_RE = re.compile(
+    r"(?:^|[^0-9a-z])gemma[-_]?4(?=$|[^0-9a-z])", re.IGNORECASE
+)
 
 
 def _is_gemma4_family(model_path: str, cfg: "ModelConfig") -> bool:
@@ -1517,7 +1528,17 @@ def _is_gemma4_family(model_path: str, cfg: "ModelConfig") -> bool:
     direct-HF-path serves whose parser stamp is a generic default, and is
     scoped to the extracted model-NAME segment so an org/parent dir
     cannot spoof the family.
+
+    codex #1112 [BLOCKING] round 2: the authoritative ``hy_v3`` native
+    stamp WINS over a stray ``gemma4`` name marker. Without this a
+    hypothetical ``Hy3-distilled-from-Gemma-4`` (native ``hy_v3`` parser
+    stamp + ``gemma-4`` in the name) would be mislabeled ``sidecar`` /
+    ``KV-share: yes`` instead of ``native`` / ``no``. Explicit family
+    stamps are resolved before any name fallback.
     """
+    # A native-MTP parser stamp is authoritative and excludes Gemma 4.
+    if cfg.tool_call_parser == "hy_v3" or cfg.reasoning_parser == "hy_v3":
+        return False
     if cfg.tool_call_parser == "gemma4" or cfg.reasoning_parser == "gemma4":
         return True
     name_seg = _extract_model_name_segment((cfg.hf_path or model_path).lower())
@@ -1531,8 +1552,15 @@ def _is_native_mtp_family(model_path: str, cfg: "ModelConfig") -> bool:
     share the generic ``hermes`` / ``qwen3_coder_xml`` parsers with
     non-MTP Qwen variants, so those need a name match — scoped to the
     extracted model-NAME segment (not the full path) so an org/parent dir
-    cannot spoof the family.
+    cannot spoof the family, and boundary-anchored so an unrelated
+    substring (``Llama-3-hy3per-8B``) does not match.
+
+    A ``gemma4`` parser stamp is authoritative and excludes the native
+    family (Gemma 4 uses the sidecar drafter), mirroring the reciprocal
+    exclusion in ``_is_gemma4_family``.
     """
+    if cfg.tool_call_parser == "gemma4" or cfg.reasoning_parser == "gemma4":
+        return False
     if cfg.tool_call_parser == "hy_v3" or cfg.reasoning_parser == "hy_v3":
         return True
     name_seg = _extract_model_name_segment((cfg.hf_path or model_path).lower())

--- a/vllm_mlx/model_auto_config.py
+++ b/vllm_mlx/model_auto_config.py
@@ -1526,38 +1526,49 @@ def _resolve_family(model_path: str, cfg: "ModelConfig") -> str:
       KV-share).
     * ``"native_mtp"`` — a native-MTP-head family (Qwen3.5 / Qwen3.6 /
       HY3).
-    * ``"other"``      — anything else, INCLUDING an ambiguous name that
-      carries BOTH a Gemma 4 and a native-MTP marker with no parser stamp
-      to disambiguate (conservative — codex #1112 [BLOCKING] round 3).
+    * ``"other"``      — anything else, including ambiguous names.
 
-    Resolution order (first authoritative signal wins), so both callers
-    (``_mtp_path_label`` / ``_kv_share_label``) always agree and there is
-    no per-caller check-ordering that could disagree:
+    Both callers (``_mtp_path_label`` / ``_kv_share_label``) consume this
+    single function so their family view can never disagree.
 
-    1. Parser stamp — the single source of truth set by
-       ``detect_model_config``'s precedence-ordered detection. ``gemma4``
-       ⇒ Gemma 4; ``hy_v3`` ⇒ native. A stamp is authoritative and a
-       stray opposite-family NAME marker cannot override it (a
-       ``Hy3-distilled-from-Gemma-4`` with a ``hy_v3`` stamp is native).
-    2. Name markers on the extracted model-NAME segment (basename only;
-       org/parent dirs stripped; boundary-anchored so substrings like
-       ``Llama-3-hy3per-8B`` / ``megemma4x`` don't match). If EXACTLY one
-       family's marker is present, that family wins. If BOTH are present
-       (a genuinely ambiguous name with no stamp), return ``"other"`` so
-       the row degrades to the conservative ``disabled`` / ``no`` rather
-       than guessing.
+    The load-bearing signal is the **name marker on the extracted
+    model-NAME segment** — the canonical basename
+    (``_extract_model_name_segment``: org/parent dirs and HF-cache
+    intermediates stripped; boundary-anchored so substrings like
+    ``Llama-3-hy3per-8B`` / ``megemma4x`` don't match). The name segment
+    is REQUIRED (codex #1112 [BLOCKING] round 4): the parser stamp alone
+    is not trusted because ``detect_model_config``'s regex table matches
+    the FULL path, so an org/parent dir like ``gemma4-labs/Llama-3-8B``
+    yields a ``gemma4`` stamp on a non-Gemma model. Every real Gemma 4 /
+    HY3 / Qwen3.5 / Qwen3.6 checkpoint carries its family marker in the
+    name segment, so requiring it costs nothing and closes the spoof.
+    (It also correctly excludes ``diffusiongemma`` — a text-diffusion
+    variant that carries the ``gemma4`` parser stamp but is not a
+    canonical Gemma 4 KV-share checkpoint.)
+
+    The parser stamp is used only as a TIE-BREAKER when the segment
+    carries BOTH a Gemma 4 and a native-MTP marker (a merge/distill name):
+    an authoritative ``gemma4`` / ``hy_v3`` stamp picks the family;
+    without one the name is genuinely ambiguous and we return ``"other"``
+    so the row degrades to the conservative ``disabled`` / ``no`` rather
+    than guessing.
     """
-    tcp, rp = cfg.tool_call_parser, cfg.reasoning_parser
-    if tcp == "gemma4" or rp == "gemma4":
-        return "gemma4"
-    if tcp == "hy_v3" or rp == "hy_v3":
-        return "native_mtp"
-
     name_seg = _extract_model_name_segment((cfg.hf_path or model_path).lower())
     is_gemma4 = bool(_GEMMA4_NAME_RE.search(name_seg))
     is_native = bool(_NATIVE_MTP_NAME_RE.search(name_seg))
+
     if is_gemma4 and is_native:
-        # Ambiguous, no stamp — do not guess.
+        # Ambiguous segment — let an authoritative parser stamp break the
+        # tie; otherwise do not guess.
+        tcp, rp = cfg.tool_call_parser, cfg.reasoning_parser
+        if (tcp == "gemma4" or rp == "gemma4") and not (
+            tcp == "hy_v3" or rp == "hy_v3"
+        ):
+            return "gemma4"
+        if (tcp == "hy_v3" or rp == "hy_v3") and not (
+            tcp == "gemma4" or rp == "gemma4"
+        ):
+            return "native_mtp"
         return "other"
     if is_gemma4:
         return "gemma4"
@@ -1682,7 +1693,10 @@ def format_profile_table(model_path: str, cfg: "ModelConfig | None") -> str:
             # MTP head / KV-share config, so both default to the
             # conservative "off" state until the model loads and the
             # runtime probe / load-time guard reports the real config.
-            ("MTP path", "disabled (unknown family)"),
+            # ``MTP path`` stays within the documented native | sidecar |
+            # disabled contract (codex #1112 [NIT] round 4 — no fourth
+            # value).
+            ("MTP path", "disabled"),
             ("KV-share", "no"),
             ("Throttle", "✗ default-off"),
             (

--- a/vllm_mlx/model_auto_config.py
+++ b/vllm_mlx/model_auto_config.py
@@ -1528,10 +1528,12 @@ _NATIVE_MTP_NAME_RE = re.compile(
 # Gemma 4 uses an assistant/sidecar drafter (``gemma4_assistant`` /
 # ``gemma4_unified_assistant`` — see
 # ``vllm_mlx.spec_decode.mtp.gemma4_inject``), NOT a native head baked
-# into the checkpoint. Identify the family from the Gemma-4-specific
-# parser stamp the profile carries; the name fallback (below) is anchored
-# to the architecture-position slot (optional ``_NAME_PREFIX`` allowed)
-# for the same reason as the native-MTP regex above.
+# into the checkpoint. ``_resolve_family`` identifies the family from this
+# name marker on the extracted NAME segment — a name-only discriminator
+# (the parser stamp is deliberately NOT consulted: it can be spoofed by an
+# org/parent dir on the full path — see ``_resolve_family``). Anchored to
+# the architecture-position slot (optional ``_NAME_PREFIX`` allowed) for
+# the same reason as the native-MTP regex above.
 _GEMMA4_NAME_RE = re.compile(
     r"^" + _NAME_PREFIX + r"gemma[-_]?4(?=$|[^0-9a-z])", re.IGNORECASE
 )

--- a/vllm_mlx/model_runner.py
+++ b/vllm_mlx/model_runner.py
@@ -434,8 +434,15 @@ class MLXModelRunner:
                     }
                 )
 
-            # Add optimization status
+            # Add optimization status. ``kernel_fusion`` is retained as a
+            # permanently-``False`` compatibility key: the always-on
+            # ``mx.compile`` forward-pass fusion it reported was rejected
+            # (A5 — bucketed compile regressed batch=1 decode; the win was
+            # already captured by ``mx.async_eval``) and its dead code was
+            # removed, but any external caller that indexes this key keeps
+            # a stable dict shape instead of hitting a ``KeyError``.
             info["optimizations"] = {
+                "kernel_fusion": False,
                 "memory_optimized": self._hardware_info is not None,
             }
 

--- a/vllm_mlx/model_runner.py
+++ b/vllm_mlx/model_runner.py
@@ -155,6 +155,11 @@ class MLXModelRunner:
 
     def _apply_optimizations(self) -> None:
         """Apply low-level optimizations for maximum performance."""
+        # Reset at entry so a failed RE-attempt after a prior success does
+        # not leave the runner falsely reporting ``optimized`` (codex
+        # #1112 [NIT] round 8). The flag is re-set True only if this
+        # attempt completes.
+        self._optimizations_applied = False
         try:
             from vllm_mlx.optimizations import (
                 configure_memory_optimization,

--- a/vllm_mlx/model_runner.py
+++ b/vllm_mlx/model_runner.py
@@ -103,6 +103,12 @@ class MLXModelRunner:
         # Optimization settings
         self._enable_optimizations = enable_optimizations
         self._hardware_info = None  # Detected hardware profile
+        # Set True only after ``_apply_optimizations`` completes without
+        # raising. ``_hardware_info`` being populated is NOT proof of
+        # success: ``configure_memory_optimization()`` can raise AFTER the
+        # hardware probe, and that exception is caught + logged. Derive the
+        # ``optimized`` status from this flag, not from ``_hardware_info``.
+        self._optimizations_applied = False
 
         logger.info(f"MLXModelRunner initialized for model: {self.model_config.model}")
         logger.info(
@@ -163,6 +169,9 @@ class MLXModelRunner:
 
             # Configure memory settings
             configure_memory_optimization()
+
+            # Reached only if every step above succeeded.
+            self._optimizations_applied = True
 
         except Exception as e:
             logger.warning(f"Failed to apply optimizations: {e}")
@@ -443,7 +452,7 @@ class MLXModelRunner:
             # a stable dict shape instead of hitting a ``KeyError``.
             info["optimizations"] = {
                 "kernel_fusion": False,
-                "memory_optimized": self._hardware_info is not None,
+                "memory_optimized": self._optimizations_applied,
             }
 
             if self._hardware_info:
@@ -459,5 +468,5 @@ class MLXModelRunner:
 
     def __repr__(self) -> str:
         status = "loaded" if self._loaded else "not loaded"
-        opt_status = "optimized" if self._hardware_info else "standard"
+        opt_status = "optimized" if self._optimizations_applied else "standard"
         return f"<MLXModelRunner model={self.model_config.model} status={status} mode={opt_status}>"

--- a/vllm_mlx/model_runner.py
+++ b/vllm_mlx/model_runner.py
@@ -6,7 +6,6 @@ This module implements the model runner that bridges vLLM's request
 handling with mlx-lm's inference capabilities.
 
 Includes low-level optimizations:
-- mx.compile() for kernel fusion
 - Memory bandwidth optimization
 - Prefill chunking for L2 cache efficiency
 """
@@ -70,7 +69,6 @@ class MLXModelRunner:
     - KV cache management (delegated to mlx-lm)
 
     Optimizations:
-    - mx.compile() for kernel fusion (fuses multiple ops into single Metal kernel)
     - Memory optimization for bandwidth efficiency
     - Prefill chunking for L2 cache utilization
     """
@@ -104,7 +102,6 @@ class MLXModelRunner:
 
         # Optimization settings
         self._enable_optimizations = enable_optimizations
-        self._compiled_forward = None  # Compiled model forward pass
         self._hardware_info = None  # Detected hardware profile
 
         logger.info(f"MLXModelRunner initialized for model: {self.model_config.model}")
@@ -167,36 +164,8 @@ class MLXModelRunner:
             # Configure memory settings
             configure_memory_optimization()
 
-            # Compile the model forward pass for kernel fusion
-            self._setup_compiled_forward()
-
         except Exception as e:
             logger.warning(f"Failed to apply optimizations: {e}")
-
-    def _setup_compiled_forward(self) -> None:
-        """
-        Setup compiled forward pass using mx.compile() for kernel fusion.
-
-        This fuses multiple operations into single Metal kernels,
-        reducing kernel launch overhead and improving throughput.
-        """
-        if self.model is None:
-            return
-
-        try:
-            # Compile the model's __call__ method
-            # This creates fused Metal kernels for the forward pass
-            if hasattr(self.model, "__call__"):
-                self._compiled_forward = mx.compile(self.model.__call__)
-                logger.info("Compiled forward pass enabled (mx.compile kernel fusion)")
-            else:
-                logger.warning(
-                    "Model does not have __call__ method, skipping compilation"
-                )
-
-        except Exception as e:
-            logger.warning(f"Failed to compile forward pass: {e}")
-            self._compiled_forward = None
 
     def _create_default_sampler(self) -> None:
         """Create default sampler for generation."""
@@ -352,8 +321,7 @@ class MLXModelRunner:
         if len(input_ids.shape) == 1:
             input_ids = input_ids.reshape(1, -1)
 
-        # Use compiled forward if available, otherwise use model directly
-        forward_fn = self._compiled_forward if self._compiled_forward else self.model
+        forward_fn = self.model
 
         if seq_len <= chunk_size:
             # Process entire sequence at once
@@ -377,7 +345,6 @@ class MLXModelRunner:
         Generate tokens for a single request.
 
         Uses optimizations when enabled:
-        - Compiled forward pass (kernel fusion)
         - Prefill chunking for long prompts
 
         Args:
@@ -469,7 +436,6 @@ class MLXModelRunner:
 
             # Add optimization status
             info["optimizations"] = {
-                "kernel_fusion": self._compiled_forward is not None,
                 "memory_optimized": self._hardware_info is not None,
             }
 
@@ -486,5 +452,5 @@ class MLXModelRunner:
 
     def __repr__(self) -> str:
         status = "loaded" if self._loaded else "not loaded"
-        opt_status = "optimized" if self._compiled_forward else "standard"
+        opt_status = "optimized" if self._hardware_info else "standard"
         return f"<MLXModelRunner model={self.model_config.model} status={status} mode={opt_status}>"


### PR DESCRIPTION
## Summary

Two systematic fixes: truth-in-labeling for `rapid-mlx info`, and removal of dead A5 `mx.compile`-bucketed code.

### 1. `rapid-mlx info` truth row for spec-decode / KV-share

`format_profile_table` (the `rapid-mlx info <alias>` table) previously showed only a `Spec decode` row that conflates MTP with SuffixDecoding/DFlash. Two derived rows are added, read from the unified frozen `ModelProfile` (`vllm_mlx/model_profile.py`, #1108):

- **`MTP path: native | sidecar | disabled`**
  - `native` — families that ship a baked-in MTP head (Qwen3.5/3.6, HY3). Mirrors the authoritative `spec_decode.mtp.detect._SUPPORTED_MODEL_TYPES` allowlist (`qwen3_5` / `qwen3_5_moe` / `hy_v3`), but derived from the name-regex profile so `info` stays weight-free — no import into the operator-owned `spec_decode` lane.
  - `sidecar` — Gemma 4's assistant drafter (`gemma4_assistant`), not a native head.
  - `disabled` — spec decode off (`supports_spec_decode=False`), or the family has no MTP mechanism (SuffixDecoding is a separate lane, surfaced by the existing `Spec decode` / `Suffix tier` rows).
- **`KV-share: yes | no`** — `yes` for Gemma 4 (every shipped checkpoint declares `num_kv_shared_layers > 0`; default 20 on the vendored `TextConfig`, verify-locked #1104), `no` otherwise.

Both derivations use the name-regex-resolved profile only (no `config.json` / weight read), preserving the `info` fast-path contract.

### 2. Remove dead A5 `mx.compile` code

A5 "always-on `mx.compile` with bucketed static shapes" was rejected (MVP-falsified: bucketed compile made batch=1 decode 0.45-0.62× **slower**; `mx.async_eval` already captures the dispatch-pipeline win). `model_runner.py`'s `_setup_compiled_forward()` ran `mx.compile(self.model.__call__)`, which **crashes if ever reached** — `mx.compile` rejects the KVCache object argument. This path is gated behind the vLLM-plugin worker (not the live `BatchedEngine` serve path) so it never fired, but it was a latent crash.

Grep-driven removal of the whole dead cluster: the `_compiled_forward` field, `_setup_compiled_forward()`, and every reference (`_apply_optimizations`, `_prefill_with_chunking`, `get_model_info` `kernel_fusion` key, `__repr__`, docstrings).

The legitimate per-function `@mx.compile` kernel-fusion decorators (`deepseek_v4`, `hy_v3`, `gemma4_vendored/language.py`, samplers) are **not** the rejected always-on-bucketed pattern and are left intact.

## Reproduction (verified in a fresh isolated venv)

**(a) Dead `mx.compile` path would crash.** `mx.compile` on a `__call__(x, cache=<KVCache-like obj>)` (mirroring `model_runner.py`'s `_setup_compiled_forward` → `_prefill_with_chunking`) raises:

```
ValueError: [compile] Function arguments must be trees of arrays or constants
(floats, ints, strings, or None), but received type ...KVCache...
```

**(b) `info` lacked the rows.** `format_profile_table(...)` on `gemma-4-12B-it-4bit` / `Qwen3.5-4B-MLX-4bit` / `Hy3-preview-4bit` had `MTP-path-row=False  KV-share-row=False` before this change.

### After — sample output

```
┌──────────────────────────────────────────────────────────────┐
│ Model: mlx-community/gemma-4-12B-it-4bit                     │
│ Tool format      : gemma4                                    │
│ Spec decode      : ✓ supported                               │
│ MTP path         : sidecar                                   │
│ KV-share         : yes                                       │
│ ...                                                          │
└──────────────────────────────────────────────────────────────┘

  Hy3-preview-4bit  → MTP path: native   / KV-share: no
  Qwen3.5-4B-4bit   → MTP path: disabled / KV-share: no  (spec off)
  Qwen3-0.6B-8bit   → MTP path: disabled / KV-share: no  (SuffixDecoding, non-MTP)
```

## Tests

7 new regression tests in `test_model_auto_config.py` covering native/sidecar/disabled + KV yes/no across Gemma4 / HY3 / Qwen3.5 / Qwen3-dense / unknown, plus box-alignment. Existing info / auto-config / mllm / profile / routing suites all green (2640+ tests). No regression. No test exercises `MLXModelRunner`'s removed compile path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)