### PR TITLE
docs: declutter README header — one hero, not two

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 <img width="1600" height="800" alt="banner" src="https://github.com/user-attachments/assets/f3743bb7-7287-4b24-ac97-a7037974396f" />
 
-<h1 align="center">Rapid-MLX</h1>
-
 <p align="center">
   <strong>The fastest local AI engine for Apple Silicon.</strong>
   <br>
@@ -31,10 +29,6 @@
     <a href="https://models.rapidmlx.com/">Model mirror</a> ·
     <a href="https://rapidmlx.com/desktop">Desktop app</a>
   </sub>
-</p>
-
-<p align="center">
-  <img src="https://raw.githubusercontent.com/raullenchai/Rapid-MLX/main/docs/assets/demo.gif" alt="Rapid-MLX demo — install, serve Gemma 4, chat, tool calling" width="700">
 </p>
 
 ---
@@ -227,6 +221,12 @@ Top three things that go wrong:
 → [All troubleshooting entries](https://rapidmlx.com/docs/troubleshooting.html) (OOM, empty responses, slow TTFT, port taken, shell completion, HF cache, and more)
 
 ---
+
+## See it in action
+
+<p align="center">
+  <img src="https://raw.githubusercontent.com/raullenchai/Rapid-MLX/main/docs/assets/demo.gif" alt="Rapid-MLX demo — install, serve Gemma 4, chat, tool calling" width="700">
+</p>
 
 ## Community & Contributing
 


### PR DESCRIPTION
## Why
The README header was heavy: **two full-width black images stacked** (the banner *and* the demo GIF) with the name/pitch repeated three times (banner art, `<h1>`, and the tagline). It reads as cluttered before you get to anything useful.

## What
- **Drop `<h1>Rapid-MLX</h1>`** — the banner already shows the wordmark large, and GitHub renders the repo name above the README regardless. Pure repetition.
- **Keep the text tagline** — the banner is an image (invisible to search + screen readers), so this line carries the value prop and the concrete claims.
- **Move the demo GIF** out of the header into a **`## See it in action`** section near the end. The header no longer has two stacked terminal images back-to-back; the GIF is preserved for anyone who wants to see it run.

**Header before:** banner → h1 → tagline → badges → links → demo.gif → Quick Start
**Header after:** banner → tagline → badges → links → Quick Start

Banner and GIF assets are untouched — this is a pure reorder/removal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)