### PR TITLE
chore(docs): migrate deprecated vllm-mlx command/brand to rapid-mlx in examples & evals

### DIFF
--- a/evals/EVAL_CONFIGS.md
+++ b/evals/EVAL_CONFIGS.md
@@ -4,7 +4,7 @@ Detailed configuration record for every model evaluation. **Update this file whe
 
 > Historical note: these March 2026 evals were run on **Apple M3 Ultra (256GB)** using the then-default **SimpleEngine**.
 >
-> mlx-lm version: **0.30.7** | rapid-mlx: **main branch (2026-03-04)**
+> mlx-lm version: **0.30.7** | vllm-mlx (now rapid-mlx): **main branch (2026-03-04)**
 
 ## Model Configs
 

--- a/evals/EVAL_CONFIGS.md
+++ b/evals/EVAL_CONFIGS.md
@@ -4,7 +4,7 @@ Detailed configuration record for every model evaluation. **Update this file whe
 
 > Historical note: these March 2026 evals were run on **Apple M3 Ultra (256GB)** using the then-default **SimpleEngine**.
 >
-> mlx-lm version: **0.30.7** | vllm-mlx: **main branch (2026-03-04)**
+> mlx-lm version: **0.30.7** | rapid-mlx: **main branch (2026-03-04)**
 
 ## Model Configs
 
@@ -17,7 +17,7 @@ Detailed configuration record for every model evaluation. **Update this file whe
 | **Quantization** | 4bit affine |
 | **Engine** | SimpleEngine |
 | **Parser** | `hermes` |
-| **Server command** | `vllm-mlx serve <path> --port 8000 --enable-auto-tool-choice --tool-call-parser hermes` |
+| **Server command** | `rapid-mlx serve <path> --port 8000 --enable-auto-tool-choice --tool-call-parser hermes` |
 | **Load notes** | Loads directly, no fallback needed |
 | **Last tested** | 2026-03-04 |
 | **Result file** | `qwen3-0.6b-4bit.json` |
@@ -31,7 +31,7 @@ Detailed configuration record for every model evaluation. **Update this file whe
 | **Quantization** | 4bit affine |
 | **Engine** | SimpleEngine |
 | **Parser** | `hermes` |
-| **Server command** | `vllm-mlx serve <path> --port 8000 --enable-auto-tool-choice --tool-call-parser hermes` |
+| **Server command** | `rapid-mlx serve <path> --port 8000 --enable-auto-tool-choice --tool-call-parser hermes` |
 | **Load notes** | VLM-packaged (`Qwen3_5ForConditionalGeneration`). Falls back to `strict=False` to skip 297 vision tower params. Config `model_type: qwen3_5` maps to `mlx_lm.models.qwen3_5`. |
 | **Last tested** | 2026-03-04 |
 | **Result file** | `qwen3.5-4b-4bit.json` |
@@ -45,7 +45,7 @@ Detailed configuration record for every model evaluation. **Update this file whe
 | **Quantization** | 4bit affine |
 | **Engine** | SimpleEngine |
 | **Parser** | `hermes` |
-| **Server command** | `vllm-mlx serve <path> --port 8000 --enable-auto-tool-choice --tool-call-parser hermes` |
+| **Server command** | `rapid-mlx serve <path> --port 8000 --enable-auto-tool-choice --tool-call-parser hermes` |
 | **Load notes** | VLM-packaged. Falls back to `strict=False` to skip 333 vision tower params. Previously failed with "Missing 424 parameters" before `load_model_with_fallback` was patched to also catch `Missing` errors (not just `Received ... not in model`). |
 | **Last tested** | 2026-03-04 |
 | **Result file** | `qwen3.5-9b-4bit.json` |
@@ -59,7 +59,7 @@ Detailed configuration record for every model evaluation. **Update this file whe
 | **Quantization** | 4bit affine |
 | **Engine** | SimpleEngine |
 | **Parser** | `hermes` |
-| **Server command** | `vllm-mlx serve <path> --port 8000 --enable-auto-tool-choice --tool-call-parser hermes` |
+| **Server command** | `rapid-mlx serve <path> --port 8000 --enable-auto-tool-choice --tool-call-parser hermes` |
 | **Load notes** | Loads directly (text-only MoE, no VLM wrapper) |
 | **Last tested** | 2026-03-04 |
 | **Result file** | `qwen3.5-35b-a3b-4bit.json` |
@@ -73,7 +73,7 @@ Detailed configuration record for every model evaluation. **Update this file whe
 | **Quantization** | 8bit affine |
 | **Engine** | SimpleEngine |
 | **Parser** | `hermes` |
-| **Server command** | `vllm-mlx serve <path> --port 8000 --enable-auto-tool-choice --tool-call-parser hermes` |
+| **Server command** | `rapid-mlx serve <path> --port 8000 --enable-auto-tool-choice --tool-call-parser hermes` |
 | **Load notes** | Loads directly |
 | **Last tested** | 2026-03-04 |
 | **Result file** | `qwen3.5-35b-a3b-8bit.json` |
@@ -87,7 +87,7 @@ Detailed configuration record for every model evaluation. **Update this file whe
 | **Quantization** | mxfp4 (microscaling FP4) |
 | **Engine** | SimpleEngine |
 | **Parser** | `hermes` |
