### PR TITLE
feat(evals): output-coherence release gate (#1247)

### DIFF
--- a/docs/development/releasing.md
+++ b/docs/development/releasing.md
@@ -158,6 +158,7 @@ This is the rule. No exceptions. CI doesn't fake-inference with a tiny model on 
 | G2 | Codex review × 2 rounds | local | maintainer machine | every PR-author bug class |
 | G3 | CLI ↔ Config fidelity audit | CI | `ci.yml` lint (ubuntu) | silent CLI flag drop (#400) |
 | G4 | unit suite (≈4500 tests) | CI | `ci.yml` test-matrix (linux) + test-apple-silicon (macOS-14) | parser/router regressions |
+| G0 | Output-coherence gate — deterministic golden answers (blocking) + garbage detector (advisory), run FIRST | **M3** | `make release-check-m3` + `scripts/coherence_sweep.sh` | garbage / coherent-but-wrong generation the perf/import/unit gates all miss (#1234 / #1247) |
 | G5 | `make stress` — 8 scenarios | **M3** | `make release-check-m3` | concurrent-batching regressions |
 | G6 | Live-server fix-path repro | **M3** | `make release-check-m3` | fix doesn't ship to user-visible path |
 | G7 | SDK integration (anthropic / pydantic_ai / smolagents) | **M3** | `make release-check-m3` | router-level breakage unit tests miss |
@@ -186,7 +187,15 @@ make release-check-m3              # uses MODEL=qwen3.5-9b-4bit (default)
 MODEL=qwen3.6-27b-4bit make release-check-m3   # override
 ```
 
-Wrapped by [`scripts/release_check_m3.sh`](../../scripts/release_check_m3.sh). It boots `rapid-mlx serve` once on port 8000, then runs G5 (stress) + G7 (anthropic + pydantic_ai + smolagents) + G7b (agent harness layer: a single `rapid-mlx bench <model> --tier harness` sweep across codex / opencode / hermes / aider / langchain) + G6 (parallel-tool-call cap repro) + G9 (10-seq latency) + G8b (parser microbench, M3 perf baseline) sequentially. The server is killed on exit.
+Wrapped by [`scripts/release_check_m3.sh`](../../scripts/release_check_m3.sh). It boots `rapid-mlx serve` once on port 8000, then runs **G0 (output coherence — first, so a garbage model fails fast before the rest re-test the same broken path)** + G5 (stress) + G7 (anthropic + pydantic_ai + smolagents) + G7b (agent harness layer: a single `rapid-mlx bench <model> --tier harness` sweep across codex / opencode / hermes / aider / langchain) + G6 (parallel-tool-call cap repro) + G9 (10-seq latency) + G8b (parser microbench, M3 perf baseline) sequentially. The server is killed on exit.
+
+**G0 is per-booted-model.** The single-boot gauntlet only proves coherence for the one alias it served. Because a model-specific regression (the 35B RMSNorm incident, #1234) is invisible to a 4B/9B-only run, a release or model-path change **must** additionally sweep the representative aliases it affects — one per family, plus any alias the change touches:
+
+```bash
+bash scripts/coherence_sweep.sh qwen3.5-4b-4bit qwen3.6-35b   # boots + gates each in turn
+```
+
+This is a hard release requirement, not advisory. (Making the serve-path gate *always-on in CI* rather than a local requirement needs a registered self-hosted Apple-Silicon runner — tracked in #1247. The pure predicate + garbage-detector logic is already always-on via `tests/test_coherence.py` on GitHub-hosted CI.)
 
 G7b covers the live-server harness path that `pr-validate`'s unit-level profile tests can't reach. Split in two parts so each is honestly scoped:
 

--- a/docs/development/releasing.md
+++ b/docs/development/releasing.md
@@ -154,11 +154,11 @@ This is the rule. No exceptions. CI doesn't fake-inference with a tiny model on 
 
 | # | Gate | Side | Where it runs | Catches |
 |---|---|---|---|---|
+| G0 | Output-coherence gate — deterministic golden answers (blocking) + garbage detector (advisory), run FIRST | **M3** | `make release-check-m3` + `scripts/coherence_sweep.sh` | garbage / coherent-but-wrong generation the perf/import/unit gates all miss (#1234 / #1247) |
 | G1 | Build wheel + sdist, then clean-room install + import both | CI | `release-preflight.yml` (macOS-14) | dev mlx symbol drift (#408), incomplete source distribution |
 | G2 | Codex review × 2 rounds | local | maintainer machine | every PR-author bug class |
 | G3 | CLI ↔ Config fidelity audit | CI | `ci.yml` lint (ubuntu) | silent CLI flag drop (#400) |
 | G4 | unit suite (≈4500 tests) | CI | `ci.yml` test-matrix (linux) + test-apple-silicon (macOS-14) | parser/router regressions |
-| G0 | Output-coherence gate — deterministic golden answers (blocking) + garbage detector (advisory), run FIRST | **M3** | `make release-check-m3` + `scripts/coherence_sweep.sh` | garbage / coherent-but-wrong generation the perf/import/unit gates all miss (#1234 / #1247) |
 | G5 | `make stress` — 8 scenarios | **M3** | `make release-check-m3` | concurrent-batching regressions |
 | G6 | Live-server fix-path repro | **M3** | `make release-check-m3` | fix doesn't ship to user-visible path |
 | G7 | SDK integration (anthropic / pydantic_ai / smolagents) | **M3** | `make release-check-m3` | router-level breakage unit tests miss |

--- a/evals/coherence_gate.py
+++ b/evals/coherence_gate.py
@@ -128,6 +128,8 @@ def main() -> int:
         if not passed:
             print(f"           output: {snippet!r}")
             failures.append((case.id, reason, snippet))
+        if transport_failed:
+            break
 
     print("=" * 60)
     passed_n = len(GOLDEN) - len(failures)

--- a/evals/coherence_gate.py
+++ b/evals/coherence_gate.py
@@ -108,10 +108,12 @@ def main() -> int:
         return 2
 
     failures: list[tuple[str, str, str]] = []  # (id, reason, snippet)
+    passed_n = 0
     transport_failed = False
     for case in GOLDEN:
         try:
             text = _generate(base_url, case, timeout=args.timeout)
+            passed, reason = evaluate_case(case, text)
         except httpx.TransportError as exc:
             passed, reason = False, f"server transport error: {exc}"
             transport_failed = True
@@ -119,20 +121,19 @@ def main() -> int:
         except Exception as exc:  # server/protocol error mid-run -> a gate failure
             passed, reason = False, f"request error: {exc}"
             text = ""
-        else:
-            passed, reason = evaluate_case(case, text)
 
         status = "PASS" if passed else "FAIL"
         snippet = " ".join(text.split())[:80]
         print(f"  [{status}] {case.id:<16} {reason}")
-        if not passed:
+        if passed:
+            passed_n += 1
+        else:
             print(f"           output: {snippet!r}")
             failures.append((case.id, reason, snippet))
         if transport_failed:
             break
 
     print("=" * 60)
-    passed_n = len(GOLDEN) - len(failures)
     print(f"  {passed_n}/{len(GOLDEN)} coherent")
     print("=" * 60)
 

--- a/evals/coherence_gate.py
+++ b/evals/coherence_gate.py
@@ -19,10 +19,16 @@ Usage
     # or point it explicitly:
     python evals/coherence_gate.py --base-url http://127.0.0.1:8000/v1
 
+Two tiers:
+    * BLOCKING — the deterministic golden-answer cases decide the exit code.
+    * ADVISORY — the heuristic garbage detector (:func:`looks_like_garbage`) is
+      printed as a diagnostic warning but NEVER changes the exit code, because a
+      frequency heuristic cannot reliably tell diverse token soup from prose.
+
 Exit codes:
-    0 — every golden case coherent + correct
-    1 — one or more cases failed (garbage, wrong answer, or think-leak)
-    2 — no server reachable at the base URL
+    0 — every BLOCKING golden case passed (advisory warnings may still print)
+    1 — one or more BLOCKING golden cases failed (wrong answer or think-leak)
+    2 — no server reachable at the base URL, or it became unreachable mid-run
 """
 
 from __future__ import annotations
@@ -43,7 +49,12 @@ _REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
 
-from vllm_mlx.coherence import GOLDEN, GoldenCase, evaluate_case  # noqa: E402
+from vllm_mlx.coherence import (  # noqa: E402
+    GOLDEN,
+    GoldenCase,
+    evaluate_case,
+    looks_like_garbage,
+)
 
 _DEFAULT_BASE_URL = os.environ.get("RAPID_MLX_BASE_URL", "http://127.0.0.1:8000/v1")
 
@@ -96,7 +107,7 @@ def main() -> int:
     print("=" * 60)
     print("  output-coherence gate (#1247)")
     print(f"  base_url: {base_url}")
-    print(f"  cases:    {len(GOLDEN)}")
+    print(f"  golden cases (blocking): {len(GOLDEN)}")
     print("=" * 60)
 
     if not _server_reachable(base_url):
@@ -107,7 +118,8 @@ def main() -> int:
         )
         return 2
 
-    failures: list[tuple[str, str, str]] = []  # (id, reason, snippet)
+    failures: list[tuple[str, str, str]] = []  # BLOCKING: (id, reason, snippet)
+    advisories: list[tuple[str, str, str]] = []  # ADVISORY: (id, why, snippet)
     passed_n = 0
     transport_failed = False
     for case in GOLDEN:
@@ -130,11 +142,23 @@ def main() -> int:
         else:
             print(f"           output: {snippet!r}")
             failures.append((case.id, reason, snippet))
+
         if transport_failed:
             break
 
+        # Advisory-only: surface obvious degeneracy as a diagnostic. Never
+        # affects the exit code — the heuristic can miss diverse token soup, so
+        # it must not gate (or falsely gate) a release.
+        is_garbage, why = looks_like_garbage(text)
+        if is_garbage:
+            advisories.append((case.id, why, snippet))
+
     print("=" * 60)
-    print(f"  {passed_n}/{len(GOLDEN)} coherent")
+    print(f"  BLOCKING: {passed_n}/{len(GOLDEN)} golden cases passed")
+    if advisories:
+        print(f"  ADVISORY: garbage detector flagged {len(advisories)} output(s):")
+        for cid, why, snippet in advisories:
+            print(f"    - {cid}: {why}  |  {snippet!r}")
     print("=" * 60)
 
     if transport_failed:
@@ -147,9 +171,9 @@ def main() -> int:
 
     if failures:
         print(
-            "COHERENCE GATE FAILED — the served model produced incoherent or "
-            "incorrect output. This is the class that shipped as garbage in "
-            "#1234; do NOT release.",
+            "COHERENCE GATE FAILED — the served model gave a wrong or incoherent "
+            "answer to a golden prompt. This is the class that shipped as garbage "
+            "in #1234; do NOT release.",
             file=sys.stderr,
         )
         return 1

--- a/evals/coherence_gate.py
+++ b/evals/coherence_gate.py
@@ -108,10 +108,15 @@ def main() -> int:
         return 2
 
     failures: list[tuple[str, str, str]] = []  # (id, reason, snippet)
+    transport_failed = False
     for case in GOLDEN:
         try:
             text = _generate(base_url, case, timeout=args.timeout)
-        except Exception as exc:  # network / server error mid-run -> a failure
+        except httpx.TransportError as exc:
+            passed, reason = False, f"server transport error: {exc}"
+            transport_failed = True
+            text = ""
+        except Exception as exc:  # server/protocol error mid-run -> a gate failure
             passed, reason = False, f"request error: {exc}"
             text = ""
         else:
@@ -128,6 +133,14 @@ def main() -> int:
     passed_n = len(GOLDEN) - len(failures)
     print(f"  {passed_n}/{len(GOLDEN)} coherent")
     print("=" * 60)
+
+    if transport_failed:
+        print(
+            "ERROR: the rapid-mlx server became unreachable while the "
+            "coherence gate was running.",
+            file=sys.stderr,
+        )
+        return 2
 
     if failures:
         print(

--- a/evals/coherence_gate.py
+++ b/evals/coherence_gate.py
@@ -59,6 +59,10 @@ from vllm_mlx.coherence import (  # noqa: E402
 _DEFAULT_BASE_URL = os.environ.get("RAPID_MLX_BASE_URL", "http://127.0.0.1:8000/v1")
 
 
+class InvalidServerResponseError(RuntimeError):
+    """The server replied, but not with a valid chat-completion payload."""
+
+
 def _generate(base_url: str, case: GoldenCase, *, timeout: float) -> str:
     """Non-streaming completion for ``case`` at temperature 0. Returns the
     visible assistant text (empty string if the model returned no content)."""
@@ -77,9 +81,18 @@ def _generate(base_url: str, case: GoldenCase, *, timeout: float) -> str:
         f"{base_url.rstrip('/')}/chat/completions", json=body, timeout=timeout
     )
     resp.raise_for_status()
-    data = resp.json()
-    content = data["choices"][0]["message"].get("content")
-    return content or ""
+    try:
+        data = resp.json()
+        content = data["choices"][0]["message"].get("content")
+    except (ValueError, KeyError, IndexError, TypeError, AttributeError) as exc:
+        raise InvalidServerResponseError("malformed chat-completion response") from exc
+    if content is None:
+        return ""
+    if not isinstance(content, str):
+        raise InvalidServerResponseError(
+            f"assistant content must be a string or null, got {type(content).__name__}"
+        )
+    return content
 
 
 def _server_reachable(base_url: str) -> bool:
@@ -121,21 +134,23 @@ def main() -> int:
     failures: list[tuple[str, str, str]] = []  # BLOCKING: (id, reason, snippet)
     advisories: list[tuple[str, str, str]] = []  # ADVISORY: (id, why, snippet)
     passed_n = 0
-    transport_failed = False
+    infrastructure_failed = False
     for case in GOLDEN:
         try:
             text = _generate(base_url, case, timeout=args.timeout)
             passed, reason = evaluate_case(case, text)
-        except httpx.TransportError as exc:
-            passed, reason = False, f"server transport error: {exc}"
-            transport_failed = True
+        except (httpx.HTTPError, InvalidServerResponseError) as exc:
+            passed, reason = False, f"server/protocol error: {exc}"
+            infrastructure_failed = True
             text = ""
         except Exception as exc:  # server/protocol error mid-run -> a gate failure
             passed, reason = False, f"request error: {exc}"
             text = ""
 
         status = "PASS" if passed else "FAIL"
-        snippet = " ".join(text.split())[:80]
+        snippet = (
+            " ".join(text.split())[:80] if isinstance(text, str) else repr(text)[:80]
+        )
         print(f"  [{status}] {case.id:<16} {reason}")
         if passed:
             passed_n += 1
@@ -143,15 +158,16 @@ def main() -> int:
             print(f"           output: {snippet!r}")
             failures.append((case.id, reason, snippet))
 
-        if transport_failed:
+        if infrastructure_failed:
             break
 
         # Advisory-only: surface obvious degeneracy as a diagnostic. Never
         # affects the exit code — the heuristic can miss diverse token soup, so
         # it must not gate (or falsely gate) a release.
-        is_garbage, why = looks_like_garbage(text)
-        if is_garbage:
-            advisories.append((case.id, why, snippet))
+        if isinstance(text, str):
+            is_garbage, why = looks_like_garbage(text)
+            if is_garbage:
+                advisories.append((case.id, why, snippet))
 
     print("=" * 60)
     print(f"  BLOCKING: {passed_n}/{len(GOLDEN)} golden cases passed")
@@ -161,10 +177,10 @@ def main() -> int:
             print(f"    - {cid}: {why}  |  {snippet!r}")
     print("=" * 60)
 
-    if transport_failed:
+    if infrastructure_failed:
         print(
-            "ERROR: the rapid-mlx server became unreachable while the "
-            "coherence gate was running.",
+            "ERROR: the rapid-mlx server became unreachable or returned an "
+            "invalid response while the coherence gate was running.",
             file=sys.stderr,
         )
         return 2

--- a/evals/coherence_gate.py
+++ b/evals/coherence_gate.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Output-coherence release gate — feeds golden prompts through a REAL running
+``rapid-mlx serve`` and asserts the generated text is coherent (#1247).
+
+This is the serve-path half of the coherence gate; the pure predicates and the
+garbage detector live in :mod:`vllm_mlx.coherence` and are unit-tested in
+ordinary CI. This script requires a server to already be listening (it does
+**not** boot one) — mirroring ``evals/run_eval.py`` and
+``tests/integrations/test_anthropic_sdk.py``. The release gauntlet
+(``scripts/release_check_m3.sh``) boots ``rapid-mlx serve <model> --no-thinking``
+and exports ``RAPID_MLX_BASE_URL``; this gate reads that env by default.
+
+Usage
+-----
+    # against the server the release gauntlet already booted:
+    python evals/coherence_gate.py
+
+    # or point it explicitly:
+    python evals/coherence_gate.py --base-url http://127.0.0.1:8000/v1
+
+Exit codes:
+    0 — every golden case coherent + correct
+    1 — one or more cases failed (garbage, wrong answer, or think-leak)
+    2 — no server reachable at the base URL
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+import httpx
+
+# Make ``vllm_mlx`` importable when run as ``python evals/coherence_gate.py``
+# from a bare checkout (sys.path[0] is evals/, not the repo root). Harmless when
+# rapid-mlx is already installed — an editable/site-packages copy still resolves
+# first only if this insert is skipped, but preferring the checkout is correct
+# for a gate that must test THIS tree.
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from vllm_mlx.coherence import GOLDEN, GoldenCase, evaluate_case  # noqa: E402
+
+_DEFAULT_BASE_URL = os.environ.get("RAPID_MLX_BASE_URL", "http://127.0.0.1:8000/v1")
+
+
+def _generate(base_url: str, case: GoldenCase, *, timeout: float) -> str:
+    """Non-streaming completion for ``case`` at temperature 0. Returns the
+    visible assistant text (empty string if the model returned no content)."""
+    body = {
+        "model": "default",
+        "messages": [{"role": "user", "content": case.prompt}],
+        "max_tokens": case.max_tokens,
+        "temperature": 0.0,
+        "stream": False,
+        # Match the gauntlet's --no-thinking boot: the gate measures answer
+        # coherence, not thinking-mode behavior. The no-think-leak case still
+        # asserts no raw <think> tag survives into the visible message.
+        "enable_thinking": False,
+    }
+    resp = httpx.post(
+        f"{base_url.rstrip('/')}/chat/completions", json=body, timeout=timeout
+    )
+    resp.raise_for_status()
+    data = resp.json()
+    content = data["choices"][0]["message"].get("content")
+    return content or ""
+
+
+def _server_reachable(base_url: str) -> bool:
+    try:
+        r = httpx.get(f"{base_url.rstrip('/')}/models", timeout=5.0)
+        return r.status_code == 200
+    except Exception:
+        return False
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--base-url",
+        default=_DEFAULT_BASE_URL,
+        help="OpenAI-compatible base URL (default: $RAPID_MLX_BASE_URL or "
+        "http://127.0.0.1:8000/v1)",
+    )
+    ap.add_argument(
+        "--timeout", type=float, default=120.0, help="per-request timeout (s)"
+    )
+    args = ap.parse_args()
+
+    base_url = args.base_url
+    print("=" * 60)
+    print("  output-coherence gate (#1247)")
+    print(f"  base_url: {base_url}")
+    print(f"  cases:    {len(GOLDEN)}")
+    print("=" * 60)
+
+    if not _server_reachable(base_url):
+        print(
+            f"ERROR: no rapid-mlx server reachable at {base_url}. "
+            "Start one with: rapid-mlx serve <model> --port 8000",
+            file=sys.stderr,
+        )
+        return 2
+
+    failures: list[tuple[str, str, str]] = []  # (id, reason, snippet)
+    for case in GOLDEN:
+        try:
+            text = _generate(base_url, case, timeout=args.timeout)
+        except Exception as exc:  # network / server error mid-run -> a failure
+            passed, reason = False, f"request error: {exc}"
+            text = ""
+        else:
+            passed, reason = evaluate_case(case, text)
+
+        status = "PASS" if passed else "FAIL"
+        snippet = " ".join(text.split())[:80]
+        print(f"  [{status}] {case.id:<16} {reason}")
+        if not passed:
+            print(f"           output: {snippet!r}")
+            failures.append((case.id, reason, snippet))
+
+    print("=" * 60)
+    passed_n = len(GOLDEN) - len(failures)
+    print(f"  {passed_n}/{len(GOLDEN)} coherent")
+    print("=" * 60)
+
+    if failures:
+        print(
+            "COHERENCE GATE FAILED — the served model produced incoherent or "
+            "incorrect output. This is the class that shipped as garbage in "
+            "#1234; do NOT release.",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/coherence_sweep.sh
+++ b/scripts/coherence_sweep.sh
@@ -40,7 +40,15 @@ cleanup() {
   fi
   rm -rf "$WORK_DIR"
 }
-trap cleanup EXIT INT TERM
+handle_signal() {
+  signal_status=$1
+  trap - EXIT
+  cleanup
+  exit "$signal_status"
+}
+trap cleanup EXIT
+trap 'handle_signal 130' INT
+trap 'handle_signal 143' TERM
 
 if lsof -i ":$PORT" >/dev/null 2>&1; then
   echo "ERROR: port $PORT already in use — pick another with PORT=... or free it." >&2

--- a/scripts/coherence_sweep.sh
+++ b/scripts/coherence_sweep.sh
@@ -26,22 +26,26 @@ set -euo pipefail
 PY="${PY:-python3.12}"
 PORT="${PORT:-8402}"
 MODELS="${*:-${MODELS:-qwen3.5-4b-4bit}}"
-LOG=/tmp/coherence-sweep.log
-PIDFILE=/tmp/coherence-sweep.pid
+WORK_DIR="$(mktemp -d "${TMPDIR:-/tmp}/rapid-mlx-coherence-sweep.XXXXXX")"
+LOG="$WORK_DIR/server.log"
+PIDFILE="$WORK_DIR/server.pid"
 
 line() { printf '%s\n' "============================================================"; }
+
+CURRENT_PID=""
+cleanup() {
+  if [ -n "$CURRENT_PID" ]; then
+    kill "$CURRENT_PID" 2>/dev/null || true
+    wait "$CURRENT_PID" 2>/dev/null || true
+  fi
+  rm -rf "$WORK_DIR"
+}
+trap cleanup EXIT INT TERM
 
 if lsof -i ":$PORT" >/dev/null 2>&1; then
   echo "ERROR: port $PORT already in use — pick another with PORT=... or free it." >&2
   exit 2
 fi
-
-CURRENT_PID=""
-cleanup() {
-  if [ -n "$CURRENT_PID" ]; then kill "$CURRENT_PID" 2>/dev/null || true; fi
-  if [ -f "$PIDFILE" ]; then kill "$(cat "$PIDFILE")" 2>/dev/null || true; rm -f "$PIDFILE"; fi
-}
-trap cleanup EXIT INT TERM
 
 export RAPID_MLX_BASE_URL="http://127.0.0.1:${PORT}/v1"
 
@@ -52,6 +56,7 @@ echo "  port:   $PORT"
 line
 
 failed=""
+infra_failed=""
 for MODEL in $MODELS; do
   line
   echo "  → $MODEL"
@@ -71,13 +76,19 @@ for MODEL in $MODELS; do
   if [ "$up" != 1 ]; then
     echo "ERROR: $MODEL server did not come up. Last log lines:" >&2
     tail -20 "$LOG" >&2
-    failed="$failed $MODEL(boot)"
+    infra_failed="$infra_failed $MODEL(boot)"
   else
     if "$PY" evals/coherence_gate.py; then
       echo "  ✓ $MODEL coherent"
     else
-      echo "  ✗ $MODEL FAILED coherence gate" >&2
-      failed="$failed $MODEL"
+      gate_status=$?
+      if [ "$gate_status" -eq 2 ]; then
+        echo "  ✗ $MODEL coherence gate infrastructure failure" >&2
+        infra_failed="$infra_failed $MODEL(gate-infra)"
+      else
+        echo "  ✗ $MODEL FAILED coherence gate" >&2
+        failed="$failed $MODEL"
+      fi
     fi
   fi
 
@@ -88,6 +99,12 @@ for MODEL in $MODELS; do
 done
 
 line
+if [ -n "$infra_failed" ]; then
+  echo "  SWEEP INFRASTRUCTURE FAILURE —$infra_failed"
+  if [ -n "$failed" ]; then echo "  MODEL FAILURES —$failed"; fi
+  line
+  exit 2
+fi
 if [ -n "$failed" ]; then
   echo "  SWEEP FAILED —$failed"
   line

--- a/scripts/coherence_sweep.sh
+++ b/scripts/coherence_sweep.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# Output-coherence sweep (#1247) — run the deterministic golden gate against a
+# SET of representative aliases, one at a time. A model-specific regression (the
+# 35B RMSNorm incident, #1234) does NOT surface if the release check only runs
+# the default 4B/9B alias, so a release / model-path change must sweep the
+# aliases it affects — one representative per family, plus any alias the change
+# touches.
+#
+# Each alias is booted on a dedicated port with --no-thinking, run through
+# evals/coherence_gate.py (blocking golden answers), then torn down before the
+# next. Any alias that fails its blocking golden gate fails the whole sweep.
+#
+# Usage:
+#   bash scripts/coherence_sweep.sh qwen3.5-4b-4bit qwen3.6-35b
+#   MODELS="qwen3.5-4b-4bit qwen3.6-35b" bash scripts/coherence_sweep.sh
+#
+# Exit codes:
+#   0 — every alias passed its blocking golden gate
+#   1 — at least one alias failed
+#   2 — pre-flight refusal (port busy) or a server that never came up
+
+set -euo pipefail
+
+PY="${PY:-python3.12}"
+PORT="${PORT:-8402}"
+MODELS="${*:-${MODELS:-qwen3.5-4b-4bit}}"
+LOG=/tmp/coherence-sweep.log
+PIDFILE=/tmp/coherence-sweep.pid
+
+line() { printf '%s\n' "============================================================"; }
+
+if lsof -i ":$PORT" >/dev/null 2>&1; then
+  echo "ERROR: port $PORT already in use — pick another with PORT=... or free it." >&2
+  exit 2
+fi
+
+CURRENT_PID=""
+cleanup() {
+  if [ -n "$CURRENT_PID" ]; then kill "$CURRENT_PID" 2>/dev/null || true; fi
+  if [ -f "$PIDFILE" ]; then kill "$(cat "$PIDFILE")" 2>/dev/null || true; rm -f "$PIDFILE"; fi
+}
+trap cleanup EXIT INT TERM
+
+export RAPID_MLX_BASE_URL="http://127.0.0.1:${PORT}/v1"
+
+line
+echo "  output-coherence sweep"
+echo "  models: $MODELS"
+echo "  port:   $PORT"
+line
+
+failed=""
+for MODEL in $MODELS; do
+  line
+  echo "  → $MODEL"
+  line
+
+  "$PY" -m vllm_mlx.cli serve "$MODEL" --port "$PORT" --no-thinking > "$LOG" 2>&1 &
+  CURRENT_PID=$!
+  echo "$CURRENT_PID" > "$PIDFILE"
+
+  up=0
+  for _ in $(seq 1 180); do
+    if curl -sf "http://127.0.0.1:$PORT/v1/models" >/dev/null 2>&1; then up=1; break; fi
+    # Bail early if the server process died during load.
+    if ! kill -0 "$CURRENT_PID" 2>/dev/null; then break; fi
+    sleep 1
+  done
+  if [ "$up" != 1 ]; then
+    echo "ERROR: $MODEL server did not come up. Last log lines:" >&2
+    tail -20 "$LOG" >&2
+    failed="$failed $MODEL(boot)"
+  else
+    if "$PY" evals/coherence_gate.py; then
+      echo "  ✓ $MODEL coherent"
+    else
+      echo "  ✗ $MODEL FAILED coherence gate" >&2
+      failed="$failed $MODEL"
+    fi
+  fi
+
+  kill "$CURRENT_PID" 2>/dev/null || true
+  wait "$CURRENT_PID" 2>/dev/null || true
+  CURRENT_PID=""
+  rm -f "$PIDFILE"
+done
+
+line
+if [ -n "$failed" ]; then
+  echo "  SWEEP FAILED —$failed"
+  line
+  exit 1
+fi
+echo "  SWEEP PASSED — all aliases coherent"
+line

--- a/scripts/release_check_m3.sh
+++ b/scripts/release_check_m3.sh
@@ -103,6 +103,18 @@ if ! curl -sf "http://127.0.0.1:$PORT/v1/models" >/dev/null 2>&1; then
   exit 2
 fi
 
+#-------------------- G4 output coherence -------------------------
+# The most fundamental gate: does the served model produce coherent,
+# correct text at all? Qwen3.6/3.5-35B shipped garbage from the first
+# token (#1234) and passed every perf / import / unit gate because
+# nothing checked generation coherence (#1247). Run this FIRST — if it
+# fails, the stress / SDK gates below would just re-test the same broken
+# inference path. Reads RAPID_MLX_BASE_URL (exported above).
+line
+echo "  G4 — output coherence gate (golden answers + garbage detector)"
+line
+"$PY" evals/coherence_gate.py
+
 #-------------------- G5 stress -----------------------------------
 line
 echo "  G5 — make stress (8 scenarios incl. tool storm)"

--- a/scripts/release_check_m3.sh
+++ b/scripts/release_check_m3.sh
@@ -103,15 +103,21 @@ if ! curl -sf "http://127.0.0.1:$PORT/v1/models" >/dev/null 2>&1; then
   exit 2
 fi
 
-#-------------------- G4 output coherence -------------------------
+#-------------------- G0 output coherence -------------------------
 # The most fundamental gate: does the served model produce coherent,
 # correct text at all? Qwen3.6/3.5-35B shipped garbage from the first
 # token (#1234) and passed every perf / import / unit gate because
 # nothing checked generation coherence (#1247). Run this FIRST — if it
 # fails, the stress / SDK gates below would just re-test the same broken
-# inference path. Reads RAPID_MLX_BASE_URL (exported above).
+# inference path. Blocking = deterministic golden answers; the garbage
+# detector is advisory-only. Reads RAPID_MLX_BASE_URL (exported above).
+#
+# This checks the ONE model the gauntlet booted. A release / model-path
+# change must ALSO sweep the representative aliases it affects (a 35B-
+# specific regression is invisible to a 4B/9B-only run) — see
+# scripts/coherence_sweep.sh and docs/development/releasing.md.
 line
-echo "  G4 — output coherence gate (golden answers + garbage detector)"
+echo "  G0 — output coherence gate (blocking golden answers)"
 line
 "$PY" evals/coherence_gate.py
 

--- a/tests/test_coherence.py
+++ b/tests/test_coherence.py
@@ -56,6 +56,7 @@ GARBAGE = [
     "the the the the the the the the the the the the the",  # bigram loop
     "cat cat cat cat cat cat cat cat cat cat cat cat",  # word loop
     "Sure! " + "!" * 40,  # long single-char run embedded in otherwise-ok text
+    "11111111111111111111",  # long numeric single-token collapse
 ]
 
 
@@ -120,10 +121,11 @@ def test_not_garbage_case_is_open_ended() -> None:
     case = next(c for c in GOLDEN if c.id == "open-ocean")
     assert case.kind == "two_sentence"
     assert evaluate_case(
-        case, "The ocean is deep and full of life. It covers most of Earth."
+        case, "The ocean is deep and full of life. Its water covers most of Earth."
     )[0]
     assert not evaluate_case(case, "ocean ocean ocean ocean ocean ocean ocean ocean")[0]
     assert not evaluate_case(case, "foo bar baz qux. foo bar baz qux.")[0]
+    assert not evaluate_case(case, "qzxv blorp fnarg glip. wug zibble plonk traz.")[0]
     assert not evaluate_case(case, "x")[0]
     assert not evaluate_case(case, "asdfghjkl")[0]
 
@@ -161,6 +163,6 @@ def test_golden_set_is_wellformed() -> None:
         assert c.kind in valid_kinds, f"{c.id}: bad kind {c.kind!r}"
         assert c.id not in ids, f"duplicate case id {c.id!r}"
         ids.add(c.id)
-        if c.kind in {"exact", "no_think_leak"}:
+        if c.kind in {"exact", "two_sentence", "no_think_leak"}:
             assert c.expect, f"{c.id}: {c.kind} needs a non-empty expect"
         assert c.max_tokens > 0

--- a/tests/test_coherence.py
+++ b/tests/test_coherence.py
@@ -34,6 +34,7 @@ COHERENT = [
     "42",
     "10000",
     "100000",
+    "Alabama",
     "9",
     "Yes",
     "No",
@@ -137,6 +138,17 @@ def test_gate_returns_infrastructure_code_for_midrun_transport_failure(
     monkeypatch.setattr(coherence_gate, "_generate", fail_transport)
     monkeypatch.setattr(sys, "argv", ["coherence_gate.py"])
     assert coherence_gate.main() == 2
+
+
+def test_gate_turns_invalid_response_content_into_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(coherence_gate, "_server_reachable", lambda _url: True)
+    monkeypatch.setattr(
+        coherence_gate, "_generate", lambda *_args, **_kwargs: ["not", "text"]
+    )
+    monkeypatch.setattr(sys, "argv", ["coherence_gate.py"])
+    assert coherence_gate.main() == 1
 
 
 def test_golden_set_is_wellformed() -> None:

--- a/tests/test_coherence.py
+++ b/tests/test_coherence.py
@@ -13,8 +13,12 @@ Acceptance for #1247 is "test the gate": the exact class that shipped in #1234
 
 from __future__ import annotations
 
+import sys
+
+import httpx
 import pytest
 
+from evals import coherence_gate
 from vllm_mlx.coherence import GOLDEN, GoldenCase, evaluate_case, looks_like_garbage
 
 # ── real, coherent outputs that must NOT be flagged as garbage ──────────────
@@ -111,15 +115,31 @@ def test_no_think_leak_case_rejects_raw_reasoning_tag() -> None:
 
 def test_not_garbage_case_is_open_ended() -> None:
     case = next(c for c in GOLDEN if c.id == "open-ocean")
-    assert case.kind == "not_garbage"
-    # Any coherent prose passes; degenerate output fails.
-    assert evaluate_case(case, "The ocean is deep and full of life. It is blue.")[0]
+    assert case.kind == "two_sentence"
+    assert evaluate_case(
+        case, "The ocean is deep and full of life. It covers most of Earth."
+    )[0]
     assert not evaluate_case(case, "ocean ocean ocean ocean ocean ocean ocean ocean")[0]
+    assert not evaluate_case(case, "x")[0]
+    assert not evaluate_case(case, "asdfghjkl")[0]
+
+
+def test_gate_returns_infrastructure_code_for_midrun_transport_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(coherence_gate, "_server_reachable", lambda _url: True)
+
+    def fail_transport(*_args: object, **_kwargs: object) -> str:
+        raise httpx.ConnectError("server stopped")
+
+    monkeypatch.setattr(coherence_gate, "_generate", fail_transport)
+    monkeypatch.setattr(sys, "argv", ["coherence_gate.py"])
+    assert coherence_gate.main() == 2
 
 
 def test_golden_set_is_wellformed() -> None:
     assert len(GOLDEN) >= 5
-    valid_kinds = {"exact", "not_garbage", "no_think_leak"}
+    valid_kinds = {"exact", "two_sentence", "no_think_leak"}
     ids = set()
     for c in GOLDEN:
         assert isinstance(c, GoldenCase)

--- a/tests/test_coherence.py
+++ b/tests/test_coherence.py
@@ -123,6 +123,7 @@ def test_not_garbage_case_is_open_ended() -> None:
         case, "The ocean is deep and full of life. It covers most of Earth."
     )[0]
     assert not evaluate_case(case, "ocean ocean ocean ocean ocean ocean ocean ocean")[0]
+    assert not evaluate_case(case, "foo bar baz qux. foo bar baz qux.")[0]
     assert not evaluate_case(case, "x")[0]
     assert not evaluate_case(case, "asdfghjkl")[0]
 

--- a/tests/test_coherence.py
+++ b/tests/test_coherence.py
@@ -158,6 +158,19 @@ def test_gate_turns_invalid_response_content_into_failure(
     assert coherence_gate.main() == 1
 
 
+def test_gate_returns_infrastructure_code_for_invalid_server_response(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(coherence_gate, "_server_reachable", lambda _url: True)
+
+    def fail_protocol(*_args: object, **_kwargs: object) -> str:
+        raise coherence_gate.InvalidServerResponseError("malformed response")
+
+    monkeypatch.setattr(coherence_gate, "_generate", fail_protocol)
+    monkeypatch.setattr(sys, "argv", ["coherence_gate.py"])
+    assert coherence_gate.main() == 2
+
+
 def test_golden_set_is_all_deterministic_blocking() -> None:
     """Every golden case must be a deterministic, exact-answer predicate — no
     heuristic / open-ended cases in the blocking set (review convergence)."""

--- a/tests/test_coherence.py
+++ b/tests/test_coherence.py
@@ -32,6 +32,8 @@ COHERENT = [
     # token answer must never be judged garbage.
     "7",
     "42",
+    "10000",
+    "100000",
     "9",
     "Yes",
     "No",

--- a/tests/test_coherence.py
+++ b/tests/test_coherence.py
@@ -88,11 +88,28 @@ def test_evaluate_case_rejects_coherent_but_wrong() -> None:
 
 
 def test_evaluate_case_rejects_garbage_for_golden_prompt() -> None:
-    """The exact #1234 failure: the model emits garbage for a golden prompt."""
+    """The exact #1234 failure: the model emits garbage for a golden prompt. The
+    BLOCKING layer rejects it deterministically — it is simply not an exact
+    match for the expected token — with NO reliance on the heuristic garbage
+    detector (which is advisory-only)."""
     case = next(c for c in GOLDEN if c.id == "arithmetic")
     passed, reason = evaluate_case(case, "!!!!!!!!!!!!!!!!!!!!")
     assert not passed
-    assert "garbage" in reason
+    assert "exact match" in reason
+
+
+def test_blocking_layer_catches_what_the_detector_cannot() -> None:
+    """The review's core point: a frequency heuristic cannot separate diverse
+    token soup from prose, so the advisory detector FALSE-GREENS on it — but the
+    deterministic golden check rejects it anyway (not an exact match). This is
+    exactly why the golden answers are the blocking layer and the detector is
+    advisory-only."""
+    token_soup = "Ocean qzxv blorp fnarg glip. Water wug zibble plonk traz."
+    # The advisory detector honestly cannot tell this from prose:
+    assert looks_like_garbage(token_soup)[0] is False
+    # But the blocking golden check rejects it — not an exact "Tokyo":
+    case = next(c for c in GOLDEN if c.id == "capital-japan")
+    assert not evaluate_case(case, token_soup)[0]
 
 
 def test_evaluate_case_arithmetic_wrong_number_fails() -> None:
@@ -115,19 +132,6 @@ def test_no_think_leak_case_rejects_raw_reasoning_tag() -> None:
     assert "think" in reason.lower() or "reasoning" in reason.lower()
     # Clean answer passes.
     assert evaluate_case(case, "Paris")[0]
-
-
-def test_not_garbage_case_is_open_ended() -> None:
-    case = next(c for c in GOLDEN if c.id == "open-ocean")
-    assert case.kind == "two_sentence"
-    assert evaluate_case(
-        case, "The ocean is deep and full of life. Its water covers most of Earth."
-    )[0]
-    assert not evaluate_case(case, "ocean ocean ocean ocean ocean ocean ocean ocean")[0]
-    assert not evaluate_case(case, "foo bar baz qux. foo bar baz qux.")[0]
-    assert not evaluate_case(case, "qzxv blorp fnarg glip. wug zibble plonk traz.")[0]
-    assert not evaluate_case(case, "x")[0]
-    assert not evaluate_case(case, "asdfghjkl")[0]
 
 
 def test_gate_returns_infrastructure_code_for_midrun_transport_failure(
@@ -154,15 +158,16 @@ def test_gate_turns_invalid_response_content_into_failure(
     assert coherence_gate.main() == 1
 
 
-def test_golden_set_is_wellformed() -> None:
+def test_golden_set_is_all_deterministic_blocking() -> None:
+    """Every golden case must be a deterministic, exact-answer predicate — no
+    heuristic / open-ended cases in the blocking set (review convergence)."""
     assert len(GOLDEN) >= 5
-    valid_kinds = {"exact", "two_sentence", "no_think_leak"}
+    valid_kinds = {"exact", "no_think_leak"}  # deterministic only
     ids = set()
     for c in GOLDEN:
         assert isinstance(c, GoldenCase)
-        assert c.kind in valid_kinds, f"{c.id}: bad kind {c.kind!r}"
+        assert c.kind in valid_kinds, f"{c.id}: non-deterministic kind {c.kind!r}"
         assert c.id not in ids, f"duplicate case id {c.id!r}"
         ids.add(c.id)
-        if c.kind in {"exact", "two_sentence", "no_think_leak"}:
-            assert c.expect, f"{c.id}: {c.kind} needs a non-empty expect"
+        assert c.expect, f"{c.id}: a deterministic case needs a non-empty expect"
         assert c.max_tokens > 0

--- a/tests/test_coherence.py
+++ b/tests/test_coherence.py
@@ -66,7 +66,7 @@ def test_garbage_text_flagged(text: str) -> None:
 
 def test_evaluate_case_accepts_correct_answer() -> None:
     case = next(c for c in GOLDEN if c.id == "capital-japan")
-    passed, _ = evaluate_case(case, "The capital of Japan is Tokyo.")
+    passed, _ = evaluate_case(case, "**Tokyo.**")
     assert passed
 
 
@@ -74,9 +74,9 @@ def test_evaluate_case_rejects_coherent_but_wrong() -> None:
     """A fluent, non-garbage, but WRONG answer must fail — this is the class no
     perf/import gate catches."""
     case = next(c for c in GOLDEN if c.id == "capital-japan")
-    passed, reason = evaluate_case(case, "The capital of Japan is Osaka.")
+    passed, reason = evaluate_case(case, "Tokyo is incorrect; Osaka is the capital.")
     assert not passed
-    assert "missing" in reason
+    assert "exact match" in reason
 
 
 def test_evaluate_case_rejects_garbage_for_golden_prompt() -> None:
@@ -89,8 +89,13 @@ def test_evaluate_case_rejects_garbage_for_golden_prompt() -> None:
 
 def test_evaluate_case_arithmetic_wrong_number_fails() -> None:
     case = next(c for c in GOLDEN if c.id == "arithmetic")
-    assert evaluate_case(case, "17 times 23 is 391.")[0]
-    assert not evaluate_case(case, "17 times 23 is 400.")[0]
+    assert evaluate_case(case, "391.")[0]
+    assert not evaluate_case(case, "1391")[0]
+
+
+def test_evaluate_case_days_rejects_number_containing_answer() -> None:
+    case = next(c for c in GOLDEN if c.id == "days-in-week")
+    assert not evaluate_case(case, "17")[0]
 
 
 def test_no_think_leak_case_rejects_raw_reasoning_tag() -> None:
@@ -114,13 +119,13 @@ def test_not_garbage_case_is_open_ended() -> None:
 
 def test_golden_set_is_wellformed() -> None:
     assert len(GOLDEN) >= 5
-    valid_kinds = {"contains", "contains_all", "not_garbage", "no_think_leak"}
+    valid_kinds = {"exact", "not_garbage", "no_think_leak"}
     ids = set()
     for c in GOLDEN:
         assert isinstance(c, GoldenCase)
         assert c.kind in valid_kinds, f"{c.id}: bad kind {c.kind!r}"
         assert c.id not in ids, f"duplicate case id {c.id!r}"
         ids.add(c.id)
-        if c.kind in {"contains", "contains_all", "no_think_leak"}:
+        if c.kind in {"exact", "no_think_leak"}:
             assert c.expect, f"{c.id}: {c.kind} needs a non-empty expect"
         assert c.max_tokens > 0

--- a/tests/test_coherence.py
+++ b/tests/test_coherence.py
@@ -1,0 +1,126 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Always-on unit tests for the output-coherence primitives (#1247).
+
+These are pure — no server, no MLX — so they run on every PR on a GitHub-hosted
+runner and lock in the *gate logic itself*: that known garbage is flagged, that
+real prose is not, and that a coherent-but-wrong answer fails its golden case.
+The serve-path half (``evals/coherence_gate.py``) runs on the Apple-Silicon
+release gauntlet where a real model is served.
+
+Acceptance for #1247 is "test the gate": the exact class that shipped in #1234
+(garbage output) and a coherent-but-wrong regression must both be rejected here.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from vllm_mlx.coherence import GOLDEN, GoldenCase, evaluate_case, looks_like_garbage
+
+# ── real, coherent outputs that must NOT be flagged as garbage ──────────────
+COHERENT = [
+    "The capital of Japan is Tokyo.",
+    "391",
+    "Tokyo",
+    "banana",
+    # Short legitimate answers — regression guard for the dogfood false
+    # positive where "7" tripped char-dominance (1/1 > 0.5). A valid single-
+    # token answer must never be judged garbage.
+    "7",
+    "42",
+    "9",
+    "Yes",
+    "No",
+    "OK",
+    "The ocean is a vast body of saltwater that covers most of Earth's "
+    "surface. It teems with life, from microscopic plankton to enormous whales.",
+    "A CPU executes instructions: it fetches, decodes, and runs the operations "
+    "that make up a program, coordinating the rest of the computer.",
+    "Yes — pedestrians are visible walking along the sidewalk on the left.",
+]
+
+# ── shipped / plausible garbage that MUST be flagged ────────────────────────
+GARBAGE = [
+    "",
+    "   ",
+    "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!",  # prefix-cache poison (#gotchas)
+    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",  # doubled-norm degenerate single token
+    "。。。。。。。。。。。。。。。。。。。。。。",  # CJK fill
+    "the the the the the the the the the the the the the",  # bigram loop
+    "cat cat cat cat cat cat cat cat cat cat cat cat",  # word loop
+    "Sure! " + "!" * 40,  # long single-char run embedded in otherwise-ok text
+]
+
+
+@pytest.mark.parametrize("text", COHERENT)
+def test_coherent_text_not_flagged(text: str) -> None:
+    is_garbage, reason = looks_like_garbage(text)
+    assert not is_garbage, f"false positive on {text[:50]!r}: {reason}"
+
+
+@pytest.mark.parametrize("text", GARBAGE)
+def test_garbage_text_flagged(text: str) -> None:
+    is_garbage, _ = looks_like_garbage(text)
+    assert is_garbage, f"missed garbage: {text[:50]!r}"
+
+
+def test_evaluate_case_accepts_correct_answer() -> None:
+    case = next(c for c in GOLDEN if c.id == "capital-japan")
+    passed, _ = evaluate_case(case, "The capital of Japan is Tokyo.")
+    assert passed
+
+
+def test_evaluate_case_rejects_coherent_but_wrong() -> None:
+    """A fluent, non-garbage, but WRONG answer must fail — this is the class no
+    perf/import gate catches."""
+    case = next(c for c in GOLDEN if c.id == "capital-japan")
+    passed, reason = evaluate_case(case, "The capital of Japan is Osaka.")
+    assert not passed
+    assert "missing" in reason
+
+
+def test_evaluate_case_rejects_garbage_for_golden_prompt() -> None:
+    """The exact #1234 failure: the model emits garbage for a golden prompt."""
+    case = next(c for c in GOLDEN if c.id == "arithmetic")
+    passed, reason = evaluate_case(case, "!!!!!!!!!!!!!!!!!!!!")
+    assert not passed
+    assert "garbage" in reason
+
+
+def test_evaluate_case_arithmetic_wrong_number_fails() -> None:
+    case = next(c for c in GOLDEN if c.id == "arithmetic")
+    assert evaluate_case(case, "17 times 23 is 391.")[0]
+    assert not evaluate_case(case, "17 times 23 is 400.")[0]
+
+
+def test_no_think_leak_case_rejects_raw_reasoning_tag() -> None:
+    case = next(c for c in GOLDEN if c.id == "no-think-leak")
+    # Correct answer but raw reasoning markers leaked into the visible output.
+    leaked = "<think>France's capital is Paris</think> Paris"
+    passed, reason = evaluate_case(case, leaked)
+    assert not passed
+    assert "think" in reason.lower() or "reasoning" in reason.lower()
+    # Clean answer passes.
+    assert evaluate_case(case, "Paris")[0]
+
+
+def test_not_garbage_case_is_open_ended() -> None:
+    case = next(c for c in GOLDEN if c.id == "open-ocean")
+    assert case.kind == "not_garbage"
+    # Any coherent prose passes; degenerate output fails.
+    assert evaluate_case(case, "The ocean is deep and full of life. It is blue.")[0]
+    assert not evaluate_case(case, "ocean ocean ocean ocean ocean ocean ocean ocean")[0]
+
+
+def test_golden_set_is_wellformed() -> None:
+    assert len(GOLDEN) >= 5
+    valid_kinds = {"contains", "contains_all", "not_garbage", "no_think_leak"}
+    ids = set()
+    for c in GOLDEN:
+        assert isinstance(c, GoldenCase)
+        assert c.kind in valid_kinds, f"{c.id}: bad kind {c.kind!r}"
+        assert c.id not in ids, f"duplicate case id {c.id!r}"
+        ids.add(c.id)
+        if c.kind in {"contains", "contains_all", "no_think_leak"}:
+            assert c.expect, f"{c.id}: {c.kind} needs a non-empty expect"
+        assert c.max_tokens > 0

--- a/vllm_mlx/coherence.py
+++ b/vllm_mlx/coherence.py
@@ -237,10 +237,17 @@ def evaluate_case(case: GoldenCase, text: str) -> tuple[bool, str]:
     if case.kind == "two_sentence":
         words = _WORD_RE.findall(text)
         sentence_ends = re.findall(r"[.!?。！？](?:\s|$)", text)
+        sentences = [
+            sentence.strip().casefold()
+            for sentence in re.split(r"[.!?。！？]+", text)
+            if sentence.strip()
+        ]
         if len(words) < 8:
             return False, f"too short ({len(words)} words; expected at least 8)"
         if len(sentence_ends) < 2:
             return False, "expected at least two complete sentences"
+        if len(set(sentences)) < 2:
+            return False, "repeated the same sentence"
         return True, "coherent two-sentence response"
 
     if case.kind == "exact":

--- a/vllm_mlx/coherence.py
+++ b/vllm_mlx/coherence.py
@@ -6,23 +6,27 @@ Motivation (#1247). Qwen3.6-35B-A3B and Qwen3.5-35B-A3B-8bit shipped producing
 ``+1.0`` norm-shift misfire; fixed in #1234). The garbage passed *every*
 automated gate — 278 delta tests, lint, install/import smoke, perf thresholds —
 because **no gate ever generates a token and checks whether the output is
-coherent**. This module supplies the two pieces that close that hole:
+coherent**. This module supplies two pieces with deliberately different roles:
 
-  * :func:`looks_like_garbage` — a cheap, deterministic detector for the two
-    collapse classes we have actually shipped (``!!!!!!`` prefix-cache poison
-    and doubled-norm token soup). Conservative by design: it only fires on
-    unambiguous degeneracy, so coherent prose never trips it and the precise
-    correctness work is left to the golden predicates below.
-  * :data:`GOLDEN` + :func:`evaluate_case` — fixed prompts with *checkable*
-    properties (``capital of Japan`` → ``Tokyo``, ``17 × 23`` → ``391``), so a
-    coherent-but-wrong regression fails deterministically at ``temperature=0``.
+  * :data:`GOLDEN` + :func:`evaluate_case` — the **BLOCKING** layer. Fixed
+    prompts with a strict, normalized, *checkable* answer (``capital of Japan``
+    → ``Tokyo``, ``17 × 23`` → ``391``). A coherent-but-wrong regression fails
+    (not an exact match), and garbage fails too (also not a match), so the
+    blocking layer needs no heuristic help and cannot false-green on
+    plausible-looking token soup.
+  * :func:`looks_like_garbage` — an **ADVISORY / diagnostic** detector for the
+    obvious collapse classes we have actually shipped (``!!!!!!`` prefix-cache
+    poison, doubled-norm single-token soup, exact loops). It is *not* a reliable
+    classifier — a frequency heuristic cannot separate diverse token soup
+    (``"Ocean qzxv blorp fnarg glip."``) from prose without trading false
+    negatives for false positives — so the runner surfaces it as a warning and
+    it **never blocks a release**. Also intended for reuse by the telemetry
+    garbage-rate alert (#1250), where an aggregate advisory signal is useful.
 
 Everything here is pure (no network, no MLX, no server) so it can be unit-tested
 in ordinary CI on a GitHub-hosted runner. The serve-path runner that feeds real
 generations through these predicates lives in ``evals/coherence_gate.py`` and
 runs on the Apple-Silicon release gauntlet (``scripts/release_check_m3.sh``).
-The detector is also intended for reuse by the telemetry garbage-rate alert
-(#1250).
 """
 
 from __future__ import annotations
@@ -130,12 +134,16 @@ def looks_like_garbage(text: str, *, min_words: int = 10) -> tuple[bool, str]:
 
 @dataclass(frozen=True)
 class GoldenCase:
-    """A fixed prompt plus a checkable predicate over its completion.
+    """A fixed prompt plus a *deterministic* checkable predicate. Every golden
+    case is BLOCKING and has a known-right answer — there are no heuristic
+    (open-ended / prose) cases in the blocking set, because a structural check
+    on free-form text still false-greens on diverse token soup that happens to
+    include the required words (``"Ocean qzxv blorp. Water wug traz."``). Only
+    exact-answer checks belong here.
 
     ``kind`` selects the predicate applied by :func:`evaluate_case`:
 
     * ``exact``         — normalized completion exactly matches one of ``expect``
-    * ``two_sentence``  — two distinct sentences containing every expected term
     * ``no_think_leak`` — exact match AND no raw reasoning tag
     """
 
@@ -190,22 +198,6 @@ GOLDEN: tuple[GoldenCase, ...] = (
         max_tokens=32,
     ),
     GoldenCase(
-        "open-ocean",
-        "Write a short two-sentence description of the ocean. "
-        "Include the exact words ocean and water.",
-        "two_sentence",
-        ("ocean", "water"),
-        max_tokens=200,
-    ),
-    GoldenCase(
-        "open-cpu",
-        "In two sentences, explain what a computer CPU does. "
-        "Include the exact words CPU and instructions.",
-        "two_sentence",
-        ("cpu", "instructions"),
-        max_tokens=200,
-    ),
-    GoldenCase(
         "no-think-leak",
         "What is the capital of France? Answer in one word.",
         "no_think_leak",
@@ -229,36 +221,17 @@ def _matches_exact(text: str, expected: tuple[str, ...]) -> bool:
 
 
 def evaluate_case(case: GoldenCase, text: str) -> tuple[bool, str]:
-    """Apply ``case``'s predicate to a completion ``text``.
+    """Apply ``case``'s deterministic golden predicate to a completion ``text``.
 
-    Returns ``(passed, reason)``. Every case is first screened by
-    :func:`looks_like_garbage` — a golden answer buried in ``!!!!`` still fails
-    — and then the kind-specific predicate is applied.
+    Returns ``(passed, reason)``. This is the BLOCKING layer: a strict,
+    normalized golden-answer check with NO heuristic garbage screen. Garbage or
+    a fluent-but-wrong answer fails naturally — it is simply not an exact match
+    for the expected token — so the blocking layer cannot false-green on
+    plausible-looking token soup. Garbage *detection*
+    (:func:`looks_like_garbage`) is a separate ADVISORY signal the runner prints
+    but never blocks on, because a frequency heuristic cannot reliably separate
+    diverse token soup (``"Ocean qzxv blorp fnarg glip."``) from prose.
     """
-    garbage, why = looks_like_garbage(text)
-    if garbage:
-        return False, f"garbage output ({why})"
-
-    if case.kind == "two_sentence":
-        words = _WORD_RE.findall(text)
-        sentence_ends = re.findall(r"[.!?。！？](?:\s|$)", text)
-        sentences = [
-            sentence.strip().casefold()
-            for sentence in re.split(r"[.!?。！？]+", text)
-            if sentence.strip()
-        ]
-        if len(words) < 8:
-            return False, f"too short ({len(words)} words; expected at least 8)"
-        if len(sentence_ends) < 2:
-            return False, "expected at least two complete sentences"
-        if len(set(sentences)) < 2:
-            return False, "repeated the same sentence"
-        output_words = {word.casefold() for word in words}
-        missing = [term for term in case.expect if term.casefold() not in output_words]
-        if missing:
-            return False, f"missing required term(s) {tuple(missing)!r}"
-        return True, "coherent two-sentence response with required terms"
-
     if case.kind == "exact":
         if _matches_exact(text, case.expect):
             return True, f"exactly matches {case.expect!r}"

--- a/vllm_mlx/coherence.py
+++ b/vllm_mlx/coherence.py
@@ -100,7 +100,7 @@ def looks_like_garbage(text: str, *, min_words: int = 10) -> tuple[bool, str]:
     # (c) character-repetition heuristics. Guarded by a length floor so short
     # legitimate answers ("7", "42", "OK") are never flagged: a doubled-norm /
     # cache-poison collapse that carries word characters ("aaaaa…") is long.
-    if len(non_space) >= 5:
+    if len(non_space) >= 5 and not s.isdecimal():
         top_char, top_n = Counter(non_space).most_common(1)[0]
         if top_n / len(non_space) > 0.5:
             return True, (

--- a/vllm_mlx/coherence.py
+++ b/vllm_mlx/coherence.py
@@ -133,10 +133,9 @@ class GoldenCase:
 
     ``kind`` selects the predicate applied by :func:`evaluate_case`:
 
-    * ``contains``      — completion contains any of ``expect`` (case-insensitive)
-    * ``contains_all``  — completion contains every string in ``expect``
+    * ``exact``         — normalized completion exactly matches one of ``expect``
     * ``not_garbage``   — open-ended prompt; only requirement is non-degeneracy
-    * ``no_think_leak`` — contains any of ``expect`` AND no raw reasoning tag
+    * ``no_think_leak`` — exact match AND no raw reasoning tag
     """
 
     id: str
@@ -153,28 +152,28 @@ GOLDEN: tuple[GoldenCase, ...] = (
     GoldenCase(
         "capital-japan",
         "What is the capital of Japan? Answer in one word.",
-        "contains",
+        "exact",
         ("Tokyo",),
         max_tokens=32,
     ),
     GoldenCase(
         "arithmetic",
         "What is 17 multiplied by 23? Reply with just the number.",
-        "contains",
+        "exact",
         ("391",),
         max_tokens=32,
     ),
     GoldenCase(
         "sky-color",
         "What color is a clear daytime sky? Answer in one word.",
-        "contains",
+        "exact",
         ("blue",),
         max_tokens=32,
     ),
     GoldenCase(
         "days-in-week",
         "How many days are in a week? Reply with just the number.",
-        "contains",
+        "exact",
         ("7", "seven"),
         max_tokens=32,
     ),
@@ -185,7 +184,7 @@ GOLDEN: tuple[GoldenCase, ...] = (
         # a case-insensitive single-letter check.
         "echo-word",
         "Repeat exactly this word back to me, nothing else: banana",
-        "contains",
+        "exact",
         ("banana",),
         max_tokens=32,
     ),
@@ -211,14 +210,17 @@ GOLDEN: tuple[GoldenCase, ...] = (
 )
 
 
-def _contains(text: str, needles: tuple[str, ...]) -> bool:
-    t = text.lower()
-    return any(n.lower() in t for n in needles)
+_ANSWER_WRAPPER = " \t\r\n`*_~\"'“”‘’.,!?;:。！？；："
 
 
-def _contains_all(text: str, needles: tuple[str, ...]) -> bool:
-    t = text.lower()
-    return all(n.lower() in t for n in needles)
+def _normalize_exact_answer(text: str) -> str:
+    """Normalize harmless presentation around a requested one-token answer."""
+    return " ".join(text.casefold().strip(_ANSWER_WRAPPER).split())
+
+
+def _matches_exact(text: str, expected: tuple[str, ...]) -> bool:
+    answer = _normalize_exact_answer(text)
+    return any(answer == _normalize_exact_answer(item) for item in expected)
 
 
 def evaluate_case(case: GoldenCase, text: str) -> tuple[bool, str]:
@@ -236,23 +238,18 @@ def evaluate_case(case: GoldenCase, text: str) -> tuple[bool, str]:
         # The garbage screen above IS the predicate for open-ended prompts.
         return True, "coherent (non-degenerate)"
 
-    if case.kind == "contains":
-        if _contains(text, case.expect):
-            return True, f"contains {case.expect!r}"
-        return False, f"missing expected {case.expect!r}"
-
-    if case.kind == "contains_all":
-        if _contains_all(text, case.expect):
-            return True, f"contains all of {case.expect!r}"
-        return False, f"missing one of {case.expect!r}"
+    if case.kind == "exact":
+        if _matches_exact(text, case.expect):
+            return True, f"exactly matches {case.expect!r}"
+        return False, f"not an exact match for {case.expect!r}"
 
     if case.kind == "no_think_leak":
         low = text.lower()
         leaked = [m for m in _THINK_MARKERS if m in low]
         if leaked:
             return False, f"leaked reasoning marker(s) {leaked!r} into visible output"
-        if _contains(text, case.expect):
-            return True, f"contains {case.expect!r}, no think-leak"
-        return False, f"missing expected {case.expect!r}"
+        if _matches_exact(text, case.expect):
+            return True, f"exactly matches {case.expect!r}, no think-leak"
+        return False, f"not an exact match for {case.expect!r}"
 
     return False, f"unknown case kind {case.kind!r}"

--- a/vllm_mlx/coherence.py
+++ b/vllm_mlx/coherence.py
@@ -1,0 +1,258 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Output-coherence primitives — the reusable core of the release coherence gate.
+
+Motivation (#1247). Qwen3.6-35B-A3B and Qwen3.5-35B-A3B-8bit shipped producing
+**pure garbage from the first token** (a doubled RMSNorm scale from an mlx-lm
+``+1.0`` norm-shift misfire; fixed in #1234). The garbage passed *every*
+automated gate — 278 delta tests, lint, install/import smoke, perf thresholds —
+because **no gate ever generates a token and checks whether the output is
+coherent**. This module supplies the two pieces that close that hole:
+
+  * :func:`looks_like_garbage` — a cheap, deterministic detector for the two
+    collapse classes we have actually shipped (``!!!!!!`` prefix-cache poison
+    and doubled-norm token soup). Conservative by design: it only fires on
+    unambiguous degeneracy, so coherent prose never trips it and the precise
+    correctness work is left to the golden predicates below.
+  * :data:`GOLDEN` + :func:`evaluate_case` — fixed prompts with *checkable*
+    properties (``capital of Japan`` → ``Tokyo``, ``17 × 23`` → ``391``), so a
+    coherent-but-wrong regression fails deterministically at ``temperature=0``.
+
+Everything here is pure (no network, no MLX, no server) so it can be unit-tested
+in ordinary CI on a GitHub-hosted runner. The serve-path runner that feeds real
+generations through these predicates lives in ``evals/coherence_gate.py`` and
+runs on the Apple-Silicon release gauntlet (``scripts/release_check_m3.sh``).
+The detector is also intended for reuse by the telemetry garbage-rate alert
+(#1250).
+"""
+
+from __future__ import annotations
+
+import re
+from collections import Counter
+from dataclasses import dataclass, field
+
+__all__ = ["GoldenCase", "GOLDEN", "looks_like_garbage", "evaluate_case"]
+
+_WORD_RE = re.compile(r"\w+", re.UNICODE)
+
+# Literal reasoning-channel markers that must never survive into the visible
+# assistant message (the OutputRouter strips them; a routing regression leaks
+# them). Kept lowercase — callers compare against a lowercased copy.
+_THINK_MARKERS = ("<think>", "</think>", "<reasoning>", "</reasoning>")
+
+
+def _max_char_run(s: str) -> int:
+    """Length of the longest run of a single non-space character."""
+    best = run = 0
+    prev = ""
+    for ch in s:
+        if ch == prev and not ch.isspace():
+            run += 1
+        else:
+            run = 1
+            prev = ch
+        if run > best:
+            best = run
+    return best
+
+
+def looks_like_garbage(text: str, *, min_words: int = 10) -> tuple[bool, str]:
+    """Return ``(is_garbage, reason)`` for a completion string.
+
+    Conservative: fires only on unambiguous degeneracy so real prose passes.
+    Detects the classes we have actually shipped or seen:
+
+    * empty / whitespace-only output;
+    * punctuation/symbol-only output (``!!!!!``, CJK fill) at any length;
+    * a single character dominating a non-trivial output (``aaaaa``);
+    * a very long single-character run embedded in otherwise-mixed text;
+    * a single word repeated (``ocean ocean ocean ocean``);
+    * a tiny vocabulary over a long output (looping token soup);
+    * one bigram dominating a long output (``the the the …``).
+
+    Short legitimate answers (``"7"``, ``"42"``, ``"391"``, ``"Tokyo"``) are
+    never flagged: the character-repetition heuristics only apply above a small
+    length floor, and a valid answer always carries at least one word
+    character. ``min_words`` guards the vocabulary/bigram checks so a short
+    answer is never judged a loop.
+    """
+    s = (text or "").strip()
+    if not s:
+        return True, "empty"
+
+    non_space = [c for c in s if not c.isspace()]
+    if not non_space:
+        return True, "whitespace-only"
+
+    words = _WORD_RE.findall(s.lower())
+
+    # (a) no word characters at all -> pure punctuation/symbol collapse
+    # ("!!!!!", "。。。。", "?????"). Fires at any length; a legitimate answer to
+    # any prompt carries at least one alphanumeric word character.
+    if not words:
+        return True, "no word characters (punctuation/symbol-only)"
+
+    # (b) a single word repeated -> "ocean ocean ocean ocean". Unambiguous at
+    # any length >= 4 (no legitimate answer is one word repeated 4+ times).
+    if len(words) >= 4 and len(set(words)) == 1:
+        return True, f"single word {words[0]!r} repeated {len(words)}x"
+
+    # (c) character-repetition heuristics. Guarded by a length floor so short
+    # legitimate answers ("7", "42", "OK") are never flagged: a doubled-norm /
+    # cache-poison collapse that carries word characters ("aaaaa…") is long.
+    if len(non_space) >= 5:
+        top_char, top_n = Counter(non_space).most_common(1)[0]
+        if top_n / len(non_space) > 0.5:
+            return True, (
+                f"char {top_char!r} is {top_n}/{len(non_space)} of non-space output"
+            )
+        if _max_char_run(s) >= 20:
+            return True, "single-character run >= 20"
+
+    if len(words) >= min_words:
+        # (c) tiny vocabulary over a long output -> looping token soup
+        uniq_ratio = len(set(words)) / len(words)
+        if uniq_ratio < 0.20:
+            return True, (
+                f"distinct-word ratio {uniq_ratio:.2f} < 0.20 over {len(words)} words"
+            )
+
+        # (d) one bigram dominates -> "the the the the …"
+        bigrams = list(zip(words, words[1:]))
+        if bigrams:
+            _, bn = Counter(bigrams).most_common(1)[0]
+            if bn / len(bigrams) > 0.30:
+                return True, f"top bigram is {bn}/{len(bigrams)} of the output"
+
+    return False, "ok"
+
+
+@dataclass(frozen=True)
+class GoldenCase:
+    """A fixed prompt plus a checkable predicate over its completion.
+
+    ``kind`` selects the predicate applied by :func:`evaluate_case`:
+
+    * ``contains``      — completion contains any of ``expect`` (case-insensitive)
+    * ``contains_all``  — completion contains every string in ``expect``
+    * ``not_garbage``   — open-ended prompt; only requirement is non-degeneracy
+    * ``no_think_leak`` — contains any of ``expect`` AND no raw reasoning tag
+    """
+
+    id: str
+    prompt: str
+    kind: str
+    expect: tuple[str, ...] = field(default_factory=tuple)
+    max_tokens: int = 64
+
+
+# Deterministic anchors a garbage / doubled-norm model cannot produce, and that
+# a coherent-but-wrong regression also fails. Kept small + fast: on the starter
+# alias (qwen3.5-4b-4bit) the whole set generates in well under a minute.
+GOLDEN: tuple[GoldenCase, ...] = (
+    GoldenCase(
+        "capital-japan",
+        "What is the capital of Japan? Answer in one word.",
+        "contains",
+        ("Tokyo",),
+        max_tokens=32,
+    ),
+    GoldenCase(
+        "arithmetic",
+        "What is 17 multiplied by 23? Reply with just the number.",
+        "contains",
+        ("391",),
+        max_tokens=32,
+    ),
+    GoldenCase(
+        "sky-color",
+        "What color is a clear daytime sky? Answer in one word.",
+        "contains",
+        ("blue",),
+        max_tokens=32,
+    ),
+    GoldenCase(
+        "days-in-week",
+        "How many days are in a week? Reply with just the number.",
+        "contains",
+        ("7", "seven"),
+        max_tokens=32,
+    ),
+    GoldenCase(
+        # Instruction-following + coherence: a garbage / doubled-norm model
+        # cannot echo a distinctive token. "banana" is 6 chars and vanishingly
+        # unlikely to appear by chance, so this is far more discriminating than
+        # a case-insensitive single-letter check.
+        "echo-word",
+        "Repeat exactly this word back to me, nothing else: banana",
+        "contains",
+        ("banana",),
+        max_tokens=32,
+    ),
+    GoldenCase(
+        "open-ocean",
+        "Write a short two-sentence description of the ocean.",
+        "not_garbage",
+        max_tokens=200,
+    ),
+    GoldenCase(
+        "open-cpu",
+        "In two sentences, explain what a computer CPU does.",
+        "not_garbage",
+        max_tokens=200,
+    ),
+    GoldenCase(
+        "no-think-leak",
+        "What is the capital of France? Answer in one word.",
+        "no_think_leak",
+        ("Paris",),
+        max_tokens=64,
+    ),
+)
+
+
+def _contains(text: str, needles: tuple[str, ...]) -> bool:
+    t = text.lower()
+    return any(n.lower() in t for n in needles)
+
+
+def _contains_all(text: str, needles: tuple[str, ...]) -> bool:
+    t = text.lower()
+    return all(n.lower() in t for n in needles)
+
+
+def evaluate_case(case: GoldenCase, text: str) -> tuple[bool, str]:
+    """Apply ``case``'s predicate to a completion ``text``.
+
+    Returns ``(passed, reason)``. Every case is first screened by
+    :func:`looks_like_garbage` — a golden answer buried in ``!!!!`` still fails
+    — and then the kind-specific predicate is applied.
+    """
+    garbage, why = looks_like_garbage(text)
+    if garbage:
+        return False, f"garbage output ({why})"
+
+    if case.kind == "not_garbage":
+        # The garbage screen above IS the predicate for open-ended prompts.
+        return True, "coherent (non-degenerate)"
+
+    if case.kind == "contains":
+        if _contains(text, case.expect):
+            return True, f"contains {case.expect!r}"
+        return False, f"missing expected {case.expect!r}"
+
+    if case.kind == "contains_all":
+        if _contains_all(text, case.expect):
+            return True, f"contains all of {case.expect!r}"
+        return False, f"missing one of {case.expect!r}"
+
+    if case.kind == "no_think_leak":
+        low = text.lower()
+        leaked = [m for m in _THINK_MARKERS if m in low]
+        if leaked:
+            return False, f"leaked reasoning marker(s) {leaked!r} into visible output"
+        if _contains(text, case.expect):
+            return True, f"contains {case.expect!r}, no think-leak"
+        return False, f"missing expected {case.expect!r}"
+
+    return False, f"unknown case kind {case.kind!r}"

--- a/vllm_mlx/coherence.py
+++ b/vllm_mlx/coherence.py
@@ -134,7 +134,7 @@ class GoldenCase:
     ``kind`` selects the predicate applied by :func:`evaluate_case`:
 
     * ``exact``         — normalized completion exactly matches one of ``expect``
-    * ``not_garbage``   — open-ended prompt; only requirement is non-degeneracy
+    * ``two_sentence``  — non-degenerate response with two sentences
     * ``no_think_leak`` — exact match AND no raw reasoning tag
     """
 
@@ -191,13 +191,13 @@ GOLDEN: tuple[GoldenCase, ...] = (
     GoldenCase(
         "open-ocean",
         "Write a short two-sentence description of the ocean.",
-        "not_garbage",
+        "two_sentence",
         max_tokens=200,
     ),
     GoldenCase(
         "open-cpu",
         "In two sentences, explain what a computer CPU does.",
-        "not_garbage",
+        "two_sentence",
         max_tokens=200,
     ),
     GoldenCase(
@@ -234,9 +234,14 @@ def evaluate_case(case: GoldenCase, text: str) -> tuple[bool, str]:
     if garbage:
         return False, f"garbage output ({why})"
 
-    if case.kind == "not_garbage":
-        # The garbage screen above IS the predicate for open-ended prompts.
-        return True, "coherent (non-degenerate)"
+    if case.kind == "two_sentence":
+        words = _WORD_RE.findall(text)
+        sentence_ends = re.findall(r"[.!?。！？](?:\s|$)", text)
+        if len(words) < 8:
+            return False, f"too short ({len(words)} words; expected at least 8)"
+        if len(sentence_ends) < 2:
+            return False, "expected at least two complete sentences"
+        return True, "coherent two-sentence response"
 
     if case.kind == "exact":
         if _matches_exact(text, case.expect):

--- a/vllm_mlx/coherence.py
+++ b/vllm_mlx/coherence.py
@@ -102,7 +102,7 @@ def looks_like_garbage(text: str, *, min_words: int = 10) -> tuple[bool, str]:
     # cache-poison collapse that carries word characters ("aaaaa…") is long.
     if len(non_space) >= 5 and not s.isdecimal():
         top_char, top_n = Counter(non_space).most_common(1)[0]
-        if top_n / len(non_space) > 0.5:
+        if top_n >= 5 and top_n / len(non_space) > 0.5:
             return True, (
                 f"char {top_char!r} is {top_n}/{len(non_space)} of non-space output"
             )

--- a/vllm_mlx/coherence.py
+++ b/vllm_mlx/coherence.py
@@ -100,7 +100,8 @@ def looks_like_garbage(text: str, *, min_words: int = 10) -> tuple[bool, str]:
     # (c) character-repetition heuristics. Guarded by a length floor so short
     # legitimate answers ("7", "42", "OK") are never flagged: a doubled-norm /
     # cache-poison collapse that carries word characters ("aaaaa…") is long.
-    if len(non_space) >= 5 and not s.isdecimal():
+    short_numeric_answer = s.isdecimal() and len(non_space) < 20
+    if len(non_space) >= 5 and not short_numeric_answer:
         top_char, top_n = Counter(non_space).most_common(1)[0]
         if top_n >= 5 and top_n / len(non_space) > 0.5:
             return True, (
@@ -134,7 +135,7 @@ class GoldenCase:
     ``kind`` selects the predicate applied by :func:`evaluate_case`:
 
     * ``exact``         — normalized completion exactly matches one of ``expect``
-    * ``two_sentence``  — non-degenerate response with two sentences
+    * ``two_sentence``  — two distinct sentences containing every expected term
     * ``no_think_leak`` — exact match AND no raw reasoning tag
     """
 
@@ -190,14 +191,18 @@ GOLDEN: tuple[GoldenCase, ...] = (
     ),
     GoldenCase(
         "open-ocean",
-        "Write a short two-sentence description of the ocean.",
+        "Write a short two-sentence description of the ocean. "
+        "Include the exact words ocean and water.",
         "two_sentence",
+        ("ocean", "water"),
         max_tokens=200,
     ),
     GoldenCase(
         "open-cpu",
-        "In two sentences, explain what a computer CPU does.",
+        "In two sentences, explain what a computer CPU does. "
+        "Include the exact words CPU and instructions.",
         "two_sentence",
+        ("cpu", "instructions"),
         max_tokens=200,
     ),
     GoldenCase(
@@ -248,7 +253,11 @@ def evaluate_case(case: GoldenCase, text: str) -> tuple[bool, str]:
             return False, "expected at least two complete sentences"
         if len(set(sentences)) < 2:
             return False, "repeated the same sentence"
-        return True, "coherent two-sentence response"
+        output_words = {word.casefold() for word in words}
+        missing = [term for term in case.expect if term.casefold() not in output_words]
+        if missing:
+            return False, f"missing required term(s) {tuple(missing)!r}"
+        return True, "coherent two-sentence response with required terms"
 
     if case.kind == "exact":
         if _matches_exact(text, case.expect):

--- a/vllm_mlx/coherence.py
+++ b/vllm_mlx/coherence.py
@@ -232,6 +232,9 @@ def evaluate_case(case: GoldenCase, text: str) -> tuple[bool, str]:
     but never blocks on, because a frequency heuristic cannot reliably separate
     diverse token soup (``"Ocean qzxv blorp fnarg glip."``) from prose.
     """
+    if not isinstance(text, str):
+        return False, f"invalid response content type {type(text).__name__}"
+
     if case.kind == "exact":
         if _matches_exact(text, case.expect):
             return True, f"exactly matches {case.expect!r}"


### PR DESCRIPTION
## What

Adds the missing **output-coherence gate** — the one class of gate that would have caught the Qwen3.6/3.5-35B shipped-garbage incident. Closes the core of #1247.

## Why

Qwen3.6-35B-A3B and Qwen3.5-35B-A3B-8bit shipped producing **pure garbage from the first token** (doubled RMSNorm scale, fixed in #1234) yet passed **every** automated gate — 278 delta tests, lint, install/import smoke, perf thresholds — because **nothing generates a token and checks whether the output is coherent**. Coherent-but-wrong or pure-garbage output at normal speed passes all of today's CI. This adds the missing check.

## Design — two layers

**`vllm_mlx/coherence.py`** — pure, dependency-free (no server, no MLX), so it unit-tests on a GitHub-hosted runner:
- `looks_like_garbage()` — deterministic detector for the collapse classes we've actually shipped/seen: `!!!!!` cache-poison, doubled-norm token soup, single-word / bigram loops, punctuation-only, empty. Conservative — fires only on unambiguous degeneracy, so real prose and short answers (`"7"`, `"42"`) never trip it. Reusable by the #1250 telemetry garbage-rate alert.
- `GOLDEN` + `evaluate_case()` — fixed prompts with checkable properties (capital of Japan → Tokyo, 17×23 → 391, sky → blue, echo `banana`, no `<think>` leak, open-ended → non-degenerate). A coherent-but-**wrong** regression fails deterministically at `temperature=0`.

**`evals/coherence_gate.py`** — serve-path runner: feeds `GOLDEN` through a **real running server** at temp=0, applies `evaluate_case`, exits `0`/`1` (`2` if unreachable). Reads `RAPID_MLX_BASE_URL` like the existing SDK gauntlet — no new boot orchestration.

**`scripts/release_check_m3.sh`** — runs the gate **first** after server boot (new `G4`), before stress/SDK: a garbage model makes every later gate moot.

## Testing

- **28 always-on unit tests** (`tests/test_coherence.py`, no server/MLX) lock in the gate logic itself — this is the "test the gate" acceptance from #1247: every garbage class is flagged; real prose + short answers are not; a coherent-but-wrong answer AND garbage-for-a-golden-prompt are both rejected (the exact #1234 class).
- **End-to-end against a live `qwen3.5-4b-4bit` server: 8/8 golden cases coherent, exit 0.** Both paths exercised against the real server (the pass path and, during dogfood, the fail path with the "COHERENCE GATE FAILED" banner + exit 1).
- Dogfood caught a real false positive in the detector (single-token `"7"` tripping char-dominance) — fixed and guarded by a regression test.

## Follow-up (ops, tracked in #1247)

To make the serve-path gate **blocking in CI** (not only in the local M3 gauntlet), the self-hosted Apple-Silicon runner needs registering — GitHub-hosted `ubuntu-latest` has no MLX runtime (which is also why `pr-validate.yml` skips `stress_e2e_bench`). The pure unit tests are already always-on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
