### PR TITLE
fix: base-wheel hybrid-VLM serve skips [vision]; pin Gemma-4 install hint

### DIFF
--- a/tests/test_basewheel_hybrid_vlm_serve_1017.py
+++ b/tests/test_basewheel_hybrid_vlm_serve_1017.py
@@ -190,3 +190,112 @@ def test_serve_guard_no_mllm_skips_vision_extra(monkeypatch):
     args = _args("mlx-community/Qwen3-VL-2B-Instruct-4bit", no_mllm=True)
     with pytest.raises(_ReachedPastVisionGuardError):
         cli.serve_command(args)
+
+
+# ---------------------------------------------------------------------------
+# Real-probe coverage: drive the ACTUAL resolve_serving_lane / is_mllm_model /
+# mllm_backbone_is_hybrid chain (no mocks) against genuinely-cached
+# checkpoint configs. Skips cleanly on a host that hasn't materialized the
+# config (CI), so the mock-driven tests above remain the always-on gate while
+# these prove the production probe path when the checkpoint is present.
+# ---------------------------------------------------------------------------
+
+
+def _cached_or_skip(hf_path: str):
+    """Skip unless ``hf_path``'s config is materialized in the local cache —
+    the probes read it offline; without it there is nothing real to test."""
+    from vllm_mlx.model_metadata import read_model_metadata
+
+    if read_model_metadata(hf_path) is None:
+        pytest.skip(f"{hf_path} config not materialized in local cache")
+
+
+def test_real_probe_cached_hybrid_vlm_downgrades_to_text(monkeypatch):
+    """REAL probe path (no mocks): the actually-cached hybrid-backbone
+    Qwen3.6 checkpoint (config declares ``vision_config`` but ``layer_types``
+    is linear-attention) must resolve to the TEXT lane, so the guard skips
+    ``[vision]``. This is the exact production scenario the fix targets —
+    exercised end-to-end through ``resolve_serving_lane`` rather than a
+    hard-coded ``hybrid=True``."""
+    from vllm_mlx import cli
+    from vllm_mlx.api.utils import is_mllm_model, mllm_backbone_is_hybrid
+
+    hf_path = "mlx-community/Qwen3.6-27B-4bit"
+    _cached_or_skip(hf_path)
+
+    # Precondition: the real probes see a multimodal config with a hybrid
+    # backbone (else this would pass vacuously if the checkpoint changed).
+    assert is_mllm_model(hf_path) is True
+    assert mllm_backbone_is_hybrid(hf_path) is True
+
+    # The guard consults the real resolve_serving_lane → text lane → no
+    # [vision] requirement, even though the raw classification is "VLM".
+    assert cli._serve_will_run_on_mllm_lane(_args(hf_path)) is False
+
+    # And end-to-end: with mlx-vlm ABSENT the boot guard lets it through.
+    _mock_mllm_absent(monkeypatch)
+    _stub_post_guard_sentinel(monkeypatch)
+    with pytest.raises(_ReachedPastVisionGuardError):
+        cli.serve_command(_args(hf_path))
+
+
+def test_real_probe_cached_genuine_vlm_stays_on_mllm_lane():
+    """REAL probe path (no mocks): an actually-cached genuine multimodal
+    checkpoint (Gemma-4, non-hybrid backbone) must stay on the MLLM lane so
+    the guard STILL requires ``[vision]`` — the fix must not weaken real
+    vision checkpoints when consulted through the production probe."""
+    from vllm_mlx import cli
+    from vllm_mlx.api.utils import is_mllm_model, mllm_backbone_is_hybrid
+
+    hf_path = "mlx-community/gemma-4-12B-it-4bit"
+    _cached_or_skip(hf_path)
+
+    assert is_mllm_model(hf_path) is True
+    assert mllm_backbone_is_hybrid(hf_path) is False
+    assert cli._serve_will_run_on_mllm_lane(_args(hf_path)) is True
+
+
+# ---------------------------------------------------------------------------
+# Explicit contract: the SAFE default for an uncached / unclassifiable
+# checkpoint. When no config is materialized, the hybrid probe answers "not
+# hybrid" by design, so a VLM-named checkpoint keeps the [vision]-required
+# guard rather than being silently let through onto a lane that might crash.
+# This is a DELIBERATE, task-scoped default (the guard runs before download
+# to fail fast) — pinned here so it can't silently drift, and so the guard's
+# message is verified to point the user at --no-mllm for a text-capable
+# backbone. (A genuinely-hybrid uncached checkpoint whose NAME does not match
+# a VLM pattern — e.g. qwen3.6-27b-4bit — is classified text and boots
+# without [vision] anyway; see the real-probe test above for the cached form.)
+# ---------------------------------------------------------------------------
+
+
+def test_uncached_vlm_named_checkpoint_keeps_safe_vision_default(monkeypatch, capsys):
+    """No cached config + a VLM-pattern name → the REAL is_mllm_model matches
+    on the name, the REAL hybrid probe can't prove hybrid (no config), so the
+    guard keeps the safe ``[vision]``-required default and fails fast with a
+    message that also names ``--no-mllm``."""
+    from vllm_mlx import cli
+    from vllm_mlx.api.utils import is_mllm_model, mllm_backbone_is_hybrid
+    from vllm_mlx.model_metadata import read_model_metadata
+
+    # A name that (a) is NOT a resolvable/cached repo and (b) trips the VLM
+    # name pattern, so the real probes are exercised without any mock.
+    fake = "nonexistent-org/Made-Up-VL-Hybrid-Model-4bit"
+    assert read_model_metadata(fake) is None, "test name must be uncached"
+    assert is_mllm_model(fake) is True, "VL-pattern name must classify as VLM"
+    assert mllm_backbone_is_hybrid(fake) is False, "no config → not provably hybrid"
+
+    # Guard decision is real (not mocked): safe default → MLLM lane → require.
+    assert cli._serve_will_run_on_mllm_lane(_args(fake)) is True
+
+    # End-to-end on a base wheel: fail fast rc=2 with the actionable message.
+    _mock_mllm_absent(monkeypatch)
+    _stub_post_guard_sentinel(monkeypatch)
+    with pytest.raises(SystemExit) as exc_info:
+        cli.serve_command(_args(fake))
+    assert exc_info.value.code == 2
+
+    err = capsys.readouterr().err
+    assert "[vision]" in err
+    # The safe-default message still surfaces the text-only escape hatch.
+    assert "--no-mllm" in err

