### PR TITLE
feat(tools): hermes + qwen structure_info for constrained tool-calling (#558 PR-2)

### DIFF
--- a/tests/test_structure_info_hermes_qwen_558.py
+++ b/tests/test_structure_info_hermes_qwen_558.py
@@ -94,32 +94,68 @@ _PARSER_IMPORTS = {
 }
 
 
-class _FakeSingleTokenizer:
-    """Minimal tokenizer stub whose declared strings encode to ONE token each.
+class _FakeTokenizer:
+    """Minimal tokenizer stub modeling the surfaces the guard probes.
 
     ``structure_info()`` opts into grammar constraint only when the model's
-    tokenizer proves ``<tool_call>``/``</tool_call>`` are single tokens (the
-    hermes parser is also routed to Llama tokenizers where they are NOT). The
-    pure-Python triple/Lark tests must therefore hand the parser a tokenizer
-    that satisfies the guard — this stub does so WITHOUT a network fetch, so
-    those tests stay hermetic and never skip. Any string not in ``_single`` is
-    reported as multi-token (length 2) so the opt-out path is exercisable too.
+    tokenizer proves ``<tool_call>``/``</tool_call>`` are DISTINCT single
+    REGISTERED special tokens (the hermes parser is also routed to Llama
+    tokenizers where they are NOT). The guard checks: ``len(encode(s)) == 1``,
+    ``decode([id]) == s`` (round-trip), the id is in ``added_tokens_decoder``
+    (registered special), and distinct ids across sentinels. This stub lets the
+    pure-Python tests exercise every opt-in/opt-out branch WITHOUT a network
+    fetch, so they stay hermetic and never skip.
+
+    ``specials`` maps each special string to its single id (registered special,
+    round-trips). Any other string encodes as multi-token (opt-out path).
+    ``ordinary`` maps a string to a single id that round-trips but is NOT a
+    registered special (ordinary-vocab opt-out case). ``collapse`` maps strings
+    to a shared single id that does NOT round-trip (``[UNK]`` collapse case).
     """
 
-    def __init__(self, single=("<tool_call>", "</tool_call>")):
-        self._single = set(single)
+    def __init__(self, specials=None, ordinary=None, collapse=None):
+        self._specials = dict(specials or {})
+        self._ordinary = dict(ordinary or {})
+        self._collapse = dict(collapse or {})
+        # id -> source string, for round-trip decode of specials + ordinary.
+        self._id_to_str = {i: s for s, i in self._specials.items()}
+        self._id_to_str.update({i: s for s, i in self._ordinary.items()})
+        # added_tokens_decoder: only the registered specials.
+        self.added_tokens_decoder = {i: object() for i in self._specials.values()}
 
     def encode(self, text, add_special_tokens=False):
-        return [0] if text in self._single else [0, 1]
+        if text in self._specials:
+            return [self._specials[text]]
+        if text in self._ordinary:
+            return [self._ordinary[text]]
+        if text in self._collapse:
+            return [self._collapse[text]]
+        return [0, 1]  # ordinary multi-token text
+
+    def decode(self, ids):
+        return "".join(self._id_to_str.get(i, "<unk>") for i in ids)
 
 
-class _MultiTokenTokenizer(_FakeSingleTokenizer):
-    """Tokenizer stub where NO sentinel is a single token (a Llama-Hermes-like
-    tokenizer). Every ``encode`` returns two ids -> the guard fails -> the
-    parser opts out of grammar constraint (``structure_info() -> None``)."""
+def _single_token_tokenizer():
+    """Qwen3-like: both sentinels are distinct single registered specials."""
+    return _FakeTokenizer(specials={"<tool_call>": 100, "</tool_call>": 101})
 
-    def __init__(self):
-        super().__init__(single=())
+
+def _multitoken_tokenizer():
+    """Llama-Hermes-like: neither sentinel is a single token -> opt out."""
+    return _FakeTokenizer(specials={})
+
+
+def _ordinary_vocab_tokenizer():
+    """Both sentinels are single tokens that round-trip but are NOT registered
+    special tokens -> opt out (special-ref semantics would not match)."""
+    return _FakeTokenizer(ordinary={"<tool_call>": 100, "</tool_call>": 101})
+
+
+def _unk_collapse_tokenizer():
+    """Both sentinels collapse to the SAME single [UNK] id that does not
+    round-trip -> opt out (distinct-id + round-trip both fail)."""
+    return _FakeTokenizer(collapse={"<tool_call>": 3, "</tool_call>": 3})
 
 
 def _make_parser(family: str, tokenizer=None):
@@ -133,7 +169,7 @@ def _make_parser(family: str, tokenizer=None):
 def _make_optin_parser(family: str):
     """A real parser whose tokenizer satisfies the single-special-token guard,
     so ``structure_info()`` opts in — used by the hermetic triple/Lark tests."""
-    return _make_parser(family, tokenizer=_FakeSingleTokenizer())
+    return _make_parser(family, tokenizer=_single_token_tokenizer())
 
 
 # --------------------------------------------------------------------------
@@ -141,7 +177,8 @@ def _make_optin_parser(family: str):
 # load-bearing correctness contract: the hermes wire's <tool_call> sentinels
 # are single special tokens ONLY on some tokenizers (Qwen3), NOT universally
 # (Llama-based Hermes). A parser must opt out where the tokenizer can't prove
-# single-token sentinels, else it would build an unenforceable grammar.
+# DISTINCT single REGISTERED special sentinels, else it would build an
+# unenforceable grammar.
 # --------------------------------------------------------------------------
 @pytest.mark.parametrize("family", ["hermes", "qwen"])
 def test_structure_info_opts_out_without_tokenizer(family):
@@ -157,14 +194,33 @@ def test_structure_info_opts_out_on_multitoken_tokenizer(family):
     # Hermes) -> opt out. Declaring a special-token sentinel there would build a
     # grammar the model's tokenizer can never satisfy — the exact bug this guard
     # prevents.
-    parser = _make_parser(family, tokenizer=_MultiTokenTokenizer())
+    parser = _make_parser(family, tokenizer=_multitoken_tokenizer())
+    assert parser.structure_info() is None
+
+
+@pytest.mark.parametrize("family", ["hermes", "qwen"])
+def test_structure_info_opts_out_on_ordinary_vocab_token(family):
+    # Both sentinels are single tokens that round-trip but are NOT registered
+    # special tokens -> opt out. A single ORDINARY vocab token cannot back a
+    # special-token Lark ref, so len==1 alone must not opt in (codex round-2).
+    parser = _make_parser(family, tokenizer=_ordinary_vocab_tokenizer())
+    assert parser.structure_info() is None
+
+
+@pytest.mark.parametrize("family", ["hermes", "qwen"])
+def test_structure_info_opts_out_on_unk_collapse(family):
+    # Both sentinels collapse to the SAME single [UNK] id that does not
+    # round-trip -> opt out. len==1 for each would otherwise falsely opt into an
+    # unenforceable grammar where open/close are indistinguishable (codex r2).
+    parser = _make_parser(family, tokenizer=_unk_collapse_tokenizer())
     assert parser.structure_info() is None
 
 
 @pytest.mark.parametrize("family", ["hermes", "qwen"])
 def test_structure_info_opts_in_on_single_token_tokenizer(family):
-    # A tokenizer where both sentinels ARE single tokens (Qwen3-like) -> opt in.
-    parser = _make_parser(family, tokenizer=_FakeSingleTokenizer())
+    # A tokenizer where both sentinels ARE distinct single registered specials
+    # (Qwen3-like) -> opt in.
+    parser = _make_parser(family, tokenizer=_single_token_tokenizer())
     assert parser.structure_info() is not None
 
 

--- a/tests/test_structure_info_hermes_qwen_558.py
+++ b/tests/test_structure_info_hermes_qwen_558.py
@@ -8,10 +8,14 @@ stub. PR-2 lands the concrete per-family overrides on the REAL
 ``<tool_call>…</tool_call>`` JSON-body wire). These tests therefore drive the
 grammar path through the ACTUAL shipped parsers — not a stub — to prove:
 
-  * each real parser's ``structure_info()`` returns a ``name -> StructureInfo``
-    factory whose wire triple is the hermes ``<tool_call>`` JSON body, with the
+  * each real parser's ``structure_info()`` is TOKENIZER-AWARE: it opts into
+    grammar constraint (returns a ``name -> StructureInfo`` factory whose wire
+    triple is the hermes ``<tool_call>`` JSON body, with the
     ``<tool_call>``/``</tool_call>`` single special tokens declared as
-    ``sentinels`` (ground-truth correction #1);
+    ``sentinels`` — ground-truth correction #1) ONLY when the model's tokenizer
+    proves both sentinels are single tokens, and OPTS OUT (returns ``None`` ->
+    free-form fallback) otherwise (no tokenizer, or a Llama-based Hermes
+    tokenizer that encodes ``<tool_call>`` as ordinary multi-token text);
   * feeding a real parser through ``build_tool_grammar`` yields a Lark with the
     ``<tool_call>`` bare special-token trigger + a ``%json`` schema-constraint
     region for the ``arguments`` object;
@@ -90,6 +94,34 @@ _PARSER_IMPORTS = {
 }
 
 
+class _FakeSingleTokenizer:
+    """Minimal tokenizer stub whose declared strings encode to ONE token each.
+
+    ``structure_info()`` opts into grammar constraint only when the model's
+    tokenizer proves ``<tool_call>``/``</tool_call>`` are single tokens (the
+    hermes parser is also routed to Llama tokenizers where they are NOT). The
+    pure-Python triple/Lark tests must therefore hand the parser a tokenizer
+    that satisfies the guard — this stub does so WITHOUT a network fetch, so
+    those tests stay hermetic and never skip. Any string not in ``_single`` is
+    reported as multi-token (length 2) so the opt-out path is exercisable too.
+    """
+
+    def __init__(self, single=("<tool_call>", "</tool_call>")):
+        self._single = set(single)
+
+    def encode(self, text, add_special_tokens=False):
+        return [0] if text in self._single else [0, 1]
+
+
+class _MultiTokenTokenizer(_FakeSingleTokenizer):
+    """Tokenizer stub where NO sentinel is a single token (a Llama-Hermes-like
+    tokenizer). Every ``encode`` returns two ids -> the guard fails -> the
+    parser opts out of grammar constraint (``structure_info() -> None``)."""
+
+    def __init__(self):
+        super().__init__(single=())
+
+
 def _make_parser(family: str, tokenizer=None):
     import importlib
 
@@ -98,15 +130,53 @@ def _make_parser(family: str, tokenizer=None):
     return cls(tokenizer=tokenizer)
 
 
+def _make_optin_parser(family: str):
+    """A real parser whose tokenizer satisfies the single-special-token guard,
+    so ``structure_info()`` opts in — used by the hermetic triple/Lark tests."""
+    return _make_parser(family, tokenizer=_FakeSingleTokenizer())
+
+
 # --------------------------------------------------------------------------
-# structure_info() wire triple (pure Python, always runs — no tokenizer,
-# no llguidance: structure_info() is stateless w.r.t. the tokenizer).
+# Tokenizer-aware opt-in/opt-out guard (pure Python, always runs). This is the
+# load-bearing correctness contract: the hermes wire's <tool_call> sentinels
+# are single special tokens ONLY on some tokenizers (Qwen3), NOT universally
+# (Llama-based Hermes). A parser must opt out where the tokenizer can't prove
+# single-token sentinels, else it would build an unenforceable grammar.
+# --------------------------------------------------------------------------
+@pytest.mark.parametrize("family", ["hermes", "qwen"])
+def test_structure_info_opts_out_without_tokenizer(family):
+    # No tokenizer -> cannot prove single-token sentinels -> opt out (None),
+    # so the builder falls back to free-form. NON-BREAKING for tokenizer-less
+    # construction paths.
+    assert _make_parser(family, tokenizer=None).structure_info() is None
+
+
+@pytest.mark.parametrize("family", ["hermes", "qwen"])
+def test_structure_info_opts_out_on_multitoken_tokenizer(family):
+    # A tokenizer where <tool_call> is ordinary multi-token text (Llama-based
+    # Hermes) -> opt out. Declaring a special-token sentinel there would build a
+    # grammar the model's tokenizer can never satisfy — the exact bug this guard
+    # prevents.
+    parser = _make_parser(family, tokenizer=_MultiTokenTokenizer())
+    assert parser.structure_info() is None
+
+
+@pytest.mark.parametrize("family", ["hermes", "qwen"])
+def test_structure_info_opts_in_on_single_token_tokenizer(family):
+    # A tokenizer where both sentinels ARE single tokens (Qwen3-like) -> opt in.
+    parser = _make_parser(family, tokenizer=_FakeSingleTokenizer())
+    assert parser.structure_info() is not None
+
+
+# --------------------------------------------------------------------------
+# structure_info() wire triple (pure Python, always runs — hermetic tokenizer
+# stub so no network is needed to exercise the opt-in path).
 # --------------------------------------------------------------------------
 @pytest.mark.parametrize("family", ["hermes", "qwen"])
 def test_structure_info_returns_hermes_wire_triple(family):
     from vllm_mlx.api.tool_grammar import StructureInfo
 
-    parser = _make_parser(family)
+    parser = _make_optin_parser(family)
     get_info = parser.structure_info()
     # PR-2 opt-in: the override returns a name->StructureInfo factory, not None.
     assert callable(get_info), f"{family}.structure_info() must return a callable"
@@ -131,7 +201,7 @@ def test_structure_info_returns_hermes_wire_triple(family):
 def test_structure_info_substitutes_each_tool_name(family):
     # The factory substitutes whatever concrete name it is given — one triple
     # per tool, so a multi-tool request constrains each tool to ITS own schema.
-    parser = _make_parser(family)
+    parser = _make_optin_parser(family)
     get_info = parser.structure_info()
     for name in ("get_weather", "get_time", "any_other_name"):
         si = get_info(name)
@@ -143,8 +213,8 @@ def test_hermes_and_qwen_share_identical_wire(family):
     # hermes and qwen intentionally emit the SAME wire triple (both are the
     # <tool_call> JSON body). Assert byte-identical triples so the two overrides
     # can never silently diverge.
-    hermes_si = _make_parser("hermes").structure_info()("get_weather")
-    other_si = _make_parser(family).structure_info()("get_weather")
+    hermes_si = _make_optin_parser("hermes").structure_info()("get_weather")
+    other_si = _make_optin_parser(family).structure_info()("get_weather")
     assert other_si == hermes_si
 
 
@@ -159,20 +229,21 @@ def test_real_parser_builds_grammar(family, tool_choice):
     # compiled grammar (non-None) for both required and auto.
     from vllm_mlx.api.tool_grammar import build_tool_grammar
 
-    parser = _make_parser(family)
+    parser = _make_optin_parser(family)
     assert build_tool_grammar(TOOLS, tool_choice, parser) is not None
 
 
-@_requires_llguidance
 @pytest.mark.parametrize("family", ["hermes", "qwen"])
 def test_real_parser_lark_has_trigger_and_schema_region(family):
     # Assemble the Lark from the REAL parser's structure_info and assert the
     # load-bearing structure: <tool_call> as a BARE special-token ref (not a
     # quoted byte literal the single <tool_call> token could never satisfy),
     # </tool_call> bare closing ref, and a %json schema-constraint region.
+    # Pure ``build_tool_lark`` (string assembly) — needs NO llguidance, so this
+    # test always runs (it does not compile the grammar).
     from vllm_mlx.api.tool_grammar import build_tool_lark
 
-    get_info = _make_parser(family).structure_info()
+    get_info = _make_optin_parser(family).structure_info()
     infos = [get_info(t["name"]) for t in TOOLS]
     lark = build_tool_lark(TOOLS, "required", infos)
 
@@ -297,7 +368,7 @@ def test_valid_call_is_accepted_and_terminates(family, tok, lltok):
     # AND is a terminal/accepting state (a complete valid derivation).
     from vllm_mlx.api.tool_grammar import build_tool_grammar
 
-    grammar = build_tool_grammar(TOOLS, "required", _make_parser(family))
+    grammar = build_tool_grammar(TOOLS, "required", _make_parser(family, tok))
     assert grammar is not None
     accepted, total, accepting = _consume(
         grammar,
@@ -317,7 +388,7 @@ def test_valid_enum_value_is_accepted(family, tok, lltok):
     # because the grammar forbids the optional `unit` property entirely.
     from vllm_mlx.api.tool_grammar import build_tool_grammar
 
-    grammar = build_tool_grammar(TOOLS, "required", _make_parser(family))
+    grammar = build_tool_grammar(TOOLS, "required", _make_parser(family, tok))
     accepted, total, accepting = _consume(
         grammar,
         lltok,
@@ -335,7 +406,7 @@ def test_valid_enum_value_is_accepted(family, tok, lltok):
 def test_hallucinated_tool_name_is_rejected(family, tok, lltok):
     from vllm_mlx.api.tool_grammar import build_tool_grammar
 
-    grammar = build_tool_grammar(TOOLS, "required", _make_parser(family))
+    grammar = build_tool_grammar(TOOLS, "required", _make_parser(family, tok))
     accepted, total, _ = _consume(
         grammar, lltok, tok, '<tool_call>\n{"name": "get_stockquote'
     )
@@ -348,7 +419,7 @@ def test_off_schema_argument_is_rejected(family, tok, lltok):
     # `city` must be a string; an integer must be forbidden.
     from vllm_mlx.api.tool_grammar import build_tool_grammar
 
-    grammar = build_tool_grammar(TOOLS, "required", _make_parser(family))
+    grammar = build_tool_grammar(TOOLS, "required", _make_parser(family, tok))
     accepted, total, _ = _consume(
         grammar,
         lltok,
@@ -364,7 +435,7 @@ def test_bad_enum_value_is_rejected(family, tok, lltok):
     # `unit` enum is {c, f}; "kelvin" must be forbidden.
     from vllm_mlx.api.tool_grammar import build_tool_grammar
 
-    grammar = build_tool_grammar(TOOLS, "required", _make_parser(family))
+    grammar = build_tool_grammar(TOOLS, "required", _make_parser(family, tok))
     accepted, total, _ = _consume(
         grammar,
         lltok,

--- a/tests/test_structure_info_hermes_qwen_558.py
+++ b/tests/test_structure_info_hermes_qwen_558.py
@@ -381,7 +381,14 @@ def test_real_parser_lark_has_trigger_and_schema_region(family):
 # tokenizer exception) propagates and FAILS the test.
 # --------------------------------------------------------------------------
 def _offline_skip_exc_types():
-    """huggingface_hub / requests offline signals that are ALWAYS a skip."""
+    """Typed offline / connection exceptions that are ALWAYS a skip.
+
+    Covers every transport transformers/hub may use (codex r5): huggingface_hub
+    offline errors, `requests` AND `httpx` connection/timeout exceptions, and
+    the Python built-in connection errors (`ConnectionError` family, which
+    `ConnectionRefusedError` subclasses). Best-effort import — a transport not
+    installed is simply omitted.
+    """
     types: list[type[BaseException]] = []
     try:
         from huggingface_hub.errors import (
@@ -394,10 +401,23 @@ def _offline_skip_exc_types():
         pass
     try:
         from requests.exceptions import ConnectionError as _ReqConnErr
+        from requests.exceptions import Timeout as _ReqTimeout
 
-        types.append(_ReqConnErr)
+        types += [_ReqConnErr, _ReqTimeout]
     except Exception:  # pragma: no cover - requests not present
         pass
+    try:
+        import httpx as _httpx
+
+        # ConnectError/ConnectTimeout/ReadTimeout all subclass TransportError;
+        # use the broad base so any transport-level failure counts as offline.
+        types.append(_httpx.TransportError)
+    except Exception:  # pragma: no cover - httpx not present
+        pass
+    # Python built-in socket-level connection errors (ConnectionRefusedError,
+    # ConnectionResetError, ... all subclass ConnectionError). TimeoutError is a
+    # builtin too (socket timeouts raise it).
+    types += [ConnectionError, TimeoutError]
     return tuple(types)
 
 
@@ -430,8 +450,10 @@ def _is_offline_oserror(exc: BaseException) -> bool:
     (codex r4):
 
       * a TYPED connection exception anywhere in the ``__cause__``/``__context__``
-        chain (``requests.ConnectionError`` / ``huggingface_hub`` offline
-        errors) — the strongest signal, immune to message wording; OR
+        chain — ``requests``/``httpx`` transport errors, ``huggingface_hub``
+        offline errors, or the Python built-in ``ConnectionError``/
+        ``TimeoutError`` family (see ``_offline_skip_exc_types``) — the strongest
+        signal, immune to message wording; OR
       * a message containing an UNAMBIGUOUS connection-failure phrase (never
         emitted for a corrupt local file).
     """
@@ -461,13 +483,30 @@ def test_offline_oserror_classification():
     )
     assert _is_offline_oserror(offline_direct)
 
