### PR TITLE
fix(lint): reformat test_vision_extra_install.py to satisfy ruff format

### DIFF
--- a/tests/test_vision_extra_install.py
+++ b/tests/test_vision_extra_install.py
@@ -582,9 +582,7 @@ def _spec_excludes_064(spec: str) -> bool:
     from packaging.requirements import Requirement
     from packaging.version import Version
 
-    return not Requirement(spec).specifier.contains(
-        Version("0.6.4"), prereleases=True
-    )
+    return not Requirement(spec).specifier.contains(Version("0.6.4"), prereleases=True)
 
 
 def test_all_mlx_vlm_specs_exclude_broken_064() -> None:


### PR DESCRIPTION
## Motivation

The repo-wide `ruff format --check vllm_mlx/ tests/` CI **lint** gate has been red since #1119 (`abd3f09c`), which landed `tests/test_vision_extra_install.py` with a `return` line exceeding the formatter width. Every PR since has shown a red `lint` check for a pre-existing, unrelated reason.

## Change

Pure mechanical `ruff format` reflow of the one offending line (joins a split `return` onto a single line). **No logic change.** `ruff format --check vllm_mlx/ tests/` is now clean across all 659 files.

## Test plan

- `ruff format --check vllm_mlx/ tests/` → clean (was: 1 file would be reformatted).
- `ruff check` → clean.
- No behavioral change; the affected test's logic is untouched (whitespace only).