### PR TITLE
feat(telemetry): client-side output_degenerate signal for per-version canary (#1250)

### DIFF
--- a/tests/test_coherence.py
+++ b/tests/test_coherence.py
@@ -19,7 +19,13 @@ import httpx
 import pytest
 
 from evals import coherence_gate
-from vllm_mlx.coherence import GOLDEN, GoldenCase, evaluate_case, looks_like_garbage
+from vllm_mlx.coherence import (
+    GOLDEN,
+    GoldenCase,
+    evaluate_case,
+    is_degenerate_completion,
+    looks_like_garbage,
+)
 
 # ── real, coherent outputs that must NOT be flagged as garbage ──────────────
 COHERENT = [
@@ -70,6 +76,27 @@ def test_coherent_text_not_flagged(text: str) -> None:
 def test_garbage_text_flagged(text: str) -> None:
     is_garbage, _ = looks_like_garbage(text)
     assert is_garbage, f"missed garbage: {text[:50]!r}"
+
+
+# ── is_degenerate_completion: the boolean #1250 telemetry canary ────────────
+@pytest.mark.parametrize("text", COHERENT)
+def test_is_degenerate_false_on_coherent(text: str) -> None:
+    assert is_degenerate_completion(text) is False
+
+
+@pytest.mark.parametrize("text", [g for g in GARBAGE if g.strip()])
+def test_is_degenerate_true_on_nonempty_garbage(text: str) -> None:
+    assert is_degenerate_completion(text) is True
+
+
+def test_is_degenerate_false_on_empty_is_absence_not_garbage() -> None:
+    """Empty / whitespace / None is absence of output — a SEPARATE signal (the
+    zero completion-token bucket), not degeneracy. Keep this bool a clean
+    "non-empty content looks like garbage" indicator so it never double-counts
+    empties with the token-bucket signal."""
+    assert is_degenerate_completion("") is False
+    assert is_degenerate_completion("   ") is False
+    assert is_degenerate_completion(None) is False
 
 
 def test_evaluate_case_accepts_correct_answer() -> None:

--- a/tests/test_telemetry_cli.py
+++ b/tests/test_telemetry_cli.py
@@ -116,6 +116,20 @@ def test_preview_emits_valid_json_payload(fake_home):
     assert payload["event"] == "session_start"
 
 
+def test_preview_shows_request_event_with_degenerate_flag(fake_home):
+    """Preview must also show the highest-volume ``request`` event so users can
+    audit it — including the #1250 ``output_degenerate`` bool, the only field
+    derived from completion text, which ships as a bare boolean. No prompt or
+    response text may appear in the sample."""
+    r = _run_cli("telemetry", "preview", home=fake_home)
+    assert r.returncode == 0, r.stderr
+    assert '"event": "request"' in r.stdout
+    assert '"output_degenerate": false' in r.stdout
+    # Only bucketed numbers + booleans — no raw-text field ever surfaces.
+    for forbidden in ('"prompt"', '"prompt_text"', '"completion"', '"messages"'):
+        assert forbidden not in r.stdout, f"{forbidden} leaked into preview"
+
+
 def test_reset_removes_consent(fake_home):
     _run_cli("telemetry", "enable", home=fake_home)
     r = _run_cli("telemetry", "reset", home=fake_home)

--- a/tests/test_telemetry_emit.py
+++ b/tests/test_telemetry_emit.py
@@ -387,6 +387,77 @@ def test_request_buckets_not_raw_numbers(opted_in, stub_queue):
         assert raw not in request_blob, f"{raw!r} survived into request payload: {r}"
 
 
+def test_request_payload_carries_every_schema_v1_field(opted_in, stub_queue):
+    """Request events now have live call sites (#1250), so a v1 consumer must
+    find EVERY ``RequestPayload`` key present — including ``output_degenerate``,
+    even when the caller doesn't pass it (defaults must still be emitted)."""
+    from dataclasses import fields as _fields
+
+    from vllm_mlx.telemetry import emit
+    from vllm_mlx.telemetry.schema import RequestPayload
+
+    expected_keys = {f.name for f in _fields(RequestPayload)}
+    emit.request(
+        endpoint="/v1/chat/completions",
+        model_alias="qwen3.5-9b-4bit",
+        stream=True,
+        tool_call_used=False,
+        prompt_tokens=10,
+        completion_tokens=20,
+        ttft_ms=100.0,
+        tps=50.0,
+        status=200,
+    )
+    r = stub_queue[-1]["request"]
+    missing = expected_keys - set(r)
+    assert not missing, f"request dropped v1 keys: {missing}"
+
+
+def test_output_degenerate_defaults_false_and_is_bool(opted_in, stub_queue):
+    """Omitting ``output_degenerate`` still emits a plain ``False`` bool — never
+    ``None`` / missing — so aggregation can count it without a null branch."""
+    from vllm_mlx.telemetry import emit
+
+    emit.request(
+        endpoint="/v1/chat/completions",
+        model_alias="qwen3.5-9b-4bit",
+        stream=False,
+        tool_call_used=False,
+        prompt_tokens=10,
+        completion_tokens=20,
+        ttft_ms=100.0,
+        tps=50.0,
+        status=200,
+    )
+    value = stub_queue[-1]["request"]["output_degenerate"]
+    assert value is False
+    assert isinstance(value, bool)
+
+
+def test_output_degenerate_true_when_caller_flags_it(opted_in, stub_queue):
+    """The caller computes the bool locally (from ``looks_like_garbage``) and
+    passes only the finished value — a truthy result lands as ``True``. This
+    field is the ONLY thing derived from completion text, and it is a bool, so
+    no text ever crosses into the payload."""
+    from vllm_mlx.telemetry import emit
+
+    emit.request(
+        endpoint="/v1/chat/completions",
+        model_alias="qwen3.5-9b-4bit",
+        stream=True,
+        tool_call_used=False,
+        prompt_tokens=10,
+        completion_tokens=20,
+        ttft_ms=100.0,
+        tps=50.0,
+        status=200,
+        output_degenerate=True,
+    )
+    r = stub_queue[-1]["request"]
+    assert r["output_degenerate"] is True
+    assert isinstance(r["output_degenerate"], bool)
+
+
 def test_error_category_and_phase_normalised_to_allowlist(opted_in, stub_queue):
     """Round 3 codex review: ``category`` + ``phase`` were stored
     verbatim. Same escape hatch as ``endpoint`` — a future caller

--- a/tests/test_telemetry_request_wiring.py
+++ b/tests/test_telemetry_request_wiring.py
@@ -113,6 +113,75 @@ async def test_nonstreaming_completion_emits_request_event(monkeypatch):
     assert kw["tool_call_used"] is False
     assert isinstance(kw["ttft_ms"], (int, float))
     assert isinstance(kw["tps"], (int, float))
+    # #1250: the call site always threads the degeneracy signal through. With
+    # telemetry off (the default here) it is None — the local heuristic is
+    # skipped entirely — but the keyword must still be passed.
+    assert "output_degenerate" in kw
+    assert kw["output_degenerate"] is None
+
+
+class _GarbageChatEngine(_FakeChatEngine):
+    async def chat(self, messages, **kwargs):
+        from vllm_mlx.engine.base import GenerationOutput
+
+        return GenerationOutput(
+            text="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",  # doubled-norm collapse (#1234)
+            finish_reason="stop",
+            prompt_tokens=12,
+            completion_tokens=8,
+        )
+
+
+@pytest.mark.asyncio
+async def test_nonstreaming_flags_degenerate_output_when_enabled(monkeypatch):
+    """When telemetry is ENABLED, the call site runs the LOCAL degeneracy
+    heuristic on the visible completion and emits the bool. A #1234-class
+    garbage completion is flagged ``True`` — the post-release canary. Only the
+    bool is passed; the garbage text never reaches ``emit.request``."""
+    from vllm_mlx.routes import chat
+    from vllm_mlx.telemetry import emit
+
+    calls: list[dict] = []
+    engine = _GarbageChatEngine()
+    _patch_route(monkeypatch, engine, calls)
+    # Force the consent gate open so the call site actually computes the
+    # signal (default is OFF, which short-circuits to None).
+    monkeypatch.setattr(emit, "is_enabled", lambda *a, **k: True)
+
+    await chat._create_chat_completion_impl(
+        _request(),
+        _RawRequest(user_agent="claude-cli/1.4.2"),
+        engine,
+        _commit_state=[False],
+        _admission_acquired=[False],
+    )
+
+    assert len(calls) == 1
+    assert calls[0]["output_degenerate"] is True
+
+
+@pytest.mark.asyncio
+async def test_nonstreaming_coherent_output_not_flagged_when_enabled(monkeypatch):
+    """The enabled path does not blanket-flag: a coherent completion is
+    ``False``, so the signal discriminates rather than always firing."""
+    from vllm_mlx.routes import chat
+    from vllm_mlx.telemetry import emit
+
+    calls: list[dict] = []
+    engine = _FakeChatEngine()  # returns "hello there"
+    _patch_route(monkeypatch, engine, calls)
+    monkeypatch.setattr(emit, "is_enabled", lambda *a, **k: True)
+
+    await chat._create_chat_completion_impl(
+        _request(),
+        _RawRequest(user_agent="claude-cli/1.4.2"),
+        engine,
+        _commit_state=[False],
+        _admission_acquired=[False],
+    )
+
+    assert len(calls) == 1
+    assert calls[0]["output_degenerate"] is False
 
 
 @pytest.mark.asyncio

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -6961,7 +6961,10 @@ def telemetry_command(args) -> None:
         record_consent,
         reset_state,
     )
-    from vllm_mlx.telemetry.schema import sample_preview_payload
+    from vllm_mlx.telemetry.schema import (
+        sample_preview_payload,
+        sample_request_preview_payload,
+    )
     from vllm_mlx.telemetry.state import client_id_path, consent_path
 
     action = getattr(args, "telemetry_action", None) or "status"
@@ -7010,13 +7013,23 @@ def telemetry_command(args) -> None:
 
     if action == "preview":
         cid = get_or_create_client_id()
-        payload = sample_preview_payload(
+        session_sample = sample_preview_payload(
+            client_id=cid, rapid_mlx_version=rapid_mlx_version
+        )
+        request_sample = sample_request_preview_payload(
             client_id=cid, rapid_mlx_version=rapid_mlx_version
         )
         print()
-        print("  Sample payload (this is exactly the shape we send):")
+        print("  Sample payloads (this is exactly the shape we send):")
         print()
-        print(json.dumps(payload.to_dict(), indent=2))
+        print("  session event:")
+        print(json.dumps(session_sample.to_dict(), indent=2))
+        print()
+        print("  request event (per completion, sampled) — only bucketed")
+        print("  numbers + booleans; never prompt or response text. The")
+        print("  output_degenerate flag is computed locally and sent as a")
+        print("  bare true/false (#1250):")
+        print(json.dumps(request_sample.to_dict(), indent=2))
         print()
         if not is_enabled(cli_no_telemetry=cli_no):
             print("  Telemetry is currently disabled — nothing is actually sent.")

--- a/vllm_mlx/coherence.py
+++ b/vllm_mlx/coherence.py
@@ -35,7 +35,13 @@ import re
 from collections import Counter
 from dataclasses import dataclass, field
 
-__all__ = ["GoldenCase", "GOLDEN", "looks_like_garbage", "evaluate_case"]
+__all__ = [
+    "GoldenCase",
+    "GOLDEN",
+    "looks_like_garbage",
+    "is_degenerate_completion",
+    "evaluate_case",
+]
 
 _WORD_RE = re.compile(r"\w+", re.UNICODE)
 
@@ -130,6 +136,23 @@ def looks_like_garbage(text: str, *, min_words: int = 10) -> tuple[bool, str]:
                 return True, f"top bigram is {bn}/{len(bigrams)} of the output"
 
     return False, "ok"
+
+
+def is_degenerate_completion(text: str | None) -> bool:
+    """Boolean form of :func:`looks_like_garbage` for the #1250 telemetry
+    canary: is a **non-empty** completion degenerate (repetition / single-token
+    collapse)?
+
+    Empty / whitespace-only input returns ``False`` — absence of output is a
+    *separate* signal (the zero completion-token bucket), not degeneracy — so
+    this stays a clean "non-empty content looks like garbage" indicator for the
+    #1234 class (normal-length but garbage output). Pure and text-only: callers
+    run it locally and emit only the returned bool, never the text.
+    """
+    s = text or ""
+    if not s.strip():
+        return False
+    return looks_like_garbage(s)[0]
 
 
 @dataclass(frozen=True)

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -119,6 +119,24 @@ _SAFE_DEEPSEEK_TOOL_NAME_RE = re.compile(r"^[A-Za-z0-9_-]{1,64}$")
 router = APIRouter()
 
 
+def _degenerate_signal(
+    visible_text: str | None, telemetry_enabled: bool
+) -> bool | None:
+    """#1250 degeneracy canary for the emit sites below.
+
+    Returns ``None`` when telemetry is disabled — the default path skips the
+    heuristic entirely and no work is done. When enabled, runs the LOCAL
+    ``vllm_mlx.coherence.is_degenerate_completion`` on the visible completion
+    and returns only the bool; the text never leaves the host and is not
+    recoverable from the bool.
+    """
+    if not telemetry_enabled:
+        return None
+    from vllm_mlx.coherence import is_degenerate_completion
+
+    return is_degenerate_completion(visible_text)
+
+
 def _tool_call_name(tc) -> str | None:
     """Extract the function name from a tool_call entry regardless of
     shape. Three real shapes seen in production:
@@ -5715,6 +5733,15 @@ async def _create_chat_completion_impl(
     # delivered in one shot); the streaming path reports true TTFT.
     from vllm_mlx.telemetry import emit as _telemetry_emit
 
+    # Client-side degeneracy check (#1250): only when telemetry is enabled,
+    # run the local ``looks_like_garbage`` heuristic on the VISIBLE content
+    # and send ONLY the resulting bool — never the text. Empty content stays
+    # ``False`` (already captured by the zero completion-token bucket), so
+    # this is a clean "non-empty output looks like garbage" post-release
+    # canary for the #1234 class. Gated on ``is_enabled()`` so the default
+    # (telemetry off) path does no extra work.
+    _output_degenerate = _degenerate_signal(final_content, _telemetry_emit.is_enabled())
+
     _telemetry_emit.request(
         endpoint="/v1/chat/completions",
         model_alias=request.model,
@@ -5728,6 +5755,7 @@ async def _create_chat_completion_impl(
         caller_agent=(
             raw_request.headers.get("user-agent") if raw_request is not None else None
         ),
+        output_degenerate=_output_degenerate,
     )
 
     return Response(
@@ -6705,6 +6733,14 @@ async def stream_chat_completion(
         )
         from vllm_mlx.telemetry import emit as _telemetry_emit
 
+        # #1250 canary on the visible streamed content — the accumulated
+        # assistant text (reasoning is separate). Runs locally, only the
+        # bool is emitted; see ``_degenerate_signal``.
+        _output_degenerate = _degenerate_signal(
+            getattr(processor, "accumulated_text", "") or "",
+            _telemetry_emit.is_enabled(),
+        )
+
         _telemetry_emit.request(
             endpoint="/v1/chat/completions",
             model_alias=request.model,
@@ -6716,6 +6752,7 @@ async def stream_chat_completion(
             tps=_decode_tps,
             status=200,
             caller_agent=caller_agent,
+            output_degenerate=_output_degenerate,
         )
     finally:
         if cfg.gc_control and gc_was_enabled:

--- a/vllm_mlx/telemetry/emit.py
+++ b/vllm_mlx/telemetry/emit.py
@@ -490,14 +490,20 @@ def request(
     tps: float,
     status: int,
     caller_agent: str | None = None,
+    output_degenerate: bool | None = None,
 ) -> None:
-    """Emit a ``request`` payload (call sites land in a follow-up PR).
+    """Emit a ``request`` payload.
 
     ``caller_agent`` is the inbound HTTP ``User-Agent``; it is bucketed to a
     fixed allowlist here (never stored raw). Sampled by
     ``RAPID_MLX_TELEMETRY_REQUEST_SAMPLE`` because request volume dwarfs the
     session events. Consent is still checked first — sampling never turns a
     disabled client on.
+
+    ``output_degenerate`` is a derived boolean the CALLER computes with
+    ``vllm_mlx.coherence.looks_like_garbage`` (#1250). This helper never sees
+    the completion text — only the finished bool — preserving the invariant
+    that no raw prompt/completion ever passes through the telemetry module.
     """
     if not is_enabled():
         return
@@ -515,6 +521,7 @@ def request(
         "tps_bucket": bucket_tps(tps),
         "status": int(status),
         "caller_agent": normalize_caller_agent(caller_agent),
+        "output_degenerate": bool(output_degenerate),
     }
     get_queue().enqueue(payload)
 

--- a/vllm_mlx/telemetry/schema.py
+++ b/vllm_mlx/telemetry/schema.py
@@ -20,6 +20,10 @@ from typing import Any
 
 from vllm_mlx.telemetry.redact import (
     bucket_memory_gb,
+    bucket_tokens,
+    bucket_tps,
+    bucket_ttft_ms,
+    normalize_caller_agent,
     platform_info,
 )
 
@@ -82,6 +86,19 @@ class RequestPayload:
     # RequestPayload positionally don't shift/break. request events ship
     # dark until the call sites land, so this widens no live wire contract.
     caller_agent: str = "unknown"
+    # v2.2 addition (#1250). A single derived boolean: did the completion
+    # look degenerate (repetition / single-token collapse) per the
+    # CLIENT-SIDE ``vllm_mlx.coherence.looks_like_garbage`` heuristic? The
+    # detector runs on the caller's machine and ONLY this bool leaves it —
+    # never the prompt or the completion text, and the bool is not
+    # reversible into either. It is the post-release canary for the #1234
+    # class (normal-length but garbage output), which the token-count
+    # buckets and the error events cannot see. Appended last + optional so
+    # positional ``RequestPayload`` construction stays stable; empty
+    # completions are reported ``False`` here (they already show up as the
+    # zero completion-token bucket) so this stays a clean "non-empty content
+    # looks like garbage" signal.
+    output_degenerate: bool = False
 
 
 @dataclass(frozen=True)
@@ -163,6 +180,51 @@ def sample_preview_payload(
     )
 
 
+def sample_request_preview_payload(
+    *,
+    client_id: str,
+    rapid_mlx_version: str,
+) -> TelemetryPayload:
+    """A representative ``request`` event for ``rapid-mlx telemetry preview``.
+
+    Request events are the highest-volume stream, so previewing one lets users
+    see the bucketed, content-free shape real traffic sends — every number is a
+    coarse bucket, and the #1250 ``output_degenerate`` flag is a bare boolean.
+    Neither the prompt nor the completion text is ever present. Bucket labels
+    are produced by the real ``redact`` helpers so the preview matches the wire.
+    """
+    info = platform_info()
+    return TelemetryPayload(
+        schema_version=SCHEMA_VERSION,
+        client_id=client_id,
+        session_id="preview-0000000000000000",
+        rapid_mlx_version=rapid_mlx_version,
+        platform=PlatformInfo(
+            os=info["os"],
+            os_version=info["os_version"],
+            arch=info["arch"],
+            chip=info["chip"],
+            memory_gb=info["memory_gb"],
+            python_version=info["python_version"],
+        ),
+        event="request",
+        timestamp=_utc_now_iso(),
+        request=RequestPayload(
+            endpoint="/v1/chat/completions",
+            model_alias="mlx-community/Qwen3.5-9B-4bit",
+            stream=True,
+            tool_call_used=True,
+            prompt_tokens_bucket=bucket_tokens(420),
+            completion_tokens_bucket=bucket_tokens(180),
+            ttft_ms_bucket=bucket_ttft_ms(310.0),
+            tps_bucket=bucket_tps(58.0),
+            status=200,
+            caller_agent=normalize_caller_agent("claude-code/1.0"),
+            output_degenerate=False,
+        ),
+    )
+
+
 __all__ = [
     "ErrorPayload",
     "PlatformInfo",
@@ -172,4 +234,5 @@ __all__ = [
     "TelemetryPayload",
     "bucket_memory_gb",
     "sample_preview_payload",
+    "sample_request_preview_payload",
 ]


### PR DESCRIPTION
## Why

`#1250` (post-release garbage/empty-rate alert) is the deliberate replacement for the dropped "RC + soak" — at a ~2-day release cadence there is no room for staged rollout, so real-user telemetry is the practical canary. The pre-release coherence gate (`#1247`) is the first net; this is the second.

The load-bearing insight: the `#1234` failure mode is **normal-length but garbage content**. Empty/short-response rate and error rate (both already on the wire) **cannot** see it — the model "succeeds" and emits a normal token count of garbage. The only signal that catches that class is a content-derived garbage flag.

## What (Phase A — client side)

Adds a single derived boolean, `output_degenerate`, to the `request` telemetry event: did the completion look degenerate (repetition / single-token collapse) per the **local** `looks_like_garbage` heuristic?

- `coherence.py`: pure `is_degenerate_completion(text) -> bool` (reuses the `#1247` detector; unit-tested).
- `telemetry/schema.py`: optional `output_degenerate` on `RequestPayload` (appended last, **no `SCHEMA_VERSION` bump**) + a `request`-event preview sample.
- `telemetry/emit.py`: `request(..., output_degenerate=...)` receives **only the bool**, never text.
- `routes/chat.py`: compute + thread the signal at both the non-streaming and streaming emit sites, gated on `is_enabled()` so the default (telemetry off) path does zero extra work.
- `cli.py`: `telemetry preview` now shows the `request` event too, so users can audit the new bool.

## Privacy

The heuristic runs on the caller's machine and **only the bool leaves it**. The prompt and completion text never cross into the telemetry module (the signature red-line test `test_public_emit_signatures_have_no_prompt_or_completion_fields` still holds), and the bool is not reversible into text. Empty completions stay `False` (already captured by the zero completion-token bucket), keeping this a clean "non-empty content looks like garbage" indicator that does not double-count empties.

Worker ingest needs **no change**: `output_degenerate` is nested under `request`, and the schema-v1 validator passes unknown nested fields through.

## Validation

- `tests/test_coherence.py` — `is_degenerate_completion`: coherent → `False`, non-empty garbage → `True`, empty/whitespace/None → `False`.
- `tests/test_telemetry_emit.py` — request payload carries every `RequestPayload` v1 key; `output_degenerate` defaults `False`, is a `bool`, and is `True` when flagged.
- `tests/test_telemetry_request_wiring.py` — the call site threads the field; with telemetry ON a `#1234`-class garbage completion is flagged `True` and a coherent one `False`.
- `tests/test_telemetry_cli.py` — preview shows the `request` event with `output_degenerate` and leaks no text field.
- 192 passed; `ruff check` + `ruff format --check` clean.

## Scope

Phase A only (client signal). Phase B — the server-side per-version aggregation + threshold alert in the telemetry worker — follows separately (deploy is gated on the worker OAuth unblock, and meaningful alerting needs opted-in volume to accumulate first, so shipping the signal now starts that data flowing).

Refs #1250. Umbrella #320.

🤖 Generated with [Claude Code](https://claude.com/claude-code)