### PR TITLE
polish(chat): show MCP tool activity and quiet startup noise

### DIFF
--- a/tests/test_chat_mcp.py
+++ b/tests/test_chat_mcp.py
@@ -5,12 +5,17 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 import threading
 from types import SimpleNamespace
 
 import pytest
 
-from vllm_mlx.chat_mcp import ChatMCPRuntime, _server_parameters
+from vllm_mlx.chat_mcp import (
+    ChatMCPRuntime,
+    _quiet_optional_component_warnings,
+    _server_parameters,
+)
 from vllm_mlx.mcp.types import MCPServerConfig, MCPTransport
 
 
@@ -394,6 +399,42 @@ def test_server_parameters_use_official_sdk_types():
     assert sse_params.url == "http://localhost:9999/sse"
     assert sse_params.timeout == 12
     assert sse_params.sse_read_timeout == 300
+
+
+def test_server_parameters_keep_npx_bootstrap_output_off_protocol():
+    quiet = _server_parameters(
+        MCPServerConfig(
+            name="filesystem",
+            command="/opt/homebrew/bin/npx",
+            args=["-y", "@modelcontextprotocol/server-filesystem", "/tmp"],
+        )
+    )
+    assert quiet.env["npm_config_loglevel"] == "silent"
+
+    explicit = _server_parameters(
+        MCPServerConfig(
+            name="filesystem",
+            command="npx",
+            args=["server"],
+            env={"NPM_CONFIG_LOGLEVEL": "warn"},
+        )
+    )
+    assert explicit.env["NPM_CONFIG_LOGLEVEL"] == "warn"
+    assert "npm_config_loglevel" not in explicit.env
+
+
+def test_optional_component_warning_filter_keeps_actionable_warnings(caplog):
+    with (
+        caplog.at_level(logging.WARNING),
+        _quiet_optional_component_warnings(),
+    ):
+        logging.warning("Could not fetch prompts: Method not found")
+        logging.warning("Could not fetch resources: Method not found")
+        logging.warning("Could not fetch prompts: permission denied")
+
+    assert [record.getMessage() for record in caplog.records] == [
+        "Could not fetch prompts: permission denied"
+    ]
 
 
 def test_runtime_thread_is_dedicated_to_chat(tmp_path):

--- a/tests/test_chat_mcp.py
+++ b/tests/test_chat_mcp.py
@@ -424,13 +424,16 @@ def test_server_parameters_keep_npx_bootstrap_output_off_protocol():
 
 
 def test_optional_component_warning_filter_keeps_actionable_warnings(caplog):
+    sdk_logger = logging.getLogger("mcp.client.session_group")
     with (
         caplog.at_level(logging.WARNING),
         _quiet_optional_component_warnings(),
     ):
+        # MCP 1.28 uses logging.warning directly; keep the named-logger path
+        # covered too so a future SDK cleanup cannot reintroduce the noise.
         logging.warning("Could not fetch prompts: Method not found")
-        logging.warning("Could not fetch resources: Method not found")
-        logging.warning("Could not fetch prompts: permission denied")
+        sdk_logger.warning("Could not fetch resources: Method not found")
+        sdk_logger.warning("Could not fetch prompts: permission denied")
 
     assert [record.getMessage() for record in caplog.records] == [
         "Could not fetch prompts: permission denied"

--- a/tests/test_cli_chat.py
+++ b/tests/test_cli_chat.py
@@ -225,6 +225,7 @@ def test_complete_chat_with_mcp_runs_standard_tool_loop(monkeypatch):
         ]
     )
     payloads = []
+    tool_progress = []
 
     def _post(_url, json, timeout):
         assert timeout == 10
@@ -245,6 +246,7 @@ def test_complete_chat_with_mcp_runs_standard_tool_loop(monkeypatch):
         },
         runtime,
         timeout_s=10,
+        on_tool_call=tool_progress.append,
     )
 
     assert answer == "The file says hello."