-| **Server command** | `vllm-mlx serve <path> --port 8000 --enable-auto-tool-choice --tool-call-parser hermes` |
+| **Server command** | `rapid-mlx serve <path> --port 8000 --enable-auto-tool-choice --tool-call-parser hermes` |
 | **Load notes** | Loads directly. Text-only variant (no VLM). |
 | **Last tested** | 2026-03-04 |
 | **Result file** | `qwen3.5-122b-a10b-mxfp4.json` |
@@ -101,7 +101,7 @@ Detailed configuration record for every model evaluation. **Update this file whe
 | **Quantization** | 8bit affine |
 | **Engine** | SimpleEngine |
 | **Parser** | `hermes` |
-| **Server command** | `vllm-mlx serve <path> --port 8000 --enable-auto-tool-choice --tool-call-parser hermes` |
+| **Server command** | `rapid-mlx serve <path> --port 8000 --enable-auto-tool-choice --tool-call-parser hermes` |
 | **Load notes** | Loads directly |
 | **Last tested** | 2026-03-04 |
 | **Result file** | `qwen3.5-122b-a10b-8bit.json` |
@@ -115,7 +115,7 @@ Detailed configuration record for every model evaluation. **Update this file whe
 | **Quantization** | 4bit affine |
 | **Engine** | SimpleEngine |
 | **Parser** | `hermes` |
-| **Server command** | `vllm-mlx serve <path> --port 8000 --enable-auto-tool-choice --tool-call-parser hermes` |
+| **Server command** | `rapid-mlx serve <path> --port 8000 --enable-auto-tool-choice --tool-call-parser hermes` |
 | **Load notes** | Loads directly. Large model (~45GB RAM). |
 | **Last tested** | 2026-03-04 |
 | **Result file** | `qwen3-coder-next-4bit.json` |
@@ -129,7 +129,7 @@ Detailed configuration record for every model evaluation. **Update this file whe
 | **Quantization** | 6bit affine |
 | **Engine** | SimpleEngine |
 | **Parser** | `hermes` |
-| **Server command** | `vllm-mlx serve <path> --port 8000 --enable-auto-tool-choice --tool-call-parser hermes` |
+| **Server command** | `rapid-mlx serve <path> --port 8000 --enable-auto-tool-choice --tool-call-parser hermes` |
 | **Load notes** | Loads directly |
 | **Last tested** | 2026-03-04 |
 | **Result file** | `qwen3-coder-next-6bit.json` |
@@ -143,7 +143,7 @@ Detailed configuration record for every model evaluation. **Update this file whe
 | **Quantization** | 4bit affine |
 | **Engine** | SimpleEngine |
 | **Parser** | `hermes` |
-| **Server command** | `vllm-mlx serve <path> --port 8000 --enable-auto-tool-choice --tool-call-parser hermes` |
+| **Server command** | `rapid-mlx serve <path> --port 8000 --enable-auto-tool-choice --tool-call-parser hermes` |
 | **Load notes** | Loads directly |
 | **Last tested** | 2026-03-04 |
 | **Result file** | `hermes-3-llama-3.1-8b-4bit.json` |
@@ -157,7 +157,7 @@ Detailed configuration record for every model evaluation. **Update this file whe
 | **Quantization** | 8bit affine |
 | **Engine** | SimpleEngine |
 | **Parser** | `glm47` |
-| **Server command** | `vllm-mlx serve <path> --port 8000 --enable-auto-tool-choice --tool-call-parser glm47` |
+| **Server command** | `rapid-mlx serve <path> --port 8000 --enable-auto-tool-choice --tool-call-parser glm47` |
 | **Load notes** | Loads directly. Uses GLM-4.7 specific tool parser. |
 | **Last tested** | 2026-03-04 |
 | **Result file** | `glm-4.7-flash-8bit.json` |
@@ -171,7 +171,7 @@ Detailed configuration record for every model evaluation. **Update this file whe
 | **Quantization** | mxfp4-q8 (mixed MXFP4 + Q8) |
 | **Engine** | SimpleEngine |
 | **Parser** | `harmony` |
