### PR TITLE
feat(chat): quiet MCP server stderr and show live stream progress

### DIFF
--- a/tests/test_chat_mcp.py
+++ b/tests/test_chat_mcp.py
@@ -4,6 +4,8 @@
 from __future__ import annotations
 
 import asyncio
+import functools
+import io
 import json
 import logging
 import threading
@@ -14,6 +16,7 @@ import pytest
 from vllm_mlx.chat_mcp import (
     ChatMCPRuntime,
     ChatToolEvent,
+    _mcp_server_stderr_to,
     _quiet_optional_component_warnings,
     _server_parameters,
 )
@@ -664,3 +667,44 @@ def test_runtime_thread_is_dedicated_to_chat(tmp_path):
         assert _FakeSessionGroup.connect_thread_names == ["rapid-mlx-chat-mcp"]
     finally:
         runtime.close()
+
+
+def test_mcp_server_stderr_to_injects_errlog_and_restores():
+    import mcp
+
+    original = mcp.stdio_client
+    logfile = io.StringIO()
+    with _mcp_server_stderr_to(logfile):
+        patched = mcp.stdio_client
+        assert patched is not original
+        assert isinstance(patched, functools.partial)
+        assert patched.func is original
+        assert patched.keywords.get("errlog") is logfile
+    assert mcp.stdio_client is original
+
+
+def test_mcp_server_stderr_to_is_noop_without_logfile():
+    import mcp
+
+    original = mcp.stdio_client
+    with _mcp_server_stderr_to(None):
+        assert mcp.stdio_client is original
+    assert mcp.stdio_client is original
+
+
+def test_runtime_exposes_server_log_path(tmp_path):
+    import os
+
+    path = _write_config(
+        tmp_path,
+        {"alpha": {"command": "python3", "args": ["alpha", "lookup"]}},
+    )
+    runtime = ChatMCPRuntime(str(path))
+    try:
+        log_path = runtime.server_log_path
+        assert log_path is not None
+        assert os.path.exists(log_path)
+    finally:
+        runtime.close()
+    # The log survives close so a user can read what the servers printed.
+    assert os.path.exists(log_path)

--- a/tests/test_chat_render.py
+++ b/tests/test_chat_render.py
@@ -135,6 +135,27 @@ def test_streaming_preview_respects_terminal_cell_width():
     assert cell_len(preview) <= 7
 
 
+def test_streaming_preview_shows_live_token_and_elapsed():
+    output = _Tty()
+    with patch.dict(
+        os.environ,
+        {"TERM": "xterm-256color", "COLUMNS": "100"},
+        clear=False,
+    ):
+        os.environ.pop("NO_COLOR", None)
+        os.environ.pop("CI", None)
+        renderer = StreamingMarkdownRenderer(output)
+        renderer.write("Hello")
+        renderer.write(" there")
+
+    # The live (pre-finish) preview line leads with a token/elapsed badge so a
+    # long answer shows progress instead of a silent ticker.
+    preview = output.getvalue().rsplit("\x1b[2m", 1)[-1].split("\x1b[0m", 1)[0]
+    assert preview.startswith("2 tok · ")
+    assert "s  " in preview
+    assert "Hello there" in preview
+
+
 def test_terminal_safe_text_removes_control_sequences():
     text = "tool\x1b]52;c;payload\x07\r\nname"
 

--- a/vllm_mlx/chat_mcp.py
+++ b/vllm_mlx/chat_mcp.py
@@ -10,10 +10,12 @@ from __future__ import annotations
 
 import asyncio
 import concurrent.futures
+import functools
 import json
 import logging
 import re
 import sys
+import tempfile
 import threading
 import time
 from collections.abc import Callable
@@ -76,6 +78,47 @@ def _quiet_optional_component_warnings():
             logger.removeFilter(warning_filter)
 
 
