### PR TITLE
feat(telemetry): emit model_load_failure on serve's async engine start

### DIFF
--- a/tests/test_telemetry_error_wiring.py
+++ b/tests/test_telemetry_error_wiring.py
@@ -185,3 +185,53 @@ def test_bench_load_failure_error_event_absent_when_opted_out(fake_home, tmp_pat
         server.server_close()
 
     assert not _all_events(captured), "opted-out run must emit no telemetry"
+
+
+async def test_serve_engine_start_failure_emits_model_load_error(monkeypatch):
+    """``serve``'s real weight load runs in the async FastAPI lifespan
+    (``_engine.start()``), NOT the CLI ``load_model()`` (which only does
+    config read + type-detection). A failure there is THE serve model-load
+    failure — it must emit ``model_load_failure`` / ``startup`` and still
+    re-raise so startup aborts exactly as before.
+
+    Driven in-process via the lifespan async-generator pattern (mirrors
+    tests/test_ready_banner_timing.py). ``emit.error`` is patched to capture
+    the call so this asserts the wiring, not the (separately-tested) redact
+    pipeline.
+    """
+    import vllm_mlx._signal_observability as _sigobs
+    import vllm_mlx.server as vllm_server
+    from vllm_mlx.config import get_config
+    from vllm_mlx.telemetry import emit as _emit
+
+    # Keep the test hermetic: don't install real SIGTERM/SIGHUP handlers on
+    # the pytest process (the failure aborts startup mid-lifespan, so the
+    # full-lifespan restore in the banner test doesn't apply here).
+    monkeypatch.setattr(_sigobs, "install_signal_observability", lambda: False)
+
+    calls = []
+    monkeypatch.setattr(_emit, "error", lambda **kw: calls.append(kw))
+
+    class _BoomEngine:
+        _loaded = False
+
+        async def start(self):
+            raise RuntimeError("checkpoint shards missing")
+
+    cfg = get_config()
+    saved = (vllm_server._engine, cfg.bind_host, cfg.bind_port, cfg.ready)
+    vllm_server._engine = _BoomEngine()
+    try:
+        agen = vllm_server.lifespan(vllm_server.app)
+        with pytest.raises(RuntimeError, match="checkpoint shards missing"):
+            await agen.__anext__()  # startup → engine.start() raises → re-raised
+    finally:
+        vllm_server._engine, cfg.bind_host, cfg.bind_port, cfg.ready = saved
+
+    assert any(
+        c.get("category") == "model_load_failure" and c.get("phase") == "startup"
+        for c in calls
+    ), calls
+    # The raw exception is handed to emit.error for fingerprinting only;
+    # its message never reaches the payload (redact.fingerprint_traceback).
+    assert isinstance(calls[0].get("exc"), RuntimeError)

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -482,7 +482,25 @@ async def lifespan(app: FastAPI):
 
     # Startup: Start engine if loaded (needed for BatchedEngine in uvicorn's event loop)
     if _engine is not None and hasattr(_engine, "_loaded") and not _engine._loaded:
-        await _engine.start()
+        try:
+            await _engine.start()
+        except Exception as _start_exc:
+            # Opt-in telemetry (Phase 2.2 error wiring): serve's real weight
+            # load happens HERE in the async lifespan, not in the CLI's
+            # ``load_model()`` (which only does config read + MLLM/LLM
+            # type-detection). A failure here is THE ``serve`` model-load
+            # failure — the CLI-side wiring (PR #1207) cannot see it. Record
+            # a bucketed error (allowlisted category + traceback fingerprint
+            # only, never the model name / message / path), then re-raise so
+            # startup still aborts exactly as before. ``emit.error`` is
+            # ``is_enabled()``-gated and ``@_safe`` → a no-op when telemetry
+            # is off and can never mask the failure.
+            from vllm_mlx.telemetry import emit as _telemetry_emit
+
+            _telemetry_emit.error(
+                category="model_load_failure", exc=_start_exc, phase="startup"
+            )
+            raise
 
     # Warmup: generate one token to trigger Metal shader compilation.
     # Runs here (not in CLI) so all engine types are fully started first.


### PR DESCRIPTION
## Why

Follow-up to #1207 (tracked there as a scope note). `serve`'s CLI-side
`load_model()` only does config read + MLLM/LLM type-detection — the real
**weight** load is deferred into the async FastAPI lifespan
(`_engine.start()`). So a `serve` model that actually fails to load
(missing shards, incompatible checkpoint, OOM-on-load) surfaces in the
lifespan, **invisible** to the CLI-side `error` wiring landed in #1207.
This closes that gap, completing `model_load_failure` coverage for the
primary user path.

## What

Wrap `await _engine.start()` in the lifespan:
`emit.error(category="model_load_failure", phase="startup")` then
**re-raise** so startup aborts exactly as before. Payload carries only the
allowlisted category/phase + a traceback fingerprint — never the model
name, message, or path. `emit.error` is `is_enabled()`-gated and `@_safe`,
so it is a no-op when telemetry is off and can never mask the failure.

## Test

`tests/test_telemetry_error_wiring.py` drives the lifespan async-generator
in-process (mirrors `test_ready_banner_timing.py`) with a fake engine whose
`start()` raises, asserting (1) the `error` event carries the allowlisted
`model_load_failure`/`startup`, and (2) the original exception is re-raised
so startup still aborts. 3/3 wiring tests pass; `ruff` clean.

## Follow-ups (unchanged from #1207)

Remaining §3.3 sites — `oom`, `tool_parse`, `shutdown_traceback` — each its
own small PR.