### PR TITLE
feat(reasoning): generation-time thinking-token budget (force-close </think>)

### DIFF
--- a/tests/test_grammar_scheduler_realign_558.py
+++ b/tests/test_grammar_scheduler_realign_558.py
@@ -13,7 +13,7 @@ the boot warmup fell back to free-form).
 from AUTHORITATIVE per-uid state: ``uid_to_request_processors`` holds the FULL
 processor list (grammar + penalties) for EVERY live uid that carries any
 processor — grammar AND penalty-only — so a bystander's penalties survive a
-length-desync rebuild (codex #3). A ``_known_grammar_processors`` identity set
+length-desync rebuild (codex #3). A ``_known_stateful_processors`` identity set
 (with tombstones for finished-but-still-leaked grammars) scrubs leaked grammars
 from untracked slots. These tests drive that method against a stand-in
 generation batch reproducing the desync shapes — no model needed.
@@ -41,34 +41,43 @@ def _make_scheduler_stub():
     stub = SimpleNamespace(
         uid_to_request_processors={},
         _uids_with_grammar=set(),
-        _known_grammar_processors=set(),
-        _grammar_processor_objs={},
-        _grammar_tombstones=set(),
+        _uids_with_reasoning_budget={},
+        _known_stateful_processors=set(),
+        _stateful_processor_objs={},
+        _stateful_tombstones=set(),
         batch_generator=None,
     )
     stub._realign_grammar_logits_processors = (
         Scheduler._realign_grammar_logits_processors.__get__(stub, type(stub))
     )
-    stub._flush_grammar_tombstones = Scheduler._flush_grammar_tombstones.__get__(
+    stub._flush_stateful_tombstones = Scheduler._flush_stateful_tombstones.__get__(
         stub, type(stub)
     )
     stub._forget_uid_grammar = Scheduler._forget_uid_grammar.__get__(stub, type(stub))
+    stub._realign_guard_armed = Scheduler._realign_guard_armed.__get__(stub, type(stub))
+    stub._register_uid_processors = Scheduler._register_uid_processors.__get__(
+        stub, type(stub)
+    )
     return stub
 
 
-def _register(stub, uid, processors, grammar=None):
-    """Mirror the scheduler's insert-time bookkeeping.
+def _register(stub, uid, processors, grammar=None, budget=None):
+    """Register a uid through the PRODUCTION bookkeeping helper.
 
-    ``grammar=None`` registers a penalty-only uid (tracked for desync repair but
-    not a grammar). A non-None ``grammar`` also registers its identity + arms
-    the guard, exactly like the scheduler insert site.
+    Delegates to ``Scheduler._register_uid_processors`` (the exact method the
+    admission path calls) rather than hand-reproducing its writes, so these
+    tests break if the real registration drops a grammar/budget arm or a penalty
+    list (codex NIT). ``grammar=None`` registers a penalty-only uid (tracked for
+    desync repair but not a grammar). A non-None ``grammar`` also registers its
+    identity + arms the guard. A non-None ``budget`` arms the guard for a
+    generation-time reasoning-budget processor AND registers its identity in the
+    same stateful set/tombstone machinery as grammar — a leaked force-close
+    processor must be scrubbed from a foreign slot exactly like a grammar (codex).
     """
-    if processors:
-        stub.uid_to_request_processors[uid] = list(processors)
-    if grammar is not None:
-        stub._uids_with_grammar.add(uid)
-        stub._known_grammar_processors.add(id(grammar))
-        stub._grammar_processor_objs[id(grammar)] = grammar
+    request = SimpleNamespace(reasoning_budget_logits_processor=budget)
+    stub._register_uid_processors(
+        uid, request, list(processors) if processors else None, grammar
+    )
 
 
 def test_realign_repairs_stale_leading_entry():
@@ -187,7 +196,7 @@ def test_realign_untracked_uid_with_no_processors_gets_empty_slot():
 def test_realign_scrubs_finished_grammar_via_tombstone():
     # codex #1: a grammar whose owning uid already FINISHED can still linger in
     # another slot. _forget_uid_grammar TOMBSTONES it (keeps it in
-    # _known_grammar_processors) so realign still scrubs it; only once it's
+    # _known_stateful_processors) so realign still scrubs it; only once it's
     # absent from every live slot is it fully forgotten.
     glp_live = object()
     glp_dead = object()  # finished owner, but leaked into uid 9's slot
@@ -196,10 +205,10 @@ def test_realign_scrubs_finished_grammar_via_tombstone():
     _register(stub, 8, [glp_dead], glp_dead)
     # uid 8 finishes: forget tombstones glp_dead (still known + scrubbable).
     stub._forget_uid_grammar(8)
-    assert id(glp_dead) in stub._known_grammar_processors, (
+    assert id(glp_dead) in stub._known_stateful_processors, (
         "must be tombstoned, not gone"
     )
-    assert id(glp_dead) in stub._grammar_tombstones
+    assert id(glp_dead) in stub._stateful_tombstones
     # A leaked slot still carries glp_dead at uid 9's (untracked) position.
     stub.batch_generator = _FakeBatchGen(
         uids=[7, 9], logits_processors=[[glp_live], [glp_dead]]
@@ -211,9 +220,9 @@ def test_realign_scrubs_finished_grammar_via_tombstone():
     assert lp[0] == [glp_live]
     assert lp[1] == [], "a finished (tombstoned) grammar must be scrubbed"
     # Now that it's absent from every slot, the tombstone is flushed.
-    assert id(glp_dead) not in stub._known_grammar_processors
-    assert id(glp_dead) not in stub._grammar_tombstones
-    assert id(glp_dead) not in stub._grammar_processor_objs
+    assert id(glp_dead) not in stub._known_stateful_processors
+    assert id(glp_dead) not in stub._stateful_tombstones
+    assert id(glp_dead) not in stub._stateful_processor_objs
 
 
 def test_tombstone_survives_until_absent_then_flushes():
@@ -228,7 +237,7 @@ def test_tombstone_survives_until_absent_then_flushes():
     stub._forget_uid_grammar(8)  # tombstoned; uid_to_request_processors now empty
     # A stale slot still holds glp_dead at an untracked position. The guard is
     # armed by the tombstone even though uid_to_request_processors is empty.
-    assert stub._grammar_tombstones, "tombstone must arm the realign guard"
+    assert stub._stateful_tombstones, "tombstone must arm the realign guard"
     stub.batch_generator = _FakeBatchGen(uids=[9], logits_processors=[[glp_dead]])
 
     stub._realign_grammar_logits_processors()
@@ -236,7 +245,7 @@ def test_tombstone_survives_until_absent_then_flushes():
     lp = stub.batch_generator._generation_batch.logits_processors
     assert lp[0] == [], "the tombstoned grammar is scrubbed from the leaked slot"
     # Scrubbed this tick -> now absent -> flushed.
-    assert id(glp_dead) not in stub._known_grammar_processors
+    assert id(glp_dead) not in stub._known_stateful_processors
 
 
 def test_realign_noop_when_already_correct():
@@ -263,8 +272,8 @@ def test_penalty_only_uid_does_not_arm_the_guard():
 
     assert 9 in stub.uid_to_request_processors, "tracked for desync repair"
     assert 9 not in stub._uids_with_grammar, "penalty-only must NOT arm the guard"
-    assert not stub._known_grammar_processors
-    assert not stub._grammar_tombstones
+    assert not stub._known_stateful_processors
+    assert not stub._stateful_tombstones
 
 
 def test_forget_penalty_only_uid_creates_no_tombstone():
@@ -275,15 +284,15 @@ def test_forget_penalty_only_uid_creates_no_tombstone():
     stub._forget_uid_grammar(9)
 
     assert 9 not in stub.uid_to_request_processors
-    assert not stub._grammar_tombstones, "a penalty-only uid must not tombstone"
-    assert not stub._known_grammar_processors
+    assert not stub._stateful_tombstones, "a penalty-only uid must not tombstone"
+    assert not stub._known_stateful_processors
 
 
-def test_forget_uid_grammar_tombstones_then_flush_drops_state():
+def test_forget_uid_stateful_tombstones_then_flush_drops_state():
     glp = object()
     stub = _make_scheduler_stub()
     _register(stub, 1, [glp], glp)
-    assert id(glp) in stub._known_grammar_processors
+    assert id(glp) in stub._known_stateful_processors
 
     stub._forget_uid_grammar(1)
 
@@ -292,14 +301,14 @@ def test_forget_uid_grammar_tombstones_then_flush_drops_state():
     # absent from every slot.
     assert 1 not in stub.uid_to_request_processors
     assert 1 not in stub._uids_with_grammar
-    assert id(glp) in stub._known_grammar_processors, "tombstoned, not yet dropped"
-    assert id(glp) in stub._grammar_tombstones
+    assert id(glp) in stub._known_stateful_processors, "tombstoned, not yet dropped"
+    assert id(glp) in stub._stateful_tombstones
 
     # No slot holds it -> flush drops it entirely.
-    stub._flush_grammar_tombstones(present=set())
-    assert id(glp) not in stub._known_grammar_processors
-    assert id(glp) not in stub._grammar_processor_objs
-    assert id(glp) not in stub._grammar_tombstones
+    stub._flush_stateful_tombstones(present=set())
+    assert id(glp) not in stub._known_stateful_processors
+    assert id(glp) not in stub._stateful_processor_objs
+    assert id(glp) not in stub._stateful_tombstones
 
 
 def test_realign_handles_missing_generation_batch():
@@ -317,7 +326,7 @@ def test_realign_handles_empty_uids_flushes_tombstones():
     stub.batch_generator = _FakeBatchGen(uids=[], logits_processors=[])
     stub._realign_grammar_logits_processors()  # no raise
     # No live slots -> tombstone is trivially absent everywhere -> flushed.
-    assert id(glp_dead) not in stub._known_grammar_processors
+    assert id(glp_dead) not in stub._known_stateful_processors
 
 
 def test_realign_empty_uids_scrubs_stale_processor_list():
@@ -343,8 +352,185 @@ def test_realign_empty_uids_scrubs_stale_processor_list():
         "slot must be scrubbed so the next plain request cannot inherit it"
     )
     # And the tombstone is flushed now that the grammar is absent everywhere.
-    assert id(glp_dead) not in stub._known_grammar_processors
-    assert id(glp_dead) not in stub._grammar_tombstones
+    assert id(glp_dead) not in stub._known_stateful_processors
+    assert id(glp_dead) not in stub._stateful_tombstones
+
+
+# ── generation-time reasoning-budget processors ───────────────────────
+#
+# A budget processor (force-close </think>) is a per-request logits processor
+# with the same desync exposure as a grammar: mlx-lm's positional list drops it
+# when a no-processor request finishes while the budget request is mid-flight.
+# Observed live on qwen3-0.6b: a plain greedy request preceding a budget request
+# left the budget inert (the </think> was never forced, reasoning ran unbounded)
+# because the budget uid did NOT arm the realign guard. So a live budget uid now
+# arms it too — its slot is rebuilt from ``uid_to_request_processors`` every tick.
+
+
+def test_realign_repairs_budget_processor_stale_leading_entry():
+    # The live-repro shape: a finished no-processor uid left a stale empty entry
+    # at index 0; the budget uid sits at index 1 but is the ONLY live uid.
+    # Realign must place the budget processor at the budget uid's real position.
+    rblp = object()
+    stub = _make_scheduler_stub()
+    _register(stub, 42, [rblp], budget=rblp)
+    stub.batch_generator = _FakeBatchGen(uids=[42], logits_processors=[[], [rblp]])
+
+    stub._realign_grammar_logits_processors()
+
+    lp = stub.batch_generator._generation_batch.logits_processors
+    assert len(lp) == 1, "logits_processors must be realigned to len(uids)"
+    assert lp[0] == [rblp], "the budget processor must land at its uid's index"
+
+
+def test_realign_preserves_budget_processor_on_length_desync():
+    # A budget request (uid 7) batched with a plain request (uid 9). A stale
+    # entry length-desyncs the positional list — the budget processor must NOT
+    # be zeroed off its uid (the exact bug: reasoning ran unbounded).
+    rblp = object()
+    stub = _make_scheduler_stub()
+    _register(stub, 7, [rblp], budget=rblp)
+    stub.batch_generator = _FakeBatchGen(
+        uids=[7, 9], logits_processors=[[], [rblp], []]
+    )
+
+    stub._realign_grammar_logits_processors()
+
+    lp = stub.batch_generator._generation_batch.logits_processors
+    assert len(lp) == 2, "realigned to len(uids)"
+    assert lp[0] == [rblp], "budget uid must keep its force-close processor"
+    assert lp[1] == [], "plain uid carries no processor"
+
+
+def test_realign_preserves_budget_plus_penalties_in_order():
+    # A budget uid may also carry penalties; the authoritative per-uid list keeps
+    # both in insert order (penalties first, budget appended LAST so its
+    # force-close mask has final say).
+    penalty = object()
+    rblp = object()
+    stub = _make_scheduler_stub()
+    _register(stub, 5, [penalty, rblp], budget=rblp)
+    stub.batch_generator = _FakeBatchGen(
+        uids=[5], logits_processors=[[], [penalty, rblp]]
+    )
+
+    stub._realign_grammar_logits_processors()
+
+    lp = stub.batch_generator._generation_batch.logits_processors
+    assert lp[0] == [penalty, rblp], "budget uid keeps penalty + budget in order"
+
+
+def test_realign_grammar_and_budget_coexist_on_distinct_uids():
+    # A grammar request and a budget request in the same batch each keep their
+    # own processor — neither leaks onto the other.
+    glp = object()
+    rblp = object()
+    stub = _make_scheduler_stub()
+    _register(stub, 7, [glp], grammar=glp)
+    _register(stub, 9, [rblp], budget=rblp)
+    stub.batch_generator = _FakeBatchGen(uids=[7, 9], logits_processors=[[glp], [rblp]])
+
+    stub._realign_grammar_logits_processors()
+
+    lp = stub.batch_generator._generation_batch.logits_processors
+    assert lp[0] == [glp]
+    assert lp[1] == [rblp]
+
+
+def test_realign_guard_armed_by_budget_uid_alone():
+    # Exercises the PRODUCTION arming predicate the scheduler step loop calls, so
+    # deleting the budget arm fails here (not only on live hardware). A live
+    # budget uid — with NO grammar and NO tombstone — must arm the realign.
+    rblp = object()
+    stub = _make_scheduler_stub()
+    assert stub._realign_guard_armed() is False, "empty batch: no realign"
+    _register(stub, 9, [rblp], budget=rblp)
+    assert stub._realign_guard_armed() is True, "a budget uid must arm the guard"
+    # It arms via the live-budget set, NOT as a grammar uid...
+    assert 9 in stub._uids_with_reasoning_budget
+    assert 9 not in stub._uids_with_grammar
+    # ...but its identity IS tracked in the stateful set so a leaked force-close
+    # processor can be tombstoned + scrubbed like a grammar (codex #1).
+    assert id(rblp) in stub._known_stateful_processors
+    assert not stub._stateful_tombstones, "not tombstoned while still live"
+
+
+def test_realign_guard_disarms_when_budget_processor_ended():
+    # codex R10 #4: once a budget processor has forced </think> (``_ended``) it is
+    # inert — it must STOP arming the guard so the answer-token decode loop does
+    # not pay an O(batch) slot rebuild per token. A live (not-ended) budget uid
+    # still arms; flipping ``_ended`` disarms it (no grammar / no tombstone here).
+    class _Budget:
+        def __init__(self):
+            self._ended = False
+
+    rblp = _Budget()
+    stub = _make_scheduler_stub()
+    _register(stub, 9, [rblp], budget=rblp)
+    assert stub._realign_guard_armed() is True, "active budget uid arms the guard"
+    rblp._ended = True
+    assert stub._realign_guard_armed() is False, (
+        "an ended (inert) budget processor must no longer arm the guard"
+    )
+    # Still tracked (uid live) so a later finish/leak is tombstoned + scrubbed.
+    assert 9 in stub._uids_with_reasoning_budget
+
+
+def test_realign_guard_not_armed_by_penalty_only_uid():
+    # A penalty-only uid is tracked for desync repair but MUST NOT arm the guard
+    # (perf: no O(batch) rebuild on the plain decode hot path).
+    penalty = object()
+    stub = _make_scheduler_stub()
+    _register(stub, 9, [penalty])  # penalty-only, no grammar, no budget
+    assert 9 in stub.uid_to_request_processors
+    assert stub._realign_guard_armed() is False
+
+
+def test_realign_guard_armed_by_grammar_uid():
+    glp = object()
+    stub = _make_scheduler_stub()
+    _register(stub, 7, [glp], grammar=glp)
+    assert stub._realign_guard_armed() is True
+
+
+def test_forget_budget_uid_tombstones_until_scrubbed():
+    # A finished budget uid must TOMBSTONE its force-close processor (not forget
+    # it outright): mlx-lm can leave the stateful processor in a leaked
+    # positional slot for a tick, and the tombstone keeps the realign guard armed
+    # so that slot is scrubbed before the processor is dropped (codex #1).
+    rblp = object()
+    stub = _make_scheduler_stub()
+    _register(stub, 9, [rblp], budget=rblp)
+
+    stub._forget_uid_grammar(9)
+
+    assert 9 not in stub._uids_with_reasoning_budget, "live arming cleared"
+    assert 9 not in stub.uid_to_request_processors, "per-uid state dropped"
+    # Tombstoned, NOT forgotten — the guard stays armed for the scrub tick.
+    assert id(rblp) in stub._stateful_tombstones
+    assert id(rblp) in stub._known_stateful_processors
+    assert stub._realign_guard_armed(), "tombstone keeps the guard armed"
+
+
+def test_leaked_budget_processor_scrubbed_from_foreign_slot_then_flushed():
+    # codex #1 end-to-end: budget uid 5 finishes, but mlx-lm leaves its
+    # force-close processor leaked in a stale slot alongside a later no-processor
+    # uid 6. The realign must scrub the leak (uid 6 -> []) and, once the leaked
+    # processor is absent from every slot, flush the tombstone + disarm — without
+    # this, the stateful </think> latch would force-close uid 6's output.
+    rblp = object()
+    stub = _make_scheduler_stub()
+    _register(stub, 5, [rblp], budget=rblp)
+    stub._forget_uid_grammar(5)  # uid 5 done → rblp tombstoned
+    # mlx-lm's lagging filter: rblp leaked onto uid 6's positional slot.
+    stub.batch_generator = _FakeBatchGen(uids=[6], logits_processors=[[rblp]])
+
+    stub._realign_grammar_logits_processors()
+
+    lp = stub.batch_generator._generation_batch.logits_processors
+    assert lp == [[]], "leaked force-close processor scrubbed from the foreign uid"
+    assert not stub._stateful_tombstones, "tombstone flushed once absent from slots"
+    assert not stub._realign_guard_armed(), "guard disarms after the scrub"
 
 
 if __name__ == "__main__":

--- a/tests/test_reasoning_budget_generation.py
+++ b/tests/test_reasoning_budget_generation.py
@@ -1,0 +1,962 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Generation-time thinking-token budget (force-close ``</think>``).
+
+Covers the decode-time budget introduced for #558: the
+``ReasoningBudgetLogitsProcessor`` phase machine, the OVERRIDE force mask, the
+``build_reasoning_budget_processor`` gate, and the chat-route
+``_effective_posthoc_reasoning_cap`` single-mechanism selector. The processor is
+the MLX-native expression of the same lever vLLM
+(``ThinkingBudgetStateHolder``), SGLang (``ReasonerGrammarObject``) and mlx-vlm
+(``ThinkingBudgetCriteria``) implement, so the assertions here pin the copied
+contract, not an invented one.
+
+The tokenizer→token-id resolution (``resolve_think_token_ids`` /
+``resolve_reasoning_sentinels``) is reused upstream code, exercised elsewhere and
+proven on a live model in the pilot; these tests monkeypatch it so the budget
+logic is isolated from tokenizer specifics.
+"""
+
+from __future__ import annotations
+
+import math
+
+import mlx.core as mx
+
+from vllm_mlx.api import reasoning_budget as rb
+from vllm_mlx.api.reasoning_budget import (
+    ReasoningBudgetLogitsProcessor,
+    build_reasoning_budget_processor,
+)
+
+THINK_END = 99
+THINK_START = 50
+
+
+def _feed(proc: ReasoningBudgetLogitsProcessor, seq: list[int]) -> str:
+    """Feed one more token (``seq`` is the FULL cumulative sequence) and return
+    the phase the processor is in for the NEXT step — mirrors the mlx-lm decode
+    loop which calls the processor with the growing token list each step."""
+    return proc._phase(seq)
+
+
+# ─────────────────────────── phase machine ────────────────────────────
+
+
+def test_seeded_counts_from_generation_start_and_forces_at_budget():
+    # Prompt already opened <think> (seeded), so every generated token counts.
+    proc = ReasoningBudgetLogitsProcessor(THINK_END, 3, seeded_thinking=True)
+    prompt = [1, 2, 3]  # baselined as prompt on first call
+    assert _feed(proc, prompt) == "free"  # thinking, 0/3 spent
+    assert _feed(proc, prompt + [10]) == "free"  # 1/3
+    assert _feed(proc, prompt + [10, 11]) == "free"  # 2/3
+    # 3/3 spent → budget exhausted → force </think>.
+    assert _feed(proc, prompt + [10, 11, 12]) == "force"
+    # The force latch persists every subsequent step until </think> is sampled.
+    assert _feed(proc, prompt + [10, 11, 12, 13]) == "force"
+
+
+def test_think_end_token_ends_span_and_makes_processor_inert():
+    proc = ReasoningBudgetLogitsProcessor(THINK_END, 3, seeded_thinking=True)
+    prompt = [1, 2]
+    _feed(proc, prompt)
+    _feed(proc, prompt + [10])
+    # Model emits </think> BEFORE the budget is hit → generation phase forever.
+    assert _feed(proc, prompt + [10, THINK_END]) == "generation"
+    assert _feed(proc, prompt + [10, THINK_END, 20, 21]) == "generation"
+    assert proc._ended is True
+
+
+def test_think_end_not_counted_toward_budget():
+    # Budget of 2: two real think tokens then </think> should NOT force (the
+    # </think> ends the span, it is not itself a budgeted token).
+    proc = ReasoningBudgetLogitsProcessor(THINK_END, 2, seeded_thinking=True)
+    prompt = [1]
+    _feed(proc, prompt)
+    _feed(proc, prompt + [10])  # 1/2
+    _feed(proc, prompt + [10, 11])  # 2/2 -> next step would force...
+    # ...but the model closes here, so we land in generation, never forcing.
+    assert _feed(proc, prompt + [10, 11, THINK_END]) == "generation"
+    # The two real tokens counted; </think> itself did NOT (asserting the phase
+    # alone would pass even if </think> were wrongly counted, since the span has
+    # ended either way).
+    assert proc._think_count == 2
+    assert proc._ended is True
+
+
+def test_model_emitted_opener_is_not_counted():
+    # An EMITTING template (route derives seeded_thinking=False): the model
+    # generates <think>. The opener, when it appears in the tail, transitions us
+    # into the span and is itself free — not counted toward the budget.
+    proc = ReasoningBudgetLogitsProcessor(
+        THINK_END, 2, think_start_id=THINK_START, seeded_thinking=False
+    )
+    prompt = [1]
+    _feed(proc, prompt)
+    _feed(proc, prompt + [THINK_START])  # opener — NOT counted
+    assert proc._think_count == 0
+    _feed(proc, prompt + [THINK_START, 30])  # 1/2
+    assert _feed(proc, prompt + [THINK_START, 30, 31]) == "force"  # 2/2
+
+
+def test_budget_zero_seeded_closes_to_matched_pair():
+    # budget=0 with a prefilled <think>: force </think> on the very first
+    # generated token → a well-formed (prompt) <think></think>, never an
+    # unmatched close.
+    proc = ReasoningBudgetLogitsProcessor(THINK_END, 0, seeded_thinking=True)
+    assert _feed(proc, [1, 2, 3]) == "force"
+
+
+def test_non_seeded_waits_for_think_start():
+    proc = ReasoningBudgetLogitsProcessor(
+        THINK_END, 2, think_start_id=THINK_START, seeded_thinking=False
+    )
+    prompt = [1, 2]
+    # Not started (no <think> yet) → inert.
+    assert _feed(proc, prompt) == "generation"
+    assert _feed(proc, prompt + [7]) == "generation"
+    # <think> appears in the generated stream → counting begins AFTER it.
+    assert _feed(proc, prompt + [7, THINK_START]) == "free"
+    assert _feed(proc, prompt + [7, THINK_START, 30]) == "free"  # 1/2
+    assert _feed(proc, prompt + [7, THINK_START, 30, 31]) == "force"  # 2/2
+
+
+# ───────────── emit-template + repeated-opener budget integrity ─────────
+
+
+def test_emit_template_never_forces_before_opener():
+    # An emitting template (route → seeded_thinking=False) with the SMALLEST
+    # budget. The processor must NOT force </think> before the model opens
+    # <think> — otherwise it injects an unmatched close (codex). Once the opener
+    # is emitted, the very next real think token hits budget=1 → matched pair.
+    proc = ReasoningBudgetLogitsProcessor(
+        THINK_END, 1, think_start_id=THINK_START, seeded_thinking=False
+    )
+    prompt = [1, 2]  # no prefilled <think>
+    assert _feed(proc, prompt) == "generation"  # not seeded → inert
+    assert _feed(proc, prompt + [5]) == "generation"  # preamble, still no opener
+    assert _feed(proc, prompt + [5, THINK_START]) == "free"  # model opens now
+    assert _feed(proc, prompt + [5, THINK_START, 30]) == "force"  # 1/1 → matched
+
+
+def test_repeated_opener_while_thinking_counts_toward_budget():
+    # A model that emits <think> AGAIN while already inside the span must have
+    # those repeats COUNTED — skipping every opener (the old bug) let the model
+    # loop <think> forever without advancing the budget, breaking the hard cap.
+    proc = ReasoningBudgetLogitsProcessor(
+        THINK_END, 2, think_start_id=THINK_START, seeded_thinking=True
+    )
+    prompt = [1]  # seeded (prefilled): span already open
+    _feed(proc, prompt)
+    assert _feed(proc, prompt + [THINK_START]) == "free"  # repeat opener → 1/2
+    assert proc._think_count == 1
+    # A second repeated opener spends the last unit → force on the next step.
+    assert _feed(proc, prompt + [THINK_START, THINK_START]) == "force"  # 2/2
+    assert proc._think_count == 2
+
+
+# ─────────────────────────── logit masks ──────────────────────────────
+
+
+def test_force_mask_makes_think_end_the_argmax():
+    proc = ReasoningBudgetLogitsProcessor(THINK_END, 1, seeded_thinking=True)
+    # Step 1: [1] is baselined as prompt; 0/1 spent → "free", logits untouched.
+    _ = proc([1], mx.zeros((128,)))
+    # Step 2: one generated think token → 1/1 spent → force on THIS call.
+    logits = mx.random.normal((128,))
+    out = proc([1, 10], logits)
+    assert int(mx.argmax(out).item()) == THINK_END
+    # </think> keeps a finite value; every other column is -inf.
+    assert math.isfinite(out[THINK_END].item())
+    masked = mx.sum((out == -math.inf).astype(mx.int32)).item()
+    assert masked == 127  # all but the single kept column
+
+
+def test_force_mask_released_when_think_end_observed():
+    # codex R14 nit: the cached OVERRIDE row must be dropped the moment </think>
+    # is observed, not pinned through the whole answer. Force once (mask built),
+    # then feed </think> (span ends) and assert the reference is cleared.
+    proc = ReasoningBudgetLogitsProcessor(THINK_END, 1, seeded_thinking=True)
+    _ = proc([1], mx.zeros((128,)))  # baseline, 0/1
+    _ = proc([1, 10], mx.random.normal((128,)))  # 1/1 → force → mask allocated
+    assert proc._force_logits is not None  # mask cached during forcing
+    # Next step the sampler picked </think>; the processor sees it in the tail.
+    out = proc([1, 10, THINK_END], mx.random.normal((128,)))
+    assert proc._ended is True
+    assert proc._force_logits is None  # released promptly, not retained
+    assert proc._force_width is None
+    # And it stays inert / a no-op thereafter (returns logits unchanged).
+    logits = mx.random.normal((128,))
+    assert bool(mx.all(proc([1, 10, THINK_END, 20], logits) == logits))
+
+
+def test_force_override_dominates_a_prior_neg_inf_at_think_end():
+    # The load-bearing #1 fix: the force is an OVERRIDE, not an additive mask.
+    # Simulate a chained grammar that already drove </think> (and much else) to
+    # -inf during the thinking span. An additive mask would leave an all -inf row
+    # (NaN after softmax); the override must still make </think> the sole finite,
+    # sampleable token.
+    proc = ReasoningBudgetLogitsProcessor(THINK_END, 1, seeded_thinking=True)
+    _ = proc([1], mx.zeros((128,)))
+    neg = float("-inf")
+    grammar_masked = mx.full((128,), neg)  # a hostile prior processor: all -inf
+    out = proc([1, 10], grammar_masked)
+    assert math.isfinite(out[THINK_END].item()), "</think> must be forced finite"
+    assert int(mx.argmax(out).item()) == THINK_END
+    finite = mx.sum((out != -math.inf).astype(mx.int32)).item()
+    assert finite == 1, "exactly one sampleable token"
+
+
+def test_force_preserves_batched_2d_shape():
+    # Regression for the pilot crash: mlx-lm's decode loop hands the processor a
+    # (1, vocab) row and concatenates each uid's processed logits, so the return
+    # MUST keep the leading batch dim. A bare (vocab,) return collapses it; the
+    # sampler then yields a 0-dim scalar token and the next step crashes on
+    # inputs[:, None] ("Too many indices for array with 0 dimensions").
+    # token_ids is the 1-D cumulative sequence (as mlx-lm hands it, same as the
+    # GrammarLogitsProcessor contract); logits is the (1, vocab) row.
+    proc = ReasoningBudgetLogitsProcessor(THINK_END, 1, seeded_thinking=True)
+    _ = proc([1], mx.zeros((1, 128)))  # baseline, 0/1
+    out = proc([1, 10], mx.random.normal((1, 128)))
+    assert out.shape == (1, 128), "must preserve the incoming (1, vocab) shape"
+    assert int(mx.argmax(out[0]).item()) == THINK_END
+    assert math.isfinite(out[0, THINK_END].item())
+
+
+def test_unlimited_budget_is_identity_noop():
+    # budget < 0 → the exact same array back (no work).
+    proc = ReasoningBudgetLogitsProcessor(THINK_END, -1, seeded_thinking=True)
+    logits = mx.random.normal((64,))
+    out = proc([1, 2, 3], logits)
+    assert out is logits
+
+
+def test_ended_latch_short_circuits_call():
+    proc = ReasoningBudgetLogitsProcessor(THINK_END, 1, seeded_thinking=True)
+    _ = proc([1], mx.zeros((32,)))
+    _ = proc([1, THINK_END], mx.zeros((32,)))  # closes the span
+    logits = mx.random.normal((32,))
+    out = proc([1, THINK_END, 5], logits)
+    assert out is logits  # inert after </think>
+
+
+# ─────────────────────────── builder gate ─────────────────────────────
+
+
+class _StubTokenizer:
+    """Placeholder — the real token-id resolution is monkeypatched out below.
+    Since R14 the build-time vocab width comes from the model head/config, not
+    ``len(tokenizer)`` (added specials make that vacuous), so callers pass an
+    explicit ``vocab_size`` and ``_FakeEngine`` exposes ``_model.vocab_size``;
+    this ``__len__`` is retained only so the stub quacks like a tokenizer."""
+
+    def __len__(self):
+        return 1000
+
+
+def _patch_ids(monkeypatch, start_id, end_id):
+    monkeypatch.setattr(
+        rb, "resolve_think_token_ids", lambda tok, name: (start_id, end_id)
+    )
+
+
+def test_build_none_when_no_budget(monkeypatch):
+    _patch_ids(monkeypatch, THINK_START, THINK_END)
+    assert (
+        build_reasoning_budget_processor(
+            _StubTokenizer(), "qwen3", None, seeded_thinking=True
+        )
+        is None
+    )
+
+
+def test_build_none_when_budget_negative(monkeypatch):
+    _patch_ids(monkeypatch, THINK_START, THINK_END)
+    assert (
+        build_reasoning_budget_processor(
+            _StubTokenizer(), "qwen3", -1, seeded_thinking=True
+        )
+        is None
+    )
+
+
+def test_build_none_when_end_token_unresolved(monkeypatch):
+    # Channel-routed family: </think> is not a single token → opt out to the
+    # post-hoc cap. This is the gate that keeps gpt-oss on the old path.
+    _patch_ids(monkeypatch, None, None)
+    assert (
+        build_reasoning_budget_processor(
+            _StubTokenizer(), "harmony", 64, seeded_thinking=True
+        )
+        is None
+    )
+
+
+def test_build_none_when_non_seeded_and_no_start(monkeypatch):
+    # Cannot know when thinking begins → never risk force-closing a
+    # non-thinking request (vLLM #39130 footgun).
+    _patch_ids(monkeypatch, None, THINK_END)
+    assert (
+        build_reasoning_budget_processor(
+            _StubTokenizer(), "qwen3", 64, seeded_thinking=False
+        )
+        is None
+    )
+
+
+def test_build_ok_wires_ids_and_budget(monkeypatch):
+    _patch_ids(monkeypatch, THINK_START, THINK_END)
+    proc = build_reasoning_budget_processor(
+        _StubTokenizer(), "qwen3", 128, seeded_thinking=True, vocab_size=1000
+    )
+    assert isinstance(proc, ReasoningBudgetLogitsProcessor)
+    assert proc._think_end_id == THINK_END
+    assert proc._budget == 128
+    assert proc._started is True
+
+
+# ─────────────── seeding derived from the template prefix ──────────────
+
+
+def test_reasoning_seed_state_open_for_prefill():
+    from vllm_mlx.api.reasoning_budget import reasoning_seed_state
+
+    # Template prefilled <think> as the generation prefix → open span, seed.
+    assert reasoning_seed_state("<|im_start|>assistant\n<think>\n", "qwen3") == "open"
+
+
+def test_reasoning_seed_state_open_for_prefill_with_preamble():
+    # codex R12: a template that prefills <think> then a NON-whitespace preamble
+    # is STILL an open span — the old endswith("<think>") check wrongly read this
+    # as not-seeded (unseeded processor never starts, yet suppresses post-hoc).
+    # Parsing the isolated delta detects the unclosed opener regardless of tail.
+    from vllm_mlx.api.reasoning_budget import reasoning_seed_state
+
+    delta = "<|im_start|>assistant\n<think>\nLet me reason:"
+    assert reasoning_seed_state(delta, "qwen3") == "open"
+
+
+def test_reasoning_seed_state_emit_when_no_markers():
+    from vllm_mlx.api.reasoning_budget import reasoning_seed_state
+
+    # Plain assistant header, no prefilled opener → the model emits <think>.
+    assert reasoning_seed_state("<|im_start|>assistant\n", "qwen3") == "emit"
+
+
+def test_reasoning_seed_state_ambiguous_for_closed_pair():
+    from vllm_mlx.api.reasoning_budget import reasoning_seed_state
+
+    # A CLOSED <think></think> in the prefix (thinking already finished) → the
+    # seed state cannot be proven → ambiguous → caller declines (post-hoc cap).
+    delta = "<|im_start|>assistant\n<think>\n\n</think>\n\n"
+    assert reasoning_seed_state(delta, "qwen3") == "ambiguous"
+
+
+def test_reasoning_seed_state_ambiguous_without_parser():
+    from vllm_mlx.api.reasoning_budget import reasoning_seed_state
+
+    assert reasoning_seed_state("<think>", None) == "ambiguous"  # no parser
+    assert reasoning_seed_state("", "qwen3") == "emit"  # empty → no markers → emit
+
+
+def test_rendered_prompt_opens_think_bool_wrapper():
+    # The bool wrapper is True only for the "open" state.
+    from vllm_mlx.api.reasoning_budget import rendered_prompt_opens_think
+
+    assert rendered_prompt_opens_think("<|im_start|>assistant\n<think>\n", "qwen3")
+    assert not rendered_prompt_opens_think("<|im_start|>assistant\n", "qwen3")
+    assert not rendered_prompt_opens_think("<think>", None)
+
+
+def test_build_budget_from_render_none_render_installs_nothing(monkeypatch):
+    # codex: when the prompt could NOT be rendered (None), install NO processor
+    # so the caller retains the post-hoc cap — never a non-seeded processor that
+    # silently disables the cap AND never fires.
+    from vllm_mlx.api import reasoning_budget as rb2
+
+    _patch_ids(monkeypatch, THINK_START, THINK_END)
+    assert rb2.build_budget_from_render(_StubTokenizer(), "qwen3", 64, None) is None
+
+
+def test_build_budget_from_render_seeds_from_prefill_suffix(monkeypatch):
+    from vllm_mlx.api import reasoning_budget as rb2
+
+    _patch_ids(monkeypatch, THINK_START, THINK_END)
+    proc = rb2.build_budget_from_render(
+        _StubTokenizer(),
+        "qwen3",
+        64,
+        "<|im_start|>assistant\n<think>\n",
+        vocab_size=1000,
+    )
+    assert isinstance(proc, ReasoningBudgetLogitsProcessor)
+    assert proc._started is True  # prefill suffix → seeded
+
+
+def test_build_budget_from_render_not_seeded_for_emit_suffix(monkeypatch):
+    from vllm_mlx.api import reasoning_budget as rb2
+
+    _patch_ids(monkeypatch, THINK_START, THINK_END)
+    proc = rb2.build_budget_from_render(
+        _StubTokenizer(), "qwen3", 64, "<|im_start|>assistant\n", vocab_size=1000
+    )
+    assert isinstance(proc, ReasoningBudgetLogitsProcessor)
+    assert proc._started is False  # no prefilled opener → wait for emitted one
+
+
+def test_build_budget_from_render_declines_on_ambiguous_closed_pair(monkeypatch):
+    # codex R12: a CLOSED <think></think> prefix → ambiguous seed state → install
+    # NO processor (retain the post-hoc cap) rather than one that never fires yet
+    # suppresses the cap.
+    from vllm_mlx.api import reasoning_budget as rb2
+
+    _patch_ids(monkeypatch, THINK_START, THINK_END)
+    assert (
+        rb2.build_budget_from_render(
+            _StubTokenizer(),
+            "qwen3",
+            64,
+            "<|im_start|>assistant\n<think>\n\n</think>\n\n",
+            vocab_size=1000,
+        )
+        is None
+    )
+
+
+# ──────────────────── stop-sequence conflict opt-out ──────────────────
+
+
+def test_reasoning_stop_conflicts_exact_end_marker():
+    from vllm_mlx.api.reasoning_budget import reasoning_stop_conflicts
+
+    # Client listed </think> as a stop → forcing it would halt at the boundary.
+    assert reasoning_stop_conflicts(["</think>"], "qwen3") is True
+
+
+def test_reasoning_stop_conflicts_substring_is_conflict():
+    from vllm_mlx.api.reasoning_budget import reasoning_stop_conflicts
+
+    # Stop is a substring of </think> ("think>") — the forced </think> contains
+    # it, so it fires at the boundary → conflict.
+    assert reasoning_stop_conflicts(["think>"], "qwen3") is True
+    # Accepts a bare string too, not only a list.
+    assert reasoning_stop_conflicts("</think>", "qwen3") is True
+
+
+def test_reasoning_stop_conflicts_marker_inside_stop_is_conflict():
+    from vllm_mlx.api.reasoning_budget import reasoning_stop_conflicts
+
+    # codex R13: a stop that CONTAINS the marker mid-string ("x</think>y") or with
+    # a trailing suffix ("</think>A") IS a conflict — the forced </think> sits
+    # between reasoning and answer tokens (…R</think>A…), so the ANSWER tokens
+    # supply the trailing chars and the stop fires, truncating the answer. An
+    # earlier revision wrongly left "x</think>y" enabled (it assumed the forced
+    # </think> was the last token; answer tokens follow it).
+    assert reasoning_stop_conflicts(["x</think>y"], "qwen3") is True
+    assert reasoning_stop_conflicts(["</think>A"], "qwen3") is True
+
+
+def test_reasoning_stop_conflicts_cross_boundary_both_sides():
+    from vllm_mlx.api.reasoning_budget import reasoning_stop_conflicts
+
+    # (c) stop ENDS in a marker prefix — preceding reasoning + forced token:
+    assert reasoning_stop_conflicts(["x</think>"], "qwen3") is True
+    assert reasoning_stop_conflicts(["foo<"], "qwen3") is True
+    assert reasoning_stop_conflicts(["bar</thi"], "qwen3") is True
+    # (d) stop STARTS with a marker suffix — forced token + following answer:
+    assert reasoning_stop_conflicts([">A"], "qwen3") is True
+    assert reasoning_stop_conflicts(["think>foo"], "qwen3") is True
+
+
+def test_reasoning_stop_conflicts_false_for_unrelated_stop():
+    from vllm_mlx.api.reasoning_budget import reasoning_stop_conflicts
+
+    assert reasoning_stop_conflicts(["<|im_end|>", "\n\n"], "qwen3") is False
+    assert reasoning_stop_conflicts([], "qwen3") is False
+    assert reasoning_stop_conflicts(None, "qwen3") is False
+    # No parser → cannot resolve the end marker → no conflict.
+    assert reasoning_stop_conflicts(["</think>"], None) is False
+
+
+# ──────────────────── single-mechanism route selector ─────────────────
+
+
+def test_effective_posthoc_cap_selector():
+    from vllm_mlx.routes.chat import _effective_posthoc_reasoning_cap
+
+    class _Req:
+        reasoning_max_tokens = 256
+
+    req = _Req()
+    # No generation-time budget in the kwargs → post-hoc cap owns the request.
+    assert _effective_posthoc_reasoning_cap({}, req) == 256
+    # A budget processor present → post-hoc cap MUST be suppressed (return None)
+    # so the two mechanisms never both run.
+    active = {"reasoning_budget_logits_processor": object()}
+    assert _effective_posthoc_reasoning_cap(active, req) is None
+    # A None-valued key is treated as "no processor" (defensive).
+    assert (
+        _effective_posthoc_reasoning_cap(
+            {"reasoning_budget_logits_processor": None}, req
+        )
+        == 256
+    )
+
+
+# ─────────── template generation-prefix seeding (codex #2 immunity) ─────────
+
+
+class _FakeEngine:
+    """Minimal text engine: renders the conversation body, then appends a fixed
+    template generation prefix ONLY when ``add_generation_prompt`` is True. The
+    seed decision diffs the two renders (``full`` − ``base``) to isolate that
+    prefix — proving seeding derives from the TEMPLATE's delta, never raw
+    conversation content."""
+
+    class _HeadWeight:
+        # (vocab, hidden) — shape[0] is the true logits width the R15 weight-only
+        # _engine_output_vocab_size reads. 1000 > THINK_END=99 so the build-time
+        # </think> bounds check admits.
+        shape = (1000, 4)
+
+    class _Embed:
+        weight = None  # set in __init__ to a _HeadWeight instance
+
+    class _Model:
+        embed_tokens = None  # set in __init__ to an _Embed instance
+
+    def __init__(self, gen_prefix):
+        self._gen = gen_prefix
+        self.tokenizer = _StubTokenizer()
+        embed = _FakeEngine._Embed()
+        embed.weight = _FakeEngine._HeadWeight()
+        model = _FakeEngine._Model()
+        model.embed_tokens = embed
+        self._model = model
+
+    def build_prompt(
+        self, messages, tools=None, enable_thinking=None, add_generation_prompt=True
+    ):
+        body = "".join(str(m.get("content", "")) for m in messages)
+        base = f"<|im_start|>user\n{body}<|im_end|>\n"
+        return base + self._gen if add_generation_prompt else base
+
+
+def test_template_generation_prefix_isolates_prefill():
+    from vllm_mlx.routes.chat import _template_generation_prefix
+
+    eng = _FakeEngine("<|im_start|>assistant\n<think>\n")  # template opens <think>
+    delta = _template_generation_prefix(
+        eng, [{"role": "user", "content": "hi"}], None, True
+    )
+    assert delta.rstrip().endswith("<think>")
+
+
+def test_template_generation_prefix_isolates_emit():
+    from vllm_mlx.routes.chat import _template_generation_prefix
+
+    eng = _FakeEngine("<|im_start|>assistant\n")  # emit template, no prefill
+    delta = _template_generation_prefix(
+        eng, [{"role": "user", "content": "hi"}], None, True
+    )
+    assert not delta.rstrip().endswith("<think>")
+
+
+def test_template_generation_prefix_immune_to_user_typed_think():
+    # codex #2: a user whose message ENDS in <think> must NOT falsely seed the
+    # budget when the template appends no opener. The user's content lives in
+    # BOTH renders (full and base), so it cancels out of the delta.
+    from vllm_mlx.routes.chat import _template_generation_prefix
+
+    eng = _FakeEngine("<|im_start|>assistant\n")  # NO prefilled <think>
+    delta = _template_generation_prefix(
+        eng, [{"role": "user", "content": "please <think>"}], None, True
+    )
+    assert "<think>" not in delta  # user marker isolated out of the delta
+    assert not delta.rstrip().endswith("<think>")
+
+
+def test_template_generation_prefix_none_for_empty_messages():
+    # codex R10 #3: an empty message list renders nothing — a prefill template
+    # must NOT be mistaken for an emit one. Decline (retain the post-hoc cap).
+    from vllm_mlx.routes.chat import _template_generation_prefix
+
+    eng = _FakeEngine("<|im_start|>assistant\n<think>\n")
+    assert _template_generation_prefix(eng, [], None, True) is None
+
+
+def test_template_generation_prefix_none_for_non_string_content():
+    from vllm_mlx.routes.chat import _template_generation_prefix
+
+    eng = _FakeEngine("<|im_start|>assistant\n")
+    delta = _template_generation_prefix(
+        eng,
+        [{"role": "user", "content": [{"type": "text", "text": "x"}]}],
+        None,
+        True,
+    )
+    assert delta is None  # non-str content → retain post-hoc cap
+
+
+def test_template_generation_prefix_none_when_full_not_startswith_base():
+    # If toggling add_generation_prompt RESTRUCTURES the render (the no-gen-prompt
+    # render is not a prefix of the gen-prompt one), the boundary can't be
+    # isolated cleanly → decline rather than risk a wrong seed (codex R10 #1).
+    from vllm_mlx.routes.chat import _template_generation_prefix
+
+    class _Restructure:
+        tokenizer = _StubTokenizer()
+
+        def build_prompt(
+            self,
+            messages,
+            tools=None,
+            enable_thinking=None,
+            add_generation_prompt=True,
+        ):
+            # base is NOT a prefix of full (leading char differs).
+            return "A<think>" if add_generation_prompt else "Bxxxx"
+
+    delta = _template_generation_prefix(
+        _Restructure(), [{"role": "user", "content": "hi"}], None, True
+    )
+    assert delta is None
+
+
+# ─────────── route builder gates (thinking / tools / stop / seeding) ────────
+
+
+class _FakeCfg:
+    def __init__(self, parser="qwen3", model="mlx-community/Qwen3-0.6B-4bit"):
+        self.reasoning_parser_name = parser
+        self.model_path = model
+        self.model_name = model
+
+
+class _FakeReq:
+    def __init__(self, budget=64, tools=None, stop=None):
+        self.reasoning_max_tokens = budget
+        self.tools = tools
+        self.stop = stop
+
+
+_MSGS = [{"role": "user", "content": "hi"}]
+
+
+def test_build_reasoning_budget_processor_stop_conflict_returns_none(monkeypatch):
+    from vllm_mlx.routes import chat as chatmod
+
+    _patch_ids(monkeypatch, THINK_START, THINK_END)
+    proc = chatmod._build_reasoning_budget_processor(
+        _FakeEngine("<|im_start|>assistant\n<think>\n"),
+        _FakeReq(budget=64, stop=["</think>"]),
+        _FakeCfg(),
+        _MSGS,
+        True,
+    )
+    assert proc is None
+
+
+def test_build_reasoning_budget_processor_tools_returns_none(monkeypatch):
+    from vllm_mlx.routes import chat as chatmod
+
+    _patch_ids(monkeypatch, THINK_START, THINK_END)
+    proc = chatmod._build_reasoning_budget_processor(
+        _FakeEngine("<|im_start|>assistant\n<think>\n"),
+        _FakeReq(budget=64, tools=[{"type": "function"}]),
+        _FakeCfg(),
+        _MSGS,
+        True,
+    )
+    assert proc is None
+
+
+def test_build_reasoning_budget_processor_thinking_off_returns_none(monkeypatch):
+    from vllm_mlx.routes import chat as chatmod
+
+    _patch_ids(monkeypatch, THINK_START, THINK_END)
+    # resolved_thinking=False → _effective_enable_thinking is False → opt out.
+    proc = chatmod._build_reasoning_budget_processor(
+        _FakeEngine("<|im_start|>assistant\n<think>\n"),
+        _FakeReq(budget=64),
+        _FakeCfg(),
+        _MSGS,
+        False,
+    )
+    assert proc is None
+
+
+def test_build_reasoning_budget_processor_seeds_from_template_prefill(monkeypatch):
+    from vllm_mlx.routes import chat as chatmod
+
+    _patch_ids(monkeypatch, THINK_START, THINK_END)
+    proc = chatmod._build_reasoning_budget_processor(
+        _FakeEngine("<|im_start|>assistant\n<think>\n"),  # prefill
+        _FakeReq(budget=64),
+        _FakeCfg(),
+        _MSGS,
+        True,
+    )
+    assert isinstance(proc, ReasoningBudgetLogitsProcessor)
+    assert proc._started is True  # seeded from the TEMPLATE's prefilled <think>
+
+
+def test_build_reasoning_budget_processor_emit_template_not_seeded(monkeypatch):
+    from vllm_mlx.routes import chat as chatmod
+
+    _patch_ids(monkeypatch, THINK_START, THINK_END)
+    proc = chatmod._build_reasoning_budget_processor(
+        _FakeEngine("<|im_start|>assistant\n"),  # emit template, no prefill
+        _FakeReq(budget=64),
+        _FakeCfg(),
+        _MSGS,
+        True,
+    )
+    assert isinstance(proc, ReasoningBudgetLogitsProcessor)
+    assert proc._started is False  # waits for the model-emitted opener
+
+
+# ─────────── out-of-range </think> guard (codex #3 defensive NIT) ───────────
+
+
+def test_force_distribution_disables_on_out_of_range_think_end():
+    # A tokenizer/model vocab mismatch puts </think> beyond the logits width.
+    # The force step must DISABLE the budget (return logits unchanged, latch
+    # inert) rather than mask to an all -inf row that yields an invalid sample.
+    proc = ReasoningBudgetLogitsProcessor(200, 0, seeded_thinking=True)  # end_id=200
+    logits = mx.zeros((1, 100))  # width 100 < 200 → out of range
+    out = proc([1, 2, 3], logits)  # budget=0 + seeded → force phase → guard trips
+    assert out.shape == (1, 100)
+    assert bool(mx.all(mx.isfinite(out)))  # NOT all -inf — unchanged
+    assert proc._ended is True  # latched inert
+    # The "forcing </think>" success line must NOT have been emitted: the guard
+    # trips FIRST, so no false success-then-disable log pair (codex R13 #4).
+    assert proc._force_logged is False
+    # subsequent steps are no-ops (never crash on the bad id again)
+    out2 = proc([1, 2, 3, 4], logits)
+    assert bool(mx.all(mx.isfinite(out2)))
+    assert proc._force_logged is False
+
+
+# ─────────── build-time </think> vocab bounds check (codex #1) ──────────────
+
+
+def test_build_none_when_think_end_exceeds_vocab(monkeypatch):
+    # </think> beyond the model's vocab → decline at BUILD time so the post-hoc
+    # cap stays active (no decode-time-only disable that would leave the budget
+    # unenforced after the cap was already suppressed).
+    _patch_ids(monkeypatch, THINK_START, 500)
+    assert (
+        build_reasoning_budget_processor(
+            _StubTokenizer(), "qwen3", 64, seeded_thinking=True, vocab_size=100
+        )
+        is None
+    )
+
+
+def test_build_ok_when_think_end_within_vocab(monkeypatch):
+    _patch_ids(monkeypatch, THINK_START, 99)
+    proc = build_reasoning_budget_processor(
+        _StubTokenizer(), "qwen3", 64, seeded_thinking=True, vocab_size=100
+    )
+    assert isinstance(proc, ReasoningBudgetLogitsProcessor)
+
+
+def test_build_none_when_non_seeded_start_exceeds_vocab(monkeypatch):
+    # NOT seeded → counting only begins once <think> (start_id) appears in the
+    # generated tail. An out-of-range start_id (500 ≥ width 100) can never match
+    # any sampled token (all < width), so the budget would silently NEVER fire —
+    # yet the processor's mere existence suppresses the post-hoc cap, leaving the
+    # request wholly unbudgeted. Decline at BUILD time, symmetric with the
+    # </think> end-id bounds check (codex R13 #2). </think> itself IS in range
+    # here (99 < 100), isolating start_id as the sole cause.
+    _patch_ids(monkeypatch, 500, 99)
+    assert (
+        build_reasoning_budget_processor(
+            _StubTokenizer(), "qwen3", 64, seeded_thinking=False, vocab_size=100
+        )
+        is None
+    )
+
+
+def test_build_none_when_vocab_size_unknown(monkeypatch):
+    # codex R11: an UNKNOWN width cannot be verified → decline so the post-hoc cap
+    # stays (a processor must never exist with an unverified force id, since its
+    # mere existence suppresses the cap). For real engines the width is always
+    # determinable (len(tokenizer)), so this residual never triggers in practice.
+    _patch_ids(monkeypatch, THINK_START, THINK_END)
+    assert (
+        build_reasoning_budget_processor(
+            _StubTokenizer(), "qwen3", 64, seeded_thinking=True, vocab_size=None
+        )
+        is None
+    )
+
+
+# ─────────── content-dependent template seeding (codex R10 #1) ──────────────
+
+
+class _ContentDepEngine:
+    """A template whose generation prefix DEPENDS on the last message: it opens
+    <think> only when the content contains "math". The two-render diff always
+    uses the REAL content in both renders, so the delta reflects the true prefix
+    for THIS request — no content substitution, no mis-seed."""
+
+    tokenizer = _StubTokenizer()
+
+    def build_prompt(
+        self, messages, tools=None, enable_thinking=None, add_generation_prompt=True
+    ):
+        body = "".join(str(m.get("content", "")) for m in messages)
+        gen = (
+            "<|im_start|>assistant\n<think>\n"
+            if "math" in body
+            else "<|im_start|>assistant\n"
+        )
+        base = f"<|im_start|>user\n{body}<|im_end|>\n"
+        return base + gen if add_generation_prompt else base
+
+
+def test_template_generation_prefix_content_dependent_seeds_correctly():
+    from vllm_mlx.routes.chat import _template_generation_prefix
+
+    # Content has "math" → the template DOES prefill <think> for this request.
+    # The old sentinel probe (content replaced) lost "math" and mis-declined; the
+    # two-render keeps the real content in both renders → seeds correctly.
+    delta = _template_generation_prefix(
+        _ContentDepEngine(), [{"role": "user", "content": "do math"}], None, True
+    )
+    assert delta is not None
+    assert delta.rstrip().endswith("<think>")
+
+
+def test_template_generation_prefix_content_dependent_emit_not_seeded():
+    from vllm_mlx.routes.chat import _template_generation_prefix
+
+    # Content lacks "math" → the SAME template emits (no prefill) for this
+    # request; the delta must not end in <think>.
+    delta = _template_generation_prefix(
+        _ContentDepEngine(), [{"role": "user", "content": "say hi"}], None, True
+    )
+    assert delta is not None
+    assert not delta.rstrip().endswith("<think>")
+
+
+def test_engine_output_vocab_size_declines_on_config_only():
+    # codex R15: a declared config vocab_size is NOT trusted — a padded/over-
+    # declared vocab can exceed the true head width, which is exactly the mismatch
+    # that would trip the decode-time guard. With no inspectable head WEIGHT,
+    # decline (None) so the post-hoc cap stays. Only the weight-derived width (==
+    # the decode logits width) may admit the force id.
+    from vllm_mlx.routes.chat import _engine_output_vocab_size
+
+    class _M:
+        vocab_size = 12345  # declared only — no head weight → must be ignored
+
+    class _E:
+        _model = _M()
+        tokenizer = None
+
+    assert _engine_output_vocab_size(_E()) is None
+
+
+def test_engine_output_vocab_size_declines_when_only_len_tokenizer():
+    # codex R14: len(tokenizer) is NOT a sound width for the </think> bounds
+    # check — it counts added specials, so </think> (an added special) is always
+    # within it, making the check vacuous. With no inspectable head/config width,
+    # decline (None) so the post-hoc cap stays rather than admit an id the output
+    # head may not be able to emit.
+    from vllm_mlx.routes.chat import _engine_output_vocab_size
+
+    class _Tok:
+        def __len__(self):
+            return 777
+
+    class _E:
+        _model = None
+        tokenizer = _Tok()
+
+    assert _engine_output_vocab_size(_E()) is None
+
+
+def test_engine_output_vocab_size_prefers_actual_weight_shape():
+    # codex R12: the ACTUAL output-head width (weight rows) is authoritative and
+    # must win over a (possibly divergent) declared config vocab_size. Mirrors a
+    # tied-embedding model (qwen3): logits come from embed_tokens.as_linear, so
+    # embed_tokens.weight.shape[0] is the true logits width.
+    from vllm_mlx.routes.chat import _engine_output_vocab_size
+
+    class _W:
+        shape = (151936, 128)  # (vocab, packed_hidden) — shape[0] is the vocab
+
+    class _Embed:
+        weight = _W()
+
+    class _Inner:
+        embed_tokens = _Embed()
+
+    class _M:
+        model = _Inner()
+        vocab_size = 999  # declared value DIVERGES — must be ignored
+
+    class _E:
+        _model = _M()
+        tokenizer = None
+
+    assert _engine_output_vocab_size(_E()) == 151936
+
+
+# ─────────── add_generation_prompt plumbing (codex R11 #1) ──────────────────
+# The two-render seed probe needs build_prompt to HONOR add_generation_prompt so
+# the True/False renders differ. base.py's build_prompt is @abstractmethod (no
+# body to forward); these pin that the shared sink and the concrete BatchedEngine
+# path both forward the flag — the real-hardware pilot already proved the
+# end-to-end effect (the budget could not have force-closed at N tokens if the
+# two renders were identical → empty delta → no processor).
+
+
+def test_apply_chat_template_forwards_add_generation_prompt():
+    from vllm_mlx.utils.chat_template import apply_chat_template
+
+    captured = []
+
+    class _Rec:
+        def apply_chat_template(self, messages, **kw):
+            captured.append(kw)
+            return "PROMPT"
+
+    apply_chat_template(
+        _Rec(), [{"role": "user", "content": "hi"}], add_generation_prompt=False
+    )
+    assert captured[-1]["add_generation_prompt"] is False
+    # Default stays True (every serving path) when not overridden.
+    apply_chat_template(_Rec(), [{"role": "user", "content": "hi"}])
+    assert captured[-1]["add_generation_prompt"] is True
+
+
+def test_batched_engine_apply_chat_template_forwards_add_generation_prompt(monkeypatch):
+    from types import SimpleNamespace
+
+    from vllm_mlx.engine import batched as batched_mod
+    from vllm_mlx.engine.batched import BatchedEngine
+
+    captured = {}
+
+    def _rec(applicator, messages, **kw):
+        captured.update(kw)
+        return "PROMPT"
+
+    monkeypatch.setattr(batched_mod, "shared_apply_chat_template", _rec)
+
+    class _Tok:
+        def apply_chat_template(self, *a, **k):
+            return "x"
+
+    # Bind the production method onto a bare stub (text engine, no MLLM) so the
+    # exact admission-path forwarding is exercised without loading a model.
+    stub = SimpleNamespace(
+        _is_mllm=False, _processor=None, tokenizer=_Tok(), _model_name="qwen3"
+    )
+    BatchedEngine._apply_chat_template(
+        stub, [{"role": "user", "content": "hi"}], add_generation_prompt=False
+    )
+    assert captured.get("add_generation_prompt") is False

--- a/vllm_mlx/api/reasoning_budget.py
+++ b/vllm_mlx/api/reasoning_budget.py
@@ -1,0 +1,547 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Generation-time thinking-token budget (force-close ``</think>``).
+
+A reasoning model emits ``<think>…</think>`` before its answer. Without a
+budget it can think for an unbounded number of tokens (burning compute and
+latency) before committing. This module enforces a per-request *thinking*
+budget AT DECODE TIME: once the model has spent ``max_think_tokens`` inside the
+thinking span, the next-token logits are OVERRIDDEN so the ONLY sampleable token
+is the single ``</think>`` id — the model is forced to close the block and move
+on to its answer. This is a real generation-time control, not the post-hoc
+reasoning-text trim in :mod:`vllm_mlx.service.postprocessor` (which lets the
+model keep generating and only relabels/injects the close marker in the OUTPUT
+the client sees).
+
+Three mature engines converge on exactly this mechanism, and we copy their
+shape rather than invent one:
+
+* **SGLang** ``ReasonerGrammarObject`` (``constrained/reasoner_grammar_backend.py``):
+  a THINKING→GENERATION state machine; the instant ``tokens_in_think`` reaches
+  the budget it rewrites the vocab mask to allow ONLY ``think_end_id``.
+* **vLLM** ``ThinkingBudgetStateHolder`` (``v1/sample/thinking_budget_state.py``):
+  fills the forced end-token logit to a DOMINATING value once the budget is
+  exhausted (an override, not a nudge).
+* **mlx-vlm** ``ThinkingBudgetCriteria`` (``mlx_vlm/utils.py``): resolves the
+  end token by id (``tokenizer.encode(...)[-1]``), counts only inside the span,
+  forces the close sequence.
+
+All three: identify ``</think>`` by TOKEN ID (not string), count only tokens
+inside the thinking span, treat ``budget < 0`` as unlimited, and force by making
+the end token the sole choice. We express that force as an mlx-lm logits
+processor so it drops into the existing per-step decode loop (the same slot the
+``GrammarLogitsProcessor`` uses) with no decode-loop changes.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+class ReasoningBudgetLogitsProcessor:
+    """Force ``</think>`` once a per-request thinking-token budget is spent.
+
+    mlx-lm contract: called every decode step as ``processor(token_ids,
+    logits) -> logits`` where ``token_ids`` is the FULL cumulative sequence
+    (prompt + everything generated so far). We baseline past the prompt on the
+    first call and commit only the newly generated tail each step (O(new
+    tokens), never O(n) — mirrors :class:`GrammarLogitsProcessor`), so the hot
+    loop stays linear.
+
+    Phase machine (mirrors SGLang ``ReasonerGrammarObject``):
+
+    * THINKING — from the start of generation (when ``seeded_thinking``, i.e.
+      the prompt prefilled ``<think>``) or from the first ``think_start_id`` in
+      the generated span, until ``think_end_id`` is emitted. Every generated
+      token in this span counts toward the budget, with two exemptions: the ONE
+      opener that BEGINS the span is free (a seeded ``<think>`` never reaches the
+      generated tail; an emitted opener transitions the machine in without being
+      counted) and ``think_end_id`` is free. A ``think_start_id`` REPEATED while
+      already thinking is NOT exempt — it counts, else a model looping ``<think>``
+      could stall the budget forever (see ``_commit_tail``). At budget, force
+      ``think_end_id``.
+    * GENERATION — once ``think_end_id`` is seen, this processor is inert
+      (returns logits unchanged) so a chained grammar/penalty processor owns
+      the rest of the request. A latch makes this O(1) after the boundary.
+
+    ``seeded_thinking`` selects between the TWO shapes a reasoning template can
+    take: one that PREFILLS ``<think>`` into the prompt (seeded — the opener
+    never appears in the generated tail, so counting starts at the first
+    generated token) AND one whose model EMITS ``<think>`` as a generated token
+    (not seeded — counting begins only AFTER that opener, and ``think_start_id``
+    identifies it). The caller derives which shape applies from the TEMPLATE'S
+    rendered generation prefix (``rendered_prompt_opens_think``), never from raw
+    conversation content, so a ``<think>`` a user typed cannot mis-seed the
+    budget. Either way the opener token is free, so a ``budget == 0`` request
+    closes to a well-formed ``<think></think>`` rather than an unmatched
+    ``</think>``.
+
+    A request whose thinking is not enabled (``seeded_thinking`` false and no
+    ``think_start_id`` ever appears) is never force-closed — the budget cannot
+    fire on a non-thinking request (guards the vLLM #39130 footgun: never wait
+    on / force a reasoning end that cannot occur).
+    """
+
+    def __init__(
+        self,
+        think_end_id: int,
+        max_think_tokens: int,
+        *,
+        think_start_id: int | None = None,
+        seeded_thinking: bool = True,
+    ) -> None:
+        self._think_end_id = int(think_end_id)
+        self._budget = int(max_think_tokens)
+        self._think_start_id = None if think_start_id is None else int(think_start_id)
+        # Initial THINKING state, authoritative: True when the caller determined
+        # (from the template's rendered generation prefix — see
+        # ``rendered_prompt_opens_think``) that the prompt PREFILLS ``<think>``,
+        # so counting starts at the first generated token. False for an emitting
+        # template — counting waits until ``think_start_id`` appears in the tail.
+        self._started = bool(seeded_thinking)
+        # Cumulative-token bookkeeping (mirrors GrammarLogitsProcessor).
+        self._prompt_len: int | None = None
+        self._committed = 0
+        self._think_count = 0
+        self._ended = False
+        # Cached OVERRIDE distribution (an mlx array), built lazily once the
+        # vocab width is known; import mlx lazily so this module is importable
+        # without the runtime for pure-logic unit tests of the phase machine.
+        self._force_logits: Any = None
+        self._force_width: int | None = None
+        # One-shot observability latch: log exactly once, at the decode step the
+        # budget first forces </think>, so operators can confirm the cap fired
+        # without a per-step hot-loop log.
+        self._force_logged = False
+        # One-shot latch for the out-of-range </think> guard (see
+        # ``_force_distribution``): a tokenizer/model vocab mismatch that puts
+        # ``think_end_id`` outside the logits width disables the budget instead
+        # of masking to an all -inf row.
+        self._oob_logged = False
+
+    # ---- phase machine (pure, unit-testable without mlx) -------------------
+
+    def _commit_tail(self, token_ids: Any, n: int) -> None:
+        """Advance the phase counters over newly generated tokens only."""
+        tail = token_ids[self._committed : n]
+        for t in tail:
+            self._committed += 1
+            tid = int(t)
+            if self._ended:
+                continue
+            if not self._started:
+                # Only the FIRST opener transitions us into the thinking span,
+                # and it is free (never counted). Everything before the opener
+                # (a model-emitted-``<think>`` template's preamble) is also not
+                # counted — the span has not begun. See the class docstring.
+                if self._think_start_id is not None and tid == self._think_start_id:
+                    self._started = True
+                continue
+            # Inside the thinking span:
+            if tid == self._think_end_id:
+                self._ended = True
+                # Release the cached OVERRIDE mask (codex R14): once </think> is
+                # observed the span is closed and ``__call__`` short-circuits on
+                # ``_ended`` for the whole remaining answer, so retaining the
+                # full-vocab row would only pin hundreds of KB per request for no
+                # further use. Whether the mask was ever built (budget forced the
+                # close) or not (the model closed on its own), dropping the
+                # reference here is safe and reclaims it promptly.
+                self._force_logits = None
+                self._force_width = None
+                continue
+            # Every other generated token counts — INCLUDING a repeated
+            # ``<think>`` emitted while already thinking. Skipping it (the old
+            # bug) would let a model loop the opener forever without advancing
+            # the budget, violating the hard token cap (codex).
+            self._think_count += 1
+
+    def _phase(self, token_ids: Any) -> str:
+        """Return ``"generation"`` | ``"force"`` | ``"free"``.
+
+        ``force`` — budget exhausted, override all but ``</think>``.
+        ``free``  — thinking, under budget, nothing to do.
+        ``generation`` — inert (not thinking yet, or thinking has ended).
+        """
+        n = len(token_ids)
+        if self._prompt_len is None:
+            self._prompt_len = n
+            self._committed = n
+        if self._committed < n:
+            self._commit_tail(token_ids, n)
+        if self._ended or not self._started:
+            return "generation"
+        if self._budget >= 0 and self._think_count >= self._budget:
+            return "force"
+        return "free"
+
+    # ---- mlx-lm logits-processor entry point -------------------------------
+
+    def __call__(self, token_ids: Any, logits: Any) -> Any:
+        # Unlimited budget is a pure no-op; skip even the tail walk so an unset
+        # cap costs nothing. The ended-latch short-circuits the O(1) tail.
+        if self._budget < 0 or self._ended:
+            return logits
+        if self._phase(token_ids) != "force":
+            return logits
+        return self._force_distribution(logits)
+
+    # ---- forced-distribution construction (cached per vocab width) ---------
+
+    def _force_distribution(self, logits: Any) -> Any:
+        import mlx.core as mx
+
+        width = logits.shape[-1]
+        # CRASH-SAFETY net (codex R15): the budget is REQUIRED to pass a build-time
+        # bounds check against the model's ACTUAL output-head WEIGHT width (see
+        # build_reasoning_budget_processor's mandatory vocab_size check, fed by
+        # routes/chat.py::_engine_output_vocab_size — now weight-derived ONLY, no
+        # config/tokenizer fallback). Since ``logits = head(hidden)`` means
+        # ``logits.shape[-1] == head.weight.shape[0]``, the width checked here is
+        # the SAME number the builder validated ``</think>`` against, so for any
+        # processor we install this guard is PROVABLY unreachable — there is no
+        # config over-declaration or tokenizer over-count left that could make a
+        # later width disagree with the head. It remains only as a defensive net:
+        # were it ever reached, masking to an id no column matches would yield an
+        # all -inf row (NaN after softmax → invalid sample / crash), so degrade
+        # gracefully — latch inert and return the incoming logits unchanged. The
+        # budget staying enforced does not depend on this branch: it can't fire.
+        if not (0 <= self._think_end_id < width):
+            if not self._oob_logged:
+                self._oob_logged = True
+                logger.warning(
+                    "reasoning budget disabled: </think> id=%d is outside the "
+                    "model's logits width %d (tokenizer/model vocab mismatch)",
+                    self._think_end_id,
+                    width,
+                )
+            self._ended = True  # latch inert: __call__ short-circuits hereafter
+            return logits
+        # Log the successful force EXACTLY once — AFTER the range check passes, so
+        # an out-of-range disable never emits a false "forcing </think>" success
+        # line immediately followed by a disable warning (codex R13 NIT).
+        if not self._force_logged:
+            self._force_logged = True
+            logger.debug(
+                "reasoning budget spent (%d think tokens) — forcing "
+                "</think> (id=%d) at decode time",
+                self._think_count,
+                self._think_end_id,
+            )
+        dtype = logits.dtype
+        if self._force_logits is None or self._force_width != width:
+            vocab = mx.arange(width)
+            # OVERRIDE (not additive): a fresh row that is -inf on every token
+            # except </think>, which gets a finite value. Returned IN PLACE OF the
+            # incoming logits so it DOMINATES any earlier processor in the chain —
+            # critically, a grammar that drove </think> to -inf during the
+            # thinking span would, under an additive mask, leave an all -inf row
+            # (NaN after softmax). Overriding guarantees </think> is the sole
+            # sampleable token (vLLM fills the end-token logit to a dominating
+            # value for the same reason).
+            self._force_logits = mx.where(
+                vocab == self._think_end_id,
+                mx.array(0.0),
+                mx.array(-float("inf")),
+            ).astype(dtype)
+            self._force_width = width
+        elif self._force_logits.dtype != dtype:
+            self._force_logits = self._force_logits.astype(dtype)
+        # PRESERVE the incoming shape ([..., vocab]). The mlx-lm logits-processor
+        # contract requires the return to match the incoming logits shape (the
+        # decode loop concatenates every row's processed logits — GrammarLogits-
+        # Processor makes the same guarantee). A bare (vocab,) return collapses
+        # the batch dim of a (1, vocab) input; the sampler then yields a 0-dim
+        # scalar token and the NEXT decode step crashes on ``inputs[:, None]``
+        # ("Too many indices for array with 0 dimensions"). Broadcasting the
+        # cached row keeps the override cheap and shape-correct for (vocab,),
+        # (1, vocab), or any (batch, vocab).
+        return mx.broadcast_to(self._force_logits, logits.shape)
+
+
+def reasoning_seed_state(
+    generation_prefix: str, reasoning_parser_name: str | None
+) -> str:
+    """Classify the reasoning state at generation start from the ISOLATED
+    template generation-prefix delta: ``"open"`` | ``"emit"`` | ``"ambiguous"``.
+
+    ``generation_prefix`` MUST be the delta the two-render probe isolates
+    (``routes/chat.py::_template_generation_prefix`` — the exact bytes the
+    template appends for the new assistant turn), never the full prompt. Because
+    the delta already excludes all conversation content, a ``<think>`` a USER
+    typed cannot appear here, so we can PARSE the delta directly instead of only
+    peeking at its suffix (codex R12: an ``endswith`` check mis-reads a template
+    that prefills ``<think>`` followed by a non-whitespace preamble as NOT
+    seeded, installing an unseeded processor that never starts yet suppresses the
+    post-hoc cap):
+
+      * ``"open"``  — the delta contains an UNCLOSED ``<think>`` (a start marker
+        with no end marker after it): generation begins inside the thinking span
+        → seed the budget (count from token 0).
+      * ``"emit"``  — the delta has NEITHER marker (plain assistant header):
+        the model itself will emit ``<think>`` → the budget waits for the opener.
+      * ``"ambiguous"`` — a CLOSED pair (``<think>…</think>`` — thinking already
+        finished in the prefix) or a stray end marker: the seed state cannot be
+        proven, so the caller DECLINES the processor and keeps the post-hoc cap.
+    """
+    if not reasoning_parser_name:
+        return "ambiguous"
+    try:
+        from ..reasoning import get_parser
+
+        parser = get_parser(reasoning_parser_name)()
+        start_marker = parser.start_token
+        end_marker = parser.end_token
+    except Exception:
+        return "ambiguous"
+    if not isinstance(start_marker, str) or not start_marker:
+        return "ambiguous"
+    text = generation_prefix or ""
+    last_open = text.rfind(start_marker)
+    last_close = (
+        text.rfind(end_marker) if isinstance(end_marker, str) and end_marker else -1
+    )
+    if last_open == -1 and last_close == -1:
+        return "emit"
+    # An unclosed opener (last ``<think>`` sits AFTER any ``</think>``) → open.
+    if last_open != -1 and last_open > last_close:
+        return "open"
+    # Closed pair or stray end marker → cannot prove the seed state → decline.
+    return "ambiguous"
+
+
+def rendered_prompt_opens_think(
+    rendered_prompt: str, reasoning_parser_name: str | None
+) -> bool:
+    """True iff the ISOLATED generation-prefix delta opens an unclosed
+    ``<think>`` span (thin bool wrapper over :func:`reasoning_seed_state`)."""
+    return reasoning_seed_state(rendered_prompt, reasoning_parser_name) == "open"
+
+
+def reasoning_stop_conflicts(stop: Any, reasoning_parser_name: str | None) -> bool:
+    """True iff a client stop sequence would fire on the FORCED ``</think>``.
+
+    The generation-time budget closes thinking by forcing ``</think>`` as a real
+    decoded token. If the client ALSO listed ``</think>`` (or a substring /
+    superstring the forced close would match) in ``stop``, that forced token
+    trips the stop matcher and generation halts AT the reasoning boundary — the
+    whole budget is spent on thinking and the ANSWER is never produced (codex).
+    A model's reasoning end is a template-internal boundary, not a user stop; to
+    keep that invariant on this degenerate config we DECLINE the generation-time
+    budget and keep the post-hoc cap, which appends ``</think>`` to the FINAL
+    text WITHOUT passing it through the decode-time stop matcher, so the answer
+    still generates. Mirrors the tools / thinking-off opt-outs.
+
+    We flag ANY stop the forced ``</think>`` can PARTICIPATE in matching — the
+    forced token sits between the last reasoning tokens and the first answer
+    tokens (``…R</think>A…``), and R/A are arbitrary model output, so the stop
+    can be completed across EITHER boundary (codex R13: an earlier revision only
+    checked the marker-prefix boundary and wrongly let ``x</think>y`` /
+    ``</think>A`` through — the trailing text is supplied by the ANSWER tokens
+    that follow the forced close, so those DO fire and truncate the answer).
+    Over-declining is safe (falls back to the post-hoc cap, which still enforces
+    the budget); only genuinely independent stops (``<|im_end|>``, ``\\n\\n``)
+    stay on the decode-time path.
+    """
+    if not stop or not reasoning_parser_name:
+        return False
+    try:
+        from ..reasoning import get_parser
+
+        end_marker = get_parser(reasoning_parser_name)().end_token
+    except Exception:
+        return False
+    if not isinstance(end_marker, str) or not end_marker:
+        return False
+    stops = [stop] if isinstance(stop, str) else stop
+    return any(
+        isinstance(s, str) and s and _overlaps_forced_marker(s, end_marker)
+        for s in stops
+    )
+
+
+def _overlaps_forced_marker(s: str, marker: str) -> bool:
+    """True iff the forced ``marker`` (``</think>``) can participate in matching
+    stop ``s`` in the stream ``…R{marker}A…`` (R/A = arbitrary surrounding
+    output). Any of four overlap alignments makes it a conflict:
+
+      (a) ``s`` wholly INSIDE the marker (``think>``, ``>``) — the forced token
+          alone matches it;
+      (b) the marker wholly INSIDE ``s`` (``x</think>y``, ``</think>A``) — R and
+          A supply the surrounding chars;
+      (c) a SUFFIX of ``s`` is a PREFIX of the marker (``foo<``, ``bar</thi``) —
+          preceding reasoning R supplies ``s``'s head, the forced token its tail;
+      (d) a PREFIX of ``s`` is a SUFFIX of the marker (``>A``, ``think>foo``) —
+          the forced token supplies ``s``'s head, the answer A its tail.
+    """
+    if s in marker or marker in s:
+        return True
+    span = range(1, min(len(s), len(marker)) + 1)
+    # (c) suffix-of-s == prefix-of-marker  |  (d) prefix-of-s == suffix-of-marker
+    return any(s[-k:] == marker[:k] for k in span) or any(
+        s[:k] == marker[-k:] for k in span
+    )
+
+
+def build_budget_from_render(
+    tokenizer: Any,
+    reasoning_parser_name: str | None,
+    max_think_tokens: int | None,
+    rendered_prompt: str | None,
+    *,
+    vocab_size: int | None = None,
+) -> ReasoningBudgetLogitsProcessor | None:
+    """Build a generation-time budget processor from a RENDERED prompt, or None.
+
+    ``rendered_prompt is None`` signals the caller could NOT render the prompt
+    (e.g. an MLLM engine that rejects ``build_prompt``). In that case we install
+    NO processor and return ``None`` so the caller retains the post-hoc reasoning
+    cap — installing a non-seeded processor instead would be a silent footgun:
+    it would never fire for a prefilling model (it never saw the ``<think>``
+    open) YET its presence suppresses the post-hoc cap, leaving the request's
+    reasoning budget COMPLETELY unenforced (codex). When the prompt rendered,
+    seeding is derived from its trusted generation prefix.
+
+    ``vocab_size`` is the model's output width (or a sound floor such as
+    ``len(tokenizer)``); the builder requires it and returns ``None`` (post-hoc
+    cap retained) when it is unknown OR ``</think>`` resolves outside it, so a
+    processor never exists with an unverified force id (see below).
+    """
+    if rendered_prompt is None:
+        return None
+    state = reasoning_seed_state(rendered_prompt, reasoning_parser_name)
+    if state == "ambiguous":
+        # Seed state cannot be proven from the isolated delta (a closed
+        # ``<think>…</think>`` pair, a stray end marker, or an unresolvable
+        # parser). Decline so the post-hoc cap stays active rather than install a
+        # processor that might never start yet suppress the cap (codex R12).
+        return None
+    return build_reasoning_budget_processor(
+        tokenizer,
+        reasoning_parser_name,
+        max_think_tokens,
+        seeded_thinking=(state == "open"),
+        vocab_size=vocab_size,
+    )
+
+
+def _encode_single_special(tokenizer: Any, marker: str) -> int | None:
+    """Return the single token id ``marker`` encodes to, or ``None``.
+
+    Mirrors SGLang ``ReasonerGrammarBackend.__init__``: a reasoning-boundary
+    marker is usable only when the tokenizer maps it to EXACTLY ONE token
+    (otherwise the id comparison in the hot loop is meaningless). Any tokenizer
+    that splits ``</think>`` into ordinary bytes (some channel-routed families)
+    yields ``None`` and the caller opts out to the post-hoc reasoning cap.
+    """
+    if not marker:
+        return None
+    try:
+        ids = tokenizer.encode(marker, add_special_tokens=False)
+    except Exception:
+        return None
+    if not ids or len(ids) != 1:
+        return None
+    return int(ids[0])
+
+
+def resolve_think_token_ids(
+    tokenizer: Any, reasoning_parser_name: str | None
+) -> tuple[int | None, int | None]:
+    """Resolve ``(think_start_id, think_end_id)`` for the configured parser.
+
+    Reads the reasoning parser's ``start_token`` / ``end_token`` (e.g.
+    ``<think>`` / ``</think>``) and requires each to be a single special token
+    on ``tokenizer`` (via ``resolve_reasoning_sentinels``, the exact gate the
+    tool sentinels use) AND to encode to exactly one id. Returns ``None`` for
+    either id that is unavailable — a missing ``think_end_id`` disables the
+    generation-time budget for that model (caller falls back to the post-hoc
+    cap; a tracked follow-up covers channel-routed families).
+    """
+    if tokenizer is None or not reasoning_parser_name:
+        return (None, None)
+    # Only trust markers that resolve_reasoning_sentinels already proved are
+    # single special tokens on this tokenizer (reuse, don't reinvent the gate).
+    from .tool_grammar import resolve_reasoning_sentinels
+
+    sentinels = set(resolve_reasoning_sentinels(reasoning_parser_name, tokenizer))
+    if not sentinels:
+        return (None, None)
+    try:
+        from ..reasoning import get_parser
+
+        parser = get_parser(reasoning_parser_name)()
+        start_marker = getattr(parser, "start_token", None)
+        end_marker = getattr(parser, "end_token", None)
+    except Exception:
+        return (None, None)
+    start_id = (
+        _encode_single_special(tokenizer, start_marker)
+        if isinstance(start_marker, str) and start_marker in sentinels
+        else None
+    )
+    end_id = (
+        _encode_single_special(tokenizer, end_marker)
+        if isinstance(end_marker, str) and end_marker in sentinels
+        else None
+    )
+    return (start_id, end_id)
+
+
+def build_reasoning_budget_processor(
+    tokenizer: Any,
+    reasoning_parser_name: str | None,
+    max_think_tokens: int | None,
+    *,
+    seeded_thinking: bool,
+    vocab_size: int | None = None,
+) -> ReasoningBudgetLogitsProcessor | None:
+    """Build a generation-time thinking-budget processor, or ``None``.
+
+    Returns ``None`` (caller keeps the post-hoc reasoning cap) when there is no
+    budget, or the model's ``</think>`` is not a single resolvable token. When
+    ``seeded_thinking`` is False the ``<think>`` open id must also resolve, else
+    the budget cannot know when thinking begins and opts out (guards the vLLM
+    #39130 footgun: never force a reasoning-end that cannot occur).
+
+    ``vocab_size`` (the model's output width, or a sound floor such as
+    ``len(tokenizer)``) is REQUIRED and validated HERE, at BUILD time. Building a
+    processor is what suppresses the post-hoc cap at the call site, so a
+    processor may exist ONLY when its ``</think>`` id is build-time verified to be
+    in range. Therefore we return ``None`` (post-hoc cap retained) when the width
+    is UNKNOWN (``vocab_size is None`` — cannot verify) OR ``</think>`` lands
+    outside it. Either way the budget is still enforced by the post-hoc cap; what
+    we refuse is the unsound combination of "suppress the cap AND install a
+    processor a decode-time out-of-range guard might silently disable, leaving the
+    budget completely unenforced" (codex R11). The caller passes the model's
+    ACTUAL output-head width (``_engine_output_vocab_size`` reads the real lm-head
+    / tied-embedding weight rows, not a possibly-divergent declared config value —
+    codex R12), so a built processor's ``</think>`` id is verified emittable by the
+    head. For a real loaded engine the width is always determinable, so this never
+    declines in practice; the decode-time guard in ``_force_distribution`` remains
+    purely as a crash-safety net for the impossible case of a runtime logits width
+    disagreeing with the inspected head weight.
+    """
+    if max_think_tokens is None or max_think_tokens < 0:
+        return None
+    start_id, end_id = resolve_think_token_ids(tokenizer, reasoning_parser_name)
+    if end_id is None:
+        return None
+    if vocab_size is None or not (0 <= end_id < vocab_size):
+        return None
+    if not seeded_thinking:
+        # An EMITTING template waits for the model to generate ``<think>`` — that
+        # id must be resolvable AND emittable by the head, else the processor can
+        # never start yet its presence suppresses the post-hoc cap (codex R13:
+        # bounds-check ``start_id`` symmetrically with ``end_id``, not just for
+        # None).
+        if start_id is None or not (0 <= start_id < vocab_size):
+            return None
+    return ReasoningBudgetLogitsProcessor(
+        end_id,
+        max_think_tokens,
+        think_start_id=start_id,
+        seeded_thinking=seeded_thinking,
+    )

--- a/vllm_mlx/engine/base.py
+++ b/vllm_mlx/engine/base.py
@@ -459,9 +459,14 @@ class BaseEngine(ABC):
         messages: list[dict[str, Any]],
         tools: list[dict] | None = None,
         enable_thinking: bool | None = None,
+        add_generation_prompt: bool = True,
     ) -> str:
         """Render the chat prompt for ``messages`` + ``tools`` without
         starting generation.
+
+        ``add_generation_prompt`` (default True) toggles the assistant
+        generation prefix so the reasoning-budget seed probe can diff two
+        renders to isolate the template-added prefix.
 
         Called by ``routes/chat.py`` for cloud-routing token estimation
         and for eager streaming chat-template validation (so template

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -1383,9 +1383,14 @@ class BatchedEngine(BaseEngine):
         messages: list[dict[str, Any]],
         tools: list[dict] | None = None,
         enable_thinking: bool | None = None,
+        add_generation_prompt: bool = True,
     ) -> str:
         """Render the chat prompt for ``messages`` + ``tools`` without starting
         generation.
+
+        ``add_generation_prompt`` (default True) toggles the assistant
+        generation prefix; the reasoning-budget seed probe renders twice
+        (True/False) and diffs to isolate the template-added prefix exactly.
 
         Used by:
           * Cloud routing (``routes/chat.py``) — needs the prompt to estimate
@@ -1410,6 +1415,7 @@ class BatchedEngine(BaseEngine):
             messages,
             tools=template_tools,
             enable_thinking=enable_thinking,
+            add_generation_prompt=add_generation_prompt,
         )
         prepared, _ = self._prepare_harmony_no_thinking_prompt(
             prompt,
@@ -1455,6 +1461,7 @@ class BatchedEngine(BaseEngine):
         tools: list[dict] | None = None,
         num_images: int = 0,
         enable_thinking: bool | None = None,
+        add_generation_prompt: bool = True,
     ) -> str:
         """Apply chat template to messages.
 
@@ -1511,6 +1518,7 @@ class BatchedEngine(BaseEngine):
             tools=tools,
             enable_thinking=enable_thinking,
             model_name=self._model_name,
+            add_generation_prompt=add_generation_prompt,
         )
 
     @staticmethod
@@ -1685,6 +1693,9 @@ class BatchedEngine(BaseEngine):
         # Grammar-constrained tool calling (#558): per-request logits
         # processor forwarded to the scheduler's request_processors slot.
         grammar_logits_processor = kwargs.pop("grammar_logits_processor", None)
+        reasoning_budget_logits_processor = kwargs.pop(
+            "reasoning_budget_logits_processor", None
+        )
         if output_router_seed is None and isinstance(prompt, str):
             # ``build_prompt(enable_thinking=False)`` is part of the public
             # engine contract and returns the prepared Harmony string. A
@@ -1709,6 +1720,7 @@ class BatchedEngine(BaseEngine):
             has_tools=has_tools,
             requires_prompt_integrity=requires_prompt_integrity,
             grammar_logits_processor=grammar_logits_processor,
+            reasoning_budget_logits_processor=reasoning_budget_logits_processor,
         )
 
         if assistant_text_prefix:
@@ -1898,6 +1910,9 @@ class BatchedEngine(BaseEngine):
         requires_prompt_integrity = bool(kwargs.pop("requires_prompt_integrity", False))
         # Grammar-constrained tool calling (#558) — streaming parity.
         grammar_logits_processor = kwargs.pop("grammar_logits_processor", None)
+        reasoning_budget_logits_processor = kwargs.pop(
+            "reasoning_budget_logits_processor", None
+        )
         request_id = await self._engine.add_request(
             prompt=prompt,
             sampling_params=sampling_params,
@@ -1905,6 +1920,7 @@ class BatchedEngine(BaseEngine):
             has_tools=has_tools,
             requires_prompt_integrity=requires_prompt_integrity,
             grammar_logits_processor=grammar_logits_processor,
+            reasoning_budget_logits_processor=reasoning_budget_logits_processor,
         )
         # C-01 force-abort: publish the scheduler request id (text path)
         # so the route's disconnect_guard can call abort_request directly

--- a/vllm_mlx/engine_core.py
+++ b/vllm_mlx/engine_core.py
@@ -742,6 +742,7 @@ class EngineCore:
         has_tools: bool = False,
         requires_prompt_integrity: bool = False,
         grammar_logits_processor: Any | None = None,
+        reasoning_budget_logits_processor: Any | None = None,
     ) -> str:
         """
         Add a request for processing.
@@ -777,6 +778,7 @@ class EngineCore:
             has_tools=has_tools,
             requires_prompt_integrity=requires_prompt_integrity,
             grammar_logits_processor=grammar_logits_processor,
+            reasoning_budget_logits_processor=reasoning_budget_logits_processor,
         )
 
         # Throttle requests for hybrid models (GatedDeltaNet + Transformer).