-    # Generic "Can't load…" wrapping a TYPED connection cause -> offline (skip).
+    # codex r5: prove the TYPED-cause path in isolation. The generic outer
+    # message and the cause message both carry NO offline marker, so this can
+    # only pass via typed-exception detection — deleting the isinstance branch
+    # would flip it red (unlike the old version, which passed on a "Max retries"
+    # string marker and left the typed path untested). ConnectionRefusedError
+    # subclasses the built-in ConnectionError, which is in _offline_skip_exc_types.
     generic_wrap = OSError("Can't load tokenizer for 'x'")
     try:
         try:
-            raise ConnectionError("Max retries exceeded with url: ...")
-        except ConnectionError as cause:
+            raise ConnectionRefusedError(61, "Connection refused")
+        except ConnectionRefusedError as cause:
             raise generic_wrap from cause
+    except OSError as raised:
+        assert _is_offline_oserror(raised)
+
+    # codex r5: an httpx transport error in the chain is also offline (transformers
+    # 5.x uses httpx). Marker-free message -> only the typed path can pass.
+    httpx = pytest.importorskip("httpx")
+    httpx_wrap = OSError("Can't load tokenizer for 'x'")
+    try:
+        try:
+            raise httpx.ConnectError("nope")
+        except httpx.ConnectError as cause:
+            raise httpx_wrap from cause
     except OSError as raised:
         assert _is_offline_oserror(raised)
 

