### PR TITLE
fix: gemma-4 tool_choice=required emits a single call and terminates (0.10.16 dogfood P1-①)

### DIFF
--- a/tests/test_grammar_processor_558.py
+++ b/tests/test_grammar_processor_558.py
@@ -1688,6 +1688,125 @@ def test_processor_negative_controls_over_prompt(tok, hermes_grammar, lltok):
     ), "invalid enum value was NOT blocked"
 
 
+def _row_after_full_call(proc, lltok, tok, prompt_ids, gen_text):
+    """Baseline over ``prompt_ids``, feed a full valid call, and return the
+    masked-logits row at the (accepting) state that follows the last token."""
+    import mlx.core as mx
+    import numpy as np
+
+    vocab = lltok.vocab_size
+    gen_ids = tok.encode(gen_text, add_special_tokens=False)
+    cumulative = list(prompt_ids)
+    proc(mx.array(cumulative), mx.zeros((1, vocab)))  # first call = prompt baseline
+    cumulative.extend(gen_ids)
+    masked = proc(mx.array(cumulative), mx.zeros((1, vocab)))
+    return np.array(masked[0])
+
+
+def _is_allowed(row, tid):
+    import math
+
+    v = float(row[tid])
+    return math.isfinite(v) and v > -1e30
+
+
+@_requires_llguidance
+def test_stop_token_readmitted_only_at_accepting_state(tok, hermes_grammar, lltok):
+    """0.10.16 dogfood P1-①: a forced ``required`` grammar must let the model
+    TERMINATE after one call. The mechanism is the Gemma-4 failure in miniature:
+    a model whose learned turn-terminator is a special token that is neither the
+    grammar's single EOS nor a grammar literal is masked out at the accepting
+    state, so under ``(tag)+`` it can only ever emit ANOTHER call — an infinite
+    loop. ``GrammarLogitsProcessor`` now re-admits the model's stop tokens when —
+    and ONLY when — the matcher ``is_accepting()``, so the model can stop like
+    Qwen/gpt-oss already do.
+
+    We use ``<|im_start|>`` as the stand-in stop token: a real special token on
+    this tokenizer that is NOT part of the hermes tool grammar and NOT the
+    grammar EOS (``<|im_end|>``), so the byte-regex ``TAG_TEXT`` tail can never
+    match it. It is therefore masked at EVERY grammar state unless our
+    re-admission fires."""
+    import mlx.core as mx
+    import numpy as np
+
+    from vllm_mlx.api.tool_grammar import GrammarLogitsProcessor
+
+    stop_id = tok.convert_tokens_to_ids("<|im_start|>")
+    assert isinstance(stop_id, int) and stop_id >= 0, (
+        "expected <|im_start|> to be a single special token id on this tokenizer"
+    )
+    eos_id = tok.convert_tokens_to_ids("<|im_end|>")
+
+    prompt_ids = tok.encode("Weather please.", add_special_tokens=False)
+    call = '<tool_call>\n{"name": "get_weather", "arguments": {"city": "Paris"}}\n</tool_call>'
+
+    # (1) WITH the stop id re-admitted: masked BEFORE the call (start state is
+    # NON-accepting for required ``+``), un-masked AFTER a complete call.
+    proc = GrammarLogitsProcessor(
+        lltok, hermes_grammar, tokenizer=tok, stop_token_ids=[stop_id]
+    )
+    start_row = np.array(
+        proc(mx.array(list(prompt_ids)), mx.zeros((1, lltok.vocab_size)))[0]
+    )
+    assert not _is_allowed(start_row, stop_id), (
+        "stop token was re-admitted BEFORE the mandatory first call — the "
+        "is_accepting gate is broken and required's force-≥1 guarantee is lost"
+    )
+    # The trigger IS forced open at the start (proves the grammar is live here).
+    trigger_id = tok.convert_tokens_to_ids("<tool_call>")
+    if isinstance(trigger_id, int) and trigger_id >= 0:
+        assert _is_allowed(start_row, trigger_id), "forced trigger was masked at start"
+
+    end_row = _row_after_full_call(proc, lltok, tok, prompt_ids, call)
+    assert _is_allowed(end_row, stop_id), (
+        "stop token was NOT re-admitted after a complete call — a Gemma-4-style "
+        "model could never terminate and would loop the same call forever"
+    )
+
+    # (2) CONTROL: identical processor WITHOUT stop_token_ids keeps the special
+    # token masked at the same accepting state — proving the re-admission (not
+    # the grammar itself) is what un-masks it, and that we did not widen the
+    # grammar's own accepted language.
+    proc_no_stop = GrammarLogitsProcessor(lltok, hermes_grammar, tokenizer=tok)
+    end_row_ctrl = _row_after_full_call(proc_no_stop, lltok, tok, prompt_ids, call)
+    assert not _is_allowed(end_row_ctrl, stop_id), (
+        "special token was allowed at the accepting state WITHOUT re-admission — "
+        "the grammar language changed unexpectedly"
+    )
+    # The grammar EOS is (and stays) allowed at the accepting state either way —
+    # this is exactly why Qwen/gpt-oss already terminate and are not regressed.
+    if isinstance(eos_id, int) and eos_id >= 0:
+        assert _is_allowed(end_row_ctrl, eos_id), (
+            "grammar EOS was not allowed at the accepting state — baseline "
+            "termination for eos==grammar-eos families regressed"
+        )
+
+
+def test_model_stop_token_ids_unions_all_surfaces():
+    """The helper unions every eos surface the scheduler halts on (0.10.16
+    P1-①), so the processor re-admits EXACTLY the ids that end generation."""
+    from vllm_mlx.api.tool_grammar import model_stop_token_ids
+
+    class _Tok:
+        _eos_token_ids = {1, 106}
+        eos_token_id = [1, 50]
+        eos_token_ids = (106,)
+        _rapid_extra_eos_token_ids = (50, 999)
+
+    assert model_stop_token_ids(_Tok()) == (1, 50, 106, 999)
+    assert model_stop_token_ids(None) == ()
+
+    class _Singular:
+        eos_token_id = 2
+
+    assert model_stop_token_ids(_Singular()) == (2,)
+
+    class _Empty:
+        pass
+
+    assert model_stop_token_ids(_Empty()) == ()
+
+
 @_requires_llguidance
 def test_named_grammar_constrains_to_single_tool(tok, lltok):
     # A NAMED choice narrows to one tool. Building the grammar over a

