### PR TITLE
fix(chat): guard list-of-blocks system content at suffix injection to return 200 instead of 500 (#1142)

### DIFF
--- a/tests/test_chat_route_tool_choice_enforcement.py
+++ b/tests/test_chat_route_tool_choice_enforcement.py
@@ -1326,3 +1326,160 @@ def test_named_function_outside_tools_returns_422(monkeypatch):
         f"BLOCKING REGRESSION: _synthesize_forced_tool_call was called "
         f"with ghost target; calls={synth_calls!r}"
     )
+
+
+# ── #1142: system-message suffix injection on list-of-blocks content ──
+#
+# ``_inject_suffix`` (one of the ``_TOOL_USE_*_SUFFIX`` strings) used to be
+# appended with a bare ``content + _inject_suffix``. When the system message
+# arrives in the OpenAI *structured* form — ``content`` is a list of content
+# blocks, e.g. ``[{"type": "text", "text": "..."}]`` — and the request goes
+# down the MLLM path (``model_dump`` preserves the list), that expression is
+# ``list + str`` → ``TypeError: can only concatenate list (not "str") to
+# list`` → a hard HTTP 500 on the first tool-use request. Observed in the
+# wild with smolagents × gemma4. The fix normalizes the append per content
+# shape (``_append_tool_use_suffix``): a list gets a trailing text block.
+
+
+class _MLLMToolCallingEngine(_ToolCallingEngine):
+    """MLLM variant of ``_ToolCallingEngine`` (``is_mllm = True``).
+
+    On the MLLM path the route builds ``messages`` via ``model_dump`` and
+    therefore preserves list-of-blocks ``content`` verbatim (the non-MLLM
+    path flattens it to a ``str`` in ``extract_multimodal_content``). This
+    is the only path that exercises the #1142 ``list + str`` crash.
+    """
+
+    is_mllm = True
+
+
+def _system_content(messages):
+    """Return the (single) system message's ``content`` from what the engine
+    saw, tolerating dict or Pydantic-model message shapes."""
+    sys_msgs = [
+        m
+        for m in messages
+        if (m.get("role") if isinstance(m, dict) else getattr(m, "role", None))
+        == "system"
+    ]
+    assert sys_msgs, "expected a system message to survive to the engine"
+    m = sys_msgs[0]
+    return m["content"] if isinstance(m, dict) else m.content
+
+
+def test_list_of_blocks_system_content_with_tools_returns_200_not_500():
+    """#1142 core regression: a system message with list-of-blocks content
+    plus a tools array must NOT 500. Pre-fix the suffix injection did
+    ``list + str`` → TypeError → 500; post-fix the suffix is appended as a
+    trailing text block and the request succeeds (200)."""
+    engine = _MLLMToolCallingEngine()
+    client = _make_client(engine)
+    resp = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "test-model",
+            "messages": [
+                {
+                    "role": "system",
+                    "content": [
+                        {"type": "text", "text": "You are a helpful assistant."}
+                    ],
+                },
+                {"role": "user", "content": "What's the weather in Paris?"},
+            ],
+            "tools": _TOOLS_FIXTURE,
+            "max_tokens": 32,
+        },
+    )
+    assert resp.status_code == 200, resp.text
+
+    # The suffix must land as an appended trailing text block, leaving the
+    # original block intact and the content shape a list (never a str+list
+    # concatenation, which is what crashed).
+    content = _system_content(engine.last_messages)
+    assert isinstance(content, list), (
+        f"expected list-of-blocks content to stay a list, got {type(content)}"
+    )
+    assert content[0]["text"] == "You are a helpful assistant."
+    joined = " ".join(b.get("text", "") for b in content if isinstance(b, dict))
+    assert "you MUST use the appropriate tool" in joined, (
+        f"tool-use suffix not appended; content={content!r}"
+    )
+
+
+def test_list_of_blocks_system_content_required_choice_returns_200():
+    """The ``required`` suffix variant (a different, longer ``str``) must
+    also append cleanly onto list-of-blocks content — same #1142 site,
+    different injected suffix string."""
+    engine = _MLLMToolCallingEngine()
+    client = _make_client(engine)
+    resp = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "test-model",
+            "messages": [
+                {
+                    "role": "system",
+                    "content": [{"type": "text", "text": "Sys."}],
+                },
+                {"role": "user", "content": "weather?"},
+            ],
+            "tools": _TOOLS_FIXTURE,
+            "tool_choice": "required",
+            "max_tokens": 32,
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    content = _system_content(engine.last_messages)
+    assert isinstance(content, list)
+    joined = " ".join(b.get("text", "") for b in content if isinstance(b, dict))
+    assert "MUST call one of the provided tools" in joined, (
+        f"required suffix not appended; content={content!r}"
+    )
+
+
+def test_plain_str_system_content_still_appends_suffix_inline():
+    """Regression guard: the ``str`` fast path must be unchanged — the
+    suffix is concatenated inline, content stays a plain ``str``."""
+    engine = _MLLMToolCallingEngine()
+    client = _make_client(engine)
+    resp = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "test-model",
+            "messages": [
+                {"role": "system", "content": "You are a helpful assistant."},
+                {"role": "user", "content": "weather?"},
+            ],
+            "tools": _TOOLS_FIXTURE,
+            "max_tokens": 32,
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    content = _system_content(engine.last_messages)
+    assert isinstance(content, str)
+    assert content.startswith("You are a helpful assistant.")
+    assert "you MUST use the appropriate tool" in content
+
+
+def test_append_tool_use_suffix_handles_all_content_shapes():
+    """Unit coverage for the ``_append_tool_use_suffix`` normalizer: every
+    legal content shape must append the suffix without raising."""
+    from vllm_mlx.service.helpers import _append_tool_use_suffix
+
+    suffix = "\n\nSUFFIX"
+
+    # str → inline concat
+    assert _append_tool_use_suffix("base", suffix) == "base" + suffix
+
+    # list → trailing text block appended, original untouched
+    original = [{"type": "text", "text": "hi"}]
+    out = _append_tool_use_suffix(original, suffix)
+    assert out == [{"type": "text", "text": "hi"}, {"type": "text", "text": suffix}]
+    assert original == [{"type": "text", "text": "hi"}], "input list was mutated"
+
+    # None / absent → suffix becomes the content
+    assert _append_tool_use_suffix(None, suffix) == suffix
+
+    # unexpected shape → coerced to text, never raises
+    assert _append_tool_use_suffix(123, suffix) == "123" + suffix

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -74,6 +74,7 @@ from ..service.helpers import (
     _TOOL_USE_REQUIRED_SUFFIX,
     _TOOL_USE_SYSTEM_SUFFIX,
     SSE_RESPONSE_HEADERS,
+    _append_tool_use_suffix,
     _apply_reasoning_cutoff_notice,
     _build_usage,
     _check_admission_or_503,
@@ -2572,10 +2573,25 @@ async def _create_chat_completion_impl(
                     m.get("role") if isinstance(m, dict) else getattr(m, "role", None)
                 )
                 if role == "system":
+                    # ``content`` may be a plain ``str`` OR a list of content
+                    # blocks (OpenAI structured form, preserved by the MLLM
+                    # ``model_dump`` path). ``list + str`` would raise and 500
+                    # the request (#1142); normalize the append per-shape.
                     if isinstance(m, dict):
-                        messages[i] = {**m, "content": m["content"] + _inject_suffix}
+                        messages[i] = {
+                            **m,
+                            "content": _append_tool_use_suffix(
+                                m.get("content"), _inject_suffix
+                            ),
+                        }
                     else:
-                        messages[i]["content"] = m["content"] + _inject_suffix
+                        # Non-dict message (Pydantic model / attr object):
+                        # read + write via attribute, not subscript, so the
+                        # append is symmetric with the dict branch and can't
+                        # itself raise ``TypeError`` (``m`` is ``messages[i]``).
+                        m.content = _append_tool_use_suffix(
+                            getattr(m, "content", None), _inject_suffix
+                        )
                     break
         else:
             system_msg = {"role": "system", "content": _inject_suffix.strip()}

--- a/vllm_mlx/service/helpers.py
+++ b/vllm_mlx/service/helpers.py
@@ -19,6 +19,7 @@ import uuid
 from collections.abc import AsyncIterator
 from functools import lru_cache
 from pathlib import Path
+from typing import Any
 
 from fastapi import HTTPException
 from starlette.requests import Request
@@ -1517,6 +1518,39 @@ def _tool_use_required_named_suffix(name: str) -> str:
         "any other tool. Call this exact tool immediately with your best guess "
         "of the arguments. A text-only response is INVALID for this request."
     )
