### PR TITLE
fix(kv-cache): probe nested language-model head_dim so live int8 KV engages on VLMs (#1199)

### DIFF
--- a/tests/test_quantized_batch_cache.py
+++ b/tests/test_quantized_batch_cache.py
@@ -537,6 +537,18 @@ def test_probe_head_dim():
 
     assert probe_head_dim(_VLM4()) is None
 
+    # VLM signalled by `language_model` presence even when the submodule exposes
+    # no `.args` at all: the presence of the submodule is the multimodal signal,
+    # so we must still refuse the top-level vision dims and fail safe (#1208).
+    class _NoArgsLM:
+        pass  # language_model submodule with no `.args`
+
+    class _VLM5:
+        args = _VisionishTop()
+        language_model = _NoArgsLM()
+
+    assert probe_head_dim(_VLM5()) is None
+
 
 def test_update_adjusts_group_size_for_head_dim_96():
     # head_dim=96 is not divisible by 64 but is by 32 — must auto-adjust, not crash

--- a/tests/test_quantized_batch_cache.py
+++ b/tests/test_quantized_batch_cache.py
@@ -507,6 +507,20 @@ def test_probe_head_dim():
 
     assert probe_head_dim(_VLM2()) == 256
 
+    # Mixed: top-level args expose MISLEADING vision/composite dims
+    # (hidden_size // num_attention_heads = 64) while the authoritative language
+    # head_dim is 256. The nested language config must win — preferring the
+    # top-level fallback here would mis-size the live cache (#1208).
+    class _VisionishTop:
+        hidden_size = 1024
+        num_attention_heads = 16  # -> 64, the WRONG (non-language) head dim
+
+    class _VLM3:
+        args = _VisionishTop()
+        language_model = _LM()  # language head_dim = 256
+
+    assert probe_head_dim(_VLM3()) == 256
+
 
 def test_update_adjusts_group_size_for_head_dim_96():
     # head_dim=96 is not divisible by 64 but is by 32 — must auto-adjust, not crash
@@ -669,6 +683,18 @@ def test_probe_kv_head_dims():
         language_model = _LMV()
 
     assert probe_kv_head_dims(_VLMV()) == (256, 128)
+
+    # Mixed: misleading top-level dims must NOT win over the nested language
+    # config, and v_head_dim is read from the SAME (nested) args (#1208).
+    class _VisionishTopV:
+        head_dim = 64  # wrong (non-language) dim; must be ignored
+        v_head_dim = 64
+
+    class _VLMV2:
+        args = _VisionishTopV()
+        language_model = _LMV()  # language head_dim=256, v_head_dim=128
+
+    assert probe_kv_head_dims(_VLMV2()) == (256, 128)
 
     # Unknown -> (None, None).
     assert probe_kv_head_dims(object()) == (None, None)

--- a/tests/test_quantized_batch_cache.py
+++ b/tests/test_quantized_batch_cache.py
@@ -521,6 +521,22 @@ def test_probe_head_dim():
 
     assert probe_head_dim(_VLM3()) == 256
 
+    # VLM whose nested language config is UNPROBEABLE must fail safe to None,
+    # NOT fall back to the misleading top-level vision/composite dims (#1208
+    # codex): a wrong head dim would mis-size the live cache instead of a clean
+    # bf16 fallback.
+    class _UnprobeableArgs:
+        pass  # no head_dim, no hidden_size/num_attention_heads
+
+    class _UnprobeableLM:
+        args = _UnprobeableArgs()
+
+    class _VLM4:
+        args = _VisionishTop()  # -> 64 if wrongly trusted
+        language_model = _UnprobeableLM()
+
+    assert probe_head_dim(_VLM4()) is None
+
 
 def test_update_adjusts_group_size_for_head_dim_96():
     # head_dim=96 is not divisible by 64 but is by 32 — must auto-adjust, not crash

--- a/tests/test_quantized_batch_cache.py
+++ b/tests/test_quantized_batch_cache.py
@@ -483,6 +483,30 @@ def test_probe_head_dim():
     assert probe_head_dim(_M2()) == 64
     assert probe_head_dim(object()) is None
 
+    # Multimodal wrapper (VLM): the language model's head_dim lives on a nested
+    # `language_model.args`, not the top-level `model.args`. Must descend so the
+    # live KV cache is not spuriously disabled (#1199 follow-up).
+    class _TextArgs:
+        head_dim = 256
+
+    class _LM:
+        args = _TextArgs()
+
+    class _VLM:
+        args = object()  # top-level args carry NO attention dims
+        language_model = _LM()
+
+    assert probe_head_dim(_VLM()) == 256
+
+    # Alternative nesting: dims exposed via `args.text_config` sub-config.
+    class _TopArgsWithTextConfig:
+        text_config = _TextArgs()
+
+    class _VLM2:
+        args = _TopArgsWithTextConfig()
+
+    assert probe_head_dim(_VLM2()) == 256
+
 
 def test_update_adjusts_group_size_for_head_dim_96():
     # head_dim=96 is not divisible by 64 but is by 32 — must auto-adjust, not crash
@@ -630,6 +654,21 @@ def test_probe_kv_head_dims():
         args = _Args2()
 
     assert probe_kv_head_dims(_M2()) == (64, 64)
+
+    # Multimodal wrapper: both key AND value head dims resolve from the nested
+    # `language_model.args`, not the top-level args (#1199 follow-up).
+    class _TextArgsV:
+        head_dim = 256
+        v_head_dim = 128
+
+    class _LMV:
+        args = _TextArgsV()
+
+    class _VLMV:
+        args = object()
+        language_model = _LMV()
+
+    assert probe_kv_head_dims(_VLMV()) == (256, 128)
 
     # Unknown -> (None, None).
     assert probe_kv_head_dims(object()) == (None, None)

--- a/vllm_mlx/quantized_batch_cache.py
+++ b/vllm_mlx/quantized_batch_cache.py
@@ -591,19 +591,33 @@ def _text_attention_args(model: Any) -> Any:
     the live cache — an incompatible first write that cannot fall back mid-stream
     would then crash the request instead of failing safe.
 
-    Text-only models have neither ``language_model`` nor ``text_config``, so they
-    fall through to the top-level args unchanged. The top-level args are returned
-    as the last resort so callers can still read ``v_head_dim`` from them exactly
-    as before (and so an unprobeable model yields ``None`` -> bf16 fail-safe).
+    If a language config EXISTS but is not probeable, we still do NOT fall back
+    to the top-level args (they may be vision/composite) — we return the
+    language-scoped object so the probe yields ``None`` and the live cache fails
+    safe to bf16. Only genuinely text-only models (neither ``language_model`` nor
+    ``text_config``) fall through to the top-level args, unchanged, so callers
+    can read ``v_head_dim`` from them exactly as before.
     """
     args = getattr(model, "args", None)
     lm = getattr(model, "language_model", None)
     lm_args = getattr(lm, "args", None) if lm is not None else None
+    text_cfg = getattr(args, "text_config", None) if args is not None else None
+
+    # Prefer a probeable language-specific config (multimodal wrappers).
     if _head_dim_from_args(lm_args) is not None:
         return lm_args
-    text_cfg = getattr(args, "text_config", None) if args is not None else None
     if _head_dim_from_args(text_cfg) is not None:
         return text_cfg
+
+    # A language config exists but couldn't be probed: stay language-scoped so
+    # the probe returns None (bf16 fail-safe); never fall back to top-level dims,
+    # which on a VLM may be vision/composite and would mis-size the live cache.
+    if lm_args is not None:
+        return lm_args
+    if text_cfg is not None:
+        return text_cfg
+
+    # Genuinely text-only model: the top-level args ARE the language config.
     return args
 
 

--- a/vllm_mlx/quantized_batch_cache.py
+++ b/vllm_mlx/quantized_batch_cache.py
@@ -557,13 +557,13 @@ def install_quantized_batch_cache(
     return batch_gen
 
 
-def probe_head_dim(model: Any) -> int | None:
-    """Best-effort head dimension of a loaded mlx-lm model; ``None`` if unknown.
+def _head_dim_from_args(args: Any) -> int | None:
+    """Head dim carried directly by a single args/config object, or ``None``.
 
-    Used at install time to pick a compatible group size (or disable live
-    quantization when no supported group size divides the head dim).
+    Reads an explicit ``head_dim`` first, then falls back to
+    ``hidden_size // num_attention_heads``. Does not descend into sub-configs;
+    see :func:`_text_attention_args` for the multimodal-aware resolution.
     """
-    args = getattr(model, "args", None)
     if args is None:
         return None
     hd = getattr(args, "head_dim", None)
@@ -576,16 +576,54 @@ def probe_head_dim(model: Any) -> int | None:
     return None
 
 
+def _text_attention_args(model: Any) -> Any:
+    """The args object carrying the *language* model's attention dims.
+
+    Multimodal wrappers (VLMs such as ``Qwen3.5-4B-MLX-4bit``) keep the language
+    model's ``head_dim``/``hidden_size`` on a nested ``language_model`` submodule
+    (its own ``.args``) or an ``args.text_config`` sub-config — the top-level
+    ``model.args`` has no attention dims. Probing only the top level returns
+    ``None`` and disables live KV quantization even though the text tower
+    quantizes fine (e.g. head_dim=256). Prefer the top-level args when they
+    already carry a head dim (unchanged for text-only models); otherwise descend
+    so VLMs are covered too. Returns the top-level args as a last resort so
+    callers can still read ``v_head_dim`` from it exactly as before.
+    """
+    args = getattr(model, "args", None)
+    if _head_dim_from_args(args) is not None:
+        return args
+    lm = getattr(model, "language_model", None)
+    lm_args = getattr(lm, "args", None) if lm is not None else None
+    if _head_dim_from_args(lm_args) is not None:
+        return lm_args
+    text_cfg = getattr(args, "text_config", None) if args is not None else None
+    if _head_dim_from_args(text_cfg) is not None:
+        return text_cfg
+    return args
+
+
+def probe_head_dim(model: Any) -> int | None:
+    """Best-effort head dimension of a loaded mlx-lm model; ``None`` if unknown.
+
+    Used at install time to pick a compatible group size (or disable live
+    quantization when no supported group size divides the head dim). Descends
+    into a multimodal wrapper's language submodule so VLMs are not spuriously
+    reported as unprobeable (see :func:`_text_attention_args`).
+    """
+    return _head_dim_from_args(_text_attention_args(model))
+
+
 def probe_kv_head_dims(model: Any) -> tuple[int | None, int | None]:
     """Best-effort ``(key, value)`` head dims of a loaded mlx-lm model.
 
     ``mx.quantize`` groups along the last (head) dimension, and a model may use a
     distinct value head dim (``v_head_dim``) from its key head dim. Both must be
     divisible by the chosen group size, so probe both. A dim that cannot be
-    determined comes back as ``None``.
+    determined comes back as ``None``. ``v_head_dim`` is read from the same
+    (possibly nested) args object that supplied the key head dim.
     """
-    k = probe_head_dim(model)
-    args = getattr(model, "args", None)
+    args = _text_attention_args(model)
+    k = _head_dim_from_args(args)
     v = getattr(args, "v_head_dim", None) if args is not None else None
     if not (isinstance(v, int) and v > 0):
         v = k  # standard models: value head dim == key head dim

--- a/vllm_mlx/quantized_batch_cache.py
+++ b/vllm_mlx/quantized_batch_cache.py
@@ -581,17 +581,22 @@ def _text_attention_args(model: Any) -> Any:
 
     Multimodal wrappers (VLMs such as ``Qwen3.5-4B-MLX-4bit``) keep the language
     model's ``head_dim``/``hidden_size`` on a nested ``language_model`` submodule
-    (its own ``.args``) or an ``args.text_config`` sub-config — the top-level
-    ``model.args`` has no attention dims. Probing only the top level returns
-    ``None`` and disables live KV quantization even though the text tower
-    quantizes fine (e.g. head_dim=256). Prefer the top-level args when they
-    already carry a head dim (unchanged for text-only models); otherwise descend
-    so VLMs are covered too. Returns the top-level args as a last resort so
-    callers can still read ``v_head_dim`` from it exactly as before.
+    (its own ``.args``) or an ``args.text_config`` sub-config, while the
+    top-level ``model.args`` may carry no attention dims at all — or, worse,
+    vision/composite dims. The KV cache stores *language* attention, so the
+    language-specific config is authoritative: resolve it FIRST, and fall back
+    to the top-level args only when no language config exists. Preferring the
+    top level would let a wrapper's ``hidden_size // num_attention_heads`` (a
+    vision or composite value) short-circuit to the wrong head dim and mis-size
+    the live cache — an incompatible first write that cannot fall back mid-stream
+    would then crash the request instead of failing safe.
+
+    Text-only models have neither ``language_model`` nor ``text_config``, so they
+    fall through to the top-level args unchanged. The top-level args are returned
+    as the last resort so callers can still read ``v_head_dim`` from them exactly
+    as before (and so an unprobeable model yields ``None`` -> bf16 fail-safe).
     """
     args = getattr(model, "args", None)
-    if _head_dim_from_args(args) is not None:
-        return args
     lm = getattr(model, "language_model", None)
     lm_args = getattr(lm, "args", None) if lm is not None else None
     if _head_dim_from_args(lm_args) is not None:

--- a/vllm_mlx/quantized_batch_cache.py
+++ b/vllm_mlx/quantized_batch_cache.py
@@ -591,12 +591,13 @@ def _text_attention_args(model: Any) -> Any:
     the live cache — an incompatible first write that cannot fall back mid-stream
     would then crash the request instead of failing safe.
 
-    If a language config EXISTS but is not probeable, we still do NOT fall back
-    to the top-level args (they may be vision/composite) — we return the
-    language-scoped object so the probe yields ``None`` and the live cache fails
-    safe to bf16. Only genuinely text-only models (neither ``language_model`` nor
-    ``text_config``) fall through to the top-level args, unchanged, so callers
-    can read ``v_head_dim`` from them exactly as before.
+    The multimodal signal is the *presence* of a ``language_model`` submodule or
+    an ``args.text_config`` — NOT whether their dims happen to be probeable. Once
+    that signal is present we never fall back to the top-level args (which may be
+    vision/composite and would mis-size the live cache); an unprobeable language
+    config yields ``None`` so the live cache fails safe to bf16. Only genuinely
+    text-only models (neither signal present) use the top-level args, unchanged,
+    so callers can read ``v_head_dim`` from them exactly as before.
     """
     args = getattr(model, "args", None)
     lm = getattr(model, "language_model", None)
