### PR TITLE
chore: bump version to 0.10.18

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.10.17"
+version = "0.10.18"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## Release 0.10.18 — thinking-token budget + MCP agent loop + DeepSeek-V3 tool grammar

Cuts 0.10.18 (even → feature release) bundling the 10 PRs merged since v0.10.17.
Version-only bump (`pyproject.toml` 0.10.17 → 0.10.18); no code change in this PR.

### Why now
The engine has accumulated a coherent batch of user-facing features + fixes since
the last release — the generation-time thinking budget, the MCP agent loop, and a
fourth constrained tool-call wire (DeepSeek-V3) — all merged and green on main. This
is the standard batch-then-bump cadence (no PR-per-release).

### What's in it (v0.10.17..main)
**Features**
- **#1185 / #1186** — generation-time thinking-token budget: `reasoning_max_tokens`
  now FORCE-CLOSES `</think>` at the budget (not just post-hoc trimming). #1186
  fixes the nested output-head width so the force actually fires.
- **#1181 / #1184 / #1188 / #1191** — MCP agent loop for `rapid-mlx chat`
  (`--mcp-config`), with quieted server stderr, live stream progress, and improved
  terminal rendering of tool activity.
- **#1182** — grammar-constrain DeepSeek-V3 section-wrapper tool-calls (#558 E1):
  the 4th top-tier tool-call wire under hard grammar constraint.

**Fixes / polish**
- **#1187 / #1193** — MLLM text lane: auto-degrade to text for vision-config
  checkpoints with no vision tower; chunk text-only prefill to bound peak memory on
  long prompts.
- **#1190** — docs for the `reasoning_max_tokens` thinking budget.

### Dogfood (fresh venv, Python 3.12, base install — G9)
Built from this tree into a clean `python -m venv`, cached models only (no network):
- **Base install clean** — no missing core deps; `mcp`, `llguidance`, `mlx 0.32.0`
  all resolve. (The naive-user install path, which is what this proof exists for.)
- **All new-feature imports PASS** — reasoning_budget, tool_grammar, DeepSeek-V3
  parser (registered), chat_mcp + mcp.config/executor, models.mllm, chat_render.
- **Serve + chat E2E (qwen3.5-4b-4bit, :8790)** — basic chat OK; **think-budget
  force-close verified**: `reasoning_max_tokens=8` cut reasoning_content 1383 → 25
  chars and still produced the correct answer with a clean stop (baseline rambled to
  max_tokens). Flagship feature works end-to-end for a naive user.
- **MCP wired** — `chat --mcp-config` flag present, config loader + MCP SDK
  base-installable.

**Honest coverage gaps** (both low-risk, code-verified + unit-tested):
- **#1182 DeepSeek-V3 tool grammar** — constraint only engages on the original
  DeepSeek-V3/R1 (not cached locally; too large to pull on this box). Parser imports
  + registers cleanly; the wire-constraint path is covered by
  `tests/test_tool_grammar_558.py`. Not run against a live V3.
- **#1187 / #1193 MLLM text lane** — import-verified; not served E2E (needs the
  `vision` extra's torch + a large MLLM, deferred on a disk-constrained box). Both
  ship with unit coverage (`tests/test_no_mllm_flag.py`, MLLM suite).

### Not included
- **#558 line①** (reasoning-gated forced tool grammar, PR #1192) is intentionally
  NOT in this release — decoupled per maintainer decision. It is HELD pending two
  structural hardening items (context-window allowance check + in-`<think>` tool
  marker quarantine) and lands in a later even release.

Merges as the auto-release trigger (`chore: bump version to 0.10.18 (#N)`).