+@contextmanager
+def _mcp_server_stderr_to(logfile):
+    """Route spawned MCP servers' stderr to *logfile* instead of the chat REPL.
+
+    The SDK's ``ClientSessionGroup`` builds the stdio transport internally and
+    exposes no way to pass ``errlog`` (it defaults to ``sys.stderr``), so a
+    server that logs to stderr — the official reference servers print a startup
+    banner, FastMCP-based ones log every request — would scribble over the clean
+    tool-activity display. We wrap the ``stdio_client`` the SDK resolves to
+    inject ``errlog`` for the duration of connection setup only. A child's
+    stderr fd is bound at exec, so it keeps writing to *logfile* for its whole
+    life, including per-request logging after setup.
+
+    The installed SDK calls ``mcp.stdio_client(...)`` by attribute, but to stay
+    robust if a future version binds ``stdio_client`` locally in the
+    ``session_group`` module instead, we patch every reachable reference. If the
+    SDK stops routing through any of them this degrades to the previous (noisy)
+    behaviour rather than breaking.
+    """
+
+    if logfile is None:
+        yield
+        return
+    import mcp
+    import mcp.client.session_group as _session_group
+
+    targets = [(mcp, "stdio_client")]
+    if hasattr(_session_group, "stdio_client"):
+        targets.append((_session_group, "stdio_client"))
+    saved = []
+    try:
+        for module, name in targets:
+            original = getattr(module, name)
+            saved.append((module, name, original))
+            setattr(module, name, functools.partial(original, errlog=logfile))
+        yield
+    finally:
+        for module, name, original in saved:
+            setattr(module, name, original)
+
+
 class ChatMCPRuntime:
     """Synchronous facade over SDK sessions running in an AnyIO portal."""
 
@@ -99,6 +142,20 @@ class ChatMCPRuntime:
         self._active_done: threading.Event | None = None
         self._stop_event: asyncio.Event | None = None
         self.tools: list[dict[str, Any]] = []
+
+        # Per-session log sink for MCP servers' stderr, so their banners and
+        # request logging land in a file instead of the interactive chat.
+        # Best-effort: if it can't be opened we simply keep the old behaviour.
+        self._server_log = None
+        self.server_log_path: str | None = None
+        try:
+            handle = tempfile.NamedTemporaryFile(
+                prefix="rapid-mlx-mcp-", suffix=".log", mode="a", delete=False
+            )
+            self._server_log = handle
+            self.server_log_path = handle.name
+        except OSError:
+            pass
 
         self._portal_context = start_blocking_portal(
             backend="asyncio",
@@ -207,6 +264,12 @@ class ChatMCPRuntime:
                     ) from exc
             finally:
                 self._portal_context.__exit__(None, None, None)
+                if self._server_log is not None:
+                    try:
+                        self._server_log.close()
+                    except OSError:
+                        pass
+                    self._server_log = None
                 self._closed = True
             if cancellation_error is not None:
                 raise cancellation_error
@@ -216,63 +279,65 @@ class ChatMCPRuntime:
 
         self._stop_event = asyncio.Event()
         async with AsyncExitStack() as stack:
