### PR TITLE
fix(cache): summarize prefix persistence logs

### DIFF
--- a/tests/test_prefix_cache_persistence.py
+++ b/tests/test_prefix_cache_persistence.py
@@ -40,6 +40,7 @@ from __future__ import annotations
 
 import array
 import json
+import logging
 import os
 from pathlib import Path
 
@@ -118,6 +119,27 @@ def test_clean_roundtrip_save_then_load(tmp_path):
     # Must hold for any well-formed entry: KV state is exactly as long
     # as the token sequence it claims to represent.
     assert entry.cache[0].offset == len(entry.tokens)
+
+
+def test_persistence_logs_entries_at_debug_and_summaries_at_info(tmp_path, caplog):
+    """Large persisted caches should produce two INFO summaries, not one
+    INFO line per entry; verbose entry details remain available at DEBUG."""
+    cache = fresh_cache()
+    cache.store(list(range(11)), make_kvcache(num_tokens=11))
+
+    with caplog.at_level(logging.DEBUG, logger="vllm_mlx.memory_cache"):
+        assert cache.save_to_disk(str(tmp_path)) is True
+        assert fresh_cache().load_from_disk(str(tmp_path)) == 1
+
+    info = [r.getMessage() for r in caplog.records if r.levelno == logging.INFO]
+    debug = [r.getMessage() for r in caplog.records if r.levelno == logging.DEBUG]
+
+    assert any("SAVED 1/1 entries" in message for message in info)
+    assert any("LOADED 1 entries" in message for message in info)
+    assert not any("saved entry 0" in message for message in info)
+    assert not any("staged entry 0" in message for message in info)
+    assert any("saved entry 0" in message for message in debug)
+    assert any("staged entry 0" in message for message in debug)
 
 
 # --------------------------------------------------------------------------

--- a/vllm_mlx/memory_cache.py
+++ b/vllm_mlx/memory_cache.py
@@ -2478,7 +2478,7 @@ class MemoryAwarePrefixCache:
                 if elapsed > 0:
                     total_bytes_written += entry.memory_bytes
                     total_write_seconds += elapsed
-                logger.info(
+                logger.debug(
                     f"[cache_persist] saved entry {i}: "
                     f"{len(tokens_key)} tokens, "
                     f"{entry.memory_bytes / _BYTES_PER_MB:.1f}MB KV, "
@@ -3339,7 +3339,7 @@ class MemoryAwarePrefixCache:
                 staged_memory += memory
                 loaded += 1
 
-                logger.info(
+                logger.debug(
                     f"[cache_persist] staged entry {i}: "
                     f"{len(tokens)} tokens, "
                     f"{memory / _BYTES_PER_MB:.1f}MB KV"


### PR DESCRIPTION
## Why

A realistic persisted prefix cache can contain hundreds of entries. Save and startup load currently emit one INFO line per entry, burying useful server logs even though both operations already emit aggregate summaries.

Closes #1257.

## Change

- Move successful per-entry save and load/staging details from INFO to DEBUG.
- Keep the existing aggregate `SAVED` and `LOADED` summaries at INFO.
- Keep warnings and failures unchanged.
- Add a round-trip regression test that locks the log-level contract on both paths.

## User impact

Normal server startup and shutdown now produce concise cache summaries. Operators can still enable DEBUG when they need individual entry size, token count, or path details.

## Validation

- `pytest -q tests/test_prefix_cache_persistence.py` — 72 passed.
- `ruff check` and `ruff format --check` — clean.
- `git diff --check` — clean.