### PR TITLE
feat(tools): grammar logits processor + required/named tool_choice routing (#558 PR-3a core)

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -137,6 +137,7 @@ Create `mcp.json`:
 | `VLLM_MLX_TEST_MODEL` | Default model for tests |
 | `HF_TOKEN` | HuggingFace authentication token |
 | `OPENAI_API_KEY` | Set to any value for SDK compatibility |
+| `RAPID_MLX_CONSTRAIN_TOOLS` | Grammar-constrained tool calling (best-effort, **opt-in**). When set to `1`/`on`/`true` AND a `--tool-call-parser` is set AND a request sends `tools` with `tool_choice="required"` or a named function, the server compiles a grammar that constrains generation so a completed tool call names a real tool with schema-valid arguments in the family wire format. **Off by default** (`0`) pending resource-hardening; requests without tools, or with `tool_choice="auto"`/`"none"`, are always unaffected. **Best-effort fallback:** the request silently falls back to the free-form-then-parse path (no hard error, no structural guarantee) when the `[guided]` extra (`llguidance`) is not installed, the model's tokenizer cannot back an `LLTokenizer`, the grammar fails to compile, or the parser family declares no structural info. `parallel_tool_calls=false` narrows the grammar to exactly one call. Note: the structural guarantee holds only for a call the model runs to a grammar-accepted completion — a `max_tokens` cutoff mid-call can still truncate the arguments and yield invalid JSON. |
 
 ## Example Configurations
 

--- a/tests/test_grammar_processor_558.py
+++ b/tests/test_grammar_processor_558.py
@@ -1,0 +1,1151 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Runtime tests for grammar-constrained tool calling (#558 PR-3).
+
+PR-1 shipped the pure grammar BUILDER and PR-2 the per-family
+``structure_info`` overrides (both covered by ``test_tool_grammar_558.py`` /
+``test_structure_info_hermes_qwen_558.py``). PR-3 adds the RUNTIME half:
+
+  * ``GrammarLogitsProcessor`` — the per-token mask applied to logits each
+    decode step, including the CUMULATIVE-BASELINE fix (mlx-lm hands the full
+    ``prompt + generated`` sequence each step; the matcher must be advanced
+    ONLY over generated tokens);
+  * ``build_lltokenizer`` — the ``LLTokenizer`` factory with the ``to_str()``
+    fallback for the transformers ``from_tokenizer`` isinstance gotcha;
+  * ``routes.chat._normalize_tool_choice_for_grammar`` — the collision-safe
+    ``tool_choice`` normalization (a tool literally named ``"required"`` must
+    never be misread as the ``required`` enum).
+
+The processor / enforcement tests need a fast (Rust) tokenizer whose
+``<tool_call>``/``</tool_call>`` are single special tokens — verified on
+``mlx-community/Qwen3.5-4B-MLX-4bit`` (the pilot wire model). They skip ONLY
+on genuine unavailability (the ``[guided]`` extra absent, or the tokenizer
+neither cached nor reachable). The pure-Python normalization tests carry no
+optional dependency and always run.
+"""
+
+import importlib.util
+
+import pytest
+
+_HAS_LLGUIDANCE = importlib.util.find_spec("llguidance") is not None
+_requires_llguidance = pytest.mark.skipif(
+    not _HAS_LLGUIDANCE, reason="llguidance ([guided] extra) not installed"
+)
+
+
+@pytest.fixture(autouse=True)
+def _opt_in_constrain_tools(monkeypatch):
+    """PR-3a ships the constraint OPT-IN (``RAPID_MLX_CONSTRAIN_TOOLS`` defaults
+    to off). These runtime tests exercise the ENABLED path, so turn it on for
+    the module. The explicit kill-switch test overrides this back to ``"0"``.
+    """
+    monkeypatch.setenv("RAPID_MLX_CONSTRAIN_TOOLS", "1")
+
+
+_TOKENIZER_MODEL = "mlx-community/Qwen3.5-4B-MLX-4bit"
+# Pin the revision so the enforcement proof runs against an IMMUTABLE artifact
+# (mirrors test_tool_grammar_558.py). The tokenizer's
+# ``<tool_call>``/``</tool_call>`` single-special-token layout is fixed here.
+_TOKENIZER_REVISION = "32f3e8ecf65426fc3306969496342d504bfa13f3"
+
+TOOLS = [
+    {
+        "name": "get_weather",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "city": {"type": "string"},
+                "unit": {"type": "string", "enum": ["c", "f"]},
+            },
+            "required": ["city"],
+            "additionalProperties": False,
+        },
+    },
+    {
+        "name": "get_time",
+        "parameters": {
+            "type": "object",
+            "properties": {"tz": {"type": "string"}},
+            "required": ["tz"],
+            "additionalProperties": False,
+        },
+    },
+]
+
+
+# --------------------------------------------------------------------------
+# Lightweight stand-ins mirroring the ToolDefinition / request / engine / cfg
+# shapes the chat route reads, so tests can drive the REAL
+# ``_maybe_build_tool_grammar_processor`` without a live server.
+# --------------------------------------------------------------------------
+class _FunctionTool:
+    """Mirrors ``ToolDefinition`` (``.function`` is a dict). ``parameters`` is
+    OMITTED from the dict entirely when not passed, so ``"parameters" in fn``
+    is False (the absent case)."""
+
+    _SENTINEL = object()
+
+    def __init__(self, name, parameters=_SENTINEL):
+        self.function = {"name": name}
+        if parameters is not _FunctionTool._SENTINEL:
+            self.function["parameters"] = parameters
+
+
+class _RequestStub:
+    def __init__(self, tools, tool_choice):
+        self.tools = tools
+        self.tool_choice = tool_choice
+
+
+class _EngineStub:
+    def __init__(self, tokenizer):
+        self.tokenizer = tokenizer
+
+
+class _CfgStub:
+    def __init__(self, tool_call_parser):
+        self.tool_call_parser = tool_call_parser
+
+
+def _http_status_of(exc):
+    """Best-effort HTTP status code for a hub/requests/httpx error, else None."""
+    resp = getattr(exc, "response", None)
+    code = getattr(resp, "status_code", None)
+    if isinstance(code, int):
+        return code
+    # huggingface_hub sometimes carries the code directly.
+    code = getattr(exc, "status_code", None)
+    return code if isinstance(code, int) else None
+
+
+def _is_offline_skippable(exc) -> bool:
+    """True iff ``exc`` is a TRANSIENT network/cache-miss error worth skipping.
+
+    Skip ONLY genuine transient signals: offline/cache-miss, a raw
+    connection/timeout error, or a rate-limit (429) / transient server (5xx)
+    HTTP response. A PERMANENT 4xx (401/403 bad creds, 404 deleted artifact,
+    422 invalid pinned revision) must FAIL — it means the test is misconfigured
+    or the artifact changed, not that the network blipped (codex #558-PR3). A
+    corrupt local file, a programming/API error, etc. also propagate.
+    """
+    # Cache-miss / explicit offline: always skippable.
+    try:
+        from huggingface_hub.errors import (
+            LocalEntryNotFoundError,
+            OfflineModeIsEnabled,
+        )
+
+        if isinstance(exc, (LocalEntryNotFoundError, OfflineModeIsEnabled)):
+            return True
+    except Exception:  # pragma: no cover - old hub without these names
+        pass
+    # Raw connection / timeout (requests + httpx): transport failure, skippable.
+    transient_types: list[type[BaseException]] = []
+    try:
+        from requests.exceptions import ConnectionError as _ReqConnErr
+        from requests.exceptions import Timeout as _ReqTimeout
+
+        transient_types += [_ReqConnErr, _ReqTimeout]
+    except Exception:  # pragma: no cover - requests not present
+        pass
+    try:
+        # ``TransportError`` is the base for ALL httpx transport-layer failures
+        # — ConnectError, TimeoutException, ReadError, RemoteProtocolError, etc.
+        # (codex #558-PR3 nit): an interrupted response mid-download is transient
+        # and must skip, not spuriously fail the network-dependent suite. HTTP
+        # STATUS errors are ``HTTPStatusError`` (NOT a TransportError), so they
+        # still fall through to the 4xx-fails / 429+5xx-skips branch below.
+        from httpx import TransportError as _HxTransport
+
+        transient_types += [_HxTransport]
+    except Exception:  # pragma: no cover - httpx not present
+        pass
+    if transient_types and isinstance(exc, tuple(transient_types)):
+        return True
+    # HTTP-status-bearing errors (HfHubHTTPError / requests.HTTPError / httpx):
+    # skip ONLY 429 + 5xx (transient); permanent 4xx must fail.
+    status = _http_status_of(exc)
+    if status is not None:
+        return status == 429 or 500 <= status < 600
+    return False
+
+
+@pytest.fixture(scope="module")
+def tok():
+    transformers = pytest.importorskip("transformers")
+    try:
+        return transformers.AutoTokenizer.from_pretrained(
+            _TOKENIZER_MODEL, revision=_TOKENIZER_REVISION
+        )
+    except Exception as exc:  # pragma: no cover - offline & uncached
+        # Skip ONLY on a transient network/cache-miss signal; a permanent 4xx
+        # (bad creds / deleted artifact / invalid revision) or any other error
+        # must FAIL, not silently green the enforcement suite (codex #558-PR3).
+        if not _is_offline_skippable(exc):
+            raise
+        pytest.skip(
+            f"tokenizer {_TOKENIZER_MODEL}@{_TOKENIZER_REVISION[:8]} not "
+            "cached and no network — runtime enforcement tests require it"
+        )
+
+
+@pytest.fixture(scope="module")
+def hermes_grammar(tok):
+    # We reach here only with llguidance present (the enforcement tests are
+    # ``@_requires_llguidance``) AND the pinned tokenizer available (``tok``
+    # succeeded). Under those conditions the hermes parser DOES declare a
+    # ``structure_info`` (proven in test_structure_info_hermes_qwen_558.py), so
+    # ``build_tool_grammar`` returning ``None`` means the production builder
+    # REGRESSED and the enforcement suite must FAIL — not silently skip and go
+    # green while the feature is broken (codex #558-PR3).
+    pytest.importorskip("llguidance")
+    from vllm_mlx.api.tool_grammar import build_tool_grammar
+    from vllm_mlx.tool_parsers.hermes_tool_parser import HermesToolParser
+
+    parser = HermesToolParser(tokenizer=tok)
+    grammar = build_tool_grammar(TOOLS, "required", parser)
+    assert grammar is not None, (
+        "build_tool_grammar returned None with llguidance present and the "
+        "hermes structure_info available — the grammar builder regressed"
+    )
+    return grammar
+
+
+@pytest.fixture(scope="module")
+def lltok(tok):
+    # Same contract as ``hermes_grammar``: with llguidance present and the
+    # pinned fast tokenizer available, ``build_lltokenizer`` MUST succeed. A
+    # ``None`` here is a regression in the LLTokenizer factory, not a sanctioned
+    # skip (codex #558-PR3).
+    pytest.importorskip("llguidance")
+    from vllm_mlx.api.tool_grammar import build_lltokenizer
+
+    llt = build_lltokenizer(tok)
+    assert llt is not None, (
+        "build_lltokenizer returned None for the pinned fast wire tokenizer "
+        "with llguidance present — the LLTokenizer factory regressed"
+    )
+    return llt
+
+
+# --------------------------------------------------------------------------
+# tool_choice normalization — collision fix (pure Python, always runs).
+# --------------------------------------------------------------------------
+def test_normalize_required_is_enum_not_named():
+    from vllm_mlx.routes.chat import _normalize_tool_choice_for_grammar
+
+    assert _normalize_tool_choice_for_grammar("required") == {"mode": "required"}
+
+
+@pytest.mark.parametrize("value", ["auto", "none", None])
+def test_normalize_auto_none_unconstrained(value):
+    # PR-3 scope: auto (PR-5-owned) and none both fall through to free-form.
+    from vllm_mlx.routes.chat import _normalize_tool_choice_for_grammar
+
+    assert _normalize_tool_choice_for_grammar(value) is None
+
+
+def test_normalize_named_object_form():
+    from vllm_mlx.routes.chat import _normalize_tool_choice_for_grammar
+
+    choice = {"type": "function", "function": {"name": "get_time"}}
+    assert _normalize_tool_choice_for_grammar(choice) == {
+        "mode": "named",
+        "name": "get_time",
+    }
+
+
+def test_normalize_bare_tool_name_string_is_never_named():
+    # Deferred codex #2: a bare string that happens to equal a tool name is
+    # an INVALID tool_choice enum, not a named selection. It must NOT be read
+    # as a named choice (that requires the object form). -> unconstrained.
+    from vllm_mlx.routes.chat import _normalize_tool_choice_for_grammar
+
+    assert _normalize_tool_choice_for_grammar("get_time") is None
+
+
+def test_normalize_tool_named_required_only_via_object_form():
+    # A tool literally named "required": under a bare string it's the enum
+    # (mode=required, forces one of ANY tool); it is selectable as a NAMED
+    # single tool ONLY via the object form. The two paths can never collide.
+    from vllm_mlx.routes.chat import _normalize_tool_choice_for_grammar
+
+    assert _normalize_tool_choice_for_grammar("required") == {"mode": "required"}
+    assert _normalize_tool_choice_for_grammar(
+        {"type": "function", "function": {"name": "required"}}
+    ) == {"mode": "named", "name": "required"}
+
+
+@pytest.mark.parametrize(
+    "bad_function",
+    [
+        "get_weather",  # truthy string, not a dict
+        ["get_weather"],  # truthy list
+        123,  # truthy int
+        {"name": 42},  # dict but name is not a str
+        {"name": ""},  # dict but empty name
+        {},  # empty dict (no name)
+    ],
+)
+def test_normalize_malformed_function_degrades_to_none(bad_function):
+    # codex #558-PR3 blocking: a dict-shaped tool_choice whose ``function`` is
+    # truthy-but-not-a-dict (or a dict without a usable name) must degrade to
+    # None (free-form), NOT reach ``.get`` on a non-dict and raise -> HTTP 500.
+    from vllm_mlx.routes.chat import _normalize_tool_choice_for_grammar
+
+    assert (
+        _normalize_tool_choice_for_grammar(
+            {"type": "function", "function": bad_function}
+        )
+        is None
+    )
+
+
+# --------------------------------------------------------------------------
+# Cheap synchronous eligibility gate — must short-circuit the offload for the
+# common no-tools / auto / none traffic (codex #558-PR3). Pure Python, always
+# runs (no llguidance, no tokenizer).
+# --------------------------------------------------------------------------
+def test_eligible_false_when_no_tools():
+    from vllm_mlx.routes.chat import _tool_grammar_eligible
+
+    cfg = _CfgStub("hermes")
+    req = _RequestStub(tools=None, tool_choice="required")
+    assert _tool_grammar_eligible(cfg, req) is False
+
+
+def test_eligible_false_when_no_parser():
+    from vllm_mlx.routes.chat import _tool_grammar_eligible
+
+    cfg = _CfgStub(None)  # no family parser configured
+    req = _RequestStub(tools=[_FunctionTool("get_time")], tool_choice="required")
+    assert _tool_grammar_eligible(cfg, req) is False
+
+
+@pytest.mark.parametrize("choice", ["auto", "none", None])
+def test_eligible_false_for_auto_none(choice):
+    # auto (PR-5-owned) and none must NOT enter the thread-pool offload.
+    from vllm_mlx.routes.chat import _tool_grammar_eligible
+
+    cfg = _CfgStub("hermes")
+    req = _RequestStub(tools=[_FunctionTool("get_time")], tool_choice=choice)
+    assert _tool_grammar_eligible(cfg, req) is False
+
+
+def test_eligible_true_for_required_and_named():
+    from vllm_mlx.routes.chat import _tool_grammar_eligible
+
+    cfg = _CfgStub("hermes")
+    tools = [_FunctionTool("get_time")]
+    assert _tool_grammar_eligible(cfg, _RequestStub(tools, "required")) is True
+    named = {"type": "function", "function": {"name": "get_time"}}
+    assert _tool_grammar_eligible(cfg, _RequestStub(tools, named)) is True
+
+
+@pytest.mark.parametrize("value", ["0", "off", "false", "no", "", "2"])
+def test_eligible_false_when_env_not_opted_in(monkeypatch, value):
+    # PR-3a is OPT-IN: only the exact ``1``/``on``/``true`` values enable the
+    # constraint. Anything else (including an unrecognized value) leaves it off.
+    from vllm_mlx.routes.chat import _tool_grammar_eligible
+
+    monkeypatch.setenv("RAPID_MLX_CONSTRAIN_TOOLS", value)
+    cfg = _CfgStub("hermes")
+    req = _RequestStub(tools=[_FunctionTool("get_time")], tool_choice="required")
+    assert _tool_grammar_eligible(cfg, req) is False
+
+
+def test_eligible_false_by_default_when_env_unset(monkeypatch):
+    # PR-3a ships OFF by default: with the env var ABSENT the constraint does
+    # not activate (client-schema DoS-hardening is PR-3b; default-on is gated
+    # on it). Overrides the module autouse opt-in fixture by deleting the var.
+    from vllm_mlx.routes.chat import _tool_grammar_eligible
+
+    monkeypatch.delenv("RAPID_MLX_CONSTRAIN_TOOLS", raising=False)
+    cfg = _CfgStub("hermes")
+    req = _RequestStub(tools=[_FunctionTool("get_time")], tool_choice="required")
+    assert _tool_grammar_eligible(cfg, req) is False
+
+
+def test_eligible_true_for_reasonable_schema():
+    # A normal-sized, shallow schema is eligible (opt-in enabled by the module
+    # autouse fixture). PR-3a applies no size/depth cap (that is PR-3b).
+    from vllm_mlx.routes.chat import _tool_grammar_eligible
+
+    ok = _FunctionTool(
+        "get_weather",
+        parameters={
+            "type": "object",
+            "properties": {"city": {"type": "string"}},
+            "required": ["city"],
+        },
+    )
+    cfg = _CfgStub("hermes")
+    req = _RequestStub(tools=[ok], tool_choice="required")
+    assert _tool_grammar_eligible(cfg, req) is True
+
+
+def test_offline_skip_classifies_http_status():
+    # codex #558-PR3 blocking: only TRANSIENT signals skip; a permanent 4xx
+    # (bad creds / deleted artifact / invalid revision) must FAIL, not silently
+    # green the suite.
+    from vllm_mlx.routes import chat  # noqa: F401  (ensure module import order)
+
+    class _Resp:
+        def __init__(self, code):
+            self.status_code = code
+
+    class _HTTPError(Exception):
+        def __init__(self, code):
+            self.response = _Resp(code)
+
+    # 429 + 5xx -> transient -> skippable.
+    assert _is_offline_skippable(_HTTPError(429)) is True
+    assert _is_offline_skippable(_HTTPError(500)) is True
+    assert _is_offline_skippable(_HTTPError(503)) is True
+    # permanent 4xx -> must FAIL (not skip).
+    assert _is_offline_skippable(_HTTPError(401)) is False
+    assert _is_offline_skippable(_HTTPError(403)) is False
+    assert _is_offline_skippable(_HTTPError(404)) is False
+    assert _is_offline_skippable(_HTTPError(422)) is False
+    # a non-HTTP programming error is not skippable either.
+    assert _is_offline_skippable(ValueError("boom")) is False
+
+    # httpx transport-layer failures (interrupted response mid-download) are
+    # transient -> skippable, but an httpx HTTP-STATUS error still classifies by
+    # code (codex #558-PR3 nit).
+    httpx = pytest.importorskip("httpx")
+    assert _is_offline_skippable(httpx.ReadError("peer reset")) is True
+    assert _is_offline_skippable(httpx.RemoteProtocolError("truncated")) is True
+    assert _is_offline_skippable(httpx.ConnectError("refused")) is True
+    req = httpx.Request("GET", "https://example.invalid")
+    resp_404 = httpx.Response(404, request=req)
+    resp_503 = httpx.Response(503, request=req)
+    assert (
+        _is_offline_skippable(
+            httpx.HTTPStatusError("nf", request=req, response=resp_404)
+        )
+        is False
+    )
+    assert (
+        _is_offline_skippable(
+            httpx.HTTPStatusError("busy", request=req, response=resp_503)
+        )
+        is True
+    )
+
+
+def test_route_offload_gated_on_eligibility_in_source():
+    # The route must run the cheap gate SYNCHRONOUSLY before the off-loop
+    # compile, so no-tools / auto traffic never enters the thread offload
+    # (codex #558-PR3). Source-position tripwire — the BEHAVIORAL guarantee is
+    # proven by ``test_ineligible_request_never_enters_heavy_build_path``.
+    # PR-3a uses a simple ``asyncio.to_thread`` offload (the bounded compile
+    # pool is PR-3b).
+    import inspect
+
+    from vllm_mlx.routes import chat as chat_mod
+
+    src = inspect.getsource(chat_mod._create_chat_completion_impl)
+    gate = src.find("_tool_grammar_eligible(cfg, request)")
+    offload = src.find("asyncio.to_thread(")
+    assert gate != -1, "route must gate the offload on _tool_grammar_eligible"
+    assert offload != -1, "route must offload the build via asyncio.to_thread"
+    assert gate < offload, "the eligibility gate must precede the off-loop compile"
+
+
+@pytest.mark.parametrize(
+    "tools, tool_choice, env",
+    [
+        ([_FunctionTool("get_time")], "required", "0"),  # opted out
+        ([], "required", "1"),  # no tools
+        ([_FunctionTool("get_time")], "auto", "1"),  # unconstrained choice
+        ([_FunctionTool("get_time")], "none", "1"),  # unconstrained choice
+    ],
+)
+def test_ineligible_request_never_enters_heavy_build_path(
+    monkeypatch, tools, tool_choice, env
+):
+    # codex #558-PR3 blocking (behavioral, not source-string): an INELIGIBLE
+    # request (opted out, no tools, or auto/none) must NEVER reach the
+    # client-schema grammar compile. ``_maybe_build_tool_grammar_processor``
+    # re-runs the gate, so booby-trap ``build_tool_grammar`` to explode — if the
+    # gate short-circuits (as it must), it's never called and we get ``None``;
+    # if the gate were bypassed, the RuntimeError would surface. This proves the
+    # gate behaviorally, independent of any source-position check.
+    from vllm_mlx.api import tool_grammar as tg_mod
+    from vllm_mlx.routes import chat as chat_mod
+
+    monkeypatch.setenv("RAPID_MLX_CONSTRAIN_TOOLS", env)
+
+    def _boom(*a, **k):  # pragma: no cover - must never be reached
+        raise RuntimeError("heavy grammar compile reached for an ineligible request")
+
+    monkeypatch.setattr(tg_mod, "build_tool_grammar", _boom)
+
+    cfg = _CfgStub("hermes")
+    engine = _EngineStub(tokenizer=object())
+    request = _RequestStub(tools, tool_choice)
+    assert chat_mod._tool_grammar_eligible(cfg, request) is False, (
+        "fixture inputs must be ineligible"
+    )
+    assert chat_mod._maybe_build_tool_grammar_processor(engine, cfg, request) is None, (
+        "ineligible request must fall back to free-form without compiling"
+    )
+
+
+# --------------------------------------------------------------------------
+# build_lltokenizer.
+# --------------------------------------------------------------------------
+@_requires_llguidance
+def test_build_lltokenizer_from_wire_tokenizer(tok):
+    from vllm_mlx.api.tool_grammar import build_lltokenizer
+
+    llt = build_lltokenizer(tok)
+    assert llt is not None
+    assert llt.vocab_size > 0
+
+
+@_requires_llguidance
+def test_build_lltokenizer_none_on_junk_tokenizer():
+    # A tokenizer with no fast internals and no backend_tokenizer -> None
+    # (caller degrades to free-form), never an exception.
+    from vllm_mlx.api.tool_grammar import build_lltokenizer
+
+    class _Junk:
+        is_fast = False
+
+    assert build_lltokenizer(_Junk()) is None
+
+
+# --------------------------------------------------------------------------
+# GrammarLogitsProcessor — enforcement + cumulative-baseline fix.
+# --------------------------------------------------------------------------
+def _feed_cumulative(proc, lltok, tok, prompt_ids, gen_text):
+    """Drive the processor the way mlx-lm does: full cumulative sequence each
+    step (prompt + generated-so-far). Returns (blocked, blocked_gen_idx).
+    """
+    import mlx.core as mx
+    import numpy as np
+
+    vocab = lltok.vocab_size
+    gen_ids = tok.encode(gen_text, add_special_tokens=False)
+    cumulative = list(prompt_ids)
+    masked = proc(mx.array(cumulative), mx.zeros((1, vocab)))
+    for k, tid in enumerate(gen_ids):
+        row = np.array(masked[0])
+        allowed = bool(np.isfinite(row[tid]) and row[tid] > -1e30)
+        if not allowed:
+            return True, k
+        cumulative.append(tid)
+        masked = proc(mx.array(cumulative), mx.zeros((1, vocab)))
+    return False, len(gen_ids)
+
+
+@_requires_llguidance
+def test_processor_baselines_past_prompt(tok, hermes_grammar, lltok):
+    # MUST-FIX #1: the matcher must NOT be fed prompt tokens. mlx-lm hands the
+    # full cumulative sequence each step; on the first call the processor must
+    # baseline ``_prompt_len`` to the prompt length so only generated tokens
+    # ever reach the matcher. A valid call over a non-empty prompt must pass.
+    import mlx.core as mx
+
+    from vllm_mlx.api.tool_grammar import GrammarLogitsProcessor
+
+    prompt_ids = tok.encode(
+        "You are a helpful assistant. What's the weather in Paris?",
+        add_special_tokens=False,
+    )
+    assert prompt_ids, "expected a non-empty prompt for the baseline test"
+
+    proc = GrammarLogitsProcessor(lltok, hermes_grammar, tokenizer=tok)
+    # First call: everything present is the prompt (no token sampled yet).
+    proc(mx.array(prompt_ids), mx.zeros((1, lltok.vocab_size)))
+    assert proc._prompt_len == len(prompt_ids), (
+        "processor did not baseline the matcher past the prompt — it would "
+        "feed prompt tokens into the grammar matcher and break enforcement"
+    )
+    # And the matcher has consumed nothing yet (prompt is not committed to it).
+    assert proc._committed == len(prompt_ids)
+
+    # A valid hermes call over that same prompt baseline is fully allowed.
+    blocked, _ = _feed_cumulative(
+        proc,
+        lltok,
+        tok,
+        prompt_ids,
+        '<tool_call>\n{"name": "get_weather", "arguments": {"city": "Paris"}}\n</tool_call>',
+    )
+    assert not blocked, "valid call over a non-empty prompt was wrongly blocked"
+
+
+@_requires_llguidance
+def test_processor_consumes_only_new_tail_each_step(tok, hermes_grammar, lltok):
+    """PERF/CORRECTNESS: each decode step feeds the matcher ONLY the newly
+    generated token(s), never the already-committed prefix.
+
+    mlx-lm hands the FULL cumulative ``prompt + generated`` sequence every
+    step. A naive processor would ``consume_token`` the whole sequence each
+    call — O(n^2) total consumes AND a double-consume that the matcher would
+    reject. The ``_committed`` offset must gate consumption so that (a) the
+    prompt baseline is never consumed and (b) exactly ONE consume happens per
+    NEW generated token per step. We spy on the real matcher's
+    ``consume_token`` to assert the exact call schedule.
+    """
+    import mlx.core as mx
+
+    from vllm_mlx.api.tool_grammar import GrammarLogitsProcessor
+
+    prompt_ids = tok.encode("Weather please.", add_special_tokens=False)
+    assert prompt_ids, "expected a non-empty prompt for the tail-consume test"
+
+    proc = GrammarLogitsProcessor(lltok, hermes_grammar, tokenizer=tok)
+
+    # Spy on the matcher's consume_token: record the (call_index -> token) log.
+    # ``LLMatcher.consume_token`` is a read-only Rust attribute, so we cannot
+    # patch the method in place — instead wrap the whole matcher in a thin proxy
+    # that delegates every attribute to the real matcher but records each
+    # ``consume_token`` call.
+    consumed: list[int] = []
+    real_matcher = proc._matcher
+
+    class _SpyMatcher:
+        def consume_token(self, tok_id):
+            consumed.append(int(tok_id))
+            return real_matcher.consume_token(tok_id)
+
+        def __getattr__(self, name):
+            return getattr(real_matcher, name)
+
+    proc._matcher = _SpyMatcher()
+
+    vocab = lltok.vocab_size
+    gen_ids = tok.encode(
+        '<tool_call>\n{"name": "get_weather", "arguments": {"city": "Paris"}}\n</tool_call>',
+        add_special_tokens=False,
+    )
+
+    # First call: only the prompt is present — NOTHING must be consumed.
+    proc(mx.array(list(prompt_ids)), mx.zeros((1, vocab)))
+    assert consumed == [], (
+        "processor consumed prompt tokens into the matcher — the baseline "
+        "gate is broken and the grammar would reject the prompt"
+    )
+
+    # Then feed one new token per step over the full cumulative sequence.
+    cumulative = list(prompt_ids)
+    for k, tid in enumerate(gen_ids):
+        cumulative.append(tid)
+        before = len(consumed)
+        proc(mx.array(cumulative), mx.zeros((1, vocab)))
+        # Exactly ONE new consume per step (the new tail token), never a
+        # re-consume of the already-committed prefix.
+        assert len(consumed) - before == 1, (
+            f"step {k}: expected exactly 1 new consume (the new tail token), "
+            f"got {len(consumed) - before} — the processor is re-consuming "
+            "the committed prefix (O(n^2))"
+        )
+        assert consumed[-1] == tid, (
+            f"step {k}: consumed token {consumed[-1]} != the new tail token {tid}"
+        )
+
+    # Total consumes == number of generated tokens (linear, not quadratic).
+    assert consumed == list(gen_ids), (
+        "the full consume log must equal exactly the generated tokens in order "
+        f"({len(consumed)} consumes for {len(gen_ids)} generated tokens)"
+    )
+    # ``_committed`` advanced exactly over prompt + generated.
+    assert proc._committed == len(prompt_ids) + len(gen_ids)
+
+
+@_requires_llguidance
+def test_processor_negative_controls_over_prompt(tok, hermes_grammar, lltok):
+    # The load-bearing #558 proof, exercised through the cumulative-baseline
+    # path (non-empty prompt). A hallucinated tool name, an off-schema
+    # argument, and a bad enum are all grammar-blocked mid-stream.
+    from vllm_mlx.api.tool_grammar import GrammarLogitsProcessor
+
+    prompt_ids = tok.encode("Weather please.", add_special_tokens=False)
+
+    def _run(gen_text):
+        proc = GrammarLogitsProcessor(lltok, hermes_grammar, tokenizer=tok)
+        return _feed_cumulative(proc, lltok, tok, prompt_ids, gen_text)[0]
+
+    assert _run('<tool_call>\n{"name": "get_stockquote'), (
+        "hallucinated tool name was NOT blocked"
+    )
+    assert _run('<tool_call>\n{"name": "get_weather", "arguments": {"city": 4'), (
+        "off-schema integer argument was NOT blocked"
+    )
+    assert _run(
+        '<tool_call>\n{"name": "get_weather", "arguments": {"city": "P", "unit": "kelvin'
+    ), "invalid enum value was NOT blocked"
+
+
+@_requires_llguidance
+def test_named_grammar_constrains_to_single_tool(tok, lltok):
+    # A NAMED choice narrows to one tool. Building the grammar over a
+    # 1-element list with "required" forces exactly that tool; a call naming a
+    # DIFFERENT (also-provided) tool is rejected.
+    from vllm_mlx.api.tool_grammar import (
+        GrammarLogitsProcessor,
+        build_tool_grammar,
+    )
+    from vllm_mlx.tool_parsers.hermes_tool_parser import HermesToolParser
+
+    parser = HermesToolParser(tokenizer=tok)
+    only_time = [t for t in TOOLS if t["name"] == "get_time"]
+    grammar = build_tool_grammar(only_time, "required", parser)
+    # llguidance is present (test is @_requires_llguidance) and the hermes
+    # structure_info is available -> None means a builder regression, fail hard.
+    assert grammar is not None, (
+        "build_tool_grammar returned None for a single-tool named narrow — "
+        "the grammar builder regressed"
+    )
+
+    prompt_ids = tok.encode("time?", add_special_tokens=False)
+
+    # get_time is allowed.
+    proc = GrammarLogitsProcessor(lltok, grammar, tokenizer=tok)
+    blocked, _ = _feed_cumulative(
+        proc,
+        lltok,
+        tok,
+        prompt_ids,
+        '<tool_call>\n{"name": "get_time", "arguments": {"tz": "UTC"}}\n</tool_call>',
+    )
+    assert not blocked, "the named tool get_time was wrongly blocked"
+
+    # get_weather (not the named target) is rejected.
+    proc2 = GrammarLogitsProcessor(lltok, grammar, tokenizer=tok)
+    blocked2, _ = _feed_cumulative(
+        proc2, lltok, tok, prompt_ids, '<tool_call>\n{"name": "get_weather'
+    )
+    assert blocked2, "a non-named tool was NOT blocked under a named choice"
+
+
+@_requires_llguidance
+def test_tool_named_required_collision_end_to_end(tok, lltok):
+    # Deferred codex #2, end-to-end: a tool literally named "required" is
+    # constrainable as a single named tool (via the object form) WITHOUT the
+    # grammar collapsing to the "required" enum over all tools. We build the
+    # named grammar the way chat.py routing does: pre-narrow to the target +
+    # "required" quantifier.
+    from vllm_mlx.api.tool_grammar import (
+        GrammarLogitsProcessor,
+        build_tool_grammar,
+    )
+    from vllm_mlx.tool_parsers.hermes_tool_parser import HermesToolParser
+
+    collide_tools = [
+        {
+            "name": "required",  # a tool whose name collides with the enum
+            "parameters": {
+                "type": "object",
+                "properties": {"x": {"type": "string"}},
+                "required": ["x"],
+                "additionalProperties": False,
+            },
+        },
+        {
+            "name": "get_time",
+            "parameters": {
+                "type": "object",
+                "properties": {"tz": {"type": "string"}},
+                "required": ["tz"],
+                "additionalProperties": False,
+            },
+        },
+    ]
+    parser = HermesToolParser(tokenizer=tok)
+    # Named choice on the "required"-named tool: narrow then "required" quant.
+    narrowed = [t for t in collide_tools if t["name"] == "required"]
+    grammar = build_tool_grammar(narrowed, "required", parser)
+    # llguidance present (test is @_requires_llguidance) + hermes structure_info
+    # available -> None is a REGRESSION that would let the exact collision this
+    # test guards ship green while production falls back to unconstrained
+    # generation (codex #558-PR3). Assert, don't skip.
+    assert grammar is not None, (
+        "build_tool_grammar returned None for the 'required'-named collision "
+        "case — the grammar builder regressed"
+    )
+
+    prompt_ids = tok.encode("go", add_special_tokens=False)
+
+    # The "required"-named tool is allowed.
+    proc = GrammarLogitsProcessor(lltok, grammar, tokenizer=tok)
+    blocked, _ = _feed_cumulative(
+        proc,
+        lltok,
+        tok,
+        prompt_ids,
+        '<tool_call>\n{"name": "required", "arguments": {"x": "y"}}\n</tool_call>',
+    )
+    assert not blocked, "the tool literally named 'required' was wrongly blocked"
+
+    # The OTHER provided tool (get_time) is rejected — the named grammar is
+    # single-tool, proving it did not collapse to a force-any-tool enum.
+    proc2 = GrammarLogitsProcessor(lltok, grammar, tokenizer=tok)
+    blocked2, _ = _feed_cumulative(
+        proc2, lltok, tok, prompt_ids, '<tool_call>\n{"name": "get_time'
+    )
+    assert blocked2, (
+        "named choice on the 'required'-named tool leaked another tool — "
+        "the string collision was not contained"
+    )
+
+
+@_requires_llguidance
+def test_processor_reset_clears_baseline(tok, hermes_grammar, lltok):
+    # reset() must clear the prompt baseline and committed counter so the
+    # processor can be reused for a fresh sequence.
+    import mlx.core as mx
+
+    from vllm_mlx.api.tool_grammar import GrammarLogitsProcessor
+
+    proc = GrammarLogitsProcessor(lltok, hermes_grammar, tokenizer=tok)
+    prompt_ids = tok.encode("hi", add_special_tokens=False)
+    proc(mx.array(prompt_ids), mx.zeros((1, lltok.vocab_size)))
+    assert proc._prompt_len == len(prompt_ids)
+    proc.reset()
+    assert proc._prompt_len is None
+    assert proc._committed == 0
+
+
+@_requires_llguidance
+def test_processor_preserves_padded_vocab_shape(tok, hermes_grammar, lltok):
+    # codex #558-PR3: when the model head is WIDER than the tokenizer vocab
+    # (padded embedding), the processor must return logits of the SAME final
+    # dimension — mlx-lm concatenates every row's processed logits, so a
+    # narrower return breaks batched decode. Verify shape is preserved and the
+    # padded tail is -inf (never sampled).
+    import mlx.core as mx
+    import numpy as np
+
+    from vllm_mlx.api.tool_grammar import GrammarLogitsProcessor
+
+    proc = GrammarLogitsProcessor(lltok, hermes_grammar, tokenizer=tok)
+    prompt_ids = tok.encode("hi", add_special_tokens=False)
+    pad = 128
+    wide_vocab = lltok.vocab_size + pad
+    out = proc(mx.array(prompt_ids), mx.zeros((1, wide_vocab)))
+    assert out.shape[-1] == wide_vocab, "padded-vocab shape not preserved"
+    tail = np.array(out[0, lltok.vocab_size :])
+    assert np.all(tail == -np.inf), "padded tail must be -inf (never sampleable)"
+
+
+@_requires_llguidance
+def test_processor_equal_vocab_shape_unchanged(tok, hermes_grammar, lltok):
+    # When model vocab == tokenizer vocab, the mask is applied in place and the
+    # shape is unchanged (no concat path).
+    import mlx.core as mx
+
+    from vllm_mlx.api.tool_grammar import GrammarLogitsProcessor
+
+    proc = GrammarLogitsProcessor(lltok, hermes_grammar, tokenizer=tok)
+    prompt_ids = tok.encode("hi", add_special_tokens=False)
+    out = proc(mx.array(prompt_ids), mx.zeros((1, lltok.vocab_size)))
+    assert out.shape[-1] == lltok.vocab_size
+
+
+@_requires_llguidance
+def test_processor_narrower_model_head_than_tokenizer(tok, hermes_grammar, lltok):
+    # codex #558-PR3 blocking: the INVERSE of the padded case — the TOKENIZER
+    # carries added tokens beyond a NARROWER model output head
+    # (``model_vocab < tokenizer_vocab``). The full-vocab bitmask must not be
+    # applied whole to the narrower logits (would over-cover); the processor
+    # slices the packed bitmask to the model-width word count and masks cleanly,
+    # returning the SAME narrow shape. Assert MASKING BEHAVIOR, not just shape:
+    # the grammar must still forbid in-range tokens (some become ``-inf``) while
+    # keeping at least one allowed — a shape-only check would stay green even if
+    # the branch returned UNMASKED logits and silently disabled enforcement.
+    import mlx.core as mx
+    import numpy as np
+
+    from vllm_mlx.api.tool_grammar import GrammarLogitsProcessor
+
+    proc = GrammarLogitsProcessor(lltok, hermes_grammar, tokenizer=tok)
+    prompt_ids = tok.encode("hi", add_special_tokens=False)
+    # Trim only a few ids off the top (not on a word boundary, to exercise the
+    # ceil-division word count) so the constrained opener is still in range.
+    narrow_vocab = lltok.vocab_size - 5
+    out = proc(mx.array(prompt_ids), mx.zeros((1, narrow_vocab)))
+    assert out.shape[-1] == narrow_vocab, "narrow-head shape not preserved"
+
+    row = np.array(out[0])
+    n_blocked = int(np.count_nonzero(~np.isfinite(row)))
+    n_allowed = int(np.count_nonzero(np.isfinite(row)))
+    # The mask MUST have been applied to the narrow logits: the input is
+    # all-zeros (finite), so any ``-inf`` entry can only come from the grammar
+    # mask. ``n_blocked > 0`` therefore proves enforcement is live on this path
+    # (an unmasked passthrough would leave every entry finite). ``n_allowed > 0``
+    # confirms the grammar still permits progress (not a broken all-mask). At
+    # grammar position 0 the hermes lazy free-prefix allows most tokens, so we
+    # do NOT assert a majority are blocked — only that masking demonstrably
+    # occurred and left a valid, non-empty allowed set.
+    assert n_blocked > 0, "narrow-head path returned UNMASKED logits (no enforcement)"
+    assert n_allowed > 0, "narrow-head path masked EVERYTHING (grammar broken)"
+
+
+@_requires_llguidance
+def test_get_lltokenizer_caches(tok):
+    # codex #558-PR3 (nit): the ~1s LLTokenizer build must be cached per
+    # tokenizer, not rebuilt on every request.
+    from vllm_mlx.api.tool_grammar import get_lltokenizer
+
+    a = get_lltokenizer(tok)
+    b = get_lltokenizer(tok)
+    assert a is not None
+    assert a is b, "get_lltokenizer must return the same cached instance"
+
+
+@_requires_llguidance
+def test_get_lltokenizer_transient_failure_is_retried(monkeypatch):
+    # codex #558-PR3 nit: a TRANSIENT build failure must NOT permanently disable
+    # grammar enforcement — it's retried up to the budget, and a subsequent
+    # success is cached. A distinct dummy tokenizer avoids poisoning the shared
+    # module-scoped ``tok`` fixture's cache.
+    import vllm_mlx.api.tool_grammar as tg_mod
+
+    class _DummyTok:
+        pass
+
+    dummy = _DummyTok()
+    sentinel = object()
+    calls = {"n": 0}
+
+    def _flaky_build(_tokenizer):
+        calls["n"] += 1
+        # Fail the first two attempts (transient), succeed on the third.
+        if calls["n"] < 3:
+            return None
+        return sentinel
+
+    monkeypatch.setattr(tg_mod, "build_lltokenizer", _flaky_build)
+
+    # First two calls hit transient failures and must NOT seal the cache.
+    assert tg_mod.get_lltokenizer(dummy) is None
+    assert tg_mod.get_lltokenizer(dummy) is None
+    # Third call succeeds and is cached.
+    assert tg_mod.get_lltokenizer(dummy) is sentinel
+    # Cached: no further build calls.
+    assert tg_mod.get_lltokenizer(dummy) is sentinel
+    assert calls["n"] == 3, "success must be cached; no rebuild after it"
+
+
+@_requires_llguidance
+def test_get_lltokenizer_seals_after_budget(monkeypatch):
+    # codex #558-PR3 nit: a PERSISTENT failure is eventually sealed as
+    # unavailable (bounded retries) so we don't rebuild-and-fail forever.
+    import vllm_mlx.api.tool_grammar as tg_mod
+
+    class _DummyTok:
+        pass
+
+    dummy = _DummyTok()
+    calls = {"n": 0}
+
+    def _always_fail(_tokenizer):
+        calls["n"] += 1
+        return None
+
+    monkeypatch.setattr(tg_mod, "build_lltokenizer", _always_fail)
+
+    budget = tg_mod._LLTOKENIZER_MAX_BUILD_ATTEMPTS
+    # Each call up to the budget retries the build.
+    for _ in range(budget):
+        assert tg_mod.get_lltokenizer(dummy) is None
+    assert calls["n"] == budget, "must retry up to the budget"
+    # Now sealed: further calls short-circuit without rebuilding.
+    assert tg_mod.get_lltokenizer(dummy) is None
+    assert calls["n"] == budget, "sealed after budget — no further rebuilds"
+
+
+@_requires_llguidance
+def test_missing_parameters_flattens_to_closed_schema_in_production_path(
+    tok, monkeypatch
+):
+    # codex #558-PR3: drive the REAL ``_maybe_build_tool_grammar_processor`` and
+    # capture the schema it flattens a no-``parameters`` tool into. Absent /
+    # null ``parameters`` must become a CLOSED empty-object schema; an explicit
+    # ``{}`` (allow-any) and an explicit schema must pass through verbatim.
+    from vllm_mlx.api import tool_grammar as tg_mod
+    from vllm_mlx.routes import chat as chat_mod
+
+    captured = {}
+
+    def _spy_build(flat_tools, mode, parser, *, single_call=False):
+        captured["flat_tools"] = flat_tools
+        captured["mode"] = mode
+        captured["single_call"] = single_call
+        return None  # short-circuit: we only need the flattened tools
+
+    # ``build_tool_grammar`` is imported inside the route function, so patch it
+    # at its defining module (the name the local import resolves to).
+    monkeypatch.setattr(tg_mod, "build_tool_grammar", _spy_build)
+
+    Fn = _FunctionTool
+    engine = _EngineStub(tok)
+    cfg = _CfgStub("hermes")
+
+    def _run(tools, tool_choice):
+        captured.clear()
+        request = _RequestStub(tools=tools, tool_choice=tool_choice)
+        # Returns None (build stub returns None) but populates ``captured``.
+        chat_mod._maybe_build_tool_grammar_processor(engine, cfg, request)
+        return {t["name"]: t["parameters"] for t in captured.get("flat_tools", [])}
+
+    # Absent parameters -> closed empty-object schema.
+    got = _run([Fn("noargs")], "required")
+    assert got["noargs"] == {
+        "type": "object",
+        "properties": {},
+        "additionalProperties": False,
+    }
+    # Explicit null -> closed.
+    assert (
+        _run([Fn("n", parameters=None)], "required")["n"]["additionalProperties"]
+        is False
+    )
+    # Explicit {} -> preserved verbatim (allow-any).
+    assert _run([Fn("n", parameters={})], "required")["n"] == {}
+    # Explicit schema -> preserved verbatim.
+    schema = {"type": "object", "properties": {"x": {"type": "string"}}}
+    assert _run([Fn("n", parameters=schema)], "required")["n"] == schema
+
+
+@_requires_llguidance
+def test_parallel_tool_calls_false_threads_single_call(tok, monkeypatch):
+    # codex #558-PR3 blocking: ``parallel_tool_calls=False`` must build an
+    # exactly-one-call grammar (``single_call=True`` to the builder); ``True`` /
+    # unset keep the one-or-more ``required`` grammar.
+    from vllm_mlx.api import tool_grammar as tg_mod
+    from vllm_mlx.routes import chat as chat_mod
+
+    captured = {}
+
+    def _spy_build(flat_tools, mode, parser, *, single_call=False):
+        captured["single_call"] = single_call
+        return None
+
+    monkeypatch.setattr(tg_mod, "build_tool_grammar", _spy_build)
+
+    engine = _EngineStub(tok)
+    cfg = _CfgStub("hermes")
+
+    class _Req:
+        def __init__(self, ptc):
+            self.tools = [_FunctionTool("get_time")]
+            self.tool_choice = "required"
+            self.parallel_tool_calls = ptc
+
+    def _single_call_for(ptc):
+        captured.clear()
+        chat_mod._maybe_build_tool_grammar_processor(engine, cfg, _Req(ptc))
+        return captured.get("single_call")
+
+    assert _single_call_for(False) is True, "parallel_tool_calls=False -> single"
+    assert _single_call_for(True) is False, "parallel_tool_calls=True -> one-or-more"
+    assert _single_call_for(None) is False, "unset -> one-or-more (OpenAI default)"
+
+
+@_requires_llguidance
+def test_broken_grammar_yields_none_so_fallback_stays_active(tok, monkeypatch):
+    # codex #558-PR3: a matcher that fails to compile is ``_broken`` and masks
+    # NOTHING. ``_maybe_build_tool_grammar_processor`` must return ``None`` for
+    # a broken processor so the route keeps the forced-prefix / free-form
+    # fallback active — never set an inert ``grammar_logits_processor`` that
+    # both disables the fallback AND leaves output unconstrained.
+    from vllm_mlx.api import tool_grammar as tg_mod
+    from vllm_mlx.routes import chat as chat_mod
+
+    # Real builder path, but force the processor to report itself broken.
+    class _BrokenProc:
+        def __init__(self, *a, **k):
+            pass
+
+        def is_broken(self):
+            return True
+
+    monkeypatch.setattr(tg_mod, "build_tool_grammar", lambda *a, **k: "GRAMMAR")
+    monkeypatch.setattr(tg_mod, "GrammarLogitsProcessor", _BrokenProc)
+
+    engine = _EngineStub(tok)
+    cfg = _CfgStub("hermes")
+    request = _RequestStub(tools=[_FunctionTool("get_time")], tool_choice="required")
+
+    result = chat_mod._maybe_build_tool_grammar_processor(engine, cfg, request)
+    assert result is None, (
+        "a broken (non-compiling) grammar must yield None so the established "
+        "fallback stays active — an inert processor would disable the fallback "
+        "AND leave output unconstrained"
+    )
+
+
+def test_broken_processor_reports_is_broken_and_masks_nothing():
+    # Unit-level guarantee behind the fallback: a GrammarLogitsProcessor built
+    # on an invalid grammar sets ``is_broken()`` and returns logits unchanged.
+    import importlib.util
+
+    if importlib.util.find_spec("llguidance") is None:
+        pytest.skip("llguidance ([guided] extra) not installed")
+
+    import mlx.core as mx
+
+    from vllm_mlx.api.tool_grammar import GrammarLogitsProcessor
+
+    class _FakeMatcher:
+        def __init__(self, *a, **k):
+            pass
+
+        def get_error(self):
+            return "unterminated grammar: deliberately invalid"
+
+    class _FakeLLTok:
+        vocab_size = 8
+
+    import vllm_mlx.api.tool_grammar as tg
+
+    # Patch the matcher + bitmask allocation so we don't need real llguidance
+    # internals for this pure broken-path assertion.
+    orig_matcher = tg.LLMatcher
+    orig_alloc = tg.allocate_token_bitmask
+    tg.LLMatcher = _FakeMatcher
+    tg.allocate_token_bitmask = lambda n, v: None
+    try:
+        proc = GrammarLogitsProcessor(_FakeLLTok(), "bad-grammar")
+        assert proc.is_broken() is True
+        logits = mx.zeros((1, 8))
+        out = proc(mx.array([1, 2, 3]), logits)
+        # Broken -> logits returned unchanged (no mask), same object/shape.
+        assert out.shape == logits.shape
+        import numpy as np
+
+        assert np.array_equal(np.array(out), np.array(logits))
+    finally:
+        tg.LLMatcher = orig_matcher
+        tg.allocate_token_bitmask = orig_alloc
+
+
+def test_forced_prefix_block_is_gated_on_grammar_absence():
+    # codex #558-PR3: the forced assistant prefix and the grammar are mutually
+    # exclusive — combining them baselines the injected prefix away and
+    # bypasses schema enforcement. The route builds ``_glp`` FIRST and gates
+    # the ``_forced_prefix`` block on ``_glp is None``. Assert that structural
+    # guarantee in the route source so a future edit that re-enables both
+    # together fails CI (a pure behavioral test would need to drive the whole
+    # ~600-line ``_create_chat_completion_impl``).
+    import inspect
+
+    from vllm_mlx.routes import chat as chat_mod
+
+    src = inspect.getsource(chat_mod._create_chat_completion_impl)
+    glp_pos = src.find("_maybe_build_tool_grammar_processor")
+    prefix_gate = src.find("if _glp is None and request.tools")
+    assert glp_pos != -1, "grammar processor build call not found in route"
+    assert prefix_gate != -1, (
+        "forced-prefix block must be gated on '_glp is None' — the two are "
+        "mutually exclusive (codex #558-PR3)"
+    )
+    assert glp_pos < prefix_gate, (
+        "the grammar processor must be built BEFORE the forced-prefix gate"
+    )

--- a/tests/test_grammar_scheduler_realign_558.py
+++ b/tests/test_grammar_scheduler_realign_558.py
@@ -1,0 +1,351 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Scheduler grammar/penalty processor↔uid realignment (#558 PR-3, codex).
+
+mlx-lm's ``GenerationBatch`` stores ``logits_processors`` as a positional
+per-uid list. When a NO-processor request finishes while a grammar request is
+mid-flight, a stale entry can survive the filter and DESYNC that list from
+``uids`` — mlx-lm's ``_step`` then iterates ``range(len(uids))`` and applies
+the wrong (or no) processor, silently leaving an explicit ``required``/named
+call unconstrained (observed live on qwen3.5-4b: the first tool request after
+the boot warmup fell back to free-form).
+
+``Scheduler._realign_grammar_logits_processors`` rebuilds the positional list
+from AUTHORITATIVE per-uid state: ``uid_to_request_processors`` holds the FULL
+processor list (grammar + penalties) for EVERY live uid that carries any
+processor — grammar AND penalty-only — so a bystander's penalties survive a
+length-desync rebuild (codex #3). A ``_known_grammar_processors`` identity set
+(with tombstones for finished-but-still-leaked grammars) scrubs leaked grammars
+from untracked slots. These tests drive that method against a stand-in
+generation batch reproducing the desync shapes — no model needed.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+
+class _FakeBatchGen:
+    """Minimal stand-in for mlx-lm's BatchGenerator + its _generation_batch."""
+
+    def __init__(self, uids, logits_processors):
+        self._generation_batch = SimpleNamespace(
+            uids=list(uids),
+            logits_processors=[list(x) for x in logits_processors],
+        )
+
+
+def _make_scheduler_stub():
+    """Bind the realign + forget methods onto a bare state object (no model)."""
+    from vllm_mlx.scheduler import Scheduler
+
+    stub = SimpleNamespace(
+        uid_to_request_processors={},
+        _uids_with_grammar=set(),
+        _known_grammar_processors=set(),
+        _grammar_processor_objs={},
+        _grammar_tombstones=set(),
+        batch_generator=None,
+    )
+    stub._realign_grammar_logits_processors = (
+        Scheduler._realign_grammar_logits_processors.__get__(stub, type(stub))
+    )
+    stub._flush_grammar_tombstones = Scheduler._flush_grammar_tombstones.__get__(
+        stub, type(stub)
+    )
+    stub._forget_uid_grammar = Scheduler._forget_uid_grammar.__get__(stub, type(stub))
+    return stub
+
+
+def _register(stub, uid, processors, grammar=None):
+    """Mirror the scheduler's insert-time bookkeeping.
+
+    ``grammar=None`` registers a penalty-only uid (tracked for desync repair but
+    not a grammar). A non-None ``grammar`` also registers its identity + arms
+    the guard, exactly like the scheduler insert site.
+    """
+    if processors:
+        stub.uid_to_request_processors[uid] = list(processors)
+    if grammar is not None:
+        stub._uids_with_grammar.add(uid)
+        stub._known_grammar_processors.add(id(grammar))
+        stub._grammar_processor_objs[id(grammar)] = grammar
+
+
+def test_realign_repairs_stale_leading_entry():
+    # The live-repro shape: a finished no-processor uid left a stale empty
+    # entry at index 0; the grammar uid sits at index 1 but is the ONLY live
+    # uid. Realign must place the grammar processor at the grammar uid's real
+    # position.
+    glp = object()
+    stub = _make_scheduler_stub()
+    _register(stub, 42, [glp], glp)
+    stub.batch_generator = _FakeBatchGen(uids=[42], logits_processors=[[], [glp]])
+
+    stub._realign_grammar_logits_processors()
+
+    lp = stub.batch_generator._generation_batch.logits_processors
+    assert len(lp) == 1, "logits_processors must be realigned to len(uids)"
+    assert lp[0] == [glp], "the grammar processor must land at its uid's index"
+
+
+def test_realign_two_uids_grammar_not_leaked():
+    # A grammar request (uid 7) batched alongside a plain request (uid 9).
+    # uid 7 -> [glp]; uid 9 -> [] (no grammar leaked onto it) even when the
+    # desynced list wrongly had glp on both slots.
+    glp = object()
+    stub = _make_scheduler_stub()
+    _register(stub, 7, [glp], glp)
+    stub.batch_generator = _FakeBatchGen(uids=[7, 9], logits_processors=[[glp], [glp]])
+
+    stub._realign_grammar_logits_processors()
+
+    lp = stub.batch_generator._generation_batch.logits_processors
+    assert lp[0] == [glp], "uid 7 must keep its grammar processor"
+    assert lp[1] == [], "uid 9 must NOT carry another uid's grammar processor"
+
+
+def test_realign_preserves_penalties_on_grammar_uid():
+    # A grammar uid's penalty processors must be PRESERVED — the authoritative
+    # per-uid list carries grammar + penalties in insert order.
+    glp = object()
+    penalty = object()
+    stub = _make_scheduler_stub()
+    _register(stub, 5, [penalty, glp], glp)
+    # Desynced batch (length mismatch) — a naive rebuild would drop penalty.
+    stub.batch_generator = _FakeBatchGen(
+        uids=[5], logits_processors=[[], [penalty, glp]]
+    )
+
+    stub._realign_grammar_logits_processors()
+
+    lp = stub.batch_generator._generation_batch.logits_processors
+    assert lp[0] == [penalty, glp], "grammar uid must keep penalty + grammar in order"
+
+
+def test_realign_preserves_untracked_penalty_when_aligned():
+    # A penalty-only uid keeps its penalties when the list is length-aligned.
+    glp = object()
+    penalty = object()
+    stub = _make_scheduler_stub()
+    _register(stub, 7, [glp], glp)  # a grammar uid must exist to trigger realign
+    _register(stub, 9, [penalty])  # penalty-only uid, now TRACKED
+    stub.batch_generator = _FakeBatchGen(
+        uids=[7, 9], logits_processors=[[glp], [penalty]]
+    )
+
+    stub._realign_grammar_logits_processors()
+
+    lp = stub.batch_generator._generation_batch.logits_processors
+    assert lp[0] == [glp]
+    assert lp[1] == [penalty], "tracked penalty-only uid's penalty must be preserved"
+
+
+def test_realign_preserves_penalty_only_uid_on_desync():
+    # codex #3 (the load-bearing regression): when the positional list is
+    # LENGTH-DESYNCED, a penalty-only bystander must NOT lose its penalties.
+    # Before the fix, an untracked uid got [] on a desync, permanently deleting
+    # its repetition/frequency/presence processors (running requests are never
+    # re-inserted). Now every processor-carrying uid is tracked, so its slot is
+    # reconstructed verbatim from uid-keyed state.
+    glp = object()
+    penalty = object()
+    stub = _make_scheduler_stub()
+    _register(stub, 7, [glp], glp)
+    _register(stub, 9, [penalty])  # penalty-only, tracked
+    # Desync: a stale entry makes the positional list longer than uids.
+    stub.batch_generator = _FakeBatchGen(
+        uids=[7, 9], logits_processors=[[], [glp], [penalty]]
+    )
+
+    stub._realign_grammar_logits_processors()
+
+    lp = stub.batch_generator._generation_batch.logits_processors
+    assert len(lp) == 2, "realigned to len(uids)"
+    assert lp[0] == [glp]
+    assert lp[1] == [penalty], (
+        "penalty-only uid must keep its penalties across a length-desync — "
+        "not be zeroed (codex #3)"
+    )
+
+
+def test_realign_untracked_uid_with_no_processors_gets_empty_slot():
+    # A truly processor-free uid (never registered) gets an empty slot, and any
+    # grammar that leaked into it is scrubbed.
+    glp = object()
+    stub = _make_scheduler_stub()
+    _register(stub, 7, [glp], glp)
+    # uid 9 was never registered (no processors) but a desync leaked glp in.
+    stub.batch_generator = _FakeBatchGen(uids=[7, 9], logits_processors=[[glp], [glp]])
+
+    stub._realign_grammar_logits_processors()
+
+    lp = stub.batch_generator._generation_batch.logits_processors
+    assert lp[0] == [glp]
+    assert lp[1] == [], "processor-free uid must get an empty, grammar-scrubbed slot"
+
+
+def test_realign_scrubs_finished_grammar_via_tombstone():
+    # codex #1: a grammar whose owning uid already FINISHED can still linger in
+    # another slot. _forget_uid_grammar TOMBSTONES it (keeps it in
+    # _known_grammar_processors) so realign still scrubs it; only once it's
+    # absent from every live slot is it fully forgotten.
+    glp_live = object()
+    glp_dead = object()  # finished owner, but leaked into uid 9's slot
+    stub = _make_scheduler_stub()
+    _register(stub, 7, [glp_live], glp_live)
+    _register(stub, 8, [glp_dead], glp_dead)
+    # uid 8 finishes: forget tombstones glp_dead (still known + scrubbable).
+    stub._forget_uid_grammar(8)
+    assert id(glp_dead) in stub._known_grammar_processors, (
+        "must be tombstoned, not gone"
+    )
+    assert id(glp_dead) in stub._grammar_tombstones
+    # A leaked slot still carries glp_dead at uid 9's (untracked) position.
+    stub.batch_generator = _FakeBatchGen(
+        uids=[7, 9], logits_processors=[[glp_live], [glp_dead]]
+    )
+
+    stub._realign_grammar_logits_processors()
+
+    lp = stub.batch_generator._generation_batch.logits_processors
+    assert lp[0] == [glp_live]
+    assert lp[1] == [], "a finished (tombstoned) grammar must be scrubbed"
+    # Now that it's absent from every slot, the tombstone is flushed.
+    assert id(glp_dead) not in stub._known_grammar_processors
+    assert id(glp_dead) not in stub._grammar_tombstones
+    assert id(glp_dead) not in stub._grammar_processor_objs
+
+
+def test_tombstone_survives_until_absent_then_flushes():
+    # A tombstoned grammar that is STILL present in a leaked slot is NOT
+    # forgotten on this tick — it stays known so the NEXT tick can still scrub
+    # it. Only when absent from every slot does the flush drop it. This closes
+    # the cleanup-ordering gap where the last grammar finishing would disarm the
+    # guard before its leaked slot was cleaned.
+    glp_dead = object()
+    stub = _make_scheduler_stub()
+    _register(stub, 8, [glp_dead], glp_dead)
+    stub._forget_uid_grammar(8)  # tombstoned; uid_to_request_processors now empty
+    # A stale slot still holds glp_dead at an untracked position. The guard is
+    # armed by the tombstone even though uid_to_request_processors is empty.
+    assert stub._grammar_tombstones, "tombstone must arm the realign guard"
+    stub.batch_generator = _FakeBatchGen(uids=[9], logits_processors=[[glp_dead]])
+
+    stub._realign_grammar_logits_processors()
+
+    lp = stub.batch_generator._generation_batch.logits_processors
+    assert lp[0] == [], "the tombstoned grammar is scrubbed from the leaked slot"
+    # Scrubbed this tick -> now absent -> flushed.
+    assert id(glp_dead) not in stub._known_grammar_processors
+
+
+def test_realign_noop_when_already_correct():
+    glp = object()
+    stub = _make_scheduler_stub()
+    _register(stub, 1, [glp], glp)
+    stub.batch_generator = _FakeBatchGen(uids=[1], logits_processors=[[glp]])
+
+    stub._realign_grammar_logits_processors()
+
+    lp = stub.batch_generator._generation_batch.logits_processors
+    assert lp == [[glp]]
+
+
+def test_penalty_only_uid_does_not_arm_the_guard():
+    # codex #558-PR3 (perf): a penalty-only request is tracked in
+    # uid_to_request_processors for desync repair, but MUST NOT be in
+    # _uids_with_grammar — the realign guard arms on _uids_with_grammar (not the
+    # broader processor map), so plain penalty traffic never triggers an
+    # O(batch) rebuild every token.
+    penalty = object()
+    stub = _make_scheduler_stub()
+    _register(stub, 9, [penalty])  # penalty-only, grammar=None
+
+    assert 9 in stub.uid_to_request_processors, "tracked for desync repair"
+    assert 9 not in stub._uids_with_grammar, "penalty-only must NOT arm the guard"
+    assert not stub._known_grammar_processors
+    assert not stub._grammar_tombstones
+
+
+def test_forget_penalty_only_uid_creates_no_tombstone():
+    penalty = object()
+    stub = _make_scheduler_stub()
+    _register(stub, 9, [penalty])  # penalty-only
+
+    stub._forget_uid_grammar(9)
+
+    assert 9 not in stub.uid_to_request_processors
+    assert not stub._grammar_tombstones, "a penalty-only uid must not tombstone"
+    assert not stub._known_grammar_processors
+
+
+def test_forget_uid_grammar_tombstones_then_flush_drops_state():
+    glp = object()
+    stub = _make_scheduler_stub()
+    _register(stub, 1, [glp], glp)
+    assert id(glp) in stub._known_grammar_processors
+
+    stub._forget_uid_grammar(1)
+
+    # uid-keyed state is gone immediately; the grammar identity is TOMBSTONED
+    # (still known so a leaked slot can be scrubbed) until a flush confirms it's
+    # absent from every slot.
+    assert 1 not in stub.uid_to_request_processors
+    assert 1 not in stub._uids_with_grammar
+    assert id(glp) in stub._known_grammar_processors, "tombstoned, not yet dropped"
+    assert id(glp) in stub._grammar_tombstones
+
+    # No slot holds it -> flush drops it entirely.
+    stub._flush_grammar_tombstones(present=set())
+    assert id(glp) not in stub._known_grammar_processors
+    assert id(glp) not in stub._grammar_processor_objs
+    assert id(glp) not in stub._grammar_tombstones
+
+
+def test_realign_handles_missing_generation_batch():
+    stub = _make_scheduler_stub()
+    _register(stub, 1, [object()], object())
+    stub.batch_generator = SimpleNamespace(_generation_batch=None)
+    stub._realign_grammar_logits_processors()  # no raise
+
+
+def test_realign_handles_empty_uids_flushes_tombstones():
+    glp_dead = object()
+    stub = _make_scheduler_stub()
+    _register(stub, 1, [glp_dead], glp_dead)
+    stub._forget_uid_grammar(1)  # tombstoned
+    stub.batch_generator = _FakeBatchGen(uids=[], logits_processors=[])
+    stub._realign_grammar_logits_processors()  # no raise
+    # No live slots -> tombstone is trivially absent everywhere -> flushed.
+    assert id(glp_dead) not in stub._known_grammar_processors
+
+
+def test_realign_empty_uids_scrubs_stale_processor_list():
+    # codex #558-PR3 blocking: the LAST grammar request finished and the batch
+    # emptied its ``uids`` WITHOUT the parallel positional ``logits_processors``
+    # list being cleared (mlx-lm keys the two separately). If realign only
+    # flushed the tombstone and returned, the leaked ``[glp_dead]`` at index 0
+    # would be inherited by the NEXT admitted plain request and silently
+    # constrain it. The no-live-slots branch must scrub the stale list to ``[]``
+    # while the grammar identity is still known.
+    glp_dead = object()
+    stub = _make_scheduler_stub()
+    _register(stub, 1, [glp_dead], glp_dead)
+    stub._forget_uid_grammar(1)  # tombstoned (uid gone, processor may linger)
+    # uids empty, but a stale processor slot survived the filter.
+    stub.batch_generator = _FakeBatchGen(uids=[], logits_processors=[[glp_dead]])
+
+    stub._realign_grammar_logits_processors()
+
+    lp = stub.batch_generator._generation_batch.logits_processors
+    assert lp == [], (
+        "a batch with zero uids must carry zero processors — the leaked grammar "
+        "slot must be scrubbed so the next plain request cannot inherit it"
+    )
+    # And the tombstone is flushed now that the grammar is absent everywhere.
+    assert id(glp_dead) not in stub._known_grammar_processors
+    assert id(glp_dead) not in stub._grammar_tombstones
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_no_out_of_band_routing.py
+++ b/tests/test_no_out_of_band_routing.py
@@ -375,6 +375,18 @@ ALLOWED_RAPID_MLX_ENV_VARS: frozenset[str] = frozenset(
         # a model, parser, or routing tier; identical semantic shape
         # to ``RAPID_MLX_PREFIX_CACHE_SHUTDOWN_BUDGET`` above.
         "RAPID_MLX_MTP_DISPATCH_TIMEOUT_SEC",
+        # #558 PR-3a grammar-constrained tool-calling opt-in toggle. A
+        # per-feature ON/OFF switch, NOT a routing decision. Defaults OFF in
+        # PR-3a (client-schema DoS-hardening is PR-3b); when set to
+        # ``1``/``on``/``true`` the chat route builds the per-request
+        # ``GrammarLogitsProcessor`` for explicit ``tool_choice`` (required /
+        # named), else it falls back to today's free-form-then-parse behavior.
+        # It never selects a model, parser, or tier — which model loads, which
+        # tool parser fires, which tier engages is all unchanged; it only
+        # decides whether an already-chosen explicit tool call is
+        # structurally masked. Read only by
+        # ``routes/chat.py::_tool_grammar_eligible``.
+        "RAPID_MLX_CONSTRAIN_TOOLS",
     }
 )
 

--- a/tests/test_tool_grammar_558.py
+++ b/tests/test_tool_grammar_558.py
@@ -246,6 +246,25 @@ def test_lark_quantifier_tracks_tool_choice():
     )
 
 
+def test_lark_single_call_forces_exactly_one_tag():
+    # parallel_tool_calls=False -> single_call -> EXACTLY ONE call (no
+    # quantifier). Overrides the ``required`` ``+`` so the grammar can't emit
+    # multiple calls (codex #558-PR3 blocking).
+    from vllm_mlx.api.tool_grammar import build_tool_lark
+
+    infos = [_hermes_structure_info()(t["name"]) for t in TOOLS]
+    lark = build_tool_lark(TOOLS, "required", infos, single_call=True)
+    # No trailing repetition quantifier on the alternation -> exactly one tag.
+    assert "start: (tag_0 | tag_1) tag_end" in lark
+    assert "start: (tag_0 | tag_1)+ tag_end" not in lark
+    assert "start: (tag_0 | tag_1)* tag_end" not in lark
+    # single_call does not override auto's zero-or-more (auto never sets it, but
+    # be explicit that auto stays ``*`` even if single_call were passed).
+    assert "start: (tag_0 | tag_1)* tag_end" in build_tool_lark(
+        TOOLS, "auto", infos, single_call=True
+    )
+
+
 def test_named_choice_narrows_to_single_forced_tag():
     # A NAMED tool_choice is expressed by the caller narrowing ``tools`` to the
     # single requested function before calling the builder (design §4). The

--- a/vllm_mlx/api/tool_grammar.py
+++ b/vllm_mlx/api/tool_grammar.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Grammar-constrained tool calling (#558) — grammar builder (PR-1).
+"""Grammar-constrained tool calling (#558) — grammar builder + runtime processor.
 
 This module turns a chat request's ``tools`` + ``tool_choice`` into an
 llguidance grammar that STRUCTURALLY GUARANTEES every emitted tool call
@@ -8,13 +8,14 @@ satisfy that tool's JSON Schema, and (c) uses the model family's tool-call
 wire format. It constrains only the FORM of a call, never the decision of
 whether/which to call.
 
-Scope of this PR-1: the pure, side-effect-free grammar BUILDER plus the
-``StructureInfo`` wire-triple dataclass and a compiled-grammar LRU cache.
-**Nothing here is wired into the request path** — no logits processor, no
-scheduler/chat.py routing. ``build_tool_grammar`` has no call sites yet, so
-this file is no-behavior-change scaffolding. The runtime
-``GrammarLogitsProcessor`` and its wiring land in PR-3; the per-family
-``ToolParser.structure_info()`` overrides land in PR-2.
+Layering: the pure, side-effect-free grammar BUILDER (``build_tool_grammar`` /
+``build_tool_lark``), the ``StructureInfo`` wire-triple dataclass and the
+compiled-grammar LRU cache landed in PR-1; the per-family
+``ToolParser.structure_info()`` overrides landed in PR-2. PR-3 (this change)
+adds the RUNTIME half: ``GrammarLogitsProcessor`` (the per-token mask that
+applies a compiled grammar to logits each decode step) and ``build_lltokenizer``
+(the ``LLTokenizer`` factory). The chat route / scheduler wiring that carries a
+per-request processor into the decode loop lands alongside these in PR-3.
 
 Design + prior-art: ``design-558-constrained-tool-calling.md``. The
 mechanism is the "structural tags with triggers" pattern that vLLM
@@ -38,6 +39,8 @@ list of "sentinel" substrings that must render as special-token refs.
 
 import json
 import logging
+import threading
+import weakref
 from dataclasses import dataclass, field
 from functools import lru_cache
 from typing import Any
@@ -45,16 +48,45 @@ from typing import Any
 logger = logging.getLogger(__name__)
 
 # Reuse the exact llguidance surface the guided-decoding path already imports
-# (proves availability + shares the native MLX mask kernel). Only the
-# compile-side factory (``LLMatcher.grammar_from_lark``) is used here; the
-# per-token mask kernel is a PR-3 concern and is deliberately not imported.
+# (proves availability + shares the native MLX mask kernel). Detection is split
+# into two INDEPENDENT layers so a failure in the runtime-only bridge cannot
+# disable the grammar BUILDER (codex #558-PR3):
+#
+#   * BUILDER + mask layer (``HAS_LLGUIDANCE``): the compile-side factory
+#     (``LLMatcher.grammar_from_lark``) drives ``build_tool_grammar``, and the
+#     per-token mask kernel (``allocate_token_bitmask`` /
+#     ``fill_next_token_bitmask`` / ``apply_token_bitmask``) drives the mask in
+#     ``GrammarLogitsProcessor``. If this layer is present the builder works.
+#   * RUNTIME BRIDGE layer (``HAS_LL_TOKENIZER``): ``llguidance.hf`` +
+#     ``LLTokenizer`` build the tokenizer that the runtime processor needs. If
+#     ONLY this layer is missing, grammars still compile — the runtime falls
+#     back (``get_lltokenizer`` returns ``None`` -> free-form) without falsely
+#     reporting the whole feature unavailable.
 try:
-    from llguidance.mlx import LLMatcher
+    from llguidance.mlx import (
+        LLMatcher,
+        allocate_token_bitmask,
+        apply_token_bitmask,
+        fill_next_token_bitmask,
+    )
 
     HAS_LLGUIDANCE = True
 except ImportError:  # pragma: no cover - mirrors guided.py degrade path
     HAS_LLGUIDANCE = False
     LLMatcher = None
+    allocate_token_bitmask = None
+    apply_token_bitmask = None
+    fill_next_token_bitmask = None
+
+try:
+    import llguidance.hf as _llguidance_hf
+    from llguidance import LLTokenizer
+
+    HAS_LL_TOKENIZER = True
+except ImportError:  # pragma: no cover - runtime bridge only
+    HAS_LL_TOKENIZER = False
+    _llguidance_hf = None
+    LLTokenizer = None
 
 
 @dataclass(frozen=True)
@@ -240,6 +272,8 @@ def build_tool_lark(
     tools: list[dict[str, Any]],
     tool_choice: str,
     structure_infos: list["StructureInfo"],
+    *,
+    single_call: bool = False,
 ) -> str:
     """Assemble the Lark grammar for a set of per-tool structure triples.
 
@@ -249,6 +283,14 @@ def build_tool_lark(
 
       * ``auto``                        -> ``(...)*``  (may emit zero calls)
       * ``required`` / a function name  -> ``(...)+``  (design R1: ≥1 forced)
+
+    ``single_call=True`` (OpenAI ``parallel_tool_calls=False``) forces EXACTLY
+    ONE call — the alternation carries NO repetition quantifier, so the model
+    must emit exactly one tag and stop. This overrides the ``required`` ``+``
+    (``auto`` never sets ``single_call`` — a zero-or-one grammar would still let
+    ``auto`` emit no call, which the ``*`` already allows). Without this the
+    ``required`` grammar could emit multiple calls even when the client
+    explicitly disabled parallel calls (codex #558-PR3).
 
     ``"none"`` must NOT reach this function — ``none`` produces no grammar at
     all (the model sees no tools, design §4); passing it here is a caller
@@ -309,8 +351,14 @@ def build_tool_lark(
                 f"sentinel (trigger={si.trigger!r}, sentinels={si.sentinels!r})"
             )
 
-    # auto -> zero-or-more (may emit no call); everything else forces ≥1.
-    quant = "*" if tool_choice == "auto" else "+"
+    # auto -> zero-or-more (may emit no call); single_call -> exactly one (no
+    # quantifier); everything else forces ≥1.
+    if tool_choice == "auto":
+        quant = "*"
+    elif single_call:
+        quant = ""  # exactly one tag: parallel_tool_calls=False
+    else:
+        quant = "+"
     tag_names = " | ".join(f"tag_{i}" for i in range(len(tools)))
     lark = (
         "%llguidance {}\n"
@@ -364,6 +412,8 @@ def build_tool_grammar(
     tools: list[dict[str, Any]],
     tool_choice: str,
     parser: Any,
+    *,
+    single_call: bool = False,
 ) -> str | None:
     """Public entry: (tools, tool_choice, parser) -> compiled llguidance grammar.
 
@@ -445,9 +495,383 @@ def build_tool_grammar(
         structure_infos.append(si)
 
     try:
-        lark = build_tool_lark(tools, tool_choice, structure_infos)
+        lark = build_tool_lark(
+            tools, tool_choice, structure_infos, single_call=single_call
+        )
     except ValueError:
         # Malformed structure_info / unsupported tool_choice -> free-form.
         logger.exception("tool-grammar: build_tool_lark rejected inputs")
         return None
     return _compile_lark_cached(lark)
+
+
+# --------------------------------------------------------------------------
+# Runtime logits processor (design §3.3 / §5). Mirrors the
+# ``MiniMaxToolLogitsProcessor.__call__(token_ids, logits)`` signature the
+# scheduler's per-request ``request_processors`` slot expects, so a
+# ``GrammarLogitsProcessor`` composes with the penalty processors already in
+# that slot.
+# --------------------------------------------------------------------------
+class GrammarLogitsProcessor:
+    """Applies a compiled llguidance grammar mask to logits each decode step.
+
+    Contract with mlx-lm's decode loop: the processor is called every step
+    with ``(token_ids, logits)`` where ``token_ids`` is the FULL CUMULATIVE
+    sequence so far (prompt + everything generated), NOT just the newly
+    sampled token. ``TokenBuffer.update_and_fetch`` returns ``buffer[:end]``,
+    so the prompt tokens are present on the very first call. Feeding those
+    prompt tokens into the grammar matcher would immediately reject them
+    (the grammar describes the tool-call OUTPUT, not the prompt) and break
+    the constraint. This processor therefore BASELINES past the prompt on the
+    first call and only ever advances the matcher over generated tokens.
+
+    Reasoning-aware (design §5): if a ``reasoning_end_token`` is supplied, the
+    mask is held OFF (all tokens allowed) until that token string appears in
+    the decoded output, so a ``<think>...</think>`` block is not constrained.
+    The chat route deliberately passes ``reasoning_end_token=None`` and relies
+    on PATH A (the grammar's own lazy ``TAG_TEXT`` free prefix swallows
+    reasoning before the trigger) — a runtime gate keyed on ``</think>`` is a
+    footgun for models that emit no reasoning (the mask would stay off
+    forever). The flag remains for defense-in-depth callers that want path B.
+    """
+
+    def __init__(
+        self,
+        lltokenizer: Any,
+        grammar: str,
+        *,
+        reasoning_end_token: str | None = None,
+        tokenizer: Any = None,
+    ):
+        self._lltok = lltokenizer
+        self._matcher = LLMatcher(lltokenizer, grammar)
+        err = self._matcher.get_error()
+        # A non-empty ``get_error()`` means the grammar failed to compile. A
+        # broken matcher masks nothing (``__call__`` returns logits unchanged),
+        # so callers MUST NOT treat a broken processor as an active constraint —
+        # they should fall back to free-form / forced-prefix instead. The route
+        # builder (``_maybe_build_tool_grammar_processor``) checks ``is_broken``
+        # and returns ``None`` in that case (codex #558-PR3).
+        self._compile_error = err or None
+        self._broken = bool(err)
+        if err:
+            logger.error("tool-grammar: matcher compile error: %s", err)
+        self._vocab = lltokenizer.vocab_size
+        self._bitmask = allocate_token_bitmask(1, self._vocab)
+        self._reasoning_end_token = reasoning_end_token
+        self._reasoning_ended = reasoning_end_token is None
+        self._tokenizer = tokenizer
+        # mlx-lm passes the FULL cumulative token sequence each step (see class
+        # docstring). ``_prompt_len`` is the baseline captured on the first
+        # call; ``_committed`` tracks how many of the cumulative ids have been
+        # consumed into the matcher so far.
+        self._prompt_len: int | None = None
+        self._committed = 0
+
+    def is_broken(self) -> bool:
+        """Whether the grammar failed to compile (masks nothing; use fallback)."""
+        return self._broken
+
+    def _maybe_open_after_reasoning(self, token_ids: Any) -> None:
+        if self._reasoning_ended or self._tokenizer is None:
+            return
+        try:
+            gen_ids = list(token_ids)
+            if self._prompt_len is not None:
+                gen_ids = gen_ids[self._prompt_len :]
+            text = self._tokenizer.decode(gen_ids)
+        except Exception:
+            return
+        if self._reasoning_end_token in text:
+            self._reasoning_ended = True
+
+    def __call__(self, token_ids: Any, logits: Any) -> Any:
+        if self._broken:
+            return logits
+        # mlx-lm hands us the FULL cumulative sequence (prompt + generated) each
+        # step. NEVER copy the whole thing (``list(token_ids)`` would be O(n) per
+        # step => O(n^2) over a long constrained generation — codex #558-PR3).
+        # ``len(...)`` is O(1); we only ever materialize the UNCOMMITTED TAIL.
+        n = len(token_ids)
+        if self._prompt_len is None:
+            # First step: everything present so far is the prompt — no token
+            # has been sampled and appended yet at mask-compute time. Baseline
+            # here so the matcher is NEVER fed prompt tokens (MUST-FIX #1).
+            self._prompt_len = n
+            self._committed = n
+        # Commit any newly-generated tokens since the last call so the matcher
+        # state tracks the real output stream (design §6: commit every token).
+        # Slice ONLY the new tail — never the already-committed prefix.
+        if self._committed < n:
+            tail = token_ids[self._committed : n]
+            for t in tail:
+                self._committed += 1
+                if not self._reasoning_ended:
+                    continue
+                tok = int(t)
+                if not self._matcher.consume_token(tok):
+                    logger.debug(
+                        "tool-grammar: matcher rejected committed token %d", tok
+                    )
+
+        # Reasoning gate is checked AFTER committing this step's tokens. NOTE
+        # (codex #558-PR3 nit, path B only): if a single multi-token update
+        # carried both ``</think>`` and the first post-reasoning tool-call
+        # tokens, those tokens are advanced past without being consumed here.
+        # Precise ``</think>``-boundary token alignment (excluding the reasoning
+        # bytes but consuming the tail) is design §7 open-Q1, deferred with the
+        # PR-5 auto path. This is dormant in production: the chat route uses
+        # PATH A (``reasoning_end_token=None`` => ``_reasoning_ended`` is True
+        # from construction, so the ``continue`` above never fires and every
+        # token is consumed). Only a defense-in-depth path-B caller that sets
+        # ``reasoning_end_token`` hits the deferral.
+        if not self._reasoning_ended:
+            self._maybe_open_after_reasoning(token_ids)
+        if not self._reasoning_ended:
+            return logits  # free generation during reasoning
+
+        if self._matcher.is_stopped():
+            return logits
+
+        fill_next_token_bitmask(self._matcher, self._bitmask, 0)
+        model_vocab = logits.shape[-1]
+        if model_vocab > self._vocab:
+            # The model head can be wider than the tokenizer vocab (padded
+            # embedding). The bitmask is real-vocab-width, so mask only the
+            # real-vocab prefix — but PRESERVE the original ``[..., model_vocab]``
+            # shape (the logits-processor contract: mlx-lm concatenates every
+            # row's processed logits, so a narrower return breaks batched
+            # decode — codex #558-PR3). Force the padded tail to ``-inf`` so
+            # those never-valid ids can't be sampled, then re-join.
+            import mlx.core as mx
+
+            head = apply_token_bitmask(logits[..., : self._vocab], self._bitmask)
+            tail_shape = (*logits.shape[:-1], model_vocab - self._vocab)
+            tail = mx.full(tail_shape, -float("inf"), dtype=logits.dtype)
+            return mx.concatenate([head, tail], axis=-1)
+        if model_vocab < self._vocab:
+            # Inverse case (codex #558-PR3): the TOKENIZER carries added tokens
+            # beyond the model's narrower output head. The bitmask is packed to
+            # the full tokenizer vocab (``ceil(vocab/32)`` int32 words), so
+            # applying it whole to the narrower logits would over-cover. Slice
+            # the packed bitmask to the model-width WORD count (each int32 word
+            # covers 32 ids) and apply that — any tokenizer id >= model_vocab
+            # has no logit column to sample from anyway, so dropping those tail
+            # words is safe. ``apply_token_bitmask`` reads only ``batch`` rows
+            # (no vocab-width assert), so the model-width prefix mask is enough.
+            words = (model_vocab + 31) // 32
+            return apply_token_bitmask(logits, self._bitmask[..., :words])
+        return apply_token_bitmask(logits, self._bitmask)
+
+    def reset(self) -> None:
+        self._matcher.reset()
+        self._prompt_len = None
+        self._committed = 0
+        self._reasoning_ended = self._reasoning_end_token is None
+
+
+def build_lltokenizer(tokenizer: Any) -> Any:
+    """Build an llguidance ``LLTokenizer`` from an mlx-lm ``TokenizerWrapper``.
+
+    llguidance needs the underlying *fast* (Rust-backed) transformers
+    tokenizer. mlx-lm's ``TokenizerWrapper`` exposes it at ``._tokenizer``
+    (what ``guided.py`` uses). We try candidates in priority order:
+
+      1. the wrapper's inner ``._tokenizer`` (a transformers 5.x
+         ``TokenizersBackend`` — this is what ``llguidance.hf.from_tokenizer``
+         accepts and is the common case);
+      2. the object as-is (for a raw fast tokenizer passed directly);
+      3. a DIRECT ``LLTokenizer(<tokenizer.json>)`` build from the fast
+         tokenizer's ``backend_tokenizer.to_str()``.
+
+    Candidate 3 is the spike-proven fallback for the transformers gotcha: on
+    some transformers revisions ``from_tokenizer``'s ``isinstance`` gate
+    rejects a ``Qwen2Tokenizer``-family object even though its serialized
+    ``tokenizer.json`` builds a valid ``LLTokenizer`` directly. ``guided.py``
+    has no such fallback, so tool-calling models on those revisions would
+    silently degrade to free-form; candidate 3 closes that gap.
+
+    Returns ``None`` if none of the candidates yields an ``LLTokenizer`` (the
+    caller degrades to today's free-form-then-parse behavior).
+    """
+    # Needs the runtime bridge (``llguidance.hf`` / ``LLTokenizer``), which is
+    # detected independently of the builder layer (codex #558-PR3).
+    if not HAS_LL_TOKENIZER:
+        return None
+
+    candidates = []
+    inner = getattr(tokenizer, "_tokenizer", None)
+    if inner is not None:
+        candidates.append(inner)
+    candidates.append(tokenizer)
+
+    # Candidates 1 & 2: llguidance.hf.from_tokenizer (the fast path).
+    for cand in candidates:
+        if getattr(cand, "is_fast", True) is False:
+            continue
+        try:
+            return _llguidance_hf.from_tokenizer(cand)
+        except Exception:
+            continue
+
+    # Candidate 3: direct build from the serialized fast tokenizer. Probe both
+    # the wrapper's inner tokenizer and the object itself for a
+    # ``backend_tokenizer`` exposing ``to_str()``.
+    for cand in candidates:
+        backend = getattr(cand, "backend_tokenizer", None)
+        to_str = getattr(backend, "to_str", None)
+        if to_str is None:
+            continue
+        try:
+            # No explicit ``n_vocab``: llguidance infers the true vocab from
+            # the serialized tokenizer (a too-small override is rejected).
+            return LLTokenizer(to_str())
+        except Exception:
+            continue
+
+    logger.warning("tool-grammar: could not build an LLTokenizer for this model")
+    return None
+
+
+# One ``LLTokenizer`` per model tokenizer. Building it is a ~1s, vocab-scale
+# operation (llguidance's own docstring flags it "expensive … should be
+# cached"), so rebuilding it on every explicit tool request would add real
+# latency + allocation churn to the async request path. The engine holds ONE
+# tokenizer for its lifetime, so we memoize per tokenizer.
+#
+# The ``LLTokenizer`` is a Rust object that CANNOT be weak-referenced, and a
+# ``TokenizerWrapper`` isn't reliably weak-referenceable either — so we cannot
+# use a WeakKey/WeakValue dictionary. Instead we (a) stash the built tokenizer
+# as a private attribute ON the tokenizer (primary cache; dies with the
+# tokenizer, no leak) and (b) fall back to a ``WeakKeyDictionary`` on the
+# tokenizer when it's weak-referenceable but rejects attribute assignment.
+# Both are keyed on the live tokenizer object, so a swapped/reloaded model
+# drops its stale entry automatically. A tokenizer that can't back an
+# ``LLTokenizer`` is remembered via a per-tokenizer sentinel so we don't
+# rebuild-and-fail on every request — but only AFTER a bounded retry budget, so
+# a TRANSIENT conversion/resource failure doesn't permanently disable grammar
+# enforcement for that tokenizer (codex #558-PR3 nit). Successful builds are
+# cached immediately; failures accrue toward the budget and are only sealed as
+# ``_LLTOKENIZER_UNAVAILABLE`` once exhausted.
+_LLTOKENIZER_ATTR = "_rapid_mlx_lltokenizer"
+_LLTOKENIZER_FAIL_ATTR = "_rapid_mlx_lltokenizer_fails"
+_LLTOKENIZER_MAX_BUILD_ATTEMPTS = 3  # transient failures retried before sealing
+_LLTOKENIZER_UNAVAILABLE = object()  # sentinel stored when build permanently fails
+_LLTOKENIZER_WEAK_CACHE: "weakref.WeakKeyDictionary[Any, Any]" = (
+    weakref.WeakKeyDictionary()
+)
+_LLTOKENIZER_FAIL_COUNTS: "weakref.WeakKeyDictionary[Any, int]" = (
+    weakref.WeakKeyDictionary()
+)
+# Single-flight lock around the cache-MISS build. ``get_lltokenizer`` now runs
+# inside ``asyncio.to_thread`` (chat route), so a cold traffic burst can land N
+# concurrent misses for the SAME tokenizer and, without this, each thread would
+# run the documented ~1s build (codex #558-PR3). We serialize the miss path and
+# re-check the caches inside the lock so the build happens at most once. The
+# lock is process-global (coarse) but only contended on the cold path — steady
+# state hits the lock-free cache reads above.
+_LLTOKENIZER_BUILD_LOCK = threading.Lock()
+
+
+def _lltokenizer_cache_get(tokenizer: Any) -> tuple[bool, Any]:
+    """Return ``(hit, value)`` from the attribute + weak caches (no build)."""
+    cached = getattr(tokenizer, _LLTOKENIZER_ATTR, None)
+    if cached is _LLTOKENIZER_UNAVAILABLE:
+        return True, None
+    if cached is not None:
+        return True, cached
+    try:
+        wcached = _LLTOKENIZER_WEAK_CACHE.get(tokenizer)
+    except TypeError:  # tokenizer not weak-referenceable
+        wcached = None
+    if wcached is _LLTOKENIZER_UNAVAILABLE:
+        return True, None
+    if wcached is not None:
+        return True, wcached
+    return False, None
+
+
+def get_lltokenizer(tokenizer: Any) -> Any:
+    """Return a cached ``LLTokenizer`` for ``tokenizer``, building once.
+
+    Thin memoizing wrapper over :func:`build_lltokenizer` (see it for the
+    candidate/fallback details). The ~1s build runs at most once per
+    tokenizer even under concurrent cold misses. Returns ``None`` (and
+    remembers it) when no ``LLTokenizer`` can be built.
+    """
+    if not HAS_LL_TOKENIZER or tokenizer is None:
+        return None
+    # Fast path: lock-free cache read.
+    hit, value = _lltokenizer_cache_get(tokenizer)
+    if hit:
+        return value
+
+    # Miss: serialize so concurrent to_thread callers don't all build (~1s each).
+    with _LLTOKENIZER_BUILD_LOCK:
+        # Re-check under the lock — another thread may have built it while we
+        # waited.
+        hit, value = _lltokenizer_cache_get(tokenizer)
+        if hit:
+            return value
+
+        built = build_lltokenizer(tokenizer)
+        if built is not None:
+            # Success: cache immediately and clear any accrued failure count.
+            _store_lltokenizer(tokenizer, built)
+            try:
+                _LLTOKENIZER_FAIL_COUNTS.pop(tokenizer, None)
+            except TypeError:
+                pass
+            return built
+
+        # Failure: only SEAL as permanently-unavailable once the retry budget is
+        # exhausted, so a transient conversion/resource error is retried on the
+        # next request instead of disabling grammar enforcement for the whole
+        # process lifetime (codex #558-PR3 nit).
+        fails = _bump_lltokenizer_fail_count(tokenizer)
+        if fails >= _LLTOKENIZER_MAX_BUILD_ATTEMPTS:
+            _store_lltokenizer(tokenizer, _LLTOKENIZER_UNAVAILABLE)
+        return None
+
+
+def _store_lltokenizer(tokenizer: Any, result: Any) -> None:
+    """Persist ``result`` (an ``LLTokenizer`` or the UNAVAILABLE sentinel)."""
+    try:
+        setattr(tokenizer, _LLTOKENIZER_ATTR, result)
+        return
+    except Exception:
+        pass
+    try:
+        _LLTOKENIZER_WEAK_CACHE[tokenizer] = result
+    except TypeError:
+        pass  # un-cacheable tokenizer: rebuild each call (correctness OK)
+
+
+def _bump_lltokenizer_fail_count(tokenizer: Any) -> int:
+    """Increment and return this tokenizer's accumulated build-failure count.
+
+    Prefers a per-tokenizer attribute (dies with the tokenizer, no leak); falls
+    back to a ``WeakKeyDictionary``; if neither is writable, treats every
+    failure as the FIRST attempt (never seals) so an un-cacheable tokenizer
+    keeps retrying rather than being wrongly disabled.
+    """
+    cur = getattr(tokenizer, _LLTOKENIZER_FAIL_ATTR, None)
+    if isinstance(cur, int):
+        nxt = cur + 1
+        try:
+            setattr(tokenizer, _LLTOKENIZER_FAIL_ATTR, nxt)
+            return nxt
+        except Exception:
+            pass
+    else:
+        try:
+            setattr(tokenizer, _LLTOKENIZER_FAIL_ATTR, 1)
+            return 1
+        except Exception:
+            pass
+    try:
+        nxt = _LLTOKENIZER_FAIL_COUNTS.get(tokenizer, 0) + 1
+        _LLTOKENIZER_FAIL_COUNTS[tokenizer] = nxt
+        return nxt
+    except TypeError:
+        return 1  # un-cacheable: always look like the first attempt, keep retrying

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -1682,6 +1682,9 @@ class BatchedEngine(BaseEngine):
         # below before the tool parser scans it.
         assistant_text_prefix = kwargs.pop("_assistant_text_prefix", "") or ""
         output_router_seed = kwargs.pop("_output_router_seed_token_ids", None)
+        # Grammar-constrained tool calling (#558): per-request logits
+        # processor forwarded to the scheduler's request_processors slot.
+        grammar_logits_processor = kwargs.pop("grammar_logits_processor", None)
         if output_router_seed is None and isinstance(prompt, str):
             # ``build_prompt(enable_thinking=False)`` is part of the public
             # engine contract and returns the prepared Harmony string. A
@@ -1705,6 +1708,7 @@ class BatchedEngine(BaseEngine):
             prefix_boundary=prefix_boundary,
             has_tools=has_tools,
             requires_prompt_integrity=requires_prompt_integrity,
+            grammar_logits_processor=grammar_logits_processor,
         )
 
         if assistant_text_prefix:
@@ -1892,12 +1896,15 @@ class BatchedEngine(BaseEngine):
         # PFlash routing hints (#287) — parity with generate().
         has_tools = bool(kwargs.pop("has_tools", False))
         requires_prompt_integrity = bool(kwargs.pop("requires_prompt_integrity", False))
+        # Grammar-constrained tool calling (#558) — streaming parity.
+        grammar_logits_processor = kwargs.pop("grammar_logits_processor", None)
         request_id = await self._engine.add_request(
             prompt=prompt,
             sampling_params=sampling_params,
             prefix_boundary=prefix_boundary,
             has_tools=has_tools,
             requires_prompt_integrity=requires_prompt_integrity,
+            grammar_logits_processor=grammar_logits_processor,
         )
         # C-01 force-abort: publish the scheduler request id (text path)
         # so the route's disconnect_guard can call abort_request directly

--- a/vllm_mlx/engine_core.py
+++ b/vllm_mlx/engine_core.py
@@ -741,6 +741,7 @@ class EngineCore:
         prefix_boundary: int = 0,
         has_tools: bool = False,
         requires_prompt_integrity: bool = False,
+        grammar_logits_processor: Any | None = None,
     ) -> str:
         """
         Add a request for processing.
@@ -775,6 +776,7 @@ class EngineCore:
             prefix_boundary=prefix_boundary,
             has_tools=has_tools,
             requires_prompt_integrity=requires_prompt_integrity,
+            grammar_logits_processor=grammar_logits_processor,
         )
 
         # Throttle requests for hybrid models (GatedDeltaNet + Transformer).

--- a/vllm_mlx/request.py
+++ b/vllm_mlx/request.py
@@ -170,6 +170,13 @@ class Request:
     has_tools: bool = False
     requires_prompt_integrity: bool = False
 
+    # Grammar-constrained tool calling (#558). Optional per-request logits
+    # processor that masks decoding to a tool-call grammar. Set by the chat
+    # route when ``tools`` + ``tool_choice in {required, named}`` and the
+    # family's parser declares a ``structure_info``. ``None`` -> today's
+    # free-form-then-parse behavior (non-breaking default).
+    grammar_logits_processor: Any | None = None
+
     # PFlash prompt compression state. When pflash_metadata["compressed"]
     # is True, prompt_token_ids is the compressed list and
     # original_prompt_token_ids holds the pre-compression sequence so

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -281,6 +281,218 @@ def _forced_tool_call_prefix(parser_name: str | None, function_name: str) -> str
     return None
 
 
+def _normalize_tool_choice_for_grammar(tool_choice) -> dict | None:
+    """Normalize an OpenAI ``tool_choice`` into a collision-safe tagged form.
+
+    Returns ``{"mode": "required"}`` or ``{"mode": "named", "name": <str>}``
+    for the two constrained-in-PR-3 modes, or ``None`` to skip grammar
+    constraint (``"auto"`` / ``"none"`` / anything unrecognized).
+
+    WHY A TAGGED FORM (deferred codex #2 — string collision): per the OpenAI
+    spec ``tool_choice`` is EITHER a string enum (``"auto" | "required" |
+    "none"``) OR an object ``{"type":"function","function":{"name":...}}``. A
+    tool NAME only ever appears inside the object form — never as a bare
+    string. So a tool literally named ``"required"`` (or ``"auto"`` /
+    ``"none"``) under ``tool_choice="auto"`` must be treated as AUTO (the tool
+    stays available, unconstrained), and selecting it requires the object form
+    ``{"type":"function","function":{"name":"required"}}``. Discriminating on
+    SHAPE here — bare string vs object — before any comparison against tool
+    names makes the string-enum path and the named-tool path structurally
+    unable to collide. The tool name is only ever read out of the object.
+
+    PR-3 SCOPE: only ``"required"`` and the named object form are constrained.
+    ``"auto"`` deliberately returns ``None`` (unconstrained — the auto-path
+    grammar is PR-5, paused pending operator greenlight), and ``"none"``
+    returns ``None`` (the model sees no tools; the #445 route handler already
+    drops ``request.tools``). ``None``/absent ``tool_choice`` is auto by
+    default -> also ``None`` here.
+    """
+    # Object form is the ONLY place a tool name appears: a named choice.
+    if isinstance(tool_choice, dict):
+        if tool_choice.get("type") == "function":
+            fn = tool_choice.get("function")
+            # ``function`` must be a dict. A malformed truthy-but-non-dict value
+            # (e.g. a string or list from external input) must degrade to
+            # free-form, NOT reach ``.get`` and raise an AttributeError -> HTTP
+            # 500 (codex #558-PR3 blocking). Anything non-dict -> unconstrained.
+            if isinstance(fn, dict):
+                name = fn.get("name")
+                if isinstance(name, str) and name:
+                    return {"mode": "named", "name": name}
+        return None
+    # Bare-string enum path (or None). Only ``"required"`` is constrained in
+    # PR-3; ``"auto"``/``"none"``/None all fall through to free-form.
+    if tool_choice == "required":
+        return {"mode": "required"}
+    return None
+
+
+def _tool_grammar_eligible(cfg, request) -> bool:
+    """Cheap synchronous gate: could this request possibly get a grammar?
+
+    Runs the trivial checks (env opt-in, tools present, a family parser
+    configured, and ``tool_choice`` in the PR-3a constrained set) with NO heavy
+    imports and NO grammar/tokenizer construction. The route calls this on the
+    event loop so the vast majority of traffic — requests without tools, and
+    ``"auto"``/``"none"`` choices — short-circuits WITHOUT ever entering the
+    thread offload. Only an eligible request pays the ``asyncio.to_thread``
+    offload for the actual (possibly ~1s cold) build (codex #558-PR3).
+
+    OPT-IN (PR-3a scope): ``RAPID_MLX_CONSTRAIN_TOOLS`` defaults to OFF. PR-3a
+    ships the runtime WITHOUT the client-schema size/depth/count DoS caps and
+    the bounded compile-pool admission (those are resource-hardening, split to
+    PR-3b). Because the compile runs on client-controlled schema input, we do
+    NOT enable it by default until that hardening lands — an operator opts in
+    explicitly (``RAPID_MLX_CONSTRAIN_TOOLS=1``/``on``/``true``). Flipping the
+    default to on is gated on PR-3b (and the auto path on PR-5).
+    """
+    if os.environ.get("RAPID_MLX_CONSTRAIN_TOOLS", "0") not in ("1", "on", "true"):
+        return False
+    if not getattr(request, "tools", None) or not getattr(
+        cfg, "tool_call_parser", None
+    ):
+        return False
+    return (
+        _normalize_tool_choice_for_grammar(getattr(request, "tool_choice", None))
+        is not None
+    )
+
+
+def _maybe_build_tool_grammar_processor(engine, cfg, request):
+    """Build a per-request ``GrammarLogitsProcessor`` for #558, or ``None``.
+
+    Non-breaking: returns ``None`` (today's free-form-then-parse fallback)
+    whenever anything is missing — env opt-out, no tools, no family parser,
+    ``tool_choice`` not in the PR-3 constrained set (required/named), the
+    parser opts out of ``structure_info``, llguidance unavailable, or the
+    tokenizer cannot back an ``LLTokenizer``.
+
+    Re-runs the cheap eligibility checks (so it stays correct when called
+    directly, e.g. from tests) before the heavy path; the route gates on
+    ``_tool_grammar_eligible`` first to keep the offload off the hot path.
+    """
+    if not _tool_grammar_eligible(cfg, request):
+        return None
+
+    choice = _normalize_tool_choice_for_grammar(getattr(request, "tool_choice", None))
+    if choice is None:  # pragma: no cover - _tool_grammar_eligible already gated
+        return None  # auto / none / unrecognized -> unconstrained (PR-5 owns auto)
+
+    try:
+        from ..api.tool_grammar import (
+            GrammarLogitsProcessor,
+            build_tool_grammar,
+            get_lltokenizer,
+        )
+        from ..tool_parsers import ToolParserManager
+
+        tokenizer = getattr(engine, "tokenizer", None)
+        if tokenizer is None:
+            return None
+        # Resolve the ``LLTokenizer`` FIRST (codex #558-PR3 nit): a tokenizer
+        # already memoized as unsupported returns ``None`` here without paying
+        # the client-controlled grammar compile below. ``get_lltokenizer`` is a
+        # cache hit in steady state, so this reorder is free on the hot path and
+        # avoids compiling a grammar we'd only discard.
+        lltok = get_lltokenizer(tokenizer)
+        if lltok is None:
+            return None
+        parser_cls = ToolParserManager.get_tool_parser(cfg.tool_call_parser)
+        parser = parser_cls(tokenizer=tokenizer)
+
+        # Flatten OpenAI tools -> [{name, parameters}] for the grammar builder.
+        flat_tools = []
+        for t in request.tools:
+            fn = t.function if hasattr(t, "function") else t.get("function", t)
+            name = fn.get("name") if isinstance(fn, dict) else getattr(fn, "name", None)
+            if not name:
+                return None
+            has_params = (
+                ("parameters" in fn)
+                if isinstance(fn, dict)
+                else hasattr(fn, "parameters")
+            )
+            params = (
+                fn.get("parameters")
+                if isinstance(fn, dict)
+                else getattr(fn, "parameters", None)
+            )
+            # ABSENT (or null) ``parameters`` == the tool takes NO arguments.
+            # Use a CLOSED empty-object schema so the grammar forbids ANY key,
+            # rather than the open ``{"type":"object"}`` (whose implicit
+            # ``additionalProperties: true`` would let the model hallucinate
+            # arbitrary arguments into a no-arg call — codex #558-PR3). An
+            # explicitly-supplied schema (including a bare ``{}`` = allow-any)
+            # is preserved verbatim; only the absent/None case is defaulted.
+            if not has_params or params is None:
+                params = {
+                    "type": "object",
+                    "properties": {},
+                    "additionalProperties": False,
+                }
+            flat_tools.append({"name": name, "parameters": params})
+
+        # For a NAMED choice, narrow to the single target tool BEFORE building.
+        # We then always pass ``tool_choice="required"`` to the builder over
+        # the (narrowed or full) tool list. This sidesteps the builder's own
+        # name-string path entirely: a tool literally named ``"required"`` can
+        # never be misread as the ``required`` enum, because we resolve the
+        # target from the tagged form's ``name`` and feed the builder a
+        # narrowed list + the ``"required"`` quantifier (forces exactly one of
+        # the listed tools). ``named`` over a 1-element list == a single forced
+        # tool; ``required`` over the full list == one-or-more of any tool.
+        if choice["mode"] == "named":
+            target = choice["name"]
+            narrowed = [t for t in flat_tools if t["name"] == target]
+            if not narrowed:
+                # Named target not in tools. The #445 route handler already
+                # 400s this case before we get here, but stay defensive:
+                # free-form fallback rather than an empty/forcing grammar.
+                return None
+            flat_tools = narrowed
+
+        # OpenAI ``parallel_tool_calls=False`` -> force EXACTLY ONE call so the
+        # grammar matches the downstream single-call cap (codex #558-PR3). A
+        # NAMED choice is already single-tool but could still emit ≥2 calls to
+        # the same tool without this; ``required`` could emit calls to several
+        # tools. Only an explicit ``False`` narrows to exactly-one (``True`` /
+        # unset keep the one-or-more ``required`` grammar, per OpenAI semantics).
+        single_call = getattr(request, "parallel_tool_calls", None) is False
+        grammar = build_tool_grammar(
+            flat_tools, "required", parser, single_call=single_call
+        )
+        if grammar is None:
+            return None
+
+        # Reasoning-aware delay (design §5). We rely on PATH A: the grammar's
+        # own lazy ``TAG_TEXT`` free prefix naturally swallows any
+        # ``<think>...</think>`` block before the trigger, so reasoning flows
+        # unconstrained WITHOUT a runtime gate. The runtime gate (path B) is a
+        # ground-truth-corrected FOOTGUN here: a model that emits NO reasoning
+        # (no ``</think>``) would keep the mask OFF forever and defeat the
+        # constraint entirely (observed on qwen3.5 tool_choice=required). So we
+        # pass ``reasoning_end_token=None`` — path A alone is correct for
+        # triggered structural tags (matches vLLM's same-step exception).
+        processor = GrammarLogitsProcessor(
+            lltok,
+            grammar,
+            reasoning_end_token=None,
+            tokenizer=tokenizer,
+        )
+        # A broken matcher (grammar failed to compile) masks NOTHING. Returning
+        # it here would set ``grammar_logits_processor`` on the request, which
+        # in turn disables the forced-prefix fallback at the call site while
+        # producing fully-unconstrained output — strictly worse than either
+        # lever alone (codex #558-PR3). Fall back to free-form/forced-prefix.
+        if processor.is_broken():
+            logger.error("tool-grammar: grammar failed to compile; free-form fallback")
+            return None
+        return processor
+    except Exception:
+        logger.exception("tool-grammar: failed to build processor; free-form fallback")
+        return None
+
+
 def _recover_partial_tool_args(
     raw_text: str | None, expected_name: str | None = None
 ) -> str | None:
@@ -2032,6 +2244,47 @@ async def _create_chat_completion_impl(
     if request.tools:
         chat_kwargs["tools"] = convert_tools_for_template(request.tools)
 
+    # Grammar-constrained tool calling (#558 PR-3a). When the request carries
+    # ``tools``, a family parser that declares a ``structure_info``, and an
+    # EXPLICIT ``tool_choice`` of ``"required"`` or a named function, build a
+    # per-request ``GrammarLogitsProcessor`` that structurally constrains a
+    # completed tool call to name a real tool and satisfy its JSON schema in the
+    # family wire format. OPT-IN via env ``RAPID_MLX_CONSTRAIN_TOOLS``
+    # (defaults OFF; set to 1/on/true — client-schema DoS-hardening is PR-3b).
+    # ``tool_choice="auto"`` stays UNCONSTRAINED (the auto-path grammar is PR-5,
+    # paused). Falls back to today's free-form-then-parse when opted out, the
+    # parser opts out (returns None), or llguidance/tokenizer is unavailable —
+    # non-breaking, no default change.
+    #
+    # Built BEFORE the forced-prefix block below because the two are mutually
+    # exclusive: when the grammar is active it already forces + fully
+    # constrains the call from token 0, whereas the forced ASSISTANT PREFIX
+    # injects the wire-envelope opener into the PROMPT. Combining them is a
+    # bug (codex #558-PR3): the grammar processor baselines the injected
+    # prefix away as "prompt", so the matcher starts at grammar position 0
+    # while generation has already emitted the opener — bypassing
+    # argument-schema enforcement or producing a duplicate opener. So we skip
+    # the forced prefix entirely whenever the grammar is active.
+    #
+    # The cheap eligibility gate runs SYNCHRONOUSLY on the loop so the vast
+    # majority of traffic (no tools, ``"auto"``/``"none"`` choices) never enters
+    # the thread offload (codex #558-PR3). Only an eligible request pays the
+    # off-loop build via ``asyncio.to_thread`` — it compiles a client-controlled
+    # grammar and, on the FIRST request for a tokenizer, does the documented ~1s
+    # ``LLTokenizer`` build; running that inline would block the event loop for
+    # every other in-flight request. The Lark->llguidance grammar compile is
+    # already ``lru_cache``d (``_compile_lark_cached``) and the tokenizer is
+    # memoized (``get_lltokenizer``), so steady-state cost is small — but the
+    # cold path and per-request ``LLMatcher`` construction still belong off-loop.
+    # (Bounded compile-pool admission + client-schema DoS caps are PR-3b.)
+    _glp = None
+    if _tool_grammar_eligible(cfg, request):
+        _glp = await asyncio.to_thread(
+            _maybe_build_tool_grammar_processor, engine, cfg, request
+        )
+    if _glp is not None:
+        chat_kwargs["grammar_logits_processor"] = _glp
+
     # OpenAI ``tool_choice`` forced-function — assistant-turn prefix
     # injection. The chat-template renderer (and the engine's
     # ``chat()``/``stream_chat()``) accept ``forced_assistant_prefix``;
@@ -2041,9 +2294,10 @@ async def _create_chat_completion_impl(
     # No per-model regex, no per-alias config — the prefix is derived
     # solely from ``cfg.tool_call_parser`` and the requested function
     # name. See ``_forced_tool_call_prefix`` for the parser-shape
-    # taxonomy.
+    # taxonomy. SKIPPED when a grammar processor is active (see above) —
+    # the grammar is the stronger, self-sufficient lever.
     _forced_prefix = None
-    if request.tools and request.tool_choice is not None:
+    if _glp is None and request.tools and request.tool_choice is not None:
         _forced_name: str | None = None
         if (
             isinstance(request.tool_choice, dict)

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -1936,6 +1936,49 @@ class Scheduler:
         self.request_id_to_uid: dict[str, int] = {}
         self.uid_to_request_id: dict[int, str] = {}
 
+        # #558 PR-3: authoritative per-uid logits-processor state. mlx-lm's
+        # ``GenerationBatch`` keys ``logits_processors`` positionally by uid
+        # index, and that list can DESYNC from ``uids`` when a no-processor
+        # request finishes while another is mid-flight (a stale entry survives
+        # the filter). A positional desync would apply a grammar mask to the
+        # wrong request — or, on a length mismatch, permanently drop a
+        # bystander's penalty processors when we rebuild.
+        #
+        # We keep the COMPLETE per-request processor list (grammar + penalties,
+        # in insert order) keyed by uid here for EVERY live uid that carries any
+        # processor — not just grammar ones — so
+        # ``_realign_grammar_logits_processors`` can reconstruct each slot
+        # entirely from uid-keyed state on a desync. This preserves a
+        # penalty-only request's repetition/frequency/presence processors (they
+        # would otherwise be zeroed when the positional list is length-mismatched
+        # and cannot be trusted), and never applies one request's grammar to
+        # another (codex #558-PR3).
+        self.uid_to_request_processors: dict[int, list] = {}
+        # Which of the tracked uids actually carry a grammar processor. The
+        # realign guard only needs to fire while a grammar is in flight; a
+        # penalty-only uid is recorded above for correct desync repair but does
+        # NOT by itself arm the guard.
+        self._uids_with_grammar: set[int] = set()
+        # Identity set of every grammar processor currently in flight (by
+        # ``id()``), so a slot can be scrubbed of ANY grammar processor before
+        # its uid's authoritative list is applied — this recognizes even a
+        # grammar whose owning uid already finished but that still lingers in a
+        # leaked slot. An id is dropped only once its owning uid is removed AND
+        # the processor is absent from every live batch slot (tombstoned until
+        # then; see ``_forget_uid_grammar`` + the sweep in the realign guard).
+        self._known_grammar_processors: set[int] = set()
+        # Keeps each tracked processor OBJECT alive while its ``id()`` is in the
+        # set above, so Python can't reuse that id for a different object while
+        # the grammar may still sit in a batch slot (id-reuse-after-GC guard).
+        self._grammar_processor_objs: dict[int, Any] = {}
+        # Grammar processors whose owning uid has left the tracking maps but
+        # that may still linger in a leaked batch slot. Kept in
+        # ``_known_grammar_processors`` (so they're still scrubbed) until the
+        # realign guard confirms they're absent from every live slot, then
+        # forgotten. Closes the cleanup-ordering gap where the LAST grammar
+        # finishing would disarm the guard before its leaked slot was cleaned.
+        self._grammar_tombstones: set[int] = set()
+
         # BatchGenerator - the actual batching engine
         self.batch_generator: BatchGenerator | None = None
         self._current_sampler_params: tuple | None = None
@@ -3983,6 +4026,135 @@ class Scheduler:
             # masks the abort in the caller's exception handler.
             pass
 
+    def _forget_uid_grammar(self, uid: int) -> None:
+        """Drop #558 PR-3 per-uid processor state for a uid leaving the batch.
+
+        Called from the abort + finish cleanup paths. Those paths remove ``uid``
+        from the generation batch's ``uids`` *before* the next tick's realign,
+        but mlx-lm's own positional ``logits_processors`` filter can lag by a
+        tick and leave the just-finished grammar in a LEAKED slot. So we do NOT
+        immediately forget the grammar's identity here: we TOMBSTONE it (keep it
+        in ``_known_grammar_processors`` so the realign guard still scrubs it)
+        until the guard confirms it's absent from every live slot. Penalty-only
+        uids carry no grammar and are simply dropped.
+        """
+        self._uids_with_grammar.discard(uid)
+        procs = self.uid_to_request_processors.pop(uid, None)
+        if not procs:
+            return
+        # A grammar in this uid's list that's still referenced by ANOTHER live
+        # uid stays fully live; otherwise it becomes a tombstone — still known
+        # (and thus still scrubbable) but pending removal once no slot holds it.
+        # A request never shares its GrammarLogitsProcessor, so the cross-uid
+        # check is defensive; the tombstone is the load-bearing part.
+        still_referenced: set[int] = set()
+        for plist in self.uid_to_request_processors.values():
+            for p in plist:
+                if id(p) in self._known_grammar_processors:
+                    still_referenced.add(id(p))
+        for p in procs:
+            pid = id(p)
+            if pid in self._known_grammar_processors and pid not in still_referenced:
+                self._grammar_tombstones.add(pid)
+
+    def _realign_grammar_logits_processors(self) -> None:
+        """Rebuild the generation batch's ``logits_processors`` aligned to uids.
+
+        #558 PR-3. mlx-lm's ``GenerationBatch`` stores ``logits_processors``
+        as a positional per-uid list. When a NO-processor request finishes
+        while a grammar request is mid-flight, a stale entry can survive the
+        filter and DESYNC that list from ``uids`` — mlx-lm's ``_step`` then
+        iterates ``range(len(uids))`` and applies the wrong (or no) processor,
+        silently leaving an explicit ``required``/named call unconstrained.
+
+        Rebuild strategy — authoritative, never lossy (codex #558-PR3):
+
+          * ``uid_to_request_processors`` is the SOURCE OF TRUTH for EVERY live
+            uid that carries any processor — grammar AND penalty-only. Each such
+            slot is rebuilt verbatim from its stored list, so a bystander's
+            repetition/frequency/presence penalties are preserved even when the
+            positional list is length-desynced (previously those uids got ``[]``,
+            silently deleting their penalties, because running requests are not
+            re-inserted).
+          * A uid we do NOT track genuinely has no processors, so its slot is
+            ``[]``. This also scrubs any grammar processor (by identity, via the
+            ``_known_grammar_processors`` set — which still contains tombstoned
+            grammars whose owning uid finished, closing the cleanup-ordering
+            gap) that leaked into that slot via a desync.
+
+        After rebuilding, sweep tombstoned grammar identities: any that is now
+        absent from every live slot is fully forgotten. This keeps the guard
+        armed across the tick that finally drops a leaked grammar even when it
+        was the LAST in-flight grammar.
+
+        Idempotent and cheap: only writes back when something actually changed.
+        """
+        bg = getattr(self.batch_generator, "_generation_batch", None)
+        if bg is None:
+            # No generation batch == no live slots at all, so no tombstoned
+            # grammar can be lingering in one. Flush them here too (codex
+            # #558-PR3 nit): otherwise a finished grammar's processor + matcher
+            # state would be retained indefinitely across an idle period where
+            # the batch object itself is absent.
+            self._flush_grammar_tombstones(present=set())
+            return
+        uids = getattr(bg, "uids", None)
+        if not uids:
+            # No live slots. A stale positional ``logits_processors`` list can
+            # still linger here if the batch emptied its ``uids`` without the
+            # filter dropping the parallel processor list (mlx-lm keys the two
+            # separately). Left in place, the NEXT admitted plain request would
+            # inherit a leaked grammar processor at position 0 and be silently
+            # constrained (codex #558-PR3 blocking). A batch with zero uids must
+            # carry zero processors — scrub the list to ``[]`` while the grammar
+            # identities are still known, THEN forget the tombstones.
+            existing = getattr(bg, "logits_processors", None)
+            if existing:
+                bg.logits_processors = []
+            self._flush_grammar_tombstones(present=set())
+            return
+        existing = getattr(bg, "logits_processors", None)
+        aligned = existing is not None and len(existing) == len(uids)
+        rebuilt: list = []
+        present_ids: set[int] = set()
+        changed = not aligned
+        for i, uid in enumerate(uids):
+            authoritative = self.uid_to_request_processors.get(uid)
+            if authoritative is not None:
+                # Source of truth: rebuild this slot verbatim (grammar +
+                # penalties). Copy so mlx-lm's in-place filters can't mutate
+                # our stored list.
+                slot = list(authoritative)
+            else:
+                # Untracked uid == no processors. Empty slot (which also drops
+                # any grammar that leaked here via a desync).
+                slot = []
+            for p in slot:
+                if id(p) in self._known_grammar_processors:
+                    present_ids.add(id(p))
+            # Detect whether this slot differs from what's there now.
+            if not aligned or existing[i] != slot:
+                changed = True
+            rebuilt.append(slot)
+        if changed:
+            bg.logits_processors = rebuilt
+        self._flush_grammar_tombstones(present=present_ids)
+
+    def _flush_grammar_tombstones(self, present: set[int]) -> None:
+        """Forget tombstoned grammar identities no longer in any live slot.
+
+        A tombstone (see ``_forget_uid_grammar``) is a grammar whose owning uid
+        has left the tracking maps but that may still linger in a leaked batch
+        slot. Once the realign guard confirms it's absent from every live slot,
+        it's safe to fully drop — releasing the id-reuse guard object too.
+        """
+        for pid in list(self._grammar_tombstones):
+            if pid in present:
+                continue
+            self._grammar_tombstones.discard(pid)
+            self._known_grammar_processors.discard(pid)
+            self._grammar_processor_objs.pop(pid, None)
+
     def _process_pending_aborts(self) -> None:
         """Drain and process pending abort requests. Called from executor thread."""
         while self._pending_abort_ids:
@@ -4040,6 +4212,9 @@ class Scheduler:
                 self.batch_generator.remove([uid])
                 removed_from_batch = True
             del self.uid_to_request_id[uid]
+            # #558 PR-3: drop the aborted uid's grammar processor state (the
+            # uid is already out of the batch via ``remove`` above).
+            self._forget_uid_grammar(uid)
             del self.request_id_to_uid[request_id]
 
         if request_id in self.running:
@@ -4250,6 +4425,13 @@ class Scheduler:
                 processor = self._tool_logits_processor_factory()
                 if processor is not None:
                     request_processors.append(processor)
+            # Grammar-constrained tool calling (#558): a per-request
+            # ``GrammarLogitsProcessor`` set on the Request masks decoding to
+            # the tool-call grammar. Same per-token slot as the (unused today)
+            # MiniMax soft-bias factory above, so it composes with penalties.
+            _glp = getattr(request, "grammar_logits_processor", None)
+            if _glp is not None:
+                request_processors.append(_glp)
             # Penalty knobs (#355) — only add the processor when at least
             # one penalty is non-default. mlx-lm's make_logits_processors
             # returns an empty list when all knobs are at defaults, but
@@ -4391,6 +4573,23 @@ class Scheduler:
                 self.uid_to_request_id[uid] = request.request_id
                 request.batch_uid = uid
                 request.status = RequestStatus.RUNNING
+                # #558 PR-3: remember this request's FULL processor list
+                # (grammar + penalties) by uid as the authoritative state the
+                # per-tick realign guard rebuilds from — immune to mlx-lm's
+                # stale-entry desync. We track EVERY uid that carries any
+                # processor, not just grammar ones, so a penalty-only bystander's
+                # processors survive a length-desync rebuild (they'd otherwise be
+                # zeroed). Grammar-carrying uids also register the grammar's
+                # identity (so leaked slots can be scrubbed even after the uid
+                # finishes) and arm the guard.
+                if request_processors:
+                    self.uid_to_request_processors[uid] = list(request_processors)
+                if _glp is not None:
+                    self._uids_with_grammar.add(uid)
+                    self._known_grammar_processors.add(id(_glp))
+                    # Keep the object alive so its ``id()`` can't be reused by a
+                    # different object while it may still linger in a slot.
+                    self._grammar_processor_objs[id(_glp)] = _glp
                 # Attach incremental decoder for multi-byte safe streaming
                 request._decoder = IncrementalDecoder(self._actual_tokenizer)
                 # Release the prompt cache reference now that BatchGenerator
@@ -4968,6 +5167,10 @@ class Scheduler:
                 uid = self.request_id_to_uid[request_id]
                 if uid in self.uid_to_request_id:
                     del self.uid_to_request_id[uid]
+                # #558 PR-3: drop the finished uid's grammar processor state so
+                # it can't linger and re-map onto a reused uid (the uid is
+                # already out of the batch by the time cleanup runs).
+                self._forget_uid_grammar(uid)
                 del self.request_id_to_uid[request_id]
 
             # Track as finished
@@ -5093,6 +5296,17 @@ class Scheduler:
 
                 # Run generation step if we have running requests
                 if self.batch_generator is not None and self.running:
+                    # #558 PR-3: repair any grammar processor↔uid positional
+                    # desync before decoding this tick. Armed ONLY while a
+                    # grammar is actually in flight, or a finished grammar is
+                    # still tombstoned (so its leaked slot is swept even when it
+                    # was the last one). Penalty-only requests do NOT arm this —
+                    # their entries in ``uid_to_request_processors`` are passive
+                    # reconstruction state used when a grammar realign fires;
+                    # arming on them would run an O(batch) rebuild every token on
+                    # the plain decode hot path (codex #558-PR3).
+                    if self._uids_with_grammar or self._grammar_tombstones:
+                        self._realign_grammar_logits_processors()
                     raw_next = self.batch_generator.next()
                     output.has_work = True
 
@@ -5113,6 +5327,21 @@ class Scheduler:
                         output.outputs = outputs
                         output.finished_request_ids = finished_ids
                         self._cleanup_finished(finished_ids)
+
+                # #558 PR-3: reconcile grammar processors when idle. The realign
+                # guard (which scrubs leaked slots AND flushes tombstones) only
+                # runs while requests are running, so if the LAST grammar request
+                # finished this tick and the batch is now empty, (a) a stale
+                # positional ``logits_processors`` list could linger and be
+                # inherited by the next admitted plain request, and (b) the
+                # tombstoned processor would stay strongly referenced through the
+                # idle period. Route through the realign method (not a bare
+                # flush): with zero uids it takes the no-live-slots branch, which
+                # scrubs ``bg.logits_processors`` to ``[]`` before forgetting the
+                # tombstones — closing the leaked-slot inheritance gap (codex
+                # #558-PR3 blocking).
+                if self._grammar_tombstones and not self.running:
+                    self._realign_grammar_logits_processors()
 
                 # Success - break out of retry loop
                 break


### PR DESCRIPTION
## Why

`#558 PR-3` grew to a 134 KB diff — too big for the codex validator's 600s window — because adversarial resource-hardening got piled onto the core grammar-constraint feature. Per raullen's call, this is **PR-3a (core)**: the grammar logits processor wired into the request path for the opt-in tool_choice modes, proven end-to-end on a real server. The resource-hardening (bounded compile pool + client-schema DoS caps) is split to a follow-up **PR-3b** — codex's one remaining blocking finding IS that split boundary, and it is now neutralized for 3a by shipping the feature OPT-IN (`RAPID_MLX_CONSTRAIN_TOOLS` off by default).

**Scope — OPT-IN ONLY.** The constraint activates only for the caller's **explicit** `tool_choice="required"` or a named function. `tool_choice="auto"` stays **UNCONSTRAINED** (the auto-path grammar is PR-5, paused pending greenlight + the 5-family matrix). `RAPID_MLX_CONSTRAIN_TOOLS` is a **disable-only kill-switch** (safety escape hatch; set `0`/`off`/`false`), never a default-on auto-constrainer.

## What

**Runtime processor** (`api/tool_grammar.py`)
- `GrammarLogitsProcessor`: applies a compiled llguidance grammar mask each decode step. Carries the **O(n²)→O(n) incremental-consume fix** — a `_committed` offset consumes only `token_ids[self._committed:]` (the new tail) rather than re-copying the whole cumulative sequence every step, mirroring `guided.py::_decode_constrained`. Baselines past the prompt on the first call so prompt tokens never reach the matcher; preserves padded-vocab logit shape for batched decode.
- `is_broken()`: a matcher that failed to compile masks nothing — the route checks this and falls back to free-form/forced-prefix rather than emitting fully-unconstrained output.
- `build_lltokenizer` / `get_lltokenizer`: `LLTokenizer` factory + per-tokenizer memoization.

**Scheduler correctness** (`scheduler.py`)
- Penalty-preservation on a `logits_processors`↔uid positional desync: `uid_to_request_processors` is the authoritative full-list source of truth, so a penalty-only bystander keeps its repetition/frequency/presence processors even under a length-desync rebuild (previously they'd be zeroed).
- Grammar-lifecycle tombstones (`_grammar_tombstones` / `_flush_grammar_tombstones`) + a per-tick realign guard, armed only while a grammar is in flight or a finished grammar is still tombstoned — so a leaked slot can't apply one request's grammar to another or leak onto a reused uid.

**Threading** (`request.py`, `engine_core.py`, `engine/batched.py`)
- Per-request `grammar_logits_processor` threaded through `add_request` → `Request` → scheduler's per-request processor slot (composes with the penalty processors).

**Routing** (`routes/chat.py`)
- `_normalize_tool_choice_for_grammar`: shape-discriminated required/named routing, collision-safe against a tool literally named `"required"` (name is only ever read from the object form). Includes the **`isinstance(fn, dict)` guard** — fixes a 500 on a malformed `tool_choice.function` (degrades to free-form).
- The cold grammar/tokenizer build runs off the event loop via a **simple `asyncio.to_thread`** (the bounded compile pool is PR-3b).
- Forced assistant-prefix injection is skipped when a grammar is active (the two levers are mutually exclusive).

**Tests**
- Grammar processor + scheduler-realign suites. Offline-skip classification fixed to skip **only** connection failures / 429 / transient 5xx, and let **permanent 4xx (401/403/404/422) FAIL** — so the enforcement suite is never falsely greened.

## Split to PR-3b (removed here)
- Bounded `ThreadPoolExecutor(max_workers=4)` compile pool + bounded-admission machinery.
- Attacker-schema-size DoS guard (64-KiB byte cap + depth-32 + 256-tool caps via the early-abort bounded walker).

## Test plan
- [x] `tests/test_grammar_processor_558.py` + `tests/test_grammar_scheduler_realign_558.py` + `tests/test_no_out_of_band_routing.py` + `tests/test_tool_grammar_558.py` — all green (102 passed)
- [x] `tests/test_model_metadata.py` unchanged and green (the stale-base `#1136` revert was correctly excluded)
- [x] `ruff check` + `ruff format --check` clean on all touched files
- [x] `scripts.pr_validate 1135` `full_unit` PASS (13184 passed, 0 failed); `codex_review` converged 3→1 blocking across rounds — the single remaining blocking is the **PR-3b split boundary** (unbounded compile / client-schema DoS caps), which is deliberately deferred and now gated behind the OPT-IN env default. Two remaining nits are the dormant path-B reasoning gate (`reasoning_end_token=None` in production, so unreachable) and a fail-open-vs-fail-closed choice on a rejected grammar token (best-effort constraint continues masking). `stress_e2e_bench` FAIL is a pre-existing `--pflash`-on-multimodal boot incompatibility in the 35B/27B matrix models — unrelated to this diff (no grammar/tool code in those logs).
- [x] Real-server smoke on cached `Qwen3.5-4B-MLX-4bit` (opt-in enabled, port 8935): `tool_choice="required"` → `finish_reason=tool_calls`, `get_weather({"city":"Paris"})` (real tool + schema-valid args); a CONCURRENT plain `repetition_penalty=1.3` request (no tools) → `finish_reason=stop`, coherent content, no tool_calls (proves scheduler penalty-preservation under a concurrent grammar request)

Opt-in required/named only (`RAPID_MLX_CONSTRAIN_TOOLS` defaults OFF); resource-hardening split to PR-3b, and flipping the default to on is gated on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
