### PR TITLE
fix(deepseek-v4): honor explicit YaRN attention_factor

### DIFF
--- a/tests/test_deepseek_v4_vendored.py
+++ b/tests/test_deepseek_v4_vendored.py
@@ -60,6 +60,58 @@ def test_register_vendored_archs_is_idempotent():
     assert first is second
 
 
+def test_deepseek_v4_rope_honors_explicit_yarn_attention_factor():
+    """HF's explicit YaRN attention factor scales only rotary channels."""
+    import mlx.core as mx
+
+    from vllm_mlx.models.deepseek_v4 import DeepseekV4RoPE
+
+    scaling = {
+        "rope_type": "yarn",
+        "factor": 4.0,
+        "original_max_position_embeddings": 128,
+    }
+    x = mx.arange(24, dtype=mx.float32).reshape(1, 3, 8) / 10
+    baseline = DeepseekV4RoPE(dims=4, base=10000.0, scaling_config=scaling)
+    explicit_one = DeepseekV4RoPE(
+        dims=4,
+        base=10000.0,
+        scaling_config={**scaling, "attention_factor": 1.0},
+    )
+    explicit_null = DeepseekV4RoPE(
+        dims=4,
+        base=10000.0,
+        scaling_config={**scaling, "attention_factor": None},
+    )
+    explicit_half = DeepseekV4RoPE(
+        dims=4,
+        base=10000.0,
+        scaling_config={**scaling, "attention_factor": 0.5},
+    )
+
+    original_input = mx.array(x)
+    expected_input = mx.concatenate([x[..., :4], 0.5 * x[..., 4:]], axis=-1)
+    baseline_output = baseline(x)
+    one_output = explicit_one(x)
+    null_output = explicit_null(x)
+    half_output = explicit_half(x)
+    expected_half_output = baseline(expected_input)
+    mx.eval(
+        original_input,
+        x,
+        baseline_output,
+        one_output,
+        null_output,
+        half_output,
+        expected_half_output,
+    )
+
+    assert mx.array_equal(x, original_input).item()
+    assert mx.allclose(baseline_output, one_output, atol=1e-6).item()
+    assert mx.allclose(baseline_output, null_output, atol=1e-6).item()
+    assert mx.allclose(half_output, expected_half_output, atol=1e-6).item()
+
+
 def test_tiny_model_forward_pass():
     """Smoke test the full forward path on a CPU-sized synthetic config.
 

--- a/tests/test_deepseek_v4_vendored.py
+++ b/tests/test_deepseek_v4_vendored.py
@@ -62,7 +62,7 @@ def test_register_vendored_archs_is_idempotent():
 
 def test_deepseek_v4_rope_honors_explicit_yarn_attention_factor():
     """HF's explicit YaRN attention factor scales only rotary channels."""
-    import mlx.core as mx
+    mx = pytest.importorskip("mlx.core")
 
     from vllm_mlx.models.deepseek_v4 import DeepseekV4RoPE
 

--- a/vllm_mlx/models/deepseek_v4.py
+++ b/vllm_mlx/models/deepseek_v4.py
@@ -192,11 +192,18 @@ class DeepseekV4RoPE(nn.Module):
     ):
         super().__init__()
         self.dims = dims
+        # HF YaRN configs may explicitly override the attention-amplitude
+        # scale. Keep Rapid's existing no-override behavior (1.0) when the
+        # field is absent or null.
+        self.attention_factor = 1.0
 
         inv_freq = 1.0 / (base ** (mx.arange(0, dims, 2, dtype=mx.float32) / dims))
         rope_type = None
         if scaling_config is not None:
             rope_type = scaling_config.get("type") or scaling_config.get("rope_type")
+            attention_factor = scaling_config.get("attention_factor")
+            if attention_factor is not None:
+                self.attention_factor = attention_factor
 
         if rope_type in ("yarn", "deepseek_yarn"):
             factor = scaling_config["factor"]
@@ -254,6 +261,13 @@ class DeepseekV4RoPE(nn.Module):
         head_dim = x.shape[-1]
         freqs = self._get_freqs(head_dim, inverse, freq_scale)
         offset = offset // freq_scale if freq_scale != 1 else offset
+        if self.attention_factor != 1.0:
+            x = x[...]
+            # DeepSeek-V4 lays out the non-rotary (NOPE) channels first and
+            # the rotary channels last. ``_get_freqs`` mirrors that layout by
+            # prepending infinite frequencies for the NOPE pairs, so apply the
+            # YaRN amplitude override to the trailing rotary slice.
+            x[..., -self.dims :] = self.attention_factor * x[..., -self.dims :]
         return mx.fast.rope(
             x,
             head_dim,


### PR DESCRIPTION
# fix(deepseek-v4): honor explicit YaRN attention_factor

Source: [ml-explore/mlx-lm#1507](https://github.com/ml-explore/mlx-lm/pull/1507)

Review state: **accepted after coordinator repair**

## Why

Some HF YaRN configurations explicitly provide
`rope_scaling.attention_factor`. Rapid's vendored DeepSeek-V4 RoPE path
previously ignored that field, so those checkpoints could receive the wrong
rotary-channel amplitude. An explicit `1.0` must preserve unscaled behavior.

## AI assistance disclosure

OpenAI Codex Terra prepared the first adaptation and focused test. Coordinator
review found that Rapid's DeepSeek-V4 layout stores non-rotary channels first
and rotary channels last; the initial agent patch scaled the wrong slice. The
coordinator corrected the implementation, expanded the regression, and reran
all focused checks.

## Implementation

- Store an explicit, non-null `attention_factor` from `rope_scaling`.
- Preserve Rapid's existing `1.0` behavior when the field is absent or null.
- Scale only the trailing rotary `self.dims` channels immediately before
  `mx.fast.rope`; the leading NOPE channels remain unchanged.
- Add regression coverage for:
  - omitted factor, null factor, and explicit `1.0` equivalence;
  - explicit `0.5` scaling only the trailing rotary slice;
  - input-array immutability.

## Risks and scope

- This does not import generic `YarnRoPE`'s separate computed `mscale`
  policy; Rapid's specialized `DeepseekV4RoPE` did not previously implement it.
- The change follows Rapid's existing compressed-attention DeepSeek-V4
  topology; no generic model loader behavior changes.
- No real-weight DeepSeek-V4 run was performed.

## Test plan

- [x] `pytest -q tests/test_deepseek_v4_vendored.py` — 5 passed.
- [x] Ruff check on both changed files.
- [x] Ruff format check on both changed files.
- [x] `git diff --check`.
- [x] Coordinator partial-rotary layout review and wrong-slice repair.

## Attribution

Behavior is adapted from mlx-lm #1507 under Apache-2.0-compatible project
licensing. Rapid's DeepSeek-V4 module remains its own vendored implementation.

---
Draft opened from `pierre427` fork after duplicate-checking fresh `raullenchai/Rapid-MLX@b3ccb921cd2d435b7238d89b079134258f7d3485`.