### PR TITLE
feat(tools): grammar-constrain Gemma-4 native tool-calls (#558 E4)

### DIFF
--- a/tests/test_gemma4_grammar_558.py
+++ b/tests/test_gemma4_grammar_558.py
@@ -605,17 +605,61 @@ def _tokenizer_in_cache() -> bool:
     return isinstance(path, str)
 
 
+def _hf_offline_mode() -> bool:
+    """True iff HuggingFace is configured for OFFLINE mode (env or hub constant).
+    Used to skip the uncached tokenizer fetch on an INTENTIONAL offline run
+    regardless of how transformers surfaces the miss (bare OSError included)."""
+    import os
+
+    if os.environ.get("HF_HUB_OFFLINE") or os.environ.get("TRANSFORMERS_OFFLINE"):
+        return True
+    try:
+        from huggingface_hub import constants
+
+        return bool(getattr(constants, "HF_HUB_OFFLINE", False))
+    except Exception:  # pragma: no cover - very old hub
+        return False
+
+
+def _is_connectivity_error(exc: BaseException) -> bool:
+    """True iff exc is a recognized NETWORK/offline connectivity type. A 404 /
+    bad-revision / corrupt error is deliberately NOT here — those must FAIL, not
+    skip (codex r6 #4). Only the transient/offline connectivity path skips."""
+    types: list[type[BaseException]] = []
+    try:
+        from huggingface_hub.errors import (
+            LocalEntryNotFoundError,
+            OfflineModeIsEnabled,
+        )
+
+        types += [LocalEntryNotFoundError, OfflineModeIsEnabled]
+    except Exception:  # pragma: no cover - old hub
+        pass
+    try:
+        from requests.exceptions import ConnectionError as _ReqConnErr
+        from requests.exceptions import Timeout as _ReqTimeout
+
+        types += [_ReqConnErr, _ReqTimeout]
+    except Exception:  # pragma: no cover - requests absent
+        pass
+    return bool(types) and isinstance(exc, tuple(types))
+
+
 @pytest.fixture(scope="module")
 def tok():
+    """Load the pinned gemma4 tokenizer for the enforcement tests.
+
+    PRIMARY gate: cache presence. A CACHED tokenizer must LOAD — if it fails, that
+    is corruption and the test FAILS (any exception propagates on the cached path
+    below). A NOT-cached tokenizer is skip-eligible ONLY when the miss is truly a
+    connectivity/offline one; the offline-vs-real-failure decision is broken by an
+    OFFLINE-INTENT tie-break (``_hf_offline_mode`` OR ``_is_connectivity_error``),
+    NOT a catch-all skip and NOT a message sniff. This resolves the r5<->r6
+    oscillation: skip-on-any-exception (r5) hid a bad revision / 404 / corrupt-
+    partial-cache as a false-GREEN (codex r6 #4), while the pre-r5 type-only skip
+    surfaced a genuine offline miss (bare wrapping ``OSError``) as a false-RED
+    (codex r5 F3). The r3 message-substring heuristic (codex r4 F3) is gone."""
     transformers = pytest.importorskip("transformers")
-    # PRIMARY gate: cache presence. A CACHED tokenizer must LOAD — if it fails, that
-    # is corruption and the test FAILS (any exception propagates on the cached path
-    # below). Only a NOT-cached tokenizer is skip-eligible (genuinely unavailable),
-    # and there ANY load failure means it could not be obtained, so it skips
-    # UNCONDITIONALLY. This replaces the r3 message-substring heuristic, which could
-    # not distinguish a corrupt cached artifact from an offline miss (codex r4 F3),
-    # and drops the r4 type-only skip that made the suite network-dependent when a
-    # real offline miss surfaced as a bare wrapping ``OSError`` (codex r5 F3).
     if _tokenizer_in_cache():
         return transformers.AutoTokenizer.from_pretrained(
             _TOKENIZER_MODEL, revision=_TOKENIZER_REVISION
@@ -625,22 +669,23 @@ def tok():
             _TOKENIZER_MODEL, revision=_TOKENIZER_REVISION
         )
     except Exception as exc:  # pragma: no cover - offline & uncached
-        # NOT cached (the cache-presence gate above returned False), so there is no
-        # local artifact that could be corrupt: ANY load failure here means the
-        # tokenizer is genuinely unavailable (offline miss / attempted fetch that
-        # could not complete) -> skip UNCONDITIONALLY. This stays SOUND w.r.t. the
-        # r4 false-GREEN fix because a CACHED-but-unloadable tokenizer never reaches
-        # this branch — it loads on the cached path above, where any exception
-        # PROPAGATES and the test FAILS. codex r5: a real offline miss can surface
-        # as a bare wrapping ``OSError`` (not only LocalEntryNotFoundError), so a
-        # type-only skip made the suite network-dependent (false-RED); cache-
-        # presence has ALREADY made the offline-vs-corrupt decision, so no exception
-        # typing is needed here.
-        pytest.skip(
-            f"tokenizer {_TOKENIZER_MODEL}@{_TOKENIZER_REVISION[:8]} not cached "
-            f"and could not be fetched ({type(exc).__name__}) — gemma4 "
-            "enforcement tests require it"
-        )
+        # NOT cached (cache-presence gate returned False). Decide offline-vs-real-
+        # failure by OFFLINE INTENT + connectivity TYPE — NOT a catch-all skip
+        # (codex r6 #4: that hid a bad revision / 404 / corrupt-partial-cache as a
+        # false-GREEN) and NOT a message sniff (codex r4 F3). Resolves the r5<->r6
+        # oscillation: skip-on-any (r5) was too broad, type-only (pre-r5) was too
+        # narrow (a genuine offline miss can surface as a bare OSError -> false-RED).
+        # If HF is in offline MODE we skip regardless of how the miss surfaced; if
+        # ONLINE, a load failure is a REAL failure (bad repo/revision/corrupt) and
+        # PROPAGATES so the suite FAILS, except a recognized transient connectivity
+        # error which skips.
+        if _hf_offline_mode() or _is_connectivity_error(exc):
+            pytest.skip(
+                f"tokenizer {_TOKENIZER_MODEL}@{_TOKENIZER_REVISION[:8]} not cached "
+                f"and unavailable offline ({type(exc).__name__}) — gemma4 "
+                "enforcement tests require it"
+            )
+        raise
 
 
 @pytest.fixture(scope="module")
@@ -1002,6 +1047,90 @@ def test_gemma4_object_value_via_json_enforced_and_roundtrips(tok, lltok):
     )
     name, args = _parse(wire, GEMMA4_OBJ_TOOL)
     assert name == "place" and args["origin"] == {"x": 3, "y": 4}
+
+
+# A tool with an OBJECT-typed property (rides ``%json``) alongside a plain STRING
+# property (the ``<|"|>`` wire) — used to refute codex r6 #1 (a brace inside a
+# ``%json`` object value's JSON string does NOT terminate the outer call).
+GEMMA4_NESTED_BRACE_TOOL = [
+    {
+        "name": "f",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "meta": {"type": "object"},
+                "name": {"type": "string"},
+            },
+            "required": ["meta", "name"],
+            "additionalProperties": False,
+        },
+    },
+]
+
+# A well-formed decoded wire whose OBJECT (``%json``) value carries a JSON string
+# containing a ``}`` AND a ``,`` — the exact shape codex r6 #1 claimed would close
+# the outer call early. Keys are in DICTSORT order (``meta`` < ``name``).
+_GEMMA4_NESTED_BRACE_WIRE = (
+    '<|tool_call>call:f{meta:{"s":"}","k":"a,b"},name:<|"|>x<|"|>}<tool_call|>'
+)
+
+
+def test_gemma4_nested_json_braces_in_object_value_round_trip():
+    # REFUTES codex r6 #1. ``_scan_gemma4_tool_calls`` tracks ``in_json_string``
+    # WITH escape handling, so a ``}`` / ``,`` / ``"`` inside a ``%json`` object
+    # value's JSON string is IGNORED for brace depth and does NOT close the outer
+    # call. (codex described ``_recover_incomplete_gemma4_calls``, the best-effort
+    # fallback that runs ONLY on the non-streaming finalize path when the balanced
+    # scanner found ZERO complete calls — never for this well-formed wire.)
+    from vllm_mlx.tool_parsers.gemma4_tool_parser import (
+        GEMMA4_TOOL_TRAILER,
+        _scan_gemma4_tool_calls,
+    )
+
+    wire = _GEMMA4_NESTED_BRACE_WIRE
+    matches, opener_count = _scan_gemma4_tool_calls(wire)
+    # Exactly ONE complete call — the inner ``}`` / ``,`` neither spawned a phantom
+    # opener nor split the body into two.
+    assert opener_count == 1
+    assert len(matches) == 1
+    match = matches[0]
+    assert match.name == "f"
+    # The call boundary is the CORRECT OUTER ``}`` (the byte immediately before the
+    # ``<tool_call|>`` trailer), consuming the whole wire — NOT the ``}`` buried in
+    # the ``meta`` JSON string value.
+    assert match.start == 0
+    assert match.end == len(wire)
+    assert wire[match.end - len(GEMMA4_TOOL_TRAILER) - 1] == "}"
+    assert match.arguments == 'meta:{"s":"}","k":"a,b"},name:<|"|>x<|"|>'
+
+    # Both args parse back with the nested object intact — the JSON-string brace
+    # and comma survive as VALUE content, not as structural delimiters.
+    name, args = _parse(wire, GEMMA4_NESTED_BRACE_TOOL)
+    assert name == "f"
+    assert args["name"] == "x"
+    assert args["meta"] == {"s": "}", "k": "a,b"}
+    assert args["meta"]["s"] == "}"
+    assert args["meta"]["k"] == "a,b"
+
+
+@_requires_llguidance
+def test_gemma4_nested_json_braces_object_prop_grammar_accepts(tok, lltok):
+    # Cross-check on the REAL tokenizer: the object-prop (``%json``) grammar ACCEPTS
+    # the same nested-brace wire end to end and reaches a terminal state, so the
+    # brace inside the JSON-string value is a legal ``%json`` byte that never
+    # mis-closes the constrained call (the grammar-side companion to the parser
+    # round-trip above; both refute codex r6 #1).
+    grammar = _gemma4_grammar(GEMMA4_NESTED_BRACE_TOOL, "required", tok)
+    assert grammar is not None
+    accepted, total, accepting = _consume(
+        grammar, lltok, tok, _GEMMA4_NESTED_BRACE_WIRE
+    )
+    assert accepted == total and accepting, (
+        f"nested-brace object value rejected ({accepted}/{total}, "
+        f"accepting={accepting})"
+    )
+    name, args = _parse(_GEMMA4_NESTED_BRACE_WIRE, GEMMA4_NESTED_BRACE_TOOL)
+    assert name == "f" and args["meta"] == {"s": "}", "k": "a,b"}
 
 
 # ==========================================================================

--- a/tests/test_gemma4_grammar_558.py
+++ b/tests/test_gemma4_grammar_558.py
@@ -164,14 +164,21 @@ _GEMMA4_GOLDEN_LARK = (
     "GEMMA_STR_TEXT: /(.|\\n)*/\n"
     'gemma_str_value: <|"|> GEMMA_STR_TEXT <|"|>\n'
     "\n"
-    # The DICTSORT-ordered comma body: required code+lang first (no comma before
-    # code; a comma separates lang), then each optional field carries its OWN
-    # leading comma inside a ``( ... )?`` group. String -> the greedy rule; enum ->
-    # per-value <|"|>-wrapped alternation; scalar -> bare %json.
-    'tag_0: <|tool_call> "call:run{" ( "code:" gemma_str_value "," "lang:" '
-    '(<|"|> "python" <|"|> | <|"|> "cpp" <|"|>) '
-    '( "," "timeout:" %json {"type": "integer"} )? '
-    '( "," "verbose:" %json {"type": "boolean"} )? ) "}" <tool_call|>\n'
+    # The DICTSORT-ordered comma body, emitted as an O(n)-size RECURSIVE grammar:
+    # the first-present head (required ``code`` at index 0, so it is the only
+    # first-present candidate) sits in ``tag_0`` with NO leading comma, then defers
+    # its comma-prefixed SUFFIX to the ``g0_rest<i>`` chain — each suffix nonterminal
+    # is emitted ONCE and references the next (right recursion), so the grammar does
+    # NOT regenerate the tail per alternative (previously O(n^2)). ``g0_rest1``
+    # carries the required ``lang`` (bare comma separator + per-value <|"|>-wrapped
+    # enum alternation); ``g0_rest2``/``g0_rest3`` carry each optional field's OWN
+    # leading comma inside a ``( ... )?`` group (string -> greedy rule; scalar ->
+    # bare %json).
+    'tag_0: <|tool_call> "call:run{" ( "code:" gemma_str_value g0_rest1 ) "}" '
+    "<tool_call|>\n"
+    'g0_rest1: "," "lang:" (<|"|> "python" <|"|> | <|"|> "cpp" <|"|>) g0_rest2\n'
+    'g0_rest2: ( "," "timeout:" %json {"type": "integer"} )? g0_rest3\n'
+    'g0_rest3: ( "," "verbose:" %json {"type": "boolean"} )?\n'
 )
 
 
@@ -190,7 +197,11 @@ def test_gemma4_lark_frame_and_sentinels():
 
     lark = build_tool_lark(GEMMA4_TOOLS, "required", [_gemma4_structure_info("run")])
     assert " <|tool_call> " in lark  # bare trigger ref
-    assert lark.rstrip().endswith("<tool_call|>")  # bare closing ref
+    # The tag frame closes with a BARE ``<tool_call|>`` ref. (The O(n) suffix chain
+    # emits ``g0_rest<i>`` rules AFTER the tag, so the grammar no longer ends on this
+    # line — assert against the ``tag_0`` rule itself, not the whole grammar.)
+    tag0_line = next(ln for ln in lark.splitlines() if ln.startswith("tag_0:"))
+    assert tag0_line.endswith("<tool_call|>")  # bare closing ref
     assert '"<|tool_call>"' not in lark  # NOT quoted literals
     assert '"<tool_call|>"' not in lark
     assert '"<|\\"|>"' not in lark  # the <|"|> marker is a ref, never a byte literal
@@ -217,12 +228,18 @@ def test_gemma4_string_value_uses_greedy_rule_not_lazy():
 def test_gemma4_comma_and_required_optional_framing():
     # Required fields come first with a bare comma separator; each optional field
     # carries its OWN leading comma inside a ``( ... )?`` group (first-present
-    # construction). ``code``/``lang`` required; ``timeout``/``verbose`` optional.
+    # construction, now emitted as an O(n) ``g0_rest<i>`` suffix chain).
+    # ``code``/``lang`` required; ``timeout``/``verbose`` optional.
     from vllm_mlx.api.tool_grammar import build_tool_lark
 
     lark = build_tool_lark(GEMMA4_TOOLS, "required", [_gemma4_structure_info("run")])
-    # Required pair separated by a bare comma (no leading/optional wrapper).
-    assert '"code:" gemma_str_value "," "lang:"' in lark
+    # Required ``code`` is the first-present head (no leading comma), deferring its
+    # comma-prefixed suffix to the shared ``g0_rest1`` nonterminal.
+    assert '( "code:" gemma_str_value g0_rest1 )' in lark
+    # The required ``lang`` suffix carries a BARE comma separator (never an optional
+    # ``( )?`` wrapper — a required field can't be skipped).
+    assert 'g0_rest1: "," "lang:"' in lark
+    assert '( "," "lang:"' not in lark
     # Each optional scalar carries its own leading comma inside ``( ... )?``.
     assert '( "," "timeout:" %json {"type": "integer"} )?' in lark
     assert '( "," "verbose:" %json {"type": "boolean"} )?' in lark
@@ -238,17 +255,123 @@ def test_gemma4_enum_is_per_value_wrapped_alternation():
 
 
 def test_gemma4_all_optional_wraps_body_in_optional_group():
-    # A tool with NO required field wraps the whole comma alternation in ``( ... )?``
-    # so an empty ``{}`` body is admitted.
+    # A tool with NO required field wraps the whole first-present alternation in an
+    # outer ``( ... )?`` so an empty ``{}`` body is admitted.
     from vllm_mlx.api.tool_grammar import build_tool_lark
 
     lark = build_tool_lark(GEMMA4_OPT_TOOL, "required", [_gemma4_structure_info("cfg")])
-    # First-present alternation over {a-first, b-first}, wrapped in an outer ``?``.
+    # First-present alternation over {a-first, b-first}, wrapped in an outer ``?``;
+    # the a-first branch defers b's comma-suffix to the shared ``g0_rest1`` rule.
     assert (
-        '"call:cfg{" ( "a:" gemma_str_value ( "," "b:" %json {"type": "integer"} )? '
+        '"call:cfg{" ( "a:" gemma_str_value g0_rest1 '
         '| "b:" %json {"type": "integer"} )? "}" <tool_call|>' in lark
     )
-    assert lark.rstrip().endswith(')? "}" <tool_call|>')
+    assert 'g0_rest1: ( "," "b:" %json {"type": "integer"} )?' in lark
+    # The comma-prefixed suffix lives ONLY in the shared rule, never inlined into the
+    # first-present alternation (that inlining was the O(n^2) construction).
+    assert 'gemma_str_value ( "," "b:"' not in lark
+    # The body group closes with the outer ``?`` right before the ``}`` frame.
+    assert ')? "}" <tool_call|>' in lark
+
+
+def test_gemma4_optional_grammar_is_linear_size_not_quadratic():
+    # FIX #2 (codex r1): the first-present body must be an O(n)-size RECURSIVE
+    # grammar — each comma-prefixed suffix emitted ONCE as a ``g0_rest<i>``
+    # nonterminal — NOT the old inline construction that regenerated the entire
+    # remaining suffix for every first-present alternative (O(n^2) grammar size AND
+    # construction time, a request-controlled CPU/memory amplifier).
+    from vllm_mlx.api.tool_grammar import build_tool_lark
+
+    def _build(n):
+        props = {f"p{i:02d}": {"type": "integer"} for i in range(n)}
+        tool = [
+            {
+                "name": "cfg",
+                "parameters": {
+                    "type": "object",
+                    "properties": props,
+                    "additionalProperties": False,
+                },
+            }
+        ]
+        lark = build_tool_lark(tool, "required", [_gemma4_structure_info("cfg")])
+        rest_defs = sum(
+            1 for ln in lark.splitlines() if ln.startswith("g0_rest") and ":" in ln
+        )
+        frag = lark.count('%json {"type": "integer"}')
+        return lark, rest_defs, frag
+
+    lark2, rest2, frag2 = _build(2)
+    lark8, rest8, frag8 = _build(8)
+
+    # Exactly n-1 suffix nonterminals -> each suffix emitted ONCE (linear rule count,
+    # not one regenerated copy per alternative).
+    assert (rest2, rest8) == (1, 7)
+    # Each field's value fragment appears O(1) times (first-present head + its suffix
+    # rule) -> exactly 2n-1: LINEAR. The old inline body was n(n+1)/2: QUADRATIC.
+    assert (frag2, frag8) == (3, 15)
+    assert frag8 < 8 * (8 + 1) // 2  # 15 < 36 (the would-be quadratic count)
+    # 4x the fields must not blow up super-linearly: linear grows ~5x here, quadratic
+    # would be ~12x. Guard the growth ratio well under quadratic.
+    assert frag8 <= 6 * frag2  # 15 <= 18 holds for linear; quadratic (36) would fail
+    # Byte size also grows sub-quadratically (each added field adds a bounded chunk).
+    assert len(lark8) < 4 * len(lark2)
+
+
+def test_gemma4_dictsort_order_is_case_insensitive():
+    # FIX #4 (codex r1): property order must match Gemma's chat template, which uses
+    # Jinja ``dictsort`` (default ``case_sensitive=False``) -> sort by the LOWERCASED
+    # key. A case-SENSITIVE ``sorted`` would order uppercase keys before lowercase
+    # ones and force the model off the order it was trained to emit.
+    from vllm_mlx.api.tool_grammar import build_tool_lark
+
+    props = {  # insertion order deliberately NEITHER sorted order
+        "Zebra": {"type": "string"},
+        "apple": {"type": "string"},
+        "Mango": {"type": "string"},
+    }
+    tool = [
+        {
+            "name": "cfg",
+            "parameters": {
+                "type": "object",
+                "properties": props,
+                "required": ["Zebra", "apple", "Mango"],
+                "additionalProperties": False,
+            },
+        }
+    ]
+    lark = build_tool_lark(tool, "required", [_gemma4_structure_info("cfg")])
+    # dictsort (case-insensitive): apple (a) < Mango (m) < Zebra (z).
+    i_apple, i_mango, i_zebra = (
+        lark.index(f'"{k}:"') for k in ("apple", "Mango", "Zebra")
+    )
+    assert i_apple < i_mango < i_zebra
+    # Case-SENSITIVE ``sorted`` would put uppercase Mango/Zebra before lowercase
+    # ``apple`` (M, Z < a) -> the exact bug this guards. Assert we are NOT there.
+    assert not (i_mango < i_apple)
+
+
+def test_gemma4_dictsort_case_collision_is_stable_insertion_order():
+    # A case-insensitive collision (``a`` vs ``A``) keeps the schema's INSERTION
+    # order via Python's stable sort -> EXACTLY Jinja ``dictsort``'s tiebreak (a
+    # secondary case-sensitive sort would instead force ``A`` before ``a``).
+    from vllm_mlx.api.tool_grammar import build_tool_lark
+
+    props = {"a": {"type": "string"}, "A": {"type": "string"}}  # 'a' inserted first
+    tool = [
+        {
+            "name": "cfg",
+            "parameters": {
+                "type": "object",
+                "properties": props,
+                "required": ["a", "A"],
+                "additionalProperties": False,
+            },
+        }
+    ]
+    lark = build_tool_lark(tool, "required", [_gemma4_structure_info("cfg")])
+    assert lark.index('"a:"') < lark.index('"A:"')
 
 
 def test_gemma4_noarg_tool_has_empty_body():
@@ -435,7 +558,14 @@ def test_gemma4_supports_grammar_and_auto_unsafe():
 # Grammar ENFORCEMENT + ROUND-TRIP on the REAL gemma4 tokenizer.
 # --------------------------------------------------------------------------
 def _offline_skip_exc_types():
