### PR TITLE
feat(telemetry): emit request event on the streaming chat path with real TTFT

### DIFF
--- a/tests/test_telemetry_streaming_request_wiring.py
+++ b/tests/test_telemetry_streaming_request_wiring.py
@@ -1,0 +1,183 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Wiring test: a completed STREAMING chat completion emits exactly one
+``request`` telemetry event carrying ``stream=True``, the inbound
+User-Agent (for ``caller_agent``), and a ``ttft_ms`` derived from the
+FIRST emitted token — not total latency.
+
+This is the streaming analogue of ``test_telemetry_request_wiring.py``.
+Real agent traffic (Cursor / Claude Code / Aider) is almost entirely
+streaming, so the non-streaming emit alone leaves ``caller_agent`` +
+``ttft_ms`` essentially empty in production; this path is what turns
+them real.
+
+Drives ``stream_chat_completion`` directly against a fake engine (no
+model load, no real generation) — the same harness as
+``tests/test_447_stream_tool_choice_auto.py`` — and intercepts
+``emit.request`` to assert the call-site contract. The bucketing of the
+raw UA and the sampling gate are covered in test_telemetry_redact.py /
+test_telemetry_emit.py; here we only assert the route reads the UA and
+threads the right fields (including a first-token-derived TTFT) through.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+
+import pytest
+
+# Importing ``vllm_mlx.routes.chat`` pulls in ``mlx`` transitively; the
+# Linux pr_validate runner has no mlx, so skip cleanly there.
+pytest.importorskip("mlx")
+
+from vllm_mlx.api.models import ChatCompletionRequest  # noqa: E402
+
+
+class _FakeStreamingOutput:
+    """Minimal ``GenerationOutput`` shim for the streaming loop."""
+
+    def __init__(self, new_text: str, finished: bool):
+        self.new_text = new_text
+        self.text = new_text
+        self.finished = finished
+        self.finish_reason = "stop" if finished else None
+        self.channel = None
+        self.prompt_tokens = 11
+        self.completion_tokens = 7
+        self.cached_tokens = 0
+        self.tokens = []
+        self.logprobs = None
+        self.tool_calls = None
+        self.matched_stop = None
+        self.raw_text = new_text
+
+
+class _FakeEngine:
+    """Yields a fixed plain-text delta sequence. Sleeps AFTER the first
+    token so the first-token wall-clock is clearly distinct from total
+    latency — this is what lets the test assert TTFT is measured at the
+    first token, not the end of the stream."""
+
+    def __init__(self, deltas: list[str], gap_after_first: float = 0.0):
+        self._deltas = deltas
+        self._gap = gap_after_first
+        self.tokenizer = None
+        self.is_mllm = False
+        self.supports_tool_calls = False
+        self.supports_guided_generation = False
+
+    async def stream_chat(self, **kwargs):
+        for i, d in enumerate(self._deltas):
+            if i == 1 and self._gap:
+                # Delay the REST of the stream, not the first token.
+                await asyncio.sleep(self._gap)
+            yield _FakeStreamingOutput(d, finished=(i == len(self._deltas) - 1))
+
+    def build_prompt(self, *args, **kwargs):
+        return "prompt"
+
+    def estimate_new_tokens(self, *args, **kwargs):
+        return (11, 7)
+
+
+@pytest.fixture(autouse=True)
+def _patch_cfg(monkeypatch):
+    """Minimal plain-text streaming config: no reasoning / tool parser so
+    each delta surfaces as a ``content`` event immediately."""
+    from vllm_mlx.config import server_config
+
+    cfg = server_config.get_config()
+    monkeypatch.setattr(cfg, "tool_call_parser", None, raising=False)
+    monkeypatch.setattr(cfg, "reasoning_parser_name", None, raising=False)
+    monkeypatch.setattr(cfg, "reasoning_parser", None, raising=False)
+    monkeypatch.setattr(cfg, "enable_auto_tool_choice", False, raising=False)
+    monkeypatch.setattr(cfg, "cloud_router", None, raising=False)
+    monkeypatch.setattr(cfg, "gc_control", False, raising=False)
+    yield
+
+
+def _request(model="test-model"):
+    return ChatCompletionRequest(
+        model=model,
+        messages=[{"role": "user", "content": "hi"}],
+        max_tokens=50,
+        stream=True,
+    )
+
+
+def _drive_stream(engine, request, *, caller_agent, emit_calls):
+    """Run ``stream_chat_completion`` to completion, capturing emit.request
+    call kwargs. Returns total wall-clock seconds spent in the stream."""
+    from vllm_mlx.routes import chat
+    from vllm_mlx.telemetry import emit
+
+    monkeypatch_target = emit
+    orig = monkeypatch_target.request
+    monkeypatch_target.request = lambda **kw: emit_calls.append(kw)
+
+    async def _run():
+        gen = chat.stream_chat_completion(
+            engine,
+            [{"role": "user", "content": "hi"}],
+            request,
+            caller_agent=caller_agent,
+        )
+        async for _sse in gen:
+            # Drain the stream; we only care about the terminal emit.
+            pass
+
+    t0 = time.perf_counter()
+    try:
+        asyncio.run(_run())
+    finally:
+        monkeypatch_target.request = orig
+    return time.perf_counter() - t0
+
+
+def test_streaming_completion_emits_request_event_with_first_token_ttft():
+    calls: list[dict] = []
+    # 0.2s gap after the first token → total latency dwarfs TTFT.
+    engine = _FakeEngine(["Hello", " ", "there", "!"], gap_after_first=0.2)
+    total_s = _drive_stream(
+        engine,
+        _request(),
+        caller_agent="cursor/1.9.0",
+        emit_calls=calls,
+    )
+
+    assert len(calls) == 1, f"expected exactly one request event, got {calls}"
+    kw = calls[0]
+    assert kw["endpoint"] == "/v1/chat/completions"
+    assert kw["stream"] is True
+    assert kw["status"] == 200
+    assert kw["model_alias"] == "test-model"
+    # The call site passes the RAW UA through; emit.request buckets it
+    # (asserted separately). It must READ the UA, not drop it.
+    assert kw["caller_agent"] == "cursor/1.9.0"
+    assert kw["prompt_tokens"] == 11
+    assert kw["completion_tokens"] == 7
+    assert kw["tool_call_used"] is False
+    assert isinstance(kw["ttft_ms"], (int, float))
+    assert isinstance(kw["tps"], (int, float))
+
+    # TTFT must be measured at the FIRST token, so it is a small fraction
+    # of total latency (which includes the 0.2s post-first-token gap) —
+    # NOT the total-latency value the non-streaming path would report.
+    total_ms = total_s * 1000.0
+    assert kw["ttft_ms"] > 0.0
+    assert kw["ttft_ms"] < 0.5 * total_ms, (
+        f"ttft_ms={kw['ttft_ms']:.1f} should be well under half of total "
+        f"latency {total_ms:.1f}ms — it must reflect first-token timing, "
+        f"not total"
+    )
+
+
+def test_streaming_request_event_caller_agent_absent_header():
+    calls: list[dict] = []
+    engine = _FakeEngine(["hi", " ", "world"])
+    _drive_stream(engine, _request(), caller_agent=None, emit_calls=calls)
+
+    assert len(calls) == 1
+    # No UA → the route passes None; emit.request maps it to "unknown".
+    assert calls[0]["caller_agent"] is None
+    assert calls[0]["stream"] is True

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -4823,6 +4823,15 @@ async def _create_chat_completion_impl(
         # the GPU once the client TCP-RST'd.
         request_id_holder: list[str | None] = [None]
         chat_kwargs["request_id_holder"] = request_id_holder
+        # Opt-in telemetry (Phase 2.2): the inbound User-Agent for the
+        # streaming ``request`` event's ``caller_agent``. Passed RAW (not
+        # bucketed) — ``emit.request`` funnels it through
+        # ``normalize_caller_agent`` exactly like the non-streaming path.
+        # Threaded as an explicit keyword so it never leaks into the
+        # ``**chat_kwargs`` the engine's ``stream_chat`` receives.
+        _caller_ua = (
+            raw_request.headers.get("user-agent") if raw_request is not None else None
+        )
         if use_guided and json_schema:
             # Constrained streaming: run guided generation buffered, then
             # synthesize an SSE stream from the buffered output. Falls
@@ -4836,6 +4845,7 @@ async def _create_chat_completion_impl(
                         request,
                         json_schema,
                         strict_mode=strict_mode,
+                        caller_agent=_caller_ua,
                         **chat_kwargs,
                     ),
                     raw_request,
@@ -4870,6 +4880,7 @@ async def _create_chat_completion_impl(
                         messages,
                         request,
                         json_schema,
+                        caller_agent=_caller_ua,
                         **chat_kwargs,
                     ),
                     raw_request,
@@ -4881,7 +4892,13 @@ async def _create_chat_completion_impl(
             )
         return StreamingResponse(
             _disconnect_guard(
-                stream_chat_completion(engine, messages, request, **chat_kwargs),
+                stream_chat_completion(
+                    engine,
+                    messages,
+                    request,
+                    caller_agent=_caller_ua,
+                    **chat_kwargs,
+                ),
                 raw_request,
                 engine=engine,
                 request_id_holder=request_id_holder,
@@ -5905,6 +5922,7 @@ async def stream_chat_completion(
     *,
     response_id: str | None = None,
     created: int | None = None,
+    caller_agent: str | None = None,
     **kwargs,
 ) -> AsyncIterator[str]:
     """Stream chat completion response.
@@ -5920,6 +5938,11 @@ async def stream_chat_completion(
             stream stays self-consistent across the guided→unconstrained
             handoff (DeepSeek pr_validate round 5 finding).
         created: Optional pre-computed Unix timestamp. Same rationale.
+        caller_agent: Raw inbound HTTP ``User-Agent`` for the opt-in
+            streaming ``request`` telemetry event. Passed through
+            unbucketed — ``emit.request`` funnels it through
+            ``normalize_caller_agent`` (never stored raw). ``None`` when
+            the header is absent or telemetry is off.
     """
     from ..service.postprocessor import StreamingPostProcessor
 
@@ -5932,6 +5955,14 @@ async def stream_chat_completion(
         if response_id is None:
             response_id = f"chatcmpl-{uuid.uuid4().hex[:8]}"
         start_time = time.perf_counter()
+        # Opt-in telemetry (Phase 2.2): wall-clock of the FIRST real output
+        # token (content / reasoning / tool_call). This is the meaningful
+        # TTFT for a streaming response — unlike non-streaming, where TTFT
+        # collapses to total latency. Stays ``None`` until the first token
+        # is emitted so an empty / immediately-aborted stream reports no
+        # first-token time. Captured inside the loop, read in the terminal
+        # block below.
+        first_token_ts: float | None = None
 
         # Check if we should include usage in the final chunk
         include_usage = request.stream_options and request.stream_options.include_usage
@@ -6151,6 +6182,15 @@ async def stream_chat_completion(
                 stream_matched_stop = _chunk_matched_stop
 
             for event in processor.process_chunk(output):
+                # Telemetry: stamp TTFT on the first real output token
+                # (content / reasoning / tool_call). Cheap monotonic read
+                # gated to fire once; never touches the wire.
+                if first_token_ts is None and event.type in (
+                    "content",
+                    "reasoning",
+                    "tool_call",
+                ):
+                    first_token_ts = time.perf_counter()
                 if event.type == "content":
                     if not want_logprobs:
                         _sse = _fast_sse_chunk(event.content, "content")
@@ -6801,6 +6841,60 @@ async def stream_chat_completion(
             yield f"data: {usage_chunk.model_dump_json(exclude_none=True)}\n\n"
 
         yield "data: [DONE]\n\n"
+
+        # Opt-in telemetry (Phase 2.2): record a bucketed ``request`` event
+        # for this completed STREAMING chat completion. This is the path
+        # real agent traffic (Cursor / Claude Code / Aider) takes, so it is
+        # where ``caller_agent`` + a MEANINGFUL ``ttft_ms`` actually come
+        # from — the non-streaming emit only ever sees one-shot self-tests.
+        #
+        # Emitted AFTER ``[DONE]`` (and any usage chunk) has been yielded so
+        # the terminal wire markers always reach the client first — the
+        # consent check / lazy queue-thread start can never delay stream
+        # completion, and it never touches first-token latency. On the
+        # SUCCESS path only: a client disconnect / early abort raises out of
+        # the loop above and unwinds through ``finally`` below, skipping
+        # this — matching the non-streaming (success-only) emit and how
+        # ``_disconnect_guard`` treats aborts.
+        #
+        # ``ttft_ms`` is wall-clock to the FIRST emitted token (captured in
+        # the loop), not total latency. ``tps`` is the DECODE throughput —
+        # completion tokens over the post-first-token window (total − ttft),
+        # the streaming analogue of the non-streaming ``completion / total``
+        # (where ttft == total collapses the window). Both fall back to the
+        # total-latency numbers when no token was emitted / the decode
+        # window is non-positive. ``emit.request`` is sampled +
+        # ``is_enabled()``-gated + ``@_safe``, so this is a cheap no-op when
+        # telemetry is off / not sampled and can never raise into the
+        # stream. ``caller_agent`` is passed RAW; the helper buckets it via
+        # ``normalize_caller_agent``.
+        if first_token_ts is not None:
+            _ttft_seconds = max(0.0, first_token_ts - start_time)
+        else:
+            _ttft_seconds = elapsed
+        _decode_seconds = elapsed - _ttft_seconds
+        _decode_tps = (
+            completion_tokens / _decode_seconds
+            if _decode_seconds > 0
+            else tokens_per_sec
+        )
+        _tool_call_used = bool(fallback_tool_calls) or (
+            getattr(processor, "_tool_calls_emitted_to_wire", 0) > 0
+        )
+        from vllm_mlx.telemetry import emit as _telemetry_emit
+
+        _telemetry_emit.request(
+            endpoint="/v1/chat/completions",
+            model_alias=request.model,
+            stream=True,
+            tool_call_used=_tool_call_used,
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+            ttft_ms=_ttft_seconds * 1000.0,
+            tps=_decode_tps,
+            status=200,
+            caller_agent=caller_agent,
+        )
     finally:
         if cfg.gc_control and gc_was_enabled:
             gc.enable()
@@ -6814,6 +6908,7 @@ async def stream_chat_completion_guided(
     json_schema: dict,
     *,
     strict_mode: bool = False,
+    caller_agent: str | None = None,
     **kwargs,
 ) -> AsyncIterator[str]:
     """Stream chat completion with json_schema constrained decoding.
@@ -6962,6 +7057,7 @@ async def stream_chat_completion_guided(
                 request,
                 response_id=response_id,
                 created=_sse_created,
+                caller_agent=caller_agent,
                 **kwargs,
             ):
                 yield chunk
@@ -7111,6 +7207,8 @@ async def stream_chat_completion_strict_postgen(
     messages: list,
     request: ChatCompletionRequest,
     json_schema: dict,
+    *,
+    caller_agent: str | None = None,
     **kwargs,
 ) -> AsyncIterator[str]:
     """R12-4 — streaming variant of post-generate strict enforcement.
@@ -7262,6 +7360,7 @@ async def stream_chat_completion_strict_postgen(
         request,
         response_id=response_id,
         created=created,
+        caller_agent=caller_agent,
         **kwargs,
     )
     try:


### PR DESCRIPTION
## Why

The engine's opt-in `request` telemetry event (bucketed `caller_agent` + perf) was wired **only on the non-streaming chat path**. Real agent traffic — Cursor, Claude Code, Aider — is almost entirely **streaming**, so in production `/v1/admin/dau`'s `caller_agent` and `ttft_ms` were essentially empty (only one-shot self-test data). Wiring the streaming path is what turns "who is calling / how fast" from empty into real coverage — the highest-ROI remaining telemetry-v2 gap.

## What

Emit exactly one `request` event on the streaming chat-completion path, with a **real** time-to-first-token:

- **`ttft_ms`** is wall-clock from request start to the **first emitted token** (content / reasoning / tool_call), captured inside the SSE generator loop. This is the meaningful number for a stream — unlike non-streaming, where TTFT collapses to total latency.
- **`tps`** is decode throughput: `completion_tokens / (total − ttft)` (the post-first-token window), the streaming analogue of the non-streaming `completion / total`. Falls back to `completion / total` when no token was emitted or the decode window is non-positive.
- **`stream=True`**, plus `endpoint`, `model_alias`, `tool_call_used`, `prompt_tokens`, `completion_tokens`, `status=200`, and `caller_agent` from the inbound `User-Agent`.
- **`caller_agent`** is passed **raw** and threaded as an explicit keyword (so it never leaks into the engine `**kwargs`); `emit.request` buckets it via `normalize_caller_agent` exactly like the non-streaming path (never stored raw).
- **Emitted after `[DONE]`** (and any usage chunk) has been yielded, on the **success path only**. It never touches first-token latency, never delays the terminal wire markers, and a client disconnect / early abort unwinds through `finally` and skips it — matching the non-streaming (success-only) emit and how `_disconnect_guard` treats aborts.
- Sampling + consent gating is **unchanged** — owned entirely by `emit.request` (`is_enabled()` + `_should_sample_request()` + `@_safe`); the call site adds no gating and cannot raise into the stream.
- Threaded `caller_agent` through the guided-fallback and strict-postgen streaming wrappers too, so those paths carry attribution when they funnel into `stream_chat_completion`.

## Tests

Adds `tests/test_telemetry_streaming_request_wiring.py`, mirroring the non-streaming `test_telemetry_request_wiring.py`. Drives `stream_chat_completion` against a fake engine (no model load), intercepts `emit.request`, and asserts:
- exactly one `request` event with `stream=True`, `status=200`, correct token counts and `tool_call_used=False`;
- a populated bucketed `caller_agent` read from the inbound UA (and `None` when the header is absent);
- `ttft_ms` derived from **first-token** timing — the fake engine sleeps 0.2s *after* the first token, and the test asserts `ttft_ms` is well under half of total latency (i.e. not the total-latency value).

`pytest.importorskip("mlx")` guards the module for the Linux `pr_validate` runner (importing `routes.chat` pulls in `mlx`). All new + related streaming/telemetry tests pass locally.

## Judgment calls

- The guided-**success** streaming path (`response_format: json_schema` + `use_guided`) runs `generate_with_schema` buffered and synthesizes its own SSE, so it does not funnel through `stream_chat_completion` and does not emit a `request` event (its guided-**fallback** path does). This is a small, non-agent-typical slice where TTFT is not meaningful anyway (buffered generation); left out to keep the diff minimal and additive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)