### PR TITLE
fix(kv-cache): degrade to bf16 when mlx-lm lacks BatchGenerator._make_new_cache

### DIFF
--- a/tests/test_quantized_kv_install_guard.py
+++ b/tests/test_quantized_kv_install_guard.py
@@ -1,0 +1,57 @@
+# SPDX-License-Identifier: Apache-2.0
+"""The QuantizedBatchKVCache install must degrade gracefully when the running
+``mlx_lm`` predates the ``BatchGenerator._make_new_cache`` hook.
+
+Regression: a too-old mlx-lm (< 0.31.3, whose ``BatchGenerator`` has no
+``_make_new_cache``) made the previously-unguarded ``batch_gen._make_new_cache``
+access raise ``AttributeError`` on EVERY scheduler step. The
+generation-error-recovery path swallowed it, turning a stale-dependency install
+into a silent, permanent serve hang (zero output, no surfaced error). The
+install now returns ``False`` (skip) so the caller keeps the bf16 live cache and
+warns, instead of the server wedging.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("mlx")  # the module under test imports mlx.core at import time
+
+from vllm_mlx.quantized_batch_cache import (  # noqa: E402
+    _QuantizableKVCache,
+    install_quantized_batch_cache,
+)
+
+
+class _NoHookBatchGen:
+    """A BatchGenerator-like object WITHOUT ``_make_new_cache`` (old mlx-lm)."""
+
+
+class _HookedBatchGen:
+    """A BatchGenerator-like object WITH ``_make_new_cache`` (mlx-lm >= 0.31.3)."""
+
+    def __init__(self):
+        from mlx_lm.models.cache import KVCache
+
+        self._make_new_cache = lambda: [KVCache()]
+
+
+def test_install_skips_and_leaves_no_hook_when_make_new_cache_missing():
+    bg = _NoHookBatchGen()
+    installed = install_quantized_batch_cache(bg, group_size=64, bits=4)
+    # Must report "not installed" (so the caller falls back to bf16) ...
+    assert installed is False
+    # ... and must NOT have raised or fabricated a hook on the way out.
+    assert not hasattr(bg, "_make_new_cache")
+
+
+def test_install_wraps_and_returns_true_when_hook_present():
+    bg = _HookedBatchGen()
+    orig = bg._make_new_cache
+    installed = install_quantized_batch_cache(bg, group_size=64, bits=4)
+    assert installed is True
+    # The hook was replaced (wrapped), not left as-is.
+    assert bg._make_new_cache is not orig
+    # The wrapped hook swaps plain KVCache layers for the quantizable type.
+    caches = bg._make_new_cache()
+    assert caches and all(isinstance(c, _QuantizableKVCache) for c in caches)

--- a/vllm_mlx/quantized_batch_cache.py
+++ b/vllm_mlx/quantized_batch_cache.py
@@ -520,7 +520,7 @@ class _QuantizableKVCache(KVCache):
 
 def install_quantized_batch_cache(
     batch_gen: Any, group_size: int = 64, bits: int = 8
-) -> Any:
+) -> bool:
     """Wire ``batch_gen``'s continuous batching to a quantized live KV cache.
 
     ``mlx_lm.generate.BatchGenerator`` builds a fresh single-sequence cache per
