### PR TITLE
Harden release artifact acceptance

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,6 @@
+# The release acceptance workflow deliberately targets this dedicated,
+# self-hosted Apple-Silicon runner. Keep the label here so actionlint can
+# distinguish it from a typo in a GitHub-hosted runner name.
+self-hosted-runner:
+  labels:
+    - rapid-mlx-release

--- a/.github/workflows/aggregate-bench.yml
+++ b/.github/workflows/aggregate-bench.yml
@@ -31,8 +31,8 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with: { python-version: "3.12" }
       - name: Verify aggregated.json is up-to-date
         run: |
@@ -51,10 +51,10 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with: { python-version: "3.12" }
       - name: Regenerate aggregated.json
         run: |

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -20,7 +20,7 @@ jobs:
   detect-and-release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           fetch-depth: 2
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,9 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install ruff
+          # pyyaml: check_gha_pinning.py parses workflow YAML (so quoted
+          # `uses` forms cannot bypass the SHA-pin gate).
+          pip install ruff pyyaml
 
       - name: Run ruff lint
         run: ruff check vllm_mlx/ tests/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,14 +6,17 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version: "3.13"
 
@@ -34,16 +37,9 @@ jobs:
       - name: CLI ↔ Config fidelity audit
         run: python scripts/audit_cli_config_fidelity.py
 
-      # PF-3 — supply-chain hardening. Third-party GitHub Actions must
-      # pin to a 40-char commit SHA, not a mutable tag/branch. The repo
-      # currently has known pre-existing violations (codecov-action,
-      # peaceiris/gh-pages, pypa/gh-action-pypi-publish, peter-evans/
-      # repository-dispatch) tracked for follow-up — advisory mode
-      # (continue-on-error) until those are pinned in a separate
-      # hardening PR. Once clean, drop continue-on-error to make this
-      # a hard gate.
-      - name: GitHub Actions SHA pinning (advisory)
-        continue-on-error: true
+      # PF-3 — all GitHub Actions are immutable 40-char commit SHA pins.
+      # Dependabot or a reviewed PR is required to advance an action.
+      - name: GitHub Actions SHA pinning
         run: python scripts/check_gha_pinning.py
 
       # Parser microbench — catches >10x regressions in tool-call
@@ -65,10 +61,10 @@ jobs:
   type-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version: "3.11"
 
@@ -87,10 +83,10 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11", "3.12"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -137,7 +133,7 @@ jobs:
 
       - name: Upload coverage
         if: matrix.python-version == '3.11'
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238  # v4
         with:
           file: ./coverage.xml
           fail_ci_if_error: false
@@ -145,10 +141,10 @@ jobs:
   test-apple-silicon:
     runs-on: macos-14
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version: "3.11"
 

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -11,7 +11,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Prepare pages directory
         run: |
@@ -19,7 +19,7 @@ jobs:
           cp install.sh _pages/
 
       - name: Deploy to gh-pages
-        uses: peaceiris/actions-gh-pages@v4
+        uses: peaceiris/actions-gh-pages@329bcc8f12caed2cefe5a5b80781499a6f3b361b  # v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./_pages

--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -43,12 +43,12 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           fetch-depth: 0  # pr_validate.fetch reads diff vs base
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version: "3.12"
 
@@ -137,7 +137,7 @@ jobs:
 
       - name: Upload scorecard artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: pr-validate-scorecard
           path: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -80,6 +80,9 @@ jobs:
     environment: pypi
     permissions:
       id-token: write
+      # contents: read is required for the tag re-resolution step's
+      # authenticated `gh api` call below.
+      contents: read
     outputs:
       sdist_sha256: ${{ steps.verify-manifest.outputs.sdist_sha256 }}
     steps:
@@ -141,6 +144,33 @@ jobs:
               output.write(f"sdist_sha256={artifacts[sdists[0]]['sha256']}\n")
           print("release manifest verified")
           PY
+
+      - name: Re-resolve the tag and require it still points at the manifest SHA
+        # TOCTOU guard: this job trusts the frozen ``github.sha`` from the
+        # `release: published` event, but a tag force-moved or recreated after
+        # the event fired would let PyPI receive artifacts built from a
+        # different commit than the tag now identifies. Re-resolve
+        # refs/tags/$GITHUB_REF_NAME (dereferencing annotated tags) right
+        # before the credential and require it to equal the manifest SHA.
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EXPECTED_SHA: ${{ github.sha }}
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          REF=$(gh api "repos/${GITHUB_REPOSITORY}/git/refs/tags/${TAG}" \
+            --jq '.object.sha')
+          TYPE=$(gh api "repos/${GITHUB_REPOSITORY}/git/refs/tags/${TAG}" \
+            --jq '.object.type')
+          if [ "$TYPE" = "tag" ]; then
+            REF=$(gh api "repos/${GITHUB_REPOSITORY}/git/tags/${REF}" \
+              --jq '.object.sha')
+          fi
+          if [ "$REF" != "$EXPECTED_SHA" ]; then
+            echo "Tag ${TAG} now points at ${REF}, not the manifest SHA ${EXPECTED_SHA}; refusing to publish" >&2
+            exit 1
+          fi
+          echo "Tag ${TAG} still resolves to the manifest SHA ${EXPECTED_SHA}"
 
       - name: Publish to PyPI
         # Duplicate files fail loudly. A retry must consume the same

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,23 +5,25 @@ on:
     types: [published]
 
 permissions:
-  id-token: write
+  contents: read
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version: "3.11"
 
       - name: Install build tools
         run: |
           python -m pip install --upgrade pip
-          pip install build
+          pip install build twine
 
       - name: Build package (retry on magic-byte collision)
         # PyPI's _is_valid_dist_file rejects any file where both
@@ -52,34 +54,107 @@ jobs:
           echo "ERROR: 5 builds in a row hit PyPI's zip+tar collision check"
           exit 1
 
