### PR TITLE
fix(doctor): warn on unsupported mlx-audio versions

### DIFF
--- a/tests/test_doctor_env_health.py
+++ b/tests/test_doctor_env_health.py
@@ -182,6 +182,34 @@ def test_missing_optional_package_marks_warning():
     assert "pip install" in audio_row.label  # hint preserved
 
 
+def test_unsupported_mlx_audio_version_marks_warning():
+    """A transitive mlx-audio outside Rapid-MLX's pin is not healthy."""
+
+    def fake_ver(dist: str) -> str | None:
+        return "0.4.6" if dist == "mlx-audio" else None
+
+    with mock.patch.object(eh, "_safe_version", side_effect=fake_ver):
+        section = eh.section_optional_packages()
+
+    audio_row = next(c for c in section.checks if "mlx-audio" in c.label)
+    assert audio_row.status is eh.CheckStatus.WARN
+    assert "0.4.6" in audio_row.label
+    assert "requires mlx-audio>=0.2.9,<0.4.4" in audio_row.label
+
+
+def test_supported_mlx_audio_version_marks_ok():
+    """A version inside the declared audio range remains healthy."""
+
+    def fake_ver(dist: str) -> str | None:
+        return "0.4.3" if dist == "mlx-audio" else None
+
+    with mock.patch.object(eh, "_safe_version", side_effect=fake_ver):
+        section = eh.section_optional_packages()
+
+    audio_row = next(c for c in section.checks if "mlx-audio" in c.label)
+    assert audio_row.status is eh.CheckStatus.OK
+
+
 # ---------------------------------------------------------------------------
 # Section: HuggingFace cache
 # ---------------------------------------------------------------------------

--- a/vllm_mlx/doctor/env_health.py
+++ b/vllm_mlx/doctor/env_health.py
@@ -583,6 +583,23 @@ def section_optional_packages() -> Section:
     for dist, label, hint in OPTIONAL_PACKAGES:
         ver = _safe_version(dist)
         if ver:
+            # #1255: mlx-vlm can install mlx-audio transitively without
+            # respecting Rapid-MLX's supported audio range. Presence alone
+            # must not make doctor report that environment as healthy.
+            if dist == "mlx-audio" and not (
+                _version_at_least(ver, (0, 2, 9))
+                and not _version_at_least(ver, (0, 4, 4))
+            ):
+                s.add(
+                    f"{label} {ver} unsupported — rapid-mlx requires "
+                    f"mlx-audio>=0.2.9,<0.4.4 (`{hint}`)",
+                    CheckStatus.WARN,
+                    detail=(
+                        f"distribution={dist} version={ver} "
+                        f"supported=>=0.2.9,<0.4.4 hint={hint}"
+                    ),
+                )
+                continue
             # #1126: mlx-vlm imports Pillow (PIL) at load. A present
             # mlx-vlm with an absent PIL (Homebrew `pip install --no-deps
             # mlx-vlm`) is a FALSE positive — metadata says "installed" but


### PR DESCRIPTION
## What changed

- make `rapid-mlx doctor` validate installed `mlx-audio` against Rapid-MLX's declared `>=0.2.9,<0.4.4` range
- report an actionable warning instead of a healthy row when a transitive install provides an unsupported version
- cover both the observed `0.4.6` false-green and a supported `0.4.3` install

## Why

`mlx-vlm` can pull in `mlx-audio` transitively without satisfying Rapid-MLX's audio constraint. The observed clean `[all]` install therefore showed `mlx-audio 0.4.6` as healthy even though Rapid-MLX explicitly caps it below `0.4.4`.

This intentionally fixes only the doctor truthfulness slice of #1255. The broader `[all]` contract and complete audio dependency-set decision remain tracked there.

## Validation

- `uv run --with pytest --with pillow python -m pytest -q tests/test_doctor_env_health.py tests/test_doctor_extras.py tests/test_vision_runtime_detection.py` — 73 passed
- `git diff --check`

Partial fix for #1255.