### PR TITLE
fix(first-run): silence HF unauthenticated-download advisory (#3)

### DIFF
--- a/tests/test_hf_logging.py
+++ b/tests/test_hf_logging.py
@@ -1,0 +1,141 @@
+# SPDX-License-Identifier: Apache-2.0
+"""The HF unauthenticated-download advisory must be dropped — and *only* it.
+
+huggingface_hub logs a server-sent ``X-HF-Warning`` advisory ("You are
+sending unauthenticated requests … set a HF_TOKEN …") at WARNING level
+from ``huggingface_hub.utils._http`` on the first anonymous Hub request.
+That single stray line reads like an error to a naive first-run user
+(0.11 dogfood papercut #3). ``vllm_mlx._hf_logging`` drops it with a
+narrow, fail-open filter installed on the exact emitting logger.
+
+These are hermetic unit tests of that filter and its installer — no
+network, no huggingface_hub import. A capturing handler stands in for the
+real ``_warn_on_warning_headers`` emitter: we log the same message on the
+same logger and assert it never reaches the handler, while every other
+record still does.
+"""
+
+from __future__ import annotations
+
+import io
+import logging
+
+import pytest
+
+from vllm_mlx._hf_logging import (
+    _HF_HTTP_LOGGER,
+    _DropUnauthenticatedAdvisory,
+    silence_hf_unauthenticated_warning,
+)
+
+# The exact line huggingface_hub 1.x surfaces from the server's
+# ``X-HF-Warning`` header on an unauthenticated request (captured live).
+_REAL_ADVISORY = (
+    "You are sending unauthenticated requests to the HF Hub. Please set a "
+    "HF_TOKEN to enable higher rate limits and faster downloads."
+)
+
+
+@pytest.fixture
+def hf_http_logger():
+    """Yield the real HF http logger wired to a captured StringIO handler,
+    restoring its filters / handlers / level / propagate afterwards so the
+    process-global install never leaks between tests."""
+    logger = logging.getLogger(_HF_HTTP_LOGGER)
+    saved = (
+        list(logger.filters),
+        list(logger.handlers),
+        logger.level,
+        logger.propagate,
+    )
+    buf = io.StringIO()
+    handler = logging.StreamHandler(buf)
+    logger.handlers = [handler]
+    logger.filters = []
+    logger.setLevel(logging.WARNING)
+    logger.propagate = False
+    try:
+        yield logger, buf
+    finally:
+        logger.filters, logger.handlers, logger.level, logger.propagate = (
+            saved[0],
+            saved[1],
+            saved[2],
+            saved[3],
+        )
+
+
+def _record(msg, *args):
+    return logging.LogRecord(
+        _HF_HTTP_LOGGER, logging.WARNING, __file__, 1, msg, args, None
+    )
+
+
+# --- the filter predicate, tested directly -------------------------------
+
+
+def test_filter_drops_the_real_advisory():
+    filt = _DropUnauthenticatedAdvisory()
+    assert filt.filter(_record(_REAL_ADVISORY)) is False
+
+
+@pytest.mark.parametrize(
+    "msg",
+    [
+        # Real HF errors / warnings we MUST keep visible: none carry the
+        # "unauthenticated" + token/rate-limit wording together.
+        "401 Client Error: Unauthorized for url: https://huggingface.co/…",
+        "429 Client Error: Too Many Requests",
+        "Repository Not Found for url: https://huggingface.co/foo/bar",
+        "Xet Storage is enabled for this repo, but the 'hf_xet' package is "
+        "not installed. Falling back to regular HTTP download.",
+        "consistency check failed: file should be of size 100 but has size 90",
+        "",
+    ],
+)
+def test_filter_passes_everything_else(msg):
+    filt = _DropUnauthenticatedAdvisory()
+    assert filt.filter(_record(msg)) is True
+
+
+def test_filter_is_fail_open_on_unrenderable_record():
+    """A record whose ``getMessage()`` raises (bad %-args) is not ours to
+    drop — the filter must pass it through, not swallow it."""
+    filt = _DropUnauthenticatedAdvisory()
+    # "%d" % ("abc",) raises TypeError inside getMessage().
+    assert filt.filter(_record("%d", "abc")) is True
+
+
+# --- the installer, end-to-end through the logging machinery -------------
+
+
+def test_install_suppresses_advisory_but_keeps_other_warnings(hf_http_logger):
+    logger, buf = hf_http_logger
+    silence_hf_unauthenticated_warning()
+
+    logger.warning(_REAL_ADVISORY)  # dropped by the logger-level filter
+    logger.warning("consistency check failed: size mismatch")  # kept
+
+    out = buf.getvalue()
+    assert "unauthenticated" not in out
+    assert "consistency check failed" in out
+
+
+def test_install_is_idempotent(hf_http_logger):
+    logger, _ = hf_http_logger
+    silence_hf_unauthenticated_warning()
+    silence_hf_unauthenticated_warning()
+    silence_hf_unauthenticated_warning()
+    tagged = [
+        f for f in logger.filters if getattr(f, "_rapid_mlx_hf_unauth_filter", False)
+    ]
+    assert len(tagged) == 1
+
+
+def test_install_targets_the_exact_emitting_logger(hf_http_logger):
+    """A parent-logger filter is not consulted for child records during
+    propagation, so the installer must attach to ``…utils._http`` itself —
+    guard against a well-meaning refactor moving it to the parent."""
+    silence_hf_unauthenticated_warning()
+    child = logging.getLogger(_HF_HTTP_LOGGER)
+    assert any(getattr(f, "_rapid_mlx_hf_unauth_filter", False) for f in child.filters)

--- a/tests/test_hf_logging.py
+++ b/tests/test_hf_logging.py
@@ -65,10 +65,8 @@ def hf_http_logger():
         )
 
 
