### PR TITLE
perf(tools): cache compiled tool grammars + startup warmup to remove per-schema cold-compile

### DIFF
--- a/tests/test_grammar_processor_558.py
+++ b/tests/test_grammar_processor_558.py
@@ -2206,6 +2206,12 @@ def test_rejected_committed_token_drops_constraint_and_stops_masking():
         def get_error(self):
             return None  # compiled fine
 
+        def deep_copy(self):
+            # get_request_matcher caches a never-consumed template and hands each
+            # request a deep_copy of it; a fresh instance (n_consumed=0) is the
+            # faithful clone of the initial-state template.
+            return _RejectingMatcher()
+
         def consume_token(self, tok_id):
             self.n_consumed += 1
             # Accept the first generated token, reject the second (simulating a

--- a/tests/test_tool_grammar_matcher_cache_558.py
+++ b/tests/test_tool_grammar_matcher_cache_558.py
@@ -33,6 +33,9 @@ class _FakeMatcher:
         self.lltok = lltok
         self.grammar = grammar
         self.is_copy = False
+        # A mutable parse cursor, so a test can prove that consuming on one
+        # per-request copy does NOT advance any other copy or the cached template.
+        self.consumed = 0
         # A grammar carrying the BROKEN marker reports a compile error, mirroring
         # llguidance's never-raise "error is stored on the matcher" contract.
         self._error = "boom" if "BROKEN" in grammar else ""
@@ -40,11 +43,16 @@ class _FakeMatcher:
     def get_error(self):
         return self._error
 
+    def consume_token(self, tok_id):
+        self.consumed += 1
+        return True
+
     def deep_copy(self):
         c = _FakeMatcher.__new__(_FakeMatcher)
         c.lltok = self.lltok
         c.grammar = self.grammar
         c._error = self._error
+        c.consumed = self.consumed  # clone COPIES the cursor at copy time
         c.is_copy = True
         return c
 
@@ -73,6 +81,18 @@ def test_same_key_builds_template_once_and_returns_distinct_copies():
     assert _FakeMatcher.builds == 1
     assert m1.is_copy and m2.is_copy
     assert m1 is not m2  # per-request isolation — no shared parse cursor
+
+    # Prove STATE isolation, not just object identity: consuming on m1 must not
+    # advance m2's cursor NOR the cached template's (the template must stay at
+    # its initial, never-consumed state so future clones start fresh).
+    m1.consume_token(7)
+    m1.consume_token(7)
+    assert m1.consumed == 2
+    assert m2.consumed == 0, "consuming on one copy must not advance another"
+    cached_template = tg._compiled_matcher_cache[(id(lltok), g)][1]
+    assert cached_template.consumed == 0, "the cached template must never be mutated"
+    m3 = tg.get_request_matcher(lltok, g)
+    assert m3.consumed == 0, "a later clone must start from the initial state"
 
 
 def test_concurrent_cold_burst_builds_template_exactly_once():

--- a/tests/test_tool_grammar_matcher_cache_558.py
+++ b/tests/test_tool_grammar_matcher_cache_558.py
@@ -195,6 +195,22 @@ def test_oversized_grammar_is_not_cached(monkeypatch):
     assert _FakeMatcher.builds == 2  # rebuilt each time (uncached)
 
 
+def test_byte_budget_counts_utf8_bytes_not_code_points(monkeypatch):
+    # A non-ASCII grammar's UTF-8 size exceeds its code-point count, so budgeting
+    # must use encoded bytes: a grammar of few code points but many UTF-8 bytes
+    # can exceed the budget and be refused caching (codex #1155).
+    monkeypatch.setattr(tg, "_COMPILED_MATCHER_CACHE_MAX_BYTES", 40)
+    lltok = object()
+    # 20 code points, each a 3-byte CJK char = 60 UTF-8 bytes > 40 budget.
+    g = "描" * 20
+    assert len(g) == 20 and len(g.encode("utf-8")) == 60
+    m = tg.get_request_matcher(lltok, g)
+    assert m.is_copy  # usable matcher returned
+    # Refused caching because its UTF-8 byte size (60) exceeds the 40 budget —
+    # would be wrongly cached if the code-point count (20) were used.
+    assert (id(lltok), g) not in tg._compiled_matcher_cache
+
+
 def test_byte_budget_evicts_before_count_cap(monkeypatch):
     # With a generous count cap but a tight byte budget, entries evict on BYTES.
     monkeypatch.setattr(tg, "_COMPILED_MATCHER_CACHE_MAX", 100)

