### PR TITLE
chore: migrate Homebrew from personal tap to homebrew/core

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -2,7 +2,7 @@ name: Auto-release on version bump
 
 # When a commit lands on main with subject ``chore: bump version to X.Y.Z``,
 # automatically tag ``vX.Y.Z`` and publish a GitHub Release. The existing
-# ``publish.yml`` then fans out to PyPI + Homebrew on the ``release:
+# ``publish.yml`` then publishes to PyPI on the ``release:
 # published`` event.
 #
 # Without this, the release pipeline stalls between "version committed
@@ -93,7 +93,7 @@ jobs:
               echo "_(no changes recorded)_"
             fi
             echo
-            echo "Install: \`brew upgrade raullenchai/rapid-mlx/rapid-mlx\` or \`pip install -U rapid-mlx==$VERSION\` (or just \`rapid-mlx upgrade\`)."
+            echo "Install: \`brew upgrade rapid-mlx\` or \`pip install -U rapid-mlx==$VERSION\` (or just \`rapid-mlx upgrade\`)."
             echo '__EOF__'
           } >> "$GITHUB_OUTPUT"
 
@@ -128,4 +128,4 @@ jobs:
             --notes-file - \
             --target "$TARGET_SHA"
 
-          echo "✓ Released $TAG — publish.yml will now fan out to PyPI + Homebrew"
+          echo "✓ Released $TAG — publish.yml will now publish to PyPI"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: Publish to PyPI & Homebrew
+name: Publish to PyPI
 
 on:
   release:
@@ -179,59 +179,3 @@ jobs:
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # release/v1
         with:
           packages-dir: candidate/dist/
-
-  update-homebrew:
-    needs: publish
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - name: Wait for PyPI to propagate
-        run: sleep 30
-
-      - name: Get release version
-        id: version
-        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
-
-      - name: Fetch tarball URL and SHA256
-        id: pypi
-        env:
-          EXPECTED_SHA256: ${{ needs.publish.outputs.sdist_sha256 }}
-        run: |
-          VERSION="${{ steps.version.outputs.version }}"
-          # Poll PyPI until the new version appears (max 5 minutes)
-          for i in $(seq 1 10); do
-            URL=$(curl -fsSL "https://pypi.org/pypi/rapid-mlx/${VERSION}/json" 2>/dev/null \
-              | python3 -c "import json,sys; d=json.load(sys.stdin); print([u['url'] for u in d['urls'] if u['packagetype']=='sdist'][0])" 2>/dev/null) && break
-            echo "Waiting for PyPI... (attempt $i)"
-            sleep 30
-          done
-          if [ -z "$URL" ]; then echo "Failed to find tarball on PyPI"; exit 1; fi
-
-          # Download and compute SHA256
-          curl -fsSL "$URL" -o /tmp/rapid-mlx.tar.gz
-          SHA256=$(sha256sum /tmp/rapid-mlx.tar.gz | cut -d' ' -f1)
-          rm /tmp/rapid-mlx.tar.gz
-          if [ "$SHA256" != "$EXPECTED_SHA256" ]; then
-            echo "PyPI sdist SHA256 does not match the manifest" >&2
-            echo "expected: $EXPECTED_SHA256" >&2
-            echo "actual:   $SHA256" >&2
-            exit 1
-          fi
-
-          echo "url=$URL" >> "$GITHUB_OUTPUT"
-          echo "sha256=$SHA256" >> "$GITHUB_OUTPUT"
-          echo "Found: $URL (sha256: $SHA256)"
-
-      - name: Update Homebrew formula
-        uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0  # v3
-        with:
-          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
-          repository: raullenchai/homebrew-rapid-mlx
-          event-type: update-formula
-          client-payload: |
-            {
-              "version": "${{ steps.version.outputs.version }}",
-              "url": "${{ steps.pypi.outputs.url }}",
-              "sha256": "${{ steps.pypi.outputs.sha256 }}"
-            }

