### PR TITLE
fix(mtp): guard extract_mtp_weights against norm double-shift

### DIFF
--- a/scripts/extract_mtp_weights.py
+++ b/scripts/extract_mtp_weights.py
@@ -39,6 +39,82 @@ def _quantize_weight(w, group_size, bits):
     return q_w, q_s, q_b
 
 
+def _norm_type(key: str) -> str:
+    """Norm-type tail used to pair an MTP norm with its backbone counterpart.
+
+    ``mtp.layers.0.input_layernorm.weight`` -> ``input_layernorm.weight``.
+    """
+    return ".".join(key.split(".")[-2:])
+
+
+def _find_backbone_reference(mtp_norm_keys, backbone_keys):
+    """Pick an ``(mtp_key, backbone_key)`` pair that share a 1-D norm type.
+
+    ``backbone_key`` is a non-``mtp.`` norm present in ``backbone_keys`` (the
+    target MLX model's tensor names). That backbone norm is the +1-shifted
+    reference produced by mlx-lm's sanitize. Returns ``(None, None)`` when no
+    shared norm type exists.
+    """
+    non_mtp = [k for k in backbone_keys if not k.startswith("mtp.")]
+    for mtp_key in mtp_norm_keys:
+        ntype = _norm_type(mtp_key)
+        for bk in non_mtp:
+            if bk == ntype or bk.endswith("." + ntype):
+                return mtp_key, bk
+    return None, None
+
+
+def _norms_already_shifted(mtp_mean: float, backbone_mean: float) -> bool:
+    """Return True when the extracted MTP norms are ALREADY +1-shifted.
+
+    The backbone norm (post mlx-lm sanitize) is the shifted reference. An
+    unshifted MTP norm sits ~1.0 below it (HF ``(1 + w)`` convention), so its
+    mean is closer to ``backbone_mean - 1.0``. If instead the MTP mean is
+    closer to ``backbone_mean``, the norms were already shifted at the source
+    and applying +1.0 again would silently double-shift them (w+2), so the
+    shift must be skipped.
+    """
+    return abs(mtp_mean - backbone_mean) < abs(mtp_mean - (backbone_mean - 1.0))
+
+
+def _mlx_backbone_norm_mean(mlx_dir: Path, mtp_norm_keys):
+    """Load a backbone (+1-shifted) norm mean from the local MLX model.
+
+    Finds a non-``mtp.`` 1-D norm in ``mlx_dir`` whose type matches one of the
+    ``mtp_norm_keys``, loads that tensor, and returns
+    ``(mean, mtp_ref_key, backbone_key)``. Returns ``(None, None, None)`` when
+    no suitable reference is found or the shard cannot be read (unusual layout).
+    """
+    try:
+        index_path = mlx_dir / "model.safetensors.index.json"
+        if index_path.exists():
+            with open(index_path) as f:
+                weight_map = json.load(f).get("weight_map", {})
+            mtp_ref_key, backbone_key = _find_backbone_reference(
+                mtp_norm_keys, weight_map.keys()
+            )
+            if backbone_key is None:
+                return None, None, None
+            shard = mx.load(str(mlx_dir / weight_map[backbone_key]))
+        else:
+            single = mlx_dir / "model.safetensors"
+            if not single.exists():
+                return None, None, None
+            shard = mx.load(str(single))
+            mtp_ref_key, backbone_key = _find_backbone_reference(
+                mtp_norm_keys, shard.keys()
+            )
+            if backbone_key is None:
+                return None, None, None
+        tensor = shard.get(backbone_key)
+        if tensor is None:
+            return None, None, None
+        return float(mx.mean(tensor).item()), mtp_ref_key, backbone_key
+    except Exception as e:  # unusual layout / corrupt or unreadable shard
+        logger.warning(f"Double-shift guard: failed to load backbone reference: {e}")
+        return None, None, None
+
+
 def main():
     parser = argparse.ArgumentParser(description="Extract MTP weights from HF model")
     parser.add_argument(
@@ -58,6 +134,12 @@ def main():
         type=int,
         default=None,
         help="Override group size (default: from MLX model config)",
+    )
+    parser.add_argument(
+        "--force-norm-shift",
+        action="store_true",
+        help="Force the +1.0 norm shift even if the double-shift guard detects "
+        "already-shifted MTP norms (escape hatch).",
     )
     args = parser.parse_args()
 
@@ -119,10 +201,59 @@ def main():
     # (the "norm" is mid-name, so an ``endswith('norm.weight')`` list silently
     # missed them — leaving the MTP head's fc-input normalization inverted and
     # producing ~0% draft acceptance). Match any 1-D norm weight instead.
