### PR TITLE
fix(mtp): resolve MTP eligibility for local model directories

### DIFF
--- a/tests/test_mtp_cli_wiring.py
+++ b/tests/test_mtp_cli_wiring.py
@@ -2922,3 +2922,31 @@ def test_install_mtp_vendored_uid_reuse_clears_stale_state(monkeypatch):
         f"(got {tokens!r}, expected [2000]). This suggests the "
         "wrapper resumed the OLD generator's queue / iteration state."
     )
+
+
+def test_gather_kv_cache_dtype_inputs_reads_local_dir_config(tmp_path):
+    """MTP eligibility must work for a LOCAL model directory served by path.
+
+    Regression for the eligibility gate: ``_gather_kv_cache_dtype_inputs`` only
+    resolved HF repo ids via ``try_to_load_from_cache``, so a local
+    ``mlx_lm``-converted build (e.g. a freshly quantized ``-rapid`` model) came
+    back with ``hf_cfg=None`` and MTP ``--speculative-config`` was rejected with
+    "does not qualify". Fails on ``main`` (returns ``None``); passes once the
+    local directory's ``config.json`` is read directly.
+    """
+    import json as _json
+
+    from vllm_mlx.cli import _gather_kv_cache_dtype_inputs
+    from vllm_mlx.spec_decode.mtp import MTPEligibility, detect_mtp_eligibility
+
+    (tmp_path / "config.json").write_text(
+        _json.dumps(
+            {"model_type": "qwen3_5_moe", "text_config": {"mtp_num_hidden_layers": 1}}
+        )
+    )
+
+    hf_cfg, _alias_meta = _gather_kv_cache_dtype_inputs(str(tmp_path))
+    assert hf_cfg is not None, "local model dir config.json should be read directly"
+    assert hf_cfg["text_config"]["mtp_num_hidden_layers"] == 1
+    # And the resolved config must clear the MTP eligibility gate.
+    assert detect_mtp_eligibility(hf_cfg) is not MTPEligibility.NONE

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -1103,7 +1103,16 @@ def _gather_kv_cache_dtype_inputs(model_name: str) -> tuple[dict | None, dict | 
         from huggingface_hub import try_to_load_from_cache as _cache_lookup
 
         hf_path = (alias_meta or {}).get("hf_path") or model_name
-        if hf_path:
+        # Local model directory (e.g. a freshly ``mlx_lm convert``-ed
+        # ``-rapid`` build served by path): read its ``config.json``
+        # directly. ``try_to_load_from_cache`` only resolves HF repo ids,
+        # so without this a local path yields ``hf_cfg=None`` and the MTP
+        # eligibility gate wrongly rejects an otherwise-eligible checkpoint.
+        _local_cfg = _os.path.join(model_name, "config.json") if model_name else None
+        if _local_cfg and _os.path.isfile(_local_cfg):
+            with open(_local_cfg) as fh:
+                hf_cfg = _json.load(fh)
+        elif hf_path:
             cached = _cache_lookup(repo_id=hf_path, filename="config.json")
             if cached and _os.path.exists(cached):
                 with open(cached) as fh:


### PR DESCRIPTION
## Why
`--speculative-config '{"method":"mtp"}'` on a **local model directory** (e.g. a freshly `mlx_lm`-converted build served by path) failed the eligibility gate with `error: ... does not qualify`, even for a checkpoint that declares `mtp_num_hidden_layers`.

## What
The gate reads `config.json` via `_gather_kv_cache_dtype_inputs`, which only resolved HF repo ids (`try_to_load_from_cache`). For a local directory `hf_cfg` came back `None` → rejection. Now reads `<model_dir>/config.json` directly when the model name is an existing local directory, before falling back to the HF-cache lookup.

## Tests
- `tests/test_mtp_cli_wiring.py` green (60 passed); full MTP suite green.
- Verified: local `-rapid` model dir now passes eligibility and serves with MTP.

## Notes
One-line-ish, self-contained. `cli.py` only.

🤖 Prepared with AI assistance (Claude Code); reviewed by the author.