### PR TITLE
chore: bump version to 0.10.15

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.10.14"
+version = "0.10.15"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## What

Bump version `0.10.14` → `0.10.15` to ship the #558 fix-slot follow-up (#1146).

## Why

0.10.14 shipped grammar-constrained tool-calling as **default-on** (#558 PR-5), but a fresh-venv dogfood found that a pure `pip install rapid-mlx` did **not** pull `llguidance` (it lived only in the `[guided]` extra). As a result, default-on silently degraded to free-form parsing for naive users — "on in name, off in reality", with no structural/schema guarantee on tool-call output.

#1146 (merged) fixes the root cause by promoting `llguidance>=1.7.6` from the `[guided]` extra to a **core dependency**, so default-on tool-calling is genuinely constrained out-of-the-box. Net install delta: **+7.87 MB** (llguidance has zero transitive Python deps) — well within the +25 MB budget.

This is the 0.10.15 odd-slot **fix** release that makes that fix reach users via PyPI + Homebrew.

## Changes

- `pyproject.toml`: `version = "0.10.14"` → `"0.10.15"` (version bump only; no code changes).

## Release contents (since 0.10.14)

- #1146 — `fix(deps)`: promote `llguidance` to a core dependency so default-on grammar-constrained tool-calling works out-of-box.

## Test plan

- [x] Version bump is the sole change in this PR (G4 — dedicated bump PR).
- [x] Bumped from the current released version 0.10.14 → 0.10.15 (odd = fix slot).
- [x] Auto-release trigger subject `chore: bump version to 0.10.15 (#N)` will fire PyPI + Homebrew publish on squash-merge.
- [x] Post-merge: re-run fresh-venv dogfood to confirm `pip install rapid-mlx==0.10.15` pulls `llguidance` and default-on tool-calling is genuinely constrained.
