### PR TITLE
feat(telemetry): request-event plumbing — caller_agent + sampling gate

### DIFF
--- a/tests/test_telemetry_emit.py
+++ b/tests/test_telemetry_emit.py
@@ -35,11 +35,17 @@ def fake_home(tmp_path, monkeypatch):
 
 
 @pytest.fixture
-def opted_in(fake_home):
-    """Persist a yes-consent so is_enabled() returns True."""
+def opted_in(fake_home, monkeypatch):
+    """Persist a yes-consent so is_enabled() returns True.
+
+    Also pins request sampling to 1.0 so payload-shape assertions on
+    ``emit.request`` are deterministic — the probabilistic sampling gate is
+    exercised separately in ``test_request_sampling_gate``.
+    """
     from vllm_mlx.telemetry.state import record_consent
 
     record_consent(True, rapid_mlx_version="0.0.0+test")
+    monkeypatch.setenv("RAPID_MLX_TELEMETRY_REQUEST_SAMPLE", "1")
     return fake_home
 
 
@@ -775,3 +781,70 @@ def test_error_fingerprint_does_not_echo_exception_message(opted_in, stub_queue)
     blob = repr(stub_queue[0])
     assert prompt_in_exc not in blob
     assert "parser failed" not in blob
+
+
+def _emit_one_request(caller_agent=None):
+    from vllm_mlx.telemetry import emit
+
+    emit.request(
+        endpoint="/v1/chat/completions",
+        model_alias="org/model",
+        stream=False,
+        tool_call_used=False,
+        prompt_tokens=10,
+        completion_tokens=20,
+        ttft_ms=120.0,
+        tps=42.0,
+        status=200,
+        caller_agent=caller_agent,
+    )
+
+
+def test_request_caller_agent_bucketed_never_raw(opted_in, stub_queue):
+    """The inbound UA is bucketed to the allowlist; the raw string (with its
+    version + any custom tokens) never reaches the payload."""
+    _emit_one_request(caller_agent="Claude-Code/1.4.2 (buildX; secret-token=abc)")
+    assert len(stub_queue) == 1
+    req = stub_queue[0]["request"]
+    assert req["caller_agent"] == "claude-code"
+    blob = repr(stub_queue[0])
+    for raw in ("1.4.2", "buildX", "secret-token", "abc"):
+        assert raw not in blob
+
+
+def test_request_caller_agent_defaults_to_unknown(opted_in, stub_queue):
+    """Omitted / missing UA → ``unknown`` (not an empty or raw value)."""
+    _emit_one_request(caller_agent=None)
+    assert stub_queue[0]["request"]["caller_agent"] == "unknown"
+
+
+def test_request_sampling_gate(opted_in, stub_queue, monkeypatch):
+    """The sample rate gates emission AFTER the consent check. rate=0 drops
+    everything; a mid rate follows ``random.random()``."""
+    from vllm_mlx.telemetry import emit
+
+    # rate 0 → never emit (even though consent is on).
+    monkeypatch.setenv("RAPID_MLX_TELEMETRY_REQUEST_SAMPLE", "0")
+    _emit_one_request()
+    assert stub_queue == []
+
+    # rate 0.5: draw below the rate emits, at/above skips.
+    monkeypatch.setenv("RAPID_MLX_TELEMETRY_REQUEST_SAMPLE", "0.5")
+    monkeypatch.setattr(emit.random, "random", lambda: 0.4)
+    _emit_one_request()
+    assert len(stub_queue) == 1
+    monkeypatch.setattr(emit.random, "random", lambda: 0.9)
+    _emit_one_request()
+    assert len(stub_queue) == 1  # skipped, still one
+
+    # A garbage rate falls back to the default (not a crash, not disabled).
+    monkeypatch.setenv("RAPID_MLX_TELEMETRY_REQUEST_SAMPLE", "not-a-number")
+    assert 0.0 <= emit._request_sample_rate() <= 1.0
+
+
+def test_request_sampling_never_overrides_consent(fake_home, stub_queue, monkeypatch):
+    """Sampling is a second gate, not a bypass: a disabled client emits
+    nothing even at rate 1.0."""
+    monkeypatch.setenv("RAPID_MLX_TELEMETRY_REQUEST_SAMPLE", "1")
+    _emit_one_request()  # consent never granted in this fixture
+    assert stub_queue == []

