### PR TITLE
fix(security): contain local model_file imports to the model root

### DIFF
--- a/tests/test_model_file_guard.py
+++ b/tests/test_model_file_guard.py
@@ -11,7 +11,7 @@ import pytest
 from vllm_mlx.utils.model_file_guard import validate_local_model_file
 
 
-def _model_dir(tmp_path: Path, model_file: str) -> Path:
+def _model_dir(tmp_path: Path, model_file: str | None) -> Path:
     model_root = tmp_path / "model"
     model_root.mkdir()
     (model_root / "config.json").write_text(
@@ -33,6 +33,12 @@ def test_accepts_local_model_without_custom_model_file(tmp_path: Path) -> None:
     model_root = tmp_path / "model"
     model_root.mkdir()
     (model_root / "config.json").write_text("{}", encoding="utf-8")
+
+    validate_local_model_file(model_root)
+
+
+def test_accepts_null_model_file(tmp_path: Path) -> None:
+    model_root = _model_dir(tmp_path, None)
 
     validate_local_model_file(model_root)
 

--- a/tests/test_model_file_guard.py
+++ b/tests/test_model_file_guard.py
@@ -1,0 +1,117 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Focused coverage for local config.json::model_file containment."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from vllm_mlx.utils.model_file_guard import validate_local_model_file
+
+
+def _model_dir(tmp_path: Path, model_file: str) -> Path:
+    model_root = tmp_path / "model"
+    model_root.mkdir()
+    (model_root / "config.json").write_text(
+        json.dumps({"model_file": model_file}), encoding="utf-8"
+    )
+    return model_root
+
+
+def test_accepts_existing_nested_python_model_file(tmp_path: Path) -> None:
+    model_root = _model_dir(tmp_path, "custom/model.py")
+    custom_dir = model_root / "custom"
+    custom_dir.mkdir()
+    (custom_dir / "model.py").write_text("# local custom model\n", encoding="utf-8")
+
+    validate_local_model_file(model_root)
+
+
+def test_accepts_local_model_without_custom_model_file(tmp_path: Path) -> None:
+    model_root = tmp_path / "model"
+    model_root.mkdir()
+    (model_root / "config.json").write_text("{}", encoding="utf-8")
+
+    validate_local_model_file(model_root)
+
+
+def test_ignores_remote_model_id() -> None:
+    validate_local_model_file("mlx-community/example-model-4bit")
+
+
+def test_rejects_absolute_model_file(tmp_path: Path) -> None:
+    model_root = _model_dir(tmp_path, str(tmp_path / "outside.py"))
+
+    with pytest.raises(ValueError, match="relative Python file"):
+        validate_local_model_file(model_root)
+
+
+def test_rejects_parent_traversal(tmp_path: Path) -> None:
+    outside = tmp_path / "outside.py"
+    outside.write_text("# outside\n", encoding="utf-8")
+    model_root = _model_dir(tmp_path, "../outside.py")
+
+    with pytest.raises(ValueError, match="must stay inside"):
+        validate_local_model_file(model_root)
+
+
+def test_rejects_symlink_escape(tmp_path: Path) -> None:
+    outside = tmp_path / "outside.py"
+    outside.write_text("# outside\n", encoding="utf-8")
+    model_root = _model_dir(tmp_path, "custom.py")
+    (model_root / "custom.py").symlink_to(outside)
+
+    with pytest.raises(ValueError, match="must stay inside"):
+        validate_local_model_file(model_root)
+
+
+def test_rejects_missing_model_file(tmp_path: Path) -> None:
+    model_root = _model_dir(tmp_path, "missing.py")
+
+    with pytest.raises(ValueError, match="existing Python file"):
+        validate_local_model_file(model_root)
+
+
+def test_rejects_directory_model_file(tmp_path: Path) -> None:
+    model_root = _model_dir(tmp_path, "custom.py")
+    (model_root / "custom.py").mkdir()
+
+    with pytest.raises(ValueError, match="regular Python file"):
+        validate_local_model_file(model_root)
+
+
+def test_rejects_non_python_model_file(tmp_path: Path) -> None:
+    model_root = _model_dir(tmp_path, "custom.txt")
+    (model_root / "custom.txt").write_text("not Python\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="relative Python file"):
+        validate_local_model_file(model_root)
+
+
+def test_shared_loader_validates_before_dispatch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from vllm_mlx.utils import tokenizer
+
+    events = []
+    expected = (object(), object())
+
+    monkeypatch.setattr(
+        tokenizer,
+        "validate_local_model_file",
+        lambda model_name: events.append(("validate", model_name)),
+    )
+    monkeypatch.setattr(
+        tokenizer,
+        "_load_model_with_fallback_impl",
+        lambda model_name, tokenizer_config=None: (
+            events.append(("load", model_name)),
+            expected,
+        )[1],
+    )
+    monkeypatch.setattr(tokenizer, "_post_load_ubc_evict", lambda model_name: None)
+
+    assert tokenizer.load_model_with_fallback("local-model") is expected
+    assert events == [("validate", "local-model"), ("load", "local-model")]

--- a/vllm_mlx/bench/pflash_replication.py
+++ b/vllm_mlx/bench/pflash_replication.py
@@ -42,7 +42,9 @@ def _build_engine(model_name: str, *, pflash_mode: str, keep_ratio: float):
     from ..engine_core import AsyncEngineCore, EngineConfig
     from ..pflash import PFlashConfig
     from ..scheduler import SchedulerConfig
+    from ..utils.model_file_guard import validate_local_model_file
 
+    validate_local_model_file(model_name)
     model, tokenizer = load(model_name)
     scheduler_config = SchedulerConfig(
         pflash_config=PFlashConfig(

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -4143,6 +4143,7 @@ def bench_command(args):
     from .pflash import validate_model_support as _bench_pflash_validate
     from .request import SamplingParams
     from .scheduler import SchedulerConfig
+    from .utils.model_file_guard import validate_local_model_file
 
     _check_disk_space(args.model, force=getattr(args, "force_disk_check", False))
     _check_memory_capacity(args.model)
@@ -4212,6 +4213,7 @@ def bench_command(args):
     async def run_benchmark():
         print(f"Loading model: {args.model}")
         try:
+            validate_local_model_file(args.model)
             model, tokenizer = load(args.model)
         except Exception as e:
             # Opt-in telemetry (Phase 2.2 error wiring): mirror the

--- a/vllm_mlx/jlens.py
+++ b/vllm_mlx/jlens.py
@@ -122,6 +122,7 @@ def _load_model(model_path: str):
     """Load an mlx_lm model, installing the MLX hardware-compat shim first."""
     # The shim must run before ``from mlx_lm import load`` (see cli.py / #404).
     from . import _mlx_compat
+    from .utils.model_file_guard import validate_local_model_file
 
     _mlx_compat.install()
 
@@ -130,6 +131,7 @@ def _load_model(model_path: str):
     # ``pull`` or from a successful mirror pass here) are picked up by
     # ``mlx_lm.load`` transparently.
     _prefetch_via_mirror(model_path)
+    validate_local_model_file(model_path)
 
     from mlx_lm import load
 

--- a/vllm_mlx/model_runner.py
+++ b/vllm_mlx/model_runner.py
@@ -123,7 +123,10 @@ class MLXModelRunner:
         try:
             from mlx_lm import load
 
+            from .utils.model_file_guard import validate_local_model_file
+
             model_name = self.model_config.model
+            validate_local_model_file(model_name)
 
             logger.info(f"Loading model with mlx-lm: {model_name}")
             start_time = time.time()

--- a/vllm_mlx/utils/model_file_guard.py
+++ b/vllm_mlx/utils/model_file_guard.py
@@ -42,7 +42,7 @@ def validate_local_model_file(model_name: str | Path) -> None:
     except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
         raise ValueError(f"Unable to read local model config at {config_path}") from exc
 
-    if not isinstance(config, dict) or "model_file" not in config:
+    if not isinstance(config, dict) or config.get("model_file") is None:
         return
 
     model_file = config["model_file"]

--- a/vllm_mlx/utils/model_file_guard.py
+++ b/vllm_mlx/utils/model_file_guard.py
@@ -1,0 +1,74 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Fail-closed validation for a local MLX model's ``model_file`` config.
+
+``mlx_lm`` can import a custom model implementation named by ``model_file`` in
+``config.json``.  Rapid-MLX validates that field only when the caller supplied
+an already-existing *local model directory*.  Repository ids and other remote
+Hugging Face loading paths deliberately remain outside this guard: they resolve
+their snapshot inside ``mlx_lm``/``huggingface_hub``, after Rapid-MLX no longer
+has a caller-supplied local root to contain.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+def validate_local_model_file(model_name: str | Path) -> None:
+    """Validate ``config.json::model_file`` before a local MLX model load.
+
+    Missing ``model_file`` is the normal case and is accepted.  When it is
+    present, the value must name an existing regular ``.py`` file relative to
+    the resolved local model directory.  Resolving both paths catches
+    ``..`` traversal and symlinks that leave the model root.
+
+    This function intentionally does nothing for a non-directory model name;
+    that is a remote/Hugging Face path whose download and custom-code policy is
+    owned by the upstream loader rather than this local containment boundary.
+    """
+    supplied_root = Path(model_name)
+    if not supplied_root.is_dir():
+        return
+
+    model_root = supplied_root.resolve(strict=True)
+    config_path = model_root / "config.json"
+    if not config_path.is_file():
+        return
+
+    try:
+        with config_path.open(encoding="utf-8") as config_file:
+            config = json.load(config_file)
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ValueError(f"Unable to read local model config at {config_path}") from exc
+
+    if not isinstance(config, dict) or "model_file" not in config:
+        return
+
+    model_file = config["model_file"]
+    if not isinstance(model_file, str):
+        raise ValueError("Local model config model_file must be a relative Python file")
+
+    relative_path = Path(model_file)
+    if relative_path.is_absolute() or relative_path.suffix != ".py":
+        raise ValueError(
+            "Local model config model_file must be a relative Python file inside "
+            "the model directory"
+        )
+
+    try:
+        custom_model_path = (model_root / relative_path).resolve(strict=True)
+    except FileNotFoundError as exc:
+        raise ValueError(
+            "Local model config model_file must name an existing Python file inside "
+            "the model directory"
+        ) from exc
+
+    if (
+        not custom_model_path.is_relative_to(model_root)
+        or not custom_model_path.is_file()
+    ):
+        raise ValueError(
+            "Local model config model_file must stay inside the model directory "
+            "and name a regular Python file"
+        )

--- a/vllm_mlx/utils/tokenizer.py
+++ b/vllm_mlx/utils/tokenizer.py
@@ -12,6 +12,7 @@ import logging
 from pathlib import Path
 
 from .chat_templates import DEFAULT_CHATML_TEMPLATE, NEMOTRON_CHAT_TEMPLATE
+from .model_file_guard import validate_local_model_file
 
 logger = logging.getLogger(__name__)
 
@@ -750,6 +751,11 @@ def load_model_with_fallback(model_name: str, tokenizer_config: dict = None):
     Returns:
         Tuple of (model, tokenizer)
     """
+    # ``mlx_lm.load`` may import config.json::model_file.  Validate that
+    # caller-supplied local path once at this shared boundary before any native
+    # or fallback loader runs.  Remote repository ids are intentionally a no-op
+    # here; see validate_local_model_file for the containment boundary.
+    validate_local_model_file(model_name)
     result = _load_model_with_fallback_impl(model_name, tokenizer_config)
     # Defect 4: evict UBC mirror of safetensors shards on Darwin so
     # the (mmap mirror + materialised weights) burst does not double


### PR DESCRIPTION
# fix(security): contain local model_file imports to the model root

Source: [ml-explore/mlx-lm#1523](https://github.com/ml-explore/mlx-lm/pull/1523)

Review state: **accepted after coordinator wiring coverage**

## Summary

Add fail-closed validation for `config.json::model_file` when Rapid-MLX is
given an existing local model directory.

Before Rapid hands a caller-supplied local directory to `mlx_lm`, the value
must now be:

- relative;
- suffixed `.py`;
- an existing regular file; and
- resolved inside the resolved model root.

This rejects absolute paths, `..` traversal, symlink escapes, missing paths,
directories, and non-Python targets.

## Necessity

A local model config should only select code contained within that model
directory. Without this boundary, a crafted `model_file` can redirect an
otherwise inspected local model to execute a Python file elsewhere on the
machine.

The main serving path uses `BatchedEngine` with remote-code support available,
so this is a live local containment improvement rather than dead validation.

## AI assistance disclosure

OpenAI Codex Terra implemented the guard and mapped direct loader call sites.
The coordinator independently reviewed the containment and loader map, added
a production-seam test proving validation occurs before shared loader
dispatch, added benign local/remote no-op cases, and reran focused checks.

## Implementation

- Add `vllm_mlx.utils.model_file_guard.validate_local_model_file`.
- Apply it at the shared `load_model_with_fallback` boundary used by normal
  serving and the general benchmark helper.
- Apply it to remaining direct local-capable `mlx_lm.load` paths:
  `jlens`, `model_runner`, freeform `bench`, and PFlash replication.
- Add focused boundary and production-wiring tests.

## Scope and risks

- This protects caller-supplied existing local model directories only.
- It does not validate remote Hugging Face IDs or snapshots resolved
  internally by `mlx_lm`/`huggingface_hub`.
- It does not sandbox Python legitimately stored inside the local model root.
- A separate malicious local process could race path replacement between
  validation and upstream loading; this narrows path selection but is not an
  `openat`-style sandbox.
- `--submit` is unchanged because it accepts registered aliases and fixed HF
  paths, not caller-supplied local directories.

## Test plan

- [x] Valid nested local `.py` file is accepted.
- [x] Ordinary local config without `model_file` is accepted.
- [x] Remote model ID is a no-op.
- [x] Absolute `model_file` is rejected.
- [x] `../` traversal is rejected.
- [x] Symlink escape is rejected.
- [x] Missing target is rejected.
- [x] Directory target is rejected.
- [x] Non-`.py` target is rejected.
- [x] Shared loader invokes validation before dispatch.
- [x] `pytest -q tests/test_model_file_guard.py` — 10 passed.
- [x] Ruff check and format check on all changed files.
- [x] `git diff --check`.

## Attribution

The security rationale is grounded in mlx-lm #1523. Rapid's implementation is
independent and Apache-2.0; no upstream source body was copied.

---
Draft opened from `pierre427` fork after duplicate-checking fresh `raullenchai/Rapid-MLX@b3ccb921cd2d435b7238d89b079134258f7d3485`.
