### PR TITLE
fix: exclude broken mlx-vlm 0.6.4 from all extras

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,7 +117,14 @@ dependencies = [
 # Required for any model with vision input. Text-only models work without this.
 # 0.5.0+ also unlocks DFlash speculative decoding (see [dflash] extras).
 vision = [
-    "mlx-vlm>=0.6.3",  # 0.6.3: DiffusionGemma (Gemma 4 DLM PR #1347 + long-context prefill PR #1348). 0.6.1 floor: gemma4_unified architecture. 0.5.0 baseline: gemma4 multi-image + tool-parser fixes, TurboQuant race-condition fix, continuous-batching guard. Also unlocks DFlash spec-decode hooks (see [dflash] extras).
+    # 0.6.3: DiffusionGemma (Gemma 4 DLM PR #1347 + long-context prefill PR #1348). 0.6.1 floor: gemma4_unified architecture. 0.5.0 baseline: gemma4 multi-image + tool-parser fixes, TurboQuant race-condition fix, continuous-batching guard. Also unlocks DFlash spec-decode hooks (see [dflash] extras).
+    # !=0.6.4 EXCLUDED: 0.6.4 ships a broken qwen3_5 GatedDeltaNet SSM forward
+    # (garbage output; this is why Bonsai 27B is served text-only via mlx-lm).
+    # It is the CURRENT PyPI latest with no 0.6.5 fix, so a bare ``>=0.6.3``
+    # resolves a fresh install straight to the broken build. All five extras
+    # that pull mlx-vlm carry this exclusion — enforced by
+    # tests/test_vision_extra_install.py so a new extra can't silently regress.
+    "mlx-vlm>=0.6.3,!=0.6.4",
     "opencv-python>=4.8.0",
     "torch>=2.3.0",
     "torchvision>=0.18.0",
@@ -131,7 +138,7 @@ vision = [
 # the vision extras do. Only enable if you serve a DFlash-eligible alias
 # (e.g. qwen3.5-27b-8bit) with --speculative-config '{"method":"dflash"}'.
 dflash = [
-    "mlx-vlm>=0.6.3",
+    "mlx-vlm>=0.6.3,!=0.6.4",
 ]
 # MTP (Multi-Token Prediction) speculative decoding — Gemma 4 external
 # assistant path via ``--speculative-config '{"method":"mtp","model":"<path>"}'``.
@@ -181,7 +188,7 @@ chat = [
 # pip install .[all] and editable installs.
 all = [
     # vision
-    "mlx-vlm>=0.6.3",
+    "mlx-vlm>=0.6.3,!=0.6.4",
     "opencv-python>=4.8.0",
     "torch>=2.3.0",
     "torchvision>=0.18.0",
@@ -234,7 +241,7 @@ test = [
     # ``pytest tests/`` without hand-installed local extras.
     "aiohttp>=3.9.0",
     "pillow>=10.0.0",
-    "mlx-vlm>=0.6.3; platform_system == 'Darwin'",
+    "mlx-vlm>=0.6.3,!=0.6.4; platform_system == 'Darwin'",
     "mlx-audio>=0.2.9,<0.4.4; platform_system == 'Darwin'",
 ]
 dev = [
@@ -249,7 +256,7 @@ dev = [
     'tomli>=2.0.1; python_version < "3.11"',
     "aiohttp>=3.9.0",
     "pillow>=10.0.0",
-    "mlx-vlm>=0.6.3; platform_system == 'Darwin'",
+    "mlx-vlm>=0.6.3,!=0.6.4; platform_system == 'Darwin'",
     "mlx-audio>=0.2.9,<0.4.4; platform_system == 'Darwin'",
     # Linters / typer — NOT in the `test` extras because pr_validate
     # only needs to *run* the tests; lint is its own pipeline step

--- a/tests/test_vision_extra_install.py
+++ b/tests/test_vision_extra_install.py
@@ -552,3 +552,66 @@ def test_dev_extra_pins_tomli_for_python_310() -> None:
         f'"3.11"` marker so 3.10 CI workers can actually run the '
         f"L-07 lock-in suite. Got dev specs: {dev_specs!r}"
     )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Broken-build exclusion: mlx-vlm 0.6.4 ships a broken qwen3_5
+# GatedDeltaNet SSM forward (garbage output — this is why Bonsai 27B is
+# served text-only via mlx-lm). It is the CURRENT PyPI latest with no
+# 0.6.5 fix, so a bare ``mlx-vlm>=0.6.3`` resolves a fresh
+# ``pip install 'rapid-mlx[vision]'`` STRAIGHT to the broken wheel.
+# Every extra that pulls mlx-vlm must exclude it. Mirrors the upstream
+# fix waybarrios/vllm-mlx#633 for our rebranded tree.
+# ──────────────────────────────────────────────────────────────────────
+
+
+def _spec_excludes_064(spec: str) -> bool:
+    """True iff ``spec`` cannot resolve to the broken mlx-vlm 0.6.4.
+
+    Evaluated with full PEP 440 semantics via ``packaging`` — NOT a
+    substring check. A naive ``"!=0.6.4" in spec`` would be fooled by
+    ``!=0.6.4.1`` (which excludes 0.6.4.1 yet still ADMITS 0.6.4), so we
+    ask the parsed specifier set directly whether it admits 0.6.4. This
+    also transparently accepts a future ``>=0.6.5`` floor after an
+    upstream fix, with no test edit. ``packaging.requirements.Requirement``
+    parses (and discards) any PEP 508 environment marker such as
+    ``; platform_system == 'Darwin'`` on its own, so the Darwin-gated
+    dev/test pins are handled identically to the unmarked ones.
+    ``prereleases=True`` keeps the check honest if a pin ever carries a
+    0.6.4 prerelease form (defensive; our pins are all final releases)."""
+    from packaging.requirements import Requirement
+    from packaging.version import Version
+
+    return not Requirement(spec).specifier.contains(
+        Version("0.6.4"), prereleases=True
+    )
+
+
+def test_all_mlx_vlm_specs_exclude_broken_064() -> None:
+    """EVERY optional-dependency extra that pulls mlx-vlm must exclude the
+    broken 0.6.4 build.
+
+    0.6.4 ships a broken qwen3_5 GatedDeltaNet SSM forward (garbage
+    output) AND is the current PyPI latest with no 0.6.5 fix, so a bare
+    ``mlx-vlm>=0.6.3`` installs it on a fresh venv — the exact fresh-user
+    trap this test guards. The scan walks ALL extras (not a hard-coded
+    list) so a NEW extra that adds mlx-vlm without the exclusion is caught
+    here, at CI time, instead of by a user's broken vision/dflash boot."""
+    py = _load_pyproject()
+    extras = py.get("project", {}).get("optional-dependencies", {})
+    offenders: list[tuple[str, str]] = []
+    for extra_name, specs in extras.items():
+        for spec in specs:
+            name, _ = _split_spec(spec)
+            if name.lower() != "mlx-vlm":
+                continue
+            if not _spec_excludes_064(spec):
+                offenders.append((extra_name, spec))
+    assert offenders == [], (
+        "These mlx-vlm specs can still resolve to the BROKEN 0.6.4 build:\n"
+        + "\n".join(f"  [{e}] {s!r}" for e, s in offenders)
+        + "\n\n0.6.4 has a broken qwen3_5 GatedDeltaNet SSM forward and is "
+        "the current PyPI latest with no fix, so a bare `>=0.6.3` installs "
+        "it on a fresh venv. Add `!=0.6.4` to each spec (or a `>=0.6.5` "
+        "floor once an upstream fix ships)."
+    )


### PR DESCRIPTION
## Why

`mlx-vlm==0.6.4` ships a **broken `qwen3_5` GatedDeltaNet SSM forward** that emits garbage — it is precisely why Bonsai 27B (a `qwen3_5` checkpoint) is served text-only via `mlx-lm` in this tree rather than through mlx-vlm.

This matters **because 0.6.4 is the current PyPI latest with no 0.6.5 fix**, so our bare `mlx-vlm>=0.6.3` floor resolves a fresh `pip install 'rapid-mlx[vision]'` *straight to the broken wheel*. That is a silent fresh-user trap: vision/dflash boots would produce garbage with no obvious cause. We exclude the known-bad build at the dependency layer so no user can install into it.

## Fix

Pin `>=0.6.3,!=0.6.4` across **all five extras** that pull mlx-vlm:

| Extra | pyproject line |
|---|---|
| `vision` | 127 |
| `dflash` | 141 |
| `all` | 191 |
| `test` | 244 (Darwin-gated) |
| `dev` | 259 (Darwin-gated) |

## Regression guard

Adds `test_all_mlx_vlm_specs_exclude_broken_064` to `tests/test_vision_extra_install.py`. It walks **every** `[project.optional-dependencies]` extra (not a hard-coded list) and asserts each mlx-vlm spec cannot resolve to 0.6.4 — so a *new* extra that adds mlx-vlm without the exclusion is caught at CI time instead of by a user's broken boot.

The admits-0.6.4 check uses full PEP 440 semantics via `packaging` (`Requirement(spec).specifier.contains(Version("0.6.4"))`), **not** a substring match — a naive `"!=0.6.4" in spec` would be fooled by `!=0.6.4.1` (excludes 0.6.4.1 yet still admits 0.6.4). It also transparently accepts a future `>=0.6.5` floor after an upstream fix, with no test edit.

Mirrors upstream [waybarrios/vllm-mlx#633](https://github.com/waybarrios/vllm-mlx/pull/633) for our rebranded tree.

## Test plan

- [x] `pytest tests/test_vision_extra_install.py -q` → **12 passed** (11 existing L-07 lock-ins + 1 new)
- [x] `full_unit` under pr_validate → **12910 passed, 17 skipped, 6 xfailed** (no regressions)
- [x] Negative-tested the `_spec_excludes_064` helper incl. the `!=0.6.4.1` trap: bare `>=0.6.3` / `==0.6.4` / `>=0.6.4` / `!=0.6.4.1` → all correctly flagged as NOT excluding 0.6.4; `!=0.6.4` / `>=0.6.5` → correctly accepted
- [x] `grep 'mlx-vlm>=0.6.3' pyproject.toml` → all 5 hits carry `,!=0.6.4`, no bare floor remains
- [x] `stress_e2e_bench` intentionally skipped (`PR_VALIDATE_NO_STRESS=1`): this PR has **zero runtime-code changes** (dependency floor + test only), and the step's model-boot matrix cannot run while an operator service holds port 8451 (the step correctly refuses to clobber it). Not a hidden red — full_unit above covers the entire relevant surface.