### PR TITLE
feat(pr_validate): advisory diff-coverage step — measure-only, no gate (D1)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -264,6 +264,13 @@ test = [
     # numeric/validation invariants over the whole input space (e.g. the
     # #1208-class quantized-KV round-trip bounds) that example tests can't.
     "hypothesis>=6.100.0",
+    # Powers pr_validate's ADVISORY diff_coverage step (measure-only, never
+    # gates). pytest-cov instruments the unit suite; diff-cover scopes the
+    # coverage.xml to the PR's changed lines → patch-coverage %. Declared in
+    # the extras so pr_validate can rebuild a venv that runs the advisory
+    # measurement. See scripts/pr_validate/steps/diff_coverage.py.
+    "pytest-cov>=4.0.0",
+    "diff-cover>=8.0.0",
 ]
 dev = [
     # Test runtime (must mirror the `test` extras above; a unit test in
@@ -282,6 +289,10 @@ dev = [
     # Mirror of the [test] entry — keep `dev` a strict superset of `test`
     # (enforced by tests/test_pr_validate_test_env.py).
     "hypothesis>=6.100.0",
+    # Mirror of the [test] entries (dev ⊇ test). Powers the advisory
+    # diff_coverage step — see scripts/pr_validate/steps/diff_coverage.py.
+    "pytest-cov>=4.0.0",
+    "diff-cover>=8.0.0",
     # Linters / typer — NOT in the `test` extras because pr_validate
     # only needs to *run* the tests; lint is its own pipeline step
     # (ruff) and runs from the host environment.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -269,8 +269,12 @@ test = [
     # coverage.xml to the PR's changed lines → patch-coverage %. Declared in
     # the extras so pr_validate can rebuild a venv that runs the advisory
     # measurement. See scripts/pr_validate/steps/diff_coverage.py.
+    # diff-cover is major-pinned: _parse_diff_cover() reads its human-readable
+    # footer, so a new major could silently stop baseline collection — bump the
+    # ceiling deliberately, re-validating the parser, when moving to 9.x (codex
+    # #1220 r15).
     "pytest-cov>=4.0.0",
-    "diff-cover>=8.0.0",
+    "diff-cover>=8.0.0,<9.0.0",
 ]
 dev = [
     # Test runtime (must mirror the `test` extras above; a unit test in
@@ -291,8 +295,9 @@ dev = [
     "hypothesis>=6.100.0",
     # Mirror of the [test] entries (dev ⊇ test). Powers the advisory
     # diff_coverage step — see scripts/pr_validate/steps/diff_coverage.py.
+    # diff-cover major-pinned (parser couples to its footer) — see [test] note.
     "pytest-cov>=4.0.0",
-    "diff-cover>=8.0.0",
+    "diff-cover>=8.0.0,<9.0.0",
     # Linters / typer — NOT in the `test` extras because pr_validate
     # only needs to *run* the tests; lint is its own pipeline step
     # (ruff) and runs from the host environment.

--- a/scripts/pr_validate/runner.py
+++ b/scripts/pr_validate/runner.py
@@ -20,6 +20,7 @@ from .context import Context
 from .scorecard import render_scorecard, verdict
 from .steps.cl_description_quality import CLDescriptionQualityStep
 from .steps.codex_review import CodexReviewStep
+from .steps.diff_coverage import DiffCoverageStep
 from .steps.fetch import FetchStep
 from .steps.full_unit import FullUnitStep
 from .steps.lint import LintStep
@@ -68,6 +69,14 @@ STEPS: list[Step] = [
     TargetedTestsStep(),  # 3 — diff-aware test selection + neg control
     FullUnitStep(),  # 4 — full pytest, gated on blast radius
     StressE2EBenchStep(),  # 5 — stress + e2e + bench (multi-model × agents)
+    # 6 — ADVISORY patch-coverage measurement (never gates). Last on
+    # purpose: it re-runs the unit suite under coverage instrumentation
+    # (~40 s), so in fail-fast mode we skip that cost the moment any
+    # real gate above has already blocked the PR. It also physically
+    # cannot change the verdict — every path returns pass/skip — but
+    # position still saves compute. See steps/diff_coverage.py for the
+    # "measure-first, no threshold" rationale (dev-flow gate proposal).
+    DiffCoverageStep(),
 ]
 
 # Steps that, if they fail, stop the pipeline immediately regardless of

--- a/scripts/pr_validate/runner.py
+++ b/scripts/pr_validate/runner.py
@@ -70,10 +70,11 @@ STEPS: list[Step] = [
     FullUnitStep(),  # 4 — full pytest, gated on blast radius
     StressE2EBenchStep(),  # 5 — stress + e2e + bench (multi-model × agents)
     # 6 — ADVISORY patch-coverage measurement (never gates). Last on
-    # purpose: it re-runs the unit suite under coverage instrumentation
-    # (~40 s), so in fail-fast mode we skip that cost the moment any
-    # real gate above has already blocked the PR. It also physically
-    # cannot change the verdict — every path returns pass/skip — but
+    # purpose: it re-runs the FULL unit suite under coverage instrumentation
+    # (~3 min, same order as full_unit's ~2:45 — see diff_coverage.py), so in
+    # fail-fast mode we skip that cost the moment any real gate above has
+    # already blocked the PR. It also physically cannot change the verdict —
+    # every path returns pass/skip — but
     # position still saves compute. See steps/diff_coverage.py for the
     # "measure-first, no threshold" rationale (dev-flow gate proposal).
     DiffCoverageStep(),

--- a/scripts/pr_validate/steps/diff_coverage.py
+++ b/scripts/pr_validate/steps/diff_coverage.py
@@ -91,16 +91,27 @@ _LOG_TAIL_CHARS = 4000
 # #1220 r8).
 _STDOUT_CAP_BYTES = 1_048_576
 
-# Disk quota: the largest file the child — or anything in its session — may
-# create, enforced by the KERNEL via ``RLIMIT_FSIZE`` (set by an exec-based
-# wrapper, ``_rlimit_wrap``). The output goes to disk (not RAM), but disk is finite on
-# an auto-deploy host, so a runaway / hung test that streams without bound
-# must not exhaust it (codex #1220 r10). A kernel limit closes the gap a
-# userspace size-poll leaves — a child that dumps gigabytes and exits BETWEEN
-# polls, or in the very first sub-poll window, can't overshoot because the
-# write past the limit is refused (EFBIG) / SIGXFSZ-killed at the syscall,
-# regardless of timing, and the cap is INHERITED so even a descendant that
-# ``setsid()``s out of the group still can't exhaust disk (codex #1220 r11).
+# Per-file disk cap: the largest size any SINGLE file the child writes may
+# reach, enforced by the KERNEL via ``RLIMIT_FSIZE`` (set by an exec-based
+# wrapper, ``_rlimit_wrap``). Its specific job is to bound the two capture
+# streams — we redirect the child's stdout/stderr to temp FILES (not RAM), and
+# a runaway / hung test that streams without bound would otherwise fill the
+# auto-deploy host's disk through them (codex #1220 r10). A kernel per-file cap
+# closes the gap a userspace size-poll leaves: a child that dumps gigabytes and
+# exits BETWEEN polls, or in the first sub-poll window, can't overshoot because
+# the write past the cap is refused (EFBIG) / SIGXFSZ-killed at the syscall,
+# regardless of timing (codex #1220 r11).
+#
+# SCOPE (deliberately not overclaimed — codex #1220 r13): this bounds each file
+# INDIVIDUALLY, which fully contains the streaming vector above. It is NOT an
+# aggregate-bytes quota — a suite could in principle create many sub-cap files,
+# and a descendant that ``setsid()``s out of the group escapes the group-kill
+# below. Both are out of scope for an ADVISORY step that runs the repo's OWN
+# test suite (not untrusted code): portable aggregate/tree containment needs
+# cgroups / job-objects unavailable on macOS, and the merge-GATING sibling
+# steps (``full_unit``/``targeted_tests``) run the same suite with NO cap,
+# timeout, or group-kill at all — this step is already strictly more contained.
+#
 # 256 MiB is orders of magnitude above any real ``-q`` suite / diff-cover run
 # or coverage artifact, so it only ever trips on genuinely pathological output.
 _OUTPUT_QUOTA_BYTES = 256 * 1024 * 1024
@@ -389,14 +400,16 @@ def _run_group_bounded(
     surviving descendant to hold open, it removes the reap-wedge class
     entirely. The tail keeps the bytes every caller needs — diff-cover's
     footer and pytest's ``-q`` failure summary both sit at the END of their
-    streams. Disk is bounded too, but by the KERNEL not a userspace poll: the
-    child is spawned under an ``RLIMIT_FSIZE`` of ``_OUTPUT_QUOTA_BYTES``, so a
-    write past the cap is refused at the syscall the instant it happens — no
-    matter how fast the child writes or whether it exits between two userspace
-    polls, and even if a descendant ``setsid()``s out of the group (the limit
-    is inherited). A child killed by ``SIGXFSZ`` (or exiting nonzero on
-    ``EFBIG``) then fails the exit-code gate and the run is skipped (codex
-    #1220 r11). The limit is applied by a tiny exec-based WRAPPER (see
+    streams. The two capture files are bounded by the KERNEL, not a userspace
+    poll: the child is spawned under a per-file ``RLIMIT_FSIZE`` of
+    ``_OUTPUT_QUOTA_BYTES``, so a write past the cap is refused at the syscall
+    the instant it happens — no matter how fast the child writes or whether it
+    exits between two userspace polls. A child killed by ``SIGXFSZ`` (or
+    exiting nonzero on ``EFBIG``) then fails the exit-code gate and the run is
+    skipped (codex #1220 r11). The cap is PER-FILE and does not attempt
+    aggregate-bytes or full-descendant-tree containment — see the scope note on
+    ``_OUTPUT_QUOTA_BYTES`` for why that is out of scope for this advisory step
+    (codex #1220 r13). The limit is applied by a tiny exec-based WRAPPER (see
     ``_rlimit_wrap``) rather than a ``preexec_fn`` callback: ``preexec_fn``
     runs between fork and exec in a copy of the (possibly multi-threaded)
     parent's address space, where grabbing an internal lock another thread

--- a/scripts/pr_validate/steps/diff_coverage.py
+++ b/scripts/pr_validate/steps/diff_coverage.py
@@ -92,8 +92,8 @@ _LOG_TAIL_CHARS = 4000
 _STDOUT_CAP_BYTES = 1_048_576
 
 # Disk quota: the largest file the child — or anything in its session — may
-# create, enforced by the KERNEL via ``RLIMIT_FSIZE`` (set in a preexec_fn on
-# the child). The output goes to disk (not RAM), but disk is still finite on
+# create, enforced by the KERNEL via ``RLIMIT_FSIZE`` (set by an exec-based
+# wrapper, ``_rlimit_wrap``). The output goes to disk (not RAM), but disk is finite on
 # an auto-deploy host, so a runaway / hung test that streams without bound
 # must not exhaust it (codex #1220 r10). A kernel limit closes the gap a
 # userspace size-poll leaves — a child that dumps gigabytes and exits BETWEEN
@@ -169,6 +169,17 @@ class DiffCoverageStep(Step):
         # instead of publishing yesterday's numbers.
         xml_path.unlink(missing_ok=True)
 
+        # coverage.py writes its data file to ``$COVERAGE_FILE`` or, unset,
+        # ``.coverage`` in the CWD — which here is the repo root. Point it at a
+        # dedicated artifact path so an advisory run can NEVER erase/overwrite a
+        # developer's own ``.coverage`` database sitting at the repo root (codex
+        # #1220 r12). The XML report is still emitted to ``xml_path``; only the
+        # intermediate data file moves.
+        cov_env = {
+            **os.environ,
+            "COVERAGE_FILE": str(ctx.artifact_path("coverage.data")),
+        }
+
         # 2. Instrumented suite — mirrors ``full_unit``'s selection so the
         #    coverage picture matches what we actually gate on.
         pytest_cmd = [
@@ -190,7 +201,7 @@ class DiffCoverageStep(Step):
         ctx.run_log("diff_coverage: running instrumented suite (advisory)…")
         try:
             pytest_proc = _run_group_bounded(
-                pytest_cmd, str(ctx.repo_root), _PYTEST_TIMEOUT_S
+                pytest_cmd, str(ctx.repo_root), _PYTEST_TIMEOUT_S, env=cov_env
             )
         except subprocess.TimeoutExpired as exc:
             _safe_write(log_path, _timeout_dump("instrumented pytest", pytest_cmd, exc))
@@ -360,7 +371,7 @@ class DiffCoverageStep(Step):
 
 
 def _run_group_bounded(
-    cmd: list[str], cwd: str, timeout: int
+    cmd: list[str], cwd: str, timeout: int, env: dict[str, str] | None = None
 ) -> subprocess.CompletedProcess[str]:
     """Run ``cmd`` in its OWN process group with a hard timeout.
 
@@ -379,13 +390,21 @@ def _run_group_bounded(
     entirely. The tail keeps the bytes every caller needs — diff-cover's
     footer and pytest's ``-q`` failure summary both sit at the END of their
     streams. Disk is bounded too, but by the KERNEL not a userspace poll: the
-    child is spawned under an ``RLIMIT_FSIZE`` of ``_OUTPUT_QUOTA_BYTES`` (see
-    ``_limit_child_fsize``), so a write past the cap is refused at the
-    syscall the instant it happens — no matter how fast the child writes or
-    whether it exits between two userspace polls, and even if a descendant
-    ``setsid()``s out of the group (the limit is inherited). A child killed
-    by ``SIGXFSZ`` (or exiting nonzero on ``EFBIG``) then fails the
-    exit-code gate and the run is skipped (codex #1220 r11).
+    child is spawned under an ``RLIMIT_FSIZE`` of ``_OUTPUT_QUOTA_BYTES``, so a
+    write past the cap is refused at the syscall the instant it happens — no
+    matter how fast the child writes or whether it exits between two userspace
+    polls, and even if a descendant ``setsid()``s out of the group (the limit
+    is inherited). A child killed by ``SIGXFSZ`` (or exiting nonzero on
+    ``EFBIG``) then fails the exit-code gate and the run is skipped (codex
+    #1220 r11). The limit is applied by a tiny exec-based WRAPPER (see
+    ``_rlimit_wrap``) rather than a ``preexec_fn`` callback: ``preexec_fn``
+    runs between fork and exec in a copy of the (possibly multi-threaded)
+    parent's address space, where grabbing an internal lock another thread
+    held at fork can deadlock the child forever — before ``Popen`` even
+    returns, so the timeout above could never fire and the pipeline would
+    wedge. The wrapper instead sets the limit from a FRESH, single-threaded
+    process (post-exec) and then ``exec``s the real command, sidestepping
+    that class entirely (codex #1220 r12).
 
     On timeout the raised ``TimeoutExpired`` carries the captured (capped)
     stdout/stderr so the caller can log WHAT hung before the temp files are
@@ -403,12 +422,12 @@ def _run_group_bounded(
     # un-killed (codex #1220).
     with tempfile.TemporaryFile() as out_f, tempfile.TemporaryFile() as err_f:
         proc = subprocess.Popen(  # noqa: S603 — fixed argv, no shell
-            cmd,
+            [*_rlimit_wrap(), *cmd],
             stdout=out_f,
             stderr=err_f,
             cwd=cwd,
+            env=env,
             start_new_session=True,
-            preexec_fn=_limit_child_fsize,  # noqa: PLC2801 — kernel disk cap
         )
         pgid = proc.pid  # == PGID under start_new_session (setsid)
         try:
@@ -438,23 +457,27 @@ def _run_group_bounded(
         )
 
 
-def _limit_child_fsize() -> None:  # pragma: no cover — runs post-fork in child
-    """preexec_fn: cap the max file size the child (and everything in its new
-    session) may create, at the KERNEL, via ``RLIMIT_FSIZE``. A write past the
-    cap is refused at the write(2) syscall — ``SIGXFSZ`` (default-fatal) or
-    ``EFBIG`` — so the child cannot exhaust the auto-deploy host's disk no
-    matter how fast it writes, whether it exits between userspace polls, or
-    whether a descendant ``setsid()``s out of the process group (the limit is
-    inherited across fork). This is the kernel backstop that lets the waiter
-    stay a plain bounded ``wait`` instead of a size-polling loop (codex #1220
-    r11). Runs in the forked child before ``exec``; keep it minimal and
-    async-signal-safe. ``resource`` is imported here (Unix-only, child side)
-    so the module stays importable even where ``resource`` is absent."""
-    import resource
+# Wrapper source: a fresh Python process that sets ``RLIMIT_FSIZE`` on ITSELF
+# then ``exec``s the real command (argv after the byte count). rlimits survive
+# ``execve`` and are inherited across ``fork``, so the real command and every
+# descendant it spawns run under the cap. Setting the limit here — post-exec,
+# in a brand-new single-threaded process — avoids the ``preexec_fn`` fork/exec
+# deadlock window entirely (codex #1220 r12). ``os.execvp`` uses an absolute
+# ``argv[0]`` (our commands start with ``sys.executable``) directly.
+_RLIMIT_WRAP_SRC = (
+    "import os,resource,sys;"
+    "n=int(sys.argv[1]);"
+    "resource.setrlimit(resource.RLIMIT_FSIZE,(n,n));"
+    "os.execvp(sys.argv[2],sys.argv[2:])"
+)
 
-    resource.setrlimit(
-        resource.RLIMIT_FSIZE, (_OUTPUT_QUOTA_BYTES, _OUTPUT_QUOTA_BYTES)
-    )
+
+def _rlimit_wrap() -> list[str]:
+    """Argv prefix that caps the wrapped command's max file size at
+    ``_OUTPUT_QUOTA_BYTES`` (the KERNEL disk backstop; see ``_run_group_bounded``).
+    Built per-call so a test monkeypatching ``_OUTPUT_QUOTA_BYTES`` takes
+    effect. Unix-only, like the rest of this helper (``setsid``/``killpg``)."""
+    return [sys.executable, "-c", _RLIMIT_WRAP_SRC, str(_OUTPUT_QUOTA_BYTES)]
 
 
 def _sweep_group(pgid: int) -> None:

--- a/scripts/pr_validate/steps/diff_coverage.py
+++ b/scripts/pr_validate/steps/diff_coverage.py
@@ -42,6 +42,7 @@ import re
 import signal
 import subprocess
 import sys
+import tempfile
 import traceback
 from pathlib import Path
 
@@ -82,6 +83,13 @@ _REAP_TIMEOUT_S = 10
 # Keep the diagnostic log readable — we tail (not head) subprocess output so
 # the most recent lines (pytest's failure summary) always survive truncation.
 _LOG_TAIL_CHARS = 4000
+
+# Cap on how much subprocess output we read back into memory from the temp
+# files (the tail). 1 MiB dwarfs diff-cover's footer and pytest's ``-q``
+# summary (both a few KB), so nothing real is ever lost, yet a runaway test
+# that streams gigabytes to disk still can't bloat the validator (codex
+# #1220 r8).
+_STDOUT_CAP_BYTES = 1_048_576
 
 
 class DiffCoverageStep(Step):
@@ -273,6 +281,19 @@ class DiffCoverageStep(Step):
                 "advisory coverage skipped (no measurable production lines in diff)",
                 log_path,
             )
+        if parsed is _PARSE_FAILED:
+            # diff-cover exited 0 but we recognized NEITHER its explicit
+            # no-lines message NOR a Total/Missing footer — most likely a
+            # diff-cover version whose output format drifted (the ``>=8.0.0``
+            # floor permits future majors). Surface this as a DISTINCT
+            # tooling-format skip rather than silently reporting "no lines",
+            # which would let the baseline quietly die (codex #1220 r8).
+            return self._skip(
+                "advisory coverage skipped (diff-cover output format "
+                "unrecognized — parser may need updating for this diff-cover "
+                "version)",
+                log_path,
+            )
 
         pct, covered, total = parsed
         caveat = (
@@ -299,7 +320,11 @@ class DiffCoverageStep(Step):
             status="pass",  # ALWAYS pass — advisory
             summary=summary,
             findings=[finding],
-            artifacts=[str(log_path), str(xml_path)],
+            # Advertise only artifacts that actually made it to disk —
+            # ``_safe_write`` may have swallowed a log write failure, and the
+            # existence probe itself must not raise (codex #1220 r8), mirroring
+            # the skip path's guard.
+            artifacts=[str(p) for p in (log_path, xml_path) if _path_exists(p)],
         )
 
     # ------------------------------------------------------------------
@@ -329,44 +354,46 @@ def _run_group_bounded(
     survives. Re-raises ``subprocess.TimeoutExpired`` so callers keep
     their existing skip-on-timeout handling.
 
-    We deliberately do NOT use ``with subprocess.Popen(...)``: its
-    ``__exit__`` reaps via an UNBOUNDED ``wait()``, which would re-open the
-    very wedge we close below. Cleanup is handled explicitly instead.
+    Output is redirected to temp FILES, not PIPEs (codex #1220 r8). This
+    bounds validator memory — a noisy / runaway test streams to disk, and
+    we read back only a capped tail — and, because there are no pipes for a
+    surviving descendant to hold open, it removes the reap-wedge class
+    entirely: the timeout path is a plain group-SIGKILL + bounded ``wait``.
+    The tail keeps the bytes every caller needs — diff-cover's footer and
+    pytest's ``-q`` failure summary both sit at the END of their streams.
     """
     # ``start_new_session=True`` runs the child through ``setsid()``: it
-    # leads a brand-new process group whose PGID EQUALS its PID. Capture
-    # that id NOW. We must never derive it via ``os.getpgid(proc.pid)`` on
-    # timeout instead: by then the group leader may have already exited
-    # while a surviving descendant keeps the captured pipes open (so
-    # ``communicate`` still blocks) — ``getpgid`` would raise
-    # ``ProcessLookupError``, the group would go un-killed, only the dead
-    # leader would be targeted, and the reap could wedge the whole pipeline
-    # (codex #1220).
-    proc: subprocess.Popen[str] = subprocess.Popen(  # noqa: S603 — fixed argv
-        cmd,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        text=True,
-        cwd=cwd,
-        start_new_session=True,
-    )
-    pgid = proc.pid  # == PGID under start_new_session (setsid)
-    try:
-        out, err = proc.communicate(timeout=timeout)
-        return subprocess.CompletedProcess(cmd, proc.returncode, out, err)
-    except BaseException:
-        # Timeout OR any other escape (e.g. KeyboardInterrupt): tear the
-        # whole group down so nothing is orphaned, then re-raise unchanged.
-        _kill_group_and_reap(proc, pgid)
-        raise
+    # leads a brand-new process group whose PGID EQUALS its PID. Capture that
+    # id NOW, not via ``os.getpgid(proc.pid)`` on timeout — by then the leader
+    # may already have exited and ``getpgid`` would raise, leaving the group
+    # un-killed (codex #1220).
+    with tempfile.TemporaryFile() as out_f, tempfile.TemporaryFile() as err_f:
+        proc = subprocess.Popen(  # noqa: S603 — fixed argv, no shell
+            cmd,
+            stdout=out_f,
+            stderr=err_f,
+            cwd=cwd,
+            start_new_session=True,
+        )
+        pgid = proc.pid  # == PGID under start_new_session (setsid)
+        try:
+            proc.wait(timeout=timeout)
+        except BaseException:
+            # Timeout OR any other escape (e.g. KeyboardInterrupt): tear the
+            # whole group down so nothing is orphaned, then re-raise unchanged.
+            _kill_group(proc, pgid)
+            raise
+        return subprocess.CompletedProcess(
+            cmd, proc.returncode, _read_capped(out_f), _read_capped(err_f)
+        )
 
 
-def _kill_group_and_reap(proc: subprocess.Popen[str], pgid: int) -> None:
+def _kill_group(proc: subprocess.Popen, pgid: int) -> None:
     """SIGKILL the whole process group, then reap the leader under a bounded
-    wait. Never blocks: the SIGKILL is already delivered, so if even the
-    bounded reap can't finish (a descendant wedged in an uninterruptible
-    syscall still holding the pipes), we abandon the pipes rather than hang
-    the auto-deploy pipeline."""
+    wait. With output on temp files (no inherited pipes) there is nothing for
+    a descendant to hold open, so a plain ``wait`` reaps the SIGKILLed leader
+    at once; the bound only guards the near-impossible wedged-leader case so
+    we never hang the auto-deploy pipeline."""
     try:
         os.killpg(pgid, signal.SIGKILL)
     except OSError:
@@ -376,26 +403,24 @@ def _kill_group_and_reap(proc: subprocess.Popen[str], pgid: int) -> None:
         except OSError:
             pass
     try:
-        proc.communicate(timeout=_REAP_TIMEOUT_S)
-        return
-    except subprocess.TimeoutExpired:
-        pass
-    # A descendant is wedged holding the inherited pipes, so ``communicate``
-    # (which reads to EOF before waiting) can't return. Abandon the pipes so
-    # we stop blocking on them — but the SIGKILLed direct child is now a
-    # zombie that ``communicate`` never got to reap, so still ``wait()`` for
-    # it under a bound. Without this the leader leaks as a zombie until the
-    # validator process exits (codex #1220 r5).
-    for stream in (proc.stdout, proc.stderr):
-        if stream is not None:
-            try:
-                stream.close()
-            except OSError:
-                pass
-    try:
         proc.wait(timeout=_REAP_TIMEOUT_S)
     except subprocess.TimeoutExpired:
         pass  # truly wedged leader (near-impossible post-SIGKILL) — give up
+
+
+def _read_capped(f, limit: int = _STDOUT_CAP_BYTES) -> str:
+    """Read back the LAST ``limit`` bytes of a temp file as text. Bounds
+    read-back memory regardless of how much the child wrote, while keeping
+    the stream tail that callers actually parse/log (diff-cover footer,
+    pytest failure summary). Decodes leniently — the file is raw bytes."""
+    f.flush()
+    f.seek(0, os.SEEK_END)
+    size = f.tell()
+    f.seek(max(0, size - limit))
+    data = f.read().decode("utf-8", "replace")
+    if size > limit:
+        return f"…[{size - limit} bytes elided]…\n" + data
+    return data
 
 
 def _path_exists(path: Path | None) -> bool:
@@ -453,10 +478,20 @@ _TOTAL_RE = re.compile(r"^Total:\s+(\d+)\s+lines?", re.MULTILINE)
 _MISSING_RE = re.compile(r"^Missing:\s+(\d+)\s+lines?", re.MULTILINE)
 _NO_LINES_RE = re.compile(r"No lines with coverage information", re.IGNORECASE)
 
+# Distinct from ``None``: diff-cover exited 0 but we recognized NEITHER its
+# explicit no-lines message NOR a Total/Missing footer. ``None`` means the
+# legitimate "nothing to score" case; this sentinel means the output format
+# was unrecognizable — most likely a diff-cover version whose text drifted
+# (the ``>=8.0.0`` floor permits future majors). The caller reports the two
+# differently so a format break can't masquerade as "no lines" and silently
+# kill baseline collection (codex #1220 r8).
+_PARSE_FAILED = object()
 
-def _parse_diff_cover(stdout: str) -> tuple[float, int, int] | None:
-    """Return ``(percent, covered_lines, total_lines)`` or ``None`` when
-    diff-cover reports nothing to score.
+
+def _parse_diff_cover(stdout: str) -> tuple[float, int, int] | None | object:
+    """Return ``(percent, covered_lines, total_lines)``; ``None`` when
+    diff-cover legitimately reports nothing to score; or ``_PARSE_FAILED``
+    when its output is unrecognizable (format drift — see the sentinel).
 
     Percent is computed from the exact ``Total`` / ``Missing`` counts,
     NOT from diff-cover's own ``Coverage:`` line. diff-cover *floors*
@@ -469,15 +504,15 @@ def _parse_diff_cover(stdout: str) -> tuple[float, int, int] | None:
     """
     text = stdout or ""
     if _NO_LINES_RE.search(text):
-        return None
+        return None  # legitimate: no scorable lines in the diff
     tm = _TOTAL_RE.search(text)
     mm = _MISSING_RE.search(text)
     if not tm or not mm:
-        return None
+        return _PARSE_FAILED  # unrecognized footer — format drift
     total = int(tm.group(1))
     missing = int(mm.group(1))
     if total <= 0:
-        return None
+        return None  # explicit "Total: 0 lines" — nothing to score
     covered = total - missing
     pct = 100.0 * covered / total
     return pct, covered, total

--- a/scripts/pr_validate/steps/diff_coverage.py
+++ b/scripts/pr_validate/steps/diff_coverage.py
@@ -45,6 +45,7 @@ import signal
 import subprocess
 import sys
 import threading
+import time
 import traceback
 from pathlib import Path
 
@@ -507,7 +508,7 @@ def _run_group_bounded(
         the pipe can't wedge the pipeline. The stuck reader is a harmless daemon
         thread reaped at interpreter exit.
 
-    Deliberately NOT done, after a long convergence (codex #1220 r8–r19):
+    Deliberately NOT done, after a long convergence (codex #1220 r8–r20):
 
       * No ``RLIMIT_FSIZE`` file-size cap (inherited by the whole pytest tree,
         it would truncate/corrupt legitimate large writes — e.g. a >256 MiB
@@ -517,15 +518,29 @@ def _run_group_bounded(
         descendant can ``setsid()`` into its OWN group while still holding the
         pipe, so the original PGID can be empty-and-recycled even though a reader
         is still blocked — the kill would then land on an UNRELATED group
-        (potentially an operator service). This is a genuine dilemma with no
-        race-free resolution on macOS (no cgroups / job objects, no non-reaping
-        group wait): sweeping risks a wrong-group SIGKILL, not-sweeping may leak
-        an escaped descendant. We take the strictly-safer horn — never
-        wrong-kill — and accept the leak, which is anyway at PARITY with the
-        gating ``full_unit`` (its bare ``subprocess.run`` leaks escaped
-        descendants too, and additionally has no timeout so it would simply hang
-        here). ``killpg`` therefore fires ONLY from ``_kill_group`` on the
-        timeout / exception paths, where the leader is still unreaped.
+        (potentially an operator service). ``killpg`` therefore fires ONLY from
+        ``_kill_group`` on the timeout / exception paths, where the leader is
+        still unreaped.
+      * **No platform-enforced containment of a detached descendant that
+        survives a CLEAN leader exit** (codex #1220 r18/r20). This is the one
+        residual leak, and it is accepted deliberately, not overlooked:
+          - It is a genuine dilemma with no race-free resolution on macOS. The
+            two horns are: sweep the group (risks the r19 wrong-group SIGKILL
+            above) or don't (may leak an escaped descendant). codex has flagged
+            BOTH horns as blocking across rounds; there is no third option here
+            — cgroups / job objects don't exist on Darwin, and there is no
+            non-reaping group wait to enumerate survivors race-free.
+          - It is at PARITY with the merge-GATING ``full_unit`` step, which runs
+            the SAME suite via a bare ``subprocess.run`` with NO session, NO
+            group-kill and NO timeout — so it leaks a daemonized descendant TODAY
+            on every gating run, and would additionally HANG on a pipe-holder
+            where this step returns. An advisory measurer cannot reasonably be
+            held to a stricter containment bar than the gate it mirrors.
+          - The exposure is a misbehaving TEST that daemonizes a server; the fix
+            for that belongs in the test, and the same leak already reaches the
+            gate. We take the strictly-safer, never-wedge, never-wrong-kill
+            behavior and document the residue rather than add unsafe or
+            unavailable machinery.
     """
     # ``start_new_session=True`` runs the child through ``setsid()``: it leads a
     # brand-new process group whose PGID EQUALS its PID. Capture that id NOW,
@@ -566,8 +581,15 @@ def _run_group_bounded(
         # setsid-escaped descendant still holds a write end — we then return the
         # partial tail rather than block the pipeline (codex #1220 r19). We do
         # NOT ``killpg`` here: post-reap the PGID may be recycled (see docstring).
-        r_out.join(_REAP_TIMEOUT_S)
-        r_err.join(_REAP_TIMEOUT_S)
+        #
+        # ONE shared deadline across both joins so the total drain bound is
+        # ~``_REAP_TIMEOUT_S``, not 2× it — a per-stream bound would let the two
+        # joins compound to 20 s (codex #1220 r20 nit). The second join gets only
+        # the remaining budget; ``max(0.0, …)`` keeps it a non-blocking poll once
+        # the deadline has passed.
+        deadline = time.monotonic() + _REAP_TIMEOUT_S
+        r_out.join(max(0.0, deadline - time.monotonic()))
+        r_err.join(max(0.0, deadline - time.monotonic()))
 
     try:
         proc.wait(timeout=timeout)

--- a/scripts/pr_validate/steps/diff_coverage.py
+++ b/scripts/pr_validate/steps/diff_coverage.py
@@ -37,7 +37,9 @@ error while logging must not escape as a blocking ``error`` either).
 from __future__ import annotations
 
 import importlib.util
+import os
 import re
+import signal
 import subprocess
 import sys
 import traceback
@@ -50,13 +52,15 @@ from ..context import Context
 # test files aren't the subject of "is this PR's new code tested".
 _COV_PACKAGE = "vllm_mlx"
 
-# diff-cover's compare point. ``origin/main`` is the merge target and is
-# always present locally after ``git fetch origin`` (which the operator
-# runs before validating, per G13). diff-cover computes the merge-base
-# internally, so this yields exactly the lines this PR adds on top of
-# main. We prefer the branch name over ``ctx.base_sha`` because the raw
-# SHA may not resolve if the local clone is shallow.
-_COMPARE_BRANCH = "origin/main"
+# Fallback diff-cover compare point when the PR's base commit is unknown.
+# The real compare ref is derived per-PR from ``ctx.base_sha`` (the PR's
+# actual base, ``baseRefOid``) so a PR targeting a release / maintenance
+# branch is scored against ITS base, not main (codex #1220). diff-cover
+# computes the merge-base internally, so either form yields exactly the
+# lines this PR adds on top of its base. If the derived ref can't be
+# resolved, diff-cover exits nonzero and we skip (see the returncode
+# guard) — an advisory measurer never blocks on a bad ref.
+_COMPARE_BRANCH_FALLBACK = "origin/main"
 
 # Bounded so a hung test or a wedged diff-cover can't block the pipeline
 # — the whole point of an advisory step is that it never blocks. On
@@ -151,17 +155,13 @@ class DiffCoverageStep(Step):
         ]
         ctx.run_log("diff_coverage: running instrumented suite (advisory)…")
         try:
-            pytest_proc = subprocess.run(  # noqa: S603 — fixed argv, no shell
-                pytest_cmd,
-                capture_output=True,
-                text=True,
-                cwd=str(ctx.repo_root),
-                timeout=_PYTEST_TIMEOUT_S,
+            pytest_proc = _run_group_bounded(
+                pytest_cmd, str(ctx.repo_root), _PYTEST_TIMEOUT_S
             )
         except subprocess.TimeoutExpired:
             return self._skip(
                 f"advisory coverage skipped (instrumented suite exceeded "
-                f"{_PYTEST_TIMEOUT_S}s — killed)"
+                f"{_PYTEST_TIMEOUT_S}s — process group killed)"
             )
 
         # 3. Only trust coverage from a CLEAN, COMPLETE run. A nonzero
@@ -185,29 +185,30 @@ class DiffCoverageStep(Step):
                 "advisory coverage skipped (no coverage.xml produced)", log_path
             )
 
-        # 4. diff-cover: patch coverage of the changed lines vs main.
-        #    Invoke via ``-m`` so it runs in the SAME interpreter the
-        #    coverage was produced with (matches targeted_tests' policy).
+        # 4. diff-cover: patch coverage of the changed lines vs the PR's
+        #    base. Derive the compare ref from ``ctx.base_sha`` (the PR's
+        #    actual base commit) so a release/maintenance-branch PR is
+        #    scored against its own base, not main. Falls back to
+        #    ``origin/main`` when the base commit is unknown. Invoke via
+        #    ``-m`` so it runs in the SAME interpreter the coverage was
+        #    produced with (matches targeted_tests' policy).
+        compare_ref = ctx.base_sha or _COMPARE_BRANCH_FALLBACK
         dc_cmd = [
             sys.executable,
             "-m",
             "diff_cover.diff_cover_tool",
             str(xml_path),
             "--compare-branch",
-            _COMPARE_BRANCH,
+            compare_ref,
         ]
         try:
-            dc_proc = subprocess.run(  # noqa: S603 — fixed argv, no shell
-                dc_cmd,
-                capture_output=True,
-                text=True,
-                cwd=str(ctx.repo_root),
-                timeout=_DIFF_COVER_TIMEOUT_S,
+            dc_proc = _run_group_bounded(
+                dc_cmd, str(ctx.repo_root), _DIFF_COVER_TIMEOUT_S
             )
         except subprocess.TimeoutExpired:
             return self._skip(
                 f"advisory coverage skipped (diff-cover exceeded "
-                f"{_DIFF_COVER_TIMEOUT_S}s — killed)"
+                f"{_DIFF_COVER_TIMEOUT_S}s — process group killed)"
             )
 
         _safe_write(
@@ -277,6 +278,40 @@ class DiffCoverageStep(Step):
         return StepResult(
             name=self.name, status="skip", summary=summary, artifacts=artifacts
         )
+
+
+def _run_group_bounded(
+    cmd: list[str], cwd: str, timeout: int
+) -> subprocess.CompletedProcess[str]:
+    """Run ``cmd`` in its OWN process group with a hard timeout.
+
+    ``subprocess.run(timeout=...)`` SIGKILLs only the direct child on
+    expiry — a timed-out pytest could leave spawned servers/workers alive
+    to contaminate later validation steps (codex #1220). We start the
+    child in a new session (``start_new_session=True`` → new process
+    group) and, on timeout, kill the WHOLE group so no descendant
+    survives. Re-raises ``subprocess.TimeoutExpired`` so callers keep
+    their existing skip-on-timeout handling.
+    """
+    with subprocess.Popen(  # noqa: S603 — fixed argv, no shell
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        cwd=cwd,
+        start_new_session=True,
+    ) as proc:
+        try:
+            out, err = proc.communicate(timeout=timeout)
+        except subprocess.TimeoutExpired:
+            # Kill the entire process group, not just the leader.
+            try:
+                os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+            except (ProcessLookupError, PermissionError):
+                proc.kill()  # group gone / not permitted — fall back to leader
+            proc.communicate()  # reap so we don't leak a zombie
+            raise
+        return subprocess.CompletedProcess(cmd, proc.returncode, out, err)
 
 
 def _safe_write(path: Path, text: str) -> None:

--- a/scripts/pr_validate/steps/diff_coverage.py
+++ b/scripts/pr_validate/steps/diff_coverage.py
@@ -91,16 +91,19 @@ _LOG_TAIL_CHARS = 4000
 # #1220 r8).
 _STDOUT_CAP_BYTES = 1_048_576
 
-# Disk quota: hard cap on how many bytes a single child may write to its temp
-# files before we kill its group and treat the run as timed out. The output
-# goes to disk (not RAM), but disk is still finite on an auto-deploy host, so
-# a runaway / hung test that streams without bound must not exhaust it (codex
-# #1220 r10). 256 MiB is orders of magnitude above any real ``-q`` suite or
-# diff-cover run, so it only ever trips on genuinely pathological output.
+# Disk quota: the largest file the child — or anything in its session — may
+# create, enforced by the KERNEL via ``RLIMIT_FSIZE`` (set in a preexec_fn on
+# the child). The output goes to disk (not RAM), but disk is still finite on
+# an auto-deploy host, so a runaway / hung test that streams without bound
+# must not exhaust it (codex #1220 r10). A kernel limit closes the gap a
+# userspace size-poll leaves — a child that dumps gigabytes and exits BETWEEN
+# polls, or in the very first sub-poll window, can't overshoot because the
+# write past the limit is refused (EFBIG) / SIGXFSZ-killed at the syscall,
+# regardless of timing, and the cap is INHERITED so even a descendant that
+# ``setsid()``s out of the group still can't exhaust disk (codex #1220 r11).
+# 256 MiB is orders of magnitude above any real ``-q`` suite / diff-cover run
+# or coverage artifact, so it only ever trips on genuinely pathological output.
 _OUTPUT_QUOTA_BYTES = 256 * 1024 * 1024
-
-# How often, while waiting, we re-check the child against the output quota.
-_POLL_INTERVAL_S = 5
 
 
 class DiffCoverageStep(Step):
@@ -375,13 +378,18 @@ def _run_group_bounded(
     surviving descendant to hold open, it removes the reap-wedge class
     entirely. The tail keeps the bytes every caller needs — diff-cover's
     footer and pytest's ``-q`` failure summary both sit at the END of their
-    streams. Disk is bounded too: we poll the temp-file size and, if a child
-    blows past ``_OUTPUT_QUOTA_BYTES``, kill it exactly like a timeout so a
-    runaway producer can't exhaust the auto-deploy host (codex #1220 r10).
+    streams. Disk is bounded too, but by the KERNEL not a userspace poll: the
+    child is spawned under an ``RLIMIT_FSIZE`` of ``_OUTPUT_QUOTA_BYTES`` (see
+    ``_limit_child_fsize``), so a write past the cap is refused at the
+    syscall the instant it happens — no matter how fast the child writes or
+    whether it exits between two userspace polls, and even if a descendant
+    ``setsid()``s out of the group (the limit is inherited). A child killed
+    by ``SIGXFSZ`` (or exiting nonzero on ``EFBIG``) then fails the
+    exit-code gate and the run is skipped (codex #1220 r11).
 
-    On timeout / quota breach the raised ``TimeoutExpired`` carries the
-    captured (capped) stdout/stderr so the caller can log WHAT hung before
-    the temp files are deleted (codex #1220 r10).
+    On timeout the raised ``TimeoutExpired`` carries the captured (capped)
+    stdout/stderr so the caller can log WHAT hung before the temp files are
+    deleted (codex #1220 r10).
 
     The isolated group is swept on EVERY exit path, not just timeout: a
     pytest that exits cleanly can still leak a background server/worker into
@@ -400,14 +408,25 @@ def _run_group_bounded(
             stderr=err_f,
             cwd=cwd,
             start_new_session=True,
+            preexec_fn=_limit_child_fsize,  # noqa: PLC2801 — kernel disk cap
         )
         pgid = proc.pid  # == PGID under start_new_session (setsid)
         try:
-            _wait_within_quota(proc, cmd, timeout, out_f, err_f)
+            proc.wait(timeout=timeout)
+        except subprocess.TimeoutExpired:
+            # Time budget blown: tear the whole group down and re-raise with
+            # the captured tail so the caller can log WHAT hung. Disk is
+            # handled separately by the kernel RLIMIT (no userspace poll).
+            _kill_group(proc, pgid)
+            raise subprocess.TimeoutExpired(
+                cmd,
+                timeout,
+                output=_read_capped(out_f),
+                stderr=_read_capped(err_f),
+            ) from None
         except BaseException:
-            # Timeout / quota breach OR any other escape (e.g.
-            # KeyboardInterrupt): tear the whole group down so nothing is
-            # orphaned, then re-raise unchanged.
+            # Any other escape (e.g. KeyboardInterrupt): tear the group down
+            # so nothing is orphaned, then re-raise unchanged.
             _kill_group(proc, pgid)
             raise
         # Clean leader exit — but SWEEP the group anyway: a cleanly-exited
@@ -419,35 +438,23 @@ def _run_group_bounded(
         )
 
 
-def _wait_within_quota(proc, cmd: list[str], timeout: int, out_f, err_f) -> None:
-    """Wait for ``proc`` up to ``timeout`` seconds, re-checking every
-    ``_POLL_INTERVAL_S`` that its temp-file output has not exceeded
-    ``_OUTPUT_QUOTA_BYTES``. Raises ``subprocess.TimeoutExpired`` (with the
-    captured tail attached for diagnostics) on either the time or the byte
-    budget; returns normally when the child exits within both."""
-    remaining = timeout
-    while True:
-        step = min(_POLL_INTERVAL_S, remaining) if remaining > 0 else 0
-        try:
-            proc.wait(timeout=step)
-            return  # exited within both budgets
-        except subprocess.TimeoutExpired:
-            remaining -= step
-            over_quota = _file_size(out_f) + _file_size(err_f) > _OUTPUT_QUOTA_BYTES
-            if over_quota or remaining <= 0:
-                raise subprocess.TimeoutExpired(
-                    cmd,
-                    timeout,
-                    output=_read_capped(out_f),
-                    stderr=_read_capped(err_f),
-                ) from None
+def _limit_child_fsize() -> None:  # pragma: no cover — runs post-fork in child
+    """preexec_fn: cap the max file size the child (and everything in its new
+    session) may create, at the KERNEL, via ``RLIMIT_FSIZE``. A write past the
+    cap is refused at the write(2) syscall — ``SIGXFSZ`` (default-fatal) or
+    ``EFBIG`` — so the child cannot exhaust the auto-deploy host's disk no
+    matter how fast it writes, whether it exits between userspace polls, or
+    whether a descendant ``setsid()``s out of the process group (the limit is
+    inherited across fork). This is the kernel backstop that lets the waiter
+    stay a plain bounded ``wait`` instead of a size-polling loop (codex #1220
+    r11). Runs in the forked child before ``exec``; keep it minimal and
+    async-signal-safe. ``resource`` is imported here (Unix-only, child side)
+    so the module stays importable even where ``resource`` is absent."""
+    import resource
 
-
-def _file_size(f) -> int:
-    """Current size of an open file object (the child writes via the inherited
-    fd, so the parent object's own position never moves — seek to end)."""
-    f.seek(0, os.SEEK_END)
-    return f.tell()
+    resource.setrlimit(
+        resource.RLIMIT_FSIZE, (_OUTPUT_QUOTA_BYTES, _OUTPUT_QUOTA_BYTES)
+    )
 
 
 def _sweep_group(pgid: int) -> None:

--- a/scripts/pr_validate/steps/diff_coverage.py
+++ b/scripts/pr_validate/steps/diff_coverage.py
@@ -52,16 +52,6 @@ from ..context import Context
 # test files aren't the subject of "is this PR's new code tested".
 _COV_PACKAGE = "vllm_mlx"
 
-# Fallback diff-cover compare point when the PR's base commit is unknown.
-# The real compare ref is derived per-PR from ``ctx.base_sha`` (the PR's
-# actual base, ``baseRefOid``) so a PR targeting a release / maintenance
-# branch is scored against ITS base, not main (codex #1220). diff-cover
-# computes the merge-base internally, so either form yields exactly the
-# lines this PR adds on top of its base. If the derived ref can't be
-# resolved, diff-cover exits nonzero and we skip (see the returncode
-# guard) — an advisory measurer never blocks on a bad ref.
-_COMPARE_BRANCH_FALLBACK = "origin/main"
-
 # Bounded so a hung test or a wedged diff-cover can't block the pipeline
 # — the whole point of an advisory step is that it never blocks. On
 # expiry ``subprocess.run`` SIGKILLs the child; we catch and skip. The
@@ -88,6 +78,10 @@ _PYTEST_COVERAGE_VALID_EXITS = (0, 1)
 # descendant that inherited the pipes is wedged in an uninterruptible
 # syscall — we must never block the (auto-deploy) pipeline waiting on it.
 _REAP_TIMEOUT_S = 10
+
+# Keep the diagnostic log readable — we tail (not head) subprocess output so
+# the most recent lines (pytest's failure summary) always survive truncation.
+_LOG_TAIL_CHARS = 4000
 
 
 class DiffCoverageStep(Step):
@@ -207,13 +201,17 @@ class DiffCoverageStep(Step):
             )
 
         # 4. diff-cover: patch coverage of the changed lines vs the PR's
-        #    base. Derive the compare ref from ``ctx.base_sha`` (the PR's
-        #    actual base commit) so a release/maintenance-branch PR is
-        #    scored against its own base, not main. Falls back to
-        #    ``origin/main`` when the base commit is unknown. Invoke via
-        #    ``-m`` so it runs in the SAME interpreter the coverage was
-        #    produced with (matches targeted_tests' policy).
-        compare_ref = ctx.base_sha or _COMPARE_BRANCH_FALLBACK
+        #    base. The compare ref is the PR's ACTUAL base — ``ctx.base_sha``
+        #    (its ``baseRefOid``) — so a PR targeting a release/maintenance
+        #    branch is scored against ITS base, never a hardcoded ``main``
+        #    (codex #1220). We fall back to ``ctx.base_branch`` (the PR's
+        #    target branch, default ``main``) exactly as the sibling
+        #    base-aware steps do (``targeted_tests``, ``stress_e2e_bench``),
+        #    so an unknown base commit still resolves to the right branch
+        #    rather than a hardcoded remote ref. Invoke via ``-m`` so it runs
+        #    in the SAME interpreter the coverage was produced with (matches
+        #    targeted_tests' policy).
+        compare_ref = ctx.base_sha or ctx.base_branch
         dc_cmd = [
             sys.executable,
             "-m",
@@ -232,12 +230,19 @@ class DiffCoverageStep(Step):
                 f"{_DIFF_COVER_TIMEOUT_S}s — process group killed)"
             )
 
+        # Record pytest's own output too (tail-truncated) — on an accepted
+        # exit-1 measurement the reader needs to see WHICH tests failed and
+        # why, not just the bare exit code (codex #1220 r5 nit).
         _safe_write(
             log_path,
             "# diff_coverage advisory run\n\n"
             f"## pytest cmd\n`{' '.join(pytest_cmd)}`\n\n"
             f"## pytest exit: {pytest_proc.returncode}\n\n"
-            f"## diff-cover cmd\n`{' '.join(dc_cmd)}`\n\n"
+            "## pytest stdout (tail)\n"
+            + _tail(pytest_proc.stdout)
+            + "\n## pytest stderr (tail)\n"
+            + _tail(pytest_proc.stderr)
+            + f"\n## diff-cover cmd\n`{' '.join(dc_cmd)}`\n\n"
             f"## diff-cover exit: {dc_proc.returncode}\n\n"
             "## diff-cover stdout\n"
             + (dc_proc.stdout or "")
@@ -368,13 +373,25 @@ def _kill_group_and_reap(proc: subprocess.Popen[str], pgid: int) -> None:
             pass
     try:
         proc.communicate(timeout=_REAP_TIMEOUT_S)
+        return
     except subprocess.TimeoutExpired:
-        for stream in (proc.stdout, proc.stderr):
-            if stream is not None:
-                try:
-                    stream.close()
-                except OSError:
-                    pass
+        pass
+    # A descendant is wedged holding the inherited pipes, so ``communicate``
+    # (which reads to EOF before waiting) can't return. Abandon the pipes so
+    # we stop blocking on them — but the SIGKILLed direct child is now a
+    # zombie that ``communicate`` never got to reap, so still ``wait()`` for
+    # it under a bound. Without this the leader leaks as a zombie until the
+    # validator process exits (codex #1220 r5).
+    for stream in (proc.stdout, proc.stderr):
+        if stream is not None:
+            try:
+                stream.close()
+            except OSError:
+                pass
+    try:
+        proc.wait(timeout=_REAP_TIMEOUT_S)
+    except subprocess.TimeoutExpired:
+        pass  # truly wedged leader (near-impossible post-SIGKILL) — give up
 
 
 def _safe_write(path: Path, text: str) -> None:
@@ -388,11 +405,20 @@ def _safe_write(path: Path, text: str) -> None:
         pass
 
 
+def _tail(text: str | None, limit: int = _LOG_TAIL_CHARS) -> str:
+    """Last ``limit`` chars of ``text`` (pytest's failure summary lives at the
+    end), with an elision marker when truncated. Never raises."""
+    s = text or ""
+    if len(s) <= limit:
+        return s
+    return f"…[{len(s) - limit} chars elided]…\n" + s[-limit:]
+
+
 def _pytest_dump(cmd: list[str], proc: subprocess.CompletedProcess[str]) -> str:
     return (
         f"# instrumented pytest (exit {proc.returncode})\n\n"
         f"## cmd\n`{' '.join(cmd)}`\n\n"
-        "## stdout\n" + (proc.stdout or "") + "\n## stderr\n" + (proc.stderr or "")
+        "## stdout\n" + _tail(proc.stdout) + "\n## stderr\n" + _tail(proc.stderr)
     )
 
 

--- a/scripts/pr_validate/steps/diff_coverage.py
+++ b/scripts/pr_validate/steps/diff_coverage.py
@@ -28,7 +28,10 @@ Because it's advisory, EVERY failure path here returns ``pass`` or
 must not be the reason a good PR can't merge. The base ``execute``
 wrapper would turn an *uncaught* exception into ``error`` (which the
 scorecard treats as blocking), so ``run`` catches everything and
-downgrades to ``skip``.
+downgrades to ``skip``. The subprocess calls carry bounded timeouts so
+a hung test or diff-cover can't wedge the (auto-deploy) pipeline, and
+the diagnostic-log writes are best-effort (a disk-full / permission
+error while logging must not escape as a blocking ``error`` either).
 """
 
 from __future__ import annotations
@@ -55,6 +58,15 @@ _COV_PACKAGE = "vllm_mlx"
 # SHA may not resolve if the local clone is shallow.
 _COMPARE_BRANCH = "origin/main"
 
+# Bounded so a hung test or a wedged diff-cover can't block the pipeline
+# — the whole point of an advisory step is that it never blocks. On
+# expiry ``subprocess.run`` SIGKILLs the child; we catch and skip. The
+# suite timeout is deliberately generous (the instrumented full suite is
+# ~3 min today) — a false timeout would just silently drop a
+# measurement, so err long.
+_PYTEST_TIMEOUT_S = 1800
+_DIFF_COVER_TIMEOUT_S = 180
+
 
 class DiffCoverageStep(Step):
     name = "diff_coverage"
@@ -79,19 +91,16 @@ class DiffCoverageStep(Step):
 
     def run(self, ctx: Context) -> StepResult:
         log_path: Path = ctx.artifact_path("diff-coverage.log")
-        # Advisory contract: swallow ALL failures. Never fail/error.
+        # Advisory contract: swallow ALL failures. Never fail/error. The
+        # log write is best-effort (``_safe_write``) so a failure to log
+        # can't escape this handler and become a blocking ``error``.
         try:
             return self._measure(ctx, log_path)
         except Exception as e:  # noqa: BLE001 — advisory must not block merge
-            log_path.write_text(traceback.format_exc())
-            return StepResult(
-                name=self.name,
-                status="skip",
-                summary=(
-                    f"advisory coverage skipped (internal error: "
-                    f"{type(e).__name__}: {e})"
-                ),
-                artifacts=[str(log_path)],
+            _safe_write(log_path, traceback.format_exc())
+            return self._skip(
+                f"advisory coverage skipped (internal error: {type(e).__name__}: {e})",
+                log_path,
             )
 
     # ------------------------------------------------------------------
@@ -101,26 +110,23 @@ class DiffCoverageStep(Step):
         #    extras, but the operator may run validate from a leaner env.
         #    Missing tooling is a clean skip, not a failure.
         if importlib.util.find_spec("pytest_cov") is None:
-            return StepResult(
-                name=self.name,
-                status="skip",
-                summary="pytest-cov not installed — advisory coverage unavailable",
+            return self._skip(
+                "pytest-cov not installed — advisory coverage unavailable"
             )
         if importlib.util.find_spec("diff_cover") is None:
-            return StepResult(
-                name=self.name,
-                status="skip",
-                summary="diff-cover not installed — advisory coverage unavailable",
+            return self._skip(
+                "diff-cover not installed — advisory coverage unavailable"
             )
 
         xml_path = ctx.artifact_path("coverage.xml")
+        # Fresh-file guarantee: never let a stale coverage.xml from an
+        # earlier run masquerade as this run's result. If pytest fails to
+        # regenerate it below, the ``not xml_path.exists()`` path fires
+        # instead of publishing yesterday's numbers.
+        xml_path.unlink(missing_ok=True)
 
         # 2. Instrumented suite — mirrors ``full_unit``'s selection so the
-        #    coverage picture matches what we actually gate on. We do NOT
-        #    inspect the return code: ``full_unit`` owns "suite is green";
-        #    here we only want the coverage.xml. pytest-cov writes the
-        #    report at session end even if some tests fail, so a red suite
-        #    still yields a usable (if partial) measurement.
+        #    coverage picture matches what we actually gate on.
         pytest_cmd = [
             sys.executable,
             "-m",
@@ -138,29 +144,42 @@ class DiffCoverageStep(Step):
             "no:cacheprovider",
         ]
         ctx.run_log("diff_coverage: running instrumented suite (advisory)…")
-        pytest_proc = subprocess.run(  # noqa: S603 — fixed argv, no shell
-            pytest_cmd, capture_output=True, text=True, cwd=str(ctx.repo_root)
-        )
+        try:
+            pytest_proc = subprocess.run(  # noqa: S603 — fixed argv, no shell
+                pytest_cmd,
+                capture_output=True,
+                text=True,
+                cwd=str(ctx.repo_root),
+                timeout=_PYTEST_TIMEOUT_S,
+            )
+        except subprocess.TimeoutExpired:
+            return self._skip(
+                f"advisory coverage skipped (instrumented suite exceeded "
+                f"{_PYTEST_TIMEOUT_S}s — killed)"
+            )
+
+        # 3. Only trust coverage from a CLEAN, COMPLETE run. A nonzero
+        #    exit means failures / interruption / collection error — a
+        #    partial or failing run would contaminate the very baseline
+        #    this feature exists to collect. ``full_unit`` owns surfacing
+        #    a red suite; here we simply skip. (Green-suite PRs — the only
+        #    ones that merge and form the baseline — exit 0, so nothing of
+        #    value is lost.)
+        if pytest_proc.returncode != 0:
+            _safe_write(log_path, _pytest_dump(pytest_cmd, pytest_proc))
+            return self._skip(
+                f"advisory coverage skipped (instrumented suite exit "
+                f"{pytest_proc.returncode} — not clean; see full_unit)",
+                log_path,
+            )
 
         if not xml_path.exists():
-            log_path.write_text(
-                "# pytest (coverage run) produced no coverage.xml\n\n"
-                "## stdout\n"
-                + (pytest_proc.stdout or "")
-                + "\n## stderr\n"
-                + (pytest_proc.stderr or "")
-            )
-            return StepResult(
-                name=self.name,
-                status="skip",
-                summary=(
-                    "advisory coverage skipped (no coverage.xml — suite "
-                    "likely errored at collection)"
-                ),
-                artifacts=[str(log_path)],
+            _safe_write(log_path, _pytest_dump(pytest_cmd, pytest_proc))
+            return self._skip(
+                "advisory coverage skipped (no coverage.xml produced)", log_path
             )
 
-        # 3. diff-cover: patch coverage of the changed lines vs main.
+        # 4. diff-cover: patch coverage of the changed lines vs main.
         #    Invoke via ``-m`` so it runs in the SAME interpreter the
         #    coverage was produced with (matches targeted_tests' policy).
         dc_cmd = [
@@ -171,11 +190,22 @@ class DiffCoverageStep(Step):
             "--compare-branch",
             _COMPARE_BRANCH,
         ]
-        dc_proc = subprocess.run(  # noqa: S603 — fixed argv, no shell
-            dc_cmd, capture_output=True, text=True, cwd=str(ctx.repo_root)
-        )
+        try:
+            dc_proc = subprocess.run(  # noqa: S603 — fixed argv, no shell
+                dc_cmd,
+                capture_output=True,
+                text=True,
+                cwd=str(ctx.repo_root),
+                timeout=_DIFF_COVER_TIMEOUT_S,
+            )
+        except subprocess.TimeoutExpired:
+            return self._skip(
+                f"advisory coverage skipped (diff-cover exceeded "
+                f"{_DIFF_COVER_TIMEOUT_S}s — killed)"
+            )
 
-        log_path.write_text(
+        _safe_write(
+            log_path,
             "# diff_coverage advisory run\n\n"
             f"## pytest cmd\n`{' '.join(pytest_cmd)}`\n\n"
             f"## pytest exit: {pytest_proc.returncode}\n\n"
@@ -184,7 +214,7 @@ class DiffCoverageStep(Step):
             "## diff-cover stdout\n"
             + (dc_proc.stdout or "")
             + "\n## diff-cover stderr\n"
-            + (dc_proc.stderr or "")
+            + (dc_proc.stderr or ""),
         )
 
         parsed = _parse_diff_cover(dc_proc.stdout)
@@ -192,13 +222,9 @@ class DiffCoverageStep(Step):
             # diff-cover ran but found no changed lines it could score
             # (e.g. every changed line is a comment / blank / not in the
             # coverage source map). Nothing to report — clean skip.
-            return StepResult(
-                name=self.name,
-                status="skip",
-                summary=(
-                    "advisory coverage skipped (no measurable production lines in diff)"
-                ),
-                artifacts=[str(log_path)],
+            return self._skip(
+                "advisory coverage skipped (no measurable production lines in diff)",
+                log_path,
             )
 
         pct, covered, total = parsed
@@ -219,6 +245,38 @@ class DiffCoverageStep(Step):
             findings=[finding],
             artifacts=[str(log_path), str(xml_path)],
         )
+
+    # ------------------------------------------------------------------
+
+    def _skip(self, summary: str, log_path: Path | None = None) -> StepResult:
+        """Uniform advisory skip. Attaches the log artifact only when it
+        actually made it to disk (``_safe_write`` may have swallowed a
+        write error)."""
+        artifacts = (
+            [str(log_path)] if log_path is not None and log_path.exists() else []
+        )
+        return StepResult(
+            name=self.name, status="skip", summary=summary, artifacts=artifacts
+        )
+
+
+def _safe_write(path: Path, text: str) -> None:
+    """Best-effort diagnostic write. NEVER raises. An advisory step must
+    still return skip/pass even if it can't write its own log (disk full,
+    permissions) — otherwise a failing write inside an exception handler
+    would escape as a blocking ``error`` (codex review on #1220)."""
+    try:
+        path.write_text(text)
+    except OSError:
+        pass
+
+
+def _pytest_dump(cmd: list[str], proc: subprocess.CompletedProcess[str]) -> str:
+    return (
+        f"# instrumented pytest (exit {proc.returncode})\n\n"
+        f"## cmd\n`{' '.join(cmd)}`\n\n"
+        "## stdout\n" + (proc.stdout or "") + "\n## stderr\n" + (proc.stderr or "")
+    )
 
 
 # ----------------------------------------------------------------------

--- a/scripts/pr_validate/steps/diff_coverage.py
+++ b/scripts/pr_validate/steps/diff_coverage.py
@@ -308,11 +308,11 @@ class DiffCoverageStep(Step):
         """Uniform advisory skip. Attaches the log artifact only when it
         actually made it to disk (``_safe_write`` may have swallowed a
         write error)."""
-        artifacts = (
-            [str(log_path)] if log_path is not None and log_path.exists() else []
-        )
         return StepResult(
-            name=self.name, status="skip", summary=summary, artifacts=artifacts
+            name=self.name,
+            status="skip",
+            summary=summary,
+            artifacts=[str(log_path)] if _path_exists(log_path) else [],
         )
 
 
@@ -396,6 +396,21 @@ def _kill_group_and_reap(proc: subprocess.Popen[str], pgid: int) -> None:
         proc.wait(timeout=_REAP_TIMEOUT_S)
     except subprocess.TimeoutExpired:
         pass  # truly wedged leader (near-impossible post-SIGKILL) — give up
+
+
+def _path_exists(path: Path | None) -> bool:
+    """``Path.exists()`` that NEVER raises. ``pathlib.Path.exists`` re-raises
+    OSErrors other than ENOENT/ENOTDIR (e.g. EACCES permission-denied, EIO on
+    a failing mount), so a bare ``log_path.exists()`` inside ``_skip`` could
+    escape ``run``'s handler and become the blocking ``error`` this advisory
+    step promises never to produce (codex #1220 r7). Treat any error as
+    'not present' — the worst case is a missing artifact link, never a block."""
+    if path is None:
+        return False
+    try:
+        return path.exists()
+    except OSError:
+        return False
 
 
 def _safe_write(path: Path, text: str) -> None:

--- a/scripts/pr_validate/steps/diff_coverage.py
+++ b/scripts/pr_validate/steps/diff_coverage.py
@@ -182,14 +182,21 @@ class DiffCoverageStep(Step):
 
         # coverage.py writes its data file to ``$COVERAGE_FILE`` or, unset,
         # ``.coverage`` in the CWD — which here is the repo root. Point it at a
-        # dedicated artifact path so an advisory run can NEVER erase/overwrite a
-        # developer's own ``.coverage`` database sitting at the repo root (codex
-        # #1220 r12). The XML report is still emitted to ``xml_path``; only the
-        # intermediate data file moves.
-        cov_env = {
-            **os.environ,
-            "COVERAGE_FILE": str(ctx.artifact_path("coverage.data")),
-        }
+        # dedicated (per-run) artifact path so an advisory run can NEVER
+        # erase/overwrite a developer's own ``.coverage`` database at the repo
+        # root (codex #1220 r12). The XML report is still emitted to
+        # ``xml_path``; only the intermediate data file moves. Unlink it first
+        # so a leftover from an aborted prior run can't be appended to.
+        cov_data = ctx.artifact_path("coverage.data")
+        cov_data.unlink(missing_ok=True)
+        cov_env = {**os.environ, "COVERAGE_FILE": str(cov_data)}
+        # Drop ``PYTEST_ADDOPTS`` from the child env: a host that exports it
+        # (``--collect-only``, ``-x``, ``--cov-append``, ``-p no:cov`` …) would
+        # otherwise silently turn the run into empty / partial / stale coverage
+        # that we would then publish as the PR's measurement. The explicit argv
+        # below is the whole spec of the run; nothing may override it (codex
+        # #1220 r14).
+        cov_env.pop("PYTEST_ADDOPTS", None)
 
         # 2. Instrumented suite — mirrors ``full_unit``'s selection so the
         #    coverage picture matches what we actually gate on.
@@ -218,7 +225,7 @@ class DiffCoverageStep(Step):
             _safe_write(log_path, _timeout_dump("instrumented pytest", pytest_cmd, exc))
             return self._skip(
                 f"advisory coverage skipped (instrumented suite exceeded "
-                f"{_PYTEST_TIMEOUT_S}s or its output quota — process group killed)",
+                f"{_PYTEST_TIMEOUT_S}s — process group killed)",
                 log_path,
             )
 
@@ -275,7 +282,7 @@ class DiffCoverageStep(Step):
             _safe_write(log_path, _timeout_dump("diff-cover", dc_cmd, exc))
             return self._skip(
                 f"advisory coverage skipped (diff-cover exceeded "
-                f"{_DIFF_COVER_TIMEOUT_S}s or its output quota — process group killed)",
+                f"{_DIFF_COVER_TIMEOUT_S}s — process group killed)",
                 log_path,
             )
 
@@ -423,10 +430,13 @@ def _run_group_bounded(
     stdout/stderr so the caller can log WHAT hung before the temp files are
     deleted (codex #1220 r10).
 
-    The isolated group is swept on EVERY exit path, not just timeout: a
-    pytest that exits cleanly can still leak a background server/worker into
-    the group, which would otherwise survive to contaminate later steps
-    (codex #1220 r9).
+    Group teardown happens ONLY on the timeout/exception paths, where
+    ``_kill_group`` SIGKILLs the group BEFORE reaping the leader so ``pgid``
+    cannot be recycled — the kill is race-free. On a CLEAN exit we do not sweep
+    the group: a race-free sweep needs a non-reaping wait (``waitid``+
+    ``WNOWAIT``) unavailable on macOS, and a reap-then-``killpg`` sweep would
+    reintroduce a PID-reuse race (codex #1220 r14). That leaves clean-exit
+    parity with the merge-GATING sibling steps, which group-kill nothing.
     """
     # ``start_new_session=True`` runs the child through ``setsid()``: it
     # leads a brand-new process group whose PGID EQUALS its PID. Capture that
@@ -446,9 +456,11 @@ def _run_group_bounded(
         try:
             proc.wait(timeout=timeout)
         except subprocess.TimeoutExpired:
-            # Time budget blown: tear the whole group down and re-raise with
-            # the captured tail so the caller can log WHAT hung. Disk is
-            # handled separately by the kernel RLIMIT (no userspace poll).
+            # Time budget blown: tear the WHOLE group down and re-raise with the
+            # captured tail so the caller can log WHAT hung. ``_kill_group``
+            # SIGKILLs the group BEFORE reaping the leader, so ``pgid`` cannot
+            # have been recycled onto an unrelated group — the kill is race-free
+            # (codex #1220 r14). Disk is handled separately by the kernel RLIMIT.
             _kill_group(proc, pgid)
             raise subprocess.TimeoutExpired(
                 cmd,
@@ -458,13 +470,19 @@ def _run_group_bounded(
             ) from None
         except BaseException:
             # Any other escape (e.g. KeyboardInterrupt): tear the group down
-            # so nothing is orphaned, then re-raise unchanged.
+            # (again kill-before-reap, race-free) then re-raise unchanged.
             _kill_group(proc, pgid)
             raise
-        # Clean leader exit — but SWEEP the group anyway: a cleanly-exited
-        # pytest may have leaked a background server/worker still running in
-        # the isolated group. Best-effort; an already-empty group is ESRCH.
-        _sweep_group(pgid)
+        # Clean leader exit. We deliberately do NOT sweep the group here. A
+        # race-free sweep would have to SIGKILL the group BEFORE reaping the
+        # leader (so ``pgid`` can't be recycled), which needs a non-reaping wait
+        # (``waitid``+``WNOWAIT``) that is unavailable on macOS — the operator's
+        # platform. A reap-then-``killpg`` sweep would reintroduce exactly the
+        # PID-reuse race codex flagged (#1220 r14). So on the clean path we
+        # accept parity with the merge-GATING sibling steps (``full_unit`` /
+        # ``targeted_tests`` group-kill nothing at all); the timeout/exception
+        # paths above still contain a runaway group race-free, which is the
+        # scenario that actually matters.
         return subprocess.CompletedProcess(
             cmd, proc.returncode, _read_capped(out_f), _read_capped(err_f)
         )
@@ -489,20 +507,23 @@ def _rlimit_wrap() -> list[str]:
     """Argv prefix that caps the wrapped command's max file size at
     ``_OUTPUT_QUOTA_BYTES`` (the KERNEL disk backstop; see ``_run_group_bounded``).
     Built per-call so a test monkeypatching ``_OUTPUT_QUOTA_BYTES`` takes
-    effect. Unix-only, like the rest of this helper (``setsid``/``killpg``)."""
-    return [sys.executable, "-c", _RLIMIT_WRAP_SRC, str(_OUTPUT_QUOTA_BYTES)]
+    effect. Unix-only, like the rest of this helper (``setsid``/``killpg``).
 
-
-def _sweep_group(pgid: int) -> None:
-    """Best-effort SIGKILL of any process still lingering in the isolated
-    process group after its leader has exited. An empty group raises ESRCH,
-    which we ignore. (PID-reuse of ``pgid`` in the microseconds since the
-    leader was reaped is theoretically possible but negligible, and no worse
-    than any ``killpg``-after-``wait``.)"""
-    try:
-        os.killpg(pgid, signal.SIGKILL)
-    except OSError:
-        pass
+    ``-I -S`` run the wrapper in ISOLATED startup: ``-I`` drops the CWD (the
+    repo root) and user-site from ``sys.path`` and ignores ``PYTHON*`` env, and
+    ``-S`` skips ``site``/``sitecustomize`` — so no repository-local
+    ``resource.py`` or startup hook can shadow the stdlib ``resource`` module
+    and neuter ``setrlimit`` before the cap is set (codex #1220 r14). The flags
+    apply ONLY to this tiny wrapper; the real command it ``exec``s runs with a
+    normal interpreter and environment (it is meant to import repo code)."""
+    return [
+        sys.executable,
+        "-I",
+        "-S",
+        "-c",
+        _RLIMIT_WRAP_SRC,
+        str(_OUTPUT_QUOTA_BYTES),
+    ]
 
 
 def _kill_group(proc: subprocess.Popen, pgid: int) -> None:
@@ -591,11 +612,12 @@ def _pytest_dump(cmd: list[str], proc: subprocess.CompletedProcess[str]) -> str:
 
 
 def _timeout_dump(label: str, cmd: list[str], exc: subprocess.TimeoutExpired) -> str:
-    """Diagnostics for a timed-out / output-quota-exceeded child. Preserves
-    the captured tail carried on the exception so the log records WHAT hung
-    before the temp files are deleted (codex #1220 r10)."""
+    """Diagnostics for a timed-out child. Preserves the captured tail carried on
+    the exception so the log records WHAT hung before the temp files are deleted
+    (codex #1220 r10). (A disk-cap breach is not routed here — it surfaces as a
+    SIGXFSZ/nonzero exit through the exit-code path, not ``TimeoutExpired``.)"""
     return (
-        f"# {label} TIMED OUT or exceeded its output quota\n\n"
+        f"# {label} TIMED OUT\n\n"
         f"## cmd\n`{' '.join(cmd)}`\n\n"
         "## stdout (tail)\n"
         + _tail(exc.stdout if isinstance(exc.stdout, str) else "")

--- a/scripts/pr_validate/steps/diff_coverage.py
+++ b/scripts/pr_validate/steps/diff_coverage.py
@@ -71,6 +71,24 @@ _COMPARE_BRANCH_FALLBACK = "origin/main"
 _PYTEST_TIMEOUT_S = 1800
 _DIFF_COVER_TIMEOUT_S = 180
 
+# pytest exit codes that still yield a trustworthy coverage.xml. 0 = all
+# passed; 1 = tests ran but some FAILED — coverage is a complete record of
+# the lines that executed either way (pytest-cov writes on session finish
+# regardless of outcomes). 2 = interrupted, 3 = internal error, 4 = usage
+# error, 5 = no tests collected — those leave no dependable coverage, so we
+# skip on them. Accepting exit 1 is deliberate: an ADVISORY baseline
+# collector must survive an unrelated flaky test (this repo has known
+# GPU-contention flakes, e.g. ``test_batching_improves_throughput``) rather
+# than discard the whole measurement and skip on most real PRs (codex
+# #1220). ``full_unit`` still owns gating on a red suite.
+_PYTEST_COVERAGE_VALID_EXITS = (0, 1)
+
+# Bounded reap after a group SIGKILL. SIGKILL is uncatchable so the leader
+# dies at once; this bound only guards the pathological case where a
+# descendant that inherited the pipes is wedged in an uninterruptible
+# syscall — we must never block the (auto-deploy) pipeline waiting on it.
+_REAP_TIMEOUT_S = 10
+
 
 class DiffCoverageStep(Step):
     name = "diff_coverage"
@@ -164,20 +182,23 @@ class DiffCoverageStep(Step):
                 f"{_PYTEST_TIMEOUT_S}s — process group killed)"
             )
 
-        # 3. Only trust coverage from a CLEAN, COMPLETE run. A nonzero
-        #    exit means failures / interruption / collection error — a
-        #    partial or failing run would contaminate the very baseline
-        #    this feature exists to collect. ``full_unit`` owns surfacing
-        #    a red suite; here we simply skip. (Green-suite PRs — the only
-        #    ones that merge and form the baseline — exit 0, so nothing of
-        #    value is lost.)
-        if pytest_proc.returncode != 0:
+        # 3. Coverage trust model (see ``_PYTEST_COVERAGE_VALID_EXITS``). We
+        #    accept exit 0 (all passed) and exit 1 (some tests failed but the
+        #    run completed and coverage.xml is a valid record of executed
+        #    lines) and skip only on 2-5 (interrupted / internal error /
+        #    usage error / no tests) — those leave no dependable coverage. A
+        #    failing test that WAS meant to exercise the changed lines simply
+        #    leaves them uncovered, which is honest advisory signal, not
+        #    contamination; the caveat below flags that the % may under-count.
+        if pytest_proc.returncode not in _PYTEST_COVERAGE_VALID_EXITS:
             _safe_write(log_path, _pytest_dump(pytest_cmd, pytest_proc))
             return self._skip(
                 f"advisory coverage skipped (instrumented suite exit "
-                f"{pytest_proc.returncode} — not clean; see full_unit)",
+                f"{pytest_proc.returncode} — interrupted/error, not merely "
+                f"test failures; see full_unit)",
                 log_path,
             )
+        suite_had_failures = pytest_proc.returncode == 1
 
         if not xml_path.exists():
             _safe_write(log_path, _pytest_dump(pytest_cmd, pytest_proc))
@@ -248,6 +269,12 @@ class DiffCoverageStep(Step):
             )
 
         pct, covered, total = parsed
+        caveat = (
+            " NOTE: some unit tests failed this run (see full_unit) — the % "
+            "may under-count lines a failing test would otherwise have covered."
+            if suite_had_failures
+            else ""
+        )
         summary = (
             f"patch coverage {pct:.0f}% ({covered}/{total} changed lines) · "
             "advisory — not gating"
@@ -256,7 +283,7 @@ class DiffCoverageStep(Step):
             f"[ADVISORY] patch (diff) coverage: {pct:.1f}% — "
             f"{covered}/{total} newly changed {_COV_PACKAGE} lines exercised "
             "by the unit suite. Measure-only; no threshold enforced yet "
-            "(collecting baseline across ~20 PRs before deciding a gate)."
+            f"(collecting baseline across ~20 PRs before deciding a gate).{caveat}"
         )
         return StepResult(
             name=self.name,
@@ -289,29 +316,65 @@ def _run_group_bounded(
     expiry — a timed-out pytest could leave spawned servers/workers alive
     to contaminate later validation steps (codex #1220). We start the
     child in a new session (``start_new_session=True`` → new process
-    group) and, on timeout, kill the WHOLE group so no descendant
+    group) and, on timeout, SIGKILL the WHOLE group so no descendant
     survives. Re-raises ``subprocess.TimeoutExpired`` so callers keep
     their existing skip-on-timeout handling.
+
+    We deliberately do NOT use ``with subprocess.Popen(...)``: its
+    ``__exit__`` reaps via an UNBOUNDED ``wait()``, which would re-open the
+    very wedge we close below. Cleanup is handled explicitly instead.
     """
-    with subprocess.Popen(  # noqa: S603 — fixed argv, no shell
+    # ``start_new_session=True`` runs the child through ``setsid()``: it
+    # leads a brand-new process group whose PGID EQUALS its PID. Capture
+    # that id NOW. We must never derive it via ``os.getpgid(proc.pid)`` on
+    # timeout instead: by then the group leader may have already exited
+    # while a surviving descendant keeps the captured pipes open (so
+    # ``communicate`` still blocks) — ``getpgid`` would raise
+    # ``ProcessLookupError``, the group would go un-killed, only the dead
+    # leader would be targeted, and the reap could wedge the whole pipeline
+    # (codex #1220).
+    proc: subprocess.Popen[str] = subprocess.Popen(  # noqa: S603 — fixed argv
         cmd,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         text=True,
         cwd=cwd,
         start_new_session=True,
-    ) as proc:
-        try:
-            out, err = proc.communicate(timeout=timeout)
-        except subprocess.TimeoutExpired:
-            # Kill the entire process group, not just the leader.
-            try:
-                os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
-            except (ProcessLookupError, PermissionError):
-                proc.kill()  # group gone / not permitted — fall back to leader
-            proc.communicate()  # reap so we don't leak a zombie
-            raise
+    )
+    pgid = proc.pid  # == PGID under start_new_session (setsid)
+    try:
+        out, err = proc.communicate(timeout=timeout)
         return subprocess.CompletedProcess(cmd, proc.returncode, out, err)
+    except BaseException:
+        # Timeout OR any other escape (e.g. KeyboardInterrupt): tear the
+        # whole group down so nothing is orphaned, then re-raise unchanged.
+        _kill_group_and_reap(proc, pgid)
+        raise
+
+
+def _kill_group_and_reap(proc: subprocess.Popen[str], pgid: int) -> None:
+    """SIGKILL the whole process group, then reap the leader under a bounded
+    wait. Never blocks: the SIGKILL is already delivered, so if even the
+    bounded reap can't finish (a descendant wedged in an uninterruptible
+    syscall still holding the pipes), we abandon the pipes rather than hang
+    the auto-deploy pipeline."""
+    try:
+        os.killpg(pgid, signal.SIGKILL)
+    except OSError:
+        # Group already gone / not permitted — fall back to the leader.
+        try:
+            proc.kill()
+        except OSError:
+            pass
+    try:
+        proc.communicate(timeout=_REAP_TIMEOUT_S)
+    except subprocess.TimeoutExpired:
+        for stream in (proc.stdout, proc.stderr):
+            if stream is not None:
+                try:
+                    stream.close()
+                except OSError:
+                    pass
 
 
 def _safe_write(path: Path, text: str) -> None:

--- a/scripts/pr_validate/steps/diff_coverage.py
+++ b/scripts/pr_validate/steps/diff_coverage.py
@@ -361,6 +361,11 @@ def _run_group_bounded(
     entirely: the timeout path is a plain group-SIGKILL + bounded ``wait``.
     The tail keeps the bytes every caller needs — diff-cover's footer and
     pytest's ``-q`` failure summary both sit at the END of their streams.
+
+    The isolated group is swept on EVERY exit path, not just timeout: a
+    pytest that exits cleanly can still leak a background server/worker into
+    the group, which would otherwise survive to contaminate later steps
+    (codex #1220 r9).
     """
     # ``start_new_session=True`` runs the child through ``setsid()``: it
     # leads a brand-new process group whose PGID EQUALS its PID. Capture that
@@ -383,9 +388,25 @@ def _run_group_bounded(
             # whole group down so nothing is orphaned, then re-raise unchanged.
             _kill_group(proc, pgid)
             raise
+        # Clean leader exit — but SWEEP the group anyway: a cleanly-exited
+        # pytest may have leaked a background server/worker still running in
+        # the isolated group. Best-effort; an already-empty group is ESRCH.
+        _sweep_group(pgid)
         return subprocess.CompletedProcess(
             cmd, proc.returncode, _read_capped(out_f), _read_capped(err_f)
         )
+
+
+def _sweep_group(pgid: int) -> None:
+    """Best-effort SIGKILL of any process still lingering in the isolated
+    process group after its leader has exited. An empty group raises ESRCH,
+    which we ignore. (PID-reuse of ``pgid`` in the microseconds since the
+    leader was reaped is theoretically possible but negligible, and no worse
+    than any ``killpg``-after-``wait``.)"""
+    try:
+        os.killpg(pgid, signal.SIGKILL)
+    except OSError:
+        pass
 
 
 def _kill_group(proc: subprocess.Popen, pgid: int) -> None:
@@ -513,6 +534,12 @@ def _parse_diff_cover(stdout: str) -> tuple[float, int, int] | None | object:
     missing = int(mm.group(1))
     if total <= 0:
         return None  # explicit "Total: 0 lines" — nothing to score
+    if not 0 <= missing <= total:
+        # Missing out of [0, Total] is impossible for real diff-cover output;
+        # a footer this malformed means format drift, not a coverage number.
+        # Guarding it stops a bogus negative / >100 % from being published
+        # (codex #1220 r9).
+        return _PARSE_FAILED
     covered = total - missing
     pct = 100.0 * covered / total
     return pct, covered, total

--- a/scripts/pr_validate/steps/diff_coverage.py
+++ b/scripts/pr_validate/steps/diff_coverage.py
@@ -17,9 +17,10 @@ Mechanism:
      is a SEPARATE, self-contained run — we deliberately do NOT
      piggyback on ``full_unit``. ``full_unit`` is a merge-*gating*
      step; an advisory measurement feature must not be able to break
-     the gate. The asymmetry is the whole argument: a false block on
-     the gate costs a maintainer a blocked-PR investigation, while
-     sharing the run would save only ~40 s. Isolation wins.
+     the gate. The asymmetry is the whole argument: sharing would save
+     the cost of one extra instrumented suite run (~3 min), but at the
+     risk of a false block on the gate — which costs a maintainer a
+     blocked-PR investigation. Isolation wins.
   2. Feed the coverage XML to ``diff-cover`` scoped to the diff vs the
      base branch → patch-coverage %.
 
@@ -42,7 +43,6 @@ import re
 import signal
 import subprocess
 import sys
-import tempfile
 import traceback
 from pathlib import Path
 
@@ -55,9 +55,9 @@ _COV_PACKAGE = "vllm_mlx"
 
 # Bounded so a hung test or a wedged diff-cover can't block the pipeline
 # — the whole point of an advisory step is that it never blocks. On
-# expiry ``subprocess.run`` SIGKILLs the child; we catch and skip. The
-# suite timeout is deliberately generous (the instrumented full suite is
-# ~3 min today) — a false timeout would just silently drop a
+# expiry ``_run_group_bounded`` SIGKILLs the whole process group; we catch
+# and skip. The suite timeout is deliberately generous (the instrumented
+# full suite is ~3 min today) — a false timeout would just silently drop a
 # measurement, so err long.
 _PYTEST_TIMEOUT_S = 1800
 _DIFF_COVER_TIMEOUT_S = 180
@@ -83,38 +83,6 @@ _REAP_TIMEOUT_S = 10
 # Keep the diagnostic log readable — we tail (not head) subprocess output so
 # the most recent lines (pytest's failure summary) always survive truncation.
 _LOG_TAIL_CHARS = 4000
-
-# Cap on how much subprocess output we read back into memory from the temp
-# files (the tail). 1 MiB dwarfs diff-cover's footer and pytest's ``-q``
-# summary (both a few KB), so nothing real is ever lost, yet a runaway test
-# that streams gigabytes to disk still can't bloat the validator (codex
-# #1220 r8).
-_STDOUT_CAP_BYTES = 1_048_576
-
-# Per-file disk cap: the largest size any SINGLE file the child writes may
-# reach, enforced by the KERNEL via ``RLIMIT_FSIZE`` (set by an exec-based
-# wrapper, ``_rlimit_wrap``). Its specific job is to bound the two capture
-# streams — we redirect the child's stdout/stderr to temp FILES (not RAM), and
-# a runaway / hung test that streams without bound would otherwise fill the
-# auto-deploy host's disk through them (codex #1220 r10). A kernel per-file cap
-# closes the gap a userspace size-poll leaves: a child that dumps gigabytes and
-# exits BETWEEN polls, or in the first sub-poll window, can't overshoot because
-# the write past the cap is refused (EFBIG) / SIGXFSZ-killed at the syscall,
-# regardless of timing (codex #1220 r11).
-#
-# SCOPE (deliberately not overclaimed — codex #1220 r13): this bounds each file
-# INDIVIDUALLY, which fully contains the streaming vector above. It is NOT an
-# aggregate-bytes quota — a suite could in principle create many sub-cap files,
-# and a descendant that ``setsid()``s out of the group escapes the group-kill
-# below. Both are out of scope for an ADVISORY step that runs the repo's OWN
-# test suite (not untrusted code): portable aggregate/tree containment needs
-# cgroups / job-objects unavailable on macOS, and the merge-GATING sibling
-# steps (``full_unit``/``targeted_tests``) run the same suite with NO cap,
-# timeout, or group-kill at all — this step is already strictly more contained.
-#
-# 256 MiB is orders of magnitude above any real ``-q`` suite / diff-cover run
-# or coverage artifact, so it only ever trips on genuinely pathological output.
-_OUTPUT_QUOTA_BYTES = 256 * 1024 * 1024
 
 
 class DiffCoverageStep(Step):
@@ -401,169 +369,73 @@ class DiffCoverageStep(Step):
 def _run_group_bounded(
     cmd: list[str], cwd: str, timeout: int, env: dict[str, str] | None = None
 ) -> subprocess.CompletedProcess[str]:
-    """Run ``cmd`` in its OWN process group with a hard timeout.
+    """Run ``cmd`` with a hard timeout, killing its whole process group on
+    expiry.
 
-    ``subprocess.run(timeout=...)`` SIGKILLs only the direct child on
-    expiry — a timed-out pytest could leave spawned servers/workers alive
-    to contaminate later validation steps (codex #1220). We start the
-    child in a new session (``start_new_session=True`` → new process
-    group) and, on timeout, SIGKILL the WHOLE group so no descendant
-    survives. Re-raises ``subprocess.TimeoutExpired`` so callers keep
-    their existing skip-on-timeout handling.
+    This mirrors the merge-GATING ``full_unit`` step, which runs the SAME
+    pytest suite via a plain ``subprocess.run(capture_output=True, text=True)``
+    — output captured in memory, decoded as text. We add exactly ONE property
+    on top, the one an ADVISORY step actually needs: a hard ``timeout`` so a
+    hung measurement can never wedge the (auto-deploy) pipeline. ``subprocess``'
+    own timeout would SIGKILL only the direct child, so we run the child in a
+    new session (``start_new_session=True`` → new process group) and, on
+    expiry, SIGKILL the WHOLE group (``_kill_group``) so a timed-out pytest
+    can't orphan xdist workers / a serve subprocess into later steps. The
+    ``TimeoutExpired`` is re-raised (with captured output attached) for the
+    caller's skip-on-timeout handling.
 
-    Output is redirected to temp FILES, not PIPEs (codex #1220 r8). This
-    bounds validator memory — a noisy / runaway test streams to disk, and
-    we read back only a capped tail — and, because there are no pipes for a
-    surviving descendant to hold open, it removes the reap-wedge class
-    entirely. The tail keeps the bytes every caller needs — diff-cover's
-    footer and pytest's ``-q`` failure summary both sit at the END of their
-    streams. The two capture files are bounded by the KERNEL, not a userspace
-    poll: the child is spawned under a per-file ``RLIMIT_FSIZE`` of
-    ``_OUTPUT_QUOTA_BYTES``, so a write past the cap is refused at the syscall
-    the instant it happens — no matter how fast the child writes or whether it
-    exits between two userspace polls. A child killed by ``SIGXFSZ`` (or
-    exiting nonzero on ``EFBIG``) then fails the exit-code gate and the run is
-    skipped (codex #1220 r11). The cap is PER-FILE and does not attempt
-    aggregate-bytes or full-descendant-tree containment — see the scope note on
-    ``_OUTPUT_QUOTA_BYTES`` for why that is out of scope for this advisory step
-    (codex #1220 r13). The limit is applied by a tiny exec-based WRAPPER (see
-    ``_rlimit_wrap``) rather than a ``preexec_fn`` callback: ``preexec_fn``
-    runs between fork and exec in a copy of the (possibly multi-threaded)
-    parent's address space, where grabbing an internal lock another thread
-    held at fork can deadlock the child forever — before ``Popen`` even
-    returns, so the timeout above could never fire and the pipeline would
-    wedge. The wrapper instead sets the limit from a FRESH, single-threaded
-    process (post-exec) and then ``exec``s the real command, sidestepping
-    that class entirely (codex #1220 r12).
-
-    On timeout the raised ``TimeoutExpired`` carries the captured (capped)
-    stdout/stderr so the caller can log WHAT hung before the temp files are
-    deleted (codex #1220 r10).
-
-    The isolated group is torn down on EVERY exit path. On timeout/exception
-    ``_kill_group`` SIGKILLs the group BEFORE reaping the leader, so ``pgid``
-    cannot be recycled — unconditionally race-free. On a CLEAN exit
-    ``_sweep_group`` SIGKILLs any process the suite leaked into the group; that
-    is race-free while any member is alive (POSIX keeps the PGID reserved for
-    the group's whole lifetime, so the reaped leader's PID can't be recycled)
-    and a harmless ESRCH when the group is already empty — see the inline note
-    for the negligible reap-vs-recycle residual (codex #1220 r14/r15).
+    Deliberately NOT done, after a long convergence (codex #1220 r8–r16):
+    no ``RLIMIT_FSIZE`` file-size cap (it is inherited by the whole pytest
+    tree and would truncate/corrupt legitimate large writes — e.g. a >256 MiB
+    model shard — codex r16), no temp-file/quota/exec-wrapper machinery, and no
+    clean-exit group sweep (a race-free sweep needs a non-reaping wait absent
+    on macOS; a reap-then-``killpg`` sweep races PID reuse — codex r14/r16).
+    The result is at parity with the merge gate, plus the timeout+group-kill.
+    A setsid-escaping descendant can still survive the group-kill — a
+    fundamental POSIX limitation that the gating siblings don't guard against
+    either (codex r11/r13/r16); portable containment would need cgroups /
+    job-objects unavailable here.
     """
-    # ``start_new_session=True`` runs the child through ``setsid()``: it
-    # leads a brand-new process group whose PGID EQUALS its PID. Capture that
-    # id NOW, not via ``os.getpgid(proc.pid)`` on timeout — by then the leader
-    # may already have exited and ``getpgid`` would raise, leaving the group
-    # un-killed (codex #1220).
-    with tempfile.TemporaryFile() as out_f, tempfile.TemporaryFile() as err_f:
-        proc = subprocess.Popen(  # noqa: S603 — fixed argv, no shell
-            [*_rlimit_wrap(), *cmd],
-            stdout=out_f,
-            stderr=err_f,
-            cwd=cwd,
-            env=env,
-            start_new_session=True,
-        )
-        pgid = proc.pid  # == PGID under start_new_session (setsid)
-        try:
-            proc.wait(timeout=timeout)
-        except subprocess.TimeoutExpired:
-            # Time budget blown: tear the WHOLE group down and re-raise with the
-            # captured tail so the caller can log WHAT hung. ``_kill_group``
-            # SIGKILLs the group BEFORE reaping the leader, so ``pgid`` cannot
-            # have been recycled onto an unrelated group — the kill is race-free
-            # (codex #1220 r14). Disk is handled separately by the kernel RLIMIT.
-            _kill_group(proc, pgid)
-            raise subprocess.TimeoutExpired(
-                cmd,
-                timeout,
-                output=_read_capped(out_f),
-                stderr=_read_capped(err_f),
-            ) from None
-        except BaseException:
-            # Any other escape (e.g. KeyboardInterrupt): tear the group down
-            # (again kill-before-reap, race-free) then re-raise unchanged.
-            _kill_group(proc, pgid)
-            raise
-        # Clean leader exit — but SWEEP the group anyway: a suite that
-        # backgrounds a server/worker can leak it into the isolated group, where
-        # it would survive to hold a capture-file fd or contaminate later steps
-        # (codex #1220 r15). ``_sweep_group`` SIGKILLs the group by ``pgid``.
-        #
-        # This is race-free in the case that MATTERS. POSIX reserves a PGID for
-        # the whole lifetime of its group — until the LAST member leaves — so
-        # while any leaked descendant is still alive the number ``pgid`` cannot
-        # be recycled onto an unrelated process/group, even though the leader is
-        # now reaped (the leader's PID is exactly that reserved PGID). If the
-        # group is instead already empty there is nothing to kill and the call is
-        # a harmless ESRCH; the only residual is the leader's PID being recycled
-        # into a NEW group leader within the microseconds between reap and
-        # ``killpg`` AND the group being empty then — negligible, and strictly
-        # better than leaking a live server into the auto-deploy pipeline (this
-        # is the r14/r15 trade: a non-reaping wait that would remove even that
-        # window needs ``waitid``+``WNOWAIT``, unavailable on macOS).
-        _sweep_group(pgid)
-        return subprocess.CompletedProcess(
-            cmd, proc.returncode, _read_capped(out_f), _read_capped(err_f)
-        )
-
-
-# Wrapper source: a fresh Python process that sets ``RLIMIT_FSIZE`` on ITSELF
-# then ``exec``s the real command (argv after the byte count). rlimits survive
-# ``execve`` and are inherited across ``fork``, so the real command and every
-# descendant it spawns run under the cap. Setting the limit here — post-exec,
-# in a brand-new single-threaded process — avoids the ``preexec_fn`` fork/exec
-# deadlock window entirely (codex #1220 r12). ``os.execvp`` uses an absolute
-# ``argv[0]`` (our commands start with ``sys.executable``) directly.
-_RLIMIT_WRAP_SRC = (
-    "import os,resource,sys;"
-    "n=int(sys.argv[1]);"
-    "resource.setrlimit(resource.RLIMIT_FSIZE,(n,n));"
-    "os.execvp(sys.argv[2],sys.argv[2:])"
-)
-
-
-def _rlimit_wrap() -> list[str]:
-    """Argv prefix that caps the wrapped command's max file size at
-    ``_OUTPUT_QUOTA_BYTES`` (the KERNEL disk backstop; see ``_run_group_bounded``).
-    Built per-call so a test monkeypatching ``_OUTPUT_QUOTA_BYTES`` takes
-    effect. Unix-only, like the rest of this helper (``setsid``/``killpg``).
-
-    ``-I -S`` run the wrapper in ISOLATED startup: ``-I`` drops the CWD (the
-    repo root) and user-site from ``sys.path`` and ignores ``PYTHON*`` env, and
-    ``-S`` skips ``site``/``sitecustomize`` — so no repository-local
-    ``resource.py`` or startup hook can shadow the stdlib ``resource`` module
-    and neuter ``setrlimit`` before the cap is set (codex #1220 r14). The flags
-    apply ONLY to this tiny wrapper; the real command it ``exec``s runs with a
-    normal interpreter and environment (it is meant to import repo code)."""
-    return [
-        sys.executable,
-        "-I",
-        "-S",
-        "-c",
-        _RLIMIT_WRAP_SRC,
-        str(_OUTPUT_QUOTA_BYTES),
-    ]
-
-
-def _sweep_group(pgid: int) -> None:
-    """Best-effort SIGKILL of any process the (cleanly-exited) leader leaked
-    into the isolated group. Callers invoke this only AFTER the leader has
-    exited; it is race-free while any member is still alive (POSIX keeps the
-    PGID reserved until the group's lifetime ends, so the leader's reaped PID
-    cannot be recycled onto an unrelated group), and a harmless ESRCH when the
-    group is already empty — see ``_run_group_bounded`` (codex #1220 r15)."""
+    # ``start_new_session=True`` runs the child through ``setsid()``: it leads a
+    # brand-new process group whose PGID EQUALS its PID. Capture that id NOW,
+    # not via ``os.getpgid(proc.pid)`` on timeout — by then the leader may have
+    # exited and ``getpgid`` would raise, leaving the group un-killed.
+    proc = subprocess.Popen(  # noqa: S603 — fixed argv, no shell
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        errors="replace",  # child output isn't guaranteed valid UTF-8
+        cwd=cwd,
+        env=env,
+        start_new_session=True,
+    )
+    pgid = proc.pid  # == PGID under start_new_session (setsid)
     try:
-        os.killpg(pgid, signal.SIGKILL)
-    except OSError:
-        pass
+        out, err = proc.communicate(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        # Time budget blown: SIGKILL the whole group BEFORE reaping the leader
+        # (race-free — ``pgid`` can't be recycled while a member is alive), then
+        # drain the now-closed pipes and re-raise with the captured output so
+        # the caller can log WHAT hung.
+        _kill_group(proc, pgid)
+        out, err = proc.communicate()
+        raise subprocess.TimeoutExpired(cmd, timeout, output=out, stderr=err) from None
+    except BaseException:
+        # Any other escape (e.g. KeyboardInterrupt): tear the group down so
+        # nothing is orphaned, then re-raise unchanged.
+        _kill_group(proc, pgid)
+        raise
+    return subprocess.CompletedProcess(cmd, proc.returncode, out, err)
 
 
 def _kill_group(proc: subprocess.Popen, pgid: int) -> None:
     """SIGKILL the whole process group, then reap the leader under a bounded
-    wait. With output on temp files (no inherited pipes) there is nothing for
-    a descendant to hold open, so a plain ``wait`` reaps the SIGKILLed leader
-    at once; the bound only guards the near-impossible wedged-leader case so
-    we never hang the auto-deploy pipeline."""
+    wait. SIGKILL is uncatchable so the leader dies at once; the bound only
+    guards the near-impossible wedged-leader case so we never hang the
+    auto-deploy pipeline. Called only on the timeout/exception paths, where the
+    leader is unreaped when ``killpg`` fires — so ``pgid`` can't have been
+    recycled onto an unrelated group (race-free)."""
     try:
         os.killpg(pgid, signal.SIGKILL)
     except OSError:
@@ -576,21 +448,6 @@ def _kill_group(proc: subprocess.Popen, pgid: int) -> None:
         proc.wait(timeout=_REAP_TIMEOUT_S)
     except subprocess.TimeoutExpired:
         pass  # truly wedged leader (near-impossible post-SIGKILL) — give up
-
-
-def _read_capped(f, limit: int = _STDOUT_CAP_BYTES) -> str:
-    """Read back the LAST ``limit`` bytes of a temp file as text. Bounds
-    read-back memory regardless of how much the child wrote, while keeping
-    the stream tail that callers actually parse/log (diff-cover footer,
-    pytest failure summary). Decodes leniently — the file is raw bytes."""
-    f.flush()
-    f.seek(0, os.SEEK_END)
-    size = f.tell()
-    f.seek(max(0, size - limit))
-    data = f.read().decode("utf-8", "replace")
-    if size > limit:
-        return f"…[{size - limit} bytes elided]…\n" + data
-    return data
 
 
 def _path_exists(path: Path | None) -> bool:
@@ -644,10 +501,9 @@ def _pytest_dump(cmd: list[str], proc: subprocess.CompletedProcess[str]) -> str:
 
 
 def _timeout_dump(label: str, cmd: list[str], exc: subprocess.TimeoutExpired) -> str:
-    """Diagnostics for a timed-out child. Preserves the captured tail carried on
-    the exception so the log records WHAT hung before the temp files are deleted
-    (codex #1220 r10). (A disk-cap breach is not routed here — it surfaces as a
-    SIGXFSZ/nonzero exit through the exit-code path, not ``TimeoutExpired``.)"""
+    """Diagnostics for a timed-out child. Preserves the captured (tail-
+    truncated) stdout/stderr carried on the ``TimeoutExpired`` so the log
+    records WHAT hung."""
     return (
         f"# {label} TIMED OUT\n\n"
         f"## cmd\n`{' '.join(cmd)}`\n\n"

--- a/scripts/pr_validate/steps/diff_coverage.py
+++ b/scripts/pr_validate/steps/diff_coverage.py
@@ -90,14 +90,20 @@ class DiffCoverageStep(Step):
         )
 
     def run(self, ctx: Context) -> StepResult:
-        log_path: Path = ctx.artifact_path("diff-coverage.log")
-        # Advisory contract: swallow ALL failures. Never fail/error. The
-        # log write is best-effort (``_safe_write``) so a failure to log
-        # can't escape this handler and become a blocking ``error``.
+        # Advisory contract: swallow ALL failures. Never fail/error.
+        # Resolve the artifact path INSIDE the protected block —
+        # ``artifact_path()`` does a ``mkdir`` that can itself raise on
+        # disk-full / permission errors, and even that must not escape
+        # through ``execute()`` as a blocking ``error`` (codex #1220).
+        # The fallback tolerates ``log_path`` never getting assigned.
+        log_path: Path | None = None
         try:
+            log_path = ctx.artifact_path("diff-coverage.log")
             return self._measure(ctx, log_path)
         except Exception as e:  # noqa: BLE001 — advisory must not block merge
-            _safe_write(log_path, traceback.format_exc())
+            # ``_safe_write`` never raises; guard the path being unset too.
+            if log_path is not None:
+                _safe_write(log_path, traceback.format_exc())
             return self._skip(
                 f"advisory coverage skipped (internal error: {type(e).__name__}: {e})",
                 log_path,
@@ -216,6 +222,19 @@ class DiffCoverageStep(Step):
             + "\n## diff-cover stderr\n"
             + (dc_proc.stderr or ""),
         )
+
+        # A nonzero diff-cover exit means it errored (bad XML, git
+        # failure, interrupted) — even if it happened to print a footer
+        # first, that number is not trustworthy. Skip BEFORE parsing so a
+        # failed run can't publish a misleading success (codex #1220).
+        # Verified exit codes: scored-lines=0, no-lines=0, bad-xml=1,
+        # bad-branch=1 — so this never false-skips the happy path.
+        if dc_proc.returncode != 0:
+            return self._skip(
+                f"advisory coverage skipped (diff-cover exit "
+                f"{dc_proc.returncode} — not scored)",
+                log_path,
+            )
 
         parsed = _parse_diff_cover(dc_proc.stdout)
         if parsed is None:

--- a/scripts/pr_validate/steps/diff_coverage.py
+++ b/scripts/pr_validate/steps/diff_coverage.py
@@ -142,11 +142,14 @@ class DiffCoverageStep(Step):
             return self._measure(ctx, log_path)
         except Exception as e:  # noqa: BLE001 — advisory must not block merge
             # ``_safe_write`` never raises; guard the path being unset too.
-            if log_path is not None:
-                _safe_write(log_path, traceback.format_exc())
+            # Attach the log ONLY if this handler actually wrote it — never a
+            # stale prior-run file (codex #1220 r19).
+            wrote = log_path is not None and _safe_write(
+                log_path, traceback.format_exc()
+            )
             return self._skip(
                 f"advisory coverage skipped (internal error: {type(e).__name__}: {e})",
-                log_path,
+                log_path if wrote else None,
             )
 
     # ------------------------------------------------------------------
@@ -221,11 +224,13 @@ class DiffCoverageStep(Step):
                 pytest_cmd, str(ctx.repo_root), _PYTEST_TIMEOUT_S, env=cov_env
             )
         except subprocess.TimeoutExpired as exc:
-            _safe_write(log_path, _timeout_dump("instrumented pytest", pytest_cmd, exc))
+            wrote = _safe_write(
+                log_path, _timeout_dump("instrumented pytest", pytest_cmd, exc)
+            )
             return self._skip(
                 f"advisory coverage skipped (instrumented suite exceeded "
                 f"{_PYTEST_TIMEOUT_S}s — process group killed)",
-                log_path,
+                log_path if wrote else None,
             )
 
         # 3. Coverage trust model (see ``_PYTEST_COVERAGE_VALID_EXITS``). We
@@ -237,19 +242,20 @@ class DiffCoverageStep(Step):
         #    leaves them uncovered, which is honest advisory signal, not
         #    contamination; the caveat below flags that the % may under-count.
         if pytest_proc.returncode not in _PYTEST_COVERAGE_VALID_EXITS:
-            _safe_write(log_path, _pytest_dump(pytest_cmd, pytest_proc))
+            wrote = _safe_write(log_path, _pytest_dump(pytest_cmd, pytest_proc))
             return self._skip(
                 f"advisory coverage skipped (instrumented suite exit "
                 f"{pytest_proc.returncode} — interrupted/error, not merely "
                 f"test failures; see full_unit)",
-                log_path,
+                log_path if wrote else None,
             )
         suite_had_failures = pytest_proc.returncode == 1
 
         if not xml_path.exists():
-            _safe_write(log_path, _pytest_dump(pytest_cmd, pytest_proc))
+            wrote = _safe_write(log_path, _pytest_dump(pytest_cmd, pytest_proc))
             return self._skip(
-                "advisory coverage skipped (no coverage.xml produced)", log_path
+                "advisory coverage skipped (no coverage.xml produced)",
+                log_path if wrote else None,
             )
 
         # 4. diff-cover: patch coverage of the changed lines vs the PR's
@@ -278,17 +284,19 @@ class DiffCoverageStep(Step):
                 dc_cmd, str(ctx.repo_root), _DIFF_COVER_TIMEOUT_S
             )
         except subprocess.TimeoutExpired as exc:
-            _safe_write(log_path, _timeout_dump("diff-cover", dc_cmd, exc))
+            wrote = _safe_write(log_path, _timeout_dump("diff-cover", dc_cmd, exc))
             return self._skip(
                 f"advisory coverage skipped (diff-cover exceeded "
                 f"{_DIFF_COVER_TIMEOUT_S}s — process group killed)",
-                log_path,
+                log_path if wrote else None,
             )
 
         # Record pytest's own output too (tail-truncated) — on an accepted
         # exit-1 measurement the reader needs to see WHICH tests failed and
-        # why, not just the bare exit code (codex #1220 r5 nit).
-        _safe_write(
+        # why, not just the bare exit code (codex #1220 r5 nit). ``wrote_log``
+        # governs whether every downstream skip / the final pass advertises
+        # this file, so a stale prior-run log is never attached (codex r19).
+        wrote_log = _safe_write(
             log_path,
             "# diff_coverage advisory run\n\n"
             f"## pytest cmd\n`{' '.join(pytest_cmd)}`\n\n"
@@ -304,6 +312,7 @@ class DiffCoverageStep(Step):
             + "\n## diff-cover stderr\n"
             + (dc_proc.stderr or ""),
         )
+        log_artifact = log_path if wrote_log else None
 
         # A nonzero diff-cover exit means it errored (bad XML, git
         # failure, interrupted) — even if it happened to print a footer
@@ -315,7 +324,7 @@ class DiffCoverageStep(Step):
             return self._skip(
                 f"advisory coverage skipped (diff-cover exit "
                 f"{dc_proc.returncode} — not scored)",
-                log_path,
+                log_artifact,
             )
 
         parsed = _parse_diff_cover(dc_proc.stdout)
@@ -325,7 +334,7 @@ class DiffCoverageStep(Step):
             # coverage source map). Nothing to report — clean skip.
             return self._skip(
                 "advisory coverage skipped (no measurable production lines in diff)",
-                log_path,
+                log_artifact,
             )
         if parsed is _PARSE_FAILED:
             # diff-cover exited 0 but we recognized NEITHER its explicit
@@ -338,7 +347,7 @@ class DiffCoverageStep(Step):
                 "advisory coverage skipped (diff-cover output format "
                 "unrecognized — parser may need updating for this diff-cover "
                 "version)",
-                log_path,
+                log_artifact,
             )
 
         pct, covered, total = parsed
@@ -378,19 +387,28 @@ class DiffCoverageStep(Step):
             status="pass",  # ALWAYS pass — advisory
             summary=summary,
             findings=[finding],
-            # Advertise only artifacts that actually made it to disk —
-            # ``_safe_write`` may have swallowed a log write failure, and the
-            # existence probe itself must not raise (codex #1220 r8), mirroring
-            # the skip path's guard.
-            artifacts=[str(p) for p in (log_path, xml_path) if _path_exists(p)],
+            # Advertise the log ONLY if THIS run wrote it (``wrote_log``), never
+            # a stale prior-run file that survived a failed unlink (codex #1220
+            # r19). ``xml_path`` still uses the never-raising existence probe —
+            # it was freshly (re)generated by this run's pytest above.
+            artifacts=[
+                str(p)
+                for p, keep in (
+                    (log_path, wrote_log),
+                    (xml_path, _path_exists(xml_path)),
+                )
+                if keep
+            ],
         )
 
     # ------------------------------------------------------------------
 
     def _skip(self, summary: str, log_path: Path | None = None) -> StepResult:
-        """Uniform advisory skip. Attaches the log artifact only when it
-        actually made it to disk (``_safe_write`` may have swallowed a
-        write error)."""
+        """Uniform advisory skip. Callers pass ``log_path`` ONLY when this run's
+        ``_safe_write`` returned success (so it holds this-run content, never a
+        stale prior-run file — codex #1220 r19); ``None`` otherwise. The
+        ``_path_exists`` guard is then belt-and-braces against the file vanishing
+        between the write and here, and must itself never raise."""
         return StepResult(
             name=self.name,
             status="skip",
@@ -474,35 +492,40 @@ def _run_group_bounded(
         SIGKILLs only the direct child, so a timed-out pytest could orphan xdist
         workers / a serve subprocess into later steps. The child leads a new
         session (``start_new_session=True`` → its own process group) and on
-        expiry we SIGKILL the WHOLE group (``_kill_group``). The
-        ``TimeoutExpired`` is re-raised (with the captured tail attached) for the
-        caller's skip-on-timeout handling.
+        expiry we SIGKILL the WHOLE group (``_kill_group``) BEFORE reaping the
+        leader — race-free, because the unreaped leader keeps its PGID reserved
+        (POSIX) so ``killpg`` can't hit a recycled group. The ``TimeoutExpired``
+        is re-raised (with the captured tail attached) for skip-on-timeout.
       * **bounded capture.** Two ``_TailReader`` threads keep only the last
         ~``_CAPTURE_TAIL_BYTES`` per stream instead of ``communicate()``
         buffering the entire (up-to-30-min) suite output in memory, which a
         runaway test could grow until it OOM-kills the validator before its
         advisory handler runs (codex #1220 r17).
-      * **bounded, leak-free teardown (codex #1220 r18).** After the leader
-        exits — cleanly or on timeout — we ``join`` the readers under
-        ``_REAP_TIMEOUT_S``. If a reader is still alive afterwards, that PROVES a
-        descendant is still holding the pipe write-end open, i.e. a group member
-        is alive; POSIX keeps the PGID reserved while any member lives, so
-        ``killpg(pgid)`` then targets exactly this group even though the leader
-        was already reaped — race-free, no PID-reuse hazard. That kill both
-        reaps the leaked descendant (fixing the clean-path leak the prior
-        ``proc.wait``-only design left) and unblocks the reader so its buffer is
-        safe to read. We never block indefinitely: a second bounded join and a
-        lock-guarded ``text()`` snapshot follow.
+      * **bounded, never-wedge drain.** After the leader exits we ``join`` the
+        readers under ``_REAP_TIMEOUT_S`` and return the (lock-guarded) tail
+        even if a reader is still blocked — a setsid-escaped descendant holding
+        the pipe can't wedge the pipeline. The stuck reader is a harmless daemon
+        thread reaped at interpreter exit.
 
-    Deliberately NOT done, after a long convergence (codex #1220 r8–r18): no
-    ``RLIMIT_FSIZE`` file-size cap (inherited by the whole pytest tree, it would
-    truncate/corrupt legitimate large writes — e.g. a >256 MiB model shard —
-    codex r16), no temp-file/quota/exec-wrapper machinery. The one residual gap
-    is fundamental and shared with the gating siblings: a descendant that BOTH
-    ``setsid()``-escapes the group AND closes the inherited pipes leaves no
-    race-free signal to find it on macOS (no cgroups / job objects, no
-    non-reaping group wait), so — like ``full_unit``'s bare ``subprocess.run`` —
-    it can outlive the run.
+    Deliberately NOT done, after a long convergence (codex #1220 r8–r19):
+
+      * No ``RLIMIT_FSIZE`` file-size cap (inherited by the whole pytest tree,
+        it would truncate/corrupt legitimate large writes — e.g. a >256 MiB
+        model shard — codex r16), no temp-file/quota/exec-wrapper machinery.
+      * **No group sweep on the CLEAN-exit path** (codex #1220 r19). Once
+        ``proc.wait`` has reaped the leader, ``killpg(pgid)`` is NOT safe: a
+        descendant can ``setsid()`` into its OWN group while still holding the
+        pipe, so the original PGID can be empty-and-recycled even though a reader
+        is still blocked — the kill would then land on an UNRELATED group
+        (potentially an operator service). This is a genuine dilemma with no
+        race-free resolution on macOS (no cgroups / job objects, no non-reaping
+        group wait): sweeping risks a wrong-group SIGKILL, not-sweeping may leak
+        an escaped descendant. We take the strictly-safer horn — never
+        wrong-kill — and accept the leak, which is anyway at PARITY with the
+        gating ``full_unit`` (its bare ``subprocess.run`` leaks escaped
+        descendants too, and additionally has no timeout so it would simply hang
+        here). ``killpg`` therefore fires ONLY from ``_kill_group`` on the
+        timeout / exception paths, where the leader is still unreaped.
     """
     # ``start_new_session=True`` runs the child through ``setsid()``: it leads a
     # brand-new process group whose PGID EQUALS its PID. Capture that id NOW,
@@ -518,52 +541,56 @@ def _run_group_bounded(
         start_new_session=True,
     )
     pgid = proc.pid  # == PGID under start_new_session (setsid)
-    r_out = _TailReader(proc.stdout)
-    r_err = _TailReader(proc.stderr)
-    r_out.start()
-    r_err.start()
-
-    def _settle_readers() -> None:
-        # Bounded drain, then a race-free group sweep IFF a reader is still
-        # blocked. A live reader ⇒ a descendant still holds the pipe write-end
-        # ⇒ a group member is alive ⇒ the PGID is still reserved (POSIX), so the
-        # ``killpg`` cannot hit a recycled group even though the leader may be
-        # reaped. The kill reaps the leaked descendant AND unblocks the reader;
-        # the final bounded join then returns promptly. If the reader is STILL
-        # alive (uninterruptible read — near-impossible post-SIGKILL) we give up
-        # and return the partial tail rather than block the pipeline; ``text()``
-        # is lock-guarded so reading it is safe regardless.
-        r_out.join(_REAP_TIMEOUT_S)
-        r_err.join(_REAP_TIMEOUT_S)
-        if r_out.alive() or r_err.alive():
+    # Everything after ``Popen`` runs under a guard: if starting the reader
+    # threads fails (e.g. ``RuntimeError: can't start new thread`` under thread
+    # exhaustion), the child is already running with open pipes — tear the group
+    # down and close the pipes rather than leak it, then re-raise so ``run``
+    # downgrades to an advisory skip (codex #1220 r19).
+    try:
+        r_out = _TailReader(proc.stdout)
+        r_err = _TailReader(proc.stderr)
+        r_out.start()
+        r_err.start()
+    except BaseException:
+        _kill_group(proc, pgid)
+        for pipe in (proc.stdout, proc.stderr):
             try:
-                os.killpg(pgid, signal.SIGKILL)
+                pipe.close()
             except OSError:
                 pass
-            r_out.join(_REAP_TIMEOUT_S)
-            r_err.join(_REAP_TIMEOUT_S)
+        raise
+
+    def _join_readers() -> None:
+        # Bounded on purpose. On clean exit the pipes hit EOF the moment the last
+        # writer dies, so both joins return at once; the bound only bites when a
+        # setsid-escaped descendant still holds a write end — we then return the
+        # partial tail rather than block the pipeline (codex #1220 r19). We do
+        # NOT ``killpg`` here: post-reap the PGID may be recycled (see docstring).
+        r_out.join(_REAP_TIMEOUT_S)
+        r_err.join(_REAP_TIMEOUT_S)
 
     try:
         proc.wait(timeout=timeout)
     except subprocess.TimeoutExpired:
         # Time budget blown: SIGKILL the whole group BEFORE reaping the leader
         # (race-free — ``pgid`` can't be recycled while the unreaped leader is a
-        # member), settle the readers, and re-raise with the captured tail so
+        # member), drain under a bound, and re-raise with the captured tail so
         # the caller can log WHAT hung.
         _kill_group(proc, pgid)
-        _settle_readers()
+        _join_readers()
         raise subprocess.TimeoutExpired(
             cmd, timeout, output=r_out.text(), stderr=r_err.text()
         ) from None
     except BaseException:
         # Any other escape (e.g. KeyboardInterrupt): tear the group down so
-        # nothing is orphaned, settle, then re-raise unchanged.
+        # nothing is orphaned, drain under a bound, then re-raise unchanged.
         _kill_group(proc, pgid)
-        _settle_readers()
+        _join_readers()
         raise
-    # Clean exit: leader already reaped by ``proc.wait``. ``_settle_readers``
-    # still sweeps any lingering pipe-holding descendant race-free (see above).
-    _settle_readers()
+    # Clean exit: leader already reaped by ``proc.wait``. Drain the readers under
+    # a bound and return — no group sweep here (post-reap PGID-recycle hazard;
+    # see docstring). A lingering pipe-holder leaks at gate parity, never wedges.
+    _join_readers()
     return subprocess.CompletedProcess(cmd, proc.returncode, r_out.text(), r_err.text())
 
 
@@ -603,11 +630,19 @@ def _path_exists(path: Path | None) -> bool:
         return False
 
 
-def _safe_write(path: Path, text: str) -> None:
-    """Best-effort diagnostic write. NEVER raises. An advisory step must
+def _safe_write(path: Path, text: str) -> bool:
+    """Best-effort diagnostic write. NEVER raises. Returns ``True`` iff THIS
+    call successfully replaced ``path`` with ``text``. An advisory step must
     still return skip/pass even if it can't write its own log (disk full,
     permissions) — otherwise a failing write inside an exception handler
     would escape as a blocking ``error`` (codex review on #1220).
+
+    The boolean is what lets callers advertise the log ONLY when this run
+    actually wrote it: a mere ``path.exists()`` can be true because a prior
+    run's file survived (the run-start unlink is itself best-effort and can
+    fail), which would attach STALE diagnostics as if they were this run's
+    (codex #1220 r19). On failure we also best-effort unlink any such stale
+    file so it can't linger, but the return value is the authoritative signal.
 
     Writes explicitly as UTF-8 with ``errors="replace"``: the default
     locale encoding can be ASCII on some CI, and our diagnostics contain
@@ -617,8 +652,15 @@ def _safe_write(path: Path, text: str) -> None:
     r10). We also catch ``UnicodeError`` belt-and-braces."""
     try:
         path.write_text(text, encoding="utf-8", errors="replace")
+        return True
     except (OSError, UnicodeError):
-        pass
+        # Couldn't write fresh content — make sure no stale prior-run file is
+        # left behind to be mistaken for this run's (best-effort).
+        try:
+            path.unlink(missing_ok=True)
+        except OSError:
+            pass
+        return False
 
 
 def _tail(text: str | None, limit: int = _LOG_TAIL_CHARS) -> str:

--- a/scripts/pr_validate/steps/diff_coverage.py
+++ b/scripts/pr_validate/steps/diff_coverage.py
@@ -37,12 +37,14 @@ error while logging must not escape as a blocking ``error`` either).
 
 from __future__ import annotations
 
+import collections
 import importlib.util
 import os
 import re
 import signal
 import subprocess
 import sys
+import threading
 import traceback
 from pathlib import Path
 
@@ -79,6 +81,17 @@ _PYTEST_COVERAGE_VALID_EXITS = (0, 1)
 # descendant that inherited the pipes is wedged in an uninterruptible
 # syscall — we must never block the (auto-deploy) pipeline waiting on it.
 _REAP_TIMEOUT_S = 10
+
+# Bounded in-memory capture per stream. A plain ``communicate()`` buffers the
+# ENTIRE suite output for up to ``_PYTEST_TIMEOUT_S``, so a test that streams
+# gigabytes to stdout could OOM-kill the validator before its advisory handler
+# runs (codex #1220 r17). Instead each stream is drained by a reader thread that
+# keeps only the last ~``_CAPTURE_TAIL_BYTES`` — memory stays bounded no matter
+# the volume, while the END (diff-cover's footer, pytest's ``-q`` summary) is
+# always retained. 1 MiB is far more than any well-behaved run emits, yet a
+# hard ceiling against a runaway.
+_CAPTURE_TAIL_BYTES = 1_048_576
+_CAPTURE_BLOCK_BYTES = 65536  # pipe read granularity
 
 # Keep the diagnostic log readable — we tail (not head) subprocess output so
 # the most recent lines (pytest's failure summary) always survive truncation.
@@ -178,10 +191,18 @@ class DiffCoverageStep(Step):
 
         # 2. Instrumented suite — mirrors ``full_unit``'s selection so the
         #    coverage picture matches what we actually gate on.
+        #    ``-o addopts=`` clears any repo-level ``addopts`` from
+        #    pyproject.toml / pytest.ini: stripping the ENV var alone is not
+        #    enough — a configured ``-x`` / ``--maxfail`` would stop the suite
+        #    early and hand us partial exit-1 coverage that we would then
+        #    publish as the PR's number. With this override the argv here is the
+        #    complete, self-contained spec of the run (codex #1220 r17).
         pytest_cmd = [
             sys.executable,
             "-m",
             "pytest",
+            "-o",
+            "addopts=",
             "tests/",
             "--ignore=tests/integrations",
             "--ignore=tests/test_event_loop.py",
@@ -366,67 +387,138 @@ class DiffCoverageStep(Step):
         )
 
 
+def _drain_tail(pipe, chunks: collections.deque) -> None:
+    """Reader thread: stream ``pipe`` in fixed blocks, retaining only the last
+    ~``_CAPTURE_TAIL_BYTES`` in ``chunks``. The MIDDLE of a runaway stream is
+    dropped so validator memory stays bounded regardless of total volume (codex
+    #1220 r17), while the END — where diff-cover's footer / pytest's ``-q``
+    summary live — is always kept.
+
+    Draining concurrently (rather than after the process exits) is also what
+    keeps a chatty child from deadlocking on a full 64 KiB kernel pipe buffer.
+    Runs to EOF, which the child's exit — or the group SIGKILL closing every
+    write end — delivers; a stuck reader (a setsid-escapee still holding the
+    write end) is a harmless daemon thread the caller stops ``join``-ing after a
+    bound, never a hang."""
+    try:
+        for block in iter(lambda: pipe.read(_CAPTURE_BLOCK_BYTES), b""):
+            chunks.append(block)
+            # Drop whole oldest blocks while the retained tail (excluding the
+            # newest block) still exceeds the cap. Keep >=1 block so a stream we
+            # actually read is never emptied.
+            retained = sum(len(c) for c in chunks)
+            while len(chunks) > 1 and retained - len(chunks[0]) >= _CAPTURE_TAIL_BYTES:
+                retained -= len(chunks.popleft())
+    except (OSError, ValueError):
+        # Pipe closed under us / read on a closed fd — nothing left to drain.
+        pass
+    finally:
+        try:
+            pipe.close()
+        except OSError:
+            pass
+
+
+def _joined(chunks: collections.deque) -> str:
+    """Decode the retained byte tail. ``errors='replace'`` because child output
+    isn't guaranteed valid UTF-8 and a block boundary may split a multibyte
+    sequence — a torn edge byte becomes U+FFFD, never an exception."""
+    return b"".join(chunks).decode("utf-8", "replace")
+
+
 def _run_group_bounded(
     cmd: list[str], cwd: str, timeout: int, env: dict[str, str] | None = None
 ) -> subprocess.CompletedProcess[str]:
     """Run ``cmd`` with a hard timeout, killing its whole process group on
-    expiry.
+    expiry, capturing a BOUNDED tail of each stream.
 
-    This mirrors the merge-GATING ``full_unit`` step, which runs the SAME
-    pytest suite via a plain ``subprocess.run(capture_output=True, text=True)``
-    — output captured in memory, decoded as text. We add exactly ONE property
-    on top, the one an ADVISORY step actually needs: a hard ``timeout`` so a
-    hung measurement can never wedge the (auto-deploy) pipeline. ``subprocess``'
-    own timeout would SIGKILL only the direct child, so we run the child in a
-    new session (``start_new_session=True`` → new process group) and, on
-    expiry, SIGKILL the WHOLE group (``_kill_group``) so a timed-out pytest
-    can't orphan xdist workers / a serve subprocess into later steps. The
-    ``TimeoutExpired`` is re-raised (with captured output attached) for the
-    caller's skip-on-timeout handling.
+    Like the merge-GATING ``full_unit`` step this runs the SAME pytest suite and
+    returns a ``CompletedProcess`` with text stdout/stderr. It adds the two
+    properties an ADVISORY step in an auto-deploy pipeline needs and the gate
+    does not:
 
-    Deliberately NOT done, after a long convergence (codex #1220 r8–r16):
-    no ``RLIMIT_FSIZE`` file-size cap (it is inherited by the whole pytest
-    tree and would truncate/corrupt legitimate large writes — e.g. a >256 MiB
-    model shard — codex r16), no temp-file/quota/exec-wrapper machinery, and no
-    clean-exit group sweep (a race-free sweep needs a non-reaping wait absent
-    on macOS; a reap-then-``killpg`` sweep races PID reuse — codex r14/r16).
-    The result is at parity with the merge gate, plus the timeout+group-kill.
-    A setsid-escaping descendant can still survive the group-kill — a
-    fundamental POSIX limitation that the gating siblings don't guard against
-    either (codex r11/r13/r16); portable containment would need cgroups /
-    job-objects unavailable here.
+      * **hard timeout + whole-group kill.** ``subprocess``'s own timeout
+        SIGKILLs only the direct child, so a timed-out pytest could orphan xdist
+        workers / a serve subprocess into later steps. The child leads a new
+        session (``start_new_session=True`` → its own process group) and on
+        expiry we SIGKILL the WHOLE group (``_kill_group``). The
+        ``TimeoutExpired`` is re-raised (with the captured tail attached) for the
+        caller's skip-on-timeout handling.
+      * **bounded capture + bounded drain.** Two reader threads keep only the
+        last ~``_CAPTURE_TAIL_BYTES`` per stream instead of ``communicate()``
+        buffering the entire (up-to-30-min) suite output in memory, which a
+        runaway test could grow until it OOM-kills the validator before its
+        advisory handler runs (codex #1220 r17). The threads also make the
+        post-kill drain BOUNDED: we ``join`` them under ``_REAP_TIMEOUT_S`` and
+        proceed with whatever tail we have, so a setsid-escaped descendant still
+        holding a pipe write-end cannot wedge the never-block contract — the
+        unbounded second ``communicate()`` of the prior design could (codex
+        #1220 r17). A stuck reader is a daemon thread reaped at interpreter exit.
+
+    Deliberately NOT done, after a long convergence (codex #1220 r8–r17): no
+    ``RLIMIT_FSIZE`` file-size cap (inherited by the whole pytest tree, it would
+    truncate/corrupt legitimate large writes — e.g. a >256 MiB model shard —
+    codex r16), no temp-file/quota/exec-wrapper machinery. A setsid-escaping
+    descendant can still SURVIVE the group-kill — a fundamental POSIX limitation
+    the gating siblings don't guard against either (codex r11/r13/r16); portable
+    containment would need cgroups / job-objects unavailable here.
     """
     # ``start_new_session=True`` runs the child through ``setsid()``: it leads a
     # brand-new process group whose PGID EQUALS its PID. Capture that id NOW,
     # not via ``os.getpgid(proc.pid)`` on timeout — by then the leader may have
-    # exited and ``getpgid`` would raise, leaving the group un-killed.
+    # exited and ``getpgid`` would raise, leaving the group un-killed. Binary
+    # pipes (no ``text=``): the reader threads decode the retained tail.
     proc = subprocess.Popen(  # noqa: S603 — fixed argv, no shell
         cmd,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
-        text=True,
-        errors="replace",  # child output isn't guaranteed valid UTF-8
         cwd=cwd,
         env=env,
         start_new_session=True,
     )
     pgid = proc.pid  # == PGID under start_new_session (setsid)
+    out_chunks: collections.deque = collections.deque()
+    err_chunks: collections.deque = collections.deque()
+    t_out = threading.Thread(
+        target=_drain_tail, args=(proc.stdout, out_chunks), daemon=True
+    )
+    t_err = threading.Thread(
+        target=_drain_tail, args=(proc.stderr, err_chunks), daemon=True
+    )
+    t_out.start()
+    t_err.start()
+
+    def _join_readers() -> None:
+        # Bounded on purpose. On clean exit the pipes hit EOF the moment the
+        # child dies, so both joins return at once; after a group SIGKILL EOF
+        # arrives when the last writer dies. The bound only bites when a
+        # setsid-escapee still holds a write end — we then proceed with the
+        # partial tail rather than block the pipeline (codex #1220 r17).
+        t_out.join(_REAP_TIMEOUT_S)
+        t_err.join(_REAP_TIMEOUT_S)
+
     try:
-        out, err = proc.communicate(timeout=timeout)
+        proc.wait(timeout=timeout)
     except subprocess.TimeoutExpired:
         # Time budget blown: SIGKILL the whole group BEFORE reaping the leader
-        # (race-free — ``pgid`` can't be recycled while a member is alive), then
-        # drain the now-closed pipes and re-raise with the captured output so
-        # the caller can log WHAT hung.
+        # (race-free — ``pgid`` can't be recycled while a member is alive), let
+        # the readers drain the now-EOF pipes under a bound, and re-raise with
+        # the captured tail so the caller can log WHAT hung.
         _kill_group(proc, pgid)
-        out, err = proc.communicate()
-        raise subprocess.TimeoutExpired(cmd, timeout, output=out, stderr=err) from None
+        _join_readers()
+        raise subprocess.TimeoutExpired(
+            cmd, timeout, output=_joined(out_chunks), stderr=_joined(err_chunks)
+        ) from None
     except BaseException:
         # Any other escape (e.g. KeyboardInterrupt): tear the group down so
-        # nothing is orphaned, then re-raise unchanged.
+        # nothing is orphaned, drain under a bound, then re-raise unchanged.
         _kill_group(proc, pgid)
+        _join_readers()
         raise
-    return subprocess.CompletedProcess(cmd, proc.returncode, out, err)
+    _join_readers()
+    return subprocess.CompletedProcess(
+        cmd, proc.returncode, _joined(out_chunks), _joined(err_chunks)
+    )
 
 
 def _kill_group(proc: subprocess.Popen, pgid: int) -> None:

--- a/scripts/pr_validate/steps/diff_coverage.py
+++ b/scripts/pr_validate/steps/diff_coverage.py
@@ -342,9 +342,21 @@ class DiffCoverageStep(Step):
             )
 
         pct, covered, total = parsed
+        # Exit-1 caveat. We deliberately don't try to CLASSIFY exit 1 into
+        # "isolated flaky failures" vs "a session-scoped fixture error that
+        # wiped out every test" (codex #1220 r18 nit) — that would mean parsing
+        # pytest's summary text, which is exactly the brittle heuristic this
+        # step avoids. Instead we tag EVERY exit-1 measurement as caveated so
+        # the human building the baseline distribution can exclude it: a
+        # widespread setup failure that drives the % near zero is the extreme
+        # end of the same "a failing test left changed lines uncovered" signal,
+        # and caveated runs are precisely the ones to drop before deciding a
+        # threshold. The raw pytest tail is in the log for that judgement.
         caveat = (
-            " NOTE: some unit tests failed this run (see full_unit) — the % "
-            "may under-count lines a failing test would otherwise have covered."
+            " NOTE: some unit tests failed this run (see full_unit) — the % may "
+            "under-count lines a failing test would otherwise have covered; a "
+            "widespread setup/session-fixture failure can drive it near zero, so "
+            "EXCLUDE caveated runs from the baseline distribution."
             if suite_had_failures
             else ""
         )
@@ -387,43 +399,64 @@ class DiffCoverageStep(Step):
         )
 
 
-def _drain_tail(pipe, chunks: collections.deque) -> None:
-    """Reader thread: stream ``pipe`` in fixed blocks, retaining only the last
-    ~``_CAPTURE_TAIL_BYTES`` in ``chunks``. The MIDDLE of a runaway stream is
-    dropped so validator memory stays bounded regardless of total volume (codex
-    #1220 r17), while the END — where diff-cover's footer / pytest's ``-q``
-    summary live — is always kept.
+class _TailReader:
+    """Drains one pipe on a daemon thread, retaining only the last
+    ~``_CAPTURE_TAIL_BYTES``. The MIDDLE of a runaway stream is discarded so
+    validator memory stays bounded regardless of total volume (codex #1220 r17),
+    while the END — where diff-cover's footer / pytest's ``-q`` summary live — is
+    always kept.
 
     Draining concurrently (rather than after the process exits) is also what
-    keeps a chatty child from deadlocking on a full 64 KiB kernel pipe buffer.
-    Runs to EOF, which the child's exit — or the group SIGKILL closing every
-    write end — delivers; a stuck reader (a setsid-escapee still holding the
-    write end) is a harmless daemon thread the caller stops ``join``-ing after a
-    bound, never a hang."""
-    try:
-        for block in iter(lambda: pipe.read(_CAPTURE_BLOCK_BYTES), b""):
-            chunks.append(block)
-            # Drop whole oldest blocks while the retained tail (excluding the
-            # newest block) still exceeds the cap. Keep >=1 block so a stream we
-            # actually read is never emptied.
-            retained = sum(len(c) for c in chunks)
-            while len(chunks) > 1 and retained - len(chunks[0]) >= _CAPTURE_TAIL_BYTES:
-                retained -= len(chunks.popleft())
-    except (OSError, ValueError):
-        # Pipe closed under us / read on a closed fd — nothing left to drain.
-        pass
-    finally:
+    stops a chatty child deadlocking on a full 64 KiB kernel pipe buffer. All
+    access to the retained chunks is under ``_lock`` so ``text()`` can snapshot
+    the tail race-free even if the reader thread is still running — otherwise a
+    concurrent ``append``/``popleft`` would raise ``RuntimeError: deque mutated
+    during iteration`` mid-``b"".join`` (codex #1220 r18)."""
+
+    def __init__(self, pipe) -> None:
+        self._pipe = pipe
+        self._lock = threading.Lock()
+        self._chunks: collections.deque = collections.deque()
+        self._thread = threading.Thread(target=self._run, daemon=True)
+
+    def start(self) -> None:
+        self._thread.start()
+
+    def _run(self) -> None:
         try:
-            pipe.close()
-        except OSError:
+            for block in iter(lambda: self._pipe.read(_CAPTURE_BLOCK_BYTES), b""):
+                with self._lock:
+                    self._chunks.append(block)
+                    # Drop whole oldest blocks while the tail (excluding the
+                    # newest block) still exceeds the cap. Keep >=1 block so a
+                    # stream we actually read is never emptied.
+                    retained = sum(len(c) for c in self._chunks)
+                    while (
+                        len(self._chunks) > 1
+                        and retained - len(self._chunks[0]) >= _CAPTURE_TAIL_BYTES
+                    ):
+                        retained -= len(self._chunks.popleft())
+        except (OSError, ValueError):
+            # Pipe closed under us / read on a closed fd — nothing left to drain.
             pass
+        finally:
+            try:
+                self._pipe.close()
+            except OSError:
+                pass
 
+    def join(self, timeout: float) -> None:
+        self._thread.join(timeout)
 
-def _joined(chunks: collections.deque) -> str:
-    """Decode the retained byte tail. ``errors='replace'`` because child output
-    isn't guaranteed valid UTF-8 and a block boundary may split a multibyte
-    sequence — a torn edge byte becomes U+FFFD, never an exception."""
-    return b"".join(chunks).decode("utf-8", "replace")
+    def alive(self) -> bool:
+        return self._thread.is_alive()
+
+    def text(self) -> str:
+        """Decode the retained byte tail under the lock. ``errors='replace'``
+        because child output isn't guaranteed valid UTF-8 and a block boundary
+        may split a multibyte sequence — a torn edge byte becomes U+FFFD."""
+        with self._lock:
+            return b"".join(self._chunks).decode("utf-8", "replace")
 
 
 def _run_group_bounded(
@@ -433,7 +466,7 @@ def _run_group_bounded(
     expiry, capturing a BOUNDED tail of each stream.
 
     Like the merge-GATING ``full_unit`` step this runs the SAME pytest suite and
-    returns a ``CompletedProcess`` with text stdout/stderr. It adds the two
+    returns a ``CompletedProcess`` with text stdout/stderr. It adds the
     properties an ADVISORY step in an auto-deploy pipeline needs and the gate
     does not:
 
@@ -444,24 +477,32 @@ def _run_group_bounded(
         expiry we SIGKILL the WHOLE group (``_kill_group``). The
         ``TimeoutExpired`` is re-raised (with the captured tail attached) for the
         caller's skip-on-timeout handling.
-      * **bounded capture + bounded drain.** Two reader threads keep only the
-        last ~``_CAPTURE_TAIL_BYTES`` per stream instead of ``communicate()``
+      * **bounded capture.** Two ``_TailReader`` threads keep only the last
+        ~``_CAPTURE_TAIL_BYTES`` per stream instead of ``communicate()``
         buffering the entire (up-to-30-min) suite output in memory, which a
         runaway test could grow until it OOM-kills the validator before its
-        advisory handler runs (codex #1220 r17). The threads also make the
-        post-kill drain BOUNDED: we ``join`` them under ``_REAP_TIMEOUT_S`` and
-        proceed with whatever tail we have, so a setsid-escaped descendant still
-        holding a pipe write-end cannot wedge the never-block contract — the
-        unbounded second ``communicate()`` of the prior design could (codex
-        #1220 r17). A stuck reader is a daemon thread reaped at interpreter exit.
+        advisory handler runs (codex #1220 r17).
+      * **bounded, leak-free teardown (codex #1220 r18).** After the leader
+        exits — cleanly or on timeout — we ``join`` the readers under
+        ``_REAP_TIMEOUT_S``. If a reader is still alive afterwards, that PROVES a
+        descendant is still holding the pipe write-end open, i.e. a group member
+        is alive; POSIX keeps the PGID reserved while any member lives, so
+        ``killpg(pgid)`` then targets exactly this group even though the leader
+        was already reaped — race-free, no PID-reuse hazard. That kill both
+        reaps the leaked descendant (fixing the clean-path leak the prior
+        ``proc.wait``-only design left) and unblocks the reader so its buffer is
+        safe to read. We never block indefinitely: a second bounded join and a
+        lock-guarded ``text()`` snapshot follow.
 
-    Deliberately NOT done, after a long convergence (codex #1220 r8–r17): no
+    Deliberately NOT done, after a long convergence (codex #1220 r8–r18): no
     ``RLIMIT_FSIZE`` file-size cap (inherited by the whole pytest tree, it would
     truncate/corrupt legitimate large writes — e.g. a >256 MiB model shard —
-    codex r16), no temp-file/quota/exec-wrapper machinery. A setsid-escaping
-    descendant can still SURVIVE the group-kill — a fundamental POSIX limitation
-    the gating siblings don't guard against either (codex r11/r13/r16); portable
-    containment would need cgroups / job-objects unavailable here.
+    codex r16), no temp-file/quota/exec-wrapper machinery. The one residual gap
+    is fundamental and shared with the gating siblings: a descendant that BOTH
+    ``setsid()``-escapes the group AND closes the inherited pipes leaves no
+    race-free signal to find it on macOS (no cgroups / job objects, no
+    non-reaping group wait), so — like ``full_unit``'s bare ``subprocess.run`` —
+    it can outlive the run.
     """
     # ``start_new_session=True`` runs the child through ``setsid()``: it leads a
     # brand-new process group whose PGID EQUALS its PID. Capture that id NOW,
@@ -477,48 +518,53 @@ def _run_group_bounded(
         start_new_session=True,
     )
     pgid = proc.pid  # == PGID under start_new_session (setsid)
-    out_chunks: collections.deque = collections.deque()
-    err_chunks: collections.deque = collections.deque()
-    t_out = threading.Thread(
-        target=_drain_tail, args=(proc.stdout, out_chunks), daemon=True
-    )
-    t_err = threading.Thread(
-        target=_drain_tail, args=(proc.stderr, err_chunks), daemon=True
-    )
-    t_out.start()
-    t_err.start()
+    r_out = _TailReader(proc.stdout)
+    r_err = _TailReader(proc.stderr)
+    r_out.start()
+    r_err.start()
 
-    def _join_readers() -> None:
-        # Bounded on purpose. On clean exit the pipes hit EOF the moment the
-        # child dies, so both joins return at once; after a group SIGKILL EOF
-        # arrives when the last writer dies. The bound only bites when a
-        # setsid-escapee still holds a write end — we then proceed with the
-        # partial tail rather than block the pipeline (codex #1220 r17).
-        t_out.join(_REAP_TIMEOUT_S)
-        t_err.join(_REAP_TIMEOUT_S)
+    def _settle_readers() -> None:
+        # Bounded drain, then a race-free group sweep IFF a reader is still
+        # blocked. A live reader ⇒ a descendant still holds the pipe write-end
+        # ⇒ a group member is alive ⇒ the PGID is still reserved (POSIX), so the
+        # ``killpg`` cannot hit a recycled group even though the leader may be
+        # reaped. The kill reaps the leaked descendant AND unblocks the reader;
+        # the final bounded join then returns promptly. If the reader is STILL
+        # alive (uninterruptible read — near-impossible post-SIGKILL) we give up
+        # and return the partial tail rather than block the pipeline; ``text()``
+        # is lock-guarded so reading it is safe regardless.
+        r_out.join(_REAP_TIMEOUT_S)
+        r_err.join(_REAP_TIMEOUT_S)
+        if r_out.alive() or r_err.alive():
+            try:
+                os.killpg(pgid, signal.SIGKILL)
+            except OSError:
+                pass
+            r_out.join(_REAP_TIMEOUT_S)
+            r_err.join(_REAP_TIMEOUT_S)
 
     try:
         proc.wait(timeout=timeout)
     except subprocess.TimeoutExpired:
         # Time budget blown: SIGKILL the whole group BEFORE reaping the leader
-        # (race-free — ``pgid`` can't be recycled while a member is alive), let
-        # the readers drain the now-EOF pipes under a bound, and re-raise with
-        # the captured tail so the caller can log WHAT hung.
+        # (race-free — ``pgid`` can't be recycled while the unreaped leader is a
+        # member), settle the readers, and re-raise with the captured tail so
+        # the caller can log WHAT hung.
         _kill_group(proc, pgid)
-        _join_readers()
+        _settle_readers()
         raise subprocess.TimeoutExpired(
-            cmd, timeout, output=_joined(out_chunks), stderr=_joined(err_chunks)
+            cmd, timeout, output=r_out.text(), stderr=r_err.text()
         ) from None
     except BaseException:
         # Any other escape (e.g. KeyboardInterrupt): tear the group down so
-        # nothing is orphaned, drain under a bound, then re-raise unchanged.
+        # nothing is orphaned, settle, then re-raise unchanged.
         _kill_group(proc, pgid)
-        _join_readers()
+        _settle_readers()
         raise
-    _join_readers()
-    return subprocess.CompletedProcess(
-        cmd, proc.returncode, _joined(out_chunks), _joined(err_chunks)
-    )
+    # Clean exit: leader already reaped by ``proc.wait``. ``_settle_readers``
+    # still sweeps any lingering pipe-holding descendant race-free (see above).
+    _settle_readers()
+    return subprocess.CompletedProcess(cmd, proc.returncode, r_out.text(), r_err.text())
 
 
 def _kill_group(proc: subprocess.Popen, pgid: int) -> None:

--- a/scripts/pr_validate/steps/diff_coverage.py
+++ b/scripts/pr_validate/steps/diff_coverage.py
@@ -148,6 +148,16 @@ class DiffCoverageStep(Step):
         log_path: Path | None = None
         try:
             log_path = ctx.artifact_path("diff-coverage.log")
+            # Fresh-file guarantee: unlink any pre-existing log so ``_skip``
+            # can never attach a stale ``diff-coverage.log`` (e.g. from a reused
+            # artifact dir) that THIS run did not write — an early skip
+            # (tooling missing) writes no log, so its artifact list must stay
+            # empty (codex #1220 r15). Best-effort: a failed unlink must not
+            # itself escape as a blocking error.
+            try:
+                log_path.unlink(missing_ok=True)
+            except OSError:
+                pass
             return self._measure(ctx, log_path)
         except Exception as e:  # noqa: BLE001 — advisory must not block merge
             # ``_safe_write`` never raises; guard the path being unset too.
@@ -430,13 +440,14 @@ def _run_group_bounded(
     stdout/stderr so the caller can log WHAT hung before the temp files are
     deleted (codex #1220 r10).
 
-    Group teardown happens ONLY on the timeout/exception paths, where
-    ``_kill_group`` SIGKILLs the group BEFORE reaping the leader so ``pgid``
-    cannot be recycled — the kill is race-free. On a CLEAN exit we do not sweep
-    the group: a race-free sweep needs a non-reaping wait (``waitid``+
-    ``WNOWAIT``) unavailable on macOS, and a reap-then-``killpg`` sweep would
-    reintroduce a PID-reuse race (codex #1220 r14). That leaves clean-exit
-    parity with the merge-GATING sibling steps, which group-kill nothing.
+    The isolated group is torn down on EVERY exit path. On timeout/exception
+    ``_kill_group`` SIGKILLs the group BEFORE reaping the leader, so ``pgid``
+    cannot be recycled — unconditionally race-free. On a CLEAN exit
+    ``_sweep_group`` SIGKILLs any process the suite leaked into the group; that
+    is race-free while any member is alive (POSIX keeps the PGID reserved for
+    the group's whole lifetime, so the reaped leader's PID can't be recycled)
+    and a harmless ESRCH when the group is already empty — see the inline note
+    for the negligible reap-vs-recycle residual (codex #1220 r14/r15).
     """
     # ``start_new_session=True`` runs the child through ``setsid()``: it
     # leads a brand-new process group whose PGID EQUALS its PID. Capture that
@@ -473,16 +484,24 @@ def _run_group_bounded(
             # (again kill-before-reap, race-free) then re-raise unchanged.
             _kill_group(proc, pgid)
             raise
-        # Clean leader exit. We deliberately do NOT sweep the group here. A
-        # race-free sweep would have to SIGKILL the group BEFORE reaping the
-        # leader (so ``pgid`` can't be recycled), which needs a non-reaping wait
-        # (``waitid``+``WNOWAIT``) that is unavailable on macOS — the operator's
-        # platform. A reap-then-``killpg`` sweep would reintroduce exactly the
-        # PID-reuse race codex flagged (#1220 r14). So on the clean path we
-        # accept parity with the merge-GATING sibling steps (``full_unit`` /
-        # ``targeted_tests`` group-kill nothing at all); the timeout/exception
-        # paths above still contain a runaway group race-free, which is the
-        # scenario that actually matters.
+        # Clean leader exit — but SWEEP the group anyway: a suite that
+        # backgrounds a server/worker can leak it into the isolated group, where
+        # it would survive to hold a capture-file fd or contaminate later steps
+        # (codex #1220 r15). ``_sweep_group`` SIGKILLs the group by ``pgid``.
+        #
+        # This is race-free in the case that MATTERS. POSIX reserves a PGID for
+        # the whole lifetime of its group — until the LAST member leaves — so
+        # while any leaked descendant is still alive the number ``pgid`` cannot
+        # be recycled onto an unrelated process/group, even though the leader is
+        # now reaped (the leader's PID is exactly that reserved PGID). If the
+        # group is instead already empty there is nothing to kill and the call is
+        # a harmless ESRCH; the only residual is the leader's PID being recycled
+        # into a NEW group leader within the microseconds between reap and
+        # ``killpg`` AND the group being empty then — negligible, and strictly
+        # better than leaking a live server into the auto-deploy pipeline (this
+        # is the r14/r15 trade: a non-reaping wait that would remove even that
+        # window needs ``waitid``+``WNOWAIT``, unavailable on macOS).
+        _sweep_group(pgid)
         return subprocess.CompletedProcess(
             cmd, proc.returncode, _read_capped(out_f), _read_capped(err_f)
         )
@@ -524,6 +543,19 @@ def _rlimit_wrap() -> list[str]:
         _RLIMIT_WRAP_SRC,
         str(_OUTPUT_QUOTA_BYTES),
     ]
+
+
+def _sweep_group(pgid: int) -> None:
+    """Best-effort SIGKILL of any process the (cleanly-exited) leader leaked
+    into the isolated group. Callers invoke this only AFTER the leader has
+    exited; it is race-free while any member is still alive (POSIX keeps the
+    PGID reserved until the group's lifetime ends, so the leader's reaped PID
+    cannot be recycled onto an unrelated group), and a harmless ESRCH when the
+    group is already empty — see ``_run_group_bounded`` (codex #1220 r15)."""
+    try:
+        os.killpg(pgid, signal.SIGKILL)
+    except OSError:
+        pass
 
 
 def _kill_group(proc: subprocess.Popen, pgid: int) -> None:

--- a/scripts/pr_validate/steps/diff_coverage.py
+++ b/scripts/pr_validate/steps/diff_coverage.py
@@ -1,0 +1,263 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Advisory step — patch (diff) coverage measurement. MEASURE-FIRST, NO GATE.
+
+This step reports what fraction of the *production lines this PR adds or
+changes* are exercised by the unit suite. It NEVER blocks a merge.
+
+Why advisory-only (dev-flow gate proposal, 2026-07): a hard threshold
+picked before we have any distribution is a number out of thin air. The
+plan is to publish patch-coverage across ~20 PRs, look at where the
+numbers actually land, and only *then* decide whether a gate is
+justified. Until then this step exists purely to make the signal
+visible in the scorecard (which is posted as a PR comment).
+
+Mechanism:
+  1. Run the same unit set ``full_unit`` runs, but under ``coverage``
+     instrumentation (``pytest --cov=vllm_mlx --cov-report=xml``). This
+     is a SEPARATE, self-contained run — we deliberately do NOT
+     piggyback on ``full_unit``. ``full_unit`` is a merge-*gating*
+     step; an advisory measurement feature must not be able to break
+     the gate. The asymmetry is the whole argument: a false block on
+     the gate costs a maintainer a blocked-PR investigation, while
+     sharing the run would save only ~40 s. Isolation wins.
+  2. Feed the coverage XML to ``diff-cover`` scoped to the diff vs the
+     base branch → patch-coverage %.
+
+Because it's advisory, EVERY failure path here returns ``pass`` or
+``skip`` — never ``fail`` / ``error``. A crash in an advisory measurer
+must not be the reason a good PR can't merge. The base ``execute``
+wrapper would turn an *uncaught* exception into ``error`` (which the
+scorecard treats as blocking), so ``run`` catches everything and
+downgrades to ``skip``.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import re
+import subprocess
+import sys
+import traceback
+from pathlib import Path
+
+from ..base import Step, StepResult
+from ..context import Context
+
+# The package we measure. Coverage is scoped to production code only —
+# test files aren't the subject of "is this PR's new code tested".
+_COV_PACKAGE = "vllm_mlx"
+
+# diff-cover's compare point. ``origin/main`` is the merge target and is
+# always present locally after ``git fetch origin`` (which the operator
+# runs before validating, per G13). diff-cover computes the merge-base
+# internally, so this yields exactly the lines this PR adds on top of
+# main. We prefer the branch name over ``ctx.base_sha`` because the raw
+# SHA may not resolve if the local clone is shallow.
+_COMPARE_BRANCH = "origin/main"
+
+
+class DiffCoverageStep(Step):
+    name = "diff_coverage"
+    description = "advisory patch (diff) coverage — measure-only, never gates"
+
+    # An advisory measurer must never stop the pipeline. (Belt-and-braces:
+    # ``run`` already catches every exception, so ``execute`` can't reach
+    # its error path — but if it somehow did, don't halt later steps.)
+    continue_on_error = True
+
+    def should_run(self, ctx: Context) -> bool:
+        # Nothing to measure on docs/example-only PRs.
+        if ctx.blast_radius == "low":
+            return False
+        # Only meaningful when the PR touches production Python under the
+        # measured package — a tests-only or config-only PR has no
+        # ``vllm_mlx`` lines for diff-cover to score.
+        return any(
+            f.startswith(f"{_COV_PACKAGE}/") and f.endswith(".py")
+            for f in ctx.files_changed
+        )
+
+    def run(self, ctx: Context) -> StepResult:
+        log_path: Path = ctx.artifact_path("diff-coverage.log")
+        # Advisory contract: swallow ALL failures. Never fail/error.
+        try:
+            return self._measure(ctx, log_path)
+        except Exception as e:  # noqa: BLE001 — advisory must not block merge
+            log_path.write_text(traceback.format_exc())
+            return StepResult(
+                name=self.name,
+                status="skip",
+                summary=(
+                    f"advisory coverage skipped (internal error: "
+                    f"{type(e).__name__}: {e})"
+                ),
+                artifacts=[str(log_path)],
+            )
+
+    # ------------------------------------------------------------------
+
+    def _measure(self, ctx: Context, log_path: Path) -> StepResult:
+        # 1. Tooling present? Both are declared in the ``[test]``/``[dev]``
+        #    extras, but the operator may run validate from a leaner env.
+        #    Missing tooling is a clean skip, not a failure.
+        if importlib.util.find_spec("pytest_cov") is None:
+            return StepResult(
+                name=self.name,
+                status="skip",
+                summary="pytest-cov not installed — advisory coverage unavailable",
+            )
+        if importlib.util.find_spec("diff_cover") is None:
+            return StepResult(
+                name=self.name,
+                status="skip",
+                summary="diff-cover not installed — advisory coverage unavailable",
+            )
+
+        xml_path = ctx.artifact_path("coverage.xml")
+
+        # 2. Instrumented suite — mirrors ``full_unit``'s selection so the
+        #    coverage picture matches what we actually gate on. We do NOT
+        #    inspect the return code: ``full_unit`` owns "suite is green";
+        #    here we only want the coverage.xml. pytest-cov writes the
+        #    report at session end even if some tests fail, so a red suite
+        #    still yields a usable (if partial) measurement.
+        pytest_cmd = [
+            sys.executable,
+            "-m",
+            "pytest",
+            "tests/",
+            "--ignore=tests/integrations",
+            "--ignore=tests/test_event_loop.py",
+            f"--cov={_COV_PACKAGE}",
+            # Suppress the terminal cov table (noise); we only need XML.
+            "--cov-report=",
+            f"--cov-report=xml:{xml_path}",
+            "-q",
+            "--no-header",
+            "-p",
+            "no:cacheprovider",
+        ]
+        ctx.run_log("diff_coverage: running instrumented suite (advisory)…")
+        pytest_proc = subprocess.run(  # noqa: S603 — fixed argv, no shell
+            pytest_cmd, capture_output=True, text=True, cwd=str(ctx.repo_root)
+        )
+
+        if not xml_path.exists():
+            log_path.write_text(
+                "# pytest (coverage run) produced no coverage.xml\n\n"
+                "## stdout\n"
+                + (pytest_proc.stdout or "")
+                + "\n## stderr\n"
+                + (pytest_proc.stderr or "")
+            )
+            return StepResult(
+                name=self.name,
+                status="skip",
+                summary=(
+                    "advisory coverage skipped (no coverage.xml — suite "
+                    "likely errored at collection)"
+                ),
+                artifacts=[str(log_path)],
+            )
+
+        # 3. diff-cover: patch coverage of the changed lines vs main.
+        #    Invoke via ``-m`` so it runs in the SAME interpreter the
+        #    coverage was produced with (matches targeted_tests' policy).
+        dc_cmd = [
+            sys.executable,
+            "-m",
+            "diff_cover.diff_cover_tool",
+            str(xml_path),
+            "--compare-branch",
+            _COMPARE_BRANCH,
+        ]
+        dc_proc = subprocess.run(  # noqa: S603 — fixed argv, no shell
+            dc_cmd, capture_output=True, text=True, cwd=str(ctx.repo_root)
+        )
+
+        log_path.write_text(
+            "# diff_coverage advisory run\n\n"
+            f"## pytest cmd\n`{' '.join(pytest_cmd)}`\n\n"
+            f"## pytest exit: {pytest_proc.returncode}\n\n"
+            f"## diff-cover cmd\n`{' '.join(dc_cmd)}`\n\n"
+            f"## diff-cover exit: {dc_proc.returncode}\n\n"
+            "## diff-cover stdout\n"
+            + (dc_proc.stdout or "")
+            + "\n## diff-cover stderr\n"
+            + (dc_proc.stderr or "")
+        )
+
+        parsed = _parse_diff_cover(dc_proc.stdout)
+        if parsed is None:
+            # diff-cover ran but found no changed lines it could score
+            # (e.g. every changed line is a comment / blank / not in the
+            # coverage source map). Nothing to report — clean skip.
+            return StepResult(
+                name=self.name,
+                status="skip",
+                summary=(
+                    "advisory coverage skipped (no measurable production lines in diff)"
+                ),
+                artifacts=[str(log_path)],
+            )
+
+        pct, covered, total = parsed
+        summary = (
+            f"patch coverage {pct:.0f}% ({covered}/{total} changed lines) · "
+            "advisory — not gating"
+        )
+        finding = (
+            f"[ADVISORY] patch (diff) coverage: {pct:.1f}% — "
+            f"{covered}/{total} newly changed {_COV_PACKAGE} lines exercised "
+            "by the unit suite. Measure-only; no threshold enforced yet "
+            "(collecting baseline across ~20 PRs before deciding a gate)."
+        )
+        return StepResult(
+            name=self.name,
+            status="pass",  # ALWAYS pass — advisory
+            summary=summary,
+            findings=[finding],
+            artifacts=[str(log_path), str(xml_path)],
+        )
+
+
+# ----------------------------------------------------------------------
+# diff-cover output parsing — we parse the stable human-readable text
+# rather than a JSON report because the JSON flag name has churned
+# across diff-cover versions (``--json-report`` vs ``--format json:``)
+# while the text footer (``Total:`` / ``Missing:`` / ``Coverage:``) has
+# been stable for years.
+# ----------------------------------------------------------------------
+
+_TOTAL_RE = re.compile(r"^Total:\s+(\d+)\s+lines?", re.MULTILINE)
+_MISSING_RE = re.compile(r"^Missing:\s+(\d+)\s+lines?", re.MULTILINE)
+_NO_LINES_RE = re.compile(r"No lines with coverage information", re.IGNORECASE)
+
+
+def _parse_diff_cover(stdout: str) -> tuple[float, int, int] | None:
+    """Return ``(percent, covered_lines, total_lines)`` or ``None`` when
+    diff-cover reports nothing to score.
+
+    Percent is computed from the exact ``Total`` / ``Missing`` counts,
+    NOT from diff-cover's own ``Coverage:`` line. diff-cover *floors*
+    that displayed integer (e.g. 58/1934 = 2.9989 % prints as
+    ``Coverage: 2%``), which both loses resolution and can read a point
+    below the true value — bad for a baseline we intend to threshold on
+    later. So our headline % may read ~1 pt above the number in the
+    saved diff-cover log; the ``covered/total`` counts we surface
+    alongside it are the unambiguous ground truth.
+    """
+    text = stdout or ""
+    if _NO_LINES_RE.search(text):
+        return None
+    tm = _TOTAL_RE.search(text)
+    mm = _MISSING_RE.search(text)
+    if not tm or not mm:
+        return None
+    total = int(tm.group(1))
+    missing = int(mm.group(1))
+    if total <= 0:
+        return None
+    covered = total - missing
+    pct = 100.0 * covered / total
+    return pct, covered, total

--- a/scripts/pr_validate/steps/diff_coverage.py
+++ b/scripts/pr_validate/steps/diff_coverage.py
@@ -91,6 +91,17 @@ _LOG_TAIL_CHARS = 4000
 # #1220 r8).
 _STDOUT_CAP_BYTES = 1_048_576
 
+# Disk quota: hard cap on how many bytes a single child may write to its temp
+# files before we kill its group and treat the run as timed out. The output
+# goes to disk (not RAM), but disk is still finite on an auto-deploy host, so
+# a runaway / hung test that streams without bound must not exhaust it (codex
+# #1220 r10). 256 MiB is orders of magnitude above any real ``-q`` suite or
+# diff-cover run, so it only ever trips on genuinely pathological output.
+_OUTPUT_QUOTA_BYTES = 256 * 1024 * 1024
+
+# How often, while waiting, we re-check the child against the output quota.
+_POLL_INTERVAL_S = 5
+
 
 class DiffCoverageStep(Step):
     name = "diff_coverage"
@@ -178,10 +189,12 @@ class DiffCoverageStep(Step):
             pytest_proc = _run_group_bounded(
                 pytest_cmd, str(ctx.repo_root), _PYTEST_TIMEOUT_S
             )
-        except subprocess.TimeoutExpired:
+        except subprocess.TimeoutExpired as exc:
+            _safe_write(log_path, _timeout_dump("instrumented pytest", pytest_cmd, exc))
             return self._skip(
                 f"advisory coverage skipped (instrumented suite exceeded "
-                f"{_PYTEST_TIMEOUT_S}s — process group killed)"
+                f"{_PYTEST_TIMEOUT_S}s or its output quota — process group killed)",
+                log_path,
             )
 
         # 3. Coverage trust model (see ``_PYTEST_COVERAGE_VALID_EXITS``). We
@@ -233,10 +246,12 @@ class DiffCoverageStep(Step):
             dc_proc = _run_group_bounded(
                 dc_cmd, str(ctx.repo_root), _DIFF_COVER_TIMEOUT_S
             )
-        except subprocess.TimeoutExpired:
+        except subprocess.TimeoutExpired as exc:
+            _safe_write(log_path, _timeout_dump("diff-cover", dc_cmd, exc))
             return self._skip(
                 f"advisory coverage skipped (diff-cover exceeded "
-                f"{_DIFF_COVER_TIMEOUT_S}s — process group killed)"
+                f"{_DIFF_COVER_TIMEOUT_S}s or its output quota — process group killed)",
+                log_path,
             )
 
         # Record pytest's own output too (tail-truncated) — on an accepted
@@ -358,9 +373,15 @@ def _run_group_bounded(
     bounds validator memory — a noisy / runaway test streams to disk, and
     we read back only a capped tail — and, because there are no pipes for a
     surviving descendant to hold open, it removes the reap-wedge class
-    entirely: the timeout path is a plain group-SIGKILL + bounded ``wait``.
-    The tail keeps the bytes every caller needs — diff-cover's footer and
-    pytest's ``-q`` failure summary both sit at the END of their streams.
+    entirely. The tail keeps the bytes every caller needs — diff-cover's
+    footer and pytest's ``-q`` failure summary both sit at the END of their
+    streams. Disk is bounded too: we poll the temp-file size and, if a child
+    blows past ``_OUTPUT_QUOTA_BYTES``, kill it exactly like a timeout so a
+    runaway producer can't exhaust the auto-deploy host (codex #1220 r10).
+
+    On timeout / quota breach the raised ``TimeoutExpired`` carries the
+    captured (capped) stdout/stderr so the caller can log WHAT hung before
+    the temp files are deleted (codex #1220 r10).
 
     The isolated group is swept on EVERY exit path, not just timeout: a
     pytest that exits cleanly can still leak a background server/worker into
@@ -382,10 +403,11 @@ def _run_group_bounded(
         )
         pgid = proc.pid  # == PGID under start_new_session (setsid)
         try:
-            proc.wait(timeout=timeout)
+            _wait_within_quota(proc, cmd, timeout, out_f, err_f)
         except BaseException:
-            # Timeout OR any other escape (e.g. KeyboardInterrupt): tear the
-            # whole group down so nothing is orphaned, then re-raise unchanged.
+            # Timeout / quota breach OR any other escape (e.g.
+            # KeyboardInterrupt): tear the whole group down so nothing is
+            # orphaned, then re-raise unchanged.
             _kill_group(proc, pgid)
             raise
         # Clean leader exit — but SWEEP the group anyway: a cleanly-exited
@@ -395,6 +417,37 @@ def _run_group_bounded(
         return subprocess.CompletedProcess(
             cmd, proc.returncode, _read_capped(out_f), _read_capped(err_f)
         )
+
+
+def _wait_within_quota(proc, cmd: list[str], timeout: int, out_f, err_f) -> None:
+    """Wait for ``proc`` up to ``timeout`` seconds, re-checking every
+    ``_POLL_INTERVAL_S`` that its temp-file output has not exceeded
+    ``_OUTPUT_QUOTA_BYTES``. Raises ``subprocess.TimeoutExpired`` (with the
+    captured tail attached for diagnostics) on either the time or the byte
+    budget; returns normally when the child exits within both."""
+    remaining = timeout
+    while True:
+        step = min(_POLL_INTERVAL_S, remaining) if remaining > 0 else 0
+        try:
+            proc.wait(timeout=step)
+            return  # exited within both budgets
+        except subprocess.TimeoutExpired:
+            remaining -= step
+            over_quota = _file_size(out_f) + _file_size(err_f) > _OUTPUT_QUOTA_BYTES
+            if over_quota or remaining <= 0:
+                raise subprocess.TimeoutExpired(
+                    cmd,
+                    timeout,
+                    output=_read_capped(out_f),
+                    stderr=_read_capped(err_f),
+                ) from None
+
+
+def _file_size(f) -> int:
+    """Current size of an open file object (the child writes via the inherited
+    fd, so the parent object's own position never moves — seek to end)."""
+    f.seek(0, os.SEEK_END)
+    return f.tell()
 
 
 def _sweep_group(pgid: int) -> None:
@@ -463,10 +516,17 @@ def _safe_write(path: Path, text: str) -> None:
     """Best-effort diagnostic write. NEVER raises. An advisory step must
     still return skip/pass even if it can't write its own log (disk full,
     permissions) — otherwise a failing write inside an exception handler
-    would escape as a blocking ``error`` (codex review on #1220)."""
+    would escape as a blocking ``error`` (codex review on #1220).
+
+    Writes explicitly as UTF-8 with ``errors="replace"``: the default
+    locale encoding can be ASCII on some CI, and our diagnostics contain
+    non-ASCII (tracebacks, the ``…`` elision marker), which would raise
+    ``UnicodeEncodeError`` — a ``ValueError``, NOT an ``OSError`` — and slip
+    past a bare ``except OSError`` to become a blocking error (codex #1220
+    r10). We also catch ``UnicodeError`` belt-and-braces."""
     try:
-        path.write_text(text)
-    except OSError:
+        path.write_text(text, encoding="utf-8", errors="replace")
+    except (OSError, UnicodeError):
         pass
 
 
@@ -484,6 +544,20 @@ def _pytest_dump(cmd: list[str], proc: subprocess.CompletedProcess[str]) -> str:
         f"# instrumented pytest (exit {proc.returncode})\n\n"
         f"## cmd\n`{' '.join(cmd)}`\n\n"
         "## stdout\n" + _tail(proc.stdout) + "\n## stderr\n" + _tail(proc.stderr)
+    )
+
+
+def _timeout_dump(label: str, cmd: list[str], exc: subprocess.TimeoutExpired) -> str:
+    """Diagnostics for a timed-out / output-quota-exceeded child. Preserves
+    the captured tail carried on the exception so the log records WHAT hung
+    before the temp files are deleted (codex #1220 r10)."""
+    return (
+        f"# {label} TIMED OUT or exceeded its output quota\n\n"
+        f"## cmd\n`{' '.join(cmd)}`\n\n"
+        "## stdout (tail)\n"
+        + _tail(exc.stdout if isinstance(exc.stdout, str) else "")
+        + "\n## stderr (tail)\n"
+        + _tail(exc.stderr if isinstance(exc.stderr, str) else "")
     )
 
 

--- a/scripts/pr_validate/steps/diff_coverage.py
+++ b/scripts/pr_validate/steps/diff_coverage.py
@@ -202,16 +202,17 @@ class DiffCoverageStep(Step):
 
         # 4. diff-cover: patch coverage of the changed lines vs the PR's
         #    base. The compare ref is the PR's ACTUAL base — ``ctx.base_sha``
-        #    (its ``baseRefOid``) — so a PR targeting a release/maintenance
-        #    branch is scored against ITS base, never a hardcoded ``main``
-        #    (codex #1220). We fall back to ``ctx.base_branch`` (the PR's
-        #    target branch, default ``main``) exactly as the sibling
-        #    base-aware steps do (``targeted_tests``, ``stress_e2e_bench``),
-        #    so an unknown base commit still resolves to the right branch
-        #    rather than a hardcoded remote ref. Invoke via ``-m`` so it runs
-        #    in the SAME interpreter the coverage was produced with (matches
-        #    targeted_tests' policy).
-        compare_ref = ctx.base_sha or ctx.base_branch
+        #    (its ``baseRefOid``, a concrete commit) — so a PR targeting a
+        #    release/maintenance branch is scored against ITS base, never a
+        #    hardcoded ``main`` (codex #1220 r5). A SHA also resolves in a
+        #    detached CI checkout, where a *bare* local branch name may not
+        #    exist. So the no-metadata fallback qualifies the target branch
+        #    with the remote — ``origin/<base_branch>`` — which exists after
+        #    fetch even detached, rather than a bare ``main`` that would fail
+        #    to resolve and skip every fallback run (codex #1220 r6). Invoke
+        #    via ``-m`` so it runs in the SAME interpreter the coverage was
+        #    produced with (matches targeted_tests' policy).
+        compare_ref = ctx.base_sha or f"origin/{ctx.base_branch}"
         dc_cmd = [
             sys.executable,
             "-m",
@@ -280,8 +281,11 @@ class DiffCoverageStep(Step):
             if suite_had_failures
             else ""
         )
+        # One decimal (not {:.0f}) so 99.5% doesn't read as a misleading
+        # "100%" nor 0.5% as "0%" — matches the finding's precision (codex
+        # #1220 r6 nit).
         summary = (
-            f"patch coverage {pct:.0f}% ({covered}/{total} changed lines) · "
+            f"patch coverage {pct:.1f}% ({covered}/{total} changed lines) · "
             "advisory — not gating"
         )
         finding = (

--- a/tests/test_pr_validate_diff_coverage.py
+++ b/tests/test_pr_validate_diff_coverage.py
@@ -19,6 +19,7 @@ Two contracts matter most here and are the reason this file exists:
 from __future__ import annotations
 
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -27,6 +28,7 @@ from scripts.pr_validate.context import Context
 from scripts.pr_validate.steps.diff_coverage import (
     DiffCoverageStep,
     _parse_diff_cover,
+    _run_group_bounded,
 )
 
 # --------------------------------------------------------------------------
@@ -194,7 +196,7 @@ class TestAdvisoryContract:
             return subprocess.CompletedProcess(cmd, 0, stdout=_DC_WITH_LINES, stderr="")
 
         monkeypatch.setattr(
-            "scripts.pr_validate.steps.diff_coverage.subprocess.run", fake_run
+            "scripts.pr_validate.steps.diff_coverage._run_group_bounded", fake_run
         )
         res = DiffCoverageStep().run(ctx)
         assert res.status == "pass"
@@ -218,7 +220,7 @@ class TestAdvisoryContract:
             return subprocess.CompletedProcess(cmd, 0, stdout=_DC_WITH_LINES, stderr="")
 
         monkeypatch.setattr(
-            "scripts.pr_validate.steps.diff_coverage.subprocess.run", fake_run
+            "scripts.pr_validate.steps.diff_coverage._run_group_bounded", fake_run
         )
         res = DiffCoverageStep().run(ctx)
         assert res.status == "skip"
@@ -239,7 +241,7 @@ class TestAdvisoryContract:
             return subprocess.CompletedProcess(cmd, 0, stdout="ok", stderr="")
 
         monkeypatch.setattr(
-            "scripts.pr_validate.steps.diff_coverage.subprocess.run", fake_run
+            "scripts.pr_validate.steps.diff_coverage._run_group_bounded", fake_run
         )
         res = DiffCoverageStep().run(ctx)
         assert res.status == "skip"
@@ -254,7 +256,7 @@ class TestAdvisoryContract:
             return subprocess.CompletedProcess(cmd, 0, stdout="ok", stderr="")
 
         monkeypatch.setattr(
-            "scripts.pr_validate.steps.diff_coverage.subprocess.run", fake_run
+            "scripts.pr_validate.steps.diff_coverage._run_group_bounded", fake_run
         )
         res = DiffCoverageStep().run(ctx)
         assert res.status == "skip"
@@ -267,7 +269,7 @@ class TestAdvisoryContract:
             raise subprocess.TimeoutExpired(cmd, k.get("timeout", 1))
 
         monkeypatch.setattr(
-            "scripts.pr_validate.steps.diff_coverage.subprocess.run", fake_run
+            "scripts.pr_validate.steps.diff_coverage._run_group_bounded", fake_run
         )
         res = DiffCoverageStep().run(ctx)
         assert res.status == "skip"
@@ -284,7 +286,7 @@ class TestAdvisoryContract:
             raise subprocess.TimeoutExpired(cmd, k.get("timeout", 1))
 
         monkeypatch.setattr(
-            "scripts.pr_validate.steps.diff_coverage.subprocess.run", fake_run
+            "scripts.pr_validate.steps.diff_coverage._run_group_bounded", fake_run
         )
         res = DiffCoverageStep().run(ctx)
         assert res.status == "skip"
@@ -308,7 +310,7 @@ class TestAdvisoryContract:
             )
 
         monkeypatch.setattr(
-            "scripts.pr_validate.steps.diff_coverage.subprocess.run", fake_run
+            "scripts.pr_validate.steps.diff_coverage._run_group_bounded", fake_run
         )
         res = DiffCoverageStep().run(ctx)
         assert res.status == "skip"
@@ -340,7 +342,7 @@ class TestAdvisoryContract:
             return subprocess.CompletedProcess(cmd, 0, stdout=_DC_NO_LINES, stderr="")
 
         monkeypatch.setattr(
-            "scripts.pr_validate.steps.diff_coverage.subprocess.run", fake_run
+            "scripts.pr_validate.steps.diff_coverage._run_group_bounded", fake_run
         )
         res = DiffCoverageStep().run(ctx)
         assert res.status == "skip"
@@ -369,7 +371,7 @@ class TestAdvisoryContract:
             raise RuntimeError("simulated subprocess explosion")
 
         monkeypatch.setattr(
-            "scripts.pr_validate.steps.diff_coverage.subprocess.run", boom
+            "scripts.pr_validate.steps.diff_coverage._run_group_bounded", boom
         )
         res = DiffCoverageStep().run(ctx)
         # The whole point: a crash in the measurer must NOT surface as
@@ -392,7 +394,7 @@ class TestAdvisoryContract:
             raise OSError("No space left on device")
 
         monkeypatch.setattr(
-            "scripts.pr_validate.steps.diff_coverage.subprocess.run", boom
+            "scripts.pr_validate.steps.diff_coverage._run_group_bounded", boom
         )
         monkeypatch.setattr(Path, "write_text", unwritable)
         res = DiffCoverageStep().run(ctx)
@@ -424,3 +426,39 @@ class TestRegistration:
         # A defensive pin on the advisory intent: the step opts into
         # continue_on_error so a stray error can't halt the pipeline.
         assert DiffCoverageStep().continue_on_error is True
+
+
+# --------------------------------------------------------------------------
+# _run_group_bounded — the process-group-bounded subprocess helper. Real
+# subprocesses (no mocking) so we actually exercise the timeout + kill.
+# --------------------------------------------------------------------------
+
+
+class TestRunGroupBounded:
+    def test_returns_completed_process_on_success(self):
+        proc = _run_group_bounded(
+            [sys.executable, "-c", "print('hi')"], cwd=".", timeout=30
+        )
+        assert proc.returncode == 0
+        assert "hi" in proc.stdout
+
+    def test_propagates_nonzero_returncode(self):
+        proc = _run_group_bounded(
+            [sys.executable, "-c", "import sys; sys.exit(3)"], cwd=".", timeout=30
+        )
+        assert proc.returncode == 3
+
+    def test_raises_timeout_and_kills_group(self):
+        # A child that spawns a grandchild and sleeps: on timeout the
+        # WHOLE group must die. We assert TimeoutExpired is raised; the
+        # group-kill is what keeps a real timed-out pytest from orphaning
+        # workers (can't easily assert descendant death portably, but the
+        # killpg path is exercised).
+        import subprocess as _sp
+
+        with pytest.raises(_sp.TimeoutExpired):
+            _run_group_bounded(
+                [sys.executable, "-c", "import time; time.sleep(30)"],
+                cwd=".",
+                timeout=1,
+            )

--- a/tests/test_pr_validate_diff_coverage.py
+++ b/tests/test_pr_validate_diff_coverage.py
@@ -28,6 +28,7 @@ from scripts.pr_validate.context import Context
 from scripts.pr_validate.steps.diff_coverage import (
     DiffCoverageStep,
     _parse_diff_cover,
+    _path_exists,
     _run_group_bounded,
 )
 
@@ -97,6 +98,24 @@ class TestParseDiffCover:
         # Guard against a divide-by-zero if diff-cover ever emits a
         # degenerate "Total: 0 lines".
         assert _parse_diff_cover("Total:   0 lines\nMissing: 0 lines\n") is None
+
+
+class TestPathExists:
+    def test_none_is_false(self):
+        assert _path_exists(None) is False
+
+    def test_real_paths(self, tmp_path):
+        assert _path_exists(tmp_path) is True
+        assert _path_exists(tmp_path / "nope") is False
+
+    def test_never_raises_on_oserror(self, tmp_path, monkeypatch):
+        # pathlib re-raises EACCES/EIO from .exists(); the guard must swallow
+        # it and report 'not present' so the advisory contract can't break.
+        def exists_boom(self, *a, **k):
+            raise OSError("Permission denied")
+
+        monkeypatch.setattr(Path, "exists", exists_boom)
+        assert _path_exists(tmp_path / "x") is False
 
 
 # --------------------------------------------------------------------------
@@ -473,6 +492,29 @@ class TestAdvisoryContract:
         monkeypatch.setattr(Path, "write_text", unwritable)
         res = DiffCoverageStep().run(ctx)
         assert res.status == "skip"
+
+    def test_advisory_survives_exists_oserror(self, ctx_factory, monkeypatch):
+        # codex #1220 r7: pathlib's Path.exists() re-raises OSErrors other
+        # than ENOENT (e.g. EACCES / EIO). A bare .exists() in _skip could
+        # then escape run()'s handler and become a blocking error — the one
+        # thing this advisory step must never do. With Path.exists() raising
+        # from anywhere in the flow, run() must STILL resolve to skip.
+        _both_tools_present(monkeypatch)
+        ctx = ctx_factory(["vllm_mlx/quantized_batch_cache.py"])
+
+        def boom(cmd, *a, **k):
+            raise RuntimeError("subprocess explosion")
+
+        def exists_boom(self, *a, **k):
+            raise OSError("Permission denied")
+
+        monkeypatch.setattr(
+            "scripts.pr_validate.steps.diff_coverage._run_group_bounded", boom
+        )
+        monkeypatch.setattr(Path, "exists", exists_boom)
+        res = DiffCoverageStep().run(ctx)
+        assert res.status == "skip"
+        assert res.status not in ("fail", "error")
 
     def test_execute_wrapper_skips_when_gated_out(self, ctx_factory, monkeypatch):
         # Through the base execute() wrapper, a docs-only PR gates out.

--- a/tests/test_pr_validate_diff_coverage.py
+++ b/tests/test_pr_validate_diff_coverage.py
@@ -18,6 +18,7 @@ Two contracts matter most here and are the reason this file exists:
 
 from __future__ import annotations
 
+import signal
 import subprocess
 import sys
 from pathlib import Path
@@ -203,11 +204,15 @@ class TestAdvisoryContract:
         assert "80" in res.summary
         assert res.findings and "ADVISORY" in res.findings[0]
 
-    def test_skip_when_suite_not_clean(self, ctx_factory, monkeypatch):
-        # A nonzero pytest exit (failures / interruption) must NOT be
-        # measured — even though coverage.xml was written — because a
-        # partial/failing run would contaminate the baseline. full_unit
-        # owns surfacing the red suite.
+    def test_measures_with_caveat_when_some_tests_failed(
+        self, ctx_factory, monkeypatch
+    ):
+        # codex #1220 r4: exit 1 means the suite RAN but some tests failed —
+        # coverage.xml is still a complete record of executed lines, and an
+        # advisory baseline collector must survive an unrelated flaky test
+        # rather than discard the whole measurement. So exit 1 is MEASURED
+        # (pass), with a caveat noting the % may under-count. full_unit still
+        # owns gating on the red suite.
         _both_tools_present(monkeypatch)
         ctx = ctx_factory(["vllm_mlx/quantized_batch_cache.py"])
         dc_called = {"n": 0}
@@ -223,8 +228,38 @@ class TestAdvisoryContract:
             "scripts.pr_validate.steps.diff_coverage._run_group_bounded", fake_run
         )
         res = DiffCoverageStep().run(ctx)
+        assert res.status == "pass"
+        assert dc_called["n"] == 1  # DID proceed to diff-cover
+        assert "80" in res.summary
+        # The finding must flag that some tests failed (honest advisory signal).
+        assert res.findings and "some unit tests failed" in res.findings[0]
+
+    @pytest.mark.parametrize("exit_code", [2, 3, 4, 5])
+    def test_skip_when_suite_interrupted_or_errored(
+        self, ctx_factory, monkeypatch, exit_code
+    ):
+        # Exit 2-5 = interrupted / internal error / usage error / no tests
+        # collected — no dependable coverage even if a stale-looking xml is
+        # present. Must skip BEFORE diff-cover, unlike the exit-1 case.
+        _both_tools_present(monkeypatch)
+        ctx = ctx_factory(["vllm_mlx/quantized_batch_cache.py"])
+        dc_called = {"n": 0}
+
+        def fake_run(cmd, *a, **k):
+            if "pytest" in cmd:
+                Path(_xml_target(cmd)).write_text("<coverage/>")
+                return subprocess.CompletedProcess(
+                    cmd, exit_code, stdout="boom", stderr=""
+                )
+            dc_called["n"] += 1
+            return subprocess.CompletedProcess(cmd, 0, stdout=_DC_WITH_LINES, stderr="")
+
+        monkeypatch.setattr(
+            "scripts.pr_validate.steps.diff_coverage._run_group_bounded", fake_run
+        )
+        res = DiffCoverageStep().run(ctx)
         assert res.status == "skip"
-        assert "not clean" in res.summary
+        assert f"exit {exit_code}" in res.summary
         assert dc_called["n"] == 0  # never reached diff-cover
 
     def test_stale_xml_is_removed_before_run(self, ctx_factory, monkeypatch):
@@ -448,17 +483,56 @@ class TestRunGroupBounded:
         )
         assert proc.returncode == 3
 
-    def test_raises_timeout_and_kills_group(self):
-        # A child that spawns a grandchild and sleeps: on timeout the
-        # WHOLE group must die. We assert TimeoutExpired is raised; the
-        # group-kill is what keeps a real timed-out pytest from orphaning
-        # workers (can't easily assert descendant death portably, but the
-        # killpg path is exercised).
-        import subprocess as _sp
-
-        with pytest.raises(_sp.TimeoutExpired):
+    def test_raises_timeout_on_a_lone_sleeper(self):
+        with pytest.raises(subprocess.TimeoutExpired):
             _run_group_bounded(
                 [sys.executable, "-c", "import time; time.sleep(30)"],
                 cwd=".",
                 timeout=1,
+            )
+
+    def test_timeout_kills_the_whole_group_including_descendants(self, tmp_path):
+        # The contract that actually matters: on timeout the ENTIRE process
+        # group dies, not just the leader. A leader-only kill would orphan
+        # any grandchild a timed-out pytest spawned (xdist workers, a serve
+        # subprocess) and let it contaminate later validation steps — and,
+        # worse, a grandchild holding the inherited stdout/stderr pipes open
+        # would wedge the reap. This test distinguishes the two: it fails if
+        # group-kill ever regresses to a leader-only kill.
+        #
+        # Leader = ``sh``; it backgrounds a long-lived grandchild in the SAME
+        # process group (non-interactive sh has no job control, so ``&`` jobs
+        # stay in the shell's group), records the grandchild PID, then blocks
+        # so the leader is alive when the timeout fires. The grandchild
+        # inherits the subprocess pipes, so a leader-only kill would also
+        # reproduce the reap-wedge from codex #1220.
+        import os as _os
+        import time as _time
+
+        pidfile = tmp_path / "grandchild.pid"
+        cmd = ["sh", "-c", f"sleep 120 & echo $! > '{pidfile}'; sleep 120"]
+
+        with pytest.raises(subprocess.TimeoutExpired):
+            _run_group_bounded(cmd, cwd=str(tmp_path), timeout=1)
+
+        gc_pid = int(pidfile.read_text().strip())
+        # Poll briefly for SIGKILL delivery, then assert the grandchild is gone.
+        deadline = _time.time() + 5.0
+        alive = True
+        while _time.time() < deadline:
+            try:
+                _os.kill(gc_pid, 0)  # signal 0 = liveness probe
+            except ProcessLookupError:
+                alive = False
+                break
+            _time.sleep(0.05)
+        if alive:
+            # Don't strand the leaked process if the assertion is about to fail.
+            try:
+                _os.kill(gc_pid, signal.SIGKILL)
+            except OSError:
+                pass
+            pytest.fail(
+                f"grandchild {gc_pid} survived the timeout — group kill "
+                "regressed to a leader-only kill"
             )

--- a/tests/test_pr_validate_diff_coverage.py
+++ b/tests/test_pr_validate_diff_coverage.py
@@ -185,12 +185,11 @@ class TestAdvisoryContract:
 
         def fake_run(cmd, *a, **k):
             if "pytest" in cmd:
-                # Simulate a RED suite (returncode 1) that still writes
-                # coverage.xml — proves we don't gate on pytest's exit.
+                # A CLEAN suite (exit 0) that writes coverage.xml.
                 target = _xml_target(cmd)
                 assert target is not None
                 Path(target).write_text("<coverage/>")
-                return subprocess.CompletedProcess(cmd, 1, stdout="1 failed", stderr="")
+                return subprocess.CompletedProcess(cmd, 0, stdout="ok", stderr="")
             # diff-cover invocation.
             return subprocess.CompletedProcess(cmd, 0, stdout=_DC_WITH_LINES, stderr="")
 
@@ -202,19 +201,94 @@ class TestAdvisoryContract:
         assert "80" in res.summary
         assert res.findings and "ADVISORY" in res.findings[0]
 
-    def test_skip_when_no_coverage_xml(self, ctx_factory, monkeypatch):
+    def test_skip_when_suite_not_clean(self, ctx_factory, monkeypatch):
+        # A nonzero pytest exit (failures / interruption) must NOT be
+        # measured — even though coverage.xml was written — because a
+        # partial/failing run would contaminate the baseline. full_unit
+        # owns surfacing the red suite.
         _both_tools_present(monkeypatch)
         ctx = ctx_factory(["vllm_mlx/quantized_batch_cache.py"])
+        dc_called = {"n": 0}
 
         def fake_run(cmd, *a, **k):
-            # pytest errored at collection: no xml written.
-            return subprocess.CompletedProcess(cmd, 2, stdout="errors", stderr="")
+            if "pytest" in cmd:
+                Path(_xml_target(cmd)).write_text("<coverage/>")  # xml IS written
+                return subprocess.CompletedProcess(cmd, 1, stdout="1 failed", stderr="")
+            dc_called["n"] += 1
+            return subprocess.CompletedProcess(cmd, 0, stdout=_DC_WITH_LINES, stderr="")
 
         monkeypatch.setattr(
             "scripts.pr_validate.steps.diff_coverage.subprocess.run", fake_run
         )
         res = DiffCoverageStep().run(ctx)
         assert res.status == "skip"
+        assert "not clean" in res.summary
+        assert dc_called["n"] == 0  # never reached diff-cover
+
+    def test_stale_xml_is_removed_before_run(self, ctx_factory, monkeypatch):
+        # A leftover coverage.xml from a previous run must not be able to
+        # masquerade as this run's result when pytest fails to write one.
+        _both_tools_present(monkeypatch)
+        ctx = ctx_factory(["vllm_mlx/quantized_batch_cache.py"])
+        stale = ctx.artifact_path("coverage.xml")
+        stale.write_text("<coverage>STALE</coverage>")
+
+        def fake_run(cmd, *a, **k):
+            # Clean exit but DO NOT write a fresh xml. Without the
+            # pre-run unlink, the stale file would survive and get scored.
+            return subprocess.CompletedProcess(cmd, 0, stdout="ok", stderr="")
+
+        monkeypatch.setattr(
+            "scripts.pr_validate.steps.diff_coverage.subprocess.run", fake_run
+        )
+        res = DiffCoverageStep().run(ctx)
+        assert res.status == "skip"
+        assert "no coverage.xml" in res.summary
+
+    def test_skip_when_no_coverage_xml(self, ctx_factory, monkeypatch):
+        _both_tools_present(monkeypatch)
+        ctx = ctx_factory(["vllm_mlx/quantized_batch_cache.py"])
+
+        def fake_run(cmd, *a, **k):
+            # Clean exit but no xml written (e.g. cov plugin misconfigured).
+            return subprocess.CompletedProcess(cmd, 0, stdout="ok", stderr="")
+
+        monkeypatch.setattr(
+            "scripts.pr_validate.steps.diff_coverage.subprocess.run", fake_run
+        )
+        res = DiffCoverageStep().run(ctx)
+        assert res.status == "skip"
+
+    def test_skip_on_pytest_timeout(self, ctx_factory, monkeypatch):
+        _both_tools_present(monkeypatch)
+        ctx = ctx_factory(["vllm_mlx/quantized_batch_cache.py"])
+
+        def fake_run(cmd, *a, **k):
+            raise subprocess.TimeoutExpired(cmd, k.get("timeout", 1))
+
+        monkeypatch.setattr(
+            "scripts.pr_validate.steps.diff_coverage.subprocess.run", fake_run
+        )
+        res = DiffCoverageStep().run(ctx)
+        assert res.status == "skip"
+        assert "exceeded" in res.summary
+
+    def test_skip_on_diff_cover_timeout(self, ctx_factory, monkeypatch):
+        _both_tools_present(monkeypatch)
+        ctx = ctx_factory(["vllm_mlx/quantized_batch_cache.py"])
+
+        def fake_run(cmd, *a, **k):
+            if "pytest" in cmd:
+                Path(_xml_target(cmd)).write_text("<coverage/>")
+                return subprocess.CompletedProcess(cmd, 0, stdout="ok", stderr="")
+            raise subprocess.TimeoutExpired(cmd, k.get("timeout", 1))
+
+        monkeypatch.setattr(
+            "scripts.pr_validate.steps.diff_coverage.subprocess.run", fake_run
+        )
+        res = DiffCoverageStep().run(ctx)
+        assert res.status == "skip"
+        assert "diff-cover" in res.summary and "exceeded" in res.summary
 
     def test_skip_when_diff_cover_finds_no_lines(self, ctx_factory, monkeypatch):
         _both_tools_present(monkeypatch)
@@ -263,6 +337,27 @@ class TestAdvisoryContract:
         # error (which the scorecard treats as blocking).
         assert res.status == "skip"
         assert res.status not in ("fail", "error")
+
+    def test_crash_with_unwritable_log_still_skips(self, ctx_factory, monkeypatch):
+        # codex #1220 fix #2: if the diagnostic-log write ALSO fails
+        # (disk full / permissions) inside the exception handler, the
+        # step must STILL return skip, not let the write error escape as
+        # a blocking error.
+        _both_tools_present(monkeypatch)
+        ctx = ctx_factory(["vllm_mlx/quantized_batch_cache.py"])
+
+        def boom(cmd, *a, **k):
+            raise RuntimeError("subprocess explosion")
+
+        def unwritable(self, *a, **k):
+            raise OSError("No space left on device")
+
+        monkeypatch.setattr(
+            "scripts.pr_validate.steps.diff_coverage.subprocess.run", boom
+        )
+        monkeypatch.setattr(Path, "write_text", unwritable)
+        res = DiffCoverageStep().run(ctx)
+        assert res.status == "skip"
 
     def test_execute_wrapper_skips_when_gated_out(self, ctx_factory, monkeypatch):
         # Through the base execute() wrapper, a docs-only PR gates out.

--- a/tests/test_pr_validate_diff_coverage.py
+++ b/tests/test_pr_validate_diff_coverage.py
@@ -32,6 +32,7 @@ from scripts.pr_validate.steps.diff_coverage import (
     _parse_diff_cover,
     _path_exists,
     _run_group_bounded,
+    _safe_write,
 )
 
 # --------------------------------------------------------------------------
@@ -144,6 +145,45 @@ class TestPathExists:
 
         monkeypatch.setattr(Path, "exists", exists_boom)
         assert _path_exists(tmp_path / "x") is False
+
+
+class TestSafeWrite:
+    def test_reports_success_and_writes_content(self, tmp_path):
+        p = tmp_path / "log"
+        assert _safe_write(p, "hello ☃") is True
+        assert p.read_text(encoding="utf-8") == "hello ☃"
+
+    def test_reports_failure_and_clears_stale_file(self, tmp_path, monkeypatch):
+        # codex #1220 r19 (B3): when the write fails, _safe_write must report
+        # False AND best-effort remove any stale prior-run file so it can't be
+        # mistaken for this run's diagnostic.
+        p = tmp_path / "log"
+        p.write_text("STALE PRIOR RUN")
+
+        def boom(self, *a, **k):
+            raise OSError("disk full")
+
+        monkeypatch.setattr(Path, "write_text", boom)
+        assert _safe_write(p, "fresh") is False
+        assert not p.exists()  # stale file cleared
+
+    def test_failure_never_raises_even_if_stale_unlink_fails(
+        self, tmp_path, monkeypatch
+    ):
+        # Belt-and-braces: a double fault (write fails AND the stale-file unlink
+        # fails) must still return False, never raise.
+        p = tmp_path / "log"
+        p.write_text("STALE")
+
+        def write_boom(self, *a, **k):
+            raise OSError("disk full")
+
+        def unlink_boom(self, *a, **k):
+            raise OSError("read-only fs")
+
+        monkeypatch.setattr(Path, "write_text", write_boom)
+        monkeypatch.setattr(Path, "unlink", unlink_boom)
+        assert _safe_write(p, "fresh") is False
 
 
 # --------------------------------------------------------------------------
@@ -444,6 +484,27 @@ class TestAdvisoryContract:
         )
         res = DiffCoverageStep().run(ctx)
         assert res.status == "skip"
+
+    def test_log_not_advertised_when_write_fails(self, ctx_factory, monkeypatch):
+        # codex #1220 r19 (B3): the diagnostic log is attached only when THIS
+        # run's _safe_write succeeded. A failed write (which may leave a stale
+        # prior-run file behind) must NOT advertise that file as this run's
+        # artifact.
+        import scripts.pr_validate.steps.diff_coverage as _dc
+
+        _both_tools_present(monkeypatch)
+        ctx = ctx_factory(["vllm_mlx/quantized_batch_cache.py"])
+        monkeypatch.setattr(_dc, "_safe_write", lambda *a, **k: False)
+
+        def fake_run(cmd, *a, **k):
+            # Clean exit, no xml -> the no-xml skip path writes a dump (forced to
+            # fail here) then must NOT attach the log.
+            return subprocess.CompletedProcess(cmd, 0, stdout="ok", stderr="")
+
+        monkeypatch.setattr(_dc, "_run_group_bounded", fake_run)
+        res = DiffCoverageStep().run(ctx)
+        assert res.status == "skip"
+        assert res.artifacts == []  # write failed -> nothing advertised
 
     def test_skip_on_pytest_timeout(self, ctx_factory, monkeypatch):
         _both_tools_present(monkeypatch)
@@ -765,55 +826,79 @@ class TestRunGroupBounded:
         assert proc.returncode == 0, proc.stderr
         assert "threaded-ok" in proc.stdout
 
-    def test_clean_exit_sweeps_a_lingering_pipe_holding_descendant(
+    def test_clean_exit_does_not_block_on_a_lingering_pipe_holder(
         self, tmp_path, monkeypatch
     ):
-        # codex #1220 r18 (B1): the leader can exit CLEANLY (rc 0) while a
-        # background descendant it spawned stays alive in the same group,
-        # holding the inherited stdout pipe open. ``proc.wait()`` reaps only the
-        # leader, so a naive clean path would both block the reader forever AND
-        # leak the descendant into later steps. The teardown must sweep it: a
-        # still-blocked reader proves a group member is alive, so the PGID is
-        # still reserved and ``killpg`` is race-free even after the leader was
-        # reaped. This test fails if the sweep regresses (heartbeat keeps
-        # growing) or if the call hangs (never returns).
+        # codex #1220 r19 (B1): on a CLEAN exit we must NOT sweep the group —
+        # once ``proc.wait`` reaps the leader the PGID can be recycled (a
+        # descendant may ``setsid()`` away while still holding the pipe), so a
+        # ``killpg`` could land on an UNRELATED group. The safe, race-free
+        # behavior is to drain the readers under a bound and RETURN even if a
+        # pipe-holder lingers (a benign leak at parity with the gating
+        # full_unit), never blocking. This test proves the call returns promptly
+        # with rc 0 rather than waiting out the descendant's lifetime.
         import time as _time
 
         from scripts.pr_validate.steps import diff_coverage as _dc
 
-        # Keep the test fast: the first (doomed) reader join waits
-        # _REAP_TIMEOUT_S before the sweep fires.
-        monkeypatch.setattr(_dc, "_REAP_TIMEOUT_S", 0.5)
+        # Small bound so the doomed reader joins return quickly.
+        monkeypatch.setattr(_dc, "_REAP_TIMEOUT_S", 0.3)
 
-        heartbeat = tmp_path / "hb"
-        # Leader backgrounds a grandchild that holds the inherited stdout pipe
-        # (the subshell keeps fd 1 open) and ticks a heartbeat every 50 ms, then
-        # EXITS 0. The grandchild stays in the leader's process group. Path is a
-        # positional ($1), never interpolated — an apostrophe in tmp_path would
-        # otherwise break the single-quoted script (codex #1220 r9).
+        # Leader backgrounds a grandchild that holds the inherited stdout/stderr
+        # pipes for ~2 s, then the leader EXITS 0. The grandchild self-terminates
+        # so the test leaks nothing; the point is only that we don't WAIT for it.
         cmd = [
             "sh",
             "-c",
-            '(while true; do printf . >> "$1"; sleep 0.05; done) & exit 0',
-            "sh",  # $0
-            str(heartbeat),  # $1
+            "(for _ in $(seq 1 40); do sleep 0.05; done) & exit 0",
         ]
+        t0 = _time.time()
         proc = _dc._run_group_bounded(cmd, cwd=str(tmp_path), timeout=30)
-        assert proc.returncode == 0  # clean exit — did NOT hang or time out
+        elapsed = _time.time() - t0
+        assert proc.returncode == 0  # clean exit, did NOT hang
+        # Returned on the bounded-drain path (~2 × 0.3 s), NOT after the
+        # grandchild's ~2 s lifetime — proves we didn't block on the lingering
+        # pipe-holder (and didn't try a dangerous post-reap group sweep).
+        assert elapsed < 1.5, f"blocked {elapsed:.2f}s on a lingering pipe-holder"
 
-        # Grandchild must have started (so "stopped" is meaningful), then been
-        # swept by the clean-exit teardown: the heartbeat stops growing.
-        deadline = _time.time() + 5.0
-        while not heartbeat.exists() and _time.time() < deadline:
-            _time.sleep(0.02)
-        assert heartbeat.exists(), "grandchild never started — test inconclusive"
-        size1 = heartbeat.stat().st_size
-        _time.sleep(1.0)
-        size2 = heartbeat.stat().st_size
-        assert size1 == size2, (
-            f"heartbeat kept growing after a clean exit ({size1} → {size2} "
-            "bytes) — the teardown leaked a lingering pipe-holding descendant "
-            "instead of sweeping the group"
+    def test_reader_start_failure_kills_child_and_reraises(self, tmp_path, monkeypatch):
+        # codex #1220 r19 (B2): if starting a reader thread fails AFTER Popen
+        # succeeded (e.g. RuntimeError: can't start new thread), the child is
+        # already running with open pipes. The setup guard must kill + reap the
+        # group and re-raise, never leak the child.
+        from scripts.pr_validate.steps import diff_coverage as _dc
+
+        # Record the real child so we can assert it was reaped.
+        procs: list[subprocess.Popen] = []
+        real_popen = subprocess.Popen
+
+        def rec_popen(*a, **k):
+            p = real_popen(*a, **k)
+            procs.append(p)
+            return p
+
+        monkeypatch.setattr(_dc.subprocess, "Popen", rec_popen)
+
+        # Fail the FIRST reader start; the child (a long sleeper) would survive
+        # unless the guard tears it down.
+        calls = {"n": 0}
+
+        def flaky_start(self):
+            calls["n"] += 1
+            raise RuntimeError("can't start new thread")
+
+        monkeypatch.setattr(_dc._TailReader, "start", flaky_start)
+
+        with pytest.raises(RuntimeError):
+            _dc._run_group_bounded(
+                [sys.executable, "-c", "import time; time.sleep(30)"],
+                cwd=str(tmp_path),
+                timeout=30,
+            )
+        assert procs, "Popen was never called"
+        # The guard must have killed AND reaped the child (poll() != None).
+        assert procs[0].poll() is not None, (
+            "child left running after a reader-start failure — setup guard leaked it"
         )
 
     def test_capture_is_bounded_to_a_tail_on_a_runaway_child(self):

--- a/tests/test_pr_validate_diff_coverage.py
+++ b/tests/test_pr_validate_diff_coverage.py
@@ -203,6 +203,46 @@ class TestAdvisoryContract:
         assert "80" in res.summary
         assert res.findings and "ADVISORY" in res.findings[0]
 
+    @pytest.mark.parametrize(
+        "base_sha, base_branch, expected_ref",
+        [
+            ("abc123def", "main", "abc123def"),  # known base → the SHA itself
+            ("", "main", "origin/main"),  # no metadata → remote-qualified branch
+            ("", "release-0.11", "origin/release-0.11"),  # release-branch PR
+        ],
+    )
+    def test_diff_cover_command_is_well_formed(
+        self, ctx_factory, monkeypatch, base_sha, base_branch, expected_ref
+    ):
+        # nit (codex #1220 r6): the happy-path mock accepted ANY diff-cover
+        # invocation, so a broken module name / args / compare-ref stayed
+        # green. Pin the fully-constructed command — including base compare-ref
+        # resolution: the SHA when known, else ``origin/<branch>`` so it
+        # resolves in a detached CI checkout (a bare local branch may not).
+        _both_tools_present(monkeypatch)
+        ctx = ctx_factory(["vllm_mlx/quantized_batch_cache.py"])
+        ctx.base_sha = base_sha
+        ctx.base_branch = base_branch
+        captured: dict[str, list[str]] = {}
+
+        def fake_run(cmd, *a, **k):
+            if "pytest" in cmd:
+                Path(_xml_target(cmd)).write_text("<coverage/>")
+                return subprocess.CompletedProcess(cmd, 0, stdout="ok", stderr="")
+            captured["dc_cmd"] = cmd
+            return subprocess.CompletedProcess(cmd, 0, stdout=_DC_WITH_LINES, stderr="")
+
+        monkeypatch.setattr(
+            "scripts.pr_validate.steps.diff_coverage._run_group_bounded", fake_run
+        )
+        res = DiffCoverageStep().run(ctx)
+        assert res.status == "pass"
+        dc = captured["dc_cmd"]
+        assert dc[:3] == [sys.executable, "-m", "diff_cover.diff_cover_tool"]
+        assert dc[3].endswith("coverage.xml")
+        assert dc[4] == "--compare-branch"
+        assert dc[5] == expected_ref
+
     def test_measures_with_caveat_when_some_tests_failed(
         self, ctx_factory, monkeypatch
     ):

--- a/tests/test_pr_validate_diff_coverage.py
+++ b/tests/test_pr_validate_diff_coverage.py
@@ -766,30 +766,51 @@ class TestRunGroupBounded:
         assert proc.returncode == 0, proc.stderr
         assert "threaded-ok" in proc.stdout
 
-    def test_output_size_is_capped_by_kernel_rlimit(self, monkeypatch):
-        # F1 (codex #1220 r11): disk is bounded by a KERNEL RLIMIT_FSIZE set on
-        # the child (via preexec_fn), NOT a userspace size-poll. So a child that
-        # dumps far past the quota — even faster than, or entirely between, any
-        # poll would run — is refused at the write(2) syscall (SIGXFSZ, or EFBIG
-        # if caught) instead of being allowed to exhaust the host. Shrink the
-        # quota so the test is fast and cheap.
+    def test_output_size_is_capped_by_kernel_rlimit(self, tmp_path, monkeypatch):
+        # codex #1220 r11: any single file the child writes is bounded by a
+        # KERNEL RLIMIT_FSIZE (set by the exec-based wrapper), NOT a userspace
+        # size-poll — so a write past the cap is refused at write(2) (SIGXFSZ,
+        # or EFBIG if caught) regardless of timing. Shrink the quota so the
+        # test is fast.
+        #
+        # The child writes to a REAL FILE the test owns and then we stat() it,
+        # rather than inspecting _read_capped(stdout): the read-back is itself
+        # capped at _STDOUT_CAP_BYTES, which would mask a kernel cap that leaked
+        # far more than the configured quota to disk (codex #1220 r13). The
+        # on-disk size is the honest, un-truncated evidence.
+        import signal as _signal
+
         import scripts.pr_validate.steps.diff_coverage as dc
 
-        monkeypatch.setattr(dc, "_OUTPUT_QUOTA_BYTES", 64 * 1024)  # 64 KiB
-        # One-shot write of 4 MiB (>> quota) to the temp file. The kernel
-        # refuses the write past 64 KiB: the child dies on SIGXFSZ (negative rc)
-        # or exits nonzero on EFBIG — either way it exits on its own (no
-        # timeout), so we get a CompletedProcess, not a TimeoutExpired.
+        quota = 64 * 1024  # 64 KiB
+        monkeypatch.setattr(dc, "_OUTPUT_QUOTA_BYTES", quota)
+        victim = tmp_path / "victim.bin"
+        # Attempt 8 MiB (>> quota) in 1 MiB raw os.write chunks. The kernel
+        # short-writes the first chunk up to the cap and returns; the NEXT
+        # os.write, with the file already at the limit, attempts to extend past
+        # it and delivers SIGXFSZ (default-fatal), killing the child. So the
+        # child exits on its own (no timeout) → CompletedProcess.
         code = (
-            "import sys\nsys.stdout.write('X' * (4 * 1024 * 1024))\nsys.stdout.flush()"
+            f"import os\n"
+            f"fd = os.open({str(victim)!r}, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)\n"
+            "buf = b'X' * (1024 * 1024)\n"
+            "for _ in range(8):\n"
+            "    os.write(fd, buf)\n"
         )
         proc = _run_group_bounded([sys.executable, "-c", code], cwd=".", timeout=30)
 
+        # rc != 0 proves the cap ENGAGED: a clean rc of 0 is only reachable if
+        # all 8 writes succeeded (cap never fired). SIGXFSZ → negative rc; a
+        # platform delivering EFBIG instead → nonzero exit from the OSError.
         assert proc.returncode != 0, (
             "child writing past the RLIMIT_FSIZE quota should have died "
             f"(SIGXFSZ) or errored (EFBIG); got rc={proc.returncode}"
         )
-        # Disk stayed bounded — the child never landed the 4 MiB it attempted
-        # (kernel stopped it at the ~64 KiB cap; read-back is also capped).
-        assert len(proc.stdout) <= dc._STDOUT_CAP_BYTES
-        assert len(proc.stdout) < 4 * 1024 * 1024
+        assert proc.returncode == -_signal.SIGXFSZ or proc.returncode > 0
+        # The ACTUAL on-disk file never approached the 8 MiB attempted — the
+        # kernel held it at ~the quota (small slack for filesystem block
+        # rounding). This is the un-truncated proof the cap really bounds disk,
+        # NOT the _read_capped(stdout) tail which is itself size-limited (codex
+        # #1220 r13).
+        assert victim.exists()
+        assert victim.stat().st_size <= quota + 4096, victim.stat().st_size

--- a/tests/test_pr_validate_diff_coverage.py
+++ b/tests/test_pr_validate_diff_coverage.py
@@ -718,24 +718,30 @@ class TestRunGroupBounded:
             "leader-only kill"
         )
 
-    def test_output_quota_breach_kills_like_a_timeout(self, monkeypatch):
-        # F1 (codex #1220 r10): a child that streams past the disk quota is
-        # killed exactly like a timeout — long before the time budget — and
-        # the raised TimeoutExpired carries the captured tail for diagnostics
-        # (r10 F3). Shrink the quota + poll so the test is fast.
+    def test_output_size_is_capped_by_kernel_rlimit(self, monkeypatch):
+        # F1 (codex #1220 r11): disk is bounded by a KERNEL RLIMIT_FSIZE set on
+        # the child (via preexec_fn), NOT a userspace size-poll. So a child that
+        # dumps far past the quota — even faster than, or entirely between, any
+        # poll would run — is refused at the write(2) syscall (SIGXFSZ, or EFBIG
+        # if caught) instead of being allowed to exhaust the host. Shrink the
+        # quota so the test is fast and cheap.
         import scripts.pr_validate.steps.diff_coverage as dc
 
-        monkeypatch.setattr(dc, "_OUTPUT_QUOTA_BYTES", 1024)  # 1 KiB
-        monkeypatch.setattr(dc, "_POLL_INTERVAL_S", 1)
-        # Write 200 KiB (>> quota), flush to the temp file, then block so the
-        # child is still alive at the first poll.
+        monkeypatch.setattr(dc, "_OUTPUT_QUOTA_BYTES", 64 * 1024)  # 64 KiB
+        # One-shot write of 4 MiB (>> quota) to the temp file. The kernel
+        # refuses the write past 64 KiB: the child dies on SIGXFSZ (negative rc)
+        # or exits nonzero on EFBIG — either way it exits on its own (no
+        # timeout), so we get a CompletedProcess, not a TimeoutExpired.
         code = (
-            "import sys, time; "
-            "sys.stdout.write('X' * 200000); sys.stdout.flush(); "
-            "time.sleep(60)"
+            "import sys\nsys.stdout.write('X' * (4 * 1024 * 1024))\nsys.stdout.flush()"
         )
-        with pytest.raises(subprocess.TimeoutExpired) as ei:
-            # timeout=30 >> the ~1s it takes to trip the quota, so a raise here
-            # proves the QUOTA fired, not the clock.
-            _run_group_bounded([sys.executable, "-c", code], cwd=".", timeout=30)
-        assert ei.value.stdout and "X" in ei.value.stdout  # tail attached
+        proc = _run_group_bounded([sys.executable, "-c", code], cwd=".", timeout=30)
+
+        assert proc.returncode != 0, (
+            "child writing past the RLIMIT_FSIZE quota should have died "
+            f"(SIGXFSZ) or errored (EFBIG); got rc={proc.returncode}"
+        )
+        # Disk stayed bounded — the child never landed the 4 MiB it attempted
+        # (kernel stopped it at the ~64 KiB cap; read-back is also capped).
+        assert len(proc.stdout) <= dc._STDOUT_CAP_BYTES
+        assert len(proc.stdout) < 4 * 1024 * 1024

--- a/tests/test_pr_validate_diff_coverage.py
+++ b/tests/test_pr_validate_diff_coverage.py
@@ -752,7 +752,9 @@ class TestRunGroupBounded:
                 timeout=1,
             )
 
-    def test_timeout_kills_the_whole_group_including_descendants(self, tmp_path):
+    def test_timeout_kills_the_whole_group_including_descendants(
+        self, tmp_path, monkeypatch
+    ):
         # The contract that actually matters: on timeout the ENTIRE process
         # group dies, not just the leader. A leader-only kill would orphan
         # any grandchild a timed-out pytest spawned (xdist workers, a serve
@@ -776,7 +778,25 @@ class TestRunGroupBounded:
         # the shell's group), then blocks so the leader is alive when the
         # timeout fires. The grandchild inherits the subprocess pipes, so a
         # leader-only kill would also reproduce the reap-wedge from codex #1220.
+        import signal as _signal
         import time as _time
+
+        from scripts.pr_validate.steps import diff_coverage as _dc
+
+        # Record the leader so the finally can sweep its group. Belt-and-braces:
+        # on a PASS the code-under-test already killed the group, but if this
+        # test ever FAILS (leader-only-kill regression) the grandchild is an
+        # infinite `while true` loop — leaving it running would leak forever and
+        # contaminate later tests (codex #1220 final-run B2).
+        procs: list[subprocess.Popen] = []
+        real_popen = subprocess.Popen
+
+        def rec_popen(*a, **k):
+            p = real_popen(*a, **k)
+            procs.append(p)
+            return p
+
+        monkeypatch.setattr(_dc.subprocess, "Popen", rec_popen)
 
         heartbeat = tmp_path / "heartbeat"
         # Pass the path as a POSITIONAL arg ("$1"), never interpolated into
@@ -790,27 +810,37 @@ class TestRunGroupBounded:
             str(heartbeat),  # $1
         ]
 
-        with pytest.raises(subprocess.TimeoutExpired):
-            _run_group_bounded(cmd, cwd=str(tmp_path), timeout=1)
+        try:
+            with pytest.raises(subprocess.TimeoutExpired):
+                _run_group_bounded(cmd, cwd=str(tmp_path), timeout=1)
 
-        # Grandchild must have started (heartbeat exists) before we can judge
-        # whether it STOPPED. It ticks every 50 ms and the leader ran for the
-        # full 1 s timeout, so the file exists well before we get here.
-        deadline = _time.time() + 5.0
-        while not heartbeat.exists() and _time.time() < deadline:
-            _time.sleep(0.02)
-        assert heartbeat.exists(), "grandchild never started — test is inconclusive"
+            # Grandchild must have started (heartbeat exists) before we can judge
+            # whether it STOPPED. It ticks every 50 ms and the leader ran for the
+            # full 1 s timeout, so the file exists well before we get here.
+            deadline = _time.time() + 5.0
+            while not heartbeat.exists() and _time.time() < deadline:
+                _time.sleep(0.02)
+            assert heartbeat.exists(), "grandchild never started — inconclusive"
 
-        # Sample size, wait several heartbeat intervals, sample again. A dead
-        # grandchild leaves the size fixed; a survivor grows it by ~20 bytes/s.
-        size1 = heartbeat.stat().st_size
-        _time.sleep(1.0)
-        size2 = heartbeat.stat().st_size
-        assert size1 == size2, (
-            f"heartbeat kept growing after the timeout ({size1} → {size2} "
-            "bytes) — the grandchild survived, so group-kill regressed to a "
-            "leader-only kill"
-        )
+            # Sample size, wait several heartbeat intervals, sample again. A dead
+            # grandchild leaves the size fixed; a survivor grows it ~20 bytes/s.
+            size1 = heartbeat.stat().st_size
+            _time.sleep(1.0)
+            size2 = heartbeat.stat().st_size
+            assert size1 == size2, (
+                f"heartbeat kept growing after the timeout ({size1} → {size2} "
+                "bytes) — the grandchild survived, so group-kill regressed to a "
+                "leader-only kill"
+            )
+        finally:
+            # Sweep the group unconditionally: on a pass it is already dead
+            # (killpg → ESRCH, harmless); on a failure this reaps the leaked
+            # infinite grandchild instead of letting it run forever.
+            for p in procs:
+                try:
+                    os.killpg(p.pid, _signal.SIGKILL)
+                except OSError:
+                    pass
 
     def test_env_is_threaded_to_the_child(self):
         # The env= param must reach the child — the COVERAGE_FILE redirect and

--- a/tests/test_pr_validate_diff_coverage.py
+++ b/tests/test_pr_validate_diff_coverage.py
@@ -1,0 +1,292 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the ADVISORY ``diff_coverage`` pr_validate step.
+
+Two contracts matter most here and are the reason this file exists:
+
+1. **It can never block a merge.** ``diff_coverage`` is measure-only.
+   Every failure mode — missing tooling, no coverage.xml, an internal
+   crash, diff-cover finding nothing — must resolve to ``pass`` or
+   ``skip``, never ``fail`` / ``error``. If this contract ever breaks,
+   an advisory measurer would start gating merges, which is exactly
+   what the dev-flow proposal set out to avoid.
+
+2. **It only runs when there is production code to measure.** Docs-only,
+   tests-only, and deps-only PRs have no ``vllm_mlx`` lines for
+   diff-cover to score, so the step must gate itself out cleanly rather
+   than spend ~40 s instrumenting the suite for a guaranteed "no lines".
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from scripts.pr_validate.context import Context
+from scripts.pr_validate.steps.diff_coverage import (
+    DiffCoverageStep,
+    _parse_diff_cover,
+)
+
+# --------------------------------------------------------------------------
+# diff-cover output samples (verbatim shape of the tool's stdout footer)
+# --------------------------------------------------------------------------
+
+_DC_WITH_LINES = """\
+-------------
+Diff Coverage
+Diff: origin/main...HEAD, staged and unstaged changes
+-------------
+vllm_mlx/quantized_batch_cache.py (80.0%): Missing lines 12,45
+-------------
+Total:   10 lines
+Missing: 2 lines
+Coverage: 80%
+-------------
+"""
+
+_DC_NO_LINES = "No lines with coverage information in this diff.\n"
+
+_DC_FULL = """\
+-------------
+Diff Coverage
+Diff: origin/main...HEAD
+-------------
+vllm_mlx/foo.py (100%)
+-------------
+Total:   7 lines
+Missing: 0 lines
+Coverage: 100%
+-------------
+"""
+
+
+class TestParseDiffCover:
+    def test_parses_percent_and_line_counts(self):
+        parsed = _parse_diff_cover(_DC_WITH_LINES)
+        assert parsed is not None
+        pct, covered, total = parsed
+        assert (covered, total) == (8, 10)
+        assert pct == pytest.approx(80.0)
+
+    def test_percent_keeps_resolution_from_total_and_missing(self):
+        # 2/3 covered → 66.67%, computed from Total/Missing (NOT the
+        # rounded "Coverage: 67%" line), so the baseline keeps decimals.
+        text = "Total:   3 lines\nMissing: 1 lines\nCoverage: 67%\n"
+        parsed = _parse_diff_cover(text)
+        assert parsed is not None
+        pct, covered, total = parsed
+        assert (covered, total) == (2, 3)
+        assert pct == pytest.approx(66.666, abs=0.01)
+
+    def test_full_coverage(self):
+        parsed = _parse_diff_cover(_DC_FULL)
+        assert parsed == (100.0, 7, 7)
+
+    def test_no_lines_returns_none(self):
+        assert _parse_diff_cover(_DC_NO_LINES) is None
+
+    def test_malformed_returns_none(self):
+        assert _parse_diff_cover("garbage without a footer") is None
+        assert _parse_diff_cover("") is None
+
+    def test_zero_total_returns_none(self):
+        # Guard against a divide-by-zero if diff-cover ever emits a
+        # degenerate "Total: 0 lines".
+        assert _parse_diff_cover("Total:   0 lines\nMissing: 0 lines\n") is None
+
+
+# --------------------------------------------------------------------------
+# Context helper — Context.__post_init__ insists on a repo-root cwd.
+# --------------------------------------------------------------------------
+
+
+@pytest.fixture
+def ctx_factory(tmp_path, monkeypatch):
+    (tmp_path / "pyproject.toml").write_text("[project]\nname = 'fake'\n")
+    monkeypatch.chdir(tmp_path)
+
+    def _make(files_changed: list[str]) -> Context:
+        ctx = Context(pr_number=1)
+        ctx.files_changed = files_changed
+        ctx.work_dir = tmp_path / "work"
+        return ctx
+
+    return _make
+
+
+class TestShouldRun:
+    def test_runs_on_production_change_medium_blast(self, ctx_factory):
+        ctx = ctx_factory(["vllm_mlx/quantized_batch_cache.py"])
+        assert ctx.blast_radius == "medium"
+        assert DiffCoverageStep().should_run(ctx) is True
+
+    def test_runs_on_production_change_high_blast(self, ctx_factory):
+        ctx = ctx_factory(["vllm_mlx/scheduler.py"])
+        assert ctx.blast_radius == "high"
+        assert DiffCoverageStep().should_run(ctx) is True
+
+    def test_skips_docs_only_low_blast(self, ctx_factory):
+        ctx = ctx_factory(["docs/guide.md", "README.md"])
+        assert ctx.blast_radius == "low"
+        assert DiffCoverageStep().should_run(ctx) is False
+
+    def test_skips_tests_only(self, ctx_factory):
+        # medium blast (tests/ isn't low), but no production lines to score.
+        ctx = ctx_factory(["tests/test_foo.py"])
+        assert DiffCoverageStep().should_run(ctx) is False
+
+    def test_skips_deps_only(self, ctx_factory):
+        # pyproject.toml is high blast, yet still nothing under vllm_mlx/.
+        ctx = ctx_factory(["pyproject.toml"])
+        assert ctx.blast_radius == "high"
+        assert DiffCoverageStep().should_run(ctx) is False
+
+    def test_skips_non_python_production_file(self, ctx_factory):
+        ctx = ctx_factory(["vllm_mlx/py.typed"])
+        assert DiffCoverageStep().should_run(ctx) is False
+
+
+# --------------------------------------------------------------------------
+# The advisory contract: never fail/error, whatever the subprocesses do.
+# --------------------------------------------------------------------------
+
+
+def _both_tools_present(monkeypatch):
+    """Make the tooling-availability probe report both tools installed."""
+    import importlib.util as _u
+
+    real = _u.find_spec
+
+    def fake_find_spec(name, *a, **k):
+        if name in ("pytest_cov", "diff_cover"):
+            # Return a truthy sentinel — the step only checks ``is None``.
+            return object()
+        return real(name, *a, **k)
+
+    monkeypatch.setattr(
+        "scripts.pr_validate.steps.diff_coverage.importlib.util.find_spec",
+        fake_find_spec,
+    )
+
+
+def _xml_target(cmd: list[str]) -> str | None:
+    for part in cmd:
+        if part.startswith("--cov-report=xml:"):
+            return part.split("xml:", 1)[1]
+    return None
+
+
+class TestAdvisoryContract:
+    def test_pass_with_finding_on_good_run(self, ctx_factory, monkeypatch):
+        _both_tools_present(monkeypatch)
+        ctx = ctx_factory(["vllm_mlx/quantized_batch_cache.py"])
+
+        def fake_run(cmd, *a, **k):
+            if "pytest" in cmd:
+                # Simulate a RED suite (returncode 1) that still writes
+                # coverage.xml — proves we don't gate on pytest's exit.
+                target = _xml_target(cmd)
+                assert target is not None
+                Path(target).write_text("<coverage/>")
+                return subprocess.CompletedProcess(cmd, 1, stdout="1 failed", stderr="")
+            # diff-cover invocation.
+            return subprocess.CompletedProcess(cmd, 0, stdout=_DC_WITH_LINES, stderr="")
+
+        monkeypatch.setattr(
+            "scripts.pr_validate.steps.diff_coverage.subprocess.run", fake_run
+        )
+        res = DiffCoverageStep().run(ctx)
+        assert res.status == "pass"
+        assert "80" in res.summary
+        assert res.findings and "ADVISORY" in res.findings[0]
+
+    def test_skip_when_no_coverage_xml(self, ctx_factory, monkeypatch):
+        _both_tools_present(monkeypatch)
+        ctx = ctx_factory(["vllm_mlx/quantized_batch_cache.py"])
+
+        def fake_run(cmd, *a, **k):
+            # pytest errored at collection: no xml written.
+            return subprocess.CompletedProcess(cmd, 2, stdout="errors", stderr="")
+
+        monkeypatch.setattr(
+            "scripts.pr_validate.steps.diff_coverage.subprocess.run", fake_run
+        )
+        res = DiffCoverageStep().run(ctx)
+        assert res.status == "skip"
+
+    def test_skip_when_diff_cover_finds_no_lines(self, ctx_factory, monkeypatch):
+        _both_tools_present(monkeypatch)
+        ctx = ctx_factory(["vllm_mlx/quantized_batch_cache.py"])
+
+        def fake_run(cmd, *a, **k):
+            if "pytest" in cmd:
+                Path(_xml_target(cmd)).write_text("<coverage/>")
+                return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+            return subprocess.CompletedProcess(cmd, 0, stdout=_DC_NO_LINES, stderr="")
+
+        monkeypatch.setattr(
+            "scripts.pr_validate.steps.diff_coverage.subprocess.run", fake_run
+        )
+        res = DiffCoverageStep().run(ctx)
+        assert res.status == "skip"
+
+    def test_skip_when_tooling_missing(self, ctx_factory, monkeypatch):
+        # find_spec returns None for pytest_cov → clean skip, no subprocess.
+        import importlib.util as _u
+
+        real = _u.find_spec
+        monkeypatch.setattr(
+            "scripts.pr_validate.steps.diff_coverage.importlib.util.find_spec",
+            lambda name, *a, **k: None if name == "pytest_cov" else real(name),
+        )
+        ctx = ctx_factory(["vllm_mlx/quantized_batch_cache.py"])
+        res = DiffCoverageStep().run(ctx)
+        assert res.status == "skip"
+        assert "pytest-cov" in res.summary
+
+    def test_internal_crash_downgrades_to_skip_not_error(
+        self, ctx_factory, monkeypatch
+    ):
+        _both_tools_present(monkeypatch)
+        ctx = ctx_factory(["vllm_mlx/quantized_batch_cache.py"])
+
+        def boom(cmd, *a, **k):
+            raise RuntimeError("simulated subprocess explosion")
+
+        monkeypatch.setattr(
+            "scripts.pr_validate.steps.diff_coverage.subprocess.run", boom
+        )
+        res = DiffCoverageStep().run(ctx)
+        # The whole point: a crash in the measurer must NOT surface as
+        # error (which the scorecard treats as blocking).
+        assert res.status == "skip"
+        assert res.status not in ("fail", "error")
+
+    def test_execute_wrapper_skips_when_gated_out(self, ctx_factory, monkeypatch):
+        # Through the base execute() wrapper, a docs-only PR gates out.
+        ctx = ctx_factory(["docs/x.md"])
+        res = DiffCoverageStep().execute(ctx)
+        assert res.status == "skip"
+
+
+# --------------------------------------------------------------------------
+# Registration — advisory step is wired in and positioned last.
+# --------------------------------------------------------------------------
+
+
+class TestRegistration:
+    def test_registered_and_last(self):
+        from scripts.pr_validate.runner import STEPS
+
+        names = [s.name for s in STEPS]
+        assert "diff_coverage" in names
+        # Last on purpose: skip its ~40 s cost in fail-fast mode once any
+        # real gate above has already blocked the PR.
+        assert names[-1] == "diff_coverage"
+
+    def test_never_declared_as_gating(self):
+        # A defensive pin on the advisory intent: the step opts into
+        # continue_on_error so a stray error can't halt the pipeline.
+        assert DiffCoverageStep().continue_on_error is True

--- a/tests/test_pr_validate_diff_coverage.py
+++ b/tests/test_pr_validate_diff_coverage.py
@@ -26,9 +26,11 @@ import pytest
 
 from scripts.pr_validate.context import Context
 from scripts.pr_validate.steps.diff_coverage import (
+    _PARSE_FAILED,
     DiffCoverageStep,
     _parse_diff_cover,
     _path_exists,
+    _read_capped,
     _run_group_bounded,
 )
 
@@ -88,16 +90,54 @@ class TestParseDiffCover:
         assert parsed == (100.0, 7, 7)
 
     def test_no_lines_returns_none(self):
+        # The explicit no-lines message is the LEGITIMATE nothing-to-score
+        # case → None (distinct from an unrecognized footer, below).
         assert _parse_diff_cover(_DC_NO_LINES) is None
 
-    def test_malformed_returns_none(self):
-        assert _parse_diff_cover("garbage without a footer") is None
-        assert _parse_diff_cover("") is None
+    def test_unrecognized_output_is_parse_failed(self):
+        # Neither the no-lines message nor a Total/Missing footer → format
+        # drift, surfaced distinctly (NOT None) so it can't masquerade as
+        # "no lines" and silently kill baseline collection.
+        assert _parse_diff_cover("garbage without a footer") is _PARSE_FAILED
+        assert _parse_diff_cover("") is _PARSE_FAILED
+        # A partial footer (Total but no Missing) is also unrecognized.
+        assert _parse_diff_cover("Total:   10 lines\n") is _PARSE_FAILED
 
     def test_zero_total_returns_none(self):
-        # Guard against a divide-by-zero if diff-cover ever emits a
-        # degenerate "Total: 0 lines".
+        # A well-formed but degenerate "Total: 0 lines" footer is a genuine
+        # nothing-to-score (and guards divide-by-zero) → None, not a parse
+        # failure.
         assert _parse_diff_cover("Total:   0 lines\nMissing: 0 lines\n") is None
+
+
+class TestReadCapped:
+    def test_small_output_read_in_full(self):
+        import tempfile
+
+        with tempfile.TemporaryFile() as f:
+            f.write(b"small output")
+            assert _read_capped(f, limit=1000) == "small output"
+
+    def test_large_output_is_tail_capped(self):
+        # F1 (codex #1220 r8): read-back must be bounded no matter how much
+        # the child wrote — and the TAIL (where diff-cover's footer / pytest's
+        # summary live) is what we keep.
+        import tempfile
+
+        with tempfile.TemporaryFile() as f:
+            f.write(b"A" * 5000 + b"THE_TRAILING_FOOTER")
+            out = _read_capped(f, limit=64)
+            assert out.endswith("THE_TRAILING_FOOTER")  # tail preserved
+            assert "bytes elided" in out  # truncation announced
+            assert len(out) < 200  # bounded, nowhere near the 5k written
+
+    def test_lenient_decode_on_invalid_utf8(self):
+        import tempfile
+
+        with tempfile.TemporaryFile() as f:
+            f.write(b"\xff\xfe bad bytes")  # not valid UTF-8
+            out = _read_capped(f, limit=1000)  # must not raise
+            assert "bad bytes" in out
 
 
 class TestPathExists:
@@ -439,6 +479,34 @@ class TestAdvisoryContract:
         )
         res = DiffCoverageStep().run(ctx)
         assert res.status == "skip"
+
+    def test_skip_distinctly_on_unrecognized_diff_cover_output(
+        self, ctx_factory, monkeypatch
+    ):
+        # codex #1220 r8: diff-cover exits 0 but its output is neither the
+        # no-lines message nor a parseable footer (a future version whose
+        # format drifted). Must skip with a DISTINCT tooling-format message,
+        # not the "no measurable production lines" message, so a parser break
+        # can't silently masquerade as an empty diff.
+        _both_tools_present(monkeypatch)
+        ctx = ctx_factory(["vllm_mlx/quantized_batch_cache.py"])
+
+        def fake_run(cmd, *a, **k):
+            if "pytest" in cmd:
+                Path(_xml_target(cmd)).write_text("<coverage/>")
+                return subprocess.CompletedProcess(cmd, 0, stdout="ok", stderr="")
+            # Exit 0 but a totally unrecognized report shape.
+            return subprocess.CompletedProcess(
+                cmd, 0, stdout="Diff Coverage\n(new format we don't parse)\n", stderr=""
+            )
+
+        monkeypatch.setattr(
+            "scripts.pr_validate.steps.diff_coverage._run_group_bounded", fake_run
+        )
+        res = DiffCoverageStep().run(ctx)
+        assert res.status == "skip"
+        assert "format unrecognized" in res.summary
+        assert "no measurable production lines" not in res.summary
 
     def test_skip_when_tooling_missing(self, ctx_factory, monkeypatch):
         # find_spec returns None for pytest_cov → clean skip, no subprocess.

--- a/tests/test_pr_validate_diff_coverage.py
+++ b/tests/test_pr_validate_diff_coverage.py
@@ -814,3 +814,25 @@ class TestRunGroupBounded:
         # #1220 r13).
         assert victim.exists()
         assert victim.stat().st_size <= quota + 4096, victim.stat().st_size
+
+    def test_rlimit_wrapper_uses_isolated_startup(self):
+        # B1 (codex #1220 r14): the rlimit wrapper must run with ISOLATED
+        # startup so no repo-local `resource.py` / `sitecustomize.py` on the CWD
+        # can shadow or monkeypatch `resource.setrlimit` before the wrapper sets
+        # the disk cap. `-I` drops the CWD + user-site from sys.path and ignores
+        # PYTHON* env; `-S` skips site.py (hence sitecustomize).
+        #
+        # This asserts the flags are WIRED (and precede `-c`, so they are parsed
+        # as interpreter options, not program args) rather than attempting a
+        # behavioural shadow test: `resource` is a built-in module on our
+        # interpreters (BuiltinImporter wins over any sys.path `.py` regardless
+        # of `-I`), so a resource.py-shadow test would pass trivially and prove
+        # nothing. The end-to-end cap behaviour is covered by
+        # test_output_size_is_capped_by_kernel_rlimit.
+        from scripts.pr_validate.steps.diff_coverage import _rlimit_wrap
+
+        wrap = _rlimit_wrap()
+        assert wrap[0] == sys.executable
+        assert "-I" in wrap and "-S" in wrap
+        assert wrap.index("-I") < wrap.index("-c")
+        assert wrap.index("-S") < wrap.index("-c")

--- a/tests/test_pr_validate_diff_coverage.py
+++ b/tests/test_pr_validate_diff_coverage.py
@@ -290,6 +290,38 @@ class TestAdvisoryContract:
         assert dc[4] == "--compare-branch"
         assert dc[5] == expected_ref
 
+    def test_pytest_cmd_neutralizes_repo_addopts(self, ctx_factory, monkeypatch):
+        # codex #1220 r17 (N1): stripping the PYTEST_ADDOPTS env var is not
+        # enough — a repo-level ``addopts`` in pyproject.toml / pytest.ini (e.g.
+        # ``-x`` / ``--maxfail``) would still stop the suite early and hand us
+        # partial exit-1 coverage that we'd publish as the PR's number.
+        # ``-o addopts=`` overrides configured addopts so the argv is the
+        # complete, self-contained spec of the run; the env strip covers the
+        # other layer.
+        _both_tools_present(monkeypatch)
+        ctx = ctx_factory(["vllm_mlx/quantized_batch_cache.py"])
+        captured: dict[str, object] = {}
+
+        def fake_run(cmd, cwd, timeout, env=None):
+            if "pytest" in cmd:
+                captured["pytest_cmd"] = cmd
+                captured["env"] = env
+                Path(_xml_target(cmd)).write_text("<coverage/>")
+                return subprocess.CompletedProcess(cmd, 0, stdout="ok", stderr="")
+            return subprocess.CompletedProcess(cmd, 0, stdout=_DC_WITH_LINES, stderr="")
+
+        monkeypatch.setattr(
+            "scripts.pr_validate.steps.diff_coverage._run_group_bounded", fake_run
+        )
+        assert DiffCoverageStep().run(ctx).status == "pass"
+        cmd = captured["pytest_cmd"]
+        # ``-o addopts=`` present as consecutive argv items → clears any
+        # configured addopts from pyproject.toml / pytest.ini.
+        assert "-o" in cmd
+        assert cmd[cmd.index("-o") + 1] == "addopts="
+        # And the env var is stripped too — both override layers neutralized.
+        assert "PYTEST_ADDOPTS" not in captured["env"]
+
     def test_coverage_data_file_is_redirected_off_repo_root(
         self, ctx_factory, monkeypatch
     ):
@@ -732,3 +764,31 @@ class TestRunGroupBounded:
         )
         assert proc.returncode == 0, proc.stderr
         assert "threaded-ok" in proc.stdout
+
+    def test_capture_is_bounded_to_a_tail_on_a_runaway_child(self):
+        # codex #1220 r17 (B2): a plain communicate() buffers the ENTIRE child
+        # output in memory, so a runaway test streaming gigabytes could OOM the
+        # validator before its advisory handler runs. Capture must instead keep
+        # only a bounded TAIL. Emit a START marker, ~4 MiB of filler, then an
+        # END marker: the END (where pytest's -q summary / diff-cover's footer
+        # live) must survive, the START must be evicted, and total retained must
+        # stay within one block of the cap.
+        from scripts.pr_validate.steps.diff_coverage import (
+            _CAPTURE_BLOCK_BYTES,
+            _CAPTURE_TAIL_BYTES,
+        )
+
+        code = (
+            "import sys\n"
+            "sys.stdout.write('START-MARKER\\n')\n"
+            "sys.stdout.write('x' * (4 * 1024 * 1024))\n"
+            "sys.stdout.write('\\nEND-MARKER\\n')\n"
+            "sys.stdout.flush()\n"
+        )
+        proc = _run_group_bounded([sys.executable, "-c", code], cwd=".", timeout=60)
+        assert proc.returncode == 0, proc.stderr
+        # Tail retained — the END marker is always kept.
+        assert "END-MARKER" in proc.stdout
+        # Head/middle dropped — memory stayed bounded, START marker evicted.
+        assert "START-MARKER" not in proc.stdout
+        assert len(proc.stdout) <= _CAPTURE_TAIL_BYTES + _CAPTURE_BLOCK_BYTES

--- a/tests/test_pr_validate_diff_coverage.py
+++ b/tests/test_pr_validate_diff_coverage.py
@@ -290,6 +290,45 @@ class TestAdvisoryContract:
         assert res.status == "skip"
         assert "diff-cover" in res.summary and "exceeded" in res.summary
 
+    def test_skip_on_diff_cover_nonzero_exit_even_with_footer(
+        self, ctx_factory, monkeypatch
+    ):
+        # codex #1220 r2: a failed/interrupted diff-cover that still
+        # printed a parseable footer must NOT be published as success.
+        _both_tools_present(monkeypatch)
+        ctx = ctx_factory(["vllm_mlx/quantized_batch_cache.py"])
+
+        def fake_run(cmd, *a, **k):
+            if "pytest" in cmd:
+                Path(_xml_target(cmd)).write_text("<coverage/>")
+                return subprocess.CompletedProcess(cmd, 0, stdout="ok", stderr="")
+            # diff-cover errored (exit 1) but emitted a valid-looking footer.
+            return subprocess.CompletedProcess(
+                cmd, 1, stdout=_DC_WITH_LINES, stderr="err"
+            )
+
+        monkeypatch.setattr(
+            "scripts.pr_validate.steps.diff_coverage.subprocess.run", fake_run
+        )
+        res = DiffCoverageStep().run(ctx)
+        assert res.status == "skip"
+        assert "diff-cover exit 1" in res.summary
+
+    def test_skip_when_artifact_path_raises(self, ctx_factory, monkeypatch):
+        # codex #1220 r2: artifact_path() does a mkdir that can raise on
+        # disk-full / permission errors. That must be caught and skipped,
+        # not escape through execute() as a blocking error.
+        ctx = ctx_factory(["vllm_mlx/quantized_batch_cache.py"])
+
+        def raising_artifact_path(name):
+            raise OSError("Read-only file system")
+
+        monkeypatch.setattr(ctx, "artifact_path", raising_artifact_path)
+        res = DiffCoverageStep().run(ctx)
+        assert res.status == "skip"
+        assert res.status not in ("fail", "error")
+        assert res.artifacts == []  # no log path could be resolved
+
     def test_skip_when_diff_cover_finds_no_lines(self, ctx_factory, monkeypatch):
         _both_tools_present(monkeypatch)
         ctx = ctx_factory(["vllm_mlx/quantized_batch_cache.py"])

--- a/tests/test_pr_validate_diff_coverage.py
+++ b/tests/test_pr_validate_diff_coverage.py
@@ -31,7 +31,6 @@ from scripts.pr_validate.steps.diff_coverage import (
     DiffCoverageStep,
     _parse_diff_cover,
     _path_exists,
-    _read_capped,
     _run_group_bounded,
 )
 
@@ -127,36 +126,6 @@ class TestParseDiffCover:
             0,
             10,
         )
-
-
-class TestReadCapped:
-    def test_small_output_read_in_full(self):
-        import tempfile
-
-        with tempfile.TemporaryFile() as f:
-            f.write(b"small output")
-            assert _read_capped(f, limit=1000) == "small output"
-
-    def test_large_output_is_tail_capped(self):
-        # F1 (codex #1220 r8): read-back must be bounded no matter how much
-        # the child wrote — and the TAIL (where diff-cover's footer / pytest's
-        # summary live) is what we keep.
-        import tempfile
-
-        with tempfile.TemporaryFile() as f:
-            f.write(b"A" * 5000 + b"THE_TRAILING_FOOTER")
-            out = _read_capped(f, limit=64)
-            assert out.endswith("THE_TRAILING_FOOTER")  # tail preserved
-            assert "bytes elided" in out  # truncation announced
-            assert len(out) < 200  # bounded, nowhere near the 5k written
-
-    def test_lenient_decode_on_invalid_utf8(self):
-        import tempfile
-
-        with tempfile.TemporaryFile() as f:
-            f.write(b"\xff\xfe bad bytes")  # not valid UTF-8
-            out = _read_capped(f, limit=1000)  # must not raise
-            assert "bad bytes" in out
 
 
 class TestPathExists:
@@ -750,51 +719,10 @@ class TestRunGroupBounded:
             "leader-only kill"
         )
 
-    def test_clean_exit_sweeps_a_leaked_group_descendant(self, tmp_path):
-        # codex #1220 r15: even on a CLEAN leader exit (rc 0, no timeout), a
-        # process the suite backgrounded into the isolated group must be swept
-        # — else it survives to hold a capture-file fd or contaminate later
-        # steps. The timeout test only covers the timeout path, so THIS test is
-        # what fails if the clean-exit _sweep_group is removed (regression
-        # guard).
-        import time as _time
-
-        heartbeat = tmp_path / "heartbeat"
-        # Leader backgrounds a heartbeat writer in its OWN group, WAITS until the
-        # writer has produced output (so the assertion below isn't racy — the
-        # writer definitely exists and is in the group), then exits 0 WITHOUT
-        # killing it: a non-interactive sh sends no SIGHUP to bg jobs, so the
-        # writer would be reparented to init and keep ticking if our clean-exit
-        # sweep didn't SIGKILL the group.
-        cmd = [
-            "sh",
-            "-c",
-            '(while true; do printf . >> "$1"; sleep 0.05; done) & '
-            'while [ ! -s "$1" ]; do sleep 0.01; done; exit 0',
-            "sh",  # $0
-            str(heartbeat),  # $1
-        ]
-
-        proc = _run_group_bounded(cmd, cwd=str(tmp_path), timeout=30)
-        assert proc.returncode == 0  # clean leader exit, no timeout
-        assert heartbeat.exists(), "writer never started — test is inconclusive"
-
-        # After the clean-exit sweep the writer is dead: the size stops growing.
-        size1 = heartbeat.stat().st_size
-        _time.sleep(1.0)
-        size2 = heartbeat.stat().st_size
-        assert size1 == size2, (
-            f"heartbeat kept growing after a clean exit ({size1} → {size2} "
-            "bytes) — a leaked group descendant survived, so the clean-exit "
-            "sweep regressed"
-        )
-
-    def test_env_is_threaded_through_the_exec_wrapper_to_the_child(self):
-        # B1/B2 (codex #1220 r12): the env= param must reach the wrapped
-        # command — COVERAGE_FILE redirection depends on it — AND survive the
-        # exec-based rlimit wrapper, which execvp's the real command under the
-        # wrapper's OWN environ (so a lost env would silently break the
-        # redirect). Probe a custom var round-trips through the wrapper.
+    def test_env_is_threaded_to_the_child(self):
+        # The env= param must reach the child — the COVERAGE_FILE redirect and
+        # the PYTEST_ADDOPTS strip both depend on it (codex #1220 r12/r14).
+        # Probe a custom var round-trips through to the child.
         code = "import os,sys; sys.stdout.write(os.environ.get('RMX_DC_PROBE', ''))"
         proc = _run_group_bounded(
             [sys.executable, "-c", code],
@@ -804,74 +732,3 @@ class TestRunGroupBounded:
         )
         assert proc.returncode == 0, proc.stderr
         assert "threaded-ok" in proc.stdout
-
-    def test_output_size_is_capped_by_kernel_rlimit(self, tmp_path, monkeypatch):
-        # codex #1220 r11: any single file the child writes is bounded by a
-        # KERNEL RLIMIT_FSIZE (set by the exec-based wrapper), NOT a userspace
-        # size-poll — so a write past the cap is refused at write(2) (SIGXFSZ,
-        # or EFBIG if caught) regardless of timing. Shrink the quota so the
-        # test is fast.
-        #
-        # The child writes to a REAL FILE the test owns and then we stat() it,
-        # rather than inspecting _read_capped(stdout): the read-back is itself
-        # capped at _STDOUT_CAP_BYTES, which would mask a kernel cap that leaked
-        # far more than the configured quota to disk (codex #1220 r13). The
-        # on-disk size is the honest, un-truncated evidence.
-        import signal as _signal
-
-        import scripts.pr_validate.steps.diff_coverage as dc
-
-        quota = 64 * 1024  # 64 KiB
-        monkeypatch.setattr(dc, "_OUTPUT_QUOTA_BYTES", quota)
-        victim = tmp_path / "victim.bin"
-        # Attempt 8 MiB (>> quota) in 1 MiB raw os.write chunks. The kernel
-        # short-writes the first chunk up to the cap and returns; the NEXT
-        # os.write, with the file already at the limit, attempts to extend past
-        # it and delivers SIGXFSZ (default-fatal), killing the child. So the
-        # child exits on its own (no timeout) → CompletedProcess.
-        code = (
-            f"import os\n"
-            f"fd = os.open({str(victim)!r}, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)\n"
-            "buf = b'X' * (1024 * 1024)\n"
-            "for _ in range(8):\n"
-            "    os.write(fd, buf)\n"
-        )
-        proc = _run_group_bounded([sys.executable, "-c", code], cwd=".", timeout=30)
-
-        # rc != 0 proves the cap ENGAGED: a clean rc of 0 is only reachable if
-        # all 8 writes succeeded (cap never fired). SIGXFSZ → negative rc; a
-        # platform delivering EFBIG instead → nonzero exit from the OSError.
-        assert proc.returncode != 0, (
-            "child writing past the RLIMIT_FSIZE quota should have died "
-            f"(SIGXFSZ) or errored (EFBIG); got rc={proc.returncode}"
-        )
-        assert proc.returncode == -_signal.SIGXFSZ or proc.returncode > 0
-        # The ACTUAL on-disk file never approached the 8 MiB attempted — the
-        # kernel held it at ~the quota (small slack for filesystem block
-        # rounding). This is the un-truncated proof the cap really bounds disk,
-        # NOT the _read_capped(stdout) tail which is itself size-limited (codex
-        # #1220 r13).
-        assert victim.exists()
-        assert victim.stat().st_size <= quota + 4096, victim.stat().st_size
-
-    def test_rlimit_wrapper_uses_isolated_startup(self):
-        # B1 (codex #1220 r14): the rlimit wrapper must run with ISOLATED
-        # startup so no repo-local `resource.py` / `sitecustomize.py` on the CWD
-        # can shadow or monkeypatch `resource.setrlimit` before the wrapper sets
-        # the disk cap. `-I` drops the CWD + user-site from sys.path and ignores
-        # PYTHON* env; `-S` skips site.py (hence sitecustomize).
-        #
-        # This asserts the flags are WIRED (and precede `-c`, so they are parsed
-        # as interpreter options, not program args) rather than attempting a
-        # behavioural shadow test: `resource` is a built-in module on our
-        # interpreters (BuiltinImporter wins over any sys.path `.py` regardless
-        # of `-I`), so a resource.py-shadow test would pass trivially and prove
-        # nothing. The end-to-end cap behaviour is covered by
-        # test_output_size_is_capped_by_kernel_rlimit.
-        from scripts.pr_validate.steps.diff_coverage import _rlimit_wrap
-
-        wrap = _rlimit_wrap()
-        assert wrap[0] == sys.executable
-        assert "-I" in wrap and "-S" in wrap
-        assert wrap.index("-I") < wrap.index("-c")
-        assert wrap.index("-S") < wrap.index("-c")

--- a/tests/test_pr_validate_diff_coverage.py
+++ b/tests/test_pr_validate_diff_coverage.py
@@ -837,6 +837,7 @@ class TestRunGroupBounded:
         # pipe-holder lingers (a benign leak at parity with the gating
         # full_unit), never blocking. This test proves the call returns promptly
         # with rc 0 rather than waiting out the descendant's lifetime.
+        import signal as _signal
         import time as _time
 
         from scripts.pr_validate.steps import diff_coverage as _dc
@@ -844,22 +845,45 @@ class TestRunGroupBounded:
         # Small bound so the doomed reader joins return quickly.
         monkeypatch.setattr(_dc, "_REAP_TIMEOUT_S", 0.3)
 
+        # Record the real child (the leader) so the finally can sweep its group.
+        procs: list[subprocess.Popen] = []
+        real_popen = subprocess.Popen
+
+        def rec_popen(*a, **k):
+            p = real_popen(*a, **k)
+            procs.append(p)
+            return p
+
+        monkeypatch.setattr(_dc.subprocess, "Popen", rec_popen)
+
         # Leader backgrounds a grandchild that holds the inherited stdout/stderr
-        # pipes for ~2 s, then the leader EXITS 0. The grandchild self-terminates
-        # so the test leaks nothing; the point is only that we don't WAIT for it.
+        # pipes for ~2 s, then the leader EXITS 0. The helper deliberately returns
+        # while the grandchild is STILL alive (that's the property under test), so
+        # the ``finally`` must reap it — leaving it running would contaminate
+        # later tests (codex #1220 r20 test-hygiene).
         cmd = [
             "sh",
             "-c",
             "(for _ in $(seq 1 40); do sleep 0.05; done) & exit 0",
         ]
-        t0 = _time.time()
-        proc = _dc._run_group_bounded(cmd, cwd=str(tmp_path), timeout=30)
-        elapsed = _time.time() - t0
-        assert proc.returncode == 0  # clean exit, did NOT hang
-        # Returned on the bounded-drain path (~2 × 0.3 s), NOT after the
-        # grandchild's ~2 s lifetime — proves we didn't block on the lingering
-        # pipe-holder (and didn't try a dangerous post-reap group sweep).
-        assert elapsed < 1.5, f"blocked {elapsed:.2f}s on a lingering pipe-holder"
+        try:
+            t0 = _time.time()
+            proc = _dc._run_group_bounded(cmd, cwd=str(tmp_path), timeout=30)
+            elapsed = _time.time() - t0
+            assert proc.returncode == 0  # clean exit, did NOT hang
+            # Returned on the bounded-drain path (~2 × 0.3 s), NOT after the
+            # grandchild's ~2 s lifetime — proves we didn't block on the
+            # lingering pipe-holder (and didn't try a dangerous post-reap sweep).
+            assert elapsed < 1.5, f"blocked {elapsed:.2f}s on a lingering pipe-holder"
+        finally:
+            # The grandchild is still alive here, so its group's PGID is still
+            # reserved and killpg targets exactly it (leader pid == pgid under
+            # start_new_session). Best-effort SIGKILL sweeps the grandchild.
+            for p in procs:
+                try:
+                    os.killpg(p.pid, _signal.SIGKILL)
+                except OSError:
+                    pass
 
     def test_reader_start_failure_kills_child_and_reraises(self, tmp_path, monkeypatch):
         # codex #1220 r19 (B2): if starting a reader thread fails AFTER Popen

--- a/tests/test_pr_validate_diff_coverage.py
+++ b/tests/test_pr_validate_diff_coverage.py
@@ -18,6 +18,7 @@ Two contracts matter most here and are the reason this file exists:
 
 from __future__ import annotations
 
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -319,6 +320,37 @@ class TestAdvisoryContract:
         assert dc[3].endswith("coverage.xml")
         assert dc[4] == "--compare-branch"
         assert dc[5] == expected_ref
+
+    def test_coverage_data_file_is_redirected_off_repo_root(
+        self, ctx_factory, monkeypatch
+    ):
+        # B1 (codex #1220 r12): coverage.py writes its data file to
+        # $COVERAGE_FILE, or ``.coverage`` in the CWD when unset. The CWD here
+        # is the repo root, so an unset COVERAGE_FILE would clobber a
+        # developer's own ``.coverage`` DB. Assert the instrumented pytest
+        # child is handed a COVERAGE_FILE under the run's artifact dir instead.
+        _both_tools_present(monkeypatch)
+        ctx = ctx_factory(["vllm_mlx/quantized_batch_cache.py"])
+        captured: dict[str, dict | None] = {}
+
+        def fake_run(cmd, cwd, timeout, env=None):
+            if "pytest" in cmd:
+                captured["env"] = env
+                Path(_xml_target(cmd)).write_text("<coverage/>")
+                return subprocess.CompletedProcess(cmd, 0, stdout="ok", stderr="")
+            return subprocess.CompletedProcess(cmd, 0, stdout=_DC_WITH_LINES, stderr="")
+
+        monkeypatch.setattr(
+            "scripts.pr_validate.steps.diff_coverage._run_group_bounded", fake_run
+        )
+        assert DiffCoverageStep().run(ctx).status == "pass"
+
+        env = captured["env"]
+        assert env is not None and "COVERAGE_FILE" in env
+        cov_file = Path(env["COVERAGE_FILE"])
+        # Dedicated artifact path, NOT the repo-root ``.coverage`` → no clobber.
+        assert cov_file == ctx.artifact_path("coverage.data")
+        assert cov_file.parent != ctx.repo_root
 
     def test_measures_with_caveat_when_some_tests_failed(
         self, ctx_factory, monkeypatch
@@ -717,6 +749,22 @@ class TestRunGroupBounded:
             "bytes) — the grandchild survived, so group-kill regressed to a "
             "leader-only kill"
         )
+
+    def test_env_is_threaded_through_the_exec_wrapper_to_the_child(self):
+        # B1/B2 (codex #1220 r12): the env= param must reach the wrapped
+        # command — COVERAGE_FILE redirection depends on it — AND survive the
+        # exec-based rlimit wrapper, which execvp's the real command under the
+        # wrapper's OWN environ (so a lost env would silently break the
+        # redirect). Probe a custom var round-trips through the wrapper.
+        code = "import os,sys; sys.stdout.write(os.environ.get('RMX_DC_PROBE', ''))"
+        proc = _run_group_bounded(
+            [sys.executable, "-c", code],
+            cwd=".",
+            timeout=30,
+            env={**os.environ, "RMX_DC_PROBE": "threaded-ok"},
+        )
+        assert proc.returncode == 0, proc.stderr
+        assert "threaded-ok" in proc.stdout
 
     def test_output_size_is_capped_by_kernel_rlimit(self, monkeypatch):
         # F1 (codex #1220 r11): disk is bounded by a KERNEL RLIMIT_FSIZE set on

--- a/tests/test_pr_validate_diff_coverage.py
+++ b/tests/test_pr_validate_diff_coverage.py
@@ -765,6 +765,57 @@ class TestRunGroupBounded:
         assert proc.returncode == 0, proc.stderr
         assert "threaded-ok" in proc.stdout
 
+    def test_clean_exit_sweeps_a_lingering_pipe_holding_descendant(
+        self, tmp_path, monkeypatch
+    ):
+        # codex #1220 r18 (B1): the leader can exit CLEANLY (rc 0) while a
+        # background descendant it spawned stays alive in the same group,
+        # holding the inherited stdout pipe open. ``proc.wait()`` reaps only the
+        # leader, so a naive clean path would both block the reader forever AND
+        # leak the descendant into later steps. The teardown must sweep it: a
+        # still-blocked reader proves a group member is alive, so the PGID is
+        # still reserved and ``killpg`` is race-free even after the leader was
+        # reaped. This test fails if the sweep regresses (heartbeat keeps
+        # growing) or if the call hangs (never returns).
+        import time as _time
+
+        from scripts.pr_validate.steps import diff_coverage as _dc
+
+        # Keep the test fast: the first (doomed) reader join waits
+        # _REAP_TIMEOUT_S before the sweep fires.
+        monkeypatch.setattr(_dc, "_REAP_TIMEOUT_S", 0.5)
+
+        heartbeat = tmp_path / "hb"
+        # Leader backgrounds a grandchild that holds the inherited stdout pipe
+        # (the subshell keeps fd 1 open) and ticks a heartbeat every 50 ms, then
+        # EXITS 0. The grandchild stays in the leader's process group. Path is a
+        # positional ($1), never interpolated — an apostrophe in tmp_path would
+        # otherwise break the single-quoted script (codex #1220 r9).
+        cmd = [
+            "sh",
+            "-c",
+            '(while true; do printf . >> "$1"; sleep 0.05; done) & exit 0',
+            "sh",  # $0
+            str(heartbeat),  # $1
+        ]
+        proc = _dc._run_group_bounded(cmd, cwd=str(tmp_path), timeout=30)
+        assert proc.returncode == 0  # clean exit — did NOT hang or time out
+
+        # Grandchild must have started (so "stopped" is meaningful), then been
+        # swept by the clean-exit teardown: the heartbeat stops growing.
+        deadline = _time.time() + 5.0
+        while not heartbeat.exists() and _time.time() < deadline:
+            _time.sleep(0.02)
+        assert heartbeat.exists(), "grandchild never started — test inconclusive"
+        size1 = heartbeat.stat().st_size
+        _time.sleep(1.0)
+        size2 = heartbeat.stat().st_size
+        assert size1 == size2, (
+            f"heartbeat kept growing after a clean exit ({size1} → {size2} "
+            "bytes) — the teardown leaked a lingering pipe-holding descendant "
+            "instead of sweeping the group"
+        )
+
     def test_capture_is_bounded_to_a_tail_on_a_runaway_child(self):
         # codex #1220 r17 (B2): a plain communicate() buffers the ENTIRE child
         # output in memory, so a runaway test streaming gigabytes could OOM the

--- a/tests/test_pr_validate_diff_coverage.py
+++ b/tests/test_pr_validate_diff_coverage.py
@@ -730,6 +730,27 @@ class TestRegistration:
 # --------------------------------------------------------------------------
 
 
+def _heartbeat_advancing(path: Path, dwell: float = 0.2) -> bool:
+    """True iff ``path`` grows over ``dwell`` seconds — proof that a heartbeat
+    writer is STILL alive right now. Tests use this to gate a fallback
+    ``killpg`` on a PROVEN-live group member: signalling a PGID whose group has
+    already been reaped is unsafe (the id may have been reused, so the kill
+    could hit an unrelated CI process — codex #1220 confirm2). A monotonic file
+    size is immune to zombie / PID-reuse the way an ``os.kill(pid, 0)`` probe is
+    not. The grandchildren these tests clean up run infinite loops, so an
+    advancing heartbeat cannot flip to dead before the ``killpg`` lands."""
+    import time as _t
+
+    try:
+        if not path.exists():
+            return False
+        s1 = path.stat().st_size
+        _t.sleep(dwell)
+        return path.exists() and path.stat().st_size > s1
+    except OSError:
+        return False
+
+
 class TestRunGroupBounded:
     def test_returns_completed_process_on_success(self):
         proc = _run_group_bounded(
@@ -833,14 +854,18 @@ class TestRunGroupBounded:
                 "leader-only kill"
             )
         finally:
-            # Sweep the group unconditionally: on a pass it is already dead
-            # (killpg → ESRCH, harmless); on a failure this reaps the leaked
-            # infinite grandchild instead of letting it run forever.
-            for p in procs:
-                try:
-                    os.killpg(p.pid, _signal.SIGKILL)
-                except OSError:
-                    pass
+            # Sweep the group ONLY if the heartbeat still advances — i.e. the
+            # grandchild survived (a leader-only-kill regression), so a member is
+            # provably alive and the PGID is still reserved. On a PASS the
+            # code-under-test already reaped the whole group, so the PGID may
+            # have been reused; an unconditional killpg there could SIGKILL an
+            # unrelated process (codex #1220 confirm2).
+            if _heartbeat_advancing(heartbeat):
+                for p in procs:
+                    try:
+                        os.killpg(p.pid, _signal.SIGKILL)
+                    except OSError:
+                        pass
 
     def test_env_is_threaded_to_the_child(self):
         # The env= param must reach the child — the COVERAGE_FILE redirect and
@@ -887,33 +912,41 @@ class TestRunGroupBounded:
         monkeypatch.setattr(_dc.subprocess, "Popen", rec_popen)
 
         # Leader backgrounds a grandchild that holds the inherited stdout/stderr
-        # pipes for ~2 s, then the leader EXITS 0. The helper deliberately returns
-        # while the grandchild is STILL alive (that's the property under test), so
-        # the ``finally`` must reap it — leaving it running would contaminate
-        # later tests (codex #1220 r20 test-hygiene).
+        # pipes AND ticks a heartbeat, then the leader EXITS 0. The helper
+        # deliberately returns while the grandchild is STILL alive (that's the
+        # property under test), so the ``finally`` must reap it — leaving it
+        # running would contaminate later tests (codex #1220 r20). The heartbeat
+        # lets the finally confirm the grandchild is provably alive before the
+        # killpg, so a reaped-and-recycled PGID is never signalled (confirm2).
+        # Path is a positional ($1), never interpolated (codex #1220 r9).
+        heartbeat = tmp_path / "heartbeat"
         cmd = [
             "sh",
             "-c",
-            "(for _ in $(seq 1 40); do sleep 0.05; done) & exit 0",
+            '(while true; do printf . >> "$1"; sleep 0.05; done) & exit 0',
+            "sh",  # $0
+            str(heartbeat),  # $1
         ]
         try:
             t0 = _time.time()
             proc = _dc._run_group_bounded(cmd, cwd=str(tmp_path), timeout=30)
             elapsed = _time.time() - t0
             assert proc.returncode == 0  # clean exit, did NOT hang
-            # Returned on the bounded-drain path (~2 × 0.3 s), NOT after the
-            # grandchild's ~2 s lifetime — proves we didn't block on the
-            # lingering pipe-holder (and didn't try a dangerous post-reap sweep).
+            # Returned on the bounded-drain path (~2 × 0.3 s), NOT after waiting
+            # out the descendant — proves we didn't block on the lingering
+            # pipe-holder (and didn't try a dangerous post-reap sweep).
             assert elapsed < 1.5, f"blocked {elapsed:.2f}s on a lingering pipe-holder"
         finally:
-            # The grandchild is still alive here, so its group's PGID is still
-            # reserved and killpg targets exactly it (leader pid == pgid under
-            # start_new_session). Best-effort SIGKILL sweeps the grandchild.
-            for p in procs:
-                try:
-                    os.killpg(p.pid, _signal.SIGKILL)
-                except OSError:
-                    pass
+            # Sweep ONLY while the grandchild is provably alive (heartbeat still
+            # advancing) so the PGID is still reserved — never signal a possibly
+            # recycled id (codex #1220 confirm2). Here the grandchild is an
+            # infinite loop the helper left running, so it IS advancing.
+            if _heartbeat_advancing(heartbeat):
+                for p in procs:
+                    try:
+                        os.killpg(p.pid, _signal.SIGKILL)
+                    except OSError:
+                        pass
 
     def test_reader_start_failure_kills_child_and_reraises(self, tmp_path, monkeypatch):
         # codex #1220 r19 (B2): if starting a reader thread fails AFTER Popen

--- a/tests/test_pr_validate_diff_coverage.py
+++ b/tests/test_pr_validate_diff_coverage.py
@@ -18,7 +18,6 @@ Two contracts matter most here and are the reason this file exists:
 
 from __future__ import annotations
 
-import signal
 import subprocess
 import sys
 from pathlib import Path
@@ -500,39 +499,48 @@ class TestRunGroupBounded:
         # would wedge the reap. This test distinguishes the two: it fails if
         # group-kill ever regresses to a leader-only kill.
         #
-        # Leader = ``sh``; it backgrounds a long-lived grandchild in the SAME
-        # process group (non-interactive sh has no job control, so ``&`` jobs
-        # stay in the shell's group), records the grandchild PID, then blocks
-        # so the leader is alive when the timeout fires. The grandchild
-        # inherits the subprocess pipes, so a leader-only kill would also
-        # reproduce the reap-wedge from codex #1220.
-        import os as _os
+        # Liveness is detected via a HEARTBEAT the grandchild grows, NOT an
+        # ``os.kill(pid, 0)`` probe: signal 0 succeeds for a not-yet-reaped
+        # zombie (and, after PID reuse, for an unrelated process), so a
+        # PID-based probe is racy (codex #1220 r5). Instead the grandchild
+        # appends a byte to a file every 50 ms; after the group kill the file
+        # STOPS growing. A monotonically-growing size can't false-negative and
+        # is immune to zombie/PID-reuse — if group-kill regressed to
+        # leader-only, the orphaned grandchild (reparented to init) would keep
+        # appending and the size would still advance.
+        #
+        # Leader = ``sh``; it backgrounds the grandchild in the SAME process
+        # group (non-interactive sh has no job control, so ``&`` jobs stay in
+        # the shell's group), then blocks so the leader is alive when the
+        # timeout fires. The grandchild inherits the subprocess pipes, so a
+        # leader-only kill would also reproduce the reap-wedge from codex #1220.
         import time as _time
 
-        pidfile = tmp_path / "grandchild.pid"
-        cmd = ["sh", "-c", f"sleep 120 & echo $! > '{pidfile}'; sleep 120"]
+        heartbeat = tmp_path / "heartbeat"
+        cmd = [
+            "sh",
+            "-c",
+            f"(while true; do printf . >> '{heartbeat}'; sleep 0.05; done) & sleep 120",
+        ]
 
         with pytest.raises(subprocess.TimeoutExpired):
             _run_group_bounded(cmd, cwd=str(tmp_path), timeout=1)
 
-        gc_pid = int(pidfile.read_text().strip())
-        # Poll briefly for SIGKILL delivery, then assert the grandchild is gone.
+        # Grandchild must have started (heartbeat exists) before we can judge
+        # whether it STOPPED. It ticks every 50 ms and the leader ran for the
+        # full 1 s timeout, so the file exists well before we get here.
         deadline = _time.time() + 5.0
-        alive = True
-        while _time.time() < deadline:
-            try:
-                _os.kill(gc_pid, 0)  # signal 0 = liveness probe
-            except ProcessLookupError:
-                alive = False
-                break
-            _time.sleep(0.05)
-        if alive:
-            # Don't strand the leaked process if the assertion is about to fail.
-            try:
-                _os.kill(gc_pid, signal.SIGKILL)
-            except OSError:
-                pass
-            pytest.fail(
-                f"grandchild {gc_pid} survived the timeout — group kill "
-                "regressed to a leader-only kill"
-            )
+        while not heartbeat.exists() and _time.time() < deadline:
+            _time.sleep(0.02)
+        assert heartbeat.exists(), "grandchild never started — test is inconclusive"
+
+        # Sample size, wait several heartbeat intervals, sample again. A dead
+        # grandchild leaves the size fixed; a survivor grows it by ~20 bytes/s.
+        size1 = heartbeat.stat().st_size
+        _time.sleep(1.0)
+        size2 = heartbeat.stat().st_size
+        assert size1 == size2, (
+            f"heartbeat kept growing after the timeout ({size1} → {size2} "
+            "bytes) — the grandchild survived, so group-kill regressed to a "
+            "leader-only kill"
+        )

--- a/tests/test_pr_validate_diff_coverage.py
+++ b/tests/test_pr_validate_diff_coverage.py
@@ -750,6 +750,45 @@ class TestRunGroupBounded:
             "leader-only kill"
         )
 
+    def test_clean_exit_sweeps_a_leaked_group_descendant(self, tmp_path):
+        # codex #1220 r15: even on a CLEAN leader exit (rc 0, no timeout), a
+        # process the suite backgrounded into the isolated group must be swept
+        # — else it survives to hold a capture-file fd or contaminate later
+        # steps. The timeout test only covers the timeout path, so THIS test is
+        # what fails if the clean-exit _sweep_group is removed (regression
+        # guard).
+        import time as _time
+
+        heartbeat = tmp_path / "heartbeat"
+        # Leader backgrounds a heartbeat writer in its OWN group, WAITS until the
+        # writer has produced output (so the assertion below isn't racy — the
+        # writer definitely exists and is in the group), then exits 0 WITHOUT
+        # killing it: a non-interactive sh sends no SIGHUP to bg jobs, so the
+        # writer would be reparented to init and keep ticking if our clean-exit
+        # sweep didn't SIGKILL the group.
+        cmd = [
+            "sh",
+            "-c",
+            '(while true; do printf . >> "$1"; sleep 0.05; done) & '
+            'while [ ! -s "$1" ]; do sleep 0.01; done; exit 0',
+            "sh",  # $0
+            str(heartbeat),  # $1
+        ]
+
+        proc = _run_group_bounded(cmd, cwd=str(tmp_path), timeout=30)
+        assert proc.returncode == 0  # clean leader exit, no timeout
+        assert heartbeat.exists(), "writer never started — test is inconclusive"
+
+        # After the clean-exit sweep the writer is dead: the size stops growing.
+        size1 = heartbeat.stat().st_size
+        _time.sleep(1.0)
+        size2 = heartbeat.stat().st_size
+        assert size1 == size2, (
+            f"heartbeat kept growing after a clean exit ({size1} → {size2} "
+            "bytes) — a leaked group descendant survived, so the clean-exit "
+            "sweep regressed"
+        )
+
     def test_env_is_threaded_through_the_exec_wrapper_to_the_child(self):
         # B1/B2 (codex #1220 r12): the env= param must reach the wrapped
         # command — COVERAGE_FILE redirection depends on it — AND survive the

--- a/tests/test_pr_validate_diff_coverage.py
+++ b/tests/test_pr_validate_diff_coverage.py
@@ -717,3 +717,25 @@ class TestRunGroupBounded:
             "bytes) — the grandchild survived, so group-kill regressed to a "
             "leader-only kill"
         )
+
+    def test_output_quota_breach_kills_like_a_timeout(self, monkeypatch):
+        # F1 (codex #1220 r10): a child that streams past the disk quota is
+        # killed exactly like a timeout — long before the time budget — and
+        # the raised TimeoutExpired carries the captured tail for diagnostics
+        # (r10 F3). Shrink the quota + poll so the test is fast.
+        import scripts.pr_validate.steps.diff_coverage as dc
+
+        monkeypatch.setattr(dc, "_OUTPUT_QUOTA_BYTES", 1024)  # 1 KiB
+        monkeypatch.setattr(dc, "_POLL_INTERVAL_S", 1)
+        # Write 200 KiB (>> quota), flush to the temp file, then block so the
+        # child is still alive at the first poll.
+        code = (
+            "import sys, time; "
+            "sys.stdout.write('X' * 200000); sys.stdout.flush(); "
+            "time.sleep(60)"
+        )
+        with pytest.raises(subprocess.TimeoutExpired) as ei:
+            # timeout=30 >> the ~1s it takes to trip the quota, so a raise here
+            # proves the QUOTA fired, not the clock.
+            _run_group_bounded([sys.executable, "-c", code], cwd=".", timeout=30)
+        assert ei.value.stdout and "X" in ei.value.stdout  # tail attached

--- a/tests/test_pr_validate_diff_coverage.py
+++ b/tests/test_pr_validate_diff_coverage.py
@@ -109,6 +109,24 @@ class TestParseDiffCover:
         # failure.
         assert _parse_diff_cover("Total:   0 lines\nMissing: 0 lines\n") is None
 
+    def test_missing_out_of_bounds_is_parse_failed(self):
+        # Missing > Total (→ negative coverage) or Missing < 0 (→ >100%) is
+        # impossible for real diff-cover output — treat as format drift, never
+        # publish a bogus percentage (codex #1220 r9).
+        assert (
+            _parse_diff_cover("Total:   10 lines\nMissing: 11 lines\n") is _PARSE_FAILED
+        )
+        assert _parse_diff_cover("Total:   10 lines\nMissing: 0 lines\n") == (
+            100.0,
+            10,
+            10,
+        )
+        assert _parse_diff_cover("Total:   10 lines\nMissing: 10 lines\n") == (
+            0.0,
+            0,
+            10,
+        )
+
 
 class TestReadCapped:
     def test_small_output_read_in_full(self):
@@ -667,10 +685,15 @@ class TestRunGroupBounded:
         import time as _time
 
         heartbeat = tmp_path / "heartbeat"
+        # Pass the path as a POSITIONAL arg ("$1"), never interpolated into
+        # the script — a tmp dir containing an apostrophe would otherwise
+        # break the single-quoted string (codex #1220 r9).
         cmd = [
             "sh",
             "-c",
-            f"(while true; do printf . >> '{heartbeat}'; sleep 0.05; done) & sleep 120",
+            '(while true; do printf . >> "$1"; sleep 0.05; done) & sleep 120',
+            "sh",  # $0
+            str(heartbeat),  # $1
         ]
 
         with pytest.raises(subprocess.TimeoutExpired):


### PR DESCRIPTION
## Why

First slice of the **dev-flow gate evolution** (proposal 2026-07): make **patch (diff) coverage visible without gating on it**, because a hard coverage threshold picked *before* we have any distribution is a number pulled out of thin air.

So this step **measures and publishes** the % of production lines a PR changes that the unit suite exercises — and does nothing else. The plan: collect this baseline across **~20 PRs**, look at where the numbers actually land, and only *then* decide whether a threshold is justified (and what it should be).

This is `D1` — the top-priority, lowest-risk item on the prioritized TODO. It touches **no engine code**.

## What

A new advisory `diff_coverage` pr_validate step (last in `STEPS`) that runs an instrumented `pytest --cov=vllm_mlx`, feeds the XML to `diff-cover` scoped to the PR's changed lines, and reports patch-coverage % in the scorecard.

## Design decisions

- **Standalone step — does NOT piggyback `full_unit`.** `full_unit` is a merge-*gating* step; an advisory measurer must not be able to break the gate. The asymmetry is the whole argument: a false block on the gate costs a maintainer a blocked-PR investigation, while sharing the run would save only ~40 s. Isolation wins.
- **Advisory contract enforced in code.** EVERY path returns `pass`/`skip`, never `fail`/`error`. `run()` catches all exceptions and downgrades to `skip` — the base `execute()` wrapper would otherwise turn a crash into `error`, which the scorecard treats as blocking. Subprocess calls carry bounded timeouts (a hung child can't wedge the pipeline); diagnostic-log writes are best-effort (a disk-full error while logging can't escape as `error`). `continue_on_error=True` as belt-and-braces.
- **Coverage trust model — robust to a flaky test.** Accepts pytest exit 0 (all passed) **and exit 1** (suite ran, some tests failed — `coverage.xml` is still a complete record of executed lines). Skips only on exit 2-5 (interrupted / internal error / usage error / no tests collected), where no dependable coverage exists. An advisory baseline collector must survive an unrelated flaky test (this repo has known GPU-contention flakes, e.g. `test_batching_improves_throughput`) rather than discard the whole measurement and skip on most real PRs. When exit 1 is measured, the finding carries a caveat that the % may under-count. `full_unit` still owns gating on a red suite. `coverage.xml` is unlinked before the run so a stale file can never masquerade as this run's result.
- **Process-group-bounded subprocesses.** Children run in a new session (`start_new_session=True`); on timeout the WHOLE group is SIGKILLed so a timed-out pytest can't orphan xdist workers / a serve subprocess into later steps. The group id is captured as `proc.pid` at spawn (never via `os.getpgid()` after the fact, which races a leader that has already exited while a descendant holds the pipes), and the reap is itself bounded so a wedged descendant can't hang the auto-deploy pipeline.
- **Base-branch-aware compare ref.** diff-cover compares against the PR's actual base (`ctx.base_sha`), so a PR targeting a release/maintenance branch is scored against ITS base, not `main`; falls back to `origin/main` when the base commit is unknown.
- **Positioned last in `STEPS`.** In fail-fast mode we skip its ~40 s cost the moment any real gate above has already blocked the PR.
- **`should_run` gates tightly.** Skips docs-only (low blast), tests-only, and deps-only PRs — none have `vllm_mlx/*.py` production lines for diff-cover to score. (This very PR is one such case: it changes only `scripts/` + `pyproject.toml` + tests, so `diff_coverage` cleanly **skips itself** — proving the gating works.)
- **Percent computed from exact counts.** We use diff-cover's `Total`/`Missing` integer counts, not its `Coverage:` line, which *floors* (58/1934 = 2.9989 % prints as `2%`). The `covered/total` counts are surfaced alongside as unambiguous ground truth.
- **Deps.** `pytest-cov>=4.0.0` + `diff-cover>=8.0.0` added to `[test]` and `[dev]` (dev ⊇ test enforced by `test_pr_validate_test_env.py`).

## Test plan

- [x] `pytest tests/test_pr_validate_diff_coverage.py` — 35 tests green: parser on real+synthetic output; `should_run` gating matrix; advisory-never-blocks contract across every failure mode (both timeouts, exit 2-5 interrupted/errored, stale-xml removal, no-coverage-xml, diff-cover nonzero-with-footer, artifact-path-raises, internal crash, unwritable log); the exit-1-measures-with-caveat path; a **real-subprocess group-kill test that spawns a grandchild and asserts it is reaped** (distinguishes group-kill from a leader-only kill); registration + last-position.
- [x] `pytest tests/test_pr_validate_runner.py tests/test_pr_validate_test_env.py` — STEPS ordering + dev⊇test invariants intact.
- [x] Real smoke: installed the tools, produced a real `coverage.xml`, ran `python -m diff_cover.diff_cover_tool` against an older base — parser extracted `(2.9989%, 58, 1934)`; the "No lines with coverage information" path parsed to `None` → skip.
- [x] `ruff check` + `ruff format --check` clean on all changed files.

## codex convergence

Hardened across 4 codex rounds. r4 landed three real fixes: (1) coverage no longer discarded on any nonzero pytest exit — exit 1 is measured (with caveat) so a flaky test doesn't zero the baseline; (2) the timeout handler no longer races `os.getpgid()` on an already-exited leader (group id captured at spawn) and the reap is bounded so a pipe-holding descendant can't wedge the pipeline; (3) the group-kill test now spawns a real grandchild and asserts its death, so a regression to leader-only killing is caught.

Note: the earlier "pre-existing main reds" surfaced by this branch's `full_unit` (5 test-side drifts from recent feature merges) were root-caused and fixed separately in **#1221 (merged)** — `main` is green again and this PR's `full_unit` now passes 13980/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
