### PR TITLE
fix(tools): gate oversized-schema 400 on parser grammar-capability, fall back to free-form for non-grammar parsers (#1144)

### DIFF
--- a/tests/test_grammar_processor_558.py
+++ b/tests/test_grammar_processor_558.py
@@ -794,6 +794,110 @@ def test_reasonable_schema_no_400_on_active_path(monkeypatch):
     assert _enforce_tool_grammar_bounds_or_400(cfg, req) is None
 
 
+# --------------------------------------------------------------------------
+# #1144: the oversized -> 400 decision is gated on parser grammar-CAPABILITY,
+# not merely on ``tool_call_parser`` being set. A grammar-capable parser
+# (hermes/qwen, ``structure_info`` -> wire triple) keeps the #561 400; a
+# non-grammar-capable parser (ABC default ``structure_info`` -> None) was never
+# going to be decoder-constrained, so an oversized schema falls back to FREE-FORM
+# instead of 400.
+# --------------------------------------------------------------------------
+# A registered parser that does NOT override ``structure_info`` (grammar-incapable).
+_NON_GRAMMAR_PARSER = "deepseek_v3"
+
+
+def test_supports_grammar_probe_matches_capability():
+    # The cheap route probe reports True only for grammar-capable parsers.
+    from vllm_mlx.routes.chat import _tool_parser_supports_grammar
+
+    assert _tool_parser_supports_grammar(_CfgStub("hermes")) is True
+    assert _tool_parser_supports_grammar(_CfgStub("qwen")) is True
+    assert _tool_parser_supports_grammar(_CfgStub(_NON_GRAMMAR_PARSER)) is False
+    # Unknown / unset parser name -> not capable (free-form), never raises.
+    assert _tool_parser_supports_grammar(_CfgStub("no_such_parser_xyz")) is False
+    assert _tool_parser_supports_grammar(_CfgStub(None)) is False
+
+
+@pytest.mark.parametrize("parser", ["hermes", "qwen"])
+@pytest.mark.parametrize("choice", ["required", "auto", None])
+def test_oversized_schema_still_400_for_grammar_capable_parser(
+    monkeypatch, parser, choice
+):
+    # #561 regression guard (#1144): a grammar-CAPABLE parser keeps the hard 400
+    # on an oversized schema across every constrainable tool_choice.
+    from fastapi import HTTPException
+
+    from vllm_mlx.routes.chat import _enforce_tool_grammar_bounds_or_400
+
+    monkeypatch.setenv("RAPID_MLX_CONSTRAIN_TOOLS", "1")
+    cfg = _CfgStub(parser)
+    req = _RequestStub(tools=[_oversized_tool()], tool_choice=choice)
+    with pytest.raises(HTTPException) as ei:
+        _enforce_tool_grammar_bounds_or_400(cfg, req)
+    assert ei.value.status_code == 400
+    assert "grammar-compile bounds" in str(ei.value.detail)
+
+
+@pytest.mark.parametrize("choice", ["required", "auto", None])
+def test_oversized_schema_falls_back_for_non_grammar_parser(monkeypatch, choice):
+    # #1144 core fix: a non-grammar-capable parser (structure_info -> None) with
+    # an oversized schema must NOT 400 — it was never going to be constrained, so
+    # it falls back to free-form exactly like the pre-#558 behavior.
+    from vllm_mlx.routes.chat import (
+        _enforce_tool_grammar_bounds_or_400,
+        _tool_grammar_constraint_active,
+    )
+
+    monkeypatch.setenv("RAPID_MLX_CONSTRAIN_TOOLS", "1")
+    cfg = _CfgStub(_NON_GRAMMAR_PARSER)
+    req = _RequestStub(tools=[_oversized_tool()], tool_choice=choice)
+    # Path is inactive for a non-grammar parser, so no 400 (free-form fallback).
+    assert _tool_grammar_constraint_active(cfg, req) is False
+    assert _enforce_tool_grammar_bounds_or_400(cfg, req) is None
+
+
+@pytest.mark.parametrize("choice", ["required", "auto", None])
+def test_normal_schema_free_form_for_non_grammar_parser(monkeypatch, choice):
+    # #1144: a non-grammar-capable parser with a normal in-bounds schema stays
+    # free-form — never eligible for the constrained offload, never 400.
+    from vllm_mlx.routes.chat import (
+        _enforce_tool_grammar_bounds_or_400,
+        _tool_grammar_eligible,
+    )
+
+    monkeypatch.setenv("RAPID_MLX_CONSTRAIN_TOOLS", "1")
+    cfg = _CfgStub(_NON_GRAMMAR_PARSER)
+    ok = _FunctionTool(
+        "get_weather",
+        parameters={"type": "object", "properties": {"city": {"type": "string"}}},
+    )
+    req = _RequestStub(tools=[ok], tool_choice=choice)
+    assert _tool_grammar_eligible(cfg, req) is False
+    assert _enforce_tool_grammar_bounds_or_400(cfg, req) is None
+
+
+def test_supports_grammar_marker_matches_structure_info_override():
+    # Invariant guard: keep the cheap class-level ``SUPPORTS_GRAMMAR`` marker in
+    # sync with the actual ``structure_info`` override across ALL registered
+    # parsers, so a new grammar-capable parser can't ship a stale marker (which
+    # would silently drop the #561 400) or a stale True (spurious 400s).
+    from vllm_mlx.tool_parsers import ToolParserManager
+    from vllm_mlx.tool_parsers.abstract_tool_parser import ToolParser
+
+    names = ToolParserManager.list_registered()
+    assert names, "no tool parsers registered"
+    for name in names:
+        cls = ToolParserManager.get_tool_parser(name)
+        overrides_structure_info = (
+            cls.structure_info is not ToolParser.structure_info
+        )
+        assert cls.supports_grammar() == overrides_structure_info, (
+            f"{cls.__name__} (parser '{name}'): SUPPORTS_GRAMMAR="
+            f"{cls.supports_grammar()} but structure_info overridden="
+            f"{overrides_structure_info}; keep the marker in sync (#1144)"
+        )
+
+
 def test_offline_skip_classifies_http_status():
     # codex #558-PR3 blocking: only TRANSIENT signals skip; a permanent 4xx
     # (bad creds / deleted artifact / invalid revision) must FAIL, not silently

--- a/tests/test_grammar_processor_558.py
+++ b/tests/test_grammar_processor_558.py
@@ -885,19 +885,30 @@ def test_supports_grammar_marker_declared_for_in_tree_parsers():
     # stale ``True`` (spurious 400s). NB: this asserts the marker DIRECTLY, not
     # the derived ``supports_grammar()`` — the runtime inference net (next test)
     # would otherwise mask a missing marker and make this a tautology.
+    #
+    # SCOPE (#1149 codex): restrict to IN-TREE parser classes (module under
+    # ``vllm_mlx.tool_parsers``). An out-of-tree parser MAY legitimately override
+    # ``structure_info`` WITHOUT the marker and still work via the inference net
+    # (proven in ``test_supports_grammar_infers_capability_without_marker``), so
+    # asserting the marker on it would contradict that compatibility contract.
     from vllm_mlx.tool_parsers import ToolParserManager
     from vllm_mlx.tool_parsers.abstract_tool_parser import ToolParser
 
     names = ToolParserManager.list_registered()
     assert names, "no tool parsers registered"
+    checked = 0
     for name in names:
         cls = ToolParserManager.get_tool_parser(name)
+        if not cls.__module__.startswith("vllm_mlx.tool_parsers"):
+            continue  # out-of-tree parser: covered by the inference net, not the marker
+        checked += 1
         overrides_structure_info = cls.structure_info is not ToolParser.structure_info
         assert bool(cls.SUPPORTS_GRAMMAR) == overrides_structure_info, (
             f"{cls.__name__} (parser '{name}'): SUPPORTS_GRAMMAR marker="
             f"{cls.SUPPORTS_GRAMMAR} but structure_info overridden="
             f"{overrides_structure_info}; declare the marker to match (#1144)"
         )
+    assert checked, "no in-tree tool parsers checked"
 
 
 def test_supports_grammar_infers_capability_without_marker():

--- a/tests/test_grammar_processor_558.py
+++ b/tests/test_grammar_processor_558.py
@@ -888,9 +888,7 @@ def test_supports_grammar_marker_matches_structure_info_override():
     assert names, "no tool parsers registered"
     for name in names:
         cls = ToolParserManager.get_tool_parser(name)
-        overrides_structure_info = (
-            cls.structure_info is not ToolParser.structure_info
-        )
+        overrides_structure_info = cls.structure_info is not ToolParser.structure_info
         assert cls.supports_grammar() == overrides_structure_info, (
             f"{cls.__name__} (parser '{name}'): SUPPORTS_GRAMMAR="
             f"{cls.supports_grammar()} but structure_info overridden="

--- a/tests/test_grammar_processor_558.py
+++ b/tests/test_grammar_processor_558.py
@@ -876,11 +876,15 @@ def test_normal_schema_free_form_for_non_grammar_parser(monkeypatch, choice):
     assert _enforce_tool_grammar_bounds_or_400(cfg, req) is None
 
 
-def test_supports_grammar_marker_matches_structure_info_override():
-    # Invariant guard: keep the cheap class-level ``SUPPORTS_GRAMMAR`` marker in
-    # sync with the actual ``structure_info`` override across ALL registered
-    # parsers, so a new grammar-capable parser can't ship a stale marker (which
-    # would silently drop the #561 400) or a stale True (spurious 400s).
+def test_supports_grammar_marker_declared_for_in_tree_parsers():
+    # In-tree DISCOVERABILITY guard (#1149 codex): the explicit
+    # ``SUPPORTS_GRAMMAR`` marker itself must match the ``structure_info``
+    # override across ALL registered parsers, so the grep-able capability list
+    # stays honest — a new grammar-capable in-tree parser can't ship WITHOUT the
+    # marker (which would rot the list), and a non-capable parser can't ship a
+    # stale ``True`` (spurious 400s). NB: this asserts the marker DIRECTLY, not
+    # the derived ``supports_grammar()`` — the runtime inference net (next test)
+    # would otherwise mask a missing marker and make this a tautology.
     from vllm_mlx.tool_parsers import ToolParserManager
     from vllm_mlx.tool_parsers.abstract_tool_parser import ToolParser
 
@@ -889,11 +893,43 @@ def test_supports_grammar_marker_matches_structure_info_override():
     for name in names:
         cls = ToolParserManager.get_tool_parser(name)
         overrides_structure_info = cls.structure_info is not ToolParser.structure_info
-        assert cls.supports_grammar() == overrides_structure_info, (
-            f"{cls.__name__} (parser '{name}'): SUPPORTS_GRAMMAR="
-            f"{cls.supports_grammar()} but structure_info overridden="
-            f"{overrides_structure_info}; keep the marker in sync (#1144)"
+        assert bool(cls.SUPPORTS_GRAMMAR) == overrides_structure_info, (
+            f"{cls.__name__} (parser '{name}'): SUPPORTS_GRAMMAR marker="
+            f"{cls.SUPPORTS_GRAMMAR} but structure_info overridden="
+            f"{overrides_structure_info}; declare the marker to match (#1144)"
         )
+
+
+def test_supports_grammar_infers_capability_without_marker():
+    # Runtime ROBUSTNESS net (#1149 codex): an out-of-tree parser that overrides
+    # ``structure_info`` but OMITS the marker is STILL grammar-capable via
+    # structural inference — no silent regression of grammar / #561 enforcement.
+    # A plain parser (no override, no marker) is NOT capable. This exercises the
+    # inference branch independently of the in-tree marker guard above.
+    from vllm_mlx.tool_parsers import ToolParserManager
+    from vllm_mlx.tool_parsers.abstract_tool_parser import ToolParser
+
+    class _OverrideNoMarker(ToolParser):
+        EXPECTED_WIRE_FORMATS = ("tool_call_json",)
+
+        def extract_tool_calls(self, model_output, request=None):
+            return None
+
+        def structure_info(self):
+            return lambda name: None
+
+    class _PlainNoOverride(ToolParser):
+        EXPECTED_WIRE_FORMATS = ("tool_call_json",)
+
+        def extract_tool_calls(self, model_output, request=None):
+            return None
+
+    assert _OverrideNoMarker.SUPPORTS_GRAMMAR is False  # marker deliberately unset
+    assert _OverrideNoMarker.supports_grammar() is True  # inferred from override
+    assert _PlainNoOverride.supports_grammar() is False
+    # And the concrete in-tree capable parsers report capable.
+    assert ToolParserManager.get_tool_parser("hermes").supports_grammar() is True
+    assert ToolParserManager.get_tool_parser("qwen").supports_grammar() is True
 
 
 def test_offline_skip_classifies_http_status():

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -616,20 +616,24 @@ def _tool_parser_supports_grammar(cfg) -> bool:
     not treat it as active.
 
     Resolving the class is a cached dict lookup (the parser module is imported
-    once at model load), and the marker is a class attribute, so this stays a
-    light synchronous check with no instantiation and no tokenizer. An unknown /
-    unresolvable parser name is treated as NOT grammar-capable (free-form) — the
-    same non-breaking fallback the heavy build path already takes.
+    once at model load), and ``supports_grammar`` is a class-level check, so this
+    stays a light synchronous probe with no instantiation and no tokenizer. An
+    UNKNOWN parser name (``KeyError`` from the manager) is treated as NOT
+    grammar-capable (free-form) — the same non-breaking fallback the heavy build
+    path already takes. Any OTHER failure (a broken import/registry for a known
+    parser) is NOT swallowed here (codex #1149): failing open would silently drop
+    both the grammar constraint and the #561 oversized-schema enforcement for a
+    genuinely-configured parser, so it propagates to surface the real bug.
     """
     name = getattr(cfg, "tool_call_parser", None)
     if not name:
         return False
-    try:
-        from ..tool_parsers import ToolParserManager
+    from ..tool_parsers import ToolParserManager
 
+    try:
         parser_cls = ToolParserManager.get_tool_parser(name)
-    except Exception:
-        return False
+    except KeyError:
+        return False  # unknown / unregistered parser name -> free-form.
     return bool(parser_cls.supports_grammar())
 
 

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -604,22 +604,59 @@ def _constrain_tools_opted_out() -> bool:
     )
 
 
+def _tool_parser_supports_grammar(cfg) -> bool:
+    """Cheap capability probe: is the configured tool parser grammar-CAPABLE?
+
+    #1144: a parser is grammar-capable only when it overrides ``structure_info``
+    to emit a wire triple — declared at the class level via the
+    ``ToolParser.SUPPORTS_GRAMMAR`` marker (default ``False`` on the ABC; ``True``
+    on hermes/qwen). A non-capable parser is NEVER decoder-constrained
+    (``_maybe_build_tool_grammar_processor`` returns ``None`` → free-form), so
+    the constrained path — including the #561 oversized-schema HTTP 400 — must
+    not treat it as active.
+
+    Resolving the class is a cached dict lookup (the parser module is imported
+    once at model load), and the marker is a class attribute, so this stays a
+    light synchronous check with no instantiation and no tokenizer. An unknown /
+    unresolvable parser name is treated as NOT grammar-capable (free-form) — the
+    same non-breaking fallback the heavy build path already takes.
+    """
+    name = getattr(cfg, "tool_call_parser", None)
+    if not name:
+        return False
+    try:
+        from ..tool_parsers import ToolParserManager
+
+        parser_cls = ToolParserManager.get_tool_parser(name)
+    except Exception:
+        return False
+    return bool(parser_cls.supports_grammar())
+
+
 def _tool_grammar_constraint_active(cfg, request) -> bool:
     """True iff the constrained-tool-calling path is ACTIVE for this request.
 
     Checks everything EXCEPT the schema-size/depth/count bound: the operator has
-    not opted out, tools are present, a family parser is configured, and
-    ``tool_choice`` resolves to a constrainable mode (auto / required / named —
-    ``"none"`` and a malformed object form normalize to ``None`` and are NOT
+    not opted out, tools are present, a family parser is configured AND that
+    parser is grammar-CAPABLE (#1144 — its ``structure_info`` can produce a wire
+    triple; a non-capable parser is never constrained so its path is inactive),
+    and ``tool_choice`` resolves to a constrainable mode (auto / required / named
+    — ``"none"`` and a malformed object form normalize to ``None`` and are NOT
     constrained). Deliberately excludes the bounds check so the caller can
-    distinguish an oversized schema (→ HTTP 400 under #561) from a genuinely
-    inactive path (→ free-form).
+    distinguish an oversized schema (→ HTTP 400 under #561, grammar-capable
+    parsers only) from a genuinely inactive path (→ free-form).
     """
     if _constrain_tools_opted_out():
         return False
     if not getattr(request, "tools", None) or not getattr(
         cfg, "tool_call_parser", None
     ):
+        return False
+    # #1144: gate on parser grammar-CAPABILITY, not merely on a parser being
+    # set. A non-grammar-capable parser (``structure_info`` is the ABC default →
+    # None) would fall back to free-form anyway, so an oversized schema must NOT
+    # 400 for it — only grammar-capable parsers (hermes/qwen) keep the #561 400.
+    if not _tool_parser_supports_grammar(cfg):
         return False
     return (
         _normalize_tool_choice_for_grammar(getattr(request, "tool_choice", None))

--- a/vllm_mlx/tool_parsers/abstract_tool_parser.py
+++ b/vllm_mlx/tool_parsers/abstract_tool_parser.py
@@ -176,6 +176,19 @@ class ToolParser(ABC):
         tokenizer (class-attribute + class-level function-identity comparison),
         so the synchronous route gate stays cheap.
 
+        DELIBERATELY class-level (#1144 mandates a cheap probe, "DO NOT invent a
+        heavy probe"): capability is a family/class property, NOT the per-request
+        result of ``structure_info()``. A grammar-capable family whose
+        ``structure_info()`` is tokenizer-GATED to ``None`` at runtime (e.g.
+        hermes on a non-Qwen tokenizer where ``<tool_call>`` is multi-token) is
+        still reported capable here, so an oversized schema for it keeps the #561
+        HTTP 400 — the SAME behavior as before this change and exactly what #1144
+        says to preserve for grammar-capable parsers (remedy:
+        ``RAPID_MLX_CONSTRAIN_TOOLS=0``). Resolving the true runtime result would
+        require instantiating the parser with the tokenizer on the event loop —
+        the heavy probe #1144 forbids. Only NON-capable families change (#1144:
+        oversized -> free-form instead of 400).
+
         Returns:
             True if this parser class supports grammar constraint.
         """

--- a/vllm_mlx/tool_parsers/abstract_tool_parser.py
+++ b/vllm_mlx/tool_parsers/abstract_tool_parser.py
@@ -150,35 +150,40 @@ class ToolParser(ABC):
     # reading-the-source archeology.
     EXPECTED_WIRE_FORMATS: tuple[str, ...] = ()
 
-    # Class-level marker for decoder-level grammar-constraint capability
-    # (#558 / #1144). A parser is grammar-CAPABLE when it overrides
-    # ``structure_info`` to return a ``name -> StructureInfo`` wire triple; set
-    # this to ``True`` in those subclasses (currently hermes + qwen). Default
-    # ``False`` on the ABC — the family is parsed free-form-then-parse and is
-    # NEVER decoder-constrained. This is a CHEAP class-level probe (no
-    # instantiation, no tokenizer) so the synchronous route gate can decide
-    # whether the constrained-tool path is even reachable before doing any
-    # heavy work; keep it in sync with ``structure_info``
-    # (``test_supports_grammar_marker_matches_structure_info_override`` enforces
-    # the invariant).
+    # Explicit opt-in marker for decoder-level grammar-constraint capability
+    # (#558 / #1144). Grammar-CAPABLE means the parser overrides
+    # ``structure_info`` to return a ``name -> StructureInfo`` wire triple.
+    # hermes + qwen set this to ``True`` for DISCOVERABILITY (grep-able list of
+    # grammar-capable families); it is NOT the sole source of truth —
+    # ``supports_grammar`` also INFERS capability from the ``structure_info``
+    # override, so an out-of-tree parser that overrides ``structure_info``
+    # without knowing about this marker still gets grammar + #561 enforcement
+    # (codex #1149: a marker-only gate would silently regress such parsers).
     SUPPORTS_GRAMMAR: bool = False
 
     @classmethod
     def supports_grammar(cls) -> bool:
         """Cheap class-level probe: is this parser grammar-CAPABLE (#558/#1144)?
 
-        Returns ``True`` iff the parser overrides ``structure_info`` to emit a
-        wire triple and is therefore eligible for decoder-level grammar
-        constraint. A non-capable parser (the ABC default) always falls back to
+        Returns ``True`` iff the parser can be decoder-constrained — i.e. it
+        overrides ``structure_info`` to emit a wire triple (inferred
+        structurally so no parser can silently regress by omitting a marker), OR
+        it explicitly opts in via ``SUPPORTS_GRAMMAR``. A non-capable parser
+        (the ABC default: no override, marker ``False``) always falls back to
         free-form-then-parse regardless of schema size, so an oversized schema
-        for such a parser must NOT be rejected with HTTP 400 (#1144) — it was
-        never going to be constrained. Backed by the ``SUPPORTS_GRAMMAR`` class
-        attribute so the check needs neither instantiation nor a tokenizer.
+        for it must NOT be rejected with HTTP 400 (#1144) — it was never going
+        to be constrained. The check needs neither instantiation nor a
+        tokenizer (class-attribute + class-level function-identity comparison),
+        so the synchronous route gate stays cheap.
 
         Returns:
             True if this parser class supports grammar constraint.
         """
-        return cls.SUPPORTS_GRAMMAR
+        if cls.SUPPORTS_GRAMMAR:
+            return True
+        # Structural inference: capable iff ``structure_info`` is overridden
+        # from the ABC default (which returns ``None`` — free-form).
+        return cls.structure_info is not ToolParser.structure_info
 
     @classmethod
     def supports_native_format(cls) -> bool:

--- a/vllm_mlx/tool_parsers/abstract_tool_parser.py
+++ b/vllm_mlx/tool_parsers/abstract_tool_parser.py
@@ -150,6 +150,36 @@ class ToolParser(ABC):
     # reading-the-source archeology.
     EXPECTED_WIRE_FORMATS: tuple[str, ...] = ()
 
+    # Class-level marker for decoder-level grammar-constraint capability
+    # (#558 / #1144). A parser is grammar-CAPABLE when it overrides
+    # ``structure_info`` to return a ``name -> StructureInfo`` wire triple; set
+    # this to ``True`` in those subclasses (currently hermes + qwen). Default
+    # ``False`` on the ABC — the family is parsed free-form-then-parse and is
+    # NEVER decoder-constrained. This is a CHEAP class-level probe (no
+    # instantiation, no tokenizer) so the synchronous route gate can decide
+    # whether the constrained-tool path is even reachable before doing any
+    # heavy work; keep it in sync with ``structure_info``
+    # (``test_supports_grammar_marker_matches_structure_info_override`` enforces
+    # the invariant).
+    SUPPORTS_GRAMMAR: bool = False
+
+    @classmethod
+    def supports_grammar(cls) -> bool:
+        """Cheap class-level probe: is this parser grammar-CAPABLE (#558/#1144)?
+
+        Returns ``True`` iff the parser overrides ``structure_info`` to emit a
+        wire triple and is therefore eligible for decoder-level grammar
+        constraint. A non-capable parser (the ABC default) always falls back to
+        free-form-then-parse regardless of schema size, so an oversized schema
+        for such a parser must NOT be rejected with HTTP 400 (#1144) — it was
+        never going to be constrained. Backed by the ``SUPPORTS_GRAMMAR`` class
+        attribute so the check needs neither instantiation nor a tokenizer.
+
+        Returns:
+            True if this parser class supports grammar constraint.
+        """
+        return cls.SUPPORTS_GRAMMAR
+
     @classmethod
     def supports_native_format(cls) -> bool:
         """

--- a/vllm_mlx/tool_parsers/hermes_tool_parser.py
+++ b/vllm_mlx/tool_parsers/hermes_tool_parser.py
@@ -310,6 +310,12 @@ class HermesToolParser(ToolParser):
 
     _GRAMMAR_SENTINELS = ("<tool_call>", "</tool_call>")
 
+    # Grammar-CAPABLE (#558/#1144): overrides ``structure_info`` below. The
+    # class-level marker lets the route gate decide the constrained path is
+    # reachable without instantiating the parser (an oversized schema still
+    # 400s here, per #561, rather than silently dropping the guarantee).
+    SUPPORTS_GRAMMAR: bool = True
+
     def structure_info(self):
         """Grammar-constraint wire triple for the hermes ``<tool_call>`` JSON
         body (#558). ``<tool_call>`` / ``</tool_call>`` are single special

--- a/vllm_mlx/tool_parsers/qwen_tool_parser.py
+++ b/vllm_mlx/tool_parsers/qwen_tool_parser.py
@@ -55,6 +55,12 @@ class QwenToolParser(ToolParser):
 
     _GRAMMAR_SENTINELS = ("<tool_call>", "</tool_call>")
 
+    # Grammar-CAPABLE (#558/#1144): overrides ``structure_info`` below. The
+    # class-level marker lets the route gate decide the constrained path is
+    # reachable without instantiating the parser (an oversized schema still
+    # 400s here, per #561, rather than silently dropping the guarantee).
+    SUPPORTS_GRAMMAR: bool = True
+
     def structure_info(self):
         """Grammar-constraint wire triple for the qwen ``<tool_call>`` JSON
         body (#558). Qwen shares the hermes ``<tool_call>…</tool_call>`` wire:


### PR DESCRIPTION
## Summary

Under default-on constrained tool-calling (#558 PR-5), an **oversized** tool schema (`> _TOOL_GRAMMAR_MAX_SCHEMA_BYTES` / `> _TOOL_GRAMMAR_MAX_SCHEMA_DEPTH` / `> _TOOL_GRAMMAR_MAX_TOOLS`) was rejected with **HTTP 400** for **any** configured `tool_call_parser` — including parsers that are **not grammar-capable** (their `structure_info()` returns `None`). A non-grammar-capable parser is never decoder-constrained (`_maybe_build_tool_grammar_processor` returns `None` → free-form-then-parse), so an oversized schema for it should fall back to **free-form**, not 400.

`Closes #1144`

## The wrong 400

`vllm_mlx/routes/chat.py::_tool_grammar_constraint_active` decided the constrained path was "active" whenever `cfg.tool_call_parser` was merely **set**. `_enforce_tool_grammar_bounds_or_400` then raised 400 on that "active" path for an oversized schema — even for a parser (e.g. `deepseek_v3`, `llama`, `qwen3_coder_xml`, `glm47`, …) whose `structure_info()` is the ABC default (`None`), which would have produced a free-form response anyway.

## Root cause

`_tool_grammar_constraint_active` never checked parser **grammar-capability** — only that a parser name was configured.

## The fix (capability gate)

- Add `supports_grammar()` + a `SUPPORTS_GRAMMAR` marker on the tool-parser ABC. `supports_grammar()` returns True iff the parser overrides `structure_info` (inferred structurally, so an **out-of-tree** parser that overrides without knowing the marker still gets grammar + #561 enforcement — no silent regression) **OR** explicitly sets `SUPPORTS_GRAMMAR = True` (kept on hermes/qwen for a grep-able discoverability list). Cheap: class-attribute + class-level function-identity check — **no instantiation, no tokenizer**.
- `_tool_grammar_constraint_active` now additionally requires the parser to be grammar-capable via `_tool_parser_supports_grammar(cfg)`: a cached-dict class lookup then `supports_grammar()`. An **unknown** parser name (`KeyError`) → not capable (free-form); any other import/registry failure for a genuinely-configured parser **propagates** (surfaces the bug) rather than silently failing open.

Result: a non-grammar-capable parser + oversized schema → **free-form** (path inactive, no 400, no wasted compile-offload); a grammar-capable parser + oversized schema → **still 400** (#561 preserved).

## Blast radius

Narrow. Only **non-hermes/qwen** parsers **with an oversized schema** change behavior (400 → free-form). #561's grammar-capable 400 for hermes/qwen (all current tool-calling families) is preserved unchanged. Golden path (in-bounds schemas) is untouched.

## Tests

Added to `tests/test_grammar_processor_558.py`:
- `test_supports_grammar_probe_matches_capability` — route probe True for hermes/qwen, False for `deepseek_v3` / unknown / None.
- `test_oversized_schema_still_400_for_grammar_capable_parser` (hermes+qwen × required/auto/None) — **#561 regression guard**: oversized still 400.
- `test_oversized_schema_falls_back_for_non_grammar_parser` — non-grammar + oversized → path inactive, **NOT 400** (free-form).
- `test_normal_schema_free_form_for_non_grammar_parser` — non-grammar + normal schema → not eligible, no 400.
- `test_supports_grammar_marker_declared_for_in_tree_parsers` — in-tree discoverability guard: `SUPPORTS_GRAMMAR` marker itself matches the `structure_info` override for every registered parser.
- `test_supports_grammar_infers_capability_without_marker` — runtime robustness net: an override-without-marker parser is still capable via inference; a plain parser is not.

## Test plan

- [x] `test_supports_grammar_probe_matches_capability` passes
- [x] grammar-capable (hermes/qwen) + oversized schema → still 400 across required/auto/None
- [x] non-grammar-capable (`deepseek_v3`) + oversized schema → free-form (NOT 400)
- [x] non-grammar-capable + normal schema → free-form (not eligible, no 400)
- [x] `SUPPORTS_GRAMMAR` marker declared to match `structure_info` override for all registered parsers
- [x] override-without-marker parser inferred grammar-capable; plain parser not
- [x] `tests/test_grammar_processor_558.py` full file green
- [x] `test_structure_info_hermes_qwen_558.py`, `test_tool_grammar_558.py`, `test_tool_parser_wire_formats.py`, `test_tool_parser_coverage.py`, `test_native_tool_format.py` green (1 network-only tokenizer-download skip unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)