### PR TITLE
feat(telemetry): wire model_load_failure error events at CLI load sites

### DIFF
--- a/tests/test_telemetry_error_wiring.py
+++ b/tests/test_telemetry_error_wiring.py
@@ -1,0 +1,187 @@
+# SPDX-License-Identifier: Apache-2.0
+"""End-to-end check that a model-load failure emits an opt-in ``error``
+telemetry event (Phase 2.2 error wiring).
+
+Companion to ``test_telemetry_cli.py``: that file pins the lifecycle
+(``session_start`` / ``session_end``) wiring; this one pins that the
+``error`` event actually lands at a real load-failure call site, carries
+the allowlisted ``category`` / ``phase``, and — critically — that the
+fingerprint is the only trace of the exception (no model name, no
+message text, no filesystem path).
+
+The ``bench`` path loads synchronously via ``mlx_lm.load`` (unlike
+``serve``, whose weight load is deferred into the async FastAPI lifespan),
+so a missing local model directory reproduces the failure deterministically
+and offline.
+"""
+
+from __future__ import annotations
+
+import http.server
+import importlib
+import json
+import os
+import re
+import subprocess
+import sys
+import threading
+
+import pytest
+
+
+@pytest.fixture
+def fake_home(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("RAPID_MLX_TELEMETRY", raising=False)
+    import vllm_mlx.telemetry.state as state
+
+    importlib.reload(state)
+    return tmp_path
+
+
+def _run_cli(*args, env_overrides=None, home=None):
+    env = os.environ.copy()
+    if home is not None:
+        env["HOME"] = str(home)
+        # Overriding HOME isolates the telemetry consent/client-id files
+        # (they live under ``~/.rapid-mlx/``), but it also drops the
+        # per-user site-packages (``~/.local/...``) from the child's
+        # import path — which on some dev machines is where ``mlx_lm``
+        # lives, so ``bench`` would fail at ``import mlx_lm`` BEFORE the
+        # load-failure site under test. Propagate the runner's resolved
+        # ``sys.path`` via PYTHONPATH so package resolution is decoupled
+        # from the HOME override. (No-op in CI, where deps sit in the
+        # HOME-independent environment site.)
+        env["PYTHONPATH"] = os.pathsep.join(
+            [p for p in sys.path if p] + [env.get("PYTHONPATH", "")]
+        ).strip(os.pathsep)
+    env.pop("RAPID_MLX_TELEMETRY", None)
+    if env_overrides:
+        env.update(env_overrides)
+    return subprocess.run(
+        [sys.executable, "-m", "vllm_mlx.cli", *args],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=120,
+        check=False,
+    )
+
+
+def _capture_server():
+    """Local HTTP server that records every POSTed telemetry batch.
+
+    Mirrors the harness in ``test_telemetry_cli.py`` — bind port 0 and
+    read ``server_port`` to avoid a probe-then-bind race.
+    """
+    captured: list[dict] = []
+
+    class _Handler(http.server.BaseHTTPRequestHandler):
+        def do_POST(self):  # noqa: N802 — name dictated by stdlib
+            length = int(self.headers.get("content-length", "0"))
+            raw = self.rfile.read(length)
+            try:
+                captured.append(json.loads(raw.decode("utf-8")))
+            except Exception:
+                captured.append({"_raw": raw[:200].decode("utf-8", "replace")})
+            self.send_response(200)
+            self.send_header("content-type", "application/json")
+            self.end_headers()
+            self.wfile.write(b'{"ok":true}')
+
+        def log_message(self, *_a, **_k):  # silence
+            return
+
+    server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), _Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return server, captured
+
+
+def _all_events(captured):
+    return [
+        ev
+        for batch in captured
+        if isinstance(batch.get("batch"), list)
+        for ev in batch["batch"]
+    ]
+
+
+def test_bench_model_load_failure_emits_error_event(fake_home, tmp_path):
+    """``bench`` on a directory with no ``config.json`` fails the
+    synchronous load; an opt-in ``error`` event must land with the
+    allowlisted ``model_load_failure`` / ``startup`` fields."""
+    empty_model = tmp_path / "empty-model"
+    empty_model.mkdir()
+
+    server, captured = _capture_server()
+    port = server.server_port
+    try:
+        _run_cli("telemetry", "enable", home=fake_home)
+        r = _run_cli(
+            "bench",
+            str(empty_model),
+            "--max-tokens",
+            "4",
+            home=fake_home,
+            env_overrides={
+                "RAPID_MLX_TELEMETRY_DEBUG": "1",
+                "RAPID_MLX_TELEMETRY_ENDPOINT": f"http://127.0.0.1:{port}/v1/events",
+            },
+        )
+        # The load failure is surfaced to the user (non-zero exit) — the
+        # telemetry hook must not have swallowed it.
+        assert r.returncode != 0, f"expected non-zero exit; stdout={r.stdout}"
+    finally:
+        server.shutdown()
+        server.server_close()
+
+    events = _all_events(captured)
+    assert events, f"no telemetry POST captured (stderr={r.stderr})"
+
+    errors = [ev for ev in events if ev.get("event") == "error"]
+    assert len(errors) >= 1, (
+        f"no error event; events={[e.get('event') for e in events]}"
+    )
+    err = errors[0]["error"]
+    assert err["category"] == "model_load_failure", err
+    assert err["phase"] == "startup", err
+    # Fingerprint is a 16-hex digest — the ONLY trace of the exception.
+    assert re.fullmatch(r"[0-9a-f]{16}", err["fingerprint"]), err
+
+    # Privacy red-line: the offending path / message text must never ride
+    # along on ANY captured payload (the error event carries only the
+    # bucketed category + fingerprint + phase).
+    blob = json.dumps(captured)
+    assert str(empty_model) not in blob
+    assert "config.json" not in blob
+    assert "No such file" not in blob
+
+
+def test_bench_load_failure_error_event_absent_when_opted_out(fake_home, tmp_path):
+    """The same failure emits NOTHING when telemetry is left at its
+    default-off state — the consent gate holds on the error path too."""
+    empty_model = tmp_path / "empty-model"
+    empty_model.mkdir()
+
+    server, captured = _capture_server()
+    port = server.server_port
+    try:
+        # No ``telemetry enable`` — consent stays default-off.
+        r = _run_cli(
+            "bench",
+            str(empty_model),
+            "--max-tokens",
+            "4",
+            home=fake_home,
+            env_overrides={
+                "RAPID_MLX_TELEMETRY_DEBUG": "1",
+                "RAPID_MLX_TELEMETRY_ENDPOINT": f"http://127.0.0.1:{port}/v1/events",
+            },
+        )
+        assert r.returncode != 0
+    finally:
+        server.shutdown()
+        server.server_close()
+
+    assert not _all_events(captured), "opted-out run must emit no telemetry"

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -3516,6 +3516,16 @@ def serve_command(args):
             ),
         )
     except Exception as e:
