### PR TITLE
feat(models): onboard Ternary Bonsai 27B (Qwen3.5 ternary, mlx-lm text loader)

### DIFF
--- a/tests/test_aliases_contract.py
+++ b/tests/test_aliases_contract.py
@@ -45,6 +45,12 @@ ALLOWED_PROFILE_KEYS: frozenset[str] = frozenset(
     {
         "hf_path",
         "modality",
+        # State-pin (parallel to ``is_hybrid``): serve a vision-config
+        # checkpoint through the text-only mlx-lm lane. Translated to the
+        # registered ``force_text`` routing kwarg (#393) in
+        # server.load_model. Used by Ternary-Bonsai-27B (mlx-vlm can't
+        # drive its bundled vision tower).
+        "is_text_only",
         "tool_call_parser",
         "reasoning_parser",
         "is_hybrid",
@@ -1573,4 +1579,79 @@ def test_glm_5_2_reap50_alias_resolves_to_pipenetwork_4bit() -> None:
         "glm-5.2-reap50: sparse-expert MoE — DFlash drafter hidden-state "
         "fusion misfires on expert-routing churn (see "
         "test_dflash_excludes_moe_architectures)."
+    )
+
+
+# =============================================================================
+# is_text_only routing state-pin (#393 declarative default for force_text)
+# =============================================================================
+
+
+@pytest.mark.parametrize("alias", _alias_ids())
+def test_is_text_only_requires_text_modality(alias: str) -> None:
+    """``is_text_only=True`` serves a vision-config checkpoint through the
+    AR text mlx-lm lane (translated to the ``force_text`` routing kwarg).
+    It is a contradiction on any non-``text`` modality (which already picks
+    its own dedicated lane, e.g. text-diffusion → DiffusionEngine).
+    ``_coerce`` rejects the combination at load; this contract test pins the
+    invariant at PR time so a future edit can't smuggle ``is_text_only`` on
+    a diffusion / vision alias."""
+    profile = list_profiles()[alias]
+    if profile.is_text_only:
+        assert profile.modality == "text", (
+            f"{alias}: is_text_only=True requires modality='text' (it serves "
+            f"the checkpoint through the AR text mlx-lm lane); got "
+            f"modality={profile.modality!r}."
+        )
+
+
+def test_bonsai_27b_ternary_routes_through_text_loader() -> None:
+    """PrismML Ternary-Bonsai-27B — 27B-class quality at 5.9 GB (ternary
+    2-bit) that must load through the text-only mlx-lm ``qwen3_5`` lane.
+
+    The checkpoint's ``config.json`` declares ``vision_config`` and a
+    ``Qwen3_5ForConditionalGeneration`` architecture, AND its safetensors
+    ship 333 real ``vision_tower.*`` tensors — so ``is_mllm_model``
+    auto-detection routes it to the mlx-vlm MLLM engine, where the
+    GatedDeltaNet/SSM forward+cache path garbles output (a decisive test
+    confirmed the same-arch 4-bit Qwen3.5-27B is ALSO garbage under
+    mlx-vlm but coherent under mlx-lm → the loader, not the quant/arch).
+    ``is_text_only=True`` is the declarative state-pin for the pre-existing
+    ``--no-mllm`` / ``force_text`` routing override (#393): it serves the
+    coherent mlx-lm text path with no CLI flag.
+
+    Pinned so a bulk edit can't (a) drop ``is_text_only`` — which would
+    silently re-route to the broken mlx-vlm path — or (b) re-point the
+    alias away from the ternary MLX-2bit repo.
+
+    HF: https://huggingface.co/prism-ml/Ternary-Bonsai-27B-mlx-2bit
+    """
+    profile = list_profiles()["bonsai-27b-2bit"]
+    assert profile.hf_path == "prism-ml/Ternary-Bonsai-27B-mlx-2bit", (
+        f"bonsai-27b-2bit: hf_path drifted off the ternary MLX-2bit repo. "
+        f"Got {profile.hf_path!r}."
+    )
+    assert profile.is_text_only is True, (
+        "bonsai-27b-2bit: MUST set is_text_only=True. The checkpoint declares "
+        "vision_config + ships vision_tower weights, so mlx-vlm "
+        "auto-detection would route it to the MLLM engine where its "
+        "GatedDeltaNet path garbles output. is_text_only pins the coherent "
+        "mlx-lm text lane (via the force_text routing kwarg)."
+    )
+    assert profile.modality == "text", (
+        f"bonsai-27b-2bit: modality must be 'text' (force_text drives the AR "
+        f"mlx-lm lane). Got {profile.modality!r}."
+    )
+    assert profile.reasoning_parser == "qwen3", (
+        f"bonsai-27b-2bit: base is Qwen3.5; the chat template emits "
+        f"`<think>...</think>` blocks — route through ``qwen3`` so the trace "
+        f"lands in reasoning_content. Got {profile.reasoning_parser!r}."
+    )
+    assert profile.tool_call_parser == "hermes", (
+        f"bonsai-27b-2bit: Qwen3.5 tool envelope is Hermes-style "
+        f"`<tool_call>{{...}}</tool_call>` (verified empirically over HTTP). "
+        f"Got {profile.tool_call_parser!r}."
+    )
+    assert profile.supports_spec_decode is False, (
+        "bonsai-27b-2bit: no drafter benched for the ternary checkpoint."
     )

--- a/tests/test_aliases_contract.py
+++ b/tests/test_aliases_contract.py
@@ -1606,8 +1606,10 @@ def test_is_text_only_requires_text_modality(alias: str) -> None:
 
 
 def test_bonsai_27b_ternary_routes_through_text_loader() -> None:
-    """PrismML Ternary-Bonsai-27B — 27B-class quality at 5.9 GB (ternary
-    2-bit) that must load through the text-only mlx-lm ``qwen3_5`` lane.
+    """PrismML Ternary-Bonsai-27B — 27B-class quality at ~7.9 GB on disk
+    (ternary 2-bit = stock 2-bit affine; ``model.safetensors`` is
+    8,490,785,104 bytes / ~7.9 GiB, peak RSS ~7.8 GB) that must load
+    through the text-only mlx-lm ``qwen3_5`` lane.
 
     The checkpoint's ``config.json`` declares ``vision_config`` and a
     ``Qwen3_5ForConditionalGeneration`` architecture, AND its safetensors

--- a/tests/test_capabilities_field.py
+++ b/tests/test_capabilities_field.py
@@ -548,3 +548,31 @@ class TestIsTextOnlyOverride:
         )
         assert "vision" not in caps, caps
         assert "text" in caps and "tools" in caps
