### PR TITLE
docs(readme): curl-first install + first-class "launch claude-code" Quick Start step

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,16 +37,16 @@
 
 **1. Install** — pick one path (run only one of these):
 
-Homebrew — prebuilt bottle straight from homebrew-core (recommended):
-
-```bash
-brew install rapid-mlx
-```
-
-or the one-liner — detects your RAM, picks a starter model:
+One-liner — detects your RAM, picks a starter model (recommended):
 
 ```bash
 curl -fsSL https://rapidmlx.com/install.sh | bash
+```
+
+or Homebrew — prebuilt bottle straight from homebrew-core:
+
+```bash
+brew install rapid-mlx
 ```
 
 Both land the same `rapid-mlx` CLI. The curl installer additionally installs Python 3.10+ if missing, creates an isolated venv at `~/.rapid-mlx/`, symlinks the `rapid-mlx` CLI into `~/.local/bin/`, and prints a serve command sized to your Mac (8–23 GB → `qwen3.5-4b-4bit`; 24–47 GB → `gpt-oss-20b-mxfp4-q8`; 48–95 GB → `qwen3.6-35b-8bit`; 96 GB+ → `gpt-oss-120b-mxfp4-q8`).
@@ -87,6 +87,14 @@ print(client.chat.completions.create(
     messages=[{"role": "user", "content": "Say hello"}],
 ).choices[0].message.content)
 ```
+
+**4. Or wire up your coding agent — one command:**
+
+```bash
+rapid-mlx launch claude-code
+```
+
+With a server running (step 3), this patches Claude Code's local config (`~/.config/claude/settings.json`) to route at `http://localhost:8000` — no manual env vars, no editing JSON by hand. You get a fully local Claude Code: `$0` per token, nothing leaves your Mac. Swap in `cursor`, `cline`, or `continue-dev` for the other IDE clients, or run `rapid-mlx launch list` to see what's detected on this machine.
 
 > **Vision / audio / diffusion models?** Base install is text-only (~460 MB). Vision, audio, embeddings, and DFlash speculative decoding ship as opt-in extras. → [Optional extras](https://rapidmlx.com/docs/extras.html)
 


### PR DESCRIPTION
## Why

Two small Quick Start edits, both to align the README with the rest of the product's touchpoints (website hero, /download page, and the CLI's own first-run guide):

1. **curl-first install.** The website hero and `/download` both lead with the `curl … install.sh | bash` one-liner (it sizes a starter model to the user's RAM and is our only install-side signal); the README was the odd surface leading with `brew`. Reordered so curl is the recommended path, Homebrew second — same two commands, no content lost.

2. **First-class `rapid-mlx launch claude-code` step.** Running a local coding agent is the ICP's first ask, but it was only reachable through prose in step 3 plus a below-the-fold link. The CLI's first-run guide (#1237) already surfaces `launch <agent>` as a top next step (claude-code preferred); this brings the 60-second README path to parity so it ends at a working, fully local Claude Code.

Docs-only change (README.md); no code, no tests affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)