### PR TITLE
feat(models): add MiniCPM5 MLX support

### DIFF
--- a/scripts/audit_tool_parser_coverage.py
+++ b/scripts/audit_tool_parser_coverage.py
@@ -92,6 +92,10 @@ MATRIX_EXEMPT: dict[str, str] = {
     "functionary": "TODO: add Functionary-medium model to golden_models",
     "xlam": "TODO: add xLAM model to golden_models",
     "seed_oss": "TODO: add Seed-OSS model to golden_models",
+    "minicpm": (
+        "TODO(#1139): add MiniCPM5 to the live matrix when capacity permits; "
+        "its native XML wire format is covered by parser and stream-parity tests."
+    ),
     "hy_v3": (
         "TODO: add Hy3-preview-4bit to golden_models once we secure a "
         "192 GB+ M3 Ultra CI slot (166 GB weights, Ultra-only launch; "

--- a/tests/test_aliases_contract.py
+++ b/tests/test_aliases_contract.py
@@ -35,6 +35,7 @@ from vllm_mlx.model_aliases import (
     VALID_SUFFIX_TIERS,
     list_profiles,
 )
+from vllm_mlx.model_auto_config import detect_model_config
 from vllm_mlx.reasoning import list_parsers as list_reasoning_parsers
 from vllm_mlx.tool_parsers import ToolParserManager
 
@@ -87,6 +88,18 @@ def _raw_aliases() -> dict[str, dict | str]:
 def _alias_ids() -> list[str]:
     """Stable alias name list for ``parametrize`` IDs."""
     return sorted(_raw_aliases().keys())
+
+
+def test_minicpm5_aliases_pin_the_verified_native_xml_contract() -> None:
+    """The two #1139 artifacts share MiniCPM5's native tool-call wire format."""
+    profiles = list_profiles()
+    for alias in ("minicpm5-1b-4bit", "minicpm5-1b-optiq-4bit"):
+        profile = profiles[alias]
+        assert profile.tool_call_parser == "minicpm"
+        assert profile.reasoning_parser == "qwen3"
+        assert profile.supports_spec_decode is False
+        assert detect_model_config(alias) == profile
+        assert detect_model_config(profile.hf_path) == profile
 
 
 # =============================================================================

--- a/tests/test_minicpm_tool_parser.py
+++ b/tests/test_minicpm_tool_parser.py
@@ -118,6 +118,82 @@ def test_invalid_self_closed_function_does_not_hide_next_tool_call() -> None:
     assert _arguments(result.tool_calls[0]) == {"city": "Paris"}
 
 
+def test_malformed_outer_opener_does_not_swallow_a_nested_valid_call() -> None:
+    """An unclosed ``<function>`` must not consume a later call's close tag.
+
+    ``_function_end`` binds the single ``</function>`` to the outer opener,
+    ``ET.fromstring`` then fails on the malformed span; the scanner must
+    resynchronize at the next opener instead of skipping past the nested
+    well-formed call.
+    """
+    result = MiniCPMToolParser().extract_tool_calls(
+        '<function name="outer"><function name="inner">'
+        '<param name="city">Paris</param></function>',
+        _request(),
+    )
+
+    assert result.tools_called is True
+    assert [call["name"] for call in result.tool_calls] == ["inner"]
+    assert _arguments(result.tool_calls[0]) == {"city": "Paris"}
+
+
+def test_valid_call_after_an_unterminated_opener_is_recovered() -> None:
+    """A dangling opener with no close must not abandon later valid calls."""
+    result = MiniCPMToolParser().extract_tool_calls(
+        '<function name="broken"<function name="ok">'
+        '<param name="city">Rome</param></function>',
+        _request(),
+    )
+
+    assert result.tools_called is True
+    assert [call["name"] for call in result.tool_calls] == ["ok"]
+    assert _arguments(result.tool_calls[0]) == {"city": "Rome"}
+
+
+def test_function_tag_inside_unterminated_cdata_is_not_a_tool_call() -> None:
+    """A complete ``<function>`` literal in a still-open CDATA stays data.
+
+    Resynchronization after the outer opener (whose CDATA has no ``]]>``)
+    must not scan into that CDATA and fabricate an executable call from a
+    string literal — everything after the unterminated CDATA is held.
+    """
+    parser = MiniCPMToolParser()
+    text = (
+        '<function name="outer"><param name="x">'
+        '<![CDATA[<function name="evil"></function>'
+    )
+
+    result = parser.extract_tool_calls(text)
+    assert result.tools_called is False
+    assert result.tool_calls == []
+    assert result.content == text
+    # Streaming holds the whole in-flight call; no markup leaks as content.
+    assert parser.extract_tool_calls_streaming("", text, text) is None
+
+
+def test_function_tag_inside_terminated_cdata_is_a_param_value_not_a_call() -> None:
+    """A closed CDATA carrying a ``<function>`` literal is the param value."""
+    result = MiniCPMToolParser().extract_tool_calls(
+        '<function name="a"><param name="x">'
+        '<![CDATA[<function name="evil"></function>]]></param></function>'
+    )
+    assert [call["name"] for call in result.tool_calls] == ["a"]
+    assert _arguments(result.tool_calls[0]) == {
+        "x": '<function name="evil"></function>'
+    }
+
+
+def test_whitespace_padded_param_name_is_stripped_to_the_schema_key() -> None:
+    """Padded ``name`` attributes normalize like the stripped function name."""
+    result = MiniCPMToolParser().extract_tool_calls(
+        '<function name="weather"><param name=" days ">3</param></function>',
+        _request(),
+    )
+
+    assert result.tools_called is True
+    assert _arguments(result.tool_calls[0]) == {"days": 3}
+
+
 def test_streaming_holds_partial_xml_and_emits_each_completed_call_once() -> None:
     parser = MiniCPMToolParser()
     first = 'Intro <function name="weather"><param name="city">San'
@@ -176,6 +252,59 @@ def test_streaming_flushes_partial_opener_after_completed_tool_call() -> None:
     assert event is not None
     assert event["tool_calls"][0]["function"]["name"] == "weather"
     assert parser.flush_held_content(text) == "<fun"
+
+
+def test_streaming_does_not_leak_outer_markup_when_cdata_holds_a_function_tag() -> None:
+    """A ``<function`` inside an unterminated CDATA must not become the hold point.
+
+    ``rfind`` would latch onto the CDATA occurrence and emit the outer
+    opener as content mid-call; the forward CDATA-aware scan holds from the
+    real outer opener so nothing leaks until the call completes.
+    """
+    parser = MiniCPMToolParser()
+    partial = '<function name="run"><param name="cmd"><![CDATA[echo <function'
+
+    assert parser.has_pending_tool_call(partial) is True
+    # Held from the outer opener at index 0 -> no content leaks.
+    assert parser.extract_tool_calls_streaming("", partial, partial) is None
+
+    full = partial + "]]></param></function>"
+    event = parser.extract_tool_calls_streaming(
+        partial, full, full[len(partial) :], request=_request()
+    )
+    assert event is not None
+    assert event["tool_calls"][0]["function"]["name"] == "run"
+    assert _arguments(event["tool_calls"][0]["function"]) == {"cmd": "echo <function"}
+
+
+def test_streaming_recovers_call_after_malformed_opener_matching_batch() -> None:
+    """Malformed-opener recovery must be identical streaming vs. one-shot."""
+    parser = MiniCPMToolParser()
+    text = (
+        '<function name="broken"<function name="ok">'
+        '<param name="city">Rome</param></function>'
+    )
+    batch = MiniCPMToolParser().extract_tool_calls(text, _request())
+
+    event = parser.extract_tool_calls_streaming("", text, text, request=_request())
+    assert event is not None
+    assert (
+        [tc["function"]["name"] for tc in event["tool_calls"]]
+        == [c["name"] for c in batch.tool_calls]
+        == ["ok"]
+    )
+    assert _arguments(event["tool_calls"][0]["function"]) == {"city": "Rome"}
+
+
+def test_flush_matches_streaming_residual_not_raw_text() -> None:
+    """Final flush is computed from the same call-stripped residual as streaming."""
+    parser = MiniCPMToolParser()
+    # Completed call + trailing partial opener: flush releases only the tail.
+    text = '<function name="weather"><param name="city">Rome</param></function><fun'
+    assert parser.flush_held_content(text) == "<fun"
+    # No pending opener after a fully-formed call: nothing to release.
+    done = '<function name="weather"><param name="city">Rome</param></function> done'
+    assert parser.flush_held_content(done) == ""
 
 
 def test_streaming_content_and_final_flush_behave_like_plain_text() -> None:

--- a/tests/test_minicpm_tool_parser.py
+++ b/tests/test_minicpm_tool_parser.py
@@ -1,0 +1,210 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Focused contract tests for MiniCPM5's native XML tool-call format."""
+
+from __future__ import annotations
+
+import json
+
+from vllm_mlx.tool_parsers import MiniCPMToolParser, ToolParserManager
+
+
+def _request() -> dict:
+    return {
+        "tools": [
+            {
+                "type": "function",
+                "function": {
+                    "name": "weather",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "city": {"type": "string"},
+                            "days": {"type": "integer"},
+                            "alerts": {"type": "boolean"},
+                            "filters": {"type": "object"},
+                        },
+                    },
+                },
+            }
+        ]
+    }
+
+
+def _arguments(call: dict) -> dict:
+    return json.loads(call["arguments"])
+
+
+def test_registry_and_wire_format_declaration() -> None:
+    assert ToolParserManager.get_tool_parser("minicpm") is MiniCPMToolParser
+    assert MiniCPMToolParser.EXPECTED_WIRE_FORMATS == ("minicpm_native",)
+    assert MiniCPMToolParser.SUPPORTS_NATIVE_TOOL_FORMAT is True
+
+
+def test_extracts_documented_xml_and_normalizes_schema_types() -> None:
+    parser = MiniCPMToolParser()
+    result = parser.extract_tool_calls(
+        '<function name="weather">\n'
+        '<param name="city"><![CDATA[San Francisco & Bay]]></param>\n'
+        '<param name="days">3</param>\n'
+        '<param name="alerts">true</param>\n'
+        '<param name="filters">{"uv":true}</param>\n'
+        "</function>",
+        _request(),
+    )
+
+    assert result.tools_called is True
+    assert result.content is None
+    assert result.tool_calls[0]["name"] == "weather"
+    assert _arguments(result.tool_calls[0]) == {
+        "city": "San Francisco & Bay",
+        "days": 3,
+        "alerts": True,
+        "filters": {"uv": True},
+    }
+
+
+def test_cdata_value_can_contain_a_literal_function_close_tag() -> None:
+    result = MiniCPMToolParser().extract_tool_calls(
+        '<function name="weather"><param name="city"><![CDATA[before '
+        "</function> after]]></param></function>"
+    )
+
+    assert result.tools_called is True
+    assert _arguments(result.tool_calls[0]) == {"city": "before </function> after"}
+
+
+def test_preserves_non_tool_content_and_wire_order() -> None:
+    parser = MiniCPMToolParser()
+    result = parser.extract_tool_calls(
+        'Before <function name="first"><param name="x">one</param></function>'
+        ' between <function name="second"></function> after'
+    )
+
+    assert result.tools_called is True
+    assert [call["name"] for call in result.tool_calls] == ["first", "second"]
+    assert _arguments(result.tool_calls[0]) == {"x": "one"}
+    assert _arguments(result.tool_calls[1]) == {}
+    assert result.content == "Before  between  after"
+
+
+def test_rejects_invalid_or_incomplete_markup_without_losing_content() -> None:
+    parser = MiniCPMToolParser()
+    for text in (
+        "No tool call here.",
+        '<functionality name="not-a-tool"></functionality>',
+        '<function name="bad"><param name="x">1</param>',
+        '<function name="bad"><param name="x"><![CDATA[1</function>',
+        '<function name="bad"><param name="x">a & b</param></function>',
+        '<function name="bad" extra="nope"><param name="x">1</param></function>',
+        '<function name="bad"><param name="x">1</param><param name="x">2</param></function>',
+        '<function name="bad"><param name="x"><nested /></param></function>',
+    ):
+        result = parser.extract_tool_calls(text)
+        assert result.tools_called is False
+        assert result.tool_calls == []
+        assert result.content == text
+
+
+def test_invalid_self_closed_function_does_not_hide_next_tool_call() -> None:
+    result = MiniCPMToolParser().extract_tool_calls(
+        '<function/><function name="weather"><param name="city">Paris</param>'
+        "</function>",
+        _request(),
+    )
+
+    assert result.tools_called is True
+    assert result.content == "<function/>"
+    assert result.tool_calls[0]["name"] == "weather"
+    assert _arguments(result.tool_calls[0]) == {"city": "Paris"}
+
+
+def test_streaming_holds_partial_xml_and_emits_each_completed_call_once() -> None:
+    parser = MiniCPMToolParser()
+    first = 'Intro <function name="weather"><param name="city">San'
+    second = first + " Francisco</param></function>"
+    third = (
+        second + '<function name="weather"><param name="city">Paris</param></function>'
+    )
+
+    assert parser.extract_tool_calls_streaming(
+        "", first, first, request=_request()
+    ) == {"content": "Intro "}
+    first_event = parser.extract_tool_calls_streaming(
+        first, second, second[len(first) :], request=_request()
+    )
+    assert first_event is not None
+    assert _arguments(first_event["tool_calls"][0]["function"]) == {
+        "city": "San Francisco"
+    }
+    second_event = parser.extract_tool_calls_streaming(
+        second, third, third[len(second) :], request=_request()
+    )
+    assert second_event is not None
+    assert second_event["tool_calls"][0]["index"] == 1
+    assert second_event["tool_calls"][0]["function"]["name"] == "weather"
+    assert _arguments(second_event["tool_calls"][0]["function"]) == {"city": "Paris"}
+
+
+def test_streaming_keeps_text_adjacent_to_valid_and_invalid_markup() -> None:
+    parser = MiniCPMToolParser()
+    complete = (
+        '<function name="weather"><param name="city">Paris</param></function> after'
+    )
+    event = parser.extract_tool_calls_streaming(
+        "", complete, complete, request=_request()
+    )
+    assert event is not None
+    assert event["content"] == " after"
+
+    partial = "Text <fun"
+    assert parser.extract_tool_calls_streaming("", partial, partial) == {
+        "content": "Text "
+    }
+    assert parser.flush_held_content(partial) == "<fun"
+    malformed = partial + 'ction name="weather" extra="bad"></function>'
+    assert parser.extract_tool_calls_streaming(
+        partial, malformed, malformed[len(partial) :]
+    ) == {"content": '<function name="weather" extra="bad"></function>'}
+
+
+def test_streaming_flushes_partial_opener_after_completed_tool_call() -> None:
+    parser = MiniCPMToolParser()
+    text = '<function name="weather"></function><fun'
+
+    event = parser.extract_tool_calls_streaming("", text, text, request=_request())
+
+    assert event is not None
+    assert event["tool_calls"][0]["function"]["name"] == "weather"
+    assert parser.flush_held_content(text) == "<fun"
+
+
+def test_streaming_content_and_final_flush_behave_like_plain_text() -> None:
+    parser = MiniCPMToolParser()
+    assert parser.extract_tool_calls_streaming("", "Hello", "Hello") == {
+        "content": "Hello"
+    }
+    partial = 'Hello <function name="weather"'
+    assert parser.extract_tool_calls_streaming("Hello", partial, partial[5:]) == {
+        "content": " "
+    }
+    assert parser.has_pending_tool_call(partial) is True
+    assert parser.flush_held_content(partial) == '<function name="weather"'
+    assert parser.extract_tool_calls_streaming("wrong", "revised", "revised") == {
+        "content": "revised"
+    }
+    assert parser.has_pending_tool_call("<functionality>") is False
+    assert (
+        parser.has_pending_tool_call('<function name="complete"></function>') is False
+    )
+    assert parser.flush_held_content("complete text") == ""
+    assert parser.extract_tool_calls_streaming(
+        "stale", 'Fresh <function name="weather"', 'Fresh <function name="weather"'
+    ) == {"content": "Fresh "}
+    revised = (
+        '<function name="weather"><param name="city">Rome</param></function> after'
+    )
+    event = parser.extract_tool_calls_streaming(
+        "stale", revised, revised, request=_request()
+    )
+    assert event is not None
+    assert event["content"] == " after"

