### PR TITLE
fix(#1126): gemma-4 vision on Homebrew — honest runtime detection + config-authoritative repo-ID MLLM routing

### DIFF
--- a/tests/test_gemma4_vision_autodetect.py
+++ b/tests/test_gemma4_vision_autodetect.py
@@ -1,0 +1,61 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression coverage for #1126 Gemma 4 repo-ID vision routing."""
+
+import json
+
+from vllm_mlx import model_metadata
+from vllm_mlx.api import utils as api_utils
+
+
+def _cached_snapshot(tmp_path, config, weights):
+    snapshot = tmp_path / "snapshot"
+    snapshot.mkdir()
+    (snapshot / "config.json").write_text(json.dumps(config), encoding="utf-8")
+    (snapshot / "model.safetensors.index.json").write_text(
+        json.dumps({"weight_map": weights}), encoding="utf-8"
+    )
+    return snapshot
+
+
+def test_gemma4_repo_id_with_cached_vision_weights_routes_to_mllm(
+    tmp_path, monkeypatch
+):
+    """A Gemma 4 repo ID must use its cached config and vision tensors."""
+    snapshot = _cached_snapshot(
+        tmp_path,
+        {
+            "architectures": ["Gemma4ForConditionalGeneration"],
+            "vision_config": {"hidden_size": 128},
+        },
+        {"vision_tower.encoder.0.weight": "model.safetensors"},
+    )
+    monkeypatch.setattr(
+        model_metadata,
+        "_cached_file",
+        lambda repo_id, filename: (
+            snapshot / filename if filename == "config.json" else None
+        ),
+    )
+
+    assert api_utils.is_mllm_model("mlx-community/gemma-4-26b-a4b-it-4bit")
+
+
+def test_gemma4_configured_text_fork_stays_on_text_route(tmp_path, monkeypatch):
+    """#393 guard: config alone cannot promote a text-only checkpoint."""
+    snapshot = _cached_snapshot(
+        tmp_path,
+        {
+            "architectures": ["Gemma4ForConditionalGeneration"],
+            "vision_config": {"hidden_size": 128},
+        },
+        {"language_model.layers.0.weight": "model.safetensors"},
+    )
+    monkeypatch.setattr(
+        model_metadata,
+        "_cached_file",
+        lambda repo_id, filename: (
+            snapshot / filename if filename == "config.json" else None
+        ),
+    )
+
+    assert not api_utils.is_mllm_model("publisher/gemma4-text-fork")

--- a/tests/test_uitars_boot_check.py
+++ b/tests/test_uitars_boot_check.py
@@ -112,10 +112,15 @@ def test_require_mlx_vlm_or_exit_prints_hint_and_exits(monkeypatch, capsys):
 def test_require_mlx_vlm_or_exit_is_noop_when_installed(monkeypatch):
     """When ``mlx_vlm`` IS installed (or its spec is fakable), the
     guard returns silently — no SystemExit, no stderr output."""
-    from vllm_mlx.models.mllm import require_mlx_vlm_or_exit
+    from vllm_mlx.models.mllm import VisionRuntimeStatus, require_mlx_vlm_or_exit
 
-    # Force the probe to report True without touching sys.modules.
-    monkeypatch.setattr("vllm_mlx.models.mllm.mlx_vlm_available", lambda: True)
+    # Force the runtime probe to report OK without touching sys.modules.
+    # ``require_mlx_vlm_or_exit`` now branches on ``vision_runtime_status()``
+    # directly (single authoritative probe), so patch that.
+    monkeypatch.setattr(
+        "vllm_mlx.models.mllm.vision_runtime_status",
+        lambda: (VisionRuntimeStatus.OK, None),
+    )
 
     # Must not raise SystemExit.
     require_mlx_vlm_or_exit("ui-tars-1.5-7b-4bit")

--- a/tests/test_vision_runtime_detection.py
+++ b/tests/test_vision_runtime_detection.py
@@ -478,6 +478,45 @@ def test_pil_importable_false_when_pillow_damaged(monkeypatch):
     assert env_health._pil_importable() is False
 
 
+def _simulate_pillow_native_backend_broken(monkeypatch):
+    """Pillow's Python layer imports fine but its native ``_imaging`` backend
+    is broken/ABI-mismatched, so a real image op raises. ``find_spec('PIL')``
+    passes and ``from PIL import Image`` succeeds — only touching the native
+    core reveals the breakage.
+
+    Hermetic: inject a stand-in ``PIL`` / ``PIL.Image`` whose ``new`` raises,
+    so no host Pillow (or a real broken build) is required."""
+    import types
+
+    fake_pil = types.ModuleType("PIL")
+    fake_image = types.ModuleType("PIL.Image")
+
+    def _broken_new(*_a, **_k):
+        raise ImportError("The _imaging C module is not installed or ABI-mismatched")
+
+    fake_image.new = _broken_new
+    fake_pil.Image = fake_image
+
+    monkeypatch.setitem(sys.modules, "PIL", fake_pil)
+    monkeypatch.setitem(sys.modules, "PIL.Image", fake_image)
+
+
+def test_pil_importable_false_when_native_backend_broken(monkeypatch):
+    """``_pil_importable`` must return False when Pillow's Python layer imports
+    but its native ``_imaging`` backend is broken — i.e. ``from PIL import
+    Image`` succeeds yet a real op (``Image.new``) raises. A probe that only
+    did the import (no native-backed op) could false-green this."""
+    from vllm_mlx.doctor import env_health
+
+    _simulate_pillow_native_backend_broken(monkeypatch)
+
+    # The import itself succeeds against the stand-in …
+    from PIL import Image  # noqa: F401
+
+    # … but the native-backed probe must still report broken.
+    assert env_health._pil_importable() is False
+
+
 def test_doctor_vision_row_red_when_pillow_damaged(monkeypatch):
     """End-to-end: a damaged/shadowed Pillow must turn the doctor vision +
     dflash rows red, exercising the REAL ``_pil_importable`` (not a stub) so

--- a/tests/test_vision_runtime_detection.py
+++ b/tests/test_vision_runtime_detection.py
@@ -66,7 +66,9 @@ def _simulate_mlx_vlm_present_but_pil_missing(monkeypatch):
         return real_import(name, *args, **kwargs)
 
     monkeypatch.setattr(builtins, "__import__", fake_import)
-    sys.modules.pop("mlx_vlm", None)
+    # ``delitem`` (not ``sys.modules.pop``) so monkeypatch restores any
+    # pre-existing cached ``mlx_vlm`` on teardown → order-independent tests.
+    monkeypatch.delitem(sys.modules, "mlx_vlm", raising=False)
 
 
 def _simulate_mlx_vlm_absent(monkeypatch):
@@ -89,7 +91,45 @@ def _simulate_mlx_vlm_absent(monkeypatch):
         return real_import(name, *args, **kwargs)
 
     monkeypatch.setattr(builtins, "__import__", fake_import)
-    sys.modules.pop("mlx_vlm", None)
+    monkeypatch.delitem(sys.modules, "mlx_vlm", raising=False)
+
+
+def _spec_present_for_mlx_vlm(monkeypatch):
+    """Make ``find_spec('mlx_vlm')`` report the top-level package present
+    (installed) without importing it — shared setup for the "installed but
+    the import chain is broken" simulators below."""
+    real_find_spec = _ilu.find_spec
+
+    def fake_find_spec(name, *args, **kwargs):
+        if name == "mlx_vlm":
+            spec = real_find_spec(name, *args, **kwargs)
+            return spec if spec is not None else object()
+        return real_find_spec(name, *args, **kwargs)
+
+    monkeypatch.setattr(_ilu, "find_spec", fake_find_spec)
+
+
+def _simulate_mlx_vlm_installed_but_import_raises(monkeypatch, exc):
+    """mlx-vlm's top-level package IS installed (``find_spec`` present) but
+    ``import mlx_vlm`` raises ``exc``.
+
+    Covers the states the pre-fix name-heuristic mishandled:
+    * a damaged/incomplete install whose OWN submodule is missing
+      (``ModuleNotFoundError(name='mlx_vlm.<sub>')`` → was wrongly ABSENT),
+    * a missing shared lib / broken native ext
+      (``OSError``/``RuntimeError`` → previously ESCAPED and crashed the guard).
+    """
+    _spec_present_for_mlx_vlm(monkeypatch)
+
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "mlx_vlm" or name.startswith("mlx_vlm."):
+            raise exc
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    monkeypatch.delitem(sys.modules, "mlx_vlm", raising=False)
 
 
 # ─────────────────────────────────────────────────────────────────────────
@@ -134,6 +174,85 @@ def test_mlx_vlm_available_false_when_pil_missing(monkeypatch):
     _simulate_mlx_vlm_present_but_pil_missing(monkeypatch)
 
     assert mlx_vlm_available() is False
+
+
+def test_status_broken_when_internal_submodule_missing(monkeypatch):
+    """A damaged/incomplete mlx-vlm whose OWN internal submodule is missing
+    (``ModuleNotFoundError(name='mlx_vlm.<sub>')``) is installed-but-broken,
+    NOT absent. Pre-fix the ``name.startswith('mlx_vlm')`` heuristic
+    mislabelled it ABSENT → misleading "install mlx-vlm" for an install that
+    is already present."""
+    from vllm_mlx.models.mllm import VisionRuntimeStatus, vision_runtime_status
+
+    _simulate_mlx_vlm_installed_but_import_raises(
+        monkeypatch,
+        ModuleNotFoundError(
+            "No module named 'mlx_vlm.trainer'", name="mlx_vlm.trainer"
+        ),
+    )
+
+    status, detail = vision_runtime_status()
+    assert status is VisionRuntimeStatus.BROKEN, (
+        f"present-but-damaged mlx-vlm must be BROKEN, not ABSENT; got {status}"
+    )
+    assert detail, "BROKEN must carry an actionable diagnostic, not None/empty"
+
+
+def test_status_broken_when_import_raises_oserror(monkeypatch):
+    """A missing shared library surfaces as ``OSError`` from ``import
+    mlx_vlm``. Pre-fix this ESCAPED ``vision_runtime_status`` (only
+    ModuleNotFoundError/ImportError were caught) and crashed the boot guard;
+    it must now be classified BROKEN without raising."""
+    from vllm_mlx.models.mllm import VisionRuntimeStatus, vision_runtime_status
+
+    _simulate_mlx_vlm_installed_but_import_raises(
+        monkeypatch, OSError("dlopen(libmlx.dylib): image not found")
+    )
+
+    status, detail = vision_runtime_status()  # must NOT raise
+    assert status is VisionRuntimeStatus.BROKEN, (
+        f"OSError on import ⇒ installed-but-broken, got {status}"
+    )
+    assert detail, "BROKEN must retain a diagnostic for the OSError failure"
+
+
+def test_status_broken_when_import_raises_runtimeerror(monkeypatch):
+    """A broken native extension / ABI mismatch can raise ``RuntimeError``
+    on import — also non-control-flow, also previously escaping. Must be
+    BROKEN, not a crash."""
+    from vllm_mlx.models.mllm import VisionRuntimeStatus, vision_runtime_status
+
+    _simulate_mlx_vlm_installed_but_import_raises(
+        monkeypatch, RuntimeError("incompatible mlx ABI")
+    )
+
+    status, detail = vision_runtime_status()  # must NOT raise
+    assert status is VisionRuntimeStatus.BROKEN
+    assert detail
+
+
+def test_boot_guard_exit_2_when_import_raises_oserror(monkeypatch, capsys):
+    """The tri-state contract's whole point: a missing-shared-lib ``OSError``
+    must be caught and turned into a clean exit-code-2 boot guard with an
+    honest diagnostic — NOT propagate as an uncaught crash, and NOT misdirect
+    the user to "install mlx-vlm" (which IS installed)."""
+    from vllm_mlx.models.mllm import require_mlx_vlm_or_exit
+
+    _simulate_mlx_vlm_installed_but_import_raises(
+        monkeypatch, OSError("dlopen(libmlx.dylib): image not found")
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        require_mlx_vlm_or_exit("gemma-4-26b-a4b-it-4bit")
+    assert exc_info.value.code == 2
+
+    err = capsys.readouterr().err
+    assert "vision runtime cannot load" in err, (
+        f"broken-runtime boot hint must say the runtime can't load, got: {err!r}"
+    )
+    # Honest: the primary directive must NOT be the misleading bare
+    # "install mlx-vlm" absent message — it IS installed.
+    assert "requires the optional `mlx-vlm` dependency" not in err
 
 
 # ─────────────────────────────────────────────────────────────────────────
@@ -306,3 +425,68 @@ def test_doctor_vision_row_warns_when_mlx_vlm_truly_absent(monkeypatch):
         f"truly-absent mlx-vlm must WARN, got {vision_row.status}"
     )
     assert "not installed" in vision_row.label.lower()
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Doctor's PIL probe must reflect the REAL import, not just find_spec.
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def _simulate_pillow_damaged(monkeypatch):
+    """Shadowed/damaged Pillow: ``find_spec('PIL')`` still succeeds (a dir /
+    stale metadata named PIL is discoverable) but the real ``from PIL import
+    Image`` raises — the exact false-green ``find_spec``-only probing would
+    miss. Leaves ``importlib.util.find_spec`` untouched precisely so a
+    find_spec-based probe would WRONGLY pass."""
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "PIL" or name.startswith("PIL."):
+            raise ImportError("cannot import name 'Image' from 'PIL' (shadowed)")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    monkeypatch.delitem(sys.modules, "PIL", raising=False)
+    monkeypatch.delitem(sys.modules, "PIL.Image", raising=False)
+
+
+def test_pil_importable_false_when_pillow_damaged(monkeypatch):
+    """``_pil_importable`` must return False when the real ``from PIL import
+    Image`` raises even though something named PIL is discoverable. Pre-fix it
+    used ``find_spec('PIL')`` only and returned True (false green)."""
+    from vllm_mlx.doctor import env_health
+
+    # find_spec('PIL') still resolves on this dev box (Pillow installed) —
+    # a find_spec-only probe would (wrongly) pass here.
+    assert _ilu.find_spec("PIL") is not None
+    _simulate_pillow_damaged(monkeypatch)
+
+    assert env_health._pil_importable() is False
+
+
+def test_doctor_vision_row_red_when_pillow_damaged(monkeypatch):
+    """End-to-end: a damaged/shadowed Pillow must turn the doctor vision +
+    dflash rows red, exercising the REAL ``_pil_importable`` (not a stub) so
+    the find_spec-only false-green regression stays pinned."""
+    from vllm_mlx.doctor import env_health
+    from vllm_mlx.doctor.env_health import CheckStatus
+
+    def fake_safe_version(dist):
+        return "0.6.5" if dist == "mlx-vlm" else None
+
+    monkeypatch.setattr(env_health, "_safe_version", fake_safe_version)
+    _simulate_pillow_damaged(monkeypatch)
+
+    section = env_health.section_optional_packages()
+
+    vision_row = _find_row(section, "mlx-vlm", "vision")
+    assert vision_row is not None, "vision (mlx-vlm) row missing from doctor"
+    assert vision_row.status is not CheckStatus.OK, (
+        f"vision row must NOT be green when Pillow is damaged, got "
+        f"{vision_row.status}: {vision_row.label!r}"
+    )
+    assert "pil" in vision_row.label.lower() or "pillow" in vision_row.label.lower()
+
+    dflash_row = _find_row(section, "dflash")
+    assert dflash_row is not None
+    assert dflash_row.status is not CheckStatus.OK

--- a/tests/test_vision_runtime_detection.py
+++ b/tests/test_vision_runtime_detection.py
@@ -433,11 +433,25 @@ def test_doctor_vision_row_warns_when_mlx_vlm_truly_absent(monkeypatch):
 
 
 def _simulate_pillow_damaged(monkeypatch):
-    """Shadowed/damaged Pillow: ``find_spec('PIL')`` still succeeds (a dir /
-    stale metadata named PIL is discoverable) but the real ``from PIL import
-    Image`` raises — the exact false-green ``find_spec``-only probing would
-    miss. Leaves ``importlib.util.find_spec`` untouched precisely so a
-    find_spec-based probe would WRONGLY pass."""
+    """Shadowed/damaged Pillow: a ``PIL`` spec is discoverable but the real
+    ``from PIL import Image`` raises — the exact false-green a
+    ``find_spec('PIL')``-only probe would miss.
+
+    BOTH the spec presence AND the failing import are simulated so the test is
+    hermetic on the supported base install that intentionally omits the
+    ``[vision]`` extra (no host Pillow required)."""
+    real_find_spec = _ilu.find_spec
+
+    def fake_find_spec(name, *args, **kwargs):
+        if name == "PIL":
+            # Discoverable even where Pillow isn't installed — a find_spec-only
+            # probe would WRONGLY pass here.
+            spec = real_find_spec(name, *args, **kwargs)
+            return spec if spec is not None else object()
+        return real_find_spec(name, *args, **kwargs)
+
+    monkeypatch.setattr(_ilu, "find_spec", fake_find_spec)
+
     real_import = builtins.__import__
 
     def fake_import(name, *args, **kwargs):
@@ -456,11 +470,11 @@ def test_pil_importable_false_when_pillow_damaged(monkeypatch):
     used ``find_spec('PIL')`` only and returned True (false green)."""
     from vllm_mlx.doctor import env_health
 
-    # find_spec('PIL') still resolves on this dev box (Pillow installed) —
-    # a find_spec-only probe would (wrongly) pass here.
-    assert _ilu.find_spec("PIL") is not None
     _simulate_pillow_damaged(monkeypatch)
 
+    # A find_spec-only probe (the pre-fix behaviour) would pass here — the
+    # simulated spec is discoverable — yet the real import is broken.
+    assert _ilu.find_spec("PIL") is not None
     assert env_health._pil_importable() is False
 
 

--- a/tests/test_vision_runtime_detection.py
+++ b/tests/test_vision_runtime_detection.py
@@ -1,0 +1,308 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for #1126 (honest vision-runtime detection — the
+Homebrew ``pip install --no-deps mlx-vlm`` half).
+
+Root cause: Homebrew installs mlx-vlm with ``pip install --no-deps
+mlx-vlm``, so mlx-vlm's source + dist metadata exist but its runtime dep
+Pillow (PIL) does NOT. Three separate "is vision available?" checks all
+answered YES from metadata/spec:
+
+* ``importlib.metadata.version("mlx-vlm")`` returns a version (doctor's
+  ``_safe_version`` → green ``✓ mlx-vlm``),
+* ``importlib.util.find_spec("mlx_vlm")`` is not None
+  (``mlx_vlm_available`` → boot guard passes),
+
+while the REAL ``import mlx_vlm`` crashes on ``from PIL import Image``
+(mlx_vlm/utils.py) — deep inside FastAPI lifespan, with a message telling
+the user to install mlx-vlm (which IS installed).
+
+The invariant these tests pin: **when mlx-vlm's metadata/spec is present
+but its import chain is broken, every "is vision usable?" surface reports
+not-usable and names the actually-missing module (PIL), distinct from the
+"mlx-vlm truly absent" message.** They simulate the PIL-missing state via
+monkeypatch (find_spec present, ``import mlx_vlm`` raising
+``ModuleNotFoundError("No module named 'PIL'")``) so they run on a normal
+dev machine where mlx-vlm + PIL are actually installed.
+
+These assertions FAIL against the pre-fix code (find_spec-only /
+metadata-only checks report "available"/green) and PASS after.
+"""
+
+from __future__ import annotations
+
+import builtins
+import importlib.util as _ilu
+import sys
+
+import pytest
+
+# ─────────────────────────────────────────────────────────────────────────
+# Simulators
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def _simulate_mlx_vlm_present_but_pil_missing(monkeypatch):
+    """Homebrew ``--no-deps`` state: ``find_spec('mlx_vlm')`` is not None
+    (dist present) but ``import mlx_vlm`` raises
+    ``ModuleNotFoundError("No module named 'PIL'")``."""
+    real_find_spec = _ilu.find_spec
+
+    def fake_find_spec(name, *args, **kwargs):
+        if name == "mlx_vlm":
+            # mlx-vlm's spec/metadata IS present (installed --no-deps).
+            spec = real_find_spec(name, *args, **kwargs)
+            return spec if spec is not None else object()
+        return real_find_spec(name, *args, **kwargs)
+
+    monkeypatch.setattr(_ilu, "find_spec", fake_find_spec)
+
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "mlx_vlm" or name.startswith("mlx_vlm."):
+            # Mirror the real crash inside mlx_vlm/utils.py:
+            # ``from PIL import Image`` with PIL uninstalled.
+            raise ModuleNotFoundError("No module named 'PIL'", name="PIL")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    sys.modules.pop("mlx_vlm", None)
+
+
+def _simulate_mlx_vlm_absent(monkeypatch):
+    """Plain ``pip install rapid-mlx`` state: mlx-vlm not installed at all
+    (``find_spec`` None, import raises for the package itself)."""
+    real_find_spec = _ilu.find_spec
+
+    def fake_find_spec(name, *args, **kwargs):
+        if name == "mlx_vlm" or name.startswith("mlx_vlm."):
+            return None
+        return real_find_spec(name, *args, **kwargs)
+
+    monkeypatch.setattr(_ilu, "find_spec", fake_find_spec)
+
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "mlx_vlm" or name.startswith("mlx_vlm."):
+            raise ModuleNotFoundError("No module named 'mlx_vlm'", name="mlx_vlm")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    sys.modules.pop("mlx_vlm", None)
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Tri-state runtime status: the single source of truth.
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def test_status_broken_when_pil_missing(monkeypatch):
+    """mlx-vlm present but PIL missing ⇒ status is the "present-but-broken"
+    state and names the missing module (PIL), NOT "absent"."""
+    from vllm_mlx.models.mllm import VisionRuntimeStatus, vision_runtime_status
+
+    _simulate_mlx_vlm_present_but_pil_missing(monkeypatch)
+
+    status, missing = vision_runtime_status()
+    assert status is VisionRuntimeStatus.BROKEN, (
+        f"expected BROKEN (metadata present, import chain broken), got {status}"
+    )
+    assert missing == "PIL", f"missing module should be PIL, got {missing!r}"
+
+
+def test_status_absent_when_mlx_vlm_missing(monkeypatch):
+    """mlx-vlm not installed at all ⇒ status is "absent" (distinct from
+    broken)."""
+    from vllm_mlx.models.mllm import VisionRuntimeStatus, vision_runtime_status
+
+    _simulate_mlx_vlm_absent(monkeypatch)
+
+    status, _missing = vision_runtime_status()
+    assert status is VisionRuntimeStatus.ABSENT, (
+        f"expected ABSENT (mlx-vlm not installed), got {status}"
+    )
+
+
+def test_mlx_vlm_available_false_when_pil_missing(monkeypatch):
+    """The boot-guard presence probe must be honest: metadata/spec present
+    but a broken import chain ⇒ NOT available. Pre-fix this returned True
+    (find_spec-only), so the boot guard passed and the crash surfaced deep
+    in FastAPI lifespan."""
+    from vllm_mlx.models.mllm import mlx_vlm_available
+
+    _simulate_mlx_vlm_present_but_pil_missing(monkeypatch)
+
+    assert mlx_vlm_available() is False
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Engine-side guard: message names PIL, distinct from the absent message.
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def test_require_mlx_vlm_message_names_pil_when_broken(monkeypatch):
+    """``_require_mlx_vlm`` (engine-side last line of defence) must raise an
+    ImportError that names the actually-missing module (PIL) rather than
+    telling the user to install mlx-vlm (which IS installed)."""
+    from vllm_mlx.models.mllm import _require_mlx_vlm
+
+    _simulate_mlx_vlm_present_but_pil_missing(monkeypatch)
+
+    with pytest.raises(ImportError) as exc_info:
+        _require_mlx_vlm()
+    msg = str(exc_info.value)
+    assert "PIL" in msg, f"broken-runtime message must name PIL, got: {msg!r}"
+
+
+def test_broken_and_absent_messages_are_distinct(monkeypatch):
+    """The two failure modes must NOT collapse into the same message: the
+    broken message names the missing runtime dep (PIL); the absent message
+    tells the user to install mlx-vlm. A user staring at 'install mlx-vlm'
+    while mlx-vlm IS installed is the exact #1126 confusion."""
+    from vllm_mlx.models.mllm import _require_mlx_vlm
+
+    _simulate_mlx_vlm_present_but_pil_missing(monkeypatch)
+    with pytest.raises(ImportError) as broken_exc:
+        _require_mlx_vlm()
+    broken_msg = str(broken_exc.value)
+
+    _simulate_mlx_vlm_absent(monkeypatch)
+    with pytest.raises(ImportError) as absent_exc:
+        _require_mlx_vlm()
+    absent_msg = str(absent_exc.value)
+
+    assert broken_msg != absent_msg, (
+        "broken and absent messages must differ so the user can tell "
+        "'install pillow' apart from 'install mlx-vlm'"
+    )
+    assert "PIL" in broken_msg and "PIL" not in absent_msg, (
+        f"only the broken message should name PIL. broken={broken_msg!r} "
+        f"absent={absent_msg!r}"
+    )
+
+
+def test_boot_guard_exit_message_names_pil_when_broken(monkeypatch, capsys):
+    """``require_mlx_vlm_or_exit`` must preserve its exit-code-2 shape AND
+    name PIL in the broken case so the operator sees the actionable hint on
+    stderr before any download starts."""
+    from vllm_mlx.models.mllm import require_mlx_vlm_or_exit
+
+    _simulate_mlx_vlm_present_but_pil_missing(monkeypatch)
+
+    with pytest.raises(SystemExit) as exc_info:
+        require_mlx_vlm_or_exit("gemma-4-26b-a4b-it-4bit")
+    assert exc_info.value.code == 2
+
+    err = capsys.readouterr().err
+    assert "PIL" in err or "Pillow" in err, (
+        f"broken-runtime boot hint must name Pillow/PIL, got: {err!r}"
+    )
+    # Still points at the fix.
+    assert "rapid-mlx[vision]" in err or "pillow" in err.lower()
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Doctor: the vision + dflash rows must not be green when mlx-vlm metadata
+# is present but PIL is missing.
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def _find_row(section, *needles):
+    for check in section.checks:
+        low = check.label.lower()
+        if all(n.lower() in low for n in needles):
+            return check
+    return None
+
+
+def test_doctor_vision_row_not_ok_and_names_pil_when_pil_missing(monkeypatch):
+    """``rapid-mlx doctor`` must NOT show a green ``✓ mlx-vlm (vision
+    extras)`` when mlx-vlm metadata is present but the import chain is
+    broken (PIL missing). It must WARN/FAIL and name PIL/Pillow.
+
+    The check stays FAST (≤5 s doctor contract) — a lightweight
+    ``find_spec('PIL')`` probe, not a heavy ``import mlx_vlm`` that would
+    pull torch."""
+    from vllm_mlx.doctor import env_health
+    from vllm_mlx.doctor.env_health import CheckStatus
+
+    # mlx-vlm metadata present (Homebrew --no-deps), PIL not importable.
+    def fake_safe_version(dist):
+        if dist == "mlx-vlm":
+            return "0.6.5"
+        return None
+
+    monkeypatch.setattr(env_health, "_safe_version", fake_safe_version)
+    monkeypatch.setattr(env_health, "_pil_importable", lambda: False)
+
+    section = env_health.section_optional_packages()
+
+    vision_row = _find_row(section, "mlx-vlm", "vision")
+    assert vision_row is not None, "vision (mlx-vlm) row missing from doctor"
+    assert vision_row.status is not CheckStatus.OK, (
+        f"vision row must NOT be green when PIL is missing, got {vision_row.status}: "
+        f"{vision_row.label!r}"
+    )
+    assert "pil" in vision_row.label.lower() or "pillow" in vision_row.label.lower(), (
+        f"vision row must name PIL/Pillow so the user knows the real gap, "
+        f"got: {vision_row.label!r}"
+    )
+
+    dflash_row = _find_row(section, "dflash")
+    assert dflash_row is not None, "dflash row missing from doctor"
+    assert dflash_row.status is not CheckStatus.OK, (
+        f"dflash row must NOT be green when PIL missing, got {dflash_row.status}"
+    )
+    assert "pil" in dflash_row.label.lower() or "pillow" in dflash_row.label.lower(), (
+        f"dflash row must name PIL/Pillow, got: {dflash_row.label!r}"
+    )
+
+
+def test_doctor_vision_row_ok_when_pil_present(monkeypatch):
+    """Guard against over-warning: when BOTH mlx-vlm metadata AND PIL are
+    present the vision + dflash rows stay green — the honest-detection fix
+    must not turn a healthy vision install red."""
+    from vllm_mlx.doctor import env_health
+    from vllm_mlx.doctor.env_health import CheckStatus
+
+    def fake_safe_version(dist):
+        if dist == "mlx-vlm":
+            return "0.6.5"
+        return None
+
+    monkeypatch.setattr(env_health, "_safe_version", fake_safe_version)
+    monkeypatch.setattr(env_health, "_pil_importable", lambda: True)
+
+    section = env_health.section_optional_packages()
+    vision_row = _find_row(section, "mlx-vlm", "vision")
+    assert vision_row is not None
+    assert vision_row.status is CheckStatus.OK, (
+        f"vision row should be green when mlx-vlm + PIL both present, got "
+        f"{vision_row.status}: {vision_row.label!r}"
+    )
+    dflash_row = _find_row(section, "dflash")
+    assert dflash_row is not None
+    assert dflash_row.status is CheckStatus.OK
+
+
+def test_doctor_vision_row_warns_when_mlx_vlm_truly_absent(monkeypatch):
+    """The truly-absent path must still WARN as before (not silently pass,
+    not spuriously name PIL). Preserves the existing text-only install
+    messaging."""
+    from vllm_mlx.doctor import env_health
+    from vllm_mlx.doctor.env_health import CheckStatus
+
+    # mlx-vlm not installed at all.
+    monkeypatch.setattr(env_health, "_safe_version", lambda dist: None)
+    # PIL state is irrelevant when mlx-vlm itself is absent, but pin it
+    # present so a spurious PIL mention can't sneak in via the absent path.
+    monkeypatch.setattr(env_health, "_pil_importable", lambda: True)
+
+    section = env_health.section_optional_packages()
+    vision_row = _find_row(section, "mlx-vlm", "vision")
+    assert vision_row is not None
+    assert vision_row.status is CheckStatus.WARN, (
+        f"truly-absent mlx-vlm must WARN, got {vision_row.status}"
+    )
+    assert "not installed" in vision_row.label.lower()

--- a/vllm_mlx/doctor/env_health.py
+++ b/vllm_mlx/doctor/env_health.py
@@ -425,6 +425,23 @@ def _safe_version(dist: str) -> str | None:
         return None
 
 
+def _pil_importable() -> bool:
+    """Lightweight probe: is Pillow (import name ``PIL``) importable?
+
+    mlx-vlm does ``from PIL import Image`` at module load, so a present
+    mlx-vlm with an absent PIL — the Homebrew ``pip install --no-deps
+    mlx-vlm`` state (#1126) — is a FALSE positive: metadata says
+    installed, but every vision path crashes on import. We probe via
+    ``find_spec`` (NOT a real ``import mlx_vlm``) to keep ``doctor`` fast
+    (≤5 s contract; a real vision import would pull torch)."""
+    import importlib.util
+
+    try:
+        return importlib.util.find_spec("PIL") is not None
+    except (ImportError, ValueError):
+        return False
+
+
 def _version_at_least(ver: str, minimum: tuple[int, ...]) -> bool:
     """Compare a PEP 440 version string against a ``(major, minor, patch)``
     floor using leading-numeric tuple semantics.
@@ -479,6 +496,23 @@ def section_optional_packages() -> Section:
     for dist, label, hint in OPTIONAL_PACKAGES:
         ver = _safe_version(dist)
         if ver:
+            # #1126: mlx-vlm imports Pillow (PIL) at load. A present
+            # mlx-vlm with an absent PIL (Homebrew `pip install --no-deps
+            # mlx-vlm`) is a FALSE positive — metadata says "installed" but
+            # every vision path crashes on `from PIL import Image` deep in
+            # the FastAPI lifespan. Report it honestly and name the real
+            # gap so the user fixes the right thing.
+            if dist == "mlx-vlm" and not _pil_importable():
+                s.add(
+                    f"{label} {ver} present but Pillow (PIL) missing — "
+                    f"vision paths will fail (`{hint}`)",
+                    CheckStatus.WARN,
+                    detail=(
+                        f"distribution={dist} version={ver} pil=missing "
+                        f"hint={hint}"
+                    ),
+                )
+                continue
             s.add(
                 f"{label} {ver}",
                 CheckStatus.OK,
@@ -499,11 +533,25 @@ def section_optional_packages() -> Section:
     dflash_min = (0, 5, 0)
     vlm_ver = _safe_version("mlx-vlm")
     if vlm_ver and _version_at_least(vlm_ver, dflash_min):
-        s.add(
-            "mlx-vlm 0.5.0+ (dflash extras)",
-            CheckStatus.OK,
-            detail=f"distribution=mlx-vlm version={vlm_ver}",
-        )
+        # #1126: same PIL honesty as the vision row — a version-adequate
+        # mlx-vlm whose Pillow dep is missing can't actually run the
+        # dflash/vision runtime, so don't paint it green.
+        if not _pil_importable():
+            s.add(
+                "mlx-vlm 0.5.0+ (dflash extras) present but Pillow (PIL) "
+                "missing — dflash/vision paths will fail",
+                CheckStatus.WARN,
+                detail=(
+                    f"distribution=mlx-vlm version={vlm_ver} pil=missing "
+                    "hint=pip install 'rapid-mlx[vision]'"
+                ),
+            )
+        else:
+            s.add(
+                "mlx-vlm 0.5.0+ (dflash extras)",
+                CheckStatus.OK,
+                detail=f"distribution=mlx-vlm version={vlm_ver}",
+            )
     else:
         current = vlm_ver or "not installed"
         s.add(

--- a/vllm_mlx/doctor/env_health.py
+++ b/vllm_mlx/doctor/env_health.py
@@ -437,13 +437,21 @@ def _pil_importable() -> bool:
     We perform the EXACT lightweight import mlx-vlm uses rather than a
     ``find_spec('PIL')`` probe: ``find_spec`` only proves *something named
     PIL is discoverable*, so a shadowed namespace dir or a damaged Pillow
-    (broken ``_imaging`` C extension) whose real ``from PIL import Image``
-    raises would still get a green row. ``PIL.Image`` is a small pure-Python
-    module over a C extension — well within doctor's ≤5 s budget and it does
-    NOT pull torch the way a real ``import mlx_vlm`` would. ANY failure
-    (missing, shadowed, broken native ext) ⇒ not importable."""
+    whose real ``from PIL import Image`` raises would still get a green row.
+    We then run a minimal native-backed op (``Image.new``) so a Pillow whose
+    Python layer imports but whose ``_imaging`` C extension is missing or
+    ABI-mismatched — present-but-broken, not merely absent — is caught too,
+    without relying on the version-specific moment Pillow first touches
+    ``_imaging``. ``PIL.Image`` + a 1×1 allocation is microsecond-cheap and
+    does NOT pull torch the way a real ``import mlx_vlm`` would, so it stays
+    well within doctor's ≤5 s budget. ANY failure (missing, shadowed, broken
+    native ext) ⇒ not importable."""
     try:
-        from PIL import Image  # noqa: F401
+        from PIL import Image
+
+        # Force the native ``_imaging`` backend to actually initialise — a
+        # broken/ABI-mismatched C ext otherwise slips through as healthy.
+        Image.new("RGB", (1, 1))
     except Exception:
         # ImportError (absent/shadowed), OSError (broken native ext), or any
         # other load-time failure — all mean the real vision import can't run.

--- a/vllm_mlx/doctor/env_health.py
+++ b/vllm_mlx/doctor/env_health.py
@@ -513,11 +513,12 @@ def section_optional_packages() -> Section:
             # gap so the user fixes the right thing.
             if dist == "mlx-vlm" and not _pil_importable():
                 s.add(
-                    f"{label} {ver} present but Pillow (PIL) missing — "
-                    f"vision paths will fail (`{hint}`)",
+                    f"{label} {ver} present but Pillow (PIL) missing or "
+                    f"broken — vision paths will fail (`{hint}`)",
                     CheckStatus.WARN,
                     detail=(
-                        f"distribution={dist} version={ver} pil=missing hint={hint}"
+                        f"distribution={dist} version={ver} "
+                        f"pil=missing-or-broken hint={hint}"
                     ),
                 )
                 continue
@@ -547,11 +548,11 @@ def section_optional_packages() -> Section:
         if not _pil_importable():
             s.add(
                 "mlx-vlm 0.5.0+ (dflash extras) present but Pillow (PIL) "
-                "missing — dflash/vision paths will fail",
+                "missing or broken — dflash/vision paths will fail",
                 CheckStatus.WARN,
                 detail=(
-                    f"distribution=mlx-vlm version={vlm_ver} pil=missing "
-                    "hint=pip install 'rapid-mlx[vision]'"
+                    f"distribution=mlx-vlm version={vlm_ver} "
+                    "pil=missing-or-broken hint=pip install 'rapid-mlx[vision]'"
                 ),
             )
         else:

--- a/vllm_mlx/doctor/env_health.py
+++ b/vllm_mlx/doctor/env_health.py
@@ -426,20 +426,29 @@ def _safe_version(dist: str) -> str | None:
 
 
 def _pil_importable() -> bool:
-    """Lightweight probe: is Pillow (import name ``PIL``) importable?
+    """Lightweight probe: does mlx-vlm's ``from PIL import Image`` actually
+    work?
 
     mlx-vlm does ``from PIL import Image`` at module load, so a present
     mlx-vlm with an absent PIL — the Homebrew ``pip install --no-deps
-    mlx-vlm`` state (#1126) — is a FALSE positive: metadata says
-    installed, but every vision path crashes on import. We probe via
-    ``find_spec`` (NOT a real ``import mlx_vlm``) to keep ``doctor`` fast
-    (≤5 s contract; a real vision import would pull torch)."""
-    import importlib.util
+    mlx-vlm`` state (#1126) — is a FALSE positive: metadata says installed,
+    but every vision path crashes on import.
 
+    We perform the EXACT lightweight import mlx-vlm uses rather than a
+    ``find_spec('PIL')`` probe: ``find_spec`` only proves *something named
+    PIL is discoverable*, so a shadowed namespace dir or a damaged Pillow
+    (broken ``_imaging`` C extension) whose real ``from PIL import Image``
+    raises would still get a green row. ``PIL.Image`` is a small pure-Python
+    module over a C extension — well within doctor's ≤5 s budget and it does
+    NOT pull torch the way a real ``import mlx_vlm`` would. ANY failure
+    (missing, shadowed, broken native ext) ⇒ not importable."""
     try:
-        return importlib.util.find_spec("PIL") is not None
-    except (ImportError, ValueError):
+        from PIL import Image  # noqa: F401
+    except Exception:
+        # ImportError (absent/shadowed), OSError (broken native ext), or any
+        # other load-time failure — all mean the real vision import can't run.
         return False
+    return True
 
 
 def _version_at_least(ver: str, minimum: tuple[int, ...]) -> bool:

--- a/vllm_mlx/doctor/env_health.py
+++ b/vllm_mlx/doctor/env_health.py
@@ -508,8 +508,7 @@ def section_optional_packages() -> Section:
                     f"vision paths will fail (`{hint}`)",
                     CheckStatus.WARN,
                     detail=(
-                        f"distribution={dist} version={ver} pil=missing "
-                        f"hint={hint}"
+                        f"distribution={dist} version={ver} pil=missing hint={hint}"
                     ),
                 )
                 continue

--- a/vllm_mlx/models/mllm.py
+++ b/vllm_mlx/models/mllm.py
@@ -170,8 +170,7 @@ def require_mlx_vlm_or_exit(model_name: str) -> None:
     if status is VisionRuntimeStatus.BROKEN and missing:
         print(
             f"error: model {model_name!r} is a vision/multimodal alias, but "
-            f"the vision runtime cannot load.\n"
-            + _vlm_broken_install_hint(missing),
+            f"the vision runtime cannot load.\n" + _vlm_broken_install_hint(missing),
             file=sys.stderr,
         )
     else:

--- a/vllm_mlx/models/mllm.py
+++ b/vllm_mlx/models/mllm.py
@@ -18,6 +18,7 @@ import base64
 import logging
 import math
 import os
+import re
 import sys
 import tempfile
 import threading
@@ -62,12 +63,15 @@ class VisionRuntimeStatus(str, Enum):
     * ``OK`` — ``import mlx_vlm`` succeeds; vision paths are usable.
     * ``ABSENT`` — ``mlx-vlm`` is not installed at all (plain
       ``pip install rapid-mlx`` without the ``[vision]`` extra).
-    * ``BROKEN`` — ``mlx-vlm`` IS installed (dist metadata + import spec
-      present) but a runtime dependency it needs (e.g. Pillow / ``PIL``)
-      is missing, so the real ``import mlx_vlm`` raises. This is the
-      Homebrew ``pip install --no-deps mlx-vlm`` state that #1126 is
-      about: three separate metadata/spec-only checks answered "yes"
-      while ``import mlx_vlm`` crashed on ``from PIL import Image``.
+    * ``BROKEN`` — the top-level ``mlx_vlm`` package IS installed (its
+      import spec is present) but the real ``import mlx_vlm`` raises. The
+      canonical case is the Homebrew ``pip install --no-deps mlx-vlm`` state
+      #1126 is about — a missing runtime dependency (Pillow / ``PIL``) —
+      where metadata/spec-only checks answered "yes" while the import
+      crashed on ``from PIL import Image``. It also covers a damaged internal
+      ``mlx_vlm.<sub>`` submodule, an incompatible symbol (``ImportError``),
+      and a missing shared library (``OSError``/``RuntimeError``): all mean
+      "installed but not loadable", never "absent".
     """
 
     OK = "ok"
@@ -75,58 +79,119 @@ class VisionRuntimeStatus(str, Enum):
     BROKEN = "broken"
 
 
+# A bare or dotted Python module name (``PIL``, ``mlx_vlm.trainer``) — used
+# to tell a "missing importable module" diagnostic apart from an opaque
+# failure summary (``OSError: dlopen(...): image not found``).
+_MODULE_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)*$")
+
+
+def _looks_like_module_name(detail: str | None) -> bool:
+    """True iff ``detail`` is a plain import-module name (no spaces/punct)."""
+    return bool(detail) and _MODULE_NAME_RE.match(detail) is not None
+
+
+def _mlx_vlm_installed() -> bool:
+    """Is the TOP-LEVEL ``mlx_vlm`` package installed on the import path,
+    independent of whether its import chain (Pillow, native libs, internal
+    submodules) actually loads?
+
+    Package PRESENCE — not an exception-``name`` heuristic — is the
+    authoritative ``ABSENT`` vs ``BROKEN`` discriminator (#1126). Probing the
+    top-level spec ONLY means an internal ``mlx_vlm.<sub>`` ModuleNotFoundError,
+    a missing runtime dep (PIL), an incompatible symbol, or a missing shared
+    lib can't masquerade as "not installed". ``find_spec`` locates the spec
+    without executing the module, so it never triggers the ``from PIL import
+    Image`` crash we are trying to classify.
+    """
+    import importlib.util
+
+    try:
+        return importlib.util.find_spec("mlx_vlm") is not None
+    except (ImportError, ValueError):
+        # ``find_spec`` on a genuinely-absent top-level package returns None
+        # (it does not raise), and for the real BROKEN scenarios — missing
+        # PIL, damaged internal submodule, missing shared lib — the top-level
+        # source IS present so ``find_spec`` returns the spec cleanly. So the
+        # only way we land here is a finder that actively refuses the name,
+        # i.e. "cannot be located" → treat as ABSENT (the conservative choice
+        # that keeps the plain "install mlx-vlm" hint for a base install).
+        return False
+
+
+def _broken_detail(exc: BaseException) -> str:
+    """Best-effort actionable detail for a ``BROKEN`` runtime.
+
+    Returns the name of the missing import when the exception carries one
+    (``ModuleNotFoundError``/``ImportError`` ``.name`` — e.g. ``PIL`` or
+    ``mlx_vlm.trainer``), otherwise a short ``TypeName: message`` summary so
+    the ORIGINAL failure (a missing shared lib ``OSError``, an incompatible
+    symbol) is retained in the diagnostic instead of being swallowed.
+    """
+    name = getattr(exc, "name", None)
+    if name:
+        return name
+    text = str(exc).strip()
+    return f"{type(exc).__name__}: {text}" if text else type(exc).__name__
+
+
 def vision_runtime_status() -> tuple[VisionRuntimeStatus, str | None]:
     """Authoritative check of whether the vision runtime can actually load.
 
     Single source of truth for "is vision usable?". Returns
-    ``(status, missing_module)`` where ``missing_module`` names the import
-    that failed (``None`` when ``OK``).
+    ``(status, detail)``:
 
-    Unlike a bare ``find_spec`` / ``importlib.metadata.version`` probe,
-    this performs the REAL ``import mlx_vlm`` so a broken dependency chain
-    (mlx-vlm present, Pillow absent) is reported honestly — and so the
-    failure surfaces FAST at ``serve`` entry rather than deep inside the
-    FastAPI lifespan (#1126). We import first (rather than probe
-    ``find_spec``) because the actual import is the authoritative signal
-    and is robust to test harnesses that inject a stand-in ``mlx_vlm``
-    into ``sys.modules``; the raised ``ModuleNotFoundError``'s ``name``
-    then distinguishes "mlx-vlm itself missing" (``ABSENT``) from
-    "mlx-vlm present but a runtime dep like ``PIL`` missing" (``BROKEN``).
+    * ``(OK, None)`` — ``import mlx_vlm`` succeeded.
+    * ``(ABSENT, "mlx_vlm")`` — the top-level package is not installed.
+    * ``(BROKEN, detail)`` — the package IS installed but its import chain
+      raised; ``detail`` is always truthy (a missing-module name like
+      ``PIL``, or an exception summary for an opaque failure).
+
+    We perform the REAL ``import mlx_vlm`` (not a bare ``find_spec`` /
+    ``importlib.metadata.version`` probe) so a broken dependency chain
+    (mlx-vlm present, Pillow absent — the Homebrew ``--no-deps`` state) is
+    reported honestly and FAST at ``serve`` entry rather than deep inside
+    the FastAPI lifespan (#1126). The ``ABSENT`` vs ``BROKEN`` split is
+    decided by TOP-LEVEL package PRESENCE (:func:`_mlx_vlm_installed`), never
+    by the exception's ``name``: a damaged internal ``mlx_vlm.<sub>``
+    ModuleNotFoundError, an incompatible-symbol ImportError, and a missing
+    shared-lib ``OSError``/``RuntimeError`` (which previously ESCAPED this
+    function and crashed the boot guard) all mean "installed but broken".
     """
     try:
         import mlx_vlm  # noqa: F401
