### PR TITLE
fix: close release dogfood gaps

### DIFF
--- a/docs/benchmarks/llm.md
+++ b/docs/benchmarks/llm.md
@@ -95,7 +95,11 @@ Notes:
 - Throughput peaks at **1024–2048** tokens, then dips at 4096 — consistent with KV-cache pressure as the rolling window fills.
 - Memory delta (baseline → DFlash) tracks the draft model + verification overhead; see the source benchmark for the exact figure.
 
-`Qwen3.6-35B-A3B-8bit` supports DFlash as an experimental opt-in (install `[dflash]` extra, pass `--speculative-config '{"method":"dflash"}'`); numbers above are from a community benchmark and reflect that single run.
+These are historical community results from a single run, not a currently
+enabled model/decoder pair. Rapid-MLX now keeps DFlash behind per-alias
+correctness and speed gates; `qwen3.6-35b-8bit` is an MoE model and does not
+currently pass those gates. Run `rapid-mlx info <alias>` for the live
+eligibility result before enabling DFlash.
 
 ## Prefix Cache Results
 

--- a/scripts/dev_test.py
+++ b/scripts/dev_test.py
@@ -6,8 +6,8 @@ Orchestrates all test levels from quick lint to overnight benchmarks.
 
 Usage:
     python scripts/dev_test.py lint          # ruff + import check (~10s)
-    python scripts/dev_test.py unit          # pytest unit suite (~30s)
-    python scripts/dev_test.py smoke         # lint + unit (~1 min)
+    python scripts/dev_test.py unit          # pytest unit suite (~3 min)
+    python scripts/dev_test.py smoke         # lint + unit (~3 min)
     python scripts/dev_test.py stress        # 8-test stress suite (needs server)
     python scripts/dev_test.py soak          # 10-min agent soak test (needs server)
     python scripts/dev_test.py cross-model   # multi-model stress (auto starts servers)
@@ -88,7 +88,7 @@ def run_unit():
             "tests/test_reasoning_parsers.py",
         ],
         "Unit tests (pytest)",
-        timeout=120,
+        timeout=300,
     )
 
 

--- a/tests/integrations/test_hermes.py
+++ b/tests/integrations/test_hermes.py
@@ -22,6 +22,7 @@ import subprocess
 import sys
 import time
 import unittest
+import uuid
 
 import httpx
 
@@ -491,12 +492,21 @@ def test_hermes_chat():
 
 def test_hermes_read_file():
     """Hermes reads a file via tool call."""
-    out, err = hermes_query("Read the first line of pyproject.toml")
-    fail_or_skip(err)
-    assert "build" in out.lower() or "project" in out.lower(), (
-        f"Unexpected: {out[:100]}"
-    )
-    print(f"  Hermes read_file: {out.strip()[:80]}")
+    marker = f"rapid-mlx-hermes-{uuid.uuid4().hex}"
+    path = os.path.join(os.getcwd(), f".hermes-read-{uuid.uuid4().hex}.txt")
+    try:
+        with open(path, "w") as f:
+            f.write(f"{marker}\n")
+        out, err = hermes_query(
+            f"Use the read_file tool to read {os.path.basename(path)}, "
+            "then reply with its exact contents."
+        )
+        fail_or_skip(err)
+        assert marker in out, f"File content missing from Hermes output: {out[:100]}"
+        print(f"  Hermes read_file: {out.strip()[:80]}")
+    finally:
+        if os.path.exists(path):
+            os.unlink(path)
 
 
 def test_hermes_terminal():

--- a/tests/test_ddtree_integration.py
+++ b/tests/test_ddtree_integration.py
@@ -232,6 +232,37 @@ def test_build_app_healthz_models_and_completion() -> None:
     assert call.kwargs["skip_special_tokens"] is True
 
 
+def test_render_prompt_defaults_to_no_thinking_but_honors_explicit_opt_in() -> None:
+    from vllm_mlx.api.models import ChatCompletionRequest
+    from vllm_mlx.speculative.ddtree.server import _render_prompt
+
+    runtime = _fake_runtime()
+    default_request = ChatCompletionRequest(
+        model="qwen3.5-9b-8bit",
+        messages=[{"role": "user", "content": "2+2?"}],
+    )
+    _render_prompt(runtime, default_request)
+    assert (
+        runtime.generator.target.tokenizer.apply_chat_template.call_args.kwargs[
+            "enable_thinking"
+        ]
+        is False
+    )
+
+    thinking_request = ChatCompletionRequest(
+        model="qwen3.5-9b-8bit",
+        messages=[{"role": "user", "content": "2+2?"}],
+        enable_thinking=True,
+    )
+    _render_prompt(runtime, thinking_request)
+    assert (
+        runtime.generator.target.tokenizer.apply_chat_template.call_args.kwargs[
+            "enable_thinking"
+        ]
+        is True
+    )
+
+
 def test_build_app_healthz_works_while_runtime_loads() -> None:
     from fastapi.testclient import TestClient
 

