### PR TITLE
fix: roll back MTP verify cache on early abort

### DIFF
--- a/tests/test_mtp_spec_decode.py
+++ b/tests/test_mtp_spec_decode.py
@@ -2192,6 +2192,55 @@ class _MockedQwen35Model:
         return []
 
 
+class _CountingKVCache:
+    """Tiny trimmable cache double for MTP rollback accounting tests."""
+
+    def __init__(self):
+        self.offset = 0
+        self.trim_calls: list[int] = []
+
+    def is_trimmable(self):
+        return True
+
+    def trim(self, n):
+        if n < 0:
+            raise AssertionError(f"negative trim: {n}")
+        self.trim_calls.append(n)
+        self.offset -= min(self.offset, n)
+
+
+class _CacheAdvancingQwen35Model(_MockedQwen35Model):
+    """Mock that advances supplied cache doubles on each forward."""
+
+    def __init__(self, backbone_outputs: list[int], mtp_outputs: list[int]):
+        super().__init__(backbone_outputs, mtp_outputs)
+        self.layers = [object()]
+
+    def __call__(
+        self,
+        inputs,
+        cache=None,
+        input_embeddings=None,
+        return_hidden: bool = False,
+        n_confirmed: int = 0,
+    ):
+        if cache is not None:
+            for c in cache:
+                c.offset += int(inputs.shape[1])
+        return super().__call__(
+            inputs,
+            cache=cache,
+            input_embeddings=input_embeddings,
+            return_hidden=return_hidden,
+            n_confirmed=n_confirmed,
+        )
+
+    def mtp_forward(self, hidden, next_token_ids, mtp_cache):
+        for c in mtp_cache:
+            c.offset += int(next_token_ids.shape[1])
+        return super().mtp_forward(hidden, next_token_ids, mtp_cache)
+
+
 def test_generator_emits_first_token_from_backbone_then_draft():
     """First yield comes from the backbone (``from_draft=False``); on
     accept the second yield is the MTP draft (``from_draft=True``).
@@ -2249,6 +2298,60 @@ def test_generator_emits_first_token_from_backbone_then_draft():
     assert snap.attempts == 1
     assert snap.accepts == 1
     assert snap.tokens_saved == 1
+
+
+def test_generator_rolls_back_verify_round_on_early_materialization_abort(
+    monkeypatch,
+):
+    """Abort after target verify advances caches, before accept state is fresh.
+
+    The first generator step commits the primary token and builds one MTP draft.
+    The second step runs the target verify forward over ``[primary, draft]``.
+    We then force the host sync/materialization boundary to raise. The guard
+    must keep the committed primary in the target cache while dropping the
+    uncommitted draft from both target and MTP caches.
+    """
+
+    import vllm_mlx.spec_decode.mtp.generator as generator_mod
+    from vllm_mlx.spec_decode.mtp.accept_counter import MTPAcceptCounter
+    from vllm_mlx.spec_decode.mtp.generator import mtp_generate_step
+
+    model_cache = _CountingKVCache()
+    mtp_cache = _CountingKVCache()
+    model = _CacheAdvancingQwen35Model([7, 11, 13], [11])
+    prompt = mx.array([1], dtype=mx.uint32)
+
+    gen = mtp_generate_step(
+        prompt,
+        model,
+        max_tokens=3,
+        prompt_cache=[model_cache, mtp_cache],
+        accept_counter=MTPAcceptCounter(),
+        disable_auto_k=True,
+    )
+
+    assert next(gen)[0] == 7
+    assert model_cache.offset == 1
+    # The draft is generated when the generator resumes for the next token.
+    assert mtp_cache.offset == 0
+
+    eval_calls = 0
+
+    def _boom_on_verify_sync(*_args, **_kwargs):
+        nonlocal eval_calls
+        eval_calls += 1
+        if eval_calls >= 2:
+            raise RuntimeError("sentinel materialization abort")
+
+    monkeypatch.setattr(generator_mod.mx, "eval", _boom_on_verify_sync)
+
+    with pytest.raises(RuntimeError, match="sentinel materialization abort"):
+        next(gen)
+
+    assert model_cache.offset == 2
+    assert model_cache.trim_calls[-1] == 1
+    assert mtp_cache.offset == 0
+    assert mtp_cache.trim_calls[-1] == 1
 
 
 def test_generator_rejection_path_does_not_count_as_accept():

--- a/vllm_mlx/spec_decode/mtp/generator.py
+++ b/vllm_mlx/spec_decode/mtp/generator.py
@@ -385,6 +385,17 @@ def mtp_generate_step(
             elif c.is_trimmable():
                 c.trim(n_to_drop)
 
+    def _rollback_verify_round(n_to_drop: int) -> None:
+        """Roll back uncommitted target + MTP draft state for one verify round."""
+        if n_to_drop <= 0:
+            _clear_rollback()
+            return
+
+        _rollback_draft(n_to_drop)
+        for mc in mtp_cache:
+            if mc.is_trimmable():
+                mc.trim(n_to_drop)
+
     def _step_backbone(yy, prev, n_predict=1, n_confirmed=0, xtc_draw=None):
         """Run backbone on ``yy`` and return (tokens, logprobs, accept_lps, hidden, prev)."""
         with mx.stream(generation_stream):
@@ -784,13 +795,25 @@ def mtp_generate_step(
                 bonus_tok_arr = toks[k_len]
 
             # ------- SINGLE SYNC -------
-            mx.eval(toks, accept_mask_arr, residual_toks_arr, bonus_tok_arr, u)
+            accepted_count = 0
+            try:
+                mx.eval(toks, accept_mask_arr, residual_toks_arr, bonus_tok_arr, u)
 
-            # ------- Host-side read (all values already resident) -------
-            accept_flags = accept_mask_arr.tolist()
-            residual_ids = residual_toks_arr.tolist()
-            bonus_id = int(bonus_tok_arr.item())
-            draft_ids = drafts_arr.tolist()
+                # ------- Host-side read (all values already resident) -------
+                accept_flags = accept_mask_arr.tolist()
+                residual_ids = residual_toks_arr.tolist()
+                bonus_id = int(bonus_tok_arr.item())
+                draft_ids = drafts_arr.tolist()
+            except BaseException:
+                # The target verify forward above has already appended
+                # ``[y, d_1, ..., d_K]`` to model_cache, and the prior
+                # MTP chain appended the K draft positions to mtp_cache.
+                # If a cancellation / injected fault / host materialization
+                # error fires before this round's fresh accept count is known,
+                # never let stale state leak into a fallback path: keep the
+                # committed ``y`` position and drop every uncommitted draft.
+                _rollback_verify_round(k_len - accepted_count)
+                raise
 
             # Bump attempts by K (one per draft position considered).
             for _ in range(k_len):
@@ -798,7 +821,6 @@ def mtp_generate_step(
 
             # Sequential accept-reject walk (host-only; no MLX ops).
             accepts: list[bool] = []
-            accepted_count = 0
             for i in range(k_len):
                 ok = bool(accept_flags[i])
                 accepts.append(ok)
@@ -866,22 +888,13 @@ def mtp_generate_step(
                 # (k_len - accepted_count) unaccepted drafts from the
                 # caches.
                 n_to_drop = k_len - accepted_count
-                _rollback_draft(n_to_drop)
+                _rollback_verify_round(n_to_drop)
                 accept_counter.record_reject()
                 if logits_processors and prev_tokens is not None:
                     # Discard the ``n_to_drop`` rejected positions
                     # from prev_tokens (they were appended by
                     # _step_backbone during the batched verify).
                     prev_tokens = prev_tokens[:-n_to_drop]
-
-                # Also trim mtp_cache by the same n_to_drop — those
-                # positions were appended by _step_mtp_chain and
-                # correspond to the rejected drafts. The MTP KV
-                # cache is per-layer KVCache (see qwen3_5_inject
-                # make_mtp_cache / gemma4_inject) — always trimmable.
-                for mc in mtp_cache:
-                    if mc.is_trimmable():
-                        mc.trim(n_to_drop)
 
                 verify_tok_id = int(residual_ids[accepted_count])
 


### PR DESCRIPTION
## Summary

- roll back the uncommitted target-cache draft suffix if an MTP verify round aborts during the single sync / host materialization boundary
- centralize MTP verify-round rollback so the normal reject path trims the MTP draft cache through the same helper
- add a regression test that injects a materialization fault after target verify advances caches but before fresh accept/reject state is read

## Why

The target verify forward appends `[current_token, draft_1, ..., draft_K]` to the main model cache, while the MTP drafter has already appended the K proposed draft positions to its own cache. If cancellation, an injected fault, or a host materialization error fires before the fresh accept state is safely available, the generator should keep the already-committed current token and drop every uncommitted draft position from both caches.

This is intentionally narrow: normal all-accept behavior is unchanged, and the existing reject behavior now goes through the same combined rollback helper.

## Validation

- [x] CPU-forced focused tests: `tests/test_mtp_spec_decode.py::test_generator_rolls_back_verify_round_on_early_materialization_abort`, `::test_generator_emits_first_token_from_backbone_then_draft`, `::test_generator_rejection_path_does_not_count_as_accept` — 3 passed
- [x] `ruff check vllm_mlx/spec_decode/mtp/generator.py tests/test_mtp_spec_decode.py`
- [x] `ruff format --check vllm_mlx/spec_decode/mtp/generator.py tests/test_mtp_spec_decode.py`
- [x] `git diff --check -- vllm_mlx/spec_decode/mtp/generator.py tests/test_mtp_spec_decode.py`

Full `tests/test_mtp_spec_decode.py` was attempted CPU-only in this worktree and is environment-blocked on the local system Python 3.9 / missing optional deps (`fastapi`, `mlx_lm.models.qwen3_5`), with the same broader toolchain mismatch outside this diff. Default-GPU validation was intentionally not run because a local Qwen3.5-122B quality gate is active on the machine.
