### PR TITLE
fix(qwen3.6): undo mlx-lm's spurious +1.0 RMSNorm shift so Qwen3.6-35B-A3B serves coherently

### DIFF
--- a/tests/test_qwen3_5_norm_shift.py
+++ b/tests/test_qwen3_5_norm_shift.py
@@ -92,6 +92,25 @@ def test_standard_form_plus_mtp_is_spurious():
     assert nsf._would_spuriously_shift(w) is True
 
 
+def test_zero_centered_mtp_norms_do_not_mask_standard_form_language_model():
+    # codex #1234: ``mtp.*`` norm gains (stripped by sanitize, and possibly a
+    # different convention) must NOT be averaged into the language-model
+    # convention check. A standard-form language model bundled with enough
+    # zero-centered MTP head norms would, under a naive aggregate, fall below
+    # the threshold and be misclassified as "already correct" — leaving the
+    # corrupting +1.0 shift on the real norms. The check must still flag it.
+    w = _add_mtp_trigger(_norm_weights(mean=1.05))
+    for layer in range(8):
+        base = f"language_model.mtp.layers.{layer}"
+        w[f"{base}.input_layernorm.weight"] = mx.full((8,), 0.0, dtype=mx.float32)
+        w[f"{base}.post_attention_layernorm.weight"] = mx.full(
+            (8,), 0.0, dtype=mx.float32
+        )
+    # A naive aggregate over all norm keys here is ~0.47 (< 0.5) and would
+    # misfire; excluding the mtp.* norms keeps it at ~1.05 and flags correctly.
+    assert nsf._would_spuriously_shift(w) is True
+
+
 def test_zero_centered_plus_mtp_is_not_spurious():
     w = _add_mtp_trigger(_norm_weights(mean=0.02))
     assert nsf._would_spuriously_shift(w) is False

--- a/tests/test_qwen3_5_norm_shift.py
+++ b/tests/test_qwen3_5_norm_shift.py
@@ -125,7 +125,29 @@ def test_sanitize_applied_shift_detects_delta():
 
 
 @pytest.fixture
-def patched_textmodel(monkeypatch):
+def _restore_install_state():
+    """Snapshot the process-wide install state and restore it on teardown.
+
+    The install patches ``mlx_lm.models.qwen3_5.TextModel`` — process-global
+    state the production serve path may have installed at import. Tests here
+    uninstall/reinstall it over a monkeypatched stub; without restoring the
+    prior state, a later test (or the real serve wiring) would silently run
+    with the fix removed, making the suite order-dependent (codex #1234).
+
+    Requested BEFORE ``monkeypatch`` so it sets up first and therefore tears
+    down LAST — after monkeypatch has reverted ``TextModel`` to the real
+    class, so a re-install lands on the real class, not the stub.
+    """
+    was_installed = nsf.is_installed()
+    yield
+    if was_installed and not nsf.is_installed():
+        nsf.install_qwen3_5_norm_shift_fix()
+    elif not was_installed and nsf.is_installed():
+        nsf.uninstall_qwen3_5_norm_shift_fix()
+
+
+@pytest.fixture
+def patched_textmodel(_restore_install_state, monkeypatch):
     """Install the fix over a stub TextModel whose original sanitize mimics
     mlx-lm. Yields a callable ``run(weights)`` invoking the patched method."""
     from mlx_lm.models import qwen3_5 as q
@@ -192,7 +214,7 @@ def test_wrapper_noop_without_proxy(patched_textmodel):
 # ----------------------------------------------------------------------
 
 
-def test_install_uninstall_roundtrip(monkeypatch):
+def test_install_uninstall_roundtrip(_restore_install_state, monkeypatch):
     from mlx_lm.models import qwen3_5 as q
 
     nsf.uninstall_qwen3_5_norm_shift_fix()

