### PR TITLE
feat(tools): grammar-constrain Qwen3-Coder XML tool-calls (#558 E3)

### DIFF
--- a/tests/test_qwen3coder_xml_grammar_558.py
+++ b/tests/test_qwen3coder_xml_grammar_558.py
@@ -462,12 +462,30 @@ def tok():
 def lltok(tok):
     """Build an llguidance LLTokenizer from the fast (Rust) tokenizer via the
     module's own resolver (the spike-proven candidate-3 direct build handles the
-    transformers ``from_tokenizer`` isinstance gotcha ``guided.py`` trips on)."""
-    from vllm_mlx.api.tool_grammar import build_lltokenizer
+    transformers ``from_tokenizer`` isinstance gotcha ``guided.py`` trips on).
 
+    FINDING 5: a blanket ``skip when build_lltokenizer() is None`` let the whole
+    enforcement/round-trip suite go GREEN even if the production
+    tokenizer->llguidance integration was BROKEN. We now sanction the skip ONLY
+    when the runtime bridge is genuinely UNAVAILABLE (``HAS_LL_TOKENIZER`` False —
+    ``llguidance.hf`` / ``LLTokenizer`` not importable, the same narrow
+    unavailability the ``tok`` fixture treats as an offline skip). When the bridge
+    IS importable AND ``tok`` loaded (cached) but ``build_lltokenizer`` returns
+    ``None``, that is a broken integration and MUST FAIL — never silently pass."""
+    from vllm_mlx.api.tool_grammar import HAS_LL_TOKENIZER, build_lltokenizer
+
+    if not HAS_LL_TOKENIZER:
+        pytest.skip(
+            "llguidance runtime bridge (llguidance.hf / LLTokenizer) not "
+            "installed — XML enforcement tests require it"
+        )
     built = build_lltokenizer(tok)
-    if built is None:
-        pytest.skip("could not build an LLTokenizer for the Qwen3-Coder tokenizer")
+    assert built is not None, (
+        "build_lltokenizer() returned None for the CACHED Qwen3-Coder tokenizer "
+        "with the llguidance runtime bridge available — the production "
+        "tokenizer->llguidance integration is BROKEN (finding 5: this must FAIL, "
+        "not skip)."
+    )
     return built
 
 
@@ -508,6 +526,24 @@ def _wire(code, *, language="python", timeout=None, verbose=None):
         s += f"<parameter=verbose>\n{verbose}\n</parameter>\n"
     s += "</function>\n</tool_call>"
     return s
+
+
+@_requires_llguidance
+def test_finding5_tokenizer_llguidance_integration_not_broken(tok):
+    # FINDING 5: with llguidance importable AND the tokenizer loaded (cached), the
+    # production ``build_lltokenizer`` MUST yield a real ``LLTokenizer`` — a
+    # ``None`` here means the tokenizer->llguidance integration is broken and the
+    # enforcement suite would silently pass on skips. Assert it directly so the
+    # breakage surfaces as a FAILURE (only ``tok``'s narrow offline/cache-miss
+    # path is a sanctioned skip; we are here only because ``tok`` loaded).
+    from vllm_mlx.api.tool_grammar import HAS_LL_TOKENIZER, build_lltokenizer
+
+    if not HAS_LL_TOKENIZER:
+        pytest.skip("llguidance runtime bridge (llguidance.hf / LLTokenizer) absent")
+    assert build_lltokenizer(tok) is not None, (
+        "build_lltokenizer() returned None despite an available runtime bridge "
+        "and a loaded tokenizer — broken integration (finding 5), not a skip."
+    )
 
 
 @_requires_llguidance
@@ -675,13 +711,19 @@ def test_roundtrip_nested_object_value():
 
 
 # ==========================================================================
-# FAITHFUL-OR-OPT-OUT (#558 E3, codex converge). The XML arg emitter is a
+# FAITHFUL-OR-OPT-OUT via a STRICT ALLOWLIST (#558 E3). The XML arg emitter is a
 # best-effort OPT-IN: when it cannot FAITHFULLY represent a schema the WHOLE
 # request opts out of grammar (``build_tool_grammar`` -> ``None``, free-form
 # fallback) rather than emit a grammar that silently allows schema-invalid or
-# mis-typed output. One test per BLOCKING finding (F1/F2/F4/F5 as opt-out, F3 as
-# a REAL fix). Pure-Python guard tests always run; the ``build_tool_grammar``
-# integration tests skip only on genuine tokenizer/llguidance unavailability.
+# mis-typed output. The guard is a CLOSED POSITIVE SET (``_xml_schema_representable``
+# returns ``True`` only when every part of the schema uses exclusively an
+# enumerated known-safe keyword/shape), so it is complete BY CONSTRUCTION — no
+# unknown JSON-Schema keyword can slip through. F1/F2/F4/F5 + the codex round-2
+# shapes (minProperties/propertyNames/required-undeclared/false-schema/$ref-with-
+# siblings/additionalProperties-schema/…) are all subsumed as "not in the
+# allowlist"; F3 stays a REAL fix. Pure-Python guard tests always run; the
+# ``build_tool_grammar`` integration tests skip only on genuine tokenizer/
+# llguidance unavailability.
 # ==========================================================================
 
 
@@ -770,6 +812,123 @@ def test_representable_unresolvable_ref_opts_out():
     # A property `$ref` that does not resolve locally is unrepresentable.
     assert rep({"properties": {"c": {"$ref": "#/$defs/missing"}, "$defs": {}}}) is False
     assert rep({"properties": {"c": {"$ref": "http://remote/x"}}}) is False
+
+
+# ---- STRICT ALLOWLIST (codex round-2): closed positive set ends whack-a-mole --
+# The guard is now an ALLOWLIST — representable ONLY when every part of the schema
+# uses exclusively a known-safe, enumerated keyword/shape. These prove the five
+# round-2 shapes a blacklist missed all opt out BY CONSTRUCTION (they are simply
+# not in the allowlist), plus a positive control that the common case is intact.
+def test_representable_allowlist_positive_control():
+    # The normal shape a blacklist would let through unchanged MUST still be fully
+    # constrained: typed scalars + string + enum + a nested OBJECT via `$ref` +
+    # required ⊆ properties + closed additionalProperties. Guards against the
+    # allowlist over-opting-out the common case.
+    from vllm_mlx.api.tool_grammar import _xml_schema_representable as rep
+
+    schema = {
+        "type": "object",
+        "properties": {
+            "code": {"type": "string"},
+            "language": {"type": "string", "enum": ["python", "cpp"]},
+            "retries": {"type": "integer"},
+            "verbose": {"type": "boolean"},
+            "origin": {"$ref": "#/$defs/point"},
+        },
+        "required": ["code", "language"],
+        "additionalProperties": False,
+        "$defs": {
+            "point": {
+                "type": "object",
+                "properties": {"x": {"type": "integer"}, "y": {"type": "integer"}},
+                "required": ["x", "y"],
+                "additionalProperties": False,
+            }
+        },
+    }
+    assert rep(schema) is True
+
+
+def test_representable_rejects_round2_minmax_properties():
+    # A blacklist keyed on `dependentRequired`/composition MISSED these object-size
+    # keywords; the allowlist opts out because they are not top-level-allowed keys.
+    from vllm_mlx.api.tool_grammar import _xml_schema_representable as rep
+
+    base = {"type": "object", "properties": {"a": {"type": "string"}}}
+    assert rep({**base, "minProperties": 1}) is False
+    assert rep({**base, "maxProperties": 2}) is False
+
+
+def test_representable_rejects_round2_required_undeclared_property():
+    # `required` names a property that is NOT declared -> it would never be emitted
+    # and thus silently unenforced -> opt out (finding 3). (Distinct from the F1
+    # property-less case: here real properties ARE present.)
+    from vllm_mlx.api.tool_grammar import _xml_schema_representable as rep
+
+    assert (
+        rep(
+            {
+                "type": "object",
+                "properties": {"a": {"type": "string"}},
+                "required": ["a", "b"],  # `b` undeclared
+            }
+        )
+        is False
+    )
+
+
+def test_representable_rejects_round2_property_schema_false():
+    # A property schema that is literally `false` (accepts NO value) is not a dict
+    # in the allowlist -> opt out (finding 1). `true` likewise.
+    from vllm_mlx.api.tool_grammar import _xml_schema_representable as rep
+
+    assert rep({"type": "object", "properties": {"a": False}}) is False
+    assert rep({"type": "object", "properties": {"a": True}}) is False
+
+
+def test_representable_rejects_round2_ref_with_sibling_enum():
+    # A `$ref` carrying SIBLING keys (here `enum`) would DROP those siblings on
+    # resolution -> opt out (finding 4), never silently ignore the enum.
+    from vllm_mlx.api.tool_grammar import _xml_schema_representable as rep
+
+    assert (
+        rep(
+            {
+                "type": "object",
+                "properties": {"a": {"$ref": "#/$defs/x", "enum": ["p", "q"]}},
+                "$defs": {"x": {"type": "string"}},
+            }
+        )
+        is False
+    )
+
+
+def test_representable_rejects_round2_additional_properties_schema():
+    # `additionalProperties` as a SCHEMA (or `True`) can't be constrained on the
+    # XML wire -> opt out; only a literal `False` is representable.
+    from vllm_mlx.api.tool_grammar import _xml_schema_representable as rep
+
+    base = {"type": "object", "properties": {"a": {"type": "string"}}}
+    assert rep({**base, "additionalProperties": {"type": "string"}}) is False
+    assert rep({**base, "additionalProperties": True}) is False
+    assert rep({**base, "additionalProperties": False}) is True  # control
+
+
+def test_representable_rejects_round2_property_names():
+    # `propertyNames` constrains KEY names — unenforceable on the delimiter wire
+    # and not a top-level-allowed key -> opt out.
+    from vllm_mlx.api.tool_grammar import _xml_schema_representable as rep
+
+    assert (
+        rep(
+            {
+                "type": "object",
+                "properties": {"a": {"type": "string"}},
+                "propertyNames": {"pattern": "^[a-z]+$"},
+            }
+        )
+        is False
+    )
 
 
 # ---- F3 REAL FIX: $ref resolved BEFORE the string-vs-%json decision ------

--- a/tests/test_qwen3coder_xml_grammar_558.py
+++ b/tests/test_qwen3coder_xml_grammar_558.py
@@ -1,0 +1,655 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Offline tests for the Qwen3-Coder XML grammar constraint (#558 E3).
+
+The JSON-body families (hermes / qwen / harmony) constrain their ``arguments``
+as a single ``%json`` object. Qwen3-Coder instead emits an XML arg body —
+``<function=NAME>\\n<parameter=KEY>\\nVALUE\\n</parameter>\\n...</function>`` — so
+its ``structure_info()`` declares ``arg_style="xml"`` and ``build_tool_lark``
+emits a per-parameter XML body (``_emit_xml_arg_body`` / ``_emit_xml_param_value``)
+instead of a whole-object ``%json``. These tests prove that path WITHOUT a model
+or a decode loop:
+
+  * ``build_tool_lark`` golden output for ``arg_style="xml"`` (function/parameter
+    frame, string values as the LAZY ``xml_param_value`` rule, enum alternation,
+    ``%json`` scalars with ``$defs``/``$ref`` propagation, required vs optional
+    ``( )?``);
+  * GAP #1 (the E3 fix): a string parameter value containing a literal ``<``
+    (a ``code`` arg such as ``a < b``, ``<html>...``, C++ ``vector<int>``) is
+    ACCEPTED and terminates at the real ``</parameter>`` — the pilot's
+    ``XMLSTR: /[^<]*/`` terminal SILENTLY TRUNCATED such a value at the first
+    ``<``. The fix ports llguidance's own ``[lazy]`` lexeme idiom (the one
+    ``StructTag.to_grammar`` uses for "text until a tag"), matching XGrammar's
+    ``qwen_xml`` semantics: value = any text up to the FIRST ``</parameter>``;
+  * grammar ENFORCEMENT via llguidance ``LLMatcher`` on the REAL Qwen3-Coder
+    tokenizer: a valid XML call is accepted + terminal, prose before a forced
+    call is masked at token 0, and a bad enum / off-schema scalar is rejected;
+  * ROUND-TRIP: the ``qwen3_coder_xml`` parser parses the constrained wire back
+    to ``{name, arguments}`` with correct types (str-with-``<`` / int / bool /
+    nested object);
+  * REGRESSION GUARD: an ``arg_style="json"`` (hermes/qwen/harmony) build is
+    byte-identical to before — it never emits the XML string constructs
+    (``XML_PARAM_TEXT`` / ``xml_param_value``) and still uses ``%json``.
+
+The enforcement / round-trip tests use the ACTUAL target model tokenizer
+``mlx-community/Qwen3-Coder-Next-4bit`` (pinned by revision below for an
+immutable artifact — its ``<tool_call>``/``</tool_call>`` single-special-token
+layout and the inner XML byte markers are fixed at this commit). They skip ONLY
+on genuine unavailability (llguidance extra absent, or the tokenizer neither
+cached nor reachable); any OTHER failure is surfaced, not swallowed. The
+pure-Python golden / structure-triple / regression tests never skip.
+"""
+
+import importlib.util
+import json
+
+import pytest
+
+_HAS_LLGUIDANCE = importlib.util.find_spec("llguidance") is not None
+_requires_llguidance = pytest.mark.skipif(
+    not _HAS_LLGUIDANCE, reason="llguidance ([guided] extra) not installed"
+)
+
+# The REAL Qwen3-Coder target model (the pilot verified the XML wire on it).
+# Pin the revision so enforcement runs against an IMMUTABLE artifact.
+_TOKENIZER_MODEL = "mlx-community/Qwen3-Coder-Next-4bit"
+_TOKENIZER_REVISION = "7b9321eabb85ce79625cac3f61ea691e4ea984b5"
+
+# A representative XML tool: required string + required enum + optional int +
+# optional bool — exercises every ``_emit_xml_param_value`` branch (lazy string
+# rule, enum alternation, ``%json`` scalar) AND required-vs-optional framing.
+XML_TOOLS = [
+    {
+        "name": "run_code",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "code": {"type": "string"},
+                "language": {"type": "string", "enum": ["python", "cpp"]},
+                "timeout": {"type": "integer"},
+                "verbose": {"type": "boolean"},
+            },
+            "required": ["code", "language"],
+            "additionalProperties": False,
+        },
+    },
+]
+
+# A nested-object tool with a ``$ref`` into ``$defs`` — proves ``$defs`` is
+# propagated into the per-value ``%json`` sub-schema so the ``$ref`` resolves.
+XML_REF_TOOL = [
+    {
+        "name": "place",
+        "parameters": {
+            "type": "object",
+            "properties": {"origin": {"$ref": "#/$defs/point"}},
+            "required": ["origin"],
+            "$defs": {
+                "point": {
+                    "type": "object",
+                    "properties": {
+                        "x": {"type": "integer"},
+                        "y": {"type": "integer"},
+                    },
+                    "required": ["x", "y"],
+                    "additionalProperties": False,
+                }
+            },
+            "additionalProperties": False,
+        },
+    },
+]
+
+
+def _xml_structure_info(name: str):
+    """The Qwen3-Coder XML wire triple, exactly as ``Qwen3CoderToolParser``
+    ships it (``arg_style="xml"``). Declared test-locally so the pure-Python
+    golden tests need no tokenizer; the enforcement tests below drive the REAL
+    parser instead."""
+    from vllm_mlx.api.tool_grammar import StructureInfo
+
+    return StructureInfo(
+        begin=f"<tool_call>\n<function={name}>\n",
+        end="</function>\n</tool_call>",
+        trigger="<tool_call>",
+        sentinels=("<tool_call>", "</tool_call>"),
+        arg_style="xml",
+    )
+
+
+def _hermes_json_structure_info(name: str):
+    """A hermes ``<tool_call>`` JSON-body wire triple (``arg_style="json"``,
+    the default) — the regression baseline the XML change must not perturb."""
+    from vllm_mlx.api.tool_grammar import StructureInfo
+
+    return StructureInfo(
+        begin=f'<tool_call>\n{{"name": "{name}", "arguments": ',
+        end="}\n</tool_call>",
+        trigger="<tool_call>",
+        sentinels=("<tool_call>", "</tool_call>"),
+    )
+
+
+# --------------------------------------------------------------------------
+# Golden Lark for the XML arg body (pure Python, always runs). A CHECKED-IN
+# golden — comparing against it (not another call of the same implementation)
+# pins the EXACT emitted grammar even if the whole builder drifted.
+# --------------------------------------------------------------------------
+_XML_GOLDEN_LARK = (
+    "%llguidance {}\n"
+    "start: (tag_0) (SEP (tag_0))* tag_end\n"
+    "tag_end: TAG_TEXT\n"
+    "SEP: /[ \\t\\r\\n]*/\n"
+    "TAG_TEXT: /(.|\\n)*/\n"
+    # The lazy string-value construct: XML_PARAM_TEXT admits ANY byte (``<``
+    # included); the lazy rule binds it to the FIRST ``</parameter>``.
+    "XML_PARAM_TEXT: /(.|\\n)*/\n"
+    'xml_param_value[lazy]: XML_PARAM_TEXT "</parameter>"\n'
+    "\n"
+    # A string value is the lazy rule + only the trailing ``\\n`` separator
+    # (the rule already consumed ``\\n</parameter>``). An enum is a literal
+    # alternation, a scalar is ``%json``; both keep the ``\\n</parameter>\\n``
+    # close. Optional params are wrapped in ``( ... )?``.
+    'tag_0: <tool_call> "\\n<function=run_code>\\n" '
+    '"<parameter=code>\\n" xml_param_value "\\n" '
+    '"<parameter=language>\\n" ("python" | "cpp") "\\n</parameter>\\n" '
+    '( "<parameter=timeout>\\n" %json {"type": "integer"} "\\n</parameter>\\n" )? '
+    '( "<parameter=verbose>\\n" %json {"type": "boolean"} "\\n</parameter>\\n" )? '
+    '"</function>\\n" </tool_call>\n'
+)
+
+
+def test_xml_lark_matches_golden():
+    from vllm_mlx.api.tool_grammar import build_tool_lark
+
+    lark = build_tool_lark(XML_TOOLS, "required", [_xml_structure_info("run_code")])
+    assert lark == _XML_GOLDEN_LARK
+
+
+def test_xml_lark_frame_and_sentinels():
+    # The function/parameter frame: <tool_call> trigger + </tool_call> close as
+    # BARE special-token refs (never quoted byte literals the single token could
+    # not satisfy), the <function=NAME> header, and per-parameter blocks.
+    from vllm_mlx.api.tool_grammar import build_tool_lark
+
+    lark = build_tool_lark(XML_TOOLS, "required", [_xml_structure_info("run_code")])
+    assert " <tool_call> " in lark  # bare trigger ref
+    assert lark.rstrip().endswith("</tool_call>")  # bare closing ref
+    assert '"<tool_call>"' not in lark  # NOT a quoted literal
+    assert '"</tool_call>"' not in lark
+    # XML frame markers are ordinary byte-string literals (multi-token text).
+    assert '"\\n<function=run_code>\\n"' in lark
+    assert '"<parameter=code>\\n"' in lark
+    assert '"</function>\\n"' in lark
+
+
+def test_xml_string_value_uses_lazy_rule_not_raw_charclass():
+    # GAP #1 fix, at the grammar-string level: a string param value must be the
+    # LAZY ``xml_param_value`` rule (any text up to the first ``</parameter>``),
+    # NOT the pilot's ``XMLSTR: /[^<]*/`` terminal that stopped at any ``<``.
+    from vllm_mlx.api.tool_grammar import build_tool_lark
+
+    lark = build_tool_lark(XML_TOOLS, "required", [_xml_structure_info("run_code")])
+    # The lazy value construct is declared once and referenced for the string.
+    assert 'xml_param_value[lazy]: XML_PARAM_TEXT "</parameter>"' in lark
+    assert "XML_PARAM_TEXT: /(.|\\n)*/" in lark
+    assert '"<parameter=code>\\n" xml_param_value "\\n"' in lark
+    # The truncating raw terminal is GONE.
+    assert "XMLSTR" not in lark
+    assert "/[^<]*/" not in lark
+
+
+def test_xml_required_vs_optional_framing():
+    # Required params are mandatory (no quantifier); optional params are wrapped
+    # in ``( ... )?``. ``code``/``language`` required; ``timeout``/``verbose`` not.
+    from vllm_mlx.api.tool_grammar import build_tool_lark
+
+    lark = build_tool_lark(XML_TOOLS, "required", [_xml_structure_info("run_code")])
+    # Required string: bare (not inside a ``( ... )?`` group).
+    assert '"<parameter=code>\\n" xml_param_value "\\n" "<parameter=language>' in lark
+    # Optional scalars: each wrapped in an optional group.
+    assert (
+        '( "<parameter=timeout>\\n" %json {"type": "integer"} "\\n</parameter>\\n" )?'
+        in lark
+    )
+    assert (
+        '( "<parameter=verbose>\\n" %json {"type": "boolean"} "\\n</parameter>\\n" )?'
+        in lark
+    )
+
+
+def test_xml_enum_is_literal_alternation():
+    # An enum value renders as an alternation of the literal enum values (raw
+    # string form for string enums), NOT ``%json`` and NOT the lazy string rule.
+    from vllm_mlx.api.tool_grammar import build_tool_lark
+
+    lark = build_tool_lark(XML_TOOLS, "required", [_xml_structure_info("run_code")])
+    assert '("python" | "cpp") "\\n</parameter>\\n"' in lark
+
+
+def test_xml_ref_defs_propagated_into_value_schema():
+    # A ``$ref`` value must carry the parent's ``$defs`` into its per-value
+    # ``%json`` sub-schema so the ``$ref`` resolves. Golden-compare the emitted
+    # ``%json`` payload.
+    from vllm_mlx.api.tool_grammar import build_tool_lark
+
+    lark = build_tool_lark(XML_REF_TOOL, "required", [_xml_structure_info("place")])
+    expected_schema = {
+        "$ref": "#/$defs/point",
+        "$defs": {
+            "point": {
+                "type": "object",
+                "properties": {
+                    "x": {"type": "integer"},
+                    "y": {"type": "integer"},
+                },
+                "required": ["x", "y"],
+                "additionalProperties": False,
+            }
+        },
+    }
+    assert f"%json {json.dumps(expected_schema)}" in lark
+
+
+def test_xml_no_string_param_tool_still_declares_lazy_rule():
+    # An XML tool with NO string params still declares the lazy rule (arg_style
+    # is xml). The unused rule must not break the grammar (a reference-free rule
+    # is tolerated) — the enforcement test below compiles exactly such a case.
+    from vllm_mlx.api.tool_grammar import build_tool_lark
+
+    int_only = [
+        {
+            "name": "cfg",
+            "parameters": {
+                "type": "object",
+                "properties": {"n": {"type": "integer"}},
+                "required": ["n"],
+                "additionalProperties": False,
+            },
+        }
+    ]
+    lark = build_tool_lark(int_only, "required", [_xml_structure_info("cfg")])
+    assert "xml_param_value[lazy]:" in lark
+    assert "xml_param_value" not in lark.split("\ntag_0:", 1)[1]  # unused in the tag
+
+
+# --------------------------------------------------------------------------
+# REGRESSION GUARD: arg_style="json" (hermes/qwen/harmony) is byte-identical —
+# the XML change must not leak the XML string constructs into JSON families.
+# --------------------------------------------------------------------------
+def test_json_family_grammar_has_no_xml_constructs():
+    from vllm_mlx.api.tool_grammar import build_tool_lark
+
+    infos = [_hermes_json_structure_info(t["name"]) for t in XML_TOOLS]
+    lark = build_tool_lark(XML_TOOLS, "required", infos)
+    # JSON body: a single ``%json`` object, none of the XML string constructs.
+    assert "%json" in lark
+    assert "XML_PARAM_TEXT" not in lark
+    assert "xml_param_value" not in lark
+    assert "XMLSTR" not in lark
+    assert "<parameter=" not in lark
+
+
+def test_json_family_grammar_byte_identical_to_pre_xml_baseline():
+    # The exact hermes forced golden (identical to the checked-in golden in
+    # test_tool_grammar_558.py). Pinning it here proves the XML feature left the
+    # JSON-family grammar byte-for-byte unchanged.
+    from vllm_mlx.api.tool_grammar import build_tool_lark
+
+    tools = [
+        {
+            "name": "get_weather",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "city": {"type": "string"},
+                    "unit": {"type": "string", "enum": ["c", "f"]},
+                },
+                "required": ["city"],
+                "additionalProperties": False,
+            },
+        }
+    ]
+    infos = [_hermes_json_structure_info("get_weather")]
+    expected = (
+        "%llguidance {}\n"
+        "start: (tag_0) (SEP (tag_0))* tag_end\n"
+        "tag_end: TAG_TEXT\n"
+        "SEP: /[ \\t\\r\\n]*/\n"
+        "TAG_TEXT: /(.|\\n)*/\n"
+        "\n"
+        'tag_0: <tool_call> "\\n{\\"name\\": \\"get_weather\\", '
+        '\\"arguments\\": " %json {"type": "object", "properties": {"city": '
+        '{"type": "string"}, "unit": {"type": "string", "enum": ["c", "f"]}}, '
+        '"required": ["city"], "additionalProperties": false} "}\\n" </tool_call>\n'
+    )
+    assert build_tool_lark(tools, "required", infos) == expected
+
+
+# --------------------------------------------------------------------------
+# Real Qwen3CoderToolParser.structure_info() (pure Python, hermetic tokenizer
+# stub — no network). Proves the parser opts in ONLY when the tokenizer proves
+# both sentinels are single special tokens, and returns arg_style="xml".
+# --------------------------------------------------------------------------
+class _FakeAddedToken:
+    def __init__(self, content, special=False):
+        self.content = content
+        self.special = special
+
+
+class _FakeTokenizer:
+    """Models the surfaces the ``are_single_special_tokens`` guard probes:
+    ``<tool_call>``/``</tool_call>`` as distinct single ADDED (special=False)
+    tokens that round-trip (the real Qwen3-Coder layout: ids 151657/151658)."""
+
+    def __init__(self, added=None):
+        self._added = dict(added or {})
+        self._id_to_str = {i: s for s, i in self._added.items()}
+        self.added_tokens_decoder = {
+            i: _FakeAddedToken(s, special=False) for s, i in self._added.items()
+        }
+
+    def encode(self, text, add_special_tokens=False):
+        if text in self._added:
+            return [self._added[text]]
+        return [0, 1]  # ordinary multi-token text
+
+    def decode(self, ids):
+        return "".join(self._id_to_str.get(i, "<unk>") for i in ids)
+
+    def get_vocab(self):
+        return dict(self._added)
+
+
+def _single_token_tokenizer():
+    return _FakeTokenizer(added={"<tool_call>": 151657, "</tool_call>": 151658})
+
+
+def _make_qwen3coder(tokenizer=None):
+    from vllm_mlx.tool_parsers.qwen3coder_tool_parser import Qwen3CoderToolParser
+
+    return Qwen3CoderToolParser(tokenizer=tokenizer)
+
+
+def test_qwen3coder_structure_info_opts_out_without_tokenizer():
+    # No tokenizer -> cannot prove single-token sentinels -> opt out (None).
+    assert _make_qwen3coder(tokenizer=None).structure_info() is None
+
+
+def test_qwen3coder_structure_info_opts_out_on_multitoken_tokenizer():
+    # A tokenizer that encodes <tool_call> as ordinary multi-token text -> opt
+    # out rather than build an unenforceable special-token grammar.
+    assert _make_qwen3coder(tokenizer=_FakeTokenizer(added={})).structure_info() is None
+
+
+def test_qwen3coder_structure_info_returns_xml_wire_triple():
+    from vllm_mlx.api.tool_grammar import StructureInfo
+
+    get_info = _make_qwen3coder(tokenizer=_single_token_tokenizer()).structure_info()
+    assert callable(get_info), "opt-in must return a name->StructureInfo factory"
+    si = get_info("run_code")
+    assert isinstance(si, StructureInfo)
+    assert si.arg_style == "xml"  # the load-bearing distinction from hermes/qwen
+    assert si.trigger == "<tool_call>"
+    assert si.begin == "<tool_call>\n<function=run_code>\n"
+    assert si.end == "</function>\n</tool_call>"
+    assert si.begin.startswith(si.trigger)  # builder invariant
+    assert si.sentinels == ("<tool_call>", "</tool_call>")
+    assert si.trigger in si.sentinels
+
+
+# --------------------------------------------------------------------------
+# Grammar ENFORCEMENT + ROUND-TRIP on the REAL Qwen3-Coder tokenizer.
+# --------------------------------------------------------------------------
+def _offline_skip_exc_types():
+    """Genuine network/cache-miss exceptions that are a sanctioned skip.
+
+    A corrupt tokenizer artifact / invalid revision must FAIL the test, not
+    skip it, so we skip ONLY on the specific offline/cache-miss signals.
+    """
+    types: list[type[BaseException]] = []
+    try:
+        from huggingface_hub.errors import (
+            LocalEntryNotFoundError,
+            OfflineModeIsEnabled,
+        )
+
+        types += [LocalEntryNotFoundError, OfflineModeIsEnabled]
+    except Exception:  # pragma: no cover - old hub without these names
+        pass
+    try:
+        from requests.exceptions import ConnectionError as _ReqConnErr
+
+        types.append(_ReqConnErr)
+    except Exception:  # pragma: no cover - requests not present
+        pass
+    return tuple(types) or (OSError,)
+
+
+@pytest.fixture(scope="module")
+def tok():
+    transformers = pytest.importorskip("transformers")
+    try:
+        return transformers.AutoTokenizer.from_pretrained(
+            _TOKENIZER_MODEL, revision=_TOKENIZER_REVISION
+        )
+    except _offline_skip_exc_types():  # pragma: no cover - offline & uncached
+        pytest.skip(
+            f"tokenizer {_TOKENIZER_MODEL}@{_TOKENIZER_REVISION[:8]} not cached "
+            "and no network — XML enforcement tests require it"
+        )
+
+
+@pytest.fixture(scope="module")
+def lltok(tok):
+    """Build an llguidance LLTokenizer from the fast (Rust) tokenizer via the
+    module's own resolver (the spike-proven candidate-3 direct build handles the
+    transformers ``from_tokenizer`` isinstance gotcha ``guided.py`` trips on)."""
+    from vllm_mlx.api.tool_grammar import build_lltokenizer
+
+    built = build_lltokenizer(tok)
+    if built is None:
+        pytest.skip("could not build an LLTokenizer for the Qwen3-Coder tokenizer")
+    return built
+
+
+def _xml_grammar(tools, tool_choice, tok):
+    """Compile the XML grammar through the REAL parser (opted-in on ``tok``)."""
+    from vllm_mlx.api.tool_grammar import build_tool_grammar
+
+    return build_tool_grammar(tools, tool_choice, _make_qwen3coder(tok))
+
+
+def _consume(grammar, lltok, tok, text):
+    """Offline enforcement probe. Returns ``(accepted, total, is_accepting)`` —
+    advances real matcher state so ``is_accepting()`` proves a COMPLETE valid
+    derivation, not merely an accepted prefix."""
+    from llguidance.mlx import LLMatcher
+
+    ids = tok.encode(text, add_special_tokens=False)
+    matcher = LLMatcher(lltok, grammar)
+    assert not matcher.get_error(), matcher.get_error()
+    accepted = 0
+    for tid in ids:
+        if not matcher.consume_tokens([tid]):
+            break
+        accepted += 1
+    return accepted, len(ids), matcher.is_accepting()
+
+
+def _wire(code, *, language="python", timeout=None, verbose=None):
+    """Build the Qwen3-Coder XML wire for the ``run_code`` tool."""
+    s = (
+        "<tool_call>\n<function=run_code>\n"
+        f"<parameter=code>\n{code}\n</parameter>\n"
+        f"<parameter=language>\n{language}\n</parameter>\n"
+    )
+    if timeout is not None:
+        s += f"<parameter=timeout>\n{timeout}\n</parameter>\n"
+    if verbose is not None:
+        s += f"<parameter=verbose>\n{verbose}\n</parameter>\n"
+    s += "</function>\n</tool_call>"
+    return s
+
+
+@_requires_llguidance
+def test_xml_valid_call_accepted_and_terminates(tok, lltok):
+    grammar = _xml_grammar(XML_TOOLS, "required", tok)
+    assert grammar is not None
+    accepted, total, accepting = _consume(grammar, lltok, tok, _wire("print(1)"))
+    assert accepted == total, f"valid XML call rejected ({accepted}/{total})"
+    assert accepting, "valid complete XML call is not an accepting (terminal) state"
+
+
+@_requires_llguidance
+@pytest.mark.parametrize(
+    "code",
+    [
+        "a < b && c > d",
+        "<html><body>x</body></html>",
+        "vector<int> v",
+        "if (a < b) { return a; }",
+        "for (int i = 0; i < n; i++) x[i] <<= 1;",
+    ],
+)
+def test_xml_string_value_with_angle_bracket_is_accepted(code, tok, lltok):
+    # GAP #1 — the E3 fix. A ``code`` arg containing a literal ``<`` must be
+    # ACCEPTED in full and terminate at the real ``</parameter>``. The pilot's
+    # ``/[^<]*/`` terminal masked the first ``<`` and SILENTLY TRUNCATED here.
+    grammar = _xml_grammar(XML_TOOLS, "required", tok)
+    assert grammar is not None
+    accepted, total, accepting = _consume(grammar, lltok, tok, _wire(code))
+    assert accepted == total, (
+        f"`<`-containing code value rejected ({accepted}/{total}) for {code!r} — "
+        "gap #1 truncation is back (string value stops at the first `<`)"
+    )
+    assert accepting, f"`<`-containing value {code!r} is not a terminal state"
+
+
+@_requires_llguidance
+def test_xml_normal_value_still_round_trips_no_regression(tok, lltok):
+    # A plain value (no ``<``) must still be accepted + terminal — the lazy rule
+    # is a strict superset of the old raw terminal for non-``<`` values.
+    grammar = _xml_grammar(XML_TOOLS, "required", tok)
+    accepted, total, accepting = _consume(grammar, lltok, tok, _wire("Paris"))
+    assert accepted == total and accepting, (
+        f"plain value regressed ({accepted}/{total}, accepting={accepting})"
+    )
+
+
+@_requires_llguidance
+def test_xml_value_containing_close_tag_closes_at_first(tok, lltok):
+    # FIRST-``</parameter>`` semantics (same as XGrammar, acceptable): a value
+    # that literally contains ``</parameter>`` closes THERE, so the trailing
+    # remainder is not part of a single value and the full wire is not a
+    # complete derivation (accepted < total). This pins the documented behavior.
+    grammar = _xml_grammar(XML_TOOLS, "required", tok)
+    accepted, total, _ = _consume(grammar, lltok, tok, _wire("a</parameter>b"))
+    assert accepted < total, (
+        "a value literally containing </parameter> must close at the FIRST one "
+        "(XGrammar semantics), not swallow the rest of the wire"
+    )
+
+
+@_requires_llguidance
+def test_xml_optional_and_scalar_params_enforced(tok, lltok):
+    # Optional int/bool params present with valid scalar surface forms are
+    # accepted + terminal; the enum on the required ``language`` is honored.
+    grammar = _xml_grammar(XML_TOOLS, "required", tok)
+    accepted, total, accepting = _consume(
+        grammar, lltok, tok, _wire("x=1", language="cpp", timeout=30, verbose="true")
+    )
+    assert accepted == total and accepting, (
+        f"valid call with optional scalars rejected ({accepted}/{total})"
+    )
+
+
+@_requires_llguidance
+def test_xml_bad_enum_value_is_rejected(tok, lltok):
+    # ``language`` enum is {python, cpp}; "rust" must be masked.
+    grammar = _xml_grammar(XML_TOOLS, "required", tok)
+    accepted, total, _ = _consume(grammar, lltok, tok, _wire("x", language="rust"))
+    assert accepted < total, "invalid enum value was NOT rejected by the grammar"
+
+
+@_requires_llguidance
+def test_xml_off_schema_scalar_is_rejected(tok, lltok):
+    # ``timeout`` is an integer; a non-numeric value must be masked by ``%json``.
+    grammar = _xml_grammar(XML_TOOLS, "required", tok)
+    bad = (
+        "<tool_call>\n<function=run_code>\n"
+        "<parameter=code>\nx\n</parameter>\n"
+        "<parameter=language>\npython\n</parameter>\n"
+        "<parameter=timeout>\nnot_an_int"
+    )
+    accepted, total, _ = _consume(grammar, lltok, tok, bad)
+    assert accepted < total, "off-schema (non-integer) timeout was NOT rejected"
+
+
+@_requires_llguidance
+def test_xml_forced_rejects_prose_before_the_call(tok, lltok):
+    # Forced (required) non-reasoning: the first call sits AT the trigger with no
+    # free prefix, so bare prose before it is masked at token 0.
+    grammar = _xml_grammar(XML_TOOLS, "required", tok)
+    assert grammar is not None
+    prose_then_call = "Sure, let me run that. " + _wire("print(1)")
+    accepted, _total, _ = _consume(grammar, lltok, tok, prose_then_call)
+    assert accepted == 0, (
+        f"forced XML grammar accepted {accepted} prose token(s) before the "
+        "trigger — the unbounded leading prefix is back (#558 forced-leak)"
+    )
+
+
+# --------------------------------------------------------------------------
+# ROUND-TRIP: the qwen3_coder_xml parser parses the constrained wire back to
+# {name, arguments} with correct types — the surface forms the grammar emits
+# are exactly what the parser type-converts.
+# --------------------------------------------------------------------------
+def _parse(wire, tools):
+    parser = _make_qwen3coder(tokenizer=None)
+    req = {
+        "tools": [
+            {
+                "type": "function",
+                "function": {"name": t["name"], "parameters": t["parameters"]},
+            }
+            for t in tools
+        ]
+    }
+    res = parser.extract_tool_calls(wire, request=req)
+    assert res.tools_called, "parser did not detect the tool call"
+    tc = res.tool_calls[0]
+    return tc["name"], json.loads(tc["arguments"])
+
+
+@pytest.mark.parametrize("code", ["a < b && c > d", "vector<int> v", "print('ok')"])
+def test_roundtrip_string_value_with_angle_bracket(code):
+    # The constrained wire round-trips back to the EXACT string value (including
+    # ``<``) — the grammar and parser agree on the surface form.
+    name, args = _parse(_wire(code), XML_TOOLS)
+    assert name == "run_code"
+    assert args["code"] == code
+    assert args["language"] == "python"
+
+
+def test_roundtrip_scalar_types_int_bool():
+    # int / bool params type-convert correctly (not left as strings).
+    name, args = _parse(
+        _wire("x", language="cpp", timeout=30, verbose="true"), XML_TOOLS
+    )
+    assert args["timeout"] == 30 and isinstance(args["timeout"], int)
+    assert args["verbose"] is True
+    assert args["language"] == "cpp"
+
+
+def test_roundtrip_nested_object_value():
+    # A nested-object ($ref) value round-trips into a JSON object with typed
+    # fields — the ``%json`` surface form the grammar emits is what the parser
+    # json.loads-decodes.
+    wire = (
+        "<tool_call>\n<function=place>\n"
+        '<parameter=origin>\n{"x": 3, "y": 4}\n</parameter>\n'
+        "</function>\n</tool_call>"
+    )
+    name, args = _parse(wire, XML_REF_TOOL)
+    assert name == "place"
+    assert args["origin"] == {"x": 3, "y": 4}