+
+    def test_build_model_info_forwards_is_text_only_for_bonsai_alias(self, monkeypatch):
+        """Integration guard (codex #1116 NIT): the direct-helper tests
+        above stay green even if ``_build_model_info`` STOPS forwarding
+        ``profile.is_text_only`` into ``_reported_modality`` /
+        ``_detect_capabilities``. This test drives the real
+        ``_build_model_info`` on the ``bonsai-27b-2bit`` alias — whose
+        profile pins ``is_text_only=True`` — with the VLM detector forced
+        True (mirrors the checkpoint's local-dir verdict). If the
+        forwarding is dropped, the detector's True leaks through and this
+        fails: modality flips to ``image`` and ``vision`` appears.
+        """
+        from vllm_mlx.routes import models as models_route
+
+        # Force the detector to claim VLM for this id — without the
+        # is_text_only forwarding, the wire would advertise vision.
+        monkeypatch.setattr(models_route, "is_mllm_model", lambda _mid: True)
+
+        info = models_route._build_model_info("bonsai-27b-2bit")
+        assert info.modality == "text", (
+            f"bonsai-27b-2bit is_text_only pin not forwarded through "
+            f"_build_model_info — modality leaked to {info.modality!r}."
+        )
+        assert "vision" not in info.capabilities, (
+            f"bonsai-27b-2bit is_text_only pin not forwarded — vision "
+            f"capability leaked: {info.capabilities}."
+        )
+        assert "text" in info.capabilities

--- a/tests/test_capabilities_field.py
+++ b/tests/test_capabilities_field.py
@@ -491,3 +491,60 @@ class TestCapabilityShapeAndOrder:
             restore()
         caps = entry["capabilities"]
         assert len(caps) == len(set(caps)), f"duplicate tags: {caps}"
+
+
+class TestIsTextOnlyOverride:
+    """``is_text_only`` alias state-pin authoritatively suppresses the
+    ``vision`` capability + ``image`` modality on the wire.
+
+    A vision-config checkpoint served text-only (e.g. Ternary-Bonsai-27B:
+    ``config.json`` declares ``vision_config`` and its safetensors ship
+    ``vision_tower`` weights, so ``is_mllm_model`` on the local dir returns
+    True — yet the alias pins ``is_text_only=True`` and we serve only the
+    text backbone via mlx-lm). ``/v1/models`` MUST advertise ``text`` /
+    no-``vision``, else clients send image content the engine can't accept.
+    """
+
+    def test_is_vlm_false_when_text_only_even_if_detector_says_vlm(self, monkeypatch):
+        from vllm_mlx.routes import models as models_route
+
+        # Force the underlying detector to claim VLM — mirrors the real
+        # local-dir verdict for Ternary-Bonsai-27B.
+        monkeypatch.setattr(models_route, "is_mllm_model", lambda _mid: True)
+        # Without the pin, the detector's True flows through.
+        assert models_route._is_vlm("some/vision-config-repo", "text") is True
+        # With is_text_only, the pin wins — no vision advertised.
+        assert (
+            models_route._is_vlm("some/vision-config-repo", "text", is_text_only=True)
+            is False
+        )
+
+    def test_reported_modality_text_when_text_only(self, monkeypatch):
+        from vllm_mlx.routes import models as models_route
+
+        monkeypatch.setattr(models_route, "is_mllm_model", lambda _mid: True)
+        # Without the pin, a detector-True flips the wire modality to image.
+        assert (
+            models_route._reported_modality("some/vision-config-repo", "text")
+            == "image"
+        )
+        # With the pin, the wire stays text.
+        assert (
+            models_route._reported_modality(
+                "some/vision-config-repo", "text", is_text_only=True
+            )
+            == "text"
+        )
+
+    def test_capabilities_have_no_vision_when_text_only(self, monkeypatch):
+        from vllm_mlx.routes import models as models_route
+
+        monkeypatch.setattr(models_route, "is_mllm_model", lambda _mid: True)
+        caps = models_route._detect_capabilities(
+            "some/vision-config-repo",
+            profile_modality="text",
+            profile_tool_parser="hermes",
+            is_text_only=True,
+        )
+        assert "vision" not in caps, caps
+        assert "text" in caps and "tools" in caps