--- a/tests/test_structure_info_hermes_qwen_558.py
+++ b/tests/test_structure_info_hermes_qwen_558.py
@@ -305,6 +305,25 @@ def test_structure_info_substitutes_each_tool_name(family):
 
 
 @pytest.mark.parametrize("family", ["hermes", "qwen"])
+def test_structure_info_json_escapes_tool_name(family):
+    # codex r4 nit: a name containing " or \ must be JSON-escaped so the wire is
+    # well-formed JSON, not broken. json.dumps handles the quoting + escaping.
+    import json
+
+    parser = _make_optin_parser(family)
+    get_info = parser.structure_info()
+    weird = 'weird"na\\me'
+    si = get_info(weird)
+    assert si.begin == f'<tool_call>\n{{"name": {json.dumps(weird)}, "arguments": '
+    # The name region round-trips as valid JSON (extract the "name": <...> part).
+    body = si.begin[len("<tool_call>\n") :]  # {"name": "...", "arguments":
+    name_json = body[len('{"name": ') : body.index(', "arguments": ')]
+    assert json.loads(name_json) == weird
+    # begin still starts with the trigger (builder invariant preserved).
+    assert si.begin.startswith("<tool_call>")
+
+
+@pytest.mark.parametrize("family", ["hermes", "qwen"])
 def test_hermes_and_qwen_share_identical_wire(family):
     # hermes and qwen intentionally emit the SAME wire triple (both are the
     # <tool_call> JSON body). Assert byte-identical triples so the two overrides
@@ -382,34 +401,47 @@ def _offline_skip_exc_types():
     return tuple(types)
 
 