-    types: list[type[BaseException]] = []
+    # ``OSError`` is included UNCONDITIONALLY: Transformers commonly wraps an
+    # unavailable tokenizer/cache as a plain ``OSError`` ("Can't load ... offline"),
+    # so a genuinely-offline run must SKIP (not FAIL) on it. The previous
+    # ``tuple(types) or (OSError,)`` dropped ``OSError`` whenever either optional
+    # import below succeeded — turning an offline run into a failure. The narrower
+    # connectivity exceptions are appended (still skip-worthy, more specific) but
+    # never displace ``OSError``.
+    types: list[type[BaseException]] = [OSError]
     try:
         from huggingface_hub.errors import (
             LocalEntryNotFoundError,
@@ -451,7 +581,7 @@ def _offline_skip_exc_types():
         types.append(_ReqConnErr)
     except Exception:  # pragma: no cover - requests not present
         pass
-    return tuple(types) or (OSError,)
+    return tuple(types)
 
 
 @pytest.fixture(scope="module")

--- a/tests/test_gemma4_grammar_558.py
+++ b/tests/test_gemma4_grammar_558.py
@@ -591,7 +591,8 @@ def _tokenizer_in_cache() -> bool:
     repo/revision was never fetched. Only a genuine ``str`` path counts as cached.
     Degrades to ``False`` (treat as not cached -> skip-eligible) if the hub helper
     is unavailable or raises — never masks a real load failure, since the ``tok``
-    fixture only skips on an offline EXCEPTION TYPE in the not-cached branch."""
+    fixture loads a present cache with ``local_files_only=True`` so a corrupt or
+    partial cache raises loudly (the test FAILS) rather than being skipped."""
     try:
         from huggingface_hub import try_to_load_from_cache
     except Exception:  # pragma: no cover - very old hub
@@ -605,87 +606,24 @@ def _tokenizer_in_cache() -> bool:
     return isinstance(path, str)
 
 
-def _hf_offline_mode() -> bool:
-    """True iff HuggingFace is configured for OFFLINE mode (env or hub constant).
-    Used to skip the uncached tokenizer fetch on an INTENTIONAL offline run
-    regardless of how transformers surfaces the miss (bare OSError included)."""
-    import os
-
-    if os.environ.get("HF_HUB_OFFLINE") or os.environ.get("TRANSFORMERS_OFFLINE"):
-        return True
-    try:
-        from huggingface_hub import constants
-
-        return bool(getattr(constants, "HF_HUB_OFFLINE", False))
-    except Exception:  # pragma: no cover - very old hub
-        return False
-
-
-def _is_connectivity_error(exc: BaseException) -> bool:
-    """True iff exc is a recognized NETWORK/offline connectivity type. A 404 /
-    bad-revision / corrupt error is deliberately NOT here — those must FAIL, not
-    skip (codex r6 #4). Only the transient/offline connectivity path skips."""
-    types: list[type[BaseException]] = []
-    try:
-        from huggingface_hub.errors import (
-            LocalEntryNotFoundError,
-            OfflineModeIsEnabled,
-        )
-
-        types += [LocalEntryNotFoundError, OfflineModeIsEnabled]
-    except Exception:  # pragma: no cover - old hub
-        pass
-    try:
-        from requests.exceptions import ConnectionError as _ReqConnErr
-        from requests.exceptions import Timeout as _ReqTimeout
-
-        types += [_ReqConnErr, _ReqTimeout]
-    except Exception:  # pragma: no cover - requests absent
-        pass
-    return bool(types) and isinstance(exc, tuple(types))
-
-
 @pytest.fixture(scope="module")
 def tok():
-    """Load the pinned gemma4 tokenizer for the enforcement tests.
-
-    PRIMARY gate: cache presence. A CACHED tokenizer must LOAD — if it fails, that
-    is corruption and the test FAILS (any exception propagates on the cached path
-    below). A NOT-cached tokenizer is skip-eligible ONLY when the miss is truly a
-    connectivity/offline one; the offline-vs-real-failure decision is broken by an
-    OFFLINE-INTENT tie-break (``_hf_offline_mode`` OR ``_is_connectivity_error``),
-    NOT a catch-all skip and NOT a message sniff. This resolves the r5<->r6
-    oscillation: skip-on-any-exception (r5) hid a bad revision / 404 / corrupt-
-    partial-cache as a false-GREEN (codex r6 #4), while the pre-r5 type-only skip
-    surfaced a genuine offline miss (bare wrapping ``OSError``) as a false-RED
-    (codex r5 F3). The r3 message-substring heuristic (codex r4 F3) is gone."""
     transformers = pytest.importorskip("transformers")
-    if _tokenizer_in_cache():
-        return transformers.AutoTokenizer.from_pretrained(
-            _TOKENIZER_MODEL, revision=_TOKENIZER_REVISION
+    # CACHE-ONLY (codex r7 #1). These enforcement tests NEVER hit the network: the
+    # offline-vs-corrupt decision is made entirely by cache presence, so there is no
+    # live download to fail on a firewalled/offline CI and no wrapped-exception
+    # classification to get wrong. NOT cached -> skip (genuinely unavailable);
+    # cached -> load with ``local_files_only=True`` so a partial/corrupt cache raises
+    # immediately (the test FAILS) instead of silently triggering a download.
+    if not _tokenizer_in_cache():
+        pytest.skip(
+            f"tokenizer {_TOKENIZER_MODEL}@{_TOKENIZER_REVISION[:8]} not in the local "
+            "HF cache — gemma4 enforcement tests are cache-only (no network). "
+            "Pre-cache the tokenizer to run them."
         )
-    try:
-        return transformers.AutoTokenizer.from_pretrained(
-            _TOKENIZER_MODEL, revision=_TOKENIZER_REVISION
-        )
-    except Exception as exc:  # pragma: no cover - offline & uncached
-        # NOT cached (cache-presence gate returned False). Decide offline-vs-real-
-        # failure by OFFLINE INTENT + connectivity TYPE — NOT a catch-all skip
-        # (codex r6 #4: that hid a bad revision / 404 / corrupt-partial-cache as a
-        # false-GREEN) and NOT a message sniff (codex r4 F3). Resolves the r5<->r6
-        # oscillation: skip-on-any (r5) was too broad, type-only (pre-r5) was too
-        # narrow (a genuine offline miss can surface as a bare OSError -> false-RED).
-        # If HF is in offline MODE we skip regardless of how the miss surfaced; if
-        # ONLINE, a load failure is a REAL failure (bad repo/revision/corrupt) and
-        # PROPAGATES so the suite FAILS, except a recognized transient connectivity
-        # error which skips.
-        if _hf_offline_mode() or _is_connectivity_error(exc):
-            pytest.skip(
-                f"tokenizer {_TOKENIZER_MODEL}@{_TOKENIZER_REVISION[:8]} not cached "
-                f"and unavailable offline ({type(exc).__name__}) — gemma4 "
-                "enforcement tests require it"
-            )
-        raise
+    return transformers.AutoTokenizer.from_pretrained(
+        _TOKENIZER_MODEL, revision=_TOKENIZER_REVISION, local_files_only=True
+    )
 
 
 @pytest.fixture(scope="module")
@@ -789,6 +727,65 @@ def test_gemma4_valid_call_accepted_and_terminates(tok, lltok):
     accepted, total, accepting = _consume(grammar, lltok, tok, _wire("print(1)"))
     assert accepted == total, f"valid gemma4 call rejected ({accepted}/{total})"
     assert accepting, "valid complete gemma4 call is not a terminal state"
+
+
+@_requires_llguidance
+def test_gemma4_chat_template_wire_matches_grammar_and_parser(tok, lltok):
+    """GROUND-TRUTH anchor (codex r7 #3): render a tool call through the pinned
+    tokenizer's REAL ``apply_chat_template`` and prove the E4 wire premise against
+    it, so the whole enforcement suite can no longer stay green on a handwritten
+    ``_wire`` that disagrees with the model's actual chat template.
+
+    The pinned gemma-4 ``chat_template`` DOES render an assistant ``tool_calls``
+    turn — its assistant branch emits, verbatim,
+    ``<|tool_call>call:<name>{<k>:<format_argument(v)>,...}<tool_call|>`` with keys
+    in ``| dictsort`` order and ``format_argument(value, escape_keys=False)`` so a
+    string value becomes ``<|"|>v<|"|>``, a bool becomes ``true``/``false`` and an
+    int is emitted bare (the exact ``%json`` scalar surface). We build a ``run``
+    call whose args cover BOTH wire shapes: ``code``/``lang`` (``<|"|>``-wrapped
+    strings) plus ``timeout`` (bare ``%json`` int) and ``verbose`` (bare bool)."""
+    args = {"code": "print(1)", "lang": "python", "timeout": 30, "verbose": True}
+    messages = [
+        {"role": "user", "content": "run print(1)"},
+        {
+            "role": "assistant",
+            "tool_calls": [
+                {"type": "function", "function": {"name": "run", "arguments": args}}
+            ],
+        },
+    ]
+    rendered = tok.apply_chat_template(
+        messages, tokenize=False, add_generation_prompt=False
+    )
+
+    # Extract the wire span the template rendered between the two special markers.
+    begin, end = "<|tool_call>", "<tool_call|>"
+    i = rendered.find(begin)
+    assert i != -1, f"chat_template did not render a tool call: {rendered!r}"
+    j = rendered.find(end, i)
+    assert j != -1, f"chat_template tool call is not terminated: {rendered!r}"
+    wire = rendered[i : j + len(end)]
+
+    # (0) The handwritten ``_wire`` helper the enforcement suite is built on IS the
+    # ground-truth wire (verbose="true" == the bool ``true`` the template emits).
+    assert wire == _wire("print(1)", lang="python", timeout=30, verbose="true"), (
+        f"handwritten _wire disagrees with the real chat_template render: {wire!r}"
+    )
+
+    # (i) The gemma4 parser recovers the tool name + args EXACTLY from the render.
+    name, parsed = _parse(wire, GEMMA4_TOOLS)
+    assert name == "run"
+    assert parsed == args, f"parser did not round-trip the rendered wire: {parsed!r}"
+
+    # (ii) The generated grammar ACCEPTS the rendered wire and reaches a terminal
+    # state — proving grammar <-> real-template agreement end to end.
+    grammar = _gemma4_grammar(GEMMA4_TOOLS, "required", tok)
+    assert grammar is not None
+    accepted, total, accepting = _consume(grammar, lltok, tok, wire)
+    assert accepted == total, (
+        f"grammar rejected the real chat_template wire ({accepted}/{total}): {wire!r}"
+    )
+    assert accepting, f"real chat_template wire is not a terminal state: {wire!r}"
 
 
 @_requires_llguidance

--- a/tests/test_gemma4_grammar_558.py
+++ b/tests/test_gemma4_grammar_558.py
@@ -557,15 +557,37 @@ def test_gemma4_supports_grammar_and_auto_unsafe():
 # --------------------------------------------------------------------------
 # Grammar ENFORCEMENT + ROUND-TRIP on the REAL gemma4 tokenizer.
 # --------------------------------------------------------------------------
+# Message substrings (case-insensitive) that mark a BARE ``OSError`` from
+# ``from_pretrained`` as genuine OFFLINE / cache-unavailability. Transformers wraps
+# an uncached-and-no-network load as a plain ``OSError`` whose message is one of
+# these ("Can't load the configuration of ...", "We couldn't connect to ...",
+# "... offline ..."). A CORRUPT artifact or INVALID REVISION is ALSO an ``OSError``
+# (e.g. a wrapped 404 "<rev> is not a valid git identifier ...") but its message is
+# NOT in this list, so it FAILS instead of skipping — corruption/bad-revision must
+# never be false-green (codex r3 E4).
+_OFFLINE_MSG_SUBSTRINGS = (
+    "offline",
+    "can't load",
+    "couldn't connect",
+    "we couldn't connect",
+    "not a local folder",
+    "connection error",
+    "max retries",
+    "failed to connect",
+    "unable to load",
+)
+
+
 def _offline_skip_exc_types():
-    # ``OSError`` is included UNCONDITIONALLY: Transformers commonly wraps an
-    # unavailable tokenizer/cache as a plain ``OSError`` ("Can't load ... offline"),
-    # so a genuinely-offline run must SKIP (not FAIL) on it. The previous
-    # ``tuple(types) or (OSError,)`` dropped ``OSError`` whenever either optional
-    # import below succeeded — turning an offline run into a failure. The narrower
-    # connectivity exceptions are appended (still skip-worthy, more specific) but
-    # never displace ``OSError``.
-    types: list[type[BaseException]] = [OSError]
+    # HF-SPECIFIC offline/connectivity types that ALWAYS mean "skip" regardless of
+    # message text (network / cache unavailability). ``OSError`` is DELIBERATELY NOT
+    # here: a bare ``OSError`` is offline ONLY when its message matches
+    # ``_OFFLINE_MSG_SUBSTRINGS`` (see ``_is_offline_unavailable``). Catching EVERY
+    # ``OSError`` as offline (the old behavior) would SKIP a corrupt artifact /
+    # invalid revision too — a false-green codex r3 flagged. The needle: keep the
+    # genuine-offline OSError skipping (message-gated) WITHOUT masking corruption,
+    # and never regress the prior fix that a plain offline ``OSError`` must skip.
+    types: list[type[BaseException]] = []
     try:
         from huggingface_hub.errors import (
             LocalEntryNotFoundError,
@@ -584,6 +606,24 @@ def _offline_skip_exc_types():
     return tuple(types)
 
 
+def _is_offline_unavailable(exc: BaseException) -> bool:
+    """True iff ``exc`` from ``AutoTokenizer.from_pretrained`` indicates genuine
+    OFFLINE / cache-unavailability (skip-worthy), NOT a corrupt artifact / invalid
+    revision (which must FAIL, not skip). Skip when: a specific HF
+    offline/connectivity TYPE (``LocalEntryNotFoundError`` / ``OfflineModeIsEnabled``
+    / ``requests.ConnectionError``), OR a bare ``OSError`` whose message matches the
+    offline allowlist. ANY OTHER ``OSError`` (corruption / bad revision / a wrapped
+    404) returns ``False`` -> the caller re-raises -> the test FAILS (codex r3
+    E4)."""
+    offline_types = _offline_skip_exc_types()
+    if offline_types and isinstance(exc, offline_types):
+        return True
+    if isinstance(exc, OSError):
+        msg = str(exc).lower()
+        return any(sub in msg for sub in _OFFLINE_MSG_SUBSTRINGS)
+    return False
+
+
 @pytest.fixture(scope="module")
 def tok():
     transformers = pytest.importorskip("transformers")
@@ -591,7 +631,12 @@ def tok():
         return transformers.AutoTokenizer.from_pretrained(
             _TOKENIZER_MODEL, revision=_TOKENIZER_REVISION
         )
-    except _offline_skip_exc_types():  # pragma: no cover - offline & uncached
+    except Exception as exc:  # pragma: no cover - offline & uncached
+        # SKIP only a genuine offline/cache-miss; RE-RAISE (FAIL) a corrupt artifact
+        # / invalid revision — both are ``OSError`` but only the former is
+        # skip-worthy, so corruption is never silently false-green (codex r3 E4).
+        if not _is_offline_unavailable(exc):
+            raise
         pytest.skip(
             f"tokenizer {_TOKENIZER_MODEL}@{_TOKENIZER_REVISION[:8]} not cached "
             "and no network — gemma4 enforcement tests require it"
@@ -989,6 +1034,39 @@ def test_gemma4_enum_type_consistency_shared():
     assert rep({"properties": {"n": {"type": "number", "enum": [1.5, 2]}}}) is True
 
 
+def test_gemma4_enum_tokenizer_complete_opt_out_and_none_fallback():
+    # FIX (codex r3 E4): the enum guard is COMPLETE BY CONSTRUCTION when a tokenizer
+    # is threaded in — it rejects an enum value that tokenizes through ANY registered
+    # special token, not only the five hard-coded structural markers. ``<bos>`` is a
+    # registered special token but NOT one of the five markers, so it is caught ONLY
+    # by the tokenizer-complete check, not the 5-marker substring blacklist.
+    from vllm_mlx.api.tool_grammar import _gemma4_schema_representable as rep
+
+    # A fake tokenizer that registers ``<bos>`` as a single added token (id 2) — the
+    # same surface ``_is_registered_added_token`` probes. ``<bos>`` is deliberately
+    # NOT in ``_GEMMA4_STRUCTURAL_MARKERS``.
+    fake = _FakeTokenizer(added={"<bos>": 2})
+    bos_enum = {"properties": {"s": {"type": "string", "enum": ["<bos>"]}}}
+    clean_enum = {"properties": {"s": {"type": "string", "enum": ["python"]}}}
+
+    # WITH tokenizer: ``<bos>`` opts out (unreachable byte-literal branch); a clean
+    # value that tokenizes to ordinary (non-registered) ids stays representable.
+    assert rep(bos_enum, tokenizer=fake) is False
+    assert rep(clean_enum, tokenizer=fake) is True
+
+    # WITHOUT tokenizer (degraded / warmup): the guard falls back to the 5-marker
+    # STRUCTURAL subset, which does NOT know ``<bos>`` — so it stays representable.
+    # This proves the None path uses exactly the structural blacklist (a safe
+    # under-approximation the warmup's fixed no-enum tool never exercises).
+    assert rep(bos_enum, tokenizer=None) is True
+    assert rep(bos_enum) is True  # default tokenizer=None
+    # The 5-marker structural check STILL fires on the None path for a real marker.
+    marker_enum = {"properties": {"s": {"type": "string", "enum": ['a<|"|>b']}}}
+    assert rep(marker_enum, tokenizer=None) is False
+    # And WITH a tokenizer the structural marker is still rejected (belt & braces).
+    assert rep(marker_enum, tokenizer=fake) is False
+
+
 # ---- OPT-OUT through build_tool_grammar (real parser) --------------------
 @_requires_llguidance
 def test_gemma4_build_tool_grammar_opts_out_bad_key(tok):
@@ -1051,3 +1129,68 @@ def test_gemma4_build_tool_grammar_opts_out_enum_with_structural_marker(marker, 
         }
     ]
     assert _gemma4_grammar(bad_enum_tool, "required", tok) is None, marker
+
+
+def _enum_tool(*enum_values):
+    """A ``run``-shaped tool whose ``lang`` enum is ``enum_values``."""
+    return [
+        {
+            "name": "run",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "code": {"type": "string"},
+                    "lang": {"type": "string", "enum": list(enum_values)},
+                },
+                "required": ["code", "lang"],
+                "additionalProperties": False,
+            },
+        }
+    ]
+
+
+@_requires_llguidance
+@pytest.mark.parametrize("special", ["<bos>", "<eos>", "<pad>", "<unk>"])
+def test_gemma4_build_tool_grammar_opts_out_enum_with_any_special_token(special, tok):
+    # FIX (codex r3 E4), end-to-end on the REAL tokenizer: the enum guard is COMPLETE
+    # BY CONSTRUCTION, not a five-marker blacklist. ``<bos>``/``<eos>``/``<pad>``/
+    # ``<unk>`` are REGISTERED single special tokens on the gemma-4 tokenizer (ids
+    # 2/1/0/3) but are NOT among ``_GEMMA4_STRUCTURAL_MARKERS`` — an enum value equal
+    # to one compiles to a DEAD byte-literal branch (llguidance emits the token
+    # atomically, never its bytes). ``build_tool_grammar`` must OPT OUT (None ->
+    # free-form) once the model tokenizer is threaded into the guard, even though the
+    # structural 5-marker check alone would MISS these. A clean enum still builds.
+    from vllm_mlx.api.tool_grammar import _GEMMA4_STRUCTURAL_MARKERS
+
+    # Precondition: OUTSIDE the hard-coded marker set (only the tokenizer-complete
+    # check can reject it) AND a single registered special token on THIS tokenizer
+    # (otherwise the value would be a reachable byte-literal and correctly kept).
+    assert special not in _GEMMA4_STRUCTURAL_MARKERS
+    ids = tok.encode(special, add_special_tokens=False)
+    assert len(ids) == 1, (special, ids)
+
+    assert _gemma4_grammar(GEMMA4_TOOLS, "required", tok) is not None  # clean builds
+    assert _gemma4_grammar(_enum_tool("python", special), "required", tok) is None, (
+        special
+    )
+
+
+@_requires_llguidance
+@pytest.mark.parametrize(
+    "multitoken", ["<start_of_turn>", "<end_of_turn>", "<unused0>"]
+)
+def test_gemma4_build_tool_grammar_keeps_enum_with_multitoken_pseudo_special(
+    multitoken, tok
+):
+    # Complete-by-construction is a PRECISE opt-out, not a blanket ``<...>`` reject:
+    # a value opts out ONLY when it is genuinely UNREACHABLE. On this pinned 4bit
+    # tokenizer ``<start_of_turn>``/``<end_of_turn>``/``<unused0>`` are NOT single
+    # special tokens — they tokenize to ordinary multi-token text (verified below),
+    # so a byte-literal alternation branch for them IS reachable and MUST be kept
+    # (opting out here would needlessly drop the grammar for a representable enum).
+    # This guards the guard against over-rejecting on a bare ``<``/``>``.
+    ids = tok.encode(multitoken, add_special_tokens=False)
+    assert len(ids) > 1, (multitoken, ids)  # genuinely multi-token, hence reachable
+    assert (
+        _gemma4_grammar(_enum_tool("python", multitoken), "required", tok) is not None
+    )

--- a/tests/test_gemma4_grammar_558.py
+++ b/tests/test_gemma4_grammar_558.py
@@ -605,59 +605,17 @@ def _tokenizer_in_cache() -> bool:
     return isinstance(path, str)
 
 
-def _offline_skip_exc_types():
-    # HF-SPECIFIC offline/connectivity exception TYPES (network / cache
-    # unavailability). Used ONLY as a belt-and-suspenders skip in the NOT-cached
-    # branch of the ``tok`` fixture (the load-attempted-while-uncached race). The
-    # PRIMARY offline-vs-corrupt decision is the cache-presence gate
-    # (``_tokenizer_in_cache``); a CACHED-but-unloadable tokenizer always FAILS, so
-    # ``OSError`` is DELIBERATELY not in this type list (catching every ``OSError``
-    # would skip corruption — the false-green codex flagged).
-    types: list[type[BaseException]] = []
-    try:
-        from huggingface_hub.errors import (
-            LocalEntryNotFoundError,
-            OfflineModeIsEnabled,
-        )
-
-        types += [LocalEntryNotFoundError, OfflineModeIsEnabled]
-    except Exception:  # pragma: no cover - old hub without these names
-        pass
-    try:
-        from requests.exceptions import ConnectionError as _ReqConnErr
-
-        types.append(_ReqConnErr)
-    except Exception:  # pragma: no cover - requests not present
-        pass
-    return tuple(types)
-
-
-def _is_offline_unavailable(exc: BaseException) -> bool:
-    """True iff ``exc`` from ``AutoTokenizer.from_pretrained`` is a genuine HF
-    OFFLINE/connectivity exception TYPE (``LocalEntryNotFoundError`` /
-    ``OfflineModeIsEnabled`` / ``requests.ConnectionError``).
-
-    Type-only — the r3 message-substring heuristic is GONE (codex r4 F3): "Can't
-    load ..." is emitted for both offline AND corrupt artifacts, so a message match
-    could not tell them apart. The cache-presence gate now makes that call, and this
-    predicate is only the belt-and-suspenders skip for the NOT-cached branch (an
-    uncached repo that failed to fetch). Any other error — including a bare
-    ``OSError`` (corruption / bad revision / wrapped 404) — returns ``False`` so the
-    caller re-raises and the test FAILS."""
-    offline_types = _offline_skip_exc_types()
-    return bool(offline_types) and isinstance(exc, offline_types)
-
-
 @pytest.fixture(scope="module")
 def tok():
     transformers = pytest.importorskip("transformers")
     # PRIMARY gate: cache presence. A CACHED tokenizer must LOAD — if it fails, that
-    # is corruption and the test FAILS (any exception propagates). Only a NOT-cached
-    # tokenizer is skip-eligible (genuinely unavailable), and even then only for an
-    # offline EXCEPTION TYPE (belt & suspenders for the attempted-fetch-while-
-    # uncached race); any other error on an uncached repo still surfaces. This
-    # replaces the r3 message-substring heuristic, which could not distinguish a
-    # corrupt cached artifact from an offline miss (codex r4 F3).
+    # is corruption and the test FAILS (any exception propagates on the cached path
+    # below). Only a NOT-cached tokenizer is skip-eligible (genuinely unavailable),
+    # and there ANY load failure means it could not be obtained, so it skips
+    # UNCONDITIONALLY. This replaces the r3 message-substring heuristic, which could
+    # not distinguish a corrupt cached artifact from an offline miss (codex r4 F3),
+    # and drops the r4 type-only skip that made the suite network-dependent when a
+    # real offline miss surfaced as a bare wrapping ``OSError`` (codex r5 F3).
     if _tokenizer_in_cache():
         return transformers.AutoTokenizer.from_pretrained(
             _TOKENIZER_MODEL, revision=_TOKENIZER_REVISION
@@ -667,11 +625,21 @@ def tok():
             _TOKENIZER_MODEL, revision=_TOKENIZER_REVISION
         )
     except Exception as exc:  # pragma: no cover - offline & uncached
-        if not _is_offline_unavailable(exc):
-            raise
+        # NOT cached (the cache-presence gate above returned False), so there is no
+        # local artifact that could be corrupt: ANY load failure here means the
+        # tokenizer is genuinely unavailable (offline miss / attempted fetch that
+        # could not complete) -> skip UNCONDITIONALLY. This stays SOUND w.r.t. the
+        # r4 false-GREEN fix because a CACHED-but-unloadable tokenizer never reaches
+        # this branch — it loads on the cached path above, where any exception
+        # PROPAGATES and the test FAILS. codex r5: a real offline miss can surface
+        # as a bare wrapping ``OSError`` (not only LocalEntryNotFoundError), so a
+        # type-only skip made the suite network-dependent (false-RED); cache-
+        # presence has ALREADY made the offline-vs-corrupt decision, so no exception
+        # typing is needed here.
         pytest.skip(
             f"tokenizer {_TOKENIZER_MODEL}@{_TOKENIZER_REVISION[:8]} not cached "
-            "and no network — gemma4 enforcement tests require it"
+            f"and could not be fetched ({type(exc).__name__}) — gemma4 "
+            "enforcement tests require it"
         )
 
 

--- a/tests/test_gemma4_grammar_558.py
+++ b/tests/test_gemma4_grammar_558.py
@@ -932,6 +932,43 @@ def test_gemma4_enum_delimiter_safety_differs_from_xml():
     )
 
 
