### PR TITLE
fix(mtp): reconcile info vs serve MTP-eligibility messaging

### DIFF
--- a/tests/test_cli_info.py
+++ b/tests/test_cli_info.py
@@ -99,9 +99,12 @@ def test_info_prints_mtp_sidecar_note_when_head_declared_but_absent(
     out = _run_info("qwen3.6-27b-8bit")
     assert "mtp_num_hidden_layers=1" in out, f"declared-layer count missing:\n{out}"
     assert "head weights are absent" in out, f"absent-head diagnosis missing:\n{out}"
-    # Actionable: mirrors the serve-time sidecar remedy.
-    assert "--speculative-config" in out and '"method":"mtp"' in out, (
-        f"sidecar serve command missing from note:\n{out}"
+    # Actionable: must emit the COMPLETE sidecar remedy — the ``model`` field
+    # is load-bearing. Asserting the full fragment (not just ``method``)
+    # guards against regressing to a bare ``{"method":"mtp"}`` that would just
+    # reproduce the original inject-time hard failure (codex #1202 round 2).
+    assert """--speculative-config '{"method":"mtp","model":"<head-repo>"}'""" in out, (
+        f"complete sidecar serve command missing from note:\n{out}"
     )
     # The serve command must carry the user-typed alias, not the HF path.
     assert "rapid-mlx serve qwen3.6-27b-8bit" in out, (

--- a/tests/test_cli_info.py
+++ b/tests/test_cli_info.py
@@ -106,9 +106,11 @@ def test_info_prints_mtp_sidecar_note_when_head_declared_but_absent(
     assert """--speculative-config '{"method":"mtp","model":"<head-repo>"}'""" in out, (
         f"complete sidecar serve command missing from note:\n{out}"
     )
-    # The serve command must carry the user-typed alias, not the HF path.
-    assert "rapid-mlx serve qwen3.6-27b-8bit" in out, (
-        f"note should reference the alias the user typed:\n{out}"
+    # The serve command must carry the user-typed alias, not the HF path —
+    # placed after the ``--`` option/positional separator so a ``-``-prefixed
+    # local path can't be misparsed as a serve option (codex #1202 round 6).
+    assert "-- qwen3.6-27b-8bit" in out, (
+        f"note should reference the alias the user typed (after ``--``):\n{out}"
     )
 
 

--- a/tests/test_cli_info.py
+++ b/tests/test_cli_info.py
@@ -76,3 +76,47 @@ def test_info_does_not_require_model_weights() -> None:
     # Reaching this point in the test session is the success condition.
     # The other tests in this module already exercise multiple aliases.
     assert True
+
+
+def test_info_prints_mtp_sidecar_note_when_head_declared_but_absent(monkeypatch) -> None:
+    """When ``config.json`` declares an MTP head but the head weights were
+    stripped from this checkpoint, ``info`` must print the actionable ``MTP:``
+    note that mirrors the serve-time hard-fail and points to the sidecar path.
+
+    This reconciles ``info`` (which otherwise reports a bare ``disabled``)
+    with ``serve --speculative-config '{"method":"mtp"}'`` (which announces
+    ``MTP: enabled`` then hard-fails at inject). The config read is
+    monkeypatched via the eligibility helper so the test is deterministic and
+    cache-independent.
+    """
+    from vllm_mlx import model_auto_config as auto_config_mod
+
+    monkeypatch.setattr(
+        auto_config_mod, "_mtp_declared_absent_layers", lambda name, cfg: 1
+    )
+    out = _run_info("qwen3.6-27b-8bit")
+    assert "mtp_num_hidden_layers=1" in out, f"declared-layer count missing:\n{out}"
+    assert "head weights are absent" in out, f"absent-head diagnosis missing:\n{out}"
+    # Actionable: mirrors the serve-time sidecar remedy.
+    assert '--speculative-config' in out and '"method":"mtp"' in out, (
+        f"sidecar serve command missing from note:\n{out}"
+    )
+    # The serve command must carry the user-typed alias, not the HF path.
+    assert "rapid-mlx serve qwen3.6-27b-8bit" in out, (
+        f"note should reference the alias the user typed:\n{out}"
+    )
+
+
+def test_info_omits_mtp_note_when_not_declared_absent(monkeypatch) -> None:
+    """The reconciliation note must stay scoped: when the helper reports the
+    model is NOT in the declared-but-absent state (returns ``None``), ``info``
+    must not print the ``MTP:`` sidecar note."""
+    from vllm_mlx import model_auto_config as auto_config_mod
+
+    monkeypatch.setattr(
+        auto_config_mod, "_mtp_declared_absent_layers", lambda name, cfg: None
+    )
+    out = _run_info("qwen3.6-27b-8bit")
+    assert "head weights are absent" not in out, (
+        f"note leaked for a model that is not declared-but-absent:\n{out}"
+    )

--- a/tests/test_cli_info.py
+++ b/tests/test_cli_info.py
@@ -78,7 +78,9 @@ def test_info_does_not_require_model_weights() -> None:
     assert True
 
 
-def test_info_prints_mtp_sidecar_note_when_head_declared_but_absent(monkeypatch) -> None:
+def test_info_prints_mtp_sidecar_note_when_head_declared_but_absent(
+    monkeypatch,
+) -> None:
     """When ``config.json`` declares an MTP head but the head weights were
     stripped from this checkpoint, ``info`` must print the actionable ``MTP:``
     note that mirrors the serve-time hard-fail and points to the sidecar path.
@@ -98,7 +100,7 @@ def test_info_prints_mtp_sidecar_note_when_head_declared_but_absent(monkeypatch)
     assert "mtp_num_hidden_layers=1" in out, f"declared-layer count missing:\n{out}"
     assert "head weights are absent" in out, f"absent-head diagnosis missing:\n{out}"
     # Actionable: mirrors the serve-time sidecar remedy.
-    assert '--speculative-config' in out and '"method":"mtp"' in out, (
+    assert "--speculative-config" in out and '"method":"mtp"' in out, (
         f"sidecar serve command missing from note:\n{out}"
     )
     # The serve command must carry the user-typed alias, not the HF path.

--- a/tests/test_model_auto_config.py
+++ b/tests/test_model_auto_config.py
@@ -2984,7 +2984,14 @@ class TestLocalWeightTensorNames:
             "__metadata__": {"format": "pt"},
         }
         blob = json.dumps(header).encode()
-        self._write(tmp_path, "model.safetensors", struct.pack("<Q", len(blob)) + blob)
+        # Append the 2-byte tensor payload declared by ``data_offsets``
+        # [0, 2] so the descriptor's byte-range is actually in-bounds — the
+        # probe now fails closed on out-of-bounds offsets (codex #1202).
+        self._write(
+            tmp_path,
+            "model.safetensors",
+            struct.pack("<Q", len(blob)) + blob + b"\x00\x00",
+        )
         names = auto_config_mod._local_weight_tensor_names(
             str(tmp_path), self._cfg(tmp_path)
         )

--- a/tests/test_model_auto_config.py
+++ b/tests/test_model_auto_config.py
@@ -2812,11 +2812,19 @@ class TestMtpDeclaredAbsentReconciliation:
     def test_weight_names_have_mtp_head_detector(self):
         # Direct unit for the segment matcher used to confirm head presence.
         assert auto_config_mod._weight_names_have_mtp_head(self._WITH_MTP_TENSORS)
+        # Sidecar layout (``mtp.*`` prefix) is also a valid exact segment.
+        assert auto_config_mod._weight_names_have_mtp_head(
+            ["mtp.layers.0.q_proj.weight"]
+        )
         assert not auto_config_mod._weight_names_have_mtp_head(self._NO_MTP_TENSORS)
-        # ``mtp`` must match only as a path segment, not a substring of an
-        # unrelated token.
+        # ``mtp`` must match only as an EXACT dot-delimited segment — neither a
+        # substring of an unrelated token nor a ``mtp``-prefixed sibling module
+        # (codex #1202 round 3).
         assert not auto_config_mod._weight_names_have_mtp_head(
             ["model.layers.0.attempts.weight"]
+        )
+        assert not auto_config_mod._weight_names_have_mtp_head(
+            ["model.mtp_adapter.0.weight", "model.mtp_cache.weight"]
         )
 
     def test_none_when_spec_decode_on(self, monkeypatch):
@@ -3005,3 +3013,56 @@ class TestLocalWeightTensorNames:
             )
             is None
         )
+
+    def test_oversized_index_returns_none(self, tmp_path, monkeypatch):
+        import json
+
+        self._write(
+            tmp_path,
+            "model.safetensors.index.json",
+            json.dumps({"weight_map": {"model.mtp.w": "s.safetensors"}}).encode(),
+        )
+        # Force the bound below the file size so the size-cap path trips
+        # without writing a genuinely huge file.
+        monkeypatch.setattr(auto_config_mod, "_SAFETENSORS_INDEX_MAX_BYTES", 4)
+        assert (
+            auto_config_mod._local_weight_tensor_names(
+                str(tmp_path), self._cfg(tmp_path)
+            )
+            is None
+        )
+
+
+class TestLoadHfConfigCached:
+    """``_load_hf_config_cached`` must always return a ``dict`` or ``None`` —
+    never a bare JSON scalar/list — and must bound the read (codex #1202
+    round 3), so a malformed cached ``config.json`` can't crash ``info``.
+    """
+
+    def _write_config(self, directory, data: bytes):
+        import os
+
+        with open(os.path.join(str(directory), "config.json"), "wb") as fh:
+            fh.write(data)
+
+    def test_non_dict_config_returns_none(self, tmp_path):
+        # A JSON list is valid JSON but not a config object ⇒ None, not a list.
+        self._write_config(tmp_path, b'["not", "a", "config"]')
+        cfg = ModelConfig(hf_path=str(tmp_path))
+        assert auto_config_mod._load_hf_config_cached(str(tmp_path), cfg) is None
+
+    def test_dict_config_returns_dict(self, tmp_path):
+        import json
+
+        self._write_config(tmp_path, json.dumps({"model_type": "qwen3_5"}).encode())
+        cfg = ModelConfig(hf_path=str(tmp_path))
+        out = auto_config_mod._load_hf_config_cached(str(tmp_path), cfg)
+        assert isinstance(out, dict) and out["model_type"] == "qwen3_5"
+
+    def test_oversized_config_returns_none(self, tmp_path, monkeypatch):
+        import json
+
+        self._write_config(tmp_path, json.dumps({"model_type": "qwen3_5"}).encode())
+        monkeypatch.setattr(auto_config_mod, "_CONFIG_JSON_MAX_BYTES", 2)
+        cfg = ModelConfig(hf_path=str(tmp_path))
+        assert auto_config_mod._load_hf_config_cached(str(tmp_path), cfg) is None

--- a/tests/test_model_auto_config.py
+++ b/tests/test_model_auto_config.py
@@ -2690,3 +2690,108 @@ class TestCheckpointMetadataFallback:
         monkeypatch.setattr(auto_config_mod, "read_model_metadata", lambda name: None)
 
         assert detect_model_config("publisher/unknown-model") is None
+
+
+class TestMtpDeclaredAbsentReconciliation:
+    """``_mtp_declared_absent_layers`` reconciles ``info`` with the config-
+    based serve-time MTP eligibility gate.
+
+    The serve gate reads ``config.json`` and, for a native-MTP checkpoint
+    whose config still declares ``mtp_num_hidden_layers >= 1`` after the head
+    weights were stripped, announces ``MTP: enabled`` then hard-fails at
+    inject. ``info`` is weight-free and reports a bare ``disabled``. This
+    helper detects the exact whiplash case so ``info`` can print the same
+    actionable sidecar note. The config read is monkeypatched here so the
+    test is deterministic and does NOT depend on the local HF cache.
+    """
+
+    _NATIVE = "mlx-community/Qwen3.6-9B-4bit"  # name segment ⇒ native_mtp
+
+    def _cfg(self, *, spec_off: bool):
+        return ModelConfig(hf_path=self._NATIVE, supports_spec_decode=not spec_off)
+
+    def test_returns_declared_layers_when_config_declares_but_spec_off(
+        self, monkeypatch
+    ):
+        # Config declares an MTP head (model_type qwen3_5, layers=1) but the
+        # profile has spec decode wired OFF ⇒ weights stripped ⇒ return N.
+        monkeypatch.setattr(
+            auto_config_mod,
+            "_load_hf_config_cached",
+            lambda path, cfg: {"model_type": "qwen3_5", "mtp_num_hidden_layers": 1},
+        )
+        n = auto_config_mod._mtp_declared_absent_layers(
+            self._NATIVE, self._cfg(spec_off=True)
+        )
+        assert n == 1
+
+    def test_none_when_spec_decode_on(self, monkeypatch):
+        # supports_spec_decode=True ⇒ native head IS wired; no whiplash, and
+        # the profile pre-filter must short-circuit BEFORE any config read.
+        def _boom(path, cfg):  # pragma: no cover - must never be called
+            raise AssertionError("config read must be skipped when spec is on")
+
+        monkeypatch.setattr(auto_config_mod, "_load_hf_config_cached", _boom)
+        assert (
+            auto_config_mod._mtp_declared_absent_layers(
+                self._NATIVE, self._cfg(spec_off=False)
+            )
+            is None
+        )
+
+    def test_none_for_non_native_family(self, monkeypatch):
+        # A non-native-MTP family (Llama) must short-circuit on the family
+        # pre-filter without reading config, even with spec decode off.
+        def _boom(path, cfg):  # pragma: no cover - must never be called
+            raise AssertionError("config read must be skipped for non-native family")
+
+        monkeypatch.setattr(auto_config_mod, "_load_hf_config_cached", _boom)
+        cfg = ModelConfig(
+            hf_path="mlx-community/Llama-3-8B-4bit", supports_spec_decode=False
+        )
+        assert (
+            auto_config_mod._mtp_declared_absent_layers(
+                "mlx-community/Llama-3-8B-4bit", cfg
+            )
+            is None
+        )
+
+    def test_none_when_config_uncached(self, monkeypatch):
+        # Config not in the local cache ⇒ helper degrades to None so the
+        # note is suppressed (info still renders, just without the note).
+        monkeypatch.setattr(
+            auto_config_mod, "_load_hf_config_cached", lambda path, cfg: None
+        )
+        assert (
+            auto_config_mod._mtp_declared_absent_layers(
+                self._NATIVE, self._cfg(spec_off=True)
+            )
+            is None
+        )
+
+    def test_none_when_config_declares_no_mtp(self, monkeypatch):
+        # Native-MTP family + spec off, but the config ALSO strips the layer
+        # count (declares nothing) ⇒ the plain ``disabled`` label is already
+        # honest; nothing to reconcile.
+        monkeypatch.setattr(
+            auto_config_mod,
+            "_load_hf_config_cached",
+            lambda path, cfg: {"model_type": "qwen3_5", "mtp_num_hidden_layers": 0},
+        )
+        assert (
+            auto_config_mod._mtp_declared_absent_layers(
+                self._NATIVE, self._cfg(spec_off=True)
+            )
+            is None
+        )
+
+    def test_profile_table_stays_deterministic_and_config_free(self, monkeypatch):
+        # Guard the design invariant: format_profile_table must NOT consult
+        # config.json — a config read there would make the fixed-width table
+        # cache-dependent and could break the MTP-path vocabulary contract.
+        def _boom(path, cfg):  # pragma: no cover - must never be called
+            raise AssertionError("format_profile_table must stay config-free")
+
+        monkeypatch.setattr(auto_config_mod, "_load_hf_config_cached", _boom)
+        table = format_profile_table(self._NATIVE, self._cfg(spec_off=True))
+        assert "MTP path         : disabled" in table

--- a/tests/test_model_auto_config.py
+++ b/tests/test_model_auto_config.py
@@ -2701,29 +2701,123 @@ class TestMtpDeclaredAbsentReconciliation:
     weights were stripped, announces ``MTP: enabled`` then hard-fails at
     inject. ``info`` is weight-free and reports a bare ``disabled``. This
     helper detects the exact whiplash case so ``info`` can print the same
-    actionable sidecar note. The config read is monkeypatched here so the
-    test is deterministic and does NOT depend on the local HF cache.
+    actionable sidecar note. The absence of the head is POSITIVELY verified
+    against the checkpoint's local safetensors index (not inferred from the
+    profile). Both the config read and the weight-index read are
+    monkeypatched here so the tests are deterministic and do NOT depend on
+    the local HF cache.
     """
 
     _NATIVE = "mlx-community/Qwen3.6-9B-4bit"  # name segment ⇒ native_mtp
+    # A weight index that declares NO MTP head tensor (stripped convert).
+    _NO_MTP_TENSORS = [
+        "model.embed_tokens.weight",
+        "model.layers.0.self_attn.q_proj.weight",
+        "lm_head.weight",
+    ]
+    # A weight index that DOES carry the native head (``model.mtp.*``).
+    _WITH_MTP_TENSORS = _NO_MTP_TENSORS + ["model.mtp.layers.0.self_attn.q_proj.weight"]
 
     def _cfg(self, *, spec_off: bool):
         return ModelConfig(hf_path=self._NATIVE, supports_spec_decode=not spec_off)
 
-    def test_returns_declared_layers_when_config_declares_but_spec_off(
-        self, monkeypatch
-    ):
-        # Config declares an MTP head (model_type qwen3_5, layers=1) but the
-        # profile has spec decode wired OFF ⇒ weights stripped ⇒ return N.
+    def _patch(self, monkeypatch, *, config, tensor_names):
+        monkeypatch.setattr(
+            auto_config_mod, "_load_hf_config_cached", lambda path, cfg: config
+        )
         monkeypatch.setattr(
             auto_config_mod,
-            "_load_hf_config_cached",
-            lambda path, cfg: {"model_type": "qwen3_5", "mtp_num_hidden_layers": 1},
+            "_local_weight_tensor_names",
+            lambda path, cfg: tensor_names,
+        )
+
+    def test_returns_declared_layers_when_config_declares_and_head_absent(
+        self, monkeypatch
+    ):
+        # Config declares an MTP head (model_type qwen3_5, layers=1), spec
+        # decode is off, AND the weight index positively confirms 0 mtp
+        # tensors ⇒ stripped convert ⇒ return N.
+        self._patch(
+            monkeypatch,
+            config={"model_type": "qwen3_5", "mtp_num_hidden_layers": 1},
+            tensor_names=self._NO_MTP_TENSORS,
         )
         n = auto_config_mod._mtp_declared_absent_layers(
             self._NATIVE, self._cfg(spec_off=True)
         )
         assert n == 1
+
+    def test_none_when_head_weights_present(self, monkeypatch):
+        # Config declares MTP and spec decode is off, BUT the weight index
+        # shows the head IS present ⇒ the profile is merely conservatively
+        # off; claiming "weights absent" would be false ⇒ return None
+        # (codex #1202 BLOCKING #1: verify, don't infer from the profile).
+        self._patch(
+            monkeypatch,
+            config={"model_type": "qwen3_5", "mtp_num_hidden_layers": 1},
+            tensor_names=self._WITH_MTP_TENSORS,
+        )
+        assert (
+            auto_config_mod._mtp_declared_absent_layers(
+                self._NATIVE, self._cfg(spec_off=True)
+            )
+            is None
+        )
+
+    def test_none_when_weight_index_unreadable(self, monkeypatch):
+        # Config declares MTP + spec off, but the weight index can't be read
+        # (uncached / no safetensors) ⇒ we cannot confirm absence ⇒ suppress
+        # the note rather than guess.
+        self._patch(
+            monkeypatch,
+            config={"model_type": "qwen3_5", "mtp_num_hidden_layers": 1},
+            tensor_names=None,
+        )
+        assert (
+            auto_config_mod._mtp_declared_absent_layers(
+                self._NATIVE, self._cfg(spec_off=True)
+            )
+            is None
+        )
+
+    def test_none_for_declared_family_without_mtp_segment_naming(self, monkeypatch):
+        # HY3 declares MTP via ``num_nextn_predict_layers`` but its extra
+        # layer is an ordinary ``model.layers.<n>`` block (no ``mtp`` segment),
+        # so the weight-index probe can't reliably confirm absence ⇒ the note
+        # is scoped out (return None) rather than risk a false claim. The
+        # weight reader must NOT even be consulted for such a model_type.
+        def _boom(path, cfg):  # pragma: no cover - must never be called
+            raise AssertionError("weight index must not be read for hy_v3")
+
+        monkeypatch.setattr(
+            auto_config_mod,
+            "_load_hf_config_cached",
+            lambda path, cfg: {
+                "model_type": "hy_v3",
+                "num_nextn_predict_layers": 1,
+            },
+        )
+        monkeypatch.setattr(auto_config_mod, "_local_weight_tensor_names", _boom)
+        # An HY3-named checkpoint so the family pre-filter passes.
+        cfg = ModelConfig(
+            hf_path="mlx-community/Hy3-preview-4bit", supports_spec_decode=False
+        )
+        assert (
+            auto_config_mod._mtp_declared_absent_layers(
+                "mlx-community/Hy3-preview-4bit", cfg
+            )
+            is None
+        )
+
+    def test_weight_names_have_mtp_head_detector(self):
+        # Direct unit for the segment matcher used to confirm head presence.
+        assert auto_config_mod._weight_names_have_mtp_head(self._WITH_MTP_TENSORS)
+        assert not auto_config_mod._weight_names_have_mtp_head(self._NO_MTP_TENSORS)
+        # ``mtp`` must match only as a path segment, not a substring of an
+        # unrelated token.
+        assert not auto_config_mod._weight_names_have_mtp_head(
+            ["model.layers.0.attempts.weight"]
+        )
 
     def test_none_when_spec_decode_on(self, monkeypatch):
         # supports_spec_decode=True ⇒ native head IS wired; no whiplash, and
@@ -2785,13 +2879,21 @@ class TestMtpDeclaredAbsentReconciliation:
             is None
         )
 
-    def test_profile_table_stays_deterministic_and_config_free(self, monkeypatch):
-        # Guard the design invariant: format_profile_table must NOT consult
-        # config.json — a config read there would make the fixed-width table
-        # cache-dependent and could break the MTP-path vocabulary contract.
-        def _boom(path, cfg):  # pragma: no cover - must never be called
-            raise AssertionError("format_profile_table must stay config-free")
+    def test_profile_table_does_not_invoke_any_config_or_weight_read(self, monkeypatch):
+        # Guard the design invariant precisely: ``format_profile_table``
+        # renders from the profile alone and must NOT invoke ANY of the
+        # disk-reading reconciliation helpers — a config.json / weight-index
+        # read there would make the fixed-width table cache-dependent and
+        # could break the MTP-path vocabulary contract. Every disk-touching
+        # entry point the reconciliation adds is patched to raise, so the
+        # test fails if the table reaches config OR the weight index through
+        # any of them (codex #1202 — the earlier version only patched the
+        # config reader and would have missed a weight-index read).
+        def _boom(*args, **kwargs):  # pragma: no cover - must never be called
+            raise AssertionError("format_profile_table must not read config/weights")
 
+        monkeypatch.setattr(auto_config_mod, "_mtp_declared_absent_layers", _boom)
         monkeypatch.setattr(auto_config_mod, "_load_hf_config_cached", _boom)
+        monkeypatch.setattr(auto_config_mod, "_local_weight_tensor_names", _boom)
         table = format_profile_table(self._NATIVE, self._cfg(spec_off=True))
         assert "MTP path         : disabled" in table

--- a/tests/test_model_auto_config.py
+++ b/tests/test_model_auto_config.py
@@ -2897,3 +2897,111 @@ class TestMtpDeclaredAbsentReconciliation:
         monkeypatch.setattr(auto_config_mod, "_local_weight_tensor_names", _boom)
         table = format_profile_table(self._NATIVE, self._cfg(spec_off=True))
         assert "MTP path         : disabled" in table
+
+
+class TestLocalWeightTensorNames:
+    """``_local_weight_tensor_names`` reads tensor names from a LOCAL
+    safetensors index / header defensively — a malformed or hostile file
+    must degrade to ``None`` ("couldn't check"), never to an empty list that
+    would falsely "confirm" the MTP head is absent (codex #1202 round 2).
+    """
+
+    @staticmethod
+    def _cfg(directory):
+        return ModelConfig(hf_path=str(directory))
+
+    def _write(self, directory, name, data: bytes):
+        import os
+
+        path = os.path.join(str(directory), name)
+        with open(path, "wb") as fh:
+            fh.write(data)
+        return path
+
+    def test_sharded_index_returns_weight_map_keys(self, tmp_path):
+        import json
+
+        keys = ["model.embed_tokens.weight", "model.mtp.layers.0.q_proj.weight"]
+        self._write(
+            tmp_path,
+            "model.safetensors.index.json",
+            json.dumps({"weight_map": {k: "shard.safetensors" for k in keys}}).encode(),
+        )
+        names = auto_config_mod._local_weight_tensor_names(
+            str(tmp_path), self._cfg(tmp_path)
+        )
+        assert set(names) == set(keys)
+
+    def test_malformed_index_missing_weight_map_returns_none(self, tmp_path):
+        import json
+
+        # Valid JSON but no ``weight_map`` — must NOT read as "zero tensors".
+        self._write(
+            tmp_path,
+            "model.safetensors.index.json",
+            json.dumps({"metadata": {"total_size": 1}}).encode(),
+        )
+        assert (
+            auto_config_mod._local_weight_tensor_names(
+                str(tmp_path), self._cfg(tmp_path)
+            )
+            is None
+        )
+
+    def test_empty_weight_map_returns_none(self, tmp_path):
+        import json
+
+        self._write(
+            tmp_path,
+            "model.safetensors.index.json",
+            json.dumps({"weight_map": {}}).encode(),
+        )
+        assert (
+            auto_config_mod._local_weight_tensor_names(
+                str(tmp_path), self._cfg(tmp_path)
+            )
+            is None
+        )
+
+    def test_single_file_header_returns_keys(self, tmp_path):
+        import json
+        import struct
+
+        header = {
+            "model.embed_tokens.weight": {
+                "dtype": "F16",
+                "shape": [1],
+                "data_offsets": [0, 2],
+            },
+            "__metadata__": {"format": "pt"},
+        }
+        blob = json.dumps(header).encode()
+        self._write(tmp_path, "model.safetensors", struct.pack("<Q", len(blob)) + blob)
+        names = auto_config_mod._local_weight_tensor_names(
+            str(tmp_path), self._cfg(tmp_path)
+        )
+        # ``__metadata__`` is filtered out; the real tensor name remains.
+        assert names == ["model.embed_tokens.weight"]
+
+    def test_single_file_oversized_header_returns_none(self, tmp_path):
+        import struct
+
+        # Header length far exceeds both the safetensors cap and the file
+        # size — must be rejected BEFORE allocating the read.
+        self._write(
+            tmp_path, "model.safetensors", struct.pack("<Q", 2_000_000_000) + b"{}"
+        )
+        assert (
+            auto_config_mod._local_weight_tensor_names(
+                str(tmp_path), self._cfg(tmp_path)
+            )
+            is None
+        )
+
+    def test_directory_without_safetensors_returns_none(self, tmp_path):
+        assert (
+            auto_config_mod._local_weight_tensor_names(
+                str(tmp_path), self._cfg(tmp_path)
+            )
+            is None
+        )

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -6405,6 +6405,7 @@ def info_command(args):
     """
     from vllm_mlx.model_aliases import resolve_model, resolve_profile
     from vllm_mlx.model_auto_config import (
+        _mtp_declared_absent_layers,
         detect_model_config,
         format_profile_table,
     )
@@ -6427,6 +6428,27 @@ def info_command(args):
     print()
     print(format_profile_table(name, cfg))
     print()
+
+    # Reconcile with the serve-time MTP eligibility gate: when config.json
+    # declares an MTP head but the head weights were stripped from this
+    # checkpoint, ``serve --speculative-config '{"method":"mtp"}'`` announces
+    # "MTP: enabled" and only hard-fails at inject time. Emit the same
+    # actionable sidecar guidance here so ``info`` and ``serve`` agree
+    # instead of the user getting whiplash.
+    if cfg is not None:
+        _declared_absent = _mtp_declared_absent_layers(name, cfg)
+        if _declared_absent is not None:
+            print(
+                f"  MTP: config declares mtp_num_hidden_layers={_declared_absent} "
+                "but the MTP head weights are absent in this checkpoint."
+            )
+            print(
+                "  Attach a separately-published MTP head, e.g.:\n"
+                f"    rapid-mlx serve {original_alias} "
+                """--speculative-config '{"method":"mtp","model":"<head-repo>"}'"""
+            )
+            print("  (or re-convert the base checkpoint with an MTP-preserving convert).")
+            print()
 
     # DFlash eligibility — render the report so users can see which
     # gates pass/fail without consulting the docs. Skipped for unknown

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -6438,16 +6438,24 @@ def info_command(args):
     if cfg is not None:
         _declared_absent = _mtp_declared_absent_layers(name, cfg)
         if _declared_absent is not None:
+            import shlex
+
+            # ``original_alias`` is user-supplied (may be a raw HF path with
+            # spaces / shell metacharacters); quote it so the printed command
+            # is safe to copy-paste.
+            _serve_target = shlex.quote(original_alias)
             print(
                 f"  MTP: config declares mtp_num_hidden_layers={_declared_absent} "
                 "but the MTP head weights are absent in this checkpoint."
             )
             print(
                 "  Attach a separately-published MTP head, e.g.:\n"
-                f"    rapid-mlx serve {original_alias} "
+                f"    rapid-mlx serve {_serve_target} "
                 """--speculative-config '{"method":"mtp","model":"<head-repo>"}'"""
             )
-            print("  (or re-convert the base checkpoint with an MTP-preserving convert).")
+            print(
+                "  (or re-convert the base checkpoint with an MTP-preserving convert)."
+            )
             print()
 
     # DFlash eligibility — render the report so users can see which

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -6448,10 +6448,15 @@ def info_command(args):
                 f"  MTP: config declares mtp_num_hidden_layers={_declared_absent} "
                 "but the MTP head weights are absent in this checkpoint."
             )
+            # Put options FIRST and separate the positional model target with
+            # ``--`` so a local model path that begins with ``-`` (or the
+            # quoting above) isn't parsed by argparse as a serve option — the
+            # copy-paste remedy must work for such paths too.
             print(
                 "  Attach a separately-published MTP head, e.g.:\n"
-                f"    rapid-mlx serve {_serve_target} "
-                """--speculative-config '{"method":"mtp","model":"<head-repo>"}'"""
+                "    rapid-mlx serve "
+                """--speculative-config '{"method":"mtp","model":"<head-repo>"}' """
+                f"-- {_serve_target}"
             )
             print(
                 "  (or re-convert the base checkpoint with an MTP-preserving convert)."

--- a/vllm_mlx/model_auto_config.py
+++ b/vllm_mlx/model_auto_config.py
@@ -2074,34 +2074,64 @@ def _mtp_path_label(model_path: str, cfg: "ModelConfig") -> str:
     return "disabled"
 
 
+# Upper bounds for the small metadata files this module reads off local
+# disk. A cached/hostile checkpoint could ship a multi-gigabyte ``config.json``
+# or ``model.safetensors.index.json``; both are normally < 1 MB, so reject
+# anything wildly larger before handing it to ``json`` rather than allocate
+# the read (codex #1202 round 3). Generous headroom over real checkpoints.
+_CONFIG_JSON_MAX_BYTES = 8_000_000
+_SAFETENSORS_INDEX_MAX_BYTES = 64_000_000
+
+
+def _read_bounded_json(path: str, max_bytes: int) -> Any:
+    """Parse JSON from ``path`` iff it is at most ``max_bytes``; else ``None``.
+
+    Size-checks before reading so an oversized/hostile file can't force a
+    huge allocation. Returns ``None`` on oversize, missing file, or any
+    parse/IO error (callers treat that as "couldn't read").
+    """
+    import json as _json
+    import os as _os
+
+    try:
+        if _os.path.getsize(path) > max_bytes:
+            return None
+        with open(path, "rb") as fh:
+            return _json.loads(fh.read(max_bytes))
+    except Exception:
+        return None
+
+
 def _load_hf_config_cached(model_path: str, cfg: "ModelConfig") -> "dict | None":
     """Read ``config.json`` for ``model_path`` from the LOCAL HF cache only.
 
     No network fetch — mirrors ``cli._gather_kv_cache_dtype_inputs``. Handles
     both a local checkpoint directory (``config.json`` on disk) and an HF
     repo id resolved through ``huggingface_hub.try_to_load_from_cache``.
-    Returns ``None`` on any miss / parse failure so callers degrade to the
-    weight-free label rather than crash.
+    Returns ``None`` on any miss / parse failure, on an oversized file, or
+    when the parsed value is not a JSON object — so callers always get a
+    ``dict`` or ``None`` and degrade to the weight-free label rather than
+    crash (codex #1202 round 3).
     """
-    import json as _json
     import os as _os
 
     hf_path = getattr(cfg, "hf_path", None) or model_path
     try:
         # Local checkpoint directory passed straight through.
         local = _os.path.join(str(hf_path), "config.json")
-        if _os.path.isfile(local):
-            with open(local) as fh:
-                return _json.load(fh)
-        from huggingface_hub import try_to_load_from_cache as _cache_lookup
+        path: str | None = local if _os.path.isfile(local) else None
+        if path is None:
+            from huggingface_hub import try_to_load_from_cache as _cache_lookup
 
-        cached = _cache_lookup(repo_id=str(hf_path), filename="config.json")
-        if cached and _os.path.exists(cached):
-            with open(cached) as fh:
-                return _json.load(fh)
+            cached = _cache_lookup(repo_id=str(hf_path), filename="config.json")
+            if isinstance(cached, str) and _os.path.isfile(cached):
+                path = cached
     except Exception:
         return None
-    return None
+    if path is None:
+        return None
+    data = _read_bounded_json(path, _CONFIG_JSON_MAX_BYTES)
+    return data if isinstance(data, dict) else None
 
 
 # ``model_type`` values whose native MTP head tensors are named with an
@@ -2140,8 +2170,9 @@ def _local_weight_tensor_names(
     hf_path = getattr(cfg, "hf_path", None) or model_path
 
     def _from_index(path: str) -> "list[str] | None":
-        with open(path) as fh:
-            data = _json.load(fh)
+        # Bounded read — a hostile/oversized index must not force a huge
+        # allocation (codex #1202 round 3).
+        data = _read_bounded_json(path, _SAFETENSORS_INDEX_MAX_BYTES)
         weight_map = data.get("weight_map") if isinstance(data, dict) else None
         # A syntactically valid but structurally broken index (missing /
         # empty ``weight_map``) must NOT be read as "zero tensors" — that
@@ -2208,16 +2239,16 @@ def _local_weight_tensor_names(
 
 
 def _weight_names_have_mtp_head(tensor_names: "list[str]") -> bool:
-    """True when any tensor name carries an ``mtp`` path segment.
+    """True when any tensor name carries an exact ``mtp`` path segment.
 
     The native Qwen3.5 / Qwen3.6 MTP head lives at ``model.mtp.*``; a
-    published sidecar carries ``mtp.*``. Matching a dot-delimited segment
-    that starts with ``mtp`` (``mtp``, ``mtp.layers``…) identifies the head
-    without false-matching unrelated tensors.
+    published sidecar carries ``mtp.*`` — in both cases ``mtp`` is its own
+    dot-delimited segment. Matching the EXACT segment (``seg == "mtp"``, not
+    a ``startswith`` prefix) avoids counting unrelated tensors like
+    ``mtp_adapter`` / ``mtp_cache`` as proof the head exists, which would
+    wrongly suppress the declared-but-absent diagnosis (codex #1202 round 3).
     """
-    return any(
-        seg.startswith("mtp") for name in tensor_names for seg in name.split(".")
-    )
+    return any(seg == "mtp" for name in tensor_names for seg in name.split("."))
 
 
 def _mtp_declared_absent_layers(model_path: str, cfg: "ModelConfig") -> int | None:

--- a/vllm_mlx/model_auto_config.py
+++ b/vllm_mlx/model_auto_config.py
@@ -2114,6 +2114,12 @@ def _load_hf_config_cached(model_path: str, cfg: "ModelConfig") -> "dict | None"
 _MTP_MTP_SEGMENT_MODEL_TYPES: frozenset[str] = frozenset({"qwen3_5", "qwen3_5_moe"})
 
 
+# safetensors caps its JSON header at 100 MB; refuse to read anything the
+# spec would reject so a malformed/hostile file can't make us allocate a
+# multi-gigabyte read (codex #1202 round 2).
+_SAFETENSORS_MAX_HEADER_BYTES = 100_000_000
+
+
 def _local_weight_tensor_names(
     model_path: str, cfg: "ModelConfig"
 ) -> "list[str] | None":
@@ -2123,8 +2129,9 @@ def _local_weight_tensor_names(
     present, else the single-file ``model.safetensors`` header (an 8-byte
     little-endian length prefix followed by a JSON blob of tensor metadata).
     LOCAL cache only — no network. Returns ``None`` when the checkpoint isn't
-    cached / has no recognizable safetensors, so callers can distinguish
-    "confirmed empty" from "couldn't check".
+    cached, has no recognizable safetensors, or the metadata is malformed —
+    so callers can distinguish "confirmed empty" from "couldn't check" and a
+    broken index never masquerades as "no MTP tensors".
     """
     import json as _json
     import os as _os
@@ -2132,34 +2139,68 @@ def _local_weight_tensor_names(
 
     hf_path = getattr(cfg, "hf_path", None) or model_path
 
-    def _from_index(path: str) -> list[str]:
+    def _from_index(path: str) -> "list[str] | None":
         with open(path) as fh:
-            weight_map = _json.load(fh).get("weight_map", {})
-        return list(weight_map.keys())
+            data = _json.load(fh)
+        weight_map = data.get("weight_map") if isinstance(data, dict) else None
+        # A syntactically valid but structurally broken index (missing /
+        # empty ``weight_map``) must NOT be read as "zero tensors" — that
+        # would falsely confirm the MTP head is absent (codex #1202 round 2).
+        if not isinstance(weight_map, dict) or not weight_map:
+            return None
+        keys = [k for k in weight_map if isinstance(k, str)]
+        return keys or None
 
-    def _from_single(path: str) -> list[str]:
+    def _from_single(path: str) -> "list[str] | None":
+        size = _os.path.getsize(path)
+        if size < 8:
+            return None
         with open(path, "rb") as fh:
             (header_len,) = _struct.unpack("<Q", fh.read(8))
+            # Reject an oversized / impossible header before allocating the
+            # read (untrusted length field — codex #1202 round 2).
+            if (
+                header_len <= 0
+                or header_len > _SAFETENSORS_MAX_HEADER_BYTES
+                or 8 + header_len > size
+            ):
+                return None
             header = _json.loads(fh.read(header_len))
-        return [k for k in header if k != "__metadata__"]
+        if not isinstance(header, dict):
+            return None
+        keys = [k for k in header if isinstance(k, str) and k != "__metadata__"]
+        return keys or None
+
+    def _resolve(directory: str, filename: str) -> "str | None":
+        """Local path for ``filename`` in a checkpoint dir or HF cache repo.
+
+        ``try_to_load_from_cache`` returns a truthy ``_CACHED_NO_EXIST``
+        sentinel (NOT a path) when it knows the file is absent; accept only
+        real ``str`` paths so the sentinel is treated as a miss and the
+        caller can fall through to the next candidate (codex #1202 round 2).
+        """
+        local = _os.path.join(directory, filename)
+        if _os.path.isfile(local):
+            return local
+        if _os.path.isdir(directory):
+            return None  # explicit local dir — don't consult the HF cache
+        from huggingface_hub import try_to_load_from_cache as _cache_lookup
+
+        cached = _cache_lookup(repo_id=directory, filename=filename)
+        if isinstance(cached, str) and _os.path.isfile(cached):
+            return cached
+        return None
 
     try:
         directory = str(hf_path)
-        if _os.path.isdir(directory):
-            idx = _os.path.join(directory, "model.safetensors.index.json")
-            if _os.path.isfile(idx):
-                return _from_index(idx)
-            single = _os.path.join(directory, "model.safetensors")
-            if _os.path.isfile(single):
-                return _from_single(single)
-            return None
-        from huggingface_hub import try_to_load_from_cache as _cache_lookup
-
-        idx = _cache_lookup(repo_id=directory, filename="model.safetensors.index.json")
-        if idx and _os.path.exists(idx):
+        idx = _resolve(directory, "model.safetensors.index.json")
+        if idx is not None:
+            # A sharded checkpoint: the index is authoritative (return its
+            # keys, or None if it's malformed — do not fall back to a
+            # single-file that won't exist alongside a real index).
             return _from_index(idx)
-        single = _cache_lookup(repo_id=directory, filename="model.safetensors")
-        if single and _os.path.exists(single):
+        single = _resolve(directory, "model.safetensors")
+        if single is not None:
             return _from_single(single)
     except Exception:
         return None

--- a/vllm_mlx/model_auto_config.py
+++ b/vllm_mlx/model_auto_config.py
@@ -2180,15 +2180,16 @@ def _local_weight_tensor_names(
         if not isinstance(weight_map, dict) or not weight_map:
             return None
         # A real weight_map maps a tensor name to a NON-EMPTY shard filename.
-        # An entry whose value is null / empty / non-string is a malformed
-        # descriptor, not evidence that the tensor is present — count only
-        # well-formed entries so a corrupt index can't fabricate a phantom
-        # MTP-head tensor name (codex #1202 round 4).
-        keys = [
-            k
-            for k, v in weight_map.items()
-            if isinstance(k, str) and isinstance(v, str) and v
-        ]
+        # Fail CLOSED: if ANY entry is malformed (non-string key, or a null /
+        # empty / non-string shard value), treat the whole index as
+        # untrustworthy and return None. Silently dropping a malformed
+        # ``mtp.*`` entry could falsely confirm the MTP head is ABSENT — a
+        # false negative in the absence probe (codex #1202 round 5).
+        keys = []
+        for k, v in weight_map.items():
+            if not (isinstance(k, str) and isinstance(v, str) and v):
+                return None
+            keys.append(k)
         return keys or None
 
     def _from_single(path: str) -> "list[str] | None":
@@ -2210,16 +2211,17 @@ def _local_weight_tensor_names(
             return None
         # Data region the tensor byte-ranges must fall inside.
         data_region = size - 8 - header_len
-        # A real tensor entry is a dict whose ``data_offsets`` [start, end]
-        # are in-bounds. Reject malformed descriptors so a corrupt header
-        # can't fabricate a phantom MTP-head tensor name from a stray key
-        # (codex #1202 round 4).
+        # Fail CLOSED: a real tensor entry is a dict whose ``data_offsets``
+        # [start, end] are in-bounds. If ANY non-``__metadata__`` entry is
+        # malformed, return None for the whole header rather than silently
+        # dropping it — a dropped ``mtp.*`` entry would falsely confirm the
+        # MTP head is absent (codex #1202 round 5).
         keys = []
         for k, desc in header.items():
-            if not isinstance(k, str) or k == "__metadata__":
+            if k == "__metadata__":
                 continue
-            if not isinstance(desc, dict):
-                continue
+            if not isinstance(k, str) or not isinstance(desc, dict):
+                return None
             offs = desc.get("data_offsets")
             if (
                 not isinstance(offs, (list, tuple))
@@ -2227,7 +2229,7 @@ def _local_weight_tensor_names(
                 or not all(isinstance(o, int) and not isinstance(o, bool) for o in offs)
                 or not (0 <= offs[0] <= offs[1] <= data_region)
             ):
-                continue
+                return None
             keys.append(k)
         return keys or None
 

--- a/vllm_mlx/model_auto_config.py
+++ b/vllm_mlx/model_auto_config.py
@@ -2179,7 +2179,16 @@ def _local_weight_tensor_names(
         # would falsely confirm the MTP head is absent (codex #1202 round 2).
         if not isinstance(weight_map, dict) or not weight_map:
             return None
-        keys = [k for k in weight_map if isinstance(k, str)]
+        # A real weight_map maps a tensor name to a NON-EMPTY shard filename.
+        # An entry whose value is null / empty / non-string is a malformed
+        # descriptor, not evidence that the tensor is present — count only
+        # well-formed entries so a corrupt index can't fabricate a phantom
+        # MTP-head tensor name (codex #1202 round 4).
+        keys = [
+            k
+            for k, v in weight_map.items()
+            if isinstance(k, str) and isinstance(v, str) and v
+        ]
         return keys or None
 
     def _from_single(path: str) -> "list[str] | None":
@@ -2199,7 +2208,27 @@ def _local_weight_tensor_names(
             header = _json.loads(fh.read(header_len))
         if not isinstance(header, dict):
             return None
-        keys = [k for k in header if isinstance(k, str) and k != "__metadata__"]
+        # Data region the tensor byte-ranges must fall inside.
+        data_region = size - 8 - header_len
+        # A real tensor entry is a dict whose ``data_offsets`` [start, end]
+        # are in-bounds. Reject malformed descriptors so a corrupt header
+        # can't fabricate a phantom MTP-head tensor name from a stray key
+        # (codex #1202 round 4).
+        keys = []
+        for k, desc in header.items():
+            if not isinstance(k, str) or k == "__metadata__":
+                continue
+            if not isinstance(desc, dict):
+                continue
+            offs = desc.get("data_offsets")
+            if (
+                not isinstance(offs, (list, tuple))
+                or len(offs) != 2
+                or not all(isinstance(o, int) and not isinstance(o, bool) for o in offs)
+                or not (0 <= offs[0] <= offs[1] <= data_region)
+            ):
+                continue
+            keys.append(k)
         return keys or None
 
     def _resolve(directory: str, filename: str) -> "str | None":

--- a/vllm_mlx/model_auto_config.py
+++ b/vllm_mlx/model_auto_config.py
@@ -2104,14 +2104,102 @@ def _load_hf_config_cached(model_path: str, cfg: "ModelConfig") -> "dict | None"
     return None
 
 
+# ``model_type`` values whose native MTP head tensors are named with an
+# ``mtp`` path segment (``model.mtp.*`` in the checkpoint, ``mtp.*`` in a
+# sidecar — see ``spec_decode.mtp.qwen3_5_inject``). Only for these can the
+# weight-index probe positively confirm the head is present or absent. Other
+# native-MTP families (e.g. HY3, whose extra predict layer is an ordinary
+# ``model.layers.<n>`` block) are NOT probed here — the caller degrades to
+# ``None`` rather than risk a false "absent" claim.
+_MTP_MTP_SEGMENT_MODEL_TYPES: frozenset[str] = frozenset({"qwen3_5", "qwen3_5_moe"})
+
+
+def _local_weight_tensor_names(
+    model_path: str, cfg: "ModelConfig"
+) -> "list[str] | None":
+    """Tensor names from the LOCAL safetensors index / header, or ``None``.
+
+    Reads the sharded ``model.safetensors.index.json`` weight map when
+    present, else the single-file ``model.safetensors`` header (an 8-byte
+    little-endian length prefix followed by a JSON blob of tensor metadata).
+    LOCAL cache only — no network. Returns ``None`` when the checkpoint isn't
+    cached / has no recognizable safetensors, so callers can distinguish
+    "confirmed empty" from "couldn't check".
+    """
+    import json as _json
+    import os as _os
+    import struct as _struct
+
+    hf_path = getattr(cfg, "hf_path", None) or model_path
+
+    def _from_index(path: str) -> list[str]:
+        with open(path) as fh:
+            weight_map = _json.load(fh).get("weight_map", {})
+        return list(weight_map.keys())
+
+    def _from_single(path: str) -> list[str]:
+        with open(path, "rb") as fh:
+            (header_len,) = _struct.unpack("<Q", fh.read(8))
+            header = _json.loads(fh.read(header_len))
+        return [k for k in header if k != "__metadata__"]
+
+    try:
+        directory = str(hf_path)
+        if _os.path.isdir(directory):
+            idx = _os.path.join(directory, "model.safetensors.index.json")
+            if _os.path.isfile(idx):
+                return _from_index(idx)
+            single = _os.path.join(directory, "model.safetensors")
+            if _os.path.isfile(single):
+                return _from_single(single)
+            return None
+        from huggingface_hub import try_to_load_from_cache as _cache_lookup
+
+        idx = _cache_lookup(repo_id=directory, filename="model.safetensors.index.json")
+        if idx and _os.path.exists(idx):
+            return _from_index(idx)
+        single = _cache_lookup(repo_id=directory, filename="model.safetensors")
+        if single and _os.path.exists(single):
+            return _from_single(single)
+    except Exception:
+        return None
+    return None
+
+
+def _weight_names_have_mtp_head(tensor_names: "list[str]") -> bool:
+    """True when any tensor name carries an ``mtp`` path segment.
+
+    The native Qwen3.5 / Qwen3.6 MTP head lives at ``model.mtp.*``; a
+    published sidecar carries ``mtp.*``. Matching a dot-delimited segment
+    that starts with ``mtp`` (``mtp``, ``mtp.layers``…) identifies the head
+    without false-matching unrelated tensors.
+    """
+    return any(
+        seg.startswith("mtp") for name in tensor_names for seg in name.split(".")
+    )
+
+
 def _mtp_declared_absent_layers(model_path: str, cfg: "ModelConfig") -> int | None:
     """Reconcile ``rapid-mlx info`` with the serve-time MTP eligibility gate.
 
     Returns the ``mtp_num_hidden_layers`` value the checkpoint's
-    ``config.json`` DECLARES when the config advertises a native MTP head
-    (supported ``model_type`` + ``mtp_num_hidden_layers >= 1``) but this
-    profile has spec decode wired OFF (``supports_spec_decode=False`` — the
-    head weights were stripped at convert time). Returns ``None`` otherwise.
+    ``config.json`` DECLARES when ALL of the following hold, and ``None``
+    otherwise:
+
+    * the config advertises a native MTP head (supported ``model_type`` +
+      ``mtp_num_hidden_layers >= 1``), AND
+    * the local weight index is READABLE and positively confirms the head
+      tensors are ABSENT (0 ``mtp`` tensors) — i.e. the head was stripped at
+      convert time.
+
+    The absence is verified against the checkpoint's own safetensors index,
+    NOT inferred from ``supports_spec_decode`` — a stale or conservative
+    profile could wire spec decode off while the head weights are actually
+    present, and claiming "weights absent" there would be false (codex
+    #1202). Verification is scoped to Qwen3.5 / Qwen3.6 (``qwen3_5`` /
+    ``qwen3_5_moe``), the families whose head tensors carry an ``mtp`` path
+    segment; when the index can't be read (uncached) the note is suppressed
+    rather than guessed.
 
     Why this exists: the serve-time gate is CONFIG-based — it runs
     ``detect_mtp_eligibility(config.json)`` and, for a checkpoint whose
@@ -2159,6 +2247,21 @@ def _mtp_declared_absent_layers(model_path: str, cfg: "ModelConfig") -> int | No
         # Config also says NONE (unsupported model_type, or the layer count
         # was stripped from config too) — the plain "disabled" label is
         # already honest; nothing to reconcile.
+        return None
+
+    # Positively verify the head tensors are absent from the local
+    # checkpoint (do NOT infer absence from ``supports_spec_decode``). Scoped
+    # to families whose head tensors carry an ``mtp`` segment; for others, or
+    # when the weight index can't be read, suppress the note rather than risk
+    # a false "weights absent" claim.
+    if result.model_type not in _MTP_MTP_SEGMENT_MODEL_TYPES:
+        return None
+    tensor_names = _local_weight_tensor_names(model_path, cfg)
+    if tensor_names is None:
+        return None
+    if _weight_names_have_mtp_head(tensor_names):
+        # Head weights ARE present — the profile is just conservatively off;
+        # this is not the declared-but-absent whiplash. No note.
         return None
     return result.num_mtp_layers
 

--- a/vllm_mlx/model_auto_config.py
+++ b/vllm_mlx/model_auto_config.py
@@ -2074,6 +2074,95 @@ def _mtp_path_label(model_path: str, cfg: "ModelConfig") -> str:
     return "disabled"
 
 
+def _load_hf_config_cached(model_path: str, cfg: "ModelConfig") -> "dict | None":
+    """Read ``config.json`` for ``model_path`` from the LOCAL HF cache only.
+
+    No network fetch — mirrors ``cli._gather_kv_cache_dtype_inputs``. Handles
+    both a local checkpoint directory (``config.json`` on disk) and an HF
+    repo id resolved through ``huggingface_hub.try_to_load_from_cache``.
+    Returns ``None`` on any miss / parse failure so callers degrade to the
+    weight-free label rather than crash.
+    """
+    import json as _json
+    import os as _os
+
+    hf_path = getattr(cfg, "hf_path", None) or model_path
+    try:
+        # Local checkpoint directory passed straight through.
+        local = _os.path.join(str(hf_path), "config.json")
+        if _os.path.isfile(local):
+            with open(local) as fh:
+                return _json.load(fh)
+        from huggingface_hub import try_to_load_from_cache as _cache_lookup
+
+        cached = _cache_lookup(repo_id=str(hf_path), filename="config.json")
+        if cached and _os.path.exists(cached):
+            with open(cached) as fh:
+                return _json.load(fh)
+    except Exception:
+        return None
+    return None
+
+
+def _mtp_declared_absent_layers(model_path: str, cfg: "ModelConfig") -> int | None:
+    """Reconcile ``rapid-mlx info`` with the serve-time MTP eligibility gate.
+
+    Returns the ``mtp_num_hidden_layers`` value the checkpoint's
+    ``config.json`` DECLARES when the config advertises a native MTP head
+    (supported ``model_type`` + ``mtp_num_hidden_layers >= 1``) but this
+    profile has spec decode wired OFF (``supports_spec_decode=False`` — the
+    head weights were stripped at convert time). Returns ``None`` otherwise.
+
+    Why this exists: the serve-time gate is CONFIG-based — it runs
+    ``detect_mtp_eligibility(config.json)`` and, for a checkpoint whose
+    config still declares ``mtp_num_hidden_layers=1`` after the head weights
+    were stripped, it announces ``MTP: enabled via --speculative-config``
+    and only hard-fails later at inject time when the weights turn out to be
+    missing. The weight-free ``info`` label, by contrast, reports a bare
+    ``disabled`` off the profile. A user who runs ``info`` then ``serve``
+    gets whiplash. Surfacing the declared layer count here lets ``info``
+    print the same actionable ``MTP:`` note the serve-time hard-fail already
+    emits: the head is declared but absent, so attach a sidecar head (or
+    re-convert preserving MTP).
+
+    Consumed by ``cli.info_command`` to render that note AFTER the profile
+    table — the fixed-width table itself stays weight-free / config-free and
+    deterministic (its cells are unchanged). This helper reads
+    ``config.json`` (LOCAL cache only, no network) and is pre-filtered on
+    the resolved profile so it only touches disk for the exact
+    whiplash-prone case: a native-MTP-family checkpoint with spec decode
+    disabled. Returns ``None`` (note suppressed) when the config isn't
+    cached, so the output degrades gracefully. Behaviour of the serve-time
+    gate is unchanged — this only reconciles the ``info`` reporting.
+    """
+    # Cheap profile pre-filter (no IO): only a native-MTP family whose
+    # profile has spec decode wired off can hit the config-declares-but-
+    # weights-absent whiplash. Everything else keeps the weight-free path.
+    if cfg.supports_spec_decode:
+        return None
+    if _resolve_family(model_path, cfg) != "native_mtp":
+        return None
+
+    config = _load_hf_config_cached(model_path, cfg)
+    if config is None:
+        return None
+
+    # Reuse the serve-time detector so info and serve read the config the
+    # same way (do NOT reinvent the layer-count logic).
+    from vllm_mlx.spec_decode.mtp.detect import (
+        MTPEligibility,
+        _detect_mtp_eligibility_verbose,
+    )
+
+    result = _detect_mtp_eligibility_verbose(config)
+    if result.eligibility is MTPEligibility.NONE:
+        # Config also says NONE (unsupported model_type, or the layer count
+        # was stripped from config too) — the plain "disabled" label is
+        # already honest; nothing to reconcile.
+        return None
+    return result.num_mtp_layers
+
+
 def _kv_share_label(model_path: str, cfg: "ModelConfig") -> str:
     """Truth-in-labeling for cross-layer KV-sharing.
 


### PR DESCRIPTION
## Why

`rapid-mlx info <native-MTP checkpoint whose head weights were stripped at convert>` (e.g. `qwen3.6-27b-8bit` → `unsloth/Qwen3.6-27B-MLX-8bit`, whose `config.json` still declares `text_config.mtp_num_hidden_layers=1` but ships 0 `mtp.*` tensors) reported a bare:

```
Spec decode      : ✗ disabled (no MTP/drafter trained)
MTP path         : disabled
```

…while `serve <same model> --speculative-config '{"method":"mtp"}'` first announced `MTP: enabled via --speculative-config` and only THEN hard-failed at inject time (the serve gate is CONFIG-based → sees the declaration → announces enabled; inject discovers the weights are absent). Both surfaces were individually correct, but a user who ran `info` then `serve` got whiplash.

## What

Add an actionable `MTP:` note under the `info` profile table that mirrors the exact serve-time hard-fail guidance and points to the resolution — the **sidecar path**:

```
  MTP: config declares mtp_num_hidden_layers=1 but the MTP head weights are absent in this checkpoint.
  Attach a separately-published MTP head, e.g.:
    rapid-mlx serve qwen3.6-27b-8bit --speculative-config '{"method":"mtp","model":"<head-repo>"}'
  (or re-convert the base checkpoint with an MTP-preserving convert).
```

The note fires exactly when the config declares an MTP head (`_detect_mtp_eligibility_verbose` != NONE, reusing the serve-time detector) but the resolved profile has spec decode wired off (head weights stripped). Now `info` and `serve` agree and both point to the sidecar.

## Design / safety

- **No gate/eligibility BEHAVIOR change.** The serve-time gate still correctly hard-fails; `detect.py` is untouched. This only reconciles the `info` REPORTING surface.
- The fixed-width profile table stays weight-free / config-free and deterministic — its cells are unchanged, preserving the `MTP path` controlled-vocabulary contract.
- The `config.json` read (LOCAL HF cache only, no network) lives solely in the new `_mtp_declared_absent_layers` helper, is pre-filtered on the resolved profile so it only touches disk for the exact whiplash-prone case (native-MTP family + spec decode off), and degrades to no-note when the config isn't cached.

## Tests

- 6 deterministic unit tests for `_mtp_declared_absent_layers` (config read monkeypatched; covers declared-but-absent, spec-on short-circuit, non-native family, uncached, config-declares-none, and a guard that `format_profile_table` stays config-free).
- 2 `info` note tests (note appears when declared-but-absent; suppressed otherwise).
- Full `test_model_auto_config.py` + `test_cli_info.py` + MTP/DFlash/DDTree suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)