### PR TITLE
docs(reference): document 0.10.12 opt-in cache flags

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -49,6 +49,8 @@ rapid-mlx serve <model> [options]
 | `--mcp-config` | Path to MCP config file | None |
 | `--paged-cache-block-size` | Tokens per cache block | 64 |
 | `--max-cache-blocks` | Maximum cache blocks | 1000 |
+| `--hybrid-cache-entries` | Opt-in trim-free prefix reuse: retain N non-trimmable prefix-cache entries (stable prefix + new suffix each turn) for hybrid (GatedDeltaNet/Mamba) and sliding-window (Gemma 4, GPT-OSS) models. 0 disables. | 0 |
+| `--response-cache-entries` | Opt-in response cache: retain N fully-computed greedy (`temperature 0` / `top_k 1`) chat completions; a completely repeated request returns the stored completion with zero GPU decode. 0 disables. | 0 |
 | `--max-num-seqs` | Max concurrent sequences | 256 |
 | `--gpu-memory-utilization` | Fraction of device memory for Metal allocation limit (0.0-1.0) | 0.90 |
 | `--default-temperature` | Default temperature when not specified in request | None |

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -37,6 +37,8 @@
 | `--use-paged-cache` | Enable paged KV cache | `false` |
 | `--paged-cache-block-size` | Tokens per block | `64` |
 | `--max-cache-blocks` | Maximum blocks | `1000` |
+| `--hybrid-cache-entries` | Opt-in: retain N non-trimmable prefix-cache entries for prefix-extension reuse (stable prefix + new suffix each turn). Covers hybrid recurrent-state (GatedDeltaNet/Mamba) and sliding-window (Gemma 4, GPT-OSS) models. `0` disables. | `0` |
+| `--response-cache-entries` | Opt-in: retain N fully-computed greedy (`temperature 0` / `top_k 1`) chat completions; a completely repeated request returns the stored completion with zero GPU decode. Sampled requests are never cached. `0` disables. | `0` |
 
 ### Tool Calling Options
 


### PR DESCRIPTION
## What

Add the two opt-in cache flags that shipped in **0.10.12** to the CLI reference tables:

| Flag | Default | What it does |
|------|---------|--------------|
| `--response-cache-entries N` | `0` (off) | Exact-match short-circuit for repeated **greedy** (`temperature 0` / `top_k 1`) chat requests — returns the stored completion with zero GPU decode (PR #1123). |
| `--hybrid-cache-entries N` | `0` (off) | Trim-free prefix reuse: retain N non-trimmable prefix-cache entries (stable prefix + new suffix each turn) for hybrid (GatedDeltaNet/Mamba) and sliding-window (Gemma 4, GPT-OSS) models (PRs #1111, #1124). |

Added to the **Cache Options** table in both `docs/reference/cli.md` and `docs/reference/configuration.md`.

## Why

Both flags shipped in 0.10.12 but were never added to the reference docs, so there was no documented way to discover them outside `rapid-mlx serve --help`. This closes that gap.

## Scope

Doc-only. No code, no `pyproject.toml` version change, no charter files. No `spec_decode/**` / `speculative/**` touched.

## Test plan

- Rendered both tables locally; the two new rows sit under the existing cache flags and match the shipped `serve --help` text and defaults (`0` = disabled).