--- a/tests/test_tool_call_streaming_parity.py
+++ b/tests/test_tool_call_streaming_parity.py
@@ -144,6 +144,13 @@ def _extract_stream(parser_name: str, text: str) -> list:
 # concrete example).
 # --------------------------------------------------------------------------
 PARITY_FIXTURES: list = [
+    # MiniCPM5 — documented native XML without a <tool_call> wrapper.
+    (
+        "minicpm",
+        "minicpm_native",
+        '<function name="read_file"><param name="path">/etc/hostname</param></function>',
+        [("read_file", {"path": "/etc/hostname"})],
+    ),
     # hermes — JSON body inside <tool_call>...</tool_call>
     (
         "hermes",

--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -1698,5 +1698,21 @@
     "reasoning_parser": null,
     "is_hybrid": false,
     "supports_spec_decode": false
+  },
+  "minicpm5-1b-4bit": {
+    "hf_path": "openbmb/MiniCPM5-1B-MLX",
+    "tool_call_parser": "minicpm",
+    "reasoning_parser": "qwen3",
+    "is_hybrid": false,
+    "is_moe": false,
+    "supports_spec_decode": false
+  },
+  "minicpm5-1b-optiq-4bit": {
+    "hf_path": "mlx-community/MiniCPM5-1B-OptiQ-4bit",
+    "tool_call_parser": "minicpm",
+    "reasoning_parser": "qwen3",
+    "is_hybrid": false,
+    "is_moe": false,
+    "supports_spec_decode": false
   }
 }

