### PR TITLE
feat(cli): first-run guide to lift install→first-token conversion

### DIFF
--- a/tests/test_cli_chat.py
+++ b/tests/test_cli_chat.py
@@ -89,23 +89,31 @@ def test_chat_subcommand_registered_in_cli():
 
 
 def test_chat_no_model_defaults_to_qwen35_4b():
-    """`rapid-mlx chat` (no model) routes chat_command with qwen3.5-4b.
+    """`rapid-mlx chat` (no model) on a COLD cache routes chat_command with
+    the first-run starter (qwen3.5-4b-4bit).
 
     Goes through the real ``cli.main()`` so a parser-wiring regression
-    (e.g. dropping ``nargs='?'`` or changing the default alias) fails the
-    test. ``chat_command`` is patched to capture args before the REPL
-    runs.
+    (e.g. dropping ``nargs='?'`` or changing the sentinel default) fails the
+    test. The HF cache is forced empty so the starter reports NOT-cached
+    deterministically (the "one-time download" notice + interactive TTY path),
+    independent of this machine's real cache. ``chat_command`` is patched to
+    capture args before the REPL runs.
     """
     captured: list = []
     with (
         patch.object(sys, "argv", ["rapid-mlx", "chat"]),
+        # Interactive: exercise the intended cold-cache auto-select path (a
+        # non-TTY cold cache deliberately refuses rather than silently pull).
+        patch.object(sys.stdin, "isatty", return_value=True),
+        # Cold cache → select_chat_default() falls back to FIRST_RUN_MODEL.
+        patch("vllm_mlx.first_run.cached_known_aliases", return_value=[]),
         patch.object(cli, "chat_command", side_effect=captured.append),
     ):
         cli.main()
     assert len(captured) == 1
     args = captured[0]
     # Either the alias name itself or the resolved HF repo path — either
-    # signals the default plumbed through. The canonical alias is the one
+    # signals the starter plumbed through. The canonical alias is the one
     # we documented as the default; confirm via the round-trip name.
     assert (
         args.model == "qwen3.5-4b-4bit"
@@ -615,6 +623,51 @@ def test_chat_command_repl_multi_turn(monkeypatch, capsys):
     assert payloads[0]["messages"] == [{"role": "user", "content": "hello"}]
     # After /reset and "again", history should NOT contain "hello".
     assert payloads[1]["messages"] == [{"role": "user", "content": "again"}]
+
+
+# ----------------------------------------------------------------------
+# First-run guide (P0-3): one-time "connect your agent" tip on chat exit
+# ----------------------------------------------------------------------
+def test_chat_exit_agent_tip_fires_once_after_response(monkeypatch, tmp_path, capsys):
+    """After a session that produced a response, the one-time agent tip prints
+    on exit — and does NOT re-appear on the next session (marker claimed)."""
+    monkeypatch.setenv("RAPID_MLX_STATE_DIR", str(tmp_path / "state"))
+    # Force the interactive path so the TTY-gated tip runs under capsys.
+    monkeypatch.setattr(
+        "vllm_mlx.chat_render.supports_rich_output", lambda *_a, **_k: True
+    )
+
+    canned = [_delta("Hi there!")]
+    with _fake_server(canned) as (port, _payloads):
+        inputs = iter(["hello", "exit"])
+        monkeypatch.setattr("builtins.input", lambda _p="": next(inputs))
+        cli.chat_command(_ns_for_chat(port))
+    # Tip text is "... → rapid-mlx launch <agent|--all>" regardless of what
+    # agent (if any) is detected on the runner.
+    assert "rapid-mlx launch" in capsys.readouterr().out
+
+    with _fake_server(canned) as (port2, _payloads2):
+        inputs2 = iter(["hey", "exit"])
+        monkeypatch.setattr("builtins.input", lambda _p="": next(inputs2))
+        cli.chat_command(_ns_for_chat(port2))
+    assert "rapid-mlx launch" not in capsys.readouterr().out
+
+
+def test_chat_exit_agent_tip_skipped_when_no_response(monkeypatch, tmp_path, capsys):
+    """Immediate exit (no response produced) → no tip, and the one-time marker
+    is NOT consumed, so a later real session can still show it."""
+    monkeypatch.setenv("RAPID_MLX_STATE_DIR", str(tmp_path / "state"))
+    monkeypatch.setattr(
+        "vllm_mlx.chat_render.supports_rich_output", lambda *_a, **_k: True
+    )
+
+    with _fake_server([_delta("unused")]) as (port, _payloads):
+        inputs = iter(["exit"])
+        monkeypatch.setattr("builtins.input", lambda _p="": next(inputs))
+        cli.chat_command(_ns_for_chat(port))
+    assert "rapid-mlx launch" not in capsys.readouterr().out
+    # Marker never created → the one-time chance is intact.
+    assert not (tmp_path / "state" / "chat_agent_tip_shown").exists()
 
 
 def test_chat_command_system_prompt_prepended(monkeypatch):
@@ -2151,126 +2204,6 @@ def test_chat_no_thinking_hidden_from_help(capsys):
     )
     # Sanity check that we actually captured the chat help (not stdlib's).
     assert "--think" in help_text or "--no-think" in help_text
-
-
-# ----------------------------------------------------------------------
-# D8 — first-launch-only banner for "agents codex" tip
-# ----------------------------------------------------------------------
-
-
-def test_seen_tips_marker_round_trip(tmp_path, monkeypatch):
-    """``_has_seen_tip`` returns False before, True after ``_mark_tip_seen``."""
-    monkeypatch.setenv("RAPID_MLX_CONFIG_HOME", str(tmp_path))
-    assert cli._has_seen_tip("chat_intro_codex") is False
-    cli._mark_tip_seen("chat_intro_codex")
-    assert cli._has_seen_tip("chat_intro_codex") is True
-    # Marker file landed in the override dir.
-    assert (tmp_path / "seen-tips.json").exists()
-
-
-def test_seen_tips_marker_survives_corrupt_file(tmp_path, monkeypatch):
-    """A corrupt marker (parse error) must be treated as 'not seen' so
-    the tip re-fires once, rather than being silently hidden forever."""
-    monkeypatch.setenv("RAPID_MLX_CONFIG_HOME", str(tmp_path))
-    (tmp_path / "seen-tips.json").write_text("not json {{")
-    assert cli._has_seen_tip("chat_intro_codex") is False
-
-
-def test_chat_banner_shown_on_first_launch_only(monkeypatch, capsys, tmp_path):
-    """First chat launch shows the agents-codex tip; subsequent launches
-    do NOT. The marker file under ``RAPID_MLX_CONFIG_HOME`` records the
-    first-seen state."""
-    monkeypatch.setenv("RAPID_MLX_CONFIG_HOME", str(tmp_path))
-
-    # Force the TTY/NO_COLOR gate to think we're interactive (otherwise
-    # the marker logic short-circuits to "skip everything").
-    class _Tty(io.StringIO):
-        def isatty(self):
-            return True
-
-    monkeypatch.delenv("NO_COLOR", raising=False)
-
-    canned = [_delta("ok")]
-    # First launch.
-    with (
-        _fake_server(canned) as (port, _payloads),
-        patch.object(sys, "stdout", _Tty()) as buf1,
-    ):
-        inputs = iter(["exit"])
-        monkeypatch.setattr("builtins.input", lambda _p="": next(inputs))
-        cli.chat_command(_ns_for_chat(port))
-        first = buf1.getvalue()
-    assert "agents codex" in first, (
-        f"first launch should show the agents-codex tip; got {first!r}"
-    )
-
-    # Second launch — marker file now exists, banner should be suppressed.
-    canned2 = [_delta("ok")]
-    with (
-        _fake_server(canned2) as (port2, _payloads),
-        patch.object(sys, "stdout", _Tty()) as buf2,
-    ):
-        inputs2 = iter(["exit"])
-        monkeypatch.setattr("builtins.input", lambda _p="": next(inputs2))
-        cli.chat_command(_ns_for_chat(port2))
-        second = buf2.getvalue()
-    assert "agents codex" not in second, (
-        f"second launch must NOT re-show the banner; got {second!r}"
-    )
-
-
-def test_chat_banner_skipped_when_no_color_set(monkeypatch, capsys, tmp_path):
-    """``NO_COLOR`` or non-TTY stdout: skip the marker logic AND the
-    banner entirely so pipe/CI runs don't pollute the user's config."""
-    monkeypatch.setenv("RAPID_MLX_CONFIG_HOME", str(tmp_path))
-    monkeypatch.setenv("NO_COLOR", "1")
-
-    canned = [_delta("ok")]
-    with _fake_server(canned) as (port, _payloads):
-        inputs = iter(["exit"])
-        monkeypatch.setattr("builtins.input", lambda _p="": next(inputs))
-        cli.chat_command(_ns_for_chat(port))
-    out = capsys.readouterr().out
-    assert "agents codex" not in out, "NO_COLOR run should suppress the banner entirely"
-    # And no marker file was written.
-    assert not (tmp_path / "seen-tips.json").exists(), (
-        "NO_COLOR run must not pollute the user's config dir"
-    )
-
-
-def test_chat_banner_write_failure_does_not_abort(monkeypatch, tmp_path, capsys):
-    """If the marker dir is unwritable (read-only FS / permission
-    denied), the tip should still print and chat must continue — best
-    effort only."""
-    monkeypatch.setenv("RAPID_MLX_CONFIG_HOME", str(tmp_path / "no_perm"))
-
-    class _Tty(io.StringIO):
-        def isatty(self):
-            return True
-
-    monkeypatch.delenv("NO_COLOR", raising=False)
-
-    # Mock os.makedirs to raise so the write path fails.
-    real_makedirs = os.makedirs
-
-    def _failing(*a, **kw):
-        if str(tmp_path / "no_perm") in str(a[0]):
-            raise PermissionError("read only fs")
-        return real_makedirs(*a, **kw)
-
-    monkeypatch.setattr("os.makedirs", _failing)
-
-    canned = [_delta("ok")]
-    with (
-        _fake_server(canned) as (port, _payloads),
-        patch.object(sys, "stdout", _Tty()) as buf,
-    ):
-        inputs = iter(["exit"])
-        monkeypatch.setattr("builtins.input", lambda _p="": next(inputs))
-        # Must NOT raise.
-        cli.chat_command(_ns_for_chat(port))
-    # Banner still printed.
-    assert "agents codex" in buf.getvalue()
 
 
 # ----------------------------------------------------------------------

--- a/tests/test_cli_chat.py
+++ b/tests/test_cli_chat.py
@@ -102,8 +102,10 @@ def test_chat_no_model_defaults_to_qwen35_4b():
     captured: list = []
     with (
         patch.object(sys, "argv", ["rapid-mlx", "chat"]),
-        # Interactive: exercise the intended cold-cache auto-select path (a
-        # non-TTY cold cache deliberately refuses rather than silently pull).
+        # Interactive: exercise the intended cold-cache auto-select path,
+        # which prints the "one-time download" notice before the gate. (A
+        # non-TTY cold cache prints no notice and falls through to the same
+        # download gate silently — that path is covered by the non-TTY tests.)
         patch.object(sys.stdin, "isatty", return_value=True),
         # Cold cache → select_chat_default() falls back to FIRST_RUN_MODEL.
         patch("vllm_mlx.first_run.cached_known_aliases", return_value=[]),

--- a/tests/test_first_run_guide.py
+++ b/tests/test_first_run_guide.py
@@ -1,0 +1,425 @@
+# SPDX-License-Identifier: Apache-2.0
+"""First-run guide — install → first-token conversion.
+
+Covers the ``vllm_mlx/first_run.py`` helpers and their three wiring points in
+``vllm_mlx/cli.py``:
+
+  * P0-1 — ``chat`` / ``run`` with no model → starter auto-select in
+    ``main()`` (the known-good starter alias chosen, notice printed only on a
+    TTY; the standard download gate is left untouched — the ~2.5 GB starter is
+    under its 10 GiB confirm threshold — and non-interactive sessions fall
+    through to that gate exactly as before this feature).
+  * P0-2 — bare ``rapid-mlx`` in an interactive terminal → nameplate + exit 0;
+    non-interactive → unchanged help + exit 1.
+  * P0-3 — one-time "connect your agent" tip after the first chat that
+    produced a response (marker + gating helpers).
+
+Fully offline: no model load, no network, no real HF cache dependency — every
+machine-state probe is monkeypatched.
+"""
+
+from __future__ import annotations
+
+import sys
+from unittest import mock
+
+import pytest
+
+import vllm_mlx.cli as cli
+import vllm_mlx.first_run as fr
+
+
+# ======================================================================
+# P0-1: no-model → starter selection
+# ======================================================================
+def test_select_chat_default_cold_cache_returns_starter(monkeypatch):
+    monkeypatch.setattr(fr, "cached_known_aliases", lambda: [])
+    alias, already_cached = fr.select_chat_default()
+    assert alias == fr.FIRST_RUN_MODEL
+    assert already_cached is False
+
+
+def test_select_chat_default_always_starter_never_arbitrary_cached(monkeypatch):
+    # Even when other (possibly non-chat) models are cached, we pick the
+    # known-good starter — never the most-recently-downloaded alias.
+    monkeypatch.setattr(
+        fr,
+        "cached_known_aliases",
+        lambda: [("embeddinggemma-300m-8bit", 200.0), ("gpt-oss-20b-mxfp4-q8", 100.0)],
+    )
+    alias, already_cached = fr.select_chat_default()
+    assert alias == fr.FIRST_RUN_MODEL
+    # Starter is not among the cached set → not already-downloaded.
+    assert already_cached is False
+
+
+def test_select_chat_default_reports_starter_cached(monkeypatch):
+    # ``already_cached`` reflects whether the STARTER itself is downloaded.
+    monkeypatch.setattr(
+        fr,
+        "cached_known_aliases",
+        lambda: [(fr.FIRST_RUN_MODEL, 100.0), ("gpt-oss-20b-mxfp4-q8", 200.0)],
+    )
+    alias, already_cached = fr.select_chat_default()
+    assert alias == fr.FIRST_RUN_MODEL
+    assert already_cached is True
+
+
+def test_cached_known_aliases_maps_sorts_and_drops_unmapped(monkeypatch):
+    # size element is index 1 in the (repo, size, mtime) tuple.
+    fake_rows = [
+        ("org/Unmapped-Model", 0, 100.0),  # not in aliases.json → dropped
+        ("mlx-community/Qwen3.5-4B-4bit", 0, 300.0),  # newest
+        ("mlx-community/Gpt-Oss-20B", 0, 200.0),
+    ]
+
+    class _P:
+        def __init__(self, hf):
+            self.hf_path = hf
+
+    fake_profiles = {
+        "qwen3.5-4b-4bit": _P("mlx-community/Qwen3.5-4B-4bit"),
+        "gpt-oss-20b-mxfp4-q8": _P("mlx-community/Gpt-Oss-20B"),
+    }
+    # String-form targets (not ``setattr(cli, ...)``): ``cached_known_aliases``
+    # re-imports these from ``sys.modules`` at call time, and a sibling suite
+    # (test_cli_argcomplete) pops+reimports ``vllm_mlx.cli``, so the module-level
+    # ``cli`` reference here can go stale. Patching by dotted path re-resolves
+    # the live module object and stays effective regardless of import churn.
+    monkeypatch.setattr("vllm_mlx.cli._scan_hf_cache_models", lambda: fake_rows)
+    monkeypatch.setattr("vllm_mlx.model_aliases.list_profiles", lambda: fake_profiles)
+
+    rows = fr.cached_known_aliases()
+    assert [a for a, _ in rows] == ["qwen3.5-4b-4bit", "gpt-oss-20b-mxfp4-q8"]
+
+
+def test_cached_known_aliases_fail_silent(monkeypatch):
+    def _boom():
+        raise RuntimeError("broken cache dir")
+
+    # Dotted-path target (see the note in the sibling test): survives the
+    # ``vllm_mlx.cli`` pop+reimport that test_cli_argcomplete performs.
+    monkeypatch.setattr("vllm_mlx.cli._scan_hf_cache_models", _boom)
+    assert fr.cached_known_aliases() == []
+
+
+# ======================================================================
+# P0-2/P0-3: agent detection
+# ======================================================================
+class _Adapter:
+    def __init__(self, detected):
+        self._detected = detected
+
+    def detect(self):
+        return self._detected
+
+
+def test_detected_agents_prefers_claude_code(monkeypatch):
+    monkeypatch.setattr(
+        "vllm_mlx.launch.ADAPTERS",
+        {
+            "cursor": _Adapter(True),
+            "claude-code": _Adapter(True),
+            "cline": _Adapter(False),
+        },
+    )
+    agents = fr.detected_agents()
+    assert agents[0] == "claude-code"  # preference order leads
+    assert "cursor" in agents
+    assert "cline" not in agents  # not detected
+    assert fr.preferred_agent() == "claude-code"
+
+
+def test_detected_agents_none(monkeypatch):
+    monkeypatch.setattr(
+        "vllm_mlx.launch.ADAPTERS",
+        {"cursor": _Adapter(False), "claude-code": _Adapter(False)},
+    )
+    assert fr.detected_agents() == []
+    assert fr.preferred_agent() is None
+
+
+def test_detected_agents_detect_error_is_safe(monkeypatch):
+    class _Raiser:
+        def detect(self):
+            raise OSError("probe blew up")
+
+    monkeypatch.setattr("vllm_mlx.launch.ADAPTERS", {"claude-code": _Raiser()})
+    assert fr.detected_agents() == []
+
+
+# ======================================================================
+# P0-2: nameplate
+# ======================================================================
+def test_nameplate_cold_cache_no_agent(monkeypatch):
+    monkeypatch.setattr(fr, "cached_known_aliases", lambda: [])
+    monkeypatch.setattr(fr, "preferred_agent", lambda: None)
+    out = fr.build_nameplate("9.9.9")
+    assert "Rapid-MLX 9.9.9" in out
+    assert "rapid-mlx chat" in out
+    assert fr.FIRST_RUN_MODEL in out
+    assert fr.FIRST_RUN_MODEL_SIZE in out
+    assert "launch --all" in out  # generic signpost when no agent
+    assert "Found in your cache" not in out
+
+
+def test_nameplate_with_cache_and_agent(monkeypatch):
+    # A cached (possibly non-chat) model is LISTED, but the chat suggestion
+    # still points at the known-good starter — never the arbitrary cached alias.
+    monkeypatch.setattr(fr, "cached_known_aliases", lambda: [("qwen3.5-9b-4bit", 10.0)])
+    monkeypatch.setattr(fr, "preferred_agent", lambda: "claude-code")
+    out = fr.build_nameplate("9.9.9")
+    assert "Found in your cache: qwen3.5-9b-4bit" in out
+    assert "rapid-mlx chat qwen3.5-9b-4bit" not in out
+    assert fr.FIRST_RUN_MODEL in out  # chat target is the starter
+    assert "rapid-mlx chat <model>" in out  # "pick a cached one" hint
+    assert "launch claude-code" in out  # named agent signpost
+
+
+def test_nameplate_starter_cached_says_already_downloaded(monkeypatch):
+    monkeypatch.setattr(
+        fr, "cached_known_aliases", lambda: [(fr.FIRST_RUN_MODEL, 10.0)]
+    )
+    monkeypatch.setattr(fr, "preferred_agent", lambda: None)
+    out = fr.build_nameplate("9.9.9")
+    assert "already downloaded" in out
+    assert "launch --all" in out
+
+
+# ======================================================================
+# P0-3: one-time tip marker + text
+# ======================================================================
+def test_tip_marker_claimed_once_only(monkeypatch, tmp_path):
+    monkeypatch.setenv("RAPID_MLX_STATE_DIR", str(tmp_path / "state"))
+    # The atomic claim wins exactly once (the exclusive-create), then every
+    # subsequent claim loses — so a second concurrent session can't re-print.
+    assert fr.claim_chat_agent_tip() is True
+    assert fr.claim_chat_agent_tip() is False
+    assert fr.claim_chat_agent_tip() is False
+
+
+def test_tip_claim_failsafe_on_unwritable_state_dir(monkeypatch, tmp_path):
+    # State dir sits under an existing FILE → the marker's parent mkdir raises
+    # → claim returns False (never nag, never crash), not True.
+    blocker = tmp_path / "blocker"
+    blocker.write_text("x")
+    monkeypatch.setenv("RAPID_MLX_STATE_DIR", str(blocker / "state"))
+    assert fr.claim_chat_agent_tip() is False
+
+
+def test_state_dir_env_override(monkeypatch, tmp_path):
+    target = tmp_path / "custom-state"
+    monkeypatch.setenv("RAPID_MLX_STATE_DIR", str(target))
+    assert fr._state_dir() == target
+
+
+def test_tip_text_with_and_without_agent(monkeypatch):
+    monkeypatch.setattr(fr, "preferred_agent", lambda: "claude-code")
+    assert "launch claude-code" in fr.chat_agent_tip_text()
+    monkeypatch.setattr(fr, "preferred_agent", lambda: None)
+    assert "launch --all" in fr.chat_agent_tip_text()
+
+
+# ======================================================================
+# main() wiring — P0-1 auto-select
+# ======================================================================
+def _run_main_capture_chat(argv, *, stdin_tty=True):
+    """Drive the REAL ``main()`` for a chat/run invocation, intercepting the
+    dispatch to ``chat_command`` so nothing loads a model. Returns the captured
+    ``args`` namespace (post auto-select + alias resolution)."""
+    captured = {}
+
+    def _capture(args):
+        captured["args"] = args
+
+    with (
+        mock.patch.object(cli, "chat_command", _capture),
+        mock.patch("vllm_mlx.telemetry.maybe_prompt_for_consent", return_value=False),
+        mock.patch(
+            "vllm_mlx._version_check.prompt_upgrade_if_available",
+            return_value=False,
+        ),
+        # Pretend everything is cached so the download-confirm gate never
+        # blocks the test on an explicit-model run.
+        mock.patch("vllm_mlx._download_gate.is_repo_cached", return_value=True),
+        mock.patch.object(sys, "argv", ["rapid-mlx", *argv]),
+        mock.patch.object(sys.stdin, "isatty", return_value=stdin_tty),
+    ):
+        cli.main()
+    return captured.get("args")
+
+
+def test_chat_no_model_auto_selects_starter(monkeypatch, capsys):
+    monkeypatch.setattr(
+        "vllm_mlx.first_run.select_chat_default",
+        lambda: ("qwen3.5-4b-4bit", False),
+    )
+    args = _run_main_capture_chat(["chat"], stdin_tty=True)
+    assert args is not None
+    # The auto-selected alias flowed through normal resolution → _original_alias
+    # holds the user-facing name, args.model the resolved HF path.
+    assert getattr(args, "_original_alias", None) == "qwen3.5-4b-4bit"
+    out = capsys.readouterr().out
+    assert "No model specified — using qwen3.5-4b-4bit" in out
+
+
+def test_run_alias_no_model_auto_selects_starter(monkeypatch, capsys):
+    # ``run`` is an argparse alias of ``chat`` (Ollama compat) and the no-model
+    # auto-select branch gates on {"chat", "run"}, so the alias must get the
+    # same starter selection + notice, not just ``chat``.
+    monkeypatch.setattr(
+        "vllm_mlx.first_run.select_chat_default",
+        lambda: ("qwen3.5-4b-4bit", False),
+    )
+    args = _run_main_capture_chat(["run"], stdin_tty=True)
+    assert args is not None
+    assert getattr(args, "_original_alias", None) == "qwen3.5-4b-4bit"
+    assert "No model specified — using qwen3.5-4b-4bit" in capsys.readouterr().out
+
+
+def test_chat_no_model_non_tty_starter_cached_proceeds_silently(monkeypatch, capsys):
+    # Non-interactive + the starter already downloaded (zero download) →
+    # proceeds silently (no notice, no prompt). The standard download gate's
+    # own is_repo_cached check governs (helper stubs it cached).
+    monkeypatch.delenv("RAPID_MLX_AUTO_PULL", raising=False)
+    monkeypatch.setattr(
+        "vllm_mlx.first_run.select_chat_default",
+        lambda: ("qwen3.5-4b-4bit", True),
+    )
+    args = _run_main_capture_chat(["chat"], stdin_tty=False)
+    assert args is not None
+    assert "No model specified" not in capsys.readouterr().out
+
+
+def test_chat_no_model_non_tty_cold_cache_falls_through_silently(monkeypatch, capsys):
+    # Non-interactive + a GENUINELY uncached starter (download gate ARMED:
+    # is_repo_cached=False). The run must (a) NOT prompt — the confirm gate is
+    # TTY-only — and (b) still fall through to dispatch, exactly as a bare
+    # `rapid-mlx chat` behaved before this feature. Exiting 1 here would
+    # silently regress documented scripted callers. Uses the gate probe (rather
+    # than the everything-cached capture helper) so the cold-cache gate path is
+    # actually exercised.
+    monkeypatch.delenv("RAPID_MLX_AUTO_PULL", raising=False)
+    confirm, dispatched = _run_main_gate_probe(
+        ["chat"],
+        auto_select_alias="qwen3.5-4b-4bit",
+        starter_cached=False,
+        stdin_tty=False,
+    )
+    assert confirm.called is False  # non-TTY → no y/N prompt
+    assert dispatched is True  # fell through to chat_command, not exit 1
+    out_err = capsys.readouterr()
+    assert "No model specified" not in out_err.out  # notice is TTY-only
+    assert "No model specified" not in out_err.err
+
+
+def test_chat_explicit_model_skips_autoselect(monkeypatch, capsys):
+    args = _run_main_capture_chat(["chat", "qwen3.5-9b-4bit"], stdin_tty=True)
+    assert getattr(args, "_original_alias", None) == "qwen3.5-9b-4bit"
+    assert "No model specified" not in capsys.readouterr().out
+
+
+# ======================================================================
+# main() wiring — download-confirm gate interaction
+# ======================================================================
+def _run_main_gate_probe(
+    argv, *, auto_select_alias=None, starter_cached=False, stdin_tty=True
+):
+    """Drive ``main()`` with the download-confirm gate armed (model reported
+    NOT cached by the gate's ``is_repo_cached``). Returns
+    ``(confirm_or_abort_mock, dispatched)``, where ``dispatched`` is True iff
+    the run reached ``chat_command`` (i.e. fell through to dispatch rather than
+    aborting). ``starter_cached`` sets what ``select_chat_default`` reports
+    about the starter (only affects the notice wording); ``stdin_tty`` toggles
+    the interactivity the gate reads (the confirm prompt is TTY-only)."""
+    confirm = mock.MagicMock()
+    state = {"dispatched": False}
+
+    def _dispatch(args):
+        state["dispatched"] = True
+
+    ctx = [
+        mock.patch.object(cli, "chat_command", _dispatch),
+        mock.patch("vllm_mlx.telemetry.maybe_prompt_for_consent", return_value=False),
+        mock.patch(
+            "vllm_mlx._version_check.prompt_upgrade_if_available",
+            return_value=False,
+        ),
+        mock.patch("vllm_mlx._download_gate.is_repo_cached", return_value=False),
+        mock.patch("vllm_mlx._download_gate.estimate_repo_size_bytes", return_value=0),
+        mock.patch("vllm_mlx._download_gate.confirm_or_abort", confirm),
+        mock.patch.object(sys, "argv", ["rapid-mlx", *argv]),
+        mock.patch.object(sys.stdin, "isatty", return_value=stdin_tty),
+    ]
+    if auto_select_alias is not None:
+        ctx.append(
+            mock.patch(
+                "vllm_mlx.first_run.select_chat_default",
+                lambda: (auto_select_alias, starter_cached),
+            )
+        )
+    with ctx[0], ctx[1], ctx[2], ctx[3], ctx[4], ctx[5], ctx[6], ctx[7]:
+        if auto_select_alias is not None:
+            with ctx[8]:
+                cli.main()
+        else:
+            cli.main()
+    return confirm, state["dispatched"]
+
+
+def test_autoselected_starter_uses_standard_download_gate():
+    # Regression guard: the auto-selected starter must NOT special-case the
+    # download gate. (An earlier revision set an `_auto_selected_model` flag
+    # from a fail-silent pre-scan and bypassed the gate entirely — codex
+    # flagged that the unreliable pre-scan could then wave through an
+    # unconfirmed download.) With the gate armed (is_repo_cached=False,
+    # interactive), an uncached auto-selected starter reaches confirm_or_abort
+    # exactly like an explicit model does. The "small model → no prompt"
+    # decision belongs to confirm_or_abort's own 10 GiB threshold (covered in
+    # test_download_gate), NOT to a bypass here — the ~2.5 GB starter is far
+    # under that threshold, so the gate stays silent for it on its own.
+    confirm, dispatched = _run_main_gate_probe(
+        ["chat"], auto_select_alias="qwen3.5-4b-4bit"
+    )
+    assert confirm.called is True  # gate NOT bypassed
+    assert dispatched is True  # and the run still reaches dispatch
+
+
+def test_explicit_uncached_model_still_confirms():
+    # Control: an explicitly-typed, uncached model DOES hit the confirm gate.
+    confirm, _dispatched = _run_main_gate_probe(["chat", "qwen3.5-9b-4bit"])
+    assert confirm.called is True
+
+
+# ======================================================================
+# main() wiring — P0-2 bare-command nameplate branch
+# ======================================================================
+def _run_bare(*, stdout_tty, stdin_tty):
+    with (
+        mock.patch(
+            "vllm_mlx.first_run.build_nameplate", return_value="NAMEPLATE-OK"
+        ) as np,
+        mock.patch(
+            "vllm_mlx._version_check.prompt_upgrade_if_available",
+            return_value=False,
+        ),
+        mock.patch.object(sys, "argv", ["rapid-mlx"]),
+        mock.patch.object(sys.stdout, "isatty", return_value=stdout_tty),
+        mock.patch.object(sys.stdin, "isatty", return_value=stdin_tty),
+        pytest.raises(SystemExit) as exc,
+    ):
+        cli.main()
+    return np, exc.value.code
+
+
+def test_bare_command_interactive_shows_nameplate(capsys):
+    np, code = _run_bare(stdout_tty=True, stdin_tty=True)
+    assert np.called is True
+    assert code == 0
+    assert "NAMEPLATE-OK" in capsys.readouterr().out
+
+
+def test_bare_command_non_tty_falls_back_to_help():
+    np, code = _run_bare(stdout_tty=False, stdin_tty=True)
+    assert np.called is False  # nameplate never built off a TTY
+    assert code == 1  # unchanged: help + exit 1

--- a/tests/test_no_out_of_band_routing.py
+++ b/tests/test_no_out_of_band_routing.py
@@ -156,6 +156,13 @@ ALLOWED_RAPID_MLX_ENV_VARS: frozenset[str] = frozenset(
         # Override the per-user config dir used to remember "seen-tips"
         # banner state (chat REPL first-launch tip gating).
         "RAPID_MLX_CONFIG_HOME",
+        # Override the ``~/.rapid-mlx/`` state dir used by the first-run guide
+        # to place its one-time "connect your agent" marker
+        # (``first_run.py::_state_dir``). Tests point it at a temp dir to
+        # isolate the marker from the real home; it also serves as an escape
+        # hatch for sandboxed / read-only-home environments. Pure state-file
+        # placement knob — never selects a model, parser, or routing tier.
+        "RAPID_MLX_STATE_DIR",
         # Override where DDTree writes its patched draft-config mirror.
         # This is a cache placement/testing knob; model routing and DDTree
         # enablement still come from explicit CLI flags and alias metadata.

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -480,65 +480,6 @@ def _port_is_busy(host: str, port: int) -> bool:
     return False
 
 
-def _chat_config_dir() -> str:
-    """Directory for first-launch tip markers (and future per-user chat
-    state). Honors ``RAPID_MLX_CONFIG_HOME`` override; otherwise falls back
-    to ``~/.config/rapid-mlx``. The directory is created lazily by the
-    writer; callers don't need to ensure it exists for reads.
-    """
-    override = os.environ.get("RAPID_MLX_CONFIG_HOME")
-    if override:
-        return override
-    return os.path.join(os.path.expanduser("~"), ".config", "rapid-mlx")
-
-
-def _seen_tips_path() -> str:
-    return os.path.join(_chat_config_dir(), "seen-tips.json")
-
-
-def _has_seen_tip(key: str) -> bool:
-    """Return True iff the marker file records ``key: true``.
-
-    Any IO/parse error is treated as "not seen" — better to show the tip
-    one extra time than to hide it forever on a corrupt marker.
-    """
-    import json
-
-    try:
-        with open(_seen_tips_path(), encoding="utf-8") as fh:
-            data = json.load(fh)
-    except (OSError, ValueError):
-        return False
-    return isinstance(data, dict) and bool(data.get(key))
-
-
-def _mark_tip_seen(key: str) -> None:
-    """Persist ``key: true`` to the seen-tips marker. Best-effort —
-    failures are swallowed so a read-only config dir never aborts chat.
-    """
-    import json
-
-    path = _seen_tips_path()
-    try:
-        os.makedirs(os.path.dirname(path), exist_ok=True)
-    except OSError:
-        return
-    try:
-        existing: dict = {}
-        try:
-            with open(path, encoding="utf-8") as fh:
-                loaded = json.load(fh)
-            if isinstance(loaded, dict):
-                existing = loaded
-        except (OSError, ValueError):
-            existing = {}
-        existing[key] = True
-        with open(path, "w", encoding="utf-8") as fh:
-            json.dump(existing, fh)
-    except OSError:
-        return
-
-
 def _print_unknown_model_help(name: str, *, full_path_example: str) -> None:
     """Print fuzzy suggestions + a curated popular-models hint.
 
@@ -5662,6 +5603,12 @@ def chat_command(args):
     RED = "\x1b[31m" if _is_tty else ""
     RESET = "\x1b[0m" if _is_tty else ""
 
+    # P0-3 (first-run guide): did the user see real value this session — i.e.
+    # at least one completed, non-empty response? Gates the one-time agent-
+    # connect tip printed on exit, so a load-then-immediate-/exit run neither
+    # nags the user nor burns the one-time marker.
+    _generated_any = False
+
     def _teardown_proc(p) -> None:
         """Terminate a spawned chat server and free its log file.
 
@@ -5915,22 +5862,13 @@ def chat_command(args):
         f"{DIM}type {RESET}{BOLD}/help{RESET}{DIM} for commands, "
         f"Ctrl-D to exit.{RESET}"
     )
-    # First-launch-only banner for the agents/codex tip. The marker-file
-    # gate keeps the tip from re-appearing on every chat launch (persona-3
-    # finding: irritating by launch #50). Marker logic is skipped entirely
-    # when stdout is not a TTY or NO_COLOR is set — pipe/CI runs shouldn't
-    # pollute the user's config dir, and the banner is fluff there anyway.
-    _is_pipe_or_no_color = (not sys.stdout.isatty()) or ("NO_COLOR" in os.environ)
-    if not _is_pipe_or_no_color and not _has_seen_tip("chat_intro_codex"):
-        print(
-            f"  {DIM}For a Claude Code-like TUI: `rapid-mlx agents codex --setup`, "
-            f"then run `codex` in any project.{RESET}\n"
-        )
-        _mark_tip_seen("chat_intro_codex")
-    else:
-        # Maintain the existing blank-line spacing the banner used to
-        # provide — keeps the prompt layout consistent across runs.
-        print()
+    # A single blank line before the prompt keeps the layout consistent.
+    # The "connect your agent" nudge that used to live here (a start-of-chat
+    # agents/codex banner) moved to a one-time tip printed after the user's
+    # FIRST successful chat exit — see the P0-3 block at the end of this
+    # function and ``vllm_mlx/first_run.py``. Nudging once, after value has
+    # landed, beats nudging on every cold start.
+    print()
 
     served_name = getattr(args, "_original_alias", args.model)
     messages: list[dict] = []
@@ -6398,6 +6336,9 @@ def chat_command(args):
                 )
             if assistant:
                 messages.append({"role": "assistant", "content": assistant})
+                # A non-empty response reached the user → the session
+                # delivered value. Arms the one-time exit tip (P0-3).
+                _generated_any = True
             else:
                 _recover_failed_chat_turn(messages, turn_start)
     finally:
@@ -6406,6 +6347,27 @@ def chat_command(args):
         # before running atexit callbacks. Closing here avoids that shutdown
         # ordering deadlock and also tears down a spawned model server promptly.
         _cleanup()
+
+    # P0-3 (first-run guide): after the user's FIRST session that actually
+    # produced a response, print a one-line nudge to connect their coding
+    # agent — the highest-retention next step, offered only once value has
+    # landed. Fires at most once per machine (a marker under ~/.rapid-mlx/),
+    # interactive terminals only, and never on a crash (an uncaught exception
+    # propagates through ``finally`` before reaching here). Fail-silent.
+    if _generated_any and _is_tty:
+        try:
+            from vllm_mlx.first_run import chat_agent_tip_text, claim_chat_agent_tip
+
+            # Build the tip text (which runs agent detection) BEFORE claiming
+            # the marker, so a detection error can't burn the one-time chance
+            # without ever showing the tip. The atomic claim is last, so only
+            # the process that wins the exclusive-create prints — concurrent
+            # first sessions can't both show it.
+            _tip = chat_agent_tip_text()
+            if claim_chat_agent_tip():
+                print(f"\n  {DIM}{_tip}{RESET}")
+        except Exception:
+            pass
 
 
 def info_command(args):
@@ -8283,9 +8245,11 @@ Examples:
     chat_parser.add_argument(
         "model",
         nargs="?",
-        default="qwen3.5-4b-4bit",
+        default=None,
         help="Model alias (e.g. qwen3.5-4b-4bit) or HF repo (org/name). "
-        "Defaults to qwen3.5-4b-4bit when omitted.",
+        "When omitted, defaults to the qwen3.5-4b-4bit starter — a "
+        "dogfood-tested, tool-call-reliable model — downloaded once on first "
+        "use. See `vllm_mlx.first_run.select_chat_default`.",
     ).completer = alias_completer
     chat_parser.add_argument(
         "--system",
@@ -8733,6 +8697,44 @@ Examples:
         _telemetry_emit.register_session_end_hook(_emit_session_end)
         _atexit.register(_telemetry_emit.fire_session_end_hook)
 
+    # First-run auto-select: ``chat`` / ``run`` invoked with no model arg.
+    # Resolve the starter alias HERE — before the alias→path resolution below —
+    # so it flows through the normal resolve + download path (and the
+    # ``_original_alias`` banner) exactly as if the user had typed it. Always
+    # the known-good starter, never an arbitrary cached model (which could be a
+    # non-chat checkpoint); the bare-command nameplate lists cached models for
+    # explicit selection instead.
+    if (
+        getattr(args, "command", None) in ("chat", "run")
+        and getattr(args, "model", None) is None
+    ):
+        from vllm_mlx.first_run import FIRST_RUN_MODEL_SIZE, select_chat_default
+
+        _cmd = getattr(args, "command", "chat")
+        _sel_alias, _starter_cached = select_chat_default()
+        args.model = _sel_alias
+        if sys.stdin.isatty():
+            if _starter_cached:
+                print(
+                    f"  No model specified — using {_sel_alias} (already downloaded)."
+                )
+            else:
+                print(
+                    f"  No model specified — using {_sel_alias} "
+                    f"({FIRST_RUN_MODEL_SIZE}, one-time download)."
+                )
+            print(f"  Browse: rapid-mlx models · Override: rapid-mlx {_cmd} <model>")
+            print()
+        # We intentionally do NOT special-case the download gate for the
+        # auto-selected starter. The starter is a small (~2.5 GB) model, well
+        # under the gate's 10 GiB confirm threshold, so the gate never prompts
+        # for it regardless — deferring to the gate's own authoritative
+        # ``is_repo_cached`` + threshold policy is simpler and safer than a
+        # bypass flag derived from a fail-silent pre-scan. Non-interactive
+        # (CI / pipe): no notice (it is TTY-only); ``main()`` sets the starter
+        # and falls through to the same gate a bare ``rapid-mlx chat`` always
+        # used, so scripted callers are unchanged (no new exit-1 path).
+
     # Resolve model aliases before dispatch.
     #
     # The doctor subcommand is exempt for historical reasons (and as a
@@ -8940,6 +8942,27 @@ Examples:
         from vllm_mlx.launch.cli import launch_command
 
         launch_command(args)
+    elif (
+        getattr(args, "command", None) is None
+        and sys.stdout.isatty()
+        and sys.stdin.isatty()
+    ):
+        # Bare ``rapid-mlx`` in an interactive terminal = a first-run
+        # nameplate (hardware + cached-model hint + "get started" signpost),
+        # not a wall of argparse help. Non-blocking: it prints and exits 0.
+        # Non-interactive invocations (pipe, redirect, CI) fall through to the
+        # unchanged help + exit 1 so scripts parsing ``rapid-mlx`` output are
+        # unaffected. Fail-silent: any nameplate error also falls through.
+        try:
+            from vllm_mlx.first_run import build_nameplate
+
+            print(build_nameplate(_version))
+            sys.exit(0)
+        except SystemExit:
+            raise
+        except Exception:
+            parser.print_help()
+            sys.exit(1)
     else:
         parser.print_help()
         sys.exit(1)

--- a/vllm_mlx/first_run.py
+++ b/vllm_mlx/first_run.py
@@ -1,0 +1,272 @@
+"""First-run guide helpers — maximize the install → first-token conversion.
+
+Three CLI surfaces share this module (wired in ``vllm_mlx/cli.py``):
+
+  * ``rapid-mlx`` (bare command) → a *nameplate*: hardware line + cached-model
+    hint + a "get started" signpost. Non-blocking, prints and exits.
+  * ``rapid-mlx chat`` with no model → auto-select the known-good starter, so
+    the user's only decision is typing ``chat`` (everything else is a default
+    + override).
+  * The first successful ``chat`` exit → a one-time "connect your agent" tip.
+
+Design constraints (mirror ``vllm_mlx/telemetry/consent.py``):
+
+  * **TTY-guarded.** The nameplate and notices only render for an interactive
+    session; non-TTY (CI, pipes) keeps today's behavior with zero extra output.
+    The callers own the TTY check; the pure helpers here never print.
+  * **Fail-silent.** Every probe (cache scan, hardware detect, agent detect,
+    state file) is wrapped so a failure degrades gracefully and NEVER crashes
+    the CLI — a broken HF cache dir must not stop ``rapid-mlx chat``.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+# The starter model for a cold-cache first run. Deliberately NOT RAM-tiered:
+# even a 96 GB Mac gets the small 4B first so a brand-new user sees a token in
+# ~1-2 minutes instead of waiting on a 60 GB download. Users graduate to the
+# bigger models (``rapid-mlx models``) on their own once they're comfortable.
+# Must stay a dogfood-tested, tool-calling-reliable alias (0.11.0 headline);
+# an experimental low-bit model would damage the first impression.
+#
+# PARITY: this is the same model install.sh recommends for its lowest RAM tier
+# (the 8-23 GB branch, ``RECOMMENDED_MODEL="qwen3.5-4b-4bit"``). If you change
+# one, change the other so the installer and the CLI tell one story.
+FIRST_RUN_MODEL = "qwen3.5-4b-4bit"
+
+# Human-facing one-time download size for FIRST_RUN_MODEL. A fixed string (not
+# a network probe) so the "no model specified" notice is instant.
+FIRST_RUN_MODEL_SIZE = "~2.5 GB"
+
+# Preference order when several coding agents are detected: claude-code is the
+# ICP, so it leads. Others follow in a stable order.
+_AGENT_PREFERENCE = ("claude-code", "cursor", "cline", "continue-dev")
+
+_DOCS_URL = "https://rapidmlx.com/docs/"
+
+
+def _state_dir() -> Path:
+    """The ``~/.rapid-mlx/`` state dir (same one telemetry uses; see
+    ``telemetry/state.py::_default_telemetry_dir``). Kept independent of the
+    telemetry opt-in so the one-time chat tip fires even when telemetry is
+    disabled.
+
+    ``RAPID_MLX_STATE_DIR`` overrides the location — used by tests to isolate
+    the one-time marker from the real home dir, and available as an escape
+    hatch for sandboxed / read-only-home environments.
+    """
+    override = os.environ.get("RAPID_MLX_STATE_DIR")
+    if override:
+        return Path(override)
+    return Path.home() / ".rapid-mlx"
+
+
+# --------------------------------------------------------------------------
+# Starter model selection (P0-1) + cached-model display (P0-2)
+# --------------------------------------------------------------------------
+def cached_known_aliases() -> list[tuple[str, float]]:
+    """``[(alias, mtime_epoch), ...]`` for cached models that map to a known
+    alias, most-recently-modified first.
+
+    Unmapped cache entries (a raw HF repo with no alias in ``aliases.json``)
+    are omitted — an unknown profile is unsafe to auto-select as the chat
+    default. Returns ``[]`` on a cold cache or any scan error.
+    """
+    try:
+        # Lazy import: cli.py imports this module, so importing it back at
+        # module-load time would cycle. By call time cli is fully loaded.
+        from vllm_mlx.cli import _scan_hf_cache_models
+        from vllm_mlx.model_aliases import list_profiles
+
+        hf_to_alias: dict[str, str] = {}
+        for alias, profile in list_profiles().items():
+            hf_to_alias.setdefault(profile.hf_path, alias)
+
+        rows: list[tuple[str, float]] = []
+        for repo, _size, mtime in _scan_hf_cache_models():
+            alias = hf_to_alias.get(repo)
+            if alias is not None:
+                rows.append((alias, mtime))
+        rows.sort(key=lambda r: -r[1])
+        return rows
+    except Exception:
+        return []
+
+
+def select_chat_default() -> tuple[str, bool]:
+    """Pick the model for ``rapid-mlx chat`` / ``run`` when the user gave no
+    model. Always the first-run starter (:data:`FIRST_RUN_MODEL`) — a known
+    chat/tool-call-capable, dogfood-tested alias.
+
+    Returns ``(alias, already_cached)``, where ``already_cached`` reports only
+    whether the starter itself is downloaded (it drives the "already
+    downloaded" vs "one-time download" notice — nothing else).
+
+    We deliberately do NOT auto-pick the most-recently-cached alias: it could
+    be a non-chat checkpoint (embedding / transcription), and silently
+    selecting a model the user never named invites surprise and a hard-to-read
+    failure. The bare-command nameplate still LISTS cached models so a
+    returning user can pick one explicitly.
+    """
+    cached_aliases = {alias for alias, _ in cached_known_aliases()}
+    return FIRST_RUN_MODEL, FIRST_RUN_MODEL in cached_aliases
+
+
+# --------------------------------------------------------------------------
+# Agent detection (P0-2 nameplate + P0-3 tip)
+# --------------------------------------------------------------------------
+def _safe_detect(adapter: object) -> bool:
+    try:
+        return bool(adapter.detect())  # type: ignore[attr-defined]
+    except Exception:
+        return False
+
+
+def detected_agents() -> list[str]:
+    """Names of coding agents detected on this machine, via the same adapters
+    ``rapid-mlx launch`` uses. Ordered by :data:`_AGENT_PREFERENCE` (claude-code
+    first). Returns ``[]`` on error."""
+    try:
+        from vllm_mlx.launch import ADAPTERS
+
+        found = {name for name, a in ADAPTERS.items() if _safe_detect(a)}
+    except Exception:
+        return []
+    ordered = [n for n in _AGENT_PREFERENCE if n in found]
+    # Any adapter not in the preference list still gets surfaced, appended
+    # in a stable (sorted) order so a new adapter isn't silently dropped.
+    ordered += sorted(found - set(ordered))
+    return ordered
+
+
+def preferred_agent() -> str | None:
+    """The single agent to name in a signpost, or ``None`` if none detected."""
+    agents = detected_agents()
+    return agents[0] if agents else None
+
+
+# --------------------------------------------------------------------------
+# Nameplate (P0-2)
+# --------------------------------------------------------------------------
+def _hardware_line(version: str) -> str:
+    try:
+        from vllm_mlx.optimizations import detect_hardware
+
+        hw = detect_hardware()
+        chip = hw.chip_name if hw.chip_name and hw.chip_name != "Unknown" else None
+        mem = f"{hw.total_memory_gb:.0f}GB" if hw.total_memory_gb else None
+        if chip and mem:
+            return f"Rapid-MLX {version} · {chip} / {mem} detected"
+        if mem:
+            return f"Rapid-MLX {version} · {mem} detected"
+    except Exception:
+        pass
+    return f"Rapid-MLX {version}"
+
+
+def _render_get_started(rows: list[tuple[str, str]]) -> list[str]:
+    """Render ``(command, comment)`` pairs with the ``#`` comments aligned to a
+    common column."""
+    width = max((len(cmd) for cmd, _ in rows), default=0)
+    out = []
+    for cmd, comment in rows:
+        out.append(f"  {cmd.ljust(width)}   # {comment}" if comment else f"  {cmd}")
+    return out
+
+
+def build_nameplate(version: str) -> str:
+    """Build the bare-command nameplate text (no ANSI, no trailing newline).
+
+    Pure/deterministic given the machine state — the caller decides whether to
+    print it (TTY only). Every probe inside is fail-silent, so a broken cache
+    or hardware-detect surface still yields a usable signpost.
+    """
+    lines: list[str] = [_hardware_line(version), ""]
+
+    cached = cached_known_aliases()
+    if cached:
+        shown = ", ".join(alias for alias, _ in cached[:3])
+        lines.append(f"Found in your cache: {shown}")
+        lines.append("")
+
+    lines.append("Get started:")
+
+    # The bare-command chat suggestion always points at the known-good starter
+    # (FIRST_RUN_MODEL) — never an arbitrary cached alias, which could be a
+    # non-chat (embedding / transcription) checkpoint. Cached models are
+    # listed above so a returning user can pick one explicitly.
+    starter_cached = any(alias == FIRST_RUN_MODEL for alias, _ in cached)
+    rows: list[tuple[str, str]] = []
+    if starter_cached:
+        rows.append(("rapid-mlx chat", f"{FIRST_RUN_MODEL} — already downloaded"))
+    else:
+        rows.append(
+            (
+                "rapid-mlx chat",
+                f"{FIRST_RUN_MODEL} ({FIRST_RUN_MODEL_SIZE} one-time download)",
+            )
+        )
+    if cached:
+        rows.append(("rapid-mlx chat <model>", "or run any model listed above"))
+    rows.append(
+        (f"rapid-mlx serve {FIRST_RUN_MODEL}", "OpenAI-compatible API on :8000")
+    )
+
+    agent = preferred_agent()
+    if agent is not None:
+        rows.append((f"rapid-mlx launch {agent}", "connect your agent (detected ✓)"))
+    else:
+        rows.append(("rapid-mlx launch --all", "detect & connect coding agents"))
+
+    lines += _render_get_started(rows)
+    lines.append("")
+    lines.append(f"Docs: {_DOCS_URL}")
+    return "\n".join(lines)
+
+
+# --------------------------------------------------------------------------
+# One-time "connect your agent" tip after the first successful chat (P0-3)
+# --------------------------------------------------------------------------
+def _chat_tip_marker() -> Path:
+    return _state_dir() / "chat_agent_tip_shown"
+
+
+def claim_chat_agent_tip() -> bool:
+    """Atomically claim the one-time chat→agent tip.
+
+    Returns ``True`` for exactly ONE caller per machine: the process that
+    creates the marker via exclusive ``O_EXCL`` creation wins and shows the
+    tip. Concurrent first-run sessions that lose the race (marker already
+    exists) get ``False``. Any other error (read-only / unwritable state
+    dir) is also ``False`` — fail-safe toward *never nagging* and never
+    crashing.
+
+    Doing the check-and-claim in one atomic OS call closes the
+    check→print→mark TOCTOU where two concurrent first sessions could each
+    see "not shown" and both print the supposedly once-per-machine tip.
+    """
+    try:
+        marker = _chat_tip_marker()
+        marker.parent.mkdir(parents=True, exist_ok=True)
+        # Mode "x" is exclusive creation (O_CREAT | O_EXCL): the OS guarantees
+        # only one concurrent creator succeeds. The context manager closes the
+        # descriptor on every path, so no fd leaks in this long-lived process.
+        with open(marker, "x"):
+            pass
+        return True
+    except FileExistsError:
+        return False
+    except Exception:
+        return False
+
+
+def chat_agent_tip_text() -> str:
+    """The one-line tip shown after a user's first successful chat. Names the
+    detected agent (claude-code preferred); falls back to the generic
+    ``launch --all`` when none is detected."""
+    agent = preferred_agent()
+    if agent is not None:
+        return f"Tip: connect {agent} to this engine → rapid-mlx launch {agent}"
+    return "Tip: connect your coding agent → rapid-mlx launch --all"

