### PR TITLE
test(auth): harden route success assertions

### DIFF
--- a/tests/test_anthropic_route_auth.py
+++ b/tests/test_anthropic_route_auth.py
@@ -107,51 +107,57 @@ def anthropic_client(monkeypatch):
             getattr(module, attr, _MISSING) if module is not None else _MISSING
         )
 
-    _install_lightweight_engine_modules(monkeypatch)
+    reset_config = None
+    rate_limiter = None
+    try:
+        _install_lightweight_engine_modules(monkeypatch)
 
-    from vllm_mlx.config import reset_config
-    from vllm_mlx.middleware.auth import rate_limiter
-    from vllm_mlx.routes.anthropic import router
+        from vllm_mlx.config import reset_config
+        from vllm_mlx.middleware.auth import rate_limiter
+        from vllm_mlx.routes.anthropic import router
 
-    cfg = reset_config()
-    cfg.api_key = "test-secret"
-    cfg.engine = _Engine()
-    cfg.model_name = "test-model"
-    cfg.model_registry = None
+        cfg = reset_config()
+        cfg.api_key = "test-secret"
+        cfg.engine = _Engine()
+        cfg.model_name = "test-model"
+        cfg.model_registry = None
 
-    rate_limiter.enabled = False
-    rate_limiter.requests_per_minute = 60
-    rate_limiter._requests.clear()
+        rate_limiter.enabled = False
+        rate_limiter.requests_per_minute = 60
+        rate_limiter._requests.clear()
 
-    app = FastAPI()
-    app.include_router(router)
-    yield SimpleNamespace(
-        client=TestClient(app),
-        engine=cfg.engine,
-        rate_limiter=rate_limiter,
-        reset_config=reset_config,
-    )
+        app = FastAPI()
+        app.include_router(router)
+        yield SimpleNamespace(
+            client=TestClient(app),
+            engine=cfg.engine,
+            rate_limiter=rate_limiter,
+            reset_config=reset_config,
+        )
+    finally:
+        try:
+            if reset_config is not None:
+                reset_config()
+            if rate_limiter is not None:
+                rate_limiter.enabled = False
+                rate_limiter.requests_per_minute = 60
+                rate_limiter._requests.clear()
+        finally:
+            for name, previous in previous_modules.items():
+                if previous is _MISSING:
+                    sys.modules.pop(name, None)
+                else:
+                    sys.modules[name] = previous
 
-    reset_config()
-    rate_limiter.enabled = False
-    rate_limiter.requests_per_minute = 60
-    rate_limiter._requests.clear()
-
-    for name, previous in previous_modules.items():
-        if previous is _MISSING:
-            sys.modules.pop(name, None)
-        else:
-            sys.modules[name] = previous
-
-    for (module_name, attr), previous in previous_attrs.items():
-        module = sys.modules.get(module_name)
-        if module is None:
-            continue
-        if previous is _MISSING:
-            if hasattr(module, attr):
-                delattr(module, attr)
-        else:
-            setattr(module, attr, previous)
+            for (module_name, attr), previous in previous_attrs.items():
+                module = sys.modules.get(module_name)
+                if module is None:
+                    continue
+                if previous is _MISSING:
+                    if hasattr(module, attr):
+                        delattr(module, attr)
+                else:
+                    setattr(module, attr, previous)
 
 
 def _messages_payload() -> dict:

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -324,17 +324,19 @@ class TestHealthRoutes:
             self._restore_config(orig)
 
     @pytest.mark.parametrize(
-        ("method", "path"),
+        ("method", "path", "expected_status"),
         [
-            ("get", "/health"),
-            ("get", "/health/ready"),
-            ("post", "/v1/cache/clear"),
-            ("get", "/v1/status"),
-            ("get", "/v1/cache/stats"),
-            ("delete", "/v1/cache"),
+            ("get", "/health", 200),
+            ("get", "/health/ready", 200),
+            ("post", "/v1/cache/clear", 200),
+            ("get", "/v1/status", 200),
+            ("get", "/v1/cache/stats", 200),
+            ("delete", "/v1/cache", 200),
         ],
     )
-    def test_health_router_accepts_valid_api_key(self, method, path, mock_engine):
+    def test_health_router_accepts_valid_api_key(
+        self, method, path, expected_status, mock_engine
+    ):
         """Valid Bearer token preserves access to protected management routes.
 
         Destructive routes (``/v1/cache/clear``, ``/v1/cache`` DELETE) also
@@ -360,7 +362,9 @@ class TestHealthRoutes:
                 },
             )
 
-            assert r.status_code != 401
+            assert r.status_code == expected_status, (
+                f"{method.upper()} {path} returned {r.status_code}: {r.text}"
+            )
         finally:
             self._restore_config(orig)
 


### PR DESCRIPTION
## What does this PR do?

- Pins exact HTTP 200 responses for authenticated management-route success cases instead of accepting any non-401 response.
- Makes the Anthropic auth fixture restore imported modules and parent attributes even when setup fails before `yield`.
- Leaves the separately assigned Bearer-whitespace item untouched.

## Why is this needed?

The remaining test-hardening items in #337 can currently hide broken 5xx handlers and can leak monkeypatched module state after fixture setup errors. This closes only those two low-risk test gaps.

Closes #337

## AI assistance disclosure

Codex updated `tests/test_routes.py` and `tests/test_anthropic_route_auth.py`. I constrained the work to the two unassigned test-only checklist items, inspected the exact route behavior, and verified the diff with targeted tests, lint, formatting, and the canonical unit suite.

## Test plan

- `python3.12 -m pytest 'tests/test_routes.py::TestHealthRoutes::test_health_router_accepts_valid_api_key' tests/test_anthropic_route_auth.py -q --no-header` — 33 passed
- `python3.12 -m ruff check tests/test_routes.py tests/test_anthropic_route_auth.py`
- `python3.12 -m ruff format --check tests/test_routes.py tests/test_anthropic_route_auth.py`
- Canonical unit suite reached 14,226 passed; the only failure was the known environment-sensitive batching performance test while two full suites competed for the same machine. Re-running that test alone twice passed.

## Checklist

- [x] Tests pass locally (canonical unit scope; known concurrent perf flake A/B-classified)
- [x] Lint passes (`ruff check && ruff format --check`)
- [x] Self-validated with `python3 -m scripts.pr_validate.pr_validate 1275 --verbose`
- [x] Critical test behavior spot-checked where applicable
- [x] Updated README/docs if applicable
- [x] No breaking changes to existing API