### PR TITLE
feat(chat): add MCP agent loop

### DIFF
--- a/docs/guides/mcp-tools.md
+++ b/docs/guides/mcp-tools.md
@@ -216,11 +216,21 @@ if message.get("tool_calls"):
 
 ## Interactive MCP Chat
 
-For testing MCP interactively:
+The built-in chat command can act as the MCP host. The config may contain one
+or more entries under `servers`:
 
 ```bash
-python examples/mcp_chat.py
+rapid-mlx chat qwen3.5-4b-4bit --mcp-config mcp.json
 ```
+
+This also works when chat connects to an existing model server:
+
+```bash
+rapid-mlx chat --base-url http://localhost:8000 --mcp-config mcp.json
+```
+
+The MCP servers run in the chat process. The model server only receives
+standard function-tool schemas, tool calls, and tool-result messages.
 
 ## Supported Tool Formats
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -221,6 +221,7 @@ rapid-mlx chat [model] [options]
 | `--base-url` | Connect to an existing server URL (overrides `--port`) | *(spawn)* |
 | `--ready-timeout` | Seconds to wait for the spawned server to become ready | 600 |
 | `--response-timeout` | Seconds to wait for a single response | 600 |
+| `--mcp-config` | Load MCP tools into this chat agent | *(none)* |
 
 > The REPL defaults to `--no-think` because reasoning models (Qwen3.5, etc.)
 > otherwise leak raw chain-of-thought and can loop until `max-tokens`. Pass
@@ -241,11 +242,19 @@ rapid-mlx chat --port 8000
 
 # Pin a system prompt
 rapid-mlx chat qwen3.5-4b-4bit --system "You are a terse, friendly Mac shell tutor."
