### PR TITLE
test(telemetry): scope caller-agent leak assertion

### DIFF
--- a/tests/test_telemetry_emit.py
+++ b/tests/test_telemetry_emit.py
@@ -813,14 +813,26 @@ def _emit_one_request(caller_agent=None):
     )
 
 
-def test_request_caller_agent_bucketed_never_raw(opted_in, stub_queue):
+def test_request_caller_agent_bucketed_never_raw(opted_in, stub_queue, monkeypatch):
     """The inbound UA is bucketed to the allowlist; the raw string (with its
     version + any custom tokens) never reaches the payload."""
+    from vllm_mlx.telemetry import emit
+
+    # Top-level UUIDs are unrelated to the caller-agent input and may
+    # coincidentally contain a short raw substring such as "abc".
+    monkeypatch.setattr(emit, "session_id", lambda: "dead-beef-9abc-cafe")
     _emit_one_request(caller_agent="Claude-Code/1.4.2 (buildX; secret-token=abc)")
     assert len(stub_queue) == 1
-    req = stub_queue[0]["request"]
+    payload = stub_queue[0]
+    req = payload["request"]
     assert req["caller_agent"] == "claude-code"
-    blob = repr(stub_queue[0])
+    assert "abc" in repr(payload)
+    leak_surface = {
+        key: value
+        for key, value in payload.items()
+        if key not in {"client_id", "session_id"}
+    }
+    blob = repr(leak_surface)
     for raw in ("1.4.2", "buildX", "secret-token", "abc"):
         assert raw not in blob
 


### PR DESCRIPTION
## Why

A full-unit run on current `main` false-failed `test_request_caller_agent_bucketed_never_raw`: the test searched the entire telemetry envelope for the short raw substring `abc`, and a random top-level UUID happened to contain `9abc`. The production caller-agent bucketing was correct.

## Change

- Exclude only the generated `client_id` and `session_id` fields from the raw caller-agent leak scan; the rest of the full envelope remains covered by the privacy assertion.
- Force a top-level session ID containing `abc` in the same test and assert the unfiltered envelope contains it. Reverting to the old whole-envelope check now fails deterministically.
- No production code changes.

## Validation

- Reproduced the original failure during the full 14k unit suite on current main.
- Full unit after the first fix: 14,175 passed; the final review-only adjustment is covered by the focused file below.
- `pytest -q tests/test_telemetry_emit.py` — 32 passed.
- Codex review converged with no blocking findings; `pr_validate` verdict MERGE-SAFE.
- `ruff check`, `ruff format --check`, and `git diff --check` — clean.