### PR TITLE
fix(deps): promote llguidance to core dep so default-on tool-calling works out-of-box (#558)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,6 +110,22 @@ dependencies = [
     # tool calling. Soft-imported at runtime; the legacy custom state
     # machine remains the fallback if the dep is unavailable.
     "openai-harmony>=0.0.8",
+    # llguidance — grammar-constrained decoding engine (native MLX Metal
+    # mask kernel via ``llguidance.mlx``). PROMOTED FROM THE [guided] EXTRA
+    # TO CORE in 0.10.15 (#558 fix-slot follow-up to PR-5). Rationale: #558
+    # PR-5 made grammar-constrained tool-calling DEFAULT-ON in 0.10.14, but a
+    # fresh-venv dogfood proved ``pip install rapid-mlx`` does NOT pull
+    # llguidance (it lived only in [guided]) — so default-on silently
+    # degraded to free-form for naive users ("on in name, off in reality":
+    # ``routes/chat.py::_maybe_build_tool_grammar_processor`` returns None
+    # when ``get_lltokenizer`` finds no llguidance, falling back to
+    # free-form-then-parse). Promoting to core makes default-on genuinely
+    # constrained out-of-the-box. Wheel/site-packages cost is a few MB
+    # (well within G12's +25 MB budget). The defensive ``HAS_LLGUIDANCE`` /
+    # ``is_guided_available()`` guards in api/guided.py + api/tool_grammar.py
+    # are RETAINED as defense-in-depth (a broken/incompatible install still
+    # degrades gracefully rather than crashing).
+    "llguidance>=1.7.6",
 ]
 
 [project.optional-dependencies]