--- a/.github/workflows/release-artifact-matrix.yml
+++ b/.github/workflows/release-artifact-matrix.yml
@@ -395,23 +395,3 @@ jobs:
             exit 1
           fi
           gh release edit "$TAG" --repo "$GITHUB_REPOSITORY" --draft=false
-
-  update-homebrew:
-    name: Promote verified sdist to Homebrew
-    needs: [build-candidate, verify-pypi, publish-github-release]
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - name: Update Homebrew formula
-        uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0  # v3
-        with:
-          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
-          repository: raullenchai/homebrew-rapid-mlx
-          event-type: update-formula
-          client-payload: |
-            {
-              "version": "${{ needs.build-candidate.outputs.version }}",
-              "url": "${{ needs.verify-pypi.outputs.sdist_url }}",
-              "sha256": "${{ needs.verify-pypi.outputs.sdist_sha256 }}"
-            }

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 <p align="center">
   <a href="https://pypi.org/project/rapid-mlx/"><img src="https://img.shields.io/pypi/v/rapid-mlx?color=blue&label=PyPI" alt="PyPI"></a>
-  <a href="https://github.com/raullenchai/homebrew-rapid-mlx"><img src="https://img.shields.io/badge/Homebrew-raullenchai%2Frapid--mlx-orange?logo=homebrew" alt="Homebrew tap"></a>
+  <a href="https://formulae.brew.sh/formula/rapid-mlx"><img src="https://img.shields.io/badge/Homebrew-core-orange?logo=homebrew" alt="Homebrew core"></a>
   <a href="https://www.python.org/downloads/"><img src="https://img.shields.io/badge/python-3.10+-blue.svg" alt="Python 3.10+"></a>
   <a href="https://support.apple.com/en-us/HT211814"><img src="https://img.shields.io/badge/Apple_Silicon-M1%20|%20M2%20|%20M3%20|%20M4-black.svg?logo=apple" alt="Apple Silicon"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-Apache_2.0-blue.svg" alt="License"></a>
@@ -146,15 +146,13 @@ The installer's RAM detector picks a sensible default. If you want to shop the f
 The curl one-liner above wraps all of these — reach for these only if you already manage Python yourself.
 
 <details>
-<summary><strong>Homebrew</strong> — Mac-native, tap + trust required on Homebrew 4.x</summary>
+<summary><strong>Homebrew</strong> — Mac-native, in <code>homebrew/core</code></summary>
 
 ```bash
-brew tap raullenchai/rapid-mlx
-brew trust raullenchai/rapid-mlx
 brew install rapid-mlx
 ```
 
-Upgrade with `brew upgrade rapid-mlx`. If `brew install` stalls on `Tapping homebrew/core`, run `brew tap homebrew/core --force` once (one-time ~1.3 GB download) and retry.
+Upgrade with `brew upgrade rapid-mlx`.
 
 </details>
 

--- a/docs/development/releasing.md
+++ b/docs/development/releasing.md
@@ -55,11 +55,11 @@ The full path from "I want to release" to "users on `brew upgrade` see the new v
 
 3. **`auto-release.yml` fires** (~30s) — verifies the commit, checks the tag doesn't already exist, builds a CHANGELOG from `git log <prev-tag>..HEAD`, creates the GitHub Release.
 
-4. **`publish.yml` fires on `release: published`** (~3min) — builds sdist + wheel, uploads to PyPI (via the `pypi` deployment environment), polls PyPI until the version is queryable, computes the tarball SHA256, dispatches an `update-formula` event to `raullenchai/homebrew-rapid-mlx`.
+4. **`publish.yml` fires on `release: published`** (~3min) — builds sdist + wheel, uploads to PyPI (via the `pypi` deployment environment).
 
-5. **The tap repo's workflow** (in `homebrew-rapid-mlx`) updates `Formula/rapid-mlx.rb` `url` + `sha256` + commits.
+5. **Homebrew (homebrew/core)** — no action needed. `rapid-mlx` is in homebrew/core, which tracks new PyPI releases via Homebrew's autobump/livecheck (BrewTestBot opens the bump PR and builds bottles). If autobump ever lags, a maintainer can run `brew bump-formula-pr --version=X.Y.Z rapid-mlx`.
 