-# Substrings transformers/hub embed in an OSError message when a model is not
-# cached AND the network is unavailable (offline / connection failure). These
-# indicate genuine UNAVAILABILITY -> a sanctioned skip. A corrupt-artifact
-# OSError (bad JSON, truncated file, checksum) carries none of these and must
-# still FAIL the test.
+# Phrases that UNAMBIGUOUSLY mean network/connection failure (offline). We
+# deliberately EXCLUDE transformers' generic "Can't load ... for X" / "look for
+# the file" wording (codex r4): those also front corrupt / incompatible /
+# incomplete artifact errors, so matching them would silently SKIP a real
+# regression. A genuine offline failure says it could not CONNECT — that
+# phrasing never appears for a corrupt local file.
 _OFFLINE_OSERROR_MARKERS = (
     "offline",
     "couldn't connect",
-    "can't load",
-    "cannot find the requested files",
-    "look for the file",
-    "connection error",
-    "not a local folder and is not a valid model identifier",
     "we couldn't connect",
+    "connection error",
     "max retries exceeded",
+    "failed to establish a new connection",
     "failed to connect",
+    "name or service not known",
+    "temporary failure in name resolution",
 )
 
 
 def _is_offline_oserror(exc: BaseException) -> bool:
     """True iff ``exc`` (a bare ``OSError`` from transformers) is an offline /
-    cache-miss wrap rather than a corrupt-artifact error — by inspecting the
-    message and the exception chain (transformers wraps the hub error as
-    ``__cause__``)."""
+    connection-failure wrap rather than a corrupt-artifact error.
+
+    Two independent signals, either sufficient — both narrowly scoped so a
+    corrupt/incompatible tokenizer artifact (which transformers ALSO raises as a
+    generic ``OSError`` with "Can't load…" wording) still FAILS, not skips
+    (codex r4):
+
+      * a TYPED connection exception anywhere in the ``__cause__``/``__context__``
+        chain (``requests.ConnectionError`` / ``huggingface_hub`` offline
+        errors) — the strongest signal, immune to message wording; OR
+      * a message containing an UNAMBIGUOUS connection-failure phrase (never
+        emitted for a corrupt local file).
+    """
+    typed_offline = _offline_skip_exc_types()
     seen = set()
     cur: BaseException | None = exc
     while cur is not None and id(cur) not in seen:
         seen.add(id(cur))
+        if typed_offline and isinstance(cur, typed_offline):
+            return True
         msg = str(cur).lower()
         if any(marker in msg for marker in _OFFLINE_OSERROR_MARKERS):
             return True
@@ -418,26 +450,38 @@ def _is_offline_oserror(exc: BaseException) -> bool:
 
 
 def test_offline_oserror_classification():
-    # codex r3: transformers wraps an offline cache-miss as a bare OSError. The
-    # `tok` fixture must SKIP on that (offline) but FAIL on a corrupt-artifact
-    # OSError. Directly exercise the classifier both ways, incl. the chained
-    # `__cause__` transformers actually sets.
+    # codex r3/r4: transformers wraps an offline cache-miss as a bare OSError.
+    # The `tok` fixture must SKIP on that (offline) but FAIL on a corrupt/
+    # incompatible-artifact OSError — including transformers' GENERIC "Can't
+    # load tokenizer for X" wording, which fronts BOTH offline and corrupt cases
+    # (so message wording alone is insufficient; a typed connection cause is
+    # the load-bearing signal).
     offline_direct = OSError(
         "We couldn't connect to 'https://huggingface.co' to load this file"
     )
     assert _is_offline_oserror(offline_direct)
 
-    # Offline signal buried in the chained cause (how transformers wraps it).
-    chained = OSError("Can't load tokenizer for 'x'")
+    # Generic "Can't load…" wrapping a TYPED connection cause -> offline (skip).
+    generic_wrap = OSError("Can't load tokenizer for 'x'")
     try:
         try:
             raise ConnectionError("Max retries exceeded with url: ...")
         except ConnectionError as cause:
-            raise chained from cause
+            raise generic_wrap from cause
     except OSError as raised:
         assert _is_offline_oserror(raised)
 
-    # A corrupt-artifact OSError carries NO offline marker -> must NOT skip.
+    # codex r4: the SAME generic "Can't load…" wording with NO connection cause
+    # is a corrupt/incompatible artifact -> must NOT skip (must fail). This is
+    # the regression the over-broad "can't load" marker would have wrongly
+    # skipped.
+    corrupt_generic = OSError(
+        "Can't load tokenizer for 'x'. Make sure it is a correct model "
+        "identifier or the tokenizer files are not corrupted."
+    )
+    assert not _is_offline_oserror(corrupt_generic)
+
+    # A corrupt-artifact OSError with unrelated wording -> must NOT skip.
     corrupt = OSError("Unable to load weights: file is not a valid JSON document")
     assert not _is_offline_oserror(corrupt)
 

--- a/tests/test_structure_info_hermes_qwen_558.py
+++ b/tests/test_structure_info_hermes_qwen_558.py
@@ -1,0 +1,374 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Offline tests for the hermes/qwen ``structure_info()`` overrides (#558 PR-2).
+
+PR-1 shipped the grammar builder plus a NON-BREAKING ``structure_info() ->
+None`` ABC default, and proved the builder against a *test-local* hermes-style
+stub. PR-2 lands the concrete per-family overrides on the REAL
+``HermesToolParser`` and ``QwenToolParser`` (which share the
+``<tool_call>…</tool_call>`` JSON-body wire). These tests therefore drive the
+grammar path through the ACTUAL shipped parsers — not a stub — to prove:
+
+  * each real parser's ``structure_info()`` returns a ``name -> StructureInfo``
+    factory whose wire triple is the hermes ``<tool_call>`` JSON body, with the
+    ``<tool_call>``/``</tool_call>`` single special tokens declared as
+    ``sentinels`` (ground-truth correction #1);
+  * feeding a real parser through ``build_tool_grammar`` yields a Lark with the
+    ``<tool_call>`` bare special-token trigger + a ``%json`` schema-constraint
+    region for the ``arguments`` object;
+  * grammar ENFORCEMENT via llguidance ``LLMatcher``: a well-formed hermes/qwen
+    tool call is ACCEPTED in full (and is a terminal/accepting state) while a
+    hallucinated tool name, an off-schema argument, and a bad enum value are
+    REJECTED mid-stream.
+
+Scope note: this PR teaches hermes/qwen to DESCRIBE their grammar; NOTHING in
+the request path calls ``structure_info()`` yet (chat.py/scheduler.py routing +
+the runtime ``GrammarLogitsProcessor`` are PR-3). So these tests are hermetic —
+no server, no decode loop, no live network beyond the pinned tokenizer fetch —
+and the overrides are pure no-behavior-change scaffolding until PR-3 wires them.
+
+The enforcement tests need a fast (Rust) tokenizer whose
+``<tool_call>``/``</tool_call>`` are single special tokens — the pilot verified
+this on ``mlx-community/Qwen3.5-4B-MLX-4bit`` (pinned by revision below for an
+immutable artifact). Those tests skip ONLY on genuine unavailability
+(llguidance extra absent, or the tokenizer neither cached nor reachable); any
+OTHER failure is surfaced, not swallowed. The pure-Python structure-triple and
+Lark-structure tests never skip — they carry no optional dependency.
+"""
+
+import importlib.util
+
+import pytest
+
+# llguidance is only needed by the grammar-BUILD / enforcement tests (they
+# compile a Lark grammar / build an LLTokenizer). The structure-triple and
+# pure-Lark-string tests need NOTHING optional, so we do NOT skip at module
+# level — a repo without the [guided] extra still exercises the real parsers'
+# structure_info triples and the builder's string output.
+_HAS_LLGUIDANCE = importlib.util.find_spec("llguidance") is not None
+_requires_llguidance = pytest.mark.skipif(
+    not _HAS_LLGUIDANCE, reason="llguidance ([guided] extra) not installed"
+)
+
+_TOKENIZER_MODEL = "mlx-community/Qwen3.5-4B-MLX-4bit"
+# Pin the revision so the enforcement proof runs against an IMMUTABLE artifact
+# (an unpinned Hub revision is a mutable third-party dependency). The
+# tokenizer's <tool_call>/</tool_call> single-special-token layout is fixed at
+# this commit; a different upstream revision must not silently change what the
+# enforcement tests exercise. Same pin as tests/test_tool_grammar_558.py.
+_TOKENIZER_REVISION = "32f3e8ecf65426fc3306969496342d504bfa13f3"
+
+TOOLS = [
+    {
+        "name": "get_weather",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "city": {"type": "string"},
+                "unit": {"type": "string", "enum": ["c", "f"]},
+            },
+            "required": ["city"],
+            "additionalProperties": False,
+        },
+    },
+    {
+        "name": "get_time",
+        "parameters": {
+            "type": "object",
+            "properties": {"tz": {"type": "string"}},
+            "required": ["tz"],
+            "additionalProperties": False,
+        },
+    },
+]
+
+# The two families that share the <tool_call>…</tool_call> JSON-body wire and
+# opt into grammar constraint in this PR. Parametrizing over the REAL parser
+# classes proves BOTH overrides (not a shared stub) with one test body.
+_PARSER_IMPORTS = {
+    "hermes": ("vllm_mlx.tool_parsers.hermes_tool_parser", "HermesToolParser"),
+    "qwen": ("vllm_mlx.tool_parsers.qwen_tool_parser", "QwenToolParser"),
+}
+
+
+def _make_parser(family: str, tokenizer=None):
+    import importlib
+
+    module_name, cls_name = _PARSER_IMPORTS[family]
+    cls = getattr(importlib.import_module(module_name), cls_name)
+    return cls(tokenizer=tokenizer)
+
+
+# --------------------------------------------------------------------------
+# structure_info() wire triple (pure Python, always runs — no tokenizer,
+# no llguidance: structure_info() is stateless w.r.t. the tokenizer).
+# --------------------------------------------------------------------------
+@pytest.mark.parametrize("family", ["hermes", "qwen"])
+def test_structure_info_returns_hermes_wire_triple(family):
+    from vllm_mlx.api.tool_grammar import StructureInfo
+
+    parser = _make_parser(family)
+    get_info = parser.structure_info()
+    # PR-2 opt-in: the override returns a name->StructureInfo factory, not None.
+    assert callable(get_info), f"{family}.structure_info() must return a callable"
+
+    si = get_info("get_weather")
+    assert isinstance(si, StructureInfo)
+    # The hermes <tool_call> JSON-body wire, with the concrete tool name
+    # substituted into ``begin``.
+    assert si.trigger == "<tool_call>"
+    assert si.begin == '<tool_call>\n{"name": "get_weather", "arguments": '
+    assert si.end == "}\n</tool_call>"
+    # begin MUST start with trigger (StructTag invariant the builder enforces).
+    assert si.begin.startswith(si.trigger)
+    # Ground-truth correction #1: <tool_call>/</tool_call> are SINGLE special
+    # tokens, so both must be declared as sentinels (the trigger among them) so
+    # the builder renders them as special-token refs, not byte strings.
+    assert si.sentinels == ("<tool_call>", "</tool_call>")
+    assert si.trigger in si.sentinels
+
+
+@pytest.mark.parametrize("family", ["hermes", "qwen"])
+def test_structure_info_substitutes_each_tool_name(family):
+    # The factory substitutes whatever concrete name it is given — one triple
+    # per tool, so a multi-tool request constrains each tool to ITS own schema.
+    parser = _make_parser(family)
+    get_info = parser.structure_info()
+    for name in ("get_weather", "get_time", "any_other_name"):
+        si = get_info(name)
+        assert si.begin == f'<tool_call>\n{{"name": "{name}", "arguments": '
+
+
+@pytest.mark.parametrize("family", ["hermes", "qwen"])
+def test_hermes_and_qwen_share_identical_wire(family):
+    # hermes and qwen intentionally emit the SAME wire triple (both are the
+    # <tool_call> JSON body). Assert byte-identical triples so the two overrides
+    # can never silently diverge.
+    hermes_si = _make_parser("hermes").structure_info()("get_weather")
+    other_si = _make_parser(family).structure_info()("get_weather")
+    assert other_si == hermes_si
+
+
+# --------------------------------------------------------------------------
+# build_tool_grammar / Lark structure via the REAL parsers (needs llguidance).
+# --------------------------------------------------------------------------
+@_requires_llguidance
+@pytest.mark.parametrize("family", ["hermes", "qwen"])
+@pytest.mark.parametrize("tool_choice", ["required", "auto"])
+def test_real_parser_builds_grammar(family, tool_choice):
+    # Driving the REAL parser (not a stub) through the public builder yields a
+    # compiled grammar (non-None) for both required and auto.
+    from vllm_mlx.api.tool_grammar import build_tool_grammar
+
+    parser = _make_parser(family)
+    assert build_tool_grammar(TOOLS, tool_choice, parser) is not None
+
+
+@_requires_llguidance
+@pytest.mark.parametrize("family", ["hermes", "qwen"])
+def test_real_parser_lark_has_trigger_and_schema_region(family):
+    # Assemble the Lark from the REAL parser's structure_info and assert the
+    # load-bearing structure: <tool_call> as a BARE special-token ref (not a
+    # quoted byte literal the single <tool_call> token could never satisfy),
+    # </tool_call> bare closing ref, and a %json schema-constraint region.
+    from vllm_mlx.api.tool_grammar import build_tool_lark
+
+    get_info = _make_parser(family).structure_info()
+    infos = [get_info(t["name"]) for t in TOOLS]
+    lark = build_tool_lark(TOOLS, "required", infos)
+
+    assert " <tool_call> " in lark  # space-delimited bare token ref (trigger)
+    assert lark.rstrip().endswith("</tool_call>")  # bare closing token ref
+    assert '"<tool_call>"' not in lark  # NOT a quoted (multi-byte) literal
+    assert '"</tool_call>"' not in lark
+    assert "%json" in lark  # arguments constrained by JSON Schema
+    assert "get_weather" in lark
+    assert "get_time" in lark
+
+
+# --------------------------------------------------------------------------
+# Grammar ENFORCEMENT via offline LLMatcher (the #558 proof, real parsers).
+#
+# Needs a fast (Rust) tokenizer whose <tool_call>/</tool_call> are single
+# special tokens. The ONLY sanctioned skip is genuine tokenizer/llguidance
+# UNAVAILABILITY (no network + not cached, or the optional extra absent) — any
+# OTHER failure (a real grammar regression, a matcher error, an unexpected
+# tokenizer exception) propagates and FAILS the test.
+# --------------------------------------------------------------------------
+def _offline_skip_exc_types():
+    """Only genuine network/cache-miss errors are a sanctioned skip.
+
+    A corrupt tokenizer artifact, an invalid revision, or a tokenizer/config
+    incompatibility must FAIL the enforcement test, not silently skip it. So we
+    skip ONLY on the specific huggingface_hub offline/cache-miss signals (and a
+    raw connection error), letting every other exception propagate.
+    """
+    types: list[type[BaseException]] = []
+    try:
+        from huggingface_hub.errors import (
+            LocalEntryNotFoundError,
+            OfflineModeIsEnabled,
+        )
+
+        types += [LocalEntryNotFoundError, OfflineModeIsEnabled]
+    except Exception:  # pragma: no cover - old hub without these names
+        pass
+    try:
+        from requests.exceptions import ConnectionError as _ReqConnErr
+
+        types.append(_ReqConnErr)
+    except Exception:  # pragma: no cover - requests not present
+        pass
+    return tuple(types) or (OSError,)
+
+
+@pytest.fixture(scope="module")
+def tok():
+    transformers = pytest.importorskip("transformers")
+    try:
+        return transformers.AutoTokenizer.from_pretrained(
+            _TOKENIZER_MODEL, revision=_TOKENIZER_REVISION
+        )
+    except _offline_skip_exc_types():  # pragma: no cover - offline & uncached
+        pytest.skip(
+            f"tokenizer {_TOKENIZER_MODEL}@{_TOKENIZER_REVISION[:8]} not "
+            "cached and no network — enforcement tests require it"
+        )
+
+
+@pytest.fixture(scope="module")
+def lltok(tok):
+    """Build an llguidance LLTokenizer from the fast (Rust) tokenizer.
+
+    Mirrors ``guided.py``'s tokenizer resolution: try the wrapper's inner fast
+    tokenizer, then the object itself. A slow tokenizer is the one sanctioned
+    skip; a genuine ``from_tokenizer`` regression is NOT swallowed.
+    """
+    import llguidance.hf as llg_hf
+
+    candidates = []
+    inner = getattr(tok, "_tokenizer", None)
+    if inner is not None:
+        candidates.append(inner)
+    candidates.append(tok)
+    fast_candidates = [
+        c for c in candidates if getattr(c, "is_fast", True) is not False
+    ]
+    if not fast_candidates:
+        pytest.skip("tokenizer is not a fast tokenizer — llguidance needs one")
+    last_exc = None
+    for cand in fast_candidates:
+        try:
+            return llg_hf.from_tokenizer(cand)
+        except Exception as exc:  # noqa: BLE001 - re-raised below if all fail
+            last_exc = exc
+    raise AssertionError(
+        f"llguidance could not build an LLTokenizer from any fast candidate: "
+        f"{last_exc!r}"
+    )
+
+
+def _consume(grammar, lltok, tok, text):
+    """Offline enforcement probe. Returns ``(accepted, total, is_accepting)``.
+
+    Advances real grammar state one token at a time via
+    ``LLMatcher.consume_tokens`` (which returns a bool per batch), counting how
+    many tokens the grammar accepts before it rejects one. Because this ADVANCES
+    matcher state, afterwards ``is_accepting()`` reports whether the grammar can
+    TERMINATE there — so a "fully accepted" positive test proves the string is a
+    COMPLETE valid derivation, not merely an accepted prefix.
+    """
+    from llguidance.mlx import LLMatcher
+
+    ids = tok.encode(text, add_special_tokens=False)
+    matcher = LLMatcher(lltok, grammar)
+    assert not matcher.get_error(), matcher.get_error()
+    accepted = 0
+    for tid in ids:
+        if not matcher.consume_tokens([tid]):
+            break
+        accepted += 1
+    return accepted, len(ids), matcher.is_accepting()
+
+
+@_requires_llguidance
+@pytest.mark.parametrize("family", ["hermes", "qwen"])
+def test_valid_call_is_accepted_and_terminates(family, tok, lltok):
+    # A well-formed call through the REAL parser's grammar is accepted in full
+    # AND is a terminal/accepting state (a complete valid derivation).
+    from vllm_mlx.api.tool_grammar import build_tool_grammar
+
+    grammar = build_tool_grammar(TOOLS, "required", _make_parser(family))
+    assert grammar is not None
+    accepted, total, accepting = _consume(
+        grammar,
+        lltok,
+        tok,
+        '<tool_call>\n{"name": "get_weather", "arguments": {"city": "Paris"}}\n</tool_call>',
+    )
+    assert accepted == total, f"valid {family} call rejected ({accepted}/{total})"
+    assert accepting, f"valid complete {family} call is not an accepting state"
+
+
+@_requires_llguidance
+@pytest.mark.parametrize("family", ["hermes", "qwen"])
+def test_valid_enum_value_is_accepted(family, tok, lltok):
+    # Positive enum control (paired with the rejection test below): a VALID enum
+    # value is accepted and terminates — so the rejection test cannot pass merely
+    # because the grammar forbids the optional `unit` property entirely.
+    from vllm_mlx.api.tool_grammar import build_tool_grammar
+
+    grammar = build_tool_grammar(TOOLS, "required", _make_parser(family))
+    accepted, total, accepting = _consume(
+        grammar,
+        lltok,
+        tok,
+        '<tool_call>\n{"name": "get_weather", "arguments": {"city": "P", "unit": "c"}}\n</tool_call>',
+    )
+    assert accepted == total, (
+        f"valid enum value rejected for {family} ({accepted}/{total})"
+    )
+    assert accepting, f"valid enum call is not an accepting state for {family}"
+
+
+@_requires_llguidance
+@pytest.mark.parametrize("family", ["hermes", "qwen"])
+def test_hallucinated_tool_name_is_rejected(family, tok, lltok):
+    from vllm_mlx.api.tool_grammar import build_tool_grammar
+
+    grammar = build_tool_grammar(TOOLS, "required", _make_parser(family))
+    accepted, total, _ = _consume(
+        grammar, lltok, tok, '<tool_call>\n{"name": "get_stockquote'
+    )
+    assert accepted < total, f"hallucinated tool name NOT rejected for {family}"
+
+
+@_requires_llguidance
+@pytest.mark.parametrize("family", ["hermes", "qwen"])
+def test_off_schema_argument_is_rejected(family, tok, lltok):
+    # `city` must be a string; an integer must be forbidden.
+    from vllm_mlx.api.tool_grammar import build_tool_grammar
+
+    grammar = build_tool_grammar(TOOLS, "required", _make_parser(family))
+    accepted, total, _ = _consume(
+        grammar,
+        lltok,
+        tok,
+        '<tool_call>\n{"name": "get_weather", "arguments": {"city": 4',
+    )
+    assert accepted < total, f"off-schema integer argument NOT rejected for {family}"
+
+
+@_requires_llguidance
+@pytest.mark.parametrize("family", ["hermes", "qwen"])
+def test_bad_enum_value_is_rejected(family, tok, lltok):
+    # `unit` enum is {c, f}; "kelvin" must be forbidden.
+    from vllm_mlx.api.tool_grammar import build_tool_grammar
+
+    grammar = build_tool_grammar(TOOLS, "required", _make_parser(family))
+    accepted, total, _ = _consume(
+        grammar,
+        lltok,
+        tok,
+        '<tool_call>\n{"name": "get_weather", "arguments": {"city": "P", "unit": "kelvin',
+    )
+    assert accepted < total, f"invalid enum value NOT rejected for {family}"

