### PR TITLE
fix(rate-limit): unwrap IPv4-mapped IPv6 in subnet bucketing (#589)

### DIFF
--- a/tests/test_subnet_bucket_ipv4_mapped.py
+++ b/tests/test_subnet_bucket_ipv4_mapped.py
@@ -1,0 +1,44 @@
+"""Regression test for #589: IPv4-mapped IPv6 rate-limit bucketing.
+
+Before the fix, all IPv4-mapped IPv6 addresses (::ffff:a.b.c.d) mapped
+to the same ``::`` bucket, so every IPv4 client behind a dual-stack
+server shared a single rate-limit quota.
+"""
+
+from __future__ import annotations
+
+from vllm_mlx.middleware.auth import _subnet_bucket
+
+
+class TestSubnetBucketIPv4Mapped:
+    """IPv4-mapped IPv6 addresses must bucket by their underlying /24."""
+
+    def test_ipv4_mapped_same_subnet(self):
+        """Two IPv4-mapped addresses in the same /24 share a bucket."""
+        assert _subnet_bucket("::ffff:192.0.2.1") == "192.0.2.0"
+        assert _subnet_bucket("::ffff:192.0.2.99") == "192.0.2.0"
+
+    def test_ipv4_mapped_matches_plain_ipv4(self):
+        """IPv4-mapped address buckets the same as the plain IPv4."""
+        assert _subnet_bucket("::ffff:192.0.2.1") == _subnet_bucket("192.0.2.1")
+
+    def test_ipv4_mapped_different_subnets(self):
+        """Different /24s get different buckets (not all collapsed to ::)."""
+        assert _subnet_bucket("::ffff:10.0.0.1") == "10.0.0.0"
+        assert _subnet_bucket("::ffff:172.16.0.1") == "172.16.0.0"
+        assert _subnet_bucket("::ffff:10.0.0.1") != _subnet_bucket("::ffff:172.16.0.1")
+
+    def test_plain_ipv4_unchanged(self):
+        """Plain IPv4 bucketing is unaffected by the fix."""
+        assert _subnet_bucket("192.168.1.100") == "192.168.1.0"
+        assert _subnet_bucket("10.0.0.5") == "10.0.0.0"
+
+    def test_plain_ipv6_unchanged(self):
+        """Pure IPv6 bucketing is unaffected by the fix."""
+        assert _subnet_bucket("2001:db8::1") == "2001:db8::"
+        assert _subnet_bucket("2001:db8:abcd:1234::1") == "2001:db8:abcd:1234::"
+
+    def test_invalid_host_passthrough(self):
+        """Non-IP host strings pass through unchanged."""
+        assert _subnet_bucket("localhost") == "localhost"
+        assert _subnet_bucket("not-an-ip") == "not-an-ip"

--- a/vllm_mlx/middleware/auth.py
+++ b/vllm_mlx/middleware/auth.py
@@ -169,11 +169,19 @@ def _bucket_id(raw: str) -> str:
 
 
 def _subnet_bucket(host: str) -> str:
-    """Group IPv4 hosts into /24 and IPv6 hosts into /64 subnets."""
+    """Group IPv4 hosts into /24 and IPv6 hosts into /64 subnets.
+
+    IPv4-mapped IPv6 addresses (``::ffff:a.b.c.d``, common when the
+    server binds to ``::`` on dual-stack Linux) are unwrapped to their
+    underlying IPv4 address before bucketing so each /24 gets its own
+    rate-limit bucket (#589).
+    """
     try:
         addr = ipaddress.ip_address(host)
         if isinstance(addr, ipaddress.IPv4Address):
             network = ipaddress.ip_network(f"{addr}/24", strict=False)
+        elif addr.ipv4_mapped is not None:
+            network = ipaddress.ip_network(f"{addr.ipv4_mapped}/24", strict=False)
         else:
             network = ipaddress.ip_network(f"{addr}/64", strict=False)
         return str(network.network_address)


### PR DESCRIPTION
## Why

Fixes #589. On dual-stack servers (bound to `::`, typical for Linux + Python `socket.AF_INET6`), IPv4 clients appear as IPv4-mapped IPv6 addresses (`::ffff:a.b.c.d`). The existing `/64` mask collapsed **all** of them to the same `::` bucket, so every IPv4 client shared a single rate-limit quota.

**Before:**
```
::ffff:192.0.2.1  → ::    (all same bucket!)
::ffff:10.0.0.1   → ::
::ffff:172.16.0.1 → ::
```

**After:**
```
::ffff:192.0.2.1  → 192.0.2.0   (correct /24 bucket)
::ffff:10.0.0.1   → 10.0.0.0
::ffff:172.16.0.1 → 172.16.0.0
```

## What

2-line fix in `_subnet_bucket()`: check `addr.ipv4_mapped` before the IPv6 `/64` branch and bucket by the underlying IPv4 `/24`.

### Files changed

| File | What |
|---|---|
| `vllm_mlx/middleware/auth.py` | Add `ipv4_mapped` check in `_subnet_bucket` (+2 LOC) |
| `tests/test_subnet_bucket_ipv4_mapped.py` | 6 regression tests |

## Tests

```
tests/test_subnet_bucket_ipv4_mapped.py — 6 passed
```

## AI assistance

All files were AI-authored (Claude Opus 4.6). Fix direction was specified in the issue by @raullenchai. Verified by reproducing the bug (all IPv4-mapped → `::`) and confirming the fix (each /24 gets its own bucket).

🤖 Generated with [Claude Code](https://claude.com/claude-code)