--- a/vllm_mlx/first_run.py
+++ b/vllm_mlx/first_run.py
@@ -194,9 +194,12 @@ def build_nameplate(version: str) -> str:
     lines.append("Get started:")
 
     # The bare-command chat suggestion always points at the known-good starter
-    # (FIRST_RUN_MODEL) — never an arbitrary cached alias, which could be a
-    # non-chat (embedding / transcription) checkpoint. Cached models are
-    # listed above so a returning user can pick one explicitly.
+    # (FIRST_RUN_MODEL), never whichever alias happens to be cached: the
+    # starter is the one model we promise reliable chat + tool-calls, and
+    # auto-picking a cached alias would run something the user never named
+    # (e.g. a text-diffusion checkpoint, which chats but with very different
+    # REPL behavior). Cached models are still listed above so a returning user
+    # can name one explicitly.
     starter_cached = any(alias == FIRST_RUN_MODEL for alias, _ in cached)
     rows: list[tuple[str, str]] = []
     if starter_cached:
@@ -209,7 +212,7 @@ def build_nameplate(version: str) -> str:
             )
         )
     if cached:
-        rows.append(("rapid-mlx chat <model>", "or run any model listed above"))
+        rows.append(("rapid-mlx chat <model>", "or name a cached model above"))
     rows.append(
         (f"rapid-mlx serve {FIRST_RUN_MODEL}", "OpenAI-compatible API on :8000")
     )