-6. **Verify**: `brew update && brew upgrade rapid-mlx` should pull in the new version.
+6. **Verify**: once the core bump merges, `brew update && brew upgrade rapid-mlx` pulls in the new version.
 
 The sequence is hands-off after step 2.
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -28,16 +28,11 @@ if you don't want to install `uv` first.
 ## Install with Homebrew
 
 ```bash
-brew tap raullenchai/rapid-mlx
-brew trust raullenchai/rapid-mlx
 brew install rapid-mlx
 ```
 
-All three steps are required. Homebrew 4.x refuses one-shot installs from
-third-party taps with `Refusing to load formula ... from untrusted tap` —
-the `brew trust` line is what marks the tap as trusted. Tap + trust are
-both per-machine and persist across upgrades; `brew upgrade rapid-mlx`
-after the first install works directly.
+`rapid-mlx` is in **homebrew/core** — no tap, no trust, just one command.
+Upgrade later with `brew upgrade rapid-mlx`.
 
 ## Install with pip
 
@@ -106,21 +101,12 @@ Use a smaller quantized model:
 rapid-mlx serve qwen3.5-4b-4bit
 ```
 
-### `Refusing to load formula ... from untrusted tap`
-
-Homebrew 4.x refuses installs from third-party taps until you mark them
-trusted. Run the three-step install at the top of this page (tap, trust,
-install). The `brew trust` line is the one that flips the refusal off.
-Only needs to be done once per machine.
-
 ### `brew install` fails with `Operation not permitted`
 
-Brew 5.x's install sandbox sometimes can't auto-tap `homebrew/core` mid-install.
+Brew's install sandbox sometimes can't auto-tap `homebrew/core` mid-install.
 Pre-tap it once, then retry:
 
 ```bash
 brew tap homebrew/core --force   # ~1.3 GB, one-time
