### PR TITLE
chore: bump version to 0.10.16

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.10.15"
+version = "0.10.16"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## chore: bump version to 0.10.16

Release-cutting bump (0.10.15 → 0.10.16). Dedicated version-only PR so `auto-release.yml`
fires (its regex matches the `chore: bump version to X.Y.Z` subject); no other files change.

### Why now
The `origin/main` accumulation since `v0.10.15` (23 commits) is release-worthy — headlined by
the **#558 constrained tool-calling** arc reaching the top-tier model families. Cutting a
release makes it installable via `pip install rapid-mlx==0.10.16` + Homebrew.

### Headline — #558 grammar-constrained tool-calling (default-on, schema-guaranteed)
- **Qwen3-Coder XML wire (E3, #1170)** — `<parameter=k>v</parameter>` constrained via a
  strict-allowlist representability guard + the `[lazy]` delimiter idiom; real-tokenizer
  LLMatcher enforcement + JSON-family byte-identical regression.
- **Gemma-4 native wire (E4, #1171)** — `call:NAME{k:<|"|>v<|"|>}` constrained; the dual-nature
  `<|"|>` delimiter handled with llguidance's native And/Not "does not contain substring"
  construct; anchored to the model's real `chat_template` (rendered wire is byte-identical to
  the constrained format) and live-dogfooded (`tool_choice=required` returns schema-valid,
  enum-constrained arguments).
- **gpt-oss / harmony (#1153)** — grammar-constrained tool-calling for the harmony channel wire.
- **forced non-reasoning fix (#1164)** — forced tool-grammar starts at the trigger (closes the
  hermes/qwen forced empty-`{}` leak).
- **compiled-grammar cache + startup warmup (#1155)** — removes the per-schema cold-compile
  from the decode-setup path.
- **oversized-schema gate (#1149)** — 400 gated on parser grammar-capability; non-grammar
  parsers fall back to free-form.

Three of the four top-tier families (gpt-oss + Qwen + Gemma-4) now have their distinct
tool-call wire grammar-constrained.

### Also in this release
- **CLI**: `update` as an alias for `upgrade` (#1173); doctor version-freshness + shadowed-install
  checks (#1158).
- **Middleware**: request logging (#1167).
- **Fixes**: gemma-4 vision on Homebrew — honest runtime detection + config-authoritative MLLM
  routing (#1130); rate-limit IPv4-mapped IPv6 unwrap (#1165); auto-enable hybrid prefix cache
  (#1163); hermes `--setup` config (#1159); list-of-blocks system-content normalization (#1148).
- **Infra/docs**: Homebrew migrated to `homebrew/core` (#1151); desktop-sidecar removal (#1166);
  SECURITY.md + signed installer checksums (#1152); README declutter + badges.

### Verification
`full_unit` 13467 passed on `origin/main`; E3/E4 real-tokenizer LLMatcher enforcement green;
fresh-venv live dogfood of the merged main (gemma-4-12B-it-4bit on real hardware) returned a
schema-valid, enum-constrained tool call. No functional diff in this PR — version string only.