--- a/tests/test_qwen3_5_norm_shift.py
+++ b/tests/test_qwen3_5_norm_shift.py
@@ -1,0 +1,288 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for the Qwen3.5/3.6 norm-shift correction.
+
+Pins the surgical fix in ``vllm_mlx.patches.qwen3_5_norm_shift`` that undoes
+mlx-lm's spurious ``+1.0`` RMSNorm-weight shift on mtp-bundled VLM checkpoints
+like ``mlx-community/Qwen3.6-35B-A3B-*`` (ml-explore/mlx-lm#1197).
+
+No model download: a stub ``TextModel.sanitize`` faithfully mimics mlx-lm's
+proxy-gated shift so the wrapper's undo behavior is exercised end-to-end.
+
+Covered:
+1. Decision helper — proxy fires + standard-form norms => spurious shift.
+2. Decision helper — proxy fires + zero-centered norms => NOT spurious (keep).
+3. Decision helper — proxy silent => never spurious.
+4. Wrapper — standard-form + mtp: shift is undone (loaded gains ~1, not ~2).
+5. Wrapper — zero-centered + mtp: shift is preserved (correct behavior).
+6. Wrapper — no proxy: unchanged.
+7. install/uninstall swap the class method and are idempotent.
+"""
+
+from __future__ import annotations
+
+import types
+
+import mlx.core as mx
+import pytest
+
+from vllm_mlx.patches import qwen3_5_norm_shift as nsf
+
+# mlx-lm's real norm-key suffixes (kept identical to the module under test).
+_NORM_KEYS = (
+    ".input_layernorm.weight",
+    ".post_attention_layernorm.weight",
+    "model.norm.weight",
+    ".q_norm.weight",
+    ".k_norm.weight",
+)
+
+
+def _mlx_lm_mimic_sanitize(self, weights):
+    """Faithful copy of ``mlx_lm.models.qwen3_5.TextModel.sanitize`` (0.31.3)."""
+    has_mtp_weights = any("mtp." in k for k in weights)
+    has_unsanitized_conv1d = any(
+        "conv1d.weight" in k and v.shape[-1] != 1 for k, v in weights.items()
+    )
+    should_shift = has_mtp_weights or has_unsanitized_conv1d
+    weights = {k: v for k, v in weights.items() if "mtp." not in k}
+    if getattr(self.args, "tie_word_embeddings", False):
+        weights.pop("lm_head.weight", None)
+    for k, v in list(weights.items()):
+        if "conv1d.weight" in k and v.shape[-1] != 1:
+            weights[k] = v.moveaxis(2, 1)
+        if should_shift and any(k.endswith(sfx) for sfx in _NORM_KEYS):
+            if v.ndim == 1:
+                weights[k] = v + 1.0
+    return weights
+
+
+def _norm_weights(mean: float, n_layers: int = 4):
+    """Build a synthetic weight dict of ``n_layers`` layers of norm gains with
+    the given aggregate mean, plus one non-norm 2-D weight for realism."""
+    w = {}
+    for layer in range(n_layers):
+        base = f"language_model.model.layers.{layer}"
+        w[f"{base}.input_layernorm.weight"] = mx.full((8,), mean, dtype=mx.float32)
+        w[f"{base}.post_attention_layernorm.weight"] = mx.full(
+            (8,), mean, dtype=mx.float32
+        )
+        w[f"{base}.self_attn.q_norm.weight"] = mx.full((4,), mean, dtype=mx.float32)
+        w[f"{base}.self_attn.o_proj.weight"] = mx.zeros((8, 8), dtype=mx.float32)
+    w["language_model.model.norm.weight"] = mx.full((8,), mean, dtype=mx.float32)
+    return w
+
+
+def _add_mtp_trigger(w):
+    # A non-norm mtp tensor so ``has_mtp`` fires without polluting the norm
+    # aggregate (mtp weights are stripped by sanitize anyway).
+    w = dict(w)
+    w["language_model.mtp.layers.0.self_attn.qkv_proj.weight"] = mx.zeros(
+        (8, 8), dtype=mx.float32
+    )
+    return w
+
+
+# ----------------------------------------------------------------------
+# Decision helpers
+# ----------------------------------------------------------------------
+
+
+def test_standard_form_plus_mtp_is_spurious():
+    w = _add_mtp_trigger(_norm_weights(mean=1.05))
+    assert nsf._would_spuriously_shift(w) is True
+
+
+def test_zero_centered_plus_mtp_is_not_spurious():
+    w = _add_mtp_trigger(_norm_weights(mean=0.02))
+    assert nsf._would_spuriously_shift(w) is False
+
+
+def test_no_proxy_is_never_spurious():
+    # Standard-form norms but no mtp / no unsanitized conv1d => proxy silent.
+    w = _norm_weights(mean=1.05)
+    assert nsf._would_spuriously_shift(w) is False
+
+
+def test_unsanitized_conv1d_standard_form_is_spurious():
+    w = _norm_weights(mean=1.05)
+    # conv1d with shape[-1] != 1 trips has_unsanitized_conv1d.
+    w["language_model.model.layers.0.linear_attn.conv1d.weight"] = mx.zeros(
+        (8, 4, 3), dtype=mx.float32
+    )
+    assert nsf._would_spuriously_shift(w) is True
+
+
+def test_sanitize_applied_shift_detects_delta():
+    raw = _norm_weights(mean=1.0)
+    shifted = {k: (v + 1.0 if v.ndim == 1 else v) for k, v in raw.items()}
+    assert nsf._sanitize_applied_shift(raw, shifted) is True
+    assert nsf._sanitize_applied_shift(raw, dict(raw)) is False
+
+
+# ----------------------------------------------------------------------
+# Full wrapper behavior (stub original mimicking mlx-lm)
+# ----------------------------------------------------------------------
+
+
+@pytest.fixture
+def patched_textmodel(monkeypatch):
+    """Install the fix over a stub TextModel whose original sanitize mimics
+    mlx-lm. Yields a callable ``run(weights)`` invoking the patched method."""
+    from mlx_lm.models import qwen3_5 as q
+
+    # Clean slate on the real module attributes the patch stashes onto.
+    nsf.uninstall_qwen3_5_norm_shift_fix()
+    for attr in (
+        "_RAPID_MLX_ORIG_TEXTMODEL_SANITIZE",
+        "_RAPID_MLX_NORM_SHIFT_INSTALLED",
+    ):
+        if hasattr(q, attr):
+            monkeypatch.delattr(q, attr, raising=False)
+
+    class _StubTextModel:
+        sanitize = _mlx_lm_mimic_sanitize
+
+    monkeypatch.setattr(q, "TextModel", _StubTextModel)
+
+    nsf.install_qwen3_5_norm_shift_fix()
+
+    fake_self = types.SimpleNamespace(
+        args=types.SimpleNamespace(tie_word_embeddings=False)
+    )
+
+    def run(weights):
+        return q.TextModel.sanitize(fake_self, weights)
+
+    yield run
+    nsf.uninstall_qwen3_5_norm_shift_fix()
+
+
+def _mean(v):
+    return float(v.astype(mx.float32).mean())
+
+
+def test_wrapper_undoes_shift_on_standard_form(patched_textmodel):
+    w = _add_mtp_trigger(_norm_weights(mean=1.05))
+    out = patched_textmodel(w)
+    key = "language_model.model.layers.0.input_layernorm.weight"
+    # mlx-lm would leave this at ~2.05; the fix restores ~1.05.
+    assert _mean(out[key]) == pytest.approx(1.05, abs=1e-4)
+    # mtp keys still stripped by the delegated original.
+    assert not any("mtp." in k for k in out)
+
+
+def test_wrapper_preserves_shift_on_zero_centered(patched_textmodel):
+    w = _add_mtp_trigger(_norm_weights(mean=0.02))
+    out = patched_textmodel(w)
+    key = "language_model.model.norm.weight"
+    # Genuinely zero-centered => the shift is correct and must be kept (~1.02).
+    assert _mean(out[key]) == pytest.approx(1.02, abs=1e-4)
+
+
+def test_wrapper_noop_without_proxy(patched_textmodel):
+    w = _norm_weights(mean=1.05)
+    out = patched_textmodel(w)
+    key = "language_model.model.layers.0.post_attention_layernorm.weight"
+    # No mtp / no unsanitized conv1d => no shift, no undo.
+    assert _mean(out[key]) == pytest.approx(1.05, abs=1e-4)
+
+
+# ----------------------------------------------------------------------
+# install / uninstall wiring
+# ----------------------------------------------------------------------
+
+
+def test_install_uninstall_roundtrip(monkeypatch):
+    from mlx_lm.models import qwen3_5 as q
+
+    nsf.uninstall_qwen3_5_norm_shift_fix()
+    for attr in (
+        "_RAPID_MLX_ORIG_TEXTMODEL_SANITIZE",
+        "_RAPID_MLX_NORM_SHIFT_INSTALLED",
+    ):
+        if hasattr(q, attr):
+            monkeypatch.delattr(q, attr, raising=False)
+
+    class _StubTextModel:
+        sanitize = _mlx_lm_mimic_sanitize
+
+    monkeypatch.setattr(q, "TextModel", _StubTextModel)
+    original = q.TextModel.sanitize
+
+    nsf.install_qwen3_5_norm_shift_fix()
+    assert nsf.is_installed() is True
+    assert q.TextModel.sanitize is not original
+    # Idempotent.
+    nsf.install_qwen3_5_norm_shift_fix()
+    assert nsf.is_installed() is True
+
+    nsf.uninstall_qwen3_5_norm_shift_fix()
+    assert nsf.is_installed() is False
+    assert q.TextModel.sanitize is original
+
+
+def test_install_fires_on_real_serve_import_path():
+    """The fix must install when a SERVE-path module is imported, not only
+    when the patch module itself is imported directly.
+
+    The production ``rapid-mlx serve`` boot path is::
+
+        cli -> server -> engine.batched -> utils.tokenizer.
+        load_model_with_fallback -> mlx_lm.load -> mlx_lm.utils.load_model
+
+    None of those import ``model_runner``, so wiring the install ONLY at
+    ``model_runner.py`` (as this fix first did) never fired in production and
+    Qwen3.6-35B still served garbage. The in-process tests above would pass
+    anyway because they import the patch module directly, masking the gap —
+    exactly the trap the deepseek_v32 indexer gate documents. This test runs
+    in a SUBPROCESS (pristine interpreter, no state leak) and imports a
+    serve-path module, then asserts the fix installed.
+
+    A future refactor that removes the ``utils/tokenizer.py`` install hook
+    makes this fail — the same symptom (garbage Qwen3.6 output) it prevents.
+    """
+    import subprocess
+    import sys
+    import textwrap
+
+    script = textwrap.dedent(
+        """
+        import sys
+
+        # Import a SERVE-path module (NOT the patch module directly).
+        import vllm_mlx.utils.tokenizer  # noqa: F401
+
+        from vllm_mlx.patches.qwen3_5_norm_shift import is_installed
+
+        if not is_installed():
+            print("FAIL: is_installed() False after serve-path import")
+            sys.exit(1)
+
+        from mlx_lm.models import qwen3_5 as q
+
+        if not getattr(q, "_RAPID_MLX_NORM_SHIFT_INSTALLED", False):
+            print(
+                "FAIL: upstream marker mlx_lm.models.qwen3_5."
+                "_RAPID_MLX_NORM_SHIFT_INSTALLED is missing"
+            )
+            sys.exit(1)
+
+        print("OK")
+        """
+    ).strip()
+
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+
+    assert result.returncode == 0, (
+        f"subprocess install-on-serve-path check failed (exit={result.returncode}).\n"
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}\n"
+        "Wiring regression — Qwen3.6-35B would serve garbage again."
+    )
+    assert "OK" in result.stdout, (
+        f"subprocess did not print OK. stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )

--- a/vllm_mlx/model_runner.py
+++ b/vllm_mlx/model_runner.py
@@ -20,6 +20,9 @@ import mlx.core as mx
 from vllm_mlx.patches.deepseek_v32_indexer_gate import (
     install_deepseek_v32_indexer_gate as _install_dsv32_indexer_gate,
 )
+from vllm_mlx.patches.qwen3_5_norm_shift import (
+    install_qwen3_5_norm_shift_fix as _install_qwen3_5_norm_shift_fix,
+)
 
 if TYPE_CHECKING:
     from vllm.config import VllmConfig
@@ -31,6 +34,12 @@ logger = logging.getLogger(__name__)
 # (e.g. mlx-community/pipenetwork-GLM-5.2-REAP50-MLX-4bit) load via mlx_lm.
 # Idempotent + no-op on configs that don't publish ``indexer_types``.
 _install_dsv32_indexer_gate()
+
+# Correct mlx-lm's spurious +1.0 RMSNorm-weight shift on mtp-bundled Qwen3.5/3.6
+# VLM checkpoints (e.g. mlx-community/Qwen3.6-35B-A3B-*), which otherwise load
+# with doubled norm scale → garbage output (ml-explore/mlx-lm#1197). Idempotent
+# + no-op on checkpoints whose norm gains are already zero-centered.
+_install_qwen3_5_norm_shift_fix()
 
 
 @dataclass

--- a/vllm_mlx/patches/qwen3_5_norm_shift.py
+++ b/vllm_mlx/patches/qwen3_5_norm_shift.py
@@ -126,10 +126,16 @@ def _would_spuriously_shift(weights: dict) -> bool:
     )
     if not (has_mtp or has_unsanitized_conv1d):
         return False
+    # Judge the convention off the LANGUAGE-MODEL norms only. ``mtp.*`` head
+    # norms are stripped by the original sanitize (they never reach the served
+    # model) and can carry a different convention; counting zero-centered MTP
+    # norms here would drag a standard-form language model's aggregate below
+    # the threshold, misclassify it as "already correct", and leave the
+    # corrupting +1.0 shift on the real norms (codex #1234).
     means = [
         m
         for k, v in weights.items()
-        if _is_norm_key(k) and (m := _norm_gain_mean(v)) is not None
+        if _is_norm_key(k) and "mtp." not in k and (m := _norm_gain_mean(v)) is not None
     ]
     if not means:
         return False

--- a/vllm_mlx/patches/qwen3_5_norm_shift.py
+++ b/vllm_mlx/patches/qwen3_5_norm_shift.py
@@ -1,0 +1,228 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Correct mlx-lm's spurious RMSNorm-weight +1.0 shift on Qwen3.5/3.6 VLM checkpoints.
+
+Background
+----------
+``mlx_lm.models.qwen3_5.TextModel.sanitize`` decides whether to add ``+1.0``
+to every RMSNorm gain via a *proxy*::
+
+    has_mtp_weights      = any("mtp." in k for k in weights)
+    has_unsanitized_conv1d = any("conv1d.weight" in k and v.shape[-1] != 1 ...)
+    should_shift_norm_weights = has_mtp_weights or has_unsanitized_conv1d
+
+The shift exists to convert checkpoints whose norm gains are stored in the
+"``1 + w`` zero-centered" convention (gains stored centered at 0) into the
+standard convention mlx-lm's ``nn.RMSNorm`` expects (gains centered at 1). The
+``mtp.``-presence / unsanitized-``conv1d`` signals were chosen as a proxy for
+"this checkpoint uses the zero-centered convention".
+
+The proxy misfires on the ``mlx-community/Qwen3.6-35B-A3B-*`` MLX quants (and
+any sibling VLM checkpoint that bundles an MTP head). These checkpoints:
+
+* bundle an MTP sidecar head (``mtp.norm.weight``, ``mtp.layers.0.*``) →
+  ``has_mtp_weights`` is True, so the proxy fires; **but**
+* store their norm gains in the **standard** convention already (per-tensor
+  means ~1, aggregate ~1.2, never ~0).
+
+So mlx-lm adds ``+1.0`` to gains that were already ~1, yielding ~2 — a doubled
+RMSNorm scale that corrupts generation into garbage from the first token.
+``mlx-vlm`` loads the identical weights **without** shifting the
+``language_model.*`` norms and generates coherently, confirming no shift is the
+correct behavior. Reported upstream: ml-explore/mlx-lm#1197.
+
+Verified: loading ``mlx-community/Qwen3.6-35B-A3B-4bit`` with this patch active
+produces coherent output ("The capital of Japan is Tokyo", "17 × 23 = 391 …");
+without it, garbage. The 105 norm tensors' loaded means drop from ~2.0 to ~1.0.
+
+What this module patches
+------------------------
+Wraps ``mlx_lm.models.qwen3_5.TextModel.sanitize`` (the single site that owns
+the shift — the MoE class ``qwen3_5_moe.Model`` and the VLM wrapper
+``qwen3_5.Model`` both delegate norm handling to it). The wrapper:
+
+1. Inspects the **raw** ``weights`` BEFORE the original runs and computes
+   whether the original will *spuriously* shift: the proxy fires
+   (``has_mtp``/unsanitized ``conv1d``) **and** the norm gains are already in
+   standard form (aggregate mean ``>= _ZERO_CENTERED_THRESHOLD``, i.e. NOT
+   zero-centered).
+2. Calls the original ``sanitize`` verbatim (so all its other behavior —
+   ``mtp.`` stripping, tied-embedding drop, ``conv1d`` moveaxis — is inherited).
+3. Only if step 1 flagged a spurious shift **and** the original actually
+   applied it (a representative norm gain rose by ~1.0 across the call) does it
+   subtract the erroneous ``+1.0`` back from the shifted norm tensors.
+
+The step-3 "actually applied" re-check keys the correction off observed
+behavior, not off a copy of upstream's gate — so if upstream later fixes the
+misfire (stops shifting standard-form checkpoints), this wrapper detects no
+shift happened and does nothing. Delete this module + the import/call in
+``vllm_mlx.model_runner`` once mlx-lm ships the fix; nothing else changes.
+
+What it does NOT change
+-----------------------
+* Checkpoints whose norms are genuinely zero-centered (aggregate mean ~0) keep
+  the shift — the correction only fires when gains are already standard-form,
+  so a currently-working checkpoint (shift correct, or proxy False) is never
+  altered. Adding +1.0 to standard-form gains is always wrong (it doubles the
+  RMSNorm scale); undoing it is therefore always safe.
+* Non-Qwen3.5 architectures are untouched (only ``qwen3_5.TextModel``).
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_LOCK = threading.Lock()
+_INSTALLED = False
+
+# The exact norm-weight suffixes mlx-lm's qwen3_5 sanitize shifts (kept in sync
+# with ``mlx_lm.models.qwen3_5.TextModel.sanitize``'s ``norm_keys``). The
+# ``linear_attn.norm.weight`` gains are deliberately absent — mlx-lm does not
+# shift them, and neither must the correction.
+_NORM_SUFFIXES = (
+    ".input_layernorm.weight",
+    ".post_attention_layernorm.weight",
+    "model.norm.weight",
+    ".q_norm.weight",
+    ".k_norm.weight",
+)
+
+# Aggregate norm-gain mean below this => "zero-centered" storage (shift is
+# legitimate). At/above => "standard" storage (a proxy-triggered shift is
+# spurious). 0.5 is the natural midpoint between gains centered at 0 and gains
+# centered at 1; observed values are ~0 (zero-centered) vs ~1.2 (Qwen3.6),
+# leaving a wide margin.
+_ZERO_CENTERED_THRESHOLD = 0.5
+
+# Delta above which a representative norm gain is considered to have been
+# shifted by the original sanitize (the shift adds exactly 1.0).
+_SHIFT_DETECT_MIN = 0.5
+
+
+def _is_norm_key(key: str) -> bool:
+    return any(key.endswith(sfx) for sfx in _NORM_SUFFIXES)
+
+
+def _norm_gain_mean(value: Any) -> float | None:
+    """Mean of a 1-D norm gain tensor, or ``None`` if it isn't one."""
+    if getattr(value, "ndim", None) != 1:
+        return None
+    try:
+        return float(value.mean())
+    except Exception:  # pragma: no cover - defensive; quantized 1-D shouldn't hit
+        return None
+
+
+def _would_spuriously_shift(weights: dict) -> bool:
+    """True when the original sanitize would shift, but the norms are already
+    standard-form (so the shift corrupts them)."""
+    has_mtp = any("mtp." in k for k in weights)
+    has_unsanitized_conv1d = any(
+        "conv1d.weight" in k and getattr(v, "shape", (1,))[-1] != 1
+        for k, v in weights.items()
+    )
+    if not (has_mtp or has_unsanitized_conv1d):
+        return False
+    means = [
+        m
+        for k, v in weights.items()
+        if _is_norm_key(k) and (m := _norm_gain_mean(v)) is not None
+    ]
+    if not means:
+        return False
+    aggregate = sum(means) / len(means)
+    return aggregate >= _ZERO_CENTERED_THRESHOLD
+
+
+def _sanitize_applied_shift(raw: dict, result: dict) -> bool:
+    """True when the original sanitize actually added ~1.0 to the norm gains.
+
+    Keys the correction off observed behavior rather than a copy of upstream's
+    gate, so an eventual upstream fix (no shift) is auto-detected as "no undo".
+    ``TextModel.sanitize`` does not rename keys, so a norm key present in the
+    input is present unchanged in the output.
+    """
+    for k, rv in raw.items():
+        if not _is_norm_key(k) or k not in result:
+            continue
+        rm = _norm_gain_mean(rv)
+        om = _norm_gain_mean(result[k])
+        if rm is None or om is None:
+            continue
+        return (om - rm) >= _SHIFT_DETECT_MIN
+    return False
+
+
+def install_qwen3_5_norm_shift_fix() -> None:
+    """Install the Qwen3.5/3.6 norm-shift correction. Idempotent + thread-safe."""
+    global _INSTALLED
+
+    with _LOCK:
+        if _INSTALLED:
+            return
+
+        try:
+            from mlx_lm.models import qwen3_5 as q
+        except ImportError:  # pragma: no cover - mlx_lm always present in our env
+            logger.debug("[qwen3_5_norm_shift] mlx_lm not importable; skipping install")
+            return
+
+        # Stash the upstream original on the module the first time so a later
+        # install after a module reload retrieves the true original instead of
+        # re-wrapping the already-patched callable (would infinite-loop).
+        if not getattr(q, "_RAPID_MLX_NORM_SHIFT_INSTALLED", False):
+            q._RAPID_MLX_ORIG_TEXTMODEL_SANITIZE = q.TextModel.sanitize
+
+        orig_sanitize = q._RAPID_MLX_ORIG_TEXTMODEL_SANITIZE
+
+        # Re-entry guard: another module instance already patched the class.
+        if getattr(q, "_RAPID_MLX_NORM_SHIFT_INSTALLED", False):
+            _INSTALLED = True
+            return
+
+        def _patched_sanitize(self, weights):
+            spurious = _would_spuriously_shift(weights)
+            result = orig_sanitize(self, weights)
+            if spurious and _sanitize_applied_shift(weights, result):
+                shifted = 0
+                for k in list(result):
+                    v = result[k]
+                    if _is_norm_key(k) and getattr(v, "ndim", None) == 1:
+                        result[k] = v - 1.0
+                        shifted += 1
+                logger.info(
+                    "[qwen3_5_norm_shift] undid spurious +1.0 norm shift on "
+                    "%d standard-form gains (mtp-bundled Qwen3.5/3.6 checkpoint)",
+                    shifted,
+                )
+            return result
+
+        q.TextModel.sanitize = _patched_sanitize
+        q._RAPID_MLX_NORM_SHIFT_INSTALLED = True
+        _INSTALLED = True
+        logger.debug("[qwen3_5_norm_shift] installed")
+
+
+def uninstall_qwen3_5_norm_shift_fix() -> None:
+    """Undo the patch. Test-only; production code does not call this."""
+    global _INSTALLED
+
+    with _LOCK:
+        if not _INSTALLED:
+            return
+        try:
+            from mlx_lm.models import qwen3_5 as q
+        except ImportError:  # pragma: no cover
+            return
+        orig = getattr(q, "_RAPID_MLX_ORIG_TEXTMODEL_SANITIZE", None)
+        if orig is not None:
+            q.TextModel.sanitize = orig
+        q._RAPID_MLX_NORM_SHIFT_INSTALLED = False
+        _INSTALLED = False
+
+
+def is_installed() -> bool:
+    return _INSTALLED

--- a/vllm_mlx/utils/tokenizer.py
+++ b/vllm_mlx/utils/tokenizer.py
@@ -30,8 +30,6 @@ from ..patches.deepseek_v32_indexer_gate import (
     install_deepseek_v32_indexer_gate as _install_dsv32_indexer_gate,
 )
 
-_install_dsv32_indexer_gate()
-
 # Same wiring rationale as the indexer gate above: the production load path
 # (engine/batched.py -> load_model_with_fallback -> mlx_lm.load) does NOT
 # import model_runner, so installing the Qwen3.5/3.6 norm-shift correction
@@ -41,6 +39,9 @@ from ..patches.qwen3_5_norm_shift import (
     install_qwen3_5_norm_shift_fix as _install_qwen3_5_norm_shift_fix,
 )
 
+# Both installers run below the import block so no module-level import
+# follows an executable statement (E402).
+_install_dsv32_indexer_gate()
 _install_qwen3_5_norm_shift_fix()
 
 # Models that require tokenizer fallback

--- a/vllm_mlx/utils/tokenizer.py
+++ b/vllm_mlx/utils/tokenizer.py
@@ -32,6 +32,17 @@ from ..patches.deepseek_v32_indexer_gate import (
 
 _install_dsv32_indexer_gate()
 
+# Same wiring rationale as the indexer gate above: the production load path
+# (engine/batched.py -> load_model_with_fallback -> mlx_lm.load) does NOT
+# import model_runner, so installing the Qwen3.5/3.6 norm-shift correction
+# there alone would miss it. Install here too. Idempotent + a no-op on
+# checkpoints whose norm gains are already zero-centered.
+from ..patches.qwen3_5_norm_shift import (
+    install_qwen3_5_norm_shift_fix as _install_qwen3_5_norm_shift_fix,
+)
+
+_install_qwen3_5_norm_shift_fix()
+
 # Models that require tokenizer fallback
 FALLBACK_MODELS = [
     "nemotron",


### PR DESCRIPTION
## Why

Every `qwen3.6-35b*` alias (all quants: 4/6/8bit, ud, dwq, mxfp4, nvfp4, mtp-4bit, optiq-4bit → `mlx-community/Qwen3.6-35B-A3B-*`) served **pure garbage from the first token**. This blocks 0.11.1.

Root cause is upstream in **mlx-lm 0.31.3** (reported: [ml-explore/mlx-lm#1197](https://github.com/ml-explore/mlx-lm/issues/1197)). `mlx_lm.models.qwen3_5.TextModel.sanitize` adds `+1.0` to every RMSNorm gain when a *proxy* fires:

```python
should_shift = has_mtp_weights or has_unsanitized_conv1d
```

The proxy is meant to detect the "`1 + w` zero-centered" norm convention. These VLM checkpoints bundle an MTP head (`mtp.*` keys) so the proxy fires — **but** they store their norm gains in the **standard** convention already (per-tensor means ~1). mlx-lm therefore adds `+1.0` to gains that were already ~1 → doubled RMSNorm scale → garbage. `mlx-vlm` loads the identical weights **without** shifting the `language_model.*` norms and is coherent, which confirms *no shift* is correct here.

Proven by a tensor-by-tensor diff: mlx-lm's 105 norm gains load exactly `+1.0` higher than mlx-vlm's; every other tensor is bit-identical. Subtracting `1.0` back yields coherent output.

## What

`vllm_mlx/patches/qwen3_5_norm_shift.py` wraps `TextModel.sanitize` and undoes the `+1.0` **only** when all three hold:

1. the proxy would fire (`has_mtp` / unsanitized `conv1d`), **and**
2. the raw norm gains are already standard-form (aggregate mean ≥ 0.5), **and**
3. the original actually applied the shift (a representative gain rose ~1.0 across the call).

Condition (3) keys the correction off observed behavior, so an eventual upstream fix auto-disables this patch (no double-correction). Genuinely zero-centered checkpoints (aggregate ~0) keep the shift, so a currently-working checkpoint is never altered. Delete this module + its two call sites once mlx-lm ships the fix.

**Wiring:** installed at import of both `model_runner.py` and `utils/tokenizer.py`. The production serve path (`engine/batched.py` → `load_model_with_fallback` → `mlx_lm.load`) does **not** import `model_runner`, so `tokenizer.py` is the site that actually covers serving — the same lesson the `deepseek_v32` indexer gate documents inline. A subprocess regression test pins this (installing only in `model_runner.py` would silently re-break serving).

## Validation

- Root-caused via 3-way norm diff (raw safetensors vs mlx-lm-loaded vs mlx-vlm-loaded).
- End-to-end through the real BatchedEngine (`qwen3.6-35b`, port-isolated): coherent text (Rayleigh scattering), math (25×16 with steps), **tool-calling** (`get_weather{"city":"Tokyo"}`), and multi-turn memory. Garbage before, coherent after.
- 10 unit tests (decision logic, wrapper undo/preserve/no-op, install/uninstall idempotency, serve-path subprocess guard). `ruff check`/`format` clean. No regression in tokenizer/patch suites (129 passed). Codex: no blocking/major issues.

Refs ml-explore/mlx-lm#1197.

🤖 Generated with [Claude Code](https://claude.com/claude-code)