### PR TITLE
fix(mtp): eliminate intermittent empty response on Qwen3.6 MTP sidecar path

### DIFF
--- a/tests/test_mtp_spec_decode.py
+++ b/tests/test_mtp_spec_decode.py
@@ -1769,6 +1769,36 @@ def test_inject_refuses_explicit_sidecar_with_malformed_packing(tmp_path):
     )
 
 
+def test_inject_refuses_corrupt_sidecar_file_without_raising(tmp_path):
+    """A truncated/unreadable safetensors sidecar makes ``mx.load`` raise —
+    codex flagged (PR #1201) that this exception was UNGUARDED and would
+    escape ``inject_mtp_support`` instead of hitting the same return-False
+    fail-safe as every other bad-sidecar path (malformed packing, shape
+    mismatch, dtype mismatch, ...). A corrupt file on disk (partial
+    download, disk error) must degrade the same way: refuse injection,
+    never abort the request mid-generation.
+    """
+    from vllm_mlx.spec_decode.mtp.qwen3_5_inject import inject_mtp_support
+
+    try:
+        base = _build_tiny_qwen3_5_text_model()
+    except (TypeError, AttributeError) as exc:
+        pytest.skip(f"Qwen3.5 TextModelArgs schema mismatch: {exc}")
+
+    sidecar_path = tmp_path / "corrupt-sidecar.safetensors"
+    sidecar_path.write_bytes(b"not a real safetensors file" * 4)
+
+    result = inject_mtp_support(base, mtp_sidecar=str(sidecar_path))
+    assert result is False, (
+        "inject_mtp_support should refuse (return False) a corrupt sidecar "
+        "file, not raise mx.load's exception mid-request."
+    )
+    assert not hasattr(base, "mtp"), (
+        "inject refused but still attached an MTP module — the refusal must "
+        "leave the base model untouched (plain path)."
+    )
+
+
 def test_inject_refuses_sidecar_with_shape_mismatched_non_fc_tensor(tmp_path):
     """The fc-derived quantization is applied UNIFORMLY across the module.
     A sidecar whose fc is well-formed but another tensor's shape disagrees

--- a/tests/test_mtp_spec_decode.py
+++ b/tests/test_mtp_spec_decode.py
@@ -1462,6 +1462,136 @@ def test_inject_mtp_support_refuses_synthetic_sidecar_missing_tensor():
         )
 
 
+def test_detect_sidecar_quantization_reads_config_json(tmp_path):
+    """The sidecar's own ``config.json`` quantization block is the source
+    of truth for how to quantize the MTP module.
+
+    Regression anchor for the 8-bit-base + 4-bit-sidecar empty-response
+    bug: the module must be quantized to match the sidecar it loads,
+    which is read here — not the base model.
+    """
+    import json
+
+    from vllm_mlx.spec_decode.mtp.qwen3_5_inject import _detect_sidecar_quantization
+
+    weights_file = tmp_path / "model.safetensors"
+    weights_file.write_bytes(b"")  # content irrelevant; only sibling config is read
+    (tmp_path / "config.json").write_text(
+        json.dumps({"quantization": {"group_size": 64, "bits": 4, "mode": "affine"}})
+    )
+    assert _detect_sidecar_quantization(weights_file) == {"bits": 4, "group_size": 64}
+
+
+def test_detect_sidecar_quantization_missing_or_malformed_returns_none(tmp_path):
+    """No config.json / no quantization block / non-int fields → ``None``
+    so the caller falls back to base-model detection (pre-fix behavior,
+    still correct for same-bit pairings)."""
+    import json
+
+    from vllm_mlx.spec_decode.mtp.qwen3_5_inject import _detect_sidecar_quantization
+
+    wf = tmp_path / "model.safetensors"
+    wf.write_bytes(b"")
+    # (a) no config.json at all (bare hand-assembled sidecar).
+    assert _detect_sidecar_quantization(wf) is None
+    # (b) config.json without a quantization block (an FP sidecar).
+    (tmp_path / "config.json").write_text(json.dumps({"model_type": "qwen3_5"}))
+    assert _detect_sidecar_quantization(wf) is None
+    # (c) quantization present but ``bits`` is a bool (int subclass) —
+    # must NOT be mistaken for a 1-bit quantization.
+    (tmp_path / "config.json").write_text(
+        json.dumps({"quantization": {"group_size": 64, "bits": True}})
+    )
+    assert _detect_sidecar_quantization(wf) is None
+
+
+def test_inject_quantizes_mtp_to_sidecar_bits_not_base_bits(tmp_path):
+    """Regression: an 8-bit base paired with a 4-bit MTP sidecar must
+    quantize the MTP module to the SIDECAR's 4 bits, not the base's 8.
+
+    Before the fix, the MTP module was quantized to the *base* model's
+    bit-width; loading the differently-packed sidecar tensors left the
+    ``fc`` layer's packed ``weight`` inconsistent with its ``bits``
+    attribute, so ``mx.quantized_matmul`` raised at the first MTP draft
+    step — surfacing to the client as an intermittent EMPTY response
+    (``prompt_tokens=0``) once the depth controller began speculating.
+    Mirrors the shipped pairing ``Qwen3.6-27B-MLX-8bit`` +
+    ``Qwen3.6-27B-MTP-4bit``.
+    """
+    import json
+
+    import mlx.core as _mx
+    import mlx.nn as _nn
+    from mlx.utils import tree_flatten
+
+    from vllm_mlx.spec_decode.mtp.head import build_mtp_module
+    from vllm_mlx.spec_decode.mtp.qwen3_5_inject import (
+        _detect_base_quantization,
+        inject_mtp_support,
+        validate_mtp_support,
+    )
+
+    try:
+        base = _build_tiny_qwen3_5_text_model()
+    except (TypeError, AttributeError) as exc:
+        pytest.skip(f"Qwen3.5 TextModelArgs schema mismatch: {exc}")
+
+    _GROUP = 32
+    _BASE_BITS = 8
+    _SIDECAR_BITS = 4
+
+    # Quantize the BASE at 8-bit so ``_detect_base_quantization`` (the
+    # pre-fix source) returns 8-bit — the WRONG width for a 4-bit sidecar.
+    _nn.quantize(base.model, group_size=_GROUP, bits=_BASE_BITS)
+    assert _detect_base_quantization(base) == {
+        "bits": _BASE_BITS,
+        "group_size": _GROUP,
+    }
+
+    # Build a 4-bit MTP sidecar (weights + a config.json declaring 4-bit).
+    args = base.args
+    template = build_mtp_module(args, int(args.mtp_num_hidden_layers))
+    _nn.quantize(template, group_size=_GROUP, bits=_SIDECAR_BITS)
+    _mx.eval(template.parameters())
+    flat = dict(tree_flatten(template.parameters()))
+    _mx.save_safetensors(str(tmp_path / "model.safetensors"), flat)
+    (tmp_path / "config.json").write_text(
+        json.dumps(
+            {
+                "quantization": {
+                    "group_size": _GROUP,
+                    "bits": _SIDECAR_BITS,
+                    "mode": "affine",
+                }
+            }
+        )
+    )
+
+    injected = inject_mtp_support(base, mtp_sidecar=str(tmp_path))
+    assert injected is True, (
+        "inject_mtp_support returned False on an 8-bit base + 4-bit sidecar; "
+        "the module was likely quantized to the base's 8-bit and load_weights "
+        "or coverage-check rejected the 4-bit tensors."
+    )
+    assert validate_mtp_support(base) is True
+
+    # The MTP fc layer must carry the SIDECAR's 4 bits, not the base's 8.
+    assert isinstance(base.mtp.fc, _nn.QuantizedLinear)
+    assert int(base.mtp.fc.bits) == _SIDECAR_BITS, (
+        f"MTP fc quantized to {base.mtp.fc.bits}-bit; expected the sidecar's "
+        f"{_SIDECAR_BITS}-bit. Quantizing to the base model's bits reintroduces "
+        "the quantized_matmul weight/scales mismatch (empty-response bug)."
+    )
+
+    # And the draft forward must run without the quantized_matmul crash —
+    # this is the exact call that raised in the field repro.
+    hidden = _mx.zeros((1, 1, int(args.hidden_size)), dtype=_mx.float32)
+    next_ids = _mx.array([[0]], dtype=_mx.uint32)
+    logits = base.mtp_forward(hidden, next_ids, base.make_mtp_cache())
+    _mx.eval(logits)
+    assert logits.shape[-1] == int(args.vocab_size)
+
+
 # ---------------------------------------------------------------------------
 # 8. Generator loop — chain MTP verify/accept logic with mocked model
 # ---------------------------------------------------------------------------

--- a/tests/test_mtp_spec_decode.py
+++ b/tests/test_mtp_spec_decode.py
@@ -1377,9 +1377,10 @@ def test_inject_mtp_support_loads_synthetic_sidecar():
 
     # Build the MTP head separately so we can capture its random-init
     # weights, write them to disk, and verify the inject loads them
-    # byte-equally. (Note: this tiny model is FP, so no quantize step
-    # — the inject's _detect_base_quantization returns None and the
-    # MTP module stays FP, matching the sidecar layout.)
+    # byte-equally. (Note: this tiny model is FP, so the sidecar ships a
+    # config.json declaring no quantization block — the inject detects a
+    # full-precision sidecar and keeps the MTP module FP, matching the
+    # sidecar layout.)
     args = model_a.args
     mtp_template = build_mtp_module(args, int(args.mtp_num_hidden_layers))
     _mx.eval(mtp_template.parameters())
@@ -1389,6 +1390,8 @@ def test_inject_mtp_support_loads_synthetic_sidecar():
     with tempfile.TemporaryDirectory() as tmp:
         sidecar_path = Path(tmp) / "synthetic-mtp-head.safetensors"
         _mx.save_safetensors(str(sidecar_path), flat)
+        # Full-precision sidecar (no fc.scales, no config.json) — recognised
+        # as FP from its tensors, so the MTP module is kept full-precision.
 
         # Build a fresh model (so MTP head random init differs from
         # the persisted template), then inject with the synthetic
@@ -1453,6 +1456,9 @@ def test_inject_mtp_support_refuses_synthetic_sidecar_missing_tensor():
     with tempfile.TemporaryDirectory() as tmp:
         sidecar_path = Path(tmp) / "crippled-sidecar.safetensors"
         _mx.save_safetensors(str(sidecar_path), crippled)
+        # FP sidecar (no fc.scales): the quantization step keeps the MTP
+        # module FP, so the inject reaches the coverage check under test —
+        # which must catch the dropped tensor.
 
         fresh_model = _build_tiny_qwen3_5_text_model()
         result = inject_mtp_support(fresh_model, mtp_sidecar=str(sidecar_path))
@@ -1462,47 +1468,134 @@ def test_inject_mtp_support_refuses_synthetic_sidecar_missing_tensor():
         )
 
 
-def test_detect_sidecar_quantization_reads_config_json(tmp_path):
-    """The sidecar's own ``config.json`` quantization block is the source
-    of truth for how to quantize the MTP module.
+@pytest.mark.parametrize("bits", [2, 3, 4, 5, 6, 8])
+@pytest.mark.parametrize("group_size", [32, 64, 128])
+def test_infer_sidecar_fc_quantization_recovers_bits_and_group_size(bits, group_size):
+    """The sidecar's own tensors are the source of truth: inverting the
+    packed ``fc.weight`` / ``fc.scales`` shapes recovers the exact
+    ``(bits, group_size)`` it was quantized with — no config.json needed.
 
     Regression anchor for the 8-bit-base + 4-bit-sidecar empty-response
-    bug: the module must be quantized to match the sidecar it loads,
-    which is read here — not the base model.
+    bug: the module is quantized to match the sidecar it loads, read off
+    the sidecar tensors — not the base model, not a config proxy.
     """