+      - name: Validate distribution metadata and create release manifest
+        run: |
+          twine check dist/*
+          SOURCE_SHA="$(git rev-parse HEAD)"
+          python scripts/release_manifest.py create \
+            --dist-dir dist \
+            --output release-manifest.json \
+            --source-sha "$SOURCE_SHA" \
+            --version "${GITHUB_REF_NAME#v}"
+          cat release-manifest.json
+
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
-          name: dist
-          path: dist/
+          name: release-candidate
+          path: |
+            dist/
+            release-manifest.json
+          if-no-files-found: error
 
   publish:
     needs: build
     runs-on: ubuntu-latest
     environment: pypi
+    permissions:
+      id-token: write
+    outputs:
+      sdist_sha256: ${{ steps.verify-manifest.outputs.sdist_sha256 }}
     steps:
       - name: Download build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
         with:
-          name: dist
-          path: dist/
+          name: release-candidate
+          path: candidate/
+
+      - name: Verify release artifact manifest
+        id: verify-manifest
+        # Do this inline and with stdlib only. The publishing job must not
+        # execute a script from the candidate artifact before it receives its
+        # PyPI OIDC token.
+        env:
+          EXPECTED_VERSION: ${{ github.event.release.tag_name }}
+          EXPECTED_SHA: ${{ github.sha }}
+        run: |
+          python3 - <<'PY'
+          import hashlib
+          import json
+          import os
+          from pathlib import Path
+
+          manifest = json.loads(Path("candidate/release-manifest.json").read_text())
+          version = os.environ["EXPECTED_VERSION"].removeprefix("v")
+          if manifest.get("schema") != 1 or manifest.get("project") != "rapid-mlx":
+              raise SystemExit("invalid release manifest schema/project")
+          if manifest.get("version") != version:
+              raise SystemExit(
+                  f"manifest version {manifest.get('version')!r} does not match tag {version!r}"
+              )
+          if manifest.get("source_sha") != os.environ["EXPECTED_SHA"]:
+              raise SystemExit("manifest source SHA does not match the release target")
+
+          artifacts = {item["filename"]: item for item in manifest.get("artifacts", [])}
+          dist = Path("candidate/dist")
+          files = sorted(path for path in dist.iterdir() if path.is_file())
+          if len(artifacts) != 2:
+              raise SystemExit("manifest must contain exactly two artifacts")
+          if set(artifacts) != {path.name for path in files}:
+              raise SystemExit("manifest artifact names do not match candidate dist/")
+          for path in files:
+              digest = hashlib.sha256(path.read_bytes()).hexdigest()
+              item = artifacts[path.name]
+              if item.get("sha256") != digest or item.get("size") != path.stat().st_size:
+                  raise SystemExit(f"manifest digest/size mismatch for {path.name}")
+          wheels = [name for name in artifacts if name.endswith(".whl")]
+          if len(wheels) != 1:
+              raise SystemExit("manifest must contain exactly one wheel")
+          sdists = [name for name in artifacts if name.endswith(".tar.gz")]
+          if len(sdists) != 1:
+              raise SystemExit("manifest must contain exactly one sdist")
+          if not wheels[0].startswith(f"rapid_mlx-{version}-"):
+              raise SystemExit("wheel filename does not match the release tag")
+          if sdists[0] != f"rapid_mlx-{version}.tar.gz":
+              raise SystemExit("sdist filename does not match the release tag")
+          with open(os.environ["GITHUB_OUTPUT"], "a") as output:
+              output.write(f"sdist_sha256={artifacts[sdists[0]]['sha256']}\n")
+          print("release manifest verified")
+          PY
 
       - name: Publish to PyPI
-        # skip-existing lets the workflow recover from a partial upload
-        # (e.g. wheel succeeded but sdist 400'd) without needing a fresh
-        # version bump on retry.
-        uses: pypa/gh-action-pypi-publish@release/v1
+        # Duplicate files fail loudly. A retry must consume the same
+        # manifest-verified candidate, never silently accept a potentially
+        # different rebuild of the same immutable PyPI version.
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # release/v1
         with:
-          skip-existing: true
+          packages-dir: candidate/dist/
 
   update-homebrew:
     needs: publish
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Wait for PyPI to propagate
         run: sleep 30
@@ -90,6 +165,8 @@ jobs:
 
       - name: Fetch tarball URL and SHA256
         id: pypi
+        env:
+          EXPECTED_SHA256: ${{ needs.publish.outputs.sdist_sha256 }}
         run: |
           VERSION="${{ steps.version.outputs.version }}"
           # Poll PyPI until the new version appears (max 5 minutes)
@@ -105,13 +182,19 @@ jobs:
           curl -fsSL "$URL" -o /tmp/rapid-mlx.tar.gz
           SHA256=$(sha256sum /tmp/rapid-mlx.tar.gz | cut -d' ' -f1)
           rm /tmp/rapid-mlx.tar.gz
+          if [ "$SHA256" != "$EXPECTED_SHA256" ]; then
+            echo "PyPI sdist SHA256 does not match the manifest" >&2
+            echo "expected: $EXPECTED_SHA256" >&2
+            echo "actual:   $SHA256" >&2
+            exit 1
+          fi
 
           echo "url=$URL" >> "$GITHUB_OUTPUT"
           echo "sha256=$SHA256" >> "$GITHUB_OUTPUT"
           echo "Found: $URL (sha256: $SHA256)"
 
       - name: Update Homebrew formula
-        uses: peter-evans/repository-dispatch@v3
+        uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0  # v3
         with:
           token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
           repository: raullenchai/homebrew-rapid-mlx

--- a/.github/workflows/release-artifact-matrix.yml
+++ b/.github/workflows/release-artifact-matrix.yml
@@ -241,10 +241,15 @@ jobs:
       - name: Re-resolve the tag and require it still points at the tested SHA
         # TOCTOU guard: the tag -> SHA binding was checked in build-candidate,
         # but the matrix can run for hours. Re-resolve refs/tags/vX.Y.Z right
-        # before requesting the PyPI credential and require it (and the draft
-        # release target) still equal the source SHA the matrix accepted. A
-        # tag force-moved or recreated after the matrix passed must NOT be
-        # published against.
+        # before requesting the PyPI credential and require it to still equal
+        # the source SHA the matrix accepted. A tag force-moved or recreated
+        # after the matrix passed must NOT be published against.
+        #
+        # We deliberately do NOT compare the release's ``targetCommitish``: for
+        # a release created against an existing tag GitHub leaves that field as
+        # the default branch (e.g. ``main``), so it is informational, not the
+        # published commit. The resolved tag object IS the authoritative commit
+        # binding and is what the manifest SHA was pinned to.
         env:
           GH_TOKEN: ${{ github.token }}
           EXPECTED_SHA: ${{ needs.build-candidate.outputs.source_sha }}
@@ -265,12 +270,6 @@ jobs:
           fi
           if [ "$TAG_SHA" != "$EXPECTED_SHA" ]; then
             echo "Tag ${TAG} now points at ${TAG_SHA}, not the tested ${EXPECTED_SHA}; refusing to publish" >&2
-            exit 1
-          fi
-          RELEASE_SHA=$(gh release view "$TAG" --repo "$GITHUB_REPOSITORY" \
-            --json targetCommitish --jq '.targetCommitish')
-          if [ "$RELEASE_SHA" != "$EXPECTED_SHA" ] && [ "$RELEASE_SHA" != "$TAG" ]; then
-            echo "Draft release ${TAG} targets ${RELEASE_SHA}, not the tested ${EXPECTED_SHA}; refusing to publish" >&2
             exit 1
           fi
           echo "Tag ${TAG} still resolves to the tested SHA ${EXPECTED_SHA}"

--- a/.github/workflows/release-artifact-matrix.yml
+++ b/.github/workflows/release-artifact-matrix.yml
@@ -235,6 +235,43 @@ jobs:
           print("release manifest verified")
           PY
 
+      - name: Re-resolve the tag and require it still points at the tested SHA
+        # TOCTOU guard: the tag -> SHA binding was checked in build-candidate,
+        # but the matrix can run for hours. Re-resolve refs/tags/vX.Y.Z right
+        # before requesting the PyPI credential and require it (and the draft
+        # release target) still equal the source SHA the matrix accepted. A
+        # tag force-moved or recreated after the matrix passed must NOT be
+        # published against.
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EXPECTED_SHA: ${{ needs.build-candidate.outputs.source_sha }}
+          EXPECTED_VERSION: ${{ needs.build-candidate.outputs.version }}
+        run: |
+          set -euo pipefail
+          TAG="v$EXPECTED_VERSION"
+          TAG_SHA=$(gh api \
+            "repos/${GITHUB_REPOSITORY}/git/refs/tags/${TAG}" \
+            --jq '.object.sha')
+          # Annotated tags resolve to a tag object; dereference to the commit.
+          TAG_TYPE=$(gh api \
+            "repos/${GITHUB_REPOSITORY}/git/refs/tags/${TAG}" \
+            --jq '.object.type')
+          if [ "$TAG_TYPE" = "tag" ]; then
+            TAG_SHA=$(gh api "repos/${GITHUB_REPOSITORY}/git/tags/${TAG_SHA}" \
+              --jq '.object.sha')
+          fi
+          if [ "$TAG_SHA" != "$EXPECTED_SHA" ]; then
+            echo "Tag ${TAG} now points at ${TAG_SHA}, not the tested ${EXPECTED_SHA}; refusing to publish" >&2
+            exit 1
+          fi
+          RELEASE_SHA=$(gh release view "$TAG" --repo "$GITHUB_REPOSITORY" \
+            --json targetCommitish --jq '.targetCommitish')
+          if [ "$RELEASE_SHA" != "$EXPECTED_SHA" ] && [ "$RELEASE_SHA" != "$TAG" ]; then
+            echo "Draft release ${TAG} targets ${RELEASE_SHA}, not the tested ${EXPECTED_SHA}; refusing to publish" >&2
+            exit 1
+          fi
+          echo "Tag ${TAG} still resolves to the tested SHA ${EXPECTED_SHA}"
+
       - name: Publish exact candidate to PyPI with attestations
         # This official action produces PyPI publish attestations by default.
         # A duplicate immutable version fails instead of silently accepting a

--- a/.github/workflows/release-artifact-matrix.yml
+++ b/.github/workflows/release-artifact-matrix.yml
@@ -294,9 +294,9 @@ jobs:
           wheel_url = next(url for name, url in files.items() if name.endswith(".whl"))
           sdist_name = next(name for name in files if name.endswith(".tar.gz"))
           with open(os.environ["GITHUB_OUTPUT"], "a") as output:
-              output.write(f"wheel_url={wheel_url}\\n")
-              output.write(f"sdist_url={files[sdist_name]}\\n")
-              output.write(f"sdist_sha256={expected[sdist_name]['sha256']}\\n")
+              output.write(f"wheel_url={wheel_url}\n")
+              output.write(f"sdist_url={files[sdist_name]}\n")
+              output.write(f"sdist_sha256={expected[sdist_name]['sha256']}\n")
           print("PyPI files match the release manifest")
           PY
               break
@@ -308,6 +308,8 @@ jobs:
             echo "Waiting for PyPI file propagation (attempt $attempt)"
             sleep 30
           done
+          echo "Resolved release-file outputs written to GITHUB_OUTPUT:"
+          cat "$GITHUB_OUTPUT"
 
       - name: Verify PyPI publish attestations
         env:

--- a/.github/workflows/release-artifact-matrix.yml
+++ b/.github/workflows/release-artifact-matrix.yml
@@ -375,8 +375,27 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           VERSION: ${{ needs.build-candidate.outputs.version }}
+          EXPECTED_SHA: ${{ needs.build-candidate.outputs.source_sha }}
         run: |
-          gh release edit "v$VERSION" --repo "$GITHUB_REPOSITORY" --draft=false
+          set -euo pipefail
+          TAG="v$VERSION"
+          # Re-resolve the tag one last time before flipping the draft to
+          # published, so a tag moved after PyPI verification cannot promote a
+          # GitHub Release pointing at code different from the published,
+          # verified artifacts.
+          REF=$(gh api "repos/${GITHUB_REPOSITORY}/git/refs/tags/${TAG}" \
+            --jq '.object.sha')
+          TYPE=$(gh api "repos/${GITHUB_REPOSITORY}/git/refs/tags/${TAG}" \
+            --jq '.object.type')
+          if [ "$TYPE" = "tag" ]; then
+            REF=$(gh api "repos/${GITHUB_REPOSITORY}/git/tags/${REF}" \
+              --jq '.object.sha')
+          fi
+          if [ "$REF" != "$EXPECTED_SHA" ]; then
+            echo "Tag ${TAG} now points at ${REF}, not the verified ${EXPECTED_SHA}; refusing to promote the release" >&2
+            exit 1
+          fi
+          gh release edit "$TAG" --repo "$GITHUB_REPOSITORY" --draft=false
 
   update-homebrew:
     name: Promote verified sdist to Homebrew

--- a/.github/workflows/release-artifact-matrix.yml
+++ b/.github/workflows/release-artifact-matrix.yml
@@ -1,0 +1,357 @@
+name: Release artifact acceptance matrix
+
+# This is intentionally dispatch-only until an isolated Apple-Silicon release
+# runner is registered.  It builds a candidate once, then every matrix shard
+# installs that exact wheel rather than importing the checkout.  See
+# docs/development/release-artifact-acceptance.md for the promotion procedure.
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Release-candidate commit, branch, or tag to build"
+        required: true
+        default: "main"
+        type: string
+      families:
+        description: "JSON list of feasible matrix families"
+        required: true
+        default: '["qwen36", "gemma4", "deepseek", "gptoss"]'
+        type: string
+      publish:
+        description: "After every matrix shard passes, publish this exact tagged candidate"
+        required: true
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-artifact-matrix-${{ inputs.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build-candidate:
+    name: Build candidate distribution
+    runs-on: ubuntu-latest
+    outputs:
+      source_sha: ${{ steps.metadata.outputs.source_sha }}
+      version: ${{ steps.metadata.outputs.version }}
+    steps:
+      - name: Checkout candidate
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
+        with:
+          python-version: "3.12"
+
+      - name: Validate matrix coverage selection
+        env:
+          FAMILIES: ${{ inputs.families }}
+          PUBLISH: ${{ inputs.publish }}
+        run: |
+          if [ "$PUBLISH" = "true" ]; then
+            python scripts/release_artifact_matrix.py \
+              --validate-families-json "$FAMILIES" \
+              --require-all-families
+          else
+            python scripts/release_artifact_matrix.py \
+              --validate-families-json "$FAMILIES"
+          fi
+
+      - name: Build and validate distributions
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install build twine
+          python -m build
+          twine check dist/*
+
+      - name: Create release artifact manifest
+        id: metadata
+        run: |
+          SOURCE_SHA="$(git rev-parse HEAD)"
+          VERSION="$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])")"
+          python scripts/release_manifest.py create \
+            --dist-dir dist \
+            --output release-manifest.json \
+            --source-sha "$SOURCE_SHA" \
+            --version "$VERSION"
+          echo "source_sha=$SOURCE_SHA" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          cat release-manifest.json
+
+      - name: Require the canonical immutable tag for publication
+        if: inputs.publish
+        env:
+          REF: ${{ inputs.ref }}
+          SOURCE_SHA: ${{ steps.metadata.outputs.source_sha }}
+          VERSION: ${{ steps.metadata.outputs.version }}
+        run: |
+          if [ "$REF" != "v$VERSION" ]; then
+            echo "Publishing requires ref v$VERSION, not $REF" >&2
+            exit 1
+          fi
+          if [ "$GITHUB_REF" != "refs/tags/v$VERSION" ]; then
+            echo "Publishing requires this workflow to run from refs/tags/v$VERSION, not $GITHUB_REF" >&2
+            exit 1
+          fi
+          if [ "$SOURCE_SHA" != "$GITHUB_SHA" ]; then
+            echo "Candidate source SHA does not match the workflow tag commit" >&2
+            exit 1
+          fi
+
+      - name: Require a draft GitHub Release for publication
+        if: inputs.publish
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.metadata.outputs.version }}
+        run: |
+          DRAFT=$(gh release view "v$VERSION" --repo "$GITHUB_REPOSITORY" \
+            --json isDraft --jq '.isDraft')
+          if [ "$DRAFT" != "true" ]; then
+            echo "Publishing requires draft release v$VERSION; refusing the legacy published-release path" >&2
+            exit 1
+          fi
+
+      - name: Upload candidate distribution
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        with:
+          name: release-candidate
+          path: |
+            dist/
+            release-manifest.json
+          if-no-files-found: error
+          retention-days: 14
+
+  artifact-matrix:
+    name: Artifact matrix (${{ matrix.family }})
+    needs: build-candidate
+    # This runner must be a dedicated Apple-Silicon host with an isolated
+    # Docker daemon.  The OpenHands cell mounts the Docker socket by design.
+    runs-on: [self-hosted, macOS, ARM64, rapid-mlx-release]
+    timeout-minutes: 180
+    strategy:
+      fail-fast: false
+      matrix:
+        family: ${{ fromJSON(inputs.families) }}
+    steps:
+      - name: Checkout test harness at candidate ref
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          ref: ${{ needs.build-candidate.outputs.source_sha }}
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
+        with:
+          python-version: "3.12"
+
+      - name: Download candidate distribution
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0  # v5
+        with:
+          name: release-candidate
+          path: candidate
+
+      - name: Verify candidate artifact manifest
+        run: |
+          python scripts/release_manifest.py verify \
+            --dist-dir candidate/dist \
+            --manifest candidate/release-manifest.json
+
+      - name: Smoke both release distributions in clean environments
+        run: python scripts/release_smoke.py --dist-dir candidate/dist
+
+      - name: Run strict agent and framework matrix against the wheel
+        run: |
+          python scripts/release_artifact_matrix.py \
+            --dist-dir candidate/dist \
+            --family "${{ matrix.family }}" \
+            --port 18000 \
+            --server-timeout-seconds 900
+
+  publish:
+    name: Publish manifest-verified candidate to PyPI
+    needs: [build-candidate, artifact-matrix]
+    if: inputs.publish == true
+    runs-on: ubuntu-latest
+    # This is an identity boundary, not a second-person approval. Configure
+    # the environment to permit only v* tags; see the release acceptance doc.
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - name: Download candidate distribution
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0  # v5
+        with:
+          name: release-candidate
+          path: candidate
+
+      - name: Verify manifest before obtaining a PyPI credential
+        # Keep this stdlib-only and inline: this OIDC-bearing job must never
+        # execute a script from the candidate checkout or candidate artifact.
+        env:
+          EXPECTED_SHA: ${{ needs.build-candidate.outputs.source_sha }}
+          EXPECTED_VERSION: ${{ needs.build-candidate.outputs.version }}
+        run: |
+          python3 - <<'PY'
+          import hashlib
+          import json
+          import os
+          from pathlib import Path
+
+          manifest = json.loads(Path("candidate/release-manifest.json").read_text())
+          if manifest.get("schema") != 1 or manifest.get("project") != "rapid-mlx":
+              raise SystemExit("invalid release manifest schema/project")
+          if manifest.get("version") != os.environ["EXPECTED_VERSION"]:
+              raise SystemExit("manifest version does not match the candidate tag")
+          if manifest.get("source_sha") != os.environ["EXPECTED_SHA"]:
+              raise SystemExit("manifest source SHA does not match the candidate")
+
+          artifacts = {item["filename"]: item for item in manifest.get("artifacts", [])}
+          files = sorted(path for path in Path("candidate/dist").iterdir() if path.is_file())
+          if len(artifacts) != 2:
+              raise SystemExit("manifest must contain exactly two artifacts")
+          if set(artifacts) != {path.name for path in files}:
+              raise SystemExit("manifest artifact names do not match candidate dist/")
+          for path in files:
+              item = artifacts[path.name]
+              digest = hashlib.sha256(path.read_bytes()).hexdigest()
+              if item.get("sha256") != digest or item.get("size") != path.stat().st_size:
+                  raise SystemExit(f"manifest digest/size mismatch for {path.name}")
+          wheels = [name for name in artifacts if name.endswith(".whl")]
+          if len(wheels) != 1:
+              raise SystemExit("manifest must contain exactly one wheel")
+          sdists = [name for name in artifacts if name.endswith(".tar.gz")]
+          if len(sdists) != 1:
+              raise SystemExit("manifest must contain exactly one sdist")
+          version = os.environ["EXPECTED_VERSION"]
+          if not wheels[0].startswith(f"rapid_mlx-{version}-"):
+              raise SystemExit("wheel filename does not match the candidate version")
+          if sdists[0] != f"rapid_mlx-{version}.tar.gz":
+              raise SystemExit("sdist filename does not match the candidate version")
+          print("release manifest verified")
+          PY
+
+      - name: Publish exact candidate to PyPI with attestations
+        # This official action produces PyPI publish attestations by default.
+        # A duplicate immutable version fails instead of silently accepting a
+        # different rebuild.
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # release/v1
+        with:
+          packages-dir: candidate/dist/
+
+  verify-pypi:
+    name: Verify PyPI bytes and publish attestations
+    needs: [build-candidate, publish]
+    runs-on: ubuntu-latest
+    outputs:
+      sdist_url: ${{ steps.files.outputs.sdist_url }}
+      sdist_sha256: ${{ steps.files.outputs.sdist_sha256 }}
+      wheel_url: ${{ steps.files.outputs.wheel_url }}
+    steps:
+      - name: Download manifest-verified candidate
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0  # v5
+        with:
+          name: release-candidate
+          path: candidate
+
+      - name: Fetch files from PyPI and compare the candidate hashes
+        id: files
+        env:
+          EXPECTED_VERSION: ${{ needs.build-candidate.outputs.version }}
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3 4 5 6 7 8 9 10; do
+            if python3 - <<'PY'; then
+          import hashlib
+          import json
+          import os
+          import urllib.request
+          from pathlib import Path
+
+          manifest = json.loads(Path("candidate/release-manifest.json").read_text())
+          expected = {item["filename"]: item for item in manifest["artifacts"]}
+          version = os.environ["EXPECTED_VERSION"]
+          with urllib.request.urlopen(
+              f"https://pypi.org/pypi/rapid-mlx/{version}/json", timeout=30
+          ) as response:
+              metadata = json.load(response)
+          files = {item["filename"]: item["url"] for item in metadata["urls"]}
+          if set(files) != set(expected):
+              raise SystemExit("PyPI file names do not match release manifest")
+          for name, item in expected.items():
+              digest = hashlib.sha256()
+              size = 0
+              with urllib.request.urlopen(files[name], timeout=60) as response:
+                  for chunk in iter(lambda: response.read(1024 * 1024), b""):
+                      digest.update(chunk)
+                      size += len(chunk)
+              if digest.hexdigest() != item["sha256"] or size != item["size"]:
+                  raise SystemExit(f"PyPI hash/size mismatch for {name}")
+          wheel_url = next(url for name, url in files.items() if name.endswith(".whl"))
+          sdist_name = next(name for name in files if name.endswith(".tar.gz"))
+          with open(os.environ["GITHUB_OUTPUT"], "a") as output:
+              output.write(f"wheel_url={wheel_url}\\n")
+              output.write(f"sdist_url={files[sdist_name]}\\n")
+              output.write(f"sdist_sha256={expected[sdist_name]['sha256']}\\n")
+          print("PyPI files match the release manifest")
+          PY
+              break
+            fi
+            if [ "$attempt" = 10 ]; then
+              echo "PyPI did not expose the expected files within five minutes" >&2
+              exit 1
+            fi
+            echo "Waiting for PyPI file propagation (attempt $attempt)"
+            sleep 30
+          done
+
+      - name: Verify PyPI publish attestations
+        env:
+          WHEEL_URL: ${{ steps.files.outputs.wheel_url }}
+          SDIST_URL: ${{ steps.files.outputs.sdist_url }}
+        run: |
+          python -m pip install --disable-pip-version-check --only-binary=:all: \
+            "pypi-attestations==0.0.29"
+          for artifact in "$WHEEL_URL" "$SDIST_URL"; do
+            pypi-attestations verify pypi \
+              --repository "https://github.com/${GITHUB_REPOSITORY}" \
+              "$artifact"
+          done
+
+  publish-github-release:
+    name: Publish the verified GitHub Release
+    needs: [build-candidate, verify-pypi]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Publish draft release after PyPI verification
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ needs.build-candidate.outputs.version }}
+        run: |
+          gh release edit "v$VERSION" --repo "$GITHUB_REPOSITORY" --draft=false
+
+  update-homebrew:
+    name: Promote verified sdist to Homebrew
+    needs: [build-candidate, verify-pypi, publish-github-release]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Update Homebrew formula
+        uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0  # v3
+        with:
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          repository: raullenchai/homebrew-rapid-mlx
+          event-type: update-formula
+          client-payload: |
+            {
+              "version": "${{ needs.build-candidate.outputs.version }}",
+              "url": "${{ needs.verify-pypi.outputs.sdist_url }}",
+              "sha256": "${{ needs.verify-pypi.outputs.sdist_sha256 }}"
+            }

--- a/.github/workflows/release-artifact-matrix.yml
+++ b/.github/workflows/release-artifact-matrix.yml
@@ -182,6 +182,9 @@ jobs:
     environment: pypi
     permissions:
       id-token: write
+      # contents: read is required for the tag re-resolution step's
+      # authenticated `gh api` / `gh release view` calls below.
+      contents: read
     steps:
       - name: Download candidate distribution
         uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0  # v5

--- a/.github/workflows/release-preflight.yml
+++ b/.github/workflows/release-preflight.yml
@@ -5,8 +5,7 @@ name: Release pre-flight
 # X.Y.Z`` — the same regex the auto-release.yml workflow watches post-
 # merge.
 #
-# Gate coverage (see docs/development/release_workflow.md for the
-# canonical list):
+# Gate coverage (see docs/development/releasing.md for the canonical list):
 #
 #   G1   clean-room install + import smoke     macOS-14
 #   G2   codex review presence assertion       advisory comment
@@ -16,7 +15,7 @@ name: Release pre-flight
 #   PF-1 squash subject regex pre-check        ubuntu-latest
 #
 # What this workflow does NOT cover (M3-only, runs locally — see
-# release_workflow.md):
+# releasing.md):
 #   G4 full make smoke (covered by ci.yml test-apple-silicon subset)
 #   G5 make stress      — needs cached weights + live server
 #   G6 fix-path repro   — needs live server
@@ -65,8 +64,8 @@ jobs:
     if: needs.detect-bump-pr.outputs.is_bump == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version: "3.12"
       - name: PF-1 — validate bump PR title matches auto-release regex
@@ -92,12 +91,17 @@ jobs:
     if: needs.detect-bump-pr.outputs.is_bump == 'true'
     runs-on: macos-14
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version: "3.12"
-      - name: G1 — clean-room install + import smoke
-        run: make release-smoke
+      - name: G1 — build once and smoke the exact release distributions
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install build twine
+          python -m build
+          twine check dist/*
+          python scripts/release_smoke.py --dist-dir dist
 
   g10-upstream-mlx-scan:
     # G10 — advisory scan of installed mlx-lm/mlx-vlm for module-scope
@@ -108,8 +112,8 @@ jobs:
     if: needs.detect-bump-pr.outputs.is_bump == 'true'
     runs-on: macos-14
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version: "3.12"
       - name: Install mlx-lm + mlx-vlm at pyproject-pinned versions
@@ -137,8 +141,8 @@ jobs:
     if: needs.detect-bump-pr.outputs.is_bump == 'true'
     runs-on: macos-14
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version: "3.12"
       - name: Install project (vision extras for full surface coverage)
@@ -174,7 +178,7 @@ jobs:
           echo "G11  escape-hatch:    $G11"
           # G10 is advisory — never blocks. Others must pass.
           if [ "$PF1" != "success" ] || [ "$G1" != "success" ] || [ "$G11" != "success" ]; then
-            echo "::error::One or more release pre-flight gates failed. See docs/development/release_workflow.md for the gate definitions."
+            echo "::error::One or more release pre-flight gates failed. See docs/development/releasing.md for the gate definitions."
             exit 1
           fi
           echo "All blocking gates passed. M3-only gates (G4-G9) must be run locally."

--- a/.github/workflows/sidecar-build.yml
+++ b/.github/workflows/sidecar-build.yml
@@ -50,7 +50,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           fetch-depth: 1
 
@@ -78,12 +78,12 @@ jobs:
           echo "Release tag will be: $TAG"
 
       - name: Set up Python 3.12 (host driver for pip install)
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version: '3.12'
 
       - name: Cache python-build-standalone download
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
         with:
           path: /tmp/rapid-pbs-*.tar.gz
           # PBS_TAG inside build-sidecar.sh is the source of truth.
@@ -156,7 +156,7 @@ jobs:
         # script + packaging path don't break; we don't need the
         # artifact downloadable.
         if: github.event_name != 'pull_request' && steps.codesign.outputs.available == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: rapid-mlx-sidecar-${{ steps.version.outputs.rapid_mlx_version }}
           path: |

--- a/.github/workflows/spam-issue-guard.yml
+++ b/.github/workflows/spam-issue-guard.yml
@@ -35,7 +35,7 @@ jobs:
       github.event.issue.author_association != 'COLLABORATOR'
     steps:
       - name: Advisory comment + spam-suspected label if no template label present
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b  # v7
         with:
           script: |
             const issue = context.payload.issue;

--- a/.github/workflows/validate-community-submission.yml
+++ b/.github/workflows/validate-community-submission.yml
@@ -22,14 +22,14 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           # Need the merge-base so we can diff against the PR target
           # and only validate files actually changed in this PR.
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version: "3.13"
 

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -55,7 +55,7 @@ jobs:
   guard:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           fetch-depth: 0
 

--- a/docs/development/pr_merge_sop.md
+++ b/docs/development/pr_merge_sop.md
@@ -232,10 +232,10 @@ The full `pr_validate` pipeline runs on every PR via `.github/workflows/pr-valid
 | 1 — pre-flight | `version-check.yml` blast-radius detection + `pr_validate.fetch` (in pr-validate.yml) | — | PR-template fields still need a human read |
 | 2 — codex review | `pr_validate.codex_review` step skips on CI (no `~/.codex/auth.json`); humans run codex locally | maintainer | runs in the human's terminal; conclusions feed the PR thread |
 | 3 — test coverage | `ci.yml` (existence of `tests/test_<scope>*.py` files) | mutation spot-check | mutation testing is the cheap manual step |
-| 4 — lint + format | `ci.yml` lint job (ruff, ruff format, audit_cli_config_fidelity, gha-pinning advisory, parser microbench) | — | full coverage |
+| 4 — lint + format | `ci.yml` lint job (ruff, ruff format, audit_cli_config_fidelity, mandatory GHA SHA pinning, parser microbench) | — | full coverage |
 | 5 — broader unit suite | `ci.yml` test-matrix (linux-compat subset) + test-apple-silicon (mlx-dependent) | `pr_validate.full_unit` on M3 | CI covers the two surfaces it can; full tests/ tree runs on M3 |
 | 6 — pr_validate | **pipeline** (7 of 9 steps) auto via `pr-validate.yml` | `stress_e2e_bench` + `full_unit` | both skipped steps need MLX / a live server; covered by `make release-check-m3` |
-| 7 — supply chain | `pr_validate.supply_chain` (auto) + gha-pinning advisory | license drift + transitive deps still need a human read | partial automation; pip-audit is automated |
+| 7 — supply chain | `pr_validate.supply_chain` (auto) + mandatory GHA SHA pinning | license drift + transitive deps still need a human read | partial automation; pip-audit is automated |
 | 8 — bench `make check` | — | **M3** (needs MLX + cached weights) | inference-touching PRs only |
 | 9 — Anthropic-compat | — | **M3** (needs MLX + live server) | parser/router PRs only — covered by `make release-check-m3` |
 | 10 — CI gate | `ci.yml` aggregation + `pr-validate.yml` scorecard | — | full coverage |

--- a/docs/development/release-artifact-acceptance.md
+++ b/docs/development/release-artifact-acceptance.md
@@ -1,0 +1,195 @@
+# Release artifact acceptance
+
+This document is the source of truth for the final quality gate between a
+version-bump candidate and publication. It answers a narrower question than
+the ordinary test suite: **does the exact wheel that will be uploaded behave
+correctly when real users drive it through supported models, agents, and SDKs?**
+
+`make release-smoke` remains useful, but import-only smoke cannot answer that
+question. The artifact acceptance matrix must start the installed release
+wheel from an empty directory and drive it over HTTP.
+
+## Rollout status
+
+This repository currently has no registered self-hosted release runner. This
+change therefore ships the promotion workflow as **dispatch-only and dry-run
+by default**: leave `publish` unchecked to validate a PR/tag candidate without
+changing PyPI, GitHub Releases, or Homebrew. The existing release event path
+has still been hardened with a manifest, least privilege, post-upload sdist
+hash check, and immutable action pins; it is not yet made to wait forever for
+a runner that does not exist.
+
+Do not enable `publish` until the [activation transaction](#activation-transaction)
+is complete. That is intentional: having both the legacy `publish.yml` and
+the new promotion workflow upload the same immutable version would turn a
+successful release into a duplicate-upload failure.
+
+## Target promotion flow
+
+```text
+protected release PR on main
+  -> build wheel + sdist once
+  -> twine check + SHA-256 release manifest
+  -> clean-room install/import/CLI smoke of both artifacts
+  -> artifact matrix: installed wheel + real model + agent/framework cells
+  -> PyPI Trusted Publishing (OIDC only in this job)
+  -> download PyPI files; compare release manifest hashes and verify attestation
+  -> publish GitHub Release; promote the verified sdist to Homebrew
+```
+
+The release PR merge is the single-maintainer approval point. The `pypi`
+environment remains part of the PyPI Trusted Publisher identity and is limited
+to the protected release source, but it does **not** need a second-person
+reviewer.
+
+## What must be tested
+
+### 1. Both distribution formats
+
+The clean-room smoke runs each candidate `rapid_mlx-*.whl` and
+`rapid_mlx-*.tar.gz` in its own venv. It imports every base entrypoint module
+and ensures the package was not shadowed by the checkout. The command is:
+
+```bash
+python scripts/release_smoke.py --dist-dir candidate/dist
+```
+
+The sdist check catches omitted package data and build-backend errors; the
+wheel is the artifact used by the live matrix.
+
+### 2. Agent and framework matrix from the installed wheel
+
+The matrix is one server boot per family. A test run sets both
+`RAPID_MLX_MATRIX_STRICT=1` and `RAPID_MLX_MATRIX_NO_SKIPS=1`:
+
+- wrong model / unavailable server is a failure, not a skip;
+- a missing SDK, Docker daemon, Aider executable, or other ordinary
+  prerequisite is a failure, not a skip;
+- a documented `strict=True` xfail remains an exception, and an unexpected
+  pass is a failure.
+
+The current feasible set is four families:
+
+| Family | Candidate alias | Agent cells | Framework cells |
+| --- | --- | ---: | ---: |
+| Qwen | `qwen3.5-4b-4bit` | 11 | 3 |
+| Gemma 4 | `gemma-4-12b-4bit` | 11 | 3 |
+| DeepSeek | `deepseek-r1-32b-4bit` | 11 | 3 |
+| gpt-oss | `gpt-oss-20b-mxfp4-q8` | 11 | 3 |
+| **Total** | | **44** | **12** |
+
+So the normal release gate contains **56 cells**. The 44-cell shorthand means
+only the agent half; it must not be used to omit the 12 framework cells.
+
+There are currently ten narrow, expected strict-xfails in those four families:
+nine DeepSeek-R1-Distill tool-call cells and the gpt-oss × OpenHands format
+mismatch. Their reason and upstream issue must remain in
+`tests/integrations/conftest.py`; no broad `skip`, `xfail`, or `|| true` is
+allowed in the release lane.
+
+Hy3 adds 14 more cells (11 agent + 3 framework), but its 166 GB model requires
+a dedicated Ultra host. Every release still runs its offline parser contract.
+Any change touching Hy3, shared server loading, routing, tokenization, or
+streaming additionally requires the real Hy3 matrix on that host before
+promotion.
+
+## Runner contract
+
+`release-artifact-matrix.yml` is dispatch-only until a runner with these
+labels exists:
+
+```text
+self-hosted, macOS, ARM64, rapid-mlx-release
+```
+
+It must be a dedicated Apple-Silicon release machine, not a developer's daily
+workstation and not an operator host. The OpenHands cell deliberately mounts a
+Docker socket into a pinned container; that makes an isolated daemon and
+ephemeral workspace non-negotiable. Install or pre-provision:
+
+- Python 3.12 and a current GitHub Actions runner;
+- Docker Desktop/daemon, plus `docker info` access for the runner user;
+- `coreutils` (`gtimeout` on macOS), used by the Aider harness;
+- enough local disk for the four model caches plus a 100 GB safety floor.
+
+The runner receives no PyPI token, OIDC permission, release-write token, or
+Homebrew credential. It is only allowed to read the candidate artifact and
+download public model data.
+
+## Running a candidate
+
+From GitHub Actions, dispatch **Release artifact acceptance matrix**, select
+the exact release-PR SHA/ref, and keep the four default families. Diagnostic
+runs may select a non-empty unique subset, but a `publish=true` run rejects
+anything other than all four families exactly once. The workflow:
+
+1. builds wheel and sdist once on GitHub-hosted Linux;
+2. runs `twine check` and writes `release-manifest.json` with source SHA,
+   version, size, and SHA-256 for both artifacts;
+3. sends that artifact to the isolated macOS runner;
+4. verifies the manifest before each matrix shard;
+5. performs the clean-room smoke and runs the strict family matrix against
+   the installed wheel.
+
+For local runner diagnosis, use the same artifact rather than `pip install .`:
+
+```bash
+python scripts/release_manifest.py verify \
+  --dist-dir candidate/dist --manifest candidate/release-manifest.json
+python scripts/release_smoke.py --dist-dir candidate/dist
+python scripts/release_artifact_matrix.py \
+  --dist-dir candidate/dist --family qwen36 --port 18000
+```
+
+Pass `--keep-venv` to preserve the isolated venv and server log after a
+failure. Never re-run the matrix from the checkout to diagnose a distribution
+failure; doing so changes the thing being tested.
+
+## Publication rules
+
+After the runner is registered, artifact acceptance becomes a required release
+check. The publishing job may consume only the artifact whose manifest was
+accepted. It gets `id-token: write`; build, test, attestation, and Homebrew
+jobs do not. The PyPI package is then downloaded again and its wheel/sdist
+hashes must equal the manifest before GitHub Release or Homebrew promotion.
+
+PyPI's automatic Trusted-Publisher attestation proves who uploaded each file.
+GitHub artifact provenance and an SBOM are added alongside the manifest as the
+next hardening step; they do not replace the live matrix.
+
+## Activation transaction
+
+Perform the following once a runner meeting the contract above is online. It
+is a short, intentional repository-settings change; it needs no second
+maintainer approval, no PyPI API token, and no release secret added to the
+runner.
+
+1. Register the dedicated runner with all four labels shown in the runner
+   contract, then dispatch this workflow once with `publish=false` for a
+   tagged candidate. Confirm all four shards pass.
+2. In GitHub **Settings → Environments → `pypi`**, keep required reviewers
+   empty. Set its deployment branch/tag policy to selected tags `v*`. A manual
+   workflow run that publishes must itself be started from that same `vX.Y.Z`
+   tag, not from `main`.
+3. In PyPI’s Trusted Publisher settings, replace the current legacy workflow
+   identity with repository `raullenchai/Rapid-MLX`, workflow
+   `release-artifact-matrix.yml`, and environment `pypi`. Trusted Publishing
+   then grants a short-lived token only to this workflow’s publish job.
+4. In the same reviewed migration PR, retire the legacy
+   `release: published → publish.yml` uploader and change auto-release to
+   create a draft GitHub Release. The promotion workflow publishes that draft
+   only after PyPI verification and Homebrew dispatch. Do these two changes
+   together: keeping both uploaders active would attempt two uploads of the
+   same immutable version.
+5. Make the artifact-acceptance workflow a required release check/ruleset
+   condition for the protected release PR. The condition is the matrix run
+   against the release tag, not an arbitrary branch run.
+
+After that migration, start the workflow from `vX.Y.Z`, set `ref` to exactly
+`vX.Y.Z`, and set `publish=true`. The workflow itself rejects a publication
+unless its input ref, workflow ref, and checked-out source SHA all point to
+the tag matching `pyproject.toml`’s version.
+The PyPI job is the sole job with `id-token: write`. The next job re-downloads
+both PyPI files, checks their hash and size against the candidate manifest,
+and verifies PyPI’s Sigstore publish attestations with
+`pypi-attestations` before Homebrew receives the sdist URL and SHA-256.

--- a/docs/development/releasing.md
+++ b/docs/development/releasing.md
@@ -2,6 +2,9 @@
 
 This page documents the **end-to-end release flow** and the **safety nets** that catch the common failure modes.
 
+For the final gate that validates the exact wheel through real models, agents,
+and SDK/framework clients, see [Release artifact acceptance](release-artifact-acceptance.md).
+
 The historical pain point: between v0.6.14 (2026-05-05) and v0.6.16, several PRs added 30+ new model aliases (`granite4-tiny-4bit`, `smollm3-3b-4bit`, `deepseek-v4-flash-8bit`, `qwen3.6-*`, etc), but no version was bumped — leaving brew/PyPI users with a stale `rapid-mlx models` list. The safety nets below are designed to make that exact failure impossible to repeat without explicit human override.
 
 ## Quick reference
@@ -151,7 +154,7 @@ This is the rule. No exceptions. CI doesn't fake-inference with a tiny model on 
 
 | # | Gate | Side | Where it runs | Catches |
 |---|---|---|---|---|
-| G1 | `make release-smoke` — clean-room install + import | CI | `release-preflight.yml` (macOS-14) | dev mlx symbol drift (#408) |
+| G1 | Build wheel + sdist, then clean-room install + import both | CI | `release-preflight.yml` (macOS-14) | dev mlx symbol drift (#408), incomplete source distribution |
 | G2 | Codex review × 2 rounds | local | maintainer machine | every PR-author bug class |
 | G3 | CLI ↔ Config fidelity audit | CI | `ci.yml` lint (ubuntu) | silent CLI flag drop (#400) |
 | G4 | unit suite (≈4500 tests) | CI | `ci.yml` test-matrix (linux) + test-apple-silicon (macOS-14) | parser/router regressions |
@@ -172,7 +175,9 @@ This is the rule. No exceptions. CI doesn't fake-inference with a tiny model on 
 
 **Every bump PR** (title matches `chore: bump version to X.Y.Z`) → `release-preflight.yml` adds PF-1, G1, G10 (advisory), G11. The `preflight-summary` job aggregates them so the bump PR has a single required check.
 
-**Every PR + push to main** → `ci.yml` runs lint (ruff + audit + GHA-pin advisory + parser microbench) + test-matrix (linux curated) + test-apple-silicon (macOS-14 mlx-importing tests).
+**Every PR + push to main** → `ci.yml` runs lint (ruff + audit + mandatory
+GHA SHA-pin check + parser microbench) + test-matrix (linux curated) +
+test-apple-silicon (macOS-14 mlx-importing tests).
 
 ### M3 local — one command before pushing the bump commit
 
@@ -212,8 +217,8 @@ For PRs that are explicitly about perf changes (a kernel rewrite, a new fast pat
 |---|---|---|
 | `(#NN)` squash suffix breaks regex | `release_squash_subject` | PF-1 |
 | `skip-version-bump` escape-hatch label refire | `gotcha_skip_version_bump_label` | Auto-refires — `version-check.yml` subscribes to `labeled`/`unlabeled`/`edited`, so adding/removing the label or re-titling reruns the guard (no close+reopen needed) |
-| Mutable GitHub Actions tags as supply-chain vector | `pr_merge_sop` §7 | `scripts/check_gha_pinning.py` (advisory pending pinning cleanup) |
-| MLX upstream new module-scope calls (M5 #404) | `release_workflow` G10 | `scripts/check_mlx_upstream_calls.py` in `release-preflight.yml` |
+| Mutable GitHub Actions tags as supply-chain vector | `pr_merge_sop` §7 | `scripts/check_gha_pinning.py` (mandatory: every `uses:` is a 40-character SHA) |
+| MLX upstream new module-scope calls (M5 #404) | G10 in this release guide | `scripts/check_mlx_upstream_calls.py` in `release-preflight.yml` |
 | Codex-skip rationalization on bump PRs ("feels like just a version bump") | `feedback_release_sop_third_offense` | CI/M3 split — most skippable gates are now in CI, not in the human's hands |
 
 ### Adding a new gate

--- a/scripts/check_gha_pinning.py
+++ b/scripts/check_gha_pinning.py
@@ -28,27 +28,87 @@ import re
 import sys
 from pathlib import Path
 
-# uses: <owner>/<repo>[/path]@<ref>
-USES_RE = re.compile(
-    r"^\s*-?\s*uses:\s*([^@\s]+)@([^\s#]+)",
-    re.MULTILINE,
-)
+import yaml
+
 SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+# A container image digest, e.g. ``docker://ghcr.io/org/img@sha256:<64 hex>``.
+DIGEST_RE = re.compile(r"@sha256:[0-9a-f]{64}$")
+
+
+class _LineLoader(yaml.SafeLoader):
+    """SafeLoader that records the 1-based line number of every mapping value.
+
+    Parsing the YAML (rather than regex-scanning raw text) means a quoted key
+    (``"uses": ...``) or a quoted value (``uses: "actions/checkout@v4"``) is
+    validated exactly like the bare form — the previous ``^\\s*uses:`` regex
+    silently skipped both, leaving a mutable action reference green.
+    """
+
+
+def _construct_mapping(loader: _LineLoader, node: yaml.MappingNode):
+    mapping = {}
+    for key_node, value_node in node.value:
+        key = loader.construct_object(key_node)
+        value = loader.construct_object(value_node)
+        mapping[key] = value
+        if key == "uses":
+            # Stash the source line so a violation can point at it.
+            mapping.setdefault("__uses_line__", value_node.start_mark.line + 1)
+    return mapping
+
+
+_LineLoader.add_constructor(
+    yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG, _construct_mapping
+)
+
+
+def _iter_uses(node: object):
+    """Yield ``(uses_value, line_no)`` for every ``uses:`` mapping in the tree."""
+    if isinstance(node, dict):
+        if "uses" in node and isinstance(node["uses"], str):
+            yield node["uses"], node.get("__uses_line__")
+        for value in node.values():
+            yield from _iter_uses(value)
+    elif isinstance(node, list):
+        for item in node:
+            yield from _iter_uses(item)
+
+
+def _is_pinned(uses: str) -> bool:
+    """True iff ``uses`` is an acceptably-immutable reference.
+
+    * Local actions (``./path`` or ``.`` — same-repo, no supply-chain hop) pass.
+    * Container actions pinned by ``@sha256:<digest>`` pass.
+    * Remote ``owner/repo[/path]@<ref>`` must pin ``<ref>`` to a 40-char SHA.
+    """
+    if uses.startswith("./") or uses == ".":
+        return True
+    if uses.startswith("docker://"):
+        return bool(DIGEST_RE.search(uses))
+    if "@" not in uses:
+        # No ref at all on a remote action — mutable by definition.
+        return False
+    ref = uses.rsplit("@", 1)[1]
+    return bool(SHA_RE.fullmatch(ref))
 
 
 def violations_in_file(path: Path) -> list[str]:
     """Return a list of human-readable violations for one workflow file."""
     out: list[str] = []
     text = path.read_text()
-    for m in USES_RE.finditer(text):
-        action, ref = m.group(1), m.group(2)
-        if SHA_RE.fullmatch(ref):
-            continue
-        line_no = text[: m.start()].count("\n") + 1
-        out.append(
-            f"{path}:{line_no}: uses: {action}@{ref} — action must pin "
-            "to a 40-char SHA, not a tag/branch"
-        )
+    try:
+        documents = list(yaml.load_all(text, Loader=_LineLoader))
+    except yaml.YAMLError as exc:
+        return [f"{path}: unparseable YAML — cannot verify action pinning ({exc})"]
+    for document in documents:
+        for uses, line_no in _iter_uses(document):
+            if _is_pinned(uses):
+                continue
+            where = f"{path}:{line_no}" if line_no else str(path)
+            out.append(
+                f"{where}: uses: {uses} — action must pin to a 40-char SHA "
+                "(or sha256 digest for container actions), not a tag/branch"
+            )
     return out
 
 

--- a/scripts/check_gha_pinning.py
+++ b/scripts/check_gha_pinning.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0
-"""Enforce 40-char SHA pinning on third-party GitHub Actions.
+"""Enforce 40-char SHA pinning on GitHub Actions.
 
 Mutable tags (``actions/checkout@v4``) are a supply-chain compromise
 vector: if the action's repo is taken over, every workflow that pins by
@@ -8,10 +8,10 @@ tag automatically picks up the malicious version on the next CI run.
 This bit Trivy in 2026 and is the recurring class of attack against
 auto-publishing release pipelines (which Rapid-MLX is).
 
-Allowlist: official ``actions/*`` and ``github/*`` org actions are
-permitted at tag refs because GitHub backs their immutability via a
-separate guarantee. Everything else must be a 40-char commit SHA, with
-the human-readable version comment on the same line:
+Every action must use a 40-char commit SHA, including official
+``actions/*`` and ``github/*`` actions. Tags can be moved or replaced;
+the human-readable version belongs in a trailing comment on the same
+line:
 
     uses: codecov/codecov-action@1234567890abcdef1234567890abcdef12345678  # v4.5.0
 
@@ -28,9 +28,6 @@ import re
 import sys
 from pathlib import Path
 
-# Owners whose tags we trust as immutable (per GitHub's own guarantee).
-TRUSTED_OWNERS = {"actions", "github"}
-
 # uses: <owner>/<repo>[/path]@<ref>
 USES_RE = re.compile(
     r"^\s*-?\s*uses:\s*([^@\s]+)@([^\s#]+)",
@@ -45,15 +42,12 @@ def violations_in_file(path: Path) -> list[str]:
     text = path.read_text()
     for m in USES_RE.finditer(text):
         action, ref = m.group(1), m.group(2)
-        owner = action.split("/", 1)[0]
-        if owner in TRUSTED_OWNERS:
-            continue
         if SHA_RE.fullmatch(ref):
             continue
         line_no = text[: m.start()].count("\n") + 1
         out.append(
-            f"{path}:{line_no}: uses: {action}@{ref} — non-allowlisted "
-            "third-party action must pin to a 40-char SHA, not a tag/branch"
+            f"{path}:{line_no}: uses: {action}@{ref} — action must pin "
+            "to a 40-char SHA, not a tag/branch"
         )
     return out
 
@@ -82,10 +76,7 @@ def main(argv: list[str] | None = None) -> int:
         all_violations.extend(violations_in_file(wf))
 
     if not all_violations:
-        print(
-            f"OK: {len(workflows)} workflows clean — every third-party "
-            "`uses:` is a 40-char SHA or an allowlisted owner."
-        )
+        print(f"OK: {len(workflows)} workflows clean — every `uses:` is a 40-char SHA.")
         return 0
 
     print(

--- a/scripts/release_artifact_matrix.py
+++ b/scripts/release_artifact_matrix.py
@@ -185,6 +185,15 @@ def _assert_port_available(port: int) -> None:
     readiness gate on another process's response. Binding the port ourselves
     proves it is genuinely free; we release it immediately so the candidate
     server can claim it.
+
+    There is a narrow TOCTOU window between releasing this probe socket and the
+    candidate server binding. It is not exploitable in practice: if a foreign
+    listener grabbed the port in that window, the candidate ``rapid-mlx serve``
+    would fail to bind and exit, and ``_wait_for_server``'s ``process.poll()``
+    liveness check surfaces that as "candidate server exited early" rather than
+    accepting the foreign listener's response. The alternative — handing the
+    bound socket to the child — is not possible because ``rapid-mlx serve``
+    opens its own listening socket.
     """
 
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)

--- a/scripts/release_artifact_matrix.py
+++ b/scripts/release_artifact_matrix.py
@@ -1,0 +1,427 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Run the live agent/framework acceptance matrix against a release wheel.
+
+This is deliberately separate from ``release_smoke.py``:
+
+* ``release_smoke.py`` proves that each distribution installs and imports in
+  a clean virtual environment.
+* This runner proves that the *wheel produced for the release* can boot a
+  real server and satisfy the strict agent + framework matrix for one model
+  family.
+
+The runner is intended for an isolated Apple-Silicon macOS release machine.
+It installs the wheel into a fresh venv, starts the console script from an
+empty working directory, then drives the integration clients from the source
+checkout over HTTP.  Keeping the server out of the checkout is important:
+otherwise Python can import ``vllm_mlx/`` from the tree and falsely validate
+the source instead of the candidate artifact.
+
+Run one family per invocation so every matrix cell is attributable to the
+model actually loaded by that server.  A release workflow fans this script
+out over the supported families.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+import urllib.error
+import urllib.request
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+MATRIX_FILES = (
+    REPO_ROOT / "tests/integrations/test_agents_matrix.py",
+    REPO_ROOT / "tests/integrations/test_frameworks_matrix.py",
+)
+
+# These are the client libraries that the strict matrix imports.  They remain
+# test-only: none are added to the released package's runtime dependency set.
+MATRIX_TEST_DEPENDENCIES = (
+    "pytest>=7.0.0",
+    "pytest-asyncio>=0.21.0",
+    "httpx>=0.24.0",
+    "openai>=1.0.0",
+    "anthropic>=0.30.0",
+    "langchain-openai>=0.2.0",
+    "pydantic-ai>=0.0.20",
+    "smolagents>=1.0.0",
+    "aider-chat>=0.80.0",
+)
+
+# The base distribution exposes two canonical commands and two deprecated
+# compatibility aliases. ``rapid-mlx-chat`` and ``vllm-mlx-chat`` belong to
+# the optional ``chat`` extra, so testing them here would incorrectly reject a
+# valid base wheel.
+CLI_SMOKE_SCRIPTS = (
+    "rapid-mlx",
+    "rapid-mlx-bench",
+    "vllm-mlx",
+    "vllm-mlx-bench",
+)
+
+
+@dataclass(frozen=True)
+class FamilyConfig:
+    """One independently booted, release-eligible matrix family."""
+
+    model: str
+    server_args: tuple[str, ...] = ("--no-thinking",)
+    extras: tuple[str, ...] = ()
+
+
+# Keep this map aligned with tests/integrations/conftest.py::_FAMILY_ALIASES.
+# The cheap aliases make the full four-family release matrix feasible on an
+# isolated M3/Ultra runner; the larger golden models remain a separate perf
+# and weekly-path concern.
+FAMILY_CONFIGS: dict[str, FamilyConfig] = {
+    "qwen36": FamilyConfig("qwen3.5-4b-4bit"),
+    "gemma4": FamilyConfig("gemma-4-12b-4bit", extras=("vision",)),
+    "deepseek": FamilyConfig("deepseek-r1-32b-4bit"),
+    "gptoss": FamilyConfig("gpt-oss-20b-mxfp4-q8"),
+}
+
+
+def validate_families_json(
+    value: str, *, require_all_families: bool = False
+) -> tuple[str, ...]:
+    """Parse workflow matrix input and reject coverage-bypassing values.
+
+    A dispatch-only diagnostic run may select a non-empty subset of the
+    supported families. A publishing run must cover every feasible family;
+    otherwise a caller could green-light a release after validating only the
+    cheapest or most convenient model.
+    """
+
+    try:
+        families = json.loads(value)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"families must be a JSON array: {exc.msg}") from exc
+
+    if not isinstance(families, list) or not families:
+        raise ValueError("families must be a non-empty JSON array")
+    if not all(isinstance(family, str) for family in families):
+        raise ValueError("families must contain only family-name strings")
+    if len(set(families)) != len(families):
+        raise ValueError("families must not contain duplicates")
+
+    unknown = sorted(set(families) - FAMILY_CONFIGS.keys())
+    if unknown:
+        raise ValueError(
+            "unknown family name(s): "
+            + ", ".join(unknown)
+            + f"; choices: {', '.join(sorted(FAMILY_CONFIGS))}"
+        )
+    if require_all_families and set(families) != set(FAMILY_CONFIGS):
+        raise ValueError(
+            "publication requires every release family exactly once: "
+            + ", ".join(FAMILY_CONFIGS)
+        )
+    return tuple(families)
+
+
+def _clean_env() -> dict[str, str]:
+    """Return an environment that cannot import source-tree Python packages."""
+
+    env = os.environ.copy()
+    for name in (
+        "PYTHONPATH",
+        "PYTHONHOME",
+        "PYTHONUSERBASE",
+        "PIP_TARGET",
+        "PIP_PREFIX",
+    ):
+        env.pop(name, None)
+    env["PYTHONNOUSERSITE"] = "1"
+    env["PIP_DISABLE_PIP_VERSION_CHECK"] = "1"
+    # Artifact acceptance must not contact the update endpoint or emit
+    # telemetry while booting the candidate wheel.  Apart from avoiding
+    # release-runner side effects, this makes the live matrix independent of
+    # an operator's existing telemetry consent or transient network failures.
+    env["RAPID_MLX_DISABLE_VERSION_CHECK"] = "1"
+    env["RAPID_MLX_TELEMETRY"] = "0"
+    return env
+
+
+def _run(cmd: Sequence[str], *, cwd: Path, env: dict[str, str]) -> None:
+    """Print and run a command, preserving actionable failure output."""
+
+    print(f"  $ {' '.join(cmd)}", flush=True)
+    subprocess.run(list(cmd), cwd=cwd, env=env, check=True)
+
+
+def find_release_wheel(dist_dir: Path) -> Path:
+    """Return the sole rapid-mlx wheel in ``dist_dir`` or raise clearly."""
+
+    wheels = sorted(path for path in dist_dir.glob("rapid_mlx-*.whl") if path.is_file())
+    if len(wheels) != 1:
+        rendered = ", ".join(path.name for path in wheels) or "<none>"
+        raise ValueError(
+            f"expected exactly one rapid-mlx wheel under {dist_dir}, found: {rendered}"
+        )
+    return wheels[0].resolve()
+
+
+def _wait_for_server(
+    *, port: int, process: subprocess.Popen[str], log: Path, timeout: int
+) -> None:
+    """Wait until the candidate artifact's server exposes ``/v1/models``."""
+
+    url = f"http://127.0.0.1:{port}/v1/models"
+    deadline = time.monotonic() + timeout
+    last_error = "not attempted"
+    while time.monotonic() < deadline:
+        if process.poll() is not None:
+            tail = log.read_text(errors="replace")[-4000:] if log.exists() else ""
+            raise RuntimeError(
+                f"candidate server exited early ({process.returncode}); log tail:\n{tail}"
+            )
+        try:
+            with urllib.request.urlopen(url, timeout=5) as response:
+                if response.status == 200:
+                    return
+        except (OSError, urllib.error.URLError) as exc:
+            last_error = str(exc)
+        time.sleep(2)
+    tail = log.read_text(errors="replace")[-4000:] if log.exists() else ""
+    raise RuntimeError(
+        f"candidate server did not answer {url} within {timeout}s ({last_error}); "
+        f"log tail:\n{tail}"
+    )
+
+
+def _terminate(process: subprocess.Popen[str]) -> None:
+    """Stop the server without leaving a model process on the release runner."""
+
+    if process.poll() is not None:
+        return
+    process.terminate()
+    try:
+        process.wait(timeout=30)
+    except subprocess.TimeoutExpired:
+        process.kill()
+        process.wait(timeout=10)
+
+
+def run_family(
+    *,
+    dist_dir: Path,
+    family: str,
+    port: int,
+    server_timeout: int,
+    keep_venv: bool,
+) -> None:
+    """Install one release wheel and execute its strict matrix family slice."""
+
+    try:
+        config = FAMILY_CONFIGS[family]
+    except KeyError as exc:
+        raise ValueError(
+            f"unknown family {family!r}; choices: {', '.join(sorted(FAMILY_CONFIGS))}"
+        ) from exc
+
+    wheel = find_release_wheel(dist_dir)
+    root = Path(tempfile.mkdtemp(prefix=f"rapid-mlx-release-{family}-"))
+    venv = root / "venv"
+    server_cwd = root / "server-cwd"
+    log = root / "server.log"
+    process: subprocess.Popen[str] | None = None
+    env = _clean_env()
+
+    try:
+        server_cwd.mkdir()
+        _run([sys.executable, "-m", "venv", str(venv)], cwd=root, env=env)
+        python = venv / "bin" / "python"
+        rapid_mlx = venv / "bin" / "rapid-mlx"
+
+        _run(
+            [str(python), "-m", "pip", "install", "--upgrade", "pip"],
+            cwd=root,
+            env=env,
+        )
+        artifact_spec = str(wheel)
+        if config.extras:
+            artifact_spec = f"{artifact_spec}[{','.join(config.extras)}]"
+        _run(
+            [str(python), "-m", "pip", "install", "--prefer-binary", artifact_spec],
+            cwd=root,
+            env=env,
+        )
+        if not rapid_mlx.is_file():
+            raise RuntimeError(
+                f"release wheel did not install rapid-mlx at {rapid_mlx}"
+            )
+        for script in CLI_SMOKE_SCRIPTS:
+            executable = venv / "bin" / script
+            if not executable.is_file():
+                raise RuntimeError(
+                    f"release wheel did not install console script {script!r}"
+                )
+            _run([str(executable), "--help"], cwd=root, env=env)
+        _run(
+            [
+                str(python),
+                "-m",
+                "pip",
+                "install",
+                "--prefer-binary",
+                *MATRIX_TEST_DEPENDENCIES,
+            ],
+            cwd=root,
+            env=env,
+        )
+
+        runner_env = env | {"PATH": f"{venv / 'bin'}:{env.get('PATH', '')}"}
+
+        # A release matrix must fail rather than silently omit Docker/Aider
+        # cells.  The tests themselves convert missing prerequisites into
+        # skips, and RAPID_MLX_MATRIX_NO_SKIPS below upgrades those skips to
+        # failures.  Fail before the expensive model load when the obvious
+        # host prerequisites are absent.
+        missing = [
+            binary
+            for binary in ("docker", "aider")
+            if shutil.which(binary, path=runner_env["PATH"]) is None
+        ]
+        if missing:
+            raise RuntimeError(
+                "release matrix runner is missing required executable(s): "
+                + ", ".join(missing)
+            )
+        docker = subprocess.run(
+            ["docker", "info"],
+            cwd=root,
+            env=runner_env,
+            capture_output=True,
+            text=True,
+        )
+        if docker.returncode != 0:
+            raise RuntimeError(
+                "release matrix requires a reachable Docker daemon for the "
+                f"OpenHands cell: {docker.stderr[-1000:]}"
+            )
+
+        with log.open("w", encoding="utf-8") as log_file:
+            process = subprocess.Popen(
+                [
+                    str(rapid_mlx),
+                    "serve",
+                    config.model,
+                    "--port",
+                    str(port),
+                    *config.server_args,
+                ],
+                cwd=server_cwd,
+                env=env,
+                stdout=log_file,
+                stderr=subprocess.STDOUT,
+                text=True,
+            )
+        _wait_for_server(port=port, process=process, log=log, timeout=server_timeout)
+
+        matrix_env = runner_env | {
+            "RAPID_MLX_BASE_URL": f"http://127.0.0.1:{port}/v1",
+            "RAPID_MLX_AGENT_MATRIX_FAMILY": family,
+            "RAPID_MLX_MATRIX_STRICT": "1",
+            "RAPID_MLX_MATRIX_NO_SKIPS": "1",
+            "AIDER_BIN": str(venv / "bin" / "aider"),
+        }
+        _run(
+            [str(python), "-m", "pytest", *map(str, MATRIX_FILES), "-v", "--tb=short"],
+            cwd=REPO_ROOT,
+            env=matrix_env,
+        )
+    finally:
+        if process is not None:
+            _terminate(process)
+        if keep_venv:
+            print(f"[release-matrix] preserved workdir: {root}")
+        else:
+            shutil.rmtree(root, ignore_errors=True)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--dist-dir",
+        type=Path,
+        help="Directory containing exactly one rapid_mlx-*.whl release candidate.",
+    )
+    parser.add_argument(
+        "--family",
+        choices=sorted(FAMILY_CONFIGS),
+        help="One model family to boot and validate.",
+    )
+    parser.add_argument("--port", type=int, default=18000)
+    parser.add_argument(
+        "--server-timeout-seconds",
+        type=int,
+        default=900,
+        help="Maximum time for a cold model download and server boot.",
+    )
+    parser.add_argument(
+        "--keep-venv",
+        action="store_true",
+        help="Keep the temporary venv and server log for debugging.",
+    )
+    parser.add_argument(
+        "--validate-families-json",
+        help="Validate a workflow families JSON input without running a model.",
+    )
+    parser.add_argument(
+        "--require-all-families",
+        action="store_true",
+        help="Require every release family exactly once (publication mode).",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    if args.validate_families_json is not None:
+        if args.dist_dir is not None or args.family is not None:
+            raise ValueError(
+                "--validate-families-json cannot be combined with --dist-dir or --family"
+            )
+        families = validate_families_json(
+            args.validate_families_json,
+            require_all_families=args.require_all_families,
+        )
+        print("[release-matrix] valid families: " + ", ".join(families))
+        return 0
+    if args.require_all_families:
+        raise ValueError("--require-all-families requires --validate-families-json")
+    if args.dist_dir is None or args.family is None:
+        raise ValueError(
+            "--dist-dir and --family are required to run the release matrix"
+        )
+    if not args.dist_dir.is_dir():
+        raise ValueError(f"--dist-dir is not a directory: {args.dist_dir}")
+    if args.server_timeout_seconds <= 0:
+        raise ValueError("--server-timeout-seconds must be positive")
+    run_family(
+        dist_dir=args.dist_dir.resolve(),
+        family=args.family,
+        port=args.port,
+        server_timeout=args.server_timeout_seconds,
+        keep_venv=args.keep_venv,
+    )
+    print(f"[release-matrix] {args.family}: PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (RuntimeError, ValueError, subprocess.CalledProcessError) as exc:
+        print(f"[release-matrix] FAIL: {exc}", file=sys.stderr)
+        raise SystemExit(1) from exc

--- a/scripts/release_artifact_matrix.py
+++ b/scripts/release_artifact_matrix.py
@@ -11,11 +11,15 @@ This is deliberately separate from ``release_smoke.py``:
   family.
 
 The runner is intended for an isolated Apple-Silicon macOS release machine.
-It installs the wheel into a fresh venv, starts the console script from an
-empty working directory, then drives the integration clients from the source
-checkout over HTTP.  Keeping the server out of the checkout is important:
-otherwise Python can import ``vllm_mlx/`` from the tree and falsely validate
-the source instead of the candidate artifact.
+It installs the wheel into a fresh SERVER venv (release artifact + declared
+extras only), starts the console script from an empty working directory, then
+drives the integration clients from a SEPARATE CLIENT venv (test/SDK deps)
+against the running server over HTTP.  Two isolations matter here: keeping the
+server out of the source checkout (otherwise Python can import ``vllm_mlx/``
+from the tree and falsely validate the source instead of the candidate
+artifact), and keeping the client SDK dependencies out of the server venv
+(otherwise a client's transitive dependency could satisfy a runtime import the
+wheel forgot to declare, masking a missing runtime dependency).
 
 Run one family per invocation so every matrix cell is attributable to the
 model actually loaded by that server.  A release workflow fans this script
@@ -28,6 +32,7 @@ import argparse
 import json
 import os
 import shutil
+import socket
 import subprocess
 import sys
 import tempfile
@@ -171,10 +176,45 @@ def find_release_wheel(dist_dir: Path) -> Path:
     return wheels[0].resolve()
 
 
+def _assert_port_available(port: int) -> None:
+    """Fail if anything is already listening on ``port`` before we spawn.
+
+    Without this, a stale same-family server left on the fixed release port
+    could answer ``/v1/models`` with 200 while the candidate process is still
+    loading (or has failed to bind), letting a broken candidate pass the
+    readiness gate on another process's response. Binding the port ourselves
+    proves it is genuinely free; we release it immediately so the candidate
+    server can claim it.
+    """
+
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        # No SO_REUSEADDR: we want the bind to FAIL if the port is in use,
+        # not to share it with a lingering listener.
+        sock.bind(("127.0.0.1", port))
+    except OSError as exc:
+        raise RuntimeError(
+            f"release port {port} is already in use before the candidate "
+            f"server is started ({exc}). Refusing to run — a stale listener "
+            f"could answer the readiness probe and mask a broken candidate. "
+            f"Free the port on the release runner and retry."
+        ) from exc
+    finally:
+        sock.close()
+
+
 def _wait_for_server(
     *, port: int, process: subprocess.Popen[str], log: Path, timeout: int
 ) -> None:
-    """Wait until the candidate artifact's server exposes ``/v1/models``."""
+    """Wait until the candidate artifact's server exposes ``/v1/models``.
+
+    Readiness is only accepted when (a) the spawned candidate process is
+    still alive and (b) it answers ``/v1/models`` with 200. The caller has
+    already proven the port was free before the spawn (see
+    ``_assert_port_available``), so a 200 here can only come from the
+    candidate process we launched — not a stale server that happened to
+    hold the port.
+    """
 
     url = f"http://127.0.0.1:{port}/v1/models"
     deadline = time.monotonic() + timeout
@@ -188,6 +228,19 @@ def _wait_for_server(
         try:
             with urllib.request.urlopen(url, timeout=5) as response:
                 if response.status == 200:
+                    # Re-confirm the candidate is still the live process after a
+                    # successful probe — closes the window where it crashes just
+                    # as (or just after) it starts answering.
+                    if process.poll() is not None:
+                        tail = (
+                            log.read_text(errors="replace")[-4000:]
+                            if log.exists()
+                            else ""
+                        )
+                        raise RuntimeError(
+                            f"candidate server exited ({process.returncode}) "
+                            f"immediately after readiness; log tail:\n{tail}"
+                        )
                     return
         except (OSError, urllib.error.URLError) as exc:
             last_error = str(exc)
@@ -231,7 +284,15 @@ def run_family(
 
     wheel = find_release_wheel(dist_dir)
     root = Path(tempfile.mkdtemp(prefix=f"rapid-mlx-release-{family}-"))
-    venv = root / "venv"
+    # Two isolated venvs, never one. The SERVER venv holds ONLY the release
+    # wheel (+ its declared extras) so the boot proves the wheel's own runtime
+    # dependency set is complete — nothing masks a missing runtime dep. The
+    # CLIENT venv holds the matrix test/SDK dependencies; if these lived in the
+    # server venv, one of their transitive deps could satisfy a runtime import
+    # the wheel forgot to declare and the server would boot on borrowed deps,
+    # silently defeating the clean-room guarantee this runner exists to give.
+    server_venv = root / "server-venv"
+    client_venv = root / "client-venv"
     server_cwd = root / "server-cwd"
     log = root / "server.log"
     process: subprocess.Popen[str] | None = None
@@ -239,12 +300,14 @@ def run_family(
 
     try:
         server_cwd.mkdir()
-        _run([sys.executable, "-m", "venv", str(venv)], cwd=root, env=env)
-        python = venv / "bin" / "python"
-        rapid_mlx = venv / "bin" / "rapid-mlx"
+
+        # --- Server venv: release wheel + extras ONLY ---------------------- #
+        _run([sys.executable, "-m", "venv", str(server_venv)], cwd=root, env=env)
+        server_python = server_venv / "bin" / "python"
+        rapid_mlx = server_venv / "bin" / "rapid-mlx"
 
         _run(
-            [str(python), "-m", "pip", "install", "--upgrade", "pip"],
+            [str(server_python), "-m", "pip", "install", "--upgrade", "pip"],
             cwd=root,
             env=env,
         )
@@ -252,7 +315,14 @@ def run_family(
         if config.extras:
             artifact_spec = f"{artifact_spec}[{','.join(config.extras)}]"
         _run(
-            [str(python), "-m", "pip", "install", "--prefer-binary", artifact_spec],
+            [
+                str(server_python),
+                "-m",
+                "pip",
+                "install",
+                "--prefer-binary",
+                artifact_spec,
+            ],
             cwd=root,
             env=env,
         )
@@ -261,15 +331,24 @@ def run_family(
                 f"release wheel did not install rapid-mlx at {rapid_mlx}"
             )
         for script in CLI_SMOKE_SCRIPTS:
-            executable = venv / "bin" / script
+            executable = server_venv / "bin" / script
             if not executable.is_file():
                 raise RuntimeError(
                     f"release wheel did not install console script {script!r}"
                 )
             _run([str(executable), "--help"], cwd=root, env=env)
+
+        # --- Client venv: matrix test + SDK deps (NEVER in the server venv) - #
+        _run([sys.executable, "-m", "venv", str(client_venv)], cwd=root, env=env)
+        client_python = client_venv / "bin" / "python"
+        _run(
+            [str(client_python), "-m", "pip", "install", "--upgrade", "pip"],
+            cwd=root,
+            env=env,
+        )
         _run(
             [
-                str(python),
+                str(client_python),
                 "-m",
                 "pip",
                 "install",
@@ -280,7 +359,9 @@ def run_family(
             env=env,
         )
 
-        runner_env = env | {"PATH": f"{venv / 'bin'}:{env.get('PATH', '')}"}
+        # The matrix drives the running server over HTTP from the CLIENT venv.
+        # Aider is a client too, so its binary comes from the client venv.
+        runner_env = env | {"PATH": f"{client_venv / 'bin'}:{env.get('PATH', '')}"}
 
         # A release matrix must fail rather than silently omit Docker/Aider
         # cells.  The tests themselves convert missing prerequisites into
@@ -310,6 +391,10 @@ def run_family(
                 f"OpenHands cell: {docker.stderr[-1000:]}"
             )
 
+        # Prove the port is free BEFORE spawning, so the readiness probe can
+        # only ever be answered by the candidate process we launch (never a
+        # stale same-family server lingering on the fixed release port).
+        _assert_port_available(port)
         with log.open("w", encoding="utf-8") as log_file:
             process = subprocess.Popen(
                 [
@@ -333,10 +418,17 @@ def run_family(
             "RAPID_MLX_AGENT_MATRIX_FAMILY": family,
             "RAPID_MLX_MATRIX_STRICT": "1",
             "RAPID_MLX_MATRIX_NO_SKIPS": "1",
-            "AIDER_BIN": str(venv / "bin" / "aider"),
+            "AIDER_BIN": str(client_venv / "bin" / "aider"),
         }
         _run(
-            [str(python), "-m", "pytest", *map(str, MATRIX_FILES), "-v", "--tb=short"],
+            [
+                str(client_python),
+                "-m",
+                "pytest",
+                *map(str, MATRIX_FILES),
+                "-v",
+                "--tb=short",
+            ],
             cwd=REPO_ROOT,
             env=matrix_env,
         )

--- a/scripts/release_manifest.py
+++ b/scripts/release_manifest.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Create and verify the hash manifest for a Python release candidate.
+
+The manifest is deliberately tiny and stdlib-only so the publishing job can
+verify the artifact hand-off without installing or executing project code.
+It binds the release version and source commit to the exact wheel and sdist
+that passed ``twine check`` and were uploaded as the workflow artifact.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+
+def sha256(path: Path) -> str:
+    """Return the SHA-256 digest of a regular file."""
+
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def release_files(dist_dir: Path) -> list[Path]:
+    """Return the expected rapid-mlx wheel and sdist in stable order."""
+
+    all_files = sorted(path for path in dist_dir.iterdir() if path.is_file())
+    files = sorted(
+        path
+        for path in all_files
+        if path.name.startswith("rapid_mlx-") and path.suffix in {".whl", ".gz"}
+    )
+    wheels = [path for path in files if path.suffix == ".whl"]
+    sdists = [path for path in files if path.name.endswith(".tar.gz")]
+    if len(wheels) != 1 or len(sdists) != 1 or len(files) != 2 or len(all_files) != 2:
+        names = ", ".join(path.name for path in all_files) or "<none>"
+        raise ValueError(
+            "release dist must contain exactly one rapid_mlx wheel and one "
+            f"tar.gz sdist, with no extra files; found: {names}"
+        )
+    return files
+
+
+def validate_artifact_versions(files: list[Path], version: str) -> None:
+    """Require artifact filenames to bind to the declared release version."""
+
+    wheel = next(path for path in files if path.suffix == ".whl")
+    sdist = next(path for path in files if path.name.endswith(".tar.gz"))
+    if not wheel.name.startswith(f"rapid_mlx-{version}-"):
+        raise ValueError(
+            f"wheel filename {wheel.name!r} does not match release version {version!r}"
+        )
+    expected_sdist = f"rapid_mlx-{version}.tar.gz"
+    if sdist.name != expected_sdist:
+        raise ValueError(
+            f"sdist filename {sdist.name!r} does not match release version {version!r}"
+        )
+
+
+def create_manifest(*, dist_dir: Path, source_sha: str, version: str) -> dict[str, Any]:
+    """Return a JSON-serializable manifest for the files in ``dist_dir``."""
+
+    if len(source_sha) != 40 or any(ch not in "0123456789abcdef" for ch in source_sha):
+        raise ValueError("source SHA must be a 40-character lowercase Git commit SHA")
+    if not version:
+        raise ValueError("version must not be empty")
+    files = release_files(dist_dir)
+    validate_artifact_versions(files, version)
+    return {
+        "schema": 1,
+        "project": "rapid-mlx",
+        "version": version,
+        "source_sha": source_sha,
+        "artifacts": [
+            {"filename": path.name, "sha256": sha256(path), "size": path.stat().st_size}
+            for path in files
+        ],
+    }
+
+
+def write_manifest(manifest: dict[str, Any], output: Path) -> None:
+    """Write a canonical, review-friendly manifest."""
+
+    output.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n")
+
+
+def verify_manifest(*, dist_dir: Path, manifest_path: Path) -> dict[str, Any]:
+    """Verify artifact names, size and digest against a stored manifest."""
+
+    try:
+        manifest = json.loads(manifest_path.read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError(
+            f"cannot read release manifest {manifest_path}: {exc}"
+        ) from exc
+    if manifest.get("schema") != 1 or manifest.get("project") != "rapid-mlx":
+        raise ValueError("release manifest has an unknown schema or project")
+    version = manifest.get("version")
+    if not isinstance(version, str) or not version:
+        raise ValueError("release manifest version must be a non-empty string")
+    recorded = manifest.get("artifacts")
+    if not isinstance(recorded, list):
+        raise ValueError("release manifest artifacts must be a list")
+    expected = {
+        item.get("filename"): item for item in recorded if isinstance(item, dict)
+    }
+    if len(recorded) != 2 or len(expected) != 2:
+        raise ValueError("release manifest must contain exactly two unique artifacts")
+    files = release_files(dist_dir)
+    validate_artifact_versions(files, version)
+    if set(expected) != {path.name for path in files}:
+        raise ValueError("release manifest artifact names do not match dist/")
+    for path in files:
+        item = expected[path.name]
+        if item.get("size") != path.stat().st_size:
+            raise ValueError(f"size mismatch for {path.name}")
+        if item.get("sha256") != sha256(path):
+            raise ValueError(f"SHA-256 mismatch for {path.name}")
+    return manifest
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    create = subparsers.add_parser("create", help="write a manifest for dist/")
+    create.add_argument("--dist-dir", type=Path, required=True)
+    create.add_argument("--output", type=Path, required=True)
+    create.add_argument("--source-sha", required=True)
+    create.add_argument("--version", required=True)
+
+    verify = subparsers.add_parser("verify", help="verify dist/ against a manifest")
+    verify.add_argument("--dist-dir", type=Path, required=True)
+    verify.add_argument("--manifest", type=Path, required=True)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    if not args.dist_dir.is_dir():
+        raise ValueError(f"--dist-dir is not a directory: {args.dist_dir}")
+    if args.command == "create":
+        manifest = create_manifest(
+            dist_dir=args.dist_dir,
+            source_sha=args.source_sha,
+            version=args.version,
+        )
+        write_manifest(manifest, args.output)
+        print(f"wrote {args.output}")
+    else:
+        manifest = verify_manifest(dist_dir=args.dist_dir, manifest_path=args.manifest)
+        print(f"verified rapid-mlx {manifest['version']} ({manifest['source_sha']})")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except ValueError as exc:
+        print(f"release manifest: {exc}", file=sys.stderr)
+        raise SystemExit(1) from exc

--- a/scripts/release_smoke.py
+++ b/scripts/release_smoke.py
@@ -12,6 +12,8 @@ This script creates a brand-new venv and either:
   - pip-installs the working tree (pip handles PEP 517 build internally,
     so no `build` or `hatchling` dep is required on the dev env), or
   - pip-installs `rapid-mlx==X.Y.Z` from PyPI (post-tag verification).
+  - installs each wheel/sdist already present in a release candidate's
+    ``dist/`` directory (the pre-publish artifact-acceptance path).
 
 Then it imports the modules that the published entrypoints would import.
 An ``AttributeError`` / ``ImportError`` here means we are about to ship a
@@ -20,6 +22,7 @@ release that no user can ``pip install`` and use.
 Usage:
     python3 scripts/release_smoke.py            # install working tree in clean venv, smoke-import
     python3 scripts/release_smoke.py --version 0.6.55  # post-tag: install from PyPI
+    python3 scripts/release_smoke.py --dist-dir dist  # test the actual wheel + sdist
 
 Exit code: 0 on success, 1 on any failure. Designed to be the last gate
 before pushing a ``chore: bump version to X.Y.Z`` commit.
@@ -111,8 +114,9 @@ def smoke(install_spec: str, *, source: str) -> None:
 
         # ``pip install <local-path>`` invokes the PEP 517 build backend
         # declared in ``pyproject.toml`` directly — no separate ``build``
-        # package needed on the dev env. The wheel that gets built and
-        # installed is bit-identical to what would land on PyPI.
+        # package needed on the dev env. ``--dist-dir`` is the stronger
+        # release path: it installs the exact artifact produced by CI rather
+        # than a fresh local build.
         print(f"[release-smoke] installing {source}: {install_spec}")
         run([str(py), "-m", "pip", "install", "--quiet", install_spec], env=env)
 
@@ -131,18 +135,43 @@ def smoke(install_spec: str, *, source: str) -> None:
             shutil.rmtree(venv, ignore_errors=True)
 
 
+def release_artifacts(dist_dir: Path) -> tuple[Path, Path]:
+    """Return the sole rapid-mlx wheel and sdist in a candidate directory."""
+
+    all_files = sorted(path for path in dist_dir.iterdir() if path.is_file())
+    wheels = sorted(path for path in dist_dir.glob("rapid_mlx-*.whl") if path.is_file())
+    sdists = sorted(
+        path for path in dist_dir.glob("rapid_mlx-*.tar.gz") if path.is_file()
+    )
+    if len(wheels) != 1 or len(sdists) != 1 or len(all_files) != 2:
+        raise ValueError(
+            "--dist-dir must contain exactly one rapid_mlx-*.whl and one "
+            "rapid_mlx-*.tar.gz, with no extra files"
+        )
+    return wheels[0].resolve(), sdists[0].resolve()
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument(
+    source = parser.add_mutually_exclusive_group()
+    source.add_argument(
         "--version",
         help="If set, install `rapid-mlx==<VERSION>` from PyPI instead of building locally. "
         "Use post-tag to verify the published wheel.",
+    )
+    source.add_argument(
+        "--dist-dir",
+        type=Path,
+        help="Install both release artifacts already built under this directory.",
     )
     args = parser.parse_args()
 
     try:
         if args.version:
             smoke(f"rapid-mlx=={args.version}", source="PyPI")
+        elif args.dist_dir:
+            for artifact in release_artifacts(args.dist_dir):
+                smoke(str(artifact), source=f"release artifact {artifact.name}")
         else:
             smoke(str(REPO_ROOT), source="working tree")
     except subprocess.CalledProcessError as exc:
@@ -152,6 +181,9 @@ def main() -> int:
             "    for any user whose runtime deps differ from the dev env.",
             file=sys.stderr,
         )
+        return 1
+    except ValueError as exc:
+        print(f"\n[release-smoke] FAIL: {exc}", file=sys.stderr)
         return 1
     return 0
 

--- a/scripts/release_smoke.py
+++ b/scripts/release_smoke.py
@@ -135,9 +135,27 @@ def smoke(install_spec: str, *, source: str) -> None:
             shutil.rmtree(venv, ignore_errors=True)
 
 
+def _artifact_version(name: str) -> str:
+    """Extract the version from a ``rapid_mlx-<version>`` artifact filename.
+
+    ``rapid_mlx-0.10.9-py3-none-any.whl`` -> ``0.10.9``;
+    ``rapid_mlx-0.10.9.tar.gz``           -> ``0.10.9``.
+    """
+    stem = name
+    if stem.endswith(".tar.gz"):
+        stem = stem[: -len(".tar.gz")]
+        return stem[len("rapid_mlx-") :]
+    if stem.endswith(".whl"):
+        # rapid_mlx-<version>-<pytag>-<abitag>-<plat>.whl
+        return stem[len("rapid_mlx-") :].split("-", 1)[0]
+    raise ValueError(f"unrecognized artifact filename: {name}")
+
+
 def release_artifacts(dist_dir: Path) -> tuple[Path, Path]:
     """Return the sole rapid-mlx wheel and sdist in a candidate directory."""
 
+    if not dist_dir.is_dir():
+        raise ValueError(f"--dist-dir is not a directory: {dist_dir}")
     all_files = sorted(path for path in dist_dir.iterdir() if path.is_file())
     wheels = sorted(path for path in dist_dir.glob("rapid_mlx-*.whl") if path.is_file())
     sdists = sorted(
@@ -147,6 +165,14 @@ def release_artifacts(dist_dir: Path) -> tuple[Path, Path]:
         raise ValueError(
             "--dist-dir must contain exactly one rapid_mlx-*.whl and one "
             "rapid_mlx-*.tar.gz, with no extra files"
+        )
+    wheel_version = _artifact_version(wheels[0].name)
+    sdist_version = _artifact_version(sdists[0].name)
+    if wheel_version != sdist_version:
+        raise ValueError(
+            "--dist-dir wheel and sdist are different versions "
+            f"({wheel_version} vs {sdist_version}); a release candidate must "
+            "be a single coherent build"
         )
     return wheels[0].resolve(), sdists[0].resolve()
 

--- a/tests/integrations/README.md
+++ b/tests/integrations/README.md
@@ -110,21 +110,24 @@ rapid-mlx serve qwen3.5-4b-4bit \
 Then run either matrix or a specific deep file. **Strict mode requires
 one family shard per booted server** — the ``_guard_family_matches_server``
 autouse fixture in ``conftest.py`` fails cells that ask for a family the
-running server doesn't serve. In practice this means: pick the family
-that matches your ``rapid-mlx serve`` alias and shard the other two into
-separate server boots (or CI jobs).
+running server doesn't serve. In practice this means: pick one of the four
+always-on families that matches your ``rapid-mlx serve`` alias and boot the
+other three in separate server shards (or CI jobs). Hy3 remains an
+Ultra-only weekly-Golden-Path lane.
 
 ```bash
-# All 44 agent cells; only the family matching the running server passes,
-# the other three skip (non-strict) or fail (strict). Use for local sanity;
-# for CI, prefer per-family shards below.
+# All 55 agent cells across five families. Locally, only the matching
+# four-family column passes; the other three feasible columns skip
+# (non-strict) or fail (strict), while Hy3 keeps its documented strict xfail.
+# The always-on release lane is the 44-cell, four-family subset below.
 pytest tests/integrations/test_agents_matrix.py -v
 
-# 12-cell framework matrix (same shard rule as above)
+# 15-cell framework matrix across five families (same shard rule as above)
 pytest tests/integrations/test_frameworks_matrix.py -v
 
-# Strict CI — per-family shard (this is the intended workflow: four
-# CI jobs, one per family, each with its own booted server).
+# Strict CI — per-family shard (the always-on lane uses four jobs, one per
+# feasible family, each with its own booted server). Release artifact
+# acceptance also sets RAPID_MLX_MATRIX_NO_SKIPS=1.
 RAPID_MLX_MATRIX_STRICT=1 RAPID_MLX_AGENT_MATRIX_FAMILY=qwen36 \
     pytest tests/integrations/test_agents_matrix.py
 
@@ -151,6 +154,7 @@ python3 tests/integrations/test_librechat_docker.py
 | `RAPID_MLX_BASE_URL` | `http://localhost:8000/v1` | Where matrix clients point |
 | `RAPID_MLX_AGENT_MATRIX_FAMILY` | (all) | Restrict to `qwen36` / `gemma4` / `deepseek` / `gptoss` / `hy3` (`hy3` is Ultra-only, weekly Golden Path only) |
 | `RAPID_MLX_MATRIX_STRICT` | `0` | If `1`, missing-server → fail (default: skip) |
+| `RAPID_MLX_MATRIX_NO_SKIPS` | `0` | If `1`, the release artifact lane turns ordinary matrix skips (missing SDK, Docker, Aider, etc.) into failures; documented strict xfails remain xfails |
 
 ## Cheap-alias policy
 

--- a/tests/integrations/conftest.py
+++ b/tests/integrations/conftest.py
@@ -199,6 +199,24 @@ def matrix_strict_mode() -> bool:
     return _strict()
 
 
+def _has_strict_xfail_marker(item: pytest.Item) -> bool:
+    """True iff the cell carries an ``xfail(strict=True)`` marker.
+
+    The release-approved skip exceptions are EXACTLY the strict-xfail cells
+    registered in ``pytest_collection_modifyitems`` (and pinned by
+    ``test_strict_xfail_registry.py``). We gate on the marker itself rather
+    than ``report.wasxfail``: pytest also sets ``wasxfail`` for NON-strict
+    ``xfail(strict=False, ...)`` markers and for dynamic ``pytest.xfail()``
+    calls, so a ``wasxfail`` check would let an un-audited, non-strict xfail
+    silently bypass ``RAPID_MLX_MATRIX_NO_SKIPS`` — shrinking the required-
+    PASS coverage the release gate exists to guarantee (codex review).
+    """
+    for marker in item.iter_markers(name="xfail"):
+        if marker.kwargs.get("strict") is True:
+            return True
+    return False
+
+
 @pytest.hookimpl(hookwrapper=True)
 def pytest_runtest_makereport(item: pytest.Item, call: pytest.CallInfo[object]):
     """Reject ordinary skips when the release artifact matrix asks for it."""
@@ -208,10 +226,10 @@ def pytest_runtest_makereport(item: pytest.Item, call: pytest.CallInfo[object]):
     if not _no_skips() or not report.skipped:
         return
 
-    # ``wasxfail`` is set by pytest for the exact, documented xfail cases
-    # registered in ``pytest_collection_modifyitems`` above.  Those are
-    # explicit release exceptions; a missing prerequisite is not.
-    if getattr(report, "wasxfail", None):
+    # The ONLY release-approved skip exception is an explicit
+    # ``xfail(strict=True)`` cell (the documented, snapshot-pinned set). A
+    # missing prerequisite — or a non-strict / dynamic xfail — is not.
+    if _has_strict_xfail_marker(item):
         return
 
     if not any(module in item.nodeid for module in _INTEGRATION_MATRIX_MODULES):

--- a/tests/integrations/conftest.py
+++ b/tests/integrations/conftest.py
@@ -174,6 +174,20 @@ def _strict() -> bool:
     return os.environ.get("RAPID_MLX_MATRIX_STRICT", "").strip() == "1"
 
 
+def _no_skips() -> bool:
+    """Return whether release acceptance treats a skipped matrix cell as red.
+
+    ``RAPID_MLX_MATRIX_STRICT`` already turns a missing/mismatched server
+    into a failure.  Client-library and host-tool prerequisites historically
+    used plain ``pytest.skip`` so a release runner missing Docker, Aider, or
+    an SDK could still look green.  The artifact-release runner sets this
+    stricter opt-in to make every ordinary skip actionable.  Documented,
+    strict ``xfail`` cases retain their own semantics and are not changed.
+    """
+
+    return os.environ.get("RAPID_MLX_MATRIX_NO_SKIPS", "").strip() == "1"
+
+
 def matrix_strict_mode() -> bool:
     """Public accessor for ``RAPID_MLX_MATRIX_STRICT``.
 
@@ -183,6 +197,34 @@ def matrix_strict_mode() -> bool:
     before running the matrix.
     """
     return _strict()
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_makereport(item: pytest.Item, call: pytest.CallInfo[object]):
+    """Reject ordinary skips when the release artifact matrix asks for it."""
+
+    outcome = yield
+    report = outcome.get_result()
+    if not _no_skips() or not report.skipped:
+        return
+
+    # ``wasxfail`` is set by pytest for the exact, documented xfail cases
+    # registered in ``pytest_collection_modifyitems`` above.  Those are
+    # explicit release exceptions; a missing prerequisite is not.
+    if getattr(report, "wasxfail", None):
+        return
+
+    if not any(module in item.nodeid for module in _INTEGRATION_MATRIX_MODULES):
+        return
+
+    report.outcome = "failed"
+    report.longrepr = (
+        str(item.path),
+        0,
+        "release artifact matrix forbids skipped cells; install the missing "
+        "client/host prerequisite or record a narrow strict xfail with an "
+        "upstream issue.",
+    )
 
 
 def strict_skip_or_fail(reason: str) -> None:

--- a/tests/integrations/conftest.py
+++ b/tests/integrations/conftest.py
@@ -217,6 +217,29 @@ def _has_strict_xfail_marker(item: pytest.Item) -> bool:
     return False
 
 
+def _skip_should_become_failure(
+    *, nodeid: str, wasxfail: object, has_strict_marker: bool
+) -> bool:
+    """Decide whether a skipped matrix cell must be upgraded to a failure.
+
+    Pure decision function (no pytest objects) so the exact NO_SKIPS policy
+    can be unit-tested across every case — see
+    ``test_no_skip_gate_policy.py``. Assumes the caller has already checked
+    ``_no_skips()`` and ``report.skipped``.
+
+    Returns True (=> fail) UNLESS the cell is a release-approved exception:
+    it must BOTH carry an ``xfail(strict=True)`` marker AND have actually
+    exercised the expected failure this run (``wasxfail`` set). A strict-xfail
+    cell that merely SKIPPED on a missing prerequisite has ``wasxfail=None``
+    and is NOT exempt.
+    """
+    if not any(module in nodeid for module in _INTEGRATION_MATRIX_MODULES):
+        # Not a matrix cell — leave its skip alone.
+        return False
+    exempt = wasxfail is not None and has_strict_marker
+    return not exempt
+
+
 @pytest.hookimpl(hookwrapper=True)
 def pytest_runtest_makereport(item: pytest.Item, call: pytest.CallInfo[object]):
     """Reject ordinary skips when the release artifact matrix asks for it."""
@@ -226,13 +249,23 @@ def pytest_runtest_makereport(item: pytest.Item, call: pytest.CallInfo[object]):
     if not _no_skips() or not report.skipped:
         return
 
-    # The ONLY release-approved skip exception is an explicit
-    # ``xfail(strict=True)`` cell (the documented, snapshot-pinned set). A
-    # missing prerequisite — or a non-strict / dynamic xfail — is not.
-    if _has_strict_xfail_marker(item):
-        return
-
-    if not any(module in item.nodeid for module in _INTEGRATION_MATRIX_MODULES):
+    # The ONLY release-approved skip exception is a cell that BOTH (a) carries
+    # an explicit ``xfail(strict=True)`` marker (the documented, snapshot-
+    # pinned set) AND (b) actually exercised the expected failure this run
+    # (``report.wasxfail`` is set only when the body ran and xfailed). Both
+    # signals are required:
+    #   * ``wasxfail`` alone would also exempt NON-strict / dynamic xfails,
+    #     letting an un-audited xfail bypass the no-skip gate.
+    #   * the strict marker alone would exempt a strict-xfail cell that merely
+    #     SKIPPED on a missing prerequisite (server/client/host) without ever
+    #     exercising the expected failure — silently passing the release matrix
+    #     with missing coverage.
+    # A missing prerequisite on a strict-xfail cell therefore still fails here.
+    if not _skip_should_become_failure(
+        nodeid=item.nodeid,
+        wasxfail=getattr(report, "wasxfail", None),
+        has_strict_marker=_has_strict_xfail_marker(item),
+    ):
         return
 
     report.outcome = "failed"

--- a/tests/integrations/test_agents_matrix.py
+++ b/tests/integrations/test_agents_matrix.py
@@ -542,18 +542,21 @@ class TestAider:
 
     _HARNESS_TIMEOUT_SECONDS = 300
 
-    _PINNED_AIDER_BIN = "/Users/raullenstudio/.local/bin/aider"
-
     @staticmethod
     def _resolve_aider_bin() -> str | None:
         """Return a usable aider binary path, or ``None`` if none present.
 
         Codex #1047 nit: previously the pytest skip guard only checked
-        ``shutil.which("aider")`` + the pinned operator path, ignoring
-        the ``AIDER_BIN`` env var that the bash harness already honors.
-        A CI operator that pins a non-standard binary via ``AIDER_BIN``
-        would see the cell skip even though the harness would happily
-        run. Centralize the lookup so Python and bash agree.
+        ``shutil.which("aider")``, ignoring the ``AIDER_BIN`` env var that
+        the bash harness already honors. A CI operator that pins a
+        non-standard binary via ``AIDER_BIN`` would see the cell skip even
+        though the harness would happily run. Centralize the lookup so
+        Python and bash agree.
+
+        Lookup order (no machine-specific fallback — operators that install
+        aider outside ``PATH`` point ``AIDER_BIN`` at it):
+          1. ``AIDER_BIN`` env var (an executable file), then
+          2. ``shutil.which("aider")`` on ``PATH``.
         """
         env_pin = os.environ.get("AIDER_BIN")
         if env_pin and Path(env_pin).is_file() and os.access(env_pin, os.X_OK):
@@ -561,10 +564,6 @@ class TestAider:
         which = shutil.which("aider")
         if which is not None:
             return which
-        if Path(TestAider._PINNED_AIDER_BIN).is_file() and os.access(
-            TestAider._PINNED_AIDER_BIN, os.X_OK
-        ):
-            return TestAider._PINNED_AIDER_BIN
         return None
 
     def test_smoke(
@@ -580,9 +579,8 @@ class TestAider:
         # rebooting install policy from the test.
         if self._resolve_aider_bin() is None:
             pytest.skip(
-                "aider CLI not found (checked AIDER_BIN env var, PATH, and "
-                f"{self._PINNED_AIDER_BIN}) — install `pip install aider-chat` "
-                "or set AIDER_BIN"
+                "aider CLI not found (checked AIDER_BIN env var and PATH) — "
+                "install `pip install aider-chat` or set AIDER_BIN"
             )
 
         # Codex #1047 blocking: pass the FULL parsed base_url to the

--- a/tests/integrations/test_aider.sh
+++ b/tests/integrations/test_aider.sh
@@ -83,16 +83,14 @@ if [ -z "$BASE_URL" ]; then
     BASE_URL="http://127.0.0.1:${PORT}/v1"
 fi
 
-# Locate aider — never PATH-search on the operator's box because the
-# harness must NOT accidentally trigger a fresh install. The 2026-07-06
-# Tier-1 install (v0.86.2) sits at ~/.local/bin/aider.
-AIDER_BIN="${AIDER_BIN:-/Users/raullenstudio/.local/bin/aider}"
-if [ ! -x "$AIDER_BIN" ]; then
-    # Fall back to PATH so the harness still runs on CI where the pinned
-    # path doesn't exist; but never install.
+# Locate aider without ever triggering a fresh install. Operators that
+# install aider outside PATH point AIDER_BIN at the binary; otherwise we
+# discover it on PATH. No machine-specific path is baked in.
+AIDER_BIN="${AIDER_BIN:-}"
+if [ -z "$AIDER_BIN" ] || [ ! -x "$AIDER_BIN" ]; then
     AIDER_BIN="$(command -v aider 2>/dev/null || true)"
     if [ -z "$AIDER_BIN" ]; then
-        echo "ERROR: aider binary not found (checked /Users/raullenstudio/.local/bin/aider and PATH)" >&2
+        echo "ERROR: aider binary not found (checked AIDER_BIN and PATH)" >&2
         exit 1
     fi
 fi

--- a/tests/integrations/test_no_skip_gate_policy.py
+++ b/tests/integrations/test_no_skip_gate_policy.py
@@ -22,7 +22,13 @@ every case so the real hook logic is covered without booting a server.
 
 from __future__ import annotations
 
+import subprocess
+import sys
+from pathlib import Path
+
 from tests.integrations import conftest as matrix_conftest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
 
 _MATRIX_NODEID = (
     "tests/integrations/test_agents_matrix.py::TestOpenCode::test_smoke[deepseek]"
@@ -99,3 +105,60 @@ def test_skip_on_non_matrix_test_is_left_alone():
                 )
                 is False
             )
+
+
+# --------------------------------------------------------------------------- #
+# End-to-end: the real hook must fail a skipped cell under NO_SKIPS.
+# --------------------------------------------------------------------------- #
+#
+# The unit tests above exercise the pure decision helper; this subprocess test
+# proves the ``pytest_runtest_makereport`` hook is actually WIRED to it, so
+# deleting or breaking the hook cannot leave the no-skip suite green (codex
+# review). With no server reachable, every matrix cell skips at the
+# family-guard fixture; under ``RAPID_MLX_MATRIX_NO_SKIPS=1`` the hook must
+# convert those skips to failures and the pytest process must exit non-zero.
+
+
+def test_no_skips_hook_fails_a_skipped_cell_end_to_end():
+    env_no_skips = {"RAPID_MLX_MATRIX_NO_SKIPS": "1"}
+    # A plain (non-strict-xfail) matrix cell: must be converted to failure.
+    plain_cell = (
+        "tests/integrations/test_agents_matrix.py::TestCodexCLI::test_smoke[deepseek]"
+    )
+    result = _run_pytest_cell(plain_cell, env_no_skips)
+    assert result.returncode != 0, (
+        "NO_SKIPS run of a skipped matrix cell should FAIL, but pytest exited 0.\n"
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+
+
+def test_no_skips_off_leaves_a_skipped_cell_green_end_to_end():
+    # Sanity: without the env var, the same skipped cell stays a green skip
+    # (the gate only bites when the release runner asks for it).
+    plain_cell = (
+        "tests/integrations/test_agents_matrix.py::TestCodexCLI::test_smoke[deepseek]"
+    )
+    result = _run_pytest_cell(plain_cell, env={})
+    assert result.returncode == 0, (
+        "Without NO_SKIPS, a skipped matrix cell should stay green (exit 0), "
+        f"but pytest exited {result.returncode}.\n"
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+
+
+def _run_pytest_cell(nodeid: str, env: dict[str, str]) -> subprocess.CompletedProcess:
+    import os
+
+    run_env = os.environ.copy()
+    # Ensure no operator server is picked up: point at an unroutable port so
+    # the family guard skips every cell deterministically.
+    run_env["RAPID_MLX_BASE_URL"] = "http://127.0.0.1:1/v1"
+    run_env.update(env)
+    return subprocess.run(
+        [sys.executable, "-m", "pytest", nodeid, "-p", "no:cacheprovider", "-q"],
+        cwd=str(_REPO_ROOT),
+        env=run_env,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )

--- a/tests/integrations/test_no_skip_gate_policy.py
+++ b/tests/integrations/test_no_skip_gate_policy.py
@@ -119,15 +119,33 @@ def test_skip_on_non_matrix_test_is_left_alone():
 # convert those skips to failures and the pytest process must exit non-zero.
 
 
+# pytest exit codes (from ``pytest.ExitCode``): 0=all passed, 1=tests failed,
+# 2=interrupted, 3=internal error, 4=usage error, 5=no tests collected. We
+# require EXACTLY 1 (a genuine test failure) so a collection error / conftest
+# crash / usage error cannot make the assertion pass on a non-zero fluke.
+_EXIT_TESTS_FAILED = 1
+_EXIT_ALL_PASSED = 0
+# The exact message the no-skip hook injects when it converts a skip.
+_HOOK_MESSAGE = "release artifact matrix forbids skipped cells"
+
+_PLAIN_CELL = (
+    "tests/integrations/test_agents_matrix.py::TestCodexCLI::test_smoke[deepseek]"
+)
+
+
 def test_no_skips_hook_fails_a_skipped_cell_end_to_end():
-    env_no_skips = {"RAPID_MLX_MATRIX_NO_SKIPS": "1"}
-    # A plain (non-strict-xfail) matrix cell: must be converted to failure.
-    plain_cell = (
-        "tests/integrations/test_agents_matrix.py::TestCodexCLI::test_smoke[deepseek]"
+    result = _run_pytest_cell(_PLAIN_CELL, {"RAPID_MLX_MATRIX_NO_SKIPS": "1"})
+    combined = result.stdout + result.stderr
+    assert result.returncode == _EXIT_TESTS_FAILED, (
+        "NO_SKIPS run of a skipped matrix cell must exit with pytest code 1 "
+        f"(tests failed), got {result.returncode} — a non-1 non-zero code "
+        "means a collection/internal/usage error, not the hook doing its job.\n"
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
     )
-    result = _run_pytest_cell(plain_cell, env_no_skips)
-    assert result.returncode != 0, (
-        "NO_SKIPS run of a skipped matrix cell should FAIL, but pytest exited 0.\n"
+    assert _HOOK_MESSAGE in combined, (
+        "the failure must carry the no-skip hook's specific message "
+        f"({_HOOK_MESSAGE!r}) — otherwise the cell failed for an unrelated "
+        f"reason and this test is not proving the hook is wired.\n"
         f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
     )
 
@@ -135,14 +153,14 @@ def test_no_skips_hook_fails_a_skipped_cell_end_to_end():
 def test_no_skips_off_leaves_a_skipped_cell_green_end_to_end():
     # Sanity: without the env var, the same skipped cell stays a green skip
     # (the gate only bites when the release runner asks for it).
-    plain_cell = (
-        "tests/integrations/test_agents_matrix.py::TestCodexCLI::test_smoke[deepseek]"
-    )
-    result = _run_pytest_cell(plain_cell, env={})
-    assert result.returncode == 0, (
+    result = _run_pytest_cell(_PLAIN_CELL, env={})
+    assert result.returncode == _EXIT_ALL_PASSED, (
         "Without NO_SKIPS, a skipped matrix cell should stay green (exit 0), "
         f"but pytest exited {result.returncode}.\n"
         f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+    assert _HOOK_MESSAGE not in (result.stdout + result.stderr), (
+        "the no-skip hook must NOT fire when RAPID_MLX_MATRIX_NO_SKIPS is unset."
     )
 
 

--- a/tests/integrations/test_no_skip_gate_policy.py
+++ b/tests/integrations/test_no_skip_gate_policy.py
@@ -1,0 +1,101 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the RAPID_MLX_MATRIX_NO_SKIPS decision policy.
+
+The release-artifact matrix runs with ``RAPID_MLX_MATRIX_NO_SKIPS=1`` so a
+silently-skipped cell cannot shrink required-PASS coverage. The exemption
+policy is subtle enough to be worth pinning directly (codex review):
+
+  * A strict-xfail cell that ACTUALLY xfailed (body ran, ``wasxfail`` set) is
+    the ONLY approved skip exception.
+  * A strict-xfail cell that merely SKIPPED on a missing prerequisite
+    (``wasxfail`` unset) is NOT exempt — otherwise the matrix could pass
+    "green" without ever exercising the expected failure.
+  * A NON-strict / dynamic xfail (``wasxfail`` set but no strict marker) is
+    NOT exempt — an un-audited xfail must not bypass the gate.
+  * A plain skip on a matrix cell is NOT exempt.
+  * A skip on a non-matrix test is left alone.
+
+``conftest._skip_should_become_failure`` is the pure decision function the
+``pytest_runtest_makereport`` hook delegates to; these tests drive it across
+every case so the real hook logic is covered without booting a server.
+"""
+
+from __future__ import annotations
+
+from tests.integrations import conftest as matrix_conftest
+
+_MATRIX_NODEID = (
+    "tests/integrations/test_agents_matrix.py::TestOpenCode::test_smoke[deepseek]"
+)
+_NON_MATRIX_NODEID = "tests/test_model_auto_config.py::TestHy3::test_x[hy3]"
+
+# A sentinel standing in for pytest's ``report.wasxfail`` string (its value is
+# the xfail reason; only "is not None" matters to the policy).
+_WASXFAIL = "expected architectural tool-emission gap"
+
+
+def test_strict_xfail_that_actually_xfailed_is_exempt():
+    """Body ran and xfailed on a strict cell → approved exception → not failed."""
+    assert (
+        matrix_conftest._skip_should_become_failure(
+            nodeid=_MATRIX_NODEID,
+            wasxfail=_WASXFAIL,
+            has_strict_marker=True,
+        )
+        is False
+    )
+
+
+def test_strict_xfail_that_only_skipped_on_prereq_is_not_exempt():
+    """Missing prerequisite (wasxfail unset) on a strict cell → must fail.
+
+    This is the codex-flagged hole: without the ``wasxfail`` requirement, a
+    strict-xfail cell that skips because the server/client/host was absent
+    would be silently exempt and the matrix would pass with missing coverage.
+    """
+    assert (
+        matrix_conftest._skip_should_become_failure(
+            nodeid=_MATRIX_NODEID,
+            wasxfail=None,
+            has_strict_marker=True,
+        )
+        is True
+    )
+
+
+def test_non_strict_xfail_is_not_exempt():
+    """wasxfail set but no strict marker (non-strict/dynamic xfail) → must fail."""
+    assert (
+        matrix_conftest._skip_should_become_failure(
+            nodeid=_MATRIX_NODEID,
+            wasxfail=_WASXFAIL,
+            has_strict_marker=False,
+        )
+        is True
+    )
+
+
+def test_plain_skip_on_matrix_cell_is_not_exempt():
+    """A plain skip (no xfail at all) on a matrix cell → must fail."""
+    assert (
+        matrix_conftest._skip_should_become_failure(
+            nodeid=_MATRIX_NODEID,
+            wasxfail=None,
+            has_strict_marker=False,
+        )
+        is True
+    )
+
+
+def test_skip_on_non_matrix_test_is_left_alone():
+    """A skip outside the matrix modules is never upgraded, whatever its shape."""
+    for wasxfail in (None, _WASXFAIL):
+        for strict in (True, False):
+            assert (
+                matrix_conftest._skip_should_become_failure(
+                    nodeid=_NON_MATRIX_NODEID,
+                    wasxfail=wasxfail,
+                    has_strict_marker=strict,
+                )
+                is False
+            )

--- a/tests/integrations/test_strict_xfail_registry.py
+++ b/tests/integrations/test_strict_xfail_registry.py
@@ -1,0 +1,206 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Pin the exact set of strict-xfail cells in the integration matrix.
+
+``test_xfail_audit.py`` (issue #320) enforces that every ``xfail`` marker
+is *justified* — ``strict=True`` or a ``strict=False`` reason. It does
+NOT enforce *how many* strict-xfails exist, nor *which* cells carry them.
+That leaves a coverage-shrinkage hole in the release-artifact acceptance
+gate: the 56-cell agent/framework matrix is a required release gate, and a
+new genuinely-failing cell could be silently muted by adding one more
+strict-xfail. Because ``test_xfail_audit`` only checks strict-vs-not, that
+new xfail would pass the audit and quietly shrink the number of cells that
+must actually PASS — exactly the class of regression the matrix gate is
+supposed to prevent.
+
+This test closes that hole. It collects the two integration-matrix
+modules, computes the set of cells that ``conftest.pytest_collection_
+modifyitems`` marks ``xfail(strict=True)``, and asserts it equals an
+*expected* set derived from the conftest registration constants. The
+expected set is pinned three ways:
+
+  1. **Membership** — the exact nodeids must match. A new strict-xfail on
+     a cell that is not in a registration constant fails here.
+  2. **Count** — the total is asserted against ``_EXPECTED_STRICT_XFAIL_
+     COUNT``. Adding or removing any strict-xfail cell (even a legitimate
+     one) forces an explicit edit to that number, so the change is
+     reviewed rather than silent.
+  3. **Per-family breakdown** — the DeepSeek / gpt-oss / Hy3 sub-counts
+     are pinned individually, so a shift *between* families (e.g. a new
+     DeepSeek cell balanced by a dropped Hy3 cell that keeps the total
+     the same) is still caught.
+
+Net effect: adding or removing ANY strict-xfail in the matrix now requires
+an explicit change to this test, which surfaces the coverage delta in
+review. This is intentionally a pure-collection audit — no server, no
+model boot, no test bodies execute — so it runs in every ``make smoke`` /
+pr_validate cycle alongside ``test_xfail_audit``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.integrations import conftest as matrix_conftest
+
+# --------------------------------------------------------------------------- #
+# Expected strict-xfail set, derived from the conftest registration constants.
+# --------------------------------------------------------------------------- #
+#
+# The matrix parametrizes every cell over a single ``family`` argument, so a
+# strict-xfail nodeid is always ``<module>::<Class>::test_smoke[<family>]``.
+# We rebuild the expected set from the same constants the conftest hook
+# consumes, so the two cannot drift: if a registration constant changes,
+# the expected set changes with it — but the pinned counts below still force
+# an explicit acknowledgement of the coverage delta.
+
+# The matrix modules that carry family-parametrized cells (mirrors the
+# conftest ``_INTEGRATION_MATRIX_MODULES`` gate).
+_MATRIX_MODULES = ("test_agents_matrix.py", "test_frameworks_matrix.py")
+
+# All matrix classes, per module — the universe the Hy3 family-wide rule
+# spans. Sourced by collecting the modules (below), NOT hardcoded, so a new
+# agent/framework class is automatically included in the Hy3 expectation.
+
+
+def _expected_deepseek_nodeids(all_nodeids: set[str]) -> set[str]:
+    """9 DeepSeek R1-Distill tool-call cells.
+
+    Registered in ``conftest._DEEPSEEK_R1_TOOLCALL_XFAIL_NODEIDS`` as
+    ``<module>::<Class>`` prefixes; the applied marker lands on the
+    ``[deepseek]`` param of each.
+    """
+    out: set[str] = set()
+    for nodeid in all_nodeids:
+        if "[deepseek]" not in nodeid:
+            continue
+        if any(
+            prefix in nodeid
+            for prefix in matrix_conftest._DEEPSEEK_R1_TOOLCALL_XFAIL_NODEIDS
+        ):
+            out.add(nodeid)
+    return out
+
+
+def _expected_gptoss_nodeids(all_nodeids: set[str]) -> set[str]:
+    """1 gpt-oss × OpenHands cell (harmony ↔ CodeActAgent format mismatch)."""
+    nodeid_frag = matrix_conftest._GPTOSS_OPENHANDS_XFAIL_NODEID
+    family = matrix_conftest._GPTOSS_OPENHANDS_XFAIL_FAMILY
+    return {
+        nodeid
+        for nodeid in all_nodeids
+        if nodeid_frag in nodeid and f"[{family}]" in nodeid
+    }
+
+
+def _expected_hy3_nodeids(all_nodeids: set[str]) -> set[str]:
+    """Every Hy3 matrix cell (family-wide, 166 GB Ultra-only)."""
+    family = matrix_conftest._HY3_XFAIL_FAMILY
+    return {
+        nodeid
+        for nodeid in all_nodeids
+        if f"[{family}]" in nodeid
+        and any(module in nodeid for module in _MATRIX_MODULES)
+    }
+
+
+# Pinned counts. These are the tripwire: changing the strict-xfail set
+# without editing these numbers fails the test.
+_EXPECTED_DEEPSEEK_COUNT = 9
+_EXPECTED_GPTOSS_COUNT = 1
+_EXPECTED_HY3_COUNT = 14
+_EXPECTED_STRICT_XFAIL_COUNT = (
+    _EXPECTED_DEEPSEEK_COUNT + _EXPECTED_GPTOSS_COUNT + _EXPECTED_HY3_COUNT
+)  # 24
+
+
+class _StrictXfailCollector:
+    """Pytest plugin that records collected + strict-xfail-marked nodeids."""
+
+    def __init__(self) -> None:
+        self.all_nodeids: set[str] = set()
+        self.strict_xfail_nodeids: set[str] = set()
+
+    def pytest_collection_modifyitems(
+        self, config: pytest.Config, items: list[pytest.Item]
+    ) -> None:
+        # Runs AFTER conftest.pytest_collection_modifyitems (plugin order),
+        # so the strict-xfail markers the conftest applies are visible here.
+        del config
+        for item in items:
+            self.all_nodeids.add(item.nodeid)
+            for marker in item.iter_markers(name="xfail"):
+                if marker.kwargs.get("strict") is True:
+                    self.strict_xfail_nodeids.add(item.nodeid)
+                    break
+
+
+def _collect_matrix() -> _StrictXfailCollector:
+    collector = _StrictXfailCollector()
+    ret = pytest.main(
+        [
+            "tests/integrations/test_agents_matrix.py",
+            "tests/integrations/test_frameworks_matrix.py",
+            "--collect-only",
+            "-q",
+            "-p",
+            "no:cacheprovider",
+        ],
+        plugins=[collector],
+    )
+    # Collection-only must succeed (0 = OK, 5 = no tests collected is a bug here).
+    assert ret == 0, f"matrix collection failed with pytest exit code {ret}"
+    assert collector.all_nodeids, "matrix collected zero cells — harness broke"
+    return collector
+
+
+def test_strict_xfail_set_is_pinned():
+    """The applied strict-xfail set must equal the registered set exactly."""
+    collector = _collect_matrix()
+    applied = collector.strict_xfail_nodeids
+
+    expected_deepseek = _expected_deepseek_nodeids(collector.all_nodeids)
+    expected_gptoss = _expected_gptoss_nodeids(collector.all_nodeids)
+    expected_hy3 = _expected_hy3_nodeids(collector.all_nodeids)
+    expected = expected_deepseek | expected_gptoss | expected_hy3
+
+    # --- Membership: exact set equality --------------------------------- #
+    unexpected = applied - expected
+    missing = expected - applied
+    assert not unexpected, (
+        "NEW strict-xfail cell(s) not registered in conftest — a genuinely-"
+        "failing matrix cell may have been silently muted, shrinking the "
+        "required-PASS coverage of the release-artifact matrix gate. Register "
+        "it in the appropriate conftest constant and update the pinned counts "
+        "in test_strict_xfail_registry.py:\n"
+        + "\n".join(f"  + {n}" for n in sorted(unexpected))
+    )
+    assert not missing, (
+        "Registered strict-xfail cell(s) are NOT being applied — the conftest "
+        "marker hook or a registration constant drifted. Reconcile "
+        "conftest.pytest_collection_modifyitems with the registration "
+        "constants:\n" + "\n".join(f"  - {n}" for n in sorted(missing))
+    )
+
+    # --- Count: total tripwire ------------------------------------------ #
+    assert len(applied) == _EXPECTED_STRICT_XFAIL_COUNT, (
+        f"strict-xfail cell count changed: expected "
+        f"{_EXPECTED_STRICT_XFAIL_COUNT}, found {len(applied)}. Adding or "
+        f"removing a strict-xfail must be an explicit, reviewed change — "
+        f"update _EXPECTED_STRICT_XFAIL_COUNT (and the per-family count) in "
+        f"test_strict_xfail_registry.py, and justify the coverage delta in "
+        f"the PR."
+    )
+
+    # --- Per-family breakdown: catch same-total shifts ------------------ #
+    assert len(expected_deepseek) == _EXPECTED_DEEPSEEK_COUNT, (
+        f"DeepSeek strict-xfail count changed: expected "
+        f"{_EXPECTED_DEEPSEEK_COUNT}, found {len(expected_deepseek)}."
+    )
+    assert len(expected_gptoss) == _EXPECTED_GPTOSS_COUNT, (
+        f"gpt-oss strict-xfail count changed: expected "
+        f"{_EXPECTED_GPTOSS_COUNT}, found {len(expected_gptoss)}."
+    )
+    assert len(expected_hy3) == _EXPECTED_HY3_COUNT, (
+        f"Hy3 strict-xfail count changed: expected {_EXPECTED_HY3_COUNT}, "
+        f"found {len(expected_hy3)}."
+    )

--- a/tests/integrations/test_strict_xfail_registry.py
+++ b/tests/integrations/test_strict_xfail_registry.py
@@ -12,105 +12,103 @@ new xfail would pass the audit and quietly shrink the number of cells that
 must actually PASS — exactly the class of regression the matrix gate is
 supposed to prevent.
 
-This test closes that hole. It collects the two integration-matrix
-modules, computes the set of cells that ``conftest.pytest_collection_
-modifyitems`` marks ``xfail(strict=True)``, and asserts it equals an
-*expected* set derived from the conftest registration constants. The
-expected set is pinned three ways:
+This test closes that hole with an **independent, checked-in snapshot** of
+the exact strict-xfail nodeids (``_EXPECTED_STRICT_XFAIL_NODEIDS`` below).
+It collects the two integration-matrix modules, computes the set of cells
+that ``conftest.pytest_collection_modifyitems`` marks ``xfail(strict=
+True)``, and asserts that set equals the snapshot exactly.
 
-  1. **Membership** — the exact nodeids must match. A new strict-xfail on
-     a cell that is not in a registration constant fails here.
-  2. **Count** — the total is asserted against ``_EXPECTED_STRICT_XFAIL_
-     COUNT``. Adding or removing any strict-xfail cell (even a legitimate
-     one) forces an explicit edit to that number, so the change is
-     reviewed rather than silent.
-  3. **Per-family breakdown** — the DeepSeek / gpt-oss / Hy3 sub-counts
-     are pinned individually, so a shift *between* families (e.g. a new
-     DeepSeek cell balanced by a dropped Hy3 cell that keeps the total
-     the same) is still caught.
+The snapshot is deliberately NOT derived from the conftest registration
+constants. An earlier draft rebuilt the expected set from those same
+constants; codex flagged (correctly) that this is tautological — swapping
+one strict-xfail for another *within the same family* preserves the count
+AND keeps the derived expected set in lock-step with the hook, so the test
+stays green while coverage silently shifts. A hardcoded snapshot removes
+that blind spot: ANY membership change (add, remove, or swap) diverges
+from the snapshot and fails here, forcing an explicit, reviewed edit to
+this file.
 
-Net effect: adding or removing ANY strict-xfail in the matrix now requires
-an explicit change to this test, which surfaces the coverage delta in
-review. This is intentionally a pure-collection audit — no server, no
-model boot, no test bodies execute — so it runs in every ``make smoke`` /
-pr_validate cycle alongside ``test_xfail_audit``.
+The snapshot pins:
+
+  1. **Exact membership** — every nodeid must match. Adding, removing, or
+     swapping a strict-xfail cell fails the set-equality assertion.
+  2. **Total count** (24) and **per-family breakdown** (9 / 1 / 14) — a
+     redundant tripwire that makes the coverage delta obvious in the
+     failure message even before the reviewer diffs the nodeid set.
+
+This is intentionally a pure-collection audit — no server, no model boot,
+no test bodies execute — so it runs in every ``make smoke`` / pr_validate
+cycle alongside ``test_xfail_audit``.
 """
 
 from __future__ import annotations
 
 import pytest
 
-from tests.integrations import conftest as matrix_conftest
-
 # --------------------------------------------------------------------------- #
-# Expected strict-xfail set, derived from the conftest registration constants.
+# Independent, checked-in snapshot of every strict-xfail matrix cell.
 # --------------------------------------------------------------------------- #
 #
-# The matrix parametrizes every cell over a single ``family`` argument, so a
-# strict-xfail nodeid is always ``<module>::<Class>::test_smoke[<family>]``.
-# We rebuild the expected set from the same constants the conftest hook
-# consumes, so the two cannot drift: if a registration constant changes,
-# the expected set changes with it — but the pinned counts below still force
-# an explicit acknowledgement of the coverage delta.
+# 24 cells total, one strict-xfail per line. Grouped by the reason family
+# (see tests/integrations/conftest.py for the root-cause of each group).
+# Editing this set is the ONLY sanctioned way to add/remove a strict-xfail
+# in the matrix — the assertion below fails until this snapshot matches the
+# markers the conftest hook actually applies.
 
-# The matrix modules that carry family-parametrized cells (mirrors the
-# conftest ``_INTEGRATION_MATRIX_MODULES`` gate).
-_MATRIX_MODULES = ("test_agents_matrix.py", "test_frameworks_matrix.py")
-
-# All matrix classes, per module — the universe the Hy3 family-wide rule
-# spans. Sourced by collecting the modules (below), NOT hardcoded, so a new
-# agent/framework class is automatically included in the Hy3 expectation.
-
-
-def _expected_deepseek_nodeids(all_nodeids: set[str]) -> set[str]:
-    """9 DeepSeek R1-Distill tool-call cells.
-
-    Registered in ``conftest._DEEPSEEK_R1_TOOLCALL_XFAIL_NODEIDS`` as
-    ``<module>::<Class>`` prefixes; the applied marker lands on the
-    ``[deepseek]`` param of each.
-    """
-    out: set[str] = set()
-    for nodeid in all_nodeids:
-        if "[deepseek]" not in nodeid:
-            continue
-        if any(
-            prefix in nodeid
-            for prefix in matrix_conftest._DEEPSEEK_R1_TOOLCALL_XFAIL_NODEIDS
-        ):
-            out.add(nodeid)
-    return out
-
-
-def _expected_gptoss_nodeids(all_nodeids: set[str]) -> set[str]:
-    """1 gpt-oss × OpenHands cell (harmony ↔ CodeActAgent format mismatch)."""
-    nodeid_frag = matrix_conftest._GPTOSS_OPENHANDS_XFAIL_NODEID
-    family = matrix_conftest._GPTOSS_OPENHANDS_XFAIL_FAMILY
-    return {
-        nodeid
-        for nodeid in all_nodeids
-        if nodeid_frag in nodeid and f"[{family}]" in nodeid
+# 9 × DeepSeek R1-Distill tool-call cells — R1 distillation dropped OpenAI
+# tool_call emission (conftest ``_DEEPSEEK_R1_TOOLCALL_XFAIL_NODEIDS``).
+_DEEPSEEK_STRICT_XFAIL = frozenset(
+    {
+        "tests/integrations/test_agents_matrix.py::TestOpenCode::test_smoke[deepseek]",
+        "tests/integrations/test_agents_matrix.py::TestQwenCode::test_smoke[deepseek]",
+        "tests/integrations/test_agents_matrix.py::TestHermesAgent::test_smoke[deepseek]",
+        "tests/integrations/test_agents_matrix.py::TestKiloCode::test_smoke[deepseek]",
+        "tests/integrations/test_agents_matrix.py::TestCopilot::test_smoke[deepseek]",
+        "tests/integrations/test_agents_matrix.py::TestDroid::test_smoke[deepseek]",
+        "tests/integrations/test_agents_matrix.py::TestKimiCode::test_smoke[deepseek]",
+        "tests/integrations/test_frameworks_matrix.py::TestLangChain::test_smoke[deepseek]",
+        "tests/integrations/test_frameworks_matrix.py::TestPydanticAI::test_smoke[deepseek]",
     }
+)
 
-
-def _expected_hy3_nodeids(all_nodeids: set[str]) -> set[str]:
-    """Every Hy3 matrix cell (family-wide, 166 GB Ultra-only)."""
-    family = matrix_conftest._HY3_XFAIL_FAMILY
-    return {
-        nodeid
-        for nodeid in all_nodeids
-        if f"[{family}]" in nodeid
-        and any(module in nodeid for module in _MATRIX_MODULES)
+# 1 × gpt-oss × OpenHands cell — harmony ↔ CodeActAgent text-action mismatch.
+_GPTOSS_STRICT_XFAIL = frozenset(
+    {
+        "tests/integrations/test_agents_matrix.py::TestOpenHands::test_smoke[gptoss]",
     }
+)
 
+# 14 × Hy3 cells — 166 GB single-node-infeasible, Ultra-only (family-wide:
+# every agent + framework class × [hy3]).
+_HY3_STRICT_XFAIL = frozenset(
+    {
+        "tests/integrations/test_agents_matrix.py::TestCodexCLI::test_smoke[hy3]",
+        "tests/integrations/test_agents_matrix.py::TestClaudeCode::test_smoke[hy3]",
+        "tests/integrations/test_agents_matrix.py::TestOpenCode::test_smoke[hy3]",
+        "tests/integrations/test_agents_matrix.py::TestQwenCode::test_smoke[hy3]",
+        "tests/integrations/test_agents_matrix.py::TestOpenHands::test_smoke[hy3]",
+        "tests/integrations/test_agents_matrix.py::TestHermesAgent::test_smoke[hy3]",
+        "tests/integrations/test_agents_matrix.py::TestAider::test_smoke[hy3]",
+        "tests/integrations/test_agents_matrix.py::TestKiloCode::test_smoke[hy3]",
+        "tests/integrations/test_agents_matrix.py::TestCopilot::test_smoke[hy3]",
+        "tests/integrations/test_agents_matrix.py::TestDroid::test_smoke[hy3]",
+        "tests/integrations/test_agents_matrix.py::TestKimiCode::test_smoke[hy3]",
+        "tests/integrations/test_frameworks_matrix.py::TestLangChain::test_smoke[hy3]",
+        "tests/integrations/test_frameworks_matrix.py::TestPydanticAI::test_smoke[hy3]",
+        "tests/integrations/test_frameworks_matrix.py::TestSmolagents::test_smoke[hy3]",
+    }
+)
 
-# Pinned counts. These are the tripwire: changing the strict-xfail set
-# without editing these numbers fails the test.
+_EXPECTED_STRICT_XFAIL_NODEIDS = (
+    _DEEPSEEK_STRICT_XFAIL | _GPTOSS_STRICT_XFAIL | _HY3_STRICT_XFAIL
+)
+
+# Redundant count tripwires — make the coverage delta obvious even before
+# the reviewer diffs the nodeid set. Guarded against snapshot typos below.
 _EXPECTED_DEEPSEEK_COUNT = 9
 _EXPECTED_GPTOSS_COUNT = 1
 _EXPECTED_HY3_COUNT = 14
-_EXPECTED_STRICT_XFAIL_COUNT = (
-    _EXPECTED_DEEPSEEK_COUNT + _EXPECTED_GPTOSS_COUNT + _EXPECTED_HY3_COUNT
-)  # 24
+_EXPECTED_STRICT_XFAIL_COUNT = 24
 
 
 class _StrictXfailCollector:
@@ -147,60 +145,82 @@ def _collect_matrix() -> _StrictXfailCollector:
         ],
         plugins=[collector],
     )
-    # Collection-only must succeed (0 = OK, 5 = no tests collected is a bug here).
+    # Collection-only must succeed (0 = OK; 5 = no tests collected is a bug here).
     assert ret == 0, f"matrix collection failed with pytest exit code {ret}"
     assert collector.all_nodeids, "matrix collected zero cells — harness broke"
     return collector
 
 
+def test_snapshot_internal_consistency():
+    """The checked-in snapshot itself must be internally consistent.
+
+    Catches a typo in ``_EXPECTED_STRICT_XFAIL_NODEIDS`` (e.g. a duplicate
+    line silently collapsed by ``frozenset``) before it can mask a real
+    coverage drift in the assertion below.
+    """
+    assert len(_DEEPSEEK_STRICT_XFAIL) == _EXPECTED_DEEPSEEK_COUNT
+    assert len(_GPTOSS_STRICT_XFAIL) == _EXPECTED_GPTOSS_COUNT
+    assert len(_HY3_STRICT_XFAIL) == _EXPECTED_HY3_COUNT
+    assert len(_EXPECTED_STRICT_XFAIL_NODEIDS) == _EXPECTED_STRICT_XFAIL_COUNT
+    # The three family sets must be disjoint (a nodeid belongs to one family).
+    assert not (_DEEPSEEK_STRICT_XFAIL & _GPTOSS_STRICT_XFAIL)
+    assert not (_DEEPSEEK_STRICT_XFAIL & _HY3_STRICT_XFAIL)
+    assert not (_GPTOSS_STRICT_XFAIL & _HY3_STRICT_XFAIL)
+
+
 def test_strict_xfail_set_is_pinned():
-    """The applied strict-xfail set must equal the registered set exactly."""
+    """The applied strict-xfail set must equal the checked-in snapshot exactly."""
     collector = _collect_matrix()
     applied = collector.strict_xfail_nodeids
+    expected = set(_EXPECTED_STRICT_XFAIL_NODEIDS)
 
-    expected_deepseek = _expected_deepseek_nodeids(collector.all_nodeids)
-    expected_gptoss = _expected_gptoss_nodeids(collector.all_nodeids)
-    expected_hy3 = _expected_hy3_nodeids(collector.all_nodeids)
-    expected = expected_deepseek | expected_gptoss | expected_hy3
+    # Every snapshot nodeid must actually be collectable — else the snapshot
+    # references a renamed/deleted cell and the audit is silently vacuous.
+    stale = expected - collector.all_nodeids
+    assert not stale, (
+        "snapshot references nodeid(s) that no longer exist in the matrix — "
+        "a class was renamed/removed without updating this snapshot:\n"
+        + "\n".join(f"  ? {n}" for n in sorted(stale))
+    )
 
-    # --- Membership: exact set equality --------------------------------- #
+    # --- Membership: exact set equality (catches add / remove / swap) ---- #
     unexpected = applied - expected
     missing = expected - applied
     assert not unexpected, (
-        "NEW strict-xfail cell(s) not registered in conftest — a genuinely-"
-        "failing matrix cell may have been silently muted, shrinking the "
-        "required-PASS coverage of the release-artifact matrix gate. Register "
-        "it in the appropriate conftest constant and update the pinned counts "
-        "in test_strict_xfail_registry.py:\n"
-        + "\n".join(f"  + {n}" for n in sorted(unexpected))
+        "NEW strict-xfail cell(s) not in the checked-in snapshot — a "
+        "genuinely-failing matrix cell may have been silently muted, "
+        "shrinking the required-PASS coverage of the release-artifact matrix "
+        "gate. Add it to _EXPECTED_STRICT_XFAIL_NODEIDS (and bump the counts) "
+        "in test_strict_xfail_registry.py, and justify the coverage delta in "
+        "the PR:\n" + "\n".join(f"  + {n}" for n in sorted(unexpected))
     )
     assert not missing, (
-        "Registered strict-xfail cell(s) are NOT being applied — the conftest "
-        "marker hook or a registration constant drifted. Reconcile "
-        "conftest.pytest_collection_modifyitems with the registration "
-        "constants:\n" + "\n".join(f"  - {n}" for n in sorted(missing))
+        "Snapshot strict-xfail cell(s) are NOT being applied by the conftest "
+        "hook — either a registration constant drifted or a cell now passes. "
+        "Reconcile the snapshot with conftest.pytest_collection_modifyitems:\n"
+        + "\n".join(f"  - {n}" for n in sorted(missing))
     )
 
-    # --- Count: total tripwire ------------------------------------------ #
+    # --- Count: redundant total + per-family tripwire -------------------- #
     assert len(applied) == _EXPECTED_STRICT_XFAIL_COUNT, (
         f"strict-xfail cell count changed: expected "
         f"{_EXPECTED_STRICT_XFAIL_COUNT}, found {len(applied)}. Adding or "
         f"removing a strict-xfail must be an explicit, reviewed change — "
-        f"update _EXPECTED_STRICT_XFAIL_COUNT (and the per-family count) in "
-        f"test_strict_xfail_registry.py, and justify the coverage delta in "
-        f"the PR."
+        f"update _EXPECTED_STRICT_XFAIL_NODEIDS (and the per-family counts) "
+        f"in test_strict_xfail_registry.py, and justify the coverage delta."
     )
-
-    # --- Per-family breakdown: catch same-total shifts ------------------ #
-    assert len(expected_deepseek) == _EXPECTED_DEEPSEEK_COUNT, (
+    applied_deepseek = {n for n in applied if "[deepseek]" in n}
+    applied_gptoss = {n for n in applied if "[gptoss]" in n}
+    applied_hy3 = {n for n in applied if "[hy3]" in n}
+    assert len(applied_deepseek) == _EXPECTED_DEEPSEEK_COUNT, (
         f"DeepSeek strict-xfail count changed: expected "
-        f"{_EXPECTED_DEEPSEEK_COUNT}, found {len(expected_deepseek)}."
+        f"{_EXPECTED_DEEPSEEK_COUNT}, found {len(applied_deepseek)}."
     )
-    assert len(expected_gptoss) == _EXPECTED_GPTOSS_COUNT, (
+    assert len(applied_gptoss) == _EXPECTED_GPTOSS_COUNT, (
         f"gpt-oss strict-xfail count changed: expected "
-        f"{_EXPECTED_GPTOSS_COUNT}, found {len(expected_gptoss)}."
+        f"{_EXPECTED_GPTOSS_COUNT}, found {len(applied_gptoss)}."
     )
-    assert len(expected_hy3) == _EXPECTED_HY3_COUNT, (
+    assert len(applied_hy3) == _EXPECTED_HY3_COUNT, (
         f"Hy3 strict-xfail count changed: expected {_EXPECTED_HY3_COUNT}, "
-        f"found {len(expected_hy3)}."
+        f"found {len(applied_hy3)}."
     )

--- a/tests/test_check_gha_pinning.py
+++ b/tests/test_check_gha_pinning.py
@@ -37,10 +37,10 @@ def _make_workflow(tmp_path: pathlib.Path, body: str) -> pathlib.Path:
     return wf
 
 
-# ---------- allowlisted owners pass ----------------------------------
+# ---------- all tag refs are violations -------------------------------
 
 
-def test_actions_owner_tag_is_allowed(cgp, tmp_path):
+def test_actions_owner_tag_is_violation(cgp, tmp_path):
     wf = _make_workflow(
         tmp_path,
         """
@@ -51,10 +51,10 @@ def test_actions_owner_tag_is_allowed(cgp, tmp_path):
               - uses: actions/setup-python@v5
         """,
     )
-    assert cgp.violations_in_file(wf) == []
+    assert len(cgp.violations_in_file(wf)) == 2
 
 
-def test_github_owner_tag_is_allowed(cgp, tmp_path):
+def test_github_owner_tag_is_violation(cgp, tmp_path):
     wf = _make_workflow(
         tmp_path,
         """
@@ -64,10 +64,10 @@ def test_github_owner_tag_is_allowed(cgp, tmp_path):
               - uses: github/codeql-action@v3
         """,
     )
-    assert cgp.violations_in_file(wf) == []
+    assert len(cgp.violations_in_file(wf)) == 1
 
 
-# ---------- third-party tag refs are violations ----------------------
+# ---------- third-party tag refs are violations -----------------------
 
 
 def test_third_party_tag_is_violation(cgp, tmp_path):
@@ -156,7 +156,7 @@ def test_main_clean_dir_exits_0(cgp, tmp_path):
         jobs:
           x:
             steps:
-              - uses: actions/checkout@v4
+              - uses: actions/checkout@0000000000000000000000000000000000000000
         """,
     )
     assert cgp.main(["--workflows-dir", str(tmp_path)]) == 0

--- a/tests/test_check_gha_pinning.py
+++ b/tests/test_check_gha_pinning.py
@@ -146,6 +146,100 @@ def test_third_party_40_char_sha_uppercase_is_rejected(cgp, tmp_path):
     assert len(cgp.violations_in_file(wf)) == 1
 
 
+# ---------- quoted YAML forms must NOT bypass the check ---------------
+
+
+def test_quoted_uses_key_tag_is_violation(cgp, tmp_path):
+    """``"uses": ...`` (quoted key) is valid YAML and must be caught.
+
+    The old raw-text ``^\\s*uses:`` regex silently skipped this, leaving a
+    mutable action reference green (codex review).
+    """
+    wf = _make_workflow(
+        tmp_path,
+        """
+        jobs:
+          x:
+            steps:
+              - "uses": actions/checkout@v4
+        """,
+    )
+    assert len(cgp.violations_in_file(wf)) == 1
+
+
+def test_quoted_uses_value_tag_is_violation(cgp, tmp_path):
+    """``uses: "actions/checkout@v4"`` (quoted value) must be caught."""
+    wf = _make_workflow(
+        tmp_path,
+        """
+        jobs:
+          x:
+            steps:
+              - uses: "actions/checkout@v4"
+        """,
+    )
+    assert len(cgp.violations_in_file(wf)) == 1
+
+
+def test_quoted_uses_value_sha_is_accepted(cgp, tmp_path):
+    """A quoted value that IS a 40-char SHA must still pass."""
+    sha = "0" * 40
+    wf = _make_workflow(
+        tmp_path,
+        f"""
+        jobs:
+          x:
+            steps:
+              - uses: "actions/checkout@{sha}"
+        """,
+    )
+    assert cgp.violations_in_file(wf) == []
+
+
+def test_local_action_is_accepted(cgp, tmp_path):
+    """A same-repo local action (``./...``) has no supply-chain hop → pass."""
+    wf = _make_workflow(
+        tmp_path,
+        """
+        jobs:
+          x:
+            steps:
+              - uses: ./.github/actions/setup
+        """,
+    )
+    assert cgp.violations_in_file(wf) == []
+
+
+def test_container_digest_is_accepted_but_tag_is_violation(cgp, tmp_path):
+    """Container actions must pin a sha256 digest; a mutable tag is a violation."""
+    good = _make_workflow(
+        tmp_path,
+        """
+        jobs:
+          x:
+            steps:
+              - uses: docker://ghcr.io/org/img@sha256:{d}
+        """.replace("{d}", "0" * 64),
+    )
+    assert good.read_text()  # sanity
+    assert cgp.violations_in_file(good) == []
+
+    bad = tmp_path / "bad.yml"
+    import textwrap
+
+    bad.write_text(
+        textwrap.dedent(
+            """
+            jobs:
+              x:
+                steps:
+                  - uses: docker://ghcr.io/org/img:latest
+            """
+        )
+    )
+    assert len(cgp.violations_in_file(bad)) == 1
+
+
 # ---------- entry point ----------------------------------------------
 
 

--- a/tests/test_release_artifact_matrix.py
+++ b/tests/test_release_artifact_matrix.py
@@ -142,14 +142,56 @@ def test_assert_port_available_accepts_a_free_port(matrix):
     matrix._assert_port_available(free_port)
 
 
+def _canonical_pkg_name(spec: str) -> str:
+    """Extract + PEP 503-normalize the package name from a requirement spec.
+
+    ``"langchain-openai>=0.2.0"`` -> ``"langchain-openai"``. Normalization
+    lower-cases and collapses ``-``/``_``/``.`` runs to a single ``-`` so a
+    runtime dep declared as ``Langchain_OpenAI`` still compares equal.
+    """
+    import re
+
+    # Strip version/marker/extras noise: name ends at the first char that is
+    # not part of a PEP 508 distribution name.
+    name = re.split(r"[<>=!~;\[ ]", spec.strip(), maxsplit=1)[0]
+    return re.sub(r"[-_.]+", "-", name).lower()
+
+
 def test_matrix_test_dependencies_are_client_only(matrix):
-    """The SDK/test clients installed into the client venv must never leak
-    into the released package's runtime dependency set — they belong in the
-    CLIENT venv, isolated from the server venv, so a missing runtime dep in
-    the wheel cannot be masked by a client's transitive closure."""
-    client_pkgs = matrix.MATRIX_TEST_DEPENDENCIES
-    # Sanity: the known client SDKs are present and none is an engine runtime
-    # dep (these names must not appear in pyproject's [project] dependencies).
-    assert any(spec.startswith("openai") for spec in client_pkgs)
-    assert any(spec.startswith("langchain-openai") for spec in client_pkgs)
-    assert any(spec.startswith("aider-chat") for spec in client_pkgs)
+    """The SDK/test clients must never leak into the wheel's RUNTIME deps.
+
+    They belong only in the CLIENT venv, isolated from the server venv, so a
+    missing runtime dep in the wheel cannot be masked by a client's transitive
+    closure. A presence check alone is not enough (it stays green even if a
+    client is ALSO added to ``[project].dependencies``); assert the client set
+    is disjoint from the released package's declared runtime dependencies.
+    """
+    try:
+        import tomllib  # type: ignore[import-not-found]
+    except ModuleNotFoundError:  # pragma: no cover — 3.10 fallback
+        try:
+            import tomli as tomllib  # type: ignore[import-not-found,no-redef]
+        except ModuleNotFoundError:
+            pytest.skip("tomllib/tomli required to parse pyproject.toml")
+
+    pyproject_path = _REPO_ROOT / "pyproject.toml"
+    with pyproject_path.open("rb") as fp:
+        pyproject = tomllib.load(fp)
+
+    runtime_deps = {
+        _canonical_pkg_name(spec)
+        for spec in pyproject.get("project", {}).get("dependencies", [])
+    }
+    client_pkgs = {
+        _canonical_pkg_name(spec) for spec in matrix.MATRIX_TEST_DEPENDENCIES
+    }
+
+    # Sanity: the known client SDKs really are in the client tuple.
+    assert {"openai", "langchain-openai", "aider-chat"} <= client_pkgs
+
+    leaked = client_pkgs & runtime_deps
+    assert not leaked, (
+        "matrix client/test package(s) also appear in the released package's "
+        "runtime [project].dependencies — this defeats the server/client venv "
+        f"split and lets a client mask a missing runtime dep: {sorted(leaked)}"
+    )

--- a/tests/test_release_artifact_matrix.py
+++ b/tests/test_release_artifact_matrix.py
@@ -106,3 +106,50 @@ def test_parser_rejects_unknown_family(matrix):
     parser = matrix._build_parser()
     with pytest.raises(SystemExit):
         parser.parse_args(["--dist-dir", "dist", "--family", "unknown"])
+
+
+def test_assert_port_available_rejects_a_busy_port(matrix):
+    """A stale listener on the release port must be caught BEFORE spawn.
+
+    Guards the readiness-probe integrity fix: if the port is already held
+    (e.g. a stale same-family server), the runner must refuse rather than let
+    that other process answer /v1/models and mask a broken candidate.
+    """
+    import socket
+
+    listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    listener.bind(("127.0.0.1", 0))
+    listener.listen(1)
+    busy_port = listener.getsockname()[1]
+    try:
+        with pytest.raises(RuntimeError, match="already in use"):
+            matrix._assert_port_available(busy_port)
+    finally:
+        listener.close()
+
+
+def test_assert_port_available_accepts_a_free_port(matrix):
+    """A genuinely-free port must pass so a normal boot is not blocked."""
+    import socket
+
+    probe = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    probe.bind(("127.0.0.1", 0))
+    free_port = probe.getsockname()[1]
+    probe.close()  # release it so the helper can re-bind
+
+    # Should not raise.
+    matrix._assert_port_available(free_port)
+
+
+def test_matrix_test_dependencies_are_client_only(matrix):
+    """The SDK/test clients installed into the client venv must never leak
+    into the released package's runtime dependency set — they belong in the
+    CLIENT venv, isolated from the server venv, so a missing runtime dep in
+    the wheel cannot be masked by a client's transitive closure."""
+    client_pkgs = matrix.MATRIX_TEST_DEPENDENCIES
+    # Sanity: the known client SDKs are present and none is an engine runtime
+    # dep (these names must not appear in pyproject's [project] dependencies).
+    assert any(spec.startswith("openai") for spec in client_pkgs)
+    assert any(spec.startswith("langchain-openai") for spec in client_pkgs)
+    assert any(spec.startswith("aider-chat") for spec in client_pkgs)

--- a/tests/test_release_artifact_matrix.py
+++ b/tests/test_release_artifact_matrix.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the non-inference helpers in release_artifact_matrix.py."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_SCRIPT = _REPO_ROOT / "scripts" / "release_artifact_matrix.py"
+
+
+@pytest.fixture(scope="module")
+def matrix():
+    spec = importlib.util.spec_from_file_location("release_artifact_matrix", _SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_find_release_wheel_requires_exactly_one_candidate(matrix, tmp_path):
+    wheel = tmp_path / "rapid_mlx-0.10.9-py3-none-any.whl"
+    wheel.write_bytes(b"placeholder")
+    assert matrix.find_release_wheel(tmp_path) == wheel.resolve()
+
+
+def test_find_release_wheel_rejects_missing_candidate(matrix, tmp_path):
+    with pytest.raises(ValueError, match="exactly one"):
+        matrix.find_release_wheel(tmp_path)
+
+
+def test_find_release_wheel_rejects_ambiguous_candidates(matrix, tmp_path):
+    (tmp_path / "rapid_mlx-0.10.8-py3-none-any.whl").write_bytes(b"one")
+    (tmp_path / "rapid_mlx-0.10.9-py3-none-any.whl").write_bytes(b"two")
+    with pytest.raises(ValueError, match="0.10.8.*0.10.9"):
+        matrix.find_release_wheel(tmp_path)
+
+
+def test_clean_env_drops_source_injection_variables(matrix, monkeypatch):
+    monkeypatch.setenv("PYTHONPATH", "/unsafe/source")
+    monkeypatch.setenv("PYTHONHOME", "/unsafe/home")
+    monkeypatch.setenv("PIP_TARGET", "/unsafe/target")
+    env = matrix._clean_env()
+    assert "PYTHONPATH" not in env
+    assert "PYTHONHOME" not in env
+    assert "PIP_TARGET" not in env
+    assert env["PYTHONNOUSERSITE"] == "1"
+    assert env["RAPID_MLX_DISABLE_VERSION_CHECK"] == "1"
+    assert env["RAPID_MLX_TELEMETRY"] == "0"
+
+
+def test_validate_families_json_allows_a_nonempty_diagnostic_subset(matrix):
+    assert matrix.validate_families_json('["qwen36", "gptoss"]') == (
+        "qwen36",
+        "gptoss",
+    )
+
+
+@pytest.mark.parametrize(
+    "value, message",
+    [
+        ("[]", "non-empty"),
+        ('["qwen36", "qwen36"]', "duplicates"),
+        ('["qwen36", "unknown"]', "unknown family"),
+        ('["qwen36", 3]', "only family-name strings"),
+        ('{"family": "qwen36"}', "JSON array"),
+        ("not-json", "JSON array"),
+    ],
+)
+def test_validate_families_json_rejects_invalid_selection(matrix, value, message):
+    with pytest.raises(ValueError, match=message):
+        matrix.validate_families_json(value)
+
+
+def test_validate_families_json_requires_all_families_for_publication(matrix):
+    all_families = list(matrix.FAMILY_CONFIGS)
+    assert matrix.validate_families_json(
+        str(all_families).replace("'", '"'), require_all_families=True
+    ) == tuple(all_families)
+
+    with pytest.raises(ValueError, match="publication requires every release family"):
+        matrix.validate_families_json('["qwen36"]', require_all_families=True)
+
+
+def test_family_configs_cover_the_release_eligible_families(matrix):
+    assert set(matrix.FAMILY_CONFIGS) == {"qwen36", "gemma4", "deepseek", "gptoss"}
+    assert matrix.FAMILY_CONFIGS["gemma4"].extras == ("vision",)
+
+
+def test_cli_smoke_covers_base_commands_but_not_optional_chat(matrix):
+    assert set(matrix.CLI_SMOKE_SCRIPTS) == {
+        "rapid-mlx",
+        "rapid-mlx-bench",
+        "vllm-mlx",
+        "vllm-mlx-bench",
+    }
+
+
+def test_parser_rejects_unknown_family(matrix):
+    parser = matrix._build_parser()
+    with pytest.raises(SystemExit):
+        parser.parse_args(["--dist-dir", "dist", "--family", "unknown"])

--- a/tests/test_release_manifest.py
+++ b/tests/test_release_manifest.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the release artifact manifest helper."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_SCRIPT = _REPO_ROOT / "scripts" / "release_manifest.py"
+_SHA = "a" * 40
+
+
+@pytest.fixture(scope="module")
+def manifest_module():
+    spec = importlib.util.spec_from_file_location("release_manifest", _SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _dist(tmp_path: Path) -> tuple[Path, Path, Path]:
+    dist = tmp_path / "dist"
+    dist.mkdir()
+    wheel = dist / "rapid_mlx-0.10.9-py3-none-any.whl"
+    sdist = dist / "rapid_mlx-0.10.9.tar.gz"
+    wheel.write_bytes(b"wheel-bytes")
+    sdist.write_bytes(b"sdist-bytes")
+    return dist, wheel, sdist
+
+
+def test_create_then_verify_round_trips(manifest_module, tmp_path):
+    dist, _, _ = _dist(tmp_path)
+    manifest = manifest_module.create_manifest(
+        dist_dir=dist, source_sha=_SHA, version="0.10.9"
+    )
+    output = tmp_path / "release-manifest.json"
+    manifest_module.write_manifest(manifest, output)
+    assert (
+        manifest_module.verify_manifest(dist_dir=dist, manifest_path=output) == manifest
+    )
+
+
+def test_verify_rejects_changed_artifact(manifest_module, tmp_path):
+    dist, wheel, _ = _dist(tmp_path)
+    output = tmp_path / "release-manifest.json"
+    manifest_module.write_manifest(
+        manifest_module.create_manifest(
+            dist_dir=dist, source_sha=_SHA, version="0.10.9"
+        ),
+        output,
+    )
+    wheel.write_bytes(b"replacement")
+    with pytest.raises(ValueError, match="SHA-256 mismatch"):
+        manifest_module.verify_manifest(dist_dir=dist, manifest_path=output)
+
+
+def test_create_rejects_unexpected_distribution_shape(manifest_module, tmp_path):
+    dist = tmp_path / "dist"
+    dist.mkdir()
+    (dist / "rapid_mlx-0.10.9-py3-none-any.whl").write_bytes(b"wheel")
+    with pytest.raises(ValueError, match="exactly one"):
+        manifest_module.create_manifest(
+            dist_dir=dist, source_sha=_SHA, version="0.10.9"
+        )
+
+
+def test_create_rejects_extra_distribution_file(manifest_module, tmp_path):
+    dist, _, _ = _dist(tmp_path)
+    (dist / "rapid_mlx-0.10.9.zip").write_bytes(b"unexpected")
+    with pytest.raises(ValueError, match="no extra files"):
+        manifest_module.create_manifest(
+            dist_dir=dist, source_sha=_SHA, version="0.10.9"
+        )
+
+
+def test_create_rejects_non_commit_sha(manifest_module, tmp_path):
+    dist, _, _ = _dist(tmp_path)
+    with pytest.raises(ValueError, match="40-character"):
+        manifest_module.create_manifest(
+            dist_dir=dist, source_sha="not-a-sha", version="0.10.9"
+        )
+
+
+def test_create_rejects_artifact_version_mismatch(manifest_module, tmp_path):
+    dist, _, _ = _dist(tmp_path)
+    with pytest.raises(ValueError, match="does not match release version"):
+        manifest_module.create_manifest(
+            dist_dir=dist, source_sha=_SHA, version="0.10.10"
+        )
+
+
+def test_verify_rejects_manifest_version_mismatch(manifest_module, tmp_path):
+    dist, _, _ = _dist(tmp_path)
+    manifest = manifest_module.create_manifest(
+        dist_dir=dist, source_sha=_SHA, version="0.10.9"
+    )
+    manifest["version"] = "0.10.10"
+    output = tmp_path / "release-manifest.json"
+    manifest_module.write_manifest(manifest, output)
+
+    with pytest.raises(ValueError, match="does not match release version"):
+        manifest_module.verify_manifest(dist_dir=dist, manifest_path=output)
+
+
+def test_verify_rejects_duplicate_manifest_artifact(manifest_module, tmp_path):
+    dist, _, _ = _dist(tmp_path)
+    manifest = manifest_module.create_manifest(
+        dist_dir=dist, source_sha=_SHA, version="0.10.9"
+    )
+    manifest["artifacts"].append(manifest["artifacts"][0])
+    output = tmp_path / "release-manifest.json"
+    manifest_module.write_manifest(manifest, output)
+
+    with pytest.raises(ValueError, match="exactly two unique artifacts"):
+        manifest_module.verify_manifest(dist_dir=dist, manifest_path=output)

--- a/tests/test_release_smoke.py
+++ b/tests/test_release_smoke.py
@@ -56,3 +56,18 @@ def test_release_artifacts_rejects_extra_file(release_smoke, tmp_path):
 
     with pytest.raises(ValueError, match="no extra files"):
         release_smoke.release_artifacts(tmp_path)
+
+
+def test_release_artifacts_rejects_version_mismatch(release_smoke, tmp_path):
+    """A wheel and sdist from different builds must not be accepted together."""
+    (tmp_path / "rapid_mlx-0.10.9-py3-none-any.whl").write_bytes(b"wheel")
+    (tmp_path / "rapid_mlx-0.10.8.tar.gz").write_bytes(b"sdist")
+
+    with pytest.raises(ValueError, match="different versions"):
+        release_smoke.release_artifacts(tmp_path)
+
+
+def test_release_artifacts_rejects_missing_directory(release_smoke, tmp_path):
+    """A --dist-dir that does not exist must raise a clear error, not traceback."""
+    with pytest.raises(ValueError, match="not a directory"):
+        release_smoke.release_artifacts(tmp_path / "does-not-exist")

--- a/tests/test_release_smoke.py
+++ b/tests/test_release_smoke.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for release-smoke artifact selection."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_SCRIPT = _REPO_ROOT / "scripts" / "release_smoke.py"
+
+
+@pytest.fixture(scope="module")
+def release_smoke():
+    spec = importlib.util.spec_from_file_location("release_smoke", _SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_release_artifacts_returns_wheel_then_sdist(release_smoke, tmp_path):
+    wheel = tmp_path / "rapid_mlx-0.10.9-py3-none-any.whl"
+    sdist = tmp_path / "rapid_mlx-0.10.9.tar.gz"
+    wheel.write_bytes(b"wheel")
+    sdist.write_bytes(b"sdist")
+    assert release_smoke.release_artifacts(tmp_path) == (
+        wheel.resolve(),
+        sdist.resolve(),
+    )
+
+
+def test_release_artifacts_rejects_missing_sdist(release_smoke, tmp_path):
+    (tmp_path / "rapid_mlx-0.10.9-py3-none-any.whl").write_bytes(b"wheel")
+    with pytest.raises(ValueError, match="exactly one"):
+        release_smoke.release_artifacts(tmp_path)
+
+
+def test_release_artifacts_rejects_multiple_wheels(release_smoke, tmp_path):
+    (tmp_path / "rapid_mlx-0.10.8-py3-none-any.whl").write_bytes(b"one")
+    (tmp_path / "rapid_mlx-0.10.9-py3-none-any.whl").write_bytes(b"two")
+    (tmp_path / "rapid_mlx-0.10.9.tar.gz").write_bytes(b"sdist")
+    with pytest.raises(ValueError, match="exactly one"):
+        release_smoke.release_artifacts(tmp_path)
+
+
+def test_release_artifacts_rejects_extra_file(release_smoke, tmp_path):
+    wheel = tmp_path / "rapid_mlx-0.10.9-py3-none-any.whl"
+    sdist = tmp_path / "rapid_mlx-0.10.9.tar.gz"
+    wheel.write_bytes(b"wheel")
+    sdist.write_bytes(b"sdist")
+    (tmp_path / "unexpected.txt").write_text("not a release artifact")
+
+    with pytest.raises(ValueError, match="no extra files"):
+        release_smoke.release_artifacts(tmp_path)


### PR DESCRIPTION
## What does this PR do?

- Adds a dispatch-only Apple Silicon release-artifact acceptance workflow that builds one wheel and sdist, hashes them into a manifest, smoke-tests both from a clean environment, then exercises the supported model/client matrix against the installed wheel.
- Binds publication to the release tag, checked-out source SHA, and exact manifest; verifies published PyPI hashes and attestations before GitHub/Homebrew promotion.
- Makes GitHub Action SHA pinning mandatory, hardens the legacy publisher during migration, and documents staged activation/rollback.

## Why is this needed?

The release path could validate source-tree state instead of the archives that are actually uploaded, lacked a required full supported-model/client artifact gate, and permitted mutable action references. This closes those release-integrity gaps while retaining the legacy publisher until the dedicated macOS release runner and PyPI Trusted Publisher migration are available.

## Follow-up review fixes (post code + codex review)

A deep review plus two codex adversarial rounds found one blocker and a set of hardening items; all actionable ones are resolved on this branch:

- **B1 (blocker) — `verify-pypi` wrote broken `$GITHUB_OUTPUT`.** The "Fetch files from PyPI" step wrote its three output lines with a literal `\\n` inside a single-quoted heredoc (`<<'PY'`). The shell passes a quoted heredoc body verbatim, so Python got a two-character `\n` and wrote a *literal* backslash-n, not a newline. The three `key=value` pairs collapsed onto one physical line, so GitHub Actions parsed only `wheel_url`; `sdist_url`/`sdist_sha256` were never set as job outputs. The downstream `update-homebrew` job reads those outputs, so it would have dispatched an **empty url + empty sha** to the Homebrew tap — a broken formula on every release. Fixed `\\n` → `\n` on all three writes (matching the correct single-`\n` pattern already in `publish.yml`), plus a defensive `cat "$GITHUB_OUTPUT"` for CI debuggability. Verified by hexdumping the corrected heredoc's output: three physical lines, real `0x0a` bytes, all three keys parse.
- **Clean-room integrity — split server/client venvs.** The live matrix runner installed the client/test SDK deps into the *same* venv as the release wheel before booting the server, so a client's transitive dep could satisfy a runtime import the wheel forgot to declare, masking a missing runtime dep. `run_family` now uses two isolated venvs: a **server** venv (wheel + declared extras only) and a **client** venv (matrix test/SDK deps + aider) that drives it over HTTP.
- **Readiness-probe integrity — prove port ownership.** The probe accepted any HTTP 200 on the fixed port without proving the candidate process owned it, so a stale same-family server could make a broken candidate pass. Added `_assert_port_available(port)` before spawn (binds the port to prove it's free) plus a post-readiness liveness re-check. Unit-tested busy/free port.
- **No-skip gate — exempt only strict-xfail.** The `RAPID_MLX_MATRIX_NO_SKIPS` hook exempted any `wasxfail` report, but pytest sets `wasxfail` for non-strict and dynamic xfails too, so an un-audited non-strict xfail could silently bypass the gate. The hook now exempts ONLY cells carrying an explicit `xfail(strict=True)` marker (the snapshot-pinned set).
- **N1 — pin the strict-xfail set with an independent snapshot.** The 56-cell matrix is a required release gate, but nothing pinned *which*/*how many* cells are strict-xfail'd. Added `tests/integrations/test_strict_xfail_registry.py` with a checked-in snapshot of all 24 strict-xfail nodeids (9 DeepSeek R1-Distill tool-call + 1 gpt-oss × OpenHands + 14 Hy3). ANY change (add / remove / **swap within a family**) diverges from the snapshot and fails, forcing an explicit reviewed edit.
- **Client-only dep test — assert real disjointness.** `test_matrix_test_dependencies_are_client_only` now parses `[project].dependencies`, PEP 503-normalizes names, and asserts the client SDK set is disjoint from the wheel's runtime deps (a presence check alone stayed green if a client also became a runtime dep).
- **Publish TOCTOU guard.** The tag→SHA binding was checked in `build-candidate` but never re-resolved before the OIDC-bearing PyPI publish. Added a `publish`-job step that re-resolves `refs/tags/vX.Y.Z` (dereferencing annotated tags) immediately before the credential and requires it — and the draft release target — to still equal the tested source SHA.
- **release_smoke nits.** `release_artifacts` now raises a clear `ValueError` on a missing `--dist-dir` and rejects a wheel+sdist pair from different versions.
- **N2 — operator-path leak.** Removed the hardcoded `/Users/raullenstudio/.local/bin/aider` fallback from the Aider matrix cell and `test_aider.sh`; discovery is now `AIDER_BIN` → `shutil.which` / `command -v aider`.

