### PR TITLE
feat(release): centralize fleet coverage

### DIFF
--- a/docs/development/release-artifact-acceptance.md
+++ b/docs/development/release-artifact-acceptance.md
@@ -68,7 +68,11 @@ The matrix is one server boot per family. A test run sets both
 - a documented `strict=True` xfail remains an exception, and an unexpected
   pass is a failure.
 
-The current feasible set is four families:
+The current feasible set is four families. The matrix aliases and required
+extras come from the same
+[`scripts/release_fleet.json`](../../scripts/release_fleet.json) manifest as
+the release coherence sweep, so its feasible stand-in aliases and required
+extras cannot drift from the broader coherence fleet:
 
 | Family | Candidate alias | Agent cells | Framework cells |
 | --- | --- | ---: | ---: |

--- a/docs/development/releasing.md
+++ b/docs/development/releasing.md
@@ -154,7 +154,7 @@ This is the rule. No exceptions. CI doesn't fake-inference with a tiny model on 
 
 | # | Gate | Side | Where it runs | Catches |
 |---|---|---|---|---|
-| G0 | Output-coherence gate — deterministic golden answers (blocking) + garbage detector (advisory), run FIRST | **M3** | `make release-check-m3` + `scripts/coherence_sweep.sh` | garbage / coherent-but-wrong generation the perf/import/unit gates all miss (#1234 / #1247) |
+| G0 | Output-coherence gate — manifest-driven family sweep, then the gauntlet model; deterministic golden answers block and the garbage detector is advisory | **M3** | `make release-check-m3` | garbage / coherent-but-wrong generation the perf/import/unit gates all miss (#1234 / #1247) |
 | G1 | Build wheel + sdist, then clean-room install + import both | CI | `release-preflight.yml` (macOS-14) | dev mlx symbol drift (#408), incomplete source distribution |
 | G2 | Codex review × 2 rounds | local | maintainer machine | every PR-author bug class |
 | G3 | CLI ↔ Config fidelity audit | CI | `ci.yml` lint (ubuntu) | silent CLI flag drop (#400) |
@@ -187,15 +187,15 @@ make release-check-m3              # uses MODEL=qwen3.5-9b-4bit (default)
 MODEL=qwen3.6-27b-4bit make release-check-m3   # override
 ```
 
-Wrapped by [`scripts/release_check_m3.sh`](../../scripts/release_check_m3.sh). It boots `rapid-mlx serve` once on port 8000, then runs **G0 (output coherence — first, so a garbage model fails fast before the rest re-test the same broken path)** + G5 (stress) + G7 (anthropic + pydantic_ai + smolagents) + G7b (agent harness layer: a single `rapid-mlx bench <model> --tier harness` sweep across codex / opencode / hermes / aider / langchain) + G6 (parallel-tool-call cap repro) + G9 (10-seq latency) + G8b (parser microbench, M3 perf baseline) sequentially. The server is killed on exit.
+Wrapped by [`scripts/release_check_m3.sh`](../../scripts/release_check_m3.sh). It first runs **G0a**, booting each family representative from [`scripts/release_fleet.json`](../../scripts/release_fleet.json) in turn. It then boots the requested `MODEL` on port 8000 and runs **G0b** against that exact model, followed by G5 (stress), G7 (anthropic + pydantic_ai + smolagents), G7b (agent harness layer: a single `rapid-mlx bench <model> --tier harness` sweep across codex / opencode / hermes / aider / langchain), G6 (parallel-tool-call cap repro), G9 (10-seq latency), and G8b (parser microbench, M3 perf baseline). Servers are killed between models and on exit.
 
-**G0 is per-booted-model.** The single-boot gauntlet only proves coherence for the one alias it served. Because a model-specific regression (the 35B RMSNorm incident, #1234) is invisible to a 4B/9B-only run, a release or model-path change **must** additionally sweep the representative aliases it affects — one per family, plus any alias the change touches:
+The normal G0a fleet covers the architecture risk classes that have historically failed differently: small dense (Qwen 3.5 4B), hybrid MoE (Qwen 3.5 35B), large dense (Qwen 3.6 and DeepSeek), large MoE (gpt-oss), and multimodal (Gemma 4). If `mlx`, `mlx-lm`, `mlx-vlm`, or `mlx-audio` changed since the previous release tag, the script automatically selects the `toolchain` scope and adds the Ultra-only Hy3 path. This works both before and after the candidate commit is tagged. A shallow checkout with no discoverable tag keeps the normal release scope; pass a base ref explicitly when toolchain comparison is required. To compare against a different release base, set `RELEASE_FLEET_BASE_REF`:
 
 ```bash
-bash scripts/coherence_sweep.sh qwen3.5-4b-4bit qwen3.6-35b   # boots + gates each in turn
+RELEASE_FLEET_BASE_REF=v0.11.0 make release-check-m3
 ```
 
-This is a hard release requirement, not advisory. (Making the serve-path gate *always-on in CI* rather than a local requirement needs a registered self-hosted Apple-Silicon runner — tracked in #1247. The pure predicate + garbage-detector logic is already always-on via `tests/test_coherence.py` on GitHub-hosted CI.)
+For focused diagnosis only, `scripts/coherence_sweep.sh` still accepts explicit aliases, `MODELS`, or `FLEET_SCOPE=release|toolchain`. The manifest-driven sweep is a hard release requirement, not advisory. (Making the serve-path gate *always-on in CI* rather than a local requirement needs a registered self-hosted Apple-Silicon runner — tracked in #1247. The pure predicate + garbage-detector logic is already always-on via `tests/test_coherence.py` on GitHub-hosted CI.)
 
 G7b covers the live-server harness path that `pr-validate`'s unit-level profile tests can't reach. Split in two parts so each is honestly scoped:
 

--- a/scripts/coherence_sweep.sh
+++ b/scripts/coherence_sweep.sh
@@ -12,9 +12,15 @@
 # evals/coherence_gate.py (blocking golden answers), then torn down before the
 # next. Any alias that fails its blocking golden gate fails the whole sweep.
 #
+# With no explicit models, the shared release fleet is selected automatically.
+# A normal release covers every routinely feasible family; changes to an MLX
+# dependency since the previous release tag add the Ultra-only Hy3 representative.
+#
 # Usage:
+#   bash scripts/coherence_sweep.sh
 #   bash scripts/coherence_sweep.sh qwen3.5-4b-4bit qwen3.6-35b
 #   MODELS="qwen3.5-4b-4bit qwen3.6-35b" bash scripts/coherence_sweep.sh
+#   FLEET_SCOPE=toolchain bash scripts/coherence_sweep.sh
 #
 # Exit codes:
 #   0 — every alias passed its blocking golden gate
@@ -25,7 +31,22 @@ set -euo pipefail
 
 PY="${PY:-python3.12}"
 PORT="${PORT:-8402}"
-MODELS="${*:-${MODELS:-qwen3.5-4b-4bit}}"
+FLEET_SCOPE="${FLEET_SCOPE:-auto}"
+if [ "$#" -gt 0 ]; then
+  MODELS="$*"
+elif [ -n "${MODELS:-}" ]; then
+  MODELS="$MODELS"
+else
+  fleet_args=(models --scope "$FLEET_SCOPE")
+  if [ -n "${RELEASE_FLEET_BASE_REF:-}" ]; then
+    fleet_args+=(--base-ref "$RELEASE_FLEET_BASE_REF")
+  fi
+  MODELS="$("$PY" scripts/release_fleet.py "${fleet_args[@]}")"
+fi
+if [ -z "$MODELS" ]; then
+  echo "ERROR: release fleet selected no coherence models." >&2
+  exit 2
+fi
 WORK_DIR="$(mktemp -d "${TMPDIR:-/tmp}/rapid-mlx-coherence-sweep.XXXXXX")"
 LOG="$WORK_DIR/server.log"
 PIDFILE="$WORK_DIR/server.pid"

--- a/scripts/release_artifact_matrix.py
+++ b/scripts/release_artifact_matrix.py
@@ -44,6 +44,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
+FLEET_MANIFEST = REPO_ROOT / "scripts" / "release_fleet.json"
 MATRIX_FILES = (
     REPO_ROOT / "tests/integrations/test_agents_matrix.py",
     REPO_ROOT / "tests/integrations/test_frameworks_matrix.py",
@@ -84,16 +85,44 @@ class FamilyConfig:
     extras: tuple[str, ...] = ()
 
 
-# Keep this map aligned with tests/integrations/conftest.py::_FAMILY_ALIASES.
-# The cheap aliases make the full four-family release matrix feasible on an
-# isolated M3/Ultra runner; the larger golden models remain a separate perf
-# and weekly-path concern.
-FAMILY_CONFIGS: dict[str, FamilyConfig] = {
-    "qwen36": FamilyConfig("qwen3.5-4b-4bit"),
-    "gemma4": FamilyConfig("gemma-4-12b-4bit", extras=("vision",)),
-    "deepseek": FamilyConfig("deepseek-r1-32b-4bit"),
-    "gptoss": FamilyConfig("gpt-oss-20b-mxfp4-q8"),
-}
+def _load_family_configs(path: Path = FLEET_MANIFEST) -> dict[str, FamilyConfig]:
+    """Load artifact-matrix cells from the shared release-fleet manifest."""
+
+    data = json.loads(path.read_text())
+    if data.get("schema") != 1 or not isinstance(data.get("families"), dict):
+        raise ValueError("release fleet manifest must contain schema 1 families")
+
+    configs: dict[str, FamilyConfig] = {}
+    for family, raw in data["families"].items():
+        if not isinstance(raw, dict) or "artifact_matrix" not in raw:
+            continue
+        artifact = raw["artifact_matrix"]
+        if not isinstance(artifact, dict):
+            raise ValueError(f"{family}: artifact_matrix must be an object")
+        model = artifact.get("model")
+        server_args = artifact.get("server_args", ["--no-thinking"])
+        extras = artifact.get("extras", [])
+        if not isinstance(model, str) or not model:
+            raise ValueError(f"{family}: artifact matrix model must be a string")
+        if not isinstance(server_args, list) or not all(
+            isinstance(arg, str) for arg in server_args
+        ):
+            raise ValueError(f"{family}: server_args must be a string list")
+        if not isinstance(extras, list) or not all(
+            isinstance(extra, str) for extra in extras
+        ):
+            raise ValueError(f"{family}: extras must be a string list")
+        configs[family] = FamilyConfig(model, tuple(server_args), tuple(extras))
+
+    if not configs:
+        raise ValueError("release fleet manifest defines no artifact matrix families")
+    return configs
+
+
+# Artifact models may be cheap stand-ins so the four-family matrix remains
+# feasible on the release runner. Coherence representatives remain real family
+# models and are consumed separately by coherence_sweep.sh.
+FAMILY_CONFIGS = _load_family_configs()
 
 
 def validate_families_json(

--- a/scripts/release_check_m3.sh
+++ b/scripts/release_check_m3.sh
@@ -78,6 +78,18 @@ cleanup() {
 }
 trap cleanup EXIT INT TERM
 
+#-------------------- G0a fleet output coherence ------------------
+# Before spending time on the full single-model gauntlet, prove that every
+# release-family representative can still answer deterministic golden
+# questions. The shared manifest expands this list automatically when an MLX
+# dependency changed since the previous release tag (or RELEASE_FLEET_BASE_REF).
+line
+echo "  G0a — release-fleet output coherence sweep"
+line
+PY="$PY" PORT="${FLEET_PORT:-8402}" \
+  FLEET_SCOPE="${FLEET_SCOPE:-auto}" \
+  bash scripts/coherence_sweep.sh
+
 echo "→ Starting server (background)…"
 # --no-thinking: gauntlet's job is API/parser/router correctness, not
 # thinking-mode evaluation. Leaving thinking ON on small models burns
@@ -103,7 +115,7 @@ if ! curl -sf "http://127.0.0.1:$PORT/v1/models" >/dev/null 2>&1; then
   exit 2
 fi
 
-#-------------------- G0 output coherence -------------------------
+#-------------------- G0b booted-model coherence ------------------
 # The most fundamental gate: does the served model produce coherent,
 # correct text at all? Qwen3.6/3.5-35B shipped garbage from the first
 # token (#1234) and passed every perf / import / unit gate because
@@ -112,12 +124,10 @@ fi
 # inference path. Blocking = deterministic golden answers; the garbage
 # detector is advisory-only. Reads RAPID_MLX_BASE_URL (exported above).
 #
-# This checks the ONE model the gauntlet booted. A release / model-path
-# change must ALSO sweep the representative aliases it affects (a 35B-
-# specific regression is invisible to a 4B/9B-only run) — see
-# scripts/coherence_sweep.sh and docs/development/releasing.md.
+# G0a covers the release fleet; this second check covers the exact MODEL used
+# by every remaining live-server gate below.
 line
-echo "  G0 — output coherence gate (blocking golden answers)"
+echo "  G0b — gauntlet-model output coherence gate"
 line
 "$PY" evals/coherence_gate.py
 

--- a/scripts/release_fleet.json
+++ b/scripts/release_fleet.json
@@ -1,0 +1,60 @@
+{
+  "schema": 1,
+  "families": {
+    "small_dense": {
+      "coherence_model": "qwen3.5-4b-4bit",
+      "coverage_class": "small_dense",
+      "scopes": ["release", "toolchain"]
+    },
+    "qwen35": {
+      "coherence_model": "qwen3.5-35b-4bit",
+      "coverage_class": "hybrid_moe",
+      "scopes": ["release", "toolchain"]
+    },
+    "qwen36": {
+      "coherence_model": "qwen3.6-27b-4bit",
+      "coverage_class": "large_dense",
+      "scopes": ["release", "toolchain"],
+      "artifact_matrix": {
+        "model": "qwen3.5-4b-4bit",
+        "server_args": ["--no-thinking"],
+        "extras": []
+      }
+    },
+    "gemma4": {
+      "coherence_model": "gemma-4-12b-4bit",
+      "coverage_class": "multimodal",
+      "scopes": ["release", "toolchain"],
+      "artifact_matrix": {
+        "model": "gemma-4-12b-4bit",
+        "server_args": ["--no-thinking"],
+        "extras": ["vision"]
+      }
+    },
+    "deepseek": {
+      "coherence_model": "deepseek-r1-32b-4bit",
+      "coverage_class": "large_dense",
+      "scopes": ["release", "toolchain"],
+      "artifact_matrix": {
+        "model": "deepseek-r1-32b-4bit",
+        "server_args": ["--no-thinking"],
+        "extras": []
+      }
+    },
+    "gptoss": {
+      "coherence_model": "gpt-oss-20b-mxfp4-q8",
+      "coverage_class": "large_moe",
+      "scopes": ["release", "toolchain"],
+      "artifact_matrix": {
+        "model": "gpt-oss-20b-mxfp4-q8",
+        "server_args": ["--no-thinking"],
+        "extras": []
+      }
+    },
+    "hy3": {
+      "coherence_model": "hy3-preview-4bit",
+      "coverage_class": "ultra_moe",
+      "scopes": ["toolchain"]
+    }
+  }
+}

--- a/scripts/release_fleet.py
+++ b/scripts/release_fleet.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Read and validate the release-fleet manifest.
+
+The manifest is the source of truth for release-time model-family coverage.
+Normal releases sweep one real representative for every routinely feasible
+family. Changes to the MLX toolchain expand the sweep to the Ultra-only Hy3
+family as well.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - Python 3.10 compatibility
+    import tomli as tomllib
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_MANIFEST = Path(__file__).with_name("release_fleet.json")
+VALID_SCOPES = frozenset({"release", "toolchain"})
+TOOLCHAIN_PACKAGES = ("mlx", "mlx-lm", "mlx-vlm", "mlx-audio")
+REQUIRED_RELEASE_CLASSES = frozenset(
+    {"small_dense", "hybrid_moe", "large_dense", "large_moe", "multimodal"}
+)
+
+
+@dataclass(frozen=True)
+class FleetFamily:
+    name: str
+    coherence_model: str
+    coverage_class: str
+    scopes: tuple[str, ...]
+    artifact_matrix: dict[str, Any] | None
+
+
+def load_fleet(path: Path = DEFAULT_MANIFEST) -> tuple[FleetFamily, ...]:
+    """Load the manifest and reject coverage-silencing mistakes."""
+
+    data = json.loads(path.read_text())
+    if data.get("schema") != 1:
+        raise ValueError("release fleet manifest must use schema 1")
+    raw_families = data.get("families")
+    if not isinstance(raw_families, dict) or not raw_families:
+        raise ValueError("release fleet manifest needs a non-empty families object")
+
+    families: list[FleetFamily] = []
+    coherence_models: set[str] = set()
+    for name, raw in raw_families.items():
+        if not isinstance(name, str) or not name or not isinstance(raw, dict):
+            raise ValueError("every release fleet family needs a non-empty name/object")
+        model = raw.get("coherence_model")
+        coverage_class = raw.get("coverage_class")
+        scopes = raw.get("scopes")
+        artifact = raw.get("artifact_matrix")
+        if (
+            not isinstance(model, str)
+            or not model
+            or any(character.isspace() for character in model)
+        ):
+            raise ValueError(f"{name}: coherence_model must be a non-empty string")
+        if model in coherence_models:
+            raise ValueError(f"{name}: duplicate coherence_model {model!r}")
+        coherence_models.add(model)
+        if not isinstance(coverage_class, str) or not coverage_class:
+            raise ValueError(f"{name}: coverage_class must be a non-empty string")
+        if (
+            not isinstance(scopes, list)
+            or not scopes
+            or not all(isinstance(scope, str) for scope in scopes)
+        ):
+            raise ValueError(f"{name}: scopes must be a non-empty string list")
+        unknown_scopes = set(scopes) - VALID_SCOPES
+        if unknown_scopes:
+            raise ValueError(f"{name}: unknown scopes {sorted(unknown_scopes)!r}")
+        if "toolchain" not in scopes:
+            raise ValueError(
+                f"{name}: every family must participate in toolchain scope"
+            )
+        if artifact is not None and not isinstance(artifact, dict):
+            raise ValueError(f"{name}: artifact_matrix must be an object")
+        families.append(
+            FleetFamily(
+                name=name,
+                coherence_model=model,
+                coverage_class=coverage_class,
+                scopes=tuple(scopes),
+                artifact_matrix=artifact,
+            )
+        )
+    release_classes = {
+        family.coverage_class for family in families if "release" in family.scopes
+    }
+    missing_classes = REQUIRED_RELEASE_CLASSES - release_classes
+    if missing_classes:
+        raise ValueError(
+            f"release fleet is missing coverage classes {sorted(missing_classes)!r}"
+        )
+    return tuple(families)
+
+
+def models_for_scope(scope: str, *, path: Path = DEFAULT_MANIFEST) -> tuple[str, ...]:
+    if scope not in VALID_SCOPES:
+        raise ValueError(f"unknown release fleet scope {scope!r}")
+    return tuple(
+        family.coherence_model for family in load_fleet(path) if scope in family.scopes
+    )
+
+
+def _canonical_package_name(name: str) -> str:
+    return re.sub(r"[-_.]+", "-", name).lower()
+
+
+def _toolchain_snapshot(
+    pyproject_text: str, lock_text: str
+) -> dict[str, tuple[tuple[str, ...], tuple[str, ...]]]:
+    """Return direct requirements and complete lock records for MLX packages."""
+
+    pyproject = tomllib.loads(pyproject_text)
+    project = pyproject.get("project", {})
+    requirement_groups = [project.get("dependencies", [])]
+    requirement_groups.extend(project.get("optional-dependencies", {}).values())
+
+    requirements: dict[str, set[str]] = {
+        package: set() for package in TOOLCHAIN_PACKAGES
+    }
+    for group in requirement_groups:
+        for requirement in group:
+            if not isinstance(requirement, str):
+                continue
+            match = re.match(r"([a-zA-Z0-9][a-zA-Z0-9._-]*)", requirement)
+            if not match:
+                continue
+            package = _canonical_package_name(match.group(1))
+            if package in requirements:
+                requirements[package].add(requirement)
+
+    locked: dict[str, set[str]] = {package: set() for package in TOOLCHAIN_PACKAGES}
+    for entry in tomllib.loads(lock_text).get("package", []):
+        if not isinstance(entry, dict) or not isinstance(entry.get("name"), str):
+            continue
+        package = _canonical_package_name(entry["name"])
+        if package not in locked:
+            continue
+        locked[package].add(json.dumps(entry, sort_keys=True, separators=(",", ":")))
+
+    return {
+        package: (tuple(sorted(requirements[package])), tuple(sorted(locked[package])))
+        for package in TOOLCHAIN_PACKAGES
+    }
+
+
+def resolve_scope(*, requested: str, base_ref: str | None) -> str:
+    if requested != "auto":
+        if requested not in VALID_SCOPES:
+            raise ValueError(f"unknown release fleet scope {requested!r}")
+        return requested
+
+    if base_ref is None:
+        describe = subprocess.run(
+            [
+                "git",
+                "describe",
+                "--tags",
+                "--match",
+                "v[0-9]*",
+                "--abbrev=0",
+                "HEAD^",
+            ],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if describe.returncode != 0 or not describe.stdout.strip():
+            # A shallow/source-archive checkout has no reliable comparison
+            # point. Keep the normal fleet instead of silently adding an
+            # Ultra-only model solely because Git metadata is unavailable.
+            return "release"
+        base_ref = describe.stdout.strip()
+
+    def tracked_file(ref: str, filename: str) -> str | None:
+        result = subprocess.run(
+            ["git", "show", f"{ref}:{filename}"],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        return result.stdout if result.returncode == 0 else None
+
+    # Compare committed release inputs. Developer-only untracked lockfiles must
+    # not make the same candidate select different fleets locally and in CI.
+    base_project = tracked_file(base_ref, "pyproject.toml")
+    current_project = tracked_file("HEAD", "pyproject.toml")
+    if base_project is None or current_project is None:
+        return "toolchain"
+
+    base_snapshot = _toolchain_snapshot(
+        base_project, tracked_file(base_ref, "uv.lock") or ""
+    )
+    current_snapshot = _toolchain_snapshot(
+        current_project,
+        tracked_file("HEAD", "uv.lock") or "",
+    )
+    return "toolchain" if base_snapshot != current_snapshot else "release"
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    models = subparsers.add_parser("models", help="print coherence models for a scope")
+    models.add_argument(
+        "--scope", choices=("auto", *sorted(VALID_SCOPES)), default="auto"
+    )
+    models.add_argument("--base-ref")
+    models.add_argument("--format", choices=("shell", "json", "lines"), default="shell")
+    return parser
+
+
+def main() -> int:
+    args = _build_parser().parse_args()
+    scope = resolve_scope(requested=args.scope, base_ref=args.base_ref)
+    models = models_for_scope(scope)
+    if args.format == "json":
+        print(json.dumps(models))
+    elif args.format == "lines":
+        print("\n".join(models))
+    else:
+        print(" ".join(models))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_release_artifact_matrix.py
+++ b/tests/test_release_artifact_matrix.py
@@ -93,6 +93,14 @@ def test_family_configs_cover_the_release_eligible_families(matrix):
     assert matrix.FAMILY_CONFIGS["gemma4"].extras == ("vision",)
 
 
+def test_workflow_default_covers_manifest_artifact_families(matrix):
+    workflow = (
+        _REPO_ROOT / ".github" / "workflows" / "release-artifact-matrix.yml"
+    ).read_text()
+    expected = "default: '" + str(list(matrix.FAMILY_CONFIGS)).replace("'", '"') + "'"
+    assert expected in workflow
+
+
 def test_cli_smoke_covers_base_commands_but_not_optional_chat(matrix):
     assert set(matrix.CLI_SMOKE_SCRIPTS) == {
         "rapid-mlx",

--- a/tests/test_release_fleet.py
+++ b/tests/test_release_fleet.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the manifest-driven release model fleet."""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "release_fleet.py"
+
+
+@pytest.fixture(scope="module")
+def fleet():
+    spec = importlib.util.spec_from_file_location("release_fleet", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_release_scope_covers_routinely_feasible_families(fleet):
+    assert fleet.models_for_scope("release") == (
+        "qwen3.5-4b-4bit",
+        "qwen3.5-35b-4bit",
+        "qwen3.6-27b-4bit",
+        "gemma-4-12b-4bit",
+        "deepseek-r1-32b-4bit",
+        "gpt-oss-20b-mxfp4-q8",
+    )
+
+
+def test_toolchain_scope_adds_ultra_only_family(fleet):
+    release_models = set(fleet.models_for_scope("release"))
+    toolchain_models = set(fleet.models_for_scope("toolchain"))
+    assert toolchain_models == release_models | {"hy3-preview-4bit"}
+
+
+def test_release_scope_covers_each_architecture_risk_class(fleet):
+    release_classes = {
+        family.coverage_class
+        for family in fleet.load_fleet()
+        if "release" in family.scopes
+    }
+    assert release_classes >= fleet.REQUIRED_RELEASE_CLASSES
+
+
+def test_toolchain_snapshot_detects_lock_only_version_bump(fleet):
+    pyproject = '[project]\ndependencies = ["mlx>=0.31"]'
+    old_lock = '[[package]]\nname = "mlx"\nversion = "0.31.0"'
+    new_lock = '[[package]]\nname = "mlx"\nversion = "0.32.0"'
+    assert fleet._toolchain_snapshot(pyproject, old_lock) != fleet._toolchain_snapshot(
+        pyproject, new_lock
+    )
+
+
+def test_toolchain_snapshot_detects_same_version_artifact_change(fleet):
+    pyproject = '[project]\ndependencies = ["mlx>=0.31"]'
+    old_lock = (
+        '[[package]]\nname = "mlx"\nversion = "0.31.0"\n'
+        'wheels = [{ url = "mlx-0.31.whl", hash = "sha256:old" }]'
+    )
+    new_lock = (
+        '[[package]]\nname = "mlx"\nversion = "0.31.0"\n'
+        'wheels = [{ url = "mlx-0.31.whl", hash = "sha256:new" }]'
+    )
+    assert fleet._toolchain_snapshot(pyproject, old_lock) != fleet._toolchain_snapshot(
+        pyproject, new_lock
+    )
+
+
+def test_toolchain_snapshot_detects_direct_requirement_bump(fleet):
+    lock = '[[package]]\nname = "mlx-lm"\nversion = "0.31.3"'
+    old_pyproject = '[project]\ndependencies = ["mlx-lm>=0.31.3"]'
+    new_pyproject = '[project]\ndependencies = ["mlx-lm>=0.32.0"]'
+    assert fleet._toolchain_snapshot(old_pyproject, lock) != fleet._toolchain_snapshot(
+        new_pyproject, lock
+    )
+
+
+def test_toolchain_snapshot_ignores_metadata_mentions(fleet):
+    lock = '[[package]]\nname = "rich"\nversion = "14.0"'
+    old_pyproject = '[project]\nname = "rapid-mlx"\nkeywords = ["llm"]'
+    new_pyproject = (
+        '[project]\nname = "rapid-mlx"\n'
+        'description = "Rapid-MLX inference"\nkeywords = ["llm", "mlx"]'
+    )
+    assert fleet._toolchain_snapshot(old_pyproject, lock) == fleet._toolchain_snapshot(
+        new_pyproject, lock
+    )
+
+
+def test_explicit_scope_does_not_require_git_lookup(fleet):
+    assert fleet.resolve_scope(requested="release", base_ref=None) == "release"
+    assert fleet.resolve_scope(requested="toolchain", base_ref=None) == "toolchain"
+
+
+def test_auto_scope_compares_with_tag_before_head(fleet, monkeypatch):
+    calls = []
+
+    def fake_run(command, **kwargs):
+        calls.append(command)
+        if command[:2] == ["git", "describe"]:
+            return subprocess.CompletedProcess(command, 0, "v0.11.0\n", "")
+        return subprocess.CompletedProcess(command, 0, command[-1], "")
+
+    monkeypatch.setattr(fleet.subprocess, "run", fake_run)
+    monkeypatch.setattr(
+        fleet,
+        "_toolchain_snapshot",
+        lambda pyproject, lock: {"pyproject": pyproject, "lock": lock},
+    )
+
+    assert fleet.resolve_scope(requested="auto", base_ref=None) == "toolchain"
+    assert calls[0][-1] == "HEAD^"
+    assert calls[0][3:5] == ["--match", "v[0-9]*"]
+    assert calls[1][-1] == "v0.11.0:pyproject.toml"
+    assert calls[2][-1] == "HEAD:pyproject.toml"
+    assert calls[3][-1] == "v0.11.0:uv.lock"
+    assert calls[4][-1] == "HEAD:uv.lock"
+
+
+def test_auto_scope_handles_untracked_lock_deterministically(fleet, monkeypatch):
+    def fake_run(command, **kwargs):
+        if command[:2] == ["git", "show"] and command[-1].endswith(":uv.lock"):
+            return subprocess.CompletedProcess(command, 128, "", "missing")
+        return subprocess.CompletedProcess(
+            command,
+            0,
+            (fleet.REPO_ROOT / "pyproject.toml").read_text(),
+            "",
+        )
+
+    monkeypatch.setattr(fleet.subprocess, "run", fake_run)
+    assert fleet.resolve_scope(requested="auto", base_ref="v0.11.0") == "release"
+
+
+def test_auto_scope_keeps_normal_fleet_when_no_tag_is_available(fleet, monkeypatch):
+    monkeypatch.setattr(
+        fleet.subprocess,
+        "run",
+        lambda command, **kwargs: subprocess.CompletedProcess(command, 128, "", ""),
+    )
+    assert fleet.resolve_scope(requested="auto", base_ref=None) == "release"
+
+
+def test_release_gauntlet_invokes_manifest_driven_sweep():
+    script = (REPO_ROOT / "scripts" / "release_check_m3.sh").read_text()
+    assert "bash scripts/coherence_sweep.sh" in script
+    assert 'FLEET_SCOPE="${FLEET_SCOPE:-auto}"' in script


### PR DESCRIPTION
## Summary

- define one release-fleet manifest for architecture-risk representatives and artifact-matrix families
- make the M3 coherence gate sweep the normal fleet before its exact gauntlet model
- automatically add the Ultra-only Hy3 path only when the MLX toolchain changed from the previous release
- keep shallow checkouts on the normal fleet and preserve explicit diagnostic overrides

This is the coverage half of #1249. Baseline inventory/refresh policy will follow separately so this PR stays focused.

## Business impact

A release can no longer pass by exercising only the cheapest/default model path while missing a model-family regression. The same manifest also prevents the artifact acceptance matrix and local release sweep from silently drifting apart.

## Validation

- Python 3.10: 34 focused tests passed
- `ruff check` passed
- shell syntax checks passed
- real local Qwen 3.5 4B coherence sweep: 6/6 passed
- Codex review converged with no actionable findings

## Scope note

MiniCPM5 was evaluated as a possible small-dense canary but was intentionally not made blocking: the current checkpoint missed two semantic golden answers despite coherent output, which would create a model-capability false alarm rather than protect release correctness.