### PR TITLE
docs(reasoning): document reasoning_max_tokens thinking budget

### DIFF
--- a/docs/guides/reasoning.md
+++ b/docs/guides/reasoning.md
@@ -197,6 +197,26 @@ response = client.chat.completions.create(
 )
 ```
 
+## Controlling Reasoning Length
+
+Reasoning models can think for a while before answering. Two request parameters bound this:
+
+- **`reasoning_max_tokens`** — caps the *thinking* portion. Once the model has produced this many tokens inside `<think>...</think>`, thinking is closed and the model moves on to its answer. It does **not** limit the answer.
+- **`max_tokens`** — caps the *total* response (thinking + answer).
+
+Use `reasoning_max_tokens` to stop a model from over-thinking, and pair it with `max_tokens` to bound the whole reply:
+
+```json
+{
+  "model": "default",
+  "messages": [{"role": "user", "content": "Explain quantum entanglement"}],
+  "reasoning_max_tokens": 256,
+  "max_tokens": 1024
+}
+```
+
+If `reasoning_max_tokens` is unset, the model decides how long to think.
+
 ## Backward Compatibility
 
 When `--reasoning-parser` is not specified, the server behaves as before:
@@ -276,6 +296,7 @@ curl http://localhost:8000/v1/chat/completions \
 ### Truncated reasoning
 
 - Increase `--max-tokens` if the model is hitting the token limit mid-thought
+- If you set `reasoning_max_tokens`, thinking is capped there — see [Controlling Reasoning Length](#controlling-reasoning-length)
 
 ## Related
 

--- a/vllm_mlx/api/models.py
+++ b/vllm_mlx/api/models.py
@@ -1578,14 +1578,10 @@ class ChatCompletionRequest(BaseModel):
     # accepted (no Pydantic drop) but not yet forwarded — see
     # ``_resolve_enable_thinking`` in service/helpers.py for precedence.
     chat_template_kwargs: dict | None = None
-    # Per-request cap on reasoning tokens (upstream vLLM PR #20859 backport).
-    # Semantic: force-close the ``<think>`` channel after N reasoning tokens
-    # are emitted; subsequent model output is routed to the final/content
-    # channel. DIFFERENT from the global ``thinking_token_budget`` which
-    # additively extends ``max_tokens`` headroom for reasoning models — this
-    # is a SUBTRACTIVE cap that gates how long the model is allowed to
-    # think before answering. Distinct from ``max_tokens`` (which caps the
-    # overall completion length). ``None`` = no cap, model decides.
+    # reasoning_max_tokens — caps the THINKING portion only (tokens inside
+    # ``<think>...</think>``); the model then answers. Does NOT bound the
+    # answer — pair with ``max_tokens`` for total length. None = no reasoning
+    # cap.
     reasoning_max_tokens: int | None = None
     # R10-H5 (R9-H3 carry) — OpenAI ``reasoning_effort`` knob. Declared
     # so Pydantic stops silently dropping it (sven r10-R1 + vlad r10-R1


### PR DESCRIPTION
## Why

`reasoning_max_tokens` had **no user-facing documentation** and its request-model field surfaced no description, so users could not tell that it caps the *thinking* portion only (not the total response) and should be paired with `max_tokens`. This closes that doc gap. Refs #1185 — the generation-time thinking budget is what made the parameter's semantics worth clarifying for users.

## What

Documents the `reasoning_max_tokens` request parameter, **semantic-only** (no internal mechanism), around the two params users actually reach for:
- `reasoning_max_tokens` — caps the **thinking** portion (tokens inside `<think>…</think>`); the model then answers. Does **not** bound the answer.
- `max_tokens` — caps the **total** response. Pair the two to bound the whole reply.

## Changes

1. **`docs/guides/reasoning.md`** — new "Controlling Reasoning Length" section + a "Truncated reasoning" troubleshooting cross-ref.
2. **`vllm_mlx/api/models.py`** — tighten the `reasoning_max_tokens` field comment to the same semantic. **No `Field(description=)` added** because this request model documents every field via `#` comments (0/32 `Field()` calls set a description); adding one would be the sole field with a schema description and break the file convention.

Comment-only + docs-only; no behavior change.

## Test plan

- [x] Docs render / links resolve (`#controlling-reasoning-length` anchor)
- [x] `vllm_mlx/api/models.py` change is comment-only — no schema/behavior change

🤖 Generated with [Claude Code](https://claude.com/claude-code)