### PR TITLE
fix(mllm): auto-degrade to text lane when a vision-config checkpoint ships no vision tower (#1187)

### DIFF
--- a/tests/test_chat_route_vlm_image.py
+++ b/tests/test_chat_route_vlm_image.py
@@ -41,6 +41,18 @@ from vllm_mlx.engine.base import GenerationOutput
 from vllm_mlx.routes.chat import router as chat_router
 
 
+@pytest.fixture(autouse=True)
+def _reset_global_config_after_test():
+    """These tests install a live MLLM stub engine (``is_mllm=True``) on the
+    GLOBAL config via ``_make_client``. Without teardown that engine leaks into
+    every later test module — and any modality-reporting test that shares the
+    served model name would then read this stale VLM engine as authoritative
+    (see ``routes/models._served_engine_is_mllm``). Reset the global config
+    after each test so the stub never escapes this module."""
+    yield
+    reset_config()
+
+
 class _StubMLLMEngine:
     """Mock MLLM engine. Records the messages it received and either
     returns a canned ``GenerationOutput`` or raises a ValueError that

--- a/tests/test_no_mllm_flag.py
+++ b/tests/test_no_mllm_flag.py
@@ -3061,3 +3061,10 @@ async def test_start_mllm_does_not_degrade_on_unrelated_load_error(monkeypatch):
     )
     assert called["start_llm"] == 0, "must NOT degrade on an unrelated error"
     assert engine.is_mllm is True, "engine modality must be unchanged on a real error"
+    # The mllm-step worker must be torn down on EVERY failed load, not only
+    # the degrade path — otherwise an unrelated error orphans the executor
+    # thread (codex BLOCKING). ``_start_mllm`` shuts it down and clears the ref.
+    assert engine._model_load_executor is None, (
+        "the mllm-step ThreadPoolExecutor must be shut down and cleared even "
+        "when the load failure is not a degrade signal, or its worker thread leaks"
+    )

--- a/tests/test_no_mllm_flag.py
+++ b/tests/test_no_mllm_flag.py
@@ -551,8 +551,9 @@ def test_friendly_error_on_missing_vision_tensors(monkeypatch):
             f"Friendly error must mention --no-mllm; got: {msg!r}"
         )
         assert "#393" in msg, "Friendly error must reference #393 for searchability"
-        assert "60 vision tensors missing" in msg, (
-            "Friendly error must surface the count from the underlying error"
+        assert "60 multimodal tensors missing" in msg, (
+            "Friendly error must surface the count from the underlying error "
+            "with modality-neutral wording (the allowlist accepts audio too)"
         )
     finally:
         # Restore original mlx_vlm so subsequent tests aren't poisoned.

--- a/tests/test_no_mllm_flag.py
+++ b/tests/test_no_mllm_flag.py
@@ -535,6 +535,18 @@ def test_friendly_error_on_missing_vision_tensors(monkeypatch):
         with pytest.raises(RuntimeError) as excinfo:
             inst.load()
 
+        # The raise is a TextOnlyCheckpointError — a RuntimeError subclass so
+        # this `pytest.raises(RuntimeError)` still holds, but a DEDICATED type
+        # so the engine can degrade on THIS condition alone (auto text-only
+        # fallback) and let every other load failure propagate.
+        assert isinstance(excinfo.value, mllm_mod.TextOnlyCheckpointError), (
+            "Missing-vision-tower load failure must raise the typed "
+            f"TextOnlyCheckpointError; got {type(excinfo.value).__name__}"
+        )
+        assert excinfo.value.missing_count == 60, (
+            "Typed error must carry the parsed missing-tensor count for the "
+            f"engine's degrade log; got {excinfo.value.missing_count!r}"
+        )
         msg = str(excinfo.value)
         assert "--no-mllm" in msg, (
             f"Friendly error must mention --no-mllm; got: {msg!r}"
@@ -2790,3 +2802,162 @@ def test_friendly_error_does_not_swallow_unrelated_valueerror(monkeypatch):
         # detection means we may not have imported it.
         if real_mlx_vlm is not None:
             sys.modules["mlx_vlm"] = real_mlx_vlm
+
+
+# ---------------------------------------------------------------------------
+# Automatic text-only degrade (#1187 / #393).
+#
+# A vision-config checkpoint whose safetensors carry no usable vision tower
+# must NOT abort startup. mlx-vlm's strict weight load is the authoritative
+# signal (the routing detector reads the index/config, which still declare
+# vision, so it cannot catch a broken quant or an index that lists vision
+# tensors the shards don't contain — e.g. gemma-4 OptiQ). On that specific
+# failure the engine auto-degrades to the text lane, exactly as --no-mllm
+# would, instead of raising. Every OTHER load failure still propagates.
+# ---------------------------------------------------------------------------
+
+
+async def test_start_mllm_degrades_to_text_on_missing_vision_tower(monkeypatch):
+    """``_start_mllm`` catches ``TextOnlyCheckpointError`` and hands off to the
+    text lane: ``is_mllm`` flips to False and the mllm loader is torn down."""
+    from vllm_mlx.engine import batched as batched_mod
+    from vllm_mlx.models import mllm as mllm_mod
+
+    class _FakeTextOnlyMLLM:
+        def __init__(self, model_name, trust_remote_code=True):
+            self.model_name = model_name
+
+        def load(self):
+            raise mllm_mod.TextOnlyCheckpointError(
+                "MLLM load failed (356 vision tensors missing): this "
+                "checkpoint is text-only despite its multimodal config. "
+                "Re-run with --no-mllm ... Tracked in #393.",
+                missing_count=356,
+            )
+
+    # The import inside ``_start_mllm`` resolves the symbol at call time, so
+    # patching the module attribute is sufficient.
+    monkeypatch.setattr(mllm_mod, "MLXMultimodalLM", _FakeTextOnlyMLLM)
+
+    # AUTO-detected MLLM routing (NOT --mllm): the checkpoint's config declared
+    # vision so ``is_mllm_model`` routed it here. Simulate that verdict without
+    # a real config on disk. ``_force_mllm`` stays False so the degrade fires.
+    engine = batched_mod.BatchedEngine("fake/gemma4-optiq-4bit")
+    engine._is_mllm = True
+    assert engine._force_mllm is False, "precondition: auto-detected, not forced"
+
+    import sys
+
+    called = {"start_llm": 0}
+    exc_state = {}
+
+    async def _fake_start_llm():
+        called["start_llm"] += 1
+        # Capture whether an exception is still being HANDLED when the text
+        # lane loads. It must NOT be — the fallback runs outside the ``except``
+        # so the failed MLLM load's traceback (which pins mlx-vlm's whole
+        # weights dict + partial model) is released BEFORE the text model
+        # allocates, or the two coexist and can OOM a RAM-tight box.
+        exc_state["info"] = sys.exc_info()
+
+    monkeypatch.setattr(engine, "_start_llm", _fake_start_llm)
+
+    await engine._start_mllm()
+
+    assert called["start_llm"] == 1, (
+        "missing vision tower must degrade to the text lane, not abort"
+    )
+    assert exc_state["info"] == (None, None, None), (
+        "text-lane load must run OUTSIDE the except block (no active exception "
+        "pinning the failed vision load's ~weights-sized memory)"
+    )
+    assert engine.is_mllm is False, (
+        "engine must report text-only after the degrade so every "
+        "engine.is_mllm consumer (chat routes, /v1/models) stays consistent"
+    )
+    assert engine._model_load_executor is None, (
+        "the mllm-step loader thread must be shut down before the text "
+        "lane spins up its own executor (no leaked thread)"
+    )
+
+
+async def test_explicit_force_mllm_does_not_degrade(monkeypatch):
+    """``--mllm`` is a deliberate demand for the vision lane. A missing vision
+    tower must HARD-FAIL for that operator (surfacing --no-mllm as the fix),
+    never silently degrade behind their back — only AUTO-detected routing
+    degrades. The loader thread is still torn down so nothing leaks."""
+    from vllm_mlx.engine import batched as batched_mod
+    from vllm_mlx.models import mllm as mllm_mod
+
+    class _FakeTextOnlyMLLM:
+        def __init__(self, model_name, trust_remote_code=True):
+            pass
+
+        def load(self):
+            raise mllm_mod.TextOnlyCheckpointError(
+                "MLLM load failed (356 vision tensors missing): ... "
+                "Re-run with --no-mllm ... Tracked in #393.",
+                missing_count=356,
+            )
+
+    monkeypatch.setattr(mllm_mod, "MLXMultimodalLM", _FakeTextOnlyMLLM)
+
+    engine = batched_mod.BatchedEngine("fake/gemma4-optiq-4bit", force_mllm=True)
+
+    called = {"start_llm": 0}
+
+    async def _fake_start_llm():
+        called["start_llm"] += 1
+
+    monkeypatch.setattr(engine, "_start_llm", _fake_start_llm)
+
+    with pytest.raises(mllm_mod.TextOnlyCheckpointError) as excinfo:
+        await engine._start_mllm()
+
+    assert "--no-mllm" in str(excinfo.value), (
+        "explicit --mllm hard-fail must point the operator at the escape hatch"
+    )
+    assert called["start_llm"] == 0, "explicit --mllm must NOT auto-degrade"
+    assert engine.is_mllm is True, "explicit --mllm keeps the vision-lane verdict"
+    assert engine._model_load_executor is None, "loader thread must still be torn down"
+
+
+async def test_start_mllm_does_not_degrade_on_unrelated_load_error(monkeypatch):
+    """A load failure that is NOT a missing-vision-tower degrade signal (e.g.
+    corrupt weights, unsupported arch, OOM) must propagate unchanged — the
+    degrade path is scoped to ``TextOnlyCheckpointError`` alone, never a bare
+    RuntimeError, so genuine errors are never masked as a silent text fallback.
+    """
+    from vllm_mlx.engine import batched as batched_mod
+    from vllm_mlx.models import mllm as mllm_mod
+
+    class _FakeBrokenMLLM:
+        def __init__(self, model_name, trust_remote_code=True):
+            pass
+
+        def load(self):
+            raise RuntimeError("CUDA OOM / corrupt safetensors header")
+
+    monkeypatch.setattr(mllm_mod, "MLXMultimodalLM", _FakeBrokenMLLM)
+
+    # AUTO-detected routing — the mode where a degrade COULD happen — so this
+    # proves the scoping (TextOnlyCheckpointError only), not just that a forced
+    # lane never degrades.
+    engine = batched_mod.BatchedEngine("fake/genuinely-broken")
+    engine._is_mllm = True
+
+    called = {"start_llm": 0}
+
+    async def _fake_start_llm():
+        called["start_llm"] += 1
+
+    monkeypatch.setattr(engine, "_start_llm", _fake_start_llm)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        await engine._start_mllm()
+
+    assert "corrupt safetensors" in str(excinfo.value), (
+        "the original error must surface, not a text-fallback message"
+    )
+    assert called["start_llm"] == 0, "must NOT degrade on an unrelated error"
+    assert engine.is_mllm is True, "engine modality must be unchanged on a real error"

--- a/tests/test_no_mllm_flag.py
+++ b/tests/test_no_mllm_flag.py
@@ -513,12 +513,11 @@ def test_friendly_error_on_missing_vision_tensors(monkeypatch):
     class _FakeMlxVlm:
         @staticmethod
         def load(_name):
-            raise ValueError(
-                "Missing 60 parameters: \n"
-                "vision_tower.blocks.27.attn.proj.bias,\n"
-                "vision_tower.blocks.27.attn.proj.weight,\n"
-                "vision_tower.blocks.27.attn.qkv.bias."
-            )
+            # Mirror mlx's exact strict-load format: `Missing N parameters:`
+            # header where N equals the number of `,\n`-joined names, list
+            # terminated by a single `.`. All 60 names are vision-tower tensors.
+            names = [f"vision_tower.blocks.{i}.attn.proj.weight" for i in range(60)]
+            raise ValueError("Missing 60 parameters: \n" + ",\n".join(names) + ".")
 
     class _FakeMlxVlmUtils:
         @staticmethod
@@ -558,6 +557,106 @@ def test_friendly_error_on_missing_vision_tensors(monkeypatch):
     finally:
         # Restore original mlx_vlm so subsequent tests aren't poisoned.
         sys.modules["mlx_vlm"] = real_mlx_vlm
+
+
+def test_mixed_vision_and_language_missing_does_not_degrade(monkeypatch):
+    """A checkpoint missing BOTH vision AND language-backbone tensors is
+    genuinely incomplete — the text lane can't serve it either — so
+    MLLMModel.load() must NOT classify it as text-only. It must re-raise the
+    RAW ValueError (never the typed TextOnlyCheckpointError), so the engine
+    surfaces the real corruption instead of masking it behind an auto-degrade
+    that fails again, more confusingly, in the text lane. Guards the codex
+    BLOCKING finding on PR #1189: the classifier keys on ALL missing weights
+    being multimodal, not just ANY vision name appearing."""
+    import importlib
+    import sys
+
+    try:
+        importlib.import_module("mlx_vlm")
+    except ImportError:
+        pytest.skip("mlx_vlm not installed (vision extra)")
+
+    from vllm_mlx.models import mllm as mllm_mod
+
+    real_mlx_vlm = sys.modules["mlx_vlm"]
+
+    class _FakeMlxVlm:
+        @staticmethod
+        def load(_name):
+            # Vision tensors AND a language-backbone tensor are both absent:
+            # this is corruption, not a text-only fork.
+            raise ValueError(
+                "Missing 3 parameters: \n"
+                "language_model.model.layers.5.mlp.gate_proj.weight,\n"
+                "vision_tower.blocks.27.attn.proj.weight,\n"
+                "vision_tower.blocks.27.attn.qkv.bias."
+            )
+
+    class _FakeMlxVlmUtils:
+        @staticmethod
+        def load_config(_name):
+            return {}
+
+    monkeypatch.setitem(sys.modules, "mlx_vlm", _FakeMlxVlm)
+    monkeypatch.setitem(sys.modules, "mlx_vlm.utils", _FakeMlxVlmUtils)
+
+    inst = mllm_mod.MLXMultimodalLM(model_name="fake/corrupt-vlm")
+
+    try:
+        with pytest.raises(ValueError) as excinfo:
+            inst.load()
+        # Must be the RAW ValueError, NOT the typed degrade signal.
+        assert not isinstance(excinfo.value, mllm_mod.TextOnlyCheckpointError), (
+            "A checkpoint missing language-backbone weights must NOT be "
+            "classified as text-only; the raw ValueError has to propagate so "
+            "the engine reports genuine corruption instead of auto-degrading."
+        )
+        assert "language_model.model.layers.5" in str(excinfo.value), (
+            "The original missing-parameter detail must survive so operators "
+            "can see WHICH weights are missing."
+        )
+    finally:
+        sys.modules["mlx_vlm"] = real_mlx_vlm
+
+
+def test_missing_param_name_parser_and_multimodal_partition():
+    """Unit-level cover for the two helpers the degrade decision rests on:
+    `_parse_missing_param_names` recovers the individual tensor names from
+    mlx's `",\\n".join(sorted(...))` + trailing-`.` format, and
+    `_all_missing_are_multimodal` is True ONLY when every name is a
+    vision/audio/projector tensor (empty / any-language → False, fail safe)."""
+    from vllm_mlx.models import mllm as mllm_mod
+
+    pure_vision = (
+        "Missing 2 parameters: \n"
+        "embed_vision.embedding_projection.weight,\n"
+        "vision_tower.encoder.layers.0.mlp.down_proj.weight."
+    )
+    names = mllm_mod._parse_missing_param_names(pure_vision)
+    assert names == [
+        "embed_vision.embedding_projection.weight",
+        "vision_tower.encoder.layers.0.mlp.down_proj.weight",
+    ]
+    assert mllm_mod._all_missing_are_multimodal(names) is True
+
+    mixed_msg = (
+        "Missing 2 parameters: \n"
+        "language_model.model.norm.weight,\n"
+        "vision_tower.encoder.layers.0.mlp.down_proj.weight."
+    )
+    mixed_names = mllm_mod._parse_missing_param_names(mixed_msg)
+    assert mllm_mod._all_missing_are_multimodal(mixed_names) is False
+
+    # mlx's declared count is recovered and, for a well-formed message, equals
+    # the number of listed names (the completeness invariant the degrade gate
+    # cross-checks so a partial parse fails safe).
+    assert mllm_mod._parse_missing_count(pure_vision) == len(names) == 2
+    assert mllm_mod._parse_missing_count(mixed_msg) == len(mixed_names) == 2
+
+    # Unparseable / unrelated error shape → empty / None → not-degradable.
+    assert mllm_mod._parse_missing_param_names("some other error") == []
+    assert mllm_mod._parse_missing_count("some other error") is None
+    assert mllm_mod._all_missing_are_multimodal([]) is False
 
 
 def _flag_in_add_argument_calls(source: str, flag: str) -> bool:

--- a/tests/test_no_mllm_flag.py
+++ b/tests/test_no_mllm_flag.py
@@ -659,6 +659,27 @@ def test_missing_param_name_parser_and_multimodal_partition():
     assert mllm_mod._parse_missing_count("some other error") is None
     assert mllm_mod._all_missing_are_multimodal([]) is False
 
+    # Segment-aware matching (precision): a language-backbone weight whose
+    # SEGMENT merely CONTAINS an allowlisted token as a substring
+    # (``visual_proj`` ⊃ ``visual``, ``connector_gate`` ⊃ ``connector``) must
+    # NOT be misclassified as multimodal — else an all-language missing set
+    # could trigger an invalid degrade. A bare substring test would misfire.
+    assert mllm_mod._name_is_multimodal_tensor("vision_tower.encoder.0.weight")
+    assert mllm_mod._name_is_multimodal_tensor("model.visual.blocks.0.attn.weight")
+    assert mllm_mod._name_is_multimodal_tensor("model.embed_vision.proj.weight")
+    assert not mllm_mod._name_is_multimodal_tensor(
+        "language_model.model.layers.0.self_attn.visual_proj.weight"
+    )
+    assert not mllm_mod._name_is_multimodal_tensor(
+        "language_model.model.layers.0.connector_gate.weight"
+    )
+    assert mllm_mod._all_missing_are_multimodal(
+        ["vision_tower.a.weight", "model.visual.b.weight"]
+    )
+    assert not mllm_mod._all_missing_are_multimodal(
+        ["vision_tower.a.weight", "model.layers.0.visual_proj.weight"]
+    )
+
 
 def _flag_in_add_argument_calls(source: str, flag: str) -> bool:
     """True iff ``flag`` appears as a positional string literal to an

--- a/tests/test_no_out_of_band_routing.py
+++ b/tests/test_no_out_of_band_routing.py
@@ -83,6 +83,17 @@ ROUTING_WRITE_ALLOWED_FUNCS: frozenset[str] = frozenset(
         # `model_post_init` is Pydantic v2's standard "after validation"
         # hook. Treated as constructor-equivalent.
         "model_post_init",
+        # Auto-degrade to the text lane (#1187). Unlike every other entry
+        # this is a RUNTIME correction, not a construction/config decision:
+        # a vision-config checkpoint whose index.json LISTS vision tensors
+        # the shards don't actually contain can only be caught when mlx-vlm's
+        # strict weight load fails DURING `start()` — the constructor and the
+        # config/index detectors cannot see it (they trust the index). So the
+        # preferred "wire a RoutingFlagPair through __init__" resolution does
+        # not apply; the write must happen where the load failure surfaces.
+        # Pinned to engine/batched.py below so only the real engine method
+        # (not a same-named helper elsewhere) may flip the flag.
+        "_start_mllm",
     }
 )
 
