### PR TITLE
feat(tools): grammar-constrain Qwen3-Coder XML tool-calls (#558 E3, PR-A)

### DIFF
--- a/tests/test_tool_grammar_e3_qwen3coder_558.py
+++ b/tests/test_tool_grammar_e3_qwen3coder_558.py
@@ -1,0 +1,428 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Offline tests for the Qwen3-Coder XML-args grammar body (#558 E3).
+
+E3 extends the #558 grammar builder beyond the JSON-object body
+(``%json <schema>``, used by hermes/qwen/harmony/deepseek-JSON) to the
+XML-argument wire the Qwen3-Coder family emits::
+
+    <tool_call>
+    <function=NAME>
+    <parameter=KEY>
+    VALUE
+    </parameter>
+    </function>
+    </tool_call>
+
+The wire and the per-property XML value rendering are COPIED from the XGrammar
+``qwen_3_coder`` built-in (``style="qwen_xml"``) and verified byte-for-byte
+against the Qwen3-Coder chat template's ``message.tool_calls`` rendering and our
+own ``qwen3coder_tool_parser`` (generation grammar and parser agree).
+
+Two layers:
+
+  * pure-Python BUILDER tests (never skip): ``build_tool_lark`` emits the
+    ``<parameter=...>`` blocks, the shared ``STRVAL``/``INTVAL``/``NUMVAL``
+    terminals, enum alternation, ``%json`` for object/array values, and wraps
+    optional properties ``( ... )?`` — while the JSON path stays byte-identical;
+  * grammar ENFORCEMENT (skip only on genuine tokenizer/llguidance
+    unavailability): a well-formed Qwen3-Coder XML call is ACCEPTED in full and
+    reaches an accepting/terminal state, while a hallucinated function name, an
+    off-schema/undeclared parameter, a bad enum value, a non-integer for an int
+    param, a JSON body instead of XML, and a missing required parameter are all
+    REJECTED mid-stream.
+
+The enforcement tests use the same pinned Qwen tokenizer as
+``tests/test_tool_grammar_558.py`` — its ``<tool_call>``/``</tool_call>`` are
+single special tokens (``<function=``/``<parameter=`` are ordinary text), which
+is exactly the layout the Qwen3-Coder wire needs.
+"""
+
+import importlib.util
+
+import pytest
+
+_HAS_LLGUIDANCE = importlib.util.find_spec("llguidance") is not None
+_requires_llguidance = pytest.mark.skipif(
+    not _HAS_LLGUIDANCE, reason="llguidance ([guided] extra) not installed"
+)
+
+_TOKENIZER_MODEL = "mlx-community/Qwen3.5-4B-MLX-4bit"
+# Pinned (immutable artifact) — same pin as tests/test_tool_grammar_558.py.
+_TOKENIZER_REVISION = "32f3e8ecf65426fc3306969496342d504bfa13f3"
+
+# A representative Qwen3-Coder tool: a required string, an optional string-enum,
+# a required integer, an optional number, a boolean, and an object-typed arg
+# (exercises every value-rule branch).
+WEATHER_TOOL = {
+    "name": "get_weather",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "city": {"type": "string"},
+            "unit": {"type": "string", "enum": ["c", "f"]},
+        },
+        "required": ["city"],
+        "additionalProperties": False,
+    },
+}
+TYPED_TOOL = {
+    "name": "configure",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "count": {"type": "integer"},
+            "ratio": {"type": "number"},
+            "flag": {"type": "boolean"},
+            "meta": {"type": "object", "properties": {"k": {"type": "string"}}},
+        },
+        "required": ["count"],
+        "additionalProperties": False,
+    },
+}
+NOARG_TOOL = {"name": "ping", "parameters": {"type": "object", "properties": {}}}
+
+
+def _qwen_xml_structure_info(name: str):
+    """The Qwen3-Coder XML wire triple, exactly as the real parser ships it."""
+    from vllm_mlx.api.tool_grammar import StructureInfo
+
+    return StructureInfo(
+        begin=f"<tool_call>\n<function={name}>\n",
+        end="</function>\n</tool_call>",
+        trigger="<tool_call>",
+        sentinels=("<tool_call>", "</tool_call>"),
+        arg_format="qwen_xml",
+    )
+
+
+# --------------------------------------------------------------------------
+# BUILDER (pure Python, always runs).
+# --------------------------------------------------------------------------
+def _lark_for(tools, tool_choice="required"):
+    from vllm_mlx.api.tool_grammar import build_tool_lark
+
+    infos = [_qwen_xml_structure_info(t["name"]) for t in tools]
+    return build_tool_lark(tools, tool_choice, infos)
+
+
+def test_qwen_xml_body_emits_parameter_blocks_and_shared_terminals():
+    lark = _lark_for([WEATHER_TOOL])
+    # XML markup, not a JSON object body.
+    assert '"<parameter=city>\\n"' in lark
+    assert '"<parameter=unit>\\n"' in lark
+    # The shared value terminals are declared exactly once.
+    assert lark.count("STRVAL: /[^<]*/") == 1
+    assert "INTVAL:" in lark and "NUMVAL:" in lark
+    # No JSON-object body for an XML tool.
+    assert "%json" not in lark
+
+
+def test_qwen_xml_enum_renders_as_alternation():
+    lark = _lark_for([WEATHER_TOOL])
+    # enum ["c", "f"] -> ("c" | "f") raw-string alternation.
+    assert '"c" | "f"' in lark
+
+
+def test_qwen_xml_optional_property_is_wrapped_optional():
+    lark = _lark_for([WEATHER_TOOL])
+    # ``city`` required (bare), ``unit`` optional -> its block is ``( ... )?``.
+    # The optional wrapper immediately precedes the ``unit`` parameter open.
+    assert '("<parameter=unit>\\n"' in lark
+    assert ")?" in lark
+
+
+def test_qwen_xml_typed_values_use_typed_rules():
+    lark = _lark_for([TYPED_TOOL])
+    assert "INTVAL" in lark  # count: integer
+    assert "NUMVAL" in lark  # ratio: number
+    assert '"true" | "false"' in lark  # flag: boolean
+    # object-typed arg constrains its value with %json of the subschema.
+    assert '%json {"type": "object"' in lark
+
+
+def test_qwen_xml_no_params_emits_empty_body():
+    lark = _lark_for([NOARG_TOOL])
+    # No <parameter=...> block for a no-arg tool; begin/end still present.
+    assert "<parameter=" not in lark
+    assert '"\\n<function=ping>\\n"' in lark
+    assert "</function>" in lark
+
+
+def test_json_arg_format_body_is_unchanged():
+    # Regression guard: a default (json) StructureInfo still emits ``%json`` and
+    # does NOT pull in the XML terminals — the pure-JSON grammar is untouched.
+    from vllm_mlx.api.tool_grammar import StructureInfo, build_tool_lark
+
+    tools = [WEATHER_TOOL]
+    infos = [
+        StructureInfo(
+            begin=f'<tool_call>\n{{"name": "{WEATHER_TOOL["name"]}", "arguments": ',
+            end="}\n</tool_call>",
+            trigger="<tool_call>",
+            sentinels=("<tool_call>", "</tool_call>"),
+        )
+    ]
+    lark = build_tool_lark(tools, "required", infos)
+    assert "%json" in lark
+    assert "STRVAL" not in lark
+    assert "<parameter=" not in lark
+
+
+# --------------------------------------------------------------------------
+# structure_info() on the REAL Qwen3CoderToolParser (pure Python).
+# --------------------------------------------------------------------------
+class _FakeAddedToken:
+    def __init__(self, content, special=False):
+        self.content = content
+        self.special = special
+
+
+class _SingleTokenTokenizer:
+    """Qwen-like: <tool_call>/</tool_call> are distinct single ADDED tokens."""
+
+    def __init__(self):
+        self._added = {"<tool_call>": 100, "</tool_call>": 101}
+        self._id_to_str = {i: s for s, i in self._added.items()}
+        self.added_tokens_decoder = {
+            i: _FakeAddedToken(s) for s, i in self._added.items()
+        }
+
+    def encode(self, text, add_special_tokens=False):
+        return [self._added[text]] if text in self._added else [0, 1]
+
+    def decode(self, ids):
+        return "".join(self._id_to_str.get(i, "<unk>") for i in ids)
+
+    def get_vocab(self):
+        return dict(self._added)
+
+
+def _parser(tokenizer=None):
+    from vllm_mlx.tool_parsers.qwen3coder_tool_parser import Qwen3CoderToolParser
+
+    return Qwen3CoderToolParser(tokenizer=tokenizer)
+
+
+def test_supports_grammar_is_true():
+    from vllm_mlx.tool_parsers.qwen3coder_tool_parser import Qwen3CoderToolParser
+
+    assert Qwen3CoderToolParser.supports_grammar() is True
+
+
+def test_structure_info_opts_out_without_tokenizer():
+    assert _parser(tokenizer=None).structure_info() is None
+
+
+def test_structure_info_opts_out_on_multitoken_tokenizer():
+    class _MT:
+        added_tokens_decoder = {}
+
+        def encode(self, t, add_special_tokens=False):
+            return [0, 1]
+
+        def decode(self, ids):
+            return "<unk>"
+
+        def get_vocab(self):
+            return {}
+
+    assert _parser(tokenizer=_MT()).structure_info() is None
+
+
+def test_structure_info_wire_triple_opts_in():
+    get_info = _parser(tokenizer=_SingleTokenTokenizer()).structure_info()
+    assert callable(get_info)
+    si = get_info("get_weather")
+    assert si.begin == "<tool_call>\n<function=get_weather>\n"
+    assert si.end == "</function>\n</tool_call>"
+    assert si.trigger == "<tool_call>"
+    assert si.sentinels == ("<tool_call>", "</tool_call>")
+    assert si.arg_format == "qwen_xml"
+    # Builder invariants: begin starts with trigger; trigger is a sentinel.
+    assert si.begin.startswith(si.trigger)
+    assert si.trigger in si.sentinels
+
+
+# --------------------------------------------------------------------------
+# Grammar ENFORCEMENT via offline consume (skip only on genuine unavailability).
+# --------------------------------------------------------------------------
+def _offline_skip_exc_types():
+    types: list[type[BaseException]] = []
+    try:
+        from huggingface_hub.errors import (
+            LocalEntryNotFoundError,
+            OfflineModeIsEnabled,
+        )
+
+        types += [LocalEntryNotFoundError, OfflineModeIsEnabled]
+    except Exception:  # pragma: no cover - old hub
+        pass
+    try:
+        from requests.exceptions import ConnectionError as _ReqConnErr
+
+        types.append(_ReqConnErr)
+    except Exception:  # pragma: no cover - requests absent
+        pass
+    return tuple(types) or (OSError,)
+
+
+@pytest.fixture(scope="module")
+def tok():
+    transformers = pytest.importorskip("transformers")
+    try:
+        return transformers.AutoTokenizer.from_pretrained(
+            _TOKENIZER_MODEL, revision=_TOKENIZER_REVISION, use_fast=True
+        )
+    except _offline_skip_exc_types():  # pragma: no cover - offline & uncached
+        pytest.skip(
+            f"tokenizer {_TOKENIZER_MODEL}@{_TOKENIZER_REVISION[:8]} not cached "
+            "and no network — enforcement tests require it"
+        )
+
+
+@pytest.fixture(scope="module")
+def lltok(tok):
+    from vllm_mlx.api.tool_grammar import build_lltokenizer
+
+    built = build_lltokenizer(tok)
+    if built is None:  # pragma: no cover - only if the fast tokenizer is absent
+        pytest.skip("could not build an LLTokenizer for the pinned tokenizer")
+    return built
+
+
+def _consume(grammar, lltok, tok, text):
+    """Advance grammar state token-by-token. Returns (accepted, total, terminal)."""
+    from llguidance.mlx import LLMatcher
+
+    ids = tok.encode(text, add_special_tokens=False)
+    matcher = LLMatcher(lltok, grammar)
+    assert not matcher.get_error(), matcher.get_error()
+    accepted = 0
+    for tid in ids:
+        if not matcher.consume_tokens([tid]):
+            break
+        accepted += 1
+    return accepted, len(ids), matcher.is_accepting()
+
+
+def _grammar():
+    from vllm_mlx.api.tool_grammar import build_tool_grammar
+
+    return build_tool_grammar([WEATHER_TOOL], "required", _optin_parser())
+
+
+def _optin_parser():
+    return _parser(tokenizer=_SingleTokenTokenizer())
+
+
+# A valid, fully-formed Qwen3-Coder XML tool call for get_weather.
+_VALID = (
+    "<tool_call>\n<function=get_weather>\n"
+    "<parameter=city>\nParis\n</parameter>\n"
+    "<parameter=unit>\nc\n</parameter>\n"
+    "</function>\n</tool_call>"
+)
+
+
+@_requires_llguidance
+def test_valid_qwen3coder_xml_accepted_and_terminates(tok, lltok):
+    grammar = _grammar()
+    assert grammar is not None
+    accepted, total, terminal = _consume(grammar, lltok, tok, _VALID)
+    assert accepted == total, f"rejected at {accepted}/{total}"
+    assert terminal, "valid call did not reach an accepting/terminal state"
+
+
+@_requires_llguidance
+def test_valid_call_with_optional_omitted_accepted(tok, lltok):
+    grammar = _grammar()
+    text = (
+        "<tool_call>\n<function=get_weather>\n"
+        "<parameter=city>\nTokyo\n</parameter>\n"
+        "</function>\n</tool_call>"
+    )
+    accepted, total, terminal = _consume(grammar, lltok, tok, text)
+    assert accepted == total and terminal
+
+
+@_requires_llguidance
+def test_reject_missing_close_tool_call(tok, lltok):
+    grammar = _grammar()
+    text = _VALID[: -len("</tool_call>")]  # drop the closing wrapper
+    accepted, total, terminal = _consume(grammar, lltok, tok, text)
+    assert not terminal  # a prefix, not a complete derivation
+
+
+@_requires_llguidance
+def test_reject_json_body_instead_of_xml(tok, lltok):
+    grammar = _grammar()
+    text = (
+        '<tool_call>\n<function=get_weather>\n{"city": "Paris"}\n'
+        "</function>\n</tool_call>"
+    )
+    accepted, total, _ = _consume(grammar, lltok, tok, text)
+    assert accepted < total, "a JSON-object body must be rejected under qwen_xml"
+
+
+@_requires_llguidance
+def test_reject_undeclared_parameter_key(tok, lltok):
+    grammar = _grammar()
+    text = (
+        "<tool_call>\n<function=get_weather>\n"
+        "<parameter=country>\nFR\n</parameter>\n"
+        "</function>\n</tool_call>"
+    )
+    accepted, total, _ = _consume(grammar, lltok, tok, text)
+    assert accepted < total, "an undeclared parameter key must be rejected"
+
+
+@_requires_llguidance
+def test_reject_bad_enum_value(tok, lltok):
+    grammar = _grammar()
+    text = (
+        "<tool_call>\n<function=get_weather>\n"
+        "<parameter=city>\nParis\n</parameter>\n"
+        "<parameter=unit>\nkelvin\n</parameter>\n"
+        "</function>\n</tool_call>"
+    )
+    accepted, total, _ = _consume(grammar, lltok, tok, text)
+    assert accepted < total, "an off-enum value must be rejected"
+
+
+@_requires_llguidance
+def test_reject_missing_required_parameter(tok, lltok):
+    grammar = _grammar()
+    text = (
+        "<tool_call>\n<function=get_weather>\n"
+        "<parameter=unit>\nc\n</parameter>\n"
+        "</function>\n</tool_call>"
+    )
+    accepted, total, _ = _consume(grammar, lltok, tok, text)
+    assert accepted < total, "omitting a required parameter must be rejected"
+
+
+@_requires_llguidance
+def test_reject_hallucinated_function_name(tok, lltok):
+    grammar = _grammar()
+    text = (
+        "<tool_call>\n<function=not_a_tool>\n"
+        "<parameter=city>\nParis\n</parameter>\n"
+        "</function>\n</tool_call>"
+    )
+    accepted, total, _ = _consume(grammar, lltok, tok, text)
+    assert accepted < total, "a hallucinated tool name must be rejected"
+
+
+@_requires_llguidance
+def test_reject_non_integer_for_int_param(tok, lltok):
+    from vllm_mlx.api.tool_grammar import build_tool_grammar
+
+    grammar = build_tool_grammar([TYPED_TOOL], "required", _optin_parser())
+    assert grammar is not None
+    text = (
+        "<tool_call>\n<function=configure>\n"
+        "<parameter=count>\nnot_a_number\n</parameter>\n"
+        "</function>\n</tool_call>"
+    )
+    accepted, total, _ = _consume(grammar, lltok, tok, text)
+    assert accepted < total, "a non-integer for an integer param must be rejected"

--- a/vllm_mlx/api/tool_grammar.py
+++ b/vllm_mlx/api/tool_grammar.py
@@ -99,12 +99,25 @@ class StructureInfo:
     ``ToolParser.structure_info()``. ``sentinels`` lists literal substrings
     inside ``begin``/``end`` that are single special tokens for this family
     and must be emitted as Lark special-token refs, not byte strings.
+
+    ``arg_format`` selects how the tool's JSON Schema is rendered as the
+    grammar BODY between ``begin`` and ``end`` (#558 E3):
+
+      * ``"json"`` (default) — the arguments are a single JSON object,
+        constrained by ``%json <schema>`` (hermes/qwen/harmony/deepseek-JSON).
+      * ``"qwen_xml"`` — the arguments are serialized as Qwen3-Coder XML
+        parameter blocks (``<parameter=key>\\nvalue\\n</parameter>\\n``), one
+        per schema property, with the value grammar-typed per the property's
+        JSON Schema type. This is the XGrammar ``qwen_3_coder`` built-in's
+        ``style="qwen_xml"``; the exact wire is verified byte-for-byte against
+        the Qwen3-Coder chat template and our ``qwen3coder_tool_parser``.
     """
 
     begin: str
     end: str
     trigger: str
     sentinels: tuple[str, ...] = field(default=())
+    arg_format: str = "json"
 
 
 def _is_registered_added_token(tokenizer: Any, tok_id: int) -> bool:
@@ -375,6 +388,99 @@ def _emit_literal_with_sentinels(text: str, sentinels: tuple[str, ...]) -> str:
     return " ".join(p for p in parts if p)
 
 
+# --------------------------------------------------------------------------
+# XML-args body (#558 E3). Shared, once-per-grammar named terminals that the
+# qwen_xml value rules reference. Kept maximal-munch so llguidance's contextual
+# lexer selects the right one per property position:
+#   * ``STRVAL`` — any run of non-``<`` bytes (incl. newlines). It ABSORBS the
+#     value's trailing ``\n`` (the qwen wire is ``<parameter=k>\nVALUE\n</...``),
+#     so a string param's close literal is ``</parameter>\n`` (NO leading ``\n``)
+#     while a typed param's is ``\n</parameter>\n`` — see ``_qwen_xml_param``.
+#     The ``[^<]*`` bound cannot represent a string value containing a literal
+#     ``<`` (a documented, conservative limitation; tool string args rarely do).
+#   * ``INTVAL`` / ``NUMVAL`` — JSON int / number, matching the chat template's
+#     ``args_value | tojson`` rendering of non-string scalars.
+_XML_ARG_TERMINALS = (
+    "STRVAL: /[^<]*/\n"
+    "INTVAL: /-?(0|[1-9][0-9]*)/\n"
+    r"NUMVAL: /-?(0|[1-9][0-9]*)(\.[0-9]+)?([eE][-+]?[0-9]+)?/"
+    "\n"
+)
+
+
+def _qwen_xml_param(key: str, subschema: dict[str, Any]) -> str:
+    """Render ONE Qwen3-Coder XML parameter block as a Lark fragment.
+
+    Wire (verified against the Qwen3-Coder chat template's ``message.tool_calls``
+    rendering and ``qwen3coder_tool_parser``):
+    ``<parameter=KEY>\\n`` + VALUE + ``\\n</parameter>\\n`` — where VALUE is the
+    raw string for a string-typed property, else the property's ``tojson``
+    (int/number/bool/array/object). We grammar-type VALUE per the JSON Schema:
+
+      * enum          -> alternation of the exact enum literals (raw if string,
+                         else its JSON form, matching the template's tojson rule)
+      * integer       -> ``INTVAL``
+      * number        -> ``NUMVAL``
+      * boolean       -> ``"true" | "false"``
+      * object/array  -> ``%json <subschema>`` (the template tojson's these; the
+                         parser ``json.loads`` them back)
+      * string / else -> ``STRVAL`` (permissive fallback for string, missing
+                         type, union types, ``null``, ``anyOf``, …)
+
+    The string path uses a close of ``</parameter>\\n`` because ``STRVAL``
+    (``[^<]*``) is maximal-munch and swallows the value's trailing ``\\n``;
+    every other path keeps the explicit ``\\n</parameter>\\n`` separator.
+    """
+    open_lit = _lark_escape(f"<parameter={key}>\n")
+    close_typed = _lark_escape("\n</parameter>\n")
+    close_str = _lark_escape("</parameter>\n")
+
+    enum_vals = subschema.get("enum") if isinstance(subschema, dict) else None
+    typ = subschema.get("type") if isinstance(subschema, dict) else None
+
+    if enum_vals:
+        # Each enum literal is emitted exactly as the model renders it: raw text
+        # for a string value, its JSON form otherwise (template ``tojson`` rule).
+        alts = " | ".join(
+            _lark_escape(v if isinstance(v, str) else json.dumps(v)) for v in enum_vals
+        )
+        return f"{open_lit} ({alts}) {close_typed}"
+    if typ == "integer":
+        return f"{open_lit} INTVAL {close_typed}"
+    if typ == "number":
+        return f"{open_lit} NUMVAL {close_typed}"
+    if typ == "boolean":
+        return f'{open_lit} ("true" | "false") {close_typed}'
+    if typ in ("object", "array"):
+        return f"{open_lit} %json {json.dumps(subschema)} {close_typed}"
+    # string, missing/union/null type, or anything unrecognized -> permissive.
+    return f"{open_lit} STRVAL {close_str}"
+
+
+def _emit_qwen_xml_args(params: dict[str, Any]) -> str:
+    """Assemble the qwen_xml args BODY (the sequence of ``<parameter=...>``
+    blocks) for one tool's JSON Schema, as a Lark fragment.
+
+    Required properties are mandatory (in schema-declared order); optional ones
+    are each wrapped ``( ... )?``. Emitting in declared order (rather than
+    XGrammar's ``any_order``) is a deliberate first-cut simplification: the
+    constraint GUIDES the model to declared order, which still yields a
+    schema-valid call. A no-property schema returns ``""`` (a bare
+    ``<function=NAME>\\n</function>`` no-arg call).
+    """
+    props = params.get("properties") if isinstance(params, dict) else None
+    if not props:
+        return ""
+    required = set(params.get("required") or [])
+    parts: list[str] = []
+    for key, subschema in props.items():
+        if not isinstance(subschema, dict):
+            subschema = {}
+        block = _qwen_xml_param(key, subschema)
+        parts.append(block if key in required else f"({block})?")
+    return " ".join(parts)
+
+
 def build_tool_lark(
     tools: list[dict[str, Any]],
     tool_choice: str,
@@ -602,6 +708,13 @@ def build_tool_lark(
         )
     prefix_ref = "bal_prefix" if reasoning_pair else "TAG_TEXT"
 
+    # #558 E3: emit the shared XML-args value terminals ONCE if any tag renders
+    # its body as XML (``arg_format != "json"``). Unused terminals compile fine,
+    # so all three are emitted whenever XML is needed; a pure-JSON grammar is
+    # byte-identical to before (no regression).
+    if any(getattr(si, "arg_format", "json") != "json" for si in structure_infos):
+        lark += _XML_ARG_TERMINALS
+
     for i, (tool, si) in enumerate(zip(tools, structure_infos)):
         # Only substitute the default when ``parameters`` is ABSENT. A
         # falsy-but-present schema ({} = allow-any, false = allow-none) is a
@@ -619,10 +732,20 @@ def build_tool_lark(
                 "properties": {},
                 "additionalProperties": False,
             }
-        schema = json.dumps(params)
         begin_body = _emit_literal_with_sentinels(si.begin, si.sentinels)
         end_body = _emit_literal_with_sentinels(si.end, si.sentinels)
-        lark += f"\ntag_{i}: {prefix_ref} {begin_body} %json {schema}"
+        # Body dispatch (#558 E3): JSON-object args -> ``%json <schema>``
+        # (unchanged); XML args -> the family's per-property XML parameter
+        # blocks. An unknown ``arg_format`` degrades to ``%json`` rather than
+        # emitting a broken grammar.
+        arg_format = getattr(si, "arg_format", "json")
+        if arg_format == "qwen_xml":
+            body = _emit_qwen_xml_args(params)
+        else:
+            body = f"%json {json.dumps(params)}"
+        lark += f"\ntag_{i}: {prefix_ref} {begin_body}"
+        if body:
+            lark += f" {body}"
         if end_body:
             lark += f" {end_body}"
         lark += "\n"

--- a/vllm_mlx/tool_parsers/qwen3coder_tool_parser.py
+++ b/vllm_mlx/tool_parsers/qwen3coder_tool_parser.py
@@ -134,6 +134,77 @@ class Qwen3CoderToolParser(ToolParser):
     SUPPORTS_NATIVE_TOOL_FORMAT = True
     EXPECTED_WIRE_FORMATS = ("qwen3_coder_xml_named", "tool_call_xml_body")
 
+    # Grammar-CAPABLE (#558 E3): overrides ``structure_info`` below to emit the
+    # Qwen3-Coder XML-args wire triple. The class-level marker lets the route
+    # gate decide the constrained path is reachable without instantiating the
+    # parser (an oversized schema still 400s here, per #561), mirroring
+    # hermes/qwen/harmony.
+    SUPPORTS_GRAMMAR: bool = True
+
+    # ``<tool_call>`` precedes ONLY tool calls (never plain-text responses), so
+    # auto's zero-call invariant holds — unlike harmony's shared ``<|channel|>``.
+    # Defaults ``True`` (see ``ToolParser.TOOL_GRAMMAR_AUTO_SAFE``); stated
+    # explicitly for discoverability alongside the other grammar flags.
+    TOOL_GRAMMAR_AUTO_SAFE: bool = True
+
+    _GRAMMAR_SENTINELS = ("<tool_call>", "</tool_call>")
+
+    def structure_info(self):
+        """Grammar-constraint wire triple for the Qwen3-Coder XML args (#558 E3).
+
+        Extends #558 constraint coverage from the JSON-body families
+        (hermes/qwen/harmony) to the XML-body Qwen3-Coder wire. The wire the
+        model emits (verified byte-for-byte against the Qwen3-Coder chat
+        template's ``message.tool_calls`` rendering and this parser's regexes)::
+
+            <tool_call>
+            <function=NAME>
+            <parameter=KEY>
+            VALUE
+            </parameter>
+            </function>
+            </tool_call>
+
+        ``begin`` = ``<tool_call>\\n<function=NAME>\\n``, ``end`` =
+        ``</function>\\n</tool_call>``. ``<tool_call>``/``</tool_call>`` are
+        single special tokens on Qwen tokenizers, so they are declared as
+        ``sentinels`` (rendered as Lark special-token refs); ``<function=`` /
+        ``</function>`` / ``<parameter=`` are ordinary multi-token text emitted
+        as byte literals. The per-property XML value bodies are grammar-typed by
+        ``build_tool_lark`` via ``arg_format="qwen_xml"`` (this is the XGrammar
+        ``qwen_3_coder`` built-in's ``style="qwen_xml"`` ported to llguidance).
+
+        As on hermes/qwen, OPT OUT (return ``None`` -> free-form-then-parse
+        fallback) unless the tokenizer proves both sentinels are single special
+        tokens — a special-token sentinel on a tokenizer that encodes
+        ``<tool_call>`` as multi-token text would build an unenforceable grammar.
+        Grammar constraint is a best-effort opt-in, never a hard requirement.
+        """
+        from vllm_mlx.api.tool_grammar import (
+            StructureInfo,
+            are_single_special_tokens,
+        )
+
+        if not are_single_special_tokens(self.model_tokenizer, self._GRAMMAR_SENTINELS):
+            return None
+
+        def _info(name: str):
+            # The tool name is a bare identifier inside the ``<function=NAME>``
+            # tag (NOT JSON-quoted). OpenAI-spec tool names are ``[\w-]+``, so
+            # the raw name is safe as a byte literal. ``begin`` starts with the
+            # ``<tool_call>`` trigger (builder invariant).
+            begin = f"<tool_call>\n<function={name}>\n"
+            end = "</function>\n</tool_call>"
+            return StructureInfo(
+                begin=begin,
+                end=end,
+                trigger="<tool_call>",
+                sentinels=self._GRAMMAR_SENTINELS,
+                arg_format="qwen_xml",
+            )
+
+        return _info
+
     def __init__(self, tokenizer=None):
         super().__init__(tokenizer)
 


### PR DESCRIPTION
## Why

Grammar-constrained tool calling (#558) currently only covers JSON-object arg
families (hermes/qwen/harmony). The Qwen3-Coder family serializes tool arguments
as **XML**, so today it gets no decoder-level guarantee — a low-quant model can
emit an off-schema or malformed call that only fails at parse time. This PR
closes that gap for Qwen3-Coder **because** it is the one XML family with a
locally-available checkpoint, so the XML-args machinery can be proven
end-to-end on real hardware before extending to the other XML families.

## What

Extends the #558 grammar builder beyond the JSON-object body
(`%json <schema>`) to the **XML-argument** wire the Qwen3-Coder family emits.
This is **PR-A** of the E1/E3 rollout (serial; E1 section-wrapper + the other
XML families follow in later PRs since they all edit `tool_grammar.py`).

Constrained wire (per-property XML args):

```
<tool_call>
<function=NAME>
<parameter=KEY>
VALUE
</parameter>
</function>
</tool_call>
```

## Copied from upstream (not invented)

The wire and per-property XML value rendering are copied from the **XGrammar-2
`qwen_3_coder` built-in** (`style="qwen_xml"`) and verified **byte-for-byte**
against the Qwen3-Coder chat template's `message.tool_calls` rendering
(`args_value if string else args_value | tojson`) and our existing parsing-side
`qwen3coder_tool_parser` — so the generation grammar and the parser agree.

## Changes

**`vllm_mlx/api/tool_grammar.py`**
- `StructureInfo` gains `arg_format: str = "json"`. The default reproduces
  today's `%json` body **byte-for-byte** — zero regression for the existing
  JSON-body families (hermes / qwen / harmony).
- `arg_format="qwen_xml"` renders one `<parameter=key>…</parameter>` block per
  schema property with the value grammar-typed per its JSON-Schema type:
  enum → literal alternation, integer → `INTVAL`, number → `NUMVAL`,
  boolean → `"true"|"false"`, object/array → inline `%json <subschema>`,
  string/unknown → `STRVAL` (`[^<]*`). Required props mandatory (declared
  order); optionals wrapped `( … )?`. Shared value terminals emitted once.

**`vllm_mlx/tool_parsers/qwen3coder_tool_parser.py`**
- `Qwen3CoderToolParser.structure_info()` emits the wire triple with
  `arg_format="qwen_xml"`, gated on the tokenizer proving
  `<tool_call>`/`</tool_call>` are single special tokens (opts out to free-form
  otherwise), mirroring hermes/qwen. `SUPPORTS_GRAMMAR` /
  `TOOL_GRAMMAR_AUTO_SAFE` set for route-gate discoverability.

## Testing

`tests/test_tool_grammar_e3_qwen3coder_558.py` (19 tests):
- pure-Python builder tests (parameter blocks, shared terminals, enum
  alternation, typed values, optional wrapping, no-arg body, **JSON-path
  regression guard**);
- llguidance **enforcement** on the pinned Qwen tokenizer: a valid XML call is
  accepted-in-full and reaches a terminal state; missing close / JSON body /
  undeclared key / bad enum / missing required / hallucinated name /
  non-integer are all rejected mid-stream.

Existing 558 suites all pass unchanged (JSON path byte-identical).

## E2E (real model)

Served `mlx-community/Qwen3-Coder-Next-4bit` with `--tool-call-parser
qwen3_coder_xml`:
- `tool_choice=required` produced valid schema-matching XML args parsed to
  `{"city":"Paris","unit":"celsius"}`;
- **3 parallel** tool calls emitted+parsed correctly;
- **constraint provably active**: a nonsense required enum `["korlan","vprix"]`
  on a normal weather question was *forced* to `mode="korlan"` — a value the
  model would never emit unconstrained;
- rough speed ~10.6 tok/s wall (80B-A3B MoE @ 4-bit, incl. prefill+HTTP).

## Known limitation

A string parameter value containing a literal `<` cannot be represented under
the conservative `STRVAL` (`[^<]*`) bound (documented inline); `any_order`
parameter ordering is a deliberate later-cut item (the constraint guides the
model to declared order, which stays schema-valid).

🤖 Generated with [Claude Code](https://claude.com/claude-code)