### PR TITLE
test: stabilize PydanticAI structured output check

### DIFF
--- a/tests/integrations/test_pydantic_ai_full.py
+++ b/tests/integrations/test_pydantic_ai_full.py
@@ -69,7 +69,12 @@ if __name__ == "__main__":
             name: str
             age: int
 
-        agent = Agent(model, output_type=Person)
+        # Keep the output-tool assertion deterministic and bound any retry.
+        agent = Agent(
+            model,
+            output_type=Person,
+            model_settings={"temperature": 0.0, "max_tokens": 256},
+        )
         r = agent.run_sync("Extract: 'Alice is 30 years old'")
         assert isinstance(r.output, Person), type(r.output)
         assert r.output.name.lower() == "alice", r.output.name


### PR DESCRIPTION
## Summary
- make the PydanticAI structured-output integration check deterministic
- cap generation at 256 tokens so a malformed output-tool retry cannot run unbounded
- test-only change; no runtime behavior changes

## Root cause
The test omitted both sampling and token settings. Qwen3.5 therefore inherited its generation config (`temperature=1.0`, effectively unbounded for this assertion), occasionally emitted invalid `final_result` arguments, and entered PydanticAI retry generation.

## Validation
- Before: 7 failures in the first 28 real-server runs, with one subsequent retry interrupted after ~66s
- After: 30/30 real-server runs passed; mean 1.264s, max 1.646s
- `ruff check`, `ruff format --check`, `py_compile`, and `git diff --check` passed
- Codex review converged with no findings