--- a/tests/test_tool_grammar_matcher_cache_558.py
+++ b/tests/test_tool_grammar_matcher_cache_558.py
@@ -1,0 +1,98 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the compiled-matcher template cache (#558 perf follow-up).
+
+``get_request_matcher`` must build the expensive ``LLMatcher`` automaton at most
+once per distinct ``(tokenizer, grammar)`` and hand each caller its OWN matcher
+via ``deep_copy`` — so repeated identical schemas skip the per-request automaton
+construction WITHOUT sharing stateful parse cursors between requests. These tests
+drive the cache with a fake ``LLMatcher`` (no model / no llguidance needed) so the
+build-count, per-request isolation, broken-grammar bypass, and LRU bound are all
+asserted deterministically.
+"""
+
+import pytest
+
+import vllm_mlx.api.tool_grammar as tg
+
+
+class _FakeMatcher:
+    """Records how many templates were CONSTRUCTED vs deep-copied."""
+
+    builds = 0
+
+    def __init__(self, lltok, grammar):
+        _FakeMatcher.builds += 1
+        self.lltok = lltok
+        self.grammar = grammar
+        self.is_copy = False
+        # A grammar carrying the BROKEN marker reports a compile error, mirroring
+        # llguidance's never-raise "error is stored on the matcher" contract.
+        self._error = "boom" if "BROKEN" in grammar else ""
+
+    def get_error(self):
+        return self._error
+
+    def deep_copy(self):
+        c = _FakeMatcher.__new__(_FakeMatcher)
+        c.lltok = self.lltok
+        c.grammar = self.grammar
+        c._error = self._error
+        c.is_copy = True
+        return c
+
+
+@pytest.fixture(autouse=True)
+def _isolate_cache(monkeypatch):
+    monkeypatch.setattr(tg, "LLMatcher", _FakeMatcher)
+    tg._compiled_matcher_cache.clear()
+    _FakeMatcher.builds = 0
+    yield
+    tg._compiled_matcher_cache.clear()
+
+
+def test_same_key_builds_template_once_and_returns_distinct_copies():
+    lltok = object()
+    g = "start: TAG\nTAG: /x/"
+    m1 = tg.get_request_matcher(lltok, g)
+    m2 = tg.get_request_matcher(lltok, g)
+    # Automaton constructed exactly ONCE (the template); both requests got copies.
+    assert _FakeMatcher.builds == 1
+    assert m1.is_copy and m2.is_copy
+    assert m1 is not m2  # per-request isolation — no shared parse cursor
+
+
+def test_distinct_grammars_build_distinct_templates():
+    lltok = object()
+    tg.get_request_matcher(lltok, "start: A\nA: /a/")
+    tg.get_request_matcher(lltok, "start: B\nB: /b/")
+    assert _FakeMatcher.builds == 2
+
+
+def test_distinct_tokenizers_do_not_share_a_template():
+    g = "start: A\nA: /a/"
+    tg.get_request_matcher(object(), g)
+    tg.get_request_matcher(object(), g)
+    # Same grammar, different tokenizer identity -> vocab-specific automaton
+    # must be rebuilt (never share a compiled matcher across tokenizers).
+    assert _FakeMatcher.builds == 2
+
+
+def test_broken_grammar_is_not_cached():
+    lltok = object()
+    g = "start: BROKEN"
+    m1 = tg.get_request_matcher(lltok, g)
+    m2 = tg.get_request_matcher(lltok, g)
+    # Broken template returned as-is (uncached) each time, so is_broken() handling
+    # in GrammarLogitsProcessor is unchanged and no bad template poisons the cache.
+    assert m1.get_error() and m2.get_error()
+    assert not m1.is_copy  # returned directly, not a deep_copy of a cached template
+    assert _FakeMatcher.builds == 2
+    assert (id(lltok), g) not in tg._compiled_matcher_cache
+
+
+def test_cache_is_bounded_lru(monkeypatch):
+    monkeypatch.setattr(tg, "_COMPILED_MATCHER_CACHE_MAX", 4)
+    lltok = object()
+    for i in range(10):
+        tg.get_request_matcher(lltok, f"start: R{i}\nR{i}: /{i}/")
+    assert len(tg._compiled_matcher_cache) <= 4

--- a/tests/test_tool_grammar_matcher_cache_558.py
+++ b/tests/test_tool_grammar_matcher_cache_558.py
@@ -126,6 +126,35 @@ def test_concurrent_cold_burst_builds_template_exactly_once():
     assert len({id(m) for m in results}) == n, "no two requests share a matcher"
 
 
+def test_concurrent_burst_of_broken_grammar_builds_once():
+    # codex #1155: a concurrent burst of the SAME broken grammar must not
+    # serialize into N compilations. The builder publishes the (inert) broken
+    # matcher via the _BuildSlot; waiters share it instead of rebuilding.
+    _FakeMatcher.construct_delay = 0.05
+    lltok = object()
+    g = "start: BROKEN"
+    n = 6
+    barrier = threading.Barrier(n)
+    results: list = []
+    res_lock = threading.Lock()
+
+    def worker():
+        barrier.wait()
+        m = tg.get_request_matcher(lltok, g)
+        with res_lock:
+            results.append(m)
+
+    threads = [threading.Thread(target=worker) for _ in range(n)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert _FakeMatcher.builds == 1, "broken grammar burst must compile once"
+    assert all(m.get_error() for m in results), "all requests see the compile error"
+    assert (id(lltok), g) not in tg._compiled_matcher_cache  # broken stays uncached
+
+
 def test_distinct_grammars_build_distinct_templates():
     lltok = object()
     tg.get_request_matcher(lltok, "start: A\nA: /a/")

--- a/tests/test_tool_grammar_matcher_cache_558.py
+++ b/tests/test_tool_grammar_matcher_cache_558.py
@@ -45,9 +45,11 @@ class _FakeMatcher:
 def _isolate_cache(monkeypatch):
     monkeypatch.setattr(tg, "LLMatcher", _FakeMatcher)
     tg._compiled_matcher_cache.clear()
+    tg._compiled_matcher_cache_bytes = 0
     _FakeMatcher.builds = 0
     yield
     tg._compiled_matcher_cache.clear()
+    tg._compiled_matcher_cache_bytes = 0
 
 
 def test_same_key_builds_template_once_and_returns_distinct_copies():
@@ -96,3 +98,46 @@ def test_cache_is_bounded_lru(monkeypatch):
     for i in range(10):
         tg.get_request_matcher(lltok, f"start: R{i}\nR{i}: /{i}/")
     assert len(tg._compiled_matcher_cache) <= 4
+
+
+def test_eviction_is_recency_ordered_not_fifo(monkeypatch):
+    # Prove LRU (not FIFO / arbitrary): fill to capacity, TOUCH the oldest key so
+    # it becomes most-recently-used, then insert one past capacity. The evicted
+    # entry must be the now-least-recently-used key, NOT the touched one.
+    monkeypatch.setattr(tg, "_COMPILED_MATCHER_CACHE_MAX", 3)
+    lltok = object()
+    g = [f"start: K{i}\nK{i}: /{i}/" for i in range(4)]
+    for i in range(3):  # fill: K0 (oldest) .. K2 (newest)
+        tg.get_request_matcher(lltok, g[i])
+    # Touch K0 -> it becomes most-recently-used; K1 is now the LRU victim.
+    tg.get_request_matcher(lltok, g[0])
+    # Insert K3, forcing one eviction.
+    tg.get_request_matcher(lltok, g[3])
+    keys = {k[1] for k in tg._compiled_matcher_cache}
+    assert g[0] in keys, "touched (recently-used) key must survive — this is LRU"
+    assert g[1] not in keys, "the least-recently-used key must be the one evicted"
+    assert g[3] in keys, "the newest inserted key must be present"
+
+
+def test_oversized_grammar_is_not_cached(monkeypatch):
+    # A single grammar larger than the whole byte budget must NOT be cached (it
+    # would evict everything and still overflow); it is served fresh each call.
+    monkeypatch.setattr(tg, "_COMPILED_MATCHER_CACHE_MAX_BYTES", 64)
+    lltok = object()
+    big = "start: BIG\nBIG: /" + ("x" * 200) + "/"
+    m1 = tg.get_request_matcher(lltok, big)
+    m2 = tg.get_request_matcher(lltok, big)
+    assert m1.is_copy and m2.is_copy  # still a usable per-request matcher
+    assert (id(lltok), big) not in tg._compiled_matcher_cache
+    assert _FakeMatcher.builds == 2  # rebuilt each time (uncached)
+
+
+def test_byte_budget_evicts_before_count_cap(monkeypatch):
+    # With a generous count cap but a tight byte budget, entries evict on BYTES.
+    monkeypatch.setattr(tg, "_COMPILED_MATCHER_CACHE_MAX", 100)
+    monkeypatch.setattr(tg, "_COMPILED_MATCHER_CACHE_MAX_BYTES", 120)
+    lltok = object()
+    for i in range(6):
+        tg.get_request_matcher(lltok, f"g{i}:" + ("y" * 40))  # ~44 bytes each
+    assert tg._compiled_matcher_cache_bytes <= 120
+    assert len(tg._compiled_matcher_cache) < 6  # byte budget bound before count

--- a/tests/test_tool_grammar_matcher_cache_558.py
+++ b/tests/test_tool_grammar_matcher_cache_558.py
@@ -10,6 +10,9 @@ build-count, per-request isolation, broken-grammar bypass, and LRU bound are all
 asserted deterministically.
 """
 
+import threading
+import time
+
 import pytest
 
 import vllm_mlx.api.tool_grammar as tg
@@ -19,9 +22,14 @@ class _FakeMatcher:
     """Records how many templates were CONSTRUCTED vs deep-copied."""
 
     builds = 0
+    _builds_lock = threading.Lock()
+    construct_delay = 0.0  # widen the race window in the concurrency test
 
     def __init__(self, lltok, grammar):
-        _FakeMatcher.builds += 1
+        with _FakeMatcher._builds_lock:
+            _FakeMatcher.builds += 1
+        if _FakeMatcher.construct_delay:
+            time.sleep(_FakeMatcher.construct_delay)
         self.lltok = lltok
         self.grammar = grammar
         self.is_copy = False
@@ -45,11 +53,15 @@ class _FakeMatcher:
 def _isolate_cache(monkeypatch):
     monkeypatch.setattr(tg, "LLMatcher", _FakeMatcher)
     tg._compiled_matcher_cache.clear()
+    tg._compiled_matcher_building.clear()
     tg._compiled_matcher_cache_bytes = 0
     _FakeMatcher.builds = 0
+    _FakeMatcher.construct_delay = 0.0
     yield
     tg._compiled_matcher_cache.clear()
+    tg._compiled_matcher_building.clear()
     tg._compiled_matcher_cache_bytes = 0
+    _FakeMatcher.construct_delay = 0.0
 
 
 def test_same_key_builds_template_once_and_returns_distinct_copies():
@@ -61,6 +73,37 @@ def test_same_key_builds_template_once_and_returns_distinct_copies():
     assert _FakeMatcher.builds == 1
     assert m1.is_copy and m2.is_copy
     assert m1 is not m2  # per-request isolation — no shared parse cursor
+
+
+def test_concurrent_cold_burst_builds_template_exactly_once():
+    # Per-key single-flight (codex #1155): a burst of N concurrent requests for
+    # the SAME uncached key must construct the expensive automaton exactly ONCE,
+    # not once-per-thread. A construct delay widens the race window, and a barrier
+    # releases all threads simultaneously so they genuinely collide on the miss.
+    _FakeMatcher.construct_delay = 0.05
+    lltok = object()
+    g = "start: HOT\nHOT: /h/"
+    n = 8
+    barrier = threading.Barrier(n)
+    results: list = []
+    res_lock = threading.Lock()
+
+    def worker():
+        barrier.wait()
+        m = tg.get_request_matcher(lltok, g)
+        with res_lock:
+            results.append(m)
+
+    threads = [threading.Thread(target=worker) for _ in range(n)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert _FakeMatcher.builds == 1, "single-flight must build the automaton once"
+    assert len(results) == n
+    assert all(m.is_copy for m in results), "every request gets its own deep_copy"
+    assert len({id(m) for m in results}) == n, "no two requests share a matcher"
 
 
 def test_distinct_grammars_build_distinct_templates():

--- a/tests/test_tool_grammar_matcher_cache_558.py
+++ b/tests/test_tool_grammar_matcher_cache_558.py
@@ -8,10 +8,16 @@ construction WITHOUT sharing stateful parse cursors between requests. These test
 drive the cache with a fake ``LLMatcher`` (no model / no llguidance needed) so the
 build-count, per-request isolation, broken-grammar bypass, and LRU bound are all
 asserted deterministically.
+
+The concurrency tests use an event-latch (NOT sleeps): the sole builder blocks in
+``__init__`` until the test confirms — by instrumenting the under-lock
+``_cache_hit_copy_locked`` entry — that every competing caller has committed
+inside the single-flight critical section. Only then is the builder released, so
+"burst builds once" holds by construction rather than by timing (codex #1155).
 """
 
 import threading
-import time
+from contextlib import contextmanager
 
 import pytest
 
@@ -23,13 +29,17 @@ class _FakeMatcher:
 
     builds = 0
     _builds_lock = threading.Lock()
-    construct_delay = 0.0  # widen the race window in the concurrency test
+    # The sole builder blocks here until a concurrency test releases it, so the
+    # single-flight slot stays open until every competitor has committed to wait
+    # on it (deterministic; no sleeps). Default set => non-concurrency tests
+    # construct synchronously.
+    proceed = threading.Event()
+    proceed.set()
 
     def __init__(self, lltok, grammar):
         with _FakeMatcher._builds_lock:
             _FakeMatcher.builds += 1
-        if _FakeMatcher.construct_delay:
-            time.sleep(_FakeMatcher.construct_delay)
+        _FakeMatcher.proceed.wait()
         self.lltok = lltok
         self.grammar = grammar
         self.is_copy = False
@@ -64,12 +74,77 @@ def _isolate_cache(monkeypatch):
     tg._compiled_matcher_building.clear()
     tg._compiled_matcher_cache_bytes = 0
     _FakeMatcher.builds = 0
-    _FakeMatcher.construct_delay = 0.0
+    _FakeMatcher.proceed.set()
     yield
     tg._compiled_matcher_cache.clear()
     tg._compiled_matcher_building.clear()
     tg._compiled_matcher_cache_bytes = 0
-    _FakeMatcher.construct_delay = 0.0
+    _FakeMatcher.proceed.set()
+
+
+@contextmanager
+def _single_flight_latch(monkeypatch, n):
+    """Hold the sole builder until all ``n`` callers commit in the critical path.
+
+    ``_cache_hit_copy_locked`` runs UNDER ``_compiled_matcher_lock`` for every
+    caller's first-pass (one thread registers the build slot; the rest read it as
+    present and commit to WAIT on it). Counting those entries lets the test
+    release the builder only once the whole burst is provably sharing one build —
+    replacing the previous timing-dependent ``sleep`` with a deterministic latch.
+    Yields a callable that blocks until all ``n`` have entered, then releases the
+    builder.
+    """
+    entered = {"n": 0}
+    cond = threading.Condition()
+    real_hit = tg._cache_hit_copy_locked
+
+    def _counting_hit(key):
+        with cond:
+            entered["n"] += 1
+            cond.notify_all()
+        return real_hit(key)
+
+    monkeypatch.setattr(tg, "_cache_hit_copy_locked", _counting_hit)
+    _FakeMatcher.proceed.clear()
+
+    def _release_when_all_entered():
+        with cond:
+            if not cond.wait_for(lambda: entered["n"] >= n, timeout=5):
+                raise AssertionError("not all workers entered the single-flight path")
+        _FakeMatcher.proceed.set()
+
+    try:
+        yield _release_when_all_entered
+    finally:
+        _FakeMatcher.proceed.set()  # never wedge threads if an assertion fails
+
+
+def _run_burst(n, target):
+    """Start ``n`` worker threads that each call ``target()`` after a barrier.
+
+    Captures per-worker exceptions (so a swallowed thread failure can't let the
+    test pass on a subset) and returns ``(results, errors)`` with both threads
+    joined (codex #1155).
+    """
+    barrier = threading.Barrier(n)
+    results: list = []
+    errors: list = []
+    lock = threading.Lock()
+
+    def worker():
+        try:
+            barrier.wait()
+            m = target()
+            with lock:
+                results.append(m)
+        except Exception as exc:  # noqa: BLE001 - record, never swallow silently
+            with lock:
+                errors.append(exc)
+
+    threads = [threading.Thread(target=worker) for _ in range(n)]
+    for t in threads:
+        t.start()
+    return threads, results, errors
 
 
 def test_same_key_builds_template_once_and_returns_distinct_copies():
@@ -95,61 +170,50 @@ def test_same_key_builds_template_once_and_returns_distinct_copies():
     assert m3.consumed == 0, "a later clone must start from the initial state"
 
 
-def test_concurrent_cold_burst_builds_template_exactly_once():
+def test_concurrent_cold_burst_builds_template_exactly_once(monkeypatch):
     # Per-key single-flight (codex #1155): a burst of N concurrent requests for
     # the SAME uncached key must construct the expensive automaton exactly ONCE,
-    # not once-per-thread. A construct delay widens the race window, and a barrier
-    # releases all threads simultaneously so they genuinely collide on the miss.
-    _FakeMatcher.construct_delay = 0.05
+    # not once-per-thread. The event-latch holds the sole builder until all N
+    # callers have committed inside the critical section, so the collision is
+    # forced deterministically (no sleep / no timing dependence).
     lltok = object()
     g = "start: HOT\nHOT: /h/"
     n = 8
-    barrier = threading.Barrier(n)
-    results: list = []
-    res_lock = threading.Lock()
+    with _single_flight_latch(monkeypatch, n) as release:
+        threads, results, errors = _run_burst(
+            n, lambda: tg.get_request_matcher(lltok, g)
+        )
+        release()
+        for t in threads:
+            t.join(timeout=5)
 
-    def worker():
-        barrier.wait()
-        m = tg.get_request_matcher(lltok, g)
-        with res_lock:
-            results.append(m)
-
-    threads = [threading.Thread(target=worker) for _ in range(n)]
-    for t in threads:
-        t.start()
-    for t in threads:
-        t.join()
-
+    assert not errors, f"worker(s) raised: {errors}"
     assert _FakeMatcher.builds == 1, "single-flight must build the automaton once"
-    assert len(results) == n
+    assert len(results) == n, "every worker must have returned a matcher"
     assert all(m.is_copy for m in results), "every request gets its own deep_copy"
     assert len({id(m) for m in results}) == n, "no two requests share a matcher"
 
 
-def test_concurrent_burst_of_broken_grammar_builds_once():
+def test_concurrent_burst_of_broken_grammar_builds_once(monkeypatch):
     # codex #1155: a concurrent burst of the SAME broken grammar must not
     # serialize into N compilations. The builder publishes the (inert) broken
-    # matcher via the _BuildSlot; waiters share it instead of rebuilding.
-    _FakeMatcher.construct_delay = 0.05
+    # matcher via the _BuildSlot; waiters share it instead of rebuilding. Because
+    # broken results are UNCACHED, this "builds once" property is guaranteed only
+    # while every waiter has committed to the slot before the builder retires it —
+    # which the latch enforces deterministically (was a flaky 50 ms sleep before).
     lltok = object()
     g = "start: BROKEN"
     n = 6
-    barrier = threading.Barrier(n)
-    results: list = []
-    res_lock = threading.Lock()
+    with _single_flight_latch(monkeypatch, n) as release:
+        threads, results, errors = _run_burst(
+            n, lambda: tg.get_request_matcher(lltok, g)
+        )
+        release()
+        for t in threads:
+            t.join(timeout=5)
 
-    def worker():
-        barrier.wait()
-        m = tg.get_request_matcher(lltok, g)
-        with res_lock:
-            results.append(m)
-
-    threads = [threading.Thread(target=worker) for _ in range(n)]
-    for t in threads:
-        t.start()
-    for t in threads:
-        t.join()
-
+    assert not errors, f"worker(s) raised: {errors}"
+    assert len(results) == n, "every worker must have returned a matcher"
     assert _FakeMatcher.builds == 1, "broken grammar burst must compile once"
     assert all(m.get_error() for m in results), "all requests see the compile error"
     assert (id(lltok), g) not in tg._compiled_matcher_cache  # broken stays uncached

--- a/tests/test_tool_grammar_warmup_558.py
+++ b/tests/test_tool_grammar_warmup_558.py
@@ -1,0 +1,105 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the startup tool-grammar warmup gating (#558 perf follow-up).
+
+``_warmup_tool_grammar`` must fire the (expensive) LLTokenizer pre-build ONLY when
+the server is actually configured for grammar-capable tool calling, and must be a
+safe no-op otherwise — so a text-only / non-grammar deploy pays nothing at boot.
+These tests drive the gating with stubs (no model, no llguidance) and assert the
+heavy path (``_do_tool_grammar_warmup``) runs exactly when expected (codex #1155).
+"""
+
+import types
+
+import pytest
+
+import vllm_mlx.server as server
+
+
+class _StubEngine:
+    def __init__(self, tokenizer):
+        self.tokenizer = tokenizer
+
+
+class _GrammarParser:
+    SUPPORTS_GRAMMAR = True
+
+    def __init__(self, tokenizer=None):
+        pass
+
+
+class _NonGrammarParser:
+    SUPPORTS_GRAMMAR = False
+
+    def __init__(self, tokenizer=None):
+        pass
+
+
+@pytest.fixture
+def _patch(monkeypatch):
+    """Return a helper that wires cfg/parser/llguidance stubs and spies the build."""
+    calls = {"n": 0}
+
+    def _install(*, parser_name, parser_cls, has_llg=True, has_lltok=True):
+        monkeypatch.setattr(
+            server,
+            "get_config",
+            lambda: types.SimpleNamespace(tool_call_parser=parser_name),
+        )
+        # ``ToolParserManager`` is imported INSIDE the function via
+        # ``from .tool_parsers import ToolParserManager``, so patch it on that
+        # module (not on ``server``).
+        import vllm_mlx.tool_parsers as tool_parsers
+
+        monkeypatch.setattr(
+            tool_parsers.ToolParserManager,
+            "get_tool_parser",
+            staticmethod(lambda name: parser_cls),
+        )
+        # HAS_* live on the api.tool_grammar module imported inside the function.
+        import vllm_mlx.api.tool_grammar as tg
+
+        monkeypatch.setattr(tg, "HAS_LLGUIDANCE", has_llg)
+        monkeypatch.setattr(tg, "HAS_LL_TOKENIZER", has_lltok)
+
+        def _spy(tokenizer, parser_cls_arg):
+            calls["n"] += 1
+            return True
+
+        monkeypatch.setattr(server, "_do_tool_grammar_warmup", _spy)
+
+    return _install, calls
+
+
+async def test_warmup_fires_for_grammar_capable_parser(_patch):
+    install, calls = _patch
+    install(parser_name="harmony", parser_cls=_GrammarParser)
+    await server._warmup_tool_grammar(_StubEngine(tokenizer=object()))
+    assert calls["n"] == 1
+
+
+async def test_warmup_skips_when_no_parser_configured(_patch):
+    install, calls = _patch
+    install(parser_name=None, parser_cls=_GrammarParser)
+    await server._warmup_tool_grammar(_StubEngine(tokenizer=object()))
+    assert calls["n"] == 0
+
+
+async def test_warmup_skips_when_parser_not_grammar_capable(_patch):
+    install, calls = _patch
+    install(parser_name="mistral", parser_cls=_NonGrammarParser)
+    await server._warmup_tool_grammar(_StubEngine(tokenizer=object()))
+    assert calls["n"] == 0
+
+
+async def test_warmup_skips_when_llguidance_unavailable(_patch):
+    install, calls = _patch
+    install(parser_name="harmony", parser_cls=_GrammarParser, has_llg=False)
+    await server._warmup_tool_grammar(_StubEngine(tokenizer=object()))
+    assert calls["n"] == 0
+
+
+async def test_warmup_skips_when_tokenizer_missing(_patch):
+    install, calls = _patch
+    install(parser_name="harmony", parser_cls=_GrammarParser)
+    await server._warmup_tool_grammar(_StubEngine(tokenizer=None))
+    assert calls["n"] == 0

--- a/vllm_mlx/api/tool_grammar.py
+++ b/vllm_mlx/api/tool_grammar.py
@@ -804,9 +804,13 @@ def get_request_matcher(lltokenizer: Any, grammar: str) -> Any:
                 is_builder = False
         if not is_builder:
             # Another thread is building this exact key: wait, then prefer the
-            # cache; else clone the builder's published (valid-but-uncached)
-            # template so a burst never re-runs the expensive build. Only a
-            # broken/crashed build leaves both empty -> loop and one rebuilds.
+            # cache; else reuse the builder's PUBLISHED template so a burst never
+            # re-runs the build — even for a grammar that is not retained in the
+            # LRU (valid-but-oversized) or is broken (codex #1155). A broken
+            # matcher is INERT (``is_broken()`` short-circuits — it never masks or
+            # consumes and the route discards it), so waiters may SHARE it
+            # directly; a valid template is cloned per request. Only a build that
+            # crashed before publishing leaves the slot empty -> loop and rebuild.
             slot.event.wait()
             with _compiled_matcher_lock:
                 hit = _cache_hit_copy_locked(key)
@@ -814,16 +818,20 @@ def get_request_matcher(lltokenizer: Any, grammar: str) -> Any:
                 return hit
             published = slot.template
             if published is not None:
-                return published.deep_copy()
+                return published if published.get_error() else published.deep_copy()
             continue
 
         # We own the build. Construct OUTSIDE the global lock so this slow step
         # blocks neither cache hits nor OTHER keys' builds.
         try:
             template = LLMatcher(lltokenizer, grammar)
+            # Publish immediately (valid OR broken) so concurrent waiters on the
+            # SAME key reuse this single build instead of each re-compiling it —
+            # covers the valid-but-oversized AND the broken-grammar bursts.
+            slot.template = template
             if template.get_error():
-                # Broken -> uncached, unpublished (is_broken() path unchanged);
-                # waiters rebuild (cheap, rare) rather than deep_copy an error.
+                # Broken -> uncached (is_broken() fallback unchanged); returned
+                # as-is, and shared with waiters (inert, so sharing is safe).
                 return template
             # Byte count (NOT len()): a non-ASCII grammar's UTF-8 size can be up
             # to ~4x its code-point count, so ``len(grammar)`` would under-count
@@ -837,10 +845,6 @@ def get_request_matcher(lltokenizer: Any, grammar: str) -> Any:
                     _compiled_matcher_cache[key] = (lltokenizer, template, nbytes)
                     _compiled_matcher_cache_bytes += nbytes
                     _evict_compiled_matchers_locked()
-            # Publish the valid template so concurrent waiters CLONE it even when
-            # it was too large to retain in the LRU (codex #1155 — no N-way
-            # rebuild of an oversized grammar under a burst).
-            slot.template = template
             return template.deep_copy()
         finally:
             # Release single-flight ATOMICALLY: signal completion AND drop the

--- a/vllm_mlx/api/tool_grammar.py
+++ b/vllm_mlx/api/tool_grammar.py
@@ -688,19 +688,38 @@ def _compile_lark_cached(lark: str) -> str | None:
 # outlier rebuilds per request (rare — the schema is already ≤64 KiB). ``len(
 # grammar)`` is the byte proxy (the automaton size scales with grammar size).
 #
-# THREAD-SAFE: the chat route runs this on a bounded build-executor pool, so N
-# threads may hit the same key concurrently. The lock guards the dict + the
-# ``deep_copy`` (cheap), but the EXPENSIVE ``LLMatcher`` construction runs OUTSIDE
-# the lock, so one slow schema miss never head-of-line-blocks cache hits or
-# unrelated grammars. A rare duplicate concurrent build of the SAME new key is
-# harmless (equivalent templates; the first inserted wins, the loser is dropped).
+# THREAD-SAFE with PER-KEY SINGLE-FLIGHT. The chat route runs this on a bounded
+# build-executor pool, so N threads may hit the same key concurrently. The global
+# lock guards the dict + the ~0.01ms ``deep_copy`` only; the EXPENSIVE
+# ``LLMatcher`` construction runs OUTSIDE the global lock so one slow schema miss
+# never head-of-line-blocks cache hits or OTHER keys' builds. A PER-KEY
+# ``Event`` makes construction at-most-once per key: the first thread to miss a
+# key builds it; concurrent threads for the SAME key wait on the Event and then
+# re-read the cache (codex #1155 — a barrier test asserts a single construction
+# under a cold burst). Different keys still build fully in parallel.
+#
+# MEMORY BOUND — count cap AND byte budget, evicting on whichever binds first. A
+# count cap alone does not bound memory: a client-controlled grammar (and the
+# native automaton built from it) can be large. The upstream route already
+# rejects a serialized tools list over 64 KiB (``_TOOL_GRAMMAR_MAX_SCHEMA_BYTES``)
+# BEFORE a grammar is built, so cached inputs are pre-bounded; ``len(grammar)`` is
+# the in-cache size proxy (the automaton scales with grammar size — llguidance
+# exposes no native byte count). A single grammar larger than the whole budget is
+# NOT cached (it would evict everything and still overflow) and rebuilds per
+# request. Retention is therefore LRU-BOUNDED, not a leak: a burst of distinct
+# one-off schemas evicts oldest-first back under the caps. The cached template
+# pins its ``lltokenizer`` (so ``id()`` can't be recycled to a different
+# tokenizer while live); rapid-mlx's engine already holds that tokenizer for the
+# model's lifetime, so this adds only bounded, LRU-evicted post-unload retention.
 _COMPILED_MATCHER_CACHE_MAX = 128
-_COMPILED_MATCHER_CACHE_MAX_BYTES = 32 * 1024 * 1024  # 32 MiB grammar-string budget
+_COMPILED_MATCHER_CACHE_MAX_BYTES = 16 * 1024 * 1024  # 16 MiB grammar-string budget
 _compiled_matcher_cache: "OrderedDict[tuple[int, str], tuple[Any, Any, int]]" = (
     OrderedDict()
 )
 _compiled_matcher_cache_bytes = 0
 _compiled_matcher_lock = threading.Lock()
+# Per-key in-flight build registry for single-flight (key -> Event).
+_compiled_matcher_building: "dict[tuple[int, str], threading.Event]" = {}
 
 
 def _evict_compiled_matchers_locked() -> None:
@@ -717,52 +736,73 @@ def _evict_compiled_matchers_locked() -> None:
         _compiled_matcher_cache_bytes -= _old_val[2]
 
 
+def _cache_hit_copy_locked(key: "tuple[int, str]") -> Any:
+    """Return a per-request ``deep_copy`` if ``key`` is cached, else ``None``.
+
+    Caller must hold ``_compiled_matcher_lock``. Refreshes LRU recency on a hit.
+    """
+    entry = _compiled_matcher_cache.get(key)
+    if entry is None:
+        return None
+    _compiled_matcher_cache.move_to_end(key)
+    return entry[1].deep_copy()
+
+
 def get_request_matcher(lltokenizer: Any, grammar: str) -> Any:
     """Return a FRESH per-request ``LLMatcher`` for ``(lltokenizer, grammar)``.
 
-    Builds the compiled automaton at most once per distinct ``(tokenizer,
-    grammar)`` and clones it per request via ``deep_copy`` (see the cache-block
-    comment above). The returned matcher is a private, initial-state instance the
-    caller owns and may ``consume_token`` freely — the cached template is never
-    mutated. A grammar that fails to compile (non-empty ``get_error()``) is NOT
-    cached and is returned as-is, so the broken-matcher fallback in
-    ``GrammarLogitsProcessor`` behaves exactly as before.
+    Builds the compiled automaton AT MOST ONCE per distinct ``(tokenizer,
+    grammar)`` — even under a concurrent cold burst (per-key single-flight) — and
+    clones it per request via ``deep_copy`` (see the cache-block comment above).
+    The returned matcher is a private, initial-state instance the caller owns and
+    may ``consume_token`` freely — the cached template is never mutated. A grammar
+    that fails to compile (non-empty ``get_error()``) is NOT cached and is
+    returned as-is, so the broken-matcher fallback in ``GrammarLogitsProcessor``
+    behaves exactly as before.
     """
     global _compiled_matcher_cache_bytes
     key = (id(lltokenizer), grammar)
-    # Fast path: cache hit under the lock (dict read + a ~0.01ms deep_copy only).
-    with _compiled_matcher_lock:
-        entry = _compiled_matcher_cache.get(key)
-        if entry is not None:
-            _compiled_matcher_cache.move_to_end(key)
-            return entry[1].deep_copy()
+    while True:
+        with _compiled_matcher_lock:
+            hit = _cache_hit_copy_locked(key)
+            if hit is not None:
+                return hit
+            ev = _compiled_matcher_building.get(key)
+            if ev is None:
+                # We own the build for this key; publish an Event others wait on.
+                ev = threading.Event()
+                _compiled_matcher_building[key] = ev
+                is_builder = True
+            else:
+                is_builder = False
+        if not is_builder:
+            # Another thread is building this exact key: wait, then re-check the
+            # cache (loop). Never construct a duplicate automaton for this key.
+            ev.wait()
+            continue
 
-    # Miss: build the automaton OUTSIDE the global lock so a slow construction
-    # never blocks cache hits / unrelated grammars (codex #1155). A broken
-    # grammar is returned uncached so the caller's ``is_broken()`` path is
-    # unchanged.
-    template = LLMatcher(lltokenizer, grammar)
-    if template.get_error():
-        return template
-
-    nbytes = len(grammar)
-    with _compiled_matcher_lock:
-        # Re-check: another thread may have inserted this key while we built.
-        existing = _compiled_matcher_cache.get(key)
-        if existing is not None:
-            _compiled_matcher_cache.move_to_end(key)
-            return existing[1].deep_copy()
-        # Refuse to cache a single grammar larger than the whole byte budget —
-        # it would evict every other entry and still overflow. It rebuilds per
-        # request (rare: the upstream schema gate already caps input at 64 KiB).
-        if nbytes > _COMPILED_MATCHER_CACHE_MAX_BYTES:
+        # We own the build. Construct OUTSIDE the global lock so this slow step
+        # blocks neither cache hits nor OTHER keys' builds.
+        try:
+            template = LLMatcher(lltokenizer, grammar)
+            if template.get_error():
+                return template  # broken -> uncached (is_broken() path unchanged)
+            nbytes = len(grammar)
+            with _compiled_matcher_lock:
+                # Refuse to cache a single grammar larger than the whole byte
+                # budget — it would evict everything and still overflow; it
+                # rebuilds per request (rare: schema pre-capped at 64 KiB).
+                if nbytes <= _COMPILED_MATCHER_CACHE_MAX_BYTES:
+                    _compiled_matcher_cache[key] = (lltokenizer, template, nbytes)
+                    _compiled_matcher_cache_bytes += nbytes
+                    _evict_compiled_matchers_locked()
             return template.deep_copy()
-        # Pin ``lltokenizer`` in the value so ``id()`` can't be recycled while
-        # the entry is live; store the byte size for the budget accounting.
-        _compiled_matcher_cache[key] = (lltokenizer, template, nbytes)
-        _compiled_matcher_cache_bytes += nbytes
-        _evict_compiled_matchers_locked()
-        return template.deep_copy()
+        finally:
+            # Release single-flight: drop the registry entry and wake waiters,
+            # which re-read the cache (hit if we cached, else one rebuilds).
+            with _compiled_matcher_lock:
+                _compiled_matcher_building.pop(key, None)
+            ev.set()
 
 
 def build_tool_grammar(

--- a/vllm_mlx/api/tool_grammar.py
+++ b/vllm_mlx/api/tool_grammar.py
@@ -677,16 +677,44 @@ def _compile_lark_cached(lark: str) -> str | None:
 # multi-model routing path.
 #
 # BOUNDED LRU (``OrderedDict`` + a lock) so a client that streams unbounded
-# distinct schemas cannot grow the cache without limit. THREAD-SAFE: the chat
-# route runs this on a bounded build-executor pool, so N threads may hit the same
-# key concurrently; the lock guards both the dict and the ``deep_copy`` (cheap
-# enough that holding the lock over it is free, and it serializes concurrent
-# reads of the same native template).
+# distinct schemas cannot grow the cache without limit. The bound is BOTH a
+# count cap AND a byte budget: a count cap alone does not bound memory, because a
+# client-controlled grammar string (and the native automaton built from it) can
+# be large — the upstream route already rejects a schema whose serialized tools
+# list exceeds 64 KiB (``_TOOL_GRAMMAR_MAX_SCHEMA_BYTES``), but ``%json``
+# expansion can still make the emitted grammar several hundred KiB. So we evict
+# by whichever limit binds first and REFUSE to cache a single grammar larger than
+# the whole byte budget (it would evict everything and still overflow); such an
+# outlier rebuilds per request (rare — the schema is already ≤64 KiB). ``len(
+# grammar)`` is the byte proxy (the automaton size scales with grammar size).
+#
+# THREAD-SAFE: the chat route runs this on a bounded build-executor pool, so N
+# threads may hit the same key concurrently. The lock guards the dict + the
+# ``deep_copy`` (cheap), but the EXPENSIVE ``LLMatcher`` construction runs OUTSIDE
+# the lock, so one slow schema miss never head-of-line-blocks cache hits or
+# unrelated grammars. A rare duplicate concurrent build of the SAME new key is
+# harmless (equivalent templates; the first inserted wins, the loser is dropped).
 _COMPILED_MATCHER_CACHE_MAX = 128
-_compiled_matcher_cache: "OrderedDict[tuple[int, str], tuple[Any, Any]]" = (
+_COMPILED_MATCHER_CACHE_MAX_BYTES = 32 * 1024 * 1024  # 32 MiB grammar-string budget
+_compiled_matcher_cache: "OrderedDict[tuple[int, str], tuple[Any, Any, int]]" = (
     OrderedDict()
 )
+_compiled_matcher_cache_bytes = 0
 _compiled_matcher_lock = threading.Lock()
+
+
+def _evict_compiled_matchers_locked() -> None:
+    """Evict LRU entries until BOTH the count cap and byte budget are satisfied.
+
+    Caller must hold ``_compiled_matcher_lock``.
+    """
+    global _compiled_matcher_cache_bytes
+    while _compiled_matcher_cache and (
+        len(_compiled_matcher_cache) > _COMPILED_MATCHER_CACHE_MAX
+        or _compiled_matcher_cache_bytes > _COMPILED_MATCHER_CACHE_MAX_BYTES
+    ):
+        _old_key, _old_val = _compiled_matcher_cache.popitem(last=False)
+        _compiled_matcher_cache_bytes -= _old_val[2]
 
 
 def get_request_matcher(lltokenizer: Any, grammar: str) -> Any:
@@ -700,25 +728,40 @@ def get_request_matcher(lltokenizer: Any, grammar: str) -> Any:
     cached and is returned as-is, so the broken-matcher fallback in
     ``GrammarLogitsProcessor`` behaves exactly as before.
     """
+    global _compiled_matcher_cache_bytes
     key = (id(lltokenizer), grammar)
+    # Fast path: cache hit under the lock (dict read + a ~0.01ms deep_copy only).
     with _compiled_matcher_lock:
         entry = _compiled_matcher_cache.get(key)
         if entry is not None:
-            # Hit: refresh LRU recency and hand back a private clone.
             _compiled_matcher_cache.move_to_end(key)
             return entry[1].deep_copy()
-        # Miss: build the template under the lock (single-flight — a duplicate
-        # concurrent build of the SAME grammar is wasteful; misses are rare and
-        # the build is typically sub-35ms). A broken grammar is returned
-        # uncached so the caller's ``is_broken()`` path is unchanged.
-        template = LLMatcher(lltokenizer, grammar)
-        if template.get_error():
-            return template
+
+    # Miss: build the automaton OUTSIDE the global lock so a slow construction
+    # never blocks cache hits / unrelated grammars (codex #1155). A broken
+    # grammar is returned uncached so the caller's ``is_broken()`` path is
+    # unchanged.
+    template = LLMatcher(lltokenizer, grammar)
+    if template.get_error():
+        return template
+
+    nbytes = len(grammar)
+    with _compiled_matcher_lock:
+        # Re-check: another thread may have inserted this key while we built.
+        existing = _compiled_matcher_cache.get(key)
+        if existing is not None:
+            _compiled_matcher_cache.move_to_end(key)
+            return existing[1].deep_copy()
+        # Refuse to cache a single grammar larger than the whole byte budget —
+        # it would evict every other entry and still overflow. It rebuilds per
+        # request (rare: the upstream schema gate already caps input at 64 KiB).
+        if nbytes > _COMPILED_MATCHER_CACHE_MAX_BYTES:
+            return template.deep_copy()
         # Pin ``lltokenizer`` in the value so ``id()`` can't be recycled while
-        # the entry is live.
-        _compiled_matcher_cache[key] = (lltokenizer, template)
-        while len(_compiled_matcher_cache) > _COMPILED_MATCHER_CACHE_MAX:
-            _compiled_matcher_cache.popitem(last=False)
+        # the entry is live; store the byte size for the budget accounting.
+        _compiled_matcher_cache[key] = (lltokenizer, template, nbytes)
+        _compiled_matcher_cache_bytes += nbytes
+        _evict_compiled_matchers_locked()
         return template.deep_copy()
 
 

--- a/vllm_mlx/api/tool_grammar.py
+++ b/vllm_mlx/api/tool_grammar.py
@@ -698,20 +698,27 @@ def _compile_lark_cached(lark: str) -> str | None:
 # re-read the cache (codex #1155 — a barrier test asserts a single construction
 # under a cold burst). Different keys still build fully in parallel.
 #
-# MEMORY BOUND — count cap AND byte budget, evicting on whichever binds first. A
-# count cap alone does not bound memory: a client-controlled grammar (and the
-# native automaton built from it) can be large. The upstream route already
-# rejects a serialized tools list over 64 KiB (``_TOOL_GRAMMAR_MAX_SCHEMA_BYTES``)
-# BEFORE a grammar is built, so cached inputs are pre-bounded; ``len(grammar)`` is
-# the in-cache size proxy (the automaton scales with grammar size — llguidance
-# exposes no native byte count). A single grammar larger than the whole budget is
-# NOT cached (it would evict everything and still overflow) and rebuilds per
-# request. Retention is therefore LRU-BOUNDED, not a leak: a burst of distinct
-# one-off schemas evicts oldest-first back under the caps. The cached template
-# pins its ``lltokenizer`` (so ``id()`` can't be recycled to a different
-# tokenizer while live); rapid-mlx's engine already holds that tokenizer for the
-# model's lifetime, so this adds only bounded, LRU-evicted post-unload retention.
-_COMPILED_MATCHER_CACHE_MAX = 128
+# MEMORY BOUND — a DELIBERATELY CONSERVATIVE entry cap AND a byte budget, evicting
+# on whichever binds first. A count cap alone does not bound memory: a
+# client-controlled grammar (and the native automaton built from it) can be
+# large, and llguidance exposes NO native byte count, so exact automaton/tokenizer
+# accounting is not possible — ``len(grammar)`` is the in-cache size proxy (the
+# automaton scales with grammar size). We therefore compensate with a SMALL entry
+# cap (32): real deployments expose a handful of distinct tool schemas, so 32
+# comfortably covers reuse while keeping the WORST-case cached automaton count
+# small even though each automaton's exact bytes are unmeasurable (codex #1155 —
+# "substantially safer entry bound"). Input is additionally pre-bounded upstream:
+# the route rejects a serialized tools list over 64 KiB
+# (``_TOOL_GRAMMAR_MAX_SCHEMA_BYTES``) BEFORE a grammar is built. A single grammar
+# larger than the whole byte budget is NOT cached (it would evict everything and
+# still overflow) and rebuilds per request. Retention is thus LRU-BOUNDED, not a
+# leak: a burst of distinct one-off schemas evicts oldest-first back under the
+# caps. The cached template pins its ``lltokenizer`` (so ``id()`` can't be
+# recycled to a different tokenizer while live); rapid-mlx's engine already holds
+# that tokenizer for the model's lifetime, so this adds only bounded, LRU-evicted
+# post-unload retention — no explicit model-lifecycle hook is warranted for a
+# cache this small.
+_COMPILED_MATCHER_CACHE_MAX = 32
 _COMPILED_MATCHER_CACHE_MAX_BYTES = 16 * 1024 * 1024  # 16 MiB grammar-string budget
 _compiled_matcher_cache: "OrderedDict[tuple[int, str], tuple[Any, Any, int]]" = (
     OrderedDict()

--- a/vllm_mlx/api/tool_grammar.py
+++ b/vllm_mlx/api/tool_grammar.py
@@ -41,6 +41,7 @@ import json
 import logging
 import threading
 import weakref
+from collections import OrderedDict
 from dataclasses import dataclass, field
 from functools import lru_cache
 from typing import Any
@@ -642,6 +643,85 @@ def _compile_lark_cached(lark: str) -> str | None:
         return None
 
 
+# --------------------------------------------------------------------------
+# Compiled-matcher template cache (removes the per-request LLMatcher automaton
+# build from the decode-setup path).
+#
+# ``_compile_lark_cached`` above only memoizes the CHEAP Lark -> grammar-JSON
+# string translation (``grammar_from_lark`` is a pure, sub-millisecond string
+# transform). The EXPENSIVE step is constructing ``LLMatcher(lltokenizer,
+# grammar)``: that builds the token-level automaton/lexer for THIS tokenizer's
+# vocab (llguidance's own ``LLMatcher.__new__`` docstring: "drops the GIL for the
+# duration of the grammar construction, which can be 100-1000ms for extremely
+# complex grammars"). ``GrammarLogitsProcessor.__init__`` rebuilt that automaton
+# fresh on EVERY request, even for an identical tool-set (measured 1-35ms for
+# typical schemas, more for large multi-tool schemas), so we cache it.
+#
+# The compiled matcher is STATEFUL (``consume_token`` advances a parse cursor),
+# so it cannot be shared across concurrent requests. We instead cache an
+# IMMUTABLE TEMPLATE — an ``LLMatcher`` in its initial, never-consumed state —
+# and hand each request its OWN matcher via ``deep_copy()`` (a ~0.01ms clone,
+# verified to produce byte-identical masks to a fresh construct). The template is
+# never fed a token, so it stays read-only in the initial state.
+#
+# KEY = (id(lltokenizer), grammar-JSON string). The grammar string already
+# encodes the full tool-set + each tool's JSON Schema + the model family's
+# wire-format sentinels (``build_tool_lark`` bakes all of that in), so it is the
+# canonicalized schema/parser-family half of the key. The tokenizer identity is
+# the other half — the compiled automaton is vocab-specific, so two models with
+# different tokenizers but the same grammar MUST NOT share a template. We pin the
+# ``lltokenizer`` object in the cache VALUE so its ``id()`` cannot be recycled to
+# a different tokenizer while an entry is live. In practice rapid-mlx holds ONE
+# tokenizer per model for its lifetime (``get_lltokenizer`` memoizes a singleton
+# per tokenizer), so the id is stable; the pin is defense-in-depth for the
+# multi-model routing path.
+#
+# BOUNDED LRU (``OrderedDict`` + a lock) so a client that streams unbounded
+# distinct schemas cannot grow the cache without limit. THREAD-SAFE: the chat
+# route runs this on a bounded build-executor pool, so N threads may hit the same
+# key concurrently; the lock guards both the dict and the ``deep_copy`` (cheap
+# enough that holding the lock over it is free, and it serializes concurrent
+# reads of the same native template).
+_COMPILED_MATCHER_CACHE_MAX = 128
+_compiled_matcher_cache: "OrderedDict[tuple[int, str], tuple[Any, Any]]" = (
+    OrderedDict()
+)
+_compiled_matcher_lock = threading.Lock()
+
+
+def get_request_matcher(lltokenizer: Any, grammar: str) -> Any:
+    """Return a FRESH per-request ``LLMatcher`` for ``(lltokenizer, grammar)``.
+
+    Builds the compiled automaton at most once per distinct ``(tokenizer,
+    grammar)`` and clones it per request via ``deep_copy`` (see the cache-block
+    comment above). The returned matcher is a private, initial-state instance the
+    caller owns and may ``consume_token`` freely — the cached template is never
+    mutated. A grammar that fails to compile (non-empty ``get_error()``) is NOT
+    cached and is returned as-is, so the broken-matcher fallback in
+    ``GrammarLogitsProcessor`` behaves exactly as before.
+    """
+    key = (id(lltokenizer), grammar)
+    with _compiled_matcher_lock:
+        entry = _compiled_matcher_cache.get(key)
+        if entry is not None:
+            # Hit: refresh LRU recency and hand back a private clone.
+            _compiled_matcher_cache.move_to_end(key)
+            return entry[1].deep_copy()
+        # Miss: build the template under the lock (single-flight — a duplicate
+        # concurrent build of the SAME grammar is wasteful; misses are rare and
+        # the build is typically sub-35ms). A broken grammar is returned
+        # uncached so the caller's ``is_broken()`` path is unchanged.
+        template = LLMatcher(lltokenizer, grammar)
+        if template.get_error():
+            return template
+        # Pin ``lltokenizer`` in the value so ``id()`` can't be recycled while
+        # the entry is live.
+        _compiled_matcher_cache[key] = (lltokenizer, template)
+        while len(_compiled_matcher_cache) > _COMPILED_MATCHER_CACHE_MAX:
+            _compiled_matcher_cache.popitem(last=False)
+        return template.deep_copy()
+
+
 def build_tool_grammar(
     tools: list[dict[str, Any]],
     tool_choice: str,
@@ -805,7 +885,12 @@ class GrammarLogitsProcessor:
         tokenizer: Any = None,
     ):
         self._lltok = lltokenizer
-        self._matcher = LLMatcher(lltokenizer, grammar)
+        # Reuse a cached compiled-grammar TEMPLATE (deep-copied per request) so
+        # the automaton is built at most once per distinct (tokenizer, grammar)
+        # instead of on every request; see ``get_request_matcher``. Falls back to
+        # a direct build on the (broken-grammar) uncached path, so the
+        # ``get_error()`` / ``is_broken()`` handling below is unchanged.
+        self._matcher = get_request_matcher(lltokenizer, grammar)
         err = self._matcher.get_error()
         # A non-empty ``get_error()`` means the grammar failed to compile. A
         # broken matcher masks nothing (``__call__`` returns logits unchanged),

--- a/vllm_mlx/api/tool_grammar.py
+++ b/vllm_mlx/api/tool_grammar.py
@@ -725,8 +725,28 @@ _compiled_matcher_cache: "OrderedDict[tuple[int, str], tuple[Any, Any, int]]" = 
 )
 _compiled_matcher_cache_bytes = 0
 _compiled_matcher_lock = threading.Lock()
-# Per-key in-flight build registry for single-flight (key -> Event).
-_compiled_matcher_building: "dict[tuple[int, str], threading.Event]" = {}
+
+
+class _BuildSlot:
+    """Per-key single-flight slot: an Event + the built template for waiters.
+
+    The builder publishes a VALID template on ``template`` before waking waiters,
+    so a concurrent burst on a grammar that is NOT retained in the LRU (a valid
+    grammar too large for the byte budget) still CLONES the one build instead of
+    each waiter re-running the expensive construction (codex #1155). A broken
+    grammar is left unpublished (``template`` stays ``None``) — those are cheap to
+    rebuild and rare, and this keeps ``deep_copy`` off an errored matcher.
+    """
+
+    __slots__ = ("event", "template")
+
+    def __init__(self) -> None:
+        self.event = threading.Event()
+        self.template: Any = None
+
+
+# Per-key in-flight build registry for single-flight (key -> _BuildSlot).
+_compiled_matcher_building: "dict[tuple[int, str], _BuildSlot]" = {}
 
 
 def _evict_compiled_matchers_locked() -> None:
@@ -774,18 +794,27 @@ def get_request_matcher(lltokenizer: Any, grammar: str) -> Any:
             hit = _cache_hit_copy_locked(key)
             if hit is not None:
                 return hit
-            ev = _compiled_matcher_building.get(key)
-            if ev is None:
-                # We own the build for this key; publish an Event others wait on.
-                ev = threading.Event()
-                _compiled_matcher_building[key] = ev
+            slot = _compiled_matcher_building.get(key)
+            if slot is None:
+                # We own the build for this key; publish a slot others wait on.
+                slot = _BuildSlot()
+                _compiled_matcher_building[key] = slot
                 is_builder = True
             else:
                 is_builder = False
         if not is_builder:
-            # Another thread is building this exact key: wait, then re-check the
-            # cache (loop). Never construct a duplicate automaton for this key.
-            ev.wait()
+            # Another thread is building this exact key: wait, then prefer the
+            # cache; else clone the builder's published (valid-but-uncached)
+            # template so a burst never re-runs the expensive build. Only a
+            # broken/crashed build leaves both empty -> loop and one rebuilds.
+            slot.event.wait()
+            with _compiled_matcher_lock:
+                hit = _cache_hit_copy_locked(key)
+            if hit is not None:
+                return hit
+            published = slot.template
+            if published is not None:
+                return published.deep_copy()
             continue
 
         # We own the build. Construct OUTSIDE the global lock so this slow step
@@ -793,7 +822,9 @@ def get_request_matcher(lltokenizer: Any, grammar: str) -> Any:
         try:
             template = LLMatcher(lltokenizer, grammar)
             if template.get_error():
-                return template  # broken -> uncached (is_broken() path unchanged)
+                # Broken -> uncached, unpublished (is_broken() path unchanged);
+                # waiters rebuild (cheap, rare) rather than deep_copy an error.
+                return template
             nbytes = len(grammar)
             with _compiled_matcher_lock:
                 # Refuse to cache a single grammar larger than the whole byte
@@ -803,13 +834,16 @@ def get_request_matcher(lltokenizer: Any, grammar: str) -> Any:
                     _compiled_matcher_cache[key] = (lltokenizer, template, nbytes)
                     _compiled_matcher_cache_bytes += nbytes
                     _evict_compiled_matchers_locked()
+            # Publish the valid template so concurrent waiters CLONE it even when
+            # it was too large to retain in the LRU (codex #1155 — no N-way
+            # rebuild of an oversized grammar under a burst).
+            slot.template = template
             return template.deep_copy()
         finally:
-            # Release single-flight: drop the registry entry and wake waiters,
-            # which re-read the cache (hit if we cached, else one rebuilds).
+            # Release single-flight: drop the registry entry and wake waiters.
             with _compiled_matcher_lock:
                 _compiled_matcher_building.pop(key, None)
-            ev.set()
+            slot.event.set()
 
 
 def build_tool_grammar(

--- a/vllm_mlx/api/tool_grammar.py
+++ b/vllm_mlx/api/tool_grammar.py
@@ -825,7 +825,10 @@ def get_request_matcher(lltokenizer: Any, grammar: str) -> Any:
                 # Broken -> uncached, unpublished (is_broken() path unchanged);
                 # waiters rebuild (cheap, rare) rather than deep_copy an error.
                 return template
-            nbytes = len(grammar)
+            # Byte count (NOT len()): a non-ASCII grammar's UTF-8 size can be up
+            # to ~4x its code-point count, so ``len(grammar)`` would under-count
+            # the byte budget (codex #1155).
+            nbytes = len(grammar.encode("utf-8"))
             with _compiled_matcher_lock:
                 # Refuse to cache a single grammar larger than the whole byte
                 # budget — it would evict everything and still overflow; it
@@ -840,10 +843,13 @@ def get_request_matcher(lltokenizer: Any, grammar: str) -> Any:
             slot.template = template
             return template.deep_copy()
         finally:
-            # Release single-flight: drop the registry entry and wake waiters.
+            # Release single-flight ATOMICALLY: signal completion AND drop the
+            # registry entry under the SAME lock, so no arrival can observe "key
+            # not building" before the Event is set and start a duplicate build
+            # of an uncached (oversized) grammar (codex #1155).
             with _compiled_matcher_lock:
+                slot.event.set()
                 _compiled_matcher_building.pop(key, None)
-            slot.event.set()
 
 
 def build_tool_grammar(

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -423,23 +423,46 @@ async def _warmup_tool_grammar(engine) -> None:
         return
     if not getattr(parser_cls, "SUPPORTS_GRAMMAR", False):
         return
-    # Bound the warmup so a stalled llguidance build can never wedge startup —
-    # the server must still become ready, paying the cold-compile on the first
-    # request instead (codex #1155 nit). The build normally takes ~1s.
-    try:
-        warmed = await asyncio.wait_for(
-            asyncio.to_thread(_do_tool_grammar_warmup, tokenizer, parser_cls),
-            timeout=_TOOL_GRAMMAR_WARMUP_TIMEOUT_S,
-        )
-    except asyncio.TimeoutError:
+    # Bound the warmup so a stalled build can never wedge startup — the server
+    # must still become ready, paying the cold-compile on the first request
+    # instead (build normally ~1s). We run it on a DAEMON thread and poll a
+    # completion Event off the event loop, rather than
+    # ``asyncio.wait_for(asyncio.to_thread(...))``: that only abandons the AWAIT
+    # while the pool thread keeps running, so a genuinely hung build would keep a
+    # non-daemon worker alive and could delay interpreter shutdown (codex #1155).
+    # A daemon thread is killed at interpreter exit, so a stall can never delay
+    # shutdown; and if it is still building when the first request lands, both
+    # serialize on the SAME single-flight build lock (``get_lltokenizer`` /
+    # ``get_request_matcher``) — never a double-build or a torn read.
+    import threading as _threading
+
+    done = _threading.Event()
+    holder: dict[str, bool] = {}
+
+    def _run():
+        try:
+            holder["warmed"] = _do_tool_grammar_warmup(tokenizer, parser_cls)
+        except Exception:
+            logger.debug("Tool-grammar warmup thread failed (non-fatal)", exc_info=True)
+        finally:
+            done.set()
+
+    _threading.Thread(target=_run, name="tool-grammar-warmup", daemon=True).start()
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + _TOOL_GRAMMAR_WARMUP_TIMEOUT_S
+    while not done.is_set() and loop.time() < deadline:
+        await asyncio.sleep(0.1)
+    if not done.is_set():
         logger.warning(
-            "Tool-grammar warmup exceeded %.0fs for parser %r; continuing "
-            "startup (first tool-call request will pay the cold-compile)",
+            "Tool-grammar warmup exceeded %.0fs for parser %r; continuing startup. "
+            "The daemon warmup thread finishes in the background (killed at exit); "
+            "the first tool-call request single-flights on the same build lock, so "
+            "it never double-builds or races.",
             _TOOL_GRAMMAR_WARMUP_TIMEOUT_S,
             parser_name,
         )
         return
-    if warmed:
+    if holder.get("warmed"):
         logger.info(
             "Tool-grammar warmup complete (LLTokenizer pre-built for parser %r)",
             parser_name,

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -333,12 +333,6 @@ async def _shutdown_save_prefix_cache() -> None:
     await asyncio.to_thread(_save_prefix_cache_to_disk)
 
 
-# Upper bound on the startup tool-grammar warmup (the LLTokenizer build normally
-# takes ~1s). If exceeded, startup proceeds and the first request pays the
-# cold-compile rather than the server hanging on a stalled build (codex #1155).
-_TOOL_GRAMMAR_WARMUP_TIMEOUT_S = 30.0
-
-
 def _do_tool_grammar_warmup(tokenizer, parser_cls) -> bool:
     """Pre-build the llguidance ``LLTokenizer`` (+ warm the grammar path).
 
@@ -423,46 +417,18 @@ async def _warmup_tool_grammar(engine) -> None:
         return
     if not getattr(parser_cls, "SUPPORTS_GRAMMAR", False):
         return
-    # Bound the warmup so a stalled build can never wedge startup — the server
-    # must still become ready, paying the cold-compile on the first request
-    # instead (build normally ~1s). We run it on a DAEMON thread and poll a
-    # completion Event off the event loop, rather than
-    # ``asyncio.wait_for(asyncio.to_thread(...))``: that only abandons the AWAIT
-    # while the pool thread keeps running, so a genuinely hung build would keep a
-    # non-daemon worker alive and could delay interpreter shutdown (codex #1155).
-    # A daemon thread is killed at interpreter exit, so a stall can never delay
-    # shutdown; and if it is still building when the first request lands, both
-    # serialize on the SAME single-flight build lock (``get_lltokenizer`` /
-    # ``get_request_matcher``) — never a double-build or a torn read.
-    import threading as _threading
-
-    done = _threading.Event()
-    holder: dict[str, bool] = {}
-
-    def _run():
-        try:
-            holder["warmed"] = _do_tool_grammar_warmup(tokenizer, parser_cls)
-        except Exception:
-            logger.debug("Tool-grammar warmup thread failed (non-fatal)", exc_info=True)
-        finally:
-            done.set()
-
-    _threading.Thread(target=_run, name="tool-grammar-warmup", daemon=True).start()
-    loop = asyncio.get_running_loop()
-    deadline = loop.time() + _TOOL_GRAMMAR_WARMUP_TIMEOUT_S
-    while not done.is_set() and loop.time() < deadline:
-        await asyncio.sleep(0.1)
-    if not done.is_set():
-        logger.warning(
-            "Tool-grammar warmup exceeded %.0fs for parser %r; continuing startup. "
-            "The daemon warmup thread finishes in the background (killed at exit); "
-            "the first tool-call request single-flights on the same build lock, so "
-            "it never double-builds or races.",
-            _TOOL_GRAMMAR_WARMUP_TIMEOUT_S,
-            parser_name,
-        )
-        return
-    if holder.get("warmed"):
+    # Run the warmup on the loop's default thread pool and AWAIT it (the ~1s
+    # build runs off the event loop, so the loop stays responsive; startup waits
+    # for it the same way it already waits for ``generate_warmup``'s Metal-shader
+    # compile above). We deliberately impose NO timeout / background thread: a
+    # ``wait_for`` cannot cancel ``to_thread`` (the worker keeps running), and a
+    # detached daemon thread is untracked at shutdown (codex #1155). The warmup is
+    # a bounded, single-flighted CPU build that cannot realistically hang, so the
+    # simplest correct shape is a plain awaited ``to_thread`` — no orphaned worker
+    # to manage, and a genuine llguidance defect surfaces as a normal startup
+    # error rather than being masked by a timeout.
+    warmed = await asyncio.to_thread(_do_tool_grammar_warmup, tokenizer, parser_cls)
+    if warmed:
         logger.info(
             "Tool-grammar warmup complete (LLTokenizer pre-built for parser %r)",
             parser_name,

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -333,6 +333,92 @@ async def _shutdown_save_prefix_cache() -> None:
     await asyncio.to_thread(_save_prefix_cache_to_disk)
 
 
+def _do_tool_grammar_warmup(tokenizer, parser_cls) -> bool:
+    """Pre-build the llguidance ``LLTokenizer`` (+ warm the grammar path).
+
+    CPU-ONLY and idempotent, safe to run on a worker thread: it touches only
+    llguidance's Rust surface, never an MLX GPU op, so it does not trip the
+    per-thread MLX stream gotcha (#170) that forbids GPU evals off the step
+    thread. The dominant cost this hoists off the first request is the
+    ``LLTokenizer`` build — a ~1s, vocab-scale operation llguidance's own docs
+    flag "expensive … should be cached". ``get_lltokenizer`` memoizes it on the
+    tokenizer, so building it here means the first real tool-call request hits a
+    warm cache instead of paying ~1s inline. Returns True if the tokenizer warmed.
+    """
+    from .api.tool_grammar import (
+        build_tool_grammar,
+        get_lltokenizer,
+        get_request_matcher,
+    )
+
+    lltok = get_lltokenizer(tokenizer)
+    if lltok is None:
+        return False
+    # Also warm the grammar-build + compiled-matcher path (module imports, the
+    # Lark->grammar compile, one automaton construction) with a trivial 0-arg
+    # tool so the first real request's setup is fully hot. Per-request schemas
+    # differ, so we cannot pre-compile a client's specific grammar — the win is
+    # the shared LLTokenizer above; this just primes the rest of the code path.
+    try:
+        parser = parser_cls(tokenizer=tokenizer)
+        warm_tools = [
+            {
+                "name": "_rapid_mlx_warmup",
+                "parameters": {
+                    "type": "object",
+                    "properties": {},
+                    "additionalProperties": False,
+                },
+            }
+        ]
+        grammar = build_tool_grammar(warm_tools, "required", parser)
+        if grammar is not None:
+            get_request_matcher(lltok, grammar)
+    except Exception:
+        # Non-fatal: the LLTokenizer (the expensive part) is already warm.
+        pass
+    return True
+
+
+async def _warmup_tool_grammar(engine) -> None:
+    """Startup warmup for grammar-constrained tool calling (#558).
+
+    Gated so it only fires when the server is actually configured for
+    grammar-capable tool calling: a ``tool_call_parser`` is set, the parser
+    class opts into ``SUPPORTS_GRAMMAR``, and the llguidance stack is importable.
+    Any other case returns immediately (a text-only or non-grammar deploy pays
+    nothing at boot). The heavy build runs via ``asyncio.to_thread`` so the ~1s
+    LLTokenizer construction never blocks the event loop. Fully non-fatal.
+    """
+    cfg = get_config()
+    parser_name = getattr(cfg, "tool_call_parser", None)
+    if not parser_name:
+        return
+    try:
+        from .api.tool_grammar import HAS_LL_TOKENIZER, HAS_LLGUIDANCE
+    except Exception:
+        return
+    if not (HAS_LLGUIDANCE and HAS_LL_TOKENIZER):
+        return
+    tokenizer = getattr(engine, "tokenizer", None)
+    if tokenizer is None:
+        return
+    try:
+        from .tool_parsers import ToolParserManager
+
+        parser_cls = ToolParserManager.get_tool_parser(parser_name)
+    except Exception:
+        return
+    if not getattr(parser_cls, "SUPPORTS_GRAMMAR", False):
+        return
+    warmed = await asyncio.to_thread(_do_tool_grammar_warmup, tokenizer, parser_cls)
+    if warmed:
+        logger.info(
+            "Tool-grammar warmup complete (LLTokenizer pre-built for parser %r)",
+            parser_name,
+        )
+
+
 async def lifespan(app: FastAPI):
     """FastAPI lifespan for startup/shutdown events."""
     global _engine, _mcp_manager
@@ -447,6 +533,19 @@ async def lifespan(app: FastAPI):
             logger.debug(f"Warmup failed (non-fatal): {e}")
         _warmup_secs = _time.monotonic() - _warmup_start
         logger.info(f"Warmup complete ({_warmup_secs:.1f}s)")
+
+    # Tool-grammar warmup (#558): the FIRST grammar-constrained tool call
+    # otherwise pays a one-time ~1s llguidance ``LLTokenizer`` build on the
+    # request path (measured on gpt-oss-20b: ~1.7s cold first tool-call vs
+    # ~0.37s warm — distinct schemas AFTER the first are already warm, so the
+    # cost is the shared tokenizer build, not per-schema compile). Pre-build it
+    # at startup, off the event loop, so no user request eats the cold-start.
+    # Self-gates to grammar-capable tool deployments and is non-fatal.
+    if _engine is not None:
+        try:
+            await _warmup_tool_grammar(_engine)
+        except Exception as _e:
+            logger.debug(f"Tool-grammar warmup failed (non-fatal): {_e}")
 
     # Load persisted cache from disk (AFTER engine start — AsyncEngineCore must exist)
     if _engine is not None and hasattr(_engine, "load_cache_from_disk"):

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -333,6 +333,12 @@ async def _shutdown_save_prefix_cache() -> None:
     await asyncio.to_thread(_save_prefix_cache_to_disk)
 
 
+# Upper bound on the startup tool-grammar warmup (the LLTokenizer build normally
+# takes ~1s). If exceeded, startup proceeds and the first request pays the
+# cold-compile rather than the server hanging on a stalled build (codex #1155).
+_TOOL_GRAMMAR_WARMUP_TIMEOUT_S = 30.0
+
+
 def _do_tool_grammar_warmup(tokenizer, parser_cls) -> bool:
     """Pre-build the llguidance ``LLTokenizer`` (+ warm the grammar path).
 
@@ -375,8 +381,14 @@ def _do_tool_grammar_warmup(tokenizer, parser_cls) -> bool:
         if grammar is not None:
             get_request_matcher(lltok, grammar)
     except Exception:
-        # Non-fatal: the LLTokenizer (the expensive part) is already warm.
-        pass
+        # Non-fatal: the LLTokenizer (the expensive part) is already warm. Log
+        # the secondary grammar-path priming failure rather than swallowing it
+        # silently, so a real defect here is diagnosable (codex #1155 nit).
+        logger.warning(
+            "Tool-grammar warmup: LLTokenizer built, but grammar-path priming "
+            "failed (non-fatal — first real request re-primes it)",
+            exc_info=True,
+        )
     return True
 
 
@@ -411,7 +423,22 @@ async def _warmup_tool_grammar(engine) -> None:
         return
     if not getattr(parser_cls, "SUPPORTS_GRAMMAR", False):
         return
-    warmed = await asyncio.to_thread(_do_tool_grammar_warmup, tokenizer, parser_cls)
+    # Bound the warmup so a stalled llguidance build can never wedge startup —
+    # the server must still become ready, paying the cold-compile on the first
+    # request instead (codex #1155 nit). The build normally takes ~1s.
+    try:
+        warmed = await asyncio.wait_for(
+            asyncio.to_thread(_do_tool_grammar_warmup, tokenizer, parser_cls),
+            timeout=_TOOL_GRAMMAR_WARMUP_TIMEOUT_S,
+        )
+    except asyncio.TimeoutError:
+        logger.warning(
+            "Tool-grammar warmup exceeded %.0fs for parser %r; continuing "
+            "startup (first tool-call request will pay the cold-compile)",
+            _TOOL_GRAMMAR_WARMUP_TIMEOUT_S,
+            parser_name,
+        )
+        return
     if warmed:
         logger.info(
             "Tool-grammar warmup complete (LLTokenizer pre-built for parser %r)",


### PR DESCRIPTION
## Problem

Grammar-constrained tool calling (#558) pays a one-time cold-compile on the **first** request instead of at startup. Hardware measurement on `mlx-community/gpt-oss-20b-MXFP4-Q8` (`tool_choice=required`, harmony parser, `max_tokens=64`):

| call | latency |
|---|---|
| first tool-call EVER | **1724 ms** |
| warm (same schema) | 373 ms |
| 2nd **distinct** schema | 429 ms |
| 3rd **distinct** schema | 435 ms |

## Root cause

The ~1.35s cold penalty is the one-time llguidance **`LLTokenizer` build** (vocab-scale; llguidance's own docstring calls it *"expensive … should be cached"*), **not** per-schema grammar compilation. `get_lltokenizer` already memoizes it — but lazily, on the first request — so the first user request eats it. Distinct schemas *after* the first are already warm, because the per-schema `LLMatcher(lltokenizer, grammar)` automaton build is only ~1-35ms (micro-measured; scales to ~34ms for an 8-tool / depth-3 / 300KB grammar).

The existing `@lru_cache` (`_compile_lark_cached`) only memoizes the *cheap* Lark→grammar-JSON string transform (`grammar_from_lark`, sub-ms), leaving the automaton construction uncached and per-request.

## Changes

**1. Startup warmup** (`server.py` lifespan). When the server is configured for a grammar-capable tool parser (`tool_call_parser` set + parser `SUPPORTS_GRAMMAR` + llguidance importable), pre-build the `LLTokenizer` and prime the grammar path **off the event loop** (`asyncio.to_thread`). CPU-only (touches only llguidance's Rust surface — no MLX GPU op, so it does not trip the per-thread MLX stream gotcha #170), self-gating (text-only / non-grammar deploys pay nothing at boot), and fully non-fatal.

**2. Compiled-matcher template cache** (`tool_grammar.py`). `get_request_matcher` caches an **immutable, never-consumed `LLMatcher` template** keyed by `(id(lltokenizer), grammar)` and hands each request its **own** matcher via `deep_copy` (~0.01ms, verified byte-identical masks to a fresh construct). The compiled matcher is stateful (`consume_token` advances a parse cursor), so the template is never fed a token and each request deep-copies it — no shared cursor across requests. **Bounded** LRU (`OrderedDict`, max 128) + a lock → thread-safe (the chat route runs builds on a bounded executor pool) and no unbounded growth. The `lltokenizer` is pinned in the cache value so `id()` can't be recycled while an entry is live (multi-model routing safety). Broken grammars are returned **uncached** so the `is_broken()` free-form fallback is unchanged.

## Result

Warmup fires at boot (log: `Tool-grammar warmup complete (LLTokenizer pre-built for parser 'harmony')`), and the same measurement becomes:

| call | before | after |
|---|---|---|
| first tool-call EVER | 1724 ms | **630 ms** (−63%) |
| warm (same schema) | 373 ms | 378 ms |
| distinct schema | 429 ms | 385 ms |

The ~1.1s `LLTokenizer` build no longer lands on any user request. The residual 630 vs 378ms gap on the first call is first-request MLX/decode warmup unrelated to the grammar path.

## Correctness

- Constrained tool-call outputs verified **byte-identical** to the uncached path end-to-end (`get_weather` / `book_flight` / `send_email` all match baseline).
- New unit test `tests/test_tool_grammar_matcher_cache_558.py` (mock-based, no model needed): template built once per key, per-request `deep_copy` isolation, distinct-tokenizer separation, broken-grammar bypass, LRU bound.
- Full `#558` grammar suites green (216 passed).
- No `pyproject` version bump (separate dedicated PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)