--- a/vllm_mlx/api/tool_grammar.py
+++ b/vllm_mlx/api/tool_grammar.py
@@ -2168,6 +2168,46 @@ def build_tool_grammar(
     return _compile_lark_cached(lark)
 
 
+def model_stop_token_ids(tokenizer: Any) -> tuple[int, ...]:
+    """Collect the model's stop/eos token ids from a tokenizer (0.10.16 P1-①).
+
+    Unions the same surfaces the scheduler's ``_get_stop_tokens`` reads so the
+    ``GrammarLogitsProcessor`` re-admits EXACTLY the ids that will actually halt
+    generation:
+
+      * ``_eos_token_ids`` — mlx-lm ``TokenizerWrapper``'s curated set, grown at
+        load by ``augment_eos_token_ids_from_generation_config`` to include the
+        chat-template terminators declared in ``generation_config.json``'s
+        ``eos_token_id`` list (Gemma-4 ``<turn|>`` id 106 / ``<|tool_response>``
+        id 50, Qwen3 ``<|endoftext|>``, Llama-3 ``<|eot_id|>``, …).
+      * ``eos_token_id`` — the singular HF surface (int or list).
+      * ``eos_token_ids`` — the plural processor surface.
+      * the Rapid-MLX extras stash (``_rapid_extra_eos_token_ids``) for raw HF
+        tokenizers whose ``eos_token_ids`` property rejects assignment.
+
+    Returns a sorted tuple (possibly empty — the processor then behaves exactly
+    as before this change)."""
+    ids: set[int] = set()
+    if tokenizer is None:
+        return ()
+    wrapper_ids = getattr(tokenizer, "_eos_token_ids", None)
+    if wrapper_ids:
+        ids.update(int(t) for t in wrapper_ids)
+    single = getattr(tokenizer, "eos_token_id", None)
+    if single is not None:
+        if isinstance(single, (list, set, tuple)):
+            ids.update(int(t) for t in single)
+        else:
+            ids.add(int(single))
+    plural = getattr(tokenizer, "eos_token_ids", None)
+    if plural is not None and isinstance(plural, (list, set, tuple)):
+        ids.update(int(t) for t in plural)
+    extras = getattr(tokenizer, "_rapid_extra_eos_token_ids", None)
+    if extras:
+        ids.update(int(t) for t in extras)
+    return tuple(sorted(ids))
+
+
 # --------------------------------------------------------------------------
 # Runtime logits processor (design §3.3 / §5). Mirrors the
 # ``MiniMaxToolLogitsProcessor.__call__(token_ids, logits)`` signature the
@@ -2205,6 +2245,7 @@ class GrammarLogitsProcessor:
         *,
         reasoning_end_token: str | None = None,
         tokenizer: Any = None,
+        stop_token_ids: Any = None,
     ):
         self._lltok = lltokenizer
         # Reuse a cached compiled-grammar TEMPLATE (deep-copied per request) so