@@ -263,6 +265,7 @@ def test_complete_chat_with_mcp_runs_standard_tool_loop(monkeypatch):
         "tool_call_id": "call-1",
         "content": '{"content":"hello"}',
     }
+    assert tool_progress == ["files__read"]
 
 
 def test_complete_chat_with_mcp_preserves_reasoning_and_normalizes_calls(monkeypatch):
@@ -791,8 +794,9 @@ def test_chat_command_owns_mcp_runtime_without_configuring_serve(monkeypatch, ca
         def close(self):
             self.closed = True
 
-    def _complete(base_url, payload, runtime, timeout_s):
+    def _complete(base_url, payload, runtime, timeout_s, on_tool_call):
         loop_payloads.append((base_url, deepcopy(payload), runtime, timeout_s))
+        on_tool_call("files__read")
         return "done", {"completion_tokens": 1, "finish_reason": "stop"}
 
     monkeypatch.setattr("vllm_mlx.chat_mcp.ChatMCPRuntime", _Runtime)
@@ -810,7 +814,9 @@ def test_chat_command_owns_mcp_runtime_without_configuring_serve(monkeypatch, ca
     assert loop_payloads[0][1]["messages"] == [
         {"role": "user", "content": "use a tool"}
     ]
-    assert "done" in capsys.readouterr().out
+    output = capsys.readouterr().out
+    assert "using files.read…" in output
+    assert "done" in output
 
     assert created[0].closed is True
     cleanup_callbacks[0]()

--- a/vllm_mlx/chat_mcp.py
+++ b/vllm_mlx/chat_mcp.py
@@ -47,13 +47,18 @@ class _OptionalComponentWarningFilter(logging.Filter):
 def _quiet_optional_component_warnings():
     """Temporarily filter known ClientSessionGroup capability-probe noise."""
 
-    root_logger = logging.getLogger()
+    loggers = (
+        logging.getLogger(),
+        logging.getLogger("mcp.client.session_group"),
+    )
     warning_filter = _OptionalComponentWarningFilter()
-    root_logger.addFilter(warning_filter)
+    for logger in loggers:
+        logger.addFilter(warning_filter)
     try:
         yield
     finally:
-        root_logger.removeFilter(warning_filter)
+        for logger in loggers:
+            logger.removeFilter(warning_filter)
 
 
 class ChatMCPRuntime:

--- a/vllm_mlx/chat_mcp.py
+++ b/vllm_mlx/chat_mcp.py
@@ -11,10 +11,12 @@ from __future__ import annotations
 import asyncio
 import concurrent.futures
 import json
+import logging
 import re
 import sys
 import threading
-from contextlib import AsyncExitStack
+from contextlib import AsyncExitStack, contextmanager
+from pathlib import Path
 from typing import Any
 
 from anyio.abc import TaskStatus
@@ -28,6 +30,30 @@ from .mcp.types import MCPServerConfig, MCPTool, MCPTransport
 
 _OPENAI_FUNCTION_NAME_RE = re.compile(r"^[A-Za-z0-9_-]{1,64}$")
 _MAX_SHUTDOWN_SECONDS = 5.0
+_OPTIONAL_COMPONENT_WARNINGS = {
+    "Could not fetch prompts: Method not found",
+    "Could not fetch resources: Method not found",
+}
+
+
+class _OptionalComponentWarningFilter(logging.Filter):
+    """Hide SDK noise for optional MCP capabilities chat does not consume."""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        return record.getMessage() not in _OPTIONAL_COMPONENT_WARNINGS
+
+
+@contextmanager
+def _quiet_optional_component_warnings():
+    """Temporarily filter known ClientSessionGroup capability-probe noise."""
+
+    root_logger = logging.getLogger()
+    warning_filter = _OptionalComponentWarningFilter()
+    root_logger.addFilter(warning_filter)
+    try:
+        yield
+    finally:
+        root_logger.removeFilter(warning_filter)
 
 
 class ChatMCPRuntime:
@@ -177,10 +203,11 @@ class ChatMCPRuntime:
                 try:
                     await group.__aenter__()
                     try:
-                        await asyncio.wait_for(
-                            group.connect_to_server(_server_parameters(server)),
-                            timeout=server.timeout,
-                        )
+                        with _quiet_optional_component_warnings():
+                            await asyncio.wait_for(
+                                group.connect_to_server(_server_parameters(server)),
+                                timeout=server.timeout,
+                            )
                     except BaseException:
                         await _close_group(
                             group,
@@ -351,6 +378,12 @@ def _server_parameters(server: MCPServerConfig):
     if server.transport == MCPTransport.STDIO:
         env = get_default_environment()
         env.update(server.env or {})
+        if Path(server.command or "").name == "npx" and not any(
+            key.lower() == "npm_config_loglevel" for key in env
+        ):
+            # npm may print cold-install progress to stdout, which is the
+            # JSON-RPC transport for stdio MCP servers.
+            env["npm_config_loglevel"] = "silent"
         return StdioServerParameters(
             command=server.command or "",
             args=server.args or [],

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -5576,6 +5576,7 @@ def _complete_chat_with_mcp(
     timeout_s: int,
     *,
     max_rounds: int = 8,
+    on_tool_call=None,
 ) -> tuple[str, dict]:
     """Run the chat agent loop with MCP tools using non-streaming responses.
 
@@ -5670,6 +5671,8 @@ def _complete_chat_with_mcp(
         messages.append(assistant_message)
         for position, tool_call in enumerate(normalized_calls):
             try:
+                if on_tool_call is not None:
+                    on_tool_call(tool_call["function"]["name"])
                 messages.extend(mcp_runtime.execute_tool_calls([tool_call]))
             except BaseException:
                 for pending_call in normalized_calls[position:]:
@@ -6408,11 +6411,18 @@ def chat_command(args):
                         metrics=metrics,
                     )
                 else:
+
+                    def _show_mcp_tool_call(name: str) -> None:
+                        display_name = name.replace("__", ".", 1)
+                        sys.stdout.write(f"{DIM}using {display_name}…{RESET}\n  ")
+                        sys.stdout.flush()
+
                     assistant, metrics = _complete_chat_with_mcp(
                         base_url,
                         payload,
                         mcp_runtime,
                         timeout_s=args.response_timeout,
+                        on_tool_call=_show_mcp_tool_call,
                     )
                     reasoning = metrics.get("reasoning_content")
                     if reasoning:


### PR DESCRIPTION
## What changed

- show `using server.tool…` while `rapid-mlx chat` executes MCP tool calls
- suppress the MCP SDK's known `Method not found` warnings for optional prompts/resources that chat does not consume, while preserving actionable warnings
- default `npx` MCP subprocesses to `npm_config_loglevel=silent` unless the user explicitly configured a log level, keeping cold-install output off the stdio JSON-RPC channel

## Why

Real multi-server dogfooding after #1181 worked end to end, but users saw several seconds of blank waiting during tool execution plus harmless SDK warnings at startup. A cold `npx` install could also write package-manager progress to MCP stdout and trigger JSON-RPC parse warnings.

This keeps the agent loop and MCP lifecycle unchanged; it only improves terminal feedback and removes known transport noise. `serve` and `share` are untouched.

## Validation

- `104 passed` — `tests/test_chat_mcp.py tests/test_cli_chat.py`
- Ruff check and format check passed
- real local source build with Qwen3.5-4B and three official MCP servers (filesystem, time, fetch): 17 tools discovered, both requested tools executed, progress lines rendered, correct final answer returned
- confirmed optional SDK warnings and npm JSON-RPC parse noise no longer appear
- confirmed model and MCP child processes are cleaned up after chat exits