### PR DESCRIPTION
## Why

The widest activation drop-off is between `pip install rapid-mlx` and the user's **first generated token**. Today three moments add friction there:

- `rapid-mlx chat` on a cold cache asks an open-ended "which model?" question (via the default) and then a `[y/N]` download confirm — two decisions before any value.
- bare `rapid-mlx` prints a wall of argparse help — a dead end, not a signpost.
- nothing nudges a satisfied chat user toward the highest-retention next step (connecting their coding agent).

Five competing tools (Codex, Claude Code, OpenHands, OpenClaw, Hermes) all gate on exactly one thing — *get a real completion running* — and defer everything else. This PR brings that discipline to our widest channels.

## What

One cohesive feature, three surfaces, sharing `vllm_mlx/first_run.py`:

1. **`chat` / `run` with no model → starter auto-select.** Always the known-good starter `qwen3.5-4b-4bit` (`FIRST_RUN_MODEL`) — dogfood-tested and tool-calling-reliable, a safe first impression. Deliberately **not** RAM-tiered (even a 96 GB Mac gets the small 4B first so the user sees a token in ~1–2 min, then graduates on their own) and deliberately **not** cache-picking: auto-selecting the most-recently-downloaded alias could hand `chat` a non-generative checkpoint (an embedding / transcription model) and fail, or silently run a model the user never named. The bare-command nameplate lists cached models so a returning user picks one explicitly. The auto-selected starter is **not** special-cased against the download gate: the ~2.5 GB starter is well under the gate's 10 GiB confirm threshold, so the gate never prompts for it regardless — deferring to the gate's own authoritative `is_repo_cached` + threshold policy is simpler and safer than a bypass flag. Non-interactive (CI / pipe) is **unchanged**: no notice — `main()` sets the starter and falls through to the same download gate a bare `rapid-mlx chat` always used, so scripted callers keep their behavior (no new exit-1 path). An explicitly-typed model is likewise untouched.
2. **Bare `rapid-mlx` (interactive TTY) → nameplate.** Hardware line + cached-model hint + a "get started" signpost that names the detected agent. Non-blocking: prints and exits 0. Non-interactive (pipe / redirect / CI) keeps today's help + exit 1 — scripts unaffected.
3. **First chat that produced a response → one-time agent tip on exit.** Names `claude-code` when detected, else `launch --all`. Fires at most once per machine (marker under `~/.rapid-mlx/`, overridable via `RAPID_MLX_STATE_DIR`), TTY-only, never on a crash. **This is now the single agent nudge** — it *replaces* the old start-of-chat "agents codex" banner, which fired on every cold start before value had landed. Removing that banner also retires its now-orphaned `seen-tips.json` helpers (`_chat_config_dir` / `_seen_tips_path` / `_has_seen_tip` / `_mark_tip_seen`) and their tests, leaving one state mechanism (`~/.rapid-mlx/`) instead of two.