@@ -544,8 +544,23 @@ def install_quantized_batch_cache(
       ``cache[0].keys = mx.depends(cache[0].keys, (cache[1].keys, ...))`` — which
       assumes a raw ``mx.array``, not a quantized ``[packed, scales, biases]``
       triple. Quantizing them is a follow-up requiring per-model handling.
+    Returns ``True`` when the quantized hook was installed, ``False`` when the
+    running ``mlx_lm`` is too old to support it (see below) — the caller must
+    keep the plain bf16 live cache in that case.
     """
-    orig_make_new_cache = batch_gen._make_new_cache
+    orig_make_new_cache = getattr(batch_gen, "_make_new_cache", None)
+    if orig_make_new_cache is None:
+        # The running mlx-lm's ``BatchGenerator`` predates the
+        # ``_make_new_cache`` hook this dequant-on-read install piggybacks on
+        # (added upstream around mlx-lm 0.31.3; pyproject floors
+        # ``mlx-lm>=0.31.3``). Guarding the access matters because without it
+        # the bare ``batch_gen._make_new_cache`` raised ``AttributeError`` on
+        # EVERY scheduler step, which the generation-error-recovery path then
+        # swallowed — turning a stale-dependency install into a silent,
+        # permanent serve hang (zero output, no surfaced error). Signal
+        # "not installed" so the caller keeps the bf16 live cache + warns
+        # instead of the server wedging.
+        return False
 
     def _quantized_make_new_cache():
         return [
@@ -554,7 +569,7 @@ def install_quantized_batch_cache(
         ]
 
     batch_gen._make_new_cache = _quantized_make_new_cache
-    return batch_gen
+    return True
 
 
 def _head_dim_from_args(args: Any) -> int | None:

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -2574,16 +2574,28 @@ class Scheduler:
 
             bits = getattr(self.config, "kv_cache_quantization_bits", 8)
             eff_gs = getattr(self, "_kv_quant_group_size", 64)
-            install_quantized_batch_cache(bg, group_size=eff_gs, bits=bits)
-            # Remember the effective params so prefix-cache HITS get normalized
-            # to the same quantized type as MISSES (#1197).
-            self._live_kv_quant = (eff_gs, bits)
-            logger.info(
-                "[kv-cache] live continuous-batching KV cache quantized to "
-                "int%d (group_size=%d)",
-                bits,
-                eff_gs,
-            )
+            if install_quantized_batch_cache(bg, group_size=eff_gs, bits=bits):
+                # Remember the effective params so prefix-cache HITS get
+                # normalized to the same quantized type as MISSES (#1197).
+                self._live_kv_quant = (eff_gs, bits)
+                logger.info(
+                    "[kv-cache] live continuous-batching KV cache quantized to "
+                    "int%d (group_size=%d)",
+                    bits,
+                    eff_gs,
+                )
+            else:
+                # Running mlx-lm lacks the ``BatchGenerator._make_new_cache``
+                # hook (need mlx-lm>=0.31.3). Keep the bf16 live cache — the
+                # retained prefix cache still quantizes — rather than letting a
+                # per-step AttributeError wedge the server into a silent hang.
+                self._live_kv_quant = None
+                logger.warning(
+                    "[kv-cache] live KV quantization skipped: this mlx-lm build "
+                    "lacks BatchGenerator._make_new_cache (need mlx-lm>=0.31.3). "
+                    "Live continuous-batching cache stays bf16; upgrade mlx-lm "
+                    "to quantize it."
+                )
 
         # Server-side wiring for ``--speculative-config '{"method":"mtp"}'``.
         # This installs the vendored PR #990 ``mtp_generate_step`` hot


### PR DESCRIPTION
## Why

`install_quantized_batch_cache` (the live continuous-batching KV quantization
from #1197 / #1199) accessed `batch_gen._make_new_cache` **without a guard**.
`BatchGenerator._make_new_cache` only exists in `mlx-lm >= 0.31.3` (our pinned
floor). On a box running an **older mlx-lm** (e.g. a stale `0.31.1`), that bare
attribute access raised `AttributeError` on **every scheduler step**, which the
`generation_error_recovery` path then swallowed — turning a stale-dependency
install into a **silent, permanent `serve` hang**:

- `--kv-cache-dtype int4` / `int8` (int4 is the M-series default) → zero output,
  no surfaced error, client times out.
- `--kv-cache-dtype bf16` → fine (no quantized install, so no hook access).

This was originally mis-diagnosed as a "Python 3.14 serve hang" — it is not
Python-version-specific at all; it is purely the stale mlx-lm missing the hook.
A `git bisect` landed on the #1199 merge, and the failing step is
`AttributeError: 'BatchGenerator' object has no attribute '_make_new_cache'`.

## What

- `install_quantized_batch_cache(...) -> bool`: `getattr(batch_gen,
  "_make_new_cache", None)`; return `False` (skip) when it's missing.
- Scheduler caller: on `False`, keep the bf16 live cache and log a `WARNING`
  naming the `mlx-lm>=0.31.3` requirement, instead of wedging. Retained
  prefix cache still quantizes.

The correct fix for an affected box is still to install the pinned deps
(`mlx-lm>=0.31.3`); this change just makes a version mismatch **fail loud and
keep working** rather than hang silently.

## Verification

End-to-end on a box with stale `mlx-lm 0.31.1`:
- Before: `serve --kv-cache-dtype int4` hangs indefinitely (client 15s+ timeout).
- After: responds in ~0.3s and logs
  `[kv-cache] live KV quantization skipped: this mlx-lm build lacks
  BatchGenerator._make_new_cache (need mlx-lm>=0.31.3) ...`.

## Test

`tests/test_quantized_kv_install_guard.py` (guarded by `importorskip("mlx")`):
install returns `False` + leaves no hook when `_make_new_cache` is absent;
returns `True` + wraps `KVCache -> _QuantizableKVCache` when present.