-    except ModuleNotFoundError as e:
-        name = e.name or ""
-        if not name or name == "mlx_vlm" or name.startswith("mlx_vlm"):
-            # mlx-vlm itself isn't importable → not installed.
+    except Exception as exc:  # noqa: BLE001 — any import failure ⇒ not usable
+        if not _mlx_vlm_installed():
             return VisionRuntimeStatus.ABSENT, "mlx_vlm"
-        # mlx-vlm imports, but a runtime dependency it needs is missing
-        # (Homebrew ``pip install --no-deps mlx-vlm`` → no PIL).
-        return VisionRuntimeStatus.BROKEN, name
-    except ImportError as e:
-        # A non-ModuleNotFound import failure somewhere in the mlx-vlm
-        # chain (e.g. a masking meta-path finder in a test harness). If it
-        # names a specific missing sub-dependency, call it broken;
-        # otherwise treat a blocked/un-locatable top-level package as
-        # absent — the conservative choice that keeps the "install mlx-vlm"
-        # hint for the genuine not-installed case.
-        name = getattr(e, "name", None)
-        if name and name != "mlx_vlm" and not name.startswith("mlx_vlm"):
-            return VisionRuntimeStatus.BROKEN, name
-        return VisionRuntimeStatus.ABSENT, "mlx_vlm"
+        return VisionRuntimeStatus.BROKEN, _broken_detail(exc)
     return VisionRuntimeStatus.OK, None
 
 
