### PR TITLE
chore: bump version to 0.10.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.10.9"
+version = "0.10.10"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## Release 0.10.10 (feature)

Cuts a feature release bundling everything merged since `v0.10.9` (14 commits). Even patch number = feature slot per the odd/even cadence.

### Why now
`0.10.9` was a fix slot. Since then two new model families landed plus KV-cache portability and a batch of Gemma 4 hardening — enough substantive feature surface to warrant a feature cut. Bump-only PR so `auto-release.yml` fires cleanly on the `chore: bump version to X.Y.Z` subject.

### Highlights

**New models**
- **Ternary Bonsai 27B** — Qwen3.5 ternary (stock MLX 2-bit affine), phone-class 7.9 GB @ ~46 tok/s, routed through the mlx-lm text loader via the new `is_text_only` profile field to sidestep the mlx-vlm SSM bug (#1116). Verified coherent + full agent/framework integration (openai SDK, LangChain, pydantic-ai, smolagents CodeAgent, aider).
- **Qwen3-Coder-Next 80B** aliases (#1099)

**Features**
- KV cache export/import engine body (#1100)
- Gemma 4 cross-layer KV-share verify-and-lock — guard + 5-size test (#1104)
- CLI update check routed through the countable landing worker (#1105)

**Fixes**
- Enforce DFlash server security policy (#1109)
- Gemma 4 explicit unified routing, no more substring match (#1098)
- Gemma 4 PLE table pinned `>=8-bit` vs 4-bit corruption (#1114)

**Refactor / infra / docs**
- Unified `AliasProfile` + `ModelConfig` into one frozen `ModelProfile` (#1108)
- Release-artifact acceptance hardening (#1115)
- Tier-1 agent docs + honest family×agent matrix (#1110)
- CLI `info` MTP/KV-share truth row + removed dead A5 `mx.compile` code (#1112)

### Test plan
- Local build from `origin/main` + `rapid-mlx serve bonsai-27b-2bit` → coherent, ~46 tok/s, 7.9 GB RSS.
- Agent/framework integration matrix all green: openai SDK 6/6 (chat, tool-call auto, multi-turn, forced tool_choice, streaming chat, streaming tool-call), LangChain `bind_tools`, pydantic-ai Agent loop, smolagents CodeAgent, aider whole-edit.
- Post-merge verification (prose, not gated checkboxes): confirm `auto-release.yml` fires, `pip install rapid-mlx==0.10.10` resolves on PyPI, Homebrew tap follows, GH Release published, then fresh-venv naive-user dogfood serving one new-family alias.

Bump-only diff: `pyproject.toml` version `0.10.9` → `0.10.10`.