### PR TITLE
bench(#269): fill phi-4-mini-4bit suffix_decoding_tier from real bench

### DIFF
--- a/evals/results/suffix_mlx-community_phi-4-mini-instruct-4bit.json
+++ b/evals/results/suffix_mlx-community_phi-4-mini-instruct-4bit.json
@@ -1,0 +1,216 @@
+{
+  "model": "mlx-community/phi-4-mini-instruct-4bit",
+  "max_tokens": 256,
+  "runs": 3,
+  "vanilla_tps": {
+    "chat": 189.3,
+    "json_array": 188.4,
+    "tool_loop": 182.8,
+    "code_edit": null
+  },
+  "suffix_tps": {
+    "chat": 127.4,
+    "json_array": 176.3,
+    "tool_loop": 389.3,
+    "code_edit": null
+  },
+  "speedup": {
+    "chat": 0.673,
+    "json_array": 0.936,
+    "tool_loop": 2.13
+  },
+  "skipped": {
+    "code_edit": "vanilla all runs rejected"
+  },
+  "tier": "avoid",
+  "raw_runs": {
+    "vanilla": {
+      "chat": [
+        {
+          "tps": 189.3,
+          "completion_tokens": 225,
+          "decode_time": 1.188,
+          "total_time": 1.279,
+          "rejected_reason": null
+        },
+        {
+          "tps": 189.2,
+          "completion_tokens": 225,
+          "decode_time": 1.189,
+          "total_time": 1.28,
+          "rejected_reason": null
+        },
+        {
+          "tps": 189.3,
+          "completion_tokens": 225,
+          "decode_time": 1.189,
+          "total_time": 1.279,
+          "rejected_reason": null
+        }
+      ],
+      "json_array": [
+        {
+          "tps": 188.2,
+          "completion_tokens": 163,
+          "decode_time": 0.866,
+          "total_time": 0.97,
+          "rejected_reason": null
+        },
+        {
+          "tps": 188.4,
+          "completion_tokens": 163,
+          "decode_time": 0.865,
+          "total_time": 0.969,
+          "rejected_reason": null
+        },
+        {
+          "tps": 188.4,
+          "completion_tokens": 163,
+          "decode_time": 0.865,
+          "total_time": 0.969,
+          "rejected_reason": null
+        }
+      ],
+      "tool_loop": [
+        {
+          "tps": 182.4,
+          "completion_tokens": 256,
+          "decode_time": 1.404,
+          "total_time": 1.639,
+          "rejected_reason": null
+        },
+        {
+          "tps": 183.1,
+          "completion_tokens": 256,
+          "decode_time": 1.398,
+          "total_time": 1.57,
+          "rejected_reason": null
+        },
+        {
+          "tps": 182.8,
+          "completion_tokens": 256,
+          "decode_time": 1.4,
+          "total_time": 1.571,
+          "rejected_reason": null
+        }
+      ],
+      "code_edit": [
+        {
+          "tps": null,
+          "completion_tokens": 64,
+          "decode_time": 0.345,
+          "total_time": 0.466,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 64,
+          "decode_time": 0.346,
+          "total_time": 0.464,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 64,
+          "decode_time": 0.346,
+          "total_time": 0.464,
+          "rejected_reason": "decode_time<0.5s"
+        }
+      ]
+    },
+    "suffix": {
+      "chat": [
+        {
+          "tps": 124.3,
+          "completion_tokens": 256,
+          "decode_time": 2.06,
+          "total_time": 2.15,
+          "rejected_reason": null
+        },
+        {
+          "tps": 127.7,
+          "completion_tokens": 225,
+          "decode_time": 1.762,
+          "total_time": 1.853,
+          "rejected_reason": null
+        },
+        {
+          "tps": 127.4,
+          "completion_tokens": 225,
+          "decode_time": 1.766,
+          "total_time": 1.856,
+          "rejected_reason": null
+        }
+      ],
+      "json_array": [
+        {
+          "tps": 170.4,
+          "completion_tokens": 163,
+          "decode_time": 0.957,
+          "total_time": 1.061,
+          "rejected_reason": null
+        },
+        {
+          "tps": 176.3,
+          "completion_tokens": 163,
+          "decode_time": 0.925,
+          "total_time": 1.029,
+          "rejected_reason": null
+        },
+        {
+          "tps": 177.4,
+          "completion_tokens": 163,
+          "decode_time": 0.919,
+          "total_time": 1.021,
+          "rejected_reason": null
+        }
+      ],
+      "tool_loop": [
+        {
+          "tps": 387.7,
+          "completion_tokens": 256,
+          "decode_time": 0.66,
+          "total_time": 0.833,
+          "rejected_reason": null
+        },
+        {
+          "tps": 390.3,
+          "completion_tokens": 256,
+          "decode_time": 0.656,
+          "total_time": 0.839,
+          "rejected_reason": null
+        },
+        {
+          "tps": 389.3,
+          "completion_tokens": 256,
+          "decode_time": 0.658,
+          "total_time": 0.839,
+          "rejected_reason": null
+        }
+      ],
+      "code_edit": [
+        {
+          "tps": null,
+          "completion_tokens": 64,
+          "decode_time": 0.412,
+          "total_time": 0.548,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 64,
+          "decode_time": 0.414,
+          "total_time": 0.548,
+          "rejected_reason": "decode_time<0.5s"
+        },
+        {
+          "tps": null,
+          "completion_tokens": 64,
+          "decode_time": 0.413,
+          "total_time": 0.546,
+          "rejected_reason": "decode_time<0.5s"
+        }
+      ]
+    }
+  }
+}

--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -1335,7 +1335,12 @@
     "is_hybrid": false,
     "is_moe": false,
     "supports_spec_decode": true,
-    "suffix_decoding_tier": "unknown"
+    "suffix_decoding_tier": "avoid",
+    "suffix_bench_speedup": {
+      "chat": 0.673,
+      "json_array": 0.936,
+      "tool_loop": 2.13
+    }
   },
   "vibethinker-1.5b-4bit": {
     "hf_path": "mlx-community/VibeThinker-1.5B-mlx-4bit",


### PR DESCRIPTION
## Why

The `suffix_decoding_tier` field feeds `rapid-mlx info` + startup hints that tell users whether SuffixDecoding is worth enabling. `phi-4-mini-4bit` carried the placeholder `"unknown"`, so the CLI was silent about its SuffixDecoding eligibility. These tiers are meant to come from a cross-model bench. This PR fills the **one** alias I could bench honestly and leaves the rest `"unknown"` **because** SuffixDecoding literally cannot run on them.

Refs #269.

## What

Fill `suffix_decoding_tier` for `phi-4-mini-4bit` from a MEASURED run of the canonical server-based bench (`scripts/bench_suffix_decoding_integrated.py` + `classify_suffix_decoding_tier` — the same harness/classifier every existing benched entry used).

| alias | tier | per-workload speedup |
|---|---|---|
| `phi-4-mini-4bit` | **avoid** | chat 0.673, json_array 0.936, tool_loop 2.13 |

- 3-run median per workload, GPU-solo, `--disable-prefix-cache`, 256 max-tokens. `code_edit` dropped honestly (outputs finished below the 0.5s decode reliability floor).
- The wide **0.67–2.13x** spread confirms the suffix-tree drafter genuinely engaged (`phi-4-mini` has `supports_spec_decode=true`). chat regresses hard with no reliable counter-win → `avoid`, matching its neighbor `phi-4-14b-4bit`.
- Tier is **noise-stable under ±0.003** and reproduces from the classifier. `suffix_bench_speedup` values are derived from the stored aggregate TPS so the committed artifact is internally auditable.

## Why only one fill (honest scope)

The scope started at 12 `"unknown"` aliases. Only `phi-4-mini-4bit` can be benched:

- **All UI-TARS aliases** (`ui-tars-1.5-7b-{4,6,8}bit`, `ui-tars-7b-{dpo,sft}-{4,6,8}bit`, `ui-tars-72b-dpo-4bit`) carry `supports_spec_decode=false`. `_install_suffix_decoding` early-returns for them (`scheduler.py:1378`) — the drafter is **never installed**. A "suffix on" run there measures vanilla-vs-vanilla (I confirmed ~1.00x flat), a no-op artifact, not a SuffixDecoding signal. `suffix_decoding_hint` also returns `None` for `supports_spec_decode=false` models, so any tier would be dead data users never see. Benching them (I did — all workloads 0.996–1.004x) does not produce a meaningful tier. Left `"unknown"`.
- **`diffusion-gemma-26b-4bit` / `-8bit`**: text-diffusion (non-autoregressive), `is_hybrid=true`, `supports_spec_decode=false` — no AR next-token verify path. Left `"unknown"`.

A partial, honest fill is the intended success criterion. Shipping a `neutral` tier derived from a no-op bench would be a fake green.

## Schema / tests

- Closed-key schema preserved: only tier + speedup **values** added on the one existing entry; `suffix_bench_speedup` shaped exactly like neighboring benched entries.
- `test_aliases_contract.py`, `test_suffix_decoding_tier.py`, `test_suffix_bench_methodology.py`, `test_model_aliases.py` — green; full suite passes under pr_validate.
- No engine behavior change; `vllm_mlx/spec_decode/**` and `speculative/**` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)