-def _vlm_broken_install_hint(missing: str) -> str:
-    """Install hint for the "mlx-vlm present but a runtime dep is missing"
-    case — names the full-stack fix AND the single missing piece."""
-    pip_name = _pip_name_for_module(missing)
+def _vlm_broken_install_hint(detail: str | None) -> str:
+    """Install hint for the "mlx-vlm present but its import chain is broken"
+    case (#1126).
+
+    ``detail`` is either the missing external module name (e.g. ``PIL``) or,
+    when the failure names no external dependency (a damaged internal
+    ``mlx_vlm`` submodule, a missing shared lib, an incompatible symbol), the
+    raw exception summary. A recognisable EXTERNAL module gets a precise
+    ``pip install`` target; everything else surfaces the diagnostic verbatim
+    and points at a clean reinstall — never a misleading "install mlx-vlm"
+    (which IS installed).
+    """
+    if _looks_like_module_name(detail) and not detail.startswith("mlx_vlm"):
+        pip_name = _pip_name_for_module(detail)
+        return (
+            f"`mlx-vlm` is installed but its dependency {detail!r} is not, so "
+            f"the vision runtime cannot load. Install the full vision stack:\n"
+            f"    pip install 'rapid-mlx[vision]'\n"
+            f"or just the missing piece:\n"
+            f"    pip install {pip_name}"
+        )
+    suffix = f" ({detail})" if detail else ""
     return (
-        f"`mlx-vlm` is installed but its dependency {missing!r} is not, so "
-        f"the vision runtime cannot load. Install the full vision stack:\n"
-        f"    pip install 'rapid-mlx[vision]'\n"
-        f"or just the missing piece:\n"
-        f"    pip install {pip_name}"
+        f"`mlx-vlm` is installed but its import chain is broken, so the "
+        f"vision runtime cannot load{suffix}. Reinstall the vision stack:\n"
+        f"    pip install --force-reinstall 'rapid-mlx[vision]'"
     )
 
 
