### PR TITLE
feat(tools): harmony structure_info — grammar-constrained tool-calling for gpt-oss (#558)

### DIFF
--- a/tests/test_grammar_processor_558.py
+++ b/tests/test_grammar_processor_558.py
@@ -876,6 +876,82 @@ def test_normal_schema_free_form_for_non_grammar_parser(monkeypatch, choice):
     assert _enforce_tool_grammar_bounds_or_400(cfg, req) is None
 
 
+# --------------------------------------------------------------------------
+# Harmony AUTO opt-out (#558 +gpt-oss) — auto path stays free-form even though
+# harmony is now grammar-CAPABLE (structure_info overridden), because its
+# <|channel|> trigger is shared with non-tool responses (TOOL_GRAMMAR_AUTO_SAFE
+# = False). required/named remain constrained.
+# --------------------------------------------------------------------------
+def test_auto_safe_probe_matches_capability():
+    from vllm_mlx.routes.chat import _tool_parser_auto_safe
+
+    # Single-special-token-trigger families are auto-safe.
+    assert _tool_parser_auto_safe(_CfgStub("hermes")) is True
+    assert _tool_parser_auto_safe(_CfgStub("qwen")) is True
+    # Harmony opts out (shared <|channel|> trigger).
+    assert _tool_parser_auto_safe(_CfgStub("harmony")) is False
+    # Unknown / unset -> permissive default (not constrained anyway).
+    assert _tool_parser_auto_safe(_CfgStub("no_such_parser_xyz")) is True
+    assert _tool_parser_auto_safe(_CfgStub(None)) is True
+
+
+@pytest.mark.parametrize("choice", ["auto", None])
+def test_harmony_auto_path_inactive_free_form(choice):
+    # Harmony is grammar-capable, but on AUTO the constraint path is INACTIVE
+    # (declines the grammar) — so it composes like a free-form path: no grammar,
+    # and (below) no #561 400 on an oversized schema.
+    from vllm_mlx.routes.chat import _tool_grammar_constraint_active
+
+    cfg = _CfgStub("harmony")
+    ok = _FunctionTool(
+        "get_weather",
+        parameters={"type": "object", "properties": {"city": {"type": "string"}}},
+    )
+    assert _tool_grammar_constraint_active(cfg, _RequestStub([ok], choice)) is False
+
+
+def test_harmony_required_and_named_paths_active():
+    # required/named ARE constrained for harmony (a forced call is what the
+    # caller asked for).
+    from vllm_mlx.routes.chat import _tool_grammar_constraint_active
+
+    cfg = _CfgStub("harmony")
+    ok = _FunctionTool(
+        "get_weather",
+        parameters={"type": "object", "properties": {"city": {"type": "string"}}},
+    )
+    assert _tool_grammar_constraint_active(cfg, _RequestStub([ok], "required")) is True
+    named = {"type": "function", "function": {"name": "get_weather"}}
+    assert _tool_grammar_constraint_active(cfg, _RequestStub([ok], named)) is True
+
+
+@pytest.mark.parametrize("choice", ["auto", None])
+def test_harmony_auto_oversized_schema_no_400(monkeypatch, choice):
+    # AUTO non-regression: harmony gaining required/named grammar support must
+    # NOT start 400-ing oversized schemas on the auto path (it declines the auto
+    # grammar, so an oversized schema stays free-form — exactly as before).
+    from vllm_mlx.routes.chat import _enforce_tool_grammar_bounds_or_400
+
+    monkeypatch.setenv("RAPID_MLX_CONSTRAIN_TOOLS", "1")
+    cfg = _CfgStub("harmony")
+    req = _RequestStub(tools=[_oversized_tool()], tool_choice=choice)
+    assert _enforce_tool_grammar_bounds_or_400(cfg, req) is None
+
+
+def test_harmony_required_oversized_schema_400(monkeypatch):
+    # But required DOES keep the #561 hard 400 for harmony (it is constrained).
+    from fastapi import HTTPException
+
+    from vllm_mlx.routes.chat import _enforce_tool_grammar_bounds_or_400
+
+    monkeypatch.setenv("RAPID_MLX_CONSTRAIN_TOOLS", "1")
+    cfg = _CfgStub("harmony")
+    req = _RequestStub(tools=[_oversized_tool()], tool_choice="required")
+    with pytest.raises(HTTPException) as ei:
+        _enforce_tool_grammar_bounds_or_400(cfg, req)
+    assert ei.value.status_code == 400
+
+
 def test_supports_grammar_marker_declared_for_in_tree_parsers():
     # In-tree DISCOVERABILITY guard (#1149 codex): the explicit
     # ``SUPPORTS_GRAMMAR`` marker itself must match the ``structure_info``

--- a/tests/test_harmony_tool_grammar_558.py
+++ b/tests/test_harmony_tool_grammar_558.py
@@ -1,0 +1,400 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Offline tests for harmony (gpt-oss) grammar-constrained tool calling (#558).
+
+Extends the #558 constraint coverage from {qwen, hermes} to +gpt-oss. These
+validate ``HarmonyToolParser.structure_info()`` and its composition with the
+grammar builder WITHOUT a decode loop:
+
+  * the AUTO-path opt-out (``TOOL_GRAMMAR_AUTO_SAFE``): harmony's only single-
+    special-token trigger (``<|channel|>``) is SHARED with non-tool responses
+    (``final``/``analysis``), so the auto grammar would force a call — harmony
+    declines auto (free-form fallback) while constraining ``required``/named;
+  * the harmony wire triple's structural invariants (begin starts with the
+    ``<|channel|>`` trigger; the four control tokens are declared sentinels);
+  * grammar ENFORCEMENT via llguidance ``LLMatcher.consume_tokens`` on the REAL
+    gpt-oss tokenizer — a well-formed harmony tool call is accepted in full and
+    terminates, while an off-schema argument, a hallucinated tool name, a
+    bad enum value, and a header missing the mandatory space before
+    ``<|constrain|>`` are rejected mid-stream. This is the load-bearing #558
+    proof that the constraint is grammar-enforced, not merely post-parsed.
+
+The enforcement tests need the gpt-oss tokenizer (whose four harmony control
+tokens are single special tokens). They skip ONLY on genuine unavailability
+(the ``[guided]`` extra absent, or the pinned snapshot not in the local HF
+cache — preflighted with no network); any other failure (a resolver regression,
+a corrupt artifact) is surfaced. The pure-Python flag/opt-out tests never skip.
+"""
+
+import importlib.util
+
+import pytest
+
+_HAS_LLGUIDANCE = importlib.util.find_spec("llguidance") is not None
+_requires_llguidance = pytest.mark.skipif(
+    not _HAS_LLGUIDANCE, reason="llguidance ([guided] extra) not installed"
+)
+
+# The cached gpt-oss-20b MXFP4-Q8 tokenizer. Its <|channel|>/<|constrain|>/
+# <|message|>/<|call|> are single special tokens (ids 200005/200003/200008/
+# 200012). Pin the revision so the enforcement proof runs against an IMMUTABLE
+# artifact — a different upstream revision must not silently change what the
+# enforcement tests exercise.
+_TOKENIZER_MODEL = "mlx-community/gpt-oss-20b-MXFP4-Q8"
+_TOKENIZER_REVISION = "773a7da77e569019bb0fd17a554b263738d669a3"
+
+TOOLS = [
+    {
+        "name": "get_weather",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "city": {"type": "string"},
+                "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]},
+            },
+            "required": ["city"],
+            "additionalProperties": False,
+        },
+    },
+    {
+        "name": "get_time",
+        "parameters": {
+            "type": "object",
+            "properties": {"tz": {"type": "string"}},
+            "required": ["tz"],
+            "additionalProperties": False,
+        },
+    },
+]
+
+
+# --------------------------------------------------------------------------
+# Pure-Python flag / opt-out contract (always runs, no tokenizer needed).
+# --------------------------------------------------------------------------
+def test_abc_tool_grammar_auto_safe_defaults_true():
+    # Every single-special-token-trigger family (hermes/qwen) is auto-safe by
+    # default — the ABC flag must default True so this change is non-breaking.
+    from vllm_mlx.tool_parsers.abstract_tool_parser import ToolParser
+
+    assert ToolParser.TOOL_GRAMMAR_AUTO_SAFE is True
+
+
+def test_harmony_opts_out_of_auto_grammar():
+    # Harmony's <|channel|> trigger is shared with final/analysis blocks, so it
+    # declares itself NOT auto-safe: the auto grammar would force a call.
+    from vllm_mlx.tool_parsers.harmony_tool_parser import HarmonyToolParser
+
+    assert HarmonyToolParser.TOOL_GRAMMAR_AUTO_SAFE is False
+
+
+@_requires_llguidance
+def test_build_tool_grammar_auto_declines_for_harmony():
+    # AUTO zero-call parity: an auto-unsafe family must yield NO grammar on the
+    # auto path (free-form fallback — the model keeps its zero-call freedom),
+    # even though the same family DOES build a grammar for required/named. This
+    # is the guard against turning harmony ``auto`` into ``required``.
+    from vllm_mlx.api.tool_grammar import build_tool_grammar
+
+    class _AutoUnsafe:
+        TOOL_GRAMMAR_AUTO_SAFE = False
+
+        def structure_info(self):
+            from vllm_mlx.api.tool_grammar import StructureInfo
+
+            def _info(name: str):
+                return StructureInfo(
+                    begin=f"<|channel|>commentary to=functions.{name} "
+                    "<|constrain|>json<|message|>",
+                    end="<|call|>",
+                    trigger="<|channel|>",
+                    sentinels=(
+                        "<|channel|>",
+                        "<|constrain|>",
+                        "<|message|>",
+                        "<|call|>",
+                    ),
+                )
+
+            return _info
+
+    parser = _AutoUnsafe()
+    # auto -> None (declined); required -> a grammar (constrained).
+    assert build_tool_grammar(TOOLS, "auto", parser) is None
+    assert build_tool_grammar(TOOLS, "required", parser) is not None
+
+
+@_requires_llguidance
+def test_build_tool_grammar_auto_still_builds_for_auto_safe_family():
+    # The opt-out is per-family: a family WITHOUT the flag (defaults auto-safe,
+    # like hermes/qwen) still builds an auto grammar. Proves the gate keys on
+    # the flag, not on some harmony-only short-circuit.
+    from vllm_mlx.api.tool_grammar import StructureInfo, build_tool_grammar
+
+    class _AutoSafe:  # no TOOL_GRAMMAR_AUTO_SAFE -> defaults True via getattr
+        def structure_info(self):
+            def _info(name: str):
+                return StructureInfo(
+                    begin=f'<tool_call>\n{{"name": "{name}", "arguments": ',
+                    end="}\n</tool_call>",
+                    trigger="<tool_call>",
+                    sentinels=("<tool_call>", "</tool_call>"),
+                )
+
+            return _info
+
+    assert build_tool_grammar(TOOLS, "auto", _AutoSafe()) is not None
+
+
+# --------------------------------------------------------------------------
+# Enforcement against the REAL gpt-oss tokenizer.
+# --------------------------------------------------------------------------
+def _pinned_snapshot_cached() -> bool:
+    """True iff the pinned gpt-oss tokenizer snapshot is in the local HF cache.
+
+    Preflight the cache BEFORE loading (codex): with ``local_files_only=True`` an
+    uncached snapshot makes transformers raise a BARE ``OSError`` ("couldn't
+    connect … couldn't find in cached files"), NOT the specialized
+    ``LocalEntryNotFoundError`` — so an except-list keyed on the specialized
+    types either over-catches every ``OSError`` (masking a corrupt-file failure)
+    or misses this one (failing a normal uncached CI box). ``try_to_load_from_
+    cache`` sidesteps the whole error-taxonomy problem: it returns a ``str`` path
+    iff the file is cached, and a sentinel/``None`` otherwise, with NO network
+    round-trip. A load-time CORRUPTION error AFTER this preflight is a real
+    failure and is left to propagate (never caught).
+    """
+    from huggingface_hub import try_to_load_from_cache
+
+    for fname in ("tokenizer.json", "tokenizer_config.json"):
+        cached = try_to_load_from_cache(
+            _TOKENIZER_MODEL, fname, revision=_TOKENIZER_REVISION
+        )
+        if not isinstance(cached, str):
+            return False
+    return True
+
+
+@pytest.fixture(scope="module")
+def tok():
+    transformers = pytest.importorskip("transformers")
+    if not _pinned_snapshot_cached():  # pragma: no cover - uncached CI box
+        pytest.skip(
+            f"tokenizer {_TOKENIZER_MODEL}@{_TOKENIZER_REVISION[:8]} not in the "
+            "local HF cache — enforcement tests require it locally"
+        )
+    # Cached (preflight passed) -> load offline; a corruption error propagates.
+    return transformers.AutoTokenizer.from_pretrained(
+        _TOKENIZER_MODEL,
+        revision=_TOKENIZER_REVISION,
+        local_files_only=True,
+    )
+
+
+@pytest.fixture(scope="module")
+def lltok(tok):
+    """Build an llguidance LLTokenizer via the engine's own resolver.
+
+    ``build_lltokenizer`` has the transformers-5.x fallback (direct build from
+    ``backend_tokenizer.to_str()``) the raw ``llguidance.hf.from_tokenizer``
+    lacks — the same path the live server uses.
+
+    Once ``tok`` (the real cached gpt-oss tokenizer) is available, the resolver
+    MUST yield an ``LLTokenizer`` — a ``None`` here would mean the production
+    resolver regressed and harmony grammar constraint is SILENTLY disabled, so we
+    FAIL rather than skip (codex): skipping would let the enforcement suite go
+    green while the feature is broken.
+    """
+    from vllm_mlx.api.tool_grammar import build_lltokenizer
+
+    lltokenizer = build_lltokenizer(tok)
+    assert lltokenizer is not None, (
+        "build_lltokenizer returned None for the real gpt-oss tokenizer — the "
+        "LLTokenizer resolver regressed; harmony grammar constraint would be "
+        "silently disabled"
+    )
+    return lltokenizer
+
+
+@pytest.fixture(scope="module")
+def harmony_parser(tok):
+    from vllm_mlx.tool_parsers.harmony_tool_parser import HarmonyToolParser
+
+    return HarmonyToolParser(tokenizer=tok)
+
+
+def _consume(grammar, lltok, tok, text):
+    """Offline enforcement probe. Returns ``(accepted, total, is_accepting)``.
+
+    Advances real grammar state one token at a time via ``consume_tokens``,
+    counting how many tokens the grammar accepts before rejecting one. A
+    "fully accepted" positive test whose final ``is_accepting()`` is True proves
+    the string is a COMPLETE valid derivation, not merely an accepted prefix.
+    """
+    from llguidance.mlx import LLMatcher
+
+    ids = tok.encode(text, add_special_tokens=False)
+    matcher = LLMatcher(lltok, grammar)
+    assert not matcher.get_error(), matcher.get_error()
+    accepted = 0
+    for tid in ids:
+        if not matcher.consume_tokens([tid]):
+            break
+        accepted += 1
+    return accepted, len(ids), matcher.is_accepting()
+
+
+@_requires_llguidance
+def test_structure_info_available_and_wire_invariants(harmony_parser):
+    # The parser opts IN on a tokenizer whose four control tokens are single
+    # special tokens, and the wire triple satisfies the builder invariants.
+    get_info = harmony_parser.structure_info()
+    assert get_info is not None
+    si = get_info("get_weather")
+    # StructTag invariants enforced by build_tool_lark:
+    assert si.begin.startswith(si.trigger)
+    assert si.trigger == "<|channel|>"
+    assert si.trigger in si.sentinels
+    assert si.end == "<|call|>"
+    # All four harmony control tokens are declared sentinels (special-token refs).
+    for s in ("<|channel|>", "<|constrain|>", "<|message|>", "<|call|>"):
+        assert s in si.sentinels
+    # Exact header bytes, including the MANDATORY space before <|constrain|>
+    # (openai-harmony rejects the header without it).
+    assert si.begin == (
+        "<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>"
+    )
+
+
+@_requires_llguidance
+def test_valid_harmony_call_is_accepted_and_terminates(harmony_parser, tok, lltok):
+    from vllm_mlx.api.tool_grammar import build_tool_grammar
+
+    grammar = build_tool_grammar(TOOLS, "required", harmony_parser)
+    assert grammar is not None
+    accepted, total, accepting = _consume(
+        grammar,
+        lltok,
+        tok,
+        "<|channel|>commentary to=functions.get_weather "
+        '<|constrain|>json<|message|>{"city": "Paris"}<|call|>',
+    )
+    assert accepted == total, f"valid harmony call rejected ({accepted}/{total})"
+    assert accepting, "valid complete harmony call is not an accepting state"
+
+
+@_requires_llguidance
+def test_valid_enum_value_is_accepted(harmony_parser, tok, lltok):
+    from vllm_mlx.api.tool_grammar import build_tool_grammar
+
+    grammar = build_tool_grammar(TOOLS, "required", harmony_parser)
+    accepted, total, accepting = _consume(
+        grammar,
+        lltok,
+        tok,
+        "<|channel|>commentary to=functions.get_weather "
+        '<|constrain|>json<|message|>{"city": "P", "unit": "celsius"}<|call|>',
+    )
+    assert accepted == total, f"valid enum value rejected ({accepted}/{total})"
+    assert accepting, "valid enum call is not an accepting state"
+
+
+@_requires_llguidance
+def test_off_schema_argument_is_rejected(harmony_parser, tok, lltok):
+    from vllm_mlx.api.tool_grammar import build_tool_grammar
+
+    grammar = build_tool_grammar(TOOLS, "required", harmony_parser)
+    # `city` must be a string; an integer must be forbidden.
+    accepted, total, _ = _consume(
+        grammar,
+        lltok,
+        tok,
+        "<|channel|>commentary to=functions.get_weather "
+        '<|constrain|>json<|message|>{"city": 4',
+    )
+    assert accepted < total, "off-schema integer argument was NOT rejected"
+
+
+@_requires_llguidance
+def test_bad_enum_value_is_rejected(harmony_parser, tok, lltok):
+    from vllm_mlx.api.tool_grammar import build_tool_grammar
+
+    grammar = build_tool_grammar(TOOLS, "required", harmony_parser)
+    # `unit` enum is {celsius, fahrenheit}; "kelvin" must be forbidden — this is
+    # the adversarial-enum proof (the live pilot's user demanded kelvin and the
+    # grammar held it in-enum).
+    accepted, total, _ = _consume(
+        grammar,
+        lltok,
+        tok,
+        "<|channel|>commentary to=functions.get_weather "
+        '<|constrain|>json<|message|>{"city": "P", "unit": "kelvin',
+    )
+    assert accepted < total, "invalid enum value was NOT rejected by the grammar"
+
+
+@_requires_llguidance
+def test_hallucinated_tool_name_is_rejected(harmony_parser, tok, lltok):
+    from vllm_mlx.api.tool_grammar import build_tool_grammar
+
+    grammar = build_tool_grammar(TOOLS, "required", harmony_parser)
+    accepted, total, _ = _consume(
+        grammar,
+        lltok,
+        tok,
+        "<|channel|>commentary to=functions.get_stock",
+    )
+    assert accepted < total, "hallucinated tool name was NOT rejected"
+
+
+@_requires_llguidance
+def test_missing_constrain_space_is_rejected(harmony_parser, tok, lltok):
+    from vllm_mlx.api.tool_grammar import build_tool_grammar
+
+    grammar = build_tool_grammar(TOOLS, "required", harmony_parser)
+    # The space before <|constrain|> is mandatory in the harmony header
+    # (openai-harmony's own parser rejects the no-space form). The grammar must
+    # too — dropping straight from the name into <|constrain|> is rejected.
+    accepted, total, _ = _consume(
+        grammar,
+        lltok,
+        tok,
+        "<|channel|>commentary to=functions.get_weather<|constrain|>",
+    )
+    assert accepted < total, "header missing the mandatory space was NOT rejected"
+
+
+@_requires_llguidance
+def test_named_choice_narrows_to_requested_tool(harmony_parser, tok, lltok):
+    from vllm_mlx.api.tool_grammar import build_tool_grammar
+
+    grammar = build_tool_grammar(TOOLS, "get_time", harmony_parser)
+    assert grammar is not None
+    assert "get_time" in grammar
+    assert "get_weather" not in grammar
+    # A call to get_time is accepted...
+    accepted, total, accepting = _consume(
+        grammar,
+        lltok,
+        tok,
+        "<|channel|>commentary to=functions.get_time "
+        '<|constrain|>json<|message|>{"tz": "UTC"}<|call|>',
+    )
+    assert accepted == total and accepting, "named get_time call rejected"
+    # ...but a call to the OTHER tool (get_weather) is rejected under the named
+    # get_time choice.
+    accepted, total, _ = _consume(
+        grammar,
+        lltok,
+        tok,
+        "<|channel|>commentary to=functions.get_weather",
+    )
+    assert accepted < total, "named get_time choice wrongly allowed get_weather"
+
+
+@_requires_llguidance
+def test_auto_opts_out_but_required_builds_on_real_parser(harmony_parser):
+    # End-to-end opt-out parity on the REAL parser: auto declines (free-form),
+    # required/named build. Mirrors the routing's builder_choice mapping.
+    from vllm_mlx.api.tool_grammar import build_tool_grammar
+
+    assert build_tool_grammar(TOOLS, "auto", harmony_parser) is None
+    assert build_tool_grammar(TOOLS, "required", harmony_parser) is not None
+    assert build_tool_grammar([TOOLS[0]], "get_weather", harmony_parser) is not None

--- a/vllm_mlx/api/tool_grammar.py
+++ b/vllm_mlx/api/tool_grammar.py
@@ -692,6 +692,21 @@ def build_tool_grammar(
     if tool_choice == "none":
         # ``none`` means the model sees no tools -> no grammar (design §4).
         return None
+    # AUTO-path soundness gate (#558). The builder's "free byte prefix + single-
+    # special-token TRIGGER" model expresses auto's zero-call invariant ONLY when
+    # the trigger token appears EXCLUSIVELY at a tool-call boundary. A family
+    # whose only single-special-token trigger is SHARED with non-tool responses
+    # (harmony: ``<|channel|>`` precedes commentary/final/analysis alike) cannot
+    # — committing to the tool tag on that shared trigger FORCES a call, turning
+    # ``auto`` into ``required`` (the #1 regression #558 guards against; verified
+    # offline: a ``<|channel|>final...`` reply is rejected at the first token).
+    # Such a family declares ``TOOL_GRAMMAR_AUTO_SAFE = False`` and stays
+    # free-form on auto (non-regressive), while ``required``/named still build a
+    # grammar below (a forced tool-call structure is exactly what those modes
+    # ask for). Every single-special-token-trigger family (hermes/qwen) defaults
+    # ``True`` and is unaffected.
+    if tool_choice == "auto" and not getattr(parser, "TOOL_GRAMMAR_AUTO_SAFE", True):
+        return None
     info_fn = getattr(parser, "structure_info", None)
     if info_fn is None:
         return None

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -638,6 +638,35 @@ def _tool_parser_supports_grammar(cfg) -> bool:
     return bool(parser_cls.supports_grammar())
 
 
+def _tool_parser_auto_safe(cfg) -> bool:
+    """Cheap capability probe: is the configured tool parser AUTO-safe (#558)?
+
+    A grammar-capable parser is AUTO-safe when its ``structure_info`` wire can
+    express auto's zero-call invariant — true for every single-special-token-
+    trigger family (hermes/qwen ``<tool_call>``). Harmony is NOT: its only
+    single-special-token trigger (``<|channel|>``) is shared with non-tool
+    responses, so ``build_tool_grammar`` DECLINES the auto grammar for it
+    (``ToolParser.TOOL_GRAMMAR_AUTO_SAFE = False``). The auto path is therefore
+    NOT a constrained path for such a family, so ``_tool_grammar_constraint_
+    active`` treats an auto request as inactive (free-form): an oversized schema
+    stays free-form instead of a spurious #561 HTTP 400, and the route skips the
+    wasted grammar-build offload that would only decline. Mirrors
+    ``_tool_parser_supports_grammar`` (class-level, no instantiation). Defaults
+    ``True`` (auto-safe) for an unset/unknown parser, matching the ABC default —
+    only a family that explicitly opts out changes behavior.
+    """
+    name = getattr(cfg, "tool_call_parser", None)
+    if not name:
+        return True
+    from ..tool_parsers import ToolParserManager
+
+    try:
+        parser_cls = ToolParserManager.get_tool_parser(name)
+    except KeyError:
+        return True  # unknown parser -> not constrained anyway; stay permissive.
+    return bool(getattr(parser_cls, "TOOL_GRAMMAR_AUTO_SAFE", True))
+
+
 def _tool_grammar_constraint_active(cfg, request) -> bool:
     """True iff the constrained-tool-calling path is ACTIVE for this request.
 
@@ -663,10 +692,19 @@ def _tool_grammar_constraint_active(cfg, request) -> bool:
     # 400 for it — only grammar-capable parsers (hermes/qwen) keep the #561 400.
     if not _tool_parser_supports_grammar(cfg):
         return False
-    return (
-        _normalize_tool_choice_for_grammar(getattr(request, "tool_choice", None))
-        is not None
-    )
+    choice = _normalize_tool_choice_for_grammar(getattr(request, "tool_choice", None))
+    if choice is None:
+        return False
+    # AUTO-soundness (#558): a grammar-capable parser that is NOT auto-safe
+    # (harmony — its ``<|channel|>`` trigger is shared with non-tool responses)
+    # DECLINES the auto grammar in ``build_tool_grammar``, so the auto path is not
+    # a constrained path for it. Treat it as inactive so an oversized schema stays
+    # free-form (no #561 400) and the route skips the wasted build offload —
+    # keeping auto fully non-regressive for such a family while ``required``/named
+    # stay constrained. Every auto-safe family (hermes/qwen) is unaffected.
+    if choice["mode"] == "auto" and not _tool_parser_auto_safe(cfg):
+        return False
+    return True
 
 
 def _tool_grammar_eligible(cfg, request) -> bool:

--- a/vllm_mlx/tool_parsers/abstract_tool_parser.py
+++ b/vllm_mlx/tool_parsers/abstract_tool_parser.py
@@ -198,6 +198,25 @@ class ToolParser(ABC):
         # from the ABC default (which returns ``None`` — free-form).
         return cls.structure_info is not ToolParser.structure_info
 
+    # Whether this family's grammar-constrained wire (``structure_info``) is
+    # SOUND on the AUTO tool_choice path (#558). The #558 builder is a "free
+    # byte prefix + single-special-token TRIGGER" model: on ``auto`` the model
+    # may emit zero calls by staying in the free prefix, and the trigger is what
+    # commits it into a constrained tool call. That is sound ONLY when the
+    # trigger token appears EXCLUSIVELY at the start of a tool call (e.g. hermes/
+    # qwen ``<tool_call>``) — then plain text never contains it and auto's
+    # zero-call invariant holds. A family whose only single-special-token
+    # trigger is ALSO emitted by non-tool responses (harmony's ``<|channel|>``
+    # precedes ``commentary``/``final``/``analysis`` alike) CANNOT express auto
+    # zero-call: committing to the tool tag on that shared trigger would FORCE a
+    # call, turning ``auto`` into ``required`` — the #1 regression #558 guards
+    # against. Such a family sets this ``False`` so ``build_tool_grammar``
+    # declines the auto path (free-form fallback, non-regressive) while still
+    # constraining the explicit ``required``/named modes where a forced tool-call
+    # structure is exactly what the caller asked for. Defaults ``True`` — every
+    # existing single-special-token-trigger family (hermes/qwen) is unaffected.
+    TOOL_GRAMMAR_AUTO_SAFE: bool = True
+
     @classmethod
     def supports_native_format(cls) -> bool:
         """

--- a/vllm_mlx/tool_parsers/harmony_tool_parser.py
+++ b/vllm_mlx/tool_parsers/harmony_tool_parser.py
@@ -87,6 +87,102 @@ class HarmonyToolParser(ToolParser):
 
     EXPECTED_WIRE_FORMATS = ("harmony_commentary",)
 
+    # Grammar-capable (#558/#1144): harmony overrides ``structure_info`` to emit a
+    # wire triple, so it declares the discoverability marker like hermes/qwen. The
+    # #1149 in-tree guard asserts this matches the override. Capability here means
+    # the REQUIRED/named modes are decoder-constrained (see ``TOOL_GRAMMAR_AUTO_
+    # SAFE`` below for why AUTO is declined).
+    SUPPORTS_GRAMMAR = True
+
+    # Grammar-constrained tool calling (#558) is SOUND for harmony only on the
+    # forced (``required``/named) modes, NOT on ``auto``. See
+    # ``ToolParser.TOOL_GRAMMAR_AUTO_SAFE``: harmony's only single-special-token
+    # trigger is ``<|channel|>``, which precedes commentary (tool call), final,
+    # AND analysis blocks alike — so committing to the tool tag on ``<|channel|>``
+    # would force a call and break auto's zero-call invariant (a plain
+    # ``<|channel|>final...`` reply gets rejected at the first token). Harmony's
+    # true tool-call trigger is a TEXT pattern (``to=functions.`` after
+    # ``<|channel|>commentary``), which the #558 builder's single-special-token
+    # trigger model cannot express (text-trigger support is design §7 open-Q1,
+    # deferred). So harmony opts OUT of the auto grammar (free-form fallback,
+    # non-regressive) and constrains only the explicit forced modes.
+    TOOL_GRAMMAR_AUTO_SAFE = False
+
+    # Harmony tool-call header control tokens, in wire order. Each is a SINGLE
+    # special token on the gpt-oss tokenizer (verified 2026-07 on
+    # ``mlx-community/gpt-oss-20b-MXFP4-Q8``: ids 200005 / 200003 / 200008 /
+    # 200012), so ``structure_info`` declares them as ``sentinels`` and the
+    # grammar builder renders them as Lark special-token refs. The literal header
+    # text BETWEEN them (``commentary to=functions.NAME `` and ``json``) is
+    # emitted as byte literals.
+    _GRAMMAR_SENTINELS = ("<|channel|>", "<|constrain|>", "<|message|>", "<|call|>")
+
+    def structure_info(self):
+        """Grammar-constraint wire triple for the harmony tool-call header (#558).
+
+        Extends the #558 constraint coverage from {qwen, hermes} to +gpt-oss.
+        The harmony tool-call wire the model emits (OpenAI harmony spec; verified
+        byte-for-byte against ``openai-harmony``'s own renderer/parser and the
+        real gpt-oss tokenizer)::
+
+            <|channel|>commentary to=functions.NAME <|constrain|>json<|message|>{args}<|call|>
+
+        The tool NAME lives in the HEADER (``to=functions.NAME``), not the body;
+        the body is a pure JSON object constrained by the tool's JSON Schema via
+        ``%json`` (injected by ``build_tool_lark``). The SPACE before
+        ``<|constrain|>`` is mandatory — ``openai-harmony``'s parser rejects the
+        header without it. ``<|channel|>``/``<|constrain|>``/``<|message|>``/
+        ``<|call|>`` are single special tokens on the gpt-oss tokenizer, so they
+        are declared as ``sentinels`` (rendered as Lark special-token refs); the
+        literal header text between them is emitted as byte literals.
+
+        ``trigger = "<|channel|>"`` satisfies the builder invariants
+        (``begin.startswith(trigger)`` and ``trigger in sentinels``). Note that
+        ``<|channel|>`` is a COARSE trigger — it also precedes ``final`` /
+        ``analysis`` blocks — which is why harmony sets
+        ``TOOL_GRAMMAR_AUTO_SAFE = False`` and this wire is only used for the
+        forced ``required``/named modes (``build_tool_grammar`` declines the auto
+        path for harmony). In a forced mode, driving the model straight into a
+        schema-valid harmony tool call from the first ``<|channel|>`` is exactly
+        the requested behavior.
+
+        As on hermes/qwen, OPT OUT (return ``None`` -> free-form-then-parse
+        fallback) unless the tokenizer proves every sentinel is a single special
+        token — a special-token sentinel on a tokenizer that encodes these as
+        multi-token text would build an unenforceable grammar. Grammar constraint
+        is a best-effort opt-in, never a hard requirement.
+        """
+        from vllm_mlx.api.tool_grammar import (
+            StructureInfo,
+            are_single_special_tokens,
+        )
+
+        if not are_single_special_tokens(self.model_tokenizer, self._GRAMMAR_SENTINELS):
+            return None
+
+        def _info(name: str):
+            # The tool name is a bare identifier inside the header literal
+            # (``to=functions.NAME``), NOT a JSON string — harmony does not quote
+            # it. The grammar emits it as a byte literal via
+            # ``_emit_literal_with_sentinels``; a name with characters that would
+            # break the header (quotes, spaces) is not representable, but tool
+            # names are OpenAI-spec identifiers (``[\w-]+``), so the raw name is
+            # safe here. ``begin`` starts with the ``<|channel|>`` trigger
+            # (builder invariant).
+            begin = (
+                f"<|channel|>commentary to=functions.{name} "
+                f"<|constrain|>json<|message|>"
+            )
+            end = "<|call|>"
+            return StructureInfo(
+                begin=begin,
+                end=end,
+                trigger="<|channel|>",
+                sentinels=self._GRAMMAR_SENTINELS,
+            )
+
+        return _info
+
     def extract_tool_calls(
         self, model_output: str, request: dict[str, Any] | None = None
     ) -> ExtractedToolCallInformation:


### PR DESCRIPTION
## What & why

Extends #558 grammar-constrained tool-calling from **{qwen, hermes}** to **+gpt-oss (harmony)**. Today `HarmonyToolParser.structure_info()` inherits the ABC default (`None`), so gpt-oss tool calls fall back to free-form-then-parse — no structural guarantee that the emitted `arguments` satisfy the tool's JSON Schema. This PR gives gpt-oss the **same genuine llguidance decoder-level constraint** qwen/hermes already get, for the modes where it is sound.

## The harmony wire (verified, not assumed)

The model emits (OpenAI harmony spec):

```
<|channel|>commentary to=functions.NAME <|constrain|>json<|message|>{args}<|call|>
```

The tool NAME lives in the **header** (`to=functions.NAME`), not the body; the body is a pure JSON object constrained by `%json <schema>`. I pinned every byte against the **real gpt-oss tokenizer** (`mlx-community/gpt-oss-20b-MXFP4-Q8`, cached) and the **openai-harmony** library's own renderer/parser:

- `are_single_special_tokens()` → **True** for all four control tokens: `<|channel|>` (200005), `<|constrain|>` (200003), `<|message|>` (200008), `<|call|>` (200012). So they are declared `sentinels` (Lark special-token refs); the header text between them (`commentary to=functions.NAME `, `json`) is byte-literal.
- The header **round-trips byte-exact** on the real tokenizer.
- The **space before `<|constrain|>` is mandatory** — openai-harmony's own parser rejects the no-space header (`unexpected tokens remaining in message header`). The grammar preserves it, and a no-space header is rejected (test).

**Port source:** openai-harmony canonical rendering + the XGrammar-2 GPT-OSS structural tag. Explicitly **NOT** SGLang's `gpt_oss_detector` (it `raise NotImplementedError` for `structure_info`).

## Honest scope: required/named constrained, auto stays free-form

Harmony's only single-special-token trigger is `<|channel|>` — but that token **also** prefixes `final` and `analysis` (non-tool) responses. The #558 builder is a *"free byte prefix + single-special-token trigger"* model: the free prefix is a **byte** regex that cannot contain a special token, so once the model emits `<|channel|>` it is committed to the tool tag. On `auto` that **forces a tool call** — turning `auto` into `required`, the #1 regression #558 guards against.

Verified offline: under an `auto` harmony grammar a plain `<|channel|>final<|message|>...` reply is **rejected at the first token**. Harmony's real tool-call trigger is a **text** pattern (`to=functions.`), which the builder can't express yet (text-trigger support is design §7 open-Q1, deferred). The reasoning-tolerant prefix (PR-4) doesn't help either — `resolve_reasoning_sentinels("harmony")` is `()` (harmony reasoning is channel-based, not `<think>`).

**Resolution:** a new `ToolParser.TOOL_GRAMMAR_AUTO_SAFE` flag (defaults `True`). Harmony sets it `False`; `build_tool_grammar` then declines the **auto** path (free-form fallback — fully non-regressive vs today) while still building the grammar for **required** and **named**, where driving the model straight into a schema-valid tool call is exactly what the caller asked for. hermes/qwen (`<tool_call>` is an unambiguous single-token trigger) keep `True` and are untouched.

A fully-sound harmony **auto** grammar needs a harmony-specific multi-channel grammar (model every channel explicitly) — a distinct design effort, not this "port structure_info" PR. Flagged as follow-up rather than invented here (charter: never invent a tool-call grammar).

## Composes with #1149 (parser-capability-gated oversized-schema 400)

Rebased on top of #1149. Because harmony now overrides `structure_info`, it declares `SUPPORTS_GRAMMAR = True` (the #1149 in-tree discoverability guard asserts the marker matches the override). But that would make `_tool_grammar_constraint_active` True for harmony on **every** mode — so a harmony **auto** request with an oversized schema would newly 400 (was free-form), and the route would pay a grammar-build offload that only declines. Fix: a new `_tool_parser_auto_safe` route probe makes `_tool_grammar_constraint_active` report **harmony + auto as inactive** — oversized schema stays free-form (no spurious #561 400), offload skipped. `required`/named keep the #561 400. Every auto-safe family (hermes/qwen) is unchanged. Covered by new routing tests.

## Proof on real hardware (gpt-oss-20b-MXFP4-Q8, non-operator port 8133)

**Offline matcher enforcement** (`LLMatcher.consume_tokens`, real tokenizer):

| input | result |
|---|---|
| valid call `{"city":"Paris"}` | accepted, terminal ✅ |
| valid enum `{"city":"P","unit":"celsius"}` | accepted, terminal ✅ |
| off-schema `{"city": 4` | rejected mid-stream ✅ |
| bad enum `"unit":"kelvin` | rejected mid-stream ✅ |
| hallucinated `to=functions.get_stock` | rejected ✅ |
| missing space before `<|constrain|>` | rejected ✅ |

`GrammarLogitsProcessor.is_broken()` → **False** for required + named (grammar compiles clean). `build_tool_grammar(auto)` → **None** (declined).

**Live end-to-end** (`/v1/models` shows `tool_call_parser: harmony`, no "Guided generation disabled"):

- `tool_choice=required` → `get_weather({"city":"Paris","unit":"fahrenheit"})` — schema-valid.
- **Adversarial enum**: schema `unit ∈ {celsius, fahrenheit}`, user demanded *"unit must be kelvin"* → emitted `unit="celsius"` — **stayed in-enum** (grammar actively constraining, mirrors the 0.10.15 dogfood).
- `tool_choice=auto` + "write a poem" → **zero tool calls**, wrote a poem (zero-call invariant holds).
- `tool_choice=auto` + weather ask → free-form call still works (auto not blocked).

## Changes

- `vllm_mlx/tool_parsers/harmony_tool_parser.py` — `structure_info()` + `SUPPORTS_GRAMMAR = True` + `TOOL_GRAMMAR_AUTO_SAFE = False` + `_GRAMMAR_SENTINELS`.
- `vllm_mlx/tool_parsers/abstract_tool_parser.py` — `TOOL_GRAMMAR_AUTO_SAFE: bool = True` (ABC default; non-breaking).
- `vllm_mlx/api/tool_grammar.py` — `build_tool_grammar` auto-soundness gate keyed on the flag.
- `vllm_mlx/routes/chat.py` — `_tool_parser_auto_safe` probe + `_tool_grammar_constraint_active` composes it so harmony+auto is inactive (free-form), keeping the #1149 oversized-schema 400 to required/named.
- `tests/test_harmony_tool_grammar_558.py` — 13 offline tests (mirrors `test_tool_grammar_558.py`).
- `tests/test_grammar_processor_558.py` — 5 harmony-auto routing tests.

Does not touch `spec_decode/**` or `speculative/**`.

## Test plan

- [x] All four harmony control tokens confirmed single special tokens on the real gpt-oss tokenizer.
- [x] Header byte-alignment verified against openai-harmony renderer/parser (incl. mandatory pre-`<|constrain|>` space).
- [x] Offline matcher: valid call + valid enum accepted & terminal; off-schema / bad-enum / hallucinated-name / missing-space rejected mid-stream.
- [x] `GrammarLogitsProcessor.is_broken()` == False for required + named; `build_tool_grammar(auto)` == None (harmony opts out).
- [x] Named `tool_choice` narrows to the single tool (other tool rejected).
- [x] #1149 composition: harmony declares `SUPPORTS_GRAMMAR = True` (in-tree marker guard passes); `_tool_grammar_constraint_active(harmony, auto)` == False and `(harmony, required/named)` == True; oversized harmony+auto → no 400, oversized harmony+required → 400.
- [x] Live pilot on gpt-oss-20b: required valid call; adversarial enum stays in-enum; auto poem = zero calls; auto weather = free-form call works.
- [x] New suite `tests/test_harmony_tool_grammar_558.py` green (13 passed).
- [x] Regression: `test_tool_grammar_558.py` + `test_harmony_parsers.py` + `test_harmony_stop_final_channel_only.py` + `test_tool_parser_wire_formats.py` pass offline (only the pre-existing network-gated `test_deepseek_r1_prefilled_think_template_is_tolerated` fails — identical on origin/main, needs an uncached 32B model).
- [x] `ruff check` clean on all changed files.
- [x] `TOOL_GRAMMAR_AUTO_SAFE` defaults True → hermes/qwen auto path unchanged (verified: an auto-safe stub still builds an auto grammar).

## codex review disposition (round 1)

- **[FIXED] lltok fixture skip → assert** — once the real cached tokenizer loads, a `None` from `build_lltokenizer` is a resolver regression, not a skip; the fixture now asserts non-`None` so the enforcement suite can't go green while harmony constraint is silently disabled.
- **[FIXED] tok fixture OSError over/under-catch** — `local_files_only=True` on an uncached box raises a bare `OSError`, not `LocalEntryNotFoundError`. Replaced the except-list with a `try_to_load_from_cache` preflight (no network); load-time corruption errors now propagate.
- **[OVERRIDE] chat.py:693 "required/named oversized→400 when structure_info() could be None"** — this is the **deliberate #1144/#1149 design**: `supports_grammar()` is class-level *by mandate* ("DO NOT invent a heavy probe"), and a grammar-capable family whose `structure_info()` is tokenizer-gated to `None` keeping the #561 400 is exactly what the #1149 docstring documents (identical to hermes-on-a-non-Qwen-tokenizer; remedy `RAPID_MLX_CONSTRAIN_TOOLS=0`). In practice harmony only runs on gpt-oss tokenizers where the four control tokens *are* single special tokens, so `structure_info()` never returns `None`. The genuinely-new case (auto) IS handled — `_tool_parser_auto_safe` makes harmony+auto inactive. Adopting codex's "runtime per-request availability" fix would require the exact heavy per-request tokenizer probe #1144 forbids.

## codex review disposition (round 2)

codex re-ran after the round-1 fixes and returned **1 blocking + 1 nit** (down from 3 blocking):

- **[OVERRIDE — re-raise of round 1] chat.py:693 / harmony_tool_parser.py:160 "required/named classified constrained from the parser class → oversized schema 400 even when structure_info() returns None"** — same finding as round-1 #3, re-surfaced verbatim (codex oscillation on a refuted point). Disposition unchanged and now hardened: class-level capability is the mandated #1144/#1149 contract; the proposed remedy ("base bounds enforcement on cached runtime grammar availability, or reject incompatible configs before serving") is precisely the per-request heavy probe #1144 forbids. On the only tokenizers harmony ever loads (gpt-oss), all four control tokens are single special tokens, so `structure_info()` never returns `None` in practice; the sole genuinely-new mode (auto) is already routed inactive via `_tool_parser_auto_safe`.
- **[DEFER — nit] test_harmony_tool_grammar_558.py:179 "real-tokenizer tests skip when the pinned tokenizer is absent; add a small checked-in tokenizer fixture for always-on CI coverage"** — convention-consistent with the entire repo's #558 enforcement suite (`test_tool_grammar_558.py` gates the same way on the real Qwen tokenizer). A synthetic small tokenizer can't reproduce the load-bearing property under test (the four gpt-oss control tokens being *single special tokens* with byte-exact header round-trip), so it would assert against a fiction. The offline pure-Python routing/flag tests (`TOOL_GRAMMAR_AUTO_SAFE` gating, build_tool_grammar decline) DO run unconditionally in CI; only the real-grammar enforcement layer is cache-gated, matching precedent. Left as a follow-up if the repo later adopts a shared checked-in tokenizer fixture convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

