### PR TITLE
feat(telemetry): emit tool_parse error when a tool parser crashes

### DIFF
--- a/tests/test_telemetry_error_wiring.py
+++ b/tests/test_telemetry_error_wiring.py
@@ -28,6 +28,14 @@ import threading
 
 import pytest
 
+# Every test here exercises a code path behind the mlx runtime: the CLI
+# subprocess (bench), the FastAPI server lifespan, and the tool parser all
+# transitively import ``mlx``. Skip the whole module cleanly where mlx is
+# not installed — e.g. the Linux ``pr_validate`` / targeted-tests runner —
+# so they skip rather than hard-fail with ModuleNotFoundError there. On the
+# apple-silicon job (where mlx is present) they run normally.
+pytest.importorskip("mlx")
+
 
 @pytest.fixture
 def fake_home(tmp_path, monkeypatch):
@@ -289,3 +297,48 @@ async def test_serve_shutdown_failure_emits_shutdown_traceback(monkeypatch):
         c.get("category") == "shutdown_traceback" and c.get("phase") == "shutdown"
         for c in calls
     ), calls
+
+
+def test_tool_parser_crash_emits_tool_parse_error(monkeypatch):
+    """When the configured tool parser raises while extracting calls, the
+    request path falls back to the generic text parser AND emits a
+    ``tool_parse`` / ``chat`` error. The fallback must still return normally
+    (the crash is never surfaced to the user)."""
+    from vllm_mlx.config import get_config
+    from vllm_mlx.service import helpers
+    from vllm_mlx.telemetry import emit as _emit
+    from vllm_mlx.tool_parsers.abstract_tool_parser import ToolParserManager
+
+    calls = []
+    monkeypatch.setattr(_emit, "error", lambda **kw: calls.append(kw))
+
+    class _BoomParser:
+        def __init__(self, tokenizer=None):
+            pass
+
+        def reset(self):
+            pass
+
+        def extract_tool_calls(self, *a, **k):
+            raise ValueError("malformed tool-call markup")
+
+    monkeypatch.setattr(
+        ToolParserManager, "get_tool_parser", staticmethod(lambda name: _BoomParser)
+    )
+
+    cfg = get_config()
+    saved = (cfg.enable_auto_tool_choice, cfg.tool_call_parser)
+    cfg.enable_auto_tool_choice = True
+    cfg.tool_call_parser = "hermes"
+    try:
+        content, tool_calls = helpers._parse_tool_calls_with_parser(
+            "here is some plain assistant text with no tool call", request=None
+        )
+    finally:
+        cfg.enable_auto_tool_choice, cfg.tool_call_parser = saved
+
+    assert any(
+        c.get("category") == "tool_parse" and c.get("phase") == "chat" for c in calls
+    ), calls
+    # Fallback returned normally — the parser crash was swallowed, not raised.
+    assert isinstance(content, str)

--- a/vllm_mlx/service/helpers.py
+++ b/vllm_mlx/service/helpers.py
@@ -2811,6 +2811,16 @@ def _parse_tool_calls_with_parser(
         else:
             return parse_tool_calls(output_text, request_dict)
     except Exception as e:
+        # Opt-in telemetry (Phase 2.2 error wiring): the configured tool
+        # parser crashed while extracting calls, so we fall back to the
+        # generic text parser below. Record a bucketed ``tool_parse`` error
+        # — allowlisted category/phase + a traceback fingerprint of the
+        # PARSER code path, never the model output being parsed.
+        # ``is_enabled()``-gated + ``@_safe`` → a no-op when telemetry is
+        # off and it never changes the fallback behaviour below.
+        from vllm_mlx.telemetry import emit as _telemetry_emit
+
+        _telemetry_emit.error(category="tool_parse", exc=e, phase="chat")
         logger.warning(f"Tool parser error: {e}")
         return parse_tool_calls(output_text, request_dict)
 


### PR DESCRIPTION
## Why

Phase 2.2 error wiring, the §3.3 `tool_parse` site. When the configured
tool-call parser crashes mid-extraction, the request path silently falls
back to the generic text parser — the user still gets a response, but the
tool call is lost and we have **zero** visibility that a parser is broken
for some model. Broken tool calling is the highest-signal failure for the
agent workloads that dominate real usage.

## What

`_parse_tool_calls_with_parser` (service/helpers.py) already wraps
`parser.extract_tool_calls(...)` in a try/except that falls back to
`parse_tool_calls(...)` on any exception. Wire
`emit.error(category="tool_parse", phase="chat")` inside that except,
before the fallback. The fingerprint is of the **parser code path**
(basename:func:lineno + exc class); the model output being parsed is never
sent. `emit.error` is `is_enabled()`-gated + `@_safe` — a no-op when off,
and the fallback behaviour is byte-for-byte unchanged.

Scope: the non-streaming finalize path (primary tool-extraction site). The
streaming postprocessor recovery (`service/postprocessor.py`) and the
debug-level auto-infer path are separate follow-ups.

## Test

Monkeypatches `ToolParserManager.get_tool_parser` to a parser whose
`extract_tool_calls` raises, then calls the helper and asserts (1) the
`tool_parse`/`chat` event lands, and (2) the fallback returns normally (the
crash is swallowed, never surfaced). 5/5 wiring tests pass; `ruff` clean.

## Chain status

`model_load_failure` (#1207, #1210) + `shutdown_traceback` (#1211) + this
`tool_parse`. Remaining §3.3 site: `oom`.