@@ -2229,6 +2270,37 @@ class GrammarLogitsProcessor:
         self._reasoning_end_token = reasoning_end_token
         self._reasoning_ended = reasoning_end_token is None
         self._tokenizer = tokenizer
+        # MODEL STOP/EOS tokens re-admitted at accepting states (0.10.16 dogfood
+        # P1-①). llguidance's compiled grammar terminates on the tokenizer's
+        # SINGLE ``eos_token``. That is correct for families whose learned turn-
+        # terminator IS that token (Qwen ``<|im_end|>`` == tokenizer eos) or is
+        # the tool-call ``end`` literal the grammar already consumes (gpt-oss
+        # harmony ``<|call|>`` is one of ``generation_config.eos_token_id``). It
+        # BREAKS Gemma-4: the model ends a tool-call turn with ``<turn|>`` (id
+        # 106) or ``<|tool_response>`` (id 50) — special tokens the grammar's
+        # ``TAG_TEXT: /(.|\n)*/`` byte-regex tail CANNOT match, and which are NOT
+        # the tokenizer eos ``<eos>`` (id 1) llguidance treats as the grammar
+        # terminator. So after ONE complete call every one of the model's real
+        # turn-terminators is masked; under the ``required``/named ``(tag)+``
+        # grammar the only unmasked structural continuation is another
+        # ``<|tool_call>`` and the model emits the identical call forever (never
+        # reaching ``finish_reason="tool_calls"`` without a ``max_tokens`` cap).
+        # We therefore re-admit the model's stop tokens WHENEVER the matcher is
+        # in an ACCEPTING state (grammar structurally complete → a call already
+        # emitted for ``required``, or zero-or-more satisfied for ``auto``), so
+        # the model can stop naturally — exactly how Qwen/gpt-oss already do. The
+        # ``is_accepting`` gate preserves ``required``'s force-≥1 guarantee: the
+        # start state is NON-accepting, so stop tokens stay masked until the
+        # first call completes.
+        stop_ids = sorted(
+            {int(t) for t in (stop_token_ids or ()) if 0 <= int(t) < self._vocab}
+        )
+        self._stop_ids: tuple[int, ...] = tuple(stop_ids)
+        self._stop_ids_arr = None
+        if self._stop_ids:
+            import mlx.core as mx
+
+            self._stop_ids_arr = mx.array(self._stop_ids)
         # mlx-lm passes the FULL cumulative token sequence each step (see class
         # docstring). ``_prompt_len`` is the baseline captured on the first
         # call; ``_committed`` tracks how many of the cumulative ids have been
@@ -2354,8 +2426,8 @@ class GrammarLogitsProcessor:
             head = apply_token_bitmask(logits[..., : self._vocab], self._bitmask)
             tail_shape = (*logits.shape[:-1], model_vocab - self._vocab)
             tail = mx.full(tail_shape, -float("inf"), dtype=logits.dtype)
-            return mx.concatenate([head, tail], axis=-1)
-        if model_vocab < self._vocab:
+            out = mx.concatenate([head, tail], axis=-1)
+        elif model_vocab < self._vocab:
             # Inverse case (codex #558-PR3): the TOKENIZER carries added tokens
             # beyond the model's narrower output head. The bitmask is packed to
             # the full tokenizer vocab (``ceil(vocab/32)`` int32 words), so
@@ -2366,8 +2438,49 @@ class GrammarLogitsProcessor:
             # words is safe. ``apply_token_bitmask`` reads only ``batch`` rows
             # (no vocab-width assert), so the model-width prefix mask is enough.
             words = (model_vocab + 31) // 32