+
+# Give the built-in chat agent tools from one or more MCP servers
+rapid-mlx chat qwen3.5-4b-4bit --mcp-config mcp.json
 ```
 
 In-REPL slash commands: `/help`, `/reset` (alias `/clear`), `/model <alias>`,
 `/save <path>` (write conversation to markdown), `/exit` (alias `/quit`).
 Type `"""` on its own line to start/end a multi-line block (pasting code).
+
+MCP belongs to the chat process: it discovers and executes the configured
+tools, while the spawned or remote Rapid-MLX server receives only standard
+OpenAI function tools and tool-result messages. `serve` and `share` do not
+need the chat's MCP configuration.
 
 ## Environment Variables
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,7 @@ dependencies = [
     "psutil>=5.9.0",
     "fastapi>=0.100.0",
     "uvicorn>=0.23.0",
-    "mcp>=1.0.0",
+    "mcp>=1.9.3",  # ClientSessionGroup: official multi-server lifecycle for chat
     "jsonschema>=4.0.0",
     # argcomplete — shell tab completion for the `rapid-mlx` CLI. Tiny
     # pure-Python package (~50 KB) wired into argparse via the magic

--- a/tests/test_chat_mcp.py
+++ b/tests/test_chat_mcp.py
@@ -1,0 +1,408 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Focused tests for the MCP runtime owned by ``rapid-mlx chat``."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import threading
+from types import SimpleNamespace
+
+import pytest
+
+from vllm_mlx.chat_mcp import ChatMCPRuntime, _server_parameters
+from vllm_mlx.mcp.types import MCPServerConfig, MCPTransport
+
+
+class _FakeResult:
+    def __init__(self, name: str, arguments: dict):
+        self.name = name
+        self.arguments = arguments
+
+    def model_dump(self, **_kwargs):
+        return {
+            "content": [{"type": "text", "text": f"{self.name}:{self.arguments}"}],
+            "isError": False,
+        }
+
+
+class _FakeSessionGroup:
+    instances: list[_FakeSessionGroup] = []
+    calls: list[tuple[str, dict]] = []
+    fail_enter = False
+    call_started = threading.Event()
+    call_cancelled = threading.Event()
+    connect_thread_names: list[str] = []
+
+    def __init__(self, component_name_hook):
+        self._name_hook = component_name_hook
+        self.tools = {}
+        self.exited = False
+        self.instances.append(self)
+
+    async def __aenter__(self):
+        if self.fail_enter:
+            raise RuntimeError("group enter failed")
+        return self
+
+    async def __aexit__(self, *_args):
+        self.exited = True
+
+    async def connect_to_server(self, params):
+        self.connect_thread_names.append(threading.current_thread().name)
+        label = params.args[0]
+        if label == "hang":
+            await asyncio.Event().wait()
+        if label == "fail":
+            raise RuntimeError("connection refused")
+        if label == "empty":
+            return
+        tool_name = params.args[1]
+        full_name = self._name_hook(
+            tool_name,
+            SimpleNamespace(name="same-name-from-every-server"),
+        )
+        schema = (
+            {
+                "type": "object",
+                "properties": {"value": {"type": "string"}},
+                "required": ["value"],
+            }
+            if tool_name == "lookup"
+            else {"type": "object"}
+        )
+        self.tools[full_name] = SimpleNamespace(
+            name=tool_name,
+            description=f"{label} tool",
+            inputSchema=schema,
+        )
+
+    async def call_tool(self, name, arguments):
+        self.calls.append((name, arguments))
+        if arguments.get("hang"):
+            self.call_started.set()
+            try:
+                await asyncio.Event().wait()
+            finally:
+                self.call_cancelled.set()
+        if arguments.get("raise"):
+            raise RuntimeError("tool exploded")
+        return _FakeResult(name, arguments)
+
+
+@pytest.fixture(autouse=True)
+def _fake_sdk_group(monkeypatch):
+    import mcp.client.session_group
+
+    _FakeSessionGroup.instances = []
+    _FakeSessionGroup.calls = []
+    _FakeSessionGroup.fail_enter = False
+    _FakeSessionGroup.call_started = threading.Event()
+    _FakeSessionGroup.call_cancelled = threading.Event()
+    _FakeSessionGroup.connect_thread_names = []
+    monkeypatch.setattr(
+        mcp.client.session_group,
+        "ClientSessionGroup",
+        _FakeSessionGroup,
+    )
+
+
+def _write_config(tmp_path, servers, **extra):
+    path = tmp_path / "mcp.json"
+    path.write_text(json.dumps({"servers": servers, **extra}))
+    return path
+
+
+def test_runtime_uses_sdk_groups_for_multiple_servers(tmp_path):
+    path = _write_config(
+        tmp_path,
+        {
+            "alpha": {"command": "python3", "args": ["alpha", "lookup"]},
+            "beta": {"command": "python3", "args": ["beta", "lookup"]},
+        },
+    )
+
+    runtime = ChatMCPRuntime(str(path))
+    try:
+        assert runtime.server_count == 2
+        assert runtime.connection_errors == {}
+        assert {tool["function"]["name"] for tool in runtime.tools} == {
+            "alpha__lookup",
+            "beta__lookup",
+        }
+
+        messages = runtime.execute_tool_calls(
+            [
+                {
+                    "id": "call-a",
+                    "function": {
+                        "name": "alpha__lookup",
+                        "arguments": '{"value":"A"}',
+                    },
+                },
+                {
+                    "id": "call-b",
+                    "function": {
+                        "name": "beta__lookup",
+                        "arguments": {"value": "B"},
+                    },
+                },
+            ]
+        )
+        assert [message["tool_call_id"] for message in messages] == [
+            "call-a",
+            "call-b",
+        ]
+        assert _FakeSessionGroup.calls == [
+            ("alpha__lookup", {"value": "A"}),
+            ("beta__lookup", {"value": "B"}),
+        ]
+        assert '"isError": false' in messages[0]["content"]
+    finally:
+        runtime.close()
+
+    assert all(group.exited for group in _FakeSessionGroup.instances)
+    runtime.close()  # idempotent
+    with pytest.raises(RuntimeError, match="closed"):
+        runtime.execute_tool_calls([])
+
+
+def test_runtime_keeps_healthy_server_when_another_fails(tmp_path):
+    path = _write_config(
+        tmp_path,
+        {
+            "broken": {"command": "python3", "args": ["fail", "lookup"]},
+            "working": {"command": "python3", "args": ["working", "lookup"]},
+        },
+    )
+
+    runtime = ChatMCPRuntime(str(path))
+    try:
+        assert runtime.server_count == 1
+        assert runtime.connection_errors == {"broken": "connection refused"}
+        assert runtime.tools[0]["function"]["name"] == "working__lookup"
+    finally:
+        runtime.close()
+
+
+def test_runtime_bounds_connection_startup(tmp_path):
+    path = _write_config(
+        tmp_path,
+        {
+            "stuck": {
+                "command": "python3",
+                "args": ["hang", "lookup"],
+                "timeout": 0.01,
+            }
+        },
+    )
+
+    with pytest.raises(RuntimeError, match="No MCP tools available.*timed out"):
+        ChatMCPRuntime(str(path))
+
+
+def test_runtime_rejects_qualified_tool_name_collisions(tmp_path):
+    path = _write_config(
+        tmp_path,
+        {
+            "a__b": {"command": "python3", "args": ["first", "c"]},
+            "a": {"command": "python3", "args": ["second", "b__c"]},
+        },
+    )
+
+    with pytest.raises(RuntimeError, match="tool name collision.*a__b__c"):
+        ChatMCPRuntime(str(path))
+
+
+def test_runtime_rejects_non_openai_tool_names(tmp_path):
+    path = _write_config(
+        tmp_path,
+        {"alpha": {"command": "python3", "args": ["alpha", "bad.name"]}},
+    )
+
+    with pytest.raises(RuntimeError, match="not a valid OpenAI function name"):
+        ChatMCPRuntime(str(path))
+
+
+def test_runtime_rejects_configs_without_usable_tools(tmp_path):
+    disabled = _write_config(
+        tmp_path,
+        {"off": {"command": "python3", "enabled": False}},
+    )
+    with pytest.raises(ValueError, match="no enabled servers"):
+        ChatMCPRuntime(str(disabled))
+
+    empty = _write_config(
+        tmp_path,
+        {"empty": {"command": "python3", "args": ["empty", "ignored"]}},
+    )
+    with pytest.raises(RuntimeError, match="No MCP tools available"):
+        ChatMCPRuntime(str(empty))
+
+
+def test_runtime_returns_validation_and_execution_errors_to_model(tmp_path):
+    path = _write_config(
+        tmp_path,
+        {"alpha": {"command": "python3", "args": ["alpha", "lookup"]}},
+    )
+    runtime = ChatMCPRuntime(str(path))
+    try:
+        messages = runtime.execute_tool_calls(
+            [
+                {
+                    "id": "bad-json",
+                    "function": {
+                        "name": "alpha__lookup",
+                        "arguments": "{",
+                    },
+                },
+                {
+                    "id": "bad-shape",
+                    "function": {
+                        "name": "alpha__lookup",
+                        "arguments": "[]",
+                    },
+                },
+                {
+                    "id": "bad-schema",
+                    "function": {
+                        "name": "alpha__lookup",
+                        "arguments": '{"value":1}',
+                    },
+                },
+                {
+                    "id": "unknown",
+                    "function": {
+                        "name": "alpha__missing",
+                        "arguments": "{}",
+                    },
+                },
+                {
+                    "id": "tool-error",
+                    "function": {
+                        "name": "alpha__lookup",
+                        "arguments": '{"value":"ok","raise":true}',
+                    },
+                },
+            ]
+        )
+    finally:
+        runtime.close()
+
+    errors = [json.loads(message["content"])["error"] for message in messages]
+    assert "Expecting property name" in errors[0]
+    assert "JSON object" in errors[1]
+    assert "is not of type 'string'" in errors[2]
+    assert "Unknown MCP tool" in errors[3]
+    assert errors[4] == "tool exploded"
+
+
+def test_runtime_close_cancels_inflight_tool(tmp_path):
+    path = _write_config(
+        tmp_path,
+        {"alpha": {"command": "python3", "args": ["alpha", "lookup"]}},
+    )
+
+    runtime = ChatMCPRuntime(str(path))
+    errors = []
+
+    def _execute():
+        try:
+            runtime.execute_tool_calls(
+                [
+                    {
+                        "id": "cancel-me",
+                        "function": {
+                            "name": "alpha__lookup",
+                            "arguments": '{"value":"ok","hang":true}',
+                        },
+                    }
+                ]
+            )
+        except BaseException as exc:
+            errors.append(exc)
+
+    caller = threading.Thread(target=_execute)
+    caller.start()
+    assert _FakeSessionGroup.call_started.wait(timeout=1)
+    runtime.close()
+    caller.join(timeout=1)
+
+    assert not caller.is_alive()
+    assert errors
+    assert _FakeSessionGroup.call_cancelled.is_set()
+
+
+def test_runtime_blocks_high_risk_tool_without_explicit_opt_in(tmp_path):
+    path = _write_config(
+        tmp_path,
+        {
+            "ops": {
+                "command": "python3",
+                "args": ["ops", "run_command"],
+            }
+        },
+    )
+    runtime = ChatMCPRuntime(str(path))
+    try:
+        [message] = runtime.execute_tool_calls(
+            [
+                {
+                    "id": "danger",
+                    "function": {
+                        "name": "ops__run_command",
+                        "arguments": "{}",
+                    },
+                }
+            ]
+        )
+    finally:
+        runtime.close()
+    assert "blocked by default" in json.loads(message["content"])["error"]
+    assert _FakeSessionGroup.calls == []
+
+
+def test_runtime_surfaces_sdk_startup_failure(tmp_path):
+    path = _write_config(
+        tmp_path,
+        {"alpha": {"command": "python3", "args": ["alpha", "lookup"]}},
+    )
+    _FakeSessionGroup.fail_enter = True
+    with pytest.raises(RuntimeError, match="group enter failed"):
+        ChatMCPRuntime(str(path))
+
+
+def test_server_parameters_use_official_sdk_types():
+    stdio = MCPServerConfig(
+        name="stdio",
+        command="python3",
+        args=["server.py"],
+        env={"TOKEN": "secret"},
+    )
+    stdio_params = _server_parameters(stdio)
+    assert stdio_params.command == "python3"
+    assert stdio_params.args == ["server.py"]
+    assert stdio_params.env["TOKEN"] == "secret"
+
+    sse = MCPServerConfig(
+        name="remote",
+        transport=MCPTransport.SSE,
+        url="http://localhost:9999/sse",
+        timeout=12,
+    )
+    sse_params = _server_parameters(sse)
+    assert sse_params.url == "http://localhost:9999/sse"
+    assert sse_params.timeout == 12
+    assert sse_params.sse_read_timeout == 300
+
+
+def test_runtime_thread_is_dedicated_to_chat(tmp_path):
+    path = _write_config(
+        tmp_path,
+        {"alpha": {"command": "python3", "args": ["alpha", "lookup"]}},
+    )
+    runtime = ChatMCPRuntime(str(path))
+    try:
+        assert _FakeSessionGroup.connect_thread_names == ["rapid-mlx-chat-mcp"]
+    finally:
+        runtime.close()

--- a/tests/test_cli_chat.py
+++ b/tests/test_cli_chat.py
@@ -9,6 +9,7 @@ import os
 import sys
 import threading
 from contextlib import contextmanager
+from copy import deepcopy
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from unittest.mock import patch
 
@@ -126,6 +127,360 @@ def test_chat_with_alias_overrides_default():
         args.model == "smollm3-3b-4bit"
         or getattr(args, "_original_alias", None) == "smollm3-3b-4bit"
     )
+
+
+def test_chat_mcp_config_flag_is_scoped_to_chat():
+    captured: list = []
+    with (
+        patch.object(
+            sys,
+            "argv",
+            ["rapid-mlx", "chat", "--mcp-config", "/tmp/tools.json"],
+        ),
+        patch.object(cli, "chat_command", side_effect=captured.append),
+    ):
+        cli.main()
+    assert captured[0].mcp_config == "/tmp/tools.json"
+
+
+class _FakeMCPRuntime:
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "files__read",
+                "description": "read a file",
+                "parameters": {"type": "object"},
+            },
+        }
+    ]
+
+    def __init__(self):
+        self.calls = []
+
+    def execute_tool_calls(self, calls):
+        self.calls.append(calls)
+        return [
+            {
+                "role": "tool",
+                "tool_call_id": calls[0]["id"],
+                "content": '{"content":"hello"}',
+            }
+        ]
+
+
+def _json_response(body, status_code=200):
+    return type(
+        "Response",
+        (),
+        {
+            "status_code": status_code,
+            "text": json.dumps(body),
+            "json": lambda self: body,
+        },
+    )()
+
+
+def test_complete_chat_with_mcp_runs_standard_tool_loop(monkeypatch):
+    responses = iter(
+        [
+            _json_response(
+                {
+                    "choices": [
+                        {
+                            "message": {
+                                "role": "assistant",
+                                "content": None,
+                                "tool_calls": [
+                                    {
+                                        "id": "call-1",
+                                        "type": "function",
+                                        "function": {
+                                            "name": "files__read",
+                                            "arguments": {"path": "/tmp/a"},
+                                        },
+                                    }
+                                ],
+                            },
+                            "finish_reason": "tool_calls",
+                        }
+                    ],
+                    "usage": {"prompt_tokens": 7, "completion_tokens": 2},
+                }
+            ),
+            _json_response(
+                {
+                    "choices": [
+                        {
+                            "message": {
+                                "role": "assistant",
+                                "content": "The file says hello.",
+                            },
+                            "finish_reason": "stop",
+                        }
+                    ],
+                    "usage": {"prompt_tokens": 8, "completion_tokens": 5},
+                }
+            ),
+        ]
+    )
+    payloads = []
+
+    def _post(_url, json, timeout):
+        assert timeout == 10
+        payloads.append(deepcopy(json))
+        return next(responses)
+
+    monkeypatch.setattr("requests.post", _post)
+    runtime = _FakeMCPRuntime()
+    messages = [{"role": "user", "content": "read it"}]
+
+    answer, metrics = cli._complete_chat_with_mcp(
+        "http://localhost:8000",
+        {
+            "model": "test",
+            "messages": messages,
+            "stream": True,
+            "stream_options": {"include_usage": True},
+        },
+        runtime,
+        timeout_s=10,
+    )
+
+    assert answer == "The file says hello."
+    assert metrics == {
+        "prompt_tokens": 15,
+        "completion_tokens": 7,
+        "finish_reason": "stop",
+    }
+    assert payloads[0]["stream"] is False
+    assert "stream_options" not in payloads[0]
+    assert payloads[0]["tools"] == runtime.tools
+    assert payloads[0]["tool_choice"] == "auto"
+    assert payloads[1]["messages"][-2]["tool_calls"][0]["id"] == "call-1"
+    assert payloads[1]["messages"][-1] == {
+        "role": "tool",
+        "tool_call_id": "call-1",
+        "content": '{"content":"hello"}',
+    }
+
+
+def test_complete_chat_with_mcp_preserves_reasoning_and_normalizes_calls(monkeypatch):
+    responses = iter(
+        [
+            _json_response(
+                {
+                    "choices": [
+                        {
+                            "message": {
+                                "reasoning_content": "need a tool",
+                                "tool_calls": [
+                                    {
+                                        "function": {
+                                            "name": "files__read",
+                                            "arguments": {},
+                                        }
+                                    }
+                                ],
+                            }
+                        }
+                    ]
+                }
+            ),
+            _json_response(
+                {
+                    "choices": [
+                        {
+                            "message": {
+                                "content": ["structured", "answer"],
+                                "reasoning_content": "done",
+                            },
+                            "finish_reason": "stop",
+                        }
+                    ]
+                }
+            ),
+        ]
+    )
+    monkeypatch.setattr(
+        "requests.post",
+        lambda *_args, **_kwargs: next(responses),
+    )
+    runtime = _FakeMCPRuntime()
+    messages = [{"role": "user", "content": "go"}]
+
+    answer, metrics = cli._complete_chat_with_mcp(
+        "http://localhost:8000",
+        {"model": "test", "messages": messages},
+        runtime,
+        timeout_s=10,
+    )
+
+    assert answer == '["structured", "answer"]'
+    assert metrics["reasoning_content"] == "done"
+    assert messages[1]["reasoning_content"] == "need a tool"
+    assert messages[1]["tool_calls"][0]["id"] == "call_0_0"
+    assert messages[1]["tool_calls"][0]["function"]["arguments"] == "{}"
+
+
+@pytest.mark.parametrize(
+    ("response", "error"),
+    [
+        (_json_response({"error": "boom"}, status_code=500), "HTTP 500"),
+        (_json_response({"choices": []}), "Malformed chat completion"),
+        (
+            _json_response({"choices": [{"message": []}]}),
+            "Malformed chat completion",
+        ),
+        (
+            _json_response({"choices": [{"message": {"tool_calls": ["bad"]}}]}),
+            "Malformed chat completion",
+        ),
+        (
+            _json_response(
+                {
+                    "choices": [
+                        {"message": {"tool_calls": [{"function": "not-an-object"}]}}
+                    ]
+                }
+            ),
+            "Malformed chat completion",
+        ),
+    ],
+)
+def test_complete_chat_with_mcp_surfaces_model_api_errors(monkeypatch, response, error):
+    monkeypatch.setattr("requests.post", lambda *_args, **_kwargs: response)
+    with pytest.raises(RuntimeError, match=error):
+        cli._complete_chat_with_mcp(
+            "http://localhost:8000",
+            {"model": "test", "messages": []},
+            _FakeMCPRuntime(),
+            timeout_s=10,
+        )
+
+
+def test_complete_chat_with_mcp_has_bounded_rounds(monkeypatch):
+    response = _json_response(
+        {
+            "choices": [
+                {
+                    "message": {
+                        "tool_calls": [
+                            {
+                                "id": "loop",
+                                "function": {
+                                    "name": "files__read",
+                                    "arguments": "{}",
+                                },
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    )
+    monkeypatch.setattr("requests.post", lambda *_args, **_kwargs: response)
+    runtime = _FakeMCPRuntime()
+    with pytest.raises(RuntimeError, match="exceeded 1 rounds"):
+        cli._complete_chat_with_mcp(
+            "http://localhost:8000",
+            {"model": "test", "messages": []},
+            runtime,
+            timeout_s=10,
+            max_rounds=1,
+        )
+    assert len(runtime.calls) == 1
+
+
+def test_complete_chat_with_mcp_preserves_partial_multi_call_results(monkeypatch):
+    response = _json_response(
+        {
+            "choices": [
+                {
+                    "message": {
+                        "tool_calls": [
+                            {
+                                "id": "completed",
+                                "function": {
+                                    "name": "files__read",
+                                    "arguments": "{}",
+                                },
+                            },
+                            {
+                                "id": "interrupted",
+                                "function": {
+                                    "name": "files__read",
+                                    "arguments": "{}",
+                                },
+                            },
+                        ]
+                    }
+                }
+            ]
+        }
+    )
+    monkeypatch.setattr("requests.post", lambda *_args, **_kwargs: response)
+
+    class _Runtime(_FakeMCPRuntime):
+        def execute_tool_calls(self, calls):
+            if calls[0]["id"] == "interrupted":
+                raise KeyboardInterrupt
+            return super().execute_tool_calls(calls)
+
+    messages = [{"role": "user", "content": "run both"}]
+    with pytest.raises(KeyboardInterrupt):
+        cli._complete_chat_with_mcp(
+            "http://localhost:8000",
+            {"model": "test", "messages": messages},
+            _Runtime(),
+            timeout_s=10,
+        )
+
+    assert messages[-2]["tool_call_id"] == "completed"
+    assert messages[-1] == {
+        "role": "tool",
+        "tool_call_id": "interrupted",
+        "content": '{"error": "Tool execution interrupted"}',
+    }
+
+
+def test_failed_followup_preserves_completed_tool_side_effects():
+    messages = [
+        {"role": "user", "content": "send it"},
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [{"id": "call-1", "type": "function", "function": {}}],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "call-1",
+            "content": '{"content":"sent","isError":false}',
+        },
+    ]
+
+    cli._recover_failed_chat_turn(messages, turn_start=0)
+
+    assert messages[2]["role"] == "tool"
+    assert messages[-1] == {
+        "role": "assistant",
+        "content": "Tool execution completed, but the follow-up response failed.",
+    }
+
+    no_side_effect = [{"role": "user", "content": "try"}]
+    cli._recover_failed_chat_turn(no_side_effect, turn_start=0)
+    assert no_side_effect == []
+
+    rejected = [
+        {"role": "user", "content": "run"},
+        {
+            "role": "tool",
+            "tool_call_id": "call-2",
+            "content": '{"error":"blocked"}',
+        },
+    ]
+    cli._recover_failed_chat_turn(rejected, turn_start=0)
+    assert rejected == []
 
 
 def test_stream_chat_response_concatenates_deltas():
@@ -416,6 +771,128 @@ def _ns_for_chat(port: int, **overrides) -> object:
     for k, v in overrides.items():
         setattr(ns, k, v)
     return ns
+
+
+def test_chat_command_owns_mcp_runtime_without_configuring_serve(monkeypatch, capsys):
+    created = []
+    cleanup_callbacks = []
+    loop_payloads = []
+
+    class _Runtime:
+        tools = _FakeMCPRuntime.tools
+        server_count = 2
+        connection_errors = {}
+
+        def __init__(self, path):
+            assert path == "/tmp/chat-mcp.json"
+            self.closed = False
+            created.append(self)
+
+        def close(self):
+            self.closed = True
+
+    def _complete(base_url, payload, runtime, timeout_s):
+        loop_payloads.append((base_url, deepcopy(payload), runtime, timeout_s))
+        return "done", {"completion_tokens": 1, "finish_reason": "stop"}
+
+    monkeypatch.setattr("vllm_mlx.chat_mcp.ChatMCPRuntime", _Runtime)
+    monkeypatch.setattr(cli, "_complete_chat_with_mcp", _complete)
+    monkeypatch.setattr("atexit.register", cleanup_callbacks.append)
+    monkeypatch.setattr("builtins.input", lambda _p="": next(iter_inputs))
+
+    iter_inputs = iter(["use a tool", "exit"])
+    with _fake_server([]) as (port, _payloads):
+        cli.chat_command(_ns_for_chat(port, mcp_config="/tmp/chat-mcp.json"))
+
+    assert len(created) == 1
+    assert len(loop_payloads) == 1
+    assert loop_payloads[0][0] == f"http://127.0.0.1:{port}"
+    assert loop_payloads[0][1]["messages"] == [
+        {"role": "user", "content": "use a tool"}
+    ]
+    assert "done" in capsys.readouterr().out
+
+    assert created[0].closed is True
+    cleanup_callbacks[0]()
+    assert created[0].closed is True
+
+
+def test_chat_command_closes_mcp_runtime_on_unexpected_error(monkeypatch):
+    created = []
+
+    class _Runtime:
+        tools = _FakeMCPRuntime.tools
+        server_count = 1
+        connection_errors = {}
+
+        def __init__(self, _path):
+            self.closed = False
+            created.append(self)
+
+        def close(self):
+            self.closed = True
+
+    def _explode(*_args, **_kwargs):
+        raise ValueError("unexpected")
+
+    monkeypatch.setattr("vllm_mlx.chat_mcp.ChatMCPRuntime", _Runtime)
+    monkeypatch.setattr(cli, "_complete_chat_with_mcp", _explode)
+    monkeypatch.setattr("builtins.input", lambda _p="": "use a tool")
+
+    with (
+        _fake_server([]) as (port, _payloads),
+        pytest.raises(ValueError, match="unexpected"),
+    ):
+        cli.chat_command(_ns_for_chat(port, mcp_config="/tmp/chat-mcp.json"))
+
+    assert created[0].closed is True
+
+
+def test_chat_command_surfaces_and_retries_mcp_close_failure(monkeypatch):
+    cleanup_callbacks = []
+    created = []
+
+    class _Runtime:
+        tools = _FakeMCPRuntime.tools
+        server_count = 1
+        connection_errors = {}
+
+        def __init__(self, _path):
+            self.close_calls = 0
+            created.append(self)
+
+        def close(self):
+            self.close_calls += 1
+            if self.close_calls == 1:
+                raise RuntimeError("still stopping")
+
+    monkeypatch.setattr("vllm_mlx.chat_mcp.ChatMCPRuntime", _Runtime)
+    monkeypatch.setattr("atexit.register", cleanup_callbacks.append)
+    monkeypatch.setattr("builtins.input", lambda _p="": "exit")
+
+    with (
+        _fake_server([]) as (port, _payloads),
+        pytest.raises(RuntimeError, match="Failed to close MCP runtime"),
+    ):
+        cli.chat_command(_ns_for_chat(port, mcp_config="/tmp/chat-mcp.json"))
+
+    cleanup_callbacks[0]()
+    assert created[0].close_calls == 2
+
+
+def test_chat_command_reports_mcp_startup_failure(monkeypatch, capsys):
+    class _BrokenRuntime:
+        def __init__(self, _path):
+            raise RuntimeError("cannot connect")
+
+    monkeypatch.setattr("vllm_mlx.chat_mcp.ChatMCPRuntime", _BrokenRuntime)
+    with (
+        _fake_server([]) as (port, _payloads),
+        pytest.raises(SystemExit) as exc,
+    ):
+        cli.chat_command(_ns_for_chat(port, mcp_config="/tmp/bad.json"))
+    assert exc.value.code == 1
+    assert "Failed to start MCP" in capsys.readouterr().out
 
 
 def test_stream_chat_response_captures_usage_into_metrics():
@@ -1969,6 +2446,7 @@ def test_spawn_chat_server_sets_chat_spawn_env(monkeypatch, tmp_path):
 
     assert captured["env"] is not None
     assert captured["env"].get("RAPID_MLX_CHAT_SPAWN") == "1"
+    assert "--mcp-config" not in captured["cmd"]
 
 
 def test_sigterm_handler_masks_second_sigterm(monkeypatch):

--- a/vllm_mlx/chat_mcp.py
+++ b/vllm_mlx/chat_mcp.py
@@ -1,0 +1,365 @@
+# SPDX-License-Identifier: Apache-2.0
+"""MCP tools for the built-in ``rapid-mlx chat`` agent.
+
+The official MCP SDK owns transports and sessions. AnyIO's BlockingPortal
+bridges the synchronous REPL to that async SDK without a custom worker queue
+or event-loop lifecycle.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import concurrent.futures
+import json
+import re
+import sys
+import threading
+from contextlib import AsyncExitStack
+from typing import Any
+
+from anyio.abc import TaskStatus
+from anyio.from_thread import start_blocking_portal
+
+from .mcp.config import load_mcp_config
+from .mcp.executor import validate_tool_arguments
+from .mcp.security import ToolSandbox
+from .mcp.tools import mcp_tools_to_openai
+from .mcp.types import MCPServerConfig, MCPTool, MCPTransport
+
+_OPENAI_FUNCTION_NAME_RE = re.compile(r"^[A-Za-z0-9_-]{1,64}$")
+_MAX_SHUTDOWN_SECONDS = 5.0
+
+
+class ChatMCPRuntime:
+    """Synchronous facade over SDK sessions running in an AnyIO portal."""
+
+    def __init__(self, config_path: str):
+        self._config = load_mcp_config(config_path)
+        self._enabled_servers = [
+            server for server in self._config.servers.values() if server.enabled
+        ]
+        if not self._enabled_servers:
+            raise ValueError("MCP config has no enabled servers")
+
+        self._sandbox = ToolSandbox(
+            allowed_high_risk_tools=set(self._config.allowed_high_risk_tools)
+        )
+        self._groups: dict[str, Any] = {}
+        self._tools_by_name: dict[str, MCPTool] = {}
+        self._connection_errors: dict[str, str] = {}
+        self._closed = False
+        self._state_lock = threading.RLock()
+        self._active_future = None
+        self._active_done: threading.Event | None = None
+        self._stop_event: asyncio.Event | None = None
+        self.tools: list[dict[str, Any]] = []
+
+        self._portal_context = start_blocking_portal(
+            backend="asyncio",
+            name="rapid-mlx-chat-mcp",
+        )
+        self._portal = self._portal_context.__enter__()
+        try:
+            self._lifecycle_future, _ = self._portal.start_task(self._lifecycle)
+        except BaseException:
+            exc_info = sys.exc_info()
+            self._portal_context.__exit__(*exc_info)
+            self._closed = True
+            raise
+
+        if not self.tools:
+            details = "; ".join(
+                f"{name}: {error}"
+                for name, error in sorted(self._connection_errors.items())
+            )
+            self.close()
+            suffix = f" ({details})" if details else ""
+            raise RuntimeError(f"No MCP tools available{suffix}")
+
+    @property
+    def connection_errors(self) -> dict[str, str]:
+        """Servers that failed while other configured servers stayed usable."""
+
+        return dict(self._connection_errors)
+
+    @property
+    def server_count(self) -> int:
+        """Number of connected MCP servers."""
+
+        return len(self._groups)
+
+    def execute_tool_calls(
+        self,
+        tool_calls: list[dict[str, Any]],
+    ) -> list[dict[str, Any]]:
+        """Execute calls sequentially and return OpenAI ``tool`` messages."""
+
+        done = threading.Event()
+        with self._state_lock:
+            if self._closed:
+                raise RuntimeError("MCP runtime is closed")
+            future = self._portal.start_task_soon(
+                self._execute_with_done,
+                tool_calls,
+                done,
+            )
+            self._active_future = future
+            self._active_done = done
+        try:
+            return future.result()
+        except BaseException:
+            future.cancel()
+            cancel_timeout = max(server.timeout for server in self._enabled_servers) + 1
+            if not done.wait(timeout=cancel_timeout):
+                raise RuntimeError(
+                    f"MCP tool cancellation timed out after {cancel_timeout:g} seconds"
+                )
+            raise
+        finally:
+            with self._state_lock:
+                if self._active_future is future:
+                    self._active_future = None
+                    self._active_done = None
+
+    def close(self) -> None:
+        """Close SDK sessions and stop the AnyIO portal."""
+
+        with self._state_lock:
+            if self._closed:
+                return
+            cancellation_error = None
+            if self._active_future is not None:
+                self._active_future.cancel()
+                cancel_timeout = (
+                    max(server.timeout for server in self._enabled_servers) + 1
+                )
+                if self._active_done is not None and not self._active_done.wait(
+                    timeout=cancel_timeout
+                ):
+                    cancellation_error = RuntimeError(
+                        "MCP tool cancellation timed out after "
+                        f"{cancel_timeout:g} seconds"
+                    )
+            try:
+                self._portal.call(self._request_stop)
+                shutdown_timeout = (
+                    sum(
+                        min(server.timeout, _MAX_SHUTDOWN_SECONDS)
+                        for server in self._enabled_servers
+                    )
+                    + 1
+                )
+                try:
+                    self._lifecycle_future.result(timeout=shutdown_timeout)
+                except concurrent.futures.TimeoutError as exc:
+                    self._lifecycle_future.cancel()
+                    raise RuntimeError(
+                        "MCP lifecycle shutdown timed out after "
+                        f"{shutdown_timeout:g} seconds"
+                    ) from exc
+            finally:
+                self._portal_context.__exit__(None, None, None)
+                self._closed = True
+            if cancellation_error is not None:
+                raise cancellation_error
+
+    async def _lifecycle(self, *, task_status: TaskStatus[None]) -> None:
+        from mcp.client.session_group import ClientSessionGroup
+
+        self._stop_event = asyncio.Event()
+        async with AsyncExitStack() as stack:
+            for server in self._enabled_servers:
+                group = ClientSessionGroup(
+                    component_name_hook=lambda name, _info, label=server.name: (
+                        f"{label}__{name}"
+                    )
+                )
+                try:
+                    await group.__aenter__()
+                    try:
+                        await asyncio.wait_for(
+                            group.connect_to_server(_server_parameters(server)),
+                            timeout=server.timeout,
+                        )
+                    except BaseException:
+                        await _close_group(
+                            group,
+                            server.name,
+                            server.timeout,
+                            sys.exc_info(),
+                        )
+                        raise
+                except (TimeoutError, asyncio.TimeoutError):
+                    self._connection_errors[server.name] = (
+                        f"connection timed out after {server.timeout:g} seconds"
+                    )
+                    continue
+                except Exception as exc:
+                    self._connection_errors[server.name] = str(exc)
+                    continue
+
+                stack.push_async_callback(
+                    _close_group,
+                    group,
+                    server.name,
+                    server.timeout,
+                    (None, None, None),
+                )
+                self._groups[server.name] = group
+                for full_name, sdk_tool in group.tools.items():
+                    if not _OPENAI_FUNCTION_NAME_RE.fullmatch(full_name):
+                        raise RuntimeError(
+                            f"MCP tool name {full_name!r} is not a valid OpenAI "
+                            "function name (1-64 letters, digits, '_' or '-')"
+                        )
+                    if full_name in self._tools_by_name:
+                        previous = self._tools_by_name[full_name]
+                        raise RuntimeError(
+                            f"MCP tool name collision: {full_name!r} is exposed by "
+                            f"both {previous.server_name!r} and {server.name!r}"
+                        )
+                    self._tools_by_name[full_name] = MCPTool(
+                        server_name=server.name,
+                        name=sdk_tool.name,
+                        description=sdk_tool.description or "",
+                        input_schema=sdk_tool.inputSchema or {},
+                    )
+
+            self.tools = mcp_tools_to_openai(list(self._tools_by_name.values()))
+            task_status.started()
+            await self._stop_event.wait()
+
+    def _request_stop(self) -> None:
+        if self._stop_event is not None:
+            self._stop_event.set()
+
+    async def _execute_with_done(
+        self,
+        tool_calls: list[dict[str, Any]],
+        done: threading.Event,
+    ) -> list[dict[str, Any]]:
+        try:
+            return await self._execute(tool_calls)
+        finally:
+            done.set()
+
+    async def _execute(
+        self,
+        tool_calls: list[dict[str, Any]],
+    ) -> list[dict[str, Any]]:
+        messages: list[dict[str, Any]] = []
+        for position, tool_call in enumerate(tool_calls):
+            call_id = str(tool_call.get("id") or f"call_{position}")
+            function = tool_call.get("function") or {}
+            full_name = str(function.get("name") or "")
+            tool = self._tools_by_name.get(full_name)
+            arguments: dict[str, Any] = {}
+
+            try:
+                raw_arguments = function.get("arguments", "{}")
+                parsed_arguments = (
+                    json.loads(raw_arguments)
+                    if isinstance(raw_arguments, str)
+                    else raw_arguments
+                )
+                if not isinstance(parsed_arguments, dict):
+                    raise ValueError("tool arguments must be a JSON object")
+                arguments = parsed_arguments
+                if tool is None:
+                    raise ValueError(f"Unknown MCP tool: {full_name or '<empty>'}")
+
+                validate_tool_arguments(tool, arguments, strict=True)
+                self._sandbox.validate_tool_execution(
+                    tool.name,
+                    tool.server_name,
+                    arguments,
+                )
+
+                group = self._groups[tool.server_name]
+                timeout = self._server_timeout(tool.server_name)
+                try:
+                    result = await asyncio.wait_for(
+                        group.call_tool(full_name, arguments),
+                        timeout=timeout,
+                    )
+                except (TimeoutError, asyncio.TimeoutError) as exc:
+                    raise RuntimeError(
+                        f"MCP tool {full_name!r} timed out after {timeout:g} seconds"
+                    ) from exc
+
+                content = json.dumps(
+                    result.model_dump(mode="json", by_alias=True, exclude_none=True),
+                    ensure_ascii=False,
+                )
+                is_error = bool(getattr(result, "isError", False))
+                self._sandbox.record_execution(
+                    tool.name,
+                    tool.server_name,
+                    arguments,
+                    success=not is_error,
+                    error_message=content if is_error else None,
+                )
+            except Exception as exc:
+                content = json.dumps({"error": str(exc)}, ensure_ascii=False)
+                if tool is not None:
+                    self._sandbox.record_execution(
+                        tool.name,
+                        tool.server_name,
+                        arguments,
+                        success=False,
+                        error_message=str(exc),
+                    )
+
+            messages.append(
+                {
+                    "role": "tool",
+                    "tool_call_id": call_id,
+                    "content": content,
+                }
+            )
+        return messages
+
+    def _server_timeout(self, server_name: str) -> float:
+        return self._config.servers[server_name].timeout
+
+
+async def _close_group(
+    group: Any,
+    server_name: str,
+    timeout: float,
+    exc_info: tuple,
+) -> None:
+    shutdown_timeout = min(timeout, _MAX_SHUTDOWN_SECONDS)
+    try:
+        await asyncio.wait_for(
+            group.__aexit__(*exc_info),
+            timeout=shutdown_timeout,
+        )
+    except (TimeoutError, asyncio.TimeoutError) as exc:
+        raise RuntimeError(
+            f"MCP server {server_name!r} shutdown timed out after "
+            f"{shutdown_timeout:g} seconds"
+        ) from exc
+
+
+def _server_parameters(server: MCPServerConfig):
+    """Translate Rapid's existing MCP config into official SDK parameters."""
+
+    from mcp.client.session_group import SseServerParameters
+    from mcp.client.stdio import StdioServerParameters, get_default_environment
+
+    if server.transport == MCPTransport.STDIO:
+        env = get_default_environment()
+        env.update(server.env or {})
+        return StdioServerParameters(
+            command=server.command or "",
+            args=server.args or [],
+            env=env,
+        )
+    if server.transport == MCPTransport.SSE:
+        return SseServerParameters(
+            url=server.url or "",
+            timeout=server.timeout,
+        )
+
+    raise ValueError(f"Unsupported MCP transport: {server.transport}")

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -5569,6 +5569,157 @@ def _stream_chat_response(
     return full
 
 
+def _complete_chat_with_mcp(
+    base_url: str,
+    payload: dict,
+    mcp_runtime,
+    timeout_s: int,
+    *,
+    max_rounds: int = 8,
+) -> tuple[str, dict]:
+    """Run the chat agent loop with MCP tools using non-streaming responses.
+
+    vLLM and SGLang use the same loop shape: expose MCP tools as ordinary
+    function tools, append the assistant tool call and matching tool output,
+    then ask the model again.  MCP transport and execution stay inside the
+    chat runtime; the inference server only sees standard Chat Completions
+    messages.
+    """
+    import json
+
+    import requests
+
+    messages = payload["messages"]
+    request_payload = {
+        **payload,
+        "stream": False,
+        "tools": mcp_runtime.tools,
+        "tool_choice": "auto",
+    }
+    request_payload.pop("stream_options", None)
+    total_usage: dict[str, int | float] = {}
+
+    for round_index in range(max_rounds + 1):
+        response = requests.post(
+            f"{base_url}/v1/chat/completions",
+            json=request_payload,
+            timeout=timeout_s,
+        )
+        if response.status_code != 200:
+            raise RuntimeError(f"HTTP {response.status_code}: {response.text[:500]}")
+        try:
+            body = response.json()
+            choice = body["choices"][0]
+            message = choice["message"]
+            if not isinstance(message, dict):
+                raise TypeError
+        except (KeyError, IndexError, TypeError, ValueError) as exc:
+            raise RuntimeError("Malformed chat completion response") from exc
+
+        usage = body.get("usage") or {}
+        if not isinstance(usage, dict):
+            raise RuntimeError("Malformed chat completion response")
+        for name, value in usage.items():
+            if isinstance(value, (int, float)) and not isinstance(value, bool):
+                total_usage[name] = total_usage.get(name, 0) + value
+
+        tool_calls = message.get("tool_calls") or []
+        if not isinstance(tool_calls, list):
+            raise RuntimeError("Malformed chat completion response")
+        if not tool_calls:
+            content = message.get("content") or ""
+            if not isinstance(content, str):
+                content = json.dumps(content, ensure_ascii=False)
+            metrics = dict(total_usage)
+            metrics["finish_reason"] = choice.get("finish_reason")
+            reasoning = message.get("reasoning_content")
+            if reasoning:
+                metrics["reasoning_content"] = reasoning
+            return content, metrics
+        if round_index == max_rounds:
+            raise RuntimeError(f"MCP tool loop exceeded {max_rounds} rounds")
+
+        normalized_calls = []
+        for position, tool_call in enumerate(tool_calls):
+            if not isinstance(tool_call, dict):
+                raise RuntimeError("Malformed chat completion response")
+            function = tool_call.get("function") or {}
+            if not isinstance(function, dict):
+                raise RuntimeError("Malformed chat completion response")
+            arguments = function.get("arguments", "{}")
+            if not isinstance(arguments, str):
+                arguments = json.dumps(arguments, ensure_ascii=False)
+            normalized_calls.append(
+                {
+                    "id": str(tool_call.get("id") or f"call_{round_index}_{position}"),
+                    "type": "function",
+                    "function": {
+                        "name": str(function.get("name") or ""),
+                        "arguments": arguments,
+                    },
+                }
+            )
+
+        assistant_message = {
+            "role": "assistant",
+            "content": message.get("content"),
+            "tool_calls": normalized_calls,
+        }
+        if message.get("reasoning_content"):
+            assistant_message["reasoning_content"] = message["reasoning_content"]
+        messages.append(assistant_message)
+        for position, tool_call in enumerate(normalized_calls):
+            try:
+                messages.extend(mcp_runtime.execute_tool_calls([tool_call]))
+            except BaseException:
+                for pending_call in normalized_calls[position:]:
+                    messages.append(
+                        {
+                            "role": "tool",
+                            "tool_call_id": pending_call["id"],
+                            "content": json.dumps(
+                                {"error": "Tool execution interrupted"},
+                                ensure_ascii=False,
+                            ),
+                        }
+                    )
+                raise
+
+    raise RuntimeError(f"MCP tool loop exceeded {max_rounds} rounds")
+
+
+def _recover_failed_chat_turn(messages: list[dict], turn_start: int) -> None:
+    """Keep completed tool side effects in history; otherwise roll back."""
+
+    import json
+
+    tool_succeeded = False
+    for message in messages[turn_start + 1 :]:
+        if message.get("role") != "tool":
+            continue
+        try:
+            result = json.loads(message.get("content") or "")
+        except (TypeError, ValueError):
+            continue
+        if (
+            isinstance(result, dict)
+            and "error" not in result
+            and result.get("isError") is not True
+        ):
+            tool_succeeded = True
+            break
+
+    if tool_succeeded:
+        messages.append(
+            {
+                "role": "assistant",
+                "content": "Tool execution completed, but the follow-up response failed.",
+            }
+        )
+    else:
+        del messages[turn_start:]
+
+
 def chat_command(args):
     """Interactive REPL chat with a model.
 
@@ -5586,6 +5737,7 @@ def chat_command(args):
     base_url: str
     proc = None
     log_path: str | None = None
+    mcp_runtime = None
     # Tracks every spawned server (initial + every /model candidate) so
     # the SIGTERM/atexit cleanup tears down in-flight candidates too —
     # not just the bound ``proc``. A SIGTERM landing while a /model
@@ -5704,8 +5856,18 @@ def chat_command(args):
         except (ValueError, OSError):
             pass
         try:
+            mcp_close_error = None
+            if mcp_runtime is not None:
+                try:
+                    mcp_runtime.close()
+                except Exception as exc:
+                    mcp_close_error = exc
             for p in list(_active_procs):
                 _teardown_proc(p)
+            if mcp_close_error is not None:
+                raise RuntimeError(
+                    f"Failed to close MCP runtime: {mcp_close_error}"
+                ) from mcp_close_error
             _cleanup_state["done"] = True
         finally:
             # Best-effort restore so post-cleanup signals route normally.
@@ -6134,143 +6296,183 @@ def chat_command(args):
             f"{DIM}(history cleared){RESET}\n"
         )
 
-    while True:
-        try:
-            line = input(prompt).rstrip()
-        except (EOFError, KeyboardInterrupt):
-            print()
-            break
-        if not line:
-            continue
-        # Heredoc-pasted content must NEVER be dispatched as a slash
-        # command — a markdown doc whose first line starts with `/path`
-        # or whose content includes `/save` would otherwise be silently
-        # eaten by the slash dispatcher. Track the source so we know.
-        is_heredoc = False
-        if line == '"""':
-            line = _read_multiline()
+    try:
+        if getattr(args, "mcp_config", None):
+            from vllm_mlx.chat_mcp import ChatMCPRuntime
+
+            try:
+                mcp_runtime = ChatMCPRuntime(args.mcp_config)
+            except (ImportError, OSError, RuntimeError, ValueError) as exc:
+                print(f"\n  {RED}Failed to start MCP:{RESET} {exc}")
+                _cleanup()
+                sys.exit(1)
+            print(
+                f"  {GREEN}✓ MCP ready:{RESET} "
+                f"{len(mcp_runtime.tools)} tool(s) from "
+                f"{mcp_runtime.server_count} server(s)."
+            )
+            for server_name, error in sorted(mcp_runtime.connection_errors.items()):
+                print(f"  {YELLOW}MCP server {server_name} unavailable:{RESET} {error}")
+
+        while True:
+            try:
+                line = input(prompt).rstrip()
+            except (EOFError, KeyboardInterrupt):
+                print()
+                break
             if not line:
                 continue
-            is_heredoc = True
-        if not is_heredoc:
-            # Parse the leading word as the command and dispatch on
-            # *exact* match. ``startswith("/save")`` would otherwise treat
-            # ``/savefoo`` as ``/save`` (with arg ``foo``), silently
-            # writing a file from a typo. Same for ``/modelfoo``.
-            # ``str.split(maxsplit=1)`` (no separator arg) splits on any
-            # whitespace, so ``/save\tpath.md`` works the same as
-            # ``/save path.md``.
-            parts = line.split(maxsplit=1)
-            cmd = parts[0] if parts else ""
-            rest = parts[1].strip() if len(parts) > 1 else ""
-            # ``/bye`` is an Ollama-muscle-memory alias for ``/exit`` /
-            # ``/quit``. ``/?`` mirrors ``/help`` and was already
-            # supported; both alias sets are advertised in ``/help``.
-            if cmd in ("exit", "quit", "/exit", "/quit", "/bye"):
-                break
-            if cmd in ("/help", "/?"):
-                _print_help()
-                continue
-            if cmd in ("/reset", "/clear"):
-                messages = (
-                    [{"role": "system", "content": args.system}] if args.system else []
-                )
-                print(f"  {DIM}(history cleared){RESET}\n")
-                continue
-            if cmd == "/save":
-                if not rest:
-                    print(f"  {YELLOW}Usage: /save <path>{RESET}\n")
-                else:
-                    _save_conversation(rest)
-                continue
-            if cmd == "/model":
-                if not rest:
+            # Heredoc-pasted content must NEVER be dispatched as a slash
+            # command — a markdown doc whose first line starts with `/path`
+            # or whose content includes `/save` would otherwise be silently
+            # eaten by the slash dispatcher. Track the source so we know.
+            is_heredoc = False
+            if line == '"""':
+                line = _read_multiline()
+                if not line:
+                    continue
+                is_heredoc = True
+            if not is_heredoc:
+                # Parse the leading word as the command and dispatch on
+                # *exact* match. ``startswith("/save")`` would otherwise treat
+                # ``/savefoo`` as ``/save`` (with arg ``foo``), silently
+                # writing a file from a typo. Same for ``/modelfoo``.
+                # ``str.split(maxsplit=1)`` (no separator arg) splits on any
+                # whitespace, so ``/save\tpath.md`` works the same as
+                # ``/save path.md``.
+                parts = line.split(maxsplit=1)
+                cmd = parts[0] if parts else ""
+                rest = parts[1].strip() if len(parts) > 1 else ""
+                # ``/bye`` is an Ollama-muscle-memory alias for ``/exit`` /
+                # ``/quit``. ``/?`` mirrors ``/help`` and was already
+                # supported; both alias sets are advertised in ``/help``.
+                if cmd in ("exit", "quit", "/exit", "/quit", "/bye"):
+                    break
+                if cmd in ("/help", "/?"):
+                    _print_help()
+                    continue
+                if cmd in ("/reset", "/clear"):
+                    messages = (
+                        [{"role": "system", "content": args.system}]
+                        if args.system
+                        else []
+                    )
+                    print(f"  {DIM}(history cleared){RESET}\n")
+                    continue
+                if cmd == "/save":
+                    if not rest:
+                        print(f"  {YELLOW}Usage: /save <path>{RESET}\n")
+                    else:
+                        _save_conversation(rest)
+                    continue
+                if cmd == "/model":
+                    if not rest:
+                        print(
+                            f"  {YELLOW}Usage: /model <alias>{RESET}  "
+                            f"{DIM}(see `rapid-mlx models`){RESET}\n"
+                        )
+                    else:
+                        _switch_model(rest)
+                    continue
+                if cmd.startswith("/"):
                     print(
-                        f"  {YELLOW}Usage: /model <alias>{RESET}  "
-                        f"{DIM}(see `rapid-mlx models`){RESET}\n"
+                        f"  {YELLOW}Unknown command: {cmd}{RESET}  "
+                        f"{DIM}(type /help){RESET}\n"
+                    )
+                    continue
+
+            turn_start = len(messages)
+            messages.append({"role": "user", "content": line})
+            payload = {
+                "model": served_name,
+                "messages": messages,
+                "max_tokens": args.max_tokens,
+                "temperature": args.temperature,
+                "stream": True,
+                "stream_options": {"include_usage": True},
+                **extra,
+            }
+            # Claude-Code-style turn marker: a colored bullet introduces the
+            # assistant's response so the user can visually scan turn
+            # boundaries when scrolling back through long conversations.
+            sys.stdout.write(f"\n  {CYAN}●{RESET} ")
+            sys.stdout.flush()
+            metrics: dict = {}
+            start_t = time.monotonic()
+            try:
+                if mcp_runtime is None:
+                    assistant = _stream_chat_response(
+                        base_url,
+                        payload,
+                        timeout_s=args.response_timeout,
+                        metrics=metrics,
                     )
                 else:
-                    _switch_model(rest)
+                    assistant, metrics = _complete_chat_with_mcp(
+                        base_url,
+                        payload,
+                        mcp_runtime,
+                        timeout_s=args.response_timeout,
+                    )
+                    reasoning = metrics.get("reasoning_content")
+                    if reasoning:
+                        sys.stdout.write(f"{DIM}[thinking] {reasoning}{RESET}\n  ")
+                    sys.stdout.write(assistant)
+                    sys.stdout.flush()
+            except KeyboardInterrupt:
+                print(f"\n  {YELLOW}(response interrupted){RESET}\n")
+                _recover_failed_chat_turn(messages, turn_start)
                 continue
-            if cmd.startswith("/"):
+            except RuntimeError as e:
+                print(f"\n  {RED}{e}{RESET}\n")
+                _recover_failed_chat_turn(messages, turn_start)
+                continue
+            except requests.RequestException as e:
+                # Connection refused, timeout, dropped midstream — keep the REPL
+                # alive and roll back the failed user turn so the next request
+                # doesn't carry a dangling user role with no assistant reply.
+                print(f"\n  {RED}Request failed:{RESET} {e}\n")
+                _recover_failed_chat_turn(messages, turn_start)
+                continue
+            elapsed = time.monotonic() - start_t
+            # Speed line: prefer server-reported usage, fall back to a rough
+            # 4-chars-per-token estimate when the server doesn't ship usage
+            # in the stream.
+            tokens = metrics.get("completion_tokens")
+            if not tokens:
+                tokens = max(1, len(assistant) // 4)
+                tokens_label = f"~{tokens}"
+            else:
+                tokens_label = str(tokens)
+            if assistant and elapsed > 0:
+                tps = tokens / elapsed
                 print(
-                    f"  {YELLOW}Unknown command: {cmd}{RESET}  "
-                    f"{DIM}(type /help){RESET}\n"
+                    f"\n  {DIM}{tokens_label} tok · {elapsed:.1f}s · "
+                    f"{tps:.0f} tok/s{RESET}\n"
                 )
-                continue
-
-        messages.append({"role": "user", "content": line})
-        payload = {
-            "model": served_name,
-            "messages": messages,
-            "max_tokens": args.max_tokens,
-            "temperature": args.temperature,
-            "stream": True,
-            "stream_options": {"include_usage": True},
-            **extra,
-        }
-        # Claude-Code-style turn marker: a colored bullet introduces the
-        # assistant's response so the user can visually scan turn
-        # boundaries when scrolling back through long conversations.
-        sys.stdout.write(f"\n  {CYAN}●{RESET} ")
-        sys.stdout.flush()
-        metrics: dict = {}
-        start_t = time.monotonic()
-        try:
-            assistant = _stream_chat_response(
-                base_url,
-                payload,
-                timeout_s=args.response_timeout,
-                metrics=metrics,
-            )
-        except KeyboardInterrupt:
-            print(f"\n  {YELLOW}(response interrupted){RESET}\n")
-            messages.pop()
-            continue
-        except RuntimeError as e:
-            print(f"\n  {RED}{e}{RESET}\n")
-            messages.pop()
-            continue
-        except requests.RequestException as e:
-            # Connection refused, timeout, dropped midstream — keep the REPL
-            # alive and roll back the failed user turn so the next request
-            # doesn't carry a dangling user role with no assistant reply.
-            print(f"\n  {RED}Request failed:{RESET} {e}\n")
-            messages.pop()
-            continue
-        elapsed = time.monotonic() - start_t
-        # Speed line: prefer server-reported usage, fall back to a rough
-        # 4-chars-per-token estimate when the server doesn't ship usage
-        # in the stream.
-        tokens = metrics.get("completion_tokens")
-        if not tokens:
-            tokens = max(1, len(assistant) // 4)
-            tokens_label = f"~{tokens}"
-        else:
-            tokens_label = str(tokens)
-        if assistant and elapsed > 0:
-            tps = tokens / elapsed
-            print(
-                f"\n  {DIM}{tokens_label} tok · {elapsed:.1f}s · "
-                f"{tps:.0f} tok/s{RESET}\n"
-            )
-        else:
-            print()
-        # Length-cut + empty-content warning. When the server stops
-        # because ``finish_reason == "length"`` AND no visible content
-        # was streamed (only reasoning), the user otherwise sees an
-        # empty bullet and has no signal that the budget was the
-        # problem. This is the round-1 ``--think`` regression: 2048-
-        # token budget filled by reasoning on small models, zero answer.
-        if metrics.get("finish_reason") == "length" and not assistant:
-            print(
-                f"  {YELLOW}(reasoning consumed the full --max-tokens "
-                f"budget; bump --max-tokens for a final answer){RESET}\n"
-            )
-        if assistant:
-            messages.append({"role": "assistant", "content": assistant})
-        else:
-            messages.pop()
+            else:
+                print()
+            # Length-cut + empty-content warning. When the server stops
+            # because ``finish_reason == "length"`` AND no visible content
+            # was streamed (only reasoning), the user otherwise sees an
+            # empty bullet and has no signal that the budget was the
+            # problem. This is the round-1 ``--think`` regression: 2048-
+            # token budget filled by reasoning on small models, zero answer.
+            if metrics.get("finish_reason") == "length" and not assistant:
+                print(
+                    f"  {YELLOW}(reasoning consumed the full --max-tokens "
+                    f"budget; bump --max-tokens for a final answer){RESET}\n"
+                )
+            if assistant:
+                messages.append({"role": "assistant", "content": assistant})
+            else:
+                _recover_failed_chat_turn(messages, turn_start)
+    finally:
+        # Do not defer MCP shutdown to ``atexit``. The official SDK owns helper
+        # threads for stdio sessions, and Python waits for non-daemon threads
+        # before running atexit callbacks. Closing here avoids that shutdown
+        # ordering deadlock and also tears down a spawned model server promptly.
+        _cleanup()
 
 
 def info_command(args):
@@ -8217,6 +8419,12 @@ Examples:
         type=int,
         default=600,
         help="Seconds to wait for a single assistant response (default: 600)",
+    )
+    chat_parser.add_argument(
+        "--mcp-config",
+        type=str,
+        default=None,
+        help="Path to an MCP config file whose tools are available in this chat",
     )
 
     # Info command — show the per-model profile (parsers + capability gates)


### PR DESCRIPTION
Closes #1140

## Why

`rapid-mlx chat` is the first-party interactive agent surface. Users should be able to give that agent tools from multiple MCP servers without moving MCP execution into the inference server or writing a separate agent loop.

## Scope and architecture

- Adds `rapid-mlx chat ... --mcp-config mcp.json`.
- Keeps MCP lifecycle, discovery, validation, and execution inside the `chat` process.
- Sends only standard OpenAI function tools, assistant tool calls, and tool-result messages to the model server.
- Uses the official MCP Python SDK's `ClientSessionGroup` for stdio/SSE transport and session lifecycle.
- Follows the bounded sequential tool loop used by vLLM/SGLang: model → tool calls → tool results → model, up to 8 rounds.
- Supports multiple configured servers with stable `server__tool` names.
- Does not change `serve`, `share`, their flags, or server-side MCP routes.

## User impact

Both a locally spawned model server and an existing `--base-url` work with the same chat-local MCP config:

```bash
rapid-mlx chat qwen3.5-4b-4bit --mcp-config mcp.json
rapid-mlx chat --base-url http://localhost:8000 --mcp-config mcp.json
```

## Validation

- Real local build/E2E: Qwen3.5 4B + two real stdio FastMCP servers; the model selected MCP tools and returned the requested `beta:final-check` result.
- Verified normal `exit` closes both MCP child processes with no leftovers.
- Focused MCP/chat suite: 102 passed.
- Full non-integration unit suite: 13,648 passed, 30 skipped, 17 deselected, 6 xfailed, 1 xpassed.
- New MCP runtime line/branch coverage: 93%.
- Ruff check/format and `git diff --check`: pass.
