### PR TITLE
chore: bump version to 0.10.17

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.10.16"
+version = "0.10.17"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## Release 0.10.17

Bump-only PR (pyproject `0.10.16` → `0.10.17`) to cut the release. Triggers `auto-release.yml` → PyPI publish.

### Why now
0.10.16 shipped three constrained tool-calling wires but a user-perspective dogfood of the published wheel surfaced three P1 pain points and two packaging warts. All are root-caused and fixed on `main`, each verified from a **fresh-venv naive-user install** of the built wheel (not just unit tests). This release delivers those fixes plus new MiniCPM5 model support.

### What's in 0.10.17 (all merged to main since 0.10.16)

**Dogfood fixes**
- **P1-① (#1177)** — gemma-4 `tool_choice=required` now emits exactly one tool call and terminates. Previously the grammar allowed unbounded repetition, so a `required` call with no `max_tokens` looped forever (worst possible first impression for constrained tool-calling). Dogfood: 1 call, `finish_reason=tool_calls`, 0.75s.
- **P1-② (#1178)** — new-flagship default `serve` no longer crashes. Hybrid GatedDeltaNet backbones registered as VLM aliases (e.g. `qwen3.6-27b-4bit`) auto-downgrade to the text-only mlx-lm lane with a correctly-attributed INFO log instead of being routed into the incompatible MLLM engine. Dogfood: boots ~21s, ~35.5 tok/s, coherent.
- **P1-③ (#1176)** — invalid `response_format` json_schema now returns HTTP **400** (`invalid_response_format_schema`) at the route boundary instead of silently falling back to unconstrained 200. Structural validity is checked once at the boundary across chat/responses (`/v1/completions` rejects json_schema up-front); valid-but-uncompilable schemas surface as strict 502 / non-strict best-effort (OpenAI semantics). Dogfood: invalid → 400, valid nested strict schema → constrained JSON.
- **P2 ⑤⑥ (#1175)** — install/serve UX: the missing-mlx-vlm hint is pinned to `mlx-vlm==0.6.3` (an unpinned suggestion pulled a transformers that violates the `transformers<5.13` core pin); a weightless-stub cache is now flagged on stderr *before* serve silently re-downloads multi-GB weights.
- **Base-wheel UX (#1179)** — a hybrid-backbone VLM alias now boots text-only from the **base wheel** without demanding the ~1GB `[vision]` extra (it runs text-only anyway); genuine VLMs still require it, and the guard now names `--no-mllm`. Gemma-4 fallback install hint pinned to `mlx-vlm==0.6.3` for consistency.

**New model support**
- **MiniCPM5 (#1161)** — first-class support for `minicpm5-1b-4bit` and `minicpm5-1b-optiq-4bit`, with a native `<function name=…><param name=…>…</param></function>` tool-call parser (CDATA-aware, OpenAI-compatible non-streaming + SSE). Dogfood: both boot from cache, coherent, structured tool_calls in both modes, ~367 / ~241 tok/s.

### Verification
Every fix was dogfooded from a fresh venv against the built wheel on real hardware (gemma-4-12B, Qwen3.6-27B, MiniCPM5 ×2). Full unit suite green (13655 passed) on the tip.