--- a/tests/test_dev_test_script.py
+++ b/tests/test_dev_test_script.py
@@ -1,0 +1,26 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression coverage for the local developer test wrapper."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+def test_unit_suite_timeout_covers_current_three_minute_runtime(monkeypatch):
+    script = Path(__file__).parents[1] / "scripts" / "dev_test.py"
+    spec = importlib.util.spec_from_file_location("rapid_mlx_dev_test", script)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    observed: dict[str, object] = {}
+
+    def fake_run(cmd, label, timeout=600):
+        observed.update(cmd=cmd, label=label, timeout=timeout)
+        return True
+
+    monkeypatch.setattr(module, "run", fake_run)
+
+    assert module.run_unit() is True
+    assert observed["timeout"] == 300

--- a/tests/test_mllm_continuous_batching.py
+++ b/tests/test_mllm_continuous_batching.py
@@ -2130,6 +2130,44 @@ class TestMLLMSchedulerErrorPropagation:
         assert outputs[0].finish_reason == "stop"
         assert outputs[0].error is None
 
+    @pytest.mark.asyncio
+    async def test_final_output_consumer_break_does_not_abort_completed_request(self):
+        """A caller may stop as soon as it receives the terminal output.
+
+        Async-generator code after ``yield`` does not run when that caller
+        closes the generator, so completion must be recorded before yielding.
+        """
+        import asyncio
+
+        from vllm_mlx.mllm_scheduler import MLLMScheduler
+        from vllm_mlx.request import RequestOutput
+
+        sched = MLLMScheduler.__new__(MLLMScheduler)
+        sched.output_queues = {}
+        sched.abort_request = MagicMock()
+
+        req_id = "req-completed-before-consumer-break"
+        queue: asyncio.Queue = asyncio.Queue()
+        sched.output_queues[req_id] = queue
+        await queue.put(
+            RequestOutput(
+                request_id=req_id,
+                output_text="done",
+                new_text="done",
+                finished=True,
+                finish_reason="stop",
+            )
+        )
+
+        stream = sched.stream_outputs(req_id)
+        async for output in stream:
+            assert output.finished is True
+            break
+        await stream.aclose()
+
+        sched.abort_request.assert_not_called()
+        assert req_id not in sched.output_queues
+
 
 # Run tests
 if __name__ == "__main__":

--- a/tests/test_responses_adapter.py
+++ b/tests/test_responses_adapter.py
@@ -1286,7 +1286,23 @@ class TestOpenaiToResponses:
         assert resp.usage.input_tokens == 100
         assert resp.usage.output_tokens == 50
         assert resp.usage.total_tokens == 150
-        assert resp.usage.input_tokens_details == {"cached_tokens": 30}
+        assert resp.usage.input_tokens_details == {
+            "cached_tokens": 30,
+            "cache_write_tokens": 0,
+        }
+
+    def test_usage_block_populated_without_cache(self):
+        chat_resp = _chat_response(
+            text="hi", prompt_tokens=100, completion_tokens=50, cached=0
+        )
+        resp = openai_to_responses(
+            chat_resp, model="test-model", request=_bare_request(), created_at=0
+        )
+        assert resp.usage.input_tokens_details == {
+            "cached_tokens": 0,
+            "cache_write_tokens": 0,
+        }
+        assert resp.usage.output_tokens_details == {"reasoning_tokens": 0}
 
     def test_cached_tokens_clamped_to_prompt(self):
         # Defensive against an over-reported cache count — same clamp
@@ -1297,7 +1313,10 @@ class TestOpenaiToResponses:
         resp = openai_to_responses(
             chat_resp, model="test-model", request=_bare_request(), created_at=0
         )
-        assert resp.usage.input_tokens_details == {"cached_tokens": 10}
+        assert resp.usage.input_tokens_details == {
+            "cached_tokens": 10,
+            "cache_write_tokens": 0,
+        }
 
     def test_request_metadata_echoed(self):
         req = ResponsesRequest(

--- a/vllm_mlx/api/responses_adapter.py
+++ b/vllm_mlx/api/responses_adapter.py
@@ -1186,6 +1186,9 @@ def _build_responses_usage(response: ChatCompletionResponse) -> ResponsesUsage:
         input_tokens=prompt,
         output_tokens=completion,
         total_tokens=prompt + completion,
-        input_tokens_details=({"cached_tokens": cached} if cached else None),
-        output_tokens_details=({"reasoning_tokens": reasoning} if reasoning else None),
+        input_tokens_details={
+            "cached_tokens": cached,
+            "cache_write_tokens": 0,
+        },
+        output_tokens_details={"reasoning_tokens": reasoning},
     )

--- a/vllm_mlx/api/responses_models.py
+++ b/vllm_mlx/api/responses_models.py
@@ -458,10 +458,14 @@ class ResponsesUsage(BaseModel):
     input_tokens: int = 0
     output_tokens: int = 0
     total_tokens: int = 0