--- a/tests/test_structure_info_hermes_qwen_558.py
+++ b/tests/test_structure_info_hermes_qwen_558.py
@@ -94,38 +94,57 @@ _PARSER_IMPORTS = {
 }
 
 
+class _FakeAddedToken:
+    """Stand-in for transformers' ``AddedToken`` — carries a ``special`` flag.
+
+    GROUND TRUTH: on the real Qwen3.5 tokenizer, ``<tool_call>``/``</tool_call>``
+    are ADDED tokens with ``special=False``. The guard must accept them, so it
+    keys on added-token REGISTRATION (``added_tokens_decoder`` membership), NOT
+    the ``special`` flag — this stub defaults ``special=False`` to hold the guard
+    to that reality.
+    """
+
+    def __init__(self, content, special=False):
+        self.content = content
+        self.special = special
+
+
 class _FakeTokenizer:
     """Minimal tokenizer stub modeling the surfaces the guard probes.
 
     ``structure_info()`` opts into grammar constraint only when the model's
     tokenizer proves ``<tool_call>``/``</tool_call>`` are DISTINCT single
-    REGISTERED special tokens (the hermes parser is also routed to Llama
-    tokenizers where they are NOT). The guard checks: ``len(encode(s)) == 1``,
-    ``decode([id]) == s`` (round-trip), the id is in ``added_tokens_decoder``
-    (registered special), and distinct ids across sentinels. This stub lets the
-    pure-Python tests exercise every opt-in/opt-out branch WITHOUT a network
-    fetch, so they stay hermetic and never skip.
+    REGISTERED added tokens that round-trip (the hermes parser is also routed to
+    Llama tokenizers where they are NOT). The guard checks: ``len(encode(s)) ==
+    1``, ``decode([id]) == s`` (round-trip), the id is in
+    ``added_tokens_decoder`` (explicitly-added atomic token), and distinct ids
+    across sentinels. This stub lets the pure-Python tests exercise every
+    opt-in/opt-out branch WITHOUT a network fetch, so they stay hermetic.
 
-    ``specials`` maps each special string to its single id (registered special,
-    round-trips). Any other string encodes as multi-token (opt-out path).
-    ``ordinary`` maps a string to a single id that round-trips but is NOT a
-    registered special (ordinary-vocab opt-out case). ``collapse`` maps strings
+    ``added`` maps each ADDED-token string to its single id (round-trips, in
+    ``added_tokens_decoder`` — modeled with ``special=False`` to match the real
+    Qwen tokenizer). Any other string encodes as multi-token (opt-out path).
+    ``ordinary`` maps a string to a single id that round-trips but is NOT in the
+    added-token registry (ordinary-BPE opt-out case). ``collapse`` maps strings
     to a shared single id that does NOT round-trip (``[UNK]`` collapse case).
     """
 
-    def __init__(self, specials=None, ordinary=None, collapse=None):
-        self._specials = dict(specials or {})
+    def __init__(self, added=None, ordinary=None, collapse=None):
+        self._added = dict(added or {})
         self._ordinary = dict(ordinary or {})
         self._collapse = dict(collapse or {})
-        # id -> source string, for round-trip decode of specials + ordinary.
-        self._id_to_str = {i: s for s, i in self._specials.items()}
+        # id -> source string, for round-trip decode of added + ordinary.
+        self._id_to_str = {i: s for s, i in self._added.items()}
         self._id_to_str.update({i: s for s, i in self._ordinary.items()})
-        # added_tokens_decoder: only the registered specials.
-        self.added_tokens_decoder = {i: object() for i in self._specials.values()}
+        # added_tokens_decoder: {id: AddedToken(special=False)} — matches the
+        # real Qwen layout where <tool_call> is an added but non-special token.
+        self.added_tokens_decoder = {
+            i: _FakeAddedToken(s, special=False) for s, i in self._added.items()
+        }
 
     def encode(self, text, add_special_tokens=False):
-        if text in self._specials:
-            return [self._specials[text]]
+        if text in self._added:
+            return [self._added[text]]
         if text in self._ordinary:
             return [self._ordinary[text]]
         if text in self._collapse:
@@ -137,18 +156,19 @@ class _FakeTokenizer:
 
 
 def _single_token_tokenizer():
-    """Qwen3-like: both sentinels are distinct single registered specials."""
-    return _FakeTokenizer(specials={"<tool_call>": 100, "</tool_call>": 101})
+    """Qwen3-like: both sentinels are distinct single ADDED (special=False)
+    tokens that round-trip -> opt in (the real Qwen layout)."""
+    return _FakeTokenizer(added={"<tool_call>": 100, "</tool_call>": 101})
 
 
 def _multitoken_tokenizer():
     """Llama-Hermes-like: neither sentinel is a single token -> opt out."""
-    return _FakeTokenizer(specials={})
+    return _FakeTokenizer(added={})
 
 
 def _ordinary_vocab_tokenizer():
-    """Both sentinels are single tokens that round-trip but are NOT registered
-    special tokens -> opt out (special-ref semantics would not match)."""
+    """Both sentinels are single tokens that round-trip but are NOT in the
+    added-token registry (ordinary BPE tokens) -> opt out."""
     return _FakeTokenizer(ordinary={"<tool_call>": 100, "</tool_call>": 101})
 
 
@@ -218,9 +238,29 @@ def test_structure_info_opts_out_on_unk_collapse(family):
 
 @pytest.mark.parametrize("family", ["hermes", "qwen"])
 def test_structure_info_opts_in_on_single_token_tokenizer(family):
-    # A tokenizer where both sentinels ARE distinct single registered specials
-    # (Qwen3-like) -> opt in.
+    # A tokenizer where both sentinels ARE distinct single added tokens that
+    # round-trip (Qwen3-like) -> opt in.
     parser = _make_parser(family, tokenizer=_single_token_tokenizer())