`FIRST_RUN_MODEL` mirrors install.sh's lowest RAM tier (a parity comment ties them so the installer and CLI tell one story). Every machine-state probe is fail-silent — a broken HF cache / hardware-detect / agent-detect / state file degrades gracefully and never crashes the CLI.

**Reuses** existing infra rather than reinventing: `_scan_hf_cache_models`, `model_aliases.list_profiles`, `launch.ADAPTERS` (the same agent detectors `rapid-mlx launch` uses), `optimizations.detect_hardware`, and the `~/.rapid-mlx` state-dir convention.

## Design decisions (call these out for review)

- **One agent nudge, at first-exit, not start.** The old banner nudged `agents codex --setup` on every cold chat start (gated by a `seen-tips.json` marker); this replaces it with a single tip after the user's *first response-producing* session, pointing at `rapid-mlx launch <detected agent>`. Nudging once, after value has landed, beats nudging on every cold start — and collapses two overlapping "connect your agent" prompts into one.
- **Always the starter, never an arbitrary cached model.** A cache-first "reuse whatever you last pulled" heuristic was considered and dropped: the most-recently-cached alias can be a non-generative checkpoint (embedding / transcription) that fails `chat`, or simply a model the user never asked for — surprise + a hard-to-read failure on the exact path meant to remove friction. The starter is the one alias we can promise chats and tool-calls reliably. Returning users pick a cached model explicitly from the nameplate list.
- **The auto-selected starter defers entirely to the existing download gate — no bypass.** An earlier revision set an `_auto_selected_model` flag (derived from a fail-silent cache pre-scan) to skip the gate's `[y/N]` on the "zero-decision" path. Codex flagged, across two rounds, that routing the bypass decision through a second, unreliable cache oracle was fragile (a transient scan failure could wave a download through). The clean resolution: **remove the flag.** The starter is deliberately small (~2.5 GB, tied to install.sh's lowest tier), and the gate only prompts for downloads ≥ 10 GiB — so it never prompts for the starter *anyway*. The feature now sets `args.model` + prints the notice and lets the gate's own authoritative `is_repo_cached` + threshold policy govern, identically for auto-selected and explicit models. Simpler, and the whole class of "pre-scan vs gate disagree" findings disappears.
- **Non-interactive behavior is preserved, not changed.** An earlier revision made a cold-cache non-TTY `chat` exit 1 with guidance; that silently regressed documented scripted callers that relied on the former default model. Reverted — non-TTY now sets the starter and falls through to the existing download gate exactly as before, so no scripted invocation changes its exit code.
- **Bare TTY exits 0**, not the conventional usage-error 1 — it's an intentional, successful signpost, not an error. Non-TTY stays 1.