--- a/tests/test_qwen3coder_xml_grammar_558.py
+++ b/tests/test_qwen3coder_xml_grammar_558.py
@@ -931,6 +931,93 @@ def test_representable_rejects_round2_property_names():
     )
 
 
+# ---- STRICT ALLOWLIST (codex round-3): enum axis + total required guard ------
+# Round-3 folded the ENUM branch INTO the allowlist (it previously blanket-accepted
+# ANY non-empty enum) and made the ``required`` guard TOTAL (it previously crashed
+# on an unhashable member). These prove the three holes opt out BY CONSTRUCTION
+# (no raise), plus a positive control that a clean string enum stays constrained.
+def test_representable_enum_positive_control_clean_string_enum():
+    # A clean string enum with only annotation keys stays representable (a literal
+    # alternation — the tightest constraint). Guards against over-opting-out.
+    from vllm_mlx.api.tool_grammar import _xml_schema_representable as rep
+
+    assert rep(
+        {"properties": {"u": {"type": "string", "enum": ["celsius", "fahrenheit"]}}}
+    )
+    # A type-less enum (the values fix the alternation) also stays representable.
+    assert rep({"properties": {"u": {"enum": ["a", "b"]}}}) is True
+    # A numeric enum consistent with its declared type stays representable.
+    assert rep({"properties": {"n": {"type": "number", "enum": [1.5, 2]}}}) is True
+
+
+def test_representable_enum_value_type_mismatch_opts_out():
+    # codex r3 #2: an enum whose declared type contradicts its values is
+    # schema-invalid on the wire -> opt out.
+    from vllm_mlx.api.tool_grammar import _xml_schema_representable as rep
+
+    assert rep({"properties": {"n": {"type": "integer", "enum": ["x"]}}}) is False
+    # bool is NOT an integer here (excluded from int/number).
+    assert rep({"properties": {"n": {"type": "integer", "enum": [True]}}}) is False
+    assert rep({"properties": {"n": {"type": "number", "enum": ["1.5"]}}}) is False
+    assert rep({"properties": {"b": {"type": "boolean", "enum": [1]}}}) is False
+    # An object/array declared type carrying an enum has no scalar wire -> opt out.
+    assert rep({"properties": {"o": {"type": "object", "enum": [{"a": 1}]}}}) is False
+
+
+def test_representable_enum_unsupported_sibling_opts_out():
+    # codex r3 #2: a validation sibling next to an enum (``minLength`` / ``pattern``
+    # / ``minItems`` / any non-annotation key) is NOT enforced by a bare
+    # alternation -> opt out rather than silently drop it.
+    from vllm_mlx.api.tool_grammar import _xml_schema_representable as rep
+
+    assert rep({"properties": {"s": {"enum": ["a", "bb"], "minLength": 2}}}) is False
+    assert (
+        rep({"properties": {"s": {"type": "string", "enum": ["a"], "pattern": "^a$"}}})
+        is False
+    )
+    assert rep({"properties": {"s": {"enum": ["a"], "minItems": 1}}}) is False
+
+
+def test_representable_enum_delimiter_bearing_value_opts_out():
+    # codex r3 #3: an enum value carrying the close delimiter (or any ``<``/``>``/
+    # newline) is grammar-accepted but truncates at the parser's FIRST
+    # ``</parameter>`` -> opt out rather than emit a wire-breaking literal.
+    from vllm_mlx.api.tool_grammar import _xml_schema_representable as rep
+
+    assert (
+        rep({"properties": {"s": {"type": "string", "enum": ["a</parameter>b"]}}})
+        is False
+    )
+    assert (
+        rep({"properties": {"s": {"type": "string", "enum": ["ok", "<x>"]}}}) is False
+    )
+    assert rep({"properties": {"s": {"type": "string", "enum": ["a\nb"]}}}) is False
+    # A non-string enum value whose json.dumps embeds a delimiter also opts out.
+    assert rep({"properties": {"o": {"enum": [{"k": "</parameter>"}]}}}) is False
+
+
+def test_representable_total_required_guard_never_raises():
+    # codex r3 #4 (REAL CRASH): a malformed ``required`` must OPT OUT, never raise.
+    # ``set(required)`` on an UNHASHABLE member (list/dict) raised ``TypeError``
+    # OUTSIDE the builder's exception handling -> a 500 on arbitrary client JSON.
+    from vllm_mlx.api.tool_grammar import _xml_schema_representable as rep
+
+    base = {"type": "object", "properties": {"a": {"type": "string"}}}
+    # ``required`` not a list -> opt out (no raise).
+    assert rep({**base, "required": "a"}) is False
+    assert rep({**base, "required": 123}) is False
+    assert rep({**base, "required": {"a": True}}) is False
+    # ``required`` containing an UNHASHABLE member (list / dict) -> opt out, and
+    # CRITICALLY does not raise ``TypeError`` from ``set(required)``.
+    assert rep({**base, "required": [["a"]]}) is False
+    assert rep({**base, "required": [{"k": "v"}]}) is False
+    assert rep({**base, "required": ["a", ["nested"]]}) is False
+    # A non-str hashable member (int) also opts out (cannot name a property).
+    assert rep({**base, "required": [1, 2]}) is False
+    # Control: a well-formed required ⊆ properties stays representable.
+    assert rep({**base, "required": ["a"]}) is True
+
+
 # ---- F3 REAL FIX: $ref resolved BEFORE the string-vs-%json decision ------
 def test_xml_ref_to_string_uses_raw_lazy_path_not_json():
     # Grammar-string level: a `$ref` -> string property emits the LAZY raw value
