### PR TITLE
chore: bump version to 0.11.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.10.18"
+version = "0.11.0"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## 0.11.0 — #558 reasoning keystone

MINOR bump marking **line①** — the reasoning-gated forced tool-call grammar (PR #1192, merge `57ea8590`) — landing on `main`.

### What ships
line① hard-constrains forced/named tool-call **arguments** on **thinking** models. The grammar mask is gated OFF during the `<think>` span (the tool-call opener token is masked) and activates at the atomic `</think>` token id, coupled to a generation-time thinking budget that force-closes `</think>` so the gate provably opens. This unlocks schema-guaranteed forced tool calls for the **reasoning-model half** of every family (qwen3-thinking, gemma4-thinking, deepseek forced, …) that the prior forced-prefix path could not constrain.

### Why MINOR (not another patch)
The reasoning keystone is the last originally-scoped #558 lane and changes the default behaviour of forced tool calls on thinking models — it earns a new minor line.

### Rationale / validation
- **16 rounds of adversarial codex review** converged to only the documented text-vs-atomic split residual (matches vLLM/SGLang decoded-text split; strictly non-regressive; adversarial-subtoken-only) + perf nits — no open blocking correctness bug.
- **GH validate CI green**: validate, lint, test-apple-silicon, test-matrix 3.10/3.11/3.12, type-check, tests.
- **full_unit**: 13806 passed; the 4 failures are all known env flakes (GPU-contention batching, test_cli_chat ×2, HF-offline deepseek tokenizer, transient signal_observability).
- **G9 fresh-venv dogfood PASSED** on real Qwen3.5-4B-4bit: gate ENGAGED (`end_id=248069`, opener `248058` masked), valid schema-complete constrained arguments (`{"city": "Tokyo", "unit": "celsius"}`), reasoning_content preserved — both streaming and non-streaming.

Single-line diff: `pyproject.toml` version `0.10.18` → `0.11.0`. Merging triggers `auto-release.yml` (PyPI + GH Release + tag `v0.11.0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)