### PR TITLE
fix(mtp): show explicit runtime mode in profile summary

### DIFF
--- a/tests/test_model_auto_config.py
+++ b/tests/test_model_auto_config.py
@@ -928,6 +928,13 @@ class TestVisibility:
         assert "unknown family" in line
         assert "brand-new-model" in line
 
+    def test_unknown_summary_shows_explicit_runtime_spec_decode(self):
+        line = format_profile_summary(
+            "brand-new-model", None, runtime_spec_decode="mtp"
+        )
+        assert "unknown family" in line
+        assert "spec decode MTP (explicit)" in line
+
     # --- Level 2 / Level 3: ASCII table ---
 
     def test_table_renders_aligned(self):

--- a/tests/test_model_auto_config.py
+++ b/tests/test_model_auto_config.py
@@ -913,6 +913,16 @@ class TestVisibility:
         assert "throttle ON" in line
         assert "spec decode OFF" in line
 
+    def test_summary_shows_explicit_runtime_spec_decode(self):
+        cfg = detect_model_config("mlx-community/Qwen3.5-35B-A3B-4bit")
+        line = format_profile_summary(
+            "mlx-community/Qwen3.5-35B-A3B-4bit",
+            cfg,
+            runtime_spec_decode="mtp",
+        )
+        assert "spec decode MTP (explicit)" in line
+        assert "spec decode OFF" not in line
+
     def test_summary_for_unknown(self):
         line = format_profile_summary("brand-new-model", None)
         assert "unknown family" in line

--- a/tests/test_no_mllm_flag.py
+++ b/tests/test_no_mllm_flag.py
@@ -2766,6 +2766,25 @@ def test_engine_core_no_override_leaves_model_config_unchanged(monkeypatch):
     assert core.model_config.supports_spec_decode is False
 
 
+def test_engine_core_profile_log_shows_explicit_mtp(monkeypatch, caplog):
+    """Runtime MTP selection must override the static profile label."""
+    try:
+        from vllm_mlx.engine_core import EngineConfig
+        from vllm_mlx.scheduler import SchedulerConfig
+    except RuntimeError as exc:
+        pytest.skip(f"MLX runtime unavailable ({exc})")
+
+    cfg = EngineConfig(
+        model_name="fake/model",
+        scheduler_config=SchedulerConfig(spec_decode="mtp"),
+    )
+    with caplog.at_level("INFO", logger="vllm_mlx.engine_core"):
+        _make_engine_core_for_override_test(monkeypatch, cfg)
+
+    assert "spec decode MTP (explicit)" in caplog.text
+    assert "spec decode OFF" not in caplog.text
+
+
 def _engine_core_mutex_cases() -> list[dict[str, bool]]:
     """Build mutex-conflict parametrize cases from the registry. For
     every pair with ``model_config_field`` not None, generate one

--- a/tests/test_no_mllm_flag.py
+++ b/tests/test_no_mllm_flag.py
@@ -2771,7 +2771,7 @@ def test_engine_core_profile_log_shows_explicit_mtp(monkeypatch, caplog):
     try:
         from vllm_mlx.engine_core import EngineConfig
         from vllm_mlx.scheduler import SchedulerConfig
-    except RuntimeError as exc:
+    except (ImportError, RuntimeError) as exc:
         pytest.skip(f"MLX runtime unavailable ({exc})")
 
     cfg = EngineConfig(

--- a/vllm_mlx/engine_core.py
+++ b/vllm_mlx/engine_core.py
@@ -300,7 +300,16 @@ class EngineCore:
         # Level 2 — verbose ASCII capability table when explicitly requested
         # via env var ``RAPID_MLX_PROFILE_VERBOSE=1`` (or set on EngineConfig).
         display_path = model_path or "(unknown)"
-        logger.info(format_profile_summary(display_path, self.model_config))
+        runtime_spec_decode = getattr(scheduler_config, "spec_decode", "none")
+        logger.info(
+            format_profile_summary(
+                display_path,
+                self.model_config,
+                runtime_spec_decode=(
+                    runtime_spec_decode if runtime_spec_decode != "none" else None
+                ),
+            )
+        )
         if os.environ.get("RAPID_MLX_PROFILE_VERBOSE") == "1" or getattr(
             self.config, "verbose_profile", False
         ):

--- a/vllm_mlx/model_auto_config.py
+++ b/vllm_mlx/model_auto_config.py
@@ -2102,7 +2102,12 @@ def _kv_share_label(model_path: str, cfg: "ModelConfig") -> str:
     return "yes (default)" if _resolve_family(model_path, cfg) == "gemma4" else "no"
 
 
-def format_profile_summary(model_path: str, cfg: "ModelConfig | None") -> str:
+def format_profile_summary(
+    model_path: str,
+    cfg: "ModelConfig | None",
+    *,
+    runtime_spec_decode: str | None = None,
+) -> str:
     """Single-line profile summary for startup logs (Level 1).
 
     Empty/no-match models return a generic line so the log is consistent
@@ -2110,9 +2115,17 @@ def format_profile_summary(model_path: str, cfg: "ModelConfig | None") -> str:
     """
     if cfg is None:
         return f"Model profile: {model_path} (unknown family — using defaults)"
+    runtime_status = (
+        f"spec decode {runtime_spec_decode.upper()} (explicit)"
+        if runtime_spec_decode
+        else None
+    )
     parts = [_arch_label(cfg)]
     parts.append(f"throttle {'ON' if cfg.is_hybrid else 'OFF'}")
-    parts.append(f"spec decode {'OFF' if not cfg.supports_spec_decode else 'OK'}")
+    parts.append(
+        runtime_status
+        or f"spec decode {'OFF' if not cfg.supports_spec_decode else 'OK'}"
+    )
     if cfg.tool_call_parser:
         parts.append(f"tool={cfg.tool_call_parser}")
     if cfg.reasoning_parser:

--- a/vllm_mlx/model_auto_config.py
+++ b/vllm_mlx/model_auto_config.py
@@ -2113,13 +2113,14 @@ def format_profile_summary(
     Empty/no-match models return a generic line so the log is consistent
     across known and unknown models.
     """
-    if cfg is None:
-        return f"Model profile: {model_path} (unknown family — using defaults)"
     runtime_status = (
         f"spec decode {runtime_spec_decode.upper()} (explicit)"
         if runtime_spec_decode
         else None
     )
+    if cfg is None:
+        summary = f"Model profile: {model_path} (unknown family — using defaults)"
+        return f"{summary}, {runtime_status}" if runtime_status else summary
     parts = [_arch_label(cfg)]
     parts.append(f"throttle {'ON' if cfg.is_hybrid else 'OFF'}")
     parts.append(


### PR DESCRIPTION
## What changed

- let the startup profile summary accept the explicitly selected runtime speculative-decoding mode
- show `spec decode MTP (explicit)` when `SchedulerConfig.spec_decode` is `mtp`, instead of repeating the static profile's `spec decode OFF`
- keep the static model profile and all scheduler/eligibility behavior unchanged

## Why

Qwen3.6 can pass the explicit MTP preflight and run MTP while the adjacent startup profile line still says `spec decode OFF`. That is confusing even though the CLI separately reports MTP selection.

This is intentionally the narrow status/UX slice of #1258. Mixed-precision sidecar performance guidance remains tracked in the issue.

## Validation

- `uv run --with pytest --with pytest-asyncio python -m pytest -q tests/test_model_auto_config.py tests/test_no_mllm_flag.py` — 357 passed, 3 skipped
- `git diff --check`

Partial fix for #1258.