+
+
+def _append_tool_use_suffix(content: Any, suffix: str) -> Any:
+    """Append a tool-use system ``suffix`` (always a ``str``) to a system
+    message's ``content``, tolerating every legal OpenAI content shape.
+
+    ``content`` may be:
+
+    - a plain ``str`` (the legacy / OpenAI simple form) → ``str + str``.
+    - a ``list`` of content-block dicts (OpenAI structured form, e.g.
+      ``[{"type": "text", "text": "..."}]``) → append a trailing text block
+      so the downstream chat-template renderer concatenates it after the
+      existing blocks. This is the shape that reaches the MLLM path
+      (``model_dump`` preserves list content), where a naive ``content +
+      suffix`` would raise ``TypeError: can only concatenate list (not
+      "str") to list`` and 500 the request (#1142). Observed in the wild
+      with smolagents × gemma4, which emits list-of-blocks system content.
+    - ``None`` / absent → the suffix becomes the whole content.
+    - any other shape → coerced to text and concatenated rather than crash.
+
+    Returns a new value; the input ``content`` is never mutated in place.
+    """
+    if content is None:
+        return suffix
+    if isinstance(content, str):
+        return content + suffix
+    if isinstance(content, list):
+        # Append a trailing text block instead of ``list + str``. Copy the
+        # list so the caller's original message object is left untouched.
+        return [*content, {"type": "text", "text": suffix}]
+    # Unknown/unexpected shape — degrade to a text concatenation so a
+    # malformed request can never hard-500 at the injection site.
+    return f"{content}{suffix}"
 
 
 # ── Resolution helpers ─────────────────────────────────────────────