-    for k in list(all_mtp_weights.keys()):
-        if "norm" in k and k.endswith(".weight") and all_mtp_weights[k].ndim == 1:
-            all_mtp_weights[k] = all_mtp_weights[k] + 1.0
-            logger.info(f"  Shifted norm: {k}")
+    #
+    # DOUBLE-SHIFT GUARD: the +1.0 shift is correct ONLY if the HF source stores
+    # its MTP norms unshifted (HF convention). If a source already stores them in
+    # MLX's shifted convention, applying +1.0 again silently double-shifts (w+2),
+    # with the SAME ~0% acceptance symptom and no error. Detect this by comparing
+    # an MTP norm's mean to the SAME-TYPE backbone norm in the target MLX model
+    # (the +1-shifted reference): if the MTP mean already matches the backbone
+    # rather than sitting ~1.0 below it, the norms are pre-shifted — skip the
+    # shift. ``--force-norm-shift`` overrides; a missing reference falls back to
+    # shifting (current behavior).
+    mtp_norm_keys = [
+        k
+        for k in all_mtp_weights
+        if "norm" in k and k.endswith(".weight") and all_mtp_weights[k].ndim == 1
+    ]
+
+    apply_shift = True
+    if not mtp_norm_keys:
+        apply_shift = False
+    elif args.force_norm_shift:
+        logger.info("--force-norm-shift set: applying +1.0 norm shift unconditionally.")
+    else:
+        backbone_mean, mtp_ref_key, backbone_key = _mlx_backbone_norm_mean(
+            mlx_dir, mtp_norm_keys
+        )
+        if backbone_mean is None:
+            logger.warning(
+                f"Double-shift guard could not find a backbone norm reference in "
+                f"{mlx_dir} (unusual layout?); falling back to applying the +1.0 "
+                "shift."
+            )
+        else:
+            mtp_mean = float(mx.mean(all_mtp_weights[mtp_ref_key]).item())
+            if _norms_already_shifted(mtp_mean, backbone_mean):
+                apply_shift = False
+                logger.warning(
+                    f"MTP norms appear already shifted (mean {mtp_mean:.4f} ~= "
+                    f"backbone '{backbone_key}' mean {backbone_mean:.4f}); skipping "
+                    "+1.0 shift to avoid double-shift. Pass --force-norm-shift to "
+                    "override."
+                )
+            else:
+                logger.info(
+                    f"Double-shift guard: MTP norm '{mtp_ref_key}' mean "
+                    f"{mtp_mean:.4f} matches the unshifted convention (backbone "
+                    f"'{backbone_key}' mean {backbone_mean:.4f}); applying +1.0 shift."
+                )
+
+    if apply_shift:
+        for k in list(all_mtp_weights.keys()):
+            if "norm" in k and k.endswith(".weight") and all_mtp_weights[k].ndim == 1:
+                all_mtp_weights[k] = all_mtp_weights[k] + 1.0
+                logger.info(f"  Shifted norm: {k}")
 
     # Convert fused MoE experts (``experts.gate_up_proj`` / ``experts.down_proj``,
     # 3-D stacked, no ``.weight`` suffix) into the ``switch_mlp.{gate,up,down}_proj``