-            for server in self._enabled_servers:
-                group = ClientSessionGroup(
-                    component_name_hook=lambda name, _info, label=server.name: (
-                        f"{label}__{name}"
+            with _mcp_server_stderr_to(self._server_log):
+                for server in self._enabled_servers:
+                    group = ClientSessionGroup(
+                        component_name_hook=lambda name, _info, label=server.name: (
+                            f"{label}__{name}"
+                        )
                     )
-                )
-                try:
-                    await group.__aenter__()
                     try:
-                        with _quiet_optional_component_warnings():
-                            await asyncio.wait_for(
-                                group.connect_to_server(_server_parameters(server)),
-                                timeout=server.timeout,
+                        await group.__aenter__()
+                        try:
+                            with _quiet_optional_component_warnings():
+                                await asyncio.wait_for(
+                                    group.connect_to_server(_server_parameters(server)),
+                                    timeout=server.timeout,
+                                )
+                        except BaseException:
+                            await _close_group(
+                                group,
+                                server.name,
+                                server.timeout,
+                                sys.exc_info(),
                             )
-                    except BaseException:
-                        await _close_group(
-                            group,
-                            server.name,
-                            server.timeout,
-                            sys.exc_info(),
+                            raise
+                    except (TimeoutError, asyncio.TimeoutError):
+                        self._connection_errors[server.name] = (
+                            f"connection timed out after {server.timeout:g} seconds"
                         )
-                        raise
-                except (TimeoutError, asyncio.TimeoutError):
-                    self._connection_errors[server.name] = (
-                        f"connection timed out after {server.timeout:g} seconds"
-                    )
-                    continue
-                except Exception as exc:
-                    self._connection_errors[server.name] = str(exc)
-                    continue
+                        continue
+                    except Exception as exc:
+                        self._connection_errors[server.name] = str(exc)
+                        continue
 
-                stack.push_async_callback(
-                    _close_group,
-                    group,
-                    server.name,
-                    server.timeout,
-                    (None, None, None),
-                )
-                self._groups[server.name] = group
-                for full_name, sdk_tool in group.tools.items():
-                    if not _OPENAI_FUNCTION_NAME_RE.fullmatch(full_name):
-                        raise RuntimeError(
-                            f"MCP tool name {full_name!r} is not a valid OpenAI "
-                            "function name (1-64 letters, digits, '_' or '-')"
-                        )
-                    if full_name in self._tools_by_name:
-                        previous = self._tools_by_name[full_name]
-                        raise RuntimeError(
-                            f"MCP tool name collision: {full_name!r} is exposed by "
-                            f"both {previous.server_name!r} and {server.name!r}"
-                        )
-                    self._tools_by_name[full_name] = MCPTool(
-                        server_name=server.name,
-                        name=sdk_tool.name,
-                        description=sdk_tool.description or "",
-                        input_schema=sdk_tool.inputSchema or {},
+                    stack.push_async_callback(
+                        _close_group,
+                        group,
+                        server.name,
+                        server.timeout,
+                        (None, None, None),
                     )
+                    self._groups[server.name] = group
+                    for full_name, sdk_tool in group.tools.items():
+                        if not _OPENAI_FUNCTION_NAME_RE.fullmatch(full_name):
+                            raise RuntimeError(
+                                f"MCP tool name {full_name!r} is not a valid OpenAI "
+                                "function name (1-64 letters, digits, '_' or '-')"
+                            )
+                        if full_name in self._tools_by_name:
+                            previous = self._tools_by_name[full_name]
+                            raise RuntimeError(
+                                f"MCP tool name collision: {full_name!r} is exposed "
+                                f"by both {previous.server_name!r} and "
+                                f"{server.name!r}"
+                            )
+                        self._tools_by_name[full_name] = MCPTool(
+                            server_name=server.name,
+                            name=sdk_tool.name,
+                            description=sdk_tool.description or "",
+                            input_schema=sdk_tool.inputSchema or {},
+                        )
 
             self.tools = mcp_tools_to_openai(list(self._tools_by_name.values()))
             task_status.started()

--- a/vllm_mlx/chat_render.py
+++ b/vllm_mlx/chat_render.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import os
 import sys
+import time
 from typing import TextIO
 
 from markdown_it import MarkdownIt
@@ -122,6 +123,8 @@ class StreamingMarkdownRenderer:
         )
         self._chunks: list[str] = []
         self._preview = ""
+        self._tokens = 0
+        self._start: float | None = None
 
     def __enter__(self) -> StreamingMarkdownRenderer:
         return self
@@ -138,6 +141,12 @@ class StreamingMarkdownRenderer:
             return
 
         self._chunks.append(text)
+        # One SSE delta ≈ one token for the streaming backends chat talks to,
+        # so a delta counter gives a live progress read during long answers
+        # (the authoritative count still prints on the speed line at the end).
+        self._tokens += 1
+        if self._start is None:
+            self._start = time.monotonic()
         preview_piece: list[str] = []
         previous_was_space = not self._preview or self._preview.endswith(" ")
         for char in text:
@@ -149,11 +158,18 @@ class StreamingMarkdownRenderer:
                 preview_piece.append(char)
                 previous_was_space = False
         if preview_piece and self._preview_width:
+            badge = f"{self._tokens} tok · {time.monotonic() - self._start:.0f}s  "
+            preview_width = self._preview_width - len(badge)
+            if preview_width < 8:
+                # Terminal too narrow to fit the badge and a useful preview;
+                # keep the preview and drop the badge rather than truncate both.
+                badge = ""
+                preview_width = self._preview_width
             self._preview = _cell_suffix(
                 self._preview + "".join(preview_piece),
-                self._preview_width,
+                preview_width,
             )
-            self._stream.write(f"\r\x1b[2K\x1b[2m{self._preview}\x1b[0m")
+            self._stream.write(f"\r\x1b[2K\x1b[2m{badge}{self._preview}\x1b[0m")
             self._stream.flush()
 
     def finish(self) -> None:

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -6186,11 +6186,16 @@ def chat_command(args):
                 print(f"\n  {RED}Failed to start MCP:{RESET} {exc}")
                 _cleanup()
                 sys.exit(1)
-            print(
+            ready_line = (
                 f"  {GREEN}✓ MCP ready:{RESET} "
                 f"{len(mcp_runtime.tools)} tool(s) from "
                 f"{mcp_runtime.server_count} server(s)."
             )
+            if mcp_runtime.server_log_path:
+                ready_line += (
+                    f"\n  {DIM}server logs → {mcp_runtime.server_log_path}{RESET}"
+                )
+            print(ready_line)
             for server_name, error in sorted(mcp_runtime.connection_errors.items()):
                 print(f"  {YELLOW}MCP server {server_name} unavailable:{RESET} {error}")
 


### PR DESCRIPTION
## Why

Two rough edges surfaced while driving `rapid-mlx chat` against the official MCP reference servers (filesystem / fetch / memory / everything):

1. **MCP server stderr clutters the REPL.** The SDK's `ClientSessionGroup` builds the stdio transport internally via `mcp.stdio_client(params)` with `errlog=sys.stderr` and exposes no override. So every server that writes to stderr scribbles over the otherwise-clean tool-activity display — the reference servers each print a `... running on stdio` banner at startup, and FastMCP-based ones (e.g. `mcp-server-fetch`) log **every** request:
   ```
     ● using fetch.fetch…
   [07/23/26 09:46:10] INFO  Processing request of type CallToolRequest  server.py:733   ← noise
     ✓ fetch.fetch (1.02s)
   ```
   Claude Desktop routes MCP server stderr to a log file; we now do the same (`rapid-mlx serve`'s own subprocess already logs to a file).

2. **Long answers stream as a silent dim ticker.** During generation the preview shows only the raw-markdown tail with no sense of progress or magnitude until the whole block pops in at the end.

## What

1. `_mcp_server_stderr_to(logfile)` wraps `mcp.stdio_client` to inject `errlog=<per-session logfile>` around connection setup only. A child's stderr fd is bound at exec, so each server keeps writing to the log for its whole life — startup banners **and** per-request logging. The log path is surfaced on the `✓ MCP ready:` line. If the SDK ever stops resolving `mcp.stdio_client` by attribute, this degrades to the previous (noisy) behaviour rather than breaking.
2. The streaming preview now leads with a dim `N tok · Xs` badge, dropped automatically when the terminal is too narrow to fit it plus a useful preview. The authoritative token count still prints on the final speed line.

## Testing

- `pytest tests/test_chat_mcp.py tests/test_chat_render.py` → 34 passed (4 new).
- End-to-end against the 4 reference servers: startup banners now land in the log file, nothing leaks to the terminal, `✓ MCP ready: 37 tool(s) from 4 server(s).` stays clean.
- Pipe / `NO_COLOR` / CI / dumb-terminal paths keep byte-for-byte plain output (unchanged).

Note: a *server* that pollutes its own **stdout** (e.g. launched via `npx`, whose install banner lands on stdout) still breaks JSON-RPC framing — that's the transport channel and out of scope here; the fix for that is to launch such servers by their real binary rather than a package-runner.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)