-    import json
+    import mlx.core as _mx
+    import mlx.nn as _nn
+    from mlx.utils import tree_flatten
 
-    from vllm_mlx.spec_decode.mtp.qwen3_5_inject import _detect_sidecar_quantization
-
-    weights_file = tmp_path / "model.safetensors"
-    weights_file.write_bytes(b"")  # content irrelevant; only sibling config is read
-    (tmp_path / "config.json").write_text(
-        json.dumps({"quantization": {"group_size": 64, "bits": 4, "mode": "affine"}})
+    from vllm_mlx.spec_decode.mtp.head import build_mtp_module
+    from vllm_mlx.spec_decode.mtp.qwen3_5_inject import (
+        _infer_sidecar_fc_quantization,
     )
-    assert _detect_sidecar_quantization(weights_file) == {"bits": 4, "group_size": 64}
+
+    try:
+        base = _build_tiny_qwen3_5_text_model()
+    except (TypeError, AttributeError) as exc:
+        pytest.skip(f"Qwen3.5 TextModelArgs schema mismatch: {exc}")
+
+    args = base.args
+    fp = build_mtp_module(args, int(args.mtp_num_hidden_layers))
+    fc_out_dims, fc_in_dims = (int(d) for d in fp.fc.weight.shape)
+
+    # Quantize a standalone Linear matching the fc — NOT the whole module,
+    # whose other layers are only ``hidden_size``-wide and can't be
+    # quantized at group_size 128 in this tiny fixture.
+    fc = _nn.Linear(fc_in_dims, fc_out_dims, bias=False)
+    qfc = _nn.QuantizedLinear.from_linear(fc, group_size, bits)
+    _mx.eval(qfc.parameters())
+    flat = {f"fc.{k}": v for k, v in dict(tree_flatten(qfc.parameters())).items()}
+    assert "fc.scales" in flat, "quantized fc should carry a scales tensor"
+
+    assert _infer_sidecar_fc_quantization(flat, fc_out_dims, fc_in_dims) == {
+        "bits": bits,
+        "group_size": group_size,
+    }
 
 
-def test_detect_sidecar_quantization_missing_or_malformed_returns_none(tmp_path):
-    """No config.json / no quantization block / non-int fields → ``None``
-    so the caller falls back to base-model detection (pre-fix behavior,
-    still correct for same-bit pairings)."""
-    import json
+def test_infer_sidecar_fc_quantization_full_precision_returns_none():
+    """A full-precision fc has no ``fc.scales`` tensor, so the inference
+    returns ``None`` and the caller keeps the MTP module FP — no config
+    metadata required (fixes the metadata-less-FP-sidecar regression)."""
+    from mlx.utils import tree_flatten
 
-    from vllm_mlx.spec_decode.mtp.qwen3_5_inject import _detect_sidecar_quantization
+    from vllm_mlx.spec_decode.mtp.head import build_mtp_module
+    from vllm_mlx.spec_decode.mtp.qwen3_5_inject import _infer_sidecar_fc_quantization
 
-    wf = tmp_path / "model.safetensors"
-    wf.write_bytes(b"")
-    # (a) no config.json at all (bare hand-assembled sidecar).
-    assert _detect_sidecar_quantization(wf) is None
-    # (b) config.json without a quantization block (an FP sidecar).
-    (tmp_path / "config.json").write_text(json.dumps({"model_type": "qwen3_5"}))
-    assert _detect_sidecar_quantization(wf) is None
-    # (c) quantization present but ``bits`` is a bool (int subclass) —
-    # must NOT be mistaken for a 1-bit quantization.
-    (tmp_path / "config.json").write_text(
-        json.dumps({"quantization": {"group_size": 64, "bits": True}})
+    try:
+        base = _build_tiny_qwen3_5_text_model()
+    except (TypeError, AttributeError) as exc:
+        pytest.skip(f"Qwen3.5 TextModelArgs schema mismatch: {exc}")
+
+    args = base.args
+    fp = build_mtp_module(args, int(args.mtp_num_hidden_layers))
+    fc_out_dims, fc_in_dims = (int(d) for d in fp.fc.weight.shape)
+    flat = dict(tree_flatten(fp.parameters()))
+    assert "fc.scales" not in flat
+    assert _infer_sidecar_fc_quantization(flat, fc_out_dims, fc_in_dims) is None
+
+
+def test_infer_sidecar_fc_quantization_raises_on_malformed_packing():
+    """``fc.scales`` present but a packing we cannot interpret — an
+    unsupported derived width, or a missing companion ``fc.weight`` —
+    raises ``ValueError`` so the caller refuses rather than mis-pack."""
+    import mlx.core as _mx
+
+    from vllm_mlx.spec_decode.mtp.head import build_mtp_module
+    from vllm_mlx.spec_decode.mtp.qwen3_5_inject import _infer_sidecar_fc_quantization
+
+    try:
+        base = _build_tiny_qwen3_5_text_model()
+    except (TypeError, AttributeError) as exc:
+        pytest.skip(f"Qwen3.5 TextModelArgs schema mismatch: {exc}")
+
+    args = base.args
+    fp = build_mtp_module(args, int(args.mtp_num_hidden_layers))
+    fc_out_dims, fc_in_dims = (int(d) for d in fp.fc.weight.shape)
+
+    # (a) shapes that invert to an unsupported width. For in=fc_in_dims,
+    # weight cols = in*7//32 and scales cols = in//32 imply bits=7 (not an
+    # MLX affine width) → ValueError.
+    packed_cols = fc_in_dims * 7 // 32
+    scale_cols = fc_in_dims // 32
+    bad = {
+        "fc.weight": _mx.zeros((fc_out_dims, packed_cols), dtype=_mx.uint32),
+        "fc.scales": _mx.zeros((fc_out_dims, scale_cols), dtype=_mx.float32),
+    }
+    with pytest.raises(ValueError):
+        _infer_sidecar_fc_quantization(bad, fc_out_dims, fc_in_dims)
+
+    # (b) scales present but the companion weight is missing entirely.
+    with pytest.raises(ValueError):
+        _infer_sidecar_fc_quantization(
+            {"fc.scales": _mx.zeros((fc_out_dims, fc_in_dims // 32))},
+            fc_out_dims,
+            fc_in_dims,
+        )
+
+    # (c) truncated quantized sidecar: a PACKED fc.weight (4-bit width)
+    # but no fc.scales. Must NOT be mistaken for full-precision (which
+    # would load a packed weight into an nn.Linear and crash later) —
+    # the shape mismatch against the FP dims raises.
+    with pytest.raises(ValueError):
+        _infer_sidecar_fc_quantization(
+            {
+                "fc.weight": _mx.zeros(
+                    (fc_out_dims, fc_in_dims * 4 // 32), dtype=_mx.uint32
+                )
+            },
+            fc_out_dims,
+            fc_in_dims,
+        )
+
+    # A correctly-shaped FP fc.weight with no scales is fine (returns None).
+    assert (
+        _infer_sidecar_fc_quantization(
+            {"fc.weight": _mx.zeros((fc_out_dims, fc_in_dims), dtype=_mx.float32)},
+            fc_out_dims,
+            fc_in_dims,
+        )
+        is None
     )
-    assert _detect_sidecar_quantization(wf) is None
 
 
 def test_inject_quantizes_mtp_to_sidecar_bits_not_base_bits(tmp_path):
@@ -1518,8 +1611,6 @@ def test_inject_quantizes_mtp_to_sidecar_bits_not_base_bits(tmp_path):
     Mirrors the shipped pairing ``Qwen3.6-27B-MLX-8bit`` +
     ``Qwen3.6-27B-MTP-4bit``.
     """
-    import json
-
     import mlx.core as _mx
     import mlx.nn as _nn
     from mlx.utils import tree_flatten
@@ -1548,24 +1639,14 @@ def test_inject_quantizes_mtp_to_sidecar_bits_not_base_bits(tmp_path):
         "group_size": _GROUP,
     }
 
-    # Build a 4-bit MTP sidecar (weights + a config.json declaring 4-bit).
+    # Build a 4-bit MTP sidecar — weights only, NO config.json: the
+    # quantization is inferred from the sidecar tensors themselves.
     args = base.args
     template = build_mtp_module(args, int(args.mtp_num_hidden_layers))
     _nn.quantize(template, group_size=_GROUP, bits=_SIDECAR_BITS)
     _mx.eval(template.parameters())
     flat = dict(tree_flatten(template.parameters()))
     _mx.save_safetensors(str(tmp_path / "model.safetensors"), flat)
-    (tmp_path / "config.json").write_text(
-        json.dumps(
-            {
-                "quantization": {
-                    "group_size": _GROUP,
-                    "bits": _SIDECAR_BITS,
-                    "mode": "affine",
-                }
-            }
-        )
-    )
 
     injected = inject_mtp_support(base, mtp_sidecar=str(tmp_path))
     assert injected is True, (
@@ -1590,6 +1671,330 @@ def test_inject_quantizes_mtp_to_sidecar_bits_not_base_bits(tmp_path):
     logits = base.mtp_forward(hidden, next_ids, base.make_mtp_cache())
     _mx.eval(logits)
     assert logits.shape[-1] == int(args.vocab_size)
+
+
+def test_inject_keeps_mtp_full_precision_for_fp_sidecar(tmp_path):
+    """A quantized base paired with a full-precision sidecar must leave
+    the MTP module FP — NOT quantize it to the base's bits (which would
+    mispack the FP sidecar tensors on load). Full-precision is recognised
+    from the ABSENCE of ``fc.scales`` in the sidecar tensors, with NO
+    config.json — the metadata-less-FP-sidecar path that previously
+    worked and must keep working."""
+    import mlx.core as _mx
+    import mlx.nn as _nn
+    from mlx.utils import tree_flatten
+
+    from vllm_mlx.spec_decode.mtp.head import build_mtp_module
+    from vllm_mlx.spec_decode.mtp.qwen3_5_inject import (
+        inject_mtp_support,
+        validate_mtp_support,
+    )
+
+    try:
+        base = _build_tiny_qwen3_5_text_model()
+    except (TypeError, AttributeError) as exc:
+        pytest.skip(f"Qwen3.5 TextModelArgs schema mismatch: {exc}")
+
+    # Quantize the base — pre-fix, this drove the MTP module's quantization.
+    _nn.quantize(base.model, group_size=32, bits=8)
+
+    # Build a full-precision MTP sidecar (no quantize, no config.json) —
+    # the fc has no scales tensor, so it is recognised as FP.
+    args = base.args
+    template = build_mtp_module(args, int(args.mtp_num_hidden_layers))
+    _mx.eval(template.parameters())
+    flat = dict(tree_flatten(template.parameters()))
+    _mx.save_safetensors(str(tmp_path / "model.safetensors"), flat)
+
+    injected = inject_mtp_support(base, mtp_sidecar=str(tmp_path))
+    assert injected is True
+    assert validate_mtp_support(base) is True
+    # The fc layer must stay a plain (full-precision) Linear.
+    assert isinstance(base.mtp.fc, _nn.Linear)
+    assert not isinstance(base.mtp.fc, _nn.QuantizedLinear)
+
+    hidden = _mx.zeros((1, 1, int(args.hidden_size)), dtype=_mx.float32)
+    next_ids = _mx.array([[0]], dtype=_mx.uint32)
+    logits = base.mtp_forward(hidden, next_ids, base.make_mtp_cache())
+    _mx.eval(logits)
+    assert logits.shape[-1] == int(args.vocab_size)
+
+
+def test_inject_refuses_explicit_sidecar_with_malformed_packing(tmp_path):
+    """An EXPLICIT sidecar whose quantized fc tensors imply a packing we
+    cannot reproduce (here: shapes that invert to an unsupported 7-bit
+    width) must make ``inject_mtp_support`` REFUSE (return False) — never
+    fall back to the base model's bit-width. Guessing the base's width for
+    a differently-packed sidecar is exactly what aborted requests at the
+    first draft step (the empty-response bug); a safe non-install (plain
+    base path) is the correct degradation.
+
+    (A *well-formed* quantized sidecar with no config.json is NOT refused
+    — its bits/group_size are recovered from the tensors; see
+    ``test_inject_quantizes_mtp_to_sidecar_bits_not_base_bits``.)
+    """
+    import mlx.core as _mx
+    import mlx.nn as _nn
+    from mlx.utils import tree_flatten
+
+    from vllm_mlx.spec_decode.mtp.head import build_mtp_module
+    from vllm_mlx.spec_decode.mtp.qwen3_5_inject import inject_mtp_support
+
+    try:
+        base = _build_tiny_qwen3_5_text_model()
+    except (TypeError, AttributeError) as exc:
+        pytest.skip(f"Qwen3.5 TextModelArgs schema mismatch: {exc}")
+
+    # Base quantized at 8-bit — the WRONG width a naive fallback would use.
+    _nn.quantize(base.model, group_size=32, bits=8)
+
+    # Start from a real 4-bit sidecar, then corrupt ONLY the fc packing so
+    # the derived width is an unsupported 7 bits. fc is Linear(2H, H) →
+    # in = 2H; weight cols = in*7//32, scales cols = in//32 imply bits=7.
+    args = base.args
+    template = build_mtp_module(args, int(args.mtp_num_hidden_layers))
+    _nn.quantize(template, group_size=32, bits=4)
+    _mx.eval(template.parameters())
+    flat = dict(tree_flatten(template.parameters()))
+    fp = build_mtp_module(args, int(args.mtp_num_hidden_layers))
+    _fc_out, _fc_in = (int(d) for d in fp.fc.weight.shape)
+    flat["fc.weight"] = _mx.zeros((_fc_out, _fc_in * 7 // 32), dtype=_mx.uint32)
+    flat["fc.scales"] = _mx.zeros((_fc_out, _fc_in // 32), dtype=_mx.float32)
+    _mx.save_safetensors(str(tmp_path / "model.safetensors"), flat)
+
+    assert inject_mtp_support(base, mtp_sidecar=str(tmp_path)) is False
+    assert not hasattr(base, "mtp"), (
+        "inject refused but still attached an MTP module — the refusal must "
+        "leave the base model untouched (plain path)."
+    )
+
+
+def test_inject_refuses_sidecar_with_shape_mismatched_non_fc_tensor(tmp_path):
+    """The fc-derived quantization is applied UNIFORMLY across the module.
+    A sidecar whose fc is well-formed but another tensor's shape disagrees
+    with that uniform packing (a mixed-bit / differently-grouped /
+    corrupted non-fc layer) must be caught by the post-quantize shape
+    check and refused — loading it would recreate the quantized_matmul
+    mismatch mid-generation, not just at fc.
+    """
+    import mlx.core as _mx
+    import mlx.nn as _nn
+    from mlx.utils import tree_flatten
+
+    from vllm_mlx.spec_decode.mtp.head import build_mtp_module
+    from vllm_mlx.spec_decode.mtp.qwen3_5_inject import inject_mtp_support
+
+    try:
+        base = _build_tiny_qwen3_5_text_model()
+    except (TypeError, AttributeError) as exc:
+        pytest.skip(f"Qwen3.5 TextModelArgs schema mismatch: {exc}")
+
+    _nn.quantize(base.model, group_size=32, bits=8)
+
+    # A valid 4-bit sidecar; fc is left intact so inference derives 4-bit.
+    args = base.args
+    template = build_mtp_module(args, int(args.mtp_num_hidden_layers))
+    _nn.quantize(template, group_size=32, bits=4)
+    _mx.eval(template.parameters())
+    flat = dict(tree_flatten(template.parameters()))
+
+    # Corrupt ONE non-fc tensor's shape (key stays present, so the coverage
+    # check passes and the SHAPE check is what must reject it).
+    victim = next(
+        k for k in sorted(flat) if not k.startswith("fc.") and k.endswith(".weight")
+    )
+    orig = flat[victim]
+    flat[victim] = _mx.zeros(
+        (int(orig.shape[0]) + 1, *(int(d) for d in orig.shape[1:])),
+        dtype=orig.dtype,
+    )
+    _mx.save_safetensors(str(tmp_path / "model.safetensors"), flat)
+
+    assert inject_mtp_support(base, mtp_sidecar=str(tmp_path)) is False
+    assert not hasattr(base, "mtp")
+
+
+def test_inject_refuses_sidecar_with_dtype_mismatched_packed_weight(tmp_path):
+    """A shape-correct sidecar can still smuggle a wrong-*dtype* packed
+    weight. MLX packs quantized ``weight`` as unsigned 32-bit; a same-shape
+    ``float32``/``int32`` packed weight passes the coverage + shape checks
+    but ``load_weights(strict=False)`` installs it without casting and the
+    first ``mx.quantized_matmul`` rejects it (the same empty-response class).
+    The by-role dtype check must catch and refuse it.
+    """
+    import mlx.core as _mx
+    import mlx.nn as _nn
+    from mlx.utils import tree_flatten
+
+    from vllm_mlx.spec_decode.mtp.head import build_mtp_module
+    from vllm_mlx.spec_decode.mtp.qwen3_5_inject import inject_mtp_support
+
+    try:
+        base = _build_tiny_qwen3_5_text_model()
+    except (TypeError, AttributeError) as exc:
+        pytest.skip(f"Qwen3.5 TextModelArgs schema mismatch: {exc}")
+
+    _nn.quantize(base.model, group_size=32, bits=8)
+
+    # A valid 4-bit sidecar; fc is intact so inference derives 4-bit.
+    args = base.args
+    template = build_mtp_module(args, int(args.mtp_num_hidden_layers))
+    _nn.quantize(template, group_size=32, bits=4)
+    _mx.eval(template.parameters())
+    flat = dict(tree_flatten(template.parameters()))
+
+    # Corrupt ONE packed weight's DTYPE (uint32 -> float32) while keeping its
+    # shape identical, so coverage + shape checks pass and only the dtype
+    # check can reject it.
+    victim = next(
+        k
+        for k in sorted(flat)
+        if k.endswith(".weight") and _mx.issubdtype(flat[k].dtype, _mx.integer)
+    )
+    flat[victim] = flat[victim].astype(_mx.float32)
+    _mx.save_safetensors(str(tmp_path / "model.safetensors"), flat)
+
+    assert inject_mtp_support(base, mtp_sidecar=str(tmp_path)) is False
+    assert not hasattr(base, "mtp")
+
+
+def test_inject_refuses_mixed_bit_sidecar_fail_safe(tmp_path):
+    """The fc-derived quantization is applied UNIFORMLY (intentional scope).
+    A hypothetical mixed-bit sidecar — FP ``fc`` but a quantized decoder —
+    must NOT be silently mis-packed: ``_infer_sidecar_fc_quantization``
+    reads FP fc and leaves the module FP, then the Step 4 shape check sees
+    the packed decoder tensors disagree with the FP module and REFUSES
+    (clean non-MTP fallback), rather than crashing at the first draft step.
+    This documents the fail-safe boundary for non-uniform sidecars.
+    """
+    import mlx.core as _mx
+    import mlx.nn as _nn
+    from mlx.utils import tree_flatten
+
+    from vllm_mlx.spec_decode.mtp.head import build_mtp_module
+    from vllm_mlx.spec_decode.mtp.qwen3_5_inject import inject_mtp_support
+
+    try:
+        base = _build_tiny_qwen3_5_text_model()
+    except (TypeError, AttributeError) as exc:
+        pytest.skip(f"Qwen3.5 TextModelArgs schema mismatch: {exc}")
+
+    _nn.quantize(base.model, group_size=32, bits=8)
+
+    # Mixed-bit sidecar: quantize EVERYTHING EXCEPT fc, so fc ships FP while
+    # the decoder layers ship 4-bit packed tensors.
+    args = base.args
+    template = build_mtp_module(args, int(args.mtp_num_hidden_layers))
+    _nn.quantize(
+        template,
+        group_size=32,
+        bits=4,
+        class_predicate=lambda path, m: (
+            hasattr(m, "to_quantized") and not path.startswith("fc")
+        ),
+    )
+    _mx.eval(template.parameters())
+    flat = dict(tree_flatten(template.parameters()))
+    # Sanity: fc stays FP (no fc.scales), decoder is packed (has scales).
+    assert not any(k.startswith("fc.scales") for k in flat)
+    assert any(k.endswith(".scales") and not k.startswith("fc.") for k in flat)
+    _mx.save_safetensors(str(tmp_path / "model.safetensors"), flat)
+
+    assert inject_mtp_support(base, mtp_sidecar=str(tmp_path)) is False
+    assert not hasattr(base, "mtp")
+
+
+def test_inject_refuses_when_module_quantize_raises_fail_safe(tmp_path):
+    """A sidecar whose ``fc`` is validly packed at group_size=128 infers
+    ``group_size=128``, but the MTP module's narrower sibling leaves (only
+    ``hidden_size``-wide in this fixture) are NOT divisible by 128, so
+    ``nn.quantize(mtp, group_size=128)`` RAISES during Step 3 — before the
+    Step 4 shape/dtype refusal can run. That exception must be caught and
+    turned into a clean refusal (return False → non-MTP fallback), never
+    propagated (an uncaught raise aborts the request at the first draft
+    step: the empty-response class this fix closes).
+    """
+    import mlx.core as _mx
+    import mlx.nn as _nn
+    from mlx.utils import tree_flatten
+
+    from vllm_mlx.spec_decode.mtp.head import build_mtp_module
+    from vllm_mlx.spec_decode.mtp.qwen3_5_inject import inject_mtp_support
+
+    try:
+        base = _build_tiny_qwen3_5_text_model()
+    except (TypeError, AttributeError) as exc:
+        pytest.skip(f"Qwen3.5 TextModelArgs schema mismatch: {exc}")
+
+    _nn.quantize(base.model, group_size=32, bits=8)
+
+    args = base.args
+    template = build_mtp_module(args, int(args.mtp_num_hidden_layers))
+    fc_out_dims, fc_in_dims = (int(d) for d in template.fc.weight.shape)
+
+    # Standalone group_size=128 fc (the fc IS wide enough for 128). The
+    # sidecar only needs the fc tensors — the crash fires in Step 3's
+    # module-wide quantize, before any other tensor is consulted.
+    fc = _nn.Linear(fc_in_dims, fc_out_dims, bias=False)
+    qfc = _nn.QuantizedLinear.from_linear(fc, 128, 4)
+    _mx.eval(qfc.parameters())
+    flat = {f"fc.{k}": v for k, v in dict(tree_flatten(qfc.parameters())).items()}
+    assert "fc.scales" in flat
+    _mx.save_safetensors(str(tmp_path / "model.safetensors"), flat)
+
+    # Must not raise; must refuse cleanly.
+    assert inject_mtp_support(base, mtp_sidecar=str(tmp_path)) is False
+    assert not hasattr(base, "mtp")
+
+
+def test_inject_catches_module_quantize_exception_deterministically(
+    tmp_path, monkeypatch
+):
+    """Pin the Step 3 quantize exception handler independent of MLX's own
+    group-size validation: monkeypatch ``nn.quantize`` so the MTP-module
+    quantize RAISES a sentinel, then assert ``inject_mtp_support`` swallows
+    it and returns ``False`` (never propagates). Uses an OTHERWISE-VALID
+    4-bit sidecar so, absent the handler, the call would raise straight out
+    of ``inject_mtp_support`` — this test fails (errors) if the try/except
+    is removed, whereas the real-crash fixture could in principle be masked
+    by a later refusal or a future MLX that tolerates the packing.
+    """
+    import mlx.core as _mx
+    import mlx.nn as _nn
+    from mlx.utils import tree_flatten
+
+    from vllm_mlx.spec_decode.mtp.head import build_mtp_module
+    from vllm_mlx.spec_decode.mtp.qwen3_5_inject import inject_mtp_support
+
+    try:
+        base = _build_tiny_qwen3_5_text_model()
+    except (TypeError, AttributeError) as exc:
+        pytest.skip(f"Qwen3.5 TextModelArgs schema mismatch: {exc}")
+
+    # Real quantize for setup (base) + sidecar construction, BEFORE the patch.
+    _nn.quantize(base.model, group_size=32, bits=8)
+    args = base.args
+    template = build_mtp_module(args, int(args.mtp_num_hidden_layers))
+    _nn.quantize(template, group_size=32, bits=4)
+    _mx.eval(template.parameters())
+    flat = dict(tree_flatten(template.parameters()))
+    _mx.save_safetensors(str(tmp_path / "model.safetensors"), flat)
+
+    class _QuantizeBoomError(RuntimeError):
+        pass
+
+    def _boom(*_a, **_k):
+        raise _QuantizeBoomError("sentinel: module quantize failed")
+
+    # ``inject_mtp_support`` does ``import mlx.nn as nn`` internally, so its
+    # ``nn`` IS this same ``mlx.nn`` module object — patching the attribute
+    # here is what its ``nn.quantize(mtp, ...)`` call resolves to. Set AFTER
+    # the setup quantizes above so only the in-inject MTP call hits the boom.
+    monkeypatch.setattr(_nn, "quantize", _boom)
+
+    # Handler must convert the raise into a clean False, not propagate.
+    assert inject_mtp_support(base, mtp_sidecar=str(tmp_path)) is False
+    assert not hasattr(base, "mtp")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_mtp_spec_decode.py
+++ b/tests/test_mtp_spec_decode.py
@@ -1377,10 +1377,10 @@ def test_inject_mtp_support_loads_synthetic_sidecar():
 
     # Build the MTP head separately so we can capture its random-init
     # weights, write them to disk, and verify the inject loads them
-    # byte-equally. (Note: this tiny model is FP, so the sidecar ships a
-    # config.json declaring no quantization block — the inject detects a
-    # full-precision sidecar and keeps the MTP module FP, matching the
-    # sidecar layout.)
+    # byte-equally. (Note: this tiny model is FP, so the sidecar ships as
+    # a metadata-less full-precision safetensors file, with no config.json
+    # and no fc.scales — the inject detects a full-precision sidecar from
+    # its tensors and keeps the MTP module FP, matching the sidecar layout.)
     args = model_a.args
     mtp_template = build_mtp_module(args, int(args.mtp_num_hidden_layers))
     _mx.eval(mtp_template.parameters())
@@ -1793,6 +1793,60 @@ def test_inject_refuses_corrupt_sidecar_file_without_raising(tmp_path):
         "inject_mtp_support should refuse (return False) a corrupt sidecar "
         "file, not raise mx.load's exception mid-request."
     )
+    assert not hasattr(base, "mtp"), (
+        "inject refused but still attached an MTP module — the refusal must "
+        "leave the base model untouched (plain path)."
+    )
+
+
+def test_inject_refuses_when_materialization_raises_without_propagating(
+    tmp_path, monkeypatch
+):
+    """``mx.load`` (Step 3) is LAZY — it only reads the safetensors header,
+    not tensor DATA. A truncated/lazily-unreadable sidecar with a VALID
+    header sails through every earlier shape/dtype check and only raises at
+    Step 4's ``mtp.load_weights(...)`` + ``mx.eval(mtp.parameters())``
+    materialization — a SECOND escape point from the same fail-safe that
+    ``test_inject_refuses_corrupt_sidecar_file_without_raising`` covers for
+    the eager ``mx.load`` header-read path (codex round-2 review on #1201).
+    Pin the materialization guard independent of a real truncated file:
+    monkeypatch ``mx.eval`` (as ``inject_mtp_support`` resolves it — it does
+    a local ``import mlx.core as mx``, the same shared module object) to
+    raise a sentinel, using an OTHERWISE-VALID sidecar so, absent the
+    try/except, this call would raise straight out of ``inject_mtp_support``.
+    """
+    import mlx.core as _mx
+    from mlx.utils import tree_flatten
+
+    from vllm_mlx.spec_decode.mtp.head import build_mtp_module
+    from vllm_mlx.spec_decode.mtp.qwen3_5_inject import inject_mtp_support
+
+    try:
+        base = _build_tiny_qwen3_5_text_model()
+    except (TypeError, AttributeError) as exc:
+        pytest.skip(f"Qwen3.5 TextModelArgs schema mismatch: {exc}")
+
+    # A valid full-precision sidecar that exactly matches the MTP module's
+    # parameter tree — built + saved BEFORE the patch, so this setup's own
+    # eval uses the real ``mx.eval``.
+    args = base.args
+    template = build_mtp_module(args, int(args.mtp_num_hidden_layers))
+    _mx.eval(template.parameters())
+    flat = dict(tree_flatten(template.parameters()))
+    _mx.save_safetensors(str(tmp_path / "model.safetensors"), flat)
+
+    class _MaterializeBoomError(RuntimeError):
+        pass
+
+    def _boom(*_a, **_k):
+        raise _MaterializeBoomError("sentinel: truncated tensor data")
+
+    # Set AFTER the setup eval above so only the in-inject materialization
+    # call hits the boom.
+    monkeypatch.setattr(_mx, "eval", _boom)
+
+    # Handler must convert the raise into a clean False, not propagate.
+    assert inject_mtp_support(base, mtp_sidecar=str(tmp_path)) is False
     assert not hasattr(base, "mtp"), (
         "inject refused but still attached an MTP module — the refusal must "
         "leave the base model untouched (plain path)."

--- a/vllm_mlx/spec_decode/mtp/qwen3_5_inject.py
+++ b/vllm_mlx/spec_decode/mtp/qwen3_5_inject.py
@@ -141,63 +141,118 @@ def _detect_base_quantization(inner: Any) -> dict | None:
     return None
 
 
-def _detect_sidecar_quantization(weights_file: Path) -> dict | None:
-    """Read the MTP *sidecar* checkpoint's own quantization params.
+# MLX affine quantization's practical value set. Every mlx-community
+# checkpoint (base + MTP sidecar alike) uses one of these — the shipped
+# Qwen3.6 pairing is 4-/8-bit at group_size 64. A sidecar whose tensors
+# imply a ``(bits, group_size)`` outside this set is anomalous (a
+# hand-corrupted or unknown packing); we refuse it rather than feed an
+# odd width into ``nn.quantize``. Kept deliberately narrow: over-inclusion
+# re-opens the exact mismatch this fix closes, while a genuinely-new width
+# simply needs one entry added here.
+_MLX_AFFINE_BITS = frozenset({2, 3, 4, 5, 6, 8})
+_MLX_AFFINE_GROUP_SIZES = frozenset({32, 64, 128})
 
-    The MTP module must be quantized to match the SIDECAR it loads its
-    weights from — NOT the base model. These usually agree (the
-    mlx-community pairing ships a 4-bit base with a 4-bit MTP head), so
-    detecting the base model's quantization happened to work. But a
-    mixed pairing makes them differ: e.g. an 8-bit base
-    (``Qwen3.6-27B-MLX-8bit``) with the only-published 4-bit MTP head
-    (``Qwen3.6-27B-MTP-4bit``). The packed ``weight`` / ``scales``
-    shapes of a ``QuantizedLinear`` are a function of ``(bits,
-    group_size)``; quantizing the module to the base's 8-bit and then
-    loading the sidecar's 4-bit tensors leaves a weight packed for
-    4-bit under a layer that still reports ``bits=8``, so
-    ``mx.quantized_matmul`` raises a "weight and scales incompatible"
-    ``ValueError`` at the first MTP draft step. Reading the sidecar's
-    own ``config.json`` quantization block fixes the shapes at their
-    true source.
 
-    Reads the ``quantization`` block from the ``config.json`` sitting
-    next to ``weights_file`` (the mlx-community MTP repos ship one).
-    Returns ``{"bits", "group_size"}`` or ``None`` when the sidecar
-    has no ``config.json`` / no top-level ``quantization`` block (e.g.
-    a hand-assembled bare ``*.safetensors``) — the caller then falls
-    back to :func:`_detect_base_quantization` (the pre-fix behavior),
-    which remains correct for the same-bit pairings.
+def _infer_sidecar_fc_quantization(
+    mtp_weights: dict, fc_out_dims: int, fc_in_dims: int
+) -> dict | None:
+    """Infer the sidecar fc layer's quantization from its LOADED tensors.
+
+    The sidecar tensors are the ground truth for how the checkpoint is
+    packed — strictly more reliable than any ``config.json`` proxy, which
+    a checkpoint may omit, mis-declare, or leave incomplete. The MTP
+    head's ``fc`` is an ``nn.Linear(2H, H)``; once MLX affine-quantizes
+    it, the packed ``fc.weight`` has shape ``(out, in * bits // 32)`` and
+    ``fc.scales`` has shape ``(out, in // group_size)``. Given the known
+    full-precision dims ``(out, in)`` read off the freshly-built module,
+    inverting those two shapes recovers ``(bits, group_size)`` exactly.
+
+    The MTP module must be quantized to match the sidecar it loads: a
+    QuantizedLinear's packed ``weight`` / ``scales`` shapes are a
+    function of ``(bits, group_size)``, so quantizing the module to a
+    DIFFERENT width than the sidecar tensors leaves a packing the layer's
+    ``bits`` attr disagrees with, and ``mx.quantized_matmul`` raises
+    "weight and scales incompatible" at the first MTP draft step —
+    surfacing to the client as an intermittent EMPTY response
+    (``prompt_tokens=0``). Reading the packing from the tensors fixes it
+    at the true source.
+
+    Returns:
+      * ``{"bits", "group_size"}`` — ``fc.scales`` is present, so the fc
+        is quantized; the affine params derived from the packed shapes
+        (validated against MLX's supported set + shape self-consistency).
+      * ``None`` — no ``fc.scales`` tensor, so the fc is full-precision;
+        the caller keeps the MTP module FP.
+
+    Raises:
+      ``ValueError`` — the sidecar's fc packing cannot be trusted: either
+      ``fc.scales`` is present but the shapes are inconsistent / the
+      derived ``(bits, group_size)`` are outside MLX affine's supported
+      set, OR ``fc.scales`` is absent yet a present ``fc.weight`` does
+      NOT carry the full-precision ``(out, in)`` shape (a truncated
+      quantized sidecar). The caller refuses injection rather than
+      mis-pack the module.
     """
-    import json
-
-    config_path = weights_file.parent / "config.json"
-    if not config_path.is_file():
+    scales = mtp_weights.get("fc.scales")
+    if scales is None:
+        # No per-group scales → the fc is full-precision. Guard against a
+        # TRUNCATED quantized sidecar that shipped a packed ``fc.weight``
+        # but lost its ``fc.scales``: if ``fc.weight`` is present it MUST
+        # carry the exact full-precision ``(out, in)`` shape, else a
+        # packed weight would be loaded into an ``nn.Linear`` and crash
+        # at inference. A *missing* ``fc.weight`` is left to the
+        # downstream coverage check (the module stays FP and the check
+        # refuses the partial head).
+        fp_weight = mtp_weights.get("fc.weight")
+        if fp_weight is not None:
+            fp_shape = tuple(int(d) for d in fp_weight.shape)
+            if fp_shape != (fc_out_dims, fc_in_dims):
+                raise ValueError(
+                    f"fc has no scales but fc.weight shape {fp_shape} != "
+                    f"full-precision ({fc_out_dims}, {fc_in_dims}) — a "
+                    f"truncated quantized sidecar (packed weight, missing "
+                    f"scales)"
+                )
         return None
-    try:
-        with config_path.open() as fh:
-            cfg = json.load(fh)
-    except (OSError, ValueError) as exc:  # pragma: no cover — malformed file
-        logger.warning(
-            "[mtp.inject] could not read sidecar config.json at %s: %s",
-            config_path,
-            exc,
+    weight = mtp_weights.get("fc.weight")
+    if weight is None:
+        raise ValueError("fc.scales present but fc.weight missing")
+    w_shape = tuple(int(d) for d in weight.shape)
+    s_shape = tuple(int(d) for d in scales.shape)
+    if len(w_shape) != 2 or len(s_shape) != 2:
+        raise ValueError(f"unexpected fc tensor ranks: weight{w_shape} scales{s_shape}")
+    if w_shape[0] != fc_out_dims or s_shape[0] != fc_out_dims:
+        raise ValueError(
+            f"fc out-dim mismatch: weight{w_shape} scales{s_shape} "
+            f"vs module out={fc_out_dims}"
         )
-        return None
-    quant = cfg.get("quantization")
-    if not isinstance(quant, dict):
-        return None
-    bits = quant.get("bits")
-    group_size = quant.get("group_size")
-    # ``bool`` is a subclass of ``int`` — guard so a malformed
-    # ``"bits": true`` is not silently treated as a 1-bit quantization.
-    if (
-        not isinstance(bits, int)
-        or isinstance(bits, bool)
-        or not isinstance(group_size, int)
-        or isinstance(group_size, bool)
-    ):
-        return None
-    return {"bits": int(bits), "group_size": int(group_size)}
+    packed_cols, scale_cols = w_shape[1], s_shape[1]
+    if scale_cols <= 0 or packed_cols <= 0:
+        raise ValueError(
+            f"non-positive fc packing cols: weight{w_shape} scales{s_shape}"
+        )
+    if fc_in_dims % scale_cols != 0:
+        raise ValueError(
+            f"in-dim {fc_in_dims} not divisible by scales cols {scale_cols}"
+        )
+    group_size = fc_in_dims // scale_cols
+    if (32 * packed_cols) % fc_in_dims != 0:
+        raise ValueError(
+            f"packed weight cols {packed_cols} inconsistent with in-dim {fc_in_dims}"
+        )
+    bits = (32 * packed_cols) // fc_in_dims
+    if bits not in _MLX_AFFINE_BITS or group_size not in _MLX_AFFINE_GROUP_SIZES:
+        raise ValueError(
+            f"derived bits={bits} group_size={group_size} outside MLX affine set"
+        )
+    # Cross-check: the packing must be exactly reproducible from the
+    # derived params (guards against a coincidental divisibility match).
+    if packed_cols != fc_in_dims * bits // 32 or scale_cols != fc_in_dims // group_size:
+        raise ValueError(
+            f"inconsistent packing: weight{w_shape} scales{s_shape} "
+            f"do not reproduce from bits={bits} group_size={group_size}"
+        )
+    return {"bits": bits, "group_size": group_size}
 
 
 def _resolve_sidecar_file(mtp_sidecar: str | Path) -> Path | None:
@@ -383,9 +438,9 @@ def inject_mtp_support(
     # --- Step 2: Resolve the sidecar file up-front ---
     # Resolved before quantization because the MTP module must be
     # quantized to match the SIDECAR checkpoint it loads (see Step 3),
-    # which is read off the file's sibling ``config.json``. Resolving
-    # here lets Step 4 reuse the same path without a second
-    # ``snapshot_download``.
+    # whose packing is read off the sidecar's own tensors. Resolving here
+    # lets Step 3 load the tensors once and Step 4 reuse them without a
+    # second ``snapshot_download`` / ``mx.load``.
     weights_file: Path | None = None
     if mtp_sidecar is not None:
         weights_file = _resolve_sidecar_file(mtp_sidecar)
@@ -400,7 +455,7 @@ def inject_mtp_support(
             )
             return False
 
-    # --- Step 3: Quantize MTP to match the SIDECAR's quantization ---
+    # --- Step 3: Match the MTP module's quantization to the SIDECAR ---
     # The packed weight/scales shapes of a ``QuantizedLinear`` are a
     # function of ``(bits, group_size)``. Loading a sidecar quantized
     # at a DIFFERENT bit-width than the module was quantized to leaves
@@ -410,29 +465,20 @@ def inject_mtp_support(
     # model's quantization, which is only safe when base bits == sidecar
     # bits (the mlx-community 4bit+4bit pairing). A mixed pairing — an
     # 8-bit base with the only-published 4-bit MTP head
-    # (Qwen3.6-27B-MLX-8bit + Qwen3.6-27B-MTP-4bit) — broke it. Prefer
-    # the sidecar's own quantization; fall back to base-model detection
-    # only when the sidecar ships no config.json (bare assembled file).
-    quant_info = None
+    # (Qwen3.6-27B-MLX-8bit + Qwen3.6-27B-MTP-4bit) — broke it.
+    #
+    # For an EXPLICIT sidecar we read the packing from the sidecar's own
+    # TENSORS (ground truth) — never the base model, and never a
+    # ``config.json`` proxy a checkpoint may omit or mis-declare. The
+    # presence of ``fc.scales`` distinguishes quantized from
+    # full-precision, and the packed ``fc.weight`` / ``fc.scales`` shapes
+    # recover ``(bits, group_size)`` exactly. The base-model fallback is
+    # legitimate ONLY on the no-sidecar path, where the MTP head is the
+    # base checkpoint's own and its bits match by construction.
+    mtp_weights: dict | None = None
     if weights_file is not None:
-        quant_info = _detect_sidecar_quantization(weights_file)
-    if quant_info is None:
-        quant_info = _detect_base_quantization(inner)
-    if quant_info is not None:
-        nn.quantize(
-            mtp,
-            group_size=quant_info["group_size"],
-            bits=quant_info["bits"],
-        )
-        logger.info(
-            "[mtp.inject] Quantized MTP: %d-bit, group_size=%d",
-            quant_info["bits"],
-            quant_info["group_size"],
-        )
-
-    # --- Step 4: Load MTP weights from sidecar safetensors ---
-    if mtp_sidecar is not None:
-        # ``weights_file`` was resolved in Step 2 above.
+        # Load the sidecar tensors up-front so their real layout drives
+        # quantization; Step 4 reuses this dict for the coverage check.
         raw = mx.load(str(weights_file))
         # Some sidecars (Qwen3-Next ``add_mtp_weights.py`` output) prefix
         # every key with ``mtp.``; others (mlx-community/Qwen3.5-9B-MTP-4bit)
@@ -442,17 +488,126 @@ def inject_mtp_support(
             (k.removeprefix("mtp.") if k.startswith("mtp.") else k): v
             for k, v in raw.items()
         }
+        # Read the fc's full-precision (out, in) dims off the freshly-built
+        # module, then invert the sidecar's packed fc shapes to recover its
+        # quantization.
+        #
+        # Scope (intentional): the recovered ``(bits, group_size)`` is applied
+        # UNIFORMLY to every quantizable leaf. Every shipped MTP sidecar
+        # (``mlx-community/Qwen3.5-9B-MTP-*``) is uniformly affine-packed, so
+        # fc is a faithful oracle for the whole head. A hypothetical mixed-bit
+        # sidecar (e.g. bf16 fc + 4-bit decoder, or 4-bit fc + 8-bit MoE gate)
+        # is NOT mis-packed here: the Step 4 shape/dtype verification below
+        # catches the resulting per-leaf disagreement and REFUSES the inject
+        # (returns False → clean non-MTP fallback), never shipping a head that
+        # aborts requests mid-generation. Per-leaf quantization inference would
+        # be a feature to *accept* such layouts, not a fix — the fail-safe
+        # refusal already holds.
+        fc_out_dims, fc_in_dims = (int(d) for d in mtp.fc.weight.shape)
+        try:
+            sidecar_quant = _infer_sidecar_fc_quantization(
+                mtp_weights, fc_out_dims, fc_in_dims
+            )
+        except ValueError as exc:
+            logger.error(
+                "[mtp.inject] sidecar %r has a quantized fc whose tensor "
+                "layout is inconsistent or an unsupported packing (%s); "
+                "refusing MTP injection rather than mis-pack the module and "
+                "abort requests at the first draft step. Provide a sidecar "
+                "packed with MLX affine quantization, or omit "
+                "--speculative-config to run the plain base path.",
+                mtp_sidecar,
+                exc,
+            )
+            return False
+        if sidecar_quant is None:
+            logger.info(
+                "[mtp.inject] Sidecar fc is full-precision; "
+                "leaving MTP module full-precision."
+            )
+        else:
+            # ``nn.quantize`` applies the fc-derived ``(bits, group_size)``
+            # to EVERY quantizable leaf and can itself RAISE — e.g. an fc
+            # wide enough for group_size=128 whose sibling projections are
+            # narrower than 128 (``last dimension needs to be divisible by
+            # group size``). That failure lands here, BEFORE Step 4's safe
+            # shape/dtype refusal can run, so it must be caught: an uncaught
+            # exception out of inject_mtp_support aborts the request at the
+            # first draft step — the very empty-response class this fix
+            # closes. Refuse (return False → clean non-MTP fallback) instead.
+            try:
+                nn.quantize(
+                    mtp,
+                    group_size=sidecar_quant["group_size"],
+                    bits=sidecar_quant["bits"],
+                )
+            except Exception as exc:
+                logger.error(
+                    "[mtp.inject] sidecar %r infers %d-bit / group_size=%d "
+                    "from its fc, but quantizing the MTP module at that "
+                    "packing failed (%s); refusing MTP injection rather than "
+                    "raise mid-request. The sidecar's fc packing is "
+                    "incompatible with its own narrower leaves — provide a "
+                    "uniformly-packed sidecar, or omit --speculative-config "
+                    "to run the plain base path.",
+                    mtp_sidecar,
+                    sidecar_quant["bits"],
+                    sidecar_quant["group_size"],
+                    exc,
+                )
+                return False
+            logger.info(
+                "[mtp.inject] Quantized MTP: %d-bit, group_size=%d "
+                "(from sidecar tensors)",
+                sidecar_quant["bits"],
+                sidecar_quant["group_size"],
+            )
+    else:
+        # No explicit sidecar: the MTP head is the base checkpoint's own,
+        # so the base model's quantization is the correct match.
+        base_quant = _detect_base_quantization(inner)
+        if base_quant is not None:
+            # Same fail-safe as the sidecar path: never let a quantize
+            # failure escape as an uncaught exception (→ empty response).
+            try:
+                nn.quantize(
+                    mtp,
+                    group_size=base_quant["group_size"],
+                    bits=base_quant["bits"],
+                )
+            except Exception as exc:
+                logger.error(
+                    "[mtp.inject] base model is %d-bit / group_size=%d but "
+                    "quantizing the MTP module at that packing failed (%s); "
+                    "refusing MTP injection rather than raise mid-request.",
+                    base_quant["bits"],
+                    base_quant["group_size"],
+                    exc,
+                )
+                return False
+            logger.info(
+                "[mtp.inject] Quantized MTP: %d-bit, group_size=%d (from base)",
+                base_quant["bits"],
+                base_quant["group_size"],
+            )
+
+    # --- Step 4: Load MTP weights from sidecar safetensors ---
+    if mtp_sidecar is not None:
+        # ``mtp_weights`` was loaded + prefix-normalised in Step 3
+        # (``mtp_sidecar is not None`` implies ``weights_file is not None``).
+        assert mtp_weights is not None
         # Pre-load coverage check: codex flagged on PR #954 that
         # ``strict=False`` lets the load silently succeed even when
         # sidecar tensors are missing or misspelled — leaving part of
         # the MTP head random-init while inject_mtp_support still
-        # returns True. Compute the expected parameter key set off
+        # returns True. Compute the expected parameter map off
         # ``mtp.parameters()`` (post-quantize, so ``weight`` /
         # ``scales`` / ``biases`` for QuantizedLinear layers) and
         # refuse the inject if any required tensor is missing.
         from mlx.utils import tree_flatten
 
-        expected_keys = {k for k, _ in tree_flatten(mtp.parameters())}
+        expected = dict(tree_flatten(mtp.parameters()))
+        expected_keys = set(expected)
         loaded_keys = set(mtp_weights.keys())
         missing = expected_keys - loaded_keys
         if missing:
@@ -468,9 +623,81 @@ def inject_mtp_support(
                 sorted(missing)[:8],
             )
             return False
+        # Shape verification: the quantization we applied above is inferred
+        # from the fc layer and applied UNIFORMLY across the module. Verify
+        # that EVERY sidecar tensor matches the corresponding post-quantize
+        # parameter shape EXACTLY — a mismatch means the sidecar's packing
+        # disagrees with the module's (a mixed-bit, differently-grouped, or
+        # corrupted non-fc layer), which is precisely what makes
+        # ``mx.quantized_matmul`` raise "weight and scales incompatible" at
+        # the first draft step (the empty-response bug). Refuse rather than
+        # ship a module that crashes mid-generation.
+        shape_mismatches = {
+            k: (
+                tuple(int(d) for d in mtp_weights[k].shape),
+                tuple(int(d) for d in v.shape),
+            )
+            for k, v in expected.items()
+            if tuple(int(d) for d in mtp_weights[k].shape)
+            != tuple(int(d) for d in v.shape)
+        }
+        if shape_mismatches:
+            sample = sorted(shape_mismatches.items())[:8]
+            logger.warning(
+                "[mtp.inject] sidecar %s has %d tensor(s) whose shape "
+                "disagrees with the module's quantization (got vs expected); "
+                "refusing rather than ship a head that aborts requests at the "
+                "first draft step. Mismatches (first 8): %s. This usually "
+                "means the sidecar is packed at a different bit-width / "
+                "group_size than its fc layer, or is corrupted.",
+                weights_file.name,
+                len(shape_mismatches),
+                sample,
+            )
+            return False
+        # Dtype verification (by ROLE, not exact match): a shape-correct
+        # sidecar can still smuggle in a wrong-*dtype* tensor that
+        # ``load_weights(strict=False)`` installs without casting, then
+        # ``mx.quantized_matmul`` / ``mx.gather_qmm`` rejects. MLX packs
+        # quantized ``weight`` as unsigned 32-bit; an ``int32``/``float32``
+        # packed weight (or an integer ``scales``/``biases``) has the right
+        # shape but blows up at the first draft step — the same empty-response
+        # class this fix closes. Enforce by role: an integer-typed expected
+        # parameter (the packed ``weight``) must match its dtype EXACTLY,
+        # while a floating-typed expected parameter (``scales`` / ``biases`` /
+        # any FP weight) need only be *some* floating dtype — a real sidecar
+        # legitimately ships bf16 scales against the freshly-quantized fp32
+        # module and ``load_weights`` casts them, so an exact float check
+        # would false-reject valid checkpoints.
+        dtype_mismatches = {}
+        for k, v in expected.items():
+            got_dt = mtp_weights[k].dtype
+            exp_dt = v.dtype
+            if mx.issubdtype(exp_dt, mx.integer):
+                ok = got_dt == exp_dt
+            else:
+                ok = mx.issubdtype(got_dt, mx.floating)
+            if not ok:
+                dtype_mismatches[k] = (str(got_dt), str(exp_dt))
+        if dtype_mismatches:
+            sample = sorted(dtype_mismatches.items())[:8]
+            logger.warning(
+                "[mtp.inject] sidecar %s has %d tensor(s) whose dtype is "
+                "incompatible with the module's quantization (got vs expected); "
+                "refusing rather than ship a head that aborts requests at the "
+                "first draft step. Mismatches (first 8): %s. A packed quantized "
+                "weight must be unsigned 32-bit and scales/biases must be "
+                "floating; a mismatch means the sidecar is corrupted or was "
+                "converted with an incompatible packer.",
+                weights_file.name,
+                len(dtype_mismatches),
+                sample,
+            )
+            return False
         # ``strict=False`` still — we deliberately tolerate EXTRA
         # keys (metadata blobs some converters bundle), but the
-        # coverage check above proves no required key is missing.
+        # coverage + shape + dtype checks above prove every required
+        # tensor is present and fits its target parameter exactly.
         mtp.load_weights(list(mtp_weights.items()), strict=False)
         mx.eval(mtp.parameters())
         extra = loaded_keys - expected_keys

--- a/vllm_mlx/spec_decode/mtp/qwen3_5_inject.py
+++ b/vllm_mlx/spec_decode/mtp/qwen3_5_inject.py
@@ -479,15 +479,29 @@ def inject_mtp_support(
     if weights_file is not None:
         # Load the sidecar tensors up-front so their real layout drives
         # quantization; Step 4 reuses this dict for the coverage check.
-        raw = mx.load(str(weights_file))
-        # Some sidecars (Qwen3-Next ``add_mtp_weights.py`` output) prefix
-        # every key with ``mtp.``; others (mlx-community/Qwen3.5-9B-MTP-4bit)
-        # store at top-level. Strip the prefix if present so both shapes
-        # land on the MTP module's parameter tree.
-        mtp_weights = {
-            (k.removeprefix("mtp.") if k.startswith("mtp.") else k): v
-            for k, v in raw.items()
-        }
+        # A truncated/unreadable/corrupt safetensors file makes ``mx.load``
+        # raise — that must hit the same return-False fail-safe as every
+        # other bad-sidecar path below, not escape as an uncaught exception
+        # and abort the request mid-generation.
+        try:
+            raw = mx.load(str(weights_file))
+            # Some sidecars (Qwen3-Next ``add_mtp_weights.py`` output) prefix
+            # every key with ``mtp.``; others (mlx-community/Qwen3.5-9B-MTP-4bit)
+            # store at top-level. Strip the prefix if present so both shapes
+            # land on the MTP module's parameter tree.
+            mtp_weights = {
+                (k.removeprefix("mtp.") if k.startswith("mtp.") else k): v
+                for k, v in raw.items()
+            }
+        except Exception as exc:
+            logger.error(
+                "[mtp.inject] sidecar %r could not be read/parsed (%s); "
+                "refusing MTP injection rather than raise mid-request. Omit "
+                "--speculative-config to run the plain base path.",
+                mtp_sidecar,
+                exc,
+            )
+            return False
         # Read the fc's full-precision (out, in) dims off the freshly-built
         # module, then invert the sidecar's packed fc shapes to recover its
         # quantization.

--- a/vllm_mlx/spec_decode/mtp/qwen3_5_inject.py
+++ b/vllm_mlx/spec_decode/mtp/qwen3_5_inject.py
@@ -712,8 +712,28 @@ def inject_mtp_support(
         # keys (metadata blobs some converters bundle), but the
         # coverage + shape + dtype checks above prove every required
         # tensor is present and fits its target parameter exactly.
-        mtp.load_weights(list(mtp_weights.items()), strict=False)
-        mx.eval(mtp.parameters())
+        #
+        # ``mx.load`` above (Step 3) is LAZY — it only reads the
+        # safetensors header, not tensor DATA. A truncated/unreadable
+        # sidecar with a valid header sails through every check above
+        # and only RAISES here, at ``mx.eval(mtp.parameters())``
+        # materialization. That must hit the same return-False
+        # fail-safe as every other bad-sidecar path in this function,
+        # not escape as an uncaught exception and abort the request
+        # mid-generation.
+        try:
+            mtp.load_weights(list(mtp_weights.items()), strict=False)
+            mx.eval(mtp.parameters())
+        except Exception as exc:
+            logger.error(
+                "[mtp.inject] sidecar %r raised while materializing MTP "
+                "weights (%s); refusing MTP injection rather than abort "
+                "the request mid-generation. Omit --speculative-config "
+                "to run the plain base path.",
+                mtp_sidecar,
+                exc,
+            )
+            return False
         extra = loaded_keys - expected_keys
         logger.info(
             "[mtp.inject] Loaded %d/%d expected MTP weight tensors from %s%s",

--- a/vllm_mlx/spec_decode/mtp/qwen3_5_inject.py
+++ b/vllm_mlx/spec_decode/mtp/qwen3_5_inject.py
@@ -141,6 +141,65 @@ def _detect_base_quantization(inner: Any) -> dict | None:
     return None
 
 
+def _detect_sidecar_quantization(weights_file: Path) -> dict | None:
+    """Read the MTP *sidecar* checkpoint's own quantization params.
+
+    The MTP module must be quantized to match the SIDECAR it loads its
+    weights from — NOT the base model. These usually agree (the
+    mlx-community pairing ships a 4-bit base with a 4-bit MTP head), so
+    detecting the base model's quantization happened to work. But a
+    mixed pairing makes them differ: e.g. an 8-bit base
+    (``Qwen3.6-27B-MLX-8bit``) with the only-published 4-bit MTP head
+    (``Qwen3.6-27B-MTP-4bit``). The packed ``weight`` / ``scales``
+    shapes of a ``QuantizedLinear`` are a function of ``(bits,
+    group_size)``; quantizing the module to the base's 8-bit and then
+    loading the sidecar's 4-bit tensors leaves a weight packed for
+    4-bit under a layer that still reports ``bits=8``, so
+    ``mx.quantized_matmul`` raises a "weight and scales incompatible"
+    ``ValueError`` at the first MTP draft step. Reading the sidecar's
+    own ``config.json`` quantization block fixes the shapes at their
+    true source.
+
+    Reads the ``quantization`` block from the ``config.json`` sitting
+    next to ``weights_file`` (the mlx-community MTP repos ship one).
+    Returns ``{"bits", "group_size"}`` or ``None`` when the sidecar
+    has no ``config.json`` / no top-level ``quantization`` block (e.g.
+    a hand-assembled bare ``*.safetensors``) — the caller then falls
+    back to :func:`_detect_base_quantization` (the pre-fix behavior),
+    which remains correct for the same-bit pairings.
+    """
+    import json
+
+    config_path = weights_file.parent / "config.json"
+    if not config_path.is_file():
+        return None
+    try:
+        with config_path.open() as fh:
+            cfg = json.load(fh)
+    except (OSError, ValueError) as exc:  # pragma: no cover — malformed file
+        logger.warning(
+            "[mtp.inject] could not read sidecar config.json at %s: %s",
+            config_path,
+            exc,
+        )
+        return None
+    quant = cfg.get("quantization")
+    if not isinstance(quant, dict):
+        return None
+    bits = quant.get("bits")
+    group_size = quant.get("group_size")
+    # ``bool`` is a subclass of ``int`` — guard so a malformed
+    # ``"bits": true`` is not silently treated as a 1-bit quantization.
+    if (
+        not isinstance(bits, int)
+        or isinstance(bits, bool)
+        or not isinstance(group_size, int)
+        or isinstance(group_size, bool)
+    ):
+        return None
+    return {"bits": int(bits), "group_size": int(group_size)}
+
+
 def _resolve_sidecar_file(mtp_sidecar: str | Path) -> Path | None:
     """Resolve a sidecar reference to a concrete safetensors file path.
 
@@ -269,7 +328,7 @@ def inject_mtp_support(
     # NOTE: the global ``ArraysCache`` rollback_state class-default and
     # the ``GatedDeltaNet.__call__`` chunk-split patches are deferred
     # until AFTER every can-fail validation completes (see ``# --- Step
-    # 4`` below). Codex flagged on PR #954 that installing these
+    # 5`` below). Codex flagged on PR #954 that installing these
     # monkey-patches up-front meant a failed sidecar load left
     # process-global behavior mutated even though inject_mtp_support
     # returned False. The patches are now strictly post-validation.
@@ -321,21 +380,13 @@ def inject_mtp_support(
         getattr(args, "hidden_size", -1),
     )
 
-    # --- Step 2: Quantize MTP to match the base model's quantization ---
-    quant_info = _detect_base_quantization(inner)
-    if quant_info is not None:
-        nn.quantize(
-            mtp,
-            group_size=quant_info["group_size"],
-            bits=quant_info["bits"],
-        )
-        logger.info(
-            "[mtp.inject] Quantized MTP: %d-bit, group_size=%d",
-            quant_info["bits"],
-            quant_info["group_size"],
-        )
-
-    # --- Step 3: Load MTP weights from sidecar safetensors ---
+    # --- Step 2: Resolve the sidecar file up-front ---
+    # Resolved before quantization because the MTP module must be
+    # quantized to match the SIDECAR checkpoint it loads (see Step 3),
+    # which is read off the file's sibling ``config.json``. Resolving
+    # here lets Step 4 reuse the same path without a second
+    # ``snapshot_download``.
+    weights_file: Path | None = None
     if mtp_sidecar is not None:
         weights_file = _resolve_sidecar_file(mtp_sidecar)
         if weights_file is None:
@@ -348,6 +399,40 @@ def inject_mtp_support(
                 mtp_sidecar,
             )
             return False
+
+    # --- Step 3: Quantize MTP to match the SIDECAR's quantization ---
+    # The packed weight/scales shapes of a ``QuantizedLinear`` are a
+    # function of ``(bits, group_size)``. Loading a sidecar quantized
+    # at a DIFFERENT bit-width than the module was quantized to leaves
+    # a weight whose packing disagrees with the layer's ``bits`` attr,
+    # so ``mx.quantized_matmul`` raises "weight and scales incompatible"
+    # at the first MTP draft step. Historically we matched the BASE
+    # model's quantization, which is only safe when base bits == sidecar
+    # bits (the mlx-community 4bit+4bit pairing). A mixed pairing — an
+    # 8-bit base with the only-published 4-bit MTP head
+    # (Qwen3.6-27B-MLX-8bit + Qwen3.6-27B-MTP-4bit) — broke it. Prefer
+    # the sidecar's own quantization; fall back to base-model detection
+    # only when the sidecar ships no config.json (bare assembled file).
+    quant_info = None
+    if weights_file is not None:
+        quant_info = _detect_sidecar_quantization(weights_file)
+    if quant_info is None:
+        quant_info = _detect_base_quantization(inner)
+    if quant_info is not None:
+        nn.quantize(
+            mtp,
+            group_size=quant_info["group_size"],
+            bits=quant_info["bits"],
+        )
+        logger.info(
+            "[mtp.inject] Quantized MTP: %d-bit, group_size=%d",
+            quant_info["bits"],
+            quant_info["group_size"],
+        )
+
+    # --- Step 4: Load MTP weights from sidecar safetensors ---
+    if mtp_sidecar is not None:
+        # ``weights_file`` was resolved in Step 2 above.
         raw = mx.load(str(weights_file))
         # Some sidecars (Qwen3-Next ``add_mtp_weights.py`` output) prefix
         # every key with ``mtp.``; others (mlx-community/Qwen3.5-9B-MTP-4bit)
@@ -424,7 +509,7 @@ def inject_mtp_support(
             "do not use in production."
         )
 
-    # --- Step 4: Install global ArraysCache + GatedDeltaNet patches ---
+    # --- Step 5: Install global ArraysCache + GatedDeltaNet patches ---
     # Deferred from the top of this function so a failed validation /
     # sidecar load (above) leaves the process global state untouched.
     # Both patches are idempotent + transparent at n_confirmed=0, so
@@ -438,7 +523,7 @@ def inject_mtp_support(
     patch_arrays_cache_rollback_state()
     patch_gated_delta_net_for_mtp()
 
-    # --- Step 5: Attach + monkey-patch ``TextModel`` class ---
+    # --- Step 6: Attach + monkey-patch ``TextModel`` class ---
     inner.mtp = mtp
     original_class = type(inner)
 


### PR DESCRIPTION
## Root cause

The Qwen3.5/3.6 MTP injector (`vllm_mlx/spec_decode/mtp/qwen3_5_inject.py`) quantizes the vendored MTP head module to match the **base model's** quantization (`_detect_base_quantization`, read off `q_proj`), then loads the **sidecar** checkpoint's weights into it. That is only correct when `base_bits == sidecar_bits` — true for the mlx-community 4bit-base + 4bit-MTP pairing, but **not** for an 8-bit base paired with the only-published 4-bit MTP head:

- base `unsloth/Qwen3.6-27B-MLX-8bit` -> `bits=8, group_size=64`
- sidecar `mlx-community/Qwen3.6-27B-MTP-4bit` -> `bits=4, group_size=64`

The module was quantized 8-bit, then the 4-bit sidecar `fc.weight` `(5120,1280)` was loaded into a `QuantizedLinear` still reporting `bits=8`. At the first MTP draft step `mx.quantized_matmul` raised:

```
ValueError: [quantized_matmul] The shapes of the weight and scales are incompatible
based on bits and group_size. w.shape() == (5120,1280) and scales.shape() == (5120,160)
with group_size=64 and bits=8
```

(the scales `(5120,160)` imply in=10240 for the `Linear(2H, H)` fc, while the 4-bit-packed weight implies in=5120). The scheduler's MTP wrapper correctly refuses to fall back mid-stream — `gb._next_tokens` is stale, so a fallback would corrupt the stream — and raises, aborting the request. The client sees an **EMPTY response** with `prompt_tokens=0` / `completion_tokens=0`.

The **first** request survives only because the depth controller parks (`K=0`) before it ever speculates; every subsequent identical greedy request reaches the draft path and crashes. This also explains the misleading `prompt_tokens=0` "cache-hit" signature — it is the aborted-request usage, not a response-cache hit (the response cache is off by default and was not enabled in the repro).

## The fix

Quantize the MTP module to match the **sidecar** it loads from, reading the packing from the sidecar's own **tensors** — the ground truth — not a `config.json` proxy a checkpoint may omit or mis-declare (new `_infer_sidecar_fc_quantization`). The MTP head's `fc` is `Linear(2H, H)`; once MLX affine-quantizes it, the packed `fc.weight` is `(out, in*bits//32)` and `fc.scales` is `(out, in//group_size)`, so given the full-precision `(out, in)` dims read off the freshly-built module, inverting the two shapes recovers `(bits, group_size)` exactly:

- `fc.scales` present -> quantized; derive + validate the affine params against MLX's supported set (`bits` in `{2,3,4,5,6,8}`, `group_size` in `{32,64,128}`) and shape self-consistency;
- no `fc.scales` -> full-precision fc; keep the MTP module FP (no config needed);
- `fc.scales` present but the packing is inconsistent / unsupported -> `ValueError`; `inject_mtp_support` **refuses** (returns `False`, actionable log) rather than mis-pack — a safe non-install (plain base path).

An **explicit** sidecar is thus quantized **only from its own tensors, never the base model's** — guessing the base's bit-width for a differently-packed sidecar is exactly what mis-packed the tensors and aborted requests at the first draft step. The base-model fallback is retained **only on the no-sidecar path**, where the MTP head is the base checkpoint's own and its bits match by construction. The sidecar tensors are loaded once, up-front, and reused by the coverage-check + load step.

## Evidence (`qwen3.6-27b-8bit` + `Qwen3.6-27B-MTP-4bit`, port 8795, `temperature=0`)

| | before | after |
|---|---|---|
| "Say the word banana." x10 | **9/10 empty** | **0/10 empty** |
| "Explain how a Bloom filter works" x6 | (crashes) | 0/6 empty |
| "Write a Python function to reverse a string" x6 | (crashes) | 0/6 empty |

Server log after fix: `[mtp.inject] Quantized MTP: 4-bit, group_size=64` (was 8-bit), zero `quantized_matmul` / generator-raised errors, and the MTP draft path now actually runs — `rapid_mlx_spec_decode_accept_ratio ~= 0.47` (attempts=17, accepts=8) instead of crashing on invocation.

**Plain-path regression check** — same base served with NO `--speculative-config`: no MTP installed, 3/3 identical greedy requests correct. The plain path never calls `inject_mtp_support`, so it is structurally unaffected.

## Tests

- `test_infer_sidecar_fc_quantization_recovers_bits_and_group_size` — parametrized over `bits x group_size`; inverting the packed `fc.weight`/`fc.scales` shapes recovers the exact `(bits, group_size)`, no config.json.
- `test_infer_sidecar_fc_quantization_full_precision_returns_none` — no `fc.scales` -> `None` -> module kept FP.
- `test_infer_sidecar_fc_quantization_raises_on_malformed_packing` — shapes implying an unsupported width, or `fc.scales` with no `fc.weight`, raise `ValueError`.
- `test_inject_quantizes_mtp_to_sidecar_bits_not_base_bits` — 8-bit base + 4-bit **config-less** sidecar; asserts `mtp.fc.bits == 4` and that a draft `mtp_forward` runs without the `quantized_matmul` crash (the exact field-repro call).
- `test_inject_keeps_mtp_full_precision_for_fp_sidecar` — quantized base + config-less FP sidecar leaves `mtp.fc` a plain `nn.Linear`.
- `test_inject_refuses_explicit_sidecar_with_malformed_packing` — sidecar whose fc packing inverts to an unsupported 7-bit width -> `inject` returns `False`, base untouched (no base-bits guess).

Full `test_mtp_spec_decode.py`: 79 passed; all MTP-tagged suites 306 passed; `ruff check` + `ruff format --check vllm_mlx/ tests/` clean.

## Defense-in-depth fail-safe guards

`inject_mtp_support` must **never raise** — an uncaught exception on the inject path aborts the request mid-stream (the empty-response class). Beyond the core fix, three guards make every reject path fail-safe (return `False` -> clean non-MTP fallback), each with a regression test:

- **Whole-module shape verification** (Step 4): the fc-derived `(bits, group_size)` is applied uniformly, so every loaded sidecar tensor is checked against the quantized module's expected parameter shape; any disagreement (a mixed-bit / differently-grouped / corrupted non-`fc` leaf) is refused before load, instead of surfacing as a `quantized_matmul` mismatch at the first draft step.
- **By-role dtype verification** (Step 4): a shape-correct tensor can still smuggle a wrong dtype (MLX packs quantized `weight` as `uint32`); integer-typed params must match exactly while float-typed params (`scales`/`biases`) need only be floating (a real bf16-scales sidecar loaded against the fp32 module is cast by `load_weights`, so an exact-float check would false-reject valid checkpoints).
- **Quantize-time guard** (Step 3): `nn.quantize(mtp, ...)` itself can raise — e.g. an `fc` wide enough for `group_size=128` whose sibling projections are narrower than 128 — so it is wrapped and converted to a refusal rather than propagated.

A hypothetical non-uniform (mixed-bit) sidecar is therefore **refused**, not mis-packed; per-leaf quantization inference would be a *feature* to accept such layouts, not a fix — the fail-safe refusal already holds.

## Scope

Out of scope (unchanged, separate known limitations): the SSM-hybrid `max_k` clamp to 1 (chain-of-K not wired) and the response-cache path. This PR only fixes the quantization-bits mismatch that produced the crash/empty-response.

Note on CI `full_unit`: 3 failures are **pre-existing on `main` and independent of this diff** (which touches only `qwen3_5_inject.py` + its test) — `test_tool_grammar_558.py::test_deepseek_r1_prefilled_think_template_is_tolerated` fails offline (fetches a DeepSeek-R1 tokenizer from HF), and `test_cli_chat.py::test_chat_command_{owns,closes}_mcp_runtime_*` fail with `_Runtime` missing `server_log_path` in the MCP-chat lane. All three reproduce on unmodified `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