--- a/tests/test_mtp_extract_double_shift.py
+++ b/tests/test_mtp_extract_double_shift.py
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the MTP norm double-shift guard.
+
+These exercise the PURE decision helper ``_norms_already_shifted`` with
+synthetic means only -- no network, no model downloads, no MLX tensors.
+"""
+
+from scripts.extract_mtp_weights import _find_backbone_reference, _norms_already_shifted
+
+
+def test_unshifted_norms_get_shifted():
+    # HF ``(1 + w)`` convention: the MTP norm mean sits ~1.0 below the
+    # +1-shifted backbone reference. Guard must say NOT already shifted so the
+    # +1.0 shift is applied.
+    backbone_mean = 1.02
+    mtp_mean = backbone_mean - 1.0  # 0.02
+    assert _norms_already_shifted(mtp_mean, backbone_mean) is False
+
+
+def test_already_shifted_norms_are_skipped():
+    # Source already stores MTP norms in MLX's shifted convention: the MTP mean
+    # already matches the backbone. Guard must detect this so the shift is
+    # skipped (avoids a silent w+2 double-shift).
+    backbone_mean = 1.02
+    mtp_mean = 1.03
+    assert _norms_already_shifted(mtp_mean, backbone_mean) is True
+
+
+def test_boundary_midpoint_prefers_shift():
+    # Exactly halfway between the shifted and unshifted references: equidistant,
+    # so the strict ``<`` resolves to "not already shifted" -> shift applied.
+    backbone_mean = 1.0
+    mtp_mean = backbone_mean - 0.5  # 0.5, equidistant from 1.0 and 0.0
+    assert _norms_already_shifted(mtp_mean, backbone_mean) is False
+
+
+def test_boundary_just_past_midpoint_detects_shift():
+    # Just closer to the backbone than to backbone-1.0 -> already shifted.
+    backbone_mean = 1.0
+    mtp_mean = backbone_mean - 0.4  # 0.6, closer to 1.0 than to 0.0
+    assert _norms_already_shifted(mtp_mean, backbone_mean) is True
+
+
+def test_find_backbone_reference_matches_same_norm_type():
+    mtp_norm_keys = [
+        "mtp.pre_fc_norm_embedding.weight",  # MTP-only: no backbone counterpart
+        "mtp.layers.0.input_layernorm.weight",
+    ]
+    backbone_keys = [
+        "model.embed_tokens.weight",
+        "model.layers.0.input_layernorm.weight",
+        "model.layers.0.post_attention_layernorm.weight",
+        "model.norm.weight",
+    ]
+    mtp_key, backbone_key = _find_backbone_reference(mtp_norm_keys, backbone_keys)
+    assert mtp_key == "mtp.layers.0.input_layernorm.weight"
+    assert backbone_key == "model.layers.0.input_layernorm.weight"
+
+
+def test_find_backbone_reference_skips_mtp_keys_and_returns_none_when_absent():
+    # Only an MTP-specific norm with no backbone counterpart present.
+    mtp_norm_keys = ["mtp.pre_fc_norm_hidden.weight"]
+    backbone_keys = ["model.layers.0.input_layernorm.weight", "mtp.something.weight"]
+    assert _find_backbone_reference(mtp_norm_keys, backbone_keys) == (None, None)


### PR DESCRIPTION
## Why

`scripts/extract_mtp_weights.py` unconditionally shifts every 1-D MTP norm weight by `+1.0` (the `if "norm" in k and k.endswith(".weight") and ndim == 1` loop) to match the `(1 + w)` convention mlx-lm's sanitize bakes into the backbone norms. That shift is correct **only** when the HF source stores its MTP norms unshifted (HF convention).

If a source already stores MTP norms in MLX's shifted convention, applying `+1.0` again **silently double-shifts** them (`w+2` instead of `w+1`). The norms end up off by 1, draft acceptance collapses to ~0%, and there is **no error** — the exact same symptom as the *missing*-shift bug fixed in #1214, just from the opposite direction. An external contributor flagged "converted-MTP norm double-shift prevention" as a real MTP-correctness gap.

## What

Add a principled double-shift guard (no fragile absolute-magnitude threshold — norm distributions vary too widely for that):

- Use the target MLX model's **backbone** norms as the reference convention. After mlx-lm sanitize they are already `+1`-shifted, so they anchor the "shifted" reference.
- Pair an MTP norm with the **same-type** backbone norm (e.g. `mtp.layers.0.input_layernorm.weight` ↔ `...layers.0.input_layernorm.weight`), read that one backbone tensor from the local MLX model, and compare means.
- Decision extracted into a pure, unit-testable helper `_norms_already_shifted(mtp_mean, backbone_mean)`: an unshifted MTP norm sits ~1.0 below the backbone; if the MTP mean is instead closer to the backbone mean, the norms are already shifted → skip the `+1.0`.
- On detection: **skip** the shift and log a loud warning naming both means.
- Add `--force-norm-shift` escape hatch to force the shift regardless.
- If no backbone reference can be found (unusual layout), fall back to the **current** behavior (shift) and log that the guard could not run.

The reference is read from the target MLX model directory (`--mlx-model`) rather than the HF source, because the guard needs a *known-shifted* anchor: the HF source and its MTP norms share one convention, so the HF backbone cannot distinguish a normal (unshifted) MTP head from a pre-shifted one — only the post-sanitize MLX backbone can. This is also network-free.

## Tests

`tests/test_mtp_extract_double_shift.py` exercises the pure helpers with synthetic means only (no network, no model downloads):
- unshifted case (`mtp = backbone - 1` → shift applied),
- already-shifted case (`mtp ≈ backbone` → shift skipped),
- boundary/midpoint cases (equidistant prefers shift; just-past-midpoint detects shift),
- `_find_backbone_reference` same-type matching and the no-counterpart → `(None, None)` fallback.

```
$ pytest tests/test_mtp_extract_double_shift.py -q
6 passed
```

`ruff check` + `ruff format` clean on both files.

## Notes

AI-assisted (Claude Opus 4.8). Behavior for well-formed sources is unchanged — normal (unshifted) sources still get the `+1.0` shift; only genuinely pre-shifted sources are spared the double-shift.