@@ -98,6 +109,7 @@ ROUTING_WRITE_ALLOWED_LOCATIONS: dict[str, frozenset[str]] = {
     "enrich_model_config": frozenset({"model_auto_config.py"}),
     "_coerce": frozenset({"model_aliases.py"}),
     "_load": frozenset({"model_aliases.py"}),
+    "_start_mllm": frozenset({"engine/batched.py"}),
 }
 
 
@@ -752,14 +764,18 @@ def test_routing_fields_written_only_in_allowed_scopes():
 
     Allowed functions: ``__init__``, ``load_model``,
     ``detect_model_config``, ``enrich_model_config``, ``_coerce``,
-    ``_load``, ``model_post_init``. See ``ROUTING_WRITE_ALLOWED_FUNCS``.
+    ``_load``, ``model_post_init``, ``_start_mllm``. See
+    ``ROUTING_WRITE_ALLOWED_FUNCS``.
 
     If you need to mutate a routing field from a new location, the
     answer is almost always "add a new ``RoutingFlagPair`` entry in
     ``test_no_mllm_flag.py`` and wire it through ``EngineCore.__init__``
     via a kwarg". Adding to the allowlist here requires a written
     justification (PR description) explaining why constructor mutation
-    isn't sufficient.
+    isn't sufficient. ``_start_mllm`` (location-pinned to
+    ``engine/batched.py``) is the one runtime exception: the text-only
+    auto-degrade (#1187) can only be decided when mlx-vlm's strict weight
+    load fails at ``start()``, which is strictly after construction.
     """
     offenders: list[str] = []
     pkg_root = _pkg_root()

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -543,6 +543,12 @@ class TestModelsRoutes:
         from vllm_mlx.config import get_config
 
         cfg = get_config()
+        # Default ``engine`` to None unless a test supplies one: these are
+        # alias/registry resolution tests that must not inherit a live engine
+        # leaked by an earlier module (a stray MLLM engine would make
+        # ``/v1/models`` report the served model as a VLM via
+        # ``_served_engine_is_mllm``). Save+restore it like any other key.
+        kwargs.setdefault("engine", None)
         orig = {}
         for k, v in kwargs.items():
             orig[k] = getattr(cfg, k)

--- a/tests/test_routes_models.py
+++ b/tests/test_routes_models.py
@@ -237,25 +237,27 @@ def test_reported_modality_prefers_degraded_engine(monkeypatch):
         restore()
 
 
-def test_reported_modality_engine_authority_is_asymmetric(monkeypatch):
-    """ASYMMETRIC authority: a live engine reporting is_mllm=True does NOT
-    force ``image``/vision — it defers to the static detector. This keeps the
-    modality decoupled from incidental/leaked engine state (a real VLM already
-    advertises image via the detector). Only is_mllm=False is authoritative
-    (the degrade / --no-mllm downgrade, tested above)."""
+def test_reported_modality_engine_authority_is_symmetric(monkeypatch):
+    """SYMMETRIC authority: the live engine for the served model wins over the
+    static detector BOTH ways. is_mllm=False → text (degrade / --no-mllm), and
+    is_mllm=True → image even when the static detector misses it (an explicit
+    --mllm that loaded a real vision tower the config/index re-detect can't
+    see). Scoping (`_served_engine_is_mllm`) — not asymmetry — is what keeps a
+    different alias's leaked engine from contaminating an unrelated model."""
     from vllm_mlx.routes import models as models_route
 
+    # Engine loaded a vision tower; static detector disagrees (says text).
+    # The live engine must win and report image/vision.
     restore = _stub_single_serve(
         monkeypatch, model_id="fake/qwen3-vl-4bit", engine_is_mllm=True
     )
-    # Detector says text — engine is_mllm=True must NOT override it to image.
     monkeypatch.setattr(models_route, "is_mllm_model", lambda _m: False)
     try:
         assert (
             models_route._reported_modality("fake/qwen3-vl-4bit", "text", False)
-            == "text"
-        ), "engine is_mllm=True must not upgrade a text detector verdict"
-        assert models_route._is_vlm("fake/qwen3-vl-4bit", "text", False) is False
+            == "image"
+        ), "live engine is_mllm=True must win over a text detector verdict"
+        assert models_route._is_vlm("fake/qwen3-vl-4bit", "text", False) is True
     finally:
         restore()
     # And when the detector agrees the model IS a VLM, image is preserved.

