### PR TITLE
fix(mtp): correct false comment on MTP sidecar float-dtype role check

### DIFF
--- a/tests/test_mtp_spec_decode.py
+++ b/tests/test_mtp_spec_decode.py
@@ -2048,18 +2048,30 @@ def test_quantized_matmul_and_gather_qmm_tolerate_mismatched_floating_dtype():
     )
 
     # The MoE path (SwitchGLU / QuantizedSwitchLinear -> gather_qmm) —
-    # exercised when a Qwen3.6 MoE MTP head layer is present.
+    # exercised when a Qwen3.6 MoE MTP head layer is present. Cover BOTH
+    # directions here too (matching the quantized_matmul cases above and
+    # the "in both directions" claim in the qwen3_5_inject.py comment):
+    # (a) fp32 module/input with mismatched bf16/fp16 sidecar scales, and
+    # (b) the reverse — a bf16 module/input with mismatched fp32 scales,
+    # which is exactly the "fp32 scales for a bf16 MoE module" config the
+    # by-role check accepts.
     from mlx_lm.models.switch_layers import SwitchGLU
 
     num_experts, top_k = 4, 2
-    switch = SwitchGLU(in_dims, in_dims, num_experts)
-    _nn.quantize(switch, group_size=group_size, bits=bits)
-    _mx.eval(switch.parameters())
-    x_moe = _mx.random.uniform(shape=(1, 3, in_dims)).astype(_mx.float32)
     inds = _mx.array([[0, 1], [1, 2], [2, 3]]).reshape(1, 3, top_k)
-    gate = switch.gate_proj
 