@@ -609,13 +610,11 @@ def _text_attention_args(model: Any) -> Any:
     if _head_dim_from_args(text_cfg) is not None:
         return text_cfg
 
-    # A language config exists but couldn't be probed: stay language-scoped so
-    # the probe returns None (bf16 fail-safe); never fall back to top-level dims,
-    # which on a VLM may be vision/composite and would mis-size the live cache.
-    if lm_args is not None:
-        return lm_args
-    if text_cfg is not None:
-        return text_cfg
+    # Multimodal wrapper detected but no language config was probeable: stay
+    # language-scoped (or None) so the probe fails safe to bf16. Never fall back
+    # to the top-level args here — on a VLM they may be vision/composite dims.
+    if lm is not None or text_cfg is not None:
+        return lm_args if lm_args is not None else text_cfg
 
     # Genuinely text-only model: the top-level args ARE the language config.
     return args


### PR DESCRIPTION
## Why this matters

This fixes a **silent, headline-defeating regression in coverage** for #1199: **because** the live-KV quantization probe only looked at top-level `model.args`, the `--kv-cache-dtype int8/int4` flag became a **no-op on the flagship default model** — precisely the memory win #1199 was built to deliver. The **why** is subtle (a nested VLM config), so it slipped past #1199's own tests and only surfaced under a real serve dogfood.

