### PR TITLE
fix(first-run): kill cold-start dead air + stop leaked HF progress bars

### DIFF
--- a/tests/test_first_run_guide.py
+++ b/tests/test_first_run_guide.py
@@ -367,35 +367,29 @@ def _run_main_gate_probe(
     return confirm, state["dispatched"]
 
 
-def test_autoselected_starter_skips_redundant_gate_probe():
-    # The auto-selected starter skips the gate's ``estimate_repo_size_bytes``
-    # HF round-trip + ``confirm_or_abort``: it is a FIXED, statically-known
-    # ~3.1 GB model (``first_run.FIRST_RUN_MODEL``), always under the gate's
-    # 10 GiB confirm threshold, so the probe can only ever return "no prompt".
-    # Skipping it removes one of the silent HF round-trips that made the
-    # first-run cold start feel hung (the disk-space gate + mirror catalog
-    # fetch are still covered — under the "Resolving…" spinner).
-    #
-    # This is NOT the old unsafe bypass codex flagged: that one derived an
-    # ``_auto_selected_model`` flag from a fail-silent scan of the cache for
-    # *any* cached alias, which could be arbitrarily large — waving through an
-    # unconfirmed multi-GB download. Here the flag is keyed strictly to the
-    # auto-selected fixed starter (``select_chat_default`` always returns
-    # ``FIRST_RUN_MODEL``), which is small by construction, so no large
-    # download can ever bypass confirmation. The disk-space gate in
-    # ``_ensure_model_downloaded`` still runs regardless.
+def test_autoselected_starter_uses_standard_download_gate():
+    # Regression guard: the auto-selected starter must NOT special-case the
+    # download gate. The starter is an unpinned Hugging Face repo whose
+    # declared size we must actually verify — never assume — before waiving
+    # confirmation, so it flows through ``estimate_repo_size_bytes`` +
+    # ``confirm_or_abort`` exactly like an explicit model. (The "small model →
+    # no prompt" decision belongs to confirm_or_abort's own 10 GiB threshold,
+    # covered in test_download_gate — the ~3.1 GB starter is under it, so the
+    # gate stays silent for it on its own, but the size is still checked.)
+    # The redundant round-trip's *latency* is what we hide — behind a
+    # "Resolving…" spinner, NOT by skipping the check.
     confirm, dispatched = _run_main_gate_probe(
         ["chat"], auto_select_alias="qwen3.5-4b-4bit"
     )
-    assert confirm.called is False  # redundant size-probe/confirm skipped
+    assert confirm.called is True  # gate NOT bypassed
     assert dispatched is True  # and the run still reaches dispatch
 
 
 def test_autoselected_starter_still_runs_disk_gate_in_prefetch(monkeypatch):
-    # Belt-and-braces for the safety argument above: skipping the CONFIRM gate
-    # for the starter must not skip the DISK-SPACE gate. ``_ensure_model_
-    # downloaded`` always calls ``_check_disk_space`` (under the spinner)
-    # before pulling, so a full disk still aborts cleanly.
+    # Belt-and-braces: the download-prep path always runs the DISK-SPACE gate
+    # before pulling. ``_ensure_model_downloaded`` calls ``_check_disk_space``
+    # (under the spinner) so a full disk still aborts cleanly regardless of the
+    # confirm gate above.
     called = {"disk": False}
 
     def _fake_disk(model_name, force=False):

--- a/tests/test_first_run_guide.py
+++ b/tests/test_first_run_guide.py
@@ -367,22 +367,47 @@ def _run_main_gate_probe(
     return confirm, state["dispatched"]
 
 
-def test_autoselected_starter_uses_standard_download_gate():
-    # Regression guard: the auto-selected starter must NOT special-case the
-    # download gate. (An earlier revision set an `_auto_selected_model` flag
-    # from a fail-silent pre-scan and bypassed the gate entirely — codex
-    # flagged that the unreliable pre-scan could then wave through an
-    # unconfirmed download.) With the gate armed (is_repo_cached=False,
-    # interactive), an uncached auto-selected starter reaches confirm_or_abort
-    # exactly like an explicit model does. The "small model → no prompt"
-    # decision belongs to confirm_or_abort's own 10 GiB threshold (covered in
-    # test_download_gate), NOT to a bypass here — the ~3.1 GB starter is far
-    # under that threshold, so the gate stays silent for it on its own.
+def test_autoselected_starter_skips_redundant_gate_probe():
+    # The auto-selected starter skips the gate's ``estimate_repo_size_bytes``
+    # HF round-trip + ``confirm_or_abort``: it is a FIXED, statically-known
+    # ~3.1 GB model (``first_run.FIRST_RUN_MODEL``), always under the gate's
+    # 10 GiB confirm threshold, so the probe can only ever return "no prompt".
+    # Skipping it removes one of the silent HF round-trips that made the
+    # first-run cold start feel hung (the disk-space gate + mirror catalog
+    # fetch are still covered — under the "Resolving…" spinner).
+    #
+    # This is NOT the old unsafe bypass codex flagged: that one derived an
+    # ``_auto_selected_model`` flag from a fail-silent scan of the cache for
+    # *any* cached alias, which could be arbitrarily large — waving through an
+    # unconfirmed multi-GB download. Here the flag is keyed strictly to the
+    # auto-selected fixed starter (``select_chat_default`` always returns
+    # ``FIRST_RUN_MODEL``), which is small by construction, so no large
+    # download can ever bypass confirmation. The disk-space gate in
+    # ``_ensure_model_downloaded`` still runs regardless.
     confirm, dispatched = _run_main_gate_probe(
         ["chat"], auto_select_alias="qwen3.5-4b-4bit"
     )
-    assert confirm.called is True  # gate NOT bypassed
+    assert confirm.called is False  # redundant size-probe/confirm skipped
     assert dispatched is True  # and the run still reaches dispatch
+
+
+def test_autoselected_starter_still_runs_disk_gate_in_prefetch(monkeypatch):
+    # Belt-and-braces for the safety argument above: skipping the CONFIRM gate
+    # for the starter must not skip the DISK-SPACE gate. ``_ensure_model_
+    # downloaded`` always calls ``_check_disk_space`` (under the spinner)
+    # before pulling, so a full disk still aborts cleanly.
+    called = {"disk": False}
+
+    def _fake_disk(model_name, force=False):
+        called["disk"] = True
+
+    # An HF-style repo id is not a local path, so the early ``os.path.exists``
+    # return is naturally skipped — no need to patch os.
+    monkeypatch.setattr(cli, "_check_disk_space", _fake_disk)
+    monkeypatch.setattr(cli, "_try_mirror_prefetch", lambda *a, **k: True)
+    monkeypatch.setattr("vllm_mlx._download_gate.is_repo_cached", lambda *a, **k: False)
+    cli._ensure_model_downloaded("mlx-community/Qwen3.5-4B-MLX-4bit")
+    assert called["disk"] is True
 
 
 def test_explicit_uncached_model_still_confirms():

--- a/tests/test_mirror_pull.py
+++ b/tests/test_mirror_pull.py
@@ -3695,14 +3695,31 @@ def test_silent_hf_tqdm_class_renders_nothing():
     assert getattr(bar, "disable", None) is True
 
 
-def test_hf_fallback_one_passes_silent_tqdm_only_when_suppressing(
-    tmp_path: Path,
+def test_feature_detect_matches_real_hf_signature():
+    """The ``tqdm_class`` feature-detect must reflect the REAL installed
+    ``hf_hub_download`` signature — the whole point is to avoid passing an
+    unsupported kwarg (codex: our >=0.23.0 floor lacks it and would TypeError).
+    """
+    import inspect
+
+    from huggingface_hub import hf_hub_download
+
+    real = "tqdm_class" in inspect.signature(hf_hub_download).parameters
+    assert _mirror._hf_supports_tqdm_class() is real
+
+
+def test_hf_fallback_one_forwards_tqdm_class_when_supported(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ):
-    """``_hf_fallback_one`` forwards a disabled ``tqdm_class`` iff asked."""
+    """On a hub that supports it, a disabled ``tqdm_class`` is forwarded iff
+    ``suppress_progress`` — and never otherwise."""
+    monkeypatch.setattr(_mirror, "_hf_supports_tqdm_class", lambda: True)
     captured: dict[str, object] = {}
 
-    def _fake_hf(repo_id, filename, revision, cache_dir=None, tqdm_class=None):
-        captured["tqdm_class"] = tqdm_class
+    def _fake_hf(repo_id, filename, revision, cache_dir=None, **kwargs):
+        # ``**kwargs`` so we can detect whether ``tqdm_class`` was actually
+        # forwarded (vs a defaulted None that would hide the distinction).
+        captured["kwargs"] = kwargs
         target = Path(cache_dir) / filename
         target.parent.mkdir(parents=True, exist_ok=True)
         target.write_bytes(b"x")
@@ -3712,7 +3729,7 @@ def test_hf_fallback_one_passes_silent_tqdm_only_when_suppressing(
         _mirror._hf_fallback_one(
             "owner/repo", "README.md", "rev", cache_dir=tmp_path, suppress_progress=True
         )
-    assert captured["tqdm_class"] is not None  # disabled class passed
+    assert captured["kwargs"].get("tqdm_class") is not None  # disabled class passed
 
     with patch("huggingface_hub.hf_hub_download", side_effect=_fake_hf):
         _mirror._hf_fallback_one(
@@ -3722,7 +3739,31 @@ def test_hf_fallback_one_passes_silent_tqdm_only_when_suppressing(
             cache_dir=tmp_path,
             suppress_progress=False,
         )
-    assert captured["tqdm_class"] is None  # HF default (bar shown)
+    assert "tqdm_class" not in captured["kwargs"]  # kwarg omitted (bar shown)
+
+
+def test_hf_fallback_one_omits_tqdm_class_on_old_hub(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Regression for codex round 2: on the >=0.23.0 floor, ``hf_hub_download``
+    has NO ``tqdm_class`` param — passing it would raise ``TypeError``. The
+    fake here deliberately does NOT accept ``tqdm_class`` (mirroring the real
+    old-hub signature), so if the kwarg were forwarded this test would raise.
+    """
+    monkeypatch.setattr(_mirror, "_hf_supports_tqdm_class", lambda: False)
+
+    def _fake_hf_old(repo_id, filename, revision, cache_dir=None):
+        target = Path(cache_dir) / filename
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(b"x")
+        return str(target)
+
+    with patch("huggingface_hub.hf_hub_download", side_effect=_fake_hf_old):
+        ok, path = _mirror._hf_fallback_one(
+            "owner/repo", "README.md", "rev", cache_dir=tmp_path, suppress_progress=True
+        )
+    assert ok is True  # would have TypeError'd if tqdm_class were forwarded
+    assert path is not None
 
 
 def _mirrored_pull_setup(tmp_path, monkeypatch, files, r2_status_per_file):
@@ -3859,6 +3900,10 @@ def test_metadata_hf_fallback_mutes_bar_but_weight_keeps_it(
     """End-to-end: on a mixed R2-miss pull, a small metadata file's HF
     fallback gets a disabled tqdm while a weight shard keeps its bar.
     """
+    # Force the modern-hub path so the mute assertion is meaningful regardless
+    # of the hub version the test env happens to run (see the old-hub test for
+    # the <0.23.0-floor behavior).
+    monkeypatch.setattr(_mirror, "_hf_supports_tqdm_class", lambda: True)
     files = [(".gitattributes", 1500), ("model.safetensors", 4000)]
     # Both files miss R2 (404) → both fall back to HF.
     repo_id, revision, router = _mirrored_pull_setup(

--- a/tests/test_mirror_pull.py
+++ b/tests/test_mirror_pull.py
@@ -3897,23 +3897,38 @@ def test_metadata_hf_fallback_mutes_bar_but_weight_keeps_it(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ):
-    """End-to-end: on a mixed R2-miss pull, a small metadata file's HF
-    fallback gets a disabled tqdm while a weight shard keeps its bar.
+    """End-to-end: on a mixed R2-miss pull, the pipeline asks to MUTE hf's
+    per-file bar for a small metadata file and to KEEP it for a weight shard.
+
+    We spy on ``_hf_fallback_one`` and assert the ``suppress_progress`` flag it
+    receives per file — i.e. the real ``_should_suppress_hf_bar`` discrimination
+    flowing through ``download_with_mirror_fallback``. This is the behavior this
+    PR introduces, and testing it here is honest and hermetic:
+
+    * It does NOT mock ``_hf_supports_tqdm_class`` (no forced feature support).
+    * It does NOT depend on the installed hub version, nor on introspecting a
+      mocked ``hf_hub_download`` (whose ``patch`` MagicMock has a generic
+      ``(*args, **kwargs)`` signature — feature-detection can't see through it).
+    * It does NOT assert "no stderr output": hf's tqdm auto-disables on a
+      non-TTY stream, so that would be trivially green even on broken code.
+
+    Whether the muted flag actually forwards a disabled ``tqdm_class`` to hf,
+    and whether the real ``hf_hub_download`` honors it, are covered separately
+    by ``test_hf_fallback_one_forwards_tqdm_class_when_supported`` /
+    ``test_feature_detect_matches_real_hf_signature`` (and hf's own contract).
     """
-    # Force the modern-hub path so the mute assertion is meaningful regardless
-    # of the hub version the test env happens to run (see the old-hub test for
-    # the <0.23.0-floor behavior).
-    monkeypatch.setattr(_mirror, "_hf_supports_tqdm_class", lambda: True)
     files = [(".gitattributes", 1500), ("model.safetensors", 4000)]
     # Both files miss R2 (404) → both fall back to HF.
     repo_id, revision, router = _mirrored_pull_setup(
         tmp_path, monkeypatch, files, [404, 404]
     )
 
-    seen: dict[str, object] = {}
+    suppress_seen: dict[str, bool] = {}
 
-    def _fake_hf(repo_id, filename, revision, cache_dir=None, tqdm_class=None):
-        seen[filename] = tqdm_class
+    def _spy_fallback(
+        repo_id, filename, revision, cache_dir=None, suppress_progress=False
+    ):
+        suppress_seen[filename] = suppress_progress
         snap = (
             Path(cache_dir)
             / f"models--{repo_id.replace('/', '--')}"
@@ -3922,8 +3937,9 @@ def test_metadata_hf_fallback_mutes_bar_but_weight_keeps_it(
         )
         snap.mkdir(parents=True, exist_ok=True)
         size = next(s for n, s in files if n == filename)
-        (snap / filename).write_bytes(b"h" * size)
-        return str(snap / filename)
+        target = snap / filename
+        target.write_bytes(b"h" * size)
+        return True, str(target)
 
     with (
         patch("urllib.request.urlopen", side_effect=router),
@@ -3931,10 +3947,10 @@ def test_metadata_hf_fallback_mutes_bar_but_weight_keeps_it(
             "huggingface_hub.model_info",
             return_value=_mk_model_info(revision, files),
         ),
-        patch("huggingface_hub.hf_hub_download", side_effect=_fake_hf),
+        patch.object(_mirror, "_hf_fallback_one", side_effect=_spy_fallback),
     ):
         ok = _mirror.download_with_mirror_fallback(repo_id, cache_dir=tmp_path)
 
     assert ok
-    assert seen[".gitattributes"] is not None  # muted
-    assert seen["model.safetensors"] is None  # bar kept
+    assert suppress_seen[".gitattributes"] is True  # metadata → bar muted
+    assert suppress_seen["model.safetensors"] is False  # weight → bar kept

--- a/tests/test_mirror_pull.py
+++ b/tests/test_mirror_pull.py
@@ -3708,6 +3708,67 @@ def test_feature_detect_matches_real_hf_signature():
     assert _mirror._hf_supports_tqdm_class() is real
 
 
+def test_silent_class_mutes_hf_real_download_bar_construction():
+    """Against the REAL installed hf, prove both (a) the per-file download bar
+    this PR mutes is a genuine leak and (b) our injected class silences it.
+
+    Exercises hf's own bar-construction function — ``_create_progress_bar``,
+    which ``hf_hub_download`` reaches via ``http_get`` →
+    ``_get_progress_bar_context`` — with the call shape hf uses, differing only
+    in ``cls``:
+
+    * hf's default tqdm            → renders a real bar (``%|`` / ``B/s``),
+    * our ``_silent_hf_tqdm_class()`` → emits nothing.
+
+    Hermetic (no network) and — unlike a "capture a real download's stderr"
+    test — not defeated by a fast sub-interval transfer or by non-TTY
+    auto-disable (both of which mask the difference). This is the direct,
+    non-mocked evidence that the injected class works with the installed hf, and
+    that ``hf_hub_download`` honors ``tqdm_class`` for its per-file bar. If hf
+    relocates these internals in a future release the test skips (the mechanism
+    is also covered by the unit-level forwarding/omit tests) rather than
+    falsely failing.
+    """
+    import logging
+
+    hf_tqdm_utils = pytest.importorskip("huggingface_hub.utils.tqdm")
+    create = getattr(hf_tqdm_utils, "_create_progress_bar", None)
+    hf_tqdm = getattr(hf_tqdm_utils, "tqdm", None)
+    if create is None or hf_tqdm is None:
+        pytest.skip("hf progress-bar internals moved; mechanism covered elsewhere")
+
+    class _FakeTTY(io.StringIO):
+        def isatty(self):  # tqdm renders only when it believes it's a terminal
+            return True
+
+    def _render(cls):
+        buf = _FakeTTY()
+        bar = create(
+            cls=cls,
+            log_level=logging.WARNING,
+            name="huggingface_hub.http_get",
+            unit="B",
+            unit_scale=True,
+            total=17_000_000,
+            initial=0,
+            desc="pytorch_model.bin",
+            file=buf,
+        )
+        for _ in range(4):
+            bar.update(4_250_000)
+            bar.refresh()
+        bar.close()
+        return buf.getvalue()
+
+    default_out = _render(hf_tqdm)
+    silent_out = _render(_mirror._silent_hf_tqdm_class())
+
+    # The leak is real: hf's default renders a per-file progress bar.
+    assert "%|" in default_out or "B/s" in default_out
+    # Our injected class suppresses it entirely.
+    assert silent_out == ""
+
+
 def test_hf_fallback_one_forwards_tqdm_class_when_supported(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ):

--- a/tests/test_mirror_pull.py
+++ b/tests/test_mirror_pull.py
@@ -302,7 +302,7 @@ def test_per_file_fallback(
     # the calls so we can assert which files HF was asked for.
     hf_calls: list[str] = []
 
-    def _fake_hf(repo_id, filename, revision, cache_dir=None):
+    def _fake_hf(repo_id, filename, revision, cache_dir=None, **kwargs):
         hf_calls.append(filename)
         snap = (
             Path(cache_dir)
@@ -386,7 +386,7 @@ def test_not_yet_mirrored_skips_r2_entirely(
 
     hf_calls: list[str] = []
 
-    def _fake_hf(repo_id, filename, revision, cache_dir=None):
+    def _fake_hf(repo_id, filename, revision, cache_dir=None, **kwargs):
         hf_calls.append(filename)
         snap = (
             Path(cache_dir)
@@ -452,7 +452,7 @@ def test_catalog_500_falls_through_to_hf(
     # fast to HF rather than incur 60s timeouts per file (codex round-4
     # BLOCKING #3). Therefore: no R2 file URL is registered.
 
-    def _fake_hf(repo_id, filename, revision, cache_dir=None):
+    def _fake_hf(repo_id, filename, revision, cache_dir=None, **kwargs):
         snap = (
             Path(cache_dir)
             / f"models--{repo_id.replace('/', '--')}"
@@ -605,7 +605,7 @@ def test_size_mismatch_deletes_r2_file_and_uses_hf(
 
     hf_calls: list[str] = []
 
-    def _fake_hf(repo_id, filename, revision, cache_dir=None):
+    def _fake_hf(repo_id, filename, revision, cache_dir=None, **kwargs):
         hf_calls.append(filename)
         snap = (
             Path(cache_dir)
@@ -752,7 +752,7 @@ def test_resume_rejects_bad_content_range(
         _FakeResponse(206, b"x" * 200, headers={"Content-Range": "bytes 0-199/200"}),
     )
 
-    def _fake_hf(repo_id, filename, revision, cache_dir=None):
+    def _fake_hf(repo_id, filename, revision, cache_dir=None, **kwargs):
         snap_local = (
             Path(cache_dir)
             / f"models--{repo_id.replace('/', '--')}"
@@ -1042,7 +1042,7 @@ def test_resume_rejects_short_content_range(
         _FakeResponse(206, b"x" * 50, headers={"Content-Range": "bytes 50-99/200"}),
     )
 
-    def _fake_hf(repo_id, filename, revision, cache_dir=None):
+    def _fake_hf(repo_id, filename, revision, cache_dir=None, **kwargs):
         snap_local = (
             Path(cache_dir)
             / f"models--{repo_id.replace('/', '--')}"
@@ -1106,7 +1106,7 @@ def test_resume_rejects_wrong_total_in_content_range(
         _FakeResponse(206, b"x" * 150, headers={"Content-Range": "bytes 50-199/300"}),
     )
 
-    def _fake_hf(repo_id, filename, revision, cache_dir=None):
+    def _fake_hf(repo_id, filename, revision, cache_dir=None, **kwargs):
         snap_local = (
             Path(cache_dir)
             / f"models--{repo_id.replace('/', '--')}"
@@ -1277,7 +1277,7 @@ def test_custom_mirror_with_5xx_catalog_skips_direct_layout(
         _FakeResponse(503, b"backend down"),
     )
 
-    def _fake_hf(repo_id, filename, revision, cache_dir=None):
+    def _fake_hf(repo_id, filename, revision, cache_dir=None, **kwargs):
         snap = (
             Path(cache_dir)
             / f"models--{repo_id.replace('/', '--')}"
@@ -1348,7 +1348,7 @@ def test_r2_lfs_sha256_mismatch_falls_back_to_hf(
         _FakeResponse(200, payload_corrupt),
     )
 
-    def _fake_hf(repo_id, filename, revision, cache_dir=None):
+    def _fake_hf(repo_id, filename, revision, cache_dir=None, **kwargs):
         snap = (
             Path(cache_dir)
             / f"models--{repo_id.replace('/', '--')}"
@@ -1571,7 +1571,7 @@ def test_r2_empty_response_without_expected_size_falls_back_to_hf(
     # re-fetched from HF (not silently accepted as R2 success).
     hf_calls: list[str] = []
 
-    def _fake_hf(repo_id, filename, revision, cache_dir=None):
+    def _fake_hf(repo_id, filename, revision, cache_dir=None, **kwargs):
         hf_calls.append(filename)
         snap = (
             Path(cache_dir)
@@ -1651,7 +1651,7 @@ def test_r2_empty_response_with_expected_size_still_falls_back_via_size_check(
 
     hf_calls: list[str] = []
 
-    def _fake_hf(repo_id, filename, revision, cache_dir=None):
+    def _fake_hf(repo_id, filename, revision, cache_dir=None, **kwargs):
         hf_calls.append(filename)
         snap = (
             Path(cache_dir)
@@ -2488,7 +2488,7 @@ def test_snap_dir_as_symlink_is_refused(
         _FakeResponse(200, b"x" * 100),
     )
 
-    def _fake_hf(repo_id, filename, revision, cache_dir=None):
+    def _fake_hf(repo_id, filename, revision, cache_dir=None, **kwargs):
         # HF would write to its own cache layout — for this test it
         # doesn't matter, we just need the per-file loop to complete.
         snap = (
@@ -3018,7 +3018,7 @@ def test_progress_file_count_matches_downloaded_files(
         else:
             router.add(url, _FakeResponse(404, b""))
 
-    def _fake_hf(repo_id, filename, revision, cache_dir=None):
+    def _fake_hf(repo_id, filename, revision, cache_dir=None, **kwargs):
         snap = (
             Path(cache_dir)
             / f"models--{repo_id.replace('/', '--')}"
@@ -3166,7 +3166,7 @@ def test_bytes_heartbeat_skipped_when_total_unknown(
             _FakeResponse(404, b""),
         )
 
-    def _fake_hf(repo_id, filename, revision, cache_dir=None):
+    def _fake_hf(repo_id, filename, revision, cache_dir=None, **kwargs):
         snap = (
             Path(cache_dir)
             / f"models--{repo_id.replace('/', '--')}"
@@ -3351,7 +3351,7 @@ def test_progress_no_double_count_on_r2_short_read_then_hf(
         _FakeResponse(200, b"x" * 400, headers={"Content-Length": "1000"}),
     )
 
-    def _fake_hf(repo_id, filename, revision, cache_dir=None):
+    def _fake_hf(repo_id, filename, revision, cache_dir=None, **kwargs):
         snap = (
             Path(cache_dir)
             / f"models--{repo_id.replace('/', '--')}"
@@ -3651,3 +3651,245 @@ def test_progress_tracker_flush_runs_even_when_worker_raises_unwhitelisted(
         f"The post-with flush is gated by a try/finally so the desktop "
         f"progress bar lands at 100% even on the failure path."
     )
+
+
+# ---------------------------------------------------------------------------
+# First-run cold-start UX (P1/P2): resolve-phase spinner hook + HF tqdm mute.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "filename,expected_size,want_suppress",
+    [
+        # Weight shards — always keep the intra-file bar (only progress
+        # signal if a big shard falls back to HF on a transient R2 failure).
+        ("model-00001-of-00002.safetensors", 2_000_000_000, False),
+        ("model.bin", 900_000_000, False),
+        ("weights.gguf", 3_000_000, False),  # weight suffix wins over size
+        # Confirmed-small non-weight metadata — mute the noise.
+        (".gitattributes", 1500, True),
+        ("README.md", 8000, True),
+        ("config.json", 900, True),
+        ("vocab.txt", 500_000, True),
+        # Unknown size → fail toward SHOWING the bar.
+        ("tokenizer.json", None, False),
+        (".gitattributes", None, False),
+        # Boundary: exactly at the 5 MiB keep-threshold stays visible.
+        ("tokenizer.json", _mirror._HF_BAR_KEEP_MIN_BYTES, False),
+        ("tokenizer.json", _mirror._HF_BAR_KEEP_MIN_BYTES - 1, True),
+    ],
+)
+def test_should_suppress_hf_bar(filename, expected_size, want_suppress):
+    assert _mirror._should_suppress_hf_bar(filename, expected_size) is want_suppress
+
+
+def test_silent_hf_tqdm_class_renders_nothing():
+    """The suppression class must be a disabled, no-op tqdm."""
+    Silent = _mirror._silent_hf_tqdm_class()
+    buf = io.StringIO()
+    bar = Silent(total=100, file=buf)
+    bar.update(50)
+    bar.update(50)
+    bar.close()
+    assert buf.getvalue() == ""
+    assert getattr(bar, "disable", None) is True
+
+
+def test_hf_fallback_one_passes_silent_tqdm_only_when_suppressing(
+    tmp_path: Path,
+):
+    """``_hf_fallback_one`` forwards a disabled ``tqdm_class`` iff asked."""
+    captured: dict[str, object] = {}
+
+    def _fake_hf(repo_id, filename, revision, cache_dir=None, tqdm_class=None):
+        captured["tqdm_class"] = tqdm_class
+        target = Path(cache_dir) / filename
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(b"x")
+        return str(target)
+
+    with patch("huggingface_hub.hf_hub_download", side_effect=_fake_hf):
+        _mirror._hf_fallback_one(
+            "owner/repo", "README.md", "rev", cache_dir=tmp_path, suppress_progress=True
+        )
+    assert captured["tqdm_class"] is not None  # disabled class passed
+
+    with patch("huggingface_hub.hf_hub_download", side_effect=_fake_hf):
+        _mirror._hf_fallback_one(
+            "owner/repo",
+            "model.safetensors",
+            "rev",
+            cache_dir=tmp_path,
+            suppress_progress=False,
+        )
+    assert captured["tqdm_class"] is None  # HF default (bar shown)
+
+
+def _mirrored_pull_setup(tmp_path, monkeypatch, files, r2_status_per_file):
+    """Wire a fully-mirrored pull; return (repo_id, revision, router, ctx).
+
+    ``ctx`` is a list of patch context managers the caller enters.
+    """
+    repo_id = "mlx-community/Qwen3-0.6B-4bit"
+    revision = "abcd1234" * 5
+    catalog = _catalog_payload([("qwen3-0.6b-4bit", repo_id, "mirrored")])
+    router = _UrlRouter()
+    router.add(
+        "https://models.rapidmlx.com/api/models",
+        _FakeResponse(200, json.dumps(catalog).encode()),
+    )
+    for (fname, size), status in zip(files, r2_status_per_file, strict=True):
+        url = f"https://models.rapidmlx.com/mlx-community/Qwen3-0.6B-4bit/{fname}"
+        router.add(
+            url,
+            _FakeResponse(200, b"x" * size)
+            if status == 200
+            else _FakeResponse(404, b""),
+        )
+    monkeypatch.setenv("RAPID_MLX_MODEL_MIRROR", "https://models.rapidmlx.com")
+    return repo_id, revision, router
+
+
+def test_on_pull_start_fires_once_before_first_pulling_line(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """The resolve-phase hook must fire exactly once, and strictly BEFORE the
+    first ``Pulling`` line — otherwise the CLI spinner would collide with the
+    download output it is meant to precede.
+    """
+    files = [("config.json", 100), ("model.safetensors", 200)]
+    repo_id, revision, router = _mirrored_pull_setup(
+        tmp_path, monkeypatch, files, [200, 200]
+    )
+
+    events: list[str] = []
+    monkeypatch.setattr(
+        _mirror, "_print_dim", lambda msg: events.append(f"print:{msg}")
+    )
+
+    with (
+        patch("urllib.request.urlopen", side_effect=router),
+        patch(
+            "huggingface_hub.model_info",
+            return_value=_mk_model_info(revision, files),
+        ),
+    ):
+        ok = _mirror.download_with_mirror_fallback(
+            repo_id,
+            cache_dir=tmp_path,
+            on_pull_start=lambda: events.append("resolve_done"),
+        )
+
+    assert ok
+    assert events.count("resolve_done") == 1, "hook must fire exactly once"
+    hook_idx = events.index("resolve_done")
+    pulling_idxs = [i for i, e in enumerate(events) if "Pulling" in e]
+    assert pulling_idxs, "expected a Pulling line"
+    assert hook_idx < pulling_idxs[0], "hook must fire before the first Pulling line"
+
+
+def test_on_pull_start_not_fired_when_mirror_skipped(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """When the catalog says the alias is NOT mirrored, the mirror returns
+    False (caller falls back to ``snapshot_download``) and must NOT fire the
+    hook — the CLI keeps its spinner up for the snapshot banner instead.
+    """
+    repo_id = "mlx-community/Gemma-4-31B-4bit"
+    revision = "beef" * 10
+    files = [("config.json", 100)]
+    catalog = _catalog_payload([("gemma-4-31b-4bit", repo_id, "not yet mirrored")])
+    router = _UrlRouter()
+    router.add(
+        "https://models.rapidmlx.com/api/models",
+        _FakeResponse(200, json.dumps(catalog).encode()),
+    )
+    monkeypatch.setenv("RAPID_MLX_MODEL_MIRROR", "https://models.rapidmlx.com")
+
+    fired: list[str] = []
+    with (
+        patch("urllib.request.urlopen", side_effect=router),
+        patch(
+            "huggingface_hub.model_info",
+            return_value=_mk_model_info(revision, files),
+        ),
+    ):
+        ok = _mirror.download_with_mirror_fallback(
+            repo_id,
+            cache_dir=tmp_path,
+            on_pull_start=lambda: fired.append("x"),
+        )
+
+    assert ok is False
+    assert fired == [], "hook must not fire on the return-False fall-through"
+
+
+def test_on_pull_start_exception_does_not_abort_pull(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """A misbehaving hook must never break a good pull."""
+    files = [("config.json", 100)]
+    repo_id, revision, router = _mirrored_pull_setup(
+        tmp_path, monkeypatch, files, [200]
+    )
+
+    def _boom():
+        raise RuntimeError("spinner blew up")
+
+    with (
+        patch("urllib.request.urlopen", side_effect=router),
+        patch(
+            "huggingface_hub.model_info",
+            return_value=_mk_model_info(revision, files),
+        ),
+    ):
+        ok = _mirror.download_with_mirror_fallback(
+            repo_id, cache_dir=tmp_path, on_pull_start=_boom
+        )
+    assert ok
+
+
+def test_metadata_hf_fallback_mutes_bar_but_weight_keeps_it(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """End-to-end: on a mixed R2-miss pull, a small metadata file's HF
+    fallback gets a disabled tqdm while a weight shard keeps its bar.
+    """
+    files = [(".gitattributes", 1500), ("model.safetensors", 4000)]
+    # Both files miss R2 (404) → both fall back to HF.
+    repo_id, revision, router = _mirrored_pull_setup(
+        tmp_path, monkeypatch, files, [404, 404]
+    )
+
+    seen: dict[str, object] = {}
+
+    def _fake_hf(repo_id, filename, revision, cache_dir=None, tqdm_class=None):
+        seen[filename] = tqdm_class
+        snap = (
+            Path(cache_dir)
+            / f"models--{repo_id.replace('/', '--')}"
+            / "snapshots"
+            / revision
+        )
+        snap.mkdir(parents=True, exist_ok=True)
+        size = next(s for n, s in files if n == filename)
+        (snap / filename).write_bytes(b"h" * size)
+        return str(snap / filename)
+
+    with (
+        patch("urllib.request.urlopen", side_effect=router),
+        patch(
+            "huggingface_hub.model_info",
+            return_value=_mk_model_info(revision, files),
+        ),
+        patch("huggingface_hub.hf_hub_download", side_effect=_fake_hf),
+    ):
+        ok = _mirror.download_with_mirror_fallback(repo_id, cache_dir=tmp_path)
+
+    assert ok
+    assert seen[".gitattributes"] is not None  # muted
+    assert seen["model.safetensors"] is None  # bar kept

--- a/tests/test_status_spinner.py
+++ b/tests/test_status_spinner.py
@@ -1,0 +1,141 @@
+"""Tests for ``vllm_mlx.cli._StatusSpinner``.
+
+The spinner covers the silent "Resolving…" window before a cold model
+download starts (disk-space probe + mirror metadata + catalog fetch) so a
+first-run user sees activity instead of an apparent hang. It must:
+
+* be fully inert on non-TTY / ``NO_COLOR`` streams (clean CI logs + pipes),
+* animate on a TTY and clear its line on stop,
+* have an idempotent, thread-safe ``stop()`` (it doubles as a download
+  ``on_pull_start`` hook AND the ``__exit__`` clear).
+
+All timing-sensitive assertions poll a thread-safe fake stream with a
+generous timeout rather than sleeping a fixed amount, so they stay
+deterministic under load.
+"""
+
+from __future__ import annotations
+
+import io
+import threading
+import time
+
+import pytest
+
+from vllm_mlx.cli import _StatusSpinner
+
+
+class _FakeTTY:
+    """Thread-safe writable stream that reports ``isatty() == True``."""
+
+    def __init__(self, is_tty: bool = True):
+        self._is_tty = is_tty
+        self._lock = threading.Lock()
+        self._parts: list[str] = []
+
+    def write(self, s: str) -> int:
+        with self._lock:
+            self._parts.append(s)
+        return len(s)
+
+    def flush(self) -> None:
+        pass
+
+    def isatty(self) -> bool:
+        return self._is_tty
+
+    def value(self) -> str:
+        with self._lock:
+            return "".join(self._parts)
+
+    def write_count(self) -> int:
+        with self._lock:
+            return len(self._parts)
+
+
+def _wait_until(predicate, timeout: float = 2.0) -> bool:
+    end = time.monotonic() + timeout
+    while time.monotonic() < end:
+        if predicate():
+            return True
+        time.sleep(0.01)
+    return False
+
+
+def test_inert_on_non_tty_stringio():
+    """A plain (non-TTY) stream → no thread, no output, no-op stop."""
+    buf = io.StringIO()  # StringIO.isatty() is False
+    sp = _StatusSpinner("Resolving foo …", stream=buf)
+    assert sp._enabled is False
+    with sp:
+        pass
+    sp.stop()
+    sp.stop()  # idempotent
+    assert buf.getvalue() == ""
+    assert sp._thread is None
+
+
+def test_inert_when_no_color(monkeypatch: pytest.MonkeyPatch):
+    """NO_COLOR mutes the spinner even on a real TTY stream."""
+    monkeypatch.setenv("NO_COLOR", "1")
+    stream = _FakeTTY(is_tty=True)
+    sp = _StatusSpinner("Resolving foo …", stream=stream)
+    assert sp._enabled is False
+    with sp:
+        pass
+    assert stream.value() == ""
+
+
+def test_animates_and_clears_on_tty(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    stream = _FakeTTY(is_tty=True)
+    sp = _StatusSpinner("Resolving qwen …", stream=stream)
+    assert sp._enabled is True
+    with sp:
+        # The first draw happens before the first 0.1s wait — it lands fast.
+        assert _wait_until(lambda: stream.write_count() >= 1), "spinner never drew"
+        mid = stream.value()
+        assert "Resolving qwen …" in mid
+        # A braille frame char from the animation set is present.
+        assert any(ch in mid for ch in _StatusSpinner._FRAMES)
+    # __exit__ → stop(): the final write clears the line with a CR.
+    final = stream.value()
+    assert final.rstrip().endswith("\r") or final.endswith("\r")
+    assert sp._done is True
+
+
+def test_stop_halts_the_thread(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    stream = _FakeTTY(is_tty=True)
+    sp = _StatusSpinner("Resolving x …", stream=stream)
+    with sp:
+        assert _wait_until(lambda: stream.write_count() >= 1)
+    # After stop, the worker thread must be gone and quiet.
+    assert sp._thread is not None
+    assert not sp._thread.is_alive()
+    count_after_stop = stream.write_count()
+    time.sleep(0.25)  # longer than the 0.1s draw interval
+    assert stream.write_count() == count_after_stop, "thread still writing after stop"
+
+
+def test_stop_is_idempotent_and_thread_safe(monkeypatch: pytest.MonkeyPatch):
+    """``stop`` doubles as the download ``on_pull_start`` hook (called once)
+    AND the ``__exit__`` clear (called again) — both must be safe.
+    """
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    stream = _FakeTTY(is_tty=True)
+    sp = _StatusSpinner("Resolving y …", stream=stream)
+    with sp:
+        assert _wait_until(lambda: stream.write_count() >= 1)
+        sp.stop()  # simulate the on_pull_start hook firing mid-with
+        first_done = sp._done
+    # No exception on the second (exit) stop; state stays done.
+    assert first_done is True
+    assert sp._done is True
+
+
+def test_stop_before_enter_is_safe():
+    """Calling stop() without ever entering must not raise."""
+    sp = _StatusSpinner("Resolving z …", stream=_FakeTTY(is_tty=True))
+    sp.stop()
+    assert sp._done is True

--- a/tests/test_status_spinner.py
+++ b/tests/test_status_spinner.py
@@ -139,3 +139,27 @@ def test_stop_before_enter_is_safe():
     sp = _StatusSpinner("Resolving z …", stream=_FakeTTY(is_tty=True))
     sp.stop()
     assert sp._done is True
+
+
+def test_clear_is_last_write_even_with_slow_stream(monkeypatch: pytest.MonkeyPatch):
+    """The draw-lock must make the clear the FINAL write — no spinner frame
+    redraws after stop, even when the stream's write() is slow enough to race
+    the stop path (the codex-flagged scenario).
+    """
+    monkeypatch.delenv("NO_COLOR", raising=False)
+
+    class _SlowTTY(_FakeTTY):
+        def write(self, s: str) -> int:
+            time.sleep(0.03)  # widen the interleave window
+            return super().write(s)
+
+    stream = _SlowTTY(is_tty=True)
+    sp = _StatusSpinner("Resolving slow …", stream=stream)
+    with sp:
+        assert _wait_until(lambda: stream.write_count() >= 2, timeout=3.0)
+    # After stop returns, the last write must be a clean clear (CR + spaces),
+    # never a braille spinner frame.
+    with stream._lock:
+        last = stream._parts[-1]
+    assert last.strip("\r ") == "", f"last write was not a clean clear: {last!r}"
+    assert not any(ch in last for ch in _StatusSpinner._FRAMES)

--- a/vllm_mlx/_mirror.py
+++ b/vllm_mlx/_mirror.py
@@ -1144,6 +1144,27 @@ def _silent_hf_tqdm_class():
     return _SilentTqdm
 
 
+# ``hf_hub_download`` only grew a ``tqdm_class`` kwarg in a huggingface_hub
+# release NEWER than our ``>=0.23.0`` floor — passing it to an older hub raises
+# ``TypeError``. Feature-detect so metadata-bar suppression is a graceful
+# enhancement on modern hubs and a silent no-op (bar leaks, nothing crashes) on
+# old ones, rather than a hard dependency-version bump. Introspected fresh on
+# each call (a handful per pull, cheap) rather than cached — a cached first call
+# made under a mocked ``hf_hub_download`` would otherwise poison the result.
+def _hf_supports_tqdm_class() -> bool:
+    """True iff the installed ``hf_hub_download`` accepts a ``tqdm_class`` kwarg."""
+    import inspect
+
+    from huggingface_hub import hf_hub_download
+
+    try:
+        return "tqdm_class" in inspect.signature(hf_hub_download).parameters
+    except (ValueError, TypeError):
+        # Signature unintrospectable (C-accelerated / heavily wrapped) — assume
+        # unsupported and skip the kwarg to stay crash-safe.
+        return False
+
+
 def _hf_fallback_one(
     repo_id: str,
     filename: str,
@@ -1162,7 +1183,10 @@ def _hf_fallback_one(
 
     ``suppress_progress`` mutes HF's own per-file tqdm bar (passed a disabled
     ``tqdm_class``); the caller sets it for confirmed-small metadata files so
-    their bars don't collide with our aggregate progress UI.
+    their bars don't collide with our aggregate progress UI. The kwarg is only
+    forwarded when the installed huggingface_hub supports it (see
+    :func:`_hf_supports_tqdm_class`) — on older hubs it is omitted, so the bar
+    leaks rather than the call raising ``TypeError``.
 
     Codex round-2 BLOCKING #4: narrow the exception net. Only expected
     network/cache/HF-API errors are swallowed; programmer errors
@@ -1175,15 +1199,19 @@ def _hf_fallback_one(
     from huggingface_hub.errors import EntryNotFoundError, HfHubHTTPError
     from huggingface_hub.utils import RepositoryNotFoundError
 
+    kwargs: dict[str, Any] = {
+        "repo_id": repo_id,
+        "filename": filename,
+        "revision": revision,
+        "cache_dir": str(cache_dir) if cache_dir else None,
+    }
+    # Only forward ``tqdm_class`` when the hub actually accepts it; on the
+    # >=0.23.0 floor it does not, and passing it would raise ``TypeError``.
+    if suppress_progress and _hf_supports_tqdm_class():
+        kwargs["tqdm_class"] = _silent_hf_tqdm_class()
+
     try:
-        path = hf_hub_download(
-            repo_id=repo_id,
-            filename=filename,
-            revision=revision,
-            cache_dir=str(cache_dir) if cache_dir else None,
-            # ``None`` = HF's default tqdm (bar shown); disabled class = quiet.
-            tqdm_class=_silent_hf_tqdm_class() if suppress_progress else None,
-        )
+        path = hf_hub_download(**kwargs)
         return True, path
     except (
         # Expected network / HF API surface — these are legitimate

--- a/vllm_mlx/_mirror.py
+++ b/vllm_mlx/_mirror.py
@@ -43,6 +43,7 @@ import unicodedata
 import urllib.error
 import urllib.parse
 import urllib.request
+from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 from typing import Any
@@ -1075,11 +1076,80 @@ def _release_part_lock(lock_fh, lock_path: Path) -> None:
     del lock_path
 
 
+# --- HF per-file tqdm suppression on the mirror path --------------------------
+# When the R2 mirror serves the weight shards (the common case) the only files
+# that fall back to ``hf_hub_download`` are tiny non-weight assets the mirror
+# doesn't carry — ``.gitattributes``, ``README.md``, small configs.
+# ``hf_hub_download`` draws a ``\r``-based tqdm bar for each of them, which
+# collides with our own aggregate ``_ProgressTracker`` heartbeat and the
+# per-file ``[N/M]`` completion lines, garbling the display. We pass a disabled
+# ``tqdm_class`` for those files so HF stays quiet and our UI owns the terminal.
+#
+# We deliberately do NOT suppress the bar for real weight downloads: if a
+# multi-GB shard ever falls back to HF (a transient R2 failure), HF's
+# intra-file bar is the only progress signal — the aggregate tracker credits
+# HF-fallback bytes only at completion (see the ``kind == "hf"`` arm in the
+# ``as_completed`` loop), so muting it there would reintroduce exactly the dead
+# air we are trying to remove. ``_should_suppress_hf_bar`` therefore fails
+# toward SHOWING the bar: it stays on for any weight suffix OR any file whose
+# size we can't confirm is small.
+
+# Binary weight containers whose HF-fallback download is worth an intra-file
+# progress bar. Excludes ``.json`` / ``.txt`` / ``.model`` — those are
+# configs/tokenizers, small enough that a bar is pure noise.
+_STREAMED_WEIGHT_SUFFIXES: tuple[str, ...] = (
+    ".safetensors",
+    ".bin",
+    ".gguf",
+    ".npz",
+    ".pt",
+    ".pth",
+)
+
+# Below this HF-advertised size a non-weight file is treated as "metadata" and
+# its bar is suppressed. 5 MiB clears every real config/README while staying
+# well under any weight shard.
+_HF_BAR_KEEP_MIN_BYTES = 5 * 1024 * 1024
+
+
+def _should_suppress_hf_bar(filename: str, expected_size: int | None) -> bool:
+    """True when HF's per-file tqdm for ``filename`` is noise, not signal.
+
+    Fails toward showing the bar (returns ``False``) for weight shards and for
+    any file whose size we can't confirm is small, so a rare big-shard HF
+    fallback still renders intra-file progress.
+    """
+    if filename.lower().endswith(_STREAMED_WEIGHT_SUFFIXES):
+        return False
+    if expected_size is None:
+        return False
+    return expected_size < _HF_BAR_KEEP_MIN_BYTES
+
+
+def _silent_hf_tqdm_class():
+    """A ``tqdm``-compatible class that never renders, for ``hf_hub_download``.
+
+    Subclasses HuggingFace's own tqdm wrapper and forces ``disable=True`` so
+    the suppression is per-call (thread-safe) — no global
+    ``disable_progress_bars()`` toggle that would race across the worker pool
+    while a concurrent big-shard fallback is still drawing its bar.
+    """
+    from huggingface_hub.utils import tqdm as _hf_tqdm
+
+    class _SilentTqdm(_hf_tqdm):  # type: ignore[misc, valid-type]
+        def __init__(self, *args, **kwargs):
+            kwargs["disable"] = True
+            super().__init__(*args, **kwargs)
+
+    return _SilentTqdm
+
+
 def _hf_fallback_one(
     repo_id: str,
     filename: str,
     revision: str,
     cache_dir: Path | None = None,
+    suppress_progress: bool = False,
 ) -> tuple[bool, str | None]:
     """Download a single file from HuggingFace into the standard cache.
 
@@ -1089,6 +1159,10 @@ def _hf_fallback_one(
     the per-file R2 miss path. Codex round-1 NIT #3: capture the path
     rather than re-resolving via ``snap_dir / fname``, so success
     accounting is robust to changes in HF's symlink layout.
+
+    ``suppress_progress`` mutes HF's own per-file tqdm bar (passed a disabled
+    ``tqdm_class``); the caller sets it for confirmed-small metadata files so
+    their bars don't collide with our aggregate progress UI.
 
     Codex round-2 BLOCKING #4: narrow the exception net. Only expected
     network/cache/HF-API errors are swallowed; programmer errors
@@ -1107,6 +1181,8 @@ def _hf_fallback_one(
             filename=filename,
             revision=revision,
             cache_dir=str(cache_dir) if cache_dir else None,
+            # ``None`` = HF's default tqdm (bar shown); disabled class = quiet.
+            tqdm_class=_silent_hf_tqdm_class() if suppress_progress else None,
         )
         return True, path
     except (
@@ -1172,6 +1248,7 @@ def download_with_mirror_fallback(
     cache_dir: Path | None = None,
     *,
     revision: str | None = None,
+    on_pull_start: Callable[[], None] | None = None,
 ) -> bool:
     """Download ``repo_id`` to the HF cache via R2-first / HF-fallback.
 
@@ -1195,6 +1272,12 @@ def download_with_mirror_fallback(
     ``snapshot_download`` runs and pins the right revision instead of us
     silently overwriting ``refs/main`` with HEAD. ``revision=None`` and
     ``revision="main"`` both mean default branch and are accepted.
+
+    ``on_pull_start`` is an optional zero-arg hook fired exactly once, right
+    before the first ``Pulling`` line is printed (i.e. after the size/catalog
+    round-trips resolve). The CLI uses it to retire a "Resolving…" spinner so
+    it doesn't collide with the download output. It never fires on the
+    ``return False`` fall-through path.
     """
     from ._hf_logging import silence_hf_unauthenticated_warning
 
@@ -1350,6 +1433,19 @@ def download_with_mirror_fallback(
     BOLD = "\x1b[1m" if is_tty else ""
     DIM = "\x1b[2m" if is_tty else ""
     RESET = "\x1b[0m" if is_tty else ""
+
+    # We're about to emit real download output. Let the caller retire any
+    # "Resolving…" spinner it started BEFORE our first ``Pulling`` line so the
+    # two don't collide on the terminal. Fired only on the paths that actually
+    # print (both ``use_r2`` branches) — never before the ``return False``
+    # below, where the caller keeps the spinner up for its own
+    # ``snapshot_download`` banner. The callback must be cheap and
+    # exception-safe; a misbehaving hook shouldn't abort a good pull.
+    if use_r2 and on_pull_start is not None:
+        try:
+            on_pull_start()
+        except Exception:
+            pass
 
     if use_r2 and catalog_mirrored:
         _print_dim(
@@ -1599,7 +1695,16 @@ def download_with_mirror_fallback(
 
         # Either R2 not eligible or R2 missed — fall back to HF for
         # this file. Let huggingface_hub handle its own cache layout.
-        ok, hf_path = _hf_fallback_one(repo_id, fname, revision, cache_dir=cache_root)
+        # Mute HF's tqdm for confirmed-small metadata files so it doesn't
+        # collide with our aggregate UI; keep it for weight/unknown-size
+        # files (see ``_should_suppress_hf_bar``).
+        ok, hf_path = _hf_fallback_one(
+            repo_id,
+            fname,
+            revision,
+            cache_dir=cache_root,
+            suppress_progress=_should_suppress_hf_bar(fname, expected_size),
+        )
         if ok:
             # ``hf_hub_download`` returns the resolved snapshot path
             # (typically a symlink to a blob). Stat the path it gave us

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -1397,21 +1397,32 @@ class _StatusSpinner:
 
         self._stop_event = threading.Event()
         self._lock = threading.Lock()
+        # Serializes the worker's frame writes against ``stop``'s clear so the
+        # clear is guaranteed to be the LAST thing written to the stream (no
+        # post-clear redraw). Held only around the brief write/flush — never
+        # across the inter-frame wait — so ``stop`` can grab it promptly.
+        self._draw_lock = threading.Lock()
 
     def _run(self) -> None:
         import time
 
         tick = 0
         while not self._stop_event.is_set():
-            try:
-                elapsed = int(time.monotonic() - self._start)
-                ch = self._FRAMES[tick % len(self._FRAMES)]
-                self._stream.write(
-                    f"\r  \x1b[36m{ch}\x1b[0m {self._label} \x1b[2m{elapsed}s\x1b[0m"
-                )
-                self._stream.flush()
-            except (ValueError, OSError):
-                return  # stream closed underneath us — stop quietly.
+            with self._draw_lock:
+                # Re-check under the lock: if ``stop`` set the event while we
+                # waited for the lock, do not draw — otherwise this frame would
+                # land AFTER stop's clear.
+                if self._stop_event.is_set():
+                    return
+                try:
+                    elapsed = int(time.monotonic() - self._start)
+                    ch = self._FRAMES[tick % len(self._FRAMES)]
+                    self._stream.write(
+                        f"\r  \x1b[36m{ch}\x1b[0m {self._label} \x1b[2m{elapsed}s\x1b[0m"
+                    )
+                    self._stream.flush()
+                except (ValueError, OSError):
+                    return  # stream closed underneath us — stop quietly.
             tick += 1
             self._stop_event.wait(0.1)
 
@@ -1431,9 +1442,17 @@ class _StatusSpinner:
             if self._done:
                 return
             self._done = True
-        if self._thread is not None:
-            self._stop_event.set()
-            self._thread.join(timeout=1.0)
+        self._stop_event.set()
+        if self._thread is None:
+            return  # inert (non-TTY) or never entered — nothing drawn.
+        self._thread.join(timeout=1.0)
+        # Clear under the draw lock so the clear is the worker's final write.
+        # If the worker is wedged in a blocked ``write()`` and never frees the
+        # lock within the timeout, the stream is broken — skip the clear rather
+        # than risk a garbled interleave or an unbounded hang (a stray frame on
+        # a broken stream won't render anyway). ``acquire`` doubles as the
+        # confirmation that no worker write is in flight.
+        if self._draw_lock.acquire(timeout=1.0):
             try:
                 # Clear the whole line; the label + " Ns" fits well within a
                 # generous fixed width (ANSI codes take no display columns).
@@ -1441,6 +1460,8 @@ class _StatusSpinner:
                 self._stream.flush()
             except (ValueError, OSError):
                 pass
+            finally:
+                self._draw_lock.release()
 
     def __exit__(self, *exc: object) -> bool:
         self.stop()
@@ -8827,14 +8848,6 @@ Examples:
         _cmd = getattr(args, "command", "chat")
         _sel_alias, _starter_cached = select_chat_default()
         args.model = _sel_alias
-        # Mark the auto-selected starter so the download gate below can skip
-        # its ``estimate_repo_size_bytes`` HF round-trip: the starter is a
-        # known ~3 GB model, always under the gate's 10 GiB confirm threshold,
-        # so the probe can only ever return "no prompt". Skipping it removes
-        # one of the silent HF round-trips that make the first-run cold start
-        # feel hung (the disk probe + mirror catalog fetch are covered by the
-        # "Resolving…" spinner instead).
-        args._autofilled_starter = True
         if sys.stdin.isatty():
             if _starter_cached:
                 print(
@@ -8973,12 +8986,6 @@ Examples:
         and "/" in args.model  # only HF-style repo ids; local paths skip
         and not os.path.exists(args.model)
         and not _chat_spawn_child
-        # The auto-selected first-run starter is a known ~3 GB model, always
-        # under the confirm threshold — skip the gate's size-probe round-trip
-        # entirely (it can only ever return "no prompt") so the cold start
-        # isn't stalled on a redundant HF ``model_info`` call. The disk-space
-        # gate in ``_ensure_model_downloaded`` still runs, under the spinner.
-        and not getattr(args, "_autofilled_starter", False)
     ):
         # Cheap checks first: env override and non-TTY both short-circuit
         # without touching the HF API. ``confirm_or_abort`` re-checks
@@ -8995,10 +9002,20 @@ Examples:
             )
 
             if not is_repo_cached(args.model):
-                confirm_or_abort(
-                    args.model,
-                    estimate_repo_size_bytes(args.model),
-                )
+                # The size estimate is a silent HF ``model_info`` round-trip
+                # (up to 5s). Cover it with a "Resolving…" spinner so the
+                # first-run cold start doesn't read as a hang here — the same
+                # treatment the download prep gets in ``_ensure_model_
+                # downloaded``. The spinner clears BEFORE ``confirm_or_abort``
+                # so a genuine confirm prompt (large uncached model) lands on a
+                # clean line. We keep the real size-based gate for EVERY model,
+                # including the auto-selected starter: it is an unpinned HF repo
+                # whose declared size we must actually verify, never assume,
+                # before waiving consent.
+                _short = args.model.split("/")[-1]
+                with _StatusSpinner(f"Resolving {_short} …"):
+                    _size = estimate_repo_size_bytes(args.model)
+                confirm_or_abort(args.model, _size)
     # --- END B2 --------------------------------------------------------
 
     if args.command == "serve":

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -18,6 +18,7 @@ Usage:
 import argparse
 import os
 import sys
+from collections.abc import Callable
 
 from vllm_mlx._completion import alias_completer
 
@@ -1364,7 +1365,92 @@ def _check_memory_capacity(model_name: str) -> None:
     print()
 
 
-def _try_mirror_prefetch(model_name: str) -> bool:
+class _StatusSpinner:
+    """Animated ``⠋ <label> Ns`` spinner on stderr for a blocking phase.
+
+    Context manager. On a TTY it spawns a daemon thread that redraws the
+    label + elapsed seconds at ~10 fps; :meth:`stop` (idempotent) clears the
+    line. Non-TTY / ``NO_COLOR`` → fully inert (no thread, no output) so CI
+    logs and pipes stay clean. :meth:`stop` is public so a caller can retire
+    the spinner mid-``with`` — e.g. from a download's ``on_pull_start`` hook,
+    right before the first real progress line — while ``__exit__`` remains a
+    belt-and-braces clear on every exit path.
+
+    Mirrors the inline spinner in :func:`_wait_for_chat_server` (same frames /
+    stream) so the cold-download "Resolving…" phase looks like the warm
+    "loading model…" phase the REPL already shows.
+    """
+
+    _FRAMES = "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"
+
+    def __init__(self, label: str, *, stream=None) -> None:
+        self._label = label
+        self._stream = stream if stream is not None else sys.stderr
+        # ``isatty`` can be absent on exotic stream stand-ins; treat missing
+        # as non-TTY so we stay inert rather than crash.
+        _isatty = getattr(self._stream, "isatty", None)
+        self._enabled = bool(_isatty and _isatty()) and "NO_COLOR" not in os.environ
+        self._done = False
+        self._start = 0.0
+        self._thread = None
+        import threading
+
+        self._stop_event = threading.Event()
+        self._lock = threading.Lock()
+
+    def _run(self) -> None:
+        import time
+
+        tick = 0
+        while not self._stop_event.is_set():
+            try:
+                elapsed = int(time.monotonic() - self._start)
+                ch = self._FRAMES[tick % len(self._FRAMES)]
+                self._stream.write(
+                    f"\r  \x1b[36m{ch}\x1b[0m {self._label} \x1b[2m{elapsed}s\x1b[0m"
+                )
+                self._stream.flush()
+            except (ValueError, OSError):
+                return  # stream closed underneath us — stop quietly.
+            tick += 1
+            self._stop_event.wait(0.1)
+
+    def __enter__(self) -> "_StatusSpinner":
+        if self._enabled:
+            import threading
+            import time
+
+            self._start = time.monotonic()
+            self._thread = threading.Thread(target=self._run, daemon=True)
+            self._thread.start()
+        return self
+
+    def stop(self) -> None:
+        """Halt the spinner and clear its line. Idempotent + thread-safe."""
+        with self._lock:
+            if self._done:
+                return
+            self._done = True
+        if self._thread is not None:
+            self._stop_event.set()
+            self._thread.join(timeout=1.0)
+            try:
+                # Clear the whole line; the label + " Ns" fits well within a
+                # generous fixed width (ANSI codes take no display columns).
+                self._stream.write("\r" + " " * (len(self._label) + 24) + "\r")
+                self._stream.flush()
+            except (ValueError, OSError):
+                pass
+
+    def __exit__(self, *exc: object) -> bool:
+        self.stop()
+        return False
+
+
+def _try_mirror_prefetch(
+    model_name: str,
+    on_pull_start: Callable[[], None] | None = None,
+) -> bool:
     """Pre-fetch a HuggingFace repo via R2-first / HF-fallback (per file).
 
     Delegates to :func:`vllm_mlx._mirror.download_with_mirror_fallback`.
@@ -1372,6 +1458,9 @@ def _try_mirror_prefetch(model_name: str) -> bool:
     and HF). Returns ``False`` if the caller should fall through to the
     plain ``snapshot_download(repo_id)`` path (catalog unavailable for
     catalog-only paths, or one or more files failed both R2 and HF).
+
+    ``on_pull_start`` is forwarded to the mirror and fired once, right before
+    the first ``Pulling`` line — used to retire a "Resolving…" spinner.
 
     Set ``RAPID_MLX_MODEL_MIRROR=""`` to disable R2 entirely and force
     HuggingFace.
@@ -1389,7 +1478,7 @@ def _try_mirror_prefetch(model_name: str) -> bool:
         # Mirror module not available (minimal-deps install or
         # deliberately removed). Use the legacy HF path.
         return False
-    return download_with_mirror_fallback(model_name)
+    return download_with_mirror_fallback(model_name, on_pull_start=on_pull_start)
 
 
 def _ensure_model_downloaded(model_name: str) -> None:
@@ -1425,17 +1514,32 @@ def _ensure_model_downloaded(model_name: str) -> None:
         # fully present.
         pass
 
-    # Disk-space gate: a 20 GB partial download that fails on the last
-    # shard wastes the user's time. ``_check_disk_space`` queries HF for
-    # the repo size and aborts with a clear message + exit(1) if there
-    # isn't enough room on the resolved HF cache filesystem.
-    _check_disk_space(model_name)
+    # Disk-space gate + mirror pull. Both the disk probe (HF ``model_info``)
+    # and the mirror's own metadata + ``/api/models`` catalog round-trips run
+    # BEFORE the first "Pulling"/"First-time download" line — up to a few
+    # seconds of total silence at the most fragile first-run moment, where it
+    # reads as a hang. Cover it with a "Resolving…" spinner (TTY-only; inert on
+    # CI/pipe) that the mirror retires via ``on_pull_start`` the instant real
+    # progress begins, and that ``__exit__`` clears on every other exit path.
+    _short = model_name.split("/")[-1]
+    spinner = _StatusSpinner(f"Resolving {_short} …")
+    with spinner:
+        # ``_check_disk_space`` queries HF for the repo size and aborts with a
+        # clear message + exit(1) if there isn't enough room on the resolved
+        # HF cache filesystem. Clear the spinner first on that fatal path so
+        # the abort message and the shell prompt after it land on clean lines.
+        try:
+            _check_disk_space(model_name)
+        except SystemExit:
+            spinner.stop()
+            raise
 
-    # User-configured mirror path (R2/S3/any HTTP host). When the mirror
-    # serves every file the repo declares, populate the HF cache layout
-    # ourselves and skip snapshot_download. On any miss we fall through
-    # to the normal HuggingFace download below.
-    if _try_mirror_prefetch(model_name):
+        # User-configured mirror path (R2/S3/any HTTP host). When the mirror
+        # serves every file the repo declares, populate the HF cache layout
+        # ourselves and skip snapshot_download. On any miss we fall through
+        # to the normal HuggingFace download below.
+        mirror_ok = _try_mirror_prefetch(model_name, on_pull_start=spinner.stop)
+    if mirror_ok:
         return
 
     try:
@@ -8723,6 +8827,14 @@ Examples:
         _cmd = getattr(args, "command", "chat")
         _sel_alias, _starter_cached = select_chat_default()
         args.model = _sel_alias
+        # Mark the auto-selected starter so the download gate below can skip
+        # its ``estimate_repo_size_bytes`` HF round-trip: the starter is a
+        # known ~3 GB model, always under the gate's 10 GiB confirm threshold,
+        # so the probe can only ever return "no prompt". Skipping it removes
+        # one of the silent HF round-trips that make the first-run cold start
+        # feel hung (the disk probe + mirror catalog fetch are covered by the
+        # "Resolving…" spinner instead).
+        args._autofilled_starter = True
         if sys.stdin.isatty():
             if _starter_cached:
                 print(
@@ -8861,6 +8973,12 @@ Examples:
         and "/" in args.model  # only HF-style repo ids; local paths skip
         and not os.path.exists(args.model)
         and not _chat_spawn_child
+        # The auto-selected first-run starter is a known ~3 GB model, always
+        # under the confirm threshold — skip the gate's size-probe round-trip
+        # entirely (it can only ever return "no prompt") so the cold start
+        # isn't stalled on a redundant HF ``model_info`` call. The disk-space
+        # gate in ``_ensure_model_downloaded`` still runs, under the spinner.
+        and not getattr(args, "_autofilled_starter", False)
     ):
         # Cheap checks first: env override and non-TTY both short-circuit
         # without touching the HF API. ``confirm_or_abort`` re-checks


### PR DESCRIPTION
## Why

The first run is the make-or-break moment for a new user, and a fresh-venv
cold-start dogfood of `rapid-mlx chat` (no model → auto-selected starter)
showed it currently reads as a **hang** — because several silent network
round-trips happen before any progress line, and because HuggingFace's own
progress bars leak into our clean UI. This PR removes both, so the first
impression is smooth activity from the first keystroke.

## Problem (found via fresh-venv cold-start dogfood)

- **P1 — dead air.** ~3.4s of *total silence* between `No model specified —
  using qwen3.5-4b-4bit …` and the first `Pulling` line. Back-to-back HF
  `model_info` round-trips (download-gate size probe → `_check_disk_space` →
  the mirror's own metadata fetch) plus the `/api/models` catalog fetch all
  run with zero feedback, because none of them were instrumented.
- **P2 — leaked progress bars.** HuggingFace's own per-file tqdm bars leak on
  HF-fallback metadata files (`.gitattributes`, `README.md`), clashing with
  our clean aggregate `↓%` progress UI.

## Fix

- **`_StatusSpinner`** — a `⠋ Resolving <model> …` spinner (same frames/stream
  as the warm `loading model…` spinner) covers every silent resolve step: the
  download-gate size probe (in `main()`) and the disk-space + catalog window
  (in `_ensure_model_downloaded`). It clears before `confirm_or_abort` (so a
  genuine prompt lands clean) and is retired via a new `on_pull_start` hook the
  instant the mirror is about to print `Pulling`. Inert on non-TTY / `NO_COLOR`.
- **Keep the size gate for every model.** The gate is *not* bypassed for the
  starter (it is an unpinned HF repo whose declared size we verify, never
  assume) — we only hide the probe's latency behind the spinner.
- **Mute HF's tqdm for metadata only.** Pass a disabled `tqdm_class` to
  `hf_hub_download` for confirmed-small non-weight files (per-call, thread-safe
  — no global `disable_progress_bars()` that would race the worker pool).
  Weight shards and unknown-size files keep their bar, so a rare big-shard HF
  fallback still shows progress (fail toward showing).

## Codex round 1 (both fixed, re-dogfooded)

1. *Gate bypass for the mutable starter was unsafe* → reverted; the size gate
   runs for every uncached model, its latency hidden by the spinner instead.
2. *`stop()` could redraw after the clear if the worker blocked in `write()`* →
   draw-lock makes the clear the worker's provably-final write; a wedged stream
   skips the clear rather than hang.

## Evidence — fresh-venv cold PTY dogfood (real 3 GB pull, run twice)

- notice→Pulling window ~3.6s, **fully spinner-covered** (worst silent gap
  **0.11s**, just the frame interval); the gate-probe and download-prep
  spinners read as one continuous `Resolving …` (0.06s gap); clears cleanly
  before `Pulling`.
- HF tqdm leak scan: **0** `%|`, **0** `B/s]`, **0** `it/s]`, **0** `Fetching`.
  The two HF-fallback files render as clean `[N/12] … HF (0 MB, fallback)`.
- model downloaded (65 MB/s) → loaded → Ready ~57s → answered correctly → clean exit.

## Test plan

- [x] `tests/test_status_spinner.py` — inert on non-TTY/`NO_COLOR`, animates +
  clears on TTY, thread halts on stop, idempotent + thread-safe stop, and the
  clear is the last write even with a slow stream (codex #2 scenario).
- [x] `tests/test_mirror_pull.py` — `_should_suppress_hf_bar` predicate
  (weight/unknown keep, small metadata mute, 5 MiB boundary), silent tqdm
  renders nothing, `_hf_fallback_one` passthrough, `on_pull_start` fires once
  before `Pulling` / never on the return-False path / exception-safe,
  end-to-end metadata-muted-but-weight-kept.
- [x] `tests/test_first_run_guide.py` — the starter still runs the size gate
  (codex #1) + belt-and-braces that the disk gate still runs.
- [x] Fresh-venv cold PTY dogfood (above) — P1 & P2 both PASS end-to-end.
- [x] `ruff check` + `ruff format` clean; full unit suite green (14077 passed).

`skip-version-bump` — batched into the pending 0.11.1.