### PR TITLE
chore: bump version to 0.10.14

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.10.12"
+version = "0.10.14"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## What
Bump 0.10.12 → 0.10.14 to ship #558 PR-5 (default-on grammar-constrained tool-calling).

## Why
PR #1143 (merged, `4c6b0f43`) flipped grammar-constrained tool-calling to **default-on** with the auto path: any tool call a supported model emits is now structurally guaranteed by default (real tool name + schema-valid args + family wire format), opt-out via `RAPID_MLX_CONSTRAIN_TOOLS=0`. Acceptance was correctness + steady-state latency parity with the free-form baseline across a 3-family default-on matrix; auto never forces a call. This dedicated bump cuts the release so `pip install rapid-mlx==0.10.14` ships it.

`0.10.14` = even patch = feature, per the release cadence (`0.10.12` was latest).

## Release
Bump-only PR (net version change, no engine diff). Merging triggers `auto-release.yml` → PyPI + Homebrew tap + GH Release.