+def test_gemma4_enum_all_structural_markers_opt_out():
+    # FIX #1 (codex r2): the enum-wire guard must reject EVERY gemma4 structural
+    # special token, not only ``<|"|>``. Each — the string delimiter ``<|"|>`` AND
+    # the ``<|tool_call>``/``<tool_call|>`` frame tokens AND the reasoning-channel
+    # ``<|channel>``/``<channel|>`` tokens — is a SINGLE special token, so a byte
+    # rendering of it inside an enum value can never be produced at runtime and would
+    # compile to a DEAD alternation branch. Faithful-or-opt-out: opt the whole
+    # request out instead of emitting an unreachable branch.
+    from vllm_mlx.api.tool_grammar import (
+        _GEMMA4_STRUCTURAL_MARKERS,
+    )
+    from vllm_mlx.api.tool_grammar import (
+        _gemma4_schema_representable as g_rep,
+    )
+
+    # The guard's marker set is exactly the five documented structural tokens.
+    assert set(_GEMMA4_STRUCTURAL_MARKERS) == {
+        "<|tool_call>",
+        "<tool_call|>",
+        '<|"|>',
+        "<|channel>",
+        "<channel|>",
+    }
+    for marker in _GEMMA4_STRUCTURAL_MARKERS:
+        schema = {"properties": {"s": {"type": "string", "enum": [f"a{marker}b"]}}}
+        assert g_rep(schema) is False, marker
+        # A marker at the very start / end of the value opts out too.
+        assert g_rep({"properties": {"s": {"enum": [marker], "type": "string"}}}) is False
+    # Control: values containing the markers' INDIVIDUAL safe bytes (``<``/``>``/
+    # ``|``) but NOT a full marker substring stay representable (gemma4 permits raw
+    # ``<``/``>`` inside the ``<|"|>`` pair — the whole point vs XML).
+    assert (
+        g_rep({"properties": {"s": {"type": "string", "enum": ["a<b>c", "x|y", "|>", "<|"]}}})
+        is True
+    )
+
+
 def test_gemma4_enum_type_consistency_shared():
     # The shared enum guard still rejects value/declared-type mismatch and
     # unsupported siblings.
@@ -975,3 +1012,32 @@ def test_gemma4_build_tool_grammar_opts_out_string_pattern(tok):
         }
     ]
     assert _gemma4_grammar(pat_tool, "required", tok) is None
+
+
+@_requires_llguidance
+@pytest.mark.parametrize(
+    "marker", ["<|tool_call>", "<tool_call|>", '<|"|>', "<|channel>", "<channel|>"]
+)
+def test_gemma4_build_tool_grammar_opts_out_enum_with_structural_marker(marker, tok):
+    # FIX #1 (codex r2), end-to-end on the REAL tokenizer: an enum value whose wire
+    # form embeds ANY gemma4 structural special token would compile to a DEAD
+    # byte-literal alternation branch (the token is emitted atomically, never as its
+    # bytes). ``build_tool_grammar`` must OPT OUT (return None -> free-form), never
+    # ship an unreachable branch. A clean enum (``lang`` in GEMMA4_TOOLS) still builds
+    # (control below), so the opt-out is specific to the marker-bearing value.
+    assert _gemma4_grammar(GEMMA4_TOOLS, "required", tok) is not None  # clean enum builds
+    bad_enum_tool = [
+        {
+            "name": "run",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "code": {"type": "string"},
+                    "lang": {"type": "string", "enum": ["python", f"c{marker}pp"]},
+                },
+                "required": ["code", "lang"],
+                "additionalProperties": False,
+            },
+        }
+    ]
+    assert _gemma4_grammar(bad_enum_tool, "required", tok) is None, marker

--- a/tests/test_gemma4_grammar_558.py
+++ b/tests/test_gemma4_grammar_558.py
@@ -959,12 +959,20 @@ def test_gemma4_enum_all_structural_markers_opt_out():
         schema = {"properties": {"s": {"type": "string", "enum": [f"a{marker}b"]}}}
         assert g_rep(schema) is False, marker
         # A marker at the very start / end of the value opts out too.
-        assert g_rep({"properties": {"s": {"enum": [marker], "type": "string"}}}) is False
+        assert (
+            g_rep({"properties": {"s": {"enum": [marker], "type": "string"}}}) is False
+        )
     # Control: values containing the markers' INDIVIDUAL safe bytes (``<``/``>``/
     # ``|``) but NOT a full marker substring stay representable (gemma4 permits raw
     # ``<``/``>`` inside the ``<|"|>`` pair — the whole point vs XML).
     assert (
-        g_rep({"properties": {"s": {"type": "string", "enum": ["a<b>c", "x|y", "|>", "<|"]}}})
+        g_rep(
+            {
+                "properties": {
+                    "s": {"type": "string", "enum": ["a<b>c", "x|y", "|>", "<|"]}
+                }
+            }
+        )
         is True
     )
 