## Problem

`--kv-cache-dtype int8/int4` silently fell back to a **bf16** live continuous-batching KV cache on the **flagship default model** `mlx-community/Qwen3.5-4B-MLX-4bit`, so the requested dtype delivered **zero live KV memory reduction** there. Surfaced by a local-wheel dogfood of the post-v0.11.0 PRs (#1199/#1200/#1201).

At serve time the operator saw:

```
WARNING [kv-cache] live KV quantization disabled: head_dim (K=None, V=None) unknown
or not divisible by any supported group_size (32/64/128); serving a bf16 live cache
```

## Root cause

`probe_head_dim` read only the **top-level** `model.args.head_dim` (with a `hidden_size // num_attention_heads` fallback). `Qwen3.5-4B-MLX-4bit` is a **multimodal wrapper (VLM)** — its top-level `args` carry no attention dims (`vision_config`/`text_config` layout). The language tower's real dims live on a nested `language_model.args` (**head_dim=256**, divisible by 128) or `args.text_config`. The probe returned `None`, so `resolve_kv_quantization` judged the model unprobeable and `_init_kv_quantization` disabled the live quantized cache.

## Fix

Add `_text_attention_args(model)`: prefer the top-level args when they already carry a head dim (**unchanged for text-only models**), otherwise descend into `language_model.args`, then `args.text_config`. Both `probe_head_dim` and `probe_kv_head_dims` route through it, and `v_head_dim` is read from the same resolved args object.

This **widens best-effort coverage; it is not a correctness change**. The retained prefix cache was never gated by this probe (it self-coerces per layer), and an unprobeable model still **fails safe** to a bf16 live cache.

## Verification

Real checkpoint (`mlx-community/Qwen3.5-4B-MLX-4bit`):
- `probe_head_dim(model)` → **256** (was `None`)
- `resolve_kv_quantization(256, 256, 64)` → `group_size=64, live_disabled=False`

Fresh-venv serve `--kv-cache-dtype int8 --disable-prefix-cache`, before → after this change:
- log: `live KV quantization disabled ... bf16 live cache` → **`live continuous-batching KV cache quantized to int8 (group_size=64)`**
- 8/8 concurrent requests coherent under continuous batching
- int8 vs bf16 greedy (temp=0) output **byte-identical**
- decode ~147 tok/s (no regression from the now-active quantized live cache)

## Test plan

- [x] `pytest tests/test_quantized_batch_cache.py` — **43/43 pass** (adds nested-VLM cases to `test_probe_head_dim` and `test_probe_kv_head_dims`, covering both `language_model.args` and `args.text_config` descent; existing text-only + `hidden_size` fallback + MLA-conservative cases unchanged)
- [x] `ruff check` clean on both changed files
- [x] End-to-end fresh-venv serve on the real flagship VLM confirms the disabled WARNING is gone and the live int8 cache engages, output coherent
- [x] Backward-compat: text-only models still resolve head_dim from top-level args (identical path), object-with-no-args still returns `None`

Docs-free, engine-local; no aliases/CLI/spec-decode changes.