+    assert parser.structure_info() is not None
+
+
+@pytest.mark.parametrize("family", ["hermes", "qwen"])
+def test_structure_info_opts_in_on_non_special_added_token(family):
+    # GROUND-TRUTH regression (codex r3): on the REAL Qwen3.5 tokenizer,
+    # <tool_call>/</tool_call> are ADDED tokens with AddedToken.special == False
+    # (and NOT in all_special_ids). They are still distinct atomic tokens a
+    # grammar special-token ref resolves against (the enforcement tests below
+    # pass on exactly this tokenizer). The guard MUST key on added-token
+    # REGISTRATION, not the `special` flag — gating on special==True would break
+    # the feature for its own target tokenizer. `_single_token_tokenizer` models
+    # special=False added tokens, so this asserting opt-in is the regression.
+    from vllm_mlx.api.tool_grammar import are_single_special_tokens
+
+    tokenizer = _single_token_tokenizer()
+    # Every modeled added token carries special=False (matches real Qwen).
+    assert all(at.special is False for at in tokenizer.added_tokens_decoder.values())
+    assert are_single_special_tokens(tokenizer, ("<tool_call>", "</tool_call>"))
+    parser = _make_parser(family, tokenizer=tokenizer)
     assert parser.structure_info() is not None
 
 
@@ -322,13 +362,7 @@ def test_real_parser_lark_has_trigger_and_schema_region(family):
 # tokenizer exception) propagates and FAILS the test.
 # --------------------------------------------------------------------------
 def _offline_skip_exc_types():
-    """Only genuine network/cache-miss errors are a sanctioned skip.
-
-    A corrupt tokenizer artifact, an invalid revision, or a tokenizer/config
-    incompatibility must FAIL the enforcement test, not silently skip it. So we
-    skip ONLY on the specific huggingface_hub offline/cache-miss signals (and a
-    raw connection error), letting every other exception propagate.
-    """
+    """huggingface_hub / requests offline signals that are ALWAYS a skip."""
     types: list[type[BaseException]] = []
     try:
         from huggingface_hub.errors import (
@@ -345,7 +379,67 @@ def _offline_skip_exc_types():
         types.append(_ReqConnErr)
     except Exception:  # pragma: no cover - requests not present
         pass
-    return tuple(types) or (OSError,)
+    return tuple(types)
+
+
+# Substrings transformers/hub embed in an OSError message when a model is not
+# cached AND the network is unavailable (offline / connection failure). These
+# indicate genuine UNAVAILABILITY -> a sanctioned skip. A corrupt-artifact
+# OSError (bad JSON, truncated file, checksum) carries none of these and must
+# still FAIL the test.
+_OFFLINE_OSERROR_MARKERS = (
+    "offline",
+    "couldn't connect",
+    "can't load",
+    "cannot find the requested files",
+    "look for the file",
+    "connection error",
+    "not a local folder and is not a valid model identifier",
+    "we couldn't connect",
+    "max retries exceeded",
+    "failed to connect",
+)
+
+
+def _is_offline_oserror(exc: BaseException) -> bool:
+    """True iff ``exc`` (a bare ``OSError`` from transformers) is an offline /
+    cache-miss wrap rather than a corrupt-artifact error — by inspecting the
+    message and the exception chain (transformers wraps the hub error as
+    ``__cause__``)."""
+    seen = set()
+    cur: BaseException | None = exc
+    while cur is not None and id(cur) not in seen:
+        seen.add(id(cur))
+        msg = str(cur).lower()
+        if any(marker in msg for marker in _OFFLINE_OSERROR_MARKERS):
+            return True
+        cur = cur.__cause__ or cur.__context__
+    return False
+
+
+def test_offline_oserror_classification():
+    # codex r3: transformers wraps an offline cache-miss as a bare OSError. The
+    # `tok` fixture must SKIP on that (offline) but FAIL on a corrupt-artifact
+    # OSError. Directly exercise the classifier both ways, incl. the chained
+    # `__cause__` transformers actually sets.
+    offline_direct = OSError(
+        "We couldn't connect to 'https://huggingface.co' to load this file"
+    )
+    assert _is_offline_oserror(offline_direct)
+
+    # Offline signal buried in the chained cause (how transformers wraps it).
+    chained = OSError("Can't load tokenizer for 'x'")
+    try:
+        try:
+            raise ConnectionError("Max retries exceeded with url: ...")
+        except ConnectionError as cause:
+            raise chained from cause
+    except OSError as raised:
+        assert _is_offline_oserror(raised)
+
+    # A corrupt-artifact OSError carries NO offline marker -> must NOT skip.
+    corrupt = OSError("Unable to load weights: file is not a valid JSON document")
+    assert not _is_offline_oserror(corrupt)
 
 
 @pytest.fixture(scope="module")
@@ -360,6 +454,17 @@ def tok():
             f"tokenizer {_TOKENIZER_MODEL}@{_TOKENIZER_REVISION[:8]} not "
             "cached and no network — enforcement tests require it"
         )
+    except OSError as exc:  # pragma: no cover - transformers-wrapped offline
+        # transformers commonly wraps an offline cache-miss as a bare OSError.
+        # Skip ONLY when the message/chain proves offline/cache-miss; a
+        # corrupt-artifact OSError has no offline marker and re-raises (fails).
+        if _is_offline_oserror(exc):
+            pytest.skip(
+                f"tokenizer {_TOKENIZER_MODEL}@{_TOKENIZER_REVISION[:8]} not "
+                "cached and no network (transformers OSError) — enforcement "
+                "tests require it"
+            )
+        raise
 
 
 @pytest.fixture(scope="module")

--- a/vllm_mlx/api/tool_grammar.py
+++ b/vllm_mlx/api/tool_grammar.py
@@ -74,12 +74,40 @@ class StructureInfo:
     sentinels: tuple[str, ...] = field(default=())
 
 
+def _is_registered_special(tokenizer: Any, tok_id: int) -> bool:
+    """True iff ``tok_id`` is a REGISTERED special/added token on ``tokenizer``.
+
+    ``len(encode(s)) == 1`` is necessary but NOT sufficient to render ``s`` as a
+    Lark special-token ref: an ordinary single vocabulary token is not a special
+    token, and an unknown string may collapse to a single ``[UNK]`` id. The
+    grammar builder emits ``<s>`` as a special-token reference, whose semantics
+    only match a token the tokenizer treats as special. So we additionally
+    require the id to appear in the tokenizer's added/special-token registry.
+
+    Probes the HF fast-tokenizer surfaces in order, degrading to ``False``
+    (conservative: caller opts out) if none are available or any raises — a
+    tokenizer that cannot prove special registration must not opt in.
+    """
+    # transformers fast tokenizers expose ``added_tokens_decoder``: {id: AddedToken}.
+    decoder = getattr(tokenizer, "added_tokens_decoder", None)
+    if isinstance(decoder, dict):
+        return tok_id in decoder
+    # Fallback: all_special_ids (covers slow tokenizers / older transformers).
+    try:
+        special_ids = getattr(tokenizer, "all_special_ids", None)
+        if special_ids is not None:
+            return tok_id in set(special_ids)
+    except Exception:
+        pass
+    return False
+
+
 def are_single_special_tokens(tokenizer: Any, candidates: tuple[str, ...]) -> bool:
-    """True iff EVERY candidate encodes to exactly one token on ``tokenizer``.
+    """True iff EVERY candidate is a DISTINCT single registered special token.
 
     A per-family ``structure_info()`` declares its ``<...>`` sentinels as
     special-token refs (see ``StructureInfo.sentinels``) ONLY when the model's
-    tokenizer actually encodes each one as a single token — this is the
+    tokenizer actually encodes each one as a single special token — this is the
     ground-truth-correction-#1 assumption (``<tool_call>``/``</tool_call>`` are
     single special tokens in Qwen3/Hermes tokenizers). It is NOT universal: the
     same ``hermes`` wire on a Llama-based Hermes tokenizer encodes
@@ -90,15 +118,31 @@ def are_single_special_tokens(tokenizer: Any, candidates: tuple[str, ...]) -> bo
     fall back to today's free-form-then-parse behavior rather than emit a
     grammar its tokenizer can never satisfy.
 
+    ``len(encode(s)) == 1`` alone is NOT enough (codex review): it also accepts
+    a string that collapses to a single ``[UNK]`` id or resolves to an ordinary
+    (non-special) vocabulary token, either of which yields an unenforceable
+    special-token grammar. So each candidate must ALSO:
+
+      * round-trip: ``decode([id]) == s`` (rejects ``[UNK]`` collapse / lossy
+        normalization — an unknown sentinel decoding to ``"<unk>"`` fails here);
+      * be a REGISTERED special/added token (rejects an ordinary single vocab
+        token whose special-ref semantics would not match);
+      * resolve to an id DISTINCT from every other candidate (rejects two
+        sentinels collapsing to the same id — e.g. both to ``[UNK]`` — which
+        would make the open/close tags grammar-indistinguishable).
+
     Returns ``False`` (conservative: caller opts out) when the tokenizer is
