### PR TITLE
chore: bump version to 0.10.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.10.10"
+version = "0.10.12"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## Release 0.10.12

This bump-only PR (version 0.10.10 → 0.10.12) exists **because** the 0.10.12 feature batch (#1123, #1124, #1125, #1127) has merged to `main` and must be published. Merging triggers `auto-release.yml`: PyPI publish + GH Release + Homebrew tap update + fresh-venv dogfood.

**Why 0.10.12 (why skip 0.10.11):** even patch = feature release per the project odd/even cadence; this batch is feature-led (the response cache is the headline), so it lands on the next even number and 0.10.11 is left as the unused reserved fix slot.

### What 0.10.12 ships (since 0.10.10)
| PR | Type | Summary |
|----|------|---------|
| #1123 | feat | **Opt-in prompt-deterministic response cache** — exact-match short-circuit returns a previously-computed greedy completion verbatim (zero admission, zero GPU decode). Default OFF (`--response-cache-entries 0`); epoch-versioned cross-model invalidation. SOTA Tier-1. |
| #1124 | fix/perf | Generalize trim-free prefix reuse to sliding-window `RotatingKVCache` (Gemma 4 / GPT-OSS) + exact-hit drift correction. |
| #1125 | fix | Explicit disk import must not be dropped by the prefix-reuse retention bound (#1111 regression; protected-entry rework). |
| #1127 | fix | Green the repo-wide `ruff format` CI lint gate. |

### Verification
- Each engine PR merged with pr_validate evidence (full unit suite green, stress matrix PASSED). #1123's residual codex-blocking items are documented deferrals (tasks #548 byte-budget, #549 single-flight) because they are enhancements, not correctness bugs.
- Version-only diff (1 line); no other files touched.

### Post-merge
Fresh-venv naive-user dogfood (`python -m venv` + `pip install rapid-mlx==0.10.12` + serve one alias per new capability) once PyPI is live.