@@ -1051,3 +1138,61 @@ def test_build_tool_grammar_opts_out_f5_unsafe_key(tok):
         }
     ]
     assert _xml_grammar(bad_key_tool, "required", tok) is None
+
+
+# ---- codex round-3: end-to-end opt-out (real parser) — no crash on bad input --
+@_requires_llguidance
+def test_build_tool_grammar_opts_out_r3_malformed_required_no_crash(tok):
+    # codex r3 #4: a malformed `required` (non-list, or a list with an UNHASHABLE
+    # member) must opt out to free-form (None) WITHOUT raising — `set(required)`
+    # in the guard previously raised `TypeError` OUTSIDE the builder's exception
+    # handling (a 500). Reaching `build_tool_grammar` at all exercises the guard
+    # site that crashed.
+    for bad_required in ("code", [["code"]], [{"k": "v"}], 7):
+        tool = [
+            {
+                "name": "run_code",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"code": {"type": "string"}},
+                    "required": bad_required,
+                },
+            }
+        ]
+        assert _xml_grammar(tool, "required", tok) is None, bad_required
+
+
+@_requires_llguidance
+def test_build_tool_grammar_opts_out_r3_bad_enum(tok):
+    # codex r3 #2/#3: an enum type-mismatch / unsupported sibling / delimiter-bearing
+    # value each opt the whole request out of grammar; a clean string enum builds.
+    def _tool(enum_schema):
+        return [
+            {
+                "name": "run_code",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"code": {"type": "string"}, "e": enum_schema},
+                    "required": ["code"],
+                },
+            }
+        ]
+
+    assert (
+        _xml_grammar(_tool({"type": "integer", "enum": ["x"]}), "required", tok) is None
+    )
+    assert (
+        _xml_grammar(_tool({"enum": ["a", "bb"], "minLength": 2}), "required", tok)
+        is None
+    )
+    assert (
+        _xml_grammar(
+            _tool({"type": "string", "enum": ["a</parameter>b"]}), "required", tok
+        )
+        is None
+    )
+    # Control: a clean string enum still builds a grammar (not a generic failure).
+    assert (
+        _xml_grammar(_tool({"type": "string", "enum": ["ok", "no"]}), "required", tok)
+        is not None
+    )

--- a/tests/test_qwen3coder_xml_grammar_558.py
+++ b/tests/test_qwen3coder_xml_grammar_558.py
@@ -100,6 +100,25 @@ XML_REF_TOOL = [
 ]
 
 