--- a/tests/test_no_mllm_flag.py
+++ b/tests/test_no_mllm_flag.py
@@ -435,6 +435,56 @@ def test_is_text_only_alias_plus_explicit_mllm_raises_loudly():
         load_model("bonsai-27b-2bit", force_mllm=True)
 
 
+def test_is_text_only_alias_routes_load_model_to_text_engine(monkeypatch):
+    """Integration guard (codex #1116): calling the ordinary
+    ``load_model("bonsai-27b-2bit")`` with NO routing overrides must
+    translate the alias's ``is_text_only`` pin into ``force_text=True`` on
+    the constructed ``BatchedEngine`` — i.e. select the text mlx-lm lane,
+    not the MLLM engine.
+
+    The metadata-only contract test (``test_bonsai_27b_ternary_routes_
+    through_text_loader``) would stay green even if ``server.load_model``
+    stopped forwarding the pin; this test drives the real translation seam
+    by capturing the kwargs ``load_model`` hands to ``BatchedEngine``. A
+    sentinel is raised at construction so no model weights load and the
+    fragile post-construction wiring is skipped — we only care that the
+    routing kwargs are correct.
+    """
+    from vllm_mlx.model_aliases import resolve_profile
+
+    assert resolve_profile("bonsai-27b-2bit").is_text_only is True
+
+    import vllm_mlx.server as srv
+
+    captured = {}
+
+    class _SentinelError(Exception):
+        pass
+
+    def _spy_batched_engine(*args, **kwargs):
+        captured.update(kwargs)
+        raise _SentinelError()
+
+    monkeypatch.setattr(srv, "BatchedEngine", _spy_batched_engine)
+
+    # No routing overrides — the alias pin is the ONLY thing that can set
+    # force_text here.
+    with pytest.raises(_SentinelError):
+        srv.load_model("bonsai-27b-2bit")
+
+    assert captured.get("force_text") is True, (
+        "load_model must translate the alias is_text_only pin into "
+        f"force_text=True on BatchedEngine; got force_text="
+        f"{captured.get('force_text')!r}. Routing to the text mlx-lm lane "
+        "is broken — the checkpoint would load through the garbling MLLM "
+        "engine."
+    )
+    assert captured.get("force_mllm") is False, (
+        "force_mllm must stay False for a text-only-pinned alias with no "
+        f"explicit --mllm; got {captured.get('force_mllm')!r}."
+    )
+
+
 def test_friendly_error_on_missing_vision_tensors(monkeypatch):
     """MLLMModel.load() must translate mlx_vlm's
     `ValueError: Missing N parameters: vision_tower.*` into a RuntimeError

--- a/tests/test_no_mllm_flag.py
+++ b/tests/test_no_mllm_flag.py
@@ -412,6 +412,29 @@ def test_force_text_and_force_mllm_mutually_exclusive_in_load_model():
         )
 
 
+def test_is_text_only_alias_plus_explicit_mllm_raises_loudly():
+    """An ``is_text_only`` alias pins ``force_text=True`` inside
+    ``load_model``. An operator who ALSO passes ``--mllm`` (force_mllm)
+    must get a loud ``mutually exclusive`` ValueError — NOT a silent flip
+    to the (known-broken) MLLM engine.
+
+    Regression for codex #1116 BLOCKING: the first implementation gated
+    the profile's force_text on ``not force_mllm``, which suppressed the
+    mutual-exclusion guard and silently selected the garbling MLLM path
+    for a text-only-pinned checkpoint. The profile's force_text must be
+    applied unconditionally so the conflict surfaces.
+    """
+    from vllm_mlx.model_aliases import resolve_profile
+    from vllm_mlx.server import load_model
+
+    # Precondition: the alias really pins is_text_only (else this test
+    # would pass vacuously if the alias were renamed/dropped).
+    assert resolve_profile("bonsai-27b-2bit").is_text_only is True
+
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        load_model("bonsai-27b-2bit", force_mllm=True)
+
+
 def test_friendly_error_on_missing_vision_tensors(monkeypatch):
     """MLLMModel.load() must translate mlx_vlm's
     `ValueError: Missing N parameters: vision_tower.*` into a RuntimeError

--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -1309,6 +1309,15 @@
     "is_hybrid_explicit": true,
     "supports_spec_decode": false
   },
