### PR TITLE
fix(cache): explicit disk import must not be dropped by prefix-reuse retention bound (#1111 regression)

### DIFF
--- a/tests/test_cache_routes.py
+++ b/tests/test_cache_routes.py
@@ -3155,6 +3155,54 @@ def test_base_engine_load_result_default_tolerates_old_one_arg_signature():
 
     assert _KwargsEngine().load_cache_with_result("/tmp/x", replace=True).entries == 1
 
+    # #1111 codex r4: forwarding of ``protected_import`` must be DECOUPLED from
+    # ``replace`` acceptance. An engine that accepts ``protected_import`` but NOT
+    # ``replace`` must still receive a non-default ``protected_import=False`` —
+    # the old nested-under-``accepts_replace`` code silently dropped it.
+    class _ProtectedOnlyEngine(BaseEngine):
+        locals().update(_stubs)
+
+        def __init__(self):
+            self.saw_protected = "unset"
+
+        def load_cache_from_disk(self, cache_dir, protected_import: bool = True):
+            self.saw_protected = protected_import
+            return 5
+
+    p = _ProtectedOnlyEngine()
+    # replace left at default (False) → dropped silently; protected_import=False
+    # is non-default and MUST be forwarded even though replace isn't accepted.
+    assert (
+        p.load_cache_with_result(
+            "/tmp/x", replace=False, protected_import=False
+        ).entries
+        == 5
+    )
+    assert p.saw_protected is False, (
+        "protected_import must forward independently of replace acceptance"
+    )
+
+    # Symmetric case: accepts ``replace`` but NOT ``protected_import``. A
+    # non-default protected_import=False can't be honored → fail loudly rather
+    # than silently upgrade to protected (which would re-open the growth bug).
+    class _ReplaceOnlyEngine(BaseEngine):
+        locals().update(_stubs)
+
+        def load_cache_from_disk(self, cache_dir, replace: bool = False):
+            return 9
+
+    with pytest.raises(TypeError, match="protected_import"):
+        _ReplaceOnlyEngine().load_cache_with_result(
+            "/tmp/x", replace=True, protected_import=False
+        )
+    # But the DEFAULT protected_import=True is fine to drop silently.
+    assert (
+        _ReplaceOnlyEngine()
+        .load_cache_with_result("/tmp/x", replace=True, protected_import=True)
+        .entries
+        == 9
+    )
+
 
 def test_read_committed_cache_counts_rejects_malformed_index_fail_closed(tmp_path):
     """#1100 codex round 7 (#3): ``_read_committed_cache_counts`` must FAIL

--- a/tests/test_engine_step_thread.py
+++ b/tests/test_engine_step_thread.py
@@ -127,10 +127,14 @@ class TestStepThread:
 
         captured = {}
 
-        def fake_load(cache_dir, replace=False):
+        # #1111 codex r3: ``protected_import`` is threaded to the scheduler
+        # alongside ``replace``; ``fake_load`` accepts AND records it so this
+        # routing test also guards the new kwarg's passthrough.
+        def fake_load(cache_dir, replace=False, protected_import=True):
             captured["thread"] = threading.current_thread().name
             captured["cache_dir"] = cache_dir
             captured["replace"] = replace
+            captured["protected_import"] = protected_import
             return 17
 
         engine_core.scheduler.load_cache_from_disk.side_effect = fake_load
@@ -138,10 +142,12 @@ class TestStepThread:
         await engine_core.start()
         try:
             # Default (merge) path: replace defaults to False and still routes
-            # to the worker.
+            # to the worker. protected_import defaults True (explicit-import
+            # semantics).
             assert engine_core.load_cache_from_disk("/tmp/whatever") == 17
             assert captured["cache_dir"] == "/tmp/whatever"
             assert captured["replace"] is False
+            assert captured["protected_import"] is True
             assert captured["thread"].startswith("mlx-step")
 
             # Explicit replace=True must be forwarded through to the scheduler
@@ -150,6 +156,16 @@ class TestStepThread:
             assert engine_core.load_cache_from_disk("/tmp/other", replace=True) == 17
             assert captured["cache_dir"] == "/tmp/other"
             assert captured["replace"] is True
+            assert captured["thread"].startswith("mlx-step")
+
+            # The STARTUP auto-load passes protected_import=False; it must be
+            # forwarded through to the scheduler on the worker thread too.
+            assert (
+                engine_core.load_cache_from_disk("/tmp/boot", protected_import=False)
+                == 17
+            )
+            assert captured["cache_dir"] == "/tmp/boot"
+            assert captured["protected_import"] is False
             assert captured["thread"].startswith("mlx-step")
         finally:
             await engine_core.stop()

--- a/tests/test_hybrid_prefix_cache_growth.py
+++ b/tests/test_hybrid_prefix_cache_growth.py
@@ -613,10 +613,19 @@ def test_persistent_load_respects_hybrid_bound(tmp_path):
     assert loaded == 1
 
 
-def test_persistent_load_drops_all_when_disabled(tmp_path):
-    """Reloading with N=0 (the default / disabled state) must drop ALL non-
-    trimmable entries — byte-for-byte the #1075 drop-at-store behavior applied
-    after a restart. This is the core "default is unchanged" guarantee."""
+def test_persistent_load_retains_all_when_disabled(tmp_path):
+    """#1111 regression: reloading with N=0 (the default / disabled state) is an
+    EXPLICIT import, so it must RETAIN every imported non-trimmable entry — the
+    retention bound does not gate an operator's deliberate disk import (#476).
+
+    ``hybrid_reuse_max_entries`` governs opportunistic within-session prefix
+    reuse at STORE time; N=0 disables that opportunistic retention. It does NOT
+    mean "reject an explicit disk import". #1111 wrongly gated the load commit
+    on N <= 0, so a default-config import dropped its own entries and reported
+    ``entries_loaded == 0``. The store-path #1075 anti-leak drop is unaffected —
+    the live-store loop still drops non-trimmable entries at N=0 (guarded by
+    ``test_hybrid_store_is_dropped`` / ``test_default_config_keeps_drop_policy``
+    above)."""
     cache_dir = _persist_three_hybrid_entries(tmp_path)
 
     dst_config = MemoryCacheConfig(
@@ -626,16 +635,18 @@ def test_persistent_load_drops_all_when_disabled(tmp_path):
     loaded = dst.load_from_disk(cache_dir, replace=True)
 
     stats = dst.get_stats()
-    assert stats["non_trimmable_entries"] == 0, (
-        "With reuse disabled, a restart must retain NO non-trimmable entries"
+    assert stats["non_trimmable_entries"] == 3, (
+        "An explicit import must retain all imported non-trimmable entries "
+        "even with opportunistic retention disabled (N=0)"
     )
-    assert len(dst._entries) == 0
-    assert loaded == 0
+    assert len(dst._entries) == 3
+    assert loaded == 3
 
 
-def test_persistent_load_keeps_trimmable_entries_when_disabled(tmp_path):
-    """The disabled-state drop is scoped to NON-trimmable entries only — a
-    persisted dense (all-KVCache) entry must still reload normally with N=0."""
+def test_persistent_load_keeps_both_kinds_when_disabled(tmp_path):
+    """#1111 regression: an explicit import with N=0 must reload BOTH a dense
+    (trimmable KVCache) entry AND a hybrid (non-trimmable ArraysCache) entry —
+    the retention bound gates neither on the explicit disk-import path."""
     import mlx.core as mx
     from mlx_lm.models.cache import KVCache
 
@@ -652,8 +663,9 @@ def test_persistent_load_keeps_trimmable_entries_when_disabled(tmp_path):
     mx.eval(dense.state)
     dense_key = list(range(500, 508))
     assert src.store(dense_key, [dense]) is True
-    # One hybrid entry too, so we can prove the drop is selective.
-    src.store(list(range(1000, 1008)), _real_hybrid_cache())
+    # One hybrid entry too, so we can prove the reload covers both kinds.
+    hybrid_key = list(range(1000, 1008))
+    src.store(hybrid_key, _real_hybrid_cache())
 
     cache_dir = str(tmp_path / "snap")
     assert src.save_to_disk(cache_dir) is True
@@ -664,9 +676,14 @@ def test_persistent_load_keeps_trimmable_entries_when_disabled(tmp_path):
     dst = MemoryAwarePrefixCache(MagicMock(), dst_config)
     dst.load_from_disk(cache_dir, replace=True)
 
-    assert dst.get_stats()["non_trimmable_entries"] == 0
+    assert dst.get_stats()["non_trimmable_entries"] == 1, (
+        "The hybrid (non-trimmable) entry must survive an N=0 explicit import"
+    )
     assert tuple(dense_key) in dst._entries, (
         "Dense (trimmable) entries must survive an N=0 reload"
+    )
+    assert tuple(hybrid_key) in dst._entries, (
+        "Hybrid (non-trimmable) entries must survive an N=0 explicit import"
     )
 
 
@@ -712,3 +729,36 @@ def test_merge_load_into_full_hybrid_cache_counts_only_imported(tmp_path):
     assert tuple(range(9000, 9008)) not in dst._entries
     # loaded_bytes ledger must stay coherent (non-negative, matches survivor).
     assert dst._last_load_bytes > 0
+
+
+def test_load_bound_seam_disabled_retains_but_positive_bound_trims(tmp_path):
+    """#1111 regression guard — pins the exact seam of the fix: the SAME 3-entry
+    snapshot imported under N=0 vs N=2 must yield DIFFERENT retention.
+
+    * N=0 (retention disabled): an explicit import retains ALL 3 non-trimmable
+      entries — the retention bound does not gate the disk-import path.
+    * N>0 (retention enabled): the load path still LRU-trims the reloaded
+      snapshot down to N, so #1111's bounded guarantee holds on reload.
+
+    A test-targeted "always keep on load" hack would make the N=2 arm keep 3;
+    the store-path-parity hack #1111 shipped would make the N=0 arm keep 0.
+    Only the intended seam (bound applies on load iff N>0) passes both arms."""
+    cache_dir = _persist_three_hybrid_entries(tmp_path)
+
+    disabled = MemoryAwarePrefixCache(
+        MagicMock(),
+        MemoryCacheConfig(
+            max_memory_mb=100, max_entries=64, hybrid_reuse_max_entries=0
+        ),
+    )
+    assert disabled.load_from_disk(cache_dir, replace=True) == 3
+    assert disabled.get_stats()["non_trimmable_entries"] == 3
+
+    bounded = MemoryAwarePrefixCache(
+        MagicMock(),
+        MemoryCacheConfig(
+            max_memory_mb=100, max_entries=64, hybrid_reuse_max_entries=2
+        ),
+    )
+    assert bounded.load_from_disk(cache_dir, replace=True) == 2
+    assert bounded.get_stats()["non_trimmable_entries"] == 2

--- a/tests/test_hybrid_prefix_cache_growth.py
+++ b/tests/test_hybrid_prefix_cache_growth.py
@@ -891,18 +891,28 @@ def test_startup_reload_cycle_does_not_grow_protected_set(tmp_path):
     def _snapshot_of_live_cache(cache, out_dir):
         assert cache.save_to_disk(out_dir) is True
 
-    # Persist an initial snapshot of N opportunistic hybrid entries (stored
-    # under a generous bound so they all land on disk unprotected).
+    def _hybrid_keys(cache):
+        # Non-trimmable keys in LRU order (OrderedDict insertion order).
+        return [key for key, e in cache._entries.items() if e.non_trimmable]
+
+    # Persist an initial snapshot of THREE opportunistic hybrid entries (stored
+    # under a generous bound so they all land on disk unprotected). Three (> n)
+    # so the reload genuinely has to trim, not merely fit.
     seed = MemoryAwarePrefixCache(
         MagicMock(),
         MemoryCacheConfig(
             max_memory_mb=200, max_entries=64, hybrid_reuse_max_entries=9
         ),
     )
-    for base in (100, 200):
+    for base in (100, 200, 300):
         assert seed.store(list(range(base, base + 8)), _real_hybrid_cache())
     snap = str(tmp_path / "snap")
     _snapshot_of_live_cache(seed, snap)
+    # Track the persisted hybrid-key order in Python state (mirrors what is on
+    # disk). save_to_disk writes _entries in LRU order, so this is the exact
+    # persisted order the reload will see. On cycle 0 = the 3-entry seed.
+    persisted_keys = _hybrid_keys(seed)
+    assert len(persisted_keys) == 3
 
     # Simulate restart cycles: each boot reloads the persisted snapshot as the
     # STARTUP path does (protected_import=False), then live-stores one fresh
@@ -914,26 +924,92 @@ def test_startup_reload_cycle_does_not_grow_protected_set(tmp_path):
                 max_memory_mb=200, max_entries=64, hybrid_reuse_max_entries=n
             ),
         )
+        # The reload must retain EXACTLY min(persisted, n).
+        expected_retained = min(len(persisted_keys), n)
+
         # STARTUP auto-load — reloaded entries must be UNPROTECTED.
         booted.load_from_disk(snap, replace=True, protected_import=False)
+
         # No reloaded entry may be protected (they are opportunistic on disk).
         assert not any(e.protected for e in booted._entries.values()), (
             "startup-reloaded entries must be UNPROTECTED (protected_import=False)"
         )
+
+        reloaded_keys = _hybrid_keys(booted)
+        # (a) NOT "keeps too many" (growth): retained == min(persisted, n).
+        # (b) NOT "keeps nothing" (discard-all): expected_retained is > 0 here,
+        #     so a reload that dropped everything would violate this equality.
+        assert len(reloaded_keys) == expected_retained, (
+            f"cycle {cycle}: reload retained {len(reloaded_keys)} non-trimmable, "
+            f"expected exactly min(persisted={len(persisted_keys)}, n={n})="
+            f"{expected_retained} — either grew (protected bug) or discarded all"
+        )
+        # (c) The survivors are the MOST-RECENT n persisted keys (LRU keeps the
+        #     tail of the persisted order). Pins WHICH entries survived, not just
+        #     the count, so a reload that keeps the wrong (or zero) set fails.
+        assert reloaded_keys == persisted_keys[-expected_retained:], (
+            f"cycle {cycle}: survivors {reloaded_keys} are not the most-recent "
+            f"{expected_retained} persisted keys {persisted_keys[-expected_retained:]}"
+        )
+
         # A fresh opportunistic hybrid request this session.
         booted.store(
             list(range(1000 + cycle * 10, 1000 + cycle * 10 + 8)),
             _real_hybrid_cache(),
         )
-        # THE INVARIANT: the retained non-trimmable set never exceeds the bound,
-        # no matter how many restart cycles have accumulated on disk.
+        # THE INVARIANT after the fresh store: still bounded at N, never growing
+        # across accumulated restart cycles.
         retained = booted.get_stats()["non_trimmable_entries"]
-        assert retained <= n, (
-            f"cycle {cycle}: retained non-trimmable {retained} exceeds bound {n} "
+        assert retained == n, (
+            f"cycle {cycle}: retained non-trimmable {retained} != bound {n} "
             "— the startup-reload protected-set growth bug regressed"
         )
-        # Persist the live cache for the next boot (mirrors shutdown).
+        # Persist the live cache for the next boot (mirrors shutdown) and update
+        # the tracked persisted order to what actually got written.
         _snapshot_of_live_cache(booted, snap)
+        persisted_keys = _hybrid_keys(booted)
+
+
+def test_production_startup_wiring_passes_protected_import_false(tmp_path):
+    """#1111 codex r4 BLOCKING-1: pin the PRODUCTION startup wiring, not just
+    the ``load_from_disk`` primitive.
+
+    The growth-prevention guarantee only holds if the real startup entry point
+    ``runtime.cache.load_prefix_cache_from_disk()`` actually passes
+    ``protected_import=False`` down to the engine. The lower-level tests call
+    ``load_from_disk(..., protected_import=False)`` directly, so they stay green
+    even if ``runtime/cache.py`` stops passing ``False``. This test drives the
+    real production call site with a mocked engine and asserts the kwarg.
+
+    Mutation-kill: delete ``protected_import=False`` from
+    ``runtime/cache.py::load_prefix_cache_from_disk`` and this test FAILS.
+    """
+    from unittest.mock import MagicMock as _MagicMock
+    from unittest.mock import patch
+
+    import vllm_mlx.runtime.cache as runtime_cache
+
+    fake_engine = _MagicMock()
+    fake_engine.load_cache_from_disk.return_value = 0  # no entries; wiring only
+    fake_cfg = _MagicMock()
+    fake_cfg.engine = fake_engine
+
+    with (
+        patch.object(runtime_cache, "get_config", return_value=fake_cfg),
+        patch.object(runtime_cache, "get_cache_dir", return_value=str(tmp_path)),
+        # _load_radix_index_after_cache pokes the engine internals; the mock has
+        # no real scheduler, so stub it out — this test is about the load kwarg.
+        patch.object(runtime_cache, "_load_radix_index_after_cache"),
+    ):
+        runtime_cache.load_prefix_cache_from_disk()
+
+    fake_engine.load_cache_from_disk.assert_called_once()
+    _args, kwargs = fake_engine.load_cache_from_disk.call_args
+    assert kwargs.get("protected_import") is False, (
+        "startup auto-load must call load_cache_from_disk(protected_import=False) "
+        "— otherwise reloaded opportunistic entries are immortalized as protected "
+        "and the retention bound grows unbounded across restarts"
+    )
 
 
 def test_startup_reload_obeys_bound_while_explicit_import_pins(tmp_path):

--- a/tests/test_hybrid_prefix_cache_growth.py
+++ b/tests/test_hybrid_prefix_cache_growth.py
@@ -691,53 +691,67 @@ def test_persistent_load_keeps_both_kinds_when_disabled(tmp_path):
     )
 
 
-def test_merge_load_evicts_opportunistic_not_imported(tmp_path):
-    """#1111 regression: merge-loading (replace=False) an imported entry into a
-    cache that already holds OPPORTUNISTIC entries AT the bound must evict the
-    OPPORTUNISTIC (unprotected) one, never the imported (protected) one, and
-    report ``loaded == 1``.
+def test_store_after_import_evicts_oldest_opportunistic_not_import(tmp_path):
+    """#1111 regression: with a protected import present, live-storing MORE
+    opportunistic hybrid entries than the bound allows must GENUINELY evict the
+    OLDEST opportunistic (unprotected) entry — never the protected import.
 
     Ports SGLang's protected/evictable split: the retention bound acts on the
-    evictable (opportunistic live-store #1075) set ONLY. The imported entry is
-    protected, so it survives; a pre-existing OPPORTUNISTIC entry above the
-    bound is the LRU victim. That eviction belongs to the destination, not this
-    import, so it must NOT be subtracted from the import's ``loaded`` tally (the
-    reconciliation loop only nets ``staged`` victims — and imports are never
-    victims).
+    evictable (opportunistic live-store #1075) set ONLY. This test forces real
+    eviction: under N=2 it stores THREE opportunistic entries, so the 3rd store
+    pushes the evictable set over the bound and the enforcer LRU-evicts the
+    oldest opportunistic entry. The protected import is excluded from the
+    candidate set (SGLang ``evictable_leaves`` skips ``lock_ref > 0`` nodes), so
+    it survives while the bound still holds at N=2 over opportunistic entries.
     """
-    # Snapshot on disk: a single NEW hybrid entry to import.
-    src_config = MemoryCacheConfig(
-        max_memory_mb=100, max_entries=64, hybrid_reuse_max_entries=9
+    # Snapshot on disk: a single NEW hybrid entry to import (becomes protected).
+    src = MemoryAwarePrefixCache(
+        MagicMock(),
+        MemoryCacheConfig(
+            max_memory_mb=100, max_entries=64, hybrid_reuse_max_entries=9
+        ),
     )
-    src = MemoryAwarePrefixCache(MagicMock(), src_config)
     assert src.store(list(range(7000, 7008)), _real_hybrid_cache()) is True
     cache_dir = str(tmp_path / "snap")
     assert src.save_to_disk(cache_dir) is True
 
-    # Destination already holds TWO pre-existing OPPORTUNISTIC (unprotected)
-    # hybrid entries under N=2, so it is FULL of evictable entries before the
-    # import. These were stored live, so ``protected`` is False.
-    dst_config = MemoryCacheConfig(
-        max_memory_mb=100, max_entries=64, hybrid_reuse_max_entries=2
+    dst = MemoryAwarePrefixCache(
+        MagicMock(),
+        MemoryCacheConfig(
+            max_memory_mb=100, max_entries=64, hybrid_reuse_max_entries=2
+        ),
     )
-    dst = MemoryAwarePrefixCache(MagicMock(), dst_config)
+    # Import first: the protected entry.
+    assert dst.load_from_disk(cache_dir, replace=False) == 1
+    import_key = tuple(range(7000, 7008))
+    assert dst._entries[import_key].protected
+
+    # Now store THREE opportunistic entries under the N=2 bound. Each store
+    # fires the enforcer; the 3rd store pushes the EVICTABLE set to 3 > 2, so
+    # the oldest opportunistic entry (9000) is genuinely LRU-evicted.
     assert dst.store(list(range(9000, 9008)), _real_hybrid_cache()) is True
     assert dst.store(list(range(9100, 9108)), _real_hybrid_cache()) is True
-    assert dst.get_stats()["non_trimmable_entries"] == 2
-    assert not dst._entries[tuple(range(9000, 9008))].protected
+    assert dst.store(list(range(9200, 9208)), _real_hybrid_cache()) is True
 
-    loaded = dst.load_from_disk(cache_dir, replace=False)
-
-    # The import is protected -> survives regardless of the bound. The bound's
-    # evictable set is now the 2 opportunistic entries (imports excluded);
-    # N=2 keeps both, so nothing is evicted and the import is purely additive.
-    assert loaded == 1, "Merge-load must count only the imported entry"
-    assert tuple(range(7000, 7008)) in dst._entries
-    assert dst._entries[tuple(range(7000, 7008))].protected
-    assert tuple(range(9000, 9008)) in dst._entries
+    # Eviction genuinely fired: the oldest opportunistic entry is GONE.
+    assert tuple(range(9000, 9008)) not in dst._entries, (
+        "the 3rd opportunistic store must LRU-evict the oldest one (bound=2)"
+    )
+    # The two newest opportunistic entries remain (bound=2 over evictable set).
     assert tuple(range(9100, 9108)) in dst._entries
-    # loaded_bytes ledger must stay coherent (non-negative, matches survivor).
-    assert dst._last_load_bytes > 0
+    assert tuple(range(9200, 9208)) in dst._entries
+    # The PROTECTED import survives the eviction that just fired.
+    assert import_key in dst._entries, (
+        "the protected import must NOT be evicted by an opportunistic store"
+    )
+    assert dst._entries[import_key].protected
+    # Bound is enforced over the EVICTABLE set only: 2 opportunistic + 1
+    # protected import = 3 non-trimmable total, but only 2 are evictable.
+    assert dst.get_stats()["non_trimmable_entries"] == 3
+    evictable = sum(
+        1 for e in dst._entries.values() if e.non_trimmable and not e.protected
+    )
+    assert evictable == 2
 
 
 def test_enforcer_never_evicts_protected_imports(tmp_path):

--- a/tests/test_hybrid_prefix_cache_growth.py
+++ b/tests/test_hybrid_prefix_cache_growth.py
@@ -592,9 +592,13 @@ def _persist_three_hybrid_entries(tmp_path) -> str:
     return cache_dir
 
 
-def test_persistent_load_respects_hybrid_bound(tmp_path):
-    """Reloading a snapshot of 3 hybrid entries with N=1 must retain only 1 —
-    the bound is applied at commit time, exactly like the store path."""
+def test_persistent_load_imports_are_protected_from_bound(tmp_path):
+    """#1111 regression (PROTECTED-entry semantics): reloading a snapshot of 3
+    hybrid entries with a LOW bound (N=1) must still retain ALL 3 — imported
+    entries are PROTECTED (SGLang ``lock_ref`` / vLLM ``ref_cnt`` idiom) and
+    exempt from the opportunistic retention bound, which governs live-store
+    entries only. The bound would otherwise LRU-trim a reloaded snapshot below
+    what the operator explicitly imported."""
     cache_dir = _persist_three_hybrid_entries(tmp_path)
 
     dst_config = MemoryCacheConfig(
@@ -604,13 +608,13 @@ def test_persistent_load_respects_hybrid_bound(tmp_path):
     loaded = dst.load_from_disk(cache_dir, replace=True)
 
     stats = dst.get_stats()
-    assert stats["non_trimmable_entries"] == 1, (
-        "Persistent load must LRU-trim hybrid entries down to the bound"
+    assert stats["non_trimmable_entries"] == 3, (
+        "Imported (protected) entries must survive the retention bound"
     )
-    assert len(dst._entries) == 1
-    # The reported loaded count must reflect only SURVIVING entries, not the
-    # 3 that were staged before the bound trimmed 2 away.
-    assert loaded == 1
+    assert len(dst._entries) == 3
+    assert loaded == 3
+    # All installed entries carry the protected marker.
+    assert all(e.protected for e in dst._entries.values())
 
 
 def test_persistent_load_retains_all_when_disabled(tmp_path):
@@ -687,15 +691,19 @@ def test_persistent_load_keeps_both_kinds_when_disabled(tmp_path):
     )
 
 
-def test_merge_load_into_full_hybrid_cache_counts_only_imported(tmp_path):
-    """#1103 codex BLOCKING-1: merge-loading (replace=False) ONE new hybrid
-    entry into a cache already AT the bound must report ``loaded == 1``.
+def test_merge_load_evicts_opportunistic_not_imported(tmp_path):
+    """#1111 regression: merge-loading (replace=False) an imported entry into a
+    cache that already holds OPPORTUNISTIC entries AT the bound must evict the
+    OPPORTUNISTIC (unprotected) one, never the imported (protected) one, and
+    report ``loaded == 1``.
 
-    The bound pass runs at commit and, being LRU, evicts the PRE-EXISTING
-    entry (older) to make room for the freshly imported one. That eviction
-    must NOT be subtracted from the import's ``loaded`` tally — the old code
-    subtracted every bound eviction and returned 0 (or corrupted the byte
-    total) for a load that actually installed a new entry.
+    Ports SGLang's protected/evictable split: the retention bound acts on the
+    evictable (opportunistic live-store #1075) set ONLY. The imported entry is
+    protected, so it survives; a pre-existing OPPORTUNISTIC entry above the
+    bound is the LRU victim. That eviction belongs to the destination, not this
+    import, so it must NOT be subtracted from the import's ``loaded`` tally (the
+    reconciliation loop only nets ``staged`` victims — and imports are never
+    victims).
     """
     # Snapshot on disk: a single NEW hybrid entry to import.
     src_config = MemoryCacheConfig(
@@ -706,43 +714,72 @@ def test_merge_load_into_full_hybrid_cache_counts_only_imported(tmp_path):
     cache_dir = str(tmp_path / "snap")
     assert src.save_to_disk(cache_dir) is True
 
-    # Destination already holds a pre-existing hybrid entry and the bound is
-    # N=1, so it is already FULL before the import.
+    # Destination already holds TWO pre-existing OPPORTUNISTIC (unprotected)
+    # hybrid entries under N=2, so it is FULL of evictable entries before the
+    # import. These were stored live, so ``protected`` is False.
     dst_config = MemoryCacheConfig(
-        max_memory_mb=100, max_entries=64, hybrid_reuse_max_entries=1
+        max_memory_mb=100, max_entries=64, hybrid_reuse_max_entries=2
     )
     dst = MemoryAwarePrefixCache(MagicMock(), dst_config)
     assert dst.store(list(range(9000, 9008)), _real_hybrid_cache()) is True
-    assert dst.get_stats()["non_trimmable_entries"] == 1
+    assert dst.store(list(range(9100, 9108)), _real_hybrid_cache()) is True
+    assert dst.get_stats()["non_trimmable_entries"] == 2
+    assert not dst._entries[tuple(range(9000, 9008))].protected
 
     loaded = dst.load_from_disk(cache_dir, replace=False)
 
-    # The imported entry survived the bound (it is the most-recent), the
-    # pre-existing one was LRU-evicted — but that eviction belongs to the
-    # destination, not this import, so the imported count stays 1.
-    assert loaded == 1, (
-        "Merge-load must count the surviving imported entry, not net it "
-        "against the pre-existing entry the bound evicted"
-    )
-    assert dst.get_stats()["non_trimmable_entries"] == 1
+    # The import is protected -> survives regardless of the bound. The bound's
+    # evictable set is now the 2 opportunistic entries (imports excluded);
+    # N=2 keeps both, so nothing is evicted and the import is purely additive.
+    assert loaded == 1, "Merge-load must count only the imported entry"
     assert tuple(range(7000, 7008)) in dst._entries
-    assert tuple(range(9000, 9008)) not in dst._entries
+    assert dst._entries[tuple(range(7000, 7008))].protected
+    assert tuple(range(9000, 9008)) in dst._entries
+    assert tuple(range(9100, 9108)) in dst._entries
     # loaded_bytes ledger must stay coherent (non-negative, matches survivor).
     assert dst._last_load_bytes > 0
 
 
-def test_load_bound_seam_disabled_retains_but_positive_bound_trims(tmp_path):
+def test_enforcer_never_evicts_protected_imports(tmp_path):
+    """The enforcer's victim list must NEVER contain a protected (imported) key,
+    even when the bound is far below the number of imported entries. This is the
+    direct invariant the load-commit reconciliation relies on: because staged
+    imports are protected, they are never victims, so the ``loaded`` tally is
+    never spuriously netted down.
+
+    Imports 3 protected entries under N=1 and asserts the enforcer, invoked
+    directly, evicts none of them (returns an empty victim list)."""
+    cache_dir = _persist_three_hybrid_entries(tmp_path)
+    dst = MemoryAwarePrefixCache(
+        MagicMock(),
+        MemoryCacheConfig(
+            max_memory_mb=100, max_entries=64, hybrid_reuse_max_entries=1
+        ),
+    )
+    assert dst.load_from_disk(cache_dir, replace=True) == 3
+    assert all(e.protected for e in dst._entries.values())
+
+    # Directly invoke the enforcer: the evictable (unprotected) candidate set is
+    # empty, so nothing is evicted regardless of the tight N=1 bound.
+    with dst._lock:
+        victims = dst._enforce_hybrid_bound_locked()
+    assert victims == []
+    assert dst.get_stats()["non_trimmable_entries"] == 3
+
+
+def test_load_seam_imports_protected_at_any_bound(tmp_path):
     """#1111 regression guard — pins the exact seam of the fix: the SAME 3-entry
-    snapshot imported under N=0 vs N=2 must yield DIFFERENT retention.
+    imported snapshot retains ALL 3 under BOTH N=0 (disabled) and a low N=1
+    bound, because imported entries are PROTECTED and exempt from the
+    opportunistic retention bound at every N.
 
-    * N=0 (retention disabled): an explicit import retains ALL 3 non-trimmable
-      entries — the retention bound does not gate the disk-import path.
-    * N>0 (retention enabled): the load path still LRU-trims the reloaded
-      snapshot down to N, so #1111's bounded guarantee holds on reload.
-
-    A test-targeted "always keep on load" hack would make the N=2 arm keep 3;
-    the store-path-parity hack #1111 shipped would make the N=0 arm keep 0.
-    Only the intended seam (bound applies on load iff N>0) passes both arms."""
+    Mutation checks:
+    * The #1111 store-parity behavior (drop-on-load at N<=0) would make the N=0
+      arm keep 0 -> fails here.
+    * A "bound also trims imports at N>0" behavior would make the N=1 arm keep 1
+      -> fails here.
+    Only the protected/evictable split (imports never counted against the bound)
+    passes both arms."""
     cache_dir = _persist_three_hybrid_entries(tmp_path)
 
     disabled = MemoryAwarePrefixCache(
@@ -754,11 +791,61 @@ def test_load_bound_seam_disabled_retains_but_positive_bound_trims(tmp_path):
     assert disabled.load_from_disk(cache_dir, replace=True) == 3
     assert disabled.get_stats()["non_trimmable_entries"] == 3
 
-    bounded = MemoryAwarePrefixCache(
+    low_bound = MemoryAwarePrefixCache(
         MagicMock(),
         MemoryCacheConfig(
-            max_memory_mb=100, max_entries=64, hybrid_reuse_max_entries=2
+            max_memory_mb=100, max_entries=64, hybrid_reuse_max_entries=1
         ),
     )
-    assert bounded.load_from_disk(cache_dir, replace=True) == 2
-    assert bounded.get_stats()["non_trimmable_entries"] == 2
+    assert low_bound.load_from_disk(cache_dir, replace=True) == 3
+    assert low_bound.get_stats()["non_trimmable_entries"] == 3
+
+
+def test_import_survives_a_later_unrelated_live_store(tmp_path):
+    """#1111 codex BLOCKING (load-then-store mutation-kill): the CORE bug was
+    that an imported non-trimmable entry survived the load MOMENT but the next
+    ordinary live ``store`` that fired the retention enforcer LRU-evicted it —
+    so an import survived ZERO subsequent requests.
+
+    With the protected-entry fix the imported entry is exempt from the enforcer
+    at the LIVE-STORE call site too, so it survives an unrelated later store.
+    Exercised under N>0 (where a fresh opportunistic hybrid store IS admitted
+    and DOES fire the enforcer at the store call site — the only config where
+    the enforcer can run after an import). Reverting the protected exclusion in
+    ``_enforce_hybrid_bound_locked`` makes this assertion fail."""
+    # Import a hybrid entry (protected) into an N=1 cache.
+    src = MemoryAwarePrefixCache(
+        MagicMock(),
+        MemoryCacheConfig(
+            max_memory_mb=100, max_entries=64, hybrid_reuse_max_entries=9
+        ),
+    )
+    assert src.store(list(range(1000, 1008)), _real_hybrid_cache()) is True
+    cache_dir = str(tmp_path / "snap")
+    assert src.save_to_disk(cache_dir) is True
+
+    dst = MemoryAwarePrefixCache(
+        MagicMock(),
+        MemoryCacheConfig(
+            max_memory_mb=100, max_entries=64, hybrid_reuse_max_entries=1
+        ),
+    )
+    assert dst.load_from_disk(cache_dir, replace=True) == 1
+    imported_key = tuple(range(1000, 1008))
+    assert imported_key in dst._entries
+    assert dst._entries[imported_key].protected
+
+    # An UNRELATED later live store of a fresh opportunistic hybrid entry. At
+    # N=1 this IS admitted (bypasses the N<=0 store gate) and fires the enforcer
+    # at the store call site over the whole non-trimmable set.
+    assert dst.store(list(range(2000, 2008)), _real_hybrid_cache()) is True
+
+    # The imported (protected) entry MUST still be present — it survived the
+    # enforcer that ran during the unrelated store.
+    assert imported_key in dst._entries, (
+        "Imported entry was wiped by a later unrelated live store — the "
+        "protected exclusion regressed (#1111 codex BLOCKING)"
+    )
+    # Both survive: the protected import + the 1 opportunistic entry within N=1.
+    assert dst.get_stats()["non_trimmable_entries"] == 2
+    assert tuple(range(2000, 2008)) in dst._entries

--- a/tests/test_hybrid_prefix_cache_growth.py
+++ b/tests/test_hybrid_prefix_cache_growth.py
@@ -863,3 +863,108 @@ def test_import_survives_a_later_unrelated_live_store(tmp_path):
     # Both survive: the protected import + the 1 opportunistic entry within N=1.
     assert dst.get_stats()["non_trimmable_entries"] == 2
     assert tuple(range(2000, 2008)) in dst._entries
+
+
+def test_startup_reload_cycle_does_not_grow_protected_set(tmp_path):
+    """#1111 codex r3 BLOCKING (restart-cycle growth) — mutation-kill.
+
+    The disk-load path is reached by BOTH the explicit HTTP import AND the
+    process-restart startup auto-load. ``save_to_disk`` persists ALL live
+    entries — including opportunistic (unprotected) non-trimmable ones. If the
+    startup reload marked them protected (as the first fix did unconditionally),
+    the protected set would grow ~N every restart and defeat the
+    ``hybrid_reuse_max_entries`` cap: shutdown persists N opportunistic -> boot
+    reloads them protected -> new opportunistic added within the bound ->
+    persisted -> protected next boot -> unbounded.
+
+    The fix threads ``protected_import`` and the STARTUP path passes ``False``,
+    so reloaded non-trimmable entries stay UNPROTECTED and obey the bound at
+    commit. This test simulates K shutdown/reload cycles under N and asserts the
+    retained non-trimmable set NEVER exceeds N.
+
+    Mutation-kill: revert the startup caller to ``protected_import=True`` (or
+    hardcode ``protected=True`` at the commit site) and the count blows past N.
+    """
+    n = 2
+    k_cycles = 5
+
+    def _snapshot_of_live_cache(cache, out_dir):
+        assert cache.save_to_disk(out_dir) is True
+
+    # Persist an initial snapshot of N opportunistic hybrid entries (stored
+    # under a generous bound so they all land on disk unprotected).
+    seed = MemoryAwarePrefixCache(
+        MagicMock(),
+        MemoryCacheConfig(
+            max_memory_mb=200, max_entries=64, hybrid_reuse_max_entries=9
+        ),
+    )
+    for base in (100, 200):
+        assert seed.store(list(range(base, base + 8)), _real_hybrid_cache())
+    snap = str(tmp_path / "snap")
+    _snapshot_of_live_cache(seed, snap)
+
+    # Simulate restart cycles: each boot reloads the persisted snapshot as the
+    # STARTUP path does (protected_import=False), then live-stores one fresh
+    # opportunistic entry, then persists the whole live cache for the next boot.
+    for cycle in range(k_cycles):
+        booted = MemoryAwarePrefixCache(
+            MagicMock(),
+            MemoryCacheConfig(
+                max_memory_mb=200, max_entries=64, hybrid_reuse_max_entries=n
+            ),
+        )
+        # STARTUP auto-load — reloaded entries must be UNPROTECTED.
+        booted.load_from_disk(snap, replace=True, protected_import=False)
+        # No reloaded entry may be protected (they are opportunistic on disk).
+        assert not any(e.protected for e in booted._entries.values()), (
+            "startup-reloaded entries must be UNPROTECTED (protected_import=False)"
+        )
+        # A fresh opportunistic hybrid request this session.
+        booted.store(
+            list(range(1000 + cycle * 10, 1000 + cycle * 10 + 8)),
+            _real_hybrid_cache(),
+        )
+        # THE INVARIANT: the retained non-trimmable set never exceeds the bound,
+        # no matter how many restart cycles have accumulated on disk.
+        retained = booted.get_stats()["non_trimmable_entries"]
+        assert retained <= n, (
+            f"cycle {cycle}: retained non-trimmable {retained} exceeds bound {n} "
+            "— the startup-reload protected-set growth bug regressed"
+        )
+        # Persist the live cache for the next boot (mirrors shutdown).
+        _snapshot_of_live_cache(booted, snap)
+
+
+def test_startup_reload_obeys_bound_while_explicit_import_pins(tmp_path):
+    """#1111 codex r3: the two callers must be treated DIFFERENTLY.
+
+    Same on-disk snapshot of 3 hybrid entries:
+    * ``protected_import=False`` (startup) under N=1 -> reloaded non-trimmable
+      entries obey the bound -> at most 1 retained.
+    * ``protected_import=True`` (explicit #476 import) under the same N=1 ->
+      all 3 pinned, exempt from the bound.
+    """
+    cache_dir = _persist_three_hybrid_entries(tmp_path)
+
+    startup = MemoryAwarePrefixCache(
+        MagicMock(),
+        MemoryCacheConfig(
+            max_memory_mb=100, max_entries=64, hybrid_reuse_max_entries=1
+        ),
+    )
+    startup.load_from_disk(cache_dir, replace=True, protected_import=False)
+    assert startup.get_stats()["non_trimmable_entries"] <= 1, (
+        "startup auto-load must obey the retention bound"
+    )
+    assert not any(e.protected for e in startup._entries.values())
+
+    explicit = MemoryAwarePrefixCache(
+        MagicMock(),
+        MemoryCacheConfig(
+            max_memory_mb=100, max_entries=64, hybrid_reuse_max_entries=1
+        ),
+    )
+    assert explicit.load_from_disk(cache_dir, replace=True, protected_import=True) == 3
+    assert explicit.get_stats()["non_trimmable_entries"] == 3
+    assert all(e.protected for e in explicit._entries.values())

--- a/vllm_mlx/engine/base.py
+++ b/vllm_mlx/engine/base.py
@@ -392,37 +392,32 @@ class BaseEngine(ABC):
 
         from ..cache.protocol import LoadResult
 
-        accepts_replace = _callable_accepts_kwarg(
-            self.load_cache_from_disk, "replace", inspect
-        )
-        # #1111 codex r3: ``protected_import`` was added to load_cache_from_disk
-        # alongside ``replace``. Same backcompat dance — pass it only if the
-        # callee accepts it. A legacy override missing it simply loads with its
-        # own default (protected), which is safe for the explicit-import path
-        # this method serves; only the non-default ``protected_import=False``
-        # (startup auto-load) MUST reach a modern callee, and the startup path
-        # calls ``load_cache_from_disk`` directly (not this result wrapper), so
-        # it never depends on this fallback.
-        accepts_protected = _callable_accepts_kwarg(
-            self.load_cache_from_disk, "protected_import", inspect
-        )
-        if accepts_replace:
-            kwargs = {"replace": replace}
-            if accepts_protected:
-                kwargs["protected_import"] = protected_import
-            entries = self.load_cache_from_disk(cache_dir, **kwargs)
-        else:
-            if replace:
-                # The callee predates ``replace`` and cannot do an atomic
-                # clear-inside-load. Surface that instead of silently degrading
-                # a requested replace into a merge (which would leave stale
-                # entries the caller expected gone).
+        # #1111 codex r4: forward each optional kwarg INDEPENDENTLY — never gate
+        # one on another's acceptance. ``replace`` (default False) and
+        # ``protected_import`` (default True) were both added over time; a legacy
+        # override may accept neither, one, or both. For EACH kwarg:
+        #  * callee accepts it            → forward the caller's value.
+        #  * callee lacks it, caller left it at DEFAULT → drop silently (the
+        #    callee's own default matches the contract, nothing is lost).
+        #  * callee lacks it, caller passed a NON-DEFAULT → fail loudly, because
+        #    silently dropping it would degrade behavior the caller explicitly
+        #    requested (a replace silently downgraded to merge leaves stale
+        #    entries; a protected_import=False silently upgraded to protected
+        #    re-opens the restart-cycle growth bug).
+        kwargs: dict[str, object] = {}
+        for name, value, default in (
+            ("replace", replace, False),
+            ("protected_import", protected_import, True),
+        ):
+            if _callable_accepts_kwarg(self.load_cache_from_disk, name, inspect):
+                kwargs[name] = value
+            elif value != default:
                 raise TypeError(
                     f"{type(self).__name__}.load_cache_from_disk does not "
-                    "support replace=True (one-arg legacy signature); cannot "
-                    "honor merge_strategy='replace'"
+                    f"support {name}={value!r} (legacy signature); cannot honor "
+                    "the caller's non-default request"
                 )
-            entries = self.load_cache_from_disk(cache_dir)
+        entries = self.load_cache_from_disk(cache_dir, **kwargs)
         return LoadResult(entries=entries, bytes_loaded=0)
 
     def save_cache_to_disk(self, cache_dir: str, should_abort=None) -> bool:

--- a/vllm_mlx/engine/base.py
+++ b/vllm_mlx/engine/base.py
@@ -365,7 +365,9 @@ class BaseEngine(ABC):
             return SaveOutcome(outcome="failed")
         return SaveOutcome(outcome="failed" if entry_count > 0 else "empty")
 
-    def load_cache_with_result(self, cache_dir: str, replace: bool = False):
+    def load_cache_with_result(
+        self, cache_dir: str, replace: bool = False, protected_import: bool = True
+    ):
         """Load the prefix cache and return a ``LoadResult`` (#1100 codex
         round 4 #2).
 
@@ -393,8 +395,22 @@ class BaseEngine(ABC):
         accepts_replace = _callable_accepts_kwarg(
             self.load_cache_from_disk, "replace", inspect
         )
+        # #1111 codex r3: ``protected_import`` was added to load_cache_from_disk
+        # alongside ``replace``. Same backcompat dance — pass it only if the
+        # callee accepts it. A legacy override missing it simply loads with its
+        # own default (protected), which is safe for the explicit-import path
+        # this method serves; only the non-default ``protected_import=False``
+        # (startup auto-load) MUST reach a modern callee, and the startup path
+        # calls ``load_cache_from_disk`` directly (not this result wrapper), so
+        # it never depends on this fallback.
+        accepts_protected = _callable_accepts_kwarg(
+            self.load_cache_from_disk, "protected_import", inspect
+        )
         if accepts_replace:
-            entries = self.load_cache_from_disk(cache_dir, replace=replace)
+            kwargs = {"replace": replace}
+            if accepts_protected:
+                kwargs["protected_import"] = protected_import
+            entries = self.load_cache_from_disk(cache_dir, **kwargs)
         else:
             if replace:
                 # The callee predates ``replace`` and cannot do an atomic
@@ -413,7 +429,9 @@ class BaseEngine(ABC):
         """Persist the prefix cache. Override in subclasses that have one."""
         return False
 
-    def load_cache_from_disk(self, cache_dir: str, replace: bool = False) -> int:
+    def load_cache_from_disk(
+        self, cache_dir: str, replace: bool = False, protected_import: bool = True
+    ) -> int:
         """Hydrate the prefix cache. Override in subclasses that have one."""
         return 0
 

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -2711,16 +2711,23 @@ class BatchedEngine(BaseEngine):
             return self._engine.save_cache_to_disk(cache_dir, should_abort=should_abort)
         return False
 
-    def load_cache_from_disk(self, cache_dir: str, replace: bool = False) -> int:
+    def load_cache_from_disk(
+        self, cache_dir: str, replace: bool = False, protected_import: bool = True
+    ) -> int:
         """Load prefix cache from disk. Returns number of entries loaded.
 
         ``replace=True`` (export/import "replace" strategy, #476) forwards
         to the underlying engine so the cache clear runs atomically on the
         mlx-step thread after index validation — see
         ``EngineCore.load_cache_from_disk``.
+
+        ``protected_import`` (#1111 codex r3): True for explicit HTTP import
+        (pin), False for startup auto-load (obey the retention bound).
         """
         if self._engine:
-            return self._engine.load_cache_from_disk(cache_dir, replace=replace)
+            return self._engine.load_cache_from_disk(
+                cache_dir, replace=replace, protected_import=protected_import
+            )
         return 0
 
     def save_cache_with_outcome(self, cache_dir: str, should_abort=None):
@@ -2744,16 +2751,23 @@ class BatchedEngine(BaseEngine):
 
         raise EngineNotReadyError("cannot export cache: inner engine is not loaded")
 
-    def load_cache_with_result(self, cache_dir: str, replace: bool = False):
+    def load_cache_with_result(
+        self, cache_dir: str, replace: bool = False, protected_import: bool = True
+    ):
         """Forward to the inner engine's result-returning load (#1100 codex
         round 4 #2). Returns a ``LoadResult`` computed on the step thread.
 
         #1100 codex round 8 (#4): absent inner engine → raise
         ``EngineNotReadyError`` (→ route 503) rather than reporting a
         successful zero-entry load, matching ``save_cache_with_outcome``.
+
+        ``protected_import`` (#1111 codex r3): defaults True — this
+        result-returning path serves the EXPLICIT HTTP import (#476).
         """
         if self._engine:
-            return self._engine.load_cache_with_result(cache_dir, replace=replace)
+            return self._engine.load_cache_with_result(
+                cache_dir, replace=replace, protected_import=protected_import
+            )
         from ..cache.protocol import EngineNotReadyError
 
         raise EngineNotReadyError("cannot import cache: inner engine is not loaded")

--- a/vllm_mlx/engine_core.py
+++ b/vllm_mlx/engine_core.py
@@ -1292,7 +1292,9 @@ class EngineCore:
             self.scheduler.save_cache_to_disk, cache_dir, should_abort=should_abort
         )
 
-    def load_cache_from_disk(self, cache_dir: str, replace: bool = False) -> int:
+    def load_cache_from_disk(
+        self, cache_dir: str, replace: bool = False, protected_import: bool = True
+    ) -> int:
         """Load prefix cache from disk.
 
         Loading also goes through the worker thread so the loaded arrays
@@ -1304,9 +1306,16 @@ class EngineCore:
         cache clear happens atomically ON THIS worker thread, after the
         on-disk index is validated — never on the asyncio loop thread
         where a concurrent request could repopulate it mid-swap.
+
+        ``protected_import`` (#1111 codex r3): True for explicit HTTP import
+        (pin loaded entries), False for startup auto-load (loaded entries obey
+        the hybrid retention bound) — see ``MemoryAwarePrefixCache.load_from_disk``.
         """
         return self._run_on_step_thread(
-            self.scheduler.load_cache_from_disk, cache_dir, replace=replace
+            self.scheduler.load_cache_from_disk,
+            cache_dir,
+            replace=replace,
+            protected_import=protected_import,
         )
 
     def save_cache_with_outcome(self, cache_dir: str, should_abort=None):
@@ -1340,18 +1349,26 @@ class EngineCore:
 
         return self._run_on_step_thread(_do)
 
-    def load_cache_with_result(self, cache_dir: str, replace: bool = False):
+    def load_cache_with_result(
+        self, cache_dir: str, replace: bool = False, protected_import: bool = True
+    ):
         """Load the prefix cache and return an operation-specific result.
 
         #1100 codex round 4 (#2): same rationale as ``save_cache_with_
         outcome`` — the load AND the loaded-byte capture run in ONE step-
         thread closure so the byte count returned is exactly this load's,
         never a value a concurrent load to another path clobbered.
+
+        ``protected_import`` (#1111 codex r3): forwarded to the load; the
+        result-returning path is used by the EXPLICIT HTTP import (#476), so it
+        defaults True (pin loaded entries).
         """
         from .cache.protocol import LoadResult
 
         def _do():
-            entries = self.scheduler.load_cache_from_disk(cache_dir, replace=replace)
+            entries = self.scheduler.load_cache_from_disk(
+                cache_dir, replace=replace, protected_import=protected_import
+            )
             cache = getattr(self.scheduler, "memory_aware_cache", None)
             # ``is not None`` — an emptied cache is falsy via ``__len__``.
             bytes_loaded = (
@@ -1506,14 +1523,22 @@ class AsyncEngineCore:
         """Save prefix cache to disk."""
         return self.engine.save_cache_to_disk(cache_dir, should_abort=should_abort)
 
-    def load_cache_from_disk(self, cache_dir: str, replace: bool = False) -> int:
+    def load_cache_from_disk(
+        self, cache_dir: str, replace: bool = False, protected_import: bool = True
+    ) -> int:
         """Load prefix cache from disk."""
-        return self.engine.load_cache_from_disk(cache_dir, replace=replace)
+        return self.engine.load_cache_from_disk(
+            cache_dir, replace=replace, protected_import=protected_import
+        )
 
     def save_cache_with_outcome(self, cache_dir: str, should_abort=None):
         """Forward the outcome-returning save (#1100 codex round 4 #2)."""
         return self.engine.save_cache_with_outcome(cache_dir, should_abort=should_abort)
 
-    def load_cache_with_result(self, cache_dir: str, replace: bool = False):
+    def load_cache_with_result(
+        self, cache_dir: str, replace: bool = False, protected_import: bool = True
+    ):
         """Forward the result-returning load (#1100 codex round 4 #2)."""
-        return self.engine.load_cache_with_result(cache_dir, replace=replace)
+        return self.engine.load_cache_with_result(
+            cache_dir, replace=replace, protected_import=protected_import
+        )

--- a/vllm_mlx/memory_cache.py
+++ b/vllm_mlx/memory_cache.py
@@ -2791,8 +2791,33 @@ class MemoryAwarePrefixCache:
         self._last_save_outcome = "committed" if committed else "failed"
         return committed
 
-    def load_from_disk(self, cache_dir: str, replace: bool = False) -> int:
+    def load_from_disk(
+        self, cache_dir: str, replace: bool = False, protected_import: bool = True
+    ) -> int:
         """Load cache entries from disk.
+
+        ``protected_import`` (#1111 regression follow-up, codex r3): marks the
+        loaded entries PROTECTED (exempt from the opportunistic hybrid retention
+        bound — SGLang ``lock_ref`` / vLLM ``ref_cnt`` idiom). It DISTINGUISHES
+        the two callers of this path, which must NOT be treated identically:
+
+        * ``True`` (default) — the EXPLICIT ``POST /v1/cache/import`` (#476): an
+          operator deliberately loading specific entries. They are pinned for
+          their lifetime, never opportunistically evicted.
+        * ``False`` — the process-restart STARTUP auto-load (radix persistence,
+          ``runtime/cache.py`` lifespan). Protection is a RUNTIME property of an
+          explicit operator action, not a persisted-and-immortalized attribute.
+          ``save_to_disk`` writes ALL live entries — including opportunistic
+          (unprotected) non-trimmable ones — so if startup reloaded them as
+          protected, the protected set would grow ~N per restart and defeat the
+          ``hybrid_reuse_max_entries`` cap (shutdown persists N opportunistic ->
+          boot reloads them protected -> new opportunistic added within the
+          bound -> persisted -> protected next boot -> unbounded). With
+          ``False``, reloaded non-trimmable entries are UNPROTECTED and obey the
+          bound at commit (N=0 default -> not retained, matching #1111's opt-in
+          design; N>0 -> bounded at N). Trimmable entries are untouched by the
+          enforcer either way. Mirrors SGLang/vLLM, where lock_ref / ref_cnt are
+          runtime refcounts, never immortal across a restart.
 
         ``replace=True`` implements the export/import "replace" merge
         strategy (#476) as an ATOMIC stage-then-swap on this thread: EVERY
@@ -3265,15 +3290,21 @@ class MemoryAwarePrefixCache:
                     # non_trimmable_entries gauge sees them the same as freshly
                     # stored ones.
                     non_trimmable=_cache_has_non_trimmable(cache),
-                    # #1111 regression fix: entries installed by a disk load are
-                    # EXPLICITLY persisted data being loaded — both the HTTP
-                    # ``POST /v1/cache/import`` (#476) and process-restart
-                    # auto-load-on-startup (radix persistence) reach here, and
-                    # the operator's decision is to treat them IDENTICALLY. Mark
-                    # them protected so the opportunistic hybrid retention bound
-                    # never evicts them (SGLang ``lock_ref`` / vLLM ``ref_cnt``
-                    # protected-set idiom, persistent-lifetime degenerate case).
-                    protected=True,
+                    # #1111 regression fix + codex r3: protection is set by the
+                    # CALLER, because the two callers of this load path are NOT
+                    # equivalent and must be treated DIFFERENTLY:
+                    #  * EXPLICIT ``POST /v1/cache/import`` (#476) ->
+                    #    ``protected_import=True``: an operator deliberately
+                    #    loading entries; pinned for their lifetime (SGLang
+                    #    ``lock_ref`` / vLLM ``ref_cnt`` protected-set idiom).
+                    #  * process-restart STARTUP auto-load ->
+                    #    ``protected_import=False``: reloaded entries stay
+                    #    UNPROTECTED and obey the retention bound. Marking them
+                    #    protected would make the protected set grow ~N per
+                    #    restart and defeat ``hybrid_reuse_max_entries`` (save
+                    #    persists opportunistic entries; see load_from_disk
+                    #    docstring for the full restart cycle).
+                    protected=protected_import,
                 )
                 staged[tokens_key] = entry
                 staged_memory += memory

--- a/vllm_mlx/memory_cache.py
+++ b/vllm_mlx/memory_cache.py
@@ -1006,10 +1006,34 @@ class _CacheEntry:
     # (hybrid GatedDeltaNet / Mamba MoE). Computed once at creation so the
     # hybrid-bound eviction scan doesn't re-inspect layers per store.
     non_trimmable: bool = False
+    # #1111 regression fix: PROTECTED vs EVICTABLE split, ported from SGLang's
+    # RadixCache (``python/sglang/srt/mem_cache/radix_cache.py``) ``lock_ref``
+    # reference-counting — a node with ``lock_ref > 0`` is moved out of the
+    # evictable set (``evictable_size_``) into the protected set
+    # (``protected_size_``) and ``evict()`` never touches it — and vLLM v1's
+    # ``KVCacheBlock.ref_cnt`` (``vllm/v1/core/block_pool.py``), where a block
+    # with ``ref_cnt > 0`` is excluded from the ``free_block_queue`` LRU.
+    #
+    # Explicitly-loaded entries (``POST /v1/cache/import`` #476 AND
+    # process-restart auto-load-on-startup / radix persistence) are the
+    # DEGENERATE, persistent-lifetime case of that idiom: a lock held for the
+    # entry's whole life — the same way SGLang's ``host_ref_counter`` protects
+    # a persisted/offloaded entry across device-pressure eviction cycles. They
+    # carry ``protected=True`` and are exempt from the opportunistic hybrid
+    # retention enforcer at BOTH its call sites: the N=0 drop skips them and
+    # they do NOT count against the N>0 bound. The bound governs OPPORTUNISTIC
+    # (unprotected, live-store #1075) non-trimmable retention only.
+    protected: bool = False
 
     @classmethod
     def create(cls, tokens: list[int], cache: list[Any]) -> _CacheEntry:
-        """Create a cache entry with memory estimation."""
+        """Create a cache entry with memory estimation.
+
+        Live-store entries are EVICTABLE (``protected=False``) — the
+        opportunistic-store path the hybrid retention bound governs. Disk-load
+        entries are constructed directly (see ``load_from_disk``) with
+        ``protected=True``.
+        """
         memory = estimate_kv_cache_memory(cache)
         return cls(
             tokens=tuple(tokens),
@@ -1932,54 +1956,61 @@ class MemoryAwarePrefixCache:
         )
 
     def _enforce_hybrid_bound_locked(self) -> list[tuple[int, ...]]:
-        """Enforce the ``hybrid_reuse_max_entries`` bound over non-trimmable
-        (hybrid recurrent-state) entries.
+        """Enforce the ``hybrid_reuse_max_entries`` bound over EVICTABLE
+        (unprotected) non-trimmable (hybrid recurrent-state) entries.
 
         Caller must hold ``self._lock``. Returns the LIST of evicted keys (in
         eviction order) so the persistent-load path can reconcile its loaded
         tallies against only the keys that belonged to THIS import — a bound
-        pass may evict PRE-EXISTING non-trimmable entries (merge mode) that
-        were never part of the current load and must not be subtracted from it.
+        pass may evict PRE-EXISTING evictable non-trimmable entries (merge mode)
+        that were never part of the current load and must not be subtracted.
 
         #1103: non-trimmable entries carry unique-superset keys across
         conversations (#1025), so unlike KV-only entries they are never
         reclaimed by prefix-subset eviction and can pile up unbounded. This
-        bound is the single source of truth for how many are retained.
+        bound is the single source of truth for how many OPPORTUNISTIC ones are
+        retained.
 
-        Semantics:
+        PROTECTED vs EVICTABLE (ported from SGLang RadixCache ``lock_ref`` /
+        vLLM ``KVCacheBlock.ref_cnt`` — see ``_CacheEntry.protected``):
+        explicitly-loaded entries (disk import #476 + auto-load-on-startup)
+        carry ``protected=True`` and are EXCLUDED from the candidate set here,
+        exactly as SGLang's ``evict()`` only draws from ``evictable_leaves``
+        (nodes with ``lock_ref == 0``). They are therefore exempt from BOTH the
+        ``N <= 0`` drop AND the ``N > 0`` count/trim below. The bound acts on
+        the opportunistic (live-store #1075) set ONLY.
+
+        Semantics over the EVICTABLE set:
 
         * ``hybrid_reuse_max_entries <= 0`` (disabled, the default) → drop ALL
-          non-trimmable entries (``keep = max(limit, 0) == 0``).
-        * ``> 0`` → LRU-evict the oldest non-trimmable entries until at most N
-          remain. ``_entries`` is an ``OrderedDict`` in LRU order, so the head
-          of the filtered list is the least-recently-used.
+          evictable non-trimmable entries (``keep = max(limit, 0) == 0``).
+        * ``> 0`` → LRU-evict the oldest evictable non-trimmable entries until
+          at most N remain. ``_entries`` is an ``OrderedDict`` in LRU order, so
+          the head of the filtered list is the least-recently-used.
 
-        Call sites and why they differ on the ``N <= 0`` case:
-
-        * The live-STORE path (after inserting a fresh non-trimmable entry)
-          calls this UNCONDITIONALLY — including ``N <= 0`` — because that path
-          is the opportunistic within-session prefix reuse the bound governs;
-          dropping at store when disabled is the #1075 anti-leak policy.
-        * The persistent-LOAD / disk-import commit path calls this ONLY when
-          ``N > 0`` (#1111 regression fix). An explicit import (#476) is an
-          operator deliberately installing entries, NOT opportunistic
-          retention, so ``N <= 0`` must not drop what was explicitly loaded.
-          When ``N > 0`` the load path still trims a reloaded snapshot down to
-          N. Callers on the load path reconcile the returned victim keys
-          against only the freshly-imported (``staged``) entries.
+        Called UNCONDITIONALLY at BOTH sites (live-store after inserting a
+        fresh non-trimmable entry; disk-load commit after installing a staged
+        set). Because protected entries are excluded from the candidate set,
+        the disk-load call no longer needs a ``N > 0`` guard — an explicit
+        import is protected and survives regardless of N, while any legacy
+        UNPROTECTED opportunistic entry still obeys the bound.
         """
         limit = self._config.hybrid_reuse_max_entries
-        non_trimmable_keys = [
-            key for key, e in self._entries.items() if e.non_trimmable
+        # PROTECTED entries (explicit import / auto-load) are never candidates —
+        # the SGLang ``evictable_leaves`` exclusion of ``lock_ref > 0`` nodes.
+        evictable_non_trimmable_keys = [
+            key
+            for key, e in self._entries.items()
+            if e.non_trimmable and not e.protected
         ]
         # limit <= 0 disables reuse: ``max(limit, 0)`` keeps NONE, dropping
-        # every non-trimmable entry (matches the store-path ``<= 0`` drop-at-
-        # store). Slice the eviction prefix once — the head of the LRU-ordered
-        # list is oldest — instead of repeated ``pop(0)`` (O(n**2) on a large
-        # persisted snapshot).
+        # every EVICTABLE non-trimmable entry (matches the store-path ``<= 0``
+        # drop-at-store). Slice the eviction prefix once — the head of the
+        # LRU-ordered list is oldest — instead of repeated ``pop(0)`` (O(n**2)
+        # on a large persisted snapshot).
         keep = max(limit, 0)
-        n_evict = max(0, len(non_trimmable_keys) - keep)
-        victims = non_trimmable_keys[:n_evict]
+        n_evict = max(0, len(evictable_non_trimmable_keys) - keep)
+        victims = evictable_non_trimmable_keys[:n_evict]
         for oldest in victims:
             self._evict_entry_locked(oldest, reason="hybrid_bound")
         return victims
@@ -3231,9 +3262,18 @@ class MemoryAwarePrefixCache:
                     memory_bytes=memory,
                     # #1103: legacy on-disk snapshots (pre-#1075 saves) can
                     # carry hybrid recurrent-state entries; flag them so the
-                    # hybrid-reuse bound and the non_trimmable_entries gauge
-                    # see them the same as freshly stored ones.
+                    # non_trimmable_entries gauge sees them the same as freshly
+                    # stored ones.
                     non_trimmable=_cache_has_non_trimmable(cache),
+                    # #1111 regression fix: entries installed by a disk load are
+                    # EXPLICITLY persisted data being loaded — both the HTTP
+                    # ``POST /v1/cache/import`` (#476) and process-restart
+                    # auto-load-on-startup (radix persistence) reach here, and
+                    # the operator's decision is to treat them IDENTICALLY. Mark
+                    # them protected so the opportunistic hybrid retention bound
+                    # never evicts them (SGLang ``lock_ref`` / vLLM ``ref_cnt``
+                    # protected-set idiom, persistent-lifetime degenerate case).
+                    protected=True,
                 )
                 staged[tokens_key] = entry
                 staged_memory += memory
@@ -3439,43 +3479,45 @@ class MemoryAwarePrefixCache:
 
                 loaded_bytes += entry.memory_bytes
 
-            # #1111 regression fix: an explicit disk load / import is an
-            # operator DELIBERATELY installing specific entries (#476 export ->
-            # import). It is NOT the opportunistic within-session prefix-reuse
-            # STORE path, so the *retention* bound must not silently drop what
-            # was explicitly imported. ``hybrid_reuse_max_entries`` governs how
-            # many non-trimmable entries the live-store path keeps hot; N == 0
-            # means "opportunistic hybrid reuse is DISABLED", not "reject every
-            # imported hybrid entry". #1111 conflated the two and gated the load
-            # commit on N <= 0, so a default-config import dropped its own
-            # ArraysCache entry -> entries_loaded == 0 (roundtrip broke).
+            # #1111 regression fix (PROTECTED-entry semantics, ported from
+            # SGLang RadixCache ``lock_ref`` / vLLM ``KVCacheBlock.ref_cnt`` —
+            # see ``_CacheEntry.protected`` and ``_enforce_hybrid_bound_locked``).
             #
-            # Correct seam:
-            #  * N <= 0 (default / disabled): DO NOT drop on load. The explicit
-            #    import installs every staged entry; the retention bound simply
-            #    does not apply to an operator-initiated load. This does NOT
-            #    re-open the #1075 leak: that leak is the LIVE-store loop
-            #    accumulating cross-conversation unique-superset keys unbounded
-            #    (still gated at store, unchanged). A one-time load of an
-            #    already-bounded snapshot file is not that loop.
-            #  * N > 0: still LRU-trim a loaded snapshot down to N, so a
-            #    reloaded snapshot can never exceed the configured retention
-            #    size — matching the live-session bound (#1111's bounded
-            #    guarantee is preserved for the opt-in path).
+            # An explicit disk load / import is an operator DELIBERATELY
+            # installing specific entries (#476 export -> import) — the same
+            # class as SGLang's persisted, ``host_ref_counter``-protected nodes.
+            # Every staged entry was constructed with ``protected=True`` above,
+            # so the retention enforcer's candidate set (evictable = unprotected
+            # non-trimmable) EXCLUDES them: they survive at any N, exactly like
+            # SGLang's ``evict()`` skipping ``lock_ref > 0`` nodes. This fixes
+            # the #1111 regression at its ROOT rather than at the load MOMENT:
+            # before, a later live ``store`` that fired the enforcer LRU-evicted
+            # the imported entry (survived zero requests); now the entry stays
+            # protected for its whole lifetime.
             #
-            # Runs inside the commit critical section so a scraper never sees an
-            # over-bound cache. Reconcile the reported tallies against ONLY the
-            # evicted keys that belonged to THIS import (``staged``): in merge
-            # mode the bound can evict PRE-EXISTING non-trimmable entries too,
-            # and those were never counted in ``loaded`` / ``loaded_bytes``, so
-            # subtracting them would under-count (potentially to 0) a load that
-            # actually installed new entries.
-            if self._config.hybrid_reuse_max_entries > 0:
-                for victim in self._enforce_hybrid_bound_locked():
-                    staged_entry = staged.get(victim)
-                    if staged_entry is not None:
-                        loaded -= 1
-                        loaded_bytes -= staged_entry.memory_bytes
+            # We STILL call the enforcer here (unconditionally — protected
+            # entries are simply not candidates): a merge load can carry legacy
+            # UNPROTECTED opportunistic non-trimmable entries (pre-existing in
+            # the live cache), and those must still obey the bound so a merge
+            # can't re-open the #1075 leak. The store path's ``N=0`` gate
+            # ensures fresh live stores never insert an unprotected non-trimmable
+            # entry, so in practice the only evictable candidates a load sees are
+            # historical — but running the enforcer keeps the invariant robust.
+            #
+            # Reconcile the reported tallies against ONLY the evicted keys that
+            # belonged to THIS import (``staged``): in merge mode the bound can
+            # evict PRE-EXISTING evictable entries too, and those were never
+            # counted in ``loaded`` / ``loaded_bytes``, so subtracting them would
+            # under-count (potentially to 0) a load that actually installed new
+            # entries. Because staged entries are protected, they are never
+            # victims here, so this subtraction is effectively a no-op for the
+            # import itself — kept for defence against a future unprotected
+            # staged path.
+            for victim in self._enforce_hybrid_bound_locked():
+                staged_entry = staged.get(victim)
+                if staged_entry is not None:
+                    loaded -= 1
+                    loaded_bytes -= staged_entry.memory_bytes
 
             self._stats.entry_count = len(self._entries)
             self._stats.current_memory_bytes = self._current_memory

--- a/vllm_mlx/memory_cache.py
+++ b/vllm_mlx/memory_cache.py
@@ -1944,20 +1944,29 @@ class MemoryAwarePrefixCache:
         #1103: non-trimmable entries carry unique-superset keys across
         conversations (#1025), so unlike KV-only entries they are never
         reclaimed by prefix-subset eviction and can pile up unbounded. This
-        bound is the single source of truth for how many are retained and is
-        shared by BOTH the store path (after inserting a fresh non-trimmable
-        entry) and the persistent-load commit path (after installing a staged
-        set, which may carry legacy hybrid entries from a pre-#1075 snapshot).
+        bound is the single source of truth for how many are retained.
 
-        Semantics MATCH the store-time gate exactly:
+        Semantics:
 
         * ``hybrid_reuse_max_entries <= 0`` (disabled, the default) → drop ALL
-          non-trimmable entries, so a server restart that reloads a snapshot is
-          byte-for-byte the #1075 drop-at-store behavior — including retaining
-          NONE when N == 0.
+          non-trimmable entries (``keep = max(limit, 0) == 0``).
         * ``> 0`` → LRU-evict the oldest non-trimmable entries until at most N
           remain. ``_entries`` is an ``OrderedDict`` in LRU order, so the head
           of the filtered list is the least-recently-used.
+
+        Call sites and why they differ on the ``N <= 0`` case:
+
+        * The live-STORE path (after inserting a fresh non-trimmable entry)
+          calls this UNCONDITIONALLY — including ``N <= 0`` — because that path
+          is the opportunistic within-session prefix reuse the bound governs;
+          dropping at store when disabled is the #1075 anti-leak policy.
+        * The persistent-LOAD / disk-import commit path calls this ONLY when
+          ``N > 0`` (#1111 regression fix). An explicit import (#476) is an
+          operator deliberately installing entries, NOT opportunistic
+          retention, so ``N <= 0`` must not drop what was explicitly loaded.
+          When ``N > 0`` the load path still trims a reloaded snapshot down to
+          N. Callers on the load path reconcile the returned victim keys
+          against only the freshly-imported (``staged``) entries.
         """
         limit = self._config.hybrid_reuse_max_entries
         non_trimmable_keys = [
@@ -3430,26 +3439,43 @@ class MemoryAwarePrefixCache:
 
                 loaded_bytes += entry.memory_bytes
 
-            # #1103 codex BLOCKING-1: loaded snapshots can carry non-trimmable
-            # hybrid entries (flagged at staging above). Unlike the store path,
-            # nothing gated them on the way in, so a restart could retain them
-            # ABOVE ``hybrid_reuse_max_entries`` — or retain them at all when
-            # N == 0 — breaking both the opt-in AND the bounded guarantee.
-            # Enforce the SAME bound the store path applies: with N <= 0 this
-            # drops every non-trimmable entry (byte-for-byte #1075 after a
-            # restart); with N > 0 it LRU-trims down to N. Runs inside the
-            # commit critical section so a scraper never sees an over-bound
-            # cache. Reconcile the reported tallies against ONLY the evicted
-            # keys that belonged to THIS import (``staged``): in merge mode the
-            # bound can evict PRE-EXISTING non-trimmable entries too, and those
-            # were never counted in ``loaded`` / ``loaded_bytes``, so
+            # #1111 regression fix: an explicit disk load / import is an
+            # operator DELIBERATELY installing specific entries (#476 export ->
+            # import). It is NOT the opportunistic within-session prefix-reuse
+            # STORE path, so the *retention* bound must not silently drop what
+            # was explicitly imported. ``hybrid_reuse_max_entries`` governs how
+            # many non-trimmable entries the live-store path keeps hot; N == 0
+            # means "opportunistic hybrid reuse is DISABLED", not "reject every
+            # imported hybrid entry". #1111 conflated the two and gated the load
+            # commit on N <= 0, so a default-config import dropped its own
+            # ArraysCache entry -> entries_loaded == 0 (roundtrip broke).
+            #
+            # Correct seam:
+            #  * N <= 0 (default / disabled): DO NOT drop on load. The explicit
+            #    import installs every staged entry; the retention bound simply
+            #    does not apply to an operator-initiated load. This does NOT
+            #    re-open the #1075 leak: that leak is the LIVE-store loop
+            #    accumulating cross-conversation unique-superset keys unbounded
+            #    (still gated at store, unchanged). A one-time load of an
+            #    already-bounded snapshot file is not that loop.
+            #  * N > 0: still LRU-trim a loaded snapshot down to N, so a
+            #    reloaded snapshot can never exceed the configured retention
+            #    size — matching the live-session bound (#1111's bounded
+            #    guarantee is preserved for the opt-in path).
+            #
+            # Runs inside the commit critical section so a scraper never sees an
+            # over-bound cache. Reconcile the reported tallies against ONLY the
+            # evicted keys that belonged to THIS import (``staged``): in merge
+            # mode the bound can evict PRE-EXISTING non-trimmable entries too,
+            # and those were never counted in ``loaded`` / ``loaded_bytes``, so
             # subtracting them would under-count (potentially to 0) a load that
             # actually installed new entries.
-            for victim in self._enforce_hybrid_bound_locked():
-                staged_entry = staged.get(victim)
-                if staged_entry is not None:
-                    loaded -= 1
-                    loaded_bytes -= staged_entry.memory_bytes
+            if self._config.hybrid_reuse_max_entries > 0:
+                for victim in self._enforce_hybrid_bound_locked():
+                    staged_entry = staged.get(victim)
+                    if staged_entry is not None:
+                        loaded -= 1
+                        loaded_bytes -= staged_entry.memory_bytes
 
             self._stats.entry_count = len(self._entries)
             self._stats.current_memory_bytes = self._current_memory

--- a/vllm_mlx/memory_cache.py
+++ b/vllm_mlx/memory_cache.py
@@ -1014,15 +1014,21 @@ class _CacheEntry:
     # ``KVCacheBlock.ref_cnt`` (``vllm/v1/core/block_pool.py``), where a block
     # with ``ref_cnt > 0`` is excluded from the ``free_block_queue`` LRU.
     #
-    # Explicitly-loaded entries (``POST /v1/cache/import`` #476 AND
-    # process-restart auto-load-on-startup / radix persistence) are the
-    # DEGENERATE, persistent-lifetime case of that idiom: a lock held for the
-    # entry's whole life — the same way SGLang's ``host_ref_counter`` protects
-    # a persisted/offloaded entry across device-pressure eviction cycles. They
-    # carry ``protected=True`` and are exempt from the opportunistic hybrid
-    # retention enforcer at BOTH its call sites: the N=0 drop skips them and
-    # they do NOT count against the N>0 bound. The bound governs OPPORTUNISTIC
-    # (unprotected, live-store #1075) non-trimmable retention only.
+    # Protection is set by the CALLER and is NOT the same for the two disk-load
+    # entry points (#1111 codex r3 — they must NOT be treated identically):
+    #  * EXPLICIT ``POST /v1/cache/import`` (#476) → ``protected=True``: an
+    #    operator deliberately loading specific entries. This is the DEGENERATE,
+    #    persistent-lifetime case of the idiom — a lock held for the entry's
+    #    whole life, like SGLang's ``host_ref_counter`` on a persisted entry.
+    #    Exempt from the opportunistic hybrid retention enforcer at BOTH call
+    #    sites (N=0 drop skips them; they do NOT count against the N>0 bound).
+    #  * process-restart AUTO-LOAD-ON-STARTUP (radix persistence) →
+    #    ``protected=False``: ``save_to_disk`` persists ALL live entries incl.
+    #    opportunistic ones, so protecting reloaded entries every boot would
+    #    grow the protected set ~N per restart and defeat the cap. Reloaded
+    #    non-trimmable entries stay UNPROTECTED and obey the bound at commit.
+    # Live-STORE entries are always ``protected=False`` (the opportunistic path
+    # the bound governs). The bound governs OPPORTUNISTIC (unprotected) entries.
     protected: bool = False
 
     @classmethod
@@ -1032,7 +1038,8 @@ class _CacheEntry:
         Live-store entries are EVICTABLE (``protected=False``) — the
         opportunistic-store path the hybrid retention bound governs. Disk-load
         entries are constructed directly (see ``load_from_disk``) with
-        ``protected=True``.
+        ``protected=protected_import``: True for the explicit HTTP import (#476),
+        False for the process-restart startup auto-load.
         """
         memory = estimate_kv_cache_memory(cache)
         return cls(

--- a/vllm_mlx/runtime/cache.py
+++ b/vllm_mlx/runtime/cache.py
@@ -67,7 +67,14 @@ def load_prefix_cache_from_disk() -> None:
     try:
         d = get_cache_dir()
         logger.info(f"[lifespan] Loading prefix cache from {d}")
-        loaded = cfg.engine.load_cache_from_disk(d)
+        # #1111 codex r3: the STARTUP auto-load must NOT protect reloaded
+        # entries. ``save_to_disk`` persists ALL live entries — including
+        # opportunistic (unprotected) non-trimmable ones — so protecting them on
+        # every boot would grow the protected set ~N per restart and defeat the
+        # ``hybrid_reuse_max_entries`` cap. ``protected_import=False`` makes
+        # reloaded non-trimmable entries obey the retention bound at commit;
+        # only the EXPLICIT ``POST /v1/cache/import`` (#476) pins its entries.
+        loaded = cfg.engine.load_cache_from_disk(d, protected_import=False)
         if loaded > 0:
             logger.info(f"[lifespan] Loaded {loaded} prefix cache entries")
         else:

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -5480,14 +5480,22 @@ class Scheduler:
         logger.info("[cache_persist] no memory-aware cache to save")
         return False
 
-    def load_cache_from_disk(self, cache_dir: str, replace: bool = False) -> int:
+    def load_cache_from_disk(
+        self, cache_dir: str, replace: bool = False, protected_import: bool = True
+    ) -> int:
         """Load prefix cache from disk. Returns number of entries loaded.
 
         ``replace=True`` (export/import "replace" strategy, #476) clears
         the in-memory cache atomically inside the load, after the on-disk
         index is validated — see ``MemoryAwarePrefixCache.load_from_disk``.
+
+        ``protected_import`` (#1111 codex r3): True for the explicit HTTP import
+        (pin loaded entries), False for the startup auto-load (loaded entries
+        obey the hybrid retention bound) — see ``load_from_disk``.
         """
         if self.memory_aware_cache is not None:
-            return self.memory_aware_cache.load_from_disk(cache_dir, replace=replace)
+            return self.memory_aware_cache.load_from_disk(
+                cache_dir, replace=replace, protected_import=protected_import
+            )
         logger.info("[cache_persist] no memory-aware cache to load into")
         return 0


### PR DESCRIPTION
## Why

PR #1111 broke the KV-cache disk export/import roundtrip (`POST /v1/cache/export` -> `POST /v1/cache/import`, feature #476). Its codex \"BLOCKING-1\" follow-up added the hybrid *retention* bound to the persistent-load / disk-import commit path, so with the default `hybrid_reuse_max_entries=0` an explicit import silently discarded its own non-trimmable (`ArraysCache`) entries -> `entries_loaded == 0`.

The retention bound governs **opportunistic within-session prefix reuse** — how many non-trimmable entries the live-**store** path keeps hot. An explicit disk import (or process-restart auto-load) is an operator deliberately installing entries; it must not be gated by that reuse bound.

`Refs #1111`
`Refs #476`

## Root cause (two layers)

**Surface (broke the 4 roundtrip tests):** `_enforce_hybrid_bound_locked()` at the load-commit path dropped all non-trimmable entries at N=0.

**Deeper (codex BLOCKING on the first attempt):** exempting imported entries only *at the load moment* left them EVICTABLE afterwards. At N>0, the next ordinary live `store()` of a hybrid entry re-fires `_enforce_hybrid_bound_locked()` over ALL non-trimmable entries and LRU-evicts the older imported one — so an import survived **zero** subsequent requests. I reproduced this directly (import at N=1 -> unrelated hybrid store -> imported key gone). The N=0 case is incidentally shielded by the store-time gate (a fresh hybrid store is dropped before the enforcer at N=0), which is why an isolated single-file `pytest` passed while a later store in full-suite ordering wiped the imported entry — matching the `full_unit` failure.

## Fix: PROTECTED vs EVICTABLE split (ported, not invented)

Ported from the proven eviction-protection idiom in both engines (verified against source):

- **SGLang RadixCache** (`python/sglang/srt/mem_cache/radix_cache.py`): `lock_ref` reference counting. On the 0->1 transition a node moves from `evictable_size_` to `protected_size_`; `evict()` only draws from `evictable_leaves`, which excludes any node with `lock_ref > 0`. Persisted entries stay alive across pressure via `host_ref_counter` / `protect_host()`.
- **vLLM v1** (`vllm/v1/core/kv_cache_utils.py` / `block_pool.py`): `KVCacheBlock.ref_cnt`; blocks with `ref_cnt > 0` are excluded from the `free_block_queue` LRU.

Mapping onto our problem:
- Explicit disk-import (#476) + auto-load-on-startup entries -> **protected** (the persistent-lifetime *degenerate case* of `lock_ref>0` / `host_ref_counter>0`: a lock held for the entry's whole life). Exempt from BOTH the N=0 opportunistic drop AND the N>0 bound.
- #1075 opportunistic live-store non-trimmable entries -> **evictable**; the bound acts on this set only.

Seam (`vllm_mlx/memory_cache.py`):
- `_CacheEntry` gains `protected: bool = False` (`~line 1020`).
- Both disk-load entry points construct entries with `protected=True` (`~line 3259`) — HTTP import and radix auto-load both flow through `load_from_disk`, treated identically per the operator's decision.
- `_enforce_hybrid_bound_locked()` (`~line 1958`) builds its candidate list from `e.non_trimmable and not e.protected` — the SGLang `evictable_leaves` exclusion of `lock_ref>0` nodes. This applies at BOTH call sites (live-store `~1879` and load-commit `~3504`), so a protected import survives the enforcer no matter which path triggers it. The load-commit call is unconditional again (protected entries are simply never candidates), so a merge load still bounds legacy UNPROTECTED opportunistic entries.

## Preserves #1111 intent (re-confirmed)

- **N=0:** opportunistic (unprotected) non-trimmable entries STILL drop at store (#1075 anti-leak), guarded by the unchanged `test_hybrid_store_is_dropped` and `test_default_config_keeps_drop_policy`.
- **N>0:** the LRU bound still applies to opportunistic entries; protected imports are exempt from the count.

## Scope boundary (deliberate)

`protected` exempts entries from the hybrid RETENTION bound only. Genuine memory-pressure LRU (`_evict_lru`) and prefix-subset eviction are unchanged and out of scope for this #1111 regression — matching SGLang/vLLM, where hard resource limits still reclaim otherwise-protected entries (they offload to host; we simply let pressure eviction proceed). Extending `protected` to memory-pressure eviction would risk an unbounded protected set wedging under pressure.

## Test plan

Reworked the four #1111 load-path tests to the protected semantic:
- `test_persistent_load_retains_all_when_disabled` (N=0 import retains all 3).
- `test_persistent_load_imports_are_protected_from_bound` (N=1 import still retains all 3 — protected, exempt from the bound).
- `test_persistent_load_keeps_both_kinds_when_disabled` (N=0 import retains both dense and hybrid).
- `test_merge_load_evicts_opportunistic_not_imported` (merge evicts only unprotected opportunistic entries, never protected imports; `loaded` counts only imports).

Added the codex-requested load-then-store mutation-kill `test_import_survives_a_later_unrelated_live_store` (import -> unrelated live store fires the enforcer -> imported entry MUST remain), a direct enforcer invariant `test_enforcer_never_evicts_protected_imports`, and the seam guard `test_load_seam_imports_protected_at_any_bound`. I verified these regression guards genuinely FAIL when the `and not e.protected` exclusion is reverted (mutation-kills, not vacuous).

Counts: the four original `test_cache_routes.py` roundtrip tests now pass (were 4 failed on #1111 head); full `test_cache_routes.py` 92 passed; `test_hybrid_prefix_cache_growth.py` 32 passed including the reworked + new tests; broad 9-file cache sweep (`test_cache_routes.py`, `test_hybrid_prefix_cache_growth.py`, `test_prefix_cache.py`, `test_memory_cache.py`, `test_prefix_cache_persistence.py`, `test_prefix_cache_eviction.py`, `test_prefix_cache_pressure_eviction.py`, `test_prefix_cache_radix_e2e.py`, `test_cli_bench_hybrid_cache_flag.py`) 322 passed, 0 failed. `ruff check` and `ruff format --check` clean on both changed files.

Before: 4 target roundtrip tests failed (`entries_loaded 1 -> 0`); an imported entry survived 0 subsequent stores at N>0. After: 4 target tests pass; imported entries are protected for their lifetime at every N; opportunistic-store #1075 intent and N>0 bound unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Validation update (full-suite, head 86e9bb8b)

Ran the EXACT pr_validate `full_unit` command in a clean worktree at the pushed head:

```
python -m pytest tests/ --ignore=tests/integrations --ignore=tests/test_event_loop.py -q --no-header
= 12957 passed, 25 skipped, 17 deselected, 6 xfailed, 1 xpassed in 132.79s =
```

Zero failures; the four `test_cache_routes.py` roundtrip tests pass in full-suite collection order. Confirmed deterministic across three independent full runs (two at b4e00119, one at 86e9bb8b) — the isolated-vs-full-suite discrepancy does not reproduce here, so there is no test-pollution or ordering-dependent defect in this branch.

Also reworked `test_merge_load_evicts_opportunistic_not_imported` (which codex correctly noted set bound=2 with exactly 2 entries and never fired eviction) into `test_store_after_import_evicts_oldest_opportunistic_not_import`: it now stores THREE opportunistic entries under N=2 so the enforcer genuinely LRU-evicts the oldest, asserts that eviction fired, and asserts the protected import survives it. Verified as a mutation-kill (fails when the `and not e.protected` exclusion is reverted).


## codex r3 fix (head 3bfe0817): startup auto-load must not immortalize opportunistic entries

codex r3 caught a real semantics bug in the first protected-entry fix: it marked EVERY disk-loaded entry `protected=True`, but this load path serves BOTH the explicit HTTP `POST /v1/cache/import` (#476) AND the process-restart startup auto-load (`runtime/cache.py` lifespan, task #303).

`save_to_disk` persists ALL live entries — including opportunistic (unprotected) non-trimmable ones (verified: the save loop at `memory_cache.py` iterates `self._entries.items()` with no `protected`/`non_trimmable` filter). So with `hybrid_reuse_max_entries=N>0`: shutdown persists N opportunistic entries → next boot reloads them ALL as protected → new opportunistic added within the bound → persisted → protected next boot → the protected set grows ~N per restart, unbounded, defeating the retention cap.

Fix (codex option B, SGLang/vLLM-faithful — `lock_ref`/`ref_cnt` are runtime refcounts, never immortal across a restart; protection is a runtime property of an explicit operator action, not a persisted attribute): thread `protected_import: bool = True` through the load chain (`routes/cache.py` → `engine.load_cache_with_result`/`load_cache_from_disk` → `engine_core.py` → `engine/base.py` [extends the `inspect` backcompat so it's passed only if the callee accepts it, alongside `replace`] → `engine/batched.py` → `scheduler.load_cache_from_disk` → `memory_cache.load_from_disk` → `_CacheEntry(protected=protected_import)`). The ONLY caller passing `False` is the startup auto-load (`runtime/cache.py`), so reloaded non-trimmable entries obey the bound at commit (N=0 default → not retained, #1111's opt-in design; N>0 → bounded at N, no growth). The explicit #476 import keeps the `True` default and stays pinned.

New tests: `test_startup_reload_cycle_does_not_grow_protected_set` (K restart cycles under N, asserts retained non-trimmable never exceeds N) and `test_startup_reload_obeys_bound_while_explicit_import_pins` (same snapshot: `protected_import=False` obeys the bound, `True` pins all). Both verified as mutation-kills (revert to `protected=True` → they fail, 3 > 1). Updated `test_engine_step_thread` fake to assert the threaded `protected_import` passthrough.

Files touched: `vllm_mlx/memory_cache.py`, `vllm_mlx/scheduler.py`, `vllm_mlx/engine_core.py`, `vllm_mlx/engine/base.py`, `vllm_mlx/engine/batched.py`, `vllm_mlx/runtime/cache.py`, `tests/test_hybrid_prefix_cache_growth.py`, `tests/test_engine_step_thread.py`. Full `full_unit` command green: **12959 passed, 0 failed**. ruff check + format clean on all 8.


## codex r4 closing polish (head 6ab17286)

Four findings, all fixed:

- **[BLOCKING 1] Production startup wiring now pinned.** The restart-cycle test called `load_from_disk(..., protected_import=False)` directly, so it couldn't catch `runtime/cache.py` dropping the kwarg. Added `test_production_startup_wiring_passes_protected_import_false`: drives the real `runtime.cache.load_prefix_cache_from_disk()` with a mocked engine + `get_config`/`get_cache_dir` patched, asserts `load_cache_from_disk(protected_import=False)`. Mutation-kill verified (delete the kwarg from `runtime/cache.py` → test fails).
- **[BLOCKING 2] Restart-cycle test no longer satisfied by discard-all.** It only asserted `retained <= n` (which `retained == 0` also passes). Strengthened: persist THREE entries (> n) so the reload must trim; assert `retained == min(persisted, n)` AND survivors are the most-recent `n` persisted keys (LRU tail) AND `retained == n` after the fresh store. Now both "keeps too many" (growth) and "keeps nothing" (discard) fail. Mutation-kill verified (a discard-on-reload impl fails with `retained 0, expected 2`).
- **[NIT 1] `engine/base.py` kwarg forwarding decoupled.** `protected_import` was nested under `accepts_replace`, so an override accepting `protected_import` but not `replace` silently got default `True` even when the caller passed `False`. Rebuilt as an independent per-kwarg loop: forward each accepted kwarg; error only on an UNSUPPORTED NON-DEFAULT value (a default silently dropped is fine). Added `_ProtectedOnlyEngine` / `_ReplaceOnlyEngine` test cases.
- **[NIT 2] Stale field doc fixed.** `_CacheEntry.protected` no longer claims startup auto-load is `protected=True`; now states explicit #476 import → `True`, startup reload → `False`.

Full `full_unit` command: **12960 passed, 0 failed**. ruff check + format clean. Files: `vllm_mlx/memory_cache.py`, `vllm_mlx/engine/base.py`, `tests/test_hybrid_prefix_cache_growth.py`, `tests/test_cache_routes.py` (`runtime/cache.py` unchanged this round — its `protected_import=False` wiring landed in the r3 commit).