--- a/tests/test_routes_models.py
+++ b/tests/test_routes_models.py
@@ -175,3 +175,175 @@ def test_retrieve_embedding_model_by_path_id():
 
 if __name__ == "__main__":  # pragma: no cover — convenience only
     pytest.main([__file__, "-v"])
+
+
+# ---------------------------------------------------------------------------
+# Served-engine modality authority (#1187 / #393).
+#
+# After the engine auto-degrades a vision-config checkpoint with no usable
+# vision tower to the text lane (or the operator passes --no-mllm), the live
+# engine's ``is_mllm`` is the truth. A fresh ``is_mllm_model`` re-detect still
+# reads config/index — which keep declaring vision — so /v1/models must prefer
+# the engine for the served model, or it advertises a vision capability the
+# server will reject.
+# ---------------------------------------------------------------------------
+
+
+class _StubEngine:
+    def __init__(self, is_mllm: bool):
+        self.is_mllm = is_mllm
+
+
+def _stub_single_serve(monkeypatch, *, model_id: str, engine_is_mllm: bool):
+    """Point get_config() at a single-model serve whose live engine reports
+    ``engine_is_mllm``. Returns a restore callable."""
+    from vllm_mlx.config import get_config
+
+    cfg = get_config()
+    saved = {
+        k: getattr(cfg, k, None)
+        for k in ("model_name", "model_alias", "model_registry", "engine")
+    }
+    cfg.model_registry = None
+    cfg.model_name = model_id
+    cfg.model_alias = None
+    cfg.engine = _StubEngine(engine_is_mllm)
+
+    def _restore() -> None:
+        for k, v in saved.items():
+            setattr(cfg, k, v)
+
+    return _restore
+
+
+def test_reported_modality_prefers_degraded_engine(monkeypatch):
+    """Engine degraded to text ⇒ wire says ``text`` even though the static
+    detector (reading the still-vision config/index) says otherwise."""
+    from vllm_mlx.routes import models as models_route
+
+    restore = _stub_single_serve(
+        monkeypatch, model_id="fake/gemma4-optiq-4bit", engine_is_mllm=False
+    )
+    # Static detector claims vision — the lying config/index. Engine must win.
+    monkeypatch.setattr(models_route, "is_mllm_model", lambda _m: True)
+    try:
+        assert models_route._served_engine_is_mllm("fake/gemma4-optiq-4bit") is False
+        assert (
+            models_route._reported_modality("fake/gemma4-optiq-4bit", "text", False)
+            == "text"
+        )
+        assert models_route._is_vlm("fake/gemma4-optiq-4bit", "text", False) is False
+    finally:
+        restore()
+
+
+def test_reported_modality_engine_authority_is_asymmetric(monkeypatch):
+    """ASYMMETRIC authority: a live engine reporting is_mllm=True does NOT
+    force ``image``/vision — it defers to the static detector. This keeps the
+    modality decoupled from incidental/leaked engine state (a real VLM already
+    advertises image via the detector). Only is_mllm=False is authoritative
+    (the degrade / --no-mllm downgrade, tested above)."""
+    from vllm_mlx.routes import models as models_route
+
+    restore = _stub_single_serve(
+        monkeypatch, model_id="fake/qwen3-vl-4bit", engine_is_mllm=True
+    )
+    # Detector says text — engine is_mllm=True must NOT override it to image.
+    monkeypatch.setattr(models_route, "is_mllm_model", lambda _m: False)
+    try:
+        assert (
+            models_route._reported_modality("fake/qwen3-vl-4bit", "text", False)
+            == "text"
+        ), "engine is_mllm=True must not upgrade a text detector verdict"
+        assert models_route._is_vlm("fake/qwen3-vl-4bit", "text", False) is False
+    finally:
+        restore()
+    # And when the detector agrees the model IS a VLM, image is preserved.
+    restore = _stub_single_serve(
+        monkeypatch, model_id="fake/qwen3-vl-4bit", engine_is_mllm=True
+    )
+    monkeypatch.setattr(models_route, "is_mllm_model", lambda _m: True)
+    try:
+        assert (
+            models_route._reported_modality("fake/qwen3-vl-4bit", "text", False)
+            == "image"
+        )
+        assert models_route._is_vlm("fake/qwen3-vl-4bit", "text", False) is True
+    finally:
+        restore()
+
+
+def test_served_engine_authority_only_for_served_model(monkeypatch):
+    """A registry-only / unserved id has no live engine ⇒ the helper returns
+    None and the static detector remains the decider (no over-reach)."""
+    from vllm_mlx.routes import models as models_route
+
+    restore = _stub_single_serve(
+        monkeypatch, model_id="fake/served-model", engine_is_mllm=False
+    )
+    monkeypatch.setattr(models_route, "is_mllm_model", lambda _m: True)
+    try:
+        assert models_route._served_engine_is_mllm("other/registry-only") is None
+        assert (
+            models_route._reported_modality("other/registry-only", "text", False)
+            == "image"
+        )
+        assert models_route._is_vlm("other/registry-only", "text", False) is True
+    finally:
+        restore()
+
+
+def test_engine_is_mllm_or_none_is_defensive():
+    """Only a real bool is authoritative; anything else (None engine, a
+    partially-built entry, a test double without ``is_mllm``) yields None so
+    /v1/models falls through to the static detector rather than raising."""
+    from vllm_mlx.routes import models as models_route
+
+    assert models_route._engine_is_mllm_or_none(None) is None
+    assert models_route._engine_is_mllm_or_none(object()) is None  # no is_mllm attr
+    assert models_route._engine_is_mllm_or_none(_StubEngine(True)) is True
+    assert models_route._engine_is_mllm_or_none(_StubEngine(False)) is False
+
+
+def test_build_model_info_raw_hf_path_honors_degraded_engine(monkeypatch):
+    """The raw-HF-path branch of ``_build_model_info`` (no alias profile — the
+    gemma-4 OptiQ case) must, once the served engine has degraded to text,
+    report the SAME wire shape as any other served raw-HF text model: the
+    baseline ``modality`` (``None`` — raw-HF text ids carry no positive
+    modality; that's the established behavior for every non-VLM raw path) and
+    NO vision capability. Pinning the exact modality (not just "!= image")
+    proves ``modality`` and ``capabilities`` are consistent and that the
+    degraded VLM is indistinguishable from a plain text model (#1187)."""
+    from vllm_mlx.routes import models as models_route
+
+    model_id = "mlx-community/gemma-4-26B-A4B-it-qat-OptiQ-4bit"
+
+    # Reference: a genuinely-text raw-HF model served by the same stub. Its
+    # modality is the raw-HF text baseline the degraded VLM must match.
+    ref_id = "mlx-community/some-plain-text-model-4bit"
+    restore = _stub_single_serve(monkeypatch, model_id=ref_id, engine_is_mllm=False)
+    monkeypatch.setattr(models_route, "is_mllm_model", lambda _m: False)
+    try:
+        baseline_modality = models_route._build_model_info(ref_id).modality
+    finally:
+        restore()
+
+    restore = _stub_single_serve(monkeypatch, model_id=model_id, engine_is_mllm=False)
+    # Static detector still sees the declared vision modality (lying index).
+    monkeypatch.setattr(models_route, "is_mllm_model", lambda _m: True)
+    try:
+        info = models_route._build_model_info(model_id)
+        assert info.modality == baseline_modality, (
+            f"degraded raw-HF VLM must report the same modality as a plain "
+            f"raw-HF text model ({baseline_modality!r}); got {info.modality!r}"
+        )
+        assert info.modality != "image", (
+            f"degraded raw-HF VLM must not advertise image modality; "
+            f"got {info.modality!r}"
+        )
+        assert "vision" not in (info.capabilities or []), (
+            f"degraded model must not advertise vision capability; "
+            f"got {info.capabilities!r}"
+        )
+    finally:
+        restore()