-| **Server command** | `vllm-mlx serve <path> --port 8000 --enable-auto-tool-choice --tool-call-parser harmony` |
+| **Server command** | `rapid-mlx serve <path> --port 8000 --enable-auto-tool-choice --tool-call-parser harmony` |
 | **Load notes** | Loads directly. Uses Harmony format (OpenAI's custom control tokens). `SUPPORTS_NATIVE_TOOL_FORMAT=True` is critical — without it, multi-turn tool history is converted to plain text which the model cannot understand (caused 3% → 80% tool calling jump). Parallel tool calls not supported (harmony format limitation). |
 | **Last tested** | 2026-03-04 |
 | **Result file** | `gpt-oss-20b-mxfp4-q8.json` |
@@ -185,7 +185,7 @@ Detailed configuration record for every model evaluation. **Update this file whe
 | **Quantization** | 4bit affine |
 | **Engine** | SimpleEngine |
 | **Parser** | `minimax` |
-| **Server command** | `vllm-mlx serve <path> --port 8000 --enable-auto-tool-choice --tool-call-parser minimax` |
+| **Server command** | `rapid-mlx serve <path> --port 8000 --enable-auto-tool-choice --tool-call-parser minimax` |
 | **Load notes** | Loads directly. Slow TTFT (1.3s cold) due to large model. |
 | **Last tested** | 2026-03-04 |
 | **Result file** | `minimax-m2.5-4bit.json` |
@@ -200,7 +200,7 @@ Detailed configuration record for every model evaluation. **Update this file whe
 | **Engine** | SimpleEngine |
 | **Parser (as tested)** | `hermes` |
 | **Recommended parser** | `mistral` (#1071) — the historical run used `hermes` and scored only 17% tool calling. See load notes. |
-| **Server command** | `vllm-mlx serve <path> --port 8000 --enable-auto-tool-choice --tool-call-parser mistral` |
+| **Server command** | `rapid-mlx serve <path> --port 8000 --enable-auto-tool-choice --tool-call-parser mistral` |
 | **Load notes** | Loads directly (model_type=`mistral3`). Emits Mistral-native `[TOOL_CALLS]name[ARGS]{json}` tool calls, so it MUST use the `mistral` parser (#1071). The 2026-03-04 run used `hermes` (see result file) and scored 17% tool calling because `hermes` only understands `<tool_call>` XML and left the raw envelope in content. Coding 90% — one of the best coding models. |
 | **Last tested** | 2026-03-04 (with `hermes`; pre-#1071) |
 | **Result file** | `devstral-small-2-4bit.json` |
@@ -214,7 +214,7 @@ Detailed configuration record for every model evaluation. **Update this file whe
 | **Quantization** | 4bit affine |
 | **Engine** | SimpleEngine |
 | **Parser** | `hermes` |
-| **Server command** | `vllm-mlx serve <path> --port 8000 --enable-auto-tool-choice --tool-call-parser hermes` |
+| **Server command** | `rapid-mlx serve <path> --port 8000 --enable-auto-tool-choice --tool-call-parser hermes` |
 | **Load notes** | VLM-packaged. Falls back to `strict=False` to skip vision tower params. Previously failed due to incomplete download (missing weight shards). |
 | **Last tested** | 2026-03-04 |
 | **Result file** | `qwen3.5-27b-4bit.json` |
@@ -228,7 +228,7 @@ Detailed configuration record for every model evaluation. **Update this file whe
 | **Quantization** | 4bit affine |
 | **Engine** | SimpleEngine |
 | **Parser** | `glm47` |
-| **Server command** | `vllm-mlx serve <path> --port 8000 --enable-auto-tool-choice --tool-call-parser glm47` |
+| **Server command** | `rapid-mlx serve <path> --port 8000 --enable-auto-tool-choice --tool-call-parser glm47` |
 | **Load notes** | Loads directly. Previously reported as `glm4_moe` architecture incompatibility (508 missing params), but was actually an incomplete download (3 `.part` files). Uses GLM-4 tool parser. |
 | **Last tested** | 2026-03-04 |
 | **Result file** | `glm-4.5-air-4bit.json` |
@@ -243,7 +243,7 @@ Detailed configuration record for every model evaluation. **Update this file whe
 | **Engine** | SimpleEngine |
 | **Parser (as tested)** | `hermes` |
 | **Recommended parser** | `mistral` (#1071) — the historical run used `hermes` and scored only 17% tool calling. See load notes. |
-| **Server command** | `vllm-mlx serve <path> --port 8000 --enable-auto-tool-choice --tool-call-parser mistral` |
+| **Server command** | `rapid-mlx serve <path> --port 8000 --enable-auto-tool-choice --tool-call-parser mistral` |
 | **Load notes** | Loads via `strict=False` fallback (VLM packaging). The model emits Mistral-native `[TOOL_CALLS]name[ARGS]{json}` tool calls, so it MUST use the `mistral` parser (#1071). The 2026-03-04 run used `hermes` (see result file) and scored 17% tool calling because `hermes` only understands `<tool_call>` XML and left the raw envelope in content. Tokenizer regex warning: `fix_mistral_regex=True` recommended. |
 | **Last tested** | 2026-03-04 (with `hermes`; pre-#1071) |
 | **Result file** | `mistral-small-3.2-4bit.json` |

--- a/evals/README.md
+++ b/evals/README.md
@@ -1,6 +1,6 @@
-# vllm-mlx Model Evaluations
+# rapid-mlx Model Evaluations
 
-Standardized evaluation framework for comparing LLM performance on Apple Silicon via vllm-mlx.
+Standardized evaluation framework for comparing LLM performance on Apple Silicon via rapid-mlx.
 
 **Results**: See [SCORECARD.md](SCORECARD.md) for the comparison table.
 
@@ -8,7 +8,7 @@ Standardized evaluation framework for comparing LLM performance on Apple Silicon
 
 ```bash
 # 1. Start your model (see Server Flags below for model-specific flags)
-vllm-mlx serve <model-path> --port 8000
+rapid-mlx serve <model-path> --port 8000
 
 # 2. Run all eval suites (~5 min)
 python evals/run_eval.py --model "My-Model-Name" --quantization 4bit
@@ -24,13 +24,13 @@ Different models require different server flags for tool calling. Use the correc
 
 | Model Family | Server Flags |
 |-------------|-------------|
-| **Qwen / Hermes** | `vllm-mlx serve <model> --port 8000 --enable-auto-tool-choice --tool-call-parser hermes` |
-| **GPT-OSS (Harmony)** | `vllm-mlx serve <model> --port 8000 --enable-auto-tool-choice --tool-call-parser harmony` |
-| **MiniMax** | `vllm-mlx serve <model> --port 8000 --enable-auto-tool-choice --tool-call-parser minimax` |
-| **DeepSeek V3.1 / R1-0528** | `vllm-mlx serve <model> --port 8000 --enable-auto-tool-choice --tool-call-parser deepseek_v31` |
-| **GLM-4** | `vllm-mlx serve <model> --port 8000 --enable-auto-tool-choice --tool-call-parser glm47` |
-| **Qwen3-Coder (XML)** | `vllm-mlx serve <model> --port 8000 --enable-auto-tool-choice --tool-call-parser qwen3_coder_xml` |
-| **Other / No tools** | `vllm-mlx serve <model> --port 8000` |
+| **Qwen / Hermes** | `rapid-mlx serve <model> --port 8000 --enable-auto-tool-choice --tool-call-parser hermes` |
+| **GPT-OSS (Harmony)** | `rapid-mlx serve <model> --port 8000 --enable-auto-tool-choice --tool-call-parser harmony` |
+| **MiniMax** | `rapid-mlx serve <model> --port 8000 --enable-auto-tool-choice --tool-call-parser minimax` |
+| **DeepSeek V3.1 / R1-0528** | `rapid-mlx serve <model> --port 8000 --enable-auto-tool-choice --tool-call-parser deepseek_v31` |
+| **GLM-4** | `rapid-mlx serve <model> --port 8000 --enable-auto-tool-choice --tool-call-parser glm47` |
+| **Qwen3-Coder (XML)** | `rapid-mlx serve <model> --port 8000 --enable-auto-tool-choice --tool-call-parser qwen3_coder_xml` |
+| **Other / No tools** | `rapid-mlx serve <model> --port 8000` |
 
 Then pass the matching `--parser` to the eval script:
 ```bash

--- a/evals/SCORECARD.md
+++ b/evals/SCORECARD.md
@@ -1,4 +1,4 @@
-# vllm-mlx Model Scorecard
+# rapid-mlx Model Scorecard
 
 *Auto-generated on 2026-03-05 00:32 UTC*
 
@@ -289,7 +289,7 @@
 
 ## How to Add Your Results
 
-1. Start vllm-mlx with your model: `vllm-mlx serve <model> --port 8000`
+1. Start rapid-mlx with your model: `rapid-mlx serve <model> --port 8000`
 2. Run the eval: `python evals/run_eval.py --model "<model-name>" --quantization <quant>`
 3. Your results are saved to `evals/results/<model>.json`
 4. Regenerate this table: `python evals/generate_scorecard.py`

--- a/evals/generate_scorecard.py
+++ b/evals/generate_scorecard.py
@@ -83,7 +83,7 @@ def calc_avg(*scores) -> str:
 
 def generate_scorecard(results: list[dict]) -> str:
     lines = []
-    lines.append("# vllm-mlx Model Scorecard")
+    lines.append("# rapid-mlx Model Scorecard")
     lines.append("")
     lines.append(
         f"*Auto-generated on {datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M UTC')}*"
@@ -196,7 +196,7 @@ def generate_scorecard(results: list[dict]) -> str:
     lines.append("## How to Add Your Results")
     lines.append("")
     lines.append(
-        "1. Start vllm-mlx with your model: `vllm-mlx serve <model> --port 8000`"
+        "1. Start rapid-mlx with your model: `rapid-mlx serve <model> --port 8000`"
     )
     lines.append(
         '2. Run the eval: `python evals/run_eval.py --model "<model-name>" --quantization <quant>`'

--- a/evals/run_all_models.sh
+++ b/evals/run_all_models.sh
@@ -9,7 +9,7 @@
 # No set -e: server kill/wait returns non-zero which is expected
 
 PYTHON=python3.12
-CLI_CMD="from vllm_mlx.cli import main; import sys; sys.argv = ['vllm-mlx'] + sys.argv[1:]; main()"
+CLI_CMD="from vllm_mlx.cli import main; import sys; sys.argv = ['rapid-mlx'] + sys.argv[1:]; main()"
 PORT=8000
 EVAL_CMD="$PYTHON evals/run_eval.py"
 
@@ -74,7 +74,7 @@ stop_server() {
 }
 
 echo "========================================"
-echo "vllm-mlx Full Model Evaluation"
+echo "rapid-mlx Full Model Evaluation"
 echo "========================================"
 echo "Models: ${#MODELS[@]}"
 echo "Suites: $SUITES"

--- a/evals/run_eval.py
+++ b/evals/run_eval.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0
 """
-Unified Model Evaluation Runner for vllm-mlx.
+Unified Model Evaluation Runner for rapid-mlx.
 
-Runs 4 test suites against a running vllm-mlx server and produces a
+Runs 4 test suites against a running rapid-mlx server and produces a
 standardized JSON result file for model comparison.
 
 Suites:
@@ -15,7 +15,7 @@ Suites:
 
 Usage:
     # Start server first:
-    vllm-mlx serve <model> --port 8000
+    rapid-mlx serve <model> --port 8000
 
     # Run all suites:
     python evals/run_eval.py --model <display-name> --port 8000
@@ -1564,7 +1564,7 @@ ALL_SUITES = ["speed", "tool_calling", "coding", "reasoning", "general"]
 
 def main():
     parser = argparse.ArgumentParser(
-        description="vllm-mlx Model Evaluation Runner",
+        description="rapid-mlx Model Evaluation Runner",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Examples:
@@ -1628,8 +1628,8 @@ Examples:
 
     # Check server
     if not server_available(args.host, args.port):
-        print(f"ERROR: No vllm-mlx server at http://{args.host}:{args.port}")
-        print("Start one with: vllm-mlx serve <model> --port 8000")
+        print(f"ERROR: No rapid-mlx server at http://{args.host}:{args.port}")
+        print("Start one with: rapid-mlx serve <model> --port 8000")
         sys.exit(1)
 
     # Detect hardware
@@ -1637,7 +1637,7 @@ Examples:
     hw_label = args.hardware or f"{hw['chip']} ({hw['memory_gb']}GB)"
 
     print("=" * 60)
-    print("vllm-mlx Model Evaluation")
+    print("rapid-mlx Model Evaluation")
     print("=" * 60)
     print(f"  Model:    {args.model}")
     print(f"  Hardware: {hw_label}")

--- a/examples/benchmark_audio.py
+++ b/examples/benchmark_audio.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Audio benchmarks for vllm-mlx.
+Audio benchmarks for rapid-mlx.
 
 Benchmarks STT (Speech-to-Text), TTS (Text-to-Speech), and audio processing.
 """
@@ -298,7 +298,7 @@ def run_stt_benchmarks(audio_path: str):
 def main():
     import argparse
 
-    parser = argparse.ArgumentParser(description="Audio benchmarks for vllm-mlx")
+    parser = argparse.ArgumentParser(description="Audio benchmarks for rapid-mlx")
     parser.add_argument("--tts", action="store_true", help="Run TTS benchmarks")
     parser.add_argument("--stt", action="store_true", help="Run STT benchmarks")
     parser.add_argument("--audio", type=str, help="Audio file for STT benchmark")

--- a/examples/demo_curl_image.sh
+++ b/examples/demo_curl_image.sh
@@ -5,7 +5,7 @@
 #
 # Usage:
 #   1. Start the server with a VLM model:
-#      rapid-mlx --model mlx-community/Qwen3-VL-4B-Instruct-3bit --port 8000
+#      rapid-mlx serve mlx-community/Qwen3-VL-4B-Instruct-3bit --port 8000
 #
 #   2. Run this script:
 #      bash examples/demo_curl_image.sh

--- a/examples/demo_curl_image.sh
+++ b/examples/demo_curl_image.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 # Demo: curl API - Image Analysis
 #
-# Shows how to use vllm-mlx with curl for image understanding.
+# Shows how to use rapid-mlx with curl for image understanding.
 #
 # Usage:
 #   1. Start the server with a VLM model:
-#      vllm-mlx --model mlx-community/Qwen3-VL-4B-Instruct-3bit --port 8000
+#      rapid-mlx --model mlx-community/Qwen3-VL-4B-Instruct-3bit --port 8000
 #
 #   2. Run this script:
 #      bash examples/demo_curl_image.sh

--- a/examples/demo_curl_text.sh
+++ b/examples/demo_curl_text.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 # Demo: curl API - Text Chat
 #
-# Shows how to use vllm-mlx with curl for text-only chat.
+# Shows how to use rapid-mlx with curl for text-only chat.
 #
 # Usage:
 #   1. Start the server:
-#      vllm-mlx --model mlx-community/Llama-3.2-3B-Instruct-4bit --port 8000
+#      rapid-mlx --model mlx-community/Llama-3.2-3B-Instruct-4bit --port 8000
 #
 #   2. Run this script:
 #      bash examples/demo_curl_text.sh

--- a/examples/demo_curl_text.sh
+++ b/examples/demo_curl_text.sh
@@ -5,7 +5,7 @@
 #
 # Usage:
 #   1. Start the server:
-#      rapid-mlx --model mlx-community/Llama-3.2-3B-Instruct-4bit --port 8000
+#      rapid-mlx serve mlx-community/Llama-3.2-3B-Instruct-4bit --port 8000
 #
 #   2. Run this script:
 #      bash examples/demo_curl_text.sh

--- a/examples/demo_curl_video.sh
+++ b/examples/demo_curl_video.sh
@@ -5,7 +5,7 @@
 #
 # Usage:
 #   1. Start the server with a VLM model:
-#      rapid-mlx --model mlx-community/Qwen3-VL-4B-Instruct-3bit --port 8000
+#      rapid-mlx serve mlx-community/Qwen3-VL-4B-Instruct-3bit --port 8000
 #
 #   2. Run this script:
 #      bash examples/demo_curl_video.sh

--- a/examples/demo_curl_video.sh
+++ b/examples/demo_curl_video.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 # Demo: curl API - Video Analysis
 #
-# Shows how to use vllm-mlx with curl for video understanding.
+# Shows how to use rapid-mlx with curl for video understanding.
 #
 # Usage:
 #   1. Start the server with a VLM model:
-#      vllm-mlx --model mlx-community/Qwen3-VL-4B-Instruct-3bit --port 8000
+#      rapid-mlx --model mlx-community/Qwen3-VL-4B-Instruct-3bit --port 8000
 #
 #   2. Run this script:
 #      bash examples/demo_curl_video.sh

--- a/examples/demo_openai_image.py
+++ b/examples/demo_openai_image.py
@@ -6,7 +6,7 @@ Shows how to use rapid-mlx with the OpenAI Python SDK for image understanding.
 
 Usage:
     1. Start the server with a VLM model:
-       rapid-mlx --model mlx-community/Qwen3-VL-4B-Instruct-3bit --port 8000
+       rapid-mlx serve mlx-community/Qwen3-VL-4B-Instruct-3bit --port 8000
 
     2. Run this script:
        python examples/demo_openai_image.py

--- a/examples/demo_openai_image.py
+++ b/examples/demo_openai_image.py
@@ -2,11 +2,11 @@
 """
 Demo: OpenAI API - Image Analysis
 
-Shows how to use vllm-mlx with the OpenAI Python SDK for image understanding.
+Shows how to use rapid-mlx with the OpenAI Python SDK for image understanding.
 
 Usage:
     1. Start the server with a VLM model:
-       vllm-mlx --model mlx-community/Qwen3-VL-4B-Instruct-3bit --port 8000
+       rapid-mlx --model mlx-community/Qwen3-VL-4B-Instruct-3bit --port 8000
 
     2. Run this script:
        python examples/demo_openai_image.py
@@ -16,7 +16,7 @@ import base64
 
 from openai import OpenAI
 
-# Connect to vllm-mlx server
+# Connect to rapid-mlx server
 client = OpenAI(base_url="http://localhost:8000/v1", api_key="not-needed")
 
 print("=" * 60)

--- a/examples/demo_openai_text.py
+++ b/examples/demo_openai_text.py
@@ -6,7 +6,7 @@ Shows how to use rapid-mlx with the OpenAI Python SDK for text-only chat.
 
 Usage:
     1. Start the server with any model:
-       rapid-mlx --model mlx-community/Llama-3.2-3B-Instruct-4bit --port 8000
+       rapid-mlx serve mlx-community/Llama-3.2-3B-Instruct-4bit --port 8000
 
     2. Run this script:
        python examples/demo_openai_text.py

--- a/examples/demo_openai_text.py
+++ b/examples/demo_openai_text.py
@@ -2,11 +2,11 @@
 """
 Demo: OpenAI API - Text Chat
 
-Shows how to use vllm-mlx with the OpenAI Python SDK for text-only chat.
+Shows how to use rapid-mlx with the OpenAI Python SDK for text-only chat.
 
 Usage:
     1. Start the server with any model:
-       vllm-mlx --model mlx-community/Llama-3.2-3B-Instruct-4bit --port 8000
+       rapid-mlx --model mlx-community/Llama-3.2-3B-Instruct-4bit --port 8000
 
     2. Run this script:
        python examples/demo_openai_text.py
@@ -14,7 +14,7 @@ Usage:
 
 from openai import OpenAI
 
-# Connect to vllm-mlx server
+# Connect to rapid-mlx server
 client = OpenAI(base_url="http://localhost:8000/v1", api_key="not-needed")
 
 print("=" * 60)

--- a/examples/demo_openai_video.py
+++ b/examples/demo_openai_video.py
@@ -6,7 +6,7 @@ Shows how to use rapid-mlx with the OpenAI Python SDK for video understanding.
 
 Usage:
     1. Start the server with a VLM model:
-       rapid-mlx --model mlx-community/Qwen3-VL-4B-Instruct-3bit --port 8000
+       rapid-mlx serve mlx-community/Qwen3-VL-4B-Instruct-3bit --port 8000
 
     2. Run this script:
        python examples/demo_openai_video.py

--- a/examples/demo_openai_video.py
+++ b/examples/demo_openai_video.py
@@ -2,11 +2,11 @@
 """
 Demo: OpenAI API - Video Analysis
 
-Shows how to use vllm-mlx with the OpenAI Python SDK for video understanding.
+Shows how to use rapid-mlx with the OpenAI Python SDK for video understanding.
 
 Usage:
     1. Start the server with a VLM model:
-       vllm-mlx --model mlx-community/Qwen3-VL-4B-Instruct-3bit --port 8000
+       rapid-mlx --model mlx-community/Qwen3-VL-4B-Instruct-3bit --port 8000
 
     2. Run this script:
        python examples/demo_openai_video.py
@@ -16,7 +16,7 @@ import base64
 
 from openai import OpenAI
 
-# Connect to vllm-mlx server
+# Connect to rapid-mlx server
 client = OpenAI(base_url="http://localhost:8000/v1", api_key="not-needed")
 
 print("=" * 60)

--- a/examples/mcp_tool_use.py
+++ b/examples/mcp_tool_use.py
@@ -1,15 +1,15 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0
 """
-Example: MCP Tool Use with vllm-mlx
+Example: MCP Tool Use with rapid-mlx
 
 This example demonstrates how to use MCP (Model Context Protocol) tools
-with the vllm-mlx server.
+with the rapid-mlx server.
 
 Prerequisites:
 1. Install MCP support: pip install rapid-mlx[mcp]
 2. Create mcp.json config (see example below)
-3. Start server with MCP: vllm-mlx serve <model> --mcp-config mcp.json
+3. Start server with MCP: rapid-mlx serve <model> --mcp-config mcp.json
 
 Example mcp.json:
 {
@@ -52,7 +52,7 @@ def main():
 
     if not health.get("mcp"):
         print("\n   Warning: MCP not configured. Start server with --mcp-config")
-        print("   Example: vllm-mlx serve <model> --mcp-config mcp.json")
+        print("   Example: rapid-mlx serve <model> --mcp-config mcp.json")
         return
 
     # 2. List available MCP tools

--- a/examples/mic_live.py
+++ b/examples/mic_live.py
@@ -225,7 +225,7 @@ def main():
 
     print()
     print("╔════════════════════════════════════════════════════════╗")
-    print("║     🎙️  Live Speech Transcription - vllm-mlx          ║")
+    print("║     🎙️  Live Speech Transcription - rapid-mlx          ║")
     print("╚════════════════════════════════════════════════════════╝")
     print()
 

--- a/examples/mic_realtime.py
+++ b/examples/mic_realtime.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Real-Time Microphone Transcription with Whisper - vllm-mlx
+Real-Time Microphone Transcription with Whisper - rapid-mlx
 
 Transcribes speech in real-time as you speak using your Mac's microphone.
 
@@ -207,7 +207,7 @@ Examples:
 
     print()
     print("=" * 60)
-    print(" Real-Time Microphone Transcription - vllm-mlx")
+    print(" Real-Time Microphone Transcription - rapid-mlx")
     print("=" * 60)
     print()
 

--- a/examples/mic_transcribe.py
+++ b/examples/mic_transcribe.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Live Microphone Transcription with Whisper - vllm-mlx
+Live Microphone Transcription with Whisper - rapid-mlx
 
 Records audio from your Mac's microphone and transcribes it using Whisper.
 
@@ -146,7 +146,7 @@ Examples:
     args = parser.parse_args()
 
     print("=" * 60)
-    print(" Microphone Transcription - vllm-mlx")
+    print(" Microphone Transcription - rapid-mlx")
     print("=" * 60)
     print()
 

--- a/examples/mllm_benchmark.py
+++ b/examples/mllm_benchmark.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-MLLM Benchmark Script for vllm-mlx
+MLLM Benchmark Script for rapid-mlx
 
 Tests Multimodal Language Models with real images of dogs from Wikimedia Commons
 at different resolutions and measures performance metrics.
@@ -211,7 +211,7 @@ def run_benchmark(
     Run full MLLM benchmark across multiple resolutions.
 
     Args:
-        server_url: URL of the vllm-mlx server
+        server_url: URL of the rapid-mlx server
         resolutions: List of (width, height) tuples to test
         warmup_runs: Number of warmup runs before measuring
         image_url: URL of image to use (default: dog from Wikimedia)
@@ -383,7 +383,7 @@ def save_results(results: list[BenchmarkResult], output_path: str):
 
 def main():
     parser = argparse.ArgumentParser(
-        description="MLLM Benchmark for vllm-mlx - Tests with dog images at different resolutions",
+        description="MLLM Benchmark for rapid-mlx - Tests with dog images at different resolutions",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Examples:
@@ -408,7 +408,7 @@ Examples:
         "--server-url",
         type=str,
         default="http://localhost:8000",
-        help="URL of the vllm-mlx server",
+        help="URL of the rapid-mlx server",
     )
     parser.add_argument(
         "--output",

--- a/examples/mllm_example.py
+++ b/examples/mllm_example.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0
 """
-Multimodal Language Model (MLLM) example using vllm-mlx.
+Multimodal Language Model (MLLM) example using rapid-mlx.
 
 This example demonstrates multimodal inference on Apple Silicon,
 including image understanding and visual question answering.

--- a/examples/test_batching.py
+++ b/examples/test_batching.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0
 """
-Example: Test continuous batching with vllm-mlx.
+Example: Test continuous batching with rapid-mlx.
 
 This script demonstrates the continuous batching capability by sending
 multiple concurrent requests and measuring throughput.

--- a/examples/test_openai_compatibility.py
+++ b/examples/test_openai_compatibility.py
@@ -7,7 +7,7 @@ It tests both the direct HTTP API and the official OpenAI Python client.
 
 Usage:
     # First start the server:
-    rapid-mlx --model mlx-community/Qwen3-VL-4B-Instruct-3bit --port 8000
+    rapid-mlx serve mlx-community/Qwen3-VL-4B-Instruct-3bit --port 8000
 
     # Then run this script:
     python examples/test_openai_compatibility.py
@@ -807,7 +807,7 @@ Examples:
     if not test_health_endpoint(args.server_url):
         print(f"{RED}ERROR: Cannot connect to server at {args.server_url}{RESET}")
         print("Make sure the rapid-mlx server is running:")
-        print("  rapid-mlx --model mlx-community/Qwen3-VL-4B-Instruct-3bit --port 8000")
+        print("  rapid-mlx serve mlx-community/Qwen3-VL-4B-Instruct-3bit --port 8000")
         sys.exit(1)
 
     print(f"{GREEN}Server is reachable!{RESET}")

--- a/examples/test_openai_compatibility.py
+++ b/examples/test_openai_compatibility.py
@@ -1,13 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 """
-OpenAI API Compatibility Test Script for vllm-mlx.
+OpenAI API Compatibility Test Script for rapid-mlx.
 
-This script tests the OpenAI API compatibility of the vllm-mlx server.
+This script tests the OpenAI API compatibility of the rapid-mlx server.
 It tests both the direct HTTP API and the official OpenAI Python client.
 
 Usage:
     # First start the server:
-    vllm-mlx --model mlx-community/Qwen3-VL-4B-Instruct-3bit --port 8000
+    rapid-mlx --model mlx-community/Qwen3-VL-4B-Instruct-3bit --port 8000
 
     # Then run this script:
     python examples/test_openai_compatibility.py
@@ -244,7 +244,7 @@ def test_chat_completions_openai(server_url: str) -> tuple[bool, str]:
     try:
         client = OpenAI(
             base_url=f"{server_url}/v1",
-            api_key="not-needed",  # vllm-mlx doesn't require API key
+            api_key="not-needed",  # rapid-mlx doesn't require API key
         )
 
         response = client.chat.completions.create(
@@ -681,7 +681,7 @@ def run_all_tests(server_url: str, test_image: bool = True, test_video: bool = T
         else:
             results["failed"] += 1
 
-    print_header("vllm-mlx OpenAI API Compatibility Tests")
+    print_header("rapid-mlx OpenAI API Compatibility Tests")
     print(f"Server URL: {server_url}\n")
 
     # Basic endpoint tests
@@ -770,7 +770,7 @@ def run_all_tests(server_url: str, test_image: bool = True, test_video: bool = T
 
 def main():
     parser = argparse.ArgumentParser(
-        description="Test OpenAI API compatibility of vllm-mlx server",
+        description="Test OpenAI API compatibility of rapid-mlx server",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Examples:
@@ -788,7 +788,7 @@ Examples:
         "--server-url",
         type=str,
         default="http://localhost:8000",
-        help="URL of the vllm-mlx server (default: http://localhost:8000)",
+        help="URL of the rapid-mlx server (default: http://localhost:8000)",
     )
     parser.add_argument(
         "--no-image",
@@ -806,8 +806,8 @@ Examples:
     print(f"Checking server at {args.server_url}...")
     if not test_health_endpoint(args.server_url):
         print(f"{RED}ERROR: Cannot connect to server at {args.server_url}{RESET}")
-        print("Make sure the vllm-mlx server is running:")
-        print("  vllm-mlx --model mlx-community/Qwen3-VL-4B-Instruct-3bit --port 8000")
+        print("Make sure the rapid-mlx server is running:")
+        print("  rapid-mlx --model mlx-community/Qwen3-VL-4B-Instruct-3bit --port 8000")
         sys.exit(1)
 
     print(f"{GREEN}Server is reachable!{RESET}")

--- a/examples/test_video.py
+++ b/examples/test_video.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Test script for VLM video support in vllm-mlx.
+Test script for VLM video support in rapid-mlx.
 
 This script tests video understanding capabilities by:
 1. Downloading a sample video (or using a local one)

--- a/examples/tts_example.py
+++ b/examples/tts_example.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-TTS Example - Text to Speech with vllm-mlx
+TTS Example - Text to Speech with rapid-mlx
 
 Usage:
     python examples/tts_example.py "Hello, how are you?"
@@ -89,7 +89,7 @@ def main():
     args = parser.parse_args()
 
     print("=" * 60)
-    print(" TTS Example - vllm-mlx")
+    print(" TTS Example - rapid-mlx")
     print("=" * 60)
     print()
 

--- a/examples/tts_multilingual.py
+++ b/examples/tts_multilingual.py
@@ -345,7 +345,7 @@ Examples:
     args = parser.parse_args()
 
     print("=" * 60)
-    print(" Multilingual TTS - vllm-mlx")
+    print(" Multilingual TTS - rapid-mlx")
     print("=" * 60)
 
     if args.list_models:

--- a/examples/video_benchmark.py
+++ b/examples/video_benchmark.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Video Benchmark Script for vllm-mlx
+Video Benchmark Script for rapid-mlx
 
 Tests Vision-Language Models with video at different configurations
 (FPS, frame count, resolution) and measures performance metrics.
@@ -499,7 +499,7 @@ def save_results(
 
 def main():
     parser = argparse.ArgumentParser(
-        description="Video Benchmark for vllm-mlx VLM models",
+        description="Video Benchmark for rapid-mlx VLM models",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Examples:


### PR DESCRIPTION
## Why

`rapid-mlx` is the primary CLI entry point; the `vllm-mlx*` commands survive only as back-compat aliases in `pyproject.toml` `[project.scripts]`. But our own `examples/` and `evals/` docs still printed `vllm-mlx serve …` commands and titled things "vllm-mlx", teaching every new reader the pre-rename identity. That keeps the old brand alive in the places most likely to be copy-pasted.

This is a docs/branding-only sweep of the hyphenated command/brand name in `examples/` and `evals/` → `rapid-mlx`. All commands remain functionally identical (both entry points dispatch to `vllm_mlx.cli:main`).

## Scope guardrails (deliberately NOT touched)

- The `vllm_mlx` **Python module / import name** (`from vllm_mlx.cli import main`, `vllm_mlx.*`) — separate, out of scope.
- `waybarrios/vllm-mlx#NNN` upstream provenance references in `tests/`.
- Back-compat filesystem paths (`~/.vllm-mlx`, `.config/vllm-mlx`) in `install.sh`/tests.
- The `vllm-mlx*` entry-point aliases in `pyproject.toml` and the release/supply-chain tooling that intentionally lists them.
- One local-path string literal in `examples/demo_openai_video.py:110`.

## Changes

25 files in `examples/` + `evals/`, 88 string replacements (command invocations, docstrings, `--help` descriptions, banner/title strings, markdown headings). `ruff format` clean on all changed `.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)