### PR TITLE
chore: bump version to 0.11.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.11.0"
+version = "0.11.1"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## Release 0.11.1

Consolidated fix/feature batch since 0.11.0 (**38 PRs**). This is a **bump-only** PR — the sole diff is the `pyproject.toml` version line; every change below already merged to `main` and was validated this cycle by a full local-wheel dark-food.

## Why

0.11.0 shipped the #558 reasoning-gated tool-grammar keystone; since then a large batch of correctness fixes (KV-quant, MTP, Qwen3.6 coherence), first-run UX, telemetry, and release-harness work has accumulated merged-but-unreleased. We cut them as 0.11.1 (odd-Y = fix release) **because** leaving validated corrections merged-but-unpublished starves users of the fixes with no upside. Refs #558.

### 🚀 Highlights
- **Live KV-cache quantization** (#1199) — the continuous-batching KV cache is now quantized live (int8/int4) via `--kv-cache-dtype`; #1208 extends engagement to VLMs (nested language-model `head_dim` probe), #1231 fail-safe bf16 degrade when mlx-lm lacks `BatchGenerator._make_new_cache`.
- **Output-coherence release gate** (#1247) — 6 blocking golden cases + advisory garbage detector, wired into centralized fleet coverage (#1262).
- **First-run experience** (#1237, #1259, #1260, #1263) — first-run guide, TTY-aware cold-download progress + correct starter size, silenced HF unauthenticated-download advisory, killed cold-start dead air + muted leaked HF progress bars.
- **MCP standard key** (#1243) — accept the standard `mcpServers` config key (previously silently resolved to 0 servers).

### 🐛 Correctness fixes
- #1234 — undo mlx-lm's spurious +1.0 RMSNorm shift so **Qwen3.6-35B-A3B** serves coherently
- #1201 / #1214 / #1215 / #1200 — **MTP**: eliminate intermittent empty response, loadable high-acceptance sidecar extraction, local-dir eligibility, sidecar-head docs
- #1225 — DeepSeek-V4: honor explicit YaRN `attention_factor`
- #1226 — security: contain local `model_file` imports to the model root
- #1244 / #1241 — DFlash: capability/startup-UX alignment, default to final-answer mode
- #1240 — close release dogfood gaps

### 📊 Telemetry
- #1207 / #1210 / #1211 / #1213 / #1217 / #1218 / #1236→#1238(revert)→#1239 — request/error event plumbing (model_load_failure, tool_parse, shutdown_traceback, streaming + non-streaming request events with real TTFT, caller_agent + sampling gate)

### 🧪 Tests / infra / release
- #1219 — hypothesis property suite (quantized-KV round-trip + sampling invariants)
- #1221 — repair 5 pre-existing main-red tests
- #1220 — pr_validate advisory diff-coverage step (measure-only, no gate)
- #1262 — centralize fleet coverage; #1264 — restore benchmark baselines
- #1242 — stabilize PydanticAI structured output check

### 📝 Docs
- #1261 — curl-first install + "launch claude-code" Quick Start
- #1209 — align README with 0.11.0; #1235 — migrate deprecated vllm-mlx brand to rapid-mlx

### ✅ Validation (this cycle, local wheel from `ae89aac6`)
- **7 families** coherent (6/6 golden each, 0 advisories): qwen3.5-4b, gpt-oss-20b, gemma-4-26b (VLM), qwen3.6-27b, qwen3.5-35b, qwen3.6-35b, deepseek-r1-32b
- **KV int8 engages** on text (qwen3.5-4b) + VLM (gemma-4-26b); **tool-call** valid on gpt-oss harmony wire; **MTP** 10/10 non-empty on Qwen3.6-27B sidecar
- **G1 clean-room wheel smoke** green; **14,161 unit tests pass** (0 regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

