### PR TITLE
docs(mtp): document MTP sidecar aliases are heads, not standalone models

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -115,6 +115,13 @@ rapid-mlx serve qwen3.5-9b-8bit --speculative-config '{"method":"ddtree"}' --por
 rapid-mlx serve <mtp-eligible-qwen-checkpoint> \
   --speculative-config '{"method":"mtp","num_speculative_tokens":1,"disable_auto_k":true}'
 
+# MTP with a sidecar head: serve a FULL base checkpoint and pass the head
+# repo in the `model` field. The `*-mtp-4bit` aliases are sidecar HEADS
+# (~246 MB, model_type qwen3_5_mtp) — do NOT serve them directly.
+# See docs/reference/configuration.md#mtp-sidecar-heads-are-not-standalone-models
+rapid-mlx serve qwen3.6-27b-8bit \
+  --speculative-config '{"method":"mtp","model":"mlx-community/Qwen3.6-27B-MTP-4bit","num_speculative_tokens":3}'
+
 # SuffixDecoding for explicit high-overlap workloads
 rapid-mlx serve gemma-4-12b-4bit \
   --speculative-config '{"method":"suffix","num_speculative_tokens":8}'

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -70,10 +70,44 @@ into the same config path.
 | `{"method":"dflash"}` | Enable the DFlash single-user bridge on validated aliases. |
 | `{"method":"ddtree"}` | Enable experimental DDTree verification on validated aliases. |
 | `{"method":"mtp"}` | Enable MTP speculative decoding for checkpoints accepted by the existing MTP eligibility gate. |
-| `{"method":"mtp","model":"<sidecar>"}` | Reserved for future validated assistant sidecars. Gemma 4 sidecar MTP is currently disabled after greedy-lossless A/B failed. |
+| `{"method":"mtp","model":"<sidecar-head-repo>"}` | Attach a standalone MTP **sidecar head** (e.g. `mlx-community/Qwen3.6-27B-MTP-4bit`) to a full base checkpoint. The base must be MTP-eligible; the head repo goes in the `model` field — **not** in the `serve` positional. See [MTP sidecar heads are not standalone models](#mtp-sidecar-heads-are-not-standalone-models) below. Gemma 4 sidecar MTP remains disabled after its greedy-lossless A/B failed. |
 | `{"method":"mtp","num_speculative_tokens":3}` | Set the MTP max-K controller ceiling. |
 | `{"method":"mtp","disable_auto_k":true}` | Disable the MTP EV depth controller for fixed-K parity benches. |
 | `{"method":"suffix","num_speculative_tokens":8}` | Enable explicit SuffixDecoding for high-overlap workloads. |
+
+#### MTP sidecar heads are not standalone models
+
+The `*-mtp-4bit` aliases — `qwen3.6-27b-mtp-4bit`
+(`mlx-community/Qwen3.6-27B-MTP-4bit`) and `qwen3.6-35b-mtp-4bit`
+(`mlx-community/Qwen3.6-35B-A3B-MTP-4bit`) — resolve to **MTP sidecar
+heads**, not servable checkpoints. Each repo (~246 MB) ships only the
+multi-token-prediction module — an `fc.*` fusion projection, a single
+`layers.0.*` predictor layer, the `pre_fc_norm_embedding` /
+`pre_fc_norm_hidden` norms, and a final `norm` — with no full transformer
+to generate from. Their `config.json` `model_type` is `qwen3_5_mtp`,
+which is intentionally **not** in the MTP eligibility allowlist.
+
+Serving a head directly is rejected by design — the alias name contains
+`mtp`, but the repo is a draft head, not a model:
+
+```bash
+# Rejected: qwen3.6-27b-mtp-4bit is a sidecar head, not a servable checkpoint
+rapid-mlx serve qwen3.6-27b-mtp-4bit --speculative-config '{"method":"mtp"}'
+```
+
+Instead, serve a **full base checkpoint** and pass the head repo in the
+`model` field of `--speculative-config`, so MTP drafts against the
+attached head:
+
+```bash
+# Correct: full base checkpoint + head repo in the `model` field
+rapid-mlx serve qwen3.6-27b-8bit \
+  --speculative-config '{"method":"mtp","model":"mlx-community/Qwen3.6-27B-MTP-4bit","num_speculative_tokens":3}'
+```
+
+Pair each head with a base of the same size class: `Qwen3.6-27B-MTP-4bit`
+with a `qwen3.6-27b-*` base, and `Qwen3.6-35B-A3B-MTP-4bit` with a
+`qwen3.6-35b-*` base.
 
 ### MCP Options
 


### PR DESCRIPTION
## Why

Because the alias name contains "mtp", a naive user reasonably assumes `qwen3.6-27b-mtp-4bit` is a servable MTP model and runs `rapid-mlx serve qwen3.6-27b-mtp-4bit --speculative-config '{"method":"mtp"}'` — which the engine rejects. The rejection is correct (the repo is a head, not a model) but the docs never explained the trap or the correct sidecar form, so the failure looks like a bug. This documents the mechanism so the rejection is expected and the working invocation is discoverable.

## The trap

The `*-mtp-4bit` aliases resolve to MTP **sidecar heads**, not full servable checkpoints:

- `qwen3.6-27b-mtp-4bit` → `mlx-community/Qwen3.6-27B-MTP-4bit`
- `qwen3.6-35b-mtp-4bit` → `mlx-community/Qwen3.6-35B-A3B-MTP-4bit`

Each repo is ~246 MB and ships only the multi-token-prediction module (an `fc.*` fusion projection, a single `layers.0.*` predictor layer, the `pre_fc_norm_embedding` / `pre_fc_norm_hidden` norms, and a final `norm`) — there is no full transformer to generate from. Their `config.json` `model_type` is `qwen3_5_mtp`, which is intentionally **not** in the MTP eligibility allowlist (`_SUPPORTED_MODEL_TYPES` in `vllm_mlx/spec_decode/mtp/detect.py` = `qwen3_5`, `qwen3_5_moe`, `hy_v3`).

So a naive user runs:

```bash
# Rejected by design — the alias name contains "mtp" but the repo is a head, not a model
rapid-mlx serve qwen3.6-27b-mtp-4bit --speculative-config '{"method":"mtp"}'
```

…and gets a confusing rejection.

## Correct usage

Serve a **full base checkpoint** and pass the head repo in the `model` field of `--speculative-config` (which the CLI maps to `args.mtp_sidecar`, `vllm_mlx/cli.py`):

```bash
rapid-mlx serve qwen3.6-27b-8bit \
  --speculative-config '{"method":"mtp","model":"mlx-community/Qwen3.6-27B-MTP-4bit","num_speculative_tokens":3}'
```

Pair each head with a base of the same size class (`Qwen3.6-27B-MTP-4bit` ↔ `qwen3.6-27b-*`, `Qwen3.6-35B-A3B-MTP-4bit` ↔ `qwen3.6-35b-*`).

## Changes (docs-only)

- **`docs/reference/configuration.md`** — rewrote the `{"method":"mtp","model":...}` row (was "reserved for future") to describe the sidecar-head mechanism, and added a **"MTP sidecar heads are not standalone models"** subsection with the rejected vs. correct invocations.
- **`docs/reference/cli.md`** — added a sidecar `serve` example next to the existing MTP examples, with an inline warning not to serve the `*-mtp-4bit` aliases directly.

No engine, spec-decode, scheduler, CLI, or `aliases.json` changes. `aliases.json` uses a closed-key schema with no human-readable annotation field, so the head aliases are documented in the reference docs rather than annotated inline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)