+# A tool whose ONLY property is a ``$ref`` resolving to a STRING (F3). Before the
+# fix, ``$defs`` were attached only AFTER the string-vs-``%json`` decision, so this
+# ``$ref`` fell through to ``%json`` and emitted QUOTED JSON the parser returned
+# with quotes preserved (``"\\"Paris\\""``). The fix resolves the ``$ref`` FIRST so
+# it takes the RAW lazy path and round-trips WITHOUT quotes.
+XML_REF_STRING_TOOL = [
+    {
+        "name": "geo",
+        "parameters": {
+            "type": "object",
+            "properties": {"city": {"$ref": "#/$defs/City"}},
+            "required": ["city"],
+            "$defs": {"City": {"type": "string"}},
+            "additionalProperties": False,
+        },
+    },
+]
+
+
 def _xml_structure_info(name: str):
     """The Qwen3-Coder XML wire triple, exactly as ``Qwen3CoderToolParser``
     ships it (``arg_style="xml"``). Declared test-locally so the pure-Python
@@ -653,3 +672,223 @@ def test_roundtrip_nested_object_value():
     name, args = _parse(wire, XML_REF_TOOL)
     assert name == "place"
     assert args["origin"] == {"x": 3, "y": 4}
+
+
+# ==========================================================================
+# FAITHFUL-OR-OPT-OUT (#558 E3, codex converge). The XML arg emitter is a
+# best-effort OPT-IN: when it cannot FAITHFULLY represent a schema the WHOLE
+# request opts out of grammar (``build_tool_grammar`` -> ``None``, free-form
+# fallback) rather than emit a grammar that silently allows schema-invalid or
+# mis-typed output. One test per BLOCKING finding (F1/F2/F4/F5 as opt-out, F3 as
+# a REAL fix). Pure-Python guard tests always run; the ``build_tool_grammar``
+# integration tests skip only on genuine tokenizer/llguidance unavailability.
+# ==========================================================================
+
+
+# ---- Pure-Python representability guard (always runs) --------------------
+def test_representable_common_and_noarg_schemas():
+    # The common case + a genuine no-arg tool MUST stay representable (no
+    # regression): typed properties, enums, required + optional, empty body.
+    from vllm_mlx.api.tool_grammar import _xml_schema_representable as rep
+
+    assert rep(XML_TOOLS[0]["parameters"]) is True
+    assert rep(XML_REF_TOOL[0]["parameters"]) is True  # $ref -> object
+    assert rep(XML_REF_STRING_TOOL[0]["parameters"]) is True  # $ref -> string
+    assert rep({"type": "object", "properties": {}, "additionalProperties": False})
+    assert rep({}) is True  # allow-any / no-arg
+
+
+def test_representable_rejects_f1_property_less_but_nontrivial():
+    from vllm_mlx.api.tool_grammar import _xml_schema_representable as rep
+
+    # F1: `false` schema (accepts no instance).
+    assert rep(False) is False
+    # F1: property-less but has `required`.
+    assert rep({"type": "object", "required": ["a"]}) is False
+    # F1: top-level `$ref` with no inline properties.
+    assert rep({"$ref": "#/$defs/x", "$defs": {"x": {"type": "object"}}}) is False
+    # F1 (spirit): a non-object top-level type has no XML parameter body.
+    assert rep({"type": "array"}) is False
+
+
+def test_representable_rejects_f2_string_facets():
+    from vllm_mlx.api.tool_grammar import _xml_schema_representable as rep
+
+    for facet in ("pattern", "minLength", "maxLength", "format", "const"):
+        params = {
+            "type": "object",
+            "properties": {
+                "s": {"type": "string", facet: "x" if facet != "minLength" else 2}
+            },
+        }
+        assert rep(params) is False, facet
+    # Enum (already enforced as an alternation) stays representable.
+    assert rep({"properties": {"s": {"type": "string", "enum": ["a", "b"]}}}) is True
+    # A `$ref` -> string carrying a facet is caught AFTER resolution (F2 + F3).
+    assert (
+        rep(
+            {
+                "properties": {"c": {"$ref": "#/$defs/C"}},
+                "$defs": {"C": {"type": "string", "pattern": "^x$"}},
+            }
+        )
+        is False
+    )
+
+
+def test_representable_rejects_f4_object_level_keywords():
+    from vllm_mlx.api.tool_grammar import _xml_schema_representable as rep
+
+    props = {"a": {"type": "string"}, "b": {"type": "string"}}
+    for kw, val in (
+        ("dependentRequired", {"a": ["b"]}),
+        ("dependencies", {"a": ["b"]}),
+        ("if", {}),
+        ("then", {}),
+        ("else", {}),
+        ("not", {}),
+        ("patternProperties", {"^x": {"type": "string"}}),
+        ("allOf", [{}]),
+        ("anyOf", [{}]),
+        ("oneOf", [{}]),
+    ):
+        assert rep({"type": "object", "properties": props, kw: val}) is False, kw
+
+
+def test_representable_rejects_f5_delimiter_unsafe_keys():
+    from vllm_mlx.api.tool_grammar import _xml_schema_representable as rep
+
+    for bad in ("x>y", "x<y", "a:b", "a,b", "a b", "a\nb", "a{b", "a}b"):
+        assert rep({"properties": {bad: {"type": "string"}}}) is False, bad
+    # A normal [\w-]+ key stays representable.
+    assert rep({"properties": {"my_key-1": {"type": "string"}}}) is True
+
+
+def test_representable_unresolvable_ref_opts_out():
+    from vllm_mlx.api.tool_grammar import _xml_schema_representable as rep
+
+    # A property `$ref` that does not resolve locally is unrepresentable.
+    assert rep({"properties": {"c": {"$ref": "#/$defs/missing"}, "$defs": {}}}) is False
+    assert rep({"properties": {"c": {"$ref": "http://remote/x"}}}) is False
+
+
+# ---- F3 REAL FIX: $ref resolved BEFORE the string-vs-%json decision ------
+def test_xml_ref_to_string_uses_raw_lazy_path_not_json():
+    # Grammar-string level: a `$ref` -> string property emits the LAZY raw value
+    # rule, NOT `%json` (whose quotes the parser would keep). The tool's only
+    # param is a `$ref` -> string, so the whole grammar has NO `%json` at all.
+    from vllm_mlx.api.tool_grammar import build_tool_lark
+
+    lark = build_tool_lark(
+        XML_REF_STRING_TOOL, "required", [_xml_structure_info("geo")]
+    )
+    assert '"<parameter=city>\\n" xml_param_value "\\n"' in lark
+    assert "%json" not in lark
+
+
+def test_xml_ref_to_object_still_uses_json():
+    # The complementary case: a `$ref` -> OBJECT still rides `%json` (over the
+    # original `$ref` + merged `$defs`, which llguidance resolves internally).
+    from vllm_mlx.api.tool_grammar import build_tool_lark
+
+    lark = build_tool_lark(XML_REF_TOOL, "required", [_xml_structure_info("place")])
+    assert '"<parameter=origin>\\n" %json' in lark
+
+
+@_requires_llguidance
+def test_xml_ref_to_string_roundtrips_without_quotes(tok, lltok):
+    # F3 end-to-end on the REAL tokenizer: the grammar for a `$ref` -> string
+    # param ACCEPTS a RAW unquoted value and is terminal (before the fix it forced
+    # a QUOTED `%json` string, so raw `Paris` would be rejected), and the parser
+    # round-trips it to the clean value `Paris` — NOT `"Paris"` (quotes preserved).
+    grammar = _xml_grammar(XML_REF_STRING_TOOL, "required", tok)
+    assert grammar is not None
+    wire = (
+        "<tool_call>\n<function=geo>\n"
+        "<parameter=city>\nParis\n</parameter>\n"
+        "</function>\n</tool_call>"
+    )
+    accepted, total, accepting = _consume(grammar, lltok, tok, wire)
+    assert accepted == total and accepting, (
+        f"$ref->string raw value rejected ({accepted}/{total}, "
+        f"accepting={accepting}) — F3 regression (still on the quoted %json path)"
+    )
+    name, args = _parse(wire, XML_REF_STRING_TOOL)
+    assert name == "geo"
+    assert args["city"] == "Paris"  # no surrounding quotes
+
+
+# ---- F1/F2/F4/F5 OPT-OUT through build_tool_grammar (real parser) --------
+@_requires_llguidance
+def test_build_tool_grammar_opts_out_f1_toplevel_ref(tok):
+    # Control: a representable XML tool DOES build a grammar (proves the opt-out
+    # below is the guard, not a generic build failure).
+    assert _xml_grammar(XML_TOOLS, "required", tok) is not None
+    # F1: a top-level `$ref` (no inline properties) would collapse to an EMPTY
+    # body allowing `{}` even though the schema requires fields -> opt out.
+    ref_tool = [
+        {
+            "name": "run_code",
+            "parameters": {
+                "$ref": "#/$defs/loc",
+                "$defs": {
+                    "loc": {
+                        "type": "object",
+                        "properties": {"x": {"type": "integer"}},
+                        "required": ["x"],
+                    }
+                },
+            },
+        }
+    ]
+    assert _xml_grammar(ref_tool, "required", tok) is None
+
+
+@_requires_llguidance
+def test_build_tool_grammar_opts_out_f2_string_pattern(tok):
+    # F2: a string param with `pattern` cannot be enforced on the raw value path.
+    pat_tool = [
+        {
+            "name": "run_code",
+            "parameters": {
+                "type": "object",
+                "properties": {"code": {"type": "string", "pattern": "^[a-z]+$"}},
+                "required": ["code"],
+            },
+        }
+    ]
+    assert _xml_grammar(pat_tool, "required", tok) is None
+
+
+@_requires_llguidance
+def test_build_tool_grammar_opts_out_f4_dependent_required(tok):
+    # F4: `dependentRequired` (object-level relation) is emitted-around, not
+    # enforced — it would let `a` appear without its required `b` -> opt out.
+    dep_tool = [
+        {
+            "name": "run_code",
+            "parameters": {
+                "type": "object",
+                "properties": {"a": {"type": "string"}, "b": {"type": "string"}},
+                "dependentRequired": {"a": ["b"]},
+            },
+        }
+    ]
+    assert _xml_grammar(dep_tool, "required", tok) is None
+
+
+@_requires_llguidance
+def test_build_tool_grammar_opts_out_f5_unsafe_key(tok):
+    # F5: a key containing `>` inserted RAW into `<parameter=KEY>` would be parsed
+    # back as a DIFFERENT key -> opt out.
+    bad_key_tool = [
+        {
+            "name": "run_code",
+            "parameters": {
+                "type": "object",
+                "properties": {"x>y": {"type": "string"}},
+                "required": ["x>y"],
+            },
+        }
+    ]
+    assert _xml_grammar(bad_key_tool, "required", tok) is None

--- a/vllm_mlx/api/tool_grammar.py
+++ b/vllm_mlx/api/tool_grammar.py
@@ -451,7 +451,9 @@ _XML_STRING_TERMINAL_DECL = (
 #     constrained); ``set(required) ⊆ set(properties)``; a genuine no-arg tool
 #     (no ``properties`` + no ``required``) stays representable (empty body).
 #   * EACH PROPERTY (after resolving a single-level local ``$ref``): a non-empty
-#     ``enum`` (alternation), OR ``type=="string"`` with keys ⊆
+#     ``enum`` (alternation) whose keys are annotation-only, whose values are
+#     type-consistent, and whose wire form is delimiter-safe
+#     (``_xml_enum_representable`` — codex r3 #2/#3), OR ``type=="string"`` with keys ⊆
 #     ``_XML_ALLOWED_STRING_KEYS`` (no ``const``/``pattern``/``minLength``/
 #     ``maxLength``/``format``), OR ``type in {integer,number,boolean}`` (bare
 #     terminal), OR ``type in {object,array}`` (``%json`` — llguidance's JSON
@@ -478,9 +480,10 @@ _XML_ALLOWED_TOPLEVEL_KEYS = frozenset(
 )
 # Keys a ``type=="string"`` property may carry. Anything else (``const`` /
 # ``pattern`` / ``minLength`` / ``maxLength`` / ``format`` / any unknown facet)
-# cannot be enforced by the raw lazy value path -> opt out. ``enum`` is listed
-# for completeness though the enum-first branch handles a non-empty enum before
-# the string-type check is reached.
+# cannot be enforced by the raw lazy value path -> opt out. This annotation-only
+# set is ALSO the allowlist for an ENUM property's keys (``_xml_enum_representable``):
+# a validation sibling (``minLength`` / ``pattern`` / …) next to an ``enum`` is
+# not enforced by a bare literal alternation, so it opts out too.
 _XML_ALLOWED_STRING_KEYS = frozenset(
     {
         "type",
@@ -573,6 +576,77 @@ def _resolve_local_ref(subschema: Any, defs: dict[str, Any]) -> Any:
     return resolved
 
 
+def _enum_value_matches_declared_type(value: Any, declared: str) -> bool:
+    """True iff ``value``'s JSON type is consistent with a declared scalar ``type``.
+
+    Maps the four JSON-Schema scalar types to their Python instance test
+    (string→``str``, integer→``int``, number→``int``|``float``, boolean→``bool``),
+    excluding ``bool`` from the numeric types (a Python ``bool`` is an ``int``
+    subclass). ANY other declared type — ``object`` / ``array`` / ``null`` / an
+    unknown string — carrying an enum returns ``False`` so the caller opts out:
+    the delimiter-based XML value wire cannot faithfully constrain a non-scalar
+    enum.
+    """
+    t = declared.strip().lower()
+    if t == "string":
+        return isinstance(value, str)
+    if t == "integer":
+        return isinstance(value, int) and not isinstance(value, bool)
+    if t == "number":
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+    if t == "boolean":
+        return isinstance(value, bool)
+    return False
+
+
+def _xml_enum_representable(resolved: dict[str, Any], enum: list[Any]) -> bool:
+    """True iff an ENUM property is inside the XML emitter's closed allowlist.
+
+    Routes the enum-first branch THROUGH the allowlist (codex r3 #2/#3) so the
+    enum axis is complete-by-construction like the rest of the guard, instead of
+    blanket-accepting ANY non-empty ``enum``. Representable ONLY when ALL hold:
+
+      * keys ⊆ the annotation-only set (``_XML_ALLOWED_STRING_KEYS`` =
+        ``{type, enum, description, title, default}``): any VALIDATION sibling
+        (``minLength`` / ``pattern`` / ``minItems`` / ``const`` / a size facet /
+        any unknown key) is NOT enforced by a bare literal alternation, so it
+        opts out rather than being silently ignored (codex r3 #2 —
+        ``{"enum": ["a", "bb"], "minLength": 2}``);
+      * if ``type`` is present it must be a STRING and EVERY enum value's JSON
+        type must be consistent with it (codex r3 #2 —
+        ``{"type": "integer", "enum": ["x"]}`` opts out on the value/type
+        mismatch; an ``object``/``array``/``null`` declared type opts out);
+      * NO enum value's WIRE form carries a delimiter-breaking byte (``<`` / ``>``
+        / CR / LF). The wire form mirrors ``_emit_xml_param_value`` EXACTLY (the
+        raw text for a string value, ``json.dumps`` otherwise), so a value such as
+        ``"a</parameter>b"`` — grammar-accepted but truncated at the parser's
+        FIRST ``</parameter>`` — is rejected here rather than emitted (codex r3
+        #3).
+    """
+    # (a) annotation-only keys: a validation sibling cannot be enforced next to a
+    # bare literal alternation, so its presence must opt out (never be dropped).
+    if not set(resolved.keys()) <= _XML_ALLOWED_STRING_KEYS:
+        return False
+    declared = resolved.get("type")
+    if declared is not None and not isinstance(declared, str):
+        # A non-string ``type`` (union list / bool / …) alongside an enum is not a
+        # shape we can verify -> opt out.
+        return False
+    for value in enum:
+        # (b) value/type consistency when a scalar ``type`` is declared.
+        if isinstance(declared, str) and not _enum_value_matches_declared_type(
+            value, declared
+        ):
+            return False
+        # (c) delimiter safety on the EXACT wire form the emitter would produce
+        # (raw for a string value, ``json.dumps`` otherwise — enum values come
+        # from parsed client JSON, so ``json.dumps`` is total and never raises).
+        wire = value if isinstance(value, str) else json.dumps(value)
+        if any(c in "<>\r\n" for c in wire):
+            return False
+    return True
+
+
 def _xml_property_representable(subschema: Any, defs: dict[str, Any]) -> bool:
     """True iff ONE property schema is inside the XML emitter's closed allowlist.
 
@@ -581,8 +655,9 @@ def _xml_property_representable(subschema: Any, defs: dict[str, Any]) -> bool:
     ``false``/``true`` bool schema returns ``None`` -> opt out), the resolved
     schema is representable ONLY as one of the enumerated shapes:
 
