### PR TITLE
feat(doctor): add version-freshness + shadowed-install checks

### DIFF
--- a/tests/test_doctor_env_health.py
+++ b/tests/test_doctor_env_health.py
@@ -583,6 +583,29 @@ def test_updates_unknown_installed_version_marks_warn():
     assert "unknown" in row.label
 
 
+@pytest.mark.parametrize(
+    "installed,latest",
+    [
+        ("0.10", "0.10.15"),  # installed unparseable (too few components)
+        ("0.10.15", "0.11.0rc1"),  # latest unparseable (rc suffix)
+        ("0.10.15.dev3", "0.10.16.dev1"),  # both dev builds
+    ],
+)
+def test_updates_unparseable_version_marks_warn_not_up_to_date(installed, latest):
+    """A version ``_parse_version`` can't order (dev/rc/short) must NOT
+    silently green-light "up to date" — that falsely reassures a user who
+    may well be behind. It downgrades to ⚠ like every other uncertain
+    branch, and never to a hard fail."""
+    section = eh.section_updates(
+        installed=lambda: installed,
+        fetch_latest=lambda: latest,
+    )
+    row = section.checks[0]
+    assert row.status is eh.CheckStatus.WARN
+    assert "up to date" not in row.label
+    assert all(c.status is not eh.CheckStatus.FAIL for c in section.checks)
+
+
 # ---------------------------------------------------------------------------
 # Section: Shell Integration — shadowed / duplicate installs
 # ---------------------------------------------------------------------------
@@ -632,3 +655,17 @@ def test_rapid_mlx_on_path_dedupes_by_resolved_target(tmp_path: Path):
     path_env = os.pathsep.join(str(d) for d in (d1, d2, d3))
     found = eh._rapid_mlx_on_path(path_env=path_env)
     assert found == [str(real), str(other)]
+
+
+def test_rapid_mlx_on_path_empty_component_is_cwd(tmp_path: Path, monkeypatch):
+    """An empty PATH component means the current directory (shutil.which
+    semantics). A ``./rapid-mlx`` shadow must be surfaced, not skipped."""
+    cli = tmp_path / "rapid-mlx"
+    cli.write_text("#!/bin/sh\n")
+    cli.chmod(0o755)
+    monkeypatch.chdir(tmp_path)
+
+    # Leading empty component ("" before the sep) resolves to cwd.
+    found = eh._rapid_mlx_on_path(path_env=os.pathsep + "/nonexistent-doctor-dir")
+    resolved = [os.path.realpath(p) for p in found]
+    assert os.path.realpath(str(cli)) in resolved

--- a/tests/test_doctor_env_health.py
+++ b/tests/test_doctor_env_health.py
@@ -18,6 +18,7 @@ mutation) so the suite runs identically on every Python and every OS.
 from __future__ import annotations
 
 import importlib
+import os
 from pathlib import Path
 from unittest import mock
 
@@ -446,15 +447,16 @@ def test_overall_exit_code_zero_with_only_warnings():
 # ---------------------------------------------------------------------------
 
 