@@ -1025,7 +1033,9 @@ def test_gemma4_build_tool_grammar_opts_out_enum_with_structural_marker(marker, 
     # bytes). ``build_tool_grammar`` must OPT OUT (return None -> free-form), never
     # ship an unreachable branch. A clean enum (``lang`` in GEMMA4_TOOLS) still builds
     # (control below), so the opt-out is specific to the marker-bearing value.
-    assert _gemma4_grammar(GEMMA4_TOOLS, "required", tok) is not None  # clean enum builds
+    assert (
+        _gemma4_grammar(GEMMA4_TOOLS, "required", tok) is not None
+    )  # clean enum builds
     bad_enum_tool = [
         {
             "name": "run",

--- a/tests/test_gemma4_grammar_558.py
+++ b/tests/test_gemma4_grammar_558.py
@@ -1,0 +1,847 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Offline tests for the Gemma-4 native grammar constraint (#558 E4).
+
+The JSON-body families (hermes / qwen / harmony) constrain their ``arguments``
+as a single ``%json`` object; Qwen3-Coder (E3) emits an XML arg body. Gemma-4
+instead emits its own native wire ::
+
+    <|tool_call>call:NAME{k1:<|"|>str<|"|>,k2:5,k3:true}<tool_call|>
+
+so its ``structure_info()`` declares ``arg_style="gemma4"`` and ``build_tool_lark``
+emits a DICTSORT-ordered, COMMA-separated ``key:VALUE`` body
+(``_emit_gemma4_arg_body`` / ``_emit_gemma4_param_value``) instead of an XML body
+or a whole-object ``%json``. These tests prove that path WITHOUT a decode loop:
+
+  * ``build_tool_lark`` golden output for ``arg_style="gemma4"`` (``call:NAME{``
+    frame, string values as the GREEDY ``gemma_str_value`` rule terminating on the
+    ``<|"|>`` SPECIAL TOKEN, enum alternation with per-value ``<|"|>`` wrapping,
+    ``%json`` scalars, and the first-present comma construction for required vs
+    optional fields);
+  * THE E4 FEASIBILITY RESULT: a string value is bounded by ``<|"|>`` — a SINGLE
+    SPECIAL TOKEN, not a byte string like E3's ``</parameter>``. llguidance rejects
+    a special token inside a ``[lazy]`` terminal, and a byte-literal ``<|"|>``
+    cannot match the atomic token at runtime; the working construct is a GREEDY
+    ``gemma_str_value: <|"|> GEMMA_STR_TEXT <|"|>`` (maximal-munch stops at the
+    special-token boundary on its own). A value containing ``<``/``{``/``}``/``,``/
+    quotes/newlines round-trips and terminates correctly;
+  * grammar ENFORCEMENT via llguidance ``LLMatcher`` on the REAL gemma4 tokenizer:
+    valid calls accepted + terminal, forced prose masked at token 0, bad enum /
+    off-schema scalar rejected, and the comma construction admits exactly the valid
+    optional subsets;
+  * ROUND-TRIP: the ``gemma4`` parser parses the constrained wire back to
+    ``{name, arguments}`` with correct types;
+  * FAITHFUL-OR-OPT-OUT: the gemma4 representability guard reuses the SHARED
+    strict-allowlist core (``_xml_schema_representable`` with the gemma4 wire
+    policy) and differs only where the wire genuinely differs (bare ``\\w+`` keys;
+    only the ``<|"|>`` marker is an unsafe enum-value byte — ``<``/newlines are
+    SAFE, unlike XML);
+  * REGRESSION GUARD: an ``arg_style="json"`` (hermes/qwen/harmony) build is
+    byte-identical to before — the E4 change never leaks gemma4 constructs.
+
+The enforcement / round-trip tests use the ACTUAL target model tokenizer
+``mlx-community/gemma-4-e2b-it-4bit`` (pinned by revision). They skip ONLY on
+genuine unavailability; the pure-Python golden / guard / regression tests never
+skip.
+"""
+
+import importlib.util
+import json
+
+import pytest
+
+_HAS_LLGUIDANCE = importlib.util.find_spec("llguidance") is not None
+_requires_llguidance = pytest.mark.skipif(
+    not _HAS_LLGUIDANCE, reason="llguidance ([guided] extra) not installed"
+)
+
+# The REAL Gemma-4 target model. Pin the revision so enforcement runs against an
+# IMMUTABLE artifact (its <|tool_call>/<tool_call|>/<|"|> single-special-token
+# layout — ids 48/49/52 — is fixed at this commit).
+_TOKENIZER_MODEL = "mlx-community/gemma-4-e2b-it-4bit"
+_TOKENIZER_REVISION = "238767527555cb75a05732a84dff5d6ba0dd6809"
+_GEMMA4_SENTINELS = ("<|tool_call>", "<tool_call|>", '<|"|>')
+
+# A representative tool: required string + required enum + optional int + optional
+# bool — exercises every ``_emit_gemma4_param_value`` branch (greedy string rule,
+# per-value-wrapped enum alternation, ``%json`` scalar) AND the required-vs-optional
+# comma construction.
+GEMMA4_TOOLS = [
+    {
+        "name": "run",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "code": {"type": "string"},
+                "lang": {"type": "string", "enum": ["python", "cpp"]},
+                "timeout": {"type": "integer"},
+                "verbose": {"type": "boolean"},
+            },
+            "required": ["code", "lang"],
+            "additionalProperties": False,
+        },
+    },
+]
+
+# All-OPTIONAL tool (no required field) — exercises the empty-body ``( ... )?`` and
+# the first-present comma alternation for every optional subset.
+GEMMA4_OPT_TOOL = [
+    {
+        "name": "cfg",
+        "parameters": {
+            "type": "object",
+            "properties": {"a": {"type": "string"}, "b": {"type": "integer"}},
+            "additionalProperties": False,
+        },
+    },
+]
+
+# A nested-object tool with a ``$ref`` into ``$defs`` — proves ``$defs`` propagates
+# into the per-value ``%json`` sub-schema.
+GEMMA4_OBJ_TOOL = [
+    {
+        "name": "place",
+        "parameters": {
+            "type": "object",
+            "properties": {"origin": {"$ref": "#/$defs/point"}},
+            "required": ["origin"],
+            "$defs": {
+                "point": {
+                    "type": "object",
+                    "properties": {
+                        "x": {"type": "integer"},
+                        "y": {"type": "integer"},
+                    },
+                    "required": ["x", "y"],
+                    "additionalProperties": False,
+                }
+            },
+            "additionalProperties": False,
+        },
+    },
+]
+
+
+def _gemma4_structure_info(name: str):
+    """The gemma4 wire triple, exactly as ``Gemma4ToolParser`` ships it
+    (``arg_style="gemma4"``). Declared test-locally so the pure-Python golden
+    tests need no tokenizer."""
+    from vllm_mlx.api.tool_grammar import StructureInfo
+
+    return StructureInfo(
+        begin=f"<|tool_call>call:{name}{{",
+        end="}<tool_call|>",
+        trigger="<|tool_call>",
+        sentinels=_GEMMA4_SENTINELS,
+        arg_style="gemma4",
+    )
+
+
+def _hermes_json_structure_info(name: str):
+    """A hermes ``<tool_call>`` JSON-body wire triple (``arg_style="json"``, the
+    default) — the regression baseline the E4 change must not perturb."""
+    from vllm_mlx.api.tool_grammar import StructureInfo
+
+    return StructureInfo(
+        begin=f'<tool_call>\n{{"name": "{name}", "arguments": ',
+        end="}\n</tool_call>",
+        trigger="<tool_call>",
+        sentinels=("<tool_call>", "</tool_call>"),
+    )
+
+
+# --------------------------------------------------------------------------
+# Golden Lark for the gemma4 arg body (pure Python, always runs).
+# --------------------------------------------------------------------------
+_GEMMA4_GOLDEN_LARK = (
+    "%llguidance {}\n"
+    "start: (tag_0) (SEP (tag_0))* tag_end\n"
+    "tag_end: TAG_TEXT\n"
+    "SEP: /[ \\t\\r\\n]*/\n"
+    "TAG_TEXT: /(.|\\n)*/\n"
+    # The gemma4 string-value construct: GEMMA_STR_TEXT admits ANY byte; the RULE
+    # (lowercase) wraps it in the <|"|> special-token markers (greedy — the special
+    # token itself terminates it, so no [lazy] is needed / possible).
+    "GEMMA_STR_TEXT: /(.|\\n)*/\n"
+    'gemma_str_value: <|"|> GEMMA_STR_TEXT <|"|>\n'
+    "\n"
+    # The DICTSORT-ordered comma body: required code+lang first (no comma before
+    # code; a comma separates lang), then each optional field carries its OWN
+    # leading comma inside a ``( ... )?`` group. String -> the greedy rule; enum ->
+    # per-value <|"|>-wrapped alternation; scalar -> bare %json.
+    'tag_0: <|tool_call> "call:run{" ( "code:" gemma_str_value "," "lang:" '
+    '(<|"|> "python" <|"|> | <|"|> "cpp" <|"|>) '
+    '( "," "timeout:" %json {"type": "integer"} )? '
+    '( "," "verbose:" %json {"type": "boolean"} )? ) "}" <tool_call|>\n'
+)
+
+
+def test_gemma4_lark_matches_golden():
+    from vllm_mlx.api.tool_grammar import build_tool_lark
+
+    lark = build_tool_lark(GEMMA4_TOOLS, "required", [_gemma4_structure_info("run")])
+    assert lark == _GEMMA4_GOLDEN_LARK
+
+
+def test_gemma4_lark_frame_and_sentinels():
+    # The call frame: <|tool_call> trigger + <tool_call|> close + the <|"|> string
+    # marker are all BARE special-token refs (never quoted byte literals the single
+    # token could not satisfy). ``call:run{`` / ``}`` are ordinary byte literals.
+    from vllm_mlx.api.tool_grammar import build_tool_lark
+
+    lark = build_tool_lark(GEMMA4_TOOLS, "required", [_gemma4_structure_info("run")])
+    assert " <|tool_call> " in lark  # bare trigger ref
+    assert lark.rstrip().endswith("<tool_call|>")  # bare closing ref
+    assert '"<|tool_call>"' not in lark  # NOT quoted literals
+    assert '"<tool_call|>"' not in lark
+    assert '"<|\\"|>"' not in lark  # the <|"|> marker is a ref, never a byte literal
+    assert '"call:run{"' in lark  # frame text is a byte literal
+    assert '"}"' in lark
+
+
+def test_gemma4_string_value_uses_greedy_rule_not_lazy():
+    # THE E4 feasibility result, at the grammar-string level: a string value is the
+    # GREEDY ``gemma_str_value`` RULE wrapping the ``<|"|>`` marker — NOT a
+    # ``[lazy]`` construct (special tokens cannot live in a lazy terminal) and NOT a
+    # byte literal for ``<|"|>`` (the atomic special token can never satisfy it).
+    from vllm_mlx.api.tool_grammar import build_tool_lark
+
+    lark = build_tool_lark(GEMMA4_TOOLS, "required", [_gemma4_structure_info("run")])
+    assert 'gemma_str_value: <|"|> GEMMA_STR_TEXT <|"|>' in lark
+    assert "GEMMA_STR_TEXT: /(.|\\n)*/" in lark
+    assert '"code:" gemma_str_value' in lark
+    # No lazy construct and no byte-literal marker.
+    assert "[lazy]" not in lark
+    assert "gemma_str_value[lazy]" not in lark
+
+
+def test_gemma4_comma_and_required_optional_framing():
+    # Required fields come first with a bare comma separator; each optional field
+    # carries its OWN leading comma inside a ``( ... )?`` group (first-present
+    # construction). ``code``/``lang`` required; ``timeout``/``verbose`` optional.
+    from vllm_mlx.api.tool_grammar import build_tool_lark
+
+    lark = build_tool_lark(GEMMA4_TOOLS, "required", [_gemma4_structure_info("run")])
+    # Required pair separated by a bare comma (no leading/optional wrapper).
+    assert '"code:" gemma_str_value "," "lang:"' in lark
+    # Each optional scalar carries its own leading comma inside ``( ... )?``.
+    assert '( "," "timeout:" %json {"type": "integer"} )?' in lark
+    assert '( "," "verbose:" %json {"type": "boolean"} )?' in lark
+
+
+def test_gemma4_enum_is_per_value_wrapped_alternation():
+    # A STRING enum renders as an alternation with each value wrapped in its OWN
+    # ``<|"|>`` marker pair (NOT one shared wrapper, NOT %json, NOT the greedy rule).
+    from vllm_mlx.api.tool_grammar import build_tool_lark
+
+    lark = build_tool_lark(GEMMA4_TOOLS, "required", [_gemma4_structure_info("run")])
+    assert '(<|"|> "python" <|"|> | <|"|> "cpp" <|"|>)' in lark
+
+
+def test_gemma4_all_optional_wraps_body_in_optional_group():
+    # A tool with NO required field wraps the whole comma alternation in ``( ... )?``
+    # so an empty ``{}`` body is admitted.
+    from vllm_mlx.api.tool_grammar import build_tool_lark
+
+    lark = build_tool_lark(GEMMA4_OPT_TOOL, "required", [_gemma4_structure_info("cfg")])
+    # First-present alternation over {a-first, b-first}, wrapped in an outer ``?``.
+    assert (
+        '"call:cfg{" ( "a:" gemma_str_value ( "," "b:" %json {"type": "integer"} )? '
+        '| "b:" %json {"type": "integer"} )? "}" <tool_call|>' in lark
+    )
+    assert lark.rstrip().endswith(')? "}" <tool_call|>')
+
+
+def test_gemma4_noarg_tool_has_empty_body():
+    # A no-argument tool renders the bare ``call:NAME{}`` frame (empty body).
+    from vllm_mlx.api.tool_grammar import build_tool_lark
+
+    noarg = [
+        {
+            "name": "ping",
+            "parameters": {
+                "type": "object",
+                "properties": {},
+                "additionalProperties": False,
+            },
+        }
+    ]
+    lark = build_tool_lark(noarg, "required", [_gemma4_structure_info("ping")])
+    assert 'tag_0: <|tool_call> "call:ping{" "}" <tool_call|>' in lark
+    # The string rule is still declared (arg_style is gemma4) but unused in the tag.
+    assert "gemma_str_value: " in lark
+
+
+def test_gemma4_ref_defs_propagated_into_value_schema():
+    # A ``$ref`` object value carries the parent's ``$defs`` into its per-value
+    # ``%json`` sub-schema so the ``$ref`` resolves.
+    from vllm_mlx.api.tool_grammar import build_tool_lark
+
+    lark = build_tool_lark(
+        GEMMA4_OBJ_TOOL, "required", [_gemma4_structure_info("place")]
+    )
+    expected_schema = {
+        "$ref": "#/$defs/point",
+        "$defs": {
+            "point": {
+                "type": "object",
+                "properties": {
+                    "x": {"type": "integer"},
+                    "y": {"type": "integer"},
+                },
+                "required": ["x", "y"],
+                "additionalProperties": False,
+            }
+        },
+    }
+    assert f"%json {json.dumps(expected_schema)}" in lark
+
+
+# --------------------------------------------------------------------------
+# REGRESSION GUARD: arg_style="json" (hermes/qwen/harmony) byte-identical — the
+# E4 change (and the shared-guard policy refactor) must not perturb JSON families.
+# --------------------------------------------------------------------------
+def test_json_family_grammar_has_no_gemma4_constructs():
+    from vllm_mlx.api.tool_grammar import build_tool_lark
+
+    infos = [_hermes_json_structure_info(t["name"]) for t in GEMMA4_TOOLS]
+    lark = build_tool_lark(GEMMA4_TOOLS, "required", infos)
+    assert "%json" in lark
+    assert "GEMMA_STR_TEXT" not in lark
+    assert "gemma_str_value" not in lark
+    assert "call:" not in lark
+    assert '<|"|>' not in lark
+
+
+def test_json_family_grammar_byte_identical_to_baseline():
+    # The exact hermes forced golden (identical to test_qwen3coder_xml_grammar_558's
+    # baseline). Pinning it proves E4 left the JSON-family grammar byte-for-byte
+    # unchanged.
+    from vllm_mlx.api.tool_grammar import build_tool_lark
+
+    tools = [
+        {
+            "name": "get_weather",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "city": {"type": "string"},
+                    "unit": {"type": "string", "enum": ["c", "f"]},
+                },
+                "required": ["city"],
+                "additionalProperties": False,
+            },
+        }
+    ]
+    infos = [_hermes_json_structure_info("get_weather")]
+    expected = (
+        "%llguidance {}\n"
+        "start: (tag_0) (SEP (tag_0))* tag_end\n"
+        "tag_end: TAG_TEXT\n"
+        "SEP: /[ \\t\\r\\n]*/\n"
+        "TAG_TEXT: /(.|\\n)*/\n"
+        "\n"
+        'tag_0: <tool_call> "\\n{\\"name\\": \\"get_weather\\", '
+        '\\"arguments\\": " %json {"type": "object", "properties": {"city": '
+        '{"type": "string"}, "unit": {"type": "string", "enum": ["c", "f"]}}, '
+        '"required": ["city"], "additionalProperties": false} "}\\n" </tool_call>\n'
+    )
+    assert build_tool_lark(tools, "required", infos) == expected
+
+
+# --------------------------------------------------------------------------
+# Real Gemma4ToolParser.structure_info() (pure Python, hermetic tokenizer stub).
+# --------------------------------------------------------------------------
+class _FakeAddedToken:
+    def __init__(self, content, special=True):
+        self.content = content
+        self.special = special
+
+
+class _FakeTokenizer:
+    """Models the ``are_single_special_tokens`` guard surfaces: the three gemma4
+    markers as distinct single ADDED tokens that round-trip (real ids 48/49/52)."""
+
+    def __init__(self, added=None):
+        self._added = dict(added or {})
+        self._id_to_str = {i: s for s, i in self._added.items()}
+        self.added_tokens_decoder = {
+            i: _FakeAddedToken(s) for s, i in self._added.items()
+        }
+
+    def encode(self, text, add_special_tokens=False):
+        if text in self._added:
+            return [self._added[text]]
+        return [0, 1]  # ordinary multi-token text
+
+    def decode(self, ids):
+        return "".join(self._id_to_str.get(i, "<unk>") for i in ids)
+
+    def get_vocab(self):
+        return dict(self._added)
+
+
+def _single_token_tokenizer():
+    return _FakeTokenizer(added={"<|tool_call>": 48, "<tool_call|>": 49, '<|"|>': 52})
+
+
+def _make_gemma4(tokenizer=None):
+    from vllm_mlx.tool_parsers.gemma4_tool_parser import Gemma4ToolParser
+
+    return Gemma4ToolParser(tokenizer=tokenizer)
+
+
+def test_gemma4_structure_info_opts_out_without_tokenizer():
+    assert _make_gemma4(tokenizer=None).structure_info() is None
+
+
+def test_gemma4_structure_info_opts_out_on_multitoken_tokenizer():
+    # A tokenizer that encodes the markers as ordinary multi-token text -> opt out.
+    assert _make_gemma4(tokenizer=_FakeTokenizer(added={})).structure_info() is None
+
+
+def test_gemma4_structure_info_opts_out_when_marker_missing():
+    # Missing even ONE of the three markers (here <|"|>) -> opt out (an
+    # unenforceable string-value rule would otherwise be emitted).
+    tok = _FakeTokenizer(added={"<|tool_call>": 48, "<tool_call|>": 49})
+    assert _make_gemma4(tokenizer=tok).structure_info() is None
+
+
+def test_gemma4_structure_info_returns_gemma4_wire_triple():
+    from vllm_mlx.api.tool_grammar import StructureInfo
+
+    get_info = _make_gemma4(tokenizer=_single_token_tokenizer()).structure_info()
+    assert callable(get_info), "opt-in must return a name->StructureInfo factory"
+    si = get_info("run")
+    assert isinstance(si, StructureInfo)
+    assert si.arg_style == "gemma4"
+    assert si.trigger == "<|tool_call>"
+    assert si.begin == "<|tool_call>call:run{"
+    assert si.end == "}<tool_call|>"
+    assert si.begin.startswith(si.trigger)  # builder invariant
+    assert si.sentinels == _GEMMA4_SENTINELS
+    assert si.trigger in si.sentinels
+
+
+def test_gemma4_supports_grammar_and_auto_unsafe():
+    from vllm_mlx.tool_parsers.gemma4_tool_parser import Gemma4ToolParser
+
+    assert Gemma4ToolParser.SUPPORTS_GRAMMAR is True
+    assert Gemma4ToolParser.supports_grammar() is True
+    # AUTO stays free-form (channel reasoning + special-token markers).
+    assert Gemma4ToolParser.TOOL_GRAMMAR_AUTO_SAFE is False
+
+
+# --------------------------------------------------------------------------
+# Grammar ENFORCEMENT + ROUND-TRIP on the REAL gemma4 tokenizer.
+# --------------------------------------------------------------------------
+def _offline_skip_exc_types():
+    types: list[type[BaseException]] = []
+    try:
+        from huggingface_hub.errors import (
+            LocalEntryNotFoundError,
+            OfflineModeIsEnabled,
+        )
+
+        types += [LocalEntryNotFoundError, OfflineModeIsEnabled]
+    except Exception:  # pragma: no cover - old hub without these names
+        pass
+    try:
+        from requests.exceptions import ConnectionError as _ReqConnErr
+
+        types.append(_ReqConnErr)
+    except Exception:  # pragma: no cover - requests not present
+        pass
+    return tuple(types) or (OSError,)
+
+
+@pytest.fixture(scope="module")
+def tok():
+    transformers = pytest.importorskip("transformers")
+    try:
+        return transformers.AutoTokenizer.from_pretrained(
+            _TOKENIZER_MODEL, revision=_TOKENIZER_REVISION
+        )
+    except _offline_skip_exc_types():  # pragma: no cover - offline & uncached
+        pytest.skip(
+            f"tokenizer {_TOKENIZER_MODEL}@{_TOKENIZER_REVISION[:8]} not cached "
+            "and no network — gemma4 enforcement tests require it"
+        )
+
+
+@pytest.fixture(scope="module")
+def lltok(tok):
+    """Build an llguidance LLTokenizer via the module's own resolver. Skip ONLY
+    when the runtime bridge is genuinely unavailable (mirrors E3 finding 5)."""
+    from vllm_mlx.api.tool_grammar import HAS_LL_TOKENIZER, build_lltokenizer
+
+    if not HAS_LL_TOKENIZER:
+        pytest.skip(
+            "llguidance runtime bridge (llguidance.hf / LLTokenizer) not "
+            "installed — gemma4 enforcement tests require it"
+        )
+    built = build_lltokenizer(tok)
+    assert built is not None, (
+        "build_lltokenizer() returned None for the CACHED gemma4 tokenizer with "
+        "the llguidance runtime bridge available — the tokenizer->llguidance "
+        "integration is BROKEN (this must FAIL, not skip)."
+    )
+    return built
+
+
+def _gemma4_grammar(tools, tool_choice, tok):
+    """Compile the gemma4 grammar through the REAL parser (opted-in on ``tok``)."""
+    from vllm_mlx.api.tool_grammar import build_tool_grammar
+
+    return build_tool_grammar(tools, tool_choice, _make_gemma4(tok))
+
+
+def _consume(grammar, lltok, tok, text):
+    """Offline enforcement probe. Returns ``(accepted, total, is_accepting)`` —
+    advances real matcher state so ``is_accepting()`` proves a COMPLETE valid
+    derivation, not merely an accepted prefix."""
+    from llguidance.mlx import LLMatcher
+
+    ids = tok.encode(text, add_special_tokens=False)
+    matcher = LLMatcher(lltok, grammar)
+    assert not matcher.get_error(), matcher.get_error()
+    accepted = 0
+    for tid in ids:
+        if not matcher.consume_tokens([tid]):
+            break
+        accepted += 1
+    return accepted, len(ids), matcher.is_accepting()
+
+
+def _wire(code, *, lang="python", timeout=None, verbose=None):
+    """Build the gemma4 wire for ``run`` (keys in DICTSORT order)."""
+    s = f'<|tool_call>call:run{{code:<|"|>{code}<|"|>,lang:<|"|>{lang}<|"|>'
+    if timeout is not None:
+        s += f",timeout:{timeout}"
+    if verbose is not None:
+        s += f",verbose:{verbose}"
+    s += "}<tool_call|>"
+    return s
+
+
+def _parse(wire, tools):
+    parser = _make_gemma4(tokenizer=None)
+    req = {
+        "tools": [
+            {
+                "type": "function",
+                "function": {"name": t["name"], "parameters": t["parameters"]},
+            }
+            for t in tools
+        ]
+    }
+    res = parser.extract_tool_calls(wire, request=req)
+    assert res.tools_called, "parser did not detect the tool call"
+    tc = res.tool_calls[0]
+    return tc["name"], json.loads(tc["arguments"])
+
+
+@_requires_llguidance
+def test_gemma4_finding_tokenizer_llguidance_integration_not_broken(tok):
+    from vllm_mlx.api.tool_grammar import HAS_LL_TOKENIZER, build_lltokenizer
+
+    if not HAS_LL_TOKENIZER:
+        pytest.skip("llguidance runtime bridge (llguidance.hf / LLTokenizer) absent")
+    assert build_lltokenizer(tok) is not None
+
+
+@_requires_llguidance
+def test_gemma4_markers_are_single_special_tokens(tok):
+    # Ground truth (probe a): the three wire markers are single special tokens.
+    for marker, expected_id in (
+        ("<|tool_call>", 48),
+        ("<tool_call|>", 49),
+        ('<|"|>', 52),
+    ):
+        ids = tok.encode(marker, add_special_tokens=False)
+        assert ids == [expected_id], (marker, ids)
+        assert tok.decode(ids) == marker
+
+
+@_requires_llguidance
+def test_gemma4_valid_call_accepted_and_terminates(tok, lltok):
+    grammar = _gemma4_grammar(GEMMA4_TOOLS, "required", tok)
+    assert grammar is not None
+    accepted, total, accepting = _consume(grammar, lltok, tok, _wire("print(1)"))
+    assert accepted == total, f"valid gemma4 call rejected ({accepted}/{total})"
+    assert accepting, "valid complete gemma4 call is not a terminal state"
+
+
+@_requires_llguidance
+@pytest.mark.parametrize(
+    "code",
+    [
+        "a < b && c > d",
+        "<html><body>x</body></html>",
+        "vector<int> v",
+        "if (a < b) { return a; }",
+        "obj = {x: 1, y: 2}",
+        "line1\nline2\nline3",
+        'she said "hi", ok',
+    ],
+)
+def test_gemma4_string_value_with_special_chars_is_accepted(code, tok, lltok):
+    # THE E4 result: a string value containing <, >, {, }, comma, quotes, or
+    # newlines is ACCEPTED in full and terminates at the closing ``<|"|>`` SPECIAL
+    # TOKEN (the greedy rule stops there because a special token isn't a byte).
+    grammar = _gemma4_grammar(GEMMA4_TOOLS, "required", tok)
+    assert grammar is not None
+    accepted, total, accepting = _consume(grammar, lltok, tok, _wire(code, lang="cpp"))
+    assert accepted == total, (
+        f"special-char string value rejected ({accepted}/{total}) for {code!r}"
+    )
+    assert accepting, f"special-char value {code!r} is not a terminal state"
+
+
+@_requires_llguidance
+def test_gemma4_optional_scalars_enforced(tok, lltok):
+    grammar = _gemma4_grammar(GEMMA4_TOOLS, "required", tok)
+    accepted, total, accepting = _consume(
+        grammar, lltok, tok, _wire("x", lang="cpp", timeout=30, verbose="true")
+    )
+    assert accepted == total and accepting, (
+        f"valid call with optional scalars rejected ({accepted}/{total})"
+    )
+
+
+@_requires_llguidance
+def test_gemma4_bad_enum_value_is_rejected(tok, lltok):
+    grammar = _gemma4_grammar(GEMMA4_TOOLS, "required", tok)
+    accepted, total, _ = _consume(grammar, lltok, tok, _wire("x", lang="rust"))
+    assert accepted < total, "invalid enum value was NOT rejected by the grammar"
+
+
+@_requires_llguidance
+def test_gemma4_off_schema_scalar_is_rejected(tok, lltok):
+    grammar = _gemma4_grammar(GEMMA4_TOOLS, "required", tok)
+    bad = '<|tool_call>call:run{code:<|"|>x<|"|>,lang:<|"|>python<|"|>,timeout:notanint'
+    accepted, total, _ = _consume(grammar, lltok, tok, bad)
+    assert accepted < total, "off-schema (non-integer) timeout was NOT rejected"
+
+
+@_requires_llguidance
+def test_gemma4_missing_required_field_is_rejected(tok, lltok):
+    # Dropping the required ``lang`` field must not reach a terminal state.
+    grammar = _gemma4_grammar(GEMMA4_TOOLS, "required", tok)
+    wire = '<|tool_call>call:run{code:<|"|>x<|"|>}<tool_call|>'
+    accepted, total, accepting = _consume(grammar, lltok, tok, wire)
+    assert not (accepted == total and accepting), "missing required field accepted"
+
+
+@_requires_llguidance
+def test_gemma4_forced_rejects_prose_before_the_call(tok, lltok):
+    grammar = _gemma4_grammar(GEMMA4_TOOLS, "required", tok)
+    assert grammar is not None
+    prose_then_call = "Sure, let me run that. " + _wire("print(1)")
+    accepted, _total, _ = _consume(grammar, lltok, tok, prose_then_call)
+    assert accepted == 0, (
+        f"forced gemma4 grammar accepted {accepted} prose token(s) before the "
+        "trigger — the unbounded leading prefix is back (#558 forced-leak)"
+    )
+
+
+@_requires_llguidance
+def test_gemma4_auto_opts_out_required_builds(tok):
+    # AUTO stays free-form (TOOL_GRAMMAR_AUTO_SAFE=False); required/named build.
+    assert _gemma4_grammar(GEMMA4_TOOLS, "auto", tok) is None
+    assert _gemma4_grammar(GEMMA4_TOOLS, "required", tok) is not None
+
+
+@_requires_llguidance
+@pytest.mark.parametrize(
+    "present",
+    [
+        "<|tool_call>call:cfg{}<tool_call|>",
+        '<|tool_call>call:cfg{a:<|"|>x<|"|>}<tool_call|>',
+        "<|tool_call>call:cfg{b:5}<tool_call|>",
+        '<|tool_call>call:cfg{a:<|"|>x<|"|>,b:5}<tool_call|>',
+    ],
+)
+def test_gemma4_all_optional_comma_subsets_accepted(present, tok, lltok):
+    # The first-present comma construction admits EVERY valid optional subset of an
+    # all-optional tool — empty, a-only, b-only, both — each accepted + terminal.
+    grammar = _gemma4_grammar(GEMMA4_OPT_TOOL, "required", tok)
+    accepted, total, accepting = _consume(grammar, lltok, tok, present)
+    assert accepted == total and accepting, f"optional subset rejected: {present!r}"
+
+
+@_requires_llguidance
+def test_gemma4_all_optional_rejects_leading_comma(tok, lltok):
+    # A misplaced LEADING comma (the bug a naive per-field ``( )?`` would allow when
+    # the first optional is absent) must be rejected.
+    grammar = _gemma4_grammar(GEMMA4_OPT_TOOL, "required", tok)
+    bad = "<|tool_call>call:cfg{,b:5}<tool_call|>"
+    accepted, total, accepting = _consume(grammar, lltok, tok, bad)
+    assert not (accepted == total and accepting), "leading-comma body was accepted"
+
+
+# --------------------------------------------------------------------------
+# ROUND-TRIP: the gemma4 parser parses the constrained wire back to
+# {name, arguments} with correct types.
+# --------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "code", ["a < b && c > d", "vector<int> v", "obj = {x:1}", "print('ok')"]
+)
+def test_gemma4_roundtrip_string_value_with_special_chars(code):
+    name, args = _parse(_wire(code), GEMMA4_TOOLS)
+    assert name == "run"
+    assert args["code"] == code
+    assert args["lang"] == "python"
+
+
+def test_gemma4_roundtrip_scalar_types_int_bool():
+    name, args = _parse(
+        _wire("x", lang="cpp", timeout=30, verbose="true"), GEMMA4_TOOLS
+    )
+    assert args["timeout"] == 30 and isinstance(args["timeout"], int)
+    assert args["verbose"] is True
+    assert args["lang"] == "cpp"
+
+
+def test_gemma4_roundtrip_nested_object_value():
+    # A nested-object ($ref) value round-trips into a JSON object with typed fields
+    # — the ``%json`` (standard-JSON) surface the grammar emits is what the lenient
+    # gemma4 parser json-decodes.
+    wire = '<|tool_call>call:place{origin:{"x": 3, "y": 4}}<tool_call|>'
+    name, args = _parse(wire, GEMMA4_OBJ_TOOL)
+    assert name == "place"
+    assert args["origin"] == {"x": 3, "y": 4}
+
+
+@_requires_llguidance
+def test_gemma4_object_value_via_json_enforced_and_roundtrips(tok, lltok):
+    grammar = _gemma4_grammar(GEMMA4_OBJ_TOOL, "required", tok)
+    assert grammar is not None
+    wire = '<|tool_call>call:place{origin:{"x": 3, "y": 4}}<tool_call|>'
+    accepted, total, accepting = _consume(grammar, lltok, tok, wire)
+    assert accepted == total and accepting, (
+        f"object %json value rejected ({accepted}/{total}, accepting={accepting})"
+    )
+    name, args = _parse(wire, GEMMA4_OBJ_TOOL)
+    assert name == "place" and args["origin"] == {"x": 3, "y": 4}
+
+
+# ==========================================================================
+# FAITHFUL-OR-OPT-OUT: the gemma4 representability guard reuses the SHARED
+# strict-allowlist core (``_xml_schema_representable`` + gemma4 wire policy) and
+# differs ONLY in the two wire-specific leaf checks.
+# ==========================================================================
+def test_gemma4_representable_common_and_noarg():
+    from vllm_mlx.api.tool_grammar import _gemma4_schema_representable as rep
+
+    assert rep(GEMMA4_TOOLS[0]["parameters"]) is True
+    assert rep(GEMMA4_OPT_TOOL[0]["parameters"]) is True
+    assert rep(GEMMA4_OBJ_TOOL[0]["parameters"]) is True  # $ref -> object
+    assert rep({"type": "object", "properties": {}, "additionalProperties": False})
+    assert rep({}) is True  # allow-any / no-arg
+
+
+def test_gemma4_representable_shares_structural_allowlist_with_xml():
+    # The structural allowlist (object-level keywords, string facets, required
+    # totality, $ref) is SHARED, so gemma4 opts out on exactly the same shapes.
+    from vllm_mlx.api.tool_grammar import _gemma4_schema_representable as rep
+
+    assert rep(False) is False
+    assert rep({"type": "object", "required": ["a"]}) is False  # property-less
+    assert rep({"type": "array"}) is False  # non-object top-level
+    assert rep({"properties": {"s": {"type": "string", "pattern": "^x$"}}}) is False
+    props = {"a": {"type": "string"}, "b": {"type": "string"}}
+    assert (
+        rep({"type": "object", "properties": props, "dependentRequired": {"a": ["b"]}})
+        is False
+    )
+    assert rep({"type": "object", "properties": props, "minProperties": 1}) is False
+    assert rep({"properties": {"c": {"$ref": "#/$defs/missing"}, "$defs": {}}}) is False
+    # Total ``required`` guard (no crash on unhashable member).
+    base = {"type": "object", "properties": {"a": {"type": "string"}}}
+    assert rep({**base, "required": [["a"]]}) is False
+
+
+def test_gemma4_key_safety_is_word_only_stricter_than_xml():
+    # gemma4 emits a BARE ``KEY:``; the parser reads ``\w+``, so only ``\w+`` keys
+    # round-trip — STRICTER than XML (which allows ``-``/``.``).
+    from vllm_mlx.api.tool_grammar import (
+        _gemma4_schema_representable as g_rep,
+    )
+    from vllm_mlx.api.tool_grammar import (
+        _xml_schema_representable as x_rep,
+    )
+
+    assert g_rep({"properties": {"my_key1": {"type": "string"}}}) is True
+    for bad in ("my-key", "a.b", "a b", "a:b", "a,b", "x<y", "a{b"):
+        assert g_rep({"properties": {bad: {"type": "string"}}}) is False, bad
+    # XML allows ``-``/``.`` (its key wire tolerates them) — proves the divergence
+    # is intentional and the shared structural guard is otherwise identical.
+    assert x_rep({"properties": {"my-key": {"type": "string"}}}) is True
+    assert g_rep({"properties": {"my-key": {"type": "string"}}}) is False
+
+
+def test_gemma4_enum_delimiter_safety_differs_from_xml():
+    # A gemma4 string value is bounded ONLY by ``<|"|>``, so an enum value
+    # containing ``<``/``>``/newlines is SAFE (unlike XML). A value containing the
+    # ``<|"|>`` marker opts out.
+    from vllm_mlx.api.tool_grammar import (
+        _gemma4_schema_representable as g_rep,
+    )
+    from vllm_mlx.api.tool_grammar import (
+        _xml_schema_representable as x_rep,
+    )
+
+    safe_lt = {"properties": {"s": {"type": "string", "enum": ["a<b", "c>d"]}}}
+    assert g_rep(safe_lt) is True  # gemma4: safe inside <|"|>
+    assert x_rep(safe_lt) is False  # XML: ``<``/``>`` desync the tag
+    # Newline inside a gemma4 string value is fine.
+    assert g_rep({"properties": {"s": {"type": "string", "enum": ["a\nb"]}}}) is True
+    # But the <|"|> marker literally inside a value opts out (would close early).
+    assert (
+        g_rep({"properties": {"s": {"type": "string", "enum": ['a<|"|>b']}}}) is False
+    )
+
+
+def test_gemma4_enum_type_consistency_shared():
+    # The shared enum guard still rejects value/declared-type mismatch and
+    # unsupported siblings.
+    from vllm_mlx.api.tool_grammar import _gemma4_schema_representable as rep
+
+    assert rep({"properties": {"n": {"type": "integer", "enum": ["x"]}}}) is False
+    assert rep({"properties": {"s": {"enum": ["a", "bb"], "minLength": 2}}}) is False
+    # Control: clean string / numeric enums stay representable.
+    assert rep({"properties": {"s": {"type": "string", "enum": ["a", "b"]}}}) is True
+    assert rep({"properties": {"n": {"type": "number", "enum": [1.5, 2]}}}) is True
+
+
+# ---- OPT-OUT through build_tool_grammar (real parser) --------------------
+@_requires_llguidance
+def test_gemma4_build_tool_grammar_opts_out_bad_key(tok):
+    # Control: a representable gemma4 tool DOES build a grammar.
+    assert _gemma4_grammar(GEMMA4_TOOLS, "required", tok) is not None
+    bad_key_tool = [
+        {
+            "name": "run",
+            "parameters": {
+                "type": "object",
+                "properties": {"a-b": {"type": "string"}},
+                "required": ["a-b"],
+            },
+        }
+    ]
+    assert _gemma4_grammar(bad_key_tool, "required", tok) is None
+
+
+@_requires_llguidance
+def test_gemma4_build_tool_grammar_opts_out_string_pattern(tok):
+    pat_tool = [
+        {
+            "name": "run",
+            "parameters": {
+                "type": "object",
+                "properties": {"code": {"type": "string", "pattern": "^[a-z]+$"}},
+                "required": ["code"],
+            },
+        }
+    ]
+    assert _gemma4_grammar(pat_tool, "required", tok) is None

--- a/tests/test_gemma4_grammar_558.py
+++ b/tests/test_gemma4_grammar_558.py
@@ -20,10 +20,15 @@ or a whole-object ``%json``. These tests prove that path WITHOUT a decode loop:
   * THE E4 FEASIBILITY RESULT: a string value is bounded by ``<|"|>`` — a SINGLE
     SPECIAL TOKEN, not a byte string like E3's ``</parameter>``. llguidance rejects
     a special token inside a ``[lazy]`` terminal, and a byte-literal ``<|"|>``
-    cannot match the atomic token at runtime; the working construct is a GREEDY
-    ``gemma_str_value: <|"|> GEMMA_STR_TEXT <|"|>`` (maximal-munch stops at the
-    special-token boundary on its own). A value containing ``<``/``{``/``}``/``,``/
-    quotes/newlines round-trips and terminates correctly;
+    cannot match the atomic token at runtime; the working construct is
+    ``gemma_str_value: <|"|> GEMMA_STR_TEXT <|"|>`` with the close as a rule-level
+    special-token ref. The content terminal EXCLUDES the byte spelling of ``<|"|>``
+    (``GEMMA_STR_TEXT: /(.|\\n)*/ & ~/(?s:.*)<\\|"\\|>(?s:.*)/`` — llguidance's
+    native regex And/Not) so the model cannot spell the marker with ordinary tokens
+    mid-value, which the parser's decoded-text scan would misread as an early close
+    (#558 E4, codex r4). A value containing ``<``/``{``/``}``/``,``/quotes/newlines
+    round-trips and terminates correctly (only the FULL ``<|"|>`` byte sequence is
+    excluded);
   * grammar ENFORCEMENT via llguidance ``LLMatcher`` on the REAL gemma4 tokenizer:
     valid calls accepted + terminal, forced prose masked at token 0, bad enum /
     off-schema scalar rejected, and the comma construction admits exactly the valid
@@ -158,10 +163,15 @@ _GEMMA4_GOLDEN_LARK = (
     "tag_end: TAG_TEXT\n"
     "SEP: /[ \\t\\r\\n]*/\n"
     "TAG_TEXT: /(.|\\n)*/\n"
-    # The gemma4 string-value construct: GEMMA_STR_TEXT admits ANY byte; the RULE
-    # (lowercase) wraps it in the <|"|> special-token markers (greedy — the special
-    # token itself terminates it, so no [lazy] is needed / possible).
-    "GEMMA_STR_TEXT: /(.|\\n)*/\n"
+    # The gemma4 string-value construct: GEMMA_STR_TEXT admits any UTF-8 byte
+    # sequence EXCEPT the byte spelling of the <|"|> marker — the base /(.|\n)*/
+    # intersected (&) with the complement (~) of "contains <|"|>", using llguidance's
+    # native regex And/Not algebra (docs/syntax.md). The RULE (lowercase) wraps the
+    # content in the <|"|> special-token markers; the atomic close is a rule-level
+    # special-token ref (the model's token 52). The exclusion stops the model from
+    # spelling <|"|> with ORDINARY bytes mid-value, which the parser's decoded-text
+    # scan would misread as an early string close (#558 E4, codex r4).
+    'GEMMA_STR_TEXT: /(.|\\n)*/ & ~/(?s:.*)<\\|"\\|>(?s:.*)/\n'
     'gemma_str_value: <|"|> GEMMA_STR_TEXT <|"|>\n'
     "\n"
     # The DICTSORT-ordered comma body, emitted as an O(n)-size RECURSIVE grammar:
@@ -211,14 +221,20 @@ def test_gemma4_lark_frame_and_sentinels():
 
 def test_gemma4_string_value_uses_greedy_rule_not_lazy():
     # THE E4 feasibility result, at the grammar-string level: a string value is the
-    # GREEDY ``gemma_str_value`` RULE wrapping the ``<|"|>`` marker — NOT a
-    # ``[lazy]`` construct (special tokens cannot live in a lazy terminal) and NOT a
-    # byte literal for ``<|"|>`` (the atomic special token can never satisfy it).
+    # ``gemma_str_value`` RULE wrapping the ``<|"|>`` marker — NOT a ``[lazy]``
+    # construct (special tokens cannot live in a lazy terminal) and NOT a byte
+    # literal for ``<|"|>`` (the atomic special token can never satisfy it). The
+    # close is the rule-level special-token ref (token 52). The content terminal
+    # EXCLUDES the byte spelling of ``<|"|>`` via llguidance's native regex And/Not
+    # (``& ~/(?s:.*)<\|"\|>(?s:.*)/``) so the model cannot spell the marker with
+    # ordinary bytes mid-value (codex r4 — the REAL under-constraint fix).
     from vllm_mlx.api.tool_grammar import build_tool_lark
 
     lark = build_tool_lark(GEMMA4_TOOLS, "required", [_gemma4_structure_info("run")])
     assert 'gemma_str_value: <|"|> GEMMA_STR_TEXT <|"|>' in lark
-    assert "GEMMA_STR_TEXT: /(.|\\n)*/" in lark
+    # The content terminal is the any-byte base INTERSECTED with the complement of
+    # "contains <|"|>" — the exact llguidance-documented UTF-8-safe exclusion.
+    assert 'GEMMA_STR_TEXT: /(.|\\n)*/ & ~/(?s:.*)<\\|"\\|>(?s:.*)/' in lark
     assert '"code:" gemma_str_value' in lark
     # No lazy construct and no byte-literal marker.
     assert "[lazy]" not in lark
@@ -557,36 +573,46 @@ def test_gemma4_supports_grammar_and_auto_unsafe():
 # --------------------------------------------------------------------------
 # Grammar ENFORCEMENT + ROUND-TRIP on the REAL gemma4 tokenizer.
 # --------------------------------------------------------------------------
-# Message substrings (case-insensitive) that mark a BARE ``OSError`` from
-# ``from_pretrained`` as genuine OFFLINE / cache-unavailability. Transformers wraps
-# an uncached-and-no-network load as a plain ``OSError`` whose message is one of
-# these ("Can't load the configuration of ...", "We couldn't connect to ...",
-# "... offline ..."). A CORRUPT artifact or INVALID REVISION is ALSO an ``OSError``
-# (e.g. a wrapped 404 "<rev> is not a valid git identifier ...") but its message is
-# NOT in this list, so it FAILS instead of skipping — corruption/bad-revision must
-# never be false-green (codex r3 E4).
-_OFFLINE_MSG_SUBSTRINGS = (
-    "offline",
-    "can't load",
-    "couldn't connect",
-    "we couldn't connect",
-    "not a local folder",
-    "connection error",
-    "max retries",
-    "failed to connect",
-    "unable to load",
-)
+# CACHE-PRESENCE gate (codex r4 F3). The offline-vs-corrupt decision is made by
+# whether the pinned tokenizer artifact is present in the LOCAL HF cache — NOT by
+# sniffing ``from_pretrained``'s error message. The r3 heuristic matched substrings
+# like ``"can't load"``, but HF emits "Can't load tokenizer for '...'" for BOTH a
+# genuine offline miss AND a corrupt/missing cached file, so a CORRUPT artifact
+# could be misclassified offline and SKIPPED (false-green — defeating the fix's own
+# goal). With cache-presence there is no ambiguity by construction: NOT cached ->
+# skip (truly unavailable); cached but unloadable -> corruption -> the test FAILS.
+
+
+def _tokenizer_in_cache() -> bool:
+    """True iff the pinned tokenizer artifact is in the LOCAL HF cache.
+
+    ``try_to_load_from_cache`` returns the real on-disk path of a cached file, a
+    ``_CACHED_NO_EXIST`` sentinel for a known-absent file, or ``None`` when the
+    repo/revision was never fetched. Only a genuine ``str`` path counts as cached.
+    Degrades to ``False`` (treat as not cached -> skip-eligible) if the hub helper
+    is unavailable or raises — never masks a real load failure, since the ``tok``
+    fixture only skips on an offline EXCEPTION TYPE in the not-cached branch."""
+    try:
+        from huggingface_hub import try_to_load_from_cache
+    except Exception:  # pragma: no cover - very old hub
+        return False
+    try:
+        path = try_to_load_from_cache(
+            _TOKENIZER_MODEL, "tokenizer_config.json", revision=_TOKENIZER_REVISION
+        )
+    except Exception:  # pragma: no cover - defensive
+        return False
+    return isinstance(path, str)
 
 
 def _offline_skip_exc_types():
-    # HF-SPECIFIC offline/connectivity types that ALWAYS mean "skip" regardless of
-    # message text (network / cache unavailability). ``OSError`` is DELIBERATELY NOT
-    # here: a bare ``OSError`` is offline ONLY when its message matches
-    # ``_OFFLINE_MSG_SUBSTRINGS`` (see ``_is_offline_unavailable``). Catching EVERY
-    # ``OSError`` as offline (the old behavior) would SKIP a corrupt artifact /
-    # invalid revision too — a false-green codex r3 flagged. The needle: keep the
-    # genuine-offline OSError skipping (message-gated) WITHOUT masking corruption,
-    # and never regress the prior fix that a plain offline ``OSError`` must skip.
+    # HF-SPECIFIC offline/connectivity exception TYPES (network / cache
+    # unavailability). Used ONLY as a belt-and-suspenders skip in the NOT-cached
+    # branch of the ``tok`` fixture (the load-attempted-while-uncached race). The
+    # PRIMARY offline-vs-corrupt decision is the cache-presence gate
+    # (``_tokenizer_in_cache``); a CACHED-but-unloadable tokenizer always FAILS, so
+    # ``OSError`` is DELIBERATELY not in this type list (catching every ``OSError``
+    # would skip corruption — the false-green codex flagged).
     types: list[type[BaseException]] = []
     try:
         from huggingface_hub.errors import (
@@ -607,34 +633,40 @@ def _offline_skip_exc_types():
 
 
 def _is_offline_unavailable(exc: BaseException) -> bool:
-    """True iff ``exc`` from ``AutoTokenizer.from_pretrained`` indicates genuine
-    OFFLINE / cache-unavailability (skip-worthy), NOT a corrupt artifact / invalid
-    revision (which must FAIL, not skip). Skip when: a specific HF
-    offline/connectivity TYPE (``LocalEntryNotFoundError`` / ``OfflineModeIsEnabled``
-    / ``requests.ConnectionError``), OR a bare ``OSError`` whose message matches the
-    offline allowlist. ANY OTHER ``OSError`` (corruption / bad revision / a wrapped
-    404) returns ``False`` -> the caller re-raises -> the test FAILS (codex r3
-    E4)."""
+    """True iff ``exc`` from ``AutoTokenizer.from_pretrained`` is a genuine HF
+    OFFLINE/connectivity exception TYPE (``LocalEntryNotFoundError`` /
+    ``OfflineModeIsEnabled`` / ``requests.ConnectionError``).
+
+    Type-only — the r3 message-substring heuristic is GONE (codex r4 F3): "Can't
+    load ..." is emitted for both offline AND corrupt artifacts, so a message match
+    could not tell them apart. The cache-presence gate now makes that call, and this
+    predicate is only the belt-and-suspenders skip for the NOT-cached branch (an
+    uncached repo that failed to fetch). Any other error — including a bare
+    ``OSError`` (corruption / bad revision / wrapped 404) — returns ``False`` so the
+    caller re-raises and the test FAILS."""
     offline_types = _offline_skip_exc_types()
-    if offline_types and isinstance(exc, offline_types):
-        return True
-    if isinstance(exc, OSError):
-        msg = str(exc).lower()
-        return any(sub in msg for sub in _OFFLINE_MSG_SUBSTRINGS)
-    return False
+    return bool(offline_types) and isinstance(exc, offline_types)
 
 
 @pytest.fixture(scope="module")
 def tok():
     transformers = pytest.importorskip("transformers")
+    # PRIMARY gate: cache presence. A CACHED tokenizer must LOAD — if it fails, that
+    # is corruption and the test FAILS (any exception propagates). Only a NOT-cached
+    # tokenizer is skip-eligible (genuinely unavailable), and even then only for an
+    # offline EXCEPTION TYPE (belt & suspenders for the attempted-fetch-while-
+    # uncached race); any other error on an uncached repo still surfaces. This
+    # replaces the r3 message-substring heuristic, which could not distinguish a
+    # corrupt cached artifact from an offline miss (codex r4 F3).
+    if _tokenizer_in_cache():
+        return transformers.AutoTokenizer.from_pretrained(
+            _TOKENIZER_MODEL, revision=_TOKENIZER_REVISION
+        )
     try:
         return transformers.AutoTokenizer.from_pretrained(
             _TOKENIZER_MODEL, revision=_TOKENIZER_REVISION
         )
     except Exception as exc:  # pragma: no cover - offline & uncached
-        # SKIP only a genuine offline/cache-miss; RE-RAISE (FAIL) a corrupt artifact
-        # / invalid revision — both are ``OSError`` but only the former is
-        # skip-worthy, so corruption is never silently false-green (codex r3 E4).
         if not _is_offline_unavailable(exc):
             raise
         pytest.skip(
@@ -770,6 +802,110 @@ def test_gemma4_string_value_with_special_chars_is_accepted(code, tok, lltok):
         f"special-char string value rejected ({accepted}/{total}) for {code!r}"
     )
     assert accepting, f"special-char value {code!r} is not a terminal state"
+
+
+def _decompose_marker(tok):
+    """Spell the 5 bytes of ``<|"|>`` with ORDINARY tokens (never the atomic id 52).
+
+    ``tok.encode('<|"|>')`` collapses the marker to the single special token 52
+    (the legitimate string close). To exercise the F1 gap we need the SAME 5 bytes
+    emitted as ORDINARY vocabulary tokens — what a model would produce if it "typed"
+    the delimiter inside a value — so we encode each character on its own and
+    concatenate."""
+    ids = []
+    for ch in '<|"|>':
+        ids += tok.encode(ch, add_special_tokens=False)
+    return ids
+
+
+def _consume_ids(grammar, lltok, ids):
+    """Like ``_consume`` but drives an EXPLICIT token-id list (so a manually
+    decomposed ``<|"|>`` is fed as ordinary tokens, not re-encoded to id 52)."""
+    from llguidance.mlx import LLMatcher
+
+    matcher = LLMatcher(lltok, grammar)
+    assert not matcher.get_error(), matcher.get_error()
+    accepted = 0
+    for tid in ids:
+        if not matcher.consume_tokens([tid]):
+            break
+        accepted += 1
+    return accepted, len(ids), matcher.is_accepting()
+
+
+@_requires_llguidance
+def test_gemma4_ordinary_byte_spelled_marker_rejected_in_string_value(tok, lltok):
+    # THE codex-r4 F1 GUARANTEE. ``<|"|>`` is DUAL-NATURE: the atomic string-close
+    # token (id 52) AND a 5-byte sequence. The gemma4 parser text-SCANS the DECODED
+    # output for the byte substring ``<|"|>`` (``gemma4_tool_parser.py:97`` toggles
+    # ``in_gemma_string`` on every occurrence, NOT on token ids), so an
+    # ORDINARY-byte-spelled ``<|"|>`` mid-value is indistinguishable from the atomic
+    # close and would terminate the string EARLY -> parser desync. The content
+    # terminal excludes that byte sequence (``& ~/(?s:.*)<\|"\|>(?s:.*)/``), so the
+    # grammar must REJECT it.
+    grammar = _gemma4_grammar(GEMMA4_TOOLS, "required", tok)
+    assert grammar is not None
+
+    decomposed = _decompose_marker(tok)
+    # The decomposition is genuinely ORDINARY tokens (never the atomic id 52) yet
+    # decodes back to the exact marker bytes — otherwise the test would be probing
+    # the legitimate atomic close instead of the byte spelling.
+    assert 52 not in decomposed, decomposed
+    assert tok.decode(decomposed) == '<|"|>'
+
+    atom = tok.encode('<|"|>', add_special_tokens=False)
+    assert atom == [52]
+
+    def enc(s):
+        return tok.encode(s, add_special_tokens=False)
+
+    # Wire: call:run{code:<|"|>a‹ordinary <|"|>›b<|"|>,lang:<|"|>python<|"|>}
+    # The INNER ``<|"|>`` (around index of ``a``…``b``) is the ordinary-byte spelling.
+    ids = (
+        enc("<|tool_call>call:run{code:")
+        + atom  # real open of the code value
+        + enc("a")
+        + decomposed
+        + enc("b")  # value "a<|"|>b" with an ORDINARY marker
+        + atom  # real close of the code value
+        + enc(",lang:")
+        + atom
+        + enc("python")
+        + atom
+        + enc("}")
+        + enc("<tool_call|>")
+    )
+    accepted, total, accepting = _consume_ids(grammar, lltok, ids)
+    assert accepted < total, (
+        'grammar ACCEPTED an ordinary-byte-spelled <|"|> inside a string value — '
+        "the F1 under-constraint is back (the parser would misread it as an early "
+        "string close and desync the key:value framing)"
+    )
+    assert not accepting, "injected byte-spelled marker reached a terminal state"
+
+    # Positive control on the SAME grammar: a value with raw ``<``/``>``/``|`` that
+    # never forms the FULL ``<|"|>`` marker still round-trips and terminates — the
+    # exclusion is scoped to the exact 5-byte sequence, not to ``<``/``>``/``|``.
+    ok_accepted, ok_total, ok_accepting = _consume(
+        grammar, lltok, tok, _wire("a < b | c > d <|x|>", lang="cpp")
+    )
+    assert ok_accepted == ok_total and ok_accepting, (
+        f"raw </>/| (non-full-marker) value wrongly rejected ({ok_accepted}/{ok_total})"
+    )
+
+    # CROSS-CHECK grammar<->parser agreement: had the grammar allowed the injected
+    # marker, the parser (scanning decoded text for <|"|>) would read the value only
+    # up to the FIRST inner <|"|> and read back a DIFFERENT value than intended —
+    # exactly the desync the grammar now structurally prevents.
+    desynced_decoded = (
+        '<|tool_call>call:run{code:<|"|>a<|"|>b<|"|>,lang:<|"|>python<|"|>}<tool_call|>'
+    )
+    name, args = _parse(desynced_decoded, GEMMA4_TOOLS)
+    assert name == "run"
+    assert args.get("code") != 'a<|"|>b', (
+        'parser cross-check invalid: an inner <|"|> did NOT desync the value — the '
+        "grammar exclusion would be unnecessary"
+    )
 
 
 @_requires_llguidance

--- a/vllm_mlx/api/tool_grammar.py
+++ b/vllm_mlx/api/tool_grammar.py
@@ -428,21 +428,45 @@ _XML_STRING_TERMINAL_DECL = (
 )
 
 
-# The gemma4 string-value construct (#558 E4). Unlike the Qwen3-Coder XML wire
-# (E3), whose ``</parameter>`` delimiter is ordinary BYTE TEXT and needs
-# llguidance's ``[lazy]`` lexeme to stop a greedy value at the first close, gemma4
-# wraps a string value in the ``<|"|>`` marker which is a SINGLE SPECIAL TOKEN
-# (id 52 on the target tokenizer). A greedy byte regex CANNOT consume a special
-# token, so maximal-munch stops at the ``<|"|>`` boundary on its own — the value
-# is simply ``<|"|> GEMMA_STR_TEXT <|"|>`` with BOTH ``<|"|>`` as RULE-LEVEL
-# special-token refs. This is a real feasibility result, not a stylistic choice:
-# llguidance REJECTS a special token inside a lexer terminal, so the ``[lazy]``
-# form (``rule[lazy]: TEXT <|"|>``) fails to COMPILE (special tokens cannot be used
-# in terminals), and a byte-literal ``"<|\"|>"`` delimiter COMPILES but can never
-# be satisfied at runtime by the atomic special token (verified on the real
-# tokenizer: the greedy rule-level form accepts a value containing
-# ``<``/``{``/``}``/``,``/quotes/newlines and terminates correctly at the closing
-# ``<|"|>``; both other forms fail).
+# The gemma4 string-value construct (#558 E4). A string value is wrapped in the
+# ``<|"|>`` marker, a SINGLE SPECIAL TOKEN (id 52 on the target tokenizer). The
+# value is a RULE ``<|"|> GEMMA_STR_TEXT <|"|>`` with BOTH ``<|"|>`` as RULE-LEVEL
+# special-token refs — the atomic close token 52 the model actually emits. The
+# close MUST stay a rule-level special-token ref (not a ``[lazy]``/byte construct):
+# llguidance REJECTS a special token inside a lexer terminal, so a lazy form
+# (``rule[lazy]: TEXT <|"|>``) cannot use the special token as its terminator, and a
+# byte-literal ``"<|\"|>"`` close COMPILES but is runtime-DEAD (the atomic token 52
+# never satisfies a byte literal). Both verified on the real tokenizer — the lazy /
+# byte-literal-close forms accept ZERO valid calls.
+#
+# THE CONTENT MUST EXCLUDE THE BYTE SPELLING OF ``<|"|>`` (#558 E4, codex r4 — a
+# REAL under-constraint fix). A bare ``GEMMA_STR_TEXT: /(.|\n)*/`` admits ANY byte
+# sequence, so the model can spell the 5 bytes ``<|"|>`` with ORDINARY tokens (ids
+# 236820/236909/236775/236909/236813 — none is the atomic token 52) INSIDE a value.
+# The gemma4 parser text-SCANS the DECODED output for the byte substring ``<|"|>``:
+# ``_scan_gemma4_tool_calls`` (``tool_parsers/gemma4_tool_parser.py`` line ~97)
+# toggles ``in_gemma_string`` on EVERY ``<|"|>`` occurrence, NOT on token ids — so
+# an ordinary-byte-spelled ``<|"|>`` mid-value is INDISTINGUISHABLE from the atomic
+# close and terminates the string EARLY, desyncing the ``key:value`` framing. We
+# therefore EXCLUDE the byte sequence ``<|"|>`` from the content via llguidance's
+# documented regex And/Not algebra (``docs/syntax.md``):
+# ``GEMMA_STR_TEXT: /(.|\n)*/ & ~/(?s:.*)<\|"\|>(?s:.*)/`` — "any UTF-8 bytes AND
+# NOT (contains ``<|"|>``)". ``~`` (complement) / ``&`` (intersection) are the
+# engine's real operators (no lookahead — which llguidance / Rust ``regex`` lack);
+# intersecting with ``/(.|\n)*/`` keeps the negation UTF-8-safe (``~`` alone may
+# match invalid UTF-8 — this is the syntax doc's own
+# ``/(?s:.*)/ & ~/(?s:.*)AAA(?s:.*)/`` recipe). VERIFIED on the real tokenizer: the
+# terminal accepts values containing ``<``/``>``/``|``/``{``/``}``/``,``/quotes/
+# newlines and even a 4-byte marker PREFIX (``<|"|``) adjacent to the close, yet
+# REJECTS at the exact ``>`` token that would complete an ordinary-byte ``<|"|>``
+# mid-value — keeping the constrained wire and the parser boundary in EXACT
+# agreement (the grammar forbids precisely the byte substring the parser reads as a
+# close). Only ``<|"|>`` needs excluding: while ``in_gemma_string`` the parser skips
+# ALL other bytes (frame tokens ``<|tool_call>``/``<tool_call|>``/``<|channel>``/
+# ``<channel|>``, braces, commas) until the next ``<|"|>``, so a byte-spelling of
+# those inside a value is harmless. Enum values get the same guarantee structurally
+# (``_gemma4_enum_wire_unsafe`` / ``_enum_wire_embeds_special_token`` opt out any
+# value whose wire embeds a structural marker).
 _GEMMA4_STRING_VALUE_TERMINAL = "GEMMA_STR_TEXT"
 _GEMMA4_STRING_VALUE_RULE = "gemma_str_value"
 # The gemma4 string-delimiter marker (``<|"|>``). Declared as a single special
@@ -450,29 +474,20 @@ _GEMMA4_STRING_VALUE_RULE = "gemma_str_value"
 # it passes ``_is_lark_special_token_ref`` (leading ``<``, trailing ``>``, no
 # interior ``<``/``>`` or whitespace — the inner ``|"|`` is fine).
 _GEMMA4_STRING_MARKER = '<|"|>'
-# ``GEMMA_STR_TEXT`` is a fresh terminal (same ``/(.|\n)*/`` pattern as
-# ``XML_PARAM_TEXT``/``TAG_TEXT`` but a DISTINCT name so a mixed tool-set never
-# cross-binds them). The lowercase ``gemma_str_value`` is a RULE (not a terminal),
-# because the special-token markers must live at rule level.
-#
-# DELIBERATE SAFE OVER-CONSTRAINT (#558 E4, codex r2). ``GEMMA_STR_TEXT`` is a
-# BYTE regex, so a free-form string value admits any byte sequence but CANNOT
-# contain a SPECIAL TOKEN — not the ``<|"|>`` delimiter itself, nor the
-# ``<|tool_call>``/``<tool_call|>``/``<|channel>``/``<channel|>`` frame tokens
-# (llguidance emits those atomically, never as their spelled-out bytes). We do NOT
-# widen this terminal to admit the special tokens, and that is INTENTIONAL, not an
-# oversight: the parser's value scanner treats the FIRST ``<|"|>`` after the opener
-# as the string's CLOSE — ``_scan_gemma4_tool_calls`` (``tool_parsers/
-# gemma4_tool_parser.py`` line ~97) toggles ``in_gemma_string`` on every ``<|"|>``
-# — so a ``<|"|>`` injected MID-VALUE would terminate the string EARLY and desync
-# the ``key:value`` framing. Admitting special tokens here would be an UNSAFE
-# UNDER-constraint (structural-marker injection -> parser boundary corruption).
-# Byte-only content is a strictly SAFE over-constraint: the rare value that truly
-# needs a structural special token simply opts the request out (enum values via
-# ``_gemma4_enum_wire_unsafe``; a non-enum free-form string cannot embed one at
-# all), keeping the constrained wire and the parser boundary in exact agreement.
+# The SAME ``<|"|>`` marker as a REGEX-ESCAPED byte literal (the two ``|`` escaped
+# for the regex engine; ``<``/``"``/``>`` are literal), used ONLY in the negated
+# substring that keeps the byte spelling out of string content. Co-located with the
+# special-token-ref spelling so the marker has one obvious source of truth.
+_GEMMA4_STRING_MARKER_RE = r'<\|"\|>'
+# ``GEMMA_STR_TEXT`` is a fresh terminal (a DISTINCT name from
+# ``XML_PARAM_TEXT``/``TAG_TEXT`` so a mixed tool-set never cross-binds them). Its
+# base is the same ``/(.|\n)*/`` any-byte pattern, intersected (``&``) with the
+# complement (``~``) of "contains ``<|"|>``" so the content can never spell the
+# string delimiter (see the block above). The lowercase ``gemma_str_value`` is a
+# RULE (not a terminal) because the special-token markers must live at rule level.
 _GEMMA4_STRING_RULE_DECL = (
-    f"{_GEMMA4_STRING_VALUE_TERMINAL}: /(.|\\n)*/\n"
+    f"{_GEMMA4_STRING_VALUE_TERMINAL}: /(.|\\n)*/ & "
+    f"~/(?s:.*){_GEMMA4_STRING_MARKER_RE}(?s:.*)/\n"
     f"{_GEMMA4_STRING_VALUE_RULE}: {_GEMMA4_STRING_MARKER} "
     f"{_GEMMA4_STRING_VALUE_TERMINAL} {_GEMMA4_STRING_MARKER}\n"
 )
@@ -1182,8 +1197,9 @@ def _emit_gemma4_param_value(subschema: Any, defs: dict[str, Any]) -> str:
         (``json.dumps`` -> ``5`` / ``true``). Per-value wrapping (not an
         all-or-nothing split) faithfully renders a mixed-type enum too.
       * STRING (non-enum) -> the ``gemma_str_value`` rule
-        (``<|"|> GEMMA_STR_TEXT <|"|>`` — greedy content up to the closing
-        special-token marker; see ``_GEMMA4_STRING_RULE_DECL``).
+        (``<|"|> GEMMA_STR_TEXT <|"|>`` — any-byte content EXCEPT the byte spelling
+        of the ``<|"|>`` marker, closed by the atomic special-token marker; see
+        ``_GEMMA4_STRING_RULE_DECL``).
       * EVERYTHING ELSE (integer / number / boolean / object / array) -> ``%json``
         over the sub-schema. ``format_argument`` emits a BARE JSON scalar for
         numbers/bools (``3`` / ``true``) and a JSON container for object/array,

--- a/vllm_mlx/api/tool_grammar.py
+++ b/vllm_mlx/api/tool_grammar.py
@@ -454,6 +454,23 @@ _GEMMA4_STRING_MARKER = '<|"|>'
 # ``XML_PARAM_TEXT``/``TAG_TEXT`` but a DISTINCT name so a mixed tool-set never
 # cross-binds them). The lowercase ``gemma_str_value`` is a RULE (not a terminal),
 # because the special-token markers must live at rule level.
+#
+# DELIBERATE SAFE OVER-CONSTRAINT (#558 E4, codex r2). ``GEMMA_STR_TEXT`` is a
+# BYTE regex, so a free-form string value admits any byte sequence but CANNOT
+# contain a SPECIAL TOKEN — not the ``<|"|>`` delimiter itself, nor the
+# ``<|tool_call>``/``<tool_call|>``/``<|channel>``/``<channel|>`` frame tokens
+# (llguidance emits those atomically, never as their spelled-out bytes). We do NOT
+# widen this terminal to admit the special tokens, and that is INTENTIONAL, not an
+# oversight: the parser's value scanner treats the FIRST ``<|"|>`` after the opener
+# as the string's CLOSE — ``_scan_gemma4_tool_calls`` (``tool_parsers/
+# gemma4_tool_parser.py`` line ~97) toggles ``in_gemma_string`` on every ``<|"|>``
+# — so a ``<|"|>`` injected MID-VALUE would terminate the string EARLY and desync
+# the ``key:value`` framing. Admitting special tokens here would be an UNSAFE
+# UNDER-constraint (structural-marker injection -> parser boundary corruption).
+# Byte-only content is a strictly SAFE over-constraint: the rare value that truly
+# needs a structural special token simply opts the request out (enum values via
+# ``_gemma4_enum_wire_unsafe``; a non-enum free-form string cannot embed one at
+# all), keeping the constrained wire and the parser boundary in exact agreement.
 _GEMMA4_STRING_RULE_DECL = (
     f"{_GEMMA4_STRING_VALUE_TERMINAL}: /(.|\\n)*/\n"
     f"{_GEMMA4_STRING_VALUE_RULE}: {_GEMMA4_STRING_MARKER} "
@@ -592,15 +609,46 @@ def _xml_enum_wire_unsafe(wire: str) -> bool:
     return any(c in "<>\r\n" for c in wire)
 
 
-def _gemma4_enum_wire_unsafe(wire: str) -> bool:
-    """gemma4 enum-value wire is unsafe iff it contains the ``<|"|>`` marker.
+# The FULL set of gemma4 structural special-token markers. Each is a SINGLE
+# SPECIAL TOKEN on the gemma4 tokenizer (verified ids on
+# ``mlx-community/gemma-4-e2b-it-4bit``): the tool-call frame ``<|tool_call>`` (48)
+# / ``<tool_call|>`` (49), the string delimiter ``<|"|>`` (52), and the
+# reasoning-channel frame ``<|channel>`` (100) / ``<channel|>`` (101). The first
+# three mirror ``Gemma4ToolParser._GRAMMAR_SENTINELS`` — the parser is the single
+# source of truth for the sentinel triple; the channel pair is documented there in
+# prose (``TOOL_GRAMMAR_AUTO_SAFE`` comment) but has no constant, so it is
+# enumerated here. Kept in THIS module (not imported from the parser) because the
+# dependency direction is parsers -> tool_grammar; ``_GEMMA4_STRING_MARKER`` is
+# reused so the ``<|"|>`` spelling has one definition.
+_GEMMA4_STRUCTURAL_MARKERS = (
+    "<|tool_call>",
+    "<tool_call|>",
+    _GEMMA4_STRING_MARKER,  # ``<|"|>``
+    "<|channel>",
+    "<channel|>",
+)
 
-    A gemma4 string value is bounded ONLY by the ``<|"|>`` marker, so a value that
-    literally contains it would close early / retokenize as the special token.
-    ``<``/``>``/CR/LF/commas/braces are all SAFE inside the ``<|"|>`` pair
-    (verified on the real tokenizer), so — unlike XML — they must NOT opt out.
+
+def _gemma4_enum_wire_unsafe(wire: str) -> bool:
+    """gemma4 enum-value wire is unsafe iff it embeds a STRUCTURAL special token.
+
+    An enum value's WIRE form is rendered as BYTE LITERALS (a ``<|"|>``-wrapped
+    string alt or a bare ``json.dumps`` scalar). Every gemma4 structural marker in
+    ``_GEMMA4_STRUCTURAL_MARKERS`` — the ``<|"|>`` string delimiter AND the
+    ``<|tool_call>``/``<tool_call|>``/``<|channel>``/``<channel|>`` frame tokens —
+    is a SINGLE SPECIAL TOKEN, which llguidance emits atomically and NEVER as its
+    spelled-out bytes. So a value whose wire form contains one compiles to a DEAD
+    byte-literal alternation branch the model can never reach (the same
+    runtime-unsatisfiable reason a byte-literal ``<|"|>`` delimiter cannot match
+    the atomic token); were such a value ever to reach the wire it would also
+    corrupt the parser's ``<|"|>`` boundary or the call frame. Faithful-or-opt-out:
+    reject it so the whole request opts out (return ``None`` -> free-form),
+    mirroring E3's ``_xml_enum_wire_unsafe``. Ordinary ``<``/``>``/CR/LF/commas/
+    braces are SAFE inside the ``<|"|>`` pair (verified on the real tokenizer), so —
+    unlike XML — a bare ``<``/``>`` must NOT opt out; only a FULL marker substring
+    does.
     """
-    return _GEMMA4_STRING_MARKER in wire
+    return any(marker in wire for marker in _GEMMA4_STRUCTURAL_MARKERS)
 
 
 @dataclass(frozen=True)

--- a/vllm_mlx/api/tool_grammar.py
+++ b/vllm_mlx/api/tool_grammar.py
@@ -44,7 +44,7 @@ import threading
 import weakref
 from collections import OrderedDict
 from collections.abc import Callable
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from functools import lru_cache
 from typing import Any
 
@@ -632,6 +632,14 @@ _GEMMA4_STRUCTURAL_MARKERS = (
 def _gemma4_enum_wire_unsafe(wire: str) -> bool:
     """gemma4 enum-value wire is unsafe iff it embeds a STRUCTURAL special token.
 
+    This is the STRUCTURAL, TOKENIZER-FREE fallback (the ``tokenizer is None``
+    degraded / warmup path). The COMPLETE, complete-by-construction check lives in
+    ``_gemma4_schema_representable`` (codex r3 E4): when the model tokenizer is
+    available it ALSO rejects an enum value that tokenizes through ANY registered
+    special token (``_enum_wire_embeds_special_token``), not just the five hard-coded
+    markers below. This function stays a cheap fast-path there (belt & suspenders)
+    and the sole check when no tokenizer is present.
+
     An enum value's WIRE form is rendered as BYTE LITERALS (a ``<|"|>``-wrapped
     string alt or a bare ``json.dumps`` scalar). Every gemma4 structural marker in
     ``_GEMMA4_STRUCTURAL_MARKERS`` — the ``<|"|>`` string delimiter AND the
@@ -651,6 +659,45 @@ def _gemma4_enum_wire_unsafe(wire: str) -> bool:
     return any(marker in wire for marker in _GEMMA4_STRUCTURAL_MARKERS)
 
 
+def _enum_wire_embeds_special_token(tokenizer: Any, wire: str) -> bool:
+    """True iff ``wire``'s BYTE content tokenizes THROUGH a registered special token.
+
+    Completes the gemma4 enum guard BY CONSTRUCTION (codex r3 E4). The 5-marker
+    ``_gemma4_enum_wire_unsafe`` substring BLACKLIST is inherently incomplete — a
+    reviewer can always name one more special token (on the pinned gemma-4
+    tokenizer ``<bos>`` / ``<eos>`` / ``<pad>`` / ``<unk>`` are single registered
+    tokens outside the five markers). This check is TOKENIZER-DRIVEN, so it opts out
+    a value ONLY when it ACTUALLY collapses to a registered token on THIS tokenizer
+    (a surface like ``<start_of_turn>`` that tokenizes to ordinary multi-token text
+    is a REACHABLE byte-literal and correctly kept). A gemma4 enum
+    value is emitted as a BYTE-LITERAL alternation branch (the raw ``wire`` bytes
+    between ``<|"|>`` markers, or a bare ``json.dumps`` scalar); if ANY of those
+    bytes resolves to a REGISTERED added/special token on ``tokenizer``, llguidance
+    emits that token ATOMICALLY, never as its spelled-out bytes, so the branch is
+    unreachable/unsatisfiable and the model can never produce it. Report it unsafe
+    so the whole request opts out (return ``None`` -> free-form) — the same
+    faithful-or-opt-out policy as the structural-marker check, now closed over the
+    tokenizer's FULL special-token set rather than five hard-coded strings.
+
+    Reuses ``_is_registered_added_token`` — the EXACT predicate
+    ``are_single_special_tokens`` uses — so "registered special token" means one
+    consistent thing across the module (do NOT reinvent). Encodes with
+    ``add_special_tokens=False`` so no BOS/EOS is auto-prepended; a value collapses
+    to a special token ONLY when it literally spells one. Degrades to ``False`` (the
+    cheap 5-marker structural fallback still applies) when the tokenizer lacks
+    ``encode`` / raises — grammar constraint is best-effort opt-in, never a hard
+    requirement.
+    """
+    encode = getattr(tokenizer, "encode", None)
+    if encode is None:
+        return False
+    try:
+        ids = encode(wire, add_special_tokens=False)
+    except Exception:
+        return False
+    return any(_is_registered_added_token(tokenizer, tok_id) for tok_id in ids)
+
+
 @dataclass(frozen=True)
 class _ArgWirePolicy:
     """Per-wire representability policy for the delimiter-based arg guards (E4).
@@ -664,8 +711,15 @@ class _ArgWirePolicy:
         key position (XML ``<parameter=KEY>`` rejects ``<>{},:``+whitespace; gemma4
         ``KEY:`` round-trips only a ``\\w+`` key).
       * ``enum_wire_unsafe`` — whether an enum value's WIRE form carries a byte
-        that breaks the value framing (XML: ``<>\\r\\n``; gemma4: only the
-        ``<|"|>`` marker).
+        sequence that breaks the value framing. XML: any ``<>\\r\\n`` byte. gemma4:
+        ANY of the five structural special-token markers
+        (``<|tool_call>`` / ``<tool_call|>`` / ``<|"|>`` / ``<|channel>`` /
+        ``<channel|>``) AND — when ``build_tool_grammar`` threads the model
+        tokenizer into ``_gemma4_schema_representable`` — ANY tokenizer-registered
+        special token the value tokenizes through (``<bos>`` / ``<eos>`` /
+        ``<pad>`` / …), so the gemma4 enum guard is COMPLETE BY CONSTRUCTION, not a
+        five-string blacklist (codex r3 E4). Without a tokenizer it falls back to
+        the five structural markers alone.
 
     Everything else (top-level key allowlist, ``additionalProperties`` /
     ``required`` totality, ``$ref`` resolution, scalar/object/array/string
@@ -959,15 +1013,41 @@ def _xml_schema_representable(
     return True
 
 
-def _gemma4_schema_representable(params: Any) -> bool:
+def _gemma4_schema_representable(params: Any, *, tokenizer: Any = None) -> bool:
     """True iff the gemma4 arg emitter can FAITHFULLY constrain ``params`` (E4).
 
     Thin binding of the shared strict-allowlist guard to the gemma4 wire policy
-    (``\\w+`` bare keys; only the ``<|"|>`` marker is an unsafe enum-value byte).
-    Reuses the SAME structural allowlist as XML — a request opts out of grammar
+    (``\\w+`` bare keys; an enum value is unsafe iff it embeds a structural marker
+    OR — when ``tokenizer`` is given — ANY registered special token). Reuses the
+    SAME structural allowlist as XML — a request opts out of grammar
     (``build_tool_grammar`` -> ``None`` -> free-form) on any unrepresentable shape.
+
+    ``tokenizer`` (the model tokenizer, read off the parser by
+    ``build_tool_grammar``) makes the enum guard COMPLETE BY CONSTRUCTION (codex r3
+    E4): the five-marker ``_gemma4_enum_wire_unsafe`` substring blacklist cannot
+    enumerate every special token, so when a tokenizer is available the per-request
+    policy ALSO rejects any enum value that tokenizes through a registered special
+    token (``_enum_wire_embeds_special_token``) — an enum such as ``["<bos>"]`` /
+    ``["<eos>"]`` compiles to an unreachable byte-literal branch and opts the
+    request out. When ``tokenizer is None`` (degraded / warmup, which uses a
+    fixed NO-enum tool) the guard falls back to the five-marker structural subset —
+    a safe under-approximation that never bites the warmup path. The cheap 5-marker
+    check runs FIRST inside the composed check (belt & suspenders) even when a
+    tokenizer is present.
     """
-    return _xml_schema_representable(params, _GEMMA4_WIRE_POLICY)
+    if tokenizer is None:
+        policy = _GEMMA4_WIRE_POLICY
+    else:
+
+        def _enum_wire_unsafe(wire: str) -> bool:
+            # Complete-by-construction: the cheap structural 5-marker check FIRST,
+            # then the tokenizer-complete registered-special-token check.
+            return _gemma4_enum_wire_unsafe(wire) or _enum_wire_embeds_special_token(
+                tokenizer, wire
+            )
+
+        policy = replace(_GEMMA4_WIRE_POLICY, enum_wire_unsafe=_enum_wire_unsafe)
+    return _xml_schema_representable(params, policy)
 
 
 def _emit_xml_param_value(subschema: Any, defs: dict[str, Any]) -> str:
@@ -2008,6 +2088,16 @@ def build_tool_grammar(
     # existing opt-outs (``structure_info() -> None`` / ``TOOL_GRAMMAR_AUTO_SAFE``)
     # and applies ONLY to ``arg_style != "json"`` tools — the JSON-body families
     # (hermes / qwen / harmony) are ``%json <schema>`` and stay byte-identical.
+    #
+    # The model tokenizer (stored on every ``ToolParser`` as ``model_tokenizer``,
+    # constructed ``parser_cls(tokenizer=...)`` on the chat route / warmup) makes
+    # the gemma4 ENUM guard COMPLETE BY CONSTRUCTION (codex r3 E4): an enum value
+    # that tokenizes through ANY registered special token — not just the five
+    # hard-coded structural markers — compiles to an unreachable byte-literal branch
+    # and opts the request out. ``None`` (no tokenizer / degraded) falls back to the
+    # structural 5-marker subset; the XML wire is unaffected (it already rejects
+    # ``<``/``>``).
+    tok = getattr(parser, "model_tokenizer", None)
     for tool, si in zip(tools, structure_infos):
         arg_style = getattr(si, "arg_style", "json")
         if arg_style == "json":
@@ -2025,7 +2115,7 @@ def build_tool_grammar(
         # Same strict-allowlist guard, per-wire policy (E3 XML / E4 gemma4). An
         # unknown non-json arg_style is treated conservatively (opt out).
         if arg_style == "gemma4":
-            representable = _gemma4_schema_representable(params)
+            representable = _gemma4_schema_representable(params, tokenizer=tok)
         elif arg_style == "xml":
             representable = _xml_schema_representable(params)
         else:

--- a/vllm_mlx/api/tool_grammar.py
+++ b/vllm_mlx/api/tool_grammar.py
@@ -39,9 +39,11 @@ list of "sentinel" substrings that must render as special-token refs.
 
 import json
 import logging
+import re
 import threading
 import weakref
 from collections import OrderedDict
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from functools import lru_cache
 from typing import Any
@@ -111,6 +113,11 @@ class StructureInfo:
         scalars/objects/arrays, an alternation for enums). See
         ``_emit_xml_arg_body``. Default stays ``"json"`` so hermes/qwen/harmony
         (and any out-of-tree JSON-body family) are byte-identical to before.
+      * ``"gemma4"`` (#558 E4) — the Gemma-4 native arg body:
+        ``call:NAME{k1:v1,k2:v2,...}`` with DICTSORT-ordered, COMMA-separated
+        ``key:VALUE`` pairs, string values wrapped in the ``<|"|>`` special-token
+        marker, bare scalars/booleans, ``%json`` objects/arrays, and an
+        alternation for enums. See ``_emit_gemma4_arg_body``.
     """
 
     begin: str
@@ -421,6 +428,39 @@ _XML_STRING_TERMINAL_DECL = (
 )
 
 
+# The gemma4 string-value construct (#558 E4). Unlike the Qwen3-Coder XML wire
+# (E3), whose ``</parameter>`` delimiter is ordinary BYTE TEXT and needs
+# llguidance's ``[lazy]`` lexeme to stop a greedy value at the first close, gemma4
+# wraps a string value in the ``<|"|>`` marker which is a SINGLE SPECIAL TOKEN
+# (id 52 on the target tokenizer). A greedy byte regex CANNOT consume a special
+# token, so maximal-munch stops at the ``<|"|>`` boundary on its own — the value
+# is simply ``<|"|> GEMMA_STR_TEXT <|"|>`` with BOTH ``<|"|>`` as RULE-LEVEL
+# special-token refs. This is a real feasibility result, not a stylistic choice:
+# llguidance REJECTS a special token inside a lexer terminal, so the ``[lazy]``
+# form (``rule[lazy]: TEXT <|"|>``) fails to COMPILE (special tokens cannot be used
+# in terminals), and a byte-literal ``"<|\"|>"`` delimiter COMPILES but can never
+# be satisfied at runtime by the atomic special token (verified on the real
+# tokenizer: the greedy rule-level form accepts a value containing
+# ``<``/``{``/``}``/``,``/quotes/newlines and terminates correctly at the closing
+# ``<|"|>``; both other forms fail).
+_GEMMA4_STRING_VALUE_TERMINAL = "GEMMA_STR_TEXT"
+_GEMMA4_STRING_VALUE_RULE = "gemma_str_value"
+# The gemma4 string-delimiter marker (``<|"|>``). Declared as a single special
+# token by ``Gemma4ToolParser`` and referenced as a bare Lark special-token ref;
+# it passes ``_is_lark_special_token_ref`` (leading ``<``, trailing ``>``, no
+# interior ``<``/``>`` or whitespace — the inner ``|"|`` is fine).
+_GEMMA4_STRING_MARKER = '<|"|>'
+# ``GEMMA_STR_TEXT`` is a fresh terminal (same ``/(.|\n)*/`` pattern as
+# ``XML_PARAM_TEXT``/``TAG_TEXT`` but a DISTINCT name so a mixed tool-set never
+# cross-binds them). The lowercase ``gemma_str_value`` is a RULE (not a terminal),
+# because the special-token markers must live at rule level.
+_GEMMA4_STRING_RULE_DECL = (
+    f"{_GEMMA4_STRING_VALUE_TERMINAL}: /(.|\\n)*/\n"
+    f"{_GEMMA4_STRING_VALUE_RULE}: {_GEMMA4_STRING_MARKER} "
+    f"{_GEMMA4_STRING_VALUE_TERMINAL} {_GEMMA4_STRING_MARKER}\n"
+)
+
+
 # ------------------------------------------------------------------------
 # STRICT-ALLOWLIST representability guard for the Qwen3-Coder XML arg wire
 # (#558 E3). The XML emitter (``_emit_xml_arg_body`` / ``_emit_xml_param_value``)
@@ -530,6 +570,74 @@ def _xml_key_is_delimiter_safe(key: Any) -> bool:
     return not any(c.isspace() for c in key)
 
 
+# gemma4 emits a property key BARE in the ``KEY:`` wire position and the parser
+# reads it back with ``GEMMA4_KEY_PATTERN`` (``\w+``), so only a ``\w+`` key
+# round-trips faithfully. This is STRICTER than the XML key check (which allows
+# ``-``/``.``): a ``my-key`` would be read back as just ``my`` (the parser stops
+# at ``-``) and desync the pair. A leading digit is fine (``\w`` admits it).
+_GEMMA4_KEY_RE = re.compile(r"\w+")
+
+
+def _gemma4_key_is_safe(key: Any) -> bool:
+    """True iff ``key`` round-trips through gemma4's BARE ``KEY:`` wire position."""
+    return isinstance(key, str) and _GEMMA4_KEY_RE.fullmatch(key) is not None
+
+
+def _xml_enum_wire_unsafe(wire: str) -> bool:
+    """XML enum-value wire is unsafe iff it carries a delimiter-breaking byte.
+
+    An XML string value truncates at the FIRST ``</parameter>`` and a ``<``/``>``
+    desyncs the tag; a CR/LF splits the wire's own ``\\n`` framing.
+    """
+    return any(c in "<>\r\n" for c in wire)
+
+
+def _gemma4_enum_wire_unsafe(wire: str) -> bool:
+    """gemma4 enum-value wire is unsafe iff it contains the ``<|"|>`` marker.
+
+    A gemma4 string value is bounded ONLY by the ``<|"|>`` marker, so a value that
+    literally contains it would close early / retokenize as the special token.
+    ``<``/``>``/CR/LF/commas/braces are all SAFE inside the ``<|"|>`` pair
+    (verified on the real tokenizer), so — unlike XML — they must NOT opt out.
+    """
+    return _GEMMA4_STRING_MARKER in wire
+
+
+@dataclass(frozen=True)
+class _ArgWirePolicy:
+    """Per-wire representability policy for the delimiter-based arg guards (E4).
+
+    The strict-allowlist representability guard (``_arg_schema_representable`` /
+    ``_arg_property_representable`` / ``_arg_enum_representable``) is IDENTICAL
+    across the delimiter-based arg wires (E3 Qwen3-Coder XML, E4 gemma4) EXCEPT for
+    two leaf checks that depend on the wire's concrete delimiters:
+
+      * ``key_safe`` — whether a property key can be inserted RAW into the wire's
+        key position (XML ``<parameter=KEY>`` rejects ``<>{},:``+whitespace; gemma4
+        ``KEY:`` round-trips only a ``\\w+`` key).
+      * ``enum_wire_unsafe`` — whether an enum value's WIRE form carries a byte
+        that breaks the value framing (XML: ``<>\\r\\n``; gemma4: only the
+        ``<|"|>`` marker).
+
+    Everything else (top-level key allowlist, ``additionalProperties`` /
+    ``required`` totality, ``$ref`` resolution, scalar/object/array/string
+    dispatch, string-facet allowlist) is wire-independent and SHARED — so the two
+    families cannot drift into inconsistent (weaker) guards. ``_xml_*`` /
+    ``_gemma4_*`` are thin wrappers that bind their policy.
+    """
+
+    key_safe: Callable[[Any], bool]
+    enum_wire_unsafe: Callable[[str], bool]
+
+
+_XML_WIRE_POLICY = _ArgWirePolicy(
+    key_safe=_xml_key_is_delimiter_safe, enum_wire_unsafe=_xml_enum_wire_unsafe
+)
+_GEMMA4_WIRE_POLICY = _ArgWirePolicy(
+    key_safe=_gemma4_key_is_safe, enum_wire_unsafe=_gemma4_enum_wire_unsafe
+)
+
+
 def _resolve_local_ref(subschema: Any, defs: dict[str, Any]) -> Any:
     """Resolve a single-level local ``$ref`` against ``defs`` (F3 / finding 4).
 
@@ -599,8 +707,15 @@ def _enum_value_matches_declared_type(value: Any, declared: str) -> bool:
     return False
 
 
-def _xml_enum_representable(resolved: dict[str, Any], enum: list[Any]) -> bool:
-    """True iff an ENUM property is inside the XML emitter's closed allowlist.
+def _xml_enum_representable(
+    resolved: dict[str, Any], enum: list[Any], policy: _ArgWirePolicy = _XML_WIRE_POLICY
+) -> bool:
+    """True iff an ENUM property is inside the emitter's closed allowlist.
+
+    Shared across the delimiter-based arg wires; ``policy`` selects the concrete
+    wire's enum-value delimiter check (``policy.enum_wire_unsafe`` — XML by
+    default, gemma4 via ``_GEMMA4_WIRE_POLICY``). The XML-specific prose below
+    describes the default policy.
 
     Routes the enum-first branch THROUGH the allowlist (codex r3 #2/#3) so the
     enum axis is complete-by-construction like the rest of the guard, instead of
@@ -641,14 +756,21 @@ def _xml_enum_representable(resolved: dict[str, Any], enum: list[Any]) -> bool:
         # (c) delimiter safety on the EXACT wire form the emitter would produce
         # (raw for a string value, ``json.dumps`` otherwise — enum values come
         # from parsed client JSON, so ``json.dumps`` is total and never raises).
+        # The concrete unsafe-byte set is the wire's (``policy.enum_wire_unsafe``).
         wire = value if isinstance(value, str) else json.dumps(value)
-        if any(c in "<>\r\n" for c in wire):
+        if policy.enum_wire_unsafe(wire):
             return False
     return True
 
 
-def _xml_property_representable(subschema: Any, defs: dict[str, Any]) -> bool:
-    """True iff ONE property schema is inside the XML emitter's closed allowlist.
+def _xml_property_representable(
+    subschema: Any, defs: dict[str, Any], policy: _ArgWirePolicy = _XML_WIRE_POLICY
+) -> bool:
+    """True iff ONE property schema is inside the emitter's closed allowlist.
+
+    Shared across the delimiter-based arg wires; ``policy`` threads to the enum
+    check (XML default, gemma4 via ``_GEMMA4_WIRE_POLICY``). The prose below
+    describes the default XML policy.
 
     After resolving a single-level local ``$ref`` (``_resolve_local_ref`` — an
     unresolvable ``$ref``, a ``$ref`` with siblings, or a non-dict such as a
@@ -678,7 +800,7 @@ def _xml_property_representable(subschema: Any, defs: dict[str, Any]) -> bool:
     # complete-by-construction too.
     enum = resolved.get("enum")
     if isinstance(enum, list) and enum:
-        return _xml_enum_representable(resolved, enum)
+        return _xml_enum_representable(resolved, enum, policy)
     prop_type = resolved.get("type")
     if not isinstance(prop_type, str):
         # Absent / union (list) / non-string ``type`` -> opt out.
@@ -696,8 +818,18 @@ def _xml_property_representable(subschema: Any, defs: dict[str, Any]) -> bool:
     return False
 
 
-def _xml_schema_representable(params: Any) -> bool:
-    """True iff the XML arg emitter can FAITHFULLY constrain ``params`` (#558 E3).
+def _xml_schema_representable(
+    params: Any, policy: _ArgWirePolicy = _XML_WIRE_POLICY
+) -> bool:
+    """True iff a delimiter-arg emitter can FAITHFULLY constrain ``params``.
+
+    Shared strict-allowlist guard for the delimiter-based arg wires (#558 E3 XML,
+    E4 gemma4). ``policy`` (default ``_XML_WIRE_POLICY``) selects the two
+    wire-specific leaf checks — key safety and enum-value delimiter safety — while
+    every structural rule (top-level keys, ``additionalProperties`` / ``required``
+    totality, ``$ref``, per-property dispatch) is shared, so no family can drift to
+    a weaker guard. ``_gemma4_schema_representable`` binds the gemma4 policy; the
+    prose below describes the default XML policy (#558 E3).
 
     STRICT ALLOWLIST (closed positive set — see the module block above): returns
     ``True`` ONLY when every part of ``params`` uses exclusively a known-safe,
@@ -770,12 +902,24 @@ def _xml_schema_representable(params: Any) -> bool:
     # arguments) skips the loop and stays representable.
     defs = _collect_xml_defs(params)
     for key, subschema in prop_map.items():
-        # F5: the key is emitted RAW into ``<parameter=KEY>`` -> must be safe.
-        if not _xml_key_is_delimiter_safe(key):
+        # The key is emitted RAW into the wire's key position -> must be safe for
+        # THIS wire (XML ``<parameter=KEY>`` vs gemma4 bare ``KEY:``).
+        if not policy.key_safe(key):
             return False
-        if not _xml_property_representable(subschema, defs):
+        if not _xml_property_representable(subschema, defs, policy):
             return False
     return True
+
+
+def _gemma4_schema_representable(params: Any) -> bool:
+    """True iff the gemma4 arg emitter can FAITHFULLY constrain ``params`` (E4).
+
+    Thin binding of the shared strict-allowlist guard to the gemma4 wire policy
+    (``\\w+`` bare keys; only the ``<|"|>`` marker is an unsafe enum-value byte).
+    Reuses the SAME structural allowlist as XML — a request opts out of grammar
+    (``build_tool_grammar`` -> ``None`` -> free-form) on any unrepresentable shape.
+    """
+    return _xml_schema_representable(params, _GEMMA4_WIRE_POLICY)
 
 
 def _emit_xml_param_value(subschema: Any, defs: dict[str, Any]) -> str:
@@ -896,6 +1040,152 @@ def _emit_xml_arg_body(params: Any) -> str:
         block = f"{open_lit} {value_lark}"
         frags.append(block if key in required_set else f"( {block} )?")
     return " ".join(frags)
+
+
+def _emit_gemma4_param_value(subschema: Any, defs: dict[str, Any]) -> str:
+    """Return the Lark for ONE gemma4 property VALUE (no key, no comma).
+
+    The gemma4 wire (``chat_template.jinja``'s ``format_argument``) serialises a
+    value by JSON type:
+
+      * ENUM -> a literal ALTERNATION, each value rendered in its OWN wire form:
+        a STRING value is wrapped in the ``<|"|>`` marker
+        (``<|"|> "python" <|"|>``), a numeric/boolean value is BARE
+        (``json.dumps`` -> ``5`` / ``true``). Per-value wrapping (not an
+        all-or-nothing split) faithfully renders a mixed-type enum too.
+      * STRING (non-enum) -> the ``gemma_str_value`` rule
+        (``<|"|> GEMMA_STR_TEXT <|"|>`` — greedy content up to the closing
+        special-token marker; see ``_GEMMA4_STRING_RULE_DECL``).
+      * EVERYTHING ELSE (integer / number / boolean / object / array) -> ``%json``
+        over the sub-schema. ``format_argument`` emits a BARE JSON scalar for
+        numbers/bools (``3`` / ``true``) and a JSON container for object/array,
+        all of which ``%json`` produces and the lenient gemma4 parser
+        (``_Gemma4ArgumentParser``) round-trips (its ``_parse_value`` accepts a
+        bare JSON object/array and a JSON string, so the standard-JSON surface
+        ``%json`` emits parses back correctly).
+
+    ``defs`` is merged into the ``%json`` sub-schema so an internal ``$ref``
+    resolves (mirrors ``_emit_xml_param_value``). ``_resolve_local_ref`` is applied
+    FIRST so a ``$ref`` -> string takes the raw ``<|"|>`` path (not quoted
+    ``%json``); a ``None`` (unresolvable) is defensive — the representability guard
+    already opted such a request out — and falls back to ``%json``.
+    """
+    if not isinstance(subschema, dict):
+        return _GEMMA4_STRING_VALUE_RULE
+    resolved = _resolve_local_ref(subschema, defs)
+    if resolved is None:
+        resolved = subschema
+    enum = resolved.get("enum")
+    if isinstance(enum, list) and enum:
+        # Every value's wire form is already delimiter-safe (the representability
+        # guard opted the request out otherwise). Wrap each STRING value in the
+        # ``<|"|>`` marker, emit every other value BARE via ``json.dumps``.
+        alts = []
+        for value in enum:
+            if isinstance(value, str):
+                alts.append(
+                    f"{_GEMMA4_STRING_MARKER} {_lark_escape(value)} "
+                    f"{_GEMMA4_STRING_MARKER}"
+                )
+            else:
+                alts.append(_lark_escape(json.dumps(value)))
+        return f"({' | '.join(alts)})"
+    # Lazy import: keep this module importable independently of api.tool_calling.
+    from .tool_calling import _schema_type
+
+    if _schema_type(resolved) == "string":
+        return _GEMMA4_STRING_VALUE_RULE
+    value_schema = dict(subschema)
+    for def_key, def_val in defs.items():
+        value_schema.setdefault(def_key, def_val)
+    return f"%json {json.dumps(value_schema)}"
+
+
+def _emit_gemma4_arg_body(params: Any) -> str:
+    """Emit the Lark for a gemma4 arg body (the part BETWEEN ``{`` and ``}``).
+
+    The gemma4 wire is ``call:NAME{k1:v1,k2:v2,...}`` where keys are emitted in
+    DICTSORT (alphabetical) order and separated by COMMAS
+    (``chat_template.jinja``'s ``found_first`` logic — a comma precedes every pair
+    except the FIRST PRESENT one). Required properties are mandatory; optional ones
+    may be omitted.
+
+    Because commas are SEPARATORS (not per-field terminators), a naive per-field
+    ``( )?`` misplaces the comma when an early optional field is absent (it would
+    emit a leading ``,`` or a doubled ``,,``). We instead build a FIRST-PRESENT
+    construction:
+
+      * ``_cont(i)`` — every field from position ``i`` on, each with a LEADING
+        comma (required: ``"," k:v``; optional: ``( "," k:v )?``). Used AFTER the
+        first present field, so a comma always separates two present pairs.
+      * the body is an ALTERNATION over WHICH field is first-present: for each
+        candidate first field ``j`` (reachable only if every earlier field is
+        optional, i.e. ``j`` is at or before the first REQUIRED field) emit
+        ``kj:vj`` with NO leading comma, then ``_cont(j+1)``.
+      * if EVERY field is optional the whole body is additionally ``( ... )?`` so
+        an empty ``{}`` body (no args emitted) is admitted.
+
+    The whole body is wrapped in a single ``( ... )`` group so an alternation binds
+    correctly when embedded as ``... "{" <body> "}" ...``. Returns ``""`` for a
+    no-argument tool (empty/absent ``properties``) -> the caller renders the bare
+    ``call:NAME{}`` frame.
+    """
+    if not isinstance(params, dict):
+        return ""
+    props = params.get("properties")
+    if not isinstance(props, dict) or not props:
+        # A no-argument tool: the EMPTY body IS the faithful constraint (forces a
+        # ``{}`` call). Mirrors ``_emit_xml_arg_body`` — a truly-open object is
+        # already opted out upstream by ``_gemma4_schema_representable``.
+        return ""
+    required = params.get("required")
+    # Only STRING members can name a property (mirrors the total guard in the
+    # representability check); a non-str member is unhashable in a bare ``set``.
+    required_set = (
+        {r for r in required if isinstance(r, str)}
+        if isinstance(required, list)
+        else set()
+    )
+    defs = _collect_xml_defs(params)
+    # DICTSORT order — matches how the chat template renders arguments, so a forced
+    # grammar constrains the model to the ordering it was trained to emit.
+    keys = sorted(props.keys())
+    fields = [
+        (key, _emit_gemma4_param_value(props[key], defs), key in required_set)
+        for key in keys
+    ]
+
+    def _kv(idx: int, *, leading_comma: bool) -> str:
+        key, value_lark, _ = fields[idx]
+        kv = f"{_lark_escape(key + ':')} {value_lark}"
+        return f'"," {kv}' if leading_comma else kv
+
+    def _cont(start: int) -> str:
+        parts: list[str] = []
+        for j in range(start, len(fields)):
+            frag = _kv(j, leading_comma=True)
+            parts.append(frag if fields[j][2] else f"( {frag} )?")
+        return " ".join(parts)
+
+    # Index of the first REQUIRED field (or len(fields) if all optional): the
+    # first-present field can be any field at or before it (earlier fields, being
+    # optional, may be absent — a required field can never be skipped).
+    first_required = len(fields)
+    for j, (_key, _val, req) in enumerate(fields):
+        if req:
+            first_required = j
+            break
+
+    alts: list[str] = []
+    for j in range(min(first_required + 1, len(fields))):
+        head = _kv(j, leading_comma=False)
+        tail = _cont(j + 1)
+        alts.append(f"{head} {tail}" if tail else head)
+    body = " | ".join(alts)
+    if first_required == len(fields):
+        # No required field -> the empty ``{}`` body is also valid.
+        return f"( {body} )?"
+    return f"( {body} )"
 
 
 def build_tool_lark(
@@ -1197,6 +1487,11 @@ def build_tool_lark(
     # per-param string check would need a second schema walk for no benefit.
     if any(getattr(si, "arg_style", "json") == "xml" for si in structure_infos):
         lark += _XML_STRING_TERMINAL_DECL
+    # Same for the gemma4 string-value rule (``<|"|> GEMMA_STR_TEXT <|"|>``),
+    # declared once iff any tag uses the gemma4 arg body. A JSON/XML-only tool-set
+    # never emits it, so those grammars stay byte-identical.
+    if any(getattr(si, "arg_style", "json") == "gemma4" for si in structure_infos):
+        lark += _GEMMA4_STRING_RULE_DECL
 
     for i, (tool, si) in enumerate(zip(tools, structure_infos)):
         # Only substitute the default when ``parameters`` is ABSENT. A
@@ -1217,13 +1512,17 @@ def build_tool_lark(
             }
         begin_body = _emit_literal_with_sentinels(si.begin, si.sentinels)
         end_body = _emit_literal_with_sentinels(si.end, si.sentinels)
-        # ARG BODY: a JSON object (``%json`` over the whole schema) for the
-        # default JSON wire, OR a Qwen3-Coder XML per-parameter body when the
-        # family's ``structure_info`` declares ``arg_style="xml"``. The XML body
-        # may be EMPTY (a no-argument tool), in which case the tag is just the
+        # ARG BODY, per the family's ``arg_style``: a JSON object (``%json`` over
+        # the whole schema) for the default JSON wire, a Qwen3-Coder XML
+        # per-parameter body for ``"xml"`` (E3), or the Gemma-4 comma-separated
+        # ``key:VALUE`` body for ``"gemma4"`` (E4). The XML/gemma4 body may be
+        # EMPTY (a no-argument tool), in which case the tag is just the
         # ``begin``/``end`` frame with no argument region.
-        if getattr(si, "arg_style", "json") == "xml":
+        arg_style = getattr(si, "arg_style", "json")
+        if arg_style == "xml":
             arg_body = _emit_xml_arg_body(params)
+        elif arg_style == "gemma4":
+            arg_body = _emit_gemma4_arg_body(params)
         else:
             arg_body = f"%json {json.dumps(params)}"
         # ``prefix_ref`` is empty on the forced-non-reasoning path (the first call
@@ -1620,7 +1919,8 @@ def build_tool_grammar(
     # and applies ONLY to ``arg_style != "json"`` tools — the JSON-body families
     # (hermes / qwen / harmony) are ``%json <schema>`` and stay byte-identical.
     for tool, si in zip(tools, structure_infos):
-        if getattr(si, "arg_style", "json") == "json":
+        arg_style = getattr(si, "arg_style", "json")
+        if arg_style == "json":
             continue
         # Resolve ``parameters`` EXACTLY as ``build_tool_lark`` does (a genuine
         # no-arg tool gets the closed default, which IS representable).
@@ -1632,10 +1932,19 @@ def build_tool_grammar(
                 "properties": {},
                 "additionalProperties": False,
             }
-        if not _xml_schema_representable(params):
+        # Same strict-allowlist guard, per-wire policy (E3 XML / E4 gemma4). An
+        # unknown non-json arg_style is treated conservatively (opt out).
+        if arg_style == "gemma4":
+            representable = _gemma4_schema_representable(params)
+        elif arg_style == "xml":
+            representable = _xml_schema_representable(params)
+        else:
+            representable = False
+        if not representable:
             logger.debug(
-                "tool-grammar: XML arg schema for tool %r not faithfully "
+                "tool-grammar: %s arg schema for tool %r not faithfully "
                 "representable; opting request out of grammar (free-form)",
+                arg_style,
                 tool.get("name"),
             )
             return None

--- a/vllm_mlx/api/tool_grammar.py
+++ b/vllm_mlx/api/tool_grammar.py
@@ -916,7 +916,15 @@ def _xml_property_representable(
     # consistency, and delimiter-safe wire values, so the enum axis is
     # complete-by-construction too.
     enum = resolved.get("enum")
-    if isinstance(enum, list) and enum:
+    if isinstance(enum, list):
+        if not enum:
+            # An EMPTY enum is UNSATISFIABLE under JSON Schema (no value validates).
+            # Falling through to the type-based path would compile an unrestricted
+            # value and ADMIT schema-invalid output (codex r6 #3). Opt out instead —
+            # faithful-or-opt-out. SHARED guard, so this also closes the latent same
+            # gap on the E3 XML wire; opting out only ever WIDENS the free-form
+            # fallback, so it cannot break a previously-valid grammar.
+            return False
         return _xml_enum_representable(resolved, enum, policy)
     prop_type = resolved.get("type")
     if not isinstance(prop_type, str):

--- a/vllm_mlx/api/tool_grammar.py
+++ b/vllm_mlx/api/tool_grammar.py
@@ -1101,43 +1101,67 @@ def _emit_gemma4_param_value(subschema: Any, defs: dict[str, Any]) -> str:
     return f"%json {json.dumps(value_schema)}"
 
 
-def _emit_gemma4_arg_body(params: Any) -> str:
+def _emit_gemma4_arg_body(params: Any, rule_prefix: str) -> tuple[str, str]:
     """Emit the Lark for a gemma4 arg body (the part BETWEEN ``{`` and ``}``).
 
+    Returns ``(inline_body, extra_rules)``: ``inline_body`` is spliced into the
+    ``tag_i`` rule (``""`` for a no-argument tool), and ``extra_rules`` is the block
+    of generated ``<rule_prefix>_rest<i>`` nonterminal definitions that ``inline_body``
+    references (the caller appends it to the grammar; ``""`` when none are needed).
+
     The gemma4 wire is ``call:NAME{k1:v1,k2:v2,...}`` where keys are emitted in
-    DICTSORT (alphabetical) order and separated by COMMAS
-    (``chat_template.jinja``'s ``found_first`` logic — a comma precedes every pair
-    except the FIRST PRESENT one). Required properties are mandatory; optional ones
-    may be omitted.
+    DICTSORT order and separated by COMMAS (``chat_template.jinja``'s ``found_first``
+    logic — a comma precedes every pair except the FIRST PRESENT one). Required
+    properties are mandatory; optional ones may be omitted.
 
     Because commas are SEPARATORS (not per-field terminators), a naive per-field
     ``( )?`` misplaces the comma when an early optional field is absent (it would
-    emit a leading ``,`` or a doubled ``,,``). We instead build a FIRST-PRESENT
-    construction:
+    emit a leading ``,`` or a doubled ``,,``). We build a FIRST-PRESENT construction
+    whose comma-prefixed SUFFIXES are SHARED via named nonterminals, so the grammar
+    is O(n)-size. (An earlier inline version regenerated the entire remaining suffix
+    for EVERY first-present alternative, making a request-controlled all-optional
+    schema O(n^2) in grammar size AND construction time — a mild DoS amplifier.)
 
-      * ``_cont(i)`` — every field from position ``i`` on, each with a LEADING
-        comma (required: ``"," k:v``; optional: ``( "," k:v )?``). Used AFTER the
-        first present field, so a comma always separates two present pairs.
+      * ``<rule_prefix>_rest<i>`` — a NAMED nonterminal for "fields ``i..n-1``, each
+        as a LEADING-comma continuation" (required: ``"," k:v``; optional:
+        ``( "," k:v )?``). ``rest_i`` ENDS in a reference to ``rest_{i+1}`` (right
+        recursion), so the whole suffix chain is ``n-1`` rules of O(1) size — NOT
+        O(n) inline text copied into each alternative. Used AFTER the first present
+        field, so a comma always separates two present pairs. The final field has an
+        empty tail, so there is no ``rest_n`` rule.
       * the body is an ALTERNATION over WHICH field is first-present: for each
         candidate first field ``j`` (reachable only if every earlier field is
         optional, i.e. ``j`` is at or before the first REQUIRED field) emit
-        ``kj:vj`` with NO leading comma, then ``_cont(j+1)``.
+        ``kj:vj`` with NO leading comma, then a REFERENCE to ``rest_{j+1}``. This
+        alternation is emitted ONCE (O(n) total), not per-suffix.
       * if EVERY field is optional the whole body is additionally ``( ... )?`` so
         an empty ``{}`` body (no args emitted) is admitted.
 
     The whole body is wrapped in a single ``( ... )`` group so an alternation binds
-    correctly when embedded as ``... "{" <body> "}" ...``. Returns ``""`` for a
+    correctly when embedded as ``... "{" <body> "}" ...``. Returns ``("", "")`` for a
     no-argument tool (empty/absent ``properties``) -> the caller renders the bare
     ``call:NAME{}`` frame.
+
+    The accepted LANGUAGE is IDENTICAL to the previous inline construction — any
+    subset of the optionals in dictsort order, required fields mandatory, no leading/
+    trailing/doubled comma, empty ``{}`` iff all-optional — only the grammar SIZE
+    drops from O(n^2) to O(n).
     """
     if not isinstance(params, dict):
-        return ""
+        return "", ""
     props = params.get("properties")
     if not isinstance(props, dict) or not props:
         # A no-argument tool: the EMPTY body IS the faithful constraint (forces a
         # ``{}`` call). Mirrors ``_emit_xml_arg_body`` — a truly-open object is
-        # already opted out upstream by ``_gemma4_schema_representable``.
-        return ""
+        # already opted out upstream by ``_gemma4_schema_representable``. This is a
+        # deliberate TOOL-CALLING-DOMAIN choice, consistent with the E3 XML path's
+        # identical decision (#1170): a tool whose ``parameters`` declares no
+        # properties takes NO arguments, so forcing ``call:NAME{}`` is the desired
+        # constraint. JSON-Schema's default-open-object semantics (an empty/omitted
+        # ``properties`` "permits arbitrary properties") are DELIBERATELY not applied
+        # on the wire — opting out here would make a no-arg tool LESS constrained
+        # (free-form body), the opposite of what tool-calling wants.
+        return "", ""
     required = params.get("required")
     # Only STRING members can name a property (mirrors the total guard in the
     # representability check); a non-str member is unhashable in a bare ``set``.
@@ -1147,45 +1171,56 @@ def _emit_gemma4_arg_body(params: Any) -> str:
         else set()
     )
     defs = _collect_xml_defs(params)
-    # DICTSORT order — matches how the chat template renders arguments, so a forced
-    # grammar constrains the model to the ordering it was trained to emit.
-    keys = sorted(props.keys())
+    # DICTSORT order — matches how the chat template renders arguments (``properties
+    # | dictsort``), so a forced grammar constrains the model to the ordering it was
+    # trained to emit. Jinja's ``dictsort`` defaults to ``case_sensitive=False``, so
+    # the sort key is the LOWERCASED key; Python's ``sorted`` is STABLE, so a
+    # case-insensitive collision (``a`` vs ``A``) keeps the schema's insertion order
+    # — EXACTLY the tiebreak ``dictsort`` uses. (A secondary case-sensitive sort would
+    # force ``A`` before ``a``, diverging from the model's actual emission order.)
+    keys = sorted(props.keys(), key=lambda k: k.lower())
     fields = [
         (key, _emit_gemma4_param_value(props[key], defs), key in required_set)
         for key in keys
     ]
+    n = len(fields)
 
     def _kv(idx: int, *, leading_comma: bool) -> str:
         key, value_lark, _ = fields[idx]
         kv = f"{_lark_escape(key + ':')} {value_lark}"
         return f'"," {kv}' if leading_comma else kv
 
-    def _cont(start: int) -> str:
-        parts: list[str] = []
-        for j in range(start, len(fields)):
-            frag = _kv(j, leading_comma=True)
-            parts.append(frag if fields[j][2] else f"( {frag} )?")
-        return " ".join(parts)
+    def _rest_ref(i: int) -> str:
+        # Reference to the suffix nonterminal for fields ``i..n-1``; empty past the
+        # last field (no ``rest_n`` rule exists).
+        return f"{rule_prefix}_rest{i}" if i < n else ""
 
-    # Index of the first REQUIRED field (or len(fields) if all optional): the
-    # first-present field can be any field at or before it (earlier fields, being
-    # optional, may be absent — a required field can never be skipped).
-    first_required = len(fields)
+    # Emit each comma-prefixed SUFFIX exactly ONCE as a named nonterminal, chained by
+    # right recursion (``rest_i -> elem_i rest_{i+1}``) for an O(n)-size grammar.
+    rest_rules: list[str] = []
+    for i in range(1, n):
+        frag = _kv(i, leading_comma=True)
+        elem = frag if fields[i][2] else f"( {frag} )?"
+        rest_rules.append(f"{rule_prefix}_rest{i}: {elem} {_rest_ref(i + 1)}".rstrip())
+
+    # Index of the first REQUIRED field (or ``n`` if all optional): the first-present
+    # field can be any field at or before it (earlier fields, being optional, may be
+    # absent — a required field can never be skipped).
+    first_required = n
     for j, (_key, _val, req) in enumerate(fields):
         if req:
             first_required = j
             break
 
     alts: list[str] = []
-    for j in range(min(first_required + 1, len(fields))):
+    for j in range(min(first_required + 1, n)):
         head = _kv(j, leading_comma=False)
-        tail = _cont(j + 1)
+        tail = _rest_ref(j + 1)
         alts.append(f"{head} {tail}" if tail else head)
     body = " | ".join(alts)
-    if first_required == len(fields):
-        # No required field -> the empty ``{}`` body is also valid.
-        return f"( {body} )?"
-    return f"( {body} )"
+    inline = f"( {body} )?" if first_required == n else f"( {body} )"
+    extra_rules = ("\n".join(rest_rules) + "\n") if rest_rules else ""
+    return inline, extra_rules
 
 
 def build_tool_lark(
@@ -1519,10 +1554,14 @@ def build_tool_lark(
         # EMPTY (a no-argument tool), in which case the tag is just the
         # ``begin``/``end`` frame with no argument region.
         arg_style = getattr(si, "arg_style", "json")
+        # ``gemma4_extra_rules`` collects the O(n) suffix nonterminals the gemma4 body
+        # references (empty for JSON/XML tags and for a no-arg gemma4 tool); appended
+        # to the grammar after the tag rule below.
+        gemma4_extra_rules = ""
         if arg_style == "xml":
             arg_body = _emit_xml_arg_body(params)
         elif arg_style == "gemma4":
-            arg_body = _emit_gemma4_arg_body(params)
+            arg_body, gemma4_extra_rules = _emit_gemma4_arg_body(params, f"g{i}")
         else:
             arg_body = f"%json {json.dumps(params)}"
         # ``prefix_ref`` is empty on the forced-non-reasoning path (the first call
@@ -1536,6 +1575,9 @@ def build_tool_lark(
         if end_body:
             lark += f" {end_body}"
         lark += "\n"
+        # Append the gemma4 body's generated suffix nonterminals (rule order is
+        # irrelevant in Lark; ``""`` when the tag emits none).
+        lark += gemma4_extra_rules
     return lark
 
 

--- a/vllm_mlx/tool_parsers/gemma4_tool_parser.py
+++ b/vllm_mlx/tool_parsers/gemma4_tool_parser.py
@@ -688,6 +688,79 @@ class Gemma4ToolParser(ToolParser):
 
     EXPECTED_WIRE_FORMATS = ("gemma4_native", "calling_tool_text")
 
+    # Grammar-CAPABLE (#558 E4): overrides ``structure_info`` below to emit the
+    # gemma4 native arg body (``arg_style="gemma4"``). The three wire markers are
+    # single special tokens on the target tokenizer (verified on
+    # ``mlx-community/gemma-4-e2b-it-4bit``): ``<|tool_call>`` (id 48),
+    # ``<tool_call|>`` (id 49), and the string-value marker ``<|"|>`` (id 52). The
+    # inner ``call:`` / ``{`` / ``}`` / ``,`` / ``KEY:`` framing is ordinary text,
+    # emitted as byte literals by the grammar builder.
+    _GRAMMAR_SENTINELS = ("<|tool_call>", "<tool_call|>", '<|"|>')
+
+    SUPPORTS_GRAMMAR: bool = True
+
+    # AUTO stays free-form (#558 E4). gemma4 routes reasoning through a channel
+    # grammar (``<|channel>thought\n...<channel|>``) whose ``<|channel>`` /
+    # ``<channel|>`` are SPECIAL tokens (ids 100/101); the #558 auto grammar's bare
+    # ``TAG_TEXT`` byte-regex free prefix cannot match a special token, so it would
+    # reject the model's pre-call reasoning at token 0 whenever it thinks first.
+    # gemma4's reasoning parser exposes no ``start_token``/``end_token``, so the
+    # reasoning-tolerant prefix (path A) is not wired for it either. The
+    # ``required``/named modes still build a grammar below (forced first call sits
+    # at the trigger — a forced tool call is exactly what those modes ask for).
+    TOOL_GRAMMAR_AUTO_SAFE: bool = False
+
+    def structure_info(self):
+        """Grammar-constraint wire triple for the gemma4 native tool call (#558 E4).
+
+        Extends #558 grammar constraint to the Gemma-4 wire. The model emits
+        (verified byte-for-byte against this model's ``chat_template.jinja``)::
+
+            <|tool_call>call:NAME{k1:<|"|>str<|"|>,k2:5,k3:true}<tool_call|>
+
+        The ARGUMENTS are a comma-separated ``key:VALUE`` body (NOT a JSON object),
+        so we return a ``StructureInfo`` with ``arg_style="gemma4"``: the builder
+        emits DICTSORT-ordered ``key:VALUE`` pairs, string values wrapped in the
+        ``<|"|>`` marker, bare scalars/booleans, ``%json`` objects/arrays, and an
+        alternation for enums (see ``tool_grammar._emit_gemma4_arg_body``). Those
+        surface forms are exactly what ``_scan_gemma4_tool_calls`` /
+        ``_Gemma4ArgumentParser`` round-trip back into JSON ``arguments``.
+
+        ``<|tool_call>`` / ``<tool_call|>`` / ``<|"|>`` are single special tokens
+        on the gemma4 tokenizer, declared as ``sentinels``; the trigger is
+        ``<|tool_call>`` (dedicated to tool calls — never emitted in plain prose,
+        so the forced grammar's trigger-first shape is sound). OPT OUT (return
+        ``None`` -> free-form fallback) unless the tokenizer proves all three are
+        single special tokens — a special-token sentinel on a tokenizer that splits
+        them into text would build an unenforceable grammar. Grammar constraint is
+        a best-effort opt-in, never a hard requirement.
+        """
+        from vllm_mlx.api.tool_grammar import (
+            StructureInfo,
+            are_single_special_tokens,
+        )
+
+        if not are_single_special_tokens(self.model_tokenizer, self._GRAMMAR_SENTINELS):
+            return None
+
+        def _info(name: str):
+            # The tool NAME is a bare identifier inside ``call:NAME{`` (NOT a JSON
+            # string — gemma4 does not quote it), emitted raw as a byte literal by
+            # the builder. ``begin`` starts with the ``<|tool_call>`` trigger
+            # (builder invariant); the ``{`` opens the arg body and the matching
+            # ``}`` closes it in ``end``.
+            begin = f"<|tool_call>call:{name}{{"
+            end = "}<tool_call|>"
+            return StructureInfo(
+                begin=begin,
+                end=end,
+                trigger="<|tool_call>",
+                sentinels=self._GRAMMAR_SENTINELS,
+                arg_style="gemma4",
+            )
+
+        return _info
+
     def __init__(self, tokenizer=None):
         super().__init__(tokenizer)
         self._emitted_tool_count = 0


### PR DESCRIPTION
## Why

Grammar-constrained tool-calling (#558) now covers the JSON-body families
(hermes/qwen/harmony) and the Qwen3-Coder XML wire (#1170, E3). **Gemma-4 is the
last of the four top families** and used a distinct native wire, so its tool
calls fell back to free-form-then-parse — the model could emit an off-schema
enum, a wrong-typed value, or a malformed call the parser then had to salvage.
This closes that gap for Gemma-4, making a schema-valid call true by
construction. Refs #558.

## The Gemma-4 native wire

```
<|tool_call>call:FUNC_NAME{key1:<|"|>strval<|"|>,key2:numval}<tool_call|>
```

`<|tool_call>` (id 48), `<tool_call|>` (id 49), and the string-quote `<|"|>`
(id 52) are each a single special token on `gemma-4-e2b-it-4bit` (verified).
String values are wrapped in `<|"|>`; numbers/bools are bare; keys are
`dictsort`-ordered, comma-separated.

## The key construct — greedy, NOT `[lazy]` (structural difference from E3)

E3's string terminator `</parameter>` is byte text, so it needs llguidance's
`[lazy]` lexeme. Gemma-4's terminator `<|"|>` is a **special token**, and the
two `[lazy]` forms both fail: a special-token ref cannot appear inside a lexer
terminal, and a byte-literal `"<|\"|>"` cannot be satisfied by the atomic token
52. The correct construct is a plain **greedy rule with rule-level special
refs**:

```
gemma_str_value: <|"|> GEMMA_STR_TEXT <|"|>
```

Because `<|"|>` is a special token, a greedy byte regex physically cannot
consume it, so maximal-munch stops at the boundary on its own — no `[lazy]`
needed. Verified on the real tokenizer: values containing `<`, `>`, `{`, `}`,
`,`, quotes, and newlines are all accepted, terminal, and round-trip exactly.

## How

- `build_tool_lark` gains an `arg_style="gemma4"` dispatch → `_emit_gemma4_arg_body`.
  Body = dictsort-ordered comma-separated `key:VALUE`; because commas are
  *separators*, optionals use a first-present construction so an absent early
  optional never misplaces a comma (verified: every subset accepted;
  leading-comma rejected). String → the greedy `<|"|>` rule; enum → per-value
  `<|"|>`-wrapped alternation (handles mixed-type enums); int/number/bool and
  object/array → `%json`.
- The E3 strict-allowlist representability guard is **reused** via a shared
  `_ArgWirePolicy`: the structural allowlist is identical; only two wire-specific
  leaf checks differ (gemma4 keys are bare `\w+`; the only wire-unsafe enum byte
  is the `<|"|>` marker, so `<`/`>`/newlines are allowed in gemma4 values, unlike
  XML). This inherits all 4 rounds of E3's codex hardening rather than
  re-deriving a weaker guard.
- `gemma4_tool_parser`: `SUPPORTS_GRAMMAR=True`, `structure_info()`
  (begin=`<|tool_call>call:NAME{`, end=`}<tool_call|>`, trigger=`<|tool_call>`,
  all three markers as sentinels; opts out unless all are single special
  tokens), and `TOOL_GRAMMAR_AUTO_SAFE=False`.
- JSON-body families are kept **byte-identical** (regression-tested).

## Evidence

- `tests/test_gemma4_grammar_558.py` → **50 passed, 0 skipped** (real-tokenizer
  `LLMatcher` enforcement + round-trip on `gemma-4-e2b-it-4bit` RAN, not skipped).
- Broader `-k "tool_grammar or 558 or gemma4 or structure_info"` → **622 passed,
  19 skipped, 1 xfailed** — E3 + hermes/qwen structure_info clean (the shared
  `_ArgWirePolicy` refactor introduced no regression).
- `ruff check` + `ruff format --check` → clean.

## Honest limitations (follow-ups, all safe)

- **AUTO opts out** (`TOOL_GRAMMAR_AUTO_SAFE=False`): Gemma-4 emits a
  `<|channel>…<channel|>` reasoning block whose special-token markers a byte
  free-prefix can't match, and the gemma4 reasoning parser exposes no
  start/end token to wire path-A tolerance. `required`/named tool_choice are
  fully constrained; `auto` falls back to free-form. Follow-up: register the
  channel markers as reasoning_sentinels (parallels the existing forced+reasoning
  follow-up).
- **object/array args go through `%json`** (standard JSON `{"x":3}`), not
  gemma's native bare-key form (`{x:3}`). The parser round-trips it (verified
  end-to-end), so correctness holds; a faithful recursive gemma-object grammar
  is a possible follow-up. Scalars/strings/bools/enums (the common case) are
  fully native.
- Feasibility, enforcement, and round-trip are proven on the real tokenizer via
  `LLMatcher`; live decode-quality under the mask is unmeasured (standard for
  these grammar PRs pre-merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
