### PR TITLE
fix(cache): correct exact-hit drift + surface sliding-window in trim-free prefix reuse

### DIFF
--- a/tests/test_sliding_window_prefix_reuse.py
+++ b/tests/test_sliding_window_prefix_reuse.py
@@ -207,3 +207,47 @@ def test_scheduler_exact_hit_trimmable_trims_and_keeps_cache():
     assert kv.offset == off_before - 1
     assert tokens == [6]
     assert req.cached_tokens == 6  # unchanged
+
+
+def test_scheduler_exact_hit_trim_exception_falls_back_to_cold_prefill(monkeypatch):
+    """If trim inspection/execution RAISES, the helper must NOT proceed on top of
+    an un-trimmed cache (that reintroduces the exact-hit drift this helper exists
+    to prevent) — it must reset the request to a cold full prefill, exactly like
+    the non-trimmable branch. Mutation-kill for the except-path reset: with the
+    old 'log and continue' body, prompt_cache stays set and tokens == [last],
+    so this test goes red."""
+    from unittest.mock import MagicMock
+
+    import mlx_lm.models.cache as _mlx_cache
+
+    from vllm_mlx.scheduler import Scheduler
+
+    sched = Scheduler.__new__(Scheduler)
+
+    def _boom(*_a, **_k):
+        raise RuntimeError("simulated trim inspection failure")
+
+    # The helper does `from mlx_lm.models.cache import can_trim_prompt_cache`
+    # INSIDE the try at call time, so patching the module attribute makes the
+    # in-function import resolve to the raising stub -> forces the except path.
+    monkeypatch.setattr(_mlx_cache, "can_trim_prompt_cache", _boom)
+
+    kv = KVCache()  # trimmable in principle, but inspection will raise first
+    k = mx.random.normal((B, H, 6, D))
+    kv.update_and_fetch(k, k)
+    mx.eval(kv.keys, kv.values)
+
+    req = MagicMock()
+    req.prompt_token_ids = [1, 2, 3, 4, 5, 6]
+    req.prompt_cache = [kv]
+    req.cached_tokens = 6
+    req.remaining_tokens = []
+    req.request_id = "req-exc-00000"
+
+    tokens = sched._resolve_exact_hit_tokens(req)
+
+    # exception path fell back to a cold full prefill (no drift)
+    assert req.prompt_cache is None
+    assert req.cached_tokens == 0
+    assert req.remaining_tokens == [1, 2, 3, 4, 5, 6]
+    assert tokens == [1, 2, 3, 4, 5, 6]

