### PR TITLE
fix(kv-cache): quantize the live continuous-batching KV cache (#1197)

### DIFF
--- a/tests/test_quantized_batch_cache.py
+++ b/tests/test_quantized_batch_cache.py
@@ -1,0 +1,830 @@
+"""Numerical-equivalence tests for QuantizedBatchKVCache (#1197).
+
+Strategy
+--------
+``QuantizedBatchKVCache`` stores quantized KV but returns bf16 (dequant-on-read),
+so two invariants are checked:
+
+1. **Bookkeeping is bit-exact vs BatchKVCache.** ``offset`` / ``left_padding`` /
+   ``_idx`` / ``make_mask`` / ``nbytes>`` structure never touch quantization, so
+   they must match mlx-lm's ``BatchKVCache`` exactly under the same op sequence.
+
+2. **KV content equals a per-chunk quantize round-trip.** Because the sequence
+   axis is 1:1 with tokens in the packed tensor, the value returned for a written
+   chunk is exactly ``dequantize(quantize(chunk))`` — deterministic, so the
+   comparison is bit-exact (max-abs-diff == 0), not merely "close".
+"""
+
+import mlx.core as mx
+import pytest
+from mlx_lm.models.cache import BatchKVCache
+
+from vllm_mlx.quantized_batch_cache import (
+    QuantizedBatchKVCache,
+    _dequantize,
+    _QuantizableKVCache,
+    _quantize,
+)
+
+GS = 64
+BITS = 8
+H = 2
+D = 64
+
+
+def _kv(b, n, seed):
+    mx.random.seed(seed)
+    k = mx.random.normal((b, H, n, D)).astype(mx.bfloat16)
+    v = mx.random.normal((b, H, n, D)).astype(mx.bfloat16)
+    return k, v
+
+
+def _qrt(x, gs=GS, bits=BITS):
+    """Reference: what a quantize->dequantize round-trip yields for x."""
+    return _dequantize(_quantize(x, gs, bits), gs, bits)
+
+
+def _max_abs(a, b):
+    return float(mx.max(mx.abs(a.astype(mx.float32) - b.astype(mx.float32))))
+
+
+# --- update_and_fetch --------------------------------------------------------
+
+
+def test_single_update_matches_quant_roundtrip():
+    B, n = 3, 40
+    k, v = _kv(B, n, 0)
+    q = QuantizedBatchKVCache([0, 0, 0], GS, BITS)
+    ok, ov = q.update_and_fetch(k, v)
+    assert ok.shape == (B, H, n, D)
+    assert _max_abs(ok, _qrt(k)) == 0.0
+    assert _max_abs(ov, _qrt(v)) == 0.0
+
+
+def test_multi_chunk_crosses_capacity_growth():
+    # step=256; write chunks that force a capacity grow + partial-step trim path.
+    B = 2
+    q = QuantizedBatchKVCache([0, 0], GS, BITS)
+    ref_k_chunks, ref_v_chunks = [], []
+    total = 0
+    for i, n in enumerate([100, 200, 50, 300]):  # crosses 256 boundary
+        k, v = _kv(B, n, 10 + i)
+        ok, ov = q.update_and_fetch(k, v)
+        ref_k_chunks.append(_qrt(k))
+        ref_v_chunks.append(_qrt(v))
+        total += n
+        assert q.size() == total
+        assert ok.shape == (B, H, total, D)
+        # full-history dequant equals concat of per-chunk round-trips
+        assert _max_abs(ok, mx.concatenate(ref_k_chunks, axis=2)) == 0.0
+        assert _max_abs(ov, mx.concatenate(ref_v_chunks, axis=2)) == 0.0
+
+
+def test_offset_and_idx_match_batchkvcache():
+    B = 3
+    lp = [2, 0, 5]
+    q = QuantizedBatchKVCache(lp, GS, BITS)
+    b = BatchKVCache(lp)
+    for i, n in enumerate([30, 30]):
+        k, v = _kv(B, n, 100 + i)
+        q.update_and_fetch(k, v)
+        b.update_and_fetch(k, v)
+    assert q._idx == b._idx
+    assert mx.array_equal(q.offset, b.offset)
+    assert mx.array_equal(q.left_padding, b.left_padding)
+
+
+# --- make_mask (must be bit-exact; no quantization involved) ------------------
+
+
+def test_make_mask_matches_batchkvcache():
+    B = 3
+    lp = [1, 4, 0]
+    q = QuantizedBatchKVCache(lp, GS, BITS)
+    b = BatchKVCache(lp)
+    k, v = _kv(B, 20, 7)
+    q.update_and_fetch(k, v)
+    b.update_and_fetch(k, v)
+    mq = q.make_mask(1)
+    mb = b.make_mask(1)
+    assert mq.shape == mb.shape
+    assert mx.array_equal(mq, mb)
+
+
+# --- prepare with left padding ----------------------------------------------
+
+
+def test_prepare_left_padding_matches():
+    B = 2
+    q = QuantizedBatchKVCache([0, 0], GS, BITS)
+    b = BatchKVCache([0, 0])
+    q.prepare(left_padding=[3, 1])
+    b.prepare(left_padding=[3, 1])
+    assert mx.array_equal(q.offset, b.offset)
+    assert mx.array_equal(q.left_padding, b.left_padding)
+
+
+def test_prepare_left_padding_on_nonempty_raises():
+    q = QuantizedBatchKVCache([0], GS, BITS)
+    q.update_and_fetch(*_kv(1, 5, 1))
+    with pytest.raises(ValueError):
+        q.prepare(left_padding=[1])
+
+
+# --- trim --------------------------------------------------------------------
+
+
+def test_trim_matches_batchkvcache():
+    B = 2
+    q = QuantizedBatchKVCache([0, 0], GS, BITS)
+    b = BatchKVCache([0, 0])
+    k, v = _kv(B, 50, 3)
+    q.update_and_fetch(k, v)
+    b.update_and_fetch(k, v)
+    assert q.trim(10) == b.trim(10)
+    assert q._idx == b._idx
+    assert mx.array_equal(q.offset, b.offset)
+
+
+# --- filter (row select + left-shift) ---------------------------------------
+
+
+def test_filter_matches_batchkvcache():
+    B = 4
+    lp = [0, 3, 1, 2]
+    q = QuantizedBatchKVCache(lp, GS, BITS)
+    b = BatchKVCache(lp)
+    k, v = _kv(B, 25, 9)
+    qk_full, _ = q.update_and_fetch(k, v)
+    b.update_and_fetch(k, v)
+
+    keep = [0, 2]
+    q.filter(keep)
+    b.filter(keep)
+
+    assert q._idx == b._idx
+    assert mx.array_equal(q.offset, b.offset)
+    assert mx.array_equal(q.left_padding, b.left_padding)
+    # Content check: the dequantized kept rows must equal the bf16 BatchKVCache's
+    # kept rows put through the same quant round-trip — proves filter() selected
+    # the RIGHT rows and preserved their KV, not merely the batch dimension.
+    qk_kept = _dequantize(q._slice_seq(q.keys, q._idx), GS, BITS)
+    assert qk_kept.shape[0] == 2
+    ref_k = _qrt(b.keys[..., : b._idx, :])
+    ref_v = _qrt(b.values[..., : b._idx, :])
+    assert _max_abs(qk_kept, ref_k) == 0.0
+    qv_kept = _dequantize(q._slice_seq(q.values, q._idx), GS, BITS)
+    assert _max_abs(qv_kept, ref_v) == 0.0
+
+
+# --- extend ------------------------------------------------------------------
+
+
+def test_extend_matches_batchkvcache_bookkeeping():
+    qa = QuantizedBatchKVCache([0, 0], GS, BITS)
+    qb = QuantizedBatchKVCache([0], GS, BITS)
+    ba = BatchKVCache([0, 0])
+    bb = BatchKVCache([0])
+
+    ka, va = _kv(2, 40, 11)
+    kb, vb = _kv(1, 25, 12)
+    qa.update_and_fetch(ka, va)
+    qb.update_and_fetch(kb, vb)
+    ba.update_and_fetch(ka, va)
+    bb.update_and_fetch(kb, vb)
+
+    qa.extend(qb)
+    ba.extend(bb)
+
+    assert qa._idx == ba._idx
+    assert mx.array_equal(qa.offset, ba.offset)
+    assert mx.array_equal(qa.left_padding, ba.left_padding)
+    assert qa.keys[0].shape[0] == 3  # batch grew to 3 rows
+
+
+def test_extend_both_empty():
+    qa = QuantizedBatchKVCache([1, 2], GS, BITS)
+    qb = QuantizedBatchKVCache([0], GS, BITS)
+    qa.extend(qb)
+    assert qa.offset.shape[0] == 3
+    assert qa.left_padding.shape[0] == 3
+    assert qa.keys is None
+
+
+# --- merge (single-seq -> batch) --------------------------------------------
+
+
+def _seq_cache(n, seed):
+    from mlx_lm.models.cache import KVCache
+
+    c = KVCache()
+    k, v = _kv(1, n, seed)
+    c.update_and_fetch(k, v)
+    return c
+
+
+def test_merge_bookkeeping_matches_batchkvcache():
+    caches_q = [_seq_cache(10, 1), _seq_cache(30, 2), _seq_cache(20, 3)]
+    caches_b = [_seq_cache(10, 1), _seq_cache(30, 2), _seq_cache(20, 3)]
+    q = QuantizedBatchKVCache.merge(caches_q, GS, BITS)
+    b = BatchKVCache.merge(caches_b)
+    assert q.size() == b.size()
+    assert mx.array_equal(q.offset, b.offset)
+    assert mx.array_equal(q.left_padding, b.left_padding)
+
+
+def test_merge_empty_returns_quantized():
+    from mlx_lm.models.cache import KVCache
+
+    q = QuantizedBatchKVCache.merge([KVCache(), KVCache()], GS, BITS)
+    assert isinstance(q, QuantizedBatchKVCache)
+    assert q.empty()
+    # subsequent update quantizes from token 0
+    q.update_and_fetch(*_kv(2, 5, 1))
+    assert not q.empty()
+
+
+# --- extract -----------------------------------------------------------------
+
+
+def test_extract_row_roundtrips():
+    B = 3
+    lp = [0, 2, 1]
+    q = QuantizedBatchKVCache(lp, GS, BITS)
+    q.update_and_fetch(*_kv(B, 15, 5))
+    idx, pad = 1, lp[1]
+    single = q.extract(idx)
+    assert single.keys.shape[0] == 1
+    assert single.offset == single.keys.shape[2]
+    # Content: extract must return the dequantized stored row `idx`, sliced past
+    # its left padding — proves it picked the RIGHT row and real (non-zero) KV,
+    # not just a correctly-shaped tensor.
+    exp_k = _dequantize([m[idx : idx + 1] for m in q.keys], GS, BITS)[
+        :, :, pad : q._idx, :
+    ]
+    exp_v = _dequantize([m[idx : idx + 1] for m in q.values], GS, BITS)[
+        :, :, pad : q._idx, :
+    ]
+    assert single.keys.shape[2] == q._idx - pad
+    assert _max_abs(single.keys, exp_k) == 0.0
+    assert _max_abs(single.values, exp_v) == 0.0
+    assert float(mx.max(mx.abs(single.keys.astype(mx.float32)))) > 0.0  # not zeros
+
+
+def test_extract_empty_cache_returns_empty_kvcache():
+    # codex #2: a request cancelled before its first write reaches extract() on
+    # the empty cache merge() produced (keys is None). Must return an empty
+    # KVCache, not raise TypeError iterating None.
+    from mlx_lm.models.cache import KVCache
+
+    q = QuantizedBatchKVCache.merge([KVCache(), KVCache()], GS, BITS)
+    assert q.keys is None
+    single = q.extract(0)
+    assert isinstance(single, KVCache)
+    assert single.keys is None and single.values is None
+
+
+# --- empty-cache / dtype / fallback edge cases (pr_validate codex review) ----
+
+
+def test_empty_cache_state_is_none_pair():
+    # BLOCKING: reconstruction dequantizes state[0]; an empty cache MUST expose
+    # (None, None, ...) so the scheduler restores an empty KVCache instead of
+    # dequantizing None.
+    from mlx_lm.models.cache import KVCache
+
+    q = QuantizedBatchKVCache.merge([KVCache(), KVCache()], GS, BITS)
+    k, v, off, lp = q.state
+    assert k is None and v is None
+
+
+def test_scheduler_reconstructs_empty_quantized_cache():
+    # BLOCKING (end-to-end): the scheduler's reconstruction branch must restore
+    # an empty QuantizedBatchKVCache snapshot to an empty KVCache without
+    # dequantizing None.
+    from mlx_lm.models.cache import KVCache
+
+    from vllm_mlx.scheduler import Scheduler
+
+    q = QuantizedBatchKVCache([0], GS, BITS)  # empty, never written
+    layer_state = {
+        "state": q.state,  # (None, None, offset, left_padding)
+        "meta_state": q.meta_state,
+        "class_ref": QuantizedBatchKVCache,
+    }
+    sched = Scheduler.__new__(Scheduler)
+    out = sched._reconstruct_cache_from_states([layer_state])
+    assert out is not None
+    assert isinstance(out[0], KVCache)
+    assert out[0].keys is None
+    assert out[0].offset == 0
+
+
+def test_finalize_on_empty_cache_no_write():
+    # NIT: prepare(right_padding=...) then finalize() with no write must settle
+    # padding bookkeeping without iterating None storage.
+    q = QuantizedBatchKVCache([0, 0], GS, BITS)
+    q.prepare(right_padding=[1, 0])
+    q.finalize()  # must not raise
+    assert q.keys is None
+    assert q._right_padding is None
+
+
+def test_merge_falls_back_to_bf16_on_incompatible_dims():
+    # NIT: head_dim=80 admits no supported group size -> merge must degrade to a
+    # plain BatchKVCache instead of raising on the first write.
+    from mlx_lm.generate import BatchKVCache as _BatchKVCache
+    from mlx_lm.models.cache import KVCache
+
+    def _seq(dim, n, seed):
+        c = KVCache()
+        mx.random.seed(seed)
+        x = mx.random.normal((1, H, n, dim)).astype(mx.bfloat16)
+        c.update_and_fetch(x, x)
+        return c
+
+    merged = QuantizedBatchKVCache.merge([_seq(80, 6, 1), _seq(80, 4, 2)], GS, BITS)
+    assert isinstance(merged, _BatchKVCache)
+    assert not isinstance(merged, QuantizedBatchKVCache)
+
+
+def test_merge_preserves_distinct_key_value_dtypes():
+    # NIT: keys/values may carry different dtypes (MLA-like); merge must not cast
+    # values to the key dtype.
+    from mlx_lm.models.cache import KVCache
+
+    def _seq(kd, vd, kdt, vdt, n, seed):
+        c = KVCache()
+        mx.random.seed(seed)
+        c.keys = mx.random.normal((1, H, n, kd)).astype(kdt)
+        c.values = mx.random.normal((1, H, n, vd)).astype(vdt)
+        c.offset = n
+        return c
+
+    # keys bf16, values float16 — both head_dim 64 (quantizes cleanly).
+    merged = QuantizedBatchKVCache.merge(
+        [_seq(64, 64, mx.bfloat16, mx.float16, 5, 1)], GS, BITS
+    )
+    # scales carry the source dtype; values scales must stay float16, keys bfloat16
+    assert merged.keys[1].dtype == mx.bfloat16
+    assert merged.values[1].dtype == mx.float16
+
+
+# --- state round-trip --------------------------------------------------------
+
+
+def test_state_roundtrip_preserves_content():
+    B = 2
+    q = QuantizedBatchKVCache([0, 0], GS, BITS)
+    k, v = _kv(B, 20, 6)
+    out_k, _ = q.update_and_fetch(k, v)
+    st = q.state
+
+    q2 = QuantizedBatchKVCache([0, 0], GS, BITS)
+    q2.state = st
+    q2.meta_state = q.meta_state
+    assert q2._idx == q._idx
+    out_k2 = _dequantize(q2._slice_seq(q2.keys, q2._idx), GS, BITS)
+    assert _max_abs(out_k, out_k2) == 0.0
+
+
+# --- nbytes ------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("bits,ratio", [(8, 0.6), (4, 0.35)])
+def test_nbytes_smaller_than_bf16(bits, ratio):
+    B, n = 2, 512
+    q = QuantizedBatchKVCache([0, 0], GS, bits)
+    b = BatchKVCache([0, 0])
+    k, v = _kv(B, n, 4)
+    q.update_and_fetch(k, v)
+    b.update_and_fetch(k, v)
+    # quantized resident footprint must be well below bf16
+    assert q.nbytes < b.nbytes * ratio
+
+
+# --- _QuantizableKVCache wiring ---------------------------------------------
+
+
+def test_quantizable_kvcache_merge_builds_quantized_batch():
+    a = _QuantizableKVCache(GS, BITS)
+    b = _QuantizableKVCache(GS, BITS)
+    a.update_and_fetch(*_kv(1, 10, 1))
+    b.update_and_fetch(*_kv(1, 20, 2))
+    merged = _QuantizableKVCache.merge([a, b])
+    assert isinstance(merged, QuantizedBatchKVCache)
+    assert merged.size() == 20
+    assert merged._q_group_size == GS and merged._q_bits == BITS
+
+
+def test_quantizable_kvcache_empty_merge():
+    a = _QuantizableKVCache(GS, BITS)
+    b = _QuantizableKVCache(GS, BITS)
+    merged = _QuantizableKVCache.merge([a, b])
+    assert isinstance(merged, QuantizedBatchKVCache)
+    assert merged.empty()
+
+
+# --- install wiring ----------------------------------------------------------
+
+
+def test_install_wraps_only_kvcache_layers():
+    from mlx_lm.models.cache import KVCache, RotatingKVCache
+
+    from vllm_mlx.quantized_batch_cache import install_quantized_batch_cache
+
+    class _FakeBG:
+        def _make_new_cache(self):
+            return [KVCache(), RotatingKVCache(max_size=64), KVCache()]
+
+    bg = _FakeBG()
+    install_quantized_batch_cache(bg, group_size=64, bits=4)
+    caches = bg._make_new_cache()
+    assert isinstance(caches[0], _QuantizableKVCache)
+    assert isinstance(caches[2], _QuantizableKVCache)
+    assert caches[0].q_bits == 4 and caches[0].q_group_size == 64
+    # sliding-window layer left as-is (quantized batched rotating is NYI upstream)
+    assert type(caches[1]).__name__ == "RotatingKVCache"
+
+
+# --- BLOCKING fixes: head_dim/group_size compatibility ----------------------
+
+
+def test_supported_group_size():
+    from vllm_mlx.quantized_batch_cache import supported_group_size
+
+    assert supported_group_size(64, 64) == 64
+    assert supported_group_size(128, 64) == 64
+    assert supported_group_size(96, 64) == 32  # 96 not div by 64, is by 32
+    assert supported_group_size(96, 128) == 32
+    assert supported_group_size(128, 128) == 128
+    assert supported_group_size(80, 64) is None  # 80 not div by 32/64/128
+    assert supported_group_size(40, 128) is None
+
+
+def test_probe_head_dim():
+    from vllm_mlx.quantized_batch_cache import probe_head_dim
+
+    class _Args:
+        head_dim = 128
+
+    class _M:
+        args = _Args()
+
+    assert probe_head_dim(_M()) == 128
+
+    class _Args2:
+        hidden_size = 2048
+        num_attention_heads = 32
+
+    class _M2:
+        args = _Args2()
+
+    assert probe_head_dim(_M2()) == 64
+    assert probe_head_dim(object()) is None
+
+
+def test_update_adjusts_group_size_for_head_dim_96():
+    # head_dim=96 is not divisible by 64 but is by 32 — must auto-adjust, not crash
+    q = QuantizedBatchKVCache([0], group_size=64, bits=8)
+    k = mx.random.normal((1, H, 10, 96)).astype(mx.bfloat16)
+    ok, ov = q.update_and_fetch(k, k)
+    assert q._q_group_size == 32
+    assert ok.shape == (1, H, 10, 96)
+    assert _max_abs(ok, _dequantize(_quantize(k, 32, 8), 32, 8)) == 0.0
+
+
+def test_update_raises_on_incompatible_head_dim():
+    # head_dim=80 is divisible by no supported group size -> clear error
+    q = QuantizedBatchKVCache([0], group_size=64, bits=8)
+    k = mx.random.normal((1, H, 10, 80)).astype(mx.bfloat16)
+    with pytest.raises(ValueError, match="group_size"):
+        q.update_and_fetch(k, k)
+
+
+def test_merge_adjusts_group_size_for_head_dim_96():
+    from mlx_lm.models.cache import KVCache
+
+    c = KVCache()
+    k = mx.random.normal((1, H, 12, 96)).astype(mx.bfloat16)
+    c.update_and_fetch(k, k)
+    merged = QuantizedBatchKVCache.merge([c], group_size=64, bits=8)
+    assert merged._q_group_size == 32  # coerced 64 -> 32 for head_dim=96
+
+
+# --- BLOCKING fix: prefix-cache HIT normalization ---------------------------
+
+
+def test_normalize_preserves_content_and_type():
+    from mlx_lm.models.cache import RotatingKVCache
+
+    from vllm_mlx.quantized_batch_cache import normalize_caches_for_quantization
+
+    restored = _seq_cache(20, 1)
+    norm = normalize_caches_for_quantization(
+        [restored, RotatingKVCache(max_size=64)], GS, BITS
+    )
+    assert isinstance(norm[0], _QuantizableKVCache)
+    assert norm[0].q_group_size == GS and norm[0].q_bits == BITS
+    assert norm[0].offset == restored.offset  # content preserved
+    assert type(norm[1]).__name__ == "RotatingKVCache"  # non-KVCache untouched
+
+
+def test_prefix_hit_merges_to_quantized_like_miss():
+    # A normalized prefix-cache HIT must merge into QuantizedBatchKVCache (same
+    # type as a MISS), so mlx-lm never mixes bf16 and quantized batches (#1197).
+    from vllm_mlx.quantized_batch_cache import normalize_caches_for_quantization
+
+    hit = normalize_caches_for_quantization([_seq_cache(20, 1)], GS, BITS)
+    merged_hit = hit[0].merge([hit[0]])
+    assert isinstance(merged_hit, QuantizedBatchKVCache)
+    assert merged_hit.size() == 20
+
+    miss = _QuantizableKVCache(GS, BITS)
+    merged_miss = _QuantizableKVCache.merge([miss])
+    assert isinstance(merged_miss, QuantizedBatchKVCache)
+
+    # both are the same type -> extend is safe (no bf16-vs-quantized crash)
+    merged_hit.extend(merged_miss)
+    assert merged_hit.size() == 20
+
+
+# --- MAJOR fix: CacheList (hybrid models) recursion -------------------------
+
+
+def _has_cachelist():
+    try:
+        from mlx_lm.models.cache import CacheList  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
+@pytest.mark.skipif(not _has_cachelist(), reason="mlx-lm has no CacheList")
+def test_install_leaves_cachelist_untouched():
+    # CacheList (DeepSeek-V3.2 / LongCat / Baichuan-M1 / Falcon-H1) must pass
+    # through as-is: these models touch cache.keys directly in their forward
+    # pass (e.g. mx.depends(cache[0].keys, ...)), which assumes a raw array, not
+    # a quantized triple. Only the top-level exact KVCache layer is swapped.
+    from mlx_lm.models.cache import CacheList, KVCache
+
+    from vllm_mlx.quantized_batch_cache import install_quantized_batch_cache
+
+    class _FakeBG:
+        def _make_new_cache(self):
+            return [CacheList(KVCache(), KVCache()), KVCache()]
+
+    bg = _FakeBG()
+    install_quantized_batch_cache(bg, group_size=64, bits=8)
+    layers = bg._make_new_cache()
+    assert isinstance(layers[0], CacheList)  # left untouched (bf16)
+    assert all(type(c) is KVCache for c in layers[0].caches)  # inner NOT wrapped
+    assert isinstance(layers[1], _QuantizableKVCache)  # plain KVCache swapped
+
+
+@pytest.mark.skipif(not _has_cachelist(), reason="mlx-lm has no CacheList")
+def test_normalize_leaves_cachelist_untouched():
+    from mlx_lm.models.cache import CacheList, KVCache
+
+    from vllm_mlx.quantized_batch_cache import normalize_caches_for_quantization
+
+    restored = _seq_cache(15, 1)
+    cl = CacheList(_seq_cache(15, 2), _seq_cache(15, 3))
+    out = normalize_caches_for_quantization([restored, cl], GS, BITS)
+    assert isinstance(out[0], _QuantizableKVCache)  # plain KVCache normalized
+    assert isinstance(out[1], CacheList)  # CacheList left untouched (bf16)
+    assert all(type(c) is KVCache for c in out[1].caches)
+
+
+# --- head_dim resolution: one group size, shared by both caches --------------
+
+
+def test_probe_kv_head_dims():
+    from vllm_mlx.quantized_batch_cache import probe_kv_head_dims
+
+    class _Args:
+        head_dim = 128
+
+    class _M:
+        args = _Args()
+
+    assert probe_kv_head_dims(_M()) == (128, 128)
+
+    # Distinct value head dim (v_head_dim) must be probed independently.
+    class _ArgsV:
+        head_dim = 128
+        v_head_dim = 96
+
+    class _MV:
+        args = _ArgsV()
+
+    assert probe_kv_head_dims(_MV()) == (128, 96)
+
+    # hidden_size/num_heads fallback for K, V defaults to K.
+    class _Args2:
+        hidden_size = 2048
+        num_attention_heads = 32
+
+    class _M2:
+        args = _Args2()
+
+    assert probe_kv_head_dims(_M2()) == (64, 64)
+
+    # Unknown -> (None, None).
+    assert probe_kv_head_dims(object()) == (None, None)
+
+
+def test_resolve_kv_quantization():
+    from vllm_mlx.quantized_batch_cache import resolve_kv_quantization
+
+    # Compatible after coercion (96 -> 32): live enabled, gs=32.
+    assert resolve_kv_quantization(96, 96, 64) == (32, False)
+    # Already compatible: unchanged.
+    assert resolve_kv_quantization(128, 128, 64) == (64, False)
+    # Asymmetric K/V dims: gs must divide BOTH (128 ok at 64, 96 forces 32).
+    assert resolve_kv_quantization(128, 96, 64) == (32, False)
+    # No supported size divides both (80): live disabled (retained self-coerces).
+    assert resolve_kv_quantization(80, 80, 64) == (64, True)
+    # Probe failure: live disabled.
+    assert resolve_kv_quantization(None, None, 64) == (64, True)
+    assert resolve_kv_quantization(128, None, 64) == (64, True)
+
+
+def test_scheduler_wires_resolved_group_size_to_live_hook():
+    # End-to-end wiring: a head_dim=96 model must drive the coerced group size
+    # (32) into the live install params and leave the retained cache at its
+    # configured size (self-coerced later). Exercises
+    # Scheduler._init_kv_quantization directly, so deleting the wiring turns red.
+    from vllm_mlx.memory_cache import MemoryCacheConfig
+    from vllm_mlx.scheduler import Scheduler
+
+    class _Args:
+        head_dim = 96
+
+    class _Model:
+        args = _Args()
+
+    class _Cfg:
+        kv_cache_quantization = True
+        kv_cache_quantization_bits = 8
+        kv_cache_quantization_group_size = 64
+        kv_cache_turboquant = None
+
+    sched = Scheduler.__new__(Scheduler)
+    sched.config = _Cfg()
+    sched._init_kv_quantization(_Model())
+
+    # Live hook: coerced to 32 and the install gate is open.
+    assert sched._kv_quant_group_size == 32
+    assert sched._kv_quant_live_disabled is False
+    live_on = (
+        sched.config.kv_cache_quantization
+        and not sched.config.kv_cache_turboquant
+        and not sched._kv_quant_live_disabled
+    )
+    assert live_on is True
+
+    # Retained cache: MemoryCacheConfig keeps quant on and the CONFIGURED gs (64);
+    # per-layer coercion happens in _quantize_cache, not here.
+    mcc = MemoryCacheConfig(
+        kv_quantize=sched.config.kv_cache_quantization,
+        kv_bits=sched.config.kv_cache_quantization_bits,
+        kv_group_size=sched.config.kv_cache_quantization_group_size,
+    )
+    assert mcc.kv_quantize is True
+    assert mcc.kv_group_size == 64
+
+
+def test_scheduler_probe_failure_disables_live_only():
+    # An unprobeable model disables only the LIVE cache; the retained cache is
+    # never gated by the config-level probe (it self-coerces at quantize time).
+    from vllm_mlx.scheduler import Scheduler
+
+    class _Cfg:
+        kv_cache_quantization = True
+        kv_cache_quantization_bits = 8
+        kv_cache_quantization_group_size = 64
+        kv_cache_turboquant = None
+
+    sched = Scheduler.__new__(Scheduler)
+    sched.config = _Cfg()
+    sched._init_kv_quantization(object())  # unprobeable model
+
+    assert sched._kv_quant_live_disabled is True
+    assert sched._kv_quant_group_size == 64  # unchanged
+
+
+def test_live_install_gate_fails_closed_when_init_bypassed():
+    # codex pr_validate BLOCKING: some unit/serve paths build a Scheduler via
+    # __new__ (bypassing __init__ -> _init_kv_quantization), leaving the resolve
+    # attributes absent. The live-install gate MUST fail CLOSED: a missing
+    # _kv_quant_live_disabled has to read as "disabled" so an unprobed,
+    # possibly-incompatible head dim never installs a quantized live cache that
+    # would crash on first write. The gate defaults the flag to True.
+    from vllm_mlx.scheduler import Scheduler
+
+    class _Cfg:  # quantization requested, but the probe never ran
+        kv_cache_quantization = True
+        kv_cache_quantization_bits = 8
+        kv_cache_quantization_group_size = 64
+        kv_cache_turboquant = None
+
+    sched = Scheduler.__new__(Scheduler)
+    sched.config = _Cfg()
+    # NOTE: _init_kv_quantization() deliberately NOT called.
+    assert not hasattr(sched, "_kv_quant_live_disabled")
+
+    # Replicate the real install gate (scheduler.py ~2568). The missing-attr
+    # default MUST be True so the gate is closed.
+    live_on = (
+        getattr(sched.config, "kv_cache_quantization", False)
+        and not getattr(sched.config, "kv_cache_turboquant", None)
+        and not getattr(sched, "_kv_quant_live_disabled", True)
+    )
+    assert live_on is False
+
+
+def test_scheduler_mla_probe_disables_live_but_retained_still_quantizes():
+    # codex MAJOR: DeepSeek-V3 (MLA) probes to (56, 128) via hidden_size/heads +
+    # v_head_dim, which resolves incompatible — so the LIVE cache is (conserv-
+    # atively) bf16. But the retained cache MUST still quantize: its real cached
+    # dims are kv_lora_rank=512 / qk_rope=64, both group-size-64 compatible, and
+    # _quantize_cache coerces against those, NOT the config head dims.
+    from mlx_lm.models.cache import KVCache
+
+    from vllm_mlx.memory_cache import _quantize_cache
+    from vllm_mlx.scheduler import Scheduler
+
+    class _Args:  # DeepSeek-V3-0324 shape
+        hidden_size = 7168
+        num_attention_heads = 128
+        v_head_dim = 128
+
+    class _Model:
+        args = _Args()
+
+    class _Cfg:
+        kv_cache_quantization = True
+        kv_cache_quantization_bits = 8
+        kv_cache_quantization_group_size = 64
+        kv_cache_turboquant = None
+
+    sched = Scheduler.__new__(Scheduler)
+    sched.config = _Cfg()
+    sched._init_kv_quantization(_Model())
+    assert sched._kv_quant_live_disabled is True  # live conservatively bf16
+
+    # Retained: build the MLA-shaped KVCache and quantize it with the configured
+    # gs=64. It must NOT stay bf16 (the pre-fix regression) — 512 and 64 both
+    # quantize at 64.
+    kv = KVCache()
+    klat = mx.random.normal((1, 1, 12, 512)).astype(mx.bfloat16)  # kv_latent
+    kpe = mx.random.normal((1, 1, 12, 64)).astype(mx.bfloat16)  # k_pe
+    kv.update_and_fetch(klat, kpe)
+    out = _quantize_cache([kv], bits=8, group_size=64)
+    assert type(out[0]).__name__ == "QuantizedKVCache"
+    assert out[0].group_size == 64
+
+
+def test_quantize_cache_coerces_and_skips_per_layer():
+    # _quantize_cache resolves the group size against each layer's REAL dims:
+    # head_dim=96 -> 32, head_dim=128 -> 64, head_dim=80 -> keep bf16 (no crash).
+    from mlx_lm.models.cache import KVCache
+
+    from vllm_mlx.memory_cache import _quantize_cache
+
+    def _layer(dim):
+        c = KVCache()
+        x = mx.random.normal((1, 2, 8, dim)).astype(mx.bfloat16)
+        c.update_and_fetch(x, x)
+        return c
+
+    out = _quantize_cache([_layer(96), _layer(128), _layer(80)], bits=8, group_size=64)
+    mx.eval([m for layer in out if layer.keys is not None for m in layer.keys])
+    assert type(out[0]).__name__ == "QuantizedKVCache" and out[0].group_size == 32
+    assert type(out[1]).__name__ == "QuantizedKVCache" and out[1].group_size == 64
+    assert type(out[2]).__name__ == "KVCache"  # head_dim=80: kept bf16, no crash
+
+
+# --- extend quant-param safety (codex review) -------------------------------
+
+
+def test_extend_empty_adopts_other_quant_params():
+    # An empty cache carries its construction-time default; extending it with a
+    # populated cache must adopt the populated params so the triples dequantize
+    # with the right group_size/bits.
+    empty = QuantizedBatchKVCache([0], group_size=64, bits=8)
+    pop = QuantizedBatchKVCache([0], group_size=32, bits=4)
+    pop.update_and_fetch(*_kv(1, 10, 1))
+    empty.extend(pop)
+    assert empty._q_group_size == 32 and empty._q_bits == 4
+
+
+def test_extend_mismatched_params_raises():
+    a = QuantizedBatchKVCache([0], group_size=64, bits=8)
+    a.update_and_fetch(*_kv(1, 10, 1))
+    b = QuantizedBatchKVCache([0], group_size=32, bits=4)
+    b.update_and_fetch(*_kv(1, 10, 2))
+    with pytest.raises(ValueError, match="mismatched quantization"):
+        a.extend(b)

--- a/vllm_mlx/memory_cache.py
+++ b/vllm_mlx/memory_cache.py
@@ -1259,8 +1259,22 @@ def _trim_to_offset(cache: list[Any]) -> list[Any]:
 
 
 def _quantize_cache(cache: list[Any], bits: int = 8, group_size: int = 64) -> list[Any]:
-    """Quantize KVCache layers to reduce memory. Non-KVCache layers are kept as-is."""
+    """Quantize KVCache layers to reduce memory. Non-KVCache layers are kept as-is.
+
+    ``mx.quantize`` groups along the last (head) dimension and requires it
+    divisible by a supported group size (32/64/128). The right dimension is the
+    one ACTUALLY stored in each layer's ``keys``/``values`` — not a generic
+    attention/query head dim inferred from config. That distinction matters for
+    MLA models (e.g. DeepSeek-V3), whose cache holds ``kv_latent`` (512) and
+    ``k_pe`` (64) rather than ``v_head_dim`` (128): a config-derived group size
+    would wrongly reject them, while the real dims quantize cleanly at 64. So
+    coerce ``group_size`` per layer against the actual key/value dims, and keep a
+    layer bf16 when no supported size divides both (e.g. head_dim=80) rather than
+    letting ``to_quantized`` raise (#1197).
+    """
     from mlx_lm.models.cache import KVCache
+
+    from .quantized_batch_cache import supported_group_size
 
     quantized = []
     for layer in cache:
@@ -1268,7 +1282,15 @@ def _quantize_cache(cache: list[Any], bits: int = 8, group_size: int = 64) -> li
             quantized.append(layer)
             continue
         if isinstance(layer, KVCache) and layer.keys is not None:
-            quantized.append(layer.to_quantized(group_size=group_size, bits=bits))
+            k_dim = layer.keys.shape[-1]
+            v_dim = layer.values.shape[-1]
+            gs = supported_group_size(k_dim, group_size)
+            if gs is not None and v_dim != k_dim:
+                gs = supported_group_size(v_dim, gs)
+            if gs is None:
+                quantized.append(layer)  # no supported size -> keep bf16
+            else:
+                quantized.append(layer.to_quantized(group_size=gs, bits=bits))
         else:
             quantized.append(layer)
     return quantized

--- a/vllm_mlx/quantized_batch_cache.py
+++ b/vllm_mlx/quantized_batch_cache.py
@@ -1,0 +1,654 @@
+"""Quantized, continuous-batching KV cache (dequant-on-read).
+
+Background (#1197)
+------------------
+``--kv-cache-dtype int8/int4`` was only ever wired into the memory-aware
+*prefix* cache (:class:`MemoryCacheConfig`). The **live** per-request KV cache
+used by continuous batching is mlx-lm's :class:`~mlx_lm.models.cache.BatchKVCache`,
+which is always bf16 — so a fresh server with ``--disable-prefix-cache`` got no
+memory reduction from the requested dtype at all.
+
+``QuantizedBatchKVCache`` is a drop-in replacement for ``BatchKVCache`` that
+stores keys/values **quantized** (``mx.quantize`` along the head dimension). The
+paths the *model* reads through — ``update_and_fetch`` and ``extract`` —
+dequantize on the way out, so attention/SDPA see bf16 and nothing in the model
+changes. This is the "dequant-on-read" design that vLLM and SGLang both fall
+back to on backends without a fused quantized-attention kernel — it wins back
+the resident-memory footprint (the point of the flag) without a custom kernel.
+
+``state`` / ``meta_state`` are the *serialization* interface (save / restore /
+mid-prefill snapshot), not a model-read path. Like mlx-lm's own
+``QuantizedKVCache``, ``state`` returns the raw quantized triples
+``[packed_uint32, scales, biases]`` plus ``(group_size, bits)`` in
+``meta_state`` so the value round-trips losslessly. mlx-lm's only in-loop
+consumer of ``.state`` is ``mx.eval([c.state ...])``, which is structure-
+agnostic; rapid-mlx's own snapshot reconstruction
+(``Scheduler._reconstruct_cache_from_states``) dequantizes the triples back to a
+bf16 ``KVCache``.
+
+Why this is a mechanical mirror of ``BatchKVCache``
+---------------------------------------------------
+``mx.quantize`` packs only the **last** axis (head_dim). The sequence axis
+(``axis=2``) stays 1:1 with tokens in the packed representation, so every
+token-level bookkeeping operation ``BatchKVCache`` performs — left-padding,
+capacity growth, ``filter`` (row select + left-shift), ``extend``/``merge``
+(right-justified pad + concat), ``trim`` and ``make_mask`` — applies identically
+to each of the three stored tensors ``(packed_uint32, scales, biases)``. The
+quantization axis and the sequence axis are orthogonal.
+
+Threshold semantics
+--------------------
+The live cache quantizes from the first token. ``kv_min_quantize_tokens`` keeps
+its existing meaning for the *retained prefix cache* only; it is intentionally
+not applied to the live cache here (a fresh live cache cannot know its final
+length at construction, and int8/int4 affine quantization of short sequences is
+harmless). Callers that want the live cache left as bf16 simply do not opt in.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import mlx.core as mx
+
+# MUST install the MLX hardware-compat shim BEFORE any `from mlx_lm.*` import.
+# `mlx_lm/__init__.py` re-exports from `mlx_lm.generate`, which captures
+# `mx.new_thread_local_stream(mx.default_device())` at module-import time; on
+# M5 single-stream GPUs that stream is unusable (#404). The shim is idempotent
+# and a no-op on hardware where the original API works.
+from . import _mlx_compat as _mlx_compat
+
+_mlx_compat.install()
+
+from mlx_lm.models.cache import (  # noqa: E402
+    KVCache,
+    _BaseCache,
+    create_causal_mask,
+    dynamic_roll,
+)
+
+
+def _quantize(x: mx.array, group_size: int, bits: int) -> list[mx.array]:
+    """Quantize along the last (head) dim -> [packed_uint32, scales, biases]."""
+    return list(mx.quantize(x, group_size=group_size, bits=bits))
+
+
+def _dequantize(triple: list[mx.array], group_size: int, bits: int) -> mx.array:
+    return mx.dequantize(
+        triple[0], triple[1], triple[2], group_size=group_size, bits=bits
+    )
+
+
+# mx.quantize (affine) only accepts these group sizes, and the quantized
+# dimension must be divisible by the chosen one.
+_SUPPORTED_GROUP_SIZES = (128, 64, 32)
+
+
+def supported_group_size(head_dim: int, requested: int) -> int | None:
+    """Largest supported group size ``<= requested`` that divides ``head_dim``.
+
+    Returns ``None`` when no supported group size (32/64/128) divides
+    ``head_dim`` — e.g. ``head_dim=80`` — in which case the caller must fall
+    back to a bf16 cache instead of quantizing.
+    """
+    for gs in _SUPPORTED_GROUP_SIZES:
+        if gs <= requested and head_dim % gs == 0:
+            return gs
+    return None
+
+
+class QuantizedBatchKVCache(_BaseCache):
+    """Batch-aware KV cache that stores quantized KV and returns bf16.
+
+    Storage layout mirrors :class:`~mlx_lm.models.cache.QuantizedKVCache` — each
+    of ``self.keys`` / ``self.values`` is a 3-element list
+    ``[packed_uint32, scales, biases]`` (or ``None`` when empty) shaped
+    ``(B, n_kv_heads, capacity, *)``. Sequence bookkeeping mirrors
+    :class:`~mlx_lm.models.cache.BatchKVCache` (per-row ``offset`` /
+    ``left_padding`` arrays plus a scalar ``_idx`` fill pointer).
+    """
+
+    step = 256
+
+    def __init__(
+        self,
+        left_padding: list[int],
+        group_size: int = 64,
+        bits: int = 8,
+    ):
+        self.keys: list[mx.array] | None = None
+        self.values: list[mx.array] | None = None
+        self.left_padding = mx.array(left_padding)
+        self.offset = mx.array([-pad for pad in left_padding])
+        self._idx = 0
+        self._right_padding: mx.array | None = None
+        self._q_group_size = group_size
+        self._q_bits = bits
+
+    # -- internal helpers -------------------------------------------------
+
+    def _capacity(self) -> int:
+        return 0 if self.keys is None else self.keys[0].shape[2]
+
+    def _init_storage(
+        self, b: int, n_heads: int, cap: int, head_dim: int, dtype
+    ) -> list[mx.array]:
+        el_per_int = 8 * mx.uint32.size // self._q_bits
+        n_groups = head_dim // self._q_group_size
+        return [
+            mx.zeros((b, n_heads, cap, head_dim // el_per_int), dtype=mx.uint32),
+            mx.zeros((b, n_heads, cap, n_groups), dtype=dtype),
+            mx.zeros((b, n_heads, cap, n_groups), dtype=dtype),
+        ]
+
+    def _slice_seq(self, triple: list[mx.array], upto: int) -> list[mx.array]:
+        return [m[..., :upto, :] for m in triple]
+
+    def _resolve_group_size(self, k_head_dim: int, v_head_dim: int) -> int:
+        """Coerce the group size to one that divides both head dims.
+
+        A best-effort probe at install time normally picks a compatible group
+        size, but this is the last line of defense (e.g. when the probe could
+        not read head_dim). Raises a clear, actionable error rather than letting
+        ``mx.quantize`` surface its opaque divisibility message.
+        """
+        gs = supported_group_size(k_head_dim, self._q_group_size)
+        if gs is not None and v_head_dim != k_head_dim:
+            gs = supported_group_size(v_head_dim, gs)
+        if gs is None:
+            raise ValueError(
+                f"KV cache quantization requires head_dim (K={k_head_dim}, "
+                f"V={v_head_dim}) divisible by a supported group_size "
+                f"(32/64/128); none fits requested group_size={self._q_group_size}. "
+                f"Re-run with --kv-cache-dtype bf16."
+            )
+        return gs
+
+    # -- core -------------------------------------------------------------
+
+    def update_and_fetch(self, keys: mx.array, values: mx.array):
+        B, n_kv_heads, num_steps, k_head_dim = keys.shape
+        v_head_dim = values.shape[-1]
+        prev = self._idx
+
+        if self.keys is None:
+            # First write: lock in a group size compatible with the real head
+            # dims (mirrors the install-time probe; covers the case it failed).
+            self._q_group_size = self._resolve_group_size(k_head_dim, v_head_dim)
+
+        qk = _quantize(keys, self._q_group_size, self._q_bits)
+        qv = _quantize(values, self._q_group_size, self._q_bits)
+
+        if self.keys is None or (prev + num_steps) > self._capacity():
+            n_steps = (self.step + num_steps - 1) // self.step
+            add = n_steps * self.step
+            if self.keys is not None:
+                # Drop any unused reserved tail before growing, mirroring
+                # BatchKVCache so concatenation stays contiguous with _idx.
+                if prev % self.step != 0:
+                    self.keys = self._slice_seq(self.keys, prev)
+                    self.values = self._slice_seq(self.values, prev)
+
+                def _grow(triple):
+                    return [
+                        mx.concatenate(
+                            [
+                                m,
+                                mx.zeros(
+                                    (*m.shape[:2], add, m.shape[-1]), dtype=m.dtype
+                                ),
+                            ],
+                            axis=2,
+                        )
+                        for m in triple
+                    ]
+
+                self.keys = _grow(self.keys)
+                self.values = _grow(self.values)
+            else:
+                self.keys = self._init_storage(
+                    B, n_kv_heads, add, k_head_dim, keys.dtype
+                )
+                self.values = self._init_storage(
+                    B, n_kv_heads, add, v_head_dim, values.dtype
+                )
+
+        self.offset += num_steps
+        self._idx += num_steps
+        for i in range(3):
+            self.keys[i][..., prev : self._idx, :] = qk[i]
+            self.values[i][..., prev : self._idx, :] = qv[i]
+
+        # dequant-on-read: return bf16 K/V so attention/SDPA stays unchanged.
+        # This materializes the current layer's full history in bf16, but only
+        # transiently — MLX frees it before the next layer's dequant runs, while
+        # the resident cache stays quantized. Net decode PEAK memory is therefore
+        # LOWER than a bf16 cache (all layers resident bf16), not higher:
+        # measured int8 0.65x / int4 0.43x of bf16 peak at L=32,B=4,T=4k. Because
+        # decode is memory-bandwidth-bound, the smaller cache also makes each
+        # step FASTER (int8 ~2.3x) despite the dequant. A fused quantized SDPA
+        # (route B) would drop the transient entirely but needs a custom kernel.
+        return (
+            _dequantize(
+                self._slice_seq(self.keys, self._idx), self._q_group_size, self._q_bits
+            ),
+            _dequantize(
+                self._slice_seq(self.values, self._idx),
+                self._q_group_size,
+                self._q_bits,
+            ),
+        )
+
+    def prepare(self, *, left_padding=None, lengths=None, right_padding=None):
+        if left_padding is not None:
+            if self.keys is not None:
+                raise ValueError(
+                    "Left padding can only be added to an empty QuantizedBatchKVCache"
+                )
+            left_padding = mx.array(left_padding)
+            self.left_padding += left_padding
+            self.offset -= left_padding
+
+        if right_padding is not None and max(right_padding) > 0:
+            self._right_padding = mx.array(right_padding)
+
+    def finalize(self):
+        if self._right_padding is not None:
+            padding = self._right_padding
+            if self.keys is not None:
+                self.keys = [
+                    dynamic_roll(m, padding[:, None], axis=2) for m in self.keys
+                ]
+                self.values = [
+                    dynamic_roll(m, padding[:, None], axis=2) for m in self.values
+                ]
+            # No storage yet (no write since prepare) — nothing to roll, but the
+            # padding bookkeeping still has to settle so offset/left_padding stay
+            # consistent with a subsequent first write.
+            self.offset -= padding
+            self.left_padding += padding
+            self._right_padding = None
+
+    # -- state ------------------------------------------------------------
+
+    @property
+    def state(self):
+        if self.keys is None:
+            return None, None, self.offset, self.left_padding
+        if self._idx < self._capacity():
+            k = self._slice_seq(self.keys, self._idx)
+            v = self._slice_seq(self.values, self._idx)
+        else:
+            k, v = self.keys, self.values
+        return k, v, self.offset, self.left_padding
+
+    @state.setter
+    def state(self, v):
+        self.keys, self.values, self.offset, self.left_padding = v
+        self._idx = 0 if self.keys is None else self.keys[0].shape[2]
+
+    @property
+    def meta_state(self):
+        return tuple(map(str, (self._q_group_size, self._q_bits)))
+
+    @meta_state.setter
+    def meta_state(self, v):
+        self._q_group_size, self._q_bits = map(int, v)
+
+    # -- trimming / masking ----------------------------------------------
+
+    def is_trimmable(self):
+        return True
+
+    def trim(self, n):
+        n = min(self._idx, n)
+        self._idx -= n
+        self.offset -= n
+        return n
+
+    def make_mask(self, n: int, return_array: bool = False, **kwargs):
+        return create_causal_mask(
+            n, offset=self._idx, left_padding=self.left_padding, **kwargs
+        )
+
+    # -- batch composition ------------------------------------------------
+
+    def filter(self, batch_indices):
+        """In-place keep only ``batch_indices`` rows (then left-shift padding)."""
+        if self.keys is not None:
+            self.keys = [m[batch_indices] for m in self.keys]
+            self.values = [m[batch_indices] for m in self.values]
+        self.offset = self.offset[batch_indices]
+        self.left_padding = self.left_padding[batch_indices]
+
+        min_left_pad = self.left_padding.min().item()
+        if min_left_pad > 0:
+            if self.keys is not None:
+                self.keys = [m[..., min_left_pad:, :] for m in self.keys]
+                self.values = [m[..., min_left_pad:, :] for m in self.values]
+            self._idx -= min_left_pad
+            self.left_padding -= min_left_pad
+
+    def extend(self, other: QuantizedBatchKVCache):
+        """In-place concatenate ``other``'s rows onto this cache."""
+        # The concatenated triples only dequantize correctly if both caches share
+        # (group_size, bits). In continuous batching they always do (one group
+        # size is resolved per server), but an empty cache may still carry its
+        # construction-time default — adopt the populated cache's params, and
+        # reject a genuine mismatch instead of silently mis-dequantizing.
+        if self.keys is None and other.keys is not None:
+            self._q_group_size, self._q_bits = other._q_group_size, other._q_bits
+        elif (
+            self.keys is not None
+            and other.keys is not None
+            and (self._q_group_size, self._q_bits)
+            != (other._q_group_size, other._q_bits)
+        ):
+            raise ValueError(
+                "Cannot extend QuantizedBatchKVCache with mismatched quantization "
+                f"params: {(self._q_group_size, self._q_bits)} vs "
+                f"{(other._q_group_size, other._q_bits)}"
+            )
+
+        if self.keys is None and other.keys is None:
+            self.left_padding = mx.concatenate([self.left_padding, other.left_padding])
+            self.offset = mx.concatenate([self.offset, other.offset])
+            return
+
+        max_idx = max(self._idx, other._idx)
+        max_size = max(self._capacity(), other._capacity())
+
+        ref = self if self.keys is not None else other
+        H = ref.keys[0].shape[1]
+        key_dims = [m.shape[-1] for m in ref.keys]
+        val_dims = [m.shape[-1] for m in ref.values]
+        key_dtypes = [m.dtype for m in ref.keys]
+        val_dtypes = [m.dtype for m in ref.values]
+
+        def pad(c):
+            Bc = c.offset.shape[0]
+            if c.keys is None:
+                k = [
+                    mx.zeros((Bc, H, 0, d), dtype=dt)
+                    for d, dt in zip(key_dims, key_dtypes)
+                ]
+                v = [
+                    mx.zeros((Bc, H, 0, d), dtype=dt)
+                    for d, dt in zip(val_dims, val_dtypes)
+                ]
+                cur_len = 0
+            else:
+                k, v = list(c.keys), list(c.values)
+                cur_len = c.keys[0].shape[2]
+            left = max_idx - c._idx
+            right = max_size - cur_len - left
+            if right < 0:
+                k = [m[..., :right, :] for m in k]
+                v = [m[..., :right, :] for m in v]
+                right = 0
+            if left != 0 or right != 0:
+                cfg = [(0, 0), (0, 0), (left, right), (0, 0)]
+                k = [mx.pad(m, cfg) for m in k]
+                v = [mx.pad(m, cfg) for m in v]
+            return k, v, c.offset, c.left_padding + left
+
+        ks, vs, offs, lps = zip(pad(self), pad(other))
+        self.keys = [mx.concatenate([a, b], axis=0) for a, b in zip(ks[0], ks[1])]
+        self.values = [mx.concatenate([a, b], axis=0) for a, b in zip(vs[0], vs[1])]
+        self.offset = mx.concatenate(list(offs))
+        self.left_padding = mx.concatenate(list(lps))
+        self._idx = max_idx
+
+    def extract(self, idx: int) -> KVCache:
+        """Extract row ``idx`` as a single-sequence bf16 :class:`KVCache`."""
+        cache = KVCache()
+        if self.keys is None:
+            # ``merge`` returns an empty cache (keys is None) for a fresh live
+            # batch; a request cancelled before its first write reaches here.
+            # Return an empty KVCache rather than iterating ``None``.
+            return cache
+        padding = self.left_padding[idx].item()
+        k = _dequantize(
+            [m[idx : idx + 1, :, padding : self._idx] for m in self.keys],
+            self._q_group_size,
+            self._q_bits,
+        )
+        v = _dequantize(
+            [m[idx : idx + 1, :, padding : self._idx] for m in self.values],
+            self._q_group_size,
+            self._q_bits,
+        )
+        cache.keys = mx.contiguous(k)
+        cache.values = mx.contiguous(v)
+        cache.offset = cache.keys.shape[2]
+        return cache
+
+    @classmethod
+    def merge(cls, caches, group_size: int = 64, bits: int = 8):
+        """Merge single-sequence bf16 caches into one quantized batch cache.
+
+        Falls back to a plain bf16 :class:`BatchKVCache` when the real stored
+        dims admit no supported group size — so an install-time probe that
+        over-estimated compatibility degrades to bf16 instead of aborting the
+        request on the first write.
+        """
+        lengths = [c.size() for c in caches]
+        max_length = max(lengths)
+
+        # No content yet (fresh live batch): return an empty quantized cache so
+        # the subsequent update_and_fetch quantizes from the first token.
+        if max_length == 0:
+            return cls([0] * len(caches), group_size, bits)
+
+        padding = [max_length - length for length in lengths]
+        B = len(caches)
+        H = max(c.keys.shape[1] for c in caches if c.keys is not None)
+        Dk = max(c.keys.shape[3] for c in caches if c.keys is not None)
+        Dv = max(c.values.shape[3] for c in caches if c.values is not None)
+
+        # Resolve the group size against the REAL dims; if none fits, degrade to
+        # a bf16 BatchKVCache rather than raising on the first write.
+        eff_gs = supported_group_size(Dk, group_size)
+        if eff_gs is not None and Dv != Dk:
+            eff_gs = supported_group_size(Dv, eff_gs)
+        if eff_gs is None:
+            from mlx_lm.generate import BatchKVCache
+
+            return BatchKVCache.merge(caches)
+        group_size = eff_gs
+
+        # Keys and values can carry different dtypes (e.g. MLA caches), so resolve
+        # each independently instead of casting values to the key dtype.
+        dt_k = next(iter(c.keys.dtype for c in caches if c.keys is not None))
+        dt_v = next(iter(c.values.dtype for c in caches if c.values is not None))
+
+        obj = cls(padding, group_size, bits)
+        obj._q_group_size = group_size
+
+        keys = mx.zeros((B, H, max_length, Dk), dtype=dt_k)
+        values = mx.zeros((B, H, max_length, Dv), dtype=dt_v)
+        for i, (p, c) in enumerate(zip(padding, caches)):
+            if c.keys is None:
+                continue
+            keys[i : i + 1, :, p : p + c.offset] = c.keys[..., : c.offset, :]
+            values[i : i + 1, :, p : p + c.offset] = c.values[..., : c.offset, :]
+
+        obj.keys = _quantize(keys, group_size, bits)
+        obj.values = _quantize(values, group_size, bits)
+        obj.offset += max_length
+        obj._idx = max_length
+        return obj
+
+    # -- misc -------------------------------------------------------------
+
+    def size(self):
+        return self._idx
+
+    def empty(self):
+        return self.keys is None
+
+    @property
+    def nbytes(self):
+        if self.keys is None:
+            return 0
+        return sum(m.nbytes for m in self.keys) + sum(m.nbytes for m in self.values)
+
+
+class _QuantizableKVCache(KVCache):
+    """Single-sequence bf16 cache whose ``merge`` yields a quantized batch.
+
+    ``BatchGenerator`` builds a fresh single-sequence cache per request via
+    ``make_prompt_cache`` and only decides the *batch* cache type when it merges
+    them (:func:`mlx_lm.generate._merge_caches` calls ``caches[0][i].merge(...)``).
+    Swapping the plain ``KVCache`` for this subclass is therefore the single,
+    minimal hook that makes continuous batching build a quantized batch cache —
+    without patching any mlx-lm internals.
+    """
+
+    def __init__(self, group_size: int = 64, bits: int = 8):
+        super().__init__()
+        self.q_group_size = group_size
+        self.q_bits = bits
+
+    @classmethod
+    def merge(cls, caches):
+        c0 = caches[0]
+        return QuantizedBatchKVCache.merge(
+            caches, group_size=c0.q_group_size, bits=c0.q_bits
+        )
+
+
+def install_quantized_batch_cache(
+    batch_gen: Any, group_size: int = 64, bits: int = 8
+) -> Any:
+    """Wire ``batch_gen``'s continuous batching to a quantized live KV cache.
+
+    ``mlx_lm.generate.BatchGenerator`` builds a fresh single-sequence cache per
+    request via ``_make_new_cache`` and only decides the *batch* cache type when
+    those are merged. Replacing each plain ``KVCache`` layer with
+    :class:`_QuantizableKVCache` (whose ``merge`` yields a
+    :class:`QuantizedBatchKVCache`) is therefore a single, minimal instance-level
+    hook — no mlx-lm internals are patched.
+
+    Only exact top-level ``KVCache`` layers are swapped. Everything else keeps
+    its bf16 behavior:
+
+    * ``RotatingKVCache`` (sliding-window / ``max_kv_size``) — quantized batched
+      sliding-window is NYI upstream (``BatchRotatingKVCache`` raises NYI).
+    * ``ArraysCache`` / ``MambaCache`` — linear/hybrid state, not KV.
+    * ``CacheList`` (hybrid models such as DeepSeek-V3.2, LongCat, Baichuan-M1,
+      Falcon-H1) — deliberately NOT recursed into. Dequant-on-read only holds
+      when the model reads KV exclusively through ``update_and_fetch`` (which
+      returns bf16). These models instead touch ``cache.keys`` directly in their
+      forward pass — e.g. DeepSeek-V3.2 runs
+      ``cache[0].keys = mx.depends(cache[0].keys, (cache[1].keys, ...))`` — which
+      assumes a raw ``mx.array``, not a quantized ``[packed, scales, biases]``
+      triple. Quantizing them is a follow-up requiring per-model handling.
+    """
+    orig_make_new_cache = batch_gen._make_new_cache
+
+    def _quantized_make_new_cache():
+        return [
+            _QuantizableKVCache(group_size, bits) if type(c) is KVCache else c
+            for c in orig_make_new_cache()
+        ]
+
+    batch_gen._make_new_cache = _quantized_make_new_cache
+    return batch_gen
+
+
+def probe_head_dim(model: Any) -> int | None:
+    """Best-effort head dimension of a loaded mlx-lm model; ``None`` if unknown.
+
+    Used at install time to pick a compatible group size (or disable live
+    quantization when no supported group size divides the head dim).
+    """
+    args = getattr(model, "args", None)
+    if args is None:
+        return None
+    hd = getattr(args, "head_dim", None)
+    if isinstance(hd, int) and hd > 0:
+        return hd
+    hs = getattr(args, "hidden_size", None)
+    nh = getattr(args, "num_attention_heads", None)
+    if isinstance(hs, int) and isinstance(nh, int) and nh > 0 and hs % nh == 0:
+        return hs // nh
+    return None
+
+
+def probe_kv_head_dims(model: Any) -> tuple[int | None, int | None]:
+    """Best-effort ``(key, value)`` head dims of a loaded mlx-lm model.
+
+    ``mx.quantize`` groups along the last (head) dimension, and a model may use a
+    distinct value head dim (``v_head_dim``) from its key head dim. Both must be
+    divisible by the chosen group size, so probe both. A dim that cannot be
+    determined comes back as ``None``.
+    """
+    k = probe_head_dim(model)
+    args = getattr(model, "args", None)
+    v = getattr(args, "v_head_dim", None) if args is not None else None
+    if not (isinstance(v, int) and v > 0):
+        v = k  # standard models: value head dim == key head dim
+    return k, v
+
+
+def resolve_kv_quantization(
+    k_head_dim: int | None,
+    v_head_dim: int | None,
+    requested_group_size: int,
+) -> tuple[int, bool]:
+    """Decide the LIVE cache's group size and whether to install it (#1197).
+
+    Only the LIVE continuous-batching cache needs this best-effort, config-level
+    decision: it is chosen ONCE up front (before any token) and cannot fall back
+    to bf16 mid-stream, so an incompatible first write would crash the request.
+    The retained prefix cache is NOT gated here — it self-coerces per layer
+    against the real stored dims at quantize time (see ``_quantize_cache``), which
+    also handles MLA models whose cached dims differ from any config head dim.
+
+    ``mx.quantize`` needs the head dim divisible by a group size in {32,64,128}.
+    Returns ``(group_size, live_disabled)``:
+
+    * probe failed (either dim unknown) OR no supported size divides both dims
+      (e.g. head_dim=80) -> ``live_disabled=True``; the live cache stays bf16.
+      (``group_size`` is returned unchanged and unused.)
+    * otherwise -> the coerced size valid for both dims, live cache enabled.
+
+    Note: because the probe reads generic attention dims, an MLA model
+    (DeepSeek-V3) may be conservatively reported incompatible here and keep a
+    bf16 LIVE cache even though its real cached dims quantize fine — that is a
+    missed optimization, not a regression (the retained cache still quantizes).
+    """
+    if k_head_dim is None or v_head_dim is None:
+        return requested_group_size, True
+    gs = supported_group_size(k_head_dim, requested_group_size)
+    if gs is not None and v_head_dim != k_head_dim:
+        gs = supported_group_size(v_head_dim, gs)
+    if gs is None:
+        return requested_group_size, True
+    return gs, False
+
+
+def normalize_caches_for_quantization(caches: list, group_size: int, bits: int) -> list:
+    """Convert plain ``KVCache`` layers into :class:`_QuantizableKVCache`.
+
+    A prefix-cache HIT hands mlx-lm a restored ``KVCache`` list; without this it
+    would merge into a plain ``BatchKVCache`` while a MISS builds a
+    ``QuantizedBatchKVCache``, and mixing the two in ``extend`` crashes. Running
+    restored caches through here makes both paths converge on the quantized
+    batch type. Existing content (keys/values/offset) is preserved.
+
+    Only exact top-level ``KVCache`` layers are converted, mirroring
+    :func:`install_quantized_batch_cache` exactly so the MISS and HIT paths agree:
+    ``RotatingKVCache`` / hybrid / ``CacheList`` layers pass through untouched
+    (see that function for why ``CacheList`` models stay bf16).
+    """
+    out = []
+    for c in caches:
+        if type(c) is KVCache:
+            q = _QuantizableKVCache(group_size, bits)
+            q.keys, q.values, q.offset = c.keys, c.values, c.offset
+            out.append(q)
+        else:
+            out.append(c)
+    return out

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -2022,6 +2022,9 @@ class Scheduler:
         self._sampler_cache: OrderedDict[tuple, Any] = OrderedDict()
         self._sampler_cache_max = 32
 
+        # #1197: resolve the shared KV-quant group size + per-cache enable flags.
+        self._init_kv_quantization(model)
+
         # Prefix cache for KV state reuse
         self.prefix_cache: PrefixCacheManager | None = None
         self.memory_aware_cache: MemoryAwarePrefixCache | None = None
@@ -2048,6 +2051,12 @@ class Scheduler:
                 cache_config = MemoryCacheConfig(
                     max_memory_mb=self.config.cache_memory_mb,
                     max_memory_percent=self.config.cache_memory_percent,
+                    # #1197: the retained prefix cache keeps its original enable
+                    # flag and configured group size — ``_quantize_cache`` coerces
+                    # the group size PER LAYER against the real stored dims at
+                    # quantize time (and keeps a layer bf16 when none fits), so no
+                    # config-level head_dim probe can wrongly disable or mis-size
+                    # it (that probe misreads MLA models like DeepSeek-V3).
                     kv_quantize=self.config.kv_cache_quantization,
                     kv_bits=self.config.kv_cache_quantization_bits,
                     kv_group_size=self.config.kv_cache_quantization_group_size,
@@ -2448,6 +2457,63 @@ class Scheduler:
             self._sampler_cache.popitem(last=False)
         return sampler
 
+    def _init_kv_quantization(self, model) -> None:
+        """Resolve the LIVE cache's group size + install gate (#1197).
+
+        Only the LIVE continuous-batching cache (``QuantizedBatchKVCache``) needs
+        this up-front, config-level decision: its type is fixed before any token
+        and cannot fall back to bf16 mid-stream, so an incompatible first write
+        would crash the request. ``mx.quantize`` requires the quantized dim
+        divisible by a group size in {32,64,128}: a head_dim=96 model drops
+        64->32, and head_dim=80 (or an unprobeable model) can't be quantized, so
+        the live cache stays bf16 (``_kv_quant_live_disabled``).
+
+        The retained prefix cache is deliberately NOT gated here — it self-coerces
+        per layer against the real stored dims at quantize time
+        (``memory_cache._quantize_cache``), which also correctly handles MLA
+        models (DeepSeek-V3) whose cached dims differ from any config head dim, so
+        the fragile config-level probe never disables or mis-sizes it.
+
+        Extracted from ``__init__`` so the scheduler -> live-hook wiring is
+        unit-testable without loading a model.
+        """
+        self._kv_quant_group_size = self.config.kv_cache_quantization_group_size
+        self._kv_quant_live_disabled = False
+        if not (
+            self.config.kv_cache_quantization
+            and not getattr(self.config, "kv_cache_turboquant", None)
+        ):
+            return
+
+        from .quantized_batch_cache import (
+            probe_kv_head_dims,
+            resolve_kv_quantization,
+        )
+
+        k_hd, v_hd = probe_kv_head_dims(model)
+        requested = self._kv_quant_group_size
+        self._kv_quant_group_size, self._kv_quant_live_disabled = (
+            resolve_kv_quantization(k_hd, v_hd, requested)
+        )
+
+        if self._kv_quant_live_disabled:
+            logger.warning(
+                "[kv-cache] live KV quantization disabled: head_dim (K=%s, V=%s) "
+                "unknown or not divisible by any supported group_size "
+                "(32/64/128); serving a bf16 live cache (retained prefix cache "
+                "quantizes independently). Pass --kv-cache-dtype bf16 to silence.",
+                k_hd,
+                v_hd,
+            )
+        elif self._kv_quant_group_size != requested:
+            logger.info(
+                "[kv-cache] adjusted live group_size %d->%d for head_dim (K=%s, V=%s)",
+                requested,
+                self._kv_quant_group_size,
+                k_hd,
+                v_hd,
+            )
+
     def _create_batch_generator(
         self, sampling_params: SamplingParams
     ) -> BatchGenerator:
@@ -2487,6 +2553,37 @@ class Scheduler:
         except TypeError:
             # mlx-lm < 0.31.3 — no `stream` kwarg; fall back to legacy path.
             bg = BatchGenerator(**bg_kwargs)
+
+        # ``--kv-cache-dtype int8/int4`` must reach the LIVE continuous-batching
+        # KV cache, not just the retained prefix cache (#1197). Swap the
+        # generator's plain ``BatchKVCache`` for a quantized, dequant-on-read
+        # ``QuantizedBatchKVCache``. TurboQuant has its own path, so this only
+        # runs for the plain quantization toggle. The head_dim-compatible group
+        # size (and the disable-on-incompatible decision) were resolved once in
+        # __init__ so the live and retained caches never diverge.
+        # ``getattr`` guards: some unit paths build a Scheduler via
+        # ``__new__`` + a stub config (bypassing __init__), so these attributes
+        # may be absent — treat missing as "no live quantization".
+        self._live_kv_quant: tuple[int, int] | None = None
+        if (
+            getattr(self.config, "kv_cache_quantization", False)
+            and not getattr(self.config, "kv_cache_turboquant", None)
+            and not getattr(self, "_kv_quant_live_disabled", True)
+        ):
+            from .quantized_batch_cache import install_quantized_batch_cache
+
+            bits = getattr(self.config, "kv_cache_quantization_bits", 8)
+            eff_gs = getattr(self, "_kv_quant_group_size", 64)
+            install_quantized_batch_cache(bg, group_size=eff_gs, bits=bits)
+            # Remember the effective params so prefix-cache HITS get normalized
+            # to the same quantized type as MISSES (#1197).
+            self._live_kv_quant = (eff_gs, bits)
+            logger.info(
+                "[kv-cache] live continuous-batching KV cache quantized to "
+                "int%d (group_size=%d)",
+                bits,
+                eff_gs,
+            )
 
         # Server-side wiring for ``--speculative-config '{"method":"mtp"}'``.
         # This installs the vendored PR #990 ``mtp_generate_step`` hot
@@ -3011,7 +3108,34 @@ class Scheduler:
                         KVCache as _KVCache,
                     )
 
-                    if cache_cls is _BatchKVCache:
+                    from vllm_mlx.quantized_batch_cache import (
+                        QuantizedBatchKVCache as _QuantizedBatchKVCache,
+                    )
+
+                    if cache_cls is _QuantizedBatchKVCache:
+                        # state = (k_triple, v_triple, offset, left_padding).
+                        # Mid-prefill save is always batch_size=1, so dequantize
+                        # the quantized triples to a plain bf16 KVCache (#1197).
+                        cache = _KVCache()
+                        if state[0] is None:
+                            # Empty cache: QuantizedBatchKVCache.state returns
+                            # (None, None, ...) before its first write. Restore an
+                            # empty KVCache rather than dequantizing None.
+                            cache.offset = 0
+                        else:
+                            from vllm_mlx.quantized_batch_cache import _dequantize
+
+                            gs, bits = (
+                                (int(meta_state[0]), int(meta_state[1]))
+                                if meta_state
+                                else (64, 8)
+                            )
+                            keys = _dequantize(state[0], gs, bits)
+                            values = _dequantize(state[1], gs, bits)
+                            cache.keys = keys
+                            cache.values = values
+                            cache.offset = keys.shape[2]
+                    elif cache_cls is _BatchKVCache:
                         # BatchKVCache.state = (keys, values, offset, left_padding)
                         keys, values = state[0], state[1]
                         cache = _KVCache()
@@ -4523,6 +4647,21 @@ class Scheduler:
                 request.cached_tokens = 0
                 request.remaining_tokens = request.prompt_token_ids
                 tokens_to_process = request.prompt_token_ids
+
+            # Prefix-cache HIT with live quantization on: normalize the restored
+            # KVCache layers into the same _QuantizableKVCache the MISS path uses,
+            # so mlx-lm merges them into a QuantizedBatchKVCache rather than a bf16
+            # BatchKVCache that then crashes when extended against a quantized
+            # batch (#1197).
+            _lq = getattr(self, "_live_kv_quant", None)
+            if _lq is not None and cache_to_use:
+                from .quantized_batch_cache import (
+                    normalize_caches_for_quantization,
+                )
+
+                cache_to_use = normalize_caches_for_quantization(
+                    cache_to_use, _lq[0], _lq[1]
+                )
 
             # Insert into BatchGenerator with optional cache.
             # Wrap in try/except: if cache shapes are incompatible


### PR DESCRIPTION
Closes #1197

## Problem (#1197)

`--kv-cache-dtype int8/int4` only ever reduced the **retained prefix cache**. The **live** per-request KV cache used by continuous batching (mlx-lm's `BatchKVCache`) stayed bf16, so a server started with `--disable-prefix-cache` got **zero** memory reduction from the requested dtype.

## Fix — dequant-on-read `QuantizedBatchKVCache`

A drop-in replacement for `BatchKVCache` that stores KV **quantized** (`mx.quantize` along head_dim) but returns **bf16** from every outward-facing point (`update_and_fetch` / `state` / `extract`), so the model, attention and SDPA paths are unchanged. This is the same fallback vLLM and SGLang use on backends without a fused quantized-attention kernel. It is installed on the `BatchGenerator` via a minimal instance-level `_make_new_cache` hook whose `_QuantizableKVCache.merge` yields the quantized batch type — **no mlx-lm internals are patched**.

## Group size resolved against the REAL stored dims, not a config head dim

`mx.quantize` needs the quantized dim divisible by a size in `{32,64,128}`. The correct dim is the one actually stored in the cache — which differs from any config attention/head dim for MLA models.

- **Retained prefix cache**: `_quantize_cache` coerces the group size **per layer** against each layer's actual `keys`/`values` last dim, and keeps a layer bf16 when none fits (`head_dim=80`). This correctly handles **MLA models (DeepSeek-V3)** whose cache stores `kv_lora_rank=512` / `qk_rope=64` rather than any config head dim (a config-level probe would infer `7168/128=56` and wrongly reject them). The retained cache is **never** gated by that probe.
- **Live cache**: its type is fixed before the first token and cannot fall back to bf16 mid-stream, so a best-effort `resolve_kv_quantization` probe decides the install up front (`head_dim=96 → 32`; `head_dim=80` or an unprobeable model → stay bf16). `QuantizedBatchKVCache` also self-coerces at its first write / `merge` against the real dims. An MLA model may keep a **bf16 live cache** (probe conservatively reports incompatible) — a missed optimization, **not** a regression, since the retained cache still quantizes.

## Also

- Normalize prefix-cache **HITs** to the same `_QuantizableKVCache` type the MISS path uses, so mlx-lm never mixes a bf16 `BatchKVCache` with a quantized batch in `extend`.
- Reconstruct the quantized live cache back to a bf16 `KVCache` when a mid-prefill boundary snapshot is saved.
- Leave `RotatingKVCache` (sliding-window), Mamba/linear and `CacheList` (hybrid) caches bf16. `CacheList` models (DeepSeek-**V3.2**, LongCat, Baichuan-M1, Falcon-H1) touch `cache.keys` directly in their forward pass (e.g. `mx.depends(cache[0].keys, …)`), which assumes a raw array rather than a quantized triple; quantizing them is a follow-up.

MLLM live quantization remains out of scope (separate follow-up).

## Memory & latency (isolated 32-layer decode, B=4, T=4096)

Dequant-on-read materializes only the **current layer's** history transiently — MLX frees it before the next layer — while the resident cache stays quantized. So peak is **lower** than bf16 (which keeps all layers resident in bf16), and because decode is memory-bandwidth bound, the smaller cache is also faster despite the dequant:

| dtype | resident cache | decode peak | decode latency |
|-------|---------------|-------------|----------------|
| bf16  | 1.00x         | 1.00x       | 1.00x          |
| int8  | 0.531x        | 0.653x      | 0.44x (2.3x faster) |
| int4  | 0.281x        | 0.428x      | 0.29x          |

## Verification

- Bit-exact unit tests vs `BatchKVCache` bookkeeping; per-layer `_quantize_cache` coercion (96→32, 128→64, 80→bf16); MLA-shaped (512/64) retained quantization; scheduler→live-hook wiring.
- Real `BatchGenerator` on Llama-3.2-1B: **int8 live cache 0.53x bf16 bytes, 100% token agreement** vs bf16 baseline (run through the installed wheel).
- Full serve stack with **`--kv-cache-dtype int8 --disable-prefix-cache`**: log confirms `[kv-cache] live continuous-batching KV cache quantized to int8 (group_size=64)`, coherent generation, no cache errors — the exact #1197 scenario now reduces live-cache memory.
