### PR TITLE
fix(dflash): align capabilities and startup UX

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -58,11 +58,20 @@ The base text-only install is ~460 MB. Vision/audio/etc. ship as opt-in extras.
 | Extra | Install | Adds |
 |---|---|---|
 | `vision` | `pip install 'rapid-mlx[vision]'` | mlx-vlm + opencv + torch (~322 MB) for VLMs (Gemma 4, Qwen-VL, video) |
+| `dflash` | `pip install 'rapid-mlx[dflash]'` | mlx-vlm for DFlash speculative decoding on supported 8-bit aliases |
 | `audio` | `pip install 'rapid-mlx[audio]'` | mlx-audio + spacy + scipy (~600 MB) for TTS / STT |
 | `embeddings` | `pip install 'rapid-mlx[embeddings]'` | mlx-embeddings (~50 MB) for `/v1/embeddings` |
 | `chat` | `pip install 'rapid-mlx[chat]'` | Gradio web UI (~150 MB) |
 | `guided` | `pip install 'rapid-mlx[guided]'` | outlines (~80 MB) for schema-constrained JSON |
 | `all` | `pip install 'rapid-mlx[all]'` | Everything above (~1.1 GB) |
+
+Homebrew installs the text-only package and does not provide Python extras.
+To switch a Homebrew installation to DFlash, use an isolated tool install:
+
+```bash
+brew uninstall rapid-mlx
+uv tool install 'rapid-mlx[dflash]'
+```
 
 ## Verify Installation
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -105,7 +105,8 @@ rapid-mlx serve deepseek-r1-8b-4bit --reasoning-parser deepseek_r1
 # Tool calling with Mistral/Devstral (parser auto-detected; pin shown for clarity)
 rapid-mlx serve devstral-24b-4bit --enable-auto-tool-choice --tool-call-parser mistral
 
-# DFlash speculative decoding (single-user, single supported alias)
+# DFlash speculative decoding (single-user, single supported alias).
+# Requires rapid-mlx[dflash]; OpenAI tools and opt-in thinking are supported.
 rapid-mlx serve qwen3.5-27b-8bit --speculative-config '{"method":"dflash"}' --port 8000
 
 # DDTree speculative decoding (experimental, single-user)

--- a/tests/test_dflash_integration.py
+++ b/tests/test_dflash_integration.py
@@ -68,6 +68,9 @@ def _reset_dflash_shared_globals():
             "max_request_bytes",
             "body_receive_timeout_seconds",
             "default_timeout",
+            "enable_auto_tool_choice",
+            "tool_call_parser",
+            "reasoning_parser_name",
         )
     }
     # codex round-8 #3: the CORS tests here call ``configure_cors_from_env``,
@@ -503,8 +506,24 @@ def test_dflash_cli_forwards_security_and_resource_limits() -> None:
         "default_timeout": "server._default_timeout",
         "max_concurrent_requests": "args.max_concurrent_requests",
         "cors_policy": "server.get_resolved_cors_policy()",
+        "tool_call_parser": (
+            "args.tool_call_parser if args.enable_auto_tool_choice else None"
+        ),
+        "reasoning_parser_name": "args.reasoning_parser",
     }
     assert {name: ast.unparse(keywords[name]) for name in expected} == expected
+
+
+def test_dflash_cli_forks_before_batched_engine_startup() -> None:
+    """DFlash startup must not advertise BatchedEngine-only features."""
+    import inspect
+
+    from vllm_mlx import cli
+
+    source = inspect.getsource(cli.serve_command)
+    dflash_call = source.index("run_dflash_server(")
+    assert dflash_call < source.index("Mode: Continuous batching")
+    assert dflash_call < source.index("Resolve per-alias TurboQuant default")
 
 
 def test_dflash_admission_cap_rejects_before_prompt_rendering() -> None:
@@ -1248,14 +1267,131 @@ def test_dflash_cors_wildcard_forces_credentials_off(monkeypatch) -> None:
     assert "Access-Control-Allow-Credentials" not in response.headers
 
 
-def test_chat_completions_rejects_tools() -> None:
-    """DFlash v1 doesn't run a tool-call parser. The route must reject
-    tool requests with a clear 400 — silent passthrough would surprise
-    users (model emits free-form text instead of structured tool calls)."""
+@pytest.mark.parametrize(
+    ("request_fields", "expected"),
+    [
+        (
+            {
+                "tools": [
+                    {
+                        "type": "function",
+                        "function": {"name": "get_weather", "parameters": {}},
+                    }
+                ]
+            },
+            "tool-call parser",
+        ),
+        ({"enable_thinking": True}, "reasoning parser"),
+    ],
+)
+def test_chat_completions_rejects_unparsed_structured_output(
+    request_fields, expected
+) -> None:
+    """Explicit parser opt-outs must not turn structured output into raw text."""
     from fastapi.testclient import TestClient
 
     from vllm_mlx.speculative.dflash.runtime import DFlashRuntime
     from vllm_mlx.speculative.dflash.server import _build_app