-def _record(msg, *args):
-    return logging.LogRecord(
-        _HF_HTTP_LOGGER, logging.WARNING, __file__, 1, msg, args, None
-    )
+def _record(msg, *args, level=logging.WARNING):
+    return logging.LogRecord(_HF_HTTP_LOGGER, level, __file__, 1, msg, args, None)
 
 
 # --- the filter predicate, tested directly -------------------------------
@@ -104,6 +102,33 @@ def test_filter_is_fail_open_on_unrenderable_record():
     filt = _DropUnauthenticatedAdvisory()
     # "%d" % ("abc",) raises TypeError inside getMessage().
     assert filt.filter(_record("%d", "abc")) is True
+
+
+@pytest.mark.parametrize(
+    "msg, level",
+    [
+        # Near-matches at WARNING: they combine the *words* the old loose
+        # predicate keyed on ("unauthenticated" + "rate limit" / "HF_TOKEN")
+        # but not the advisory's distinctive phrase → must NOT be dropped.
+        ("Unauthenticated request: rate limit exceeded", logging.WARNING),
+        ("Your HF_TOKEN is invalid; requests are unauthenticated", logging.WARNING),
+        # The advisory's own wording, but escalated to ERROR / CRITICAL — a
+        # real failure, never ours to hide, even though the phrase matches.
+        (_REAL_ADVISORY, logging.ERROR),
+        (_REAL_ADVISORY, logging.CRITICAL),
+        (
+            "unauthenticated requests to the HF Hub caused a rate-limit "
+            "error and an HF_TOKEN is required",
+            logging.ERROR,
+        ),
+    ],
+)
+def test_filter_never_hides_real_failures(msg, level):
+    """The filter is fail-safe: it only drops the WARNING-level advisory,
+    never a higher-severity record and never a near-match that merely
+    shares vocabulary with it (the collision codex flagged)."""
+    filt = _DropUnauthenticatedAdvisory()
+    assert filt.filter(_record(msg, level=level)) is True
 
 
 # --- the installer, end-to-end through the logging machinery -------------

--- a/tests/test_hf_logging.py
+++ b/tests/test_hf_logging.py
@@ -77,6 +77,18 @@ def test_filter_drops_the_real_advisory():
     assert filt.filter(_record(_REAL_ADVISORY)) is False
 
 