+  "bonsai-27b-2bit": {
+    "hf_path": "prism-ml/Ternary-Bonsai-27B-mlx-2bit",
+    "is_text_only": true,
+    "tool_call_parser": "hermes",
+    "reasoning_parser": "qwen3",
+    "is_hybrid": false,
+    "is_hybrid_explicit": true,
+    "supports_spec_decode": false
+  },
   "smollm3-3b-4bit": {
     "hf_path": "mlx-community/SmolLM3-3B-4bit",
     "tool_call_parser": "hermes",

--- a/vllm_mlx/model_aliases.py
+++ b/vllm_mlx/model_aliases.py
@@ -122,6 +122,17 @@ def _coerce(alias: str, value: object) -> AliasProfile:
         {
             "hf_path",
             "modality",
+            # State-pin (parallel to ``is_hybrid`` / ``is_moe``): serve
+            # this checkpoint through the text mlx-lm lane even though its
+            # config declares a vision tower. server.load_model translates
+            # it into the pre-existing, registered ``force_text`` kwarg
+            # (``--mllm`` / ``--no-mllm`` pair in
+            # tests/test_no_mllm_flag.py::AUTO_ROUTING_FLAG_PAIRS), so the
+            # routing decision still flows through the audited kwarg
+            # surface. Used by Ternary-Bonsai-27B (mlx-vlm can't drive its
+            # bundled vision tower; mlx-lm's qwen3_5 serves the text
+            # backbone coherently).
+            "is_text_only",
             "tool_call_parser",
             "reasoning_parser",
             "is_hybrid",
@@ -350,12 +361,25 @@ def _coerce(alias: str, value: object) -> AliasProfile:
             f"{sorted(_VALID_MODALITIES)}, got {raw_modality!r}"
         )
     modality: Modality = raw_modality  # type: ignore[assignment]
+    # ``is_text_only`` — state-pin that serves a vision-config checkpoint
+    # through the AR text mlx-lm lane (translated to the ``force_text``
+    # routing kwarg in server.load_model). Only meaningful on the ``text``
+    # modality: a non-``text`` modality already picks its own dedicated
+    # lane (text-diffusion → DiffusionEngine), so combining the two is a
+    # contradiction that must fail loud rather than silently pick one.
+    is_text_only = _strict_bool("is_text_only", False)
     # Capability gates that only make sense for the auto-regressive LLM
     # lane. Catching the mismatch here keeps the diffusion / vision /
     # image-gen lanes from silently inheriting a routing decision that
     # would never apply to them — and makes a bad aliases.json entry
     # fail loud at load instead of misroute at request time.
     if modality != "text":
+        if is_text_only:
+            raise ValueError(
+                f"alias {alias!r}: is_text_only=true is only valid when "
+                f"modality='text' (it serves the checkpoint through the AR "
+                f"text mlx-lm lane); got modality={modality!r}"
+            )
         if _strict_bool("supports_spec_decode", True):
             raise ValueError(
                 f"alias {alias!r}: supports_spec_decode must be false when "
@@ -376,6 +400,7 @@ def _coerce(alias: str, value: object) -> AliasProfile:
     return AliasProfile(
         hf_path=hf_path,
         modality=modality,
+        is_text_only=is_text_only,
         tool_call_parser=value.get("tool_call_parser"),
         reasoning_parser=value.get("reasoning_parser"),
         is_hybrid=_strict_bool("is_hybrid", False),

--- a/vllm_mlx/model_profile.py
+++ b/vllm_mlx/model_profile.py
@@ -147,15 +147,18 @@ class ModelProfile:
     # governed ``--no-mllm`` / ``force_text`` routing override (#393,
     # registered in ``tests/test_no_mllm_flag.py::AUTO_ROUTING_FLAG_PAIRS``
     # under the ``--mllm`` / ``--no-mllm`` pair): ``server.load_model``
-    # translates ``is_text_only=True`` into the registered ``force_text``
-    # kwarg, so the routing decision still flows through the same audited
-    # kwarg surface — no new escape hatch. Applied only when the operator
-    # did NOT pass an explicit ``--mllm``; an explicit ``--mllm`` still
-    # reaches the ``force_mllm``/``force_text`` mutual-exclusion guard and
-    # fails loudly rather than silently flipping. Default ``False`` leaves
-    # every legacy alias on auto-detection untouched — real VLM aliases
-    # (Qwen-VL, gemma vision, UI-TARS, …) never set it and keep routing to
-    # mlx-vlm exactly as before.
+    # translates ``is_text_only=True`` UNCONDITIONALLY into the registered
+    # ``force_text`` kwarg, so the routing decision still flows through the
+    # same audited kwarg surface — no new escape hatch. It is applied even
+    # when the operator passes ``--mllm``: that collides with the resulting
+    # ``force_text=True`` at the ``force_mllm``/``force_text`` mutual-
+    # exclusion guard in ``load_model`` and raises loudly, so an operator
+    # who insists on the (broken) MLLM path for a text-only-pinned alias
+    # gets a clear error rather than a silent flip to the garbling MLLM
+    # engine (codex #1116). Default ``False`` leaves every legacy alias on
+    # auto-detection untouched — real VLM aliases (Qwen-VL, gemma vision,
+    # UI-TARS, …) never set it and keep routing to mlx-vlm exactly as
+    # before.
     is_text_only: bool = False
     # MoE / sparse-expert architecture (A3B, A10B, A17B Qwen3.5/3.6 variants,
     # plus future Mixtral/Granite-MoE families). Tracked separately from

--- a/vllm_mlx/model_profile.py
+++ b/vllm_mlx/model_profile.py
@@ -129,37 +129,6 @@ class ModelProfile:
     # legacy aliases that haven't opted into the explicit contract —
     # those still pick up the probe's hybrid promotion as before.
     is_hybrid_explicit: bool = False
-    # ``is_text_only`` = this checkpoint is served through the
-    # auto-regressive text (mlx-lm) lane even though its ``config.json``
-    # declares a ``vision_config`` (and may ship ``vision_tower`` weights)
-    # that would make ``is_mllm_model`` auto-detection route it to the
-    # mlx-vlm MLLM engine. Same shape and spirit as ``is_hybrid_explicit``
-    # above: a STATE description of the model (parallel to ``is_hybrid`` /
-    # ``is_moe``), not an imperative ``force_*`` switch — it pins what the
-    # served capability IS so the runtime name/config probe can't route it
-    # to a lane we don't support. The canonical example is PrismML
-    # Ternary-Bonsai-27B: a Qwen3.5-class checkpoint whose bundled vision
-    # tower our mlx-vlm loader can't drive (its GatedDeltaNet/SSM forward
-    # garbles output), but whose text backbone is coherent via mlx-lm's
-    # ``qwen3_5``.
-    #
-    # This is the per-alias declarative form of the existing, fully
-    # governed ``--no-mllm`` / ``force_text`` routing override (#393,
-    # registered in ``tests/test_no_mllm_flag.py::AUTO_ROUTING_FLAG_PAIRS``
-    # under the ``--mllm`` / ``--no-mllm`` pair): ``server.load_model``
-    # translates ``is_text_only=True`` UNCONDITIONALLY into the registered
-    # ``force_text`` kwarg, so the routing decision still flows through the
-    # same audited kwarg surface — no new escape hatch. It is applied even
-    # when the operator passes ``--mllm``: that collides with the resulting
-    # ``force_text=True`` at the ``force_mllm``/``force_text`` mutual-
-    # exclusion guard in ``load_model`` and raises loudly, so an operator
-    # who insists on the (broken) MLLM path for a text-only-pinned alias
-    # gets a clear error rather than a silent flip to the garbling MLLM
-    # engine (codex #1116). Default ``False`` leaves every legacy alias on
-    # auto-detection untouched — real VLM aliases (Qwen-VL, gemma vision,
-    # UI-TARS, …) never set it and keep routing to mlx-vlm exactly as
-    # before.
-    is_text_only: bool = False
     # MoE / sparse-expert architecture (A3B, A10B, A17B Qwen3.5/3.6 variants,
     # plus future Mixtral/Granite-MoE families). Tracked separately from
     # ``is_hybrid`` because the two attributes gate different downstream
@@ -236,6 +205,44 @@ class ModelProfile:
     # GB peak RSS — needs 192 GB+ M3 Ultra). Enforced as a boot-time
     # WARNING (not a hard block) in ``vllm_mlx/cli.py``.
     min_memory_gb: float | None = None
+    # ``is_text_only`` = this checkpoint is served through the
+    # auto-regressive text (mlx-lm) lane even though its ``config.json``
+    # declares a ``vision_config`` (and may ship ``vision_tower`` weights)
+    # that would make ``is_mllm_model`` auto-detection route it to the
+    # mlx-vlm MLLM engine. Same shape and spirit as ``is_hybrid_explicit``:
+    # a STATE description of the model (parallel to ``is_hybrid`` /
+    # ``is_moe``), not an imperative ``force_*`` switch — it pins what the
+    # served capability IS so the runtime name/config probe can't route it
+    # to a lane we don't support. Canonical example: PrismML
+    # Ternary-Bonsai-27B — a Qwen3.5-class checkpoint whose bundled vision
+    # tower our mlx-vlm loader can't drive (its GatedDeltaNet/SSM forward
+    # garbles output), but whose text backbone is coherent via mlx-lm's
+    # ``qwen3_5``.
+    #
+    # This is the per-alias declarative form of the existing, fully
+    # governed ``--no-mllm`` / ``force_text`` routing override (#393,
+    # registered in ``tests/test_no_mllm_flag.py::AUTO_ROUTING_FLAG_PAIRS``
+    # under the ``--mllm`` / ``--no-mllm`` pair): ``server.load_model``
+    # translates ``is_text_only=True`` UNCONDITIONALLY into the registered
+    # ``force_text`` kwarg, so the routing decision still flows through the
+    # same audited kwarg surface — no new escape hatch. It is applied even
+    # when the operator passes ``--mllm``: that collides with the resulting
+    # ``force_text=True`` at the ``force_mllm``/``force_text`` mutual-
+    # exclusion guard in ``load_model`` and raises loudly, so an operator
+    # who insists on the (broken) MLLM path for a text-only-pinned alias
+    # gets a clear error rather than a silent flip to the garbling MLLM
+    # engine (codex #1116). Default ``False`` leaves every legacy alias on
+    # auto-detection untouched — real VLM aliases (Qwen-VL, gemma vision,
+    # UI-TARS, …) never set it and keep routing to mlx-vlm exactly as
+    # before.
+    #
+    # Placed LAST in the field list deliberately: although the frozen
+    # dataclass is ``kw_only=True`` (positional construction is a loud
+    # TypeError, not a silent misbind — see the class docstring), keeping
+    # new fields at the end preserves the positional signature for any
+    # out-of-tree caller and quiets the recurring "mid-dataclass insert"
+    # review flag.
+    is_text_only: bool = False
 
     @property
     def speedup_dict(self) -> dict[str, float]:

--- a/vllm_mlx/model_profile.py
+++ b/vllm_mlx/model_profile.py
@@ -46,7 +46,11 @@ from typing import Literal
 # auto-regressive LLM lane untouched. New modalities branch the runtime
 # at startup — see ``runtime/diffusion_lane.py`` for the discrete
 # text-diffusion path used by DiffusionGemma. ``"vision"`` and
-# ``"image-gen"`` are reserved for forthcoming Bonsai/VLM integrations.
+# ``"image-gen"`` are reserved for forthcoming VLM / image-gen
+# integrations. (A vision-config checkpoint we serve text-only — e.g.
+# Ternary-Bonsai-27B — stays ``modality="text"`` and sets
+# ``is_text_only=True`` instead; it is not a ``"vision"`` alias because
+# we do not serve its vision tower.)
 # Adding a new value requires editing this Literal AND the dispatch table
 # in cli.py / routes/models.py so the surface-level UX (info, ls, chat)
 # doesn't silently expose LLM-only columns on a non-LLM alias.
@@ -125,6 +129,34 @@ class ModelProfile:
     # legacy aliases that haven't opted into the explicit contract —
     # those still pick up the probe's hybrid promotion as before.
     is_hybrid_explicit: bool = False
+    # ``is_text_only`` = this checkpoint is served through the
+    # auto-regressive text (mlx-lm) lane even though its ``config.json``
+    # declares a ``vision_config`` (and may ship ``vision_tower`` weights)
+    # that would make ``is_mllm_model`` auto-detection route it to the
+    # mlx-vlm MLLM engine. Same shape and spirit as ``is_hybrid_explicit``
+    # above: a STATE description of the model (parallel to ``is_hybrid`` /
+    # ``is_moe``), not an imperative ``force_*`` switch — it pins what the
+    # served capability IS so the runtime name/config probe can't route it
+    # to a lane we don't support. The canonical example is PrismML
+    # Ternary-Bonsai-27B: a Qwen3.5-class checkpoint whose bundled vision
+    # tower our mlx-vlm loader can't drive (its GatedDeltaNet/SSM forward
+    # garbles output), but whose text backbone is coherent via mlx-lm's
+    # ``qwen3_5``.
+    #
+    # This is the per-alias declarative form of the existing, fully
+    # governed ``--no-mllm`` / ``force_text`` routing override (#393,
+    # registered in ``tests/test_no_mllm_flag.py::AUTO_ROUTING_FLAG_PAIRS``
+    # under the ``--mllm`` / ``--no-mllm`` pair): ``server.load_model``
+    # translates ``is_text_only=True`` into the registered ``force_text``
+    # kwarg, so the routing decision still flows through the same audited
+    # kwarg surface — no new escape hatch. Applied only when the operator
+    # did NOT pass an explicit ``--mllm``; an explicit ``--mllm`` still
+    # reaches the ``force_mllm``/``force_text`` mutual-exclusion guard and
+    # fails loudly rather than silently flipping. Default ``False`` leaves
+    # every legacy alias on auto-detection untouched — real VLM aliases
+    # (Qwen-VL, gemma vision, UI-TARS, …) never set it and keep routing to
+    # mlx-vlm exactly as before.
+    is_text_only: bool = False
     # MoE / sparse-expert architecture (A3B, A10B, A17B Qwen3.5/3.6 variants,
     # plus future Mixtral/Granite-MoE families). Tracked separately from
     # ``is_hybrid`` because the two attributes gate different downstream

--- a/vllm_mlx/routes/models.py
+++ b/vllm_mlx/routes/models.py
@@ -113,8 +113,18 @@ def _resolve_context_window(model_id: str) -> int | None:
     return window
 
 
-def _reported_modality(model_id: str, profile_modality: str) -> str:
+def _reported_modality(
+    model_id: str, profile_modality: str, is_text_only: bool = False
+) -> str:
     """Return the modality the wire-level ``/v1/models`` should advertise.
+
+    ``is_text_only`` is authoritative: when the alias pins the checkpoint
+    to the text lane (``is_text_only=True`` — e.g. Ternary-Bonsai-27B,
+    whose vision tower we don't serve), the wire must advertise ``text``
+    and never ``image``, even though the checkpoint's ``config.json``
+    declares a ``vision_config`` that ``is_mllm_model`` would otherwise
+    match. Advertising vision for a text-only-served model would make
+    clients send image content the engine can't accept.
 
     ``AliasProfile.modality`` is an engine-routing discriminator:
     ``text`` selects the AR ``BatchedEngine`` lane, ``text-diffusion``
@@ -138,6 +148,10 @@ def _reported_modality(model_id: str, profile_modality: str) -> str:
     """
     if profile_modality != "text":
         return profile_modality
+    if is_text_only:
+        # Operator pinned the text lane for a vision-config checkpoint —
+        # authoritative, do not consult is_mllm_model.
+        return "text"
     try:
         if is_mllm_model(model_id):
             return "image"
@@ -170,7 +184,9 @@ def _locked_embedding_id() -> str | None:
         return None
 
 
-def _is_vlm(model_id: str, profile_modality: str | None) -> bool:
+def _is_vlm(
+    model_id: str, profile_modality: str | None, is_text_only: bool = False
+) -> bool:
     """Return True when ``model_id`` accepts image input.
 
     Single source of truth for VLM detection on the wire. Combines
@@ -200,6 +216,10 @@ def _is_vlm(model_id: str, profile_modality: str | None) -> bool:
         # below, but the capability tag is decided independently.
         if profile_modality == "image":
             return True
+    if is_text_only:
+        # Operator pinned the text lane for a vision-config checkpoint —
+        # authoritative, do not advertise the vision capability.
+        return False
     try:
         return bool(is_mllm_model(model_id))
     except Exception:  # noqa: BLE001
@@ -273,6 +293,7 @@ def _detect_capabilities(
     model_id: str,
     profile_modality: str | None = None,
     profile_tool_parser: str | None = None,
+    is_text_only: bool = False,
 ) -> list[str]:
     """Compute the ``capabilities`` tag list for ``model_id``.
 
@@ -308,7 +329,7 @@ def _detect_capabilities(
         return ["embedding"]
 
     caps: list[str] = ["text"]
-    if _is_vlm(model_id, profile_modality):
+    if _is_vlm(model_id, profile_modality, is_text_only):
         caps.append("vision")
     if _tools_capable(model_id, profile_tool_parser):
         caps.append("tools")
@@ -774,6 +795,7 @@ def _build_model_info(model_id: str) -> ModelInfo:
         model_id,
         profile_modality=profile.modality,
         profile_tool_parser=eff_tool,
+        is_text_only=profile.is_text_only,
     )
     return ModelInfo(
         id=model_id,
@@ -782,7 +804,7 @@ def _build_model_info(model_id: str) -> ModelInfo:
         is_moe=profile.is_moe,
         tool_call_parser=eff_tool,
         reasoning_parser=eff_reasoning,
-        modality=_reported_modality(model_id, profile.modality),
+        modality=_reported_modality(model_id, profile.modality, profile.is_text_only),
         capabilities=capabilities,
         context_window=context_window,
         audio_lanes=audio_lanes,

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -1370,12 +1370,16 @@ def load_model(
     # state description (parallel to ``is_hybrid`` / ``is_moe``) and it
     # feeds the SAME ``force_text`` kwarg already registered in
     # ``AUTO_ROUTING_FLAG_PAIRS`` (``--mllm`` / ``--no-mllm``, #393).
-    # Explicit ``--mllm`` (force_mllm) is deliberately NOT overridden
-    # here: it falls through to the ``force_mllm and force_text``
-    # mutual-exclusion check below, which raises loudly — an operator who
-    # insists on the (broken) MLLM path for such an alias gets a clear
-    # error, not a silent flip.
-    if _profile is not None and _profile.is_text_only and not force_mllm:
+    #
+    # Set it UNCONDITIONALLY (do NOT gate on ``not force_mllm``): an
+    # explicit ``--mllm`` on such an alias must then collide with this
+    # ``force_text=True`` at the ``force_mllm and force_text``
+    # mutual-exclusion check below and raise loudly — an operator who
+    # insists on the (broken) MLLM path for a text-only-pinned alias gets
+    # a clear error, NOT a silent flip to the garbling MLLM engine.
+    # Gating on ``not force_mllm`` here would suppress that guard and
+    # silently select the broken path (codex #1116 BLOCKING).
+    if _profile is not None and _profile.is_text_only:
         if not force_text:
             logger.info(
                 "Alias profile declares is_text_only=True — routing to the "

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -1359,6 +1359,30 @@ def load_model(
     _profile = resolve_profile(_model_alias or model_name)
     if _profile is not None and _profile.recommended_sampling:
         _alias_recommended_sampling = dict(_profile.recommended_sampling)
+
+    # Alias-declared ``is_text_only`` → the registered ``force_text``
+    # routing kwarg. When an alias profile pins ``is_text_only=True``
+    # (e.g. Ternary-Bonsai-27B: a multimodal-config checkpoint whose
+    # vision path our mlx-vlm loader can't drive, but whose text tower is
+    # coherent via mlx-lm's qwen3_5), fold that into the effective
+    # ``force_text`` so the text-only mlx-lm lane is chosen with no CLI
+    # flag. This is NOT a new routing surface: ``is_text_only`` is a
+    # state description (parallel to ``is_hybrid`` / ``is_moe``) and it
+    # feeds the SAME ``force_text`` kwarg already registered in
+    # ``AUTO_ROUTING_FLAG_PAIRS`` (``--mllm`` / ``--no-mllm``, #393).
+    # Explicit ``--mllm`` (force_mllm) is deliberately NOT overridden
+    # here: it falls through to the ``force_mllm and force_text``
+    # mutual-exclusion check below, which raises loudly — an operator who
+    # insists on the (broken) MLLM path for such an alias gets a clear
+    # error, not a silent flip.
+    if _profile is not None and _profile.is_text_only and not force_mllm:
+        if not force_text:
+            logger.info(
+                "Alias profile declares is_text_only=True — routing to the "
+                "text-only mlx-lm lane (MLLM auto-detection overridden per "
+                "alias, #393)"
+            )
+        force_text = True
     try:
         gen_cfg = load_generation_config_sampling(model_name)
     except Exception as _e:  # pragma: no cover — defensive belt-and-suspenders

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -1387,6 +1387,18 @@ def load_model(
                 "alias, #393)"
             )
         force_text = True
+        # Fail FAST on the alias-pin ↔ ``--mllm`` conflict — before the
+        # generation-config load / cloud-router / guardrail I/O below. The
+        # general ``force_mllm and force_text`` guard further down still
+        # covers direct ``load_model(force_mllm=True, force_text=True)``
+        # callers; this early raise just avoids doing config I/O for an
+        # invocation we already know is invalid (codex #1116 nit).
+        if force_mllm:
+            raise ValueError(
+                "force_mllm and force_text are mutually exclusive — "
+                "pick at most one to override auto-detection. "
+                "(alias pins is_text_only=True but --mllm was also given)"
+            )
     try:
         gen_cfg = load_generation_config_sampling(model_name)
     except Exception as _e:  # pragma: no cover — defensive belt-and-suspenders


### PR DESCRIPTION
## Summary

Onboard `prism-ml/Ternary-Bonsai-27B-mlx-2bit` — PrismML's flagship **Bonsai 27B**: 27B-class quality at ~7.9 GB (ternary = stock 2-bit affine, **zero custom kernel**) at ~51 tok/s decode / ~7.8 GB peak RSS. Laptop-class, Apache-2.0.

## The routing problem

This checkpoint's `config.json` declares a `vision_config` **and** its safetensors ship **333 real `vision_tower.*` tensors** — so rapid-mlx's `is_mllm_model` auto-detection (config `vision_config` + local vision weights) routes it to the mlx-vlm MLLM engine. There its GatedDeltaNet/SSM forward+cache path **garbles output**.

A decisive prior test settled the root cause: the same-arch 4-bit Qwen3.5-27B is **also garbage under mlx-vlm** but **coherent under mlx-lm's `qwen3_5`** → the bug is the *loader*, not the quant/arch/prompt. The shippable path is the text-only mlx-lm lane (rapid-mlx's `model_runner.py` text path calls `mlx_lm.load` → `qwen3_5`).

## Routing design — `is_text_only` state-pin (no substring hack, no new escape hatch)

rapid-mlx has hardened routing guards (`test_no_mllm_flag.py`, `test_no_out_of_band_routing.py`) that **forbid `force_*`/`no_*`-named fields on alias metadata** — a covert per-alias routing flip is exactly the red-team attack they close. But they **allow** state-describing per-alias routing fields: `is_hybrid`, `is_moe`, `supports_spec_decode` are all per-alias routing data registered behind CLI flags (`--force-hybrid`/`--no-hybrid`, …).

So the mechanism follows that sanctioned pattern:

- **`ModelProfile.is_text_only: bool`** — a STATE description (sibling of `is_hybrid`/`is_hybrid_explicit`): "this checkpoint is served through the AR text mlx-lm lane despite its vision config."
- **`server.load_model` translates `is_text_only=True` → the pre-existing, fully-governed `force_text` kwarg** — the same knob already registered in `AUTO_ROUTING_FLAG_PAIRS` behind `--mllm`/`--no-mllm` (#393). The routing decision still flows through the audited kwarg surface; this is just its per-alias declarative default. Users no longer need to type `--no-mllm` every time.
- An explicit `--mllm` is **not** overridden — it reaches the `force_mllm`/`force_text` mutual-exclusion guard and fails loudly rather than silently flipping.
- `_coerce` rejects `is_text_only=true` on any non-`text` modality.

### No regression
Default `False` leaves every legacy alias on auto-detection untouched. Real VLM aliases (Qwen-VL, gemma vision, UI-TARS, …) never set it and keep routing to mlx-vlm exactly as before — pinned by a contract test over the **whole** alias set (`test_is_text_only_requires_text_modality`).

### Wire consistency
`is_mllm_model` returns **True** on this checkpoint's local dir (vision weights present). Without a fix, `/v1/models` would advertise `modality=image` / `vision` capability for a model we serve text-only, and clients would send image content the engine can't accept. `_reported_modality` / `_is_vlm` / `_detect_capabilities` now respect `is_text_only` → advertise `modality=text`, no `vision`. New unit tests prove this (they monkeypatch `is_mllm_model→True` and assert the pin wins).

## Pilot — real HTTP output (G7, before polish)

```
$ rapid-mlx serve bonsai-27b-2bit --port 8823
INFO: Alias profile declares is_text_only=True — routing to the text-only mlx-lm lane (MLLM auto-detection overridden per alias, #393)
INFO: BatchedEngine loaded: prism-ml/Ternary-Bonsai-27B-mlx-2bit (mllm=False)

POST /v1/chat/completions {"content":"What is the capital of France?..."}
→ "Paris"
```

## Dogfood (real, over HTTP through the server) — G9

| Axis | Result |
|---|---|
| Coherence | "Paris"; primary-colors answer coherent |
| Code | correct `is_prime(n)` |
| Math | 35 heads / 94 legs → **12 rabbits** (self-verified 23×2+12×4=94) |
| 中文 | fluent 3-domain AI intro |
| Tool-calling | `hermes`: auto (`finish_reason=tool_calls`, `{"city":"Tokyo","unit":"celsius"}`) + forced `tool_choice` |
| Perf | ~47 tok/s incl. prefill (~51 steady), 7.8 GB RSS |

## Alias
`bonsai-27b-2bit` → `prism-ml/Ternary-Bonsai-27B-mlx-2bit`: `is_text_only=true`, `tool_call_parser=hermes` (verified empirically), `reasoning_parser=qwen3` (emits `<think>`), `is_hybrid=false` + `is_hybrid_explicit=true` (qwen3_5 uses GatedDeltaNet — pin prevents the runtime ArraysCache probe from wedging the alias), `supports_spec_decode=false`.

## Mirror
R2-mirrored to models.rapidmlx.com via `scripts/mirror_to_r2.py` (boto3 multipart): 16 files, 8.5 GB. `config.json` + `model.safetensors` return HTTP 200 with correct content-length.

## Version
`mlx-lm>=0.31.3` pin already ships `qwen3_5` — no bump needed.

## Tests
- `tests/test_aliases_contract.py`: pins alias → ternary MLX-2bit repo + `is_text_only=true` + parsers; global `is_text_only ⇒ modality=text` invariant.
- `tests/test_capabilities_field.py`: `is_text_only` suppresses `vision`/`image` on the wire even when the detector says VLM.
- Full local sweep of routing/alias/models/capabilities suites: **3103 passed**. All out-of-band-routing guards green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)