--- a/tests/test_routes_models.py
+++ b/tests/test_routes_models.py
@@ -328,11 +328,24 @@ def test_build_model_info_raw_hf_path_honors_degraded_engine(monkeypatch):
     finally:
         restore()
 
+    # Pin the baseline EXPLICITLY to None (not just "whatever the function
+    # returns") so a shared None -> other-non-image regression can't slip past
+    # both the reference and the degraded check (codex NIT, PR #1189).
+    assert baseline_modality is None, (
+        f"raw-HF text baseline modality must be None; got {baseline_modality!r} "
+        "— the reference itself regressed, so the equality check below would be "
+        "meaningless"
+    )
+
     restore = _stub_single_serve(monkeypatch, model_id=model_id, engine_is_mllm=False)
     # Static detector still sees the declared vision modality (lying index).
     monkeypatch.setattr(models_route, "is_mllm_model", lambda _m: True)
     try:
         info = models_route._build_model_info(model_id)
+        assert info.modality is None, (
+            f"degraded raw-HF VLM must report modality None (the raw-HF text "
+            f"baseline), not {info.modality!r}"
+        )
         assert info.modality == baseline_modality, (
             f"degraded raw-HF VLM must report the same modality as a plain "
             f"raw-HF text model ({baseline_modality!r}); got {info.modality!r}"

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -7945,7 +7945,7 @@ Examples:
     serve_parser.add_argument(
         "--mllm",
         action="store_true",
-        help="Force load model as multimodal (vision) even if name doesn't match auto-detection patterns",
+        help="Force load model as multimodal (vision) even if name doesn't match auto-detection patterns. Also DISABLES the automatic text-only fallback: normally a vision-config checkpoint that ships no usable vision tower auto-degrades to text-only serving (#1187); with --mllm it hard-fails instead so a deliberate demand for the vision lane is never silently downgraded.",
     )
     serve_parser.add_argument(
         "--no-mllm",

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -1055,30 +1055,32 @@ class BatchedEngine(BaseEngine):
         degrade_reason: str | None = None
         try:
             self._mllm_instance = self._model_load_executor.submit(_load_mllm).result()
-        except TextOnlyCheckpointError as e:
-            # The checkpoint's config.json declares a vision modality (so
-            # ``is_mllm_model`` routed it here) but mlx-vlm found no usable
-            # vision tower in the actual safetensors — a text-only fork, a
-            # broken multimodal quant, or an index.json that lists vision
-            # tensors the shards don't contain (gemma-4 OptiQ, #1187). The
-            # routing detector reads the index and cannot see this before
-            # load; mlx-vlm's strict weight load is the authoritative signal.
-            # The language backbone IS fully present, so auto-degrade to the
-            # text lane instead of aborting startup — exactly what passing
-            # ``--no-mllm`` would have done, done automatically. Any OTHER
-            # load failure (corrupt language weights, unsupported arch, OOM)
-            # is NOT a TextOnlyCheckpointError and propagates unchanged.
-            #
-            # Tear down the mllm-step worker now (whether we degrade or
-            # re-raise) so the loader thread never leaks.
+        except Exception as e:
+            # ANY load failure tears down the mllm-step worker FIRST so its
+            # thread never leaks — this runs whether we degrade or re-raise
+            # (codex BLOCKING: previously only TextOnlyCheckpointError shut it
+            # down, so an unrelated failure orphaned the executor).
             self._model_load_executor.shutdown(wait=True)
             self._model_load_executor = None
-            if self._force_mllm:
-                # The operator EXPLICITLY demanded the vision lane via --mllm.
-                # Degrading silently would betray that intent, so surface the
-                # error and let them choose --no-mllm (text) or a real VLM.
+            # A TextOnlyCheckpointError means the checkpoint's config.json
+            # declares a vision modality (so ``is_mllm_model`` routed it here)
+            # but mlx-vlm found no usable vision tower in the actual
+            # safetensors — a text-only fork, a broken multimodal quant, or an
+            # index.json that lists vision tensors the shards don't contain
+            # (gemma-4 OptiQ, #1187). The routing detector reads the index and
+            # cannot see this before load; mlx-vlm's strict weight load is the
+            # authoritative signal. The language backbone IS fully present, so
+            # auto-degrade to the text lane instead of aborting startup —
+            # exactly what ``--no-mllm`` would have done, done automatically.
+            #
+            # Everything else — corrupt language weights, unsupported arch,
+            # OOM — and ANY failure under an explicit ``--mllm`` (``force_mllm``,
+            # where degrading silently would betray a deliberate demand for the
+            # vision lane) is a hard failure and propagates unchanged.
+            if isinstance(e, TextOnlyCheckpointError) and not self._force_mllm:
+                degrade_reason = str(e)
+            else:
                 raise
-            degrade_reason = str(e)
 
         # Fallback runs OUTSIDE the ``except`` so the caught exception (and the
         # traceback frames it pins) is released FIRST. mlx-vlm's failed

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -808,6 +808,12 @@ class BatchedEngine(BaseEngine):
         # enforces; engine accepts and asserts defensively at use time).
         self._force_openai_harmony_streaming = force_openai_harmony_streaming
         self._no_openai_harmony_streaming = no_openai_harmony_streaming
+        # Remember whether the operator EXPLICITLY forced the vision lane.
+        # The automatic text-only degrade (#393/#1187) fires only for
+        # AUTO-detected MLLM routing; an explicit ``--mllm`` is a deliberate
+        # demand for the vision lane, so a missing vision tower must hard-fail
+        # for that operator rather than silently degrade behind their back.
+        self._force_mllm = force_mllm
         if force_text:
             # User explicitly opted out of MLLM routing. Skip the probe
             # entirely so a False from auto-detection can't be overridden
@@ -1010,7 +1016,7 @@ class BatchedEngine(BaseEngine):
 
         from ..engine_core import _init_mlx_step_thread
         from ..mllm_scheduler import MLLMScheduler, MLLMSchedulerConfig
-        from ..models.mllm import MLXMultimodalLM
+        from ..models.mllm import MLXMultimodalLM, TextOnlyCheckpointError
         from ..scheduler import SchedulerConfig
 
         # MLLM-tuned default for ``prefill_step_size``. Vision tokens balloon
@@ -1043,7 +1049,61 @@ class BatchedEngine(BaseEngine):
             instance.load()
             return instance
 
-        self._mllm_instance = self._model_load_executor.submit(_load_mllm).result()
+        # Reason string for the text-only degrade, set only when we intend to
+        # fall back. Captured so the fallback can run OUTSIDE the ``except``
+        # block — see the memory-release note below.
+        degrade_reason: str | None = None
+        try:
+            self._mllm_instance = self._model_load_executor.submit(_load_mllm).result()
+        except TextOnlyCheckpointError as e:
+            # The checkpoint's config.json declares a vision modality (so
+            # ``is_mllm_model`` routed it here) but mlx-vlm found no usable
+            # vision tower in the actual safetensors — a text-only fork, a
+            # broken multimodal quant, or an index.json that lists vision
+            # tensors the shards don't contain (gemma-4 OptiQ, #1187). The
+            # routing detector reads the index and cannot see this before
+            # load; mlx-vlm's strict weight load is the authoritative signal.
+            # The language backbone IS fully present, so auto-degrade to the
+            # text lane instead of aborting startup — exactly what passing
+            # ``--no-mllm`` would have done, done automatically. Any OTHER
+            # load failure (corrupt language weights, unsupported arch, OOM)
+            # is NOT a TextOnlyCheckpointError and propagates unchanged.
+            #
+            # Tear down the mllm-step worker now (whether we degrade or
+            # re-raise) so the loader thread never leaks.
+            self._model_load_executor.shutdown(wait=True)
+            self._model_load_executor = None
+            if self._force_mllm:
+                # The operator EXPLICITLY demanded the vision lane via --mllm.
+                # Degrading silently would betray that intent, so surface the
+                # error and let them choose --no-mllm (text) or a real VLM.
+                raise
+            degrade_reason = str(e)
+
+        # Fallback runs OUTSIDE the ``except`` so the caught exception (and the
+        # traceback frames it pins) is released FIRST. mlx-vlm's failed
+        # ``load_model`` holds the whole weights dict + the partially built
+        # model in the frame that raised; ``e.__cause__``'s traceback keeps
+        # that alive for the duration of the handler. Loading the text model
+        # while it is still pinned would transiently DOUBLE resident memory and
+        # can OOM a RAM-tight box (the #1187 reporter is on a 48 GB M4 Max).
+        # ``gc.collect()`` forces the now-unreferenced partial vision load to
+        # be reclaimed before the text lane allocates. (Codex review: MAJOR.)
+        if degrade_reason is not None:
+            import gc
+
+            logger.warning(
+                "%s — auto-falling back to text-only serving for '%s'. "
+                "Image/video requests will be rejected. Pass --mllm to force "
+                "the vision lane (it will fail on this checkpoint), or "
+                "--no-mllm to silence this warning. See #393.",
+                degrade_reason,
+                self._model_name,
+            )
+            gc.collect()
+            self._is_mllm = False
+            await self._start_llm()
+            return
 
         self._model = self._mllm_instance.model
         self._processor = self._mllm_instance.processor

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -1096,9 +1096,9 @@ class BatchedEngine(BaseEngine):
 
             logger.warning(
                 "%s — auto-falling back to text-only serving for '%s'. "
-                "Image/video requests will be rejected. Pass --mllm to force "
-                "the vision lane (it will fail on this checkpoint), or "
-                "--no-mllm to silence this warning. See #393.",
+                "Multimodal requests (image/video/audio) will be rejected. "
+                "Pass --mllm to force the multimodal lane (it will fail on this "
+                "checkpoint), or --no-mllm to silence this warning. See #393.",
                 degrade_reason,
                 self._model_name,
             )

--- a/vllm_mlx/models/mllm.py
+++ b/vllm_mlx/models/mllm.py
@@ -35,6 +35,38 @@ from vllm_mlx.mllm_cache import MLLMPrefixCacheManager
 logger = logging.getLogger(__name__)
 
 
+class TextOnlyCheckpointError(RuntimeError):
+    """A vision-config checkpoint that ships no usable vision tower.
+
+    Raised by :meth:`MLXMultimodalLM.load` when ``config.json`` declares a
+    vision (or audio) modality — so auto-detection routed the checkpoint to
+    the MLLM lane — but the actual safetensors do NOT carry a complete vision
+    tower. Three real-world sources produce this state, all indistinguishable
+    at load time and all handled identically:
+
+    * a text-only *fork* of a multimodal architecture (config inherited from
+      the base, weights language-only);
+    * a broken multimodal *quant* that dropped the vision tower;
+    * an ``index.json`` whose ``weight_map`` LISTS vision tensors the shards
+      don't actually contain (e.g. ``gemma-4`` OptiQ — the routing detector
+      trusts the index, so it can't catch this before load).
+
+    The language backbone is fully present and servable, so the engine treats
+    this as the authoritative "serve text-only" signal and auto-degrades to
+    the text lane (equivalent to the operator passing ``--no-mllm``), rather
+    than aborting startup. A dedicated subclass (not a bare ``RuntimeError``)
+    lets the engine degrade on THIS condition alone and let every other load
+    failure propagate. Subclasses ``RuntimeError`` so existing callers that
+    catch ``RuntimeError`` (and the #393 friendly-message contract) still hold.
+
+    Tracked in #393.
+    """
+
+    def __init__(self, message: str, *, missing_count: int | None = None):
+        super().__init__(message)
+        self.missing_count = missing_count
+
+
 # The bare-mlx-vlm line is PINNED to ``==0.6.3`` on purpose (0.10.16
 # dogfood finding ⑤). An unpinned ``pip install 'mlx-vlm>=0.6.3'`` run
 # against a base install resolves to the current PyPI latest (0.6.6),
@@ -1045,12 +1077,14 @@ class MLXMultimodalLM:
                 and any(p in msg for p in ("vision_tower", "vision_model", "visual."))
             ):
                 missing_count_hint = ""
+                missing_count: int | None = None
                 # Pull "Missing N" if present, just for the friendly head.
                 import re
 
                 m = re.search(r"Missing\s+(\d+)\s+parameters?", msg)
                 if m:
-                    missing_count_hint = f" ({m.group(1)} vision tensors missing)"
+                    missing_count = int(m.group(1))
+                    missing_count_hint = f" ({missing_count} vision tensors missing)"
                 logger.error(
                     "MLLM load failed%s — this checkpoint declares "
                     "vision_config in config.json but its safetensors don't "
@@ -1059,11 +1093,12 @@ class MLXMultimodalLM:
                     "See #393 for context.",
                     missing_count_hint,
                 )
-                raise RuntimeError(
+                raise TextOnlyCheckpointError(
                     f"MLLM load failed{missing_count_hint}: this checkpoint "
                     "is text-only despite its multimodal config. "
                     "Re-run with --no-mllm (or --text-only) to force "
-                    "text-only routing. Tracked in #393."
+                    "text-only routing. Tracked in #393.",
+                    missing_count=missing_count,
                 ) from e
             logger.error(f"Failed to load MLLM: {e}")
             raise

--- a/vllm_mlx/models/mllm.py
+++ b/vllm_mlx/models/mllm.py
@@ -1144,11 +1144,14 @@ class MLXMultimodalLM:
                 and _all_missing_are_multimodal(missing_names)
             ):
                 missing_count = declared_count
-                missing_count_hint = f" ({missing_count} vision tensors missing)"
+                # Modality-neutral wording: the allowlist accepts audio and
+                # projector tensors too, so an audio-only checkpoint can reach
+                # here — don't hard-code "vision".
+                missing_count_hint = f" ({missing_count} multimodal tensors missing)"
                 logger.error(
-                    "MLLM load failed%s — this checkpoint declares "
-                    "vision_config in config.json but its safetensors don't "
-                    "carry a complete vision tower. Re-run with --no-mllm "
+                    "MLLM load failed%s — this checkpoint declares a vision/"
+                    "audio modality in config.json but its safetensors don't "
+                    "carry a complete multimodal tower. Re-run with --no-mllm "
                     "(or --text-only) to force text-only routing. "
                     "See #393 for context.",
                     missing_count_hint,

--- a/vllm_mlx/models/mllm.py
+++ b/vllm_mlx/models/mllm.py
@@ -97,21 +97,47 @@ def _parse_missing_count(msg: str) -> int | None:
     return int(m.group(1)) if m else None
 
 
+def _name_is_multimodal_tensor(name: str) -> bool:
+    """Whether a single tensor path names a vision/audio/projector weight.
+
+    Draws the vocabulary from the canonical :data:`MULTIMODAL_TENSOR_PREFIXES`
+    allowlist the routing detector keys on (one source of truth), but matches
+    each token at a DOTTED-SEGMENT boundary rather than by bare substring: a
+    tensor path is a dot-joined module chain (``a.b.c.weight``), so a token
+    counts only when it is a whole segment (start-of-path, after a ``.``, or a
+    trailing leaf). This is stricter than the detector's substring test on
+    purpose — the degrade decision wants PRECISION (never mistake a language
+    weight like ``...q_proj.weight`` for multimodal just because a token is a
+    substring of a segment), and erring strict only ever degrades LESS (re-
+    raises), which is the fail-safe direction. Segment-anchored matching still
+    catches every real layout: top-level (``vision_tower.…``), nested
+    (``model.visual.blocks.…``), and leaf (``…image_newline``).
+    """
+    for prefix in MULTIMODAL_TENSOR_PREFIXES:
+        token = prefix.rstrip(".")
+        if (
+            name == token
+            or name.startswith(token + ".")
+            or ("." + token + ".") in name
+            or name.endswith("." + token)
+        ):
+            return True
+    return False
+
+
 def _all_missing_are_multimodal(missing_names: list[str]) -> bool:
     """Whether EVERY missing tensor belongs to a vision/audio/projector module.
 
-    Uses the same canonical :data:`MULTIMODAL_TENSOR_PREFIXES` allowlist the
-    routing detector keys on, so the degrade decision stays in lockstep with
-    detection (one source of truth). A checkpoint whose ONLY missing weights are
-    multimodal has a fully-present language backbone → the text lane is viable
-    → degrade. If ANY missing weight is a language/text-backbone tensor the
-    checkpoint is genuinely incomplete; degrading would mask real corruption, so
-    the caller must re-raise. Empty ``missing_names`` (unparseable message) is
-    ``False`` — fail safe, don't degrade on an unrecognised error shape.
+    A checkpoint whose ONLY missing weights are multimodal (per
+    :func:`_name_is_multimodal_tensor`) has a fully-present language backbone →
+    the text lane is viable → degrade. If ANY missing weight is a language/
+    text-backbone tensor the checkpoint is genuinely incomplete; degrading
+    would mask real corruption, so the caller must re-raise. Empty
+    ``missing_names`` (unparseable message) is ``False`` — fail safe, don't
+    degrade on an unrecognised error shape.
     """
     return bool(missing_names) and all(
-        any(prefix in name for prefix in MULTIMODAL_TENSOR_PREFIXES)
-        for name in missing_names
+        _name_is_multimodal_tensor(name) for name in missing_names
     )
 
 

--- a/vllm_mlx/models/mllm.py
+++ b/vllm_mlx/models/mllm.py
@@ -18,6 +18,7 @@ import base64
 import logging
 import math
 import os
+import re
 import sys
 import tempfile
 import threading
@@ -31,6 +32,7 @@ import numpy as np
 import requests
 
 from vllm_mlx.mllm_cache import MLLMPrefixCacheManager
+from vllm_mlx.model_metadata import MULTIMODAL_TENSOR_PREFIXES
 
 logger = logging.getLogger(__name__)
 
@@ -65,6 +67,52 @@ class TextOnlyCheckpointError(RuntimeError):
     def __init__(self, message: str, *, missing_count: int | None = None):
         super().__init__(message)
         self.missing_count = missing_count
+
+
+def _parse_missing_param_names(msg: str) -> list[str]:
+    """Extract the missing tensor names from mlx's strict-load ``ValueError``.
+
+    ``mlx.nn.Module.load_weights(..., strict=True)`` raises
+    ``f"Missing {n} parameters: \\n{name1},\\n{name2},...{nameK}."`` — the
+    names are comma-joined (mlx uses ``",\\n".join(sorted(missing))``) and the
+    whole list is terminated by a single ``.``. Return the individual names
+    (empty list if the message doesn't match, so callers fail safe).
+    """
+    m = re.search(r"Missing\s+\d+\s+parameters?:(.*)", msg, re.DOTALL)
+    if not m:
+        return []
+    body = m.group(1).strip().rstrip(".")
+    return [tok.strip() for tok in body.split(",") if tok.strip()]
+
+
+def _parse_missing_count(msg: str) -> int | None:
+    """Return mlx's own ``Missing N`` count from the strict-load ``ValueError``.
+
+    This is mlx's authoritative tally; it always equals the number of names it
+    then lists. Callers cross-check it against ``_parse_missing_param_names`` —
+    a mismatch means the name list wasn't parsed in full, so the degrade
+    decision can't be trusted and must fail safe.
+    """
+    m = re.search(r"Missing\s+(\d+)\s+parameters?", msg)
+    return int(m.group(1)) if m else None
+
+
+def _all_missing_are_multimodal(missing_names: list[str]) -> bool:
+    """Whether EVERY missing tensor belongs to a vision/audio/projector module.
+
+    Uses the same canonical :data:`MULTIMODAL_TENSOR_PREFIXES` allowlist the
+    routing detector keys on, so the degrade decision stays in lockstep with
+    detection (one source of truth). A checkpoint whose ONLY missing weights are
+    multimodal has a fully-present language backbone → the text lane is viable
+    → degrade. If ANY missing weight is a language/text-backbone tensor the
+    checkpoint is genuinely incomplete; degrading would mask real corruption, so
+    the caller must re-raise. Empty ``missing_names`` (unparseable message) is
+    ``False`` — fail safe, don't degrade on an unrecognised error shape.
+    """
+    return bool(missing_names) and all(
+        any(prefix in name for prefix in MULTIMODAL_TENSOR_PREFIXES)
+        for name in missing_names
+    )
 
 
 # The bare-mlx-vlm line is PINNED to ``==0.6.3`` on purpose (0.10.16
@@ -1062,29 +1110,41 @@ class MLXMultimodalLM:
                 "Install with: pip install 'rapid-mlx[vision]'"
             )
         except ValueError as e:
-            # mlx_vlm raises `ValueError: Missing N parameters: vision_*`
-            # when the checkpoint is a text-only fork (or an incomplete
-            # quant) of a multimodal architecture — config.json declares
-            # vision_config so MLLM auto-detection routes it here, but
-            # the actual safetensors lack the vision_tower weights.
-            # See #393 (Tylast: Qwen3.6-35B-A3B 8-bit community quant
-            # ships a partial vision tower). Translate to an actionable
-            # message instead of re-raising the raw ValueError.
+            # mlx's strict `load_weights` raises `ValueError: Missing N
+            # parameters: <names>` when config.json declares a vision (or
+            # audio) modality — so MLLM auto-detection routed the checkpoint
+            # here — but the actual safetensors don't carry every tensor the
+            # assembled multimodal model expects. Two very different states hit
+            # this path and MUST be distinguished by WHICH tensors are missing:
+            #
+            #   * ONLY vision/audio/projector tensors missing → the language
+            #     backbone is intact, the text lane is viable → raise the typed
+            #     `TextOnlyCheckpointError` so the engine auto-degrades to
+            #     text-only (equivalent to `--no-mllm`). See #393 (Qwen3.6-35B
+            #     8-bit partial vision tower) and #1187 (gemma-4 OptiQ, whose
+            #     index.json lists 356 vision tensors the shards lack).
+            #   * ANY language/text-backbone tensor also missing → the
+            #     checkpoint is genuinely incomplete; the text lane can't serve
+            #     it either. Degrading would MASK real corruption behind a
+            #     confusing two-stage failure, so re-raise the raw ValueError.
+            #
+            # The partition uses the SAME canonical MULTIMODAL_TENSOR_PREFIXES
+            # allowlist the routing detector keys on — one source of truth, not
+            # an ad-hoc vision-name substring test.
             msg = str(e)
+            declared_count = _parse_missing_count(msg)
+            missing_names = _parse_missing_param_names(msg)
+            # Degrade ONLY when we recovered EVERY name mlx reported (parse is
+            # complete: len matches mlx's own count) AND every one is a
+            # multimodal tensor. A parse gap or any language/text-backbone
+            # weight means the text lane isn't provably viable → re-raise.
             if (
-                "Missing" in msg
-                and "parameters" in msg
-                and any(p in msg for p in ("vision_tower", "vision_model", "visual."))
+                declared_count is not None
+                and len(missing_names) == declared_count
+                and _all_missing_are_multimodal(missing_names)
             ):
-                missing_count_hint = ""
-                missing_count: int | None = None
-                # Pull "Missing N" if present, just for the friendly head.
-                import re
-
-                m = re.search(r"Missing\s+(\d+)\s+parameters?", msg)
-                if m:
-                    missing_count = int(m.group(1))
-                    missing_count_hint = f" ({missing_count} vision tensors missing)"
+                missing_count = declared_count
+                missing_count_hint = f" ({missing_count} vision tensors missing)"
                 logger.error(
                     "MLLM load failed%s — this checkpoint declares "
                     "vision_config in config.json but its safetensors don't "

--- a/vllm_mlx/models/mllm.py
+++ b/vllm_mlx/models/mllm.py
@@ -1148,12 +1148,18 @@ class MLXMultimodalLM:
                 # projector tensors too, so an audio-only checkpoint can reach
                 # here — don't hard-code "vision".
                 missing_count_hint = f" ({missing_count} multimodal tensors missing)"
-                logger.error(
-                    "MLLM load failed%s — this checkpoint declares a vision/"
-                    "audio modality in config.json but its safetensors don't "
-                    "carry a complete multimodal tower. Re-run with --no-mllm "
-                    "(or --text-only) to force text-only routing. "
-                    "See #393 for context.",
+                # INFO, not ERROR: this is a recoverable, policy-eligible
+                # condition — the engine catches the typed error below and
+                # (unless --mllm forces the vision lane) auto-degrades to the
+                # text lane, logging its own WARNING. Emitting ERROR here fires
+                # a false failure alert during an otherwise healthy startup
+                # (codex NIT). The engine owns the policy-level severity.
+                logger.info(
+                    "MLLM checkpoint has no usable multimodal tower%s — declares"
+                    " a vision/audio modality in config.json but its safetensors"
+                    " don't carry the multimodal weights. Surfacing to the "
+                    "engine for the text-only auto-degrade (pass --mllm to force"
+                    " the vision lane, --no-mllm to pin text). See #393.",
                     missing_count_hint,
                 )
                 raise TextOnlyCheckpointError(

--- a/vllm_mlx/routes/models.py
+++ b/vllm_mlx/routes/models.py
@@ -212,20 +212,16 @@ def _reported_modality(
         # Operator pinned the text lane for a vision-config checkpoint —
         # authoritative, do not consult is_mllm_model.
         return "text"
-    if _served_engine_is_mllm(model_id) is False:
-        # ASYMMETRIC engine authority (INTENTIONAL — codex flagged the
-        # asymmetry as a nit on PR #1189; kept by design): a live engine that
-        # is serving text — because it auto-degraded a vision-config checkpoint
-        # with no vision tower (#1187) or the operator passed --no-mllm — is
-        # authoritative that vision is UNAVAILABLE, which a config/index-based
-        # re-detect cannot see. The reverse (engine is_mllm=True) does NOT force
-        # ``image`` here: a genuine VLM loaded a vision tower, and the static
-        # detector below keys on that same weight evidence, so it already
-        # advertises ``image`` for it — honoring engine True adds nothing but
-        # re-couples the wire modality to incidental/leaked engine state (the
-        # exact bleed this asymmetry was introduced to avoid). Deferring the
-        # positive case keeps modality decoupled and never over-claims vision.
-        return "text"
+    served = _served_engine_is_mllm(model_id)
+    if served is not None:
+        # The LIVE engine is the post-load SSOT for the served model and wins
+        # over a config/index re-detect, BOTH ways: is_mllm=False captures the
+        # text-only auto-degrade (#1187) and --no-mllm (vision unavailable →
+        # text), and is_mllm=True captures an explicit --mllm that loaded a
+        # vision tower the static detector missed (vision available → image).
+        # ``_served_engine_is_mllm`` is scoped to the served model, so a
+        # registry entry for a different alias never contaminates this verdict.
+        return "image" if served else "text"
     try:
         if is_mllm_model(model_id):
             return "image"
@@ -294,12 +290,14 @@ def _is_vlm(
         # Operator pinned the text lane for a vision-config checkpoint —
         # authoritative, do not advertise the vision capability.
         return False
-    if _served_engine_is_mllm(model_id) is False:
-        # ASYMMETRIC engine authority (see _reported_modality): a live engine
-        # serving text (text-only degrade / --no-mllm) authoritatively has NO
-        # vision capability. is_mllm=True does not force the tag on — genuine
-        # VLMs get it from the static detector below.
-        return False
+    served = _served_engine_is_mllm(model_id)
+    if served is not None:
+        # Live engine is authoritative for the served model, BOTH ways (see
+        # _reported_modality): a text-only degrade / --no-mllm reports no
+        # vision (False); an explicit --mllm that loaded a vision tower the
+        # static detector missed reports vision (True). Scoped to the served
+        # model, so a different alias's engine can't contaminate this.
+        return served
     try:
         return bool(is_mllm_model(model_id))
     except Exception:  # noqa: BLE001

--- a/vllm_mlx/routes/models.py
+++ b/vllm_mlx/routes/models.py
@@ -213,14 +213,18 @@ def _reported_modality(
         # authoritative, do not consult is_mllm_model.
         return "text"
     if _served_engine_is_mllm(model_id) is False:
-        # ASYMMETRIC engine authority: a live engine that is serving text —
-        # because it auto-degraded a vision-config checkpoint with no vision
-        # tower (#1187) or the operator passed --no-mllm — is authoritative
-        # that vision is UNAVAILABLE, which a config/index-based re-detect
-        # cannot see. The reverse (engine is_mllm=True) does NOT force
-        # ``image`` here: genuine VLMs already advertise it via the static
-        # detector below, so deferring keeps the modality decoupled from
-        # incidental engine state and avoids over-claiming vision.
+        # ASYMMETRIC engine authority (INTENTIONAL — codex flagged the
+        # asymmetry as a nit on PR #1189; kept by design): a live engine that
+        # is serving text — because it auto-degraded a vision-config checkpoint
+        # with no vision tower (#1187) or the operator passed --no-mllm — is
+        # authoritative that vision is UNAVAILABLE, which a config/index-based
+        # re-detect cannot see. The reverse (engine is_mllm=True) does NOT force
+        # ``image`` here: a genuine VLM loaded a vision tower, and the static
+        # detector below keys on that same weight evidence, so it already
+        # advertises ``image`` for it — honoring engine True adds nothing but
+        # re-couples the wire modality to incidental/leaked engine state (the
+        # exact bleed this asymmetry was introduced to avoid). Deferring the
+        # positive case keeps modality decoupled and never over-claims vision.
         return "text"
     try:
         if is_mllm_model(model_id):

--- a/vllm_mlx/routes/models.py
+++ b/vllm_mlx/routes/models.py
@@ -113,6 +113,66 @@ def _resolve_context_window(model_id: str) -> int | None:
     return window
 
 
+def _engine_is_mllm_or_none(engine: object | None) -> bool | None:
+    """Return ``engine.is_mllm`` only when it is a real ``bool``.
+
+    Defensive by design (matching this module's "never 500 /v1/models"
+    contract): a ``None`` engine, a partially-built entry, or a test double
+    whose ``is_mllm`` is absent/non-boolean yields ``None`` so the caller
+    falls through to the static detector rather than raising.
+    """
+    if engine is None:
+        return None
+    is_mllm = getattr(engine, "is_mllm", None)
+    return is_mllm if isinstance(is_mllm, bool) else None
+
+
+def _served_engine_is_mllm(model_id: str) -> bool | None:
+    """Return the LIVE engine's actual modality for the served model.
+
+    The engine's ``is_mllm`` reflects what was ACTUALLY loaded and is the
+    authoritative capability signal on the wire. It captures two states a
+    fresh ``is_mllm_model`` re-detect cannot see, because that re-reads
+    ``config.json`` / the weight index — which still declare a vision
+    modality — rather than the loaded engine:
+
+    * ``--no-mllm`` / ``force_text`` (operator pinned the text lane);
+    * the automatic text-only degrade for a vision-config checkpoint whose
+      safetensors ship no usable vision tower (#393 / gemma-4 OptiQ, #1187).
+
+    Returns ``None`` when no live engine matches ``model_id`` (a registry
+    entry that is not the served model, or the standalone path before an
+    engine is attached) so the caller falls back to static detection.
+    Resolution mirrors :func:`_context_window_for`.
+
+    Never raises: ``_is_vlm`` consults this BEFORE its own ``is_mllm_model``
+    guard, so any registry/attribute error here would otherwise 500 the
+    listing. Any exception collapses to ``None`` (fall through to the static
+    detector), matching the module's "never 500 /v1/models" contract.
+    """
+    try:
+        cfg = get_config()
+        if cfg.model_registry is not None:
+            try:
+                entry = cfg.model_registry.get_entry(model_id)
+            except KeyError:
+                return None
+            # ``get_entry`` falls back to the default entry on miss — guard
+            # that the entry actually matches so we don't report the default
+            # engine's modality for an unrelated/unloaded alias.
+            if entry is not None and entry.matches(model_id):
+                return _engine_is_mllm_or_none(entry.engine)
+            return None
+        candidate = getattr(cfg, "engine", None)
+        if candidate is not None:
+            served = {cfg.model_name, cfg.model_alias} - {None}
+            if model_id in served:
+                return _engine_is_mllm_or_none(candidate)
+        return None
+    except Exception:  # noqa: BLE001
+        return None
+
+
 def _reported_modality(
     model_id: str, profile_modality: str, is_text_only: bool = False
 ) -> str:
@@ -151,6 +211,16 @@ def _reported_modality(
     if is_text_only:
         # Operator pinned the text lane for a vision-config checkpoint —
         # authoritative, do not consult is_mllm_model.
+        return "text"
+    if _served_engine_is_mllm(model_id) is False:
+        # ASYMMETRIC engine authority: a live engine that is serving text —
+        # because it auto-degraded a vision-config checkpoint with no vision
+        # tower (#1187) or the operator passed --no-mllm — is authoritative
+        # that vision is UNAVAILABLE, which a config/index-based re-detect
+        # cannot see. The reverse (engine is_mllm=True) does NOT force
+        # ``image`` here: genuine VLMs already advertise it via the static
+        # detector below, so deferring keeps the modality decoupled from
+        # incidental engine state and avoids over-claiming vision.
         return "text"
     try:
         if is_mllm_model(model_id):
@@ -219,6 +289,12 @@ def _is_vlm(
     if is_text_only:
         # Operator pinned the text lane for a vision-config checkpoint —
         # authoritative, do not advertise the vision capability.
+        return False
+    if _served_engine_is_mllm(model_id) is False:
+        # ASYMMETRIC engine authority (see _reported_modality): a live engine
+        # serving text (text-only degrade / --no-mllm) authoritatively has NO
+        # vision capability. is_mllm=True does not force the tag on — genuine
+        # VLMs get it from the static detector below.
         return False
     try:
         return bool(is_mllm_model(model_id))
@@ -749,7 +825,14 @@ def _build_model_info(model_id: str) -> ModelInfo:
             model_id, profile_modality=None, profile_tool_parser=eff_tool
         )
         try:
-            if is_mllm_model(model_id):
+            # Route through ``_reported_modality`` (not a bare
+            # ``is_mllm_model``) so this raw-HF-path branch honours the LIVE
+            # engine for the served model — a vision-config checkpoint that
+            # auto-degraded to text (or --no-mllm) must advertise text here,
+            # matching the ``capabilities`` tag above and the registered-alias
+            # path. Without this, ``modality`` and ``capabilities`` diverged
+            # for a degraded raw-HF VLM (#1187).
+            if _reported_modality(model_id, "text", is_text_only=False) == "image":
                 return ModelInfo(
                     id=model_id,
                     modality="image",

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -2114,7 +2114,7 @@ Examples:
     parser.add_argument(
         "--mllm",
         action="store_true",
-        help="Force loading as MLLM (multimodal language model)",
+        help="Force loading as MLLM (multimodal language model). Also disables the automatic text-only fallback: a vision-config checkpoint with no usable vision tower normally auto-degrades to text-only serving (#1187), but with --mllm it hard-fails instead.",
     )
     parser.add_argument(
         "--no-mllm",


### PR DESCRIPTION
## Why

Fixes #1187. A checkpoint whose `config.json` declares a vision modality but whose safetensors ship **no usable vision tower** crashes the server at startup. The reporter hit this on `mlx-community/gemma-4-26B-A4B-it-qat-OptiQ-4bit`: its `model.safetensors.index.json` *lists* 356 vision tensors (`vision_tower.*`, `embed_vision.*`) that the actual shards don't contain, so the routing detector (`is_mllm_model`, which reads the index) routes to the MLLM lane and mlx-vlm's strict weight load aborts with `Missing 356 parameters: vision_tower.*`. The operator had to know to re-run with `--no-mllm`.

## Root fix (systematic, not a detector patch)

The detector reads the index/config, which *keep declaring* vision — no amount of detector heuristics can see that the shards are text-only before the load. So the fix makes **mlx-vlm's strict load the authoritative signal**: when the MLLM load fails *specifically* because the vision tower is absent, the engine **auto-degrades to the text lane** (the language backbone is fully present and servable) — exactly what `--no-mllm` does, done automatically. This covers every source of the state uniformly: text-only fork, broken quant, or an index that lists tensors the shards lack.

- **`models/mllm.py`** — new typed `TextOnlyCheckpointError(RuntimeError)`, raised by `MLXMultimodalLM.load()` on the missing-vision-tower signature, carrying `missing_count`. A `RuntimeError` subclass so the existing `#393` friendly-message contract still holds, but a dedicated type so the engine degrades on **this condition alone** and every other load failure propagates.
- **`engine/batched.py`** — `_start_mllm` catches it and hands off to `_start_llm` with `is_mllm=False` and the mllm-step loader torn down. An explicit `--mllm` (`force_mllm`) still **hard-fails** — degrading silently would betray a deliberate demand for the vision lane. The fallback runs **outside** the `except` (with `gc.collect()`) so the failed load's traceback — which pins mlx-vlm's whole weights dict + partial model — is released before the text model allocates, avoiding a transient memory doubling on RAM-tight boxes.
- **`routes/models.py`** — `/v1/models` derives the served model's modality/capabilities from the **live engine** (the post-degrade SSOT). Authority is **asymmetric**: a live engine serving text (degrade / `--no-mllm`) authoritatively has no vision; `is_mllm=True` defers to the static detector (genuine VLMs already advertise vision there), keeping the wire decoupled from incidental engine state. The helper never raises.

## Verified end-to-end on the real model

`mlx-community/gemma-4-26B-A4B-it-qat-OptiQ-4bit` (20 GB, downloaded and run locally):

- `serve` (no flags) → **auto-degrades and serves**: `"test"` → coherent reply; tool call → `get_weather{"city":"Tokyo"}`.
- `serve --mllm` (force vision) → still **hard-fails** with the 356-tensor error (exit 3) — reproduces the underlying crash and confirms explicit intent is respected.
- `/v1/models` → `modality`/`capabilities` consistent (text, no `vision`).

Touched-area + full unit suite pass; new tests cover the degrade, the `--mllm` hard-fail, the non-degrade-on-unrelated-error scoping + executor teardown, the out-of-`except` memory-release, the symmetric wire authority, and the defensive helper.

## Review follow-ups (pr_validate + codex)

- **Partition the missing set before degrading (codex BLOCKING).** The classifier degraded on *any* vision name in mlx's `Missing N parameters` error, so a checkpoint missing **both** vision **and** language weights was wrongly degraded — masking genuine corruption behind a confusing two-stage failure. It now parses the **full** missing set and degrades only when **every** missing tensor is a vision/audio/projector weight, keyed on the same canonical `MULTIMODAL_TENSOR_PREFIXES` allowlist the routing detector uses (one source of truth, not an ad-hoc substring test). Any language/text-backbone weight re-raises the raw `ValueError`. A parse-completeness guard (recovered name count must equal mlx's own declared count) fails safe on any unrecognised message shape. New tests cover mixed vision+language omission and the parser/partition helpers.

- **Tear down the mllm-step executor on every failed load (codex BLOCKING).** The load-failure handler caught only `TextOnlyCheckpointError`, so an unrelated failure (corrupt language weights, OOM, unsupported arch) left the `_model_load_executor` worker thread orphaned on the engine. It now catches any load exception, shuts down + clears the executor first, then re-raises anything not eligible for degradation. Regression test asserts the executor is `None` after an unrelated error.

- **Symmetric wire authority (codex BLOCKING).** `/v1/models` now treats the live served engine as authoritative **both** ways: `is_mllm=False` → text (degrade / `--no-mllm`), `is_mllm=True` → image (an explicit `--mllm` that loaded a vision tower the static detector missed). The earlier asymmetry was a band-aid for a cross-test state leak; the real fix is scoping (`_served_engine_is_mllm` is pinned to the served model) plus test isolation — a VLM-stub test module now resets the global config in teardown, and the models-route test helper defaults `engine` to `None` so no test inherits a stray engine. (No production impact: in single-serve the live engine always corresponds to the served model.)

- **Allowlist the runtime routing write (`test_no_out_of_band_routing` gate).** The auto-degrade flips `self._is_mllm = False` inside `_start_mllm`, which the SOP §10 out-of-band-routing gate flags. This is the gate's one legitimate **runtime** exception: a lying vision index can only be detected when mlx-vlm's strict weight load fails at `start()`, strictly after construction — so the gate's preferred "wire a `RoutingFlagPair` through `__init__`" resolution cannot express it. `_start_mllm` is added to the allowlist, **location-pinned to `engine/batched.py`** so no same-named helper elsewhere can flip the flag.

- **Modality-neutral wording + non-alarming severity (codex NIT).** The missing-weight allowlist accepts audio/projector tensors too, so the degrade log + count hint now say "multimodal tensors" / "vision/audio modality" instead of hard-coding "vision". The model-layer breadcrumb for the recoverable degrade is now `INFO`, not `ERROR`, so a healthy auto-degrade doesn't fire a false failure alert (the engine owns the policy-level `WARNING`).

- The flaky `full_unit` failures surfaced by earlier runs (`test_batched_faster_than_sequential`, sighup default-disposition, `test_ubc_evict_darwin_releases_pages`) all pass in isolation — timing / signal / memory-page environment noise under concurrent load, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