@@ -272,6 +288,16 @@ vllm = [
 # kernel (llguidance.mlx); it interprets JSON Schema natively ($defs/$ref/
 # anyOf/enum/numeric-bounds/additionalProperties). Replaced outlines[mlxlm]
 # in 0.10 — see vllm_mlx/api/guided.py.
+#
+# NOTE (0.10.15, #558 fix-slot): llguidance was PROMOTED TO CORE
+# ``[project].dependencies`` above so default-on grammar-constrained
+# tool-calling (#558 PR-5) actually works out-of-the-box. This extra is
+# RETAINED (still pins llguidance explicitly) purely for backward compat so
+# ``pip install 'rapid-mlx[guided]'`` — the historical install path printed
+# in guided.py's degrade warning and referenced across docs — keeps
+# resolving. It is now effectively a no-op superset of core. Follows the
+# codebase's established duplicate-pin convention (mlx-vlm is likewise
+# repeated across [vision]/[dflash]/[all]/[test]/[dev]).
 guided = [
     "llguidance>=1.7.6",
 ]

--- a/tests/test_tool_grammar_558.py
+++ b/tests/test_tool_grammar_558.py
@@ -1299,15 +1299,11 @@ def test_deepseek_r1_prefilled_think_template_is_tolerated(lltok):
 # it lived only in the ``[guided]`` extra — so the default-on path silently
 # degraded to free-form for naive users (``_maybe_build_tool_grammar_processor``
 # returns None when ``get_lltokenizer`` finds no llguidance). The 0.10.15 fix
-# promotes llguidance to core ``[project].dependencies``. This structural test
-# locks that in so a future refactor cannot demote it back to extra-only and
-# silently re-break default-on out-of-the-box. It carries NO optional dependency
-# (parses pyproject.toml only), so it ALWAYS runs — never skipped.
-def test_llguidance_is_core_dependency():
-    """llguidance MUST be in core ``[project].dependencies`` (not only the
-    ``[guided]`` extra) so default-on constrained tool-calling (#558 PR-5)
-    works out-of-the-box on a bare ``pip install rapid-mlx``.
-    """
+# promotes llguidance to core ``[project].dependencies``. These structural tests
+# lock that in so a future refactor cannot demote it back to extra-only and
+# silently re-break default-on out-of-the-box. They carry NO optional dependency
+# (parse pyproject.toml only), so they ALWAYS run — never skipped.
+def _load_pyproject():
     import sys
     from pathlib import Path
 
@@ -1318,15 +1314,50 @@ def test_llguidance_is_core_dependency():
 
     pyproject = Path(__file__).resolve().parents[1] / "pyproject.toml"
     with pyproject.open("rb") as fh:
-        data = tomllib.load(fh)
+        return tomllib.load(fh)
 
-    core_deps = data["project"]["dependencies"]
-    assert any(d.startswith("llguidance") for d in core_deps), (
+
+def _find_llguidance_requirement(dep_strings):
+    """Return the parsed ``Requirement`` whose CANONICAL name is exactly
+    ``llguidance`` (or ``None``). Uses ``packaging.requirements.Requirement``
+    so a look-alike like ``llguidance-fake`` cannot satisfy the check
+    (codex #558 fix-slot: a bare ``startswith('llguidance')`` matched
+    ``llguidance-fake`` and never verified the version floor).
+    """
+    from packaging.requirements import Requirement
+    from packaging.utils import canonicalize_name
+
+    for dep in dep_strings:
+        req = Requirement(dep)
+        if canonicalize_name(req.name) == "llguidance":
+            return req
+    return None
+
+
+def test_llguidance_is_core_dependency():
+    """llguidance MUST be in core ``[project].dependencies`` (not only the
+    ``[guided]`` extra), pinned to a ``>=1.7.6`` floor, so default-on
+    constrained tool-calling (#558 PR-5) works out-of-the-box on a bare
+    ``pip install rapid-mlx``.
+    """
+    core_deps = _load_pyproject()["project"]["dependencies"]
+    req = _find_llguidance_requirement(core_deps)
+    assert req is not None, (
         "llguidance is missing from core [project].dependencies. Default-on "
         "grammar-constrained tool-calling (#558 PR-5) needs it out-of-the-box; "
         "with it only in the [guided] extra, a bare `pip install rapid-mlx` "
         "silently degrades default-on to free-form (the 0.10.14 regression). "
         f"Got core deps: {core_deps!r}"
+    )
+    # Verify the version FLOOR is at least 1.7.6 — the minimum that ships the
+    # native llguidance.mlx Metal mask kernel the runtime relies on. A specifier
+    # that admitted 1.7.5 would silently allow an incompatible install.
+    assert not req.specifier.contains("1.7.5", prereleases=True), (
+        f"llguidance core pin must floor at >=1.7.6, but {str(req.specifier)!r} "
+        "still admits 1.7.5"
+    )
+    assert req.specifier.contains("1.7.6", prereleases=True), (
+        f"llguidance core pin {str(req.specifier)!r} must admit the 1.7.6 floor"
     )
 
 
@@ -1334,26 +1365,20 @@ def test_guided_extra_still_resolves():
     """The ``[guided]`` extra is retained for backward compat (historical
     install path ``pip install 'rapid-mlx[guided]'`` printed in guided.py's
     degrade warning + docs). Assert it still exists and still pins llguidance
-    so that install path keeps working even though llguidance is now core.
+    (>=1.7.6) so that install path keeps working even though llguidance is now
+    core.
     """
-    import sys
-    from pathlib import Path
-
-    if sys.version_info >= (3, 11):
-        import tomllib
-    else:  # pragma: no cover — 3.10 floor
-        import tomli as tomllib
-
-    pyproject = Path(__file__).resolve().parents[1] / "pyproject.toml"
-    with pyproject.open("rb") as fh:
-        data = tomllib.load(fh)
-
-    extras = data["project"]["optional-dependencies"]
+    extras = _load_pyproject()["project"]["optional-dependencies"]
     assert "guided" in extras, (
         "pyproject.toml dropped the [guided] extra. Keep it as a "
         "backward-compat alias so `pip install 'rapid-mlx[guided]'` still "
         "resolves — that command is printed in guided.py's degrade warning."
     )
-    assert any(d.startswith("llguidance") for d in extras["guided"]), (
+    req = _find_llguidance_requirement(extras["guided"])
+    assert req is not None, (
         f"[guided] extra must still pin llguidance; got {extras['guided']!r}"
+    )
+    assert req.specifier.contains("1.7.6", prereleases=True), (
+        f"[guided] llguidance pin {str(req.specifier)!r} must admit the "
+        "1.7.6 floor"
     )

--- a/tests/test_tool_grammar_558.py
+++ b/tests/test_tool_grammar_558.py
@@ -1289,3 +1289,71 @@ def test_deepseek_r1_prefilled_think_template_is_tolerated(lltok):
         "DeepSeek-R1 prefilled-<think> generated stream was rejected — the "
         "required tool call would be blocked on DeepSeek-R1"
     )
+
+
+# ---------------------------------------------------------------------------
+# 0.10.15 fix-slot regression lock-in (#558): llguidance is a CORE dependency.
+# ---------------------------------------------------------------------------
+# #558 PR-5 shipped grammar-constrained tool-calling DEFAULT-ON (0.10.14), but a
+# fresh-venv dogfood proved ``pip install rapid-mlx`` did NOT pull llguidance —
+# it lived only in the ``[guided]`` extra — so the default-on path silently
+# degraded to free-form for naive users (``_maybe_build_tool_grammar_processor``
+# returns None when ``get_lltokenizer`` finds no llguidance). The 0.10.15 fix
+# promotes llguidance to core ``[project].dependencies``. This structural test
+# locks that in so a future refactor cannot demote it back to extra-only and
+# silently re-break default-on out-of-the-box. It carries NO optional dependency
+# (parses pyproject.toml only), so it ALWAYS runs — never skipped.
+def test_llguidance_is_core_dependency():
+    """llguidance MUST be in core ``[project].dependencies`` (not only the
+    ``[guided]`` extra) so default-on constrained tool-calling (#558 PR-5)
+    works out-of-the-box on a bare ``pip install rapid-mlx``.
+    """
+    import sys
+    from pathlib import Path
+
+    if sys.version_info >= (3, 11):
+        import tomllib
+    else:  # pragma: no cover — 3.10 floor
+        import tomli as tomllib
+
+    pyproject = Path(__file__).resolve().parents[1] / "pyproject.toml"
+    with pyproject.open("rb") as fh:
+        data = tomllib.load(fh)
+
+    core_deps = data["project"]["dependencies"]
+    assert any(d.startswith("llguidance") for d in core_deps), (
+        "llguidance is missing from core [project].dependencies. Default-on "
+        "grammar-constrained tool-calling (#558 PR-5) needs it out-of-the-box; "
+        "with it only in the [guided] extra, a bare `pip install rapid-mlx` "
+        "silently degrades default-on to free-form (the 0.10.14 regression). "
+        f"Got core deps: {core_deps!r}"
+    )
+
+
+def test_guided_extra_still_resolves():
+    """The ``[guided]`` extra is retained for backward compat (historical
+    install path ``pip install 'rapid-mlx[guided]'`` printed in guided.py's
+    degrade warning + docs). Assert it still exists and still pins llguidance
+    so that install path keeps working even though llguidance is now core.
+    """
+    import sys
+    from pathlib import Path
+
+    if sys.version_info >= (3, 11):
+        import tomllib
+    else:  # pragma: no cover — 3.10 floor
+        import tomli as tomllib
+
+    pyproject = Path(__file__).resolve().parents[1] / "pyproject.toml"
+    with pyproject.open("rb") as fh:
+        data = tomllib.load(fh)
+
+    extras = data["project"]["optional-dependencies"]
+    assert "guided" in extras, (
+        "pyproject.toml dropped the [guided] extra. Keep it as a "
+        "backward-compat alias so `pip install 'rapid-mlx[guided]'` still "
+        "resolves — that command is printed in guided.py's degrade warning."
+    )
+    assert any(d.startswith("llguidance") for d in extras["guided"]), (
+        f"[guided] extra must still pin llguidance; got {extras['guided']!r}"
+    )

--- a/tests/test_tool_grammar_558.py
+++ b/tests/test_tool_grammar_558.py
@@ -1334,6 +1334,24 @@ def _find_llguidance_requirement(dep_strings):
     return None
 
 
+def _has_lower_bound_at_least(specifier_set, floor="1.7.6"):
+    """True iff ``specifier_set`` GUARANTEES every allowed version is >= floor.
+
+    Codex #1146 round-2: a ``.contains("1.7.5") is False`` style check is not a
+    real floor — ``>=1.0,!=1.7.5`` excludes exactly 1.7.5 yet still admits 1.7.4,
+    and an EMPTY specifier admits everything. We instead require an explicit
+    lower-bound clause (``>=`` / ``==`` / ``~=``) whose own floor is >= the
+    target, which rigorously proves no version below ``floor`` can resolve.
+    """
+    from packaging.version import Version
+
+    floor_v = Version(floor)
+    for spec in specifier_set:
+        if spec.operator in (">=", "==", "~=") and Version(spec.version) >= floor_v:
+            return True
+    return False
+
+
 def test_llguidance_is_core_dependency():
     """llguidance MUST be in core ``[project].dependencies`` (not only the
     ``[guided]`` extra), pinned to a ``>=1.7.6`` floor, so default-on
@@ -1349,15 +1367,12 @@ def test_llguidance_is_core_dependency():
         "silently degrades default-on to free-form (the 0.10.14 regression). "
         f"Got core deps: {core_deps!r}"
     )
-    # Verify the version FLOOR is at least 1.7.6 — the minimum that ships the
-    # native llguidance.mlx Metal mask kernel the runtime relies on. A specifier
-    # that admitted 1.7.5 would silently allow an incompatible install.
-    assert not req.specifier.contains("1.7.5", prereleases=True), (
-        f"llguidance core pin must floor at >=1.7.6, but {str(req.specifier)!r} "
-        "still admits 1.7.5"
-    )
-    assert req.specifier.contains("1.7.6", prereleases=True), (
-        f"llguidance core pin {str(req.specifier)!r} must admit the 1.7.6 floor"
+    # The floor must be at least 1.7.6 — the minimum that ships the native
+    # llguidance.mlx Metal mask kernel the runtime relies on. Assert an explicit
+    # >=1.7.6 lower-bound clause so no version below it can ever resolve.
+    assert _has_lower_bound_at_least(req.specifier), (
+        f"llguidance core pin {str(req.specifier)!r} must floor at >=1.7.6 "
+        "(an explicit >=/==/~= lower bound of at least 1.7.6)"
     )
 
 
@@ -1378,7 +1393,7 @@ def test_guided_extra_still_resolves():
     assert req is not None, (
         f"[guided] extra must still pin llguidance; got {extras['guided']!r}"
     )
-    assert req.specifier.contains("1.7.6", prereleases=True), (
-        f"[guided] llguidance pin {str(req.specifier)!r} must admit the "
-        "1.7.6 floor"
+    assert _has_lower_bound_at_least(req.specifier), (
+        f"[guided] llguidance pin {str(req.specifier)!r} must floor at >=1.7.6 "
+        "(an explicit >=/==/~= lower bound of at least 1.7.6)"
     )

--- a/tests/test_tool_grammar_558.py
+++ b/tests/test_tool_grammar_558.py
@@ -1367,6 +1367,16 @@ def test_llguidance_is_core_dependency():
         "silently degrades default-on to free-form (the 0.10.14 regression). "
         f"Got core deps: {core_deps!r}"
     )
+    # The core pin must be UNCONDITIONAL (no environment marker). A marker like
+    # ``; python_version < "3"`` or ``; platform_system == "Linux"`` would
+    # exclude some supported Python/platform, so a bare ``pip install rapid-mlx``
+    # there would NOT receive llguidance and default-on would silently regress
+    # to free-form on that environment (codex #1146 round-3).
+    assert req.marker is None, (
+        "llguidance core dep must be UNCONDITIONAL (no environment marker); got "
+        f"marker {str(req.marker)!r} — that would exclude some supported "
+        "Python/platform and silently re-break default-on there."
+    )
     # The floor must be at least 1.7.6 — the minimum that ships the native
     # llguidance.mlx Metal mask kernel the runtime relies on. Assert an explicit
     # >=1.7.6 lower-bound clause so no version below it can ever resolve.
@@ -1392,6 +1402,12 @@ def test_guided_extra_still_resolves():
     req = _find_llguidance_requirement(extras["guided"])
     assert req is not None, (
         f"[guided] extra must still pin llguidance; got {extras['guided']!r}"
+    )
+    assert req.marker is None, (
+        "[guided] llguidance pin must be UNCONDITIONAL (no environment marker); "
+        f"got marker {str(req.marker)!r} — a marked pin would leave "
+        "`pip install 'rapid-mlx[guided]'` without llguidance on some supported "
+        "environment."
     )
     assert _has_lower_bound_at_least(req.specifier), (
         f"[guided] llguidance pin {str(req.specifier)!r} must floor at >=1.7.6 "


### PR DESCRIPTION
## Why

Refs #558. #558 **PR-5** (#1143, merged into 0.10.14) shipped grammar-constrained
tool-calling as **DEFAULT-ON** — but that default is a lie for naive users,
**because** a fresh-venv dogfood proved `pip install rapid-mlx==0.10.14` does
**NOT** pull **llguidance** (the constraint engine lived only in the `[guided]`
optional-dependencies extra). So the default-on path silently degraded to
**free-form**: "on in name, off in reality". This PR promotes llguidance to a
core dependency so default-on constrained tool-calling is genuinely constrained
out-of-the-box. This is the **0.10.15 fix-slot** follow-up to PR-5.

## Problem (dogfood finding)

The degrade path is `routes/chat.py::_maybe_build_tool_grammar_processor` →
`get_lltokenizer(...)` returns `None` when llguidance can't be imported → the
request falls back to the old free-form-then-parse behavior. No error, no
warning — the feature just isn't actually constrained out-of-the-box on a bare
`pip install rapid-mlx`.

## Fix

Move `llguidance>=1.7.6` from the `[guided]` extra into core
`[project].dependencies`.

- The `[guided]` extra is **retained** (still pins `llguidance>=1.7.6`) purely
  for backward compat, so `pip install 'rapid-mlx[guided]'` — the historical
  install path printed in `api/guided.py`'s degrade warning and referenced in
  docs — keeps resolving. It is now a no-op superset of core. This follows the
  codebase's established duplicate-pin convention (`mlx-vlm` is likewise
  repeated across `[vision]`/`[dflash]`/`[all]`/`[test]`/`[dev]`).
- The defensive `HAS_LLGUIDANCE` / `is_guided_available()` guards in
  `api/guided.py` + `api/tool_grammar.py` are **kept as defense-in-depth** — a
  broken/version-incompatible install still degrades gracefully rather than
  crashing. With llguidance now core, the "guided disabled" boot warning simply
  won't fire on a normal install.

## Size delta (G12)

Verified with a pure core install (`pip install .` of this branch) in a fresh
throwaway venv:

- `import llguidance` → **1.7.6**
- llguidance has **zero transitive Python deps** (`pip show llguidance` →
  `Requires:` empty), so the net add is exactly its own footprint.
- **Net site-packages add: 7.87 MB** (`llguidance/` 7.9 MB + dist-info 28 KB) —
  well within **G12's +25 MB** budget. No sign-off needed.

## Tests

Adds two structural regression tests (`tests/test_tool_grammar_558.py`) that
(a) lock llguidance into core so a future refactor can't demote it back to
extra-only and silently re-break default-on, and (b) assert the `[guided]`
extra still resolves. Both parse each dep with `packaging.requirements.
Requirement` — matching the canonical name exactly (a look-alike like
`llguidance-fake` cannot satisfy it) and asserting the `>=1.7.6` version floor.
They carry no optional dependency (parse `pyproject.toml`), so they always run.

Version field is **untouched** (the bump is a separate PR per the Release SOP).

## Test plan

- [x] Pure core install pulls llguidance — `python3.12 -m venv /tmp/coredep-check && /tmp/coredep-check/bin/pip install .` then `import llguidance` → **1.7.6** (fresh throwaway venv, no extras)
- [x] Size delta within G12 — **+7.87 MB** net add (llguidance package footprint; zero transitive deps), ≤ +25 MB
- [x] `[guided]` extra still resolves for backward compat (`test_guided_extra_still_resolves`)
- [x] New structural regression tests pass and verify canonical name + `>=1.7.6` floor (`test_llguidance_is_core_dependency`, `test_guided_extra_still_resolves`)
- [x] `pyproject.toml` parses; version field unchanged (still 0.10.14)
- [x] Existing unit suite green (the 4 full_unit failures are pre-existing/environmental — 3× prometheus_client missing, 1× deepseek-r1 tokenizer load — NOT introduced by this deps change; targeted_tests confirms they also fail on main)
- [x] No changes to `vllm_mlx/spec_decode/**` or `vllm_mlx/speculative/**`

🤖 Generated with [Claude Code](https://claude.com/claude-code)