### PR TITLE
fix(first-run): TTY-aware cold-download progress + correct starter size

### DIFF
--- a/tests/test_first_run_guide.py
+++ b/tests/test_first_run_guide.py
@@ -6,7 +6,7 @@ Covers the ``vllm_mlx/first_run.py`` helpers and their three wiring points in
 
   * P0-1 — ``chat`` / ``run`` with no model → starter auto-select in
     ``main()`` (the known-good starter alias chosen, notice printed only on a
-    TTY; the standard download gate is left untouched — the ~2.5 GB starter is
+    TTY; the standard download gate is left untouched — the ~3.1 GB starter is
     under its 10 GiB confirm threshold — and non-interactive sessions fall
     through to that gate exactly as before this feature).
   * P0-2 — bare ``rapid-mlx`` in an interactive terminal → nameplate + exit 0;
@@ -376,7 +376,7 @@ def test_autoselected_starter_uses_standard_download_gate():
     # interactive), an uncached auto-selected starter reaches confirm_or_abort
     # exactly like an explicit model does. The "small model → no prompt"
     # decision belongs to confirm_or_abort's own 10 GiB threshold (covered in
-    # test_download_gate), NOT to a bypass here — the ~2.5 GB starter is far
+    # test_download_gate), NOT to a bypass here — the ~3.1 GB starter is far
     # under that threshold, so the gate stays silent for it on its own.
     confirm, dispatched = _run_main_gate_probe(
         ["chat"], auto_select_alias="qwen3.5-4b-4bit"

--- a/tests/test_mirror_progress_tty.py
+++ b/tests/test_mirror_progress_tty.py
@@ -20,6 +20,7 @@ These are direct unit tests of the tracker: fast and hermetic, no network.
 from __future__ import annotations
 
 import io
+import os
 import sys
 
 import pytest
@@ -164,6 +165,75 @@ def test_narrow_tty_never_wraps(monkeypatch):
         row = seg.split("\n")[0]
         if "↓" in row:
             assert len(row) <= 20, f"bar row exceeds width: {row!r} ({len(row)})"
+
+
+def _render_bar_under_pty(cols, total, adds, monkeypatch):
+    """Run a real ``_ProgressTracker`` with stdout wired to a PTY sized to
+    ``cols`` columns, and return the captured output. Exercises the true
+    ``os.get_terminal_size(self._out.fileno())`` width path — no ``COLUMNS``,
+    no ``_FakeTTY``."""
+    import fcntl
+    import pty
+    import struct
+    import termios
+    import threading
+
+    master, slave = pty.openpty()
+    # Size the PTY to `cols` columns (rows irrelevant to the bar).
+    fcntl.ioctl(slave, termios.TIOCSWINSZ, struct.pack("HHHH", 24, cols, 0, 0))
+
+    # Drain the master concurrently: on macOS, closing the slave can discard
+    # buffered data before a serial read gets to it, so read as it's written.
+    captured = bytearray()
+
+    def _reader():
+        while True:
+            try:
+                chunk = os.read(master, 65536)
+            except OSError:
+                break
+            if not chunk:
+                break
+            captured.extend(chunk)
+
+    reader = threading.Thread(target=_reader, daemon=True)
+    reader.start()
+
+    slave_f = os.fdopen(slave, "w", buffering=1)
+    monkeypatch.setattr(sys, "stdout", slave_f)
+    try:
+        t = _ProgressTracker(total=total)
+        for a in adds:
+            t.add(a)
+        t.flush()
+    finally:
+        slave_f.flush()
+        slave_f.close()  # slave EOF → the reader thread exits
+        monkeypatch.setattr(sys, "stdout", sys.__stdout__)
+    reader.join(timeout=2)
+    os.close(master)
+    return bytes(captured).decode("utf-8", "replace")
+
+
+@pytest.mark.skipif(not hasattr(os, "openpty"), reason="PTY unavailable")
+def test_pty_width_measures_output_stream_not_default(monkeypatch):
+    """The bar sizes to ITS OWN output PTY, not the process's default
+    terminal (codex #1259 BLOCKING). Two PTYs of differing widths, COLUMNS
+    unset: every bar row must fit its own PTY's width. If width detection
+    fell back to a constant (e.g. 80), the 34-col PTY's rows would overflow
+    and this fails.
+    """
+    monkeypatch.delenv("COLUMNS", raising=False)  # force the fileno path
+    for cols in (34, 72):
+        out = _render_bar_under_pty(
+            cols, 500_000_000, [250_000_000, 250_000_000], monkeypatch
+        )
+        assert "[bytes]" not in out
+        assert "↓" in out
+        for seg in out.replace("\x1b[2K", "").split("\r"):
+            row = seg.split("\n")[0]
+            if "↓" in row:
+                assert len(row) <= cols, f"cols={cols}: row {row!r} len={len(row)}"
 
 
 def test_no_color_tty_keeps_bar_without_ansi(monkeypatch):

--- a/tests/test_mirror_progress_tty.py
+++ b/tests/test_mirror_progress_tty.py
@@ -129,3 +129,28 @@ def test_tty_stays_silent_when_total_unknown(monkeypatch):
     t.add(500)
     t.flush()
     assert fake.getvalue() == ""
+
+
+def test_no_color_tty_keeps_bar_without_ansi(monkeypatch):
+    """NO_COLOR must NOT re-trigger the machine ``[bytes]`` flood on a
+    terminal — that's the exact regression this feature removes, and the
+    NO_COLOR user is precisely who wants clean output. NO_COLOR only drops
+    ANSI: the bar still redraws in place via ``\\r`` + space-pad, emitting
+    zero escape sequences.
+    """
+    monkeypatch.setenv("NO_COLOR", "1")  # re-set (autouse fixture cleared it)
+    fake = _FakeTTY()
+    monkeypatch.setattr(sys, "stdout", fake)
+    t = _ProgressTracker(total=1000)
+    t.add(250)
+    t.add(250)  # 50%
+    t.write_line("  [1/3] config.json")  # erases the bar without ANSI
+    t.add(500)  # 100%
+    t.flush()
+    out = fake.getvalue()
+    assert "[bytes]" not in out  # no machine flood for a NO_COLOR terminal
+    assert "\x1b" not in out  # zero ANSI escapes
+    assert "\r" in out  # still an in-place bar
+    assert "↓" in out and "100%" in out
+    assert "[1/3] config.json" in out
+    assert out.endswith("\n")  # flush finalized the row

--- a/tests/test_mirror_progress_tty.py
+++ b/tests/test_mirror_progress_tty.py
@@ -77,14 +77,19 @@ def test_tty_draws_single_inplace_bar(monkeypatch):
     t.add(250)  # 50%
     mid = fake.getvalue()
     assert "[bytes]" not in mid  # machine format never shown to a human
-    assert "\r" in mid and "↓" in mid  # in-place bar
-    assert "50%" in mid
-    assert not mid.endswith("\n")  # mid-stream redraw carries no newline
+    assert "50%" in mid and "↓" in mid
+    # ONE line, redrawn in place: NO newline anywhere mid-stream (a scroll
+    # would insert one), and every redraw is a carriage-return + erase-line.
+    assert "\n" not in mid
+    assert mid.count("\r\x1b[2K") == 2  # exactly the two add() redraws
     t.add(500)  # 100%
     t.flush()
     final = fake.getvalue()
     assert "100%" in final
     assert final.endswith("\n")  # flush finalizes the bar's row
+    # The finalizing newline is the ONLY newline in the whole TTY session —
+    # proof the bar never scrolled.
+    assert final.count("\n") == 1
 
 
 def test_tty_bar_clamps_display_at_100_percent(monkeypatch):

--- a/tests/test_mirror_progress_tty.py
+++ b/tests/test_mirror_progress_tty.py
@@ -46,9 +46,14 @@ class _FakePipe(io.StringIO):
 def _every_add_emits(monkeypatch):
     # No throttle — every add() renders, so a single add is observable.
     monkeypatch.setattr(_mirror, "_PROGRESS_HEARTBEAT_SECONDS", 0.0)
-    # NO_COLOR forces the non-TTY branch regardless of isatty() — clear it so
-    # the _FakeTTY tests actually exercise the human bar.
+    # Clear NO_COLOR so the _FakeTTY tests exercise the ANSI bar. NO_COLOR
+    # does NOT switch to the non-TTY [bytes] protocol — isatty() alone selects
+    # the bar; NO_COLOR only drops ANSI styling (covered by
+    # test_no_color_tty_keeps_bar_without_ansi).
     monkeypatch.delenv("NO_COLOR", raising=False)
+    # Pin a wide terminal so the width-adaptive bar renders a full 24-cell bar
+    # deterministically, independent of the CI runner's real COLUMNS.
+    monkeypatch.setenv("COLUMNS", "100")
 
 
 def test_non_tty_keeps_machine_bytes_heartbeat(monkeypatch):
@@ -134,6 +139,31 @@ def test_tty_stays_silent_when_total_unknown(monkeypatch):
     t.add(500)
     t.flush()
     assert fake.getvalue() == ""
+
+
+def test_narrow_tty_never_wraps(monkeypatch):
+    """A narrow terminal must not wrap a redraw onto a second row: the bar
+    shrinks (or drops to a compact percentage + bytes readout) and no single
+    redrawn row exceeds the column count (codex #1259).
+    """
+    monkeypatch.setenv("COLUMNS", "20")  # overrides the fixture's wide default
+    fake = _FakeTTY()
+    monkeypatch.setattr(sys, "stdout", fake)
+    t = _ProgressTracker(total=500_000_000)
+    t.add(250_000_000)  # 50%
+    t.write_line("  [1/2] model.safetensors")
+    t.add(250_000_000)  # 100%
+    t.flush()
+    out = fake.getvalue()
+    assert "[bytes]" not in out  # still the human path, not the machine flood
+    assert "↓" in out  # a bar (compact or full) is present
+    # Every redrawn bar row (split on \r, escapes + trailing newline removed)
+    # must fit within the 20-column terminal. write_line status lines are
+    # one-shot (not redrawn), so exempt them from the width check.
+    for seg in out.replace("\x1b[2K", "").split("\r"):
+        row = seg.split("\n")[0]
+        if "↓" in row:
+            assert len(row) <= 20, f"bar row exceeds width: {row!r} ({len(row)})"
 
 
 def test_no_color_tty_keeps_bar_without_ansi(monkeypatch):

--- a/tests/test_mirror_progress_tty.py
+++ b/tests/test_mirror_progress_tty.py
@@ -1,0 +1,131 @@
+# SPDX-License-Identifier: Apache-2.0
+"""The mirror pull's byte-progress renderer must adapt to its output sink.
+
+Two contracts share one ``_ProgressTracker``:
+
+* **Piped stdout** (the desktop app's captured subprocess, a redirected log,
+  pytest capture) keeps the machine-readable ``[bytes] D/T`` heartbeat the
+  desktop's ``DownloadProgress`` parser reads. Breaking this format silently
+  freezes the desktop progress bar — the regression this file guards.
+* **A human TTY** (someone running bare ``rapid-mlx chat`` in a terminal) gets
+  ONE in-place bar redrawn with ``\\r`` instead of the hundreds of raw
+  ``[bytes]`` lines a multi-GB cold pull used to scroll (0.11 first-run
+  dogfood papercut). Per-file completion lines route through ``write_line`` so
+  they erase the bar cleanly rather than shredding it.
+
+These are direct unit tests of the tracker: fast and hermetic, no network.
+``_mirror._PROGRESS_HEARTBEAT_SECONDS`` is dropped to 0 so every ``add`` emits.
+"""
+
+from __future__ import annotations
+
+import io
+import sys
+
+import pytest
+
+from vllm_mlx import _mirror
+from vllm_mlx._mirror import _ProgressTracker
+
+
+class _FakeTTY(io.StringIO):
+    """A captured stdout that claims to be an interactive terminal."""
+
+    def isatty(self) -> bool:
+        return True
+
+
+class _FakePipe(io.StringIO):
+    """A captured stdout that is NOT a terminal (desktop pipe / log)."""
+
+    def isatty(self) -> bool:
+        return False
+
+
+@pytest.fixture(autouse=True)
+def _every_add_emits(monkeypatch):
+    # No throttle — every add() renders, so a single add is observable.
+    monkeypatch.setattr(_mirror, "_PROGRESS_HEARTBEAT_SECONDS", 0.0)
+    # NO_COLOR forces the non-TTY branch regardless of isatty() — clear it so
+    # the _FakeTTY tests actually exercise the human bar.
+    monkeypatch.delenv("NO_COLOR", raising=False)
+
+
+def test_non_tty_keeps_machine_bytes_heartbeat(monkeypatch):
+    """Piped stdout emits ``[bytes] D/T`` and never the human bar."""
+    fake = _FakePipe()
+    monkeypatch.setattr(sys, "stdout", fake)
+    t = _ProgressTracker(total=1000)
+    t.add(400)
+    t.add(600)  # done == total
+    t.flush()
+    out = fake.getvalue()
+    assert "[bytes] 400/1000" in out
+    assert "[bytes] 1000/1000" in out
+    # No terminal control sequences or bar glyphs leak onto a pipe.
+    assert "\r" not in out
+    assert "↓" not in out
+    assert "\x1b" not in out
+
+
+def test_tty_draws_single_inplace_bar(monkeypatch):
+    """A human terminal gets one carriage-return bar, no ``[bytes]`` lines."""
+    fake = _FakeTTY()
+    monkeypatch.setattr(sys, "stdout", fake)
+    t = _ProgressTracker(total=1000)
+    t.add(250)
+    t.add(250)  # 50%
+    mid = fake.getvalue()
+    assert "[bytes]" not in mid  # machine format never shown to a human
+    assert "\r" in mid and "↓" in mid  # in-place bar
+    assert "50%" in mid
+    assert not mid.endswith("\n")  # mid-stream redraw carries no newline
+    t.add(500)  # 100%
+    t.flush()
+    final = fake.getvalue()
+    assert "100%" in final
+    assert final.endswith("\n")  # flush finalizes the bar's row
+
+
+def test_tty_bar_clamps_display_at_100_percent(monkeypatch):
+    """An oversized/corrupt stream can't render >100% (same clamp as add)."""
+    fake = _FakeTTY()
+    monkeypatch.setattr(sys, "stdout", fake)
+    t = _ProgressTracker(total=1000)
+    t.add(1500)  # Content-Length lied / proxy injected bytes
+    out = fake.getvalue()
+    assert "100%" in out
+    assert "150%" not in out
+
+
+def test_tty_write_line_erases_bar_then_prints(monkeypatch):
+    """A completion line erases the live bar and lands on its own row."""
+    fake = _FakeTTY()
+    monkeypatch.setattr(sys, "stdout", fake)
+    t = _ProgressTracker(total=1000)
+    t.add(300)  # bar now live
+    t.write_line("  [1/3] config.json")
+    out = fake.getvalue()
+    # erase-line sequence, the completion text, then a newline
+    assert "\r\x1b[2K  [1/3] config.json\n" in out
+
+
+def test_non_tty_write_line_is_plain_print(monkeypatch):
+    """On a pipe, write_line == the old ``_print_dim`` (byte-identical)."""
+    fake = _FakePipe()
+    monkeypatch.setattr(sys, "stdout", fake)
+    t = _ProgressTracker(total=1000)
+    t.write_line("  [1/3] config.json")
+    out = fake.getvalue()
+    assert out == "  [1/3] config.json\n"
+    assert "\r" not in out and "\x1b" not in out
+
+
+def test_tty_stays_silent_when_total_unknown(monkeypatch):
+    """total==0 (HF didn't expose sizes) → no bar, no divide-by-zero."""
+    fake = _FakeTTY()
+    monkeypatch.setattr(sys, "stdout", fake)
+    t = _ProgressTracker(total=0)
+    t.add(500)
+    t.flush()
+    assert fake.getvalue() == ""

--- a/tests/test_mirror_pull.py
+++ b/tests/test_mirror_pull.py
@@ -3494,9 +3494,13 @@ def test_progress_tracker_clamps_display_at_total():
     saved = _mirror._PROGRESS_HEARTBEAT_SECONDS
     _mirror._PROGRESS_HEARTBEAT_SECONDS = 0.0
     try:
-        t = _mirror._ProgressTracker(total=1000)
         buf = io.StringIO()
         with redirect_stdout(buf):
+            # Construct INSIDE the redirect: the tracker captures its output
+            # stream once at construction (codex #1259) and writes there for
+            # the life of the pull, so ``buf`` must be the active stdout when
+            # it's built — not merely when add()/flush() run.
+            t = _mirror._ProgressTracker(total=1000)
             t.add(800)  # 800/1000
             t.add(400)  # over-streamed: internal _done=1200, display 1000/1000
             t.subtract(1200)  # rollback raw 1200 → internal _done=0

--- a/vllm_mlx/_mirror.py
+++ b/vllm_mlx/_mirror.py
@@ -113,7 +113,9 @@ class _ProgressTracker:
       in-place bar with ``\\r`` so a multi-GB cold pull shows one live line
       instead of scrolling hundreds of raw ``[bytes]`` lines (0.11 dogfood
       papercut). Discrete status lines route through :meth:`write_line` so
-      they don't shred the bar.
+      they don't shred the bar. ``isatty()`` alone selects this mode;
+      ``NO_COLOR`` keeps the bar but drops ANSI (``\\r`` + space-pad erase)
+      rather than falling back to the machine flood.
 
     Two robustness properties, both from codex review on PR #1259:
 
@@ -136,15 +138,19 @@ class _ProgressTracker:
         self._total = max(0, int(total))
         self._last_emit = 0.0
         # Capture the stream once so the isatty() decision and every write
-        # target the same object even if sys.stdout is later swapped. A
-        # human terminal gets the in-place bar; anything piped keeps the
-        # machine ``[bytes] D/T`` contract. Same predicate as the puller's
-        # own ``is_tty`` banner styling so the two agree.
+        # target the same object even if sys.stdout is later swapped.
         self._out = sys.stdout
-        self._is_tty = (
-            bool(self._out) and self._out.isatty() and "NO_COLOR" not in os.environ
-        )
+        # A human terminal gets the in-place bar; anything piped keeps the
+        # machine ``[bytes] D/T`` contract. The TTY-vs-machine choice is
+        # ``isatty()`` ALONE — ``NO_COLOR`` must NOT push an interactive user
+        # back to the byte flood this change removes (codex #1259). NO_COLOR
+        # only downgrades *styling*: an escape-free ``\r`` + space-pad bar
+        # instead of the ``\x1b[2K`` erase (``\r`` is a carriage return, not
+        # color, so a colorless progress bar is still fine under NO_COLOR).
+        self._is_tty = bool(self._out) and self._out.isatty()
+        self._ansi = self._is_tty and "NO_COLOR" not in os.environ
         self._bar_live = False  # a bar is currently drawn on the TTY row
+        self._last_line_len = 0  # width of the current row (no-ANSI erase)
 
     def add(self, delta: int) -> None:
         if delta <= 0:
@@ -176,23 +182,29 @@ class _ProgressTracker:
         else:
             print(f"  [bytes] {done}/{total}", file=self._out, flush=True)
 
-    def _draw_bar(self, done: int, total: int) -> None:
-        """Redraw the single in-place progress bar (TTY only, no newline).
-        Caller holds ``self._lock``.
+    def _inplace(self, text: str, newline: bool) -> None:
+        """Redraw ``text`` on the current terminal row (caller holds the
+        lock). With styling allowed, uses the ANSI erase-line; under
+        ``NO_COLOR`` falls back to a carriage return + trailing-space pad so
+        a shorter line still overwrites a longer predecessor without emitting
+        any escape sequence."""
+        if self._ansi:
+            body = f"\r\x1b[2K{text}"
+        else:
+            pad = " " * max(0, self._last_line_len - len(text))
+            body = f"\r{text}{pad}"
+        self._last_line_len = 0 if newline else len(text)
+        print(body, end=("\n" if newline else ""), file=self._out, flush=True)
 
-        Leads with ``\\r\\x1b[2K`` (carriage-return + erase-line) so a
-        shorter redraw can't leave stale tail characters from a longer one.
-        """
+    def _draw_bar(self, done: int, total: int, newline: bool = False) -> None:
+        """Redraw the single in-place progress bar (TTY only). Caller holds
+        ``self._lock``. ``newline=True`` finalizes the row (used by flush)."""
         pct = int(done * 100 / total) if total else 0
         width = 24
         filled = int(width * done / total) if total else 0
         bar = "█" * filled + "░" * (width - filled)
-        print(
-            f"\r\x1b[2K  ↓ {pct:3d}%  [{bar}]  {done / 1e6:.0f}/{total / 1e6:.0f} MB",
-            end="",
-            file=self._out,
-            flush=True,
-        )
+        text = f"  ↓ {pct:3d}%  [{bar}]  {done / 1e6:.0f}/{total / 1e6:.0f} MB"
+        self._inplace(text, newline)
 
     def write_line(self, text: str) -> None:
         """Print a discrete status line without corrupting the live bar.
@@ -204,10 +216,13 @@ class _ProgressTracker:
         """
         with self._lock:
             if self._is_tty and self._bar_live:
-                print(f"\r\x1b[2K{text}", file=self._out, flush=True)
+                # Erase the live bar and print the line on its own row (ANSI
+                # erase, or \r + pad under NO_COLOR); next heartbeat redraws.
+                self._inplace(text, newline=True)
                 self._bar_live = False
             else:
                 print(text, file=self._out)
+                self._last_line_len = 0
 
     def subtract(self, delta: int) -> None:
         """Roll back optimistic R2-chunk credits when the file fails
@@ -234,8 +249,9 @@ class _ProgressTracker:
             done = min(self._done, self._total)
             if self._is_tty:
                 if self._bar_live or done > 0:
-                    self._draw_bar(done, self._total)
-                    print(file=self._out, flush=True)  # newline finalizes
+                    # Finalize the bar with a trailing newline so the next
+                    # banner starts on a clean row.
+                    self._draw_bar(done, self._total, newline=True)
                     self._bar_live = False
             else:
                 print(f"  [bytes] {done}/{self._total}", file=self._out, flush=True)

--- a/vllm_mlx/_mirror.py
+++ b/vllm_mlx/_mirror.py
@@ -229,18 +229,22 @@ class _ProgressTracker:
         process's default controlling terminal — which can differ from
         ``self._out`` when stdout is redirected to a different-width PTY; the
         bar would then wrap despite the single-line guarantee (codex #1259).
-        So measure ``self._out`` directly. Precedence: an explicit
-        ``COLUMNS`` override (documented convention) wins; otherwise the
-        stream's own ``TIOCGWINSZ``; a stream with no real terminal
-        (``StringIO``, a pipe) falls back to 80.
+        So measure ``self._out`` directly.
+
+        Precedence: the stream's OWN live ``TIOCGWINSZ`` wins — it is the
+        true source of truth for wrapping, so a stale/oversized inherited
+        ``COLUMNS`` can't wrap the bar. ``COLUMNS`` is only a fallback for
+        streams with no queryable terminal (``StringIO``, a pipe); failing
+        that, 80.
         """
-        cols_env = os.environ.get("COLUMNS")
-        if cols_env and cols_env.isdigit():
-            return int(cols_env)
         try:
             return os.get_terminal_size(self._out.fileno()).columns
         except (OSError, ValueError, AttributeError):
-            return 80
+            pass
+        cols_env = os.environ.get("COLUMNS")
+        if cols_env and cols_env.isdigit():
+            return int(cols_env)
+        return 80
 
     def _draw_bar(self, done: int, total: int, newline: bool = False) -> None:
         """Redraw the single in-place progress bar (TTY only). Caller holds

--- a/vllm_mlx/_mirror.py
+++ b/vllm_mlx/_mirror.py
@@ -36,7 +36,6 @@ from __future__ import annotations
 import http.client
 import json
 import os
-import shutil
 import sys
 import threading
 import time
@@ -223,6 +222,26 @@ class _ProgressTracker:
         self._last_line_len = 0 if newline else len(text)
         print(body, end=("\n" if newline else ""), file=self._out, flush=True)
 
+    def _terminal_width(self) -> int:
+        """Column count of THIS output stream's terminal.
+
+        ``shutil.get_terminal_size`` measures ``sys.__stdout__`` — the
+        process's default controlling terminal — which can differ from
+        ``self._out`` when stdout is redirected to a different-width PTY; the
+        bar would then wrap despite the single-line guarantee (codex #1259).
+        So measure ``self._out`` directly. Precedence: an explicit
+        ``COLUMNS`` override (documented convention) wins; otherwise the
+        stream's own ``TIOCGWINSZ``; a stream with no real terminal
+        (``StringIO``, a pipe) falls back to 80.
+        """
+        cols_env = os.environ.get("COLUMNS")
+        if cols_env and cols_env.isdigit():
+            return int(cols_env)
+        try:
+            return os.get_terminal_size(self._out.fileno()).columns
+        except (OSError, ValueError, AttributeError):
+            return 80
+
     def _draw_bar(self, done: int, total: int, newline: bool = False) -> None:
         """Redraw the single in-place progress bar (TTY only). Caller holds
         ``self._io_lock``. ``newline=True`` finalizes the row (used by flush).
@@ -236,10 +255,7 @@ class _ProgressTracker:
         pct = int(done * 100 / total) if total else 0
         head = f"  ↓ {pct:3d}%  "
         tail = f"  {done / 1e6:.0f}/{total / 1e6:.0f} MB"
-        try:
-            cols = shutil.get_terminal_size().columns
-        except (ValueError, OSError):
-            cols = 80
+        cols = self._terminal_width()
         # Cells left for the bar after the head, the ``[]`` brackets, and tail.
         bar_cells = min(_BAR_MAX_CELLS, cols - len(head) - len(tail) - 2)
         if bar_cells >= _BAR_MIN_CELLS:

--- a/vllm_mlx/_mirror.py
+++ b/vllm_mlx/_mirror.py
@@ -98,11 +98,12 @@ _PROGRESS_HEARTBEAT_SECONDS = 0.5
 class _ProgressTracker:
     """Aggregate bytes-done counter for one R2 pull.
 
-    Workers call ``add(delta)`` for each chunk they write; the call is
-    cheap (atomic int add under a lock) and at most one in every
-    ``_PROGRESS_HEARTBEAT_SECONDS`` window renders a progress observation.
+    Workers call ``add(delta)`` for each chunk they write; at most one call
+    per ``_PROGRESS_HEARTBEAT_SECONDS`` window renders a progress
+    observation.
 
-    Two render modes, chosen once at construction from ``stdout``:
+    Two render modes, chosen once at construction from the captured
+    ``stdout``:
 
     * **non-TTY** (the desktop app's captured pipe, a redirected log, or
       pytest capture) — emit the machine-readable ``[bytes] D/T`` line the
@@ -114,27 +115,40 @@ class _ProgressTracker:
       papercut). Discrete status lines route through :meth:`write_line` so
       they don't shred the bar.
 
-    Prints are flushed eagerly and serialized on ``_io_lock`` so a redraw
-    fired from a worker thread and a completion line printed from the main
-    dispatcher thread can't interleave mid-escape-sequence.
+    Two robustness properties, both from codex review on PR #1259:
+
+    * **Single lock guards counters AND rendering.** A render happens while
+      the lock is held, immediately after the byte-count update — so
+      renders fire in lock-acquisition (== byte-count) order and the bar
+      can never regress to a stale value when two workers heartbeat close
+      together. The lock is held across the tiny, throttled (≤2/s) terminal
+      write; contention is negligible (a decode-loop's chunk accounting was
+      already serialized on this lock).
+    * **The output stream is captured once** (``self._out``) and used for
+      both the ``isatty()`` decision and every write, so swapping or
+      redirecting ``sys.stdout`` after construction can't send ANSI to a
+      pipe or machine heartbeats to a terminal.
     """
 
     def __init__(self, total: int = 0) -> None:
-        self._lock = threading.Lock()  # guards the byte counters
-        self._io_lock = threading.Lock()  # serializes terminal writes
+        self._lock = threading.Lock()  # guards the counters AND rendering
         self._done = 0
         self._total = max(0, int(total))
         self._last_emit = 0.0
-        # A human terminal gets the in-place bar; anything piped keeps the
+        # Capture the stream once so the isatty() decision and every write
+        # target the same object even if sys.stdout is later swapped. A
+        # human terminal gets the in-place bar; anything piped keeps the
         # machine ``[bytes] D/T`` contract. Same predicate as the puller's
         # own ``is_tty`` banner styling so the two agree.
-        self._is_tty = sys.stdout.isatty() and "NO_COLOR" not in os.environ
+        self._out = sys.stdout
+        self._is_tty = (
+            bool(self._out) and self._out.isatty() and "NO_COLOR" not in os.environ
+        )
         self._bar_live = False  # a bar is currently drawn on the TTY row
 
     def add(self, delta: int) -> None:
         if delta <= 0:
             return
-        emit: tuple[int, int] | None = None
         with self._lock:
             self._done += int(delta)
             if self._total <= 0:
@@ -144,28 +158,27 @@ class _ProgressTracker:
                 self._last_emit = now
                 # Codex R3 BLOCKING on PR #682: clamp DISPLAY at total so
                 # an oversized/corrupt R2 stream (Content-Length lies,
-                # proxy injects extra bytes) can't emit ``[bytes] 1200/1000``
+                # proxy injects extra bytes) can't render ``1200/1000``
                 # before the final-size-mismatch rollback runs. Internal
                 # ``_done`` stays raw so ``subtract`` continues to balance
                 # against the actual credit (rollback of raw 1200 from
                 # raw 1200 leaves _done=0 → next ``add(1000)`` from HF
-                # lands at clean 1000/1000).
-                emit = (min(self._done, self._total), self._total)
-        if emit is not None:
-            self._emit(*emit)
+                # lands at clean 1000/1000). Render under the lock so
+                # concurrent workers emit in byte-count order and the bar
+                # never regresses (codex #1259 BLOCKING).
+                self._render(min(self._done, self._total), self._total)
 
-    def _emit(self, done: int, total: int) -> None:
-        """Render one progress observation in the mode picked at init."""
-        with self._io_lock:
-            if self._is_tty:
-                self._draw_bar(done, total)
-                self._bar_live = True
-            else:
-                print(f"  [bytes] {done}/{total}", flush=True)
+    def _render(self, done: int, total: int) -> None:
+        """Render one observation. Caller MUST hold ``self._lock``."""
+        if self._is_tty:
+            self._draw_bar(done, total)
+            self._bar_live = True
+        else:
+            print(f"  [bytes] {done}/{total}", file=self._out, flush=True)
 
-    @staticmethod
-    def _draw_bar(done: int, total: int) -> None:
+    def _draw_bar(self, done: int, total: int) -> None:
         """Redraw the single in-place progress bar (TTY only, no newline).
+        Caller holds ``self._lock``.
 
         Leads with ``\\r\\x1b[2K`` (carriage-return + erase-line) so a
         shorter redraw can't leave stale tail characters from a longer one.
@@ -177,6 +190,7 @@ class _ProgressTracker:
         print(
             f"\r\x1b[2K  ↓ {pct:3d}%  [{bar}]  {done / 1e6:.0f}/{total / 1e6:.0f} MB",
             end="",
+            file=self._out,
             flush=True,
         )
 
@@ -185,15 +199,15 @@ class _ProgressTracker:
 
         On a TTY, erase the in-place bar first and print ``text`` on its own
         row; the next heartbeat redraws the bar below it. On a non-TTY
-        stdout this is a plain ``print`` — byte-identical to the old
+        stream this is a plain ``print`` — byte-identical to the old
         ``_print_dim`` path the desktop parser and tests observe.
         """
-        with self._io_lock:
+        with self._lock:
             if self._is_tty and self._bar_live:
-                print(f"\r\x1b[2K{text}", flush=True)
+                print(f"\r\x1b[2K{text}", file=self._out, flush=True)
                 self._bar_live = False
             else:
-                print(text)
+                print(text, file=self._out)
 
     def subtract(self, delta: int) -> None:
         """Roll back optimistic R2-chunk credits when the file fails
@@ -218,14 +232,13 @@ class _ProgressTracker:
                 return
             # Clamp display at total — same rationale as ``add()``.
             done = min(self._done, self._total)
-        with self._io_lock:
             if self._is_tty:
                 if self._bar_live or done > 0:
                     self._draw_bar(done, self._total)
-                    print(flush=True)  # newline finalizes the bar row
+                    print(file=self._out, flush=True)  # newline finalizes
                     self._bar_live = False
             else:
-                print(f"  [bytes] {done}/{self._total}", flush=True)
+                print(f"  [bytes] {done}/{self._total}", file=self._out, flush=True)
 
 
 def _rollback_credits(

--- a/vllm_mlx/_mirror.py
+++ b/vllm_mlx/_mirror.py
@@ -117,15 +117,18 @@ class _ProgressTracker:
       ``NO_COLOR`` keeps the bar but drops ANSI (``\\r`` + space-pad erase)
       rather than falling back to the machine flood.
 
-    Two robustness properties, both from codex review on PR #1259:
+    Three robustness properties, all from codex review on PR #1259:
 
-    * **Single lock guards counters AND rendering.** A render happens while
-      the lock is held, immediately after the byte-count update — so
-      renders fire in lock-acquisition (== byte-count) order and the bar
-      can never regress to a stale value when two workers heartbeat close
-      together. The lock is held across the tiny, throttled (≤2/s) terminal
-      write; contention is negligible (a decode-loop's chunk accounting was
-      already serialized on this lock).
+    * **Two locks: counters (``_lock``) vs rendering (``_io_lock``).** Chunk
+      accounting stays on the fast ``_lock``; the potentially-blocking
+      terminal/pipe write happens with only ``_io_lock`` held, so a slow or
+      backpressured stdout can never stall a worker updating its byte count.
+    * **Renders read the freshest count, and can't regress.** ``_emit``
+      re-reads ``_done`` under a brief ``_lock`` nested inside ``_io_lock``,
+      so serialized renders are monotonic (each reads a ``_done`` ≥ the
+      previous render's) — no out-of-order/stale bar even when two workers
+      heartbeat close together. Lock order is always ``_io_lock`` → ``_lock``
+      (never the reverse while held), so there is no deadlock.
     * **The output stream is captured once** (``self._out``) and used for
       both the ``isatty()`` decision and every write, so swapping or
       redirecting ``sys.stdout`` after construction can't send ANSI to a
@@ -133,7 +136,8 @@ class _ProgressTracker:
     """
 
     def __init__(self, total: int = 0) -> None:
-        self._lock = threading.Lock()  # guards the counters AND rendering
+        self._lock = threading.Lock()  # guards the byte counters (fast)
+        self._io_lock = threading.Lock()  # serializes rendering + bar state
         self._done = 0
         self._total = max(0, int(total))
         self._last_emit = 0.0
@@ -149,12 +153,14 @@ class _ProgressTracker:
         # color, so a colorless progress bar is still fine under NO_COLOR).
         self._is_tty = bool(self._out) and self._out.isatty()
         self._ansi = self._is_tty and "NO_COLOR" not in os.environ
+        # Render state — guarded by ``_io_lock`` (never ``_lock``).
         self._bar_live = False  # a bar is currently drawn on the TTY row
         self._last_line_len = 0  # width of the current row (no-ANSI erase)
 
     def add(self, delta: int) -> None:
         if delta <= 0:
             return
+        do_emit = False
         with self._lock:
             self._done += int(delta)
             if self._total <= 0:
@@ -162,29 +168,43 @@ class _ProgressTracker:
             now = time.monotonic()
             if now - self._last_emit >= _PROGRESS_HEARTBEAT_SECONDS:
                 self._last_emit = now
-                # Codex R3 BLOCKING on PR #682: clamp DISPLAY at total so
-                # an oversized/corrupt R2 stream (Content-Length lies,
-                # proxy injects extra bytes) can't render ``1200/1000``
-                # before the final-size-mismatch rollback runs. Internal
-                # ``_done`` stays raw so ``subtract`` continues to balance
-                # against the actual credit (rollback of raw 1200 from
-                # raw 1200 leaves _done=0 → next ``add(1000)`` from HF
-                # lands at clean 1000/1000). Render under the lock so
-                # concurrent workers emit in byte-count order and the bar
-                # never regresses (codex #1259 BLOCKING).
-                self._render(min(self._done, self._total), self._total)
+                do_emit = True
+        # Render OUTSIDE the counter lock (codex #1259): a slow / backpressured
+        # stdout must not stall every worker's chunk accounting. ``_emit``
+        # re-reads the freshest byte count under a brief counter-lock nested
+        # inside ``_io_lock``, so serialized renders stay monotonic (each
+        # reads a ``_done`` ≥ the previous render's) and never regress.
+        if do_emit:
+            self._emit()
 
-    def _render(self, done: int, total: int) -> None:
-        """Render one observation. Caller MUST hold ``self._lock``."""
-        if self._is_tty:
-            self._draw_bar(done, total)
-            self._bar_live = True
-        else:
-            print(f"  [bytes] {done}/{total}", file=self._out, flush=True)
+    def _emit(self) -> None:
+        """Render the current progress under ``_io_lock``.
+
+        The byte snapshot is read under a brief ``_lock`` nested inside
+        ``_io_lock``; the potentially-blocking terminal/pipe write then runs
+        with only ``_io_lock`` held, so it never stalls a worker updating
+        counters. Lock order ``_io_lock`` → ``_lock`` matches :meth:`flush`.
+        """
+        with self._io_lock:
+            with self._lock:
+                if self._total <= 0:
+                    return
+                # Clamp DISPLAY at total (codex R3 on PR #682): an oversized
+                # / corrupt R2 stream (Content-Length lies, proxy injects
+                # extra bytes) must not render ``1200/1000`` before the
+                # final-size-mismatch rollback runs. ``_done`` stays raw so
+                # ``subtract`` still balances against the actual credit.
+                done = min(self._done, self._total)
+                total = self._total
+            if self._is_tty:
+                self._draw_bar(done, total)
+                self._bar_live = True
+            else:
+                print(f"  [bytes] {done}/{total}", file=self._out, flush=True)
 
     def _inplace(self, text: str, newline: bool) -> None:
-        """Redraw ``text`` on the current terminal row (caller holds the
-        lock). With styling allowed, uses the ANSI erase-line; under
+        """Redraw ``text`` on the current terminal row (caller holds
+        ``_io_lock``). With styling allowed, uses the ANSI erase-line; under
         ``NO_COLOR`` falls back to a carriage return + trailing-space pad so
         a shorter line still overwrites a longer predecessor without emitting
         any escape sequence."""
@@ -198,7 +218,7 @@ class _ProgressTracker:
 
     def _draw_bar(self, done: int, total: int, newline: bool = False) -> None:
         """Redraw the single in-place progress bar (TTY only). Caller holds
-        ``self._lock``. ``newline=True`` finalizes the row (used by flush)."""
+        ``self._io_lock``. ``newline=True`` finalizes the row (used by flush)."""
         pct = int(done * 100 / total) if total else 0
         width = 24
         filled = int(width * done / total) if total else 0
@@ -214,7 +234,7 @@ class _ProgressTracker:
         stream this is a plain ``print`` — byte-identical to the old
         ``_print_dim`` path the desktop parser and tests observe.
         """
-        with self._lock:
+        with self._io_lock:
             if self._is_tty and self._bar_live:
                 # Erase the live bar and print the line on its own row (ANSI
                 # erase, or \r + pad under NO_COLOR); next heartbeat redraws.
@@ -242,19 +262,21 @@ class _ProgressTracker:
         throttle window — the last 500 ms of bytes would otherwise be
         invisible. On a TTY this finalizes the in-place bar with a trailing
         newline so the next banner starts on a clean row."""
-        with self._lock:
-            if self._total <= 0:
-                return
-            # Clamp display at total — same rationale as ``add()``.
-            done = min(self._done, self._total)
+        with self._io_lock:
+            with self._lock:
+                if self._total <= 0:
+                    return
+                # Clamp display at total — same rationale as ``_emit``.
+                done = min(self._done, self._total)
+                total = self._total
             if self._is_tty:
                 if self._bar_live or done > 0:
                     # Finalize the bar with a trailing newline so the next
                     # banner starts on a clean row.
-                    self._draw_bar(done, self._total, newline=True)
+                    self._draw_bar(done, total, newline=True)
                     self._bar_live = False
             else:
-                print(f"  [bytes] {done}/{self._total}", file=self._out, flush=True)
+                print(f"  [bytes] {done}/{total}", file=self._out, flush=True)
 
 
 def _rollback_credits(

--- a/vllm_mlx/_mirror.py
+++ b/vllm_mlx/_mirror.py
@@ -36,6 +36,7 @@ from __future__ import annotations
 import http.client
 import json
 import os
+import shutil
 import sys
 import threading
 import time
@@ -93,6 +94,12 @@ _CHUNK_BYTES = 8 * 1024 * 1024
 # concurrent pulls in the same process don't trample each other's totals
 # (codex R1 BLOCKING on PR #682).
 _PROGRESS_HEARTBEAT_SECONDS = 0.5
+
+# In-place TTY bar sizing. The bar shrinks to the terminal width; below the
+# minimum it's dropped for a compact percentage + bytes readout so a narrow
+# terminal never wraps a redraw onto a second row (codex #1259).
+_BAR_MAX_CELLS = 24
+_BAR_MIN_CELLS = 8
 
 
 class _ProgressTracker:
@@ -218,12 +225,31 @@ class _ProgressTracker:
 
     def _draw_bar(self, done: int, total: int, newline: bool = False) -> None:
         """Redraw the single in-place progress bar (TTY only). Caller holds
-        ``self._io_lock``. ``newline=True`` finalizes the row (used by flush)."""
+        ``self._io_lock``. ``newline=True`` finalizes the row (used by flush).
+
+        Width-adaptive: the whole line is kept within the terminal so a
+        narrow TTY doesn't wrap a redraw onto a second row and defeat the
+        single-line guarantee (codex #1259). The bar shrinks to fit; below a
+        minimum it's dropped for a compact percentage + bytes readout; and the
+        line is hard-capped at the column count as a final backstop.
+        """
         pct = int(done * 100 / total) if total else 0
-        width = 24
-        filled = int(width * done / total) if total else 0
-        bar = "█" * filled + "░" * (width - filled)
-        text = f"  ↓ {pct:3d}%  [{bar}]  {done / 1e6:.0f}/{total / 1e6:.0f} MB"
+        head = f"  ↓ {pct:3d}%  "
+        tail = f"  {done / 1e6:.0f}/{total / 1e6:.0f} MB"
+        try:
+            cols = shutil.get_terminal_size().columns
+        except (ValueError, OSError):
+            cols = 80
+        # Cells left for the bar after the head, the ``[]`` brackets, and tail.
+        bar_cells = min(_BAR_MAX_CELLS, cols - len(head) - len(tail) - 2)
+        if bar_cells >= _BAR_MIN_CELLS:
+            filled = int(bar_cells * done / total) if total else 0
+            text = f"{head}[{'█' * filled}{'░' * (bar_cells - filled)}]{tail}"
+        else:
+            # Too narrow for a legible bar — percentage + bytes only.
+            text = f"  ↓ {pct:3d}%{tail}"
+        if cols > 0 and len(text) > cols:
+            text = text[:cols]  # backstop: a redraw never exceeds one row
         self._inplace(text, newline)
 
     def write_line(self, text: str) -> None:

--- a/vllm_mlx/_mirror.py
+++ b/vllm_mlx/_mirror.py
@@ -100,16 +100,36 @@ class _ProgressTracker:
 
     Workers call ``add(delta)`` for each chunk they write; the call is
     cheap (atomic int add under a lock) and at most one in every
-    ``_PROGRESS_HEARTBEAT_SECONDS`` window emits a ``[bytes] D/T``
-    line to stdout. Print is flushed eagerly so a non-TTY stdout
-    (desktop pipe) sees the line as soon as it's emitted.
+    ``_PROGRESS_HEARTBEAT_SECONDS`` window renders a progress observation.
+
+    Two render modes, chosen once at construction from ``stdout``:
+
+    * **non-TTY** (the desktop app's captured pipe, a redirected log, or
+      pytest capture) — emit the machine-readable ``[bytes] D/T`` line the
+      desktop's ``DownloadProgress`` parser and the mirror regression tests
+      depend on. Unchanged from the original heartbeat.
+    * **TTY** (a human running bare ``rapid-mlx chat``) — redraw a single
+      in-place bar with ``\\r`` so a multi-GB cold pull shows one live line
+      instead of scrolling hundreds of raw ``[bytes]`` lines (0.11 dogfood
+      papercut). Discrete status lines route through :meth:`write_line` so
+      they don't shred the bar.
+
+    Prints are flushed eagerly and serialized on ``_io_lock`` so a redraw
+    fired from a worker thread and a completion line printed from the main
+    dispatcher thread can't interleave mid-escape-sequence.
     """
 
     def __init__(self, total: int = 0) -> None:
-        self._lock = threading.Lock()
+        self._lock = threading.Lock()  # guards the byte counters
+        self._io_lock = threading.Lock()  # serializes terminal writes
         self._done = 0
         self._total = max(0, int(total))
         self._last_emit = 0.0
+        # A human terminal gets the in-place bar; anything piped keeps the
+        # machine ``[bytes] D/T`` contract. Same predicate as the puller's
+        # own ``is_tty`` banner styling so the two agree.
+        self._is_tty = sys.stdout.isatty() and "NO_COLOR" not in os.environ
+        self._bar_live = False  # a bar is currently drawn on the TTY row
 
     def add(self, delta: int) -> None:
         if delta <= 0:
@@ -132,8 +152,48 @@ class _ProgressTracker:
                 # lands at clean 1000/1000).
                 emit = (min(self._done, self._total), self._total)
         if emit is not None:
-            done, total = emit
-            print(f"  [bytes] {done}/{total}", flush=True)
+            self._emit(*emit)
+
+    def _emit(self, done: int, total: int) -> None:
+        """Render one progress observation in the mode picked at init."""
+        with self._io_lock:
+            if self._is_tty:
+                self._draw_bar(done, total)
+                self._bar_live = True
+            else:
+                print(f"  [bytes] {done}/{total}", flush=True)
+
+    @staticmethod
+    def _draw_bar(done: int, total: int) -> None:
+        """Redraw the single in-place progress bar (TTY only, no newline).
+
+        Leads with ``\\r\\x1b[2K`` (carriage-return + erase-line) so a
+        shorter redraw can't leave stale tail characters from a longer one.
+        """
+        pct = int(done * 100 / total) if total else 0
+        width = 24
+        filled = int(width * done / total) if total else 0
+        bar = "█" * filled + "░" * (width - filled)
+        print(
+            f"\r\x1b[2K  ↓ {pct:3d}%  [{bar}]  {done / 1e6:.0f}/{total / 1e6:.0f} MB",
+            end="",
+            flush=True,
+        )
+
+    def write_line(self, text: str) -> None:
+        """Print a discrete status line without corrupting the live bar.
+
+        On a TTY, erase the in-place bar first and print ``text`` on its own
+        row; the next heartbeat redraws the bar below it. On a non-TTY
+        stdout this is a plain ``print`` — byte-identical to the old
+        ``_print_dim`` path the desktop parser and tests observe.
+        """
+        with self._io_lock:
+            if self._is_tty and self._bar_live:
+                print(f"\r\x1b[2K{text}", flush=True)
+                self._bar_live = False
+            else:
+                print(text)
 
     def subtract(self, delta: int) -> None:
         """Roll back optimistic R2-chunk credits when the file fails
@@ -149,17 +209,23 @@ class _ProgressTracker:
             self._done = max(0, self._done - int(delta))
 
     def flush(self) -> None:
-        """Emit a final heartbeat at the end of a pull regardless of
+        """Emit a final observation at the end of a pull regardless of the
         throttle window — the last 500 ms of bytes would otherwise be
-        invisible to the UI."""
-        emit: tuple[int, int] | None = None
+        invisible. On a TTY this finalizes the in-place bar with a trailing
+        newline so the next banner starts on a clean row."""
         with self._lock:
-            if self._total > 0:
-                # Clamp display at total — same rationale as ``add()``.
-                emit = (min(self._done, self._total), self._total)
-        if emit is not None:
-            done, total = emit
-            print(f"  [bytes] {done}/{total}", flush=True)
+            if self._total <= 0:
+                return
+            # Clamp display at total — same rationale as ``add()``.
+            done = min(self._done, self._total)
+        with self._io_lock:
+            if self._is_tty:
+                if self._bar_live or done > 0:
+                    self._draw_bar(done, self._total)
+                    print(flush=True)  # newline finalizes the bar row
+                    self._bar_live = False
+            else:
+                print(f"  [bytes] {done}/{self._total}", flush=True)
 
 
 def _rollback_credits(
@@ -1547,7 +1613,12 @@ def download_with_mirror_fallback(
                     # users aren't surprised when the outer caller falls
                     # back to ``snapshot_download``.
                     tag = f"{DIM}miss (will retry via HF snapshot_download){RESET}"
-                _print_dim(
+                # Route through the tracker (not ``_print_dim``): on a TTY it
+                # erases the in-place byte bar before printing this line and
+                # lets the next heartbeat redraw it below, so the completion
+                # lines and the live bar don't clobber each other. On a
+                # non-TTY stdout this is a plain print — unchanged output.
+                progress_tracker.write_line(
                     f"  {DIM}[{completed}/{total_files_planned}]{RESET} "
                     f"{_safe_display_name(fname)} {tag}"
                 )

--- a/vllm_mlx/first_run.py
+++ b/vllm_mlx/first_run.py
@@ -37,8 +37,12 @@ from pathlib import Path
 FIRST_RUN_MODEL = "qwen3.5-4b-4bit"
 
 # Human-facing one-time download size for FIRST_RUN_MODEL. A fixed string (not
-# a network probe) so the "no model specified" notice is instant.
-FIRST_RUN_MODEL_SIZE = "~2.5 GB"
+# a network probe) so the "no model specified" notice is instant. Anchored to
+# the actual snapshot size of ``mlx-community/Qwen3.5-4B-MLX-4bit`` — 3.061 GB
+# decimal (2.85 GiB), i.e. the ``3061132920`` bytes the download bar counts up
+# to. The old "~2.5 GB" undershot the real download by ~0.5 GB (0.11 dogfood).
+# If the starter checkpoint is re-quantized, re-probe and update this.
+FIRST_RUN_MODEL_SIZE = "~3.1 GB"
 
 # Preference order when several coding agents are detected: claude-code is the
 # ICP, so it leads. Others follow in a stable order.


### PR DESCRIPTION
## Why

Two cold-first-run download papercuts from the 0.11 dogfood, both on the very first thing a brand-new user sees — the multi-GB starter download that fires on their first `rapid-mlx chat`:

1. **The download scrolled ~366 raw `[bytes] 73951746/3061132920` lines** down the terminal. Those are the desktop app's machine-readable `DownloadProgress` heartbeat (`_mirror._ProgressTracker`), fed to `applyDiskObservation`/`setTotalBytes` so the GUI bar advances during a long single-shard window. On a bare CLI terminal they're just noise — a wall of raw byte counts instead of a progress bar.
2. **`FIRST_RUN_MODEL_SIZE` claimed "~2.5 GB"** but the real snapshot of `mlx-community/Qwen3.5-4B-MLX-4bit` is **3.061 GB** (2.85 GiB) — the `3061132920` bytes the download counts up to. The "no model specified" notice under-promised the download by ~0.5 GB.

## What

**Fix 1 — `_ProgressTracker` renders per output sink.** Mode chosen once at construction from `sys.stdout.isatty()` (same predicate as the puller's existing banner styling; `NO_COLOR` forces the machine path):

- **non-TTY** (desktop's captured subprocess pipe, a redirected log, pytest capture) — **unchanged**: emit `[bytes] D/T`. The desktop parser and the two `test_mirror_pull.py` heartbeat regression tests observe the identical format.
- **TTY** (a human at a terminal) — redraw **one** in-place bar with `\r\x1b[2K` (carriage-return + erase-line): `  ↓  42%  [██████████░░░░░░░░░░░░░░]  1286/3061 MB`. The per-file `[N/M] file R2 (X MB)` completion lines route through a new `write_line`, which erases the live bar first and prints the line on its own row (the next heartbeat redraws the bar below it) — so completion lines and the bar don't clobber each other.

A **single lock** guards both the counters and rendering: the render fires while the lock is held, right after the byte-count update, so concurrent streaming **workers** and the **dispatcher** thread emit in byte-count order — the bar can never regress to a stale value, and a redraw and a completion line can't interleave mid-escape-sequence. The lock is held across the throttled (≤2/s) terminal write; contention is negligible (chunk accounting already serialized on it). The output stream is **captured once at construction** and used for both the `isatty()` decision and every write, so a later `sys.stdout` swap can't send ANSI to a pipe or heartbeats to a terminal. Both properties came out of codex review (single-lock = BLOCKING, captured-stream = NIT).

**Fix 2 — correct the starter size string** to `"~3.1 GB"`, anchored in a comment to the real `3061132920`-byte snapshot so a future re-quant re-probes it. Static string (no network probe) so the notice stays instant.

## Design notes

- **The `[bytes] D/T` contract is load-bearing for the desktop app** — this PR does not touch it. The human bar is strictly additive on the TTY branch the desktop never takes.
- **`\x1b[2K` (erase entire line)** rather than `\x1b[K` (erase-to-EOL) so a shorter redraw can't leave stale tail characters from a longer one, regardless of cursor column.
- **`NO_COLOR` keeps the bar, drops the ANSI.** TTY-vs-machine is decided by `isatty()` alone — `NO_COLOR` must not route an interactive user back to the `[bytes]` flood (that's who most wants clean output). Under `NO_COLOR` the bar still redraws in place via `\r` + a trailing-space pad (no `\x1b[2K`), emitting zero escape sequences.
- **`total == 0` stays silent** in both modes (HF didn't expose sizes) — preserves the desktop's divide-by-zero guard and the `test_bytes_heartbeat_skipped_when_total_unknown` contract.
- **Display clamps at 100%** on both paths — an oversized/corrupt stream (Content-Length lies) can't render `150%` before the final-size rollback runs.
- Scope held to the download UX: the HF unauthenticated-access warning (a third-party `huggingface_hub` message) and the first-run funnel telemetry are intentionally **not** in this PR.

## Test plan

- [x] New `tests/test_mirror_progress_tty.py` (6 tests, hermetic, no network): non-TTY keeps `[bytes] D/T` and leaks no `\r`/`↓`/`\x1b`; TTY draws a single `\r` bar (no `[bytes]`), finalizes with a newline on `flush`; oversized stream clamps at 100%; `write_line` erases the bar then prints on a TTY and is a byte-identical plain `print` on a pipe; `total==0` stays silent on a TTY.
- [x] Regression: `tests/test_mirror_pull.py` full suite = **63 passed** — the `[bytes] D/T` machine format (heartbeat emitted, skipped-when-unknown, per-pull isolation) is unchanged on the non-TTY path pytest capture takes.
- [x] Regression: `tests/test_first_run_guide.py` = **24 passed** — the guide asserts against the `FIRST_RUN_MODEL_SIZE` constant, not a literal, so the size correction is safe.
- [x] Authoritative size confirmed via `huggingface_hub.model_info(files_metadata=True)`: `mlx-community/Qwen3.5-4B-MLX-4bit` sums to `3061132920` bytes = 3.061 GB.
- [x] Adapted the existing `test_progress_tracker_clamps_display_at_total` to build the tracker inside `redirect_stdout` (capture-at-construction semantics); the clamp behavior it asserts is unchanged.
- [x] **Fresh-wheel dogfood (G9):** built the wheel, installed into a clean py3.12 venv (`rapid-mlx 0.11.0`, all deps), and drove the wheel-installed `_ProgressTracker` under a **real PTY** and a **pipe**. TTY → one in-place bar (`↓ 100% [████████████████████████] 402/402 MB`), 28 `\r` redraws, **0 `[bytes]` lines**, 10 permanent lines (vs the old ~366). Pipe → 15 `[bytes] D/T` lines, **0 bar glyphs** — desktop parser format intact. `NO_COLOR=1` TTY → still one in-place bar, **0 `\x1b[2K` escapes**, **0 `[bytes]` lines**.
- [x] `ruff check` + `ruff format` clean on all changed files.

## Scope

`skip-version-bump` — onboarding UX only; batches into the pending 0.11.1 bump-only release alongside the other post-0.11.0 merges (#1237, #1243, …).