-    absent or lacks ``encode`` / raises — grammar constraint is a best-effort
-    opt-in, never a hard requirement, so an unknown tokenizer degrades safely.
+    absent or lacks ``encode``/``decode`` / raises — grammar constraint is a
+    best-effort opt-in, never a hard requirement, so an unknown or partially
+    featured tokenizer degrades safely to free-form.
     """
     if tokenizer is None:
         return False
     encode = getattr(tokenizer, "encode", None)
-    if encode is None:
+    decode = getattr(tokenizer, "decode", None)
+    if encode is None or decode is None:
         return False
+    seen_ids: set[int] = set()
     for tok_str in candidates:
         try:
             ids = encode(tok_str, add_special_tokens=False)
@@ -107,6 +151,20 @@ def are_single_special_tokens(tokenizer: Any, candidates: tuple[str, ...]) -> bo
             # status -> conservatively report False so the family opts out.
             return False
         if len(ids) != 1:
+            return False
+        tok_id = ids[0]
+        if tok_id in seen_ids:
+            return False  # two sentinels collapsed to the same id (e.g. [UNK])
+        seen_ids.add(tok_id)
+        # Round-trip: the single id must decode back to the exact candidate.
+        # Rejects [UNK] collapse and any lossy normalization.
+        try:
+            if decode([tok_id]) != tok_str:
+                return False
+        except Exception:
+            return False
+        # Must be a registered special/added token, not an ordinary vocab token.
+        if not _is_registered_special(tokenizer, tok_id):
             return False
     return True
 

--- a/vllm_mlx/api/tool_grammar.py
+++ b/vllm_mlx/api/tool_grammar.py
@@ -74,6 +74,43 @@ class StructureInfo:
     sentinels: tuple[str, ...] = field(default=())
 
 
+def are_single_special_tokens(tokenizer: Any, candidates: tuple[str, ...]) -> bool:
+    """True iff EVERY candidate encodes to exactly one token on ``tokenizer``.
+
+    A per-family ``structure_info()`` declares its ``<...>`` sentinels as
+    special-token refs (see ``StructureInfo.sentinels``) ONLY when the model's
+    tokenizer actually encodes each one as a single token — this is the
+    ground-truth-correction-#1 assumption (``<tool_call>``/``</tool_call>`` are
+    single special tokens in Qwen3/Hermes tokenizers). It is NOT universal: the
+    same ``hermes`` wire on a Llama-based Hermes tokenizer encodes
+    ``<tool_call>`` as ordinary multi-token text, where declaring it a
+    special-token sentinel would build an UNENFORCEABLE grammar (the model has
+    no single ``<tool_call>`` token to satisfy the ref). A family that cannot
+    prove single-token sentinels must OPT OUT (``structure_info() -> None``) and
+    fall back to today's free-form-then-parse behavior rather than emit a
+    grammar its tokenizer can never satisfy.
+
+    Returns ``False`` (conservative: caller opts out) when the tokenizer is
+    absent or lacks ``encode`` / raises — grammar constraint is a best-effort
+    opt-in, never a hard requirement, so an unknown tokenizer degrades safely.
+    """
+    if tokenizer is None:
+        return False
+    encode = getattr(tokenizer, "encode", None)
+    if encode is None:
+        return False
+    for tok_str in candidates:
+        try:
+            ids = encode(tok_str, add_special_tokens=False)
+        except Exception:
+            # A tokenizer that rejects the probe cannot prove single-token
+            # status -> conservatively report False so the family opts out.
+            return False
+        if len(ids) != 1:
+            return False
+    return True
+
+
 def _lark_escape(s: str) -> str:
     """Render ``s`` as a Lark double-quoted string literal (JSON-escaped)."""
     if not s:

--- a/vllm_mlx/api/tool_grammar.py
+++ b/vllm_mlx/api/tool_grammar.py
@@ -74,25 +74,45 @@ class StructureInfo:
     sentinels: tuple[str, ...] = field(default=())
 
 
-def _is_registered_special(tokenizer: Any, tok_id: int) -> bool:
-    """True iff ``tok_id`` is a REGISTERED special/added token on ``tokenizer``.
+def _is_registered_added_token(tokenizer: Any, tok_id: int) -> bool:
+    """True iff ``tok_id`` is an EXPLICITLY-REGISTERED added/special token.
 
     ``len(encode(s)) == 1`` is necessary but NOT sufficient to render ``s`` as a
-    Lark special-token ref: an ordinary single vocabulary token is not a special
-    token, and an unknown string may collapse to a single ``[UNK]`` id. The
-    grammar builder emits ``<s>`` as a special-token reference, whose semantics
-    only match a token the tokenizer treats as special. So we additionally
-    require the id to appear in the tokenizer's added/special-token registry.
+    Lark special-token ref: an ordinary single BPE-merge vocabulary token (e.g.
+    ``"hello"``) is not a referenceable atomic token, and an unknown string may
+    collapse to a single ``[UNK]`` id. The grammar builder emits ``<s>`` as a
+    special-token reference that only resolves against a token the tokenizer
+    holds as an EXPLICITLY-ADDED atomic entry (the tokenizer will never split
+    such a token further, so the model can emit it as one piece). So we require
+    the id to appear in the tokenizer's added-token registry.
 
-    Probes the HF fast-tokenizer surfaces in order, degrading to ``False``
-    (conservative: caller opts out) if none are available or any raises — a
-    tokenizer that cannot prove special registration must not opt in.
+    GROUND TRUTH (verified on the pinned Qwen3.5 tokenizer, 2026-07): its
+    ``<tool_call>``/``</tool_call>`` added tokens carry ``AddedToken.special ==
+    False`` and are NOT in ``all_special_ids`` — yet they ARE distinct atomic
+    added tokens the grammar's special-token ref resolves against (the #558
+    enforcement tests pass on exactly this tokenizer). We therefore key on
+    ADDED-TOKEN registration (``added_tokens_decoder`` membership), NOT the HF
+    ``special`` flag: gating on ``special==True`` / ``all_special_ids`` would
+    wrongly REJECT the real target's ``<tool_call>`` and disable the feature for
+    the very tokenizer it ships for. The ``special`` flag distinguishes control
+    tokens (``<|endoftext|>``) from added content tokens; both are atomic and
+    both are valid special-token-ref targets, so it is not the right gate here.
+
+    What this correctly REJECTS: an ordinary BPE token not in the added-token
+    registry (``"hello"`` -> not in ``added_tokens_decoder`` -> False). Probes
+    the added-token surface, then falls back to ``all_special_ids`` for
+    tokenizers that expose no ``added_tokens_decoder`` (older/slow). Degrades to
+    ``False`` (caller opts out) if neither is available or any raises.
     """
     # transformers fast tokenizers expose ``added_tokens_decoder``: {id: AddedToken}.
+    # Membership means the id is an explicitly-added atomic token (special flag
+    # irrelevant — see docstring GROUND TRUTH).
     decoder = getattr(tokenizer, "added_tokens_decoder", None)
     if isinstance(decoder, dict):
         return tok_id in decoder
-    # Fallback: all_special_ids (covers slow tokenizers / older transformers).
+    # Fallback for tokenizers without added_tokens_decoder: all_special_ids
+    # (control tokens). This path only sees special==True ids, which is fine —
+    # it is a strictly-narrower best-effort fallback, not the primary gate.
     try:
         special_ids = getattr(tokenizer, "all_special_ids", None)
         if special_ids is not None:
@@ -125,8 +145,10 @@ def are_single_special_tokens(tokenizer: Any, candidates: tuple[str, ...]) -> bo
 
       * round-trip: ``decode([id]) == s`` (rejects ``[UNK]`` collapse / lossy
         normalization — an unknown sentinel decoding to ``"<unk>"`` fails here);
-      * be a REGISTERED special/added token (rejects an ordinary single vocab
-        token whose special-ref semantics would not match);
+      * be an EXPLICITLY-REGISTERED added token (rejects an ordinary single
+        BPE-merge vocab token — e.g. ``"hello"`` — that is not a referenceable
+        atomic token; keys on added-token registration, NOT the HF ``special``
+        flag, because the real Qwen ``<tool_call>`` is ``special=False``);
       * resolve to an id DISTINCT from every other candidate (rejects two
         sentinels collapsing to the same id — e.g. both to ``[UNK]`` — which
         would make the open/close tags grammar-indistinguishable).
@@ -163,8 +185,10 @@ def are_single_special_tokens(tokenizer: Any, candidates: tuple[str, ...]) -> bo
                 return False
         except Exception:
             return False
-        # Must be a registered special/added token, not an ordinary vocab token.
-        if not _is_registered_special(tokenizer, tok_id):
+        # Must be an explicitly-registered added token, not an ordinary BPE
+        # vocab token (see _is_registered_added_token — keyed on added-token
+        # registration, not the HF ``special`` flag).
+        if not _is_registered_added_token(tokenizer, tok_id):
             return False
     return True
 

--- a/vllm_mlx/tool_parsers/hermes_tool_parser.py
+++ b/vllm_mlx/tool_parsers/hermes_tool_parser.py
@@ -339,7 +339,11 @@ class HermesToolParser(ToolParser):
             return None
 
         def _info(name: str):
-            begin = f'<tool_call>\n{{"name": "{name}", "arguments": '
+            # JSON-encode ``name`` so a name containing ``"`` or ``\`` yields a
+            # well-formed JSON string literal in the wire, not a broken one
+            # (json.dumps adds the surrounding quotes and escapes). ``begin``
+            # still starts with the ``<tool_call>`` trigger (builder invariant).
+            begin = f'<tool_call>\n{{"name": {json.dumps(name)}, "arguments": '
             end = "}\n</tool_call>"
             return StructureInfo(
                 begin=begin,

--- a/vllm_mlx/tool_parsers/hermes_tool_parser.py
+++ b/vllm_mlx/tool_parsers/hermes_tool_parser.py
@@ -308,6 +308,8 @@ class HermesToolParser(ToolParser):
             return None
         return None
 
+    _GRAMMAR_SENTINELS = ("<tool_call>", "</tool_call>")
+
     def structure_info(self):
         """Grammar-constraint wire triple for the hermes ``<tool_call>`` JSON
         body (#558). ``<tool_call>`` / ``</tool_call>`` are single special
@@ -317,8 +319,24 @@ class HermesToolParser(ToolParser):
         Schema via ``%json`` (injected by ``build_tool_lark``).
 
         Wire: ``<tool_call>\n{"name": "NAME", "arguments": <schema>}\n</tool_call>``
+
+        The ``hermes`` parser is routed to families with DIFFERENT tokenizers
+        (Qwen3, Nous-Hermes-on-Llama, Phi, Gemma, Granite, …). The
+        single-special-token assumption only holds where the tokenizer actually
+        encodes ``<tool_call>``/``</tool_call>`` as one token each (e.g. Qwen3).
+        On a Llama-based Hermes tokenizer they are ordinary multi-token text, so
+        a special-token sentinel would build an UNENFORCEABLE grammar. We
+        therefore OPT OUT (return ``None`` -> free-form-then-parse fallback)
+        unless the model's tokenizer proves both sentinels are single tokens.
+        Grammar constraint is a best-effort opt-in, never a hard requirement.
         """
-        from vllm_mlx.api.tool_grammar import StructureInfo
+        from vllm_mlx.api.tool_grammar import (
+            StructureInfo,
+            are_single_special_tokens,
+        )
+
+        if not are_single_special_tokens(self.model_tokenizer, self._GRAMMAR_SENTINELS):
+            return None
 
         def _info(name: str):
             begin = f'<tool_call>\n{{"name": "{name}", "arguments": '
@@ -327,7 +345,7 @@ class HermesToolParser(ToolParser):
                 begin=begin,
                 end=end,
                 trigger="<tool_call>",
-                sentinels=("<tool_call>", "</tool_call>"),
+                sentinels=self._GRAMMAR_SENTINELS,
             )
 
         return _info