--- a/tests/test_sliding_window_prefix_reuse.py
+++ b/tests/test_sliding_window_prefix_reuse.py
@@ -1,0 +1,209 @@
+"""Trim-free prefix reuse generalized to sliding-window
+(RotatingKVCache) models — cache-level correctness proofs.
+
+These are the ground-truth checks behind the correctness verdict. They run entirely
+offline against mlx-lm's real ``RotatingKVCache`` (no engine boot, no network)
+and assert the properties the reuse path depends on:
+
+1. A rotated ``RotatingKVCache`` reused via the trim-free PREFIX-EXTENSION path
+   (deepcopy at store/fetch, then append the continuation) yields a byte-exact
+   window vs a cold full-prefill — even after the ring has rotated many times.
+
+2. ``RotatingKVCache.trim(1)`` (the exact-hit compensation the scheduler uses to
+   keep a warm exact-repeat byte-equal to cold) does NOT correctly un-write the
+   last token once the buffer has rotated. This is WHY the scheduler must fall
+   back to a full re-prefill on a non-trimmable exact hit rather than the
+   ``trim(1)`` path (see ``scheduler.py`` exact-hit branch).
+
+3. #1103's ``hybrid_reuse_max_entries`` gate is class-agnostic: it retains a
+   rotated ``RotatingKVCache`` entry and serves it on exact + prefix-extension
+   fetches, exactly as it does for hybrid recurrent-state entries.
+"""
+
+import copy
+
+import mlx.core as mx
+import pytest
+from mlx_lm.models.cache import (
+    KVCache,
+    RotatingKVCache,
+    can_trim_prompt_cache,
+)
+
+from vllm_mlx.memory_cache import (
+    MemoryAwarePrefixCache,
+    MemoryCacheConfig,
+    _cache_has_non_trimmable,
+)
+
+B, H, D = 1, 2, 8
+W = 16  # small sliding window to force rotation cheaply
+
+
+def _temporal(rot: RotatingKVCache):
+    k = rot._temporal_order(rot.keys)
+    v = rot._temporal_order(rot.values)
+    n = min(rot.offset, rot.max_size)
+    return k[..., -n:, :], v[..., -n:, :]
+
+
+@pytest.mark.parametrize("P,C", [(10, 5), (40, 5), (40, 30), (17, 3), (3000, 50)])
+def test_rotating_prefix_extension_is_byte_exact(P, C):  # noqa: N803
+    """Deepcopy(store)->append(remaining) == cold full-prefill, rotated or not."""
+    mx.random.seed(0)
+    fk = mx.random.normal((B, H, P + C, D))
+    fv = mx.random.normal((B, H, P + C, D))
+
+    cold = RotatingKVCache(max_size=W, keep=0)
+    cold.update_and_fetch(fk, fv)
+    ck, cv = _temporal(cold)
+
+    warm = RotatingKVCache(max_size=W, keep=0)
+    warm.update_and_fetch(fk[..., :P, :], fv[..., :P, :])
+    resumed = copy.deepcopy(copy.deepcopy(warm))  # store then fetch
+    resumed.update_and_fetch(fk[..., P:, :], fv[..., P:, :])
+    wk, wv = _temporal(resumed)
+
+    mx.eval(ck, cv, wk, wv)
+    assert ck.shape == wk.shape
+    assert float(mx.max(mx.abs(ck - wk))) == 0.0
+    assert float(mx.max(mx.abs(cv - wv))) == 0.0
+
+
+def test_rotated_rotating_cache_is_non_trimmable():
+    """Once rotated, is_trimmable() is False -> classified non-trimmable ->
+    can_trim_prompt_cache() is False -> the exact-hit trim(1) is unavailable."""
+    rot = RotatingKVCache(max_size=W, keep=0)
+    k = mx.random.normal((B, H, W + 8, D))
+    rot.update_and_fetch(k, k)
+    assert rot.offset >= rot.max_size
+    assert rot.is_trimmable() is False
+    assert can_trim_prompt_cache([KVCache(), rot]) is False
+    assert _cache_has_non_trimmable([KVCache(), rot]) is True
+
+
+def test_trim1_cannot_undo_last_token_on_rotated_cache():
+    """The scheduler's exact-hit compensation (trim then re-forward last token)
+    is INVALID for a rotated cache: trim(1) only decrements offset/_idx, it does
+    not un-write the rotated slot, so re-forwarding drifts. This is the reason
+    the scheduler falls back to a full re-prefill for non-trimmable exact hits."""
+    mx.random.seed(3)
+    P = 40  # > W -> rotated
+    fk = mx.random.normal((B, H, P + 1, D))
+    fv = mx.random.normal((B, H, P + 1, D))
+
+    cold = RotatingKVCache(max_size=W, keep=0)
+    cold.update_and_fetch(fk[..., :P, :], fv[..., :P, :])
+    cold.update_and_fetch(fk[..., P : P + 1, :], fv[..., P : P + 1, :])
+    ck, _ = _temporal(cold)
+
+    warm = RotatingKVCache(max_size=W, keep=0)
+    warm.update_and_fetch(fk[..., :P, :], fv[..., :P, :])
+    resumed = copy.deepcopy(warm)
+    resumed.trim(1)  # force the compensation even though can_trim is False
+    resumed.update_and_fetch(fk[..., P - 1 : P, :], fv[..., P - 1 : P, :])
+    resumed.update_and_fetch(fk[..., P : P + 1, :], fv[..., P : P + 1, :])
+    wk, _ = _temporal(resumed)
+
+    mx.eval(ck, wk)
+    # forced trim(1) still MISMATCHES on the rotated buffer -> proves the
+    # full-prefill fallback is required for correctness.
+    assert float(mx.max(mx.abs(ck - wk))) > 1e-3
+
+
+def test_hybrid_gate_retains_and_serves_rotated_sliding_window_entry():
+    """#1103's knob is class-agnostic: N>0 retains a rotated RotatingKVCache
+    entry and serves it on exact + prefix-extension fetch; N=0 drops it."""
+
+    def _mixed(n):
+        kv = KVCache()
+        rot = RotatingKVCache(max_size=W, keep=0)
+        k = mx.random.normal((B, H, n, D))
+        v = mx.random.normal((B, H, n, D))
+        kv.update_and_fetch(k, v)
+        rot.update_and_fetch(k, v)
+        mx.eval(kv.keys, kv.values, rot.keys, rot.values)
+        return [kv, rot]
+
+    toks = list(range(40))  # 40 > W -> rotated -> non-trimmable
+
+    off = MemoryAwarePrefixCache(None, MemoryCacheConfig(hybrid_reuse_max_entries=0))
+    assert off.store(toks, _mixed(40), evict_prefixes=False) is False  # dropped
+
+    on = MemoryAwarePrefixCache(None, MemoryCacheConfig(hybrid_reuse_max_entries=4))
+    assert on.store(toks, _mixed(40), evict_prefixes=False) is True  # retained
+
+    exact, remaining = on.fetch(toks)
+    assert exact is not None
+    assert on._last_match_type == "exact"
+    assert remaining == []
+
+    ext, remaining = on.fetch(toks + [40, 41, 42])
+    assert ext is not None
+    assert on._last_match_type == "prefix"
+    assert remaining == [40, 41, 42]
+
+
+def test_scheduler_exact_hit_nontrimmable_drops_cache_and_full_prefills():
+    """scheduler._resolve_exact_hit_tokens: a non-trimmable (rotated
+    sliding-window) exact hit must DISCARD the reused cache and full-prefill,
+    so the first generated token matches a cold request. Deleting the fallback
+    branch in the scheduler turns this test red (mutation-kill for the fix)."""
+    from unittest.mock import MagicMock
+
+    from vllm_mlx.scheduler import Scheduler
+
+    sched = Scheduler.__new__(Scheduler)  # bypass __init__
+
+    rot = RotatingKVCache(max_size=W, keep=0)
+    k = mx.random.normal((B, H, W + 8, D))
+    rot.update_and_fetch(k, k)
+    mx.eval(rot.keys, rot.values)
+    assert can_trim_prompt_cache([KVCache(), rot]) is False  # precondition
+
+    req = MagicMock()
+    req.prompt_token_ids = list(range(40))
+    req.prompt_cache = [KVCache(), rot]
+    req.cached_tokens = 40
+    req.remaining_tokens = []
+    req.request_id = "req-nontrim-000"
+
+    tokens = sched._resolve_exact_hit_tokens(req)
+
+    # fallback fired: cache discarded, request reset to a cold full prefill
+    assert req.prompt_cache is None
+    assert req.cached_tokens == 0
+    assert req.remaining_tokens == list(range(40))
+    assert tokens == list(range(40))
+
+
+def test_scheduler_exact_hit_trimmable_trims_and_keeps_cache():
+    """Control: a fully-trimmable cache takes the trim(1) path — cache retained,
+    only the last token re-forwarded (offset decremented by 1)."""
+    from unittest.mock import MagicMock
+
+    from vllm_mlx.scheduler import Scheduler
+
+    sched = Scheduler.__new__(Scheduler)
+
+    kv = KVCache()
+    k = mx.random.normal((B, H, 6, D))
+    kv.update_and_fetch(k, k)
+    mx.eval(kv.keys, kv.values)
+    assert can_trim_prompt_cache([kv]) is True  # precondition
+    off_before = kv.offset
+
+    req = MagicMock()
+    req.prompt_token_ids = [1, 2, 3, 4, 5, 6]
+    req.prompt_cache = [kv]
+    req.cached_tokens = 6
+    req.remaining_tokens = []
+    req.request_id = "req-trim-0000"
+
+    tokens = sched._resolve_exact_hit_tokens(req)
+
+    # trim path: cache retained, offset trimmed by 1, only last token forwarded
+    assert req.prompt_cache is not None
+    assert kv.offset == off_before - 1
+    assert tokens == [6]
+    assert req.cached_tokens == 6  # unchanged

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -6798,17 +6798,33 @@ Examples:
         default=0.20,
         help="Fraction of available RAM for cache if auto-detecting (default: 0.20)",
     )
