### PR TITLE
docs: add a Contributors section to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,14 @@ Top three things that go wrong:
 
 Rapid-MLX ships **opt-in anonymous telemetry** (off by default; explicit `rapid-mlx telemetry enable` required). No prompts, completions, paths, IPs, or API keys are ever collected. → [What we do and don't collect](https://rapidmlx.com/docs/telemetry.html)
 
+### 🚀 Contributors
+
+Every avatar here shipped something in rapid-mlx — model support, tool-call parsers, fixes, docs, and benchmark submissions. Thank you.
+
+<a href="https://github.com/raullenchai/Rapid-MLX/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=raullenchai/Rapid-MLX" alt="rapid-mlx contributors" />
+</a>
+
 ### Star History
 
 <a href="https://star-history.com/#raullenchai/Rapid-MLX&Date">


### PR DESCRIPTION
## Why
The README credits Issues / Discussions / CONTRIBUTING but never actually shows the people who've contributed. A contributor wall is a small but real recognition + social-proof win.

## What
Adds a **🚀 Contributors** subsection under *Community & Contributing* (right above Star History):

```md
<a href="https://github.com/raullenchai/Rapid-MLX/graphs/contributors">
  <img src="https://contrib.rocks/image?repo=raullenchai/Rapid-MLX" alt="rapid-mlx contributors" />
</a>
```

- Uses [contrib.rocks](https://contrib.rocks) — the avatar grid **auto-updates** from the contributors graph, so there's nothing to maintain (no all-contributors bot, no manual list).
- Linked to the full contributors page.

Renders as the usual circular-avatar wall on the repo homepage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)