+
+    app = _build_app(
+        model=MagicMock(),
+        processor=MagicMock(),
+        runtime=DFlashRuntime(
+            drafter=MagicMock(),
+            kind="dflash",
+            drafter_repo="z-lab/Qwen3.5-27B-DFlash",
+        ),
+        served_model_name="qwen3.5-27b-8bit",
+        default_max_tokens=64,
+        cors_origins=["*"],
+    )
+    response = TestClient(app).post(
+        "/v1/chat/completions",
+        json={
+            "model": "qwen3.5-27b-8bit",
+            "messages": [{"role": "user", "content": "hi"}],
+            **request_fields,
+        },
+    )
+    assert response.status_code == 400
+    assert expected in response.json()["error"]["message"]
+
+
+@pytest.mark.parametrize(
+    "tool_choice",
+    [
+        "required",
+        "none",
+        {"type": "function", "function": {"name": "get_weather"}},
+    ],
+)
+def test_chat_completions_rejects_unsupported_tool_choice(tool_choice) -> None:
+    """DFlash must not silently claim forced-tool semantics it cannot enforce."""
+    from fastapi.testclient import TestClient
+
+    from vllm_mlx.speculative.dflash.runtime import DFlashRuntime
+    from vllm_mlx.speculative.dflash.server import _build_app
+
+    app = _build_app(
+        model=MagicMock(),
+        processor=MagicMock(),
+        runtime=DFlashRuntime(
+            drafter=MagicMock(),
+            kind="dflash",
+            drafter_repo="z-lab/Qwen3.5-27B-DFlash",
+        ),
+        served_model_name="qwen3.5-27b-8bit",
+        default_max_tokens=64,
+        cors_origins=["*"],
+        tool_call_parser="hermes",
+    )
+    response = TestClient(app).post(
+        "/v1/chat/completions",
+        json={
+            "model": "qwen3.5-27b-8bit",
+            "messages": [{"role": "user", "content": "hi"}],
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {"name": "get_weather", "parameters": {}},
+                }
+            ],
+            "tool_choice": tool_choice,
+        },
+    )
+    assert response.status_code == 400
+    assert "tool_choice='auto' only" in response.json()["error"]["message"]
+
+
+@_skip_without_mlx_vlm
+def test_chat_completions_parses_tool_calls(monkeypatch) -> None:
+    """DFlash reuses the standard Hermes parser for OpenAI tool calls."""
+    import mlx_vlm
+    import mlx_vlm.prompt_utils
+    from fastapi.testclient import TestClient
+
+    from vllm_mlx.speculative.dflash.runtime import DFlashRuntime
+    from vllm_mlx.speculative.dflash.server import _build_app
+
+    captured_template: dict = {}
+
+    def _render(*args, **kwargs):
+        captured_template.update(kwargs)
+        return "rendered prompt"
+
+    monkeypatch.setattr(mlx_vlm.prompt_utils, "apply_chat_template", _render)
+    monkeypatch.setattr(
+        mlx_vlm,
+        "generate",
+        lambda *args, **kwargs: SimpleNamespace(
+            text=(
+                '<tool_call>{"name":"get_weather",'
+                '"arguments":{"city":"Paris"}}</tool_call>'
+            ),
+            prompt_tokens=8,
+            generation_tokens=6,
+        ),
+    )
 
     runtime = DFlashRuntime(
         drafter=MagicMock(),
@@ -1269,6 +1405,8 @@ def test_chat_completions_rejects_tools() -> None:
         served_model_name="qwen3.5-27b-8bit",
         default_max_tokens=512,
         cors_origins=["*"],
+        tool_call_parser="hermes",
+        reasoning_parser_name="qwen3",
     )
     client = TestClient(app)
 
@@ -1280,17 +1418,115 @@ def test_chat_completions_rejects_tools() -> None:
             "tools": [
                 {
                     "type": "function",
-                    "function": {"name": "get_weather", "parameters": {}},
+                    "function": {
+                        "name": "get_weather",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {"city": {"type": "string"}},
+                        },
+                    },
                 }
             ],
         },
     )
-    assert r.status_code == 400
-    # D-ANTHRO-VALIDATION F11: the dflash app now installs the shared
-    # exception handlers so HTTPException responses go through the
-    # canonical envelope ``{"error":{"message":...}}`` instead of the
-    # bare FastAPI ``{"detail":...}`` shape.
-    assert "tool calling" in r.json()["error"]["message"].lower()
+    assert r.status_code == 200, r.text
+    choice = r.json()["choices"][0]
+    assert choice["finish_reason"] == "tool_calls"
+    assert choice["message"]["content"] == ""
+    call = choice["message"]["tool_calls"][0]
+    assert call["function"]["name"] == "get_weather"
+    assert call["function"]["arguments"] == '{"city": "Paris"}'
+    assert captured_template["tools"][0]["function"]["name"] == "get_weather"
+
+
+@_skip_without_mlx_vlm
+def test_chat_completions_streams_tool_calls(monkeypatch) -> None:
+    """DFlash streaming emits structured deltas, not raw tool markup."""
+    import json
+
+    import mlx_vlm
+    import mlx_vlm.prompt_utils
+    from fastapi.testclient import TestClient
+
+    from vllm_mlx.speculative.dflash.runtime import DFlashRuntime
+    from vllm_mlx.speculative.dflash.server import _build_app
+
+    monkeypatch.setattr(
+        mlx_vlm.prompt_utils,
+        "apply_chat_template",
+        lambda *args, **kwargs: "rendered prompt",
+    )
+
+    chunks = (
+        "<tool_call>",
+        '{"name":"get_weather","arguments":{"city":"Paris"}}',
+        "</tool_call>",
+    )
+
+    def _stream(*args, **kwargs):
+        for index, text in enumerate(chunks, start=1):
+            yield SimpleNamespace(
+                text=text,
+                token=index,
+                prompt_tokens=8,
+                generation_tokens=index,
+            )
+
+    monkeypatch.setattr(mlx_vlm, "stream_generate", _stream)
+    app = _build_app(
+        model=MagicMock(),
+        processor=MagicMock(),
+        runtime=DFlashRuntime(
+            drafter=MagicMock(),
+            kind="dflash",
+            drafter_repo="z-lab/Qwen3.5-27B-DFlash",
+        ),
+        served_model_name="qwen3.5-27b-8bit",
+        default_max_tokens=512,
+        cors_origins=["*"],
+        tool_call_parser="hermes",
+        reasoning_parser_name="qwen3",
+    )
+
+    with TestClient(app).stream(
+        "POST",
+        "/v1/chat/completions",
+        json={
+            "model": "qwen3.5-27b-8bit",
+            "messages": [{"role": "user", "content": "weather in Paris?"}],
+            "stream": True,
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "get_weather",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {"city": {"type": "string"}},
+                        },
+                    },
+                }
+            ],
+        },
+    ) as response:
+        assert response.status_code == 200
+        body = b"".join(response.iter_bytes()).decode()
+
+    payloads = [
+        json.loads(line.removeprefix("data: "))
+        for line in body.splitlines()
+        if line.startswith("data: {")
+    ]
+    tool_deltas = [
+        choice["delta"]["tool_calls"]
+        for payload in payloads
+        for choice in payload.get("choices", [])
+        if choice.get("delta", {}).get("tool_calls")
+    ]
+    assert tool_deltas[0][0]["function"]["name"] == "get_weather"
+    assert '"city": "Paris"' in tool_deltas[0][0]["function"]["arguments"]
+    assert payloads[-1]["choices"][0]["finish_reason"] == "tool_calls"
+    assert "<tool_call>" not in body
 
 
 def test_chat_completions_rejects_empty_messages() -> None:
@@ -1440,6 +1676,7 @@ def _capture_enable_thinking(monkeypatch, *, no_thinking: bool, request_body: di
         default_max_tokens=64,
         cors_origins=["*"],
         no_thinking=no_thinking,
+        reasoning_parser_name="qwen3",
     )
     client = TestClient(app)
     # Stream=True so the request reaches _render_prompt then exits via
@@ -1515,6 +1752,99 @@ def test_request_enable_thinking_true_honored(monkeypatch) -> None:
         },
     )
     assert captured.get("enable_thinking") is True
+
+
+@_skip_without_mlx_vlm
+@pytest.mark.parametrize("stream", [False, True])
+def test_explicit_thinking_is_parsed_into_reasoning_content(
+    monkeypatch, stream: bool
+) -> None:
+    """DFlash opt-in thinking uses the standard Qwen reasoning parser."""
+    import json
+
+    import mlx_vlm
+    import mlx_vlm.prompt_utils
+    from fastapi.testclient import TestClient
+
+    from vllm_mlx.speculative.dflash.runtime import DFlashRuntime
+    from vllm_mlx.speculative.dflash.server import _build_app
+
+    monkeypatch.setattr(
+        mlx_vlm.prompt_utils,
+        "apply_chat_template",
+        lambda *args, **kwargs: "rendered prompt",
+    )
+    monkeypatch.setattr(
+        mlx_vlm,
+        "generate",
+        lambda *args, **kwargs: SimpleNamespace(
+            text="<think>Need one addition.</think>Four.",
+            prompt_tokens=5,
+            generation_tokens=7,
+        ),
+    )
+
+    def _stream(*args, **kwargs):
+        for index, text in enumerate(
+            ("<think>", "Need one addition.", "</think>", "Four."), start=1
+        ):
+            yield SimpleNamespace(
+                text=text,
+                token=index,
+                prompt_tokens=5,
+                generation_tokens=index,
+            )
+
+    monkeypatch.setattr(mlx_vlm, "stream_generate", _stream)
+    app = _build_app(
+        model=MagicMock(),
+        processor=MagicMock(),
+        runtime=DFlashRuntime(
+            drafter=MagicMock(),
+            kind="dflash",
+            drafter_repo="z-lab/Qwen3.5-27B-DFlash",
+        ),
+        served_model_name="qwen3.5-27b-8bit",
+        default_max_tokens=64,
+        cors_origins=["*"],
+        reasoning_parser_name="qwen3",
+    )
+    request_body = {
+        "model": "qwen3.5-27b-8bit",
+        "messages": [{"role": "user", "content": "What is 2 + 2?"}],
+        "enable_thinking": True,
+        "stream": stream,
+    }
+
+    if not stream:
+        response = TestClient(app).post(
+            "/v1/chat/completions",
+            json=request_body,
+        )
+        assert response.status_code == 200, response.text
+        message = response.json()["choices"][0]["message"]
+        assert message["reasoning_content"] == "Need one addition."
+        assert message["content"] == "Four."
+        return
+
+    with TestClient(app).stream(
+        "POST", "/v1/chat/completions", json=request_body
+    ) as response:
+        assert response.status_code == 200
+        body = b"".join(response.iter_bytes()).decode()
+    payloads = [
+        json.loads(line.removeprefix("data: "))
+        for line in body.splitlines()
+        if line.startswith("data: {")
+    ]
+    deltas = [
+        choice["delta"] for payload in payloads for choice in payload.get("choices", [])
+    ]
+    assert "".join(delta.get("reasoning_content", "") for delta in deltas) == (
+        "Need one addition."
+    )
+    assert "".join(delta.get("content", "") for delta in deltas) == "Four."
+    assert "<think>" not in body
 
 
 @_skip_without_mlx_vlm

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -2233,7 +2233,7 @@ def serve_command(args):
     #   - tool/reasoning parsers auto-configured
     #   - CORS allow-origin warning printed
     # so the operator saw five INFO lines and a banner before the
-    # actionable ``Install with: pip install 'rapid-mlx[dflash]'`` line,
+    # actionable optional-extra install instructions,
     # matching Diego's earlier ``[embeddings]`` regression shape exactly.
     # Hoist the cheap ``have_runtime()`` probe to the same boot-guard tier
     # as the other extras so the error lands FIRST. ``importlib.util.