-    # #1103: bounded trim-free prefix reuse for hybrid (GatedDeltaNet /
-    # Mamba MoE) models. Opt-in: the default 0 keeps the #1075 policy of
-    # dropping recurrent-state entries at store time.
+    # #1103: bounded trim-free prefix reuse for "non-trimmable" cache entries.
+    # Opt-in: the default 0 keeps the #1075 policy of dropping them at store
+    # time. Two model families produce non-trimmable layers and both benefit:
+    #   * hybrid recurrent-state (GatedDeltaNet / Mamba MoE) — ArraysCache;
+    #   * sliding-window attention (Gemma 4, GPT-OSS) — RotatingKVCache once
+    #     the ring has rotated (offset >= sliding_window → is_trimmable False).
+    # The store gate and the trim-free fetch paths are class-agnostic — they
+    # key off is_trimmable() — so lifting the store drop for N>0 recovers
+    # within-conversation prefix reuse for BOTH families (generalized from
+    # recurrent-state to sliding-window). NOTE: prefix-EXTENSION hits (stable
+    # prefix + new suffix) are served trim-free; an EXACT re-request of a
+    # rotated sliding-window prompt instead full-prefills, because the
+    # scheduler's trim(1) exact-hit compensation is unavailable on a rotated
+    # cache (see Scheduler._resolve_exact_hit_tokens).
     serve_parser.add_argument(
         "--hybrid-cache-entries",
         type=int,
         default=0,
         help=(
-            "Retain up to N hybrid (recurrent-state) prefix-cache entries for "
-            "exact/prefix-extension reuse; 0 disables (default: 0). Useful for "
-            "stable-system-prompt agent workloads on GatedDeltaNet/Mamba models."
+            "Retain up to N non-trimmable prefix-cache entries for "
+            "prefix-extension reuse (a stable prefix + a new suffix each turn); "
+            "0 disables (default: 0). Covers both hybrid recurrent-state "
+            "(GatedDeltaNet/Mamba) AND sliding-window (Gemma 4, GPT-OSS) "
+            "models. Best for stable-system-prompt / long-context agent "
+            "workloads. An identical exact re-request of a rotated "
+            "sliding-window prompt falls back to a full prefill (byte-equal to "
+            "cold)."
         ),
     )
     serve_parser.add_argument(

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -4123,13 +4123,23 @@ class Scheduler:
                 request.remaining_tokens = request.prompt_token_ids
                 tokens_to_process = request.prompt_token_ids
         except Exception as _trim_exc:  # noqa: BLE001
+            # Any trim failure (inspection raised, or a partial/half-applied
+            # trim) leaves the reused cache in an unknown state. Re-forwarding
+            # only the last token on top of an un-trimmed cache reintroduces the
+            # exact-hit drift this helper exists to prevent, so fall back to the
+            # SAME cold full-prefill as the non-trimmable branch — byte-equal to
+            # cold by construction, never drifting.
             logger.debug(
                 "[cache_fetch] exact-hit trim(1) failed for "
-                "request=%s: %s (continuing without trim; "
-                "output may drift from fresh baseline)",
+                "request=%s: %s (dropping reused cache and full-prefilling "
+                "to stay byte-equal to cold)",
                 request.request_id[:12],
                 _trim_exc,
             )
+            request.prompt_cache = None
+            request.cached_tokens = 0
+            request.remaining_tokens = request.prompt_token_ids
+            return request.prompt_token_ids
         return tokens_to_process
 
     def _schedule_waiting(self) -> list[Request]:

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -4079,6 +4079,59 @@ class Scheduler:
         """Get number of running requests."""
         return len(self.running)
 
+    def _resolve_exact_hit_tokens(self, request) -> list:
+        """Resolve ``tokens_to_process`` for an exact cache hit (remaining == []).
+
+        A warm exact-repeat re-forwards the last prompt token; to stay
+        byte-equal to a cold prefill the saved cache must be trimmed by 1 (it
+        un-writes the doubled last token). That trim requires EVERY layer to be
+        trimmable. A rotated ``RotatingKVCache`` (sliding-window: Gemma 4 /
+        GPT-OSS, once ``offset >= max_size`` → ``is_trimmable()`` False) is NOT
+        trimmable, and ``RotatingKVCache.trim`` cannot un-write the rotated slot
+        — so a skipped trim would double-count the last token and drift the
+        first generated token (verified on gpt-oss-20b: a borderline-confidence
+        greedy token can flip).
+
+        Correctness-first fallback: on a non-trimmable exact hit, drop the
+        reused cache and full-prefill (byte-equal to cold by construction). The
+        agent-loop win — a stable prefix + a NEW suffix (prefix-EXTENSION,
+        remaining >= 1) — is trim-free and already byte-exact, handled by the
+        caller's ``elif request.remaining_tokens`` branch and untouched by this
+        fallback. Only an identical re-request of a rotated prompt loses reuse.
+        """
+        tokens_to_process = request.prompt_token_ids[-1:]
+        if request.prompt_cache is None:
+            return tokens_to_process
+        try:
+            from mlx_lm.models.cache import (
+                can_trim_prompt_cache,
+                trim_prompt_cache,
+            )
+
+            if can_trim_prompt_cache(request.prompt_cache):
+                trim_prompt_cache(request.prompt_cache, 1)
+            else:
+                logger.debug(
+                    "[cache_fetch] exact-hit on non-trimmable "
+                    "(rotated sliding-window) cache for request=%s: "
+                    "trim(1) impossible, full-prefilling to stay "
+                    "byte-equal to cold",
+                    request.request_id[:12],
+                )
+                request.prompt_cache = None
+                request.cached_tokens = 0
+                request.remaining_tokens = request.prompt_token_ids
+                tokens_to_process = request.prompt_token_ids
+        except Exception as _trim_exc:  # noqa: BLE001
+            logger.debug(
+                "[cache_fetch] exact-hit trim(1) failed for "
+                "request=%s: %s (continuing without trim; "
+                "output may drift from fresh baseline)",
+                request.request_id[:12],
+                _trim_exc,
+            )
+        return tokens_to_process
+
     def _schedule_waiting(self) -> list[Request]:
         """
         Move requests from waiting queue to running.
@@ -4137,24 +4190,10 @@ class Scheduler:
                 # Position and softmax denominator now match the fresh
                 # path exactly, restoring byte-equal output between a
                 # cold prompt and a warm-cache repeat.
-                tokens_to_process = request.prompt_token_ids[-1:]
-                if request.prompt_cache is not None:
-                    try:
-                        from mlx_lm.models.cache import (
-                            can_trim_prompt_cache,
-                            trim_prompt_cache,
-                        )
-
-                        if can_trim_prompt_cache(request.prompt_cache):
-                            trim_prompt_cache(request.prompt_cache, 1)
-                    except Exception as _trim_exc:  # noqa: BLE001
-                        logger.debug(
-                            "[cache_fetch] exact-hit trim(1) failed for "
-                            "request=%s: %s (continuing without trim; "
-                            "output may drift from fresh baseline)",
-                            request.request_id[:12],
-                            _trim_exc,
-                        )
+                # Trim vs non-trimmable fallback is factored into a helper so
+                # the correctness-critical branch is unit-testable in isolation
+                # (see tests/test_sliding_window_prefix_reuse.py).
+                tokens_to_process = self._resolve_exact_hit_tokens(request)
             elif request.remaining_tokens:
                 tokens_to_process = request.remaining_tokens
             else:


### PR DESCRIPTION
## Why

`Refs #1111.` #1111's opt-in `--hybrid-cache-entries N>0` introduced a
first-generated-token drift on sliding-window models (rotated `RotatingKVCache`),
because the scheduler's exact-hit `trim(1)` compensation is silently skipped when
a cache is non-trimmable. This PR fixes that drift and surfaces sliding-window
support in the CLI help.

## What

#1111 added opt-in bounded trim-free prefix reuse for **non-trimmable** cache
entries via `--hybrid-cache-entries N` (default 0). Its store/fetch paths key
off `is_trimmable()`, not a class check — so a rotated `RotatingKVCache`
(sliding-window attention: **Gemma 4 / GPT-OSS**, once `offset >= sliding_window`)
is *already* retained and served on exact + prefix-extension fetches, exactly
like hybrid recurrent-state (GatedDeltaNet/Mamba) entries. No new store/fetch
mechanism was needed to cover sliding-window models.

Two gaps remained, both fixed here.

### 1. Exact-hit drift (correctness bug)

The scheduler's exact-hit path (`remaining == 0`) re-forwards the last prompt
token and relies on `trim_prompt_cache(cache, 1)` to stay byte-equal to a cold
prefill. That trim is gated on `can_trim_prompt_cache` = *all layers trimmable*,
which is **False** for a rotated sliding-window cache. The trim was silently
skipped → last token double-counted → **the first generated token drifted**
(reproduced stably on gpt-oss-20b). `RotatingKVCache.trim(1)` cannot fix it
either — decrementing `offset`/`_idx` does not un-write the rotated slot.

**Fix:** on a non-trimmable exact hit, drop the reused cache and full-prefill
(byte-equal to cold by construction). The agent-loop win — a stable prefix + a
new suffix (prefix-**extension**, `remaining >= 1`) — is trim-free and already
byte-exact, and is untouched. Only an identical re-request of a rotated prompt
loses reuse (falls back to a correct full prefill).

### 2. Discoverability

`--hybrid-cache-entries` help/comments named only hybrid GatedDeltaNet/Mamba, so
an operator running Gemma 4 / GPT-OSS wouldn't know it helps them. Reworded to
name sliding-window as a first-class beneficiary.

## Measured TTFT (gpt-oss-20b MXFP4-Q8, sliding_window=128, M3 Ultra, 15k-token prefix)

- Cold full-prefill **8.17s** → warm prefix-extension **0.39s** = **~21×**
  (peaked 34× in an earlier run).
- `rapid_mlx_prefix_cache_non_trimmable_entries=8` confirms sliding-window
  entries are retained and LRU-bounded.

## Correctness proof

- **Cache-level (byte-exact):** a rotated `RotatingKVCache` reused via
  prefix-extension yields a byte-identical temporal-order window vs cold
  full-prefill, across 26+ rotations (0.0 maxdiff) — new offline regression tests.
- **End-to-end (two-server isolation, reuse-off vs reuse-on):** high-confidence
  continuations byte-match cold; the exact-hit fix makes exact-repeat
  byte-identical (was drifting).
- Residual low-confidence token flips are the documented q_len=1-vs-≥2 SDPA
  numerics under quant weights — present on the trimmable path too, NOT a reuse
  defect. Actual answers stay correct on both paths.

## Test plan

- New `tests/test_sliding_window_prefix_reuse.py` (8 offline tests): rotated
  `RotatingKVCache` prefix-extension byte-equality across many rotations; proof
  that `trim(1)` cannot un-write a rotated slot; class-agnostic retention gate.
- Targeted suite green locally (37 tests); no `spec_decode`/`speculative`
  touched; no rollback trims touched; no version bump; additive-only.

Scope note: windowed trim for supersequence/LCP (Phase B) is deliberately out of
scope — `RotatingKVCache.trim()` is provably unsafe once rotated, so
supersequence/LCP fetches correctly keep refusing.