--- a/tests/test_telemetry_redact.py
+++ b/tests/test_telemetry_redact.py
@@ -17,6 +17,7 @@ from vllm_mlx.telemetry.redact import (
     bucket_ttft_ms,
     fingerprint_traceback,
     hash_flag_names,
+    normalize_caller_agent,
     normalize_model_path,
     platform_info,
 )
@@ -319,3 +320,51 @@ def test_platform_info_no_unbounded_strings():
     for key in ("os", "os_version", "arch", "chip", "python_version"):
         assert isinstance(info[key], str)
         assert len(info[key]) < 200, f"{key} suspiciously long: {info[key]!r}"
+
+
+# --------------------------------------------------------- caller agent
+
+
+@pytest.mark.parametrize(
+    "ua,expected",
+    [
+        ("claude-cli/1.4.2", "claude-code"),
+        ("Claude-Code/2.0 (macOS)", "claude-code"),
+        ("cursor/0.42.1", "cursor"),
+        ("aider/0.50.0", "aider"),
+        ("OpenAI/Python 1.30.1", "openai-python"),
+        ("openai-python/1.30", "openai-python"),
+        ("anthropic-sdk-python/0.34", "anthropic-sdk"),
+        ("litellm/1.40", "litellm"),
+        ("python-httpx/0.27.0", "python-httpx"),
+        ("python-requests/2.32", "python-requests"),
+        ("node-fetch/2.6", "node-fetch"),
+        ("curl/8.4.0", "curl"),
+    ],
+)
+def test_normalize_caller_agent_buckets_known(ua, expected):
+    assert normalize_caller_agent(ua) == expected
+
+
+def test_normalize_caller_agent_named_agent_beats_generic_client():
+    """An agent that rides a generic HTTP client still resolves to the
+    agent, not the transport."""
+    assert normalize_caller_agent("aider python-httpx/0.27") == "aider"
+
+
+@pytest.mark.parametrize("ua", [None, "", 123, "   "])
+def test_normalize_caller_agent_missing_is_unknown(ua):
+    # whitespace-only still matches no marker -> "other"; empty/None -> "unknown"
+    result = normalize_caller_agent(ua)
+    assert result in ("unknown", "other")
+    if ua in (None, ""):
+        assert result == "unknown"
+
+
+def test_normalize_caller_agent_unmatched_is_other_never_raw():
+    ua = "SomeCustomBot/9.9 (token=leak-me)"
+    out = normalize_caller_agent(ua)
+    assert out == "other"
+    # The raw UA (with its embedded token) must never be the return value.
+    assert "leak-me" not in out
+    assert "9.9" not in out

--- a/vllm_mlx/telemetry/emit.py
+++ b/vllm_mlx/telemetry/emit.py
@@ -26,6 +26,8 @@ helpers own the four things every call site needs to get right:
 from __future__ import annotations
 
 import itertools
+import os
+import random
 import threading
 from collections.abc import Iterable
 from datetime import datetime, timezone
@@ -39,11 +41,45 @@ from vllm_mlx.telemetry.redact import (
     bucket_tps,
     bucket_ttft_ms,
     fingerprint_traceback,
+    normalize_caller_agent,
     normalize_model_path,
     platform_info,
 )
 from vllm_mlx.telemetry.schema import SCHEMA_VERSION
 from vllm_mlx.telemetry.state import get_or_create_client_id, is_enabled