@@ -164,13 +229,15 @@ def require_mlx_vlm_or_exit(model_name: str) -> None:
     so the hint names the actually-missing piece rather than telling the
     user to install a package they already have.
     """
-    if mlx_vlm_available():
+    # One authoritative probe; branch on the returned status (a second
+    # ``mlx_vlm_available()`` call would re-run the import redundantly).
+    status, detail = vision_runtime_status()
+    if status is VisionRuntimeStatus.OK:
         return
-    status, missing = vision_runtime_status()
-    if status is VisionRuntimeStatus.BROKEN and missing:
+    if status is VisionRuntimeStatus.BROKEN:
         print(
             f"error: model {model_name!r} is a vision/multimodal alias, but "
-            f"the vision runtime cannot load.\n" + _vlm_broken_install_hint(missing),
+            f"the vision runtime cannot load.\n" + _vlm_broken_install_hint(detail),
             file=sys.stderr,
         )
     else:
@@ -196,13 +263,13 @@ def _require_mlx_vlm() -> None:
     (Homebrew ``--no-deps`` → no PIL), name the missing module instead
     of the misleading "install mlx-vlm" (which IS installed).
     """
-    status, missing = vision_runtime_status()
+    status, detail = vision_runtime_status()
     if status is VisionRuntimeStatus.OK:
         return