@@ -2246,9 +2246,14 @@ def serve_command(args):
         if not have_runtime():
             print(
                 "\n  Error: DFlash speculative decoding "
-                '(``--speculative-config \'{"method":"dflash"}\'``) requires '
-                "mlx-vlm 0.5.0+ for the DFlash drafter hooks. Install with: "
-                "``pip install 'rapid-mlx[dflash]'``.\n"
+                '(--speculative-config \'{"method":"dflash"}\') requires '
+                "mlx-vlm 0.5.0+ for the DFlash drafter hooks.\n"
+                "\n  Install in a Python environment with:\n"
+                "    pip install 'rapid-mlx[dflash]'\n"
+                "\n  Homebrew installs the text-only package. Homebrew users "
+                "can switch to the isolated full install with:\n"
+                "    brew uninstall rapid-mlx\n"
+                "    uv tool install 'rapid-mlx[dflash]'\n"
             )
             sys.exit(1)
 
@@ -2414,24 +2419,25 @@ def serve_command(args):
     # the effective lane, NOT the raw multimodal classification: a hybrid VLM
     # that auto-downgrades to the text-only lane is PFlash-capable there,
     # exactly as an explicit ``--text-only`` run would be (#352 dogfood P1-②).
-    _serve_is_mllm, _ = resolve_serving_lane(
-        args.model,
-        force_mllm=getattr(args, "mllm", False),
-        force_text=getattr(args, "no_mllm", False),
-    )
-    args.pflash = resolve_pflash_mode_default(
-        args, model_name=args.model, is_multimodal=_serve_is_mllm
-    )
-    try:
-        pflash_config = config_from_args(args)
-        validate_model_support(
-            pflash_config,
-            model_name=args.model,
-            is_mllm=_serve_is_mllm,
+    if not args.enable_dflash:
+        _serve_is_mllm, _ = resolve_serving_lane(
+            args.model,
+            force_mllm=getattr(args, "mllm", False),
+            force_text=getattr(args, "no_mllm", False),
         )
-    except ValueError as e:
-        print(f"Error: {e}")
-        sys.exit(1)
+        args.pflash = resolve_pflash_mode_default(
+            args, model_name=args.model, is_multimodal=_serve_is_mllm
+        )
+        try:
+            pflash_config = config_from_args(args)
+            validate_model_support(
+                pflash_config,
+                model_name=args.model,
+                is_mllm=_serve_is_mllm,
+            )
+        except ValueError as e:
+            print(f"Error: {e}")
+            sys.exit(1)
 
     # Auto-detect parser config from model name when not explicitly set.
     # --no-tool-call-parser / --no-reasoning-parser are escape hatches
@@ -2786,10 +2792,16 @@ def serve_command(args):
         # the user explicitly set away from their default.
         _GPU_MEM_DEFAULT = 0.90  # keep in sync with the serve_parser default
         _dflash_ignored: list[str] = []
-        if getattr(args, "enable_prefix_cache", False):
-            _dflash_ignored.append("--enable-prefix-cache")
+        # Prefix caching is enabled by default in the shared serve parser,
+        # so it is not evidence that the user explicitly requested it.
+        # DFlash already documents its no-prefix-cache limitation; avoid a
+        # warning on every normal DFlash startup.
         if getattr(args, "kv_cache_quantization", None):
             _dflash_ignored.append("--kv-cache-quantization")
+        if getattr(args, "kv_cache_turboquant", None):
+            _dflash_ignored.append("--kv-cache-turboquant")
+        if getattr(args, "pflash", None) not in (None, "auto"):
+            _dflash_ignored.append("--pflash")
         # gpu-memory-utilization defaults to 0.90 (not None) in the serve
         # parser, so an ``is not None`` check would fire on every invocation.
         # Compare to the real default — only warn when the user explicitly
@@ -2797,12 +2809,8 @@ def serve_command(args):
         _gpu_mem = getattr(args, "gpu_memory_utilization", _GPU_MEM_DEFAULT)
         if _gpu_mem is not None and abs(_gpu_mem - _GPU_MEM_DEFAULT) > 1e-6:
             _dflash_ignored.append("--gpu-memory-utilization")
-        if getattr(args, "enable_auto_tool_choice", False):
-            _dflash_ignored.append("--enable-auto-tool-choice")
-        if getattr(args, "tool_call_parser", None):
-            _dflash_ignored.append("--tool-call-parser")
-        if getattr(args, "reasoning_parser", None):
-            _dflash_ignored.append("--reasoning-parser")
+        if getattr(args, "enable_tool_logits_bias", False):
+            _dflash_ignored.append("--enable-tool-logits-bias")
         if getattr(args, "embedding_model", None):
             _dflash_ignored.append("--embedding-model")
         if getattr(args, "mcp_config", None):
@@ -2872,11 +2880,11 @@ def serve_command(args):
         features.append(auth_feature)
     if args.rate_limit > 0:
         features.append(f"rate-limit: {args.rate_limit}/min")
-    if args.cloud_model:
+    if args.cloud_model and not args.enable_dflash:
         features.append(f"cloud: {args.cloud_model}")
-    if gc_control:
+    if gc_control and not args.enable_dflash:
         features.append("gc-control")
-    if args.pin_system_prompt:
+    if args.pin_system_prompt and not args.enable_dflash:
         features.append("pin-system-prompt")
     # Show CORS in the startup banner when CLI flag or env-var-driven
     # config produced an origin list (``configure_cors_from_env`` is what
@@ -2891,9 +2899,57 @@ def serve_command(args):
         print(f"  Features: {', '.join(features)}")
     print(f"  Model: {args.model}")
     # Store MCP config path for FastAPI startup
-    if args.mcp_config:
+    if args.mcp_config and not args.enable_dflash:
         print(f"MCP config: {args.mcp_config}")
         os.environ["RAPID_MLX_MCP_CONFIG"] = args.mcp_config
+
+    # DFlash owns a dedicated single-user runtime. Fork before constructing
+    # BatchedEngine-only cache/TurboQuant/PFlash state so startup output and
+    # initialization describe capabilities that actually apply.
+    if args.enable_dflash:
+        if getattr(args, "no_spec_decode", False):
+            print(
+                "error: DFlash and --no-spec-decode are mutually "
+                "exclusive — DFlash is a speculative-decode mode.",
+                file=sys.stderr,
+            )
+            sys.exit(2)
+
+        from .model_aliases import resolve_profile
+        from .speculative.dflash.server import run_dflash_server
+
+        _alias_name = getattr(args, "_original_alias", None) or args.model
+        _profile = resolve_profile(_alias_name)
+        assert _profile is not None and _profile.supports_dflash, (
+            f"DFlash profile invariant violated for {_alias_name!r}"
+        )
+
+        _check_disk_space(args.model, force=getattr(args, "force_disk_check", False))
+        _check_memory_capacity(args.model)
+        server._sync_config()
+        run_dflash_server(
+            main_model_repo=_profile.hf_path,
+            drafter_repo=_resolve_dflash_drafter_repo(args, _profile),
+            host=args.host,
+            port=args.port,
+            served_model_name=args.served_model_name or _alias_name,
+            default_max_tokens=effective_max_tokens,
+            cors_origins=cors_origins,
+            uvicorn_log_level=uvicorn_log_level,
+            no_thinking=args.no_thinking,
+            api_key=server._api_key,
+            rate_limit=args.rate_limit,
+            max_request_bytes=server._max_request_bytes,
+            body_receive_timeout_seconds=server._body_receive_timeout_seconds,
+            default_timeout=server._default_timeout,
+            max_concurrent_requests=args.max_concurrent_requests,
+            cors_policy=server.get_resolved_cors_policy(),
+            tool_call_parser=(
+                args.tool_call_parser if args.enable_auto_tool_choice else None
+            ),
+            reasoning_parser_name=args.reasoning_parser,
+        )
+        return
 
     # Pre-load embedding model if specified.
     #
@@ -3323,52 +3379,6 @@ def serve_command(args):
     # Pre-flight memory check — warn (don't abort) if model + working set
     # would push unified memory past the kernel-panic threshold (issue #324).
     _check_memory_capacity(args.model)
-
-    # DFlash fork: when method=dflash is set, skip BatchedEngine entirely
-    # and run the dedicated DFlash server. The eligibility check above has
-    # already validated the alias, so by here we have a known-good profile.
-    if args.enable_dflash:
-        # DFlash IS a speculative-decode path. The --no-spec-decode escape
-        # hatch (SOP §10) must reject it here — otherwise the user thinks
-        # they've disabled spec-decode but DFlash silently proceeds via
-        # its dedicated server, never touching EngineCore / ModelConfig.
-        if getattr(args, "no_spec_decode", False):
-            print(
-                "error: DFlash and --no-spec-decode are mutually "
-                "exclusive — DFlash is a speculative-decode mode.",
-                file=sys.stderr,
-            )
-            sys.exit(2)
-        from .model_aliases import resolve_profile
-        from .speculative.dflash.server import run_dflash_server
-
-        _alias_name = getattr(args, "_original_alias", None) or args.model
-        _profile = resolve_profile(_alias_name)
-        # The eligibility check at top of serve_command guarantees this
-        # passes — assert to be defensive against future refactors.
-        assert _profile is not None and _profile.supports_dflash, (
-            f"DFlash profile invariant violated for {_alias_name!r}"
-        )
-        # The vLLM-style surface uses ``model`` for the drafter override.
-        run_dflash_server(
-            main_model_repo=_profile.hf_path,
-            drafter_repo=_resolve_dflash_drafter_repo(args, _profile),
-            host=args.host,
-            port=args.port,
-            served_model_name=args.served_model_name or _alias_name,
-            default_max_tokens=effective_max_tokens,
-            cors_origins=cors_origins,
-            uvicorn_log_level=uvicorn_log_level,
-            no_thinking=args.no_thinking,
-            api_key=server._api_key,
-            rate_limit=args.rate_limit,
-            max_request_bytes=server._max_request_bytes,
-            body_receive_timeout_seconds=server._body_receive_timeout_seconds,
-            default_timeout=server._default_timeout,
-            max_concurrent_requests=args.max_concurrent_requests,
-            cors_policy=server.get_resolved_cors_policy(),
-        )
-        return
 
     # DDTree fork: same blast-radius boundary as DFlash. It is a
     # speculative-decode mode, but the MVP runs through the external

--- a/vllm_mlx/speculative/dflash/server.py
+++ b/vllm_mlx/speculative/dflash/server.py
@@ -18,10 +18,10 @@ Why a separate server (not a fork of the standard route)?
   - A separate, opt-in server is a clean blast-radius boundary: turning
     on DFlash can never break a request that doesn't use it.
 
-v1 limitations (documented in README + ``rapid-mlx info``):
+Current limitations (documented in README + ``rapid-mlx info``):
   - Single-user serial. Concurrent requests queue on an ``asyncio.Lock``.
-  - No tool calling, MCP, embeddings, or audio in this server (the
-    standard server handles those).
+  - No MCP, embeddings, or audio in this server (the standard server
+    handles those).
   - No prefix cache (per-request KV cache built fresh each call).
 
 These limitations are deliberate for v1 — the target user is someone
@@ -57,6 +57,12 @@ from vllm_mlx.api.models import (
     Usage,
 )
 from vllm_mlx.config import get_config
+from vllm_mlx.engine import GenerationOutput
+from vllm_mlx.service.helpers import (
+    _parse_tool_calls_with_parser,
+    _validate_tool_call_params,
+)
+from vllm_mlx.service.postprocessor import StreamingPostProcessor
 
 from .eligibility import have_runtime
 from .runtime import DFlashRuntime, load_runtime
@@ -617,6 +623,8 @@ def _build_app(
     default_timeout: float = 1800.0,
     max_concurrent_requests: int = 256,
     cors_policy: Any | None = None,
+    tool_call_parser: str | None = None,
+    reasoning_parser_name: str | None = None,
 ) -> FastAPI:
     """Create the FastAPI application for DFlash mode.
 
@@ -644,6 +652,9 @@ def _build_app(
     cfg.max_request_bytes = max(0, int(max_request_bytes))
     cfg.body_receive_timeout_seconds = max(0.0, float(body_receive_timeout_seconds))
     cfg.default_timeout = max(0.0, float(default_timeout))
+    cfg.enable_auto_tool_choice = bool(tool_call_parser)
+    cfg.tool_call_parser = tool_call_parser
+    cfg.reasoning_parser_name = reasoning_parser_name
 
     from ...middleware.auth import (
         configure_rate_limiter,
@@ -791,15 +802,20 @@ def _build_app(
             raise HTTPException(status_code=400, detail="messages must not be empty")
         if request.n is not None and request.n > 1:
             raise HTTPException(status_code=400, detail="n > 1 is not supported")
-        if request.tools:
-            # DFlash server doesn't run a tool-call parser. Surface this so
-            # users don't think their tools "silently worked" when in fact
-            # the model just emitted free-form text.
+        if request.tools and not cfg.tool_call_parser:
             raise HTTPException(
                 status_code=400,
                 detail=(
-                    "Tool calling is not supported in DFlash mode (v1 "
-                    "limitation). Restart without DFlash to use tools."
+                    "DFlash tool calling requires an enabled tool-call parser. "
+                    "Remove --no-tool-call-parser or configure one explicitly."
+                ),
+            )
+        if request.tools and request.tool_choice not in (None, "auto"):
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    "DFlash currently supports tool_choice='auto' only. "
+                    "Restart without DFlash for forced or disabled tool choice."
                 ),
             )
         # Surface unsupported params explicitly rather than silently
@@ -895,6 +911,15 @@ def _build_app(
                 enable_thinking: bool | None = False
             else:
                 enable_thinking = _extract_thinking_from_request(request)
+            effective_thinking = False if enable_thinking is None else enable_thinking
+            if effective_thinking and not cfg.reasoning_parser_name:
+                raise HTTPException(
+                    status_code=400,
+                    detail=(
+                        "DFlash thinking output requires a reasoning parser. "
+                        "Remove --no-reasoning-parser or configure one explicitly."
+                    ),
+                )
 
             # codex round-4 #4 → round-5 #1/#2: OFFLOAD rendering so a heavy
             # chat template cannot block the event loop (starving other
@@ -916,7 +941,10 @@ def _build_app(
             # behind it, unlike a timed-out generation worker.
             def _render() -> str:
                 return _render_prompt(
-                    processor, model, request, enable_thinking=enable_thinking
+                    processor,
+                    model,
+                    request,
+                    enable_thinking=effective_thinking,
                 )
 
             # codex round-8 #1: validate the remaining budget BEFORE submitting
@@ -1048,6 +1076,7 @@ def _build_app(
                         timeout_label=request_timeout_for_diagnostics,
                         deadline=request_deadline,
                         admission_reservation=reservation,
+                        enable_thinking=effective_thinking,
                     ),
                     reservation,
                 ),
@@ -1074,6 +1103,7 @@ def _build_app(
                 timeout_label=request_timeout_for_diagnostics,
                 deadline=request_deadline,
                 admission_reservation=reservation,
+                enable_thinking=effective_thinking,
             )
         finally:
             reservation.release()
@@ -1104,6 +1134,7 @@ def _render_prompt(
 
     messages = []
     for m in request.messages:
+        message = m.model_dump(exclude_none=True)
         content = m.content
         if isinstance(content, list):
             # Multimodal payload — DFlash server is text-only. Collapse
@@ -1132,19 +1163,27 @@ def _render_prompt(
                     sorted(set(dropped_kinds)),
                 )
             content = "".join(text_pieces)
-        messages.append({"role": m.role, "content": content})
+        message["content"] = content
+        messages.append(message)
 
-    # DFlash bypasses the normal reasoning parser, so thinking tokens would
-    # otherwise be exposed directly in ``content`` and commonly exhaust the
-    # response budget. Keep thinking available as an explicit request opt-in.
+    # Default to final-answer mode. Explicit thinking opt-in is post-processed
+    # by the same reasoning pipeline as the standard server.
     effective_thinking = False if enable_thinking is None else enable_thinking
+    template_kwargs: dict[str, Any] = {
+        "num_images": 0,
+        "num_audios": 0,
+        "enable_thinking": effective_thinking,
+    }
+    if request.tools:
+        from ...api.tool_calling import convert_tools_for_template
+
+        template_kwargs["tools"] = convert_tools_for_template(request.tools)
+
     return apply_chat_template(
         processor,
         model.config,
         messages,
-        num_images=0,
-        num_audios=0,
-        enable_thinking=effective_thinking,
+        **template_kwargs,
     )
 
 
@@ -1204,6 +1243,7 @@ async def _stream_completion(
     timeout_label: float | None = None,
     deadline: float | None = None,
     admission_reservation: _DFlashAdmissionReservation | None = None,
+    enable_thinking: bool = False,
 ) -> AsyncIterator[bytes]:
     """Stream OpenAI-format chunks. Generation happens under the serial
     lock; chunks are forwarded as ``data: ...\\n\\n`` SSE events.
@@ -1228,6 +1268,15 @@ async def _stream_completion(
 
     completion_id = f"chatcmpl-{uuid.uuid4().hex[:24]}"
     created = int(time.time())
+    postprocessor: StreamingPostProcessor | None = None
+    if request.tools or enable_thinking:
+        postprocessor = StreamingPostProcessor(
+            get_config(),
+            tools_requested=bool(request.tools),
+            enable_thinking=enable_thinking,
+            request=request.model_dump(),
+        )
+        postprocessor.reset()
 
     # First chunk — role marker. Emitted by the consumer loop below,
     # before the producer task is started, so the client sees the role
@@ -1315,6 +1364,7 @@ async def _stream_completion(
         # budget. None means "no token observed yet".
         last_token_id: int | None = None
         error_message: str | None = None
+        postprocess_spilled = False
 
         async def _emit(item: bytes, *, terminal: bool = False) -> None:
             """Put one SSE frame on the bounded queue.
@@ -1361,6 +1411,48 @@ async def _stream_completion(
                 if deadline_left is not None and deadline_left <= backpressure:
                     raise _DFlashStreamDeadlineError from exc
                 raise _DFlashClientGoneError from exc
+
+        async def _emit_postprocessed_event(
+            event: Any, *, terminal: bool = False
+        ) -> None:
+            """Translate one shared postprocessor event to OpenAI SSE."""
+            nonlocal finish_reason, postprocess_spilled
+
+            if event.finish_reason is not None:
+                finish_reason = event.finish_reason
+            delta: dict[str, Any] = {}
+            if event.content:
+                delta["content"] = event.content
+            if event.reasoning:
+                delta["reasoning_content"] = event.reasoning
+            if event.tool_calls:
+                delta["tool_calls"] = event.tool_calls
+            if not delta:
+                return
+            piece = {
+                "id": completion_id,
+                "object": "chat.completion.chunk",
+                "created": created,
+                "model": served_model_name,
+                "choices": [
+                    {
+                        "index": 0,
+                        "delta": delta,
+                        "finish_reason": None,
+                    }
+                ],
+            }
+            frame = f"data: {json.dumps(piece)}\n\n".encode()
+            if terminal and postprocess_spilled:
+                pending_terminal.append(frame)
+                return
+            try:
+                await _emit(frame, terminal=terminal)
+            except _DFlashClientGoneError:
+                if not terminal:
+                    raise
+                postprocess_spilled = True
+                pending_terminal.append(frame)
 
         async def _await_worker(func: Any, *, makes_generator: bool = False) -> Any:
             """Wait without cancelling an mlx operation on deadline expiry."""
@@ -1522,19 +1614,6 @@ async def _stream_completion(
                     last_token_id = _ct
                 if not chunk.text:
                     continue
-                piece = {
-                    "id": completion_id,
-                    "object": "chat.completion.chunk",
-                    "created": created,
-                    "model": served_model_name,
-                    "choices": [
-                        {
-                            "index": 0,
-                            "delta": {"content": chunk.text},
-                            "finish_reason": None,
-                        }
-                    ],
-                }
                 # F2: push to the bounded queue instead of yielding to the
                 # socket directly, so the lease (and its lock) is never held
                 # across a suspended socket write. ``_emit`` on a content frame
@@ -1555,7 +1634,32 @@ async def _stream_completion(
                 #     cap and be swallowed in ``_drive_producer`` — no hang
                 #     either way.
                 try:
-                    await _emit(f"data: {json.dumps(piece)}\n\n".encode())
+                    if postprocessor is None:
+                        piece = {
+                            "id": completion_id,
+                            "object": "chat.completion.chunk",
+                            "created": created,
+                            "model": served_model_name,
+                            "choices": [
+                                {
+                                    "index": 0,
+                                    "delta": {"content": chunk.text},
+                                    "finish_reason": None,
+                                }
+                            ],
+                        }
+                        await _emit(f"data: {json.dumps(piece)}\n\n".encode())
+                    else:
+                        output = GenerationOutput(
+                            text=chunk.text,
+                            new_text=chunk.text,
+                            prompt_tokens=chunk.prompt_tokens,
+                            completion_tokens=chunk.generation_tokens,
+                            finished=False,
+                            finish_reason=None,
+                        )
+                        for event in postprocessor.process_chunk(output):
+                            await _emit_postprocessed_event(event)
                 except _DFlashStreamDeadlineError:
                     error_message = f"DFlash stream timed out after {_format_timeout_seconds(timeout_label)}."
                     finish_reason = "length"
@@ -1588,6 +1692,20 @@ async def _stream_completion(
             and last_token_id not in _eos_ids
         ):
             finish_reason = "length"
+
+        if postprocessor is not None and error_message is None:
+            finished_output = GenerationOutput(
+                text="",
+                new_text="",
+                prompt_tokens=prompt_tokens,
+                completion_tokens=total_completion_tokens,
+                finished=True,
+                finish_reason=finish_reason,
+            )
+            terminal_events = postprocessor.process_chunk(finished_output)
+            terminal_events.extend(postprocessor.finalize())
+            for event in terminal_events:
+                await _emit_postprocessed_event(event, terminal=True)
 
         # Final chunk — finish_reason + usage. If we broke out of the loop
         # because the underlying generator raised, attach an OpenAI-style
@@ -1626,7 +1744,7 @@ async def _stream_completion(
         # subsequent frame MUST go there too, even if the queue drains in
         # between; otherwise a later ``[DONE]`` could be enqueued and delivered
         # ahead of the still-pending final frame. ``spilled`` latches that.
-        spilled = False
+        spilled = postprocess_spilled
         for frame in (final_frame, done_frame):
             if spilled:
                 pending_terminal.append(frame)
@@ -1738,6 +1856,7 @@ async def _non_stream_completion(
     timeout_label: float | None = None,
     deadline: float | None = None,
     admission_reservation: _DFlashAdmissionReservation | None = None,
+    enable_thinking: bool = False,
 ) -> ChatCompletionResponse:
     """Run generation under the serial lock and enforce a safe deadline.
 
@@ -1886,6 +2005,30 @@ async def _non_stream_completion(
         else "stop"
     )
 
+    content: str | None = result.text
+    reasoning_content: str | None = None
+    cfg = get_config()
+    if cfg.reasoning_parser_name:
+        from ...reasoning import get_parser
+
+        parser_cls = get_parser(cfg.reasoning_parser_name)
+        reasoning_parser = parser_cls()
+        reasoning_content, parsed_content = reasoning_parser.extract_reasoning(
+            result.text,
+            enable_thinking=enable_thinking,
+        )
+        if parsed_content is not None:
+            content = parsed_content
+        elif reasoning_content is not None:
+            content = None
+
+    tool_calls = None
+    if request.tools:
+        content, tool_calls = _parse_tool_calls_with_parser(content or "", request)
+        if tool_calls:
+            _validate_tool_call_params(tool_calls, request.tools)
+            finish_reason = "tool_calls"
+
     return ChatCompletionResponse(
         id=completion_id,
         object="chat.completion",
@@ -1894,7 +2037,12 @@ async def _non_stream_completion(
         choices=[
             ChatCompletionChoice(
                 index=0,
-                message=AssistantMessage(role="assistant", content=result.text),
+                message=AssistantMessage(
+                    role="assistant",
+                    content=content,
+                    reasoning_content=reasoning_content,
+                    tool_calls=tool_calls,
+                ),
                 finish_reason=finish_reason,
             )
         ],
@@ -1924,6 +2072,8 @@ def run_dflash_server(
     default_timeout: float = 1800.0,
     max_concurrent_requests: int = 256,
     cors_policy: Any | None = None,
+    tool_call_parser: str | None = "hermes",
+    reasoning_parser_name: str | None = "qwen3",
 ) -> None:
     """Load the model + DFlash drafter via mlx-vlm and start uvicorn.
 
@@ -1948,7 +2098,9 @@ def run_dflash_server(
     if not have_runtime():
         raise RuntimeError(
             "DFlash server requires mlx-vlm 0.5.0+ — install with "
-            "``pip install 'rapid-mlx[dflash]'``."
+            "pip install 'rapid-mlx[dflash]'. Homebrew installs the "
+            "text-only package; switch to an isolated uv tool install "
+            "for optional extras."
         )
 
     # Belt-and-suspenders eligibility re-check for programmatic callers
@@ -2007,6 +2159,8 @@ def run_dflash_server(
         default_timeout=default_timeout,
         max_concurrent_requests=max_concurrent_requests,
         cors_policy=cors_policy,
+        tool_call_parser=tool_call_parser,
+        reasoning_parser_name=reasoning_parser_name,
     )
 
     print()


### PR DESCRIPTION
## What does this PR do?

- forks into the dedicated DFlash server before BatchedEngine-only PFlash, TurboQuant, cache, and continuous-batching setup
- reuses the existing Hermes tool-call and Qwen reasoning post-processors for DFlash, including streaming and multi-turn tool-result messages
- rejects explicit parser opt-outs and non-auto `tool_choice` values instead of silently leaking raw markup or claiming unsupported semantics
- documents the `dflash` extra and gives Homebrew users an executable migration path

## Why is this needed?

Without this PR, DFlash startup advertises features from a server path it never uses, Homebrew users receive a pip command that cannot modify the brew-managed environment, tool-capable clients receive a hard 400, and opted-in thinking is returned as raw content. Qwen3.5-27B DFlash already has compatible shared Hermes/Qwen parsers, so these are user-visible integration gaps rather than new parser work.

## AI assistance disclosure

Codex wrote and reviewed the five touched files. Codex verified the change with focused and broader unit tests, a contract mutation spot-check, two iterative Codex review rounds, a clean wheel in a fresh venv, and real Qwen3.5-27B + DFlash drafter inference. Human maintainer review remains visible through this draft PR.

> By submitting this PR I confirm I can explain the intent, risk, and behavior of every non-generated change in this PR. For generated sections, the verification evidence is listed below.

## Test plan

- [x] `python3.12 -m pytest tests/test_dflash_integration.py -q` — 64 passed, 1 skipped
- [x] `python3.12 -m pytest tests/test_postprocessor.py tests/test_tool_calling.py tests/test_reasoning_parsers.py -q` — 354 passed
- [x] Ruff format/check and `git diff --check`
- [x] Mutation: changed `if request.tools or enable_thinking` to an always-false gate; `test_chat_completions_streams_tool_calls` failed with no tool delta and `test_explicit_thinking_is_parsed_into_reasoning_content[True]` failed with no reasoning delta; restored the production condition and both passed
- [x] Codex review round 1: rejected unsupported explicit `tool_choice`; round 2: no correctness findings
- [x] Clean local wheel installed with `[dflash]`
- [x] Real `mlx-community/Qwen3.5-27B-8bit` + `z-lab/Qwen3.5-27B-DFlash`: plain completion, streaming/non-streaming tool call, multi-turn tool result, and streaming/non-streaming explicit thinking all passed

## Checklist

- [x] Focused tests pass locally
- [x] Lint and format pass
- [x] Critical parser-path tests mutation-checked
- [x] README/docs updated where applicable
- [x] No breaking change to the existing default DFlash completion path

## Out of scope

- Forced/disabled tool choice remains on the standard server; DFlash returns a clear 400 for non-auto choices.
- DFlash remains single-user and does not add MCP, embeddings, audio, or prefix caching.