### PR TITLE
fix(routing): infer agent tools from checkpoint metadata

### DIFF
--- a/tests/test_api_utils.py
+++ b/tests/test_api_utils.py
@@ -380,6 +380,24 @@ class TestIsMllmModelWeightsPresenceOverride:
         )
         assert is_mllm_model(str(model_dir)) is True
 
+    def test_vision_config_with_unrecognised_vision_namespace_stays_vlm(self, tmp_path):
+        """An unknown encoder prefix is insufficient evidence to force text."""
+        model_dir = self._make_model_dir(
+            tmp_path,
+            "repackaged-vlm",
+            {
+                "model_type": "qwen3_5_moe",
+                "architectures": ["Qwen3_5MoeForConditionalGeneration"],
+                "vision_config": {"hidden_size": 1152},
+            },
+            weight_names=[
+                "language_model.lm_head.weight",
+                "vision_encoder.blocks.0.weight",
+            ],
+        )
+
+        assert is_mllm_model(str(model_dir)) is True
+
     def test_audio_only_checkpoint_with_audio_weights(self, tmp_path):
         """Same principle but for the audio branch (audio_tower prefix)."""
         model_dir = self._make_model_dir(
@@ -513,7 +531,9 @@ class TestIsMllmModelCachedMetadata:
             ),
         )
         monkeypatch.setattr(
-            utils_mod, "checkpoint_has_multimodal_weights", lambda snapshot: True
+            utils_mod,
+            "checkpoint_has_multimodal_weights",
+            lambda snapshot, config: True,
         )
         assert is_mllm_model("publisher/research-agent-mlx") is True
 
@@ -533,7 +553,9 @@ class TestIsMllmModelCachedMetadata:
             ),
         )
         monkeypatch.setattr(
-            utils_mod, "checkpoint_has_multimodal_weights", lambda snapshot: None
+            utils_mod,
+            "checkpoint_has_multimodal_weights",
+            lambda snapshot, config: None,
         )
 
         assert is_mllm_model("publisher/text-only-repack") is False
@@ -552,7 +574,9 @@ class TestIsMllmModelCachedMetadata:
             ),
         )
         monkeypatch.setattr(
-            utils_mod, "checkpoint_has_multimodal_weights", lambda snapshot: True
+            utils_mod,
+            "checkpoint_has_multimodal_weights",
+            lambda snapshot, config: True,
         )
 
         assert is_mllm_model("mlx-community/Qwen3.5-4B-MLX-4bit") is False

--- a/tests/test_api_utils.py
+++ b/tests/test_api_utils.py
@@ -453,7 +453,7 @@ class TestIsMllmModelWeightsPresenceOverride:
 
 
 class TestIsMllmModelCachedMetadata:
-    """Cached checkpoint metadata is authoritative over mutable repo names."""
+    """Cached metadata needs actual modality evidence for a new VLM route."""
 
     @staticmethod
     def _metadata(config):
@@ -501,7 +501,7 @@ class TestIsMllmModelCachedMetadata:
         from vllm_mlx.api import utils as utils_mod
 
         # A re-packaged checkpoint need not contain a historical name marker.
-        # Its cached config declares the modality, so it is routed correctly.
+        # Its cached config plus real checkpoint evidence route it correctly.
         monkeypatch.setattr(
             utils_mod,
             "read_model_metadata",
@@ -512,7 +512,50 @@ class TestIsMllmModelCachedMetadata:
                 }
             ),
         )
+        monkeypatch.setattr(
+            utils_mod, "checkpoint_has_multimodal_weights", lambda snapshot: True
+        )
         assert is_mllm_model("publisher/research-agent-mlx") is True
+
+    def test_cached_inherited_vision_config_without_weights_stays_text(
+        self, monkeypatch
+    ):
+        from vllm_mlx.api import utils as utils_mod
+
+        monkeypatch.setattr(
+            utils_mod,
+            "read_model_metadata",
+            lambda name: self._metadata(
+                {
+                    "architectures": ["Qwen3_5MoeForConditionalGeneration"],
+                    "vision_config": {"hidden_size": 1024},
+                }
+            ),
+        )
+        monkeypatch.setattr(
+            utils_mod, "checkpoint_has_multimodal_weights", lambda snapshot: None
+        )
+
+        assert is_mllm_model("publisher/text-only-repack") is False
+
+    def test_registered_text_alias_beats_cached_vision_evidence(self, monkeypatch):
+        from vllm_mlx.api import utils as utils_mod
+
+        monkeypatch.setattr(
+            utils_mod,
+            "read_model_metadata",
+            lambda name: self._metadata(
+                {
+                    "architectures": ["Qwen3_5MoeForConditionalGeneration"],
+                    "vision_config": {"hidden_size": 1024},
+                }
+            ),
+        )
+        monkeypatch.setattr(
+            utils_mod, "checkpoint_has_multimodal_weights", lambda snapshot: True
+        )
+
+        assert is_mllm_model("mlx-community/Qwen3.5-4B-MLX-4bit") is False
 
     def test_hub_helper_rejects_local_path_lookalikes(self):
         from vllm_mlx.api.utils import _try_read_hub_config_json

--- a/tests/test_api_utils.py
+++ b/tests/test_api_utils.py
@@ -17,6 +17,7 @@ from vllm_mlx.api.utils import (
     _check_legacy_string_patterns,
     _config_indicates_vlm,
     _content_to_text,
+    _local_checkpoint_has_multimodal_weights,
     _try_read_config_json,
     clean_output_text,
     extract_multimodal_content,
@@ -440,72 +441,78 @@ class TestIsMllmModelWeightsPresenceOverride:
         )
         assert is_mllm_model(str(model_dir)) is False
 
+    def test_legacy_weights_probe_wrapper_delegates_to_shared_metadata(self, tmp_path):
+        model_dir = self._make_model_dir(
+            tmp_path,
+            "vision-weights",
+            {"vision_config": {}},
+            ["vision_tower.blocks.0.weight"],
+        )
 
-class TestIsMllmModelHubOverride:
-    """Verifies the hub config override for substring false-positives.
+        assert _local_checkpoint_has_multimodal_weights(model_dir) is True
 
-    The legacy substring matcher catches family names like ``gemma-3`` /
-    ``gemma3`` which are correct for the vision variants (4b/12b/27b) but
-    misclassify the text-only 1B (``Gemma3ForCausalLM``, no
-    ``vision_config``). Detection now fetches just ``config.json`` from
-    the repo and lets the model's own metadata override a substring
-    false-positive — but only in the True → False direction, so repos
-    whose names lack a VLM token retain their existing text routing
-    even if their config exposes a vision branch.
-    """
+
+class TestIsMllmModelCachedMetadata:
+    """Cached checkpoint metadata is authoritative over mutable repo names."""
+
+    @staticmethod
+    def _metadata(config):
+        from vllm_mlx.model_metadata import ModelMetadata
+
+        return ModelMetadata(config=config, chat_template=None, snapshot_dir=None)
 
     def test_text_only_config_overrides_substring_match(self, monkeypatch):
         from vllm_mlx.api import utils as utils_mod
 
-        # Substring "gemma-3" would flag this as MLLM. Hub config says
-        # Gemma3ForCausalLM (text-only) → override to False.
+        # Substring "gemma-3" would flag this as MLLM. Metadata says
+        # Gemma3ForCausalLM (text-only) → route as text.
         monkeypatch.setattr(
             utils_mod,
-            "_try_read_hub_config_json",
-            lambda name: {"architectures": ["Gemma3ForCausalLM"]},
+            "read_model_metadata",
+            lambda name: self._metadata({"architectures": ["Gemma3ForCausalLM"]}),
         )
         assert is_mllm_model("mlx-community/gemma-3-1b-it-4bit") is False
 
     def test_vlm_config_keeps_substring_match(self, monkeypatch):
         from vllm_mlx.api import utils as utils_mod
 
-        # Substring "gemma-3" matches and hub config also says VLM.
+        # Substring "gemma-3" matches and metadata also says VLM.
         monkeypatch.setattr(
             utils_mod,
-            "_try_read_hub_config_json",
-            lambda name: {
-                "architectures": ["Gemma3ForConditionalGeneration"],
-                "vision_config": {"hidden_size": 1024},
-            },
+            "read_model_metadata",
+            lambda name: self._metadata(
+                {
+                    "architectures": ["Gemma3ForConditionalGeneration"],
+                    "vision_config": {"hidden_size": 1024},
+                }
+            ),
         )
         assert is_mllm_model("mlx-community/gemma-3-27b-it-4bit") is True
 
     def test_hub_unreachable_falls_back_to_substring(self, monkeypatch):
         from vllm_mlx.api import utils as utils_mod
 
-        # Substring matches; hub call returns None (404, gated, offline).
+        # Substring matches; metadata is unavailable (offline / cold cache).
         # Should preserve the legacy True result.
-        monkeypatch.setattr(utils_mod, "_try_read_hub_config_json", lambda name: None)
+        monkeypatch.setattr(utils_mod, "read_model_metadata", lambda name: None)
         assert is_mllm_model("mlx-community/gemma-3-4b-it-4bit") is True
 
-    def test_no_substring_match_skips_hub_call(self, monkeypatch):
+    def test_metadata_detects_vlm_without_name_marker(self, monkeypatch):
         from vllm_mlx.api import utils as utils_mod
 
-        # Repos whose names don't match MLLM_PATTERNS short-circuit to
-        # False without consulting the hub — preserves existing routing
-        # for models like Qwen3.5/3.6 whose configs happen to expose a
-        # vision branch even though we've always routed them as text.
-        called = []
-
-        def spy(name):
-            called.append(name)
-            return {"vision_config": {}}
-
-        monkeypatch.setattr(utils_mod, "_try_read_hub_config_json", spy)
-        assert is_mllm_model("mlx-community/Qwen3.5-4B-MLX-4bit") is False
-        assert called == [], (
-            "hub config should not be consulted when substring rules out MLLM"
+        # A re-packaged checkpoint need not contain a historical name marker.
+        # Its cached config declares the modality, so it is routed correctly.
+        monkeypatch.setattr(
+            utils_mod,
+            "read_model_metadata",
+            lambda name: self._metadata(
+                {
+                    "architectures": ["Qwen3_5MoeForConditionalGeneration"],
+                    "vision_config": {"hidden_size": 1024},
+                }
+            ),
         )
+        assert is_mllm_model("publisher/research-agent-mlx") is True
 
     def test_hub_helper_rejects_local_path_lookalikes(self):
         from vllm_mlx.api.utils import _try_read_hub_config_json

--- a/tests/test_api_utils.py
+++ b/tests/test_api_utils.py
@@ -560,9 +560,22 @@ class TestIsMllmModelCachedMetadata:
 
         assert is_mllm_model("publisher/text-only-repack") is False
 
-    def test_registered_text_alias_beats_cached_vision_evidence(self, monkeypatch):
+    def test_text_only_alias_beats_cached_vision_evidence(self, monkeypatch):
+        """An alias that POSITIVELY declares ``is_text_only`` short-circuits
+        even against positive checkpoint evidence — the operator pin is
+        authoritative for a checkpoint we deliberately serve text-only."""
         from vllm_mlx.api import utils as utils_mod
+        from vllm_mlx.model_profile import ModelProfile
 
+        text_only_profile = ModelProfile(
+            hf_path="publisher/vision-config-served-text",
+            is_text_only=True,
+        )
+        monkeypatch.setattr(
+            utils_mod,
+            "resolve_profile",
+            lambda name: text_only_profile,
+        )
         monkeypatch.setattr(
             utils_mod,
             "read_model_metadata",
@@ -579,7 +592,54 @@ class TestIsMllmModelCachedMetadata:
             lambda snapshot, config: True,
         )
 
-        assert is_mllm_model("mlx-community/Qwen3.5-4B-MLX-4bit") is False
+        assert is_mllm_model("publisher/vision-config-served-text") is False
+
+    def test_registered_non_text_alias_yields_to_positive_vision_weights(
+        self, monkeypatch
+    ):
+        """Regression for the #1121 routing-order bug: a registered alias that
+        is NOT ``is_text_only`` and whose name carries NO legacy VLM substring
+        must still route as multimodal once the checkpoint supplies positive
+        vision weights. The bare alias entry must not override real evidence.
+
+        Before the reorder, ``if profile is not None`` short-circuited to the
+        (False) legacy name matcher BEFORE the ``verdict is True`` branch, so
+        this repackaged VLM was misrouted to the text engine. This test fails
+        against the old order and passes after evidence-priority routing.
+        """
+        from vllm_mlx.api import utils as utils_mod
+        from vllm_mlx.model_profile import ModelProfile
+
+        # A registered non-text alias (e.g. a text-family entry someone
+        # repackaged a VLM under). ``is_text_only`` is False, and the alias
+        # name has NO legacy VLM marker (``_check_legacy_string_patterns`` False).
+        non_text_profile = ModelProfile(
+            hf_path="publisher/research-agent-4b",
+            is_text_only=False,
+        )
+        monkeypatch.setattr(
+            utils_mod,
+            "resolve_profile",
+            lambda name: non_text_profile,
+        )
+        assert _check_legacy_string_patterns("publisher/research-agent-4b") is False
+        monkeypatch.setattr(
+            utils_mod,
+            "read_model_metadata",
+            lambda name: self._metadata(
+                {
+                    "architectures": ["Qwen3_5MoeForConditionalGeneration"],
+                    "vision_config": {"hidden_size": 1024},
+                }
+            ),
+        )
+        monkeypatch.setattr(
+            utils_mod,
+            "checkpoint_has_multimodal_weights",
+            lambda snapshot, config: True,
+        )
+
+        assert is_mllm_model("publisher/research-agent-4b") is True
 
     def test_hub_helper_rejects_local_path_lookalikes(self):
         from vllm_mlx.api.utils import _try_read_hub_config_json

--- a/tests/test_api_utils.py
+++ b/tests/test_api_utils.py
@@ -641,6 +641,99 @@ class TestIsMllmModelCachedMetadata:
 
         assert is_mllm_model("publisher/research-agent-4b") is True
 
+    def test_curated_text_alias_beats_real_vision_weights(self, monkeypatch):
+        """FIX 1 regression: a curated ``is_text_only`` alias whose CHECKPOINT
+        genuinely ships ``vision_tower`` weights must still route as TEXT.
+
+        ``mlx-community/Qwen3.5-4B-MLX-4bit`` (the default smoke alias) is
+        curated text-only, yet its real ``model.safetensors.index.json`` carries
+        BOTH ``language_model.*`` AND ``vision_tower.*`` tensors — so
+        ``checkpoint_has_multimodal_weights`` correctly returns True on the raw
+        bytes.  A prior fix let that True win over the curated alias, flipping
+        the model to the MLLM lane and tripping the ``--pflash not supported for
+        multimodal`` guard (7 CLI serve tests went red).  The curated
+        ``is_text_only`` pin must short-circuit to text BEFORE the weight-
+        evidence path.  Fails before FIX 1 (returns True), passes after.
+        """
+        from vllm_mlx.api import utils as utils_mod
+        from vllm_mlx.model_profile import ModelProfile
+
+        curated_text_profile = ModelProfile(
+            hf_path="mlx-community/Qwen3.5-4B-MLX-4bit",
+            is_text_only=True,
+        )
+        monkeypatch.setattr(
+            utils_mod, "resolve_profile", lambda name: curated_text_profile
+        )
+        # Real checkpoint evidence: a genuine ``vision_tower.`` tensor is present
+        # (positive multimodal verdict) — the curated pin must still win.
+        monkeypatch.setattr(
+            utils_mod,
+            "read_model_metadata",
+            lambda name: self._metadata(
+                {
+                    "architectures": ["Qwen3_5ForConditionalGeneration"],
+                    "vision_config": {"hidden_size": 1024},
+                    "image_token_id": 248056,
+                }
+            ),
+        )
+        monkeypatch.setattr(
+            utils_mod,
+            "checkpoint_has_multimodal_weights",
+            lambda snapshot, config: True,
+        )
+
+        assert is_mllm_model("mlx-community/Qwen3.5-4B-MLX-4bit") is False
+
+    def test_curated_text_alias_smoke_qwen35_4b_is_text(self):
+        """End-to-end: the shipped alias registry curates the default smoke
+        model as text, so ``is_mllm_model`` returns False through the REAL
+        ``resolve_profile`` (no monkeypatch).  This is the exact routing the
+        7 previously-red CLI serve tests depend on."""
+        assert is_mllm_model("mlx-community/Qwen3.5-4B-MLX-4bit") is False
+        assert is_mllm_model("qwen3.5-4b-4bit") is False
+
+    def test_inconclusive_verdict_is_not_promoted_by_file_existence(
+        self, monkeypatch, tmp_path
+    ):
+        """FIX 2 regression: an inconclusive checkpoint verdict (``None``) must
+        NOT be promoted to multimodal just because checkpoint files exist on
+        disk.  A cached (non-local) VLM-config snapshot whose weights are
+        inconclusive and whose name carries NO legacy VLM substring must fall
+        through to the name matcher (False), not be promoted to True.
+        """
+        from vllm_mlx.api import utils as utils_mod
+        from vllm_mlx.model_metadata import ModelMetadata
+
+        # Snapshot dir that HAS checkpoint files (so a file-existence probe
+        # would say "evidence available") but the modality verdict is None.
+        (tmp_path / "model.safetensors").write_bytes(b"\x00\x00")
+
+        def _cached_meta(name):
+            return ModelMetadata(
+                config={
+                    "architectures": ["Qwen3_5MoeForConditionalGeneration"],
+                    "vision_config": {"hidden_size": 1024},
+                },
+                chat_template=None,
+                snapshot_dir=tmp_path,
+                is_local=False,
+            )
+
+        monkeypatch.setattr(utils_mod, "resolve_profile", lambda name: None)
+        monkeypatch.setattr(utils_mod, "read_model_metadata", _cached_meta)
+        monkeypatch.setattr(
+            utils_mod,
+            "checkpoint_has_multimodal_weights",
+            lambda snapshot, config: None,
+        )
+        # Name has NO legacy VLM substring.
+        assert _check_legacy_string_patterns("publisher/plain-repack") is False
+
+        # Must NOT be promoted on bare file existence — stays text (False).
+        assert is_mllm_model("publisher/plain-repack") is False
+
     def test_hub_helper_rejects_local_path_lookalikes(self):
         from vllm_mlx.api.utils import _try_read_hub_config_json
 

--- a/tests/test_api_utils.py
+++ b/tests/test_api_utils.py
@@ -459,6 +459,104 @@ class TestIsMllmModelWeightsPresenceOverride:
         )
         assert is_mllm_model(str(model_dir)) is False
 