-            return apply_token_bitmask(logits, self._bitmask[..., :words])
-        return apply_token_bitmask(logits, self._bitmask)
+            out = apply_token_bitmask(logits, self._bitmask[..., :words])
+        else:
+            out = apply_token_bitmask(logits, self._bitmask)
+        return self._readmit_stop_tokens_if_accepting(out, logits)
+
+    def _readmit_stop_tokens_if_accepting(self, out: Any, logits: Any) -> Any:
+        """Un-mask the model's stop/eos tokens when the grammar could terminate.
+
+        See ``__init__`` for the Gemma-4 root cause (0.10.16 dogfood P1-①): a
+        family whose learned turn-terminator is neither the tokenizer's single
+        grammar-EOS nor the tool-call ``end`` literal can never emit a stop token
+        under the mask, so ``tool_choice="required"`` loops the same call forever.
+        Whenever the matcher ``is_accepting()`` — the grammar is structurally
+        complete and MAY end here — we restore the ORIGINAL (unmasked) logits for
+        exactly the model's stop token columns, letting the sampler pick one and
+        terminate. The gate is essential: in a NON-accepting state (e.g. before
+        the mandatory first ``required`` call, or mid-call) the stop tokens stay
+        masked, preserving the force-≥1 and shape guarantees. A no-op for
+        families that already terminate cleanly (their stop token is already
+        grammar-allowed at the accepting state, so restoring its finite logit
+        changes nothing)."""
+        if self._stop_ids_arr is None:
+            return out
+        try:
+            if not self._matcher.is_accepting():
+                return out
+        except Exception:  # pragma: no cover - defensive; matcher API is stable
+            return out
+        idx = self._stop_ids_arr
+        width = out.shape[-1]
+        # Defensive width clamp: ``_stop_ids`` is already bounded by the tokenizer
+        # vocab at construction, but the model head can be NARROWER than the
+        # tokenizer (``model_vocab < self._vocab`` branch above) — never index a
+        # stop id past the actual logits width.
+        if self._stop_ids[-1] >= width:
+            import mlx.core as mx
+
+            clamped = [t for t in self._stop_ids if t < width]
+            if not clamped:
+                return out
+            idx = mx.array(clamped)
+        out[..., idx] = logits[..., idx]
+        return out
 
     def reset(self) -> None:
         self._matcher.reset()

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -791,6 +791,7 @@ def _maybe_build_tool_grammar_processor(engine, cfg, request):
             GrammarLogitsProcessor,
             build_tool_grammar,
             get_lltokenizer,
+            model_stop_token_ids,
             resolve_reasoning_sentinels,
         )
         from ..tool_parsers import ToolParserManager
@@ -914,11 +915,21 @@ def _maybe_build_tool_grammar_processor(engine, cfg, request):
         # boundaries. So we pass ``reasoning_end_token=None`` — the grammar's
         # reasoning-tolerant free prefix is the correct and only reasoning lever
         # for triggered structural tags (matches vLLM's same-step exception).
+        # Re-admit the model's stop/eos tokens at accepting grammar states so a
+        # forced (required/named) call TERMINATES after one call instead of
+        # looping (0.10.16 dogfood P1-①). Without this, a family whose learned
+        # turn-terminator is not the tokenizer's single grammar-EOS — Gemma-4
+        # ends a tool-call turn with ``<turn|>`` / ``<|tool_response>``, not
+        # ``<eos>`` — can never emit a stop under the mask and repeats the
+        # identical call until ``max_tokens``. Qwen/gpt-oss are unaffected (their
+        # terminator is already grammar-allowed at the accepting state).
+        stop_ids = model_stop_token_ids(tokenizer)
         processor = GrammarLogitsProcessor(
             lltok,
             grammar,
             reasoning_end_token=None,
             tokenizer=tokenizer,
+            stop_token_ids=stop_ids,
         )
         # A broken matcher (grammar failed to compile) masks NOTHING. Returning
         # it here would set ``grammar_logits_processor`` on the request, which


### PR DESCRIPTION
## Root cause — grammar / EOS layer (not the parser, not the grammar *shape*)

`tool_choice="required"` on **Gemma-4-12B** emitted the identical valid tool-call over and over and never stopped (>120s / 3840+ scheduler steps with no `max_tokens`; 13 duplicate `tool_calls` with `max_tokens:300`). The grammar constrains the call SHAPE correctly (`{"code":"print(1)","lang":"python"}` is byte-correct, enum honored) — the defect is that nothing let generation terminate.