### PR DESCRIPTION
## Summary

`/v1/chat/completions` returned **HTTP 500** whenever a client sent a **system message whose `content` is a list of content blocks** (the OpenAI structured form, `[{"type":"text","text":"..."}]`) **and** the request triggered tool-use suffix injection. This PR normalizes the suffix append per content shape so the request succeeds with a clean **200** (suffix appended), the correct semantic for what is valid OpenAI input.

## The crash

At the suffix-injection site in `vllm_mlx/routes/chat.py`, the code appended:

```python
messages[i] = {**m, "content": m["content"] + _inject_suffix}   # list + str
```

`_inject_suffix` is always one of the `_TOOL_USE_*_SUFFIX` strings. `m["content"]` may legitimately be a **list** of content-block dicts. On the **MLLM path** (`is_mllm=True`, e.g. gemma4) the route builds `messages` via `model_dump`, which **preserves the list verbatim**, so `list + str` raises:

```
TypeError: can only concatenate list (not "str") to list
```

→ unhandled → **HTTP 500** on the first tool-use request. Observed in the wild with **smolagents × gemma4**, which emits list-of-blocks system content.

## Root cause

Single-shape (`str`) assumption at the injection site. The **non-MLLM** path flattens list content to a `str` inside `extract_multimodal_content`, which hid the bug; the **MLLM** path does not, so the raw list reaches the `+` and crashes. Constraint-independent and pre-existing (unrelated to the #558 constrained-tool-calling work) — it fires whenever suffix injection runs.

## The fix

New helper `_append_tool_use_suffix(content, suffix)` in `vllm_mlx/service/helpers.py` (next to the suffix constants) that appends per shape:

- **`str`** → inline concat `content + suffix` (unchanged fast path).
- **`list`** → append a trailing `{"type":"text","text":suffix}` block, so the downstream chat-template renderer still concatenates the suffix after the existing blocks. Copies the list — never mutates the caller's message.
- **`None`/absent** → the suffix becomes the content.
- **any other shape** → text-coerced concat, so a malformed request can never hard-500 at this site.

The route calls this helper for both the `dict` and non-`dict` message branches. Result: a correct **200** with the suffix appended (not a 4xx, not a 500) — list-of-blocks system content is valid OpenAI input, so coercion is the right semantic here (matches the issue's "Expected: 200 with the suffix appended").

## Regression tests

`tests/test_chat_route_tool_choice_enforcement.py` — a new `_MLLMToolCallingEngine` (`is_mllm=True`, the only path that exercises the crash) plus:

- `test_list_of_blocks_system_content_with_tools_returns_200_not_500` — the core #1142 repro: previously-500 request now 200, suffix appended as a trailing text block, original block intact, content stays a list.
- `test_list_of_blocks_system_content_required_choice_returns_200` — the longer `required` suffix variant appends cleanly too.
- `test_plain_str_system_content_still_appends_suffix_inline` — the `str` fast path is unchanged (content stays a `str`).
- `test_append_tool_use_suffix_handles_all_content_shapes` — unit coverage of the normalizer across `str`/`list`/`None`/other, incl. no-mutation of the input list.

Verified the two list-content tests **fail with the exact `TypeError`** on the pre-fix code and pass after.

## Test plan

- [x] Repro test added that reproduces the previously-500 input (fails with `TypeError` on pre-fix code)
- [x] Fix returns a correct 200 (suffix appended) instead of 500 for list-of-blocks system content
- [x] `str` fast path unchanged (regression-guarded)
- [x] Unit test of `_append_tool_use_suffix` across all content shapes
- [x] `required` suffix variant covered
- [x] `tests/test_chat_route_tool_choice_enforcement.py` + `tests/test_tool_choice_enforcement.py` green (126 passed)
- [x] `tests/test_anthropic_tool_usage_d.py` + `tests/test_anthropic_spec_polish_bundle.py` green (39 passed)
- [x] `ruff check` clean on changed files

Closes #1142

🤖 Generated with [Claude Code](https://claude.com/claude-code)