+
+# ``request`` events are per-API-call — orders of magnitude higher volume
+# than the once-per-process session events (one automated eval client can
+# emit ~1M/day). This gate samples them so turning the call sites on does
+# not flood R2. Rate is read from ``RAPID_MLX_TELEMETRY_REQUEST_SAMPLE``
+# (0.0–1.0) each call so ops can retune live; the default is conservative.
+# Session / error events are NOT sampled — they are already low-volume and
+# load-bearing for DAU / triage.
+_REQUEST_SAMPLE_ENV = "RAPID_MLX_TELEMETRY_REQUEST_SAMPLE"
+_REQUEST_SAMPLE_DEFAULT = 0.1
+
+
+def _request_sample_rate() -> float:
+    raw = os.environ.get(_REQUEST_SAMPLE_ENV)
+    if raw is None or raw == "":
+        return _REQUEST_SAMPLE_DEFAULT
+    try:
+        rate = float(raw)
+    except (TypeError, ValueError):
+        return _REQUEST_SAMPLE_DEFAULT
+    # Clamp — a bad env value should degrade to a sane bound, not disable
+    # or over-emit unexpectedly.
+    return max(0.0, min(1.0, rate))
+
+
+def _should_sample_request() -> bool:
+    rate = _request_sample_rate()
+    if rate >= 1.0:
+        return True
+    if rate <= 0.0:
+        return False
+    return random.random() < rate
+
 
 # ---------------------------------------------------------------- singleton
 
@@ -439,13 +475,19 @@ def request(
     ttft_ms: float,
     tps: float,
     status: int,
+    caller_agent: str | None = None,
 ) -> None:
-    """Emit a ``request`` payload (Phase 2.2 sites use this).
+    """Emit a ``request`` payload (call sites land in a follow-up PR).
 
