### PR TITLE
revert: test(batching): remove flaky throughput checks

### DIFF
--- a/tests/test_batching_deterministic.py
+++ b/tests/test_batching_deterministic.py
@@ -7,6 +7,7 @@ Run with: pytest tests/test_batching_deterministic.py -v
 """
 
 import asyncio
+import time
 
 import pytest
 
@@ -15,7 +16,12 @@ TEST_MODEL = "mlx-community/Llama-3.2-1B-Instruct-4bit"
 
 
 async def _warmup_engine(engine, sampling_params) -> None:
-    """Pay the Metal kernel JIT before concurrent determinism checks."""
+    """Pay the Metal kernel JIT + first-inference cost outside the timed
+    region so concurrent-request tests aren't racing against cold
+    compilation. Without this, the first 1–2 requests hit slow JIT paths
+    while later requests hit hot kernels — and on temp=0 greedy decoding
+    that scheduling skew can flip a single token, breaking determinism
+    asserts on overloaded CI runners."""
     rid = await engine.add_request("warmup:", sampling_params)
     async for out in engine.stream_outputs(rid, timeout=30):
         if out.finished:
@@ -269,6 +275,110 @@ class TestDeterministicConcurrentRequests:
         # Each run should produce same results
         assert all_results[0] == all_results[1], (
             f"Results differ between runs: {all_results}"
+        )
+
+
+class TestBatchingPerformance:
+    """Test that batching improves throughput."""
+
+    @pytest.mark.asyncio
+    async def test_batched_faster_than_sequential(
+        self, model_and_tokenizer, mlx_executor
+    ):
+        """Batched requests should not be catastrophically slower than sequential.
+
+        This is a regression guard, not a perf benchmark. The threshold
+        is loose (0.7x) on purpose — real batching wins are 2-3x but
+        the workload here is tiny (40 tokens × 2 runs) so engine
+        startup overhead and Metal kernel JIT swamp the signal. A
+        warmup pass per-engine eliminates the cold/warm asymmetry that
+        used to make this test flake under any concurrent system load.
+        Catastrophic regressions (sequential outperforming batched by
+        more than 30%) still fire.
+        """
+        from vllm_mlx import (
+            AsyncEngineCore,
+            EngineConfig,
+            SamplingParams,
+            SchedulerConfig,
+        )
+
+        model, tokenizer = model_and_tokenizer
+        config = EngineConfig(
+            scheduler_config=SchedulerConfig(
+                max_num_seqs=8,
+                prefill_batch_size=4,
+                completion_batch_size=8,
+            )
+        )
+
+        params = SamplingParams(max_tokens=10, temperature=0.0)
+        prompts = [f"Count to {i}:" for i in range(1, 5)]
+
+        async def run_sequential():
+            """Run requests one at a time (after warmup)."""
+            total_tokens = 0
+            async with AsyncEngineCore(
+                model, tokenizer, config, executor=mlx_executor
+            ) as engine:
+                await asyncio.sleep(0.05)
+                await _warmup_engine(engine, params)
+
+                for prompt in prompts:
+                    rid = await engine.add_request(prompt, params)
+                    async for out in engine.stream_outputs(rid, timeout=30):
+                        if out.finished:
+                            total_tokens += out.completion_tokens
+                            break
+            return total_tokens
+
+        async def run_batched():
+            """Run requests concurrently (after warmup)."""
+            async with AsyncEngineCore(
+                model, tokenizer, config, executor=mlx_executor
+            ) as engine:
+                await asyncio.sleep(0.05)
+                await _warmup_engine(engine, params)
+
+                request_ids = []
+                for prompt in prompts:
+                    rid = await engine.add_request(prompt, params)
+                    request_ids.append(rid)
+
+                async def get_output(rid):
+                    async for out in engine.stream_outputs(rid, timeout=30):
+                        if out.finished:
+                            return out.completion_tokens
+                    return 0
+
+                tokens = await asyncio.gather(*[get_output(r) for r in request_ids])
+                return sum(tokens)
+
+        # Time sequential
+        start = time.perf_counter()
+        seq_tokens = await run_sequential()
+        seq_time = time.perf_counter() - start
+
+        # Time batched
+        start = time.perf_counter()
+        batch_tokens = await run_batched()
+        batch_time = time.perf_counter() - start
+
+        seq_throughput = seq_tokens / seq_time
+        batch_throughput = batch_tokens / batch_time
+
+        print(f"\nSequential: {seq_throughput:.1f} tok/s")
+        print(f"Batched: {batch_throughput:.1f} tok/s")
+        print(f"Speedup: {batch_throughput / seq_throughput:.2f}x")
+
+        # Catastrophic-regression guard. Real batching wins are 2-3x;
+        # 0.7x leaves headroom for the inherent noise of a 40-token
+        # workload while still catching a fundamental break.
+        assert batch_throughput > seq_throughput * 0.7, (
+            f"Batched ({batch_throughput:.1f} tok/s) regressed badly "
+            f"vs sequential ({seq_throughput:.1f} tok/s) — speedup "
+            f"{batch_throughput / seq_throughput:.2f}x is below the "
+            f"0.7x catastrophic-regression floor"
         )
 
 

--- a/tests/test_continuous_batching.py
+++ b/tests/test_continuous_batching.py
@@ -1,10 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 """
-Tests for continuous batching behavior.
+Tests for continuous batching performance.
 
