### PR TITLE
docs(patches): require production-path install tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,23 @@ ruff format --check .
 
 Most tests run without a model. Tests in `tests/test_event_loop.py` require a running server.
 
+### Testing install-time patches
+
+An import-time monkeypatch can pass unit tests while never running in
+`rapid-mlx serve` if its installer is wired to the wrong module. For every
+install-time patch:
+
+- install it from a module on the real production load path;
+- add a subprocess test that imports that production module *before* importing
+  the patch's `is_installed` probe; and
+- assert the installer state and its marker on the patched upstream object.
+
+Use the existing `test_install_fires_on_real_serve_import_path` tests in
+`tests/test_deepseek_v32_indexer_gate.py` and
+`tests/test_qwen3_5_norm_shift.py` as the template. The subprocess is required:
+directly importing the patch in the pytest worker can install it as a side
+effect and mask a broken production wiring path.
+
 ## Pull Request Workflow
 
 1. Fork the repo and create a branch: `feat/`, `fix/`, `docs/`, `refactor/`

--- a/vllm_mlx/patches/README.md
+++ b/vllm_mlx/patches/README.md
@@ -1,0 +1,15 @@
+# Runtime compatibility patches
+
+Install-time patches must be wired from a module on the real production load
+path, not only from `model_runner.py` or from their own test module. Each
+installer therefore needs a subprocess regression test that:
+
+1. starts a clean interpreter;
+2. imports the production entrypoint first (currently
+   `vllm_mlx.utils.tokenizer` for model-load patches); and
+3. only then imports the patch's public `is_installed` probe and verifies both
+   it and any upstream marker.
+
+See `test_install_fires_on_real_serve_import_path` in
+`tests/test_deepseek_v32_indexer_gate.py` and
+`tests/test_qwen3_5_norm_shift.py` for the standing pattern.


### PR DESCRIPTION
## What does this PR do?

Documents the standing contract for install-time compatibility patches in both the patch README and contributor guide: install from a real production load-path module, then verify that wiring in a pristine subprocess before importing the patch probe.

It points contributors at the existing DeepSeek V3.2 and Qwen3.5/3.6 contract tests instead of introducing a new framework or touching runtime Python code.

## Why is this needed?

#1251 records a real release incident: patch unit tests passed because they imported the patch directly, while the actual `rapid-mlx serve` path never installed it and served broken output. The existing subprocess tests catch the failure, but the rule was not discoverable as a standing requirement for future patches.

Closes #1251

## AI assistance disclosure

Codex wrote the focused documentation in `CONTRIBUTING.md` and `vllm_mlx/patches/README.md`. I verified it against the actual production import chain and both existing subprocess contract tests.

## Test plan

- Negative control: temporarily removed the Qwen3.5/3.6 installer call from `vllm_mlx.utils.tokenizer`; the subprocess test failed with `is_installed() False after serve-path import`.
- Restored the hook and ran both DeepSeek V3.2 and Qwen3.5/3.6 production-path tests — 2 passed.
- Local Codex review: no blocking issues.
- The first full-unit validation reached 14,223 passed; its unrelated failures were a Hugging Face metadata network timeout and the known environment-sensitive batching performance test. The final PR is docs-only, so runtime suites are not applicable.

## Checklist

- [x] Tests pass locally for the documented production-path contract
- [x] Lint/format not applicable to the final docs-only diff
- [x] Self-validated with `python3 -m scripts.pr_validate.pr_validate 1274 --verbose`
- [x] Install-time hook negative control fails as expected
- [x] Updated contributor and patch documentation
- [x] No breaking changes to existing API