-    if status is VisionRuntimeStatus.BROKEN and missing:
+    if status is VisionRuntimeStatus.BROKEN:
         raise ImportError(
             "Vision/multimodal models cannot load the vision runtime.\n"
-            + _vlm_broken_install_hint(missing)
+            + _vlm_broken_install_hint(detail)
         )
     raise ImportError(
         "Vision/multimodal models require the optional `mlx-vlm` "

--- a/vllm_mlx/models/mllm.py
+++ b/vllm_mlx/models/mllm.py
@@ -18,7 +18,6 @@ import base64
 import logging
 import math
 import os
-import re
 import sys
 import tempfile
 import threading
@@ -77,17 +76,6 @@ class VisionRuntimeStatus(str, Enum):
     OK = "ok"
     ABSENT = "absent"
     BROKEN = "broken"
-
-
-# A bare or dotted Python module name (``PIL``, ``mlx_vlm.trainer``) — used
-# to tell a "missing importable module" diagnostic apart from an opaque
-# failure summary (``OSError: dlopen(...): image not found``).
-_MODULE_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)*$")
-
-
-def _looks_like_module_name(detail: str | None) -> bool:
-    """True iff ``detail`` is a plain import-module name (no spaces/punct)."""
-    return bool(detail) and _MODULE_NAME_RE.match(detail) is not None
 
 
 def _mlx_vlm_installed() -> bool:
@@ -170,15 +158,19 @@ def _vlm_broken_install_hint(detail: str | None) -> str:
     """Install hint for the "mlx-vlm present but its import chain is broken"
     case (#1126).
 
-    ``detail`` is either the missing external module name (e.g. ``PIL``) or,
+    ``detail`` is either a missing external module name (e.g. ``PIL``) or,
     when the failure names no external dependency (a damaged internal
     ``mlx_vlm`` submodule, a missing shared lib, an incompatible symbol), the
-    raw exception summary. A recognisable EXTERNAL module gets a precise
-    ``pip install`` target; everything else surfaces the diagnostic verbatim
-    and points at a clean reinstall — never a misleading "install mlx-vlm"
+    raw exception summary. Only a module we EXPLICITLY map to a PyPI
+    distribution (:data:`_MISSING_MODULE_PIP_NAME`) earns a precise
+    ``pip install <dist>`` line — guessing ``pip install <import-name>`` for
+    an unmapped module produces invalid commands (``cv2`` is really
+    ``opencv-python``; a dotted submodule isn't a distribution at all).
+    Everything else surfaces the diagnostic verbatim and points at a clean
+    reinstall of the vision extra — never a misleading "install mlx-vlm"
     (which IS installed).
     """
-    if _looks_like_module_name(detail) and not detail.startswith("mlx_vlm"):
+    if detail in _MISSING_MODULE_PIP_NAME:
         pip_name = _pip_name_for_module(detail)
         return (
             f"`mlx-vlm` is installed but its dependency {detail!r} is not, so "

--- a/vllm_mlx/models/mllm.py
+++ b/vllm_mlx/models/mllm.py
@@ -23,6 +23,7 @@ import tempfile
 import threading
 from collections.abc import Iterator
 from dataclasses import dataclass, field
+from enum import Enum
 from pathlib import Path
 from urllib.parse import urlparse
 
@@ -42,19 +43,106 @@ VLM_EXTRA_INSTALL_HINT = (
 )
 
 
-def mlx_vlm_available() -> bool:
-    """Return True iff the optional ``mlx-vlm`` package can be imported.
+# Import-module → PyPI-distribution name for the runtime deps mlx-vlm
+# pulls. mlx-vlm imports Pillow as ``PIL`` but the installable package is
+# ``pillow``; naming the import module in a ``pip install`` line would 404.
+_MISSING_MODULE_PIP_NAME = {
+    "PIL": "pillow",
+}
 
-    Mirrors :func:`vllm_mlx.embedding.mlx_embeddings_available` so the
-    cli-side ``--mllm`` / vision-alias boot guard
-    (:func:`require_mlx_vlm_or_exit`) can probe presence without
-    actually importing the dependency at module top-level. ``mlx-vlm``
-    lives behind the ``[vision]`` extra; a plain
-    ``pip install rapid-mlx`` will not have it.
+
+def _pip_name_for_module(module: str) -> str:
+    """Map a missing *import* module name to its ``pip install`` target."""
+    return _MISSING_MODULE_PIP_NAME.get(module, module)
+
+
+class VisionRuntimeStatus(str, Enum):
+    """Tri-state health of the vision runtime (``mlx-vlm`` + its deps).
+
+    * ``OK`` — ``import mlx_vlm`` succeeds; vision paths are usable.
+    * ``ABSENT`` — ``mlx-vlm`` is not installed at all (plain
+      ``pip install rapid-mlx`` without the ``[vision]`` extra).
+    * ``BROKEN`` — ``mlx-vlm`` IS installed (dist metadata + import spec
+      present) but a runtime dependency it needs (e.g. Pillow / ``PIL``)
+      is missing, so the real ``import mlx_vlm`` raises. This is the
+      Homebrew ``pip install --no-deps mlx-vlm`` state that #1126 is
+      about: three separate metadata/spec-only checks answered "yes"
+      while ``import mlx_vlm`` crashed on ``from PIL import Image``.
     """
-    import importlib.util
 
-    return importlib.util.find_spec("mlx_vlm") is not None
+    OK = "ok"
+    ABSENT = "absent"
+    BROKEN = "broken"
+
+
+def vision_runtime_status() -> tuple[VisionRuntimeStatus, str | None]:
+    """Authoritative check of whether the vision runtime can actually load.
+
+    Single source of truth for "is vision usable?". Returns
+    ``(status, missing_module)`` where ``missing_module`` names the import
+    that failed (``None`` when ``OK``).
+
+    Unlike a bare ``find_spec`` / ``importlib.metadata.version`` probe,
+    this performs the REAL ``import mlx_vlm`` so a broken dependency chain
+    (mlx-vlm present, Pillow absent) is reported honestly — and so the
+    failure surfaces FAST at ``serve`` entry rather than deep inside the
+    FastAPI lifespan (#1126). We import first (rather than probe
+    ``find_spec``) because the actual import is the authoritative signal
+    and is robust to test harnesses that inject a stand-in ``mlx_vlm``
+    into ``sys.modules``; the raised ``ModuleNotFoundError``'s ``name``
+    then distinguishes "mlx-vlm itself missing" (``ABSENT``) from
+    "mlx-vlm present but a runtime dep like ``PIL`` missing" (``BROKEN``).
+    """
+    try:
+        import mlx_vlm  # noqa: F401
+    except ModuleNotFoundError as e:
+        name = e.name or ""
+        if not name or name == "mlx_vlm" or name.startswith("mlx_vlm"):
+            # mlx-vlm itself isn't importable → not installed.
+            return VisionRuntimeStatus.ABSENT, "mlx_vlm"
+        # mlx-vlm imports, but a runtime dependency it needs is missing
+        # (Homebrew ``pip install --no-deps mlx-vlm`` → no PIL).
+        return VisionRuntimeStatus.BROKEN, name
+    except ImportError as e:
+        # A non-ModuleNotFound import failure somewhere in the mlx-vlm
+        # chain (e.g. a masking meta-path finder in a test harness). If it
+        # names a specific missing sub-dependency, call it broken;
+        # otherwise treat a blocked/un-locatable top-level package as
+        # absent — the conservative choice that keeps the "install mlx-vlm"
+        # hint for the genuine not-installed case.
+        name = getattr(e, "name", None)
+        if name and name != "mlx_vlm" and not name.startswith("mlx_vlm"):
+            return VisionRuntimeStatus.BROKEN, name
+        return VisionRuntimeStatus.ABSENT, "mlx_vlm"
+    return VisionRuntimeStatus.OK, None
+
+
+def _vlm_broken_install_hint(missing: str) -> str:
+    """Install hint for the "mlx-vlm present but a runtime dep is missing"
+    case — names the full-stack fix AND the single missing piece."""
+    pip_name = _pip_name_for_module(missing)
+    return (
+        f"`mlx-vlm` is installed but its dependency {missing!r} is not, so "
+        f"the vision runtime cannot load. Install the full vision stack:\n"
+        f"    pip install 'rapid-mlx[vision]'\n"
+        f"or just the missing piece:\n"
+        f"    pip install {pip_name}"
+    )
+
+
+def mlx_vlm_available() -> bool:
+    """Return True iff the vision runtime can actually be imported.
+
+    Historically a bare ``find_spec('mlx_vlm')`` probe, which answered
+    True for the Homebrew ``pip install --no-deps mlx-vlm`` state where
+    mlx-vlm's spec exists but ``import mlx_vlm`` crashes on a missing
+    Pillow (#1126). It now reflects REAL importability so the boot guard
+    (:func:`require_mlx_vlm_or_exit`) fails fast with an honest message
+    instead of passing to a lifespan crash. Mirrors
+    :func:`vllm_mlx.embedding.mlx_embeddings_available`'s role as the
+    cli-side ``--mllm`` / vision-alias presence probe.
+    """
+    return vision_runtime_status()[0] is VisionRuntimeStatus.OK
 
 
 def require_mlx_vlm_or_exit(model_name: str) -> None:
@@ -70,34 +158,57 @@ def require_mlx_vlm_or_exit(model_name: str) -> None:
     message. Probe at flag-parse / serve_command entry instead and
     exit ``2`` (argparse usage-error code) with the same install hint
     on stderr — matches :func:`require_mlx_embeddings_or_exit` shape.
+
+    #1126: distinguish "mlx-vlm not installed" from "mlx-vlm installed
+    but its dependency (e.g. PIL) is missing" (Homebrew ``--no-deps``)
+    so the hint names the actually-missing piece rather than telling the
+    user to install a package they already have.
     """
     if mlx_vlm_available():
         return
-    print(
-        f"error: model {model_name!r} is a vision/multimodal alias and "
-        f"requires the optional `mlx-vlm` dependency (shipped with the "
-        f"[vision] extra).\n" + VLM_EXTRA_INSTALL_HINT,
-        file=sys.stderr,
-    )
+    status, missing = vision_runtime_status()
+    if status is VisionRuntimeStatus.BROKEN and missing:
+        print(
+            f"error: model {model_name!r} is a vision/multimodal alias, but "
+            f"the vision runtime cannot load.\n"
+            + _vlm_broken_install_hint(missing),
+            file=sys.stderr,
+        )
+    else:
+        print(
+            f"error: model {model_name!r} is a vision/multimodal alias and "
+            f"requires the optional `mlx-vlm` dependency (shipped with the "
+            f"[vision] extra).\n" + VLM_EXTRA_INSTALL_HINT,
+            file=sys.stderr,
+        )
     sys.exit(2)
 
 
 def _require_mlx_vlm() -> None:
-    """Verify mlx-vlm is installed; raise actionable error if not.
+    """Verify the vision runtime can load; raise actionable error if not.
 
     Engine-side last-line-of-defence: ``rapid-mlx serve`` is supposed
     to short-circuit at :func:`require_mlx_vlm_or_exit` before this
     runs, but library callers (``MLXMultimodalLM`` used directly,
     benchmark/eval harnesses) still need an actionable error if they
     skipped the CLI guard.
+
+    #1126: when mlx-vlm is installed but a runtime dep is missing
+    (Homebrew ``--no-deps`` → no PIL), name the missing module instead
+    of the misleading "install mlx-vlm" (which IS installed).
     """
-    try:
-        import mlx_vlm  # noqa: F401
-    except ImportError as e:
+    status, missing = vision_runtime_status()
+    if status is VisionRuntimeStatus.OK:
+        return
+    if status is VisionRuntimeStatus.BROKEN and missing:
         raise ImportError(
-            "Vision/multimodal models require the optional `mlx-vlm` "
-            "dependency.\n" + VLM_EXTRA_INSTALL_HINT
-        ) from e
+            "Vision/multimodal models cannot load the vision runtime.\n"
+            + _vlm_broken_install_hint(missing)
+        )
+    raise ImportError(
+        "Vision/multimodal models require the optional `mlx-vlm` "
+        "dependency.\n" + VLM_EXTRA_INSTALL_HINT
+    )
 
 
 class TempFileManager:


### PR DESCRIPTION
## Summary

- Fix Homebrew/no-deps vision environments where `mlx-vlm` is installed but importing it fails because Pillow (`PIL`) is missing.
- Use one import-based, tri-state vision-runtime check across the MLLM boot guards; fail before server startup with an actionable Pillow/vision-extra message.
- Make `doctor` report the broken runtime honestly instead of a false green result.
- Rebased onto current `main`. The generic cached repo-ID config + checkpoint-evidence routing is now supplied by the shared metadata implementation merged in #1132; this PR adds Gemma-4 regression coverage for that path.

## Why

Fixes #1126. A Homebrew install could report vision as available even though `import mlx_vlm` failed on its missing Pillow dependency; forcing MLLM then failed inside the FastAPI lifespan. Separately, Gemma-4's config-declared vision route must select MLLM from its cached config and actual vision tensors, while a text-only fork of the same architecture must remain on the text route.

## Test plan

- [x] Reproduced the Pillow-missing runtime state and verified a fast, actionable failure.
- [x] Verified `doctor` reports the broken vision runtime rather than a false green result.
- [x] Added cached repo-ID Gemma-4 regression coverage: a VLM config with `vision_tower.*` weights routes to MLLM.
- [x] Added the complementary text-fork regression: VLM config with only language weights stays on the text route.
- [x] Focused vision/routing/doctor suite: 223 passed.
- [x] `pr_validate` targeted suite: 234 passed, 9 deselected.
- [x] `pr_validate` full unit suite: 13,173 passed, 17 skipped, 17 deselected, 6 xfailed, 1 xpassed.
- [x] Ruff format and lint checks passed.
- [x] Supply-chain and test-environment checks passed.
- [x] Codex adversarial review completed with no reported findings.