**Why:** llguidance's compiled tool grammar terminates on the tokenizer's **single** `eos_token`. Gemma-4's tokenizer eos is `<eos>` (id 1), but the model ends a tool-call turn with `<turn|>` (id 106) or `<|tool_response>` (id 50) — its real `generation_config.eos_token_id = [1, 106, 50]` (confirmed in the checkpoint + in the boot log: `augment_eos: set _rapid_extra_eos_token_ids=[1, 50, 106]`). Ids 106/50 are **special tokens** that:
- the grammar's `TAG_TEXT: /(.|\n)*/` byte-regex tail **cannot** match, and
- are **not** the grammar's designated EOS (`<eos>` id 1).

So after one complete call every one of the model's real turn-terminators is masked. Under the `required`/named `(tag)+` grammar the only unmasked structural continuation is another `<|tool_call>` → the model emits the identical call forever.

**Why gpt-oss / Qwen don't hit it** (they finish with `finish_reason:tool_calls` after one call):
- **Qwen-Coder (XML):** the model's `<|im_end|>` **is** the tokenizer eos == the grammar's EOS → allowed at the accepting state.
- **gpt-oss (harmony):** the tool-call `end` literal `<|call|>` (id 200012) is itself one of `generation_config.eos_token_id = [200002, 199999, 200012]` → the grammar consumes a token that is also a stop token.

Gemma-4 is the only top-tier family whose learned terminator is neither the tokenizer eos nor the tool-call `end` literal.

## Fix — minimal, cross-family, copies the pattern the working families already rely on

`GrammarLogitsProcessor` now **re-admits the model's stop/eos tokens whenever the matcher `is_accepting()`** — i.e. the grammar is structurally complete and MAY end here — by restoring their original (unmasked) logits so the sampler can pick one and terminate. This makes Gemma-4 stop naturally exactly as Qwen/gpt-oss already do.

- **The `is_accepting` gate preserves `required`'s force-≥1 guarantee:** the start state is non-accepting, so stop tokens stay masked until the first call completes (no early bail-out before the mandatory call).
- Stop ids come from `model_stop_token_ids(tokenizer)` — the same eos surfaces the scheduler halts on (`_eos_token_ids` / `eos_token_id` / `eos_token_ids` / `_rapid_extra_eos_token_ids`).
- **No grammar construct is changed** — the grammar's accepted *language* is untouched; this is a runtime-mask augmentation only. Qwen/gpt-oss are unaffected because their terminator was already allowed at the accepting state (restoring an already-finite logit is a no-op).

## Real-serve proof (reused cache, real weights, port 8790, **no** `max_tokens`)

`mlx-community/gemma-4-12B-it-4bit --tool-call-parser gemma4`:
```
tool_choice=required, no max_tokens
-> HTTP 200 in 0.93s
-> finish_reason: tool_calls
-> num tool_calls: 1
-> call[0]: run_code {"code": "print(1)", "lang": "python"}
-> completion_tokens: 23
```
(was: >120s loop, or 13 duplicate calls with max_tokens:300)

Auto still answers normally: `finish_reason: stop`, content `"The capital of France is Paris."`, 0 tool_calls, 0.68s. Second required request identical (1 call, 23 tokens). **Zero** `matcher rejected committed token` warnings — the scheduler halts on the stop token before the processor is re-invoked.

**No cross-family regression** (shared code touched): `mlx-community/gpt-oss-20b-MXFP4-Q8 --tool-call-parser harmony`, forced call, no `max_tokens` → `finish_reason: tool_calls`, **1** call `run_code {"code":"print(1)","lang":"python"}`, 25 tokens, HTTP 200 in 1.08s.

## Tests

- New `test_stop_token_readmitted_only_at_accepting_state` (real hermes grammar + LLTokenizer): a special token that is neither the grammar EOS nor a grammar literal is **masked before the mandatory first call**, **un-masked after a complete call**, and **still masked without re-admission** (control) — proving the re-admission (not a grammar-language change) is what un-masks it and the `is_accepting` gate holds.
- New `test_model_stop_token_ids_unions_all_surfaces` unit test for the helper.
- 292 existing grammar tests (`test_grammar_processor_558`, `test_gemma4_grammar_558`, `test_harmony_tool_grammar_558`, `test_qwen3coder_xml_grammar_558`, `test_tool_grammar_558`) + gemma4/parallel parser tests green. `ruff check` + `ruff format` clean.

## Files touched
- `vllm_mlx/api/tool_grammar.py` — `model_stop_token_ids()` helper + `GrammarLogitsProcessor` re-admits stop tokens at accepting states
- `vllm_mlx/routes/chat.py` — pass `stop_token_ids` from the tokenizer into the processor
- `tests/test_grammar_processor_558.py` — focused single-call-termination + helper tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)