## Test plan

- [x] `tests/test_first_run_guide.py` — offline tests, all green: starter selection always returns `FIRST_RUN_MODEL` (never an arbitrary cached alias) + correctly reports starter-cached, unmapped-cache drop + fail-silent scan, agent detection + `claude-code` preference + detect-error safety, nameplate cold/cached/agent variants (cached model **listed** but never a chat target), one-time marker claimed exactly once (atomic `O_EXCL`) + fail-safe on unwritable state dir, `RAPID_MLX_STATE_DIR` override, `main()` auto-select (sets alias + notice), notice suppressed on non-TTY, explicit-model skips auto-select, **auto-selected starter uses the standard download gate — not bypassed — vs confirm on explicit-uncached** (regression guard for the removed bypass), non-TTY falls through to the gate silently (cold + cached, no exit-1 regression), `run` alias coverage, and bare nameplate (exit 0) vs non-TTY help (exit 1).
- [x] `tests/test_cli_chat.py::test_chat_no_model_defaults_to_qwen35_4b` made **hermetic**. It is a pre-existing test that asserted the hardcoded default; it read the machine's real HF cache to decide the "already downloaded" vs "one-time download" branch. Now forces a cold cache (`patch vllm_mlx.first_run.cached_known_aliases → []`) + TTY so it deterministically exercises the starter's one-time-download path independent of this machine.
- [x] Removed the now-obsolete D8 banner suite from `tests/test_cli_chat.py` (`test_chat_banner_*`, `test_seen_tips_marker_*`) — they guarded the retired start-of-chat banner and its `seen-tips.json` helpers.
- [x] End-to-end pilot (real `main()`): bare `rapid-mlx` under a pty → nameplate renders with live hardware line, cached-model hint, and detected `claude-code`; non-TTY → unchanged help + exit 1.
- [x] End-to-end pilot (real chat): `rapid-mlx chat <small model>` under a pty → asked a question, got a real completion, `/exit` → the one-time tip fired and the marker was written to an isolated state dir (operator `~/.rapid-mlx` untouched).
- [x] Test-isolation hardening: the two `cached_known_aliases` tests now monkeypatch `_scan_hf_cache_models` **by dotted path** (`"vllm_mlx.cli._scan_hf_cache_models"`) rather than by module object. `pr_validate`'s cross-file `targeted_tests` run surfaced them failing (2 regressions) while they passed in isolation — a sibling suite (`test_cli_argcomplete`) does a bare `sys.modules.pop("vllm_mlx.cli")` + reimport, leaving this file's module-level `cli` reference stale; the object-form patch then missed the live module the code re-imports at call time. Dotted-path patching re-resolves the live module and is immune to that churn. Verified green in the full 18-file targeted set.
- [x] `RAPID_MLX_STATE_DIR` registered in `ALLOWED_RAPID_MLX_ENV_VARS` (`tests/test_no_out_of_band_routing.py`) with a comment marking it a non-routing state-file placement knob. `first_run.py::_state_dir` reads it to isolate the one-time-tip marker (tests + read-only-home escape hatch); the guardrail test `test_no_routing_shaped_rapid_mlx_env_vars` requires every referenced `RAPID_MLX_*` var to be either allowlisted or a routing decision — this is the former. Verified green.
- [x] `ruff format` + `ruff check` clean on all changed files. Rebased onto `origin/main`.

Notes for reviewers:
- The local validate venv was missing `hypothesis` (a declared `[test]` extra), which surfaced as a `tests/property` collection error in `full_unit` — unrelated to this PR; resolved by installing the declared dep.
- A local `full_unit` run showed `tests/test_signal_observability.py::test_subprocess_sighup_default_disposition_dumps_and_stays_alive` red ("subprocess died before emitting READY"). **Root-caused to the local launch wrapper, not this PR:** that test asserts the production SIGHUP baseline `SIG_DFL`, but the run was started under `nohup`, which sets SIGHUP to `SIG_IGN` — inherited across `exec()` by the whole process tree down to the test's spawned `python -c` child, so its startup `assert getsignal(SIGHUP)==SIG_DFL` failed. Proven by A/B: the test passes when the suite is launched normally (13997 passed, 0 failed) and fails only under `nohup`. This PR's diff touches zero signal/subprocess machinery, and GH CI (`test-apple-silicon`, `test-matrix` 3.10/3.11/3.12, `tests`, `validate`) is fully green.

## Scope

`skip-version-bump` — feature only; batches into a later bump-only release per the "no PR per release" convention.