Two codex findings were assessed and intentionally not changed, with rationale:
- **`pypi-attestations verify pypi` "URL vs local file"** — false positive. The pinned `pypi-attestations==0.0.29` CLI documents `PYPI_FILE` as accepting "A direct URL to files.pythonhosted.org" (confirmed via the tool's `--help`), which is exactly what the workflow passes.
- **Removing `skip-existing` from the legacy publisher** — the PR's deliberate, documented supply-chain thesis: fail loudly on a duplicate upload rather than silently accept a divergent rebuild of an immutable PyPI version.

## AI assistance disclosure

Codex authored and reviewed the release workflows, helper scripts, tests, and release documentation in this PR. The follow-up review fixes above were reviewed and empirically verified: heredoc hexdump, strict-xfail snapshot tripwire (add/remove/swap), critical-path SHA-mismatch mutation, no-skip strict-vs-plain cell behavior, and unit tests for the port-ownership guard and dep-disjointness.

> By submitting this PR I confirm I can explain the intent, risk, and behavior of every non-generated change in this PR. For any generated / boilerplate / scaffolded sections, I have identified them above and can describe how I verified them.

## Test plan

- `python3.12 -m pytest tests/test_release_manifest.py tests/test_release_artifact_matrix.py tests/test_release_smoke.py tests/test_check_gha_pinning.py tests/test_packaging_data_files.py tests/test_vision_extra_install.py tests/test_xfail_audit.py tests/integrations/test_strict_xfail_registry.py -q` (63 passed).
- **B1 verification:** ran the corrected `verify-pypi` heredoc against a stub `$GITHUB_OUTPUT` and `xxd`'d it — real `0x0a` newlines, three distinct non-empty outputs, versus a single collapsed line pre-fix.
- **N1 tripwire:** the registry test FAILS on a strict-xfail add, remove, AND same-family swap, then PASSES after restore.
- **No-skip gate:** under `RAPID_MLX_MATRIX_NO_SKIPS=1`, a strict-xfail cell stays exempt (skipped) while a plain cell is converted to failed.
- **Critical-path spot-check:** disabling the SHA-256 compare in `release_manifest.py` makes `test_verify_rejects_changed_artifact` fail with "DID NOT RAISE ValueError"; restored and re-confirmed PASS.
- `ruff check` + `ruff format --check` on changed files (clean); `actionlint` on `release-artifact-matrix.yml` + `publish.yml` (exit 0); `scripts/check_gha_pinning.py` (12 workflows clean) and `git diff --check` (clean).

## Rollout

- Keep the artifact matrix dispatch-only until the dedicated `rapid-mlx-release` macOS ARM64 runner and PyPI Trusted Publisher migration are configured; the included runbook covers activation and rollback.

## Checklist

- [x] Updated README/docs where applicable.
- [x] No breaking changes to the existing API.
- [x] Tests pass locally (63 passed — full test plan above).
- [x] Lint passes (`ruff check` + `ruff format --check` + `actionlint`).
- [x] Self-validated with `pr_validate` in an isolated venv.
- [x] Critical-path spot-check: mutating the SHA-256 compare makes `test_verify_rejects_changed_artifact` fail (guard confirmed live).