-      * a non-empty ``enum`` list — rendered as a literal ALTERNATION (the
-        tightest possible constraint; facets are irrelevant next to it), OR
+      * a non-empty ``enum`` list — rendered as a literal ALTERNATION, admitted
+        ONLY through ``_xml_enum_representable`` (annotation-only keys, value/
+        declared-type consistency, delimiter-safe wire values — codex r3 #2/#3), OR
       * ``type == "string"`` whose keys ⊆ ``_XML_ALLOWED_STRING_KEYS`` — the raw
         lazy value path (a ``const``/``pattern``/``minLength``/``maxLength``/
         ``format`` or ANY unknown facet it cannot enforce opts out), OR
@@ -596,11 +671,14 @@ def _xml_property_representable(subschema: Any, defs: dict[str, Any]) -> bool:
         # Unresolvable/sibling ``$ref`` (None) or a ``false``/``true`` bool schema
         # / non-dict -> not representable.
         return False
-    # Enum-first: a non-empty enum renders as an alternation of literals — the
-    # tightest constraint, so it is representable regardless of ``type``/facets.
+    # Enum-first: a non-empty enum renders as an alternation of literals. Route it
+    # THROUGH the allowlist (codex r3 #2/#3) rather than blanket-accepting any
+    # non-empty enum — validate annotation-only keys, value/declared-type
+    # consistency, and delimiter-safe wire values, so the enum axis is
+    # complete-by-construction too.
     enum = resolved.get("enum")
     if isinstance(enum, list) and enum:
-        return True
+        return _xml_enum_representable(resolved, enum)
     prop_type = resolved.get("type")
     if not isinstance(prop_type, str):
         # Absent / union (list) / non-string ``type`` -> opt out.
@@ -673,7 +751,16 @@ def _xml_schema_representable(params: Any) -> bool:
     # also opts out the property-less-but-``required`` case (empty body wrong).
     required = params.get("required")
     if required is not None:
-        if not isinstance(required, list):
+        # TOTAL guard (codex r3 #4): ``required`` must be a list of STRINGS. A
+        # non-list, or ANY non-str member (a client-supplied list/dict is
+        # UNHASHABLE), would otherwise make ``set(required)`` below raise
+        # ``TypeError`` — and this guard runs OUTSIDE the builder's exception
+        # handling, so an arbitrary-client-JSON ``required`` would 500. Validate
+        # the shape first and opt out gracefully; only then is ``set(required)``
+        # provably safe. (The guard must NEVER raise on arbitrary client JSON.)
+        if not isinstance(required, list) or not all(
+            isinstance(r, str) for r in required
+        ):
             return False
         if not set(required) <= set(prop_map.keys()):
             return False
@@ -740,6 +827,11 @@ def _emit_xml_param_value(subschema: Any, defs: dict[str, Any]) -> str:
         resolved = subschema
     enum = resolved.get("enum")
     if isinstance(enum, list) and enum:
+        # Every value's wire form here is already delimiter-safe and type-consistent:
+        # ``_xml_enum_representable`` (in the representability guard) opted the whole
+        # request out otherwise (codex r3 #2/#3), so this raw emission cannot break
+        # the ``</parameter>`` framing. Keep the wire form byte-identical to that
+        # guard's check (raw for a string value, ``json.dumps`` otherwise).
         alts = []
         for value in enum:
             literal = value if isinstance(value, str) else json.dumps(value)
@@ -772,9 +864,30 @@ def _emit_xml_arg_body(params: Any) -> str:
         return ""
     props = params.get("properties")
     if not isinstance(props, dict) or not props:
+        # INTENTIONAL tool-calling-domain choice (codex r3 #1), NOT an oversight:
+        # a tool whose ``parameters`` declares no properties takes NO arguments, so
+        # the EMPTY body IS the correct, desired constraint — it forces a no-arg
+        # call. JSON-Schema's default-OPEN-object semantics (where ``{}`` /
+        # ``{"type": "object"}`` permit arbitrary properties) are DELIBERATELY not
+        # applied on the tool-call wire: opting out here would leave a no-arg tool
+        # LESS constrained (the model could emit arbitrary ``<parameter=…>``
+        # blocks). The genuinely-OPEN case — an EXPLICIT ``additionalProperties:
+        # true`` (or a schema value) — is already opted out UPSTREAM by
+        # ``_xml_schema_representable`` (only a literal ``additionalProperties:
+        # false`` / absent reaches here), so a truly-open object never collapses to
+        # an empty body while the common no-arg shape stays fully constrained.
         return ""
     required = params.get("required")
-    required_set = set(required) if isinstance(required, list) else set()
+    # Only STRING members can name a property (mirrors the total guard in
+    # ``_xml_schema_representable`` — codex r3 #4); a non-str member is unhashable
+    # and would raise in a bare ``set(required)``. The representability guard has
+    # already opted out any malformed ``required`` before we reach here, but stay
+    # total regardless of caller.
+    required_set = (
+        {r for r in required if isinstance(r, str)}
+        if isinstance(required, list)
+        else set()
+    )
     defs = _collect_xml_defs(params)
     frags: list[str] = []
     for key, subschema in props.items():

--- a/vllm_mlx/api/tool_grammar.py
+++ b/vllm_mlx/api/tool_grammar.py
@@ -421,6 +421,195 @@ _XML_STRING_TERMINAL_DECL = (
 )
 
 
+# ------------------------------------------------------------------------
+# FAITHFUL-OR-OPT-OUT representability guard for the Qwen3-Coder XML arg wire
+# (#558 E3, codex converge). The XML emitter (``_emit_xml_arg_body`` /
+# ``_emit_xml_param_value``) is a BEST-EFFORT OPT-IN: it can faithfully
+# constrain the common tool schema (typed top-level ``properties``, enums,
+# nested objects/arrays via ``%json``, required + optional ``( )?``), but a
+# handful of schema shapes CANNOT be represented on the delimiter-based XML
+# wire without silently permitting schema-invalid or mis-typed output. When a
+# request contains ANY such shape on an XML-arg tool, the whole request must
+# OPT OUT of grammar (``build_tool_grammar`` returns ``None`` -> free-form-
+# then-parse, the safe existing path) rather than emit a lax grammar.
+#
+# The unrepresentable shapes (mirroring the 5 codex BLOCKING findings):
+#   * F1 — a property-less BUT non-trivial top-level schema (``required`` /
+#     top-level ``$ref`` / non-object ``type``; ``false`` / composition / ``not``
+#     are caught by the checks below) would collapse to an EMPTY body (``{}``),
+#     which is wrong for a schema that requires fields or accepts no instance.
+#   * F2 — a top-level string property carrying ``const`` / ``pattern`` /
+#     ``minLength`` / ``maxLength`` / ``format`` cannot be enforced by the raw
+#     lazy value path (it admits ANY text), so those constraints are silently
+#     ignored. (Enum IS enforced — an alternation — so it stays representable.)
+#   * F4 — object-level relational keywords (``dependentRequired`` /
+#     ``dependencies`` / ``if`` / ``then`` / ``else`` / ``not`` /
+#     ``patternProperties``) and top-level composition (``allOf`` / ``anyOf`` /
+#     ``oneOf``) are emitted-around, not enforced, so e.g. ``dependentRequired``
+#     would let an ``a`` block appear without its required ``b``.
+#   * F5 — a property KEY that is not delimiter-safe (contains ``< > { } : ,`` or
+#     whitespace) would be inserted RAW into ``<parameter=KEY>`` and parsed back
+#     as a DIFFERENT key.
+# (F3 is a REAL fix, not an opt-out: ``_emit_xml_param_value`` resolves a local
+# ``$ref`` BEFORE the string-vs-``%json`` decision so a ``$ref``->string
+# round-trips without quotes; only an UNRESOLVABLE ``$ref`` opts out here.)
+_XML_UNSUPPORTED_OBJECT_KEYWORDS: tuple[str, ...] = (
+    "dependentRequired",
+    "dependencies",
+    "if",
+    "then",
+    "else",
+    "not",
+    "patternProperties",
+    "allOf",
+    "anyOf",
+    "oneOf",
+)
+_XML_UNSUPPORTED_STRING_KEYWORDS: tuple[str, ...] = (
+    "const",
+    "pattern",
+    "minLength",
+    "maxLength",
+    "format",
+)
+# Characters that would break out of the ``<parameter=KEY>`` delimiter wire (or
+# collide with the JSON-ish surfaces the parser round-trips). OpenAI tool
+# parameter names are normally ``[\w-]+``; be conservative.
+_XML_UNSAFE_KEY_CHARS = frozenset("<>{},:")
+
+
+def _collect_xml_defs(params: dict[str, Any]) -> dict[str, Any]:
+    """Return the ``$defs`` / ``definitions`` containers present in ``params``."""
+    defs: dict[str, Any] = {}
+    for def_key in ("$defs", "definitions"):
+        d = params.get(def_key)
+        if isinstance(d, dict):
+            defs[def_key] = d
+    return defs
+
+
+def _xml_key_is_delimiter_safe(key: Any) -> bool:
+    """True iff ``key`` is safe to insert RAW into ``<parameter=KEY>`` (F5).
+
+    Rejects a non-string / empty key, any ``< > { } : ,`` (which would desync the
+    delimiter wire so the parser reads back a DIFFERENT key), and any whitespace
+    (a newline would split the ``<parameter=KEY>`` header across the wire's own
+    ``\\n`` framing).
+    """
+    if not isinstance(key, str) or not key:
+        return False
+    if any(c in _XML_UNSAFE_KEY_CHARS for c in key):
+        return False
+    return not any(c.isspace() for c in key)
+
+
+def _resolve_local_ref(subschema: Any, defs: dict[str, Any]) -> Any:
+    """Resolve a single-level local ``$ref`` against ``defs`` (F3).
+
+    ``defs`` is the ``{"$defs": {...}, "definitions": {...}}`` mapping
+    ``_collect_xml_defs`` returns. Handles ONLY a single-level local pointer
+    (``#/$defs/NAME`` or ``#/definitions/NAME``):
+
+      * a schema WITHOUT a ``$ref`` is returned UNCHANGED (the caller decides its
+        type as before);
+      * a resolvable single-level local ``$ref`` returns the target dict;
+      * an unresolvable / unsupported ``$ref`` (remote, non-local, multi-hop, or
+        a missing/ non-dict target) returns ``None`` — the caller treats that as
+        UNREPRESENTABLE and opts the request out.
+    """
+    if not isinstance(subschema, dict):
+        return subschema
+    ref = subschema.get("$ref")
+    if ref is None:
+        return subschema
+    if not isinstance(ref, str) or not ref.startswith("#/"):
+        return None
+    parts = ref[2:].split("/")
+    if len(parts) != 2 or parts[0] not in ("$defs", "definitions"):
+        return None
+    container = defs.get(parts[0])
+    if not isinstance(container, dict):
+        return None
+    # JSON-pointer unescape (``~1`` -> ``/``, ``~0`` -> ``~``).
+    name = parts[1].replace("~1", "/").replace("~0", "~")
+    resolved = container.get(name)
+    if not isinstance(resolved, dict):
+        return None
+    return resolved
+
+
+def _xml_schema_representable(params: Any) -> bool:
+    """True iff the XML arg emitter can FAITHFULLY constrain ``params`` (#558 E3).
+
+    Returns ``False`` -> the request OPTS OUT of grammar (free-form fallback) for
+    the unrepresentable schema shapes described in the module block above
+    (F1/F2/F4/F5, plus an unresolvable ``$ref``). Returns ``True`` for the common
+    case (typed top-level ``properties``, enums, nested objects/arrays, required +
+    optional) AND for a genuine no-argument tool (no ``properties``, no
+    ``required``, no ``$ref``, object/absent top-level ``type``) — whose empty
+    body IS the faithful representation.
+    """
+    # F1: a ``false`` schema (accepts NO instance) — or any non-dict — cannot be
+    # rendered as an empty XML body; opt out.
+    if not isinstance(params, dict):
+        return False
+    # Lazy import: keep this module importable independently of api.tool_calling.
+    from .tool_calling import _schema_type
+
+    # F4: object-level relational keywords + top-level composition are emitted
+    # AROUND, never enforced. Reject them whether or not ``properties`` is present.
+    for kw in _XML_UNSUPPORTED_OBJECT_KEYWORDS:
+        if kw in params:
+            return False
+
+    defs = _collect_xml_defs(params)
+    props = params.get("properties")
+    has_props = isinstance(props, dict) and bool(props)
+
+    if not has_props:
+        # F1: property-less BUT non-trivial -> the empty body would misrepresent
+        # it. (Composition / ``not`` already rejected above.)
+        required = params.get("required")
+        if isinstance(required, list) and required:
+            return False
+        if "$ref" in params:
+            return False
+        # A non-object top-level ``type`` (array / string / number / ...) has no
+        # XML parameter-body representation; the empty body would misrepresent it.
+        top_type = params.get("type")
+        if isinstance(top_type, str) and top_type.strip().lower() not in (
+            "object",
+            "null",
+        ):
+            return False
+        if isinstance(top_type, list):
+            norm = {t.strip().lower() for t in top_type if isinstance(t, str)}
+            if norm - {"object", "null"}:
+                return False
+        # Genuine no-argument tool -> empty body is correct.
+        return True
+
+    # Has ``properties``: validate each TOP-LEVEL property (nested schemas ride
+    # ``%json`` and are enforced there, so only the top level needs guarding).
+    for key, subschema in props.items():
+        # F5: the key is emitted RAW into ``<parameter=KEY>`` -> must be safe.
+        if not _xml_key_is_delimiter_safe(key):
+            return False
+        # F3: resolve a single-level local ``$ref`` first; an unresolvable ref is
+        # unrepresentable.
+        resolved = _resolve_local_ref(subschema, defs)
+        if resolved is None:
+            return False
+        # F2: a top-level string property takes the RAW lazy value path, which
+        # cannot enforce these facets -> opt out. (Enum is enforced separately as
+        # an alternation, so an enum WITHOUT these facets stays representable.)
+        if _schema_type(resolved) == "string":
+            for kw in _XML_UNSUPPORTED_STRING_KEYWORDS:
+                if kw in resolved:
+                    return False
+    return True
+
+
 def _emit_xml_param_value(subschema: Any, defs: dict[str, Any]) -> str:
     """Return the Lark for one XML parameter's VALUE plus its closing literal.
 
@@ -454,7 +643,21 @@ def _emit_xml_param_value(subschema: Any, defs: dict[str, Any]) -> str:
     close_lazy = _lark_escape("\n")
     if not isinstance(subschema, dict):
         return f"{_XML_STRING_VALUE_RULE} {close_lazy}"
-    enum = subschema.get("enum")
+    # F3 (#558 E3 codex converge): resolve a single-level local ``$ref`` BEFORE
+    # the enum/string-vs-``%json`` decision, so a ``$ref``->string takes the
+    # RAW-string (lazy) path and round-trips WITHOUT surrounding quotes — the
+    # pilot attached ``$defs`` only AFTER this decision, so a ``$ref``->string
+    # fell through to ``%json`` and emitted QUOTED JSON the parser returned with
+    # quotes preserved (``"\\"Paris\\""``). A ``$ref``->object still takes the
+    # ``%json`` path below (over the ORIGINAL ``$ref`` + merged ``$defs``, which
+    # llguidance resolves internally). ``_resolve_local_ref`` returns the schema
+    # unchanged when there is no ``$ref``; a ``None`` (unresolvable) is defensive
+    # — the representability guard already opted such a request out — and falls
+    # back to the ``%json`` path over the original.
+    resolved = _resolve_local_ref(subschema, defs)
+    if resolved is None:
+        resolved = subschema
+    enum = resolved.get("enum")
     if isinstance(enum, list) and enum:
         alts = []
         for value in enum:
@@ -465,7 +668,7 @@ def _emit_xml_param_value(subschema: Any, defs: dict[str, Any]) -> str:
     # (no cycle today, but the lazy import future-proofs it).
     from .tool_calling import _schema_type
 
-    if _schema_type(subschema) == "string":
+    if _schema_type(resolved) == "string":
         return f"{_XML_STRING_VALUE_RULE} {close_lazy}"
     value_schema = dict(subschema)
     for def_key, def_val in defs.items():
@@ -491,11 +694,7 @@ def _emit_xml_arg_body(params: Any) -> str:
         return ""
     required = params.get("required")
     required_set = set(required) if isinstance(required, list) else set()
-    defs: dict[str, Any] = {}
-    for def_key in ("$defs", "definitions"):
-        d = params.get(def_key)
-        if isinstance(d, dict):
-            defs[def_key] = d
+    defs = _collect_xml_defs(params)
     frags: list[str] = []
     for key, subschema in props.items():
         open_lit = _lark_escape(f"<parameter={key}>\n")
@@ -1214,6 +1413,38 @@ def build_tool_grammar(
         if si is None:
             return None
         structure_infos.append(si)
+
+    # FAITHFUL-OR-OPT-OUT gate for the Qwen3-Coder XML arg wire (#558 E3, codex
+    # converge). The XML emitter cannot faithfully constrain a handful of schema
+    # shapes (property-less-but-non-trivial / unconstrained string facets /
+    # object-level relational keywords / delimiter-unsafe keys / an unresolvable
+    # ``$ref`` — see ``_xml_schema_representable``). When ANY xml-arg tool carries
+    # such a shape, opt the WHOLE request OUT of grammar (return ``None`` -> the
+    # route falls back to free-form-then-parse) rather than emit a grammar that
+    # silently allows schema-invalid or mis-typed output. This mirrors the
+    # existing opt-outs (``structure_info() -> None`` / ``TOOL_GRAMMAR_AUTO_SAFE``)
+    # and applies ONLY to ``arg_style != "json"`` tools — the JSON-body families
+    # (hermes / qwen / harmony) are ``%json <schema>`` and stay byte-identical.
+    for tool, si in zip(tools, structure_infos):
+        if getattr(si, "arg_style", "json") == "json":
+            continue
+        # Resolve ``parameters`` EXACTLY as ``build_tool_lark`` does (a genuine
+        # no-arg tool gets the closed default, which IS representable).
+        if "parameters" in tool and tool["parameters"] is not None:
+            params = tool["parameters"]
+        else:
+            params = {
+                "type": "object",
+                "properties": {},
+                "additionalProperties": False,
+            }
+        if not _xml_schema_representable(params):
+            logger.debug(
+                "tool-grammar: XML arg schema for tool %r not faithfully "
+                "representable; opting request out of grammar (free-form)",
+                tool.get("name"),
+            )
+            return None
 
     try:
         lark = build_tool_lark(

--- a/vllm_mlx/api/tool_grammar.py
+++ b/vllm_mlx/api/tool_grammar.py
@@ -422,56 +422,80 @@ _XML_STRING_TERMINAL_DECL = (
 
 
 # ------------------------------------------------------------------------
-# FAITHFUL-OR-OPT-OUT representability guard for the Qwen3-Coder XML arg wire
-# (#558 E3, codex converge). The XML emitter (``_emit_xml_arg_body`` /
-# ``_emit_xml_param_value``) is a BEST-EFFORT OPT-IN: it can faithfully
-# constrain the common tool schema (typed top-level ``properties``, enums,
-# nested objects/arrays via ``%json``, required + optional ``( )?``), but a
-# handful of schema shapes CANNOT be represented on the delimiter-based XML
-# wire without silently permitting schema-invalid or mis-typed output. When a
-# request contains ANY such shape on an XML-arg tool, the whole request must
-# OPT OUT of grammar (``build_tool_grammar`` returns ``None`` -> free-form-
-# then-parse, the safe existing path) rather than emit a lax grammar.
+# STRICT-ALLOWLIST representability guard for the Qwen3-Coder XML arg wire
+# (#558 E3). The XML emitter (``_emit_xml_arg_body`` / ``_emit_xml_param_value``)
+# is a BEST-EFFORT OPT-IN: it can faithfully constrain the common tool schema
+# (typed top-level ``properties``, enums, nested objects/arrays via ``%json``,
+# required + optional ``( )?``), but MANY JSON-Schema shapes CANNOT be
+# represented on the delimiter-based XML wire without silently permitting
+# schema-invalid or mis-typed output.
 #
-# The unrepresentable shapes (mirroring the 5 codex BLOCKING findings):
-#   * F1 — a property-less BUT non-trivial top-level schema (``required`` /
-#     top-level ``$ref`` / non-object ``type``; ``false`` / composition / ``not``
-#     are caught by the checks below) would collapse to an EMPTY body (``{}``),
-#     which is wrong for a schema that requires fields or accepts no instance.
-#   * F2 — a top-level string property carrying ``const`` / ``pattern`` /
-#     ``minLength`` / ``maxLength`` / ``format`` cannot be enforced by the raw
-#     lazy value path (it admits ANY text), so those constraints are silently
-#     ignored. (Enum IS enforced — an alternation — so it stays representable.)
-#   * F4 — object-level relational keywords (``dependentRequired`` /
-#     ``dependencies`` / ``if`` / ``then`` / ``else`` / ``not`` /
-#     ``patternProperties``) and top-level composition (``allOf`` / ``anyOf`` /
-#     ``oneOf``) are emitted-around, not enforced, so e.g. ``dependentRequired``
-#     would let an ``a`` block appear without its required ``b``.
-#   * F5 — a property KEY that is not delimiter-safe (contains ``< > { } : ,`` or
-#     whitespace) would be inserted RAW into ``<parameter=KEY>`` and parsed back
-#     as a DIFFERENT key.
-# (F3 is a REAL fix, not an opt-out: ``_emit_xml_param_value`` resolves a local
-# ``$ref`` BEFORE the string-vs-``%json`` decision so a ``$ref``->string
-# round-trips without quotes; only an UNRESOLVABLE ``$ref`` opts out here.)
-_XML_UNSUPPORTED_OBJECT_KEYWORDS: tuple[str, ...] = (
-    "dependentRequired",
-    "dependencies",
-    "if",
-    "then",
-    "else",
-    "not",
-    "patternProperties",
-    "allOf",
-    "anyOf",
-    "oneOf",
+# WHY AN ALLOWLIST (closed positive set), NOT A BLACKLIST. JSON Schema has
+# dozens of keywords; an opt-out-on-known-bad-keywords BLACKLIST is inherently
+# incomplete — a reviewer can always name "one more" unsupported shape
+# (``minProperties`` / ``propertyNames`` / ``contains`` / ``unevaluatedProperties``
+# / a ``false`` schema / a ``$ref`` with siblings / …). We instead REQUIRE the
+# schema to use EXCLUSIVELY an explicitly-enumerated, known-safe set of
+# keywords/shapes: ``_xml_schema_representable`` returns ``True`` ONLY when every
+# part of the schema falls inside that closed set; ANYTHING outside → opt out.
+# This is complete BY CONSTRUCTION (no unknown keyword can be faithfully
+# constrained, so any unknown keyword safely opts out) and ends the whack-a-mole.
+# When a request contains ANY non-allowlisted shape on an XML-arg tool, the whole
+# request OPTS OUT of grammar (``build_tool_grammar`` returns ``None`` ->
+# free-form-then-parse, the safe existing path) rather than emit a lax grammar.
+#
+# THE ALLOWLIST (see ``_xml_schema_representable`` / ``_xml_property_representable``):
+#   * TOP-LEVEL: a dict whose keys ⊆ ``_XML_ALLOWED_TOPLEVEL_KEYS``; ``type`` (if
+#     present) == ``"object"``; ``additionalProperties`` (if present) is literally
+#     ``False`` (a schema value OR ``True`` opts out — extra props can't be
+#     constrained); ``set(required) ⊆ set(properties)``; a genuine no-arg tool
+#     (no ``properties`` + no ``required``) stays representable (empty body).
+#   * EACH PROPERTY (after resolving a single-level local ``$ref``): a non-empty
+#     ``enum`` (alternation), OR ``type=="string"`` with keys ⊆
+#     ``_XML_ALLOWED_STRING_KEYS`` (no ``const``/``pattern``/``minLength``/
+#     ``maxLength``/``format``), OR ``type in {integer,number,boolean}`` (bare
+#     terminal), OR ``type in {object,array}`` (``%json`` — llguidance's JSON
+#     grammar handles the inner keywords), OR else opt out (a ``false``/``true``
+#     bool schema, a ``null``/absent/union ``type``, an unresolved ``$ref``).
+# F3 remains a REAL fix, not an opt-out: ``_emit_xml_param_value`` resolves a
+# local ``$ref`` BEFORE the string-vs-``%json`` decision so a ``$ref``->string
+# round-trips without quotes; only an UNRESOLVABLE ``$ref`` (or one with siblings)
+# opts out.
+#
+# The closed positive sets. Membership is REQUIRED (not merely tolerated): any
+# key outside these opts the request out.
+_XML_ALLOWED_TOPLEVEL_KEYS = frozenset(
+    {
+        "type",
+        "properties",
+        "required",
+        "description",
+        "title",
+        "$defs",
+        "definitions",
+        "additionalProperties",
+    }
 )
-_XML_UNSUPPORTED_STRING_KEYWORDS: tuple[str, ...] = (
-    "const",
-    "pattern",
-    "minLength",
-    "maxLength",
-    "format",
+# Keys a ``type=="string"`` property may carry. Anything else (``const`` /
+# ``pattern`` / ``minLength`` / ``maxLength`` / ``format`` / any unknown facet)
+# cannot be enforced by the raw lazy value path -> opt out. ``enum`` is listed
+# for completeness though the enum-first branch handles a non-empty enum before
+# the string-type check is reached.
+_XML_ALLOWED_STRING_KEYS = frozenset(
+    {
+        "type",
+        "enum",
+        "description",
+        "title",
+        "default",
+    }
 )
+# Property ``type`` values that render as a bare JSON terminal (the parser
+# type-converts VALUE per int/float/bool paths).
+_XML_SCALAR_TERMINAL_TYPES = frozenset({"integer", "number", "boolean"})
+# Property ``type`` values that ride ``%json`` (llguidance's JSON grammar
+# enforces the whole sub-schema, inner keywords included — do NOT recurse).
+_XML_JSON_SUBSCHEMA_TYPES = frozenset({"object", "array"})
 # Characters that would break out of the ``<parameter=KEY>`` delimiter wire (or
 # collide with the JSON-ish surfaces the parser round-trips). OpenAI tool
 # parameter names are normally ``[\w-]+``; be conservative.
@@ -504,7 +528,7 @@ def _xml_key_is_delimiter_safe(key: Any) -> bool:
 
 
 def _resolve_local_ref(subschema: Any, defs: dict[str, Any]) -> Any:
-    """Resolve a single-level local ``$ref`` against ``defs`` (F3).
+    """Resolve a single-level local ``$ref`` against ``defs`` (F3 / finding 4).
 
     ``defs`` is the ``{"$defs": {...}, "definitions": {...}}`` mapping
     ``_collect_xml_defs`` returns. Handles ONLY a single-level local pointer
@@ -512,7 +536,14 @@ def _resolve_local_ref(subschema: Any, defs: dict[str, Any]) -> Any:
 
       * a schema WITHOUT a ``$ref`` is returned UNCHANGED (the caller decides its
         type as before);
-      * a resolvable single-level local ``$ref`` returns the target dict;
+      * a resolvable single-level local ``$ref`` (with NO sibling keys) returns
+        the target dict;
+      * a ``$ref`` object carrying SIBLING keys beyond ``$ref`` (e.g.
+        ``{"$ref": "#/$defs/x", "enum": [...]}``) returns ``None`` — the sibling
+        keywords would be SILENTLY DROPPED if we resolved to the bare target
+        (finding 4), so we opt out rather than under-constrain. (Cleanly merging
+        the siblings into the resolved target is possible but the safe choice is
+        to opt out.)
       * an unresolvable / unsupported ``$ref`` (remote, non-local, multi-hop, or
         a missing/ non-dict target) returns ``None`` — the caller treats that as
         UNREPRESENTABLE and opts the request out.
@@ -522,6 +553,10 @@ def _resolve_local_ref(subschema: Any, defs: dict[str, Any]) -> Any:
     ref = subschema.get("$ref")
     if ref is None:
         return subschema
+    # Finding 4: a ``$ref`` alongside OTHER keys would drop those siblings on
+    # resolution. Opt out (return ``None``) rather than silently ignore them.
+    if len(subschema) != 1:
+        return None
     if not isinstance(ref, str) or not ref.startswith("#/"):
         return None
     parts = ref[2:].split("/")
@@ -538,75 +573,121 @@ def _resolve_local_ref(subschema: Any, defs: dict[str, Any]) -> Any:
     return resolved
 
 
+def _xml_property_representable(subschema: Any, defs: dict[str, Any]) -> bool:
+    """True iff ONE property schema is inside the XML emitter's closed allowlist.
+
+    After resolving a single-level local ``$ref`` (``_resolve_local_ref`` — an
+    unresolvable ``$ref``, a ``$ref`` with siblings, or a non-dict such as a
+    ``false``/``true`` bool schema returns ``None`` -> opt out), the resolved
+    schema is representable ONLY as one of the enumerated shapes:
+
+      * a non-empty ``enum`` list — rendered as a literal ALTERNATION (the
+        tightest possible constraint; facets are irrelevant next to it), OR
+      * ``type == "string"`` whose keys ⊆ ``_XML_ALLOWED_STRING_KEYS`` — the raw
+        lazy value path (a ``const``/``pattern``/``minLength``/``maxLength``/
+        ``format`` or ANY unknown facet it cannot enforce opts out), OR
+      * ``type in {integer,number,boolean}`` — a bare JSON terminal, OR
+      * ``type in {object,array}`` — ``%json`` over the sub-schema (llguidance's
+        JSON grammar enforces the inner keywords; we do NOT recurse/restrict), OR
+      * else opt out (a ``null``/absent/union/non-string ``type``).
+    """
+    resolved = _resolve_local_ref(subschema, defs)
+    if not isinstance(resolved, dict):
+        # Unresolvable/sibling ``$ref`` (None) or a ``false``/``true`` bool schema
+        # / non-dict -> not representable.
+        return False
+    # Enum-first: a non-empty enum renders as an alternation of literals — the
+    # tightest constraint, so it is representable regardless of ``type``/facets.
+    enum = resolved.get("enum")
+    if isinstance(enum, list) and enum:
+        return True
+    prop_type = resolved.get("type")
+    if not isinstance(prop_type, str):
+        # Absent / union (list) / non-string ``type`` -> opt out.
+        return False
+    t = prop_type.strip().lower()
+    if t == "string":
+        # Only annotation keys may accompany a string; any facet the raw lazy
+        # value path cannot enforce (or an unknown key) opts out.
+        return set(resolved.keys()) <= _XML_ALLOWED_STRING_KEYS
+    if t in _XML_SCALAR_TERMINAL_TYPES:
+        return True
+    if t in _XML_JSON_SUBSCHEMA_TYPES:
+        return True
+    # ``null`` or any unknown type -> opt out.
+    return False
+
+
 def _xml_schema_representable(params: Any) -> bool:
     """True iff the XML arg emitter can FAITHFULLY constrain ``params`` (#558 E3).
 
-    Returns ``False`` -> the request OPTS OUT of grammar (free-form fallback) for
-    the unrepresentable schema shapes described in the module block above
-    (F1/F2/F4/F5, plus an unresolvable ``$ref``). Returns ``True`` for the common
-    case (typed top-level ``properties``, enums, nested objects/arrays, required +
-    optional) AND for a genuine no-argument tool (no ``properties``, no
-    ``required``, no ``$ref``, object/absent top-level ``type``) — whose empty
-    body IS the faithful representation.
+    STRICT ALLOWLIST (closed positive set — see the module block above): returns
+    ``True`` ONLY when every part of ``params`` uses exclusively a known-safe,
+    explicitly-enumerated keyword/shape; ANYTHING outside opts the request out
+    (``False`` -> free-form fallback). Complete by construction, so no unknown
+    JSON-Schema keyword can slip a lax grammar through.
+
+    Representable ``True`` iff ALL hold:
+      * ``params`` is a dict whose keys ⊆ ``_XML_ALLOWED_TOPLEVEL_KEYS``;
+      * ``type`` (if present) is ``"object"``;
+      * ``additionalProperties`` (if present) is literally ``False`` (a schema
+        value or ``True`` opts out — extra props can't be constrained);
+      * ``properties`` (if present) is a dict;
+      * ``set(required) ⊆ set(properties)`` (a required name with no declared
+        property opts out — finding 3);
+      * every property key is delimiter-safe (``_xml_key_is_delimiter_safe``, F5)
+        AND every property schema is in the per-property allowlist
+        (``_xml_property_representable``).
+    A genuine no-argument tool (no ``properties`` + no ``required``) is
+    representable — its empty body IS the faithful representation.
     """
-    # F1: a ``false`` schema (accepts NO instance) — or any non-dict — cannot be
-    # rendered as an empty XML body; opt out.
+    # A ``false``/``true`` bool schema — or any non-dict — cannot be rendered as
+    # an XML parameter body; opt out.
     if not isinstance(params, dict):
         return False
-    # Lazy import: keep this module importable independently of api.tool_calling.
-    from .tool_calling import _schema_type
-
-    # F4: object-level relational keywords + top-level composition are emitted
-    # AROUND, never enforced. Reject them whether or not ``properties`` is present.
-    for kw in _XML_UNSUPPORTED_OBJECT_KEYWORDS:
-        if kw in params:
+    # CLOSED top-level key set: any key outside the allowlist (``minProperties`` /
+    # ``maxProperties`` / ``propertyNames`` / ``patternProperties`` /
+    # ``dependentRequired`` / ``dependencies`` / ``if`` / ``then`` / ``else`` /
+    # ``not`` / ``allOf`` / ``anyOf`` / ``oneOf`` / ``contains`` /
+    # ``unevaluatedProperties`` / a top-level ``$ref`` / … ) opts out. This single
+    # check subsumes the former object-keyword + composition + top-level-``$ref``
+    # blacklists — completely, since membership is required not merely tolerated.
+    if not set(params.keys()) <= _XML_ALLOWED_TOPLEVEL_KEYS:
+        return False
+    # ``type``, if present, must be exactly ``object`` (a non-object top-level
+    # type has no XML parameter-body representation).
+    top_type = params.get("type")
+    if top_type is not None:
+        if not isinstance(top_type, str) or top_type.strip().lower() != "object":
             return False
-
-    defs = _collect_xml_defs(params)
+    # ``additionalProperties``: absent OK; literal ``False`` OK; a schema value or
+    # ``True`` opts out (the XML wire cannot constrain undeclared extra props).
+    if "additionalProperties" in params and params["additionalProperties"] is not False:
+        return False
     props = params.get("properties")
-    has_props = isinstance(props, dict) and bool(props)
-
-    if not has_props:
-        # F1: property-less BUT non-trivial -> the empty body would misrepresent
-        # it. (Composition / ``not`` already rejected above.)
-        required = params.get("required")
-        if isinstance(required, list) and required:
+    if props is not None and not isinstance(props, dict):
+        return False
+    prop_map: dict[str, Any] = props if isinstance(props, dict) else {}
+    # ``required`` must be a list naming ONLY declared properties (finding 3) — an
+    # undeclared required name would never be emitted, silently unenforced. This
+    # also opts out the property-less-but-``required`` case (empty body wrong).
+    required = params.get("required")
+    if required is not None:
+        if not isinstance(required, list):
             return False
-        if "$ref" in params:
+        if not set(required) <= set(prop_map.keys()):
             return False
-        # A non-object top-level ``type`` (array / string / number / ...) has no
-        # XML parameter-body representation; the empty body would misrepresent it.
-        top_type = params.get("type")
-        if isinstance(top_type, str) and top_type.strip().lower() not in (
-            "object",
-            "null",
-        ):
-            return False
-        if isinstance(top_type, list):
-            norm = {t.strip().lower() for t in top_type if isinstance(t, str)}
-            if norm - {"object", "null"}:
-                return False
-        # Genuine no-argument tool -> empty body is correct.
-        return True
-
-    # Has ``properties``: validate each TOP-LEVEL property (nested schemas ride
-    # ``%json`` and are enforced there, so only the top level needs guarding).
-    for key, subschema in props.items():
+    # Validate each TOP-LEVEL property against the closed per-property allowlist
+    # (nested object/array schemas ride ``%json`` and are enforced there, so only
+    # the top level needs the key-safety + shape guard). An empty ``prop_map`` (no
+    # arguments) skips the loop and stays representable.
+    defs = _collect_xml_defs(params)
+    for key, subschema in prop_map.items():
         # F5: the key is emitted RAW into ``<parameter=KEY>`` -> must be safe.
         if not _xml_key_is_delimiter_safe(key):
             return False
-        # F3: resolve a single-level local ``$ref`` first; an unresolvable ref is
-        # unrepresentable.
-        resolved = _resolve_local_ref(subschema, defs)
-        if resolved is None:
+        if not _xml_property_representable(subschema, defs):
             return False
-        # F2: a top-level string property takes the RAW lazy value path, which
-        # cannot enforce these facets -> opt out. (Enum is enforced separately as
-        # an alternation, so an enum WITHOUT these facets stays representable.)
-        if _schema_type(resolved) == "string":
-            for kw in _XML_UNSUPPORTED_STRING_KEYWORDS:
-                if kw in resolved:
-                    return False
     return True
 
 

--- a/vllm_mlx/api/tool_grammar.py
+++ b/vllm_mlx/api/tool_grammar.py
@@ -99,12 +99,25 @@ class StructureInfo:
     ``ToolParser.structure_info()``. ``sentinels`` lists literal substrings
     inside ``begin``/``end`` that are single special tokens for this family
     and must be emitted as Lark special-token refs, not byte strings.
+
+    ``arg_style`` selects how the tool's ARGUMENTS are constrained between
+    ``begin`` and ``end``:
+
+      * ``"json"`` (default) — a single JSON object constrained by the tool's
+        JSON Schema via ``%json`` (hermes / qwen / harmony wire).
+      * ``"xml"`` — a Qwen3-Coder XML arg body: one
+        ``<parameter=KEY>\nVALUE\n</parameter>`` block per property, each VALUE
+        constrained per its sub-schema (raw text for strings, ``%json`` for
+        scalars/objects/arrays, an alternation for enums). See
+        ``_emit_xml_arg_body``. Default stays ``"json"`` so hermes/qwen/harmony
+        (and any out-of-tree JSON-body family) are byte-identical to before.
     """
 
     begin: str
     end: str
     trigger: str
     sentinels: tuple[str, ...] = field(default=())
+    arg_style: str = "json"
 
 
 def _is_registered_added_token(tokenizer: Any, tok_id: int) -> bool:
@@ -373,6 +386,96 @@ def _emit_literal_with_sentinels(text: str, sentinels: tuple[str, ...]) -> str:
             parts.append(_lark_escape(text[i:j]))
             i = j
     return " ".join(p for p in parts if p)
+
+
+# The raw-string value terminal used by the XML arg body (see
+# ``_emit_xml_param_value``). ``/[^<]*/`` matches the RAW (unquoted) parameter
+# value up to — but not including — the ``<`` that opens ``</parameter>``, so it
+# also absorbs the single ``\n`` the wire puts BEFORE ``</parameter>`` (the
+# qwen3_coder parser strips that trailing newline). Consequence: a string value
+# containing a literal ``<`` (e.g. a ``code`` argument with XML) cannot be
+# expressed by this terminal and is a known constrained-mode limitation —
+# ``RAPID_MLX_CONSTRAIN_TOOLS=0`` restores free-form for such tools.
+_XML_STRING_TERMINAL_NAME = "XMLSTR"
+_XML_STRING_TERMINAL_DECL = f"{_XML_STRING_TERMINAL_NAME}: /[^<]*/\n"
+
+
+def _emit_xml_param_value(subschema: Any, defs: dict[str, Any]) -> str:
+    """Return the Lark for one XML parameter's VALUE plus its closing literal.
+
+    The Qwen3-Coder wire is ``<parameter=KEY>\\nVALUE\\n</parameter>\\n`` and the
+    ``qwen3_coder`` parser type-converts VALUE per the tool schema, so the
+    grammar must emit each value in the SAME surface form the parser round-trips:
+
+      * ENUM -> an alternation of the literal enum values (raw string form for
+        string enums, JSON scalar for numeric/bool enums), then the
+        ``\\n</parameter>\\n`` close.
+      * STRING (non-enum) -> the RAW (unquoted) ``XMLSTR`` terminal, NOT ``%json``
+        (whose surrounding quotes the parser keeps verbatim, yielding
+        ``"\\"Paris\\""``). ``XMLSTR: /[^<]*/`` absorbs the value AND the trailing
+        ``\\n``, so the close literal here is ``</parameter>\\n`` with NO leading
+        newline.
+      * EVERYTHING ELSE (number / integer / boolean / object / array / null) ->
+        JSON-constrained via ``%json`` (these surface forms match the parser's
+        int / float / bool / ``json.loads`` paths), then the ``\\n</parameter>\\n``
+        close (leading newline preserved — ``%json`` does not consume it).
+
+    ``defs`` (the parent schema's ``$defs`` / ``definitions``) is merged into each
+    ``%json`` value sub-schema so an internal ``$ref`` still resolves.
+    """
+    close_json = _lark_escape("\n</parameter>\n")
+    close_raw = _lark_escape("</parameter>\n")  # XMLSTR already ate the newline
+    if not isinstance(subschema, dict):
+        return f"{_XML_STRING_TERMINAL_NAME} {close_raw}"
+    enum = subschema.get("enum")
+    if isinstance(enum, list) and enum:
+        alts = []
+        for value in enum:
+            literal = value if isinstance(value, str) else json.dumps(value)
+            alts.append(_lark_escape(literal))
+        return f"({' | '.join(alts)}) {close_json}"
+    # Lazy import: keep this module importable independently of api.tool_calling
+    # (no cycle today, but the lazy import future-proofs it).
+    from .tool_calling import _schema_type
+
+    if _schema_type(subschema) == "string":
+        return f"{_XML_STRING_TERMINAL_NAME} {close_raw}"
+    value_schema = dict(subschema)
+    for def_key, def_val in defs.items():
+        value_schema.setdefault(def_key, def_val)
+    return f"%json {json.dumps(value_schema)} {close_json}"
+
+
+def _emit_xml_arg_body(params: Any) -> str:
+    """Emit the Lark for a Qwen3-Coder XML argument body from a JSON Schema.
+
+    One property renders as ``<parameter=KEY>\\n<value>\\n</parameter>\\n``.
+    REQUIRED properties are mandatory; the rest are OPTIONAL (``( ... )?``).
+    Properties are emitted in schema order — any-order permutation is DEFERRED
+    (a forced grammar makes the model follow this order, which real Qwen3-Coder
+    already does for its own schemas). Returns ``""`` for a no-argument tool
+    (empty / absent ``properties``), which the caller renders as the bare
+    ``<function=NAME>\\n</function>`` frame.
+    """
+    if not isinstance(params, dict):
+        return ""
+    props = params.get("properties")
+    if not isinstance(props, dict) or not props:
+        return ""
+    required = params.get("required")
+    required_set = set(required) if isinstance(required, list) else set()
+    defs: dict[str, Any] = {}
+    for def_key in ("$defs", "definitions"):
+        d = params.get(def_key)
+        if isinstance(d, dict):
+            defs[def_key] = d
+    frags: list[str] = []
+    for key, subschema in props.items():
+        open_lit = _lark_escape(f"<parameter={key}>\n")
+        value_lark = _emit_xml_param_value(subschema, defs)
+        block = f"{open_lit} {value_lark}"
+        frags.append(block if key in required_set else f"( {block} )?")
+    return " ".join(frags)
 
 
 def build_tool_lark(
@@ -665,6 +768,12 @@ def build_tool_lark(
         )
         prefix_ref = "bal_prefix"
 
+    # Declare the raw-string value terminal ONCE, iff any tag uses the XML arg
+    # body (``arg_style == "xml"``). A JSON-only tool-set (hermes/qwen/harmony)
+    # never emits it, so its grammar is byte-identical to before this change.
+    if any(getattr(si, "arg_style", "json") == "xml" for si in structure_infos):
+        lark += _XML_STRING_TERMINAL_DECL
+
     for i, (tool, si) in enumerate(zip(tools, structure_infos)):
         # Only substitute the default when ``parameters`` is ABSENT. A
         # falsy-but-present schema ({} = allow-any, false = allow-none) is a
@@ -682,15 +791,25 @@ def build_tool_lark(
                 "properties": {},
                 "additionalProperties": False,
             }
-        schema = json.dumps(params)
         begin_body = _emit_literal_with_sentinels(si.begin, si.sentinels)
         end_body = _emit_literal_with_sentinels(si.end, si.sentinels)
+        # ARG BODY: a JSON object (``%json`` over the whole schema) for the
+        # default JSON wire, OR a Qwen3-Coder XML per-parameter body when the
+        # family's ``structure_info`` declares ``arg_style="xml"``. The XML body
+        # may be EMPTY (a no-argument tool), in which case the tag is just the
+        # ``begin``/``end`` frame with no argument region.
+        if getattr(si, "arg_style", "json") == "xml":
+            arg_body = _emit_xml_arg_body(params)
+        else:
+            arg_body = f"%json {json.dumps(params)}"
         # ``prefix_ref`` is empty on the forced-non-reasoning path (the first call
         # sits AT the trigger; ``SEP`` in ``start`` separates repeats), non-empty
         # otherwise (``TAG_TEXT`` / ``bal_prefix``). Omit the leading space when
         # empty so the tag rule starts cleanly at the begin literal.
         pfx = f"{prefix_ref} " if prefix_ref else ""
-        lark += f"\ntag_{i}: {pfx}{begin_body} %json {schema}"
+        lark += f"\ntag_{i}: {pfx}{begin_body}"
+        if arg_body:
+            lark += f" {arg_body}"
         if end_body:
             lark += f" {end_body}"
         lark += "\n"

--- a/vllm_mlx/api/tool_grammar.py
+++ b/vllm_mlx/api/tool_grammar.py
@@ -388,16 +388,37 @@ def _emit_literal_with_sentinels(text: str, sentinels: tuple[str, ...]) -> str:
     return " ".join(p for p in parts if p)
 
 
-# The raw-string value terminal used by the XML arg body (see
-# ``_emit_xml_param_value``). ``/[^<]*/`` matches the RAW (unquoted) parameter
-# value up to — but not including — the ``<`` that opens ``</parameter>``, so it
-# also absorbs the single ``\n`` the wire puts BEFORE ``</parameter>`` (the
-# qwen3_coder parser strips that trailing newline). Consequence: a string value
-# containing a literal ``<`` (e.g. a ``code`` argument with XML) cannot be
-# expressed by this terminal and is a known constrained-mode limitation —
-# ``RAPID_MLX_CONSTRAIN_TOOLS=0`` restores free-form for such tools.
-_XML_STRING_TERMINAL_NAME = "XMLSTR"
-_XML_STRING_TERMINAL_DECL = f"{_XML_STRING_TERMINAL_NAME}: /[^<]*/\n"
+# The raw-string value construct used by the XML arg body (see
+# ``_emit_xml_param_value``). A Qwen3-Coder string parameter value is "any text
+# up to the FIRST literal ``</parameter>`` close tag" — so a value MAY contain a
+# literal ``<`` (a ``code`` arg such as ``a < b``, ``<html>...``, or C++
+# ``vector<int>``), it just may not contain the whole ``</parameter>`` delimiter.
+# We express that with llguidance's first-class LAZY lexeme (``rule[lazy]:``): a
+# lazy rule matches its leading text terminal MINIMALLY, stopping at the first
+# occurrence of the trailing literal. This is the exact idiom llguidance's own
+# ``StructTag.to_grammar`` uses for "text until a tag" (``_struct_tag.py``:
+# ``..._trig[lazy]: TAG_TEXT <trigger>``), and it mirrors XGrammar's ``qwen_xml``
+# style (value = any text up to the first ``</parameter>``).
+#
+# ``XML_PARAM_TEXT: /(.|\n)*/`` admits ANY byte (crucially including ``<``); the
+# lazy rule then binds it to the ``</parameter>`` delimiter so the value
+# terminates at the first close. The lazy rule consumes the value, the single
+# ``\n`` the wire puts BEFORE ``</parameter>``, AND the ``</parameter>`` tag
+# itself — so ``_emit_xml_param_value`` appends only the trailing ``\n`` (the
+# separator AFTER the close). The ``qwen3_coder`` parser strips the leading /
+# trailing ``\n`` from the captured value, so this reproduces the exact surface
+# form it round-trips. FIRST-``</parameter>`` semantics: a value that literally
+# contains ``</parameter>`` closes there (same as XGrammar — acceptable).
+# NOTE (previous limitation, now FIXED): the pilot used ``XMLSTR: /[^<]*/`` which
+# stopped at ANY ``<`` and thus SILENTLY TRUNCATED a ``<``-containing code arg.
+_XML_STRING_VALUE_TERMINAL = "XML_PARAM_TEXT"
+_XML_STRING_VALUE_RULE = "xml_param_value"
+# ``\\n`` here is a LITERAL backslash-n (the Lark regex ``/(.|\n)*/``), matching
+# how ``TAG_TEXT`` is declared; the trailing ``\n`` are real line breaks.
+_XML_STRING_TERMINAL_DECL = (
+    f"{_XML_STRING_VALUE_TERMINAL}: /(.|\\n)*/\n"
+    f'{_XML_STRING_VALUE_RULE}[lazy]: {_XML_STRING_VALUE_TERMINAL} "</parameter>"\n'
+)
 
 
 def _emit_xml_param_value(subschema: Any, defs: dict[str, Any]) -> str:
@@ -410,11 +431,15 @@ def _emit_xml_param_value(subschema: Any, defs: dict[str, Any]) -> str:
       * ENUM -> an alternation of the literal enum values (raw string form for
         string enums, JSON scalar for numeric/bool enums), then the
         ``\\n</parameter>\\n`` close.
-      * STRING (non-enum) -> the RAW (unquoted) ``XMLSTR`` terminal, NOT ``%json``
-        (whose surrounding quotes the parser keeps verbatim, yielding
-        ``"\\"Paris\\""``). ``XMLSTR: /[^<]*/`` absorbs the value AND the trailing
-        ``\\n``, so the close literal here is ``</parameter>\\n`` with NO leading
-        newline.
+      * STRING (non-enum) -> the LAZY ``xml_param_value`` rule (NOT ``%json``,
+        whose surrounding quotes the parser keeps verbatim, yielding
+        ``"\\"Paris\\""``). The lazy rule matches ANY text (``<`` included) up to
+        AND INCLUDING the first ``</parameter>`` — so it absorbs the value, the
+        ``\\n`` before ``</parameter>``, AND the ``</parameter>`` tag itself. The
+        close appended here is therefore just the trailing ``\\n`` separator (NO
+        ``</parameter>`` — the rule already consumed it). This is what lets a
+        ``<``-containing code arg (``a < b``, ``vector<int>``) round-trip instead
+        of truncating at the first ``<`` (the pilot's ``/[^<]*/`` bug).
       * EVERYTHING ELSE (number / integer / boolean / object / array / null) ->
         JSON-constrained via ``%json`` (these surface forms match the parser's
         int / float / bool / ``json.loads`` paths), then the ``\\n</parameter>\\n``
@@ -424,9 +449,11 @@ def _emit_xml_param_value(subschema: Any, defs: dict[str, Any]) -> str:
     ``%json`` value sub-schema so an internal ``$ref`` still resolves.
     """
     close_json = _lark_escape("\n</parameter>\n")
-    close_raw = _lark_escape("</parameter>\n")  # XMLSTR already ate the newline
+    # The lazy rule already consumed ``\n</parameter>``; only the trailing
+    # separator newline (AFTER the close tag) remains for the string case.
+    close_lazy = _lark_escape("\n")
     if not isinstance(subschema, dict):
-        return f"{_XML_STRING_TERMINAL_NAME} {close_raw}"
+        return f"{_XML_STRING_VALUE_RULE} {close_lazy}"
     enum = subschema.get("enum")
     if isinstance(enum, list) and enum:
         alts = []
@@ -439,7 +466,7 @@ def _emit_xml_param_value(subschema: Any, defs: dict[str, Any]) -> str:
     from .tool_calling import _schema_type
 
     if _schema_type(subschema) == "string":
-        return f"{_XML_STRING_TERMINAL_NAME} {close_raw}"
+        return f"{_XML_STRING_VALUE_RULE} {close_lazy}"
     value_schema = dict(subschema)
     for def_key, def_val in defs.items():
         value_schema.setdefault(def_key, def_val)
@@ -768,9 +795,13 @@ def build_tool_lark(
         )
         prefix_ref = "bal_prefix"
 
-    # Declare the raw-string value terminal ONCE, iff any tag uses the XML arg
-    # body (``arg_style == "xml"``). A JSON-only tool-set (hermes/qwen/harmony)
-    # never emits it, so its grammar is byte-identical to before this change.
+    # Declare the lazy string-value construct (``XML_PARAM_TEXT`` terminal +
+    # ``xml_param_value[lazy]`` rule) ONCE, iff any tag uses the XML arg body
+    # (``arg_style == "xml"``). A JSON-only tool-set (hermes/qwen/harmony) never
+    # emits it, so its grammar is byte-identical to before this change. The rule
+    # is declared whenever ANY xml tag is present (even one with no string
+    # params); llguidance tolerates the reference-free rule, and gating it on the
+    # per-param string check would need a second schema walk for no benefit.
     if any(getattr(si, "arg_style", "json") == "xml" for si in structure_infos):
         lark += _XML_STRING_TERMINAL_DECL
 

--- a/vllm_mlx/tool_parsers/qwen3coder_tool_parser.py
+++ b/vllm_mlx/tool_parsers/qwen3coder_tool_parser.py
@@ -134,6 +134,81 @@ class Qwen3CoderToolParser(ToolParser):
     SUPPORTS_NATIVE_TOOL_FORMAT = True
     EXPECTED_WIRE_FORMATS = ("qwen3_coder_xml_named", "tool_call_xml_body")
 
+    # Grammar-CAPABLE (#558 "做全"): overrides ``structure_info`` below to emit
+    # the Qwen3-Coder XML arg body. Only ``<tool_call>``/``</tool_call>`` are
+    # single special tokens on the Qwen3-Coder tokenizer (verified on
+    # ``mlx-community/Qwen3-Coder-Next-4bit``: ids 151657 / 151658); the inner
+    # ``<function=`` / ``<parameter=`` / ``</parameter>`` / ``</function>``
+    # markers are ordinary MULTI-token text, emitted as byte literals by the
+    # grammar builder.
+    _GRAMMAR_SENTINELS = ("<tool_call>", "</tool_call>")
+
+    SUPPORTS_GRAMMAR: bool = True
+
+    def structure_info(self):
+        """Grammar-constraint wire triple for the Qwen3-Coder XML tool call (#558).
+
+        Extends #558 grammar constraint from the JSON-body families
+        (hermes / qwen / harmony) to the Qwen3-Coder XML wire. The model emits
+        (verified byte-for-byte against this model's ``chat_template.jinja``)::
+
+            <tool_call>
+            <function=NAME>
+            <parameter=KEY>
+            VALUE
+            </parameter>
+            ...
+            </function>
+            </tool_call>
+
+        The ARGUMENTS are an XML body, NOT a JSON object, so we return a
+        ``StructureInfo`` with ``arg_style="xml"``: the builder emits one
+        ``<parameter=KEY>\\nVALUE\\n</parameter>`` block per schema property, each
+        VALUE constrained per its sub-schema (raw text for strings, ``%json`` for
+        scalars / objects / arrays, an alternation for enums) — see
+        ``vllm_mlx.api.tool_grammar._emit_xml_arg_body``. Those surface forms are
+        exactly what ``_parse_xml_function_call`` / ``_convert_param_value``
+        round-trip back into JSON ``arguments``.
+
+        ``<tool_call>`` / ``</tool_call>`` are single special tokens on the
+        Qwen3-Coder tokenizer, declared as ``sentinels`` (rendered as Lark
+        special-token refs); the trigger is ``<tool_call>``. The inner
+        ``<function=`` / ``<parameter=`` markers are ordinary text (byte
+        literals).
+
+        As on hermes / qwen / harmony, OPT OUT (return ``None`` -> free-form
+        fallback) unless the tokenizer proves both sentinels are single special
+        tokens — a special-token sentinel on a tokenizer that encodes
+        ``<tool_call>`` as multi-token text would build an unenforceable grammar.
+        Grammar constraint is a best-effort opt-in, never a hard requirement.
+        """
+        from vllm_mlx.api.tool_grammar import (
+            StructureInfo,
+            are_single_special_tokens,
+        )
+
+        if not are_single_special_tokens(
+            self.model_tokenizer, self._GRAMMAR_SENTINELS
+        ):
+            return None
+
+        def _info(name: str):
+            # The tool NAME is a bare identifier inside the ``<function=NAME>``
+            # header (NOT a JSON string — Qwen3-Coder does not quote it), emitted
+            # raw as a byte literal by the builder. ``begin`` starts with the
+            # ``<tool_call>`` trigger (builder invariant).
+            begin = f"<tool_call>\n<function={name}>\n"
+            end = "</function>\n</tool_call>"
+            return StructureInfo(
+                begin=begin,
+                end=end,
+                trigger="<tool_call>",
+                sentinels=self._GRAMMAR_SENTINELS,
+                arg_style="xml",
+            )
+
+        return _info
+
     def __init__(self, tokenizer=None):
         super().__init__(tokenizer)
 

--- a/vllm_mlx/tool_parsers/qwen3coder_tool_parser.py
+++ b/vllm_mlx/tool_parsers/qwen3coder_tool_parser.py
@@ -187,9 +187,7 @@ class Qwen3CoderToolParser(ToolParser):
             are_single_special_tokens,
         )
 
-        if not are_single_special_tokens(
-            self.model_tokenizer, self._GRAMMAR_SENTINELS
-        ):
+        if not are_single_special_tokens(self.model_tokenizer, self._GRAMMAR_SENTINELS):
             return None
 
         def _info(name: str):


### PR DESCRIPTION
## Why

Grammar-constrained tool-calling (#558) today only covers JSON-body wires
(hermes / qwen / harmony). The flagship coder model — Qwen3-Coder — serializes
tool arguments as an XML parameter body, so its calls fell back to
free-form-then-parse: the model could emit an off-schema enum, a wrong-typed
value, or a malformed call the parser then had to salvage. Constraining the XML
wire at generation time makes a schema-valid call true by construction, closing
the same reliability gap #558 already closed for the JSON families. Refs #558.

## What

Extends #558 grammar-constrained tool-calling from the JSON-body families
(hermes / qwen / harmony) to the **Qwen3-Coder XML wire**. Previously only
JSON-object argument bodies could be grammar-constrained; a Qwen3-Coder tool
call is an XML parameter body, so it fell back to free-form-then-parse. This
teaches `build_tool_lark` to emit a grammar for that wire.

Wire (verified byte-for-byte against the Qwen3-Coder chat template + this repo's
`qwen3coder_tool_parser`):

```
<tool_call>
<function=NAME>
<parameter=KEY>
VALUE
</parameter>
</function>
</tool_call>
```

## How

- **`StructureInfo` gains `arg_style: str = "json"`** (frozen default). JSON-body
  families are byte-identical to before — a regression test pins that the
  `arg_style="json"` grammar emits no XML terminals and still uses `%json`.
- **`build_tool_lark` dispatches on `arg_style`**: `"xml"` emits one
  `<parameter=KEY>\nVALUE\n</parameter>\n` block per schema property, each VALUE
  grammar-typed per its sub-schema — enum → literal alternation, integer/number
  → JSON scalar terminals, boolean → `"true"|"false"`, object/array → `%json`,
  string → the lazy text rule below. Required props are mandatory (schema order),
  optional props are `( ... )?`.
- **`qwen3coder_tool_parser`** overrides `structure_info()` + sets
  `SUPPORTS_GRAMMAR=True`. It **opts out** (returns `None` → free-form fallback)
  unless `are_single_special_tokens` proves `<tool_call>`/`</tool_call>` are
  single special tokens on the live tokenizer (only Qwen tokenizers are), so a
  non-Qwen route can never build an unenforceable grammar.

### gap #1 — a string arg containing `<` (solved, not documented-around)

A first cut used `XMLSTR: /[^<]*/` for string values, which stops at the FIRST
`<` — so a `code` arg like `a < b`, `<html>…`, or `vector<int>` silently
truncated at that `<`. Fixed by porting **llguidance's first-class `[lazy]`
lexeme** — the exact idiom `StructTag.to_grammar` uses internally:

```
XML_PARAM_TEXT: /(.|\n)*/
xml_param_value[lazy]: XML_PARAM_TEXT "</parameter>"
```

`XML_PARAM_TEXT` admits any byte (incl. `<`); the lazy rule binds it to the
FIRST `</parameter>`. This matches XGrammar's `qwen_xml` "value up to first
`</parameter>`" semantics without needing regex lookahead (llguidance's engine
has none). Naive greedy `.*` overshoots (maximal-munch) and a lone-`<` rule
fails on `<html>`; `[lazy]` is the correct construct.

## Copy-source (no wheels invented)

- **Wire shape** — XGrammar-2 `builtin_structural_tag.py` `qwen_3_coder`
  built-in, `style="qwen_xml"` (reference for what the wire looks like).
- **Termination idiom** — llguidance `_struct_tag.py` `[lazy]` lexeme.
- **Plumbing pattern** — vLLM's Mistral tool parser proves llguidance can
  constrain a non-JSON wire via a generic Lark grammar on the guidance backend
  (`StructuredOutputsParams(grammar=...)`). No `xgrammar` runtime dependency is
  added; we stay on the llguidance backend adopted in #1131.

## Evidence (real tokenizer, not mocks)

`mlx-community/Qwen3-Coder-Next-4bit` via llguidance `LLMatcher`:

- Adversarial **enum** value CONSTRAINED (off-schema scalar + bad enum rejected).
- `<`-in-value accepted + terminal: `a < b && c > d` (27/27), `<html><body>x</body></html>` (28/28), `vector<int> v` (24/24), multiline code.
- `Paris` still 21/21 (no regression); leading prose masked at token 0.
- The `qwen3coder` parser round-trips every value back to the exact JSON `arguments`.

`pytest -k "tool_grammar or 558 or qwen3coder or structure_info"` → **324 passed,
1 skipped** (skip is an unrelated missing-`botocore` mirror test). `ruff check` +
`ruff format --check` clean. 29 new tests in `tests/test_qwen3coder_xml_grammar_558.py`
(golden Lark, real-tokenizer enforcement, round-trip, JSON-family byte-identical
regression guard).

## Scope

Fixes the **E3 slice** of #558 (Qwen3-Coder XML). Supersedes #1160 (which
branched before #1164's forced-tool fix and did not solve gap #1). Gemma-4 custom
`<|"|>` wire (E4) and the reasoning-gate (线①) are follow-up PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
