### PR TITLE
fix: pad ragged sorted MoE gathers

### DIFF
--- a/tests/test_switch_layers_gather_pad.py
+++ b/tests/test_switch_layers_gather_pad.py
@@ -1,0 +1,75 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for the sorted gather_qmm/gather_mm row-alignment guard."""
+
+from types import SimpleNamespace
+
+import pytest
+
+mx = pytest.importorskip("mlx.core")
+
+from vllm_mlx.patches.switch_layers_gather_pad import install
+
+
+def _module_with_gather_sort():
+    calls = []
+
+    def _original_gather_sort(x, indices):
+        calls.append(True)
+        *_, M = indices.shape
+        indices = indices.flatten()
+        order = mx.argsort(indices)
+        inv_order = mx.argsort(order)
+        return x.flatten(0, -3)[order // M], indices[order], inv_order
+
+    return SimpleNamespace(mx=mx, _gather_sort=_original_gather_sort, calls=calls)
+
+
+def test_sorted_gather_pad_aligns_large_ragged_row_count():
+    module = _module_with_gather_sort()
+
+    assert install(module) is True
+
+    tokens, top_k = 8193, 4
+    x = mx.arange(tokens, dtype=mx.float32).reshape(1, tokens, 1)
+    x = mx.expand_dims(x, (-2, -3))
+    indices = (mx.arange(tokens * top_k, dtype=mx.int32) % 8).reshape(1, tokens, top_k)
+
+    sorted_x, sorted_indices, inv_order = module._gather_sort(x, indices)
+
+    assert module.calls == [True]
+    assert indices.size == 32772
+    assert sorted_indices.size == 32832
+    assert sorted_indices.size % 64 == 0
+    assert inv_order.size == indices.size
+    assert sorted_x.shape[0] == sorted_indices.size
+    assert mx.all(sorted_x[-1] == sorted_x[-2]).item()
+    assert sorted_indices[-1].item() == sorted_indices[-2].item()
+
+
+def test_sorted_gather_pad_leaves_aligned_large_row_count_unchanged():
+    module = _module_with_gather_sort()
+
+    assert install(module) is True
+
+    tokens, top_k = 8208, 4
+    x = mx.arange(tokens, dtype=mx.float32).reshape(1, tokens, 1)
+    x = mx.expand_dims(x, (-2, -3))
+    indices = (mx.arange(tokens * top_k, dtype=mx.int32) % 8).reshape(1, tokens, top_k)
+
+    _, sorted_indices, inv_order = module._gather_sort(x, indices)
+
+    assert module.calls == [True]
+    assert indices.size == 32832
+    assert indices.size % 64 == 0
+    assert sorted_indices.size == indices.size
+    assert inv_order.size == indices.size
+
+
+def test_sorted_gather_pad_install_is_idempotent():
+    module = _module_with_gather_sort()
+
+    assert install(module) is True
+    patched = module._gather_sort
+
+    assert install(module) is False
+    assert module._gather_sort is patched

--- a/vllm_mlx/_mlx_compat.py
+++ b/vllm_mlx/_mlx_compat.py
@@ -131,3 +131,13 @@ def install() -> None:
     mx.new_thread_local_stream = patched_new_thread_local_stream
     mx._rapid_mlx_compat_installed = True
     logger.debug("MLX compat shim installed (#404 M5 single-stream guard).")
+
+    try:
+        from vllm_mlx.patches.switch_layers_gather_pad import (
+            install as _install_switch_layers_gather_pad,
+        )
+    except ImportError:
+        return
+
+    if _install_switch_layers_gather_pad():
+        logger.debug("MLX compat shim installed sorted gather row-alignment guard.")

--- a/vllm_mlx/patches/switch_layers_gather_pad.py
+++ b/vllm_mlx/patches/switch_layers_gather_pad.py
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Compatibility patch for mlx-lm sorted MoE gathers.
+
+MLX's sorted ``gather_qmm`` / ``gather_mm`` path can silently corrupt affine
+MoE outputs when the flattened routed-row count is greater than 32768 and is
+not 64-aligned. Padding the sorted rows by duplicating the final row keeps the
+expert indices sorted, and mlx-lm's unsort step drops the padding before the
+result is reshaped back to the original token/expert grid.
+"""
+
+from __future__ import annotations
+
+from types import ModuleType
+
+
+def install(module: ModuleType | None = None) -> bool:
+    """Patch ``mlx_lm.models.switch_layers._gather_sort``.
+
+    Returns ``True`` when this call installs the patch, ``False`` when the
+    module is unavailable or was already patched.
+    """
+
+    if module is None:
+        try:
+            from mlx_lm.models import switch_layers as module
+        except ImportError:
+            return False
+
+    if getattr(module, "_rapid_mlx_sorted_gather_pad_installed", False):
+        return False
+
+    mx = module.mx
+    original = module._gather_sort
+
+    def _gather_sort(x, indices):
+        x, indices, inv_order = original(x, indices)
+        n = indices.size
+        if n > 32768 and n % 64 != 0:
+            pad = 64 - n % 64
+            x = mx.concatenate(
+                [x, mx.broadcast_to(x[-1:], (pad,) + x.shape[1:])], axis=0
+            )
+            indices = mx.concatenate(
+                [indices, mx.broadcast_to(indices[-1:], (pad,))], axis=0
+            )
+
+        return x, indices, inv_order
+
+    module._rapid_mlx_original_gather_sort = original
+    module._gather_sort = _gather_sort
+    module._rapid_mlx_sorted_gather_pad_installed = True
+    return True


### PR DESCRIPTION
## Summary

Installs an opt-in Rapid compatibility guard for mlx-lm's sorted MoE `gather_qmm` / `gather_mm` path. When the flattened routed-row count is greater than 32768 and not divisible by 64, the shim pads the sorted rows by duplicating the final sorted row before the affine gather runs.

## Why

This is a correctness-only guard for a quantized MoE row-alignment corruption class. The risky shape is directly relevant to Rapid's MoE model paths, and the fix is intentionally narrow: sorted, large, ragged routed-row gathers only. Aligned shapes and small shapes are unchanged.

The patch is installed from the existing `_mlx_compat.install()` hook so plain `import vllm_mlx` still avoids importing `mlx.core` / `mlx_lm` on metadata-only or non-Apple-Silicon paths.

## Validation

- [x] `python3 - <<'PY'` CPU-forced `pytest tests/test_switch_layers_gather_pad.py -q` -> 3 passed
- [x] `/Users/pierrelamy/Desktop/mlx-uag/.venv-vlm/bin/ruff check vllm_mlx/_mlx_compat.py vllm_mlx/patches/switch_layers_gather_pad.py tests/test_switch_layers_gather_pad.py`
- [x] `/Users/pierrelamy/Desktop/mlx-uag/.venv-vlm/bin/ruff format --check vllm_mlx/_mlx_compat.py vllm_mlx/patches/switch_layers_gather_pad.py tests/test_switch_layers_gather_pad.py`
- [x] `git diff --check -- vllm_mlx/_mlx_compat.py vllm_mlx/patches/switch_layers_gather_pad.py tests/test_switch_layers_gather_pad.py`

Note: a Qwen3.5-122B MLX quality-gate run was already active on the machine, so I avoided default-GPU validation and forced the focused MLX regression test onto CPU to avoid contention.
