### PR TITLE
feat(cli): add `update` as an alias for `upgrade`

### DIFF
--- a/tests/test_telemetry_emit.py
+++ b/tests/test_telemetry_emit.py
@@ -189,6 +189,22 @@ def test_subcommand_normalized_to_allowlist(opted_in, stub_queue):
     assert "alice" not in repr(stub_queue[-1])
 
 
+def test_subcommand_aliases_canonicalize(opted_in, stub_queue):
+    """CLI ``aliases=`` (argparse reports the typed name) roll into the
+    primary command so ``rapid-mlx run``/``update`` count with
+    ``chat``/``upgrade`` instead of redacting to ``"other"``."""
+    from vllm_mlx.telemetry import emit
+
+    emit.session_start(subcommand="run")  # alias of `chat`
+    assert stub_queue[-1]["session"]["subcommand"] == "chat"
+
+    emit.session_start(subcommand="update")  # alias of `upgrade`
+    assert stub_queue[-1]["session"]["subcommand"] == "upgrade"
+
+    emit.session_end(subcommand="update", duration_seconds=3)
+    assert stub_queue[-1]["session"]["subcommand"] == "upgrade"
+
+
 def test_runtime_payload_carries_every_schema_v1_field(opted_in, stub_queue):
     """Round 8 codex review: ``SCHEMA_VERSION == 1`` means the runtime
     payload must include EVERY key the dataclass

--- a/tests/test_upgrade_cli.py
+++ b/tests/test_upgrade_cli.py
@@ -87,3 +87,43 @@ def test_dry_run_returns_silently_when_already_up_to_date(monkeypatch, capsys):
     out = capsys.readouterr().out
     assert "Already up to date" in out
     assert "dry-run" not in out  # no point printing dry-run if there's nothing to do
+
+
+# ---------------------------------------------------------------------------
+# `update` alias — muscle-memory parity with npm/brew/claude/rustup.
+# Exercised via the real argparse (subprocess `--help`) so we pin that the
+# alias is registered AND accepts the same flags, without importing the giant
+# CLI module in-process (which would drag in torch/mlx-vlm). Mirrors the
+# `_serve_help_stdout` pattern in test_mtp_cli_wiring.py.
+# ---------------------------------------------------------------------------
+
+
+def _cli_help_stdout(*argv: str):
+    import subprocess
+    import sys
+
+    return subprocess.run(
+        [sys.executable, "-m", "vllm_mlx.cli", *argv],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+
+
+def test_update_alias_is_registered_and_routes_to_upgrade():
+    """`rapid-mlx update --help` exits 0 (alias registered) and its help is
+    the upgrade help — an unregistered subcommand would exit 2 instead."""
+    proc = _cli_help_stdout("update", "--help")
+    assert proc.returncode == 0, proc.stderr
+    # --help of the alias renders the upgrade parser: same flags, same
+    # description note pointing back at `upgrade`. Collapse whitespace
+    # first — argparse hard-wraps the description to terminal width.
+    normalized = " ".join(proc.stdout.split())
+    assert "--dry-run" in normalized
+    assert "'rapid-mlx update' is an alias for 'upgrade'" in normalized
+
+
+def test_update_alias_accepts_upgrade_flags():
+    """The alias shares the parser, so `-y`/`--dry-run` parse identically."""
+    proc = _cli_help_stdout("update", "-y", "--dry-run", "--help")
+    assert proc.returncode == 0, proc.stderr

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -7706,9 +7706,19 @@ Examples:
     subparsers.add_parser("ps", help="List running rapid-mlx servers")
 
     # Upgrade — detect install method and run the right upgrade command
+    # ``update`` is exposed as a subparser alias purely for muscle-memory
+    # parity (``npm update`` / ``brew update`` / ``claude update`` /
+    # ``rustup update`` all spell it "update"); both names route to
+    # ``upgrade_command``. argparse reports the user-typed name on
+    # ``args.command``, so the dispatch below matches both.
     upgrade_parser = subparsers.add_parser(
         "upgrade",
+        aliases=["update"],
         help="Upgrade rapid-mlx to the latest version (brew / pip / install.sh)",
+        description=(
+            "Upgrade rapid-mlx to the latest version.\n\n"
+            "Note: 'rapid-mlx update' is an alias for 'upgrade'."
+        ),
     )
     upgrade_parser.add_argument(
         "-y",
@@ -8363,7 +8373,10 @@ Examples:
         rm_command(args)
     elif args.command == "ps":
         ps_command(args)
-    elif args.command == "upgrade":
+    elif args.command in ("upgrade", "update"):
+        # ``update`` is exposed as a subparser alias for muscle-memory
+        # parity; argparse routes via ``aliases=`` but reports the
+        # user-typed name on ``args.command``. Both names land here.
         upgrade_command(args)
     elif args.command in ("chat", "run"):
         # ``run`` is exposed as a subparser alias for Ollama compatibility;

--- a/vllm_mlx/telemetry/emit.py
+++ b/vllm_mlx/telemetry/emit.py
@@ -124,10 +124,21 @@ _ALLOWED_SUBCOMMANDS: frozenset[str] = frozenset(
 )
 
 
+# CLI subcommand aliases (argparse ``aliases=``) canonicalize to their
+# primary name so telemetry rolls ``rapid-mlx run`` into ``chat`` and
+# ``rapid-mlx update`` into ``upgrade`` instead of redacting them to
+# "other". Keep in sync with the ``aliases=`` lists in cli.py.
+_SUBCOMMAND_ALIASES: dict[str, str] = {
+    "run": "chat",
+    "update": "upgrade",
+}
+
+
 def _normalize_subcommand(raw: str) -> str:
     if not isinstance(raw, str):
         return "other"
-    return raw if raw in _ALLOWED_SUBCOMMANDS else "other"
+    canonical = _SUBCOMMAND_ALIASES.get(raw, raw)
+    return canonical if canonical in _ALLOWED_SUBCOMMANDS else "other"
 
 
 def get_queue() -> TelemetryQueue:


### PR DESCRIPTION
## Why

Users reach for `rapid-mlx update` from muscle memory — every neighbouring tool spells the self-update verb "update" (`npm update`, `brew update`, `rustup update`, `claude update`) — and today they hit `invalid choice: 'update'` because our subcommand is named `upgrade`. This closes that gap **because** the fix is a zero-risk argparse alias, exactly like the existing `run`→`chat` Ollama-parity alias.

## What

`rapid-mlx upgrade` self-updates the install (brew / pip / install.sh). This exposes `update` as an argparse **alias** of `upgrade`.

```
$ rapid-mlx update --help
usage: rapid-mlx upgrade [-h] [-y] [--dry-run]

Upgrade rapid-mlx to the latest version. Note: 'rapid-mlx update' is an alias for 'upgrade'.
```

## Changes

- `vllm_mlx/cli.py`: `aliases=["update"]` on the `upgrade` subparser; dispatch matches `args.command in ("upgrade", "update")` (argparse reports the user-typed name).
- `vllm_mlx/telemetry/emit.py`: canonicalize CLI aliases before the subcommand allowlist so `update` rolls into `upgrade` — and, fixing a **latent gap**, `run` rolls into `chat` — instead of being redacted to `"other"`.

## Tests

- `test_upgrade_cli.py`: `update --help` routes to the upgrade parser with the same flags (subprocess `--help`, no network).
- `test_telemetry_emit.py`: alias canonicalization (`run`→`chat`, `update`→`upgrade`) for both `session_start` and `session_end`.

150 passed across the touched surface (cli + telemetry + version-check). No version bump. Codex review (local): 0 blocking / 0 major / 0 minor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)