### PR TITLE
fix(auth): reject malformed API keys without timing short-circuit

### DIFF
--- a/tests/test_config_and_middleware.py
+++ b/tests/test_config_and_middleware.py
@@ -185,6 +185,50 @@ class TestVerifyApiKey:
         assert r.status_code == 401
         get_config().api_key = None
 
+    def test_non_ascii_key_is_rejected_as_401(self):
+        """Malformed header text must not escape compare_digest as a 500."""
+        import pytest
+        from fastapi import HTTPException
+
+        from vllm_mlx.config import get_config
+        from vllm_mlx.middleware.auth import _verify_api_key_values
+
+        cfg = get_config()
+        cfg.api_key = "test-secret"
+        try:
+            with pytest.raises(HTTPException) as exc_info:
+                _verify_api_key_values("tést-secret")
+            assert exc_info.value.status_code == 401
+        finally:
+            cfg.api_key = None
+
+    def test_all_provided_keys_are_compared(self, monkeypatch):
+        """A mismatch must not skip comparison of companion credentials."""
+        import pytest
+        from fastapi import HTTPException
+
+        from vllm_mlx.config import get_config
+        from vllm_mlx.middleware import auth
+
+        calls = []
+
+        def record_compare(provided, expected):
+            calls.append((provided, expected))
+            return provided == expected
+
+        monkeypatch.setattr(auth.secrets, "compare_digest", record_compare)
+        cfg = get_config()
+        cfg.api_key = "test-secret"
+        try:
+            with pytest.raises(HTTPException):
+                auth._verify_api_key_values("wrong", "test-secret")
+            assert calls == [
+                ("wrong", "test-secret"),
+                ("test-secret", "test-secret"),
+            ]
+        finally:
+            cfg.api_key = None
+
 
 # ======================================================================
 # check_rate_limit

--- a/tests/test_config_and_middleware.py
+++ b/tests/test_config_and_middleware.py
@@ -3,6 +3,7 @@
 
 import time
 
+import pytest
 from fastapi import Depends, FastAPI
 from fastapi.testclient import TestClient
 
@@ -187,7 +188,7 @@ class TestVerifyApiKey:
 
     def test_non_ascii_key_is_rejected_as_401(self):
         """Malformed header text must not escape compare_digest as a 500."""
-        import pytest
+        pytest.importorskip("mlx")
         from fastapi import HTTPException
 
         from vllm_mlx.config import get_config
@@ -204,7 +205,7 @@ class TestVerifyApiKey:
 
     def test_all_provided_keys_are_compared(self, monkeypatch):
         """A mismatch must not skip comparison of companion credentials."""
-        import pytest
+        pytest.importorskip("mlx")
         from fastapi import HTTPException
 
         from vllm_mlx.config import get_config

--- a/vllm_mlx/middleware/auth.py
+++ b/vllm_mlx/middleware/auth.py
@@ -260,9 +260,18 @@ def _verify_api_key_values(*api_keys: str | None) -> bool:
     provided_keys = [api_key for api_key in api_keys if api_key]
     if not provided_keys:
         raise HTTPException(status_code=401, detail="API key required")
-    if not all(
-        secrets.compare_digest(api_key, cfg.api_key) for api_key in provided_keys
-    ):
+    valid = True
+    for api_key in provided_keys:
+        try:
+            matches = secrets.compare_digest(api_key, cfg.api_key)
+        except TypeError:
+            # compare_digest(str, str) rejects non-ASCII text. Treat malformed
+            # header values as invalid credentials instead of leaking a 500.
+            matches = False
+        # Do not short-circuit: every supplied credential gets the same
+        # comparison work even when an earlier companion header was invalid.
+        valid &= matches
+    if not valid:
         raise HTTPException(status_code=401, detail="Invalid API key")
     return True
 


### PR DESCRIPTION
## What changed

- treat non-ASCII credential text rejected by `secrets.compare_digest` as an invalid API key (HTTP 401) instead of allowing `TypeError` to become a 500
- compare every supplied credential before deciding the result, so a bad Bearer header does not skip comparison of its companion `x-api-key`
- add regression tests for both behaviors

## Why

`secrets.compare_digest(str, str)` raises `TypeError` for non-ASCII input, and the existing `all(generator)` stopped after the first mismatch. Both behaviors lived in the shared `_verify_api_key_values` helper used by OpenAI- and Anthropic-compatible authentication. Invalid credentials should consistently return 401, and companion credential comparisons should not leak which header failed first.

This resolves only the constant-time short-circuit and non-ASCII failure items in #337. It does not overlap the bearer-whitespace item already assigned to an external contributor.

## Validation

- reproduced both failures before the fix
- `uv run --with pytest --with pytest-asyncio python -m pytest -q tests/test_config_and_middleware.py tests/test_anthropic_route_auth.py tests/test_internal_route_auth.py tests/test_server_auth_ordering.py` — 93 passed
- `git diff --check`

Partial fix for #337.