--- a/vllm_mlx/tool_parsers/__init__.py
+++ b/vllm_mlx/tool_parsers/__init__.py
@@ -65,6 +65,7 @@ from .hy_v3_tool_parser import HyV3ToolParser
 from .kimi_tool_parser import KimiToolParser
 from .lfm_tool_parser import LfmToolParser
 from .llama_tool_parser import LlamaToolParser
+from .minicpm_tool_parser import MiniCPMToolParser
 from .minimax_tool_parser import MiniMaxToolParser
 from .mistral_tool_parser import MistralToolParser
 from .nemotron_tool_parser import NemotronToolParser
@@ -96,6 +97,7 @@ __all__ = [
     "Glm47ToolParser",
     "HarmonyToolParser",
     "HyV3ToolParser",
+    "MiniCPMToolParser",
     "MiniMaxToolParser",
     "SeedOssToolParser",
     "DeepSeekV3ToolParser",

--- a/vllm_mlx/tool_parsers/abstract_tool_parser.py
+++ b/vllm_mlx/tool_parsers/abstract_tool_parser.py
@@ -98,6 +98,8 @@ class ExtractedToolCallInformation:
 #                           ``<tool_call>NAME</arg_value>`` malformed-close
 #                           fallback for 4-bit numerical noise on the
 #                           preview checkpoint.
+#   minicpm_native        — <function name="NAME"><param name="KEY">VALUE
+#                           </param></function>  (MiniCPM5 XML tool contract)
 WIRE_FORMAT_LABELS: frozenset[str] = frozenset(
     {
         "tool_call_json",
@@ -122,6 +124,7 @@ WIRE_FORMAT_LABELS: frozenset[str] = frozenset(
         "qwen3_coder_xml_named",
         "ui_tars_action",
         "hy3_native",
+        "minicpm_native",
     }
 )
 

--- a/vllm_mlx/tool_parsers/minicpm_tool_parser.py
+++ b/vllm_mlx/tool_parsers/minicpm_tool_parser.py
@@ -32,10 +32,6 @@ class MiniCPMToolParser(ToolParser):
     SUPPORTS_NATIVE_TOOL_FORMAT = True
     EXPECTED_WIRE_FORMATS = ("minicpm_native",)
 
-    def __init__(self, tokenizer=None):
-        super().__init__(tokenizer)
-        self._streamed_call_count = 0
-
     @staticmethod
     def _is_function_opener(text: str, start: int) -> bool:
         """Avoid treating ordinary words such as ``<functionality>`` as XML."""
@@ -62,6 +58,31 @@ class MiniCPMToolParser(ToolParser):
             cursor = cdata_end + len(_CDATA_CLOSE)
 
     @classmethod
+    def _next_opener_outside_cdata(cls, text: str, pos: int) -> int:
+        """Index of the next ``<function`` at/after ``pos`` outside CDATA, or -1.
+
+        Resynchronization after a malformed opener must never land on a
+        ``<function`` that lives inside a CDATA *value* — that text is data,
+        not markup, and parsing it would fabricate an executable tool call
+        from a string literal. Skips over terminated CDATA sections; an
+        unterminated CDATA swallows the rest of the text, so nothing valid
+        can follow and we report -1.
+        """
+        i = pos
+        while True:
+            opener = text.find(_OPEN, i)
+            if opener == -1:
+                return -1
+            cdata = text.find(_CDATA_OPEN, i)
+            if cdata != -1 and cdata < opener:
+                cdata_end = text.find(_CDATA_CLOSE, cdata + len(_CDATA_OPEN))
+                if cdata_end == -1:
+                    return -1
+                i = cdata_end + len(_CDATA_CLOSE)
+                continue
+            return opener
+
+    @classmethod
     def _blocks(cls, text: str) -> Iterator[tuple[int, int, ET.Element]]:
         """Yield complete, well-formed native call elements in wire order."""
         cursor = 0
@@ -72,11 +93,24 @@ class MiniCPMToolParser(ToolParser):
 
             end = cls._function_end(text, start)
             if end is None:
+                # No complete close for this opener: either no ``</function>``
+                # at all, or an unterminated CDATA that swallows the rest of
+                # the text. In both cases no complete call can follow, and
+                # scanning forward would risk parsing CDATA data as markup —
+                # so stop.
                 return
             try:
                 element = ET.fromstring(text[start:end])
             except ET.ParseError:
-                cursor = end
+                # ``_function_end`` may have bound a *later* call's close tag
+                # to this malformed opener (e.g. a nested ``<function>``).
+                # Resync at the next opener that is NOT inside a CDATA value
+                # so the nested/later valid call is recovered without ever
+                # treating CDATA data as a tool call.
+                nxt = cls._next_opener_outside_cdata(text, start + len(_OPEN))
+                if nxt == -1:
+                    return
+                cursor = nxt
                 continue
             yield start, end, element
             cursor = end
@@ -98,12 +132,16 @@ class MiniCPMToolParser(ToolParser):
 
         arguments: dict[str, str] = {}
         for param in element:
-            param_name = param.get("name")
+            raw_name = param.get("name")
+            # Strip before both duplicate detection and insertion so a
+            # whitespace-padded name maps to the same schema key that type
+            # normalization looks up — mirrors the ``name.strip()`` applied
+            # to the function name above.
+            param_name = raw_name.strip() if isinstance(raw_name, str) else None
             if (
                 param.tag != "param"
                 or set(param.attrib) != {"name"}
-                or not isinstance(param_name, str)
-                or not param_name.strip()
+                or not param_name
                 or param_name in arguments
                 or len(param)
                 or (param.tail or "").strip()
@@ -141,13 +179,31 @@ class MiniCPMToolParser(ToolParser):
 
     @classmethod
     def _incomplete_start(cls, text: str) -> int | None:
-        """Return a partial native-call opener that must stay out of SSE text."""
+        """Index of the outermost pending native opener, or ``None``.
+
+        Everything from this index onward is in-flight tool markup that
+        must stay out of streamed content until the call completes (or is
+        proven invalid). Scans forward and is CDATA-aware via
+        ``_function_end``: a ``<function`` substring inside an unterminated
+        CDATA value belongs to the enclosing call, not a new opener, so the
+        outer markup is never mistaken for the pending opener and leaked as
+        SSE content mid-call. Returns the FIRST opener with no complete
+        close (``rfind`` would pick an inner CDATA occurrence instead).
+        """
+        cursor = 0
+        while (start := text.find(_OPEN, cursor)) != -1:
+            if not cls._is_function_opener(text, start):
+                cursor = start + len(_OPEN)
+                continue
+            end = cls._function_end(text, start)
+            if end is None:
+                return start
+            cursor = end
+        # No full opener pending: a trailing partial prefix ("<", "<f",
+        # "<fun", …) could still grow into an opener, so hold it too.
         for length in range(min(len(_OPEN) - 1, len(text)), 0, -1):
             if text.endswith(_OPEN[:length]):
                 return len(text) - length
-        start = text.rfind(_OPEN)
-        if start != -1 and cls._is_function_opener(text, start):
-            return start if cls._function_end(text, start) is None else None
         return None
 
     @classmethod
@@ -156,16 +212,19 @@ class MiniCPMToolParser(ToolParser):
         start = cls._incomplete_start(text)
         return text if start is None else text[:start]
 
-    def reset(self) -> None:
-        super().reset()
-        self._streamed_call_count = 0
-
     def has_pending_tool_call(self, text: str) -> bool:
         return self._incomplete_start(text) is not None
 
     def flush_held_content(self, full_text: str) -> str:
-        start = self._incomplete_start(full_text)
-        return full_text[start:] if start is not None else ""
+        # Release exactly what streaming withheld: compute the held tail
+        # from the call-stripped residual (``_parsed(...)[1]``, the same
+        # representation ``_safe_content_prefix`` runs on during
+        # streaming) rather than the raw text. A raw-text scan could drop
+        # a malformed residual that streaming held, or re-release bytes
+        # that belong to an already-completed call.
+        _, residual = self._parsed(full_text, None)
+        start = self._incomplete_start(residual)
+        return residual[start:] if start is not None else ""
 
     def extract_tool_calls(
         self, model_output: str, request: dict[str, Any] | None = None
@@ -187,16 +246,26 @@ class MiniCPMToolParser(ToolParser):
         delta_token_ids: Sequence[int] | None = None,
         request: dict[str, Any] | None = None,
     ) -> dict[str, Any] | None:
-        if not previous_text or not current_text.startswith(previous_text):
-            self.reset()
-
+        # De-duplicate emitted calls statelessly: derive the count of
+        # already-streamed calls from ``previous_text`` on every delta
+        # rather than caching a running counter. This mirrors
+        # ``HermesToolParser`` (which recomputes ``prev_completed`` from
+        # ``previous_text``) and is what makes a non-monotonic prefix
+        # revision safe — with no counter to reset, a call that
+        # ``previous_text`` already contains can never be re-emitted, so
+        # an SSE client cannot execute the same tool twice. The
+        # postprocessor drives this method with strictly append-only
+        # accumulated text (``current = previous + delta``), so the two
+        # ``_parsed`` scans stay within the established ABC streaming
+        # contract; tool-call bodies are bounded, so the re-scan is
+        # dominated by decode cost, same as every sibling parser.
+        previous_calls, previous_content = self._parsed(previous_text, request)
         calls, current_content = self._parsed(current_text, request)
-        _, previous_content = self._parsed(previous_text, request)
         safe_current = self._safe_content_prefix(current_content)
         safe_previous = self._safe_content_prefix(previous_content)
-        new_calls = calls[self._streamed_call_count :]
+        already_emitted = len(previous_calls)
+        new_calls = calls[already_emitted:]
         if new_calls:
-            self._streamed_call_count = len(calls)
             event: dict[str, Any] = {
                 "tool_calls": [
                     {
@@ -208,9 +277,7 @@ class MiniCPMToolParser(ToolParser):
                             "arguments": call["arguments"],
                         },
                     }
-                    for index, call in enumerate(
-                        new_calls, self._streamed_call_count - len(new_calls)
-                    )
+                    for index, call in enumerate(new_calls, already_emitted)
                 ]
             }
             if safe_current.startswith(safe_previous):

--- a/vllm_mlx/tool_parsers/minicpm_tool_parser.py
+++ b/vllm_mlx/tool_parsers/minicpm_tool_parser.py
@@ -1,0 +1,228 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tool-call parser for MiniCPM5's documented native XML format."""
+
+from __future__ import annotations
+
+import uuid
+import xml.etree.ElementTree as ET
+from collections.abc import Iterator, Sequence
+from typing import Any
+
+from ..api.tool_calling import _serialize_tool_arguments
+from .abstract_tool_parser import (
+    ExtractedToolCallInformation,
+    ToolParser,
+    ToolParserManager,
+)
+
+_OPEN = "<function"
+_CLOSE = "</function>"
+_CDATA_OPEN = "<![CDATA["
+_CDATA_CLOSE = "]]>"
+
+
+def _tool_id() -> str:
+    return f"call_{uuid.uuid4().hex[:8]}"
+
+
+@ToolParserManager.register_module("minicpm")
+class MiniCPMToolParser(ToolParser):
+    """Parse ``<function name=...><param name=...>...</param></function>``."""
+
+    SUPPORTS_NATIVE_TOOL_FORMAT = True
+    EXPECTED_WIRE_FORMATS = ("minicpm_native",)
+
+    def __init__(self, tokenizer=None):
+        super().__init__(tokenizer)
+        self._streamed_call_count = 0
+
+    @staticmethod
+    def _is_function_opener(text: str, start: int) -> bool:
+        """Avoid treating ordinary words such as ``<functionality>`` as XML."""
+        end = start + len(_OPEN)
+        return end == len(text) or text[end].isspace() or text[end] in ">/"
+
+    @staticmethod
+    def _function_end(text: str, start: int) -> int | None:
+        """Find the native close tag without mistaking CDATA data for markup."""
+        cursor = start + len(_OPEN)
+        opener_end = text.find(">", cursor)
+        if opener_end != -1 and text[opener_end - 1] == "/":
+            return opener_end + 1
+        while True:
+            close = text.find(_CLOSE, cursor)
+            if close == -1:
+                return None
+            cdata = text.find(_CDATA_OPEN, cursor)
+            if cdata == -1 or close < cdata:
+                return close + len(_CLOSE)
+            cdata_end = text.find(_CDATA_CLOSE, cdata + len(_CDATA_OPEN))
+            if cdata_end == -1:
+                return None
+            cursor = cdata_end + len(_CDATA_CLOSE)
+
+    @classmethod
+    def _blocks(cls, text: str) -> Iterator[tuple[int, int, ET.Element]]:
+        """Yield complete, well-formed native call elements in wire order."""
+        cursor = 0
+        while (start := text.find(_OPEN, cursor)) != -1:
+            if not cls._is_function_opener(text, start):
+                cursor = start + len(_OPEN)
+                continue
+
+            end = cls._function_end(text, start)
+            if end is None:
+                return
+            try:
+                element = ET.fromstring(text[start:end])
+            except ET.ParseError:
+                cursor = end
+                continue
+            yield start, end, element
+            cursor = end
+
+    @staticmethod
+    def _call_from_element(
+        element: ET.Element, request: dict[str, Any] | None
+    ) -> dict[str, Any] | None:
+        """Validate one documented element and normalize it to OpenAI JSON."""
+        name = element.get("name")
+        if (
+            element.tag != "function"
+            or set(element.attrib) != {"name"}
+            or not isinstance(name, str)
+            or not name.strip()
+            or (element.text or "").strip()
+        ):
+            return None
+
+        arguments: dict[str, str] = {}
+        for param in element:
+            param_name = param.get("name")
+            if (
+                param.tag != "param"
+                or set(param.attrib) != {"name"}
+                or not isinstance(param_name, str)
+                or not param_name.strip()
+                or param_name in arguments
+                or len(param)
+                or (param.tail or "").strip()
+            ):
+                return None
+            arguments[param_name] = param.text or ""
+
+        return {
+            "id": _tool_id(),
+            "name": name.strip(),
+            "arguments": _serialize_tool_arguments(arguments, name.strip(), request),
+        }
+
+    @classmethod
+    def _parsed(
+        cls, text: str, request: dict[str, Any] | None
+    ) -> tuple[list[dict[str, Any]], str]:
+        calls: list[dict[str, Any]] = []
+        spans: list[tuple[int, int]] = []
+        for start, end, element in cls._blocks(text):
+            call = cls._call_from_element(element, request)
+            if call is not None:
+                calls.append(call)
+                spans.append((start, end))
+
+        if not spans:
+            return calls, text
+        content: list[str] = []
+        cursor = 0
+        for start, end in spans:
+            content.append(text[cursor:start])
+            cursor = end
+        content.append(text[cursor:])
+        return calls, "".join(content)
+
+    @classmethod
+    def _incomplete_start(cls, text: str) -> int | None:
+        """Return a partial native-call opener that must stay out of SSE text."""
+        for length in range(min(len(_OPEN) - 1, len(text)), 0, -1):
+            if text.endswith(_OPEN[:length]):
+                return len(text) - length
+        start = text.rfind(_OPEN)
+        if start != -1 and cls._is_function_opener(text, start):
+            return start if cls._function_end(text, start) is None else None
+        return None
+
+    @classmethod
+    def _safe_content_prefix(cls, text: str) -> str:
+        """Return the part of an SSE prefix known not to be native markup."""
+        start = cls._incomplete_start(text)
+        return text if start is None else text[:start]
+
+    def reset(self) -> None:
+        super().reset()
+        self._streamed_call_count = 0
+
+    def has_pending_tool_call(self, text: str) -> bool:
+        return self._incomplete_start(text) is not None
+
+    def flush_held_content(self, full_text: str) -> str:
+        start = self._incomplete_start(full_text)
+        return full_text[start:] if start is not None else ""
+
+    def extract_tool_calls(
+        self, model_output: str, request: dict[str, Any] | None = None
+    ) -> ExtractedToolCallInformation:
+        calls, content = self._parsed(model_output, request)
+        return ExtractedToolCallInformation(
+            tools_called=bool(calls),
+            tool_calls=calls,
+            content=(content or None) if calls else model_output,
+        )
+
+    def extract_tool_calls_streaming(
+        self,
+        previous_text: str,
+        current_text: str,
+        delta_text: str,
+        previous_token_ids: Sequence[int] | None = None,
+        current_token_ids: Sequence[int] | None = None,
+        delta_token_ids: Sequence[int] | None = None,
+        request: dict[str, Any] | None = None,
+    ) -> dict[str, Any] | None:
+        if not previous_text or not current_text.startswith(previous_text):
+            self.reset()
+
+        calls, current_content = self._parsed(current_text, request)
+        _, previous_content = self._parsed(previous_text, request)
+        safe_current = self._safe_content_prefix(current_content)
+        safe_previous = self._safe_content_prefix(previous_content)
+        new_calls = calls[self._streamed_call_count :]
+        if new_calls:
+            self._streamed_call_count = len(calls)
+            event: dict[str, Any] = {
+                "tool_calls": [
+                    {
+                        "index": index,
+                        "id": call["id"],
+                        "type": "function",
+                        "function": {
+                            "name": call["name"],
+                            "arguments": call["arguments"],
+                        },
+                    }
+                    for index, call in enumerate(
+                        new_calls, self._streamed_call_count - len(new_calls)
+                    )
+                ]
+            }
+            if safe_current.startswith(safe_previous):
+                content = safe_current[len(safe_previous) :]
+            else:
+                content = safe_current
+            if content:
+                event["content"] = content
+            return event
+
+        if safe_current.startswith(safe_previous):
+            delta = safe_current[len(safe_previous) :]
+        else:
+            delta = safe_current
+        return {"content": delta} if delta else None


### PR DESCRIPTION
## What does this PR do?

Adds first-class support for the two MiniCPM5 MLX artifacts requested in #1139:

- `minicpm5-1b-4bit` → `openbmb/MiniCPM5-1B-MLX`
- `minicpm5-1b-optiq-4bit` → `mlx-community/MiniCPM5-1B-OptiQ-4bit`

It registers a small native parser for MiniCPM5’s documented `<function name="…"><param name="…">…</param></function>` format, including CDATA parameter values and OpenAI-compatible non-streaming and SSE tool calls.

## Why is this needed?

MiniCPM5 is a capable 1B on-device model, but its native tool-call format is not handled by existing parsers. Without this change, valid calls are returned as text instead of OpenAI `tool_calls`.

This intentionally supports only the two verified MLX checkpoints. It does not add generic template/checkpoint inference, and it does not claim BitCPM support: the current BitCPM release has no compatible MLX artifact.

## AI assistance disclosure

Codex wrote the alias entries, parser, and tests. The implementation was checked with focused tests, full unit regression coverage, a wheel installed in a fresh isolated environment, and live tool-calling against the official checkpoint.

> By submitting this PR I confirm I can explain the intent, risk, and behavior of every non-generated change in this PR.

## Test plan

- Focused alias/parser/stream-parity/coverage suite: 2,573 passed
- `coverage run -m pytest tests/test_minicpm_tool_parser.py -q`: 100% (130/130 statements)
- `ruff check` and `ruff format --check` for touched files
- Full unit suite excluding integrations: 13,514 passed, 17 skipped, 17 deselected, 6 xfailed, 1 xpassed
- `python scripts/audit_tool_parser_coverage.py`
- Built wheel, installed it into a fresh isolated virtual environment, and verified both alias and full HF-path profile resolution
- Live `rapid-mlx serve minicpm5-1b-4bit --enable-auto-tool-choice --tool-call-parser minicpm`: official checkpoint returned structured `get_weather({"city":"Paris"})` in both regular and SSE OpenAI responses

## Checklist

- [x] Tests pass locally
- [x] Lint and formatting pass
- [x] No breaking API changes
- [x] No new dependencies