-    def gather_qmm_ok(scales, biases):
+    def make_switch(param_dtype):
+        switch = SwitchGLU(in_dims, in_dims, num_experts)
+        # Cast each SwitchLinear's FP weight before quantizing so the
+        # derived scales/biases land in ``param_dtype``.
+        for _name in ("gate_proj", "up_proj", "down_proj"):
+            _lin = getattr(switch, _name)
+            _lin.weight = _lin.weight.astype(param_dtype)
+        _nn.quantize(switch, group_size=group_size, bits=bits)
+        _mx.eval(switch.parameters())
+        return switch
+
+    def gather_qmm_ok(gate, x_moe, scales, biases):
         out = _mx.gather_qmm(
             x_moe,
             gate.weight,
@@ -2073,8 +2085,34 @@ def test_quantized_matmul_and_gather_qmm_tolerate_mismatched_floating_dtype():
         _mx.eval(out)
         assert bool(_mx.all(_mx.isfinite(out)).item())
 
-    gather_qmm_ok(gate.scales.astype(_mx.bfloat16), gate.biases)
-    gather_qmm_ok(gate.scales, gate.biases.astype(_mx.float16))
+    # (a) fp32 MoE module + fp32 input, scales/biases forced to bf16 / fp16.
+    fp32_switch = make_switch(_mx.float32)
+    fp32_gate = fp32_switch.gate_proj
+    assert fp32_gate.scales.dtype == _mx.float32
+    x_moe_fp32 = _mx.random.uniform(shape=(1, 3, in_dims)).astype(_mx.float32)
+    gather_qmm_ok(
+        fp32_gate, x_moe_fp32, fp32_gate.scales.astype(_mx.bfloat16), fp32_gate.biases
+    )
+    gather_qmm_ok(
+        fp32_gate, x_moe_fp32, fp32_gate.scales, fp32_gate.biases.astype(_mx.float16)
+    )
+
+    # (b) the reverse: bf16 MoE module + bf16 input, scales/biases forced
+    # to fp32 — the "fp32 scales for a bf16 MoE module" config the by-role
+    # check accepts and the comment claims tolerance for.
+    bf16_switch = make_switch(_mx.bfloat16)
+    bf16_gate = bf16_switch.gate_proj
+    assert bf16_gate.scales.dtype == _mx.bfloat16
+    x_moe_bf16 = _mx.random.uniform(shape=(1, 3, in_dims)).astype(_mx.bfloat16)
+    gather_qmm_ok(
+        bf16_gate, x_moe_bf16, bf16_gate.scales.astype(_mx.float32), bf16_gate.biases
+    )
+    gather_qmm_ok(
+        bf16_gate,
+        x_moe_bf16,
+        bf16_gate.scales.astype(_mx.float32),
+        bf16_gate.biases.astype(_mx.float32),
+    )
 
 
 def test_inject_accepts_sidecar_with_mismatched_floating_scales_dtype_and_drafts_correctly(

--- a/tests/test_mtp_spec_decode.py
+++ b/tests/test_mtp_spec_decode.py
@@ -1962,8 +1962,9 @@ def test_quantized_matmul_and_gather_qmm_tolerate_mismatched_floating_dtype():
     ``QuantizedLinear`` for ``fc`` / attention projections, and
     ``QuantizedSwitchLinear`` via ``gather_qmm`` for any MoE MTP
     layer) actually reject a float-dtype mismatch between
-    weight/scales/biases/x. Empirically — on this repo's pinned MLX
-    (``mlx>=0.31.2``), on the default GPU (Metal) device — they do
+    weight/scales/biases/x. Empirically — on the default GPU (Metal)
+    device, on both MLX versions this was checked against (0.31.2, the
+    ``mlx>=0.31.2`` floor pyproject declares, and 0.32.0) — they do
     NOT: every fp32/bf16/fp16 combination below (module built fp32
     with mismatched scales/biases, and the reverse: module built
     bf16 with mismatched scales) runs to completion and returns a

--- a/tests/test_mtp_spec_decode.py
+++ b/tests/test_mtp_spec_decode.py
@@ -2288,6 +2288,23 @@ def test_inject_accepts_sidecar_with_mismatched_floating_scales_dtype_and_drafts
     and the resulting logits are compared against an
     otherwise-identical fp32-scale CONTROL forward within an
     explicit tolerance.
+
+    Hardened AGAIN, terminally, per THREE independent codex reviews of
+    THIS PR unanimously flagging the same residual gap: the
+    tolerance-vs-CONTROL ``allclose`` above can still pass VACUOUSLY —
+    if ``mtp_forward`` never actually reads the selected ``victim``
+    tensor (an unused param, or one that's off the single-token compute
+    path), the mismatch and control logits are trivially identical
+    regardless of whether a dtype mismatch is tolerated on a tensor the
+    forward actually uses. Two things close this for good, below: (1)
+    ``victim`` is no longer "whatever sorts first" — it is a fixed
+    choice on a compute path a single-token forward provably always
+    takes (see the comment at its assignment); (2) an execution-
+    sensitivity guard re-injects the SAME control sidecar with
+    ``victim``'s values scaled 8x and asserts the draft logits move
+    materially — a dead-code tensor would leave them unchanged. Together
+    with the two proofs above, this completes the chain: installed ->
+    participates -> tolerated.
     """
     import mlx.core as _mx
     import mlx.nn as _nn
@@ -2316,10 +2333,38 @@ def test_inject_accepts_sidecar_with_mismatched_floating_scales_dtype_and_drafts
     # Corrupt ONE floating tensor's DTYPE (fp32 -> bf16) while keeping its
     # shape and values (up to bf16 precision) intact — exactly the
     # "shape-correct but mismatched float dtype" shape the codex finding
-    # describes. Target a non-fc ``.scales`` tensor so the fc-inference
-    # step (which reads fc's own tensors) is unaffected.
-    victim = next(
-        k for k in sorted(flat) if k.endswith(".scales") and not k.startswith("fc.")
+    # describes.
+    #
+    # Victim selection [terminal hardening, PR #1206 — three independent
+    # codex runs unanimously flagged this]: a self-attention projection's
+    # ``.scales``, NOT "the lexicographically-first non-fc ``.scales``
+    # tensor" (the prior selection, which happened to resolve to
+    # ``layers.0.mlp.down_proj.scales`` in this fixture). That pick was
+    # only safe by coincidence: ``num_experts == 0`` here makes the MLP
+    # dense, so ``down_proj`` is unconditionally on-path today — but a
+    # SparseMoeBlock fixture (one field-flip away) routes tokens to a
+    # top-k subset of experts, so a lexicographically-first expert
+    # projection could go UNUSED for a given routing draw on a given
+    # input, silently reopening the exact vacuous-participation loophole
+    # this test exists to close. Attention has no such conditional path:
+    # ``Qwen3NextAttention.__call__`` (``mlx_lm.models.qwen3_next``,
+    # imported as ``Attention`` in ``head.py``) unconditionally computes
+    # ``self.o_proj(output * mx.sigmoid(gate))`` on every call regardless
+    # of batch/sequence length or MoE config, and
+    # ``_MTPDecoderLayer.__call__`` (``head.py``) adds that result
+    # straight into the residual stream (``h = x + r`` — never gated,
+    # never skipped) — so ``o_proj``'s scale provably participates in
+    # EVERY single-token MTP forward, by construction of the vendored
+    # module, not by accident of dict key ordering. (The execution-
+    # sensitivity guard further below still empirically PROVES this for
+    # whichever victim is chosen — this static pick just means that
+    # proof is backed by an analytical guarantee too, not only an
+    # empirically-measured threshold.)
+    victim = "layers.0.self_attn.o_proj.scales"
+    assert victim in flat, (
+        f"expected {victim!r} among the MTP module's flattened floating "
+        f"parameters; got {sorted(flat)} instead — did head.py's layer "
+        f"count/attention field naming change?"
     )
     assert flat[victim].dtype == _mx.float32
     # Snapshot the UNCORRUPTED tensors before mutating ``flat`` below —
@@ -2388,14 +2433,15 @@ def test_inject_accepts_sidecar_with_mismatched_floating_scales_dtype_and_drafts
     control_logits = base.mtp_forward(hidden, next_ids, base.make_mtp_cache())
     _mx.eval(control_logits)
 
-    # Tolerance: empirically, corrupting one non-fc ``.scales`` tensor from
-    # fp32 to bf16 in this exact fixture (hidden_size=64, group_size=32,
+    # Tolerance: empirically, corrupting ``layers.0.self_attn.o_proj.scales``
+    # from fp32 to bf16 in this exact fixture (hidden_size=64, group_size=32,
     # bits=4, 1 MTP layer) produces a max per-logit absolute drift of
-    # ~6e-4 to ~2e-3 against control logits with |value| up to ~1.5-1.8
+    # ~7e-4 to ~4.1e-3 against control logits with |value| up to ~1.5-1.8
     # (measured across 8 random seeds locally) — consistent with a single
     # bf16 rounding (relative precision ~2**-8 ~= 0.0039) propagated
     # through one quantized matmul + norm + lm_head, the same
-    # order-of-magnitude drift the PR body's own probe showed
+    # order-of-magnitude drift the PR body's own probe showed for a
+    # different (also non-fc) victim tensor
     # (``out[0,:4]``: fp32 ``[0.34953, -0.30505, -0.37162, -0.24791]`` vs
     # bf16 ``[0.35309, -0.29941, -0.37214, -0.24651]``, diffs ~4e-4 to
     # 6e-3). ``atol=rtol=1e-2`` gives several-fold headroom over the
@@ -2418,12 +2464,14 @@ def test_inject_accepts_sidecar_with_mismatched_floating_scales_dtype_and_drafts
     # consumption by re-injecting with the victim's VALUES scaled up 8x
     # (kept fp32, a legitimate sidecar) and asserting the draft logits
     # move materially: a dead-code tensor would leave them unchanged.
-    # ``victim`` is ``layers.0.mlp.down_proj.scales`` here — squarely on
-    # the single-step forward path (fc -> decoder layer -> norm ->
-    # lm_head) — so an 8x scale shift moves logits by O(1) (measured
-    # ~1.5 against a control |logit| up to ~1.8), vs the ~1e-3 bf16
-    # mismatch drift; ``> 0.1`` sits ~15x above the mismatch noise floor
-    # and far below the perturbation's real effect.
+    # ``victim`` is ``layers.0.self_attn.o_proj.scales`` here — squarely
+    # on the single-step forward path (self_attn's residual contribution
+    # ``h = x + r`` inside ``_MTPDecoderLayer.__call__``, see the
+    # ``victim = ...`` comment above for the analytical argument) — so an
+    # 8x scale shift moves logits by O(1) (measured ~1.37 against a
+    # control |logit| up to ~1.8), vs the ~1e-3 bf16 mismatch drift;
+    # ``> 0.1`` sits well above the mismatch noise floor and far below
+    # the perturbation's real effect.
     pert_flat = dict(control_flat)
     pert_flat[victim] = control_flat[victim] * 8.0
     pert_dir = tmp_path / "perturbed"

--- a/tests/test_mtp_spec_decode.py
+++ b/tests/test_mtp_spec_decode.py
@@ -105,6 +105,16 @@ def _reset_mtp_module_state():
     sys.modules["mlx_lm.generate"].generation_stream = mx.default_stream(
         mx.default_device()
     )
+    # Un-stick the global MLX RNG after each test. A test that calls
+    # ``mx.random.seed(N)`` for its own determinism would otherwise leave
+    # the process-global RNG pinned at that seed, making the NEXT test's
+    # unseeded ``mx.random.*`` draws depend on whether the seeding test
+    # ran first (codex NIT on PR #1206). Reseeding from OS entropy here
+    # restores the fresh, order-independent RNG every other test assumes,
+    # while a self-seeding test stays fully deterministic within itself.
+    import os
+
+    mx.random.seed(int.from_bytes(os.urandom(8), "little") & 0x7FFFFFFFFFFFFFFF)
 
 
 # ---------------------------------------------------------------------------
@@ -1991,7 +2001,10 @@ def test_quantized_matmul_and_gather_qmm_tolerate_mismatched_floating_dtype():
     import mlx.nn as _nn
 
     # Deterministic: fix the seed so the exercised values and any
-    # numerical failure are reproducible (codex NIT on PR #1206).
+    # numerical failure are reproducible (codex NIT on PR #1206). The
+    # autouse ``_reset_mtp_module_state`` fixture reseeds the global RNG
+    # from entropy at teardown, so this fixed seed does NOT leak into
+    # subsequent tests.
     _mx.random.seed(0)
 
     group_size, bits = 64, 4
@@ -2101,7 +2114,11 @@ def test_quantized_matmul_and_gather_qmm_tolerate_mismatched_floating_dtype():
         ctrl_fp32,
     )
     # ... "and the reverse": bf16 module + bf16 input baseline, then
-    # scales forced to fp32 must land close to it.
+    # scales AND/OR biases forced to fp32 must land close to it (both the
+    # scales-only and the scales+biases variants — a bf16 module with an
+    # fp32 bias is a config production accepts, so cover it too; codex
+    # BLOCKING on PR #1206).
+    assert bf16_layer.biases.dtype == _mx.bfloat16
     ctrl_bf16 = matmul(x_bf16, bf16_layer.weight, bf16_layer.scales, bf16_layer.biases)
     assert _close(
         matmul(
@@ -2109,6 +2126,24 @@ def test_quantized_matmul_and_gather_qmm_tolerate_mismatched_floating_dtype():
             bf16_layer.weight,
             _forced(bf16_layer.scales, _mx.float32),
             bf16_layer.biases,
+        ),
+        ctrl_bf16,
+    )
+    assert _close(
+        matmul(
+            x_bf16,
+            bf16_layer.weight,
+            bf16_layer.scales,
+            _forced(bf16_layer.biases, _mx.float32),
+        ),
+        ctrl_bf16,
+    )
+    assert _close(
+        matmul(
+            x_bf16,
+            bf16_layer.weight,
+            _forced(bf16_layer.scales, _mx.float32),
+            _forced(bf16_layer.biases, _mx.float32),
         ),
         ctrl_bf16,
     )
@@ -2191,12 +2226,22 @@ def test_quantized_matmul_and_gather_qmm_tolerate_mismatched_floating_dtype():
     ctrl_moe_bf16 = gather_qmm(
         bf16_gate, x_moe_bf16, bf16_gate.scales, bf16_gate.biases
     )
+    assert bf16_gate.biases.dtype == _mx.bfloat16
     assert _close(
         gather_qmm(
             bf16_gate,
             x_moe_bf16,
             _forced(bf16_gate.scales, _mx.float32),
             bf16_gate.biases,
+        ),
+        ctrl_moe_bf16,
+    )
+    assert _close(
+        gather_qmm(
+            bf16_gate,
+            x_moe_bf16,
+            bf16_gate.scales,
+            _forced(bf16_gate.biases, _mx.float32),
         ),
         ctrl_moe_bf16,
     )

--- a/tests/test_mtp_spec_decode.py
+++ b/tests/test_mtp_spec_decode.py
@@ -1976,9 +1976,9 @@ def test_quantized_matmul_and_gather_qmm_tolerate_mismatched_floating_dtype():
     future MLX that silently returned finite-but-wrong output for a
     mixed-dtype call would keep a finiteness-only test green, so each
     mismatched case is compared against its own matched-dtype control
-    within a generous tolerance (well above the measured ~0.02-abs
-    bf16-rounding noise at this magnitude, far below the
-    order-of-magnitude error garbage would produce).
+    under a fixed seed and a bounded max abs error (~3x the measured
+    worst-case bf16/fp16 rounding drift, far below the fraction-of-
+    magnitude error garbage would produce — see ``_MAX_ABS_ERR``).
 
     This test is the tripwire: if a future MLX bump starts raising on —
     OR silently corrupting — ANY of these combinations, this test fails
@@ -1990,25 +1990,45 @@ def test_quantized_matmul_and_gather_qmm_tolerate_mismatched_floating_dtype():
     import mlx.core as _mx
     import mlx.nn as _nn
 
+    # Deterministic: fix the seed so the exercised values and any
+    # numerical failure are reproducible (codex NIT on PR #1206).
+    _mx.random.seed(0)
+
     group_size, bits = 64, 4
     in_dims = out_dims = 128
 
-    # Generous tolerance: tracks the "MLX still does the math across the
-    # dtype mismatch" contract without being brittle to bf16/fp16
-    # rounding, while still failing a truly divergent ("finite garbage")
-    # result.
-    _ATOL, _RTOL = 0.2, 0.1
+    # Bounded max-error tolerance. Under the fixed seed above, the worst
+    # per-element abs error across ALL cases below (dense + MoE, both
+    # directions) is ~0.016 — a single bf16/fp16 rounding of scales/biases
+    # (relative precision ~2**-8 ~= 0.004) propagated through one
+    # quantized matmul, against control outputs whose |value| runs up to
+    # ~1.5. ``_MAX_ABS_ERR = 0.05`` is ~3x that measured worst case — tight
+    # enough that a materially corrupted / "finite garbage" result (off by
+    # a fraction of the ~1.5 magnitude, i.e. >> 0.05) fails, loose enough
+    # to absorb rounding without flaking. (codex BLOCKING on PR #1206: the
+    # earlier atol=0.2/rtol=0.1 permitted magnitude-comparable error.)
+    _MAX_ABS_ERR = 0.05
 
     def _close(mismatch, baseline):
+        err = _mx.abs(mismatch.astype(_mx.float32) - baseline.astype(_mx.float32))
         return bool(
-            _mx.all(
-                _mx.isfinite(mismatch)
-                & (
-                    _mx.abs(mismatch.astype(_mx.float32) - baseline.astype(_mx.float32))
-                    <= _ATOL + _RTOL * _mx.abs(baseline.astype(_mx.float32))
-                )
-            ).item()
+            _mx.all(_mx.isfinite(mismatch)).item()
+            and _mx.max(err).item() <= _MAX_ABS_ERR
         )
+
+    def _forced(tensor, dtype):
+        """Cast ``tensor`` to ``dtype``, asserting the cast is a REAL
+        dtype change (not a no-op) — else an allegedly-mismatched case
+        would silently exercise matched dtypes (codex BLOCKING on PR #1206).
+        """
+        assert tensor.dtype != dtype, (
+            f"expected a dtype MISMATCH but operand is already {dtype}; "
+            f".astype({dtype}) would be a no-op and the case would not "
+            f"exercise mixed dtypes"
+        )
+        out = tensor.astype(dtype)
+        assert out.dtype == dtype
+        return out
 
     def quantized_linear(param_dtype):
         lin = _nn.Linear(in_dims, out_dims, bias=False)
@@ -2034,6 +2054,11 @@ def test_quantized_matmul_and_gather_qmm_tolerate_mismatched_floating_dtype():
     bf16_layer = quantized_linear(_mx.bfloat16)
     x_fp32 = _mx.random.uniform(shape=(1, in_dims)).astype(_mx.float32)
     x_bf16 = _mx.random.uniform(shape=(1, in_dims)).astype(_mx.bfloat16)
+    # Baseline dtypes must be what we think they are, so the ``_forced``
+    # casts below are genuine mismatches (codex BLOCKING on PR #1206).
+    assert fp32_layer.scales.dtype == _mx.float32
+    assert fp32_layer.biases.dtype == _mx.float32
+    assert bf16_layer.scales.dtype == _mx.bfloat16
 
     # fp32 module + fp32 input: matched-dtype baseline, then every
     # scales/biases-forced-to-bf16/fp16 mismatch must land close to it
@@ -2043,7 +2068,7 @@ def test_quantized_matmul_and_gather_qmm_tolerate_mismatched_floating_dtype():
         matmul(
             x_fp32,
             fp32_layer.weight,
-            fp32_layer.scales.astype(_mx.bfloat16),
+            _forced(fp32_layer.scales, _mx.bfloat16),
             fp32_layer.biases,
         ),
         ctrl_fp32,
@@ -2053,7 +2078,7 @@ def test_quantized_matmul_and_gather_qmm_tolerate_mismatched_floating_dtype():
             x_fp32,
             fp32_layer.weight,
             fp32_layer.scales,
-            fp32_layer.biases.astype(_mx.bfloat16),
+            _forced(fp32_layer.biases, _mx.bfloat16),
         ),
         ctrl_fp32,
     )
@@ -2061,7 +2086,7 @@ def test_quantized_matmul_and_gather_qmm_tolerate_mismatched_floating_dtype():
         matmul(
             x_fp32,
             fp32_layer.weight,
-            fp32_layer.scales.astype(_mx.float16),
+            _forced(fp32_layer.scales, _mx.float16),
             fp32_layer.biases,
         ),
         ctrl_fp32,
@@ -2070,8 +2095,8 @@ def test_quantized_matmul_and_gather_qmm_tolerate_mismatched_floating_dtype():
         matmul(
             x_fp32,
             fp32_layer.weight,
-            fp32_layer.scales.astype(_mx.bfloat16),
-            fp32_layer.biases.astype(_mx.bfloat16),
+            _forced(fp32_layer.scales, _mx.bfloat16),
+            _forced(fp32_layer.biases, _mx.bfloat16),
         ),
         ctrl_fp32,
     )
@@ -2082,7 +2107,7 @@ def test_quantized_matmul_and_gather_qmm_tolerate_mismatched_floating_dtype():
         matmul(
             x_bf16,
             bf16_layer.weight,
-            bf16_layer.scales.astype(_mx.float32),
+            _forced(bf16_layer.scales, _mx.float32),
             bf16_layer.biases,
         ),
         ctrl_bf16,
@@ -2140,7 +2165,7 @@ def test_quantized_matmul_and_gather_qmm_tolerate_mismatched_floating_dtype():
         gather_qmm(
             fp32_gate,
             x_moe_fp32,
-            fp32_gate.scales.astype(_mx.bfloat16),
+            _forced(fp32_gate.scales, _mx.bfloat16),
             fp32_gate.biases,
         ),
         ctrl_moe_fp32,
@@ -2150,7 +2175,7 @@ def test_quantized_matmul_and_gather_qmm_tolerate_mismatched_floating_dtype():
             fp32_gate,
             x_moe_fp32,
             fp32_gate.scales,
-            fp32_gate.biases.astype(_mx.float16),
+            _forced(fp32_gate.biases, _mx.float16),
         ),
         ctrl_moe_fp32,
     )
@@ -2170,7 +2195,7 @@ def test_quantized_matmul_and_gather_qmm_tolerate_mismatched_floating_dtype():
         gather_qmm(
             bf16_gate,
             x_moe_bf16,
-            bf16_gate.scales.astype(_mx.float32),
+            _forced(bf16_gate.scales, _mx.float32),
             bf16_gate.biases,
         ),
         ctrl_moe_bf16,
@@ -2179,8 +2204,8 @@ def test_quantized_matmul_and_gather_qmm_tolerate_mismatched_floating_dtype():
         gather_qmm(
             bf16_gate,
             x_moe_bf16,
-            bf16_gate.scales.astype(_mx.float32),
-            bf16_gate.biases.astype(_mx.float32),
+            _forced(bf16_gate.scales, _mx.float32),
+            _forced(bf16_gate.biases, _mx.float32),
         ),
         ctrl_moe_bf16,
     )
@@ -2338,6 +2363,36 @@ def test_inject_accepts_sidecar_with_mismatched_floating_scales_dtype_and_drafts
         "test_quantized_matmul_and_gather_qmm_tolerate_mismatched_floating_dtype) "
         "or the forward path is producing something other than a "
         "rounding-level perturbation of the control."
+    )
+
+    # [codex BLOCKING] Execution-sensitivity guard: the closeness check
+    # above is only meaningful if ``mtp_forward`` ACTUALLY consumes the
+    # ``victim`` tensor — an ``allclose`` that passes because the forward
+    # IGNORES the corrupted tensor would be vacuous (the mismatch and
+    # control forwards would then be trivially identical). Prove
+    # consumption by re-injecting with the victim's VALUES scaled up 8x
+    # (kept fp32, a legitimate sidecar) and asserting the draft logits
+    # move materially: a dead-code tensor would leave them unchanged.
+    # ``victim`` is ``layers.0.mlp.down_proj.scales`` here — squarely on
+    # the single-step forward path (fc -> decoder layer -> norm ->
+    # lm_head) — so an 8x scale shift moves logits by O(1) (measured
+    # ~1.5 against a control |logit| up to ~1.8), vs the ~1e-3 bf16
+    # mismatch drift; ``> 0.1`` sits ~15x above the mismatch noise floor
+    # and far below the perturbation's real effect.
+    pert_flat = dict(control_flat)
+    pert_flat[victim] = control_flat[victim] * 8.0
+    pert_dir = tmp_path / "perturbed"
+    pert_dir.mkdir()
+    _mx.save_safetensors(str(pert_dir / "model.safetensors"), pert_flat)
+    assert inject_mtp_support(base, mtp_sidecar=str(pert_dir)) is True
+    pert_logits = base.mtp_forward(hidden, next_ids, base.make_mtp_cache())
+    _mx.eval(pert_logits)
+    max_shift = float(_mx.max(_mx.abs(pert_logits - control_logits)).item())
+    assert max_shift > 0.1, (
+        f"scaling {victim!r} 8x left the draft logits essentially unchanged "
+        f"(max shift {max_shift:.4g}); mtp_forward is not consuming that "
+        f"tensor, so the numerical-closeness control check above is vacuous "
+        f"— pick a victim tensor the one-step forward actually executes."
     )
 
 

--- a/tests/test_mtp_spec_decode.py
+++ b/tests/test_mtp_spec_decode.py
@@ -1942,6 +1942,216 @@ def test_inject_refuses_sidecar_with_dtype_mismatched_packed_weight(tmp_path):
     assert not hasattr(base, "mtp")
 
 
+def test_quantized_matmul_and_gather_qmm_tolerate_mismatched_floating_dtype():
+    """Canary for the MLX behavior the by-role dtype check (Step 4 above)
+    relies on but does not itself exercise.
+
+    Follow-up to an independent codex review of PR #1201 ("[BLOCKING]
+    the dtype check accepts each floating tensor independently ...
+    a sidecar with shape-correct but MISMATCHED scales/biases float
+    dtype passes validation and can still fail later in
+    mx.quantized_matmul at the first draft step"). The finding also
+    noted the code comment defending the loose check ("load_weights
+    casts them") is factually wrong — confirmed by reading
+    ``nn.Module.load_weights`` / ``nn.Module.update``: they assign
+    ``dst[k] = new_value`` verbatim, with NO ``.astype`` anywhere.
+
+    That does NOT automatically make the finding's failure mode real —
+    it depends on whether ``mx.quantized_matmul`` / ``mx.gather_qmm``
+    (the two ops the MTP head's quantized leaves route through: plain
+    ``QuantizedLinear`` for ``fc`` / attention projections, and
+    ``QuantizedSwitchLinear`` via ``gather_qmm`` for any MoE MTP
+    layer) actually reject a float-dtype mismatch between
+    weight/scales/biases/x. Empirically — on this repo's pinned MLX
+    (``mlx>=0.31.2``), on the default GPU (Metal) device — they do
+    NOT: every fp32/bf16/fp16 combination below (module built fp32
+    with mismatched scales/biases, and the reverse: module built
+    bf16 with mismatched scales) runs to completion and returns a
+    finite tensor, never raises. MLX silently promotes/computes
+    across floating dtypes here, it does not enforce an exact match.
+
+    This test is the tripwire: if a future MLX bump starts raising on
+    ANY of these combinations, this test fails FIRST — before an
+    operator sees an intermittent empty response — and the by-role
+    dtype check in ``qwen3_5_inject.py`` (which currently accepts any
+    floating dtype for scales/biases) needs to be tightened to an
+    exact-match check for the affected op.
+    """
+    import mlx.core as _mx
+    import mlx.nn as _nn
+
+    group_size, bits = 64, 4
+    in_dims = out_dims = 128
+
+    def quantized_linear(param_dtype):
+        lin = _nn.Linear(in_dims, out_dims, bias=False)
+        lin.weight = lin.weight.astype(param_dtype)
+        qlin = lin.to_quantized(group_size=group_size, bits=bits, mode="affine")
+        _mx.eval(qlin.parameters())
+        return qlin
+
+    fp32_layer = quantized_linear(_mx.float32)
+    bf16_layer = quantized_linear(_mx.bfloat16)
+    x_fp32 = _mx.random.uniform(shape=(1, in_dims)).astype(_mx.float32)
+    x_bf16 = _mx.random.uniform(shape=(1, in_dims)).astype(_mx.bfloat16)
+
+    def matmul_ok(x, weight, scales, biases):
+        out = _mx.quantized_matmul(
+            x,
+            weight,
+            scales=scales,
+            biases=biases,
+            transpose=True,
+            group_size=group_size,
+            bits=bits,
+        )
+        _mx.eval(out)
+        assert bool(_mx.all(_mx.isfinite(out)).item()), (
+            "mismatched-dtype matmul produced non-finite output"
+        )
+        return out
+
+    # fp32 module, scales/biases forced to bf16 / fp16 (both directions
+    # the codex finding names: "module built for fp32 activations but
+    # scales forced to bf16 or fp16").
+    matmul_ok(
+        x_fp32,
+        fp32_layer.weight,
+        fp32_layer.scales.astype(_mx.bfloat16),
+        fp32_layer.biases,
+    )
+    matmul_ok(
+        x_fp32,
+        fp32_layer.weight,
+        fp32_layer.scales,
+        fp32_layer.biases.astype(_mx.bfloat16),
+    )
+    matmul_ok(
+        x_fp32,
+        fp32_layer.weight,
+        fp32_layer.scales.astype(_mx.float16),
+        fp32_layer.biases,
+    )
+    matmul_ok(
+        x_fp32,
+        fp32_layer.weight,
+        fp32_layer.scales.astype(_mx.bfloat16),
+        fp32_layer.biases.astype(_mx.bfloat16),
+    )
+    # ... "and the reverse": bf16 module, scales forced to fp32.
+    matmul_ok(
+        x_bf16,
+        bf16_layer.weight,
+        bf16_layer.scales.astype(_mx.float32),
+        bf16_layer.biases,
+    )
+
+    # The MoE path (SwitchGLU / QuantizedSwitchLinear -> gather_qmm) —
+    # exercised when a Qwen3.6 MoE MTP head layer is present.
+    from mlx_lm.models.switch_layers import SwitchGLU
+
+    num_experts, top_k = 4, 2
+    switch = SwitchGLU(in_dims, in_dims, num_experts)
+    _nn.quantize(switch, group_size=group_size, bits=bits)
+    _mx.eval(switch.parameters())
+    x_moe = _mx.random.uniform(shape=(1, 3, in_dims)).astype(_mx.float32)
+    inds = _mx.array([[0, 1], [1, 2], [2, 3]]).reshape(1, 3, top_k)
+    gate = switch.gate_proj
+
+    def gather_qmm_ok(scales, biases):
+        out = _mx.gather_qmm(
+            x_moe,
+            gate.weight,
+            scales,
+            biases,
+            rhs_indices=inds,
+            transpose=True,
+            group_size=group_size,
+            bits=bits,
+        )
+        _mx.eval(out)
+        assert bool(_mx.all(_mx.isfinite(out)).item())
+
+    gather_qmm_ok(gate.scales.astype(_mx.bfloat16), gate.biases)
+    gather_qmm_ok(gate.scales, gate.biases.astype(_mx.float16))
+
+
+def test_inject_accepts_sidecar_with_mismatched_floating_scales_dtype_and_drafts_correctly(
+    tmp_path,
+):
+    """Companion to ``test_inject_refuses_sidecar_with_dtype_mismatched_packed_weight``:
+    that test proves an INTEGER-role mismatch (packed ``weight``) is
+    correctly refused. This test proves the intentionally looser
+    FLOATING-role check (``scales`` / ``biases`` need only be *some*
+    floating dtype, not an exact match) is safe to accept — per the
+    codex-finding follow-up on PR #1201, verified empirically by
+    ``test_quantized_matmul_and_gather_qmm_tolerate_mismatched_floating_dtype``
+    above: a shape-correct sidecar with mismatched-but-floating
+    ``scales`` dtype passes the check AND the MTP draft forward runs
+    to completion without raising — it does not "fail later in
+    mx.quantized_matmul at the first draft step" as the codex finding
+    hypothesized. (The finding's factual premise about the defending
+    comment — "load_weights casts them" — IS wrong, confirmed by
+    reading ``nn.Module.load_weights``/``update``; but the conclusion
+    the comment reached, that the loose check is safe, holds anyway —
+    for the real reason documented above, not the stated one.)
+    """
+    import mlx.core as _mx
+    import mlx.nn as _nn
+    from mlx.utils import tree_flatten
+
+    from vllm_mlx.spec_decode.mtp.head import build_mtp_module
+    from vllm_mlx.spec_decode.mtp.qwen3_5_inject import (
+        inject_mtp_support,
+        validate_mtp_support,
+    )
+
+    try:
+        base = _build_tiny_qwen3_5_text_model()
+    except (TypeError, AttributeError) as exc:
+        pytest.skip(f"Qwen3.5 TextModelArgs schema mismatch: {exc}")
+
+    _nn.quantize(base.model, group_size=32, bits=4)
+
+    # A valid, uniformly 4-bit-packed sidecar.
+    args = base.args
+    template = build_mtp_module(args, int(args.mtp_num_hidden_layers))
+    _nn.quantize(template, group_size=32, bits=4)
+    _mx.eval(template.parameters())
+    flat = dict(tree_flatten(template.parameters()))
+
+    # Corrupt ONE floating tensor's DTYPE (fp32 -> bf16) while keeping its
+    # shape and values (up to bf16 precision) intact — exactly the
+    # "shape-correct but mismatched float dtype" shape the codex finding
+    # describes. Target a non-fc ``.scales`` tensor so the fc-inference
+    # step (which reads fc's own tensors) is unaffected.
+    victim = next(
+        k for k in sorted(flat) if k.endswith(".scales") and not k.startswith("fc.")
+    )
+    assert flat[victim].dtype == _mx.float32
+    flat[victim] = flat[victim].astype(_mx.bfloat16)
+    _mx.save_safetensors(str(tmp_path / "model.safetensors"), flat)
+
+    injected = inject_mtp_support(base, mtp_sidecar=str(tmp_path))
+    assert injected is True, (
+        "inject_mtp_support refused a shape-correct sidecar whose only "
+        "defect is a mismatched-but-floating scales dtype; the by-role "
+        "check is supposed to accept this (floating-role tensors need only "
+        "be *some* floating dtype)."
+    )
+    assert validate_mtp_support(base) is True
+
+    # The draft forward must run without raising — this is the exact call
+    # path (QuantizedLinear.__call__ -> mx.quantized_matmul) the codex
+    # finding predicted would crash mid-generation.
+    hidden = _mx.zeros((1, 1, int(args.hidden_size)), dtype=_mx.float32)
+    next_ids = _mx.array([[0]], dtype=_mx.uint32)
+    logits = base.mtp_forward(hidden, next_ids, base.make_mtp_cache())
+    _mx.eval(logits)
+    assert logits.shape[-1] == int(args.vocab_size)
+    assert bool(_mx.all(_mx.isfinite(logits)).item())
+
+
 def test_inject_refuses_mixed_bit_sidecar_fail_safe(tmp_path):
     """The fc-derived quantization is applied UNIFORMLY (intentional scope).
     A hypothetical mixed-bit sidecar — FP ``fc`` but a quantized decoder —

--- a/tests/test_mtp_spec_decode.py
+++ b/tests/test_mtp_spec_decode.py
@@ -2134,6 +2134,19 @@ def test_inject_accepts_sidecar_with_mismatched_floating_scales_dtype_and_drafts
     reading ``nn.Module.load_weights``/``update``; but the conclusion
     the comment reached, that the loose check is safe, holds anyway —
     for the real reason documented above, not the stated one.)
+
+    Hardened per an independent codex review of THIS PR (two BLOCKING
+    findings): (1) the test never verified the corrupted dtype was
+    actually installed post-inject — a ``strict=False`` load that
+    silently reverted to the template's original fp32 scale would
+    have gone green without ever exercising the claimed mismatch;
+    (2) asserting only shape + finiteness would also pass for
+    "finite garbage" or a forward path that happens to ignore the
+    corrupted tensor. Both are closed below: the victim parameter's
+    installed dtype/values are asserted BEFORE ``mtp_forward`` runs,
+    and the resulting logits are compared against an
+    otherwise-identical fp32-scale CONTROL forward within an
+    explicit tolerance.
     """
     import mlx.core as _mx
     import mlx.nn as _nn
@@ -2168,10 +2181,20 @@ def test_inject_accepts_sidecar_with_mismatched_floating_scales_dtype_and_drafts
         k for k in sorted(flat) if k.endswith(".scales") and not k.startswith("fc.")
     )
     assert flat[victim].dtype == _mx.float32
+    # Snapshot the UNCORRUPTED tensors before mutating ``flat`` below —
+    # this becomes the CONTROL sidecar for the numerical-closeness check
+    # further down. Every key except ``victim`` is the same array object
+    # in both dicts (``.astype`` below returns a NEW array rather than
+    # mutating in place, so it only touches ``flat[victim]``) — the
+    # mismatch and control sidecars therefore differ in exactly one
+    # tensor's dtype, an apples-to-apples control.
+    control_flat = dict(flat)
     flat[victim] = flat[victim].astype(_mx.bfloat16)
-    _mx.save_safetensors(str(tmp_path / "model.safetensors"), flat)
+    mismatch_dir = tmp_path / "mismatch"
+    mismatch_dir.mkdir()
+    _mx.save_safetensors(str(mismatch_dir / "model.safetensors"), flat)
 
-    injected = inject_mtp_support(base, mtp_sidecar=str(tmp_path))
+    injected = inject_mtp_support(base, mtp_sidecar=str(mismatch_dir))
     assert injected is True, (
         "inject_mtp_support refused a shape-correct sidecar whose only "
         "defect is a mismatched-but-floating scales dtype; the by-role "
@@ -2179,6 +2202,25 @@ def test_inject_accepts_sidecar_with_mismatched_floating_scales_dtype_and_drafts
         "be *some* floating dtype)."
     )
     assert validate_mtp_support(base) is True
+
+    # [codex BLOCKING #1] Prove the corruption was ACTUALLY installed on
+    # the live module BEFORE trusting a downstream forward pass to have
+    # exercised it. ``load_weights(strict=False)`` assigns verbatim (no
+    # ``.astype`` — see the module docstring above and the injector's own
+    # comment); if it had somehow reverted to the template's original
+    # fp32 scale instead, the rest of this test would be vacuous — green
+    # without ever exercising the claimed mismatch.
+    installed = dict(tree_flatten(base.mtp.parameters()))
+    assert installed[victim].dtype == _mx.bfloat16, (
+        f"expected the corrupted sidecar tensor {victim!r} to land on "
+        f"base.mtp as bfloat16 (proving the loose by-role check accepted "
+        f"a REAL dtype mismatch); got {installed[victim].dtype} instead — "
+        f"if this fires, load_weights(strict=False) silently reverted the "
+        f"corruption and the rest of this test never exercised it."
+    )
+    assert bool(_mx.array_equal(installed[victim], flat[victim]).item()), (
+        f"installed {victim!r} values differ from what the sidecar shipped"
+    )
 
     # The draft forward must run without raising — this is the exact call
     # path (QuantizedLinear.__call__ -> mx.quantized_matmul) the codex
@@ -2189,6 +2231,43 @@ def test_inject_accepts_sidecar_with_mismatched_floating_scales_dtype_and_drafts
     _mx.eval(logits)
     assert logits.shape[-1] == int(args.vocab_size)
     assert bool(_mx.all(_mx.isfinite(logits)).item())
+
+    # [codex BLOCKING #2] Shape + finiteness alone would also pass for
+    # "finite garbage" or a forward path that happens to ignore the
+    # corrupted tensor. Re-inject the SAME ``base`` against an otherwise
+    # byte-identical CONTROL sidecar whose ``victim`` tensor kept its
+    # original fp32 dtype — this only replaces ``base.mtp`` with a fresh
+    # module; ``base.model`` / ``base.lm_head``, already quantized above,
+    # are untouched — and assert the mismatched-dtype logits are
+    # numerically CLOSE to the control's.
+    control_dir = tmp_path / "control"
+    control_dir.mkdir()
+    _mx.save_safetensors(str(control_dir / "model.safetensors"), control_flat)
+    assert inject_mtp_support(base, mtp_sidecar=str(control_dir)) is True
+    control_logits = base.mtp_forward(hidden, next_ids, base.make_mtp_cache())
+    _mx.eval(control_logits)
+
+    # Tolerance: empirically, corrupting one non-fc ``.scales`` tensor from
+    # fp32 to bf16 in this exact fixture (hidden_size=64, group_size=32,
+    # bits=4, 1 MTP layer) produces a max per-logit absolute drift of
+    # ~6e-4 to ~2e-3 against control logits with |value| up to ~1.5-1.8
+    # (measured across 8 random seeds locally) — consistent with a single
+    # bf16 rounding (relative precision ~2**-8 ~= 0.0039) propagated
+    # through one quantized matmul + norm + lm_head, the same
+    # order-of-magnitude drift the PR body's own probe showed
+    # (``out[0,:4]``: fp32 ``[0.34953, -0.30505, -0.37162, -0.24791]`` vs
+    # bf16 ``[0.35309, -0.29941, -0.37214, -0.24651]``, diffs ~4e-4 to
+    # 6e-3). ``atol=rtol=1e-2`` gives several-fold headroom over the
+    # observed worst case while still being tight enough that a truly
+    # divergent ("finite garbage") forward would fail it.
+    assert bool(_mx.allclose(logits, control_logits, rtol=1e-2, atol=1e-2).item()), (
+        "mismatched-dtype draft logits diverge from the fp32-scale control "
+        "beyond bf16-rounding tolerance — either the mismatch is no longer "
+        "silently tolerated (see "
+        "test_quantized_matmul_and_gather_qmm_tolerate_mismatched_floating_dtype) "
+        "or the forward path is producing something other than a "
+        "rounding-level perturbation of the control."
+    )
 
 
 def test_inject_refuses_mixed_bit_sidecar_fail_safe(tmp_path):

--- a/tests/test_mtp_spec_decode.py
+++ b/tests/test_mtp_spec_decode.py
@@ -1967,22 +1967,48 @@ def test_quantized_matmul_and_gather_qmm_tolerate_mismatched_floating_dtype():
     ``mlx>=0.31.2`` floor pyproject declares, and 0.32.0) — they do
     NOT: every fp32/bf16/fp16 combination below (module built fp32
     with mismatched scales/biases, and the reverse: module built
-    bf16 with mismatched scales) runs to completion and returns a
-    finite tensor, never raises. MLX silently promotes/computes
+    bf16 with mismatched scales) runs to completion AND returns the
+    RIGHT numbers, never raising. MLX silently promotes/computes
     across floating dtypes here, it does not enforce an exact match.
 
-    This test is the tripwire: if a future MLX bump starts raising on
-    ANY of these combinations, this test fails FIRST — before an
-    operator sees an intermittent empty response — and the by-role
-    dtype check in ``qwen3_5_inject.py`` (which currently accepts any
-    floating dtype for scales/biases) needs to be tightened to an
-    exact-match check for the affected op.
+    "Tolerate" is asserted as numerical CLOSENESS to a matched-dtype
+    baseline, not merely finiteness (codex BLOCKING on PR #1206): a
+    future MLX that silently returned finite-but-wrong output for a
+    mixed-dtype call would keep a finiteness-only test green, so each
+    mismatched case is compared against its own matched-dtype control
+    within a generous tolerance (well above the measured ~0.02-abs
+    bf16-rounding noise at this magnitude, far below the
+    order-of-magnitude error garbage would produce).
+
+    This test is the tripwire: if a future MLX bump starts raising on —
+    OR silently corrupting — ANY of these combinations, this test fails
+    FIRST, before an operator sees an intermittent empty response, and
+    the by-role dtype check in ``qwen3_5_inject.py`` (which currently
+    accepts any floating dtype for scales/biases) needs to be tightened
+    to an exact-match check for the affected op.
     """
     import mlx.core as _mx
     import mlx.nn as _nn
 
     group_size, bits = 64, 4
     in_dims = out_dims = 128
+
+    # Generous tolerance: tracks the "MLX still does the math across the
+    # dtype mismatch" contract without being brittle to bf16/fp16
+    # rounding, while still failing a truly divergent ("finite garbage")
+    # result.
+    _ATOL, _RTOL = 0.2, 0.1
+
+    def _close(mismatch, baseline):
+        return bool(
+            _mx.all(
+                _mx.isfinite(mismatch)
+                & (
+                    _mx.abs(mismatch.astype(_mx.float32) - baseline.astype(_mx.float32))
+                    <= _ATOL + _RTOL * _mx.abs(baseline.astype(_mx.float32))
+                )
+            ).item()
+        )
 
     def quantized_linear(param_dtype):
         lin = _nn.Linear(in_dims, out_dims, bias=False)
@@ -1991,12 +2017,7 @@ def test_quantized_matmul_and_gather_qmm_tolerate_mismatched_floating_dtype():
         _mx.eval(qlin.parameters())
         return qlin
 
-    fp32_layer = quantized_linear(_mx.float32)
-    bf16_layer = quantized_linear(_mx.bfloat16)
-    x_fp32 = _mx.random.uniform(shape=(1, in_dims)).astype(_mx.float32)
-    x_bf16 = _mx.random.uniform(shape=(1, in_dims)).astype(_mx.bfloat16)
-
-    def matmul_ok(x, weight, scales, biases):
+    def matmul(x, weight, scales, biases):
         out = _mx.quantized_matmul(
             x,
             weight,
@@ -2007,44 +2028,64 @@ def test_quantized_matmul_and_gather_qmm_tolerate_mismatched_floating_dtype():
             bits=bits,
         )
         _mx.eval(out)
-        assert bool(_mx.all(_mx.isfinite(out)).item()), (
-            "mismatched-dtype matmul produced non-finite output"
-        )
         return out
 
-    # fp32 module, scales/biases forced to bf16 / fp16 (both directions
-    # the codex finding names: "module built for fp32 activations but
-    # scales forced to bf16 or fp16").
-    matmul_ok(
-        x_fp32,
-        fp32_layer.weight,
-        fp32_layer.scales.astype(_mx.bfloat16),
-        fp32_layer.biases,
+    fp32_layer = quantized_linear(_mx.float32)
+    bf16_layer = quantized_linear(_mx.bfloat16)
+    x_fp32 = _mx.random.uniform(shape=(1, in_dims)).astype(_mx.float32)
+    x_bf16 = _mx.random.uniform(shape=(1, in_dims)).astype(_mx.bfloat16)
+
+    # fp32 module + fp32 input: matched-dtype baseline, then every
+    # scales/biases-forced-to-bf16/fp16 mismatch must land close to it
+    # ("module built for fp32 activations but scales forced to bf16/fp16").
+    ctrl_fp32 = matmul(x_fp32, fp32_layer.weight, fp32_layer.scales, fp32_layer.biases)
+    assert _close(
+        matmul(
+            x_fp32,
+            fp32_layer.weight,
+            fp32_layer.scales.astype(_mx.bfloat16),
+            fp32_layer.biases,
+        ),
+        ctrl_fp32,
     )
-    matmul_ok(
-        x_fp32,
-        fp32_layer.weight,
-        fp32_layer.scales,
-        fp32_layer.biases.astype(_mx.bfloat16),
+    assert _close(
+        matmul(
+            x_fp32,
+            fp32_layer.weight,
+            fp32_layer.scales,
+            fp32_layer.biases.astype(_mx.bfloat16),
+        ),
+        ctrl_fp32,
     )
-    matmul_ok(
-        x_fp32,
-        fp32_layer.weight,
-        fp32_layer.scales.astype(_mx.float16),
-        fp32_layer.biases,
+    assert _close(
+        matmul(
+            x_fp32,
+            fp32_layer.weight,
+            fp32_layer.scales.astype(_mx.float16),
+            fp32_layer.biases,
+        ),
+        ctrl_fp32,
     )
-    matmul_ok(
-        x_fp32,
-        fp32_layer.weight,
-        fp32_layer.scales.astype(_mx.bfloat16),
-        fp32_layer.biases.astype(_mx.bfloat16),
+    assert _close(
+        matmul(
+            x_fp32,
+            fp32_layer.weight,
+            fp32_layer.scales.astype(_mx.bfloat16),
+            fp32_layer.biases.astype(_mx.bfloat16),
+        ),
+        ctrl_fp32,
     )
-    # ... "and the reverse": bf16 module, scales forced to fp32.
-    matmul_ok(
-        x_bf16,
-        bf16_layer.weight,
-        bf16_layer.scales.astype(_mx.float32),
-        bf16_layer.biases,
+    # ... "and the reverse": bf16 module + bf16 input baseline, then
+    # scales forced to fp32 must land close to it.
+    ctrl_bf16 = matmul(x_bf16, bf16_layer.weight, bf16_layer.scales, bf16_layer.biases)
+    assert _close(
+        matmul(
+            x_bf16,
+            bf16_layer.weight,
+            bf16_layer.scales.astype(_mx.float32),
+            bf16_layer.biases,
+        ),
+        ctrl_bf16,
     )
 
     # The MoE path (SwitchGLU / QuantizedSwitchLinear -> gather_qmm) —
@@ -2054,7 +2095,8 @@ def test_quantized_matmul_and_gather_qmm_tolerate_mismatched_floating_dtype():
     # (a) fp32 module/input with mismatched bf16/fp16 sidecar scales, and
     # (b) the reverse — a bf16 module/input with mismatched fp32 scales,
     # which is exactly the "fp32 scales for a bf16 MoE module" config the
-    # by-role check accepts.
+    # by-role check accepts. Each mismatch is checked against its own
+    # matched-dtype baseline, same as the dense path above.
     from mlx_lm.models.switch_layers import SwitchGLU
 
     num_experts, top_k = 4, 2
@@ -2071,7 +2113,7 @@ def test_quantized_matmul_and_gather_qmm_tolerate_mismatched_floating_dtype():
         _mx.eval(switch.parameters())
         return switch
 
-    def gather_qmm_ok(gate, x_moe, scales, biases):
+    def gather_qmm(gate, x_moe, scales, biases):
         out = _mx.gather_qmm(
             x_moe,
             gate.weight,
@@ -2083,35 +2125,64 @@ def test_quantized_matmul_and_gather_qmm_tolerate_mismatched_floating_dtype():
             bits=bits,
         )
         _mx.eval(out)
-        assert bool(_mx.all(_mx.isfinite(out)).item())
+        return out
 
-    # (a) fp32 MoE module + fp32 input, scales/biases forced to bf16 / fp16.
+    # (a) fp32 MoE module + fp32 input: matched baseline, then bf16/fp16
+    # scales/biases mismatches must land close to it.
     fp32_switch = make_switch(_mx.float32)
     fp32_gate = fp32_switch.gate_proj
     assert fp32_gate.scales.dtype == _mx.float32
     x_moe_fp32 = _mx.random.uniform(shape=(1, 3, in_dims)).astype(_mx.float32)
-    gather_qmm_ok(
-        fp32_gate, x_moe_fp32, fp32_gate.scales.astype(_mx.bfloat16), fp32_gate.biases
+    ctrl_moe_fp32 = gather_qmm(
+        fp32_gate, x_moe_fp32, fp32_gate.scales, fp32_gate.biases
     )
-    gather_qmm_ok(
-        fp32_gate, x_moe_fp32, fp32_gate.scales, fp32_gate.biases.astype(_mx.float16)
+    assert _close(
+        gather_qmm(
+            fp32_gate,
+            x_moe_fp32,
+            fp32_gate.scales.astype(_mx.bfloat16),
+            fp32_gate.biases,
+        ),
+        ctrl_moe_fp32,
+    )
+    assert _close(
+        gather_qmm(
+            fp32_gate,
+            x_moe_fp32,
+            fp32_gate.scales,
+            fp32_gate.biases.astype(_mx.float16),
+        ),
+        ctrl_moe_fp32,
     )
 
-    # (b) the reverse: bf16 MoE module + bf16 input, scales/biases forced
-    # to fp32 — the "fp32 scales for a bf16 MoE module" config the by-role
-    # check accepts and the comment claims tolerance for.
+    # (b) the reverse: bf16 MoE module + bf16 input matched baseline, then
+    # scales/biases forced to fp32 — the "fp32 scales for a bf16 MoE
+    # module" config the by-role check accepts and the comment claims
+    # tolerance for — must land close to it.
     bf16_switch = make_switch(_mx.bfloat16)
     bf16_gate = bf16_switch.gate_proj
     assert bf16_gate.scales.dtype == _mx.bfloat16
     x_moe_bf16 = _mx.random.uniform(shape=(1, 3, in_dims)).astype(_mx.bfloat16)
-    gather_qmm_ok(
-        bf16_gate, x_moe_bf16, bf16_gate.scales.astype(_mx.float32), bf16_gate.biases
+    ctrl_moe_bf16 = gather_qmm(
+        bf16_gate, x_moe_bf16, bf16_gate.scales, bf16_gate.biases
     )
-    gather_qmm_ok(
-        bf16_gate,
-        x_moe_bf16,
-        bf16_gate.scales.astype(_mx.float32),
-        bf16_gate.biases.astype(_mx.float32),
+    assert _close(
+        gather_qmm(
+            bf16_gate,
+            x_moe_bf16,
+            bf16_gate.scales.astype(_mx.float32),
+            bf16_gate.biases,
+        ),
+        ctrl_moe_bf16,
+    )
+    assert _close(
+        gather_qmm(
+            bf16_gate,
+            x_moe_bf16,
+            bf16_gate.scales.astype(_mx.float32),
+            bf16_gate.biases.astype(_mx.float32),
+        ),
+        ctrl_moe_bf16,
     )
 
 

--- a/vllm_mlx/spec_decode/mtp/qwen3_5_inject.py
+++ b/vllm_mlx/spec_decode/mtp/qwen3_5_inject.py
@@ -692,10 +692,14 @@ def inject_mtp_support(
         # via ``gather_qmm`` for any MoE layer) TOLERATE a floating-dtype
         # mismatch between weight/scales/biases/x: they silently
         # promote/compute rather than raise. Verified empirically across
-        # fp32/bf16/fp16 combinations in both directions, on this repo's
-        # pinned MLX (``mlx>=0.31.2``), on the default GPU device — see
+        # fp32/bf16/fp16 combinations in both directions, on the default
+        # GPU device, on the two MLX versions tested — 0.31.2 (the
+        # ``mlx>=0.31.2`` floor pyproject declares) and 0.32.0. Because
+        # that floor is an unbounded minimum, tolerance is NOT guaranteed
+        # for an arbitrary future MLX; it is asserted by the canary test
         # ``test_quantized_matmul_and_gather_qmm_tolerate_mismatched_floating_dtype``
-        # and ``test_inject_accepts_sidecar_with_mismatched_floating_scales_dtype_and_drafts_correctly``
+        # (plus the injector-level
+        # ``test_inject_accepts_sidecar_with_mismatched_floating_scales_dtype_and_drafts_correctly``)
         # in ``tests/test_mtp_spec_decode.py``. If a future MLX version
         # starts rejecting a floating-dtype mismatch, those tests fail
         # first and this check needs tightening to an exact-match — same

--- a/vllm_mlx/spec_decode/mtp/qwen3_5_inject.py
+++ b/vllm_mlx/spec_decode/mtp/qwen3_5_inject.py
@@ -671,18 +671,35 @@ def inject_mtp_support(
             return False
         # Dtype verification (by ROLE, not exact match): a shape-correct
         # sidecar can still smuggle in a wrong-*dtype* tensor that
-        # ``load_weights(strict=False)`` installs without casting, then
-        # ``mx.quantized_matmul`` / ``mx.gather_qmm`` rejects. MLX packs
-        # quantized ``weight`` as unsigned 32-bit; an ``int32``/``float32``
-        # packed weight (or an integer ``scales``/``biases``) has the right
-        # shape but blows up at the first draft step — the same empty-response
-        # class this fix closes. Enforce by role: an integer-typed expected
-        # parameter (the packed ``weight``) must match its dtype EXACTLY,
-        # while a floating-typed expected parameter (``scales`` / ``biases`` /
-        # any FP weight) need only be *some* floating dtype — a real sidecar
-        # legitimately ships bf16 scales against the freshly-quantized fp32
-        # module and ``load_weights`` casts them, so an exact float check
-        # would false-reject valid checkpoints.
+        # ``load_weights(strict=False)`` installs VERBATIM — it does NOT
+        # cast (confirmed by reading ``nn.Module.load_weights`` /
+        # ``nn.Module.update``: the assignment is a bare ``dst[k] =
+        # new_value``, no ``.astype`` anywhere). MLX packs quantized
+        # ``weight`` as unsigned 32-bit, so an ``int32``/``float32`` packed
+        # weight (or an integer ``scales``/``biases``) has the right shape
+        # but IS a corrupt/incompatible sidecar — reject it. Enforce by
+        # role: an integer-typed expected parameter (the packed ``weight``)
+        # must match its dtype EXACTLY.
+        #
+        # A floating-typed expected parameter (``scales`` / ``biases`` /
+        # any FP weight), by contrast, only needs to be *some* floating
+        # dtype. This is intentionally loose — a real sidecar legitimately
+        # ships bf16 scales against the freshly-quantized fp32 module — but
+        # NOT because ``load_weights`` casts them (it doesn't, see above).
+        # It is safe because ``mx.quantized_matmul`` / ``mx.gather_qmm``
+        # (the ops every quantized MTP leaf routes through — plain
+        # ``QuantizedLinear`` for ``fc``/attention, ``QuantizedSwitchLinear``
+        # via ``gather_qmm`` for any MoE layer) TOLERATE a floating-dtype
+        # mismatch between weight/scales/biases/x: they silently
+        # promote/compute rather than raise. Verified empirically across
+        # fp32/bf16/fp16 combinations in both directions, on this repo's
+        # pinned MLX (``mlx>=0.31.2``), on the default GPU device — see
+        # ``test_quantized_matmul_and_gather_qmm_tolerate_mismatched_floating_dtype``
+        # and ``test_inject_accepts_sidecar_with_mismatched_floating_scales_dtype_and_drafts_correctly``
+        # in ``tests/test_mtp_spec_decode.py``. If a future MLX version
+        # starts rejecting a floating-dtype mismatch, those tests fail
+        # first and this check needs tightening to an exact-match — same
+        # as the integer branch above.
         dtype_mismatches = {}
         for k, v in expected.items():
             got_dt = mtp_weights[k].dtype


### PR DESCRIPTION
## Follow-up to PR #1201 codex finding

PR #1201 (`fix(mtp): eliminate intermittent empty response on Qwen3.6 MTP sidecar path`) added a by-role dtype check in `vllm_mlx/spec_decode/mtp/qwen3_5_inject.py`. An independent codex review run raised one more finding that 2 of 3 review runs did NOT flag:

> [BLOCKING] the dtype check accepts each floating tensor independently (integer-role params like the packed `weight` must match dtype EXACTLY, but floating-role params `scales`/`biases` need only be *some* floating dtype). So a sidecar with shape-correct but MISMATCHED `scales`/`biases` float dtype passes validation and can still fail later in `mx.quantized_matmul` at the first draft step — recreating the mid-stream empty-response failure.

The code defends the loose float check with a comment: *"a real sidecar legitimately ships bf16 scales against the freshly-quantized fp32 module and `load_weights` casts them, so an exact float check would false-reject valid checkpoints."*

## Investigation

**Fact-check #1 — the comment's stated mechanism is wrong.** Read `mlx.nn.Module.load_weights` / `Module.update` source directly:

```python
# nn.Module.update
if isinstance(current_value, mx.array):
    ...
    dst[k] = new_value   # <-- bare assignment, no cast
```

`load_weights(strict=False)` calls `self.update(tree_unflatten(weights), strict=False)`, which assigns arrays verbatim. **It does not cast dtypes.** The comment's rationale is factually wrong.

**Fact-check #2 (the decisive part) — does that make the loose check actually unsafe?** That depends entirely on whether `mx.quantized_matmul` / `mx.gather_qmm` reject a floating-dtype mismatch between `x`/`weight`/`scales`/`biases`, which is an empirical MLX question, not something you can reason about from the Python source. I wrote a standalone probe building `nn.QuantizedLinear` (the exact call the MTP `fc`/attention layers make: `mx.quantized_matmul(x, weight, scales=scales, biases=biases, transpose=True, group_size=.., bits=..)`) and forced mismatched floating dtypes onto `scales`/`biases` in both directions (fp32 module + bf16/fp16 scales, and bf16 module + fp32 scales), plus the MoE path (`SwitchGLU`/`QuantizedSwitchLinear` → `mx.gather_qmm`).

**Result: every combination TOLERATES the mismatch — none raise.** MLX silently promotes/computes across floating dtypes rather than enforcing an exact match. Ran on both `mlx==0.31.2` (this repo's pinned floor) and `mlx==0.32.0`, on the default GPU (Metal) device — same result both times, 10/10 cases tolerate:

```
control_fp32_matches: tolerate
scales_bf16_vs_fp32: tolerate
biases_bf16_vs_fp32: tolerate
scales_fp16_vs_fp32: tolerate
both_bf16_vs_fp32: tolerate
scales_fp32_vs_bf16: tolerate
x_bf16_scales_fp32: tolerate
gather_qmm_control: tolerate
gather_qmm_scales_bf16: tolerate
gather_qmm_biases_fp16: tolerate
```

Sample precision-diff evidence (same weight, only `scales` dtype differs — fp32 vs bf16):
```
CONTROL (fp32 scales): out[0,:4]=[0.34953, -0.30505, -0.37162, -0.24791]
MISMATCH (bf16 scales): out[0,:4]=[0.35309, -0.29941, -0.37214, -0.24651]
```
Small bf16-precision drift, no crash, no NaN/Inf, finite output.

Per STEP 2 of the task instructions ("only if STEP 1 shows it CAN raise") — since STEP 1 showed unconditional tolerance across every combination and both pinned MLX versions, an end-to-end sidecar-corruption repro was not needed to demonstrate a crash (there is none to reproduce). Instead I built the injector-level integration test directly (see below), which proves the same thing from the other end: a real corrupted-dtype sidecar passes injection and drafts without raising.

## Verdict: NOT reproducible (false positive on the failure mechanism)

The codex finding's factual premise about the comment ("load_weights casts them") is **wrong**, but its predicted failure ("fails in mx.quantized_matmul at the first draft step") does **not** happen — `quantized_matmul`/`gather_qmm` tolerate the mismatch. The loose by-role check is safe, just not for the reason the code claimed.

## Changes

1. **`vllm_mlx/spec_decode/mtp/qwen3_5_inject.py`** — corrected the comment: `load_weights` does NOT cast; the loose floating check is safe because `mx.quantized_matmul`/`mx.gather_qmm` tolerate a floating-dtype mismatch (verified, cites the new tests below). If a future MLX version changes this, the tests are the tripwire and the check needs tightening to an exact match, mirroring the integer branch.
2. **`tests/test_mtp_spec_decode.py`** — two new regression tests:
   - `test_quantized_matmul_and_gather_qmm_tolerate_mismatched_floating_dtype` — direct MLX-behavior canary (the probe above, as a test). Fails first if a future MLX bump starts rejecting floating-dtype mismatches.
   - `test_inject_accepts_sidecar_with_mismatched_floating_scales_dtype_and_drafts_correctly` — injector-level integration test: builds a valid quantized synthetic sidecar, corrupts one non-`fc` `.scales` tensor's dtype (fp32 → bf16, same shape/values), confirms `inject_mtp_support` still returns `True` (the loose check correctly accepts it) and the MTP draft forward (`mtp_forward`) runs to completion with finite output — the exact call path the codex finding predicted would crash.

## Test plan

- [x] `ruff format` + `ruff check` on both changed files — clean
- [x] `pytest tests/test_mtp_spec_decode.py -q` — 94/94 passed (including the 2 new tests)
- [x] Probe run on both `mlx==0.31.2` and `mlx==0.32.0` — same tolerant result

Does NOT touch operator spec-decode initiative lanes (`vllm_mlx/spec_decode/spec_decode/`, `vllm_mlx/speculative/*`).