### PR TITLE
fix(tests): repair 5 pre-existing main-red tests (stale doubles + wrapped-offline skip)

### DIFF
--- a/tests/test_cli_chat.py
+++ b/tests/test_cli_chat.py
@@ -822,6 +822,10 @@ def test_chat_command_owns_mcp_runtime_without_configuring_serve(monkeypatch, ca
         tools = _FakeMCPRuntime.tools
         server_count = 2
         connection_errors = {}
+        # Mirror ChatMCPRuntime (chat_mcp.py) — chat_command reads this in
+        # the "MCP ready" banner (cli.py). Added when #1191 introduced
+        # server_log_path; the hand-rolled double must carry it too.
+        server_log_path = None
 
         def __init__(self, path):
             assert path == "/tmp/chat-mcp.json"
@@ -882,6 +886,7 @@ def test_chat_command_closes_mcp_runtime_on_unexpected_error(monkeypatch):
         tools = _FakeMCPRuntime.tools
         server_count = 1
         connection_errors = {}
+        server_log_path = None  # mirror ChatMCPRuntime (#1191); banner reads it
 
         def __init__(self, _path):
             self.closed = False
@@ -914,6 +919,11 @@ def test_chat_command_surfaces_and_retries_mcp_close_failure(monkeypatch):
         tools = _FakeMCPRuntime.tools
         server_count = 1
         connection_errors = {}
+        # mirror ChatMCPRuntime (#1191) — without this the banner's
+        # server_log_path read raised AttributeError, which was masked by
+        # the close-failure RuntimeError this test asserts (right assert,
+        # wrong reason). Now the close-failure is the ONLY failure path.
+        server_log_path = None
 
         def __init__(self, _path):
             self.close_calls = 0

--- a/tests/test_max_tokens_resolver.py
+++ b/tests/test_max_tokens_resolver.py
@@ -56,8 +56,13 @@ def test_non_thinking_request_does_not_get_implicit_headroom():
 
 
 class _RawRequest:
-    def __init__(self, body: dict | None = None):
+    def __init__(self, body: dict | None = None, headers: dict | None = None):
         self._body = body or {}
+        # Mirror Starlette's Request.headers (a .get()-able Mapping). The
+        # chat route reads ``raw_request.headers.get("user-agent")`` for
+        # the telemetry caller_agent field (routes/chat.py); without this
+        # the double raised AttributeError before the resolver ran.
+        self.headers = headers or {}
 
     async def json(self):
         return self._body

--- a/tests/test_no_out_of_band_routing.py
+++ b/tests/test_no_out_of_band_routing.py
@@ -141,6 +141,13 @@ ALLOWED_RAPID_MLX_ENV_VARS: frozenset[str] = frozenset(
         # local-Worker testing. Production stays on
         # ``telemetry.rapidmlx.com``; never consulted by the engine.
         "RAPID_MLX_TELEMETRY_ENDPOINT",
+        # Telemetry request-event sampling rate (0.0–1.0). Bounds the
+        # volume of high-frequency per-API-call ``request`` events so
+        # turning those call sites on doesn't flood the collector. Pure
+        # observability knob — read only by
+        # ``telemetry/emit.py::_request_sample_rate``; never chooses
+        # model / parser / tier / any routing decision.
+        "RAPID_MLX_TELEMETRY_REQUEST_SAMPLE",
         # Port for doctor harness probe checks, not engine routing.
         "RAPID_MLX_PORT",
         # Skip the [Y/n] confirmation prompt before large model downloads

--- a/tests/test_tool_grammar_558.py
+++ b/tests/test_tool_grammar_558.py
@@ -399,7 +399,13 @@ def _offline_skip_exc_types():
         types.append(_ReqConnErr)
     except Exception:  # pragma: no cover - requests not present
         pass
-    return tuple(types) or (OSError,)
+    # No broad ``(OSError,)`` fallback: ``_is_offline_cache_miss`` walks the
+    # whole exception chain, so an OSError fallback here would make *any*
+    # OSError anywhere in the chain (e.g. a corrupt tokenizer artifact) look
+    # like a sanctioned offline skip. If none of the specific HF offline
+    # signals are importable we return an empty tuple — the chain check then
+    # matches nothing and the real failure propagates (codex round-5 #2).
+    return tuple(types)
 
 
 def _is_offline_cache_miss(exc: BaseException) -> bool:
@@ -425,6 +431,36 @@ def _is_offline_cache_miss(exc: BaseException) -> bool:
             return True
         cur = cur.__cause__ or cur.__context__
     return False
+
+
+def test_is_offline_cache_miss_rejects_bare_oserror():
+    """A plain ``OSError`` with no HF offline/cache-miss link in its chain is a
+    REAL failure (corrupt artifact / disk error), not a sanctioned skip.
+
+    Regression guard: an earlier ``_offline_skip_exc_types()`` fell back to
+    ``(OSError,)`` when the specific huggingface_hub error names could not be
+    imported. Combined with the chain walk that made *every* ``OSError`` — at
+    any depth — look like an offline miss, silently skipping genuine failures.
+    """
+    assert _is_offline_cache_miss(OSError("corrupt tokenizer.json")) is False
+    # …and still False when a bare OSError merely *wraps* another bare OSError.
+    inner = OSError("bad bytes")
+    outer = OSError("load failed")
+    outer.__cause__ = inner
+    assert _is_offline_cache_miss(outer) is False
+
+
+def test_is_offline_cache_miss_detects_wrapped_hf_offline_signal():
+    """A real HF offline/cache-miss anywhere in the chain IS a sanctioned skip.
+
+    ``transformers`` re-wraps ``LocalEntryNotFoundError`` in a generic
+    ``OSError`` ("We couldn't connect to huggingface.co …"); the chain walk
+    must still recognise the wrapped signal so uncached+offline runs skip.
+    """
+    hub_errors = pytest.importorskip("huggingface_hub.errors")
+    wrapped = OSError("We couldn't connect to 'https://huggingface.co'")
+    wrapped.__cause__ = hub_errors.LocalEntryNotFoundError("not cached")
+    assert _is_offline_cache_miss(wrapped) is True
 
 
 @pytest.fixture(scope="module")

--- a/tests/test_tool_grammar_558.py
+++ b/tests/test_tool_grammar_558.py
@@ -402,6 +402,31 @@ def _offline_skip_exc_types():
     return tuple(types) or (OSError,)
 
 
+def _is_offline_cache_miss(exc: BaseException) -> bool:
+    """True iff ``exc`` — or anything in its ``__cause__`` / ``__context__``
+    chain — is a genuine HF offline / cache-miss signal.
+
+    ``transformers`` re-wraps ``huggingface_hub``'s ``LocalEntryNotFoundError``
+    into a generic ``OSError`` ("We couldn't connect to 'https://huggingface.co'
+    …"), so a type-only ``except _offline_skip_exc_types()`` misses the wrapped
+    cache-miss and the enforcement test FAILS instead of skipping. We walk the
+    exception chain and treat it as a sanctioned skip ONLY when an offline /
+    cache-miss link is present. A corrupt-file ``OSError``, an invalid revision
+    (RepositoryNotFound / RevisionNotFound), or a tokenizer incompatibility has
+    no such link, so it still propagates as a real failure — preserving the
+    codex round-5 intent that only genuine network/cache misses skip.
+    """
+    offline_types = _offline_skip_exc_types()
+    seen: set[int] = set()
+    cur: BaseException | None = exc
+    while cur is not None and id(cur) not in seen:
+        seen.add(id(cur))
+        if isinstance(cur, offline_types):
+            return True
+        cur = cur.__cause__ or cur.__context__
+    return False
+
+
 @pytest.fixture(scope="module")
 def tok():
     transformers = pytest.importorskip("transformers")
@@ -409,8 +434,10 @@ def tok():
         return transformers.AutoTokenizer.from_pretrained(
             _TOKENIZER_MODEL, revision=_TOKENIZER_REVISION
         )
-    except _offline_skip_exc_types():  # pragma: no cover - offline & uncached
-        pytest.skip(
+    except Exception as exc:  # noqa: BLE001 — re-raised unless offline cache-miss
+        if not _is_offline_cache_miss(exc):
+            raise
+        pytest.skip(  # pragma: no cover - offline & uncached
             f"tokenizer {_TOKENIZER_MODEL}@{_TOKENIZER_REVISION[:8]} not "
             "cached and no network — enforcement tests require it"
         )
@@ -1419,8 +1446,10 @@ def test_deepseek_r1_prefilled_think_template_is_tolerated(lltok):
             revision=_DEEPSEEK_REVISION,
             local_files_only=True,
         )
-    except _offline_skip_exc_types():  # pragma: no cover - uncached revision
-        pytest.skip(
+    except Exception as exc:  # noqa: BLE001 — re-raised unless offline cache-miss
+        if not _is_offline_cache_miss(exc):
+            raise
+        pytest.skip(  # pragma: no cover - uncached revision
             f"{_DEEPSEEK_MODEL}@{_DEEPSEEK_REVISION[:8]} not in local cache — "
             "prefill proof requires the pinned revision cached locally"
         )


### PR DESCRIPTION
## Why

The full unit suite (pr_validate's `full_unit` gate) is **red on `main`** with 5 failing tests — none caught by GitHub CI's subset, so they slipped in behind recent feature merges and now block every PR's `full_unit`. This is a W8 firefight: get `main` green so the pipeline unblocks.

All 5 are **test-side drift behind shipped features** — the production code is correct; the test doubles / allowlist / skip-guard fell out of date. So the fix is entirely test-only (`+56/-5`, 4 files).

## What (root-cause per failure)

1–2. **`test_cli_chat`** (×2) — two hand-rolled `ChatMCPRuntime` doubles lacked `server_log_path`, which `chat_command`'s "MCP ready" banner reads (`cli.py:6211`) ever since #1191 added it (`chat_mcp.py:150`). → `AttributeError` before the tested behavior ran. Mirrored the attr on the doubles. **Bonus:** `test_chat_command_surfaces_and_retries_mcp_close_failure` was green for the *wrong* reason — the banner `AttributeError` was masked by the close-failure `RuntimeError` it asserts; now the close-failure is the only path.
3. **`test_max_tokens_resolver`** — the `_RawRequest` double lacked `.headers`, which the chat route reads for the telemetry caller-agent (`raw_request.headers.get("user-agent")`, `routes/chat.py`). Added a `.get()`-able headers mapping.
4. **`test_no_out_of_band_routing`** — `RAPID_MLX_TELEMETRY_REQUEST_SAMPLE` (telemetry request-event sampling rate, `telemetry/emit.py`) wasn't in `ALLOWED_RAPID_MLX_ENV_VARS`. It's a pure observability knob, not routing — allowlisted with a comment per the file's convention.
5. **`test_tool_grammar_558`** deepseek prefill — the offline skip-guard *missed* the failure: `transformers` **re-wraps** `huggingface_hub`'s `LocalEntryNotFoundError` into a generic `OSError` ("couldn't connect to huggingface.co"), which the type-only `except _offline_skip_exc_types()` doesn't match, so an uncached model **failed instead of skipping**. Added `_is_offline_cache_miss` which walks the `__cause__`/`__context__` chain and skips ONLY when an offline/cache-miss link is present — a corrupt-file `OSError` / invalid revision still propagates (preserves the codex round-5 intent that only genuine misses skip). Applied to both skip sites.

## Test plan

- [x] The 5 formerly-failing tests: 4 pass, deepseek correctly **skips** (model not cached locally).
- [x] Full affected files: `pytest tests/test_cli_chat.py tests/test_max_tokens_resolver.py tests/test_no_out_of_band_routing.py tests/test_tool_grammar_558.py` → **159 passed, 1 skipped**.
- [x] **FULL unit suite green**: `pytest tests/ --ignore=tests/integrations --ignore=tests/test_event_loop.py` → **13948 passed, 78 skipped, 0 failed** (was 5 failed). `main` is green again.
- [x] `ruff check` + `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)