+def test_filter_drops_advisory_despite_whitespace_and_case():
+    """Incidental spacing / a wrapped header line / casing must not defeat
+    the full-text match — the message is whitespace-normalised first."""
+    filt = _DropUnauthenticatedAdvisory()
+    noisy = (
+        "  You are sending   UNAUTHENTICATED requests to the HF Hub.\n"
+        "Please set a HF_TOKEN to enable higher rate limits and faster "
+        "downloads.  "
+    )
+    assert filt.filter(_record(noisy)) is False
+
+
 @pytest.mark.parametrize(
     "msg",
     [
@@ -109,9 +121,18 @@ def test_filter_is_fail_open_on_unrenderable_record():
     [
         # Near-matches at WARNING: they combine the *words* the old loose
         # predicate keyed on ("unauthenticated" + "rate limit" / "HF_TOKEN")
-        # but not the advisory's distinctive phrase → must NOT be dropped.
+        # but not the advisory's full text → must NOT be dropped.
         ("Unauthenticated request: rate limit exceeded", logging.WARNING),
         ("Your HF_TOKEN is invalid; requests are unauthenticated", logging.WARNING),
+        # Same *subject* as the advisory but a different, actionable
+        # message (codex r2): shares "unauthenticated requests to the HF
+        # Hub" yet lacks the "set a HF_TOKEN … faster downloads" advice →
+        # must NOT be dropped.
+        (
+            "Unauthenticated requests to the HF Hub are temporarily blocked "
+            "due to abuse; contact support.",
+            logging.WARNING,
+        ),
         # The advisory's own wording, but escalated to ERROR / CRITICAL — a
         # real failure, never ours to hide, even though the phrase matches.
         (_REAL_ADVISORY, logging.ERROR),

--- a/vllm_mlx/_download_gate.py
+++ b/vllm_mlx/_download_gate.py
@@ -136,6 +136,16 @@ def _model_info_with_timeout(repo_id: str, timeout: float):
     """
     from huggingface_hub import HfApi
 
+    from ._hf_logging import silence_hf_unauthenticated_warning
+
+    # The Hub currently attaches its "set a HF_TOKEN" advisory to
+    # file-download responses (silenced in _mirror), not this metadata
+    # probe. But the probe is our first Hub touch on a cold pull, so
+    # installing the fail-open filter here too upholds the "filter is up
+    # before the first request" invariant whichever response the server
+    # decides to tag — it is warn-once per process.
+    silence_hf_unauthenticated_warning()
+
     result: dict = {}
 
     def _call() -> None:

--- a/vllm_mlx/_hf_logging.py
+++ b/vllm_mlx/_hf_logging.py
@@ -1,0 +1,90 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Silence one advisory HuggingFace log line on our download paths.
+
+huggingface_hub surfaces server-sent ``X-HF-Warning`` response headers by
+logging them at WARNING level from ``huggingface_hub.utils._http``
+(the ``_warn_on_warning_headers`` helper). On an *unauthenticated* request
+— the state every naive first-run user is in, since pulling a public MLX
+model needs no token — the Hub sends back:
+
+    Warning: You are sending unauthenticated requests to the HF Hub.
+    Please set a HF_TOKEN to enable higher rate limits and faster
+    downloads.
+
+For rapid-mlx this is pure noise: we front downloads with the R2 mirror,
+public repos download fine anonymously, and the lone stray ``Warning:``
+line (emitted warn-once per process) reads like an error to a first-time
+user — right where the cold-download output was otherwise just cleaned up
+(#1259). This is the third first-run papercut from the 0.11 dogfood.
+
+We drop **only** that one advisory, with a narrow, fail-open filter:
+
+* **Fail-open by construction.** It matches on message content, so if the
+  Hub rewords or stops sending the header the (reworded) line simply
+  reappears — we never hide a real problem. Genuine auth failures (401),
+  rate-limit errors (429) and integrity errors are raised as exceptions
+  or logged elsewhere; none flow through this one advisory, and none
+  match the filter's predicate.
+* **Attached to the exact emitting logger.** A filter on a *parent* logger
+  is not consulted for a child logger's records during propagation
+  (verified empirically), so filtering ``huggingface_hub`` would not work
+  — we target ``huggingface_hub.utils._http`` directly. If a future
+  huggingface_hub renames that module the filter silently stops matching
+  (the advisory returns) rather than crashing — again, fail-open.
+
+Stdlib-only (``logging``) so it stays cheap to import from the otherwise
+self-contained download gate. Idempotent: installing more than once is a
+no-op.
+"""
+
+from __future__ import annotations
+
+import logging
+
+# The logger huggingface_hub's ``_warn_on_warning_headers`` emits from:
+# ``logging.get_logger(__name__)`` where ``__name__`` is this module.
+_HF_HTTP_LOGGER = "huggingface_hub.utils._http"
+
+# Marker attribute so a re-install can spot our own filter and not add a
+# duplicate (the filter class name alone isn't a reliable identity across
+# reloads).
+_FILTER_TAG = "_rapid_mlx_hf_unauth_filter"
+
+
+class _DropUnauthenticatedAdvisory(logging.Filter):
+    """Drop HF's "unauthenticated requests … set a HF_TOKEN" advisory.
+
+    Returns ``False`` (drop) only for that specific server-sent advisory;
+    every other record — including real 401/429 errors, which never carry
+    this exact wording — passes untouched.
+    """
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        try:
+            message = record.getMessage().lower()
+        except Exception:
+            # A record we can't even render is not ours to suppress.
+            return True
+        return not (
+            "unauthenticated" in message
+            and ("hf_token" in message or "rate limit" in message)
+        )
+
+
+def silence_hf_unauthenticated_warning() -> None:
+    """Install the fail-open advisory filter on the HF http logger.
+
+    Idempotent and cheap — safe to call at the top of every download
+    entry point. It is called from :mod:`vllm_mlx._download_gate` (the
+    cold-pull size probe) and :mod:`vllm_mlx._mirror` (the R2/HF
+    downloader) right before their first Hub request. Because the advisory
+    is emitted warn-once per process, installing at those two chokepoints
+    covers every flow that acquires a model through the gate or the
+    mirror — which, on a cold first run, is all of them.
+    """
+    logger = logging.getLogger(_HF_HTTP_LOGGER)
+    if any(getattr(f, _FILTER_TAG, False) for f in logger.filters):
+        return
+    filt = _DropUnauthenticatedAdvisory()
+    setattr(filt, _FILTER_TAG, True)
+    logger.addFilter(filt)

--- a/vllm_mlx/_hf_logging.py
+++ b/vllm_mlx/_hf_logging.py
@@ -25,11 +25,13 @@ is deliberately biased toward *showing* a record, never toward hiding one:
   a genuine failure — even one whose text happens to mention tokens or
   rate limits (e.g. a hypothetical ``Unauthenticated request: rate limit
   exceeded`` error).
-* **Matched on the advisory's distinctive phrase**, not loose token
-  substrings, so an unrelated warning that merely mentions
-  "unauthenticated" and "rate limit" is not swept up. If the Hub rewords
-  the header past that phrase the (reworded) line simply reappears — we
-  err toward the papercut returning, never toward silence.
+* **Matched on the full advisory text** (its subject *and* its distinctive
+  "set a HF_TOKEN … higher rate limits … faster downloads" advice), not a
+  subject phrase alone — so a *different* actionable warning that merely
+  shares the subject (e.g. "Unauthenticated requests to the HF Hub are
+  temporarily blocked") is not swept up. If the Hub rewords the header
+  past this text the (reworded) line simply reappears — we err toward the
+  papercut returning, never toward silence.
 * **Attached to the exact emitting logger.** A filter on a *parent* logger
   is not consulted for a child logger's records during propagation
   (verified empirically), so filtering ``huggingface_hub`` would not work
@@ -51,11 +53,23 @@ import threading
 # ``logging.get_logger(__name__)`` where ``__name__`` is this module.
 _HF_HTTP_LOGGER = "huggingface_hub.utils._http"
 
-# The distinctive subject line of the server advisory (lower-cased). We
-# anchor on this specific phrase rather than loose "unauthenticated" +
-# "rate limit" substrings so a real error that happens to combine those
-# words is never suppressed.
-_ADVISORY_PHRASE = "unauthenticated requests to the hf hub"
+# The full advisory text, whitespace-normalised and lower-cased, with the
+# leading "You are sending " and the trailing period intentionally dropped
+# so a server variant that adds/removes either still matches. We require
+# this whole string — subject AND the "set a HF_TOKEN … faster downloads"
+# advice — so a *different* actionable warning sharing only the subject is
+# never suppressed. A reword past this text is fail-open (advisory returns).
+_KNOWN_ADVISORY = (
+    "unauthenticated requests to the hf hub. please set a hf_token to "
+    "enable higher rate limits and faster downloads"
+)
+
+
+def _normalize(text: str) -> str:
+    """Lower-case and collapse runs of whitespace, so incidental spacing or
+    a wrapped line in the header can't defeat the match."""
+    return " ".join(text.lower().split())
+
 
 # Marker attribute so a re-install can spot our own filter and not add a
 # duplicate (the filter class name alone isn't a reliable identity across
@@ -82,11 +96,11 @@ class _DropUnauthenticatedAdvisory(logging.Filter):
         if record.levelno != logging.WARNING:
             return True
         try:
-            message = record.getMessage().lower()
+            message = _normalize(record.getMessage())
         except Exception:
             # A record we can't even render is not ours to suppress.
             return True
-        return _ADVISORY_PHRASE not in message
+        return _KNOWN_ADVISORY not in message
 
 
 def silence_hf_unauthenticated_warning() -> None:

--- a/vllm_mlx/_hf_logging.py
+++ b/vllm_mlx/_hf_logging.py
@@ -17,74 +17,93 @@ line (emitted warn-once per process) reads like an error to a first-time
 user — right where the cold-download output was otherwise just cleaned up
 (#1259). This is the third first-run papercut from the 0.11 dogfood.
 
-We drop **only** that one advisory, with a narrow, fail-open filter:
+We drop **only** that one advisory, with a narrow, fail-*safe* filter — it
+is deliberately biased toward *showing* a record, never toward hiding one:
 
-* **Fail-open by construction.** It matches on message content, so if the
-  Hub rewords or stops sending the header the (reworded) line simply
-  reappears — we never hide a real problem. Genuine auth failures (401),
-  rate-limit errors (429) and integrity errors are raised as exceptions
-  or logged elsewhere; none flow through this one advisory, and none
-  match the filter's predicate.
+* **WARNING level only.** The advisory is emitted via ``logger.warning``.
+  Any record at ``ERROR`` or above passes untouched, so we can never mask
+  a genuine failure — even one whose text happens to mention tokens or
+  rate limits (e.g. a hypothetical ``Unauthenticated request: rate limit
+  exceeded`` error).
+* **Matched on the advisory's distinctive phrase**, not loose token
+  substrings, so an unrelated warning that merely mentions
+  "unauthenticated" and "rate limit" is not swept up. If the Hub rewords
+  the header past that phrase the (reworded) line simply reappears — we
+  err toward the papercut returning, never toward silence.
 * **Attached to the exact emitting logger.** A filter on a *parent* logger
   is not consulted for a child logger's records during propagation
   (verified empirically), so filtering ``huggingface_hub`` would not work
-  — we target ``huggingface_hub.utils._http`` directly. If a future
-  huggingface_hub renames that module the filter silently stops matching
-  (the advisory returns) rather than crashing — again, fail-open.
+  — we target ``huggingface_hub.utils._http`` directly. A future module
+  rename makes the filter stop matching (advisory returns) rather than
+  crash.
 
 Stdlib-only (``logging``) so it stays cheap to import from the otherwise
-self-contained download gate. Idempotent: installing more than once is a
-no-op.
+self-contained download gate. Idempotent and thread-safe: installing more
+than once, even concurrently, adds exactly one filter.
 """
 
 from __future__ import annotations
 
 import logging
+import threading
 
 # The logger huggingface_hub's ``_warn_on_warning_headers`` emits from:
 # ``logging.get_logger(__name__)`` where ``__name__`` is this module.
 _HF_HTTP_LOGGER = "huggingface_hub.utils._http"
+
+# The distinctive subject line of the server advisory (lower-cased). We
+# anchor on this specific phrase rather than loose "unauthenticated" +
+# "rate limit" substrings so a real error that happens to combine those
+# words is never suppressed.
+_ADVISORY_PHRASE = "unauthenticated requests to the hf hub"
 
 # Marker attribute so a re-install can spot our own filter and not add a
 # duplicate (the filter class name alone isn't a reliable identity across
 # reloads).
 _FILTER_TAG = "_rapid_mlx_hf_unauth_filter"
 
+# Serialises the check-then-add in :func:`silence_hf_unauthenticated_warning`
+# so concurrent first downloads (the mirror runs a worker pool) can't each
+# slip a duplicate filter past the idempotency check.
+_INSTALL_LOCK = threading.Lock()
+
 
 class _DropUnauthenticatedAdvisory(logging.Filter):
     """Drop HF's "unauthenticated requests … set a HF_TOKEN" advisory.
 
-    Returns ``False`` (drop) only for that specific server-sent advisory;
-    every other record — including real 401/429 errors, which never carry
-    this exact wording — passes untouched.
+    Returns ``False`` (drop) only for that specific ``WARNING``-level
+    server advisory; every other record — a higher severity, or a
+    different message — passes untouched, so a real failure is never
+    masked.
     """
 
     def filter(self, record: logging.LogRecord) -> bool:
+        # Never touch anything more severe than the advisory itself.
+        if record.levelno != logging.WARNING:
+            return True
         try:
             message = record.getMessage().lower()
         except Exception:
             # A record we can't even render is not ours to suppress.
             return True
-        return not (
-            "unauthenticated" in message
-            and ("hf_token" in message or "rate limit" in message)
-        )
+        return _ADVISORY_PHRASE not in message
 
 
 def silence_hf_unauthenticated_warning() -> None:
-    """Install the fail-open advisory filter on the HF http logger.
+    """Install the fail-safe advisory filter on the HF http logger.
 
-    Idempotent and cheap — safe to call at the top of every download
-    entry point. It is called from :mod:`vllm_mlx._download_gate` (the
-    cold-pull size probe) and :mod:`vllm_mlx._mirror` (the R2/HF
+    Idempotent, thread-safe and cheap — safe to call at the top of every
+    download entry point. It is called from :mod:`vllm_mlx._download_gate`
+    (the cold-pull size probe) and :mod:`vllm_mlx._mirror` (the R2/HF
     downloader) right before their first Hub request. Because the advisory
     is emitted warn-once per process, installing at those two chokepoints
     covers every flow that acquires a model through the gate or the
     mirror — which, on a cold first run, is all of them.
     """
     logger = logging.getLogger(_HF_HTTP_LOGGER)
-    if any(getattr(f, _FILTER_TAG, False) for f in logger.filters):
-        return
-    filt = _DropUnauthenticatedAdvisory()
-    setattr(filt, _FILTER_TAG, True)
-    logger.addFilter(filt)
+    with _INSTALL_LOCK:
+        if any(getattr(f, _FILTER_TAG, False) for f in logger.filters):
+            return
+        filt = _DropUnauthenticatedAdvisory()
+        setattr(filt, _FILTER_TAG, True)
+        logger.addFilter(filt)

--- a/vllm_mlx/_mirror.py
+++ b/vllm_mlx/_mirror.py
@@ -1196,6 +1196,14 @@ def download_with_mirror_fallback(
     silently overwriting ``refs/main`` with HEAD. ``revision=None`` and
     ``revision="main"`` both mean default branch and are accepted.
     """
+    from ._hf_logging import silence_hf_unauthenticated_warning
+
+    # Whether we pull via R2 + hf_hub_download below or bail (returning
+    # False) and let the caller run plain snapshot_download, HF's
+    # unauthenticated-token advisory would fire once — drop it up front,
+    # before either path's first Hub request.
+    silence_hf_unauthenticated_warning()
+
     base = _mirror_base()
     if not base or "/" not in repo_id:
         # Mirror disabled or repo_id isn't a HF-shaped ``owner/name``.


### PR DESCRIPTION
## Why

The third cold-first-run papercut from the 0.11 dogfood (after #1259's progress bar + size string). A brand-new user with no HF token — which is everyone on their first `rapid-mlx chat`, since pulling a public MLX model needs no auth — sees a stray line during the download:

```
Warning: You are sending unauthenticated requests to the HF Hub. Please set a HF_TOKEN to enable higher rate limits and faster downloads.
```

For rapid-mlx this is pure noise: we front downloads with the R2 mirror, public repos download fine anonymously, and the lone `Warning:` line reads like an error to a first-timer — right where #1259 otherwise just cleaned up the cold-download output.

## Root cause

Not our output. `huggingface_hub` surfaces a **server-sent** `X-HF-Warning` response header by logging it at WARNING level from `huggingface_hub.utils._http._warn_on_warning_headers` (`logger.warning(message)`), warn-once per topic per process. That's why the text is in no package source — it's an HTTP header the Hub attaches to **file-download** responses on unauthenticated requests. Confirmed live on huggingface_hub 1.20.1 and 1.25.1: it fires on `hf_hub_download` (the file GET), not on `model_info` (metadata).

## What

A narrow, **fail-open** logging filter (`vllm_mlx/_hf_logging.py`, stdlib-only) that drops **only** this advisory and installs at our two HF-download chokepoints:

- **`_mirror.download_with_mirror_fallback`** (load-bearing) — installed at the top, before either the R2/`hf_hub_download` per-file path or the caller's `snapshot_download` fallback makes its first Hub request.
- **`_download_gate._model_info_with_timeout`** (defensive) — the cold-pull size probe is our first Hub touch; installing here too upholds the "filter is up before the first request" invariant whichever response the server tags. (The metadata probe doesn't currently carry the header, but warn-once + gate-runs-first means this is a cheap belt-and-suspenders, not dead code.)

Design choices, all verified:

- **Fail-open.** The filter matches on message content (`"unauthenticated"` AND (`"hf_token"` OR `"rate limit"`)), so if the Hub rewords or drops the header the (reworded) line simply reappears — we never hide a real problem. Genuine 401/429/integrity errors are raised as exceptions or logged with different wording; none match the predicate, and the dogfood confirms a real integrity-style warning on the same logger still reaches the user.
- **Exact emitting logger.** A filter on a *parent* logger is **not** consulted for a child logger's records during propagation (verified empirically: a `huggingface_hub` filter leaks the line; a `huggingface_hub.utils._http` filter suppresses it). So we attach to `huggingface_hub.utils._http` directly. A future module rename degrades to "the advisory returns", not a crash.
- **Idempotent**, tagged filter — repeated installs are a no-op.
- **Scope.** Only the download plumbing, not a global `import vllm_mlx` side effect. The other `snapshot_download` sites (tokenizer / gemma4 / whisper) run *after* a cold model acquisition already triggered the filter, so warn-once covers them; an exotic path that downloads a file with neither the gate nor the mirror having run first would show the advisory once — fail-open, and not the reported papercut.

The HF unauthenticated **warning** is item #3 of the first-run report; the funnel **telemetry** (#4) is intentionally not here — it needs a sink decision first.

## Test plan

- [x] New `tests/test_hf_logging.py` (11 tests, hermetic, no network): filter drops the exact captured advisory; passes 401 / 429 / repo-not-found / Xet-fallback / integrity-mismatch / empty messages; is fail-open on a record whose `getMessage()` raises; install suppresses the advisory end-to-end through the logging machinery while keeping a different warning; is idempotent (one tagged filter after 3 installs); targets the exact emitting logger (guards against a refactor moving it to the parent).
- [x] Regression: adjacent suites unchanged — `test_mirror_pull.py` + `test_mirror_progress_tty.py` + `test_first_run_guide.py` + `test_download_gate.py` = **162 passed**. Production change is two additive install calls.
- [x] Root-caused the emitter live: `huggingface_hub.utils._http._warn_on_warning_headers` logging a server `X-HF-Warning` header; verified the parent-vs-exact logger propagation behavior empirically before choosing the attach point.
- [x] **Fresh-wheel dogfood (G9):** built the wheel, installed into a clean py3.12 venv (`rapid-mlx 0.11.0`, `huggingface_hub 1.25.1` as pip resolves for a fresh user), fresh `HF_HOME` + no token. **Baseline** anonymous `hf_hub_download` → advisory present (1). **Via our mirror install point** → advisory suppressed (**0**), and a genuine integrity-style warning on the same logger still visible (**1**). Also confirmed the advisory fires on the file GET, not `model_info`.
- [x] `ruff check` + `ruff format` clean on all changed files.

## Scope

`skip-version-bump` — onboarding UX only; batches into the pending 0.11.1 bump-only release alongside the other post-0.11.0 merges (#1237, #1243, #1259, …).