-brew tap raullenchai/rapid-mlx
-brew trust raullenchai/rapid-mlx
 brew install rapid-mlx
 ```

--- a/tests/test_upgrade_cli.py
+++ b/tests/test_upgrade_cli.py
@@ -26,8 +26,8 @@ def _stub_brew_with_upgrade_available(monkeypatch):
         lambda: vc.InstallInfo(
             method="brew",
             binary_path="/opt/homebrew/bin/rapid-mlx",
-            upgrade_command="brew upgrade raullenchai/rapid-mlx/rapid-mlx",
-            upgrade_argv=["brew", "upgrade", "raullenchai/rapid-mlx/rapid-mlx"],
+            upgrade_command="brew upgrade rapid-mlx",
+            upgrade_argv=["brew", "upgrade", "rapid-mlx"],
         ),
     )
 
@@ -45,7 +45,7 @@ def test_dry_run_does_not_invoke_subprocess(monkeypatch, capsys):
     out = capsys.readouterr().out
     assert "Current:  rapid-mlx 0.9.3" in out
     assert "Latest:   rapid-mlx 0.9.4" in out
-    assert "brew upgrade raullenchai/rapid-mlx/rapid-mlx" in out
+    assert "brew upgrade rapid-mlx" in out
     assert "(dry-run — not executed" in out
 
 
@@ -68,9 +68,7 @@ def test_non_dry_run_still_calls_subprocess(monkeypatch):
         pytest.raises(SystemExit) as exc,
     ):
         upgrade_command(args)
-    run.assert_called_once_with(
-        ["brew", "upgrade", "raullenchai/rapid-mlx/rapid-mlx"], check=False
-    )
+    run.assert_called_once_with(["brew", "upgrade", "rapid-mlx"], check=False)
     assert exc.value.code == 0
 
 

--- a/tests/test_version_check.py
+++ b/tests/test_version_check.py
@@ -335,10 +335,9 @@ def test_print_helper_swallows_all_exceptions(monkeypatch, capsys):
 def test_warning_message_recommends_upgrade_subcommand(isolated_cache, monkeypatch):
     """The banner must point users at our own upgrade subcommand.
 
-    Pre-0.6.31 we suggested raw ``brew upgrade rapid-mlx`` — wrong formula
-    path (the tap is ``raullenchai/rapid-mlx/rapid-mlx``) AND it stranded pip /
-    install.sh users. The new flow centralises the install-method detection
-    in ``rapid-mlx upgrade``, so the warning just needs to point there.
+    We centralise install-method detection in ``rapid-mlx upgrade`` (it also
+    handles pip / install.sh users, who a raw ``brew upgrade`` would strand),
+    so the warning just needs to point there.
     """
     monkeypatch.setattr(vc, "_installed_version", lambda: "0.6.20")
     _seed_cache(isolated_cache, "0.6.30")
@@ -354,9 +353,8 @@ def test_warning_message_recommends_upgrade_subcommand(isolated_cache, monkeypat
 def test_detect_install_method_brew(monkeypatch):
     """A brew install resolves through realpath into ``/opt/homebrew/Cellar/``.
 
-    The detector must spot that and return the *tap-qualified* formula path
-    — ``brew upgrade rapid-mlx`` alone doesn't know about external taps and
-    fails with ``Error: rapid-mlx not installed`` for users on the tap.
+    The detector must spot that and return the core formula upgrade command
+    — ``brew upgrade rapid-mlx`` (rapid-mlx is in homebrew/core, no tap needed).
     """
     fake_binary = "/opt/homebrew/bin/rapid-mlx"
     fake_realpath = "/opt/homebrew/Cellar/rapid-mlx/0.6.20/bin/rapid-mlx"
@@ -368,8 +366,8 @@ def test_detect_install_method_brew(monkeypatch):
 
     info = vc.detect_install_method()
     assert info.method == "brew"
-    assert info.upgrade_command == "brew upgrade raullenchai/rapid-mlx/rapid-mlx"
-    assert info.upgrade_argv == ["brew", "upgrade", "raullenchai/rapid-mlx/rapid-mlx"]
+    assert info.upgrade_command == "brew upgrade rapid-mlx"
+    assert info.upgrade_argv == ["brew", "upgrade", "rapid-mlx"]
     assert info.binary_path == fake_binary
 
 
@@ -562,8 +560,8 @@ def test_prompt_returns_false_when_upgrade_subprocess_fails(monkeypatch, interac
         "detect_install_method",
         lambda: vc.InstallInfo(
             method="brew",
-            upgrade_command="brew upgrade raullenchai/rapid-mlx/rapid-mlx",
-            upgrade_argv=["brew", "upgrade", "raullenchai/rapid-mlx/rapid-mlx"],
+            upgrade_command="brew upgrade rapid-mlx",
+            upgrade_argv=["brew", "upgrade", "rapid-mlx"],
         ),
     )
     fake_result = MagicMock(returncode=1)
@@ -613,8 +611,8 @@ def test_prompt_returns_true_and_runs_upgrade_on_accept(monkeypatch, interactive
         "detect_install_method",
         lambda: vc.InstallInfo(
             method="brew",
-            upgrade_command="brew upgrade raullenchai/rapid-mlx/rapid-mlx",
-            upgrade_argv=["brew", "upgrade", "raullenchai/rapid-mlx/rapid-mlx"],
+            upgrade_command="brew upgrade rapid-mlx",
+            upgrade_argv=["brew", "upgrade", "rapid-mlx"],
         ),
     )
     fake_result = MagicMock(returncode=0)
@@ -624,9 +622,7 @@ def test_prompt_returns_true_and_runs_upgrade_on_accept(monkeypatch, interactive
         patch("subprocess.run", return_value=fake_result) as run,
     ):
         assert vc.prompt_upgrade_if_available() is True
-        run.assert_called_once_with(
-            ["brew", "upgrade", "raullenchai/rapid-mlx/rapid-mlx"], check=False
-        )
+        run.assert_called_once_with(["brew", "upgrade", "rapid-mlx"], check=False)
 
 
 def test_prompt_crosses_minor_boundary(monkeypatch, interactive):

--- a/vllm_mlx/_version_check.py
+++ b/vllm_mlx/_version_check.py
@@ -372,7 +372,7 @@ def detect_install_method() -> InstallInfo:
     Detection order:
       1. brew — ``rapid-mlx`` realpath under ``/Cellar/rapid-mlx``,
          ``/opt/homebrew/`` (macOS) or ``/home/linuxbrew/`` (Linux brew)
-         triggers ``brew upgrade raullenchai/rapid-mlx/rapid-mlx``.
+         triggers ``brew upgrade rapid-mlx`` (now in homebrew/core).
       2. install.sh — binary under ``~/.local/bin`` (or realpath under
          the install.sh venv at ``~/.rapid-mlx/``) triggers a re-run of
          the install.sh script.
@@ -389,8 +389,8 @@ def detect_install_method() -> InstallInfo:
         if any(m in normalized for m in brew_markers):
             return InstallInfo(
                 method="brew",
-                upgrade_command="brew upgrade raullenchai/rapid-mlx/rapid-mlx",
-                upgrade_argv=["brew", "upgrade", "raullenchai/rapid-mlx/rapid-mlx"],
+                upgrade_command="brew upgrade rapid-mlx",
+                upgrade_argv=["brew", "upgrade", "rapid-mlx"],
                 binary_path=binary,
             )
         # install.sh creates ``~/.rapid-mlx`` (venv) and symlinks the


### PR DESCRIPTION
## Why

`rapid-mlx` landed in **homebrew/core** (merged 2026-07-21; arm64 bottles for sonoma/sequoia/tahoe are live), so `brew install rapid-mlx` now works with **no tap, no trust**. The personal tap `raullenchai/homebrew-rapid-mlx` is now a second, redundant source — the same-name collision we hit last week. This retires the tap plumbing so there's a single source of truth (core), and fixes the spots that still hardcoded the old tap formula.

## What changes

**Homebrew tap → core**
- **README**: drop `brew tap` / `brew trust` steps → just `brew install rapid-mlx`; remove the "Tapping homebrew/core stalls" note; badge points at `formulae.brew.sh`.
- **CI**: remove the `update-homebrew` jobs in `publish.yml` + `release-artifact-matrix.yml` (they `repository_dispatch` to the tap). `auto-release.yml` release-note + comments now say `brew upgrade rapid-mlx` / "publish to PyPI".

**Fix the half-done migration (caught in review)**
- `vllm_mlx/_version_check.py`: `rapid-mlx upgrade` for brew installs now runs `brew upgrade rapid-mlx` instead of the retired `brew upgrade raullenchai/rapid-mlx/rapid-mlx` (which would fail for core users). Tests + the now-inverted docstrings updated.
- `docs/getting-started/installation.md` + `docs/development/releasing.md`: Homebrew = one `brew install rapid-mlx`; release flow no longer dispatches to the tap.

## How core stays current
homebrew/core tracks new PyPI releases via Homebrew's **autobump / livecheck** (BrewTestBot). No fork/token to maintain. If autobump ever lags, a maintainer can `brew bump-formula-pr --version=X.Y.Z rapid-mlx`.

Because the tap is retired, `scripts/pr_validate/steps/supply_chain.py`'s `Formula/` / `homebrew-rapid-mlx/` HOOK_PATHS are left in place — they're fail-closed guards for paths that don't exist here, harmless to keep.

## Test plan
- [x] `pytest tests/test_upgrade_cli.py tests/test_version_check.py` → 56 passed
- [x] `ruff format --check` clean
- [x] both workflows still parse as YAML; no job `needs:` the removed ones

## Follow-up (done outside this PR)
- Retired the tap repo `raullenchai/homebrew-rapid-mlx`: README → migration notice, formula → `deprecate!`.
- `HOMEBREW_TAP_TOKEN` repo secret is now unused and can be deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)