### PR TITLE
ci(release): credit external PR contributors

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -22,7 +22,9 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
-          fetch-depth: 2
+          # Release notes and contributor recognition need the complete range
+          # from the previous tag, not only the version-bump commit.
+          fetch-depth: 0
 
       - name: Parse commit subject
         id: parse
@@ -83,6 +85,34 @@ jobs:
             COMMITS=$(git log -50 --pretty='- %s (%h)')
           fi
 
+          # Credit every merged PR author other than the repository owner.
+          # Squash commits end in ``(#123)``; merge commits use the standard
+          # ``Merge pull request #123`` subject.
+          OWNER="${GITHUB_REPOSITORY%%/*}"
+          PR_NUMBERS=$(
+            {
+              git log "${PREV_TAG:+$PREV_TAG..}HEAD" --pretty='%s' |
+                sed -nE 's/.*\(#([0-9]+)\)$/\1/p'
+              git log "${PREV_TAG:+$PREV_TAG..}HEAD" --pretty='%s' |
+                sed -nE 's/^Merge pull request #([0-9]+).*/\1/p'
+            } | sort -nu
+          )
+          CONTRIBUTIONS=()
+          while IFS= read -r PR_NUMBER; do
+            [ -n "$PR_NUMBER" ] || continue
+            PR_JSON=$(gh pr view "$PR_NUMBER" \
+              --repo "$GITHUB_REPOSITORY" \
+              --json author,title,url 2>/dev/null) || continue
+            AUTHOR=$(jq -r '.author.login // empty' <<<"$PR_JSON")
+            if [ -z "$AUTHOR" ] || [ "$AUTHOR" = "$OWNER" ]; then
+              continue
+            fi
+            CONTRIBUTIONS+=("$(
+              jq -r '"- [@\(.author.login)](https://github.com/\(.author.login)) — [\(.title)](\(.url))"' \
+                <<<"$PR_JSON"
+            )")
+          done <<<"$PR_NUMBERS"
+
           {
             echo 'body<<__EOF__'
             echo "## What's new in v$VERSION"
@@ -93,6 +123,12 @@ jobs:
               echo "_(no changes recorded)_"
             fi
             echo
+            if [ "${#CONTRIBUTIONS[@]}" -gt 0 ]; then
+              echo "## Community contributors"
+              echo
+              printf '%s\n' "${CONTRIBUTIONS[@]}"
+              echo
+            fi
             echo "Install: \`brew upgrade rapid-mlx\` or \`pip install -U rapid-mlx==$VERSION\` (or just \`rapid-mlx upgrade\`)."
             echo '__EOF__'
           } >> "$GITHUB_OUTPUT"

--- a/docs/development/releasing.md
+++ b/docs/development/releasing.md
@@ -11,7 +11,7 @@ The historical pain point: between v0.6.14 (2026-05-05) and v0.6.16, several PRs
 
 | Trigger | What happens automatically |
 |---|---|
-| Push commit `chore: bump version to X.Y.Z` to `main` | `auto-release.yml` creates tag `vX.Y.Z` + GitHub Release |
+| Push commit `chore: bump version to X.Y.Z` to `main` | `auto-release.yml` creates tag `vX.Y.Z` + GitHub Release, crediting every merged PR author other than the repository owner |
 | GitHub Release published | `publish.yml` builds → PyPI publish → dispatches Homebrew tap to bump formula |
 | PR changes the `pyproject.toml` `version` line outside a dedicated bump PR | `version-check.yml` **fails** — version may only change in a PR titled `chore: bump version to X.Y.Z` (the `version-bump` label authorizes the change but still requires that release-shaped title; the `skip-version-bump` label is the escape hatch for corrections) |
 
@@ -53,7 +53,7 @@ The full path from "I want to release" to "users on `brew upgrade` see the new v
 
    The commit subject **must** match `chore: bump version to X.Y.Z` exactly — `auto-release.yml` parses it.
 
-3. **`auto-release.yml` fires** (~30s) — verifies the commit, checks the tag doesn't already exist, builds a CHANGELOG from `git log <prev-tag>..HEAD`, creates the GitHub Release.
+3. **`auto-release.yml` fires** (~30s) — verifies the commit, checks the tag doesn't already exist, builds a CHANGELOG from `git log <prev-tag>..HEAD`, adds a linked **Community contributors** entry for every merged PR author other than the repository owner, and creates the GitHub Release.
 
 4. **`publish.yml` fires on `release: published`** (~3min) — builds sdist + wheel, uploads to PyPI (via the `pypi` deployment environment).
 


### PR DESCRIPTION
## What changed

- Generate release notes from the full previous-tag range instead of a two-commit shallow checkout.
- Add a linked `Community contributors` section for every merged PR author other than the repository owner.
- Document the recognition behavior in the release runbook.

## Why

External contributors should receive visible, contribution-specific recognition in every release, including repeat contributors rather than only first-time contributors.

## Validation

- Replayed the collector against `v0.9.14..v0.10.0`, `v0.10.5..v0.10.7`, `v0.10.10..v0.10.12`, and `v0.10.18..v0.11.0`; it found exactly 9 external PRs by 7 contributors.
- `python3 scripts/check_gha_pinning.py`
- `git diff --check`