-    # Optional details for prompt cache + reasoning tokens. Codex parses
-    # these fields and they're 1:1 with the OpenAI public spec.
-    input_tokens_details: dict[str, int] | None = None
-    output_tokens_details: dict[str, int] | None = None
+    # Current OpenAI SDKs require both details objects, including for zero
+    # cache hits and zero reasoning tokens.
+    input_tokens_details: dict[str, int] = Field(
+        default_factory=lambda: {"cached_tokens": 0, "cache_write_tokens": 0}
+    )
+    output_tokens_details: dict[str, int] = Field(
+        default_factory=lambda: {"reasoning_tokens": 0}
+    )
 
 
 class ResponsesOutputContent(BaseModel):

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -1680,9 +1680,15 @@ class MLLMScheduler:
                     # doesn't double-abort what's already cleaned up.
                     finished_normally = True
                     raise ValueError(output.error)
-                yield output
+                # Mark terminal output before yielding it. A consumer of an
+                # async generator may stop immediately after receiving the
+                # final item, so code after ``yield`` is not guaranteed to
+                # run. Marking it here prevents a successful request from
+                # being misclassified and aborted as an orphan.
                 if output.finished:
                     finished_normally = True
+                yield output
+                if output.finished:
                     break
         finally:
             if not finished_normally:

--- a/vllm_mlx/routes/responses.py
+++ b/vllm_mlx/routes/responses.py
@@ -2810,6 +2810,7 @@ async def _stream_responses(
                     "cached_tokens": cached_tokens_clamped
                     if cached_tokens_clamped
                     else 0,
+                    "cache_write_tokens": 0,
                 },
                 "output_tokens_details": {"reasoning_tokens": reasoning_token_credit},
             }

--- a/vllm_mlx/speculative/ddtree/server.py
+++ b/vllm_mlx/speculative/ddtree/server.py
@@ -392,7 +392,11 @@ def _render_prompt(
         messages.append({"role": m.role, "content": content})
 
     enable_thinking = False if no_thinking else _extract_thinking_from_request(request)
-    effective_thinking = True if enable_thinking is None else enable_thinking
+    # DDTree does not run the normal reasoning parser, so thinking tokens
+    # would be exposed directly in ``content`` and commonly exhaust the
+    # response budget. Default to a clean final answer while still honoring
+    # an explicit per-request ``enable_thinking=true`` opt-in.
+    effective_thinking = False if enable_thinking is None else enable_thinking
     if hasattr(tokenizer, "apply_chat_template"):
         try:
             return tokenizer.apply_chat_template(


### PR DESCRIPTION
## What changed

- Increase the local unit-test wrapper timeout from 120s to 300s, with a regression test, so a healthy ~160s full suite is not reported as failed.
- Stop successful multimodal requests from being logged and aborted as orphans when consumers close the stream after the terminal result.
- Default DDTree requests to non-thinking mode because the DDTree path does not run the reasoning parser; explicit `enable_thinking=true` is still honored.
- Make the Hermes integration prompt explicitly request `read_file`, removing a sampling-sensitive tool-selection failure.
- Include the `cache_write_tokens` field now required by current OpenAI SDK Responses usage models.
- Clarify that the published Qwen3.6 DFlash number is a historical community result, not a currently enabled model pair.

## Why

Release dogfooding found several small but user-visible gaps: a false test timeout, a misleading Gemma 4 orphan warning, DDTree thinking text leaking into normal content, a flaky Hermes smoke prompt, and incompatibility with the latest OpenAI Python SDK. These are focused root-cause fixes; no release version or unrelated subsystem is changed.

## User impact

- Release validation completes reliably on current Apple Silicon machines.
- Gemma 4 multimodal requests finish cleanly without false abort logs.
- Qwen3.5 DDTree produces concise normal answers by default and remains opt-in for explicit thinking.
- Hermes tool-use smoke testing is deterministic.
- Responses API output parses with current OpenAI SDK releases.
- DFlash docs match current runtime eligibility.

## Validation

- Codex review: no actionable correctness findings.
- Full suite: `13809 passed, 80 skipped, 212 deselected, 6 xfailed` in 161.52s; the wrapper reports PASS at 162.7s.
- Post-rebase focused suite: `113 passed`.
- Real local dogfood:
  - Gemma 4 26B multimodal image request: HTTP 200, correct image description, no orphan-abort log.
  - Qwen3.5 9B DDTree: actual drafter loaded; math/code/Chinese prompts succeeded; changed default verified without `--no-thinking`.
  - Hermes + Qwen3.5 9B: real `read_file` tool call and correct final answer.
  - LangChain + Qwen3.5 9B: 6/6 integration scenarios passed, including streaming, tools, and structured output.
  - DFlash runtime and Qwen3.5 drafter loaded; Qwen3.6 MoE remains correctly unsupported after direct compatibility testing.
- Clean wheel/sdist builds passed release smoke tests and `twine check`.