-def test_run_all_returns_all_eight_sections():
-    """run_all() must emit exactly the eight sections the spec mandates,
-    in the spec order. Test pins the order so future drift is loud."""
+def test_run_all_returns_all_sections():
+    """run_all() must emit exactly the sections the spec mandates, in the spec
+    order. Test pins the order so future drift is loud."""
     report = eh.run_all()
     titles = [s.title for s in report.sections]
     expected = [
         "System",
         "Python",
         "Required Packages",
+        "Updates",
         "Optional Packages",
         "HuggingFace Cache",
         "Network",
@@ -530,3 +532,103 @@ def test_env_health_public_exports():
     pkg = importlib.import_module("vllm_mlx.doctor")
     for name in ("run_all", "Report", "Section", "Check", "CheckStatus"):
         assert hasattr(pkg, name), f"vllm_mlx.doctor missing {name}"
+
+
+# ---------------------------------------------------------------------------
+# Section: Updates (version freshness)
+# ---------------------------------------------------------------------------
+
+
+def test_updates_up_to_date_marks_ok():
+    section = eh.section_updates(
+        installed=lambda: "0.10.15",
+        fetch_latest=lambda: "0.10.15",
+    )
+    row = section.checks[0]
+    assert row.status is eh.CheckStatus.OK
+    assert "up to date" in row.label
+
+
+def test_update_available_marks_warn_with_upgrade_command():
+    info = mock.Mock(upgrade_command="brew upgrade rapid-mlx", method="brew")
+    section = eh.section_updates(
+        installed=lambda: "0.10.12",
+        fetch_latest=lambda: "0.10.15",
+        install_info=info,
+    )
+    row = section.checks[0]
+    assert row.status is eh.CheckStatus.WARN
+    assert "update available: 0.10.15" in row.label
+    assert "brew upgrade rapid-mlx" in row.label
+
+
+def test_updates_offline_marks_warn_never_fail():
+    section = eh.section_updates(
+        installed=lambda: "0.10.15",
+        fetch_latest=lambda: None,
+    )
+    row = section.checks[0]
+    assert row.status is eh.CheckStatus.WARN
+    # Air-gapped doctor must never escalate the update check to a hard fail.
+    assert all(c.status is not eh.CheckStatus.FAIL for c in section.checks)
+
+
+def test_updates_unknown_installed_version_marks_warn():
+    section = eh.section_updates(
+        installed=lambda: None,
+        fetch_latest=lambda: "0.10.15",
+    )
+    row = section.checks[0]
+    assert row.status is eh.CheckStatus.WARN
+    assert "unknown" in row.label
+
+
+# ---------------------------------------------------------------------------
+# Section: Shell Integration — shadowed / duplicate installs
+# ---------------------------------------------------------------------------
+
+
+def test_shadowed_install_marks_warn(tmp_path: Path):
+    section = eh.section_shell_integration(
+        which=lambda name: (
+            "/opt/homebrew/bin/rapid-mlx" if name == "rapid-mlx" else None
+        ),
+        rcs=[tmp_path / "missing.zshrc"],
+        find_all=lambda: [
+            "/opt/homebrew/bin/rapid-mlx",
+            "/Users/x/.local/bin/rapid-mlx",
+        ],
+    )
+    shadow_row = next(c for c in section.checks if "shadowed" in c.label)
+    assert shadow_row.status is eh.CheckStatus.WARN
+    assert "2 places" in shadow_row.label
+    assert ".local/bin/rapid-mlx" in shadow_row.label
+
+
+def test_single_install_has_no_shadow_warn(tmp_path: Path):
+    section = eh.section_shell_integration(
+        which=lambda name: (
+            "/opt/homebrew/bin/rapid-mlx" if name == "rapid-mlx" else None
+        ),
+        rcs=[tmp_path / "missing.zshrc"],
+        find_all=lambda: ["/opt/homebrew/bin/rapid-mlx"],
+    )
+    assert not any("shadowed" in c.label for c in section.checks)
+
+
+def test_rapid_mlx_on_path_dedupes_by_resolved_target(tmp_path: Path):
+    """A symlink to the same binary is one install; a distinct binary is two."""
+    d1, d2, d3 = tmp_path / "a", tmp_path / "b", tmp_path / "c"
+    for d in (d1, d2, d3):
+        d.mkdir()
+    real = d1 / "rapid-mlx"
+    real.write_text("#!/bin/sh\n")
+    real.chmod(0o755)
+    (d2 / "rapid-mlx").symlink_to(real)  # same target → deduped
+    other = d3 / "rapid-mlx"
+    other.write_text("#!/bin/sh\n")
+    other.chmod(0o755)
+
+    path_env = os.pathsep.join(str(d) for d in (d1, d2, d3))
+    found = eh._rapid_mlx_on_path(path_env=path_env)
+    assert found == [str(real), str(other)]

--- a/vllm_mlx/doctor/env_health.py
+++ b/vllm_mlx/doctor/env_health.py
@@ -544,7 +544,22 @@ def section_updates(
         return s
 
     pc, pl = vc._parse_version(cur), vc._parse_version(latest)
-    if pc and pl and pl > pc:
+    if pc is None or pl is None:
+        # One side is a dev/rc/git-describe build ``_parse_version`` won't
+        # touch (e.g. ``0.10.15.dev3``, ``0.11.0rc1``, ``0.10``). We can't
+        # order them, so DON'T fall through to a green "up to date" — that
+        # would falsely reassure a user who might well be behind. Downgrade
+        # to ⚠ like every other uncertain branch in this section.
+        s.add(
+            f"rapid-mlx {cur} — can't compare against latest {latest} "
+            "(unrecognized version format); freshness check skipped",
+            CheckStatus.WARN,
+            detail=(
+                f"installed={cur} latest={latest} "
+                f"parsed_installed={pc} parsed_latest={pl}"
+            ),
+        )
+    elif pl > pc:
         info = install_info if install_info is not None else vc.detect_install_method()
         cmd = getattr(info, "upgrade_command", None) or "rapid-mlx upgrade"
         s.add(
@@ -855,9 +870,14 @@ def _rapid_mlx_on_path(path_env: str | None = None) -> list[str]:
     seen: set[str] = set()
     out: list[str] = []
     for d in raw.split(os.pathsep):
-        if not d:
-            continue
-        cand = os.path.join(d, "rapid-mlx")
+        # An empty PATH component means the current directory on POSIX, which
+        # is exactly how ``shutil.which()`` (the function that picks the
+        # *active* rapid-mlx above) resolves it. Skipping it would let a
+        # ``./rapid-mlx`` shadow slip past this very check — the kind of
+        # competing install it exists to surface — so map "" → os.curdir
+        # instead of dropping it.
+        directory = d or os.curdir
+        cand = os.path.join(directory, "rapid-mlx")
         if os.path.isfile(cand) and os.access(cand, os.X_OK):
             target = os.path.realpath(cand)
             if target not in seen:

--- a/vllm_mlx/doctor/env_health.py
+++ b/vllm_mlx/doctor/env_health.py
@@ -508,6 +508,61 @@ def section_required_packages() -> Section:
     return s
 
 
+def section_updates(
+    *,
+    installed: Callable[[], str | None] | None = None,
+    fetch_latest: Callable[[], str | None] | None = None,
+    install_info: object | None = None,
+) -> Section:
+    """Is the installed rapid-mlx the latest release?
+
+    Best-effort and network-bounded — reuses ``_version_check``'s 2 s timeout and
+    cache-first fetch, and warms the same cache the CLI's staleness banner reads.
+    Never fatal: an unknown installed version or an unreachable endpoint
+    downgrades to ⚠ (like the HF network probe), so ``doctor`` never exits
+    non-zero just because the machine is offline.
+    """
+    s = Section("Updates")
+    from vllm_mlx import _version_check as vc
+
+    cur = (installed or vc._installed_version)()
+    if not cur:
+        s.add(
+            "installed rapid-mlx version unknown",
+            CheckStatus.WARN,
+            detail="_installed_version() returned None",
+        )
+        return s
+
+    latest = (fetch_latest or vc.get_latest_version)()
+    if latest is None:
+        s.add(
+            f"rapid-mlx {cur} — couldn't reach the update endpoint (offline?)",
+            CheckStatus.WARN,
+            detail="version endpoint unreachable; freshness check skipped",
+        )
+        return s
+
+    pc, pl = vc._parse_version(cur), vc._parse_version(latest)
+    if pc and pl and pl > pc:
+        info = install_info if install_info is not None else vc.detect_install_method()
+        cmd = getattr(info, "upgrade_command", None) or "rapid-mlx upgrade"
+        s.add(
+            f"update available: {latest} (installed {cur}) — run `{cmd}`",
+            CheckStatus.WARN,
+            detail=(
+                f"installed={cur} latest={latest} method={getattr(info, 'method', '?')}"
+            ),
+        )
+    else:
+        s.add(
+            f"rapid-mlx {cur} is up to date",
+            CheckStatus.OK,
+            detail=f"installed={cur} latest={latest}",
+        )
+    return s
+
+
 def section_optional_packages() -> Section:
     s = Section("Optional Packages")
     for dist, label, hint in OPTIONAL_PACKAGES:
@@ -790,14 +845,36 @@ def _argcomplete_hook_present(
     return False, None
 
 
+def _rapid_mlx_on_path(path_env: str | None = None) -> list[str]:
+    """Every ``rapid-mlx`` executable on PATH, in PATH order, deduped by resolved
+    target. More than one distinct target means competing installs — e.g. a
+    ``curl | bash`` copy in ``~/.local/bin`` shadowing a Homebrew one — where the
+    first on PATH silently wins and upgrades to the others do nothing.
+    """
+    raw = os.environ.get("PATH", "") if path_env is None else path_env
+    seen: set[str] = set()
+    out: list[str] = []
+    for d in raw.split(os.pathsep):
+        if not d:
+            continue
+        cand = os.path.join(d, "rapid-mlx")
+        if os.path.isfile(cand) and os.access(cand, os.X_OK):
+            target = os.path.realpath(cand)
+            if target not in seen:
+                seen.add(target)
+                out.append(cand)
+    return out
+
+
 def section_shell_integration(
     *,
     which: Callable[[str], str | None] | None = None,
     rcs: list[Path] | None = None,
+    find_all: Callable[[], list[str]] | None = None,
 ) -> Section:
     """Verify the CLI is on PATH and argcomplete is wired up.
 
-    ``which`` and ``rcs`` are dependency-injected for tests.
+    ``which``, ``rcs`` and ``find_all`` are dependency-injected for tests.
     """
     s = Section("Shell Integration")
     which_fn = which or shutil.which
@@ -809,6 +886,15 @@ def section_shell_integration(
             CheckStatus.OK,
             detail=f"path={cli_path}",
         )
+        installs = (find_all or _rapid_mlx_on_path)()
+        if len(installs) > 1:
+            active, shadowed = installs[0], installs[1:]
+            s.add(
+                f"rapid-mlx installed in {len(installs)} places — {active} wins on "
+                f"$PATH, {', '.join(shadowed)} shadowed; remove the extra install(s)",
+                CheckStatus.WARN,
+                detail=f"active={active} shadowed={shadowed}",
+            )
     else:
         s.add(
             "rapid-mlx NOT on $PATH",
@@ -878,6 +964,7 @@ _SECTION_BUILDERS = (
     section_system,
     section_python,
     section_required_packages,
+    section_updates,
     section_optional_packages,
     section_hf_cache,
     section_network,


### PR DESCRIPTION
## Why
`rapid-mlx doctor` is already the best-in-class env check for a local inference engine (HW/RAM, ML deps + versions, HF cache, network — none of which codex/claude doctors do). But a side-by-side with `codex doctor` and `claude doctor` surfaced two things they have and we didn't — both cheap, both real footguns for this project:

## What

**1. New `Updates` section — is your rapid-mlx current?**
- Reuses `vllm_mlx/_version_check.py` (`get_latest_version` cache-first + 2 s timeout; warms the same cache the CLI's staleness banner reads).
- On an available update, prints the **install-method-correct** upgrade command (`brew upgrade rapid-mlx` / `pip install -U …` / curl) via `detect_install_method()`.
- Never fatal — unknown installed version or an unreachable endpoint → ⚠, never ✗ (mirrors the HF network probe; air-gapped `doctor` stays exit-0).

**2. Shadowed-install detection in `Shell Integration`**
- Previously only checked `which('rapid-mlx') is not None`. Now scans **all** of PATH, deduped by resolved target.
- Catches the known footgun: a `curl | bash` copy in `~/.local/bin` shadowing a Homebrew install (the Homebrew formula literally ships a caveat about this) — where `rapid-mlx upgrade` on the shadowed copy silently does nothing. Warns with which wins and which are shadowed.

## Tests
- 7 new dependency-injected tests (`installed`/`fetch_latest`/`install_info`, `find_all`, plus a realpath-dedup test for `_rapid_mlx_on_path`). No real network/disk.
- `test_doctor_env_health.py`: **37 passed**; `test_version_check.py` + `test_upgrade_cli.py`: **56 passed**. ruff format + lint clean.
- Updated the run_all order-pinning test to include `Updates`.

## Notes
- Adds one more (bounded, cache-first) network call. Within the ≤5 s doctor budget; cached after first run.
- Deliberately kept out of scope: `--json` output, "problems-first" reordering, `--fix`. Happy to follow up if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)