+        # Opt-in telemetry (Phase 2.2 error wiring): record that a model
+        # failed to load on the ``serve`` path. The payload carries only a
+        # bucketed category + a traceback fingerprint (basename:func:lineno
+        # + exception class) — never the model name, message text, or path.
+        # ``emit.error`` is ``is_enabled()``-gated and ``@_safe``, so it is a
+        # no-op when telemetry is off and can never mask the user-facing
+        # error handled just below.
+        from vllm_mlx.telemetry import emit as _telemetry_emit
+
+        _telemetry_emit.error(category="model_load_failure", exc=e, phase="startup")
         # Show clean error instead of raw traceback. Catch the typed
         # HF exception class for the 404 case; fall back to substring
         # match for legacy callers (older huggingface_hub) and for
@@ -4204,6 +4214,13 @@ def bench_command(args):
         try:
             model, tokenizer = load(args.model)
         except Exception as e:
+            # Opt-in telemetry (Phase 2.2 error wiring): mirror the
+            # ``serve`` path — record a bucketed model-load failure
+            # (category + traceback fingerprint only, no model name /
+            # message / path). ``is_enabled()``-gated + ``@_safe``.
+            from vllm_mlx.telemetry import emit as _telemetry_emit
+
+            _telemetry_emit.error(category="model_load_failure", exc=e, phase="startup")
             # Mirror serve_command: clean message instead of a 30-line
             # traceback when the user typed a missing repo / bad alias.
             from huggingface_hub.utils import RepositoryNotFoundError


### PR DESCRIPTION
## Why

Phase 2.2 of the opt-in telemetry pipeline wires the `error` event, which
was defined in Phase 1 (`ErrorPayload` + `emit.error` + allowlists) but
ships **dark** — no runtime call site emits it. Model-load failures are the
single highest-signal triage input (`docs/plans/telemetry-golden-profile.md`
§2, "Errors / crashes"): a model that won't load = broken model / bad config
/ missing extra / OOM, and today we are blind to it in the field.

## What

Emit `error(category="model_load_failure", phase="startup")` at the two
**synchronous** model-load exception boundaries in the CLI:
- `serve_command` — around `load_model(...)` (config read + MLLM/LLM
  type-detection + R2-mirror fetch).
- `bench_command` — around the direct `mlx_lm.load(...)`.

The payload carries only the allowlisted `category`/`phase` + a traceback
fingerprint (`basename:func:lineno` + exception class). Never the model
name, message text, or path. `emit.error` is `is_enabled()`-gated and
`@_safe`, so it is a no-op when telemetry is off and can never mask the
user-facing error handled right below it.

## Scope / follow-ups

Synchronous load failures only. `serve`'s **weight** load is deferred into
the async FastAPI lifespan (`_engine.start()`) — instrumenting that site,
plus the `oom` / `tool_parse` / `shutdown_traceback` sites in §3.3, are
tracked follow-ups (each its own small PR).

## Test

`tests/test_telemetry_error_wiring.py` drives `bench` on a config-less
model dir end-to-end through a local capture server and asserts:
1. the `error` event lands with the allowlisted fields + a 16-hex fingerprint;
2. the offending path / message text never rides along on any payload;
3. nothing is emitted when telemetry is opted out (consent gate holds on
   the error path too).

42/42 telemetry tests pass; `ruff format` + `ruff check` clean; codex review LGTM.