### PR TITLE
feat(telemetry): emit shutdown_traceback error on lifespan teardown crash

### DIFF
--- a/tests/test_telemetry_error_wiring.py
+++ b/tests/test_telemetry_error_wiring.py
@@ -235,3 +235,57 @@ async def test_serve_engine_start_failure_emits_model_load_error(monkeypatch):
     # The raw exception is handed to emit.error for fingerprinting only;
     # its message never reaches the payload (redact.fingerprint_traceback).
     assert isinstance(calls[0].get("exc"), RuntimeError)
+
+
+async def test_serve_shutdown_failure_emits_shutdown_traceback(monkeypatch):
+    """A crash during lifespan teardown (cache save / MCP close / engine
+    stop) must emit ``shutdown_traceback`` / ``shutdown`` and re-raise so
+    the shutdown path is unchanged."""
+    import vllm_mlx._signal_observability as _sigobs
+    import vllm_mlx.server as vllm_server
+    from vllm_mlx.config import get_config
+    from vllm_mlx.telemetry import emit as _emit
+
+    monkeypatch.setattr(_sigobs, "install_signal_observability", lambda: False)
+
+    calls = []
+    monkeypatch.setattr(_emit, "error", lambda **kw: calls.append(kw))
+
+    class _EngineBoomOnStop:
+        # ``_loaded=True`` skips ``start()`` so startup reaches ``yield``;
+        # no ``save_cache_to_disk`` attr so the cache-save step is a no-op;
+        # warmup calls are swallowed (non-fatal) by the lifespan.
+        _loaded = True
+
+        async def stop(self):
+            raise RuntimeError("engine stop boom")
+
+    cfg = get_config()
+    saved = (
+        vllm_server._engine,
+        cfg.bind_host,
+        cfg.bind_port,
+        cfg.ready,
+        getattr(cfg, "draining", False),
+    )
+    vllm_server._engine = _EngineBoomOnStop()
+    cfg.bind_host = None  # suppress the Ready banner
+    cfg.bind_port = None
+    try:
+        agen = vllm_server.lifespan(vllm_server.app)
+        await agen.__anext__()  # startup → yield
+        with pytest.raises(RuntimeError, match="engine stop boom"):
+            await agen.__anext__()  # shutdown → stop() raises → re-raised
+    finally:
+        (
+            vllm_server._engine,
+            cfg.bind_host,
+            cfg.bind_port,
+            cfg.ready,
+            cfg.draining,
+        ) = saved
+
+    assert any(
+        c.get("category") == "shutdown_traceback" and c.get("phase") == "shutdown"
+        for c in calls
+    ), calls

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -681,22 +681,39 @@ async def lifespan(app: FastAPI):
     _shutdown_cfg.ready = False
     _shutdown_cfg.draining = True
 
-    # Shutdown: Save cache to disk BEFORE stopping engine.
+    # Shutdown teardown: save cache, close MCP, stop engine.
     #
-    # Delegates to ``_shutdown_save_prefix_cache`` which wraps the
-    # synchronous save in ``asyncio.to_thread`` — see that function's
-    # docstring for the rationale. Extracted so the regression test
-    # pins the wrapper at the production callsite rather than wrapping
-    # ``to_thread`` test-side (codex PR #667 round 1 BLOCKING-3).
-    await _shutdown_save_prefix_cache()
+    # ``_shutdown_save_prefix_cache`` wraps the synchronous save in
+    # ``asyncio.to_thread`` — see that function's docstring for the
+    # rationale. Extracted so the regression test pins the wrapper at
+    # the production callsite rather than wrapping ``to_thread``
+    # test-side (codex PR #667 round 1 BLOCKING-3).
+    #
+    # Opt-in telemetry (Phase 2.2 error wiring): a crash while tearing
+    # down is exactly the "process disappeared during shutdown" shape the
+    # signal-observability hooks above were installed for. Record a
+    # bucketed ``shutdown_traceback`` error (allowlisted category/phase +
+    # traceback fingerprint only — no message text or path), then re-raise
+    # so the shutdown path behaves identically. ``emit.error`` is
+    # ``is_enabled()``-gated and ``@_safe`` → a no-op when telemetry is off
+    # and never masks the failure.
+    try:
+        await _shutdown_save_prefix_cache()
 
-    # Shutdown: Close MCP connections and stop engine
-    if _mcp_manager is not None:
-        await _mcp_manager.stop()
-        logger.info("MCP manager stopped")
-    if _engine is not None:
-        await _engine.stop()
-        logger.info("Engine stopped")
+        # Shutdown: Close MCP connections and stop engine
+        if _mcp_manager is not None:
+            await _mcp_manager.stop()
+            logger.info("MCP manager stopped")
+        if _engine is not None:
+            await _engine.stop()
+            logger.info("Engine stopped")
+    except Exception as _shutdown_exc:
+        from vllm_mlx.telemetry import emit as _telemetry_emit
+
+        _telemetry_emit.error(
+            category="shutdown_traceback", exc=_shutdown_exc, phase="shutdown"
+        )
+        raise
 
     # Round 19 codex review (PR #532): Drive the telemetry session_end
     # path here too. ``atexit`` does NOT fire on SIGTERM (systemd /


### PR DESCRIPTION
## Why

Phase 2.2 error wiring, the §3.3 `shutdown_traceback` site. The huge
signal-observability block at lifespan startup exists because 0.8.5
dogfooding kept hitting the "process disappeared between two stdout writes"
shape — no traceback, no shutdown banner. A crash *during teardown* (cache
save / MCP close / engine stop) is that shape, and we're currently blind to
it in the field.

## What

Wrap the lifespan teardown block:
`emit.error(category="shutdown_traceback", phase="shutdown")` then
**re-raise** so the shutdown path behaves identically. Payload carries only
the allowlisted category/phase + a traceback fingerprint — never a message
or path. `emit.error` is `is_enabled()`-gated and `@_safe` (no-op when off,
never masks the failure).

## Test

Drives the lifespan async-generator through startup → shutdown (mirrors
`test_ready_banner_timing.py`) with a fake engine whose `stop()` raises;
asserts the `shutdown_traceback`/`shutdown` event lands and the original
exception is re-raised. 4/4 wiring tests pass; `ruff` clean.

## Chain status

`model_load_failure` complete (#1207 CLI + #1210 serve lifespan); this adds
`shutdown_traceback`. Remaining §3.3 sites: `oom`, `tool_parse`.