-    Defined now so call sites can land without touching this module
-    later. The Phase 2.0/2.1 PR does not call this — it ships dark.
+    ``caller_agent`` is the inbound HTTP ``User-Agent``; it is bucketed to a
+    fixed allowlist here (never stored raw). Sampled by
+    ``RAPID_MLX_TELEMETRY_REQUEST_SAMPLE`` because request volume dwarfs the
+    session events. Consent is still checked first — sampling never turns a
+    disabled client on.
     """
     if not is_enabled():
+        return
+    if not _should_sample_request():
         return
     payload = _envelope("request")
     payload["request"] = {
@@ -458,6 +500,7 @@ def request(
         "ttft_ms_bucket": bucket_ttft_ms(ttft_ms),
         "tps_bucket": bucket_tps(tps),
         "status": int(status),
+        "caller_agent": normalize_caller_agent(caller_agent),
     }
     get_queue().enqueue(payload)
 

--- a/vllm_mlx/telemetry/redact.py
+++ b/vllm_mlx/telemetry/redact.py
@@ -132,6 +132,65 @@ def normalize_model_path(path: str) -> str:
     return path
 
 
+# ------------------------------------------------------------- caller agent
+
+# Map an inbound HTTP ``User-Agent`` to a SMALL fixed allowlist of caller
+# buckets. This is the ``[NIT] no caller-controlled free-form text`` red-line
+# in action: the raw UA carries versions and sometimes custom tokens, so we
+# NEVER return it — we return one of the labels below (or ``"other"`` /
+# ``"unknown"``). Matching is substring-on-lowercase because SDKs vary the
+# surrounding version/format (``OpenAI/Python 1.2``, ``openai-python/1.2``).
+# Order matters: more specific agent markers are checked before the generic
+# HTTP-client fallbacks so e.g. an agent that rides ``python-httpx`` still
+# resolves to the agent, not ``python-httpx``.
+_CALLER_AGENT_MARKERS: tuple[tuple[str, str], ...] = (
+    ("claude-code", "claude-code"),
+    ("claudecode", "claude-code"),
+    ("claude-cli", "claude-code"),
+    ("cursor", "cursor"),
+    ("aider", "aider"),
+    ("cline", "cline"),
+    ("continue", "continue"),
+    ("openai-python", "openai-python"),
+    ("openai/python", "openai-python"),
+    ("openai-node", "openai-node"),
+    ("anthropic", "anthropic-sdk"),
+    ("litellm", "litellm"),
+    ("langchain", "langchain"),
+    ("llama-index", "llamaindex"),
+    ("llamaindex", "llamaindex"),
+    ("ollama", "ollama"),
+    # Generic HTTP clients — last, so a named agent above wins.
+    ("python-httpx", "python-httpx"),
+    ("httpx", "python-httpx"),
+    ("python-requests", "python-requests"),
+    ("requests", "python-requests"),
+    ("node-fetch", "node-fetch"),
+    ("undici", "node-fetch"),
+    ("axios", "axios"),
+    ("curl", "curl"),
+    ("wget", "curl"),
+    ("okhttp", "okhttp"),
+    ("go-http-client", "go-http"),
+)
+
+
+def normalize_caller_agent(user_agent: str | None) -> str:
+    """Bucket an inbound ``User-Agent`` to a fixed allowlist label.
+
+    Returns ``"unknown"`` for a missing/empty UA and ``"other"`` for a UA
+    that matches no marker. The raw string is never returned, so no
+    caller-controlled free-form text lands on a payload.
+    """
+    if not user_agent or not isinstance(user_agent, str):
+        return "unknown"
+    ua = user_agent.lower()
+    for marker, label in _CALLER_AGENT_MARKERS:
+        if marker in ua:
+            return label
+    return "other"
+
+
 # ---------------------------------------------------------------- argv flags
 
 # Captures ``--flag``, ``--flag-name``, and short ``-x`` (single letter

--- a/vllm_mlx/telemetry/schema.py
+++ b/vllm_mlx/telemetry/schema.py
@@ -67,6 +67,12 @@ class RequestPayload:
     ttft_ms_bucket: str
     tps_bucket: str
     status: int
+    # v2 addition. Inbound HTTP User-Agent bucketed to a fixed allowlist
+    # (redact.normalize_caller_agent) — "which agent is calling", never the
+    # raw UA. Optional (default "unknown") so v1 external callers that build
+    # RequestPayload positionally don't shift/break. request events ship
+    # dark until the call sites land, so this widens no live wire contract.
+    caller_agent: str = "unknown"
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
## Why

The v2 goal for the ⚙️ engine is per-request attribution + usage data:
**who is calling** (Claude Code / Cursor / openai-python …) and what
model/perf they run. That rides `request` events, which are defined but
ship **dark**. Before wiring the (hot-path) call sites, land the
telemetry-module plumbing so the wiring PR is a minimal diff — and so the
two things request events NEED to get right (a privacy-safe caller field +
a volume gate) are reviewed in isolation.

## What

- **`redact.normalize_caller_agent(ua)`** — buckets an inbound HTTP
  `User-Agent` to a fixed allowlist (`claude-code`/`cursor`/`aider`/
  `openai-python`/…; unmatched → `other`; missing → `unknown`). The raw UA
  (versions, custom tokens) is **never** returned — same red-line as
  `endpoint`/`category`/`phase`.
- **`RequestPayload.caller_agent: str = "unknown"`** — optional + appended
  so v1 positional constructors don't shift. Request events are dark, so no
  live wire contract widens.
- **Sampling gate in `emit.request`** — `RAPID_MLX_TELEMETRY_REQUEST_SAMPLE`
  (0.0–1.0, default 0.1) gates emission **after** the consent check. Request
  volume dwarfs the once-per-process session events (one automated eval
  client can emit ~1M/day). `session`/`error` events are **not** sampled.

No call site emits `request` yet — this changes no runtime behavior; it's
pure plumbing + tests.

## Test

`normalize_caller_agent` bucketing (incl. named-agent-beats-generic-client
and raw-UA-never-returned); payload `caller_agent` default + the sampling
gate (rate 0 drops; mid-rate follows a seeded `random`); sampling never
overrides consent. The `opted_in` fixture pins rate=1.0 so payload-shape
tests stay deterministic. **201 telemetry tests pass**; `ruff` clean.

## Next

Follow-up PR wires `emit.request(...)` at the non-streaming chat completion
site (reads `raw_request` UA → `caller_agent`, perf from the response
metrics). Streaming path after that.