### PR TITLE
feat(chat): improve MCP execution and terminal rendering

### DIFF
--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -64,7 +64,7 @@ jobs:
           # - test deps: mirror the test-matrix job so `full_unit` and
           #   `targeted_tests` see the same import surface they would
           #   if a contributor ran `make smoke` locally.
-          pip install pyyaml requests pip-audit ruff
+          pip install pyyaml requests pip-audit ruff rich mcp
           pip install pytest pytest-asyncio pytest-cov pydantic fastapi jsonschema httpx psutil transformers
 
       - name: Resolve PR number

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,7 @@ dependencies = [
     # benchmark.py image mode) touch PIL, and mlx-vlm requires it anyway.
     "pyyaml>=6.0",
     "requests>=2.28.0",
+    "rich>=13.8.0",
     "tabulate>=0.9.0",
     "psutil>=5.9.0",
     "fastapi>=0.100.0",

--- a/tests/test_chat_mcp.py
+++ b/tests/test_chat_mcp.py
@@ -13,6 +13,7 @@ import pytest
 
 from vllm_mlx.chat_mcp import (
     ChatMCPRuntime,
+    ChatToolEvent,
     _quiet_optional_component_warnings,
     _server_parameters,
 )
@@ -23,12 +24,17 @@ class _FakeResult:
     def __init__(self, name: str, arguments: dict):
         self.name = name
         self.arguments = arguments
+        self.isError = bool(arguments.get("is_error"))
 
     def model_dump(self, **_kwargs):
         return {
             "content": [{"type": "text", "text": f"{self.name}:{self.arguments}"}],
-            "isError": False,
+            "isError": self.isError,
         }
+
+
+class _LaneAbort(BaseException):
+    pass
 
 
 class _FakeSessionGroup:
@@ -38,6 +44,10 @@ class _FakeSessionGroup:
     call_started = threading.Event()
     call_cancelled = threading.Event()
     connect_thread_names: list[str] = []
+    active_calls = 0
+    max_active_calls = 0
+    active_calls_by_server: dict[str, int] = {}
+    max_active_calls_by_server: dict[str, int] = {}
 
     def __init__(self, component_name_hook):
         self._name_hook = component_name_hook
@@ -84,15 +94,34 @@ class _FakeSessionGroup:
 
     async def call_tool(self, name, arguments):
         self.calls.append((name, arguments))
-        if arguments.get("hang"):
-            self.call_started.set()
-            try:
-                await asyncio.Event().wait()
-            finally:
-                self.call_cancelled.set()
-        if arguments.get("raise"):
-            raise RuntimeError("tool exploded")
-        return _FakeResult(name, arguments)
+        server_name = name.split("__", 1)[0]
+        type(self).active_calls += 1
+        type(self).active_calls_by_server[server_name] = (
+            type(self).active_calls_by_server.get(server_name, 0) + 1
+        )
+        type(self).max_active_calls = max(
+            type(self).max_active_calls,
+            type(self).active_calls,
+        )
+        type(self).max_active_calls_by_server[server_name] = max(
+            type(self).max_active_calls_by_server.get(server_name, 0),
+            type(self).active_calls_by_server[server_name],
+        )
+        try:
+            if arguments.get("delay"):
+                await asyncio.sleep(arguments["delay"])
+            if arguments.get("hang"):
+                self.call_started.set()
+                try:
+                    await asyncio.Event().wait()
+                finally:
+                    self.call_cancelled.set()
+            if arguments.get("raise"):
+                raise RuntimeError("tool exploded")
+            return _FakeResult(name, arguments)
+        finally:
+            type(self).active_calls -= 1
+            type(self).active_calls_by_server[server_name] -= 1
 
 
 @pytest.fixture(autouse=True)
@@ -105,6 +134,10 @@ def _fake_sdk_group(monkeypatch):
     _FakeSessionGroup.call_started = threading.Event()
     _FakeSessionGroup.call_cancelled = threading.Event()
     _FakeSessionGroup.connect_thread_names = []
+    _FakeSessionGroup.active_calls = 0
+    _FakeSessionGroup.max_active_calls = 0
+    _FakeSessionGroup.active_calls_by_server = {}
+    _FakeSessionGroup.max_active_calls_by_server = {}
     monkeypatch.setattr(
         mcp.client.session_group,
         "ClientSessionGroup",
@@ -158,7 +191,7 @@ def test_runtime_uses_sdk_groups_for_multiple_servers(tmp_path):
             "call-a",
             "call-b",
         ]
-        assert _FakeSessionGroup.calls == [
+        assert sorted(_FakeSessionGroup.calls) == [
             ("alpha__lookup", {"value": "A"}),
             ("beta__lookup", {"value": "B"}),
         ]
@@ -170,6 +203,187 @@ def test_runtime_uses_sdk_groups_for_multiple_servers(tmp_path):
     runtime.close()  # idempotent
     with pytest.raises(RuntimeError, match="closed"):
         runtime.execute_tool_calls([])
+
+
+def test_runtime_parallelizes_servers_but_serializes_each_server(tmp_path):
+    path = _write_config(
+        tmp_path,
+        {
+            "alpha": {"command": "python3", "args": ["alpha", "lookup"]},
+            "beta": {"command": "python3", "args": ["beta", "lookup"]},
+        },
+    )
+    runtime = ChatMCPRuntime(str(path))
+    try:
+        messages = runtime.execute_tool_calls(
+            [
+                {
+                    "id": "alpha-first",
+                    "function": {
+                        "name": "alpha__lookup",
+                        "arguments": {"value": "first", "delay": 0.02},
+                    },
+                },
+                {
+                    "id": "beta",
+                    "function": {
+                        "name": "beta__lookup",
+                        "arguments": {"value": "beta", "delay": 0.02},
+                    },
+                },
+                {
+                    "id": "alpha-second",
+                    "function": {
+                        "name": "alpha__lookup",
+                        "arguments": {"value": "second", "delay": 0.02},
+                    },
+                },
+            ]
+        )
+    finally:
+        runtime.close()
+
+    assert _FakeSessionGroup.max_active_calls == 2
+    assert _FakeSessionGroup.max_active_calls_by_server == {
+        "alpha": 1,
+        "beta": 1,
+    }
+    assert [message["tool_call_id"] for message in messages] == [
+        "alpha-first",
+        "beta",
+        "alpha-second",
+    ]
+    alpha_calls = [
+        arguments["value"]
+        for name, arguments in _FakeSessionGroup.calls
+        if name == "alpha__lookup"
+    ]
+    assert alpha_calls == ["first", "second"]
+
+
+@pytest.mark.asyncio
+async def test_runtime_cancels_sibling_lanes_when_one_aborts():
+    runtime = object.__new__(ChatMCPRuntime)
+    runtime._tools_by_name = {
+        "alpha__lookup": SimpleNamespace(server_name="alpha"),
+        "beta__lookup": SimpleNamespace(server_name="beta"),
+    }
+    first_started = asyncio.Event()
+    first_cancelled = asyncio.Event()
+
+    async def _execute_one(position, _tool_call, _on_event):
+        if position == 0:
+            first_started.set()
+            try:
+                await asyncio.Event().wait()
+            finally:
+                first_cancelled.set()
+        await first_started.wait()
+        raise _LaneAbort
+
+    runtime._execute_one = _execute_one
+    calls = [
+        {"function": {"name": "alpha__lookup"}},
+        {"function": {"name": "beta__lookup"}},
+    ]
+
+    with pytest.raises(_LaneAbort):
+        await runtime._execute(calls, None)
+
+    assert first_cancelled.is_set()
+
+
+def test_runtime_emits_tool_start_and_finish_events(tmp_path):
+    path = _write_config(
+        tmp_path,
+        {"alpha": {"command": "python3", "args": ["alpha", "lookup"]}},
+    )
+    events: list[ChatToolEvent] = []
+    runtime = ChatMCPRuntime(str(path))
+    try:
+        [message] = runtime.execute_tool_calls(
+            [
+                {
+                    "id": "call-a",
+                    "function": {
+                        "name": "alpha__lookup",
+                        "arguments": '{"value":"A"}',
+                    },
+                }
+            ],
+            on_event=events.append,
+        )
+    finally:
+        runtime.close()
+
+    assert [(event.phase, event.call_id, event.name) for event in events] == [
+        ("start", "call-a", "alpha__lookup"),
+        ("finish", "call-a", "alpha__lookup"),
+    ]
+    assert events[0].elapsed_seconds is None
+    assert events[0].message is None
+    assert events[1].elapsed_seconds is not None
+    assert events[1].elapsed_seconds >= 0
+    assert events[1].is_error is False
+    assert events[1].message == message
+
+
+def test_runtime_finish_event_marks_mcp_errors(tmp_path):
+    path = _write_config(
+        tmp_path,
+        {"alpha": {"command": "python3", "args": ["alpha", "lookup"]}},
+    )
+    events: list[ChatToolEvent] = []
+    runtime = ChatMCPRuntime(str(path))
+    try:
+        [message] = runtime.execute_tool_calls(
+            [
+                {
+                    "id": "call-a",
+                    "function": {
+                        "name": "alpha__lookup",
+                        "arguments": '{"value":"A","is_error":true}',
+                    },
+                }
+            ],
+            on_event=events.append,
+        )
+    finally:
+        runtime.close()
+
+    assert events[-1].phase == "finish"
+    assert events[-1].is_error is True
+    assert events[-1].message == message
+
+
+def test_runtime_tool_event_callback_failure_does_not_fail_tool(tmp_path, caplog):
+    path = _write_config(
+        tmp_path,
+        {"alpha": {"command": "python3", "args": ["alpha", "lookup"]}},
+    )
+
+    def _fail(_event):
+        raise RuntimeError("renderer failed")
+
+    runtime = ChatMCPRuntime(str(path))
+    try:
+        [message] = runtime.execute_tool_calls(
+            [
+                {
+                    "id": "call-a",
+                    "function": {
+                        "name": "alpha__lookup",
+                        "arguments": '{"value":"A"}',
+                    },
+                }
+            ],
+            on_event=_fail,
+        )
+    finally:
+        runtime.close()
+
+    assert message["tool_call_id"] == "call-a"
+    assert "renderer failed" in caplog.text
 
 
 def test_runtime_keeps_healthy_server_when_another_fails(tmp_path):

--- a/tests/test_chat_render.py
+++ b/tests/test_chat_render.py
@@ -1,0 +1,203 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Terminal rendering tests for ``rapid-mlx chat``."""
+
+from __future__ import annotations
+
+import io
+import os
+import re
+from unittest.mock import patch
+
+from rich.cells import cell_len
+
+from vllm_mlx.chat_render import (
+    StreamingMarkdownRenderer,
+    render_markdown,
+    terminal_safe_text,
+)
+
+
+class _Tty(io.StringIO):
+    def isatty(self):
+        return True
+
+
+def _visible(text: str) -> str:
+    text = re.sub(r"\x1b\[[0-?]*[ -/]*[@-~]", "", text)
+    return text.replace("\r", "")
+
+
+def test_render_markdown_formats_common_agent_output():
+    output = _Tty()
+    markdown = """\
+# Result
+
+Use **care** with `rm`.
+
+- first item is intentionally long enough to wrap instead of disappearing at the terminal edge WRAP-END
+- second
+
+```python
+print("hello")
+```
+
+| Name | Value |
+| --- | --- |
+| answer | 42 |
+"""
+
+    with patch.dict(os.environ, {"TERM": "xterm-256color"}, clear=False):
+        os.environ.pop("NO_COLOR", None)
+        os.environ.pop("CI", None)
+        render_markdown(markdown, stream=output)
+
+    rendered = output.getvalue()
+    visible = _visible(rendered)
+    assert "\x1b[" in rendered
+    assert visible.splitlines()[0].startswith("Result")
+    assert "# Result" not in visible
+    assert "**care**" not in visible
+    assert "`rm`" not in visible
+    assert "Result" in visible
+    assert "care" in visible
+    assert "rm" in visible
+    assert "first" in visible and "second" in visible
+    assert "WRAP-END" in visible
+    assert 'print("hello")' in visible
+    assert "answer" in visible and "42" in visible
+
+
+def test_streaming_renderer_keeps_plain_output_for_pipes():
+    output = io.StringIO()
+    renderer = StreamingMarkdownRenderer(output)
+
+    renderer.write("A **bold")
+    renderer.write("** answer.")
+    renderer.finish()
+
+    assert output.getvalue() == "A **bold** answer."
+
+
+def test_streaming_renderer_renders_complete_markdown_document():
+    output = _Tty()
+    with patch.dict(os.environ, {"TERM": "xterm-256color"}, clear=False):
+        os.environ.pop("NO_COLOR", None)
+        os.environ.pop("CI", None)
+        renderer = StreamingMarkdownRenderer(output)
+        renderer.write("# Res")
+        assert "Res" in _visible(output.getvalue())
+        renderer.write("ult\n\nUse **care**")
+        assert "Use **care**" in _visible(output.getvalue())
+        renderer.write(" and `code`.")
+        renderer.finish()
+
+    rendered = output.getvalue().rsplit("\x1b[2K", 1)[-1]
+    visible = _visible(rendered)
+    assert "Result" in visible
+    assert "care" in visible
+    assert "code" in visible
+    assert "# Result" not in visible
+    assert "**care**" not in visible
+
+
+def test_streaming_renderer_flushes_partial_block_after_error():
+    output = _Tty()
+    with patch.dict(os.environ, {"TERM": "xterm-256color"}, clear=False):
+        os.environ.pop("NO_COLOR", None)
+        os.environ.pop("CI", None)
+        try:
+            with StreamingMarkdownRenderer(output) as renderer:
+                renderer.write("partial **answer**")
+                raise RuntimeError("stream failed")
+        except RuntimeError as exc:
+            assert str(exc) == "stream failed"
+
+    final_render = output.getvalue().rsplit("\x1b[2K", 1)[-1]
+    visible = _visible(final_render)
+    assert "partial" in visible
+    assert "answer" in visible
+    assert "**answer**" not in visible
+
+
+def test_streaming_preview_respects_terminal_cell_width():
+    output = _Tty()
+    with patch.dict(
+        os.environ,
+        {"TERM": "xterm-256color", "COLUMNS": "8"},
+        clear=False,
+    ):
+        os.environ.pop("NO_COLOR", None)
+        os.environ.pop("CI", None)
+        renderer = StreamingMarkdownRenderer(output)
+        renderer.write("prefix 你好世界")
+
+    preview = output.getvalue().rsplit("\x1b[2m", 1)[-1].split("\x1b[0m", 1)[0]
+    assert cell_len(preview) <= 7
+
+
+def test_terminal_safe_text_removes_control_sequences():
+    text = "tool\x1b]52;c;payload\x07\r\nname"
+
+    assert terminal_safe_text(text) == "tool]52;c;payloadname"
+
+
+def test_render_markdown_preserves_unfenced_html():
+    output = _Tty()
+    with patch.dict(os.environ, {"TERM": "xterm-256color"}, clear=False):
+        os.environ.pop("NO_COLOR", None)
+        os.environ.pop("CI", None)
+        render_markdown("<div>hello</div>", stream=output)
+
+    visible = _visible(output.getvalue())
+    assert "<div>hello</div>" in visible
+
+
+def test_streaming_renderer_preserves_cross_block_markdown_context():
+    output = _Tty()
+    with patch.dict(os.environ, {"TERM": "xterm-256color"}, clear=False):
+        os.environ.pop("NO_COLOR", None)
+        os.environ.pop("CI", None)
+        renderer = StreamingMarkdownRenderer(output)
+        renderer.write("[Rapid][project]\n\n")
+        assert "[Rapid][project]" in _visible(output.getvalue())
+        renderer.write("[project]: https://rapidmlx.com\n")
+        renderer.finish()
+
+    visible = _visible(output.getvalue().rsplit("\x1b[2K", 1)[-1])
+    assert "Rapid" in visible
+    assert "[Rapid][project]" not in visible
+
+
+def test_no_color_disables_markdown_rendering():
+    output = _Tty()
+    with patch.dict(os.environ, {"NO_COLOR": "1"}, clear=True):
+        render_markdown("**plain**", stream=output)
+
+    assert output.getvalue() == "**plain**"
+
+
+def test_dumb_terminal_keeps_incremental_plain_output():
+    output = _Tty()
+    with patch.dict(os.environ, {"TERM": "dumb"}, clear=True):
+        renderer = StreamingMarkdownRenderer(output)
+        renderer.write("first ")
+        assert output.getvalue() == "first "
+        renderer.write("**second**")
+        renderer.finish()
+
+    assert output.getvalue() == "first **second**"
+
+
+def test_ci_pseudo_terminal_keeps_plain_output():
+    output = _Tty()
+    with patch.dict(
+        os.environ,
+        {"CI": "true", "TERM": "xterm-256color"},
+        clear=False,
+    ):
+        os.environ.pop("NO_COLOR", None)
+        renderer = StreamingMarkdownRenderer(output)
+        renderer.write("A **captured** answer.")
+        renderer.finish()
+
+    assert output.getvalue() == "A **captured** answer."

--- a/tests/test_cli_chat.py
+++ b/tests/test_cli_chat.py
@@ -158,15 +158,33 @@ class _FakeMCPRuntime:
     def __init__(self):
         self.calls = []
 
-    def execute_tool_calls(self, calls):
+    def execute_tool_calls(self, calls, on_event=None):
         self.calls.append(calls)
-        return [
+        messages = [
             {
                 "role": "tool",
-                "tool_call_id": calls[0]["id"],
+                "tool_call_id": call["id"],
                 "content": '{"content":"hello"}',
             }
+            for call in calls
         ]
+        if on_event is not None:
+            from vllm_mlx.chat_mcp import ChatToolEvent
+
+            for call, message in zip(calls, messages, strict=True):
+                name = call["function"]["name"]
+                on_event(ChatToolEvent("start", call["id"], name))
+                on_event(
+                    ChatToolEvent(
+                        "finish",
+                        call["id"],
+                        name,
+                        elapsed_seconds=0.01,
+                        is_error=False,
+                        message=message,
+                    )
+                )
+        return messages
 
 
 def _json_response(body, status_code=200):
@@ -225,7 +243,7 @@ def test_complete_chat_with_mcp_runs_standard_tool_loop(monkeypatch):
         ]
     )
     payloads = []
-    tool_progress = []
+    tool_events = []
 
     def _post(_url, json, timeout):
         assert timeout == 10
@@ -246,7 +264,7 @@ def test_complete_chat_with_mcp_runs_standard_tool_loop(monkeypatch):
         },
         runtime,
         timeout_s=10,
-        on_tool_call=tool_progress.append,
+        on_tool_event=tool_events.append,
     )
 
     assert answer == "The file says hello."
@@ -265,7 +283,10 @@ def test_complete_chat_with_mcp_runs_standard_tool_loop(monkeypatch):
         "tool_call_id": "call-1",
         "content": '{"content":"hello"}',
     }
-    assert tool_progress == ["files__read"]
+    assert [(event.phase, event.name) for event in tool_events] == [
+        ("start", "files__read"),
+        ("finish", "files__read"),
+    ]
 
 
 def test_complete_chat_with_mcp_preserves_reasoning_and_normalizes_calls(monkeypatch):
@@ -425,10 +446,26 @@ def test_complete_chat_with_mcp_preserves_partial_multi_call_results(monkeypatch
     monkeypatch.setattr("requests.post", lambda *_args, **_kwargs: response)
 
     class _Runtime(_FakeMCPRuntime):
-        def execute_tool_calls(self, calls):
-            if calls[0]["id"] == "interrupted":
-                raise KeyboardInterrupt
-            return super().execute_tool_calls(calls)
+        def execute_tool_calls(self, calls, on_event=None):
+            from vllm_mlx.chat_mcp import ChatToolEvent
+
+            completed = {
+                "role": "tool",
+                "tool_call_id": calls[0]["id"],
+                "content": '{"content":"hello"}',
+            }
+            if on_event is not None:
+                on_event(
+                    ChatToolEvent(
+                        "finish",
+                        calls[0]["id"],
+                        calls[0]["function"]["name"],
+                        elapsed_seconds=0.01,
+                        is_error=False,
+                        message=completed,
+                    )
+                )
+            raise KeyboardInterrupt
 
     messages = [{"role": "user", "content": "run both"}]
     with pytest.raises(KeyboardInterrupt):
@@ -794,9 +831,21 @@ def test_chat_command_owns_mcp_runtime_without_configuring_serve(monkeypatch, ca
         def close(self):
             self.closed = True
 
-    def _complete(base_url, payload, runtime, timeout_s, on_tool_call):
+    def _complete(base_url, payload, runtime, timeout_s, on_tool_event):
+        from vllm_mlx.chat_mcp import ChatToolEvent
+
         loop_payloads.append((base_url, deepcopy(payload), runtime, timeout_s))
-        on_tool_call("files__read")
+        on_tool_event(ChatToolEvent("start", "call-1", "files__read"))
+        on_tool_event(ChatToolEvent("start", "call-evil", "\x1b]52;c;payload\x07"))
+        on_tool_event(
+            ChatToolEvent(
+                "finish",
+                "call-1",
+                "files__read",
+                elapsed_seconds=0.25,
+                is_error=False,
+            )
+        )
         return "done", {"completion_tokens": 1, "finish_reason": "stop"}
 
     monkeypatch.setattr("vllm_mlx.chat_mcp.ChatMCPRuntime", _Runtime)
@@ -816,6 +865,9 @@ def test_chat_command_owns_mcp_runtime_without_configuring_serve(monkeypatch, ca
     ]
     output = capsys.readouterr().out
     assert "using files.read…" in output
+    assert "using ]52;c;payload…" in output
+    assert "\x1b" not in output
+    assert "✓ files.read (0.25s)" in output
     assert "done" in output
 
     assert created[0].closed is True
@@ -1022,9 +1074,7 @@ def test_chat_command_speed_line_uses_server_token_count(monkeypatch, capsys):
 
 
 def test_stream_chat_response_renders_atx_headings(monkeypatch):
-    """ATX headings (`# h1`..`###### h6`) at line start get a colored
-    style applied across the heading line. We simulate a TTY so the
-    state machine path runs."""
+    """TTY output renders Markdown headings and inline code semantically."""
 
     class _Tty(io.StringIO):
         def isatty(self):
@@ -1041,25 +1091,63 @@ def test_stream_chat_response_renders_atx_headings(monkeypatch):
     with (
         _fake_server(canned) as (port, _payloads),
         patch.object(sys, "stdout", out_buf),
-        patch.dict("os.environ", {}, clear=False),
+        patch.dict("os.environ", {"TERM": "xterm-256color"}, clear=False),
     ):
         # Make sure NO_COLOR isn't set in the test env.
         os = __import__("os")
         os.environ.pop("NO_COLOR", None)
+        os.environ.pop("CI", None)
         full = cli._stream_chat_response(
             f"http://127.0.0.1:{port}",
             {"model": "x", "messages": [], "stream": True},
             timeout_s=10,
         )
     rendered = out_buf.getvalue()
+    final_render = rendered.rsplit("\x1b[2K", 1)[-1]
     # Plain text content survived intact.
     assert full == "# Big\n## Sub\nBody line with `code`.\n### Smaller\nTail.\n"
-    # Heading lines are wrapped in ANSI escapes.
-    assert "\x1b[" in rendered, "expected ANSI escapes on a TTY render"
-    assert "# Big" in rendered and "## Sub" in rendered
-    # Plain body line did not pick up a heading style — only inline `code`
-    # got the cyan single-backtick wrap.
-    assert "Body line with " in rendered
+    assert "# Big" in rendered  # Incremental preview before the final render.
+    # Rich terminal output styles content and removes Markdown punctuation.
+    assert "\x1b[" in final_render, "expected ANSI escapes on a TTY render"
+    assert "Big" in final_render and "Sub" in final_render
+    assert "# Big" not in final_render and "## Sub" not in final_render
+    assert "`code`" not in final_render
+    assert "Body line with " in final_render and "code" in final_render
+
+
+@pytest.mark.parametrize(
+    "environment",
+    [
+        {"CI": "true", "TERM": "xterm-256color"},
+        {"TERM": "dumb"},
+    ],
+)
+def test_stream_chat_response_reasoning_is_plain_on_noninteractive_tty(environment):
+    """CI and dumb pseudo-TTYs must not receive direct ANSI reasoning chrome."""
+
+    class _Tty(io.StringIO):
+        def isatty(self):
+            return True
+
+    canned = [
+        {"choices": [{"delta": {"reasoning_content": "working"}}]},
+        _delta("answer"),
+    ]
+    out_buf = _Tty()
+    with (
+        _fake_server(canned) as (port, _payloads),
+        patch.object(sys, "stdout", out_buf),
+        patch.dict("os.environ", environment, clear=True),
+    ):
+        full = cli._stream_chat_response(
+            f"http://127.0.0.1:{port}",
+            {"model": "x", "messages": [], "stream": True},
+            timeout_s=10,
+        )
+
+    assert full == "answer"
+    assert out_buf.getvalue() == "[thinking] working\nanswer"
+    assert "\x1b" not in out_buf.getvalue()
 
 
 def test_chat_command_heredoc_does_not_trigger_slash_dispatch(monkeypatch):

--- a/vllm_mlx/chat_mcp.py
+++ b/vllm_mlx/chat_mcp.py
@@ -15,9 +15,12 @@ import logging
 import re
 import sys
 import threading
+import time
+from collections.abc import Callable
 from contextlib import AsyncExitStack, contextmanager
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 from anyio.abc import TaskStatus
 from anyio.from_thread import start_blocking_portal
@@ -34,6 +37,18 @@ _OPTIONAL_COMPONENT_WARNINGS = {
     "Could not fetch prompts: Method not found",
     "Could not fetch resources: Method not found",
 }
+
+
+@dataclass(frozen=True)
+class ChatToolEvent:
+    """One lifecycle update for a tool call owned by ``rapid-mlx chat``."""
+
+    phase: Literal["start", "finish"]
+    call_id: str
+    name: str
+    elapsed_seconds: float | None = None
+    is_error: bool | None = None
+    message: dict[str, Any] | None = None
 
 
 class _OptionalComponentWarningFilter(logging.Filter):
@@ -122,8 +137,9 @@ class ChatMCPRuntime:
     def execute_tool_calls(
         self,
         tool_calls: list[dict[str, Any]],
+        on_event: Callable[[ChatToolEvent], None] | None = None,
     ) -> list[dict[str, Any]]:
-        """Execute calls sequentially and return OpenAI ``tool`` messages."""
+        """Execute independent server lanes and return ordered tool messages."""
 
         done = threading.Event()
         with self._state_lock:
@@ -133,6 +149,7 @@ class ChatMCPRuntime:
                 self._execute_with_done,
                 tool_calls,
                 done,
+                on_event,
             )
             self._active_future = future
             self._active_done = done
@@ -269,90 +286,160 @@ class ChatMCPRuntime:
         self,
         tool_calls: list[dict[str, Any]],
         done: threading.Event,
+        on_event: Callable[[ChatToolEvent], None] | None,
     ) -> list[dict[str, Any]]:
         try:
-            return await self._execute(tool_calls)
+            return await self._execute(tool_calls, on_event)
         finally:
             done.set()
 
     async def _execute(
         self,
         tool_calls: list[dict[str, Any]],
+        on_event: Callable[[ChatToolEvent], None] | None,
     ) -> list[dict[str, Any]]:
-        messages: list[dict[str, Any]] = []
+        messages: list[dict[str, Any] | None] = [None] * len(tool_calls)
+        lanes: dict[str, list[tuple[int, dict[str, Any]]]] = {}
         for position, tool_call in enumerate(tool_calls):
-            call_id = str(tool_call.get("id") or f"call_{position}")
             function = tool_call.get("function") or {}
-            full_name = str(function.get("name") or "")
-            tool = self._tools_by_name.get(full_name)
-            arguments: dict[str, Any] = {}
+            tool = self._tools_by_name.get(str(function.get("name") or ""))
+            lane = (
+                f"server:{tool.server_name}"
+                if tool is not None
+                else f"invalid:{position}"
+            )
+            lanes.setdefault(lane, []).append((position, tool_call))
 
+        async def _run_lane(
+            calls: list[tuple[int, dict[str, Any]]],
+        ) -> None:
+            for position, tool_call in calls:
+                messages[position] = await self._execute_one(
+                    position,
+                    tool_call,
+                    on_event,
+                )
+
+        tasks = [asyncio.create_task(_run_lane(calls)) for calls in lanes.values()]
+        try:
+            await asyncio.gather(*tasks)
+        except BaseException:
+            for task in tasks:
+                task.cancel()
+            await asyncio.gather(*tasks, return_exceptions=True)
+            raise
+        return [message for message in messages if message is not None]
+
+    async def _execute_one(
+        self,
+        position: int,
+        tool_call: dict[str, Any],
+        on_event: Callable[[ChatToolEvent], None] | None,
+    ) -> dict[str, Any]:
+        call_id = str(tool_call.get("id") or f"call_{position}")
+        function = tool_call.get("function") or {}
+        full_name = str(function.get("name") or "")
+        tool = self._tools_by_name.get(full_name)
+        arguments: dict[str, Any] = {}
+        started = time.monotonic()
+        _emit_tool_event(
+            on_event,
+            ChatToolEvent("start", call_id, full_name),
+        )
+        content: str | None = None
+        message: dict[str, Any] | None = None
+        is_error = True
+
+        try:
+            raw_arguments = function.get("arguments", "{}")
+            parsed_arguments = (
+                json.loads(raw_arguments)
+                if isinstance(raw_arguments, str)
+                else raw_arguments
+            )
+            if not isinstance(parsed_arguments, dict):
+                raise ValueError("tool arguments must be a JSON object")
+            arguments = parsed_arguments
+            if tool is None:
+                raise ValueError(f"Unknown MCP tool: {full_name or '<empty>'}")
+
+            validate_tool_arguments(tool, arguments, strict=True)
+            self._sandbox.validate_tool_execution(
+                tool.name,
+                tool.server_name,
+                arguments,
+            )
+
+            group = self._groups[tool.server_name]
+            timeout = self._server_timeout(tool.server_name)
             try:
-                raw_arguments = function.get("arguments", "{}")
-                parsed_arguments = (
-                    json.loads(raw_arguments)
-                    if isinstance(raw_arguments, str)
-                    else raw_arguments
+                result = await asyncio.wait_for(
+                    group.call_tool(full_name, arguments),
+                    timeout=timeout,
                 )
-                if not isinstance(parsed_arguments, dict):
-                    raise ValueError("tool arguments must be a JSON object")
-                arguments = parsed_arguments
-                if tool is None:
-                    raise ValueError(f"Unknown MCP tool: {full_name or '<empty>'}")
+            except (TimeoutError, asyncio.TimeoutError) as exc:
+                raise RuntimeError(
+                    f"MCP tool {full_name!r} timed out after {timeout:g} seconds"
+                ) from exc
 
-                validate_tool_arguments(tool, arguments, strict=True)
-                self._sandbox.validate_tool_execution(
-                    tool.name,
-                    tool.server_name,
-                    arguments,
-                )
-
-                group = self._groups[tool.server_name]
-                timeout = self._server_timeout(tool.server_name)
-                try:
-                    result = await asyncio.wait_for(
-                        group.call_tool(full_name, arguments),
-                        timeout=timeout,
-                    )
-                except (TimeoutError, asyncio.TimeoutError) as exc:
-                    raise RuntimeError(
-                        f"MCP tool {full_name!r} timed out after {timeout:g} seconds"
-                    ) from exc
-
-                content = json.dumps(
-                    result.model_dump(mode="json", by_alias=True, exclude_none=True),
-                    ensure_ascii=False,
-                )
-                is_error = bool(getattr(result, "isError", False))
+            content = json.dumps(
+                result.model_dump(mode="json", by_alias=True, exclude_none=True),
+                ensure_ascii=False,
+            )
+            is_error = bool(getattr(result, "isError", False))
+            self._sandbox.record_execution(
+                tool.name,
+                tool.server_name,
+                arguments,
+                success=not is_error,
+                error_message=content if is_error else None,
+            )
+        except Exception as exc:
+            content = json.dumps({"error": str(exc)}, ensure_ascii=False)
+            if tool is not None:
                 self._sandbox.record_execution(
                     tool.name,
                     tool.server_name,
                     arguments,
-                    success=not is_error,
-                    error_message=content if is_error else None,
+                    success=False,
+                    error_message=str(exc),
                 )
-            except Exception as exc:
-                content = json.dumps({"error": str(exc)}, ensure_ascii=False)
-                if tool is not None:
-                    self._sandbox.record_execution(
-                        tool.name,
-                        tool.server_name,
-                        arguments,
-                        success=False,
-                        error_message=str(exc),
-                    )
-
-            messages.append(
-                {
+        finally:
+            if content is not None:
+                message = {
                     "role": "tool",
                     "tool_call_id": call_id,
                     "content": content,
                 }
+            _emit_tool_event(
+                on_event,
+                ChatToolEvent(
+                    "finish",
+                    call_id,
+                    full_name,
+                    elapsed_seconds=time.monotonic() - started,
+                    is_error=is_error,
+                    message=message,
+                ),
             )
-        return messages
+
+        assert message is not None
+        return message
 
     def _server_timeout(self, server_name: str) -> float:
         return self._config.servers[server_name].timeout
+
+
+def _emit_tool_event(
+    on_event: Callable[[ChatToolEvent], None] | None,
+    event: ChatToolEvent,
+) -> None:
+    if on_event is None:
+        return
+    try:
+        on_event(event)
+    except Exception:
+        logging.getLogger(__name__).exception("MCP tool event callback failed")
 
 
 async def _close_group(

--- a/vllm_mlx/chat_render.py
+++ b/vllm_mlx/chat_render.py
@@ -1,0 +1,164 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Markdown rendering for the built-in chat terminal."""
+
+from __future__ import annotations
+
+import os
+import sys
+from typing import TextIO
+
+from markdown_it import MarkdownIt
+from rich.cells import get_character_cell_size
+from rich.console import Console
+from rich.markdown import Heading, Markdown
+from rich.theme import Theme
+
+_CHAT_THEME = Theme(
+    {
+        "markdown.h1": "bold cyan",
+        "markdown.h1.border": "cyan",
+        "markdown.h2": "bold magenta",
+        "markdown.h3": "bold cyan",
+        "markdown.h4": "bold",
+        "markdown.h5": "italic",
+        "markdown.h6": "dim",
+        "markdown.strong": "bold bright_white",
+        "markdown.code": "bold yellow",
+        "markdown.block_quote": "italic magenta",
+        "markdown.list": "cyan",
+        "markdown.item.bullet": "bold cyan",
+        "markdown.item.number": "bold cyan",
+        "markdown.link": "underline bright_blue",
+        "markdown.link_url": "underline bright_blue",
+        "markdown.table.border": "cyan",
+        "markdown.table.header": "bold cyan",
+    }
+)
+
+
+class _LeftHeading(Heading):
+    """Use agent-style left-aligned headings, including level one."""
+
+    LEVEL_ALIGN = {f"h{level}": "left" for level in range(1, 7)}
+
+
+class _ChatMarkdown(Markdown):
+    elements = {**Markdown.elements, "heading_open": _LeftHeading}
+
+
+def _cell_suffix(text: str, width: int) -> str:
+    """Return the longest suffix that fits in *width* terminal cells."""
+
+    cells = 0
+    suffix: list[str] = []
+    for char in reversed(text):
+        char_cells = get_character_cell_size(char)
+        if cells + char_cells > width:
+            break
+        cells += char_cells
+        suffix.append(char)
+    return "".join(reversed(suffix))
+
+
+def supports_rich_output(stream: TextIO) -> bool:
+    """Whether *stream* can safely use interactive terminal formatting."""
+
+    if (
+        not bool(getattr(stream, "isatty", lambda: False)())
+        or "NO_COLOR" in os.environ
+        or "CI" in os.environ
+    ):
+        return False
+    return not _console(stream).is_dumb_terminal
+
+
+def terminal_safe_text(text: str) -> str:
+    """Remove terminal control characters from untrusted display text."""
+
+    return "".join(char for char in text if char.isprintable())
+
+
+def _console(stream: TextIO) -> Console:
+    return Console(
+        file=stream,
+        force_terminal=True,
+        color_system="auto",
+        highlight=False,
+        theme=_CHAT_THEME,
+    )
+
+
+def _markdown(text: str) -> _ChatMarkdown:
+    markdown = _ChatMarkdown(
+        text,
+        code_theme="monokai",
+        hyperlinks=True,
+    )
+    parser = MarkdownIt("commonmark", {"html": False})
+    parser.enable("strikethrough").enable("table")
+    markdown.parsed = parser.parse(text)
+    return markdown
+
+
+def render_markdown(text: str, *, stream: TextIO | None = None) -> None:
+    """Render a completed answer, preserving raw output for pipes."""
+
+    target = stream or sys.stdout
+    if not supports_rich_output(target):
+        target.write(text)
+        target.flush()
+        return
+    _console(target).print(_markdown(text))
+
+
+class StreamingMarkdownRenderer:
+    """Preview a TTY answer, then replace it with one correct Markdown render."""
+
+    def __init__(self, stream: TextIO | None = None):
+        self._stream = stream or sys.stdout
+        self._enabled = supports_rich_output(self._stream)
+        self._preview_width = (
+            max(0, _console(self._stream).size.width - 1) if self._enabled else 0
+        )
+        self._chunks: list[str] = []
+        self._preview = ""
+
+    def __enter__(self) -> StreamingMarkdownRenderer:
+        return self
+
+    def __exit__(self, *_exc_info) -> None:
+        self.finish()
+
+    def write(self, text: str) -> None:
+        if not text:
+            return
+        if not self._enabled:
+            self._stream.write(text)
+            self._stream.flush()
+            return
+
+        self._chunks.append(text)
+        preview_piece: list[str] = []
+        previous_was_space = not self._preview or self._preview.endswith(" ")
+        for char in text:
+            if char.isspace():
+                if not previous_was_space:
+                    preview_piece.append(" ")
+                previous_was_space = True
+            elif char.isprintable():
+                preview_piece.append(char)
+                previous_was_space = False
+        if preview_piece and self._preview_width:
+            self._preview = _cell_suffix(
+                self._preview + "".join(preview_piece),
+                self._preview_width,
+            )
+            self._stream.write(f"\r\x1b[2K\x1b[2m{self._preview}\x1b[0m")
+            self._stream.flush()
+
+    def finish(self) -> None:
+        if self._enabled and self._chunks:
+            self._stream.write("\r\x1b[2K")
+            render_markdown("".join(self._chunks), stream=self._stream)
+            self._chunks.clear()
+            self._preview = ""

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -5249,160 +5249,23 @@ def _stream_chat_response(
     string — chat history stores only the final answer, matching the
     OpenAI-compat split between ``content`` and ``reasoning_content``.
 
-    Plain streaming: tokens land directly in the user's terminal as they
-    arrive. We deliberately do NOT use ``rich.Live`` + ``Markdown`` here:
-    Live re-renders the panel on every refresh and, when the console's
-    cursor-overwrite path is unreliable (recordings, some terminal
-    multiplexers), each refresh appends rather than overwrites — turning
-    a 200-token response into a wall of repeated text. Live markdown
-    rendering deserves a separate, more careful effort with explicit
-    fallback detection; for now correctness wins over formatting.
+    Interactive terminals show a one-line incremental preview, then replace it
+    with one correct Rich Markdown render containing structured headings,
+    lists, links, tables, and code. Pipes, CI, dumb terminals, and
+    ``NO_COLOR`` retain byte-for-byte plain streaming.
     """
     import json
 
     import requests
 
+    from .chat_render import StreamingMarkdownRenderer, supports_rich_output
+
     DIM = "\x1b[2m"
-    BOLD = "\x1b[1m"
     RESET = "\x1b[0m"
     MAGENTA = "\x1b[35m"
-    CYAN = "\x1b[36m"
-    is_tty = sys.stdout.isatty() and "NO_COLOR" not in os.environ
+    is_tty = supports_rich_output(sys.stdout)
     in_reasoning = False
     full = ""
-
-    # ----- Streaming markdown colorer ------------------------------------
-    # Body text streams in the terminal's default color (Claude-Code-style
-    # — accents only on chrome). Inline coloring handles the markers users
-    # see most often: ``\`code\``` (cyan), ``\`\`\`fence\`\`\``` (dim cyan
-    # block), ``**bold**`` (ANSI bold), and ATX headers (``#`` … ``####``)
-    # at line start. Lists / italic stay raw so the parser stays small.
-    HEADING_STYLE = {
-        1: BOLD + CYAN,  # `# h1`     — most prominent
-        2: BOLD + MAGENTA,  # `## h2`    — secondary
-        3: BOLD,  # `### h3`   — bold only
-        4: CYAN,  # `#### h4`  — cyan
-        5: MAGENTA,  # `##### h5` — magenta
-        6: DIM,  # `###### h6`— dim
-    }
-    _state = {
-        "in_fence": False,  # inside a ``` block
-        "in_inline_code": False,  # inside a `code` span
-        "in_bold": False,  # inside **bold**
-        "in_heading": False,  # inside an ATX heading line
-        "at_line_start": True,  # cursor is at start of a logical line
-        "pending": "",  # buffered chars awaiting lookahead
-    }
-
-    def _emit_with_inline_md(piece: str) -> None:
-        if not is_tty:
-            sys.stdout.write(piece)
-            sys.stdout.flush()
-            return
-        text = _state["pending"] + piece
-        _state["pending"] = ""
-        out: list[str] = []
-        i, n = 0, len(text)
-        while i < n:
-            c = text[i]
-            # Newline closes any line-scoped span (heading) and resets the
-            # line-start anchor so the next `#`/`*`/etc. is interpreted in
-            # the right context.
-            if c == "\n":
-                if _state["in_heading"]:
-                    out.append(RESET)
-                    _state["in_heading"] = False
-                out.append("\n")
-                _state["at_line_start"] = True
-                i += 1
-                continue
-            # ATX heading: `#`..`######` followed by space at line start.
-            # We skip this inside fences (a `#` at line start there is
-            # almost always a comment, not a heading).
-            if _state["at_line_start"] and c == "#" and not _state["in_fence"]:
-                # Count consecutive `#` (1..6).
-                j = i
-                while j < n and j - i < 6 and text[j] == "#":
-                    j += 1
-                # Need to see one more char after the hashes to decide
-                # heading vs literal "###foo" — buffer if we don't have it.
-                if j == n:
-                    _state["pending"] = text[i:]
-                    break
-                hashes = j - i
-                if 1 <= hashes <= 6 and text[j] == " ":
-                    style = HEADING_STYLE.get(hashes, BOLD)
-                    out.append(style)
-                    out.append(text[i : j + 1])  # emit "## "
-                    _state["in_heading"] = True
-                    _state["at_line_start"] = False
-                    i = j + 1
-                    continue
-                # Not a heading — fall through to literal emission below.
-            if c == "`":
-                # Need 2 chars of lookahead to disambiguate ``` vs `.
-                if i + 2 >= n:
-                    _state["pending"] = text[i:]
-                    break
-                if text[i : i + 3] == "```":
-                    if _state["in_fence"]:
-                        out.append("```" + RESET)
-                        _state["in_fence"] = False
-                    else:
-                        out.append(DIM + CYAN + "```")
-                        _state["in_fence"] = True
-                    _state["at_line_start"] = False
-                    i += 3
-                    continue
-                # Single backtick.
-                if _state["in_fence"]:
-                    out.append("`")
-                elif _state["in_inline_code"]:
-                    out.append("`" + RESET)
-                    _state["in_inline_code"] = False
-                else:
-                    out.append(CYAN + "`")
-                    _state["in_inline_code"] = True
-                _state["at_line_start"] = False
-                i += 1
-                continue
-            if c == "*" and not _state["in_fence"] and not _state["in_inline_code"]:
-                if i + 1 >= n:
-                    _state["pending"] = text[i:]
-                    break
-                if text[i : i + 2] == "**":
-                    if _state["in_bold"]:
-                        out.append("**" + RESET)
-                        _state["in_bold"] = False
-                    else:
-                        out.append(BOLD + "**")
-                        _state["in_bold"] = True
-                    _state["at_line_start"] = False
-                    i += 2
-                    continue
-            out.append(c)
-            # Whitespace (other than newline, handled above) keeps the
-            # line-start anchor true so leading-indent headings still
-            # parse — e.g., a list item's child paragraph is rare here.
-            if c not in " \t":
-                _state["at_line_start"] = False
-            i += 1
-        sys.stdout.write("".join(out))
-        sys.stdout.flush()
-
-    def _close_open_md_spans() -> None:
-        if is_tty and (
-            _state["in_fence"]
-            or _state["in_inline_code"]
-            or _state["in_bold"]
-            or _state["in_heading"]
-        ):
-            sys.stdout.write(RESET)
-            sys.stdout.flush()
-        if _state["pending"]:
-            sys.stdout.write(_state["pending"])
-            sys.stdout.flush()
-            _state["pending"] = ""
 
     # ----- Repetition guard ----------------------------------------------
     # Models occasionally degenerate into the same token repeated until
@@ -5427,12 +5290,15 @@ def _stream_chat_response(
     repeat_run = 0
     repetition_aborted = False
 
-    with requests.post(
-        f"{base_url}/v1/chat/completions",
-        json=payload,
-        stream=True,
-        timeout=timeout_s,
-    ) as resp:
+    with (
+        requests.post(
+            f"{base_url}/v1/chat/completions",
+            json=payload,
+            stream=True,
+            timeout=timeout_s,
+        ) as resp,
+        StreamingMarkdownRenderer() as renderer,
+    ):
         if resp.status_code != 200:
             # With stream=True the body may still be partial / mid-chunk when
             # the server closed the socket; read defensively so we surface a
@@ -5484,7 +5350,7 @@ def _stream_chat_response(
                 sys.stdout.flush()
             if piece:
                 if in_reasoning:
-                    sys.stdout.write(f"{RESET}\n  " if is_tty else "\n")
+                    sys.stdout.write(f"{RESET}\n" if is_tty else "\n")
                     in_reasoning = False
                 # Detect repetition BEFORE emitting. If a single coalesced
                 # delta contains the cutoff inside it (server batched many
@@ -5529,10 +5395,10 @@ def _stream_chat_response(
                         seen += 1
                     prefix = piece[:pos]
                     if prefix:
-                        _emit_with_inline_md(prefix)
+                        renderer.write(prefix)
                         full += prefix
                 else:
-                    _emit_with_inline_md(piece)
+                    renderer.write(piece)
                     full += piece
                 # Char-level guard: catches no-whitespace degenerate
                 # output like ``"BarleyBarleyBarley..."`` that the
@@ -5553,7 +5419,6 @@ def _stream_chat_response(
                     repetition_aborted = True
                 if repetition_aborted:
                     break
-    _close_open_md_spans()
     if in_reasoning and is_tty:
         sys.stdout.write(RESET)
         sys.stdout.flush()
@@ -5576,7 +5441,7 @@ def _complete_chat_with_mcp(
     timeout_s: int,
     *,
     max_rounds: int = 8,
-    on_tool_call=None,
+    on_tool_event=None,
 ) -> tuple[str, dict]:
     """Run the chat agent loop with MCP tools using non-streaming responses.
 
@@ -5669,24 +5534,35 @@ def _complete_chat_with_mcp(
         if message.get("reasoning_content"):
             assistant_message["reasoning_content"] = message["reasoning_content"]
         messages.append(assistant_message)
-        for position, tool_call in enumerate(normalized_calls):
-            try:
-                if on_tool_call is not None:
-                    on_tool_call(tool_call["function"]["name"])
-                messages.extend(mcp_runtime.execute_tool_calls([tool_call]))
-            except BaseException:
-                for pending_call in normalized_calls[position:]:
-                    messages.append(
-                        {
-                            "role": "tool",
-                            "tool_call_id": pending_call["id"],
-                            "content": json.dumps(
-                                {"error": "Tool execution interrupted"},
-                                ensure_ascii=False,
-                            ),
-                        }
-                    )
-                raise
+        completed_messages = {}
+
+        def _handle_tool_event(event, completed=completed_messages):
+            if event.phase == "finish" and event.message is not None:
+                completed[event.call_id] = event.message
+            if on_tool_event is not None:
+                on_tool_event(event)
+
+        try:
+            messages.extend(
+                mcp_runtime.execute_tool_calls(
+                    normalized_calls,
+                    on_event=_handle_tool_event,
+                )
+            )
+        except BaseException:
+            for pending_call in normalized_calls:
+                messages.append(
+                    completed_messages.get(pending_call["id"])
+                    or {
+                        "role": "tool",
+                        "tool_call_id": pending_call["id"],
+                        "content": json.dumps(
+                            {"error": "Tool execution interrupted"},
+                            ensure_ascii=False,
+                        ),
+                    }
+                )
+            raise
 
     raise RuntimeError(f"MCP tool loop exceeded {max_rounds} rounds")
 
@@ -5736,6 +5612,7 @@ def chat_command(args):
     import subprocess
 
     from vllm_mlx._tempfile_safe import managed_tempfile_path
+    from vllm_mlx.chat_render import supports_rich_output, terminal_safe_text
 
     base_url: str
     proc = None
@@ -5747,8 +5624,8 @@ def chat_command(args):
     # swap is mid-spawn would otherwise orphan the candidate server.
     _active_procs: list[subprocess.Popen] = []
 
-    # TTY-gated ANSI palette for the chat UI. NO_COLOR is honoured.
-    _is_tty = sys.stdout.isatty() and "NO_COLOR" not in os.environ
+    # ANSI palette only when the output supports interactive formatting.
+    _is_tty = supports_rich_output(sys.stdout)
     BOLD = "\x1b[1m" if _is_tty else ""
     DIM = "\x1b[2m" if _is_tty else ""
     GREEN = "\x1b[32m" if _is_tty else ""
@@ -6398,7 +6275,7 @@ def chat_command(args):
             # Claude-Code-style turn marker: a colored bullet introduces the
             # assistant's response so the user can visually scan turn
             # boundaries when scrolling back through long conversations.
-            sys.stdout.write(f"\n  {CYAN}●{RESET} ")
+            sys.stdout.write(f"\n  {CYAN}●{RESET}\n")
             sys.stdout.flush()
             metrics: dict = {}
             start_t = time.monotonic()
@@ -6412,9 +6289,21 @@ def chat_command(args):
                     )
                 else:
 
-                    def _show_mcp_tool_call(name: str) -> None:
-                        display_name = name.replace("__", ".", 1)
-                        sys.stdout.write(f"{DIM}using {display_name}…{RESET}\n  ")
+                    def _show_mcp_tool_event(event) -> None:
+                        display_name = terminal_safe_text(event.name).replace(
+                            "__", ".", 1
+                        )
+                        if event.phase == "start":
+                            text = f"{DIM}using {display_name}…{RESET}"
+                        else:
+                            elapsed = event.elapsed_seconds or 0
+                            if event.is_error:
+                                text = f"{RED}✗ {display_name} ({elapsed:.2f}s){RESET}"
+                            else:
+                                text = (
+                                    f"{GREEN}✓ {display_name} ({elapsed:.2f}s){RESET}"
+                                )
+                        sys.stdout.write(f"  {text}\n")
                         sys.stdout.flush()
 
                     assistant, metrics = _complete_chat_with_mcp(
@@ -6422,13 +6311,14 @@ def chat_command(args):
                         payload,
                         mcp_runtime,
                         timeout_s=args.response_timeout,
-                        on_tool_call=_show_mcp_tool_call,
+                        on_tool_event=_show_mcp_tool_event,
                     )
                     reasoning = metrics.get("reasoning_content")
                     if reasoning:
-                        sys.stdout.write(f"{DIM}[thinking] {reasoning}{RESET}\n  ")
-                    sys.stdout.write(assistant)
-                    sys.stdout.flush()
+                        sys.stdout.write(f"{DIM}[thinking] {reasoning}{RESET}\n")
+                    from .chat_render import render_markdown
+
+                    render_markdown(assistant)
             except KeyboardInterrupt:
                 print(f"\n  {YELLOW}(response interrupted){RESET}\n")
                 _recover_failed_chat_turn(messages, turn_start)


### PR DESCRIPTION
## What changed

- execute tool calls from different MCP servers concurrently while keeping each server's calls serialized
- preserve model tool-call result order and completed results on interruption
- show minimal `using …` / success / failure lifecycle status with elapsed time
- improve interactive terminal rendering:
  - bounded one-line live preview while the model generates
  - colored, left-aligned headings
  - bold and inline-code emphasis
  - syntax-highlighted fenced code
  - readable lists, quotes, links, and tables
- retain byte-for-byte streaming for pipes, CI, `NO_COLOR`, and dumb terminals

## Why

The built-in chat should feel responsive and readable from a user's perspective. Independent MCP calls should not add their latencies together, users should see what tools are doing, and normal model Markdown should look like terminal UI rather than raw punctuation.

This stays scoped to `rapid-mlx chat`. It does not change `serve`, `share`, MCP configuration, or introduce an agent framework.

## Design choices

- concurrency uses one lane per MCP server because SDK sessions are not assumed to support concurrent calls
- tool messages are returned in original model order even when servers finish out of order
- interactive answers show a terminal-width preview and then one complete Markdown render, preserving cross-block Markdown semantics without `rich.Live` transcript duplication
- preview state is incremental and cell-width bounded, including CJK and emoji
- non-interactive output remains raw and immediately streaming for scripting compatibility
- unfenced HTML is displayed literally rather than silently dropped

## Validation

- `python3.12 -m pytest -q tests/test_chat_render.py tests/test_chat_mcp.py tests/test_cli_chat.py` — 122 passed
- Ruff check and format — passed
- GitHub Actions pinning audit — passed
- Codex review converged — no actionable correctness findings
- 10,000 preview writes: 0.048s after the bounded-state fix
- clean wheel build and install into a fresh Python 3.12 venv
- end-to-end final-wheel dogfood with Qwen3.5-4B plus official filesystem and time MCP servers:
  - both servers invoked in one model turn and completed independently
  - lifecycle state and elapsed time were visible
  - Chinese/emoji heading, bold, inline code, highlighted Python, and table rendered correctly
  - no stale preview rows remained before the final answer