+    def test_non_qwen_text_only_fork_is_text_architecture_agnostic(self, tmp_path):
+        """Round-5 REGRESSION repro (the origin/main regression).
+
+        A text-only fork of a NON-Qwen VLM architecture (Gemma3) — config
+        declares ``vision_config`` but the weight index ships only language
+        tensors — must route as TEXT (``False``).  The round-3/4 code returned
+        ``None`` here (because the text-only detector recognised ONLY
+        Qwen3.5-MoE), and the local-dir fallback then force-routed it to the
+        MLLM engine, crashing on a missing vision tower.  The architecture-
+        agnostic weight-evidence rule (no vision tensors → text) restores
+        origin/main for EVERY architecture, not just Qwen.
+        """
+        model_dir = self._make_model_dir(
+            tmp_path,
+            "Gemma3-Research-Text-Fork",
+            {
+                "model_type": "gemma3",
+                "architectures": ["Gemma3ForConditionalGeneration"],
+                "vision_config": {"hidden_size": 1152},
+            },
+            weight_names=[
+                "language_model.model.embed_tokens.weight",
+                "language_model.model.layers.0.self_attn.q_proj.weight",
+                "language_model.model.norm.weight",
+                "lm_head.weight",
+            ],
+        )
+        assert is_mllm_model(str(model_dir)) is False
+
+    def test_non_qwen_repackaged_vlm_with_vision_weights_is_vlm(self, tmp_path):
+        """Round-5 #1121 guard: the SAME non-Qwen config, but the weight index
+        DOES ship vision tensors → must route as VLM (``True``).  Distinguishes
+        the two opposite failure modes purely by weight evidence."""
+        model_dir = self._make_model_dir(
+            tmp_path,
+            "Gemma3-Real-VLM",
+            {
+                "model_type": "gemma3",
+                "architectures": ["Gemma3ForConditionalGeneration"],
+                "vision_config": {"hidden_size": 1152},
+            },
+            weight_names=[
+                "language_model.model.embed_tokens.weight",
+                "vision_tower.encoder.layers.0.self_attn.q_proj.weight",
+                "multi_modal_projector.mm_input_projection_weight",
+            ],
+        )
+        assert is_mllm_model(str(model_dir)) is True
+
+    def test_gemma4_vision_embedder_family_is_vlm(self, tmp_path):
+        """Round-5 prefix-audit guard: gemma-4-12B ships its vision stack as
+        ``vision_embedder`` / ``embed_vision`` / ``embed_audio`` (NOT
+        ``vision_tower``).  These prefixes were MISSING from the pre-round-5
+        list, so the architecture-agnostic "absent → text" rule would have
+        misrouted this real VLM to text.  The expanded
+        ``MULTIMODAL_TENSOR_PREFIXES`` must catch it (True)."""
+        model_dir = self._make_model_dir(
+            tmp_path,
+            "gemma-4-12B-it",
+            {
+                "model_type": "gemma4",
+                "architectures": ["Gemma4ForConditionalGeneration"],
+                "vision_config": {"hidden_size": 1152},
+            },
+            weight_names=[
+                "language_model.model.embed_tokens.weight",
+                "vision_embedder.patch_dense.weight",
+                "embed_vision.embedding_projection.weight",
+                "embed_audio.embedding_projection.weight",
+            ],
+        )
+        assert is_mllm_model(str(model_dir)) is True
+
+    def test_qwen35_moe_text_fork_still_text(self, tmp_path):
+        """Round-3 behaviour preserved: a Qwen3.5-MoE text fork (no vision
+        tensors) stays TEXT under the general rule (the former Qwen-specific
+        special-case is now subsumed)."""
+        model_dir = self._make_model_dir(
+            tmp_path,
+            "Qwen3.5-MoE-Text-Fork",
+            {
+                "model_type": "qwen3_5_moe",
+                "architectures": ["Qwen3_5MoeForConditionalGeneration"],
+                "vision_config": {"hidden_size": 1152},
+            },
+            weight_names=[
+                "language_model.model.embed_tokens.weight",
+                "language_model.model.layers.0.mlp.switch_mlp.gate_proj.weight",
+                "language_model.model.norm.weight",
+            ],
+        )
+        assert is_mllm_model(str(model_dir)) is False
+
+    def test_qwen35_4b_alias_pin_still_text_only(self):
+        """The aliases.json ``is_text_only`` pin on qwen3.5-4b short-circuits
+        BEFORE weight inspection and must keep returning text (round-3 fix)."""
+        assert is_mllm_model("mlx-community/Qwen3.5-4B-MLX-4bit") is False
+
     def test_legacy_weights_probe_wrapper_delegates_to_shared_metadata(self, tmp_path):
         model_dir = self._make_model_dir(
             tmp_path,

--- a/tests/test_model_auto_config.py
+++ b/tests/test_model_auto_config.py
@@ -2311,15 +2311,11 @@ class TestCheckpointMetadataFallback:
         assert config.is_hybrid_explicit is True
         assert config.supports_spec_decode is False
 
-    def test_repackaged_agents_a1_moe_keeps_hybrid_safety_gates(
-        self, monkeypatch
-    ):
+    def test_repackaged_agents_a1_moe_keeps_hybrid_safety_gates(self, monkeypatch):
         monkeypatch.setattr(
             auto_config_mod,
             "read_model_metadata",
-            lambda name: self._metadata(
-                {"model_type": "qwen3_5_moe"}, self._XML_TOOLS
-            ),
+            lambda name: self._metadata({"model_type": "qwen3_5_moe"}, self._XML_TOOLS),
         )
 
         config = detect_model_config("publisher/renamed-research-agent-moe")
@@ -2332,16 +2328,26 @@ class TestCheckpointMetadataFallback:
         assert config.is_moe is True
         assert config.supports_spec_decode is False
 
-    def test_incomplete_template_is_not_advertised_as_native_tools(
-        self, monkeypatch
-    ):
+    def test_incomplete_template_is_not_advertised_as_native_tools(self, monkeypatch):
         monkeypatch.setattr(
             auto_config_mod,
             "read_model_metadata",
-            lambda name: self._metadata({}, "<tool_call><function=example>"),
+            lambda name: self._metadata(
+                {}, "{% if tools %}<tool_call><function=example><parameter=value>"
+            ),
         )
 
         assert detect_model_config("publisher/unknown-tool-format") is None
+
+    def test_jinja_comment_cannot_advertise_a_tool_protocol(self, monkeypatch):
+        comment = "{# tools " + self._XML_TOOLS + " #}"
+        monkeypatch.setattr(
+            auto_config_mod,
+            "read_model_metadata",
+            lambda name: self._metadata({}, comment),
+        )
+
+        assert detect_model_config("publisher/comment-only-template") is None
 
     def test_generic_xml_template_routes_tools_without_assuming_reasoning(
         self, monkeypatch
@@ -2364,7 +2370,9 @@ class TestCheckpointMetadataFallback:
         def unexpected_metadata_read(name):
             raise AssertionError("known-family detection must not read metadata")
 
-        monkeypatch.setattr(auto_config_mod, "read_model_metadata", unexpected_metadata_read)
+        monkeypatch.setattr(
+            auto_config_mod, "read_model_metadata", unexpected_metadata_read
+        )
 
         config = detect_model_config("Qwen/Qwen3-Coder-Next")
 

--- a/tests/test_model_auto_config.py
+++ b/tests/test_model_auto_config.py
@@ -2349,6 +2349,20 @@ class TestCheckpointMetadataFallback:
 
         assert detect_model_config("publisher/comment-only-template") is None
 
+    def test_jinja_comment_cannot_enable_qwen_thinking(self, monkeypatch):
+        template = self._XML_TOOLS + "{# enable_thinking <think> #}"
+        monkeypatch.setattr(
+            auto_config_mod,
+            "read_model_metadata",
+            lambda name: self._metadata({"model_type": "qwen3_5"}, template),
+        )
+
+        config = detect_model_config("publisher/comment-only-thinking")
+
+        assert config is not None
+        assert config.tool_call_parser == "hermes"
+        assert config.reasoning_parser is None
+
     def test_generic_xml_template_routes_tools_without_assuming_reasoning(
         self, monkeypatch
     ):

--- a/tests/test_model_auto_config.py
+++ b/tests/test_model_auto_config.py
@@ -2407,6 +2407,81 @@ class TestCheckpointMetadataFallback:
         assert config is not None
         assert config.tool_call_parser == "hermes"
 
+    def test_tool_xml_in_uncalled_macro_is_not_detected(self, monkeypatch):
+        # FIX A (codex #3): a ``{% macro %}...{% endmacro %}`` definition emits
+        # NO output at its definition site (a macro renders only when CALLED).
+        # Tool XML inside an UNCALLED helper macro must therefore NOT enable the
+        # Hermes parser — real chat templates commonly define helper macros.
+        macro_template = (
+            "{% macro render_tools() %}"
+            "<tool_call><function=example><parameter=value>"
+            "x</parameter></function></tool_call>"
+            "{% endmacro %}Hello"
+        )
+        # Sanity: the template PARSES (rejection is about macro non-rendering,
+        # not a syntax error) and the FLATTENED whole-AST output DOES contain
+        # the full contract (proving the pre-fix ``body``-recursion would have
+        # fabricated a match).
+        flat = auto_config_mod._template_output_contract(macro_template)
+        assert flat is not None
+        assert "<tool_call>" in flat[0] and "</tool_call>" in flat[0]
+
+        assert (
+            auto_config_mod._template_uses_parameterized_xml_tools(macro_template)
+            is False
+        )
+        monkeypatch.setattr(
+            auto_config_mod,
+            "read_model_metadata",
+            lambda name: self._metadata({}, macro_template),
+        )
+        assert detect_model_config("publisher/macro-only-tools") is None
+
+    def test_tool_xml_in_set_capture_block_is_not_detected(self, monkeypatch):
+        # FIX A (codex #3): a capture-only ``{% set x %}...{% endset %}`` block
+        # (jinja2 ``AssignBlock``) captures its body INTO a variable rather than
+        # rendering it into the output stream at that site.  Tool XML inside such
+        # a capture must NOT enable the Hermes parser.
+        set_template = (
+            "{% set captured %}"
+            "<tool_call><function=example><parameter=value>"
+            "x</parameter></function></tool_call>"
+            "{% endset %}Hello"
+        )
+        # Sanity: parses cleanly and the flattened whole-AST output contains the
+        # full contract (pre-fix ``body`` recursion would have matched it).
+        flat = auto_config_mod._template_output_contract(set_template)
+        assert flat is not None
+        assert "<tool_call>" in flat[0] and "</tool_call>" in flat[0]
+
+        assert (
+            auto_config_mod._template_uses_parameterized_xml_tools(set_template)
+            is False
+        )
+        monkeypatch.setattr(
+            auto_config_mod,
+            "read_model_metadata",
+            lambda name: self._metadata({}, set_template),
+        )
+        assert detect_model_config("publisher/set-capture-tools") is None
+
+    def test_tool_xml_on_reachable_path_still_detected_after_macro_set_fix(
+        self, monkeypatch
+    ):
+        # FIX A true-positive guard: tool XML on a genuinely reachable render
+        # path (inside a rendered ``{% if tools %}``) must STILL be detected
+        # after the macro/set-capture exclusion — the fix must not over-exclude.
+        template = self._XML_TOOLS
+        assert auto_config_mod._template_uses_parameterized_xml_tools(template) is True
+        monkeypatch.setattr(
+            auto_config_mod,
+            "read_model_metadata",
+            lambda name: self._metadata({}, template),
+        )
+        config = detect_model_config("publisher/reachable-if-tools")
+        assert config is not None
+        assert config.tool_call_parser == "hermes"
+
     def test_generation_block_template_still_routes_tools(self, monkeypatch):
         """A Transformers ``{% generation %}`` block around a valid
         parameterized-XML tool contract must still be recognised.

--- a/tests/test_model_auto_config.py
+++ b/tests/test_model_auto_config.py
@@ -2358,6 +2358,55 @@ class TestCheckpointMetadataFallback:
         )
         assert detect_model_config("publisher/unknown-tool-format") is None
 
+    def test_contract_split_across_exclusive_branches_is_not_detected(
+        self, monkeypatch
+    ):
+        # FIX 4: the opening XML fragments live in the ``{% if %}`` body and the
+        # closing fragments in the ``{% else %}`` — MUTUALLY EXCLUSIVE branches.
+        # No single reachable output path emits the full nested
+        # ``<tool_call>…</tool_call>`` contract, so flattening the whole AST
+        # (the pre-fix behaviour) would FABRICATE a match the model never
+        # renders.  Branch-local path detection must reject it.
+        split = (
+            "{% if tools %}<tool_call><function=example><parameter=value>"
+            "{% else %}</parameter></function></tool_call>{% endif %}"
+        )
+        # Sanity: the template PARSES (so rejection is about branch locality,
+        # not a syntax error), and the FLATTENED output DOES contain every tag
+        # (proving the old whole-AST flatten would have matched).
+        flat = auto_config_mod._template_output_contract(split)
+        assert flat is not None
+        flat_source = flat[0]
+        assert "<tool_call>" in flat_source and "</tool_call>" in flat_source
+
+        assert auto_config_mod._template_uses_parameterized_xml_tools(split) is False
+
+        monkeypatch.setattr(
+            auto_config_mod,
+            "read_model_metadata",
+            lambda name: self._metadata({}, split),
+        )
+        assert detect_model_config("publisher/split-branch-tools") is None
+
+    def test_full_contract_in_single_else_branch_is_detected(self, monkeypatch):
+        # FIX 4 counterpart: when ONE reachable branch emits the whole nested
+        # contract (here the ``{% else %}`` path), it must still be detected.
+        template = (
+            "{% if legacy %}plain text{% else %}"
+            "<tool_call><function=example><parameter=value>"
+            "x</parameter></function></tool_call>{% endif %}"
+            "{% if tools %}{% endif %}"
+        )
+        assert auto_config_mod._template_uses_parameterized_xml_tools(template) is True
+        monkeypatch.setattr(
+            auto_config_mod,
+            "read_model_metadata",
+            lambda name: self._metadata({}, template),
+        )
+        config = detect_model_config("publisher/else-branch-tools")
+        assert config is not None
+        assert config.tool_call_parser == "hermes"
+
     def test_generation_block_template_still_routes_tools(self, monkeypatch):
         """A Transformers ``{% generation %}`` block around a valid
         parameterized-XML tool contract must still be recognised.

--- a/tests/test_model_auto_config.py
+++ b/tests/test_model_auto_config.py
@@ -4,6 +4,7 @@ import logging
 
 import pytest
 
+from vllm_mlx import model_auto_config as auto_config_mod
 from vllm_mlx.model_auto_config import (
     ModelConfig,
     _deepseek_template_family,
@@ -15,6 +16,7 @@ from vllm_mlx.model_auto_config import (
     get_profile,
     warn_misbound_deepseek_v3_parser,
 )
+from vllm_mlx.model_metadata import ModelMetadata
 
 
 class TestDetectModelConfig:
@@ -2266,3 +2268,110 @@ class TestMistralFamilyToolParser:
             f"static _MISTRAL_ALIASES is {sorted(self._MISTRAL_ALIASES)}. "
             "Update both together."
         )
+
+
+class TestCheckpointMetadataFallback:
+    """Unknown HF names inherit only explicit checkpoint contracts."""
+
+    _XML_TOOLS = (
+        "{% if tools %}<tool_call><function=example><parameter=value>"
+        "x</parameter></function></tool_call>{% endif %}"
+    )
+
+    @staticmethod
+    def _metadata(config, template):
+        return ModelMetadata(
+            config=config,
+            chat_template=template,
+            snapshot_dir=None,
+        )
+
+    def test_repackaged_agents_a1_dense_routes_from_config_and_template(
+        self, monkeypatch
+    ):
+        """The #1121 4B shape needs no Agents-A1 name special case."""
+        monkeypatch.setattr(
+            auto_config_mod,
+            "read_model_metadata",
+            lambda name: self._metadata(
+                {
+                    "model_type": "qwen3_5",
+                    "text_config": {"model_type": "qwen3_5_text"},
+                },
+                self._XML_TOOLS + "{% if enable_thinking %}<think>{% endif %}",
+            ),
+        )
+
+        config = detect_model_config("publisher/renamed-research-agent-4b")
+
+        assert config is not None
+        assert config.tool_call_parser == "hermes"
+        assert config.reasoning_parser == "qwen3"
+        assert config.is_hybrid is False
+        assert config.is_hybrid_explicit is True
+        assert config.supports_spec_decode is False
+
+    def test_repackaged_agents_a1_moe_keeps_hybrid_safety_gates(
+        self, monkeypatch
+    ):
+        monkeypatch.setattr(
+            auto_config_mod,
+            "read_model_metadata",
+            lambda name: self._metadata(
+                {"model_type": "qwen3_5_moe"}, self._XML_TOOLS
+            ),
+        )
+
+        config = detect_model_config("publisher/renamed-research-agent-moe")
+
+        assert config is not None
+        assert config.tool_call_parser == "hermes"
+        assert config.reasoning_parser is None
+        assert config.is_hybrid is True
+        assert config.is_hybrid_explicit is True
+        assert config.is_moe is True
+        assert config.supports_spec_decode is False
+
+    def test_incomplete_template_is_not_advertised_as_native_tools(
+        self, monkeypatch
+    ):
+        monkeypatch.setattr(
+            auto_config_mod,
+            "read_model_metadata",
+            lambda name: self._metadata({}, "<tool_call><function=example>"),
+        )
+
+        assert detect_model_config("publisher/unknown-tool-format") is None
+
+    def test_generic_xml_template_routes_tools_without_assuming_reasoning(
+        self, monkeypatch
+    ):
+        monkeypatch.setattr(
+            auto_config_mod,
+            "read_model_metadata",
+            lambda name: self._metadata({}, self._XML_TOOLS),
+        )
+
+        config = detect_model_config("publisher/xml-tool-agent")
+
+        assert config is not None
+        assert config.tool_call_parser == "hermes"
+        assert config.reasoning_parser is None
+
+    def test_known_family_has_priority_over_generic_template_fallback(
+        self, monkeypatch
+    ):
+        def unexpected_metadata_read(name):
+            raise AssertionError("known-family detection must not read metadata")
+
+        monkeypatch.setattr(auto_config_mod, "read_model_metadata", unexpected_metadata_read)
+
+        config = detect_model_config("Qwen/Qwen3-Coder-Next")
+
+        assert config is not None
+        assert config.tool_call_parser == "qwen3_coder_xml"
+
+    def test_cold_or_uncached_model_keeps_existing_no_profile_result(self, monkeypatch):
+        monkeypatch.setattr(auto_config_mod, "read_model_metadata", lambda name: None)
+
+        assert detect_model_config("publisher/unknown-model") is None

--- a/tests/test_model_auto_config.py
+++ b/tests/test_model_auto_config.py
@@ -2482,6 +2482,97 @@ class TestCheckpointMetadataFallback:
         assert config is not None
         assert config.tool_call_parser == "hermes"
 
+    # Raw nested XML contract (no ``{% if %}`` wrapper) for the macro tests.
+    _RAW_XML = (
+        "<tool_call><function=example><parameter=value>"
+        "x</parameter></function></tool_call>"
+    )
+
+    def test_tool_xml_in_called_macro_is_detected(self, monkeypatch):
+        # FIX #3: a macro that defines tool XML and is CALLED on a reachable
+        # render path (``{% if tools %}{{ emit() }}{% endif %}``) DOES render
+        # that XML — the round-4 uncalled-macro exclusion wrongly suppressed it,
+        # leaking unparsed tool calls.  Bounded macro-call resolution must
+        # substitute the macro body's output paths so the contract is detected.
+        called = (
+            "{% macro emit() %}"
+            + self._RAW_XML
+            + "{% endmacro %}{% if tools %}{{ emit() }}{% endif %}"
+        )
+        assert auto_config_mod._template_uses_parameterized_xml_tools(called) is True
+        monkeypatch.setattr(
+            auto_config_mod,
+            "read_model_metadata",
+            lambda name: self._metadata({}, called),
+        )
+        config = detect_model_config("publisher/called-macro-tools")
+        assert config is not None
+        assert config.tool_call_parser == "hermes"
+
+    def test_tool_xml_in_uncalled_macro_still_not_detected(self):
+        # FIX #3 must PRESERVE the round-4 exclusion: a macro that is DEFINED
+        # but never CALLED emits nothing, so its tool XML must NOT enable the
+        # parser.
+        uncalled = (
+            "{% macro emit() %}"
+            + self._RAW_XML
+            + "{% endmacro %}{% if tools %}Hi{% endif %}"
+        )
+        assert auto_config_mod._template_uses_parameterized_xml_tools(uncalled) is False
+
+    def test_nested_called_macro_is_detected(self):
+        # A macro that calls another macro (both reachable) resolves through the
+        # chain up to the recursion cap.
+        nested = (
+            "{% macro inner() %}"
+            + self._RAW_XML
+            + "{% endmacro %}{% macro outer() %}{{ inner() }}{% endmacro %}"
+            "{% if tools %}{{ outer() }}{% endif %}"
+        )
+        assert auto_config_mod._template_uses_parameterized_xml_tools(nested) is True
+
+    def test_recursive_macro_does_not_hang(self):
+        # A (self-)recursive macro must terminate via the cycle guard, not loop.
+        recursive = (
+            "{% macro rec() %}"
+            + self._RAW_XML
+            + "{{ rec() }}{% endmacro %}{% if tools %}{{ rec() }}{% endif %}"
+        )
+        # Detected (the body's XML is on the first expansion) and terminates.
+        assert auto_config_mod._template_uses_parameterized_xml_tools(recursive) is True
+
+    def test_attribute_call_is_not_resolved_as_local_macro(self):
+        # ``{{ x.emit() }}`` is an attribute call, NOT a bare call to a
+        # locally-defined macro, so it must not be resolved (no false positive).
+        attr = (
+            "{% macro emit() %}"
+            + self._RAW_XML
+            + "{% endmacro %}{% if tools %}{{ x.emit() }}{% endif %}"
+        )
+        assert auto_config_mod._template_uses_parameterized_xml_tools(attr) is False
+
+    def test_path_enumeration_bounded_by_cumulative_byte_budget(self):
+        # FIX #5: a template whose path COUNT stays under the cap but whose
+        # cumulative path BYTES would blow up must be bounded by the byte budget
+        # (enumeration aborts, total retained bytes stay within budget) and must
+        # not hang.
+        import time
+
+        big = "Z" * 4096
+        parts = [
+            "{% if a" + str(i) + " %}" + big + "{% else %}" + big + "{% endif %}"
+            for i in range(400)
+        ]
+        template = "".join(parts)
+        start = time.time()
+        result = auto_config_mod._template_output_paths(template)
+        elapsed = time.time() - start
+        assert result is not None
+        paths, _ = result
+        total = sum(len(p) for p in paths)
+        assert total <= auto_config_mod._MAX_TEMPLATE_OUTPUT_BYTES
+        assert elapsed < 5.0  # generous ceiling; real runs are ~0.1s
+
     def test_generation_block_template_still_routes_tools(self, monkeypatch):
         """A Transformers ``{% generation %}`` block around a valid
         parameterized-XML tool contract must still be recognised.

--- a/tests/test_model_auto_config.py
+++ b/tests/test_model_auto_config.py
@@ -2329,15 +2329,93 @@ class TestCheckpointMetadataFallback:
         assert config.supports_spec_decode is False
 
     def test_incomplete_template_is_not_advertised_as_native_tools(self, monkeypatch):
+        # The template PARSES successfully (``{% endif %}`` is present), but the
+        # XML tool contract is genuinely INCOMPLETE: it opens
+        # ``<tool_call><function=…><parameter=…>`` and never emits the closing
+        # ``</parameter></function></tool_call>`` tags. This exercises the
+        # XML closing-tag nesting checks in ``_template_uses_parameterized_xml_tools``
+        # rather than passing via a parse failure (see the assertion below that
+        # the template parses cleanly).
+        incomplete = (
+            "{% if tools %}<tool_call><function=example><parameter=value>x{% endif %}"
+        )
+        # Sanity guard: this template must PARSE (so the test is not
+        # tautologically satisfied by ``_template_output_contract`` returning
+        # None on a syntax error). If it did not parse, the missing-closing-tag
+        # logic below would never be reached.
+        assert auto_config_mod._template_output_contract(incomplete) is not None
+
         monkeypatch.setattr(
             auto_config_mod,
             "read_model_metadata",
-            lambda name: self._metadata(
-                {}, "{% if tools %}<tool_call><function=example><parameter=value>"
-            ),
+            lambda name: self._metadata({}, incomplete),
         )
 
+        # The routing helper must reject it because the closing XML tags are
+        # absent — not because parsing failed.
+        assert (
+            auto_config_mod._template_uses_parameterized_xml_tools(incomplete) is False
+        )
         assert detect_model_config("publisher/unknown-tool-format") is None
+
+    def test_generation_block_template_still_routes_tools(self, monkeypatch):
+        """A Transformers ``{% generation %}`` block around a valid
+        parameterized-XML tool contract must still be recognised.
+
+        A bare ``jinja2.Environment().parse()`` raises ``TemplateSyntaxError``
+        on the custom ``generation`` tag (registered by Transformers'
+        ``AssistantTracker`` extension), which would silently disable inference
+        (``_template_output_contract`` → None). The Transformers-compatible
+        parsing environment must accept it.
+        """
+        template = (
+            "{% if tools %}{% generation %}"
+            + self._XML_TOOLS.removeprefix("{% if tools %}").removesuffix("{% endif %}")
+            + "{% endgeneration %}{% endif %}"
+        )
+        # The bare-jinja env would reject this template; confirm the fixture is
+        # actually exercising the extension path.
+        import jinja2
+
+        with pytest.raises(jinja2.exceptions.TemplateSyntaxError):
+            jinja2.Environment().parse(template)
+
+        monkeypatch.setattr(
+            auto_config_mod,
+            "read_model_metadata",
+            lambda name: self._metadata({}, template),
+        )
+
+        config = detect_model_config("publisher/generation-block-agent")
+
+        assert config is not None
+        assert config.tool_call_parser == "hermes"
+        assert config.reasoning_parser is None
+
+    def test_loop_control_template_still_routes_tools(self, monkeypatch):
+        """Loop-control statements (``{% break %}``) — enabled in Transformers
+        via ``jinja2.ext.loopcontrols`` — must also parse without disabling
+        tool routing."""
+        template = (
+            "{% for t in tools %}<tool_call><function=example>"
+            "<parameter=value>x</parameter></function></tool_call>"
+            "{% break %}{% endfor %}"
+        )
+        import jinja2
+
+        with pytest.raises(jinja2.exceptions.TemplateSyntaxError):
+            jinja2.Environment().parse(template)
+
+        monkeypatch.setattr(
+            auto_config_mod,
+            "read_model_metadata",
+            lambda name: self._metadata({}, template),
+        )
+
+        config = detect_model_config("publisher/loop-control-agent")
+
+        assert config is not None
+        assert config.tool_call_parser == "hermes"
 
     def test_jinja_comment_cannot_advertise_a_tool_protocol(self, monkeypatch):
         comment = "{# tools " + self._XML_TOOLS + " #}"

--- a/tests/test_model_metadata.py
+++ b/tests/test_model_metadata.py
@@ -76,6 +76,46 @@ def test_local_metadata_prefers_standalone_template_then_tokenizer_fallback(tmp_
     assert metadata.read_local_model_metadata(object()) is None
 
 
+def test_named_template_directory_selects_tool_use_over_default(tmp_path):
+    """A snapshot with named templates under ``additional_chat_templates/``
+    (Transformers' modern layout) selects ``tool_use`` over ``default``.
+
+    Mirrors ``PreTrainedTokenizerBase._from_pretrained``: ``chat_template.jinja``
+    supplies the ``default`` template, and each ``<name>.jinja`` under
+    ``additional_chat_templates/`` contributes a named template; ``tool_use``
+    then wins over ``default`` for tool-carrying requests.
+    """
+    snap = tmp_path / "named-templates"
+    snap.mkdir()
+    _write_json(snap / "config.json", {"model_type": "qwen3"})
+    # ``default`` comes from chat_template.jinja; the tokenizer_config entry must
+    # NOT win (standalone files take priority in Transformers).
+    _write_json(snap / "tokenizer_config.json", {"chat_template": "TOKENIZER_CONF"})
+    (snap / "chat_template.jinja").write_text("DEFAULT_BODY", encoding="utf-8")
+    template_dir = snap / "additional_chat_templates"
+    template_dir.mkdir()
+    (template_dir / "tool_use.jinja").write_text("TOOL_USE_BODY", encoding="utf-8")
+    (template_dir / "rag.jinja").write_text("RAG_BODY", encoding="utf-8")
+
+    result = metadata.read_local_model_metadata(str(snap))
+
+    assert result is not None
+    assert result.chat_template == "TOOL_USE_BODY"
+
+
+def test_named_template_directory_default_only_flattens_to_string(tmp_path):
+    """A lone ``default.jinja`` under the named directory (no ``tool_use``)
+    flattens to that single template, matching Transformers' collapse of a
+    lone ``default`` to a bare string."""
+    snap = tmp_path / "default-only"
+    snap.mkdir()
+    template_dir = snap / "additional_chat_templates"
+    template_dir.mkdir()
+    (template_dir / "default.jinja").write_text("ONLY_DEFAULT", encoding="utf-8")
+
+    assert metadata._chat_template(snap) == "ONLY_DEFAULT"
+
+
 def test_named_tokenizer_templates_prefer_tool_use_then_default():
     assert (
         metadata._select_chat_template(

--- a/tests/test_model_metadata.py
+++ b/tests/test_model_metadata.py
@@ -15,6 +15,11 @@ def _write_json(path: Path, value) -> None:
     path.write_text(json.dumps(value), encoding="utf-8")
 
 
+def _write_safetensors_header(path: Path, tensor_names) -> None:
+    header = json.dumps({name: {} for name in tensor_names}).encode("utf-8")
+    path.write_bytes(len(header).to_bytes(8, "little") + header)
+
+
 def test_readers_reject_missing_malformed_non_object_and_oversized_files(tmp_path):
     missing = tmp_path / "missing.json"
     assert metadata._read_json(None) is None
@@ -53,6 +58,7 @@ def test_local_metadata_prefers_standalone_template_then_tokenizer_fallback(tmp_
         config={"model_type": "qwen3"},
         chat_template="standalone",
         snapshot_dir=standalone,
+        is_local=True,
     )
 
     fallback = tmp_path / "fallback"
@@ -64,9 +70,27 @@ def test_local_metadata_prefers_standalone_template_then_tokenizer_fallback(tmp_
         config=None,
         chat_template="tokenizer",
         snapshot_dir=fallback,
+        is_local=True,
     )
     assert metadata._chat_template(None) is None
     assert metadata.read_local_model_metadata(object()) is None
+
+
+def test_named_tokenizer_templates_prefer_tool_use_then_default():
+    assert (
+        metadata._select_chat_template(
+            {"chat_template": {"default": "default", "tool_use": "tool-use"}}
+        )
+        == "tool-use"
+    )
+    assert (
+        metadata._select_chat_template({"chat_template": {"default": "default"}})
+        == "default"
+    )
+    assert (
+        metadata._select_chat_template({"chat_template": {"a": "one", "b": "two"}})
+        is None
+    )
 
 
 @pytest.mark.parametrize(
@@ -134,7 +158,9 @@ def test_cached_metadata_reads_standalone_template_and_tokenizer_fallback(
         "chat_template.jinja": standalone,
         "tokenizer_config.json": tokenizer,
     }
-    monkeypatch.setattr(metadata, "_cached_file", lambda name, filename: paths[filename])
+    monkeypatch.setattr(
+        metadata, "_cached_file", lambda name, filename: paths[filename]
+    )
 
     result = metadata.read_cached_model_metadata("publisher/model")
 
@@ -149,6 +175,34 @@ def test_cached_metadata_reads_standalone_template_and_tokenizer_fallback(
     result = metadata.read_cached_model_metadata("publisher/model")
     assert result is not None
     assert result.chat_template == "tokenizer"
+
+
+def test_cached_metadata_reads_one_snapshot_when_cache_refs_change(
+    monkeypatch, tmp_path
+):
+    snapshot = tmp_path / "snapshot"
+    stale = tmp_path / "stale"
+    snapshot.mkdir()
+    stale.mkdir()
+    _write_json(snapshot / "config.json", {"model_type": "qwen3"})
+    (snapshot / "chat_template.jinja").write_text("current", encoding="utf-8")
+    (stale / "chat_template.jinja").write_text("stale", encoding="utf-8")
+    calls = []
+
+    def cached_file(name, filename):
+        calls.append(filename)
+        if filename == "config.json":
+            return snapshot / filename
+        return stale / filename
+
+    monkeypatch.setattr(metadata, "_cached_file", cached_file)
+
+    result = metadata.read_cached_model_metadata("publisher/model")
+
+    assert result is not None
+    assert result.snapshot_dir == snapshot
+    assert result.chat_template == "current"
+    assert calls == ["config.json"]
 
 
 def test_cached_metadata_returns_none_without_any_cached_metadata(monkeypatch):
@@ -192,3 +246,31 @@ def test_multimodal_config_and_sharded_weight_detection(tmp_path):
         {"weight_map": {"vision_tower.blocks.0.weight": "model.safetensors"}},
     )
     assert metadata.checkpoint_has_multimodal_weights(tmp_path) is True
+
+    (tmp_path / "model.safetensors.index.json").unlink()
+    safetensors = tmp_path / "model.safetensors"
+    _write_safetensors_header(safetensors, ["language_model.layers.0.weight"])
+    assert metadata.checkpoint_has_multimodal_weights(tmp_path) is False
+
+    _write_safetensors_header(safetensors, ["vision_tower.blocks.0.weight"])
+    assert metadata.checkpoint_has_multimodal_weights(tmp_path) is True
+
+
+def test_single_safetensors_header_rejects_corrupt_or_unsupported_shapes(tmp_path):
+    model = tmp_path / "model.safetensors"
+
+    model.write_bytes(b"tiny")
+    assert metadata._single_safetensors_has_multimodal_weights(tmp_path) is None
+
+    model.write_bytes((metadata.MAX_METADATA_FILE_BYTES + 1).to_bytes(8, "little"))
+    assert metadata._single_safetensors_has_multimodal_weights(tmp_path) is None
+
+    model.write_bytes((8).to_bytes(8, "little") + b"{}")
+    assert metadata._single_safetensors_has_multimodal_weights(tmp_path) is None
+
+    model.write_bytes((1).to_bytes(8, "little") + b"[")
+    assert metadata._single_safetensors_has_multimodal_weights(tmp_path) is None
+
+    header = json.dumps(["not", "an", "object"]).encode("utf-8")
+    model.write_bytes(len(header).to_bytes(8, "little") + header)
+    assert metadata._single_safetensors_has_multimodal_weights(tmp_path) is None

--- a/tests/test_model_metadata.py
+++ b/tests/test_model_metadata.py
@@ -398,6 +398,82 @@ def test_known_text_only_layout_rejects_modality_subtree_under_language_model():
     )
 
 
+def test_qwen3_5_moe_text_tensor_allowlist_rejects_deep_modality_subtree():
+    """codex #2: the qwen3.5-moe text allowlist enumerates the ACTUAL backbone
+    children (``embed_tokens`` / ``layers`` / ``norm`` under
+    ``language_model.model.``) + ``language_model.lm_head``, NOT the bare
+    ``language_model.model.`` prefix.
+
+    A modality subtree nested ONE LEVEL DEEPER — ``language_model.model
+    .vision_encoder.*`` — matches the bare ``language_model.model.`` prefix the
+    OLD code trusted and would let a genuine VLM reach an authoritative
+    text-only verdict.  The tightened allowlist must reject it (inconclusive),
+    while every real text tensor is still accepted.
+
+    Tensor names are derived from mlx-lm ``models/qwen3_5.py``
+    (``Qwen3_5TextModel`` → ``embed_tokens`` / ``layers`` / ``norm``; wrapper
+    ``TextModel`` → ``lm_head``) — not invented.
+    """
+    # The exact codex #2 concern: deep vision subtree under ``.model.``.
+    assert (
+        metadata._is_qwen3_5_moe_text_tensor(
+            "language_model.model.vision_encoder.blocks.0.weight"
+        )
+        is False
+    )
+    # Any other unknown modality subtree under ``.model.`` is likewise rejected.
+    assert (
+        metadata._is_qwen3_5_moe_text_tensor(
+            "language_model.model.audio_tower.0.weight"
+        )
+        is False
+    )
+
+    # The real text tensors ARE still accepted.
+    assert metadata._is_qwen3_5_moe_text_tensor(
+        "language_model.model.embed_tokens.weight"
+    )
+    assert metadata._is_qwen3_5_moe_text_tensor(
+        "language_model.model.layers.0.self_attn.q_proj.weight"
+    )
+    assert metadata._is_qwen3_5_moe_text_tensor("language_model.model.norm.weight")
+    assert metadata._is_qwen3_5_moe_text_tensor("language_model.lm_head.weight")
+    # MoE expert tensors (the sanitizer emits ``...mlp.switch_mlp.*``) live
+    # under ``language_model.model.layers.*`` and are still recognised.
+    assert metadata._is_qwen3_5_moe_text_tensor(
+        "language_model.model.layers.0.mlp.switch_mlp.gate_proj.weight"
+    )
+
+    # A whole checkpoint whose vision encoder nests under ``.model.`` is NOT a
+    # text-only layout — the verdict must stay inconclusive (never text).
+    cfg = {"architectures": ["Qwen3_5MoeForConditionalGeneration"]}
+    deep_vision_layout = {
+        "language_model.model.embed_tokens.weight": "s",
+        "language_model.model.layers.0.self_attn.q_proj.weight": "s",
+        "language_model.model.vision_encoder.blocks.0.weight": "s",
+    }
+    assert metadata._known_text_only_weight_layout(deep_vision_layout, cfg) is False
+
+
+def test_single_safetensors_glob_oserror_is_inconclusive(tmp_path, monkeypatch):
+    """codex #5: file enumeration (``snapshot_dir.glob``) is inside the
+    exception handler, so a permission error / stale mount / cache race yields
+    the documented inconclusive result (``None``) instead of crashing routing.
+    """
+    from pathlib import Path
+
+    def _boom(self, *args, **kwargs):
+        raise OSError("stale mount / permission denied")
+
+    monkeypatch.setattr(Path, "glob", _boom)
+
+    # Direct helper: must not raise, returns inconclusive.
+    assert metadata._single_safetensors_has_multimodal_weights(tmp_path) is None
+    # Higher-level entry point (no index → falls through to the single-file
+    # header path) must also stay inconclusive rather than crash.
+    assert metadata.checkpoint_has_multimodal_weights(tmp_path, None) is None
+
+
 def test_weight_index_has_independent_production_size_bound(tmp_path):
     weight_map = {
         "language_model." + "x" * metadata.MAX_METADATA_FILE_BYTES: "model.safetensors",

--- a/tests/test_model_metadata.py
+++ b/tests/test_model_metadata.py
@@ -284,9 +284,20 @@ def test_multimodal_config_and_sharded_weight_detection(tmp_path):
     assert metadata.checkpoint_has_multimodal_weights(None) is None
     assert metadata.checkpoint_has_multimodal_weights(tmp_path) is None
 
+    # Real Qwen3.5-MoE text tensors live under ``language_model.model.*`` (the
+    # backbone) and ``language_model.lm_head`` (the head); the precise text
+    # allowlist recognises this exact layout as text-only.
     _write_json(
         tmp_path / "model.safetensors.index.json",
-        {"weight_map": {"language_model.layers.0.weight": "model.safetensors"}},
+        {
+            "weight_map": {
+                "language_model.model.layers.0.self_attn.q_proj.weight": (
+                    "model.safetensors"
+                ),
+                "language_model.model.embed_tokens.weight": "model.safetensors",
+                "language_model.lm_head.weight": "model.safetensors",
+            }
+        },
     )
     assert metadata.checkpoint_has_multimodal_weights(tmp_path) is None
     assert (
@@ -295,6 +306,26 @@ def test_multimodal_config_and_sharded_weight_detection(tmp_path):
             {"architectures": ["Qwen3_5MoeForConditionalGeneration"]},
         )
         is False
+    )
+    # A modality subtree nested under ``language_model.`` (a bare-prefix match
+    # that is NOT a real text tensor) must NOT be mistaken for text-only: the
+    # tightened allowlist leaves the verdict inconclusive (``None``) so a real
+    # VLM is never misrouted to the text loader.
+    _write_json(
+        tmp_path / "model.safetensors.index.json",
+        {
+            "weight_map": {
+                "language_model.model.embed_tokens.weight": "model.safetensors",
+                "language_model.vision_encoder.blocks.0.weight": "model.safetensors",
+            }
+        },
+    )
+    assert (
+        metadata.checkpoint_has_multimodal_weights(
+            tmp_path,
+            {"architectures": ["Qwen3_5MoeForConditionalGeneration"]},
+        )
+        is None
     )
 
     _write_json(tmp_path / "model.safetensors.index.json", {"weight_map": []})
@@ -316,6 +347,55 @@ def test_multimodal_config_and_sharded_weight_detection(tmp_path):
 
     _write_safetensors_header(safetensors, ["vision_encoder.blocks.0.weight"])
     assert metadata.checkpoint_has_multimodal_weights(tmp_path) is None
+
+
+def test_known_text_only_layout_rejects_modality_subtree_under_language_model():
+    """FIX 3: the text-only allowlist is validated against precise text tensor
+    paths, NOT the bare ``language_model.`` prefix.
+
+    A modality subtree nested under ``language_model.`` (e.g.
+    ``language_model.vision_encoder.blocks.0.weight``) must NOT be classified as
+    text-only, or a real VLM whose vision encoder is namespaced under
+    ``language_model.`` would be misrouted to the text loader.
+    """
+    cfg = {"architectures": ["Qwen3_5MoeForConditionalGeneration"]}
+
+    # Precise real text layout (backbone + head) -> recognised as text-only.
+    text_layout = {
+        "language_model.model.embed_tokens.weight": "s",
+        "language_model.model.layers.0.self_attn.q_proj.weight": "s",
+        "language_model.model.norm.weight": "s",
+        "language_model.lm_head.weight": "s",
+    }
+    assert metadata._known_text_only_weight_layout(text_layout, cfg) is True
+
+    # Tied-embedding checkpoint (no ``lm_head``) is still text-only.
+    tied_layout = {
+        "language_model.model.embed_tokens.weight": "s",
+        "language_model.model.layers.0.mlp.gate_proj.weight": "s",
+    }
+    assert metadata._known_text_only_weight_layout(tied_layout, cfg) is True
+
+    # A vision subtree nested under ``language_model.`` is NOT text-only.
+    nested_vision = {
+        "language_model.model.embed_tokens.weight": "s",
+        "language_model.vision_encoder.blocks.0.weight": "s",
+    }
+    assert metadata._known_text_only_weight_layout(nested_vision, cfg) is False
+
+    # The bare-prefix form the OLD code accepted (``language_model.layers.*``
+    # without the ``.model.`` segment) is not the real layout and is no longer
+    # blindly trusted as text-only.
+    bare_prefix = {"language_model.layers.0.weight": "s"}
+    assert metadata._known_text_only_weight_layout(bare_prefix, cfg) is False
+
+    # Wrong architecture -> never text-only regardless of tensor names.
+    assert (
+        metadata._known_text_only_weight_layout(
+            text_layout, {"architectures": ["SomeOtherForCausalLM"]}
+        )
+        is False
+    )
 
 
 def test_weight_index_has_independent_production_size_bound(tmp_path):

--- a/tests/test_model_metadata.py
+++ b/tests/test_model_metadata.py
@@ -91,6 +91,18 @@ def test_named_tokenizer_templates_prefer_tool_use_then_default():
         metadata._select_chat_template({"chat_template": {"a": "one", "b": "two"}})
         is None
     )
+    assert (
+        metadata._select_chat_template(
+            {
+                "chat_template": [
+                    {"name": "default", "template": "default"},
+                    {"name": "tool_use", "template": "tool-use"},
+                    {"name": 1, "template": "ignored"},
+                ]
+            }
+        )
+        == "tool-use"
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_model_metadata.py
+++ b/tests/test_model_metadata.py
@@ -236,7 +236,14 @@ def test_multimodal_config_and_sharded_weight_detection(tmp_path):
         tmp_path / "model.safetensors.index.json",
         {"weight_map": {"language_model.layers.0.weight": "model.safetensors"}},
     )
-    assert metadata.checkpoint_has_multimodal_weights(tmp_path) is False
+    assert metadata.checkpoint_has_multimodal_weights(tmp_path) is None
+    assert (
+        metadata.checkpoint_has_multimodal_weights(
+            tmp_path,
+            {"architectures": ["Qwen3_5MoeForConditionalGeneration"]},
+        )
+        is False
+    )
 
     _write_json(tmp_path / "model.safetensors.index.json", {"weight_map": []})
     assert metadata.checkpoint_has_multimodal_weights(tmp_path) is None
@@ -257,6 +264,19 @@ def test_multimodal_config_and_sharded_weight_detection(tmp_path):
 
     _write_safetensors_header(safetensors, ["vision_encoder.blocks.0.weight"])
     assert metadata.checkpoint_has_multimodal_weights(tmp_path) is None
+
+
+def test_weight_index_has_independent_production_size_bound(tmp_path):
+    weight_map = {
+        "language_model." + "x" * metadata.MAX_METADATA_FILE_BYTES: "model.safetensors",
+        "vision_tower.blocks.0.weight": "model.safetensors",
+    }
+    _write_json(tmp_path / "model.safetensors.index.json", {"weight_map": weight_map})
+
+    assert (
+        tmp_path / "model.safetensors.index.json"
+    ).stat().st_size > metadata.MAX_METADATA_FILE_BYTES
+    assert metadata.checkpoint_has_multimodal_weights(tmp_path) is True
 
 
 def test_single_safetensors_header_rejects_corrupt_or_unsupported_shapes(tmp_path):

--- a/tests/test_model_metadata.py
+++ b/tests/test_model_metadata.py
@@ -250,10 +250,13 @@ def test_multimodal_config_and_sharded_weight_detection(tmp_path):
     (tmp_path / "model.safetensors.index.json").unlink()
     safetensors = tmp_path / "model.safetensors"
     _write_safetensors_header(safetensors, ["language_model.layers.0.weight"])
-    assert metadata.checkpoint_has_multimodal_weights(tmp_path) is False
+    assert metadata.checkpoint_has_multimodal_weights(tmp_path) is None
 
     _write_safetensors_header(safetensors, ["vision_tower.blocks.0.weight"])
     assert metadata.checkpoint_has_multimodal_weights(tmp_path) is True
+
+    _write_safetensors_header(safetensors, ["vision_encoder.blocks.0.weight"])
+    assert metadata.checkpoint_has_multimodal_weights(tmp_path) is None
 
 
 def test_single_safetensors_header_rejects_corrupt_or_unsupported_shapes(tmp_path):

--- a/tests/test_model_metadata.py
+++ b/tests/test_model_metadata.py
@@ -1,0 +1,194 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Hermetic coverage for offline model metadata inspection."""
+
+import json
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+from vllm_mlx import model_metadata as metadata
+
+
+def _write_json(path: Path, value) -> None:
+    path.write_text(json.dumps(value), encoding="utf-8")
+
+
+def test_readers_reject_missing_malformed_non_object_and_oversized_files(tmp_path):
+    missing = tmp_path / "missing.json"
+    assert metadata._read_json(None) is None
+    assert metadata._read_json(missing) is None
+    assert metadata._read_text(None) is None
+    assert metadata._read_text(missing) is None
+
+    malformed = tmp_path / "malformed.json"
+    malformed.write_text("{not json", encoding="utf-8")
+    assert metadata._read_json(malformed) is None
+
+    list_json = tmp_path / "list.json"
+    _write_json(list_json, ["not", "an", "object"])
+    assert metadata._read_json(list_json) is None
+
+    huge = tmp_path / "huge.txt"
+    huge.write_text("x" * (metadata.MAX_METADATA_FILE_BYTES + 1), encoding="utf-8")
+    assert metadata._read_json(huge) is None
+    assert metadata._read_text(huge) is None
+
+    invalid_utf8 = tmp_path / "invalid-utf8.jinja"
+    invalid_utf8.write_bytes(b"\xff")
+    assert metadata._read_text(invalid_utf8) is None
+
+
+def test_local_metadata_prefers_standalone_template_then_tokenizer_fallback(tmp_path):
+    standalone = tmp_path / "standalone"
+    standalone.mkdir()
+    _write_json(standalone / "config.json", {"model_type": "qwen3"})
+    _write_json(standalone / "tokenizer_config.json", {"chat_template": "tokenizer"})
+    (standalone / "chat_template.jinja").write_text("standalone", encoding="utf-8")
+
+    result = metadata.read_local_model_metadata(str(standalone))
+
+    assert result == metadata.ModelMetadata(
+        config={"model_type": "qwen3"},
+        chat_template="standalone",
+        snapshot_dir=standalone,
+    )
+
+    fallback = tmp_path / "fallback"
+    fallback.mkdir()
+    _write_json(fallback / "tokenizer_config.json", {"chat_template": "tokenizer"})
+    fallback_result = metadata.read_local_model_metadata(str(fallback))
+
+    assert fallback_result == metadata.ModelMetadata(
+        config=None,
+        chat_template="tokenizer",
+        snapshot_dir=fallback,
+    )
+    assert metadata._chat_template(None) is None
+    assert metadata.read_local_model_metadata(object()) is None
+
+
+@pytest.mark.parametrize(
+    ("model_name", "expected"),
+    [
+        ("publisher/model", True),
+        ("publisher/nested/model", True),
+        ("plain-name", False),
+        ("/absolute/model", False),
+        ("./relative/model", False),
+        ("../parent/model", False),
+        ("~/cache/model", False),
+    ],
+)
+def test_hub_repo_id_validation_rejects_path_lookalikes(model_name, expected):
+    assert metadata._looks_like_hub_repo_id(model_name) is expected
+
+
+def test_cached_file_handles_cache_hit_missing_and_lookup_error(monkeypatch, tmp_path):
+    hit = tmp_path / "config.json"
+    _write_json(hit, {"ok": True})
+    no_exist = object()
+    responses = {
+        "config.json": str(hit),
+        "missing.json": None,
+        "no-exist.json": no_exist,
+    }
+
+    def lookup(repo_id, filename):
+        if filename == "explode.json":
+            raise RuntimeError("cache unavailable")
+        return responses[filename]
+
+    hub = types.ModuleType("huggingface_hub")
+    hub._CACHED_NO_EXIST = no_exist
+    hub.try_to_load_from_cache = lookup
+    monkeypatch.setitem(sys.modules, "huggingface_hub", hub)
+
+    assert metadata._cached_file("publisher/model", "config.json") == hit
+    assert metadata._cached_file("publisher/model", "missing.json") is None
+    assert metadata._cached_file("publisher/model", "no-exist.json") is None
+    assert metadata._cached_file("publisher/model", "explode.json") is None
+    assert metadata._cached_file("not-a-repo", "config.json") is None
+
+
+def test_cached_file_handles_missing_huggingface_hub_dependency(monkeypatch):
+    monkeypatch.setitem(sys.modules, "huggingface_hub", None)
+
+    assert metadata._cached_file("publisher/model", "config.json") is None
+
+
+def test_cached_metadata_reads_standalone_template_and_tokenizer_fallback(
+    monkeypatch, tmp_path
+):
+    snapshot = tmp_path / "snapshot"
+    snapshot.mkdir()
+    config = snapshot / "config.json"
+    standalone = snapshot / "chat_template.jinja"
+    tokenizer = snapshot / "tokenizer_config.json"
+    _write_json(config, {"model_type": "qwen3_5"})
+    standalone.write_text("standalone", encoding="utf-8")
+    _write_json(tokenizer, {"chat_template": "tokenizer"})
+    paths = {
+        "config.json": config,
+        "chat_template.jinja": standalone,
+        "tokenizer_config.json": tokenizer,
+    }
+    monkeypatch.setattr(metadata, "_cached_file", lambda name, filename: paths[filename])
+
+    result = metadata.read_cached_model_metadata("publisher/model")
+
+    assert result == metadata.ModelMetadata(
+        config={"model_type": "qwen3_5"},
+        chat_template="standalone",
+        snapshot_dir=snapshot,
+    )
+
+    standalone.unlink()
+    paths["chat_template.jinja"] = None
+    result = metadata.read_cached_model_metadata("publisher/model")
+    assert result is not None
+    assert result.chat_template == "tokenizer"
+
+
+def test_cached_metadata_returns_none_without_any_cached_metadata(monkeypatch):
+    monkeypatch.setattr(metadata, "_cached_file", lambda name, filename: None)
+
+    assert metadata.read_cached_model_metadata("publisher/model") is None
+
+
+def test_read_model_metadata_prefers_local_directory_then_cache(monkeypatch, tmp_path):
+    local = metadata.ModelMetadata({}, "local", tmp_path)
+    cached = metadata.ModelMetadata({}, "cached", tmp_path)
+    monkeypatch.setattr(metadata, "read_local_model_metadata", lambda name: local)
+    monkeypatch.setattr(metadata, "read_cached_model_metadata", lambda name: cached)
+    assert metadata.read_model_metadata("anything") is local
+
+    monkeypatch.setattr(metadata, "read_local_model_metadata", lambda name: None)
+    assert metadata.read_model_metadata("anything") is cached
+
+
+def test_multimodal_config_and_sharded_weight_detection(tmp_path):
+    assert metadata.config_indicates_multimodal(
+        {"architectures": ["LlavaForConditionalGeneration"]}
+    )
+    assert metadata.config_indicates_multimodal({"audio_config": {}})
+    assert not metadata.config_indicates_multimodal({"architectures": "not-a-list"})
+
+    assert metadata.checkpoint_has_multimodal_weights(None) is None
+    assert metadata.checkpoint_has_multimodal_weights(tmp_path) is None
+
+    _write_json(
+        tmp_path / "model.safetensors.index.json",
+        {"weight_map": {"language_model.layers.0.weight": "model.safetensors"}},
+    )
+    assert metadata.checkpoint_has_multimodal_weights(tmp_path) is False
+
+    _write_json(tmp_path / "model.safetensors.index.json", {"weight_map": []})
+    assert metadata.checkpoint_has_multimodal_weights(tmp_path) is None
+
+    _write_json(
+        tmp_path / "model.safetensors.index.json",
+        {"weight_map": {"vision_tower.blocks.0.weight": "model.safetensors"}},
+    )
+    assert metadata.checkpoint_has_multimodal_weights(tmp_path) is True

--- a/tests/test_model_metadata.py
+++ b/tests/test_model_metadata.py
@@ -284,9 +284,10 @@ def test_multimodal_config_and_sharded_weight_detection(tmp_path):
     assert metadata.checkpoint_has_multimodal_weights(None) is None
     assert metadata.checkpoint_has_multimodal_weights(tmp_path) is None
 
-    # Real Qwen3.5-MoE text tensors live under ``language_model.model.*`` (the
-    # backbone) and ``language_model.lm_head`` (the head); the precise text
-    # allowlist recognises this exact layout as text-only.
+    # ARCHITECTURE-AGNOSTIC weight-evidence rule (round-5 regression fix,
+    # restoring origin/main): a readable weight index with NO multimodal tensors
+    # is a text-only verdict (``False``) for EVERY architecture, not just
+    # Qwen3.5-MoE.  A language-only backbone (no vision/audio tensors) → text.
     _write_json(
         tmp_path / "model.safetensors.index.json",
         {
@@ -299,7 +300,10 @@ def test_multimodal_config_and_sharded_weight_detection(tmp_path):
             }
         },
     )
-    assert metadata.checkpoint_has_multimodal_weights(tmp_path) is None
+    # No config, no vision tensors → text-only (False), architecture-agnostic.
+    assert metadata.checkpoint_has_multimodal_weights(tmp_path) is False
+    # Same with a VLM-capable arch declared: still text-only, because the
+    # WEIGHTS carry no vision tensors (the #393 / codex #2 text-only-fork case).
     assert (
         metadata.checkpoint_has_multimodal_weights(
             tmp_path,
@@ -307,10 +311,10 @@ def test_multimodal_config_and_sharded_weight_detection(tmp_path):
         )
         is False
     )
-    # A modality subtree nested under ``language_model.`` (a bare-prefix match
-    # that is NOT a real text tensor) must NOT be mistaken for text-only: the
-    # tightened allowlist leaves the verdict inconclusive (``None``) so a real
-    # VLM is never misrouted to the text loader.
+    # A real vision tensor (``vision_encoder``) nested under ``language_model.``
+    # is POSITIVE modality evidence → VLM (True).  Weight evidence, not the
+    # namespace prefix, decides: a checkpoint that actually ships vision weights
+    # is multimodal regardless of where they are nested.
     _write_json(
         tmp_path / "model.safetensors.index.json",
         {
@@ -325,11 +329,18 @@ def test_multimodal_config_and_sharded_weight_detection(tmp_path):
             tmp_path,
             {"architectures": ["Qwen3_5MoeForConditionalGeneration"]},
         )
-        is None
+        is True
     )
 
+    # A malformed weight_map (a list, not a dict) is unreadable evidence →
+    # inconclusive (None), so the caller falls back to config/name heuristics.
     _write_json(tmp_path / "model.safetensors.index.json", {"weight_map": []})
     assert metadata.checkpoint_has_multimodal_weights(tmp_path) is None
+
+    # An EMPTY-but-well-formed weight_map ({}) is a readable index with no
+    # vision tensors → text-only (False), architecture-agnostic.
+    _write_json(tmp_path / "model.safetensors.index.json", {"weight_map": {}})
+    assert metadata.checkpoint_has_multimodal_weights(tmp_path) is False
 
     _write_json(
         tmp_path / "model.safetensors.index.json",
@@ -337,16 +348,18 @@ def test_multimodal_config_and_sharded_weight_detection(tmp_path):
     )
     assert metadata.checkpoint_has_multimodal_weights(tmp_path) is True
 
+    # Single-file safetensors header path applies the SAME architecture-agnostic
+    # rule: language-only header → text (False); vision tensor → VLM (True).
     (tmp_path / "model.safetensors.index.json").unlink()
     safetensors = tmp_path / "model.safetensors"
     _write_safetensors_header(safetensors, ["language_model.layers.0.weight"])
-    assert metadata.checkpoint_has_multimodal_weights(tmp_path) is None
+    assert metadata.checkpoint_has_multimodal_weights(tmp_path) is False
 
     _write_safetensors_header(safetensors, ["vision_tower.blocks.0.weight"])
     assert metadata.checkpoint_has_multimodal_weights(tmp_path) is True
 
     _write_safetensors_header(safetensors, ["vision_encoder.blocks.0.weight"])
-    assert metadata.checkpoint_has_multimodal_weights(tmp_path) is None
+    assert metadata.checkpoint_has_multimodal_weights(tmp_path) is True
 
 
 def test_known_text_only_layout_rejects_modality_subtree_under_language_model():

--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -1,6 +1,7 @@
 {
   "qwen3.5-4b-4bit": {
     "hf_path": "mlx-community/Qwen3.5-4B-MLX-4bit",
+    "is_text_only": true,
     "tool_call_parser": "hermes",
     "reasoning_parser": "qwen3",
     "is_hybrid": false,

--- a/vllm_mlx/api/utils.py
+++ b/vllm_mlx/api/utils.py
@@ -923,15 +923,31 @@ def is_mllm_model(model_name: str) -> bool:
         # text-family name would be misrouted to the text engine (#1121).
         if verdict is True:
             return True
-        # An inconclusive verdict (``None``) is NEVER promoted on the bare
-        # existence of checkpoint files: file presence is not modality
-        # evidence.  Fall through to the name/locality fallback below, which
-        # already handles inconclusive results correctly (name matcher for
-        # cached-remote, trust for a bare local VLM-config directory).
-        # The verdict is unavailable (no index/header evidence). A registered
-        # alias or a cached remote config can be a partial metadata download, so
-        # a name without legacy MLLM evidence stays on text until positive proof.
-        # A bare local directory with a VLM config and no index is trusted.
+        # An inconclusive verdict (``None`` — the checkpoint was inspected but
+        # its tensor layout is unrecognised, or there is no index/header
+        # evidence at all) routes to the NAME/LOCALITY fallback below, NOT to a
+        # forced-multimodal verdict.
+        #
+        # DELIBERATE OVERRIDE of codex round-3 #1, which asked to PRESERVE the
+        # multimodal route on an inspected-but-unknown layout.  That reverses
+        # codex round-2 #1, which demanded we "never promote an inconclusive
+        # result based solely on file existence" — the author complied and
+        # removed exactly that promotion.  Honouring round-3 #1 would
+        # re-introduce what round-2 #1 rejected (codex oscillated between the two
+        # rounds).  Both misroute directions are harmful: force-VLM crashes a
+        # text-only fork in the MLLM batched engine on a missing vision tower
+        # (#393), while force-text starves a genuine VLM of its vision path.
+        # With genuinely ambiguous evidence there is no evidentiary basis to
+        # prefer either, so the name/locality heuristic — the established
+        # rapid-mlx default — is used as the NEUTRAL tie-breaker: it decides on
+        # the repo-name signal rather than on the bare presence of files.  This
+        # note is left so a future reviewer sees the round-2↔round-3 oscillation
+        # and the reasoned choice rather than re-litigating it.
+        #
+        # The fallback itself: a registered alias or a cached remote config can
+        # be a partial metadata download, so a name without legacy MLLM evidence
+        # stays on text until positive proof.  A bare local directory with a VLM
+        # config and no index is trusted as multimodal.
         if profile is not None:
             return _check_legacy_string_patterns(model_name)
         if metadata.is_local:

--- a/vllm_mlx/api/utils.py
+++ b/vllm_mlx/api/utils.py
@@ -894,7 +894,7 @@ def is_mllm_model(model_name: str) -> bool:
     if config is not None:
         if not _config_indicates_vlm(config):
             return False
-        verdict = checkpoint_has_multimodal_weights(metadata.snapshot_dir)
+        verdict = checkpoint_has_multimodal_weights(metadata.snapshot_dir, config)
         if verdict is False:
             return False
         if profile is not None:

--- a/vllm_mlx/api/utils.py
+++ b/vllm_mlx/api/utils.py
@@ -9,7 +9,6 @@ import re
 
 from ..model_aliases import resolve_profile
 from ..model_metadata import (
-    checkpoint_evidence_is_available,
     checkpoint_has_multimodal_weights,
     config_indicates_multimodal,
     read_cached_model_metadata,
@@ -852,12 +851,19 @@ def _check_legacy_string_patterns(model_name: str) -> bool:
 def is_mllm_model(model_name: str) -> bool:
     """Check if a model name or path indicates a multimodal language model.
 
-    An explicit ``is_text_only`` alias pin is authoritative.  Otherwise,
-    local metadata is authoritative for unaliased paths.  A cached HF
-    snapshot is promoted only after it supplies positive modality evidence;
-    this preserves text routing for a partial cache that contains an inherited
-    vision config but no vision weights.  The shared probe never sends a
-    network request.  It applies two checks in order:
+    A curated alias that POSITIVELY declares text-only serving
+    (``is_text_only`` — the #393 state-pin) is authoritative and stays on the
+    text lane even against real vision weights: it is an operator decision, with
+    text-serve coverage, to run a vision-config checkpoint through the AR text
+    lane.  A bare alias that merely defaults to the ``text`` modality does NOT
+    override real vision weights — such a repackaged VLM still routes to the
+    MLLM lane via the checkpoint-evidence path (#1121).  Otherwise, local
+    metadata is authoritative for unaliased paths.  A cached HF snapshot is
+    promoted only after it supplies positive modality evidence; this preserves
+    text routing for a partial cache that contains an inherited vision config
+    but no vision weights, and an inconclusive verdict is NEVER promoted on the
+    bare existence of checkpoint files.  The shared probe never sends a network
+    request.  It applies two checks in order:
 
     1. Config inspection: ``architectures`` / ``vision_config`` /
        ``audio_config`` declare whether the checkpoint is multimodal.
@@ -887,6 +893,17 @@ def is_mllm_model(model_name: str) -> bool:
         True if the model is detected as multimodal (MLLM/VLM).
     """
     profile = resolve_profile(model_name)
+    # A curated alias that declares text-only serving (``is_text_only`` — the
+    # #393 state-pin) is authoritative and outranks the checkpoint's raw vision
+    # weights: it is a deliberate operator decision, with text-serve coverage,
+    # to run a vision-config checkpoint through the AR text lane.  Some upstream
+    # repackages of a Qwen3.5 text model still ship a ``vision_tower`` in the
+    # safetensors index, so the weight-evidence path below would (correctly, on
+    # the raw bytes) return True; the pin short-circuits BEFORE that path so the
+    # curated text modality wins.  A bare alias that merely defaults to the
+    # ``text`` modality is NOT short-circuited here — real vision weights still
+    # route it to the MLLM lane via the evidence path (#1121), so a repackaged
+    # VLM served under a text-family alias name is not misrouted to text.
     if profile is not None and profile.is_text_only:
         return False
 
@@ -906,8 +923,11 @@ def is_mllm_model(model_name: str) -> bool:
         # text-family name would be misrouted to the text engine (#1121).
         if verdict is True:
             return True
-        if verdict is None and checkpoint_evidence_is_available(metadata.snapshot_dir):
-            return True
+        # An inconclusive verdict (``None``) is NEVER promoted on the bare
+        # existence of checkpoint files: file presence is not modality
+        # evidence.  Fall through to the name/locality fallback below, which
+        # already handles inconclusive results correctly (name matcher for
+        # cached-remote, trust for a bare local VLM-config directory).
         # The verdict is unavailable (no index/header evidence). A registered
         # alias or a cached remote config can be a partial metadata download, so
         # a name without legacy MLLM evidence stays on text until positive proof.

--- a/vllm_mlx/api/utils.py
+++ b/vllm_mlx/api/utils.py
@@ -9,6 +9,7 @@ import re
 
 from ..model_aliases import resolve_profile
 from ..model_metadata import (
+    checkpoint_evidence_is_available,
     checkpoint_has_multimodal_weights,
     config_indicates_multimodal,
     read_cached_model_metadata,
@@ -897,6 +898,8 @@ def is_mllm_model(model_name: str) -> bool:
         verdict = checkpoint_has_multimodal_weights(metadata.snapshot_dir, config)
         if verdict is False:
             return False
+        if verdict is None and checkpoint_evidence_is_available(metadata.snapshot_dir):
+            return True
         if profile is not None:
             return _check_legacy_string_patterns(model_name)
         if verdict is True or metadata.is_local:

--- a/vllm_mlx/api/utils.py
+++ b/vllm_mlx/api/utils.py
@@ -7,6 +7,7 @@ import json
 import logging
 import re
 
+from ..model_aliases import resolve_profile
 from ..model_metadata import (
     checkpoint_has_multimodal_weights,
     config_indicates_multimodal,
@@ -850,9 +851,12 @@ def _check_legacy_string_patterns(model_name: str) -> bool:
 def is_mllm_model(model_name: str) -> bool:
     """Check if a model name or path indicates a multimodal language model.
 
-    Metadata is authoritative whenever it is available.  The shared offline
-    probe reads a local directory or an already-cached HF snapshot; it never
-    sends a network request.  It applies two checks in order:
+    An explicit ``is_text_only`` alias pin is authoritative.  Otherwise,
+    local metadata is authoritative for unaliased paths.  A cached HF
+    snapshot is promoted only after it supplies positive modality evidence;
+    this preserves text routing for a partial cache that contains an inherited
+    vision config but no vision weights.  The shared probe never sends a
+    network request.  It applies two checks in order:
 
     1. Config inspection: ``architectures`` / ``vision_config`` /
        ``audio_config`` declare whether the checkpoint is multimodal.
@@ -869,10 +873,11 @@ def is_mllm_model(model_name: str) -> bool:
        multimodal-capable, but the user's safetensors only contain
        language tensors).
 
-    If metadata is unavailable or malformed, the legacy name matcher remains
-    the conservative compatibility fallback.  This allows a re-packaged VLM
-    such as Agents-A1 to select the MLLM route based on its checkpoint rather
-    than an arbitrary repository name.
+    If cached metadata has no index/header evidence, the legacy name matcher
+    remains the compatibility fallback.  During ``serve``, model download has
+    already completed before this function runs, so a re-packaged VLM such as
+    Agents-A1 has its actual checkpoint evidence available rather than relying
+    on an arbitrary repository name.
 
     Args:
         model_name: HuggingFace repo ID or local filesystem path.
@@ -880,6 +885,10 @@ def is_mllm_model(model_name: str) -> bool:
     Returns:
         True if the model is detected as multimodal (MLLM/VLM).
     """
+    profile = resolve_profile(model_name)
+    if profile is not None and profile.is_text_only:
+        return False
+
     metadata = read_model_metadata(model_name)
     config = metadata.config if metadata is not None else None
     if config is not None:
@@ -888,10 +897,14 @@ def is_mllm_model(model_name: str) -> bool:
         verdict = checkpoint_has_multimodal_weights(metadata.snapshot_dir)
         if verdict is False:
             return False
-        # Verdict is True or None (unsharded / unavailable index).  Trust the
-        # config in both cases: wrong-True fails visibly on image use, while
-        # wrong-False would silently send a real VLM through the text lane.
-        return True
+        if profile is not None:
+            return _check_legacy_string_patterns(model_name)
+        if verdict is True or metadata.is_local:
+            return True
+        # The verdict is unavailable. Trust config for a local directory; a
+        # cached remote config can be a partial metadata download, so a name
+        # without legacy MLLM evidence stays on text until positive proof.
+        return _check_legacy_string_patterns(model_name)
 
     return _check_legacy_string_patterns(model_name)
 

--- a/vllm_mlx/api/utils.py
+++ b/vllm_mlx/api/utils.py
@@ -898,15 +898,24 @@ def is_mllm_model(model_name: str) -> bool:
         verdict = checkpoint_has_multimodal_weights(metadata.snapshot_dir, config)
         if verdict is False:
             return False
+        # Positive checkpoint evidence is authoritative and must win over any
+        # repository-name pattern.  A registered alias only short-circuits when
+        # it POSITIVELY declares text-only (handled above via
+        # ``profile.is_text_only``); a bare alias entry must never override real
+        # vision weights, or a renamed/repackaged VLM served under an aliased
+        # text-family name would be misrouted to the text engine (#1121).
+        if verdict is True:
+            return True
         if verdict is None and checkpoint_evidence_is_available(metadata.snapshot_dir):
             return True
+        # The verdict is unavailable (no index/header evidence). A registered
+        # alias or a cached remote config can be a partial metadata download, so
+        # a name without legacy MLLM evidence stays on text until positive proof.
+        # A bare local directory with a VLM config and no index is trusted.
         if profile is not None:
             return _check_legacy_string_patterns(model_name)
-        if verdict is True or metadata.is_local:
+        if metadata.is_local:
             return True
-        # The verdict is unavailable. Trust config for a local directory; a
-        # cached remote config can be a partial metadata download, so a name
-        # without legacy MLLM evidence stays on text until positive proof.
         return _check_legacy_string_patterns(model_name)
 
     return _check_legacy_string_patterns(model_name)

--- a/vllm_mlx/api/utils.py
+++ b/vllm_mlx/api/utils.py
@@ -5,10 +5,15 @@ Utility functions for text processing and model detection.
 
 import json
 import logging
-import os
 import re
-from pathlib import Path
 
+from ..model_metadata import (
+    checkpoint_has_multimodal_weights,
+    config_indicates_multimodal,
+    read_cached_model_metadata,
+    read_local_model_metadata,
+    read_model_metadata,
+)
 from .models import Message
 
 logger = logging.getLogger(__name__)
@@ -810,201 +815,26 @@ MLLM_PATTERNS = [
 ]
 
 
-# Config.json keys that, when present, indicate a multimodal model.
-_VLM_CONFIG_KEYS = (
-    "vision_config",
-    "audio_config",
-    "vision_tower",
-    "mm_vision_tower",
-    "image_token_id",
-    "image_token_index",
-    "audio_token_id",
-    "audio_token_index",
-)
-
-# Substrings (case-insensitive) inside `architectures` entries that identify VLMs.
-# Covers both ForConditionalGeneration VLMs (Qwen2VL, LLaVA, PaliGemma, Mllama, etc.)
-# and the few VLMs that use ForCausalLM (Phi3V, Molmo, CogVLM, InternVL).
-_VLM_ARCHITECTURE_KEYWORDS = (
-    "VLForCondition",
-    "VLForCausal",
-    "VisionForCondition",
-    "VisionForCausal",
-    "MultiModalityCausalLM",
-    "Llava",
-    "Idefics",
-    "PaliGemma",
-    "Pixtral",
-    "Molmo",
-    "Phi3V",
-    "Phi4V",
-    "CogVLM",
-    "InternVL",
-    "DeepseekVL",
-    "Mllama",
-    "Gemma3ForConditional",
-    "Gemma4ForConditional",
-)
-
-# Defensive cap on config.json size to bound parsing cost.
-_MAX_CONFIG_JSON_BYTES = 1 * 1024 * 1024
-
-
 def _try_read_config_json(name_or_path: str) -> dict | None:
-    """Read config.json from a local model directory.
-
-    Returns None when the input is not a local directory, the directory has
-    no config.json, the file is too large, or it cannot be parsed.
-    """
-    try:
-        candidate = Path(name_or_path)
-    except (TypeError, ValueError):
-        return None
-
-    if not candidate.is_dir():
-        return None
-
-    config_path = candidate / "config.json"
-    if not config_path.is_file():
-        return None
-
-    try:
-        if config_path.stat().st_size > _MAX_CONFIG_JSON_BYTES:
-            return None
-        with config_path.open("r", encoding="utf-8") as f:
-            data = json.load(f)
-    except (OSError, json.JSONDecodeError, UnicodeDecodeError, ValueError):
-        return None
-
-    return data if isinstance(data, dict) else None
+    """Compatibility wrapper for local config metadata lookup."""
+    metadata = read_local_model_metadata(name_or_path)
+    return metadata.config if metadata is not None else None
 
 
 def _try_read_hub_config_json(model_name: str) -> dict | None:
-    """Read a cached config.json for an HF repo ID without going online.
-
-    Looks up the repo in the local ``huggingface_hub`` cache via
-    ``try_to_load_from_cache``. If the model has already been downloaded
-    (or even just had its config fetched), the file is on disk and we
-    can read it authoritatively. If nothing is cached, returns None —
-    the caller falls back to legacy substring matching rather than
-    making a network call. Never raises; never reaches the network.
-
-    Only runs for inputs that look like repo IDs (``owner/name``), so
-    arbitrary strings and local-path lookalikes can't accidentally
-    trigger a cache lookup.
-    """
-    if not isinstance(model_name, str) or "/" not in model_name:
-        return None
-    if model_name.startswith(("/", "./", "../", "~")):
-        return None
-
-    try:
-        from huggingface_hub import _CACHED_NO_EXIST, try_to_load_from_cache
-    except ImportError:
-        return None
-
-    try:
-        cached = try_to_load_from_cache(model_name, "config.json")
-    except Exception:
-        return None
-    if cached is None or cached is _CACHED_NO_EXIST:
-        return None
-    if not isinstance(cached, (str, os.PathLike)):
-        return None
-
-    try:
-        config_path = Path(cached)
-        if not config_path.is_file():
-            return None
-        if config_path.stat().st_size > _MAX_CONFIG_JSON_BYTES:
-            return None
-        with config_path.open(encoding="utf-8") as f:
-            data = json.load(f)
-    except (OSError, json.JSONDecodeError, UnicodeDecodeError, ValueError):
-        return None
-
-    return data if isinstance(data, dict) else None
+    """Compatibility wrapper for cached HF config metadata lookup."""
+    metadata = read_cached_model_metadata(model_name)
+    return metadata.config if metadata is not None else None
 
 
 def _config_indicates_vlm(config: dict) -> bool:
-    """Inspect a parsed config.json dict for multimodal markers."""
-    archs = config.get("architectures") or []
-    if isinstance(archs, list):
-        for arch in archs:
-            if not isinstance(arch, str):
-                continue
-            arch_lower = arch.lower()
-            for keyword in _VLM_ARCHITECTURE_KEYWORDS:
-                if keyword.lower() in arch_lower:
-                    return True
-
-    for key in _VLM_CONFIG_KEYS:
-        if key in config:
-            return True
-
-    return False
+    """Compatibility wrapper for shared multimodal config inspection."""
+    return config_indicates_multimodal(config)
 
 
-# Tensor-name prefixes that indicate actual vision/audio weights live in
-# the checkpoint. Used to distinguish text-only forks of multimodal
-# architectures (where config.json declares ``vision_config`` but the
-# safetensors ship no ``vision_tower.*`` tensors) from genuine VLMs.
-# See issue #393 (Qwen3.6-35B-A3B text-only fork misrouted into MLLM
-# batched path because Qwen3.5MoeForConditionalGeneration declares
-# vision_config even when the user's safetensors are language-only).
-_MULTIMODAL_TENSOR_PREFIXES = (
-    "vision_tower",
-    "vision_model",
-    "visual.",
-    "audio_tower",
-    "audio_model",
-    "mm_projector",
-    "patch_embed.",
-)
-
-
-def _local_checkpoint_has_multimodal_weights(model_dir: Path) -> bool | None:
-    """Probe a local model dir for actual vision/audio tensor weights.
-
-    Returns:
-        ``True`` if at least one tensor name in ``model.safetensors.index.json``
-        matches a known multimodal prefix (``vision_tower``, ``visual.``,
-        ``mm_projector``, …).
-        ``False`` if the index is present, readable, and contains zero
-        such tensors — meaning the checkpoint is text-only despite
-        whatever ``config.json`` declares.
-        ``None`` when we can't authoritatively answer (no index file,
-        single-file safetensors, unreadable index). Caller should fall
-        back to the config-based decision rather than flipping it.
-
-    The single-file-safetensors branch returns ``None`` rather than
-    parsing the file header ourselves — the cost of a wrong False (text
-    routing for a real VLM → crash later on first image input) is much
-    larger than the cost of a wrong True (current behavior, the bug we
-    want to fix only for the multi-file case Tylast reported in #393).
-    """
-    index_path = model_dir / "model.safetensors.index.json"
-    if not index_path.is_file():
-        # No sharded index. Caller must rely on config-based detection.
-        return None
-    try:
-        if index_path.stat().st_size > _MAX_CONFIG_JSON_BYTES:
-            # Unreasonably large index — bail rather than guess.
-            return None
-        with index_path.open(encoding="utf-8") as f:
-            idx = json.load(f)
-    except (OSError, json.JSONDecodeError, UnicodeDecodeError, ValueError):
-        return None
-    weight_map = idx.get("weight_map")
-    if not isinstance(weight_map, dict):
-        return None
-    for tensor_name in weight_map:
-        if not isinstance(tensor_name, str):
-            continue
-        for prefix in _MULTIMODAL_TENSOR_PREFIXES:
-            if prefix in tensor_name:
-                return True
-    return False
+def _local_checkpoint_has_multimodal_weights(model_dir) -> bool | None:
+    """Compatibility wrapper for sharded-checkpoint modality inspection."""
+    return checkpoint_has_multimodal_weights(model_dir)
 
 
 def _check_legacy_string_patterns(model_name: str) -> bool:
@@ -1020,15 +850,15 @@ def _check_legacy_string_patterns(model_name: str) -> bool:
 def is_mllm_model(model_name: str) -> bool:
     """Check if a model name or path indicates a multimodal language model.
 
-    Four complementary validations are run, in order:
+    Metadata is authoritative whenever it is available.  The shared offline
+    probe reads a local directory or an already-cached HF snapshot; it never
+    sends a network request.  It applies two checks in order:
 
-    1. Local config.json inspection: when ``model_name`` resolves to a
-       local directory containing a readable config.json, inspect the
-       model's own metadata (``architectures`` field, ``vision_config``,
-       ``audio_config``, etc.).
+    1. Config inspection: ``architectures`` / ``vision_config`` /
+       ``audio_config`` declare whether the checkpoint is multimodal.
 
-    2. Local weights-presence override: when (1) said "VLM" but the
-       directory ships a ``model.safetensors.index.json`` with NO
+    2. Weights-presence override: when the config says "VLM" but a
+       ``model.safetensors.index.json`` has NO
        multimodal tensors (``vision_tower``, ``visual.``, ``mm_projector``,
        …), the checkpoint is a text-only fork of a multimodal
        architecture. Flip the answer to False so the model loads
@@ -1039,20 +869,10 @@ def is_mllm_model(model_name: str) -> bool:
        multimodal-capable, but the user's safetensors only contain
        language tensors).
 
-    3. Legacy substring match against ``MLLM_PATTERNS``: when no local
-       config is reachable, the historical name-based heuristic decides.
-
-    4. Cached-config override (false-positive correction): when the
-       legacy substring says "MLLM" but the repo's own config (already
-       in the local HF cache from a prior download or warmup call)
-       disagrees (e.g. ``mlx-community/gemma-3-1b-it-4bit`` matches the
-       ``gemma-3`` substring yet ships as ``Gemma3ForCausalLM`` with no
-       ``vision_config``), the cached config wins and the result flips
-       to False. The cache lookup is purely local — no network call,
-       so tests don't slow down or flake on HF outages. We deliberately
-       only override the True → False direction: the False direction is
-       preserved as-is so existing text-routed models with vision-capable
-       architectures keep their routing.
+    If metadata is unavailable or malformed, the legacy name matcher remains
+    the conservative compatibility fallback.  This allows a re-packaged VLM
+    such as Agents-A1 to select the MLLM route based on its checkpoint rather
+    than an arbitrary repository name.
 
     Args:
         model_name: HuggingFace repo ID or local filesystem path.
@@ -1060,39 +880,20 @@ def is_mllm_model(model_name: str) -> bool:
     Returns:
         True if the model is detected as multimodal (MLLM/VLM).
     """
-    config = _try_read_config_json(model_name)
+    metadata = read_model_metadata(model_name)
+    config = metadata.config if metadata is not None else None
     if config is not None:
         if not _config_indicates_vlm(config):
             return False
-        # Config says VLM. For local directories, verify the checkpoint
-        # actually carries vision/audio tensors — text-only forks of
-        # multimodal architectures (#393) ship a config that declares
-        # vision_config but no vision_tower weights, and routing them
-        # to the MLLM batched engine crashes at first request.
-        try:
-            model_dir = Path(model_name)
-        except (TypeError, ValueError):
-            return True
-        if model_dir.is_dir():
-            verdict = _local_checkpoint_has_multimodal_weights(model_dir)
-            if verdict is False:
-                return False
-            # verdict is True or None (unable to authoritatively decide);
-            # trust the config in both cases — wrong-True here means an
-            # unnecessary text-path attempt that returns a clear error,
-            # vs wrong-False which would corrupt every request silently.
+        verdict = checkpoint_has_multimodal_weights(metadata.snapshot_dir)
+        if verdict is False:
+            return False
+        # Verdict is True or None (unsharded / unavailable index).  Trust the
+        # config in both cases: wrong-True fails visibly on image use, while
+        # wrong-False would silently send a real VLM through the text lane.
         return True
 
-    legacy = _check_legacy_string_patterns(model_name)
-    if not legacy:
-        return False
-
-    # Substring says "MLLM" — verify via the repo's own config and let it
-    # override a name-based false positive (e.g. text-only Gemma 3 1B).
-    hub_config = _try_read_hub_config_json(model_name)
-    if hub_config is not None and not _config_indicates_vlm(hub_config):
-        return False
-    return True
+    return _check_legacy_string_patterns(model_name)
 
 
 # Backwards compatibility alias

--- a/vllm_mlx/model_auto_config.py
+++ b/vllm_mlx/model_auto_config.py
@@ -761,9 +761,28 @@ def _node_output_paths(node) -> list[str]:
         paths = list(_sequence_output_paths(node.body))
         paths.extend(_sequence_output_paths(node.else_) if node.else_ else [""])
         return paths or [""]
-    # Transparent wrapper blocks (``{% generation %}`` → ``CallBlock``, plus
-    # ``FilterBlock`` / ``Scope`` / ``ScopedEvalContextModifier`` / ``With`` /
-    # ``Block``): recurse into their body and pass the path structure through.
+    if isinstance(node, (nodes.Macro, nodes.AssignBlock)):
+        # A ``{% macro %}...{% endmacro %}`` definition and a capture-only
+        # ``{% set x %}...{% endset %}`` (jinja2 ``AssignBlock``) BOTH carry a
+        # ``body`` list, but NEITHER renders that body into the output stream at
+        # this site — a ``Macro`` emits nothing until it is *called*, and an
+        # ``AssignBlock`` captures its body into a variable rather than printing
+        # it (verified: ``env.from_string("{% macro m() %}X{% endmacro %}")
+        # .render() == ""`` and the same for ``{% set x %}X{% endset %}``).
+        # Recursing into their body (as the generic ``body`` fallthrough below
+        # would) falsely enables the Hermes tool parser whenever helper macros /
+        # captures contain tool XML — a common real-template shape.  So these
+        # emit an EMPTY output path at their definition site (codex #3).  The
+        # tool XML would only reach output through a genuinely reachable
+        # ``If``/``For``/``Output`` path, which the branches above still detect.
+        return [""]
+    # Transparent wrapper blocks that DO render their body into the output
+    # stream at this site: ``{% generation %}`` → ``CallBlock`` (our extension's
+    # ``_noop`` caller returns ``caller()``), ``{% filter %}`` → ``FilterBlock``,
+    # ``{% with %}`` → ``With``, ``{% block %}`` → ``Block``, plus ``Scope`` /
+    # ``OverlayScope`` / ``ScopedEvalContextModifier``.  Recurse into their body
+    # and pass the path structure through.  (``Macro`` / ``AssignBlock`` are
+    # handled above precisely because they do NOT render-through.)
     body = getattr(node, "body", None)
     if isinstance(body, list):
         return _sequence_output_paths(body)
@@ -779,6 +798,22 @@ def _sequence_output_paths(node_list) -> list[str]:
     of accumulated paths.  Growth is bounded by ``_MAX_TEMPLATE_OUTPUT_PATHS``
     to keep pathological templates cheap (the cap can only DROP a would-be
     match, never fabricate one).
+
+    The Cartesian enumeration here is intentionally STRUCTURAL — it models
+    per-node reachability (each ``If``/``For`` alternative is a real path) but
+    does NOT track branch *predicates*.  In principle two independent top-level
+    ``{% if tools %}`` / ``{% if not tools %}`` blocks could Cartesian-combine a
+    tool-call opening fragment from one with a closing fragment from the other
+    into a spuriously "reachable" contract (codex #4).  We deliberately do NOT
+    thread correlated-predicate tracking through here: no real chat template
+    splits a single tool-call wire contract across two mutually exclusive
+    top-level conditionals, and either carrying predicates or conservatively
+    rejecting cross-conditional contracts would risk FALSE NEGATIVES on genuine
+    templates that legitimately span sequential blocks.  The realistic
+    false-positive vector — tool XML in an uncalled ``{% macro %}`` or a
+    ``{% set x %}...{% endset %}`` capture — is already removed at the node
+    level in ``_node_output_paths`` (FIX A).  Predicate correlation is treated
+    as over-engineering for a template shape that does not occur in practice.
     """
     paths = [""]
     for child in node_list:

--- a/vllm_mlx/model_auto_config.py
+++ b/vllm_mlx/model_auto_config.py
@@ -659,13 +659,6 @@ def _detect_mistral_family_config(model_path: str) -> ModelConfig | None:
     return None
 
 
-_PARAMETERIZED_XML_TOOL_MARKERS = (
-    "<tool_call>",
-    "<function=",
-    "<parameter=",
-)
-
-
 def _metadata_model_types(config: dict[str, Any]) -> frozenset[str]:
     """Return top-level and text-backbone model types from a config."""
     types: set[str] = set()
@@ -678,16 +671,49 @@ def _metadata_model_types(config: dict[str, Any]) -> frozenset[str]:
     return frozenset(types)
 
 
+def _without_jinja_comments(template: str) -> str:
+    """Remove Jinja comments so documentation cannot advertise a protocol."""
+    visible: list[str] = []
+    cursor = 0
+    while True:
+        comment_start = template.find("{#", cursor)
+        if comment_start == -1:
+            visible.append(template[cursor:])
+            return "".join(visible)
+        visible.append(template[cursor:comment_start])
+        comment_end = template.find("#}", comment_start + 2)
+        if comment_end == -1:
+            return "".join(visible)
+        cursor = comment_end + 2
+
+
 def _template_uses_parameterized_xml_tools(template: str | None) -> bool:
-    """Recognise the public XML contract handled by ``HermesToolParser``."""
-    return template is not None and all(
-        marker in template for marker in _PARAMETERIZED_XML_TOOL_MARKERS
+    """Recognise one complete, nested XML tool contract for Hermes parsing."""
+    if template is None:
+        return False
+    source = _without_jinja_comments(template)
+    tool_start = source.find("<tool_call>")
+    function_start = source.find("<function=", tool_start + 1)
+    parameter_start = source.find("<parameter=", function_start + 1)
+    parameter_end = source.find("</parameter>", parameter_start + 1)
+    function_end = source.find("</function>", parameter_end + 1)
+    tool_end = source.find("</tool_call>", function_end + 1)
+    return (
+        "tools" in source
+        and tool_start != -1
+        and function_start != -1
+        and parameter_start != -1
+        and parameter_end != -1
+        and function_end != -1
+        and tool_end != -1
     )
 
 
 def _template_injects_qwen_thinking(template: str | None) -> bool:
     """Recognise Qwen's ``enable_thinking`` / ``<think>`` template contract."""
-    return template is not None and "enable_thinking" in template and "<think>" in template
+    return (
+        template is not None and "enable_thinking" in template and "<think>" in template
+    )
 
 
 def _detect_metadata_config(model_path: str) -> ModelConfig | None:
@@ -731,10 +757,9 @@ def _detect_metadata_config(model_path: str) -> ModelConfig | None:
     if _template_uses_parameterized_xml_tools(metadata.chat_template):
         settings["tool_call_parser"] = "hermes"
         reasons.append("parameterized XML tool template")
-        if (
-            any(model_type.startswith("qwen3") for model_type in model_types)
-            and _template_injects_qwen_thinking(metadata.chat_template)
-        ):
+        if any(
+            model_type.startswith("qwen3") for model_type in model_types
+        ) and _template_injects_qwen_thinking(metadata.chat_template):
             settings["reasoning_parser"] = "qwen3"
             reasons.append("Qwen thinking template")
 

--- a/vllm_mlx/model_auto_config.py
+++ b/vllm_mlx/model_auto_config.py
@@ -717,6 +717,110 @@ def _chat_template_environment():
     )
 
 
+# Cap on the number of distinct output paths enumerated per template.  Real
+# chat templates emit a tool contract inside a single ``if``/``for`` block, so
+# a small handful of paths cover every legitimate case.  If a pathological
+# template exceeds this, path enumeration stops growing: the effect is a
+# conservative "no native-tool contract detected" (safe text fallback), never a
+# fabricated cross-branch match.
+_MAX_TEMPLATE_OUTPUT_PATHS = 256
+
+
+def _node_output_paths(node) -> list[str]:
+    """Return the possible literal-output strings a single AST node can emit.
+
+    Each returned string is the concatenation of literals along ONE reachable
+    control-flow path through ``node``.  Mutually exclusive ``{% if %}`` /
+    ``{% elif %}`` / ``{% else %}`` branches become SEPARATE alternatives — the
+    opening fragment from one branch is never concatenated with the closing
+    fragment of a sibling branch.
+    """
+    from jinja2 import nodes
+
+    if isinstance(node, nodes.TemplateData):
+        return [node.data]
+    if isinstance(node, nodes.Output):
+        # ``Output.nodes`` interleaves literal ``TemplateData`` with printed
+        # expressions ``{{ ... }}``; only the literals are known statically.
+        return _sequence_output_paths(node.nodes)
+    if isinstance(node, nodes.If):
+        alternatives: list[str] = []
+        alternatives.extend(_sequence_output_paths(node.body))
+        # ``elif`` chains parse as nested ``If`` nodes hanging off ``elif_``.
+        for elif_node in node.elif_:
+            alternatives.extend(_node_output_paths(elif_node))
+        if node.else_:
+            alternatives.extend(_sequence_output_paths(node.else_))
+        else:
+            # No ``else`` → the "condition false, emit nothing" path is real.
+            alternatives.append("")
+        return alternatives or [""]
+    if isinstance(node, nodes.For):
+        # A loop body may execute (emit its contract) or the loop may be empty
+        # (emit only the ``else`` block, if any).  Both are reachable paths.
+        paths = list(_sequence_output_paths(node.body))
+        paths.extend(_sequence_output_paths(node.else_) if node.else_ else [""])
+        return paths or [""]
+    # Transparent wrapper blocks (``{% generation %}`` → ``CallBlock``, plus
+    # ``FilterBlock`` / ``Scope`` / ``ScopedEvalContextModifier`` / ``With`` /
+    # ``Block``): recurse into their body and pass the path structure through.
+    body = getattr(node, "body", None)
+    if isinstance(body, list):
+        return _sequence_output_paths(body)
+    # Statements with no literal output (Assign, Break, Continue, bare
+    # expressions, …) contribute the empty string on every path.
+    return [""]
+
+
+def _sequence_output_paths(node_list) -> list[str]:
+    """Cartesian concatenation of the per-node path sets for a node sequence.
+
+    Sequential nodes are concatenated; a branching node multiplies the number
+    of accumulated paths.  Growth is bounded by ``_MAX_TEMPLATE_OUTPUT_PATHS``
+    to keep pathological templates cheap (the cap can only DROP a would-be
+    match, never fabricate one).
+    """
+    paths = [""]
+    for child in node_list:
+        child_paths = _node_output_paths(child)
+        if not child_paths:
+            continue
+        combined: list[str] = []
+        for prefix in paths:
+            for suffix in child_paths:
+                combined.append(prefix + suffix)
+                if len(combined) >= _MAX_TEMPLATE_OUTPUT_PATHS:
+                    break
+            if len(combined) >= _MAX_TEMPLATE_OUTPUT_PATHS:
+                break
+        paths = combined
+    return paths
+
+
+def _template_output_paths(
+    template: str | None,
+) -> tuple[list[str], frozenset[str]] | None:
+    """Return per-reachable-path literal outputs and declared variables.
+
+    Unlike :func:`_template_output_contract` (which flattens every
+    ``TemplateData`` node across the whole AST), this walks the parsed AST and
+    keeps each ``{% if %}``/``{% else %}`` branch as a separate output path, so
+    a contract that only appears when fragments from mutually exclusive
+    branches are concatenated is NOT reported as present on any single path.
+    """
+    if template is None:
+        return None
+    try:
+        from jinja2 import meta
+
+        parsed = _chat_template_environment().parse(template)
+        paths = _sequence_output_paths(parsed.body)
+        variables = frozenset(meta.find_undeclared_variables(parsed))
+    except Exception:
+        return None
+    return paths, variables
+
+
 def _template_output_contract(
     template: str | None,
 ) -> tuple[str, frozenset[str]] | None:
@@ -724,7 +828,10 @@ def _template_output_contract(
 
     Uses a Transformers-compatible parsing environment so valid chat templates
     (``{% generation %}``, ``{% break %}``/``{% continue %}``) do not silently
-    disable inference by raising ``TemplateSyntaxError``.
+    disable inference by raising ``TemplateSyntaxError``.  The returned text is
+    the flattened concatenation of ALL literals (used for single-token presence
+    checks such as ``<think>``); branch-sensitive contract detection uses
+    :func:`_template_output_paths` instead.
     """
     if template is None:
         return None
@@ -739,12 +846,13 @@ def _template_output_contract(
     return output, variables
 
 
-def _template_uses_parameterized_xml_tools(template: str | None) -> bool:
-    """Recognise one complete, nested XML tool contract for Hermes parsing."""
-    contract = _template_output_contract(template)
-    if contract is None:
-        return False
-    source, variables = contract
+def _path_has_nested_xml_tool_contract(source: str) -> bool:
+    """Return whether ONE output path contains the full nested XML tool contract.
+
+    The tags must appear in the exact opening→closing nesting order
+    ``<tool_call>`` → ``<function=`` → ``<parameter=`` → ``</parameter>`` →
+    ``</function>`` → ``</tool_call>`` within this single reachable path.
+    """
     tool_start = source.find("<tool_call>")
     function_start = source.find("<function=", tool_start + 1)
     parameter_start = source.find("<parameter=", function_start + 1)
@@ -752,13 +860,30 @@ def _template_uses_parameterized_xml_tools(template: str | None) -> bool:
     function_end = source.find("</function>", parameter_end + 1)
     tool_end = source.find("</tool_call>", function_end + 1)
     return (
-        "tools" in variables
-        and tool_start != -1
+        tool_start != -1
         and function_start != -1
         and parameter_start != -1
         and parameter_end != -1
         and function_end != -1
         and tool_end != -1
+    )
+
+
+def _template_uses_parameterized_xml_tools(template: str | None) -> bool:
+    """Recognise one complete, nested XML tool contract for Hermes parsing.
+
+    The complete nested contract must appear on ONE reachable output path.  A
+    template that splits the contract across mutually exclusive
+    ``{% if %}``/``{% else %}`` branches (so no single path emits the whole
+    thing) is rejected — flattening the whole AST would fabricate a match that
+    the model never actually renders.
+    """
+    result = _template_output_paths(template)
+    if result is None:
+        return False
+    paths, variables = result
+    return "tools" in variables and any(
+        _path_has_nested_xml_tool_contract(path) for path in paths
     )
 
 

--- a/vllm_mlx/model_auto_config.py
+++ b/vllm_mlx/model_auto_config.py
@@ -711,9 +711,10 @@ def _template_uses_parameterized_xml_tools(template: str | None) -> bool:
 
 def _template_injects_qwen_thinking(template: str | None) -> bool:
     """Recognise Qwen's ``enable_thinking`` / ``<think>`` template contract."""
-    return (
-        template is not None and "enable_thinking" in template and "<think>" in template
-    )
+    if template is None:
+        return False
+    source = _without_jinja_comments(template)
+    return "enable_thinking" in source and "<think>" in source
 
 
 def _detect_metadata_config(model_path: str) -> ModelConfig | None:

--- a/vllm_mlx/model_auto_config.py
+++ b/vllm_mlx/model_auto_config.py
@@ -687,11 +687,29 @@ def _without_jinja_comments(template: str) -> str:
         cursor = comment_end + 2
 
 
+def _template_output_contract(
+    template: str | None,
+) -> tuple[str, frozenset[str]] | None:
+    """Return literal output text and declared variables from a Jinja template."""
+    if template is None:
+        return None
+    try:
+        from jinja2 import Environment, meta, nodes
+
+        parsed = Environment().parse(template)
+        output = "".join(node.data for node in parsed.find_all(nodes.TemplateData))
+        variables = frozenset(meta.find_undeclared_variables(parsed))
+    except Exception:
+        return None
+    return output, variables
+
+
 def _template_uses_parameterized_xml_tools(template: str | None) -> bool:
     """Recognise one complete, nested XML tool contract for Hermes parsing."""
-    if template is None:
+    contract = _template_output_contract(template)
+    if contract is None:
         return False
-    source = _without_jinja_comments(template)
+    source, variables = contract
     tool_start = source.find("<tool_call>")
     function_start = source.find("<function=", tool_start + 1)
     parameter_start = source.find("<parameter=", function_start + 1)
@@ -699,7 +717,7 @@ def _template_uses_parameterized_xml_tools(template: str | None) -> bool:
     function_end = source.find("</function>", parameter_end + 1)
     tool_end = source.find("</tool_call>", function_end + 1)
     return (
-        "tools" in source
+        "tools" in variables
         and tool_start != -1
         and function_start != -1
         and parameter_start != -1
@@ -711,10 +729,11 @@ def _template_uses_parameterized_xml_tools(template: str | None) -> bool:
 
 def _template_injects_qwen_thinking(template: str | None) -> bool:
     """Recognise Qwen's ``enable_thinking`` / ``<think>`` template contract."""
-    if template is None:
+    contract = _template_output_contract(template)
+    if contract is None:
         return False
-    source = _without_jinja_comments(template)
-    return "enable_thinking" in source and "<think>" in source
+    source, variables = contract
+    return "enable_thinking" in variables and "<think>" in source
 
 
 def _detect_metadata_config(model_path: str) -> ModelConfig | None:

--- a/vllm_mlx/model_auto_config.py
+++ b/vllm_mlx/model_auto_config.py
@@ -5,12 +5,12 @@ parser, throttle, or optimization flag explicitly, this module infers
 the best configuration from the model name/path pattern, with optional
 runtime enrichment from the loaded model object.
 
-Two stages:
+Three stages:
 
-1. ``detect_model_config(model_path)`` — declarative, name-regex based.
-   Runs *before* model load. Returns ``ModelConfig`` with parser
-   defaults and capability gates (e.g. whether spec decoding is safe
-   for this arch).
+1. ``detect_model_config(model_path)`` — resolves an explicit alias, then
+   known model families, then an offline checkpoint-metadata fallback.  It
+   returns ``ModelConfig`` with parser defaults and capability gates (e.g.
+   whether spec decoding is safe for this arch).
 
 2. ``enrich_model_config(cfg, model)`` — runtime probe of the loaded
    model. Used as a safety net for unrecognized hybrid models — if the
@@ -28,6 +28,7 @@ from dataclasses import replace
 from typing import Any
 
 from .model_aliases import resolve_profile
+from .model_metadata import read_model_metadata
 from .model_profile import ModelProfile
 
 logger = logging.getLogger(__name__)
@@ -658,6 +659,98 @@ def _detect_mistral_family_config(model_path: str) -> ModelConfig | None:
     return None
 
 
+_PARAMETERIZED_XML_TOOL_MARKERS = (
+    "<tool_call>",
+    "<function=",
+    "<parameter=",
+)
+
+
+def _metadata_model_types(config: dict[str, Any]) -> frozenset[str]:
+    """Return top-level and text-backbone model types from a config."""
+    types: set[str] = set()
+    for candidate in (config, config.get("text_config")):
+        if not isinstance(candidate, dict):
+            continue
+        model_type = candidate.get("model_type")
+        if isinstance(model_type, str):
+            types.add(model_type.lower())
+    return frozenset(types)
+
+
+def _template_uses_parameterized_xml_tools(template: str | None) -> bool:
+    """Recognise the public XML contract handled by ``HermesToolParser``."""
+    return template is not None and all(
+        marker in template for marker in _PARAMETERIZED_XML_TOOL_MARKERS
+    )
+
+
+def _template_injects_qwen_thinking(template: str | None) -> bool:
+    """Recognise Qwen's ``enable_thinking`` / ``<think>`` template contract."""
+    return template is not None and "enable_thinking" in template and "<think>" in template
+
+
+def _detect_metadata_config(model_path: str) -> ModelConfig | None:
+    """Infer a safe fallback profile from an already-downloaded checkpoint.
+
+    This is deliberately lower priority than an alias or a dedicated family
+    parser: those encode implementation-specific behavior that a generic
+    template cannot know.  For an otherwise unknown repackage, however, its
+    own template is the authoritative tool wire contract.  The probe is
+    offline-only, so detecting a profile never adds a Hub request to startup.
+    """
+    metadata = read_model_metadata(model_path)
+    if metadata is None:
+        return None
+
+    config = metadata.config or {}
+    model_types = _metadata_model_types(config)
+    settings: dict[str, Any] = {}
+    reasons: list[str] = []
+
+    if "qwen3_5_moe" in model_types:
+        settings.update(
+            is_hybrid=True,
+            is_hybrid_explicit=True,
+            is_moe=True,
+            supports_spec_decode=False,
+        )
+        reasons.append("Qwen3.5 MoE architecture")
+    elif "qwen3_5" in model_types:
+        # Dense Qwen3.5 caches contain linear-attention layers, but their
+        # hybrid scheduler path is known to wedge on Metal.  Pinning this
+        # from config matches the existing dense-Qwen aliases and prevents
+        # the runtime cache probe from silently promoting it back to hybrid.
+        settings.update(
+            is_hybrid=False,
+            is_hybrid_explicit=True,
+            supports_spec_decode=False,
+        )
+        reasons.append("dense Qwen3.5 architecture")
+
+    if _template_uses_parameterized_xml_tools(metadata.chat_template):
+        settings["tool_call_parser"] = "hermes"
+        reasons.append("parameterized XML tool template")
+        if (
+            any(model_type.startswith("qwen3") for model_type in model_types)
+            and _template_injects_qwen_thinking(metadata.chat_template)
+        ):
+            settings["reasoning_parser"] = "qwen3"
+            reasons.append("Qwen thinking template")
+
+    if not settings:
+        return None
+    profile = ModelConfig(**settings)
+    _log_resolution_once(
+        model_path,
+        "Auto-detected checkpoint metadata for "
+        f"'{model_path}' → tool_call_parser={profile.tool_call_parser}, "
+        f"reasoning_parser={profile.reasoning_parser}, "
+        f"is_hybrid={profile.is_hybrid} ({', '.join(reasons)})",
+    )
+    return profile
+
+
 def detect_model_config(model_path: str) -> ModelConfig | None:
     """Detect optimal parser config from model name/path.
 
@@ -667,9 +760,12 @@ def detect_model_config(model_path: str) -> ModelConfig | None:
        (``mlx-community/Qwen3.5-4B-MLX-4bit``), return that profile's
        config directly. This guarantees per-alias granularity for any
        optimization that varies by size/quant within a family.
-    2. **Regex fallback** (``_MODEL_PATTERNS``) — for non-aliased HF
+    2. **Known-family fallback** (``_MODEL_PATTERNS``) — for non-aliased HF
        paths the user serves directly. Coarser-grained: one pattern
        covers a whole family.
+    3. **Checkpoint metadata fallback** — for an otherwise unknown local
+       directory or already-cached HF path, infer only documented template
+       contracts and architecture safety gates.  The probe is offline-only.
 
     Args:
         model_path: Model name or path (e.g. "mlx-community/Qwen3.5-9B-4bit")
@@ -779,7 +875,7 @@ def detect_model_config(model_path: str) -> ModelConfig | None:
             f"supports_spec_decode={config.supports_spec_decode}",
         )
         return config
-    return None
+    return _detect_metadata_config(model_path)
 
 
 # DeepSeek V3-template wire-shape parsers, by the sub-family each one

--- a/vllm_mlx/model_auto_config.py
+++ b/vllm_mlx/model_auto_config.py
@@ -725,8 +725,94 @@ def _chat_template_environment():
 # fabricated cross-branch match.
 _MAX_TEMPLATE_OUTPUT_PATHS = 256
 
+# Cumulative byte budget for path enumeration (codex #5).  The path-COUNT cap
+# above bounds the number of alternatives but NOT the total work: a large
+# template could retain up to ``_MAX_TEMPLATE_OUTPUT_PATHS`` paths each many KiB
+# long, so the concatenated material is O(paths × template_size).  Once the
+# summed length of all accumulated paths crosses this budget, enumeration
+# aborts and fails SAFE (an empty path set → "no native-tool contract
+# detected" → text fallback).  8 MiB is far above any real chat template
+# (largest observed ≈ tens of KiB) yet caps a pathological input's work.  This
+# is defensive against trusted load-time input only.
+_MAX_TEMPLATE_OUTPUT_BYTES = 8 * 1024 * 1024
 
-def _node_output_paths(node) -> list[str]:
+# Bound on macro-call resolution (FIX #3).  Reachable ``{{ macro() }}`` calls to
+# locally-defined macros are expanded so tool XML defined in a macro body and
+# CALLED on a render path is still detected — but recursion is capped to avoid
+# blowups from deep or (mutually) recursive macro chains.
+_MAX_MACRO_RESOLUTION_DEPTH = 8
+
+
+class _MacroCtx:
+    """Resolution context threaded through path analysis (FIX #3).
+
+    ``macros`` maps a locally-defined macro name to its body node list.
+    ``active`` is the set of macro names currently being expanded on this call
+    stack (cycle guard).  ``depth`` bounds total expansion nesting.  A default
+    (empty-``macros``) context makes macro resolution a no-op, so callers that
+    do not pre-collect macros keep the pre-FIX-#3 behaviour.
+    """
+
+    __slots__ = ("macros", "active", "depth")
+
+    def __init__(self, macros=None, active=None, depth=0):
+        self.macros = macros or {}
+        self.active = active or frozenset()
+        self.depth = depth
+
+
+_EMPTY_MACRO_CTX = _MacroCtx()
+
+
+def _collect_macro_bodies(node) -> dict:
+    """Map every locally-defined ``{% macro name %}`` to its body node list.
+
+    Walks the WHOLE parsed AST (macros may be defined anywhere, including inside
+    blocks) via ``find_all`` so a call reachable on a render path can be
+    resolved regardless of where the macro was declared.
+    """
+    from jinja2 import nodes
+
+    macros: dict = {}
+    for macro in node.find_all(nodes.Macro):
+        # Last definition wins, mirroring jinja2's runtime rebinding semantics.
+        macros[macro.name] = macro.body
+    return macros
+
+
+def _resolve_macro_call(node, ctx: "_MacroCtx"):
+    """If ``node`` is a bare call to a locally-defined macro, return its body's
+    output paths (bounded); otherwise return ``None``.
+
+    Recognises the reachable-call shape ``{{ emit(...) }}`` → jinja2 ``Call``
+    whose ``.node`` is a ``Name`` (``ctx='load'``) bound to a collected macro.
+    Attribute/dynamic callees (``{{ x.emit() }}``) are intentionally NOT
+    resolved — they are not locally-defined macros in the template namespace.
+    """
+    from jinja2 import nodes
+
+    if not isinstance(node, nodes.Call):
+        return None
+    callee = node.node
+    if not isinstance(callee, nodes.Name):
+        return None
+    name = callee.name
+    body = ctx.macros.get(name)
+    if body is None:
+        return None
+    # Cycle / depth guard: a macro that (transitively) calls itself, or a chain
+    # deeper than the cap, contributes an empty path rather than looping.
+    if name in ctx.active or ctx.depth >= _MAX_MACRO_RESOLUTION_DEPTH:
+        return [""]
+    child_ctx = _MacroCtx(
+        macros=ctx.macros,
+        active=ctx.active | {name},
+        depth=ctx.depth + 1,
+    )
+    return _sequence_output_paths(body, child_ctx)
+
+
+def _node_output_paths(node, ctx: "_MacroCtx" = _EMPTY_MACRO_CTX) -> list[str]:
     """Return the possible literal-output strings a single AST node can emit.
 
     Each returned string is the concatenation of literals along ONE reachable
@@ -734,6 +820,9 @@ def _node_output_paths(node) -> list[str]:
     ``{% elif %}`` / ``{% else %}`` branches become SEPARATE alternatives — the
     opening fragment from one branch is never concatenated with the closing
     fragment of a sibling branch.
+
+    ``ctx`` carries the macro-resolution state (FIX #3); the default empty
+    context makes macro-call resolution a no-op.
     """
     from jinja2 import nodes
 
@@ -742,15 +831,23 @@ def _node_output_paths(node) -> list[str]:
     if isinstance(node, nodes.Output):
         # ``Output.nodes`` interleaves literal ``TemplateData`` with printed
         # expressions ``{{ ... }}``; only the literals are known statically.
-        return _sequence_output_paths(node.nodes)
+        return _sequence_output_paths(node.nodes, ctx)
+    # A reachable ``{{ macro() }}`` call to a locally-defined macro renders that
+    # macro's body INTO the output stream at this site (FIX #3).  Resolve it to
+    # the macro body's output paths so tool XML defined in a called macro is
+    # still detected.  (Uncalled macro DEFINITIONS remain empty — see the
+    # ``Macro`` branch below.)
+    resolved = _resolve_macro_call(node, ctx)
+    if resolved is not None:
+        return resolved
     if isinstance(node, nodes.If):
         alternatives: list[str] = []
-        alternatives.extend(_sequence_output_paths(node.body))
+        alternatives.extend(_sequence_output_paths(node.body, ctx))
         # ``elif`` chains parse as nested ``If`` nodes hanging off ``elif_``.
         for elif_node in node.elif_:
-            alternatives.extend(_node_output_paths(elif_node))
+            alternatives.extend(_node_output_paths(elif_node, ctx))
         if node.else_:
-            alternatives.extend(_sequence_output_paths(node.else_))
+            alternatives.extend(_sequence_output_paths(node.else_, ctx))
         else:
             # No ``else`` → the "condition false, emit nothing" path is real.
             alternatives.append("")
@@ -758,8 +855,8 @@ def _node_output_paths(node) -> list[str]:
     if isinstance(node, nodes.For):
         # A loop body may execute (emit its contract) or the loop may be empty
         # (emit only the ``else`` block, if any).  Both are reachable paths.
-        paths = list(_sequence_output_paths(node.body))
-        paths.extend(_sequence_output_paths(node.else_) if node.else_ else [""])
+        paths = list(_sequence_output_paths(node.body, ctx))
+        paths.extend(_sequence_output_paths(node.else_, ctx) if node.else_ else [""])
         return paths or [""]
     if isinstance(node, (nodes.Macro, nodes.AssignBlock)):
         # A ``{% macro %}...{% endmacro %}`` definition and a capture-only
@@ -772,9 +869,10 @@ def _node_output_paths(node) -> list[str]:
         # Recursing into their body (as the generic ``body`` fallthrough below
         # would) falsely enables the Hermes tool parser whenever helper macros /
         # captures contain tool XML — a common real-template shape.  So these
-        # emit an EMPTY output path at their definition site (codex #3).  The
-        # tool XML would only reach output through a genuinely reachable
-        # ``If``/``For``/``Output`` path, which the branches above still detect.
+        # emit an EMPTY output path at their definition site (codex #3).  A
+        # macro's body IS accounted for when the macro is CALLED on a render
+        # path (``_resolve_macro_call`` above, FIX #3); the exclusion here only
+        # suppresses the UNCALLED definition site.
         return [""]
     # Transparent wrapper blocks that DO render their body into the output
     # stream at this site: ``{% generation %}`` → ``CallBlock`` (our extension's
@@ -785,19 +883,20 @@ def _node_output_paths(node) -> list[str]:
     # handled above precisely because they do NOT render-through.)
     body = getattr(node, "body", None)
     if isinstance(body, list):
-        return _sequence_output_paths(body)
+        return _sequence_output_paths(body, ctx)
     # Statements with no literal output (Assign, Break, Continue, bare
     # expressions, …) contribute the empty string on every path.
     return [""]
 
 
-def _sequence_output_paths(node_list) -> list[str]:
+def _sequence_output_paths(node_list, ctx: "_MacroCtx" = _EMPTY_MACRO_CTX) -> list[str]:
     """Cartesian concatenation of the per-node path sets for a node sequence.
 
     Sequential nodes are concatenated; a branching node multiplies the number
     of accumulated paths.  Growth is bounded by ``_MAX_TEMPLATE_OUTPUT_PATHS``
-    to keep pathological templates cheap (the cap can only DROP a would-be
-    match, never fabricate one).
+    (path count) AND ``_MAX_TEMPLATE_OUTPUT_BYTES`` (cumulative length, codex
+    #5) to keep pathological templates cheap; either cap can only DROP a
+    would-be match, never fabricate one.
 
     The Cartesian enumeration here is intentionally STRUCTURAL — it models
     per-node reachability (each ``If``/``For`` alternative is a real path) but
@@ -817,18 +916,29 @@ def _sequence_output_paths(node_list) -> list[str]:
     """
     paths = [""]
     for child in node_list:
-        child_paths = _node_output_paths(child)
+        child_paths = _node_output_paths(child, ctx)
         if not child_paths:
             continue
         combined: list[str] = []
+        total_bytes = 0
+        capped = False
         for prefix in paths:
             for suffix in child_paths:
-                combined.append(prefix + suffix)
-                if len(combined) >= _MAX_TEMPLATE_OUTPUT_PATHS:
+                combined_path = prefix + suffix
+                combined.append(combined_path)
+                total_bytes += len(combined_path)
+                # codex #5: abort on cumulative byte budget as well as count.
+                if (
+                    len(combined) >= _MAX_TEMPLATE_OUTPUT_PATHS
+                    or total_bytes >= _MAX_TEMPLATE_OUTPUT_BYTES
+                ):
+                    capped = True
                     break
-            if len(combined) >= _MAX_TEMPLATE_OUTPUT_PATHS:
+            if capped:
                 break
         paths = combined
+        if capped:
+            break
     return paths
 
 
@@ -849,7 +959,10 @@ def _template_output_paths(
         from jinja2 import meta
 
         parsed = _chat_template_environment().parse(template)
-        paths = _sequence_output_paths(parsed.body)
+        # Pre-collect locally-defined macros so reachable ``{{ macro() }}`` calls
+        # can be resolved to their bodies during path analysis (FIX #3).
+        ctx = _MacroCtx(macros=_collect_macro_bodies(parsed))
+        paths = _sequence_output_paths(parsed.body, ctx)
         variables = frozenset(meta.find_undeclared_variables(parsed))
     except Exception:
         return None

--- a/vllm_mlx/model_auto_config.py
+++ b/vllm_mlx/model_auto_config.py
@@ -671,32 +671,67 @@ def _metadata_model_types(config: dict[str, Any]) -> frozenset[str]:
     return frozenset(types)
 
 
-def _without_jinja_comments(template: str) -> str:
-    """Remove Jinja comments so documentation cannot advertise a protocol."""
-    visible: list[str] = []
-    cursor = 0
-    while True:
-        comment_start = template.find("{#", cursor)
-        if comment_start == -1:
-            visible.append(template[cursor:])
-            return "".join(visible)
-        visible.append(template[cursor:comment_start])
-        comment_end = template.find("#}", comment_start + 2)
-        if comment_end == -1:
-            return "".join(visible)
-        cursor = comment_end + 2
+def _chat_template_environment():
+    """Build a Jinja environment that PARSES Transformers chat templates.
+
+    Transformers compiles chat templates with a specific environment (see
+    ``transformers.utils.chat_template_utils._cached_compile_jinja_template``):
+    an ``ImmutableSandboxedEnvironment`` with ``trim_blocks``/``lstrip_blocks``
+    and ``extensions=[AssistantTracker, jinja2.ext.loopcontrols]``. Valid
+    templates therefore use constructs a bare ``jinja2.Environment`` rejects at
+    parse time — the ``{% generation %}...{% endgeneration %}`` block (a custom
+    ``generation`` tag registered by ``AssistantTracker``) and loop-control
+    statements (``{% break %}`` / ``{% continue %}``). We only ever ``.parse()``
+    the template (to extract ``TemplateData`` literals and undeclared
+    variables); we never render it. So we mirror the SAME extension set that
+    makes those constructs parse, but need not replicate the sandbox or the
+    runtime rendering hooks.
+
+    The ``_GenerationExtension`` below ports the parse behaviour of
+    Transformers' ``AssistantTracker`` (``tags = {"generation"}``; consumes the
+    block up to ``endgeneration``) so ``{% generation %}`` parses identically.
+    """
+    import jinja2
+    import jinja2.ext
+
+    class _GenerationExtension(jinja2.ext.Extension):
+        # Mirror transformers.utils.chat_template_utils.AssistantTracker: the
+        # ``generation`` tag brackets assistant-generated spans. We only need
+        # its PARSE behaviour (consume the body up to ``endgeneration``) so a
+        # template that uses it does not raise TemplateSyntaxError; the tracked
+        # output is a rendering concern we never reach.
+        tags = {"generation"}
+
+        def parse(self, parser):
+            lineno = next(parser.stream).lineno
+            body = parser.parse_statements(["name:endgeneration"], drop_needle=True)
+            return jinja2.nodes.CallBlock(
+                self.call_method("_noop"), [], [], body
+            ).set_lineno(lineno)
+
+        def _noop(self, caller):  # pragma: no cover - never rendered
+            return caller()
+
+    return jinja2.Environment(
+        extensions=[_GenerationExtension, jinja2.ext.loopcontrols]
+    )
 
 
 def _template_output_contract(
     template: str | None,
 ) -> tuple[str, frozenset[str]] | None:
-    """Return literal output text and declared variables from a Jinja template."""
+    """Return literal output text and declared variables from a Jinja template.
+
+    Uses a Transformers-compatible parsing environment so valid chat templates
+    (``{% generation %}``, ``{% break %}``/``{% continue %}``) do not silently
+    disable inference by raising ``TemplateSyntaxError``.
+    """
     if template is None:
         return None
     try:
-        from jinja2 import Environment, meta, nodes
+        from jinja2 import meta, nodes
 
-        parsed = Environment().parse(template)
+        parsed = _chat_template_environment().parse(template)
         output = "".join(node.data for node in parsed.find_all(nodes.TemplateData))
         variables = frozenset(meta.find_undeclared_variables(parsed))
     except Exception:

--- a/vllm_mlx/model_metadata.py
+++ b/vllm_mlx/model_metadata.py
@@ -18,6 +18,10 @@ from typing import Any
 # anyway: a corrupt cache entry must not turn startup classification into an
 # unbounded allocation.
 MAX_METADATA_FILE_BYTES = 1 * 1024 * 1024
+# Checkpoint indexes enumerate every tensor in large sharded models, so they
+# legitimately exceed the config/template cap.  Keep their own bounded budget
+# rather than silently discarding modality evidence for production checkpoints.
+MAX_WEIGHT_INDEX_BYTES = 64 * 1024 * 1024
 
 
 @dataclass(frozen=True)
@@ -30,12 +34,14 @@ class ModelMetadata:
     is_local: bool = False
 
 
-def _read_json(path: Path | None) -> dict[str, Any] | None:
+def _read_json(
+    path: Path | None, *, max_bytes: int = MAX_METADATA_FILE_BYTES
+) -> dict[str, Any] | None:
     """Read one bounded JSON object, returning ``None`` on cache failures."""
     if path is None or not path.is_file():
         return None
     try:
-        if path.stat().st_size > MAX_METADATA_FILE_BYTES:
+        if path.stat().st_size > max_bytes:
             return None
         with path.open(encoding="utf-8") as f:
             value = json.load(f)
@@ -196,6 +202,8 @@ MULTIMODAL_TENSOR_PREFIXES = (
     "mm_projector",
     "patch_embed.",
 )
+_QWEN3_5_MOE_ARCHITECTURE = "qwen3_5moeforconditionalgeneration"
+_QWEN3_5_MOE_TEXT_TENSOR_PREFIX = "language_model."
 
 
 def config_indicates_multimodal(config: dict[str, Any]) -> bool:
@@ -217,6 +225,21 @@ def _contains_multimodal_weight_names(weight_names) -> bool:
         isinstance(name, str)
         and any(prefix in name for prefix in MULTIMODAL_TENSOR_PREFIXES)
         for name in weight_names
+    )
+
+
+def _known_text_only_weight_layout(weight_names, config: dict[str, Any] | None) -> bool:
+    """Recognise only an exhaustive architecture-specific text-only layout."""
+    architectures = config.get("architectures") if config else None
+    if not isinstance(architectures, list) or not any(
+        isinstance(architecture, str)
+        and architecture.lower() == _QWEN3_5_MOE_ARCHITECTURE
+        for architecture in architectures
+    ):
+        return False
+    names = tuple(name for name in weight_names if isinstance(name, str))
+    return bool(names) and all(
+        name.startswith(_QWEN3_5_MOE_TEXT_TENSOR_PREFIX) for name in names
     )
 
 
@@ -252,14 +275,26 @@ def _single_safetensors_has_multimodal_weights(snapshot_dir: Path) -> bool | Non
     return True if _contains_multimodal_weight_names(parsed) else None
 
 
-def checkpoint_has_multimodal_weights(snapshot_dir: Path | None) -> bool | None:
-    """Inspect a checkpoint index or single safetensors header for modality weights."""
+def checkpoint_has_multimodal_weights(
+    snapshot_dir: Path | None, config: dict[str, Any] | None = None
+) -> bool | None:
+    """Return positive modality proof or a schema-backed text-only verdict.
+
+    Unrecognised tensor namespaces are deliberately inconclusive.  A generic
+    prefix list cannot prove a checkpoint has no vision encoder; only a known
+    architecture's complete language-only layout may return ``False``.
+    """
     if snapshot_dir is None:
         return None
-    index = _read_json(snapshot_dir / "model.safetensors.index.json")
+    index = _read_json(
+        snapshot_dir / "model.safetensors.index.json",
+        max_bytes=MAX_WEIGHT_INDEX_BYTES,
+    )
     if index is None:
         return _single_safetensors_has_multimodal_weights(snapshot_dir)
     weights = index.get("weight_map")
     if not isinstance(weights, dict):
         return None
-    return _contains_multimodal_weight_names(weights)
+    if _contains_multimodal_weight_names(weights):
+        return True
+    return False if _known_text_only_weight_layout(weights, config) else None

--- a/vllm_mlx/model_metadata.py
+++ b/vllm_mlx/model_metadata.py
@@ -245,14 +245,49 @@ VLM_ARCHITECTURE_KEYWORDS = (
     "Gemma3ForConditional",
     "Gemma4ForConditional",
 )
+# Tensor-name substrings that indicate ACTUAL vision/audio weights ship in the
+# checkpoint.  This list is LOAD-BEARING: ``checkpoint_has_multimodal_weights``
+# now returns a text-only verdict (``False``) — architecture-agnostic — for any
+# weight index that contains NONE of these substrings, so the list must
+# comprehensively catch real modality tensors across every supported VLM family
+# or a genuine VLM whose vision tensors are not listed here would be misrouted
+# to the text engine (re-opening #1121).  Every entry below was DERIVED from the
+# top-level tensor namespaces of real cached VLM checkpoints (not invented):
+#
+#   vision_tower              gemma-3/4, Qwen2.5/3-VL, Bonsai-27B, most VLMs
+#   vision_model              InternVL3, SmolVLM2
+#   vision_embedder           gemma-4-12B (SigLIP-style patch embedder)
+#   embed_vision              gemma-4 family + DiffusionGemma (vision embedder)
+#   embed_audio               gemma-4-12B (audio modality)
+#   multi_modal_projector     gemma-3 (image->text projector) — was MISSING pre-fix
+#   connector.                SmolVLM2 (vision->text connector)
+#   visual.                   raw-HF Qwen-VL naming (mlx-vlm renames it to
+#                             vision_tower, but the HF checkpoint index keeps it)
+#   mm_projector / patch_embed. / vision_encoder / audio_tower / audio_model /
+#   audio_encoder / image_newline / resampler   other real VLM families
+#
+# Matching is SUBSTRING (``prefix in name``), so a nested occurrence anywhere in
+# the tensor path counts.  ``embed_vision`` / ``embed_audio`` are unambiguous —
+# the text token embedding is ``embed_tokens``, never ``embed_vision``, so these
+# never false-positive on a text-only checkpoint (verified against the local HF
+# cache: zero pure-text checkpoints match any entry).
 MULTIMODAL_TENSOR_PREFIXES = (
     "vision_tower",
     "vision_model",
+    "vision_embedder",
+    "vision_encoder",
     "visual.",
+    "embed_vision",
     "audio_tower",
     "audio_model",
+    "audio_encoder",
+    "embed_audio",
+    "multi_modal_projector",
     "mm_projector",
     "patch_embed.",
+    "image_newline",
+    "resampler",
+    "connector.",
 )
 _QWEN3_5_MOE_ARCHITECTURE = "qwen3_5moeforconditionalgeneration"
 # Precise allowlist of the ``Qwen3_5MoeForConditionalGeneration`` TEXT-only
@@ -345,12 +380,14 @@ def _known_text_only_weight_layout(weight_names, config: dict[str, Any] | None) 
 def _single_safetensors_has_multimodal_weights(snapshot_dir: Path) -> bool | None:
     """Inspect one safetensors header without loading model tensor data.
 
-    The header is useful positive evidence: a known vision/audio prefix proves
-    that the checkpoint is multimodal.  It is *not* exhaustive negative
-    evidence, though.  Repackagers may name a vision encoder differently, and
-    the header does not declare an architecture-wide tensor schema.  Preserve
-    that uncertainty as ``None`` instead of routing such a VLM to the text
-    loader.
+    Applies the SAME architecture-agnostic weight-evidence rule as
+    ``checkpoint_has_multimodal_weights``: the header lists every tensor in the
+    single-file checkpoint, so a known vision/audio name → ``True`` (VLM) and a
+    fully-read header with NONE of those names → ``False`` (text-only fork —
+    #393/#2).  ``None`` is reserved for genuinely UNREADABLE evidence (not
+    exactly one ``*.safetensors`` file, truncated/oversized/corrupt header, or
+    an ``OSError`` during enumeration/read) so the caller falls back to config /
+    name heuristics rather than flipping a verdict on absent evidence.
     """
     try:
         # ``glob`` file enumeration is INSIDE the try (codex #5): a permission
@@ -377,17 +414,40 @@ def _single_safetensors_has_multimodal_weights(snapshot_dir: Path) -> bool | Non
         return None
     if not isinstance(parsed, dict):
         return None
-    return True if _contains_multimodal_weight_names(parsed) else None
+    # Fully-read header: vision/audio tensor present -> VLM (True); absent ->
+    # text-only (False), architecture-agnostic (matches the multi-file index
+    # path and origin/main's negative detection).
+    return _contains_multimodal_weight_names(parsed)
 
 
 def checkpoint_has_multimodal_weights(
     snapshot_dir: Path | None, config: dict[str, Any] | None = None
 ) -> bool | None:
-    """Return positive modality proof or a schema-backed text-only verdict.
+    """Return a modality verdict from the checkpoint's own tensor names.
 
-    Unrecognised tensor namespaces are deliberately inconclusive.  A generic
-    prefix list cannot prove a checkpoint has no vision encoder; only a known
-    architecture's complete language-only layout may return ``False``.
+    The rule is ARCHITECTURE-AGNOSTIC and driven purely by WEIGHT EVIDENCE
+    (restoring origin/main's ``_local_checkpoint_has_multimodal_weights`` after
+    the round-3/4 regression):
+
+    * A weight index that CONTAINS a known vision/audio tensor
+      (``MULTIMODAL_TENSOR_PREFIXES``) → ``True`` (genuine / repackaged VLM;
+      satisfies #1121 — a renamed VLM whose safetensors ship ``vision_tower.*``
+      routes to the MLLM lane).
+    * A readable weight index that contains NONE of those tensors → ``False``
+      (text-only fork of a VLM-capable architecture; satisfies codex #2 / #393 —
+      config.json may declare ``vision_config`` but the safetensors are
+      language-only, so it must route to the text engine, NOT crash the MLLM
+      batched path on a missing vision tower).  This holds for EVERY
+      architecture, not just Qwen3.5-MoE.
+    * Only genuinely UNREADABLE evidence (missing/oversized/corrupt index, no
+      files) stays ``None`` so the caller falls back to config/name heuristics.
+
+    #2 and #1121 are OPPOSITE failure modes distinguished solely by whether
+    vision tensors are present; this single evidence rule resolves both.  The
+    ``config`` argument is retained for signature/back-compat but the verdict no
+    longer depends on the declared architecture (the former Qwen3.5-MoE
+    ``_known_text_only_weight_layout`` special-case is now subsumed by the
+    general "no vision tensors -> text" path and kept only as documentation).
     """
     if snapshot_dir is None:
         return None
@@ -400,9 +460,11 @@ def checkpoint_has_multimodal_weights(
     weights = index.get("weight_map")
     if not isinstance(weights, dict):
         return None
-    if _contains_multimodal_weight_names(weights):
-        return True
-    return False if _known_text_only_weight_layout(weights, config) else None
+    # Architecture-agnostic weight-evidence verdict: vision tensors present ->
+    # VLM (True); absent (readable index, zero modality tensors) -> text-only
+    # (False), for ANY architecture.  This restores origin/main and is the
+    # negative branch #2 needs (a text-only fork of any VLM architecture).
+    return _contains_multimodal_weight_names(weights)
 
 
 def checkpoint_evidence_is_available(snapshot_dir: Path | None) -> bool:

--- a/vllm_mlx/model_metadata.py
+++ b/vllm_mlx/model_metadata.py
@@ -1,0 +1,215 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Offline model metadata inspection shared by routing decisions.
+
+Model names are mutable packaging labels, while a downloaded checkpoint's
+``config.json`` and chat template declare the architecture and wire protocol
+the runtime actually needs to support.  This module reads that metadata from
+either a local model directory or the local Hugging Face cache.  It never
+contacts Hugging Face, so callers may safely use it on every server start.
+"""
+
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+# These files are configuration, not model weights.  Keep the reads bounded
+# anyway: a corrupt cache entry must not turn startup classification into an
+# unbounded allocation.
+MAX_METADATA_FILE_BYTES = 1 * 1024 * 1024
+
+
+@dataclass(frozen=True)
+class ModelMetadata:
+    """Offline metadata available for a local directory or HF snapshot."""
+
+    config: dict[str, Any] | None
+    chat_template: str | None
+    snapshot_dir: Path | None
+
+
+def _read_json(path: Path | None) -> dict[str, Any] | None:
+    """Read one bounded JSON object, returning ``None`` on cache failures."""
+    if path is None or not path.is_file():
+        return None
+    try:
+        if path.stat().st_size > MAX_METADATA_FILE_BYTES:
+            return None
+        with path.open(encoding="utf-8") as f:
+            value = json.load(f)
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError, ValueError):
+        return None
+    return value if isinstance(value, dict) else None
+
+
+def _read_text(path: Path | None) -> str | None:
+    """Read one bounded template, returning ``None`` on cache failures."""
+    if path is None or not path.is_file():
+        return None
+    try:
+        if path.stat().st_size > MAX_METADATA_FILE_BYTES:
+            return None
+        with path.open(encoding="utf-8") as f:
+            return f.read()
+    except (OSError, UnicodeDecodeError, ValueError):
+        return None
+
+
+def _chat_template(snapshot_dir: Path | None) -> str | None:
+    """Load the template using Transformers' standalone-file precedence."""
+    if snapshot_dir is None:
+        return None
+    standalone = _read_text(snapshot_dir / "chat_template.jinja")
+    if standalone is not None:
+        return standalone
+    tokenizer_config = _read_json(snapshot_dir / "tokenizer_config.json")
+    template = tokenizer_config.get("chat_template") if tokenizer_config else None
+    return template if isinstance(template, str) else None
+
+
+def read_local_model_metadata(model_path: str) -> ModelMetadata | None:
+    """Read metadata from a local model directory without interpreting IDs."""
+    try:
+        snapshot_dir = Path(model_path)
+    except (TypeError, ValueError):
+        return None
+    if not snapshot_dir.is_dir():
+        return None
+    return ModelMetadata(
+        config=_read_json(snapshot_dir / "config.json"),
+        chat_template=_chat_template(snapshot_dir),
+        snapshot_dir=snapshot_dir,
+    )
+
+
+def _looks_like_hub_repo_id(model_name: str) -> bool:
+    """Accept HF ``owner/repository`` IDs, never filesystem lookalikes."""
+    return (
+        isinstance(model_name, str)
+        and "/" in model_name
+        and not model_name.startswith(("/", "./", "../", "~"))
+    )
+
+
+def _cached_file(model_name: str, filename: str) -> Path | None:
+    """Resolve a cache file through huggingface_hub without network access."""
+    if not _looks_like_hub_repo_id(model_name):
+        return None
+    try:
+        from huggingface_hub import _CACHED_NO_EXIST, try_to_load_from_cache
+    except ImportError:
+        return None
+    try:
+        cached = try_to_load_from_cache(model_name, filename)
+    except Exception:
+        return None
+    if cached is None or cached is _CACHED_NO_EXIST or not isinstance(cached, (str, os.PathLike)):
+        return None
+    return Path(cached)
+
+
+def read_cached_model_metadata(model_name: str) -> ModelMetadata | None:
+    """Read metadata for a cached HF repository, never triggering download."""
+    config_path = _cached_file(model_name, "config.json")
+    template_path = _cached_file(model_name, "chat_template.jinja")
+    tokenizer_path = _cached_file(model_name, "tokenizer_config.json")
+    snapshot_dir = next(
+        (
+            path.parent
+            for path in (config_path, template_path, tokenizer_path)
+            if path is not None
+        ),
+        None,
+    )
+    if snapshot_dir is None:
+        return None
+    template = _read_text(template_path)
+    if template is None:
+        tokenizer_config = _read_json(tokenizer_path)
+        candidate = tokenizer_config.get("chat_template") if tokenizer_config else None
+        template = candidate if isinstance(candidate, str) else None
+    return ModelMetadata(
+        config=_read_json(config_path),
+        chat_template=template,
+        snapshot_dir=snapshot_dir,
+    )
+
+
+def read_model_metadata(model_name: str) -> ModelMetadata | None:
+    """Read local-directory metadata first, then the local HF-cache entry."""
+    local = read_local_model_metadata(model_name)
+    return local if local is not None else read_cached_model_metadata(model_name)
+
+
+# Config keys / architecture fragments shared by MLLM routing and tests.
+VLM_CONFIG_KEYS = (
+    "vision_config",
+    "audio_config",
+    "vision_tower",
+    "visual_config",
+    "mm_vision_tower",
+    "image_token_id",
+    "image_token_index",
+    "audio_token_id",
+    "audio_token_index",
+)
+VLM_ARCHITECTURE_KEYWORDS = (
+    "VLForCondition",
+    "VLForCausal",
+    "VisionForCondition",
+    "VisionForCausal",
+    "MultiModalityCausalLM",
+    "Llava",
+    "Idefics",
+    "PaliGemma",
+    "Pixtral",
+    "Molmo",
+    "Phi3V",
+    "Phi4V",
+    "CogVLM",
+    "InternVL",
+    "DeepseekVL",
+    "Mllama",
+    "Gemma3ForConditional",
+    "Gemma4ForConditional",
+)
+MULTIMODAL_TENSOR_PREFIXES = (
+    "vision_tower",
+    "vision_model",
+    "visual.",
+    "audio_tower",
+    "audio_model",
+    "mm_projector",
+    "patch_embed.",
+)
+
+
+def config_indicates_multimodal(config: dict[str, Any]) -> bool:
+    """Return whether a model config declares a vision or audio modality."""
+    architectures = config.get("architectures") or []
+    if isinstance(architectures, list):
+        for architecture in architectures:
+            if isinstance(architecture, str) and any(
+                keyword.lower() in architecture.lower()
+                for keyword in VLM_ARCHITECTURE_KEYWORDS
+            ):
+                return True
+    return any(key in config for key in VLM_CONFIG_KEYS)
+
+
+def checkpoint_has_multimodal_weights(snapshot_dir: Path | None) -> bool | None:
+    """Inspect a sharded checkpoint index for actual vision/audio tensors."""
+    if snapshot_dir is None:
+        return None
+    index = _read_json(snapshot_dir / "model.safetensors.index.json")
+    if index is None:
+        return None
+    weights = index.get("weight_map")
+    if not isinstance(weights, dict):
+        return None
+    return any(
+        isinstance(name, str)
+        and any(prefix in name for prefix in MULTIMODAL_TENSOR_PREFIXES)
+        for name in weights
+    )

--- a/vllm_mlx/model_metadata.py
+++ b/vllm_mlx/model_metadata.py
@@ -88,13 +88,57 @@ def _select_chat_template(tokenizer_config: dict[str, Any] | None) -> str | None
     return templates[0] if len(templates) == 1 else None
 
 
+# Transformers stores extra (named) chat templates under this directory, one
+# ``<name>.jinja`` per template, with ``chat_template.jinja`` acting as the
+# ``default``.  Mirrors ``transformers.utils.hub.CHAT_TEMPLATE_DIR``.
+CHAT_TEMPLATE_DIR = "additional_chat_templates"
+
+
+def _read_named_chat_templates(snapshot_dir: Path) -> dict[str, str]:
+    """Read named templates from the ``additional_chat_templates/`` directory.
+
+    Mirrors ``PreTrainedTokenizerBase._from_pretrained`` (tokenization_utils_base):
+    each ``<name>.jinja`` under ``additional_chat_templates/`` becomes a
+    ``chat_templates[name]`` entry, with ``name = filename.removesuffix(".jinja")``.
+    """
+    template_dir = snapshot_dir / CHAT_TEMPLATE_DIR
+    if not template_dir.is_dir():
+        return {}
+    named: dict[str, str] = {}
+    try:
+        template_files = sorted(template_dir.glob("*.jinja"))
+    except OSError:
+        return {}
+    for template_file in template_files:
+        template = _read_text(template_file)
+        if template is not None:
+            named[template_file.name.removesuffix(".jinja")] = template
+    return named
+
+
 def _chat_template(snapshot_dir: Path | None) -> str | None:
-    """Load the template using Transformers' standalone-file precedence."""
+    """Load the template using Transformers' standalone-file precedence.
+
+    Mirrors ``PreTrainedTokenizerBase._from_pretrained`` (tokenization_utils_base
+    ~lines 1665-1808): independent chat-template files take priority over the
+    ``tokenizer_config.json`` entry.  ``chat_template.jinja`` supplies the
+    ``default`` template, while every ``<name>.jinja`` under
+    ``additional_chat_templates/`` contributes a named template.  Transformers
+    collapses a lone ``default`` to a single string and otherwise keeps a
+    ``{name: template}`` dict; we then apply the SAME ``tool_use`` → ``default``
+    selection used for the tokenizer-config form via ``_select_chat_template``.
+    """
     if snapshot_dir is None:
         return None
+    templates = _read_named_chat_templates(snapshot_dir)
     standalone = _read_text(snapshot_dir / "chat_template.jinja")
     if standalone is not None:
-        return standalone
+        templates["default"] = standalone
+    if templates:
+        # Transformers flattens a lone ``default`` to a bare string.
+        if len(templates) == 1 and "default" in templates:
+            return templates["default"]
+        return _select_chat_template({"chat_template": templates})
     return _select_chat_template(_read_json(snapshot_dir / "tokenizer_config.json"))
 
 

--- a/vllm_mlx/model_metadata.py
+++ b/vllm_mlx/model_metadata.py
@@ -27,6 +27,7 @@ class ModelMetadata:
     config: dict[str, Any] | None
     chat_template: str | None
     snapshot_dir: Path | None
+    is_local: bool = False
 
 
 def _read_json(path: Path | None) -> dict[str, Any] | None:
@@ -56,6 +57,23 @@ def _read_text(path: Path | None) -> str | None:
         return None
 
 
+def _select_chat_template(tokenizer_config: dict[str, Any] | None) -> str | None:
+    """Select the template Transformers uses when tools are present."""
+    candidate = tokenizer_config.get("chat_template") if tokenizer_config else None
+    if isinstance(candidate, str):
+        return candidate
+    if not isinstance(candidate, dict):
+        return None
+    for name in ("tool_use", "default"):
+        template = candidate.get(name)
+        if isinstance(template, str):
+            return template
+    templates = [
+        template for template in candidate.values() if isinstance(template, str)
+    ]
+    return templates[0] if len(templates) == 1 else None
+
+
 def _chat_template(snapshot_dir: Path | None) -> str | None:
     """Load the template using Transformers' standalone-file precedence."""
     if snapshot_dir is None:
@@ -63,9 +81,7 @@ def _chat_template(snapshot_dir: Path | None) -> str | None:
     standalone = _read_text(snapshot_dir / "chat_template.jinja")
     if standalone is not None:
         return standalone
-    tokenizer_config = _read_json(snapshot_dir / "tokenizer_config.json")
-    template = tokenizer_config.get("chat_template") if tokenizer_config else None
-    return template if isinstance(template, str) else None
+    return _select_chat_template(_read_json(snapshot_dir / "tokenizer_config.json"))
 
 
 def read_local_model_metadata(model_path: str) -> ModelMetadata | None:
@@ -80,6 +96,7 @@ def read_local_model_metadata(model_path: str) -> ModelMetadata | None:
         config=_read_json(snapshot_dir / "config.json"),
         chat_template=_chat_template(snapshot_dir),
         snapshot_dir=snapshot_dir,
+        is_local=True,
     )
 
 
@@ -104,7 +121,11 @@ def _cached_file(model_name: str, filename: str) -> Path | None:
         cached = try_to_load_from_cache(model_name, filename)
     except Exception:
         return None
-    if cached is None or cached is _CACHED_NO_EXIST or not isinstance(cached, (str, os.PathLike)):
+    if (
+        cached is None
+        or cached is _CACHED_NO_EXIST
+        or not isinstance(cached, (str, os.PathLike))
+    ):
         return None
     return Path(cached)
 
@@ -112,26 +133,18 @@ def _cached_file(model_name: str, filename: str) -> Path | None:
 def read_cached_model_metadata(model_name: str) -> ModelMetadata | None:
     """Read metadata for a cached HF repository, never triggering download."""
     config_path = _cached_file(model_name, "config.json")
-    template_path = _cached_file(model_name, "chat_template.jinja")
-    tokenizer_path = _cached_file(model_name, "tokenizer_config.json")
-    snapshot_dir = next(
-        (
-            path.parent
-            for path in (config_path, template_path, tokenizer_path)
-            if path is not None
-        ),
-        None,
-    )
+    snapshot_dir = config_path.parent if config_path is not None else None
+    if snapshot_dir is None:
+        template_path = _cached_file(model_name, "chat_template.jinja")
+        snapshot_dir = template_path.parent if template_path is not None else None
+    if snapshot_dir is None:
+        tokenizer_path = _cached_file(model_name, "tokenizer_config.json")
+        snapshot_dir = tokenizer_path.parent if tokenizer_path is not None else None
     if snapshot_dir is None:
         return None
-    template = _read_text(template_path)
-    if template is None:
-        tokenizer_config = _read_json(tokenizer_path)
-        candidate = tokenizer_config.get("chat_template") if tokenizer_config else None
-        template = candidate if isinstance(candidate, str) else None
     return ModelMetadata(
-        config=_read_json(config_path),
-        chat_template=template,
+        config=_read_json(snapshot_dir / "config.json"),
+        chat_template=_chat_template(snapshot_dir),
         snapshot_dir=snapshot_dir,
     )
 
@@ -198,18 +211,47 @@ def config_indicates_multimodal(config: dict[str, Any]) -> bool:
     return any(key in config for key in VLM_CONFIG_KEYS)
 
 
+def _contains_multimodal_weight_names(weight_names) -> bool:
+    """Return whether an iterable of safetensors names has modality weights."""
+    return any(
+        isinstance(name, str)
+        and any(prefix in name for prefix in MULTIMODAL_TENSOR_PREFIXES)
+        for name in weight_names
+    )
+
+
+def _single_safetensors_has_multimodal_weights(snapshot_dir: Path) -> bool | None:
+    """Inspect one safetensors header without loading model tensor data."""
+    files = tuple(snapshot_dir.glob("*.safetensors"))
+    if len(files) != 1:
+        return None
+    try:
+        with files[0].open("rb") as f:
+            size_bytes = f.read(8)
+            if len(size_bytes) != 8:
+                return None
+            header_size = int.from_bytes(size_bytes, "little")
+            if header_size > MAX_METADATA_FILE_BYTES:
+                return None
+            header = f.read(header_size)
+        if len(header) != header_size:
+            return None
+        parsed = json.loads(header.decode("utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError, ValueError):
+        return None
+    if not isinstance(parsed, dict):
+        return None
+    return _contains_multimodal_weight_names(parsed)
+
+
 def checkpoint_has_multimodal_weights(snapshot_dir: Path | None) -> bool | None:
-    """Inspect a sharded checkpoint index for actual vision/audio tensors."""
+    """Inspect a checkpoint index or single safetensors header for modality weights."""
     if snapshot_dir is None:
         return None
     index = _read_json(snapshot_dir / "model.safetensors.index.json")
     if index is None:
-        return None
+        return _single_safetensors_has_multimodal_weights(snapshot_dir)
     weights = index.get("weight_map")
     if not isinstance(weights, dict):
         return None
-    return any(
-        isinstance(name, str)
-        and any(prefix in name for prefix in MULTIMODAL_TENSOR_PREFIXES)
-        for name in weights
-    )
+    return _contains_multimodal_weight_names(weights)

--- a/vllm_mlx/model_metadata.py
+++ b/vllm_mlx/model_metadata.py
@@ -68,6 +68,14 @@ def _select_chat_template(tokenizer_config: dict[str, Any] | None) -> str | None
     candidate = tokenizer_config.get("chat_template") if tokenizer_config else None
     if isinstance(candidate, str):
         return candidate
+    if isinstance(candidate, list):
+        candidate = {
+            item["name"]: item["template"]
+            for item in candidate
+            if isinstance(item, dict)
+            and isinstance(item.get("name"), str)
+            and isinstance(item.get("template"), str)
+        }
     if not isinstance(candidate, dict):
         return None
     for name in ("tool_use", "default"):
@@ -298,3 +306,12 @@ def checkpoint_has_multimodal_weights(
     if _contains_multimodal_weight_names(weights):
         return True
     return False if _known_text_only_weight_layout(weights, config) else None
+
+
+def checkpoint_evidence_is_available(snapshot_dir: Path | None) -> bool:
+    """Return whether checkpoint metadata was available for inspection."""
+    if snapshot_dir is None:
+        return False
+    return (snapshot_dir / "model.safetensors.index.json").is_file() or any(
+        snapshot_dir.glob("*.safetensors")
+    )

--- a/vllm_mlx/model_metadata.py
+++ b/vllm_mlx/model_metadata.py
@@ -255,7 +255,19 @@ MULTIMODAL_TENSOR_PREFIXES = (
     "patch_embed.",
 )
 _QWEN3_5_MOE_ARCHITECTURE = "qwen3_5moeforconditionalgeneration"
-_QWEN3_5_MOE_TEXT_TENSOR_PREFIX = "language_model."
+# Precise allowlist of the ``Qwen3_5MoeForConditionalGeneration`` TEXT-only
+# tensor namespace.  The text backbone lives under ``language_model.model.``
+# (embed_tokens / layers / norm) and the head under ``language_model.lm_head``.
+# A bare ``language_model.`` prefix is deliberately NOT trusted: a modality
+# subtree can nest under it (e.g. ``language_model.vision_encoder.blocks.*``)
+# and a bare-prefix ``all(...)`` check would wrongly classify such a VLM as
+# text-only.  Any tensor whose path is not covered by this precise allowlist
+# leaves the layout UNrecognised (inconclusive), never a false text verdict.
+_QWEN3_5_MOE_TEXT_TENSOR_ALLOWLIST = (
+    "language_model.model.",
+    "language_model.lm_head.",
+    "language_model.lm_head",
+)
 
 
 def config_indicates_multimodal(config: dict[str, Any]) -> bool:
@@ -280,8 +292,29 @@ def _contains_multimodal_weight_names(weight_names) -> bool:
     )
 
 
+def _is_qwen3_5_moe_text_tensor(name: str) -> bool:
+    """Return whether one tensor name is a known Qwen3.5-MoE text tensor.
+
+    Validated against a PRECISE allowlist of text submodule paths rather than
+    the bare ``language_model.`` prefix, so a modality subtree nested under
+    ``language_model.`` (e.g. ``language_model.vision_encoder.blocks.0.weight``)
+    is NOT accepted as text-only.
+    """
+    return name == "language_model.lm_head" or any(
+        name.startswith(prefix) for prefix in _QWEN3_5_MOE_TEXT_TENSOR_ALLOWLIST
+    )
+
+
 def _known_text_only_weight_layout(weight_names, config: dict[str, Any] | None) -> bool:
-    """Recognise only an exhaustive architecture-specific text-only layout."""
+    """Recognise only an exhaustive architecture-specific text-only layout.
+
+    Returns ``True`` ONLY when the architecture is the Qwen3.5-MoE conditional-
+    generation class AND every tensor name matches the precise text allowlist.
+    A single unrecognised name (any modality subtree nested under
+    ``language_model.``, or a foreign namespace) makes the layout unrecognised
+    → ``False`` here, so the overall verdict stays inconclusive (``None``)
+    rather than falsely declaring the checkpoint text-only.
+    """
     architectures = config.get("architectures") if config else None
     if not isinstance(architectures, list) or not any(
         isinstance(architecture, str)
@@ -290,9 +323,7 @@ def _known_text_only_weight_layout(weight_names, config: dict[str, Any] | None) 
     ):
         return False
     names = tuple(name for name in weight_names if isinstance(name, str))
-    return bool(names) and all(
-        name.startswith(_QWEN3_5_MOE_TEXT_TENSOR_PREFIX) for name in names
-    )
+    return bool(names) and all(_is_qwen3_5_moe_text_tensor(name) for name in names)
 
 
 def _single_safetensors_has_multimodal_weights(snapshot_dir: Path) -> bool | None:

--- a/vllm_mlx/model_metadata.py
+++ b/vllm_mlx/model_metadata.py
@@ -221,7 +221,15 @@ def _contains_multimodal_weight_names(weight_names) -> bool:
 
 
 def _single_safetensors_has_multimodal_weights(snapshot_dir: Path) -> bool | None:
-    """Inspect one safetensors header without loading model tensor data."""
+    """Inspect one safetensors header without loading model tensor data.
+
+    The header is useful positive evidence: a known vision/audio prefix proves
+    that the checkpoint is multimodal.  It is *not* exhaustive negative
+    evidence, though.  Repackagers may name a vision encoder differently, and
+    the header does not declare an architecture-wide tensor schema.  Preserve
+    that uncertainty as ``None`` instead of routing such a VLM to the text
+    loader.
+    """
     files = tuple(snapshot_dir.glob("*.safetensors"))
     if len(files) != 1:
         return None
@@ -241,7 +249,7 @@ def _single_safetensors_has_multimodal_weights(snapshot_dir: Path) -> bool | Non
         return None
     if not isinstance(parsed, dict):
         return None
-    return _contains_multimodal_weight_names(parsed)
+    return True if _contains_multimodal_weight_names(parsed) else None
 
 
 def checkpoint_has_multimodal_weights(snapshot_dir: Path | None) -> bool | None:

--- a/vllm_mlx/model_metadata.py
+++ b/vllm_mlx/model_metadata.py
@@ -256,17 +256,31 @@ MULTIMODAL_TENSOR_PREFIXES = (
 )
 _QWEN3_5_MOE_ARCHITECTURE = "qwen3_5moeforconditionalgeneration"
 # Precise allowlist of the ``Qwen3_5MoeForConditionalGeneration`` TEXT-only
-# tensor namespace.  The text backbone lives under ``language_model.model.``
-# (embed_tokens / layers / norm) and the head under ``language_model.lm_head``.
-# A bare ``language_model.`` prefix is deliberately NOT trusted: a modality
-# subtree can nest under it (e.g. ``language_model.vision_encoder.blocks.*``)
-# and a bare-prefix ``all(...)`` check would wrongly classify such a VLM as
-# text-only.  Any tensor whose path is not covered by this precise allowlist
-# leaves the layout UNrecognised (inconclusive), never a false text verdict.
+# tensor namespace.  Derived from the ACTUAL module tree of the text backbone,
+# NOT invented: ``mlx_lm.models.qwen3_5.Qwen3_5TextModel`` defines exactly
+# ``embed_tokens`` / ``layers`` / ``norm`` as its children, its wrapper
+# ``TextModel`` adds ``model`` (that backbone) + optional ``lm_head``, and the
+# top-level ``Model`` wraps it under ``language_model`` (mlx-lm
+# ``models/qwen3_5.py`` lines 243-297, 367-372; the MoE sanitizer in
+# ``models/qwen3_5_moe.py`` emits ``language_model.model.layers.{l}.mlp.*``).
+# So the ONLY recognised text tensors are the specific backbone children under
+# ``language_model.model.`` (``embed_tokens`` / ``layers`` / ``norm``) plus the
+# head ``language_model.lm_head``.
+#
+# A bare ``language_model.model.`` prefix is deliberately NOT trusted (codex
+# #2): a modality subtree can nest one level DEEPER under it — e.g.
+# ``language_model.model.vision_encoder.blocks.*`` — and a bare-prefix
+# ``startswith`` check would wrongly classify such a VLM as text-only, letting a
+# genuine multimodal checkpoint reach an authoritative text-only verdict.
+# Enumerating the specific backbone children rejects any unrecognised
+# descendant (``vision_encoder``, ``audio_tower``, …) as inconclusive.  Any
+# tensor whose path is not covered by this precise allowlist leaves the layout
+# UNrecognised (inconclusive), never a false text verdict.
 _QWEN3_5_MOE_TEXT_TENSOR_ALLOWLIST = (
-    "language_model.model.",
+    "language_model.model.embed_tokens.",
+    "language_model.model.layers.",
+    "language_model.model.norm.",
     "language_model.lm_head.",
-    "language_model.lm_head",
 )
 
 
@@ -295,14 +309,16 @@ def _contains_multimodal_weight_names(weight_names) -> bool:
 def _is_qwen3_5_moe_text_tensor(name: str) -> bool:
     """Return whether one tensor name is a known Qwen3.5-MoE text tensor.
 
-    Validated against a PRECISE allowlist of text submodule paths rather than
-    the bare ``language_model.`` prefix, so a modality subtree nested under
-    ``language_model.`` (e.g. ``language_model.vision_encoder.blocks.0.weight``)
-    is NOT accepted as text-only.
+    Validated against a PRECISE allowlist of the ACTUAL backbone submodule paths
+    (``language_model.model.{embed_tokens,layers,norm}`` + ``language_model
+    .lm_head``) rather than the bare ``language_model.model.`` prefix, so a
+    modality subtree nested one level deeper under the backbone (e.g.
+    ``language_model.model.vision_encoder.blocks.0.weight``) is NOT accepted as
+    text-only (codex #2).  Only the recognised text children match; every
+    unrecognised descendant leaves the tensor UNrecognised (→ inconclusive
+    layout verdict, never a false text-only verdict).
     """
-    return name == "language_model.lm_head" or any(
-        name.startswith(prefix) for prefix in _QWEN3_5_MOE_TEXT_TENSOR_ALLOWLIST
-    )
+    return any(name.startswith(prefix) for prefix in _QWEN3_5_MOE_TEXT_TENSOR_ALLOWLIST)
 
 
 def _known_text_only_weight_layout(weight_names, config: dict[str, Any] | None) -> bool:
@@ -336,10 +352,16 @@ def _single_safetensors_has_multimodal_weights(snapshot_dir: Path) -> bool | Non
     that uncertainty as ``None`` instead of routing such a VLM to the text
     loader.
     """
-    files = tuple(snapshot_dir.glob("*.safetensors"))
-    if len(files) != 1:
-        return None
     try:
+        # ``glob`` file enumeration is INSIDE the try (codex #5): a permission
+        # error, stale/unmounted network share, or cache race during directory
+        # scan must yield the documented inconclusive result (``None``), not
+        # crash the routing path.  ``Path.glob`` can raise ``OSError`` at the
+        # first directory read, so it belongs under the same handler as the
+        # header read below.
+        files = tuple(snapshot_dir.glob("*.safetensors"))
+        if len(files) != 1:
+            return None
         with files[0].open("rb") as f:
             size_bytes = f.read(8)
             if len(size_bytes) != 8:


### PR DESCRIPTION
## Summary

- Infer safe routing from a checkpoint's declared architecture, chat-template wire protocol, and checkpoint evidence—not an Agents-A1 repository-name rule.
- Use one coherent cached snapshot and the Transformers tool-use template selection rules.
- Treat tensor names as positive modality evidence only. Text routing from a VLM-capable configuration requires a complete, architecture-specific language-only schema; unknown namespaces remain inconclusive.
- Read large sharded weight indexes under their own 64 MiB bound so production-size indexes retain evidence.

## Why

Closes #1121. Agents-A1 packages Qwen3.5 with a tool template whose parameterized XML was emitted as visible streaming content when no parser was selected. The parser is now inferred from the checkpoint's documented template contract and uses the existing Hermes parser. This works for a repackage without encoding its mutable repository label.

## Test plan

- [x] Reproduced the original 4B failure: streaming `<tool_call><function=…>` leaked with no parser.
- [x] Re-ran the same real SSE request after the fix: `/v1/models` exposes `hermes`, visible content is empty, one structured tool chunk emits, finish reason is `tool_calls`, and no XML leaks.
- [x] Verified metadata profiles: 4B is dense Qwen3.5/text-safe; full Agents-A1 is Qwen3.5 MoE/hybrid-safe.
- [x] Added contract tests for named templates, snapshot coherence, malformed/oversized metadata, complete XML nesting, comment-only protocols/thinking, unknown vision namespaces, schema-backed Qwen text forks, and oversized sharded indexes.
- [x] Focused regression suite: 465 passed.
- [x] New production code coverage: `vllm_mlx/model_metadata.py` is 145 statements / 58 branches, 100%.
- [x] Full unit suite: 13,065 passed; 17 skipped, 6 xfailed, 1 xpassed.
- [x] Rebased on current `main`; lint, supply-chain, environment, and test-plan gates pass.
- [x] Addressed rounds 1 and 2 of Codex review findings.

## Round-3 Codex convergence (commit 976b86c8)

Round-3 pr_validate was green on all tests; the only outstanding gate was `codex_review` with 5 findings. Three were fixed; two were declined with an in-code rationale so the override is on the trail.

- [x] Fixed codex #3 — `_node_output_paths` no longer treats an uncalled `{% macro %}` or a capture-only `{% set x %}...{% endset %}` (`AssignBlock`) as render-through, so tool XML in a helper macro / capture no longer falsely enables the Hermes parser (jinja2 AST semantics verified empirically). True positives on reachable `If`/`For`/`Output` paths preserved.
- [x] Fixed codex #2 — tightened the qwen3.5-moe text allowlist from the bare `language_model.model.` prefix to the actual backbone children (`embed_tokens` / `layers` / `norm` + `lm_head`, per mlx-lm `models/qwen3_5.py`), so `language_model.model.vision_encoder.*` is inconclusive rather than a false text-only verdict.
- [x] Fixed codex #5 — moved `snapshot_dir.glob("*.safetensors")` inside the `except OSError` handler so a permission error / stale mount / cache race returns the documented inconclusive result instead of crashing routing.
- [x] Push-back codex #1 — declined to force-VLM on an inspected-but-unknown layout: it reverses round-2 #1 ("never promote an inconclusive result based solely on file existence"). Inconclusive routes to the name/locality neutral tie-breaker; documented the round-2↔round-3 oscillation in-code.
- [x] Push-back codex #4 — declined to thread correlated-branch predicates through path enumeration: no real chat template splits a tool-call contract across two independent top-level conditionals, and it risks false-negatives; FIX A already removes the realistic false-positive vector. Documented in-code.
- [x] Added 5 targeted tests (macro-uncalled / set-capture NOT detected, reachable path STILL detected, deep-modality-subtree rejected, glob-OSError inconclusive). Full unit suite (pr_validate-style, `--ignore=tests/integrations`): 13,040 passed, 0 failed; ruff check + format clean; `is_mllm_model('mlx-community/Qwen3.5-4B-MLX-4bit')` stays `False`.
