### PR TITLE
fix(tests): stub request logging middleware in listen_fd fixture

### DIFF
--- a/tests/test_serve_listen_fd.py
+++ b/tests/test_serve_listen_fd.py
@@ -276,7 +276,9 @@ def stub_heavy_serve_deps(monkeypatch):
     # — same "after an application has started" failure as CORS (#1167).
     from vllm_mlx.middleware import request_logging as reqlog_mod
 
-    monkeypatch.setattr(reqlog_mod, "install_request_logging_middleware", lambda *a: None)
+    monkeypatch.setattr(
+        reqlog_mod, "install_request_logging_middleware", lambda *a: None
+    )
     return monkeypatch
 
 

--- a/tests/test_serve_listen_fd.py
+++ b/tests/test_serve_listen_fd.py
@@ -272,6 +272,11 @@ def stub_heavy_serve_deps(monkeypatch):
     from vllm_mlx.middleware import auth as auth_mod
 
     monkeypatch.setattr(auth_mod, "configure_rate_limiter", lambda *a, **kw: None)
+    # ``install_request_logging_middleware`` also calls ``app.add_middleware``
+    # — same "after an application has started" failure as CORS (#1167).
+    from vllm_mlx.middleware import request_logging as reqlog_mod
+
+    monkeypatch.setattr(reqlog_mod, "install_request_logging_middleware", lambda *a: None)
     return monkeypatch
 
 


### PR DESCRIPTION
## Why

PR #1167 (request logging middleware, #51) introduced a full-suite test pollution: `install_request_logging_middleware(server.app)` calls `app.add_middleware()` inside `serve_command`. When a prior test starts `server.app` via `TestClient`, Starlette raises `RuntimeError: Cannot add middleware after an application has started` — failing 5 tests in `test_serve_listen_fd.py`.

## What

Add a no-op `monkeypatch.setattr` for `install_request_logging_middleware` in the `stub_heavy_serve_deps` fixture, matching the existing pattern for `configure_cors`.

## Tests

- Full suite: 21/21 `test_serve_listen_fd` pass (were 5 FAIL before fix)
- Only remaining failure is pre-existing `test_tool_grammar_558` (HF offline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)