### PR TITLE
fix: default DFlash to final-answer mode

### DIFF
--- a/tests/test_dflash_integration.py
+++ b/tests/test_dflash_integration.py
@@ -1487,10 +1487,8 @@ def test_request_enable_thinking_false_honored(monkeypatch) -> None:
 
 
 @_skip_without_mlx_vlm
-def test_enable_thinking_default_preserved(monkeypatch) -> None:
-    """When neither --no-thinking nor request enable_thinking is set,
-    the historic default (True) must still reach the chat template so
-    existing Qwen3 callers see no behaviour change."""
+def test_enable_thinking_defaults_false_without_reasoning_parser(monkeypatch) -> None:
+    """DFlash must not leak unparsed thinking into normal response content."""
     captured = _capture_enable_thinking(
         monkeypatch,
         no_thinking=False,
@@ -1498,6 +1496,22 @@ def test_enable_thinking_default_preserved(monkeypatch) -> None:
             "model": "qwen3.5-27b-8bit",
             "messages": [{"role": "user", "content": "hi"}],
             "stream": True,
+        },
+    )
+    assert captured.get("enable_thinking") is False
+
+
+@_skip_without_mlx_vlm
+def test_request_enable_thinking_true_honored(monkeypatch) -> None:
+    """Callers can still explicitly opt in to the model's thinking output."""
+    captured = _capture_enable_thinking(
+        monkeypatch,
+        no_thinking=False,
+        request_body={
+            "model": "qwen3.5-27b-8bit",
+            "messages": [{"role": "user", "content": "hi"}],
+            "stream": True,
+            "enable_thinking": True,
         },
     )
     assert captured.get("enable_thinking") is True

--- a/vllm_mlx/speculative/dflash/server.py
+++ b/vllm_mlx/speculative/dflash/server.py
@@ -1095,7 +1095,7 @@ def _render_prompt(
     DFlash-eligible aliases are text-only Qwen3.5/3.6 variants today).
 
     ``enable_thinking`` resolution (caller-side; we just thread through):
-      None  → defer to mlx-vlm default (Qwen3 family = True).
+      None  → disable thinking because DFlash has no reasoning parser.
       True  → force chain-of-thought on.
       False → force chain-of-thought off (server --no-thinking or per-
               request ``enable_thinking=false`` body field).
@@ -1134,10 +1134,10 @@ def _render_prompt(
             content = "".join(text_pieces)
         messages.append({"role": m.role, "content": content})
 
-    # Preserve historic default (enable_thinking=True) when neither the
-    # server-level --no-thinking nor a per-request body override is set,
-    # to keep behaviour stable for callers that never opt out.
-    effective_thinking = True if enable_thinking is None else enable_thinking
+    # DFlash bypasses the normal reasoning parser, so thinking tokens would
+    # otherwise be exposed directly in ``content`` and commonly exhaust the
+    # response budget. Keep thinking available as an explicit request opt-in.
+    effective_thinking = False if enable_thinking is None else enable_thinking
     return apply_chat_template(
         processor,
         model.config,


### PR DESCRIPTION
## Summary
- default DFlash chat rendering to `enable_thinking=false` when the request does not specify it
- preserve explicit per-request opt-in with `enable_thinking=true`
- cover the default and both explicit boolean values

## Why
DFlash bypasses Rapid-MLX reasoning parsing. With the Qwen3.5 template defaulting to thinking mode, normal responses expose `Thinking Process` in `content` and frequently consume the full response budget before producing a final answer.

## Validation
- `pytest -q tests/test_dflash_integration.py` — 55 passed, 1 skipped
- Ruff and `git diff --check` passed
- Codex review converged with no findings
- Real local build: `mlx-community/Qwen3.5-27B-8bit` + `z-lab/Qwen3.5-27B-DFlash`; math, code, Chinese, streaming, and explicit tool rejection behaved correctly
- Same 700-token prompt: DFlash median 89.13 tok/s vs standard server 22.69 tok/s (~3.9x)