### PR TITLE
feat(pr_validate): quarantine-aware full_unit + advisory flake tracking (dev-flow ③)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -276,11 +276,13 @@ test = [
     "pytest-cov>=4.0.0",
     "diff-cover>=8.0.0,<9.0.0",
     # Powers pr_validate's ADVISORY flake_tracking step (dev-flow ③,
-    # measure-only, never gates). Used to re-run the handful of tests
-    # that failed the full suite and classify pass-after-rerun as a
-    # flake candidate. Import is OPTIONAL — the step skips cleanly when
-    # the plugin is absent, so it is NOT in the required-plugin set that
-    # test_env_check pins. See scripts/pr_validate/steps/flake_tracking.py.
+    # never gates — the verdict cannot depend on it). Used to re-run the
+    # handful of tests that failed the full suite, classify pass-after-
+    # rerun as a flake candidate, and loudly flag a quarantined test that
+    # reproduced (for a human to de-quarantine). Import is OPTIONAL — the
+    # step skips cleanly when the plugin is absent, so it is NOT in the
+    # required-plugin set that test_env_check pins. See
+    # scripts/pr_validate/steps/flake_tracking.py.
     "pytest-rerunfailures>=14.0",
 ]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -275,6 +275,13 @@ test = [
     # #1220 r15).
     "pytest-cov>=4.0.0",
     "diff-cover>=8.0.0,<9.0.0",
+    # Powers pr_validate's ADVISORY flake_tracking step (dev-flow ③,
+    # measure-only, never gates). Used to re-run the handful of tests
+    # that failed the full suite and classify pass-after-rerun as a
+    # flake candidate. Import is OPTIONAL — the step skips cleanly when
+    # the plugin is absent, so it is NOT in the required-plugin set that
+    # test_env_check pins. See scripts/pr_validate/steps/flake_tracking.py.
+    "pytest-rerunfailures>=14.0",
 ]
 dev = [
     # Test runtime (must mirror the `test` extras above; a unit test in
@@ -298,6 +305,9 @@ dev = [
     # diff-cover major-pinned (parser couples to its footer) — see [test] note.
     "pytest-cov>=4.0.0",
     "diff-cover>=8.0.0,<9.0.0",
+    # Mirror of the [test] entry (dev ⊇ test). Powers the advisory
+    # flake_tracking step — see scripts/pr_validate/steps/flake_tracking.py.
+    "pytest-rerunfailures>=14.0",
     # Linters / typer — NOT in the `test` extras because pr_validate
     # only needs to *run* the tests; lint is its own pipeline step
     # (ruff) and runs from the host environment.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -283,7 +283,7 @@ test = [
     # step skips cleanly when the plugin is absent, so it is NOT in the
     # required-plugin set that test_env_check pins. See
     # scripts/pr_validate/steps/flake_tracking.py.
-    "pytest-rerunfailures>=14.0",
+    "pytest-rerunfailures>=14.0,<17",
 ]
 dev = [
     # Test runtime (must mirror the `test` extras above; a unit test in
@@ -309,7 +309,7 @@ dev = [
     "diff-cover>=8.0.0,<9.0.0",
     # Mirror of the [test] entry (dev ⊇ test). Powers the advisory
     # flake_tracking step — see scripts/pr_validate/steps/flake_tracking.py.
-    "pytest-rerunfailures>=14.0",
+    "pytest-rerunfailures>=14.0,<17",
     # Linters / typer — NOT in the `test` extras because pr_validate
     # only needs to *run* the tests; lint is its own pipeline step
     # (ruff) and runs from the host environment.

--- a/scripts/pr_validate/_nodeid_reporter.py
+++ b/scripts/pr_validate/_nodeid_reporter.py
@@ -25,9 +25,10 @@ back):
     logging them all would bloat the gate's artifact for no benefit.
   * session finished      → ``SESSIONFINISH\t<ran> <collected>`` — one
     line written from ``pytest_sessionfinish``, proving the run reached a
-    GRACEFUL end and recording how many items pytest attempted vs
-    collected. The quarantine downgrade in ``full_unit`` is only sound on a
-    COMPLETE run, and this record is how the consumer proves completeness
+    GRACEFUL end and recording how many DISTINCT items pytest attempted vs
+    collected (distinct so ``--reruns`` retries can't inflate the count —
+    codex #1222 r16). The quarantine downgrade in ``full_unit`` is only
+    sound on a COMPLETE run, and this record is how the consumer proves it
     STRUCTURALLY instead of scraping stdout banners (codex #1222 r15):
       - the hook fires only on a graceful end, so its ABSENCE flags a hard
         truncation — ``os._exit`` / a crash / SIGKILL kills the process
@@ -63,13 +64,15 @@ PLUGIN_MODULE = "scripts.pr_validate._nodeid_reporter"
 # run before granting any quarantine downgrade (codex #1222 r15).
 SESSION_LABEL = "SESSIONFINISH"
 
-# Count of test items pytest ATTEMPTED this session — one ``setup`` report
-# per item, regardless of pass/fail/skip. Compared against
-# ``session.testscollected`` at sessionfinish to detect an early stop
-# (``-x`` / ``--maxfail`` / ``--stepwise`` attempt fewer than they
-# collected). Reset at ``pytest_sessionstart`` so the module can be reused
-# in-process without carrying a stale count.
-_ran_tests = 0
+# The DISTINCT node ids pytest ATTEMPTED this session (each gets a ``setup``
+# report). Compared against ``session.testscollected`` at sessionfinish to
+# detect an early stop (``-x`` / ``--maxfail`` / ``--stepwise`` attempt fewer
+# items than they collected). A SET, not a counter: ``pytest-rerunfailures``
+# retries emit MULTIPLE setup reports for the SAME id, so a raw count would
+# inflate past ``collected`` and mask a truncated run — deduping by node id
+# keeps the comparison item-for-item (codex #1222 r16). Reset at
+# ``pytest_sessionstart`` so a reused module never carries a stale set.
+_attempted_ids: set[str] = set()
 
 
 def available() -> bool:
@@ -131,21 +134,21 @@ def _append(label: str, nodeid: str) -> None:
 
 
 def pytest_sessionstart(session) -> None:  # noqa: ANN001, ARG001 — pytest hook
-    # Reset the attempt counter so a reused module (e.g. a harness running
-    # multiple sessions in one process) never carries a stale count into
-    # the next session's completeness check (codex #1222 r15).
-    global _ran_tests
-    _ran_tests = 0
+    # Reset the attempt set so a reused module (e.g. a harness running
+    # multiple sessions in one process) never carries stale ids into the
+    # next session's completeness check (codex #1222 r15).
+    _attempted_ids.clear()
 
 
 def pytest_runtest_logreport(report) -> None:  # noqa: ANN001 — pytest hook
     if report.when == "setup":
-        # One setup report per item pytest ATTEMPTS (pass, fail, or skip) —
-        # count them so pytest_sessionfinish can prove ran == collected. A
-        # run truncated by -x / --maxfail / --stepwise attempts strictly
-        # fewer than it collected (codex #1222 r15).
-        global _ran_tests
-        _ran_tests += 1
+        # One setup report per item pytest ATTEMPTS (pass, fail, or skip);
+        # record the DISTINCT node id so pytest_sessionfinish can prove
+        # ran == collected. Deduping matters under --reruns, where the same
+        # id emits several setups (codex #1222 r16). A run truncated by -x /
+        # --maxfail / --stepwise attempts strictly fewer distinct items than
+        # it collected.
+        _attempted_ids.add(report.nodeid)
     if report.when == "call":
         if report.outcome == "failed":
             _append("FAILED", report.nodeid)
@@ -173,4 +176,4 @@ def pytest_sessionfinish(session, exitstatus) -> None:  # noqa: ANN001, ARG001 �
     # old stdout-banner heuristic (codex #1222 r15). ``_append`` no-ops
     # when no log path is configured.
     collected = int(getattr(session, "testscollected", 0) or 0)
-    _append(SESSION_LABEL, f"{_ran_tests} {collected}")
+    _append(SESSION_LABEL, f"{len(_attempted_ids)} {collected}")

--- a/scripts/pr_validate/_nodeid_reporter.py
+++ b/scripts/pr_validate/_nodeid_reporter.py
@@ -23,6 +23,19 @@ back):
     ``$PR_VALIDATE_NODEID_LOG_PASSES=1``. The rerun classifier needs
     positive PASSED signals; the full suite (14k passes) does not, and
     logging them all would bloat the gate's artifact for no benefit.
+  * session finished      → ``SESSIONFINISH\t<ran> <collected>`` — one
+    line written from ``pytest_sessionfinish``, proving the run reached a
+    GRACEFUL end and recording how many items pytest attempted vs
+    collected. The quarantine downgrade in ``full_unit`` is only sound on a
+    COMPLETE run, and this record is how the consumer proves completeness
+    STRUCTURALLY instead of scraping stdout banners (codex #1222 r15):
+      - the hook fires only on a graceful end, so its ABSENCE flags a hard
+        truncation — ``os._exit`` / a crash / SIGKILL kills the process
+        mid-suite and this line is simply never written;
+      - ``ran < collected`` flags an EARLY stop — ``-x`` / a hit
+        ``--maxfail`` / ``--stepwise`` run fewer items than they collected.
+    This replaces a fragile ``"stopping after" in stdout`` heuristic that
+    false-positived when those words appeared in a test's own traceback.
 
 Reads/skips are never logged: a test absent from the log positively
 "didn't fail (or pass, if passes are logged)", which is exactly the
@@ -44,6 +57,19 @@ _ENV_LOG = "PR_VALIDATE_NODEID_LOG"
 _ENV_PASSES = "PR_VALIDATE_NODEID_LOG_PASSES"
 
 PLUGIN_MODULE = "scripts.pr_validate._nodeid_reporter"
+
+# Label of the one-per-session completion record (see module docstring and
+# ``pytest_sessionfinish``). The consumer keys on this to prove a COMPLETE
+# run before granting any quarantine downgrade (codex #1222 r15).
+SESSION_LABEL = "SESSIONFINISH"
+
+# Count of test items pytest ATTEMPTED this session — one ``setup`` report
+# per item, regardless of pass/fail/skip. Compared against
+# ``session.testscollected`` at sessionfinish to detect an early stop
+# (``-x`` / ``--maxfail`` / ``--stepwise`` attempt fewer than they
+# collected). Reset at ``pytest_sessionstart`` so the module can be reused
+# in-process without carrying a stale count.
+_ran_tests = 0
 
 
 def available() -> bool:
@@ -104,7 +130,22 @@ def _append(label: str, nodeid: str) -> None:
         fh.write(f"{label}\t{nodeid}\n")
 
 
+def pytest_sessionstart(session) -> None:  # noqa: ANN001, ARG001 — pytest hook
+    # Reset the attempt counter so a reused module (e.g. a harness running
+    # multiple sessions in one process) never carries a stale count into
+    # the next session's completeness check (codex #1222 r15).
+    global _ran_tests
+    _ran_tests = 0
+
+
 def pytest_runtest_logreport(report) -> None:  # noqa: ANN001 — pytest hook
+    if report.when == "setup":
+        # One setup report per item pytest ATTEMPTS (pass, fail, or skip) —
+        # count them so pytest_sessionfinish can prove ran == collected. A
+        # run truncated by -x / --maxfail / --stepwise attempts strictly
+        # fewer than it collected (codex #1222 r15).
+        global _ran_tests
+        _ran_tests += 1
     if report.when == "call":
         if report.outcome == "failed":
             _append("FAILED", report.nodeid)
@@ -120,3 +161,16 @@ def pytest_collectreport(report) -> None:  # noqa: ANN001 — pytest hook
     # node id is the module/dir that failed to collect.
     if report.failed:
         _append("ERROR", report.nodeid)
+
+
+def pytest_sessionfinish(session, exitstatus) -> None:  # noqa: ANN001, ARG001 — pytest hook
+    # Write the STRUCTURED completion record. This hook fires only on a
+    # graceful session end, so the record's mere presence proves the
+    # process did not die mid-suite (os._exit / crash / SIGKILL), and the
+    # ran-vs-collected counts prove no early stop (-x / --maxfail /
+    # --stepwise). The consumer requires this record with ran >= collected
+    # before any quarantine downgrade — a structural replacement for the
+    # old stdout-banner heuristic (codex #1222 r15). ``_append`` no-ops
+    # when no log path is configured.
+    collected = int(getattr(session, "testscollected", 0) or 0)
+    _append(SESSION_LABEL, f"{_ran_tests} {collected}")

--- a/scripts/pr_validate/_nodeid_reporter.py
+++ b/scripts/pr_validate/_nodeid_reporter.py
@@ -173,32 +173,55 @@ def build_invocation(
     return args, env
 
 
+# Every character ``str.splitlines()`` treats as a line boundary BEYOND
+# ``\n`` / ``\r`` (handled by their own named escapes). A consumer that reads
+# the log with ``splitlines()`` — the readers in ``_pytest_summary`` do —
+# would break a record on ANY of these, so a hostile node id embedding one
+# would still forge a second record (a fake ``SESSIONFINISH`` / ``PASSED``),
+# the r23 injection channel via a separator the original escape missed (codex
+# #1222 r28). None has a legitimate place in a pytest node id; each is encoded
+# as a ``\uXXXX`` escape so the written value is a single "line" under BOTH
+# ``splitlines()`` and ``split("\n")``.
+_EXTRA_LINE_SEPARATORS = (
+    "\v",  # U+000B LINE TABULATION
+    "\f",  # U+000C FORM FEED
+    "\x1c",  # U+001C FILE SEPARATOR
+    "\x1d",  # U+001D GROUP SEPARATOR
+    "\x1e",  # U+001E RECORD SEPARATOR
+    "\x85",  # U+0085 NEXT LINE
+    "\u2028",  # U+2028 LINE SEPARATOR
+    "\u2029",  # U+2029 PARAGRAPH SEPARATOR
+)
+
+_HEX_DIGITS = frozenset("0123456789abcdefABCDEF")
+
+
 def escape_field(value: str) -> str:
     """Encode a value field so it round-trips through the one-record-per-line
-    log even when it embeds the tab/newline the format uses as delimiters.
+    log even when it embeds a delimiter or a line-boundary character.
 
     A node id is untrusted text (a hostile ``pytest_make_parametrize_id``
-    can smuggle a literal ``\\t``/``\\n`` into it), so an unescaped write
-    would let it forge additional log records. Escape the BACKSLASH first,
-    then tab / newline / carriage-return, so the written value occupies
-    exactly one physical line with no injectable delimiter and decodes
-    back losslessly (codex #1222 r23)."""
-    return (
-        value.replace("\\", "\\\\")
-        .replace("\t", "\\t")
-        .replace("\n", "\\n")
-        .replace("\r", "\\r")
-    )
+    can smuggle a literal ``\\t``/``\\n`` — or a Unicode line separator like
+    ``\\u2028`` — into it), so an unescaped write would let it forge additional
+    log records. Escape the BACKSLASH first, then tab / newline / CR, then
+    every OTHER character ``str.splitlines()`` recognizes (as ``\\uXXXX``), so
+    the written value occupies exactly one physical line under any line-split
+    definition and decodes back losslessly (codex #1222 r23/r28)."""
+    value = value.replace("\\", "\\\\")
+    value = value.replace("\t", "\\t").replace("\n", "\\n").replace("\r", "\\r")
+    for sep in _EXTRA_LINE_SEPARATORS:
+        value = value.replace(sep, f"\\u{ord(sep):04x}")
+    return value
 
 
 def unescape_field(value: str) -> str:
     """Inverse of ``escape_field``. Scans left-to-right so an escaped
     backslash (``\\\\``) is consumed as one literal ``\\`` and can't pair
-    with a following ``t``/``n``/``r`` to fabricate a control char
-    (``\\\\t`` decodes to ``\\`` + ``t``, NOT a tab). An unknown escape or a
-    trailing lone backslash is preserved verbatim — the writer never emits
-    those, so this only keeps a hand-written/raw record intact rather than
-    corrupting it."""
+    with a following ``t``/``n``/``r``/``uXXXX`` to fabricate a control char
+    (``\\\\t`` decodes to ``\\`` + ``t``, NOT a tab). An unknown escape, a
+    malformed ``\\u`` (not four hex digits), or a trailing lone backslash is
+    preserved verbatim — the writer never emits those, so this only keeps a
+    hand-written/raw record intact rather than corrupting it."""
     if "\\" not in value:
         return value
     out: list[str] = []
@@ -213,6 +236,13 @@ def unescape_field(value: str) -> str:
                 out.append(decoded)
                 i += 2
                 continue
+            # ``\uXXXX`` (exactly four hex digits) → the encoded separator.
+            if nxt == "u" and i + 6 <= n:
+                hexdigits = value[i + 2 : i + 6]
+                if all(ch in _HEX_DIGITS for ch in hexdigits):
+                    out.append(chr(int(hexdigits, 16)))
+                    i += 6
+                    continue
         out.append(c)
         i += 1
     return "".join(out)

--- a/scripts/pr_validate/_nodeid_reporter.py
+++ b/scripts/pr_validate/_nodeid_reporter.py
@@ -351,9 +351,12 @@ def pytest_sessionfinish(session, exitstatus) -> None:  # noqa: ANN001, ARG001 â
     # graceful session end, so the record's mere presence proves the
     # process did not die mid-suite (os._exit / crash / SIGKILL), and the
     # ran-vs-collected counts prove no early stop (-x / --maxfail /
-    # --stepwise). The consumer requires this record with ran >= collected
+    # --stepwise). The consumer requires this record with ran == collected
     # before any quarantine downgrade â€” a structural replacement for the
-    # old stdout-banner heuristic (codex #1222 r15). ``_append`` no-ops
-    # when no log path is configured.
+    # old stdout-banner heuristic (codex #1222 r15). ``ran`` counts DISTINCT
+    # terminal teardowns, so a faithful record has ran == collected exactly;
+    # ran > collected is impossible-except-forged and the consumer rejects it
+    # as malformed (codex #1222 r36). ``_append`` no-ops when no log path is
+    # configured.
     collected = int(getattr(session, "testscollected", 0) or 0)
     _append(SESSION_LABEL, f"{len(_completed_ids)} {collected}")

--- a/scripts/pr_validate/_nodeid_reporter.py
+++ b/scripts/pr_validate/_nodeid_reporter.py
@@ -294,7 +294,7 @@ def pytest_runtest_logreport(report) -> None:  # noqa: ANN001 — pytest hook
         # that a ``-p no:<name>`` block can't reach (codex #1222 r23). A
         # gating run disables reruns, so any RERUN record is a tamper signal.
         _append(RERUN_LABEL, report.nodeid)
-    if report.when == "teardown":
+    if report.when == "teardown" and report.outcome != "rerun":
         # One teardown report per item pytest ran to COMPLETION; record the
         # DISTINCT node id so pytest_sessionfinish can prove ran == collected.
         # Teardown (not setup) so a ``pytest.exit()`` mid-call can't leave a
@@ -303,6 +303,14 @@ def pytest_runtest_logreport(report) -> None:  # noqa: ANN001 — pytest hook
         # several reports (codex #1222 r16). A run truncated by -x / --maxfail
         # / --stepwise / a mid-call pytest.exit tears down strictly fewer
         # distinct items than it collected.
+        #
+        # ``outcome != "rerun"`` (codex #1222 r32): a TEARDOWN-phase failure
+        # that pytest-rerunfailures retries emits an INTERMEDIATE teardown
+        # report with ``outcome == "rerun"`` (verified — unlike a call-phase
+        # rerun, which emits no intermediate teardown at all). Counting that
+        # provisional teardown would let a later truncated FINAL attempt still
+        # satisfy ``ran == collected``. Only a terminal (non-rerun) teardown
+        # proves the item actually finished, so gate on it.
         _completed_ids.add(report.nodeid)
     if report.when == "call":
         if report.outcome == "failed":

--- a/scripts/pr_validate/_nodeid_reporter.py
+++ b/scripts/pr_validate/_nodeid_reporter.py
@@ -17,6 +17,10 @@ It writes tab-separated ``<LABEL>\t<nodeid>`` lines to the file named by
 back):
 
   * call-phase failure  → ``FAILED``
+  * strict-xfail XPASS   → ``ERROR`` — a call-phase "failed" that pytest makes
+    FATAL because the xfail marker is stale; recorded as ERROR (unconditional
+    block, never a quarantinable flake) rather than a downgradeable FAILED
+    (codex #1222 r31). Detected by its string ``"[XPASS(strict)]"`` longrepr.
   * setup/teardown fail  → ``ERROR``  (mirrors pytest's own -rfE split)
   * collection failure   → ``ERROR``
   * call-phase pass      → ``PASSED`` — ONLY when
@@ -268,6 +272,20 @@ def pytest_sessionstart(session) -> None:  # noqa: ANN001, ARG001 — pytest hoo
     _completed_ids.clear()
 
 
+def _is_strict_xpass(report) -> bool:  # noqa: ANN001
+    """True iff ``report`` is a strict-xfail test that XPASSED.
+
+    pytest makes a ``@pytest.mark.xfail(strict=True)`` that unexpectedly
+    passes FATAL (``outcome == "failed"``) — the xfail marker is now stale.
+    Its call report carries a STRING ``longrepr`` of the form
+    ``"[XPASS(strict)] <reason>"``, whereas a genuine call failure carries an
+    ``ExceptionRepr`` OBJECT — the only clean, attribute-stable discriminator
+    (``report.wasxfail`` is UNSET for a strict xpass; verified codex
+    #1222 r27/r31)."""
+    longrepr = getattr(report, "longrepr", None)
+    return isinstance(longrepr, str) and longrepr.startswith("[XPASS(strict)]")
+
+
 def pytest_runtest_logreport(report) -> None:  # noqa: ANN001 — pytest hook
     if report.outcome == "rerun":
         # pytest-rerunfailures emitted a retry. Record it NAME-INDEPENDENTLY
@@ -288,7 +306,17 @@ def pytest_runtest_logreport(report) -> None:  # noqa: ANN001 — pytest hook
         _completed_ids.add(report.nodeid)
     if report.when == "call":
         if report.outcome == "failed":
-            _append("FAILED", report.nodeid)
+            if _is_strict_xpass(report):
+                # A strict-xfail XPASS is pytest's INTENTIONAL fatal signal
+                # (the xfail marker is stale). Record it as ERROR, not FAILED,
+                # so it BLOCKS unconditionally in every gate: ERROR is never a
+                # quarantinable flake in full_unit and always makes targeted
+                # untrusted — a FAILED strict-xpass on a (mistakenly)
+                # quarantined node would otherwise be downgraded to a
+                # non-blocking flake, masking the fatal (codex #1222 r31).
+                _append("ERROR", report.nodeid)
+            else:
+                _append("FAILED", report.nodeid)
         elif report.outcome == "passed" and os.environ.get(_ENV_PASSES) == "1":
             _append("PASSED", report.nodeid)
     elif report.failed:

--- a/scripts/pr_validate/_nodeid_reporter.py
+++ b/scripts/pr_validate/_nodeid_reporter.py
@@ -82,6 +82,13 @@ def build_invocation(
     env[_ENV_LOG] = str(log_path)
     if log_passes:
         env[_ENV_PASSES] = "1"
+    else:
+        # Set the flag DEFINITIVELY, don't just skip it: an inherited
+        # PR_VALIDATE_NODEID_LOG_PASSES=1 from the parent env would
+        # otherwise make full_unit (log_passes=False) log all ~14k passes
+        # and bloat the artifact (codex #1222 r12). Pop it so False means
+        # off regardless of what was inherited.
+        env.pop(_ENV_PASSES, None)
     env["PYTHONPATH"] = str(repo_root) + os.pathsep + env.get("PYTHONPATH", "")
     return args, env
 

--- a/scripts/pr_validate/_nodeid_reporter.py
+++ b/scripts/pr_validate/_nodeid_reporter.py
@@ -64,15 +64,30 @@ PLUGIN_MODULE = "scripts.pr_validate._nodeid_reporter"
 # run before granting any quarantine downgrade (codex #1222 r15).
 SESSION_LABEL = "SESSIONFINISH"
 
-# The DISTINCT node ids pytest ATTEMPTED this session (each gets a ``setup``
-# report). Compared against ``session.testscollected`` at sessionfinish to
-# detect an early stop (``-x`` / ``--maxfail`` / ``--stepwise`` attempt fewer
-# items than they collected). A SET, not a counter: ``pytest-rerunfailures``
-# retries emit MULTIPLE setup reports for the SAME id, so a raw count would
-# inflate past ``collected`` and mask a truncated run — deduping by node id
-# keeps the comparison item-for-item (codex #1222 r16). Reset at
-# ``pytest_sessionstart`` so a reused module never carries a stale set.
-_attempted_ids: set[str] = set()
+# The DISTINCT node ids pytest ran to COMPLETION this session — counted on
+# the ``teardown`` report, which fires only AFTER an item's full lifecycle
+# (setup + call + teardown) finishes. Compared against
+# ``session.testscollected`` at sessionfinish to detect an early stop (``-x``
+# / ``--maxfail`` / ``--stepwise`` tear down fewer items than they collected).
+#
+# Counting the ``teardown`` (terminal) report, NOT the ``setup`` report, is
+# deliberate (codex #1222 r20): a ``setup`` report is emitted the moment an
+# item STARTS, so a test that calls ``pytest.exit(returncode=0)`` from its
+# CALL body — after its own setup report but before completing — would leave
+# ``ran == collected`` and be accepted as a complete green run even though its
+# body never finished and every later item was skipped. An item that exits
+# mid-call emits NO teardown report (verified empirically), so teardown-
+# counting withholds on exactly that truncation. skip / skipif / xfail /
+# xpass / runtime-``pytest.skip`` / setup-ERROR / teardown-ERROR items all DO
+# emit a teardown report, so a legitimately complete run still counts
+# item-for-item.
+#
+# A SET, not a counter: ``pytest-rerunfailures`` retries can emit multiple
+# reports for the SAME id, so a raw count could inflate past ``collected`` and
+# mask a truncated run — deduping by node id keeps the comparison
+# item-for-item (codex #1222 r16). Reset at ``pytest_sessionstart`` so a
+# reused module never carries a stale set.
+_completed_ids: set[str] = set()
 
 
 def available() -> bool:
@@ -134,21 +149,23 @@ def _append(label: str, nodeid: str) -> None:
 
 
 def pytest_sessionstart(session) -> None:  # noqa: ANN001, ARG001 — pytest hook
-    # Reset the attempt set so a reused module (e.g. a harness running
+    # Reset the completion set so a reused module (e.g. a harness running
     # multiple sessions in one process) never carries stale ids into the
     # next session's completeness check (codex #1222 r15).
-    _attempted_ids.clear()
+    _completed_ids.clear()
 
 
 def pytest_runtest_logreport(report) -> None:  # noqa: ANN001 — pytest hook
-    if report.when == "setup":
-        # One setup report per item pytest ATTEMPTS (pass, fail, or skip);
-        # record the DISTINCT node id so pytest_sessionfinish can prove
-        # ran == collected. Deduping matters under --reruns, where the same
-        # id emits several setups (codex #1222 r16). A run truncated by -x /
-        # --maxfail / --stepwise attempts strictly fewer distinct items than
-        # it collected.
-        _attempted_ids.add(report.nodeid)
+    if report.when == "teardown":
+        # One teardown report per item pytest ran to COMPLETION; record the
+        # DISTINCT node id so pytest_sessionfinish can prove ran == collected.
+        # Teardown (not setup) so a ``pytest.exit()`` mid-call can't leave a
+        # phantom "ran" for an item whose body never finished (codex #1222
+        # r20). Deduping matters under --reruns, where the same id can emit
+        # several reports (codex #1222 r16). A run truncated by -x / --maxfail
+        # / --stepwise / a mid-call pytest.exit tears down strictly fewer
+        # distinct items than it collected.
+        _completed_ids.add(report.nodeid)
     if report.when == "call":
         if report.outcome == "failed":
             _append("FAILED", report.nodeid)
@@ -176,4 +193,4 @@ def pytest_sessionfinish(session, exitstatus) -> None:  # noqa: ANN001, ARG001 �
     # old stdout-banner heuristic (codex #1222 r15). ``_append`` no-ops
     # when no log path is configured.
     collected = int(getattr(session, "testscollected", 0) or 0)
-    _append(SESSION_LABEL, f"{len(_attempted_ids)} {collected}")
+    _append(SESSION_LABEL, f"{len(_completed_ids)} {collected}")

--- a/scripts/pr_validate/_nodeid_reporter.py
+++ b/scripts/pr_validate/_nodeid_reporter.py
@@ -1,0 +1,115 @@
+# SPDX-License-Identifier: Apache-2.0
+"""pytest plugin: record the CANONICAL node id of each test outcome.
+
+``full_unit`` (quarantine partition) and ``flake_tracking`` (rerun
+classification) both need the exact node id of every failing/passing test.
+Parsing them out of pytest's terminal short-summary is IRREDUCIBLY
+ambiguous: a summary line is ``<LABEL> <nodeid>[ - <message>]``, but a
+parametrized node id can itself contain ``" - "`` and unbalanced ``[]``
+(``test_x[a] - [b]``, ``test_x[a] - b]``, ``test_x[a] - b[c]`` …), so no
+text rule can split id-from-message without a hole — five successive
+patches each grew a new edge case (codex #1222 r4/r5/r6/r9/r10). This
+plugin sidesteps the parse entirely: ``report.nodeid`` is pytest's ground
+truth, the same string a ``quarantine.yaml`` entry is written as.
+
+It writes tab-separated ``<LABEL>\t<nodeid>`` lines to the file named by
+``$PR_VALIDATE_NODEID_LOG`` (a plain, append-only log the consumers read
+back):
+
+  * call-phase failure  → ``FAILED``
+  * setup/teardown fail  → ``ERROR``  (mirrors pytest's own -rfE split)
+  * collection failure   → ``ERROR``
+  * call-phase pass      → ``PASSED`` — ONLY when
+    ``$PR_VALIDATE_NODEID_LOG_PASSES=1``. The rerun classifier needs
+    positive PASSED signals; the full suite (14k passes) does not, and
+    logging them all would bloat the gate's artifact for no benefit.
+
+Reads/skips are never logged: a test absent from the log positively
+"didn't fail (or pass, if passes are logged)", which is exactly the
+"inconclusive, not a flake" signal ``flake_tracking`` wants.
+
+This is NOT tamper-proof against a hostile in-process author (an
+``atexit``/``conftest`` could rewrite the file) — nothing in-process is,
+junit-xml included; that residual is scoped in ``_pytest_summary`` and
+defended by the other gates. What it DOES buy is exact, unambiguous node
+ids for every realistic run, closing the parse-ambiguity class for good.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+
+_ENV_LOG = "PR_VALIDATE_NODEID_LOG"
+_ENV_PASSES = "PR_VALIDATE_NODEID_LOG_PASSES"
+
+PLUGIN_MODULE = "scripts.pr_validate._nodeid_reporter"
+
+
+def available() -> bool:
+    """True iff this plugin module can be imported by a pytest subprocess.
+
+    It is normally always importable (the validator itself runs as
+    ``scripts.pr_validate``), but the check lets a caller degrade to
+    terminal-summary parsing instead of passing an unloadable ``-p`` that
+    would make pytest exit with a usage error."""
+    return importlib.util.find_spec(PLUGIN_MODULE) is not None
+
+
+def build_invocation(
+    log_path,
+    repo_root,
+    *,
+    log_passes: bool = False,
+    base_env: dict | None = None,
+) -> tuple[list[str], dict]:
+    """Build the ``(extra_pytest_args, env)`` that make a pytest subprocess
+    emit the structured node-id log at ``log_path``.
+
+    NOTE: this helper must NOT be named ``pytest_*`` — pytest's plugin
+    manager treats every ``pytest_``-prefixed callable in a loaded plugin
+    module as a hook and raises ``PluginValidationError: unknown hook`` at
+    collection when the name isn't a real hook (this module IS loaded as a
+    ``-p`` plugin, so the two genuine hooks below are the only ``pytest_``
+    names allowed).
+
+    ``repo_root`` is prepended to ``PYTHONPATH`` so the ``-p`` plugin
+    resolves in the subprocess (``scripts`` is a namespace package, so it
+    must be importable from the repo root). Pass ``log_passes=True`` for the
+    rerun classifier, which needs positive PASSED signals."""
+    args = ["-p", PLUGIN_MODULE]
+    env = dict(os.environ if base_env is None else base_env)
+    env[_ENV_LOG] = str(log_path)
+    if log_passes:
+        env[_ENV_PASSES] = "1"
+    env["PYTHONPATH"] = str(repo_root) + os.pathsep + env.get("PYTHONPATH", "")
+    return args, env
+
+
+def _append(label: str, nodeid: str) -> None:
+    path = os.environ.get(_ENV_LOG)
+    if not path:
+        return
+    # Append so setup/call/teardown reports for the same test each add
+    # their own line; open per-call to stay robust to xdist workers each
+    # writing (append is atomic for the small line sizes here).
+    with open(path, "a", encoding="utf-8") as fh:
+        fh.write(f"{label}\t{nodeid}\n")
+
+
+def pytest_runtest_logreport(report) -> None:  # noqa: ANN001 — pytest hook
+    if report.when == "call":
+        if report.outcome == "failed":
+            _append("FAILED", report.nodeid)
+        elif report.outcome == "passed" and os.environ.get(_ENV_PASSES) == "1":
+            _append("PASSED", report.nodeid)
+    elif report.failed:
+        # A failure in setup or teardown — pytest reports these as ERROR.
+        _append("ERROR", report.nodeid)
+
+
+def pytest_collectreport(report) -> None:  # noqa: ANN001 — pytest hook
+    # A collection failure (import error, bad conftest) — ERROR, and the
+    # node id is the module/dir that failed to collect.
+    if report.failed:
+        _append("ERROR", report.nodeid)

--- a/scripts/pr_validate/_nodeid_reporter.py
+++ b/scripts/pr_validate/_nodeid_reporter.py
@@ -38,15 +38,35 @@ back):
     This replaces a fragile ``"stopping after" in stdout`` heuristic that
     false-positived when those words appeared in a test's own traceback.
 
+  * retried attempt        → ``RERUN`` — logged whenever a report's
+    ``outcome`` is ``"rerun"`` (pytest-rerunfailures). A GATING run
+    DISABLES reruns, so any RERUN record proves the plugin was smuggled
+    back in — under an ARBITRARY name that a ``-p no:<name>`` block can't
+    reach (``config.pluginmanager.register(mod, name="…")`` + a
+    ``@pytest.mark.flaky`` marker still reruns, verified). ``full_unit``
+    blocks on this record NAME-INDEPENDENTLY (codex #1222 r23), the
+    backstop the by-name guard alone can't provide.
+
 Reads/skips are never logged: a test absent from the log positively
 "didn't fail (or pass, if passes are logged)", which is exactly the
 "inconclusive, not a flake" signal ``flake_tracking`` wants.
 
+Node ids are NOT trustworthy text. A hostile
+``pytest_make_parametrize_id`` can return a param id containing a literal
+``\t`` or ``\n`` (verified — pytest preserves both), which written raw
+would forge extra log records — a fake ``SESSIONFINISH`` masking a
+truncated run, a fake ``PASSED`` turning a real failure into a
+"recovered" flake in the advisory step. So every value field is
+``escape_field``-encoded on write (backslash, tab, newline, CR) and
+``unescape_field``-decoded on read, guaranteeing one record per physical
+line with no injectable delimiter (codex #1222 r23).
+
 This is NOT tamper-proof against a hostile in-process author (an
-``atexit``/``conftest`` could rewrite the file) — nothing in-process is,
-junit-xml included; that residual is scoped in ``_pytest_summary`` and
-defended by the other gates. What it DOES buy is exact, unambiguous node
-ids for every realistic run, closing the parse-ambiguity class for good.
+``atexit``/``conftest`` could rewrite the file with real newlines) —
+nothing in-process is, junit-xml included; that residual is scoped in
+``_pytest_summary`` and defended by the other gates. What escaping buys
+is closing the node-id INJECTION channel (the realistic vector), on top
+of exact, unambiguous node ids for every realistic run.
 """
 
 from __future__ import annotations
@@ -63,6 +83,14 @@ PLUGIN_MODULE = "scripts.pr_validate._nodeid_reporter"
 # ``pytest_sessionfinish``). The consumer keys on this to prove a COMPLETE
 # run before granting any quarantine downgrade (codex #1222 r15).
 SESSION_LABEL = "SESSIONFINISH"
+
+# Label of a retried-attempt record. Logged on any ``outcome == "rerun"``
+# report so ``full_unit`` can detect a smuggled pytest-rerunfailures
+# NAME-INDEPENDENTLY: a gating run disables reruns, so any RERUN record
+# means the plugin was re-registered under a name the ``-p no:<name>``
+# block can't reach, and a rerun could retry a real failure into a pass
+# (codex #1222 r23).
+RERUN_LABEL = "RERUN"
 
 # The DISTINCT node ids pytest ran to COMPLETION this session — counted on
 # the ``teardown`` report, which fires only AFTER an item's full lifecycle
@@ -137,15 +165,62 @@ def build_invocation(
     return args, env
 
 
+def escape_field(value: str) -> str:
+    """Encode a value field so it round-trips through the one-record-per-line
+    log even when it embeds the tab/newline the format uses as delimiters.
+
+    A node id is untrusted text (a hostile ``pytest_make_parametrize_id``
+    can smuggle a literal ``\\t``/``\\n`` into it), so an unescaped write
+    would let it forge additional log records. Escape the BACKSLASH first,
+    then tab / newline / carriage-return, so the written value occupies
+    exactly one physical line with no injectable delimiter and decodes
+    back losslessly (codex #1222 r23)."""
+    return (
+        value.replace("\\", "\\\\")
+        .replace("\t", "\\t")
+        .replace("\n", "\\n")
+        .replace("\r", "\\r")
+    )
+
+
+def unescape_field(value: str) -> str:
+    """Inverse of ``escape_field``. Scans left-to-right so an escaped
+    backslash (``\\\\``) is consumed as one literal ``\\`` and can't pair
+    with a following ``t``/``n``/``r`` to fabricate a control char
+    (``\\\\t`` decodes to ``\\`` + ``t``, NOT a tab). An unknown escape or a
+    trailing lone backslash is preserved verbatim — the writer never emits
+    those, so this only keeps a hand-written/raw record intact rather than
+    corrupting it."""
+    if "\\" not in value:
+        return value
+    out: list[str] = []
+    i = 0
+    n = len(value)
+    while i < n:
+        c = value[i]
+        if c == "\\" and i + 1 < n:
+            nxt = value[i + 1]
+            decoded = {"\\": "\\", "t": "\t", "n": "\n", "r": "\r"}.get(nxt)
+            if decoded is not None:
+                out.append(decoded)
+                i += 2
+                continue
+        out.append(c)
+        i += 1
+    return "".join(out)
+
+
 def _append(label: str, nodeid: str) -> None:
     path = os.environ.get(_ENV_LOG)
     if not path:
         return
     # Append so setup/call/teardown reports for the same test each add
     # their own line; open per-call to stay robust to xdist workers each
-    # writing (append is atomic for the small line sizes here).
+    # writing (append is atomic for the small line sizes here). The value
+    # is escape_field-encoded so an injected tab/newline in a hostile node
+    # id can't forge a second record (codex #1222 r23).
     with open(path, "a", encoding="utf-8") as fh:
-        fh.write(f"{label}\t{nodeid}\n")
+        fh.write(f"{label}\t{escape_field(nodeid)}\n")
 
 
 def pytest_sessionstart(session) -> None:  # noqa: ANN001, ARG001 — pytest hook
@@ -156,6 +231,13 @@ def pytest_sessionstart(session) -> None:  # noqa: ANN001, ARG001 — pytest hoo
 
 
 def pytest_runtest_logreport(report) -> None:  # noqa: ANN001 — pytest hook
+    if report.outcome == "rerun":
+        # pytest-rerunfailures emitted a retry. Record it NAME-INDEPENDENTLY
+        # (this fires on the OUTCOME, not the plugin's registered name) so
+        # full_unit can detect a plugin smuggled in under an arbitrary name
+        # that a ``-p no:<name>`` block can't reach (codex #1222 r23). A
+        # gating run disables reruns, so any RERUN record is a tamper signal.
+        _append(RERUN_LABEL, report.nodeid)
     if report.when == "teardown":
         # One teardown report per item pytest ran to COMPLETION; record the
         # DISTINCT node id so pytest_sessionfinish can prove ran == collected.

--- a/scripts/pr_validate/_nodeid_reporter.py
+++ b/scripts/pr_validate/_nodeid_reporter.py
@@ -92,6 +92,14 @@ SESSION_LABEL = "SESSIONFINISH"
 # (codex #1222 r23).
 RERUN_LABEL = "RERUN"
 
+# SUPPLEMENTARY label for a COLLECTION failure, written ALONGSIDE the ERROR
+# record (never instead of it), so ``full_unit``'s gate — which reads ERROR
+# — is untouched and can't be weakened. The advisory classifier reads this
+# to recognize a collection target whose id CONTAINS ``::`` (a class
+# collector: ``tests/test_x.py::TestClass``), which the "``::``-absence"
+# heuristic alone misses (codex #1222 r24).
+COLLECTERROR_LABEL = "COLLECTERROR"
+
 # The DISTINCT node ids pytest ran to COMPLETION this session — counted on
 # the ``teardown`` report, which fires only AFTER an item's full lifecycle
 # (setup + call + teardown) finishes. Compared against
@@ -260,9 +268,16 @@ def pytest_runtest_logreport(report) -> None:  # noqa: ANN001 — pytest hook
 
 def pytest_collectreport(report) -> None:  # noqa: ANN001 — pytest hook
     # A collection failure (import error, bad conftest) — ERROR, and the
-    # node id is the module/dir that failed to collect.
+    # node id is the module/dir/class that failed to collect.
     if report.failed:
         _append("ERROR", report.nodeid)
+        # ALSO tag it as a COLLECTION error (in ADDITION to ERROR, never
+        # instead) so the advisory classifier can recognize a collection
+        # target even when its id contains "::" — a class collector reports
+        # `tests/test_x.py::TestClass`, which the "::"-absence heuristic
+        # misses. full_unit reads ERROR for its gate, so this extra label
+        # cannot weaken it (codex #1222 r24).
+        _append(COLLECTERROR_LABEL, report.nodeid)
 
 
 def pytest_sessionfinish(session, exitstatus) -> None:  # noqa: ANN001, ARG001 — pytest hook

--- a/scripts/pr_validate/_pytest_summary.py
+++ b/scripts/pr_validate/_pytest_summary.py
@@ -22,6 +22,8 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
+from ._nodeid_reporter import SESSION_LABEL, unescape_field
+
 # pytest writes the section header as a full-width separator banner:
 # ``==================== short test summary info ====================``.
 # Anchoring on that *padded* banner — not a bare ``"short test summary"``
@@ -59,11 +61,66 @@ def report_log_node_ids(path: Path, *labels: str) -> list[str]:
     out: list[str] = []
     seen: set[str] = set()
     for line in path.read_text(encoding="utf-8").splitlines():
-        label, tab, nodeid = line.partition("\t")
-        if tab and label in wanted and nodeid and nodeid not in seen:
+        label, tab, raw = line.partition("\t")
+        if not (tab and label in wanted and raw):
+            continue
+        # Decode the escaped value back to the exact node id. Dedup on the
+        # DECODED id so an escaped and a raw spelling of the same id can't
+        # both slip through (codex #1222 r23).
+        nodeid = unescape_field(raw)
+        if nodeid and nodeid not in seen:
             seen.add(nodeid)
             out.append(nodeid)
     return out
+
+
+def raw_session_records(path: Path) -> list[str]:
+    """Every ``SESSIONFINISH`` value line in the log, decoded but WITHOUT the
+    node-id dedup ``report_log_node_ids`` applies.
+
+    Two identical completion records must count as two so ``session_completed``
+    can reject the duplicate (an unexpected xdist/tamper shape) — deduping
+    would collapse them to one and slip a second record past the "exactly
+    one" rule (codex #1222 r16)."""
+    out: list[str] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        rec_label, tab, raw = line.partition("\t")
+        if tab and rec_label == SESSION_LABEL and raw:
+            out.append(unescape_field(raw))
+    return out
+
+
+def session_completed(path: Path) -> bool:
+    """True iff the reporter's session-finish record proves pytest ran the
+    WHOLE collected suite — the precondition for a sound quarantine
+    downgrade (``full_unit``) and for trusting a rerun classification
+    (``flake_tracking``) (codex #1222 r15/r23).
+
+    Both truncation modes are caught STRUCTURALLY, replacing an old
+    stdout-banner heuristic that false-positived when a test's own traceback
+    contained ``"stopping after"`` / ``"Interrupted:"`` (r15 B2):
+
+      * ABSENT record → ``pytest_sessionfinish`` never fired, i.e. the
+        process died mid-suite (``os._exit`` / crash / SIGKILL) (r15 B1).
+      * ``ran < collected`` → the session ended early (``-x`` / a hit
+        ``--maxfail`` / ``--stepwise`` / a mid-call ``pytest.exit``), so
+        tests after the stop never ran.
+
+    Requires EXACTLY one well-formed record (``<ran> <collected>``) with a
+    positive collected count and ``ran >= collected``. Anything else —
+    missing, malformed, duplicated — withholds trust, the safe direction.
+
+    Kept here (not in a step) so ``full_unit`` and ``flake_tracking`` share
+    ONE completeness definition and can't drift on it."""
+    records = raw_session_records(path)
+    if len(records) != 1:
+        return False
+    try:
+        ran_s, collected_s = records[0].split()
+        ran, collected = int(ran_s), int(collected_s)
+    except (ValueError, TypeError):
+        return False
+    return collected > 0 and ran >= collected
 
 
 def summary_node_ids(text: str, *labels: str) -> list[str]:

--- a/scripts/pr_validate/_pytest_summary.py
+++ b/scripts/pr_validate/_pytest_summary.py
@@ -84,19 +84,31 @@ def _strip_message(rest: str) -> str:
     (``test_x - AssertionError: [1]`` → ``test_x``) — the earlier
     ``rfind("]")`` approach got the latter wrong (codex #1222 r5).
 
-    Known limitation (codex #1222 r6): a node id whose EXPLICIT param id
-    contains an *unmatched* bracket (e.g. ``ids=["["]`` → ``test_x[[]``)
-    leaves the depth counter unbalanced, so the message is absorbed into
-    the returned id. This is irreducible in pytest's terminal output —
-    ``nodeid - message`` is genuinely ambiguous when the id may hold
-    ``" - "`` and unbalanced ``[]`` while the message may hold anything.
-    It fails SAFE: a mangled id won't match a (normal) quarantine entry,
-    so the failure BLOCKS rather than being wrongly downgraded, and a
-    mistargeted advisory re-run just yields an inconclusive result. A
-    structured report (junit-xml) was considered and rejected: its
+    Ambiguity is resolved by failing SAFE, never by guessing. Two cases:
+
+      * ``r6``: a node id whose EXPLICIT param id holds an *unmatched*
+        bracket (``ids=["["]`` → ``test_x[[]``) leaves the depth counter
+        unbalanced, so the message is absorbed into the returned id.
+      * ``r9``: a param id that itself contains ``"] - ["`` (e.g.
+        ``test_x[a] - [b]``) makes the inner ``]`` close the depth
+        prematurely, so the FIRST depth-0 ``" - "`` lands *inside* the
+        param sequence. Splitting there would truncate to ``test_x[a]`` —
+        which could wrongly match a shorter quarantine entry and DOWNGRADE
+        a real failure. To prevent that, a candidate split is rejected when
+        the message it would produce begins with ``"["`` (the tell-tale of
+        a mid-param split, or a genuine bracket-leading message we equally
+        can't disambiguate). We then return the whole line as the id.
+
+    Both cases return a mangled id that won't match a normal quarantine
+    entry, so the failure BLOCKS rather than being wrongly waived, and a
+    mistargeted advisory re-run just yields an inconclusive result. The
+    r4/r5 common cases are unaffected — their message begins with the
+    exception text (``AssertionError: …``) or a bare word, not ``"["``.
+
+    A structured report (junit-xml) was considered and rejected: its
     ``classname``/``name`` split can't be mapped back to a pytest node id
-    unambiguously for class-based / deep-package tests, trading this rare
-    safe failure for a common-path matching risk."""
+    unambiguously for class-based / deep-package tests, trading these rare
+    safe failures for a common-path matching risk."""
     depth = 0
     i = 0
     n = len(rest)
@@ -108,6 +120,13 @@ def _strip_message(rest: str) -> str:
             if depth > 0:
                 depth -= 1
         elif depth == 0 and rest.startswith(" - ", i):
+            # A message beginning with "[" means we can't tell a genuine
+            # bracket-leading message from a split taken in the MIDDLE of a
+            # bracketed param sequence ("test_x[a] - [b]"). Fail safe:
+            # return the whole line so an ambiguous id can't be wrongly
+            # matched against a shorter quarantine entry (codex #1222 r9).
+            if rest[i + 3 :].startswith("["):
+                return rest.strip()
             return rest[:i].strip()
         i += 1
     return rest.strip()

--- a/scripts/pr_validate/_pytest_summary.py
+++ b/scripts/pr_validate/_pytest_summary.py
@@ -310,13 +310,36 @@ def _strip_message(rest: str) -> str:
             if depth > 0:
                 depth -= 1
         elif depth == 0 and rest.startswith(" - ", i):
-            # A message beginning with "[" means we can't tell a genuine
-            # bracket-leading message from a split taken in the MIDDLE of a
-            # bracketed param sequence ("test_x[a] - [b]"). Fail safe:
-            # return the whole line so an ambiguous id can't be wrongly
-            # matched against a shorter quarantine entry (codex #1222 r9).
-            if rest[i + 3 :].startswith("["):
+            msg = rest[i + 3 :]
+            # Fail safe (return the WHOLE line, which won't match a shorter
+            # id) whenever the split is unreliable:
+            #  * message begins with "[" — can't tell a genuine bracket-
+            #    leading message from a split taken in the MIDDLE of a
+            #    bracketed param sequence ("test_x[a] - [b]") (codex r9).
+            #  * message contains an UNMATCHED "]" — that "]" almost
+            #    certainly closes a param bracket in the REAL node id (a
+            #    custom param id like "a] - b" → node "test_x[a] - b]"), so
+            #    the id extends PAST this "-" and splitting here would
+            #    COLLAPSE it to a shorter id ("test_x[a]") that could wrongly
+            #    match a PR-introduced failure and waive it as pre-existing —
+            #    a FALSE GREEN in the base negative control (codex #1222 r40).
+            if msg.startswith("[") or _has_unmatched_close_bracket(msg):
                 return rest.strip()
             return rest[:i].strip()
         i += 1
     return rest.strip()
+
+
+def _has_unmatched_close_bracket(s: str) -> bool:
+    """True if ``s`` holds a ``]`` with no matching earlier ``[`` — the
+    tell-tale that a candidate node-id/message split fell INSIDE the id's
+    parametrization brackets (codex #1222 r40)."""
+    depth = 0
+    for c in s:
+        if c == "[":
+            depth += 1
+        elif c == "]":
+            depth -= 1
+            if depth < 0:
+                return True
+    return False

--- a/scripts/pr_validate/_pytest_summary.py
+++ b/scripts/pr_validate/_pytest_summary.py
@@ -121,6 +121,29 @@ def render_fence_safe(node_id: str) -> str:
     return json.dumps(node_id, ensure_ascii=False)
 
 
+_SUMMARY_COUNTS_RE = re.compile(
+    r"\b\d+ (passed|failed|error|skipped|xfailed|xpassed|deselected)\b"
+)
+
+
+def last_summary_line(stdout: str) -> str:
+    """pytest's final counts line, WITH or WITHOUT the ``====`` bars.
+
+    In verbose mode the line is fenced (``==== 3 passed in 1s ====``); once the
+    inherited ``-v`` is dropped (``-o addopts=`` neutralizes the repo addopts)
+    pytest prints it bar-less (``3 passed in 1s``). A ``startswith("=")`` rule
+    would miss the bar-less form and degrade the step summary to a bare
+    "exit N" (codex #1222 r27/r28). Anchor on the ``<n> <outcome> … in <t>s``
+    shape so both forms are recognized. Shared by ``targeted_tests`` and
+    ``full_unit`` so the two can't drift. Returns "" when there is no counts
+    line (the caller falls back to the exit code)."""
+    for line in reversed((stdout or "").splitlines()):
+        stripped = line.strip().strip("=").strip()
+        if _SUMMARY_COUNTS_RE.search(stripped) and " in " in stripped:
+            return stripped
+    return ""
+
+
 def session_completed(path: Path) -> bool:
     """True iff the reporter's session-finish record proves pytest ran the
     WHOLE collected suite — the precondition for a sound quarantine

--- a/scripts/pr_validate/_pytest_summary.py
+++ b/scripts/pr_validate/_pytest_summary.py
@@ -19,10 +19,11 @@ derived (a divergence would silently mis-gate).
 
 from __future__ import annotations
 
+import json
 import re
 from pathlib import Path
 
-from ._nodeid_reporter import SESSION_LABEL, unescape_field
+from ._nodeid_reporter import RERUN_LABEL, SESSION_LABEL, unescape_field
 
 # pytest writes the section header as a full-width separator banner:
 # ``==================== short test summary info ====================``.
@@ -88,6 +89,36 @@ def raw_session_records(path: Path) -> list[str]:
         if tab and rec_label == SESSION_LABEL and raw:
             out.append(unescape_field(raw))
     return out
+
+
+def rerun_detected(path: Path) -> bool:
+    """True iff the reporter logged any RERUN record — a gating pytest run
+    reran a test, which it must NEVER do.
+
+    Name-based ``-p no:<name>`` blocking is bypassable — a conftest can
+    register pytest-rerunfailures under an arbitrary name (verified, codex
+    #1222 r23) — so this OUTCOME-based signal is the name-independent
+    backstop shared by EVERY gating pytest step (``full_unit``,
+    ``targeted_tests``): a real failure could have been retried into a pass,
+    so any RERUN in a gating run makes it untrustworthy (codex #1222 r24).
+    Kept here so no gating step reimplements the check and drifts."""
+    return bool(report_log_node_ids(path, RERUN_LABEL))
+
+
+def render_fence_safe(node_id: str) -> str:
+    """JSON-encode a node id for safe interpolation into a Markdown ``` code
+    fence in the scorecard.
+
+    ``report.nodeid`` is not trustworthy display text — a hostile
+    ``pytest_make_parametrize_id`` can embed a newline (and backticks) in it
+    (codex #1222 r24). Interpolated raw into a fenced block, a newline could
+    start a fence-closing line and let the rest of the id spoof scorecard
+    Markdown. JSON escaping collapses the value to a single quoted line
+    (newline → ``\\n``, tab → ``\\t``, backslash/quote escaped), so no
+    embedded newline can begin a fence-closer; ``ensure_ascii=False`` keeps
+    a legitimate non-ASCII id readable. A normal id is unchanged except for
+    the surrounding quotes."""
+    return json.dumps(node_id, ensure_ascii=False)
 
 
 def session_completed(path: Path) -> bool:

--- a/scripts/pr_validate/_pytest_summary.py
+++ b/scripts/pr_validate/_pytest_summary.py
@@ -82,7 +82,21 @@ def _strip_message(rest: str) -> str:
     ``" - "`` inside ``[...]`` is part of the id (``test_x[a - b]``), and
     a ``]`` inside the *message* can't be mistaken for the id's bracket
     (``test_x - AssertionError: [1]`` → ``test_x``) — the earlier
-    ``rfind("]")`` approach got the latter wrong (codex #1222 r5)."""
+    ``rfind("]")`` approach got the latter wrong (codex #1222 r5).
+
+    Known limitation (codex #1222 r6): a node id whose EXPLICIT param id
+    contains an *unmatched* bracket (e.g. ``ids=["["]`` → ``test_x[[]``)
+    leaves the depth counter unbalanced, so the message is absorbed into
+    the returned id. This is irreducible in pytest's terminal output —
+    ``nodeid - message`` is genuinely ambiguous when the id may hold
+    ``" - "`` and unbalanced ``[]`` while the message may hold anything.
+    It fails SAFE: a mangled id won't match a (normal) quarantine entry,
+    so the failure BLOCKS rather than being wrongly downgraded, and a
+    mistargeted advisory re-run just yields an inconclusive result. A
+    structured report (junit-xml) was considered and rejected: its
+    ``classname``/``name`` split can't be mapped back to a pytest node id
+    unambiguously for class-based / deep-package tests, trading this rare
+    safe failure for a common-path matching risk."""
     depth = 0
     i = 0
     n = len(rest)

--- a/scripts/pr_validate/_pytest_summary.py
+++ b/scripts/pr_validate/_pytest_summary.py
@@ -274,7 +274,8 @@ def _strip_message(rest: str) -> str:
     (``test_x - AssertionError: [1]`` → ``test_x``) — the earlier
     ``rfind("]")`` approach got the latter wrong (codex #1222 r5).
 
-    Ambiguity is resolved by failing SAFE, never by guessing. Two cases:
+    Ambiguity is resolved by failing SAFE, never by guessing. Four tells,
+    all making a split return the WHOLE line instead of a truncated id:
 
       * ``r6``: a node id whose EXPLICIT param id holds an *unmatched*
         bracket (``ids=["["]`` → ``test_x[[]``) leaves the depth counter
@@ -284,16 +285,31 @@ def _strip_message(rest: str) -> str:
         prematurely, so the FIRST depth-0 ``" - "`` lands *inside* the
         param sequence. Splitting there would truncate to ``test_x[a]`` —
         which could wrongly match a shorter quarantine entry and DOWNGRADE
-        a real failure. To prevent that, a candidate split is rejected when
-        the message it would produce begins with ``"["`` (the tell-tale of
-        a mid-param split, or a genuine bracket-leading message we equally
-        can't disambiguate). We then return the whole line as the id.
+        a real failure. Rejected when the message begins with ``"["``.
+      * ``r40``: a custom param id like ``ids=["a] - b"]`` yields
+        ``test_x[a] - b]``; the inner ``]`` drops depth to 0 so the first
+        depth-0 ``" - "`` would COLLAPSE it to ``test_x[a]``. Rejected when
+        the message holds an UNMATCHED ``"]"`` (that ``"]"`` closes a real
+        param bracket, so the id extends past the ``"-"``).
+      * ``r41``: the BALANCED variant ``test_x[a] - b[c]`` (param value
+        ``a] - b[c``) — the r40 tell misses it because ``b[c]`` balances,
+        yet it is still indistinguishable from a single node id. Rejected
+        when the id-part ends with ``"]"`` and the message contains ``"["``.
 
-    Both cases return a mangled id that won't match a normal quarantine
-    entry, so the failure BLOCKS rather than being wrongly waived, and a
-    mistargeted advisory re-run just yields an inconclusive result. The
-    r4/r5 common cases are unaffected — their message begins with the
-    exception text (``AssertionError: …``) or a bare word, not ``"["``.
+    After these four guards a split is taken ONLY when the id-part is
+    unparametrized (no ``"]"``, so no ``" - "`` can lie inside it) or the
+    message provably cannot be a bracketed param continuation (no ``"["``,
+    no unmatched ``"]"``). That makes the scrape FAIL-CLOSED SOUND: it never
+    truncates to a shorter id that could false-green the base negative
+    control — at the cost of over-blocking a pre-existing PARAMETRIZED
+    failure whose message contains ``"["`` (safe, and rare: a normal
+    parametrized failure only trips it when it was ALREADY failing at base).
+    A blocked id won't match a normal quarantine entry either, so the
+    failure blocks rather than being wrongly waived, and a mistargeted
+    advisory re-run just yields an inconclusive result. The r4/r5 common
+    cases are unaffected — an UNPARAMETRIZED test's message can hold any
+    brackets (``test_x - AssertionError: [1]`` → ``test_x``); only a
+    parametrized id-part gates on the message's ``"["``.
 
     A structured report (junit-xml) was considered and rejected: its
     ``classname``/``name`` split can't be mapped back to a pytest node id
@@ -310,6 +326,7 @@ def _strip_message(rest: str) -> str:
             if depth > 0:
                 depth -= 1
         elif depth == 0 and rest.startswith(" - ", i):
+            id_part = rest[:i]
             msg = rest[i + 3 :]
             # Fail safe (return the WHOLE line, which won't match a shorter
             # id) whenever the split is unreliable:
@@ -323,9 +340,31 @@ def _strip_message(rest: str) -> str:
             #    COLLAPSE it to a shorter id ("test_x[a]") that could wrongly
             #    match a PR-introduced failure and waive it as pre-existing —
             #    a FALSE GREEN in the base negative control (codex #1222 r40).
-            if msg.startswith("[") or _has_unmatched_close_bracket(msg):
+            #  * the id-part ends with "]" AND the message contains a "[" —
+            #    a BALANCED-bracket variant of the above ("test_x[a] - b[c]",
+            #    from a custom param value that embeds "] ... ["). The r40
+            #    unmatched-"]" tell misses it because "b[c]" is balanced, yet
+            #    the string is still indistinguishable from a single node id
+            #    whose param value is "a] - b[c". Splitting COLLAPSES it to
+            #    "test_x[a]", which could coincide with a DIFFERENT test's
+            #    canonical id and waive a real PR regression as pre-existing —
+            #    the same FALSE GREEN r40 closed for the unbalanced case
+            #    (codex #1222 r41). This is the LAST ambiguous shape: after
+            #    these three guards, a split is only taken when the id-part is
+            #    unparametrized (no "]" → no " - " can be inside it) or the
+            #    message provably can't be a bracketed param continuation (no
+            #    "[", no unmatched "]"), so the scrape is fail-closed sound —
+            #    never a false green, at the cost of blocking a pre-existing
+            #    PARAMETRIZED failure whose message contains "[" (a safe,
+            #    rare over-block that matches this scrape's stated preference:
+            #    a false block over an unsound negative control).
+            if (
+                msg.startswith("[")
+                or _has_unmatched_close_bracket(msg)
+                or (id_part.endswith("]") and "[" in msg)
+            ):
                 return rest.strip()
-            return rest[:i].strip()
+            return id_part.strip()
         i += 1
     return rest.strip()
 

--- a/scripts/pr_validate/_pytest_summary.py
+++ b/scripts/pr_validate/_pytest_summary.py
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Shared parser for pytest's short-summary section.
+
+Two steps (``full_unit`` — quarantine partition — and ``flake_tracking``
+— rerun classification) need to pull node ids out of pytest's short test
+summary. Keeping one parser here means the FAILED/ERROR extraction can't
+drift between them (a divergence would silently mis-gate).
+"""
+
+from __future__ import annotations
+
+
+def summary_node_ids(text: str, *labels: str) -> list[str]:
+    """Node ids pytest lists under the given short-summary labels.
+
+    A summary line is ``<LABEL> <nodeid>[ - <message>]``; the node id is
+    everything between the label and the ``" - "`` message separator.
+    Parametrized ids can hold spaces inside ``[...]``, so we split on
+    ``" - "`` rather than on whitespace. (A param value literally
+    containing ``" - "`` is inherently ambiguous in pytest's own text
+    output and is not handled — that is a pytest-format limitation, not
+    one we can resolve here.)
+
+    Only lines inside the ``short test summary info`` block count — a
+    ``FAILED`` token in a traceback above it is ignored. Defaults to the
+    ``FAILED`` label when none is given.
+    """
+    wanted = labels or ("FAILED",)
+    out: list[str] = []
+    in_summary = False
+    for line in (text or "").splitlines():
+        if "short test summary" in line:
+            in_summary = True
+            continue
+        if not in_summary:
+            continue
+        if line.startswith("="):
+            break
+        for label in wanted:
+            if line.startswith(label + " "):
+                node_id = line[len(label) + 1 :].split(" - ", 1)[0].strip()
+                if node_id:
+                    out.append(node_id)
+                break
+    return out

--- a/scripts/pr_validate/_pytest_summary.py
+++ b/scripts/pr_validate/_pytest_summary.py
@@ -9,6 +9,18 @@ drift between them (a divergence would silently mis-gate).
 
 from __future__ import annotations
 
+import re
+
+# pytest writes the section header as a full-width separator banner:
+# ``==================== short test summary info ====================``.
+# Anchoring on that *padded* banner — not a bare ``"short test summary"``
+# substring — stops a test from injecting a forged summary block: a test
+# that prints ``short test summary`` (or even a fully padded fake banner)
+# in its own captured stdout can't be mistaken for the real section,
+# because we take the LAST banner and captured output always renders in
+# the FAILURES section *above* the genuine summary (codex #1222 r2).
+_SUMMARY_BANNER = re.compile(r"^=+\s*short test summary info\s*=+$")
+
 
 def summary_node_ids(text: str, *labels: str) -> list[str]:
     """Node ids pytest lists under the given short-summary labels.
@@ -21,19 +33,24 @@ def summary_node_ids(text: str, *labels: str) -> list[str]:
     output and is not handled — that is a pytest-format limitation, not
     one we can resolve here.)
 
-    Only lines inside the ``short test summary info`` block count — a
-    ``FAILED`` token in a traceback above it is ignored. Defaults to the
-    ``FAILED`` label when none is given.
+    Only lines inside the genuine ``short test summary info`` banner block
+    count — a ``FAILED`` token in a traceback (or a forged banner) above
+    it is ignored. Defaults to the ``FAILED`` label when none is given.
     """
     wanted = labels or ("FAILED",)
+    lines = (text or "").splitlines()
+
+    # Find the LAST real banner. Anything before it — captured stdout,
+    # tracebacks, a test-forged banner — is not the authoritative summary.
+    start = None
+    for i, line in enumerate(lines):
+        if _SUMMARY_BANNER.match(line.strip()):
+            start = i
+    if start is None:
+        return []
+
     out: list[str] = []
-    in_summary = False
-    for line in (text or "").splitlines():
-        if "short test summary" in line:
-            in_summary = True
-            continue
-        if not in_summary:
-            continue
+    for line in lines[start + 1 :]:
         if line.startswith("="):
             break
         for label in wanted:

--- a/scripts/pr_validate/_pytest_summary.py
+++ b/scripts/pr_validate/_pytest_summary.py
@@ -19,6 +19,18 @@ import re
 # in its own captured stdout can't be mistaken for the real section,
 # because we take the LAST banner and captured output always renders in
 # the FAILURES section *above* the genuine summary (codex #1222 r2).
+#
+# Scope of the guarantee (codex #1222 r3): this defeats the REALISTIC
+# vectors — an accidental "short test summary" string, and captured
+# stdout above the summary. It does NOT defend against an author who
+# deliberately weaponizes their own test process (e.g. an ``atexit``
+# handler that prints a forged banner *after* pytest's genuine summary).
+# That is out of scope by design: the gate runs the candidate's code
+# in-process, so a hostile author owning the interpreter has strictly
+# easier sabotage routes (``@pytest.mark.skip``, deleting the test,
+# xfail) and no in-process report source — junit-xml included, since it
+# too can be rewritten from an ``atexit`` handler — is tamper-proof
+# against them. We defend against mistakes and flakes, not self-sabotage.
 _SUMMARY_BANNER = re.compile(r"^=+\s*short test summary info\s*=+$")
 
 

--- a/scripts/pr_validate/_pytest_summary.py
+++ b/scripts/pr_validate/_pytest_summary.py
@@ -105,6 +105,13 @@ def rerun_detected(path: Path) -> bool:
     return bool(report_log_node_ids(path, RERUN_LABEL))
 
 
+# The three ``str.splitlines()`` line boundaries that ``json.dumps`` leaves
+# LITERAL under ``ensure_ascii=False``: it escapes every control char < U+0020
+# (``\n``/``\r``/``\t``/``\v``/``\f``/``\x1c``-``\x1e``) but NOT U+0085 (NEL),
+# U+2028 (LINE SEP), or U+2029 (PARA SEP), which are all ≥ U+0020 (codex r31).
+_JSON_UNESCAPED_LINE_SEPARATORS = ("\x85", "\u2028", "\u2029")
+
+
 def render_fence_safe(node_id: str) -> str:
     """JSON-encode a node id for safe interpolation into a Markdown ``` code
     fence in the scorecard.
@@ -117,8 +124,19 @@ def render_fence_safe(node_id: str) -> str:
     (newline → ``\\n``, tab → ``\\t``, backslash/quote escaped), so no
     embedded newline can begin a fence-closer; ``ensure_ascii=False`` keeps
     a legitimate non-ASCII id readable. A normal id is unchanged except for
-    the surrounding quotes."""
-    return json.dumps(node_id, ensure_ascii=False)
+    the surrounding quotes.
+
+    ``json.dumps`` escapes only control chars < U+0020, so it would leave
+    U+0085/U+2028/U+2029 LITERAL — yet ``str.splitlines()`` (and some Markdown
+    renderers) treat those as line boundaries too, so a hostile id embedding
+    one could still begin a fence-closer on a second physical line. Escape
+    them explicitly as ``\\uXXXX`` (valid JSON, so ``json.loads`` still
+    round-trips the id) to keep the single-line guarantee under splitlines
+    (codex #1222 r31, mirroring the escape_field hardening in r28)."""
+    out = json.dumps(node_id, ensure_ascii=False)
+    for sep in _JSON_UNESCAPED_LINE_SEPARATORS:
+        out = out.replace(sep, f"\\u{ord(sep):04x}")
+    return out
 
 
 # ``errors?`` — pytest pluralizes the error outcome ("1 error" vs "2 errors"),

--- a/scripts/pr_validate/_pytest_summary.py
+++ b/scripts/pr_validate/_pytest_summary.py
@@ -76,12 +76,24 @@ def summary_node_ids(text: str, *labels: str) -> list[str]:
 def _strip_message(rest: str) -> str:
     """Return the node id from a ``<nodeid>[ - <message>]`` tail.
 
-    The message separator is the first ``" - "`` that falls *after* the
-    node id's final ``]`` (or the first one at all, for an unparametrized
-    id). This keeps a ``" - "`` inside a parametrization bracket as part
-    of the id instead of truncating it (codex #1222 r4)."""
-    bracket_end = rest.rfind("]")
-    search_from = bracket_end + 1 if bracket_end != -1 else 0
-    sep = rest.find(" - ", search_from)
-    node_id = rest if sep == -1 else rest[:sep]
-    return node_id.strip()
+    The message separator is the FIRST ``" - "`` that falls outside the
+    node id's parametrization brackets. Scanning left-to-right with a
+    bracket-depth counter handles both directions of ambiguity: a
+    ``" - "`` inside ``[...]`` is part of the id (``test_x[a - b]``), and
+    a ``]`` inside the *message* can't be mistaken for the id's bracket
+    (``test_x - AssertionError: [1]`` → ``test_x``) — the earlier
+    ``rfind("]")`` approach got the latter wrong (codex #1222 r5)."""
+    depth = 0
+    i = 0
+    n = len(rest)
+    while i < n:
+        c = rest[i]
+        if c == "[":
+            depth += 1
+        elif c == "]":
+            if depth > 0:
+                depth -= 1
+        elif depth == 0 and rest.startswith(" - ", i):
+            return rest[:i].strip()
+        i += 1
+    return rest.strip()

--- a/scripts/pr_validate/_pytest_summary.py
+++ b/scripts/pr_validate/_pytest_summary.py
@@ -38,12 +38,11 @@ def summary_node_ids(text: str, *labels: str) -> list[str]:
     """Node ids pytest lists under the given short-summary labels.
 
     A summary line is ``<LABEL> <nodeid>[ - <message>]``; the node id is
-    everything between the label and the ``" - "`` message separator.
-    Parametrized ids can hold spaces inside ``[...]``, so we split on
-    ``" - "`` rather than on whitespace. (A param value literally
-    containing ``" - "`` is inherently ambiguous in pytest's own text
-    output and is not handled — that is a pytest-format limitation, not
-    one we can resolve here.)
+    everything between the label and the ``" - "`` message separator. A
+    parametrized id can itself contain ``" - "`` inside its ``[...]``
+    (e.g. ``test_x[a - b]``), so we only treat a ``" - "`` that occurs
+    *after* the final ``]`` as the separator — inside the bracket it's
+    part of the id (codex #1222 r4).
 
     Only lines inside the genuine ``short test summary info`` banner block
     count — a ``FAILED`` token in a traceback (or a forged banner) above
@@ -67,8 +66,22 @@ def summary_node_ids(text: str, *labels: str) -> list[str]:
             break
         for label in wanted:
             if line.startswith(label + " "):
-                node_id = line[len(label) + 1 :].split(" - ", 1)[0].strip()
+                node_id = _strip_message(line[len(label) + 1 :])
                 if node_id:
                     out.append(node_id)
                 break
     return out
+
+
+def _strip_message(rest: str) -> str:
+    """Return the node id from a ``<nodeid>[ - <message>]`` tail.
+
+    The message separator is the first ``" - "`` that falls *after* the
+    node id's final ``]`` (or the first one at all, for an unparametrized
+    id). This keeps a ``" - "`` inside a parametrization bracket as part
+    of the id instead of truncating it (codex #1222 r4)."""
+    bracket_end = rest.rfind("]")
+    search_from = bracket_end + 1 if bracket_end != -1 else 0
+    sep = rest.find(" - ", search_from)
+    node_id = rest if sep == -1 else rest[:sep]
+    return node_id.strip()

--- a/scripts/pr_validate/_pytest_summary.py
+++ b/scripts/pr_validate/_pytest_summary.py
@@ -182,8 +182,15 @@ def session_completed(path: Path) -> bool:
         tests after the stop never ran.
 
     Requires EXACTLY one well-formed record (``<ran> <collected>``) with a
-    positive collected count and ``ran >= collected``. Anything else —
-    missing, malformed, duplicated — withholds trust, the safe direction.
+    positive collected count and ``ran == collected``. Anything else —
+    missing, malformed, duplicated, or ``ran != collected`` — withholds trust,
+    the safe direction. ``ran > collected`` is rejected as MALFORMED, not
+    accepted as a benign over-count (codex #1222 r36): the reporter counts
+    DISTINCT terminal-teardown ids (``--reruns`` retries can't inflate it), so
+    a faithful record can never complete more distinct tests than it collected
+    — an over-count is an inconsistent/forged record, and treating it as
+    "complete" would let an inflated ``ran`` paper over unexecuted collected
+    tests.
 
     SCOPE (codex #1222 r27): this proves every SELECTED item finished; it does
     NOT prove the selection itself was the whole real suite. ``collected`` is
@@ -214,7 +221,7 @@ def session_completed(path: Path) -> bool:
         ran, collected = int(ran_s), int(collected_s)
     except (ValueError, TypeError):
         return False
-    return collected > 0 and ran >= collected
+    return collected > 0 and ran == collected
 
 
 def summary_node_ids(text: str, *labels: str) -> list[str]:

--- a/scripts/pr_validate/_pytest_summary.py
+++ b/scripts/pr_validate/_pytest_summary.py
@@ -1,15 +1,26 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Shared parser for pytest's short-summary section.
+"""Extract failing/passing node ids from a pytest run.
 
 Two steps (``full_unit`` — quarantine partition — and ``flake_tracking``
-— rerun classification) need to pull node ids out of pytest's short test
-summary. Keeping one parser here means the FAILED/ERROR extraction can't
-drift between them (a divergence would silently mis-gate).
+— rerun classification) need node ids out of a pytest run. There are two
+sources, in order of preference:
+
+  * ``report_log_node_ids`` — reads the STRUCTURED log written by the
+    ``_nodeid_reporter`` plugin (``report.nodeid``, exact + unambiguous).
+    This is the source of truth; use it whenever the plugin ran.
+  * ``summary_node_ids`` — a FALLBACK that scrapes pytest's terminal
+    short-summary when the plugin didn't run. It is irreducibly ambiguous
+    for exotic parametrized ids (see ``_strip_message``); it fails SAFE
+    (an ambiguous id won't match a quarantine entry → the failure blocks).
+
+Keeping both here means the two steps can't drift on how a failure set is
+derived (a divergence would silently mis-gate).
 """
 
 from __future__ import annotations
 
 import re
+from pathlib import Path
 
 # pytest writes the section header as a full-width separator banner:
 # ``==================== short test summary info ====================``.
@@ -32,6 +43,27 @@ import re
 # too can be rewritten from an ``atexit`` handler — is tamper-proof
 # against them. We defend against mistakes and flakes, not self-sabotage.
 _SUMMARY_BANNER = re.compile(r"^=+\s*short test summary info\s*=+$")
+
+
+def report_log_node_ids(path: Path, *labels: str) -> list[str]:
+    """Node ids the ``_nodeid_reporter`` plugin recorded under ``labels``.
+
+    The log is append-only ``<LABEL>\\t<nodeid>`` lines (see
+    ``_nodeid_reporter``). Returns the ids for the requested labels
+    (default ``FAILED``), first-seen order, de-duplicated. Unlike
+    ``summary_node_ids`` there is NO parsing ambiguity — ``report.nodeid``
+    is pytest's own canonical id. The caller is responsible for checking
+    the file exists (a missing log means the plugin didn't run → fall back
+    to ``summary_node_ids``)."""
+    wanted = set(labels or ("FAILED",))
+    out: list[str] = []
+    seen: set[str] = set()
+    for line in path.read_text(encoding="utf-8").splitlines():
+        label, tab, nodeid = line.partition("\t")
+        if tab and label in wanted and nodeid and nodeid not in seen:
+            seen.add(nodeid)
+            out.append(nodeid)
+    return out
 
 
 def summary_node_ids(text: str, *labels: str) -> list[str]:

--- a/scripts/pr_validate/_pytest_summary.py
+++ b/scripts/pr_validate/_pytest_summary.py
@@ -141,6 +141,25 @@ def session_completed(path: Path) -> bool:
     positive collected count and ``ran >= collected``. Anything else —
     missing, malformed, duplicated — withholds trust, the safe direction.
 
+    SCOPE (codex #1222 r27): this proves every SELECTED item finished; it does
+    NOT prove the selection itself was the whole real suite. ``collected`` is
+    pytest's count under candidate-controlled collection — a committed
+    ``pytest.ini`` (``python_files`` / ``norecursedirs``) or a ``conftest.py``
+    collection hook (``pytest_collection_modifyitems`` / ``collect_ignore`` /
+    ``pytest_ignore_collect``) could reduce ``tests/`` to a handful of passing
+    tests and still yield a truthful ``ran == collected``. A base-derived
+    count/manifest cross-check does NOT close this soundly: the SAME in-process
+    access that shrinks the set can SURGICALLY deselect the one regression test
+    (``collected`` drops by 1, under any ratio floor) or reparametrize its id,
+    so a count guard would only catch the crudest variant while advertising a
+    completeness it can't deliver. This is the documented in-process-hostile-
+    author residual — a candidate with commit access to shared test
+    infrastructure has strictly easier sabotage routes (a fixture that
+    monkeypatches the code under test, an ``atexit`` forging this very record);
+    the quarantine downgrade is scoped to mistakes and flakes, not such an
+    author, and the PR body states this plainly rather than shipping a guard we
+    can't keep.
+
     Kept here (not in a step) so ``full_unit`` and ``flake_tracking`` share
     ONE completeness definition and can't drift on it."""
     records = raw_session_records(path)

--- a/scripts/pr_validate/_pytest_summary.py
+++ b/scripts/pr_validate/_pytest_summary.py
@@ -121,8 +121,11 @@ def render_fence_safe(node_id: str) -> str:
     return json.dumps(node_id, ensure_ascii=False)
 
 
+# ``errors?`` — pytest pluralizes the error outcome ("1 error" vs "2 errors"),
+# so an error-only run summary ("2 errors in 0.10s") must still match or it
+# degrades to a bare "exit 2" (codex #1222 r29).
 _SUMMARY_COUNTS_RE = re.compile(
-    r"\b\d+ (passed|failed|error|skipped|xfailed|xpassed|deselected)\b"
+    r"\b\d+ (passed|failed|errors?|skipped|xfailed|xpassed|deselected)\b"
 )
 
 

--- a/scripts/pr_validate/base.py
+++ b/scripts/pr_validate/base.py
@@ -40,13 +40,30 @@ StepStatus = Literal["pass", "fail", "skip", "error"]
 # pytest run (targeted_tests, full_unit) re-run and pass it, bypassing the
 # quarantine registry. ``-o addopts=`` / PYTEST_ADDOPTS-stripping can't stop
 # an autoloaded plugin, and disabling autoload globally would also drop
-# plugins the gates rely on (pytest-asyncio, etc.), so we block this one
-# plugin by its registered name on every gating invocation. It is a harmless
-# no-op when the plugin isn't installed. flake_tracking deliberately does NOT
-# use this — its post-gating advisory re-run WANTS reruns. A shared constant
-# (not per-step literals) so a new gating step can't silently forget it; the
-# invariant is pinned by ``test_every_gating_pytest_cmd_blocks_rerunfailures``.
-GATING_PYTEST_GUARD: tuple[str, ...] = ("-p", "no:rerunfailures")
+# plugins the gates rely on (pytest-asyncio, etc.), so we block it by name on
+# every gating invocation. We block BOTH the entry-point name
+# (``rerunfailures``) and the module name (``pytest_rerunfailures``), since a
+# conftest can register it under either.
+#
+# By-name blocking is the cheap first line, NOT the whole defense: a hostile
+# conftest can register the plugin under an ARBITRARY name that no ``-p
+# no:<name>`` can enumerate (``pluginmanager.register(mod, name="x")`` + a
+# ``@pytest.mark.flaky`` marker still reruns — verified, codex #1222 r23).
+# The NAME-INDEPENDENT backstop lives in ``full_unit``: the _nodeid_reporter
+# logs a RERUN record on any rerun OUTCOME, and full_unit blocks if one
+# appears (a gating run must never rerun). This constant just stops the
+# common/accidental autoload path without paying the reporter round-trip.
+#
+# Harmless no-op when the plugin isn't installed. flake_tracking deliberately
+# does NOT use this — its post-gating advisory re-run WANTS reruns. A shared
+# constant (not per-step literals) so a new gating step can't silently forget
+# it; pinned by ``test_every_gating_pytest_cmd_blocks_rerunfailures``.
+GATING_PYTEST_GUARD: tuple[str, ...] = (
+    "-p",
+    "no:rerunfailures",
+    "-p",
+    "no:pytest_rerunfailures",
+)
 
 
 @dataclass

--- a/scripts/pr_validate/base.py
+++ b/scripts/pr_validate/base.py
@@ -32,6 +32,23 @@ if TYPE_CHECKING:
 StepStatus = Literal["pass", "fail", "skip", "error"]
 
 
+# Args every GATING pytest subprocess must carry so a candidate can't use
+# an autoloaded plugin to fake a green run (codex #1222 r20/r21). This PR
+# installs pytest-rerunfailures (for the advisory flake_tracking step), and
+# it autoloads by entry point — so WITHOUT this block a PR could tag a
+# genuinely failing test ``@pytest.mark.flaky(reruns=N)`` and have ANY gating
+# pytest run (targeted_tests, full_unit) re-run and pass it, bypassing the
+# quarantine registry. ``-o addopts=`` / PYTEST_ADDOPTS-stripping can't stop
+# an autoloaded plugin, and disabling autoload globally would also drop
+# plugins the gates rely on (pytest-asyncio, etc.), so we block this one
+# plugin by its registered name on every gating invocation. It is a harmless
+# no-op when the plugin isn't installed. flake_tracking deliberately does NOT
+# use this — its post-gating advisory re-run WANTS reruns. A shared constant
+# (not per-step literals) so a new gating step can't silently forget it; the
+# invariant is pinned by ``test_every_gating_pytest_cmd_blocks_rerunfailures``.
+GATING_PYTEST_GUARD: tuple[str, ...] = ("-p", "no:rerunfailures")
+
+
 @dataclass
 class StepResult:
     """Per-step output the scorecard renders.

--- a/scripts/pr_validate/quarantine.py
+++ b/scripts/pr_validate/quarantine.py
@@ -85,6 +85,13 @@ def load_quarantine(path: Path | None = None) -> list[QuarantineEntry]:
         # QuarantineError so the gating caller fails safe to empty rather
         # than crashing on an unhandled ValueError (codex #1222 r5).
         raise QuarantineError(f"{path}: not valid UTF-8: {e}") from e
+    except OSError as e:
+        # A present-but-unreadable file (permissions, an I/O error, a
+        # TOCTOU vanish after the exists() check) is a read failure, not
+        # "absent" — the docstring promises QuarantineError for a present-
+        # but-unusable registry, so a caller catching only that exception
+        # doesn't crash on a raw OSError (codex #1222 r18).
+        raise QuarantineError(f"{path}: could not be read: {e}") from e
     return _parse_quarantine_text(text, source=str(path))
 
 

--- a/scripts/pr_validate/quarantine.py
+++ b/scripts/pr_validate/quarantine.py
@@ -155,6 +155,27 @@ def load_quarantine_from_ref(
     return _parse_quarantine_text(proc.stdout, source=f"{ref}:{rel_path}")
 
 
+def _audit_string(
+    value: object, *, source: str, index: int, node_id: str, field: str
+) -> str:
+    """Validate a free-text audit field (``reason`` / ``issue``).
+
+    A MISSING field (``None``) is the empty string. A present but non-string
+    value — e.g. ``reason: [foo, bar]`` — is a schema violation, NOT
+    something to silently ``str(...)``-coerce into a bogus ``"['foo', …]"``
+    rationale that then satisfies the mandatory-field check (codex #1222
+    r15). Returns the stripped string; the caller enforces non-emptiness for
+    a mandatory field."""
+    if value is None:
+        return ""
+    if not isinstance(value, str):
+        raise QuarantineError(
+            f"{source}: test #{index} ('{node_id}') '{field}' must be a "
+            f"string, got {type(value).__name__}"
+        )
+    return value.strip()
+
+
 def _parse_quarantine_text(text: str, source: str) -> list[QuarantineEntry]:
     try:
         raw = yaml.safe_load(text)
@@ -194,8 +215,12 @@ def _parse_quarantine_text(text: str, source: str) -> list[QuarantineEntry]:
         # date) is how a permanent silent waiver creeps in. Enforce them so
         # a bare ``{id: …}`` can't slip a test onto the allowlist without a
         # paper trail (codex #1222 r10). ``issue`` stays optional (not every
-        # flake has a tracker link yet).
-        reason = str(item.get("reason", "") or "").strip()
+        # flake has a tracker link yet). ``reason``/``issue`` must be actual
+        # strings, not ``str(...)``-coerced from a list/mapping (codex #1222
+        # r15); ``added`` is checked below by strict date parsing.
+        reason = _audit_string(
+            item.get("reason"), source=source, index=i, node_id=node_id, field="reason"
+        )
         added = str(item.get("added", "") or "").strip()
         if not reason:
             raise QuarantineError(
@@ -239,7 +264,13 @@ def _parse_quarantine_text(text: str, source: str) -> list[QuarantineEntry]:
                 id=node_id,
                 reason=reason,
                 added=added,
-                issue=str(item.get("issue", "") or "").strip(),
+                issue=_audit_string(
+                    item.get("issue"),
+                    source=source,
+                    index=i,
+                    node_id=node_id,
+                    field="issue",
+                ),
                 family=family,
             )
         )

--- a/scripts/pr_validate/quarantine.py
+++ b/scripts/pr_validate/quarantine.py
@@ -27,6 +27,7 @@ Design notes:
 from __future__ import annotations
 
 import os
+import shutil
 import subprocess
 from collections.abc import Iterable
 from dataclasses import dataclass, replace
@@ -41,6 +42,22 @@ DEFAULT_QUARANTINE_PATH = Path(__file__).with_name("quarantine.yaml")
 # git revision (the protected base) rather than the candidate checkout.
 QUARANTINE_REL_PATH = "scripts/pr_validate/quarantine.yaml"
 _GIT_SHOW_TIMEOUT_S = 30
+
+# Resolve the git binary ONCE, at import time — which runs when pr_validate
+# boots, BEFORE any candidate test code executes in a later pipeline step
+# (targeted_tests / full_unit). Resolving lazily at call time would look up
+# ``git`` through the inherited PATH *after* a failing candidate test had a
+# chance to plant a fake ``git`` in a writable leading PATH directory (e.g. the
+# venv's own bin, which is writable and typically first on PATH). That fake git
+# could serve a forged base/head registry from ``git show`` and self-quarantine
+# the candidate's own failure, bypassing the ``--no-replace-objects`` pin.
+# Pinning the absolute path resolved from the operator's clean startup PATH
+# closes that PATH-injection vector (codex #1222 r35). Overwriting the resolved
+# binary *in place* would instead require write access to a system / Homebrew
+# bin and would corrupt the operator's git globally — a far louder, out-of-scope
+# attack, not a silent registry forgery. Fall back to the bare name only when
+# git is absent at import (then the FileNotFoundError path reports infra loudly).
+_GIT = shutil.which("git") or "git"
 
 
 class QuarantineError(Exception):
@@ -135,9 +152,11 @@ def load_quarantine_from_ref(
     """
     try:
         proc = subprocess.run(  # noqa: S603
+            # _GIT is the import-time-resolved absolute git path, NOT a bare
+            # "git" looked up now through a candidate-tamperable PATH (r35).
             # --no-replace-objects: ignore any refs/replace/* a candidate
             # test may have planted; read the true base blob (codex r12).
-            ["git", "--no-replace-objects", "show", f"{ref}:{rel_path}"],  # noqa: S607
+            [_GIT, "--no-replace-objects", "show", f"{ref}:{rel_path}"],  # noqa: S607
             capture_output=True,
             text=True,
             encoding="utf-8",

--- a/scripts/pr_validate/quarantine.py
+++ b/scripts/pr_validate/quarantine.py
@@ -52,12 +52,29 @@ _GIT_SHOW_TIMEOUT_S = 30
 # could serve a forged base/head registry from ``git show`` and self-quarantine
 # the candidate's own failure, bypassing the ``--no-replace-objects`` pin.
 # Pinning the absolute path resolved from the operator's clean startup PATH
-# closes that PATH-injection vector (codex #1222 r35). Overwriting the resolved
-# binary *in place* would instead require write access to a system / Homebrew
-# bin and would corrupt the operator's git globally — a far louder, out-of-scope
-# attack, not a silent registry forgery. Fall back to the bare name only when
-# git is absent at import (then the FileNotFoundError path reports infra loudly).
-_GIT = shutil.which("git") or "git"
+# closes that PATH-injection vector (codex #1222 r35).
+#
+# r36: NO bare-name fallback. ``shutil.which("git") or "git"`` re-opened the
+# very PATH-lookup hole this pins away whenever git was absent at import — so
+# when git can't be resolved we keep ``None`` and FAIL CLOSED at call time
+# (a QuarantineError → the gating caller treats every failure as blocking),
+# never a bare "git" re-looked-up through a candidate-tamperable PATH.
+_GIT = shutil.which("git")
+
+# Registries are also SNAPSHOTTED at fetch — before any candidate code runs —
+# into this cache (see ``snapshot_quarantine_registries``); ``load_quarantine
+# _from_ref`` then serves the cached blob WITHOUT re-invoking git. That closes
+# the residual r35 left open (codex #1222 r36): pinning the git *path* doesn't
+# stop a candidate that can WRITE the resolved binary — e.g. a Homebrew git at
+# ``/opt/homebrew/bin/git`` is owned by the operator's user, so a candidate
+# subprocess could overwrite it in place, let ``git show`` serve a forged
+# allowlist, then restore it. Loading every registry blob at fetch (git clean,
+# no candidate has run) and caching pure data removes the post-candidate git
+# invocation entirely. Keyed by ``(ref, str(repo_root), rel_path)``; a value is
+# either the parsed ``list[QuarantineEntry]`` or the ``QuarantineError`` to
+# re-raise. Lives in the pr_validate PARENT process — candidate tests run in a
+# separate pytest subprocess and cannot reach it.
+_REGISTRY_SNAPSHOT: dict[tuple[str, str, str], list | QuarantineError] = {}
 
 
 class QuarantineError(Exception):
@@ -149,7 +166,65 @@ def load_quarantine_from_ref(
     true content-addressed blob — the only git indirection that could remap
     it is closed (grafts/alternates can't override an existing object's
     content; a mutable branch ref is no longer used per r10).
+
+    r36: prefer the fetch-time SNAPSHOT. If this ``(ref, repo_root, rel_path)``
+    was pre-loaded by ``snapshot_quarantine_registries`` (at fetch, before any
+    candidate code ran), return the cached blob and never invoke git here — so
+    a candidate that overwrote the git binary after fetch cannot forge the
+    result. A cache MISS (isolated unit tests; production always hits since
+    fetch snapshots the exact base/head SHAs full_unit later reads) falls
+    through to a live read.
     """
+    key = (ref, str(repo_root), rel_path)
+    cached = _REGISTRY_SNAPSHOT.get(key)
+    if cached is not None:
+        if isinstance(cached, QuarantineError):
+            raise cached
+        return list(cached)
+    return _load_quarantine_from_ref_live(ref, repo_root, rel_path)
+
+
+def snapshot_quarantine_registries(
+    refs: Iterable[str],
+    repo_root: Path,
+    rel_path: str = QUARANTINE_REL_PATH,
+) -> None:
+    """Load each ref's registry NOW — called at fetch, BEFORE any candidate
+    test code runs — and cache the result (parsed entries or the
+    ``QuarantineError`` to re-raise) so a later ``load_quarantine_from_ref``
+    for the same key serves the snapshot without re-invoking git (codex #1222
+    r36). Idempotent; skips falsy refs (an unset base/head SHA → full_unit's
+    own fail-closed branch handles it). Never raises: every failure mode is
+    already normalized to ``QuarantineError`` by the live loader and cached."""
+    for ref in refs:
+        if not ref:
+            continue
+        key = (ref, str(repo_root), rel_path)
+        if key in _REGISTRY_SNAPSHOT:
+            continue
+        try:
+            _REGISTRY_SNAPSHOT[key] = _load_quarantine_from_ref_live(
+                ref, repo_root, rel_path
+            )
+        except QuarantineError as e:
+            _REGISTRY_SNAPSHOT[key] = e
+
+
+def _load_quarantine_from_ref_live(
+    ref: str,
+    repo_root: Path,
+    rel_path: str = QUARANTINE_REL_PATH,
+) -> list[QuarantineEntry]:
+    """Uncached ``git show`` read — used by the fetch-time snapshot and as the
+    cache-miss fallback. This is the ONLY place that invokes git; callers in a
+    post-candidate context must go through ``load_quarantine_from_ref`` so the
+    snapshot short-circuits before any git process is spawned."""
+    if _GIT is None:
+        # git wasn't resolvable at import → fail CLOSED (r36). Never fall back
+        # to a bare "git" re-looked-up through a candidate-tamperable PATH.
+        raise QuarantineError(
+            f"git could not be resolved at startup — cannot read {ref}:{rel_path}"
+        )
     try:
         proc = subprocess.run(  # noqa: S603
             # _GIT is the import-time-resolved absolute git path, NOT a bare

--- a/scripts/pr_validate/quarantine.py
+++ b/scripts/pr_validate/quarantine.py
@@ -402,13 +402,15 @@ def effective_quarantine(
 
     Intersecting base with the candidate registry fixes that while keeping the
     self-quarantine protection intact:
-      * an id is effective ONLY if BOTH base and candidate list it — a
-        candidate REMOVAL drops it, so a still-red de-quarantined test blocks;
-      * a candidate ADDITION (id absent from base) is ignored — a PR still
+      * an id is effective ONLY if base COVERS it — a candidate REMOVAL drops
+        it, so a still-red de-quarantined test blocks;
+      * a candidate ADDITION (id not covered by base) is ignored — a PR still
         cannot waive its own failure;
-      * breadth is the NARROWER of the two (``family`` only when BOTH set it),
-        so a candidate may TIGHTEN (family→exact, or drop a param) but can
-        never WIDEN (exact→family) to waive more than the base approved.
+      * breadth is the NARROWER of the two (``family`` survives only when the
+        ids are identical AND both set it), so a candidate may TIGHTEN
+        (family→exact on the same id, or drop a param by narrowing a base
+        ``family`` entry to a specific ``id[param]``) but can never WIDEN
+        (exact→family) to waive more than the base approved.
 
     The result is ALWAYS a subset of ``base_entries`` with breadth no wider,
     so even a maximally-hostile candidate registry can only make the gate
@@ -416,18 +418,40 @@ def effective_quarantine(
     Base audit metadata (reason / added / issue) is preserved; only ``family``
     is narrowed.
     """
-    # Narrowest candidate breadth per id — a duplicate candidate id can only
-    # tighten (``family`` stays True only if EVERY candidate copy is family).
-    cand_family: dict[str, bool] = {}
-    for c in candidate_entries:
-        cand_family[c.id] = (
-            c.family if c.id not in cand_family else (cand_family[c.id] and c.family)
-        )
+    # Iterate the CANDIDATE registry and, for each entry, find a base entry
+    # that COVERS it (``node_id_matches`` with the base entry's breadth). An
+    # entry is effective ONLY if such a covering base entry exists, so:
+    #   * a candidate ADDITION not backed by base → no cover → ignored (a PR
+    #     still can't waive its own failure);
+    #   * a candidate REMOVAL → its id is never iterated → dropped (a still-red
+    #     de-quarantined test blocks);
+    #   * a candidate that NARROWS a base ``family`` entry to a specific
+    #     parametrized id (``test_x`` family → ``test_x[p1]``, the documented
+    #     "drop a param" tighten) IS covered by the base family entry, so it is
+    #     materialized as an EXACT effective entry carrying the base's audit
+    #     metadata (codex #1222 r33) — the old exact-id-only intersection
+    #     dropped it entirely and false-blocked the retained known flake.
+    # Because every effective id is covered by base and its breadth is the
+    # narrower of candidate and cover (``family`` survives only when the ids are
+    # identical AND both set it — a more-specific id can never carry family
+    # coverage upward), the result is ALWAYS a subset of base coverage: a
+    # candidate can only TIGHTEN, never WIDEN to waive more than base approved.
+    base_list = list(base_entries)
     effective: list[QuarantineEntry] = []
-    for b in base_entries:
-        if b.id not in cand_family:
-            continue  # removed / never listed by the candidate → drop
-        effective.append(replace(b, family=b.family and cand_family[b.id]))
+    seen: set[tuple[str, bool]] = set()
+    for c in candidate_entries:
+        cover = next(
+            (b for b in base_list if node_id_matches(c.id, b.id, family=b.family)),
+            None,
+        )
+        if cover is None:
+            continue  # candidate addition not backed by base → ignore
+        family = c.family and cover.family and c.id == cover.id
+        key = (c.id, family)
+        if key in seen:
+            continue  # a duplicate candidate copy adds nothing
+        seen.add(key)
+        effective.append(replace(cover, id=c.id, family=family))
     return effective
 
 

--- a/scripts/pr_validate/quarantine.py
+++ b/scripts/pr_validate/quarantine.py
@@ -28,7 +28,7 @@ from __future__ import annotations
 
 import subprocess
 from collections.abc import Iterable
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import date
 from pathlib import Path
 
@@ -183,9 +183,42 @@ def _audit_string(
     return value.strip()
 
 
+class _UniqueKeySafeLoader(yaml.SafeLoader):
+    """A ``SafeLoader`` that REJECTS duplicate mapping keys (codex #1222 r21).
+
+    PyYAML's default silently keeps the LAST value for a duplicated key, so a
+    quarantine entry like ``{id: real, id: attacker}`` — or a duplicated
+    top-level ``tests:`` / a duplicated ``family:`` — would let a reviewer
+    approve one value while another invisibly overrides it, exactly the kind
+    of audit-trail swap the mandatory ``reason``/``added`` fields exist to
+    prevent. Rejecting duplicates keeps the YAML honest BEFORE schema
+    validation runs. Raises ``ConstructorError`` (a ``yaml.YAMLError``), so the
+    caller's existing YAML-error handling wraps it as a ``QuarantineError``.
+    Checks every mapping level (root + each test dict) because the loader
+    routes every mapping node through ``construct_mapping``.
+    """
+
+    def construct_mapping(self, node, deep=False):  # noqa: ANN001, ANN201, FBT002
+        seen: set = set()
+        for key_node, _value_node in node.value:
+            key = self.construct_object(key_node, deep=deep)
+            if key in seen:
+                raise yaml.constructor.ConstructorError(
+                    "while constructing a mapping",
+                    node.start_mark,
+                    f"found duplicate key {key!r}",
+                    key_node.start_mark,
+                )
+            seen.add(key)
+        return super().construct_mapping(node, deep=deep)
+
+
 def _parse_quarantine_text(text: str, source: str) -> list[QuarantineEntry]:
     try:
-        raw = yaml.safe_load(text)
+        # Strict loader: duplicate keys raise instead of silently last-wins
+        # (codex #1222 r21). Loader is a SafeLoader subclass, so this is not
+        # an unsafe ``yaml.load``.
+        raw = yaml.load(text, Loader=_UniqueKeySafeLoader)  # noqa: S506
     except yaml.YAMLError as e:
         raise QuarantineError(f"{source}: not valid YAML: {e}") from e
 
@@ -303,6 +336,50 @@ def node_id_matches(failed_id: str, entry_id: str, *, family: bool = False) -> b
 def is_quarantined(failed_id: str, entries: Iterable[QuarantineEntry]) -> bool:
     """True iff any entry covers ``failed_id``."""
     return any(node_id_matches(failed_id, e.id, family=e.family) for e in entries)
+
+
+def effective_quarantine(
+    base_entries: Iterable[QuarantineEntry],
+    candidate_entries: Iterable[QuarantineEntry],
+) -> list[QuarantineEntry]:
+    """The registry the gate enforces: base ∩ candidate (codex #1222 r21).
+
+    The gate reads quarantine coverage from the PROTECTED base so a PR cannot
+    quarantine its OWN failing tests. But base-only silently ignored the other
+    direction — a PR that REMOVES an entry (de-quarantine): the removed test's
+    failure would still be waived off the stale base list, so a de-quarantine
+    PR could merge while that test is still red, reintroducing a regression
+    alongside the removal.
+
+    Intersecting base with the candidate registry fixes that while keeping the
+    self-quarantine protection intact:
+      * an id is effective ONLY if BOTH base and candidate list it — a
+        candidate REMOVAL drops it, so a still-red de-quarantined test blocks;
+      * a candidate ADDITION (id absent from base) is ignored — a PR still
+        cannot waive its own failure;
+      * breadth is the NARROWER of the two (``family`` only when BOTH set it),
+        so a candidate may TIGHTEN (family→exact, or drop a param) but can
+        never WIDEN (exact→family) to waive more than the base approved.
+
+    The result is ALWAYS a subset of ``base_entries`` with breadth no wider,
+    so even a maximally-hostile candidate registry can only make the gate
+    STRICTER — never waive anything the protected base didn't already approve.
+    Base audit metadata (reason / added / issue) is preserved; only ``family``
+    is narrowed.
+    """
+    # Narrowest candidate breadth per id — a duplicate candidate id can only
+    # tighten (``family`` stays True only if EVERY candidate copy is family).
+    cand_family: dict[str, bool] = {}
+    for c in candidate_entries:
+        cand_family[c.id] = (
+            c.family if c.id not in cand_family else (cand_family[c.id] and c.family)
+        )
+    effective: list[QuarantineEntry] = []
+    for b in base_entries:
+        if b.id not in cand_family:
+            continue  # removed / never listed by the candidate → drop
+        effective.append(replace(b, family=b.family and cand_family[b.id]))
+    return effective
 
 
 def partition_failures(

--- a/scripts/pr_validate/quarantine.py
+++ b/scripts/pr_validate/quarantine.py
@@ -1,0 +1,135 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Known-flaky test registry — loader + node-id matcher.
+
+Backs dev-flow proposal item ③ (flake tracking). The registry lives in
+``quarantine.yaml`` next to this module; a test listed there that fails
+does NOT block a PR (the ``full_unit`` gate consults ``partition_failures``
+to split a failure set into blocking vs quarantined). See the YAML header
+for the discipline on what may be added.
+
+Design notes:
+  * Loading is FAIL-SAFE at the call site, not here. ``load_quarantine``
+    returns ``[]`` for a missing file (no quarantine configured is a
+    legitimate state) but RAISES ``QuarantineError`` for a present-but-
+    malformed file — that's an author mistake worth surfacing. The
+    gating step catches the error and falls back to an EMPTY quarantine,
+    i.e. a *stricter* gate: a broken registry can never make the gate
+    pass something it otherwise wouldn't.
+  * Matching is by exact pytest node id, with one deliberate
+    convenience: an entry id carrying no ``[...]`` also matches every
+    parametrization of that test (``foo::test`` quarantines
+    ``foo::test[a]`` and ``foo::test[b]``). An entry that DOES name a
+    specific parametrization matches only that one.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+from pathlib import Path
+
+import yaml
+
+DEFAULT_QUARANTINE_PATH = Path(__file__).with_name("quarantine.yaml")
+
+
+class QuarantineError(Exception):
+    """Raised when a present quarantine file is malformed."""
+
+
+@dataclass(frozen=True)
+class QuarantineEntry:
+    """One known-flaky test. ``id`` is a pytest node id; the rest is
+    human bookkeeping the scorecard can echo back."""
+
+    id: str
+    reason: str = ""
+    added: str = ""
+    issue: str = ""
+
+
+def load_quarantine(path: Path | None = None) -> list[QuarantineEntry]:
+    """Parse the quarantine registry.
+
+    Missing file → ``[]`` (legitimate: no quarantine configured).
+    Present but malformed → ``QuarantineError`` (author mistake).
+    """
+    path = path or DEFAULT_QUARANTINE_PATH
+    if not path.exists():
+        return []
+
+    try:
+        raw = yaml.safe_load(path.read_text()) or {}
+    except yaml.YAMLError as e:
+        raise QuarantineError(f"quarantine file is not valid YAML: {e}") from e
+
+    if not isinstance(raw, dict):
+        raise QuarantineError(
+            f"quarantine file must be a mapping with a 'tests' key, "
+            f"got {type(raw).__name__}"
+        )
+    tests = raw.get("tests", [])
+    if tests is None:
+        tests = []
+    if not isinstance(tests, list):
+        raise QuarantineError(
+            f"quarantine 'tests' must be a list, got {type(tests).__name__}"
+        )
+
+    entries: list[QuarantineEntry] = []
+    for i, item in enumerate(tests):
+        if not isinstance(item, dict):
+            raise QuarantineError(
+                f"quarantine test #{i} must be a mapping, got {type(item).__name__}"
+            )
+        node_id = item.get("id")
+        if not isinstance(node_id, str) or not node_id.strip():
+            raise QuarantineError(f"quarantine test #{i} needs a non-empty string 'id'")
+        entries.append(
+            QuarantineEntry(
+                id=node_id.strip(),
+                reason=str(item.get("reason", "") or "").strip(),
+                added=str(item.get("added", "") or "").strip(),
+                issue=str(item.get("issue", "") or "").strip(),
+            )
+        )
+    return entries
+
+
+def node_id_matches(failed_id: str, entry_id: str) -> bool:
+    """True iff a failed node id is covered by a quarantine entry.
+
+    Exact match, OR the entry names a whole test and the failure is one
+    of its parametrizations (``entry_id`` + ``[...]``).
+    """
+    if failed_id == entry_id:
+        return True
+    # A base entry (no bracket of its own) covers every parametrization.
+    if "[" not in entry_id and failed_id.startswith(entry_id + "["):
+        return True
+    return False
+
+
+def is_quarantined(failed_id: str, entries: Iterable[QuarantineEntry]) -> bool:
+    """True iff any entry covers ``failed_id``."""
+    return any(node_id_matches(failed_id, e.id) for e in entries)
+
+
+def partition_failures(
+    failed_ids: Iterable[str], entries: Iterable[QuarantineEntry]
+) -> tuple[list[str], list[str]]:
+    """Split a failure set into ``(blocking, quarantined)``.
+
+    Order is preserved from ``failed_ids``. ``blocking`` is everything
+    NOT covered by a quarantine entry — those still fail the gate.
+    ``quarantined`` is reported but non-blocking.
+    """
+    entries = list(entries)
+    blocking: list[str] = []
+    quarantined: list[str] = []
+    for fid in failed_ids:
+        if is_quarantined(fid, entries):
+            quarantined.append(fid)
+        else:
+            blocking.append(fid)
+    return blocking, quarantined

--- a/scripts/pr_validate/quarantine.py
+++ b/scripts/pr_validate/quarantine.py
@@ -349,18 +349,35 @@ def _parse_quarantine_text(text: str, source: str) -> list[QuarantineEntry]:
     return entries
 
 
+def _has_param_suffix(node_id: str) -> bool:
+    """True iff the node id's FINAL component carries a ``[...]`` parameter
+    suffix (``tests/x.py::TestC::test_y[p]``).
+
+    Only the last ``::`` component can hold a parametrization bracket; a ``[``
+    earlier in the path is a directory or class name (e.g. a test living under
+    ``tests/models/[legacy]/test_x.py::test_y``). Searching the WHOLE id for
+    ``[`` wrongly disabled family matching for such tests (codex #1222 r27)."""
+    return "[" in node_id.rsplit("::", 1)[-1]
+
+
 def node_id_matches(failed_id: str, entry_id: str, *, family: bool = False) -> bool:
     """True iff a failed node id is covered by a quarantine entry.
 
     EXACT match by default. Only when ``family`` is set does a base
-    (no-bracket) entry also cover every parametrization (``entry_id`` +
+    (unparametrized) entry also cover every parametrization (``entry_id`` +
     ``[...]``) — exact-by-default keeps a newly-added, deterministically
     failing parametrization from being silently waived (codex #1222 r14).
     """
     if failed_id == entry_id:
         return True
-    # Family coverage is OPT-IN and only meaningful for a base entry.
-    if family and "[" not in entry_id and failed_id.startswith(entry_id + "["):
+    # Family coverage is OPT-IN and only meaningful for a base (unparametrized)
+    # entry — gated on the FINAL component's suffix, not any ``[`` in the path,
+    # so a test under a bracket-named directory can still use it (codex r27).
+    if (
+        family
+        and not _has_param_suffix(entry_id)
+        and failed_id.startswith(entry_id + "[")
+    ):
         return True
     return False
 

--- a/scripts/pr_validate/quarantine.py
+++ b/scripts/pr_validate/quarantine.py
@@ -24,6 +24,7 @@ Design notes:
 
 from __future__ import annotations
 
+import subprocess
 from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
@@ -31,6 +32,11 @@ from pathlib import Path
 import yaml
 
 DEFAULT_QUARANTINE_PATH = Path(__file__).with_name("quarantine.yaml")
+
+# Registry location relative to the repo root — used to read it out of a
+# git revision (the protected base) rather than the candidate checkout.
+QUARANTINE_REL_PATH = "scripts/pr_validate/quarantine.yaml"
+_GIT_SHOW_TIMEOUT_S = 30
 
 
 class QuarantineError(Exception):
@@ -49,42 +55,82 @@ class QuarantineEntry:
 
 
 def load_quarantine(path: Path | None = None) -> list[QuarantineEntry]:
-    """Parse the quarantine registry.
+    """Parse the quarantine registry from a file on disk.
 
     Missing file → ``[]`` (legitimate: no quarantine configured).
     Present but malformed → ``QuarantineError`` (author mistake).
+
+    NOTE for gating callers: prefer ``load_quarantine_from_ref`` so the
+    registry is read from the protected base, not the candidate checkout
+    (otherwise a PR could quarantine its own failing tests). This
+    file-path form is for tests and for reading the shipped default.
     """
     path = path or DEFAULT_QUARANTINE_PATH
     if not path.exists():
         return []
+    return _parse_quarantine_text(path.read_text(), source=str(path))
 
+
+def load_quarantine_from_ref(
+    ref: str,
+    repo_root: Path,
+    rel_path: str = QUARANTINE_REL_PATH,
+) -> list[QuarantineEntry]:
+    """Read the registry from a git revision (the PROTECTED base) via
+    ``git show <ref>:<rel_path>``, NOT from the working tree — so the
+    same PR being validated cannot add its own failing tests to the
+    allowlist and make them non-blocking (codex #1222).
+
+    Absent at ``ref`` (the revision predates the registry, or any other
+    git non-zero) → ``[]``: a base without the file has no quarantine,
+    and falling back to empty keeps the gate *stricter*, never looser.
+    A malformed file that IS present at ``ref`` → ``QuarantineError``
+    (the caller fails safe to empty).
+    """
     try:
-        raw = yaml.safe_load(path.read_text()) or {}
+        proc = subprocess.run(  # noqa: S603
+            ["git", "show", f"{ref}:{rel_path}"],  # noqa: S607
+            capture_output=True,
+            text=True,
+            cwd=str(repo_root),
+            timeout=_GIT_SHOW_TIMEOUT_S,
+        )
+    except (OSError, subprocess.SubprocessError):
+        # git missing / not a repo / timeout → treat as no quarantine
+        # (stricter gate). Never let an infra hiccup loosen the gate.
+        return []
+    if proc.returncode != 0:
+        return []
+    return _parse_quarantine_text(proc.stdout, source=f"{ref}:{rel_path}")
+
+
+def _parse_quarantine_text(text: str, source: str) -> list[QuarantineEntry]:
+    try:
+        raw = yaml.safe_load(text) or {}
     except yaml.YAMLError as e:
-        raise QuarantineError(f"quarantine file is not valid YAML: {e}") from e
+        raise QuarantineError(f"{source}: not valid YAML: {e}") from e
 
     if not isinstance(raw, dict):
         raise QuarantineError(
-            f"quarantine file must be a mapping with a 'tests' key, "
-            f"got {type(raw).__name__}"
+            f"{source}: must be a mapping with a 'tests' key, got {type(raw).__name__}"
         )
     tests = raw.get("tests", [])
     if tests is None:
         tests = []
     if not isinstance(tests, list):
         raise QuarantineError(
-            f"quarantine 'tests' must be a list, got {type(tests).__name__}"
+            f"{source}: 'tests' must be a list, got {type(tests).__name__}"
         )
 
     entries: list[QuarantineEntry] = []
     for i, item in enumerate(tests):
         if not isinstance(item, dict):
             raise QuarantineError(
-                f"quarantine test #{i} must be a mapping, got {type(item).__name__}"
+                f"{source}: test #{i} must be a mapping, got {type(item).__name__}"
             )
         node_id = item.get("id")
         if not isinstance(node_id, str) or not node_id.strip():
-            raise QuarantineError(f"quarantine test #{i} needs a non-empty string 'id'")
+            raise QuarantineError(f"{source}: test #{i} needs a non-empty string 'id'")
         entries.append(
             QuarantineEntry(
                 id=node_id.strip(),

--- a/scripts/pr_validate/quarantine.py
+++ b/scripts/pr_validate/quarantine.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 import subprocess
 from collections.abc import Iterable
 from dataclasses import dataclass
+from datetime import date
 from pathlib import Path
 
 import yaml
@@ -196,6 +197,24 @@ def _parse_quarantine_text(text: str, source: str) -> list[QuarantineEntry]:
             raise QuarantineError(
                 f"{source}: test #{i} ('{node_id}') needs a non-empty 'added' "
                 f"date (YYYY-MM-DD)"
+            )
+        # ``added`` claims to be a YYYY-MM-DD date, so ENFORCE it — a
+        # non-empty-but-garbage value ("soon", "2026-13-40") is exactly the
+        # silent audit rot the mandatory field exists to prevent. Require a
+        # value that round-trips through ``date.fromisoformat`` to canonical
+        # YYYY-MM-DD (rejects "2026-7-5", timestamps, and out-of-range
+        # dates) (codex #1222 r13).
+        try:
+            parsed = date.fromisoformat(added)
+        except ValueError as e:
+            raise QuarantineError(
+                f"{source}: test #{i} ('{node_id}') 'added' must be a "
+                f"YYYY-MM-DD date, got {added!r}: {e}"
+            ) from e
+        if parsed.isoformat() != added:
+            raise QuarantineError(
+                f"{source}: test #{i} ('{node_id}') 'added' must be canonical "
+                f"YYYY-MM-DD, got {added!r} (expected {parsed.isoformat()})"
             )
         entries.append(
             QuarantineEntry(

--- a/scripts/pr_validate/quarantine.py
+++ b/scripts/pr_validate/quarantine.py
@@ -15,11 +15,13 @@ Design notes:
     gating step catches the error and falls back to an EMPTY quarantine,
     i.e. a *stricter* gate: a broken registry can never make the gate
     pass something it otherwise wouldn't.
-  * Matching is by exact pytest node id, with one deliberate
-    convenience: an entry id carrying no ``[...]`` also matches every
-    parametrization of that test (``foo::test`` quarantines
-    ``foo::test[a]`` and ``foo::test[b]``). An entry that DOES name a
-    specific parametrization matches only that one.
+  * Matching is by EXACT pytest node id by default (codex #1222 r14).
+    An entry may opt into parameter-family matching with ``family: true``,
+    which makes a base (no-bracket) id also cover every parametrization
+    (``foo::test`` then quarantines ``foo::test[a]`` and ``foo::test[b]``).
+    Exact-by-default is deliberate: a PR that adds a NEW, deterministically
+    failing parametrization to a listed test must not have it silently
+    waived — family coverage is a reviewed decision, made once at the base.
 """
 
 from __future__ import annotations
@@ -47,12 +49,19 @@ class QuarantineError(Exception):
 @dataclass(frozen=True)
 class QuarantineEntry:
     """One known-flaky test. ``id`` is a pytest node id; the rest is
-    human bookkeeping the scorecard can echo back."""
+    human bookkeeping the scorecard can echo back.
+
+    ``family`` opts a base (no-bracket) entry into matching EVERY
+    parametrization of the test, not just the exact id. It defaults False
+    so that adding a new, deterministically-failing parametrization to a
+    quarantined test is never silently waived without an explicit,
+    base-reviewed decision (codex #1222 r14)."""
 
     id: str
     reason: str = ""
     added: str = ""
     issue: str = ""
+    family: bool = False
 
 
 def load_quarantine(path: Path | None = None) -> list[QuarantineEntry]:
@@ -216,34 +225,46 @@ def _parse_quarantine_text(text: str, source: str) -> list[QuarantineEntry]:
                 f"{source}: test #{i} ('{node_id}') 'added' must be canonical "
                 f"YYYY-MM-DD, got {added!r} (expected {parsed.isoformat()})"
             )
+        # ``family`` is an explicit, reviewed opt-in — a strict boolean so a
+        # stray string can't be truthy-by-accident and silently widen the
+        # allowlist to every parametrization (codex #1222 r14).
+        family = item.get("family", False)
+        if not isinstance(family, bool):
+            raise QuarantineError(
+                f"{source}: test #{i} ('{node_id}') 'family' must be a boolean, "
+                f"got {type(family).__name__}"
+            )
         entries.append(
             QuarantineEntry(
                 id=node_id,
                 reason=reason,
                 added=added,
                 issue=str(item.get("issue", "") or "").strip(),
+                family=family,
             )
         )
     return entries
 
 
-def node_id_matches(failed_id: str, entry_id: str) -> bool:
+def node_id_matches(failed_id: str, entry_id: str, *, family: bool = False) -> bool:
     """True iff a failed node id is covered by a quarantine entry.
 
-    Exact match, OR the entry names a whole test and the failure is one
-    of its parametrizations (``entry_id`` + ``[...]``).
+    EXACT match by default. Only when ``family`` is set does a base
+    (no-bracket) entry also cover every parametrization (``entry_id`` +
+    ``[...]``) — exact-by-default keeps a newly-added, deterministically
+    failing parametrization from being silently waived (codex #1222 r14).
     """
     if failed_id == entry_id:
         return True
-    # A base entry (no bracket of its own) covers every parametrization.
-    if "[" not in entry_id and failed_id.startswith(entry_id + "["):
+    # Family coverage is OPT-IN and only meaningful for a base entry.
+    if family and "[" not in entry_id and failed_id.startswith(entry_id + "["):
         return True
     return False
 
 
 def is_quarantined(failed_id: str, entries: Iterable[QuarantineEntry]) -> bool:
     """True iff any entry covers ``failed_id``."""
-    return any(node_id_matches(failed_id, e.id) for e in entries)
+    return any(node_id_matches(failed_id, e.id, family=e.family) for e in entries)
 
 
 def partition_failures(

--- a/scripts/pr_validate/quarantine.py
+++ b/scripts/pr_validate/quarantine.py
@@ -440,6 +440,24 @@ def _parse_quarantine_text(text: str, source: str) -> list[QuarantineEntry]:
                 family=family,
             )
         )
+    # Reject duplicate node ids across ENTRIES — the strict loader above only
+    # catches duplicate KEYS within one mapping (codex #1222 r37). Two list
+    # entries for the same id (e.g. one ``family: true`` and one
+    # ``family: false``) would make ``effective_quarantine``'s first-match
+    # selection depend on YAML list order and could drop valid family
+    # coverage. A registry with a repeated id is always an authoring mistake;
+    # reject it loudly so coverage is order-independent and unambiguous. (A
+    # ``family``-covering entry and a specific parametrization carry DIFFERENT
+    # id strings — ``t`` vs ``t[p1]`` — so this never rejects that legit pair.)
+    seen_ids: set[str] = set()
+    for e in entries:
+        if e.id in seen_ids:
+            raise QuarantineError(
+                f"{source}: duplicate quarantine id {e.id!r} — each test may "
+                f"appear at most once (a repeated id makes effective coverage "
+                f"depend on list order)"
+            )
+        seen_ids.add(e.id)
     return entries
 
 

--- a/scripts/pr_validate/quarantine.py
+++ b/scripts/pr_validate/quarantine.py
@@ -88,11 +88,13 @@ def load_quarantine_from_ref(
     same PR being validated cannot add its own failing tests to the
     allowlist and make them non-blocking (codex #1222).
 
-    Absent at ``ref`` (the revision predates the registry, or any other
-    git non-zero) → ``[]``: a base without the file has no quarantine,
-    and falling back to empty keeps the gate *stricter*, never looser.
-    A malformed file that IS present at ``ref`` → ``QuarantineError``
-    (the caller fails safe to empty).
+    Note the outcomes carefully (codex #1222 r10): only a CONFIRMED
+    missing path → ``[]`` (the base predates the registry; empty keeps the
+    gate stricter, never looser). Every other failure — git absent, a
+    timeout, a bad ref, a non-UTF-8 or malformed blob — raises
+    ``QuarantineError`` so the gating caller falls back to empty *and
+    reports it loudly*, instead of a silent empty that's indistinguishable
+    from "nothing is quarantined". Never let an infra hiccup pass unseen.
     """
     try:
         proc = subprocess.run(  # noqa: S603
@@ -103,17 +105,31 @@ def load_quarantine_from_ref(
             cwd=str(repo_root),
             timeout=_GIT_SHOW_TIMEOUT_S,
         )
-    except (OSError, subprocess.SubprocessError):
-        # git missing / not a repo / timeout → treat as no quarantine
-        # (stricter gate). Never let an infra hiccup loosen the gate.
-        return []
+    except FileNotFoundError as e:
+        # git not installed / not on PATH — infra failure, not "no registry".
+        raise QuarantineError(f"git unavailable to read {ref}:{rel_path}: {e}") from e
+    except subprocess.TimeoutExpired as e:
+        raise QuarantineError(
+            f"git show timed out after {_GIT_SHOW_TIMEOUT_S}s reading {ref}:{rel_path}"
+        ) from e
+    except (OSError, subprocess.SubprocessError) as e:
+        raise QuarantineError(f"git show failed for {ref}:{rel_path}: {e}") from e
     except UnicodeDecodeError as e:
         # A non-UTF-8 blob at ref is malformed → QuarantineError so the
         # gating caller fails safe to empty, not an unhandled ValueError
         # (codex #1222 r5).
         raise QuarantineError(f"{ref}:{rel_path}: not valid UTF-8: {e}") from e
     if proc.returncode != 0:
-        return []
+        # git exits 128 for BOTH "path absent at this ref" (legitimate) and
+        # real errors (bad ref, not a repo). Only a confirmed missing PATH
+        # is an empty registry; anything else is surfaced.
+        stderr = (proc.stderr or "").lower()
+        if "does not exist in" in stderr or "exists on disk, but not in" in stderr:
+            return []
+        raise QuarantineError(
+            f"git show failed for {ref}:{rel_path} (exit {proc.returncode}): "
+            f"{(proc.stderr or '').strip()}"
+        )
     return _parse_quarantine_text(proc.stdout, source=f"{ref}:{rel_path}")
 
 
@@ -150,11 +166,30 @@ def _parse_quarantine_text(text: str, source: str) -> list[QuarantineEntry]:
         node_id = item.get("id")
         if not isinstance(node_id, str) or not node_id.strip():
             raise QuarantineError(f"{source}: test #{i} needs a non-empty string 'id'")
+        node_id = node_id.strip()
+        # ``reason`` and ``added`` are MANDATORY audit data — every entry is
+        # a hole in the gate, and an undocumented one (no rationale, no
+        # date) is how a permanent silent waiver creeps in. Enforce them so
+        # a bare ``{id: …}`` can't slip a test onto the allowlist without a
+        # paper trail (codex #1222 r10). ``issue`` stays optional (not every
+        # flake has a tracker link yet).
+        reason = str(item.get("reason", "") or "").strip()
+        added = str(item.get("added", "") or "").strip()
+        if not reason:
+            raise QuarantineError(
+                f"{source}: test #{i} ('{node_id}') needs a non-empty 'reason' "
+                f"— document WHY it is flaky"
+            )
+        if not added:
+            raise QuarantineError(
+                f"{source}: test #{i} ('{node_id}') needs a non-empty 'added' "
+                f"date (YYYY-MM-DD)"
+            )
         entries.append(
             QuarantineEntry(
-                id=node_id.strip(),
-                reason=str(item.get("reason", "") or "").strip(),
-                added=str(item.get("added", "") or "").strip(),
+                id=node_id,
+                reason=reason,
+                added=added,
                 issue=str(item.get("issue", "") or "").strip(),
             )
         )

--- a/scripts/pr_validate/quarantine.py
+++ b/scripts/pr_validate/quarantine.py
@@ -26,6 +26,7 @@ Design notes:
 
 from __future__ import annotations
 
+import os
 import subprocess
 from collections.abc import Iterable
 from dataclasses import dataclass, replace
@@ -142,6 +143,13 @@ def load_quarantine_from_ref(
             encoding="utf-8",
             cwd=str(repo_root),
             timeout=_GIT_SHOW_TIMEOUT_S,
+            # Pin the locale so the "missing path" stderr fragments matched
+            # below are git's stable C-locale English, not a translated
+            # message under a non-English LANG — otherwise a legitimately
+            # absent registry would misclassify as a hard error (codex #1222
+            # r25). LC_ALL wins over LANG/LC_MESSAGES; set both for belt-and-
+            # braces.
+            env={**os.environ, "LC_ALL": "C", "LANG": "C"},
         )
     except FileNotFoundError as e:
         # git not installed / not on PATH — infra failure, not "no registry".

--- a/scripts/pr_validate/quarantine.py
+++ b/scripts/pr_validate/quarantine.py
@@ -76,21 +76,30 @@ def load_quarantine(path: Path | None = None) -> list[QuarantineEntry]:
     file-path form is for tests and for reading the shipped default.
     """
     path = path or DEFAULT_QUARANTINE_PATH
-    if not path.exists():
-        return []
+    # Attempt the read DIRECTLY — never gate on ``path.exists()`` first.
+    # ``Path.exists()`` re-raises a ``PermissionError`` when a parent
+    # directory is inaccessible (it only swallows ENOENT/ENOTDIR/etc.), so
+    # a pre-check outside the handler could escape the documented
+    # QuarantineError fail-safe with a raw OSError (codex #1222 r24). Only a
+    # CONFIRMED-missing file (``FileNotFoundError``) is the legitimate
+    # "absent → empty" case; every other OSError is a present-but-unusable
+    # registry.
     try:
         text = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        # No registry configured — legitimate empty quarantine.
+        return []
     except UnicodeDecodeError as e:
         # A non-UTF-8 registry is malformed, not "absent" — surface it as
         # QuarantineError so the gating caller fails safe to empty rather
         # than crashing on an unhandled ValueError (codex #1222 r5).
         raise QuarantineError(f"{path}: not valid UTF-8: {e}") from e
     except OSError as e:
-        # A present-but-unreadable file (permissions, an I/O error, a
-        # TOCTOU vanish after the exists() check) is a read failure, not
-        # "absent" — the docstring promises QuarantineError for a present-
-        # but-unusable registry, so a caller catching only that exception
-        # doesn't crash on a raw OSError (codex #1222 r18).
+        # A present-but-unreadable file (permission denied, an inaccessible
+        # parent, an I/O error) is a read failure, not "absent" — the
+        # docstring promises QuarantineError for a present-but-unusable
+        # registry, so a caller catching only that exception doesn't crash on
+        # a raw OSError (codex #1222 r18/r24).
         raise QuarantineError(f"{path}: could not be read: {e}") from e
     return _parse_quarantine_text(text, source=str(path))
 

--- a/scripts/pr_validate/quarantine.py
+++ b/scripts/pr_validate/quarantine.py
@@ -95,10 +95,22 @@ def load_quarantine_from_ref(
     ``QuarantineError`` so the gating caller falls back to empty *and
     reports it loudly*, instead of a silent empty that's indistinguishable
     from "nothing is quarantined". Never let an infra hiccup pass unseen.
+
+    ``--no-replace-objects`` is REQUIRED, not cosmetic (codex #1222 r12):
+    an immutable base SHA pins the *object*, but ``git show`` otherwise
+    honors local replacement refs, so a candidate test that ran earlier in
+    the pipeline could ``git replace <base_sha> <attacker-commit>`` and make
+    ``git show <base_sha>:…`` serve its own allowlist despite the pinned
+    SHA. With replacement disabled, ``<40-hex-sha>:<path>`` resolves the
+    true content-addressed blob — the only git indirection that could remap
+    it is closed (grafts/alternates can't override an existing object's
+    content; a mutable branch ref is no longer used per r10).
     """
     try:
         proc = subprocess.run(  # noqa: S603
-            ["git", "show", f"{ref}:{rel_path}"],  # noqa: S607
+            # --no-replace-objects: ignore any refs/replace/* a candidate
+            # test may have planted; read the true base blob (codex r12).
+            ["git", "--no-replace-objects", "show", f"{ref}:{rel_path}"],  # noqa: S607
             capture_output=True,
             text=True,
             encoding="utf-8",

--- a/scripts/pr_validate/quarantine.py
+++ b/scripts/pr_validate/quarantine.py
@@ -68,7 +68,14 @@ def load_quarantine(path: Path | None = None) -> list[QuarantineEntry]:
     path = path or DEFAULT_QUARANTINE_PATH
     if not path.exists():
         return []
-    return _parse_quarantine_text(path.read_text(), source=str(path))
+    try:
+        text = path.read_text(encoding="utf-8")
+    except UnicodeDecodeError as e:
+        # A non-UTF-8 registry is malformed, not "absent" — surface it as
+        # QuarantineError so the gating caller fails safe to empty rather
+        # than crashing on an unhandled ValueError (codex #1222 r5).
+        raise QuarantineError(f"{path}: not valid UTF-8: {e}") from e
+    return _parse_quarantine_text(text, source=str(path))
 
 
 def load_quarantine_from_ref(
@@ -92,6 +99,7 @@ def load_quarantine_from_ref(
             ["git", "show", f"{ref}:{rel_path}"],  # noqa: S607
             capture_output=True,
             text=True,
+            encoding="utf-8",
             cwd=str(repo_root),
             timeout=_GIT_SHOW_TIMEOUT_S,
         )
@@ -99,6 +107,11 @@ def load_quarantine_from_ref(
         # git missing / not a repo / timeout → treat as no quarantine
         # (stricter gate). Never let an infra hiccup loosen the gate.
         return []
+    except UnicodeDecodeError as e:
+        # A non-UTF-8 blob at ref is malformed → QuarantineError so the
+        # gating caller fails safe to empty, not an unhandled ValueError
+        # (codex #1222 r5).
+        raise QuarantineError(f"{ref}:{rel_path}: not valid UTF-8: {e}") from e
     if proc.returncode != 0:
         return []
     return _parse_quarantine_text(proc.stdout, source=f"{ref}:{rel_path}")

--- a/scripts/pr_validate/quarantine.py
+++ b/scripts/pr_validate/quarantine.py
@@ -106,10 +106,16 @@ def load_quarantine_from_ref(
 
 def _parse_quarantine_text(text: str, source: str) -> list[QuarantineEntry]:
     try:
-        raw = yaml.safe_load(text) or {}
+        raw = yaml.safe_load(text)
     except yaml.YAMLError as e:
         raise QuarantineError(f"{source}: not valid YAML: {e}") from e
 
+    # Only an ABSENT document (empty file / all comments → None) is an
+    # empty registry. A falsey-but-present root such as ``[]`` / ``false``
+    # / ``0`` is a schema violation and must surface, not be swallowed by
+    # ``or {}`` (codex #1222 r2).
+    if raw is None:
+        raw = {}
     if not isinstance(raw, dict):
         raise QuarantineError(
             f"{source}: must be a mapping with a 'tests' key, got {type(raw).__name__}"

--- a/scripts/pr_validate/quarantine.py
+++ b/scripts/pr_validate/quarantine.py
@@ -202,7 +202,22 @@ class _UniqueKeySafeLoader(yaml.SafeLoader):
         seen: set = set()
         for key_node, _value_node in node.value:
             key = self.construct_object(key_node, deep=deep)
-            if key in seen:
+            # A complex (list / mapping) YAML key is unhashable, so ``key in
+            # seen`` would raise a raw ``TypeError`` instead of the documented
+            # ``QuarantineError`` (codex #1222 r22). Convert it to a
+            # ``ConstructorError`` (a ``yaml.YAMLError``) so the caller's
+            # error handling wraps it — the same class of complaint pyyaml
+            # itself raises for an unhashable key, just surfaced here first.
+            try:
+                is_dup = key in seen
+            except TypeError as e:
+                raise yaml.constructor.ConstructorError(
+                    "while constructing a mapping",
+                    node.start_mark,
+                    f"unacceptable (unhashable) key: {e}",
+                    key_node.start_mark,
+                ) from e
+            if is_dup:
                 raise yaml.constructor.ConstructorError(
                     "while constructing a mapping",
                     node.start_mark,

--- a/scripts/pr_validate/quarantine.py
+++ b/scripts/pr_validate/quarantine.py
@@ -43,6 +43,7 @@ DEFAULT_QUARANTINE_PATH = Path(__file__).with_name("quarantine.yaml")
 QUARANTINE_REL_PATH = "scripts/pr_validate/quarantine.yaml"
 _GIT_SHOW_TIMEOUT_S = 30
 
+
 # Resolve the git binary ONCE, at import time — which runs when pr_validate
 # boots, BEFORE any candidate test code executes in a later pipeline step
 # (targeted_tests / full_unit). Resolving lazily at call time would look up
@@ -59,7 +60,24 @@ _GIT_SHOW_TIMEOUT_S = 30
 # when git can't be resolved we keep ``None`` and FAIL CLOSED at call time
 # (a QuarantineError → the gating caller treats every failure as blocking),
 # never a bare "git" re-looked-up through a candidate-tamperable PATH.
-_GIT = shutil.which("git")
+#
+# r39: the result must also be ABSOLUTE. ``shutil.which`` returns a relative
+# path when PATH holds ``.`` (or any relative entry); the subprocess runs with
+# ``cwd=repo_root``, so a relative ``_GIT`` would resolve under the CANDIDATE
+# checkout at call time — a committed ``./git`` could then forge the registry.
+# Only an absolute path is trustworthy; a relative one fails closed like an
+# unresolved git.
+def _resolve_git() -> str | None:
+    """Resolve git to an ABSOLUTE path, or None (→ fail closed). A relative
+    ``which`` result (PATH held ``.``) is rejected — it would resolve under
+    the subprocess ``cwd`` (the candidate checkout) at call time (codex r39)."""
+    g = shutil.which("git")
+    if g is not None and not os.path.isabs(g):
+        return None
+    return g
+
+
+_GIT = _resolve_git()
 
 # Registries are also SNAPSHOTTED at fetch — before any candidate code runs —
 # into this cache (see ``snapshot_quarantine_registries``); ``load_quarantine

--- a/scripts/pr_validate/quarantine.yaml
+++ b/scripts/pr_validate/quarantine.yaml
@@ -15,12 +15,16 @@
 #     human promotes a confirmed one here. Never auto-populate.
 #   * NEVER add an entry to silence a real regression. A test that fails
 #     deterministically is a bug, not a flake — fix the code or the test.
-#   * Match is by EXACT pytest node id (an entry with no ``[param]`` also
-#     matches every parametrization of that test — see quarantine.py).
+#   * Match is by EXACT pytest node id. To cover every parametrization of a
+#     test with one base (no-bracket) entry, set ``family: true`` — an
+#     explicit, reviewed opt-in (a new failing parametrization is otherwise
+#     NOT waived without review). See quarantine.py.
 #   * Keep the list SMALL. Every entry is a hole in the gate; each must
 #     carry a reason, an added-date, and an issue link where one exists.
 #
-# Schema: ``tests`` is a list of {id, reason, added, issue}.
+# Schema: ``tests`` is a list of {id, reason, added, issue, family?}.
+#   ``added`` must be a canonical YYYY-MM-DD date; ``family`` is an optional
+#   boolean (default false).
 tests:
   - id: "tests/test_signal_observability.py::test_subprocess_sighup_default_disposition_dumps_and_stays_alive"
     reason: >-

--- a/scripts/pr_validate/quarantine.yaml
+++ b/scripts/pr_validate/quarantine.yaml
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Known-flaky test registry — the trust infrastructure for hard gates
+# (dev-flow proposal item ③). A test listed here that FAILS does NOT
+# block a PR, but IS reported prominently on the scorecard. This exists
+# so a confirmed-nondeterministic test cannot force the "rerun the whole
+# PR until it's green" ritual that quietly destroys gate credibility:
+# once one flake is allowed to fail silently-by-rerun, every red is
+# suspect and no gate is trusted.
+#
+# DISCIPLINE — read before adding an entry:
+#   * Add ONLY after CONFIRMING flakiness — a pass-after-rerun actually
+#     observed, or a documented environmental race. The advisory
+#     ``flake_tracking`` step surfaces candidates from real PR runs; a
+#     human promotes a confirmed one here. Never auto-populate.
+#   * NEVER add an entry to silence a real regression. A test that fails
+#     deterministically is a bug, not a flake — fix the code or the test.
+#   * Match is by EXACT pytest node id (an entry with no ``[param]`` also
+#     matches every parametrization of that test — see quarantine.py).
+#   * Keep the list SMALL. Every entry is a hole in the gate; each must
+#     carry a reason, an added-date, and an issue link where one exists.
+#
+# Schema: ``tests`` is a list of {id, reason, added, issue}.
+tests:
+  - id: "tests/test_signal_observability.py::test_subprocess_sighup_default_disposition_dumps_and_stays_alive"
+    reason: >-
+      Signal-delivery timing race. Asserts a SIGHUP-defaulted subprocess
+      dumps state and stays alive, but delivery/scheduling latency makes
+      the observation window intermittently miss under load. Documented
+      G8 flake — surfaces as an isolated red on an otherwise-green full
+      suite (e.g. "14003 passed, 1 failed" where the 1 is this test).
+    added: "2026-07-25"
+    issue: ""
+  - id: "tests/test_continuous_batching.py::TestContinuousBatchingIntegration::test_batching_improves_throughput"
+    reason: >-
+      GPU-contention sensitive. Absolute tok/s varies ~6x run-to-run on
+      one machine from suite-wide GPU contention (382-697 tok/s observed
+      per the test's own docstring). The relative batched-vs-sequential
+      comparison is meant to be robust, but still trips intermittently
+      under heavy parallel load.
+    added: "2026-07-25"
+    issue: ""

--- a/scripts/pr_validate/quarantine.yaml
+++ b/scripts/pr_validate/quarantine.yaml
@@ -33,7 +33,7 @@ tests:
     issue: ""
   - id: "tests/test_continuous_batching.py::TestContinuousBatchingIntegration::test_batching_improves_throughput"
     reason: >-
-      GPU-contention sensitive. Absolute tok/s varies ~6x run-to-run on
+      GPU-contention sensitive. Absolute tok/s varies ~1.8x run-to-run on
       one machine from suite-wide GPU contention (382-697 tok/s observed
       per the test's own docstring). The relative batched-vs-sequential
       comparison is meant to be robust, but still trips intermittently

--- a/scripts/pr_validate/runner.py
+++ b/scripts/pr_validate/runner.py
@@ -69,15 +69,21 @@ STEPS: list[Step] = [
     LintStep(),  # 2 — ruff check + format
     TargetedTestsStep(),  # 3 — diff-aware test selection + neg control
     FullUnitStep(),  # 4 — full pytest, gated on blast radius
-    # 4.5 — ADVISORY flake classification (never gates; dev-flow ③).
-    # Placed right after full_unit because it reads full-unit.log and
-    # re-runs only the tests that failed (a tiny set — usually zero), so
-    # it's cheap. In default mode it runs even when full_unit blocked,
-    # which is exactly when "is this red a flake?" matters most; note it
-    # is still skipped under user-opted --fail-fast (a known slice-1
-    # limitation — CI reruns locally to get the classification).
-    FlakeTrackingStep(),
     StressE2EBenchStep(),  # 5 — stress + e2e + bench (multi-model × agents)
+    # 5.5 — flake classification (dev-flow ③). Mostly advisory: it reads
+    # full-unit.log and re-runs only the tests that failed (a tiny set —
+    # usually zero), classifying flake-vs-real. It has ONE gating case —
+    # a quarantined test that reproduces deterministically on every re-run
+    # blocks (a regression the quarantine would otherwise mask). Placed
+    # AFTER every GATING step (full_unit, stress/e2e) on purpose: its
+    # re-runs can leak a detached descendant on macOS (no cgroup to
+    # contain a setsid escapee — see flake_tracking.py), so no gating step
+    # runs after it and such a leak can't contaminate one (codex #1222
+    # r7). Only the advisory diff_coverage follows — and running the gate
+    # before that 3-min coverage rerun gives fail-fast a cheaper exit.
+    # Still skipped under user-opted --fail-fast if an earlier gate
+    # already blocked (a known slice-1 limitation).
+    FlakeTrackingStep(),
     # 6 — ADVISORY patch-coverage measurement (never gates). Last on
     # purpose: it re-runs the FULL unit suite under coverage instrumentation
     # (~3 min, same order as full_unit's ~2:45 — see diff_coverage.py), so in

--- a/scripts/pr_validate/runner.py
+++ b/scripts/pr_validate/runner.py
@@ -22,6 +22,7 @@ from .steps.cl_description_quality import CLDescriptionQualityStep
 from .steps.codex_review import CodexReviewStep
 from .steps.diff_coverage import DiffCoverageStep
 from .steps.fetch import FetchStep
+from .steps.flake_tracking import FlakeTrackingStep
 from .steps.full_unit import FullUnitStep
 from .steps.lint import LintStep
 from .steps.stress_e2e_bench import StressE2EBenchStep
@@ -68,6 +69,14 @@ STEPS: list[Step] = [
     LintStep(),  # 2 — ruff check + format
     TargetedTestsStep(),  # 3 — diff-aware test selection + neg control
     FullUnitStep(),  # 4 — full pytest, gated on blast radius
+    # 4.5 — ADVISORY flake classification (never gates; dev-flow ③).
+    # Placed right after full_unit because it reads full-unit.log and
+    # re-runs only the tests that failed (a tiny set — usually zero), so
+    # it's cheap. In default mode it runs even when full_unit blocked,
+    # which is exactly when "is this red a flake?" matters most; note it
+    # is still skipped under user-opted --fail-fast (a known slice-1
+    # limitation — CI reruns locally to get the classification).
+    FlakeTrackingStep(),
     StressE2EBenchStep(),  # 5 — stress + e2e + bench (multi-model × agents)
     # 6 — ADVISORY patch-coverage measurement (never gates). Last on
     # purpose: it re-runs the FULL unit suite under coverage instrumentation

--- a/scripts/pr_validate/runner.py
+++ b/scripts/pr_validate/runner.py
@@ -70,19 +70,17 @@ STEPS: list[Step] = [
     TargetedTestsStep(),  # 3 — diff-aware test selection + neg control
     FullUnitStep(),  # 4 — full pytest, gated on blast radius
     StressE2EBenchStep(),  # 5 — stress + e2e + bench (multi-model × agents)
-    # 5.5 — flake classification (dev-flow ③). Mostly advisory: it reads
-    # full-unit.log and re-runs only the tests that failed (a tiny set —
-    # usually zero), classifying flake-vs-real. It has ONE gating case —
-    # a quarantined test that reproduces deterministically on every re-run
-    # blocks (a regression the quarantine would otherwise mask). Placed
-    # AFTER every GATING step (full_unit, stress/e2e) on purpose: its
-    # re-runs can leak a detached descendant on macOS (no cgroup to
-    # contain a setsid escapee — see flake_tracking.py), so no gating step
-    # runs after it and such a leak can't contaminate one (codex #1222
-    # r7). Only the advisory diff_coverage follows — and running the gate
-    # before that 3-min coverage rerun gives fail-fast a cheaper exit.
-    # Still skipped under user-opted --fail-fast if an earlier gate
-    # already blocked (a known slice-1 limitation).
+    # 5.5 — flake classification (dev-flow ③). ADVISORY — never gates
+    # (every path returns pass/skip; the verdict cannot depend on it). It
+    # reads full-unit.log and re-runs only the tests that failed (a tiny
+    # set — usually zero), classifying flake-vs-real and loudly flagging a
+    # quarantined test that reproduced (a human de-quarantines; correlated
+    # in-process re-runs can't prove determinism, so we don't auto-block —
+    # see flake_tracking.py). Placed AFTER every step that spawns model
+    # servers / GPU workers (full_unit, stress/e2e) on purpose: its re-runs
+    # can leak a detached descendant on macOS (no cgroup to contain a
+    # setsid escapee), so nothing but the advisory diff_coverage runs after
+    # it and such a leak can't contaminate a later gate (codex #1222 r7).
     FlakeTrackingStep(),
     # 6 — ADVISORY patch-coverage measurement (never gates). Last on
     # purpose: it re-runs the FULL unit suite under coverage instrumentation

--- a/scripts/pr_validate/steps/fetch.py
+++ b/scripts/pr_validate/steps/fetch.py
@@ -22,6 +22,7 @@ import subprocess
 
 from ..base import Step, StepResult
 from ..context import Context
+from ..quarantine import snapshot_quarantine_registries
 
 
 class FetchStep(Step):
@@ -127,6 +128,16 @@ class FetchStep(Step):
                 summary="PR has merge conflicts (mergeStateStatus=DIRTY) — "
                 "rebase before validating",
             )
+
+        # Snapshot the quarantine registries HERE — fetch is the first step,
+        # git is clean, and NO candidate code has run yet. full_unit later
+        # reads the base/head registry from these cached blobs instead of
+        # re-invoking git after candidate tests, so a candidate that overwrites
+        # the git binary in place can't forge the allowlist (codex #1222 r36).
+        # base_sha/head_sha come from gh's baseRefOid/headRefOid (immutable,
+        # not candidate-controlled); a falsy SHA is skipped and full_unit's own
+        # fail-closed branch handles it. Never raises.
+        snapshot_quarantine_registries([ctx.base_sha, ctx.head_sha], ctx.repo_root)
 
         ctx.run_log(
             f"fetched: '{ctx.pr_title[:60]}' by {ctx.pr_author} "

--- a/scripts/pr_validate/steps/fetch.py
+++ b/scripts/pr_validate/steps/fetch.py
@@ -20,9 +20,15 @@ import shlex
 import shutil
 import subprocess
 
+from .._pytest_summary import render_fence_safe
 from ..base import Step, StepResult
 from ..context import Context
-from ..quarantine import snapshot_quarantine_registries
+from ..quarantine import (
+    QUARANTINE_REL_PATH,
+    QuarantineError,
+    load_quarantine_from_ref,
+    snapshot_quarantine_registries,
+)
 
 
 class FetchStep(Step):
@@ -138,6 +144,26 @@ class FetchStep(Step):
         # not candidate-controlled); a falsy SHA is skipped and full_unit's own
         # fail-closed branch handles it. Never raises.
         snapshot_quarantine_registries([ctx.base_sha, ctx.head_sha], ctx.repo_root)
+
+        # If THIS PR modifies quarantine.yaml, its committed (head) registry
+        # MUST parse. A green full_unit only READS the registry when a test
+        # fails, so a malformed candidate registry would otherwise merge
+        # undetected on a passing run and then fail-closed EVERY later PR's
+        # quarantine (their base load raises) (codex #1222 r39). The snapshot
+        # above already parsed + cached it; surface a malformed one here.
+        if QUARANTINE_REL_PATH in ctx.files_changed and ctx.head_sha:
+            try:
+                load_quarantine_from_ref(ctx.head_sha, ctx.repo_root)
+            except QuarantineError as e:
+                # The error text is candidate-controlled (it echoes the PR's
+                # own registry) — render it fence-safe (codex #1222 r25).
+                return StepResult(
+                    name=self.name,
+                    status="fail",
+                    summary="this PR's quarantine.yaml does not parse — fix it "
+                    "before merge (a green test run would not catch it)",
+                    details=f"malformed quarantine registry: {render_fence_safe(str(e))}",
+                )
 
         ctx.run_log(
             f"fetched: '{ctx.pr_title[:60]}' by {ctx.pr_author} "

--- a/scripts/pr_validate/steps/flake_tracking.py
+++ b/scripts/pr_validate/steps/flake_tracking.py
@@ -277,11 +277,16 @@ def _run_session(cmd: list[str], cwd: str, timeout: int) -> subprocess.Completed
 def _drain_bounded(proc: subprocess.Popen) -> tuple[str, str]:
     """Drain the child's pipes after a kill, but never block forever.
 
-    The normal case returns immediately (the group is dead). If a
-    descendant escaped the process group and still holds the write end
-    open, the bounded ``communicate`` raises again — we then re-kill,
-    force the pipes closed, and give up on the tail so the gate proceeds
-    instead of hanging (macOS has no cgroup to contain such an escape)."""
+    The normal case returns immediately (the group is dead) with the full
+    captured output. If a descendant escaped the process group and still
+    holds the write end open, the bounded ``communicate`` raises again —
+    we then re-kill, force the pipes closed, and REAP the direct child so
+    it can't be left a zombie (the group leader is already SIGKILLed, so
+    the bounded ``wait`` returns promptly — codex #1222 r4). The tail of
+    output is unrecoverable on this rare double-timeout path: CPython does
+    not expose the bytes buffered inside a timed-out ``communicate``, so
+    we return empties and rely on the module docstring's honest note that
+    a setsid-escaping descendant is not portably containable on macOS."""
     try:
         return proc.communicate(timeout=_DRAIN_TIMEOUT_S)
     except subprocess.TimeoutExpired:
@@ -292,6 +297,12 @@ def _drain_bounded(proc: subprocess.Popen) -> tuple[str, str]:
                     stream.close()
                 except OSError:
                     pass
+        # Reap the (already-killed) direct child; bounded so a wedged
+        # waitpid can't hang the gate either.
+        try:
+            proc.wait(timeout=_DRAIN_TIMEOUT_S)
+        except (subprocess.TimeoutExpired, OSError):
+            pass
         return "", ""
 
 

--- a/scripts/pr_validate/steps/flake_tracking.py
+++ b/scripts/pr_validate/steps/flake_tracking.py
@@ -80,7 +80,12 @@ from .. import _nodeid_reporter
 from .._pytest_summary import report_log_node_ids, summary_node_ids
 from ..base import Step, StepResult
 from ..context import Context
-from ..quarantine import QuarantineError, is_quarantined, load_quarantine_from_ref
+from ..quarantine import (
+    QuarantineError,
+    effective_quarantine,
+    is_quarantined,
+    load_quarantine_from_ref,
+)
 
 # Cap on how many failed ids we re-run. If main is broken with hundreds
 # of reds, re-running them all (× reruns) would blow the budget for no
@@ -184,15 +189,21 @@ class FlakeTrackingStep(Step):
                 ),
             )
 
-        # Report against the ACTIVE quarantine, read from the IMMUTABLE base
-        # SHA — same protected source full_unit's downgrade uses, and never
-        # the mutable branch ref a candidate could rewrite (codex #1222 r10).
-        # Fail-safe: no SHA / a broken registry just means "nothing
-        # known-flaky yet" for the advisory report.
+        # Report against the SAME effective quarantine full_unit enforces —
+        # base ∩ candidate (codex #1222 r22). Reading base-only would label a
+        # test the PR just DE-QUARANTINED as "known-flaky" (rode along) when
+        # full_unit actually BLOCKED it, so the advisory would contradict the
+        # gate. Base comes from the immutable base SHA, the candidate from the
+        # pinned head SHA — never the mutable branch ref a candidate could
+        # rewrite (codex r10). Fail-safe for this ADVISORY report: any unread
+        # side → empty ("nothing known-flaky yet"), which conservatively
+        # matches full_unit's fail-closed direction.
         entries = []
-        if ctx.base_sha:
+        if ctx.base_sha and ctx.head_sha:
             try:
-                entries = load_quarantine_from_ref(ctx.base_sha, ctx.repo_root)
+                base_entries = load_quarantine_from_ref(ctx.base_sha, ctx.repo_root)
+                cand_entries = load_quarantine_from_ref(ctx.head_sha, ctx.repo_root)
+                entries = effective_quarantine(base_entries, cand_entries)
             except QuarantineError:
                 entries = []
 

--- a/scripts/pr_validate/steps/flake_tracking.py
+++ b/scripts/pr_validate/steps/flake_tracking.py
@@ -587,8 +587,18 @@ def _run_session(
         # KeyboardInterrupt during cancellation, an OSError from the pipe,
         # anything — sweep the process group and bounded-reap the child so it
         # can't be orphaned, then propagate the original exception unchanged.
-        _kill_group(proc)
-        _drain_bounded(proc)
+        #
+        # BUT only killpg while the leader is demonstrably UNREAPED
+        # (``returncode is None``): ``communicate()`` may have already waited
+        # and reaped the child while unwinding a KeyboardInterrupt, and once
+        # reaped its pgid can be RECYCLED — a blind ``os.getpgid(proc.pid)`` +
+        # killpg could then SIGKILL an unrelated group (codex #1222 r38→r39;
+        # the same pgid-recycling hazard the timeout path avoids by construction
+        # since a timeout leaves the child unreaped). Reaped → nothing of ours
+        # is left to kill; skip straight to the re-raise.
+        if proc.returncode is None:
+            _kill_group(proc)
+            _drain_bounded(proc)
         raise
     return subprocess.CompletedProcess(cmd, proc.returncode, out, err)
 

--- a/scripts/pr_validate/steps/flake_tracking.py
+++ b/scripts/pr_validate/steps/flake_tracking.py
@@ -138,11 +138,18 @@ class FlakeTrackingStep(Step):
             )
 
     def _run(self, ctx: Context) -> StepResult:
-        # Clear any stale candidate artifact from a REUSED run dir up front —
-        # ``flake-candidates.json`` is (over)written only on the success path
-        # below, so a skip/error return would otherwise leave an earlier run's
-        # candidates in place and misrepresent this run (codex #1222 r37).
-        ctx.artifact_path("flake-candidates.json").unlink(missing_ok=True)
+        # Clear EVERY artifact this step generates from a REUSED run dir up
+        # front — each is written only on a path that may not be reached this
+        # run (``flake-candidates.json`` on the success path; the rerun log +
+        # nodeid tsv only once a rerun actually launches). A skip/error return
+        # before those points would otherwise leave an earlier run's files in
+        # place and misrepresent THIS run (codex #1222 r37 / r41 NIT).
+        for stale in (
+            "flake-candidates.json",
+            "flake-rerun.log",
+            "flake-rerun-nodeids.tsv",
+        ):
+            ctx.artifact_path(stale).unlink(missing_ok=True)
 
         log_path = ctx.artifact_path("full-unit.log")
         if not log_path.exists():

--- a/scripts/pr_validate/steps/flake_tracking.py
+++ b/scripts/pr_validate/steps/flake_tracking.py
@@ -77,7 +77,11 @@ import sys
 import traceback
 
 from .. import _nodeid_reporter
-from .._pytest_summary import report_log_node_ids, summary_node_ids
+from .._pytest_summary import (
+    report_log_node_ids,
+    session_completed,
+    summary_node_ids,
+)
 from ..base import Step, StepResult
 from ..context import Context
 from ..quarantine import (
@@ -327,6 +331,29 @@ class FlakeTrackingStep(Step):
         # Prefer the structured node-id log (exact ids); fall back to
         # scraping the summary only if the plugin didn't run (codex r10).
         if rerun_nodeids.exists():
+            # The structured rerun is only trustworthy on a COMPLETE session.
+            # A rerun truncated mid-flight (a sampled test's pytest.exit /
+            # os._exit, a crash) tears down fewer items than it collected, so
+            # its PASSED/FAILED set is partial: an id whose real reproduction
+            # was in the un-run tail could be mislabeled a recovered flake and
+            # wrongly recommended for a quarantine promotion. Prove
+            # completeness structurally from the reporter's session-finish
+            # record — the SAME check full_unit applies to the gate (codex
+            # #1222 r23) — and skip rather than emit a misleading advisory
+            # when the rerun didn't finish. A COMPLETE rerun holds whether the
+            # sampled tests passed (recovered) or failed (reproduced), so this
+            # doesn't suppress either legitimate signal.
+            if not session_completed(rerun_nodeids):
+                return StepResult(
+                    name=self.name,
+                    status="skip",
+                    summary=(
+                        "flake re-run did not run to completion "
+                        "(truncated session) — classification inconclusive, "
+                        "skipped"
+                    ),
+                    artifacts=[str(rerun_log)],
+                )
             passed = set(report_log_node_ids(rerun_nodeids, "PASSED"))
             still_bad = set(report_log_node_ids(rerun_nodeids, "FAILED", "ERROR"))
         else:

--- a/scripts/pr_validate/steps/flake_tracking.py
+++ b/scripts/pr_validate/steps/flake_tracking.py
@@ -1,13 +1,19 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Advisory step — flake tracking (dev-flow proposal item ③).
+"""Flake tracking (dev-flow proposal item ③).
 
-MEASURE-ONLY. This step never blocks a PR: every path returns ``pass``
-or ``skip`` (the base ``execute`` would turn an uncaught exception into a
-blocking ``error``, so ``run`` catches everything and downgrades to
-``skip``). It is the reporting half of the flake system whose gating half
-lives in ``full_unit`` (quarantine-aware) — here we surface *candidates*
-for that quarantine from real PR runs, so a human can promote a confirmed
-flake instead of hand-hunting for it.
+MOSTLY advisory: it surfaces flake *candidates* for the quarantine from
+real PR runs (so a human can promote a confirmed flake instead of
+hand-hunting for it), and it never lets its own crash block a PR — the
+base ``execute`` would turn an uncaught exception into a blocking
+``error``, so ``run`` catches everything and downgrades to ``skip``.
+
+It has exactly ONE gating case (codex #1222 r7): a test that is
+*quarantined* — so ``full_unit`` downgraded its failure to non-blocking —
+but then fails EVERY isolated re-run here is not flaky, it's a
+deterministic regression the quarantine would otherwise mask forever.
+That revokes the downgrade and BLOCKS. This closes the "quarantine
+graveyard" hole where an allowlisted test silently rots into a real
+regression. Every other outcome is advisory (``pass`` / ``skip``).
 
 Mechanism: after ``full_unit`` runs, read its log for the tests that
 failed, then re-run exactly those node ids in isolation with
@@ -81,9 +87,13 @@ _CLASSIFIABLE_EXITS = (0, 1)
 
 class FlakeTrackingStep(Step):
     name = "flake_tracking"
-    description = "advisory — classify full_unit failures as flake vs real"
-    # Advisory: an error here must not sink the PR. run() also catches
-    # everything itself; this is belt-and-suspenders with the runner.
+    description = (
+        "classify full_unit failures — blocks a deterministic quarantined regression"
+    )
+    # A CRASH here must never sink the PR (advisory heritage): run() also
+    # catches everything itself and downgrades to skip, so this step only
+    # ever emits a *deliberate* fail (the reproduced-quarantined gate) —
+    # never an error. continue_on_error stays True as belt-and-suspenders.
     continue_on_error = True
 
     def should_run(self, ctx: Context) -> bool:
@@ -245,11 +255,31 @@ class FlakeTrackingStep(Step):
             inconclusive,
             truncated,
         )
+
+        # The ONE gating case (codex #1222 r7): a quarantined test that
+        # full_unit downgraded to non-blocking, yet failed EVERY isolated
+        # re-run here, is not flaky — it's a deterministic regression the
+        # quarantine would otherwise mask forever ("quarantine graveyard").
+        # Revoke the downgrade and BLOCK. Everything else stays advisory.
+        if reproduced_known:
+            summary = (
+                f"{len(reproduced_known)} quarantined test(s) failed "
+                f"deterministically on {_RERUNS} re-run(s) — a regression, "
+                f"not a flake; fix the test or remove it from "
+                f"quarantine.yaml (blocking)"
+            )
+            return StepResult(
+                name=self.name,
+                status="fail",
+                summary=summary,
+                details=details,
+                artifacts=[str(cand_path), str(rerun_log)],
+            )
+
         summary = (
             f"{len(new_candidates)} new flake candidate(s), "
             f"{len(reproduced_new)} reproduced, "
             f"{len(known_flakes)} known-flaky, "
-            f"{len(reproduced_known)} quarantined-reproduced, "
             f"{len(inconclusive)} inconclusive — advisory"
         )
         return StepResult(

--- a/scripts/pr_validate/steps/flake_tracking.py
+++ b/scripts/pr_validate/steps/flake_tracking.py
@@ -138,6 +138,12 @@ class FlakeTrackingStep(Step):
             )
 
     def _run(self, ctx: Context) -> StepResult:
+        # Clear any stale candidate artifact from a REUSED run dir up front —
+        # ``flake-candidates.json`` is (over)written only on the success path
+        # below, so a skip/error return would otherwise leave an earlier run's
+        # candidates in place and misrepresent this run (codex #1222 r37).
+        ctx.artifact_path("flake-candidates.json").unlink(missing_ok=True)
+
         log_path = ctx.artifact_path("full-unit.log")
         if not log_path.exists():
             return StepResult(

--- a/scripts/pr_validate/steps/flake_tracking.py
+++ b/scripts/pr_validate/steps/flake_tracking.py
@@ -16,24 +16,34 @@ here (first try or after a rerun) is non-deterministic — a flake
 candidate. One that reproduces its failure is likely a real bug, and is
 reported as such (``full_unit`` already blocked on it).
 
-The re-run set is tiny (only the failures — usually zero), so a plain
-``subprocess.run`` with a timeout is enough; none of the bounded-tail /
-process-group machinery the full-suite ``diff_coverage`` run needs. If
-``pytest-rerunfailures`` is not installed, the step skips cleanly — the
-plugin is an optional [test]/[dev] extra, not a required one.
+Two soundness guards (codex #1222):
+  * Classification only runs when the re-run exits with a code we can
+    reason about (0 = all passed, 1 = some failed). Anything else
+    (collection error, crash, usage error) is inconclusive → we skip
+    rather than mislabel a real failure as a flake.
+  * The re-run is launched in its own session; on timeout the whole
+    process group is SIGKILLed (race-free — the leader is unreaped at
+    that point, so its pgid is still reserved), so a test that spawned
+    an inference server / GPU worker can't leak into later steps.
+
+If ``pytest-rerunfailures`` is not installed, the step skips cleanly —
+the plugin is an optional [test]/[dev] extra, not a required one.
 """
 
 from __future__ import annotations
 
 import importlib.util
 import json
+import os
+import signal
 import subprocess
 import sys
 import traceback
 
+from .._pytest_summary import summary_node_ids
 from ..base import Step, StepResult
 from ..context import Context
-from ..quarantine import QuarantineError, is_quarantined, load_quarantine
+from ..quarantine import QuarantineError, is_quarantined, load_quarantine_from_ref
 
 # Cap on how many failed ids we re-run. If main is broken with hundreds
 # of reds, re-running them all (× reruns) would blow the budget for no
@@ -41,6 +51,10 @@ from ..quarantine import QuarantineError, is_quarantined, load_quarantine
 _MAX_RERUN_IDS = 25
 _RERUNS = 3
 _RERUN_TIMEOUT_S = 900
+# pytest exit codes we can classify: 0 = all passed, 1 = some failed.
+# 2 (interrupted), 3 (internal), 4 (usage), 5 (no tests) are abnormal —
+# treating an unlisted id as "passed" would then mislabel real failures.
+_CLASSIFIABLE_EXITS = (0, 1)
 
 
 class FlakeTrackingStep(Step):
@@ -77,7 +91,7 @@ class FlakeTrackingStep(Step):
                 summary="no full-unit.log to classify",
             )
 
-        original_failed = _failed_ids(log_path.read_text())
+        original_failed = summary_node_ids(log_path.read_text(), "FAILED")
         if not original_failed:
             return StepResult(
                 name=self.name,
@@ -95,10 +109,13 @@ class FlakeTrackingStep(Step):
                 ),
             )
 
-        # Fail-safe: advisory, so a broken registry just means "nothing
-        # is known-flaky yet" for the purpose of the report.
+        # Report against the ACTIVE (protected base) quarantine, same
+        # source the gate uses. Fail-safe: a broken/absent registry just
+        # means "nothing known-flaky yet" for the report.
         try:
-            entries = load_quarantine()
+            entries = load_quarantine_from_ref(
+                ctx.base_sha or ctx.base_branch, ctx.repo_root
+            )
         except QuarantineError:
             entries = []
 
@@ -118,13 +135,7 @@ class FlakeTrackingStep(Step):
             "no:cacheprovider",
         ]
         try:
-            proc = subprocess.run(  # noqa: S603
-                cmd,
-                capture_output=True,
-                text=True,
-                cwd=str(ctx.repo_root),
-                timeout=_RERUN_TIMEOUT_S,
-            )
+            proc = _run_session(cmd, cwd=str(ctx.repo_root), timeout=_RERUN_TIMEOUT_S)
         except subprocess.TimeoutExpired:
             return StepResult(
                 name=self.name,
@@ -136,10 +147,25 @@ class FlakeTrackingStep(Step):
             )
         rerun_log.write_text((proc.stdout or "") + (proc.stderr or ""))
 
-        # A test that still failed/errored on isolated re-run (with
-        # reruns) reproduces → likely a real bug. Everything else in the
-        # sample passed this time → non-deterministic → flake candidate.
-        still_bad = set(_bad_ids(proc.stdout))
+        # Guard: only classify when the re-run exit code is one we can
+        # interpret. On an abnormal exit, "absent from FAILED/ERROR" no
+        # longer implies "passed" — bail rather than mislabel real
+        # failures as flakes (codex #1222).
+        if proc.returncode not in _CLASSIFIABLE_EXITS:
+            return StepResult(
+                name=self.name,
+                status="skip",
+                summary=(
+                    f"flake re-run exited abnormally (code {proc.returncode}) "
+                    f"— classification inconclusive, skipped"
+                ),
+                artifacts=[str(rerun_log)],
+            )
+
+        # A test still FAILED/ERRORed on isolated re-run (with reruns) →
+        # reproduces → likely a real bug. Everything else in the sample
+        # passed this time → non-deterministic → flake candidate.
+        still_bad = set(summary_node_ids(proc.stdout, "FAILED", "ERROR"))
         candidates = [i for i in sample if i not in still_bad]
         reproduced = [i for i in sample if i in still_bad]
 
@@ -171,6 +197,46 @@ class FlakeTrackingStep(Step):
             details=details,
             artifacts=[str(cand_path), str(rerun_log)],
         )
+
+
+def _run_session(cmd: list[str], cwd: str, timeout: int) -> subprocess.CompletedProcess:
+    """Run ``cmd`` in its own session and, on timeout, SIGKILL the whole
+    process group so test-spawned descendants (inference servers, GPU
+    workers) can't leak into later validation steps (codex #1222).
+
+    ``start_new_session=True`` makes the child a session/group leader
+    (pgid == pid). On timeout the child has not been reaped, so its pgid
+    is still reserved — killpg is race-free (the safe pre-reap case). We
+    kill BEFORE the final ``communicate`` so a descendant holding the
+    pipe open can't hang the drain.
+    """
+    proc = subprocess.Popen(  # noqa: S603
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        cwd=cwd,
+        start_new_session=True,
+    )
+    try:
+        out, err = proc.communicate(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        _kill_group(proc)
+        out, err = proc.communicate()
+        raise subprocess.TimeoutExpired(cmd, timeout, output=out, stderr=err)
+    return subprocess.CompletedProcess(cmd, proc.returncode, out, err)
+
+
+def _kill_group(proc: subprocess.Popen) -> None:
+    try:
+        os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+    except (ProcessLookupError, PermissionError, OSError):
+        # Group already gone, or getpgid raced the exit — best-effort
+        # kill the direct child and move on.
+        try:
+            proc.kill()
+        except OSError:
+            pass
 
 
 def _render(
@@ -206,42 +272,3 @@ def _render(
             f"re-run this pass._"
         )
     return "\n\n".join(parts) if parts else "no classification produced"
-
-
-def _failed_ids(text: str) -> list[str]:
-    """Node ids pytest labels FAILED in its short-summary section."""
-    return _summary_ids(text, prefixes=("FAILED",))
-
-
-def _bad_ids(text: str) -> list[str]:
-    """Node ids pytest labels FAILED or ERROR — an ERROR on re-run is
-    not a pass, so it counts as 'reproduced', not a flake candidate."""
-    return _summary_ids(text, prefixes=("FAILED", "ERROR"))
-
-
-def _summary_ids(text: str, prefixes: tuple[str, ...]) -> list[str]:
-    """Parse node ids out of pytest's short test summary block.
-
-    A summary line is ``<LABEL> <nodeid>[ - <message>]``; the node id is
-    everything between the label and the ``" - "`` message separator
-    (parametrized ids can hold spaces inside ``[...]``, so we split on
-    ``" - "`` rather than whitespace).
-    """
-    out: list[str] = []
-    in_summary = False
-    for line in (text or "").splitlines():
-        if "short test summary" in line:
-            in_summary = True
-            continue
-        if not in_summary:
-            continue
-        if line.startswith("="):
-            break
-        for prefix in prefixes:
-            if line.startswith(prefix + " "):
-                rest = line[len(prefix) + 1 :]
-                node_id = rest.split(" - ", 1)[0].strip()
-                if node_id:
-                    out.append(node_id)
-                break
-    return out

--- a/scripts/pr_validate/steps/flake_tracking.py
+++ b/scripts/pr_validate/steps/flake_tracking.py
@@ -298,9 +298,26 @@ class FlakeTrackingStep(Step):
         # it must be a reproduction, never a flake candidate. Subtracting
         # ``still_bad`` from the passed set makes the three buckets disjoint
         # and gives badness the last word.
-        candidates = [i for i in sample if i in passed and i not in still_bad]
+        #
+        # Collection-error targets need special handling (codex #1222 r17): a
+        # collection ERROR id is a MODULE / DIR path (no "::"), and on a clean
+        # re-run its CONTAINED tests log PASSED under their own "::"-bearing
+        # ids — the target id itself never logs a PASSED. So a collection
+        # flake that recovered would fall through to "inconclusive" forever.
+        # Treat a collection target that did NOT re-error (absent from
+        # still_bad) as a recovered flake candidate: it errored in the suite,
+        # collected cleanly in isolation → non-deterministic collection.
+        candidates = [
+            i
+            for i in sample
+            if i not in still_bad and (i in passed or _is_collection_target(i))
+        ]
         reproduced = [i for i in sample if i in still_bad]
-        inconclusive = [i for i in sample if i not in passed and i not in still_bad]
+        inconclusive = [
+            i
+            for i in sample
+            if i not in still_bad and i not in passed and not _is_collection_target(i)
+        ]
 
         # Split candidates by whether they're already covered.
         new_candidates = [i for i in candidates if not is_quarantined(i, entries)]
@@ -367,6 +384,15 @@ class FlakeTrackingStep(Step):
             details=details,
             artifacts=[str(cand_path), str(rerun_log)],
         )
+
+
+def _is_collection_target(node_id: str) -> bool:
+    """True for a collection-error id — a module / directory path with no
+    ``::`` test component. pytest reports a collection failure against the
+    module/dir, whose contained tests re-run under their own ``::`` ids, so
+    the target itself never logs a PASSED and needs recovery handled
+    explicitly (codex #1222 r17)."""
+    return "::" not in node_id
 
 
 def _run_session(

--- a/scripts/pr_validate/steps/flake_tracking.py
+++ b/scripts/pr_validate/steps/flake_tracking.py
@@ -152,15 +152,20 @@ class FlakeTrackingStep(Step):
             failed_only = summary_node_ids(text, "FAILED")
             error_only = summary_node_ids(text, "ERROR")
         failed_set = set(failed_only)
-        # Ids that appeared ONLY as ERROR (setup / teardown / collection).
-        # full_unit blocks any run containing an ERROR UNCONDITIONALLY (it
-        # never quarantines what it couldn't even complete), so promoting one
-        # of these to quarantine.yaml would be INEFFECTIVE — a quarantine
-        # entry can't waive an ERROR run. Track their origin so a recovered
-        # ERROR flake is reported in its own "investigate, not quarantinable"
-        # bucket rather than recommended for a promotion that wouldn't work
-        # (codex #1222 r18).
-        error_origin = {i for i in error_only if i not in failed_set}
+        # Ids that logged an ERROR in ANY phase (setup / call / teardown /
+        # collection). full_unit blocks any run containing an ERROR
+        # UNCONDITIONALLY (it never quarantines what it couldn't even
+        # complete), so promoting one of these to quarantine.yaml would be
+        # INEFFECTIVE — a quarantine entry can't waive an ERROR run. This
+        # deliberately includes an id that ALSO logged a FAILED — a call
+        # failure followed by a teardown ERROR: the ERROR still makes the
+        # whole run un-waivable, so it is error-origin regardless of the
+        # FAILED (codex #1222 r19 — excluding failed_set here would mislabel
+        # such an id as a quarantinable flake). Track their origin so a
+        # recovered ERROR flake is reported in its own "investigate, not
+        # quarantinable" bucket rather than recommended for a promotion that
+        # wouldn't work.
+        error_origin = set(error_only)
         original_failed = failed_only + [i for i in error_only if i not in failed_set]
         if not original_failed:
             return StepResult(
@@ -327,7 +332,7 @@ class FlakeTrackingStep(Step):
         # gives badness the last word.
         #
         # Collection-error targets need special handling (codex #1222 r17): a
-        # collection ERROR id is a MODULE / DIR path (no "::"), and on a clean
+        # collection ERROR id is a MODULE or DIR path (no "::"), and on a clean
         # re-run its CONTAINED tests log PASSED under their own "::"-bearing
         # ids — the target id itself never logs a PASSED. So a recovered
         # collection flake would fall through to "inconclusive" forever.
@@ -335,11 +340,21 @@ class FlakeTrackingStep(Step):
         # actually PASSED — not merely on the absence of a re-error (codex
         # #1222 r18): a module that collected nothing or only skipped is
         # inconclusive, not a proven flake, same as any other id.
+        #
+        # A MODULE target (``tests/test_x.py``) contains tests at the ``::``
+        # boundary (``tests/test_x.py::test_y``); a DIRECTORY target
+        # (``tests/subdir``) contains them at the ``/`` boundary
+        # (``tests/subdir/test_x.py::test_y``) and would NEVER satisfy a
+        # ``::`` check, leaving genuine directory-collection flakes forever
+        # inconclusive (codex #1222 r19). Accept a passed descendant at
+        # EITHER boundary — both are true containment, and the required
+        # separator (``::`` or ``/``) prevents a sibling-prefix false match
+        # (``tests/foo.py`` is not a descendant of dir ``tests/foo``).
         def _recovered(i: str) -> bool:
             if i in passed:
                 return True
             return _is_collection_target(i) and any(
-                p.startswith(i + "::") for p in passed
+                p.startswith(i + "::") or p.startswith(i + "/") for p in passed
             )
 
         candidates = [i for i in sample if i not in still_bad and _recovered(i)]

--- a/scripts/pr_validate/steps/flake_tracking.py
+++ b/scripts/pr_validate/steps/flake_tracking.py
@@ -78,6 +78,7 @@ import traceback
 
 from .. import _nodeid_reporter
 from .._pytest_summary import (
+    render_fence_safe,
     report_log_node_ids,
     session_completed,
     summary_node_ids,
@@ -156,10 +157,17 @@ class FlakeTrackingStep(Step):
         if nodeid_log.exists():
             failed_only = report_log_node_ids(nodeid_log, "FAILED")
             error_only = report_log_node_ids(nodeid_log, "ERROR")
+            # Ids the reporter tagged as COLLECTION targets (module / dir /
+            # CLASS collectors). A class collector id contains "::"
+            # (`tests/x.py::TestClass`), which the "::"-absence heuristic
+            # misses, so recovery detection consults this structured set too
+            # (codex #1222 r24). Absent on the summary-fallback path below.
+            collect_targets = set(report_log_node_ids(nodeid_log, "COLLECTERROR"))
         else:
             text = log_path.read_text()
             failed_only = summary_node_ids(text, "FAILED")
             error_only = summary_node_ids(text, "ERROR")
+            collect_targets = set()
         failed_set = set(failed_only)
         # Ids that logged an ERROR in ANY phase (setup / call / teardown /
         # collection). full_unit blocks any run containing an ERROR
@@ -391,7 +399,13 @@ class FlakeTrackingStep(Step):
         def _recovered(i: str) -> bool:
             if i in passed:
                 return True
-            return _is_collection_target(i) and any(
+            # A collection target is recovered on POSITIVE evidence — a
+            # contained test passed. Recognize the target by EITHER the
+            # "::"-absence heuristic (module / dir, works on the fallback
+            # path) OR the structured COLLECTERROR set (also catches a class
+            # collector whose id contains "::" — codex #1222 r24).
+            is_collection = _is_collection_target(i) or i in collect_targets
+            return is_collection and any(
                 p.startswith(i + "::") or p.startswith(i + "/") for p in passed
             )
 
@@ -419,14 +433,25 @@ class FlakeTrackingStep(Step):
             if i not in error_origin and is_quarantined(i, entries)
         ]
 
-        # Split reproductions the same way: a NON-quarantined test that
-        # reproduces is a real failure full_unit blocked on. A QUARANTINED
-        # one reproduced deterministically here — full_unit PASSED it as
-        # non-blocking, so it's NOT something the gate blocked on; flag it
-        # separately as "quarantine may be masking a now-deterministic
-        # bug" rather than mislabeling it (codex #1222 r5).
-        reproduced_new = [i for i in reproduced if not is_quarantined(i, entries)]
-        reproduced_known = [i for i in reproduced if is_quarantined(i, entries)]
+        # Split reproductions the same way, but an ERROR-origin id is NEVER
+        # "reproduced_quarantined" even if it's in the registry: full_unit
+        # blocks ANY run containing an ERROR unconditionally, so the
+        # quarantine never actually waived it — labeling it "full_unit PASSED
+        # this as quarantined" would be false. Route ERROR-origin
+        # reproductions to reproduced_likely_real (the gate DID block them),
+        # matching the r18/r19 error-origin discipline (codex #1222 r24).
+        # A NON-quarantined (or error-origin) reproduction is a real failure
+        # full_unit blocked on; a quarantined, non-error one reproduced
+        # deterministically while full_unit PASSED it as non-blocking — flag
+        # that separately as "quarantine may be masking a now-deterministic
+        # bug" (codex #1222 r5).
+        reproduced_known = [
+            i
+            for i in reproduced
+            if is_quarantined(i, entries) and i not in error_origin
+        ]
+        reproduced_known_set = set(reproduced_known)
+        reproduced_new = [i for i in reproduced if i not in reproduced_known_set]
 
         payload = {
             "original_failed": original_failed,
@@ -592,12 +617,19 @@ def _render(
     sampled: int,
     total: int,
 ) -> str:
+    # Every node id below is interpolated into a Markdown ``` code fence.
+    # report.nodeid can embed a newline/backticks (a hostile
+    # pytest_make_parametrize_id), which raw could break out of the fence and
+    # spoof scorecard content — render each id fence-safe (codex #1222 r24).
+    def _fence(ids: list[str]) -> str:
+        return "\n".join(render_fence_safe(i) for i in ids)
+
     parts: list[str] = []
     if new_candidates:
         parts.append(
             "**New flake candidates** (failed the full suite, passed on "
             "isolated re-run — consider promoting to `quarantine.yaml` "
-            "after confirming):\n```\n" + "\n".join(new_candidates) + "\n```"
+            "after confirming):\n```\n" + _fence(new_candidates) + "\n```"
         )
     if error_candidates:
         parts.append(
@@ -606,13 +638,13 @@ def _render(
             "isolated re-run — so non-deterministic, but `full_unit` blocks "
             "ANY run containing an ERROR unconditionally, so a `quarantine.yaml`"
             " entry would NOT waive these; fix the fixture / collection or the "
-            "code):\n```\n" + "\n".join(error_candidates) + "\n```"
+            "code):\n```\n" + _fence(error_candidates) + "\n```"
         )
     if reproduced_new:
         parts.append(
             "**Reproduced on re-run** (failure is deterministic — likely a "
             "real bug, NOT a flake; `full_unit` blocked on these):\n```\n"
-            + "\n".join(reproduced_new)
+            + _fence(reproduced_new)
             + "\n```"
         )
     if reproduced_known:
@@ -621,19 +653,19 @@ def _render(
             "PASSED these as quarantined, but they failed every re-run here "
             "— the quarantine may be masking a now-deterministic bug; "
             "re-check whether the entry still belongs in `quarantine.yaml`):"
-            "\n```\n" + "\n".join(reproduced_known) + "\n```"
+            "\n```\n" + _fence(reproduced_known) + "\n```"
         )
     if known_flakes:
         parts.append(
             "**Already quarantined** (confirmed still flaky):\n```\n"
-            + "\n".join(known_flakes)
+            + _fence(known_flakes)
             + "\n```"
         )
     if inconclusive:
         parts.append(
             "**Inconclusive** (didn't positively pass or fail on isolated "
             "re-run — skipped, deselected, or not collected; NOT classified "
-            "as a flake):\n```\n" + "\n".join(inconclusive) + "\n```"
+            "as a flake):\n```\n" + _fence(inconclusive) + "\n```"
         )
     if total > sampled:
         parts.append(

--- a/scripts/pr_validate/steps/flake_tracking.py
+++ b/scripts/pr_validate/steps/flake_tracking.py
@@ -561,6 +561,12 @@ def _run_session(
     pipe open can't hang the drain, and the drain itself is time-bounded
     so even a group-escaping descendant can't wedge the gate (codex
     #1222 r2).
+
+    The SAME sweep must run on ANY non-timeout exit from ``communicate`` —
+    most importantly a ``KeyboardInterrupt`` when the operator Ctrl-C's the
+    gate mid-rerun. Without it, pytest and its GPU/inference descendants
+    would outlive the interrupted gate. So a ``BaseException`` handler kills
+    the group + bounded-reaps, then re-raises the original (codex #1222 r38).
     """
     proc = subprocess.Popen(  # noqa: S603
         cmd,
@@ -577,6 +583,13 @@ def _run_session(
         _kill_group(proc)
         out, err = _drain_bounded(proc)
         raise subprocess.TimeoutExpired(cmd, timeout, output=out, stderr=err)
+    except BaseException:
+        # KeyboardInterrupt during cancellation, an OSError from the pipe,
+        # anything — sweep the process group and bounded-reap the child so it
+        # can't be orphaned, then propagate the original exception unchanged.
+        _kill_group(proc)
+        _drain_bounded(proc)
+        raise
     return subprocess.CompletedProcess(cmd, proc.returncode, out, err)
 
 

--- a/scripts/pr_validate/steps/flake_tracking.py
+++ b/scripts/pr_validate/steps/flake_tracking.py
@@ -163,15 +163,19 @@ class FlakeTrackingStep(Step):
         except QuarantineError:
             entries = []
 
-        # Cap the re-run set, but check EVERY quarantined failure first
-        # (codex #1222 r8 nit): a graveyard candidate — a quarantined test
-        # that may have stopped flaking — is the highest-value review
-        # signal, so it must never be dropped by the cap just because it
-        # sorted past the 25th id. The cap then applies to the advisory
-        # non-quarantined remainder.
+        # Check EVERY quarantined failure, then fill the rest of the cap
+        # with non-quarantined candidates (codex #1222 r8→r9 nit): a
+        # graveyard candidate — a quarantined test that may have stopped
+        # flaking — is the highest-value review signal, so it must NEVER be
+        # dropped by the cap. The cap bounds only the advisory
+        # non-quarantined remainder; if quarantined failures alone exceed
+        # _MAX_RERUN_IDS we re-run all of them anyway (they're the whole
+        # point). In practice the human-curated registry is tiny, so this
+        # is a handful at most.
         q_failed = [i for i in original_failed if is_quarantined(i, entries)]
         other_failed = [i for i in original_failed if not is_quarantined(i, entries)]
-        sample = (q_failed + other_failed)[:_MAX_RERUN_IDS]
+        remaining = max(0, _MAX_RERUN_IDS - len(q_failed))
+        sample = q_failed + other_failed[:remaining]
         truncated = len(original_failed) - len(sample)
 
         rerun_log = ctx.artifact_path("flake-rerun.log")

--- a/scripts/pr_validate/steps/flake_tracking.py
+++ b/scripts/pr_validate/steps/flake_tracking.py
@@ -212,25 +212,41 @@ class FlakeTrackingStep(Step):
         new_candidates = [i for i in candidates if not is_quarantined(i, entries)]
         known_flakes = [i for i in candidates if is_quarantined(i, entries)]
 
+        # Split reproductions the same way: a NON-quarantined test that
+        # reproduces is a real failure full_unit blocked on. A QUARANTINED
+        # one reproduced deterministically here — full_unit PASSED it as
+        # non-blocking, so it's NOT something the gate blocked on; flag it
+        # separately as "quarantine may be masking a now-deterministic
+        # bug" rather than mislabeling it (codex #1222 r5).
+        reproduced_new = [i for i in reproduced if not is_quarantined(i, entries)]
+        reproduced_known = [i for i in reproduced if is_quarantined(i, entries)]
+
         payload = {
             "original_failed": original_failed,
             "sampled": sample,
             "truncated": truncated,
             "flake_candidates_new": new_candidates,
             "flake_candidates_known": known_flakes,
-            "reproduced_likely_real": reproduced,
+            "reproduced_likely_real": reproduced_new,
+            "reproduced_quarantined": reproduced_known,
             "inconclusive": inconclusive,
         }
         cand_path = ctx.artifact_path("flake-candidates.json")
         cand_path.write_text(json.dumps(payload, indent=2))
 
         details = _render(
-            new_candidates, known_flakes, reproduced, inconclusive, truncated
+            new_candidates,
+            known_flakes,
+            reproduced_new,
+            reproduced_known,
+            inconclusive,
+            truncated,
         )
         summary = (
             f"{len(new_candidates)} new flake candidate(s), "
-            f"{len(reproduced)} reproduced, "
+            f"{len(reproduced_new)} reproduced, "
             f"{len(known_flakes)} known-flaky, "
+            f"{len(reproduced_known)} quarantined-reproduced, "
             f"{len(inconclusive)} inconclusive — advisory"
         )
         return StepResult(
@@ -321,7 +337,8 @@ def _kill_group(proc: subprocess.Popen) -> None:
 def _render(
     new_candidates: list[str],
     known_flakes: list[str],
-    reproduced: list[str],
+    reproduced_new: list[str],
+    reproduced_known: list[str],
     inconclusive: list[str],
     truncated: int,
 ) -> str:
@@ -332,12 +349,20 @@ def _render(
             "isolated re-run — consider promoting to `quarantine.yaml` "
             "after confirming):\n```\n" + "\n".join(new_candidates) + "\n```"
         )
-    if reproduced:
+    if reproduced_new:
         parts.append(
             "**Reproduced on re-run** (failure is deterministic — likely a "
             "real bug, NOT a flake; `full_unit` blocked on these):\n```\n"
-            + "\n".join(reproduced)
+            + "\n".join(reproduced_new)
             + "\n```"
+        )
+    if reproduced_known:
+        parts.append(
+            "**Quarantined but reproduced deterministically** (`full_unit` "
+            "PASSED these as quarantined, but they failed every re-run here "
+            "— the quarantine may be masking a now-deterministic bug; "
+            "re-check whether the entry still belongs in `quarantine.yaml`):"
+            "\n```\n" + "\n".join(reproduced_known) + "\n```"
         )
     if known_flakes:
         parts.append(

--- a/scripts/pr_validate/steps/flake_tracking.py
+++ b/scripts/pr_validate/steps/flake_tracking.py
@@ -145,9 +145,23 @@ class FlakeTrackingStep(Step):
         # r15 NIT).
         nodeid_log = ctx.artifact_path("full-unit-nodeids.tsv")
         if nodeid_log.exists():
-            original_failed = report_log_node_ids(nodeid_log, "FAILED", "ERROR")
+            failed_only = report_log_node_ids(nodeid_log, "FAILED")
+            error_only = report_log_node_ids(nodeid_log, "ERROR")
         else:
-            original_failed = summary_node_ids(log_path.read_text(), "FAILED", "ERROR")
+            text = log_path.read_text()
+            failed_only = summary_node_ids(text, "FAILED")
+            error_only = summary_node_ids(text, "ERROR")
+        failed_set = set(failed_only)
+        # Ids that appeared ONLY as ERROR (setup / teardown / collection).
+        # full_unit blocks any run containing an ERROR UNCONDITIONALLY (it
+        # never quarantines what it couldn't even complete), so promoting one
+        # of these to quarantine.yaml would be INEFFECTIVE — a quarantine
+        # entry can't waive an ERROR run. Track their origin so a recovered
+        # ERROR flake is reported in its own "investigate, not quarantinable"
+        # bucket rather than recommended for a promotion that wouldn't work
+        # (codex #1222 r18).
+        error_origin = {i for i in error_only if i not in failed_set}
+        original_failed = failed_only + [i for i in error_only if i not in failed_set]
         if not original_failed:
             return StepResult(
                 name=self.name,
@@ -234,6 +248,18 @@ class FlakeTrackingStep(Step):
         # otherwise (codex #1222 r16). Done regardless of plugin availability.
         rerun_env = dict(os.environ)
         rerun_env.pop("PYTEST_ADDOPTS", None)
+        # pytest-rerunfailures provides ``--reruns``. It autoloads by entry
+        # point (registered under the name "rerunfailures") UNLESS
+        # PYTEST_DISABLE_PLUGIN_AUTOLOAD is set. Add an explicit ``-p`` ONLY
+        # when autoload is off: a redundant ``-p`` on an already-autoloaded
+        # plugin is NOT a no-op — pluggy raises "Plugin already registered
+        # under a different name" because the entry-point name (rerunfailures)
+        # differs from the module name (pytest_rerunfailures), which crashes
+        # the whole advisory re-run (codex #1222 r18 regression, fixed r19).
+        # find_spec confirmed it's importable above, so the -p can't
+        # ImportError when we do add it.
+        if rerun_env.get("PYTEST_DISABLE_PLUGIN_AUTOLOAD"):
+            cmd += ["-p", "pytest_rerunfailures"]
         # Emit the structured node-id log (with PASSED, which the classifier
         # needs) so flake-vs-real is decided on exact ids, not summary text.
         if _nodeid_reporter.available():
@@ -290,38 +316,55 @@ class FlakeTrackingStep(Step):
         else:
             passed = set(summary_node_ids(proc.stdout, "PASSED"))
             still_bad = set(summary_node_ids(proc.stdout, "FAILED", "ERROR"))
+
         # FAILED/ERROR takes PRECEDENCE over PASSED for the same node id
         # (codex #1222 r12): a test whose call PASSES but whose teardown
         # ERRORs emits BOTH a PASSED and an ERROR line (they're different
         # pytest phases), and a test can likewise fail then pass across
         # phases. Such a run is NOT "green on re-run" — it ended badly — so
         # it must be a reproduction, never a flake candidate. Subtracting
-        # ``still_bad`` from the passed set makes the three buckets disjoint
-        # and gives badness the last word.
+        # ``still_bad`` from the passed set makes the buckets disjoint and
+        # gives badness the last word.
         #
         # Collection-error targets need special handling (codex #1222 r17): a
         # collection ERROR id is a MODULE / DIR path (no "::"), and on a clean
         # re-run its CONTAINED tests log PASSED under their own "::"-bearing
-        # ids — the target id itself never logs a PASSED. So a collection
-        # flake that recovered would fall through to "inconclusive" forever.
-        # Treat a collection target that did NOT re-error (absent from
-        # still_bad) as a recovered flake candidate: it errored in the suite,
-        # collected cleanly in isolation → non-deterministic collection.
-        candidates = [
-            i
-            for i in sample
-            if i not in still_bad and (i in passed or _is_collection_target(i))
-        ]
-        reproduced = [i for i in sample if i in still_bad]
-        inconclusive = [
-            i
-            for i in sample
-            if i not in still_bad and i not in passed and not _is_collection_target(i)
-        ]
+        # ids — the target id itself never logs a PASSED. So a recovered
+        # collection flake would fall through to "inconclusive" forever.
+        # Treat it as recovered ONLY on POSITIVE evidence — a contained test
+        # actually PASSED — not merely on the absence of a re-error (codex
+        # #1222 r18): a module that collected nothing or only skipped is
+        # inconclusive, not a proven flake, same as any other id.
+        def _recovered(i: str) -> bool:
+            if i in passed:
+                return True
+            return _is_collection_target(i) and any(
+                p.startswith(i + "::") for p in passed
+            )
 
-        # Split candidates by whether they're already covered.
-        new_candidates = [i for i in candidates if not is_quarantined(i, entries)]
-        known_flakes = [i for i in candidates if is_quarantined(i, entries)]
+        candidates = [i for i in sample if i not in still_bad and _recovered(i)]
+        reproduced = [i for i in sample if i in still_bad]
+        cand_set = set(candidates)
+        inconclusive = [i for i in sample if i not in still_bad and i not in cand_set]
+
+        # Split candidates three ways (codex #1222 r18): an ERROR-origin flake
+        # can NOT be quarantined — full_unit blocks any run containing an
+        # ERROR unconditionally, so a quarantine entry would never waive it.
+        # Report those separately as "investigate / fix the root cause"
+        # instead of recommending an ineffective promotion. The remaining
+        # (call-phase FAILED) candidates split by whether they're already
+        # covered, as before.
+        error_candidates = [i for i in candidates if i in error_origin]
+        new_candidates = [
+            i
+            for i in candidates
+            if i not in error_origin and not is_quarantined(i, entries)
+        ]
+        known_flakes = [
+            i
+            for i in candidates
+            if i not in error_origin and is_quarantined(i, entries)
+        ]
 
         # Split reproductions the same way: a NON-quarantined test that
         # reproduces is a real failure full_unit blocked on. A QUARANTINED
@@ -338,6 +381,7 @@ class FlakeTrackingStep(Step):
             "truncated": truncated,
             "flake_candidates_new": new_candidates,
             "flake_candidates_known": known_flakes,
+            "error_flake_candidates": error_candidates,
             "reproduced_likely_real": reproduced_new,
             "reproduced_quarantined": reproduced_known,
             "inconclusive": inconclusive,
@@ -348,6 +392,7 @@ class FlakeTrackingStep(Step):
         details = _render(
             new_candidates,
             known_flakes,
+            error_candidates,
             reproduced_new,
             reproduced_known,
             inconclusive,
@@ -370,9 +415,15 @@ class FlakeTrackingStep(Step):
             if reproduced_known
             else ""
         )
+        error_note = (
+            f"{len(error_candidates)} error-flake(s) [not quarantinable], "
+            if error_candidates
+            else ""
+        )
         summary = (
             f"{review}"
             f"{len(new_candidates)} new flake candidate(s), "
+            f"{error_note}"
             f"{len(reproduced_new)} reproduced, "
             f"{len(known_flakes)} known-flaky, "
             f"{len(inconclusive)} inconclusive — advisory"
@@ -480,6 +531,7 @@ def _kill_group(proc: subprocess.Popen) -> None:
 def _render(
     new_candidates: list[str],
     known_flakes: list[str],
+    error_candidates: list[str],
     reproduced_new: list[str],
     reproduced_known: list[str],
     inconclusive: list[str],
@@ -493,6 +545,15 @@ def _render(
             "**New flake candidates** (failed the full suite, passed on "
             "isolated re-run — consider promoting to `quarantine.yaml` "
             "after confirming):\n```\n" + "\n".join(new_candidates) + "\n```"
+        )
+    if error_candidates:
+        parts.append(
+            "**Error flakes — investigate, NOT quarantinable** (errored "
+            "(setup / teardown / collection) in the full suite, recovered on "
+            "isolated re-run — so non-deterministic, but `full_unit` blocks "
+            "ANY run containing an ERROR unconditionally, so a `quarantine.yaml`"
+            " entry would NOT waive these; fix the fixture / collection or the "
+            "code):\n```\n" + "\n".join(error_candidates) + "\n```"
         )
     if reproduced_new:
         parts.append(

--- a/scripts/pr_validate/steps/flake_tracking.py
+++ b/scripts/pr_validate/steps/flake_tracking.py
@@ -29,9 +29,20 @@ Soundness guards (codex #1222):
     rather than mislabel a real failure as a flake.
   * The re-run is launched in its own session; on timeout the whole
     process group is SIGKILLed (race-free — the leader is unreaped at
-    that point, so its pgid is still reserved), and the post-kill output
-    drain is time-bounded, so a test that spawned an inference server /
-    GPU worker can neither leak into later steps nor wedge the gate.
+    that point, so its pgid is still reserved), sweeping in-group
+    descendants, and the post-kill drain is time-bounded so it can't
+    WEDGE the gate.
+
+Containment is best-effort, not absolute (codex #1222 r3, honestly
+scoped): a descendant that escapes its group via its own ``setsid()``,
+or a detached-stdio survivor of a *normally*-exiting re-run, is not
+portably reapable on macOS — there is no cgroup / job object, and once
+the group leader is reaped pgid recycling makes a post-reap ``killpg``
+unsafe (it could SIGKILL an unrelated, recycled group). We do NOT sweep
+after normal completion for that reason; this is the same trade-off
+accepted in #1220. In practice a pytest re-run does neither of these,
+and this step is advisory (never gates), so the residual leak is
+tolerated rather than papered over with an unsafe kill.
 
 If ``pytest-rerunfailures`` is not installed, the step skips cleanly —
 the plugin is an optional [test]/[dev] extra, not a required one.
@@ -154,7 +165,11 @@ class FlakeTrackingStep(Step):
         ]
         try:
             proc = _run_session(cmd, cwd=str(ctx.repo_root), timeout=_RERUN_TIMEOUT_S)
-        except subprocess.TimeoutExpired:
+        except subprocess.TimeoutExpired as e:
+            # Persist whatever we drained before the kill so a human can
+            # see which re-run hung, instead of discarding it (codex
+            # #1222 r3). _run_session attaches the partial output/stderr.
+            rerun_log.write_text((e.output or "") + (e.stderr or ""))
             return StepResult(
                 name=self.name,
                 status="skip",
@@ -162,6 +177,7 @@ class FlakeTrackingStep(Step):
                     f"flake re-run exceeded {_RERUN_TIMEOUT_S}s on "
                     f"{len(sample)} test(s) — skipped (non-blocking)"
                 ),
+                artifacts=[str(rerun_log)],
             )
         rerun_log.write_text((proc.stdout or "") + (proc.stderr or ""))
 
@@ -228,8 +244,10 @@ class FlakeTrackingStep(Step):
 
 def _run_session(cmd: list[str], cwd: str, timeout: int) -> subprocess.CompletedProcess:
     """Run ``cmd`` in its own session and, on timeout, SIGKILL the whole
-    process group so test-spawned descendants (inference servers, GPU
-    workers) can't leak into later validation steps (codex #1222).
+    process group so in-group test-spawned descendants (inference
+    servers, GPU workers) are swept before later validation steps
+    (codex #1222). Best-effort: a setsid-escaping descendant is not
+    portably containable on macOS — see the module docstring.
 
     ``start_new_session=True`` makes the child a session/group leader
     (pgid == pid). On timeout the child has not been reaped, so its pgid

--- a/scripts/pr_validate/steps/flake_tracking.py
+++ b/scripts/pr_validate/steps/flake_tracking.py
@@ -278,16 +278,28 @@ class FlakeTrackingStep(Step):
         rerun_env.pop("PYTEST_ADDOPTS", None)
         # pytest-rerunfailures provides ``--reruns``. It autoloads by entry
         # point (registered under the name "rerunfailures") UNLESS
-        # PYTEST_DISABLE_PLUGIN_AUTOLOAD is set. Add an explicit ``-p`` ONLY
-        # when autoload is off: a redundant ``-p`` on an already-autoloaded
-        # plugin is NOT a no-op — pluggy raises "Plugin already registered
-        # under a different name" because the entry-point name (rerunfailures)
-        # differs from the module name (pytest_rerunfailures), which crashes
-        # the whole advisory re-run (codex #1222 r18 regression, fixed r19).
-        # find_spec confirmed it's importable above, so the -p can't
-        # ImportError when we do add it.
+        # PYTEST_DISABLE_PLUGIN_AUTOLOAD is set. When autoload is OFF we do not
+        # try to hand-load it: even a correct ``-p pytest_rerunfailures`` would
+        # revive only --reruns while the project's OTHER required plugins
+        # (pytest-asyncio, …) stay disabled — so an async / plugin-dependent
+        # test would ERROR on re-run and be misclassified as reproduced /
+        # inconclusive instead of a flake (codex #1222 r32). We can't reliably
+        # enumerate every required plugin here (test_env_check owns that, and
+        # not all are ``-p`` loadable), and a redundant ``-p`` on an
+        # already-autoloaded plugin is itself a crash ("Plugin already
+        # registered under a different name", codex #1222 r18/r19). So rather
+        # than emit a wrong advisory signal we SKIP — this step is best-effort
+        # and never gates.
         if rerun_env.get("PYTEST_DISABLE_PLUGIN_AUTOLOAD"):
-            cmd += ["-p", "pytest_rerunfailures"]
+            return StepResult(
+                name=self.name,
+                status="skip",
+                summary=(
+                    "flake re-run skipped — PYTEST_DISABLE_PLUGIN_AUTOLOAD is "
+                    "set, so a faithful re-run of plugin-dependent tests "
+                    "(pytest-asyncio, …) can't be guaranteed (advisory)"
+                ),
+            )
         # Emit the structured node-id log (with PASSED, which the classifier
         # needs) so flake-vs-real is decided on exact ids, not summary text.
         if _nodeid_reporter.available():

--- a/scripts/pr_validate/steps/flake_tracking.py
+++ b/scripts/pr_validate/steps/flake_tracking.py
@@ -76,7 +76,8 @@ import subprocess
 import sys
 import traceback
 
-from .._pytest_summary import summary_node_ids
+from .. import _nodeid_reporter
+from .._pytest_summary import report_log_node_ids, summary_node_ids
 from ..base import Step, StepResult
 from ..context import Context
 from ..quarantine import QuarantineError, is_quarantined, load_quarantine_from_ref
@@ -135,7 +136,13 @@ class FlakeTrackingStep(Step):
                 summary="no full-unit.log to classify",
             )
 
-        original_failed = summary_node_ids(log_path.read_text(), "FAILED")
+        # Prefer full_unit's STRUCTURED node-id log (exact ids); fall back
+        # to scraping its text log only if the plugin didn't run there.
+        nodeid_log = ctx.artifact_path("full-unit-nodeids.tsv")
+        if nodeid_log.exists():
+            original_failed = report_log_node_ids(nodeid_log, "FAILED")
+        else:
+            original_failed = summary_node_ids(log_path.read_text(), "FAILED")
         if not original_failed:
             return StepResult(
                 name=self.name,
@@ -153,15 +160,17 @@ class FlakeTrackingStep(Step):
                 ),
             )
 
-        # Report against the ACTIVE (protected base) quarantine, same
-        # source full_unit's downgrade uses. Fail-safe: a broken/absent
-        # registry just means "nothing known-flaky yet" for the report.
-        try:
-            entries = load_quarantine_from_ref(
-                ctx.base_sha or ctx.base_branch, ctx.repo_root
-            )
-        except QuarantineError:
-            entries = []
+        # Report against the ACTIVE quarantine, read from the IMMUTABLE base
+        # SHA — same protected source full_unit's downgrade uses, and never
+        # the mutable branch ref a candidate could rewrite (codex #1222 r10).
+        # Fail-safe: no SHA / a broken registry just means "nothing
+        # known-flaky yet" for the advisory report.
+        entries = []
+        if ctx.base_sha:
+            try:
+                entries = load_quarantine_from_ref(ctx.base_sha, ctx.repo_root)
+            except QuarantineError:
+                entries = []
 
         # Check EVERY quarantined failure, then fill the rest of the cap
         # with non-quarantined candidates (codex #1222 r8→r9 nit): a
@@ -179,6 +188,9 @@ class FlakeTrackingStep(Step):
         truncated = len(original_failed) - len(sample)
 
         rerun_log = ctx.artifact_path("flake-rerun.log")
+        rerun_nodeids = ctx.artifact_path("flake-rerun-nodeids.tsv")
+        if rerun_nodeids.exists():
+            rerun_nodeids.unlink()
         cmd = [
             sys.executable,
             "-m",
@@ -191,17 +203,28 @@ class FlakeTrackingStep(Step):
             # (codex #1222 r6) — same reason as full_unit.
             "--color=no",
             # -rA => list every test's final outcome (PASSED/FAILED/…) in
-            # the short summary. We classify a flake candidate on a
-            # *positive* PASSED, not on mere absence from FAILED — so a
-            # test that got SKIPPED / deselected / never ran on the
-            # isolated re-run is inconclusive, not a false flake
-            # (codex #1222 r2).
+            # the short summary. Used as the FALLBACK when the structured
+            # node-id plugin isn't available; the plugin path classifies on
+            # exact ``report.nodeid`` instead. Either way we classify on a
+            # *positive* PASSED, not on mere absence from FAILED — a test
+            # SKIPPED / deselected / never run is inconclusive, not a false
+            # flake (codex #1222 r2).
             "-rA",
             "-p",
             "no:cacheprovider",
         ]
+        # Emit the structured node-id log (with PASSED, which the classifier
+        # needs) so flake-vs-real is decided on exact ids, not summary text.
+        rerun_env = None
+        if _nodeid_reporter.available():
+            plugin_args, rerun_env = _nodeid_reporter.build_invocation(
+                rerun_nodeids, ctx.repo_root, log_passes=True
+            )
+            cmd += plugin_args
         try:
-            proc = _run_session(cmd, cwd=str(ctx.repo_root), timeout=_RERUN_TIMEOUT_S)
+            proc = _run_session(
+                cmd, cwd=str(ctx.repo_root), timeout=_RERUN_TIMEOUT_S, env=rerun_env
+            )
         except subprocess.TimeoutExpired as e:
             # Persist whatever we drained before the kill so a human can
             # see which re-run hung, instead of discarding it (codex
@@ -239,8 +262,14 @@ class FlakeTrackingStep(Step):
         #   * FAILED/ERROR again → reproduces → likely a real bug.
         #   * anything else (SKIPPED / deselected / never collected) →
         #     INCONCLUSIVE — reported, but NOT called a flake.
-        passed = set(summary_node_ids(proc.stdout, "PASSED"))
-        still_bad = set(summary_node_ids(proc.stdout, "FAILED", "ERROR"))
+        # Prefer the structured node-id log (exact ids); fall back to
+        # scraping the summary only if the plugin didn't run (codex r10).
+        if rerun_nodeids.exists():
+            passed = set(report_log_node_ids(rerun_nodeids, "PASSED"))
+            still_bad = set(report_log_node_ids(rerun_nodeids, "FAILED", "ERROR"))
+        else:
+            passed = set(summary_node_ids(proc.stdout, "PASSED"))
+            still_bad = set(summary_node_ids(proc.stdout, "FAILED", "ERROR"))
         candidates = [i for i in sample if i in passed]
         reproduced = [i for i in sample if i in still_bad]
         inconclusive = [i for i in sample if i not in passed and i not in still_bad]
@@ -277,7 +306,8 @@ class FlakeTrackingStep(Step):
             reproduced_new,
             reproduced_known,
             inconclusive,
-            truncated,
+            sampled=len(sample),
+            total=len(original_failed),
         )
 
         # The "quarantine graveyard" signal (codex #1222 r7 → r8): a
@@ -311,12 +341,17 @@ class FlakeTrackingStep(Step):
         )
 
 
-def _run_session(cmd: list[str], cwd: str, timeout: int) -> subprocess.CompletedProcess:
+def _run_session(
+    cmd: list[str], cwd: str, timeout: int, env: dict | None = None
+) -> subprocess.CompletedProcess:
     """Run ``cmd`` in its own session and, on timeout, SIGKILL the whole
     process group so in-group test-spawned descendants (inference
     servers, GPU workers) are swept before later validation steps
     (codex #1222). Best-effort: a setsid-escaping descendant is not
     portably containable on macOS — see the module docstring.
+
+    ``env`` (when given) is the subprocess environment — used to carry the
+    ``_nodeid_reporter`` plugin's log path + PYTHONPATH; ``None`` inherits.
 
     ``start_new_session=True`` makes the child a session/group leader
     (pgid == pid). On timeout the child has not been reaped, so its pgid
@@ -333,6 +368,7 @@ def _run_session(cmd: list[str], cwd: str, timeout: int) -> subprocess.Completed
         text=True,
         cwd=cwd,
         start_new_session=True,
+        env=env,
     )
     try:
         out, err = proc.communicate(timeout=timeout)
@@ -393,7 +429,9 @@ def _render(
     reproduced_new: list[str],
     reproduced_known: list[str],
     inconclusive: list[str],
-    truncated: int,
+    *,
+    sampled: int,
+    total: int,
 ) -> str:
     parts: list[str] = []
     if new_candidates:
@@ -429,10 +467,10 @@ def _render(
             "re-run — skipped, deselected, or not collected; NOT classified "
             "as a flake):\n```\n" + "\n".join(inconclusive) + "\n```"
         )
-    if truncated > 0:
+    if total > sampled:
         parts.append(
-            f"_Sampled the first {_MAX_RERUN_IDS} of "
-            f"{_MAX_RERUN_IDS + truncated} failures — {truncated} not "
-            f"re-run this pass._"
+            f"_Re-ran {sampled} of {total} failures (quarantined first, then "
+            f"non-quarantined up to the cap) — {total - sampled} not re-run "
+            f"this pass._"
         )
     return "\n\n".join(parts) if parts else "no classification produced"

--- a/scripts/pr_validate/steps/flake_tracking.py
+++ b/scripts/pr_validate/steps/flake_tracking.py
@@ -153,6 +153,9 @@ class FlakeTrackingStep(Step):
             f"--reruns={_RERUNS}",
             "-q",
             "--no-header",
+            # Force color off so ANSI escapes can't break outcome parsing
+            # (codex #1222 r6) — same reason as full_unit.
+            "--color=no",
             # -rA => list every test's final outcome (PASSED/FAILED/…) in
             # the short summary. We classify a flake candidate on a
             # *positive* PASSED, not on mere absence from FAILED — so a

--- a/scripts/pr_validate/steps/flake_tracking.py
+++ b/scripts/pr_validate/steps/flake_tracking.py
@@ -1,19 +1,31 @@
 # SPDX-License-Identifier: Apache-2.0
 """Flake tracking (dev-flow proposal item ③).
 
-MOSTLY advisory: it surfaces flake *candidates* for the quarantine from
-real PR runs (so a human can promote a confirmed flake instead of
-hand-hunting for it), and it never lets its own crash block a PR — the
-base ``execute`` would turn an uncaught exception into a blocking
-``error``, so ``run`` catches everything and downgrades to ``skip``.
+ADVISORY ONLY — this step never blocks a PR. It surfaces flake
+*candidates* for the quarantine from real PR runs (so a human can promote
+a confirmed flake instead of hand-hunting for it), and it loudly flags the
+inverse — a *quarantined* test that stopped flaking and now reproduces —
+for a human to DE-quarantine. It never turns either signal into an
+automated gate, and it never lets its own crash block a PR: the base
+``execute`` would turn an uncaught exception into a blocking ``error``, so
+``run`` catches everything and downgrades to ``skip``.
 
-It has exactly ONE gating case (codex #1222 r7): a test that is
-*quarantined* — so ``full_unit`` downgraded its failure to non-blocking —
-but then fails EVERY isolated re-run here is not flaky, it's a
-deterministic regression the quarantine would otherwise mask forever.
-That revokes the downgrade and BLOCKS. This closes the "quarantine
-graveyard" hole where an allowlisted test silently rots into a real
-regression. Every other outcome is advisory (``pass`` / ``skip``).
+Why not auto-gate the "quarantine graveyard" case (codex #1222 r7 → r8):
+r7 added a hard block when a quarantined test reproduced on every re-run,
+reasoning it must be a deterministic regression the allowlist masks. r8
+correctly rebutted that: back-to-back, in-process re-runs are
+*correlated*, so this cannot soundly decide the quarantine question in
+EITHER direction. A genuine environmental flake — e.g. the seeded
+GPU-contention case — fails the whole retry batch under sustained
+contention and *looks* deterministic; and an isolated re-run's order /
+fixture scope / resource state differs from the full suite, so a failure
+that is deterministic only under full-suite conditions *passes* here and
+looks flaky. Four correlated re-runs are evidence for a human, not a
+verdict — deciding it needs independent runs / history (slice 2+). So we
+report it LOUDLY (a ``pass`` whose summary leads with a REVIEW flag and a
+populated ``reproduced_quarantined`` bucket) and leave the call to the
+human, exactly like the *adding*-to-quarantine direction. This keeps the
+"never automate the quarantine decision" contract symmetric.
 
 Mechanism: after ``full_unit`` runs, read its log for the tests that
 failed, then re-run exactly those node ids in isolation with
@@ -88,12 +100,12 @@ _CLASSIFIABLE_EXITS = (0, 1)
 class FlakeTrackingStep(Step):
     name = "flake_tracking"
     description = (
-        "classify full_unit failures — blocks a deterministic quarantined regression"
+        "classify full_unit failures — advisory (flake candidates + graveyard review)"
     )
-    # A CRASH here must never sink the PR (advisory heritage): run() also
-    # catches everything itself and downgrades to skip, so this step only
-    # ever emits a *deliberate* fail (the reproduced-quarantined gate) —
-    # never an error. continue_on_error stays True as belt-and-suspenders.
+    # Advisory: this step never emits fail/error — every path returns
+    # pass/skip, and run() catches everything and downgrades to skip so a
+    # crash can't turn into a blocking error. continue_on_error stays True
+    # as belt-and-suspenders; the verdict cannot depend on this step.
     continue_on_error = True
 
     def should_run(self, ctx: Context) -> bool:
@@ -142,8 +154,8 @@ class FlakeTrackingStep(Step):
             )
 
         # Report against the ACTIVE (protected base) quarantine, same
-        # source the gate uses. Fail-safe: a broken/absent registry just
-        # means "nothing known-flaky yet" for the report.
+        # source full_unit's downgrade uses. Fail-safe: a broken/absent
+        # registry just means "nothing known-flaky yet" for the report.
         try:
             entries = load_quarantine_from_ref(
                 ctx.base_sha or ctx.base_branch, ctx.repo_root
@@ -151,7 +163,15 @@ class FlakeTrackingStep(Step):
         except QuarantineError:
             entries = []
 
-        sample = original_failed[:_MAX_RERUN_IDS]
+        # Cap the re-run set, but check EVERY quarantined failure first
+        # (codex #1222 r8 nit): a graveyard candidate — a quarantined test
+        # that may have stopped flaking — is the highest-value review
+        # signal, so it must never be dropped by the cap just because it
+        # sorted past the 25th id. The cap then applies to the advisory
+        # non-quarantined remainder.
+        q_failed = [i for i in original_failed if is_quarantined(i, entries)]
+        other_failed = [i for i in original_failed if not is_quarantined(i, entries)]
+        sample = (q_failed + other_failed)[:_MAX_RERUN_IDS]
         truncated = len(original_failed) - len(sample)
 
         rerun_log = ctx.artifact_path("flake-rerun.log")
@@ -256,27 +276,23 @@ class FlakeTrackingStep(Step):
             truncated,
         )
 
-        # The ONE gating case (codex #1222 r7): a quarantined test that
-        # full_unit downgraded to non-blocking, yet failed EVERY isolated
-        # re-run here, is not flaky — it's a deterministic regression the
-        # quarantine would otherwise mask forever ("quarantine graveyard").
-        # Revoke the downgrade and BLOCK. Everything else stays advisory.
-        if reproduced_known:
-            summary = (
-                f"{len(reproduced_known)} quarantined test(s) failed "
-                f"deterministically on {_RERUNS} re-run(s) — a regression, "
-                f"not a flake; fix the test or remove it from "
-                f"quarantine.yaml (blocking)"
-            )
-            return StepResult(
-                name=self.name,
-                status="fail",
-                summary=summary,
-                details=details,
-                artifacts=[str(cand_path), str(rerun_log)],
-            )
-
+        # The "quarantine graveyard" signal (codex #1222 r7 → r8): a
+        # quarantined test that full_unit downgraded, yet reproduced on
+        # every isolated re-run, MAY be a deterministic regression the
+        # allowlist is masking — but correlated in-process re-runs can't
+        # prove that (a sustained-contention flake looks identical). So we
+        # surface it LOUDLY for a human to de-quarantine rather than
+        # auto-blocking on weak evidence (see module docstring). The
+        # summary leads with the review flag; status stays advisory.
+        review = (
+            f"⚠ REVIEW: {len(reproduced_known)} quarantined test(s) "
+            f"reproduced on all {_RERUNS} re-run(s) — may be a regression, "
+            f"not a flake; a human should re-verify and de-quarantine. "
+            if reproduced_known
+            else ""
+        )
         summary = (
+            f"{review}"
             f"{len(new_candidates)} new flake candidate(s), "
             f"{len(reproduced_new)} reproduced, "
             f"{len(known_flakes)} known-flaky, "

--- a/scripts/pr_validate/steps/flake_tracking.py
+++ b/scripts/pr_validate/steps/flake_tracking.py
@@ -200,6 +200,16 @@ class FlakeTrackingStep(Step):
             sys.executable,
             "-m",
             "pytest",
+            # Neutralize candidate-controlled config for the advisory re-run
+            # too (codex #1222 r16): -o addopts= drops the pytest.ini /
+            # pyproject addopts wholesale so a planted --collect-only / marker
+            # filter / -p no:<reporter> can't suppress classification, and
+            # PYTEST_ADDOPTS is stripped from the env below (it bites through
+            # -o addopts=). We re-run EXPLICIT node ids, so no marker filter
+            # needs re-applying — the sample already comes from full_unit's
+            # filtered run.
+            "-o",
+            "addopts=",
             *sample,
             f"--reruns={_RERUNS}",
             "-q",
@@ -218,12 +228,17 @@ class FlakeTrackingStep(Step):
             "-p",
             "no:cacheprovider",
         ]
+        # Strip PYTEST_ADDOPTS from the subprocess env — it bites THROUGH
+        # ``-o addopts=`` (that only overrides the ini file), so a candidate
+        # env var could still inject options into the advisory re-run
+        # otherwise (codex #1222 r16). Done regardless of plugin availability.
+        rerun_env = dict(os.environ)
+        rerun_env.pop("PYTEST_ADDOPTS", None)
         # Emit the structured node-id log (with PASSED, which the classifier
         # needs) so flake-vs-real is decided on exact ids, not summary text.
-        rerun_env = None
         if _nodeid_reporter.available():
             plugin_args, rerun_env = _nodeid_reporter.build_invocation(
-                rerun_nodeids, ctx.repo_root, log_passes=True
+                rerun_nodeids, ctx.repo_root, log_passes=True, base_env=rerun_env
             )
             cmd += plugin_args
         try:

--- a/scripts/pr_validate/steps/flake_tracking.py
+++ b/scripts/pr_validate/steps/flake_tracking.py
@@ -1,0 +1,247 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Advisory step — flake tracking (dev-flow proposal item ③).
+
+MEASURE-ONLY. This step never blocks a PR: every path returns ``pass``
+or ``skip`` (the base ``execute`` would turn an uncaught exception into a
+blocking ``error``, so ``run`` catches everything and downgrades to
+``skip``). It is the reporting half of the flake system whose gating half
+lives in ``full_unit`` (quarantine-aware) — here we surface *candidates*
+for that quarantine from real PR runs, so a human can promote a confirmed
+flake instead of hand-hunting for it.
+
+Mechanism: after ``full_unit`` runs, read its log for the tests that
+failed, then re-run exactly those node ids in isolation with
+``pytest-rerunfailures``. A test that FAILED in the full suite but PASSES
+here (first try or after a rerun) is non-deterministic — a flake
+candidate. One that reproduces its failure is likely a real bug, and is
+reported as such (``full_unit`` already blocked on it).
+
+The re-run set is tiny (only the failures — usually zero), so a plain
+``subprocess.run`` with a timeout is enough; none of the bounded-tail /
+process-group machinery the full-suite ``diff_coverage`` run needs. If
+``pytest-rerunfailures`` is not installed, the step skips cleanly — the
+plugin is an optional [test]/[dev] extra, not a required one.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+import traceback
+
+from ..base import Step, StepResult
+from ..context import Context
+from ..quarantine import QuarantineError, is_quarantined, load_quarantine
+
+# Cap on how many failed ids we re-run. If main is broken with hundreds
+# of reds, re-running them all (× reruns) would blow the budget for no
+# advisory benefit — the signal is the same from a sample.
+_MAX_RERUN_IDS = 25
+_RERUNS = 3
+_RERUN_TIMEOUT_S = 900
+
+
+class FlakeTrackingStep(Step):
+    name = "flake_tracking"
+    description = "advisory — classify full_unit failures as flake vs real"
+    # Advisory: an error here must not sink the PR. run() also catches
+    # everything itself; this is belt-and-suspenders with the runner.
+    continue_on_error = True
+
+    def should_run(self, ctx: Context) -> bool:
+        # Nothing to classify unless full_unit actually ran (same blast
+        # gate) and left a log to read.
+        if ctx.blast_radius == "low":
+            return False
+        return ctx.artifact_path("full-unit.log").exists()
+
+    def run(self, ctx: Context) -> StepResult:
+        try:
+            return self._run(ctx)
+        except Exception:  # noqa: BLE001 — advisory: never block a PR
+            return StepResult(
+                name=self.name,
+                status="skip",
+                summary="advisory step errored; skipped (non-blocking)",
+                details=f"```\n{traceback.format_exc()}\n```",
+            )
+
+    def _run(self, ctx: Context) -> StepResult:
+        log_path = ctx.artifact_path("full-unit.log")
+        if not log_path.exists():
+            return StepResult(
+                name=self.name,
+                status="skip",
+                summary="no full-unit.log to classify",
+            )
+
+        original_failed = _failed_ids(log_path.read_text())
+        if not original_failed:
+            return StepResult(
+                name=self.name,
+                status="skip",
+                summary="full_unit had no failures — nothing to classify",
+            )
+
+        if importlib.util.find_spec("pytest_rerunfailures") is None:
+            return StepResult(
+                name=self.name,
+                status="skip",
+                summary=(
+                    "pytest-rerunfailures not installed — skipping flake "
+                    "classification (add the [test] extra to enable)"
+                ),
+            )
+
+        # Fail-safe: advisory, so a broken registry just means "nothing
+        # is known-flaky yet" for the purpose of the report.
+        try:
+            entries = load_quarantine()
+        except QuarantineError:
+            entries = []
+
+        sample = original_failed[:_MAX_RERUN_IDS]
+        truncated = len(original_failed) - len(sample)
+
+        rerun_log = ctx.artifact_path("flake-rerun.log")
+        cmd = [
+            sys.executable,
+            "-m",
+            "pytest",
+            *sample,
+            f"--reruns={_RERUNS}",
+            "-q",
+            "--no-header",
+            "-p",
+            "no:cacheprovider",
+        ]
+        try:
+            proc = subprocess.run(  # noqa: S603
+                cmd,
+                capture_output=True,
+                text=True,
+                cwd=str(ctx.repo_root),
+                timeout=_RERUN_TIMEOUT_S,
+            )
+        except subprocess.TimeoutExpired:
+            return StepResult(
+                name=self.name,
+                status="skip",
+                summary=(
+                    f"flake re-run exceeded {_RERUN_TIMEOUT_S}s on "
+                    f"{len(sample)} test(s) — skipped (non-blocking)"
+                ),
+            )
+        rerun_log.write_text((proc.stdout or "") + (proc.stderr or ""))
+
+        # A test that still failed/errored on isolated re-run (with
+        # reruns) reproduces → likely a real bug. Everything else in the
+        # sample passed this time → non-deterministic → flake candidate.
+        still_bad = set(_bad_ids(proc.stdout))
+        candidates = [i for i in sample if i not in still_bad]
+        reproduced = [i for i in sample if i in still_bad]
+
+        # Split candidates by whether they're already covered.
+        new_candidates = [i for i in candidates if not is_quarantined(i, entries)]
+        known_flakes = [i for i in candidates if is_quarantined(i, entries)]
+
+        payload = {
+            "original_failed": original_failed,
+            "sampled": sample,
+            "truncated": truncated,
+            "flake_candidates_new": new_candidates,
+            "flake_candidates_known": known_flakes,
+            "reproduced_likely_real": reproduced,
+        }
+        cand_path = ctx.artifact_path("flake-candidates.json")
+        cand_path.write_text(json.dumps(payload, indent=2))
+
+        details = _render(new_candidates, known_flakes, reproduced, truncated)
+        summary = (
+            f"{len(new_candidates)} new flake candidate(s), "
+            f"{len(reproduced)} reproduced, "
+            f"{len(known_flakes)} known-flaky — advisory"
+        )
+        return StepResult(
+            name=self.name,
+            status="pass",
+            summary=summary,
+            details=details,
+            artifacts=[str(cand_path), str(rerun_log)],
+        )
+
+
+def _render(
+    new_candidates: list[str],
+    known_flakes: list[str],
+    reproduced: list[str],
+    truncated: int,
+) -> str:
+    parts: list[str] = []
+    if new_candidates:
+        parts.append(
+            "**New flake candidates** (failed the full suite, passed on "
+            "isolated re-run — consider promoting to `quarantine.yaml` "
+            "after confirming):\n```\n" + "\n".join(new_candidates) + "\n```"
+        )
+    if reproduced:
+        parts.append(
+            "**Reproduced on re-run** (failure is deterministic — likely a "
+            "real bug, NOT a flake; `full_unit` blocked on these):\n```\n"
+            + "\n".join(reproduced)
+            + "\n```"
+        )
+    if known_flakes:
+        parts.append(
+            "**Already quarantined** (confirmed still flaky):\n```\n"
+            + "\n".join(known_flakes)
+            + "\n```"
+        )
+    if truncated > 0:
+        parts.append(
+            f"_Sampled the first {_MAX_RERUN_IDS} of "
+            f"{_MAX_RERUN_IDS + truncated} failures — {truncated} not "
+            f"re-run this pass._"
+        )
+    return "\n\n".join(parts) if parts else "no classification produced"
+
+
+def _failed_ids(text: str) -> list[str]:
+    """Node ids pytest labels FAILED in its short-summary section."""
+    return _summary_ids(text, prefixes=("FAILED",))
+
+
+def _bad_ids(text: str) -> list[str]:
+    """Node ids pytest labels FAILED or ERROR — an ERROR on re-run is
+    not a pass, so it counts as 'reproduced', not a flake candidate."""
+    return _summary_ids(text, prefixes=("FAILED", "ERROR"))
+
+
+def _summary_ids(text: str, prefixes: tuple[str, ...]) -> list[str]:
+    """Parse node ids out of pytest's short test summary block.
+
+    A summary line is ``<LABEL> <nodeid>[ - <message>]``; the node id is
+    everything between the label and the ``" - "`` message separator
+    (parametrized ids can hold spaces inside ``[...]``, so we split on
+    ``" - "`` rather than whitespace).
+    """
+    out: list[str] = []
+    in_summary = False
+    for line in (text or "").splitlines():
+        if "short test summary" in line:
+            in_summary = True
+            continue
+        if not in_summary:
+            continue
+        if line.startswith("="):
+            break
+        for prefix in prefixes:
+            if line.startswith(prefix + " "):
+                rest = line[len(prefix) + 1 :]
+                node_id = rest.split(" - ", 1)[0].strip()
+                if node_id:
+                    out.append(node_id)
+                break
+    return out

--- a/scripts/pr_validate/steps/flake_tracking.py
+++ b/scripts/pr_validate/steps/flake_tracking.py
@@ -270,7 +270,15 @@ class FlakeTrackingStep(Step):
         else:
             passed = set(summary_node_ids(proc.stdout, "PASSED"))
             still_bad = set(summary_node_ids(proc.stdout, "FAILED", "ERROR"))
-        candidates = [i for i in sample if i in passed]
+        # FAILED/ERROR takes PRECEDENCE over PASSED for the same node id
+        # (codex #1222 r12): a test whose call PASSES but whose teardown
+        # ERRORs emits BOTH a PASSED and an ERROR line (they're different
+        # pytest phases), and a test can likewise fail then pass across
+        # phases. Such a run is NOT "green on re-run" — it ended badly — so
+        # it must be a reproduction, never a flake candidate. Subtracting
+        # ``still_bad`` from the passed set makes the three buckets disjoint
+        # and gives badness the last word.
+        candidates = [i for i in sample if i in passed and i not in still_bad]
         reproduced = [i for i in sample if i in still_bad]
         inconclusive = [i for i in sample if i not in passed and i not in still_bad]
 

--- a/scripts/pr_validate/steps/flake_tracking.py
+++ b/scripts/pr_validate/steps/flake_tracking.py
@@ -16,15 +16,22 @@ here (first try or after a rerun) is non-deterministic — a flake
 candidate. One that reproduces its failure is likely a real bug, and is
 reported as such (``full_unit`` already blocked on it).
 
-Two soundness guards (codex #1222):
+Classification is on POSITIVE outcomes (``-rA`` gives every test's final
+verdict): a node id that PASSED on the isolated re-run is the flake
+candidate; one that FAILED/ERRORed again reproduces; anything that merely
+went missing from the summary (skipped, deselected, never collected) is
+reported as inconclusive, never called a flake.
+
+Soundness guards (codex #1222):
   * Classification only runs when the re-run exits with a code we can
     reason about (0 = all passed, 1 = some failed). Anything else
     (collection error, crash, usage error) is inconclusive → we skip
     rather than mislabel a real failure as a flake.
   * The re-run is launched in its own session; on timeout the whole
     process group is SIGKILLed (race-free — the leader is unreaped at
-    that point, so its pgid is still reserved), so a test that spawned
-    an inference server / GPU worker can't leak into later steps.
+    that point, so its pgid is still reserved), and the post-kill output
+    drain is time-bounded, so a test that spawned an inference server /
+    GPU worker can neither leak into later steps nor wedge the gate.
 
 If ``pytest-rerunfailures`` is not installed, the step skips cleanly —
 the plugin is an optional [test]/[dev] extra, not a required one.
@@ -51,6 +58,10 @@ from ..quarantine import QuarantineError, is_quarantined, load_quarantine_from_r
 _MAX_RERUN_IDS = 25
 _RERUNS = 3
 _RERUN_TIMEOUT_S = 900
+# Upper bound on the post-kill output drain. If a descendant escaped the
+# process group (e.g. via its own setsid) and still holds the pipe open,
+# we abandon the drain rather than let it hang the whole gate.
+_DRAIN_TIMEOUT_S = 10
 # pytest exit codes we can classify: 0 = all passed, 1 = some failed.
 # 2 (interrupted), 3 (internal), 4 (usage), 5 (no tests) are abnormal —
 # treating an unlisted id as "passed" would then mislabel real failures.
@@ -131,6 +142,13 @@ class FlakeTrackingStep(Step):
             f"--reruns={_RERUNS}",
             "-q",
             "--no-header",
+            # -rA => list every test's final outcome (PASSED/FAILED/…) in
+            # the short summary. We classify a flake candidate on a
+            # *positive* PASSED, not on mere absence from FAILED — so a
+            # test that got SKIPPED / deselected / never ran on the
+            # isolated re-run is inconclusive, not a false flake
+            # (codex #1222 r2).
+            "-rA",
             "-p",
             "no:cacheprovider",
         ]
@@ -162,12 +180,17 @@ class FlakeTrackingStep(Step):
                 artifacts=[str(rerun_log)],
             )
 
-        # A test still FAILED/ERRORed on isolated re-run (with reruns) →
-        # reproduces → likely a real bug. Everything else in the sample
-        # passed this time → non-deterministic → flake candidate.
+        # Classify on POSITIVE outcomes, not on absence (codex #1222 r2):
+        #   * PASSED on isolated re-run → was red in the suite, green now
+        #     → non-deterministic → flake candidate.
+        #   * FAILED/ERROR again → reproduces → likely a real bug.
+        #   * anything else (SKIPPED / deselected / never collected) →
+        #     INCONCLUSIVE — reported, but NOT called a flake.
+        passed = set(summary_node_ids(proc.stdout, "PASSED"))
         still_bad = set(summary_node_ids(proc.stdout, "FAILED", "ERROR"))
-        candidates = [i for i in sample if i not in still_bad]
+        candidates = [i for i in sample if i in passed]
         reproduced = [i for i in sample if i in still_bad]
+        inconclusive = [i for i in sample if i not in passed and i not in still_bad]
 
         # Split candidates by whether they're already covered.
         new_candidates = [i for i in candidates if not is_quarantined(i, entries)]
@@ -180,15 +203,19 @@ class FlakeTrackingStep(Step):
             "flake_candidates_new": new_candidates,
             "flake_candidates_known": known_flakes,
             "reproduced_likely_real": reproduced,
+            "inconclusive": inconclusive,
         }
         cand_path = ctx.artifact_path("flake-candidates.json")
         cand_path.write_text(json.dumps(payload, indent=2))
 
-        details = _render(new_candidates, known_flakes, reproduced, truncated)
+        details = _render(
+            new_candidates, known_flakes, reproduced, inconclusive, truncated
+        )
         summary = (
             f"{len(new_candidates)} new flake candidate(s), "
             f"{len(reproduced)} reproduced, "
-            f"{len(known_flakes)} known-flaky — advisory"
+            f"{len(known_flakes)} known-flaky, "
+            f"{len(inconclusive)} inconclusive — advisory"
         )
         return StepResult(
             name=self.name,
@@ -208,7 +235,9 @@ def _run_session(cmd: list[str], cwd: str, timeout: int) -> subprocess.Completed
     (pgid == pid). On timeout the child has not been reaped, so its pgid
     is still reserved — killpg is race-free (the safe pre-reap case). We
     kill BEFORE the final ``communicate`` so a descendant holding the
-    pipe open can't hang the drain.
+    pipe open can't hang the drain, and the drain itself is time-bounded
+    so even a group-escaping descendant can't wedge the gate (codex
+    #1222 r2).
     """
     proc = subprocess.Popen(  # noqa: S603
         cmd,
@@ -222,9 +251,30 @@ def _run_session(cmd: list[str], cwd: str, timeout: int) -> subprocess.Completed
         out, err = proc.communicate(timeout=timeout)
     except subprocess.TimeoutExpired:
         _kill_group(proc)
-        out, err = proc.communicate()
+        out, err = _drain_bounded(proc)
         raise subprocess.TimeoutExpired(cmd, timeout, output=out, stderr=err)
     return subprocess.CompletedProcess(cmd, proc.returncode, out, err)
+
+
+def _drain_bounded(proc: subprocess.Popen) -> tuple[str, str]:
+    """Drain the child's pipes after a kill, but never block forever.
+
+    The normal case returns immediately (the group is dead). If a
+    descendant escaped the process group and still holds the write end
+    open, the bounded ``communicate`` raises again — we then re-kill,
+    force the pipes closed, and give up on the tail so the gate proceeds
+    instead of hanging (macOS has no cgroup to contain such an escape)."""
+    try:
+        return proc.communicate(timeout=_DRAIN_TIMEOUT_S)
+    except subprocess.TimeoutExpired:
+        _kill_group(proc)
+        for stream in (proc.stdout, proc.stderr):
+            if stream is not None:
+                try:
+                    stream.close()
+                except OSError:
+                    pass
+        return "", ""
 
 
 def _kill_group(proc: subprocess.Popen) -> None:
@@ -243,6 +293,7 @@ def _render(
     new_candidates: list[str],
     known_flakes: list[str],
     reproduced: list[str],
+    inconclusive: list[str],
     truncated: int,
 ) -> str:
     parts: list[str] = []
@@ -264,6 +315,12 @@ def _render(
             "**Already quarantined** (confirmed still flaky):\n```\n"
             + "\n".join(known_flakes)
             + "\n```"
+        )
+    if inconclusive:
+        parts.append(
+            "**Inconclusive** (didn't positively pass or fail on isolated "
+            "re-run — skipped, deselected, or not collected; NOT classified "
+            "as a flake):\n```\n" + "\n".join(inconclusive) + "\n```"
         )
     if truncated > 0:
         parts.append(

--- a/scripts/pr_validate/steps/flake_tracking.py
+++ b/scripts/pr_validate/steps/flake_tracking.py
@@ -138,16 +138,21 @@ class FlakeTrackingStep(Step):
 
         # Prefer full_unit's STRUCTURED node-id log (exact ids); fall back
         # to scraping its text log only if the plugin didn't run there.
+        # Read BOTH FAILED and ERROR: a setup / teardown / collection flake
+        # is recorded as ERROR, not FAILED, and it's just as much a flake
+        # candidate as a call-phase failure — reading only FAILED reported
+        # "no failures" and never re-ran those errored tests (codex #1222
+        # r15 NIT).
         nodeid_log = ctx.artifact_path("full-unit-nodeids.tsv")
         if nodeid_log.exists():
-            original_failed = report_log_node_ids(nodeid_log, "FAILED")
+            original_failed = report_log_node_ids(nodeid_log, "FAILED", "ERROR")
         else:
-            original_failed = summary_node_ids(log_path.read_text(), "FAILED")
+            original_failed = summary_node_ids(log_path.read_text(), "FAILED", "ERROR")
         if not original_failed:
             return StepResult(
                 name=self.name,
                 status="skip",
-                summary="full_unit had no failures — nothing to classify",
+                summary="full_unit had no failures or errors — nothing to classify",
             )
 
         if importlib.util.find_spec("pytest_rerunfailures") is None:

--- a/scripts/pr_validate/steps/full_unit.py
+++ b/scripts/pr_validate/steps/full_unit.py
@@ -27,6 +27,7 @@ import sys
 
 from .. import _nodeid_reporter
 from .._pytest_summary import (
+    last_summary_line,
     render_fence_safe,
     report_log_node_ids,
     summary_node_ids,
@@ -163,7 +164,7 @@ class FullUnitStep(Step):
 
         # Pull the summary line: pytest ends with a line like
         # "==== 3 failed, 2080 passed, 17 skipped in 25.56s ===="
-        summary_line = _last_summary_line(proc.stdout)
+        summary_line = last_summary_line(proc.stdout)
 
         # A GATING run must NEVER rerun a test. GATING_PYTEST_GUARD disables
         # pytest-rerunfailures by name, but name-based ``-p no:<name>``
@@ -489,13 +490,3 @@ def _render_unaccounted(
     if not failed_ids and not error_ids:
         parts.append(f"(no parseable FAILED/ERROR node ids — see {log_path})")
     return "\n\n".join(parts)
-
-
-def _last_summary_line(stdout: str) -> str:
-    """Pytest writes its overall summary as the very last non-empty
-    line wrapped in '====' decorations. Return without decorations."""
-    for line in reversed((stdout or "").splitlines()):
-        line = line.strip()
-        if line.startswith("=") and ("passed" in line or "failed" in line):
-            return line.strip("= ").strip()
-    return ""

--- a/scripts/pr_validate/steps/full_unit.py
+++ b/scripts/pr_validate/steps/full_unit.py
@@ -103,6 +103,22 @@ class FullUnitStep(Step):
             # quarantined failure and have the partial, regression-hiding run
             # accepted as green (codex #1222 r13).
             "--maxfail=0",
+            # Disable pytest-rerunfailures in the GATING run (codex #1222
+            # r20). This PR adds rerunfailures to the [test] extra so the
+            # advisory flake_tracking step can use it — but it autoloads by
+            # entry point, so without this block a candidate could tag a
+            # genuinely failing test `@pytest.mark.flaky(reruns=N)` (or set
+            # reruns via a conftest) and have full_unit RE-RUN and pass it,
+            # producing exit 0 WITHOUT ever consulting the protected
+            # quarantine registry — defeating the gate and violating the
+            # "advisory never affects the verdict" contract. -o addopts= /
+            # PYTEST_ADDOPTS-strip can't stop an AUTOLOADED plugin, so block
+            # it by its registered name. Verified: `-p no:rerunfailures`
+            # makes the flaky mark inert (the test fails as it should) and is
+            # a harmless no-op when the plugin isn't installed. flake_tracking
+            # re-enables reruns only for its own advisory, post-gating re-run.
+            "-p",
+            "no:rerunfailures",
         ]
 
         # Emit a STRUCTURED node-id log via the _nodeid_reporter plugin so

--- a/scripts/pr_validate/steps/full_unit.py
+++ b/scripts/pr_validate/steps/full_unit.py
@@ -135,7 +135,32 @@ class FullUnitStep(Step):
         # "==== 3 failed, 2080 passed, 17 skipped in 25.56s ===="
         summary_line = _last_summary_line(proc.stdout)
 
+        # Did the STRUCTURED reporter run? Its log carries pytest's exact
+        # node ids AND the session-completion record; a downgrade / clean
+        # pass is only trusted on the exact structured source (codex r13).
+        structured = nodeid_log.exists()
+
         if proc.returncode == 0:
+            # A clean exit is only trustworthy on a COMPLETE run: os._exit(0)
+            # can terminate pytest with code 0 after skipping the rest of the
+            # suite, hiding a regression in the un-run tail (codex #1222 r16
+            # B1). When the reporter ran, require its completion record before
+            # accepting green — an absent record / a ran<collected gap means
+            # the session was truncated. If the plugin couldn't be injected at
+            # all (no structured log), there's no signal to check, so fall
+            # back to the exit code (the degraded, non-candidate path).
+            if structured and not _session_completed(nodeid_log):
+                return StepResult(
+                    name=self.name,
+                    status="fail",
+                    summary=summary_line or "pytest exited 0 but did not complete",
+                    details="⚠️ pytest exited 0 but the session did not run to "
+                    "completion — no session-finish record (os._exit / crash / "
+                    "SIGKILL), or fewer tests ran than were collected. A later "
+                    "regression may not have run, so a truncated run is not "
+                    "accepted as green.",
+                    artifacts=[str(log_path)],
+                )
             return StepResult(
                 name=self.name,
                 status="pass",
@@ -147,10 +172,8 @@ class FullUnitStep(Step):
         # ERROR entries (collection / fixture failures) separately. The
         # STRUCTURED plugin log carries pytest's exact node ids; the
         # terminal-summary fallback is ambiguous (its id/message split has
-        # documented edge cases — ``test_x[a] - b]`` …). ``structured``
-        # records which source we got: the quarantine downgrade below is
-        # only granted on the exact source (codex #1222 r13).
-        structured = nodeid_log.exists()
+        # documented edge cases — ``test_x[a] - b]`` …). The quarantine
+        # downgrade below is only granted on the exact source (codex r13).
         if structured:
             failed_ids = report_log_node_ids(nodeid_log, "FAILED")
             error_ids = report_log_node_ids(nodeid_log, "ERROR")
@@ -350,8 +373,13 @@ def _session_completed(nodeid_log) -> bool:
     Requires EXACTLY one well-formed record (``<ran> <collected>``) with a
     positive collected count and ``ran >= collected``. Anything else —
     missing, malformed, duplicated (an unexpected xdist/tamper shape) —
-    withholds the downgrade, the safe direction."""
-    records = report_log_node_ids(nodeid_log, _nodeid_reporter.SESSION_LABEL)
+    withholds the downgrade, the safe direction.
+
+    Reads RAW records, NOT via ``report_log_node_ids`` — that dedups by
+    value, so two IDENTICAL ``SESSIONFINISH\t50 50`` lines would collapse to
+    one and slip past the "exactly one" rule (codex #1222 r16). Counting raw
+    lines rejects any duplicate, identical or not."""
+    records = _raw_session_records(nodeid_log)
     if len(records) != 1:
         return False
     try:
@@ -360,6 +388,20 @@ def _session_completed(nodeid_log) -> bool:
     except (ValueError, TypeError):
         return False
     return collected > 0 and ran >= collected
+
+
+def _raw_session_records(nodeid_log) -> list[str]:
+    """Every ``SESSIONFINISH`` value line in the log, WITHOUT the node-id
+    dedup ``report_log_node_ids`` applies. Two identical completion records
+    must count as two so ``_session_completed`` can reject the duplicate
+    (codex #1222 r16)."""
+    label = _nodeid_reporter.SESSION_LABEL
+    out: list[str] = []
+    for line in nodeid_log.read_text(encoding="utf-8").splitlines():
+        rec_label, tab, value = line.partition("\t")
+        if tab and rec_label == label and value:
+            out.append(value)
+    return out
 
 
 def _last_summary_line(stdout: str) -> str:

--- a/scripts/pr_validate/steps/full_unit.py
+++ b/scripts/pr_validate/steps/full_unit.py
@@ -9,6 +9,14 @@ For medium and high blast PRs, runs the same set we use locally:
 Pre-existing failures on main are NOT filtered here — that's step 3's
 job. This step validates "the suite as-is is still green"; if main is
 broken that's a separate problem and we want to surface it loudly.
+
+Quarantine (dev-flow ③): a failure whose node id is listed in
+``quarantine.yaml`` is reported but does NOT block the PR. This exists
+so a single CONFIRMED flake can't force the "rerun until green" ritual
+that quietly destroys gate credibility. The split is fail-safe — an
+unreadable registry falls back to an empty quarantine, so a broken file
+can only make the gate *stricter*, never pass something it otherwise
+wouldn't. A non-quarantined failure still blocks, exactly as before.
 """
 
 from __future__ import annotations
@@ -18,6 +26,7 @@ import sys
 
 from ..base import Step, StepResult
 from ..context import Context
+from ..quarantine import QuarantineError, load_quarantine, partition_failures
 
 
 class FullUnitStep(Step):
@@ -64,21 +73,92 @@ class FullUnitStep(Step):
                 artifacts=[str(log_path)],
             )
 
-        # On failure, extract the per-test FAILED lines for the
-        # scorecard's detail block — much more useful than dumping the
-        # whole log inline.
-        failed = _extract_failed_lines(proc.stdout)
-        details = ["**Failed tests:**\n```", *failed[:30], "```"]
-        if len(failed) > 30:
-            details.append(f"\n…and {len(failed) - 30} more — see {log_path}")
+        # Non-zero exit. Extract the per-test node ids so we can consult
+        # the quarantine registry.
+        failed_ids = _failed_node_ids(proc.stdout)
 
+        # If pytest exited non-zero but we parsed NO per-test failures,
+        # this is a collection/internal/xdist-level error we can't name —
+        # never quarantine what we can't identify. Block on the raw exit.
+        if not failed_ids:
+            raw = _extract_failed_lines(proc.stdout)
+            body = raw[:30] if raw else ["(no FAILED lines — see log)"]
+            details = [
+                "**pytest failed with no parseable test ids:**\n```",
+                *body,
+                "```",
+            ]
+            return StepResult(
+                name=self.name,
+                status="fail",
+                summary=summary_line or f"pytest exited {proc.returncode}",
+                details="\n".join(details),
+                artifacts=[str(log_path)],
+            )
+
+        # Fail-safe: an unreadable registry means "no quarantine", i.e.
+        # every failure blocks. A broken file can only make us stricter.
+        registry_note = ""
+        try:
+            entries = load_quarantine()
+        except QuarantineError as e:
+            entries = []
+            registry_note = (
+                f"\n\n⚠️ quarantine registry unreadable — treating every "
+                f"failure as blocking: {e}"
+            )
+        blocking, quarantined = partition_failures(failed_ids, entries)
+
+        details = _render_details(blocking, quarantined, log_path) + registry_note
+
+        if blocking:
+            # Real failures present → still a red, regardless of any
+            # quarantined flakes riding along.
+            return StepResult(
+                name=self.name,
+                status="fail",
+                summary=summary_line or f"pytest exited {proc.returncode}",
+                details=details,
+                artifacts=[str(log_path)],
+            )
+
+        # Every failure was a known flake → do NOT block, but say so
+        # loudly so a quarantined red is never mistaken for a clean run.
         return StepResult(
             name=self.name,
-            status="fail",
-            summary=summary_line or f"pytest exited {proc.returncode}",
-            details="\n".join(details),
+            status="pass",
+            summary=(
+                f"{len(quarantined)} known-flaky test(s) failed "
+                f"(quarantined, non-blocking) — {summary_line}"
+                if summary_line
+                else f"{len(quarantined)} known-flaky test(s) failed "
+                f"(quarantined, non-blocking)"
+            ),
+            details=details,
             artifacts=[str(log_path)],
         )
+
+
+def _render_details(blocking: list[str], quarantined: list[str], log_path) -> str:
+    """Scorecard detail block — blocking failures first (the actionable
+    part), then any quarantined flakes that rode along (visible, but
+    flagged non-blocking)."""
+    parts: list[str] = []
+    if blocking:
+        shown = blocking[:30]
+        parts.append("**Failed tests (blocking):**\n```\n" + "\n".join(shown) + "\n```")
+        if len(blocking) > 30:
+            parts.append(f"…and {len(blocking) - 30} more — see {log_path}")
+    if quarantined:
+        shown = quarantined[:30]
+        parts.append(
+            "**Quarantined flakes that failed (non-blocking):**\n```\n"
+            + "\n".join(shown)
+            + "\n```"
+        )
+        if len(quarantined) > 30:
+            parts.append(f"…and {len(quarantined) - 30} more — see {log_path}")
+    return "\n\n".join(parts)
 
 
 def _last_summary_line(stdout: str) -> str:
@@ -105,3 +185,23 @@ def _extract_failed_lines(stdout: str) -> list[str]:
             if line.startswith("FAILED"):
                 out.append(line)
     return out
+
+
+def _failed_node_ids(stdout: str) -> list[str]:
+    """Extract pytest node ids from the short-summary FAILED lines.
+
+    A FAILED line looks like ``FAILED tests/foo.py::test_bar - AssertionError``
+    or bare ``FAILED tests/foo.py::test_bar``. The node id is the token
+    after ``FAILED `` and before the ``  - <message>`` separator pytest
+    inserts (space-dash-space). Parametrized ids can contain spaces
+    inside ``[...]``, so we split on the first ``" - "`` rather than on
+    whitespace.
+    """
+    ids: list[str] = []
+    for line in _extract_failed_lines(stdout):
+        rest = line[len("FAILED ") :] if line.startswith("FAILED ") else line
+        # Strip the trailing " - <error message>" if present.
+        node_id = rest.split(" - ", 1)[0].strip()
+        if node_id:
+            ids.append(node_id)
+    return ids

--- a/scripts/pr_validate/steps/full_unit.py
+++ b/scripts/pr_validate/steps/full_unit.py
@@ -26,7 +26,13 @@ import subprocess
 import sys
 
 from .. import _nodeid_reporter
-from .._pytest_summary import report_log_node_ids, summary_node_ids
+from .._pytest_summary import (
+    report_log_node_ids,
+    summary_node_ids,
+)
+from .._pytest_summary import (
+    session_completed as _session_completed,
+)
 from ..base import GATING_PYTEST_GUARD, Step, StepResult
 from ..context import Context
 from ..quarantine import (
@@ -154,6 +160,28 @@ class FullUnitStep(Step):
         # Pull the summary line: pytest ends with a line like
         # "==== 3 failed, 2080 passed, 17 skipped in 25.56s ===="
         summary_line = _last_summary_line(proc.stdout)
+
+        # A GATING run must NEVER rerun a test. GATING_PYTEST_GUARD disables
+        # pytest-rerunfailures by name, but name-based ``-p no:<name>``
+        # blocking is bypassable — a conftest can re-register the plugin
+        # under an arbitrary name (codex #1222 r23). The reporter's RERUN
+        # record is name-independent: any RERUN means the plugin ran anyway
+        # and a real failure may have been retried into a pass, so the run's
+        # exit code and FAILED set are both untrustworthy. Block regardless
+        # of exit code, before either the clean-exit or the failure path
+        # can trust this run.
+        if structured and _rerun_detected(nodeid_log):
+            return StepResult(
+                name=self.name,
+                status="fail",
+                summary=summary_line or "gating run reran a test",
+                details="⚠️ the gating pytest run reran at least one test — "
+                "pytest-rerunfailures was active despite the by-name block, so "
+                "it was smuggled in under a different name. A rerun can retry a "
+                "real failure into a pass, so this run is not trusted; reruns "
+                "must be OFF for the gate.",
+                artifacts=[str(log_path)],
+            )
 
         if proc.returncode == 0:
             # A clean exit is trustworthy only on a COMPLETE run that recorded
@@ -448,52 +476,18 @@ def _render_unaccounted(
     return "\n\n".join(parts)
 
 
-def _session_completed(nodeid_log) -> bool:
-    """True iff the reporter's session-finish record proves pytest ran the
-    WHOLE collected suite — the precondition for a sound quarantine
-    downgrade (codex #1222 r15).
+def _rerun_detected(nodeid_log) -> bool:
+    """True iff the reporter logged any RERUN record — pytest-rerunfailures
+    retried a test inside a GATING run that must never rerun.
 
-    Both truncation modes are caught STRUCTURALLY, replacing the old
-    stdout-banner heuristic that false-positived when a test's own traceback
-    contained ``"stopping after"`` / ``"Interrupted:"`` (r15 B2):
-
-      * ABSENT record → ``pytest_sessionfinish`` never fired, i.e. the
-        process died mid-suite (``os._exit`` / crash / SIGKILL) (r15 B1).
-      * ``ran < collected`` → the session ended early (``-x`` / a hit
-        ``--maxfail`` / ``--stepwise``), so tests after the stop never ran.
-
-    Requires EXACTLY one well-formed record (``<ran> <collected>``) with a
-    positive collected count and ``ran >= collected``. Anything else —
-    missing, malformed, duplicated (an unexpected xdist/tamper shape) —
-    withholds the downgrade, the safe direction.
-
-    Reads RAW records, NOT via ``report_log_node_ids`` — that dedups by
-    value, so two IDENTICAL ``SESSIONFINISH\t50 50`` lines would collapse to
-    one and slip past the "exactly one" rule (codex #1222 r16). Counting raw
-    lines rejects any duplicate, identical or not."""
-    records = _raw_session_records(nodeid_log)
-    if len(records) != 1:
-        return False
-    try:
-        ran_s, collected_s = records[0].split()
-        ran, collected = int(ran_s), int(collected_s)
-    except (ValueError, TypeError):
-        return False
-    return collected > 0 and ran >= collected
-
-
-def _raw_session_records(nodeid_log) -> list[str]:
-    """Every ``SESSIONFINISH`` value line in the log, WITHOUT the node-id
-    dedup ``report_log_node_ids`` applies. Two identical completion records
-    must count as two so ``_session_completed`` can reject the duplicate
-    (codex #1222 r16)."""
-    label = _nodeid_reporter.SESSION_LABEL
-    out: list[str] = []
-    for line in nodeid_log.read_text(encoding="utf-8").splitlines():
-        rec_label, tab, value = line.partition("\t")
-        if tab and rec_label == label and value:
-            out.append(value)
-    return out
+    ``GATING_PYTEST_GUARD`` blocks the plugin by its registered NAME, but a
+    hostile conftest can register the same plugin under an ARBITRARY name
+    that ``-p no:<name>`` can't reach (verified — a ``@pytest.mark.flaky``
+    marker plus ``config.pluginmanager.register(mod, name="…")`` still
+    reruns) (codex #1222 r23). The reporter records a rerun OUTCOME
+    independent of the plugin's name, so any RERUN record means a real
+    failure could have been retried into a pass — the run is not trusted."""
+    return bool(report_log_node_ids(nodeid_log, _nodeid_reporter.RERUN_LABEL))
 
 
 def _last_summary_line(stdout: str) -> str:

--- a/scripts/pr_validate/steps/full_unit.py
+++ b/scripts/pr_validate/steps/full_unit.py
@@ -120,11 +120,23 @@ class FullUnitStep(Step):
         # (codex #1222 r14). Done regardless of plugin availability.
         run_env = dict(os.environ)
         run_env.pop("PYTEST_ADDOPTS", None)
-        if _nodeid_reporter.available():
+        # ``structured`` means the reporter was INJECTED, decided HERE — not
+        # inferred later from ``nodeid_log.exists()``. The reporter creates
+        # the file only when it appends the first outcome / SESSIONFINISH, so
+        # a hard ``os._exit(0)`` before the first test leaves NO file, which
+        # ``exists()`` would misread as "plugin unavailable" and trust the
+        # zero exit on a fully-truncated run (codex #1222 r17). We instead
+        # pre-create the log as a START SENTINEL right after injecting, so its
+        # existence is decoupled from whether any record was written: an
+        # injected run with an empty/record-less log → no completion record →
+        # withhold, never "unavailable → trust exit code".
+        structured = _nodeid_reporter.available()
+        if structured:
             plugin_args, run_env = _nodeid_reporter.build_invocation(
                 nodeid_log, ctx.repo_root, base_env=run_env
             )
             cmd += plugin_args
+            nodeid_log.write_text("", encoding="utf-8")
 
         proc = subprocess.run(  # noqa: S603
             cmd, capture_output=True, text=True, cwd=str(ctx.repo_root), env=run_env
@@ -134,11 +146,6 @@ class FullUnitStep(Step):
         # Pull the summary line: pytest ends with a line like
         # "==== 3 failed, 2080 passed, 17 skipped in 25.56s ===="
         summary_line = _last_summary_line(proc.stdout)
-
-        # Did the STRUCTURED reporter run? Its log carries pytest's exact
-        # node ids AND the session-completion record; a downgrade / clean
-        # pass is only trusted on the exact structured source (codex r13).
-        structured = nodeid_log.exists()
 
         if proc.returncode == 0:
             # A clean exit is only trustworthy on a COMPLETE run: os._exit(0)

--- a/scripts/pr_validate/steps/full_unit.py
+++ b/scripts/pr_validate/steps/full_unit.py
@@ -356,9 +356,14 @@ class FullUnitStep(Step):
                 base_entries = load_quarantine_from_ref(ctx.base_sha, ctx.repo_root)
             except QuarantineError as e:
                 entries = []
+                # The exception message can echo candidate-controlled
+                # registry text (a bad node id / reason from the PR's own
+                # quarantine.yaml), so render it as a single JSON-quoted line
+                # — a raw newline/backtick would otherwise spoof a scorecard
+                # heading or fence out of this note (codex #1222 r25).
                 registry_note = (
                     f"\n\n⚠️ base quarantine registry unreadable — treating "
-                    f"every failure as blocking: {e}"
+                    f"every failure as blocking: {render_fence_safe(str(e))}"
                 )
             else:
                 # Intersect base with the CANDIDATE registry so a
@@ -396,10 +401,14 @@ class FullUnitStep(Step):
                         )
                     except QuarantineError as e:
                         entries = []
+                        # Single-line JSON render — the candidate CONTROLS
+                        # this registry, so its error text is fully attacker-
+                        # chosen and must not reach the scorecard raw (codex
+                        # #1222 r25).
                         registry_note = (
                             f"\n\n⚠️ candidate quarantine registry unreadable — "
                             f"failing closed to an empty quarantine (every "
-                            f"failure blocks): {e}"
+                            f"failure blocks): {render_fence_safe(str(e))}"
                         )
                     else:
                         entries = effective_quarantine(base_entries, cand_entries)

--- a/scripts/pr_validate/steps/full_unit.py
+++ b/scripts/pr_validate/steps/full_unit.py
@@ -205,22 +205,29 @@ class FullUnitStep(Step):
                 artifacts=[str(log_path)],
             )
 
-        # A quarantine downgrade is only sound on a COMPLETE run. If pytest
-        # terminated the session early — --stepwise / -x / --maxfail (a
-        # conftest can still set these programmatically even with addopts
-        # cleared) or any interrupt — a later real regression may simply not
-        # have run yet, so the FAILED set doesn't account for the whole
-        # suite. Withhold the downgrade and block (codex #1222 r14). The
-        # banners pytest prints for these are unambiguous.
-        if _stopped_early(proc.stdout):
+        # A quarantine downgrade is only sound on a COMPLETE run. Prove
+        # completeness STRUCTURALLY from the reporter's session-finish
+        # record (codex #1222 r15), not by scraping stdout: the record is
+        # ABSENT when the process died mid-suite (os._exit / crash / SIGKILL
+        # — pytest_sessionfinish never fired), and shows ran < collected
+        # when the session stopped early (-x / --maxfail / --stepwise, which
+        # a conftest can still set programmatically even with addopts
+        # cleared). Either way a later real regression may not have run, so
+        # the FAILED set can't account for the whole suite — withhold the
+        # downgrade and block. This replaces a fragile stdout heuristic that
+        # false-positived when "stopping after" / "Interrupted:" appeared in
+        # a quarantined test's own traceback (codex #1222 r15 B2).
+        if not _session_completed(nodeid_log):
             return StepResult(
                 name=self.name,
                 status="fail",
-                summary=summary_line or "pytest stopped early",
+                summary=summary_line or "pytest did not run to completion",
                 details=_render_details(failed_ids, [], log_path)
-                + "\n\n⚠️ pytest terminated the session early (--stepwise / "
-                "-x / --maxfail / interrupt) — the suite did not complete, so "
-                "the quarantine downgrade is withheld; every failure blocks.",
+                + "\n\n⚠️ the pytest session did not run to completion — no "
+                "session-finish record (os._exit / crash / SIGKILL), or fewer "
+                "tests ran than were collected (--stepwise / -x / --maxfail). "
+                "A later regression may not have run, so the quarantine "
+                "downgrade is withheld; every failure blocks.",
                 artifacts=[str(log_path)],
             )
 
@@ -326,18 +333,33 @@ def _render_unaccounted(
     return "\n\n".join(parts)
 
 
-def _stopped_early(stdout: str) -> bool:
-    """True iff pytest terminated the session EARLY (—x / --maxfail /
-    --stepwise / an interrupt) instead of running the whole suite.
+def _session_completed(nodeid_log) -> bool:
+    """True iff the reporter's session-finish record proves pytest ran the
+    WHOLE collected suite — the precondition for a sound quarantine
+    downgrade (codex #1222 r15).
 
-    Its interruption banners are unambiguous and stable: ``-x`` / maxfail
-    print ``… stopping after N failures …`` and --stepwise / keyboard /
-    collection interrupts print ``Interrupted: …``. Both land at the left
-    margin (captured test output is indented under its test), so a false
-    positive is unlikely; if one did occur it would only WITHHOLD a
-    downgrade (block), which is the safe direction."""
-    text = stdout or ""
-    return "stopping after" in text or "Interrupted:" in text
+    Both truncation modes are caught STRUCTURALLY, replacing the old
+    stdout-banner heuristic that false-positived when a test's own traceback
+    contained ``"stopping after"`` / ``"Interrupted:"`` (r15 B2):
+
+      * ABSENT record → ``pytest_sessionfinish`` never fired, i.e. the
+        process died mid-suite (``os._exit`` / crash / SIGKILL) (r15 B1).
+      * ``ran < collected`` → the session ended early (``-x`` / a hit
+        ``--maxfail`` / ``--stepwise``), so tests after the stop never ran.
+
+    Requires EXACTLY one well-formed record (``<ran> <collected>``) with a
+    positive collected count and ``ran >= collected``. Anything else —
+    missing, malformed, duplicated (an unexpected xdist/tamper shape) —
+    withholds the downgrade, the safe direction."""
+    records = report_log_node_ids(nodeid_log, _nodeid_reporter.SESSION_LABEL)
+    if len(records) != 1:
+        return False
+    try:
+        ran_s, collected_s = records[0].split()
+        ran, collected = int(ran_s), int(collected_s)
+    except (ValueError, TypeError):
+        return False
+    return collected > 0 and ran >= collected
 
 
 def _last_summary_line(stdout: str) -> str:

--- a/scripts/pr_validate/steps/full_unit.py
+++ b/scripts/pr_validate/steps/full_unit.py
@@ -64,6 +64,11 @@ class FullUnitStep(Step):
             "--ignore=tests/test_event_loop.py",
             "-q",
             "--no-header",
+            # Force color OFF so the summary/label parsing can't be broken
+            # by ANSI escapes when color is forced via PY_COLORS=1 or an
+            # inherited --color=yes (codex #1222 r6). --color=no overrides
+            # PY_COLORS on the command line.
+            "--color=no",
             # PIN the short-summary contents: always list FAILED and ERROR
             # node ids regardless of any future default change. The
             # quarantine downgrade's soundness rests on being able to SEE

--- a/scripts/pr_validate/steps/full_unit.py
+++ b/scripts/pr_validate/steps/full_unit.py
@@ -24,7 +24,8 @@ from __future__ import annotations
 import subprocess
 import sys
 
-from .._pytest_summary import summary_node_ids
+from .. import _nodeid_reporter
+from .._pytest_summary import report_log_node_ids, summary_node_ids
 from ..base import Step, StepResult
 from ..context import Context
 from ..quarantine import (
@@ -81,8 +82,25 @@ class FullUnitStep(Step):
             # the scorecard ("3 failed, 2080 passed" is more actionable
             # than "1 failed, ???? passed").
         ]
+
+        # Emit a STRUCTURED node-id log via the _nodeid_reporter plugin so
+        # the quarantine partition uses pytest's exact ``report.nodeid``
+        # instead of scraping the ambiguous terminal summary (codex #1222
+        # r4→r10). A stale log from a prior run would poison the read, so
+        # start clean; fall back to summary parsing if the plugin can't be
+        # loaded (never pass an unloadable ``-p`` — that's a usage error).
+        nodeid_log = ctx.artifact_path("full-unit-nodeids.tsv")
+        if nodeid_log.exists():
+            nodeid_log.unlink()
+        run_env = None
+        if _nodeid_reporter.available():
+            plugin_args, run_env = _nodeid_reporter.build_invocation(
+                nodeid_log, ctx.repo_root
+            )
+            cmd += plugin_args
+
         proc = subprocess.run(  # noqa: S603
-            cmd, capture_output=True, text=True, cwd=str(ctx.repo_root)
+            cmd, capture_output=True, text=True, cwd=str(ctx.repo_root), env=run_env
         )
         log_path.write_text((proc.stdout or "") + (proc.stderr or ""))
 
@@ -99,9 +117,15 @@ class FullUnitStep(Step):
             )
 
         # Non-zero exit. Extract the per-test node ids (FAILED) and any
-        # ERROR entries (collection / fixture failures) separately.
-        failed_ids = summary_node_ids(proc.stdout, "FAILED")
-        error_ids = summary_node_ids(proc.stdout, "ERROR")
+        # ERROR entries (collection / fixture failures) separately —
+        # preferring the structured plugin log (exact node ids) and
+        # falling back to terminal-summary parsing only if it didn't run.
+        if nodeid_log.exists():
+            failed_ids = report_log_node_ids(nodeid_log, "FAILED")
+            error_ids = report_log_node_ids(nodeid_log, "ERROR")
+        else:
+            failed_ids = summary_node_ids(proc.stdout, "FAILED")
+            error_ids = summary_node_ids(proc.stdout, "ERROR")
 
         # The quarantine downgrade is only sound when the ONLY thing that
         # went wrong is ordinary, named test failures we can reason about:
@@ -129,19 +153,29 @@ class FullUnitStep(Step):
 
         # Read the registry from the PROTECTED base revision, not the
         # candidate checkout — a PR must not be able to quarantine its own
-        # failing tests (codex #1222). Fail-safe: any read error → empty
-        # quarantine → every failure blocks (stricter, never looser).
+        # failing tests (codex #1222). Pin to the IMMUTABLE base SHA
+        # (``baseRefOid``, resolved at fetch before any candidate code
+        # ran); never fall back to the mutable ``base_branch`` ref, which a
+        # candidate test could rewrite (``git branch -f main …``) between
+        # the pytest run above and this load, then serve its own allowlist
+        # (codex #1222 r10). No SHA → fail CLOSED to an empty quarantine.
         registry_note = ""
-        try:
-            entries = load_quarantine_from_ref(
-                ctx.base_sha or ctx.base_branch, ctx.repo_root
-            )
-        except QuarantineError as e:
+        if not ctx.base_sha:
             entries = []
             registry_note = (
-                f"\n\n⚠️ base quarantine registry unreadable — treating "
-                f"every failure as blocking: {e}"
+                "\n\n⚠️ no immutable base SHA available — treating every "
+                "failure as blocking (quarantine requires a protected base "
+                "commit; the mutable branch ref is not trusted)."
             )
+        else:
+            try:
+                entries = load_quarantine_from_ref(ctx.base_sha, ctx.repo_root)
+            except QuarantineError as e:
+                entries = []
+                registry_note = (
+                    f"\n\n⚠️ base quarantine registry unreadable — treating "
+                    f"every failure as blocking: {e}"
+                )
         blocking, quarantined = partition_failures(failed_ids, entries)
 
         details = _render_details(blocking, quarantined, log_path) + registry_note

--- a/scripts/pr_validate/steps/full_unit.py
+++ b/scripts/pr_validate/steps/full_unit.py
@@ -21,6 +21,7 @@ wouldn't. A non-quarantined failure still blocks, exactly as before.
 
 from __future__ import annotations
 
+import os
 import subprocess
 import sys
 
@@ -63,6 +64,21 @@ class FullUnitStep(Step):
             "tests/",
             "--ignore=tests/integrations",
             "--ignore=tests/test_event_loop.py",
+            # Neutralize candidate-controlled config: -o addopts= drops the
+            # pytest.ini / pyproject addopts wholesale so a planted -x /
+            # --maxfail / --stepwise / -p no:<reporter> / weaponized -m
+            # filter can't steer the gate (--maxfail=0 alone does NOT stop
+            # --stepwise — codex #1222 r14). We then RE-SPECIFY the marker
+            # filter we actually want below; PYTEST_ADDOPTS is cleared from
+            # the subprocess env for the same reason.
+            "-o",
+            "addopts=",
+            # Re-apply the same exclusions the repo's addopts carried
+            # (slow / integration / needle need real models or a live
+            # server). Hardcoded here so the SELECTION can't be widened or
+            # narrowed by candidate config.
+            "-m",
+            "not slow and not integration and not needle",
             "-q",
             "--no-header",
             # Force color OFF so the summary/label parsing can't be broken
@@ -98,10 +114,15 @@ class FullUnitStep(Step):
         nodeid_log = ctx.artifact_path("full-unit-nodeids.tsv")
         if nodeid_log.exists():
             nodeid_log.unlink()
-        run_env = None
+        # Build the subprocess env with PYTEST_ADDOPTS stripped — it bites
+        # THROUGH ``-o addopts=`` (that only overrides the ini file), so a
+        # candidate env var could still inject --stepwise / -x otherwise
+        # (codex #1222 r14). Done regardless of plugin availability.
+        run_env = dict(os.environ)
+        run_env.pop("PYTEST_ADDOPTS", None)
         if _nodeid_reporter.available():
             plugin_args, run_env = _nodeid_reporter.build_invocation(
-                nodeid_log, ctx.repo_root
+                nodeid_log, ctx.repo_root, base_env=run_env
             )
             cmd += plugin_args
 
@@ -181,6 +202,25 @@ class FullUnitStep(Step):
                 + "\n\n⚠️ structured node-id log absent (reporter plugin did "
                 "not run) — quarantine downgrade withheld; every failure "
                 "blocks.",
+                artifacts=[str(log_path)],
+            )
+
+        # A quarantine downgrade is only sound on a COMPLETE run. If pytest
+        # terminated the session early — --stepwise / -x / --maxfail (a
+        # conftest can still set these programmatically even with addopts
+        # cleared) or any interrupt — a later real regression may simply not
+        # have run yet, so the FAILED set doesn't account for the whole
+        # suite. Withhold the downgrade and block (codex #1222 r14). The
+        # banners pytest prints for these are unambiguous.
+        if _stopped_early(proc.stdout):
+            return StepResult(
+                name=self.name,
+                status="fail",
+                summary=summary_line or "pytest stopped early",
+                details=_render_details(failed_ids, [], log_path)
+                + "\n\n⚠️ pytest terminated the session early (--stepwise / "
+                "-x / --maxfail / interrupt) — the suite did not complete, so "
+                "the quarantine downgrade is withheld; every failure blocks.",
                 artifacts=[str(log_path)],
             )
 
@@ -284,6 +324,20 @@ def _render_unaccounted(
     if not failed_ids and not error_ids:
         parts.append(f"(no parseable FAILED/ERROR node ids — see {log_path})")
     return "\n\n".join(parts)
+
+
+def _stopped_early(stdout: str) -> bool:
+    """True iff pytest terminated the session EARLY (—x / --maxfail /
+    --stepwise / an interrupt) instead of running the whole suite.
+
+    Its interruption banners are unambiguous and stable: ``-x`` / maxfail
+    print ``… stopping after N failures …`` and --stepwise / keyboard /
+    collection interrupts print ``Interrupted: …``. Both land at the left
+    margin (captured test output is indented under its test), so a false
+    positive is unlikely; if one did occur it would only WITHHOLD a
+    downgrade (block), which is the safe direction."""
+    text = stdout or ""
+    return "stopping after" in text or "Interrupted:" in text
 
 
 def _last_summary_line(stdout: str) -> str:

--- a/scripts/pr_validate/steps/full_unit.py
+++ b/scripts/pr_validate/steps/full_unit.py
@@ -24,9 +24,21 @@ from __future__ import annotations
 import subprocess
 import sys
 
+from .._pytest_summary import summary_node_ids
 from ..base import Step, StepResult
 from ..context import Context
-from ..quarantine import QuarantineError, load_quarantine, partition_failures
+from ..quarantine import (
+    QuarantineError,
+    load_quarantine_from_ref,
+    partition_failures,
+)
+
+# pytest exit code 1 is the ordinary "some tests failed" outcome — the
+# only one where the FAILED list fully explains the red. 2 (interrupted),
+# 3 (internal error), 4 (usage), 5 (no tests) all mean something the
+# FAILED list can't account for, so the quarantine downgrade must NOT
+# apply. See https://docs.pytest.org/en/stable/reference/exit-codes.html
+_PYTEST_TESTS_FAILED = 1
 
 
 class FullUnitStep(Step):
@@ -73,39 +85,49 @@ class FullUnitStep(Step):
                 artifacts=[str(log_path)],
             )
 
-        # Non-zero exit. Extract the per-test node ids so we can consult
-        # the quarantine registry.
-        failed_ids = _failed_node_ids(proc.stdout)
+        # Non-zero exit. Extract the per-test node ids (FAILED) and any
+        # ERROR entries (collection / fixture failures) separately.
+        failed_ids = summary_node_ids(proc.stdout, "FAILED")
+        error_ids = summary_node_ids(proc.stdout, "ERROR")
 
-        # If pytest exited non-zero but we parsed NO per-test failures,
-        # this is a collection/internal/xdist-level error we can't name —
-        # never quarantine what we can't identify. Block on the raw exit.
-        if not failed_ids:
-            raw = _extract_failed_lines(proc.stdout)
-            body = raw[:30] if raw else ["(no FAILED lines — see log)"]
-            details = [
-                "**pytest failed with no parseable test ids:**\n```",
-                *body,
-                "```",
-            ]
+        # The quarantine downgrade is only sound when the ONLY thing that
+        # went wrong is ordinary, named test failures we can reason about:
+        #   * exit code exactly 1 (not interrupted / internal / usage), and
+        #   * at least one parseable FAILED id, and
+        #   * NO ERROR entries (an errored test isn't a quarantinable flake
+        #     — the suite couldn't even complete it).
+        # Anything else blocks unconditionally — we never quarantine what
+        # we can't fully account for (codex #1222).
+        only_test_failures = (
+            proc.returncode == _PYTEST_TESTS_FAILED
+            and bool(failed_ids)
+            and not error_ids
+        )
+        if not only_test_failures:
             return StepResult(
                 name=self.name,
                 status="fail",
                 summary=summary_line or f"pytest exited {proc.returncode}",
-                details="\n".join(details),
+                details=_render_unaccounted(
+                    proc.returncode, failed_ids, error_ids, log_path
+                ),
                 artifacts=[str(log_path)],
             )
 
-        # Fail-safe: an unreadable registry means "no quarantine", i.e.
-        # every failure blocks. A broken file can only make us stricter.
+        # Read the registry from the PROTECTED base revision, not the
+        # candidate checkout — a PR must not be able to quarantine its own
+        # failing tests (codex #1222). Fail-safe: any read error → empty
+        # quarantine → every failure blocks (stricter, never looser).
         registry_note = ""
         try:
-            entries = load_quarantine()
+            entries = load_quarantine_from_ref(
+                ctx.base_sha or ctx.base_branch, ctx.repo_root
+            )
         except QuarantineError as e:
             entries = []
             registry_note = (
-                f"\n\n⚠️ quarantine registry unreadable — treating every "
-                f"failure as blocking: {e}"
+                f"\n\n⚠️ base quarantine registry unreadable — treating "
+                f"every failure as blocking: {e}"
             )
         blocking, quarantined = partition_failures(failed_ids, entries)
 
@@ -161,6 +183,29 @@ def _render_details(blocking: list[str], quarantined: list[str], log_path) -> st
     return "\n\n".join(parts)
 
 
+def _render_unaccounted(
+    returncode: int,
+    failed_ids: list[str],
+    error_ids: list[str],
+    log_path,
+) -> str:
+    """Detail block for a red the quarantine logic must NOT relax — an
+    abnormal exit code, an ERROR entry, or no parseable failures. Shows
+    whatever we could name plus why it's blocking."""
+    parts: list[str] = [
+        f"**Blocking — not eligible for quarantine** (pytest exit "
+        f"{returncode}; quarantine only applies to exit "
+        f"{_PYTEST_TESTS_FAILED} with no errors)."
+    ]
+    if failed_ids:
+        parts.append("**FAILED:**\n```\n" + "\n".join(failed_ids[:30]) + "\n```")
+    if error_ids:
+        parts.append("**ERROR:**\n```\n" + "\n".join(error_ids[:30]) + "\n```")
+    if not failed_ids and not error_ids:
+        parts.append(f"(no parseable FAILED/ERROR node ids — see {log_path})")
+    return "\n\n".join(parts)
+
+
 def _last_summary_line(stdout: str) -> str:
     """Pytest writes its overall summary as the very last non-empty
     line wrapped in '====' decorations. Return without decorations."""
@@ -169,39 +214,3 @@ def _last_summary_line(stdout: str) -> str:
         if line.startswith("=") and ("passed" in line or "failed" in line):
             return line.strip("= ").strip()
     return ""
-
-
-def _extract_failed_lines(stdout: str) -> list[str]:
-    """Return the lines pytest's short summary section labels FAILED."""
-    out = []
-    in_summary = False
-    for line in (stdout or "").splitlines():
-        if "short test summary" in line:
-            in_summary = True
-            continue
-        if in_summary:
-            if line.startswith("="):
-                break
-            if line.startswith("FAILED"):
-                out.append(line)
-    return out
-
-
-def _failed_node_ids(stdout: str) -> list[str]:
-    """Extract pytest node ids from the short-summary FAILED lines.
-
-    A FAILED line looks like ``FAILED tests/foo.py::test_bar - AssertionError``
-    or bare ``FAILED tests/foo.py::test_bar``. The node id is the token
-    after ``FAILED `` and before the ``  - <message>`` separator pytest
-    inserts (space-dash-space). Parametrized ids can contain spaces
-    inside ``[...]``, so we split on the first ``" - "`` rather than on
-    whitespace.
-    """
-    ids: list[str] = []
-    for line in _extract_failed_lines(stdout):
-        rest = line[len("FAILED ") :] if line.startswith("FAILED ") else line
-        # Strip the trailing " - <error message>" if present.
-        node_id = rest.split(" - ", 1)[0].strip()
-        if node_id:
-            ids.append(node_id)
-    return ids

--- a/scripts/pr_validate/steps/full_unit.py
+++ b/scripts/pr_validate/steps/full_unit.py
@@ -78,9 +78,15 @@ class FullUnitStep(Step):
             # ordinary test failures" — codex #1222 r3). -rfE is explicit
             # so the gate never depends on pytest's implicit default.
             "-rfE",
-            # Don't stop on first failure — we want the full count for
-            # the scorecard ("3 failed, 2080 passed" is more actionable
-            # than "1 failed, ???? passed").
+            # Don't stop on first failure — we want the full count for the
+            # scorecard, and, critically, the quarantine downgrade is only
+            # SOUND on a COMPLETE run. --maxfail=0 (= no limit) overrides any
+            # -x / --maxfail a candidate planted in pytest.ini / pyproject
+            # addopts (a command-line maxfail wins over the prepended ini
+            # one); without it, a candidate could stop the suite after one
+            # quarantined failure and have the partial, regression-hiding run
+            # accepted as green (codex #1222 r13).
+            "--maxfail=0",
         ]
 
         # Emit a STRUCTURED node-id log via the _nodeid_reporter plugin so
@@ -117,10 +123,14 @@ class FullUnitStep(Step):
             )
 
         # Non-zero exit. Extract the per-test node ids (FAILED) and any
-        # ERROR entries (collection / fixture failures) separately —
-        # preferring the structured plugin log (exact node ids) and
-        # falling back to terminal-summary parsing only if it didn't run.
-        if nodeid_log.exists():
+        # ERROR entries (collection / fixture failures) separately. The
+        # STRUCTURED plugin log carries pytest's exact node ids; the
+        # terminal-summary fallback is ambiguous (its id/message split has
+        # documented edge cases — ``test_x[a] - b]`` …). ``structured``
+        # records which source we got: the quarantine downgrade below is
+        # only granted on the exact source (codex #1222 r13).
+        structured = nodeid_log.exists()
+        if structured:
             failed_ids = report_log_node_ids(nodeid_log, "FAILED")
             error_ids = report_log_node_ids(nodeid_log, "ERROR")
         else:
@@ -148,6 +158,29 @@ class FullUnitStep(Step):
                 details=_render_unaccounted(
                     proc.returncode, failed_ids, error_ids, log_path
                 ),
+                artifacts=[str(log_path)],
+            )
+
+        # The quarantine downgrade turns a red green, so it MUST rest on
+        # pytest's exact ``report.nodeid`` — never the ambiguous summary
+        # fallback, whose id/message split could truncate a param id and
+        # wrongly match a family quarantine entry, waiving a real failure.
+        # If the structured log is absent — the plugin couldn't load, or a
+        # candidate disabled it via pytest plugin config — grant NO
+        # downgrade: every failure blocks, with the fallback ids used only
+        # to REPORT which tests failed. This keeps the ambiguous parser out
+        # of the gating path entirely (it survives only in the advisory
+        # flake_tracking step, where a mis-split is a mislabeled advisory,
+        # not a wrongly-waived gate) (codex #1222 r13).
+        if not structured:
+            return StepResult(
+                name=self.name,
+                status="fail",
+                summary=summary_line or f"pytest exited {proc.returncode}",
+                details=_render_details(failed_ids, [], log_path)
+                + "\n\n⚠️ structured node-id log absent (reporter plugin did "
+                "not run) — quarantine downgrade withheld; every failure "
+                "blocks.",
                 artifacts=[str(log_path)],
             )
 

--- a/scripts/pr_validate/steps/full_unit.py
+++ b/scripts/pr_validate/steps/full_unit.py
@@ -27,10 +27,11 @@ import sys
 
 from .. import _nodeid_reporter
 from .._pytest_summary import report_log_node_ids, summary_node_ids
-from ..base import Step, StepResult
+from ..base import GATING_PYTEST_GUARD, Step, StepResult
 from ..context import Context
 from ..quarantine import (
     QuarantineError,
+    effective_quarantine,
     load_quarantine_from_ref,
     partition_failures,
 )
@@ -103,22 +104,13 @@ class FullUnitStep(Step):
             # quarantined failure and have the partial, regression-hiding run
             # accepted as green (codex #1222 r13).
             "--maxfail=0",
-            # Disable pytest-rerunfailures in the GATING run (codex #1222
-            # r20). This PR adds rerunfailures to the [test] extra so the
-            # advisory flake_tracking step can use it — but it autoloads by
-            # entry point, so without this block a candidate could tag a
-            # genuinely failing test `@pytest.mark.flaky(reruns=N)` (or set
-            # reruns via a conftest) and have full_unit RE-RUN and pass it,
-            # producing exit 0 WITHOUT ever consulting the protected
-            # quarantine registry — defeating the gate and violating the
-            # "advisory never affects the verdict" contract. -o addopts= /
-            # PYTEST_ADDOPTS-strip can't stop an AUTOLOADED plugin, so block
-            # it by its registered name. Verified: `-p no:rerunfailures`
-            # makes the flaky mark inert (the test fails as it should) and is
-            # a harmless no-op when the plugin isn't installed. flake_tracking
-            # re-enables reruns only for its own advisory, post-gating re-run.
-            "-p",
-            "no:rerunfailures",
+            # Block pytest-rerunfailures in this GATING run so a candidate
+            # `@pytest.mark.flaky(reruns=N)` can't rerun-and-pass a real
+            # failure without consulting the quarantine (codex #1222 r20).
+            # Shared with targeted_tests via base.GATING_PYTEST_GUARD so no
+            # gating step can silently forget it (codex #1222 r21). See the
+            # constant's docstring for the full rationale.
+            *GATING_PYTEST_GUARD,
         ]
 
         # Emit a STRUCTURED node-id log via the _nodeid_reporter plugin so
@@ -164,26 +156,60 @@ class FullUnitStep(Step):
         summary_line = _last_summary_line(proc.stdout)
 
         if proc.returncode == 0:
-            # A clean exit is only trustworthy on a COMPLETE run: os._exit(0)
-            # can terminate pytest with code 0 after skipping the rest of the
-            # suite, hiding a regression in the un-run tail (codex #1222 r16
-            # B1). When the reporter ran, require its completion record before
-            # accepting green — an absent record / a ran<collected gap means
-            # the session was truncated. If the plugin couldn't be injected at
-            # all (no structured log), there's no signal to check, so fall
-            # back to the exit code (the degraded, non-candidate path).
-            if structured and not _session_completed(nodeid_log):
-                return StepResult(
-                    name=self.name,
-                    status="fail",
-                    summary=summary_line or "pytest exited 0 but did not complete",
-                    details="⚠️ pytest exited 0 but the session did not run to "
-                    "completion — no session-finish record (os._exit / crash / "
-                    "SIGKILL), or fewer tests ran than were collected. A later "
-                    "regression may not have run, so a truncated run is not "
-                    "accepted as green.",
-                    artifacts=[str(log_path)],
-                )
+            # A clean exit is trustworthy only on a COMPLETE run that recorded
+            # NO failures. When the reporter ran, the STRUCTURED log — not the
+            # exit code — is the source of truth (the exit code is candidate-
+            # influenceable and never trusted over the records):
+            #
+            #   * Completeness: os._exit(0) can terminate pytest with code 0
+            #     after skipping the rest of the suite, hiding a regression in
+            #     the un-run tail (codex #1222 r16 B1). Require the completion
+            #     record — an absent record / a ran<collected gap means the
+            #     session was truncated.
+            #   * No masked failures: a conftest / exit-code plugin can
+            #     normalize a FAILING run to code 0 (e.g. pytest_sessionfinish
+            #     setting session.exitstatus = 0), so a clean exit whose
+            #     structured log carries FAILED / ERROR ids is tampering or a
+            #     bug, not green (codex #1222 r21). Block and surface those
+            #     ids; grant NO quarantine downgrade — a forged clean exit is
+            #     exactly the signal we must not reward. A legitimately green
+            #     run records zero FAILED/ERROR (xfail logs as skipped;
+            #     xfail_strict xpass exits non-zero), so this never fires on a
+            #     real pass.
+            #
+            # If the plugin couldn't be injected at all (no structured log),
+            # there's no signal to check, so fall back to the exit code (the
+            # degraded, non-candidate path; the plugin is always available in
+            # production).
+            if structured:
+                if not _session_completed(nodeid_log):
+                    return StepResult(
+                        name=self.name,
+                        status="fail",
+                        summary=summary_line or "pytest exited 0 but did not complete",
+                        details="⚠️ pytest exited 0 but the session did not run to "
+                        "completion — no session-finish record (os._exit / crash / "
+                        "SIGKILL), or fewer tests ran than were collected. A later "
+                        "regression may not have run, so a truncated run is not "
+                        "accepted as green.",
+                        artifacts=[str(log_path)],
+                    )
+                clean_failed = report_log_node_ids(nodeid_log, "FAILED")
+                clean_errors = report_log_node_ids(nodeid_log, "ERROR")
+                if clean_failed or clean_errors:
+                    return StepResult(
+                        name=self.name,
+                        status="fail",
+                        summary=summary_line or "pytest exited 0 but recorded failures",
+                        details="⚠️ pytest exited 0 but the structured log recorded "
+                        f"{len(clean_failed)} FAILED / {len(clean_errors)} ERROR "
+                        "test(s) — the exit code was normalized away from the real "
+                        "outcome (a conftest / plugin can force exit 0). A forged "
+                        "clean exit is not accepted as green and grants no "
+                        "quarantine downgrade.\n\n"
+                        + _render_details(clean_failed + clean_errors, [], log_path),
+                        artifacts=[str(log_path)],
+                    )
             return StepResult(
                 name=self.name,
                 status="pass",
@@ -295,13 +321,45 @@ class FullUnitStep(Step):
             )
         else:
             try:
-                entries = load_quarantine_from_ref(ctx.base_sha, ctx.repo_root)
+                base_entries = load_quarantine_from_ref(ctx.base_sha, ctx.repo_root)
             except QuarantineError as e:
                 entries = []
                 registry_note = (
                     f"\n\n⚠️ base quarantine registry unreadable — treating "
                     f"every failure as blocking: {e}"
                 )
+            else:
+                # Intersect base with the CANDIDATE registry so a
+                # de-quarantine (removal) in THIS PR is honored: an entry the
+                # PR removed drops out of the effective set, so a still-red
+                # de-quarantined test blocks instead of riding on the stale
+                # base list (codex #1222 r21). Read the candidate from the
+                # pinned PR HEAD sha — symmetric with base, and immune to a
+                # candidate test rewriting the working-tree file at runtime.
+                # The intersection is ALWAYS ⊆ base, so a hostile candidate
+                # registry can only TIGHTEN, never waive more than the base
+                # approved (a PR that DELETES quarantine.yaml → candidate empty
+                # → nothing waived, the correct strict de-quarantine-all).
+                if not ctx.head_sha:
+                    entries = base_entries
+                    registry_note = (
+                        "\n\n⚠️ no PR head SHA — de-quarantine (removal) "
+                        "detection disabled; using the base registry as-is."
+                    )
+                else:
+                    try:
+                        cand_entries = load_quarantine_from_ref(
+                            ctx.head_sha, ctx.repo_root
+                        )
+                    except QuarantineError as e:
+                        entries = base_entries
+                        registry_note = (
+                            f"\n\n⚠️ candidate quarantine registry unreadable — "
+                            f"de-quarantine (removal) detection disabled; using "
+                            f"the base registry as-is: {e}"
+                        )
+                    else:
+                        entries = effective_quarantine(base_entries, cand_entries)
         blocking, quarantined = partition_failures(failed_ids, entries)
 
         details = _render_details(blocking, quarantined, log_path) + registry_note

--- a/scripts/pr_validate/steps/full_unit.py
+++ b/scripts/pr_validate/steps/full_unit.py
@@ -340,11 +340,22 @@ class FullUnitStep(Step):
                 # registry can only TIGHTEN, never waive more than the base
                 # approved (a PR that DELETES quarantine.yaml → candidate empty
                 # → nothing waived, the correct strict de-quarantine-all).
+                #
+                # If the candidate revision can't be read/validated, fail
+                # CLOSED to an EMPTY effective quarantine — NEVER back to the
+                # base list (codex #1222 r22). A candidate CONTROLS its own
+                # committed quarantine.yaml, so falling back to base on a
+                # malformed/corrupt registry would let a PR keep a
+                # base-quarantined but now-failing test green by simply
+                # breaking its own registry. Empty → every failure blocks,
+                # the same fail-closed posture as a missing base sha /
+                # unreadable base registry.
                 if not ctx.head_sha:
-                    entries = base_entries
+                    entries = []
                     registry_note = (
-                        "\n\n⚠️ no PR head SHA — de-quarantine (removal) "
-                        "detection disabled; using the base registry as-is."
+                        "\n\n⚠️ no PR head SHA — cannot confirm the candidate "
+                        "registry; failing closed to an empty quarantine (every "
+                        "failure blocks)."
                     )
                 else:
                     try:
@@ -352,11 +363,11 @@ class FullUnitStep(Step):
                             ctx.head_sha, ctx.repo_root
                         )
                     except QuarantineError as e:
-                        entries = base_entries
+                        entries = []
                         registry_note = (
                             f"\n\n⚠️ candidate quarantine registry unreadable — "
-                            f"de-quarantine (removal) detection disabled; using "
-                            f"the base registry as-is: {e}"
+                            f"failing closed to an empty quarantine (every "
+                            f"failure blocks): {e}"
                         )
                     else:
                         entries = effective_quarantine(base_entries, cand_entries)

--- a/scripts/pr_validate/steps/full_unit.py
+++ b/scripts/pr_validate/steps/full_unit.py
@@ -27,8 +27,12 @@ import sys
 
 from .. import _nodeid_reporter
 from .._pytest_summary import (
+    render_fence_safe,
     report_log_node_ids,
     summary_node_ids,
+)
+from .._pytest_summary import (
+    rerun_detected as _rerun_detected,
 )
 from .._pytest_summary import (
     session_completed as _session_completed,
@@ -437,12 +441,12 @@ def _render_details(blocking: list[str], quarantined: list[str], log_path) -> st
     flagged non-blocking)."""
     parts: list[str] = []
     if blocking:
-        shown = blocking[:30]
+        shown = [render_fence_safe(i) for i in blocking[:30]]
         parts.append("**Failed tests (blocking):**\n```\n" + "\n".join(shown) + "\n```")
         if len(blocking) > 30:
             parts.append(f"…and {len(blocking) - 30} more — see {log_path}")
     if quarantined:
-        shown = quarantined[:30]
+        shown = [render_fence_safe(i) for i in quarantined[:30]]
         parts.append(
             "**Quarantined flakes that failed (non-blocking):**\n```\n"
             + "\n".join(shown)
@@ -468,26 +472,14 @@ def _render_unaccounted(
         f"{_PYTEST_TESTS_FAILED} with no errors)."
     ]
     if failed_ids:
-        parts.append("**FAILED:**\n```\n" + "\n".join(failed_ids[:30]) + "\n```")
+        shown = [render_fence_safe(i) for i in failed_ids[:30]]
+        parts.append("**FAILED:**\n```\n" + "\n".join(shown) + "\n```")
     if error_ids:
-        parts.append("**ERROR:**\n```\n" + "\n".join(error_ids[:30]) + "\n```")
+        shown = [render_fence_safe(i) for i in error_ids[:30]]
+        parts.append("**ERROR:**\n```\n" + "\n".join(shown) + "\n```")
     if not failed_ids and not error_ids:
         parts.append(f"(no parseable FAILED/ERROR node ids — see {log_path})")
     return "\n\n".join(parts)
-
-
-def _rerun_detected(nodeid_log) -> bool:
-    """True iff the reporter logged any RERUN record — pytest-rerunfailures
-    retried a test inside a GATING run that must never rerun.
-
-    ``GATING_PYTEST_GUARD`` blocks the plugin by its registered NAME, but a
-    hostile conftest can register the same plugin under an ARBITRARY name
-    that ``-p no:<name>`` can't reach (verified — a ``@pytest.mark.flaky``
-    marker plus ``config.pluginmanager.register(mod, name="…")`` still
-    reruns) (codex #1222 r23). The reporter records a rerun OUTCOME
-    independent of the plugin's name, so any RERUN record means a real
-    failure could have been retried into a pass — the run is not trusted."""
-    return bool(report_log_node_ids(nodeid_log, _nodeid_reporter.RERUN_LABEL))
 
 
 def _last_summary_line(stdout: str) -> str:

--- a/scripts/pr_validate/steps/full_unit.py
+++ b/scripts/pr_validate/steps/full_unit.py
@@ -64,6 +64,14 @@ class FullUnitStep(Step):
             "--ignore=tests/test_event_loop.py",
             "-q",
             "--no-header",
+            # PIN the short-summary contents: always list FAILED and ERROR
+            # node ids regardless of any future default change. The
+            # quarantine downgrade's soundness rests on being able to SEE
+            # every error (a fixture/collection error must never be
+            # silently absent from the summary and mistaken for "only
+            # ordinary test failures" — codex #1222 r3). -rfE is explicit
+            # so the gate never depends on pytest's implicit default.
+            "-rfE",
             # Don't stop on first failure — we want the full count for
             # the scorecard ("3 failed, 2080 passed" is more actionable
             # than "1 failed, ???? passed").

--- a/scripts/pr_validate/steps/targeted_tests.py
+++ b/scripts/pr_validate/steps/targeted_tests.py
@@ -123,28 +123,35 @@ class TargetedTestsStep(Step):
         # no-collection run WITHOUT a deselection (an empty/renamed file, or a
         # candidate ``python_files`` matching nothing) has no "deselected" in
         # pytest's summary and no structured ERROR, so it stays BLOCKED by
-        # ``_untrusted_run_reason`` below. The summary is pytest's own output;
-        # candidate addopts is already neutralized (``-o addopts=``), and the
-        # ``-m`` filter is gate-owned, so "deselected" can't be candidate-forged
-        # (a conftest that deselects everything is the documented collection
-        # residual, and full_unit still runs the whole suite regardless).
+        # ``_untrusted_run_reason`` below. Candidate ``addopts`` is neutralized
+        # (``-o addopts=``) and the ``-m`` filter is gate-owned.
         #
-        # BOUNDARY (codex #1222 r30): an author could newly mark a *changed*
-        # test ``slow``/``integration``/``needle`` to move it out of this fast
-        # gate — and on a LOW-blast PR (full_unit skipped) nothing else here
-        # runs it. This fast gate cannot close that: it deliberately does NOT
-        # run those markers (they need real models / a live server — the very
-        # reason they're excluded), so it can't tell a broken new slow test
-        # from a legitimately-slow passing one. And the base-comparison codex
-        # proposed is BACKWARDS — a *new* broken slow test is absent on base
-        # (so a "did base run it?" check misses exactly the dangerous case)
-        # while an existing test legitimately reclassified as slow WOULD trip
-        # it (a false block of routine maintenance). Marking a test slow is a
-        # uniform repo policy (full_unit excludes the same markers), owned by
-        # the separate slow-lane CI that runs ``-m slow`` + diff review that
-        # sees the added marker — NOT this gate. We therefore SKIP (never
-        # false-block legitimate reclassification) but make it LOUD so a
-        # reviewer is prompted to confirm the reclassification is intentional.
+        # BOUNDARY (codex #1222 r30/r31) — this SKIP is the in-process
+        # collection-control residual (r27), NOT a closed hole, and the earlier
+        # "full_unit runs the whole suite regardless" reassurance was WRONG on a
+        # low-blast PR (full_unit is skipped, so targeted is the only
+        # candidate-test gate). Two routes reach an all-deselected exit 5:
+        #   (a) an author newly marks a *changed* test slow/integration/needle
+        #       to move it out of this fast gate; and
+        #   (b) a candidate ``conftest.py`` deselects from
+        #       ``pytest_collection_modifyitems`` (``-o addopts=`` doesn't stop
+        #       conftest loading), forging the "deselected" summary.
+        # Neither is soundly closeable here. This gate DELIBERATELY cannot run
+        # slow/integration/needle tests (they need real models / a live server —
+        # the reason they're excluded), so it can't tell a broken new slow test
+        # from a legitimately-slow passing one. codex's "block unless the base
+        # proves the exclusion pre-existing" is BACKWARDS AND incomplete: a
+        # *new* broken slow test is absent on base (so a "did base run it?"
+        # check misses exactly the dangerous case) while an existing test
+        # legitimately reclassified WOULD trip it (a false block of routine
+        # maintenance) — and either attacker can instead deselect JUST the one
+        # failing test (exit 0, not 5), sailing past any exit-5 rule. That
+        # surgical exit-0 deselection is the fundamental r27 residual: no
+        # in-process count/manifest floor closes it. The real defenses are the
+        # separate slow-lane CI (``-m slow``) and diff review (which sees the
+        # added marker or conftest hook). We therefore SKIP (never false-block
+        # legitimate reclassification) but make it LOUD so a reviewer is
+        # prompted to confirm the deselection is intentional.
         if pr.returncode == 5 and "deselected" in pr.summary and not pr.errored:
             return StepResult(
                 name=self.name,

--- a/scripts/pr_validate/steps/targeted_tests.py
+++ b/scripts/pr_validate/steps/targeted_tests.py
@@ -38,7 +38,7 @@ import sys
 import tempfile
 from pathlib import Path
 
-from ..base import Step, StepResult
+from ..base import GATING_PYTEST_GUARD, Step, StepResult
 from ..context import Context
 
 
@@ -216,6 +216,11 @@ _PYTEST_CMD = [
     "-q",
     "--no-header",
     "--tb=no",  # we don't render tracebacks here; the artifact has them
+    # Block pytest-rerunfailures so a candidate ``@pytest.mark.flaky`` on a
+    # changed test can't rerun-and-pass a real failure past this gate — same
+    # reason as full_unit (codex #1222 r21). Used by both _run_pytest (the
+    # candidate run) and _run_on_main (the negative control).
+    *GATING_PYTEST_GUARD,
 ]
 
 

--- a/scripts/pr_validate/steps/targeted_tests.py
+++ b/scripts/pr_validate/steps/targeted_tests.py
@@ -32,7 +32,6 @@ on PR → real regression → BLOCK.
 from __future__ import annotations
 
 import os
-import re
 import shutil
 import subprocess
 import sys
@@ -46,6 +45,7 @@ from .._pytest_summary import (
     report_log_node_ids,
     rerun_detected,
     session_completed,
+    summary_node_ids,
 )
 from ..base import GATING_PYTEST_GUARD, Step, StepResult
 from ..context import Context
@@ -454,7 +454,7 @@ def _run_pytest(
     else:
         reran = errored = False
         complete = True
-        failed = _extract_failed_node_ids(proc.stdout)
+        failed = summary_node_ids(proc.stdout, "FAILED")
     return _PytestRun(
         summary=summary,
         failed=failed,
@@ -508,7 +508,15 @@ def _run_on_main(
                 cwd=str(tmp),
             )
             log_path.write_text((proc.stdout or "") + (proc.stderr or ""))
-            return _extract_failed_node_ids(proc.stdout)
+            # Space-preserving scrape (NOT a ``\S+`` grab): the PR side now
+            # records canonical ``report.nodeid`` via the reporter, so a
+            # pre-existing failure whose param id contains spaces —
+            # ``test_x[param with spaces]`` — must be parsed whole here too,
+            # or the truncated base id wouldn't match the PR id and the
+            # pre-existing failure would be misclassified as a PR-only
+            # regression (codex #1222 r29). The base predates the reporter,
+            # so we scrape its stdout rather than inject the plugin.
+            return summary_node_ids(proc.stdout, "FAILED")
         finally:
             # Remove the worktree even if pytest crashed.
             subprocess.run(  # noqa: S603
@@ -521,26 +529,6 @@ def _run_on_main(
         # In case `git worktree remove` failed, nuke the dir.
         if tmp.exists():
             shutil.rmtree(tmp, ignore_errors=True)
-
-
-_FAIL_RE = re.compile(r"^FAILED\s+(\S+)")
-
-
-def _extract_failed_node_ids(stdout: str) -> list[str]:
-    """Pull the FAILED <node_id> lines from pytest's short summary."""
-    out = []
-    in_summary = False
-    for line in (stdout or "").splitlines():
-        if "short test summary" in line:
-            in_summary = True
-            continue
-        if in_summary:
-            if line.startswith("="):
-                break
-            m = _FAIL_RE.match(line)
-            if m:
-                out.append(m.group(1))
-    return out
 
 
 def _failed_block(items: list[str]) -> str:

--- a/scripts/pr_validate/steps/targeted_tests.py
+++ b/scripts/pr_validate/steps/targeted_tests.py
@@ -42,6 +42,7 @@ from typing import NamedTuple
 
 from .. import _nodeid_reporter
 from .._pytest_summary import (
+    last_summary_line,
     report_log_node_ids,
     rerun_detected,
     session_completed,
@@ -109,6 +110,31 @@ class TargetedTestsStep(Step):
                 "it was smuggled in under a different name. A rerun can retry a "
                 "real failure into a pass, so this run is not trusted; reruns "
                 "must be OFF for the gate.",
+                artifacts=[str(pr_log)],
+            )
+
+        # The gate-owned ``-m "not slow and not integration and not needle"``
+        # filter can legitimately deselect EVERY test in the targeted files (a
+        # PR touching only slow/integration/needle tests), which makes pytest
+        # exit 5 ("no tests collected"). That is NOT a tamper signal — nothing
+        # gate-relevant remained to run — so SKIP rather than block on the exit
+        # code (codex #1222 r28, a regression from the r27 ``-m`` re-apply). A
+        # no-collection run WITHOUT a deselection (an empty/renamed file, or a
+        # candidate ``python_files`` matching nothing) has no "deselected" in
+        # pytest's summary and no structured ERROR, so it stays BLOCKED by
+        # ``_untrusted_run_reason`` below. The summary is pytest's own output;
+        # candidate addopts is already neutralized (``-o addopts=``), and the
+        # ``-m`` filter is gate-owned, so "deselected" can't be candidate-forged
+        # (a conftest that deselects everything is the documented collection
+        # residual, and full_unit still runs the whole suite regardless).
+        if pr.returncode == 5 and "deselected" in pr.summary and not pr.errored:
+            return StepResult(
+                name=self.name,
+                status="skip",
+                summary=(
+                    f"{pr.summary} (all targets deselected by the gate "
+                    f"marker filter — nothing gate-relevant to run)"
+                ),
                 artifacts=[str(pr_log)],
             )
 
@@ -407,7 +433,7 @@ def _run_pytest(
         env=env,
     )
     log_path.write_text((proc.stdout or "") + (proc.stderr or ""))
-    summary = _last_summary_line(proc.stdout) or f"exit {proc.returncode}"
+    summary = last_summary_line(proc.stdout) or f"exit {proc.returncode}"
     # Reporter-derived signals. Without the reporter we can't prove
     # completeness / distinguish ERROR from a clean run, so degrade to the
     # trusting defaults (structured=False, reran/errored=False, complete=True)
@@ -495,26 +521,6 @@ def _run_on_main(
         # In case `git worktree remove` failed, nuke the dir.
         if tmp.exists():
             shutil.rmtree(tmp, ignore_errors=True)
-
-
-_SUMMARY_RE = re.compile(
-    r"\b\d+ (passed|failed|error|skipped|xfailed|xpassed|deselected)\b"
-)
-
-
-def _last_summary_line(stdout: str) -> str:
-    # Match pytest's final counts line whether or not it carries the ``====``
-    # bars. In verbose mode the line is fenced (``==== 3 passed in 1s ====``),
-    # but once the inherited ``-v`` is dropped (``-o addopts=`` neutralizes the
-    # repo addopts) pytest prints it bar-less (``3 passed in 1s``), so a
-    # ``startswith("=")`` rule would miss it and fall back to a bare "exit 0"
-    # (codex #1222 r26). Anchor on the ``<n> <outcome>`` shape + the timing
-    # suffix instead so both forms are recognized.
-    for line in reversed((stdout or "").splitlines()):
-        stripped = line.strip().strip("=").strip()
-        if _SUMMARY_RE.search(stripped) and " in " in stripped:
-            return stripped
-    return ""
 
 
 _FAIL_RE = re.compile(r"^FAILED\s+(\S+)")

--- a/scripts/pr_validate/steps/targeted_tests.py
+++ b/scripts/pr_validate/steps/targeted_tests.py
@@ -38,9 +38,14 @@ import subprocess
 import sys
 import tempfile
 from pathlib import Path
+from typing import NamedTuple
 
 from .. import _nodeid_reporter
-from .._pytest_summary import rerun_detected
+from .._pytest_summary import (
+    report_log_node_ids,
+    rerun_detected,
+    session_completed,
+)
 from ..base import GATING_PYTEST_GUARD, Step, StepResult
 from ..context import Context
 
@@ -84,9 +89,7 @@ class TargetedTestsStep(Step):
         # PR head here too.
         pr_log = ctx.artifact_path("targeted-pr.log")
         pr_nodeids = ctx.artifact_path("targeted-pr-nodeids.tsv")
-        pr_summary, pr_failed, pr_reran = _run_pytest(
-            targets, pr_log, ctx.repo_root, pr_nodeids
-        )
+        pr = _run_pytest(targets, pr_log, ctx.repo_root, pr_nodeids)
 
         # A GATING run must never rerun. targeted_tests is the FIRST — and,
         # for a low-blast PR where full_unit is skipped, the ONLY — gating
@@ -96,11 +99,11 @@ class TargetedTestsStep(Step):
         # and if full_unit never runs, nothing else would catch the rerun
         # (codex #1222 r24). Any RERUN record → a real failure may have been
         # retried to green → block, regardless of the scraped FAILED set.
-        if pr_reran:
+        if pr.reran:
             return StepResult(
                 name=self.name,
                 status="fail",
-                summary=f"{pr_summary} (gating run reran a test)",
+                summary=f"{pr.summary} (gating run reran a test)",
                 details="⚠️ the targeted gating run reran at least one test — "
                 "pytest-rerunfailures was active despite the by-name block, so "
                 "it was smuggled in under a different name. A rerun can retry a "
@@ -109,13 +112,37 @@ class TargetedTestsStep(Step):
                 artifacts=[str(pr_log)],
             )
 
-        if not pr_failed:
+        # An empty scraped FAILED list is only a genuine PASS when the run
+        # actually finished as an ORDINARY pass (exit 0) or fail (exit 1).
+        # ``_run_pytest`` scrapes only ``FAILED`` summary lines, so a
+        # collection error, a usage error, "no tests collected", or an early
+        # ``pytest.exit`` would otherwise slip through as a false green with
+        # an empty FAILED set — the same class of hole full_unit closes with
+        # its exit-code / ERROR / session-completeness checks (codex #1222
+        # r25). Gate on those signals BEFORE trusting an empty FAILED list.
+        untrusted = _untrusted_run_reason(pr.returncode, pr.errored, pr.complete)
+        if untrusted:
+            return StepResult(
+                name=self.name,
+                status="fail",
+                summary=f"{pr.summary} (untrusted targeted run)",
+                details=(
+                    f"⚠️ the targeted run cannot be trusted as green: {untrusted}. "
+                    "An empty FAILED list is not accepted as a pass on an "
+                    "abnormal/truncated run — blocking fail-safe."
+                ),
+                artifacts=[str(pr_log)],
+            )
+
+        if not pr.failed:
             return StepResult(
                 name=self.name,
                 status="pass",
-                summary=f"{pr_summary} (in {len(targets)} target file(s))",
+                summary=f"{pr.summary} (in {len(targets)} target file(s))",
                 artifacts=[str(pr_log)],
             )
+
+        pr_failed = pr.failed
 
         # Failures on PR branch — run negative control on main.
         ctx.run_log(
@@ -251,18 +278,70 @@ _PYTEST_CMD = [
 ]
 
 
+class _PytestRun(NamedTuple):
+    """Result of a targeted pytest run.
+
+    ``failed`` is the scraped ``FAILED`` node-id list (empty => none scraped).
+    ``reran`` / ``errored`` / ``complete`` come from the structured reporter
+    when it was injected; without it (``nodeid_log`` absent / plugin
+    unimportable) they degrade to the trusting defaults ``False`` / ``False``
+    / ``True`` so a legacy no-reporter run behaves as before. ``returncode``
+    is always pytest's real exit code."""
+
+    summary: str
+    failed: list[str]
+    reran: bool
+    returncode: int
+    errored: bool
+    complete: bool
+
+
+def _untrusted_run_reason(returncode: int, errored: bool, complete: bool) -> str | None:
+    """Why a targeted run can't be trusted as a clean pass/fail, or ``None``.
+
+    An empty scraped ``FAILED`` list only means "clean" when the run finished
+    as an ordinary pass (exit 0) or fail (exit 1). Any OTHER exit — collection
+    error (2), internal error (3), usage error (4), no tests collected (5) — or
+    a structured ``ERROR`` record (a collection / setup / teardown failure,
+    which NEVER appears as a ``FAILED`` summary line so it can't be
+    negative-control filtered), or a truncated session (an early
+    ``pytest.exit`` / crash before the session-finish record) would otherwise
+    slip through as a false green with an empty FAILED set (codex #1222 r25).
+    ``errored`` / ``complete`` are only meaningful when the structured reporter
+    ran; the caller passes the trusting defaults otherwise."""
+    if returncode not in (0, 1):
+        return (
+            f"pytest exited {returncode} (not a plain pass=0 / fail=1 — a "
+            "collection/usage/internal error, or no tests were collected)"
+        )
+    if errored:
+        return (
+            "the structured log recorded an ERROR (collection or "
+            "setup/teardown failure), which never scrapes as a FAILED line"
+        )
+    if not complete:
+        return (
+            "pytest did not run to completion (an early pytest.exit / crash "
+            "before the session-finish record) — a truncated run is not green"
+        )
+    return None
+
+
 def _run_pytest(
     targets: list[str], log_path: Path, cwd: Path, nodeid_log: Path | None = None
-) -> tuple[str, list[str], bool]:
-    """Run pytest against ``targets``. Returns (one-line summary, list of
-    FAILED node IDs, reran) where ``reran`` is True iff the run reran a test
-    (a gating run must never rerun). Empty failed list => clean run.
+) -> _PytestRun:
+    """Run pytest against ``targets``. Returns a ``_PytestRun`` — the one-line
+    summary, scraped FAILED node IDs, and the structured-reporter signals
+    (``reran`` / ``errored`` / ``complete``) plus the real exit code. A gating
+    run must never rerun; and an empty FAILED list is only trusted as a pass
+    when the exit code + reporter signals confirm an ordinary complete run
+    (see ``_untrusted_run_reason``).
 
     When ``nodeid_log`` is given and the reporter plugin is importable, the
-    run emits the structured RERUN record used for the name-independent
-    rerun backstop. ``cwd`` (the PR head worktree) must contain the reporter
-    module — it does, since this PR adds it; the negative-control run on the
-    protected base does NOT inject it (the base predates the plugin)."""
+    run emits the structured RERUN / ERROR / SESSIONFINISH records those
+    signals read from. ``cwd`` (the PR head worktree) must contain the
+    reporter module — it does, since this PR adds it; the negative-control run
+    on the protected base does NOT inject it (the base predates the plugin)."""
     cmd = [*_PYTEST_CMD, *targets]
     env = dict(os.environ)
     env.pop("PYTEST_ADDOPTS", None)
@@ -273,7 +352,7 @@ def _run_pytest(
         )
         cmd += plugin_args
         # Start-sentinel so an empty log is distinguishable from "plugin
-        # never ran" (mirrors full_unit); rerun detection reads it below.
+        # never ran" (mirrors full_unit); the signals below read it back.
         nodeid_log.write_text("", encoding="utf-8")
     proc = subprocess.run(  # noqa: S603
         cmd,
@@ -285,8 +364,24 @@ def _run_pytest(
     log_path.write_text((proc.stdout or "") + (proc.stderr or ""))
     summary = _last_summary_line(proc.stdout) or f"exit {proc.returncode}"
     failed = _extract_failed_node_ids(proc.stdout)
-    reran = bool(inject and nodeid_log.exists() and rerun_detected(nodeid_log))
-    return summary, failed, reran
+    # Reporter-derived signals. Without the reporter we can't prove
+    # completeness / distinguish ERROR from a clean run, so degrade to the
+    # trusting defaults (reran=False, errored=False, complete=True) — the
+    # exit-code check in _untrusted_run_reason still applies either way.
+    reran = errored = False
+    complete = True
+    if inject and nodeid_log.exists():
+        reran = rerun_detected(nodeid_log)
+        errored = bool(report_log_node_ids(nodeid_log, "ERROR"))
+        complete = session_completed(nodeid_log)
+    return _PytestRun(
+        summary=summary,
+        failed=failed,
+        reran=reran,
+        returncode=proc.returncode,
+        errored=errored,
+        complete=complete,
+    )
 
 
 def _run_on_main(

--- a/scripts/pr_validate/steps/targeted_tests.py
+++ b/scripts/pr_validate/steps/targeted_tests.py
@@ -279,6 +279,14 @@ _PYTEST_CMD = [
     # repo's own ``addopts`` is empty, so this is a no-op on the trusted base.
     "-o",
     "addopts=",
+    # Re-apply the marker exclusion the repo's addopts carried (slow /
+    # integration / needle need real models or a live server). ``-o addopts=``
+    # above dropped it, so re-specify it HARDCODED — exactly as full_unit does
+    # — so the selection can't be widened/narrowed by candidate config and
+    # targeted keeps the same exclusion it inherited before the addopts was
+    # neutralized (codex #1222 r26).
+    "-m",
+    "not slow and not integration and not needle",
     "-q",
     "--no-header",
     "--tb=no",  # we don't render tracebacks here; the artifact has them
@@ -489,11 +497,23 @@ def _run_on_main(
             shutil.rmtree(tmp, ignore_errors=True)
 
 
+_SUMMARY_RE = re.compile(
+    r"\b\d+ (passed|failed|error|skipped|xfailed|xpassed|deselected)\b"
+)
+
+
 def _last_summary_line(stdout: str) -> str:
+    # Match pytest's final counts line whether or not it carries the ``====``
+    # bars. In verbose mode the line is fenced (``==== 3 passed in 1s ====``),
+    # but once the inherited ``-v`` is dropped (``-o addopts=`` neutralizes the
+    # repo addopts) pytest prints it bar-less (``3 passed in 1s``), so a
+    # ``startswith("=")`` rule would miss it and fall back to a bare "exit 0"
+    # (codex #1222 r26). Anchor on the ``<n> <outcome>`` shape + the timing
+    # suffix instead so both forms are recognized.
     for line in reversed((stdout or "").splitlines()):
-        line = line.strip()
-        if line.startswith("=") and ("passed" in line or "failed" in line):
-            return line.strip("= ").strip()
+        stripped = line.strip().strip("=").strip()
+        if _SUMMARY_RE.search(stripped) and " in " in stripped:
+            return stripped
     return ""
 
 

--- a/scripts/pr_validate/steps/targeted_tests.py
+++ b/scripts/pr_validate/steps/targeted_tests.py
@@ -120,7 +120,7 @@ class TargetedTestsStep(Step):
         # an empty FAILED set — the same class of hole full_unit closes with
         # its exit-code / ERROR / session-completeness checks (codex #1222
         # r25). Gate on those signals BEFORE trusting an empty FAILED list.
-        untrusted = _untrusted_run_reason(pr.returncode, pr.errored, pr.complete)
+        untrusted = _untrusted_run_reason(pr)
         if untrusted:
             return StepResult(
                 name=self.name,
@@ -267,9 +267,33 @@ _PYTEST_CMD = [
     sys.executable,
     "-m",
     "pytest",
+    # Neutralize candidate-controlled config: ``-o addopts=`` drops the
+    # pytest.ini / pyproject ``addopts`` wholesale, so a planted ``--deselect``
+    # / weaponized ``-m`` filter / ``-x`` / ``-rN`` can't steer this GATING run
+    # — a subset that omits the changed failing test would otherwise exit 0 and
+    # false-pass (codex #1222 r26). Every option we rely on is spelled out
+    # explicitly below (never inherited from addopts), and ``PYTEST_ADDOPTS``
+    # is popped from the subprocess env in ``_run_pytest`` because it bites
+    # THROUGH ``-o addopts=`` (that only overrides the ini file). Shared by the
+    # PR run AND the negative control so both stay hermetic and symmetric — the
+    # repo's own ``addopts`` is empty, so this is a no-op on the trusted base.
+    "-o",
+    "addopts=",
     "-q",
     "--no-header",
     "--tb=no",  # we don't render tracebacks here; the artifact has them
+    # Force color OFF and PIN the short summary to list FAILED + ERROR. The
+    # negative control (`_run_on_main`) runs on the pre-plugin base and so
+    # CANNOT use the structured reporter — it must scrape stdout, and that
+    # scrape has to be a stable, ANSI-free summary regardless of an inherited
+    # PY_COLORS or a future pytest default (mirrors full_unit, codex #1222 r6).
+    "--color=no",
+    "-rfE",
+    # No early stop — a candidate ``-x`` / ``--maxfail`` must not truncate the
+    # failure set the negative control compares (a command-line ``--maxfail=0``
+    # overrides any ini one); an early stop would also trip the completeness
+    # guard in ``_untrusted_run_reason``.
+    "--maxfail=0",
     # Block pytest-rerunfailures so a candidate ``@pytest.mark.flaky`` on a
     # changed test can't rerun-and-pass a real failure past this gate — same
     # reason as full_unit (codex #1222 r21). Used by both _run_pytest (the
@@ -281,12 +305,15 @@ _PYTEST_CMD = [
 class _PytestRun(NamedTuple):
     """Result of a targeted pytest run.
 
-    ``failed`` is the scraped ``FAILED`` node-id list (empty => none scraped).
-    ``reran`` / ``errored`` / ``complete`` come from the structured reporter
-    when it was injected; without it (``nodeid_log`` absent / plugin
-    unimportable) they degrade to the trusting defaults ``False`` / ``False``
-    / ``True`` so a legacy no-reporter run behaves as before. ``returncode``
-    is always pytest's real exit code."""
+    ``failed`` is the authoritative FAILED node-id list: read from the
+    structured reporter when it was injected, else scraped from stdout.
+    ``reran`` / ``errored`` / ``complete`` / ``structured`` also come from the
+    reporter; without it (``nodeid_log`` absent / plugin unimportable) they
+    degrade to the trusting defaults ``False`` / ``False`` / ``True`` /
+    ``False`` so a legacy no-reporter run behaves as before. ``returncode`` is
+    always pytest's real exit code; ``structured`` records whether the reporter
+    ran, so the exit-code / completeness / unaccounted-exit checks know when
+    they may trust the reporter-derived fields."""
 
     summary: str
     failed: list[str]
@@ -294,35 +321,45 @@ class _PytestRun(NamedTuple):
     returncode: int
     errored: bool
     complete: bool
+    structured: bool
 
 
-def _untrusted_run_reason(returncode: int, errored: bool, complete: bool) -> str | None:
+def _untrusted_run_reason(run: _PytestRun) -> str | None:
     """Why a targeted run can't be trusted as a clean pass/fail, or ``None``.
 
-    An empty scraped ``FAILED`` list only means "clean" when the run finished
-    as an ordinary pass (exit 0) or fail (exit 1). Any OTHER exit — collection
-    error (2), internal error (3), usage error (4), no tests collected (5) — or
-    a structured ``ERROR`` record (a collection / setup / teardown failure,
-    which NEVER appears as a ``FAILED`` summary line so it can't be
-    negative-control filtered), or a truncated session (an early
-    ``pytest.exit`` / crash before the session-finish record) would otherwise
-    slip through as a false green with an empty FAILED set (codex #1222 r25).
-    ``errored`` / ``complete`` are only meaningful when the structured reporter
-    ran; the caller passes the trusting defaults otherwise."""
-    if returncode not in (0, 1):
+    An empty ``FAILED`` list only means "clean" when the run finished as an
+    ordinary pass (exit 0) or fail (exit 1). Any OTHER exit — collection error
+    (2), internal error (3), usage error (4), no tests collected (5) — or a
+    structured ``ERROR`` record (a collection / setup / teardown failure, which
+    NEVER appears as a ``FAILED`` line so it can't be negative-control
+    filtered), or a truncated session (an early ``pytest.exit`` / crash before
+    the session-finish record) would otherwise slip through as a false green
+    with an empty FAILED set (codex #1222 r25). And an exit of 1 with NO
+    structured FAILED/RERUN record accounting for it means the failure summary
+    was suppressed (``-rN`` / a summary-blanking addopts) — the empty list is
+    not trusted (codex #1222 r26). The reporter-derived checks apply only when
+    ``run.structured`` (the reporter ran); otherwise the caller passed the
+    trusting defaults and only the exit-code check is meaningful."""
+    if run.returncode not in (0, 1):
         return (
-            f"pytest exited {returncode} (not a plain pass=0 / fail=1 — a "
+            f"pytest exited {run.returncode} (not a plain pass=0 / fail=1 — a "
             "collection/usage/internal error, or no tests were collected)"
         )
-    if errored:
+    if run.errored:
         return (
             "the structured log recorded an ERROR (collection or "
             "setup/teardown failure), which never scrapes as a FAILED line"
         )
-    if not complete:
+    if not run.complete:
         return (
             "pytest did not run to completion (an early pytest.exit / crash "
             "before the session-finish record) — a truncated run is not green"
+        )
+    if run.returncode == 1 and run.structured and not run.failed and not run.reran:
+        return (
+            "pytest exited 1 but no structured FAILED/RERUN record accounts "
+            "for it — the failure summary was suppressed; an empty FAILED list "
+            "is not accepted as green"
         )
     return None
 
@@ -363,17 +400,27 @@ def _run_pytest(
     )
     log_path.write_text((proc.stdout or "") + (proc.stderr or ""))
     summary = _last_summary_line(proc.stdout) or f"exit {proc.returncode}"
-    failed = _extract_failed_node_ids(proc.stdout)
     # Reporter-derived signals. Without the reporter we can't prove
     # completeness / distinguish ERROR from a clean run, so degrade to the
-    # trusting defaults (reran=False, errored=False, complete=True) — the
-    # exit-code check in _untrusted_run_reason still applies either way.
-    reran = errored = False
-    complete = True
-    if inject and nodeid_log.exists():
+    # trusting defaults (structured=False, reran/errored=False, complete=True)
+    # and fall back to scraping stdout for FAILED — the exit-code check in
+    # _untrusted_run_reason still applies either way.
+    structured = inject and nodeid_log.exists()
+    if structured:
         reran = rerun_detected(nodeid_log)
         errored = bool(report_log_node_ids(nodeid_log, "ERROR"))
         complete = session_completed(nodeid_log)
+        # Take FAILED from the reporter's records, NOT scraped stdout: a
+        # candidate that suppresses the short summary (``-rN`` / a
+        # summary-blanking addopts, though addopts is already neutralized)
+        # would blank the scrape and false-pass, but the structured FAILED
+        # record is written per failing outcome and can't be turned off from
+        # candidate config (codex #1222 r26).
+        failed = report_log_node_ids(nodeid_log, "FAILED")
+    else:
+        reran = errored = False
+        complete = True
+        failed = _extract_failed_node_ids(proc.stdout)
     return _PytestRun(
         summary=summary,
         failed=failed,
@@ -381,6 +428,7 @@ def _run_pytest(
         returncode=proc.returncode,
         errored=errored,
         complete=complete,
+        structured=structured,
     )
 
 

--- a/scripts/pr_validate/steps/targeted_tests.py
+++ b/scripts/pr_validate/steps/targeted_tests.py
@@ -42,6 +42,7 @@ from typing import NamedTuple
 from .. import _nodeid_reporter
 from .._pytest_summary import (
     last_summary_line,
+    render_fence_safe,
     report_log_node_ids,
     rerun_detected,
     session_completed,
@@ -127,13 +128,33 @@ class TargetedTestsStep(Step):
         # ``-m`` filter is gate-owned, so "deselected" can't be candidate-forged
         # (a conftest that deselects everything is the documented collection
         # residual, and full_unit still runs the whole suite regardless).
+        #
+        # BOUNDARY (codex #1222 r30): an author could newly mark a *changed*
+        # test ``slow``/``integration``/``needle`` to move it out of this fast
+        # gate — and on a LOW-blast PR (full_unit skipped) nothing else here
+        # runs it. This fast gate cannot close that: it deliberately does NOT
+        # run those markers (they need real models / a live server — the very
+        # reason they're excluded), so it can't tell a broken new slow test
+        # from a legitimately-slow passing one. And the base-comparison codex
+        # proposed is BACKWARDS — a *new* broken slow test is absent on base
+        # (so a "did base run it?" check misses exactly the dangerous case)
+        # while an existing test legitimately reclassified as slow WOULD trip
+        # it (a false block of routine maintenance). Marking a test slow is a
+        # uniform repo policy (full_unit excludes the same markers), owned by
+        # the separate slow-lane CI that runs ``-m slow`` + diff review that
+        # sees the added marker — NOT this gate. We therefore SKIP (never
+        # false-block legitimate reclassification) but make it LOUD so a
+        # reviewer is prompted to confirm the reclassification is intentional.
         if pr.returncode == 5 and "deselected" in pr.summary and not pr.errored:
             return StepResult(
                 name=self.name,
                 status="skip",
                 summary=(
-                    f"{pr.summary} (all targets deselected by the gate "
-                    f"marker filter — nothing gate-relevant to run)"
+                    f"⚠ REVIEW: {pr.summary} — every targeted test was "
+                    f"deselected by the slow/integration/needle filter. If this "
+                    f"PR newly marked a changed test with one of those markers, "
+                    f"its failures run only in the slow-lane CI, not here; "
+                    f"confirm the reclassification is intentional."
                 ),
                 artifacts=[str(pr_log)],
             )
@@ -223,12 +244,15 @@ class TargetedTestsStep(Step):
                 artifacts=[str(pr_log), str(main_log)],
             )
 
-        details = ["**Regressions (fail on PR, pass on main):**", "```"]
-        details.extend(regressions)
-        details.append("```")
+        details = [
+            "**Regressions (fail on PR, pass on main):**",
+            "```",
+            _failed_block(regressions),
+            "```",
+        ]
         if pre_existing:
             details.append("\n**Pre-existing (also fail on main, not blocking):**\n```")
-            details.extend(pre_existing)
+            details.append(_failed_block(pre_existing))
             details.append("```")
         return StepResult(
             name=self.name,
@@ -508,14 +532,28 @@ def _run_on_main(
                 cwd=str(tmp),
             )
             log_path.write_text((proc.stdout or "") + (proc.stderr or ""))
-            # Space-preserving scrape (NOT a ``\S+`` grab): the PR side now
-            # records canonical ``report.nodeid`` via the reporter, so a
-            # pre-existing failure whose param id contains spaces —
-            # ``test_x[param with spaces]`` — must be parsed whole here too,
-            # or the truncated base id wouldn't match the PR id and the
-            # pre-existing failure would be misclassified as a PR-only
-            # regression (codex #1222 r29). The base predates the reporter,
-            # so we scrape its stdout rather than inject the plugin.
+            # Space-preserving scrape (NOT a ``\S+`` grab): the PR side records
+            # canonical ``report.nodeid`` via the reporter, so a pre-existing
+            # failure whose param id contains spaces — ``test_x[param with
+            # spaces]`` — must be parsed whole here too, or the truncated base
+            # id wouldn't match the PR id and the pre-existing failure would be
+            # misclassified as a PR-only regression (codex #1222 r29).
+            #
+            # RESIDUAL (codex #1222 r30, fail-safe): ``summary_node_ids`` is
+            # exact for normal ids but IRREDUCIBLY ambiguous for an id that
+            # itself contains ``" - "`` with unbalanced brackets
+            # (``test_x[a] - b]``) — the same wall that motivated the structured
+            # reporter plugin (see its module docstring; codex r4/r5/r6/r9/r10).
+            # The base predates that plugin, so it cannot get canonical ids here,
+            # and injecting the PR checkout's plugin would drag the PR's library
+            # onto the base run's ``PYTHONPATH`` — contaminating the negative
+            # control (base TEST files run against PR code), a worse and unsound
+            # failure than the one it fixes. So a ``" - "``-laden base id may
+            # truncate and NOT match the PR-side canonical id — which fails
+            # CLOSED: the pre-existing failure is treated as a regression and
+            # BLOCKS (never a false green — a real regression is never masked;
+            # see the fail-safe test). We accept a rare false block of a
+            # pathological pre-existing id over an unsound negative control.
             return summary_node_ids(proc.stdout, "FAILED")
         finally:
             # Remove the worktree even if pytest crashed.
@@ -532,4 +570,12 @@ def _run_on_main(
 
 
 def _failed_block(items: list[str]) -> str:
-    return "\n".join(items) if items else "(none)"
+    # Node ids reach here from the reporter's structured records (r26), which
+    # capture pytest's exact ``report.nodeid`` — and a hostile
+    # ``pytest_make_parametrize_id`` can embed a newline + triple backticks in
+    # that id (r23). Emitted verbatim into the scorecard's ``` fence, such an id
+    # could close the fence and spoof review content, the same sink r24 hardened
+    # for full_unit/flake_tracking — reachable in targeted only once it switched
+    # to canonical ids. ``render_fence_safe`` renders each id as a single quoted
+    # line so no embedded newline can begin a fence-closer (codex #1222 r30).
+    return "\n".join(render_fence_safe(i) for i in items) if items else "(none)"

--- a/scripts/pr_validate/steps/targeted_tests.py
+++ b/scripts/pr_validate/steps/targeted_tests.py
@@ -404,7 +404,8 @@ def _untrusted_run_reason(run: _PytestRun) -> str | None:
     was suppressed (``-rN`` / a summary-blanking addopts) — the empty list is
     not trusted (codex #1222 r26). The reporter-derived checks apply only when
     ``run.structured`` (the reporter ran); otherwise the caller passed the
-    trusting defaults and only the exit-code check is meaningful."""
+    trusting defaults and only the exit-code and exit-1-accounting checks are
+    meaningful."""
     if run.returncode not in (0, 1):
         return (
             f"pytest exited {run.returncode} (not a plain pass=0 / fail=1 — a "
@@ -420,11 +421,21 @@ def _untrusted_run_reason(run: _PytestRun) -> str | None:
             "pytest did not run to completion (an early pytest.exit / crash "
             "before the session-finish record) — a truncated run is not green"
         )
-    if run.returncode == 1 and run.structured and not run.failed and not run.reran:
+    if run.returncode == 1 and not run.failed and not run.reran:
+        # Exit 1 means tests were collected and some failed/errored — there is
+        # no green exit-1. An empty failure list therefore can't be trusted:
+        # in the STRUCTURED path a suppressed summary (``-rN`` / a
+        # summary-blanking addopts) blanks the scrape while the reporter's
+        # FAILED record would normally account for it; in the NO-REPORTER
+        # FALLBACK path a setup/teardown ERROR exits 1 yet scrapes NO ``FAILED``
+        # line at all (it prints ``ERROR``), so ``run.errored`` is the trusting
+        # default False and the failure would slip through as a false green
+        # (codex #1222 r33). Either way, an unaccounted exit 1 is untrusted.
         return (
-            "pytest exited 1 but no structured FAILED/RERUN record accounts "
-            "for it — the failure summary was suppressed; an empty FAILED list "
-            "is not accepted as green"
+            "pytest exited 1 but no FAILED/RERUN record (or scraped FAILED "
+            "line) accounts for it — the failure summary was suppressed or a "
+            "setup/teardown ERROR produced no FAILED line; an empty FAILED "
+            "list is not accepted as green"
         )
     return None
 

--- a/scripts/pr_validate/steps/targeted_tests.py
+++ b/scripts/pr_validate/steps/targeted_tests.py
@@ -31,6 +31,7 @@ on PR → real regression → BLOCK.
 
 from __future__ import annotations
 
+import os
 import re
 import shutil
 import subprocess
@@ -38,6 +39,8 @@ import sys
 import tempfile
 from pathlib import Path
 
+from .. import _nodeid_reporter
+from .._pytest_summary import rerun_detected
 from ..base import GATING_PYTEST_GUARD, Step, StepResult
 from ..context import Context
 
@@ -80,7 +83,31 @@ class TargetedTestsStep(Step):
         # ensure it).  TODO if we ever auto-checkout PRs: switch to the
         # PR head here too.
         pr_log = ctx.artifact_path("targeted-pr.log")
-        pr_summary, pr_failed = _run_pytest(targets, pr_log, ctx.repo_root)
+        pr_nodeids = ctx.artifact_path("targeted-pr-nodeids.tsv")
+        pr_summary, pr_failed, pr_reran = _run_pytest(
+            targets, pr_log, ctx.repo_root, pr_nodeids
+        )
+
+        # A GATING run must never rerun. targeted_tests is the FIRST — and,
+        # for a low-blast PR where full_unit is skipped, the ONLY — gating
+        # step that runs candidate tests, so the RERUN backstop has to live
+        # here too: the by-name GATING_PYTEST_GUARD is bypassable by a
+        # conftest registering pytest-rerunfailures under an arbitrary name,
+        # and if full_unit never runs, nothing else would catch the rerun
+        # (codex #1222 r24). Any RERUN record → a real failure may have been
+        # retried to green → block, regardless of the scraped FAILED set.
+        if pr_reran:
+            return StepResult(
+                name=self.name,
+                status="fail",
+                summary=f"{pr_summary} (gating run reran a test)",
+                details="⚠️ the targeted gating run reran at least one test — "
+                "pytest-rerunfailures was active despite the by-name block, so "
+                "it was smuggled in under a different name. A rerun can retry a "
+                "real failure into a pass, so this run is not trusted; reruns "
+                "must be OFF for the gate.",
+                artifacts=[str(pr_log)],
+            )
 
         if not pr_failed:
             return StepResult(
@@ -224,19 +251,42 @@ _PYTEST_CMD = [
 ]
 
 
-def _run_pytest(targets: list[str], log_path: Path, cwd: Path) -> tuple[str, list[str]]:
-    """Run pytest against ``targets``. Returns (one-line summary,
-    list of FAILED node IDs). Empty failed list => clean run."""
+def _run_pytest(
+    targets: list[str], log_path: Path, cwd: Path, nodeid_log: Path | None = None
+) -> tuple[str, list[str], bool]:
+    """Run pytest against ``targets``. Returns (one-line summary, list of
+    FAILED node IDs, reran) where ``reran`` is True iff the run reran a test
+    (a gating run must never rerun). Empty failed list => clean run.
+
+    When ``nodeid_log`` is given and the reporter plugin is importable, the
+    run emits the structured RERUN record used for the name-independent
+    rerun backstop. ``cwd`` (the PR head worktree) must contain the reporter
+    module — it does, since this PR adds it; the negative-control run on the
+    protected base does NOT inject it (the base predates the plugin)."""
+    cmd = [*_PYTEST_CMD, *targets]
+    env = dict(os.environ)
+    env.pop("PYTEST_ADDOPTS", None)
+    inject = nodeid_log is not None and _nodeid_reporter.available()
+    if inject:
+        plugin_args, env = _nodeid_reporter.build_invocation(
+            nodeid_log, cwd, base_env=env
+        )
+        cmd += plugin_args
+        # Start-sentinel so an empty log is distinguishable from "plugin
+        # never ran" (mirrors full_unit); rerun detection reads it below.
+        nodeid_log.write_text("", encoding="utf-8")
     proc = subprocess.run(  # noqa: S603
-        [*_PYTEST_CMD, *targets],
+        cmd,
         capture_output=True,
         text=True,
         cwd=str(cwd),
+        env=env,
     )
     log_path.write_text((proc.stdout or "") + (proc.stderr or ""))
     summary = _last_summary_line(proc.stdout) or f"exit {proc.returncode}"
     failed = _extract_failed_node_ids(proc.stdout)
-    return summary, failed
+    reran = bool(inject and nodeid_log.exists() and rerun_detected(nodeid_log))
+    return summary, failed, reran
 
 
 def _run_on_main(

--- a/scripts/pr_validate/steps/targeted_tests.py
+++ b/scripts/pr_validate/steps/targeted_tests.py
@@ -42,6 +42,7 @@ from typing import NamedTuple
 from .. import _nodeid_reporter
 from .._pytest_summary import (
     last_summary_line,
+    raw_session_records,
     render_fence_safe,
     report_log_node_ids,
     rerun_detected,
@@ -152,7 +153,21 @@ class TargetedTestsStep(Step):
         # added marker or conftest hook). We therefore SKIP (never false-block
         # legitimate reclassification) but make it LOUD so a reviewer is
         # prompted to confirm the deselection is intentional.
-        if pr.returncode == 5 and "deselected" in pr.summary and not pr.errored:
+        #
+        # GATE (codex #1222 r34): grant this non-blocking skip ONLY on
+        # ``all_deselected_clean`` — the reporter's structured proof of a benign
+        # zero-selection run (exactly ``SESSIONFINISH 0 0`` with NO
+        # FAILED/ERROR/RERUN). Exit 5 + "deselected" ALONE is not enough: a
+        # candidate hook could normalize a run that actually FAILED (or was
+        # truncated) to exit 5 with a "deselected" summary and steal the skip.
+        # Requiring positive structured proof that nothing failed and nothing
+        # ran closes that; if the reporter didn't run, the proof is absent →
+        # skip denied → falls through to ``_untrusted_run_reason`` (blocks).
+        if (
+            pr.returncode == 5
+            and "deselected" in pr.summary
+            and pr.all_deselected_clean
+        ):
             return StepResult(
                 name=self.name,
                 status="skip",
@@ -378,7 +393,15 @@ class _PytestRun(NamedTuple):
     ``False`` so a legacy no-reporter run behaves as before. ``returncode`` is
     always pytest's real exit code; ``structured`` records whether the reporter
     ran, so the exit-code / completeness / unaccounted-exit checks know when
-    they may trust the reporter-derived fields."""
+    they may trust the reporter-derived fields.
+
+    ``all_deselected_clean`` is the STRUCTURED proof of a benign zero-selection
+    run — the reporter recorded exactly ``SESSIONFINISH 0 0`` (nothing was
+    collected/run) with NO FAILED/ERROR/RERUN. It gates the exit-5
+    all-deselected skip so a candidate can't force an exit-5-with-``deselected``
+    summary over a run that actually FAILED and steal a non-blocking skip
+    (codex #1222 r34). Without the reporter it is the trusting default False,
+    so a fallback exit-5 is not granted the skip (fails safe → blocks)."""
 
     summary: str
     failed: list[str]
@@ -387,6 +410,7 @@ class _PytestRun(NamedTuple):
     errored: bool
     complete: bool
     structured: bool
+    all_deselected_clean: bool = False
 
 
 def _untrusted_run_reason(run: _PytestRun) -> str | None:
@@ -493,10 +517,24 @@ def _run_pytest(
         # record is written per failing outcome and can't be turned off from
         # candidate config (codex #1222 r26).
         failed = report_log_node_ids(nodeid_log, "FAILED")
+        # Structured proof of a BENIGN zero-selection run: exactly one
+        # ``SESSIONFINISH 0 0`` record (nothing collected/run to completion)
+        # AND no failing outcomes. This gates the exit-5 all-deselected skip so
+        # a forced exit-5-with-``deselected`` summary over a run that actually
+        # failed can't steal a non-blocking skip (codex #1222 r34).
+        all_deselected_clean = (
+            raw_session_records(nodeid_log) == ["0 0"]
+            and not failed
+            and not errored
+            and not reran
+        )
     else:
         reran = errored = False
         complete = True
         failed = summary_node_ids(proc.stdout, "FAILED")
+        # No reporter → we can't prove a clean zero-selection; the exit-5 skip
+        # is therefore denied on the fallback path (fails safe → blocks).
+        all_deselected_clean = False
     return _PytestRun(
         summary=summary,
         failed=failed,
@@ -505,6 +543,7 @@ def _run_pytest(
         errored=errored,
         complete=complete,
         structured=structured,
+        all_deselected_clean=all_deselected_clean,
     )
 
 
@@ -543,11 +582,23 @@ def _run_on_main(
                 )
                 return []
 
+            # Strip PYTEST_ADDOPTS from the base subprocess env too — the
+            # PR-side run pops it (it bites THROUGH ``-o addopts=``), so the
+            # negative control MUST do the same or the comparison is asymmetric:
+            # an inherited ``PYTEST_ADDOPTS=--runxfail`` (etc.) applied only on
+            # base could make base report a node as FAILED that the PR side does
+            # not, so a real PR regression gets misclassified as pre-existing
+            # and waived — a FALSE GREEN (codex #1222 r34). ``_PYTEST_CMD``
+            # already makes the two runs command-symmetric; this makes them
+            # env-symmetric.
+            base_env = dict(os.environ)
+            base_env.pop("PYTEST_ADDOPTS", None)
             proc = subprocess.run(  # noqa: S603
                 [*_PYTEST_CMD, *existing_targets],
                 capture_output=True,
                 text=True,
                 cwd=str(tmp),
+                env=base_env,
             )
             log_path.write_text((proc.stdout or "") + (proc.stderr or ""))
             # Space-preserving scrape (NOT a ``\S+`` grab): the PR side records

--- a/scripts/pr_validate/steps/targeted_tests.py
+++ b/scripts/pr_validate/steps/targeted_tests.py
@@ -154,6 +154,22 @@ class TargetedTestsStep(Step):
         # legitimate reclassification) but make it LOUD so a reviewer is
         # prompted to confirm the deselection is intentional.
         #
+        # MULTI-FILE variant (codex #1222 r41): the ``SESSIONFINISH 0 0`` proof
+        # is AGGREGATE across all changed test targets, so when one changed file
+        # legitimately deselects to zero, a SIBLING changed test file that
+        # contributed ZERO trace — empty, renamed out of ``python_files``, or
+        # a candidate-conftest ``pytest_ignore_collect`` drop — rides along under
+        # the shared "deselected" summary. This is NOT separately closeable: the
+        # sound per-target check codex proposes (require every requested file to
+        # contribute a gate-owned deselection, or collect each target alone)
+        # FALSE-BLOCKS the routine cases — a PR that deletes all tests from a
+        # file, or renames a test module, leaves exactly that zero-trace
+        # signature — while the in-process conftest drop is the SAME r27 surgical
+        # residual reached a different way (a hook that forges per-file
+        # "deselected" defeats a per-file check too). Same defenses apply:
+        # slow-lane CI and diff review, which see the emptied/renamed file and
+        # any added collection hook.
+        #
         # GATE (codex #1222 r34): grant this non-blocking skip ONLY on
         # ``all_deselected_clean`` — the reporter's structured proof of a benign
         # zero-selection run (exactly ``SESSIONFINISH 0 0`` with NO
@@ -608,21 +624,24 @@ def _run_on_main(
             # id wouldn't match the PR id and the pre-existing failure would be
             # misclassified as a PR-only regression (codex #1222 r29).
             #
-            # RESIDUAL (codex #1222 r30, fail-safe): ``summary_node_ids`` is
-            # exact for normal ids but IRREDUCIBLY ambiguous for an id that
-            # itself contains ``" - "`` with unbalanced brackets
-            # (``test_x[a] - b]``) — the same wall that motivated the structured
-            # reporter plugin (see its module docstring; codex r4/r5/r6/r9/r10).
-            # The base predates that plugin, so it cannot get canonical ids here,
-            # and injecting the PR checkout's plugin would drag the PR's library
-            # onto the base run's ``PYTHONPATH`` — contaminating the negative
-            # control (base TEST files run against PR code), a worse and unsound
-            # failure than the one it fixes. So a ``" - "``-laden base id may
-            # truncate and NOT match the PR-side canonical id — which fails
-            # CLOSED: the pre-existing failure is treated as a regression and
-            # BLOCKS (never a false green — a real regression is never masked;
-            # see the fail-safe test). We accept a rare false block of a
-            # pathological pre-existing id over an unsound negative control.
+            # RESIDUAL (codex #1222 r30/r41, fail-safe): ``summary_node_ids``
+            # is exact for normal ids but AMBIGUOUS for an id that itself
+            # contains ``" - "`` next to brackets (``test_x[a] - b]`` unbalanced,
+            # ``test_x[a] - b[c]`` balanced) — the same wall that motivated the
+            # structured reporter plugin (see its module docstring; codex
+            # r4/r5/r6/r9/r40/r41). The base predates that plugin, so it cannot
+            # get canonical ids here, and injecting the PR checkout's plugin
+            # would drag the PR's library onto the base run's ``PYTHONPATH`` —
+            # contaminating the negative control (base TEST files run against PR
+            # code), a worse and unsound failure than the one it fixes. So a
+            # ``" - "``-laden base id may truncate and NOT match the PR-side
+            # canonical id. ``_strip_message`` fails CLOSED on EVERY such
+            # ambiguous shape (r40 unbalanced + r41 balanced): it returns the
+            # WHOLE line, which can't match a shorter PR-side canonical id, so
+            # the pre-existing failure is treated as a regression and BLOCKS —
+            # never a false green (a real regression is never masked; see the
+            # fail-safe tests). We accept a rare false block of a pathological
+            # pre-existing id over an unsound negative control.
             return summary_node_ids(proc.stdout, "FAILED")
         finally:
             # Remove the worktree even if pytest crashed.

--- a/tests/test_pr_validate_flake_tracking.py
+++ b/tests/test_pr_validate_flake_tracking.py
@@ -288,6 +288,21 @@ class TestLoadQuarantine:
         with pytest.raises(QuarantineError):
             load_quarantine(p)
 
+    def test_unreadable_file_raises_quarantine_error(self, tmp_path, monkeypatch):
+        # A present-but-unreadable registry (permissions / I/O error) is a
+        # read failure, not "absent" — the loader must re-raise it as the
+        # documented QuarantineError so a caller catching only that exception
+        # doesn't crash on a raw OSError (codex #1222 r18).
+        p = tmp_path / "q.yaml"
+        p.write_text("tests: []\n")
+
+        def boom(*a, **k):
+            raise PermissionError("permission denied")
+
+        monkeypatch.setattr(type(p), "read_text", boom)
+        with pytest.raises(QuarantineError, match="could not be read"):
+            load_quarantine(p)
+
     def test_tests_must_be_list(self, tmp_path):
         p = tmp_path / "q.yaml"
         p.write_text("tests: not-a-list\n")
@@ -1118,13 +1133,17 @@ class TestFlakeTrackingContract:
         FlakeTrackingStep().run(ctx)
         assert "tests/x.py::errored" in captured["cmd"]
 
-    def test_recovered_collection_error_is_candidate(self, ctx_factory, monkeypatch):
-        # codex #1222 r17 NIT: a collection ERROR id is a MODULE / DIR path
-        # (no "::"); on a clean re-run its CONTAINED tests log PASSED under
-        # their own "::" ids, but the module id itself never logs a PASSED —
-        # so a recovered collection flake would wrongly land in `inconclusive`
-        # forever. A collection target that did NOT re-error is a recovered
-        # flake candidate instead.
+    def test_recovered_collection_error_is_error_candidate(
+        self, ctx_factory, monkeypatch
+    ):
+        # codex #1222 r17: a collection ERROR id is a MODULE / DIR path (no
+        # "::"); on a clean re-run its CONTAINED tests log PASSED under their
+        # own "::" ids, but the module id itself never logs a PASSED — so a
+        # recovered collection flake would wrongly land in `inconclusive`
+        # forever. With POSITIVE evidence (a contained test passed) it is a
+        # recovered flake — but as an ERROR-origin one it is NOT quarantinable
+        # (full_unit blocks any ERROR run), so it lands in
+        # `error_flake_candidates`, not `flake_candidates_new` (codex r18).
         ctx = ctx_factory()
         ctx.artifact_path("full-unit.log").write_text("boom")
         ctx.artifact_path("full-unit-nodeids.tsv").write_text("ERROR\ttests/mod.py\n")
@@ -1145,8 +1164,67 @@ class TestFlakeTrackingContract:
         res = FlakeTrackingStep().run(ctx)
         assert res.status == "pass"
         data = json.loads(ctx.artifact_path("flake-candidates.json").read_text())
-        assert "tests/mod.py" in data["flake_candidates_new"]
+        assert "tests/mod.py" in data["error_flake_candidates"]
+        assert "tests/mod.py" not in data["flake_candidates_new"]
         assert "tests/mod.py" not in data["inconclusive"]
+
+    def test_collection_target_no_positive_outcome_is_inconclusive(
+        self, ctx_factory, monkeypatch
+    ):
+        # codex #1222 r18: a collection target that stopped erroring but
+        # produced NO positive outcome on re-run (collected nothing, or only
+        # skipped) is NOT a proven flake — same positive-outcome rule as any
+        # other id. It must land in `inconclusive`, not be falsely recovered.
+        ctx = ctx_factory()
+        ctx.artifact_path("full-unit.log").write_text("boom")
+        ctx.artifact_path("full-unit-nodeids.tsv").write_text("ERROR\ttests/mod.py\n")
+        monkeypatch.setattr(
+            flake_mod.importlib.util, "find_spec", lambda name: object()
+        )
+        monkeypatch.setattr(flake_mod, "load_quarantine_from_ref", lambda *a, **k: [])
+
+        def fake(cmd, cwd, timeout, env=None):
+            # Re-run collected but nothing passed (all skipped / empty).
+            ctx.artifact_path("flake-rerun-nodeids.tsv").write_text("")
+            return _completed(0, "")
+
+        monkeypatch.setattr(flake_mod, "_run_session", fake)
+        res = FlakeTrackingStep().run(ctx)
+        assert res.status == "pass"
+        data = json.loads(ctx.artifact_path("flake-candidates.json").read_text())
+        assert "tests/mod.py" in data["inconclusive"]
+        assert "tests/mod.py" not in data["error_flake_candidates"]
+        assert "tests/mod.py" not in data["flake_candidates_new"]
+
+    def test_recovered_setup_error_is_not_quarantinable(self, ctx_factory, monkeypatch):
+        # codex #1222 r18: a setup/teardown ERROR flake that recovers is real
+        # (non-deterministic) but NOT quarantinable — full_unit blocks any
+        # ERROR run unconditionally, so a quarantine entry would never waive
+        # it. It lands in error_flake_candidates ("investigate"), never in
+        # flake_candidates_new (which recommends quarantine promotion).
+        ctx = ctx_factory()
+        ctx.artifact_path("full-unit.log").write_text("boom")
+        ctx.artifact_path("full-unit-nodeids.tsv").write_text(
+            "ERROR\ttests/x.py::test_boom\n"
+        )
+        monkeypatch.setattr(
+            flake_mod.importlib.util, "find_spec", lambda name: object()
+        )
+        monkeypatch.setattr(flake_mod, "load_quarantine_from_ref", lambda *a, **k: [])
+
+        def fake(cmd, cwd, timeout, env=None):
+            ctx.artifact_path("flake-rerun-nodeids.tsv").write_text(
+                "PASSED\ttests/x.py::test_boom\n"
+            )
+            return _completed(0, "")
+
+        monkeypatch.setattr(flake_mod, "_run_session", fake)
+        res = FlakeTrackingStep().run(ctx)
+        assert res.status == "pass"
+        assert "not quarantinable" in res.summary
+        data = json.loads(ctx.artifact_path("flake-candidates.json").read_text())
+        assert data["error_flake_candidates"] == ["tests/x.py::test_boom"]
+        assert data["flake_candidates_new"] == []
 
     def test_reproduced_collection_error_not_candidate(self, ctx_factory, monkeypatch):
         # The inverse: a collection target that RE-ERRORS on re-run reproduces
@@ -1319,6 +1397,54 @@ class TestFlakeTrackingContract:
         FlakeTrackingStep().run(ctx)
         assert "--color=no" in captured["cmd"]
         assert "-rA" in captured["cmd"]
+
+    def test_rerun_loads_rerunfailures_explicitly_when_autoload_disabled(
+        self, ctx_factory, monkeypatch
+    ):
+        # codex #1222 r18: find_spec confirms rerunfailures is installed but
+        # not that it's ACTIVE — under PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 an
+        # installed plugin won't register, so --reruns would be unknown and
+        # the advisory would silently skip. In THAT case only, load it
+        # explicitly with -p so --reruns is recognized.
+        monkeypatch.setenv("PYTEST_DISABLE_PLUGIN_AUTOLOAD", "1")
+        ctx = ctx_factory()
+        self._prime(ctx, monkeypatch)
+        monkeypatch.setattr(flake_mod, "load_quarantine_from_ref", lambda *a, **k: [])
+        captured = {}
+
+        def fake(cmd, cwd, timeout, env=None):
+            captured["cmd"] = cmd
+            return _completed(0, _passed())
+
+        monkeypatch.setattr(flake_mod, "_run_session", fake)
+        FlakeTrackingStep().run(ctx)
+        cmd = captured["cmd"]
+        # -p pytest_rerunfailures appears as adjacent argv entries.
+        assert "pytest_rerunfailures" in cmd
+        assert cmd[cmd.index("pytest_rerunfailures") - 1] == "-p"
+
+    def test_rerun_omits_explicit_rerunfailures_when_autoload_on(
+        self, ctx_factory, monkeypatch
+    ):
+        # codex #1222 r18 REGRESSION (fixed r19): with autoload ON,
+        # rerunfailures self-registers under the entry-point name
+        # "rerunfailures". Passing an extra ``-p pytest_rerunfailures`` then
+        # makes pluggy raise "Plugin already registered under a different
+        # name" and crashes the advisory re-run entirely. So the explicit
+        # ``-p`` MUST be absent unless autoload is disabled.
+        monkeypatch.delenv("PYTEST_DISABLE_PLUGIN_AUTOLOAD", raising=False)
+        ctx = ctx_factory()
+        self._prime(ctx, monkeypatch)
+        monkeypatch.setattr(flake_mod, "load_quarantine_from_ref", lambda *a, **k: [])
+        captured = {}
+
+        def fake(cmd, cwd, timeout, env=None):
+            captured["cmd"] = cmd
+            return _completed(0, _passed())
+
+        monkeypatch.setattr(flake_mod, "_run_session", fake)
+        FlakeTrackingStep().run(ctx)
+        assert "pytest_rerunfailures" not in captured["cmd"]
 
     def test_rerun_neutralizes_candidate_addopts_and_env(
         self, ctx_factory, monkeypatch

--- a/tests/test_pr_validate_flake_tracking.py
+++ b/tests/test_pr_validate_flake_tracking.py
@@ -24,10 +24,12 @@ import pytest
 
 from scripts.pr_validate import _nodeid_reporter
 from scripts.pr_validate._pytest_summary import summary_node_ids
+from scripts.pr_validate.base import GATING_PYTEST_GUARD
 from scripts.pr_validate.context import Context
 from scripts.pr_validate.quarantine import (
     QuarantineEntry,
     QuarantineError,
+    effective_quarantine,
     load_quarantine,
     load_quarantine_from_ref,
     node_id_matches,
@@ -35,6 +37,7 @@ from scripts.pr_validate.quarantine import (
 )
 from scripts.pr_validate.steps import flake_tracking as flake_mod
 from scripts.pr_validate.steps import full_unit as full_unit_mod
+from scripts.pr_validate.steps import targeted_tests as targeted_mod
 from scripts.pr_validate.steps.flake_tracking import FlakeTrackingStep, _run_session
 from scripts.pr_validate.steps.full_unit import FullUnitStep
 
@@ -349,6 +352,39 @@ class TestLoadQuarantine:
         with pytest.raises(QuarantineError, match="reason"):
             load_quarantine(p)
 
+    def test_duplicate_entry_key_rejected(self, tmp_path):
+        # codex #1222 r21: yaml.safe_load silently keeps the LAST value for a
+        # duplicated key, so a reviewer could approve `reason: real` while a
+        # duplicate `reason:` invisibly overrides it. The strict loader rejects
+        # duplicate mapping keys.
+        p = tmp_path / "q.yaml"
+        p.write_text(
+            "tests:\n"
+            "  - id: a.py::t\n"
+            "    reason: real\n"
+            "    added: 2026-01-01\n"
+            "    reason: attacker-override\n"
+        )
+        with pytest.raises(QuarantineError, match="[Dd]uplicate"):
+            load_quarantine(p)
+
+    def test_duplicate_top_level_key_rejected(self, tmp_path):
+        # A duplicated top-level `tests:` key would silently replace the whole
+        # reviewed list — also rejected.
+        p = tmp_path / "q.yaml"
+        p.write_text(
+            "tests:\n"
+            "  - id: a.py::t\n"
+            "    reason: r\n"
+            "    added: 2026-01-01\n"
+            "tests:\n"
+            "  - id: b.py::t\n"
+            "    reason: r\n"
+            "    added: 2026-01-01\n"
+        )
+        with pytest.raises(QuarantineError, match="[Dd]uplicate"):
+            load_quarantine(p)
+
     def test_missing_added_raises(self, tmp_path):
         p = tmp_path / "q.yaml"
         p.write_text("tests:\n  - id: a.py::t\n    reason: flaky\n")
@@ -643,6 +679,69 @@ class TestPartition:
         assert quarantined == []
 
 
+class TestEffectiveQuarantine:
+    # codex #1222 r21: effective registry = base ∩ candidate, so a
+    # de-quarantine REMOVAL is honored while a candidate can never widen or
+    # self-add coverage.
+    def _e(self, i, fam=False):
+        return QuarantineEntry(id=i, reason="r", added="2026-07-25", family=fam)
+
+    def test_kept_when_in_both(self):
+        eff = effective_quarantine([self._e("t::a")], [self._e("t::a")])
+        assert [e.id for e in eff] == ["t::a"]
+
+    def test_removal_dropped(self):
+        # base lists it, candidate removed it → not effective.
+        eff = effective_quarantine([self._e("t::a")], [])
+        assert eff == []
+
+    def test_candidate_addition_ignored(self):
+        # candidate lists it, base doesn't → not effective (no self-quarantine).
+        eff = effective_quarantine([], [self._e("t::a")])
+        assert eff == []
+
+    def test_candidate_cannot_widen_family(self):
+        # base exact, candidate widens to family → stays exact (narrower wins).
+        eff = effective_quarantine(
+            [self._e("t::a", fam=False)], [self._e("t::a", fam=True)]
+        )
+        assert eff[0].family is False
+
+    def test_candidate_may_tighten_family(self):
+        # base family, candidate tightens to exact → effective exact (allowed).
+        eff = effective_quarantine(
+            [self._e("t::a", fam=True)], [self._e("t::a", fam=False)]
+        )
+        assert eff[0].family is False
+
+    def test_family_kept_when_both_family(self):
+        eff = effective_quarantine(
+            [self._e("t::a", fam=True)], [self._e("t::a", fam=True)]
+        )
+        assert eff[0].family is True
+
+    def test_result_is_always_subset_of_base(self):
+        base = [self._e("t::a"), self._e("t::b", fam=True)]
+        # A maximally-permissive candidate cannot add ids nor widen breadth.
+        candidate = [
+            self._e("t::a", fam=True),
+            self._e("t::c"),
+            self._e("t::b", fam=True),
+        ]
+        eff = effective_quarantine(base, candidate)
+        assert {e.id for e in eff} <= {b.id for b in base}
+        by_id = {e.id: e.family for e in eff}
+        assert by_id["t::a"] is False  # base was exact → stays exact
+        assert by_id["t::b"] is True
+        assert "t::c" not in by_id  # candidate-added ignored
+
+    def test_base_audit_metadata_preserved(self):
+        base = [QuarantineEntry(id="t::a", reason="base-why", added="2026-01-01")]
+        cand = [QuarantineEntry(id="t::a", reason="cand-why", added="2026-09-09")]
+        (eff,) = effective_quarantine(base, cand)
+        assert eff.reason == "base-why" and eff.added == "2026-01-01"
+
+
 # --------------------------------------------------------------------------
 # full_unit.py — quarantine-aware verdict (subprocess mocked)
 # --------------------------------------------------------------------------
@@ -797,6 +896,108 @@ class TestFullUnitQuarantineAware:
         cmd = captured["cmd"]
         assert "no:rerunfailures" in cmd
         assert cmd[cmd.index("no:rerunfailures") - 1] == "-p"
+
+    def test_every_gating_pytest_cmd_blocks_rerunfailures(
+        self, ctx_factory, monkeypatch
+    ):
+        # codex #1222 r21: r20 disabled rerunfailures only in full_unit, but
+        # targeted_tests ALSO runs candidate tests — a `@pytest.mark.flaky` on
+        # a changed file could rerun-and-pass there. Both gating pytest
+        # invocations must carry the shared guard so no step can silently
+        # forget it. full_unit is captured live; targeted_tests exposes its
+        # base command as a module constant.
+        guard = list(GATING_PYTEST_GUARD)
+
+        def _contains_subseq(seq, sub):
+            return any(
+                seq[i : i + len(sub)] == sub for i in range(len(seq) - len(sub) + 1)
+            )
+
+        # targeted_tests base cmd
+        assert _contains_subseq(list(targeted_mod._PYTEST_CMD), guard)
+
+        # full_unit cmd (captured)
+        captured = {}
+
+        def fake_run(cmd, **kw):
+            captured["cmd"] = cmd
+            return subprocess.CompletedProcess(cmd, 0, _passed(), "")
+
+        monkeypatch.setattr(full_unit_mod.subprocess, "run", fake_run)
+        FullUnitStep().run(ctx_factory())
+        assert _contains_subseq(list(captured["cmd"]), guard)
+
+    def test_exit_zero_with_recorded_failures_blocks(self, ctx_factory, monkeypatch):
+        # codex #1222 r21: a conftest / exit-code plugin can normalize a
+        # FAILING run to exit 0 (e.g. pytest_sessionfinish setting
+        # session.exitstatus = 0). The exit-0 fast path must NOT trust the
+        # code over the structured records — a clean exit whose log carries
+        # FAILED ids is tampering, not green. Block, and grant no downgrade.
+        self._patch_pytest(monkeypatch, 0, _summary("FAILED tests/a.py::test_real - X"))
+        res = FullUnitStep().run(ctx_factory())
+        assert res.status == "fail"
+        assert "exited 0" in res.details
+        assert "tests/a.py::test_real" in res.details
+
+    def _patch_quarantine_by_ref(self, monkeypatch, *, base, candidate):
+        # Return DIFFERENT registries for the base_sha vs head_sha reads so
+        # the base ∩ candidate intersection can be exercised (codex #1222 r21).
+        def fake(ref, *a, **k):
+            return candidate if ref == "headsha1111" else base
+
+        monkeypatch.setattr(full_unit_mod, "load_quarantine_from_ref", fake)
+
+    def test_dequarantine_removal_blocks(self, ctx_factory, monkeypatch):
+        # A PR that REMOVES an entry (base lists it, candidate doesn't) while
+        # the test still fails must BLOCK — the removal drops it from the
+        # effective (base ∩ candidate) set, so it's no longer waived.
+        self._patch_quarantine_by_ref(
+            monkeypatch,
+            base=[QuarantineEntry(id="tests/a.py::test_flaky")],
+            candidate=[],  # de-quarantined in this PR
+        )
+        self._patch_pytest(
+            monkeypatch, 1, _summary("FAILED tests/a.py::test_flaky - X")
+        )
+        ctx = ctx_factory()
+        ctx.head_sha = "headsha1111"
+        res = FullUnitStep().run(ctx)
+        assert res.status == "fail"
+        assert "tests/a.py::test_flaky" in res.details
+
+    def test_quarantine_in_both_still_waived(self, ctx_factory, monkeypatch):
+        # An entry present in BOTH base and candidate is still effective → the
+        # flaky failure is waived (non-blocking), as before.
+        self._patch_quarantine_by_ref(
+            monkeypatch,
+            base=[QuarantineEntry(id="tests/a.py::test_flaky")],
+            candidate=[QuarantineEntry(id="tests/a.py::test_flaky")],
+        )
+        self._patch_pytest(
+            monkeypatch, 1, _summary("FAILED tests/a.py::test_flaky - X")
+        )
+        ctx = ctx_factory()
+        ctx.head_sha = "headsha1111"
+        res = FullUnitStep().run(ctx)
+        assert res.status == "pass"
+        assert "known-flaky" in res.summary
+
+    def test_candidate_added_quarantine_ignored(self, ctx_factory, monkeypatch):
+        # A candidate ADDITION (id in candidate but not base) is ignored — a
+        # PR still can't self-quarantine its own failing test.
+        self._patch_quarantine_by_ref(
+            monkeypatch,
+            base=[],
+            candidate=[QuarantineEntry(id="tests/a.py::test_flaky")],
+        )
+        self._patch_pytest(
+            monkeypatch, 1, _summary("FAILED tests/a.py::test_flaky - X")
+        )
+        ctx = ctx_factory()
+        ctx.head_sha = "headsha1111"
+        res = FullUnitStep().run(ctx)
+        assert res.status == "fail"
+        assert "tests/a.py::test_flaky" in res.details
 
     def test_abnormal_exit_blocks(self, ctx_factory, monkeypatch):
         # Exit 2 (interrupted) with an otherwise-quarantined failure must

--- a/tests/test_pr_validate_flake_tracking.py
+++ b/tests/test_pr_validate_flake_tracking.py
@@ -2455,6 +2455,20 @@ class TestRenderFenceSafe:
         assert json.dumps(evil, ensure_ascii=False) in block
         assert targeted_mod._failed_block([]) == "(none)"
 
+    def test_unicode_line_separators_escaped(self):
+        # json.dumps(ensure_ascii=False) escapes control chars < U+0020 but
+        # leaves U+0085/U+2028/U+2029 literal — yet str.splitlines() (and some
+        # Markdown renderers) treat those as line boundaries, so a hostile id
+        # embedding one could still begin a fence-closer on a second physical
+        # line. render_fence_safe must escape them (codex #1222 r31).
+        for sep in ("\x85", "\u2028", "\u2029"):
+            evil = f"tests/a.py::t[a{sep}```\n# spoof]"
+            out = render_fence_safe(evil)
+            assert len(out.splitlines()) == 1  # single line under splitlines
+            assert "\n" not in out
+            assert sep not in out  # the literal separator is gone
+            assert json.loads(out) == evil  # valid JSON → still round-trips
+
 
 class TestNodeidReporter:
     """Prove the plugin round-trips real ``report.nodeid`` values through a
@@ -2735,17 +2749,21 @@ class TestNodeidReporter:
         assert rerun, ("expected RERUN records under --reruns", rows)
         assert "test_flaky.py::test_always_bad" in rerun
 
-    def test_strict_xpass_logged_failed_and_carries_no_wasxfail(self, tmp_path):
-        # codex #1222 r27 (finding 2) REBUTTAL, locked as committed evidence.
-        # Claim: a strict-xfail test that unexpectedly PASSES is logged FAILED
-        # and, if quarantined, wrongly waived — "fix: detect report.wasxfail".
-        # EMPIRICALLY a strict XPASS report has outcome=='failed' but NO
-        # wasxfail (only the NON-strict xpass and the as-expected xfail carry
-        # it), so the proposed detection can't fire — the premise is false. The
-        # scenario is also not reachable: the allowlist is base-protected
-        # (candidates can't add), and a flaky (quarantined) test that is ALSO
-        # xfail(strict=True) is self-contradictory. A conftest captures the
-        # report to prove the wasxfail attribute is unset.
+    def test_strict_xpass_logged_error_via_longrepr_signal(self, tmp_path):
+        # codex #1222 r27 (rebuttal) + r31 (fix), locked as committed evidence.
+        # A strict-xfail test that unexpectedly PASSES is pytest's INTENTIONAL
+        # fatal (the xfail marker is now stale). r27 rebutted codex's "detect
+        # via report.wasxfail" — a strict XPASS report has outcome=='failed'
+        # but NO wasxfail (only the NON-strict xpass / as-expected xfail carry
+        # it), so that detection can't fire. r31 then closed the underlying gap
+        # (a FAILED strict-xpass on a — mistakenly — quarantined node would be
+        # downgraded to a non-blocking flake, masking the fatal) using the
+        # CLEAN signal that IS present: the call report's longrepr is the STRING
+        # "[XPASS(strict)] …" (a genuine call failure carries an exception-repr
+        # OBJECT). The reporter now records the strict-xpass as ERROR —
+        # unconditional block, never quarantinable in full_unit, always makes
+        # targeted untrusted — not a downgradeable FAILED. A conftest captures
+        # the report to prove both the missing wasxfail and the string longrepr.
         (tmp_path / "conftest.py").write_text(
             textwrap.dedent(
                 """
@@ -2756,7 +2774,10 @@ class TestNodeidReporter:
                     if (report.when == 'call'
                             and report.nodeid.endswith('::test_strict_xpass')):
                         wx = getattr(report, 'wasxfail', '<UNSET>')
-                        _obs.write_text(f'{report.outcome}|{wx!r}')
+                        lr = getattr(report, 'longrepr', None)
+                        _obs.write_text(
+                            f'{report.outcome}|{wx!r}|{isinstance(lr, str)}|{str(lr)[:16]}'
+                        )
                 """
             )
         )
@@ -2799,13 +2820,77 @@ class TestNodeidReporter:
             if "\t" in ln
         ]
         failed = [nid for label, nid in rows if label == "FAILED"]
-        # (a) The strict XPASS is recorded as a plain FAILED …
-        assert "test_xp.py::test_strict_xpass" in failed
-        # (b) … and the report carried NO wasxfail, so codex's wasxfail-based
-        # detection is inapplicable — the finding's premise is empirically false.
-        outcome, wasxfail = (tmp_path / ".obs").read_text().split("|", 1)
+        errored = [nid for label, nid in rows if label == "ERROR"]
+        # (a) r31: the strict XPASS is recorded as ERROR (unconditional block),
+        #     NOT a quarantinable FAILED.
+        assert "test_xp.py::test_strict_xpass" in errored
+        assert "test_xp.py::test_strict_xpass" not in failed
+        # (b) The report carried NO wasxfail (r27 rebuttal stands) but DID carry
+        #     the "[XPASS(strict)]" string longrepr the r31 detection keys on.
+        outcome, wasxfail, lr_is_str, lr_head = (
+            (tmp_path / ".obs").read_text().split("|", 3)
+        )
         assert outcome == "failed"
         assert wasxfail == "'<UNSET>'"
+        assert lr_is_str == "True"
+        assert lr_head.startswith("[XPASS(strict)]")
+
+    def test_rerun_completion_reflects_only_final_attempt(self, tmp_path):
+        # codex #1222 r31 REBUTTAL, locked as committed evidence. Claim:
+        # _completed_ids retains an id "after any completed retry attempt", so a
+        # later retry that terminates before teardown still shows ran==collected.
+        # EMPIRICALLY FALSE: pytest-rerunfailures emits NO teardown report for a
+        # non-final attempt (verified — a rerun attempt is setup+call(rerun)
+        # only, even with a yield fixture whose teardown would emit), so the id
+        # is added to the completion set ONLY on the FINAL attempt's teardown.
+        # The SESSIONFINISH ran count therefore reflects the final attempt: a
+        # flaky-then-pass test is counted once (ran==collected==1), and a
+        # hard-truncated final attempt writes no teardown → ran<collected (or,
+        # if the process dies, no SESSIONFINISH → the absent-record check fires).
+        (tmp_path / "test_fl.py").write_text(
+            textwrap.dedent(
+                """
+                import pytest
+                _n = {'v': 0}
+
+                @pytest.mark.flaky(reruns=2)
+                def test_flaky():
+                    _n['v'] += 1
+                    assert _n['v'] >= 2  # fail attempt 1, pass attempt 2
+                """
+            )
+        )
+        log_path = tmp_path / "nodeids.tsv"
+        repo_root = self._repo_root()
+        plugin_args, env = flake_mod._nodeid_reporter.build_invocation(
+            log_path, repo_root, log_passes=True
+        )
+        subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "pytest",
+                "-p",
+                "no:randomly",
+                "-o",
+                "addopts=",
+                *plugin_args,
+                "test_fl.py",
+            ],
+            cwd=str(tmp_path),
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+        # Exactly ONE SESSIONFINISH, ran==collected==1 — the single test counted
+        # once despite two attempts (no premature/duplicate completion).
+        assert raw_session_records(log_path) == ["1 1"]
+        # The final attempt's terminal outcome (PASSED) is recorded; the
+        # intermediate failure is a 'rerun' outcome, never logged FAILED.
+        failed = report_log_node_ids(log_path, "FAILED")
+        passed = report_log_node_ids(log_path, "PASSED")
+        assert "test_fl.py::test_flaky" in passed
+        assert "test_fl.py::test_flaky" not in failed
 
     def _session_records(self, log_path):
         if not log_path.exists():

--- a/tests/test_pr_validate_flake_tracking.py
+++ b/tests/test_pr_validate_flake_tracking.py
@@ -76,10 +76,14 @@ def ctx_factory(tmp_path, monkeypatch):
         # steps' should_run predicate is satisfied.
         ctx.files_changed = files_changed or ["vllm_mlx/scheduler.py"]
         ctx.work_dir = tmp_path / "work"
-        # A truthy immutable base SHA so the quarantine load path runs
-        # (steps read the registry only from base_sha now — codex r10).
-        # Tests exercising the no-SHA fail-closed path clear it explicitly.
+        # Truthy immutable base + head SHAs so the quarantine load path runs
+        # the base ∩ candidate intersection (codex r10/r21). full_unit reads
+        # the base registry from base_sha and the candidate from head_sha;
+        # `_patch_quarantine` returns the same list for both, so the effective
+        # set equals the patched registry. Tests exercising a fail-closed path
+        # (no base/head sha, unreadable candidate) clear / diverge these.
         ctx.base_sha = "basesha0000000000000000000000000000000000"
+        ctx.head_sha = "headsha0000000000000000000000000000000000"
         return ctx
 
     return _make
@@ -383,6 +387,16 @@ class TestLoadQuarantine:
             "    added: 2026-01-01\n"
         )
         with pytest.raises(QuarantineError, match="[Dd]uplicate"):
+            load_quarantine(p)
+
+    def test_unhashable_mapping_key_raises_quarantine_error(self, tmp_path):
+        # codex #1222 r22: a complex YAML key (`? [a, b]` → a list) is
+        # unhashable, so the duplicate-key check's `key in seen` would raise a
+        # raw TypeError instead of the documented QuarantineError. The loader
+        # must convert it to a QuarantineError so the gating caller fails safe.
+        p = tmp_path / "q.yaml"
+        p.write_text("tests:\n  - ? [a, b]\n    : value\n")
+        with pytest.raises(QuarantineError):
             load_quarantine(p)
 
     def test_missing_added_raises(self, tmp_path):
@@ -999,6 +1013,43 @@ class TestFullUnitQuarantineAware:
         assert res.status == "fail"
         assert "tests/a.py::test_flaky" in res.details
 
+    def test_malformed_candidate_registry_fails_closed(self, ctx_factory, monkeypatch):
+        # codex #1222 r22: a candidate CONTROLS its own committed
+        # quarantine.yaml. If it's malformed/unreadable, we must NOT fall back
+        # to the stale base waiver (that would let a PR keep a base-quarantined
+        # but now-failing test green by breaking its own registry). Fail CLOSED
+        # to an empty quarantine → the failure blocks.
+        def fake(ref, *a, **k):
+            if ref == "headsha1111":  # candidate read
+                raise QuarantineError("candidate registry is malformed")
+            return [QuarantineEntry(id="tests/a.py::test_flaky")]  # base
+
+        monkeypatch.setattr(full_unit_mod, "load_quarantine_from_ref", fake)
+        self._patch_pytest(
+            monkeypatch, 1, _summary("FAILED tests/a.py::test_flaky - X")
+        )
+        ctx = ctx_factory()
+        ctx.head_sha = "headsha1111"
+        res = FullUnitStep().run(ctx)
+        assert res.status == "fail"
+        assert "failing closed" in res.details
+        assert "tests/a.py::test_flaky" in res.details
+
+    def test_missing_head_sha_fails_closed(self, ctx_factory, monkeypatch):
+        # No pinned head sha → the candidate registry can't be confirmed →
+        # fail closed to empty (every failure blocks), not the base waiver.
+        self._patch_quarantine(
+            monkeypatch, [QuarantineEntry(id="tests/a.py::test_flaky")]
+        )
+        self._patch_pytest(
+            monkeypatch, 1, _summary("FAILED tests/a.py::test_flaky - X")
+        )
+        ctx = ctx_factory()
+        ctx.head_sha = ""  # unavailable
+        res = FullUnitStep().run(ctx)
+        assert res.status == "fail"
+        assert "failing closed" in res.details
+
     def test_abnormal_exit_blocks(self, ctx_factory, monkeypatch):
         # Exit 2 (interrupted) with an otherwise-quarantined failure must
         # still block — the exit code says something the FAILED list
@@ -1031,14 +1082,17 @@ class TestFullUnitQuarantineAware:
         res = FullUnitStep().run(ctx_factory())
         assert res.status == "fail"
 
-    def test_registry_sourced_from_base_revision(self, ctx_factory, monkeypatch):
-        # The gate must read the registry from the PROTECTED base, not the
-        # candidate checkout — assert full_unit passes ctx.base_sha to the
-        # loader (so a PR can't quarantine its own failing tests).
-        captured = {}
+    def test_registry_sourced_from_base_and_head_revisions(
+        self, ctx_factory, monkeypatch
+    ):
+        # The gate reads the BASE registry from the protected base SHA (so a
+        # PR can't quarantine its own failing tests) and the CANDIDATE from
+        # the pinned head SHA (so a de-quarantine removal is honored) — both
+        # from immutable revisions, never the working tree (codex r10/r21).
+        captured = {"refs": []}
 
         def fake_loader(ref, repo_root, *a, **k):
-            captured["ref"] = ref
+            captured["refs"].append(ref)
             return [QuarantineEntry(id="tests/a.py::test_flaky")]
 
         monkeypatch.setattr(full_unit_mod, "load_quarantine_from_ref", fake_loader)
@@ -1047,9 +1101,11 @@ class TestFullUnitQuarantineAware:
         )
         ctx = ctx_factory()
         ctx.base_sha = "deadbeefbase"
+        ctx.head_sha = "deadbeefhead"
         res = FullUnitStep().run(ctx)
-        assert captured["ref"] == "deadbeefbase"
-        assert res.status == "pass"  # quarantined → non-blocking
+        # Base read first (base_sha), then candidate (head_sha) — both pinned.
+        assert captured["refs"] == ["deadbeefbase", "deadbeefhead"]
+        assert res.status == "pass"  # in both → quarantined → non-blocking
 
     def test_downgrade_withheld_without_structured_log(self, ctx_factory, monkeypatch):
         # codex #1222 r13: the quarantine downgrade must rest on the exact
@@ -1854,6 +1910,48 @@ class TestFlakeTrackingContract:
         data = json.loads(ctx.artifact_path("flake-candidates.json").read_text())
         assert data["flake_candidates_known"] == ["tests/x.py::flaky"]
         assert data["reproduced_quarantined"] == []
+
+    def test_dequarantined_flake_classified_against_effective_intersection(
+        self, ctx_factory, monkeypatch
+    ):
+        # codex #1222 r22: the advisory must classify against the SAME
+        # effective quarantine (base ∩ candidate) full_unit enforces. A test
+        # the PR DE-QUARANTINED (in base, removed in candidate) that reproduces
+        # must NOT be mislabeled "known-flaky" / reproduced_quarantined —
+        # full_unit actually BLOCKED it, so the advisory reports it as a real
+        # reproduction, matching the gate instead of contradicting it.
+        ctx = ctx_factory()
+        ctx.head_sha = "headsha1111"
+        ctx.artifact_path("full-unit.log").write_text(
+            _summary("FAILED tests/x.py::flaky - X")
+        )
+        monkeypatch.setattr(
+            flake_mod.importlib.util, "find_spec", lambda name: object()
+        )
+
+        def fake_loader(ref, *a, **k):
+            # base still lists it; candidate (head) removed it → de-quarantined.
+            if ref == "headsha1111":
+                return []
+            return [QuarantineEntry(id="tests/x.py::flaky")]
+
+        monkeypatch.setattr(flake_mod, "load_quarantine_from_ref", fake_loader)
+        rerun = (
+            "==================== short test summary info ====================\n"
+            "FAILED tests/x.py::flaky\n"
+            "==== 1 failed in 0.20s ====\n"
+        )
+        monkeypatch.setattr(
+            flake_mod, "_run_session", lambda *a, **k: _completed(1, rerun)
+        )
+        res = FlakeTrackingStep().run(ctx)
+        assert res.status == "pass"  # advisory never blocks
+        data = json.loads(ctx.artifact_path("flake-candidates.json").read_text())
+        # De-quarantined → NOT known / not reproduced_quarantined; it's a real
+        # reproduction, same as full_unit treated it.
+        assert data["flake_candidates_known"] == []
+        assert data["reproduced_quarantined"] == []
+        assert "tests/x.py::flaky" in data["reproduced_likely_real"]
 
     def test_teardown_error_after_pass_is_reproduced_not_flake(
         self, ctx_factory, monkeypatch

--- a/tests/test_pr_validate_flake_tracking.py
+++ b/tests/test_pr_validate_flake_tracking.py
@@ -25,6 +25,7 @@ import pytest
 
 from scripts.pr_validate import _nodeid_reporter
 from scripts.pr_validate._pytest_summary import (
+    last_summary_line,
     raw_session_records,
     render_fence_safe,
     report_log_node_ids,
@@ -2373,6 +2374,46 @@ class TestFieldEscaping:
         assert raw_session_records(log) == []
         assert report_log_node_ids(log, "FAILED") == ["evil\nSESSIONFINISH\t9999 1"]
 
+    def test_all_splitlines_separators_neutralized(self):
+        # codex #1222 r28: str.splitlines() splits on more than \n/\r — a
+        # hostile id embedding U+000B/000C/001C-E/0085/2028/2029 would forge a
+        # record for a reader using splitlines() (the log readers do). Each such
+        # separator must encode to a single "line" under BOTH splitlines() AND
+        # split("\n"), and round-trip losslessly.
+        seps = [
+            "\v",
+            "\f",
+            "\x1c",
+            "\x1d",
+            "\x1e",
+            "\x85",
+            chr(0x2028),
+            chr(0x2029),
+        ]
+        for sep in seps:
+            payload = f"evil{sep}SESSIONFINISH\t9999 1"
+            enc = _nodeid_reporter.escape_field(payload)
+            assert len(enc.splitlines()) == 1, (hex(ord(sep)), enc)
+            assert len(enc.split("\n")) == 1
+            assert _nodeid_reporter.unescape_field(enc) == payload
+
+    def test_unicode_separator_injection_inert_end_to_end(self, tmp_path, monkeypatch):
+        # A U+2028-bearing id written via the REAL _append yields exactly one
+        # FAILED record and ZERO forged SESSIONFINISH when read back through the
+        # splitlines()-based readers (codex #1222 r28).
+        log = tmp_path / "n.tsv"
+        monkeypatch.setenv("PR_VALIDATE_NODEID_LOG", str(log))
+        evil = f"evil{chr(0x2028)}SESSIONFINISH\t9999 1"
+        _nodeid_reporter._append("FAILED", evil)
+        assert raw_session_records(log) == []
+        assert report_log_node_ids(log, "FAILED") == [evil]
+
+    def test_malformed_unicode_escape_preserved(self):
+        # "\u12" (fewer than four hex digits) is not a valid encoded separator;
+        # a hand-written record keeps it verbatim rather than mis-decoding.
+        assert _nodeid_reporter.unescape_field("a\\u12b") == "a\\u12b"
+        assert _nodeid_reporter.unescape_field("x\\uZZZZy") == "x\\uZZZZy"
+
 
 class TestRenderFenceSafe:
     """A node id interpolated into a Markdown ``` code fence must not be able
@@ -3372,16 +3413,63 @@ class TestTargetedTestsUntrustedRun:
     def test_last_summary_line_parses_barless_quiet_mode(self):
         # Once `-v` is dropped (via `-o addopts=`) pytest prints the counts
         # line WITHOUT the ==== bars; the parser must still find it rather than
-        # fall back to a bare "exit N" (codex #1222 r27).
+        # fall back to a bare "exit N" (codex #1222 r27). Shared parser lives in
+        # _pytest_summary so full_unit and targeted can't drift (codex r28).
         stdout = "........\n261 passed, 2 skipped in 10.86s\n"
-        assert (
-            targeted_mod._last_summary_line(stdout) == "261 passed, 2 skipped in 10.86s"
-        )
+        assert last_summary_line(stdout) == "261 passed, 2 skipped in 10.86s"
 
     def test_last_summary_line_parses_fenced_and_failures(self):
         assert (
-            targeted_mod._last_summary_line("==== 5 failed, 3 passed in 2.0s ====")
+            last_summary_line("==== 5 failed, 3 passed in 2.0s ====")
             == "5 failed, 3 passed in 2.0s"
         )
         # No summary at all → empty (caller falls back to the exit code).
-        assert targeted_mod._last_summary_line("collecting...\n") == ""
+        assert last_summary_line("collecting...\n") == ""
+        # A bar-less "all deselected" summary is recognized (drives the r28
+        # exit-5 skip path).
+        assert last_summary_line("2 deselected in 0.05s") == "2 deselected in 0.05s"
+
+    def test_run_skips_when_all_targets_deselected_by_marker(
+        self, ctx_factory, monkeypatch
+    ):
+        # The gate-owned `-m "not slow…"` filter can deselect every test in the
+        # targeted files (a PR touching only slow/integration/needle tests) →
+        # pytest exit 5. That's not a tamper signal, so SKIP not block (codex
+        # #1222 r28 — a regression from the r27 `-m` re-apply).
+        ctx = self._patch_run_pytest(
+            monkeypatch,
+            ctx_factory,
+            targeted_mod._PytestRun(
+                summary="2 deselected in 0.05s",
+                failed=[],
+                reran=False,
+                returncode=5,
+                errored=False,
+                complete=False,
+                structured=True,
+            ),
+        )
+        res = targeted_mod.TargetedTestsStep().run(ctx)
+        assert res.status == "skip"
+        assert "deselected" in res.summary
+
+    def test_run_blocks_exit5_without_deselection(self, ctx_factory, monkeypatch):
+        # exit 5 WITHOUT a deselection (empty/renamed file, or a candidate
+        # python_files matching nothing) is NOT the benign case — no
+        # "deselected" in the summary → stays blocked (codex #1222 r28).
+        ctx = self._patch_run_pytest(
+            monkeypatch,
+            ctx_factory,
+            targeted_mod._PytestRun(
+                summary="no tests ran in 0.01s",
+                failed=[],
+                reran=False,
+                returncode=5,
+                errored=False,
+                complete=False,
+                structured=True,
+            ),
+        )
+        res = targeted_mod.TargetedTestsStep().run(ctx)
+        assert res.status == "fail"
+        assert "untrusted" in res.summary

--- a/tests/test_pr_validate_flake_tracking.py
+++ b/tests/test_pr_validate_flake_tracking.py
@@ -360,6 +360,30 @@ class TestLoadQuarantine:
         with pytest.raises(QuarantineError, match="added"):
             load_quarantine(p)
 
+    def test_family_field_defaults_false_and_parses_true(self, tmp_path):
+        # codex #1222 r14: family is an optional boolean, default False.
+        p = tmp_path / "q.yaml"
+        p.write_text(
+            "tests:\n"
+            "  - id: a.py::t\n    reason: flaky\n    added: 2026-01-01\n"
+            "  - id: b.py::t\n    reason: flaky\n    added: 2026-01-01\n"
+            "    family: true\n"
+        )
+        a, b = load_quarantine(p)
+        assert a.family is False
+        assert b.family is True
+
+    def test_non_boolean_family_raises(self, tmp_path):
+        # A truthy string must not silently widen the allowlist — family
+        # must be a real boolean (codex #1222 r14).
+        p = tmp_path / "q.yaml"
+        p.write_text(
+            "tests:\n  - id: a.py::t\n    reason: flaky\n    added: 2026-01-01\n"
+            '    family: "yes"\n'
+        )
+        with pytest.raises(QuarantineError, match="family"):
+            load_quarantine(p)
+
 
 # --------------------------------------------------------------------------
 # quarantine.py — git base-ref loader (a PR must not quarantine itself)
@@ -525,11 +549,21 @@ class TestNodeIdMatch:
     def test_exact(self):
         assert node_id_matches("a.py::t", "a.py::t")
 
-    def test_param_family(self):
-        assert node_id_matches("a.py::t[x-1]", "a.py::t")
+    def test_param_family_requires_opt_in(self):
+        # codex #1222 r14: a base entry covers parametrizations ONLY with
+        # family=True — exact by default so a new failing param isn't
+        # silently waived.
+        assert node_id_matches("a.py::t[x-1]", "a.py::t", family=True)
+
+    def test_exact_by_default_does_not_match_params(self):
+        assert not node_id_matches("a.py::t[x-1]", "a.py::t")
+
+    def test_family_only_expands_base_entry(self):
+        # family on an already-specific param id doesn't widen it.
+        assert not node_id_matches("a.py::t[y]", "a.py::t[x]", family=True)
 
     def test_base_entry_does_not_match_prefix_sibling(self):
-        assert not node_id_matches("a.py::t_extra", "a.py::t")
+        assert not node_id_matches("a.py::t_extra", "a.py::t", family=True)
 
     def test_specific_param_entry_is_exact_only(self):
         assert node_id_matches("a.py::t[x]", "a.py::t[x]")
@@ -553,13 +587,23 @@ class TestPartition:
         assert blocking == ["a.py::x"]
         assert quarantined == []
 
-    def test_param_family_all_quarantined(self):
-        entries = [QuarantineEntry(id="a.py::t")]
+    def test_param_family_all_quarantined_with_opt_in(self):
+        entries = [QuarantineEntry(id="a.py::t", family=True)]
         blocking, quarantined = partition_failures(
             ["a.py::t[1]", "a.py::t[2]"], entries
         )
         assert blocking == []
         assert quarantined == ["a.py::t[1]", "a.py::t[2]"]
+
+    def test_base_entry_without_family_blocks_new_params(self):
+        # codex #1222 r14: without family=True, a base entry does NOT waive
+        # parametrizations — a newly-added failing case still blocks.
+        entries = [QuarantineEntry(id="a.py::t")]
+        blocking, quarantined = partition_failures(
+            ["a.py::t[1]", "a.py::t[2]"], entries
+        )
+        assert blocking == ["a.py::t[1]", "a.py::t[2]"]
+        assert quarantined == []
 
 
 # --------------------------------------------------------------------------
@@ -759,6 +803,45 @@ class TestFullUnitQuarantineAware:
         monkeypatch.setattr(full_unit_mod.subprocess, "run", fake_run)
         FullUnitStep().run(ctx_factory())
         assert "--maxfail=0" in captured["cmd"]
+
+    def test_neutralizes_candidate_addopts_and_env(self, ctx_factory, monkeypatch):
+        # codex #1222 r14: --maxfail=0 alone does NOT stop --stepwise, so the
+        # gate clears the candidate's ini addopts (-o addopts=) AND strips
+        # PYTEST_ADDOPTS from the subprocess env, re-applying its OWN marker
+        # filter so selection can't be steered by candidate config.
+        captured = {}
+
+        def fake_run(cmd, **kw):
+            captured["cmd"] = cmd
+            captured["env"] = kw.get("env")
+            return subprocess.CompletedProcess(cmd, 0, _passed(), "")
+
+        monkeypatch.setattr(full_unit_mod.subprocess, "run", fake_run)
+        monkeypatch.setenv("PYTEST_ADDOPTS", "--stepwise")
+        FullUnitStep().run(ctx_factory())
+        assert "-o" in captured["cmd"]
+        assert "addopts=" in captured["cmd"]
+        assert "not slow and not integration and not needle" in captured["cmd"]
+        assert "PYTEST_ADDOPTS" not in (captured["env"] or {})
+
+    def test_early_stop_withholds_downgrade(self, ctx_factory, monkeypatch):
+        # codex #1222 r14: a conftest can set --stepwise programmatically even
+        # with addopts cleared. If pytest terminated the session early, the
+        # suite is incomplete — a later real regression may not have run — so
+        # the quarantine downgrade is withheld and every failure blocks.
+        self._patch_quarantine(
+            monkeypatch, [QuarantineEntry(id="tests/a.py::test_flaky")]
+        )
+        stdout = (
+            "==== short test summary info ====\n"
+            "FAILED tests/a.py::test_flaky - X\n"
+            "!!!!!!!! Interrupted: Test failed, continuing next run. !!!!!!!!\n"
+            "==== 1 failed in 0.20s ====\n"
+        )
+        self._patch_pytest(monkeypatch, 1, stdout)
+        res = FullUnitStep().run(ctx_factory())
+        assert res.status == "fail"  # withheld despite being listed
+        assert "terminated the session early" in res.details
 
 
 # --------------------------------------------------------------------------

--- a/tests/test_pr_validate_flake_tracking.py
+++ b/tests/test_pr_validate_flake_tracking.py
@@ -153,12 +153,47 @@ class TestSummaryNodeIds:
         )
         assert out == ["tests/a.py::test_x"]
 
-    def test_param_id_and_message_both_bracketed(self):
+    def test_param_id_and_message_both_bracketed_fails_safe(self):
+        # codex #1222 r41: a PARAMETRIZED id-part followed by a message that
+        # contains "[" is IRREDUCIBLY ambiguous — "test_x[a - b] - ValueError:
+        # got [2]" is indistinguishable from a single node id whose custom param
+        # value is "a - b] - ValueError: got [2". Splitting to "test_x[a - b]"
+        # could coincide with a DIFFERENT test's canonical id and waive a real
+        # PR regression as pre-existing (a false green in the base negative
+        # control), so we fail SAFE and return the whole line — it won't match a
+        # shorter id, so the failure BLOCKS. This over-blocks a genuine
+        # parametrized failure whose message holds "[" (safe, and only when it
+        # was ALREADY failing at base); an UNPARAMETRIZED failure with the same
+        # message still splits (see test_message_with_bracket_not_absorbed).
         out = summary_node_ids(
             _summary("FAILED tests/a.py::test_x[a - b] - ValueError: got [2]"),
             "FAILED",
         )
-        assert out == ["tests/a.py::test_x[a - b]"]
+        assert out == ["tests/a.py::test_x[a - b] - ValueError: got [2]"]
+
+    def test_balanced_bracket_param_after_dash_fails_safe(self):
+        # codex #1222 r41: the BALANCED sibling of the r40 unmatched-"]" case.
+        # A custom param id like ids=["a] - b[c"] yields node
+        # "test_x[a] - b[c]". The message "b[c]" balances, so the r40 tell
+        # (unmatched "]") MISSES it, yet splitting still COLLAPSES the id to
+        # "test_x[a]" — which could match a PR-introduced "test_x[a]" and waive
+        # it as pre-existing (a FALSE GREEN). The id-part ends "]" and the
+        # message contains "[", so we now fail safe and return the whole line.
+        out = summary_node_ids(
+            _summary("FAILED tests/a.py::test_x[a] - b[c]"), "FAILED"
+        )
+        assert out == ["tests/a.py::test_x[a] - b[c]"]
+
+    def test_unparametrized_message_with_balanced_bracket_still_splits(self):
+        # The r41 guard is scoped to a PARAMETRIZED id-part (ends with "]"): an
+        # unparametrized test's "-" is unambiguously the separator because a
+        # function name can't contain " - ", so its message may hold any
+        # brackets and the split is still taken. Guards the common case against
+        # the r41 fail-safe over-firing (would false-block ordinary failures).
+        out = summary_node_ids(
+            _summary("FAILED tests/a.py::test_x - ValueError: got [2]"), "FAILED"
+        )
+        assert out == ["tests/a.py::test_x"]
 
     def test_nested_balanced_brackets_ok(self):
         # A param id with nested, BALANCED brackets and inner " - " is
@@ -1940,6 +1975,23 @@ class TestFlakeTrackingContract:
         res = FlakeTrackingStep().run(ctx)
         assert res.status == "skip"
         assert not stale.exists()  # the stale candidates were removed
+
+    def test_stale_rerun_artifacts_cleared_on_skip(self, ctx_factory):
+        # codex #1222 r41 NIT: the rerun log + nodeid tsv are written only once a
+        # rerun launches, so a REUSED run dir with stale copies must ALSO be
+        # cleared up front (not just flake-candidates.json) — an early skip must
+        # not leave an earlier run's rerun evidence behind to misrepresent this
+        # run.
+        ctx = ctx_factory()
+        stale_log = ctx.artifact_path("flake-rerun.log")
+        stale_ids = ctx.artifact_path("flake-rerun-nodeids.tsv")
+        stale_log.write_text("old rerun output\n")
+        stale_ids.write_text("RERUN\ttests/old.py::stale\n")
+        ctx.artifact_path("full-unit.log").write_text(_passed())  # no failures
+        res = FlakeTrackingStep().run(ctx)
+        assert res.status == "skip"
+        assert not stale_log.exists()
+        assert not stale_ids.exists()
 
     def test_reruns_error_nodeids_structured(self, ctx_factory, monkeypatch):
         # codex #1222 r15 NIT: a setup / teardown / collection flake is
@@ -4425,3 +4477,17 @@ class TestTargetedTestsUntrustedRun:
         res = targeted_mod.TargetedTestsStep().run(ctx)
         assert res.status == "fail"  # fail-safe: never a false green
         assert json.dumps(canonical, ensure_ascii=False) in res.details
+
+    def test_balanced_ambiguous_base_id_does_not_waive_short_regression(self):
+        # codex #1222 r41, end-to-end: the base has a real failure whose node id
+        # is the BALANCED-ambiguous "test_x[a] - b[c]" (custom param "a] - b[c").
+        # If summary_node_ids collapsed it to "test_x[a]", a PR that newly breaks
+        # a DIFFERENT test literally named "test_x[a]" would be waived as
+        # pre-existing — a FALSE GREEN. The r41 guard keeps the base id WHOLE, so
+        # the short PR-side id is NOT in the base set and stays a regression.
+        base_line = _summary("FAILED tests/a.py::test_x[a] - b[c]")
+        base_set = set(summary_node_ids(base_line, "FAILED"))
+        # The base failure is kept whole (not truncated to the short id).
+        assert base_set == {"tests/a.py::test_x[a] - b[c]"}
+        # A different PR regression with the short canonical id is NOT masked.
+        assert "tests/a.py::test_x[a]" not in base_set

--- a/tests/test_pr_validate_flake_tracking.py
+++ b/tests/test_pr_validate_flake_tracking.py
@@ -780,6 +780,24 @@ class TestFullUnitQuarantineAware:
         assert "-rfE" in captured["cmd"]
         assert "--color=no" in captured["cmd"]
 
+    def test_gate_disables_rerunfailures(self, ctx_factory, monkeypatch):
+        # codex #1222 r20: the gating run must block pytest-rerunfailures so a
+        # candidate `@pytest.mark.flaky(reruns=N)` can't re-run and pass a
+        # genuinely failing test to green without consulting the quarantine.
+        # It's an AUTOLOADED plugin, so it must be disabled by its registered
+        # name (`-p no:rerunfailures`); -o addopts= / env-strip can't stop it.
+        captured = {}
+
+        def fake_run(cmd, **kw):
+            captured["cmd"] = cmd
+            return subprocess.CompletedProcess(cmd, 0, _passed(), "")
+
+        monkeypatch.setattr(full_unit_mod.subprocess, "run", fake_run)
+        FullUnitStep().run(ctx_factory())
+        cmd = captured["cmd"]
+        assert "no:rerunfailures" in cmd
+        assert cmd[cmd.index("no:rerunfailures") - 1] == "-p"
+
     def test_abnormal_exit_blocks(self, ctx_factory, monkeypatch):
         # Exit 2 (interrupted) with an otherwise-quarantined failure must
         # still block — the exit code says something the FAILED list
@@ -2089,6 +2107,46 @@ class TestNodeidReporter:
             text=True,
         )
         assert self._session_records(log_path) == ["1 3"]
+
+    def test_session_finish_mid_call_exit_records_gap(self, tmp_path):
+        # codex #1222 r20: the LAST collected item calls pytest.exit(0) from
+        # its CALL body. It emits a setup report but NO teardown, and pytest
+        # ends gracefully with exitstatus 0. Counting on SETUP would record
+        # ran == collected — a phantom "ran" for an item whose body never
+        # finished — and full_unit would accept a truncated run as green.
+        # Counting on TEARDOWN (terminal) records ran < collected, so the gap
+        # is visible and the quarantine downgrade is withheld. This is the
+        # exact hole that setup-counting missed.
+        (tmp_path / "test_midexit.py").write_text(
+            "import pytest\n"
+            "def test_a(): assert True\n"
+            "def test_b(): assert True\n"
+            "def test_c(): pytest.exit('bail', returncode=0)\n"
+        )
+        log_path = tmp_path / "nodeids.tsv"
+        plugin_args, env = flake_mod._nodeid_reporter.build_invocation(
+            log_path, self._repo_root()
+        )
+        proc = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "pytest",
+                "-p",
+                "no:randomly",
+                "-p",
+                "no:cacheprovider",
+                *plugin_args,
+                "test_midexit.py",
+            ],
+            cwd=str(tmp_path),
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+        assert proc.returncode == 0  # pytest.exit(returncode=0) → graceful zero
+        # test_c exited mid-call → no teardown for it → ran(2) < collected(3).
+        assert self._session_records(log_path) == ["2 3"]
 
     def test_session_finish_reruns_do_not_inflate(self, tmp_path):
         # codex #1222 r16 B2: under --reruns a flaky test emits SEVERAL setup

--- a/tests/test_pr_validate_flake_tracking.py
+++ b/tests/test_pr_validate_flake_tracking.py
@@ -1251,6 +1251,100 @@ class TestFlakeTrackingContract:
         assert "tests/mod.py" not in data["flake_candidates_new"]
         assert "tests/mod.py" in data["reproduced_likely_real"]
 
+    def test_call_fail_plus_teardown_error_is_not_quarantinable(
+        self, ctx_factory, monkeypatch
+    ):
+        # codex #1222 r19: an id that logs BOTH a FAILED (call) and an ERROR
+        # (teardown) in the full suite is still un-waivable — full_unit blocks
+        # ANY run containing an ERROR unconditionally. Even though it also
+        # appears under FAILED, it must be treated as error-origin and land in
+        # error_flake_candidates ("investigate"), NOT flake_candidates_new
+        # (which recommends an ineffective quarantine promotion). The r18 code
+        # excluded FAILED ids from error_origin and mislabeled this case.
+        ctx = ctx_factory()
+        ctx.artifact_path("full-unit.log").write_text("boom")
+        ctx.artifact_path("full-unit-nodeids.tsv").write_text(
+            "FAILED\ttests/x.py::test_flaky\nERROR\ttests/x.py::test_flaky\n"
+        )
+        monkeypatch.setattr(
+            flake_mod.importlib.util, "find_spec", lambda name: object()
+        )
+        monkeypatch.setattr(flake_mod, "load_quarantine_from_ref", lambda *a, **k: [])
+
+        def fake(cmd, cwd, timeout, env=None):
+            ctx.artifact_path("flake-rerun-nodeids.tsv").write_text(
+                "PASSED\ttests/x.py::test_flaky\n"
+            )
+            return _completed(0, "")
+
+        monkeypatch.setattr(flake_mod, "_run_session", fake)
+        res = FlakeTrackingStep().run(ctx)
+        assert res.status == "pass"
+        data = json.loads(ctx.artifact_path("flake-candidates.json").read_text())
+        assert data["error_flake_candidates"] == ["tests/x.py::test_flaky"]
+        assert data["flake_candidates_new"] == []
+
+    def test_recovered_directory_collection_error_is_error_candidate(
+        self, ctx_factory, monkeypatch
+    ):
+        # codex #1222 r19: a DIRECTORY collection target ("tests/subdir", no
+        # ".py") contains its tests at the "/" boundary
+        # ("tests/subdir/test_x.py::test_y"), which never satisfies a "::"
+        # check — so the r18 code left genuine directory-collection flakes
+        # permanently inconclusive. A passed descendant at the "/" boundary is
+        # positive recovery evidence; as an ERROR-origin id it is not
+        # quarantinable → error_flake_candidates.
+        ctx = ctx_factory()
+        ctx.artifact_path("full-unit.log").write_text("boom")
+        ctx.artifact_path("full-unit-nodeids.tsv").write_text("ERROR\ttests/subdir\n")
+        monkeypatch.setattr(
+            flake_mod.importlib.util, "find_spec", lambda name: object()
+        )
+        monkeypatch.setattr(flake_mod, "load_quarantine_from_ref", lambda *a, **k: [])
+
+        def fake(cmd, cwd, timeout, env=None):
+            ctx.artifact_path("flake-rerun-nodeids.tsv").write_text(
+                "PASSED\ttests/subdir/test_x.py::test_y\n"
+            )
+            return _completed(0, "")
+
+        monkeypatch.setattr(flake_mod, "_run_session", fake)
+        res = FlakeTrackingStep().run(ctx)
+        assert res.status == "pass"
+        data = json.loads(ctx.artifact_path("flake-candidates.json").read_text())
+        assert "tests/subdir" in data["error_flake_candidates"]
+        assert "tests/subdir" not in data["inconclusive"]
+        assert "tests/subdir" not in data["flake_candidates_new"]
+
+    def test_dir_collection_target_not_recovered_by_sibling_prefix(
+        self, ctx_factory, monkeypatch
+    ):
+        # codex #1222 r19 boundary guard: a passed id that merely shares a
+        # string prefix with a dir target but sits at NEITHER a "::" nor a "/"
+        # boundary ("tests/foo.py::test" vs dir "tests/foo") is NOT a
+        # descendant and must not count as recovery — the id stays
+        # inconclusive, not a false error-flake.
+        ctx = ctx_factory()
+        ctx.artifact_path("full-unit.log").write_text("boom")
+        ctx.artifact_path("full-unit-nodeids.tsv").write_text("ERROR\ttests/foo\n")
+        monkeypatch.setattr(
+            flake_mod.importlib.util, "find_spec", lambda name: object()
+        )
+        monkeypatch.setattr(flake_mod, "load_quarantine_from_ref", lambda *a, **k: [])
+
+        def fake(cmd, cwd, timeout, env=None):
+            ctx.artifact_path("flake-rerun-nodeids.tsv").write_text(
+                "PASSED\ttests/foo.py::test_sibling\n"
+            )
+            return _completed(0, "")
+
+        monkeypatch.setattr(flake_mod, "_run_session", fake)
+        res = FlakeTrackingStep().run(ctx)
+        assert res.status == "pass"
+        data = json.loads(ctx.artifact_path("flake-candidates.json").read_text())
+        assert "tests/foo" in data["inconclusive"]
+        assert "tests/foo" not in data["error_flake_candidates"]
+
     def test_reruns_error_nodeids_fallback(self, ctx_factory, monkeypatch):
         # Same NIT via the terminal-summary FALLBACK (no structured log): an
         # ERROR line in full-unit.log must be picked up for the advisory

--- a/tests/test_pr_validate_flake_tracking.py
+++ b/tests/test_pr_validate_flake_tracking.py
@@ -712,13 +712,14 @@ class TestFlakeTrackingContract:
         assert "--color=no" in captured["cmd"]
         assert "-rA" in captured["cmd"]
 
-    def test_quarantined_reproduction_not_labeled_blocked(
+    def test_quarantined_deterministic_reproduction_blocks(
         self, ctx_factory, monkeypatch
     ):
-        # A quarantined test that reproduces on re-run must land in
-        # `reproduced_quarantined`, NOT `reproduced_likely_real` — full_unit
-        # PASSED it (quarantined), so it isn't a failure the gate blocked
-        # on (codex #1222 r5).
+        # A quarantined test that reproduces its failure on EVERY re-run is
+        # a deterministic regression the quarantine would otherwise mask —
+        # flake_tracking must BLOCK (status=fail), revoking full_unit's
+        # downgrade (codex #1222 r7). Its id lands in `reproduced_quarantined`;
+        # a non-quarantined reproduction lands in `reproduced_likely_real`.
         ctx = ctx_factory()
         ctx.artifact_path("full-unit.log").write_text(
             _summary(
@@ -744,10 +745,41 @@ class TestFlakeTrackingContract:
             flake_mod, "_run_session", lambda *a, **k: _completed(1, rerun)
         )
         res = FlakeTrackingStep().run(ctx)
-        assert res.status == "pass"
+        assert res.status == "fail"  # deterministic quarantined regression
+        assert "deterministically" in res.summary
         data = json.loads(ctx.artifact_path("flake-candidates.json").read_text())
         assert data["reproduced_likely_real"] == ["tests/x.py::real"]
         assert data["reproduced_quarantined"] == ["tests/x.py::flaky"]
+
+    def test_quarantined_flake_confirmed_does_not_block(self, ctx_factory, monkeypatch):
+        # The inverse: a quarantined test that PASSES on re-run is a genuine
+        # flake — the quarantine downgrade was correct, so we do NOT block;
+        # it's reported as a confirmed known-flake (advisory pass).
+        ctx = ctx_factory()
+        ctx.artifact_path("full-unit.log").write_text(
+            _summary("FAILED tests/x.py::flaky - X")
+        )
+        monkeypatch.setattr(
+            flake_mod.importlib.util, "find_spec", lambda name: object()
+        )
+        monkeypatch.setattr(
+            flake_mod,
+            "load_quarantine_from_ref",
+            lambda *a, **k: [QuarantineEntry(id="tests/x.py::flaky")],
+        )
+        rerun = (
+            "==================== short test summary info ====================\n"
+            "PASSED tests/x.py::flaky\n"
+            "==== 1 passed in 0.20s ====\n"
+        )
+        monkeypatch.setattr(
+            flake_mod, "_run_session", lambda *a, **k: _completed(0, rerun)
+        )
+        res = FlakeTrackingStep().run(ctx)
+        assert res.status == "pass"  # confirmed flake → downgrade was right
+        data = json.loads(ctx.artifact_path("flake-candidates.json").read_text())
+        assert data["flake_candidates_known"] == ["tests/x.py::flaky"]
+        assert data["reproduced_quarantined"] == []
 
 
 class TestFlakeTrackingClassification:
@@ -807,17 +839,33 @@ class TestRunSession:
 
     def test_timeout_kills_grandchild_in_group(self, tmp_path):
         # Prove it's a process-GROUP kill, not just proc.kill(): the child
-        # spawns a long-lived grandchild in the SAME group (no setsid) and
-        # records its pid. On timeout, killpg must reap the grandchild too —
-        # a bare proc.kill() on the direct child would leave it alive
-        # (codex #1222 r2).
+        # spawns a long-lived grandchild in the SAME group (no setsid). On
+        # timeout, killpg must kill the grandchild too — a bare proc.kill()
+        # on the direct child would leave it running (codex #1222 r2).
+        #
+        # Liveness is checked via a HEARTBEAT, not os.kill(pid, 0): a
+        # SIGKILLed-but-not-yet-reaped ZOMBIE still answers signal 0, so a
+        # PID-disappearance poll can flake when the reaper is slow (codex
+        # #1222 r7). A killed process — zombie or not — cannot tick the
+        # heartbeat file, so a frozen counter is unambiguous proof of death.
         pidfile = tmp_path / "grandchild.pid"
+        heartbeat = tmp_path / "heartbeat"
+        grandchild_prog = textwrap.dedent(
+            f"""
+            import time
+            n = 0
+            while True:
+                with open({str(heartbeat)!r}, "w") as f:
+                    f.write(str(n))
+                    f.flush()
+                n += 1
+                time.sleep(0.05)
+            """
+        )
         child_prog = textwrap.dedent(
             f"""
             import subprocess, sys, time
-            gc = subprocess.Popen(
-                [sys.executable, "-c", "import time; time.sleep(120)"]
-            )
+            gc = subprocess.Popen([sys.executable, "-c", {grandchild_prog!r}])
             with open({str(pidfile)!r}, "w") as f:
                 f.write(str(gc.pid))
                 f.flush()
@@ -832,23 +880,23 @@ class TestRunSession:
         assert time.monotonic() - t0 < 20.0
 
         gc_pid = int(pidfile.read_text().strip())
-        # killpg SIGKILL is async; poll briefly for the grandchild to die.
-        deadline = time.monotonic() + 5.0
-        alive = True
-        while time.monotonic() < deadline:
-            try:
-                os.kill(gc_pid, 0)
-            except ProcessLookupError:
-                alive = False
-                break
-            time.sleep(0.1)
-        if alive:
-            # Clean up before failing so we don't leak a 120s sleeper.
+        try:
+            # Let the SIGKILL settle, then confirm the heartbeat froze.
+            time.sleep(0.3)
+            assert heartbeat.exists(), "grandchild never started"
+            beat1 = heartbeat.read_text()
+            time.sleep(1.0)  # >> 0.05s tick — an ALIVE grandchild ticks ~20×
+            beat2 = heartbeat.read_text()
+            assert beat1 == beat2, (
+                f"grandchild heartbeat advanced {beat1!r}->{beat2!r} — it "
+                f"survived the process-group kill"
+            )
+        finally:
+            # best-effort cleanup so a survivor (on failure) doesn't leak.
             try:
                 os.kill(gc_pid, signal.SIGKILL)
-            except ProcessLookupError:
+            except (ProcessLookupError, OSError):
                 pass
-            pytest.fail(f"grandchild {gc_pid} survived the process-group kill")
 
     def test_double_timeout_reaps_direct_child(self, monkeypatch):
         # If the post-kill drain ALSO times out (a group-escaping
@@ -878,12 +926,18 @@ class TestRunSession:
 
 
 class TestRegistration:
-    def test_registered_after_full_unit(self):
+    def test_registered_after_all_gating_steps(self):
+        # Must read full-unit.log (so after full_unit) AND run after every
+        # gating step so its possible descendant leak can't contaminate one
+        # (codex #1222 r7): after full_unit and stress_e2e_bench.
         from scripts.pr_validate.runner import STEPS
 
         names = [s.name for s in STEPS]
         assert "flake_tracking" in names
         assert names.index("flake_tracking") > names.index("full_unit")
+        assert names.index("flake_tracking") > names.index("stress_e2e_bench")
 
-    def test_is_advisory(self):
+    def test_crash_never_blocks(self):
+        # A crash in this step must never sink the PR (advisory heritage);
+        # its only blocking path is a deliberate reproduced-quarantined fail.
         assert FlakeTrackingStep().continue_on_error is True

--- a/tests/test_pr_validate_flake_tracking.py
+++ b/tests/test_pr_validate_flake_tracking.py
@@ -1995,30 +1995,30 @@ class TestFlakeTrackingContract:
         assert "--color=no" in captured["cmd"]
         assert "-rA" in captured["cmd"]
 
-    def test_rerun_loads_rerunfailures_explicitly_when_autoload_disabled(
-        self, ctx_factory, monkeypatch
-    ):
-        # codex #1222 r18: find_spec confirms rerunfailures is installed but
-        # not that it's ACTIVE — under PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 an
-        # installed plugin won't register, so --reruns would be unknown and
-        # the advisory would silently skip. In THAT case only, load it
-        # explicitly with -p so --reruns is recognized.
+    def test_rerun_skips_when_autoload_disabled(self, ctx_factory, monkeypatch):
+        # codex #1222 r32 (supersedes r18): under PYTEST_DISABLE_PLUGIN_AUTOLOAD
+        # the advisory re-run can't faithfully reproduce plugin-dependent tests.
+        # Hand-loading ``-p pytest_rerunfailures`` would revive --reruns but
+        # leave the project's OTHER required plugins (pytest-asyncio, …)
+        # disabled, so a recovered async test would ERROR on re-run and be
+        # misclassified as reproduced/inconclusive rather than a flake. The step
+        # is advisory (never gates), so rather than emit a wrong signal it SKIPS
+        # — and must NOT even launch the re-run subprocess.
         monkeypatch.setenv("PYTEST_DISABLE_PLUGIN_AUTOLOAD", "1")
         ctx = ctx_factory()
         self._prime(ctx, monkeypatch)
         monkeypatch.setattr(flake_mod, "load_quarantine_from_ref", lambda *a, **k: [])
-        captured = {}
+        called = {"ran": False}
 
         def fake(cmd, cwd, timeout, env=None):
-            captured["cmd"] = cmd
+            called["ran"] = True
             return _completed(0, _passed())
 
         monkeypatch.setattr(flake_mod, "_run_session", fake)
-        FlakeTrackingStep().run(ctx)
-        cmd = captured["cmd"]
-        # -p pytest_rerunfailures appears as adjacent argv entries.
-        assert "pytest_rerunfailures" in cmd
-        assert cmd[cmd.index("pytest_rerunfailures") - 1] == "-p"
+        res = FlakeTrackingStep().run(ctx)
+        assert res.status == "skip"
+        assert called["ran"] is False  # no advisory subprocess was launched
+        assert "PYTEST_DISABLE_PLUGIN_AUTOLOAD" in res.summary
 
     def test_rerun_omits_explicit_rerunfailures_when_autoload_on(
         self, ctx_factory, monkeypatch
@@ -2891,6 +2891,106 @@ class TestNodeidReporter:
         passed = report_log_node_ids(log_path, "PASSED")
         assert "test_fl.py::test_flaky" in passed
         assert "test_fl.py::test_flaky" not in failed
+
+    def test_teardown_phase_rerun_emits_intermediate_teardown(self, tmp_path):
+        # codex #1222 r32 EMPIRICAL ANCHOR (correcting the r31 rebuttal, which
+        # probed only CALL-phase reruns). A TEARDOWN-phase flake — a yield
+        # fixture whose teardown fails once then passes — really DOES emit an
+        # intermediate teardown report carrying outcome=='rerun', UNLIKE a
+        # call-phase rerun which emits no intermediate teardown at all. Proof:
+        # a RERUN record is written for it. Yet the completing test still counts
+        # exactly once (ran==collected==1) — the ``outcome != "rerun"`` guard
+        # drops the PROVISIONAL teardown while keeping the terminal one.
+        pytest.importorskip("pytest_rerunfailures")
+        (tmp_path / "test_td.py").write_text(
+            textwrap.dedent(
+                """
+                import pytest
+                _n = {'v': 0}
+
+                @pytest.fixture
+                def res():
+                    yield 'r'
+                    _n['v'] += 1
+                    assert _n['v'] >= 2   # TEARDOWN fails attempt 1, passes on 2
+
+                @pytest.mark.flaky(reruns=2)
+                def test_td(res):
+                    assert True           # call always passes; the teardown reruns
+                """
+            )
+        )
+        log_path = tmp_path / "nodeids.tsv"
+        plugin_args, env = flake_mod._nodeid_reporter.build_invocation(
+            log_path, self._repo_root(), log_passes=True
+        )
+        subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "pytest",
+                "-p",
+                "no:randomly",
+                "-o",
+                "addopts=",
+                *plugin_args,
+                "test_td.py",
+            ],
+            cwd=str(tmp_path),
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+        # The intermediate teardown really carried outcome=='rerun' → RERUN logged.
+        assert report_log_node_ids(log_path, "RERUN") == ["test_td.py::test_td"]
+        # …but the completing test is counted exactly once, so the completeness
+        # record stays ran==collected==1 (the guard kept only the terminal
+        # teardown, not the provisional rerun one).
+        assert raw_session_records(log_path) == ["1 1"]
+
+    def test_teardown_phase_rerun_does_not_prematurely_complete(
+        self, tmp_path, monkeypatch
+    ):
+        # codex #1222 r32: without the ``outcome != "rerun"`` teardown guard,
+        # the INTERMEDIATE teardown/rerun report would add the id to
+        # _completed_ids, so a FINAL attempt truncated before its terminal
+        # teardown would still satisfy ran==collected — masking an incomplete
+        # rerun. Drive the hooks directly with the exact report sequence a
+        # teardown-phase flake produces (verified real in the test above) and
+        # prove the guard keeps the truncation visible as ran < collected.
+        import types
+
+        log_path = tmp_path / "nodeids.tsv"
+        monkeypatch.setenv(_nodeid_reporter._ENV_LOG, str(log_path))
+        _nodeid_reporter.pytest_sessionstart(object())  # clears _completed_ids
+
+        def _rpt(when, outcome, nodeid):
+            return types.SimpleNamespace(
+                when=when,
+                outcome=outcome,
+                nodeid=nodeid,
+                failed=(outcome == "failed"),
+            )
+
+        nid = "tests/x.py::test_teardown_flaky"
+        # Attempt 1: setup+call pass, TEARDOWN fails → rerunfailures marks the
+        # teardown report outcome=='rerun' and retries.
+        _nodeid_reporter.pytest_runtest_logreport(_rpt("setup", "passed", nid))
+        _nodeid_reporter.pytest_runtest_logreport(_rpt("call", "passed", nid))
+        _nodeid_reporter.pytest_runtest_logreport(_rpt("teardown", "rerun", nid))
+        # Final attempt is TRUNCATED mid-flight (process killed / early-stop
+        # elsewhere): it emits setup+call but its terminal teardown never lands.
+        _nodeid_reporter.pytest_runtest_logreport(_rpt("setup", "passed", nid))
+        _nodeid_reporter.pytest_runtest_logreport(_rpt("call", "passed", nid))
+        # Session still finishes gracefully, having collected 1 item.
+        _nodeid_reporter.pytest_sessionfinish(
+            types.SimpleNamespace(testscollected=1), 0
+        )
+
+        # WITHOUT the guard the provisional teardown/rerun would have completed
+        # the id → "1 1" (falsely complete). WITH it, the item never reached a
+        # terminal teardown → ran(0) < collected(1); the gap stays visible.
+        assert raw_session_records(log_path) == ["0 1"]
 
     def _session_records(self, log_path):
         if not log_path.exists():

--- a/tests/test_pr_validate_flake_tracking.py
+++ b/tests/test_pr_validate_flake_tracking.py
@@ -951,6 +951,40 @@ class TestFullUnitQuarantineAware:
         assert res.status == "fail"
         assert "did not run to completion" in res.details
 
+    def test_clean_exit_without_completion_blocks(self, ctx_factory, monkeypatch):
+        # codex #1222 r16 B1: os._exit(0) can exit pytest with code 0 after
+        # skipping the rest of the suite, hiding a regression in the un-run
+        # tail. When the reporter ran, even a GREEN exit requires the
+        # completion record — its absence proves the run was truncated.
+        self._patch_pytest(monkeypatch, 0, _passed(), session=False)
+        res = FullUnitStep().run(ctx_factory())
+        assert res.status == "fail"
+        assert "did not run to completion" in res.details
+
+    def test_clean_exit_early_stop_record_blocks(self, ctx_factory, monkeypatch):
+        # Exit 0 with a ran<collected record is still a truncated run (a
+        # conftest could stop early yet exit 0) — not accepted as green.
+        self._patch_pytest(monkeypatch, 0, _passed(), ran=1, collected=50)
+        res = FullUnitStep().run(ctx_factory())
+        assert res.status == "fail"
+        assert "did not run to completion" in res.details
+
+    def test_clean_exit_with_completion_passes(self, ctx_factory, monkeypatch):
+        # Positive control: a green exit WITH a complete record is a clean
+        # pass (the plugin ran and the whole suite completed).
+        self._patch_pytest(monkeypatch, 0, _passed(), ran=50, collected=50)
+        res = FullUnitStep().run(ctx_factory())
+        assert res.status == "pass"
+
+    def test_clean_exit_without_plugin_trusts_exit_code(self, ctx_factory, monkeypatch):
+        # If the reporter couldn't be injected at all (no structured log),
+        # there's no completeness signal to check — a green exit falls back to
+        # the exit code (the degraded, non-candidate path). structured=False
+        # simulates the plugin not writing a log.
+        self._patch_pytest(monkeypatch, 0, _passed(), structured=False)
+        res = FullUnitStep().run(ctx_factory())
+        assert res.status == "pass"
+
 
 # --------------------------------------------------------------------------
 # full_unit._session_completed — structured completeness proof (codex r15)
@@ -996,6 +1030,14 @@ class TestSessionCompleted:
         # safe direction.
         assert not full_unit_mod._session_completed(
             self._tsv(tmp_path, "SESSIONFINISH\t50 50\nSESSIONFINISH\t1 50\n")
+        )
+
+    def test_identical_duplicate_records_incomplete(self, tmp_path):
+        # codex #1222 r16: two IDENTICAL completion records must NOT collapse
+        # — report_log_node_ids would dedup them by value and pass the
+        # "exactly one" check; the raw line count rejects the duplicate.
+        assert not full_unit_mod._session_completed(
+            self._tsv(tmp_path, "SESSIONFINISH\t50 50\nSESSIONFINISH\t50 50\n")
         )
 
     def test_malformed_value_is_incomplete(self, tmp_path):
@@ -1205,6 +1247,30 @@ class TestFlakeTrackingContract:
         FlakeTrackingStep().run(ctx)
         assert "--color=no" in captured["cmd"]
         assert "-rA" in captured["cmd"]
+
+    def test_rerun_neutralizes_candidate_addopts_and_env(
+        self, ctx_factory, monkeypatch
+    ):
+        # codex #1222 r16: the advisory re-run must be hermetic like full_unit
+        # — clear ini addopts (-o addopts=) and strip PYTEST_ADDOPTS so a
+        # candidate can't suppress classification via --collect-only / a
+        # marker filter / -p no:<reporter>.
+        ctx = ctx_factory()
+        self._prime(ctx, monkeypatch)
+        monkeypatch.setattr(flake_mod, "load_quarantine_from_ref", lambda *a, **k: [])
+        monkeypatch.setenv("PYTEST_ADDOPTS", "--collect-only")
+        captured = {}
+
+        def fake(cmd, cwd, timeout, env=None):
+            captured["cmd"] = cmd
+            captured["env"] = env
+            return _completed(0, _passed())
+
+        monkeypatch.setattr(flake_mod, "_run_session", fake)
+        FlakeTrackingStep().run(ctx)
+        assert "-o" in captured["cmd"]
+        assert "addopts=" in captured["cmd"]
+        assert "PYTEST_ADDOPTS" not in (captured["env"] or {})
 
     def test_quarantined_reproduction_is_advisory_loud(self, ctx_factory, monkeypatch):
         # A quarantined test that reproduces on EVERY re-run MAY be a
@@ -1731,6 +1797,46 @@ class TestNodeidReporter:
             text=True,
         )
         assert self._session_records(log_path) == ["1 3"]
+
+    def test_session_finish_reruns_do_not_inflate(self, tmp_path):
+        # codex #1222 r16 B2: under --reruns a flaky test emits SEVERAL setup
+        # reports for the same id, so a raw setup COUNT would inflate ran past
+        # collected and mask a truncated run. The record counts DISTINCT node
+        # ids, so a complete run stays ran == collected despite the retries.
+        pytest.importorskip("pytest_rerunfailures")
+        (tmp_path / "test_reruns.py").write_text(
+            "import pathlib\n"
+            "_c = pathlib.Path(__file__).with_name('.n')\n"
+            "def test_flaky():\n"
+            "    n = int(_c.read_text()) if _c.exists() else 0\n"
+            "    _c.write_text(str(n + 1))\n"
+            "    assert n >= 2\n"  # fails attempts 0,1,2 → passes on the 3rd
+            "def test_a(): assert True\n"
+            "def test_b(): assert True\n"
+        )
+        log_path = tmp_path / "nodeids.tsv"
+        plugin_args, env = flake_mod._nodeid_reporter.build_invocation(
+            log_path, self._repo_root(), log_passes=True
+        )
+        subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "pytest",
+                "-p",
+                "no:randomly",
+                "--reruns=3",
+                *plugin_args,
+                "test_reruns.py",
+            ],
+            cwd=str(tmp_path),
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+        # 3 distinct tests all ran to completion → ran == collected == 3,
+        # even though the flaky one produced ~5 setup reports.
+        assert self._session_records(log_path) == ["3 3"]
 
 
 # --------------------------------------------------------------------------

--- a/tests/test_pr_validate_flake_tracking.py
+++ b/tests/test_pr_validate_flake_tracking.py
@@ -72,6 +72,10 @@ def ctx_factory(tmp_path, monkeypatch):
         # steps' should_run predicate is satisfied.
         ctx.files_changed = files_changed or ["vllm_mlx/scheduler.py"]
         ctx.work_dir = tmp_path / "work"
+        # A truthy immutable base SHA so the quarantine load path runs
+        # (steps read the registry only from base_sha now — codex r10).
+        # Tests exercising the no-SHA fail-closed path clear it explicitly.
+        ctx.base_sha = "basesha0000000000000000000000000000000000"
         return ctx
 
     return _make
@@ -311,12 +315,29 @@ class TestLoadQuarantine:
         p.write_text("tests:\n")
         assert load_quarantine(p) == []
 
-    def test_optional_fields_default_empty(self, tmp_path):
+    def test_issue_optional_reason_added_present(self, tmp_path):
+        # reason + added are mandatory audit data; issue stays optional
+        # (not every flake has a tracker yet) — codex #1222 r10.
         p = tmp_path / "q.yaml"
-        p.write_text("tests:\n  - id: a.py::t\n")
+        p.write_text(
+            "tests:\n  - id: a.py::t\n    reason: flaky\n    added: 2026-01-01\n"
+        )
         (entry,) = load_quarantine(p)
         assert entry.id == "a.py::t"
-        assert entry.reason == "" and entry.added == "" and entry.issue == ""
+        assert entry.reason == "flaky" and entry.added == "2026-01-01"
+        assert entry.issue == ""
+
+    def test_missing_reason_raises(self, tmp_path):
+        p = tmp_path / "q.yaml"
+        p.write_text("tests:\n  - id: a.py::t\n    added: 2026-01-01\n")
+        with pytest.raises(QuarantineError, match="reason"):
+            load_quarantine(p)
+
+    def test_missing_added_raises(self, tmp_path):
+        p = tmp_path / "q.yaml"
+        p.write_text("tests:\n  - id: a.py::t\n    reason: flaky\n")
+        with pytest.raises(QuarantineError, match="added"):
+            load_quarantine(p)
 
 
 # --------------------------------------------------------------------------
@@ -326,7 +347,7 @@ class TestLoadQuarantine:
 
 class TestLoadQuarantineFromRef:
     def test_returns_entries_from_git_show(self, tmp_path, monkeypatch):
-        yaml_text = "tests:\n  - id: a.py::t\n    reason: r\n"
+        yaml_text = "tests:\n  - id: a.py::t\n    reason: r\n    added: 2026-01-01\n"
         monkeypatch.setattr(
             "scripts.pr_validate.quarantine.subprocess.run",
             lambda *a, **k: _completed(0, yaml_text),
@@ -335,20 +356,45 @@ class TestLoadQuarantineFromRef:
         assert entry.id == "a.py::t"
 
     def test_absent_at_ref_is_empty(self, tmp_path, monkeypatch):
-        # git show returns 128 when the path doesn't exist at that rev.
+        # git show returns 128 with a "does not exist in" message when the
+        # PATH isn't in that rev's tree — a legitimate empty registry (the
+        # base predates the file), NOT an infra failure (codex #1222 r10).
         monkeypatch.setattr(
             "scripts.pr_validate.quarantine.subprocess.run",
-            lambda *a, **k: _completed(128, "", "fatal: path does not exist"),
+            lambda *a, **k: _completed(
+                128, "", "fatal: path 'q.yaml' does not exist in 'BASE'"
+            ),
         )
         assert load_quarantine_from_ref("BASE", tmp_path) == []
 
-    def test_git_missing_is_empty_not_raise(self, tmp_path, monkeypatch):
+    def test_git_missing_raises(self, tmp_path, monkeypatch):
+        # git not on PATH is an INFRA failure, not "no registry" — it must
+        # raise so full_unit reports the fail-safe fallback loudly instead
+        # of silently behaving as if nothing is quarantined (codex r10).
         def boom(*a, **k):
             raise FileNotFoundError("git not found")
 
         monkeypatch.setattr("scripts.pr_validate.quarantine.subprocess.run", boom)
-        # Fail-safe: infra hiccup → empty quarantine (stricter gate).
-        assert load_quarantine_from_ref("BASE", tmp_path) == []
+        with pytest.raises(QuarantineError):
+            load_quarantine_from_ref("BASE", tmp_path)
+
+    def test_git_timeout_raises(self, tmp_path, monkeypatch):
+        def boom(*a, **k):
+            raise subprocess.TimeoutExpired(cmd="git", timeout=30)
+
+        monkeypatch.setattr("scripts.pr_validate.quarantine.subprocess.run", boom)
+        with pytest.raises(QuarantineError):
+            load_quarantine_from_ref("BASE", tmp_path)
+
+    def test_bad_ref_git_error_raises(self, tmp_path, monkeypatch):
+        # A non-"missing path" git error (bad ref, not a repo) must surface,
+        # not be swallowed as an empty registry (codex #1222 r10).
+        monkeypatch.setattr(
+            "scripts.pr_validate.quarantine.subprocess.run",
+            lambda *a, **k: _completed(128, "", "fatal: invalid object name 'BASE'"),
+        )
+        with pytest.raises(QuarantineError):
+            load_quarantine_from_ref("BASE", tmp_path)
 
     def test_malformed_at_ref_raises(self, tmp_path, monkeypatch):
         monkeypatch.setattr(
@@ -392,7 +438,9 @@ class TestLoadQuarantineFromRef:
         git("init", "-q")
         rel = "scripts/pr_validate/quarantine.yaml"
         (tmp_path / "scripts" / "pr_validate").mkdir(parents=True)
-        (tmp_path / rel).write_text("tests:\n  - id: x.py::t\n    reason: r\n")
+        (tmp_path / rel).write_text(
+            "tests:\n  - id: x.py::t\n    reason: r\n    added: 2026-01-01\n"
+        )
         git("add", "-A")
         git("commit", "-q", "-m", "seed")
         (entry,) = load_quarantine_from_ref("HEAD", tmp_path)
@@ -733,7 +781,7 @@ class TestFlakeTrackingContract:
         monkeypatch.setattr(flake_mod, "load_quarantine_from_ref", lambda *a, **k: [])
         captured = {}
 
-        def fake(cmd, cwd, timeout):
+        def fake(cmd, cwd, timeout, env=None):
             captured["cmd"] = cmd
             return _completed(0, _passed())
 
@@ -838,7 +886,7 @@ class TestFlakeTrackingContract:
         )
         captured = {}
 
-        def _capture(cmd, cwd, timeout):
+        def _capture(cmd, cwd, timeout, env=None):
             captured["cmd"] = cmd
             return _completed(0, _passed())
 
@@ -871,7 +919,7 @@ class TestFlakeTrackingContract:
         )
         captured = {}
 
-        def _capture(cmd, cwd, timeout):
+        def _capture(cmd, cwd, timeout, env=None):
             captured["cmd"] = cmd
             return _completed(0, _passed())
 
@@ -886,8 +934,15 @@ class TestFlakeTrackingClassification:
     """Drive a real pytest subprocess so the flake-vs-real split is
     proven end-to-end, not mocked."""
 
-    def test_classifies_flake_vs_real(self, ctx_factory, tmp_path):
+    def test_classifies_flake_vs_real_fallback(
+        self, ctx_factory, tmp_path, monkeypatch
+    ):
+        # Exercises the terminal-summary FALLBACK classification path with a
+        # real subprocess. The structured-plugin path can't load here (the
+        # fake repo root has no `scripts` package), so force the fallback;
+        # the dedicated plugin round-trip is proven in TestNodeidReporter.
         pytest.importorskip("pytest_rerunfailures")
+        monkeypatch.setattr(flake_mod._nodeid_reporter, "available", lambda: False)
         (tmp_path / "test_sample.py").write_text(
             "import pathlib\n"
             "_c = pathlib.Path(__file__).with_name('.count')\n"
@@ -910,6 +965,122 @@ class TestFlakeTrackingClassification:
         data = json.loads(ctx.artifact_path("flake-candidates.json").read_text())
         assert "test_sample.py::test_flaky" in data["flake_candidates_new"]
         assert "test_sample.py::test_real" in data["reproduced_likely_real"]
+
+
+# --------------------------------------------------------------------------
+# _nodeid_reporter — structured node-id log (the parse-ambiguity fix)
+# --------------------------------------------------------------------------
+
+
+class TestNodeidReporter:
+    """Prove the plugin round-trips real ``report.nodeid`` values through a
+    genuine pytest subprocess, using the ACTUAL repo root on PYTHONPATH so
+    the risky ``-p scripts.pr_validate._nodeid_reporter`` import is exercised
+    end-to-end (not mocked). This is what lets full_unit/flake_tracking stop
+    scraping the ambiguous terminal summary."""
+
+    def _repo_root(self):
+        # _nodeid_reporter.py lives at <root>/scripts/pr_validate/ — climb two.
+        import pathlib
+
+        return pathlib.Path(flake_mod._nodeid_reporter.__file__).resolve().parents[2]
+
+    def test_plugin_writes_structured_log(self, tmp_path):
+        (tmp_path / "test_outcomes.py").write_text(
+            textwrap.dedent(
+                """
+                import pytest
+
+                def test_ok():
+                    assert True
+
+                # A node id that would defeat any terminal-summary text rule:
+                # it contains ' - ' and unbalanced brackets. report.nodeid is
+                # exact, so the structured log must capture it verbatim.
+                @pytest.mark.parametrize("x", ["a - b]"])
+                def test_param(x):
+                    assert False
+
+                @pytest.fixture
+                def broken():
+                    raise RuntimeError("setup boom")
+
+                def test_setup_error(broken):
+                    assert True
+                """
+            )
+        )
+        # A second module that fails to even collect → ERROR (collection).
+        (tmp_path / "test_uncollectable.py").write_text(
+            "import this_module_does_not_exist_xyz  # noqa: F401\n"
+        )
+
+        log_path = tmp_path / "nodeids.tsv"
+        repo_root = self._repo_root()
+        assert flake_mod._nodeid_reporter.available()
+        plugin_args, env = flake_mod._nodeid_reporter.build_invocation(
+            log_path, repo_root, log_passes=True
+        )
+
+        subprocess.run(
+            # --continue-on-collection-errors so the collection ERROR and the
+            # call/setup outcomes are all recorded in ONE run (pytest would
+            # otherwise abort the whole session on the first collection error).
+            [
+                sys.executable,
+                "-m",
+                "pytest",
+                "-p",
+                "no:randomly",
+                "--continue-on-collection-errors",
+                *plugin_args,
+                "test_outcomes.py",
+                "test_uncollectable.py",
+            ],
+            cwd=str(tmp_path),
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+
+        assert log_path.exists(), "plugin never wrote the structured log"
+        lines = log_path.read_text(encoding="utf-8").splitlines()
+        rows = [tuple(ln.split("\t", 1)) for ln in lines if "\t" in ln]
+
+        passed = {nid for label, nid in rows if label == "PASSED"}
+        failed = {nid for label, nid in rows if label == "FAILED"}
+        errored = {nid for label, nid in rows if label == "ERROR"}
+
+        assert "test_outcomes.py::test_ok" in passed
+        # The bracket/dash-laden parametrization is captured EXACTLY — the
+        # whole point of the structured reporter over summary scraping.
+        assert "test_outcomes.py::test_param[a - b]]" in failed
+        # Setup-phase failure is an ERROR, not a FAILED (mirrors -rfE).
+        assert any("test_setup_error" in nid for nid in errored)
+        # Collection failure is an ERROR keyed on the uncollectable module.
+        assert any("test_uncollectable.py" in nid for nid in errored)
+        # A pass is never mis-logged as a failure.
+        assert "test_outcomes.py::test_ok" not in failed
+
+    def test_passes_not_logged_without_opt_in(self, tmp_path):
+        (tmp_path / "test_only_pass.py").write_text("def test_ok():\n    assert True\n")
+        log_path = tmp_path / "nodeids.tsv"
+        repo_root = self._repo_root()
+        # log_passes defaults False → the 14k-pass full suite stays lean.
+        plugin_args, env = flake_mod._nodeid_reporter.build_invocation(
+            log_path, repo_root
+        )
+        subprocess.run(
+            [sys.executable, "-m", "pytest", *plugin_args, "test_only_pass.py"],
+            cwd=str(tmp_path),
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+        # No failures/errors and passes opted out → nothing to write. The
+        # file may be absent or empty; either way, no PASSED rows.
+        if log_path.exists():
+            assert "PASSED" not in log_path.read_text(encoding="utf-8")
 
 
 # --------------------------------------------------------------------------

--- a/tests/test_pr_validate_flake_tracking.py
+++ b/tests/test_pr_validate_flake_tracking.py
@@ -3453,6 +3453,13 @@ class TestTargetedTestsUntrustedRun:
         assert res.status == "skip"
         assert "deselected" in res.summary
 
+    def test_last_summary_line_recognizes_plural_errors(self):
+        # pytest pluralizes the error outcome ("1 error" vs "2 errors"), so an
+        # error-only run summary must still be recognized or the step summary
+        # degrades to a bare "exit 2" (codex #1222 r29).
+        assert last_summary_line("2 errors in 0.10s") == "2 errors in 0.10s"
+        assert last_summary_line("==== 1 error in 0.1s ====") == "1 error in 0.1s"
+
     def test_run_blocks_exit5_without_deselection(self, ctx_factory, monkeypatch):
         # exit 5 WITHOUT a deselection (empty/renamed file, or a candidate
         # python_files matching nothing) is NOT the benign case — no
@@ -3473,3 +3480,78 @@ class TestTargetedTestsUntrustedRun:
         res = targeted_mod.TargetedTestsStep().run(ctx)
         assert res.status == "fail"
         assert "untrusted" in res.summary
+
+    def test_run_pytest_fallback_scrape_preserves_spaced_param_ids(
+        self, tmp_path, monkeypatch
+    ):
+        # Without the reporter, _run_pytest scrapes stdout — and the scrape must
+        # be space-preserving (summary_node_ids), NOT a `\S+` grab, so a failing
+        # param id containing spaces is captured whole. Otherwise it couldn't
+        # match the base negative control's parse of the same id and a
+        # pre-existing failure would be misclassified as a PR-only regression
+        # (codex #1222 r29).
+        stdout = (
+            "==== short test summary info ====\n"
+            "FAILED tests/a.py::test_x[param with spaces] - AssertionError\n"
+            "==== 1 failed in 0.1s ====\n"
+        )
+
+        def fake_run(cmd, **kw):
+            return subprocess.CompletedProcess(cmd, 1, stdout, "")
+
+        monkeypatch.setattr(targeted_mod.subprocess, "run", fake_run)
+        result = targeted_mod._run_pytest(
+            ["tests/a.py"], tmp_path / "log.txt", tmp_path
+        )
+        assert result.structured is False
+        assert result.failed == ["tests/a.py::test_x[param with spaces]"]
+
+    def test_negative_control_scrape_matches_canonical_reporter_id(self, tmp_path):
+        # The base negative control scrapes stdout (summary_node_ids); the PR
+        # side records report.nodeid via the reporter. To classify a shared
+        # failure as pre-existing (not a PR-only regression), the two parsers
+        # must yield the SAME id — even when the param id contains spaces. Run a
+        # real pytest and prove parity end-to-end (codex #1222 r29). Pre-fix the
+        # base used `^FAILED\s+(\S+)`, truncating `test_x[a b c]` to `test_x[a`.
+        import pathlib
+
+        (tmp_path / "test_spaced.py").write_text(
+            textwrap.dedent(
+                """
+                import pytest
+
+                @pytest.mark.parametrize("x", ["a b c"])
+                def test_x(x):
+                    assert False
+                """
+            )
+        )
+        repo_root = (
+            pathlib.Path(targeted_mod._nodeid_reporter.__file__).resolve().parents[2]
+        )
+        log_path = tmp_path / "nodeids.tsv"
+        plugin_args, env = targeted_mod._nodeid_reporter.build_invocation(
+            log_path, repo_root
+        )
+        proc = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "pytest",
+                "-p",
+                "no:randomly",
+                "-rfE",
+                *plugin_args,
+                "test_spaced.py",
+            ],
+            cwd=str(tmp_path),
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+        canonical = report_log_node_ids(log_path, "FAILED")
+        scraped = summary_node_ids(proc.stdout, "FAILED")
+        assert canonical == ["test_spaced.py::test_x[a b c]"]
+        # Parity: base scrape == PR canonical id → shared failure classified
+        # pre-existing, not a false regression.
+        assert scraped == canonical

--- a/tests/test_pr_validate_flake_tracking.py
+++ b/tests/test_pr_validate_flake_tracking.py
@@ -425,6 +425,20 @@ class TestFullUnitQuarantineAware:
         assert res.status == "fail"
         assert "test_boom" in res.details
 
+    def test_gate_pins_error_reporting(self, ctx_factory, monkeypatch):
+        # The quarantine downgrade's soundness rests on ERROR lines always
+        # appearing in the summary. The command must pin -rfE so it never
+        # depends on pytest's implicit default (codex #1222 r3).
+        captured = {}
+
+        def fake_run(cmd, **kw):
+            captured["cmd"] = cmd
+            return subprocess.CompletedProcess(cmd, 0, _passed(), "")
+
+        monkeypatch.setattr(full_unit_mod.subprocess, "run", fake_run)
+        FullUnitStep().run(ctx_factory())
+        assert "-rfE" in captured["cmd"]
+
     def test_abnormal_exit_blocks(self, ctx_factory, monkeypatch):
         # Exit 2 (interrupted) with an otherwise-quarantined failure must
         # still block — the exit code says something the FAILED list
@@ -544,6 +558,26 @@ class TestFlakeTrackingContract:
         res = FlakeTrackingStep().run(ctx)
         assert res.status == "skip"
         assert "exceeded" in res.summary
+
+    def test_timeout_persists_drained_output(self, ctx_factory, monkeypatch):
+        # On timeout the partial output must be written to flake-rerun.log
+        # and attached, so a human can see which re-run hung (codex r3).
+        ctx = ctx_factory()
+        self._prime(ctx, monkeypatch)
+
+        def timeout(*a, **k):
+            raise subprocess.TimeoutExpired(
+                cmd="pytest", timeout=1, output="partial stdout here", stderr="err tail"
+            )
+
+        monkeypatch.setattr(flake_mod, "_run_session", timeout)
+        res = FlakeTrackingStep().run(ctx)
+        assert res.status == "skip"
+        log = ctx.artifact_path("flake-rerun.log")
+        assert log.exists()
+        body = log.read_text()
+        assert "partial stdout here" in body and "err tail" in body
+        assert str(log) in res.artifacts
 
     def test_abnormal_rerun_exit_skips(self, ctx_factory, monkeypatch):
         ctx = ctx_factory()

--- a/tests/test_pr_validate_flake_tracking.py
+++ b/tests/test_pr_validate_flake_tracking.py
@@ -38,6 +38,7 @@ from scripts.pr_validate.quarantine import (
     QuarantineError,
     _has_param_suffix,
     effective_quarantine,
+    is_quarantined,
     load_quarantine,
     load_quarantine_from_ref,
     node_id_matches,
@@ -810,6 +811,42 @@ class TestEffectiveQuarantine:
         cand = [QuarantineEntry(id="t::a", reason="cand-why", added="2026-09-09")]
         (eff,) = effective_quarantine(base, cand)
         assert eff.reason == "base-why" and eff.added == "2026-01-01"
+
+    def test_candidate_may_drop_a_param(self):
+        # codex #1222 r33: base ``t::a`` family (covers t::a + every t::a[...]),
+        # candidate NARROWS it to the specific param t::a[p1] (the documented
+        # "drop a param" tighten). The old exact-id-only intersection dropped
+        # the entry entirely (b.id "t::a" != cand id "t::a[p1]") → false-blocked
+        # the retained known flake. Now the covered param is materialized as an
+        # EXACT effective entry carrying the base's audit metadata.
+        base = [
+            QuarantineEntry(
+                id="t::a", reason="base-why", added="2026-01-01", family=True
+            )
+        ]
+        cand = [QuarantineEntry(id="t::a[p1]", reason="cand-why", added="2026-09-09")]
+        (eff,) = effective_quarantine(base, cand)
+        assert eff.id == "t::a[p1]"
+        assert eff.family is False  # a specific param can't carry family upward
+        assert eff.reason == "base-why" and eff.added == "2026-01-01"  # base meta
+
+    def test_dropped_param_still_subset_of_base_and_narrows(self):
+        # The materialized param quarantines ONLY t::a[p1]; a DIFFERENT param
+        # t::a[p2], still covered by the base family entry but not listed by the
+        # candidate, is NO LONGER effective → it blocks (the narrowing took
+        # effect, and the result never waives more than base approved).
+        base = [self._e("t::a", fam=True)]
+        cand = [self._e("t::a[p1]")]
+        eff = effective_quarantine(base, cand)
+        assert is_quarantined("t::a[p1]", eff) is True
+        assert is_quarantined("t::a[p2]", eff) is False
+
+    def test_candidate_param_not_covered_by_exact_base_ignored(self):
+        # base is EXACT (family=False) on t::a, so it does NOT cover t::a[p1];
+        # a candidate listing t::a[p1] is an ADDITION not backed by base →
+        # ignored (a PR still can't quarantine a new failing param on its own).
+        eff = effective_quarantine([self._e("t::a", fam=False)], [self._e("t::a[p1]")])
+        assert eff == []
 
 
 # --------------------------------------------------------------------------
@@ -2962,35 +2999,50 @@ class TestNodeidReporter:
 
         log_path = tmp_path / "nodeids.tsv"
         monkeypatch.setenv(_nodeid_reporter._ENV_LOG, str(log_path))
-        _nodeid_reporter.pytest_sessionstart(object())  # clears _completed_ids
+        # HERMETIC: this module is ALSO loaded as the live ``-p`` reporter for
+        # the CURRENT pytest run, and ``_completed_ids`` is a module global.
+        # Snapshot + restore it around the direct hook calls so this test can't
+        # corrupt the OUTER session's completion set — a bare clear() here (or a
+        # call to pytest_sessionstart, which clears it) would drop every
+        # already-completed item and make the whole run look truncated
+        # (ran < collected), failing full_unit / targeted. The env log is
+        # monkeypatched to a tmp file, so the fake SESSIONFINISH we write below
+        # lands there, never in the live log.
+        saved = set(_nodeid_reporter._completed_ids)
+        _nodeid_reporter._completed_ids.clear()
+        try:
 
-        def _rpt(when, outcome, nodeid):
-            return types.SimpleNamespace(
-                when=when,
-                outcome=outcome,
-                nodeid=nodeid,
-                failed=(outcome == "failed"),
+            def _rpt(when, outcome, nodeid):
+                return types.SimpleNamespace(
+                    when=when,
+                    outcome=outcome,
+                    nodeid=nodeid,
+                    failed=(outcome == "failed"),
+                )
+
+            nid = "tests/x.py::test_teardown_flaky"
+            # Attempt 1: setup+call pass, TEARDOWN fails → rerunfailures marks
+            # the teardown report outcome=='rerun' and retries.
+            _nodeid_reporter.pytest_runtest_logreport(_rpt("setup", "passed", nid))
+            _nodeid_reporter.pytest_runtest_logreport(_rpt("call", "passed", nid))
+            _nodeid_reporter.pytest_runtest_logreport(_rpt("teardown", "rerun", nid))
+            # Final attempt is TRUNCATED mid-flight (process killed / early-stop
+            # elsewhere): setup+call, but its terminal teardown never lands.
+            _nodeid_reporter.pytest_runtest_logreport(_rpt("setup", "passed", nid))
+            _nodeid_reporter.pytest_runtest_logreport(_rpt("call", "passed", nid))
+            # Session still finishes gracefully, having collected 1 item.
+            _nodeid_reporter.pytest_sessionfinish(
+                types.SimpleNamespace(testscollected=1), 0
             )
-
-        nid = "tests/x.py::test_teardown_flaky"
-        # Attempt 1: setup+call pass, TEARDOWN fails → rerunfailures marks the
-        # teardown report outcome=='rerun' and retries.
-        _nodeid_reporter.pytest_runtest_logreport(_rpt("setup", "passed", nid))
-        _nodeid_reporter.pytest_runtest_logreport(_rpt("call", "passed", nid))
-        _nodeid_reporter.pytest_runtest_logreport(_rpt("teardown", "rerun", nid))
-        # Final attempt is TRUNCATED mid-flight (process killed / early-stop
-        # elsewhere): it emits setup+call but its terminal teardown never lands.
-        _nodeid_reporter.pytest_runtest_logreport(_rpt("setup", "passed", nid))
-        _nodeid_reporter.pytest_runtest_logreport(_rpt("call", "passed", nid))
-        # Session still finishes gracefully, having collected 1 item.
-        _nodeid_reporter.pytest_sessionfinish(
-            types.SimpleNamespace(testscollected=1), 0
-        )
+            records = raw_session_records(log_path)
+        finally:
+            _nodeid_reporter._completed_ids.clear()
+            _nodeid_reporter._completed_ids.update(saved)
 
         # WITHOUT the guard the provisional teardown/rerun would have completed
         # the id → "1 1" (falsely complete). WITH it, the item never reached a
         # terminal teardown → ran(0) < collected(1); the gap stays visible.
-        assert raw_session_records(log_path) == ["0 1"]
+        assert records == ["0 1"]
 
     def _session_records(self, log_path):
         if not log_path.exists():
@@ -3473,15 +3525,18 @@ class TestTargetedTestsUntrustedRun:
         )
         assert reason and "exited 1" in reason
 
-    def test_reason_unaccounted_exit_one_only_when_structured(self):
-        # Without the reporter we can't prove the record set, so we don't
-        # second-guess an exit-1 (the degraded, non-candidate path).
-        assert (
-            targeted_mod._untrusted_run_reason(
-                self._run(1, failed=[], structured=False)
-            )
-            is None
+    def test_reason_unaccounted_exit_one_untrusted_in_fallback(self):
+        # codex #1222 r33 (supersedes r26's structured-only guard): even WITHOUT
+        # the reporter, an exit-1 with an empty scraped FAILED list can't be
+        # trusted. A setup/teardown ERROR exits 1 but prints ``ERROR``, not
+        # ``FAILED``, so the scrape is empty and (on the fallback path
+        # ``errored`` is the trusting default False) the run would otherwise
+        # slip through as a false green. An unaccounted exit 1 is untrusted on
+        # the fallback path too.
+        reason = targeted_mod._untrusted_run_reason(
+            self._run(1, failed=[], structured=False)
         )
+        assert reason and "exited 1" in reason
 
     def _patch_run_pytest(self, monkeypatch, ctx_factory, run):
         ctx = ctx_factory(["vllm_mlx/scheduler.py"])

--- a/tests/test_pr_validate_flake_tracking.py
+++ b/tests/test_pr_validate_flake_tracking.py
@@ -1082,6 +1082,89 @@ class TestNodeidReporter:
         if log_path.exists():
             assert "PASSED" not in log_path.read_text(encoding="utf-8")
 
+    def test_reruns_log_only_terminal_outcome(self, tmp_path):
+        # The reporter is consumed downstream WITH pytest-rerunfailures, so a
+        # flaky test's INTERMEDIATE attempts must never leak into the log: a
+        # fail-then-pass test has to appear ONLY as PASSED (never also FAILED)
+        # and a fail-then-pass-in-SETUP test likewise, else flake_tracking
+        # would classify one node id as flake AND reproduction at once. This
+        # locks that behavior against a future rerunfailures change — pytest
+        # marks retried attempts outcome=="rerun", which the plugin's
+        # failed/passed matchers exclude by construction.
+        pytest.importorskip("pytest_rerunfailures")
+        (tmp_path / "test_flaky.py").write_text(
+            textwrap.dedent(
+                """
+                import pathlib
+
+                _call = pathlib.Path(__file__).with_name('.call')
+                _setup = pathlib.Path(__file__).with_name('.setup')
+
+                def _bump(p):
+                    n = int(p.read_text()) if p.exists() else 0
+                    p.write_text(str(n + 1))
+                    return n
+
+                def test_call_flake():
+                    assert _bump(_call) >= 2          # fails attempts 0,1,2, passes on 3rd
+
+                import pytest
+
+                @pytest.fixture
+                def flaky_setup():
+                    if _bump(_setup) < 1:             # setup fails once, then passes
+                        raise RuntimeError("setup flake")
+
+                def test_setup_flake(flaky_setup):
+                    assert True
+
+                def test_always_bad():
+                    assert False                       # exhausts reruns → terminal FAILED
+                """
+            )
+        )
+        log_path = tmp_path / "nodeids.tsv"
+        repo_root = self._repo_root()
+        plugin_args, env = flake_mod._nodeid_reporter.build_invocation(
+            log_path, repo_root, log_passes=True
+        )
+        subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "pytest",
+                "-p",
+                "no:randomly",
+                "--reruns=3",
+                *plugin_args,
+                "test_flaky.py",
+            ],
+            cwd=str(tmp_path),
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+        rows = [
+            tuple(ln.split("\t", 1))
+            for ln in log_path.read_text(encoding="utf-8").splitlines()
+            if "\t" in ln
+        ]
+        passed = [nid for label, nid in rows if label == "PASSED"]
+        failed = [nid for label, nid in rows if label == "FAILED"]
+        errored = [nid for label, nid in rows if label == "ERROR"]
+
+        # Eventually-passing flakes: PASSED exactly once, never FAILED/ERROR.
+        for nid in (
+            "test_flaky.py::test_call_flake",
+            "test_flaky.py::test_setup_flake",
+        ):
+            assert passed.count(nid) == 1, (nid, rows)
+            assert nid not in failed
+            assert nid not in errored
+        # The always-failing test: terminal FAILED exactly once, never PASSED.
+        assert failed.count("test_flaky.py::test_always_bad") == 1
+        assert "test_flaky.py::test_always_bad" not in passed
+
 
 # --------------------------------------------------------------------------
 # flake_tracking._run_session — process-group timeout kill

--- a/tests/test_pr_validate_flake_tracking.py
+++ b/tests/test_pr_validate_flake_tracking.py
@@ -19,12 +19,14 @@ import subprocess
 import sys
 import textwrap
 import time
+from pathlib import Path
 
 import pytest
 
 from scripts.pr_validate import _nodeid_reporter
 from scripts.pr_validate._pytest_summary import (
     raw_session_records,
+    render_fence_safe,
     report_log_node_ids,
     summary_node_ids,
 )
@@ -270,6 +272,22 @@ class TestLoadQuarantine:
 
     def test_missing_file_is_empty(self, tmp_path):
         assert load_quarantine(tmp_path / "nope.yaml") == []
+
+    def test_permission_error_raises_quarantine_error(self, tmp_path, monkeypatch):
+        # codex #1222 r24: the old `if not path.exists(): return []` pre-check
+        # ran OUTSIDE the try/except, and `Path.exists()` re-raises a
+        # PermissionError (inaccessible parent dir) rather than swallowing it —
+        # so a raw OSError escaped the documented QuarantineError fail-safe.
+        # The read now goes direct; only FileNotFoundError → [], every other
+        # OSError → QuarantineError.
+        p = tmp_path / "q.yaml"
+
+        def boom(*_a, **_k):
+            raise PermissionError("permission denied")
+
+        monkeypatch.setattr(Path, "read_text", boom)
+        with pytest.raises(QuarantineError):
+            load_quarantine(p)
 
     def test_malformed_yaml_raises(self, tmp_path):
         p = tmp_path / "q.yaml"
@@ -1683,6 +1701,74 @@ class TestFlakeTrackingContract:
         assert "tests/subdir" not in data["inconclusive"]
         assert "tests/subdir" not in data["flake_candidates_new"]
 
+    def test_recovered_class_collection_error_is_error_candidate(
+        self, ctx_factory, monkeypatch
+    ):
+        # codex #1222 r24: a CLASS collection error id CONTAINS "::"
+        # ("tests/x.py::TestC"), so the "::"-absence heuristic misses it and
+        # the r19 code left it permanently inconclusive. The structured
+        # COLLECTERROR label (written alongside ERROR, so the gate is
+        # untouched) lets the classifier recognize it; a passed descendant
+        # ("tests/x.py::TestC::test_m") is positive recovery evidence. As an
+        # ERROR-origin id it is not quarantinable → error_flake_candidates.
+        ctx = ctx_factory()
+        ctx.artifact_path("full-unit.log").write_text("boom")
+        ctx.artifact_path("full-unit-nodeids.tsv").write_text(
+            "ERROR\ttests/x.py::TestC\nCOLLECTERROR\ttests/x.py::TestC\n"
+        )
+        monkeypatch.setattr(
+            flake_mod.importlib.util, "find_spec", lambda name: object()
+        )
+        monkeypatch.setattr(flake_mod, "load_quarantine_from_ref", lambda *a, **k: [])
+
+        def fake(cmd, cwd, timeout, env=None):
+            ctx.artifact_path("flake-rerun-nodeids.tsv").write_text(
+                "PASSED\ttests/x.py::TestC::test_m\n" + _RERUN_DONE
+            )
+            return _completed(0, "")
+
+        monkeypatch.setattr(flake_mod, "_run_session", fake)
+        res = FlakeTrackingStep().run(ctx)
+        assert res.status == "pass"
+        data = json.loads(ctx.artifact_path("flake-candidates.json").read_text())
+        assert "tests/x.py::TestC" in data["error_flake_candidates"]
+        assert "tests/x.py::TestC" not in data["inconclusive"]
+        assert "tests/x.py::TestC" not in data["flake_candidates_new"]
+
+    def test_error_origin_reproduced_is_not_reproduced_quarantined(
+        self, ctx_factory, monkeypatch
+    ):
+        # codex #1222 r24: an ERROR-origin id that is ALSO quarantined and
+        # reproduces must NOT be labeled reproduced_quarantined ("full_unit
+        # PASSED as quarantined") — full_unit BLOCKS any ERROR run regardless
+        # of the registry, so the quarantine never waived it. Route it to
+        # reproduced_likely_real (the gate DID block it).
+        ctx = ctx_factory()
+        ctx.artifact_path("full-unit.log").write_text("boom")
+        ctx.artifact_path("full-unit-nodeids.tsv").write_text(
+            "ERROR\ttests/x.py::test_e\n"
+        )
+        monkeypatch.setattr(
+            flake_mod.importlib.util, "find_spec", lambda name: object()
+        )
+        monkeypatch.setattr(
+            flake_mod,
+            "load_quarantine_from_ref",
+            lambda *a, **k: [QuarantineEntry(id="tests/x.py::test_e")],
+        )
+
+        def fake(cmd, cwd, timeout, env=None):
+            ctx.artifact_path("flake-rerun-nodeids.tsv").write_text(
+                "ERROR\ttests/x.py::test_e\n" + _RERUN_DONE
+            )
+            return _completed(1, "")
+
+        monkeypatch.setattr(flake_mod, "_run_session", fake)
+        FlakeTrackingStep().run(ctx)
+        data = json.loads(ctx.artifact_path("flake-candidates.json").read_text())
+        assert "tests/x.py::test_e" in data["reproduced_likely_real"]
+        assert "tests/x.py::test_e" not in data["reproduced_quarantined"]
+
     def test_dir_collection_target_not_recovered_by_sibling_prefix(
         self, ctx_factory, monkeypatch
     ):
@@ -2237,6 +2323,36 @@ class TestFieldEscaping:
         _nodeid_reporter._append("FAILED", "evil\nSESSIONFINISH\t9999 1")
         assert raw_session_records(log) == []
         assert report_log_node_ids(log, "FAILED") == ["evil\nSESSIONFINISH\t9999 1"]
+
+
+class TestRenderFenceSafe:
+    """A node id interpolated into a Markdown ``` code fence must not be able
+    to break out of it and spoof scorecard content (codex #1222 r24)."""
+
+    def test_collapses_newlines_to_single_line(self):
+        evil = "tests/a.py::t[a\n```\n# spoof]"
+        out = render_fence_safe(evil)
+        # No embedded newline survives → no line can start a fence-closer.
+        assert "\n" not in out
+        assert out.startswith('"') and out.endswith('"')
+        # Data fidelity: the original id is recoverable via JSON.
+        assert json.loads(out) == evil
+
+    def test_preserves_unicode(self):
+        assert render_fence_safe("tests/tûv.py::tîme") == '"tests/tûv.py::tîme"'
+
+    def test_full_unit_render_details_is_fence_safe(self):
+        evil = "tests/a.py::test_x[a\n```\n# spoof]"
+        out = full_unit_mod._render_details([evil], [], "/tmp/log")
+        assert json.dumps(evil, ensure_ascii=False) in out
+        # The raw fence-breaking newline sequence must NOT leak into the block.
+        assert "a\n```\n# spoof" not in out
+
+    def test_flake_render_is_fence_safe(self):
+        evil = "tests/a.py::test_y[b\n```\n# spoof]"
+        out = flake_mod._render([evil], [], [], [], [], [], sampled=1, total=1)
+        assert json.dumps(evil, ensure_ascii=False) in out
+        assert "b\n```\n# spoof" not in out
 
 
 class TestNodeidReporter:
@@ -2866,3 +2982,74 @@ class TestRegistration:
         # pass/skip, and run() downgrades any crash to skip so an uncaught
         # exception can't become a blocking error (codex #1222 r8).
         assert FlakeTrackingStep().continue_on_error is True
+
+
+class TestTargetedTestsRerunBackstop:
+    """targeted_tests is a gating run — and, for a low-blast PR where
+    full_unit is skipped, the ONLY gating run of candidate tests — so the
+    name-independent RERUN backstop must live here too (codex #1222 r24)."""
+
+    def test_run_pytest_detects_rerun_record(self, tmp_path, monkeypatch):
+        # _run_pytest injects the reporter and flags reran=True when the
+        # structured log carries a RERUN record (rerunfailures smuggled in
+        # under a non-blocked name).
+        nodeid_log = tmp_path / "n.tsv"
+
+        def fake_run(cmd, **kw):
+            env = kw.get("env") or {}
+            log = env.get("PR_VALIDATE_NODEID_LOG")
+            assert log, "reporter was not injected"
+            with open(log, "w", encoding="utf-8") as fh:
+                fh.write("RERUN\ttests/a.py::t\nFAILED\ttests/a.py::t\n")
+            return subprocess.CompletedProcess(cmd, 1, "==== 1 failed in 1s ====\n", "")
+
+        monkeypatch.setattr(targeted_mod.subprocess, "run", fake_run)
+        summary, failed, reran = targeted_mod._run_pytest(
+            ["tests/a.py"], tmp_path / "log.txt", tmp_path, nodeid_log
+        )
+        assert reran is True
+
+    def test_run_pytest_no_rerun_is_false(self, tmp_path, monkeypatch):
+        nodeid_log = tmp_path / "n.tsv"
+
+        def fake_run(cmd, **kw):
+            env = kw.get("env") or {}
+            log = env.get("PR_VALIDATE_NODEID_LOG")
+            with open(log, "w", encoding="utf-8") as fh:
+                fh.write("FAILED\ttests/a.py::t\nSESSIONFINISH\t1 1\n")
+            return subprocess.CompletedProcess(cmd, 1, "==== 1 failed in 1s ====\n", "")
+
+        monkeypatch.setattr(targeted_mod.subprocess, "run", fake_run)
+        _, _, reran = targeted_mod._run_pytest(
+            ["tests/a.py"], tmp_path / "log.txt", tmp_path, nodeid_log
+        )
+        assert reran is False
+
+    def test_run_blocks_when_pr_run_reran(self, ctx_factory, monkeypatch):
+        ctx = ctx_factory(["vllm_mlx/scheduler.py"])
+        monkeypatch.setattr(
+            targeted_mod, "_select_test_files", lambda c: ["tests/test_scheduler.py"]
+        )
+        monkeypatch.setattr(
+            targeted_mod,
+            "_run_pytest",
+            lambda *a, **k: (
+                "1 failed, 2 passed",
+                ["tests/test_scheduler.py::t"],
+                True,
+            ),
+        )
+        res = targeted_mod.TargetedTestsStep().run(ctx)
+        assert res.status == "fail"
+        assert "rerun" in res.details.lower()
+
+    def test_negative_control_run_does_not_inject_reporter(self):
+        # The base predates this PR's reporter module, so the negative-control
+        # run on main must NOT try to inject `-p …_nodeid_reporter` (it would
+        # be an unloadable plugin → usage error). _run_on_main uses the plain
+        # _PYTEST_CMD, never the reporter.
+        import inspect
+
+        src = inspect.getsource(targeted_mod._run_on_main)
+        assert "build_invocation" not in src
+        assert "_nodeid_reporter" not in src

--- a/tests/test_pr_validate_flake_tracking.py
+++ b/tests/test_pr_validate_flake_tracking.py
@@ -210,6 +210,28 @@ class TestSummaryNodeIds:
         )
         assert out == ["tests/a.py::test_x - [Errno 2] no such file"]
 
+    def test_param_id_with_trailing_unmatched_close_fails_safe(self):
+        # codex #1222 r40: a custom param id like ids=["a] - b"] yields node
+        # "test_x[a] - b]". The inner ']' at "a]" drops depth to 0, so the
+        # first depth-0 " - " used to split and COLLAPSE the id to "test_x[a]"
+        # (the r9 guard only caught a message STARTING with "["; here the
+        # message "b]" starts with "b"). That collapse could waive a real,
+        # PR-introduced "test_x[a]" as pre-existing in the base negative
+        # control — a FALSE GREEN. The "]" in the message is now recognized as
+        # UNMATCHED, so we fail safe and return the whole line, which won't
+        # match the shorter id → the failure BLOCKS.
+        out = summary_node_ids(_summary("FAILED tests/a.py::test_x[a] - b]"), "FAILED")
+        assert out == ["tests/a.py::test_x[a] - b]"]
+
+    def test_plain_test_message_with_unmatched_close_fails_safe(self):
+        # A plain test whose MESSAGE happens to hold an unmatched ']' is also
+        # unresolvable, so it fails safe (whole line) — over-blocking, never a
+        # false green. Rare, and the conservative direction (codex #1222 r40).
+        out = summary_node_ids(
+            _summary("FAILED tests/a.py::test_x - unexpected ] here"), "FAILED"
+        )
+        assert out == ["tests/a.py::test_x - unexpected ] here"]
+
     def test_ignores_failed_outside_summary(self):
         text = (
             "tests/a.py::test_x FAILED in call setup\n"  # pre-summary noise

--- a/tests/test_pr_validate_flake_tracking.py
+++ b/tests/test_pr_validate_flake_tracking.py
@@ -660,6 +660,85 @@ class TestLoadQuarantineFromRef:
         (entry,) = load_quarantine_from_ref(base_sha, tmp_path)
         assert entry.id == "GOOD::t"
 
+    def test_git_binary_is_preresolved_absolute(self):
+        # codex #1222 r35 (security): the git binary is resolved ONCE at
+        # import — when pr_validate boots, before any candidate test runs —
+        # so the pinned value must be an absolute path, NOT a bare "git"
+        # re-looked-up through a candidate-tamperable PATH at call time.
+        from scripts.pr_validate import quarantine as q
+
+        assert q._GIT != "git", "git must be pre-resolved, not a bare PATH lookup"
+        assert os.path.isabs(q._GIT), f"_GIT must be absolute, got {q._GIT!r}"
+
+    def test_git_show_invokes_preresolved_binary(self, tmp_path, monkeypatch):
+        # The subprocess argv[0] must be the pinned absolute `_GIT`, never a
+        # bare "git" a candidate could shadow via a writable leading PATH dir.
+        from scripts.pr_validate import quarantine as q
+
+        captured: dict[str, object] = {}
+
+        def capture(cmd, *a, **k):
+            captured["argv0"] = cmd[0]
+            return _completed(0, "tests: []\n")
+
+        monkeypatch.setattr("scripts.pr_validate.quarantine.subprocess.run", capture)
+        load_quarantine_from_ref("BASE", tmp_path)
+        assert captured["argv0"] == q._GIT
+        assert os.path.isabs(captured["argv0"])
+
+    def test_hostile_git_on_path_is_ignored(self, tmp_path, monkeypatch):
+        # codex #1222 r35 (security, end-to-end): a failing candidate test
+        # could drop a fake `git` into a writable leading PATH directory to
+        # make the registry loader serve a forged allowlist and self-
+        # quarantine its own failure. Because the loader invokes the git
+        # binary resolved at import (from the clean startup PATH), a hostile
+        # git planted on PATH *after* import must be ignored entirely.
+        def git(*args):
+            return subprocess.run(
+                ["git", *args],
+                cwd=tmp_path,
+                check=True,
+                capture_output=True,
+                text=True,
+                env={
+                    **os.environ,
+                    "GIT_AUTHOR_NAME": "t",
+                    "GIT_AUTHOR_EMAIL": "t@t",
+                    "GIT_COMMITTER_NAME": "t",
+                    "GIT_COMMITTER_EMAIL": "t@t",
+                },
+            )
+
+        git("init", "-q")
+        rel = "scripts/pr_validate/quarantine.yaml"
+        (tmp_path / "scripts" / "pr_validate").mkdir(parents=True)
+        (tmp_path / rel).write_text(
+            "tests:\n  - id: GOOD::t\n    reason: r\n    added: 2026-01-01\n"
+        )
+        git("add", "-A")
+        git("commit", "-q", "-m", "base")
+
+        # Plant a hostile `git` earlier on PATH: it would serve an attacker
+        # allowlist (and leave a sentinel proving it ran) if ever invoked.
+        fakebin = tmp_path / "fakebin"
+        fakebin.mkdir()
+        sentinel = tmp_path / "fakegit-was-called"
+        fake = fakebin / "git"
+        fake.write_text(
+            "#!/bin/sh\n"
+            f"touch '{sentinel}'\n"
+            "echo 'tests:'\n"
+            "echo '  - id: EVIL::t'\n"
+            "echo '    reason: r'\n"
+            "echo '    added: 2026-01-01'\n"
+        )
+        fake.chmod(0o755)
+        monkeypatch.setenv("PATH", f"{fakebin}{os.pathsep}{os.environ.get('PATH', '')}")
+
+        (entry,) = load_quarantine_from_ref("HEAD", tmp_path)
+        assert entry.id == "GOOD::t"  # real git served the true base blob
+        assert not sentinel.exists()  # the hostile git was never invoked
+
 
 # --------------------------------------------------------------------------
 # quarantine.py — matcher / partition

--- a/tests/test_pr_validate_flake_tracking.py
+++ b/tests/test_pr_validate_flake_tracking.py
@@ -3065,6 +3065,7 @@ class TestTargetedTestsRerunBackstop:
                 returncode=1,
                 errored=False,
                 complete=True,
+                structured=True,
             ),
         )
         res = targeted_mod.TargetedTestsStep().run(ctx)
@@ -3084,28 +3085,70 @@ class TestTargetedTestsRerunBackstop:
 
 
 class TestTargetedTestsUntrustedRun:
-    """An empty scraped FAILED list is only a genuine pass when the run
-    finished as an ordinary pass (0) or fail (1). A collection error, usage
-    error, "no tests collected", a structured ERROR (which never scrapes as a
-    FAILED line), or an early ``pytest.exit`` must NOT slip through as a false
-    green (codex #1222 r25)."""
+    """An empty FAILED list is only a genuine pass when the run finished as an
+    ordinary pass (0) or fail (1). A collection error, usage error, "no tests
+    collected", a structured ERROR (which never scrapes as a FAILED line), an
+    early ``pytest.exit``, or an exit-1 with a suppressed failure summary must
+    NOT slip through as a false green (codex #1222 r25/r26)."""
+
+    @staticmethod
+    def _run(
+        returncode,
+        *,
+        errored=False,
+        complete=True,
+        failed=(),
+        reran=False,
+        structured=True,
+    ):
+        return targeted_mod._PytestRun(
+            summary="s",
+            failed=list(failed),
+            reran=reran,
+            returncode=returncode,
+            errored=errored,
+            complete=complete,
+            structured=structured,
+        )
 
     def test_reason_none_for_ordinary_pass_or_fail(self):
-        assert targeted_mod._untrusted_run_reason(0, False, True) is None
-        assert targeted_mod._untrusted_run_reason(1, False, True) is None
+        assert targeted_mod._untrusted_run_reason(self._run(0)) is None
+        # exit 1 is trusted only when a concrete failure accounts for it.
+        assert (
+            targeted_mod._untrusted_run_reason(self._run(1, failed=["tests/a.py::t"]))
+            is None
+        )
 
     def test_reason_flags_abnormal_exit(self):
         for code in (2, 3, 4, 5):
-            reason = targeted_mod._untrusted_run_reason(code, False, True)
+            reason = targeted_mod._untrusted_run_reason(self._run(code))
             assert reason and str(code) in reason
 
     def test_reason_flags_error_record(self):
-        reason = targeted_mod._untrusted_run_reason(0, True, True)
+        reason = targeted_mod._untrusted_run_reason(self._run(0, errored=True))
         assert reason and "ERROR" in reason
 
     def test_reason_flags_incomplete_session(self):
-        reason = targeted_mod._untrusted_run_reason(0, False, False)
+        reason = targeted_mod._untrusted_run_reason(self._run(0, complete=False))
         assert reason and "completion" in reason
+
+    def test_reason_flags_unaccounted_exit_one(self):
+        # exit 1 but the structured log has NO FAILED/RERUN record → the
+        # summary was suppressed; the empty FAILED list must not pass (r26).
+        reason = targeted_mod._untrusted_run_reason(
+            self._run(1, failed=[], reran=False, structured=True)
+        )
+        assert reason and "exited 1" in reason
+
+    def test_reason_unaccounted_exit_one_only_when_structured(self):
+        # Without the reporter we can't prove the record set, so we don't
+        # second-guess an exit-1 (the degraded, non-candidate path).
+        assert (
+            targeted_mod._untrusted_run_reason(
+                self._run(1, failed=[], structured=False)
+            )
+            is None
+        )
 
     def _patch_run_pytest(self, monkeypatch, ctx_factory, run):
         ctx = ctx_factory(["vllm_mlx/scheduler.py"])
@@ -3124,14 +3167,7 @@ class TestTargetedTestsUntrustedRun:
         ctx = self._patch_run_pytest(
             monkeypatch,
             ctx_factory,
-            targeted_mod._PytestRun(
-                summary="1 error in 0.5s",
-                failed=[],
-                reran=False,
-                returncode=2,
-                errored=True,
-                complete=False,
-            ),
+            self._run(2, errored=True, complete=False),
         )
         res = targeted_mod.TargetedTestsStep().run(ctx)
         assert res.status == "fail"
@@ -3141,34 +3177,26 @@ class TestTargetedTestsUntrustedRun:
         # Exit 1 but only a setup/teardown ERROR (no scrapable FAILED) — still
         # must block, not pass on the empty FAILED list.
         ctx = self._patch_run_pytest(
-            monkeypatch,
-            ctx_factory,
-            targeted_mod._PytestRun(
-                summary="1 error in 0.5s",
-                failed=[],
-                reran=False,
-                returncode=1,
-                errored=True,
-                complete=True,
-            ),
+            monkeypatch, ctx_factory, self._run(1, errored=True)
         )
         res = targeted_mod.TargetedTestsStep().run(ctx)
         assert res.status == "fail"
+
+    def test_run_blocks_on_unaccounted_exit_one(self, ctx_factory, monkeypatch):
+        # Exit 1, structured, but empty FAILED + no RERUN — the failure summary
+        # was suppressed. Must block, not pass (codex #1222 r26).
+        ctx = self._patch_run_pytest(
+            monkeypatch, ctx_factory, self._run(1, failed=[], reran=False)
+        )
+        res = targeted_mod.TargetedTestsStep().run(ctx)
+        assert res.status == "fail"
+        assert "untrusted" in res.summary
 
     def test_run_blocks_on_incomplete_session(self, ctx_factory, monkeypatch):
         # Exit 0 but a truncated session (early pytest.exit before the
         # session-finish record) → not accepted as green.
         ctx = self._patch_run_pytest(
-            monkeypatch,
-            ctx_factory,
-            targeted_mod._PytestRun(
-                summary="truncated",
-                failed=[],
-                reran=False,
-                returncode=0,
-                errored=False,
-                complete=False,
-            ),
+            monkeypatch, ctx_factory, self._run(0, complete=False)
         )
         res = targeted_mod.TargetedTestsStep().run(ctx)
         assert res.status == "fail"
@@ -3176,18 +3204,7 @@ class TestTargetedTestsUntrustedRun:
     def test_run_passes_on_clean_exit_zero(self, ctx_factory, monkeypatch):
         # The hardening must not break the happy path: exit 0, complete, no
         # errors, empty FAILED → pass.
-        ctx = self._patch_run_pytest(
-            monkeypatch,
-            ctx_factory,
-            targeted_mod._PytestRun(
-                summary="3 passed in 0.5s",
-                failed=[],
-                reran=False,
-                returncode=0,
-                errored=False,
-                complete=True,
-            ),
-        )
+        ctx = self._patch_run_pytest(monkeypatch, ctx_factory, self._run(0))
         res = targeted_mod.TargetedTestsStep().run(ctx)
         assert res.status == "pass"
 
@@ -3210,3 +3227,35 @@ class TestTargetedTestsUntrustedRun:
         assert result.errored is True
         assert result.complete is False
         assert result.returncode == 2
+        assert result.structured is True
+
+    def test_pytest_cmd_neutralizes_candidate_addopts(self):
+        # "-o" immediately followed by "addopts=" must be on the shared gating
+        # command so a candidate pytest.ini / pyproject addopts (a planted
+        # --deselect / -m filter / -x / -rN) can't steer this gating run
+        # (codex #1222 r26).
+        cmd = list(targeted_mod._PYTEST_CMD)
+        assert any(
+            cmd[i] == "-o" and cmd[i + 1] == "addopts=" for i in range(len(cmd) - 1)
+        )
+
+    def test_run_pytest_uses_structured_failed_not_scrape(self, tmp_path, monkeypatch):
+        # The reporter's FAILED record is authoritative even when the stdout
+        # short summary is blank (summary suppressed): the scrape would return
+        # [] but the structured read must still surface the failure (r26).
+        nodeid_log = tmp_path / "n.tsv"
+
+        def fake_run(cmd, **kw):
+            env = kw.get("env") or {}
+            log = env.get("PR_VALIDATE_NODEID_LOG")
+            with open(log, "w", encoding="utf-8") as fh:
+                fh.write("FAILED\ttests/a.py::t\nSESSIONFINISH\t1 1\n")
+            # stdout carries NO "short test summary" section → scrape sees [].
+            return subprocess.CompletedProcess(cmd, 1, "1 failed in 0.1s\n", "")
+
+        monkeypatch.setattr(targeted_mod.subprocess, "run", fake_run)
+        result = targeted_mod._run_pytest(
+            ["tests/a.py"], tmp_path / "log.txt", tmp_path, nodeid_log
+        )
+        assert result.failed == ["tests/a.py::t"]
+        assert result.structured is True

--- a/tests/test_pr_validate_flake_tracking.py
+++ b/tests/test_pr_validate_flake_tracking.py
@@ -711,6 +711,27 @@ class TestLoadQuarantineFromRef:
         assert q._GIT != "git", "git must be pre-resolved, not a bare PATH lookup"
         assert os.path.isabs(q._GIT), f"_GIT must be absolute, got {q._GIT!r}"
 
+    def test_resolve_git_rejects_relative_path(self, monkeypatch):
+        # codex #1222 r39: a relative `which` result (PATH held ".") would
+        # resolve under the subprocess cwd (the candidate checkout), letting a
+        # committed ./git forge the registry — so it must fail closed to None.
+        from scripts.pr_validate import quarantine as q
+
+        monkeypatch.setattr(q.shutil, "which", lambda _n: "some/rel/git")
+        assert q._resolve_git() is None
+
+    def test_resolve_git_keeps_absolute_path(self, monkeypatch):
+        from scripts.pr_validate import quarantine as q
+
+        monkeypatch.setattr(q.shutil, "which", lambda _n: "/usr/bin/git")
+        assert q._resolve_git() == "/usr/bin/git"
+
+    def test_resolve_git_none_when_absent(self, monkeypatch):
+        from scripts.pr_validate import quarantine as q
+
+        monkeypatch.setattr(q.shutil, "which", lambda _n: None)
+        assert q._resolve_git() is None
+
     def test_git_show_invokes_preresolved_binary(self, tmp_path, monkeypatch):
         # The subprocess argv[0] must be the pinned absolute `_GIT`, never a
         # bare "git" a candidate could shadow via a writable leading PATH dir.
@@ -931,6 +952,71 @@ class TestFetchSnapshotWiring:
         # Snapshotted the exact immutable base/head SHAs full_unit later reads.
         assert recorded["refs"] == ["BASESHA", "HEADSHA"]
         assert recorded["repo_root"] == ctx.repo_root
+
+    def _run_fetch(self, tmp_path, monkeypatch, files, head_loader):
+        """Drive FetchStep with a stub gh + snapshot, a given changed-file
+        list, and a head-registry loader — returns the StepResult."""
+        from scripts.pr_validate.context import Context
+        from scripts.pr_validate.steps import fetch as fetch_mod
+
+        monkeypatch.setattr(
+            fetch_mod, "snapshot_quarantine_registries", lambda *a, **k: None
+        )
+        monkeypatch.setattr(fetch_mod, "load_quarantine_from_ref", head_loader)
+        monkeypatch.setattr(fetch_mod.shutil, "which", lambda _n: "/usr/bin/gh")
+        meta = {
+            "number": 1,
+            "title": "t",
+            "body": "b",
+            "author": {"login": "u"},
+            "isCrossRepository": False,
+            "headRefOid": "HEADSHA",
+            "headRefName": "feat",
+            "baseRefOid": "BASESHA",
+            "additions": 1,
+            "deletions": 0,
+            "files": [{"path": p} for p in files],
+            "state": "OPEN",
+            "mergeStateStatus": "CLEAN",
+        }
+        monkeypatch.setattr(
+            fetch_mod,
+            "_gh",
+            lambda args: json.dumps(meta) if args.startswith("pr view") else "diff\n",
+        )
+        (tmp_path / "pyproject.toml").write_text("[project]\nname = 'fake'\n")
+        monkeypatch.chdir(tmp_path)
+        ctx = Context(pr_number=1)
+        ctx.work_dir = tmp_path / "work"
+        return fetch_mod.FetchStep().run(ctx)
+
+    def test_fetch_fails_on_malformed_candidate_registry(self, tmp_path, monkeypatch):
+        # codex #1222 r39 NIT: a PR that commits a malformed quarantine.yaml
+        # would merge on a green full_unit (the registry is only read on
+        # failure) and then break every later PR's quarantine. When the PR
+        # MODIFIES the registry, fetch validates the candidate blob and fails.
+        from scripts.pr_validate.quarantine import QUARANTINE_REL_PATH, QuarantineError
+
+        def boom(ref, repo_root, *a, **k):
+            raise QuarantineError("test #0 needs a non-empty 'reason'")
+
+        res = self._run_fetch(
+            tmp_path, monkeypatch, files=[QUARANTINE_REL_PATH, "a.py"], head_loader=boom
+        )
+        assert res.status == "fail"
+        assert "quarantine.yaml" in res.summary
+
+    def test_fetch_ignores_registry_error_when_registry_unchanged(
+        self, tmp_path, monkeypatch
+    ):
+        # If the PR does NOT touch quarantine.yaml, a (pre-existing) registry
+        # problem is not this PR's fault — the head-registry validation is
+        # scoped to modifications, so the loader is never consulted here.
+        def boom(ref, repo_root, *a, **k):
+            raise AssertionError("head registry must not be validated when unchanged")
+
+        res = self._run_fetch(tmp_path, monkeypatch, files=["a.py"], head_loader=boom)
+        assert res.status == "pass"
 
 
 # --------------------------------------------------------------------------
@@ -3696,6 +3782,39 @@ class TestRunSession:
         with pytest.raises(KeyboardInterrupt):
             _run_session([sys.executable, "-c", "pass"], cwd=".", timeout=30)
         assert killed["pgid"] == 999999  # group swept before the re-raise
+
+    def test_interrupt_after_reap_skips_killpg(self, monkeypatch):
+        # codex #1222 r39: if communicate() already reaped the child while
+        # unwinding the interrupt (returncode set), its pgid can be RECYCLED —
+        # killpg would then risk SIGKILLing an unrelated group. The handler
+        # must SKIP the group-kill (nothing of ours is left) and still
+        # re-raise. getpgid is booby-trapped to prove it's never consulted.
+        class _FakeProc:
+            def __init__(self):
+                self.stdout = None
+                self.stderr = None
+                self.pid = 999999
+                self.returncode = -2  # already reaped by communicate()
+
+            def communicate(self, timeout=None):
+                raise KeyboardInterrupt
+
+            def wait(self, timeout=None):
+                return -2
+
+        killpg_called = {"v": False}
+        monkeypatch.setattr(flake_mod.subprocess, "Popen", lambda *a, **k: _FakeProc())
+
+        def _no_getpgid(_pid):
+            raise AssertionError("must not getpgid a reaped (recyclable) pid")
+
+        monkeypatch.setattr(flake_mod.os, "getpgid", _no_getpgid)
+        monkeypatch.setattr(
+            flake_mod.os, "killpg", lambda *a: killpg_called.__setitem__("v", True)
+        )
+        with pytest.raises(KeyboardInterrupt):
+            _run_session([sys.executable, "-c", "pass"], cwd=".", timeout=30)
+        assert not killpg_called["v"]  # no group-kill on a reaped child
 
 
 class TestRegistration:

--- a/tests/test_pr_validate_flake_tracking.py
+++ b/tests/test_pr_validate_flake_tracking.py
@@ -43,6 +43,7 @@ from scripts.pr_validate.quarantine import (
     load_quarantine_from_ref,
     node_id_matches,
     partition_failures,
+    snapshot_quarantine_registries,
 )
 from scripts.pr_validate.steps import flake_tracking as flake_mod
 from scripts.pr_validate.steps import full_unit as full_unit_mod
@@ -77,8 +78,8 @@ def _completed(returncode: int, stdout: str = "", stderr: str = ""):
 # flake_tracking now requires the advisory rerun to have run to completion
 # before it trusts the structured classification (codex #1222 r23); a real
 # rerun always writes this record, so the fakes must too. The exact counts
-# don't matter to session_completed beyond ``collected > 0 and ran >=
-# collected``.
+# don't matter to session_completed beyond ``collected > 0 and ran ==
+# collected`` (codex #1222 r36 tightened `>=` to `==`), so use equal counts.
 _RERUN_DONE = f"{_nodeid_reporter.SESSION_LABEL}\t99 99\n"
 
 
@@ -740,6 +741,158 @@ class TestLoadQuarantineFromRef:
         assert not sentinel.exists()  # the hostile git was never invoked
 
 
+class TestQuarantineSnapshot:
+    """r36: registries are snapshotted at fetch (before candidate code), so
+    ``load_quarantine_from_ref`` serves the cached blob without re-invoking
+    git — closing the residual r35 left open (a candidate that can WRITE the
+    resolved git binary, e.g. a user-owned Homebrew git, and overwrite it
+    in place)."""
+
+    def setup_method(self):
+        from scripts.pr_validate import quarantine as q
+
+        q._REGISTRY_SNAPSHOT.clear()
+
+    def teardown_method(self):
+        from scripts.pr_validate import quarantine as q
+
+        q._REGISTRY_SNAPSHOT.clear()
+
+    def test_snapshot_serves_cache_without_reinvoking_git(self, tmp_path, monkeypatch):
+        good = "tests:\n  - id: GOOD::t\n    reason: r\n    added: 2026-01-01\n"
+        calls = {"n": 0}
+
+        def fake_run(*a, **k):
+            calls["n"] += 1
+            return _completed(0, good)
+
+        monkeypatch.setattr("scripts.pr_validate.quarantine.subprocess.run", fake_run)
+        snapshot_quarantine_registries(["BASE"], tmp_path)  # one git call, at fetch
+        assert calls["n"] == 1
+
+        # Now a candidate has "overwritten" git: any further invocation is a
+        # test failure. The snapshot must satisfy the later load with NO git.
+        def poison(*a, **k):
+            raise AssertionError("git must not be invoked after the snapshot")
+
+        monkeypatch.setattr("scripts.pr_validate.quarantine.subprocess.run", poison)
+        (entry,) = load_quarantine_from_ref("BASE", tmp_path)
+        assert entry.id == "GOOD::t"  # served from the pre-candidate snapshot
+
+    def test_snapshot_caches_error_and_load_reraises(self, tmp_path, monkeypatch):
+        # A malformed blob at snapshot time is cached as its QuarantineError;
+        # the later load must RE-RAISE it, never silently re-read live (which
+        # a poisoned git could turn into a forged clean allowlist).
+        monkeypatch.setattr(
+            "scripts.pr_validate.quarantine.subprocess.run",
+            lambda *a, **k: _completed(0, "tests: [unclosed\n"),
+        )
+        snapshot_quarantine_registries(["BASE"], tmp_path)
+        monkeypatch.setattr(
+            "scripts.pr_validate.quarantine.subprocess.run",
+            lambda *a, **k: _completed(0, "tests: []\n"),  # would-be forged clean
+        )
+        with pytest.raises(QuarantineError):
+            load_quarantine_from_ref("BASE", tmp_path)
+
+    def test_cache_miss_falls_through_to_live(self, tmp_path, monkeypatch):
+        # An un-snapshotted ref (isolated unit tests) reads live — production
+        # always snapshots the exact base/head SHAs full_unit later reads.
+        monkeypatch.setattr(
+            "scripts.pr_validate.quarantine.subprocess.run",
+            lambda *a, **k: _completed(
+                0, "tests:\n  - id: L::t\n    reason: r\n    added: 2026-01-01\n"
+            ),
+        )
+        (entry,) = load_quarantine_from_ref("UNSNAPSHOTTED", tmp_path)
+        assert entry.id == "L::t"
+
+    def test_snapshot_skips_falsy_refs_and_is_idempotent(self, tmp_path, monkeypatch):
+        calls = {"n": 0}
+
+        def fake_run(*a, **k):
+            calls["n"] += 1
+            return _completed(0, "tests: []\n")
+
+        monkeypatch.setattr("scripts.pr_validate.quarantine.subprocess.run", fake_run)
+        # "" and None are unset base/head SHAs → skipped (full_unit fails
+        # closed on those); only BASE is loaded.
+        snapshot_quarantine_registries(["", "BASE", None], tmp_path)
+        assert calls["n"] == 1
+        # Re-snapshotting the same ref does not re-invoke git.
+        snapshot_quarantine_registries(["BASE"], tmp_path)
+        assert calls["n"] == 1
+
+    def test_git_unresolved_at_import_fails_closed(self, tmp_path, monkeypatch):
+        # r36: no bare-name fallback. If git wasn't resolvable at import
+        # (`_GIT is None`), the live loader raises QuarantineError and NEVER
+        # spawns a subprocess that a candidate-tamperable PATH could resolve.
+        from scripts.pr_validate import quarantine as q
+
+        monkeypatch.setattr(q, "_GIT", None)
+
+        def no_git(*a, **k):
+            raise AssertionError("must not spawn git when _GIT is unresolved")
+
+        monkeypatch.setattr("scripts.pr_validate.quarantine.subprocess.run", no_git)
+        with pytest.raises(QuarantineError, match="could not be resolved"):
+            load_quarantine_from_ref("BASE", tmp_path)
+
+
+class TestFetchSnapshotWiring:
+    """r36: the fetch step MUST snapshot the registries before any candidate
+    code runs. If this wiring is ever dropped, full_unit falls back to a live
+    git read after candidate tests and the binary-overwrite vector reopens —
+    so pin it behaviorally, not just by comment."""
+
+    def test_fetch_snapshots_base_and_head_registries(self, tmp_path, monkeypatch):
+        from scripts.pr_validate.context import Context
+        from scripts.pr_validate.steps import fetch as fetch_mod
+
+        recorded = {}
+
+        def rec(refs, repo_root, *a, **k):
+            recorded["refs"] = list(refs)
+            recorded["repo_root"] = repo_root
+
+        monkeypatch.setattr(fetch_mod, "snapshot_quarantine_registries", rec)
+        monkeypatch.setattr(fetch_mod.shutil, "which", lambda _n: "/usr/bin/gh")
+
+        meta = {
+            "number": 1,
+            "title": "t",
+            "body": "b",
+            "author": {"login": "u"},
+            "isCrossRepository": False,
+            "headRefOid": "HEADSHA",
+            "headRefName": "feat",
+            "baseRefOid": "BASESHA",
+            "additions": 1,
+            "deletions": 0,
+            "files": [{"path": "a.py"}],
+            "state": "OPEN",
+            "mergeStateStatus": "CLEAN",
+        }
+
+        def fake_gh(args):
+            if args.startswith("pr view"):
+                return json.dumps(meta)
+            return "diff --git a/a.py b/a.py\n"  # pr diff
+
+        monkeypatch.setattr(fetch_mod, "_gh", fake_gh)
+
+        (tmp_path / "pyproject.toml").write_text("[project]\nname = 'fake'\n")
+        monkeypatch.chdir(tmp_path)
+        ctx = Context(pr_number=1)
+        ctx.work_dir = tmp_path / "work"
+
+        res = fetch_mod.FetchStep().run(ctx)
+        assert res.status == "pass"
+        # Snapshotted the exact immutable base/head SHAs full_unit later reads.
+        assert recorded["refs"] == ["BASESHA", "HEADSHA"]
+        assert recorded["repo_root"] == ctx.repo_root
+
+
 # --------------------------------------------------------------------------
 # quarantine.py — matcher / partition
 # --------------------------------------------------------------------------
@@ -973,8 +1126,9 @@ class TestFullUnitQuarantineAware:
                     f"{_nodeid_reporter.RERUN_LABEL}\t{nid}" for nid in rerun_ids or []
                 ]
                 # The reporter's session-finish completion record (codex
-                # #1222 r15). ``ran >= collected`` marks a COMPLETE run — the
-                # precondition for a downgrade. Truncation tests pass
+                # #1222 r15). ``ran == collected`` marks a COMPLETE run — the
+                # precondition for a downgrade (r36 tightened `>=` to `==`).
+                # Truncation tests pass
                 # ``session=False`` (hard exit / crash → the hook never fires,
                 # no record) or ``ran < collected`` (early stop); a malformed
                 # record is driven via ``session_value``.
@@ -1450,7 +1604,7 @@ class TestFullUnitQuarantineAware:
 
     def test_complete_run_allows_downgrade(self, ctx_factory, monkeypatch):
         # The positive control for r15: a well-formed completion record with
-        # ran >= collected proves the whole suite ran, so a solely-quarantined
+        # ran == collected proves the whole suite ran, so a solely-quarantined
         # red is correctly downgraded to a (loud) pass.
         self._patch_quarantine(
             monkeypatch, [QuarantineEntry(id="tests/a.py::test_flaky")]
@@ -1552,10 +1706,14 @@ class TestSessionCompleted:
             self._tsv(tmp_path, "SESSIONFINISH\t50 50\n")
         )
 
-    def test_ran_exceeds_collected_is_complete(self, tmp_path):
-        # A benign over-count (e.g. a reran item logs an extra setup) still
-        # ran the whole suite — completeness is ran >= collected, not ==.
-        assert full_unit_mod._session_completed(
+    def test_ran_exceeds_collected_is_malformed(self, tmp_path):
+        # codex #1222 r36: ran > collected is IMPOSSIBLE for a faithful
+        # reporter — it counts DISTINCT terminal-teardown ids, so it can never
+        # complete more distinct tests than it collected. An over-count is an
+        # inconsistent/forged record and is rejected as malformed (not accepted
+        # as a "benign over-count"), so an inflated `ran` can't paper over
+        # unexecuted collected tests.
+        assert not full_unit_mod._session_completed(
             self._tsv(tmp_path, "SESSIONFINISH\t51 50\n")
         )
 

--- a/tests/test_pr_validate_flake_tracking.py
+++ b/tests/test_pr_validate_flake_tracking.py
@@ -100,6 +100,19 @@ class TestSummaryNodeIds:
         )
         assert out == ["tests/a.py::test_x[a b c]"]
 
+    def test_param_id_with_dash_space_not_truncated(self):
+        # A param value containing " - " must NOT be cut at the first
+        # occurrence — the separator is the one after the final ']'
+        # (codex #1222 r4).
+        out = summary_node_ids(
+            _summary("FAILED tests/a.py::test_x[a - b] - AssertionError"), "FAILED"
+        )
+        assert out == ["tests/a.py::test_x[a - b]"]
+
+    def test_param_id_with_dash_space_no_message(self):
+        out = summary_node_ids(_summary("FAILED tests/a.py::test_x[a - b]"), "FAILED")
+        assert out == ["tests/a.py::test_x[a - b]"]
+
     def test_ignores_failed_outside_summary(self):
         text = (
             "tests/a.py::test_x FAILED in call setup\n"  # pre-summary noise
@@ -725,6 +738,32 @@ class TestRunSession:
             except ProcessLookupError:
                 pass
             pytest.fail(f"grandchild {gc_pid} survived the process-group kill")
+
+    def test_double_timeout_reaps_direct_child(self, monkeypatch):
+        # If the post-kill drain ALSO times out (a group-escaping
+        # descendant holds the pipe), _drain_bounded must still reap the
+        # direct child so it isn't left a zombie (codex #1222 r4). Driven
+        # with a stub so it's deterministic and fast.
+        class _FakeProc:
+            def __init__(self):
+                self.stdout = None
+                self.stderr = None
+                self.pid = 999999
+                self.wait_called = False
+
+            def communicate(self, timeout=None):
+                raise subprocess.TimeoutExpired(cmd="x", timeout=timeout)
+
+            def wait(self, timeout=None):
+                self.wait_called = True
+                return -9
+
+        monkeypatch.setattr(flake_mod.os, "getpgid", lambda pid: pid)
+        monkeypatch.setattr(flake_mod.os, "killpg", lambda pgid, sig: None)
+        fake = _FakeProc()
+        out, err = flake_mod._drain_bounded(fake)
+        assert (out, err) == ("", "")
+        assert fake.wait_called  # direct child was reaped, not orphaned
 
 
 class TestRegistration:

--- a/tests/test_pr_validate_flake_tracking.py
+++ b/tests/test_pr_validate_flake_tracking.py
@@ -424,6 +424,46 @@ class TestLoadQuarantine:
         with pytest.raises(QuarantineError, match="[Dd]uplicate"):
             load_quarantine(p)
 
+    def test_duplicate_id_across_entries_rejected(self, tmp_path):
+        # codex #1222 r37: the strict loader catches duplicate KEYS within one
+        # mapping, but two separate list entries for the SAME id (e.g. one
+        # family:true, one family:false) would make effective_quarantine's
+        # first-match selection depend on YAML list order. A repeated id is an
+        # authoring mistake — reject it so coverage is order-independent.
+        p = tmp_path / "q.yaml"
+        p.write_text(
+            "tests:\n"
+            "  - id: tests/a.py::t\n"
+            "    reason: r\n"
+            "    added: 2026-01-01\n"
+            "    family: true\n"
+            "  - id: tests/a.py::t\n"
+            "    reason: r2\n"
+            "    added: 2026-01-02\n"
+        )
+        with pytest.raises(QuarantineError, match="[Dd]uplicate"):
+            load_quarantine(p)
+
+    def test_family_base_and_specific_param_not_duplicate(self, tmp_path):
+        # A family-covering base entry (``t``) and a specific parametrization
+        # (``t[p1]``) carry DIFFERENT id strings, so they are NOT duplicates —
+        # the r37 duplicate-id guard must not reject this legitimate pair.
+        p = tmp_path / "q.yaml"
+        p.write_text(
+            "tests:\n"
+            "  - id: tests/a.py::t\n"
+            "    reason: r\n"
+            "    added: 2026-01-01\n"
+            "    family: true\n"
+            "  - id: tests/a.py::t[p1]\n"
+            "    reason: r2\n"
+            "    added: 2026-01-02\n"
+        )
+        assert [e.id for e in load_quarantine(p)] == [
+            "tests/a.py::t",
+            "tests/a.py::t[p1]",
+        ]
+
     def test_unhashable_mapping_key_raises_quarantine_error(self, tmp_path):
         # codex #1222 r22: a complex YAML key (`? [a, b]` → a list) is
         # unhashable, so the duplicate-key check's `key in seen` would raise a
@@ -1779,6 +1819,19 @@ class TestFlakeTrackingContract:
         ctx.artifact_path("full-unit.log").write_text(_passed())
         res = FlakeTrackingStep().run(ctx)
         assert res.status == "skip"
+
+    def test_stale_candidate_artifact_cleared_on_skip(self, ctx_factory):
+        # codex #1222 r37 NIT: flake-candidates.json is written only on the
+        # classify path, so a REUSED run dir with a stale one must be cleared
+        # up front — a skip/error return must not leave an earlier run's
+        # candidates behind to misrepresent this run.
+        ctx = ctx_factory()
+        stale = ctx.artifact_path("flake-candidates.json")
+        stale.write_text('{"flake_candidates_new": ["tests/old.py::stale"]}')
+        ctx.artifact_path("full-unit.log").write_text(_passed())  # no failures
+        res = FlakeTrackingStep().run(ctx)
+        assert res.status == "skip"
+        assert not stale.exists()  # the stale candidates were removed
 
     def test_reruns_error_nodeids_structured(self, ctx_factory, monkeypatch):
         # codex #1222 r15 NIT: a setup / teardown / collection flake is

--- a/tests/test_pr_validate_flake_tracking.py
+++ b/tests/test_pr_validate_flake_tracking.py
@@ -129,6 +129,26 @@ class TestSummaryNodeIds:
         )
         assert out == ["tests/a.py::test_x[a - b]"]
 
+    def test_nested_balanced_brackets_ok(self):
+        # A param id with nested, BALANCED brackets and inner " - " is
+        # parsed whole (depth returns to 0 only at the real separator).
+        out = summary_node_ids(
+            _summary("FAILED tests/a.py::test_x[[1, 2] - [3, 4]] - ValueError"),
+            "FAILED",
+        )
+        assert out == ["tests/a.py::test_x[[1, 2] - [3, 4]]"]
+
+    def test_unmatched_bracket_param_id_is_known_safe_limitation(self):
+        # DOCUMENTED r6 limitation: an unmatched '[' in the param id leaves
+        # the depth counter unbalanced, so the message is absorbed. Fails
+        # SAFE — the mangled id won't match a normal quarantine entry, so
+        # the failure BLOCKS. Locked here so it's an intentional trade-off,
+        # not a silent regression.
+        out = summary_node_ids(
+            _summary("FAILED tests/a.py::test_x[[] - AssertionError"), "FAILED"
+        )
+        assert out == ["tests/a.py::test_x[[] - AssertionError"]
+
     def test_ignores_failed_outside_summary(self):
         text = (
             "tests/a.py::test_x FAILED in call setup\n"  # pre-summary noise
@@ -474,10 +494,10 @@ class TestFullUnitQuarantineAware:
         assert res.status == "fail"
         assert "test_boom" in res.details
 
-    def test_gate_pins_error_reporting(self, ctx_factory, monkeypatch):
+    def test_gate_pins_error_reporting_and_no_color(self, ctx_factory, monkeypatch):
         # The quarantine downgrade's soundness rests on ERROR lines always
-        # appearing in the summary. The command must pin -rfE so it never
-        # depends on pytest's implicit default (codex #1222 r3).
+        # appearing (-rfE, codex r3) in ANSI-free text (--color=no, codex
+        # r6) — otherwise forced color would break summary parsing.
         captured = {}
 
         def fake_run(cmd, **kw):
@@ -487,6 +507,7 @@ class TestFullUnitQuarantineAware:
         monkeypatch.setattr(full_unit_mod.subprocess, "run", fake_run)
         FullUnitStep().run(ctx_factory())
         assert "-rfE" in captured["cmd"]
+        assert "--color=no" in captured["cmd"]
 
     def test_abnormal_exit_blocks(self, ctx_factory, monkeypatch):
         # Exit 2 (interrupted) with an otherwise-quarantined failure must
@@ -673,6 +694,23 @@ class TestFlakeTrackingContract:
         assert data["flake_candidates_new"] == ["tests/x.py::a"]
         assert data["reproduced_likely_real"] == ["tests/x.py::b"]
         assert data["inconclusive"] == ["tests/x.py::c"]
+
+    def test_rerun_forces_color_off(self, ctx_factory, monkeypatch):
+        # The advisory re-run must also disable color so ANSI escapes can't
+        # break its outcome parsing (codex #1222 r6).
+        ctx = ctx_factory()
+        self._prime(ctx, monkeypatch)
+        monkeypatch.setattr(flake_mod, "load_quarantine_from_ref", lambda *a, **k: [])
+        captured = {}
+
+        def fake(cmd, cwd, timeout):
+            captured["cmd"] = cmd
+            return _completed(0, _passed())
+
+        monkeypatch.setattr(flake_mod, "_run_session", fake)
+        FlakeTrackingStep().run(ctx)
+        assert "--color=no" in captured["cmd"]
+        assert "-rA" in captured["cmd"]
 
     def test_quarantined_reproduction_not_labeled_blocked(
         self, ctx_factory, monkeypatch

--- a/tests/test_pr_validate_flake_tracking.py
+++ b/tests/test_pr_validate_flake_tracking.py
@@ -13,8 +13,11 @@ Units under test:
 from __future__ import annotations
 
 import json
+import os
+import signal
 import subprocess
 import sys
+import textwrap
 import time
 
 import pytest
@@ -119,6 +122,32 @@ class TestSummaryNodeIds:
     def test_default_label_is_failed(self):
         assert summary_node_ids(_summary("FAILED tests/a.py::t")) == ["tests/a.py::t"]
 
+    def test_requires_padded_banner_not_bare_substring(self):
+        # A bare "short test summary" line (no '=' padding) is NOT the real
+        # pytest banner and must not open a summary block.
+        text = (
+            "some test printed: short test summary\n"
+            "FAILED tests/evil.py::forged - injected\n"
+        )
+        assert summary_node_ids(text, "FAILED") == []
+
+    def test_forged_banner_in_captured_output_is_ignored(self):
+        # A malicious/careless test prints a fully-padded fake banner in its
+        # captured stdout (which renders ABOVE the real summary). Taking the
+        # LAST banner means the genuine final summary wins, so the real
+        # failure can't be masked by a forged quarantined id (codex r2).
+        text = (
+            "==== FAILURES ====\n"
+            "____ test_evil ____\n"
+            "----- Captured stdout call -----\n"
+            "==================== short test summary info ====================\n"
+            "FAILED tests/quarantined.py::known_flake - forged\n"
+            "==================== short test summary info ====================\n"
+            "FAILED tests/real.py::genuine - AssertionError\n"
+            "==== 1 failed in 0.10s ====\n"
+        )
+        assert summary_node_ids(text, "FAILED") == ["tests/real.py::genuine"]
+
 
 # --------------------------------------------------------------------------
 # quarantine.py — file loader
@@ -149,6 +178,22 @@ class TestLoadQuarantine:
         p.write_text("- a\n- b\n")
         with pytest.raises(QuarantineError):
             load_quarantine(p)
+
+    @pytest.mark.parametrize("body", ["[]\n", "false\n", "0\n"])
+    def test_falsey_non_mapping_root_raises(self, tmp_path, body):
+        # A present-but-falsey root ([] / false / 0) is a schema violation,
+        # NOT an empty registry — it must raise, not be swallowed (codex r2).
+        p = tmp_path / "q.yaml"
+        p.write_text(body)
+        with pytest.raises(QuarantineError):
+            load_quarantine(p)
+
+    def test_empty_file_is_empty_registry(self, tmp_path):
+        # An absent document (empty / all-comments → None root) IS a valid
+        # empty registry.
+        p = tmp_path / "q.yaml"
+        p.write_text("# just a comment\n")
+        assert load_quarantine(p) == []
 
     def test_tests_must_be_list(self, tmp_path):
         p = tmp_path / "q.yaml"
@@ -512,6 +557,40 @@ class TestFlakeTrackingContract:
         assert res.status == "skip"
         assert "abnormally" in res.summary
 
+    def test_classifies_on_positive_outcomes(self, ctx_factory, monkeypatch):
+        # Three sampled failures; the -rA re-run reports one PASSED (flake
+        # candidate), one FAILED again (reproduced), and one that only went
+        # SKIPPED — which must land in `inconclusive`, NOT be called a flake
+        # just because it's absent from FAILED (codex r2).
+        ctx = ctx_factory()
+        ctx.artifact_path("full-unit.log").write_text(
+            _summary(
+                "FAILED tests/x.py::a - X",
+                "FAILED tests/x.py::b - X",
+                "FAILED tests/x.py::c - X",
+            )
+        )
+        monkeypatch.setattr(
+            flake_mod.importlib.util, "find_spec", lambda name: object()
+        )
+        monkeypatch.setattr(flake_mod, "load_quarantine_from_ref", lambda *a, **k: [])
+        rerun = (
+            "==================== short test summary info ====================\n"
+            "PASSED tests/x.py::a\n"
+            "FAILED tests/x.py::b - AssertionError\n"
+            "SKIPPED [1] tests/x.py::c:1: conditionally skipped\n"
+            "==== 1 failed, 1 passed, 1 skipped in 0.20s ====\n"
+        )
+        monkeypatch.setattr(
+            flake_mod, "_run_session", lambda *a, **k: _completed(1, rerun)
+        )
+        res = FlakeTrackingStep().run(ctx)
+        assert res.status == "pass"
+        data = json.loads(ctx.artifact_path("flake-candidates.json").read_text())
+        assert data["flake_candidates_new"] == ["tests/x.py::a"]
+        assert data["reproduced_likely_real"] == ["tests/x.py::b"]
+        assert data["inconclusive"] == ["tests/x.py::c"]
+
 
 class TestFlakeTrackingClassification:
     """Drive a real pytest subprocess so the flake-vs-real split is
@@ -567,6 +646,51 @@ class TestRunSession:
                 timeout=0.5,
             )
         assert time.monotonic() - t0 < 10.0
+
+    def test_timeout_kills_grandchild_in_group(self, tmp_path):
+        # Prove it's a process-GROUP kill, not just proc.kill(): the child
+        # spawns a long-lived grandchild in the SAME group (no setsid) and
+        # records its pid. On timeout, killpg must reap the grandchild too —
+        # a bare proc.kill() on the direct child would leave it alive
+        # (codex #1222 r2).
+        pidfile = tmp_path / "grandchild.pid"
+        child_prog = textwrap.dedent(
+            f"""
+            import subprocess, sys, time
+            gc = subprocess.Popen(
+                [sys.executable, "-c", "import time; time.sleep(120)"]
+            )
+            with open({str(pidfile)!r}, "w") as f:
+                f.write(str(gc.pid))
+                f.flush()
+            time.sleep(120)
+            """
+        )
+        t0 = time.monotonic()
+        with pytest.raises(subprocess.TimeoutExpired):
+            _run_session(
+                [sys.executable, "-c", child_prog], cwd=str(tmp_path), timeout=3
+            )
+        assert time.monotonic() - t0 < 20.0
+
+        gc_pid = int(pidfile.read_text().strip())
+        # killpg SIGKILL is async; poll briefly for the grandchild to die.
+        deadline = time.monotonic() + 5.0
+        alive = True
+        while time.monotonic() < deadline:
+            try:
+                os.kill(gc_pid, 0)
+            except ProcessLookupError:
+                alive = False
+                break
+            time.sleep(0.1)
+        if alive:
+            # Clean up before failing so we don't leak a 120s sleeper.
+            try:
+                os.kill(gc_pid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+            pytest.fail(f"grandchild {gc_pid} survived the process-group kill")
 
 
 class TestRegistration:

--- a/tests/test_pr_validate_flake_tracking.py
+++ b/tests/test_pr_validate_flake_tracking.py
@@ -113,6 +113,22 @@ class TestSummaryNodeIds:
         out = summary_node_ids(_summary("FAILED tests/a.py::test_x[a - b]"), "FAILED")
         assert out == ["tests/a.py::test_x[a - b]"]
 
+    def test_message_with_bracket_not_absorbed_into_id(self):
+        # A ']' inside the MESSAGE must not be mistaken for the id's
+        # parametrization bracket — the separator is the first " - "
+        # outside brackets (codex #1222 r5 regression guard).
+        out = summary_node_ids(
+            _summary("FAILED tests/a.py::test_x - AssertionError: [1]"), "FAILED"
+        )
+        assert out == ["tests/a.py::test_x"]
+
+    def test_param_id_and_message_both_bracketed(self):
+        out = summary_node_ids(
+            _summary("FAILED tests/a.py::test_x[a - b] - ValueError: got [2]"),
+            "FAILED",
+        )
+        assert out == ["tests/a.py::test_x[a - b]"]
+
     def test_ignores_failed_outside_summary(self):
         text = (
             "tests/a.py::test_x FAILED in call setup\n"  # pre-summary noise
@@ -208,6 +224,15 @@ class TestLoadQuarantine:
         p.write_text("# just a comment\n")
         assert load_quarantine(p) == []
 
+    def test_non_utf8_file_raises(self, tmp_path):
+        # A non-UTF-8 blob is malformed, not absent — must surface as
+        # QuarantineError (not an unhandled UnicodeDecodeError) so the gate
+        # fails safe to empty (codex #1222 r5).
+        p = tmp_path / "q.yaml"
+        p.write_bytes(b"tests:\n  - id: \xff\xfe not utf8\n")
+        with pytest.raises(QuarantineError):
+            load_quarantine(p)
+
     def test_tests_must_be_list(self, tmp_path):
         p = tmp_path / "q.yaml"
         p.write_text("tests: not-a-list\n")
@@ -280,6 +305,17 @@ class TestLoadQuarantineFromRef:
             "scripts.pr_validate.quarantine.subprocess.run",
             lambda *a, **k: _completed(0, "tests: [unclosed\n"),
         )
+        with pytest.raises(QuarantineError):
+            load_quarantine_from_ref("BASE", tmp_path)
+
+    def test_non_utf8_at_ref_raises(self, tmp_path, monkeypatch):
+        # A non-UTF-8 blob at the ref makes `text=True` subprocess.run
+        # raise UnicodeDecodeError — it must be wrapped as QuarantineError,
+        # not escape as an unhandled ValueError (codex #1222 r5).
+        def boom(*a, **k):
+            raise UnicodeDecodeError("utf-8", b"\xff", 0, 1, "invalid start byte")
+
+        monkeypatch.setattr("scripts.pr_validate.quarantine.subprocess.run", boom)
         with pytest.raises(QuarantineError):
             load_quarantine_from_ref("BASE", tmp_path)
 
@@ -637,6 +673,43 @@ class TestFlakeTrackingContract:
         assert data["flake_candidates_new"] == ["tests/x.py::a"]
         assert data["reproduced_likely_real"] == ["tests/x.py::b"]
         assert data["inconclusive"] == ["tests/x.py::c"]
+
+    def test_quarantined_reproduction_not_labeled_blocked(
+        self, ctx_factory, monkeypatch
+    ):
+        # A quarantined test that reproduces on re-run must land in
+        # `reproduced_quarantined`, NOT `reproduced_likely_real` — full_unit
+        # PASSED it (quarantined), so it isn't a failure the gate blocked
+        # on (codex #1222 r5).
+        ctx = ctx_factory()
+        ctx.artifact_path("full-unit.log").write_text(
+            _summary(
+                "FAILED tests/x.py::flaky - X",
+                "FAILED tests/x.py::real - X",
+            )
+        )
+        monkeypatch.setattr(
+            flake_mod.importlib.util, "find_spec", lambda name: object()
+        )
+        monkeypatch.setattr(
+            flake_mod,
+            "load_quarantine_from_ref",
+            lambda *a, **k: [QuarantineEntry(id="tests/x.py::flaky")],
+        )
+        rerun = (
+            "==================== short test summary info ====================\n"
+            "FAILED tests/x.py::flaky - AssertionError\n"
+            "FAILED tests/x.py::real - AssertionError\n"
+            "==== 2 failed in 0.20s ====\n"
+        )
+        monkeypatch.setattr(
+            flake_mod, "_run_session", lambda *a, **k: _completed(1, rerun)
+        )
+        res = FlakeTrackingStep().run(ctx)
+        assert res.status == "pass"
+        data = json.loads(ctx.artifact_path("flake-candidates.json").read_text())
+        assert data["reproduced_likely_real"] == ["tests/x.py::real"]
+        assert data["reproduced_quarantined"] == ["tests/x.py::flaky"]
 
 
 class TestFlakeTrackingClassification:

--- a/tests/test_pr_validate_flake_tracking.py
+++ b/tests/test_pr_validate_flake_tracking.py
@@ -446,6 +446,54 @@ class TestLoadQuarantineFromRef:
         (entry,) = load_quarantine_from_ref("HEAD", tmp_path)
         assert entry.id == "x.py::t"
 
+    def test_real_git_show_ignores_replace_ref(self, tmp_path):
+        # codex #1222 r12 (security): pinning to an immutable base SHA is not
+        # enough on its own — `git show` honors local refs/replace/*, so a
+        # candidate test that ran earlier could `git replace <base_sha>
+        # <attacker-commit>` and make `git show <base_sha>:…` serve its own
+        # allowlist. The loader passes --no-replace-objects, so the TRUE
+        # content-addressed base blob wins regardless of any planted replace.
+        import os
+
+        def git(*args):
+            return subprocess.run(
+                ["git", *args],
+                cwd=tmp_path,
+                check=True,
+                capture_output=True,
+                text=True,
+                env={
+                    **os.environ,
+                    "GIT_AUTHOR_NAME": "t",
+                    "GIT_AUTHOR_EMAIL": "t@t",
+                    "GIT_COMMITTER_NAME": "t",
+                    "GIT_COMMITTER_EMAIL": "t@t",
+                },
+            )
+
+        git("init", "-q")
+        rel = "scripts/pr_validate/quarantine.yaml"
+        (tmp_path / "scripts" / "pr_validate").mkdir(parents=True)
+        (tmp_path / rel).write_text(
+            "tests:\n  - id: GOOD::t\n    reason: r\n    added: 2026-01-01\n"
+        )
+        git("add", "-A")
+        git("commit", "-q", "-m", "base")
+        base_sha = git("rev-parse", "HEAD").stdout.strip()
+        # An attacker commit carrying a DIFFERENT allowlist.
+        (tmp_path / rel).write_text(
+            "tests:\n  - id: EVIL::t\n    reason: r\n    added: 2026-01-01\n"
+        )
+        git("add", "-A")
+        git("commit", "-q", "-m", "evil")
+        evil_sha = git("rev-parse", "HEAD").stdout.strip()
+        git("replace", base_sha, evil_sha)
+        # Sanity: a naive `git show <base_sha>:…` IS fooled by the replace.
+        assert "EVIL::t" in git("show", f"{base_sha}:{rel}").stdout
+        # The loader must NOT be — it reads the true base blob.
+        (entry,) = load_quarantine_from_ref(base_sha, tmp_path)
+        assert entry.id == "GOOD::t"
+
 
 # --------------------------------------------------------------------------
 # quarantine.py — matcher / partition
@@ -862,6 +910,39 @@ class TestFlakeTrackingContract:
         assert data["flake_candidates_known"] == ["tests/x.py::flaky"]
         assert data["reproduced_quarantined"] == []
 
+    def test_teardown_error_after_pass_is_reproduced_not_flake(
+        self, ctx_factory, monkeypatch
+    ):
+        # codex #1222 r12 BLOCKING: the structured reporter logs one line per
+        # pytest PHASE, so a test whose call PASSES but whose teardown ERRORs
+        # emits BOTH a PASSED and an ERROR line for the same node id. That run
+        # ended badly — it must classify as a reproduction, never a flake
+        # candidate. FAILED/ERROR takes precedence over PASSED, keeping the
+        # buckets disjoint.
+        ctx = ctx_factory()
+        ctx.artifact_path("full-unit.log").write_text(
+            _summary("FAILED tests/x.py::td - X")
+        )
+        monkeypatch.setattr(
+            flake_mod.importlib.util, "find_spec", lambda name: object()
+        )
+        monkeypatch.setattr(flake_mod, "load_quarantine_from_ref", lambda *a, **k: [])
+
+        def fake(cmd, cwd, timeout, env=None):
+            # Emulate the plugin writing PASSED (call) + ERROR (teardown) for
+            # the same id — the exact double-log codex flagged.
+            ctx.artifact_path("flake-rerun-nodeids.tsv").write_text(
+                "PASSED\ttests/x.py::td\nERROR\ttests/x.py::td\n"
+            )
+            return _completed(1, "")
+
+        monkeypatch.setattr(flake_mod, "_run_session", fake)
+        res = FlakeTrackingStep().run(ctx)
+        assert res.status == "pass"
+        data = json.loads(ctx.artifact_path("flake-candidates.json").read_text())
+        assert "tests/x.py::td" not in data["flake_candidates_new"]
+        assert "tests/x.py::td" in data["reproduced_likely_real"]
+
     def test_quarantined_failure_always_sampled_past_cap(
         self, ctx_factory, monkeypatch
     ):
@@ -1081,6 +1162,22 @@ class TestNodeidReporter:
         # file may be absent or empty; either way, no PASSED rows.
         if log_path.exists():
             assert "PASSED" not in log_path.read_text(encoding="utf-8")
+
+    def test_log_passes_false_clears_inherited_flag(self, tmp_path):
+        # codex #1222 r12 nit: log_passes=False must POP an inherited
+        # PR_VALIDATE_NODEID_LOG_PASSES=1, else full_unit (which passes
+        # False) would log all ~14k passes and bloat the artifact.
+        _, env_off = flake_mod._nodeid_reporter.build_invocation(
+            tmp_path / "n.tsv",
+            tmp_path,
+            base_env={"PR_VALIDATE_NODEID_LOG_PASSES": "1", "PATH": "/usr/bin"},
+        )
+        assert "PR_VALIDATE_NODEID_LOG_PASSES" not in env_off
+        # log_passes=True still turns it on.
+        _, env_on = flake_mod._nodeid_reporter.build_invocation(
+            tmp_path / "n.tsv", tmp_path, log_passes=True, base_env={}
+        )
+        assert env_on["PR_VALIDATE_NODEID_LOG_PASSES"] == "1"
 
     def test_reruns_log_only_terminal_outcome(self, tmp_path):
         # The reporter is consumed downstream WITH pytest-rerunfailures, so a

--- a/tests/test_pr_validate_flake_tracking.py
+++ b/tests/test_pr_validate_flake_tracking.py
@@ -1,33 +1,38 @@
 # SPDX-License-Identifier: Apache-2.0
 """Tests for the flake-tracking system (dev-flow proposal item ③).
 
-Three units under test:
-  * ``quarantine.py`` — registry loader + node-id matcher (pure).
-  * ``full_unit.py`` — quarantine-aware pass/fail split of a failure set.
-  * ``flake_tracking.py`` — advisory classification of full_unit failures
-    (flake candidate vs reproduced-real), driven against a real pytest
-    subprocess so the classification is proven, not mocked.
+Units under test:
+  * ``_pytest_summary.summary_node_ids`` — shared FAILED/ERROR parser.
+  * ``quarantine.py`` — registry loader (file + git base ref) + matcher.
+  * ``full_unit.py`` — quarantine-aware pass/fail split, exit-code and
+    ERROR guards, base-revision registry source.
+  * ``flake_tracking.py`` — advisory classification (flake vs reproduced),
+    exit-code guard, and process-group timeout kill.
 """
 
 from __future__ import annotations
 
 import json
 import subprocess
+import sys
+import time
 
 import pytest
 
+from scripts.pr_validate._pytest_summary import summary_node_ids
 from scripts.pr_validate.context import Context
 from scripts.pr_validate.quarantine import (
     QuarantineEntry,
     QuarantineError,
     load_quarantine,
+    load_quarantine_from_ref,
     node_id_matches,
     partition_failures,
 )
 from scripts.pr_validate.steps import flake_tracking as flake_mod
 from scripts.pr_validate.steps import full_unit as full_unit_mod
-from scripts.pr_validate.steps.flake_tracking import FlakeTrackingStep
-from scripts.pr_validate.steps.full_unit import FullUnitStep, _failed_node_ids
+from scripts.pr_validate.steps.flake_tracking import FlakeTrackingStep, _run_session
+from scripts.pr_validate.steps.full_unit import FullUnitStep
 
 # --------------------------------------------------------------------------
 # helpers
@@ -48,6 +53,10 @@ def _passed(n: int = 10) -> str:
     return f"==== {n} passed in 1.00s ====\n"
 
 
+def _completed(returncode: int, stdout: str = "", stderr: str = ""):
+    return subprocess.CompletedProcess(["pytest"], returncode, stdout, stderr)
+
+
 @pytest.fixture
 def ctx_factory(tmp_path, monkeypatch):
     """Context.__post_init__ insists on a repo-root cwd (a pyproject)."""
@@ -66,21 +75,64 @@ def ctx_factory(tmp_path, monkeypatch):
 
 
 # --------------------------------------------------------------------------
-# quarantine.py — loader
+# _pytest_summary.summary_node_ids
+# --------------------------------------------------------------------------
+
+
+class TestSummaryNodeIds:
+    def test_plain_failed(self):
+        assert summary_node_ids(_summary("FAILED tests/a.py::test_x"), "FAILED") == [
+            "tests/a.py::test_x"
+        ]
+
+    def test_strips_message(self):
+        out = summary_node_ids(
+            _summary("FAILED tests/a.py::test_x - AssertionError: nope"), "FAILED"
+        )
+        assert out == ["tests/a.py::test_x"]
+
+    def test_parametrized_with_spaces(self):
+        out = summary_node_ids(
+            _summary("FAILED tests/a.py::test_x[a b c] - ValueError"), "FAILED"
+        )
+        assert out == ["tests/a.py::test_x[a b c]"]
+
+    def test_ignores_failed_outside_summary(self):
+        text = (
+            "tests/a.py::test_x FAILED in call setup\n"  # pre-summary noise
+            + _summary("FAILED tests/a.py::test_x")
+        )
+        assert summary_node_ids(text, "FAILED") == ["tests/a.py::test_x"]
+
+    def test_multiple_labels(self):
+        text = _summary(
+            "FAILED tests/a.py::test_x - X",
+            "ERROR tests/a.py::test_y - Y",
+        )
+        assert summary_node_ids(text, "FAILED") == ["tests/a.py::test_x"]
+        assert summary_node_ids(text, "ERROR") == ["tests/a.py::test_y"]
+        assert summary_node_ids(text, "FAILED", "ERROR") == [
+            "tests/a.py::test_x",
+            "tests/a.py::test_y",
+        ]
+
+    def test_default_label_is_failed(self):
+        assert summary_node_ids(_summary("FAILED tests/a.py::t")) == ["tests/a.py::t"]
+
+
+# --------------------------------------------------------------------------
+# quarantine.py — file loader
 # --------------------------------------------------------------------------
 
 
 class TestLoadQuarantine:
     def test_loads_shipped_registry(self):
-        # Default path = the quarantine.yaml we ship. It must parse and
-        # contain the seeded G8 signal flake.
         entries = load_quarantine()
         ids = {e.id for e in entries}
         assert (
             "tests/test_signal_observability.py::"
             "test_subprocess_sighup_default_disposition_dumps_and_stays_alive" in ids
         )
-        # Every shipped entry carries a justification.
         assert all(e.reason for e in entries)
 
     def test_missing_file_is_empty(self, tmp_path):
@@ -135,6 +187,75 @@ class TestLoadQuarantine:
 
 
 # --------------------------------------------------------------------------
+# quarantine.py — git base-ref loader (a PR must not quarantine itself)
+# --------------------------------------------------------------------------
+
+
+class TestLoadQuarantineFromRef:
+    def test_returns_entries_from_git_show(self, tmp_path, monkeypatch):
+        yaml_text = "tests:\n  - id: a.py::t\n    reason: r\n"
+        monkeypatch.setattr(
+            "scripts.pr_validate.quarantine.subprocess.run",
+            lambda *a, **k: _completed(0, yaml_text),
+        )
+        (entry,) = load_quarantine_from_ref("BASE", tmp_path)
+        assert entry.id == "a.py::t"
+
+    def test_absent_at_ref_is_empty(self, tmp_path, monkeypatch):
+        # git show returns 128 when the path doesn't exist at that rev.
+        monkeypatch.setattr(
+            "scripts.pr_validate.quarantine.subprocess.run",
+            lambda *a, **k: _completed(128, "", "fatal: path does not exist"),
+        )
+        assert load_quarantine_from_ref("BASE", tmp_path) == []
+
+    def test_git_missing_is_empty_not_raise(self, tmp_path, monkeypatch):
+        def boom(*a, **k):
+            raise FileNotFoundError("git not found")
+
+        monkeypatch.setattr("scripts.pr_validate.quarantine.subprocess.run", boom)
+        # Fail-safe: infra hiccup → empty quarantine (stricter gate).
+        assert load_quarantine_from_ref("BASE", tmp_path) == []
+
+    def test_malformed_at_ref_raises(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            "scripts.pr_validate.quarantine.subprocess.run",
+            lambda *a, **k: _completed(0, "tests: [unclosed\n"),
+        )
+        with pytest.raises(QuarantineError):
+            load_quarantine_from_ref("BASE", tmp_path)
+
+    def test_real_git_show_roundtrip(self, tmp_path):
+        # End-to-end proof the actual `git show <ref>:<path>` path works.
+        import os
+
+        def git(*args):
+            subprocess.run(
+                ["git", *args],
+                cwd=tmp_path,
+                check=True,
+                capture_output=True,
+                text=True,
+                env={
+                    **os.environ,
+                    "GIT_AUTHOR_NAME": "t",
+                    "GIT_AUTHOR_EMAIL": "t@t",
+                    "GIT_COMMITTER_NAME": "t",
+                    "GIT_COMMITTER_EMAIL": "t@t",
+                },
+            )
+
+        git("init", "-q")
+        rel = "scripts/pr_validate/quarantine.yaml"
+        (tmp_path / "scripts" / "pr_validate").mkdir(parents=True)
+        (tmp_path / rel).write_text("tests:\n  - id: x.py::t\n    reason: r\n")
+        git("add", "-A")
+        git("commit", "-q", "-m", "seed")
+        (entry,) = load_quarantine_from_ref("HEAD", tmp_path)
+        assert entry.id == "x.py::t"
+
+
+# --------------------------------------------------------------------------
 # quarantine.py — matcher / partition
 # --------------------------------------------------------------------------
 
@@ -147,8 +268,6 @@ class TestNodeIdMatch:
         assert node_id_matches("a.py::t[x-1]", "a.py::t")
 
     def test_base_entry_does_not_match_prefix_sibling(self):
-        # "a.py::t" must NOT swallow "a.py::t_extra" — a real bug risk if
-        # we matched on bare startswith without the '[' guard.
         assert not node_id_matches("a.py::t_extra", "a.py::t")
 
     def test_specific_param_entry_is_exact_only(self):
@@ -183,37 +302,6 @@ class TestPartition:
 
 
 # --------------------------------------------------------------------------
-# full_unit.py — FAILED-line node id parsing
-# --------------------------------------------------------------------------
-
-
-class TestFailedNodeIds:
-    def test_plain(self):
-        assert _failed_node_ids(_summary("FAILED tests/a.py::test_x")) == [
-            "tests/a.py::test_x"
-        ]
-
-    def test_with_message(self):
-        out = _failed_node_ids(
-            _summary("FAILED tests/a.py::test_x - AssertionError: nope")
-        )
-        assert out == ["tests/a.py::test_x"]
-
-    def test_parametrized_with_spaces(self):
-        out = _failed_node_ids(
-            _summary("FAILED tests/a.py::test_x[a b c] - ValueError")
-        )
-        assert out == ["tests/a.py::test_x[a b c]"]
-
-    def test_ignores_failed_outside_summary_section(self):
-        text = (
-            "tests/a.py::test_x FAILED in call setup\n"  # pre-summary noise
-            + _summary("FAILED tests/a.py::test_x")
-        )
-        assert _failed_node_ids(text) == ["tests/a.py::test_x"]
-
-
-# --------------------------------------------------------------------------
 # full_unit.py — quarantine-aware verdict (subprocess mocked)
 # --------------------------------------------------------------------------
 
@@ -225,23 +313,26 @@ class TestFullUnitQuarantineAware:
 
         monkeypatch.setattr(full_unit_mod.subprocess, "run", fake_run)
 
+    def _patch_quarantine(self, monkeypatch, entries):
+        monkeypatch.setattr(
+            full_unit_mod, "load_quarantine_from_ref", lambda *a, **k: entries
+        )
+
     def test_clean_pass(self, ctx_factory, monkeypatch):
         self._patch_pytest(monkeypatch, 0, _passed())
         res = FullUnitStep().run(ctx_factory())
         assert res.status == "pass"
 
     def test_blocking_failure_fails(self, ctx_factory, monkeypatch):
-        monkeypatch.setattr(full_unit_mod, "load_quarantine", lambda: [])
+        self._patch_quarantine(monkeypatch, [])
         self._patch_pytest(monkeypatch, 1, _summary("FAILED tests/a.py::test_real - X"))
         res = FullUnitStep().run(ctx_factory())
         assert res.status == "fail"
         assert "tests/a.py::test_real" in res.details
 
     def test_all_quarantined_passes_but_loud(self, ctx_factory, monkeypatch):
-        monkeypatch.setattr(
-            full_unit_mod,
-            "load_quarantine",
-            lambda: [QuarantineEntry(id="tests/a.py::test_flaky")],
+        self._patch_quarantine(
+            monkeypatch, [QuarantineEntry(id="tests/a.py::test_flaky")]
         )
         self._patch_pytest(
             monkeypatch, 1, _summary("FAILED tests/a.py::test_flaky - X")
@@ -252,10 +343,8 @@ class TestFullUnitQuarantineAware:
         assert "tests/a.py::test_flaky" in res.details
 
     def test_mixed_blocks_and_shows_both(self, ctx_factory, monkeypatch):
-        monkeypatch.setattr(
-            full_unit_mod,
-            "load_quarantine",
-            lambda: [QuarantineEntry(id="tests/a.py::test_flaky")],
+        self._patch_quarantine(
+            monkeypatch, [QuarantineEntry(id="tests/a.py::test_flaky")]
         )
         self._patch_pytest(
             monkeypatch,
@@ -268,13 +357,47 @@ class TestFullUnitQuarantineAware:
         res = FullUnitStep().run(ctx_factory())
         assert res.status == "fail"
         assert "test_real" in res.details
-        assert "test_flaky" in res.details  # quarantined still surfaced
+        assert "test_flaky" in res.details
+
+    def test_error_entry_blocks_even_if_failed_quarantined(
+        self, ctx_factory, monkeypatch
+    ):
+        # A quarantined FAILED riding along with an ERROR (collection /
+        # fixture failure) must still BLOCK — an errored test is not a
+        # quarantinable flake.
+        self._patch_quarantine(
+            monkeypatch, [QuarantineEntry(id="tests/a.py::test_flaky")]
+        )
+        self._patch_pytest(
+            monkeypatch,
+            1,
+            _summary(
+                "FAILED tests/a.py::test_flaky - X",
+                "ERROR tests/a.py::test_boom - fixture blew up",
+            ),
+        )
+        res = FullUnitStep().run(ctx_factory())
+        assert res.status == "fail"
+        assert "test_boom" in res.details
+
+    def test_abnormal_exit_blocks(self, ctx_factory, monkeypatch):
+        # Exit 2 (interrupted) with an otherwise-quarantined failure must
+        # still block — the exit code says something the FAILED list
+        # can't account for.
+        self._patch_quarantine(
+            monkeypatch, [QuarantineEntry(id="tests/a.py::test_flaky")]
+        )
+        self._patch_pytest(
+            monkeypatch, 2, _summary("FAILED tests/a.py::test_flaky - X")
+        )
+        res = FullUnitStep().run(ctx_factory())
+        assert res.status == "fail"
 
     def test_unreadable_registry_fails_safe(self, ctx_factory, monkeypatch):
-        def boom():
+        def boom(*a, **k):
             raise QuarantineError("broken registry")
 
-        monkeypatch.setattr(full_unit_mod, "load_quarantine", boom)
+        monkeypatch.setattr(full_unit_mod, "load_quarantine_from_ref", boom)
         self._patch_pytest(
             monkeypatch, 1, _summary("FAILED tests/a.py::test_flaky - X")
         )
@@ -285,15 +408,33 @@ class TestFullUnitQuarantineAware:
         assert "unreadable" in res.details
 
     def test_nonzero_exit_without_node_ids_blocks(self, ctx_factory, monkeypatch):
-        # Collection/internal error: exit 1 but no FAILED short-summary.
         self._patch_pytest(monkeypatch, 1, "==== 1 error in 0.50s ====\n")
         res = FullUnitStep().run(ctx_factory())
         assert res.status == "fail"
-        assert "no parseable test ids" in res.details
+
+    def test_registry_sourced_from_base_revision(self, ctx_factory, monkeypatch):
+        # The gate must read the registry from the PROTECTED base, not the
+        # candidate checkout — assert full_unit passes ctx.base_sha to the
+        # loader (so a PR can't quarantine its own failing tests).
+        captured = {}
+
+        def fake_loader(ref, repo_root, *a, **k):
+            captured["ref"] = ref
+            return [QuarantineEntry(id="tests/a.py::test_flaky")]
+
+        monkeypatch.setattr(full_unit_mod, "load_quarantine_from_ref", fake_loader)
+        self._patch_pytest(
+            monkeypatch, 1, _summary("FAILED tests/a.py::test_flaky - X")
+        )
+        ctx = ctx_factory()
+        ctx.base_sha = "deadbeefbase"
+        res = FullUnitStep().run(ctx)
+        assert captured["ref"] == "deadbeefbase"
+        assert res.status == "pass"  # quarantined → non-blocking
 
 
 # --------------------------------------------------------------------------
-# flake_tracking.py — advisory step
+# flake_tracking.py — advisory step contract
 # --------------------------------------------------------------------------
 
 
@@ -327,8 +468,8 @@ class TestFlakeTrackingContract:
         assert res.status == "skip"
         assert "rerunfailures" in res.summary
 
-    def test_advisory_never_errors(self, ctx_factory, monkeypatch):
-        ctx = ctx_factory()
+    def _prime(self, ctx, monkeypatch):
+        """full-unit.log with a failure + plugin present."""
         ctx.artifact_path("full-unit.log").write_text(
             _summary("FAILED tests/a.py::t - X")
         )
@@ -336,29 +477,40 @@ class TestFlakeTrackingContract:
             flake_mod.importlib.util, "find_spec", lambda name: object()
         )
 
+    def test_advisory_never_errors(self, ctx_factory, monkeypatch):
+        ctx = ctx_factory()
+        self._prime(ctx, monkeypatch)
+
         def boom(*a, **k):
             raise RuntimeError("kaboom")
 
-        monkeypatch.setattr(flake_mod.subprocess, "run", boom)
+        monkeypatch.setattr(flake_mod, "_run_session", boom)
         res = FlakeTrackingStep().run(ctx)
         assert res.status == "skip"  # downgraded, NOT a blocking error
 
     def test_timeout_skips(self, ctx_factory, monkeypatch):
         ctx = ctx_factory()
-        ctx.artifact_path("full-unit.log").write_text(
-            _summary("FAILED tests/a.py::t - X")
-        )
-        monkeypatch.setattr(
-            flake_mod.importlib.util, "find_spec", lambda name: object()
-        )
+        self._prime(ctx, monkeypatch)
 
         def timeout(*a, **k):
             raise subprocess.TimeoutExpired(cmd="pytest", timeout=1)
 
-        monkeypatch.setattr(flake_mod.subprocess, "run", timeout)
+        monkeypatch.setattr(flake_mod, "_run_session", timeout)
         res = FlakeTrackingStep().run(ctx)
         assert res.status == "skip"
         assert "exceeded" in res.summary
+
+    def test_abnormal_rerun_exit_skips(self, ctx_factory, monkeypatch):
+        ctx = ctx_factory()
+        self._prime(ctx, monkeypatch)
+        # Re-run exits 2 (interrupted/collection) — cannot infer "passed"
+        # from absence in FAILED, so classification must bail.
+        monkeypatch.setattr(
+            flake_mod, "_run_session", lambda *a, **k: _completed(2, "boom")
+        )
+        res = FlakeTrackingStep().run(ctx)
+        assert res.status == "skip"
+        assert "abnormally" in res.summary
 
 
 class TestFlakeTrackingClassification:
@@ -367,9 +519,6 @@ class TestFlakeTrackingClassification:
 
     def test_classifies_flake_vs_real(self, ctx_factory, tmp_path):
         pytest.importorskip("pytest_rerunfailures")
-        # A genuinely flaky test (fails the first attempt, passes on the
-        # rerun via a filesystem counter) alongside a deterministic
-        # failure.
         (tmp_path / "test_sample.py").write_text(
             "import pathlib\n"
             "_c = pathlib.Path(__file__).with_name('.count')\n"
@@ -381,7 +530,6 @@ class TestFlakeTrackingClassification:
             "    assert False\n"
         )
         ctx = ctx_factory()
-        # full_unit's log: both failed the full suite.
         ctx.artifact_path("full-unit.log").write_text(
             _summary(
                 "FAILED test_sample.py::test_flaky - AssertionError",
@@ -393,6 +541,32 @@ class TestFlakeTrackingClassification:
         data = json.loads(ctx.artifact_path("flake-candidates.json").read_text())
         assert "test_sample.py::test_flaky" in data["flake_candidates_new"]
         assert "test_sample.py::test_real" in data["reproduced_likely_real"]
+
+
+# --------------------------------------------------------------------------
+# flake_tracking._run_session — process-group timeout kill
+# --------------------------------------------------------------------------
+
+
+class TestRunSession:
+    def test_normal_completion(self, tmp_path):
+        proc = _run_session(
+            [sys.executable, "-c", "print('hi')"], cwd=str(tmp_path), timeout=30
+        )
+        assert proc.returncode == 0
+        assert "hi" in proc.stdout
+
+    def test_timeout_raises_bounded(self, tmp_path):
+        # A child that would sleep far past the timeout must raise
+        # TimeoutExpired quickly (not hang), and the kill path must run.
+        t0 = time.monotonic()
+        with pytest.raises(subprocess.TimeoutExpired):
+            _run_session(
+                [sys.executable, "-c", "import time; time.sleep(30)"],
+                cwd=str(tmp_path),
+                timeout=0.5,
+            )
+        assert time.monotonic() - t0 < 10.0
 
 
 class TestRegistration:

--- a/tests/test_pr_validate_flake_tracking.py
+++ b/tests/test_pr_validate_flake_tracking.py
@@ -1150,6 +1150,31 @@ class TestFullUnitQuarantineAware:
         assert res.status == "fail"
         assert "unreadable" in res.details
 
+    def test_registry_error_message_is_single_line_sanitized(
+        self, ctx_factory, monkeypatch
+    ):
+        # codex #1222 r25: a QuarantineError message can echo candidate-
+        # controlled registry text (a bad node id / reason from the PR's own
+        # quarantine.yaml). Interpolated RAW into the scorecard note, a newline
+        # + "## heading" would forge a scorecard section; render_fence_safe
+        # collapses it to a single escaped JSON line, so the hostile text
+        # survives for the reader but can NEVER inject a raw newline/heading.
+        hostile = "bad id\n## FORGED HEADING\n```\nnot a real fence"
+
+        def boom(*a, **k):
+            raise QuarantineError(hostile)
+
+        monkeypatch.setattr(full_unit_mod, "load_quarantine_from_ref", boom)
+        self._patch_pytest(
+            monkeypatch, 1, _summary("FAILED tests/a.py::test_flaky - X")
+        )
+        res = FullUnitStep().run(ctx_factory())
+        assert res.status == "fail"
+        # No raw newline-injected heading anywhere in the rendered note …
+        assert "\n## FORGED HEADING" not in res.details
+        # … but the text is preserved as an escaped single-line JSON string.
+        assert "\\n## FORGED HEADING" in res.details
+
     def test_nonzero_exit_without_node_ids_blocks(self, ctx_factory, monkeypatch):
         self._patch_pytest(monkeypatch, 1, "==== 1 error in 0.50s ====\n")
         res = FullUnitStep().run(ctx_factory())
@@ -3004,10 +3029,10 @@ class TestTargetedTestsRerunBackstop:
             return subprocess.CompletedProcess(cmd, 1, "==== 1 failed in 1s ====\n", "")
 
         monkeypatch.setattr(targeted_mod.subprocess, "run", fake_run)
-        summary, failed, reran = targeted_mod._run_pytest(
+        result = targeted_mod._run_pytest(
             ["tests/a.py"], tmp_path / "log.txt", tmp_path, nodeid_log
         )
-        assert reran is True
+        assert result.reran is True
 
     def test_run_pytest_no_rerun_is_false(self, tmp_path, monkeypatch):
         nodeid_log = tmp_path / "n.tsv"
@@ -3020,10 +3045,10 @@ class TestTargetedTestsRerunBackstop:
             return subprocess.CompletedProcess(cmd, 1, "==== 1 failed in 1s ====\n", "")
 
         monkeypatch.setattr(targeted_mod.subprocess, "run", fake_run)
-        _, _, reran = targeted_mod._run_pytest(
+        result = targeted_mod._run_pytest(
             ["tests/a.py"], tmp_path / "log.txt", tmp_path, nodeid_log
         )
-        assert reran is False
+        assert result.reran is False
 
     def test_run_blocks_when_pr_run_reran(self, ctx_factory, monkeypatch):
         ctx = ctx_factory(["vllm_mlx/scheduler.py"])
@@ -3033,10 +3058,13 @@ class TestTargetedTestsRerunBackstop:
         monkeypatch.setattr(
             targeted_mod,
             "_run_pytest",
-            lambda *a, **k: (
-                "1 failed, 2 passed",
-                ["tests/test_scheduler.py::t"],
-                True,
+            lambda *a, **k: targeted_mod._PytestRun(
+                summary="1 failed, 2 passed",
+                failed=["tests/test_scheduler.py::t"],
+                reran=True,
+                returncode=1,
+                errored=False,
+                complete=True,
             ),
         )
         res = targeted_mod.TargetedTestsStep().run(ctx)
@@ -3053,3 +3081,132 @@ class TestTargetedTestsRerunBackstop:
         src = inspect.getsource(targeted_mod._run_on_main)
         assert "build_invocation" not in src
         assert "_nodeid_reporter" not in src
+
+
+class TestTargetedTestsUntrustedRun:
+    """An empty scraped FAILED list is only a genuine pass when the run
+    finished as an ordinary pass (0) or fail (1). A collection error, usage
+    error, "no tests collected", a structured ERROR (which never scrapes as a
+    FAILED line), or an early ``pytest.exit`` must NOT slip through as a false
+    green (codex #1222 r25)."""
+
+    def test_reason_none_for_ordinary_pass_or_fail(self):
+        assert targeted_mod._untrusted_run_reason(0, False, True) is None
+        assert targeted_mod._untrusted_run_reason(1, False, True) is None
+
+    def test_reason_flags_abnormal_exit(self):
+        for code in (2, 3, 4, 5):
+            reason = targeted_mod._untrusted_run_reason(code, False, True)
+            assert reason and str(code) in reason
+
+    def test_reason_flags_error_record(self):
+        reason = targeted_mod._untrusted_run_reason(0, True, True)
+        assert reason and "ERROR" in reason
+
+    def test_reason_flags_incomplete_session(self):
+        reason = targeted_mod._untrusted_run_reason(0, False, False)
+        assert reason and "completion" in reason
+
+    def _patch_run_pytest(self, monkeypatch, ctx_factory, run):
+        ctx = ctx_factory(["vllm_mlx/scheduler.py"])
+        monkeypatch.setattr(
+            targeted_mod, "_select_test_files", lambda c: ["tests/test_scheduler.py"]
+        )
+        monkeypatch.setattr(targeted_mod, "_run_pytest", lambda *a, **k: run)
+        return ctx
+
+    def test_run_blocks_on_collection_error_empty_failed(
+        self, ctx_factory, monkeypatch
+    ):
+        # Exit 2 + ERROR record + EMPTY FAILED (a collection failure scrapes no
+        # FAILED summary line). Pre-r25 this passed as a false green because the
+        # gate only checked the empty FAILED list.
+        ctx = self._patch_run_pytest(
+            monkeypatch,
+            ctx_factory,
+            targeted_mod._PytestRun(
+                summary="1 error in 0.5s",
+                failed=[],
+                reran=False,
+                returncode=2,
+                errored=True,
+                complete=False,
+            ),
+        )
+        res = targeted_mod.TargetedTestsStep().run(ctx)
+        assert res.status == "fail"
+        assert "untrusted" in res.summary
+
+    def test_run_blocks_on_error_record_with_exit_one(self, ctx_factory, monkeypatch):
+        # Exit 1 but only a setup/teardown ERROR (no scrapable FAILED) — still
+        # must block, not pass on the empty FAILED list.
+        ctx = self._patch_run_pytest(
+            monkeypatch,
+            ctx_factory,
+            targeted_mod._PytestRun(
+                summary="1 error in 0.5s",
+                failed=[],
+                reran=False,
+                returncode=1,
+                errored=True,
+                complete=True,
+            ),
+        )
+        res = targeted_mod.TargetedTestsStep().run(ctx)
+        assert res.status == "fail"
+
+    def test_run_blocks_on_incomplete_session(self, ctx_factory, monkeypatch):
+        # Exit 0 but a truncated session (early pytest.exit before the
+        # session-finish record) → not accepted as green.
+        ctx = self._patch_run_pytest(
+            monkeypatch,
+            ctx_factory,
+            targeted_mod._PytestRun(
+                summary="truncated",
+                failed=[],
+                reran=False,
+                returncode=0,
+                errored=False,
+                complete=False,
+            ),
+        )
+        res = targeted_mod.TargetedTestsStep().run(ctx)
+        assert res.status == "fail"
+
+    def test_run_passes_on_clean_exit_zero(self, ctx_factory, monkeypatch):
+        # The hardening must not break the happy path: exit 0, complete, no
+        # errors, empty FAILED → pass.
+        ctx = self._patch_run_pytest(
+            monkeypatch,
+            ctx_factory,
+            targeted_mod._PytestRun(
+                summary="3 passed in 0.5s",
+                failed=[],
+                reran=False,
+                returncode=0,
+                errored=False,
+                complete=True,
+            ),
+        )
+        res = targeted_mod.TargetedTestsStep().run(ctx)
+        assert res.status == "pass"
+
+    def test_run_pytest_populates_error_and_incomplete(self, tmp_path, monkeypatch):
+        # _run_pytest reads ERROR + session-completeness from the structured
+        # log, not just RERUN, and always carries the real exit code.
+        nodeid_log = tmp_path / "n.tsv"
+
+        def fake_run(cmd, **kw):
+            env = kw.get("env") or {}
+            log = env.get("PR_VALIDATE_NODEID_LOG")
+            with open(log, "w", encoding="utf-8") as fh:
+                fh.write("ERROR\ttests/a.py::t\n")  # no SESSIONFINISH → incomplete
+            return subprocess.CompletedProcess(cmd, 2, "", "")
+
+        monkeypatch.setattr(targeted_mod.subprocess, "run", fake_run)
+        result = targeted_mod._run_pytest(
+            ["tests/a.py"], tmp_path / "log.txt", tmp_path, nodeid_log
+        )
+        assert result.errored is True
+        assert result.complete is False
+        assert result.returncode == 2

--- a/tests/test_pr_validate_flake_tracking.py
+++ b/tests/test_pr_validate_flake_tracking.py
@@ -149,6 +149,36 @@ class TestSummaryNodeIds:
         )
         assert out == ["tests/a.py::test_x[[] - AssertionError"]
 
+    def test_param_id_with_bracket_dash_bracket_no_message(self):
+        # A param id containing "] - [" (e.g. ids=["a] - [b"]) makes the
+        # inner ']' close depth early. With no message, failing safe returns
+        # the WHOLE line — which is exactly the correct node id here.
+        out = summary_node_ids(_summary("FAILED tests/a.py::test_x[a] - [b]"), "FAILED")
+        assert out == ["tests/a.py::test_x[a] - [b]"]
+
+    def test_param_id_with_bracket_dash_bracket_and_message_fails_safe(self):
+        # DOCUMENTED r9 limitation: the same "] - [" param WITH a message is
+        # irreducibly ambiguous. We must NOT truncate to "test_x[a]" (which
+        # could wrongly match a shorter quarantine entry and downgrade a real
+        # failure), so we fail SAFE and return the whole line — it won't match
+        # a normal entry, so the failure BLOCKS. Locked as an intentional
+        # trade-off, not a silent regression.
+        out = summary_node_ids(
+            _summary("FAILED tests/a.py::test_x[a] - [b] - AssertionError"), "FAILED"
+        )
+        assert out == ["tests/a.py::test_x[a] - [b] - AssertionError"]
+
+    def test_bracket_leading_message_fails_safe_not_mismatched(self):
+        # A genuine bracket-LEADING message ("[Errno 2] …") on a plain test
+        # is equally indistinguishable from a mid-param split, so it also
+        # fails safe (returns the whole line). This never mis-waives; at
+        # worst a quarantined flake with such a message blocks instead of
+        # being downgraded — the safe direction (codex #1222 r9).
+        out = summary_node_ids(
+            _summary("FAILED tests/a.py::test_x - [Errno 2] no such file"), "FAILED"
+        )
+        assert out == ["tests/a.py::test_x - [Errno 2] no such file"]
+
     def test_ignores_failed_outside_summary(self):
         text = (
             "tests/a.py::test_x FAILED in call setup\n"  # pre-summary noise
@@ -818,6 +848,38 @@ class TestFlakeTrackingContract:
         # ...and the cap still bounds the total re-run set.
         rerun_ids = [c for c in captured["cmd"] if c.startswith("tests/x.py::")]
         assert len(rerun_ids) == flake_mod._MAX_RERUN_IDS
+
+    def test_all_quarantined_sampled_even_past_cap(self, ctx_factory, monkeypatch):
+        # When quarantined failures ALONE exceed the cap, every one is still
+        # re-run — the cap bounds only the non-quarantined remainder (codex
+        # #1222 r9 nit): dropping a quarantined failure would silently skip
+        # the graveyard check the step promises.
+        n_q = flake_mod._MAX_RERUN_IDS + 5
+        q_ids = [f"tests/x.py::q{i}" for i in range(n_q)]
+        other_ids = [f"tests/x.py::o{i}" for i in range(10)]
+        ctx = ctx_factory()
+        ctx.artifact_path("full-unit.log").write_text(
+            _summary(*[f"FAILED {i} - X" for i in q_ids + other_ids])
+        )
+        monkeypatch.setattr(
+            flake_mod.importlib.util, "find_spec", lambda name: object()
+        )
+        monkeypatch.setattr(
+            flake_mod,
+            "load_quarantine_from_ref",
+            lambda *a, **k: [QuarantineEntry(id=i) for i in q_ids],
+        )
+        captured = {}
+
+        def _capture(cmd, cwd, timeout):
+            captured["cmd"] = cmd
+            return _completed(0, _passed())
+
+        monkeypatch.setattr(flake_mod, "_run_session", _capture)
+        FlakeTrackingStep().run(ctx)
+        rerun = set(captured["cmd"])
+        assert all(q in rerun for q in q_ids)  # every quarantined id re-run
+        assert not any(o in rerun for o in other_ids)  # cap spent on quarantined
 
 
 class TestFlakeTrackingClassification:

--- a/tests/test_pr_validate_flake_tracking.py
+++ b/tests/test_pr_validate_flake_tracking.py
@@ -1,0 +1,407 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the flake-tracking system (dev-flow proposal item ③).
+
+Three units under test:
+  * ``quarantine.py`` — registry loader + node-id matcher (pure).
+  * ``full_unit.py`` — quarantine-aware pass/fail split of a failure set.
+  * ``flake_tracking.py`` — advisory classification of full_unit failures
+    (flake candidate vs reproduced-real), driven against a real pytest
+    subprocess so the classification is proven, not mocked.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+
+import pytest
+
+from scripts.pr_validate.context import Context
+from scripts.pr_validate.quarantine import (
+    QuarantineEntry,
+    QuarantineError,
+    load_quarantine,
+    node_id_matches,
+    partition_failures,
+)
+from scripts.pr_validate.steps import flake_tracking as flake_mod
+from scripts.pr_validate.steps import full_unit as full_unit_mod
+from scripts.pr_validate.steps.flake_tracking import FlakeTrackingStep
+from scripts.pr_validate.steps.full_unit import FullUnitStep, _failed_node_ids
+
+# --------------------------------------------------------------------------
+# helpers
+# --------------------------------------------------------------------------
+
+
+def _summary(*failed_lines: str) -> str:
+    """A minimal pytest tail with a short-summary section."""
+    body = "\n".join(failed_lines)
+    return (
+        "==== short test summary info ====\n"
+        f"{body}\n"
+        "==== 1 failed, 10 passed in 1.23s ====\n"
+    )
+
+
+def _passed(n: int = 10) -> str:
+    return f"==== {n} passed in 1.00s ====\n"
+
+
+@pytest.fixture
+def ctx_factory(tmp_path, monkeypatch):
+    """Context.__post_init__ insists on a repo-root cwd (a pyproject)."""
+    (tmp_path / "pyproject.toml").write_text("[project]\nname = 'fake'\n")
+    monkeypatch.chdir(tmp_path)
+
+    def _make(files_changed: list[str] | None = None) -> Context:
+        ctx = Context(pr_number=1)
+        # Default to a high-blast production file so full_unit / flake
+        # steps' should_run predicate is satisfied.
+        ctx.files_changed = files_changed or ["vllm_mlx/scheduler.py"]
+        ctx.work_dir = tmp_path / "work"
+        return ctx
+
+    return _make
+
+
+# --------------------------------------------------------------------------
+# quarantine.py — loader
+# --------------------------------------------------------------------------
+
+
+class TestLoadQuarantine:
+    def test_loads_shipped_registry(self):
+        # Default path = the quarantine.yaml we ship. It must parse and
+        # contain the seeded G8 signal flake.
+        entries = load_quarantine()
+        ids = {e.id for e in entries}
+        assert (
+            "tests/test_signal_observability.py::"
+            "test_subprocess_sighup_default_disposition_dumps_and_stays_alive" in ids
+        )
+        # Every shipped entry carries a justification.
+        assert all(e.reason for e in entries)
+
+    def test_missing_file_is_empty(self, tmp_path):
+        assert load_quarantine(tmp_path / "nope.yaml") == []
+
+    def test_malformed_yaml_raises(self, tmp_path):
+        p = tmp_path / "q.yaml"
+        p.write_text("tests: [unclosed\n")
+        with pytest.raises(QuarantineError):
+            load_quarantine(p)
+
+    def test_root_must_be_mapping(self, tmp_path):
+        p = tmp_path / "q.yaml"
+        p.write_text("- a\n- b\n")
+        with pytest.raises(QuarantineError):
+            load_quarantine(p)
+
+    def test_tests_must_be_list(self, tmp_path):
+        p = tmp_path / "q.yaml"
+        p.write_text("tests: not-a-list\n")
+        with pytest.raises(QuarantineError):
+            load_quarantine(p)
+
+    def test_entry_must_be_mapping(self, tmp_path):
+        p = tmp_path / "q.yaml"
+        p.write_text("tests:\n  - just-a-string\n")
+        with pytest.raises(QuarantineError):
+            load_quarantine(p)
+
+    def test_entry_needs_nonempty_id(self, tmp_path):
+        p = tmp_path / "q.yaml"
+        p.write_text("tests:\n  - reason: no id here\n")
+        with pytest.raises(QuarantineError):
+            load_quarantine(p)
+
+    def test_empty_tests_ok(self, tmp_path):
+        p = tmp_path / "q.yaml"
+        p.write_text("tests: []\n")
+        assert load_quarantine(p) == []
+
+    def test_null_tests_ok(self, tmp_path):
+        p = tmp_path / "q.yaml"
+        p.write_text("tests:\n")
+        assert load_quarantine(p) == []
+
+    def test_optional_fields_default_empty(self, tmp_path):
+        p = tmp_path / "q.yaml"
+        p.write_text("tests:\n  - id: a.py::t\n")
+        (entry,) = load_quarantine(p)
+        assert entry.id == "a.py::t"
+        assert entry.reason == "" and entry.added == "" and entry.issue == ""
+
+
+# --------------------------------------------------------------------------
+# quarantine.py — matcher / partition
+# --------------------------------------------------------------------------
+
+
+class TestNodeIdMatch:
+    def test_exact(self):
+        assert node_id_matches("a.py::t", "a.py::t")
+
+    def test_param_family(self):
+        assert node_id_matches("a.py::t[x-1]", "a.py::t")
+
+    def test_base_entry_does_not_match_prefix_sibling(self):
+        # "a.py::t" must NOT swallow "a.py::t_extra" — a real bug risk if
+        # we matched on bare startswith without the '[' guard.
+        assert not node_id_matches("a.py::t_extra", "a.py::t")
+
+    def test_specific_param_entry_is_exact_only(self):
+        assert node_id_matches("a.py::t[x]", "a.py::t[x]")
+        assert not node_id_matches("a.py::t[y]", "a.py::t[x]")
+
+    def test_unrelated(self):
+        assert not node_id_matches("a.py::t", "b.py::t")
+
+
+class TestPartition:
+    def test_splits_preserving_order(self):
+        entries = [QuarantineEntry(id="a.py::flaky")]
+        blocking, quarantined = partition_failures(
+            ["a.py::real", "a.py::flaky", "a.py::real2"], entries
+        )
+        assert blocking == ["a.py::real", "a.py::real2"]
+        assert quarantined == ["a.py::flaky"]
+
+    def test_empty_registry_all_block(self):
+        blocking, quarantined = partition_failures(["a.py::x"], [])
+        assert blocking == ["a.py::x"]
+        assert quarantined == []
+
+    def test_param_family_all_quarantined(self):
+        entries = [QuarantineEntry(id="a.py::t")]
+        blocking, quarantined = partition_failures(
+            ["a.py::t[1]", "a.py::t[2]"], entries
+        )
+        assert blocking == []
+        assert quarantined == ["a.py::t[1]", "a.py::t[2]"]
+
+
+# --------------------------------------------------------------------------
+# full_unit.py — FAILED-line node id parsing
+# --------------------------------------------------------------------------
+
+
+class TestFailedNodeIds:
+    def test_plain(self):
+        assert _failed_node_ids(_summary("FAILED tests/a.py::test_x")) == [
+            "tests/a.py::test_x"
+        ]
+
+    def test_with_message(self):
+        out = _failed_node_ids(
+            _summary("FAILED tests/a.py::test_x - AssertionError: nope")
+        )
+        assert out == ["tests/a.py::test_x"]
+
+    def test_parametrized_with_spaces(self):
+        out = _failed_node_ids(
+            _summary("FAILED tests/a.py::test_x[a b c] - ValueError")
+        )
+        assert out == ["tests/a.py::test_x[a b c]"]
+
+    def test_ignores_failed_outside_summary_section(self):
+        text = (
+            "tests/a.py::test_x FAILED in call setup\n"  # pre-summary noise
+            + _summary("FAILED tests/a.py::test_x")
+        )
+        assert _failed_node_ids(text) == ["tests/a.py::test_x"]
+
+
+# --------------------------------------------------------------------------
+# full_unit.py — quarantine-aware verdict (subprocess mocked)
+# --------------------------------------------------------------------------
+
+
+class TestFullUnitQuarantineAware:
+    def _patch_pytest(self, monkeypatch, returncode, stdout):
+        def fake_run(cmd, **kw):
+            return subprocess.CompletedProcess(cmd, returncode, stdout, "")
+
+        monkeypatch.setattr(full_unit_mod.subprocess, "run", fake_run)
+
+    def test_clean_pass(self, ctx_factory, monkeypatch):
+        self._patch_pytest(monkeypatch, 0, _passed())
+        res = FullUnitStep().run(ctx_factory())
+        assert res.status == "pass"
+
+    def test_blocking_failure_fails(self, ctx_factory, monkeypatch):
+        monkeypatch.setattr(full_unit_mod, "load_quarantine", lambda: [])
+        self._patch_pytest(monkeypatch, 1, _summary("FAILED tests/a.py::test_real - X"))
+        res = FullUnitStep().run(ctx_factory())
+        assert res.status == "fail"
+        assert "tests/a.py::test_real" in res.details
+
+    def test_all_quarantined_passes_but_loud(self, ctx_factory, monkeypatch):
+        monkeypatch.setattr(
+            full_unit_mod,
+            "load_quarantine",
+            lambda: [QuarantineEntry(id="tests/a.py::test_flaky")],
+        )
+        self._patch_pytest(
+            monkeypatch, 1, _summary("FAILED tests/a.py::test_flaky - X")
+        )
+        res = FullUnitStep().run(ctx_factory())
+        assert res.status == "pass"
+        assert "known-flaky" in res.summary
+        assert "tests/a.py::test_flaky" in res.details
+
+    def test_mixed_blocks_and_shows_both(self, ctx_factory, monkeypatch):
+        monkeypatch.setattr(
+            full_unit_mod,
+            "load_quarantine",
+            lambda: [QuarantineEntry(id="tests/a.py::test_flaky")],
+        )
+        self._patch_pytest(
+            monkeypatch,
+            1,
+            _summary(
+                "FAILED tests/a.py::test_real - X",
+                "FAILED tests/a.py::test_flaky - Y",
+            ),
+        )
+        res = FullUnitStep().run(ctx_factory())
+        assert res.status == "fail"
+        assert "test_real" in res.details
+        assert "test_flaky" in res.details  # quarantined still surfaced
+
+    def test_unreadable_registry_fails_safe(self, ctx_factory, monkeypatch):
+        def boom():
+            raise QuarantineError("broken registry")
+
+        monkeypatch.setattr(full_unit_mod, "load_quarantine", boom)
+        self._patch_pytest(
+            monkeypatch, 1, _summary("FAILED tests/a.py::test_flaky - X")
+        )
+        res = FullUnitStep().run(ctx_factory())
+        # Even though test_flaky *would* be quarantined, a broken registry
+        # collapses to an empty quarantine → strict gate → it blocks.
+        assert res.status == "fail"
+        assert "unreadable" in res.details
+
+    def test_nonzero_exit_without_node_ids_blocks(self, ctx_factory, monkeypatch):
+        # Collection/internal error: exit 1 but no FAILED short-summary.
+        self._patch_pytest(monkeypatch, 1, "==== 1 error in 0.50s ====\n")
+        res = FullUnitStep().run(ctx_factory())
+        assert res.status == "fail"
+        assert "no parseable test ids" in res.details
+
+
+# --------------------------------------------------------------------------
+# flake_tracking.py — advisory step
+# --------------------------------------------------------------------------
+
+
+class TestFlakeTrackingContract:
+    def test_should_run_false_without_log(self, ctx_factory):
+        assert FlakeTrackingStep().should_run(ctx_factory()) is False
+
+    def test_should_run_false_low_blast(self, ctx_factory):
+        ctx = ctx_factory(["docs/x.md"])
+        ctx.artifact_path("full-unit.log").write_text("x")
+        assert FlakeTrackingStep().should_run(ctx) is False
+
+    def test_should_run_true_with_log(self, ctx_factory):
+        ctx = ctx_factory()
+        ctx.artifact_path("full-unit.log").write_text("x")
+        assert FlakeTrackingStep().should_run(ctx) is True
+
+    def test_skip_when_no_failures(self, ctx_factory):
+        ctx = ctx_factory()
+        ctx.artifact_path("full-unit.log").write_text(_passed())
+        res = FlakeTrackingStep().run(ctx)
+        assert res.status == "skip"
+
+    def test_skip_when_plugin_absent(self, ctx_factory, monkeypatch):
+        ctx = ctx_factory()
+        ctx.artifact_path("full-unit.log").write_text(
+            _summary("FAILED tests/a.py::t - X")
+        )
+        monkeypatch.setattr(flake_mod.importlib.util, "find_spec", lambda name: None)
+        res = FlakeTrackingStep().run(ctx)
+        assert res.status == "skip"
+        assert "rerunfailures" in res.summary
+
+    def test_advisory_never_errors(self, ctx_factory, monkeypatch):
+        ctx = ctx_factory()
+        ctx.artifact_path("full-unit.log").write_text(
+            _summary("FAILED tests/a.py::t - X")
+        )
+        monkeypatch.setattr(
+            flake_mod.importlib.util, "find_spec", lambda name: object()
+        )
+
+        def boom(*a, **k):
+            raise RuntimeError("kaboom")
+
+        monkeypatch.setattr(flake_mod.subprocess, "run", boom)
+        res = FlakeTrackingStep().run(ctx)
+        assert res.status == "skip"  # downgraded, NOT a blocking error
+
+    def test_timeout_skips(self, ctx_factory, monkeypatch):
+        ctx = ctx_factory()
+        ctx.artifact_path("full-unit.log").write_text(
+            _summary("FAILED tests/a.py::t - X")
+        )
+        monkeypatch.setattr(
+            flake_mod.importlib.util, "find_spec", lambda name: object()
+        )
+
+        def timeout(*a, **k):
+            raise subprocess.TimeoutExpired(cmd="pytest", timeout=1)
+
+        monkeypatch.setattr(flake_mod.subprocess, "run", timeout)
+        res = FlakeTrackingStep().run(ctx)
+        assert res.status == "skip"
+        assert "exceeded" in res.summary
+
+
+class TestFlakeTrackingClassification:
+    """Drive a real pytest subprocess so the flake-vs-real split is
+    proven end-to-end, not mocked."""
+
+    def test_classifies_flake_vs_real(self, ctx_factory, tmp_path):
+        pytest.importorskip("pytest_rerunfailures")
+        # A genuinely flaky test (fails the first attempt, passes on the
+        # rerun via a filesystem counter) alongside a deterministic
+        # failure.
+        (tmp_path / "test_sample.py").write_text(
+            "import pathlib\n"
+            "_c = pathlib.Path(__file__).with_name('.count')\n"
+            "def test_flaky():\n"
+            "    n = int(_c.read_text()) if _c.exists() else 0\n"
+            "    _c.write_text(str(n + 1))\n"
+            "    assert n >= 1\n"
+            "def test_real():\n"
+            "    assert False\n"
+        )
+        ctx = ctx_factory()
+        # full_unit's log: both failed the full suite.
+        ctx.artifact_path("full-unit.log").write_text(
+            _summary(
+                "FAILED test_sample.py::test_flaky - AssertionError",
+                "FAILED test_sample.py::test_real - AssertionError",
+            )
+        )
+        res = FlakeTrackingStep().run(ctx)
+        assert res.status == "pass"  # advisory always pass/skip
+        data = json.loads(ctx.artifact_path("flake-candidates.json").read_text())
+        assert "test_sample.py::test_flaky" in data["flake_candidates_new"]
+        assert "test_sample.py::test_real" in data["reproduced_likely_real"]
+
+
+class TestRegistration:
+    def test_registered_after_full_unit(self):
+        from scripts.pr_validate.runner import STEPS
+
+        names = [s.name for s in STEPS]
+        assert "flake_tracking" in names
+        assert names.index("flake_tracking") > names.index("full_unit")
+
+    def test_is_advisory(self):
+        assert FlakeTrackingStep().continue_on_error is True

--- a/tests/test_pr_validate_flake_tracking.py
+++ b/tests/test_pr_validate_flake_tracking.py
@@ -35,6 +35,7 @@ from scripts.pr_validate.context import Context
 from scripts.pr_validate.quarantine import (
     QuarantineEntry,
     QuarantineError,
+    _has_param_suffix,
     effective_quarantine,
     load_quarantine,
     load_quarantine_from_ref,
@@ -689,6 +690,29 @@ class TestNodeIdMatch:
 
     def test_unrelated(self):
         assert not node_id_matches("a.py::t", "b.py::t")
+
+    def test_has_param_suffix_only_inspects_final_component(self):
+        # codex #1222 r27: the parametrization bracket is only in the last
+        # ``::`` component — a "[" in the directory/class path is not a param.
+        assert _has_param_suffix("a.py::t[x]")
+        assert _has_param_suffix("tests/[legacy]/a.py::TestC::t[x-1]")
+        assert not _has_param_suffix("tests/[legacy]/a.py::t")
+        assert not _has_param_suffix("tests/models/[v2]/a.py::TestC::t")
+
+    def test_family_matches_under_bracketed_directory(self):
+        # A test beneath a bracket-named directory must still get family
+        # coverage — the "[" is in the path, not a param suffix (codex r27).
+        entry = "tests/models/[legacy]/test_x.py::test_y"
+        assert node_id_matches(entry + "[a-1]", entry, family=True)
+        assert not node_id_matches(entry + "[a-1]", entry)  # exact by default
+
+    def test_family_disabled_when_final_component_parametrized(self):
+        # Even under a bracket dir, an entry whose FINAL component is already
+        # parametrized is exact-only (family can't widen a specific param).
+        entry = "tests/[legacy]/test_x.py::test_y[a]"
+        assert not node_id_matches(
+            "tests/[legacy]/test_x.py::test_y[b]", entry, family=True
+        )
 
 
 class TestPartition:
@@ -2659,6 +2683,78 @@ class TestNodeidReporter:
         assert rerun, ("expected RERUN records under --reruns", rows)
         assert "test_flaky.py::test_always_bad" in rerun
 
+    def test_strict_xpass_logged_failed_and_carries_no_wasxfail(self, tmp_path):
+        # codex #1222 r27 (finding 2) REBUTTAL, locked as committed evidence.
+        # Claim: a strict-xfail test that unexpectedly PASSES is logged FAILED
+        # and, if quarantined, wrongly waived — "fix: detect report.wasxfail".
+        # EMPIRICALLY a strict XPASS report has outcome=='failed' but NO
+        # wasxfail (only the NON-strict xpass and the as-expected xfail carry
+        # it), so the proposed detection can't fire — the premise is false. The
+        # scenario is also not reachable: the allowlist is base-protected
+        # (candidates can't add), and a flaky (quarantined) test that is ALSO
+        # xfail(strict=True) is self-contradictory. A conftest captures the
+        # report to prove the wasxfail attribute is unset.
+        (tmp_path / "conftest.py").write_text(
+            textwrap.dedent(
+                """
+                import pathlib
+                _obs = pathlib.Path(__file__).with_name('.obs')
+
+                def pytest_runtest_logreport(report):
+                    if (report.when == 'call'
+                            and report.nodeid.endswith('::test_strict_xpass')):
+                        wx = getattr(report, 'wasxfail', '<UNSET>')
+                        _obs.write_text(f'{report.outcome}|{wx!r}')
+                """
+            )
+        )
+        (tmp_path / "test_xp.py").write_text(
+            textwrap.dedent(
+                """
+                import pytest
+
+                @pytest.mark.xfail(strict=True, reason='exp')
+                def test_strict_xpass():
+                    assert True  # unexpectedly passes -> strict -> XPASS-as-fail
+                """
+            )
+        )
+        log_path = tmp_path / "nodeids.tsv"
+        repo_root = self._repo_root()
+        plugin_args, env = flake_mod._nodeid_reporter.build_invocation(
+            log_path, repo_root
+        )
+        subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "pytest",
+                "-p",
+                "no:randomly",
+                "-o",
+                "addopts=",
+                *plugin_args,
+                "test_xp.py",
+            ],
+            cwd=str(tmp_path),
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+        rows = [
+            tuple(ln.split("\t", 1))
+            for ln in log_path.read_text(encoding="utf-8").splitlines()
+            if "\t" in ln
+        ]
+        failed = [nid for label, nid in rows if label == "FAILED"]
+        # (a) The strict XPASS is recorded as a plain FAILED …
+        assert "test_xp.py::test_strict_xpass" in failed
+        # (b) … and the report carried NO wasxfail, so codex's wasxfail-based
+        # detection is inapplicable — the finding's premise is empirically false.
+        outcome, wasxfail = (tmp_path / ".obs").read_text().split("|", 1)
+        assert outcome == "failed"
+        assert wasxfail == "'<UNSET>'"
+
     def _session_records(self, log_path):
         if not log_path.exists():
             return []
@@ -3259,3 +3355,33 @@ class TestTargetedTestsUntrustedRun:
         )
         assert result.failed == ["tests/a.py::t"]
         assert result.structured is True
+
+    def test_pytest_cmd_reapplies_marker_exclusion(self):
+        # `-o addopts=` drops the repo's addopts, which carried
+        # `-m "not slow and not integration and not needle"`. That exclusion
+        # must be RE-SPECIFIED on the gating command or targeted would start
+        # running slow/integration/needle tests it used to inherit-exclude
+        # (codex #1222 r26 regression, caught in r27). Mirrors full_unit.
+        cmd = list(targeted_mod._PYTEST_CMD)
+        mexpr = "not slow and not integration and not needle"
+        # present as a value, and immediately preceded by the `-m` flag (not
+        # the leading `python -m pytest`).
+        assert mexpr in cmd
+        assert cmd[cmd.index(mexpr) - 1] == "-m"
+
+    def test_last_summary_line_parses_barless_quiet_mode(self):
+        # Once `-v` is dropped (via `-o addopts=`) pytest prints the counts
+        # line WITHOUT the ==== bars; the parser must still find it rather than
+        # fall back to a bare "exit N" (codex #1222 r27).
+        stdout = "........\n261 passed, 2 skipped in 10.86s\n"
+        assert (
+            targeted_mod._last_summary_line(stdout) == "261 passed, 2 skipped in 10.86s"
+        )
+
+    def test_last_summary_line_parses_fenced_and_failures(self):
+        assert (
+            targeted_mod._last_summary_line("==== 5 failed, 3 passed in 2.0s ====")
+            == "5 failed, 3 passed in 2.0s"
+        )
+        # No summary at all → empty (caller falls back to the exit code).
+        assert targeted_mod._last_summary_line("collecting...\n") == ""

--- a/tests/test_pr_validate_flake_tracking.py
+++ b/tests/test_pr_validate_flake_tracking.py
@@ -712,14 +712,16 @@ class TestFlakeTrackingContract:
         assert "--color=no" in captured["cmd"]
         assert "-rA" in captured["cmd"]
 
-    def test_quarantined_deterministic_reproduction_blocks(
-        self, ctx_factory, monkeypatch
-    ):
-        # A quarantined test that reproduces its failure on EVERY re-run is
-        # a deterministic regression the quarantine would otherwise mask —
-        # flake_tracking must BLOCK (status=fail), revoking full_unit's
-        # downgrade (codex #1222 r7). Its id lands in `reproduced_quarantined`;
-        # a non-quarantined reproduction lands in `reproduced_likely_real`.
+    def test_quarantined_reproduction_is_advisory_loud(self, ctx_factory, monkeypatch):
+        # A quarantined test that reproduces on EVERY re-run MAY be a
+        # deterministic regression the quarantine is masking — but
+        # correlated in-process re-runs can't prove that (a sustained-
+        # contention flake looks identical), so flake_tracking does NOT
+        # auto-block (codex #1222 r8, reverting r7's hard gate). It surfaces
+        # the case LOUDLY for human de-quarantine: status stays advisory
+        # (pass), the summary leads with a REVIEW flag, and the id lands in
+        # `reproduced_quarantined`. A non-quarantined reproduction still
+        # lands in `reproduced_likely_real` (full_unit already blocked it).
         ctx = ctx_factory()
         ctx.artifact_path("full-unit.log").write_text(
             _summary(
@@ -745,8 +747,9 @@ class TestFlakeTrackingContract:
             flake_mod, "_run_session", lambda *a, **k: _completed(1, rerun)
         )
         res = FlakeTrackingStep().run(ctx)
-        assert res.status == "fail"  # deterministic quarantined regression
-        assert "deterministically" in res.summary
+        assert res.status == "pass"  # advisory — never auto-blocks (r8)
+        assert "REVIEW" in res.summary
+        assert "de-quarantine" in res.summary
         data = json.loads(ctx.artifact_path("flake-candidates.json").read_text())
         assert data["reproduced_likely_real"] == ["tests/x.py::real"]
         assert data["reproduced_quarantined"] == ["tests/x.py::flaky"]
@@ -780,6 +783,41 @@ class TestFlakeTrackingContract:
         data = json.loads(ctx.artifact_path("flake-candidates.json").read_text())
         assert data["flake_candidates_known"] == ["tests/x.py::flaky"]
         assert data["reproduced_quarantined"] == []
+
+    def test_quarantined_failure_always_sampled_past_cap(
+        self, ctx_factory, monkeypatch
+    ):
+        # A quarantined failure is the highest-value review signal, so it
+        # must be re-run even when it sorts past the _MAX_RERUN_IDS cap —
+        # otherwise the graveyard-review report silently drops it (codex
+        # #1222 r8 nit). Put the quarantined id LAST among 40 failures and
+        # assert it still reaches the re-run command.
+        ids = [f"tests/x.py::t{i}" for i in range(40)]
+        q_id = ids[-1]
+        ctx = ctx_factory()
+        ctx.artifact_path("full-unit.log").write_text(
+            _summary(*[f"FAILED {i} - X" for i in ids])
+        )
+        monkeypatch.setattr(
+            flake_mod.importlib.util, "find_spec", lambda name: object()
+        )
+        monkeypatch.setattr(
+            flake_mod,
+            "load_quarantine_from_ref",
+            lambda *a, **k: [QuarantineEntry(id=q_id)],
+        )
+        captured = {}
+
+        def _capture(cmd, cwd, timeout):
+            captured["cmd"] = cmd
+            return _completed(0, _passed())
+
+        monkeypatch.setattr(flake_mod, "_run_session", _capture)
+        FlakeTrackingStep().run(ctx)
+        assert q_id in captured["cmd"]  # quarantined id survived the cap
+        # ...and the cap still bounds the total re-run set.
+        rerun_ids = [c for c in captured["cmd"] if c.startswith("tests/x.py::")]
+        assert len(rerun_ids) == flake_mod._MAX_RERUN_IDS
 
 
 class TestFlakeTrackingClassification:
@@ -928,8 +966,9 @@ class TestRunSession:
 class TestRegistration:
     def test_registered_after_all_gating_steps(self):
         # Must read full-unit.log (so after full_unit) AND run after every
-        # gating step so its possible descendant leak can't contaminate one
-        # (codex #1222 r7): after full_unit and stress_e2e_bench.
+        # step that spawns model servers / GPU workers, so its possible
+        # descendant leak on macOS can't contaminate a later gate (codex
+        # #1222 r7): after full_unit and stress_e2e_bench.
         from scripts.pr_validate.runner import STEPS
 
         names = [s.name for s in STEPS]
@@ -938,6 +977,7 @@ class TestRegistration:
         assert names.index("flake_tracking") > names.index("stress_e2e_bench")
 
     def test_crash_never_blocks(self):
-        # A crash in this step must never sink the PR (advisory heritage);
-        # its only blocking path is a deliberate reproduced-quarantined fail.
+        # Advisory: this step has NO blocking path — every outcome is
+        # pass/skip, and run() downgrades any crash to skip so an uncaught
+        # exception can't become a blocking error (codex #1222 r8).
         assert FlakeTrackingStep().continue_on_error is True

--- a/tests/test_pr_validate_flake_tracking.py
+++ b/tests/test_pr_validate_flake_tracking.py
@@ -3663,6 +3663,40 @@ class TestRunSession:
         assert (out, err) == ("", "")
         assert fake.wait_called  # direct child was reaped, not orphaned
 
+    def test_interrupt_during_communicate_sweeps_group(self, monkeypatch):
+        # codex #1222 r38: a NON-timeout exit from communicate() — most
+        # importantly a KeyboardInterrupt when the operator Ctrl-C's the gate
+        # mid-rerun — must still SIGKILL the process group and bounded-reap
+        # the child, then re-raise, so pytest + its GPU/inference descendants
+        # aren't orphaned. Driven with a stub so it's deterministic and fast.
+        killed = {"pgid": None}
+
+        class _FakeProc:
+            def __init__(self):
+                self.stdout = None
+                self.stderr = None
+                self.pid = 999999
+                self.returncode = None
+                self._calls = 0
+
+            def communicate(self, timeout=None):
+                self._calls += 1
+                if self._calls == 1:
+                    raise KeyboardInterrupt  # the interrupted wait
+                return "", ""  # the post-kill bounded drain succeeds
+
+            def wait(self, timeout=None):
+                return -9
+
+        monkeypatch.setattr(flake_mod.subprocess, "Popen", lambda *a, **k: _FakeProc())
+        monkeypatch.setattr(flake_mod.os, "getpgid", lambda pid: pid)
+        monkeypatch.setattr(
+            flake_mod.os, "killpg", lambda pgid, sig: killed.__setitem__("pgid", pgid)
+        )
+        with pytest.raises(KeyboardInterrupt):
+            _run_session([sys.executable, "-c", "pass"], cwd=".", timeout=30)
+        assert killed["pgid"] == 999999  # group swept before the re-raise
+
 
 class TestRegistration:
     def test_registered_after_all_gating_steps(self):

--- a/tests/test_pr_validate_flake_tracking.py
+++ b/tests/test_pr_validate_flake_tracking.py
@@ -22,6 +22,7 @@ import time
 
 import pytest
 
+from scripts.pr_validate import _nodeid_reporter
 from scripts.pr_validate._pytest_summary import summary_node_ids
 from scripts.pr_validate.context import Context
 from scripts.pr_validate.quarantine import (
@@ -339,6 +340,27 @@ class TestLoadQuarantine:
         with pytest.raises(QuarantineError, match="added"):
             load_quarantine(p)
 
+    def test_non_string_reason_raises(self, tmp_path):
+        # codex #1222 r15: a non-string reason (e.g. a YAML list) must raise,
+        # not be str()-coerced into a bogus "['foo', 'bar']" rationale that
+        # then satisfies the mandatory non-empty check.
+        p = tmp_path / "q.yaml"
+        p.write_text(
+            "tests:\n  - id: a.py::t\n    reason: [foo, bar]\n    added: 2026-01-01\n"
+        )
+        with pytest.raises(QuarantineError, match="reason"):
+            load_quarantine(p)
+
+    def test_non_string_issue_raises(self, tmp_path):
+        # Same guard on the optional ``issue`` audit field (codex #1222 r15).
+        p = tmp_path / "q.yaml"
+        p.write_text(
+            "tests:\n  - id: a.py::t\n    reason: flaky\n    added: 2026-01-01\n"
+            "    issue: [123]\n"
+        )
+        with pytest.raises(QuarantineError, match="issue"):
+            load_quarantine(p)
+
     def test_non_date_added_raises(self, tmp_path):
         # `added` claims YYYY-MM-DD, so a non-empty-but-garbage value is
         # audit rot and must be rejected, not silently accepted (codex r13).
@@ -612,7 +634,18 @@ class TestPartition:
 
 
 class TestFullUnitQuarantineAware:
-    def _patch_pytest(self, monkeypatch, returncode, stdout, *, structured=True):
+    def _patch_pytest(
+        self,
+        monkeypatch,
+        returncode,
+        stdout,
+        *,
+        structured=True,
+        session=True,
+        ran=100,
+        collected=100,
+        session_value=None,
+    ):
         def fake_run(cmd, **kw):
             # Simulate the reporter plugin: when structured logging is on,
             # mirror the summary's FAILED/ERROR lines into the node-id TSV
@@ -628,6 +661,19 @@ class TestFullUnitQuarantineAware:
                     for label in ("FAILED", "ERROR")
                     for nid in summary_node_ids(stdout, label)
                 ]
+                # The reporter's session-finish completion record (codex
+                # #1222 r15). ``ran >= collected`` marks a COMPLETE run — the
+                # precondition for a downgrade. Truncation tests pass
+                # ``session=False`` (hard exit / crash → the hook never fires,
+                # no record) or ``ran < collected`` (early stop); a malformed
+                # record is driven via ``session_value``.
+                if session:
+                    value = (
+                        session_value
+                        if session_value is not None
+                        else f"{ran} {collected}"
+                    )
+                    rows.append(f"{_nodeid_reporter.SESSION_LABEL}\t{value}")
                 with open(log, "w", encoding="utf-8") as fh:
                     fh.write("\n".join(rows) + ("\n" if rows else ""))
             return subprocess.CompletedProcess(cmd, returncode, stdout, "")
@@ -825,23 +871,142 @@ class TestFullUnitQuarantineAware:
         assert "PYTEST_ADDOPTS" not in (captured["env"] or {})
 
     def test_early_stop_withholds_downgrade(self, ctx_factory, monkeypatch):
-        # codex #1222 r14: a conftest can set --stepwise programmatically even
-        # with addopts cleared. If pytest terminated the session early, the
-        # suite is incomplete — a later real regression may not have run — so
-        # the quarantine downgrade is withheld and every failure blocks.
+        # codex #1222 r15: completeness is proven STRUCTURALLY from the
+        # reporter's session-finish record, not a stdout banner (which
+        # false-positived when "Interrupted:" appeared in a test's own
+        # traceback — r15 B2). An early stop (-x / --maxfail / --stepwise,
+        # which a conftest can set even with addopts cleared) attempts fewer
+        # items than it collected: ran < collected → the suite is incomplete,
+        # a later regression may not have run, so the downgrade is withheld
+        # and every failure blocks.
         self._patch_quarantine(
             monkeypatch, [QuarantineEntry(id="tests/a.py::test_flaky")]
         )
-        stdout = (
-            "==== short test summary info ====\n"
-            "FAILED tests/a.py::test_flaky - X\n"
-            "!!!!!!!! Interrupted: Test failed, continuing next run. !!!!!!!!\n"
-            "==== 1 failed in 0.20s ====\n"
+        self._patch_pytest(
+            monkeypatch,
+            1,
+            _summary("FAILED tests/a.py::test_flaky - X"),
+            ran=1,
+            collected=50,  # 49 collected tests never ran → truncated
         )
-        self._patch_pytest(monkeypatch, 1, stdout)
         res = FullUnitStep().run(ctx_factory())
         assert res.status == "fail"  # withheld despite being listed
-        assert "terminated the session early" in res.details
+        assert "did not run to completion" in res.details
+
+    def test_hard_truncation_withholds_downgrade(self, ctx_factory, monkeypatch):
+        # codex #1222 r15 B1: a test calling os._exit(1) (or a crash /
+        # SIGKILL) kills the process mid-suite, so pytest_sessionfinish never
+        # fires and NO completion record is written — even though the exit
+        # code is 1 and the only logged failure is quarantined. The record's
+        # absence proves the run was truncated, so the downgrade is withheld
+        # and the failure blocks. This is the case the old stdout heuristic
+        # could not see (os._exit prints no banner).
+        self._patch_quarantine(
+            monkeypatch, [QuarantineEntry(id="tests/a.py::test_flaky")]
+        )
+        self._patch_pytest(
+            monkeypatch,
+            1,
+            _summary("FAILED tests/a.py::test_flaky - X"),
+            session=False,  # process died before sessionfinish → no record
+        )
+        res = FullUnitStep().run(ctx_factory())
+        assert res.status == "fail"  # withheld → blocks despite being listed
+        assert "did not run to completion" in res.details
+
+    def test_complete_run_allows_downgrade(self, ctx_factory, monkeypatch):
+        # The positive control for r15: a well-formed completion record with
+        # ran >= collected proves the whole suite ran, so a solely-quarantined
+        # red is correctly downgraded to a (loud) pass.
+        self._patch_quarantine(
+            monkeypatch, [QuarantineEntry(id="tests/a.py::test_flaky")]
+        )
+        self._patch_pytest(
+            monkeypatch,
+            1,
+            _summary("FAILED tests/a.py::test_flaky - X"),
+            ran=50,
+            collected=50,
+        )
+        res = FullUnitStep().run(ctx_factory())
+        assert res.status == "pass"
+        assert "known-flaky" in res.summary
+
+    def test_malformed_session_record_withholds_downgrade(
+        self, ctx_factory, monkeypatch
+    ):
+        # A present-but-unparseable completion record (a tampered / unexpected
+        # shape) is not proof of completeness — withhold the downgrade, the
+        # safe direction (codex #1222 r15).
+        self._patch_quarantine(
+            monkeypatch, [QuarantineEntry(id="tests/a.py::test_flaky")]
+        )
+        self._patch_pytest(
+            monkeypatch,
+            1,
+            _summary("FAILED tests/a.py::test_flaky - X"),
+            session_value="garbage-not-two-ints",
+        )
+        res = FullUnitStep().run(ctx_factory())
+        assert res.status == "fail"
+        assert "did not run to completion" in res.details
+
+
+# --------------------------------------------------------------------------
+# full_unit._session_completed — structured completeness proof (codex r15)
+# --------------------------------------------------------------------------
+
+
+class TestSessionCompleted:
+    """The quarantine downgrade's completeness precondition is proven from
+    the reporter's SESSIONFINISH record, replacing the fragile stdout-banner
+    heuristic (codex #1222 r15)."""
+
+    def _tsv(self, tmp_path, text):
+        p = tmp_path / "nodeids.tsv"
+        p.write_text(text, encoding="utf-8")
+        return p
+
+    def test_complete_run(self, tmp_path):
+        assert full_unit_mod._session_completed(
+            self._tsv(tmp_path, "SESSIONFINISH\t50 50\n")
+        )
+
+    def test_ran_exceeds_collected_is_complete(self, tmp_path):
+        # A benign over-count (e.g. a reran item logs an extra setup) still
+        # ran the whole suite — completeness is ran >= collected, not ==.
+        assert full_unit_mod._session_completed(
+            self._tsv(tmp_path, "SESSIONFINISH\t51 50\n")
+        )
+
+    def test_early_stop_is_incomplete(self, tmp_path):
+        # ran < collected → -x / --maxfail / --stepwise truncated the suite.
+        assert not full_unit_mod._session_completed(
+            self._tsv(tmp_path, "SESSIONFINISH\t1 50\n")
+        )
+
+    def test_absent_record_is_incomplete(self, tmp_path):
+        # os._exit / crash / SIGKILL → sessionfinish never fired → no record.
+        assert not full_unit_mod._session_completed(
+            self._tsv(tmp_path, "FAILED\ttests/a.py::t\n")
+        )
+
+    def test_duplicate_record_is_incomplete(self, tmp_path):
+        # An unexpected multi-record shape (xdist / tamper) → withhold, the
+        # safe direction.
+        assert not full_unit_mod._session_completed(
+            self._tsv(tmp_path, "SESSIONFINISH\t50 50\nSESSIONFINISH\t1 50\n")
+        )
+
+    def test_malformed_value_is_incomplete(self, tmp_path):
+        assert not full_unit_mod._session_completed(
+            self._tsv(tmp_path, "SESSIONFINISH\tgarbage\n")
+        )
+
+    def test_zero_collected_is_incomplete(self, tmp_path):
+        assert not full_unit_mod._session_completed(
+            self._tsv(tmp_path, "SESSIONFINISH\t0 0\n")
+        )
 
 
 # --------------------------------------------------------------------------
@@ -868,6 +1033,53 @@ class TestFlakeTrackingContract:
         ctx.artifact_path("full-unit.log").write_text(_passed())
         res = FlakeTrackingStep().run(ctx)
         assert res.status == "skip"
+
+    def test_reruns_error_nodeids_structured(self, ctx_factory, monkeypatch):
+        # codex #1222 r15 NIT: a setup / teardown / collection flake is
+        # recorded as ERROR, not FAILED. The advisory tracker must re-run
+        # those too (reading only FAILED reported "nothing to classify" and
+        # skipped them). Structured-log path: an ERROR id must reach the
+        # re-run command.
+        ctx = ctx_factory()
+        ctx.artifact_path("full-unit.log").write_text("boom")
+        ctx.artifact_path("full-unit-nodeids.tsv").write_text(
+            "ERROR\ttests/x.py::errored\n"
+        )
+        monkeypatch.setattr(
+            flake_mod.importlib.util, "find_spec", lambda name: object()
+        )
+        monkeypatch.setattr(flake_mod, "load_quarantine_from_ref", lambda *a, **k: [])
+        captured = {}
+
+        def _capture(cmd, cwd, timeout, env=None):
+            captured["cmd"] = cmd
+            return _completed(0, _passed())
+
+        monkeypatch.setattr(flake_mod, "_run_session", _capture)
+        FlakeTrackingStep().run(ctx)
+        assert "tests/x.py::errored" in captured["cmd"]
+
+    def test_reruns_error_nodeids_fallback(self, ctx_factory, monkeypatch):
+        # Same NIT via the terminal-summary FALLBACK (no structured log): an
+        # ERROR line in full-unit.log must be picked up for the advisory
+        # re-run, not dropped.
+        ctx = ctx_factory()
+        ctx.artifact_path("full-unit.log").write_text(
+            _summary("ERROR tests/x.py::errored - fixture boom")
+        )
+        monkeypatch.setattr(
+            flake_mod.importlib.util, "find_spec", lambda name: object()
+        )
+        monkeypatch.setattr(flake_mod, "load_quarantine_from_ref", lambda *a, **k: [])
+        captured = {}
+
+        def _capture(cmd, cwd, timeout, env=None):
+            captured["cmd"] = cmd
+            return _completed(0, _passed())
+
+        monkeypatch.setattr(flake_mod, "_run_session", _capture)
+        FlakeTrackingStep().run(ctx)
+        assert "tests/x.py::errored" in captured["cmd"]
 
     def test_skip_when_plugin_absent(self, ctx_factory, monkeypatch):
         ctx = ctx_factory()
@@ -1417,6 +1629,108 @@ class TestNodeidReporter:
         # The always-failing test: terminal FAILED exactly once, never PASSED.
         assert failed.count("test_flaky.py::test_always_bad") == 1
         assert "test_flaky.py::test_always_bad" not in passed
+
+    def _session_records(self, log_path):
+        if not log_path.exists():
+            return []
+        return [
+            ln.split("\t", 1)[1]
+            for ln in log_path.read_text(encoding="utf-8").splitlines()
+            if ln.startswith(_nodeid_reporter.SESSION_LABEL + "\t")
+        ]
+
+    def test_session_finish_record_on_complete_run(self, tmp_path):
+        # codex #1222 r15: a graceful, complete run writes exactly ONE
+        # SESSIONFINISH record with ran == collected — the structural proof
+        # full_unit requires before granting a quarantine downgrade.
+        (tmp_path / "test_three.py").write_text(
+            "def test_a(): assert True\n"
+            "def test_b(): assert True\n"
+            "def test_c(): assert True\n"
+        )
+        log_path = tmp_path / "nodeids.tsv"
+        plugin_args, env = flake_mod._nodeid_reporter.build_invocation(
+            log_path, self._repo_root()
+        )
+        subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "pytest",
+                "-p",
+                "no:randomly",
+                *plugin_args,
+                "test_three.py",
+            ],
+            cwd=str(tmp_path),
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+        assert self._session_records(log_path) == ["3 3"]
+
+    def test_session_finish_absent_on_hard_exit(self, tmp_path):
+        # codex #1222 r15 B1: a test calling os._exit kills the process
+        # before pytest_sessionfinish, so the record is never written — this
+        # ABSENCE is how full_unit detects a truncated run.
+        (tmp_path / "test_hardexit.py").write_text(
+            "import os\n"
+            "def test_a(): assert True\n"
+            "def test_boom(): os._exit(1)\n"
+            "def test_c(): assert True\n"
+        )
+        log_path = tmp_path / "nodeids.tsv"
+        plugin_args, env = flake_mod._nodeid_reporter.build_invocation(
+            log_path, self._repo_root()
+        )
+        subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "pytest",
+                "-p",
+                "no:randomly",
+                "-p",
+                "no:cacheprovider",
+                *plugin_args,
+                "test_hardexit.py",
+            ],
+            cwd=str(tmp_path),
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+        assert self._session_records(log_path) == []  # hook never fired
+
+    def test_session_finish_early_stop_records_gap(self, tmp_path):
+        # codex #1222 r15: -x stops after the first failure, so the record
+        # carries ran < collected — full_unit reads that gap as incomplete.
+        (tmp_path / "test_earlystop.py").write_text(
+            "def test_a(): assert False\n"
+            "def test_b(): assert True\n"
+            "def test_c(): assert True\n"
+        )
+        log_path = tmp_path / "nodeids.tsv"
+        plugin_args, env = flake_mod._nodeid_reporter.build_invocation(
+            log_path, self._repo_root()
+        )
+        subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "pytest",
+                "-p",
+                "no:randomly",
+                "-x",
+                *plugin_args,
+                "test_earlystop.py",
+            ],
+            cwd=str(tmp_path),
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+        assert self._session_records(log_path) == ["1 3"]
 
 
 # --------------------------------------------------------------------------

--- a/tests/test_pr_validate_flake_tracking.py
+++ b/tests/test_pr_validate_flake_tracking.py
@@ -645,6 +645,7 @@ class TestFullUnitQuarantineAware:
         ran=100,
         collected=100,
         session_value=None,
+        write_log=True,
     ):
         def fake_run(cmd, **kw):
             # Simulate the reporter plugin: when structured logging is on,
@@ -652,10 +653,12 @@ class TestFullUnitQuarantineAware:
             # the real plugin would have written. full_unit reads THAT for
             # the quarantine decision (the summary is only a fallback, and a
             # downgrade is withheld entirely when the structured log is
-            # absent — codex #1222 r13).
+            # absent — codex #1222 r13). ``write_log=False`` simulates a hard
+            # os._exit before the first append: the plugin writes NOTHING, so
+            # only full_unit's own start sentinel remains (codex #1222 r17).
             env = kw.get("env") or {}
             log = env.get("PR_VALIDATE_NODEID_LOG")
-            if structured and log:
+            if structured and log and write_log:
                 rows = [
                     f"{label}\t{nid}"
                     for label in ("FAILED", "ERROR")
@@ -817,10 +820,12 @@ class TestFullUnitQuarantineAware:
     def test_downgrade_withheld_without_structured_log(self, ctx_factory, monkeypatch):
         # codex #1222 r13: the quarantine downgrade must rest on the exact
         # structured node ids, never the ambiguous summary fallback. If the
-        # reporter log is absent (plugin couldn't load, or a candidate
-        # disabled it via pytest config), grant NO downgrade — a would-be
-        # quarantined failure BLOCKS, so a mis-split fallback id can never
-        # wrongly match a family entry and waive a real red.
+        # reporter can't be injected (available() False), grant NO downgrade —
+        # a would-be quarantined failure BLOCKS, so a mis-split fallback id can
+        # never wrongly match a family entry and waive a real red. (r17: "no
+        # structured log" now means available() False, since an injected
+        # plugin always leaves a start sentinel.)
+        monkeypatch.setattr(full_unit_mod._nodeid_reporter, "available", lambda: False)
         self._patch_quarantine(
             monkeypatch, [QuarantineEntry(id="tests/a.py::test_flaky")]
         )
@@ -977,13 +982,25 @@ class TestFullUnitQuarantineAware:
         assert res.status == "pass"
 
     def test_clean_exit_without_plugin_trusts_exit_code(self, ctx_factory, monkeypatch):
-        # If the reporter couldn't be injected at all (no structured log),
+        # If the reporter genuinely can't be injected (available() False),
         # there's no completeness signal to check — a green exit falls back to
-        # the exit code (the degraded, non-candidate path). structured=False
-        # simulates the plugin not writing a log.
+        # the exit code (the degraded, non-candidate path).
+        monkeypatch.setattr(full_unit_mod._nodeid_reporter, "available", lambda: False)
         self._patch_pytest(monkeypatch, 0, _passed(), structured=False)
         res = FullUnitStep().run(ctx_factory())
         assert res.status == "pass"
+
+    def test_clean_exit_injected_but_no_output_blocks(self, ctx_factory, monkeypatch):
+        # codex #1222 r17 B1: a hard os._exit(0) before the first report
+        # leaves the log UNwritten (not even empty). full_unit pre-creates a
+        # start sentinel when it injects the plugin, so injection is known
+        # independent of any append — the empty sentinel + exit 0 blocks,
+        # instead of being misread as "plugin unavailable → trust exit code".
+        # write_log=False simulates the plugin writing nothing at all.
+        self._patch_pytest(monkeypatch, 0, _passed(), write_log=False)
+        res = FullUnitStep().run(ctx_factory())
+        assert res.status == "fail"
+        assert "did not run to completion" in res.details
 
 
 # --------------------------------------------------------------------------
@@ -1100,6 +1117,61 @@ class TestFlakeTrackingContract:
         monkeypatch.setattr(flake_mod, "_run_session", _capture)
         FlakeTrackingStep().run(ctx)
         assert "tests/x.py::errored" in captured["cmd"]
+
+    def test_recovered_collection_error_is_candidate(self, ctx_factory, monkeypatch):
+        # codex #1222 r17 NIT: a collection ERROR id is a MODULE / DIR path
+        # (no "::"); on a clean re-run its CONTAINED tests log PASSED under
+        # their own "::" ids, but the module id itself never logs a PASSED —
+        # so a recovered collection flake would wrongly land in `inconclusive`
+        # forever. A collection target that did NOT re-error is a recovered
+        # flake candidate instead.
+        ctx = ctx_factory()
+        ctx.artifact_path("full-unit.log").write_text("boom")
+        ctx.artifact_path("full-unit-nodeids.tsv").write_text("ERROR\ttests/mod.py\n")
+        monkeypatch.setattr(
+            flake_mod.importlib.util, "find_spec", lambda name: object()
+        )
+        monkeypatch.setattr(flake_mod, "load_quarantine_from_ref", lambda *a, **k: [])
+
+        def fake(cmd, cwd, timeout, env=None):
+            # Clean re-run: the module collected fine and its test passed; the
+            # module id itself logs nothing.
+            ctx.artifact_path("flake-rerun-nodeids.tsv").write_text(
+                "PASSED\ttests/mod.py::test_a\n"
+            )
+            return _completed(0, "")
+
+        monkeypatch.setattr(flake_mod, "_run_session", fake)
+        res = FlakeTrackingStep().run(ctx)
+        assert res.status == "pass"
+        data = json.loads(ctx.artifact_path("flake-candidates.json").read_text())
+        assert "tests/mod.py" in data["flake_candidates_new"]
+        assert "tests/mod.py" not in data["inconclusive"]
+
+    def test_reproduced_collection_error_not_candidate(self, ctx_factory, monkeypatch):
+        # The inverse: a collection target that RE-ERRORS on re-run reproduces
+        # (still_bad) and must NOT be a candidate — badness takes precedence
+        # over the collection-recovery rule.
+        ctx = ctx_factory()
+        ctx.artifact_path("full-unit.log").write_text("boom")
+        ctx.artifact_path("full-unit-nodeids.tsv").write_text("ERROR\ttests/mod.py\n")
+        monkeypatch.setattr(
+            flake_mod.importlib.util, "find_spec", lambda name: object()
+        )
+        monkeypatch.setattr(flake_mod, "load_quarantine_from_ref", lambda *a, **k: [])
+
+        def fake(cmd, cwd, timeout, env=None):
+            ctx.artifact_path("flake-rerun-nodeids.tsv").write_text(
+                "ERROR\ttests/mod.py\n"
+            )
+            return _completed(1, "")
+
+        monkeypatch.setattr(flake_mod, "_run_session", fake)
+        res = FlakeTrackingStep().run(ctx)
+        assert res.status == "pass"
+        data = json.loads(ctx.artifact_path("flake-candidates.json").read_text())
+        assert "tests/mod.py" not in data["flake_candidates_new"]
+        assert "tests/mod.py" in data["reproduced_likely_real"]
 
     def test_reruns_error_nodeids_fallback(self, ctx_factory, monkeypatch):
         # Same NIT via the terminal-summary FALLBACK (no structured log): an
@@ -1837,6 +1909,40 @@ class TestNodeidReporter:
         # 3 distinct tests all ran to completion → ran == collected == 3,
         # even though the flaky one produced ~5 setup reports.
         assert self._session_records(log_path) == ["3 3"]
+
+    def test_no_log_written_on_hard_exit_zero_before_tests(self, tmp_path):
+        # codex #1222 r17 B1: os._exit(0) at collection time (here from a
+        # conftest imported before any test runs) kills pytest before any
+        # setup report or sessionfinish, so the reporter writes NOTHING — the
+        # log file is never even created. This is exactly why full_unit
+        # pre-creates a start sentinel: without it, "no file" would be
+        # misread as "plugin unavailable" and the zero exit trusted on a
+        # fully-truncated run. (The plugin itself cannot defend this; the
+        # sentinel in full_unit does.)
+        (tmp_path / "conftest.py").write_text("import os\nos._exit(0)\n")
+        (tmp_path / "test_never.py").write_text("def test_a(): assert True\n")
+        log_path = tmp_path / "nodeids.tsv"
+        plugin_args, env = flake_mod._nodeid_reporter.build_invocation(
+            log_path, self._repo_root()
+        )
+        subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "pytest",
+                "-p",
+                "no:randomly",
+                "-p",
+                "no:cacheprovider",
+                *plugin_args,
+                "test_never.py",
+            ],
+            cwd=str(tmp_path),
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+        assert not log_path.exists()  # plugin wrote nothing → sentinel needed
 
 
 # --------------------------------------------------------------------------

--- a/tests/test_pr_validate_flake_tracking.py
+++ b/tests/test_pr_validate_flake_tracking.py
@@ -2444,6 +2444,17 @@ class TestRenderFenceSafe:
         assert json.dumps(evil, ensure_ascii=False) in out
         assert "b\n```\n# spoof" not in out
 
+    def test_targeted_failed_block_is_fence_safe(self):
+        # targeted surfaces canonical reporter ids (r26), which a hostile
+        # pytest_make_parametrize_id can load with a newline + triple backticks
+        # (r23); _failed_block must render each fence-safe or the id could close
+        # the scorecard fence and spoof review content (codex #1222 r30).
+        evil = "tests/a.py::test_x[a\n```\n# spoof]"
+        block = targeted_mod._failed_block([evil])
+        assert "\n" not in block  # single physical line → no fence-closer
+        assert json.dumps(evil, ensure_ascii=False) in block
+        assert targeted_mod._failed_block([]) == "(none)"
+
 
 class TestNodeidReporter:
     """Prove the plugin round-trips real ``report.nodeid`` values through a
@@ -3452,6 +3463,13 @@ class TestTargetedTestsUntrustedRun:
         res = targeted_mod.TargetedTestsStep().run(ctx)
         assert res.status == "skip"
         assert "deselected" in res.summary
+        # The skip is LOUD (codex #1222 r30): moving a changed test into
+        # slow/integration/needle to dodge this fast gate can't be caught here
+        # (excluded tests need real models / a live server — they run only in
+        # the slow-lane CI), so the summary prompts a reviewer to confirm the
+        # reclassification is intentional rather than silently skipping.
+        assert "⚠ REVIEW" in res.summary
+        assert "reclassification" in res.summary
 
     def test_last_summary_line_recognizes_plural_errors(self):
         # pytest pluralizes the error outcome ("1 error" vs "2 errors"), so an
@@ -3555,3 +3573,43 @@ class TestTargetedTestsUntrustedRun:
         # Parity: base scrape == PR canonical id → shared failure classified
         # pre-existing, not a false regression.
         assert scraped == canonical
+
+    def test_regression_details_render_fence_safe(self, ctx_factory, monkeypatch):
+        # A hostile canonical id (newline + triple backticks) classified as a
+        # regression must be rendered fence-safe in the scorecard details, or it
+        # could close the ``` fence and spoof review content — the same sink r24
+        # hardened for the sibling steps, newly reachable in targeted once it
+        # switched to canonical reporter ids (codex #1222 r30).
+        hostile = "tests/a.py::test_x[a\n```\n## spoof]"
+        ctx = self._patch_run_pytest(
+            monkeypatch, ctx_factory, self._run(1, failed=[hostile])
+        )
+        # Empty base set → the hostile id is classified a regression and rendered.
+        monkeypatch.setattr(targeted_mod, "_run_on_main", lambda *a, **k: [])
+        res = targeted_mod.TargetedTestsStep().run(ctx)
+        assert res.status == "fail"
+        assert json.dumps(hostile, ensure_ascii=False) in res.details
+        # The raw fence-breaking sequence must NOT leak into the details block.
+        assert "a\n```\n## spoof" not in res.details
+
+    def test_ambiguous_preexisting_id_fails_closed(self, ctx_factory, monkeypatch):
+        # A pre-existing failure whose id contains `" - "` with unbalanced
+        # brackets (`test_x[a] - b]`) is IRREDUCIBLY ambiguous to the base
+        # summary scrape (the reporter wall, r4-r10) — verified: it truncates to
+        # `test_x[a]`. The base predates the reporter and can't get canonical ids
+        # without contaminating the negative control, so the truncated base id
+        # won't match the PR-side canonical id. That fails CLOSED — the
+        # pre-existing failure is treated as a regression and BLOCKS — never a
+        # false green (a real regression is never masked; codex #1222 r30).
+        canonical = "tests/a.py::test_x[a] - b]"
+        ctx = self._patch_run_pytest(
+            monkeypatch, ctx_factory, self._run(1, failed=[canonical])
+        )
+        # Base scrape truncates the ambiguous id (empirically what
+        # summary_node_ids returns for its `FAILED <id> - <msg>` line).
+        monkeypatch.setattr(
+            targeted_mod, "_run_on_main", lambda *a, **k: ["tests/a.py::test_x[a]"]
+        )
+        res = targeted_mod.TargetedTestsStep().run(ctx)
+        assert res.status == "fail"  # fail-safe: never a false green
+        assert json.dumps(canonical, ensure_ascii=False) in res.details

--- a/tests/test_pr_validate_flake_tracking.py
+++ b/tests/test_pr_validate_flake_tracking.py
@@ -23,7 +23,11 @@ import time
 import pytest
 
 from scripts.pr_validate import _nodeid_reporter
-from scripts.pr_validate._pytest_summary import summary_node_ids
+from scripts.pr_validate._pytest_summary import (
+    raw_session_records,
+    report_log_node_ids,
+    summary_node_ids,
+)
 from scripts.pr_validate.base import GATING_PYTEST_GUARD
 from scripts.pr_validate.context import Context
 from scripts.pr_validate.quarantine import (
@@ -62,6 +66,15 @@ def _passed(n: int = 10) -> str:
 
 def _completed(returncode: int, stdout: str = "", stderr: str = ""):
     return subprocess.CompletedProcess(["pytest"], returncode, stdout, stderr)
+
+
+# A complete-session marker appended to a simulated rerun node-id log.
+# flake_tracking now requires the advisory rerun to have run to completion
+# before it trusts the structured classification (codex #1222 r23); a real
+# rerun always writes this record, so the fakes must too. The exact counts
+# don't matter to session_completed beyond ``collected > 0 and ran >=
+# collected``.
+_RERUN_DONE = f"{_nodeid_reporter.SESSION_LABEL}\t99 99\n"
 
 
 @pytest.fixture
@@ -774,6 +787,7 @@ class TestFullUnitQuarantineAware:
         collected=100,
         session_value=None,
         write_log=True,
+        rerun_ids=None,
     ):
         def fake_run(cmd, **kw):
             # Simulate the reporter plugin: when structured logging is on,
@@ -791,6 +805,13 @@ class TestFullUnitQuarantineAware:
                     f"{label}\t{nid}"
                     for label in ("FAILED", "ERROR")
                     for nid in summary_node_ids(stdout, label)
+                ]
+                # A RERUN record simulates pytest-rerunfailures having run in a
+                # gating invocation despite the by-name block (smuggled in under
+                # an arbitrary name) — full_unit must block on it name-
+                # independently (codex #1222 r23).
+                rows += [
+                    f"{_nodeid_reporter.RERUN_LABEL}\t{nid}" for nid in rerun_ids or []
                 ]
                 # The reporter's session-finish completion record (codex
                 # #1222 r15). ``ran >= collected`` marks a COMPLETE run — the
@@ -910,6 +931,40 @@ class TestFullUnitQuarantineAware:
         cmd = captured["cmd"]
         assert "no:rerunfailures" in cmd
         assert cmd[cmd.index("no:rerunfailures") - 1] == "-p"
+        # codex #1222 r23: block BOTH the entry-point name (rerunfailures) and
+        # the module name (pytest_rerunfailures) — a conftest can register
+        # under either. (Name-blocking is only the cheap first line; the
+        # name-independent RERUN backstop is asserted separately.)
+        assert "no:pytest_rerunfailures" in cmd
+        assert cmd[cmd.index("no:pytest_rerunfailures") - 1] == "-p"
+
+    def test_gate_blocks_on_rerun_record(self, ctx_factory, monkeypatch):
+        # codex #1222 r23: name-based -p blocking is bypassable — a conftest
+        # can register pytest-rerunfailures under an ARBITRARY name, then a
+        # @pytest.mark.flaky marker reruns a real failure to green. The
+        # reporter logs a RERUN record on any rerun OUTCOME (name-independent),
+        # and full_unit must BLOCK on it regardless of a green exit code, since
+        # a gating run must never rerun. Here the exit code is 0 with a passing
+        # summary, yet a RERUN record is present → block.
+        self._patch_pytest(monkeypatch, 0, _passed(), rerun_ids=["tests/a.py::test_x"])
+        res = FullUnitStep().run(ctx_factory())
+        assert res.status == "fail"
+        assert "rerun" in res.details.lower()
+
+    def test_nonzero_exit_with_rerun_record_blocks(self, ctx_factory, monkeypatch):
+        # The RERUN backstop fires on the failure path too: a run that reran
+        # (and passed some tests) but still exited non-zero is equally
+        # untrusted — the rerun could have flipped OTHER real failures green.
+        self._patch_quarantine(monkeypatch, [])
+        self._patch_pytest(
+            monkeypatch,
+            1,
+            _summary("FAILED tests/a.py::test_real - X"),
+            rerun_ids=["tests/a.py::test_real"],
+        )
+        res = FullUnitStep().run(ctx_factory())
+        assert res.status == "fail"
+        assert "rerun" in res.details.lower()
 
     def test_every_gating_pytest_cmd_blocks_rerunfailures(
         self, ctx_factory, monkeypatch
@@ -1408,6 +1463,42 @@ class TestFlakeTrackingContract:
         FlakeTrackingStep().run(ctx)
         assert "tests/x.py::errored" in captured["cmd"]
 
+    def test_incomplete_rerun_session_skips_classification(
+        self, ctx_factory, monkeypatch
+    ):
+        # codex #1222 r23: the structured rerun classification is only trusted
+        # on a COMPLETE rerun. A truncated rerun (a sampled test's pytest.exit
+        # / os._exit / crash) leaves a structured log with NO session-finish
+        # record, so its PASSED/FAILED set is partial — an id whose real
+        # reproduction was in the un-run tail could be mislabeled a recovered
+        # flake and wrongly recommended for a quarantine promotion. When the
+        # rerun didn't run to completion the step SKIPS instead.
+        ctx = ctx_factory()
+        ctx.artifact_path("full-unit.log").write_text("boom")
+        ctx.artifact_path("full-unit-nodeids.tsv").write_text(
+            "FAILED\ttests/x.py::test_real\n"
+        )
+        monkeypatch.setattr(
+            flake_mod.importlib.util, "find_spec", lambda name: object()
+        )
+        monkeypatch.setattr(flake_mod, "load_quarantine_from_ref", lambda *a, **k: [])
+
+        def fake(cmd, cwd, timeout, env=None):
+            # A truncated rerun: test_real logged a PASSED before a mid-session
+            # exit, but NO session-finish record was written (deliberately no
+            # _RERUN_DONE) — the completeness proof is absent.
+            ctx.artifact_path("flake-rerun-nodeids.tsv").write_text(
+                "PASSED\ttests/x.py::test_real\n"
+            )
+            return _completed(0, "")
+
+        monkeypatch.setattr(flake_mod, "_run_session", fake)
+        res = FlakeTrackingStep().run(ctx)
+        assert res.status == "skip"
+        assert "did not run to completion" in res.summary
+        # No misleading candidate artifact is emitted on the truncated path.
+        assert not ctx.artifact_path("flake-candidates.json").exists()
+
     def test_recovered_collection_error_is_error_candidate(
         self, ctx_factory, monkeypatch
     ):
@@ -1431,7 +1522,7 @@ class TestFlakeTrackingContract:
             # Clean re-run: the module collected fine and its test passed; the
             # module id itself logs nothing.
             ctx.artifact_path("flake-rerun-nodeids.tsv").write_text(
-                "PASSED\ttests/mod.py::test_a\n"
+                "PASSED\ttests/mod.py::test_a\n" + _RERUN_DONE
             )
             return _completed(0, "")
 
@@ -1459,8 +1550,9 @@ class TestFlakeTrackingContract:
         monkeypatch.setattr(flake_mod, "load_quarantine_from_ref", lambda *a, **k: [])
 
         def fake(cmd, cwd, timeout, env=None):
-            # Re-run collected but nothing passed (all skipped / empty).
-            ctx.artifact_path("flake-rerun-nodeids.tsv").write_text("")
+            # Re-run collected but nothing passed (all skipped) — the session
+            # still completed, so only the completion marker is present.
+            ctx.artifact_path("flake-rerun-nodeids.tsv").write_text(_RERUN_DONE)
             return _completed(0, "")
 
         monkeypatch.setattr(flake_mod, "_run_session", fake)
@@ -1489,7 +1581,7 @@ class TestFlakeTrackingContract:
 
         def fake(cmd, cwd, timeout, env=None):
             ctx.artifact_path("flake-rerun-nodeids.tsv").write_text(
-                "PASSED\ttests/x.py::test_boom\n"
+                "PASSED\ttests/x.py::test_boom\n" + _RERUN_DONE
             )
             return _completed(0, "")
 
@@ -1515,7 +1607,7 @@ class TestFlakeTrackingContract:
 
         def fake(cmd, cwd, timeout, env=None):
             ctx.artifact_path("flake-rerun-nodeids.tsv").write_text(
-                "ERROR\ttests/mod.py\n"
+                "ERROR\ttests/mod.py\n" + _RERUN_DONE
             )
             return _completed(1, "")
 
@@ -1548,7 +1640,7 @@ class TestFlakeTrackingContract:
 
         def fake(cmd, cwd, timeout, env=None):
             ctx.artifact_path("flake-rerun-nodeids.tsv").write_text(
-                "PASSED\ttests/x.py::test_flaky\n"
+                "PASSED\ttests/x.py::test_flaky\n" + _RERUN_DONE
             )
             return _completed(0, "")
 
@@ -1579,7 +1671,7 @@ class TestFlakeTrackingContract:
 
         def fake(cmd, cwd, timeout, env=None):
             ctx.artifact_path("flake-rerun-nodeids.tsv").write_text(
-                "PASSED\ttests/subdir/test_x.py::test_y\n"
+                "PASSED\ttests/subdir/test_x.py::test_y\n" + _RERUN_DONE
             )
             return _completed(0, "")
 
@@ -1609,7 +1701,7 @@ class TestFlakeTrackingContract:
 
         def fake(cmd, cwd, timeout, env=None):
             ctx.artifact_path("flake-rerun-nodeids.tsv").write_text(
-                "PASSED\ttests/foo.py::test_sibling\n"
+                "PASSED\ttests/foo.py::test_sibling\n" + _RERUN_DONE
             )
             return _completed(0, "")
 
@@ -1975,7 +2067,7 @@ class TestFlakeTrackingContract:
             # Emulate the plugin writing PASSED (call) + ERROR (teardown) for
             # the same id — the exact double-log codex flagged.
             ctx.artifact_path("flake-rerun-nodeids.tsv").write_text(
-                "PASSED\ttests/x.py::td\nERROR\ttests/x.py::td\n"
+                "PASSED\ttests/x.py::td\nERROR\ttests/x.py::td\n" + _RERUN_DONE
             )
             return _completed(1, "")
 
@@ -2096,6 +2188,57 @@ class TestFlakeTrackingClassification:
 # --------------------------------------------------------------------------
 
 
+class TestFieldEscaping:
+    """The log's value fields are escape_field-encoded so a hostile node id
+    can't inject a delimiter and forge a record (codex #1222 r23)."""
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "tests/a.py::test_x",
+            "tests/a.py::test_x[a - b]",
+            "evil\nSESSIONFINISH\t9999 1",
+            "tab\there",
+            "cr\rhere",
+            "back\\slash",
+            "escaped\\tnot_a_tab",
+            "trailing\\",
+            "50 50",
+            "",
+        ],
+    )
+    def test_round_trip(self, value):
+        enc = _nodeid_reporter.escape_field(value)
+        # No raw delimiter survives encoding — the whole point.
+        assert "\n" not in enc and "\t" not in enc
+        assert _nodeid_reporter.unescape_field(enc) == value
+
+    def test_escaped_backslash_does_not_pair_with_following_letter(self):
+        # "\\t" (a literal backslash then a 't') must decode to backslash+'t',
+        # NOT a tab — otherwise a node id containing a literal backslash could
+        # still smuggle a control char through.
+        assert _nodeid_reporter.unescape_field("\\\\t") == "\\t"
+        assert _nodeid_reporter.unescape_field("\\\\n") == "\\n"
+
+    def test_unknown_escape_preserved_verbatim(self):
+        # The writer never emits "\z"; a raw/hand-written record keeps it
+        # intact rather than being corrupted.
+        assert _nodeid_reporter.unescape_field("a\\zb") == "a\\zb"
+
+    def test_no_backslash_is_identity_fast_path(self):
+        assert _nodeid_reporter.unescape_field("plain::id") == "plain::id"
+
+    def test_reader_not_fooled_by_injected_value(self, tmp_path, monkeypatch):
+        # End-to-end at the writer/reader boundary: append a malicious id via
+        # the REAL _append, then prove the readers see one FAILED id and ZERO
+        # session records (the injected SESSIONFINISH is inert).
+        log = tmp_path / "n.tsv"
+        monkeypatch.setenv("PR_VALIDATE_NODEID_LOG", str(log))
+        _nodeid_reporter._append("FAILED", "evil\nSESSIONFINISH\t9999 1")
+        assert raw_session_records(log) == []
+        assert report_log_node_ids(log, "FAILED") == ["evil\nSESSIONFINISH\t9999 1"]
+
+
 class TestNodeidReporter:
     """Prove the plugin round-trips real ``report.nodeid`` values through a
     genuine pytest subprocess, using the ACTUAL repo root on PYTHONPATH so
@@ -2185,6 +2328,68 @@ class TestNodeidReporter:
         assert any("test_uncollectable.py" in nid for nid in errored)
         # A pass is never mis-logged as a failure.
         assert "test_outcomes.py::test_ok" not in failed
+
+    def test_hostile_param_id_cannot_forge_records(self, tmp_path):
+        # codex #1222 r23: a hostile pytest_make_parametrize_id can embed a
+        # literal newline/tab in report.nodeid (verified — pytest preserves
+        # both). Written RAW, the id would forge a second log record — a fake
+        # SESSIONFINISH masking a truncated run, or a fake PASSED faking a
+        # recovery. escape_field keeps the value on ONE physical line, so the
+        # reader sees the exact id and NO injected record.
+        (tmp_path / "conftest.py").write_text(
+            textwrap.dedent(
+                """
+                def pytest_make_parametrize_id(config, val, argname):
+                    return val
+                """
+            )
+        )
+        (tmp_path / "test_inj.py").write_text(
+            textwrap.dedent(
+                """
+                import pytest
+
+                # A param id carrying a newline + tab that spells a forged
+                # completion record: "SESSIONFINISH\\t9999 1".
+                INJECT = "evil\\nSESSIONFINISH\\t9999 1"
+
+                @pytest.mark.parametrize("x", [INJECT])
+                def test_p(x):
+                    assert False
+                """
+            )
+        )
+        log_path = tmp_path / "nodeids.tsv"
+        plugin_args, env = flake_mod._nodeid_reporter.build_invocation(
+            log_path, self._repo_root(), log_passes=True
+        )
+        subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "pytest",
+                "-p",
+                "no:randomly",
+                *plugin_args,
+                "test_inj.py",
+            ],
+            cwd=str(tmp_path),
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+        assert log_path.exists()
+        # Exactly ONE genuine SESSIONFINISH record — the injected
+        # "SESSIONFINISH\t9999 1" is escaped inside the FAILED value, not a
+        # record of its own, so it can't forge a second completion line.
+        assert len(raw_session_records(log_path)) == 1
+        # The real record (1 item collected, 1 ran) proves completeness; the
+        # injection did NOT fabricate an early-stop/garbage record.
+        assert full_unit_mod._session_completed(log_path)
+        failed = report_log_node_ids(log_path, "FAILED")
+        # The malicious id round-trips EXACTLY — newline + tab intact, as ONE
+        # id, not two records.
+        assert any("evil\nSESSIONFINISH\t9999 1" in nid for nid in failed)
 
     def test_passes_not_logged_without_opt_in(self, tmp_path):
         (tmp_path / "test_only_pass.py").write_text("def test_ok():\n    assert True\n")
@@ -2292,6 +2497,7 @@ class TestNodeidReporter:
         passed = [nid for label, nid in rows if label == "PASSED"]
         failed = [nid for label, nid in rows if label == "FAILED"]
         errored = [nid for label, nid in rows if label == "ERROR"]
+        rerun = [nid for label, nid in rows if label == "RERUN"]
 
         # Eventually-passing flakes: PASSED exactly once, never FAILED/ERROR.
         for nid in (
@@ -2304,6 +2510,13 @@ class TestNodeidReporter:
         # The always-failing test: terminal FAILED exactly once, never PASSED.
         assert failed.count("test_flaky.py::test_always_bad") == 1
         assert "test_flaky.py::test_always_bad" not in passed
+        # codex #1222 r23: every retried attempt logs a RERUN record so
+        # full_unit can detect a smuggled pytest-rerunfailures NAME-
+        # INDEPENDENTLY (a gating run disables reruns, so any RERUN is a
+        # tamper signal). All three tests here are retried, so RERUN records
+        # exist — including the always-bad one that exhausts its reruns.
+        assert rerun, ("expected RERUN records under --reruns", rows)
+        assert "test_flaky.py::test_always_bad" in rerun
 
     def _session_records(self, log_path):
         if not log_path.exists():

--- a/tests/test_pr_validate_flake_tracking.py
+++ b/tests/test_pr_validate_flake_tracking.py
@@ -339,6 +339,27 @@ class TestLoadQuarantine:
         with pytest.raises(QuarantineError, match="added"):
             load_quarantine(p)
 
+    def test_non_date_added_raises(self, tmp_path):
+        # `added` claims YYYY-MM-DD, so a non-empty-but-garbage value is
+        # audit rot and must be rejected, not silently accepted (codex r13).
+        p = tmp_path / "q.yaml"
+        p.write_text(
+            'tests:\n  - id: a.py::t\n    reason: flaky\n    added: "someday"\n'
+        )
+        with pytest.raises(QuarantineError, match="added"):
+            load_quarantine(p)
+
+    def test_noncanonical_added_date_raises(self, tmp_path):
+        # A date that doesn't round-trip to canonical YYYY-MM-DD (non-padded,
+        # out-of-range month/day, a timestamp) is rejected so the audit trail
+        # stays uniform (codex #1222 r13).
+        p = tmp_path / "q.yaml"
+        p.write_text(
+            'tests:\n  - id: a.py::t\n    reason: flaky\n    added: "2026-13-40"\n'
+        )
+        with pytest.raises(QuarantineError, match="added"):
+            load_quarantine(p)
+
 
 # --------------------------------------------------------------------------
 # quarantine.py — git base-ref loader (a PR must not quarantine itself)
@@ -547,8 +568,24 @@ class TestPartition:
 
 
 class TestFullUnitQuarantineAware:
-    def _patch_pytest(self, monkeypatch, returncode, stdout):
+    def _patch_pytest(self, monkeypatch, returncode, stdout, *, structured=True):
         def fake_run(cmd, **kw):
+            # Simulate the reporter plugin: when structured logging is on,
+            # mirror the summary's FAILED/ERROR lines into the node-id TSV
+            # the real plugin would have written. full_unit reads THAT for
+            # the quarantine decision (the summary is only a fallback, and a
+            # downgrade is withheld entirely when the structured log is
+            # absent — codex #1222 r13).
+            env = kw.get("env") or {}
+            log = env.get("PR_VALIDATE_NODEID_LOG")
+            if structured and log:
+                rows = [
+                    f"{label}\t{nid}"
+                    for label in ("FAILED", "ERROR")
+                    for nid in summary_node_ids(stdout, label)
+                ]
+                with open(log, "w", encoding="utf-8") as fh:
+                    fh.write("\n".join(rows) + ("\n" if rows else ""))
             return subprocess.CompletedProcess(cmd, returncode, stdout, "")
 
         monkeypatch.setattr(full_unit_mod.subprocess, "run", fake_run)
@@ -686,6 +723,42 @@ class TestFullUnitQuarantineAware:
         res = FullUnitStep().run(ctx)
         assert captured["ref"] == "deadbeefbase"
         assert res.status == "pass"  # quarantined → non-blocking
+
+    def test_downgrade_withheld_without_structured_log(self, ctx_factory, monkeypatch):
+        # codex #1222 r13: the quarantine downgrade must rest on the exact
+        # structured node ids, never the ambiguous summary fallback. If the
+        # reporter log is absent (plugin couldn't load, or a candidate
+        # disabled it via pytest config), grant NO downgrade — a would-be
+        # quarantined failure BLOCKS, so a mis-split fallback id can never
+        # wrongly match a family entry and waive a real red.
+        self._patch_quarantine(
+            monkeypatch, [QuarantineEntry(id="tests/a.py::test_flaky")]
+        )
+        self._patch_pytest(
+            monkeypatch,
+            1,
+            _summary("FAILED tests/a.py::test_flaky - X"),
+            structured=False,  # plugin produced no log
+        )
+        res = FullUnitStep().run(ctx_factory())
+        assert res.status == "fail"  # withheld → blocks despite being listed
+        assert "structured node-id log absent" in res.details
+
+    def test_cmd_overrides_candidate_maxfail(self, ctx_factory, monkeypatch):
+        # codex #1222 r13: a candidate could plant -x / --maxfail=1 in
+        # pytest.ini addopts to stop the suite after one quarantined failure
+        # and have the partial, regression-hiding run accepted. full_unit
+        # appends --maxfail=0 (no limit) so a trailing command-line maxfail
+        # overrides the prepended ini one and the WHOLE suite always runs.
+        captured = {}
+
+        def fake_run(cmd, **kw):
+            captured["cmd"] = cmd
+            return subprocess.CompletedProcess(cmd, 0, _passed(), "")
+
+        monkeypatch.setattr(full_unit_mod.subprocess, "run", fake_run)
+        FullUnitStep().run(ctx_factory())
+        assert "--maxfail=0" in captured["cmd"]
 
 
 # --------------------------------------------------------------------------

--- a/tests/test_pr_validate_flake_tracking.py
+++ b/tests/test_pr_validate_flake_tracking.py
@@ -3468,6 +3468,62 @@ class TestTargetedTestsRerunBackstop:
         assert "build_invocation" not in src
         assert "_nodeid_reporter" not in src
 
+    def test_negative_control_strips_pytest_addopts(self, tmp_path, monkeypatch):
+        # codex #1222 r34: the base negative control must strip PYTEST_ADDOPTS
+        # from its subprocess env, SYMMETRIC with the PR-side run. Otherwise an
+        # inherited option (e.g. ``--runxfail``) applied only on base could make
+        # base report a node as FAILED that the PR side does not, so a real PR
+        # regression is misclassified as pre-existing and waived — a false green.
+        base_root = tmp_path / "base"
+        base_root.mkdir()
+        (base_root / "test_x.py").write_text("def test_x(): assert True\n")
+        monkeypatch.setattr(
+            targeted_mod.tempfile, "mkdtemp", lambda prefix="": str(base_root)
+        )
+        monkeypatch.setenv("PYTEST_ADDOPTS", "--runxfail")
+        captured = {}
+
+        def fake_run(cmd, **kw):
+            if cmd and cmd[0] == "git":  # worktree add / remove
+                return subprocess.CompletedProcess(cmd, 0, "", "")
+            captured["env"] = kw.get("env")  # the pytest invocation
+            return subprocess.CompletedProcess(cmd, 0, "1 passed in 0.1s\n", "")
+
+        monkeypatch.setattr(targeted_mod.subprocess, "run", fake_run)
+        targeted_mod._run_on_main(
+            ["test_x.py"], tmp_path / "log.txt", tmp_path, "basesha"
+        )
+        assert captured.get("env") is not None
+        assert "PYTEST_ADDOPTS" not in captured["env"]
+
+    def test_run_pytest_marks_clean_all_deselected(self, tmp_path):
+        # codex #1222 r34: a genuine all-deselected run (every target test
+        # carries a filtered marker) records a structured ``SESSIONFINISH 0 0``
+        # with no failures → _run_pytest reports all_deselected_clean True (the
+        # gate for the benign exit-5 skip). A run with a real failure does NOT.
+        repo_root = Path(targeted_mod.__file__).resolve().parents[3]
+        allslow = tmp_path / "test_allslow.py"
+        allslow.write_text(
+            "import pytest\n"
+            "@pytest.mark.slow\n"
+            "def test_a(): assert True\n"
+            "@pytest.mark.slow\n"
+            "def test_b(): assert True\n"
+        )
+        clean = targeted_mod._run_pytest(
+            [str(allslow)], tmp_path / "d.log", repo_root, nodeid_log=tmp_path / "d.tsv"
+        )
+        assert clean.structured is True
+        assert clean.all_deselected_clean is True
+        assert "deselected" in clean.summary
+
+        failing = tmp_path / "test_boom.py"
+        failing.write_text("def test_boom(): assert False\n")
+        bad = targeted_mod._run_pytest(
+            [str(failing)], tmp_path / "e.log", repo_root, nodeid_log=tmp_path / "e.tsv"
+        )
+        assert bad.all_deselected_clean is False  # a real failure is not "clean"
+
 
 class TestTargetedTestsUntrustedRun:
     """An empty FAILED list is only a genuine pass when the run finished as an
@@ -3698,6 +3754,7 @@ class TestTargetedTestsUntrustedRun:
                 errored=False,
                 complete=False,
                 structured=True,
+                all_deselected_clean=True,  # structured proof: SESSIONFINISH 0 0
             ),
         )
         res = targeted_mod.TargetedTestsStep().run(ctx)
@@ -3721,7 +3778,8 @@ class TestTargetedTestsUntrustedRun:
     def test_run_blocks_exit5_without_deselection(self, ctx_factory, monkeypatch):
         # exit 5 WITHOUT a deselection (empty/renamed file, or a candidate
         # python_files matching nothing) is NOT the benign case — no
-        # "deselected" in the summary → stays blocked (codex #1222 r28).
+        # "deselected" in the summary → stays blocked (codex #1222 r28). Even
+        # with a clean structured proof, the missing "deselected" is what blocks.
         ctx = self._patch_run_pytest(
             monkeypatch,
             ctx_factory,
@@ -3733,11 +3791,60 @@ class TestTargetedTestsUntrustedRun:
                 errored=False,
                 complete=False,
                 structured=True,
+                all_deselected_clean=True,
             ),
         )
         res = targeted_mod.TargetedTestsStep().run(ctx)
         assert res.status == "fail"
         assert "untrusted" in res.summary
+
+    def test_run_blocks_exit5_deselected_but_run_failed(self, ctx_factory, monkeypatch):
+        # codex #1222 r34: a candidate hook could normalize a run that actually
+        # FAILED to exit 5 with a "deselected" summary and steal the benign
+        # skip. Without the structured clean-zero-selection proof
+        # (all_deselected_clean False — the reporter recorded a FAILED, so it is
+        # NOT ``SESSIONFINISH 0 0`` with no failures), the exit-5 skip is denied
+        # and the run BLOCKS.
+        ctx = self._patch_run_pytest(
+            monkeypatch,
+            ctx_factory,
+            targeted_mod._PytestRun(
+                summary="1 failed, 2 deselected in 0.05s",
+                failed=["tests/a.py::test_real"],
+                reran=False,
+                returncode=5,
+                errored=False,
+                complete=False,
+                structured=True,
+                all_deselected_clean=False,
+            ),
+        )
+        res = targeted_mod.TargetedTestsStep().run(ctx)
+        assert res.status == "fail"
+
+    def test_run_blocks_exit5_deselected_without_structured_proof(
+        self, ctx_factory, monkeypatch
+    ):
+        # exit 5 + "deselected" but NO structured proof (reporter didn't run, so
+        # all_deselected_clean is the trusting default False) → the skip is
+        # denied and the run BLOCKS (fails safe). Only a positive
+        # ``SESSIONFINISH 0 0`` earns the non-blocking skip (codex #1222 r34).
+        ctx = self._patch_run_pytest(
+            monkeypatch,
+            ctx_factory,
+            targeted_mod._PytestRun(
+                summary="2 deselected in 0.05s",
+                failed=[],
+                reran=False,
+                returncode=5,
+                errored=False,
+                complete=True,
+                structured=False,
+                all_deselected_clean=False,
+            ),
+        )
+        res = targeted_mod.TargetedTestsStep().run(ctx)
+        assert res.status == "fail"
 
     def test_run_pytest_fallback_scrape_preserves_spaced_param_ids(
         self, tmp_path, monkeypatch


### PR DESCRIPTION
## Why

dev-flow gate proposal item ③ (**flake tracking**) — the trust infrastructure every future hard gate depends on.

Today a single confirmed-flaky test (e.g. the documented G8 `test_subprocess_sighup` signal-timing race, or the GPU-contention `test_batching_improves_throughput`) forces a "rerun the whole PR until it's green" ritual. Once one red is dismissed by rerun, *every* red is suspect and no gate is trusted — which blocks us from adding **more** determinism gates (the whole point of the proposal). This PR makes confirmed flakes **explicit and non-blocking**, and surfaces **new flake candidates** automatically so a human can promote them.

Measure-first, same discipline as #1219 (property) / #1220 (diff-coverage): the gating change is minimal and fail-safe; the new detection step is advisory-only.

## Changes

- **`quarantine.yaml` + `quarantine.py`** — human-curated known-flaky registry (loader + exact / param-family node-id matcher). Seeded with the two confirmed flakes above. The gating loader reads the registry from the **protected base revision** (`git show <base>:scripts/pr_validate/quarantine.yaml`), *not* the candidate checkout — so a PR can't add its own failing test to the allowlist and wave it through.
- **`full_unit` is quarantine-aware** — a failure whose node id is quarantined is reported prominently but does **not** block; a non-quarantined failure still blocks exactly as before. The downgrade is only applied when the red is fully accounted for: pytest **exit code exactly 1**, ≥1 parseable `FAILED` id, and **no `ERROR` entries** (collection/fixture failures). Any abnormal exit (2 interrupted / 3 internal / 4 usage / 5 no-tests) or any `ERROR` blocks unconditionally — we never quarantine what we can't name. A malformed/unreadable registry fails **safe** to an empty quarantine (stricter gate, never looser). The registry is loaded only from the **immutable base commit SHA** (`baseRefOid`, resolved before any candidate code ran) — never the mutable `main` ref — so a candidate test can't `git branch -f main …` between the pytest run and the load to serve its own allowlist; no base SHA → fail **closed** to empty (codex r10 finding 2).
- **`flake_tracking` (new, advisory — never gates)** — reads `full-unit.log`, re-runs only the failed node ids with `pytest-rerunfailures`, and classifies pass-on-rerun as a flake candidate vs reproduced-real, writing `flake-candidates.json`. **The verdict can never depend on it**: every path returns pass/skip, `run()` catches everything and downgrades to skip, and `continue_on_error` stays on. It surfaces **both** quarantine directions for a human: new flake *candidates* to promote, and — loudly (`⚠ REVIEW` at the head of the summary) — a *quarantined* test that stopped flaking and now **reproduces on every re-run**, for a human to de-quarantine ("quarantine graveyard" signal). It does **not** auto-block that case: back-to-back in-process re-runs are correlated, so they can't prove determinism in either direction (a sustained-contention flake fails the whole batch and looks deterministic; an isolated re-run's env differs from the full suite) — deciding it needs independent runs / history (slice 2+), so the call stays human, symmetric with the *adding*-to-quarantine direction (r7 added a hard gate here; r8 reverted it as unsound). Two soundness guards on classification: it runs **only** on a re-run exit code we can interpret (0/1) — an abnormal rerun is inconclusive → skip, never mislabel; and the re-run is launched in **its own session** with the whole process group SIGKILLed on timeout (race-free pre-reap path, mirroring #1220) so a test that spawns an inference server / GPU worker can't leak into later steps. Every quarantined failure is re-run **before** the sample cap applies, so the graveyard-review signal is never dropped. Placed **after every gating step** so a re-run's detached-descendant leak can't contaminate a gate. Skips cleanly if the plugin is absent.
- **`_nodeid_reporter` structured plugin (r10) — the definitive fix for parse ambiguity.** Both `full_unit` and `flake_tracking` need the exact node id of every outcome. Scraping it out of pytest's terminal short-summary (`<LABEL> <nodeid>[ - <message>]`) is *irreducibly* ambiguous — a parametrized node id can itself contain `" - "` and unbalanced brackets (`test_x[a] - b]`, `test_x[a] - b[c]`), and **five** successive patches (r4/r5/r6/r9/r10) each grew a new edge case without ever closing the class. This tiny pytest plugin records pytest's own `report.nodeid` (ground truth, the same string a `quarantine.yaml` entry is written as) to a tab-separated log; the steps read that log for exact ids and fall back to summary scraping only if the plugin can't load. Building it surfaced a real showstopper: a helper named `pytest_*` inside a plugin module is registered as a hook by pluggy and **INTERNALERRORs the whole run** — renamed and now covered by a real-subprocess integration test.
- **Shared `_pytest_summary` parser (fallback).** `summary_node_ids` is now the FALLBACK short-summary parser (used only when the plugin can't load); `report_log_node_ids` reads the structured log. Both are shared by `full_unit` and `flake_tracking` so the two can't drift.
- **`pytest-rerunfailures`** added to `[test]` and `[dev]` (optional extra; deliberately not in the required-plugin set that `test_env_check` pins).

## Scope / honesty

- Slice 1 is **human-in-the-loop by design** in **both** directions: the advisory step *suggests* quarantine additions (a flake candidate to promote) and *flags* quarantine removals (an allowlisted test that stopped flaking), but a human decides either way. Never auto-quarantine (could hide a real regression) and — after r8 — never auto-de-quarantine either (four correlated in-process re-runs can't distinguish a deterministic regression from a sustained-contention flake). Automating the revocation is slice 2+ (independent runs / history).
- Known limitation: under user-opted `--fail-fast`, a `full_unit` block halts the pipeline before `flake_tracking` runs. Default mode runs it. Documented in the runner comment.

## Test plan

- [x] `tests/test_pr_validate_flake_tracking.py` — 254 tests: shared summary parser (plain / with-message / spaces-in-params / ignores-pre-summary / multi-label / default-label / **requires-padded-banner** / **forged-banner-in-captured-output-ignored**); file loader (missing / malformed / wrong-shape / null-tests / **falsey-non-mapping-root-raises** / **empty-file-is-empty** / optional-field defaults); **base-ref loader** (returns entries via mocked `git show`, absent-at-ref → empty, malformed-at-ref raises, plus one real-git round-trip using per-commit `GIT_AUTHOR_*` env so no global config is touched); matcher (exact / param-family / no-false-prefix / specific-param); partition (order-preserving split, empty registry, param family); quarantine-aware `full_unit` verdict (clean-pass / blocking / all-quarantined-passes-loud / mixed-blocks-shows-both / **ERROR-blocks** / **abnormal-exit-blocks** / unreadable-registry-fails-safe / no-parseable-ids-blocks / **registry-read-from-base-revision**); advisory contract (should_run gates, no-failures skip, plugin-absent skip, never-errors, timeout-skips, **abnormal-rerun-exit-skips**, **positive-outcome classification into candidate/reproduced/inconclusive**); a **real-subprocess flake-vs-real classification** test (fallback path, plugin forced off); the **`_nodeid_reporter` plugin round-trip** (real pytest subprocess against the actual repo root: exact `report.nodeid` captured for pass / call-failure / setup-error / collection-error, a bracket-and-dash param id `test_x[a - b]]` captured **verbatim**, passes-not-logged-without-opt-in, and — **with `--reruns`** — a call-phase *and* a setup-phase fail-then-pass flake each logged PASSED exactly once and never FAILED/ERROR, an always-fail logged FAILED exactly once and never PASSED); **`--no-replace-objects` defeats a `git replace` allowlist injection** (real-git: plant a replace ref → naive `git show` is fooled, the loader is not); **a call-pass/teardown-error node classifies as reproduction, not flake** (FAILED/ERROR precedence); **`log_passes=False` clears an inherited passes-flag**; **`--maxfail=0` overrides a candidate's `-x`/`--maxfail`** so the whole suite always runs; **the downgrade is withheld when the structured log is absent** (a listed test still blocks); **a non-date / non-canonical `added` is rejected**; **exact-match by default vs opt-in `family` both directions** (a new failing param blocks unless `family: true`); **`family` must be a strict boolean**; **candidate addopts/`PYTEST_ADDOPTS` are neutralized** and the marker filter re-applied; **an early-stop banner withholds the downgrade**; and `_run_session` (normal / timeout-bounded / **grandchild-in-group killed**); **`_session_completed` structured completeness proof** (complete / ran≥collected / early-stop / absent-record / duplicate-record / malformed-value / zero-collected); **full_unit hard-truncation (os._exit → no record) + early-stop (ran<collected) + complete-run-downgrade + malformed-record-withheld**; **real-subprocess session-finish round-trips** (complete run → one `ran collected` record, os._exit → no record, `-x` → `ran<collected`); **flake_tracking re-runs ERROR node ids** (structured + fallback); **non-string `reason`/`issue` rejected**; **negative-control scrape parity** (real-subprocess proof that `summary_node_ids` == the reporter's canonical `report.nodeid` for a spaced param id, no-reporter fallback scrape preserves spaced ids, plural-`errors` summary recognized); **r32 teardown-phase rerun** (real-subprocess proof a teardown-phase flake emits an intermediate teardown/rerun — RERUN logged — yet the completing test still counts exactly once `ran==collected==1`; a direct-hook test drives the exact truncated-final-attempt sequence and proves the `outcome != "rerun"` guard keeps it visible as `ran<collected`; autoload-disabled → advisory SKIP with no subprocess launched); **r35: the git binary is pre-resolved to an absolute path (`_GIT` != bare "git"), `git show`'s argv[0] is that pinned `_GIT`, and an end-to-end hostile `git` planted on PATH *after* import is ignored — real git serves the true base blob and the fake's sentinel is never touched**; **r36: the registries are snapshotted at fetch (before candidate code) — `snapshot_quarantine_registries` then `load_quarantine_from_ref` serves the cache with NO post-snapshot git (a poison `subprocess.run` never fires), a snapshotted `QuarantineError` is re-raised (not silently re-read live), a cache miss falls through to a live read, falsy refs are skipped + the snapshot is idempotent, `_GIT is None` fails closed with no subprocess, and `FetchStep` behaviorally wires the snapshot for `[base_sha, head_sha]`; plus `session_completed` rejects `ran > collected` as malformed**.
- [x] Full `pr_validate` test surface green: `pytest -k pr_validate` → **551 passed** (incl. gate pins `-rfE`/`--color=no`, timeout persists drained log, double-timeout reaps child, depth-scan node-id split, unicode-safe registry, quarantined-reproduction is advisory-loud + confirmed-flake-does-not-block + quarantined-always-sampled-past-cap + all-quarantined-past-cap, heartbeat grandchild-containment, registration-after-all-gating-steps, nested-bracket + unmatched-bracket-safe + `] - [`-param-fails-safe + bracket-leading-message-fails-safe cases; **r23: TSV escape/unescape codec round-trip + real-plugin hostile-`pytest_make_parametrize_id` injection proof (`SESSIONFINISH\t9999 1` stays inert), RERUN written per rerun-outcome + full_unit blocks on any RERUN record on both exit paths, `GATING_PYTEST_GUARD` blocks both plugin names, advisory rerun skips on an incomplete session**; **r29: negative-control scrape parity — real-subprocess proof that `summary_node_ids` matches the reporter's canonical `report.nodeid` for a spaced param id, fallback scrape preserves spaced ids, plural-`errors` summary recognized**; **r32: teardown-phase rerun completion guard (`outcome != "rerun"` so an intermediate teardown/rerun no longer inflates `ran`) + `PYTEST_DISABLE_PLUGIN_AUTOLOAD` → advisory SKIP (can't guarantee pytest-asyncio et al.)**).
- [x] Regression: `test_pr_validate_runner.py` (ordering invariants) + `test_pr_validate_test_env.py` (dev ⊇ test) pass with the new dep.
- [x] `ruff check` + `ruff format --check` clean on all changed files.

## codex convergence

- **Round 1** — four BLOCKING findings, all genuine, fixed in `1ba8592b`: self-quarantine integrity (read registry from protected base), ERROR/exit-code accounting, rerun-classification exit-code guard, timeout descendant leak.
- **Round 2** — five findings (4 BLOCKING + 1 nit), all genuine, fixed in `e7422815`: forged-summary injection (anchor the padded banner, take the last), positive-outcome classification (`-rA` PASSED vs mere absence → new `inconclusive` bucket), bounded post-kill drain (can't hang the gate), a stronger group-kill test (grandchild in-group is reaped), and strict registry root (falsey non-mapping raises).
- **Round 3** — two genuine fixes in `3aad752e`: gate pins `-rfE` so ERROR lines are always in the summary (the quarantine downgrade never depends on an implicit pytest default), and the re-run timeout now persists the drained partial output to `flake-rerun.log`. The remaining three (forged summary via a hostile `atexit`; sweeping a normally-exiting run's detached survivor; containing a `setsid`-escaping descendant) are the **macOS-uncontainable residual**, handled by honest scoping rather than unsafe code — see below.
- **Round 4** (codex converged to 1 blocking + 2 nit) — two genuine fixes in `3577ad1b`: the double-timeout drain branch now does a bounded `proc.wait()` to reap the direct child (it's always reapable — we're its parent — unlike an escaping *descendant*), and `summary_node_ids` splits the message only after the final `]` so a param id like `test_x[a - b]` isn't truncated. The last nit (partial output unrecoverable on the double-timeout path) is a CPython limitation — bytes buffered inside a timed-out `communicate()` aren't exposed; the realistic single-timeout path already persists full output.
- **Round 5** — three genuine fixes in `78b9f60e`, including a **regression this diff introduced in r4**: the r4 `rfind("]")` node-id split broke the *common* case where the message contains a bracket (`test_x - AssertionError: [1]`), so it's replaced with a left-to-right bracket-depth scan (correct for both dash-in-param and bracket-in-message, with regression tests); a non-UTF-8 registry now raises `QuarantineError` (fail-safe) instead of an unhandled `UnicodeDecodeError`; and a quarantined test that reproduces on re-run is reported in its own `reproduced_quarantined` bucket instead of being mislabeled "full_unit blocked on these" (full_unit *passed* it).
- **Round 6** (atexit finding dropped) — one genuine fix in `f0567450`: both pytest commands now pass `--color=no` so forced color (`PY_COLORS=1` / inherited `--color=yes`) can't inject ANSI escapes that break summary parsing (verified empirically that `--color=no` overrides `PY_COLORS`). The other finding — an **unmatched** bracket in an explicit param id (`ids=["["]`) — is an irreducible pytest-terminal-format ambiguity that fails **safe** (a mangled id won't match a normal quarantine entry → blocks); a junit-xml rewrite is rejected because its `classname`/`name` split can't be mapped back to a pytest node id unambiguously for class-based / deep-package tests, which would trade this rare safe failure for a common-path matching risk. Documented in `_strip_message`; balanced-nested handled and the unmatched-safe behavior locked by tests.
- **Round 7** — three genuine fixes in `312523a5`: (1) **quarantine graveyard** — a quarantined test that reproduces on every isolated re-run was made a **blocking** `fail`; **later reverted in r8, see below**. (2) **leak isolation** — `FlakeTrackingStep` moved *after* `stress_e2e_bench` (after every gating step) so a re-run's detached-descendant leak on macOS can't contaminate a gate; ordering locked by test. (3) **test bug I introduced** — `test_timeout_kills_grandchild_in_group` used `os.kill(pid, 0)`, which reports a zombie (killed-but-unreaped) grandchild as *alive* → flaky; rewritten with a heartbeat sentinel (the grandchild ticks a counter file every 50ms; after the group kill the test asserts the counter stops advancing, which is what "contained" actually means).
- **Round 8** — four BLOCKING findings that converge on one root critique, resolved in `ff104933` by making `flake_tracking` **fully advisory** (reverting r7's gate). codex correctly showed the r7 hard block is *unsound*: back-to-back, in-process re-runs are **correlated**, so they can't decide the quarantine question in either direction — a genuine environmental flake (the seeded GPU-contention case) fails the whole retry batch under sustained contention and *looks* deterministic (finding 2), while an isolated re-run's order/fixture/resource state differs from the full suite, so a failure deterministic only under full-suite conditions *passes* here and looks flaky (finding 4). With no automated gate, finding 1 (a crash silently waiving a quarantined red) and finding 3 (rerun-final-`PASSED` masking a deterministic-from-clean failure) are both moot — those only bite an *automated verdict*. The quarantine-graveyard case is now surfaced **loudly** (`⚠ REVIEW` at the head of the summary + `reproduced_quarantined` bucket) for a human to de-quarantine — symmetric with the human-in-the-loop *adding* direction; automating revocation is slice 2+ (independent runs/history). Nits: (5) every quarantined failure is now re-run *before* the sample cap so the graveyard signal can't be dropped by the 25-cap; (6) the pyproject "never gates" comment is true again. The only residual is the r6 unmatched-bracket parse ambiguity, already documented and fail-safe.
- **Round 9** — two BLOCKING + one nit, resolved in `99d10cd9` (two fixes, one documented override). (2) **bracket parse mis-waive** — FIXED: a param id containing `] - [` (`test_x[a] - [b]`) makes the inner `]` close bracket-depth early, so a naive split truncates to `test_x[a]`, which could wrongly match a shorter quarantine entry and downgrade a real failure. `_strip_message` now fails **safe** — a candidate split whose message begins with `[` is rejected and the whole line returned (won't match a normal entry → the failure BLOCKS, never mis-waives); r4/r5 common cases unaffected. (3) **cap drops quarantined** (nit) — FIXED: the sample cap now bounds only the non-quarantined remainder, so every quarantined failure is re-run even past the cap. (1) **atexit-forged summary** — DOCUMENTED RESIDUAL / override: an author who forges a summary block from their own in-process `atexit`/`conftest` is out of scope — the gate runs candidate code in-process, so such an author has strictly easier sabotage routes (skip/xfail/delete) and **no** in-process report source is tamper-proof (the same `atexit` rewrites a junit-xml / report-log just as easily); it's defended by the other gates (human review, `codex_review`, `supply_chain`), and the realistic vectors (captured stdout, accidental strings) stay closed by the take-the-last-padded-banner anchor.
- **Round 10** — two BLOCKING + three nits, resolved in `ea5d6c60`. The r9 bracket **fix itself had a hole** (`test_x[a] - b]`, suffix not starting with `[`, still mis-splits) — and codex's *own* suggested patch had a further hole. Five edge cases (r4/r5/r6/r9/r10) is the proof that no text rule can split id-from-message: the honest fix is to stop parsing text. **(1) Structured node-id reporter** — new `_nodeid_reporter.py` pytest plugin records pytest's exact `report.nodeid` for every outcome to a TSV; `full_unit` + `flake_tracking` read that and fall back to summary scraping only if the plugin can't load. Caught a real showstopper building it: a `pytest_*`-named helper in a plugin module is treated as a hook by pluggy and INTERNALERRORs the run — renamed to `build_invocation`, now covered by a real-subprocess integration test that also verifies a bracket/dash-laden param id round-trips verbatim. **(2) Immutable base SHA** (finding 2, security) — `full_unit` ran candidate pytest *before* loading the allowlist; using the mutable `main` ref let a candidate `git branch -f main <malicious>` in between and serve its own quarantine. Now pinned to `ctx.base_sha` only; no SHA → fail **closed**. **Nits, all fixed:** (3) git-show errors are classified — only a confirmed missing path → empty, every other failure (bad ref / timeout / git absent / non-UTF-8) raises so the caller fails safe *and* reports it; (4) `reason` + `added` are now **mandatory** audit fields so a bare `{id: …}` can't slip onto the allowlist without a paper trail (`issue` stays optional); (5) truncation message reworded. **Residual (finding 1, override):** a hostile in-process author could rewrite the TSV via `atexit`/`conftest` — but nothing in-process is tamper-proof (junit-xml included), such an author has strictly easier routes, and the other gates defend that surface. Scoped in the plugin docstring, not a blocker (same standing override as r9's atexit finding).
- **Round 11** — one BLOCKING (rebutted with evidence) + one nit (fixed), in `e1f0f748`. **(1) BLOCKING claim: the reporter double-logs a fail-then-pass under `--reruns` (appears in both `PASSED` and `FAILED`) → classified as flake AND reproduction.** This mechanism does **not** exist: `pytest-rerunfailures` marks each retried attempt `outcome=="rerun"`, and the plugin keys on `outcome=="failed"`/`"passed"` (the ERROR branch fires on `report.failed`, i.e. `outcome=="failed"`), so intermediate attempts are excluded **by construction** — verified empirically for both a **call-phase** and a **setup-phase** fail-then-pass flake (each logs one `PASSED`, no `FAILED`/`ERROR`). codex's *requested test* was worth adding regardless, and is now committed: `test_reruns_log_only_terminal_outcome` drives a real `--reruns=3` subprocess over a call-flake, a setup-flake and an always-fail test and asserts exactly-once terminal outcomes — locking the behavior against a future rerunfailures change and standing as committed evidence the finding doesn't reproduce. No production code changed (there was no defect). **(2) NIT — fixed:** the `test_batching_improves_throughput` quarantine rationale said "~6×" while citing 382–697 tok/s (~1.8×); corrected to ~1.8× so the audit paper trail is accurate (the point of the mandatory `reason` field from r10).
- **Round 12** — two BLOCKING + one nit, all genuine, all fixed in `7effa6e8`. **(1) BLOCKING (security): `git replace` TOCTOU.** Pinning the immutable base SHA (r10) is necessary but not sufficient — `git show <sha>:…` still honors local `refs/replace/*`, so a candidate test that ran earlier in the pipeline could `git replace <base_sha> <attacker-commit>` and make the loader serve its own allowlist despite the pinned SHA. Verified empirically (post-`git replace`, a naive `git show` returns the attacker blob; `--no-replace-objects` returns the true base). Fixed at `load_quarantine_from_ref` with `git --no-replace-objects`, covering both call sites in one change and **closing the git-after-candidate-code TOCTOU class**: the SHA is content-addressed, replace refs are ignored, grafts/alternates can't override an existing object's content, and the mutable branch ref was already dropped in r10. **(2) BLOCKING: phase double-log.** The structured reporter emits one line per pytest *phase*, so a test whose call PASSES but whose teardown ERRORs produced both a `PASSED` and an `ERROR` line for the same id → classified as flake candidate AND reproduction at once. Verified empirically. Fixed by giving FAILED/ERROR **precedence** (`candidates = passed − still_bad`), so a run that ended badly in any phase is a reproduction, never a candidate — the three buckets are now disjoint. **(3) NIT — fixed:** `build_invocation(log_passes=False)` now *pops* an inherited `PR_VALIDATE_NODEID_LOG_PASSES=1` so the full suite can't unexpectedly log all ~14k passes. Three new regression tests (real-git replace-ref, teardown-precedence, inherited-flag).
- **Round 13** — four BLOCKING + one nit; **three genuine (fixed)**, **two re-raise settled decisions (documented overrides)**, in `2bf5ef55`. **FIXED (blocking): `-x`/`--maxfail` truncation.** A candidate's `pytest.ini`/`pyproject` addopts could carry `-x`/`--maxfail=1` and stop the suite after one quarantined failure, so the partial (regression-hiding) run is accepted green. Append `--maxfail=0` (no limit) — a trailing command-line maxfail overrides the prepended ini one (verified empirically). **FIXED (blocking): downgrade could rest on the ambiguous fallback.** The quarantine downgrade (turns a red green) could use the summary-fallback ids when the structured reporter log is absent — and a candidate can disable the plugin via pytest config — whose documented id/message split edge cases could truncate a param id and wrongly match a family entry, waiving a real failure. The downgrade now **requires** the structured log: no log → every failure blocks (fallback ids used only to report which). The ambiguous parser is out of the gating path entirely (it survives only in advisory `flake_tracking`, where a mis-split is a mislabeled advisory). **FIXED (nit): `added` date now validated** via `date.fromisoformat` + canonical round-trip, rejecting garbage/non-padded/out-of-range so the audit trail can't silently rot. **OVERRIDE (blocking): "quarantine defeats the gate for the seeded tests; retain a block until independent history."** This is the *approved feature*, not a defect — slice-1 is human-in-the-loop by design (a human confirms flakiness before listing; the downgrade is loud; the graveyard advisory flags a listed test that starts reproducing). "Don't downgrade without history" **is** slice-2, out of scope, and r8 already proved in-process reruns can't soundly decide it either way — no cheap sound middle ground exists. Accepted, documented trade-off scoped to two human-curated tests. **OVERRIDE (blocking): "reap same-group descendants on normal completion."** The standing macOS-uncontainable residual (r3/r7/r8, #1220): once the group leader is reaped, pgid recycling makes a post-reap `killpg` unsafe (could SIGKILL an unrelated recycled group — an operator service), and macOS has no cgroup/job-object to enumerate a group race-free. `flake_tracking` is *advisory* and runs after every gating step. Documented in the code, not papered over. Four new regression tests (maxfail override, structured-log-gated downgrade, non-date + non-canonical `added`).
- **Round 14** — three BLOCKING; **two genuine (fixed)**, **one the irreducible in-process residual (documented override)**, in `a756b159`. **FIXED (blocking): implicit param-family waive.** A base (no-bracket) entry quarantined *every* parametrization, so a PR could add a new, deterministically-failing param to a listed test and have it waived without a base-reviewed decision. Matching is now **exact by default**; whole-test coverage requires an explicit, reviewed `family: true` (a strict boolean — a truthy string is rejected). Exact-by-default fails safe (a new failing case blocks); the two seeded tests aren't parametrized, so no migration. **FIXED (blocking): `--stepwise` early-stop.** `--maxfail=0` (r13) does *not* stop `--stepwise`, which a candidate could plant in `pytest.ini` addopts / `PYTEST_ADDOPTS` to halt the suite after one quarantined failure. Close the class: `-o addopts=` drops the ini addopts wholesale and `PYTEST_ADDOPTS` is stripped from the subprocess env (it bites through `-o addopts=`), neutralizing any planted `-x`/`--maxfail`/`--stepwise`/`-p no:<reporter>`/weaponized `-m`; the gate re-applies its **own** marker filter. Plus a **completion check**: an early-stop banner (`stopping after` / `Interrupted:`) — e.g. a conftest setting `--stepwise` programmatically — means the suite is incomplete, so the downgrade is withheld and every failure blocks. All verified empirically. **OVERRIDE (blocking): "a conftest can overwrite the structured TSV during `pytest_sessionfinish` and swap a real failure for a quarantined id."** This is the irreducible in-process hostile-author residual codex itself scoped out in r6/r9: the gate runs candidate code in-process, so no in-process report source (TSV, junit-xml, report-log, terminal summary) is tamper-proof; such an author has strictly easier routes (skip/xfail/delete), the forging conftest is itself visible in the diff and caught by `codex_review`/human review, and there is no out-of-process per-test oracle short of sandboxing every test. Documented in the plugin docstring; defended by the other gates. Seven new regression tests (exact-vs-family both directions, `family` parse + strict-boolean, addopts/env neutralization, early-stop withholding).
- **Round 15** — two BLOCKING + two nits, **all genuine, all fixed** in `7feeca52`. The two blockings both hit the r14 `_stopped_early` **stdout heuristic**, and — like r10's summary-parse whack-a-mole — the honest fix is to stop parsing text and use a **structured record**. **(B1) `os._exit(1)` truncation.** A test calling `os._exit(1)` kills the process mid-suite with exit code `1` and **no banner**, so a quarantined-only failure passed the gate on an incomplete run (a later regression may never have run). **(B2) heuristic false-positive.** The bare `"stopping after"` / `"Interrupted:"` substring search matched those words appearing in a *quarantined test's own traceback / captured output*, wrongly **blocking** a documented flake. Both closed by a **structured session-completion record**: the `_nodeid_reporter` plugin now writes one `SESSIONFINISH\t<ran> <collected>` line from `pytest_sessionfinish`, and `full_unit._session_completed` requires exactly that record with `ran >= collected` before any downgrade — an **absent** record catches hard truncation (`os._exit`/crash/SIGKILL never reach `sessionfinish`), and `ran < collected` catches every early stop (`-x` / hit `--maxfail` / `--stepwise`). `_stopped_early` and its stdout parsing are **deleted**. Verified empirically that `sessionfinish` fires on `-x`/`--stepwise` (graceful) but never on `os._exit`, and that ran-vs-collected distinguishes each early-stop mode from a `-m`-deselection-reduced complete run. **(NIT) advisory missed ERROR flakes.** `flake_tracking` read only `FAILED` records, so a setup/teardown/collection flake (recorded as `ERROR`) was reported as "nothing to classify" and never re-run — now reads `FAILED` + `ERROR` on both the structured and fallback paths. **(NIT) `reason` type coercion.** `reason` was `str(...)`-coerced, so `reason: [foo, bar]` became a bogus `"['foo', 'bar']"` rationale that satisfied the mandatory non-empty check — a new `_audit_string` requires `reason`/`issue` to be actual strings. Seventeen new tests (session-completeness unit matrix, full_unit hard-truncation / early-stop / complete-downgrade / malformed-record, real-subprocess session-record round-trips, ERROR advisory on both paths, non-string reason/issue).
- **Round 16** — two BLOCKING + two nits, **all genuine, all fixed** in `775402c0` — follow-ups hardening the r15 completion-record mechanism itself. **(B1) exit-0 path skipped the completeness check.** `_session_completed` guarded only the *failure* path, so `os._exit(0)` could terminate pytest with code 0 after skipping the rest of the suite and still produce a green gate (a regression in the un-run tail hidden). The exit-0 fast path now **also** requires the completion record when the reporter ran — an absent record / a `ran<collected` gap blocks; if the plugin couldn't be injected at all (no structured log) it falls back to the exit code (the degraded, non-candidate path). **(B2) setup-count inflation under `--reruns`.** `_ran_tests` counted setup *reports*, and `pytest-rerunfailures` emits several setups for the same id, so retries could inflate `ran >= collected` and mask an early-stopped suite. Now counts **distinct attempted node ids** (a set) vs collected — verified empirically that `--reruns=3` over a flaky test yields 5 setups but 3 distinct == 3 collected. **(NIT) advisory rerun not hermetic.** Unlike `full_unit`, the `flake_tracking` re-run inherited candidate `addopts` / `PYTEST_ADDOPTS`, so `--collect-only` / a marker filter / `-p no:<reporter>` could suppress classification — now `-o addopts=` + `PYTEST_ADDOPTS` stripped (repo addopts is empty and the re-run targets explicit node ids, so no marker re-apply needed). **(NIT) identical-duplicate completion records.** `_session_completed` read the record via `report_log_node_ids`, which dedups by value, so two *identical* `SESSIONFINISH\t50 50` lines collapsed to one and passed the "exactly one" rule — now reads **raw** value lines (`_raw_session_records`) and rejects any duplicate. Seven new tests (exit-0 completeness in four modes, identical-duplicate rejection, real-subprocess `--reruns`-no-inflation, hermetic-rerun addopts/env).
- **Round 17** — one BLOCKING + one nit, **both genuine, both fixed** in `3798439b`. **(B1) the exit-0 completeness check had a hole in how it detected "was the reporter injected".** `structured = nodeid_log.exists()` is False when `os._exit(0)` kills pytest *before the first append* — the reporter creates the log only on the first outcome / `SESSIONFINISH` — so an injected-but-truncated run was misread as "plugin unavailable" and its zero exit trusted on a fully-truncated suite. Fixed by deciding `structured` from `_nodeid_reporter.available()` at injection time and **pre-creating the log as a start sentinel** (`write_text("")`) right after injecting, so the file's existence is decoupled from whether any record was appended — an injected run with an empty/record-less log now yields no completion record → withhold, never "unavailable → trust exit code". Added a real-subprocess regression test proving the plugin writes nothing when a conftest `os._exit(0)` fires at collection (so the sentinel must live in `full_unit`, not the plugin), plus a `full_unit` test with the mock writing nothing at all. **(NIT) recovered collection flakes were mislabeled.** A collection-error id is a MODULE / DIR path (no `::`); on a clean re-run its *contained* tests log `PASSED` under their own `::` ids while the target id never logs a `PASSED`, so a recovered collection flake fell through to `inconclusive` forever. New `_is_collection_target`: a collection target absent from `still_bad` (didn't re-error) is now a recovered flake candidate; one that re-errors still reproduces (badness keeps precedence). Four new tests (clean-exit-injected-but-no-output, real-subprocess no-log-on-hard-exit-zero, collection-flake recovered→candidate + reproduced→not-candidate).
- **Round 18** — zero blocking (MERGE-SAFE) + four nits, **all genuine accuracy fixes to my own r15/r17 additions, all fixed** in `f2fdf269`. **(1) ERROR-origin flakes were recommended for a quarantine that can't work.** `full_unit` blocks *any* run containing an ERROR unconditionally (it never quarantines what it couldn't complete), so promoting a setup/teardown/collection flake to `quarantine.yaml` is ineffective — the entry can never waive an ERROR run. The read is now split `FAILED`-only vs `ERROR`-only; an id seen *only* as ERROR is tracked as `error_origin` and a recovered one is routed to a dedicated **"investigate, NOT quarantinable"** bucket (`error_flake_candidates`) instead of the promote-me bucket. **(2) collection-target recovery now needs positive evidence.** r17 treated a collection target's mere *absence from re-error* as recovery; a module that collected nothing or only skipped isn't a proven flake. `_recovered` now requires a contained test to have actually `PASSED` (`p.startswith(id + "::")`), same positive-outcome bar as any other id. **(3) `load_quarantine` OSError contract.** A present-but-unreadable registry (permissions / I/O / TOCTOU vanish after the `exists()` check) raised a raw `OSError`, but the docstring promises `QuarantineError` for a present-but-unusable registry, so a caller catching only that would crash — now mapped to `QuarantineError`, fail-safe to empty. **(4) `-p pytest_rerunfailures` regression I introduced mid-r18.** Adding the explicit `-p` *unconditionally* crashes the advisory re-run whenever autoload is ON (the normal pipeline): pluggy raises "Plugin already registered under a different name" because the entry-point name (`rerunfailures`) ≠ the module name (`pytest_rerunfailures`). The explicit load is now gated on `PYTEST_DISABLE_PLUGIN_AUTOLOAD` actually being set — the only case where autoload wouldn't self-register it. Five new tests (error-origin→not-quarantinable bucket, positive-evidence collection recovery, unreadable-registry→QuarantineError, explicit-load-only-when-autoload-disabled + absent-when-autoload-on regression guard).
- **Round 19** — zero blocking (MERGE-SAFE) + two nits, **both genuine mislabels in my own r18 additions, both fixed** in `ae3e79ca`. **(1) error-origin excluded FAILED+ERROR ids.** r18 computed `error_origin` as ids seen *only* as ERROR (`i not in failed_set`), so an id whose call FAILED and whose teardown ERRORed — present under both FAILED and ERROR — was routed to the quarantinable `flake_candidates_new` bucket. But `full_unit` blocks *any* run containing an ERROR unconditionally, so that id is un-waivable; `error_origin` is now **every** id that logged an ERROR in any phase, landing it in the "investigate, NOT quarantinable" bucket. **(2) directory-collection recovery never matched.** `_recovered` accepted a passed descendant only at the `::` boundary (`i + "::"`), correct for a MODULE target (`tests/test_x.py::test_y`) but never for a DIRECTORY target (`tests/subdir`, whose tests are `tests/subdir/test_x.py::test_y`) — leaving genuine directory-collection flakes permanently `inconclusive`. Now accepts a passed descendant at **either** the `::` or the `/` boundary; the required separator prevents a sibling-prefix false match (`tests/foo.py` is not a descendant of dir `tests/foo`). Three new tests (call-fail+teardown-error → not quarantinable, directory-collection recovery via `/` boundary, sibling-prefix non-recovery guard).
- **Round 20** — three BLOCKING; **two genuine (fixed)**, **one the documented macOS-uncontainable residual (override)**, in `4724cadf`. **FIXED (blocking, gate integrity): `pytest-rerunfailures` autoloaded into the gating run.** This PR adds rerunfailures to the `[test]` extra for the advisory step, but it autoloads by entry point — so a candidate could tag a genuinely failing test `@pytest.mark.flaky(reruns=N)` (or set reruns via a conftest) and have the GATING `full_unit` **re-run and pass it** to exit 0 without ever consulting the protected quarantine, defeating the gate. `-o addopts=` / `PYTEST_ADDOPTS`-strip can't stop an autoloaded plugin — `full_unit` now blocks it by registered name (`-p no:rerunfailures`). Verified empirically the block makes the flaky mark inert (the test fails as it should) and is a harmless no-op when the plugin is absent; `flake_tracking` re-enables reruns only for its own post-gating advisory. **FIXED (blocking, completeness soundness): completion counted on `setup`, not `teardown`.** The `_nodeid_reporter` recorded an item as "ran" the moment its `setup` report arrived, so a test calling `pytest.exit(returncode=0)` from its **call body** — after its own setup but before finishing — left `ran == collected`, and `full_unit` accepted the truncated run (every later item skipped) as green. Now counts the **teardown** (terminal) report: an item that exits mid-call emits no teardown (verified empirically), so `ran < collected` and the downgrade is withheld. Verified skip / skipif / xfail / xpass / runtime-skip / setup-ERROR / teardown-ERROR all still emit a teardown (a legitimately complete run stays item-for-item), and the `-x` / `-m`-deselection invariants are preserved. **OVERRIDE (blocking): "`_run_session` cleans the process group only on timeout, so a normally-exiting descendant leaks."** This is the macOS-uncontainable residual settled in r3/r7/r8/r13: once pytest is reaped its pgid can be recycled, so a post-reap `killpg` could SIGKILL an unrelated operator service, and a `setsid`-escaping descendant has no portable containment on macOS (no cgroup/job-object). It is the **advisory** step (runs after every gating step), the same clean-exit leak **#1220 already accepted for the stronger gating path**, and the flake sample is drawn only from `full_unit` **unit-test** failures (integrations are `--ignore`d + `-m "not integration"`), so the inference-server/GPU-worker scenario can't enter the sample. Documented in `_run_session` + the module docstring, not papered over. Two new tests (gate blocks rerunfailures; real-subprocess mid-call `pytest.exit` records a `ran<collected` gap).
- **Round 21** — three BLOCKING + one nit, **all four genuine, all fixed** in `10c70b33` (codex did NOT re-raise the r20 macOS residual — it found new, real issues). **FIXED (blocking): rerunfailures block was incomplete.** r20 disabled rerunfailures only in `full_unit`, but `targeted_tests` also runs candidate tests — a `@pytest.mark.flaky` on a changed file could rerun-and-pass a real failure there. Hoisted the block into a shared `base.GATING_PYTEST_GUARD` used by **both** gating pytest cmds, pinned by an invariant test so a future gating step can't silently forget it (global autoload-disable rejected — it would also drop pytest-asyncio etc. the gates need). **FIXED (blocking): exit-0 path trusted the code over the records.** The clean-exit branch checked completeness but never the structured FAILED/ERROR log, so a conftest / exit-code plugin that normalizes a failing run to exit 0 (e.g. `pytest_sessionfinish` setting `session.exitstatus = 0`) passed despite recorded failures. On a structured run the log — not the exit code — is now the source of truth: a clean exit whose log carries FAILED/ERROR ids blocks and grants no downgrade (a real green records zero — xfail logs as skipped, xfail_strict xpass exits non-zero — so it never misfires). **FIXED (blocking): base-only registry ignored candidate removals.** Reading quarantine coverage only from the protected base meant a de-quarantine PR could pass while the REMOVED test still failed, merging a regression alongside the removal. New `effective_quarantine(base, candidate)` = the **intersection**: an id is effective only if BOTH list it (removal → the still-red test blocks), a candidate ADD is ignored (no self-quarantine), and breadth is the narrower of the two (candidate may tighten family→exact, never widen). The result is always ⊆ base, so a hostile candidate registry can only make the gate stricter; the candidate side is read from the pinned PR HEAD sha (same `--no-replace-objects` path as base, immune to runtime working-tree mutation), and a PR that deletes `quarantine.yaml` → candidate empty → the correct strict de-quarantine-all. **FIXED (nit): duplicate YAML keys silently last-won.** `yaml.safe_load` kept the last value for a duplicated `id` / `family` / top-level `tests`, letting a duplicate invisibly override a reviewer-approved value; a strict `SafeLoader` subclass now rejects duplicate keys at every mapping level. 15 new tests (gating-guard invariant across both cmds, forged exit-0 blocks, de-quarantine removal blocks / kept-in-both waived / candidate-add ignored, `effective_quarantine` unit matrix incl. widen-rejected + subset-of-base + audit-preserved, duplicate entry/top-level key rejected).
- **Round 22** — one BLOCKING + two nits, **all three genuine follow-ups on the r21 additions, all fixed** in `fbd1ed62`. **FIXED (blocking): the r21 fallback re-opened the removal hole.** When the candidate revision couldn't be read/validated, r21 fell back to the BASE registry — but a candidate CONTROLS its own committed `quarantine.yaml`, so it could keep a base-quarantined but now-failing test green by simply corrupting/deleting its own registry. `full_unit` now fails **CLOSED** to an empty effective quarantine whenever the candidate can't be confirmed (missing head sha / malformed candidate blob) → every failure blocks, the same posture as a missing base sha. **FIXED (nit): advisory used base-only.** `flake_tracking` now classifies against the same `effective_quarantine(base, candidate)` intersection `full_unit` enforces (base sha + pinned head sha) — base-only would label a de-quarantined failure "known-flaky" (rode along) when `full_unit` actually BLOCKED it, so the advisory contradicted the gate. Any unread side → empty, matching the gate's fail-closed direction. **FIXED (nit): unhashable YAML key crashed.** `_UniqueKeySafeLoader.construct_mapping` now catches the `TypeError` a complex (list / mapping) YAML key raises on `key in seen` and converts it to a `ConstructorError` → `QuarantineError`, so the gating caller fails safe instead of crashing. 5 new/updated tests (malformed-candidate + missing-head-sha fail closed, unhashable-key → QuarantineError, de-quarantined flake classified against the intersection, both-pinned-reads).

- **Round 23** — three BLOCKING, **all three genuine defects in my own r18-r22 code, all empirically confirmed and fixed** in `5bf68848`. **FIXED (blocking): control-char injection into the node-id log.** The reporter wrote `<LABEL>\t<nodeid>\n` **raw**, but a hostile `pytest_make_parametrize_id` can return a param id containing a literal `\n`/`\t` — verified end-to-end: the id `evil\nSESSIONFINISH\t9999 1` reaches `report.nodeid` intact and, written raw, would forge a **second** record (a fake `SESSIONFINISH` masking a truncated run, or a fake `PASSED` faking a recovery in the advisory step). Every value field is now `escape_field`-encoded on write (backslash, tab, newline, CR) and `unescape_field`-decoded on read, so each record occupies exactly one physical line with no injectable delimiter; a real-plugin test proves the injected `SESSIONFINISH\t9999 1` stays inert inside the FAILED value (still exactly one genuine completion record). **FIXED (blocking): the rerunfailures block was bypassable by an arbitrary name.** `GATING_PYTEST_GUARD` disabled the plugin only by its registered *name* (`-p no:rerunfailures`), but a conftest can re-register the same module under an **arbitrary** name — verified: `config.pluginmanager.register(mod, name="smuggled")` + a `@pytest.mark.flaky` marker (no `--reruns`) still reruns (`1 passed, 1 rerun`), so a real failure could be retried to green. Added a **name-independent** backstop: the reporter logs a `RERUN` record on any `report.outcome == "rerun"`, and `full_unit` blocks if **any** RERUN record is present (a gating run must never rerun), on both the exit-0 and non-zero paths — plus the module name `no:pytest_rerunfailures` is now blocked as the cheap first line. **FIXED (blocking): the advisory rerun didn't prove completeness.** `flake_tracking` classified the structured rerun without checking it ran to completion, so a rerun truncated mid-flight (a sampled test's `pytest.exit`/`os._exit`) with a partial PASSED/FAILED set could mislabel an id whose real reproduction was in the un-run tail as a recovered flake and recommend it for promotion. It now requires the reporter's session-finish record (the **same** `session_completed` proof `full_unit` uses for the gate) before trusting the classification, else skips. **Refactor:** `session_completed`/`raw_session_records` moved into the shared `_pytest_summary` (re-exported in `full_unit`) so the gate and the advisory can't drift on one completeness definition. 18 new tests (escape/unescape codec incl. escaped-backslash-doesn't-pair + unknown-escape-preserved + reader-not-fooled-by-injected-value, real-plugin hostile-param-id injection proof, RERUN written-per-outcome + full_unit blocks on RERUN on both exit paths + both-names-blocked, advisory-skips-on-incomplete-rerun).

- **Round 24** — three BLOCKING + two nits, **all five genuine follow-ups on the r23 additions, all fixed** in `d691cd19`. **FIXED (blocking): the RERUN backstop was missing from `targeted_tests`.** r23 added the name-independent RERUN backstop to `full_unit` only, but `targeted_tests` is ALSO a gating run — and for a low-blast PR (where `full_unit` is skipped) it's the ONLY gating run of candidate tests. A conftest could smuggle `pytest-rerunfailures` under an arbitrary name and rerun a real failure to green there with nothing to catch it. `targeted_tests` now injects the structured reporter into the PR-branch run and blocks on any `RERUN` record; the negative-control run on the protected base deliberately does NOT inject it (the base predates the plugin module, so `-p …_nodeid_reporter` would be an unloadable usage error). The `rerun_detected` check is hoisted into shared `_pytest_summary` so both gating steps use one definition. **FIXED (blocking): scorecard Markdown spoofing.** Decoded node ids were interpolated RAW into Markdown ``` code fences, but the reporter now permits embedded newlines/tabs (r23) — so a parametrization id with a newline + backticks could close the fence and spoof scorecard content (`full_unit._render_details`/`_render_unaccounted` + `flake_tracking._render`). All node-id display sinks now render through `render_fence_safe` (JSON string literal → single quoted line, so no embedded newline can begin a fence-closer; non-ASCII preserved). **FIXED (blocking): `load_quarantine` fail-safe hole.** It gated on `path.exists()` OUTSIDE the `OSError` handler, and `Path.exists()` re-raises a `PermissionError` (inaccessible parent dir) instead of swallowing it — so a raw `OSError` escaped the documented `QuarantineError` fail-safe. The read now goes DIRECT: only `FileNotFoundError` → `[]`, every other `OSError` → `QuarantineError`. **FIXED (nit): `reproduced_quarantined` mislabeled error-origin ids.** An ERROR-origin id that was also quarantined and reproduced landed in `reproduced_quarantined` ("full_unit PASSED as quarantined") — false, since `full_unit` BLOCKS any ERROR run regardless of the registry; error-origin reproductions now route to `reproduced_likely_real` (the gate DID block them), matching the r18/r19 error-origin discipline. **FIXED (nit): class-collection targets stayed inconclusive.** `_is_collection_target` assumed a collection-error id lacks `::`, but a CLASS collector reports `tests/x.py::TestClass` (with `::`), so recovered class-collection flakes were permanently inconclusive. The reporter now writes a supplementary `COLLECTERROR` label ALONGSIDE `ERROR` (never instead — `full_unit`'s gate reads ERROR and is untouched, so it can't be weakened), and the classifier recognizes a collection target by the `::`-heuristic OR that structured set. 11 new tests (targeted RERUN detect/block + negative-control-no-inject, `render_fence_safe` codec + both render sinks fence-safe, quarantine `PermissionError` → `QuarantineError`, error-origin reproduction routing, class-collection recovery via `COLLECTERROR`).

- **Round 25** — three BLOCKING + one nit; **two blocking genuine (fixed)**, **one blocking the documented macOS residual (override)**, **one nit genuine (fixed)**, in `af7b3080`. **FIXED (blocking): `targeted_tests` trusted an empty scraped FAILED list.** `_run_pytest` discarded pytest's exit code and returned only the `FAILED` node ids scraped from the short-summary, so a run that produced **no** FAILED line — a collection error (exit 2), a usage error (exit 4), "no tests collected" (exit 5), a setup/teardown/collection `ERROR` (which never appears as a `FAILED` summary line), or an early `pytest.exit(0)` truncation — passed the gate as a false green. `_run_pytest` now returns a `_PytestRun` carrying the real `returncode` plus the structured-reporter signals (`errored`, `complete`), and `run()` rejects any run that isn't an ordinary pass (0) / fail (1), that logged a structured `ERROR`, or that didn't reach the session-finish record **before** trusting an empty FAILED list — the same exit-code / ERROR / completeness discipline `full_unit` already enforces. The legitimate exit-1-with-FAILED path still flows to the negative control unchanged. **FIXED (blocking): candidate-controlled `QuarantineError` text spoofed the scorecard.** When the base or candidate quarantine registry was unreadable, `full_unit` interpolated the exception message **raw** into the scorecard `registry_note`; that message can echo candidate-controlled registry content (a bad node id / reason from the PR's own `quarantine.yaml`, surfaced by `_audit_string`), so a newline + `## heading` could forge a scorecard section out of the note. Both sinks (base-unreadable and candidate-unreadable) now render the message through `render_fence_safe` → a single escaped JSON line, so the text survives for the reader but can never inject a raw newline/heading. **FIXED (nit): locale-fragile git stderr matching.** `load_quarantine_from_ref` distinguished "path absent at this ref" (legitimate → `[]`) from a real error by matching English `git show` stderr fragments (`does not exist in` / `exists on disk, but not in`); under a non-English `LANG` those translate and an absent registry would misclassify as a hard `QuarantineError`. The `git show` subprocess now pins `LC_ALL=C` / `LANG=C` so the match is against git's stable C-locale English. **OVERRIDE (blocking): "`_run_session` cleans the process group only on timeout, so a normally-exiting descendant leaks."** This is the **identical** macOS-uncontainable residual already fixed-as-far-as-portable and overridden in r20 (and accepted for the stronger gating path in #1220): once pytest is reaped its pgid can be recycled, so a post-reap `killpg` could SIGKILL an unrelated operator service, and a `setsid`-escaping descendant has no portable containment on macOS (no cgroup/job object). It is the **advisory** step, its flake sample is drawn only from `full_unit` **unit-test** failures (integrations `--ignore`d + `-m "not integration"`), and it is documented in `_run_session` + the module docstring — see the residual note below. 10 new tests (untrusted-run reason matrix over exit code / ERROR / incompleteness; `run()` blocks on collection-error / exit-1-ERROR / incomplete-session and passes a clean exit-0; `_run_pytest` populates `errored`/`complete`/`returncode`; registry-note single-line sanitization).

- **Round 26** — two BLOCKING, **both genuine follow-ups on the r25 `targeted_tests` hardening, both fixed** in `98d0f5bb`. **FIXED (blocking): the targeted gating run wasn't hermetic against candidate `addopts`.** The PR-side pytest invocation left candidate-controlled `pytest.ini` / `pyproject.toml` `addopts` active, so a planted `--deselect` / weaponized `-m` filter / `-x` / `-rN` could omit the changed failing test while the selected subset exits 0 and satisfies the r25 completeness check — a false green. The shared `_PYTEST_CMD` now pins `-o addopts=` (drops the ini/pyproject addopts wholesale; `PYTEST_ADDOPTS` was already popped in `_run_pytest` because it bites THROUGH `-o addopts=`), and every option the gate relies on is now spelled out explicitly rather than inherited — plus `--color=no` / `-rfE` / `--maxfail=0` so the **negative control** (which runs on the pre-plugin base and so must scrape stdout) reads a stable, ANSI-free, complete FAILED+ERROR summary. Applied to the shared command so the PR run and the base negative control stay symmetric; the repo's own `addopts` is empty, so it's a no-op on the trusted base. This is the same hermeticity `full_unit` (r14/r16) and `flake_tracking` (r16) already enforce. **FIXED (blocking): the targeted `FAILED` set was scraped even when the structured reporter ran.** r25 injected the reporter but still derived `pr.failed` from the stdout short-summary scrape, so an exit-1 run with the summary suppressed (`-rN`) produced an empty scraped list that the `if not pr.failed` pass path accepted as green. `_run_pytest` now reads `FAILED` from the reporter's records when injected (written per failing outcome, un-blankable from candidate config), and `_untrusted_run_reason` additionally rejects an exit-1 with **no** structured `FAILED`/`RERUN` record accounting for it (a suppressed-summary run is not trusted). A new `structured` field on `_PytestRun` gates the reporter-derived checks so the degraded no-reporter path keeps its prior behavior. 5 new tests (unaccounted-exit-1 reason + structured-only guard, `run()` blocks on an unaccounted exit-1, `-o addopts=` present on the gating command, `_run_pytest` surfaces the structured FAILED when the stdout summary is blank).

- **Round 27** — two BLOCKING + one nit; **one nit genuine (fixed)**, **one blocking rebutted with committed evidence (codex's mechanism is empirically false)**, **one blocking documented as the in-process-author residual (override)** — plus **two r26 regressions I found while investigating and fixed**, in `2bb9f481`. **FIXED (nit → real correctness): family matching broke under a bracket-named directory.** `node_id_matches` disabled `family: true` whenever the WHOLE node id contained `[`, so a test at `tests/models/[legacy]/test_x.py::test_y` could never use documented family coverage (the `[` is in the *path*, not a param suffix). New `_has_param_suffix` inspects only the final `::` component, where a parametrization bracket actually lives. **FIXED (r26 regression — dropped marker exclusion):** the repo's `addopts` is **not** empty — it carries `-m "not slow and not integration and not needle"`. r26's `-o addopts=` (added for hermeticity) silently dropped that, so `targeted_tests` would begin running slow/integration/needle tests it used to inherit-exclude (each needs real models / a live server). Re-applied the exclusion hardcoded on `_PYTEST_CMD`, exactly as `full_unit` does. **FIXED (r26 regression — "exit 0" summary):** dropping the inherited `-v` put pytest in bar-less quiet mode, so `_last_summary_line`'s `startswith("=")` rule missed the counts line and the step summary degraded to a bare "exit 0". Anchored the parser on the `<n> <outcome> … in <t>s` shape so both fenced and bar-less forms parse (verified end-to-end: `6 passed in 0.55s`). **REBUTTED (blocking, evidence): "a strict-xfail XPASS is logged FAILED and, if quarantined, wrongly accepted — detect `report.wasxfail`."** A committed real-subprocess test proves the premise **empirically false**: a strict XPASS report has `outcome=='failed'` but **no** `wasxfail` (only the *non-strict* xpass and the as-expected xfail carry it), so the proposed detection can't fire. The scenario is also not attacker-reachable (the allowlist is base-protected — candidates can't add) and self-contradictory (a flaky/quarantined test that is *also* `xfail(strict=True)`). No code change; the behavior is locked as evidence. **OVERRIDE (blocking, in-process-author residual): "`session_completed` only proves the SELECTED items finished, so candidate `python_files`/`norecursedirs`/collection hooks can reduce `tests/` to a few passing tests and still show `ran==collected`."** True, and it's the in-process-author residual: a base-derived count/manifest cross-check is defeated by **surgical** deselection from the *same* in-process access (`collected` drops by exactly 1, under any ratio floor) or by id reparametrization, so it would advertise a completeness it can't deliver — and a candidate with commit access to shared test infrastructure has strictly easier sabotage routes (a fixture monkeypatching the code under test; an `atexit` forging this very record). Documented precisely in the `session_completed` docstring + the residual note below, rather than shipping a guard we can't keep (see G8). 7 new tests (family under a bracket dir + final-component gate + `_has_param_suffix` unit; targeted re-applies the `-m` exclusion; bar-less/fenced summary parsing; strict-XPASS real-subprocess rebuttal).

- **Round 28** — two BLOCKING + one nit, **all three genuine follow-ups on the r23/r27 hardening, all fixed** in `7c21f6cf`. **FIXED (blocking): the r23 escape codec missed Unicode line separators.** `escape_field` escaped only `\t`/`\n`/`\r`, but `str.splitlines()` — which the log readers (`report_log_node_ids`, `raw_session_records`) use — also splits on `U+000B`/`000C`/`001C`/`001D`/`001E`/`0085`/`2028`/`2029`, so a hostile parametrization id embedding any of those would still forge a second record (a fake `SESSIONFINISH`/`PASSED`) — the r23 injection channel via a separator the original escape missed (empirically verified: each split a value into two records). `escape_field` now encodes every extra `splitlines()` separator as a `\uXXXX` escape (backslash-first, so no collision), and `unescape_field` decodes `\uXXXX` (four hex digits, else preserved verbatim) — verified all eight now yield a single "line" under **both** `splitlines()` and `split("\n")` and round-trip losslessly, plus an end-to-end U+2028 injection stays inert through the real writer/reader. **FIXED (blocking): a PR touching only slow/integration/needle tests failed validation.** The r27 `-m "not slow and not integration and not needle"` re-apply (itself a fix for the r26 dropped-exclusion regression) created a new case: when every targeted test is deselected by the gate-owned filter, pytest exits 5, and r25's `_untrusted_run_reason` blocked exit 5 as an "abnormal exit" — a false block. `targeted_tests` now **SKIPs** on exit 5 when pytest's own summary reports a deselection and there's no structured `ERROR` (nothing gate-relevant remained to run); a no-collection run **without** a deselection (an empty/renamed file, or a candidate `python_files` matching nothing) stays **blocked**. The "deselected" signal is pytest's own output — candidate addopts is neutralized and the `-m` is gate-owned, so it can't be forged (a conftest that deselects everything is the documented collection residual, and `full_unit` runs the whole suite regardless). Verified end-to-end (exit 5, `2 deselected in 0.09s`, skip engaged). **FIXED (nit): `full_unit` kept its own `_last_summary_line`** still requiring an `=`-prefix, so it hit the same bar-less quiet-mode gap the r27 targeted fix closed. Moved the robust bar-less/fenced parser to `_pytest_summary.last_summary_line` and imported it in **both** steps — one definition, can't drift (the same DRY discipline as `session_completed`). 5 new tests (all-splitlines-separator neutralization + end-to-end U+2028 injection-inert + malformed `\u` preserved; exit-5 all-deselected SKIP + exit-5 without-deselection still BLOCKS; shared parser recognizes a bar-less deselected summary).
- **Round 29** — one BLOCKING + one nit, **both genuine follow-ups on the r26 canonical-id switch, both fixed** in `aa637702`. **FIXED (blocking): the negative control truncated spaced param ids.** r26 made the PR side record pytest's canonical `report.nodeid` via the reporter, but the base negative control (`_run_on_main`) — and the no-reporter fallback in `_run_pytest` — still scraped stdout with `^FAILED\s+(\S+)`, which stops at the first whitespace. A pre-existing failure whose param id contains spaces, `test_x[param with spaces]`, was truncated to `test_x[param` on base, so the full PR-side canonical id no longer matched the base set → `set(pr_failed) - set(main_failed)` classified the pre-existing failure as a **PR-only regression** → false block. Both scrape paths now parse with the shared **space-preserving** `summary_node_ids`, so base ids match the PR-side canonical ids exactly (proven end-to-end: a real pytest run of a spaced-param failure yields `report.nodeid == summary_node_ids(stdout)`). The now-dead `_FAIL_RE`/`_extract_failed_node_ids` and the unused `re` import were removed. **FIXED (nit): plural `errors` summary degraded to "exit 2".** `_SUMMARY_COUNTS_RE` matched singular `error` but not pytest's plural `errors` (`\berror\b` can't match "errors"), so an error-only run summary (`2 errors in 0.10s`) failed to parse and the step summary fell back to a bare `exit 2`; now matches `errors?`. 3 new tests (real-subprocess negative-control scrape parity for a spaced param id; fallback scrape preserves spaced ids; plural-`errors` summary recognized).
- **Round 30** — three BLOCKING (codex's diff was **truncated — 1 file unreviewed**); **one genuine (fixed)**, **two overrides with honest documentation + fail-safe proof**, in `4f99e173`. **FIXED (blocking): targeted node-id sinks weren't fence-safe.** `_failed_block` and the raw `details.extend(regressions/pre_existing)` emitted node ids verbatim into the scorecard ``` fence. Since r26 targeted surfaces **canonical** reporter ids, which a hostile `pytest_make_parametrize_id` can load with a newline + triple backticks (r23) — the exact fence-escape spoof r24 closed for `full_unit`/`flake_tracking`, newly reachable in targeted once it switched off the `\S+` scrape. All targeted node-id display sinks now render through `render_fence_safe` (JSON-quoted single line; no embedded newline can begin a fence-closer). **OVERRIDE (blocking — codex's proposed fix is BACKWARDS): "exit-5 all-deselected is accepted; block unless base metadata proves the exclusion is pre-existing."** A *newly-added* broken slow test is **absent on base**, so a "did base run it?" check misses **exactly** the dangerous case — while an existing test *legitimately* reclassified as slow WOULD trip it (a false block of routine maintenance). This fast gate also **cannot run** slow/integration/needle tests (they need real models / a live server — the reason they're excluded), so it can't tell a broken new slow test from a legitimately-slow passing one. Moving a test into those markers is a **uniform repo policy** (`full_unit` excludes the same markers), owned by the separate slow-lane CI (`-m slow`) + diff review that sees the added marker — **not** this gate. We keep the SKIP (never false-block legit reclassification) but make it **LOUD** (`⚠ REVIEW`, naming the exact concern) so a reviewer confirms intent. Documented as a boundary, not papered over. **OVERRIDE (blocking — fail-safe irreducible-ambiguity residual): "the base negative control's summary parser is ambiguous vs the PR's canonical ids (`test_x[a] - b]`)."** True and **verified** (`summary_node_ids` truncates `test_x[a] - b]` → `test_x[a]`; grabs the message for `test_x[a] - [b]`) — the **same wall that motivated the reporter** (r4/r5/r6/r9/r10: no text rule can split id-from-message). But the base **predates the plugin**, and codex's "canonical on both revisions" would inject the PR checkout's plugin → drag PR **library** code onto the base run's `PYTHONPATH` → contaminate the negative control (base TEST files run against PR code) — a **worse, unsound** bug than the one it fixes. So an ambiguous base id may not match the PR canonical id — which **fails CLOSED** (the pre-existing failure is treated as a regression → **BLOCKS**), **never a false green** (base scrape only ever lists FAILED tests, so a pass-on-base regression is always caught). Documented + proven with a fail-safe test; **honestly corrects the r29 note**, which over-claimed the asymmetry was fully closed — r29 fixed spaces, not the `" - "` ambiguity. 3 new tests (`_failed_block` fence-safe unit + regression-details run-level fence-safe; exit-5 skip asserts `⚠ REVIEW` loudness; ambiguous pre-existing id fails closed → blocks).
- **Round 31** — one BLOCKING + three nits (codex's diff **truncated — 1 file unreviewed**); **two nits genuine (fixed)**, **one nit rebutted with committed evidence**, **the blocking an honest correction of a prior over-claim (override)**, in `32cf918b`. **FIXED (nit → real correctness): strict-xfail XPASS was quarantine-maskable.** A `@pytest.mark.xfail(strict=True)` that unexpectedly passes is pytest's **intentional fatal** (the marker is stale), but the reporter logged it as `FAILED` — so a (mistakenly) quarantined node would **downgrade it to a non-blocking flake**. A strict XPASS carries **no** `report.wasxfail` (the r27 rebuttal stands — codex's wasxfail-detection can't fire) but **does** carry a string `longrepr` `"[XPASS(strict)]…"` (a genuine call failure carries an exception-repr *object*). The reporter now records it as **ERROR** via that clean signal — unconditional block, never quarantinable in `full_unit`, always makes `targeted` untrusted — reusing existing ERROR semantics with no new label and no `full_unit` change. **FIXED (nit): `render_fence_safe` left three Unicode line separators literal.** `json.dumps(ensure_ascii=False)` escapes control chars < U+0020 but leaves U+0085/U+2028/U+2029 **literal**, and `str.splitlines()` (+ some Markdown renderers) treat those as line boundaries — so a hostile id could still begin a fence-closer on a second physical line. Now escapes them as `\uXXXX` (valid JSON → still round-trips), mirroring the r28 `escape_field` hardening. **REBUTTED (nit, evidence): "`_completed_ids` retains an id after a completed retry → a later truncated retry still shows ran==collected."** Empirically **false**: pytest-rerunfailures emits **no teardown report** for a non-final attempt (verified, even with a yield fixture), so the id is added to the completion set **only on the FINAL attempt's teardown** — a hard-truncated final attempt writes no teardown (→ ran<collected) or kills the process (→ no SESSIONFINISH → absent-record check fires). Locked with a real-subprocess test (flaky-then-pass → exactly one SESSIONFINISH, `ran==collected==1`). **OVERRIDE (blocking, honest correction): "exit-5 all-deselected trusts 'deselected', but a candidate `conftest.py` can forge it from `pytest_collection_modifyitems`."** True — and it exposes that r30's "full_unit runs the whole suite regardless" reassurance was **WRONG on a low-blast PR** (full_unit is skipped, so targeted is the only candidate-test gate). This is the **r27 in-process collection-control residual**, not soundly closeable here: codex's "fail-closed on exit 5" is **incomplete** (a conftest can surgically deselect **just** the failing test → exit 0, sailing past any exit-5 rule) **and** would false-block legitimate reclassification / slow-only PRs. This gate deliberately can't run slow/integration/needle tests (real models / live server); the real defenses are the slow-lane CI + diff review, and the loud `⚠ REVIEW` skip surfaces it. Corrected the comment to say this plainly rather than claim a guarantee it can't keep. 3 new tests (strict-xpass → ERROR real-subprocess incl. `[XPASS(strict)]` longrepr + no-wasxfail; U+0085/U+2028/U+2029 escaped single-line + round-trip; rerun completion reflects only the final attempt).
- **Round 32** — MERGE-SAFE verdict, **two nits, both genuine (fixed)**, in `11ab5b32`. **FIXED (nit → real correctness — honestly corrects the r31 rebuttal, which was incomplete): the teardown-phase rerun DID inflate the completion set.** The r31 rebuttal probed only **call-phase** reruns (which emit no intermediate teardown) and concluded the id is added "only on the FINAL attempt's teardown." That's true for a call-phase flake but **false for a teardown-phase flake**: a yield fixture whose *teardown* fails then passes emits an **INTERMEDIATE teardown report carrying `outcome == "rerun"`** before the retry (re-probed and confirmed). The reporter added that provisional teardown to `_completed_ids`, so a subsequently truncated FINAL attempt could still satisfy `ran == collected` and mask an incomplete rerun. Fixed by gating the completion count on `outcome != "rerun"` — only a **terminal** teardown proves the item finished. **FIXED (nit): advisory rerun under `PYTEST_DISABLE_PLUGIN_AUTOLOAD` could misclassify.** With autoload off, hand-loading `-p pytest_rerunfailures` revives `--reruns` but leaves the project's OTHER required plugins (pytest-asyncio, …) disabled, so a recovered async test would ERROR on re-run and be misread as reproduced/inconclusive rather than a flake. We can't reliably enumerate every required plugin here (test_env_check owns that list; not all are `-p` loadable), and this step is advisory (never gates) — so it now **SKIPS** in that mode rather than emit a wrong signal. 3 new tests (real-subprocess teardown-phase flake: RERUN logged **and** `ran==collected==1` proving the guard drops only the provisional teardown; a direct-hook test driving the exact truncated-final-attempt sequence → `ran<collected` stays visible; autoload-disabled → SKIP with no subprocess launched). Full suite still green (full_unit 14224 passed; targeted 281 passed; `-k pr_validate` 523 passed).
- **Round 33** — one BLOCKING + one nit + a self-inflicted **test regression from r32**; **all three fixed**, in `8a3c515c`. **FIXED (r32 test regression — mine): the r32 truncation test corrupted the live reporter.** `test_teardown_phase_rerun_does_not_prematurely_complete` drove the reporter hooks (`pytest_sessionstart`/`finish`/`logreport`) **directly on the same `_nodeid_reporter` module that is loaded as the live `-p` plugin for the current run** — and `pytest_sessionstart` **clears the module-global `_completed_ids`**, dropping every already-completed item so the whole session looked truncated (`ran<collected`). That is why BOTH `targeted` (which runs only the changed test files — **not** the signal test) **and** `full_unit` reported "did not run to completion." Made the test **HERMETIC**: snapshot + restore `_completed_ids` around the direct calls, never call `pytest_sessionstart`. Proven — a reporter-injected run of the file now records `SESSIONFINISH 225 225` (`ran==collected`), 0 ERROR/FAILED. **FIXED (blocking, genuine): `effective_quarantine` false-blocked a legitimately-narrowed known flake.** It intersected base∩candidate by **exact id string**, so narrowing a base `family: true` entry to a specific param (`test_x` family → `test_x[p1]`, the docstring's own "drop a param" tighten) dropped the entry entirely → the retained flake **blocked**. Reworked to iterate the candidate registry and **materialize each entry COVERED by a base entry** (via `node_id_matches`), carrying the base's audit metadata, breadth = narrower of the two. **Safety invariant preserved and proven:** every effective id is covered by base, and `family` survives only when the ids are identical AND both set it, so the result is **ALWAYS ⊆ base coverage** — a candidate can only TIGHTEN, never WIDEN. All existing intersection tests still pass; 3 new (drop-a-param materializes the param + base metadata; the narrowing takes effect and stays a base subset; an exact base does NOT cover a new param → candidate addition ignored). **FIXED (nit, genuine): fallback exit-1 false-green.** `_untrusted_run_reason`'s exit-1-empty guard required `run.structured`, so on the **no-reporter fallback** path a setup/teardown ERROR (exits 1, prints `ERROR` not `FAILED` → empty scrape, `errored` defaults False) slipped through as green. Dropped the `structured` condition — an unaccounted exit 1 is now untrusted on the fallback path too (there is no green exit-1); rewrote the contradicting r26 test. **HONEST NOTE (not a regression): the one `full_unit` red — `test_signal_observability.py::test_subprocess_sighup_default_disposition_dumps_and_stays_alive` — is a pre-existing load-sensitive flake** (passes 3/3 in isolation on this branch, unrelated to these pr_validate-internal changes; `targeted`, which doesn't run it, went red only from the test-regression above). It reproduced once under the heavy concurrent `stress_e2e_bench` model-loading in this run — the same correlated-rerun caveat Round 8 documents — not something this diff touches.
- **Round 34** — two BLOCKING (codex's diff **truncated — 1 file unreviewed**), **both genuine and soundly fixed** (neither is the irreducible in-process collection residual), in `2eeca232`. **FIXED (blocking): the exit-5 all-deselected skip ignored `pr.failed`/`pr.complete`.** It granted a **non-blocking** skip on exit-5 + "deselected"-in-summary without checking that the run actually passed — so a candidate hook that normalized a run which **failed** (or was truncated) to exit 5 with a "deselected" summary could **steal the skip and waive real failures**. Now gated on a new `_PytestRun.all_deselected_clean` field: the reporter's **structured proof of a benign zero-selection run** (exactly `SESSIONFINISH 0 0` with **no** FAILED/ERROR/RERUN). Empirically both the all-deselected and empty-file cases write `SESSIONFINISH 0 0` regardless of exit code, so the legit skip still fires; a forced exit-5-**with-failures** has a FAILED record → not clean → skip **denied** → falls through to `_untrusted_run_reason` (**blocks**). Without the reporter the proof is the trusting default False → fallback exit-5 blocks (fails safe). This closes the concrete exit-5 hole; the **surgical exit-0 deselection** (deselect JUST the failing test → exit 0) remains the documented, in-process-unclosable r27 residual. **FIXED (blocking): the base negative control inherited `PYTEST_ADDOPTS` while the PR side strips it.** `_PYTEST_CMD` already makes the two runs **command**-symmetric, but only `_run_pytest` popped `PYTEST_ADDOPTS` (it bites THROUGH `-o addopts=`); `_run_on_main` did not. An inherited `--runxfail` (etc.) applied only on base could make base report a node as FAILED that the PR side does not → a real PR regression misclassified as **pre-existing** and waived (a **FALSE GREEN**). `_run_on_main` now builds an explicit env with `PYTEST_ADDOPTS` removed — **env-symmetric** with the PR side. 5 new tests (exit-5-deselected-but-failed blocks; exit-5-deselected-without-structured-proof blocks; benign all-deselected skip still fires; a real `_run_pytest` all-deselected run computes `all_deselected_clean` True while a failing run computes False; `_run_on_main` strips `PYTEST_ADDOPTS`). **HONEST NOTE (not a regression): the one `stress_e2e_bench` red — pydantic_ai 5/6 vs base 6/6 on Qwen3.5-35B — is a stochastic agent-over-real-model result.** These pr_validate-internal script changes have **no causal path to model inference** (the served model loads `vllm_mlx/`, not `scripts/pr_validate/`), so a 1/6 agent-workflow difference on a 35B model is non-determinism, not a diff-caused regression — the same class as the r33 signal flake. full_unit (14229 passed) and targeted (286 passed) both clean; the r33 signal flake did **not** recur (confirming it was a flake).

- **Round 35** — one BLOCKING + one nit, **both genuine and fixed** in `bba8184c`; full_unit (14233 passed) and targeted (290 passed) both clean, and the r33 signal flake did **not** recur again. **FIXED (blocking): the base-registry loader resolved `git` through the inherited PATH at call time.** `load_quarantine_from_ref` invoked a bare `["git", "--no-replace-objects", "show", …]`, looked up on PATH **after** candidate tests had already run in an earlier pipeline step. A failing candidate could plant a fake `git` in a **writable leading PATH directory** (e.g. the venv's own `bin`, which is writable and typically first on PATH), so the later `git show <base>:<registry>` served a **forged allowlist** and self-quarantined the candidate's own failure — bypassing the `--no-replace-objects` pin entirely. Fix: resolve the git binary **once at import** (`_GIT = shutil.which("git")`), which runs when pr_validate boots — **before any candidate code executes** — from the operator's clean startup PATH, and invoke that absolute path thereafter. (Overwriting the resolved binary *in place* would instead require write access to a system / Homebrew bin and would corrupt the operator's git globally — a far louder, out-of-scope attack, not a silent registry forgery.) **FIXED (nit): `pytest-rerunfailures>=14.0` was unbounded** → `>=14.0,<17` (installed/tested = 16.4) in **both** the `test` and `dev` extras, keeping the mirror the `test_env_check` unit asserts. 3 new tests (`_GIT` is absolute not bare "git"; `git show` argv[0] is the pinned `_GIT`; **end-to-end** — a hostile `git` planted on PATH after import is ignored: real git serves the true base blob and the fake's sentinel is never touched). **HONEST NOTE (not a regression), stress_e2e_bench again 5/6 vs base 6/6 (pydantic_ai, Qwen3.5-35B): provably a flake.** `git diff --name-only origin/main...HEAD` shows **ZERO engine files** — all 11 changed files are `scripts/pr_validate/`, `tests/`, `pyproject.toml`, `quarantine.yaml`, **none of which the served model (`vllm_mlx/`) imports** — so the diff has **no causal path to model inference**. The failing subtest is "Test 3: Structured output" → `Tool 'Alice' exceeded max retries count of 1`: a stochastic agent-over-real-model retry exhaustion at `max_retries=1`, identical in class to the r33/r34 non-determinism. This red exercises **unchanged** engine code and cannot be caused by this PR.

- **Round 36** — two BLOCKING (codex's diff **truncated — 1 file unreviewed**), **both genuine and soundly fixed** in `db340827`; full flake file **238 passed**, `-k pr_validate` **539 passed**. **FIXED (blocking): r35 pinned the git *path* but not the git *binary*.** On a Homebrew Mac `_GIT` resolves to `/opt/homebrew/bin/git`, **owned by the operator's user** — so a candidate subprocess could **overwrite it in place**, let a later `git show <base>:<registry>` serve a forged allowlist, then restore it (a transient, traceless swap), defeating the path-pin. And `shutil.which("git") or "git"` **re-opened the PATH-lookup hole** whenever git was absent at import. Fix — codex's own suggestion #1: **snapshot both registry blobs at fetch** (the FIRST step, git clean, **before any candidate code runs**) and cache the parsed entries (or the `QuarantineError` to re-raise); `load_quarantine_from_ref` serves that cache and **spawns no git after candidate tests**, removing the post-candidate git invocation entirely. The cache lives in the pr_validate **parent** process — candidate tests run in a separate pytest subprocess and can't reach it. Plus the **bare-name fallback is dropped**: `_GIT = shutil.which("git")` may be `None`, and the live loader **fails CLOSED** (QuarantineError → every failure blocks) rather than re-looking-up a tamperable `"git"`. `full_unit` and its ~6 registry-mocking tests are **unchanged** — the cache is transparent behind the same `load_quarantine_from_ref` entry point. **FIXED (blocking): `session_completed` accepted `ran >= collected`.** The reporter counts **DISTINCT terminal-teardown ids** (reruns can't inflate it), so a faithful record can never complete more distinct tests than it collected — `ran > collected` is an **impossible/forged** state, and accepting it let an inflated `ran` paper over unexecuted collected tests. Tightened to **`ran == collected`**; `ran > collected` is now rejected as malformed (the obsolete `test_ran_exceeds_collected_is_complete` → `_is_malformed`, and the reporter/consumer/`_RERUN_DONE` comments reconciled). 6 new tests (snapshot serves cache with NO post-snapshot git; snapshot caches + re-raises a `QuarantineError`; cache-miss → live; falsy-refs-skipped + idempotent; `_GIT is None` fails closed with no subprocess; `FetchStep` wires the snapshot for `[base_sha, head_sha]`). **HONEST NOTE (unchanged from r34/r35): the sole `stress_e2e_bench` red remains a provable flake** — `git diff --name-only origin/main...HEAD` = **0 engine files**, the served model (`vllm_mlx/`) imports none of the changed `scripts/pr_validate/` · `tests/` · `pyproject.toml` · `quarantine.yaml`, so the diff has **no causal path** to the pydantic_ai structured-output retry-exhaustion at `max_retries=1`.

- **Round 37** — **MERGE-SAFE**: codex cleared all BLOCKING (0 blocking), surfacing **2 nits** (498s, under the 600s wall — the two prior full-run codex timeouts were transient variance right at the boundary on a now-160KB diff, not findings). Both nits were **cheap and genuine, so fixed** in `33394400` rather than waived. **NIT (quarantine.py): duplicate-id order-dependence.** The strict loader rejects duplicate KEYS within one mapping but not two list ENTRIES sharing the same `id` (one `family:true`, one `family:false`) — `effective_quarantine`'s first-match selection would then depend on YAML list order. A repeated id is always an authoring mistake; now **rejected at parse** so coverage is order-independent. A family-covering entry (`t`) and a specific parametrization (`t[p1]`) carry different id strings and are **not** rejected; the shipped `quarantine.yaml` (2 unique entries) still loads. **NIT (flake_tracking.py): stale artifact.** `flake-candidates.json` is written only on the classify path, so a reused run dir could retain an earlier run's candidates on a skip/error return — now **unlinked at the top of `_run`** (advisory step only). 3 new tests (duplicate-id rejected; family-base + specific-param not a duplicate; stale candidate cleared on the no-failures skip). full_unit (14242 passed) + targeted (299 passed) + lint stay green from the r37 full run; flake file **241 passed**, `-k pr_validate` **542 passed**.

- **Round 38** — one BLOCKING (codex's diff **truncated — 1 file unreviewed**, so it reviews new slices of the brand-new `flake_tracking.py` each round; **codex completed at 476s, under the 600s wall**), **genuine and fixed** in `587e4bf7`; full_unit (14245 passed) + targeted (302 passed) + lint green. **FIXED (blocking): `_run_session` only swept the process group on `TimeoutExpired`.** Any OTHER exception from `communicate()` — most importantly a `KeyboardInterrupt` when the operator Ctrl-C's the gate mid-rerun — unwound **without** killing or reaping the pytest process group, orphaning it and its GPU/inference descendants. Added a `BaseException` handler that kills the group + bounded-reaps the child (reusing the existing `_kill_group` + `_drain_bounded` helpers), then **re-raises the original exception unchanged**; the `TimeoutExpired` path keeps its output-carrying re-raise. 1 new test (a stubbed `communicate()` raising `KeyboardInterrupt` → the group is SIGKILLed before the interrupt propagates). flake file **242 passed**, `-k pr_validate` **543 passed**.

- **Round 39** — codex completed at 468s (2 blocking + 1 nit; the two prior 600s reds were the same boundary-variance timeout, not findings), **all three genuine follow-ups to r35/r36/r38 and fixed** in `c6f479f2`. **FIXED (blocking, quarantine.py): `shutil.which("git")` can return a RELATIVE path** when `PATH` holds `.` — and the subprocess runs with `cwd=repo_root`, so a relative `_GIT` would resolve under the CANDIDATE checkout at call time (a committed `./git` forges the registry). Extracted `_resolve_git()` that rejects non-absolute results → `None` (fail closed, like an unresolved git). **FIXED (blocking, flake_tracking.py): the r38 interrupt handler killed the group unconditionally.** `communicate()` may have already waited+reaped the child while unwinding a `KeyboardInterrupt`; once reaped its pgid can be **RECYCLED**, so `os.getpgid(proc.pid)` + killpg could SIGKILL an unrelated group (the documented pgid-recycling hazard). Now group-kill ONLY while `returncode is None` (demonstrably unreaped — the same guarantee the timeout path has by construction); reaped → skip straight to the re-raise. **FIXED (nit, fetch.py): a malformed candidate `quarantine.yaml` merged undetected on a green `full_unit`** (which only READS the registry on failure), then fail-closed every later PR's quarantine. When the PR **modifies** `quarantine.yaml`, fetch now validates the committed head registry (via the snapshot cache — no extra git) and fails with a fence-safe error if it doesn't parse. 6 new tests (`_resolve_git` rejects-relative / keeps-absolute / none-when-absent; interrupt-after-reap skips killpg with `getpgid` booby-trapped; fetch fails on a malformed candidate registry + ignores a registry error when the registry is unchanged). flake file **248 passed**, `-k pr_validate` **549 passed**.

- **Round 40** — codex completed at 386s (1 blocking + 1 nit). **FIXED (blocking, _pytest_summary.py): a real base-scrape FALSE GREEN — honestly correcting the r30/r29 "never a false green" claim.** `summary_node_ids` scrapes base failures for the negative control; `_strip_message` split at the first depth-0 `" - "`. A custom param id `ids=["a] - b"]` yields node `test_x[a] - b]`, whose inner `]` at `a]` drops depth to 0 → the split **collapsed** the id to `test_x[a]`. The r9 guard only rejected a message **starting with `[`**; here the message is `b]`, so the collapse went through — and a collapsed `test_x[a]` in the base waiver set could match a genuinely **PR-introduced** `test_x[a]` and waive it as pre-existing (a false green). r30 asserted this case "fails CLOSED, never a false green"; that was **wrong** for the non-`[`-leading variant. **Fix**: also fail safe (return the whole line → won't match the shorter id → **BLOCKS**) when the candidate message holds an **UNMATCHED `]`** (the tell-tale that the split fell inside the id's real param brackets); added `_has_unmatched_close_bracket`. Balanced-bracket messages (`ValueError: got [2]`, `[[1,2] - [3,4]]`) are unaffected; a plain test whose message merely holds an unmatched `]` now over-blocks (fails safe), never a false green. 2 new tests (the collapse case → whole line; plain-test unmatched-`]` → fails safe). **DEFERRED (nit, advisory-only): a collection-error target in the rerun sample exits pytest 2**, and the `_CLASSIFIABLE_EXITS` guard then skips classification of the *whole* sample. This is the **advisory** `flake_tracking` step (never gates — no false-green, no correctness/security impact); codex's fix (a separate rerun lane for collection-error targets) is deferred as a follow-up rather than expand this 167KB PR. flake file **250 passed**, `-k pr_validate` **551 passed**.

- **Round 41** — codex completed at 452s (2 blocking + 1 nit; diff **truncated — 1 file unreviewed**, so codex reviews new slices of the same irreducibly-ambiguous parser each round). **FIXED (blocking, _pytest_summary.py): the r40 close was incomplete — a BALANCED-bracket variant still collapsed.** `test_x[a] - b[c]` (custom param value `a] - b[c`) balances, so the r40 unmatched-`]` tell misses it, yet splitting still collapses the id to `test_x[a]` → the same base-negative-control false green r40 closed for the unbalanced case. The **sound** fix codex recommends (canonical base ids via the reporter) is architecturally **unavailable** at the base checkout — the reporter is *new in this PR*, absent at the base SHA, and injecting the PR's copy would shadow base modules on `PYTHONPATH` and contaminate the negative control. **Fix**: extend the fail-closed guard with the minimal provably-sound rule — at a depth-0 `" - "` split, if the id-part ends with `]` **and** the message contains `[`, return the whole line. After the four guards (r6/r9/r40/r41) a split is taken **only** when the id-part is unparametrized (no `]` → no `" - "` inside it) or the message provably can't be a bracketed param continuation (no `[`, no unmatched `]`) → **fail-closed sound, no false green**, at the cost of over-blocking a *pre-existing parametrized* failure whose message holds `[` (safe, rare — only fires when a changed test file was already failing at base; matches this scrape's stated "false block over unsound negative control" preference). An **unparametrized** failure with the same message still splits correctly. **DOCUMENTED (blocking, targeted_tests.py — accepted residual, same class as r27/r30/r31/r34): the all-deselected exit-5 skip's `SESSIONFINISH 0 0` proof is AGGREGATE.** A zero-trace sibling changed file (empty / renamed out of `python_files` / conftest-dropped) can ride under another changed file's legitimate deselection. **Not separately closeable**: codex's per-target check false-blocks the routine emptied/renamed-file signature, and the in-process conftest drop is the *same* r27 surgical residual reached another way (a hook forging per-file "deselected" defeats a per-file check too). Extended the BOUNDARY comment to name the variant; defenses remain slow-lane CI + diff review. **FIXED (nit, flake_tracking.py): clear `flake-rerun.log` + `flake-rerun-nodeids.tsv`** (not just `flake-candidates.json`) at `_run` start, so an early skip in a reused run dir can't leave stale rerun evidence. 4 new tests (balanced fail-safe; unparametrized-still-splits; end-to-end "balanced ambiguous base id doesn't waive a short regression"; stale rerun-artifact clearing); retitled the both-bracketed test to expect the fail-safe whole line. full_unit **14254 passed**, targeted **311 passed**, flake file **254 passed**, `-k pr_validate` **557 passed**, ruff clean. Commit `292559a3`.

**Residual, scoped honestly (not papered over):** an author who weaponizes their own in-process test (e.g. an `atexit` handler forging a summary after the genuine one) is out of scope — the gate runs candidate code in-process, so such an author has strictly easier sabotage routes and *no* in-process report source (junit-xml included) is tamper-proof against them; we defend against mistakes and flakes. **This includes candidate-controlled test COLLECTION** (codex r27): `session_completed` proves every *selected* item ran, not that the selection was the whole suite — a committed `pytest.ini` (`python_files`/`norecursedirs`) or a `conftest.py` collection hook could shrink `tests/` to a handful of passing tests with a truthful `ran==collected`. A count/manifest cross-check doesn't close this soundly (the same in-process access can *surgically* deselect the one regression test, or reparametrize its id, under any floor), so we document the boundary instead of advertising a defense we can't keep. And fully reaping a descendant that escapes its process group via `setsid()`, or a detached survivor of a normally-exiting re-run, has no portable answer on macOS (no cgroup/job object; a post-reap `killpg` is unsafe due to pgid recycling — the same trade-off accepted in #1220). The bounded drain guarantees the gate can never *hang*; the advisory step tolerates the residual leak rather than risk SIGKILLing a recycled group. The docstrings state these limits plainly instead of claiming a guarantee we can't keep. — the gate runs candidate code in-process, so such an author has strictly easier sabotage routes and *no* in-process report source (junit-xml included) is tamper-proof against them; we defend against mistakes and flakes. And fully reaping a descendant that escapes its process group via `setsid()`, or a detached survivor of a normally-exiting re-run, has no portable answer on macOS (no cgroup/job object; a post-reap `killpg` is unsafe due to pgid recycling — the same trade-off accepted in #1220). The bounded drain guarantees the gate can never *hang*; the advisory step tolerates the residual leak rather than risk SIGKILLing a recycled group. The docstrings state this limit plainly instead of claiming a guarantee we can't keep. **Two further boundaries documented in r30/r31:** (1) an all-deselected exit 5 in `targeted_tests` is a **SKIP**, and that is the **r27 in-process collection-control residual**, not a closed hole (r30's "full_unit runs the whole suite regardless" reassurance was **wrong on a low-blast PR**, where full_unit is skipped and targeted is the only candidate-test gate). Two routes reach it — newly marking a *changed* test `slow`/`integration`/`needle` (a **uniform repo policy**; `full_unit` excludes the same markers), or a candidate `conftest.py` deselecting from `pytest_collection_modifyitems` (r31). Neither is soundly closeable here: this gate deliberately can't run those tests (real models / live server), and codex's "fail-closed on exit 5" is both **incomplete** (a conftest can surgically deselect **just** the failing test → exit 0, past any exit-5 rule) **and** false-blocks legit reclassification / slow-only PRs. The real defenses are the slow-lane CI (`-m slow`) + diff review (which sees the marker or conftest hook); the exit-5 SKIP is made **loud** (`⚠ REVIEW`) so a reviewer confirms intent. (2) The base negative control cannot get canonical node ids (it predates the reporter plugin, and injecting it would contaminate the run with PR library code), so a `" - "`-with-unbalanced-brackets id is irreducibly ambiguous to its summary scrape and **fails CLOSED** (a pathological pre-existing id blocks as a conservative regression) — never a false green. **(r40 correction, honestly logged):** r30 asserted this was already true, but the `_strip_message` r9 guard only failed-closed when the message began with `[` — a param id `test_x[a] - b]` (message `b]`) still collapsed to `test_x[a]` and WAS a false green. r40 closes it: any candidate message with an **unmatched `]`** now fails closed too. **(3) Advisory-step boundary (r40):** a collection-error target in the `flake_tracking` rerun sample makes pytest exit 2, and the classifiable-exit guard then skips classification of the whole sample. This is the **advisory** step (never gates), so it costs completeness, not correctness; a separate rerun lane for collection-error targets is a deferred follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