--- a/vllm_mlx/request.py
+++ b/vllm_mlx/request.py
@@ -177,6 +177,15 @@ class Request:
     # free-form-then-parse behavior (non-breaking default).
     grammar_logits_processor: Any | None = None
 
+    # Generation-time thinking-token budget (force-close ``</think>``). Optional
+    # per-request logits processor set by the chat route when
+    # ``reasoning_max_tokens`` is set, thinking is enabled, and the model's
+    # ``</think>`` resolves to a single token. Runs as a per-step logits
+    # processor (same slot mechanics as ``grammar_logits_processor``), forcing
+    # the model to close its ``<think>`` block once the budget is spent. ``None``
+    # -> the post-hoc reasoning cap in the postprocessor owns the request.
+    reasoning_budget_logits_processor: Any | None = None
+
     # PFlash prompt compression state. When pflash_metadata["compressed"]
     # is True, prompt_token_ids is the compressed list and
     # original_prompt_token_ids holds the pre-compression sequence so

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -2159,6 +2159,254 @@ async def create_chat_completion(request: ChatCompletionRequest, raw_request: Re
             _release_admission_unless_committed(engine, _commit_state[0])
 
 
+def _effective_posthoc_reasoning_cap(sampling_kwargs: dict, request) -> int | None:
+    """Return the post-hoc reasoning-token cap for the postprocessor, or
+    ``None`` when the generation-time thinking-budget processor owns this
+    request.
+
+    #558 SINGLE MECHANISM: when the chat route built a
+    ``reasoning_budget_logits_processor`` (a text-parser family whose
+    ``</think>`` is a single token, with a resolved budget), the thinking span
+    is force-closed AT DECODE TIME — so the post-hoc char-count trim in the
+    postprocessor MUST NOT also run, or it would double-count / re-inject a
+    second close marker. Both postprocessor construction sites (non-stream in
+    ``_create_chat_completion_impl``, streaming in ``stream_chat_completion``)
+    route their cap through here so the "generation-time budget XOR post-hoc
+    cap" invariant has ONE definition and can never drift between the two paths.
+    Every request WITHOUT a budget processor (channel-routed families that keep
+    the post-hoc cap, no cap set, or thinking-off) falls back to the request's
+    ``reasoning_max_tokens`` — the pre-#558 behaviour, unchanged.
+    """
+    if sampling_kwargs.get("reasoning_budget_logits_processor") is not None:
+        return None
+    return getattr(request, "reasoning_max_tokens", None)
+
+
+def _template_generation_prefix(engine, messages, tools, enable_thinking) -> str | None:
+    """Return the TEMPLATE-added generation-prefix delta for ``messages``.
+
+    The seed decision (does the budget start already inside a ``<think>`` span?)
+    must trust ONLY what the chat TEMPLATE appends for the new assistant turn —
+    never raw conversation content — so a ``<think>`` a USER typed cannot
+    mis-seed the budget (codex). We isolate that prefix EXACTLY by diffing two
+    renders against the template's own generation boundary (the
+    ``add_generation_prompt`` flag every HF chat template honours):
+
+      * ``full`` — render WITH the assistant generation prompt (what decode
+        actually starts from).
+      * ``base`` — render the SAME conversation WITHOUT the generation prompt.
+
+    In the normal case ``full`` STARTS WITH ``base`` (toggling the generation
+    prompt only APPENDS the assistant header; it never rewrites history), so the
+    delta ``full[len(base):]`` is EXACTLY the template-added generation prefix
+    for the REAL content — assistant header plus a prefilled ``<think>`` iff the
+    template opens one. Because the delta is obtained by SUBTRACTION, not by
+    matching a guessed suffix, a short generic prefix (e.g. ``"\\n"``) can never
+    spuriously validate against a longer real one (codex R10 #1: the old
+    ``full.endswith(probe_delta)`` check accepted ``"\\n"`` when the real prefix
+    was ``"<think>\\n"``), and any ``<think>`` the user typed lives in ``base``
+    too and cancels out of the delta (immune to injection). No content is ever
+    substituted, so content-dependent templates render with their real inputs.
+
+    Returns ``None`` (caller retains the post-hoc cap) when the last message's
+    content is not a plain string (``build_prompt`` is text-only), ``messages``
+    is empty (nothing rendered), ``full`` does not start with ``base`` (a
+    template that restructures when the generation prompt toggles — the prefix
+    can't be isolated cleanly, so be safe), or the delta is empty.
+    """
+    if not messages:
+        # Nothing was rendered — a prefill template must NOT be mistaken for an
+        # emit one (which would install a never-starting processor that still
+        # suppresses the post-hoc cap). Decline (codex R10 #3).
+        return None
+    last = messages[-1]
+    content = last.get("content") if isinstance(last, dict) else None
+    if not isinstance(content, str):
+        return None
+    full = engine.build_prompt(
+        messages,
+        tools=tools,
+        enable_thinking=enable_thinking,
+        add_generation_prompt=True,
+    )
+    base = engine.build_prompt(
+        messages,
+        tools=tools,
+        enable_thinking=enable_thinking,
+        add_generation_prompt=False,
+    )
+    if not full.startswith(base):
+        # Template restructures when the generation prompt toggles (the added
+        # prefix is not a clean suffix of the full render) — cannot isolate the
+        # boundary, so decline rather than risk a wrong seed (codex).
+        return None
+    delta = full[len(base) :]
+    if not delta:
+        return None  # generation prompt added nothing after content — no seed
+    return delta
+
+
+def _actual_output_head_width(model) -> int | None:
+    """The model's TRUE logits width — the vocab dimension (rows) of the output
+    projection weight — or ``None`` if it cannot be inspected.
+
+    This is the AUTHORITATIVE bound the decode-time force validates against
+    (codex R12: the declared ``config.vocab_size`` can differ from the real
+    lm-head width; validate against the actual head so a processor is never
+    installed — and the post-hoc cap never suppressed — for a ``</think>`` id the
+    head cannot emit). Tries the untied ``lm_head`` first, then the tied
+    embedding projected via ``as_linear`` (qwen3 and most MLX text models), each
+    time reading ``weight.shape[0]`` — still the vocab dim under quantization
+    (qwen3-4bit's ``embed_tokens.weight`` is ``(vocab, packed_hidden)``).
+    """
+    if model is None:
+        return None
+    for path in (
+        ("lm_head", "weight"),
+        ("model", "embed_tokens", "weight"),
+        ("embed_tokens", "weight"),
+    ):
+        obj = model
+        for attr in path:
+            obj = getattr(obj, attr, None)
+            if obj is None:
+                break
+        shape = getattr(obj, "shape", None)
+        if (
+            shape is not None
+            and len(shape) >= 1
+            and isinstance(shape[0], int)
+            and shape[0] > 0
+        ):
+            return int(shape[0])
+    return None
+
+
+def _engine_output_vocab_size(engine) -> int | None:
+    """The model's output-vocab width, for the build-time ``</think>`` bounds
+    check — the ACTUAL output-head weight width (``_actual_output_head_width``),
+    or ``None`` when it cannot be inspected.
+
+    This is deliberately the WEIGHT-DERIVED width ONLY — the same number the
+    decode step's logits carry (``logits = head(hidden)`` ⇒
+    ``logits.shape[-1] == head.weight.shape[0]``). Because the build-time bounds
+    check and the decode-time force therefore validate ``</think>`` against the
+    IDENTICAL width, the decode-time out-of-range guard in ``_force_distribution``
+    is provably unreachable for any processor we install: it can only fire if a
+    later width disagrees with the head we inspected, which cannot happen when
+    both come from that one weight (codex R15).
+
+    Two rejected fallbacks, both UNSOUND for this check because they can exceed
+    the real head width and let an out-of-range force id install (suppressing the
+    post-hoc cap) only for the decode guard to then disable the budget — silently
+    leaving ``reasoning_max_tokens`` unenforced:
+      • ``len(tokenizer)`` (codex R14) — counts added specials, so ``</think>``
+        (itself an added special) is always within it: a vacuous check.
+      • declared ``config.vocab_size`` (codex R15) — a padded / over-declared
+        vocab can exceed the true head width, which is EXACTLY the mismatch that
+        would trip the decode guard.
+
+    When the head weight is not inspectable we return ``None`` and the builder
+    DECLINES (retaining the post-hoc cap; codex R11) rather than admit an
+    unverified force id. Every current text reasoning family (qwen3 tied embed,
+    gpt-oss / llama untied ``lm_head``) resolves via the weight, so the budget is
+    not declined for this reason in practice.
+    """
+    model = getattr(engine, "_model", None)
+    if model is None:
+        model = getattr(engine, "model", None)
+    return _actual_output_head_width(model)
+
+
+def _build_reasoning_budget_processor(
+    engine, request, cfg, messages, resolved_thinking
+) -> "ReasoningBudgetLogitsProcessor | None":  # noqa: F821 — forward ref
+    """Build the generation-time thinking-budget processor for this request, or
+    ``None`` (the caller then keeps the post-hoc reasoning cap).
+
+    This is the AUTHORITATIVE reasoning cap for text-parser families: once the
+    model has spent ``reasoning_max_tokens`` inside its ``<think>…</think>``
+    span, the next-token logits are OVERRIDDEN so the only sampleable token is
+    the single ``</think>`` id — the exact lever vLLM (``ThinkingBudgetState-
+    Holder``), SGLang (``ReasonerGrammarObject``) and mlx-vlm (``ThinkingBudget-
+    Criteria``) use. It REPLACES the post-hoc char-count trim: when this returns
+    a processor, ``_effective_posthoc_reasoning_cap`` suppresses the post-hoc cap
+    so the two never both run (single mechanism, one source of truth).
+
+    Called from the route ONLY once the request is committed to LOCAL generation
+    (past cloud offload) — a cloud-routed request neither installs the processor
+    nor has its post-hoc cap suppressed (codex).
+
+    Gating (each returns ``None`` → post-hoc cap retained):
+      * Thinking must be DEFINITIVELY on — ``_effective_enable_thinking`` is
+        ``True`` (mirrors what ``apply_chat_template`` does to pre-inject
+        ``<think>``). A thinking-OFF request (explicit off / coder default) OR an
+        unknown-model default (``None``) is skipped, so we never install an
+        unseeded processor that can't fire yet still suppresses the post-hoc cap
+        (guards vLLM #39130: never force a reasoning-end that cannot occur).
+      * TOOL requests opt out — a mid-span force-close could inject ``</think>``
+        after a tool-call opener and corrupt the call (vLLM #44676); a tracked
+        follow-up adds SGLang's ``think_excluded_tokens`` so the two can coexist.
+      * A request that lists ``</think>`` (or an overlapping substring) in
+        ``stop`` opts out — forcing ``</think>`` would trip that client stop AT
+        the reasoning boundary; the post-hoc cap (which appends ``</think>`` to
+        the FINAL text, not through the decode-time stop matcher) still enforces
+        the budget with no behaviour change vs pre-feature.
+      * ``build_budget_from_render`` returns ``None`` for any model whose
+        ``</think>`` is not a single token (channel-routed gpt-oss / harmony).
+
+    Whether the span is SEEDED (template prefills ``<think>``) vs EMITTED (the
+    model generates it) is derived from the TEMPLATE'S generation-prefix delta
+    (``_template_generation_prefix``), never from raw conversation content.
+    """
+    from ..api.reasoning_budget import (
+        build_budget_from_render,
+        reasoning_stop_conflicts,
+    )
+
+    if (
+        _effective_enable_thinking(resolved_thinking, cfg.model_path or cfg.model_name)
+        is not True
+    ):
+        return None
+    if getattr(request, "reasoning_max_tokens", None) is None:
+        return None
+    if request.tools:
+        return None
+    if reasoning_stop_conflicts(
+        getattr(request, "stop", None), getattr(cfg, "reasoning_parser_name", None)
+    ):
+        return None
+    try:
+        seed_suffix = _template_generation_prefix(
+            engine, messages, request.tools, resolved_thinking
+        )
+    except Exception as exc:
+        # Rendering can fail (e.g. MLLM engines reject build_prompt). Signal that
+        # with None so build_budget_from_render installs NO processor and the
+        # post-hoc cap is retained — never a non-seeded processor that would
+        # silently suppress the cap yet never fire (codex). The budget stays
+        # enforced via the post-hoc cap, so this is a legitimate fallback for some
+        # engines — but log it (debug, with model context) so a genuine rendering
+        # regression is diagnosable instead of silently degrading to post-hoc for
+        # every request (codex R16 nit).
+        logger.debug(
+            "reasoning budget: generation-prefix render failed for model=%s "
+            "(%s: %s) — falling back to the post-hoc reasoning cap",
+            getattr(cfg, "model_path", None) or getattr(cfg, "model_name", None),
+            type(exc).__name__,
+            exc,
+        )
+        seed_suffix = None
+    return build_budget_from_render(
+        getattr(engine, "tokenizer", None),
+        getattr(cfg, "reasoning_parser_name", None),
+        getattr(request, "reasoning_max_tokens", None),
+        seed_suffix,
+        vocab_size=_engine_output_vocab_size(engine),
+    )
+
+
 async def _create_chat_completion_impl(
     request: ChatCompletionRequest,
     raw_request: Request,
@@ -3052,6 +3300,16 @@ async def _create_chat_completion_impl(
                 f"[LOCAL] {new_tokens} new tokens (total {total_tokens}) "
                 f"<= threshold {cfg.cloud_router.threshold}, using local inference"
             )
+
+    # Generation-time thinking-token budget — built HERE, only once the request
+    # is committed to LOCAL generation (past the cloud-offload decision), so a
+    # cloud-routed request neither installs the processor nor has its post-hoc
+    # cap suppressed (codex). See ``_build_reasoning_budget_processor``.
+    _rblp = _build_reasoning_budget_processor(
+        engine, request, cfg, messages, resolved_thinking
+    )
+    if _rblp is not None:
+        chat_kwargs["reasoning_budget_logits_processor"] = _rblp
 
     # ``tool_choice="required"`` + ``stream=true`` is enforceable IF the
     # engine has SOME path to produce a streaming tool_call:
@@ -4349,8 +4607,9 @@ async def _create_chat_completion_impl(
             resolved_thinking, cfg.model_path or cfg.model_name
         ),
         # Per-request reasoning cap (upstream vLLM PR #20859 backport).
-        # None → back-compat no-op.
-        reasoning_max_tokens=getattr(request, "reasoning_max_tokens", None),
+        # None → back-compat no-op. Suppressed when the generation-time
+        # thinking-budget processor owns this request (#558 single mechanism).
+        reasoning_max_tokens=_effective_posthoc_reasoning_cap(chat_kwargs, request),
         # r5-D — finalize-on-truncation shared plug needs to know if
         # generation was cut short so it can re-classify an unclosed
         # think buffer as ``reasoning_content`` instead of leaking it
@@ -4681,7 +4940,11 @@ async def stream_chat_completion(
             request=request_dict,
             # Per-request reasoning cap (upstream vLLM PR #20859 backport).
             # When None the postprocessor is a no-op for the cap path.
-            reasoning_max_tokens=getattr(request, "reasoning_max_tokens", None),
+            # Suppressed when the generation-time thinking-budget processor
+            # (``kwargs["reasoning_budget_logits_processor"]``, set by the chat
+            # route into chat_kwargs and unpacked here) owns this request —
+            # #558 single mechanism, decision shared with the non-stream path.
+            reasoning_max_tokens=_effective_posthoc_reasoning_cap(kwargs, request),
         )
         processor.set_thinking_model(request.model)
         processor.reset()

--- a/vllm_mlx/runtime/diffusion_lane.py
+++ b/vllm_mlx/runtime/diffusion_lane.py
@@ -795,11 +795,12 @@ class DiffusionEngine(BaseEngine):
         messages: list[dict[str, Any]],
         tools: list[dict] | None = None,
         enable_thinking: bool | None = None,
+        add_generation_prompt: bool = True,
     ) -> str:
         self._ensure_loaded()
         template_kwargs: dict[str, Any] = {
             "tokenize": False,
-            "add_generation_prompt": True,
+            "add_generation_prompt": add_generation_prompt,
         }
         # Only forward ``tools`` to the chat template when the active
         # alias declares a tool parser this engine can actually surface

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -1959,25 +1959,48 @@ class Scheduler:
         # penalty-only uid is recorded above for correct desync repair but does
         # NOT by itself arm the guard.
         self._uids_with_grammar: set[int] = set()
-        # Identity set of every grammar processor currently in flight (by
-        # ``id()``), so a slot can be scrubbed of ANY grammar processor before
-        # its uid's authoritative list is applied — this recognizes even a
-        # grammar whose owning uid already finished but that still lingers in a
-        # leaked slot. An id is dropped only once its owning uid is removed AND
-        # the processor is absent from every live batch slot (tombstoned until
-        # then; see ``_forget_uid_grammar`` + the sweep in the realign guard).
-        self._known_grammar_processors: set[int] = set()
+        # Which tracked uids carry a generation-time reasoning-budget processor
+        # (force-close </think>). Like a grammar, a budget processor is a
+        # per-request logits processor whose slot MUST stay aligned to its uid
+        # across ticks: mlx-lm's positional ``logits_processors`` list can desync
+        # when a NO-processor request finishes while this one is mid-flight,
+        # silently dropping the budget so the </think> is never forced (observed
+        # on a live model: a plain greedy request preceding a budget request left
+        # the budget inert). So a live budget uid ALSO arms the realign guard,
+        # which rebuilds every slot from ``uid_to_request_processors`` (the source
+        # of truth that already holds the budget processor). Penalty-only uids
+        # still do NOT arm it — only grammar and budget carry a hard per-token
+        # guarantee that a desync would violate.
+        #
+        # Maps uid -> budget processor (not a bare set) so the realign guard can
+        # see each processor's ``_ended`` latch: a budget processor arms the guard
+        # ONLY while it can still act (before it has forced ``</think>``). Once it
+        # is ``_ended`` (thinking closed, now emitting the answer) it is inert —
+        # keeping the guard armed for it would add an O(batch) slot rebuild to
+        # EVERY answer token for nothing (codex R10 #4). A finished uid's leaked
+        # processor is still handled: ``_forget_uid_grammar`` tombstones it, and
+        # the tombstone re-arms the guard for the scrub tick.
+        self._uids_with_reasoning_budget: dict[int, Any] = {}
+        # Identity set of every STATEFUL per-request processor currently in
+        # flight (by ``id()``) — a grammar OR a reasoning-budget force-close.
+        # Lets a slot be scrubbed of ANY such processor before its uid's
+        # authoritative list is applied — recognizing even one whose owning uid
+        # already finished but that still lingers in a leaked slot. An id is
+        # dropped only once its owning uid is removed AND the processor is absent
+        # from every live batch slot (tombstoned until then; see
+        # ``_forget_uid_grammar`` + the sweep in the realign guard).
+        self._known_stateful_processors: set[int] = set()
         # Keeps each tracked processor OBJECT alive while its ``id()`` is in the
         # set above, so Python can't reuse that id for a different object while
-        # the grammar may still sit in a batch slot (id-reuse-after-GC guard).
-        self._grammar_processor_objs: dict[int, Any] = {}
-        # Grammar processors whose owning uid has left the tracking maps but
-        # that may still linger in a leaked batch slot. Kept in
-        # ``_known_grammar_processors`` (so they're still scrubbed) until the
+        # the processor may still sit in a batch slot (id-reuse-after-GC guard).
+        self._stateful_processor_objs: dict[int, Any] = {}
+        # Stateful processors (grammar/budget) whose owning uid has left the
+        # tracking maps but that may still linger in a leaked batch slot. Kept in
+        # ``_known_stateful_processors`` (so they're still scrubbed) until the
         # realign guard confirms they're absent from every live slot, then
-        # forgotten. Closes the cleanup-ordering gap where the LAST grammar
+        # forgotten. Closes the cleanup-ordering gap where the LAST such processor
         # finishing would disarm the guard before its leaked slot was cleaned.
-        self._grammar_tombstones: set[int] = set()
+        self._stateful_tombstones: set[int] = set()
 
         # BatchGenerator - the actual batching engine
         self.batch_generator: BatchGenerator | None = None
@@ -4026,36 +4049,122 @@ class Scheduler:
             # masks the abort in the caller's exception handler.
             pass
 
+    def _register_uid_processors(
+        self,
+        uid: int,
+        request: Any,
+        request_processors: list | None,
+        grammar_lp: Any,
+    ) -> None:
+        """Record a uid's logits-processor bookkeeping at admission.
+
+        Single source of truth for the per-tick realign guard (the COUNTERPART
+        of :meth:`_forget_uid_grammar`). Both the scheduler's admission path and
+        the realign unit tests call THIS method, so a regression in the recorded
+        state (a dropped budget/grammar arm, a lost penalty list) fails a test
+        rather than only surfacing on live hardware (codex #558 NIT).
+
+        * ``uid_to_request_processors`` remembers EVERY uid that carries any
+          processor (grammar + penalties), the authoritative list the realign
+          rebuilds each slot from — immune to mlx-lm's stale-entry desync.
+        * A grammar-carrying uid also registers the grammar's identity in the
+          stateful-processor set (so a leaked slot can be scrubbed even after the
+          uid finishes) and arms the guard.
+        * A reasoning-budget uid arms the guard so its force-close ``</think>``
+          processor is realigned every tick, AND registers the budget
+          processor's identity in the SAME stateful set — a budget processor is
+          per-request stateful (a ``</think>`` force-close latch), so if a
+          finished budget uid's processor leaks into a stale positional slot
+          after cancellation/truncation it must be tombstoned and scrubbed
+          exactly like a leaked grammar (codex: track + tombstone budget like
+          grammar). Its object already lives in ``uid_to_request_processors[uid]``
+          too.
+        """
+        if request_processors:
+            self.uid_to_request_processors[uid] = list(request_processors)
+        if grammar_lp is not None:
+            self._uids_with_grammar.add(uid)
+            self._known_stateful_processors.add(id(grammar_lp))
+            # Keep the object alive so its ``id()`` can't be reused by a
+            # different object while it may still linger in a slot.
+            self._stateful_processor_objs[id(grammar_lp)] = grammar_lp
+        _rblp = getattr(request, "reasoning_budget_logits_processor", None)
+        if _rblp is not None:
+            self._uids_with_reasoning_budget[uid] = _rblp
+            # Same tombstone/scrub treatment as grammar (see docstring): register
+            # identity + keep the object alive so a leaked force-close processor
+            # is scrubbed from a foreign slot and the guard stays armed for that
+            # scrubbing tick.
+            self._known_stateful_processors.add(id(_rblp))
+            self._stateful_processor_objs[id(_rblp)] = _rblp
+
     def _forget_uid_grammar(self, uid: int) -> None:
         """Drop #558 PR-3 per-uid processor state for a uid leaving the batch.
 
         Called from the abort + finish cleanup paths. Those paths remove ``uid``
         from the generation batch's ``uids`` *before* the next tick's realign,
         but mlx-lm's own positional ``logits_processors`` filter can lag by a
-        tick and leave the just-finished grammar in a LEAKED slot. So we do NOT
-        immediately forget the grammar's identity here: we TOMBSTONE it (keep it
-        in ``_known_grammar_processors`` so the realign guard still scrubs it)
-        until the guard confirms it's absent from every live slot. Penalty-only
-        uids carry no grammar and are simply dropped.
+        tick and leave the just-finished STATEFUL processor (grammar OR
+        reasoning-budget force-close) in a LEAKED slot. So we do NOT immediately
+        forget its identity here: we TOMBSTONE it (keep it in
+        ``_known_stateful_processors`` so the realign guard stays armed and still
+        scrubs it) until the guard confirms it's absent from every live slot.
+        This is what stops a finished budget uid's force-close processor from
+        leaking onto a later no-processor request after the last budget uid
+        disarms the guard (codex). Penalty-only uids carry no stateful processor
+        and are simply dropped.
         """
         self._uids_with_grammar.discard(uid)
+        self._uids_with_reasoning_budget.pop(uid, None)
         procs = self.uid_to_request_processors.pop(uid, None)
         if not procs:
             return
-        # A grammar in this uid's list that's still referenced by ANOTHER live
-        # uid stays fully live; otherwise it becomes a tombstone — still known
-        # (and thus still scrubbable) but pending removal once no slot holds it.
-        # A request never shares its GrammarLogitsProcessor, so the cross-uid
-        # check is defensive; the tombstone is the load-bearing part.
+        # A stateful processor (grammar/budget) in this uid's list that's still
+        # referenced by ANOTHER live uid stays fully live; otherwise it becomes a
+        # tombstone — still known (and thus still scrubbable) but pending removal
+        # once no slot holds it. A request never shares its stateful processor, so
+        # the cross-uid check is defensive; the tombstone is the load-bearing part.
         still_referenced: set[int] = set()
         for plist in self.uid_to_request_processors.values():
             for p in plist:
-                if id(p) in self._known_grammar_processors:
+                if id(p) in self._known_stateful_processors:
                     still_referenced.add(id(p))
         for p in procs:
             pid = id(p)
-            if pid in self._known_grammar_processors and pid not in still_referenced:
-                self._grammar_tombstones.add(pid)
+            if pid in self._known_stateful_processors and pid not in still_referenced:
+                self._stateful_tombstones.add(pid)
+
+    def _realign_guard_armed(self) -> bool:
+        """True when the per-tick logits-processor realign must run.
+
+        Armed by any live GRAMMAR uid, a not-yet-flushed stateful tombstone, or
+        any reasoning-BUDGET uid whose processor is still ACTIVE (has not yet
+        forced ``</think>``). All carry a HARD per-token guarantee (a constrained
+        tool call / a pending forced ``</think>``) that mlx-lm's positional
+        ``logits_processors`` desync would silently violate, so their slots must
+        be rebuilt from ``uid_to_request_processors`` every tick.
+
+        A budget processor that has already ``_ended`` (thinking closed; now
+        emitting the answer) is INERT — it returns logits unchanged — so it no
+        longer needs its slot realigned, and keeping the guard armed for it would
+        add an O(batch) rebuild to every remaining ANSWER token for no benefit
+        (codex R10 #4). Disarming is safe: if such an inert processor later leaks
+        into a foreign slot, applying it is a no-op, and when its uid finishes
+        ``_forget_uid_grammar`` tombstones it — which re-arms the guard for the
+        scrub tick. Penalty-only uids never arm it (plain decode hot path).
+
+        This is the single source of truth for the arming condition so it can be
+        unit-tested directly (a deleted budget arm fails a test rather than only
+        surfacing on live hardware).
+        """
+        return bool(
+            self._uids_with_grammar
+            or self._stateful_tombstones
+            or any(
+                not getattr(p, "_ended", False)
+                for p in self._uids_with_reasoning_budget.values()
+            )
+        )
 
     def _realign_grammar_logits_processors(self) -> None:
         """Rebuild the generation batch's ``logits_processors`` aligned to uids.
@@ -4078,7 +4187,7 @@ class Scheduler:
             re-inserted).
           * A uid we do NOT track genuinely has no processors, so its slot is
             ``[]``. This also scrubs any grammar processor (by identity, via the
-            ``_known_grammar_processors`` set — which still contains tombstoned
+            ``_known_stateful_processors`` set — which still contains tombstoned
             grammars whose owning uid finished, closing the cleanup-ordering
             gap) that leaked into that slot via a desync.
 
@@ -4096,7 +4205,7 @@ class Scheduler:
             # #558-PR3 nit): otherwise a finished grammar's processor + matcher
             # state would be retained indefinitely across an idle period where
             # the batch object itself is absent.
-            self._flush_grammar_tombstones(present=set())
+            self._flush_stateful_tombstones(present=set())
             return
         uids = getattr(bg, "uids", None)
         if not uids:
@@ -4111,7 +4220,7 @@ class Scheduler:
             existing = getattr(bg, "logits_processors", None)
             if existing:
                 bg.logits_processors = []
-            self._flush_grammar_tombstones(present=set())
+            self._flush_stateful_tombstones(present=set())
             return
         existing = getattr(bg, "logits_processors", None)
         aligned = existing is not None and len(existing) == len(uids)
@@ -4130,7 +4239,7 @@ class Scheduler:
                 # any grammar that leaked here via a desync).
                 slot = []
             for p in slot:
-                if id(p) in self._known_grammar_processors:
+                if id(p) in self._known_stateful_processors:
                     present_ids.add(id(p))
             # Detect whether this slot differs from what's there now.
             if not aligned or existing[i] != slot:
@@ -4138,9 +4247,9 @@ class Scheduler:
             rebuilt.append(slot)
         if changed:
             bg.logits_processors = rebuilt
-        self._flush_grammar_tombstones(present=present_ids)
+        self._flush_stateful_tombstones(present=present_ids)
 
-    def _flush_grammar_tombstones(self, present: set[int]) -> None:
+    def _flush_stateful_tombstones(self, present: set[int]) -> None:
         """Forget tombstoned grammar identities no longer in any live slot.
 
         A tombstone (see ``_forget_uid_grammar``) is a grammar whose owning uid
@@ -4148,12 +4257,12 @@ class Scheduler:
         slot. Once the realign guard confirms it's absent from every live slot,
         it's safe to fully drop — releasing the id-reuse guard object too.
         """
-        for pid in list(self._grammar_tombstones):
+        for pid in list(self._stateful_tombstones):
             if pid in present:
                 continue
-            self._grammar_tombstones.discard(pid)
-            self._known_grammar_processors.discard(pid)
-            self._grammar_processor_objs.pop(pid, None)
+            self._stateful_tombstones.discard(pid)
+            self._known_stateful_processors.discard(pid)
+            self._stateful_processor_objs.pop(pid, None)
 
     def _process_pending_aborts(self) -> None:
         """Drain and process pending abort requests. Called from executor thread."""
@@ -4473,6 +4582,14 @@ class Scheduler:
                         frequency_context_size=4096,
                     )
                 )
+            # Generation-time thinking-token budget (force-close </think>).
+            # Appended LAST so its force-close mask (all but </think> -> -inf)
+            # has final say over any penalty/grammar bias in the same step;
+            # it is inert (returns logits unchanged) once thinking has ended,
+            # so a chained grammar processor owns the generation phase.
+            _rblp = getattr(request, "reasoning_budget_logits_processor", None)
+            if _rblp is not None:
+                request_processors.append(_rblp)
             request_logits_processors = (
                 [request_processors] if request_processors else None
             )
@@ -4573,23 +4690,12 @@ class Scheduler:
                 self.uid_to_request_id[uid] = request.request_id
                 request.batch_uid = uid
                 request.status = RequestStatus.RUNNING
-                # #558 PR-3: remember this request's FULL processor list
-                # (grammar + penalties) by uid as the authoritative state the
-                # per-tick realign guard rebuilds from — immune to mlx-lm's
-                # stale-entry desync. We track EVERY uid that carries any
-                # processor, not just grammar ones, so a penalty-only bystander's
-                # processors survive a length-desync rebuild (they'd otherwise be
-                # zeroed). Grammar-carrying uids also register the grammar's
-                # identity (so leaked slots can be scrubbed even after the uid
-                # finishes) and arm the guard.
-                if request_processors:
-                    self.uid_to_request_processors[uid] = list(request_processors)
-                if _glp is not None:
-                    self._uids_with_grammar.add(uid)
-                    self._known_grammar_processors.add(id(_glp))
-                    # Keep the object alive so its ``id()`` can't be reused by a
-                    # different object while it may still linger in a slot.
-                    self._grammar_processor_objs[id(_glp)] = _glp
+                # #558 PR-3 / #558 budget: record this request's FULL processor
+                # list (grammar + penalties + budget) by uid as the authoritative
+                # state the per-tick realign guard rebuilds from — immune to
+                # mlx-lm's stale-entry desync. Extracted into a production helper
+                # so the realign tests exercise the SAME registration (codex NIT).
+                self._register_uid_processors(uid, request, request_processors, _glp)
                 # Attach incremental decoder for multi-byte safe streaming
                 request._decoder = IncrementalDecoder(self._actual_tokenizer)
                 # Release the prompt cache reference now that BatchGenerator
@@ -5305,7 +5411,7 @@ class Scheduler:
                     # reconstruction state used when a grammar realign fires;
                     # arming on them would run an O(batch) rebuild every token on
                     # the plain decode hot path (codex #558-PR3).
-                    if self._uids_with_grammar or self._grammar_tombstones:
+                    if self._realign_guard_armed():
                         self._realign_grammar_logits_processors()
                     raw_next = self.batch_generator.next()
                     output.has_work = True
@@ -5340,7 +5446,7 @@ class Scheduler:
                 # scrubs ``bg.logits_processors`` to ``[]`` before forgetting the
                 # tombstones — closing the leaked-slot inheritance gap (codex
                 # #558-PR3 blocking).
-                if self._grammar_tombstones and not self.running:
+                if self._stateful_tombstones and not self.running:
                     self._realign_grammar_logits_processors()
 
                 # Success - break out of retry loop

--- a/vllm_mlx/utils/chat_template.py
+++ b/vllm_mlx/utils/chat_template.py
@@ -880,6 +880,7 @@ def apply_chat_template(
     tools: list[dict] | None = None,
     enable_thinking: bool | None = None,
     model_name: str = "",
+    add_generation_prompt: bool = True,
 ) -> str:
     """Apply a chat template to messages with consistent fallback behavior.
 
@@ -896,6 +897,12 @@ def apply_chat_template(
             - None: auto-detect (True except for coder models)
         model_name: Model name string, used for auto-detection of
             ``enable_thinking`` when set to None.
+        add_generation_prompt: Whether the template should append the
+            assistant generation prefix (default True — every serving path).
+            Passed False only by the reasoning-budget seed probe
+            (``routes/chat.py::_template_generation_prefix``), which renders the
+            SAME conversation with and without the generation prompt and takes
+            the delta to isolate the template-added prefix exactly.
 
     Returns:
         The formatted prompt string.  Falls back to a plain
@@ -978,7 +985,7 @@ def apply_chat_template(
 
     template_kwargs: dict = {
         "tokenize": False,
-        "add_generation_prompt": True,
+        "add_generation_prompt": add_generation_prompt,
         "enable_thinking": enable_thinking,
     }
     if tools:


### PR DESCRIPTION
## What

Enforce a per-request **thinking** budget **at decode time** for text-parser reasoning families. Once the model has spent `reasoning_max_tokens` inside its `<think>…</think>` span, the next-token logits are OVERRIDDEN so the only sampleable token is the single `</think>` id — the model is forced to close the block and commit to its answer.

This is the mechanism three mature engines converge on; we copy their shape rather than invent one, expressed as an mlx-lm logits processor so it drops into the existing per-step decode loop with no decode-loop changes:

- **vLLM** `ThinkingBudgetStateHolder` (fills the end-token logit to a dominating value)
- **SGLang** `ReasonerGrammarObject` (THINKING → GENERATION phase machine)
- **mlx-vlm** `ThinkingBudgetCriteria` (MLX-native, ~40 LOC)

## Why (single mechanism, not two)

Before this PR the only reasoning cap was a **post-hoc char-count trim** in the postprocessor: it let the model keep burning compute for the full unbounded think span and only relabelled/injected `</think>` in the OUTPUT the client sees. That is a band-aid, not a budget.

This PR makes the generation-time force-close **authoritative** for models whose `</think>` is a single token, and **suppresses** the post-hoc trim for those requests so the two never both run. The XOR decision has one definition — `_effective_posthoc_reasoning_cap(...)` — shared by the streaming and non-streaming postprocessor sites, so it can never drift between the two paths.

## Template-derived seeding (not conversation content)

A reasoning template takes one of two shapes: it either PREFILLS `<think>` into the rendered prompt (counting starts at the first generated token) or the model EMITS `<think>` as a generated token (counting waits for that opener). Which shape applies is derived **here in the route, from the template's own rendered generation prefix** (`rendered_prompt_opens_think` checks the rstripped SUFFIX of `build_prompt(...)`), never from raw conversation content — so a `<think>` a user typed earlier cannot mis-seed the budget. Either way the span-opening opener is free, so a `budget == 0` request closes to a well-formed `<think></think>`.

## Guards (copied from upstream)

- **Never force a reasoning-end that cannot occur** (vLLM #39130): a request whose thinking is not DEFINITIVELY on (`_effective_enable_thinking(...)` resolves to `True`, mirroring `apply_chat_template`) never builds a budget processor.
- **Identify `</think>` by TOKEN ID**, single-special-token only — reuses the exact `resolve_reasoning_sentinels` gate the tool-grammar path uses. A family whose `</think>` splits into ordinary bytes (channel-routed gpt-oss / harmony) opts out to the post-hoc cap; a tracked follow-up covers them.
- **Never inject `</think>` mid tool-call** (vLLM #44676): **tool** requests opt out; the post-hoc cap owns them until a follow-up wires SGLang's `think_excluded_tokens` so budget + tools can coexist.
- **Render failure keeps the budget enforced**: if `build_prompt` can't render (e.g. an MLLM engine), `build_budget_from_render` installs NO processor and RETAINS the post-hoc cap — never a non-seeded processor that would silently suppress the cap yet never fire.
- **Stop-sequence conflict opts out** (this round): a request that lists `</think>` (or an overlapping substring) in `stop` declines the generation-time budget (`reasoning_stop_conflicts`). Forcing `</think>` would trip that client stop AT the reasoning boundary and truncate reasoning before the answer; the model's reasoning end is a template-internal boundary, not a user stop. The post-hoc cap (which appends `</think>` to the FINAL text, not through the decode-time stop matcher) still enforces the budget — so budget + `stop=["</think>"]` behaves EXACTLY as pre-PR, no feature-introduced regression.

## Scheduler desync fix (found via live pilot)

A budget processor is a per-request logits processor with the **same positional-list desync exposure as a grammar**. Discovered on a live qwen3-0.6b pilot: a plain greedy request *preceding* a budget request left the budget **inert** — mlx-lm's positional `logits_processors` list dropped it when the no-processor request finished, so `</think>` was never forced and reasoning ran unbounded.

Fix mirrors the proven grammar path: a live budget uid now ALSO arms `_realign_grammar_logits_processors`, which rebuilds every slot from the authoritative `uid_to_request_processors` each tick, plus a tombstone so a finished budget uid stays armed for the scrubbing tick. Penalty-only uids still don't arm it (perf).

## Real-hardware proof (qwen3-0.6b-4bit)

| scenario | reasoning | answer |
|---|---|---|
| `budget=8`, no stop | ~20 chars (~8 tok) then FORCED `</think>` | complete answer (234 chars) ✅ |
| `budget=200`, no stop | 638 chars (finished under budget) | complete answer (269 chars) ✅ |
| **regression:** budget req after a prior no-budget req | bounded | ✅ (was unbounded before the desync fix) |
| `budget=200` + `stop=["</think>"]` | post-hoc cap (fix); == pre-PR | reasoning-only per user stop, no crash ✅ |
| `enable_thinking=false` + budget | — | never forces (guard) ✅ |
| no budget | unbounded | full answer ✅ |

Server log confirms the decode-time force: `reasoning budget spent (N think tokens) — forcing </think> (id=151668) at decode time`.

## Tests

- `test_reasoning_budget_generation.py` — 29 tests: processor phase-machine, force OVERRIDE dominates a prior `-inf` at `</think>`, 2-D batched shape preservation, repeated-opener-counts-toward-budget, template-derived seeding (incl. immunity to a user-typed marker), render-failure fallback, stop-conflict opt-out, `_effective_posthoc_reasoning_cap` selector.
- `test_grammar_scheduler_realign_558.py` — 24 tests: budget-uid desync repair, tombstone-until-scrubbed, leaked-budget-processor scrubbed from a foreign slot then flushed, arming by a budget uid alone.

No version bump (batched separately per release SOP).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

### Update (codex convergence, round 8)

Three further hardening items, all with new tests + a fresh real-hardware pilot:

- **Cloud-safe placement** — the budget is now built by `_build_reasoning_budget_processor(...)`, called only once the request is committed to LOCAL generation (past the cloud-offload decision). A cloud-routed request neither installs the processor nor has its post-hoc cap suppressed. The 95-line inline block became one call site + a documented helper.
- **Seeding from the TEMPLATE delta, not the whole prompt** — `_template_generation_prefix` re-renders with the last message's content replaced by an opaque sentinel and inspects only what the template appends *after* it. A `<think>` a user typed can no longer reach the seed decision even on a template that appends no assistant prefix (the previous whole-suffix check assumed one always exists). Immunity is now a property, not an assumption.
- **Out-of-range `</think>` guard** — if a tokenizer/model vocab mismatch put `</think>` beyond the logits width, the force step now DISABLES the budget (graceful unbounded reasoning) instead of masking to an all-`-inf` row.

Also relocated the whole block after `enforce_context_length_for_messages` so an oversized request is rejected before any budget render (perf, invalid requests).

**Tests:** `test_reasoning_budget_generation.py` now 40 (added template-delta seeding + immunity, route-builder gates, out-of-range guard); `test_grammar_scheduler_realign_558.py` 24. Both green.

**Real-hardware pilot (qwen3-0.6b-4bit), post-refactor:** budget=8 (explicit & default thinking) → ~8-token reasoning + complete answer; budget=200 no-stop → bounded + answer; budget=200 + `stop=["</think>"]` → post-hoc opt-out; user message ending in `<think>` → still correctly bounded (no mis-seed); no-budget → unbounded. 0 errors.


---

### Update (codex convergence, rounds 9–15)

Further hardening; every item has new tests + a fresh real-hardware pilot (now qwen3.5-4b-4bit). Supersedes stale details above (seeding is no longer a suffix heuristic; test counts updated).

**Exact template-derived seeding (R10).** The template's generation prefix is isolated by rendering the prompt TWICE — `build_prompt(add_generation_prompt=True)` minus `build_prompt(add_generation_prompt=False)` — and taking the string delta. That delta is precisely the text the chat template appends after the conversation, immune to any `<think>` in user content (it is present in both renders and cancels). Replaces the earlier sentinel/suffix heuristic. `add_generation_prompt` is now threaded through `apply_chat_template` and every engine `build_prompt`.

**Tri-state seed parse (R12).** The isolated delta is classified `open` (unclosed `<think>` → seeded, count from token 0), `emit` (no marker → model emits the opener, count after it), or `ambiguous` (closed pair / stray marker / no parser → DECLINE, keep the post-hoc cap).

**Weight-derived output-head width, no fallbacks (R11/R12/R14/R15).** A processor installs only when the `</think>` id is verified `< the model's real logits width`, read from the lm-head (untied) or tied-embedding **weight rows**. Because `logits = head(hidden)` ⇒ `logits.shape[-1] == head.weight.shape[0]`, the build-time bounds check and the decode-time force validate `</think>` against the **identical** width — so the decode-time out-of-range guard in `_force_distribution` is **provably unreachable** for any installed processor, sound for both the streaming and non-streaming paths (the decision is fixed at build time). Two fallbacks were rejected as unsound because each can exceed the true head width, admitting an out-of-range force id (suppressing the post-hoc cap) only for the decode guard to then disable the budget → silently unenforced: `len(tokenizer)` (**R14** — counts added specials, so `</think>` is always within it, a vacuous check) and declared `config.vocab_size` (**R15** — a padded/over-declared vocab can exceed the real head width, the exact mismatch that would trip the guard). When the head weight is not inspectable → DECLINE (keep the post-hoc cap; R11). Every current text reasoning family (qwen3 tied embed, gpt-oss/llama untied `lm_head`) resolves via the weight, verified on the qwen3.5-4b pilot.

**Full stop-overlap opt-out (R13).** `reasoning_stop_conflicts` now flags a `stop` that overlaps the forced `</think>` on ANY of the four ways two strings can collide at the `…R</think>A…` boundary: stop⊂marker, marker⊂stop, stop-suffix==marker-prefix, stop-prefix==marker-suffix. Previously only one cross-boundary side was caught, so `stop=["</think>A"]` / `["x</think>y"]` slipped through.

**start_id bounds symmetric with end_id (R13).** A non-seeded processor force-masks the OPEN id too; an out-of-range `start_id` can never match a sampled token, so the budget would silently never fire — the builder now bounds-checks `start_id` and declines when it is out of range.

**Mask released on span close (R14).** The cached full-vocab OVERRIDE row is dropped the moment `</think>` is observed (the processor is inert thereafter), instead of pinned through the whole answer — reclaims a few hundred KB per concurrent budgeted request.

**Log after the guard (R13).** The one-shot "forcing `</think>`" success log now emits only after the out-of-range check passes, so a disabled budget never prints a false success line followed by its disable warning.

**Deferred (documented).** codex flagged that `_template_generation_prefix` renders the prompt twice at admission, on top of the generation render. Deferred: the double render is admission-time only, on the minority of budgeted requests, and threading the `full` render into the generation path touches the hot generate loop for marginal gain. Tracked for a follow-up.

**Tests.** `test_reasoning_budget_generation.py` now 58 (added: two-render forwarding through `apply_chat_template` + batched engine, tri-state seed parse, weight-derived head width, decline-when-only-`len(tokenizer)` and decline-on-config-only, 4-condition stop-overlap both sides, start-id-out-of-range decline, mask-released-on-close, log-after-guard). `test_grammar_scheduler_realign_558.py` 25. Both green.

**Real-hardware re-verify (qwen3.5-4b-4bit).** `17*24` at `budget=16` → 26 reasoning tokens, forced `</think>`, answer `408`, `finish=stop`, no marker leak; `budget=400` → 170 reasoning tokens, `408`. A control (thinking on, no budget) uses 1568 reasoning tokens + full answer with `finish=stop`, confirming the budget only BOUNDS reasoning and never corrupts output. Reasoning stays at or below the budget at every level (16→26, 32→46, 256→317, 400→391 forced / 170 natural-close), and no case leaked `<think>`/`</think>` into visible content.

**CI note.** Local `full_unit` and `stress_e2e_bench` cannot run in this environment (disk full — the suite's Qwen3-Coder tokenizer and the 35 GB matrix models cannot be fetched); both are covered by GitHub CI, where `tests`, `test-apple-silicon`, `test-matrix (3.10/3.11/3.12)`, `type-check`, `lint`, and `validate` are all green on this commit.

**codex verdict: MERGE-SAFE (round 16)** — no blocking findings. Three nits surfaced; disposition: **took** the silent-`except` observability nit (a generation-prefix render failure now logs at debug with model context before falling back to the post-hoc cap). **Declined** two as low-value: the `embed_tokens.weight` tie-check nit (input embedding and output head share the vocab dimension `shape[0]` even when untied, so the *width* is robust regardless of tying — only an exotic asymmetric-vocab model would differ, and it is not a text reasoning LLM), and the forwarding-test-through-`build_prompt` nit (the end-to-end `add_generation_prompt` forwarding is already protected by the route-builder seed tests, which assert seeding from the two-render delta and would fail if the two renders collapsed to identical).