--- a/vllm_mlx/tool_parsers/hermes_tool_parser.py
+++ b/vllm_mlx/tool_parsers/hermes_tool_parser.py
@@ -308,6 +308,30 @@ class HermesToolParser(ToolParser):
             return None
         return None
 
+    def structure_info(self):
+        """Grammar-constraint wire triple for the hermes ``<tool_call>`` JSON
+        body (#558). ``<tool_call>`` / ``</tool_call>`` are single special
+        tokens in Qwen3/Hermes tokenizers, so they are declared as
+        ``sentinels`` and rendered as Lark special-token refs by the grammar
+        builder. The arguments object is constrained by the tool's JSON
+        Schema via ``%json`` (injected by ``build_tool_lark``).
+
+        Wire: ``<tool_call>\n{"name": "NAME", "arguments": <schema>}\n</tool_call>``
+        """
+        from vllm_mlx.api.tool_grammar import StructureInfo
+
+        def _info(name: str):
+            begin = f'<tool_call>\n{{"name": "{name}", "arguments": '
+            end = "}\n</tool_call>"
+            return StructureInfo(
+                begin=begin,
+                end=end,
+                trigger="<tool_call>",
+                sentinels=("<tool_call>", "</tool_call>"),
+            )
+
+        return _info
+
     def extract_tool_calls(
         self, model_output: str, request: dict[str, Any] | None = None
     ) -> ExtractedToolCallInformation:

--- a/vllm_mlx/tool_parsers/qwen_tool_parser.py
+++ b/vllm_mlx/tool_parsers/qwen_tool_parser.py
@@ -81,7 +81,11 @@ class QwenToolParser(ToolParser):
             return None
 
         def _info(name: str):
-            begin = f'<tool_call>\n{{"name": "{name}", "arguments": '
+            # JSON-encode ``name`` so a name containing ``"`` or ``\`` yields a
+            # well-formed JSON string literal in the wire (json.dumps adds the
+            # surrounding quotes and escapes). ``begin`` still starts with the
+            # ``<tool_call>`` trigger (builder invariant).
+            begin = f'<tool_call>\n{{"name": {json.dumps(name)}, "arguments": '
             end = "}\n</tool_call>"
             return StructureInfo(
                 begin=begin,

--- a/vllm_mlx/tool_parsers/qwen_tool_parser.py
+++ b/vllm_mlx/tool_parsers/qwen_tool_parser.py
@@ -53,6 +53,31 @@ class QwenToolParser(ToolParser):
     # Pattern for bracket-style: [Calling tool: func_name({...})]
     BRACKET_PATTERN = re.compile(r"\[Calling tool:\s*(\w+)\((\{.*?\})\)\]", re.DOTALL)
 
+    def structure_info(self):
+        """Grammar-constraint wire triple for the qwen ``<tool_call>`` JSON
+        body (#558). Qwen shares the hermes ``<tool_call>…</tool_call>`` wire:
+        ``<tool_call>`` / ``</tool_call>`` are single special tokens in
+        Qwen3/Hermes tokenizers, so they are declared as ``sentinels`` and
+        rendered as Lark special-token refs by the grammar builder. The
+        arguments object is constrained by the tool's JSON Schema via ``%json``
+        (injected by ``build_tool_lark``).
+
+        Wire: ``<tool_call>\n{"name": "NAME", "arguments": <schema>}\n</tool_call>``
+        """
+        from vllm_mlx.api.tool_grammar import StructureInfo
+
+        def _info(name: str):
+            begin = f'<tool_call>\n{{"name": "{name}", "arguments": '
+            end = "}\n</tool_call>"
+            return StructureInfo(
+                begin=begin,
+                end=end,
+                trigger="<tool_call>",
+                sentinels=("<tool_call>", "</tool_call>"),
+            )
+
+        return _info
+
     def extract_tool_calls(
         self, model_output: str, request: dict[str, Any] | None = None
     ) -> ExtractedToolCallInformation:

--- a/vllm_mlx/tool_parsers/qwen_tool_parser.py
+++ b/vllm_mlx/tool_parsers/qwen_tool_parser.py
@@ -53,6 +53,8 @@ class QwenToolParser(ToolParser):
     # Pattern for bracket-style: [Calling tool: func_name({...})]
     BRACKET_PATTERN = re.compile(r"\[Calling tool:\s*(\w+)\((\{.*?\})\)\]", re.DOTALL)
 
+    _GRAMMAR_SENTINELS = ("<tool_call>", "</tool_call>")
+
     def structure_info(self):
         """Grammar-constraint wire triple for the qwen ``<tool_call>`` JSON
         body (#558). Qwen shares the hermes ``<tool_call>…</tool_call>`` wire:
@@ -63,8 +65,20 @@ class QwenToolParser(ToolParser):
         (injected by ``build_tool_lark``).
 
         Wire: ``<tool_call>\n{"name": "NAME", "arguments": <schema>}\n</tool_call>``
+
+        As on the hermes parser, we OPT OUT (return ``None`` -> free-form
+        fallback) unless the model's tokenizer proves both sentinels are single
+        tokens — a special-token sentinel on a tokenizer that encodes
+        ``<tool_call>`` as multi-token text would build an unenforceable
+        grammar. Grammar constraint is a best-effort opt-in, never required.
         """
-        from vllm_mlx.api.tool_grammar import StructureInfo
+        from vllm_mlx.api.tool_grammar import (
+            StructureInfo,
+            are_single_special_tokens,
+        )
+
+        if not are_single_special_tokens(self.model_tokenizer, self._GRAMMAR_SENTINELS):
+            return None
 
         def _info(name: str):
             begin = f'<tool_call>\n{{"name": "{name}", "arguments": '
@@ -73,7 +87,7 @@ class QwenToolParser(ToolParser):
                 begin=begin,
                 end=end,
                 trigger="<tool_call>",
-                sentinels=("<tool_call>", "</tool_call>"),
+                sentinels=self._GRAMMAR_SENTINELS,
             )
 
         return _info


### PR DESCRIPTION
## What

PR-2 of the #558 constrained-tool-calling feature. Lands the per-family `structure_info()` overrides on the REAL `HermesToolParser` and `QwenToolParser` (both share the `<tool_call>…</tool_call>` JSON-body wire), plus offline grammar-validation tests. Builds on PR-1 (#1133 / `05f71e12`), which shipped the grammar builder + the non-breaking `structure_info() -> None` ABC default.

Each override returns a `name -> StructureInfo(begin, end, trigger, sentinels)` factory describing the family's tool-call wire, so the PR-1 builder can assemble an llguidance grammar that structurally guarantees a call names a real tool whose `arguments` satisfy that tool's JSON Schema.

**Ground-truth correction #1:** `<tool_call>` / `</tool_call>` are SINGLE tokens (ids 248058/248059) in Qwen3/Hermes tokenizers, so both flow through the builder's special-token `sentinels` mechanism (the trigger among them) — they render as Lark special-token refs, not multi-byte byte-strings the model's single sentinel token could never satisfy.

## Tokenizer-aware opt-in/opt-out (correctness)

The `hermes` parser is routed (`model_auto_config.py`) to families with DIFFERENT tokenizers — Qwen3, Nous-Hermes-on-Llama, Phi, Gemma, Granite. The single-token assumption only holds on some (Qwen3); on a Llama-based Hermes tokenizer `<tool_call>` is ordinary multi-token text, where a special-token sentinel would build an UNENFORCEABLE grammar. So `structure_info()` is **tokenizer-aware**: a new `tool_grammar.are_single_special_tokens(tokenizer, candidates)` helper gates both parsers — opt in only when every sentinel is a DISTINCT single token that ROUND-TRIPS (`decode([id]) == s`, rejecting `[UNK]` collapse) and is an EXPLICITLY-REGISTERED added token (rejecting an ordinary BPE token). GROUND TRUTH: the real Qwen `<tool_call>` is an `AddedToken` with `special=False`, so the gate keys on added-token REGISTRATION, not the HF `special` flag (gating on `special==True` would break the feature for its own target tokenizer). Otherwise OPT OUT (`None` -> free-form fallback, which the builder already handles). Grammar constraint is best-effort opt-in, never a hard requirement.

## No behavior change

This PR only teaches hermes/qwen to **describe** their grammar. Nothing in the request path calls `structure_info()` yet — chat.py/scheduler.py routing and the runtime `GrammarLogitsProcessor` land in PR-3. The only reference to `.structure_info()` is inside the still-unwired `build_tool_grammar` (no request-path call sites). Verified via `git grep`: no new callers. No `chat.py`/`scheduler.py` diff.

## Tests

New `tests/test_structure_info_hermes_qwen_558.py` (35 cases, parametrized over both real parsers), all hermetic — no server, no decode loop, tokenizer pinned to an immutable revision (same pin as PR-1):

- tokenizer-aware guard: opt out on no-tokenizer / multi-token (Llama-like) / ordinary-BPE-single-token / `[UNK]`-collapse tokenizers; opt in on a distinct-single-added-token (Qwen3-like) tokenizer; regression proving opt-in on a `special=False` added token (the real Qwen layout)
- offline-`OSError` classification: skip a transformers-wrapped offline cache-miss, fail a corrupt-artifact `OSError`
- structure-triple shape, name substitution, hermes≡qwen byte-identical wire (via a hermetic tokenizer stub, no network)
- real-parser `build_tool_grammar` non-None for `auto` + `required`; Lark structure (`<tool_call>` bare trigger + `%json` region, pure string always-run)
- offline llguidance `LLMatcher` ENFORCEMENT (real pinned Qwen tokenizer through the guard): well-formed call accepted + terminates; hallucinated name / off-schema arg / bad enum rejected mid-stream

Ported from the proven pilot branch `feat/558-constrained-tool-calling-pilot` (tip `68d5f12a`).

## Test plan

- [x] `ruff check` + `ruff format --check` clean on all 4 changed files
- [x] New suite green: `tests/test_structure_info_hermes_qwen_558.py` (35 passed)
- [x] PR-1 suite still green: `tests/test_tool_grammar_558.py` (20 passed)
- [x] No regression across tool-parser/guided/tool-calling/metrics suites (353 passed)
- [x] Guardrails: no `spec_decode`/`speculative` touch, no version bump, no new `structure_info()` request-path call sites

Refs #558. Builds on #1133.

🤖 Generated with [Claude Code](https://claude.com/claude-code)