--- a/tests/test_basewheel_hybrid_vlm_serve_1017.py
+++ b/tests/test_basewheel_hybrid_vlm_serve_1017.py
@@ -1,0 +1,192 @@
+# SPDX-License-Identifier: Apache-2.0
+"""0.10.16 dogfood P1 (④) — a base-wheel serve of a HYBRID-backbone VLM
+alias must boot text-only WITHOUT demanding the ``[vision]`` extra.
+
+Context
+-------
+#1178 added ``mllm_backbone_is_hybrid`` + ``resolve_serving_lane``: a
+multimodal alias whose LANGUAGE backbone is hybrid/linear-attention
+(Qwen3.6 GatedDeltaNet — ``mlx-community/Qwen3.6-27B-4bit``) auto-downgrades
+to the text-only mlx-lm lane at load time and never touches mlx-vlm.
+
+But the CLI boot guard (``serve_command``) hard-required the ``[vision]``
+extra whenever ``is_mllm_model(args.model)`` was True — which fires for a
+hybrid VLM checkpoint (its config declares ``vision_config``) BEFORE the
+auto-downgrade decision. Result: a base-wheel user was pushed into a ~1 GB
+``[vision]`` install for a model that then serves text-only.
+
+The fix makes the guard consult the SAME resolved-lane signal the engine
+uses (``resolve_serving_lane``) via the ``_serve_will_run_on_mllm_lane``
+helper: require ``[vision]`` ONLY when the model will actually run on the
+MLLM lane. A genuine VLM (non-hybrid backbone, e.g. qwen3-vl) still requires
+it; ``--mllm`` / ``--no-mllm`` are honoured.
+
+These tests pin:
+  * the helper decision for hybrid / genuine / forced / text-only / non-VLM,
+  * the end-to-end guard behaviour with mlx-vlm mocked ABSENT (base wheel):
+    hybrid VLM boots past the guard, genuine VLM still exits rc=2.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+
+def _args(model: str = "some/model", *, mllm: bool = False, no_mllm: bool = False):
+    return SimpleNamespace(model=model, mllm=mllm, no_mllm=no_mllm)
+
+
+# ---------------------------------------------------------------------------
+# Unit: the decision helper ``_serve_will_run_on_mllm_lane``.
+# ---------------------------------------------------------------------------
+
+
+def _patch_probes(monkeypatch, *, is_mllm: bool, hybrid: bool):
+    """Stub the two offline probes ``resolve_serving_lane`` consults so the
+    lane decision is exercised without a materialized checkpoint config."""
+    from vllm_mlx.api import utils as api_utils
+
+    monkeypatch.setattr(api_utils, "is_mllm_model", lambda name: is_mllm)
+    monkeypatch.setattr(api_utils, "mllm_backbone_is_hybrid", lambda name: hybrid)
+
+
+def test_helper_hybrid_vlm_does_not_run_on_mllm_lane(monkeypatch):
+    """A multimodal alias with a hybrid backbone auto-downgrades to text —
+    the helper reports it will NOT run on the MLLM lane, so the guard skips
+    the ``[vision]`` requirement (the base-wheel fix)."""
+    from vllm_mlx import cli
+
+    _patch_probes(monkeypatch, is_mllm=True, hybrid=True)
+    assert cli._serve_will_run_on_mllm_lane(_args()) is False
+
+
+def test_helper_genuine_vlm_runs_on_mllm_lane(monkeypatch):
+    """A genuine VLM (non-hybrid backbone) stays on the MLLM lane, so the
+    helper reports True and the guard STILL requires ``[vision]``."""
+    from vllm_mlx import cli
+
+    _patch_probes(monkeypatch, is_mllm=True, hybrid=False)
+    assert cli._serve_will_run_on_mllm_lane(_args()) is True
+
+
+def test_helper_force_mllm_on_hybrid_still_requires_vision(monkeypatch):
+    """Explicit ``--mllm`` wins: even a hybrid backbone is reported as the
+    MLLM lane so the operator gets the flag they asked for (and its
+    ``[vision]`` requirement)."""
+    from vllm_mlx import cli
+
+    _patch_probes(monkeypatch, is_mllm=True, hybrid=True)
+    assert cli._serve_will_run_on_mllm_lane(_args(mllm=True)) is True
+
+
+def test_helper_no_mllm_never_runs_on_mllm_lane(monkeypatch):
+    """``--no-mllm`` forces the text lane regardless of the checkpoint — the
+    guard must never require ``[vision]`` for it."""
+    from vllm_mlx import cli
+
+    _patch_probes(monkeypatch, is_mllm=True, hybrid=False)
+    assert cli._serve_will_run_on_mllm_lane(_args(no_mllm=True)) is False
+
+
+def test_helper_non_vlm_does_not_run_on_mllm_lane(monkeypatch):
+    """A plain text model is never on the MLLM lane."""
+    from vllm_mlx import cli
+
+    _patch_probes(monkeypatch, is_mllm=False, hybrid=False)
+    assert cli._serve_will_run_on_mllm_lane(_args()) is False
+
+
+# ---------------------------------------------------------------------------
+# Integration: drive the real ``serve_command`` boot guard with mlx-vlm
+# mocked ABSENT (the fresh ``pip install rapid-mlx`` state, no [vision]).
+# ---------------------------------------------------------------------------
+
+
+class _ReachedPastVisionGuardError(Exception):
+    """Sentinel raised by the stubbed audio probe that immediately follows
+    the vision guard — proves the vision guard did NOT sys.exit(2)."""
+
+
+def _mock_mllm_absent(monkeypatch):
+    from vllm_mlx.models import mllm as mllm_mod
+
+    monkeypatch.setattr(
+        mllm_mod,
+        "vision_runtime_status",
+        lambda: (mllm_mod.VisionRuntimeStatus.ABSENT, "mlx_vlm"),
+    )
+
+
+def _stub_post_guard_sentinel(monkeypatch):
+    """Make the audio boot guard (the very next step after the vision guard)
+    raise a sentinel so ``serve_command`` stops right there — we only care
+    whether the vision guard let us through."""
+    import vllm_mlx.audio.probe as audio_probe
+
+    def _raise(_name):
+        raise _ReachedPastVisionGuardError()
+
+    monkeypatch.setattr(audio_probe, "is_audio_model_alias", _raise)
+
+
+def test_serve_guard_hybrid_vlm_boots_without_vision_extra(monkeypatch, capsys):
+    """Base wheel (mlx-vlm ABSENT): a hybrid-backbone VLM must pass the boot
+    guard WITHOUT the ``[vision]``-required ``sys.exit(2)`` — it will
+    auto-downgrade to the text lane."""
+    from vllm_mlx import cli
+
+    _patch_probes(monkeypatch, is_mllm=True, hybrid=True)
+    _mock_mllm_absent(monkeypatch)
+    _stub_post_guard_sentinel(monkeypatch)
+
+    args = _args("mlx-community/Qwen3.6-27B-4bit")
+    # Reaching the sentinel means the vision guard did NOT exit — the model
+    # is allowed to boot text-only from the base wheel.
+    with pytest.raises(_ReachedPastVisionGuardError):
+        cli.serve_command(args)
+
+    err = capsys.readouterr().err
+    assert "[vision]" not in err, (
+        "hybrid-backbone VLM must not be pushed into the [vision] install on "
+        f"a base wheel; stderr was: {err!r}"
+    )
+
+
+def test_serve_guard_genuine_vlm_still_requires_vision_extra(monkeypatch, capsys):
+    """Base wheel (mlx-vlm ABSENT): a genuine VLM (non-hybrid backbone) must
+    STILL fail fast with the ``[vision]``-required guard — the fix must not
+    weaken real vision aliases."""
+    from vllm_mlx import cli
+
+    _patch_probes(monkeypatch, is_mllm=True, hybrid=False)
+    _mock_mllm_absent(monkeypatch)
+    # If the guard wrongly let this through, the sentinel would surface
+    # instead of SystemExit — making the test fail loudly rather than pass.
+    _stub_post_guard_sentinel(monkeypatch)
+
+    args = _args("mlx-community/Qwen3-VL-2B-Instruct-4bit")
+    with pytest.raises(SystemExit) as exc_info:
+        cli.serve_command(args)
+    assert exc_info.value.code == 2
+
+    err = capsys.readouterr().err
+    assert "Qwen3-VL-2B-Instruct-4bit" in err
+    assert "[vision]" in err
+    # The guard message also surfaces --no-mllm as the text-only escape hatch.
+    assert "--no-mllm" in err
+
+
+def test_serve_guard_no_mllm_skips_vision_extra(monkeypatch):
+    """``--no-mllm`` on a genuine VLM must bypass the vision guard entirely
+    even on a base wheel (the pre-existing escape hatch, preserved)."""
+    from vllm_mlx import cli
+
+    _patch_probes(monkeypatch, is_mllm=True, hybrid=False)
+    _mock_mllm_absent(monkeypatch)
+    _stub_post_guard_sentinel(monkeypatch)
+
+    args = _args("mlx-community/Qwen3-VL-2B-Instruct-4bit", no_mllm=True)
+    with pytest.raises(_ReachedPastVisionGuardError):
+        cli.serve_command(args)

--- a/tests/test_install_hint_pinned_1016.py
+++ b/tests/test_install_hint_pinned_1016.py
@@ -62,6 +62,35 @@ def test_boot_guard_absent_hint_names_pinned_install(monkeypatch, capsys):
     assert "mlx-vlm>=0.6.3" not in err
 
 
+def test_gemma4_load_fallback_hint_is_pinned():
+    """The Gemma-4-specific ``serve``/``chat`` load-fallback hint (printed
+    when mlx-lm can't import the Gemma-4 architecture classes on a base
+    wheel) must pin the bare mlx-vlm text-only install to ``==0.6.3`` too.
+
+    Pre-fix this site still printed ``pip install --no-deps 'mlx-vlm>=0.6.1'``
+    — an unpinned lower bound that resolves to the current PyPI latest and
+    violates rapid-mlx's ``transformers<5.13`` core pin (0.10.16 dogfood ⑤,
+    the site #1175 missed). Scan the CLI source so a future edit can't
+    silently regress this last user-facing hint back to the unpinned form.
+    """
+    import pathlib
+
+    import vllm_mlx.cli as cli_mod
+
+    source = pathlib.Path(cli_mod.__file__).read_text()
+
+    # The text-only footprint fallback must be pinned...
+    assert "pip install --no-deps 'mlx-vlm==0.6.3'" in source, (
+        "Gemma-4 load-fallback hint must pin mlx-vlm==0.6.3 to match "
+        "VLM_EXTRA_INSTALL_HINT (0.10.16 dogfood ⑤)."
+    )
+    # ...and no CLI hint may use the conflict-producing unpinned lower bound.
+    assert "mlx-vlm>=0.6.1" not in source, (
+        "cli.py still recommends the unpinned 'mlx-vlm>=0.6.1' which pulls "
+        "transformers 5.14.x and breaks the transformers<5.13 core pin."
+    )
+
+
 def test_diffusion_lane_import_error_hint_is_pinned(monkeypatch):
     """DiffusionEngine's dependency-import failure (Gemma 4 DLM path) points
     at the extra + a PINNED mlx-vlm, dropping the old ``-U 'mlx-vlm>=0.6.3'``

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -2137,6 +2137,36 @@ def _resolve_hybrid_cache_entries(
     return explicit_value
 
 
+def _serve_will_run_on_mllm_lane(args) -> bool:
+    """Whether ``serve`` will actually run this model on the MLLM/VLM
+    continuous-batching lane — the ONLY lane that needs the optional
+    ``mlx-vlm`` runtime (shipped behind the ``[vision]`` extra).
+
+    Delegates to #1178's :func:`resolve_serving_lane` so the boot-time
+    ``[vision]``-required guard agrees with the load-time routing decision.
+    A multimodal alias whose LANGUAGE backbone is hybrid/linear-attention
+    (Qwen3.6 GatedDeltaNet) auto-downgrades to the text-only mlx-lm lane and
+    never touches mlx-vlm, so it must NOT be pushed into a ~1 GB ``[vision]``
+    install. A genuine VLM (non-hybrid backbone, e.g. qwen3-vl) stays on the
+    MLLM lane and still needs it. ``--mllm`` / ``--no-mllm`` are honoured via
+    ``resolve_serving_lane``'s explicit-flag short-circuits.
+
+    The probe reads the cached checkpoint config offline (no network, no
+    weight load). On a first-time uncached start the config isn't
+    materialized yet, so the hybrid probe answers "not hybrid" and the model
+    keeps the SAFE ``[vision]``-required default — the guard's error message
+    then points at ``--no-mllm`` for a text-capable backbone.
+    """
+    from .api.utils import resolve_serving_lane
+
+    is_mllm_lane, _auto_text_fallback = resolve_serving_lane(
+        args.model,
+        force_mllm=getattr(args, "mllm", False),
+        force_text=getattr(args, "no_mllm", False),
+    )
+    return is_mllm_lane
+
+
 def serve_command(args):
     """Start the OpenAI-compatible server."""
     import logging
@@ -2190,17 +2220,27 @@ def serve_command(args):
     # path BEFORE the missing-dep error surfaced (deep ImportError
     # after weight download + alias resolution). Probe here so the
     # operator sees an actionable hint before the long download starts.
-    # Honors ``--mllm`` force-on AND the alias-name / HF-path probe
-    # used downstream by ``pflash.validate_model_support``. The
-    # ``--no-mllm`` escape hatch (force_text in load_model) bypasses
-    # this guard, matching the engine-side semantics.
-    if not getattr(args, "no_mllm", False):
-        from .api.utils import is_mllm_model as _boot_is_mllm
+    #
+    # 0.10.16 dogfood follow-up (④): consult the SAME resolved-lane signal
+    # the engine uses (#1178 ``resolve_serving_lane`` + ``_auto_text_
+    # fallback``) instead of the raw ``is_mllm_model`` classification. A
+    # multimodal alias whose LANGUAGE backbone is hybrid/linear-attention
+    # (Qwen3.6 GatedDeltaNet) auto-downgrades to the text-only mlx-lm lane
+    # and NEVER touches mlx-vlm — forcing a base-wheel user into a ~1 GB
+    # ``[vision]`` install for a model that then serves text-only was the
+    # dogfood pain point. ``_serve_will_run_on_mllm_lane`` is True only when
+    # the model will actually run on the MLLM lane, so:
+    #   * genuine VLM (qwen3-vl, non-hybrid backbone) → still requires it,
+    #   * hybrid-backbone VLM (qwen3.6) → boots text-only from the base wheel,
+    #   * ``--mllm`` force-on / ``--no-mllm`` escape hatch → honoured by
+    #     ``resolve_serving_lane``, matching the engine-side semantics.
+    # An uncached checkpoint (config not yet materialized) probes "not
+    # hybrid" and keeps the SAFE ``[vision]``-required default; the guard's
+    # message points at ``--no-mllm`` for a text-capable backbone.
+    if _serve_will_run_on_mllm_lane(args):
+        from .models.mllm import require_mlx_vlm_or_exit
 
-        if getattr(args, "mllm", False) or _boot_is_mllm(args.model):
-            from .models.mllm import require_mlx_vlm_or_exit
-
-            require_mlx_vlm_or_exit(args.model)
+        require_mlx_vlm_or_exit(args.model)
 
     # R6-H4 (Eva 0.8.7 dogfood): same boot-guard shape for audio aliases.
     # ``mlx-audio`` lives behind the ``[audio]`` extra; pre-fix
@@ -3922,7 +3962,11 @@ def _run_submit_flow(
                     "  Or, if you only need text inference (smaller "
                     "footprint, ~16 MB vs ~450 MB):"
                 )
-                print("    pip install --no-deps 'mlx-vlm>=0.6.1'")
+                # Pinned to ==0.6.3 to match VLM_EXTRA_INSTALL_HINT (0.10.16
+                # dogfood ⑤): an unpinned mlx-vlm resolves to the current
+                # PyPI latest, which pulls transformers 5.14.x and violates
+                # rapid-mlx's own ``transformers<5.13`` core pin.
+                print("    pip install --no-deps 'mlx-vlm==0.6.3'")
                 print()
             else:
                 print(f"  Error loading model: {e}")

--- a/vllm_mlx/models/mllm.py
+++ b/vllm_mlx/models/mllm.py
@@ -246,7 +246,10 @@ def require_mlx_vlm_or_exit(model_name: str) -> None:
         print(
             f"error: model {model_name!r} is a vision/multimodal alias and "
             f"requires the optional `mlx-vlm` dependency (shipped with the "
-            f"[vision] extra).\n" + VLM_EXTRA_INSTALL_HINT,
+            f"[vision] extra).\n" + VLM_EXTRA_INSTALL_HINT + "\n"
+            "Or, if this checkpoint has a text-capable backbone and you only "
+            "need text output, `--no-mllm` boots the text-only lane straight "
+            "from the base wheel (no mlx-vlm, drops image/vision input).",
             file=sys.stderr,
         )
     sys.exit(2)


### PR DESCRIPTION
## 0.10.16 dogfood polish (pre-0.10.17) — two fixes in one PR

Both are rough edges found dogfooding the 0.10.16 release wheel.

### Fix ① (primary) — base-wheel serve of a HYBRID-backbone VLM alias must boot text-only WITHOUT demanding `[vision]`

**Problem.** #1178 added `resolve_serving_lane()` / `mllm_backbone_is_hybrid()`: a multimodal alias whose **language** backbone is hybrid/linear-attention (Qwen3.6 GatedDeltaNet — `mlx-community/Qwen3.6-27B-4bit`) auto-downgrades to the text-only mlx-lm lane at load time and never touches mlx-vlm. But the CLI boot guard hard-required the `[vision]` extra whenever `is_mllm_model(args.model)` was True — which fires for a hybrid VLM checkpoint (its `config.json` declares `vision_config`) **before** the auto-downgrade decision. Net effect on a base wheel: the user is pushed into a ~1 GB `[vision]` install for a model that then serves text-only.

**Fix.** The boot guard now consults the **same** resolved-lane signal the engine uses, via a small `_serve_will_run_on_mllm_lane()` helper that delegates to `resolve_serving_lane`. It requires `[vision]` **only** when the model will actually run on the MLLM lane:

- hybrid-backbone VLM (`qwen3.6-27b-4bit`) → boots text-only from the base wheel ✅
- genuine VLM (`qwen3-vl-2b-4bit`, non-hybrid backbone) → **still** requires `[vision]` ✅
- `--mllm` / `--no-mllm` → honoured by `resolve_serving_lane`'s explicit-flag short-circuits
- uncached checkpoint (config not materialized) → probes "not hybrid" → keeps the **safe** `[vision]`-required default

No new hybrid-detection logic — it reuses #1178's helpers. `aliases.json` untouched. The guard's ABSENT-path error message now also names `--no-mllm` as the text-only escape hatch from the base wheel.

### Fix ② (trivial) — pin the Gemma-4 fallback install hint

The Gemma-4-specific load-fallback path printed `pip install --no-deps 'mlx-vlm>=0.6.1'` — inconsistent with the P2 fix (`VLM_EXTRA_INSTALL_HINT` pins `mlx-vlm==0.6.3`). An unpinned mlx-vlm resolves to the current PyPI latest, pulling `transformers 5.14.x` and violating rapid-mlx's `transformers<5.13` core pin. Changed to `mlx-vlm==0.6.3` (kept `--no-deps`).

## Real-serve proof (base venv, NO `[vision]` — `mlx_vlm` spec `None`)

- `serve qwen3.6-27b-4bit --port 8790` → boots text-only (`BatchedEngine loaded ... (mllm=False)`, "Hybrid model: compiling GatedDeltaNet kernels"), no `[vision]` demand; chat completion returned `hello from base wheel`.
- `serve qwen3-vl-2b-4bit` → exits rc=2 with the `[vision]` demand (genuine VLM), no download.
- `serve gemma-4-12b-4bit` → exits rc=2 with the `[vision]` demand — **unchanged** (genuine multimodal checkpoint, non-hybrid backbone); the new `--no-mllm` hint now tells users they can boot text-only from the base wheel.

## Tests

- `tests/test_basewheel_hybrid_vlm_serve_1017.py` (new): `_serve_will_run_on_mllm_lane` decision matrix (hybrid / genuine / `--mllm` / `--no-mllm` / non-VLM) + end-to-end `serve_command` boot-guard behaviour with mlx-vlm mocked ABSENT (hybrid boots past the guard; genuine VLM still exits rc=2).
- `tests/test_install_hint_pinned_1016.py` (extended): pins the Gemma-4 fallback hint site to `mlx-vlm==0.6.3`.

### Why this matters

This matters **because** a base-wheel (no `[vision]`) user should never be pushed into a ~1 GB optional install for a model that then serves text-only — that is the whole point of #1178's auto-downgrade lane. The boot guard was deciding on the raw multimodal classification instead of the resolved lane, which is **why** it fired too early. Fix ② removes an install hint that would silently break the user's `transformers` pin.