-These tests verify that continuous batching properly handles multiple
-concurrent requests. The standalone runner below remains the place for
-hardware-dependent throughput measurement.
+These tests verify that continuous batching properly handles
+multiple concurrent requests with improved throughput.
 """
 
 import asyncio
@@ -155,6 +154,107 @@ class TestContinuousBatchingIntegration:
             assert all(r is not None for r in results)
             assert all(r.finished for r in results)
             assert all(r.completion_tokens > 0 for r in results)
+
+    async def test_batching_improves_throughput(self, small_model):
+        """Batched throughput must clearly beat sequential.
+
+        Relative comparison rather than an absolute tok/s threshold —
+        absolute numbers vary 6× run-to-run on the same machine
+        (382-697 tok/s observed) due to GPU contention from the rest
+        of the suite, so a hardcoded floor is inherently flaky. Same
+        prompts, same model, same engine: the only thing that changes
+        between the two phases is concurrent vs serial dispatch, so
+        the speedup directly measures batching's benefit.
+        """
+        from vllm_mlx import (
+            AsyncEngineCore,
+            EngineConfig,
+            SamplingParams,
+            SchedulerConfig,
+        )
+
+        model, tokenizer = small_model
+        config = EngineConfig(
+            model_name="test",
+            scheduler_config=SchedulerConfig(
+                max_num_seqs=32,
+                prefill_batch_size=8,
+                completion_batch_size=16,
+            ),
+        )
+
+        prompts = [
+            "What is 2+2?",
+            "Name 3 colors.",
+            "What is Python?",
+            "Capital of Japan?",
+            "Who wrote Hamlet?",
+        ]
+        params = SamplingParams(max_tokens=30, temperature=0.0)
+
+        def _format(p: str) -> str:
+            return tokenizer.apply_chat_template(
+                [{"role": "user", "content": p}],
+                tokenize=False,
+                add_generation_prompt=True,
+            )
+
+        async with AsyncEngineCore(model, tokenizer, config) as engine:
+            await asyncio.sleep(0.1)
+
+            async def _await_one(rid):
+                async for out in engine.stream_outputs(rid, timeout=60):
+                    if out.finished:
+                        return out.completion_tokens
+                return 0
+
+            # Warmup: first request through a fresh engine pays for
+            # initial cache allocation + Metal kernel JIT. Don't
+            # measure it.
+            warm_rid = await engine.add_request(_format(prompts[0]), params)
+            await _await_one(warm_rid)
+
+            # Sequential — one at a time, await each before sending the next
+            seq_start = time.perf_counter()
+            seq_results: list[int] = []
+            for p in prompts:
+                rid = await engine.add_request(_format(p), params)
+                seq_results.append(await _await_one(rid))
+            seq_time = time.perf_counter() - seq_start
+            seq_total = sum(seq_results)
+            seq_throughput = seq_total / seq_time
+
+            # Batch — submit all then await concurrently
+            batch_start = time.perf_counter()
+            request_ids = [
+                await engine.add_request(_format(p), params) for p in prompts
+            ]
+            batch_results = await asyncio.gather(*[_await_one(r) for r in request_ids])
+            batch_time = time.perf_counter() - batch_start
+            batch_total = sum(batch_results)
+            batch_throughput = batch_total / batch_time
+
+            speedup = batch_throughput / seq_throughput
+            print(
+                f"\nSequential: {seq_total} tok in {seq_time:.2f}s = "
+                f"{seq_throughput:.1f} tok/s"
+            )
+            print(
+                f"Batch:      {batch_total} tok in {batch_time:.2f}s = "
+                f"{batch_throughput:.1f} tok/s"
+            )
+            print(f"Speedup:    {speedup:.2f}x")
+
+            # Sanity: every request must produce some output
+            assert all(t > 0 for t in seq_results), seq_results
+            assert all(t > 0 for t in batch_results), batch_results
+            # Batching should clearly beat sequential — 1.5x is well
+            # below the typical 2-3x observed on small models, so this
+            # only fires if batching is genuinely broken.
+            assert speedup > 1.5, (
+                f"batch={batch_throughput:.1f} not >1.5x of "
+                f"sequential={seq_throughput:.1f} (speedup={speedup:.2f}x)"
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Reverts #1168 exactly, restoring the two batching throughput tests it deleted.
- Leaves runtime code unchanged.

## Why
The merged PR deleted existing tests, while the requested correction is to retain them. This revert restores both tests because they remain valuable coverage; their timing-based nature should be handled separately rather than by removing them.

## Validation
- Ruff format and lint passed.
- The non-timing batching tests passed: 13 passed, 2 deselected, 1 xpassed.